### PR TITLE
fix(ui): improve terminal legibility in light mode

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -5,7 +5,7 @@
   import type { Session, SessionUsage } from "$lib/types";
   import { elapsed, STATUS_COLOR, statusLabel, formatTokens } from "$lib/format";
   import { connectPty, type PtyConn } from "$lib/pty";
-  import { theme, xtermTheme } from "$lib/theme.svelte";
+  import { theme, xtermTheme, xtermMinContrast } from "$lib/theme.svelte";
   import { getSessionUsage, uploadImage } from "$lib/api";
   import { imageFilesFromItems } from "$lib/clipboard";
   import TodoPanel from "$lib/components/TodoPanel.svelte";
@@ -150,6 +150,7 @@
       fontFamily: "'JetBrains Mono', monospace",
       fontSize: mobile || touch ? 11 : 12.5,
       theme: xtermTheme(initialTheme),
+      minimumContrastRatio: xtermMinContrast(initialTheme),
       cursorBlink: true,
     });
     termRef = term;
@@ -315,6 +316,7 @@
     const term = termRef;
     if (!term) return;
     term.options.theme = xtermTheme(resolved);
+    term.options.minimumContrastRatio = xtermMinContrast(resolved);
     term.refresh(0, Math.max(0, term.rows - 1));
   });
 </script>

--- a/ui/src/lib/theme.svelte.ts
+++ b/ui/src/lib/theme.svelte.ts
@@ -88,3 +88,23 @@ export function xtermTheme(resolved: Resolved): { background: string; foreground
     foreground: read("--color-term-fg", fallback.foreground),
   };
 }
+
+/**
+ * Contrast floor xterm enforces between each glyph and its cell background.
+ * Claude's TUI is tuned for a dark terminal: on the near-white light surface its
+ * bright/white and washed-out secondary greys drop near-invisible. xterm's
+ * `minimumContrastRatio` darkens only the under-contrast pairs (hue preserved)
+ * back to legible; body text already above the floor is left alone.
+ *
+ * The floor is `7`, not the WCAG-AA `4.5`, because Claude renders its secondary
+ * lines (search results, tool output, "(ctrl+o to expand)") with the ANSI *dim*
+ * attribute, and xterm only holds dim cells to *half* the configured ratio
+ * (`minimumContrastRatio / 2`). `7` lands dim text at ~3.5:1 — clearly readable
+ * yet still visibly secondary — while non-dim glyphs get the full 7:1.
+ *
+ * Dark mode is already legible — `1` disables enforcement (xterm's no-op fast
+ * path), so this never touches the dark palette.
+ */
+export function xtermMinContrast(resolved: Resolved): number {
+  return resolved === "light" ? 7 : 1;
+}


### PR DESCRIPTION
## Problem

In light mode, the embedded xterm terminal showed Claude's TUI output as washed-out grey on near-white — secondary lines (search results, tool output, `(ctrl+o to expand)`) were barely legible.

**Root cause:** the terminal only set `background`/`foreground`, leaving xterm's dark-tuned defaults. Claude Code (Ink) renders secondary text with the ANSI *dim* attribute, which composites to ~2.6:1 contrast on the light surface.

## Fix

Enforce an xterm `minimumContrastRatio` floor in **light mode only** — it darkens just the under-contrast glyphs (hue preserved) and leaves already-legible body text alone.

- `theme.svelte.ts` — new `xtermMinContrast(resolved)`: `7` for light, `1` (no-op fast path) for dark.
- `Viewport.svelte` — applied at terminal construction and in the live theme-switch effect.

**Why 7, not WCAG-AA 4.5:** xterm holds *dim* cells to only half the configured ratio, so 4.5 would target dim text at 2.25:1 and leave the offending grey unchanged. `7` lands dim text at ~3.5:1 (legible, still visibly secondary) and non-dim glyphs at the full 7:1. Body text (~11.8:1) is already above the floor; dark mode is untouched.

Verified against the installed `@xterm/xterm@6.0.0` source — `_applyMinimumContrast` runs in the DOM render path for indexed, truecolor, and dim cells.

## Verification

- `cd ui && bun run check` — 0 errors
- eslint / prettier clean (pre-push passed)
- Visual confirmation pending on the running app in light mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)