### PR TITLE
fix(pty): stop mobile terminal reconnect loop on resize storms

### DIFF
--- a/src/pty-attach.mjs
+++ b/src/pty-attach.mjs
@@ -21,9 +21,26 @@ const pty = spawn(herdrBin, ["agent", "attach", terminalId, "--takeover"], {
 pty.onData((d) => process.stdout.write(d));
 pty.onExit(({ exitCode }) => process.exit(exitCode ?? 0));
 
+// Guard write/resize: when the herdr attach pty is transiently gone (e.g. a
+// takeover bumped this client between frames), node-pty throws EBADF. Letting
+// that propagate crashes the helper → the WS closes → the client reconnects →
+// on mobile, resize storms re-trigger it instantly: a visible jump loop. Swallow
+// it; pty.onExit handles a genuine exit cleanly.
 const demux = createDemux({
-  onInput: (data) => pty.write(data),
-  onResize: (c, r) => pty.resize(c, r),
+  onInput: (data) => {
+    try {
+      pty.write(data);
+    } catch {
+      /* pty gone; onExit will fire */
+    }
+  },
+  onResize: (c, r) => {
+    try {
+      pty.resize(c, r);
+    } catch {
+      /* pty gone; onExit will fire */
+    }
+  },
 });
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => demux.feed(chunk));

--- a/src/pty-demux.mjs
+++ b/src/pty-demux.mjs
@@ -9,6 +9,11 @@
 // terminal. This splits the buffer at NUL boundaries so that can't happen.
 export function createDemux({ onInput, onResize }) {
   let buf = "";
+  // last forwarded size; mobile storms identical resize frames on keyboard /
+  // URL-bar toggles — forwarding each one repaints the TUI (and can poke a
+  // transiently-dead pty), so only forward genuine size changes.
+  let lastC = -1;
+  let lastR = -1;
   return {
     feed(chunk) {
       buf += chunk;
@@ -20,7 +25,13 @@ export function createDemux({ onInput, onResize }) {
         while (buf.startsWith("\x00resize:") && (nl = buf.indexOf("\n")) !== -1) {
           const [, c, r] = buf.slice(0, nl).split(":");
           buf = buf.slice(nl + 1);
-          onResize(Number(c) || 100, Number(r) || 30);
+          const cols = Number(c) || 100;
+          const rows = Number(r) || 30;
+          if (cols !== lastC || rows !== lastR) {
+            lastC = cols;
+            lastR = rows;
+            onResize(cols, rows);
+          }
           progressed = true;
         }
         // forward the leading run of input, stopping at the next NUL (which

--- a/test/pty-demux.test.ts
+++ b/test/pty-demux.test.ts
@@ -34,6 +34,28 @@ test("LEAK BUG: text before a resize frame must NOT leak control bytes", () => {
   expect(resizes).toEqual([[90, 28]]);
 });
 
+test("suppresses identical consecutive resizes, forwards real changes", () => {
+  // mobile storms the same size on keyboard/URL-bar toggles; only real changes
+  // should reach the pty (each forwarded resize repaints the TUI)
+  const { resizes } = run([
+    "\x00resize:90:28\n",
+    "\x00resize:90:28\n",
+    "\x00resize:100:30\n",
+    "\x00resize:100:30\n",
+    "\x00resize:90:28\n",
+  ]);
+  expect(resizes).toEqual([
+    [90, 28],
+    [100, 30],
+    [90, 28],
+  ]);
+});
+
+test("dedup holds across a chunk split mid-frame", () => {
+  const { resizes } = run(["\x00resize:90:28\n\x00resize:90:", "28\n"]);
+  expect(resizes).toEqual([[90, 28]]); // second (identical) frame suppressed
+});
+
 test("buffers a resize frame split across chunks", () => {
   const { input, resizes } = run(["\x00resize:90:", "28\nX"]);
   expect(resizes).toEqual([[90, 28]]);


### PR DESCRIPTION
## Symptom
On **mobile** the terminal screen jumps constantly and flashes a herdr socket re-attach message. **Desktop is unaffected.**

## Cause
Mobile browsers fire `resize` continuously (URL-bar show/hide, soft keyboard). Two things turned that into a reconnect loop:
1. `pty.resize` / `pty.write` throw `EBADF` (ioctl on a closed fd) when the herdr attach pty is transiently gone (e.g. bumped between frames). The throw propagated and **crashed the attach helper** → WS closes → client reconnects after 1s → the next resize re-crashes it → visible jump loop.
2. The demux forwarded **every** resize frame, including identical ones, repainting the TUI each time.

Desktop never hit it: stable size → no resize storm.

## Fix
- `pty-attach.mjs`: wrap `pty.write`/`pty.resize` in try/catch — a dead pty no longer crashes the helper (`onExit` handles a genuine exit).
- `pty-demux.mjs`: suppress no-op resizes; forward only real size changes.

## Verifikation
- New demux tests (dedup + dedup-across-chunk-split). `bun run lint` ✅ · `bun run test` ✅ 205/205.

## Note
Independent, based on `main`. Does **not** address the separate single-owner/takeover behaviour when the *same* session is open on two devices — that's a UX decision tracked separately.