### PR TITLE
fix: handle claude session termination (ctrl-c) instead of reconnect-looping

### DIFF
--- a/src/poller.ts
+++ b/src/poller.ts
@@ -24,7 +24,18 @@ export class StatusPoller {
     for (const s of this.store.list({ activeOnly: true })) {
       activeIds.add(s.id);
       const agent = byTerm.get(s.herdrAgentId);
-      if (!agent) continue;
+      if (!agent) {
+        // the herdr agent is gone (claude exited / user ctrl-c'd the session).
+        // mirror reconcile()'s startup behavior, but live — otherwise the session
+        // stays "running" forever and the pty client keeps re-attaching a dead
+        // terminal (herdr replies agent_not_found in a tight reconnect loop).
+        this.clearBlock(s.id);
+        if (s.status !== "done") {
+          this.store.update(s.id, { status: "done", lastState: "done" });
+          this.onChange(s.id, "done");
+        }
+        continue;
+      }
       const status = mapState(agent.agentStatus);
       if (status !== s.status || agent.agentStatus !== s.lastState) {
         this.store.update(s.id, { status, lastState: agent.agentStatus });

--- a/src/server.ts
+++ b/src/server.ts
@@ -283,13 +283,19 @@ export function makeApp(deps: AppDeps) {
 
 type WsData =
   | { kind: "events" }
-  | { kind: "pty"; terminalId: string; cols: number; rows: number; bridge?: PtyBridge };
+  | { kind: "pty"; id: string; terminalId: string; cols: number; rows: number; bridge?: PtyBridge };
 
 // A pty WS closed with this code means "a newer client took over this terminal".
 // The client parks (shows a take-over prompt) instead of reconnecting — without
 // it, two devices on the same session ping-pong herdr's --takeover forever.
 // Keep in sync with PTY_SUPERSEDED_CODE in ui/src/lib/pty.ts.
 export const PTY_SUPERSEDED_CODE = 4000;
+
+// A pty WS closed with this code means "this session has ended" — its herdr
+// agent is gone (the user quit claude / ctrl-c'd). The client stops reconnecting
+// and shows an ended state instead of looping on herdr's agent_not_found.
+// Keep in sync with PTY_GONE_CODE in ui/src/lib/pty.ts.
+export const PTY_GONE_CODE = 4001;
 
 export function serve(deps: AppDeps, port: number) {
   const app = makeApp(deps);
@@ -331,7 +337,7 @@ export function serve(deps: AppDeps, port: number) {
           url.searchParams.get("rows"),
         );
         return server.upgrade(req, {
-          data: { kind: "pty", terminalId: s.herdrAgentId, cols, rows },
+          data: { kind: "pty", id: s.id, terminalId: s.herdrAgentId, cols, rows },
         })
           ? undefined
           : new Response("upgrade failed", { status: 500 });
@@ -346,6 +352,15 @@ export function serve(deps: AppDeps, port: number) {
           );
           (ws.data as any).unsub = unsub;
         } else {
+          // session ended (claude quit / ctrl-c → herdr agent reaped): don't
+          // attach a dead terminal. Attaching would make herdr reply
+          // agent_not_found and the client would reconnect-loop on it. Tell the
+          // client it's gone so it stops and shows an ended state.
+          const cur = deps.store.get(ws.data.id);
+          if (!cur || cur.status === "done" || cur.status === "archived") {
+            ws.close(PTY_GONE_CODE, "ended");
+            return;
+          }
           // single owner per terminal: claim it, then bump the previous owner
           // with a "superseded" close so it parks instead of fighting back.
           const tid = ws.data.terminalId;

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -142,6 +142,66 @@ test("re-emits onBlock when the blocked reason changes after the cadence", () =>
   expect((blocks[1]!.block as any).shape).toBe("yes-no");
 });
 
+test("marks a session done and emits once when its herdr agent is gone", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const emitted: { id: string; status: string }[] = [];
+
+  // herdr no longer lists the agent (claude exited / ctrl-c reaped the terminal)
+  const poller = new StatusPoller(
+    store,
+    { list: () => [] as HerdrAgent[], read: () => "" } as any,
+    (id, status) => emitted.push({ id, status }),
+    () => {},
+  );
+
+  poller.tick();
+  expect(store.get(s.id)?.status).toBe("done");
+  expect(store.get(s.id)?.lastState).toBe("done");
+  expect(emitted).toEqual([{ id: s.id, status: "done" }]);
+
+  poller.tick(); // already done → no duplicate emit
+  expect(emitted.length).toBe(1);
+});
+
+test("clears an active block when the agent disappears", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const blocks: { id: string; block: unknown }[] = [];
+
+  let agents: HerdrAgent[] = [
+    {
+      agent: "claude",
+      agentStatus: "blocked",
+      cwd: "/wt",
+      paneId: "p",
+      tabId: "t",
+      terminalId: "term_a",
+      workspaceId: "w",
+    },
+  ];
+  let clock = 100_000;
+  const poller = new StatusPoller(
+    store,
+    { list: () => agents, read: () => "❯ 1. Yes\n  2. No" } as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+  );
+
+  poller.tick();
+  expect(blocks).toHaveLength(1); // classified the block
+
+  agents = []; // agent gone
+  clock += 5000;
+  poller.tick();
+  expect(store.get(s.id)?.status).toBe("done");
+  expect(blocks[blocks.length - 1]).toEqual({ id: s.id, block: null }); // block cleared
+});
+
 test("does not emit onBlock when reading the terminal throws", () => {
   const store = new SessionStore(":memory:");
   store.create(baseSession);

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -5,7 +5,7 @@ import { stagingDir } from "../src/uploads";
 import { SessionStore } from "../src/store";
 import { SessionService } from "../src/service";
 import { EventHub } from "../src/events";
-import { makeApp, serve, type AppDeps } from "../src/server";
+import { makeApp, serve, PTY_GONE_CODE, type AppDeps } from "../src/server";
 import { config } from "../src/config";
 
 // Create a real tmp dir inside config.repoRoot so validation passes
@@ -211,6 +211,38 @@ test("WS /pty/:id with evil Origin → 403", async () => {
       headers: { Origin: "https://evil.com" },
     });
     expect(res.status).toBe(403);
+  } finally {
+    server.stop();
+  }
+});
+
+// ── PTY: terminated session must not attach (would loop on agent_not_found) ────
+
+test("WS /pty/:id for a terminated (done) session closes with PTY_GONE_CODE", async () => {
+  const deps = makeDeps();
+  const session = deps.store.create({
+    name: "test",
+    prompt: "go",
+    repoPath: "/wt",
+    baseBranch: "main",
+    branch: null,
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_dead",
+  });
+  // claude exited / ctrl-c → the poller (or reconcile) has marked it done
+  deps.store.update(session.id, { status: "done", lastState: "done" });
+
+  const server = serve(deps, 0);
+  try {
+    const code = await new Promise<number>((resolve, reject) => {
+      const ws = new WebSocket(`ws://localhost:${server.port}/pty/${session.id}`);
+      ws.onclose = (e) => resolve(e.code);
+      ws.onerror = () => {};
+      setTimeout(() => reject(new Error("timed out waiting for close")), 3000);
+    });
+    expect(code).toBe(PTY_GONE_CODE);
   } finally {
     server.stop();
   }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -170,6 +170,11 @@
       () => {
         parked = true;
       },
+      // the session ended (agent gone) — note it in the buffer; the status badge
+      // already flips to "done" via the session:status event
+      () => {
+        term.write("\r\n\x1b[2m── session ended ──\x1b[0m\r\n");
+      },
     );
     conn = c;
     term.onData((d) => c.send(d));

--- a/ui/src/lib/pty.test.ts
+++ b/ui/src/lib/pty.test.ts
@@ -38,6 +38,11 @@ class FakeWs {
     this.readyState = this.CLOSED;
     this.onclose?.({ code });
   }
+  /** server closed us because the agent is gone (session terminated) */
+  gone(code = 4001) {
+    this.readyState = this.CLOSED;
+    this.onclose?.({ code });
+  }
   send(d: string | ArrayBufferLike | ArrayBufferView) {
     this.sent.push(d);
   }
@@ -46,7 +51,7 @@ class FakeWs {
   }
 }
 
-function make(onReconnect = () => {}, onParked = () => {}) {
+function make(onReconnect = () => {}, onParked = () => {}, onEnded = () => {}) {
   FakeWs.instances = [];
   const onData = vi.fn();
   const conn = connectPty(
@@ -56,6 +61,7 @@ function make(onReconnect = () => {}, onParked = () => {}) {
     onData,
     onReconnect,
     onParked,
+    onEnded,
     (path) => new FakeWs(path) as unknown as WebSocket,
   );
   return { conn, onData, last: () => FakeWs.instances[FakeWs.instances.length - 1]! };
@@ -132,6 +138,27 @@ describe("connectPty", () => {
     conn.takeover();
     expect(FakeWs.instances).toHaveLength(2); // new attach → becomes owner again
     expect(last().url).toBe("/pty/abc?cols=100&rows=30");
+  });
+
+  it("ends on a gone close and does NOT reconnect", () => {
+    vi.useFakeTimers();
+    const onEnded = vi.fn();
+    const { conn, last } = make(
+      () => {},
+      () => {},
+      onEnded,
+    );
+    last().open();
+
+    last().gone(); // server says the agent is gone (close code 4001)
+    expect(onEnded).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(5000);
+    expect(FakeWs.instances).toHaveLength(1); // never reconnected — no attach loop
+
+    conn.poke(); // a refocus must not resurrect an ended session
+    expect(FakeWs.instances).toHaveLength(1);
+    vi.useRealTimers();
   });
 
   it("close stops reconnection", () => {

--- a/ui/src/lib/pty.ts
+++ b/ui/src/lib/pty.ts
@@ -5,6 +5,12 @@ import { wsUrl } from "./store.svelte";
 // don't ping-pong the attach. Keep in sync with PTY_SUPERSEDED_CODE in src/server.ts.
 const PTY_SUPERSEDED_CODE = 4000;
 
+// Server closes a pty WS with this code when the session has ended (its herdr
+// agent is gone — the user quit claude / ctrl-c'd). We stop for good instead of
+// reconnecting, which would loop on herdr's agent_not_found. Keep in sync with
+// PTY_GONE_CODE in src/server.ts.
+const PTY_GONE_CODE = 4001;
+
 export interface PtyConn {
   send(data: string): void;
   resize(c: number, r: number): void;
@@ -30,6 +36,9 @@ export function connectPty(
   // fired when the server hands this terminal to another device — caller shows a
   // "take over" affordance instead of fighting for the attach
   onParked: () => void = () => {},
+  // fired when the session has ended (agent gone) — caller shows an ended state;
+  // the connection stops for good and never reconnects
+  onEnded: () => void = () => {},
   makeWs: (path: string) => WebSocket = (p) => new WebSocket(wsUrl(p)),
 ): PtyConn {
   let ws: WebSocket;
@@ -62,6 +71,13 @@ export function connectPty(
       if (e && e.code === PTY_SUPERSEDED_CODE) {
         parked = true;
         onParked();
+        return;
+      }
+      // the session ended (agent gone) → stop for good; reconnecting would just
+      // loop on herdr's agent_not_found
+      if (e && e.code === PTY_GONE_CODE) {
+        stopped = true;
+        onEnded();
         return;
       }
       if (!stopped && !parked && !retry) retry = setTimeout(open, 1000);


### PR DESCRIPTION
## Problem
Ctrl-C'ing a Claude session left the Shepherd session stuck: the terminal spammed `herdr: server shut down: terminal … exited` + `{"error":{"code":"agent_not_found",…,"id":"cli: agent: attach: resolve"}}` ~once a second, and the session never left `running`.

## Root cause
Two compounding defects once herdr reaps the terminal on exit:
- **Server never noticed mid-run.** `StatusPoller.tick()` skipped vanished agents (`if (!agent) continue`). `reconcile()` marks them `done` — but only at startup — so a session ending while the server is up stayed `running` forever.
- **Client reconnect-looped.** PTY helper exits → WS closes (normal code) → `connectPty` reconnects after 1s → re-runs `herdr agent attach` on the gone id → `agent_not_found` → exits → loop. With status stuck `running`, the client never learned to stop.

## Fix (defense-in-depth)
- `src/poller.ts` — when the herdr agent is gone: clear block, mark `done`, emit `session:status` (live, mirroring `reconcile`); emits once.
- `src/server.ts` — new `PTY_GONE_CODE = 4001`; `/pty/:id` refuses to attach a terminated/missing session, closing with `4001` instead of looping.
- `ui/src/lib/pty.ts` — handle `4001`: stop for good (no reconnect) + `onEnded`.
- `ui/src/lib/components/Viewport.svelte` — `onEnded` writes a `── session ended ──` marker (badge already flips to `done`).

`UnitTile.svelte` unchanged — read-only tiles stop automatically via the loop-break.

Net: a Ctrl-C'd session flips to **done** within ~1s, terminal stops cleanly, no `agent_not_found` loop.

## Tests (TDD)
- `test/poller.test.ts` (+2), `test/server.test.ts` (+1, real WS asserting close 4001), `ui/src/lib/pty.test.ts` (+1). Each watched fail → pass.
- Root: lint clean, `tsc --noEmit` clean, `bun test` → 245 pass / 0 fail / 246 tests.
- UI: `svelte-check` → 0 errors/0 warnings, `vitest` → 36 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)