### PR TITLE
fix(ui): empty-herd "New Task" text opens new-task modal

### DIFF
--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -8,12 +8,14 @@
     selectedId,
     nowMs,
     onselect,
+    onnew,
     git,
   }: {
     sessions: Session[];
     selectedId: string | null;
     nowMs: number;
     onselect: (id: string) => void;
+    onnew: () => void;
     git: Record<string, GitState>;
   } = $props();
 </script>
@@ -25,7 +27,7 @@
   </div>
   <div class="units">
     {#if sessions.length === 0}
-      <div class="empty micro">{m.herd_empty()}</div>
+      <button type="button" class="empty micro" onclick={onnew}>{m.herd_empty()}</button>
     {:else}
       {#each sessions as session (session.id)}
         <UnitRow
@@ -101,8 +103,17 @@
   }
 
   .empty {
+    width: 100%;
     padding: 24px 14px;
     text-align: center;
     color: var(--color-faint);
+    border: 0;
+    background: none;
+    font-family: inherit;
+    cursor: pointer;
+    transition: color 0.12s ease;
+  }
+  .empty:hover {
+    color: var(--color-ink);
   }
 </style>

--- a/ui/src/lib/components/HerdGrid.svelte
+++ b/ui/src/lib/components/HerdGrid.svelte
@@ -8,18 +8,20 @@
     selectedId,
     nowMs,
     onselect,
+    onnew,
     git,
   }: {
     sessions: Session[];
     selectedId: string | null;
     nowMs: number;
     onselect: (id: string) => void;
+    onnew: () => void;
     git: Record<string, GitState>;
   } = $props();
 </script>
 
 {#if sessions.length === 0}
-  <div class="empty">{m.herd_empty()}</div>
+  <button type="button" class="empty" onclick={onnew}>{m.herd_empty()}</button>
 {:else}
   <div class="herd-grid">
     {#each sessions as session (session.id)}
@@ -47,14 +49,24 @@
   }
   .empty {
     flex: 1;
+    width: 100%;
     border: 1px solid var(--color-line);
     background: var(--color-panel);
     display: flex;
     align-items: center;
     justify-content: center;
     color: var(--color-faint);
+    font-family: inherit;
     font-size: 10.5px;
     letter-spacing: 0.18em;
     text-transform: uppercase;
+    cursor: pointer;
+    transition:
+      color 0.12s ease,
+      border-color 0.12s ease;
+  }
+  .empty:hover {
+    color: var(--color-ink);
+    border-color: var(--color-line-bright);
   }
 </style>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -140,6 +140,7 @@
           {selectedId}
           {nowMs}
           onselect={(id) => selectUnit(id)}
+          onnew={() => (showNew = true)}
           git={store.git}
         />
       </div>
@@ -171,6 +172,7 @@
           selectedId = id;
           viewMode = "focus";
         }}
+        onnew={() => (showNew = true)}
       />
     </div>
   {:else}
@@ -180,6 +182,7 @@
         {selectedId}
         {nowMs}
         onselect={(id) => selectUnit(id)}
+        onnew={() => (showNew = true)}
         git={store.git}
       />
       {#if selected}


### PR DESCRIPTION
## What

The empty-state shown when there are no open sessions ("No tasks — + New Task") was a plain non-interactive `<div>`, so clicking the "New Task" text did nothing.

## Fix

- `Herd.svelte` / `HerdGrid.svelte`: added `onnew: () => void` prop; converted the empty-state element from `<div>` → `<button onclick={onnew}>` with hover affordance + reset button styling.
- `+page.svelte`: pass `onnew={() => (showNew = true)}` (the same handler ActionBar's "+ New Task" button uses) to all four `Herd`/`HerdGrid` instances (mobile, all-mode, desktop).

Clicking the empty-state text now opens the New Task modal, identical to the button.

## Validation

- `cd ui && bun run check` — 0 errors
- `bun run check:i18n` — locales in parity
- eslint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)