### PR TITLE
ci: bump actions/checkout v4 → v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
`actions/checkout@v4` runs on Node 20, which GitHub deprecates 2026-06-16. Bump to `@v5` (Node 24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)