### PR TITLE
fix(config): default repo-root ceiling to $HOME (was ~/Work)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ All via environment variables (`src/config.ts`):
 | `SHEPHERD_PORT`          | `7330`                                | HTTP/WS listen port                                                             |
 | `SHEPHERD_HOST`          | `127.0.0.1`                           | Bind address; loopback-only by default (set `0.0.0.0` to expose all NICs)       |
 | `SHEPHERD_DB`            | `~/.shepherd/shepherd.db`             | SQLite session store path                                                       |
-| `SHEPHERD_REPO_ROOT`     | `~/Work`                              | Repos must live under this root (spawn is confined to it)                       |
+| `SHEPHERD_REPO_ROOT`     | `~` (home)                            | Repos must live under this root (spawn is confined to it)                       |
 | `SHEPHERD_ALLOWED_HOSTS` | `localhost,127.0.0.1,::1,[::1]`       | Comma-separated origin hostnames allowed for writes + WS (CSRF/CSWSH guard)     |
 | `SHEPHERD_TOKEN`         | _(none)_                              | When set, require `Authorization: Bearer <token>`                               |
 | `HERDR_BIN`              | `herdr`                               | Path to the herdr binary                                                        |

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,12 +26,13 @@ export const config = {
     `${process.env.CLAUDE_CONFIG_DIR ?? `${process.env.HOME}/.claude`}/projects`,
   // security
   // immutable ceiling: the absolute outermost dir the UI may ever reach. captured
-  // once from the env (or ~/Work) and NEVER mutated by settings. the settable
-  // `repoRoot` below and the dir browser must always stay within this.
-  rootCeiling: process.env.SHEPHERD_REPO_ROOT ?? `${process.env.HOME}/Work`,
+  // once from the env (or $HOME) and NEVER mutated by settings. the settable
+  // `repoRoot` below and the dir browser must always stay within this. defaults to
+  // $HOME so a fresh install can reach any repo without needing SHEPHERD_REPO_ROOT.
+  rootCeiling: process.env.SHEPHERD_REPO_ROOT ?? process.env.HOME ?? "/",
   // active repo root: defaults to the ceiling, but is UI-configurable (boot-override
   // from the store + PUT /api/settings) so long as it stays inside `rootCeiling`.
-  repoRoot: process.env.SHEPHERD_REPO_ROOT ?? `${process.env.HOME}/Work`,
+  repoRoot: process.env.SHEPHERD_REPO_ROOT ?? process.env.HOME ?? "/",
   allowedOriginHosts: (process.env.SHEPHERD_ALLOWED_HOSTS ?? "localhost,127.0.0.1,::1,[::1]").split(
     ",",
   ),

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -5,7 +5,7 @@ import { timingSafeEqual, randomUUID } from "node:crypto";
 import { MODELS, type CreateSessionInput, type Steer } from "./types";
 import { stagingDir } from "./uploads";
 
-/** Expand a leading `~` / `~/` to the user's home dir (the UI suggests `~/Work/…`). */
+/** Expand a leading `~` / `~/` to the user's home dir (the UI suggests `~/<repo>/…`). */
 export function expandHome(p: string): string {
   if (p === "~") return homedir();
   if (p.startsWith("~/")) return join(homedir(), p.slice(2));


### PR DESCRIPTION
## What

Default the repo-root **ceiling** and active **repoRoot** to `$HOME` instead of `~/Work`.

## Why

Traversal in the dir browser / `validateRoot` is clamped to the immutable `rootCeiling`. With the old `~/Work` default, a user whose repos live elsewhere couldn't pick their actual repo-root on a fresh install without first setting `SHEPHERD_REPO_ROOT` — a hassle at first-run. Defaulting the ceiling to `$HOME` makes any repo under home reachable out of the box; users who genuinely need to escape home still set the env var as before.

## Changes

- `src/config.ts` — `rootCeiling` + `repoRoot` default to `process.env.HOME ?? "/"`; comment updated.
- `README.md` — env table default `~/Work` → `~` (home).
- `src/validate.ts` — stale `~/Work/…` comment → `~/<repo>/…`.

## Verification

- `bunx tsc --noEmit` clean
- 337/337 root tests pass
- eslint clean
- UI untouched (fetches default from server; nothing hardcoded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)