### PR TITLE
fix(push): stall-specific notification body

### DIFF
--- a/src/push.ts
+++ b/src/push.ts
@@ -39,6 +39,7 @@ const NOTIFY_TEXT = {
     blockedTitle: (name: string) => `${name} — needs you`,
     menu: "Waiting on a menu choice.",
     "yes-no": "Waiting on a yes/no.",
+    stall: "Quiet — no recent activity; may be stuck.",
     other: "Waiting on your input.",
   },
   de: {
@@ -47,6 +48,7 @@ const NOTIFY_TEXT = {
     blockedTitle: (name: string) => `${name} — braucht dich`,
     menu: "Wartet auf eine Menüauswahl.",
     "yes-no": "Wartet auf ein Ja/Nein.",
+    stall: "Ruhig — keine Aktivität; möglicherweise hängengeblieben.",
     other: "Wartet auf deine Eingabe.",
   },
 } as const;
@@ -63,6 +65,8 @@ export function blockSummary(reason: BlockReason, locale: string = "en"): string
       return t.menu;
     case "yes-no":
       return t["yes-no"];
+    case "stall":
+      return t.stall;
     default:
       return t.other;
   }

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -108,6 +108,9 @@ test("blockSummary maps shapes to human text", () => {
   expect(blockSummary({ shape: "menu", options: [], tail: [] })).toMatch(/menu/i);
   expect(blockSummary({ shape: "yes-no", options: [], tail: [] })).toMatch(/yes/i);
   expect(blockSummary({ shape: "awaiting-input", options: [], tail: [] })).toMatch(/input/i);
+  // a stall reads as quiet/stuck, not a generic input prompt (EN + DE)
+  expect(blockSummary({ shape: "stall", options: [], tail: [] })).toMatch(/quiet|stuck/i);
+  expect(blockSummary({ shape: "stall", options: [], tail: [] }, "de")).toMatch(/ruhig|hängen/i);
 });
 
 test("buildPayload localizes title + body by subscriber locale", () => {


### PR DESCRIPTION
A stalled agent already triggers a Web Push (the poller emits `session:block` with shape `stall`, which #43's `attachPush` fans out) — no wiring was missing. But `blockSummary()` had no `stall` case, so the notification body fell through to the generic **"Waiting on your input."** This adds a stall-specific line (EN + DE) so the push reads as quiet/stuck.

Server-side notification copy only (`src/push.ts` + test); no UI catalog change.

## Checks
Full pre-push gate passed (tsc, eslint, prettier, root + ui tests incl. new stall-body assertions, i18n parity, build).