### PR TITLE
fix(ui): optimize mobile touch targets, wrapping & scrolling

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -122,6 +122,7 @@
   "viewport_decommission_title": "Agent stoppen + Worktree entfernen",
   "viewport_confirm_decommission": "bestätigen ✕",
   "viewport_decommission": "✕ stilllegen",
+  "viewport_decommission_aria": "Einheit stilllegen",
   "viewport_upload_failed": "Upload fehlgeschlagen — zum Wiederholen tippen",
   "viewport_attach_image": "Bild anhängen",
   "viewport_type_steer_hint": "⌁ tippen zum Steuern",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -122,6 +122,7 @@
   "viewport_decommission_title": "stop agent + remove worktree",
   "viewport_confirm_decommission": "confirm ✕",
   "viewport_decommission": "✕ decommission",
+  "viewport_decommission_aria": "decommission unit",
   "viewport_upload_failed": "Upload failed — tap to retry",
   "viewport_attach_image": "Attach image",
   "viewport_type_steer_hint": "⌁ type to steer",

--- a/ui/src/lib/components/ControlBar.svelte
+++ b/ui/src/lib/components/ControlBar.svelte
@@ -42,8 +42,8 @@
 
   .key {
     flex: 0 0 auto;
-    min-width: 40px;
-    height: 36px;
+    min-width: 42px;
+    height: 40px;
     background: var(--color-inset);
     border: 1px solid var(--color-line-bright);
     border-radius: 3px;

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -391,6 +391,11 @@
     .run {
       min-height: 44px;
     }
+    .x {
+      min-width: 44px;
+      min-height: 44px;
+      font-size: 16px;
+    }
   }
 
   @keyframes sheet-up {

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -59,8 +59,8 @@
   }
   .chip {
     flex: 0 0 auto;
-    height: 32px;
-    padding: 0 12px;
+    height: 38px;
+    padding: 0 14px;
     background: var(--color-inset);
     border: 1px solid var(--color-line-bright);
     border-radius: 3px;

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -186,6 +186,7 @@
     letter-spacing: 0.34em;
     color: var(--color-ink-bright);
     font-size: 15px;
+    flex-shrink: 0;
   }
   .logo b {
     color: var(--color-amber);
@@ -356,7 +357,12 @@
     color: var(--color-green);
   }
   .hud.mobile {
+    /* wrap instead of overflowing: on fold-cover (~280px) and phones the
+       logo+tallies sit on line 1, the right-side controls drop to line 2
+       rather than forcing horizontal page scroll or clipping the gear */
+    flex-wrap: wrap;
     gap: 10px;
+    row-gap: 8px;
     padding: 10px 12px;
   }
   .hud.mobile .logo {
@@ -368,6 +374,7 @@
     align-items: center;
     gap: 5px;
     font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
   }
   .tallies.compact .cdot {
     font-size: 9px;
@@ -380,7 +387,26 @@
     display: none;
   }
   .hud.mobile .rightside {
+    flex-wrap: wrap;
+    justify-content: flex-end;
     gap: 9px;
+    row-gap: 8px;
+  }
+  /* finger-sized tap targets on touch HUDs (≥40px) — the desktop sizes are
+     tuned for a cursor and are too small to hit reliably on a phone */
+  .hud.mobile .gear,
+  .hud.mobile .theme-cycle {
+    min-height: 40px;
+    min-width: 40px;
+    padding: 5px 11px;
+    font-size: 16px;
+  }
+  .hud.mobile .needsyou {
+    min-height: 40px;
+    padding: 8px 12px;
+  }
+  .hud.mobile .update-badge {
+    min-height: 40px;
   }
 
   /* Desktop-only hover tooltips — never shown on touch / mobile devices. */

--- a/ui/src/lib/components/TriageDrawer.svelte
+++ b/ui/src/lib/components/TriageDrawer.svelte
@@ -132,6 +132,9 @@
     border: 0;
     color: var(--color-muted);
     cursor: pointer;
