### PR TITLE
feat(icons): per-project emoji icon picker (F12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,9 @@ dist/
 *.db-wal
 .DS_Store
 
-# Planning docs — not part of the shipped app
+# Planning docs / brainstorm artifacts — not part of the shipped app
 /docs/superpowers/
+.superpowers/
 
 # Transient agent worktrees (Claude Code isolation checkouts)
 /.claude/worktrees/

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## Backlog (from PRD)
 
-- [ ] Per-project icon picker — F12 (untracked in PRD phasing; not built)
+- [x] Per-project icon picker — F12 (emoji icon per repo, shown in the session list)
 - [ ] Research chat with sub-agents + searxng; saved history — F9. Confirm searxng is still in stack.
 - [ ] Hermes migration off `claude -p` onto interactive-via-herdr — compliance-critical, likely its own milestone (workstream 3)
 - [ ] Per-agent sandboxing (firejail/bwrap/nspawn) + permission profiles — I3/I4, before any unattended autonomy

--- a/src/project-icons.ts
+++ b/src/project-icons.ts
@@ -1,0 +1,38 @@
+import type { SessionStore } from "./store";
+
+const SETTING_KEY = "projectIcons";
+const MAX_ENTRIES = 500; // safety bound; far above any realistic repo count
+
+type IconStore = Pick<SessionStore, "getSetting" | "setSetting">;
+
+/** Read the saved repoPath→emoji map. Empty default; tolerant of corrupt JSON. */
+export function loadIcons(store: IconStore): Record<string, string> {
+  const raw = store.getSetting(SETTING_KEY);
+  if (raw == null) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Patch a single project's emoji ("" clears it), persist, and return the full map.
+ * New paths beyond MAX_ENTRIES (500) are silently ignored; existing paths always update.
+ */
+export function setIcon(store: IconStore, path: string, emoji: string): Record<string, string> {
+  const map = loadIcons(store);
+  if (emoji === "") {
+    delete map[path];
+  } else if (path in map || Object.keys(map).length < MAX_ENTRIES) {
+    map[path] = emoji;
+  }
+  store.setSetting(SETTING_KEY, JSON.stringify(map));
+  return map;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,10 +11,12 @@ import {
   parseTermDims,
   validateSteers,
   validateBroadcast,
+  validateIconPatch,
 } from "./validate";
 import { listRepos, readTodo, writeTodo } from "./repos";
 import { listDirs, validateRoot, collapseHome } from "./dirs";
 import { loadSteers, saveSteers } from "./steers";
+import { loadIcons, setIcon } from "./project-icons";
 import { listBranches } from "./branches";
 import { computeDiff } from "./diff";
 import { sessionTokens, jsonlPathFor } from "./usage";
@@ -344,6 +346,22 @@ export function makeApp(deps: AppDeps) {
           if (!steers) return json({ error: "invalid steers payload" }, 400);
           saveSteers(deps.store, steers);
           return json(steers);
+        }
+      }
+
+      // ── per-project icons: read full map / patch one entry ──
+      if (parts[0] === "api" && parts[1] === "project-icons" && !parts[2]) {
+        if (req.method === "GET") return json(loadIcons(deps.store));
+        if (req.method === "PUT") {
+          if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
+            return json({ error: "Content-Type must be application/json" }, 415);
+          }
+          const body = await req.json().catch(() => null);
+          const patch = validateIconPatch(body);
+          if (!patch) return json({ error: "invalid project-icon payload" }, 400);
+          const map = setIcon(deps.store, patch.path, patch.emoji);
+          deps.events.emit("project-icons:update", map);
+          return json(map);
         }
       }
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -201,6 +201,22 @@ export function validateSteers(body: unknown): Steer[] | null {
   return out;
 }
 
+/** Validate a PUT /api/project-icons patch. `emoji === ""` means "clear". Returns null on violation. */
+export function validateIconPatch(body: unknown): { path: string; emoji: string } | null {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) return null;
+  const o = body as Record<string, unknown>;
+  if (typeof o.path !== "string" || typeof o.emoji !== "string") return null;
+  const path = o.path.trim();
+  if (path.length === 0 || path.length > 1024) return null;
+  const emoji = o.emoji.trim();
+  if (emoji.length > 0) {
+    const codePoints = [...emoji];
+    if (codePoints.length > 8) return null; // code-point cap (covers ZWJ sequences)
+    if (codePoints.some((c) => (c.codePointAt(0) ?? 0x20) < 0x20)) return null; // no control chars
+  }
+  return { path, emoji };
+}
+
 /** Validate a POST /api/broadcast payload. Returns null on any violation. */
 export function validateBroadcast(body: unknown): { text: string; ids: string[] } | null {
   if (body === null || typeof body !== "object" || Array.isArray(body)) return null;

--- a/test/project-icons.test.ts
+++ b/test/project-icons.test.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "bun:test";
+import { loadIcons, setIcon } from "../src/project-icons";
+import { validateIconPatch } from "../src/validate";
+
+function fakeStore() {
+  const m = new Map<string, string>();
+  return {
+    getSetting: (k: string) => m.get(k) ?? null,
+    setSetting: (k: string, v: string) => {
+      m.set(k, v);
+    },
+  };
+}
+
+test("loadIcons defaults to an empty map", () => {
+  expect(loadIcons(fakeStore())).toEqual({});
+});
+
+test("setIcon adds an entry and loadIcons round-trips it", () => {
+  const store = fakeStore();
+  const map = setIcon(store, "/home/u/Work/shepherd", "📦");
+  expect(map).toEqual({ "/home/u/Work/shepherd": "📦" });
+  expect(loadIcons(store)).toEqual({ "/home/u/Work/shepherd": "📦" });
+});
+
+test("setIcon with empty emoji clears the entry", () => {
+  const store = fakeStore();
+  setIcon(store, "/p", "🚀");
+  const map = setIcon(store, "/p", "");
+  expect(map).toEqual({});
+});
+
+test("loadIcons tolerates corrupt JSON", () => {
+  const store = fakeStore();
+  store.setSetting("projectIcons", "{not json");
+  expect(loadIcons(store)).toEqual({});
+});
+
+test("validateIconPatch accepts a valid patch", () => {
+  expect(validateIconPatch({ path: "/p", emoji: "📦" })).toEqual({ path: "/p", emoji: "📦" });
+});
+
+test("validateIconPatch accepts an empty emoji (clear)", () => {
+  expect(validateIconPatch({ path: "/p", emoji: "" })).toEqual({ path: "/p", emoji: "" });
+});
+
+test("validateIconPatch rejects bad payloads", () => {
+  expect(validateIconPatch(null)).toBeNull();
+  expect(validateIconPatch({ path: "", emoji: "📦" })).toBeNull(); // empty path
+  expect(validateIconPatch({ path: "/p" })).toBeNull(); // missing emoji
+  expect(validateIconPatch({ path: "/p", emoji: "a".repeat(9) })).toBeNull(); // > 8 code points
+  expect(validateIconPatch({ path: "/p", emoji: "\x01" })).toBeNull(); // control char
+});
+
+test("loadIcons returns {} for valid JSON that is not a plain object", () => {
+  const store = fakeStore();
+  store.setSetting("projectIcons", "[]");
+  expect(loadIcons(store)).toEqual({});
+  store.setSetting("projectIcons", "42");
+  expect(loadIcons(store)).toEqual({});
+});
+
+test("validateIconPatch trims surrounding whitespace from emoji", () => {
+  expect(validateIconPatch({ path: "/p", emoji: " 📦 " })).toEqual({ path: "/p", emoji: "📦" });
+});
+
+test("setIcon silently ignores new paths beyond MAX_ENTRIES, but updates existing", () => {
+  const store = fakeStore();
+  for (let i = 0; i < 500; i++) {
+    setIcon(store, `/p${i}`, "🔵");
+  }
+  const afterCap = setIcon(store, "/new", "🚀");
+  expect("/new" in afterCap).toBe(false);
+  const afterUpdate = setIcon(store, "/p0", "🎨");
+  expect(afterUpdate["/p0"]).toBe("🎨");
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -174,5 +174,9 @@
   "broadcast_sending": "Sendet…",
   "broadcast_send_to": "An {count} senden",
   "broadcast_result_sent": "{sent}/{total} gesendet",
-  "broadcast_failed": "Broadcast fehlgeschlagen"
+  "broadcast_failed": "Broadcast fehlgeschlagen",
+  "emojipicker_search": "Emoji suchen…",
+  "emojipicker_custom": "Emoji einfügen",
+  "emojipicker_clear": "Symbol entfernen",
+  "reposelect_set_icon": "Projektsymbol setzen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -174,5 +174,9 @@
   "broadcast_sending": "Sending…",
   "broadcast_send_to": "Send to {count}",
   "broadcast_result_sent": "sent {sent}/{total}",
-  "broadcast_failed": "broadcast failed"
+  "broadcast_failed": "broadcast failed",
+  "emojipicker_search": "search emoji…",
+  "emojipicker_custom": "paste any emoji",
+  "emojipicker_clear": "remove icon",
+  "reposelect_set_icon": "set project icon"
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -14,6 +14,7 @@ import type {
   UpdateStatus,
   Steer,
   DiffResult,
+  ProjectIcons,
 } from "./types";
 
 const JSON_HEADERS = { "content-type": "application/json" };
@@ -244,5 +245,24 @@ export async function broadcast(
     body: JSON.stringify({ text, ids }),
   });
   if (!r.ok) throw new Error(`broadcast failed: ${r.status}`);
+  return r.json();
+}
+
+export async function getProjectIcons(): Promise<ProjectIcons> {
+  const r = await fetch("/api/project-icons");
+  if (!r.ok) throw new Error(`project-icons failed: ${r.status}`);
+  return r.json();
+}
+
+export async function putProjectIcon(path: string, emoji: string): Promise<ProjectIcons> {
+  const r = await fetch("/api/project-icons", {
+    method: "PUT",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ path, emoji }),
+  });
+  if (!r.ok) {
+    const msg = await r.json().catch(() => ({ error: `${r.status}` }));
+    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+  }
   return r.json();
 }

