### PR TITLE
chore: auto-install deps on session start in fresh worktrees

### DIFF
--- a/.claude/hooks/ensure-deps.sh
+++ b/.claude/hooks/ensure-deps.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SessionStart hook: install deps in fresh worktrees so agents never hit the
+# "missing node_modules" tax. Installs only when node_modules is absent, so
+# warm worktrees pay nothing. Root + ui/ are separate packages (own deps).
+set -euo pipefail
+
+root="${CLAUDE_PROJECT_DIR:-$PWD}"
+bun="$(command -v bun || true)"
+[ -n "$bun" ] || { echo '{"suppressOutput": true}'; exit 0; }
+
+installed=()
+for dir in "$root" "$root/ui"; do
+  if [ -f "$dir/package.json" ] && [ ! -d "$dir/node_modules" ]; then
+    ( cd "$dir" && "$bun" install ) >/dev/null 2>&1 && installed+=("$dir")
+  fi
+done
+
+if [ "${#installed[@]}" -gt 0 ]; then
+  printf '{"systemMessage": "ensure-deps: ran bun install in %s"}\n' "${installed[*]}"
+else
+  echo '{"suppressOutput": true}'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/ensure-deps.sh\"",
+            "timeout": 300,
+            "statusMessage": "Ensuring deps installed…"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Problem

Shepherd worktrees start without `node_modules` (per CLAUDE.md). Every Claude session in a fresh worktree rediscovers this the hard way — a lint/check/test fails cryptically, the agent investigates, eventually runs `bun install`. Repeated across sessions it's a recurring time + token tax.

## Fix

A committed **SessionStart hook** (`.claude/settings.json`) runs `.claude/hooks/ensure-deps.sh`, which:

- installs **root** and **ui/** deps with `bun install` **only when `node_modules` is missing** (warm worktrees no-op instantly),
- keys off `$CLAUDE_PROJECT_DIR`, no-ops gracefully if `bun` isn't on PATH,
- emits a `systemMessage` when it installs, `suppressOutput` otherwise.

Committed to the repo (not personal global settings) so it applies to **every** worktree and every contributor automatically.

## Verification

- Warm worktree (deps present): no-op, exit 0
- Cold dir (no `node_modules`): creates `node_modules` in both root + ui/, emits systemMessage
- Re-run on now-warm dir: no-op
- Committed with executable bit (`100755`)

## Caveat

The guard is `[ ! -d node_modules ]`, so it fixes the **fresh-worktree** case (entirely missing deps). It does **not** detect a *partial/stale* install (node_modules present but a package missing) — that's a rarer, separate problem; running `bun install` every session would be wasteful.

Takes effect in **future** sessions/worktrees (SessionStart fires at launch). Review/disable anytime via \`/hooks\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)