### PR TITLE
fix(ui): respect iOS safe-area insets on Dynamic Island iPhones

### DIFF
--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -9,7 +9,10 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Shepherd" />
     <meta name="theme-color" content="#0b0f0d" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- viewport-fit=cover is required for env(safe-area-inset-*) to return non-zero
+         values; without it iOS letterboxes content and the insets stay 0. Paired with
+         apple-mobile-web-app-status-bar-style=black-translucent for a full-bleed dark shell. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="text-scale" content="scale" />
     <title>Shepherd</title>
     <!-- Resolve the theme before first paint so there's no flash of wrong theme.

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -252,7 +252,12 @@
   .shell {
     max-width: 1480px;
     margin: 0 auto;
-    padding: 22px;
+    /* max(base, inset): on devices/browsers without safe areas env() is 0 so the
+       base padding wins (no regression); in an iOS standalone PWA the Dynamic Island
+       (top) and home indicator (bottom) insets win. Everything flows inside .shell,
+       so insetting it alone clears both edges + the landscape sides. */
+    padding: max(22px, env(safe-area-inset-top)) max(22px, env(safe-area-inset-right))
+      max(22px, env(safe-area-inset-bottom)) max(22px, env(safe-area-inset-left));
     display: flex;
     flex-direction: column;
     gap: 14px;
@@ -304,7 +309,8 @@
 
   .shell.mobile {
     max-width: none;
-    padding: 10px;
+    padding: max(10px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right))
+      max(10px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
     gap: 10px;
   }
 </style>


### PR DESCRIPTION
## Was & warum

Der Mobile-Pfad (≤768px) deckt das **iPhone 14 Pro Max** schon ab — es nutzt denselben Code wie Patricks Fold *zugeklappt*. Der einzige iPhone-spezifische Gap: im **installierten PWA-Standalone-Modus** lief der Inhalt **hinter** der Dynamic Island (oben) und dem Home-Indicator (unten).

Ursache:
1. Das Viewport-Meta hatte kein `viewport-fit=cover` → `env(safe-area-inset-*)` lieferte immer `0`.
2. Nichts hat `.shell` von den Bildschirmkanten weggerückt.

## Änderung (2 Dateien)

- **`app.html`**: `viewport-fit=cover` ergänzt, damit iOS die Insets überhaupt freigibt.
- **`+page.svelte`**: `.shell`-Padding auf allen vier Seiten mit `max(basis, env(safe-area-inset-*))`. Da alles als Flex-Spalte **in** `.shell` fließt (kein `position: fixed/sticky`), räumt ein einziger Inset oben, unten **und** die Landscape-Seiten frei. `max()` behält das Basis-Padding, wo `env()` = 0 ist → **keine Regression** auf Desktop/Android/Browser-Tab.

## Bewusst beibehalten
- `apple-mobile-web-app-status-bar-style: black-translucent` — korrekt für eine dunkle Full-Bleed-PWA, gehört zwingend zu `viewport-fit=cover`.
- `100dvh` als Shell-Höhe — schützt den In-Safari-Tab-Fall.

## Testen
- ✅ `cd ui && bun run check` grün (reines CSS/Meta, keine i18n-Strings).
- 📱 Visueller Beweis braucht das **physische iPhone als installierte PWA** — Desktop-Browser & DevTools-Emulation simulieren `env(safe-area-inset-*)` nicht (immer 0).
  - Oben: TopBar/Gauge unter der Dynamic Island statt dahinter.
  - Unten: SteerBar/ControlBar über dem Home-Indicator.
  - Landscape: Inhalt klebt nicht an den abgerundeten Ecken.