### PR TITLE
fix(ui): theme-aware terminal output in triage drawer

### DIFF
--- a/ui/src/lib/components/TriageDrawer.svelte
+++ b/ui/src/lib/components/TriageDrawer.svelte
@@ -171,7 +171,8 @@
   .tail {
     margin: 0;
     padding: 8px;
-    background: #0c100f;
+    background: var(--color-inset);
+    color: var(--color-term-fg);
     border: 1px solid var(--color-line);
     font-size: 11.5px;
     line-height: 1.4;
@@ -207,7 +208,7 @@
   input {
     flex: 1;
     min-width: 120px;
-    background: #0c100f;
+    background: var(--color-inset);
     border: 1px solid var(--color-line-bright);
     color: var(--color-ink-bright);
     padding: 6px 8px;


### PR DESCRIPTION
## Problem

The "Needs You" pane (`TriageDrawer`) terminal output box was invisible in light mode — dark text on a hardcoded near-black background.

## Cause

Two hardcoded `#0c100f` backgrounds that never adapt to theme. The output box (`.tail`) also had no explicit text color, so it inherited the drawer's dark `--ink` → dark-on-dark.

## Fix

Swapped both to theme tokens: `--color-inset` surface + `--color-term-fg` for the output box, `--color-inset` for the reply input. These flip correctly between dark/light.

## Scope

Not all terminal output — the real xterm terminals (`Viewport`, `UnitTile`) already theme correctly via `xtermTheme()`. Only the triage drawer had hardcoded colors.

`bun run check` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)