### PR TITLE
fix(ui): prevent NEEDS YOU badge wrapping on portrait

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -216,6 +216,8 @@
     font-size: 11px;
     padding: 5px 10px;
     cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
   .rightside {
     margin-left: auto;


### PR DESCRIPTION
## Problem
The `NEEDS YOU · N` marker in the top-right HUD wrapped onto two lines on narrow/portrait mobile layouts. The label contains a space and a middle-dot (both wrap points), and `.rightside`/`.hud` are non-wrapping flex rows, so the badge got squeezed.

## Fix
Added `white-space: nowrap` and `flex-shrink: 0` to `.needsyou` in `TopBar.svelte` — keeps the label on one line and stops sibling HUD items from compressing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)