### PR TITLE
chore(format): exclude CHANGELOG.md from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,9 @@
 # Lockfiles
 bun.lock
 
+# Generated changelog — leave its formatting alone
+CHANGELOG.md
+
 # Build outputs
 node_modules
 .svelte-kit


### PR DESCRIPTION
Adds `CHANGELOG.md` to `.prettierignore` so prettier (and lint-staged) leave the generated changelog's formatting alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)