### PR TITLE
feat(triage): flag silent stalled agents as a needs-you reason

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,11 @@
       classifier + poller emit `session:block` + POST `/reply` (types into PTY) + "Needs you" drawer.
 - [x] Agent activity feed — render existing PreToolUse/PostToolUse hook data as compact
       human log per agent ("edited server.ts · ran tests (2 failed) · waiting").
+- [x] Silent-stall detection — flag a "working" agent gone quiet (no new tool-use in 8m;
+      hung-command ceiling 20m, pending-tool guard avoids false positives on long builds) as
+      a `stall` "needs you" reason in the triage drawer; fires once/episode, re-arms on resume.
+      Poller reads session JSONL (`src/stall.ts`); ToS-clean (observe-only). Catches the silent
+      wedge that blocked-triage (explicit asks) misses.
 - [x] Push notifications — Web Push from PWA on blocked(needs-you)/done; reuses F3 hook
       telemetry + herdr status. Per-device locale → localized notification payloads (EN/DE).
 - [x] Inline diff review — per-worktree `git diff` panel in HUD; review before merge,

--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -1,4 +1,4 @@
-export type BlockShape = "menu" | "yes-no" | "awaiting-input";
+export type BlockShape = "menu" | "yes-no" | "awaiting-input" | "stall";
 
 export interface BlockOption {
   label: string;
@@ -20,13 +20,18 @@ const YES_NO_RE = /\(\s*y\s*\/\s*n\s*\)|\[\s*y\s*\/\s*n\s*\]/i;
 // eslint-disable-next-line no-control-regex
 const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
 
-/** Classify a blocked agent's terminal tail into an actionable shape. Never throws. */
-export function classifyBlocked(text: string): BlockReason {
-  const tail = text
+/** Strip ANSI + trailing whitespace, drop blank lines, keep the last `n` lines. */
+export function tailLines(text: string, n = TAIL_LINES): string[] {
+  return text
     .split("\n")
     .map((l) => l.replace(ANSI_RE, "").replace(/\s+$/, ""))
     .filter((l) => l.trim() !== "")
-    .slice(-TAIL_LINES);
+    .slice(-n);
+}
+
+/** Classify a blocked agent's terminal tail into an actionable shape. Never throws. */
+export function classifyBlocked(text: string): BlockReason {
+  const tail = tailLines(text);
 
   // Capture the last contiguous 1..n run of numbered options.
   let run: BlockOption[] = [];

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1,11 +1,17 @@
 import type { SessionStore } from "./store";
+import type { Session } from "./types";
 import { mapState, type HerdrDriver } from "./herdr";
-import { classifyBlocked, type BlockReason } from "./blocked";
+import { classifyBlocked, tailLines, type BlockReason } from "./blocked";
+import { isStalled, readSnapshot, DEFAULT_STALL, type ActivitySnapshot } from "./stall";
+import { jsonlPathFor } from "./usage";
+
+const STALL_SIG = "stall"; // fixed signature → a stall fires once per episode
 
 export class StatusPoller {
   private timer: ReturnType<typeof setInterval> | null = null;
   private lastReadAt = new Map<string, number>();
   private lastSig = new Map<string, string>();
+  private lastStallAt = new Map<string, number>();
 
   constructor(
     private store: SessionStore,
@@ -16,6 +22,11 @@ export class StatusPoller {
     private reclassifyMs = 3000,
     private classify: (text: string) => BlockReason = classifyBlocked,
     private now: () => number = Date.now,
+    /** Latest tool-activity snapshot for a session; defaults to reading its JSONL. */
+    private stallProbe: (s: Session) => ActivitySnapshot | null = (s) =>
+      s.claudeSessionId ? readSnapshot(jsonlPathFor(s.worktreePath, s.claudeSessionId)) : null,
+    private stallCfg = DEFAULT_STALL,
+    private stallCheckMs = 30_000,
   ) {}
 
   tick(): void {
@@ -42,6 +53,7 @@ export class StatusPoller {
         this.onChange(s.id, status);
       }
       if (status === "blocked") this.maybeClassify(s.id, s.herdrAgentId);
+      else if (status === "running") this.maybeStall(s);
       else this.clearBlock(s.id);
     }
     // prune tracking state for sessions no longer active (archived/removed)
@@ -49,8 +61,41 @@ export class StatusPoller {
       if (!activeIds.has(id)) {
         this.lastReadAt.delete(id);
         this.lastSig.delete(id);
+        this.lastStallAt.delete(id);
       }
     }
+  }
+
+  /**
+   * Flag a *working* agent that has gone silent — no new tool-use within the
+   * stall window (a tool still running is excluded until the hung-command
+   * ceiling). Surfaces as a "needs you" reason; fires once until activity
+   * resumes, then re-arms. Throttled to `stallCheckMs` per session.
+   */
+  private maybeStall(s: Session): void {
+    const t = this.now();
+    if (t - (this.lastStallAt.get(s.id) ?? 0) < this.stallCheckMs) return;
+    this.lastStallAt.set(s.id, t);
+    let snap: ActivitySnapshot | null;
+    try {
+      snap = this.stallProbe(s);
+    } catch (err) {
+      console.warn(`[poller] stall probe failed for ${s.id}:`, err);
+      return; // best-effort; retry next cadence
+    }
+    if (!snap || !isStalled(snap, t, this.stallCfg)) {
+      this.clearBlock(s.id); // activity resumed (or never stalled) → re-arm
+      return;
+    }
+    if (this.lastSig.get(s.id) === STALL_SIG) return; // already announced this episode
+    this.lastSig.set(s.id, STALL_SIG);
+    let tail: string[] = [];
+    try {
+      tail = tailLines(this.herdr.read(s.herdrAgentId, "visible"));
+    } catch {
+      // terminal read is best-effort context; an empty tail still flags the stall
+    }
+    this.onBlock(s.id, { shape: "stall", options: [], tail });
   }
 
   /** Read + classify a blocked agent at most every `reclassifyMs`; emit only on change. */

--- a/src/stall.ts
+++ b/src/stall.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { parseActivity } from "./activity";
+
+/** A minimal read of a session's most-recent tool activity, for stall detection. */
+export interface ActivitySnapshot {
+  /** ms epoch of the most recent tool_use, or 0 if the transcript has none yet. */
+  lastTs: number;
+  /** the newest tool_use has no tool_result yet → a tool is still running. */
+  pending: boolean;
+}
+
+export interface StallConfig {
+  /** working + last tool finished + no new tool-use within this window → stalled. */
+  stallMs: number;
+  /** working + a tool still running with no result within this window → hung command. */
+  pendingStallMs: number;
+}
+
+export const DEFAULT_STALL: StallConfig = {
+  // 8m of pure think/generate time with zero new tool-use is abnormal; the
+  // pending-guard below already excludes legitimate long-running commands, so
+  // this only fires on a genuinely wedged turn. Single knob, easy to tune.
+  stallMs: 8 * 60_000,
+  // a tool that has been "running" for 20m with no result is almost certainly a
+  // hung command (the pending-guard would otherwise mask it forever).
+  pendingStallMs: 20 * 60_000,
+};
+
+/** Pure stall decision for a *working* agent, given its latest activity snapshot. */
+export function isStalled(snap: ActivitySnapshot, now: number, cfg: StallConfig): boolean {
+  if (snap.lastTs <= 0) return false; // no tool activity to measure a gap against yet
+  const gap = now - snap.lastTs;
+  return snap.pending ? gap > cfg.pendingStallMs : gap > cfg.stallMs;
+}
+
+/**
+ * Synchronously derive a snapshot from a session JSONL. Missing/unreadable
+ * (e.g. a just-spawned session with no transcript) → null, treated as "no signal".
+ */
+export function readSnapshot(path: string): ActivitySnapshot | null {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  const entries = parseActivity(text, 5);
+  if (entries.length === 0) return null;
+  const last = entries[entries.length - 1]!;
+  return { lastTs: last.ts, pending: last.status === "pending" };
+}

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -202,6 +202,71 @@ test("clears an active block when the agent disappears", () => {
   expect(blocks[blocks.length - 1]).toEqual({ id: s.id, block: null }); // block cleared
 });
 
+test("flags a silent working agent as a stall, fires once, re-arms on resume", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const blocks: { id: string; block: unknown }[] = [];
+
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working",
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => "still chewing on it",
+  };
+
+  let clock = 1_700_000_000_000; // realistic ms epoch so a past lastTs stays positive
+  let stalled = true;
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    () => ({ lastTs: stalled ? clock - 600_000 : clock, pending: false }),
+    { stallMs: 1, pendingStallMs: 1 }, // 10m-old activity counts as stalled; fresh does not
+    30_000,
+  );
+
+  poller.tick();
+  expect(blocks).toHaveLength(1);
+  expect((blocks[0]!.block as any).shape).toBe("stall");
+  expect((blocks[0]!.block as any).tail).toEqual(["still chewing on it"]);
+
+  // throttled within stallCheckMs → no re-probe
+  clock += 1000;
+  poller.tick();
+  expect(blocks).toHaveLength(1);
+
+  // past the throttle, still stalled → fires only once per episode
+  clock += 30_000;
+  poller.tick();
+  expect(blocks).toHaveLength(1);
+
+  // activity resumes → one clear, then re-arms for the next episode
+  stalled = false;
+  clock += 30_000;
+  poller.tick();
+  expect(blocks).toHaveLength(2);
+  expect(blocks[1]).toEqual({ id: s.id, block: null });
+
+  stalled = true;
+  clock += 30_000;
+  poller.tick();
+  expect(blocks).toHaveLength(3);
+  expect((blocks[2]!.block as any).shape).toBe("stall");
+});
+
 test("does not emit onBlock when reading the terminal throws", () => {
   const store = new SessionStore(":memory:");
   store.create(baseSession);

--- a/test/stall.test.ts
+++ b/test/stall.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { isStalled, readSnapshot, DEFAULT_STALL } from "../src/stall";
+
+const NOW = 1_000_000_000_000;
+
+test("not stalled when last tool finished within the window", () => {
+  const snap = { lastTs: NOW - 2 * 60_000, pending: false };
+  expect(isStalled(snap, NOW, DEFAULT_STALL)).toBe(false);
+});
+
+test("stalled when a finished tool went quiet past stallMs", () => {
+  const snap = { lastTs: NOW - 9 * 60_000, pending: false };
+  expect(isStalled(snap, NOW, DEFAULT_STALL)).toBe(true);
+});
+
+test("a long-running (pending) tool is NOT a stall until the hung-command ceiling", () => {
+  const running = { lastTs: NOW - 9 * 60_000, pending: true }; // 9m build, still going
+  expect(isStalled(running, NOW, DEFAULT_STALL)).toBe(false);
+  const hung = { lastTs: NOW - 21 * 60_000, pending: true };
+  expect(isStalled(hung, NOW, DEFAULT_STALL)).toBe(true);
+});
+
+test("no measurable activity yet → never stalled", () => {
+  expect(isStalled({ lastTs: 0, pending: false }, NOW, DEFAULT_STALL)).toBe(false);
+});
+
+test("readSnapshot returns null for a missing transcript", () => {
+  expect(readSnapshot(join(tmpdir(), "does-not-exist-shepherd.jsonl"))).toBeNull();
+});
+
+test("readSnapshot reads lastTs + pending from the newest tool_use", () => {
+  const dir = mkdtempSync(join(tmpdir(), "stall-"));
+  const path = join(dir, "s.jsonl");
+  try {
+    // an Edit (paired result → ok) then a Bash with no result yet (pending)
+    const lines = [
+      JSON.stringify({
+        timestamp: "2026-05-31T10:00:00.000Z",
+        message: { content: [{ type: "tool_use", id: "u1", name: "Edit", input: {} }] },
+      }),
+      JSON.stringify({
+        timestamp: "2026-05-31T10:00:01.000Z",
+        message: { content: [{ type: "tool_result", tool_use_id: "u1", is_error: false }] },
+      }),
+      JSON.stringify({
+        timestamp: "2026-05-31T10:05:00.000Z",
+        message: {
+          content: [{ type: "tool_use", id: "u2", name: "Bash", input: { command: "bun test" } }],
+        },
+      }),
+    ];
+    writeFileSync(path, lines.join("\n"));
+    const snap = readSnapshot(path);
+    expect(snap).not.toBeNull();
+    expect(snap!.pending).toBe(true); // newest tool_use (u2) has no result
+    expect(snap!.lastTs).toBe(Date.parse("2026-05-31T10:05:00.000Z"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -112,6 +112,7 @@
   "topbar_settings_aria": "Einstellungen",
   "triage_close_aria": "Schließen",
   "triage_empty": "Keine Agenten warten auf dich.",
+  "triage_stall_note": "Still — seit einer Weile keine Aktivität. Möglicherweise hängt er; anstoßen oder Terminal öffnen.",
   "triage_checkbox_aria": "{desig} auswählen",
   "triage_reply_placeholder": "Antwort eingeben…",
   "triage_reply_aria": "Auf {desig} antworten",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -112,6 +112,7 @@
   "topbar_settings_aria": "settings",
   "triage_close_aria": "Close",
   "triage_empty": "No agents are waiting on you.",
+  "triage_stall_note": "Quiet — no activity for a while. May be stuck; nudge it or open the terminal.",
   "triage_checkbox_aria": "Select {desig}",
   "triage_reply_placeholder": "Type a reply…",
   "triage_reply_aria": "Reply to {desig}",

--- a/ui/src/lib/components/TriageDrawer.svelte
+++ b/ui/src/lib/components/TriageDrawer.svelte
@@ -59,9 +59,13 @@
         <span class="waited">{waited(e.since)}</span>
       </div>
 
+      {#if e.reason.shape === "stall"}
+        <p class="stall-note">{m.triage_stall_note()}</p>
+      {/if}
+
       <pre class="tail">{e.reason.tail.join("\n")}</pre>
 
-      {#if e.reason.shape === "awaiting-input"}
+      {#if e.reason.shape === "awaiting-input" || e.reason.shape === "stall"}
         <form
           class="reply"
           onsubmit={(ev) => {
@@ -166,6 +170,11 @@
   .waited {
     color: var(--color-amber);
     font-variant-numeric: tabular-nums;
+    font-size: 12px;
+  }
+  .stall-note {
+    margin: 0;
+    color: var(--color-amber);
     font-size: 12px;
   }
   .tail {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -37,7 +37,7 @@ export interface TodoDoc {
   content: string;
 }
 
-export type BlockShape = "menu" | "yes-no" | "awaiting-input";
+export type BlockShape = "menu" | "yes-no" | "awaiting-input" | "stall";
 export interface BlockOption {
   label: string;
   send: string;


### PR DESCRIPTION
## What

Adds **silent-stall detection** to the attention-routing layer. Blocked-triage already surfaces agents that *explicitly* ask for you (herdr `blocked`). A `working` agent that's gone quiet — stuck in a loop, hung on a command, or wedged mid-turn — emitted **zero** signal, so the only recourse was to open each terminal and read it. That polling is the residual bottleneck the product exists to kill.

## How

- `src/stall.ts` — pure `isStalled()` decision + a synchronous `readSnapshot()` that pulls the newest tool-use ts + pending-state from a session's `~/.claude` JSONL.
- `src/poller.ts` — for `working` sessions, throttled (30s) stall probe. Flags a stall when no new tool-use within **8m**.
  - **Pending-tool guard:** a tool still running (no `tool_result` yet — e.g. a long `bun install`/test run/build) is *not* a stall until a **20m** hung-command ceiling. This is the false-positive killer; the exact threshold matters less than the guard.
  - Fires **once per episode** (fixed signature), **re-arms** when activity resumes.
- Surfaces as a new `stall` `BlockShape` in the **existing** triage drawer (`TriageDrawer.svelte`) with a "quiet — may be stuck" note + nudge box; counts toward the Needs-you badge automatically.
- i18n: `triage_stall_note` added to EN + DE (parity gate green).

ToS-clean — pure observation (reads transcript + terminal tail), no new steering. Push payload follows once the Web Push PR (#43) lands; the once-per-episode emission is already in place for it to subscribe to.

## Test

- `test/stall.test.ts` — `isStalled` windows, pending-guard, hung ceiling, `readSnapshot` parsing.
- `test/poller.test.ts` — stall emission, throttle, fire-once, clear-on-resume, re-arm.
- Full suite: backend 298 pass / tsc / eslint clean; UI svelte-check clean, 53 pass, i18n parity (166 keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)