### PR TITLE
fix(pty): resolve node binary robustly for the attach helper

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { resolveNodeBin } from "./node-bin";
+
 export const config = {
   port: Number(process.env.SHEPHERD_PORT ?? 7330),
   // bind to loopback only; the Tailscale-serve proxy reaches it via 127.0.0.1.
@@ -5,6 +7,10 @@ export const config = {
   host: process.env.SHEPHERD_HOST ?? "127.0.0.1",
   dbPath: process.env.SHEPHERD_DB ?? `${process.env.HOME}/.shepherd/shepherd.db`,
   herdrBin: process.env.HERDR_BIN ?? "herdr",
+  // node binary for the PTY attach helper (pty-attach.mjs). Resolved so a node
+  // managed by mise/nvm/fnm still works when the launcher's PATH excludes it —
+  // otherwise the helper can't spawn and every session pane stays black.
+  nodeBin: resolveNodeBin({ override: process.env.SHEPHERD_NODE_BIN }),
   herdrSession: process.env.HERDR_SESSION ?? "default",
   ollamaModel: process.env.SHEPHERD_NAMER_MODEL ?? "mistral-small3.1:latest",
   ollamaEndpoint: process.env.OLLAMA_URL ?? "http://localhost:11434/api/generate",

--- a/src/node-bin.ts
+++ b/src/node-bin.ts
@@ -1,0 +1,48 @@
+import { existsSync } from "node:fs";
+
+export interface ResolveNodeOpts {
+  /** Explicit override (SHEPHERD_NODE_BIN); wins over everything when non-empty. */
+  override?: string | null;
+  /** PATH lookup; defaults to Bun.which. Injectable for tests. */
+  which?: (cmd: string) => string | null;
+  /** Existence probe; defaults to fs.existsSync. Injectable for tests. */
+  exists?: (p: string) => boolean;
+  /** Home dir; defaults to $HOME. Injectable for tests. */
+  home?: string;
+}
+
+/**
+ * Resolve a `node` binary for spawning the PTY attach helper (pty-attach.mjs).
+ *
+ * The server itself runs under Bun, but the helper needs Node (node-pty is a
+ * native Node addon). When Shepherd runs under systemd or another launcher whose
+ * PATH excludes a version-manager-managed node (mise/nvm/fnm), spawning bare
+ * "node" fails — and every session pane silently stays black. Resolution order:
+ *   1. explicit override (SHEPHERD_NODE_BIN)
+ *   2. node on PATH
+ *   3. known install locations (mise shims, common bin dirs)
+ *   4. bare "node" as a last resort, so the spawn error is at least legible
+ */
+export function resolveNodeBin(opts: ResolveNodeOpts = {}): string {
+  const override = opts.override;
+  if (typeof override === "string" && override.trim()) return override.trim();
+
+  const which = opts.which ?? ((c) => Bun.which(c));
+  const onPath = which("node");
+  if (onPath) return onPath;
+
+  const exists = opts.exists ?? existsSync;
+  const home = opts.home ?? process.env.HOME ?? "";
+  const candidates = [
+    home && `${home}/.local/share/mise/shims/node`, // mise (managed node)
+    home && `${home}/.local/bin/node`,
+    "/usr/local/bin/node",
+    "/usr/bin/node",
+    "/bin/node",
+  ].filter((c): c is string => Boolean(c));
+
+  for (const c of candidates) {
+    if (exists(c)) return c;
+  }
+  return "node"; // surfaces a clear ENOENT instead of a silent black pane
+}

--- a/src/pty-bridge.ts
+++ b/src/pty-bridge.ts
@@ -15,17 +15,21 @@ export class PtyBridge {
     private terminalId: string,
     private ws: PtySocket,
     private helperPath = new URL("./pty-attach.mjs", import.meta.url).pathname,
+    private nodeBin = config.nodeBin,
   ) {}
 
   open(cols = 100, rows = 30): void {
     if (!isValidTerminalId(this.terminalId)) throw new Error("invalid terminalId");
-    this.proc = Bun.spawn(["node", this.helperPath, this.terminalId, String(cols), String(rows)], {
-      stdin: "pipe" as const,
-      stdout: "pipe" as const,
-      stderr: "inherit" as const,
-      env: { ...process.env, HERDR_BIN: config.herdrBin },
-      onExit: () => this.ws.close(),
-    }) as NodeProc;
+    this.proc = Bun.spawn(
+      [this.nodeBin, this.helperPath, this.terminalId, String(cols), String(rows)],
+      {
+        stdin: "pipe" as const,
+        stdout: "pipe" as const,
+        stderr: "inherit" as const,
+        env: { ...process.env, HERDR_BIN: config.herdrBin },
+        onExit: () => this.ws.close(),
+      },
+    ) as NodeProc;
     (async () => {
       for await (const chunk of this.proc!.stdout as ReadableStream<Uint8Array>) {
         this.ws.send(chunk);

--- a/test/node-bin.test.ts
+++ b/test/node-bin.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "bun:test";
+import { resolveNodeBin } from "../src/node-bin";
+
+const never = () => null;
+const noExist = () => false;
+
+test("override wins over everything (trimmed)", () => {
+  expect(
+    resolveNodeBin({
+      override: "  /opt/node/bin/node  ",
+      which: () => "/usr/bin/node",
+      exists: () => true,
+    }),
+  ).toBe("/opt/node/bin/node");
+});
+
+test("blank/whitespace override is ignored", () => {
+  expect(resolveNodeBin({ override: "   ", which: () => "/usr/bin/node" })).toBe("/usr/bin/node");
+});
+
+test("falls back to node on PATH when no override", () => {
+  expect(resolveNodeBin({ override: null, which: () => "/home/u/.bun/bin/node" })).toBe(
+    "/home/u/.bun/bin/node",
+  );
+});
+
+test("probes the mise shims dir when node is not on PATH", () => {
+  const home = "/home/u";
+  const shim = `${home}/.local/share/mise/shims/node`;
+  expect(resolveNodeBin({ which: never, home, exists: (p) => p === shim })).toBe(shim);
+});
+
+test("probes common bin dirs when neither PATH nor mise has it", () => {
+  expect(
+    resolveNodeBin({ which: never, home: "/home/u", exists: (p) => p === "/usr/bin/node" }),
+  ).toBe("/usr/bin/node");
+});
+
+test("falls back to bare 'node' when nothing resolves", () => {
+  expect(resolveNodeBin({ which: never, home: "/home/u", exists: noExist })).toBe("node");
+});


### PR DESCRIPTION
## Problem

Wenn Shepherd unter **systemd** (oder einem anderen Launcher) mit einem PATH läuft, der den per **mise/nvm/fnm** verwalteten `node` nicht enthält, scheitert der PTY-Attach-Helper (`pty-attach.mjs`) lautlos beim Spawn — und **jede Session-Kachel bleibt schwarz**, obwohl der Agent unter herdr läuft.

Konkret auf der Dev-Box aufgetreten: `node` liegt unter `~/.local/share/mise/installs/node/…`, das systemd-Unit hatte aber nur `~/.bun/bin:~/.local/bin:/usr/local/bin:/usr/bin:/bin`. Der Server läuft unter Bun, der Helper braucht aber Node (node-pty ist ein nativer Node-Addon) → `Bun.spawn(["node", …])` findet nichts.

## Fix

Neue Auflösung `resolveNodeBin()` mit klarer Reihenfolge:
1. `SHEPHERD_NODE_BIN` (expliziter Override)
2. `node` auf PATH (`Bun.which`)
3. bekannte Speicherorte: mise-Shims (`~/.local/share/mise/shims/node`), `~/.local/bin`, `/usr/local/bin`, `/usr/bin`, `/bin`
4. bare `"node"` als letzter Ausweg (damit der Fehler lesbar ist statt stiller schwarzer Kachel)

`config.nodeBin` hält den aufgelösten Pfad; `PtyBridge` spawnt diesen statt eines hartcodierten `"node"`.

## Verifikation

- PATH-loses Setup → `resolveNodeBin` findet den mise-Shim; reales Setup → `…/mise/installs/node/24.14.1/bin/node`.
- Neuer Test `test/node-bin.test.ts` (Override / PATH / mise-Shim / bin-Dirs / Fallback).
- `bun run lint` ✅ · `bun run test` ✅ 209/209.

## Hinweis

Macht das `node`-auf-PATH-Erfordernis im ausgelieferten `deploy/shepherd.service` überflüssig — Terminals funktionieren unabhängig vom Launcher-PATH. Unabhängig von #9 / #10, basiert auf `main`.