### PR TITLE
fix(ui): i18n the update-available modal (was hardcoded German)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -182,5 +182,13 @@
   "emojipicker_search": "Emoji suchen…",
   "emojipicker_custom": "Emoji einfügen",
   "emojipicker_clear": "Symbol entfernen",
-  "reposelect_set_icon": "Projektsymbol setzen"
+  "reposelect_set_icon": "Projektsymbol setzen",
+  "updatemodal_available": "Update verfügbar",
+  "updatemodal_commits_one": "neuer Commit auf main",
+  "updatemodal_commits_other": "neue Commits auf main",
+  "updatemodal_status": "⟳ Wird aktualisiert… Server startet neu, die Seite lädt automatisch neu.",
+  "updatemodal_update_failed": "Update fehlgeschlagen",
+  "updatemodal_later": "Später",
+  "updatemodal_updating": "Aktualisiere…",
+  "updatemodal_update_now": "Update jetzt"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -182,5 +182,13 @@
   "emojipicker_search": "search emoji…",
   "emojipicker_custom": "paste any emoji",
   "emojipicker_clear": "remove icon",
-  "reposelect_set_icon": "set project icon"
+  "reposelect_set_icon": "set project icon",
+  "updatemodal_available": "Update available",
+  "updatemodal_commits_one": "new commit on main",
+  "updatemodal_commits_other": "new commits on main",
+  "updatemodal_status": "⟳ Updating… The server is restarting; the page will reload automatically.",
+  "updatemodal_update_failed": "update failed",
+  "updatemodal_later": "Later",
+  "updatemodal_updating": "Updating…",
+  "updatemodal_update_now": "Update now"
 }

--- a/ui/src/lib/components/UpdateModal.svelte
+++ b/ui/src/lib/components/UpdateModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { UpdateStatus } from "$lib/types";
   import { applyUpdate } from "$lib/api";
+  import { m } from "$lib/paraglide/messages";
 
   let {
     update,
@@ -24,7 +25,7 @@
       await applyUpdate();
       onconfirm?.(); // store marks `updating`; the page reloads once the new build is live
     } catch (e) {
-      error = e instanceof Error ? e.message : "update failed";
+      error = e instanceof Error ? e.message : m.updatemodal_update_failed();
       submitting = false;
     }
   }
@@ -41,16 +42,18 @@
 >
   <div class="card bracket">
     <div class="chead">
-      <span class="micro">Update&nbsp;verfügbar</span>
+      <span class="micro">{m.updatemodal_available()}</span>
       {#if !busy}
-        <button type="button" class="x" onclick={() => onclose?.()} aria-label="close">✕</button>
+        <button type="button" class="x" onclick={() => onclose?.()} aria-label={m.common_close()}
+          >✕</button
+        >
       {/if}
     </div>
 
     <div class="summary">
       <span class="count">{update.behind}</span>
       <span class="micro"
-        >{update.behind === 1 ? "neuer Commit" : "neue Commits"} auf&nbsp;main</span
+        >{update.behind === 1 ? m.updatemodal_commits_one() : m.updatemodal_commits_other()}</span
       >
       {#if update.current && update.latest}
         <span class="shas micro">{update.current} → {update.latest}</span>
@@ -67,18 +70,18 @@
     </div>
 
     {#if busy}
-      <div class="status">
-        ⟳ Wird aktualisiert… Server startet neu, die Seite lädt automatisch neu.
-      </div>
+      <div class="status">{m.updatemodal_status()}</div>
     {/if}
     {#if error}<div class="err">{error}</div>{/if}
 
     <div class="actions">
       {#if !busy}
-        <button type="button" class="later" onclick={() => onclose?.()}>Später</button>
+        <button type="button" class="later" onclick={() => onclose?.()}
+          >{m.updatemodal_later()}</button
+        >
       {/if}
       <button type="button" class="run" onclick={confirm} disabled={busy}>
-        {busy ? "Aktualisiere…" : "Update jetzt"}
+        {busy ? m.updatemodal_updating() : m.updatemodal_update_now()}
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Problem

The "Update available" modal (`UpdateModal.svelte`) bypassed Paraglide entirely — UI chrome was hardcoded in German (`Update verfügbar`, `neue Commits auf main`, the updating/restart status, `Später`, `Aktualisiere…`, `Update jetzt`), plus two stray English strings (`aria-label="close"`, the `"update failed"` error fallback). Violates the project i18n requirement that **all** authored chrome route through `m.*`.

## Fix

- Added 8 `updatemodal_*` keys to **both** `ui/messages/en.json` and `ui/messages/de.json`. Commit count kept as singular/plural variant keys (`_commits_one` / `_commits_other`), selected in-component — matches the existing catalog convention (no plural-match syntax in use).
- Reused `common_close` for the close-button `aria-label`.
- Wired the component to `m.*`; the error fallback now uses `m.updatemodal_update_failed()`.

Dropped the original `&nbsp;` non-breaking spaces in favor of plain spaces — these short uppercase micro-labels won't wrap awkwardly.

## Gates

- `check:i18n` → 2 locales in parity (191 keys each)
- `svelte-check` → 0 errors / 0 warnings
- `prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)