--- a/ui/src/lib/components/EmojiPicker.svelte
+++ b/ui/src/lib/components/EmojiPicker.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import { searchEmoji, isSingleEmoji } from "$lib/emoji";
+
+  let {
+    value,
+    onpick,
+    onclose,
+  }: {
+    value: string | null;
+    onpick: (emoji: string | null) => void;
+    onclose: () => void;
+  } = $props();
+
+  let query = $state("");
+  let custom = $state("");
+  let searchInput = $state<HTMLInputElement | null>(null);
+
+  const shown = $derived(searchEmoji(query));
+  const customOk = $derived(isSingleEmoji(custom));
+
+  $effect(() => {
+    searchInput?.focus();
+  });
+
+  function commitCustom() {
+    if (customOk) {
+      onpick(custom.trim());
+      custom = "";
+    }
+  }
+
+  $effect(() => {
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") onclose();
+    }
+    window.addEventListener("keydown", onKeydown);
+    return () => window.removeEventListener("keydown", onKeydown);
+  });
+</script>
+
+<div class="ep" role="dialog" aria-label={m.reposelect_set_icon()}>
+  <input
+    bind:this={searchInput}
+    bind:value={query}
+    class="ep-search"
+    placeholder={m.emojipicker_search()}
+    type="text"
+    autocomplete="off"
+    spellcheck="false"
+  />
+  <div class="ep-grid">
+    {#each shown as e (e.char)}
+      <button
+        type="button"
+        class="ep-cell"
+        class:on={e.char === value}
+        title={e.keywords}
+        onclick={() => onpick(e.char)}
+      >
+        {e.char}
+      </button>
+    {/each}
+  </div>
+  <div class="ep-foot">
+    <input
+      bind:value={custom}
+      class="ep-custom"
+      class:bad={custom.length > 0 && !customOk}
+      placeholder={m.emojipicker_custom()}
+      type="text"
+      autocomplete="off"
+      onkeydown={(e) => {
+        if (e.key === "Enter") commitCustom();
+      }}
+    />
+    <button type="button" class="ep-clear" onclick={() => onpick(null)}>
+      {m.emojipicker_clear()}
+    </button>
+  </div>
+</div>
+
+<style>
+  .ep {
+    background: var(--color-panel-2);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 4px;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.6);
+    padding: 8px;
+    width: 240px;
+  }
+  .ep-search {
+    width: 100%;
+    box-sizing: border-box;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: 12px;
+    padding: 6px 8px;
+    border-radius: 2px;
+  }
+  .ep-search:focus {
+    outline: none;
+    border-color: var(--color-amber);
+  }
+  .ep-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 2px;
+    margin-top: 7px;
+    max-height: 180px;
+    overflow-y: auto;
+  }
+  .ep-cell {
+    aspect-ratio: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    background: transparent;
+    border: 0;
+    border-radius: 3px;
+    cursor: pointer;
+    padding: 0;
+  }
+  .ep-cell:hover {
+    background: var(--color-hover);
+  }
+  .ep-cell.on {
+    outline: 1.5px solid var(--color-amber);
+    background: color-mix(in srgb, var(--color-amber) 12%, transparent);
+  }
+  .ep-foot {
+    display: flex;
+    gap: 6px;
+    margin-top: 7px;
+  }
+  .ep-custom {
+    flex: 1;
+    min-width: 0;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: 16px; /* prevents iOS zoom-on-focus; also fits emoji */
+    padding: 4px 7px;
+    border-radius: 2px;
+  }
+  .ep-custom.bad {
+    border-color: var(--color-blue);
+  }
+  .ep-clear {
+    flex-shrink: 0;
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    font: inherit;
+    font-size: 11px;
+    padding: 0 8px;
+    border-radius: 2px;
+    cursor: pointer;
+  }
+  .ep-clear:hover {
+    color: var(--color-ink-bright);
+    border-color: var(--color-amber);
+  }
+</style>

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { RepoEntry } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import EmojiPicker from "./EmojiPicker.svelte";
+  import { projectIcons } from "$lib/projectIcons.svelte";
 
   let {
     repos,
@@ -12,6 +14,14 @@
   let filter = $state("");
   let root = $state<HTMLElement | null>(null);
   let filterInput = $state<HTMLInputElement | null>(null);
+
+  // repo path whose emoji picker is currently open (null = none)
+  let pickerFor = $state<string | null>(null);
+
+  function setIcon(path: string, emoji: string | null) {
+    projectIcons.set(path, emoji).catch(() => {});
+    pickerFor = null;
+  }
 
   const selected = $derived(repos.find((r) => r.path === value) ?? null);
   const shown = $derived(
@@ -28,6 +38,7 @@
   function pick(path: string) {
     onchange(path);
     open = false;
+    pickerFor = null;
     filter = "";
   }
 
@@ -41,12 +52,14 @@
     function onKeydown(e: KeyboardEvent) {
       if (e.key === "Escape" && open) {
         open = false;
+        pickerFor = null;
         filter = "";
       }
     }
     function onClick(e: MouseEvent) {
       if (open && root && !root.contains(e.target as Node)) {
         open = false;
+        pickerFor = null;
         filter = "";
       }
     }
@@ -68,6 +81,7 @@
     aria-expanded={open}
   >
     {#if selected}
+      <span class="rs-emoji" aria-hidden="true">{projectIcons.iconFor(selected.path) ?? "▣"}</span>
       <b>{selected.name}</b>
       <span class="dim">{selected.display}</span>
     {:else}
@@ -100,6 +114,18 @@
               if (e.key === "Enter" || e.key === " ") pick(r.path);
             }}
           >
+            <button
+              type="button"
+              class="rs-emoji-btn"
+              title={m.reposelect_set_icon()}
+              aria-label={m.reposelect_set_icon()}
+              onclick={(e) => {
+                e.stopPropagation();
+                pickerFor = pickerFor === r.path ? null : r.path;
+              }}
+            >
+              {projectIcons.iconFor(r.path) ?? "▣"}
+            </button>
             <b>{r.name}</b>
             <span class="dim">{r.display}</span>
           </li>
@@ -108,6 +134,15 @@
           <li class="rs-empty">{m.reposelect_no_matches()}</li>
         {/if}
       </ul>
+      {#if pickerFor !== null}
+        <div class="rs-picker">
+          <EmojiPicker
+            value={projectIcons.iconFor(pickerFor)}
+            onpick={(emoji) => setIcon(pickerFor!, emoji)}
+            onclose={() => (pickerFor = null)}
+          />
+        </div>
+      {/if}
     </div>
   {/if}
 </div>
@@ -256,6 +291,33 @@
     font-size: 12px;
     font-style: italic;
     text-align: center;
+  }
+
+  .rs-emoji {
+    flex-shrink: 0;
+    font-size: 13px;
+    line-height: 1;
+  }
+  .rs-emoji-btn {
+    flex-shrink: 0;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    font-size: 14px;
+    line-height: 1;
+    padding: 1px 3px;
+    cursor: pointer;
+    color: var(--color-amber);
+  }
+  .rs-emoji-btn:hover {
+    border-color: var(--color-amber);
+    background: var(--color-hover);
+  }
+  .rs-picker {
+    position: absolute;
+    z-index: 60;
+    left: 8px;
+    margin-top: 4px;
   }
 
   @media (max-width: 768px) {

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -3,6 +3,7 @@
   import { elapsed, STATUS_COLOR, statusLabel } from "$lib/format";
   import StatusPip from "./StatusPip.svelte";
   import PrBadge from "./PrBadge.svelte";
+  import { projectIcons } from "$lib/projectIcons.svelte";
 
   let {
     session,
@@ -26,6 +27,7 @@
 
   // repo the unit works in — the last path segment of its repoPath (e.g. "community-map")
   const repoName = $derived(session.repoPath.split("/").filter(Boolean).at(-1) ?? session.repoPath);
+  const repoIcon = $derived(projectIcons.iconFor(session.repoPath));
 </script>
 
 <button
@@ -45,7 +47,8 @@
       <span class="name">{session.name}</span>
     </div>
     <div class="u-repo" title={session.repoPath}>
-      <span class="repo-glyph" aria-hidden="true">▣</span>{repoName}
+      <span class="repo-glyph" class:emoji={repoIcon} aria-hidden="true">{repoIcon ?? "▣"}</span
+      >{repoName}
     </div>
     <div class="u-sub">
       {session.prompt}
@@ -180,6 +183,9 @@
     color: var(--color-amber);
     font-size: 10px;
     flex-shrink: 0;
+  }
+  .repo-glyph.emoji {
+    font-size: 12px;
   }
 
   .u-sub {

--- a/ui/src/lib/emoji.test.ts
+++ b/ui/src/lib/emoji.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { EMOJI, isSingleEmoji, searchEmoji } from "./emoji";
+
+describe("emoji helpers", () => {
+  it("ships a non-trivial curated set", () => {
+    expect(EMOJI.length).toBeGreaterThan(40);
+    expect(EMOJI.every((e) => typeof e.char === "string" && e.char.length > 0)).toBe(true);
+  });
+
+  it("isSingleEmoji accepts a single emoji incl. ZWJ sequences", () => {
+    expect(isSingleEmoji("📦")).toBe(true);
+    expect(isSingleEmoji("👩‍💻")).toBe(true);
+  });
+
+  it("isSingleEmoji rejects empty, plain ascii, control chars and overlong input", () => {
+    expect(isSingleEmoji("")).toBe(false);
+    expect(isSingleEmoji("  ")).toBe(false);
+    expect(isSingleEmoji("ab")).toBe(false);
+    expect(isSingleEmoji("x")).toBe(false);
+    expect(isSingleEmoji("📦📦📦📦📦")).toBe(false); // > 8 code points
+  });
+
+  it("searchEmoji filters by keyword, returns all on empty query", () => {
+    expect(searchEmoji("").length).toBe(EMOJI.length);
+    const rocket = searchEmoji("rocket");
+    expect(rocket.some((e) => e.char === "🚀")).toBe(true);
+  });
+});

--- a/ui/src/lib/emoji.ts
+++ b/ui/src/lib/emoji.ts
@@ -1,0 +1,106 @@
+export interface EmojiEntry {
+  char: string;
+  keywords: string;
+}
+
+// Curated set tuned for software projects. The paste field covers the long tail,
+// so this only needs the common picks — not the whole Unicode emoji table.
+export const EMOJI: EmojiEntry[] = [
+  { char: "📦", keywords: "package box module library bundle" },
+  { char: "🚀", keywords: "rocket launch ship deploy fast" },
+  { char: "🔐", keywords: "lock auth security secret login" },
+  { char: "🔑", keywords: "key auth token credential" },
+  { char: "🛡️", keywords: "shield security guard protect" },
+  { char: "🤖", keywords: "robot bot agent ai automation" },
+  { char: "🧠", keywords: "brain ai ml model think" },
+  { char: "🧪", keywords: "test lab experiment tube" },
+  { char: "🧬", keywords: "dna bio science" },
+  { char: "🎨", keywords: "art design palette ui paint" },
+  { char: "🖌️", keywords: "brush design paint" },
+  { char: "✨", keywords: "sparkles polish magic feature" },
+  { char: "⚙️", keywords: "gear settings config engine" },
+  { char: "🔧", keywords: "wrench tool fix config" },
+  { char: "🔨", keywords: "hammer build tool" },
+  { char: "🛠️", keywords: "tools build maintain" },
+  { char: "🐙", keywords: "octopus github octocat git" },
+  { char: "🌿", keywords: "branch git leaf green" },
+  { char: "🌱", keywords: "seedling new grow start" },
+  { char: "🌳", keywords: "tree worktree grow" },
+  { char: "📡", keywords: "satellite signal api network broadcast" },
+  { char: "🛰️", keywords: "satellite space orbit network" },
+  { char: "🔭", keywords: "telescope observe research explore" },
+  { char: "🔬", keywords: "microscope research inspect detail" },
+  { char: "🧩", keywords: "puzzle plugin module piece integration" },
+  { char: "📊", keywords: "chart bar stats analytics metrics" },
+  { char: "📈", keywords: "chart up growth metrics trend" },
+  { char: "📉", keywords: "chart down decline metrics" },
+  { char: "💾", keywords: "disk save storage db floppy" },
+  { char: "🗄️", keywords: "cabinet storage archive files" },
+  { char: "🗃️", keywords: "box files database records" },
+  { char: "🧱", keywords: "brick block infra foundation" },
+  { char: "🏗️", keywords: "construction build scaffold wip" },
+  { char: "🏛️", keywords: "bank classic institution legacy" },
+  { char: "🗺️", keywords: "map navigation geo route" },
+  { char: "🧭", keywords: "compass navigate direction explore" },
+  { char: "📍", keywords: "pin location marker place" },
+  { char: "🌐", keywords: "globe web internet world i18n" },
+  { char: "🌍", keywords: "earth globe world region" },
+  { char: "💬", keywords: "chat message talk comment" },
+  { char: "📨", keywords: "mail email message inbox send" },
+  { char: "📬", keywords: "mailbox inbox notify" },
+  { char: "🔔", keywords: "bell notify alert reminder" },
+  { char: "📅", keywords: "calendar schedule date plan" },
+  { char: "📝", keywords: "memo note doc write todo" },
+  { char: "📋", keywords: "clipboard tasks list copy" },
+  { char: "📚", keywords: "books docs library knowledge" },
+  { char: "📖", keywords: "book docs read manual" },
+  { char: "🏷️", keywords: "label tag name release" },
+  { char: "💡", keywords: "idea bulb feature insight" },
+  { char: "🔥", keywords: "fire hot flame trending hotfix" },
+  { char: "⚡", keywords: "bolt fast power performance energy" },
+  { char: "🐛", keywords: "bug defect issue insect" },
+  { char: "🩹", keywords: "bandage fix patch hotfix" },
+  { char: "🧹", keywords: "broom cleanup chore tidy" },
+  { char: "♻️", keywords: "recycle refactor reuse" },
+  { char: "🔁", keywords: "loop repeat sync cycle" },
+  { char: "🔄", keywords: "sync refresh reload update" },
+  { char: "🎯", keywords: "target goal focus aim mvp" },
+  { char: "🏁", keywords: "finish flag done release ship" },
+  { char: "🚦", keywords: "signal status traffic gate ci" },
+  { char: "🚧", keywords: "construction wip barrier blocked" },
+  { char: "🔒", keywords: "locked private secure closed" },
+  { char: "🔓", keywords: "unlocked open public" },
+  { char: "👁️", keywords: "eye watch observe monitor view" },
+  { char: "🦾", keywords: "robot arm automation mech" },
+  { char: "🐳", keywords: "whale docker container ship" },
+  { char: "☁️", keywords: "cloud server hosting infra" },
+  { char: "🖥️", keywords: "desktop server computer machine" },
+  { char: "📱", keywords: "phone mobile app device" },
+  { char: "⌨️", keywords: "keyboard cli terminal input" },
+  { char: "🧰", keywords: "toolbox kit utils helpers" },
+  { char: "🪝", keywords: "hook webhook git" },
+  { char: "🧾", keywords: "receipt log invoice record" },
+  { char: "👩‍💻", keywords: "developer coder engineer person" },
+  { char: "🎛️", keywords: "control dashboard knobs hud" },
+  { char: "🛎️", keywords: "bell service desk support" },
+  { char: "🦄", keywords: "unicorn special rare magic" },
+];
+
+const _segmenter = new Intl.Segmenter();
+
+/** True when `s` is a single emoji (incl. ZWJ sequences), not ascii/control/overlong. */
+export function isSingleEmoji(s: string): boolean {
+  const t = s.trim();
+  if (t.length === 0) return false;
+  if ([...t].length > 8) return false; // code-point cap, matches server
+  const segments = [..._segmenter.segment(t)];
+  if (segments.length !== 1) return false; // reject multi-emoji strings
+  return /\p{Extended_Pictographic}/u.test(t);
+}
+
+/** Filter the curated set by keyword/char; empty query returns the whole set. */
+export function searchEmoji(query: string): EmojiEntry[] {
+  const q = query.trim().toLowerCase();
+  if (q === "") return EMOJI;
+  return EMOJI.filter((e) => e.keywords.includes(q) || e.char === query.trim());
+}

--- a/ui/src/lib/projectIcons.svelte.test.ts
+++ b/ui/src/lib/projectIcons.svelte.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { projectIcons } from "./projectIcons.svelte";
+
+beforeEach(() => {
+  projectIcons.map = {};
+  projectIcons.error = null;
+  projectIcons.loaded = false;
+});
+
+describe("projectIcons store", () => {
+  it("load() populates the map from GET /api/project-icons", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ "/a": "📦" }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    await projectIcons.load();
+    expect(projectIcons.map).toEqual({ "/a": "📦" });
+    expect(projectIcons.loaded).toBe(true);
+  });
+
+  it("iconFor returns the emoji when set and null otherwise", () => {
+    projectIcons.map = { "/a": "🚀" };
+    expect(projectIcons.iconFor("/a")).toBe("🚀");
+    expect(projectIcons.iconFor("/missing")).toBeNull();
+  });
+
+  it("set() PUTs the patch and adopts the returned map", async () => {
+    const calls: { method?: string; body?: string }[] = [];
+    globalThis.fetch = vi.fn(async (_url: unknown, init?: { method?: string; body?: string }) => {
+      calls.push({ method: init?.method, body: init?.body });
+      return new Response(JSON.stringify({ "/a": "🎨" }), { status: 200 });
+    }) as unknown as typeof fetch;
+    await projectIcons.set("/a", "🎨");
+    expect(calls[0]!.method).toBe("PUT");
+    expect(JSON.parse(calls[0]!.body!)).toEqual({ path: "/a", emoji: "🎨" });
+    expect(projectIcons.map).toEqual({ "/a": "🎨" });
+  });
+
+  it("apply() replaces the map (WS broadcast)", () => {
+    projectIcons.apply({ "/b": "🤖" });
+    expect(projectIcons.map).toEqual({ "/b": "🤖" });
+  });
+});

--- a/ui/src/lib/projectIcons.svelte.ts
+++ b/ui/src/lib/projectIcons.svelte.ts
@@ -1,0 +1,44 @@
+import type { ProjectIcons } from "./types";
+import { getProjectIcons, putProjectIcon } from "./api";
+
+// Client cache of the repoPath→emoji map. Loaded once on app start; each pick
+// persists to the server and adopts the returned map. Live updates from other
+// clients arrive via the `project-icons:update` WS event (see store.svelte.ts).
+class ProjectIconsStore {
+  map = $state<ProjectIcons>({});
+  loaded = $state(false);
+  error = $state<string | null>(null);
+
+  async load() {
+    try {
+      this.map = await getProjectIcons();
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : "failed to load project icons";
+    } finally {
+      this.loaded = true;
+    }
+  }
+
+  /** Emoji for a repo path, or null when unset (caller falls back to ▣). */
+  iconFor(path: string): string | null {
+    return this.map[path] ?? null;
+  }
+
+  /** Set ("" or null clears) a project's emoji. Persists + adopts the server map. */
+  async set(path: string, emoji: string | null) {
+    this.error = null;
+    try {
+      this.map = await putProjectIcon(path, emoji ?? "");
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : "failed to save project icon";
+      throw e;
+    }
+  }
+
+  /** Adopt a full map pushed over the WS. */
+  apply(map: ProjectIcons) {
+    this.map = map;
+  }
+}
+
+export const projectIcons = new ProjectIconsStore();

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -1,5 +1,6 @@
 import type { Session, WsEvent, UsageLimits, UpdateStatus, GitState } from "./types";
 import type { BlockState } from "./triage";
+import { projectIcons } from "./projectIcons.svelte";
 
 export class HerdStore {
   sessions = $state<Session[]>([]);
@@ -76,6 +77,8 @@ export class HerdStore {
       this.usageLimits = ev.data;
     } else if (ev.event === "update:status") {
       this.setUpdate(ev.data);
+    } else if (ev.event === "project-icons:update") {
+      projectIcons.apply(ev.data);
     }
   }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -131,6 +131,9 @@ export interface UpdateStatus {
   error?: string;
 }
 
+/** repoPath → emoji map for per-project icons. */
+export type ProjectIcons = Record<string, string>;
+
 export type WsEvent =
   | { event: "session:new"; data: Session }
   | { event: "session:status"; data: { id: string; status: SessionStatus } }
@@ -138,7 +141,8 @@ export type WsEvent =
   | { event: "usage:limits"; data: UsageLimits }
   | { event: "session:block"; data: { id: string; block: BlockReason | null } }
   | { event: "session:git"; data: { id: string; git: GitState } }
-  | { event: "update:status"; data: UpdateStatus };
+  | { event: "update:status"; data: UpdateStatus }
+  | { event: "project-icons:update"; data: ProjectIcons };
 
 export interface CreateInput {
   repoPath: string;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -13,6 +13,7 @@
   } from "$lib/api";
   import { sortBlocked } from "$lib/triage";
   import { steers } from "$lib/steers.svelte";
+  import { projectIcons } from "$lib/projectIcons.svelte";
   import TopBar from "$lib/components/TopBar.svelte";
   import TriageDrawer from "$lib/components/TriageDrawer.svelte";
   import Herd from "$lib/components/Herd.svelte";
@@ -85,6 +86,7 @@
       .then((m) => store.setGit(m))
       .catch(() => {});
     steers.load();
+    projectIcons.load();
     const dispose = store.connect();
     const t = setInterval(() => (nowMs = Date.now()), 1000);
     return () => {


### PR DESCRIPTION
## Summary
Implements F12 from the PRD — a **per-project emoji icon picker**. Each project (repo) can be assigned an emoji that renders wherever the project appears, replacing the static `▣` glyph. Opt-in: unset projects keep `▣`.

- **Server** — `Record<repoPath, emoji>` persisted in the key/value `settings` table (`src/project-icons.ts`), validated by `validateIconPatch` (`src/validate.ts`), exposed via `GET/PUT /api/project-icons` with a `project-icons:update` WS broadcast (`src/server.ts`). Mirrors the existing **steers** pattern.
- **UI** — global `$state` store (`projectIcons.svelte.ts`) loaded on boot + live-updated over WS; dependency-free `EmojiPicker.svelte` popover (curated grid + keyword search + paste-any-emoji field + clear); opened inline from the repo dropdown (`RepoSelect.svelte`); emoji rendered in the session list (`UnitRow.svelte`). i18n strings added (EN + DE).

Picker richness: curated ~78-emoji grid for quick picks, with a paste field that accepts any single emoji via the OS keyboard (great on the mobile PWA). `isSingleEmoji` enforces exactly one grapheme cluster; the server caps at ≤8 code points / no control chars — validation parity verified.

## Test Plan
- [x] Root: `bun run lint`, `bun test ./test` (302 pass), `bunx tsc --noEmit` — all clean
- [x] UI: `bun run check` (0 errors / 0 warnings), `bun run test` (61 pass)
- [x] Server route smoke-tested: `GET` → `{}` → `PUT` → `{"/x":"📦"}` → `PUT ""` clears
- [ ] Manual: open a task, expand the repo dropdown, click a repo's `▣`, pick from the grid + try the paste field; confirm (1) row + trigger + session list show the emoji, (2) "remove icon" restores `▣`, (3) a second tab updates live (WS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)