### PR TITLE
feat(ui): move theme switcher to action bar, add repo + git sha

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,8 @@ export default [
   {
     files: ["**/*.svelte", "**/*.svelte.ts", "**/*.svelte.js"],
     languageOptions: {
-      globals: globals.browser,
+      // __GIT_SHA__ is injected at build time via ui/vite.config.ts `define`
+      globals: { ...globals.browser, __GIT_SHA__: "readonly" },
       parserOptions: {
         parser: ts.parser,
         extraFileExtensions: [".svelte"],

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -14,6 +14,7 @@
         "@sveltejs/kit": "^2.57.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tailwindcss/vite": "^4.3.0",
+        "@types/node": "^25.9.1",
         "svelte": "^5.55.2",
         "svelte-check": "^4.4.6",
         "typescript": "^6.0.2",
@@ -128,6 +129,8 @@
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -280,6 +283,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "vite": ["vite@8.0.14", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.2", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "@sveltejs/kit": "^2.57.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@tailwindcss/vite": "^4.3.0",
+    "@types/node": "^25.9.1",
     "svelte": "^5.55.2",
     "svelte-check": "^4.4.6",
     "typescript": "^6.0.2",

--- a/ui/src/app.d.ts
+++ b/ui/src/app.d.ts
@@ -1,6 +1,9 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
 declare global {
+  // injected at build time by vite.config.ts (`define`)
+  const __GIT_SHA__: string;
+
   namespace App {
     // interface Error {}
     // interface Locals {}

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -1,4 +1,17 @@
 <script lang="ts">
+  import { theme, type ThemePref } from "$lib/theme.svelte";
+
+  const REPO = "erwins-enkel/shepherd";
+  const REPO_URL = `https://github.com/${REPO}`;
+  const sha = __GIT_SHA__;
+  const commitUrl = sha === "unknown" ? REPO_URL : `https://github.com/${REPO}/commit/${sha}`;
+
+  const THEMES: { pref: ThemePref; glyph: string; label: string }[] = [
+    { pref: "dark", glyph: "☾", label: "Dark" },
+    { pref: "light", glyph: "☀", label: "Light" },
+    { pref: "system", glyph: "◐", label: "System" },
+  ];
+
   let {
     onnew,
     mode = "focus",
@@ -32,7 +45,31 @@
         type="button"
         onclick={() => onmode?.("focus")}>Focus ⌖</button
       >
-      <span class="hint">node-pty ⇄ herdr · sub · skip-permissions</span>
+      <div class="meta">
+        <a class="repo" href={REPO_URL} target="_blank" rel="external noreferrer noopener">{REPO}</a
+        >
+        <span class="dot">·</span>
+        <a
+          class="sha"
+          href={commitUrl}
+          target="_blank"
+          rel="external noreferrer noopener"
+          title="commit {sha}">{sha}</a
+        >
+        <div class="theme-seg" role="group" aria-label="Theme">
+          {#each THEMES as t (t.pref)}
+            <button
+              type="button"
+              class="t-opt"
+              class:on={theme.pref === t.pref}
+              aria-pressed={theme.pref === t.pref}
+              title="{t.label} theme"
+              aria-label="{t.label} theme"
+              onclick={() => theme.setPref(t.pref)}>{t.glyph}</button
+            >
+          {/each}
+        </div>
+      </div>
     {/if}
   </div>
 {/if}
@@ -70,11 +107,55 @@
     color: var(--color-amber);
     box-shadow: inset 0 0 18px -10px var(--color-amber);
   }
-  .hint {
+  .meta {
     margin-left: auto;
-    color: var(--color-faint);
+    display: flex;
+    align-items: center;
+    gap: 10px;
     font-size: 11px;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.06em;
+    font-variant-numeric: tabular-nums;
+  }
+  .repo,
+  .sha {
+    color: var(--color-muted);
+    text-decoration: none;
+  }
+  .sha {
+    color: var(--color-ink);
+  }
+  .repo:hover,
+  .sha:hover {
+    color: var(--color-amber);
+  }
+  .dot {
+    color: var(--color-faint);
+  }
+  .theme-seg {
+    display: flex;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .t-opt {
+    background: transparent;
+    border: 0;
+    border-left: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    font-size: 13px;
+    line-height: 1;
+    padding: 4px 8px;
+    cursor: pointer;
+  }
+  .t-opt:first-child {
+    border-left: 0;
+  }
+  .t-opt:hover {
+    color: var(--color-ink-bright);
+  }
+  .t-opt.on {
+    color: var(--color-amber);
+    background: var(--color-inset);
   }
   .actions.mobile {
     padding: 10px;

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
   import type { Session, UsageLimits } from "$lib/types";
   import { formatReset } from "$lib/format";
-  import { theme, type ThemePref } from "$lib/theme.svelte";
+  import { theme } from "$lib/theme.svelte";
 
-  const THEMES: { pref: ThemePref; glyph: string; label: string }[] = [
-    { pref: "dark", glyph: "☾", label: "Dark" },
-    { pref: "light", glyph: "☀", label: "Light" },
-    { pref: "system", glyph: "◐", label: "System" },
-  ];
-  const current = $derived(THEMES.find((t) => t.pref === theme.pref) ?? THEMES[0]);
+  // mobile shows a single compact cycle glyph; desktop's switcher lives in the ActionBar
+  const GLYPHS = { dark: "☾", light: "☀", system: "◐" } as const;
+  const LABELS = { dark: "Dark", light: "Light", system: "System" } as const;
 
   let {
     sessions,
@@ -100,23 +97,9 @@
       class="theme-cycle"
       type="button"
       onclick={() => theme.cycle()}
-      title="Theme: {current.label} — tap to cycle"
-      aria-label="Theme: {current.label}">{current.glyph}</button
+      title="Theme: {LABELS[theme.pref]} — tap to cycle"
+      aria-label="Theme: {LABELS[theme.pref]}">{GLYPHS[theme.pref]}</button
     >
-  {:else}
-    <div class="theme-seg" role="group" aria-label="Theme">
-      {#each THEMES as t (t.pref)}
-        <button
-          type="button"
-          class="t-opt"
-          class:on={theme.pref === t.pref}
-          aria-pressed={theme.pref === t.pref}
-          title="{t.label} theme"
-          aria-label="{t.label} theme"
-          onclick={() => theme.setPref(t.pref)}>{t.glyph}</button
-        >
-      {/each}
-    </div>
   {/if}
   <div class="clock">
     <span class="dot" class:on={connected}>●</span><span>{clock}</span>
@@ -187,46 +170,6 @@
     color: var(--color-ink-bright);
     font-weight: 500;
   }
-  .theme-seg {
-    display: flex;
-    border: 1px solid var(--color-line-bright);
-    border-radius: 2px;
-    overflow: hidden;
-  }
-  .t-opt {
-    background: transparent;
-    border: 0;
-    border-left: 1px solid var(--color-line-bright);
-    color: var(--color-muted);
-    font-size: 13px;
-    line-height: 1;
-    padding: 5px 8px;
-    cursor: pointer;
-  }
-  .t-opt:first-child {
-    border-left: 0;
-  }
-  .t-opt:hover {
-    color: var(--color-ink-bright);
-  }
-  .t-opt.on {
-    color: var(--color-amber);
-    background: var(--color-inset);
-  }
-  .theme-cycle {
-    background: transparent;
-    border: 1px solid var(--color-line-bright);
-    color: var(--color-muted);
-    font-size: 13px;
-    line-height: 1;
-    padding: 5px 8px;
-    border-radius: 2px;
-    cursor: pointer;
-  }
-  .theme-cycle:hover {
-    color: var(--color-amber);
-    border-color: var(--color-amber);
-  }
   .gauges {
     margin-left: auto;
     display: flex;
@@ -271,6 +214,20 @@
   .gauges.mobile .g-pct {
     min-width: 26px;
     font-size: 10.5px;
+  }
+  .theme-cycle {
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    font-size: 13px;
+    line-height: 1;
+    padding: 5px 8px;
+    border-radius: 2px;
+    cursor: pointer;
+  }
+  .theme-cycle:hover {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
   }
   .clock {
     color: var(--color-ink-bright);

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,8 +1,20 @@
+import { execFileSync } from "node:child_process";
 import { sveltekit } from "@sveltejs/kit/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 
+function gitSha(): string {
+  try {
+    return execFileSync("git", ["rev-parse", "--short", "HEAD"], { encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
 export default defineConfig({
+  define: {
+    __GIT_SHA__: JSON.stringify(gitSha()),
+  },
   plugins: [tailwindcss(), sveltekit()],
   server: {
     proxy: {


### PR DESCRIPTION
## What

The light/dark/system theme switcher took too much room in the top bar. Moved it into the existing bottom action bar, alongside a new repo link and build SHA — and dropped the redundant separate footer from the first pass.

- **Top bar:** theme switcher removed (desktop). Mobile keeps the compact single-glyph cycle button there, since the action bar's right side is desktop-only and the mobile detail screen has no action bar.
- **Action bar (desktop):** right side now shows `erwins-enkel/shepherd · <sha> ☾☀◐`, replacing the static `node-pty ⇄ herdr · sub · skip-permissions` hint — that text conveyed no live state and wasn't actionable.
- **Git SHA:** injected at build time via `vite.config.ts` `define` (`git rev-parse --short HEAD`, `execFileSync`, falls back to `unknown`). Reflects build-time HEAD — correct for a static SPA. The `<sha>` links to its commit; the repo name links to the repo. External links use `rel="external noreferrer noopener"`.
- Added `@types/node` (needed by the vite config; also cleared a pre-existing node-types warning) and registered `__GIT_SHA__` as an eslint global.

## Verification

- `cd ui && bun run check` → 0 errors
- root `bun run lint` → clean
- `cd ui && bun run build` → succeeds, SHA inlined into bundle
- `cd ui && bun test` → 31 passed
- Screenshotted the running app (dev server proxying to live backend) to confirm the consolidated single bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)