### PR TITLE
fix(pty): reopen finished-but-alive sessions instead of "session ended"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ const server = serve(
     events,
     usageLimits,
     updates,
+    herdr,
     resolveForge: (dir) => detectForge(dir, config.forges),
   },
   config.port,

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import { handleUpload } from "./uploads";
 import type { UsageLimitsService } from "./usage-limits";
 import type { UpdateService } from "./update";
 import type { Session } from "./types";
+import type { HerdrDriver } from "./herdr";
 import type { GitForge, MergeMethod } from "./forge/types";
 import { join, normalize } from "node:path";
 import type { ServerWebSocket } from "bun";
@@ -56,6 +57,8 @@ export interface AppDeps {
   resolveForge?: (repoDir: string) => GitForge | null;
   /** Self-update tracker; absent in environments where it isn't wired. */
   updates?: Pick<UpdateService, "current" | "apply">;
+  /** Herdr driver (for liveness checks). Absent in some tests; gate fails open. */
+  herdr?: Pick<HerdrDriver, "list">;
 }
 
 const sessionUsage = (s: Session) =>
@@ -408,12 +411,24 @@ export function serve(deps: AppDeps, port: number) {
           );
           (ws.data as any).unsub = unsub;
         } else {
-          // session ended (claude quit / ctrl-c → herdr agent reaped): don't
-          // attach a dead terminal. Attaching would make herdr reply
-          // agent_not_found and the client would reconnect-loop on it. Tell the
-          // client it's gone so it stops and shows an ended state.
+          // Don't attach a terminal whose herdr agent is gone: attaching would make
+          // herdr reply agent_not_found and the client would reconnect-loop on it.
+          // A "done" status only means the agent finished its turn (idle at the
+          // prompt) — its herdr pane may still be alive and attachable. So gate on
+          // herdr LIVENESS, not on status: block only when the session is missing,
+          // archived, or its herdr agent is no longer listed by `herdr agent list`.
           const cur = deps.store.get(ws.data.id);
-          if (!cur || cur.status === "done" || cur.status === "archived") {
+          if (!cur || cur.status === "archived") {
+            ws.close(PTY_GONE_CODE, "ended");
+            return;
+          }
+          let agentLive: boolean;
+          try {
+            agentLive = deps.herdr?.list().some((a) => a.terminalId === cur.herdrAgentId) ?? true;
+          } catch {
+            agentLive = true; // a herdr CLI hiccup shouldn't strand a live session
+          }
+          if (!agentLive) {
             ws.close(PTY_GONE_CODE, "ended");
             return;
           }

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -218,7 +218,35 @@ test("WS /pty/:id with evil Origin → 403", async () => {
 
 // ── PTY: terminated session must not attach (would loop on agent_not_found) ────
 
-test("WS /pty/:id for a terminated (done) session closes with PTY_GONE_CODE", async () => {
+// Build a herdr stub whose live list contains exactly the given terminal ids.
+function herdrWith(...liveTerminalIds: string[]): AppDeps["herdr"] {
+  return {
+    list: () =>
+      liveTerminalIds.map((terminalId) => ({
+        agent: "claude",
+        agentStatus: "done",
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        terminalId,
+        workspaceId: "w",
+      })),
+  };
+}
+
+// Wait for a gone/archived session's pty WS to be rejected, resolving the close
+// code. Only listens for onclose (the server closes immediately) — never onopen,
+// which under a loaded full-suite run can race ahead of the server's close frame.
+function expectPtyClose(port: number | undefined, id: string): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const ws = new WebSocket(`ws://localhost:${port}/pty/${id}`);
+    ws.onclose = (e) => resolve(e.code);
+    ws.onerror = () => {};
+    setTimeout(() => reject(new Error("timed out waiting for close")), 3000);
+  });
+}
+
+test("WS /pty/:id for a done session whose herdr agent is GONE closes with PTY_GONE_CODE", async () => {
   const deps = makeDeps();
   const session = deps.store.create({
     name: "test",
@@ -231,18 +259,80 @@ test("WS /pty/:id for a terminated (done) session closes with PTY_GONE_CODE", as
     herdrSession: "default",
     herdrAgentId: "term_dead",
   });
-  // claude exited / ctrl-c → the poller (or reconcile) has marked it done
+  // claude exited / ctrl-c: the poller (or reconcile) has marked it done AND the
+  // herdr agent has been reaped (absent from the live list).
   deps.store.update(session.id, { status: "done", lastState: "done" });
 
-  const server = serve(deps, 0);
+  const server = serve({ ...deps, herdr: herdrWith() }, 0);
   try {
-    const code = await new Promise<number>((resolve, reject) => {
+    expect(await expectPtyClose(server.port, session.id)).toBe(PTY_GONE_CODE);
+  } finally {
+    server.stop();
+  }
+});
+
+test("WS /pty/:id for an archived session closes with PTY_GONE_CODE even if its agent is live", async () => {
+  const deps = makeDeps();
+  const session = deps.store.create({
+    name: "test",
+    prompt: "go",
+    repoPath: "/wt",
+    baseBranch: "main",
+    branch: null,
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_archived",
+  });
+  deps.store.update(session.id, { status: "archived", lastState: "done" });
+
+  const server = serve({ ...deps, herdr: herdrWith("term_archived") }, 0);
+  try {
+    expect(await expectPtyClose(server.port, session.id)).toBe(PTY_GONE_CODE);
+  } finally {
+    server.stop();
+  }
+});
+
+test("WS /pty/:id for a done session whose herdr agent is STILL ALIVE is allowed to attach", async () => {
+  const deps = makeDeps();
+  const session = deps.store.create({
+    name: "test",
+    prompt: "go",
+    repoPath: "/wt",
+    baseBranch: "main",
+    branch: null,
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_alive",
+  });
+  // 'done' means the agent finished its turn and is idle at the prompt, but the
+  // herdr pane is still alive (listed by `herdr agent list`). It must attach.
+  deps.store.update(session.id, { status: "done", lastState: "done" });
+
+  const server = serve({ ...deps, herdr: herdrWith("term_alive") }, 0);
+  try {
+    // A live-but-done session must NOT be closed with PTY_GONE_CODE. The attach
+    // is allowed (socket opens); resolve with the close code only if the server
+    // rejects it, else "open".
+    const outcome = await new Promise<number | "open">((resolve, reject) => {
       const ws = new WebSocket(`ws://localhost:${server.port}/pty/${session.id}`);
-      ws.onclose = (e) => resolve(e.code);
+      let settled = false;
+      const done = (v: number | "open") => {
+        if (settled) return;
+        settled = true;
+        resolve(v);
+      };
+      ws.onopen = () => {
+        ws.close();
+        done("open");
+      };
+      ws.onclose = (e) => done(e.code);
       ws.onerror = () => {};
-      setTimeout(() => reject(new Error("timed out waiting for close")), 3000);
+      setTimeout(() => reject(new Error("timed out waiting for open/close")), 3000);
     });
-    expect(code).toBe(PTY_GONE_CODE);
+    expect(outcome).not.toBe(PTY_GONE_CODE);
   } finally {
     server.stop();
   }


### PR DESCRIPTION
## Problem

UNIT-44 (and any session) showed **"── session ended ──"** and refused to open, even though its herdr pane was alive and idling at the prompt.

Root cause: herdr reports `agent_status: "done"` when an agent **finishes its turn and idles** — the pane is still alive and attachable. shepherd's `mapState()` maps herdr `"done"` → session status `"done"`, and the PTY attach gate (`server.ts`) refused to attach **any** `"done"` session (close `PTY_GONE_CODE` 4001) → UI prints "session ended". So a finished-but-alive session became permanently un-openable.

This is distinct from the legit reaped-agent case handled in #30 — there the agent **disappears from `herdr agent list`** entirely.

## Fix

Gate PTY attach on **herdr liveness**, not on `status === "done"`: block only when the session is missing, archived, or its `herdrAgentId` is absent from `herdr agent list`. Fails open on a herdr CLI hiccup so a transient error can't strand a live session.

- `src/server.ts` — liveness-based gate + optional `AppDeps.herdr`
- `src/index.ts` — wire the existing herdr instance through
- `test/server.test.ts` — TDD: new "done + agent-live → attach allowed" test (red→green); gone/archived cases preserved

`mapState`/poller/UI untouched — the "done" badge is preserved; only the openable/ended decision is decoupled.

## Validation

- `bunx tsc --noEmit`: clean
- `bun run lint`: clean
- `bun test ./test`: 273 pass / 0 fail
- `cd ui && bun run test`: 41 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)