### PR TITLE
fix(ui): show git rail on mobile + unfolded fold

### DIFF
--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -6,7 +6,8 @@
     sessionId,
     name = "",
     prompt = "",
-  }: { sessionId: string; name?: string; prompt?: string } = $props();
+    mobile = false,
+  }: { sessionId: string; name?: string; prompt?: string; mobile?: boolean } = $props();
 
   let git = $state<GitState | null>(null);
   let busy = $state(false);
@@ -110,7 +111,7 @@
 </script>
 
 {#if git}
-  <span class="rail">
+  <span class="rail" class:mobile>
     {#if git.state === "none"}
       <button class="gbtn" type="button" disabled={busy} onclick={startPr}>↟ Open PR</button>
     {:else if git.state === "open"}
@@ -206,6 +207,24 @@
   .gbtn.primary {
     border-color: var(--color-amber);
     color: var(--color-amber);
+  }
+
+  /* touch layouts: bigger tap targets + readable PR link/dot */
+  .rail.mobile {
+    gap: 10px;
+  }
+  .rail.mobile .gbtn {
+    min-height: 40px;
+    padding: 6px 14px;
+    font-size: 12px;
+  }
+  .rail.mobile .prlink {
+    font-size: 13px;
+    padding: 4px 2px;
+  }
+  .rail.mobile .dot {
+    width: 9px;
+    height: 9px;
   }
 
   .prlink {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -292,6 +292,14 @@
     </button>
   </div>
 
+  <!-- compact layouts (mobile + unfolded fold) get the git rail its own strip,
+       since the wrapping header has no room for it -->
+  {#if compact}
+    <div class="vp-git-strip">
+      <GitRail sessionId={session.id} name={session.name} prompt={session.prompt} mobile />
+    </div>
+  {/if}
+
   <!-- scan overlay + terminal (terminal stays mounted across tab switches) -->
   <div class="vp-body">
     <div class="scan" aria-hidden="true"></div>
@@ -534,6 +542,21 @@
   }
   .back:hover {
     background: #0c1110;
+  }
+
+  /* dedicated git-rail strip for compact layouts (mobile + unfolded fold) */
+  .vp-git-strip {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 6px 10px;
+    background: #0a0f0d;
+    border-bottom: 1px solid var(--color-line);
+    flex-shrink: 0;
+    min-height: 44px;
   }
 
   .vp-head.mobile {


### PR DESCRIPTION
## Problem

The git rail (Open PR / Merge / Redeploy) only rendered on the desktop header — gated behind `{#if !compact}`. Since `compact = mobile || touch`, it was hidden on phones **and** on touch devices using the desktop layout (e.g. an **unfolded fold**), which have no hardware keyboard and a header with no spare room.

## Fix

- **Dedicated strip on compact:** desktop keeps the inline rail in `.vp-head`; compact layouts get the rail in its own full-width `.vp-git-strip` directly below the header (44px min-height, right-aligned, wraps, `position: relative` so the Open-PR popover anchors correctly).
- **Touch-sized targets:** pass `mobile` to `GitRail` → 40px min-height buttons, 12px text, larger PR link + CI dot.

## Validation

- `svelte-check`: 0 errors / 0 warnings (362 files)
- `eslint`: clean · `ui build`: succeeds
- No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
