### PR TITLE
fix(types): restore root strict tsc after wave merges

### DIFF
--- a/src/pty-demux.d.mts
+++ b/src/pty-demux.d.mts
@@ -1,0 +1,15 @@
+// Type declarations for the plain-JS pty-demux helper (imported by tests under
+// the root strict tsconfig, which type-checks all .ts and resolves this .mjs).
+export interface DemuxHandlers {
+  /** Forwarded terminal input (control frames stripped). */
+  onInput: (data: string) => void;
+  /** Forwarded resize frames, de-duplicated to genuine size changes. */
+  onResize: (cols: number, rows: number) => void;
+}
+
+export interface Demux {
+  /** Feed a raw stdin chunk; buffers partial frames across calls. */
+  feed(chunk: string): void;
+}
+
+export function createDemux(handlers: DemuxHandlers): Demux;

--- a/ui/src/lib/pty.test.ts
+++ b/ui/src/lib/pty.test.ts
@@ -58,7 +58,7 @@ function make(onReconnect = () => {}, onParked = () => {}) {
     onParked,
     (path) => new FakeWs(path) as unknown as WebSocket,
   );
-  return { conn, onData, last: () => FakeWs.instances[FakeWs.instances.length - 1] };
+  return { conn, onData, last: () => FakeWs.instances[FakeWs.instances.length - 1]! };
 }
 
 describe("connectPty", () => {


### PR DESCRIPTION
Root `bunx tsc --noEmit` checks `ui/` + `test/` more strictly than svelte-check (noUncheckedIndexedAccess, noImplicitAny). PRs #15 and #13 passed their own gates but broke the root gate:

- **#15** — `ui/src/lib/pty.test.ts` `last()` returned `FakeWs | undefined`; assert non-null.
- **#13** — `test/pty-demux.test.ts` imported untyped `src/pty-demux.mjs` (TS7016); add ambient `src/pty-demux.d.mts`.

Test-only/types-only; no runtime change. Verified: root tsc clean, `bun run test` 214 pass, ui svelte-check 0 / vitest 31, build ok.