### PR TITLE
fix(ui): theme-aware gradient + elevation for limits popover

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -387,9 +387,10 @@
     right: 0;
     z-index: 50;
     min-width: 200px;
-    background: linear-gradient(180deg, var(--color-panel), #0c100f);
+    background: linear-gradient(180deg, var(--color-panel), var(--color-panel-2));
     border: 1px solid var(--color-line-bright);
     border-radius: 2px;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
     padding: 10px 11px;
     display: flex;
     flex-direction: column;
@@ -557,8 +558,9 @@
       top: calc(100% + 9px);
       right: 0;
       white-space: nowrap;
-      background: linear-gradient(180deg, var(--color-panel), #0c100f);
+      background: linear-gradient(180deg, var(--color-panel), var(--color-panel-2));
       border: 1px solid var(--color-line-bright);
+      box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
       color: var(--color-ink-bright);
       font-size: 10.5px;
       letter-spacing: 0.06em;


### PR DESCRIPTION
## Problem
The limits popover (5H / WK usage breakdown) gradiented from `var(--color-panel)` to a **hardcoded** `#0c100f` — the dark theme's `--panel-2`. In light mode that's a near-white→near-black gradient, which looks broken.

## Fix
- `.gauge-pop` — use `var(--color-panel-2)` instead of hardcoded `#0c100f` so the gradient stays subtle and theme-correct in both themes; add `box-shadow` to match the elevation of sibling popovers (EmojiPicker, RepoSelect, GitRail).
- `.tip::after` (gauge hover tooltip) — identical hardcoded bug, fixed the same way.

CSS-only; no new user-facing strings, so i18n is unaffected. `bun run check` passes (0 errors, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)