### PR TITLE
fix(stall): clear flag on resumed activity + manual dismiss

### DIFF
--- a/src/activity.ts
+++ b/src/activity.ts
@@ -118,6 +118,29 @@ export function parseActivity(text: string, limit = DEFAULT_LIMIT): ActivityEntr
   return limit >= 0 ? entries.slice(-limit) : entries;
 }
 
+/**
+ * Newest record timestamp across the whole transcript — assistant turns AND the
+ * user records that carry tool_results. Unlike a tool_use entry's `ts` (the
+ * tool's *start*), this advances on tool completions and resumed output, so it
+ * reflects genuine forward progress. 0 when no record has a parseable timestamp.
+ */
+export function latestRecordTs(text: string): number {
+  let max = 0;
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let o: any;
+    try {
+      o = JSON.parse(t);
+    } catch {
+      continue;
+    }
+    const ts = Date.parse(o?.timestamp) || 0;
+    if (ts > max) max = ts;
+  }
+  return max;
+}
+
 /** Read + parse one session's JSONL. Missing/unreadable file → []. */
 export async function sessionActivity(
   path: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ const server = serve(
     resolveForge: (dir) => detectForge(dir, config.forges),
     prCache: prPoller,
     push,
+    poller,
   },
   config.port,
 );

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -116,6 +116,19 @@ export class StatusPoller {
     this.onBlock(id, reason);
   }
 
+  /**
+   * Manually clear a *stall* flag without re-arming it: broadcasts the clear but
+   * keeps `lastSig` so `maybeStall`'s once-per-episode guard suppresses an
+   * immediate re-fire. The episode re-arms on its own when activity resumes
+   * (the `!isStalled` path in `maybeStall` calls `clearBlock`), so a later
+   * genuine stall still surfaces. No-op (returns false) unless a stall is live.
+   */
+  acknowledgeStall(id: string): boolean {
+    if (this.lastSig.get(id) !== STALL_SIG) return false;
+    this.onBlock(id, null);
+    return true;
+  }
+
   private clearBlock(id: string): void {
     if (!this.lastSig.has(id)) return;
     this.lastSig.delete(id);

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import type { HerdrDriver } from "./herdr";
 import type { GitForge, GitState, MergeMethod } from "./forge/types";
 import type { PrCache } from "./pr-poller";
 import type { PushService } from "./push";
+import type { StatusPoller } from "./poller";
 import { join, normalize } from "node:path";
 import type { ServerWebSocket } from "bun";
 
@@ -72,6 +73,8 @@ export interface AppDeps {
   prCache?: PrCache;
   /** Web Push delivery; absent in tests that don't exercise notifications. */
   push?: Pick<PushService, "publicKey" | "subscribe" | "unsubscribe">;
+  /** Status poller; used to manually dismiss a stall flag. Absent in tests. */
+  poller?: Pick<StatusPoller, "acknowledgeStall">;
 }
 
 const sessionUsage = (s: Session) =>
@@ -209,6 +212,10 @@ export function makeApp(deps: AppDeps) {
           }
           const ok = deps.service.reply(parts[2], (body as { text: string }).text);
           return ok ? json({ ok: true }) : json({ error: "not found" }, 404);
+        }
+        if (req.method === "POST" && parts[2] && parts[3] === "dismiss-stall") {
+          const ok = deps.poller?.acknowledgeStall(parts[2]) ?? false;
+          return ok ? json({ ok: true }) : json({ error: "no stall to dismiss" }, 404);
         }
       }
       // ── git host (forge) actions: /api/sessions/:id/git[/pr|/merge|/redeploy] ──

