### PR TITLE
feat(ui): wrap sidebar prompt to 2 lines

### DIFF
--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -157,9 +157,14 @@
     color: var(--color-muted);
     margin-top: 3px;
     font-size: 12px;
-    white-space: nowrap;
+    line-height: 1.35;
+    /* wrap to a 2nd line — fills the vertical space the right column
+       (badge / elapsed / meta) already occupies, then ellipsis */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
     overflow: hidden;
-    text-overflow: ellipsis;
     max-width: 34ch;
   }
 


### PR DESCRIPTION
## Why

The sidebar row's right column (badge / elapsed / meta) is 3 lines tall, but the left column only used 2 (designator+name, then a single-line prompt) — leaving vertical space unused.

## Change

`.u-sub` (the prompt line) now clamps to **2 lines** via `-webkit-line-clamp`, with ellipsis on overflow, filling the available height. Rows top-align (`align-items: start`) so short prompts still render compactly.

## Verification

svelte-check 0 errors · eslint clean · prettier formatted · 23 UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)