### PR TITLE
docs: roadmap update + ignore agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 
 # Planning docs — not part of the shipped app
 /docs/superpowers/
+
+# Transient agent worktrees (Claude Code isolation checkouts)
+/.claude/worktrees/

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,9 @@ node_modules
 build
 dist
 
+# Transient agent worktrees (nested checkouts; not project source)
+.claude/worktrees
+
 # Agent-generated planning artifacts — leave their formatting alone
 docs/superpowers
 

--- a/TODO.md
+++ b/TODO.md
@@ -15,13 +15,13 @@
 - [x] Blocked-triage queue — list of red agents + WHY each is blocked (tailed from terminal:
       permission prompt / question / test fail), batch-answer w/ quick replies. Server heuristic
       classifier + poller emit `session:block` + POST `/reply` (types into PTY) + "Needs you" drawer.
+- [x] Agent activity feed — render existing PreToolUse/PostToolUse hook data as compact
+      human log per agent ("edited server.ts · ran tests (2 failed) · waiting").
 - [ ] Push notifications — Web Push from PWA on blocked(needs-you)/done; reuses F3 hook
       telemetry + herdr status. Highest leverage; serves core thesis. Pairs w/ triage queue. **NEXT.**
-- [ ] Agent activity feed — render existing PreToolUse/PostToolUse hook data as compact
-      human log per agent ("edited server.ts · ran tests (2 failed) · waiting").
 - [ ] Inline diff review — per-worktree `git diff` panel in HUD; review before merge,
       ToS-clean (read-only git). Precursor to F6 merge buttons.
-- [ ] Saved steers / broadcast — canned prompts ("commit & push", "rebase", "run tests")
+- [x] Saved steers / broadcast — canned prompts ("commit & push", "rebase", "run tests")
       as one-tap buttons; optional fan-out to N selected agents. Mobile-critical.
 
 ## PRD open questions still unresolved
@@ -30,6 +30,9 @@
 
 ## Done
 
+- [x] In-app self-update — version badge + commit list + one-tap pull→build→restart when behind origin/main
+- [x] Internationalization — Paraglide i18n (EN + DE catalogs) with in-app language switcher
+- [x] PR status in session list — per-session PR/CI badge in the row + grid views (PrPoller snapshot)
 - [x] Headless core: spawn interactive claude in worktrees via herdr, REST + WS (/events, /pty)
 - [x] HUD UI: SvelteKit5 + Tailwind4 + xterm.js, status lights, live scrollable terminal
 - [x] Repo + branch pickers (autocomplete, ~/Work compaction, most-recently-used default)


### PR DESCRIPTION
## What

- **TODO.md** — bring the roadmap current: mark *Agent activity feed* (#37) and *Saved steers / broadcast* (#31) done, fix orphaned continuation lines from an earlier manual edit, and add the newly-shipped infra items to Done: in-app self-update (#27), internationalization (#34), PR status in session list (#38).
- **.gitignore / .prettierignore** — exclude `.claude/worktrees/` (transient Claude Code agent checkouts nested in the repo). They were untracked but unignored, so `prettier --check .` from the main worktree tripped on planning-doc copies inside them and blocked the pre-push gate.

## Why a PR

TODO.md was sitting as an uncommitted working-tree edit on main. Routed through a PR per the usual PR-first workflow rather than committing to main directly.

## Checks
Full pre-push gate passed locally (prettier, eslint, root tsc, ui svelte-check, root + ui tests, ui build).