### PR TITLE
fix(ui): shift+enter inserts newline in terminal

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -174,6 +174,25 @@
     conn = c;
     term.onData((d) => c.send(d));
 
+    // Shift+Enter → newline: xterm emits a bare CR for both Enter and
+    // Shift+Enter, so Claude Code can't tell them apart and submits. Send a
+    // line feed (0x0A, same byte as Ctrl+J / chat:newline) instead and swallow
+    // xterm's default CR. keydown-only so the keyup doesn't double-send.
+    term.attachCustomKeyEventHandler((e) => {
+      if (
+        e.type === "keydown" &&
+        e.key === "Enter" &&
+        e.shiftKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.metaKey
+      ) {
+        c.send("\n");
+        return false;
+      }
+      return true;
+    });
+
     // mobile freezes backgrounded tabs and drops the WS; nudge a reconnect when
     // the tab returns. pageshow+persisted covers iOS Safari's bfcache restore,
     // which doesn't always fire visibilitychange.


### PR DESCRIPTION
## Problem
Shift+Enter in the session terminal submitted instead of inserting a newline. xterm emits a bare CR (`\r`) for both Enter and Shift+Enter via `term.onData`, so Claude Code couldn't distinguish them.

## Fix
`attachCustomKeyEventHandler` in `Viewport.svelte` catches Shift+Enter on keydown, sends `\n` (0x0A — Claude Code's `chat:newline` byte, same as Ctrl+J), and returns `false` to swallow xterm's default CR. Keydown-only guard avoids a keyup double-send; bare Enter and modified combos fall through untouched.

## Validation
- `bun run check` — 0 errors
- `bun test` — 35 pass
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)