+    min-width: 40px;
+    min-height: 40px;
+    font-size: 15px;
   }
   .empty {
     color: var(--color-muted);
@@ -191,6 +194,15 @@
     color: var(--color-ink-bright);
     padding: 6px 12px;
     cursor: pointer;
+  }
+  /* reply / option / batch controls are the drawer's primary actions and the
+     drawer goes full-screen on phones — keep them finger-sized (≥40px) */
+  .opts button,
+  .reply button,
+  .reply input,
+  .batch button,
+  .batch input {
+    min-height: 40px;
   }
   input {
     flex: 1;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -378,8 +378,13 @@
       type="button"
       onclick={decommission}
       title={m.viewport_decommission_title()}
+      aria-label={m.viewport_decommission_aria()}
     >
-      {armed ? m.viewport_confirm_decommission() : m.viewport_decommission()}
+      {#if compact}
+        {armed ? "✓" : "✕"}
+      {:else}
+        {armed ? m.viewport_confirm_decommission() : m.viewport_decommission()}
+      {/if}
     </button>
   </div>
 
@@ -469,12 +474,16 @@
     />
   {/if}
 
-  <!-- footer -->
-  <div class="vp-foot">
-    <span>{m.viewport_type_steer_hint()}</span>
-    <span class="sep">·</span>
-    <span>{m.viewport_detach_hint()}</span>
-  </div>
+  <!-- footer: keyboard-affordance hints — desktop / foldable only. On a phone
+       there's no Tab key and the back button already affords leaving, so the
+       row is pure overhead; dropping it hands the height back to the terminal -->
+  {#if !mobile}
+    <div class="vp-foot">
+      <span>{m.viewport_type_steer_hint()}</span>
+      <span class="sep">·</span>
+      <span>{m.viewport_detach_hint()}</span>
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -710,8 +719,15 @@
   .vp-head.mobile .tab-btn {
     flex: 1;
     text-align: center;
-    padding: 8px 6px;
+    padding: 10px 6px;
     font-size: 11px;
+  }
+  /* finger-sized header controls on touch layouts (≥40px) */
+  .vp-head.mobile .back,
+  .vp-head.mobile .decom {
+    min-height: 40px;
+    padding: 8px 12px;
+    font-size: 12px;
   }
 
   .tab-btn {
@@ -769,7 +785,7 @@
   .ctrl-row .attach {
     flex: 0 0 auto;
     min-width: 44px;
-    height: 36px;
+    height: 40px;
     margin: 6px 0 6px 10px;
     background: var(--color-inset);
     border: 1px solid var(--color-line-bright);


### PR DESCRIPTION
Full mobile UX pass for **fold-cover (~280px)**, **regular portrait (~390px)**, and **unfolded/wide** form factors. Verified live in-browser at each width.

## Critical — HUD overflow
The HUD was a single non-wrapping flex row, so on fold-cover and even regular phones it exceeded the width and **clipped the settings gear** (or forced horizontal page scroll). Prior commits only trimmed content; the row still couldn't fit.

- `.hud.mobile` + `.rightside` now `flex-wrap` with `row-gap`; logo/tallies pinned `flex-shrink: 0`.
- Result: logo+tallies on line 1, controls wrap below — no overflow, gear always reachable.

## Touch targets → ≥40px
- TopBar gear / theme-cycle / NEEDS-YOU / update badge
- Viewport back button + decommission (were ~26px)
- SteerBar chips 32→38px · ControlBar keys 36→40px · attach 36→40px
- TriageDrawer (full-screen on phones) reply/option/batch buttons + inputs; close ✕ → 40×40
- NewTask close ✕ → 44×44 on mobile

## Wrapping & scrolling
- Decommission goes **icon-only `✕`** on compact (armed shows `✓`) so the mobile header stays unwrapped.
- Keyboard-only viewport footer (`⌁ type to steer · ⇥ detach`) dropped on phones — reclaims ~26px of terminal height. Kept on desktop/foldable.

## Validation
- `bun run lint` clean · `cd ui && bun run check` → 0 errors/warnings · `bun run build` succeeds.
- Screenshots at 280 / 390 / 1000 / 1024px: HUD wraps cleanly, targets sized, decom icon-only, footer dropped on phone — **desktop layout unchanged**.

_Note: the cramped letter-wrap inside the terminal at narrow widths is the herdr PTY content reflowing to its column count, not app chrome — tracked separately (`evaluate-herdr-pane-zoom`)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)