### PR TITLE
feat(pty): graceful single-owner terminal handoff across devices

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import type { UsageLimitsService } from "./usage-limits";
 import type { Session } from "./types";
 import type { GitForge, MergeMethod } from "./forge/types";
 import { join, normalize } from "node:path";
+import type { ServerWebSocket } from "bun";
 
 const UI_DIR = join(import.meta.dir, "..", "ui", "build");
 
@@ -247,8 +248,16 @@ type WsData =
   | { kind: "events" }
   | { kind: "pty"; terminalId: string; cols: number; rows: number; bridge?: PtyBridge };
 
+// A pty WS closed with this code means "a newer client took over this terminal".
+// The client parks (shows a take-over prompt) instead of reconnecting — without
+// it, two devices on the same session ping-pong herdr's --takeover forever.
+// Keep in sync with PTY_SUPERSEDED_CODE in ui/src/lib/pty.ts.
+export const PTY_SUPERSEDED_CODE = 4000;
+
 export function serve(deps: AppDeps, port: number) {
   const app = makeApp(deps);
+  // current owning socket per terminal — a single owner avoids the takeover war
+  const ptyOwners = new Map<string, ServerWebSocket<WsData>>();
   return Bun.serve<WsData>({
     port,
     hostname: config.host,
@@ -300,7 +309,13 @@ export function serve(deps: AppDeps, port: number) {
           );
           (ws.data as any).unsub = unsub;
         } else {
-          const bridge = new PtyBridge(ws.data.terminalId, {
+          // single owner per terminal: claim it, then bump the previous owner
+          // with a "superseded" close so it parks instead of fighting back.
+          const tid = ws.data.terminalId;
+          const prev = ptyOwners.get(tid);
+          ptyOwners.set(tid, ws);
+          if (prev && prev !== ws) prev.close(PTY_SUPERSEDED_CODE, "superseded");
+          const bridge = new PtyBridge(tid, {
             send: (d) => ws.send(d),
             close: () => ws.close(),
           });
@@ -314,7 +329,12 @@ export function serve(deps: AppDeps, port: number) {
       },
       close(ws) {
         if (ws.data.kind === "events") (ws.data as any).unsub?.();
-        else ws.data.bridge?.close();
+        else {
+          // only drop ownership if we're still the owner (a newer client may have
+          // already claimed this terminal before our close fired)
+          if (ptyOwners.get(ws.data.terminalId) === ws) ptyOwners.delete(ws.data.terminalId);
+          ws.data.bridge?.close();
+        }
       },
     },
   });

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -32,6 +32,8 @@
   let el: HTMLDivElement | undefined = $state();
   let tab = $state<"term" | "todo" | "issues">("term");
   let conn = $state<PtyConn | undefined>();
+  // true when another device took over this terminal — show a take-over prompt
+  let parked = $state(false);
   let dragging = $state(false);
   let uploading = $state(false);
   let uploadFailed = $state(false);
@@ -119,9 +121,15 @@
     if (e.dataTransfer?.files?.length) attachImages(e.dataTransfer.files);
   }
 
+  function takeover() {
+    parked = false;
+    conn?.takeover();
+  }
+
   $effect(() => {
     const id = unitId;
     if (!el) return;
+    parked = false; // fresh attach for this unit
 
     const term = new Terminal({
       fontFamily: "'JetBrains Mono', monospace",
@@ -150,6 +158,10 @@
       () => {
         fit.fit();
         c.resize(term.cols, term.rows);
+      },
+      // another device took over this terminal — park and offer to take it back
+      () => {
+        parked = true;
       },
     );
     conn = c;
@@ -319,6 +331,13 @@
       }}
       ondrop={onTermDrop}
     ></div>
+    {#if parked && tab === "term"}
+      <button class="parked" type="button" onclick={takeover}>
+        <span class="parked-icon" aria-hidden="true">▶</span>
+        <span class="parked-title">Auf anderem Gerät aktiv</span>
+        <span class="parked-sub">Tippen zum Übernehmen</span>
+      </button>
+    {/if}
     {#if tab === "todo"}
       <div class="panel-wrap">
         <TodoPanel repoPath={session.repoPath} />
@@ -510,6 +529,40 @@
     overflow: hidden;
     /* we drive vertical scroll via touch handlers; keep the browser out of it */
     touch-action: none;
+  }
+
+  /* parked: this terminal is live on another device — tap to take it back */
+  .parked {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    background: color-mix(in srgb, var(--color-bg, #070a09) 78%, transparent);
+    backdrop-filter: blur(1.5px);
+    border: 0;
+    cursor: pointer;
+    font: inherit;
+    color: var(--color-ink);
+  }
+  .parked-icon {
+    color: var(--color-amber);
+    font-size: 22px;
+    line-height: 1;
+  }
+  .parked-title {
+    color: var(--color-ink-bright);
+    letter-spacing: 0.08em;
+    font-size: 13px;
+  }
+  .parked-sub {
+    color: var(--color-muted);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
   }
 
   /* let xterm fill the mount */

--- a/ui/src/lib/pty.test.ts
+++ b/ui/src/lib/pty.test.ts
@@ -19,7 +19,7 @@ class FakeWs {
   sent: (string | ArrayBufferLike | ArrayBufferView)[] = [];
   onmessage: ((e: { data: unknown }) => void) | null = null;
   onopen: (() => void) | null = null;
-  onclose: (() => void) | null = null;
+  onclose: ((e?: { code?: number }) => void) | null = null;
   onerror: (() => void) | null = null;
 
   constructor(public url: string) {
@@ -33,6 +33,11 @@ class FakeWs {
     this.readyState = this.CLOSED;
     this.onclose?.();
   }
+  /** server bumped us with the superseded close code (another device took over) */
+  supersede(code = 4000) {
+    this.readyState = this.CLOSED;
+    this.onclose?.({ code });
+  }
   send(d: string | ArrayBufferLike | ArrayBufferView) {
     this.sent.push(d);
   }
@@ -41,7 +46,7 @@ class FakeWs {
   }
 }
 
-function make(onReconnect = () => {}) {
+function make(onReconnect = () => {}, onParked = () => {}) {
   FakeWs.instances = [];
   const onData = vi.fn();
   const conn = connectPty(
@@ -50,6 +55,7 @@ function make(onReconnect = () => {}) {
     30,
     onData,
     onReconnect,
+    onParked,
     (path) => new FakeWs(path) as unknown as WebSocket,
   );
   return { conn, onData, last: () => FakeWs.instances[FakeWs.instances.length - 1] };
@@ -95,6 +101,37 @@ describe("connectPty", () => {
     last().open();
     conn.poke();
     expect(FakeWs.instances).toHaveLength(1);
+  });
+
+  it("parks on a superseded close and does NOT reconnect", () => {
+    vi.useFakeTimers();
+    const onParked = vi.fn();
+    const { last } = make(() => {}, onParked);
+    last().open();
+
+    last().supersede(); // another device took over (close code 4000)
+    expect(onParked).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(5000);
+    expect(FakeWs.instances).toHaveLength(1); // never reconnected — no takeover war
+    vi.useRealTimers();
+  });
+
+  it("poke does not steal back a parked terminal", () => {
+    const { conn, last } = make();
+    last().open();
+    last().supersede();
+    conn.poke();
+    expect(FakeWs.instances).toHaveLength(1); // still parked, no new socket
+  });
+
+  it("takeover re-attaches after being parked", () => {
+    const { conn, last } = make();
+    last().open();
+    last().supersede();
+    conn.takeover();
+    expect(FakeWs.instances).toHaveLength(2); // new attach → becomes owner again
+    expect(last().url).toBe("/pty/abc?cols=100&rows=30");
   });
 
   it("close stops reconnection", () => {

--- a/ui/src/lib/pty.ts
+++ b/ui/src/lib/pty.ts
@@ -1,5 +1,10 @@
 import { wsUrl } from "./store.svelte";
 
+// Server closes a pty WS with this code when a newer client takes over the
+// terminal. We park instead of reconnecting, so two devices on the same session
+// don't ping-pong the attach. Keep in sync with PTY_SUPERSEDED_CODE in src/server.ts.
+const PTY_SUPERSEDED_CODE = 4000;
+
 export interface PtyConn {
   send(data: string): void;
   resize(c: number, r: number): void;
@@ -10,6 +15,8 @@ export interface PtyConn {
    * running, so a fresh attach (`--takeover`) repaints the live session.
    */
   poke(): void;
+  /** Re-attach after being parked (superseded) — makes this client the owner again. */
+  takeover(): void;
 }
 
 export function connectPty(
@@ -20,10 +27,14 @@ export function connectPty(
   // fired on every reconnect (not the first connect) — caller refits + resizes
   // so a fresh attach repaints at the current size
   onReconnect: () => void = () => {},
+  // fired when the server hands this terminal to another device — caller shows a
+  // "take over" affordance instead of fighting for the attach
+  onParked: () => void = () => {},
   makeWs: (path: string) => WebSocket = (p) => new WebSocket(wsUrl(p)),
 ): PtyConn {
   let ws: WebSocket;
   let stopped = false;
+  let parked = false;
   let everOpened = false;
   let retry: ReturnType<typeof setTimeout> | null = null;
   // track the latest fitted size so a reconnect attaches at the right dimensions
@@ -32,6 +43,7 @@ export function connectPty(
   let lastRows = rows;
 
   const open = () => {
+    parked = false;
     if (retry) {
       clearTimeout(retry);
       retry = null;
@@ -44,8 +56,15 @@ export function connectPty(
       if (everOpened) onReconnect();
       everOpened = true;
     };
-    ws.onclose = () => {
-      if (!stopped && !retry) retry = setTimeout(open, 1000);
+    ws.onclose = (e) => {
+      // a newer client took the terminal → park; never auto-reconnect (that would
+      // bump them right back, and they'd bump us: the takeover war)
+      if (e && e.code === PTY_SUPERSEDED_CODE) {
+        parked = true;
+        onParked();
+        return;
+      }
+      if (!stopped && !parked && !retry) retry = setTimeout(open, 1000);
     };
     ws.onerror = () => ws.close();
   };
@@ -64,10 +83,14 @@ export function connectPty(
       ws.close();
     },
     poke: () => {
-      if (stopped) return;
+      if (stopped || parked) return; // parked is deliberate — don't steal back on refocus
       // a scheduled retry → run it immediately; otherwise reconnect only if the
       // socket is actually gone (CLOSING/CLOSED), never disturb a live one
       if (retry || ws.readyState >= ws.CLOSING) open();
+    },
+    takeover: () => {
+      if (stopped) return;
+      open(); // re-attach → server makes us the owner and parks the other device
     },
   };
 }


### PR DESCRIPTION
## Problem
Opening the **same session on a second device** (e.g. desktop + phone) makes the screen jump and flash a re-attach forever. Each browser attaches with herdr `--takeover`, bumping the other; the bumped one reconnects after 1s and bumps back — an endless **takeover war**. herdr allows only **one owner per terminal**.

## Approach — graceful handoff (chosen over a shared multi-client view)
Single owner, but no fighting:
- **Server** (`server.ts`): track the owning socket per terminal. A new pty connection claims ownership and closes the previous owner with a dedicated code (`4000 superseded`).
- **Client** (`pty.ts`): on a `4000` close, **park** instead of reconnecting (reconnecting would just bump the new owner → war). New `takeover()` re-attaches on demand; `poke()` no longer steals back a parked terminal on tab refocus.
- **UI** (`Viewport.svelte`): a parked terminal shows *„Auf anderem Gerät aktiv — Tippen zum Übernehmen"*; tapping takes it back (which parks the other device).

Result: both devices stay open, no jumping; whichever you touch becomes live, the other parks calmly.

## Verifikation
- New `pty.test.ts` cases: parks on superseded close (no reconnect), poke doesn't steal back, takeover re-attaches.
- `bun run lint` ✅ · root `bun run test` ✅ 203 · UI `bun run check` ✅ · UI `bun run test` ✅ 26 · build ✅.

## Note
The discarded alternative (one shared attach streamed to all devices, both live) hits a hard limit: one TUI = one size, so desktop+phone can't both render well. Handoff sidesteps that.