### PR TITLE
fix(ui): hide clock time on mobile, keep connection dot

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -111,7 +111,7 @@
       </div>
     {/if}
     <div class="clock tip" data-tip={connText} aria-label={connText}>
-      <span class="dot" class:on={connected}>●</span><span>{clock}</span>
+      <span class="dot" class:on={connected}>●</span><span class="time">{clock}</span>
     </div>
     {#if updateAvailable}
       <button
@@ -366,8 +366,9 @@
   .tallies.compact .csep {
     color: var(--color-faint);
   }
-  .hud.mobile .clock {
-    font-size: 12px;
+  /* Mobile keeps the connection dot but hides the time to save space. */
+  .hud.mobile .clock .time {
+    display: none;
   }
   .hud.mobile .rightside {
     gap: 9px;


### PR DESCRIPTION
On mobile, the top-right HUD now hides the HH:MM:SS time to save horizontal space, while keeping the connection-status dot visible.

- `TopBar.svelte`: tag the time `<span>` with `.time`; mobile CSS sets `.hud.mobile .clock .time { display: none }` (replaces the now-moot `font-size: 12px` mobile rule).

UI check: 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)