### PR TITLE
feat(newtask): paste a screenshot (Cmd/Ctrl+V) to attach it

### DIFF
--- a/ui/src/lib/clipboard.test.ts
+++ b/ui/src/lib/clipboard.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { imageFilesFromItems } from "./clipboard";
+import { describe, it, expect, vi } from "vitest";
+import { imageFilesFromItems, handleImagePaste } from "./clipboard";
 
 /** Minimal DataTransferItem stub. */
 function item(kind: string, type: string, file: File | null): DataTransferItem {
@@ -41,5 +41,31 @@ describe("imageFilesFromItems", () => {
   it("handles null/empty clipboard", () => {
     expect(imageFilesFromItems(null)).toEqual([]);
     expect(imageFilesFromItems(list([]))).toEqual([]);
+  });
+});
+
+/** Minimal ClipboardEvent stub carrying the given items. */
+function pasteEvent(items: DataTransferItem[]): ClipboardEvent {
+  return {
+    clipboardData: { items: list(items) },
+    preventDefault: vi.fn(),
+  } as unknown as ClipboardEvent;
+}
+
+describe("handleImagePaste", () => {
+  it("uploads the screenshot and swallows the paste", () => {
+    const e = pasteEvent([item("file", "image/png", png)]);
+    const onImages = vi.fn();
+    expect(handleImagePaste(e, onImages)).toBe(true);
+    expect(onImages).toHaveBeenCalledWith([png]);
+    expect(e.preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it("lets a plain-text paste fall through untouched", () => {
+    const e = pasteEvent([item("string", "text/plain", null)]);
+    const onImages = vi.fn();
+    expect(handleImagePaste(e, onImages)).toBe(false);
+    expect(onImages).not.toHaveBeenCalled();
+    expect(e.preventDefault).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/lib/clipboard.ts
+++ b/ui/src/lib/clipboard.ts
@@ -17,3 +17,17 @@ export function imageFilesFromItems(items: DataTransferItemList | null | undefin
   }
   return out;
 }
+
+/**
+ * Paste handler shared by the new-task form: if the clipboard carries image
+ * files (Cmd/Ctrl+V of a screenshot), swallow the paste and hand the images to
+ * `onImages`, returning `true`. A plain-text paste carries no image item, so we
+ * leave the event untouched and return `false` — text paste falls through.
+ */
+export function handleImagePaste(e: ClipboardEvent, onImages: (files: File[]) => void): boolean {
+  const imgs = imageFilesFromItems(e.clipboardData?.items);
+  if (imgs.length === 0) return false;
+  e.preventDefault();
+  onImages(imgs);
+  return true;
+}

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { listRepos, listBranches, uploadImage } from "$lib/api";
+  import { handleImagePaste } from "$lib/clipboard";
   import { MODELS, type RepoEntry } from "$lib/types";
   import RepoSelect from "./RepoSelect.svelte";
   import PromptSources from "./PromptSources.svelte";
@@ -61,6 +62,9 @@
         if (!repoPath && r.length > 0) repoPath = defaultRepoPath(r);
       })
       .catch(() => {});
+    // Paste anywhere in the modal (the textarea need not be focused first).
+    window.addEventListener("paste", onPaste);
+    return () => window.removeEventListener("paste", onPaste);
   });
 
   // load branches for the selected repo; reset base to the repo's current branch
@@ -102,6 +106,12 @@
     e.preventDefault();
     dragging = false;
     if (e.dataTransfer?.files?.length) addFiles(e.dataTransfer.files);
+  }
+
+  // Cmd/Ctrl+V of a screenshot: upload any image on the clipboard. A plain-text
+  // paste carries no image item, so handleImagePaste leaves it alone.
+  function onPaste(e: ClipboardEvent) {
+    handleImagePaste(e, addFiles);
   }
 
   function removeImage(path: string) {


### PR DESCRIPTION
## Was

Im „Neue Aufgabe"-Dialog kann jetzt ein Screenshot direkt mit **Cmd/Ctrl+V** eingefügt werden. Vorher gingen nur Datei-Auswahl und Drag&Drop — ein Paste wurde ignoriert.

## Wie

- **`NewTask.svelte`**: fensterweiter Paste-Handler, der registriert wird, solange der Dialog offen ist (mit Cleanup beim Schließen). Dadurch reicht Cmd+V, ohne vorher ins Textfeld zu klicken. Der Upload läuft über die bestehende `addFiles`-Logik (gleiche Pipeline wie Datei-Button/Drag&Drop → `/api/uploads`).
- **`clipboard.ts`**: neue `handleImagePaste(e, onImages)`, die den vorhandenen `imageFilesFromItems`-Helper wiederverwendet (denselben, den der Terminal-Paste in `Viewport.svelte` nutzt). Bei Bildern: `preventDefault` + Upload. Bei reinem Text: unangetastet → Text-Paste läuft normal durch.

## Tests

- `clipboard.test.ts`: 2 neue Unit-Tests (Screenshot → Upload + `preventDefault`; Text → kein Upload, kein `preventDefault`).
- `cd ui && bun run test` → 80 passed
- `cd ui && bun run check` → 0 Fehler/Warnungen
- `bun run lint` → sauber
- Manuell verifiziert: Dialog öffnen → Cmd+V → Bild erscheint als Chip.

Keine neuen i18n-Keys nötig (reine Wiederverwendung der bestehenden Upload-UI).