### PR TITLE
chore(ci): i18n catalog-parity gate + CLAUDE.md steering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Typecheck (ui svelte-check)
         run: cd ui && bun run check
 
+      - name: i18n catalog parity (en ↔ de)
+        run: cd ui && bun run check:i18n
+
       - name: Test (root)
         # server.test.ts creates its temp repo inside repoRoot (default
         # $HOME/Work, absent on the runner). Point it at a writable temp dir.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -24,6 +24,9 @@ bun run typecheck
 echo "→ ui svelte-check"
 (cd ui && bun run check)
 
+echo "→ i18n catalog parity (en ↔ de)"
+(cd ui && bun run check:i18n)
+
 echo "→ root tests"
 # server.test.ts builds a throwaway git repo under SHEPHERD_REPO_ROOT;
 # point it at a temp dir so we never touch the operator's real repo root.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,15 @@ Shepherd worktrees start without `node_modules`. Install per package before lint
 | UI      | `cd ui && bun install` | `bun run check` | `bun test` |
 
 Run both halves when a change spans server + UI.
+
+## Internationalization (REQUIRED for any UI work)
+
+The UI is fully internationalized with Paraglide JS (EN + DE). **Never hardcode user-facing text.** Every display string — labels, buttons, placeholders, `title`/`aria-label`, empty/error/loading states, toast text, and **server-side notification payloads** — must route through a message:
+
+1. Add the key to **both** `ui/messages/en.json` and `ui/messages/de.json`. Keys are snake_case and component-prefixed (`viewport_diff_tab`, `broadcast_failed`, `prbadge_open`); use `{param}` for interpolation.
+2. Import and call it: `import { m } from "$lib/paraglide/messages"` → `m.my_key()` / `m.my_key({ count })`.
+3. Reuse existing keys where one fits (e.g. `common_close`, `common_loading`).
+
+Data passed through verbatim (tool-use summaries, PR titles, designations like `TASK-07`) is **not** translated — only chrome the app itself authors.
+
+**Gate:** `cd ui && bun run check:i18n` enforces that all locale catalogs share an identical, non-empty key set (Paraglide silently falls back to EN for a missing key, so an incomplete `de.json` would otherwise ship looking fine). It runs in CI `verify` and the pre-push hook — a PR that adds an EN key without its DE counterpart fails. It does not detect hardcoded strings that skip the catalog entirely; that's on you and review.

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,7 @@
     "prepare": "svelte-kit sync || echo '' && paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide || echo ''",
     "check": "paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "check:i18n": "node scripts/check-i18n.mjs",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/ui/scripts/check-i18n.mjs
+++ b/ui/scripts/check-i18n.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// i18n gate: every locale catalog under ui/messages/ must carry the SAME set of
+// keys, and no value may be empty. Paraglide silently falls back to the base
+// locale for a missing key, so an incomplete translation ships looking "fine" —
+// this check turns that into a hard failure (CI `verify` + pre-push).
+//
+// It does NOT detect hardcoded strings that bypass the catalog entirely; that's
+// covered by the i18n steering in CLAUDE.md + code review.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MESSAGES_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..", "messages");
+const META_KEYS = new Set(["$schema"]);
+
+const files = readdirSync(MESSAGES_DIR).filter((f) => f.endsWith(".json"));
+if (files.length < 2) {
+  console.error(`i18n: expected ≥2 locale catalogs in ${MESSAGES_DIR}, found ${files.length}`);
+  process.exit(1);
+}
+
+/** @type {Map<string, Set<string>>} locale → key set */
+const keysByLocale = new Map();
+/** @type {Map<string, string[]>} locale → keys with empty values */
+const emptyByLocale = new Map();
+
+for (const file of files) {
+  const locale = file.replace(/\.json$/, "");
+  const data = JSON.parse(readFileSync(join(MESSAGES_DIR, file), "utf8"));
+  const keys = new Set();
+  const empty = [];
+  for (const [k, v] of Object.entries(data)) {
+    if (META_KEYS.has(k)) continue;
+    keys.add(k);
+    if (typeof v === "string" && v.trim() === "") empty.push(k);
+  }
+  keysByLocale.set(locale, keys);
+  emptyByLocale.set(locale, empty);
+}
+
+const locales = [...keysByLocale.keys()];
+const union = new Set(locales.flatMap((l) => [...keysByLocale.get(l)]));
+
+const problems = [];
+for (const locale of locales) {
+  const has = keysByLocale.get(locale);
+  const missing = [...union].filter((k) => !has.has(k)).sort();
+  if (missing.length)
+    problems.push(`  ${locale}.json missing ${missing.length}: ${missing.join(", ")}`);
+  const empty = emptyByLocale.get(locale);
+  if (empty.length) problems.push(`  ${locale}.json empty values: ${empty.join(", ")}`);
+}
+
+if (problems.length) {
+  console.error(
+    `i18n: catalog parity check failed (${locales.join(", ")} must share identical, non-empty keys):\n${problems.join("\n")}`,
+  );
+  process.exit(1);
+}
+
+console.log(`✓ i18n: ${locales.length} locales in parity (${union.size} keys each)`);


### PR DESCRIPTION
Stops the recurring "feature PR shipped hardcoded strings → retrofit i18n in review" churn, via **both** steering and gating.

## Steering
`CLAUDE.md` gains an **Internationalization (REQUIRED)** section: every user-facing string (labels, placeholders, `title`/`aria-label`, empty/error states, **server-side notification payloads**) must route through Paraglide `m.*` with keys in both `en.json` + `de.json`; never hardcode. Verbatim data (tool summaries, `TASK-07` designations) is exempt.

## Gating
`ui/scripts/check-i18n.mjs` (`bun run check:i18n`) asserts every locale catalog shares an identical, non-empty key set. Paraglide silently falls back to EN for a missing key, so an incomplete `de.json` ships looking fine — this turns that into a hard failure. Wired into the CI `verify` job and the pre-push hook.

Catches asymmetric/missing/empty translations. It does **not** detect hardcoded strings that bypass the catalog entirely — steering + review cover that (a literal-text linter was considered but is too noisy to gate on).

## Checks
Full pre-push gate passed (incl. the new `check:i18n` → 165 keys in parity).