### PR TITLE
fix(ui): keep decommission button inline with long task names

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -537,8 +537,12 @@
   .vp-name {
     color: var(--color-ink);
     font-size: 12px;
-    min-width: 4ch;
-    flex: 1 1 auto;
+    /* flex-basis 0 (not auto) so the name's content width doesn't drive the
+       wrap calc on mobile — otherwise a long name reserves the whole row and
+       pushes the decommission button onto the next line. It absorbs the slack
+       and ellipsizes instead. */
+    min-width: 0;
+    flex: 1 1 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
## Problem

On mobile/smartphone widths, a long task name pushed the decommission `✕` button onto its own line in the session header.

## Cause

`.vp-name` used `flex: 1 1 auto`, so its flex base size equalled its full content width. Flexbox uses base size for line-break decisions (shrink only redistributes *within* an already-formed line), so a long name reserved the whole row and forced the trailing `✕` to wrap. Confirmed in the report screenshot — everything else fit on row 1; only the X wrapped.

## Fix

`flex: 1 1 0` + `min-width: 0` on `.vp-name`. The name no longer reserves its content width during the wrap calc; it absorbs the slack and ellipsizes, leaving room for the decommission button on the same row.

## Verification

- `cd ui && bun run check` → 0 errors, 0 warnings
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)