### PR TITLE
feat(ui): stronger active-agent highlight + tailnet dev access

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -11,6 +11,7 @@
   --color-head: var(--head);
   --color-inset: var(--inset);
   --color-hover: var(--hover);
+  --color-sel: var(--sel);
   --color-line: var(--line);
   --color-line-bright: var(--line-bright);
   --color-ink: var(--ink);
@@ -40,6 +41,7 @@
   --head: #0a0f0d;
   --inset: #070a09;
   --hover: #0c1110;
+  --sel: #18211e;
   --line: #1b2422;
   --line-bright: #2c3835;
 
@@ -77,6 +79,7 @@
   --head: #eef2f0;
   --inset: #f3f6f4;
   --hover: #e4e9e6;
+  --sel: #d2dbd6;
   --line: #d2dad6;
   --line-bright: #b9c4bf;
 

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -108,10 +108,10 @@
     background:
       radial-gradient(
         120% 140% at 0% 50%,
-        color-mix(in srgb, var(--rule) 9%, transparent),
+        color-mix(in srgb, var(--rule) 12%, transparent),
         transparent 70%
       ),
-      var(--color-hover);
+      var(--color-sel);
   }
 
   /* bracket corners on selected */

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -26,6 +26,12 @@ export default defineConfig({
     sveltekit(),
   ],
   server: {
+    port: 5174,
+    strictPort: true,
+    // Vite listens on localhost; `tailscale serve --https 5173 http://localhost:5173`
+    // proxies the tailnet in front of it. allowedHosts must list the tailnet suffix
+    // so Vite doesn't reject the forwarded Host header (*.ts.net).
+    allowedHosts: [".ts.net"],
     proxy: {
       "/api": "http://localhost:7330",
       "/events": { target: "ws://localhost:7330", ws: true },


### PR DESCRIPTION
## Was

Zwei Änderungen aus einem Durchgang:

### feat(ui): aktives Schaf hervorheben
Die ausgewählte Zeile in der Herd-Sidebar nutzte `--color-hover` — praktisch identisch zum Panel-Hintergrund, dadurch war kaum zu erkennen, an welchem Agent man gerade arbeitet. Jetzt gibt es eine dedizierte `--sel`-Fläche:
- **Dark:** deutlich heller (`#18211e`)
- **Light:** spürbar dunkler (`#d2dbd6`)
- Status-Farbverlauf links leicht verstärkt (9% → 12%), heller Rahmen + Eck-Bracket bleiben.

### fix(dev): Tailnet-Zugriff auf Vite-Dev-Server
Vite lehnte den von `tailscale serve` weitergereichten Host-Header ab (*"Blocked request… not allowed"*). Fix:
- `allowedHosts: ['.ts.net']` — Suffix-Match, kein persönlicher FQDN im Repo
- fester Port 5174 + `strictPort`
- nur localhost-Bind (kein `host: true`) → keine Kollision mit dem Tailnet-Bind von `tailscale serve`

## Test
- `cd ui && bun run check` → 0 errors
- Dev-Server über `https://…ts.net:5174/` erreichbar (200), Block-Fehler weg