### PR TITLE
feat(forge): SHEPHERD_FORGES env-path for the forge map

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,17 @@
+import { dirname, join } from "node:path";
 import { resolveNodeBin } from "./node-bin";
+import { loadForgeMap } from "./forge/load-config";
+
+const dbPath = process.env.SHEPHERD_DB ?? `${process.env.HOME}/.shepherd/shepherd.db`;
+// forge map sits next to the db by default; SHEPHERD_FORGES overrides the path.
+const forgesPath = process.env.SHEPHERD_FORGES ?? join(dirname(dbPath), "forges.json");
 
 export const config = {
   port: Number(process.env.SHEPHERD_PORT ?? 7330),
   // bind to loopback only; the Tailscale-serve proxy reaches it via 127.0.0.1.
   // set SHEPHERD_HOST=0.0.0.0 to expose on all interfaces (not recommended).
   host: process.env.SHEPHERD_HOST ?? "127.0.0.1",
-  dbPath: process.env.SHEPHERD_DB ?? `${process.env.HOME}/.shepherd/shepherd.db`,
+  dbPath,
   herdrBin: process.env.HERDR_BIN ?? "herdr",
   // node binary for the PTY attach helper (pty-attach.mjs). Resolved so a node
   // managed by mise/nvm/fnm still works when the launcher's PATH excludes it —
@@ -24,4 +30,7 @@ export const config = {
     ",",
   ),
   token: process.env.SHEPHERD_TOKEN ?? null, // when set, require Authorization: Bearer <token>
+  // git host (forge) integration: per-host {type,baseUrl,token,deployWorkflow,mergeMethod}
+  forgesPath,
+  forges: loadForgeMap(forgesPath),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 import { config } from "./config";
 import { SessionStore } from "./store";
 import { WorktreeMgr } from "./worktree";
@@ -11,7 +11,6 @@ import { StatusPoller } from "./poller";
 import { reconcile } from "./reconcile";
 import { serve } from "./server";
 import { detectForge } from "./forge";
-import { loadForgeMap } from "./forge/load-config";
 import { AccountUsageIndex } from "./usage";
 import { UsageLimitsService } from "./usage-limits";
 import { HerdrUsageProbe } from "./usage-probe";
@@ -62,12 +61,10 @@ setTimeout(calibrate, 3_000);
 setInterval(calibrate, 24 * 60 * 60 * 1000);
 
 // forge resolution: detect a repo's GitHub/Gitea host from its `origin` remote.
-// Per-host config (tokens, gitea base URLs) is optional — github.com works through
-// the operator's existing `gh` CLI auth, so an absent forges.json is fine.
-const forgeMap = loadForgeMap(join(dirname(config.dbPath), "forges.json"));
-
+// Per-host config (tokens, gitea base URLs) loads from config.forges (SHEPHERD_FORGES);
+// github.com works through the operator's existing `gh` CLI auth, so an absent file is fine.
 const server = serve(
-  { store, service, events, usageLimits, resolveForge: (dir) => detectForge(dir, forgeMap) },
+  { store, service, events, usageLimits, resolveForge: (dir) => detectForge(dir, config.forges) },
   config.port,
 );
 console.log(`shepherd core on http://localhost:${server.port}`);


### PR DESCRIPTION
Folds PR #7's env-path config into #10's merged forge wiring, then #7 can close.

- `config.ts`: load the forge map here with a `SHEPHERD_FORGES` override (default: `forges.json` next to `SHEPHERD_DB`, i.e. `~/.shepherd/forges.json`). Exposes `config.forges` / `config.forgesPath`.
- `index.ts`: use `config.forges`; drop the inline `loadForgeMap` + now-unused `join` import.

Keeps #10's smarter db-relative default rather than #7's hardcoded `$HOME`. `SHEPHERD_FORGES` was already in the README env table — this makes it functional.

Verified: root tsc clean, lint clean, `bun run test` 214 pass, forge tests 44 pass.