### PR TITLE
fix(ui): guard terminal refit while mount hidden

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -166,8 +166,7 @@
       // reconnected (e.g. after a mobile app-switch dropped the socket): refit in
       // case the layout changed while away, then resize to repaint the attach
       () => {
-        fit.fit();
-        c.resize(term.cols, term.rows);
+        refit();
       },
       // another device took over this terminal — park and offer to take it back
       () => {
@@ -181,6 +180,18 @@
     );
     conn = c;
     term.onData((d) => c.send(d));
+
+    // Fit + push the size to the PTY — but only while the mount is actually
+    // visible. A hidden (To-Do/Issues tab → display:none) or mid-layout mount
+    // has zero width, where FitAddon clamps to its 2-col minimum; resizing the
+    // PTY to 2 cols makes Claude reflow its transcript at 2 cols and permanently
+    // poisons the scrollback with 2-char-wide wrapping. offsetParent===null
+    // catches display:none; the client-size checks catch transient collapses.
+    const refit = () => {
+      if (!el || el.offsetParent === null || el.clientWidth === 0 || el.clientHeight === 0) return;
+      fit.fit();
+      c.resize(term.cols, term.rows);
+    };
 
     // Shift+Enter → newline: xterm emits a bare CR for both Enter and
     // Shift+Enter, so Claude Code can't tell them apart and submits. Send a
@@ -266,8 +277,7 @@
 
     // refit after layout settles (mount may start hidden during mobile nav)
     requestAnimationFrame(() => {
-      fit.fit();
-      c.resize(term.cols, term.rows);
+      refit();
       // desktop: selecting a unit hands the keyboard straight to its terminal —
       // clicking a sidebar card otherwise leaves focus on the card button, so
       // typing goes nowhere. Mobile keeps tap-to-focus so the soft keyboard
@@ -276,8 +286,7 @@
     });
 
     const ro = new ResizeObserver(() => {
-      fit.fit();
-      c.resize(term.cols, term.rows);
+      refit();
     });
     ro.observe(el);
 


### PR DESCRIPTION
## Problem
Terminal scrollback renders tall and narrow — text wrapped at ~2 chars/line — on desktop and mobile.

## Root cause
Not herdr / pane sizing. Switching to the **To-Do** or **Issues** tab hides the term mount via `display:none`. The `ResizeObserver` then runs `fit.fit()` on a zero-width element, where xterm's `FitAddon` clamps to its `MINIMUM_COLS = 2`. That 2-col size is pushed to the live PTY, Claude reflows its transcript at 2 cols, and the 2-char-wide lines are baked into scrollback. Switching back widens the live view but the poisoned scrollback stays wrapped.

The rAF refit and reconnect paths shared the same unguarded `fit + resize`.

## Verification
Empirically ruled out herdr as the cause: `herdr agent attach <term> --takeover` grants the pane exactly the attaching client's cols (200→200, 60→60), shows a single full-width pane (no tiling chrome), and `ctrl+a z` zoom changes nothing. The narrowness is entirely the cols the browser computes.

## Fix
Add a `refit()` helper guarded on `offsetParent` + client size, shared by the ResizeObserver, rAF, and reconnect callbacks, so a degenerate resize never reaches the PTY.

`bun run check`, prettier, and the 41 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)