### PR TITLE
fix(ui): anchor Open-PR popover to button on desktop

### DIFF
--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -111,67 +111,77 @@
 </script>
 
 {#if git}
-  <span class="rail" class:mobile>
-    {#if git.state === "none"}
-      <button class="gbtn" type="button" disabled={busy} onclick={startPr}>↟ Open PR</button>
-    {:else if git.state === "open"}
-      {#if git.url}
-        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
-        <a class="prlink" href={git.url} target="_blank" rel="noopener">PR #{git.number} ↗</a>
-      {:else}
-        <span class="prlink">PR #{git.number}</span>
-      {/if}
-      <span class="dot dot-{git.checks}" title="CI: {git.checks}" aria-label="CI {git.checks}"
-      ></span>
-      <button
-        class="gbtn"
-        class:armed={armed === "merge"}
-        type="button"
-        disabled={mergeBlocked}
-        onclick={doMerge}
-      >
-        {armed === "merge" ? "confirm ✓" : "Merge"}
-      </button>
-    {:else if git.state === "merged"}
-      <span class="merged">merged ✓</span>
-      {#if git.deployConfigured}
+  <span class="git-rail-wrap">
+    <span class="rail" class:mobile>
+      {#if git.state === "none"}
+        <button class="gbtn" type="button" disabled={busy} onclick={startPr}>↟ Open PR</button>
+      {:else if git.state === "open"}
+        {#if git.url}
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
+          <a class="prlink" href={git.url} target="_blank" rel="noopener">PR #{git.number} ↗</a>
+        {:else}
+          <span class="prlink">PR #{git.number}</span>
+        {/if}
+        <span class="dot dot-{git.checks}" title="CI: {git.checks}" aria-label="CI {git.checks}"
+        ></span>
         <button
           class="gbtn"
-          class:armed={armed === "redeploy"}
+          class:armed={armed === "merge"}
           type="button"
-          disabled={busy}
-          onclick={doRedeploy}
+          disabled={mergeBlocked}
+          onclick={doMerge}
         >
-          {armed === "redeploy" ? "confirm ⟳" : "⟳ Redeploy"}
+          {armed === "merge" ? "confirm ✓" : "Merge"}
         </button>
+      {:else if git.state === "merged"}
+        <span class="merged">merged ✓</span>
+        {#if git.deployConfigured}
+          <button
+            class="gbtn"
+            class:armed={armed === "redeploy"}
+            type="button"
+            disabled={busy}
+            onclick={doRedeploy}
+          >
+            {armed === "redeploy" ? "confirm ⟳" : "⟳ Redeploy"}
+          </button>
+        {/if}
+      {:else}
+        <span class="merged">closed</span>
       {/if}
-    {:else}
-      <span class="merged">closed</span>
-    {/if}
 
-    {#if err}<span class="err" title={err}>{err}</span>{/if}
-  </span>
+      {#if err}<span class="err" title={err}>{err}</span>{/if}
+    </span>
 
-  {#if showPr}
-    <div class="pr-pop">
-      <input class="pr-title" bind:value={prTitle} placeholder="PR title" />
-      <textarea class="pr-body" bind:value={prBody} placeholder="Description" rows="4"></textarea>
-      <div class="pr-actions">
-        <button class="gbtn" type="button" onclick={() => (showPr = false)}>Cancel</button>
-        <button
-          class="gbtn primary"
-          type="button"
-          disabled={busy || !prTitle.trim()}
-          onclick={submitPr}
-        >
-          Create PR
-        </button>
+    {#if showPr}
+      <div class="pr-pop">
+        <input class="pr-title" bind:value={prTitle} placeholder="PR title" />
+        <textarea class="pr-body" bind:value={prBody} placeholder="Description" rows="4"></textarea>
+        <div class="pr-actions">
+          <button class="gbtn" type="button" onclick={() => (showPr = false)}>Cancel</button>
+          <button
+            class="gbtn primary"
+            type="button"
+            disabled={busy || !prTitle.trim()}
+            onclick={submitPr}
+          >
+            Create PR
+          </button>
+        </div>
       </div>
-    </div>
-  {/if}
+    {/if}
+  </span>
 {/if}
 
 <style>
+  /* own positioning context so .pr-pop anchors to the button in every
+     mount site (desktop header + compact strip), not to some far ancestor */
+  .git-rail-wrap {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+  }
+
   .rail {
     display: inline-flex;
     align-items: center;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -435,7 +435,9 @@
     font-size: 11.5px;
     flex-shrink: 0;
     white-space: nowrap;
-    overflow: hidden;
+    /* not overflow:hidden — the Open-PR popover drops below the header and must
+       escape it; long content is still clipped by .viewport's overflow */
+    overflow: visible;
   }
 
   .desig {


### PR DESCRIPTION
## Problem

Clicking **↟ Open PR** on a done session did nothing visible — no form, no PR.

## Root cause

`GitRail.svelte`'s `.pr-pop` form is `position: absolute; top: 100%`. On **desktop**, `GitRail` is mounted bare inside `.vp-head`, which is `position: static` (so the popover anchored to the page's initial containing block → dropped ~a full viewport below, off-screen) **and** `overflow: hidden` (which would clip it anyway). The compact/mobile mount already wraps it in a `position: relative` `.vp-git-strip`, so it worked there — that asymmetry was the tell.

The button + handler were fine: `↟ Open PR` only opens the popover form; `Create PR` inside it is what POSTs to `/api/sessions/:id/git/pr`. You just never saw the form.

## Fix

- Wrap rail + popover in a `position: relative` `.git-rail-wrap` inside `GitRail.svelte`, so the popover anchors to the button at **every** mount site.
- Drop `overflow: hidden` on `.vp-head` so the dropdown can escape the header (`.viewport` still provides the clipping backstop).

## Verification

- `bun run check` (svelte-check): 0 errors, 0 warnings
- prettier: clean
- eslint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)