### PR TITLE
feat(ui): light/dark/system theme switcher

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { resolveNodeBin } from "./node-bin";
+
 export const config = {
   port: Number(process.env.SHEPHERD_PORT ?? 7330),
   // bind to loopback only; the Tailscale-serve proxy reaches it via 127.0.0.1.
@@ -5,6 +7,10 @@ export const config = {
   host: process.env.SHEPHERD_HOST ?? "127.0.0.1",
   dbPath: process.env.SHEPHERD_DB ?? `${process.env.HOME}/.shepherd/shepherd.db`,
   herdrBin: process.env.HERDR_BIN ?? "herdr",
+  // node binary for the PTY attach helper (pty-attach.mjs). Resolved so a node
+  // managed by mise/nvm/fnm still works when the launcher's PATH excludes it —
+  // otherwise the helper can't spawn and every session pane stays black.
+  nodeBin: resolveNodeBin({ override: process.env.SHEPHERD_NODE_BIN }),
   herdrSession: process.env.HERDR_SESSION ?? "default",
   ollamaModel: process.env.SHEPHERD_NAMER_MODEL ?? "mistral-small3.1:latest",
   ollamaEndpoint: process.env.OLLAMA_URL ?? "http://localhost:11434/api/generate",

--- a/src/dirs.ts
+++ b/src/dirs.ts
@@ -1,0 +1,80 @@
+import { readdirSync, statSync } from "node:fs";
+import { resolve, join, dirname } from "node:path";
+import { expandHome } from "./validate";
+
+const home = (): string => process.env.HOME ?? "";
+
+/** Collapse a leading home-dir prefix to `~` for friendlier display. */
+export function collapseHome(p: string): string {
+  const h = home();
+  return h && (p === h || p.startsWith(h + "/")) ? "~" + p.slice(h.length) : p;
+}
+
+export interface DirEntry {
+  name: string;
+  path: string;
+}
+
+export interface DirListing {
+  /** Absolute path currently being listed. */
+  path: string;
+  /** `~`-collapsed form of `path` for display. */
+  display: string;
+  /** Parent dir, or null when at the filesystem root. */
+  parent: string | null;
+  /** Immediate sub-directories (dotdirs excluded), sorted by name. */
+  entries: DirEntry[];
+}
+
+/**
+ * List the immediate sub-directories of `pathRaw` for the root-directory browser.
+ * Read-only. Empty/invalid input falls back to $HOME; an unreadable path climbs to
+ * the nearest readable ancestor so the browser never lands on a dead end.
+ */
+export function listDirs(pathRaw: string): DirListing {
+  const start = pathRaw && pathRaw.trim() ? pathRaw.trim() : home() || "/";
+  let dir = resolve(expandHome(start));
+  try {
+    if (!statSync(dir).isDirectory()) dir = dirname(dir);
+  } catch {
+    dir = home() || "/";
+  }
+
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    names = [];
+  }
+
+  const entries = names
+    .filter((n) => !n.startsWith("."))
+    .map((n) => ({ name: n, path: join(dir, n) }))
+    .filter((e) => {
+      try {
+        return statSync(e.path).isDirectory();
+      } catch {
+        return false; // unreadable / broken symlink → skip
+      }
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const parent = dirname(dir);
+  return {
+    path: dir,
+    display: collapseHome(dir),
+    parent: parent === dir ? null : parent,
+    entries,
+  };
+}
+
+/** Validate a candidate repo root. Returns the resolved absolute path, or null if invalid. */
+export function validateRoot(pathRaw: unknown): string | null {
+  if (typeof pathRaw !== "string" || pathRaw.trim().length === 0) return null;
+  const resolved = resolve(expandHome(pathRaw.trim()));
+  try {
+    return statSync(resolved).isDirectory() ? resolved : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { mkdirSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { config } from "./config";
 import { SessionStore } from "./store";
 import { WorktreeMgr } from "./worktree";
@@ -10,6 +10,8 @@ import { SessionService } from "./service";
 import { StatusPoller } from "./poller";
 import { reconcile } from "./reconcile";
 import { serve } from "./server";
+import { detectForge } from "./forge";
+import { loadForgeMap } from "./forge/load-config";
 import { AccountUsageIndex } from "./usage";
 import { UsageLimitsService } from "./usage-limits";
 import { HerdrUsageProbe } from "./usage-probe";
@@ -59,5 +61,13 @@ const calibrate = async () => {
 setTimeout(calibrate, 3_000);
 setInterval(calibrate, 24 * 60 * 60 * 1000);
 
-const server = serve({ store, service, events, usageLimits }, config.port);
+// forge resolution: detect a repo's GitHub/Gitea host from its `origin` remote.
+// Per-host config (tokens, gitea base URLs) is optional — github.com works through
+// the operator's existing `gh` CLI auth, so an absent forges.json is fine.
+const forgeMap = loadForgeMap(join(dirname(config.dbPath), "forges.json"));
+
+const server = serve(
+  { store, service, events, usageLimits, resolveForge: (dir) => detectForge(dir, forgeMap) },
+  config.port,
+);
 console.log(`shepherd core on http://localhost:${server.port}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,14 @@ import { HerdrUsageProbe } from "./usage-probe";
 import { sweepStaging } from "./uploads";
 
 mkdirSync(dirname(config.dbPath), { recursive: true });
-// drop abandoned New-Task uploads (attached but never submitted) older than 24h
-sweepStaging(config.repoRoot, 24 * 60 * 60 * 1000, Date.now());
 
 const store = new SessionStore(config.dbPath);
+// a repo root chosen in the UI (persisted) overrides the env var / default
+const savedRoot = store.getSetting("repoRoot");
+if (savedRoot) config.repoRoot = savedRoot;
+
+// drop abandoned New-Task uploads (attached but never submitted) older than 24h
+sweepStaging(config.repoRoot, 24 * 60 * 60 * 1000, Date.now());
 const herdr = new HerdrDriver();
 const worktree = new WorktreeMgr();
 const events = new EventHub();

--- a/src/node-bin.ts
+++ b/src/node-bin.ts
@@ -1,0 +1,48 @@
+import { existsSync } from "node:fs";
+
+export interface ResolveNodeOpts {
+  /** Explicit override (SHEPHERD_NODE_BIN); wins over everything when non-empty. */
+  override?: string | null;
+  /** PATH lookup; defaults to Bun.which. Injectable for tests. */
+  which?: (cmd: string) => string | null;
+  /** Existence probe; defaults to fs.existsSync. Injectable for tests. */
+  exists?: (p: string) => boolean;
+  /** Home dir; defaults to $HOME. Injectable for tests. */
+  home?: string;
+}
+
+/**
+ * Resolve a `node` binary for spawning the PTY attach helper (pty-attach.mjs).
+ *
+ * The server itself runs under Bun, but the helper needs Node (node-pty is a
+ * native Node addon). When Shepherd runs under systemd or another launcher whose
+ * PATH excludes a version-manager-managed node (mise/nvm/fnm), spawning bare
+ * "node" fails — and every session pane silently stays black. Resolution order:
+ *   1. explicit override (SHEPHERD_NODE_BIN)
+ *   2. node on PATH
+ *   3. known install locations (mise shims, common bin dirs)
+ *   4. bare "node" as a last resort, so the spawn error is at least legible
+ */
+export function resolveNodeBin(opts: ResolveNodeOpts = {}): string {
+  const override = opts.override;
+  if (typeof override === "string" && override.trim()) return override.trim();
+
+  const which = opts.which ?? ((c) => Bun.which(c));
+  const onPath = which("node");
+  if (onPath) return onPath;
+
+  const exists = opts.exists ?? existsSync;
+  const home = opts.home ?? process.env.HOME ?? "";
+  const candidates = [
+    home && `${home}/.local/share/mise/shims/node`, // mise (managed node)
+    home && `${home}/.local/bin/node`,
+    "/usr/local/bin/node",
+    "/usr/bin/node",
+    "/bin/node",
+  ].filter((c): c is string => Boolean(c));
+
+  for (const c of candidates) {
+    if (exists(c)) return c;
+  }
+  return "node"; // surfaces a clear ENOENT instead of a silent black pane
+}

--- a/src/pty-bridge.ts
+++ b/src/pty-bridge.ts
@@ -15,17 +15,21 @@ export class PtyBridge {
     private terminalId: string,
     private ws: PtySocket,
     private helperPath = new URL("./pty-attach.mjs", import.meta.url).pathname,
+    private nodeBin = config.nodeBin,
   ) {}
 
   open(cols = 100, rows = 30): void {
     if (!isValidTerminalId(this.terminalId)) throw new Error("invalid terminalId");
-    this.proc = Bun.spawn(["node", this.helperPath, this.terminalId, String(cols), String(rows)], {
-      stdin: "pipe" as const,
-      stdout: "pipe" as const,
-      stderr: "inherit" as const,
-      env: { ...process.env, HERDR_BIN: config.herdrBin },
-      onExit: () => this.ws.close(),
-    }) as NodeProc;
+    this.proc = Bun.spawn(
+      [this.nodeBin, this.helperPath, this.terminalId, String(cols), String(rows)],
+      {
+        stdin: "pipe" as const,
+        stdout: "pipe" as const,
+        stderr: "inherit" as const,
+        env: { ...process.env, HERDR_BIN: config.herdrBin },
+        onExit: () => this.ws.close(),
+      },
+    ) as NodeProc;
     (async () => {
       for await (const chunk of this.proc!.stdout as ReadableStream<Uint8Array>) {
         this.ws.send(chunk);

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import {
   parseTermDims,
 } from "./validate";
 import { listRepos, readTodo, writeTodo } from "./repos";
+import { listDirs, validateRoot, collapseHome } from "./dirs";
 import { listBranches } from "./branches";
 import { sessionTokens, jsonlPathFor } from "./usage";
 import { handleUpload } from "./uploads";
@@ -187,6 +188,29 @@ export function makeApp(deps: AppDeps) {
           }));
           return json(repos);
         }
+      }
+
+      // ── settings: read/update the repo root (persisted, applied at runtime) ──
+      if (parts[0] === "api" && parts[1] === "settings" && !parts[2]) {
+        if (req.method === "GET") {
+          return json({
+            repoRoot: config.repoRoot,
+            repoRootDisplay: collapseHome(config.repoRoot),
+          });
+        }
+        if (req.method === "PUT") {
+          const body = (await req.json().catch(() => null)) as { repoRoot?: unknown } | null;
+          const root = validateRoot(body?.repoRoot);
+          if (!root) return json({ error: "repoRoot must be an existing directory" }, 400);
+          config.repoRoot = root; // live: every later read picks it up
+          deps.store.setSetting("repoRoot", root); // persist across restarts
+          return json({ repoRoot: root, repoRootDisplay: collapseHome(root) });
+        }
+      }
+
+      // ── filesystem browser: list sub-directories for the root picker ──
+      if (req.method === "GET" && parts[0] === "api" && parts[1] === "fs" && parts[2] === "dirs") {
+        return json(listDirs(url.searchParams.get("path") ?? ""));
       }
 
       if (req.method === "GET" && parts[0] === "api" && parts[1] === "branches" && !parts[2]) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -42,6 +42,25 @@ export class SessionStore implements CapStore {
     this.db.run(`CREATE TABLE IF NOT EXISTS usage_caps (
       window TEXT PRIMARY KEY, cap REAL NOT NULL, resetAt INTEGER NOT NULL,
       pct INTEGER NOT NULL, scrapedAt INTEGER NOT NULL)`);
+    // small key/value store for runtime-configurable settings (e.g. repoRoot)
+    this.db.run(`CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY, value TEXT NOT NULL)`);
+  }
+
+  // ── settings (key/value) ──────────────────────────────────────────────────
+  getSetting(key: string): string | null {
+    const r = this.db.query(`SELECT value FROM settings WHERE key = ?`).get(key) as {
+      value: string;
+    } | null;
+    return r ? r.value : null;
+  }
+
+  setSetting(key: string, value: string): void {
+    this.db.run(
+      `INSERT INTO settings (key, value) VALUES (?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      [key, value],
+    );
   }
 
   create(input: NewSession): Session {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -71,30 +71,34 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
   if (obj.images != null) {
     if (!Array.isArray(obj.images)) return err("images must be an array");
     if (obj.images.length > 10) return err("images must be ≤ 10 entries");
-    let stagingReal: string;
-    try {
-      stagingReal = realpathSync(stagingDir(root));
-    } catch {
-      return err("no staged uploads exist");
-    }
-    for (const it of obj.images) {
-      if (typeof it !== "string") return err("each image must be a string path");
-      let real: string;
+    // an empty list needs no confinement — don't require a staging dir to exist
+    // (the staging dir is created lazily on first upload; a fresh repoRoot has none)
+    if (obj.images.length > 0) {
+      let stagingReal: string;
       try {
-        real = realpathSync(resolve(it));
+        stagingReal = realpathSync(stagingDir(root));
       } catch {
-        return err("image does not exist");
+        return err("no staged uploads exist");
       }
-      const inside = real === stagingReal || real.startsWith(stagingReal + sep);
-      if (!inside) return err("image must be inside the staging dir");
-      try {
-        if (!statSync(real).isFile()) return err("image must be a file");
-      } catch {
-        return err("image does not exist");
+      for (const it of obj.images) {
+        if (typeof it !== "string") return err("each image must be a string path");
+        let real: string;
+        try {
+          real = realpathSync(resolve(it));
+        } catch {
+          return err("image does not exist");
+        }
+        const inside = real === stagingReal || real.startsWith(stagingReal + sep);
+        if (!inside) return err("image must be inside the staging dir");
+        try {
+          if (!statSync(real).isFile()) return err("image must be a file");
+        } catch {
+          return err("image does not exist");
+        }
+        images.push(real);
       }
-      images.push(real);
+      if (new Set(images).size !== images.length) return err("duplicate image paths");
     }
-    if (new Set(images).size !== images.length) return err("duplicate image paths");
   }
 
   return {

--- a/test/dirs.test.ts
+++ b/test/dirs.test.ts
@@ -1,0 +1,66 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { listDirs, validateRoot, collapseHome } from "../src/dirs";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "shepherd-dirs-test-"));
+  mkdirSync(join(root, "alpha"));
+  mkdirSync(join(root, "beta"));
+  mkdirSync(join(root, ".hidden"));
+  writeFileSync(join(root, "file.txt"), "not a dir");
+});
+
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+// ── listDirs ──────────────────────────────────────────────────────────────────
+
+test("listDirs returns sorted sub-dirs, excludes files and dotdirs", () => {
+  const l = listDirs(root);
+  expect(l.path).toBe(root);
+  expect(l.entries.map((e) => e.name)).toEqual(["alpha", "beta"]);
+  expect(l.entries[0]!.path).toBe(join(root, "alpha"));
+  expect(l.parent).toBe(dirname(root));
+});
+
+test("listDirs climbs to parent when the path is a file", () => {
+  const l = listDirs(join(root, "file.txt"));
+  expect(l.path).toBe(root);
+  expect(l.entries.map((e) => e.name)).toEqual(["alpha", "beta"]);
+});
+
+test("listDirs on a leaf dir returns empty entries but a valid parent", () => {
+  const l = listDirs(join(root, "alpha"));
+  expect(l.entries).toEqual([]);
+  expect(l.parent).toBe(root);
+});
+
+test("listDirs falls back to $HOME for empty input", () => {
+  const l = listDirs("");
+  expect(l.path).toBe(process.env.HOME ?? "/");
+});
+
+// ── validateRoot ────────────────────────────────────────────────────────────────
+
+test("validateRoot accepts an existing directory and returns the resolved path", () => {
+  expect(validateRoot(join(root, "alpha"))).toBe(join(root, "alpha"));
+});
+
+test("validateRoot rejects a file, a non-existent path, and non-strings", () => {
+  expect(validateRoot(join(root, "file.txt"))).toBeNull();
+  expect(validateRoot(join(root, "nope"))).toBeNull();
+  expect(validateRoot("")).toBeNull();
+  expect(validateRoot(null)).toBeNull();
+  expect(validateRoot(42)).toBeNull();
+});
+
+// ── collapseHome ────────────────────────────────────────────────────────────────
+
+test("collapseHome collapses the home prefix to ~", () => {
+  const home = process.env.HOME ?? "";
+  expect(collapseHome(join(home, "Work"))).toBe("~/Work");
+  expect(collapseHome("/opt/elsewhere")).toBe("/opt/elsewhere");
+});

--- a/test/forge-detect.test.ts
+++ b/test/forge-detect.test.ts
@@ -1,0 +1,38 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectForge } from "../src/forge";
+
+// `index.ts` wires resolveForge as (dir) => detectForge(dir, forgeMap). These
+// tests cover that resolution path: an origin remote → a concrete forge.
+
+let dir: string;
+
+function git(...args: string[]) {
+  execFileSync("git", ["-C", dir, ...args], { stdio: ["ignore", "ignore", "ignore"] });
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "shepherd-forge-detect-"));
+  git("init", "-q");
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+test("detectForge resolves a github.com origin to a github forge with the slug", () => {
+  git("remote", "add", "origin", "https://github.com/acme/widget.git");
+  const forge = detectForge(dir, {});
+  expect(forge).not.toBeNull();
+  expect(forge!.kind).toBe("github");
+  expect(forge!.slug).toBe("acme/widget");
+});
+
+test("detectForge returns null for a repo without an origin remote", () => {
+  expect(detectForge(dir, {})).toBeNull();
+});
+
+test("detectForge returns null for a non-repo / unreadable dir", () => {
+  expect(detectForge(join(dir, "does-not-exist"), {})).toBeNull();
+});

--- a/test/node-bin.test.ts
+++ b/test/node-bin.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "bun:test";
+import { resolveNodeBin } from "../src/node-bin";
+
+const never = () => null;
+const noExist = () => false;
+
+test("override wins over everything (trimmed)", () => {
+  expect(
+    resolveNodeBin({
+      override: "  /opt/node/bin/node  ",
+      which: () => "/usr/bin/node",
+      exists: () => true,
+    }),
+  ).toBe("/opt/node/bin/node");
+});
+
+test("blank/whitespace override is ignored", () => {
+  expect(resolveNodeBin({ override: "   ", which: () => "/usr/bin/node" })).toBe("/usr/bin/node");
+});
+
+test("falls back to node on PATH when no override", () => {
+  expect(resolveNodeBin({ override: null, which: () => "/home/u/.bun/bin/node" })).toBe(
+    "/home/u/.bun/bin/node",
+  );
+});
+
+test("probes the mise shims dir when node is not on PATH", () => {
+  const home = "/home/u";
+  const shim = `${home}/.local/share/mise/shims/node`;
+  expect(resolveNodeBin({ which: never, home, exists: (p) => p === shim })).toBe(shim);
+});
+
+test("probes common bin dirs when neither PATH nor mise has it", () => {
+  expect(
+    resolveNodeBin({ which: never, home: "/home/u", exists: (p) => p === "/usr/bin/node" }),
+  ).toBe("/usr/bin/node");
+});
+
+test("falls back to bare 'node' when nothing resolves", () => {
+  expect(resolveNodeBin({ which: never, home: "/home/u", exists: noExist })).toBe("node");
+});

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -1,0 +1,83 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { makeApp, type AppDeps } from "../src/server";
+import { config } from "../src/config";
+
+let tmp: string;
+let savedRoot: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "shepherd-settings-test-"));
+  mkdirSync(join(tmp, "child"));
+  savedRoot = config.repoRoot; // PUT mutates the shared config; restore after
+});
+
+afterEach(() => {
+  config.repoRoot = savedRoot;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function harness(): { app: ReturnType<typeof makeApp>; store: SessionStore } {
+  const store = new SessionStore(":memory:");
+  const deps: AppDeps = {
+    store,
+    events: new EventHub(),
+    service: {} as any,
+    usageLimits: { limits: () => ({}) } as any,
+  };
+  return { app: makeApp(deps), store };
+}
+
+const put = (app: ReturnType<typeof makeApp>, body: unknown) =>
+  app.fetch(
+    new Request("http://x/api/settings", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+
+test("GET /api/settings returns the current repo root", async () => {
+  config.repoRoot = tmp;
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/settings"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.repoRoot).toBe(tmp);
+  expect(typeof body.repoRootDisplay).toBe("string");
+});
+
+test("PUT /api/settings updates config, persists, and is reflected by GET", async () => {
+  const { app, store } = harness();
+  const res = await put(app, { repoRoot: tmp });
+  expect(res.status).toBe(200);
+  expect((await res.json()).repoRoot).toBe(tmp);
+  // runtime config updated
+  expect(config.repoRoot).toBe(tmp);
+  // persisted
+  expect(store.getSetting("repoRoot")).toBe(tmp);
+  // reflected by a subsequent GET
+  const got = await (await app.fetch(new Request("http://x/api/settings"))).json();
+  expect(got.repoRoot).toBe(tmp);
+});
+
+test("PUT /api/settings rejects a non-existent directory", async () => {
+  const { app } = harness();
+  const before = config.repoRoot;
+  const res = await put(app, { repoRoot: join(tmp, "does-not-exist") });
+  expect(res.status).toBe(400);
+  expect(config.repoRoot).toBe(before); // unchanged on failure
+});
+
+test("GET /api/fs/dirs lists sub-directories of the given path", async () => {
+  const { app } = harness();
+  const res = await app.fetch(new Request(`http://x/api/fs/dirs?path=${encodeURIComponent(tmp)}`));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.path).toBe(tmp);
+  expect(body.entries.map((e: { name: string }) => e.name)).toEqual(["child"]);
+});

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -284,6 +284,18 @@ test("validateCreate defaults images to [] when omitted", () => {
   if (r.ok) expect(r.value.images).toEqual([]);
 });
 
+// regression: an empty images array must NOT require the staging dir to exist.
+// `root` here has no staging dir (as a freshly-configured repoRoot wouldn't),
+// which previously failed with "no staged uploads exist" on every create.
+test("validateCreate accepts an empty images array without a staging dir", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", images: [] },
+    root,
+  );
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.images).toEqual([]);
+});
+
 test("validateCreate rejects an image outside the staging dir", () => {
   const outside = join(root, "evil.png");
   writeFileSync(outside, "x");

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -1,33 +1,105 @@
 @import "tailwindcss";
 
+/* Tailwind theme tokens reference the runtime palette variables below, so the
+   whole UI re-themes by swapping the underscored source vars on :root /
+   [data-theme="light"] — utilities and component `var(--color-*)` reads follow. */
 @theme {
-  --color-bg: #0a0d0c;
-  --color-panel: #0f1413;
-  --color-inset: #070a09;
-  --color-line: #1b2422;
-  --color-line-bright: #2c3835;
-  --color-ink: #aab8b2;
-  --color-ink-bright: #e9f1ec;
-  --color-muted: #5d6c67;
-  --color-faint: #3a4742;
-  --color-amber: #e8a13a;
-  --color-green: #5ad19a;
-  --color-red: #e5484d;
-  --color-slate: #566460;
+  --color-bg: var(--bg);
+  --color-glow: var(--glow);
+  --color-panel: var(--panel);
+  --color-panel-2: var(--panel-2);
+  --color-head: var(--head);
+  --color-inset: var(--inset);
+  --color-hover: var(--hover);
+  --color-line: var(--line);
+  --color-line-bright: var(--line-bright);
+  --color-ink: var(--ink);
+  --color-ink-bright: var(--ink-bright);
+  --color-muted: var(--muted);
+  --color-faint: var(--faint);
+  --color-amber: var(--amber);
+  --color-green: var(--green);
+  --color-red: var(--red);
+  --color-blue: var(--blue);
+  --color-slate: var(--slate);
+  --color-scrim: var(--scrim);
+  --color-term-fg: var(--term-fg);
   --font-mono: "Berkeley Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
+/* ── Dark (default) ──────────────────────────────────────────────────────────
+   Fließtext (--ink) ~12:1 and secondary (--muted) ~5.5:1 on --bg — both clear
+   WCAG AA. Brighter than the original deck for low-light legibility. */
 :root {
+  color-scheme: dark;
+
+  --bg: #0a0d0c;
+  --glow: #0d1211;
+  --panel: #0f1413;
+  --panel-2: #0c100f;
+  --head: #0a0f0d;
+  --inset: #070a09;
+  --hover: #0c1110;
+  --line: #1b2422;
+  --line-bright: #2c3835;
+
+  --ink: #c4d0cb;
+  --ink-bright: #eef4f0;
+  --muted: #7c8c86;
+  --faint: #4a5752;
+
+  --amber: #e8a13a;
+  --green: #5ad19a;
+  --red: #e5484d;
+  --blue: #4a90d9;
+  --slate: #566460;
+
+  --scrim: rgba(3, 6, 5, 0.66);
+  --term-fg: #c4d0cb;
+
   --status-running: var(--color-amber);
   --status-done: var(--color-green);
   --status-blocked: var(--color-red);
   --status-idle: var(--color-slate);
 }
 
+/* ── Light ────────────────────────────────────────────────────────────────────
+   Same green-tinted family, luminance inverted. --ink #2b3633 ~11.8:1 and
+   --muted #5a6862 ~5.5:1 on the panel surface — both clear WCAG AA. Accents
+   darkened so they stay legible on near-white. */
+[data-theme="light"] {
+  color-scheme: light;
+
+  --bg: #e7ebe9;
+  --glow: #f3f6f4;
+  --panel: #f7f9f8;
+  --panel-2: #eef1ef;
+  --head: #eef2f0;
+  --inset: #f3f6f4;
+  --hover: #e4e9e6;
+  --line: #d2dad6;
+  --line-bright: #b9c4bf;
+
+  --ink: #2b3633;
+  --ink-bright: #131a18;
+  --muted: #5a6862;
+  --faint: #93a09a;
+
+  --amber: #a8680a;
+  --green: #1d8a5d;
+  --red: #c2363b;
+  --blue: #2f6fb0;
+  --slate: #6b7873;
+
+  --scrim: rgba(20, 28, 25, 0.42);
+  --term-fg: #2b3633;
+}
+
 html,
 body {
   background:
-    radial-gradient(120% 100% at 50% -10%, #0d1211 0%, var(--color-bg) 60%), var(--color-bg);
+    radial-gradient(120% 100% at 50% -10%, var(--color-glow) 0%, var(--color-bg) 60%),
+    var(--color-bg);
   color: var(--color-ink);
   font-family: var(--font-mono);
   margin: 0;

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -6,6 +6,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="text-scale" content="scale" />
     <title>Shepherd</title>
+    <!-- Resolve the theme before first paint so there's no flash of wrong theme.
+         Mirrors the logic in src/lib/theme.svelte.ts. -->
+    <script>
+      (function () {
+        try {
+          var pref = localStorage.getItem("shepherd:theme") || "system";
+          var dark =
+            pref === "dark" ||
+            (pref !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+          document.documentElement.dataset.theme = dark ? "dark" : "light";
+        } catch (e) {
+          document.documentElement.dataset.theme = "dark";
+        }
+      })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -8,6 +8,8 @@ import type {
   GitState,
   PrStatus,
   MergeMethod,
+  Settings,
+  DirListing,
 } from "./types";
 
 const JSON_HEADERS = { "content-type": "application/json" };
@@ -48,6 +50,32 @@ export async function archiveSession(id: string): Promise<void> {
 export async function listRepos(): Promise<RepoEntry[]> {
   const r = await fetch("/api/repos");
   if (!r.ok) throw new Error(`repos failed: ${r.status}`);
+  return r.json();
+}
+
+export async function getSettings(): Promise<Settings> {
+  const r = await fetch("/api/settings");
+  if (!r.ok) throw new Error(`settings failed: ${r.status}`);
+  return r.json();
+}
+
+export async function putSettings(repoRoot: string): Promise<Settings> {
+  const r = await fetch("/api/settings", {
+    method: "PUT",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ repoRoot }),
+  });
+  if (!r.ok) {
+    const msg = await r.json().catch(() => ({ error: `${r.status}` }));
+    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+  }
+  return r.json();
+}
+
+export async function listDirs(path?: string): Promise<DirListing> {
+  const q = path ? `?path=${encodeURIComponent(path)}` : "";
+  const r = await fetch(`/api/fs/dirs${q}`);
+  if (!r.ok) throw new Error(`dirs failed: ${r.status}`);
   return r.json();
 }
 

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -63,7 +63,7 @@
     box-shadow: inset 0 0 18px -10px var(--color-amber);
   }
   .btn:hover {
-    background: #0c1110;
+    background: var(--color-hover);
   }
   .btn.active {
     border-color: var(--color-amber);

--- a/ui/src/lib/components/ControlBar.svelte
+++ b/ui/src/lib/components/ControlBar.svelte
@@ -24,7 +24,7 @@
     display: flex;
     gap: 4px;
     padding: 6px 10px;
-    background: #0a0f0d;
+    background: var(--color-head);
     border-top: 1px solid var(--color-line);
     overflow-x: auto;
     white-space: nowrap;

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -82,7 +82,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    background: #070a09;
+    background: var(--color-inset);
     font-family: var(--font-mono);
     overflow: hidden;
   }

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -225,7 +225,7 @@
   .overlay {
     position: fixed;
     inset: 0;
-    background: rgba(3, 6, 5, 0.66);
+    background: var(--color-scrim);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -233,7 +233,7 @@
   }
 
   .rs-row:hover {
-    background: #0c1110;
+    background: var(--color-hover);
   }
 
   .rs-row.active {

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -1,0 +1,316 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { getSettings, putSettings, listDirs } from "$lib/api";
+  import type { DirListing } from "$lib/types";
+
+  let { onclose, onsaved }: { onclose?: () => void; onsaved?: (root: string) => void } = $props();
+
+  let currentRoot = $state(""); // the persisted root (display form)
+  let listing = $state<DirListing | null>(null);
+  let loading = $state(false);
+  let saving = $state(false);
+  let error = $state<string | null>(null);
+
+  async function browse(path?: string) {
+    loading = true;
+    error = null;
+    try {
+      listing = await listDirs(path);
+    } catch (e) {
+      error = e instanceof Error ? e.message : "failed to list directory";
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(async () => {
+    try {
+      const s = await getSettings();
+      currentRoot = s.repoRootDisplay;
+      await browse(s.repoRoot);
+    } catch {
+      await browse();
+    }
+  });
+
+  const isCurrent = $derived(
+    listing != null && currentRoot !== "" && listing.display === currentRoot,
+  );
+
+  async function useThisFolder() {
+    if (!listing || saving) return;
+    saving = true;
+    error = null;
+    try {
+      const s = await putSettings(listing.path);
+      currentRoot = s.repoRootDisplay;
+      onsaved?.(s.repoRoot);
+      onclose?.();
+    } catch (e) {
+      error = e instanceof Error ? e.message : "failed to save";
+      saving = false;
+    }
+  }
+</script>
+
+<div
+  class="overlay"
+  role="presentation"
+  onclick={(e) => {
+    if (e.target === e.currentTarget) onclose?.();
+  }}
+>
+  <div class="card bracket">
+    <div class="chead">
+      <span class="micro">Settings</span>
+      <button type="button" class="x" onclick={() => onclose?.()} aria-label="close">✕</button>
+    </div>
+
+    <div class="cur">
+      <span class="micro">Current&nbsp;Repo&nbsp;Root</span>
+      <code>{currentRoot || "—"}</code>
+    </div>
+
+    <span class="micro path-label">Browse</span>
+    <div class="crumbs">
+      <button
+        type="button"
+        class="up"
+        disabled={!listing?.parent || loading}
+        onclick={() => listing?.parent && browse(listing.parent)}
+        title="Up one level"
+      >
+        ↑
+      </button>
+      <code class="here">{listing?.display ?? "…"}</code>
+    </div>
+
+    <div class="list">
+      {#if loading}
+        <div class="placeholder">Loading…</div>
+      {:else if listing && listing.entries.length === 0}
+        <div class="placeholder">no sub-folders here</div>
+      {:else if listing}
+        {#each listing.entries as e (e.path)}
+          <button type="button" class="row" onclick={() => browse(e.path)}>
+            <span class="ico">📁</span><span class="nm">{e.name}</span>
+            <span class="chev">›</span>
+          </button>
+        {/each}
+      {/if}
+    </div>
+
+    {#if error}<div class="err">{error}</div>{/if}
+
+    <button
+      class="run"
+      type="button"
+      disabled={!listing || saving || isCurrent}
+      onclick={useThisFolder}
+    >
+      {#if saving}
+        Saving…
+      {:else if isCurrent}
+        Already the current root
+      {:else}
+        Use this folder
+      {/if}
+    </button>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(3, 6, 5, 0.66);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+  }
+  .card {
+    position: relative;
+    width: min(520px, 92vw);
+    border: 1px solid var(--color-line-bright);
+    background: var(--color-panel);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .bracket::before,
+  .bracket::after {
+    content: "";
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    border: 1px solid var(--color-line-bright);
+  }
+  .bracket::before {
+    top: -1px;
+    left: -1px;
+    border-right: 0;
+    border-bottom: 0;
+  }
+  .bracket::after {
+    bottom: -1px;
+    right: -1px;
+    border-left: 0;
+    border-top: 0;
+  }
+  .chead {
+    display: flex;
+    align-items: center;
+    margin-bottom: 4px;
+  }
+  .x {
+    margin-left: auto;
+    background: transparent;
+    border: 0;
+    color: var(--color-muted);
+    cursor: pointer;
+    font: inherit;
+  }
+  .micro {
+    font-size: 10.5px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .cur {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    padding: 8px 10px;
+    border-radius: 2px;
+  }
+  .cur code {
+    color: var(--color-amber);
+    font-size: 12.5px;
+    word-break: break-all;
+  }
+  .path-label {
+    margin-top: 4px;
+  }
+  .crumbs {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .up {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-ink);
+    font: inherit;
+    font-size: 14px;
+    line-height: 1;
+    padding: 5px 9px;
+    border-radius: 2px;
+    cursor: pointer;
+  }
+  .up:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .here {
+    color: var(--color-ink-bright);
+    font-size: 12.5px;
+    word-break: break-all;
+  }
+  .list {
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    border-radius: 2px;
+    max-height: 280px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+  .placeholder {
+    padding: 14px 12px;
+    color: var(--color-faint);
+    font-size: 11.5px;
+    letter-spacing: 0.06em;
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: 13px;
+    text-align: left;
+    padding: 9px 11px;
+    cursor: pointer;
+  }
+  .row:last-child {
+    border-bottom: 0;
+  }
+  .row:hover {
+    background: var(--color-panel);
+  }
+  .ico {
+    opacity: 0.85;
+  }
+  .nm {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .chev {
+    color: var(--color-faint);
+  }
+  .err {
+    color: var(--color-red);
+    font-size: 11.5px;
+    margin-top: 2px;
+  }
+  .run {
+    margin-top: 8px;
+    border: 1px solid var(--color-amber);
+    color: var(--color-amber);
+    background: transparent;
+    padding: 9px 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: 11px;
+    cursor: pointer;
+    box-shadow: inset 0 0 18px -10px var(--color-amber);
+  }
+  .run:disabled {
+    opacity: 0.5;
+    cursor: default;
+    box-shadow: none;
+  }
+
+  @media (max-width: 768px) {
+    .overlay {
+      align-items: stretch;
+      justify-content: stretch;
+    }
+    .card {
+      width: 100%;
+      max-width: none;
+      height: 100dvh;
+      border: 0;
+      overflow-y: auto;
+    }
+    .list {
+      max-height: none;
+      flex: 1;
+    }
+    .row,
+    .up,
+    .run {
+      min-height: 44px;
+    }
+  }
+</style>

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -123,7 +123,7 @@
   .overlay {
     position: fixed;
     inset: 0;
-    background: rgba(3, 6, 5, 0.66);
+    background: var(--color-scrim);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/ui/src/lib/components/TodoPanel.svelte
+++ b/ui/src/lib/components/TodoPanel.svelte
@@ -110,7 +110,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    background: #070a09;
+    background: var(--color-inset);
     font-family: var(--font-mono);
     overflow: hidden;
   }
@@ -207,7 +207,9 @@
     top: 0px;
     width: 5px;
     height: 8px;
-    border: 1.5px solid #070a09;
+    /* tick "cuts out" of the green box — inset flips with the theme so it stays
+       dark-on-light-green (dark) and light-on-dark-green (light) */
+    border: 1.5px solid var(--color-inset);
     border-top: none;
     border-left: none;
     transform: rotate(45deg);

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
   import type { Session, UsageLimits } from "$lib/types";
   import { formatReset } from "$lib/format";
+  import { theme, type ThemePref } from "$lib/theme.svelte";
+
+  const THEMES: { pref: ThemePref; glyph: string; label: string }[] = [
+    { pref: "dark", glyph: "☾", label: "Dark" },
+    { pref: "light", glyph: "☀", label: "Light" },
+    { pref: "system", glyph: "◐", label: "System" },
+  ];
+  const current = $derived(THEMES.find((t) => t.pref === theme.pref) ?? THEMES[0]);
 
   let {
     sessions,
@@ -90,6 +98,29 @@
         {/each}
       </div>
     {/if}
+    {#if mobile}
+      <button
+        class="theme-cycle"
+        type="button"
+        onclick={() => theme.cycle()}
+        title="Theme: {current.label} — tap to cycle"
+        aria-label="Theme: {current.label}">{current.glyph}</button
+      >
+    {:else}
+      <div class="theme-seg" role="group" aria-label="Theme">
+        {#each THEMES as t (t.pref)}
+          <button
+            type="button"
+            class="t-opt"
+            class:on={theme.pref === t.pref}
+            aria-pressed={theme.pref === t.pref}
+            title="{t.label} theme"
+            aria-label="{t.label} theme"
+            onclick={() => theme.setPref(t.pref)}>{t.glyph}</button
+          >
+        {/each}
+      </div>
+    {/if}
     <div class="clock">
       <span class="dot" class:on={connected}>●</span><span>{clock}</span>
     </div>
@@ -107,7 +138,7 @@
   .hud {
     position: relative;
     border: 1px solid var(--color-line);
-    background: linear-gradient(180deg, var(--color-panel), #0c100f);
+    background: linear-gradient(180deg, var(--color-panel), var(--color-panel-2));
     padding: 12px 16px;
     display: flex;
     align-items: center;
@@ -184,6 +215,46 @@
     cursor: pointer;
   }
   .gear:hover {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
+  }
+  .theme-seg {
+    display: flex;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .t-opt {
+    background: transparent;
+    border: 0;
+    border-left: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    font-size: 13px;
+    line-height: 1;
+    padding: 5px 8px;
+    cursor: pointer;
+  }
+  .t-opt:first-child {
+    border-left: 0;
+  }
+  .t-opt:hover {
+    color: var(--color-ink-bright);
+  }
+  .t-opt.on {
+    color: var(--color-amber);
+    background: var(--color-inset);
+  }
+  .theme-cycle {
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    font-size: 13px;
+    line-height: 1;
+    padding: 5px 8px;
+    border-radius: 2px;
+    cursor: pointer;
+  }
+  .theme-cycle:hover {
     color: var(--color-amber);
     border-color: var(--color-amber);
   }

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -8,12 +8,14 @@
     connected = false,
     mobile = false,
     limits = null,
+    onsettings,
   }: {
     sessions: Session[];
     nowMs: number;
     connected?: boolean;
     mobile?: boolean;
     limits?: UsageLimits | null;
+    onsettings?: () => void;
   } = $props();
 
   const working = $derived(sessions.filter((s) => s.status === "running").length);
@@ -67,28 +69,37 @@
       </div>
     </div>
   {/if}
-  {#if gauges.length}
-    <div class="gauges" class:mobile class:stale={limits?.stale}>
-      {#each gauges as g (g.label)}
-        <div
-          class="gauge"
-          title="{g.label === '5H' ? '5-hour' : 'weekly'} limit · {g.w!
-            .pct}% used · resets {formatReset(g.w!.resetAt, nowMs)}{limits?.stale
-            ? ' · stale'
-            : ''}"
-        >
-          <span class="g-label micro">{g.label}</span>
-          <span class="g-bar"
-            ><span class="g-fill" style="width:{g.w!.pct}%;background:{gaugeColor(g.w!.pct)}"
-            ></span></span
+  <div class="rightside">
+    {#if gauges.length}
+      <div class="gauges" class:mobile class:stale={limits?.stale}>
+        {#each gauges as g (g.label)}
+          <div
+            class="gauge"
+            title="{g.label === '5H' ? '5-hour' : 'weekly'} limit · {g.w!
+              .pct}% used · resets {formatReset(g.w!.resetAt, nowMs)}{limits?.stale
+              ? ' · stale'
+              : ''}"
           >
-          <span class="g-pct" style="color:{gaugeColor(g.w!.pct)}">{g.w!.pct}%</span>
-        </div>
-      {/each}
+            <span class="g-label micro">{g.label}</span>
+            <span class="g-bar"
+              ><span class="g-fill" style="width:{g.w!.pct}%;background:{gaugeColor(g.w!.pct)}"
+              ></span></span
+            >
+            <span class="g-pct" style="color:{gaugeColor(g.w!.pct)}">{g.w!.pct}%</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+    <div class="clock">
+      <span class="dot" class:on={connected}>●</span><span>{clock}</span>
     </div>
-  {/if}
-  <div class="clock">
-    <span class="dot" class:on={connected}>●</span><span>{clock}</span>
+    <button
+      class="gear"
+      type="button"
+      onclick={() => onsettings?.()}
+      title="Settings"
+      aria-label="settings">⚙</button
+    >
   </div>
 </div>
 
@@ -156,8 +167,27 @@
     color: var(--color-ink-bright);
     font-weight: 500;
   }
-  .gauges {
+  .rightside {
     margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+  .gear {
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    font-size: 14px;
+    line-height: 1;
+    padding: 5px 8px;
+    border-radius: 2px;
+    cursor: pointer;
+  }
+  .gear:hover {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
+  }
+  .gauges {
     display: flex;
     gap: 14px;
     align-items: center;
@@ -237,5 +267,8 @@
   }
   .hud.mobile .clock {
     font-size: 12px;
+  }
+  .hud.mobile .rightside {
+    gap: 9px;
   }
 </style>

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -93,7 +93,7 @@
 
   .unit:hover {
     border-color: var(--color-line);
-    background: #0c1110;
+    background: var(--color-hover);
   }
 
   .unit.sel {
@@ -104,7 +104,7 @@
         color-mix(in srgb, var(--rule) 9%, transparent),
         transparent 70%
       ),
-      #0c1211;
+      var(--color-hover);
   }
 
   /* bracket corners on selected */

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -20,6 +20,9 @@
   const desigParts = $derived(session.desig.match(/^(.*?)(\d+)$/));
   const desigStem = $derived(desigParts?.[1] ?? "");
   const desigNum = $derived(desigParts?.[2] ?? session.desig);
+
+  // repo the unit works in — the last path segment of its repoPath (e.g. "community-map")
+  const repoName = $derived(session.repoPath.split("/").filter(Boolean).at(-1) ?? session.repoPath);
 </script>
 
 <button
@@ -37,6 +40,9 @@
     <div class="u-top">
       <span class="desig micro"><span class="desig-stem">{desigStem}</span>{desigNum}</span>
       <span class="name">{session.name}</span>
+    </div>
+    <div class="u-repo" title={session.repoPath}>
+      <span class="repo-glyph" aria-hidden="true">▣</span>{repoName}
     </div>
     <div class="u-sub">
       {session.prompt}
@@ -151,6 +157,25 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+  }
+
+  .u-repo {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-top: 3px;
+    color: var(--color-ink);
+    font-size: 11.5px;
+    letter-spacing: 0.04em;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 34ch;
+  }
+  .repo-glyph {
+    color: var(--color-amber);
+    font-size: 10px;
+    flex-shrink: 0;
   }
 
   .u-sub {

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -5,6 +5,7 @@
   import type { Session } from "$lib/types";
   import { STATUS_COLOR, statusLabel, elapsed } from "$lib/format";
   import { connectPty } from "$lib/pty";
+  import { theme, xtermTheme } from "$lib/theme.svelte";
 
   let {
     session,
@@ -19,6 +20,7 @@
   } = $props();
 
   let el: HTMLDivElement | undefined = $state();
+  let termRef = $state<Terminal | undefined>();
 
   // read-only live terminal: stream PTY output, never send input.
   // mirrors Viewport's xterm/fit/resize/teardown discipline minus input wiring
@@ -27,13 +29,15 @@
     const id = session.id;
     if (!el) return;
 
+    const initialTheme = document.documentElement.dataset.theme === "light" ? "light" : "dark";
     const term = new Terminal({
       fontFamily: "'JetBrains Mono', monospace",
       fontSize: 10,
       disableStdin: true,
       cursorBlink: false,
-      theme: { background: "#070a09", foreground: "#b9c7c1" },
+      theme: xtermTheme(initialTheme),
     });
+    termRef = term;
 
     const fit = new FitAddon();
     term.loadAddon(fit);
@@ -68,8 +72,18 @@
       cancelAnimationFrame(raf);
       ro.disconnect();
       c.close();
+      termRef = undefined;
       term.dispose();
     };
+  });
+
+  // repaint the read-only tile terminal when the active theme changes
+  $effect(() => {
+    const resolved = theme.resolved;
+    const term = termRef;
+    if (!term) return;
+    term.options.theme = xtermTheme(resolved);
+    term.refresh(0, Math.max(0, term.rows - 1));
   });
 </script>
 
@@ -103,7 +117,7 @@
     height: 240px;
     border: 1px solid var(--color-line);
     border-radius: 2px;
-    background: #070a09;
+    background: var(--color-inset);
     padding: 0;
     cursor: pointer;
     color: inherit;
@@ -134,7 +148,7 @@
     align-items: center;
     gap: 7px;
     padding: 6px 10px;
-    background: #0a0f0d;
+    background: var(--color-head);
     border-bottom: 1px solid var(--color-line);
     flex-shrink: 0;
     white-space: nowrap;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -209,6 +209,11 @@
     requestAnimationFrame(() => {
       fit.fit();
       c.resize(term.cols, term.rows);
+      // desktop: selecting a unit hands the keyboard straight to its terminal —
+      // clicking a sidebar card otherwise leaves focus on the card button, so
+      // typing goes nowhere. Mobile keeps tap-to-focus so the soft keyboard
+      // doesn't pop open on every selection.
+      if (!mobile && !touch && tab === "term") term.focus();
     });
 
     const ro = new ResizeObserver(() => {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -5,6 +5,7 @@
   import type { Session, SessionUsage } from "$lib/types";
   import { elapsed, STATUS_COLOR, statusLabel, formatTokens } from "$lib/format";
   import { connectPty, type PtyConn } from "$lib/pty";
+  import { theme, xtermTheme } from "$lib/theme.svelte";
   import { getSessionUsage, uploadImage } from "$lib/api";
   import TodoPanel from "$lib/components/TodoPanel.svelte";
   import IssuesPanel from "$lib/components/IssuesPanel.svelte";
@@ -32,6 +33,9 @@
   let el: HTMLDivElement | undefined = $state();
   let tab = $state<"term" | "todo" | "issues">("term");
   let conn = $state<PtyConn | undefined>();
+  // mirror the live terminal so the theme effect can repaint it without
+  // recreating it (recreating would tear down the PTY socket)
+  let termRef = $state<Terminal | undefined>();
   let dragging = $state(false);
   let uploading = $state(false);
   let uploadFailed = $state(false);
@@ -123,15 +127,17 @@
     const id = unitId;
     if (!el) return;
 
+    // initial palette: non-reactive DOM read so this effect doesn't depend on
+    // theme.resolved (which would recreate the whole terminal — and its PTY —
+    // on every theme switch). Live updates are handled by the effect below.
+    const initialTheme = document.documentElement.dataset.theme === "light" ? "light" : "dark";
     const term = new Terminal({
       fontFamily: "'JetBrains Mono', monospace",
       fontSize: mobile || touch ? 11 : 12.5,
-      theme: {
-        background: "#070a09",
-        foreground: "#b9c7c1",
-      },
+      theme: xtermTheme(initialTheme),
       cursorBlink: true,
     });
+    termRef = term;
 
     const fit = new FitAddon();
     term.loadAddon(fit);
@@ -232,8 +238,18 @@
       ro.disconnect();
       c.close();
       conn = undefined;
+      termRef = undefined;
       term.dispose();
     };
+  });
+
+  // repaint the live terminal when the active theme changes (no recreation)
+  $effect(() => {
+    const resolved = theme.resolved;
+    const term = termRef;
+    if (!term) return;
+    term.options.theme = xtermTheme(resolved);
+    term.refresh(0, Math.max(0, term.rows - 1));
   });
 </script>
 
@@ -385,7 +401,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    background: #070a09;
+    background: var(--color-inset);
     border: 1px solid var(--color-line);
     border-radius: 2px;
     overflow: hidden;
@@ -396,7 +412,7 @@
     align-items: center;
     gap: 7px;
     padding: 6px 12px;
-    background: #0a0f0d;
+    background: var(--color-head);
     border-bottom: 1px solid var(--color-line);
     font-size: 11.5px;
     flex-shrink: 0;
@@ -546,7 +562,7 @@
     flex-shrink: 0;
   }
   .back:hover {
-    background: #0c1110;
+    background: var(--color-hover);
   }
 
   /* dedicated git-rail strip for compact layouts (mobile + unfolded fold) */
@@ -558,7 +574,7 @@
     flex-wrap: wrap;
     gap: 6px;
     padding: 6px 10px;
-    background: #0a0f0d;
+    background: var(--color-head);
     border-bottom: 1px solid var(--color-line);
     flex-shrink: 0;
     min-height: 44px;
@@ -617,7 +633,7 @@
     align-items: center;
     gap: 6px;
     padding: 5px 12px;
-    background: #0a0f0d;
+    background: var(--color-head);
     border-top: 1px solid var(--color-line);
     font-size: 11px;
     color: var(--color-muted);

--- a/ui/src/lib/theme.svelte.ts
+++ b/ui/src/lib/theme.svelte.ts
@@ -1,0 +1,90 @@
+// App theme controller. The user's preference is dark / light / system; the
+// *resolved* value (dark | light) is what the CSS keys on via the
+// `data-theme` attribute on <html>. An inline script in app.html sets that
+// attribute before first paint (no flash of wrong theme); this module owns it
+// at runtime so the switcher and OS-theme changes stay in sync.
+
+export type ThemePref = "dark" | "light" | "system";
+export type Resolved = "dark" | "light";
+
+const STORAGE_KEY = "shepherd:theme";
+const DARK_QUERY = "(prefers-color-scheme: dark)";
+
+function readPref(): ThemePref {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    if (v === "dark" || v === "light" || v === "system") return v;
+  } catch {
+    /* localStorage unavailable (SSR / privacy mode) */
+  }
+  return "system";
+}
+
+function systemPrefersDark(): boolean {
+  return typeof matchMedia !== "undefined" ? matchMedia(DARK_QUERY).matches : true;
+}
+
+class ThemeController {
+  pref = $state<ThemePref>(readPref());
+  systemDark = $state<boolean>(systemPrefersDark());
+
+  resolved = $derived<Resolved>(
+    this.pref === "system" ? (this.systemDark ? "dark" : "light") : this.pref,
+  );
+
+  /** Persist + apply a new preference. */
+  setPref(p: ThemePref) {
+    this.pref = p;
+    try {
+      localStorage.setItem(STORAGE_KEY, p);
+    } catch {
+      /* ignore — preference just won't survive reload */
+    }
+    this.#apply();
+  }
+
+  /** Cycle dark → light → system → dark (compact mobile control). */
+  cycle() {
+    this.setPref(this.pref === "dark" ? "light" : this.pref === "light" ? "system" : "dark");
+  }
+
+  #apply() {
+    if (typeof document !== "undefined") {
+      document.documentElement.dataset.theme = this.resolved;
+    }
+  }
+
+  /** Wire OS-theme changes. Call once on mount; returns a disposer. */
+  init(): () => void {
+    this.#apply();
+    if (typeof matchMedia === "undefined") return () => {};
+    const mq = matchMedia(DARK_QUERY);
+    const onChange = () => {
+      this.systemDark = mq.matches;
+      this.#apply();
+    };
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }
+}
+
+export const theme = new ThemeController();
+
+/**
+ * xterm theme object for the active app theme. Reads the live computed token
+ * values so it tracks whatever `[data-theme]` is currently applied; the
+ * `resolved` argument only supplies a fallback if a custom property is missing.
+ */
+export function xtermTheme(resolved: Resolved): { background: string; foreground: string } {
+  const fallback =
+    resolved === "light"
+      ? { background: "#f3f6f4", foreground: "#2b3633" }
+      : { background: "#070a09", foreground: "#c4d0cb" };
+  if (typeof document === "undefined") return fallback;
+  const cs = getComputedStyle(document.documentElement);
+  const read = (name: string, f: string) => cs.getPropertyValue(name).trim() || f;
+  return {
+    background: read("--color-inset", fallback.background),
+    foreground: read("--color-term-fg", fallback.foreground),
+  };
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -8,6 +8,23 @@ export interface RepoEntry {
   lastUsedAt?: number;
 }
 
+export interface Settings {
+  repoRoot: string;
+  repoRootDisplay: string;
+}
+
+export interface DirEntry {
+  name: string;
+  path: string;
+}
+
+export interface DirListing {
+  path: string;
+  display: string;
+  parent: string | null;
+  entries: DirEntry[];
+}
+
 export interface Issue {
   number: number;
   title: string;

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import "../app.css";
+  import { onMount } from "svelte";
+  import { theme } from "$lib/theme.svelte";
+
   let { children } = $props();
+
+  // keep `data-theme` in sync with OS changes when the preference is "system"
+  onMount(() => theme.init());
 </script>
 
 {@render children()}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -7,12 +7,14 @@
   import Herd from "$lib/components/Herd.svelte";
   import Viewport from "$lib/components/Viewport.svelte";
   import NewTask from "$lib/components/NewTask.svelte";
+  import Settings from "$lib/components/Settings.svelte";
   import ActionBar from "$lib/components/ActionBar.svelte";
   import HerdGrid from "$lib/components/HerdGrid.svelte";
 
   const store = new HerdStore();
   let selectedId = $state<string | null>(null);
   let showNew = $state(false);
+  let showSettings = $state(false);
   let viewMode = $state<"focus" | "all">("focus");
   let nowMs = $state(Date.now());
   let composeRepoPath = $state<string | null>(null);
@@ -84,6 +86,7 @@
     connected={store.connected}
     mobile={mobile.current}
     limits={store.usageLimits}
+    onsettings={() => (showSettings = true)}
   />
 
   {#if mobile.current}
@@ -159,6 +162,10 @@
       composePrompt = "";
     }}
   />
+{/if}
+
+{#if showSettings}
+  <Settings onclose={() => (showSettings = false)} />
 {/if}
 
 <style>


### PR DESCRIPTION
## Was

Bisher hatte das UI nur ein hartcodiertes Dark-Theme; bei wenig Licht war der Fließtext schwer lesbar. Dieser PR führt umschaltbare Themes ein (Dark / Light / System) und hebt den Dark-Kontrast an.

## Ansatz

- **Token-Entkopplung** (`app.css`): Farbwerte liegen jetzt als Runtime-Variablen auf `:root` (Dark-Default) + `[data-theme="light"]`; der Tailwind-`@theme`-Block referenziert sie via `var()`. Ein Attribut-Wechsel re-themed das ganze UI.
- **Light-Palette**: WCAG-AA-geprüft — Fließtext (`--ink`) ~11.8:1, Sekundärtext (`--muted`) ~5.5:1 auf der Panel-Fläche. Akzente abgedunkelt für Lesbarkeit auf Hell.
- **Dark-Kontrast angehoben**: `--ink` `#aab8b2`→`#c4d0cb`, `--muted` `#5d6c67`→`#7c8c86` (jetzt ~5.5:1, vorher 3.5:1 — unter AA).
- **Umschalter** in der TopBar: `☾/☀/◐`-Segmentcontrol (Desktop), Cycle-Button (Mobile). Persistenz via `localStorage["shepherd:theme"]`, OS-Änderungen live über `matchMedia`.
- **Kein FOUC**: Inline-Script in `app.html` setzt `data-theme` auf `<html>` vor dem ersten Paint.
- **xterm folgt dem Theme**: `Viewport` + `UnitTile` repainten `term.options.theme` reaktiv, ohne das Terminal (und damit die PTY-Verbindung) neu zu erzeugen.
- Hartcodierte Surface-/Text-Hex-Werte in 10 Komponenten durch Tokens ersetzt.

## Akzeptanzkriterien

- [x] Umschaltbar zwischen Dark, Light und System
- [x] Auswahl überlebt Reload (localStorage)
- [x] Light- und Dark-Fließtext erfüllen WCAG AA (≥ 4.5:1)
- [x] xterm.js-Pane-Farben folgen dem aktiven Theme
- [x] Kein Flash of Wrong Theme beim Laden

## Checks

`bun run check` → 0 Fehler · `bun run test` (vitest) → 23/23 · `bun run build` → grün; kompiliertes CSS enthält Token-Indirektion + beide Paletten.

> Hinweis: Eine lokale `vite.config.ts`-Anpassung (fester Port + persönlicher Tailnet-Host in `allowedHosts`) ist **bewusst nicht** Teil dieses PRs, da maschinen-/personenspezifisch.