### PR TITLE
fix(herdr): give each agent its own tab so HUD terminal is full-width

### DIFF
--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -47,7 +47,42 @@ export class HerdrDriver {
   }
 
   start(name: string, cwd: string, argv: string[]): HerdrAgent {
-    this.runner(["agent", "start", name, "--cwd", cwd, "--no-focus", "--", ...argv]);
+    // Give each agent its OWN tab so its pane spans the full herdr window width.
+    // `agent start` with no --tab splits the active tab, so agents pile up as
+    // side-by-side panes each ~window/N wide — and that split-fixed width (not the
+    // browser's attach size) is what the PTY renders at, so the HUD terminal comes
+    // out tall-and-narrow and resizing the browser can't widen it. A dedicated tab
+    // keeps every agent full-width regardless of how many are running.
+    const created = JSON.parse(
+      this.runner(["tab", "create", "--cwd", cwd, "--label", name, "--no-focus"]),
+    );
+    const tabId: string | undefined = created?.result?.tab?.tab_id;
+    // a fresh tab opens with an empty shell pane; `agent start --tab` splits it, so
+    // we close that leftover pane afterward to leave the agent as the sole pane
+    const rootPaneId: string | undefined = created?.result?.root_pane?.pane_id;
+    if (!tabId) throw new Error(`herdr: tab create returned no tab_id for ${name}`);
+
+    this.runner([
+      "agent",
+      "start",
+      name,
+      "--tab",
+      tabId,
+      "--cwd",
+      cwd,
+      "--no-focus",
+      "--",
+      ...argv,
+    ]);
+
+    if (rootPaneId) {
+      try {
+        this.runner(["pane", "close", rootPaneId]);
+      } catch {
+        /* best-effort: agent still runs if the shell pane lingers, just at split width */
+      }
+    }
+
     // NOTE: resolves the just-started agent by its unique worktree cwd; ambiguous only if two
     // sessions share a cwd (e.g. two non-git cwd-fallbacks on the same repoPath). TODO: prefer a
     // terminal_id returned directly by `herdr agent start` if herdr exposes it.

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -34,18 +34,31 @@ test("list parses herdr json into typed agents", () => {
   expect(a[0]).toMatchObject({ terminalId: "term_a", agentStatus: "working", cwd: "/wt/a" });
 });
 
-test("start runs herdr then resolves the new agent by unique cwd", () => {
+const TAB_CREATE = JSON.stringify({
+  result: {
+    type: "tab_created",
+    tab: { tab_id: "t_new", workspace_id: "w1" },
+    root_pane: { pane_id: "p_root", tab_id: "t_new", terminal_id: "term_root" },
+  },
+});
+
+test("start gives each agent its own full-width tab, not a shared split pane", () => {
   const calls: string[][] = [];
   const d = new HerdrDriver((args) => {
     calls.push(args);
-    return FIXTURE;
+    return args[0] === "tab" && args[1] === "create" ? TAB_CREATE : FIXTURE;
   });
   const agent = d.start("flatten", "/wt/a", ["claude", "--dangerously-skip-permissions", "go"]);
   expect(agent.terminalId).toBe("term_a");
-  expect(calls[0]).toEqual([
+  // 1) a dedicated tab is created first (so the agent isn't split into a shared one)
+  expect(calls[0]).toEqual(["tab", "create", "--cwd", "/wt/a", "--label", "flatten", "--no-focus"]);
+  // 2) the agent starts INTO that tab
+  expect(calls[1]).toEqual([
     "agent",
     "start",
     "flatten",
+    "--tab",
+    "t_new",
     "--cwd",
     "/wt/a",
     "--no-focus",
@@ -54,6 +67,9 @@ test("start runs herdr then resolves the new agent by unique cwd", () => {
     "--dangerously-skip-permissions",
     "go",
   ]);
+  // 3) the leftover shell root pane is closed so the agent is the tab's sole,
+  //    full-width pane — a split pane would only get ~window/N width (the bug)
+  expect(calls[2]).toEqual(["pane", "close", "p_root"]);
 });
 
 test("stop closes the pane backing a terminal id", () => {


### PR DESCRIPTION
## Problem
The HUD terminal always rendered **tall and narrow**, everywhere, and resizing the browser couldn't widen it — essentially unusable.

## Root cause
Not the UI fit logic / CSS / cols default. `HerdrDriver.start()` ran `herdr agent start … --no-focus` with **no `--tab`**, so every agent piled into one shared herdr tab as **side-by-side split panes** (~`window-width / N` cols each). The HUD xterm renders at the pane's split-fixed width — *not* the browser attach size — so the terminal stayed narrow no matter how the client resized, and got narrower per added agent.

Confirmed on the live server: the "shepherd" workspace was a single tab with `pane_count: 3` for 3 agents.

## Fix
`start()` now isolates each agent in its own full-width tab:
1. `herdr tab create --cwd … --label … --no-focus` → capture `tab_id` + `root_pane.pane_id`
2. `herdr agent start … --tab <tab_id> … -- <argv>`
3. `herdr pane close <root_pane_id>` — drop the leftover shell pane so the agent is the tab's **sole, full-width** pane

The exact command sequence was validated against a live herdr (throwaway probe agent → `pane_count` ends at 1 → cleaned up).

## Tests
- Updated `test/herdr.test.ts` to assert the tab→start→close sequence (red before, green after)
- `tsc` clean, `eslint` clean, root suite **338 pass / 0 fail**

## Notes
- Existing **already-running** agents stay in the old shared split tab; only newly-started agents get their own tab. They'd need recreating to benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)