### PR TITLE
fix(ui): hide Mission Control label on touch HUDs

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -14,6 +14,7 @@
     nowMs,
     connected = false,
     mobile = false,
+    touch = false,
     limits = null,
     onsettings,
     needsYou = 0,
@@ -25,6 +26,7 @@
     nowMs: number;
     connected?: boolean;
     mobile?: boolean;
+    touch?: boolean;
     limits?: UsageLimits | null;
     onsettings?: () => void;
     needsYou?: number;
@@ -59,7 +61,9 @@
 
 <div class="hud bracket" class:mobile>
   <div class="logo">SHEP<b>HERD</b></div>
-  {#if !mobile}
+  {#if !mobile && !touch}
+    <!-- hidden on phones AND unfolded foldables: the label crowds the bar and
+         pushes the gear out on touch layouts narrower than a real desktop -->
     <div class="sep"></div>
     <div class="micro">Mission&nbsp;Control</div>
   {/if}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -110,6 +110,7 @@
     {nowMs}
     connected={store.connected}
     mobile={mobile.current}
+    touch={touch.current}
     limits={store.usageLimits}
     onsettings={() => (showSettings = true)}
     needsYou={blockedEntries.length}


### PR DESCRIPTION
## What
Hide the "Mission Control" label in the top bar on phones **and** unfolded foldables.

## Why
The label only ever fit on a real desktop. On unfolded foldables (>768px but `pointer: coarse`) it crowded the bar and pushed the gear button out.

## How
Gate the label on `!mobile && !touch` instead of just `!mobile`. `touch` is the existing `pointer: coarse` MediaQuery (same `compact` signal used in `Viewport.svelte`), passed through to `TopBar`. True desktops (`pointer: fine`) still show it.

`bun run check` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)