### PR TITLE
feat(ui): paste an image into the terminal (Cmd/Ctrl+V)

### DIFF
--- a/ui/src/lib/clipboard.test.ts
+++ b/ui/src/lib/clipboard.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { imageFilesFromItems } from "./clipboard";
+
+/** Minimal DataTransferItem stub. */
+function item(kind: string, type: string, file: File | null): DataTransferItem {
+  return { kind, type, getAsFile: () => file } as unknown as DataTransferItem;
+}
+
+function list(items: DataTransferItem[]): DataTransferItemList {
+  const l = { length: items.length } as unknown as Record<number, DataTransferItem> & {
+    length: number;
+  };
+  items.forEach((it, i) => (l[i] = it));
+  return l as unknown as DataTransferItemList;
+}
+
+const png = new File(["x"], "shot.png", { type: "image/png" });
+
+describe("imageFilesFromItems", () => {
+  it("returns image files (Cmd+V of a screenshot)", () => {
+    const out = imageFilesFromItems(list([item("file", "image/png", png)]));
+    expect(out).toEqual([png]);
+  });
+
+  it("ignores plain-text items (so text paste falls through to xterm)", () => {
+    const out = imageFilesFromItems(list([item("string", "text/plain", null)]));
+    expect(out).toEqual([]);
+  });
+
+  it("picks only the image out of a mixed clipboard", () => {
+    const out = imageFilesFromItems(
+      list([item("string", "text/plain", null), item("file", "image/png", png)]),
+    );
+    expect(out).toEqual([png]);
+  });
+
+  it("skips image items whose getAsFile yields null", () => {
+    expect(imageFilesFromItems(list([item("file", "image/png", null)]))).toEqual([]);
+  });
+
+  it("handles null/empty clipboard", () => {
+    expect(imageFilesFromItems(null)).toEqual([]);
+    expect(imageFilesFromItems(list([]))).toEqual([]);
+  });
+});

--- a/ui/src/lib/clipboard.ts
+++ b/ui/src/lib/clipboard.ts
@@ -1,0 +1,19 @@
+/**
+ * Extract image files from a clipboard/drag `DataTransferItemList`.
+ *
+ * Used by the terminal's paste handler: xterm only pastes text, so a copied
+ * screenshot (Cmd/Ctrl+V) is otherwise dropped. We pull image items out here,
+ * upload them, and inject their paths — the same flow as a drag-drop.
+ */
+export function imageFilesFromItems(items: DataTransferItemList | null | undefined): File[] {
+  const out: File[] = [];
+  if (!items) return out;
+  for (let i = 0; i < items.length; i++) {
+    const it = items[i];
+    if (it && it.kind === "file" && it.type.startsWith("image/")) {
+      const f = it.getAsFile();
+      if (f) out.push(f);
+    }
+  }
+  return out;
+}

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -6,6 +6,7 @@
   import { elapsed, STATUS_COLOR, statusLabel, formatTokens } from "$lib/format";
   import { connectPty, type PtyConn } from "$lib/pty";
   import { getSessionUsage, uploadImage } from "$lib/api";
+  import { imageFilesFromItems } from "$lib/clipboard";
   import TodoPanel from "$lib/components/TodoPanel.svelte";
   import IssuesPanel from "$lib/components/IssuesPanel.svelte";
   import ControlBar from "$lib/components/ControlBar.svelte";
@@ -174,6 +175,19 @@
     };
     el.addEventListener("click", onTap);
 
+    // Cmd/Ctrl+V of an image: xterm only pastes text, so a copied screenshot is
+    // silently dropped. Intercept in the capture phase (before xterm's textarea
+    // handler), upload any image like a drag-drop, and inject its path. A plain
+    // text paste matches no image item, so it falls through to xterm untouched.
+    const onPaste = (e: ClipboardEvent) => {
+      const imgs = imageFilesFromItems(e.clipboardData?.items);
+      if (imgs.length === 0) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      attachImages(imgs);
+    };
+    el.addEventListener("paste", onPaste, true);
+
     // Claude Code runs as a full-screen TUI on the alternate screen (no
     // scrollback) with mouse tracking on: scrolling means sending wheel input
     // to the app, which is what the mouse wheel does on desktop. Touch emits no
@@ -221,6 +235,7 @@
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("pageshow", onPageShow);
       el?.removeEventListener("click", onTap);
+      el?.removeEventListener("paste", onPaste, true);
       el?.removeEventListener("touchstart", onTouchStart);
       el?.removeEventListener("touchmove", onTouchMove);
       el?.removeEventListener("touchend", onTouchEnd);


### PR DESCRIPTION
## Want
Paste a screenshot straight into a session's terminal with **Cmd/Ctrl+V** — like Claude Code in a native terminal, and like the existing drag-drop. Essential for mobile app dev (screenshots).

## Why it didn't work
xterm's paste handler only reads **text** from the clipboard; an image item is ignored, so nothing happened. Shepherd already had the upload + path-injection flow (`attachImages` / drag-drop) — it just wasn't wired to clipboard paste.

## Fix
- `clipboard.ts`: `imageFilesFromItems()` pulls image files out of a `DataTransferItemList` (unit-tested).
- `Viewport.svelte`: a capture-phase `paste` listener (before xterm's textarea handler) extracts images, `preventDefault`s, and runs them through the same `attachImages` flow (upload → inject path as a bracketed paste). A plain-text paste matches no image item and falls through to xterm untouched.

Works on desktop (Cmd+V) and any browser that exposes image clipboard items.

## Verifikation
- New `clipboard.test.ts` (image / text / mixed / null cases). `bun run check` ✅ · `bun run test` ✅ 28/28 · build ✅.