### PR TITLE
feat(ui): agent activity feed from tool-use transcript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 *.db-shm
 *.db-wal
 .DS_Store
+
+# Planning docs — not part of the shipped app
+/docs/superpowers/

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -1,0 +1,129 @@
+export interface ActivityEntry {
+  ts: number; // ms epoch (tool_use message timestamp)
+  tool: string; // raw tool name, e.g. "Edit"
+  summary: string; // "edited server.ts"
+  status: "ok" | "error" | "pending";
+}
+
+const DEFAULT_LIMIT = 30;
+const CMD_MAX = 60;
+
+function basename(p: unknown): string {
+  if (typeof p !== "string" || !p) return "?";
+  const parts = p.split("/");
+  return parts[parts.length - 1] || p;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + "…" : s;
+}
+
+function host(url: unknown): string {
+  if (typeof url !== "string") return "?";
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+/** Render a tool_use block into a compact human summary line. */
+function summarize(tool: string, input: Record<string, unknown>): string {
+  switch (tool) {
+    case "Edit":
+    case "MultiEdit":
+    case "NotebookEdit":
+      return `edited ${basename(input.file_path ?? input.notebook_path)}`;
+    case "Write":
+      return `wrote ${basename(input.file_path)}`;
+    case "Read":
+      return `read ${basename(input.file_path)}`;
+    case "Bash":
+      return `$ ${truncate(String(input.command ?? ""), CMD_MAX)}`;
+    case "Grep":
+      return `searched "${input.pattern ?? ""}"`;
+    case "Glob":
+      return `globbed ${input.pattern ?? ""}`;
+    case "Task":
+    case "Agent":
+      return `dispatched ${input.subagent_type ?? "agent"}`;
+    case "Skill":
+      return `skill ${input.skill ?? ""}`;
+    case "TodoWrite":
+      return "updated todos";
+    case "WebFetch":
+      return `fetched ${host(input.url)}`;
+    case "WebSearch":
+      return `web search "${input.query ?? ""}"`;
+    default:
+      return tool.toLowerCase();
+  }
+}
+
+interface Block {
+  type?: string;
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  tool_use_id?: string;
+  is_error?: boolean;
+}
+
+/**
+ * Parse a JSONL transcript into a chronological list of tool-use activity entries,
+ * pairing each tool_use with its tool_result for status. Returns the most-recent
+ * `limit` entries (oldest→newest). Malformed lines are skipped.
+ */
+export function parseActivity(text: string, limit = DEFAULT_LIMIT): ActivityEntry[] {
+  const records: { o: any; blocks: Block[] }[] = [];
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let o: any;
+    try {
+      o = JSON.parse(t);
+    } catch {
+      continue;
+    }
+    const blocks = o?.message?.content;
+    if (Array.isArray(blocks)) records.push({ o, blocks });
+  }
+
+  // pass 1: map tool_use_id → is_error from every tool_result block
+  const errored = new Map<string, boolean>();
+  for (const { blocks } of records) {
+    for (const b of blocks) {
+      if (b?.type === "tool_result" && typeof b.tool_use_id === "string") {
+        errored.set(b.tool_use_id, Boolean(b.is_error));
+      }
+    }
+  }
+
+  // pass 2: collect tool_use blocks in order, attaching paired status
+  const entries: ActivityEntry[] = [];
+  for (const { o, blocks } of records) {
+    const ts = Date.parse(o?.timestamp) || 0;
+    for (const b of blocks) {
+      if (b?.type !== "tool_use" || typeof b.name !== "string") continue;
+      const id = typeof b.id === "string" ? b.id : "";
+      const status: ActivityEntry["status"] = !errored.has(id)
+        ? "pending"
+        : errored.get(id)
+          ? "error"
+          : "ok";
+      entries.push({ ts, tool: b.name, summary: summarize(b.name, b.input ?? {}), status });
+    }
+  }
+
+  return limit >= 0 ? entries.slice(-limit) : entries;
+}
+
+/** Read + parse one session's JSONL. Missing/unreadable file → []. */
+export async function sessionActivity(
+  path: string,
+  limit = DEFAULT_LIMIT,
+): Promise<ActivityEntry[]> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return [];
+  return parseActivity(await file.text(), limit);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { listDirs, validateRoot, collapseHome } from "./dirs";
 import { loadSteers, saveSteers } from "./steers";
 import { listBranches } from "./branches";
 import { sessionTokens, jsonlPathFor } from "./usage";
