### PR TITLE
feat(ui): drag-to-reorder saved steers in settings

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
+        "svelte-dnd-action": "^0.9.69",
       },
       "devDependencies": {
         "@inlang/paraglide-js": "^2.18.1",
@@ -302,6 +303,8 @@
     "svelte": ["svelte@5.56.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.9", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-kTXr26t1bchFp28ROrb957LtbujpBmBDibmqMGziVpUs7awBi96TGgX6SovrA8BNoEUDVRK2Fb9FkeYlGspoVg=="],
 
     "svelte-check": ["svelte-check@4.4.8", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w=="],
+
+    "svelte-dnd-action": ["svelte-dnd-action@0.9.69", "", { "peerDependencies": { "svelte": ">=3.23.0 || ^5.0.0-next.0" } }, "sha512-NAmSOH7htJoYraTQvr+q5whlIuVoq88vEuHr4NcFgscDRUxfWPPxgie2OoxepBCQCikrXZV4pqV86aun60wVyw=="],
 
     "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -147,6 +147,7 @@
   "steerseditor_label_placeholder": "Bezeichnung",
   "steerseditor_text_placeholder": "Prompt-Text",
   "steerseditor_delete_aria": "Steer löschen",
+  "steerseditor_reorder_aria": "Steer verschieben",
   "steerseditor_empty": "noch keine Steers",
   "steerseditor_add": "+ Hinzufügen",
   "steerseditor_saving": "Speichert…",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -147,6 +147,7 @@
   "steerseditor_label_placeholder": "label",
   "steerseditor_text_placeholder": "prompt text",
   "steerseditor_delete_aria": "delete steer",
+  "steerseditor_reorder_aria": "reorder steer",
   "steerseditor_empty": "no steers yet",
   "steerseditor_add": "+ Add",
   "steerseditor_saving": "Saving…",

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
-    "@xterm/xterm": "^6.0.0"
+    "@xterm/xterm": "^6.0.0",
+    "svelte-dnd-action": "^0.9.69"
   }
 }

--- a/ui/src/lib/components/SteersEditor.svelte
+++ b/ui/src/lib/components/SteersEditor.svelte
@@ -1,13 +1,23 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { flip } from "svelte/animate";
+  import { dragHandleZone, dragHandle } from "svelte-dnd-action";
+  import type { DndEvent } from "svelte-dnd-action";
   import { steers } from "$lib/steers.svelte";
   import type { Steer } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+
+  const flipDurationMs = 150;
 
   let draft = $state<Steer[]>([]);
   let saving = $state(false);
   let error = $state<string | null>(null);
   let saved = $state(false);
+
+  function reorder(e: CustomEvent<DndEvent<Steer>>) {
+    draft = e.detail.items;
+    saved = false;
+  }
 
   function syncFromStore() {
     draft = steers.list.map((s) => ({ ...s }));
@@ -49,9 +59,20 @@
 
 <div class="editor">
   <span class="micro">{m.steerseditor_title()}</span>
-  <div class="rows">
+  <div
+    class="rows"
+    use:dragHandleZone={{ items: draft, flipDurationMs }}
+    onconsider={reorder}
+    onfinalize={reorder}
+  >
     {#each draft as s (s.id)}
-      <div class="srow">
+      <div class="srow" animate:flip={{ duration: flipDurationMs }}>
+        <span
+          class="grip"
+          use:dragHandle
+          aria-label={m.steerseditor_reorder_aria()}
+          title={m.steerseditor_reorder_aria()}>⠿</span
+        >
         <input
           class="label"
           bind:value={s.label}
@@ -113,6 +134,22 @@
     display: flex;
     gap: 4px;
     align-items: center;
+  }
+  .grip {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    align-self: stretch;
+    padding: 0 6px;
+    color: var(--color-muted);
+    cursor: grab;
+    user-select: none;
+    touch-action: none;
+    line-height: 1;
+  }
+  .grip:active {
+    cursor: grabbing;
   }
   .srow input {
     background: var(--color-inset);
@@ -182,6 +219,9 @@
     .save,
     .del {
       min-height: 40px;
+    }
+    .grip {
+      min-width: 40px;
     }
   }
 </style>


### PR DESCRIPTION
## What

Adds drag-to-reorder for saved steers in the Settings editor. Steer chip order in `SteerBar` is array position, so reordering in the editor directly controls chip order.

## How

- `SteersEditor.svelte`: `.rows` is now a `dragHandleZone` (svelte-dnd-action); `onconsider`/`onfinalize` reassign `draft` and mark the editor dirty.
- Each row gets a leading subtle `⠿` drag handle (`use:dragHandle`) so the label/text **inputs stay editable** — only the handle initiates a drag. `animate:flip` gives smooth reflow.
- Touch + keyboard accessibility come from the library; handle gets `min-width: 40px` on touch HUDs.
- New paraglide message `steerseditor_reorder_aria` (en + de).
- Added dep `svelte-dnd-action@0.9.69`.

No server/store/API/type changes — order is positional and persisted verbatim by the existing **Save steers** path (manual save, unchanged).

## Verify

- `cd ui && bun run check` → 0 errors, 0 warnings
- `cd ui && bun run test` → 53 passed
- Manual: drag a `⠿` handle → reflow + dirty state → Save → reload → order persists; inputs remain editable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)