### PR TITLE
fix(ui): collapse UNIT- stem on cramped sidebar

### DIFF
--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -86,6 +86,9 @@
     padding: 6px;
     flex: 1;
     min-height: 0;
+    /* size context for UnitRow's container queries — lets rows adapt the
+       designator to the actual sidebar width (compact vs desktop) */
+    container: herd / inline-size;
   }
 
   .empty {

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -14,6 +14,12 @@
     nowMs: number;
     onselect: (id: string) => void;
   } = $props();
+
+  // split "UNIT-07" into the constant stem ("UNIT-") and disambiguating number ("07")
+  // so the stem can collapse on a cramped sidebar, leaving the unit name room to breathe
+  const desigParts = $derived(session.desig.match(/^(.*?)(\d+)$/));
+  const desigStem = $derived(desigParts?.[1] ?? "");
+  const desigNum = $derived(desigParts?.[2] ?? session.desig);
 </script>
 
 <button
@@ -29,7 +35,7 @@
 
   <div class="u-main">
     <div class="u-top">
-      <span class="desig micro">{session.desig}</span>
+      <span class="desig micro"><span class="desig-stem">{desigStem}</span>{desigNum}</span>
       <span class="name">{session.name}</span>
     </div>
     <div class="u-sub">
@@ -191,6 +197,15 @@
   .meta {
     color: var(--color-muted);
     font-size: 11.5px;
+  }
+
+  /* cramped sidebar (compact touch layout, narrow phones): drop the constant
+     "UNIT-" stem and keep just the number, handing the reclaimed width to the
+     name. The wide desktop sidebar (>=300px) stays above this threshold. */
+  @container herd (max-width: 270px) {
+    .desig-stem {
+      display: none;
+    }
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
## Problem

On the compact/touch sidebar layout (220–260px), the `UNIT-NN` designator — a fixed-width, non-shrinking inline prefix — starved the unit name down to ~6 characters. The `UNIT-` stem is identical on every row; only the number disambiguates.

## Fix

- **`UnitRow.svelte`**: split `session.desig` into stem (`UNIT-`) + number (`07`). A container query hides the stem below 270px, reclaiming ~50px for the name.
- **`Herd.svelte`**: made the scroll list a size container (`container: herd / inline-size`).

A container query (not a media query) keys off the actual sidebar width: the 270px threshold sits cleanly between the compact list (~206–246px → shows `07`) and the desktop list (~286–346px → keeps full `UNIT-07`). No layout props threaded down.

| Layout | Before | After |
| --- | --- | --- |
| Desktop sidebar (300–360px) | `UNIT-07 feature-login-page` | unchanged |
| Compact/touch (220–260px) | `UNIT-07 featu…` | `07 feature-log…` |

## Verification

svelte-check 0 errors · eslint clean · prettier formatted · 23 UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)