### PR TITLE
fix(forge): restore forge wiring dropped in PR #1 merge (git rail 404)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,7 @@
+import { loadForgeMap } from "./forge/load-config";
+
+const forgesPath = process.env.SHEPHERD_FORGES ?? `${process.env.HOME}/.shepherd/forges.json`;
+
 export const config = {
   port: Number(process.env.SHEPHERD_PORT ?? 7330),
   // bind to loopback only; the Tailscale-serve proxy reaches it via 127.0.0.1.
@@ -18,4 +22,7 @@ export const config = {
     ",",
   ),
   token: process.env.SHEPHERD_TOKEN ?? null, // when set, require Authorization: Bearer <token>
+  // git host (forge) integration: per-host {type,baseUrl,token,deployWorkflow,mergeMethod}
+  forgesPath,
+  forges: loadForgeMap(forgesPath),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,5 +59,14 @@ const calibrate = async () => {
 setTimeout(calibrate, 3_000);
 setInterval(calibrate, 24 * 60 * 60 * 1000);
 
-const server = serve({ store, service, events, usageLimits }, config.port);
+const server = serve(
+  {
+    store,
+    service,
+    events,
+    usageLimits,
+    resolveForge: (repoDir: string) => detectForge(repoDir, config.forges),
+  },
+  config.port,
+);
 console.log(`shepherd core on http://localhost:${server.port}`);


### PR DESCRIPTION
## Problem

The git rail never appeared — every `GET /api/sessions/:id/git` returned **404 "no forge for this repo"**, even for the GitHub-hosted `tank` repo with `gh` authed.

Root cause: the **PR #1 merge silently dropped the forge wiring** (the conflict churn + a reverted lint-staged hook). Two losses:

1. **`config.ts`** — lost the `loadForgeMap` import and the `forges`/`forgesPath` fields, so `config.forges` was `undefined`. `kindFor` then threw `TypeError: undefined is not an object (evaluating 'map[host]')`, which the route swallowed into a 404.
2. **`index.ts`** — `resolveForge` was never passed into `serve()` (and the `detectForge` import was duplicated as a merge artifact). So even with config fixed, `deps.resolveForge` was undefined.

The forge layer, server routes, and UI rail were all intact — only the wiring between them was missing.

## Fix

- `config.ts`: restore `import { loadForgeMap }`, `forgesPath`, and `forges: loadForgeMap(forgesPath)`.
- `index.ts`: dedupe the `detectForge` import; pass `resolveForge: (repoDir) => detectForge(repoDir, config.forges)` into `serve()`.

Verified: `detectForge("/home/patrick/Work/tank", config.forges)` now returns `github slug=erwins-enkel/shepherd`.

## Validation

- `tsc --noEmit`: 0 errors
- `bun test`: 257 pass / 0 fail
- `eslint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
