### PR TITLE
fix(forge): wire repo forge resolution into the running server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { mkdirSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { config } from "./config";
 import { SessionStore } from "./store";
 import { WorktreeMgr } from "./worktree";
@@ -10,6 +10,8 @@ import { SessionService } from "./service";
 import { StatusPoller } from "./poller";
 import { reconcile } from "./reconcile";
 import { serve } from "./server";
+import { detectForge } from "./forge";
+import { loadForgeMap } from "./forge/load-config";
 import { AccountUsageIndex } from "./usage";
 import { UsageLimitsService } from "./usage-limits";
 import { HerdrUsageProbe } from "./usage-probe";
@@ -59,5 +61,13 @@ const calibrate = async () => {
 setTimeout(calibrate, 3_000);
 setInterval(calibrate, 24 * 60 * 60 * 1000);
 
-const server = serve({ store, service, events, usageLimits }, config.port);
+// forge resolution: detect a repo's GitHub/Gitea host from its `origin` remote.
+// Per-host config (tokens, gitea base URLs) is optional — github.com works through
+// the operator's existing `gh` CLI auth, so an absent forges.json is fine.
+const forgeMap = loadForgeMap(join(dirname(config.dbPath), "forges.json"));
+
+const server = serve(
+  { store, service, events, usageLimits, resolveForge: (dir) => detectForge(dir, forgeMap) },
+  config.port,
+);
 console.log(`shepherd core on http://localhost:${server.port}`);

--- a/test/forge-detect.test.ts
+++ b/test/forge-detect.test.ts
@@ -1,0 +1,38 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectForge } from "../src/forge";
+
+// `index.ts` wires resolveForge as (dir) => detectForge(dir, forgeMap). These
+// tests cover that resolution path: an origin remote → a concrete forge.
+
+let dir: string;
+
+function git(...args: string[]) {
+  execFileSync("git", ["-C", dir, ...args], { stdio: ["ignore", "ignore", "ignore"] });
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "shepherd-forge-detect-"));
+  git("init", "-q");
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+test("detectForge resolves a github.com origin to a github forge with the slug", () => {
+  git("remote", "add", "origin", "https://github.com/acme/widget.git");
+  const forge = detectForge(dir, {});
+  expect(forge).not.toBeNull();
+  expect(forge!.kind).toBe("github");
+  expect(forge!.slug).toBe("acme/widget");
+});
+
+test("detectForge returns null for a repo without an origin remote", () => {
+  expect(detectForge(dir, {})).toBeNull();
+});
+
+test("detectForge returns null for a non-repo / unreadable dir", () => {
+  expect(detectForge(join(dir, "does-not-exist"), {})).toBeNull();
+});


### PR DESCRIPTION
## Problem

Der **Issues-Tab** (und das gesamte **Git-Rail**: PR-Status, Open-PR, Merge, CI-Checks) zeigt für **jedes** Repo „no GitHub upstream" — selbst wenn das Repo ein GitHub-Remote hat.

## Ursache

Die Forge-Schicht (`src/forge/*`: GitHub/Gitea-Erkennung, Issues, PR, Merge, Checks) ist vollständig gebaut **und unit-getestet**, aber **nie verdrahtet**: `index.ts` rief `serve({ store, service, events, usageLimits }, …)` **ohne `resolveForge`** auf. Damit war `deps.resolveForge` zur Laufzeit immer `undefined`, und sowohl `/api/issues` als auch `/api/sessions/:id/git` lieferten „no forge".

Die Tests bestehen trotzdem, weil `server-issues.test.ts` / `server-git.test.ts` `resolveForge` im Harness selbst injizieren — nur die Produktiv-Verdrahtung fehlte.

## Fix

```ts
const forgeMap = loadForgeMap(join(dirname(config.dbPath), "forges.json"));
serve({ …, resolveForge: (dir) => detectForge(dir, forgeMap) }, config.port);
```

- `detectForge` liest das `origin`-Remote des Repos und baut daraus den passenden Forge.
- Per-Host-Config (`~/.shepherd/forges.json`) ist **optional** — github.com läuft über die bestehende `gh`-CLI-Auth, also ist eine fehlende Datei in Ordnung.

## Verifikation

- Reale Auflösung von `~/projects/community-map` → `{ kind: "github", slug: "zwei-zeiler/community-maps" }`, `gh listIssues` liefert **18 offene Issues**.
- Neuer Test `test/forge-detect.test.ts` deckt die Auflösung ab (github-Remote → forge+slug; kein Remote → null; kein Repo → null).
- `bun run lint` ✅ · `bun run test` ✅ 206/206.

## Hinweis

Unabhängig von #9 (configurable repo root) — basiert sauber auf `main`.