+import { sessionActivity } from "./activity";
 import { handleUpload } from "./uploads";
 import type { UsageLimitsService } from "./usage-limits";
 import type { UpdateService } from "./update";
@@ -111,6 +112,13 @@ export function makeApp(deps: AppDeps) {
         if (req.method === "GET" && parts[2] && parts[3] === "usage") {
           const s = deps.store.get(parts[2]);
           return s ? json(await sessionUsage(s)) : json({ error: "not found" }, 404);
+        }
+        if (req.method === "GET" && parts[2] && parts[3] === "activity") {
+          const s = deps.store.get(parts[2]);
+          if (!s) return json({ error: "not found" }, 404);
+          // pre-feature session (no pinned id) → no transcript to read
+          const path = s.claudeSessionId ? jsonlPathFor(s.worktreePath, s.claudeSessionId) : "";
+          return json(path ? await sessionActivity(path) : []);
         }
         if (req.method === "GET" && parts[2] && !parts[3]) {
           const s = deps.store.get(parts[2]);

--- a/test/activity.test.ts
+++ b/test/activity.test.ts
@@ -1,0 +1,114 @@
+import { test, expect } from "bun:test";
+import { parseActivity, sessionActivity } from "../src/activity";
+
+function toolUse(name: string, input: unknown, id = "t1", ts = "2026-05-31T10:00:00.000Z"): string {
+  return JSON.stringify({
+    type: "assistant",
+    timestamp: ts,
+    message: { role: "assistant", content: [{ type: "tool_use", id, name, input }] },
+  });
+}
+
+function toolResult(
+  id: string,
+  opts: { is_error?: boolean; content?: unknown } = {},
+  ts = "2026-05-31T10:00:01.000Z",
+): string {
+  return JSON.stringify({
+    type: "user",
+    timestamp: ts,
+    message: {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: id,
+          is_error: opts.is_error,
+          content: opts.content ?? "",
+        },
+      ],
+    },
+  });
+}
+
+test("Edit summarizes as edited <basename>", () => {
+  const e = parseActivity(toolUse("Edit", { file_path: "/a/b/server.ts" }));
+  expect(e).toHaveLength(1);
+  expect(e[0]).toMatchObject({ tool: "Edit", summary: "edited server.ts" });
+});
+
+test("ts is parsed from the tool_use line timestamp", () => {
+  const e = parseActivity(
+    toolUse("Read", { file_path: "/a/z.ts" }, "i", "2026-05-31T10:00:00.000Z"),
+  );
+  expect(e[0]!.ts).toBe(Date.parse("2026-05-31T10:00:00.000Z"));
+});
+
+test("status: ok when a non-error result follows, error on is_error, pending when none", () => {
+  const lines = [
+    toolUse("Read", { file_path: "/x/a.ts" }, "r1"),
+    toolResult("r1", { is_error: false }),
+    toolUse("Bash", { command: "bun test" }, "b1"),
+    toolResult("b1", { is_error: true }),
+    toolUse("Read", { file_path: "/x/c.ts" }, "r2"),
+  ].join("\n");
+  const e = parseActivity(lines);
+  expect(e.map((x) => x.status)).toEqual(["ok", "error", "pending"]);
+});
+
+test("returns the most recent `limit` entries in chronological order", () => {
+  const lines = Array.from({ length: 5 }, (_, i) =>
+    toolUse("Read", { file_path: `/x/f${i}.ts` }, `id${i}`, `2026-05-31T10:0${i}:00.000Z`),
+  ).join("\n");
+  const e = parseActivity(lines, 3);
+  expect(e.map((x) => x.summary)).toEqual(["read f2.ts", "read f3.ts", "read f4.ts"]);
+});
+
+test("Bash summary is $ <command>, truncated past ~60 chars", () => {
+  expect(parseActivity(toolUse("Bash", { command: "bun test" }))[0]!.summary).toBe("$ bun test");
+  const s = parseActivity(toolUse("Bash", { command: "x".repeat(80) }))[0]!.summary;
+  expect(s.startsWith("$ ")).toBe(true);
+  expect(s.endsWith("…")).toBe(true);
+  expect(s.length).toBeLessThanOrEqual(2 + 61);
+});
+
+test("summaries per tool family", () => {
+  const cases: [string, unknown, string][] = [
+    ["Write", { file_path: "/a/notes.md" }, "wrote notes.md"],
+    ["MultiEdit", { file_path: "/a/x.ts" }, "edited x.ts"],
+    ["NotebookEdit", { notebook_path: "/a/n.ipynb" }, "edited n.ipynb"],
+    ["Read", { file_path: "/a/y.ts" }, "read y.ts"],
+    ["Grep", { pattern: "foo" }, 'searched "foo"'],
+    ["Glob", { pattern: "**/*.ts" }, "globbed **/*.ts"],
+    ["Task", { subagent_type: "Explore" }, "dispatched Explore"],
+    ["Task", {}, "dispatched agent"],
+    ["Skill", { skill: "superpowers:brainstorming" }, "skill superpowers:brainstorming"],
+    ["TodoWrite", { todos: [] }, "updated todos"],
+    ["WebFetch", { url: "https://example.com/p" }, "fetched example.com"],
+    ["WebSearch", { query: "svelte 5" }, 'web search "svelte 5"'],
+    ["FancyNewTool", {}, "fancynewtool"],
+  ];
+  for (const [name, input, expected] of cases) {
+    expect(parseActivity(toolUse(name, input))[0]!.summary).toBe(expected);
+  }
+});
+
+test("ignores assistant messages without tool_use", () => {
+  const textMsg = JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-05-31T10:00:00.000Z",
+    message: { content: [{ type: "text", text: "hi" }] },
+  });
+  expect(parseActivity(textMsg)).toEqual([]);
+});
+
+test("skips malformed lines and blanks", () => {
+  const lines = ["", "not json", toolUse("Read", { file_path: "/a/z.ts" }), "  "].join("\n");
+  const e = parseActivity(lines);
+  expect(e).toHaveLength(1);
+  expect(e[0]!.summary).toBe("read z.ts");
+});
+
+test("sessionActivity returns [] for a missing file", async () => {
+  expect(await sessionActivity("/nonexistent/definitely-not-here.jsonl")).toEqual([]);
+});

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -75,6 +75,21 @@ test("GET /api/sessions/:id/usage returns zeroed usage for a session w/o JSONL",
   expect(u.messageCount).toBe(0);
 });
 
