### PR TITLE
feat(ui): show repo on session cards + focus terminal on select

### DIFF
--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -20,6 +20,9 @@
   const desigParts = $derived(session.desig.match(/^(.*?)(\d+)$/));
   const desigStem = $derived(desigParts?.[1] ?? "");
   const desigNum = $derived(desigParts?.[2] ?? session.desig);
+
+  // repo the unit works in — the last path segment of its repoPath (e.g. "community-map")
+  const repoName = $derived(session.repoPath.split("/").filter(Boolean).at(-1) ?? session.repoPath);
 </script>
 
 <button
@@ -37,6 +40,9 @@
     <div class="u-top">
       <span class="desig micro"><span class="desig-stem">{desigStem}</span>{desigNum}</span>
       <span class="name">{session.name}</span>
+    </div>
+    <div class="u-repo" title={session.repoPath}>
+      <span class="repo-glyph" aria-hidden="true">▣</span>{repoName}
     </div>
     <div class="u-sub">
       {session.prompt}
@@ -151,6 +157,25 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+  }
+
+  .u-repo {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-top: 3px;
+    color: var(--color-ink);
+    font-size: 11.5px;
+    letter-spacing: 0.04em;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 34ch;
+  }
+  .repo-glyph {
+    color: var(--color-amber);
+    font-size: 10px;
+    flex-shrink: 0;
   }
 
   .u-sub {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -209,6 +209,11 @@
     requestAnimationFrame(() => {
       fit.fit();
       c.resize(term.cols, term.rows);
+      // desktop: selecting a unit hands the keyboard straight to its terminal —
+      // clicking a sidebar card otherwise leaves focus on the card button, so
+      // typing goes nowhere. Mobile keeps tap-to-focus so the soft keyboard
+      // doesn't pop open on every selection.
+      if (!mobile && !touch && tab === "term") term.focus();
     });
 
     const ro = new ResizeObserver(() => {


### PR DESCRIPTION
Two small herd-overview UX fixes (independent, based on `main`).

## 1. Repo visible on each card
The overview showed `UNIT-xx` (designation), the generated name, and the prompt — but **never which repo** a unit works in. Added a repo line (last segment of `repoPath`, full path on hover) under the name.

## 2. Terminal focus on select (desktop)
Clicking a sidebar card left keyboard focus on the **card button**, so typing right after a click went nowhere until you clicked into the terminal. Now the terminal grabs focus on attach (desktop only — mobile keeps tap-to-focus so the soft keyboard doesn't auto-open).

## Verifikation
- `bun run check` ✅ 0 errors / 0 warnings · UI build ✅

Note: `UNIT-02` etc. is the sequential unit **designation** (`desig`); the bold word next to it is the AI-generated **name** from the prompt.