### PR TITLE
feat(update): in-app self-update from new commits on main

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { UsageLimitsService } from "./usage-limits";
 import { HerdrUsageProbe } from "./usage-probe";
 import { sweepStaging } from "./uploads";
 import { validateRoot } from "./dirs";
+import { UpdateService } from "./update";
 
 mkdirSync(dirname(config.dbPath), { recursive: true });
 
@@ -73,11 +74,25 @@ const calibrate = async () => {
 setTimeout(calibrate, 3_000);
 setInterval(calibrate, 24 * 60 * 60 * 1000);
 
+// watch origin/main for new commits and push the result to clients; the badge in
+// the UI keys off `behind > 0`, so it only appears when main has moved ahead.
+const updates = new UpdateService();
+const checkUpdates = () => events.emit("update:status", updates.check(Date.now()));
+setTimeout(checkUpdates, 3_000);
+setInterval(checkUpdates, 5 * 60 * 1000);
+
 // forge resolution: detect a repo's GitHub/Gitea host from its `origin` remote.
 // Per-host config (tokens, gitea base URLs) loads from config.forges (SHEPHERD_FORGES);
 // github.com works through the operator's existing `gh` CLI auth, so an absent file is fine.
 const server = serve(
-  { store, service, events, usageLimits, resolveForge: (dir) => detectForge(dir, config.forges) },
+  {
+    store,
+    service,
+    events,
+    usageLimits,
+    updates,
+    resolveForge: (dir) => detectForge(dir, config.forges),
+  },
   config.port,
 );
 console.log(`shepherd core on http://localhost:${server.port}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import { listBranches } from "./branches";
 import { sessionTokens, jsonlPathFor } from "./usage";
 import { handleUpload } from "./uploads";
 import type { UsageLimitsService } from "./usage-limits";
+import type { UpdateService } from "./update";
 import type { Session } from "./types";
 import type { GitForge, MergeMethod } from "./forge/types";
 import { join, normalize } from "node:path";
@@ -50,6 +51,8 @@ export interface AppDeps {
   usageLimits: Pick<UsageLimitsService, "limits">;
   /** Resolve the git forge for a repo dir; null when none is configured. */
   resolveForge?: (repoDir: string) => GitForge | null;
+  /** Self-update tracker; absent in environments where it isn't wired. */
+  updates?: Pick<UpdateService, "current" | "apply">;
 }
 
 const sessionUsage = (s: Session) =>
@@ -183,6 +186,28 @@ export function makeApp(deps: AppDeps) {
         parts[2] === "limits"
       ) {
         return json(deps.usageLimits.limits(Date.now()));
+      }
+
+      // ── self-update: status + trigger ──────────────────────────────────────
+      if (parts[0] === "api" && parts[1] === "update" && !parts[2]) {
+        if (req.method === "GET") {
+          return json(
+            deps.updates?.current() ?? {
+              behind: 0,
+              current: null,
+              latest: null,
+              commits: [],
+              checkedAt: Date.now(),
+            },
+          );
+        }
+        if (req.method === "POST") {
+          if (!deps.updates) return json({ error: "updates not available" }, 503);
+          const status = deps.updates.current();
+          if (!status || status.behind <= 0) return json({ error: "no update available" }, 409);
+          const r = deps.updates.apply();
+          return json({ ok: r.started }, r.started ? 202 : 409);
+        }
       }
 
       if (parts[0] === "api" && parts[1] === "uploads" && !parts[2]) {

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,0 +1,138 @@
+import { execFileSync, spawn } from "node:child_process";
+import { join } from "node:path";
+
+export interface UpdateCommit {
+  sha: string;
+  subject: string;
+}
+
+export interface UpdateStatus {
+  /** how many commits the tracked branch is ahead of the running HEAD; 0 = up to date */
+  behind: number;
+  /** short SHA of the running checkout (HEAD) */
+  current: string | null;
+  /** short SHA of origin/<branch> after fetch */
+  latest: string | null;
+  /** the new commits (HEAD..origin/branch), newest first; empty when up to date */
+  commits: UpdateCommit[];
+  checkedAt: number;
+  /** set when the check itself failed (network/git); badge stays hidden on error */
+  error?: string;
+}
+
+const EMPTY = (now: number): UpdateStatus => ({
+  behind: 0,
+  current: null,
+  latest: null,
+  commits: [],
+  checkedAt: now,
+});
+
+/** Runs git inside a fixed repo dir and returns stdout; injectable for tests. */
+export type GitRunner = (args: string[]) => string;
+
+export interface UpdateDeps {
+  /** repo to check; defaults to the service working dir (the live deployment) */
+  repoDir?: string;
+  /** branch to track on origin; defaults to "main" */
+  branch?: string;
+  /** path to the deploy script run on apply */
+  scriptPath?: string;
+  /** inject point for tests; defaults to real `git -C <repoDir> …` */
+  git?: GitRunner;
+  /** inject point for tests; defaults to launching the deploy script detached */
+  launch?: () => void;
+  /** cap the commit list shown in the UI */
+  limit?: number;
+}
+
+/**
+ * Tracks how far the running checkout is behind origin/<branch> and, on demand,
+ * launches the existing deploy script to pull + rebuild + restart the service.
+ *
+ * The check compares HEAD against origin/<branch> *after* a fetch, so the badge
+ * surfaces individual new commits on main — no version tags required.
+ */
+export class UpdateService {
+  private repoDir: string;
+  private branch: string;
+  private scriptPath: string;
+  private git: GitRunner;
+  private launch: () => void;
+  private limit: number;
+  private last: UpdateStatus | null = null;
+  private applying = false;
+
+  constructor(deps: UpdateDeps = {}) {
+    this.repoDir = deps.repoDir ?? process.cwd();
+    this.branch = deps.branch ?? "main";
+    this.scriptPath = deps.scriptPath ?? join(this.repoDir, "deploy", "update.sh");
+    this.limit = deps.limit ?? 20;
+    this.git =
+      deps.git ??
+      ((args) =>
+        execFileSync("git", ["-C", this.repoDir, ...args], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        }));
+    this.launch = deps.launch ?? (() => this.defaultLaunch());
+  }
+
+  /** Launch the deploy script in its own transient systemd scope so it survives
+   *  the `systemctl restart shepherd` it triggers (otherwise the script, being a
+   *  child in the service cgroup, would be killed mid-update). */
+  private defaultLaunch(): void {
+    // forward our PATH: a transient --user unit gets a bare environment, but the
+    // deploy script needs bun/herdr/git/systemctl, which live on the service's PATH.
+    const args = ["--user", "--collect", "--unit=shepherd-update"];
+    if (process.env.PATH) args.push(`--setenv=PATH=${process.env.PATH}`);
+    args.push("bash", this.scriptPath, "--pull");
+    const child = spawn("systemd-run", args, { cwd: this.repoDir, stdio: "ignore" });
+    child.unref();
+  }
+
+  /** Last computed status, or null before the first check. */
+  current(): UpdateStatus | null {
+    return this.last;
+  }
+
+  /** Fetch origin and recompute how far behind the tracked branch we are. On any
+   *  git/network failure, returns behind:0 (fail safe → no false update badge). */
+  check(now: number): UpdateStatus {
+    try {
+      const remote = `origin/${this.branch}`;
+      this.git(["fetch", "--quiet", "origin", this.branch]);
+      const current = this.git(["rev-parse", "--short", "HEAD"]).trim() || null;
+      const latest = this.git(["rev-parse", "--short", remote]).trim() || null;
+      const range = `HEAD..${remote}`;
+      const behind = Number(this.git(["rev-list", "--count", range]).trim()) || 0;
+      const commits =
+        behind > 0
+          ? this.git(["log", `--max-count=${this.limit}`, "--format=%h%x09%s", range])
+              .split("\n")
+              .filter(Boolean)
+              .map((line) => {
+                const tab = line.indexOf("\t");
+                return { sha: line.slice(0, tab), subject: line.slice(tab + 1) };
+              })
+          : [];
+      this.last = { behind, current, latest, commits, checkedAt: now };
+    } catch (e) {
+      this.last = {
+        ...EMPTY(now),
+        current: this.last?.current ?? null,
+        error: e instanceof Error ? e.message : "git error",
+      };
+    }
+    return this.last;
+  }
+
+  /** Kick off the detached deploy script. Guards against double-launch within a
+   *  single process lifetime; returns whether it actually started. */
+  apply(): { started: boolean } {
+    if (this.applying) return { started: false };
+    this.applying = true;
+    this.launch();
+    return { started: true };
+  }
+}

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -387,3 +387,57 @@ test("POST /api/sessions/:id/reply types into the agent and 404s unknown ids", a
   );
   expect(wrongType.status).toBe(415);
 });
+
+// ── self-update routes ─────────────────────────────────────────────────────
+function harnessWithUpdates(updates: AppDeps["updates"]) {
+  return makeApp({ ...makeDeps(), updates });
+}
+
+test("GET /api/update with no updater returns a zeroed status", async () => {
+  const res = await harness().fetch(new Request("http://x/api/update"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.behind).toBe(0);
+});
+
+test("GET /api/update returns the updater's current status", async () => {
+  const status = {
+    behind: 2,
+    current: "abc1234",
+    latest: "def5678",
+    commits: [{ sha: "def5678", subject: "feat: x" }],
+    checkedAt: 1,
+  };
+  const app = harnessWithUpdates({ current: () => status, apply: () => ({ started: true }) });
+  const res = await app.fetch(new Request("http://x/api/update"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual(status);
+});
+
+test("POST /api/update with no updater → 503", async () => {
+  const res = await harness().fetch(new Request("http://x/api/update", { method: "POST" }));
+  expect(res.status).toBe(503);
+});
+
+test("POST /api/update when up to date → 409", async () => {
+  const app = harnessWithUpdates({
+    current: () => ({ behind: 0, current: "a", latest: "a", commits: [], checkedAt: 1 }),
+    apply: () => ({ started: true }),
+  });
+  const res = await app.fetch(new Request("http://x/api/update", { method: "POST" }));
+  expect(res.status).toBe(409);
+});
+
+test("POST /api/update when behind triggers apply → 202", async () => {
+  let applied = 0;
+  const app = harnessWithUpdates({
+    current: () => ({ behind: 1, current: "a", latest: "b", commits: [], checkedAt: 1 }),
+    apply: () => {
+      applied++;
+      return { started: true };
+    },
+  });
+  const res = await app.fetch(new Request("http://x/api/update", { method: "POST" }));
+  expect(res.status).toBe(202);
+  expect(applied).toBe(1);
+});

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "bun:test";
+import { UpdateService, type GitRunner } from "../src/update";
+
+/** Build a git runner from a map of "joined args" → stdout. */
+function fakeGit(responses: Record<string, string>): GitRunner {
+  return (args) => {
+    const key = args.join(" ");
+    if (!(key in responses)) throw new Error(`unexpected git: ${key}`);
+    return responses[key]!;
+  };
+}
+
+const UP_TO_DATE = {
+  "fetch --quiet origin main": "",
+  "rev-parse --short HEAD": "abc1234\n",
+  "rev-parse --short origin/main": "abc1234\n",
+  "rev-list --count HEAD..origin/main": "0\n",
+};
+
+const BEHIND_TWO = {
+  "fetch --quiet origin main": "",
+  "rev-parse --short HEAD": "abc1234\n",
+  "rev-parse --short origin/main": "def5678\n",
+  "rev-list --count HEAD..origin/main": "2\n",
+  "log --max-count=20 --format=%h%x09%s HEAD..origin/main":
+    "def5678\tfeat(ui): add update badge\nbbb2222\tfix(server): guard route\n",
+};
+
+test("up to date → behind 0, no commits", () => {
+  const svc = new UpdateService({ git: fakeGit(UP_TO_DATE), launch: () => {} });
+  const s = svc.check(1000);
+  expect(s.behind).toBe(0);
+  expect(s.commits).toEqual([]);
+  expect(s.current).toBe("abc1234");
+  expect(s.latest).toBe("abc1234");
+  expect(s.error).toBeUndefined();
+});
+
+test("behind main → behind count + parsed commit list (newest first)", () => {
+  const svc = new UpdateService({ git: fakeGit(BEHIND_TWO), launch: () => {} });
+  const s = svc.check(2000);
+  expect(s.behind).toBe(2);
+  expect(s.current).toBe("abc1234");
+  expect(s.latest).toBe("def5678");
+  expect(s.commits).toEqual([
+    { sha: "def5678", subject: "feat(ui): add update badge" },
+    { sha: "bbb2222", subject: "fix(server): guard route" },
+  ]);
+});
+
+test("subjects containing tabs survive parsing", () => {
+  const svc = new UpdateService({
+    git: fakeGit({
+      ...BEHIND_TWO,
+      "rev-list --count HEAD..origin/main": "1\n",
+      "log --max-count=20 --format=%h%x09%s HEAD..origin/main": "def5678\tfix: a\tb\tc\n",
+    }),
+    launch: () => {},
+  });
+  const s = svc.check(3000);
+  expect(s.commits).toEqual([{ sha: "def5678", subject: "fix: a\tb\tc" }]);
+});
+
+test("git failure fails safe to behind 0 with an error", () => {
+  const svc = new UpdateService({
+    git: () => {
+      throw new Error("network down");
+    },
+    launch: () => {},
+  });
+  const s = svc.check(4000);
+  expect(s.behind).toBe(0);
+  expect(s.error).toContain("network down");
+});
+
+test("current() caches the last check", () => {
+  const svc = new UpdateService({ git: fakeGit(BEHIND_TWO), launch: () => {} });
+  expect(svc.current()).toBeNull();
+  svc.check(5000);
+  expect(svc.current()?.behind).toBe(2);
+});
+
+test("apply() launches once and guards double-launch", () => {
+  let launches = 0;
+  const svc = new UpdateService({ git: fakeGit(UP_TO_DATE), launch: () => launches++ });
+  expect(svc.apply()).toEqual({ started: true });
+  expect(svc.apply()).toEqual({ started: false });
+  expect(launches).toBe(1);
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   MergeMethod,
   Settings,
   DirListing,
+  UpdateStatus,
 } from "./types";
 
 const JSON_HEADERS = { "content-type": "application/json" };
@@ -165,6 +166,22 @@ export async function mergePr(
   body?: { method?: MergeMethod; deleteBranch?: boolean },
 ): Promise<PrStatus> {
   return gitJson(await fetch(`/api/sessions/${id}/git/merge`, JSON_POST(body ?? {})));
+}
+
+/** Current self-update status (how far the running checkout is behind main). */
+export async function getUpdate(): Promise<UpdateStatus> {
+  const r = await fetch("/api/update");
+  if (!r.ok) throw new Error(`update status failed: ${r.status}`);
+  return r.json();
+}
+
+/** Trigger the deploy script (pull → rebuild → restart). Server restarts on success. */
+export async function applyUpdate(): Promise<void> {
+  const r = await fetch("/api/update", { method: "POST", headers: JSON_HEADERS });
+  if (!r.ok) {
+    const msg = await r.json().catch(() => ({ error: `${r.status}` }));
+    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+  }
 }
 
 export async function redeploy(id: string): Promise<void> {

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Session, UsageLimits } from "$lib/types";
+  import type { Session, UsageLimits, UpdateStatus } from "$lib/types";
   import { formatReset } from "$lib/format";
   import { theme } from "$lib/theme.svelte";
 
@@ -16,6 +16,8 @@
     onsettings,
     needsYou = 0,
     ontriage,
+    update = null,
+    onupdate,
   }: {
     sessions: Session[];
     nowMs: number;
@@ -25,7 +27,11 @@
     onsettings?: () => void;
     needsYou?: number;
     ontriage?: () => void;
+    update?: UpdateStatus | null;
+    onupdate?: () => void;
   } = $props();
+
+  const updateAvailable = $derived(!!update && update.behind > 0);
 
   const working = $derived(sessions.filter((s) => s.status === "running").length);
   const idle = $derived(sessions.filter((s) => s.status === "idle").length);
@@ -105,6 +111,18 @@
     <div class="clock">
       <span class="dot" class:on={connected}>●</span><span>{clock}</span>
     </div>
+    {#if updateAvailable}
+      <button
+        class="update-badge"
+        class:mobile
+        onclick={() => onupdate?.()}
+        title="{update!.behind} {update!.behind === 1 ? 'neuer Commit' : 'neue Commits'} auf main"
+      >
+        <span class="up-dot">▲</span>
+        {#if !mobile}<span class="up-label">Update</span>{/if}
+        <span class="up-n">{update!.behind}</span>
+      </button>
+    {/if}
     {#if mobile}
       <button
         class="theme-cycle"
@@ -274,6 +292,43 @@
   .theme-cycle:hover {
     color: var(--color-amber);
     border-color: var(--color-amber);
+  }
+  .update-badge {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 11px;
+    background: color-mix(in srgb, var(--color-amber) 14%, transparent);
+    border: 1px solid var(--color-amber);
+    color: var(--color-amber);
+    cursor: pointer;
+    font: inherit;
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    border-radius: 2px;
+    animation: update-pulse 2.4s ease-in-out infinite;
+  }
+  .update-badge .up-dot {
+    font-size: 8px;
+  }
+  .update-badge .up-n {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+  }
+  .update-badge.mobile {
+    padding: 4px 8px;
+    gap: 4px;
+    letter-spacing: 0.08em;
+  }
+  @keyframes update-pulse {
+    0%,
+    100% {
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-amber) 40%, transparent);
+    }
+    50% {
+      box-shadow: 0 0 0 4px transparent;
+    }
   }
   .clock {
     color: var(--color-ink-bright);

--- a/ui/src/lib/components/UpdateModal.svelte
+++ b/ui/src/lib/components/UpdateModal.svelte
@@ -1,0 +1,224 @@
+<script lang="ts">
+  import type { UpdateStatus } from "$lib/types";
+  import { applyUpdate } from "$lib/api";
+
+  let {
+    update,
+    updating = false,
+    onconfirm,
+    onclose,
+  }: {
+    update: UpdateStatus;
+    updating?: boolean;
+    onconfirm?: () => void;
+    onclose?: () => void;
+  } = $props();
+
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+
+  async function confirm() {
+    submitting = true;
+    error = null;
+    try {
+      await applyUpdate();
+      onconfirm?.(); // store marks `updating`; the page reloads once the new build is live
+    } catch (e) {
+      error = e instanceof Error ? e.message : "update failed";
+      submitting = false;
+    }
+  }
+
+  const busy = $derived(submitting || updating);
+</script>
+
+<div
+  class="overlay"
+  role="presentation"
+  onclick={(e) => {
+    if (e.target === e.currentTarget && !busy) onclose?.();
+  }}
+>
+  <div class="card bracket">
+    <div class="chead">
+      <span class="micro">Update&nbsp;verfügbar</span>
+      {#if !busy}
+        <button type="button" class="x" onclick={() => onclose?.()} aria-label="close">✕</button>
+      {/if}
+    </div>
+
+    <div class="summary">
+      <span class="count">{update.behind}</span>
+      <span class="micro"
+        >{update.behind === 1 ? "neuer Commit" : "neue Commits"} auf&nbsp;main</span
+      >
+      {#if update.current && update.latest}
+        <span class="shas micro">{update.current} → {update.latest}</span>
+      {/if}
+    </div>
+
+    <div class="commits">
+      {#each update.commits as c (c.sha)}
+        <div class="commit">
+          <span class="sha">{c.sha}</span>
+          <span class="subject">{c.subject}</span>
+        </div>
+      {/each}
+    </div>
+
+    {#if busy}
+      <div class="status">
+        ⟳ Wird aktualisiert… Server startet neu, die Seite lädt automatisch neu.
+      </div>
+    {/if}
+    {#if error}<div class="err">{error}</div>{/if}
+
+    <div class="actions">
+      {#if !busy}
+        <button type="button" class="later" onclick={() => onclose?.()}>Später</button>
+      {/if}
+      <button type="button" class="run" onclick={confirm} disabled={busy}>
+        {busy ? "Aktualisiere…" : "Update jetzt"}
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(3, 6, 5, 0.66);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 30;
+    padding: 16px;
+  }
+  .card {
+    position: relative;
+    width: min(520px, 100%);
+    max-height: 80dvh;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line-bright);
+    padding: 18px 18px 16px;
+    box-shadow: inset 0 0 30px -16px var(--color-amber);
+  }
+  .bracket::before,
+  .bracket::after {
+    content: "";
+    position: absolute;
+    width: 9px;
+    height: 9px;
+    border: 1px solid var(--color-line-bright);
+  }
+  .bracket::before {
+    top: -1px;
+    left: -1px;
+    border-right: 0;
+    border-bottom: 0;
+  }
+  .bracket::after {
+    bottom: -1px;
+    right: -1px;
+    border-left: 0;
+    border-top: 0;
+  }
+  .chead {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .micro {
+    font-size: 10.5px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .x {
+    background: transparent;
+    border: 0;
+    color: var(--color-muted);
+    cursor: pointer;
+    font-size: 13px;
+  }
+  .summary {
+    display: flex;
+    align-items: baseline;
+    gap: 9px;
+  }
+  .summary .count {
+    color: var(--color-amber);
+    font-size: 22px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  .summary .shas {
+    margin-left: auto;
+    color: var(--color-faint);
+    font-variant-numeric: tabular-nums;
+  }
+  .commits {
+    overflow-y: auto;
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .commit {
+    display: flex;
+    gap: 9px;
+    align-items: baseline;
+    font-size: 12.5px;
+  }
+  .commit .sha {
+    color: var(--color-amber);
+    font-variant-numeric: tabular-nums;
+    flex: none;
+  }
+  .commit .subject {
+    color: var(--color-ink-bright);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .status {
+    color: var(--color-amber);
+    font-size: 12px;
+  }
+  .err {
+    color: var(--color-red);
+    font-size: 12px;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+  }
+  .later {
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    padding: 8px 14px;
+    cursor: pointer;
+    letter-spacing: 0.06em;
+  }
+  .run {
+    background: var(--color-amber);
+    border: 1px solid var(--color-amber);
+    color: #0c100f;
+    font-weight: 600;
+    padding: 8px 16px;
+    cursor: pointer;
+    letter-spacing: 0.06em;
+  }
+  .run:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+</style>

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -1,4 +1,4 @@
-import type { Session, WsEvent, UsageLimits } from "./types";
+import type { Session, WsEvent, UsageLimits, UpdateStatus } from "./types";
 import type { BlockState } from "./triage";
 
 export class HerdStore {
@@ -6,6 +6,11 @@ export class HerdStore {
   blocks = $state<Record<string, BlockState>>({});
   connected = $state(false);
   usageLimits = $state<UsageLimits | null>(null);
+  update = $state<UpdateStatus | null>(null);
+  /** true once the user has confirmed an update; cleared by the reload it triggers */
+  updating = $state(false);
+  /** SHA we booted on; a different `current` after an update means a fresh build is live */
+  private runningVersion: string | null = null;
 
   setAll(list: Session[]) {
     this.sessions = list;
@@ -15,6 +20,29 @@ export class HerdStore {
   }
   byId(id: string) {
     return this.sessions.find((s) => s.id === id);
+  }
+
+  /** Record the user's confirmation; the next status carrying a new SHA reloads. */
+  beginUpdate() {
+    this.updating = true;
+  }
+
+  setUpdate(u: UpdateStatus) {
+    // the first status we ever see pins the version the page was loaded against
+    if (this.runningVersion === null) this.runningVersion = u.current;
+    // after a confirmed update the server returns on a new SHA → reload so the
+    // browser (e.g. the phone) picks up the freshly built UI assets
+    if (
+      this.updating &&
+      u.current &&
+      this.runningVersion &&
+      u.current !== this.runningVersion &&
+      typeof location !== "undefined"
+    ) {
+      location.reload();
+      return;
+    }
+    this.update = u;
   }
 
   apply(ev: WsEvent) {
@@ -39,6 +67,8 @@ export class HerdStore {
       }
     } else if (ev.event === "usage:limits") {
       this.usageLimits = ev.data;
+    } else if (ev.event === "update:status") {
+      this.setUpdate(ev.data);
     }
   }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -110,12 +110,27 @@ export interface UsageLimits {
   calibratedAt: number | null;
 }
 
+export interface UpdateCommit {
+  sha: string;
+  subject: string;
+}
+
+export interface UpdateStatus {
+  behind: number;
+  current: string | null;
+  latest: string | null;
+  commits: UpdateCommit[];
+  checkedAt: number;
+  error?: string;
+}
+
 export type WsEvent =
   | { event: "session:new"; data: Session }
   | { event: "session:status"; data: { id: string; status: SessionStatus } }
   | { event: "session:archived"; data: { id: string } }
   | { event: "usage:limits"; data: UsageLimits }
-  | { event: "session:block"; data: { id: string; block: BlockReason | null } };
+  | { event: "session:block"; data: { id: string; block: BlockReason | null } }
+  | { event: "update:status"; data: UpdateStatus };
 
 export interface CreateInput {
   repoPath: string;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -8,6 +8,7 @@
     archiveSession,
     getUsageLimits,
     replySession,
+    getUpdate,
   } from "$lib/api";
   import { sortBlocked } from "$lib/triage";
   import TopBar from "$lib/components/TopBar.svelte";
@@ -18,12 +19,14 @@
   import Settings from "$lib/components/Settings.svelte";
   import ActionBar from "$lib/components/ActionBar.svelte";
   import HerdGrid from "$lib/components/HerdGrid.svelte";
+  import UpdateModal from "$lib/components/UpdateModal.svelte";
 
   const store = new HerdStore();
   let selectedId = $state<string | null>(null);
   let showNew = $state(false);
   let showSettings = $state(false);
   let showTriage = $state(false);
+  let showUpdate = $state(false);
   const blockedEntries = $derived(sortBlocked(store.sessions, store.blocks));
   let viewMode = $state<"focus" | "all">("focus");
   let nowMs = $state(Date.now());
@@ -59,6 +62,9 @@
       .catch(() => {});
     getUsageLimits()
       .then((l) => store.setUsageLimits(l))
+      .catch(() => {});
+    getUpdate()
+      .then((u) => store.setUpdate(u))
       .catch(() => {});
     const dispose = store.connect();
     const t = setInterval(() => (nowMs = Date.now()), 1000);
@@ -99,6 +105,8 @@
     onsettings={() => (showSettings = true)}
     needsYou={blockedEntries.length}
     ontriage={() => (showTriage = true)}
+    update={store.update}
+    onupdate={() => (showUpdate = true)}
   />
 
   {#if mobile.current}
@@ -171,6 +179,15 @@
     />
   {/if}
 </div>
+
+{#if showUpdate && store.update && store.update.behind > 0}
+  <UpdateModal
+    update={store.update}
+    updating={store.updating}
+    onconfirm={() => store.beginUpdate()}
+    onclose={() => (showUpdate = false)}
+  />
+{/if}
 
 {#if showNew}
   <NewTask

--- a/ui/test/store.test.ts
+++ b/ui/test/store.test.ts
@@ -75,3 +75,35 @@ test("clears block state when the session is archived", () => {
   store.apply({ event: "session:archived", data: { id: "s1" } });
   expect(store.blocks["s1"]).toBeUndefined();
 });
+
+const upd = (behind: number, current: string, latest = current) => ({
+  behind,
+  current,
+  latest,
+  commits: behind ? [{ sha: latest, subject: "feat: x" }] : [],
+  checkedAt: 0,
+});
+
+test("applies update:status", () => {
+  const store = new HerdStore();
+  expect(store.update).toBeNull();
+  store.apply({ event: "update:status", data: upd(2, "aaa", "bbb") });
+  expect(store.update?.behind).toBe(2);
+  expect(store.update?.latest).toBe("bbb");
+});
+
+test("update without a confirmed apply just stores (no reload)", () => {
+  const store = new HerdStore();
+  store.apply({ event: "update:status", data: upd(0, "aaa") }); // pins running version
+  store.apply({ event: "update:status", data: upd(1, "aaa", "bbb") });
+  // a different `current` arrives but we never confirmed → still just stored, no throw
+  store.apply({ event: "update:status", data: upd(0, "bbb") });
+  expect(store.update?.current).toBe("bbb");
+  expect(store.updating).toBe(false);
+});
+
+test("beginUpdate marks the store as updating", () => {
+  const store = new HerdStore();
+  store.beginUpdate();
+  expect(store.updating).toBe(true);
+});


### PR DESCRIPTION
## Was

In-App-Self-Update: ein **Badge oben rechts** erscheint, sobald der laufende Stand hinter `origin/main` liegt — auf **Commit-Ebene**, keine Versionsnummern nötig. Klick öffnet ein Modal mit den neuen Commits, „Update jetzt" zieht den vorhandenen `deploy/update.sh`-Mechanismus (pull → build → restart) und die Seite lädt nach dem Neustart automatisch neu, sodass auch das Smartphone die neue Version bekommt.

## Wie

**Backend**
- `src/update.ts` — `UpdateService`: `git fetch origin main`, Diff `HEAD..origin/main` → `{ behind, current, latest, commits[] }`. Fehlschlag → fail-safe `behind: 0` (kein falsches Badge). `apply()` startet das Deploy-Script in einer **transienten `systemd-run --user`-Unit** (mit durchgereichtem PATH), damit es das `systemctl restart shepherd` überlebt.
- `src/index.ts` — periodischer Check (3 s nach Start, dann alle 5 min), pusht `update:status` über den vorhandenen `/events`-WS.
- `src/server.ts` — `GET /api/update` (Status) + `POST /api/update` (löst aus; 409 wenn nichts ansteht, 202 bei Start).

**Frontend**
- `TopBar.svelte` — amber Badge, nur bei `behind > 0`.
- `UpdateModal.svelte` — Commit-Liste + Bestätigung + Status.
- `store.svelte.ts` — merkt sich die laufende SHA; nach bestätigtem Update + Reconnect auf neuer SHA → `location.reload()`.

## Checks
- Root: `bun test` → **214 pass** · `bun run lint` clean
- UI: `bun run test` (vitest) → **26 pass** · `bun run check` → **0 errors** · Build ok

## Hinweis
Das Auslösen wirkt nur gegen die systemd-Prod-Instanz (`update.sh --pull` braucht sauberen `main`); im Dev-Worktree wird es korrekt abgelehnt.

cc @scoop