+test("GET /api/sessions/:id/activity returns [] for a session w/o JSONL", async () => {
+  const app = harness();
+  const created = await (
+    await postSessions(app, { repoPath: validRepo, baseBranch: "main", prompt: "go" })
+  ).json();
+  const res = await app.fetch(new Request(`http://x/api/sessions/${created.id}/activity`));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual([]);
+});
+
+test("GET /api/sessions/:id/activity 404s for unknown id", async () => {
+  const res = await harness().fetch(new Request("http://x/api/sessions/nope/activity"));
+  expect(res.status).toBe(404);
+});
+
 test("GET /api/sessions/:id/usage 404s for unknown id", async () => {
   const res = await harness().fetch(new Request("http://x/api/sessions/nope/usage"));
   expect(res.status).toBe(404);

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -119,6 +119,8 @@
   "viewport_terminal_tab": "Terminal",
   "viewport_todo_tab": "To-Do",
   "viewport_issues_tab": "Issues",
+  "viewport_activity_tab": "Aktivität",
+  "activity_empty": "Noch keine Aktivität.",
   "viewport_decommission_title": "Agent stoppen + Worktree entfernen",
   "viewport_confirm_decommission": "bestätigen ✕",
   "viewport_decommission": "✕ stilllegen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -119,6 +119,8 @@
   "viewport_terminal_tab": "Terminal",
   "viewport_todo_tab": "To-Do",
   "viewport_issues_tab": "Issues",
+  "viewport_activity_tab": "Activity",
+  "activity_empty": "No activity yet.",
   "viewport_decommission_title": "stop agent + remove worktree",
   "viewport_confirm_decommission": "confirm ✕",
   "viewport_decommission": "✕ decommission",

--- a/ui/src/lib/activity.test.ts
+++ b/ui/src/lib/activity.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { glyph, clock } from "./activity";
+
+describe("glyph", () => {
+  it("maps edit-family tools to ✎", () => {
+    for (const t of ["Edit", "MultiEdit", "NotebookEdit", "Write"]) {
+      expect(glyph(t)).toBe("✎");
+    }
+  });
+  it("maps read/bash/search/todo/dispatch/web to their glyphs", () => {
+    expect(glyph("Read")).toBe("⤷");
+    expect(glyph("Bash")).toBe("$");
+    expect(glyph("Grep")).toBe("⌕");
+    expect(glyph("Glob")).toBe("⌕");
+    expect(glyph("TodoWrite")).toBe("⊞");
+    expect(glyph("Task")).toBe("◆");
+    expect(glyph("Skill")).toBe("◆");
+    expect(glyph("WebFetch")).toBe("⇲");
+  });
+  it("falls back to · for unknown tools", () => {
+    expect(glyph("FancyNewTool")).toBe("·");
+  });
+});
+
+describe("clock", () => {
+  it("formats a ms-epoch as local HH:MM", () => {
+    const ts = new Date("2026-05-31T14:32:00").getTime();
+    expect(clock(ts)).toBe("14:32");
+  });
+});

--- a/ui/src/lib/activity.ts
+++ b/ui/src/lib/activity.ts
@@ -1,0 +1,33 @@
+/** Glyph for an activity entry's tool, grouped by action kind. */
+export function glyph(tool: string): string {
+  switch (tool) {
+    case "Edit":
+    case "MultiEdit":
+    case "NotebookEdit":
+    case "Write":
+      return "✎";
+    case "Read":
+      return "⤷";
+    case "Bash":
+      return "$";
+    case "Grep":
+    case "Glob":
+      return "⌕";
+    case "TodoWrite":
+      return "⊞";
+    case "Task":
+    case "Agent":
+    case "Skill":
+      return "◆";
+    case "WebFetch":
+    case "WebSearch":
+      return "⇲";
+    default:
+      return "·";
+  }
+}
+
+/** ms-epoch → local HH:MM. */
+export function clock(ts: number): string {
+  return new Date(ts).toTimeString().slice(0, 5);
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -3,6 +3,7 @@ import type {
   CreateInput,
   RepoEntry,
   Issue,
+  ActivityEntry,
   SessionUsage,
   UsageLimits,
   GitState,
@@ -107,6 +108,12 @@ export async function putTodo(repoPath: string, content: string): Promise<void> 
 export async function getSessionUsage(id: string): Promise<SessionUsage> {
   const r = await fetch(`/api/sessions/${id}/usage`);
   if (!r.ok) throw new Error(`usage failed: ${r.status}`);
+  return r.json();
+}
+
+export async function getActivity(id: string): Promise<ActivityEntry[]> {
+  const r = await fetch(`/api/sessions/${id}/activity`);
+  if (!r.ok) throw new Error(`activity failed: ${r.status}`);
   return r.json();
 }
 

--- a/ui/src/lib/components/ActivityFeed.svelte
+++ b/ui/src/lib/components/ActivityFeed.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { getActivity } from "$lib/api";
+  import { glyph, clock } from "$lib/activity";
+  import type { ActivityEntry } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  let { sessionId }: { sessionId: string } = $props();
+
+  let entries = $state<ActivityEntry[]>([]);
+  let loaded = $state(false);
+
+  // poll the JSONL-derived activity on select + every 5s; mirrors Viewport's usage effect.
+  // this panel mounts only while its tab is active, so polling runs only when viewed.
+  $effect(() => {
+    const id = sessionId;
+    entries = [];
+    loaded = false;
+    let alive = true;
+    const load = () =>
+      getActivity(id)
+        .then((e) => {
+          if (!alive) return;
+          entries = e;
+          loaded = true;
+        })
+        .catch(() => {});
+    load();
+    const t = setInterval(load, 5000);
+    return () => {
+      alive = false;
+      clearInterval(t);
+    };
+  });
+
+  // newest-first for display (server returns oldest→newest)
+  const rows = $derived([...entries].reverse());
+</script>
+
+<div class="feed">
+  {#if rows.length}
+    <ul>
+      {#each rows as e (e.ts + e.tool + e.summary)}
+        <li class:error={e.status === "error"} class:pending={e.status === "pending"}>
+          <span class="time">{clock(e.ts)}</span>
+          <span class="glyph" aria-hidden="true">{glyph(e.tool)}</span>
+          <span class="summary">{e.summary}</span>
+        </li>
+      {/each}
+    </ul>
+  {:else}
+    <p class="empty">{loaded ? m.activity_empty() : m.common_loading()}</p>
+  {/if}
+</div>
+
+<style>
+  .feed {
+    height: 100%;
+    overflow-y: auto;
+    padding: 8px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+  }
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  li {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 2px 0;
+    color: var(--color-ink);
+    white-space: nowrap;
+  }
+  .time {
+    color: var(--color-faint);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+  .glyph {
+    color: var(--color-muted);
+    width: 1em;
+    text-align: center;
+    flex-shrink: 0;
+  }
+  .summary {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  li.error .summary {
+    color: var(--color-red);
+  }
+  li.error .glyph {
+    color: var(--color-red);
+  }
+  li.pending {
+    color: var(--color-muted);
+  }
+  .empty {
+    color: var(--color-muted);
+    margin: 0;
+    padding: 4px 0;
+  }
+</style>

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -10,6 +10,7 @@
   import { imageFilesFromItems } from "$lib/clipboard";
   import TodoPanel from "$lib/components/TodoPanel.svelte";
   import IssuesPanel from "$lib/components/IssuesPanel.svelte";
+  import ActivityFeed from "$lib/components/ActivityFeed.svelte";
   import ControlBar from "$lib/components/ControlBar.svelte";
   import GitRail from "$lib/components/GitRail.svelte";
   import SteerBar from "$lib/components/SteerBar.svelte";
@@ -36,7 +37,7 @@
   } = $props();
 
   let el: HTMLDivElement | undefined = $state();
-  let tab = $state<"term" | "todo" | "issues">("term");
+  let tab = $state<"term" | "todo" | "issues" | "activity">("term");
   let conn = $state<PtyConn | undefined>();
   // true when another device took over this terminal — show a take-over prompt
   let parked = $state(false);
@@ -355,6 +356,9 @@
       <button class="tab-btn" class:active={tab === "issues"} onclick={() => (tab = "issues")}
         >{m.viewport_issues_tab()}</button
       >
+      <button class="tab-btn" class:active={tab === "activity"} onclick={() => (tab = "activity")}
+        >{m.viewport_activity_tab()}</button
+      >
     </div>
     {#if !compact}
       <span class="sep">·</span>
@@ -433,6 +437,11 @@
           repoPath={session.repoPath}
           onnewtask={(p) => onnewtask?.(session.repoPath, p)}
         />
+      </div>
+    {/if}
+    {#if tab === "activity"}
+      <div class="panel-wrap">
+        <ActivityFeed sessionId={session.id} />
       </div>
     {/if}
   </div>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -99,6 +99,13 @@ export interface SessionUsage {
   byModel: Record<string, number>;
 }
 
+export interface ActivityEntry {
+  ts: number;
+  tool: string;
+  summary: string;
+  status: "ok" | "error" | "pending";
+}
+
 export interface LimitWindow {
   pct: number;
   resetAt: number;


### PR DESCRIPTION
Renders a compact, human-readable activity log per agent from data already on disk — the Claude Code JSONL transcript (same source `usage.ts` reads). Closes the "Agent activity feed" roadmap item.

## What
- **`src/activity.ts`** — `parseActivity()` walks the transcript, pairs each `tool_use` with its `tool_result` for status (ok/error/pending), and summarizes into compact lines (`edited server.ts`, `$ bun test`, `read usage.ts`, …). Returns the most-recent N (default 30).
- **`GET /api/sessions/:id/activity`** — sibling of `/usage`; pre-feature sessions → `[]`, unknown id → 404.
- **`ActivityFeed.svelte`** + new **Activity tab** in `Viewport` — polls every 5s, mounted only while the tab is active. Newest-first, error rows tinted.

Read-only, ToS-clean, **no changes to how agents spawn**.

## Out of scope (v1)
Test-failure counts beyond the `is_error` flag; SSE push; per-tile feed lines; incremental tail-read (re-reads whole file per poll, exactly like `usage.ts`).

## Tests / gates
- Root `test/activity.test.ts` (parser: ordering, pairing, status, summaries, limit, malformed skip, missing file) + `/activity` endpoint tests.
- UI `activity.test.ts` (glyph map + clock).
- All green: root **267 pass**, `tsc` clean, lint clean; UI **svelte-check 0 errors**, **vitest 43 pass**.

Design spec: `docs/superpowers/specs/2026-05-31-activity-feed-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)