### PR TITLE
feat(ui): show full task name in compact session detail header

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -327,6 +327,9 @@
       >
     {/if}
     <span class="desig">{session.desig}</span>
+    {#if compact}
+      <span class="vp-name" title={session.name}>{session.name}</span>
+    {/if}
     {#if !compact}
       <span class="sep">·</span>
       <span class="branch">{session.branch ?? session.worktreePath}</span>
@@ -526,6 +529,19 @@
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
+    flex-shrink: 0;
+  }
+
+  /* full task name — surfaced in compact headers where the session list is
+     hidden, so the desig number alone can't identify the session */
+  .vp-name {
+    color: var(--color-ink);
+    font-size: 12px;
+    min-width: 4ch;
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .branch {
@@ -719,6 +735,11 @@
     flex-wrap: wrap;
     row-gap: 6px;
     padding: 8px 10px;
+  }
+  /* let the task name claim the free space instead of splitting it with the
+     spacer; its flex-grow still pushes the status badge + decom to the right */
+  .vp-head.mobile .spacer {
+    display: none;
   }
   .tab-group.mobile {
     order: 10;


### PR DESCRIPTION
## Problem

On mobile the session list is hidden, so the detail view is the only thing on screen — but its header showed only the desig number (e.g. `TASK-07`), never `session.name`. Hard to tell which session you're in without reading terminal output.

## Change

`ui/src/lib/components/Viewport.svelte`:
- Render `session.name` next to the desig on **compact** (mobile/touch) headers, with `title` for the full string and inline ellipsis truncation.
- `.vp-name` flex-grows to claim free space; `.desig` no longer shrinks.
- Hide `.spacer` in `.vp-head.mobile` so the name takes the full free row instead of splitting it — its flex-grow still pushes the status badge + decom button to the right.

Desktop is untouched (the session list is visible there, so the name stays redundant-free).

Mobile header now reads: `[back] TASK-07  Add feature X…  [running] [✕]`, with the tab row wrapping below as before.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)