--- a/src/stall.ts
+++ b/src/stall.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "node:fs";
-import { parseActivity } from "./activity";
+import { latestRecordTs, parseActivity } from "./activity";
 
 /** A minimal read of a session's most-recent tool activity, for stall detection. */
 export interface ActivitySnapshot {
-  /** ms epoch of the most recent tool_use, or 0 if the transcript has none yet. */
+  /** ms epoch of the newest transcript record — tool completions and resumed
+   *  output included, not just a new tool_use's start. 0 if none yet. */
   lastTs: number;
   /** the newest tool_use has no tool_result yet → a tool is still running. */
   pending: boolean;
@@ -36,6 +37,11 @@ export function isStalled(snap: ActivitySnapshot, now: number, cfg: StallConfig)
 /**
  * Synchronously derive a snapshot from a session JSONL. Missing/unreadable
  * (e.g. a just-spawned session with no transcript) → null, treated as "no signal".
+ *
+ * `lastTs` tracks the newest record of *any* kind so a completing long-running
+ * tool or a resumed turn clears a stall; `pending` still keys off the newest
+ * tool_use so a genuinely running command keeps its longer hung-command window.
+ * A transcript with no tool_use can't stall → null.
  */
 export function readSnapshot(path: string): ActivitySnapshot | null {
   let text: string;
@@ -47,5 +53,5 @@ export function readSnapshot(path: string): ActivitySnapshot | null {
   const entries = parseActivity(text, 5);
   if (entries.length === 0) return null;
   const last = entries[entries.length - 1]!;
-  return { lastTs: last.ts, pending: last.status === "pending" };
+  return { lastTs: latestRecordTs(text), pending: last.status === "pending" };
 }

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -267,6 +267,69 @@ test("flags a silent working agent as a stall, fires once, re-arms on resume", (
   expect((blocks[2]!.block as any).shape).toBe("stall");
 });
 
+test("acknowledgeStall clears the flag without re-firing while still stalled", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const blocks: { id: string; block: unknown }[] = [];
+
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working",
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => "still chewing on it",
+  };
+
+  let clock = 1_700_000_000_000;
+  let stalled = true;
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    () => ({ lastTs: stalled ? clock - 600_000 : clock, pending: false }),
+    { stallMs: 1, pendingStallMs: 1 },
+    30_000,
+  );
+
+  poller.tick(); // stall fires
+  expect(blocks).toHaveLength(1);
+  expect((blocks[0]!.block as any).shape).toBe("stall");
+
+  // manual dismiss: clears the flag now, but keeps the once-per-episode guard
+  expect(poller.acknowledgeStall(s.id)).toBe(true);
+  expect(blocks).toHaveLength(2);
+  expect(blocks[1]).toEqual({ id: s.id, block: null });
+
+  // still stalled on the next probe → does NOT re-announce (episode acknowledged)
+  clock += 30_000;
+  poller.tick();
+  expect(blocks).toHaveLength(2);
+
+  // activity resumes → episode re-arms; acknowledgeStall now no-ops (no live stall)
+  stalled = false;
+  clock += 30_000;
+  poller.tick();
+  expect(poller.acknowledgeStall(s.id)).toBe(false);
+
+  // a later stall fires again
+  stalled = true;
+  clock += 30_000;
+  poller.tick();
+  expect((blocks[blocks.length - 1]!.block as any).shape).toBe("stall");
+});
+
 test("does not emit onBlock when reading the terminal throws", () => {
   const store = new SessionStore(":memory:");
   store.create(baseSession);

--- a/test/stall.test.ts
+++ b/test/stall.test.ts
@@ -61,3 +61,63 @@ test("readSnapshot reads lastTs + pending from the newest tool_use", () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("readSnapshot advances lastTs to a long tool's completion, not its start", () => {
+  const dir = mkdtempSync(join(tmpdir(), "stall-"));
+  const path = join(dir, "s.jsonl");
+  try {
+    // a Bash that started 25m ago but only just finished — the result record is
+    // the freshest activity, so lastTs must reflect it (else the stall sticks).
+    const start = "2026-05-31T10:00:00.000Z";
+    const done = "2026-05-31T10:25:00.000Z";
+    const lines = [
+      JSON.stringify({
+        timestamp: start,
+        message: {
+          content: [{ type: "tool_use", id: "u1", name: "Bash", input: { command: "build" } }],
+        },
+      }),
+      JSON.stringify({
+        timestamp: done,
+        message: { content: [{ type: "tool_result", tool_use_id: "u1", is_error: false }] },
+      }),
+    ];
+    writeFileSync(path, lines.join("\n"));
+    const snap = readSnapshot(path);
+    expect(snap!.pending).toBe(false); // u1 now has a result
+    expect(snap!.lastTs).toBe(Date.parse(done)); // completion, not the 25m-old start
+    // measured from completion, it is NOT stalled
+    expect(isStalled(snap!, Date.parse(done) + 60_000, DEFAULT_STALL)).toBe(false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readSnapshot advances lastTs on a resumed turn with no new tool_use", () => {
+  const dir = mkdtempSync(join(tmpdir(), "stall-"));
+  const path = join(dir, "s.jsonl");
+  try {
+    // last tool_use is old, but the agent has since emitted a fresh assistant
+    // turn (text only) — that progress must move lastTs and clear the stall.
+    const lines = [
+      JSON.stringify({
+        timestamp: "2026-05-31T10:00:00.000Z",
+        message: { content: [{ type: "tool_use", id: "u1", name: "Read", input: {} }] },
+      }),
+      JSON.stringify({
+        timestamp: "2026-05-31T10:00:01.000Z",
+        message: { content: [{ type: "tool_result", tool_use_id: "u1", is_error: false }] },
+      }),
+      JSON.stringify({
+        timestamp: "2026-05-31T10:30:00.000Z",
+        message: { content: [{ type: "text", text: "still thinking out loud" }] },
+      }),
+    ];
+    writeFileSync(path, lines.join("\n"));
+    const snap = readSnapshot(path);
+    expect(snap!.pending).toBe(false);
+    expect(snap!.lastTs).toBe(Date.parse("2026-05-31T10:30:00.000Z"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -113,6 +113,8 @@
   "triage_close_aria": "Schließen",
   "triage_empty": "Keine Agenten warten auf dich.",
   "triage_stall_note": "Still — seit einer Weile keine Aktivität. Möglicherweise hängt er; anstoßen oder Terminal öffnen.",
+  "triage_dismiss_button": "Verwerfen",
+  "triage_dismiss_aria": "Hängt-Markierung für {desig} verwerfen",
   "triage_checkbox_aria": "{desig} auswählen",
   "triage_reply_placeholder": "Antwort eingeben…",
   "triage_reply_aria": "Auf {desig} antworten",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -113,6 +113,8 @@
   "triage_close_aria": "Close",
   "triage_empty": "No agents are waiting on you.",
   "triage_stall_note": "Quiet — no activity for a while. May be stuck; nudge it or open the terminal.",
+  "triage_dismiss_button": "Dismiss",
+  "triage_dismiss_aria": "Dismiss stall flag for {desig}",
   "triage_checkbox_aria": "Select {desig}",
   "triage_reply_placeholder": "Type a reply…",
   "triage_reply_aria": "Reply to {desig}",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -140,6 +140,11 @@ export async function replySession(id: string, text: string): Promise<void> {
   if (!r.ok) throw new Error(`reply failed: ${r.status}`);
 }
 
+export async function dismissStall(id: string): Promise<void> {
+  const r = await fetch(`/api/sessions/${id}/dismiss-stall`, { method: "POST" });
+  if (!r.ok) throw new Error(`dismiss-stall failed: ${r.status}`);
+}
+
 export async function listIssues(
   repoPath: string,
 ): Promise<{ slug: string | null; issues: Issue[] }> {

--- a/ui/src/lib/components/TriageDrawer.svelte
+++ b/ui/src/lib/components/TriageDrawer.svelte
@@ -6,11 +6,13 @@
     entries,
     nowMs,
     onreply,
+    ondismiss,
     onclose,
   }: {
     entries: BlockedEntry[];
     nowMs: number;
     onreply: (id: string, text: string) => void;
+    ondismiss: (id: string) => void;
     onclose: () => void;
   } = $props();
 
@@ -60,7 +62,16 @@
       </div>
 
       {#if e.reason.shape === "stall"}
-        <p class="stall-note">{m.triage_stall_note()}</p>
+        <div class="stall-head">
+          <p class="stall-note">{m.triage_stall_note()}</p>
+          <button
+            class="dismiss"
+            onclick={() => ondismiss(e.session.id)}
+            aria-label={m.triage_dismiss_aria({ desig: e.session.desig })}
+          >
+            {m.triage_dismiss_button()}
+          </button>
+        </div>
       {/if}
 
       <pre class="tail">{e.reason.tail.join("\n")}</pre>
@@ -172,10 +183,22 @@
     font-variant-numeric: tabular-nums;
     font-size: 12px;
   }
+  .stall-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
   .stall-note {
     margin: 0;
     color: var(--color-amber);
     font-size: 12px;
+    flex: 1;
+  }
+  .dismiss {
+    min-height: 32px;
+    padding: 4px 10px;
+    font-size: 12px;
+    color: var(--color-muted);
   }
   .tail {
     margin: 0;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -8,6 +8,7 @@
     archiveSession,
     getUsageLimits,
     replySession,
+    dismissStall,
     getUpdate,
     gitStates,
   } from "$lib/api";
@@ -216,6 +217,7 @@
       entries={blockedEntries}
       {nowMs}
       onreply={(id, text) => replySession(id, text).catch(() => {})}
+      ondismiss={(id) => dismissStall(id).catch(() => {})}
       onclose={() => (showTriage = false)}
     />
   {/if}


### PR DESCRIPTION
## Problem
Once a task was flagged **stalled (no activity)** the flag never cleared — even after the agent resumed — and there was no way to dismiss it.

## Root cause
The stall snapshot's `lastTs` was the newest tool_use's **start** timestamp (`activity.ts` sets every entry's `ts` to the tool_use message time; `readSnapshot` took the last one). So it never advanced when:
- a long-running tool (e.g. a 20-min `Bash`) **completed** — the result arrived but `lastTs` stayed at the start, and with `pending` flipping to false it was now measured against the shorter 8-min window → still "stalled".
- the agent **resumed** with output before its next tool_use.

The auto-clear path (`clearBlock`) was wired correctly; it was just fed a stale timestamp.

## Fix
- `readSnapshot` now sets `lastTs` to the newest transcript record of **any** kind (`latestRecordTs` in `activity.ts`) — tool completions and resumed turns included. `pending` still keys off the newest tool_use, so a genuinely running command keeps its longer hung-command window. Also makes the *trigger* more accurate (won't false-fire mid-stream).
- **Manual dismiss** safety net: `POST /api/sessions/:id/dismiss-stall` → `StatusPoller.acknowledgeStall(id)` clears the current episode's flag without re-firing (keeps the once-per-episode guard); it re-arms automatically when activity resumes. Surfaced as a **Dismiss** button on stall entries in the triage drawer (EN+DE keys added).

## Scope notes
Per-episode acknowledge (no persisted mute); no agent interrupt/restart (the reply box already steers); 30s stall-check throttle unchanged — auto-clear now lands within ≤30s instead of never, and dismiss is instant.

## Tests
- `readSnapshot`: long tool completing → `lastTs` = completion (not stalled); resumed text-only turn advances `lastTs`.
- poller: `acknowledgeStall` clears without re-firing while still stalled, then re-arms on resume.
- Full gate green: root tests/lint/tsc, UI check + i18n parity + vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)