### PR TITLE
fix(newtask): New Task create after herdr 0.6 update + real error messages

### DIFF
--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -49,7 +49,27 @@ export class HerdrDriver {
     }));
   }
 
+  /**
+   * herdr ≥0.6 refuses `tab create` with `workspace_not_found: no active workspace`
+   * unless a workspace exists. A fresh daemon — or one restarted after an update —
+   * has none, so the very first New Task after a herdr restart used to 500. Create a
+   * "shepherd" workspace on demand. Idempotent: skips when any workspace already exists.
+   */
+  private ensureWorkspace(cwd: string): void {
+    let workspaces: unknown[];
+    try {
+      workspaces = JSON.parse(this.runner(["workspace", "list"]))?.result?.workspaces ?? [];
+    } catch {
+      workspaces = []; // unparseable/empty reply → treat as "none", create one
+    }
+    if (workspaces.length === 0) {
+      this.runner(["workspace", "create", "--cwd", cwd, "--label", "shepherd", "--no-focus"]);
+    }
+  }
+
   start(name: string, cwd: string, argv: string[]): HerdrAgent {
+    // herdr needs an active workspace before any tab can be created — guarantee one.
+    this.ensureWorkspace(cwd);
     // Give each agent its OWN tab so its pane spans the full herdr window width.
     // `agent start` with no --tab splits the active tab, so agents pile up as
     // side-by-side panes each ~window/N wide — and that split-fixed width (not the

--- a/src/server.ts
+++ b/src/server.ts
@@ -106,7 +106,7 @@ function checkOrigin(req: Request): Response | null {
 
 /** Returns an object with a `fetch(Request)` method — unit-testable without a port. */
 export function makeApp(deps: AppDeps) {
-  return {
+  const app = {
     async fetch(req: Request): Promise<Response> {
       const authErr = checkAuth(req);
       if (authErr) return authErr;
@@ -479,6 +479,15 @@ export function makeApp(deps: AppDeps) {
       }
       return json({ error: "not found" }, 404);
     },
+  };
+  // Any unhandled throw (e.g. `service.create` when herdr rejects a command) would
+  // otherwise bubble out as Bun's HTML error page — which the UI can't parse, so it
+  // only sees a bare status code. Convert it to a JSON 500 carrying the real message.
+  return {
+    fetch: (req: Request): Promise<Response> =>
+      app
+        .fetch(req)
+        .catch((e) => json({ error: e instanceof Error ? e.message : "internal error" }, 500)),
   };
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -21,32 +21,50 @@ export class SessionService {
   async create(input: CreateSessionInput): Promise<Session> {
     const name = this.uniqueName(await this.deps.namer(input.prompt));
     const wt = this.deps.worktree.create(input.repoPath, input.baseBranch, name);
-    const claudeSessionId = randomUUID();
+    // The worktree is created before the agent can start, so any failure past this
+    // point (e.g. herdr `tab create` rejecting) would otherwise leave an orphan
+    // worktree with no session row. Roll it back so a failed create leaves nothing.
+    try {
+      const claudeSessionId = randomUUID();
 
-    let promptArg = input.prompt;
-    if (input.images.length > 0) {
-      const move = this.deps.moveUploads ?? moveStagedIntoWorktree;
-      const moved = move(input.images, wt.worktreePath);
-      promptArg = `${input.prompt}\n\nAttached images:\n${moved.join("\n")}`;
+      let promptArg = input.prompt;
+      if (input.images.length > 0) {
+        const move = this.deps.moveUploads ?? moveStagedIntoWorktree;
+        const moved = move(input.images, wt.worktreePath);
+        promptArg = `${input.prompt}\n\nAttached images:\n${moved.join("\n")}`;
+      }
+
+      const argv = ["claude", "--dangerously-skip-permissions", "--session-id", claudeSessionId];
+      if (input.model) argv.push("--model", input.model);
+      argv.push(promptArg);
+      const agent = this.deps.herdr.start(name, wt.worktreePath, argv);
+      return this.deps.store.create({
+        name,
+        prompt: input.prompt, // store the original user text, not the argv-augmented version
+        repoPath: input.repoPath,
+        baseBranch: input.baseBranch,
+        branch: wt.branch,
+        worktreePath: wt.worktreePath,
+        isolated: wt.isolated,
+        herdrSession: config.herdrSession,
+        herdrAgentId: agent.terminalId,
+        claudeSessionId,
+        model: input.model,
+      });
+    } catch (e) {
+      // best-effort rollback; surface the original failure, not any cleanup error
+      if (wt.isolated) {
+        try {
+          this.deps.worktree.remove(wt.worktreePath, {
+            branch: wt.branch,
+            baseBranch: input.baseBranch,
+          });
+        } catch {
+          /* ignore */
+        }
+      }
+      throw e;
     }
-
-    const argv = ["claude", "--dangerously-skip-permissions", "--session-id", claudeSessionId];
-    if (input.model) argv.push("--model", input.model);
-    argv.push(promptArg);
-    const agent = this.deps.herdr.start(name, wt.worktreePath, argv);
-    return this.deps.store.create({
-      name,
-      prompt: input.prompt, // store the original user text, not the argv-augmented version
-      repoPath: input.repoPath,
-      baseBranch: input.baseBranch,
-      branch: wt.branch,
-      worktreePath: wt.worktreePath,
-      isolated: wt.isolated,
-      herdrSession: config.herdrSession,
-      herdrAgentId: agent.terminalId,
-      claudeSessionId,
-      model: input.model,
-    });
   }
 
   /**

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -50,18 +50,37 @@ test("list surfaces the agent name (empty when herdr omits it)", () => {
   expect(a[1]!.name).toBe(""); // second fixture agent has no name field
 });
 
+// herdr reply for `workspace list` — one workspace exists, so start() skips bootstrap
+const WORKSPACE_LIST = JSON.stringify({
+  result: { type: "workspace_list", workspaces: [{ workspace_id: "w1", label: "shepherd" }] },
+});
+// herdr reply for `workspace list` on a fresh/restarted daemon — none yet
+const WORKSPACE_LIST_EMPTY = JSON.stringify({
+  result: { type: "workspace_list", workspaces: [] },
+});
+
+// route a runner's reply by the herdr subcommand it's invoked with
+function reply(args: string[], workspaceList: string): string {
+  if (args[0] === "workspace" && args[1] === "list") return workspaceList;
+  if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
+  return FIXTURE;
+}
+
 test("start gives each agent its own full-width tab, not a shared split pane", () => {
   const calls: string[][] = [];
   const d = new HerdrDriver((args) => {
     calls.push(args);
-    return args[0] === "tab" && args[1] === "create" ? TAB_CREATE : FIXTURE;
+    return reply(args, WORKSPACE_LIST);
   });
   const agent = d.start("flatten", "/wt/a", ["claude", "--dangerously-skip-permissions", "go"]);
   expect(agent.terminalId).toBe("term_a");
-  // 1) a dedicated tab is created first (so the agent isn't split into a shared one)
-  expect(calls[0]).toEqual(["tab", "create", "--cwd", "/wt/a", "--label", "flatten", "--no-focus"]);
+  // 0) a workspace already exists, so we only check for one — no create
+  expect(calls[0]).toEqual(["workspace", "list"]);
+  expect(calls.some((c) => c[0] === "workspace" && c[1] === "create")).toBe(false);
+  // 1) a dedicated tab is created (so the agent isn't split into a shared one)
+  expect(calls[1]).toEqual(["tab", "create", "--cwd", "/wt/a", "--label", "flatten", "--no-focus"]);
   // 2) the agent starts INTO that tab
-  expect(calls[1]).toEqual([
+  expect(calls[2]).toEqual([
     "agent",
     "start",
     "flatten",
@@ -77,7 +96,29 @@ test("start gives each agent its own full-width tab, not a shared split pane", (
   ]);
   // 3) the leftover shell root pane is closed so the agent is the tab's sole,
   //    full-width pane — a split pane would only get ~window/N width (the bug)
-  expect(calls[2]).toEqual(["pane", "close", "p_root"]);
+  expect(calls[3]).toEqual(["pane", "close", "p_root"]);
+});
+
+test("start bootstraps a 'shepherd' workspace when herdr has none (fresh/restarted daemon)", () => {
+  const calls: string[][] = [];
+  const d = new HerdrDriver((args) => {
+    calls.push(args);
+    return reply(args, WORKSPACE_LIST_EMPTY);
+  });
+  d.start("flatten", "/wt/a", ["claude", "go"]);
+  // with no active workspace, `tab create` would 500 — so we create one first
+  expect(calls[0]).toEqual(["workspace", "list"]);
+  expect(calls[1]).toEqual([
+    "workspace",
+    "create",
+    "--cwd",
+    "/wt/a",
+    "--label",
+    "shepherd",
+    "--no-focus",
+  ]);
+  // …then the normal tab-create flow proceeds
+  expect(calls[2]).toEqual(["tab", "create", "--cwd", "/wt/a", "--label", "flatten", "--no-focus"]);
 });
 
 test("stop closes the pane backing a terminal id", () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -120,6 +120,39 @@ test("POST /api/sessions creates, GET lists", async () => {
   expect(list.length).toBe(1);
 });
 
+test("POST /api/sessions surfaces a herdr failure with its real message (not a bare status)", async () => {
+  const deps = makeDeps();
+  // mirror herdr rejecting `tab create` — the create path throws past validation
+  deps.service = {
+    create: async () => {
+      throw new Error("Command failed: herdr tab create … no active workspace");
+    },
+  } as any;
+  const res = await postSessions(makeApp(deps), {
+    repoPath: validRepo,
+    baseBranch: "main",
+    prompt: "go",
+  });
+  expect(res.status).toBe(502); // herdr/git failure
+  const body = await res.json();
+  expect(body.error).toContain("no active workspace"); // real cause reaches the client
+});
+
+test("an unhandled throw on any route becomes a JSON 500, not Bun's HTML error page", async () => {
+  const deps = makeDeps();
+  // a route with no local try/catch (GET /api/sessions) — exercise the global safety net
+  deps.store = {
+    list: () => {
+      throw new Error("db exploded");
+    },
+  } as any;
+  const res = await makeApp(deps).fetch(new Request("http://x/api/sessions"));
+  expect(res.status).toBe(500);
+  expect(res.headers.get("content-type")).toContain("application/json");
+  const body = await res.json();
+  expect(body.error).toBe("db exploded"); // message preserved as JSON, parseable by the UI
+});
+
 test("DELETE /api/sessions/:id archives", async () => {
   const app = harness();
   const created = await (

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -246,6 +246,77 @@ test("createSession: no images leaves the prompt argv unchanged", async () => {
   expect(calls.argv[calls.argv.length - 1]).toBe("go");
 });
 
+test("createSession: rolls back the worktree when the agent fails to start", async () => {
+  const store = new SessionStore(":memory:");
+  const removed: { path: string; opts: any }[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "boom",
+    worktree: {
+      create: (_r: string, _b: string, name: string) => ({
+        worktreePath: `/wt/${name}`,
+        branch: `shepherd/${name}`,
+        isolated: true,
+      }),
+      remove: (path: string, opts: any) => removed.push({ path, opts }),
+    } as any,
+    herdr: {
+      // mirrors herdr rejecting `tab create` with "no active workspace"
+      start: () => {
+        throw new Error("no active workspace");
+      },
+      list: () => [],
+    } as any,
+  });
+
+  await expect(
+    service.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "go",
+      model: null,
+      images: [],
+    }),
+  ).rejects.toThrow("no active workspace"); // original failure is surfaced, not a cleanup error
+  // the orphan worktree we created is removed, with branch + baseBranch for branch deletion
+  expect(removed).toEqual([
+    { path: "/wt/boom", opts: { branch: "shepherd/boom", baseBranch: "main" } },
+  ]);
+});
+
+test("createSession: skips worktree rollback when the cwd fallback isn't isolated", async () => {
+  const store = new SessionStore(":memory:");
+  let removeCalls = 0;
+  const service = new SessionService({
+    store,
+    namer: async () => "boom",
+    worktree: {
+      // non-git repoPath → herdr runs in-place, no worktree to clean up
+      create: () => ({ worktreePath: "/repo", branch: null, isolated: false }),
+      remove: () => {
+        removeCalls++;
+      },
+    } as any,
+    herdr: {
+      start: () => {
+        throw new Error("no active workspace");
+      },
+      list: () => [],
+    } as any,
+  });
+
+  await expect(
+    service.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "go",
+      model: null,
+      images: [],
+    }),
+  ).rejects.toThrow("no active workspace");
+  expect(removeCalls).toBe(0);
+});
+
 test("archive stops the herdr agent, removes the worktree, and archives the row", () => {
   const store = new SessionStore(":memory:");
   const calls: any = { stopped: [], removed: [] };

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -20,9 +20,20 @@ import type {
 
 const JSON_HEADERS = { "content-type": "application/json" };
 
+/** Build an Error from a failed response, preferring the server's `{error}` body
+ *  (e.g. "no active workspace") over the bare status code so the UI shows the real
+ *  cause. Falls back to "<label> failed: <status>" when the body carries no message. */
+async function failed(r: Response, label: string): Promise<Error> {
+  const detail = await r
+    .json()
+    .then((b) => (b as { error?: string })?.error)
+    .catch(() => null);
+  return new Error(detail ?? `${label} failed: ${r.status}`);
+}
+
 export async function listSessions(): Promise<Session[]> {
   const r = await fetch("/api/sessions");
-  if (!r.ok) throw new Error(`list failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "list");
   return r.json();
 }
 
@@ -32,15 +43,7 @@ export async function createSession(input: CreateInput): Promise<Session> {
     headers: JSON_HEADERS,
     body: JSON.stringify(input),
   });
-  if (!r.ok) {
-    // server sends {error} for create failures; prefer it over the bare status code
-    const detail = await r
-      .clone()
-      .json()
-      .then((b) => (b as { error?: string })?.error)
-      .catch(() => null);
-    throw new Error(detail ?? `create failed: ${r.status}`);
-  }
+  if (!r.ok) throw await failed(r, "create");
   return r.json();
 }
 
@@ -52,24 +55,24 @@ export async function uploadImage(file: File, sessionId?: string): Promise<strin
   const q = sessionId ? `?session=${encodeURIComponent(sessionId)}` : "";
   // no content-type header: the browser sets the multipart boundary
   const r = await fetch(`/api/uploads${q}`, { method: "POST", body: fd });
-  if (!r.ok) throw new Error(`upload failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "upload");
   return (await r.json()).path as string;
 }
 
 export async function archiveSession(id: string): Promise<void> {
   const r = await fetch(`/api/sessions/${id}`, { method: "DELETE" });
-  if (!r.ok) throw new Error(`archive failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "archive");
 }
 
 export async function listRepos(): Promise<RepoEntry[]> {
   const r = await fetch("/api/repos");
-  if (!r.ok) throw new Error(`repos failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "repos");
   return r.json();
 }
 
 export async function getSettings(): Promise<Settings> {
   const r = await fetch("/api/settings");
-  if (!r.ok) throw new Error(`settings failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "settings");
   return r.json();
 }
 
@@ -89,7 +92,7 @@ export async function putSettings(repoRoot: string): Promise<Settings> {
 export async function listDirs(path?: string): Promise<DirListing> {
   const q = path ? `?path=${encodeURIComponent(path)}` : "";
   const r = await fetch(`/api/fs/dirs${q}`);
-  if (!r.ok) throw new Error(`dirs failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "dirs");
   return r.json();
 }
 
@@ -97,13 +100,13 @@ export async function listBranches(
   repoPath: string,
 ): Promise<{ branches: string[]; current: string | null }> {
   const r = await fetch(`/api/branches?repo=${encodeURIComponent(repoPath)}`);
-  if (!r.ok) throw new Error(`branches failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "branches");
   return r.json();
 }
 
 export async function getTodo(repoPath: string): Promise<{ exists: boolean; content: string }> {
   const r = await fetch(`/api/todo?repo=${encodeURIComponent(repoPath)}`);
-  if (!r.ok) throw new Error(`todo get failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "todo get");
   return r.json();
 }
 
@@ -113,30 +116,30 @@ export async function putTodo(repoPath: string, content: string): Promise<void> 
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ content }),
   });
-  if (!r.ok) throw new Error(`todo put failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "todo put");
 }
 
 export async function getSessionUsage(id: string): Promise<SessionUsage> {
   const r = await fetch(`/api/sessions/${id}/usage`);
-  if (!r.ok) throw new Error(`usage failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "usage");
   return r.json();
 }
 
 export async function getActivity(id: string): Promise<ActivityEntry[]> {
   const r = await fetch(`/api/sessions/${id}/activity`);
-  if (!r.ok) throw new Error(`activity failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "activity");
   return r.json();
 }
 
 export async function getDiff(id: string): Promise<DiffResult> {
   const r = await fetch(`/api/sessions/${id}/diff`);
-  if (!r.ok) throw new Error(`diff failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "diff");
   return r.json();
 }
 
 export async function getUsageLimits(): Promise<UsageLimits> {
   const r = await fetch("/api/usage/limits");
-  if (!r.ok) throw new Error(`limits failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "limits");
   return r.json();
 }
 
@@ -146,19 +149,19 @@ export async function replySession(id: string, text: string): Promise<void> {
     headers: JSON_HEADERS,
     body: JSON.stringify({ text }),
   });
-  if (!r.ok) throw new Error(`reply failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "reply");
 }
 
 export async function dismissStall(id: string): Promise<void> {
   const r = await fetch(`/api/sessions/${id}/dismiss-stall`, { method: "POST" });
-  if (!r.ok) throw new Error(`dismiss-stall failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "dismiss-stall");
 }
 
 export async function listIssues(
   repoPath: string,
 ): Promise<{ slug: string | null; issues: Issue[] }> {
   const r = await fetch(`/api/issues?repo=${encodeURIComponent(repoPath)}`);
-  if (!r.ok) throw new Error(`issues failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "issues");
   return r.json();
 }
 
@@ -172,7 +175,7 @@ const JSON_POST = (body?: unknown): RequestInit => ({
 export async function gitState(id: string): Promise<GitState | null> {
   const r = await fetch(`/api/sessions/${id}/git`);
   if (r.status === 404) return null;
-  if (!r.ok) throw new Error(`git status failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "git status");
   return r.json();
 }
 
@@ -180,7 +183,7 @@ export async function gitState(id: string): Promise<GitState | null> {
  *  list overview). Empty object when no forge is configured anywhere. */
 export async function gitStates(): Promise<Record<string, GitState>> {
   const r = await fetch("/api/git");
-  if (!r.ok) throw new Error(`git states failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "git states");
   return r.json();
 }
 
@@ -209,14 +212,14 @@ export async function mergePr(
 /** Current self-update status (how far the running checkout is behind main). */
 export async function getUpdate(): Promise<UpdateStatus> {
   const r = await fetch("/api/update");
-  if (!r.ok) throw new Error(`update status failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "update status");
   return r.json();
 }
 
 /** Current herdr-version update status (whether a newer herdr exists). */
 export async function getHerdrUpdate(): Promise<HerdrUpdateStatus> {
   const r = await fetch("/api/herdr-update");
-  if (!r.ok) throw new Error(`herdr update status failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "herdr update status");
   return r.json();
 }
 
@@ -248,7 +251,7 @@ export async function redeploy(id: string): Promise<void> {
 
 export async function getSteers(): Promise<Steer[]> {
   const r = await fetch("/api/steers");
-  if (!r.ok) throw new Error(`steers failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "steers");
   return r.json();
 }
 
@@ -274,13 +277,13 @@ export async function broadcast(
     headers: JSON_HEADERS,
     body: JSON.stringify({ text, ids }),
   });
-  if (!r.ok) throw new Error(`broadcast failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "broadcast");
   return r.json();
 }
 
 export async function getProjectIcons(): Promise<ProjectIcons> {
   const r = await fetch("/api/project-icons");
-  if (!r.ok) throw new Error(`project-icons failed: ${r.status}`);
+  if (!r.ok) throw await failed(r, "project-icons");
   return r.json();
 }
 


### PR DESCRIPTION
## Problem

After herdr was updated to **0.6.5** and the daemon restarted, every **New Task** failed with a bare `create failed: 400` in the UI — no explanation.

The real cause was hidden: Shepherd shells out to `herdr tab create`, which in herdr ≥0.6 **requires an active workspace**. A fresh/restarted daemon has none, so herdr replied:

```
{"error":{"code":"workspace_not_found","message":"no active workspace"}}
```

`service.create` let that throw bubble out as **Bun's HTML error page**, which the UI can't parse — so it only ever saw a status code.

## Fixes

1. **`fix(herdr)`** — `HerdrDriver.ensureWorkspace()` checks `workspace list` and creates a `shepherd` workspace on demand before `tab create`. Idempotent; survives any herdr restart.
2. **`fix(create)`** — the worktree is created *before* the agent starts, so a failed start used to leak an orphan worktree with no session row. Now rolled back on failure (and the original error is rethrown).
3. **`fix(server,ui)`** — unhandled throws are wrapped into a JSON `500 {error}` instead of Bun's HTML page, and the UI api client reads the server's `{error}` body. So 4xx/5xx now show the real message (e.g. "no active workspace") instead of a naked status code.

## Tests

- `herdr.test.ts` — workspace bootstrap when none exists; skip when one already does.
- `service.test.ts` — worktree rollback on failed start; no rollback for the non-isolated cwd fallback.
- `server.test.ts` — herdr failure surfaces its message (502); unhandled throw on any route becomes a JSON 500.

All green: root `bun test` 358 pass, UI `vitest` 80 pass, lint + `svelte-check` + i18n parity clean.

## Note

Also cleaned up the orphan worktrees this bug left behind (`shepherd-haben-wir-eine-m` and two stale `shepherd-test*`).