### PR TITLE
chore: adopt fallow (dead-code, complexity, dupes) with CI audit gate

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+
+  // Two packages, one config (no workspaces field in package.json; fallow still
+  // discovers ui/ as a workspace via its package.json). Entries cover both trees.
+  //
+  //   Root  = Bun server. Real entry is src/index.ts (package.json "main");
+  //           pty-attach.mjs is spawned as a Node subprocess, not imported.
+  //   Tests = run by `bun test ./test` / vitest — genuine roots. Without them
+  //           every test/** file shows up as an "unused file".
+  //   UI    = SvelteKit. The svelte plugin auto-detects routes/app shell, but we
+  //           list them defensively so the report is stable if discovery changes.
+  "entry": [
+    "src/index.ts",
+    "src/pty-attach.mjs",
+    "test/**/*.ts",
+    "test/**/*.mjs",
+    "ui/src/routes/**/+*.ts",
+    "ui/src/routes/**/+*.js",
+    "ui/src/routes/**/+*.svelte",
+    "ui/src/hooks.server.ts",
+    "ui/src/hooks.client.ts",
+    "ui/src/app.d.ts",
+    "ui/src/app.html",
+    "ui/src/app.css",
+    "ui/svelte.config.js",
+    "ui/vite.config.ts",
+    "ui/scripts/**/*.mjs",
+    "eslint.config.js",
+    "commitlint.config.js"
+  ],
+
+  // sw.js is the service worker: never imported statically — the browser fetches
+  // it via navigator.serviceWorker.register("/sw.js") in ui/src/lib/push.ts.
+  "dynamicallyLoaded": ["ui/static/sw.js"],
+
+  // tailwindcss is pulled in through `@import "tailwindcss"` in app.css + the
+  // @tailwindcss/vite plugin, not an ESM import — so fallow sees it as unlisted.
+  // It is build/runtime-provided, not a missing dependency.
+  "ignoreDependencies": ["tailwindcss"],
+
+  "rules": {
+    // OFF — every method fallow flags here (GitForge.openPr, the HerdrDriver
+    // send/read, the *Poller.stop, PtyBridge.write, PushService.subscribe/
+    // unsubscribe, SessionStore.lastUsedByRepo) is concrete polymorphic API
+    // invoked through an interface type or an injected dependency, and is
+    // exercised by tests. Static analysis can't see interface dispatch, so this
+    // is one structural false-positive class, not nine dead members. Fallow's
+    // own note: "may be used via dependency injection".
+    "unused-class-member": "off",
+    // OFF — the server (src/forge/types.ts) and the client (ui/src/lib/types.ts)
+    // deliberately keep parallel copies of shared shapes (PrStatus, MergeMethod,
+    // …) because they don't share a build; the duplicate-export reports on those
+    // mirrors are intentional.
+    "duplicate-exports": "off"
+  },
+
+  // Generated / codegen, plus the parallel forge adapters. GiteaForge.prStatus
+  // and GithubForge.prStatus share a shape but map two unrelated REST APIs and
+  // evolve independently; a shared abstraction would couple Gitea to GitHub.
+  // Kept separate by design (skill §8: parallel impls, not real duplication).
+  "duplicates": {
+    "ignore": [
+      "**/.svelte-kit/**",
+      "**/src/lib/paraglide/**",
+      "**/scripts/**",
+      "**/build/**",
+      "**/src/forge/gitea.ts",
+      "**/src/forge/github.ts"
+    ]
+  },
+
+  // Cyclomatic/cognitive kept at fallow defaults (20/15) — the codebase sits
+  // comfortably under them (see PR body for avg/p90). maxCrap raised to 1000:
+  // CRAP = CC^2*(1-cov)^3 + CC is coverage-driven, and this repo's coverage
+  // ramp-up is deferred, so near-zero coverage would push every moderately
+  // branchy function past the default 30 while saying nothing about readability.
+  // Revisit once a coverage target lands. Generated paraglide, build scripts and
+  // test files are excluded from complexity scoring.
+  "health": {
+    "maxCyclomatic": 20,
+    "maxCognitive": 15,
+    "maxCrap": 1000,
+    "ignore": [
+      "**/src/lib/paraglide/**",
+      "**/scripts/**",
+      "**/*.test.ts",
+      "**/*.spec.ts",
+      "**/*.svelte.test.ts"
+    ]
+  }
+}

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -27,7 +27,7 @@
     "ui/vite.config.ts",
     "ui/scripts/**/*.mjs",
     "eslint.config.js",
-    "commitlint.config.js"
+    "commitlint.config.js",
   ],
 
   // sw.js is the service worker: never imported statically — the browser fetches
@@ -52,7 +52,7 @@
     // deliberately keep parallel copies of shared shapes (PrStatus, MergeMethod,
     // …) because they don't share a build; the duplicate-export reports on those
     // mirrors are intentional.
-    "duplicate-exports": "off"
+    "duplicate-exports": "off",
   },
 
   // Generated / codegen, plus the parallel forge adapters. GiteaForge.prStatus
@@ -66,8 +66,8 @@
       "**/scripts/**",
       "**/build/**",
       "**/src/forge/gitea.ts",
-      "**/src/forge/github.ts"
-    ]
+      "**/src/forge/github.ts",
+    ],
   },
 
   // Cyclomatic/cognitive kept at fallow defaults (20/15) — the codebase sits
@@ -86,7 +86,7 @@
       "**/scripts/**",
       "**/*.test.ts",
       "**/*.spec.ts",
-      "**/*.svelte.test.ts"
-    ]
-  }
+      "**/*.svelte.test.ts",
+    ],
+  },
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # Fallow's PR audit diffs against the base branch — needs full history.
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -62,3 +65,9 @@ jobs:
 
       - name: Build (ui)
         run: cd ui && bun run build
+
+      - name: Fallow audit (PR delta)
+        # Only new findings introduced by the PR block — inherited issues don't.
+        # Skip on direct pushes to main: there's no base branch to diff against.
+        if: github.event_name == 'pull_request'
+        run: bunx fallow audit --base origin/${{ github.base_ref }} --fail-on-issues

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -41,4 +41,13 @@ echo "→ ui tests"
 echo "→ ui build"
 (cd ui && bun run build)
 
+# Delta audit vs the merge base — only new dead-code/complexity/dupes block.
+# Skipped when origin/main is unavailable (e.g. offline) so a push isn't wedged.
+if git rev-parse --verify --quiet origin/main >/dev/null; then
+  echo "→ fallow audit (delta vs origin/main)"
+  bunx fallow audit --base origin/main --fail-on-issues
+else
+  echo "→ fallow audit skipped (origin/main not available)"
+fi
+
 echo "✓ pre-push passed"

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -27,37 +27,30 @@ function host(url: unknown): string {
   }
 }
 
+type Summarizer = (input: Record<string, unknown>) => string;
+
+/** Per-tool summary renderers; one shared renderer aliased across equivalent tools. */
+const SUMMARIZERS: Record<string, Summarizer> = {
+  Edit: (i) => `edited ${basename(i.file_path ?? i.notebook_path)}`,
+  MultiEdit: (i) => `edited ${basename(i.file_path ?? i.notebook_path)}`,
+  NotebookEdit: (i) => `edited ${basename(i.file_path ?? i.notebook_path)}`,
+  Write: (i) => `wrote ${basename(i.file_path)}`,
+  Read: (i) => `read ${basename(i.file_path)}`,
+  Bash: (i) => `$ ${truncate(String(i.command ?? ""), CMD_MAX)}`,
+  Grep: (i) => `searched "${i.pattern ?? ""}"`,
+  Glob: (i) => `globbed ${i.pattern ?? ""}`,
+  Task: (i) => `dispatched ${i.subagent_type ?? "agent"}`,
+  Agent: (i) => `dispatched ${i.subagent_type ?? "agent"}`,
+  Skill: (i) => `skill ${i.skill ?? ""}`,
+  TodoWrite: () => "updated todos",
+  WebFetch: (i) => `fetched ${host(i.url)}`,
+  WebSearch: (i) => `web search "${i.query ?? ""}"`,
+};
+
 /** Render a tool_use block into a compact human summary line. */
 function summarize(tool: string, input: Record<string, unknown>): string {
-  switch (tool) {
-    case "Edit":
-    case "MultiEdit":
-    case "NotebookEdit":
-      return `edited ${basename(input.file_path ?? input.notebook_path)}`;
-    case "Write":
-      return `wrote ${basename(input.file_path)}`;
-    case "Read":
-      return `read ${basename(input.file_path)}`;
-    case "Bash":
-      return `$ ${truncate(String(input.command ?? ""), CMD_MAX)}`;
-    case "Grep":
-      return `searched "${input.pattern ?? ""}"`;
-    case "Glob":
-      return `globbed ${input.pattern ?? ""}`;
-    case "Task":
-    case "Agent":
-      return `dispatched ${input.subagent_type ?? "agent"}`;
-    case "Skill":
-      return `skill ${input.skill ?? ""}`;
-    case "TodoWrite":
-      return "updated todos";
-    case "WebFetch":
-      return `fetched ${host(input.url)}`;
-    case "WebSearch":
-      return `web search "${input.query ?? ""}"`;
-    default:
-      return tool.toLowerCase();
-  }
+  const fn = SUMMARIZERS[tool];
+  return fn ? fn(input) : tool.toLowerCase();
 }
 
 interface Block {
@@ -69,13 +62,14 @@ interface Block {
   is_error?: boolean;
 }
 
-/**
- * Parse a JSONL transcript into a chronological list of tool-use activity entries,
- * pairing each tool_use with its tool_result for status. Returns the most-recent
- * `limit` entries (oldest→newest). Malformed lines are skipped.
- */
-export function parseActivity(text: string, limit = DEFAULT_LIMIT): ActivityEntry[] {
-  const records: { o: any; blocks: Block[] }[] = [];
+interface ParsedRecord {
+  o: any;
+  blocks: Block[];
+}
+
+/** Parse JSONL lines, keeping only records whose message content is a block array. */
+function parseRecords(text: string): ParsedRecord[] {
+  const records: ParsedRecord[] = [];
   for (const line of text.split("\n")) {
     const t = line.trim();
     if (!t) continue;
@@ -88,8 +82,11 @@ export function parseActivity(text: string, limit = DEFAULT_LIMIT): ActivityEntr
     const blocks = o?.message?.content;
     if (Array.isArray(blocks)) records.push({ o, blocks });
   }
+  return records;
+}
 
-  // pass 1: map tool_use_id → is_error from every tool_result block
+/** Map tool_use_id → is_error from every tool_result block (pass 1). */
+function collectErrors(records: ParsedRecord[]): Map<string, boolean> {
   const errored = new Map<string, boolean>();
   for (const { blocks } of records) {
     for (const b of blocks) {
@@ -98,23 +95,39 @@ export function parseActivity(text: string, limit = DEFAULT_LIMIT): ActivityEntr
       }
     }
   }
+  return errored;
+}
 
-  // pass 2: collect tool_use blocks in order, attaching paired status
+/** Resolve a tool_use's status from the paired tool_result error map. */
+function resolveStatus(errored: Map<string, boolean>, id: string): ActivityEntry["status"] {
+  if (!errored.has(id)) return "pending";
+  return errored.get(id) ? "error" : "ok";
+}
+
+/** Build ordered tool-use entries, attaching paired status (pass 2). */
+function collectEntries(records: ParsedRecord[], errored: Map<string, boolean>): ActivityEntry[] {
   const entries: ActivityEntry[] = [];
   for (const { o, blocks } of records) {
     const ts = Date.parse(o?.timestamp) || 0;
     for (const b of blocks) {
       if (b?.type !== "tool_use" || typeof b.name !== "string") continue;
       const id = typeof b.id === "string" ? b.id : "";
-      const status: ActivityEntry["status"] = !errored.has(id)
-        ? "pending"
-        : errored.get(id)
-          ? "error"
-          : "ok";
+      const status = resolveStatus(errored, id);
       entries.push({ ts, tool: b.name, summary: summarize(b.name, b.input ?? {}), status });
     }
   }
+  return entries;
+}
 
+/**
+ * Parse a JSONL transcript into a chronological list of tool-use activity entries,
+ * pairing each tool_use with its tool_result for status. Returns the most-recent
+ * `limit` entries (oldest→newest). Malformed lines are skipped.
+ */
+export function parseActivity(text: string, limit = DEFAULT_LIMIT): ActivityEntry[] {
+  const records = parseRecords(text);
+  const errored = collectErrors(records);
+  const entries = collectEntries(records, errored);
   return limit >= 0 ? entries.slice(-limit) : entries;
 }
 

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -10,6 +10,87 @@ function stripPrefix(p: string): string {
   return p.replace(/^[ab]\//, "");
 }
 
+/** Start a fresh DiffFile from a `diff --git a/… b/…` header line. */
+function startFile(raw: string): DiffFile {
+  const m = raw.match(/^diff --git a\/(.+) b\/(.+)$/);
+  return {
+    path: m ? m[2]! : "",
+    status: "modified",
+    additions: 0,
+    deletions: 0,
+    binary: false,
+    hunks: [],
+  };
+}
+
+/**
+ * Apply a file-metadata header line (mode/rename/binary/---/+++ ) to `cur`.
+ * Returns true when the line was a recognized header and consumed.
+ */
+function applyFileHeader(cur: DiffFile, raw: string): boolean {
+  if (raw.startsWith("new file mode")) {
+    cur.status = "added";
+  } else if (raw.startsWith("deleted file mode")) {
+    cur.status = "deleted";
+  } else if (raw.startsWith("rename from ")) {
+    cur.status = "renamed";
+    cur.oldPath = raw.slice("rename from ".length);
+  } else if (raw.startsWith("rename to ")) {
+    cur.status = "renamed";
+    cur.path = raw.slice("rename to ".length);
+  } else if (raw.startsWith("Binary files")) {
+    cur.binary = true;
+  } else if (raw.startsWith("--- ")) {
+    const p = stripPrefix(raw.slice(4));
+    if (p) cur.oldPath = cur.status === "renamed" ? cur.oldPath : p;
+  } else if (raw.startsWith("+++ ")) {
+    const p = stripPrefix(raw.slice(4));
+    if (p) cur.path = p;
+  } else {
+    return false;
+  }
+  return true;
+}
+
+/** Parse a `@@ -a,b +c,d @@` hunk header into 1-based old/new starting line numbers. */
+function parseHunkHeader(raw: string): { oldNo: number; newNo: number } {
+  const m = raw.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+  return {
+    oldNo: m ? parseInt(m[1]!, 10) : 0,
+    newNo: m ? parseInt(m[2]!, 10) : 0,
+  };
+}
+
+/** Cursor over old/new line numbers, mutated as hunk body lines are classified. */
+interface LineCursor {
+  oldNo: number;
+  newNo: number;
+}
+
+/**
+ * Classify one hunk body line and append it to `hunk`, advancing line numbers and
+ * file counts. Returns true when the line counted toward MAX_FILE_LINES (add/del/ctx).
+ */
+function appendBodyLine(cur: DiffFile, hunk: DiffHunk, cursor: LineCursor, raw: string): boolean {
+  const marker = raw[0];
+  const content = raw.slice(1);
+  if (marker === "+") {
+    cur.additions++;
+    hunk.lines.push({ kind: "add", content, newNo: cursor.newNo++ });
+    return true;
+  }
+  if (marker === "-") {
+    cur.deletions++;
+    hunk.lines.push({ kind: "del", content, oldNo: cursor.oldNo++ });
+    return true;
+  }
+  if (marker === " ") {
+    hunk.lines.push({ kind: "ctx", content, oldNo: cursor.oldNo++, newNo: cursor.newNo++ });
+    return true;
+  }
+  return false;
+}
+
 /**
  * Parse `git diff --no-color` unified output into structured files.
  * Handles added / modified / deleted / renamed / binary, computes +/- counts,
@@ -20,8 +101,7 @@ export function parseUnifiedDiff(text: string): DiffFile[] {
   const files: DiffFile[] = [];
   let cur: DiffFile | null = null;
   let hunk: DiffHunk | null = null;
-  let oldNo = 0;
-  let newNo = 0;
+  const cursor: LineCursor = { oldNo: 0, newNo: 0 };
   let lineCount = 0; // add/del/ctx lines accumulated for cur
 
   const finishFile = () => {
@@ -38,77 +118,24 @@ export function parseUnifiedDiff(text: string): DiffFile[] {
       finishFile();
       hunk = null;
       lineCount = 0;
-      const m = raw.match(/^diff --git a\/(.+) b\/(.+)$/);
-      cur = {
-        path: m ? m[2]! : "",
-        status: "modified",
-        additions: 0,
-        deletions: 0,
-        binary: false,
-        hunks: [],
-      };
+      cur = startFile(raw);
       continue;
     }
     if (!cur) continue;
+    if (applyFileHeader(cur, raw)) continue;
 
-    if (raw.startsWith("new file mode")) {
-      cur.status = "added";
-      continue;
-    }
-    if (raw.startsWith("deleted file mode")) {
-      cur.status = "deleted";
-      continue;
-    }
-    if (raw.startsWith("rename from ")) {
-      cur.status = "renamed";
-      cur.oldPath = raw.slice("rename from ".length);
-      continue;
-    }
-    if (raw.startsWith("rename to ")) {
-      cur.status = "renamed";
-      cur.path = raw.slice("rename to ".length);
-      continue;
-    }
-    if (raw.startsWith("Binary files")) {
-      cur.binary = true;
-      continue;
-    }
-    if (raw.startsWith("--- ")) {
-      const p = stripPrefix(raw.slice(4));
-      if (p) cur.oldPath = cur.status === "renamed" ? cur.oldPath : p;
-      continue;
-    }
-    if (raw.startsWith("+++ ")) {
-      const p = stripPrefix(raw.slice(4));
-      if (p) cur.path = p;
-      continue;
-    }
     if (raw.startsWith("@@")) {
-      const m = raw.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
-      oldNo = m ? parseInt(m[1]!, 10) : 0;
-      newNo = m ? parseInt(m[2]!, 10) : 0;
+      const start = parseHunkHeader(raw);
+      cursor.oldNo = start.oldNo;
+      cursor.newNo = start.newNo;
       hunk = { header: raw, lines: [] };
       cur.hunks.push(hunk);
       continue;
     }
     if (!hunk) continue;
-
     if (raw.startsWith("\\")) continue; // "\ No newline at end of file"
 
-    const marker = raw[0];
-    const content = raw.slice(1);
-    if (marker === "+") {
-      cur.additions++;
-      lineCount++;
-      hunk.lines.push({ kind: "add", content, newNo: newNo++ });
-    } else if (marker === "-") {
-      cur.deletions++;
-      lineCount++;
-      hunk.lines.push({ kind: "del", content, oldNo: oldNo++ });
-    } else if (marker === " ") {
-      lineCount++;
-      hunk.lines.push({ kind: "ctx", content, oldNo: oldNo++, newNo: newNo++ });
-    }
+    if (appendBodyLine(cur, hunk, cursor, raw)) lineCount++;
   }
   finishFile();
   return files;

--- a/src/forge/index.ts
+++ b/src/forge/index.ts
@@ -4,9 +4,6 @@ import { GiteaForge } from "./gitea";
 import { parseRemote } from "./remote";
 import type { ForgeKind, ForgeMap, GitForge } from "./types";
 
-export type { GitForge, PrStatus, ForgeMap, ForgeConfig, MergeMethod } from "./types";
-export { parseRemote } from "./remote";
-
 /** Decide the forge kind for a host: explicit config wins, else github.com is github. */
 function kindFor(host: string, map: ForgeMap): ForgeKind | null {
   const cfg = map[host];
@@ -28,7 +25,7 @@ export function forgeFor(remoteUrl: string, map: ForgeMap): GitForge | null {
 }
 
 /** Read `origin` remote URL for a repo dir, or null. */
-export function originUrl(repoDir: string): string | null {
+function originUrl(repoDir: string): string | null {
   try {
     return execFileSync("git", ["-C", repoDir, "remote", "get-url", "origin"], {
       encoding: "utf8",

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1,6 +1,6 @@
 import type { SessionStore } from "./store";
 import type { Session } from "./types";
-import { mapState, type HerdrDriver } from "./herdr";
+import { mapState, type HerdrDriver, type HerdrAgent } from "./herdr";
 import { classifyBlocked, tailLines, type BlockReason } from "./blocked";
 import { isStalled, readSnapshot, DEFAULT_STALL, type ActivitySnapshot } from "./stall";
 import { jsonlPathFor } from "./usage";
@@ -35,28 +35,40 @@ export class StatusPoller {
     for (const s of this.store.list({ activeOnly: true })) {
       activeIds.add(s.id);
       const agent = byTerm.get(s.herdrAgentId);
-      if (!agent) {
-        // the herdr agent is gone (claude exited / user ctrl-c'd the session).
-        // mirror reconcile()'s startup behavior, but live — otherwise the session
-        // stays "running" forever and the pty client keeps re-attaching a dead
-        // terminal (herdr replies agent_not_found in a tight reconnect loop).
-        this.clearBlock(s.id);
-        if (s.status !== "done") {
-          this.store.update(s.id, { status: "done", lastState: "done" });
-          this.onChange(s.id, "done");
-        }
-        continue;
-      }
-      const status = mapState(agent.agentStatus);
-      if (status !== s.status || agent.agentStatus !== s.lastState) {
-        this.store.update(s.id, { status, lastState: agent.agentStatus });
-        this.onChange(s.id, status);
-      }
-      if (status === "blocked") this.maybeClassify(s.id, s.herdrAgentId);
-      else if (status === "running") this.maybeStall(s);
-      else this.clearBlock(s.id);
+      if (!agent) this.reapGone(s);
+      else this.reconcileAgent(s, agent);
     }
-    // prune tracking state for sessions no longer active (archived/removed)
+    this.pruneInactive(activeIds);
+  }
+
+  /**
+   * The herdr agent is gone (claude exited / user ctrl-c'd the session).
+   * Mirror reconcile()'s startup behavior, but live — otherwise the session
+   * stays "running" forever and the pty client keeps re-attaching a dead
+   * terminal (herdr replies agent_not_found in a tight reconnect loop).
+   */
+  private reapGone(s: Session): void {
+    this.clearBlock(s.id);
+    if (s.status !== "done") {
+      this.store.update(s.id, { status: "done", lastState: "done" });
+      this.onChange(s.id, "done");
+    }
+  }
+
+  /** Sync a live agent's status into the store and route its block/stall handling. */
+  private reconcileAgent(s: Session, agent: HerdrAgent): void {
+    const status = mapState(agent.agentStatus);
+    if (status !== s.status || agent.agentStatus !== s.lastState) {
+      this.store.update(s.id, { status, lastState: agent.agentStatus });
+      this.onChange(s.id, status);
+    }
+    if (status === "blocked") this.maybeClassify(s.id, s.herdrAgentId);
+    else if (status === "running") this.maybeStall(s);
+    else this.clearBlock(s.id);
+  }
+
+  /** Prune tracking state for sessions no longer active (archived/removed). */
+  private pruneInactive(activeIds: Set<string>): void {
     for (const id of this.lastSig.keys()) {
       if (!activeIds.has(id)) {
         this.lastReadAt.delete(id);

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -2,7 +2,7 @@
 // Absolute scale is irrelevant: the daily /usage calibration backs out the cap against these,
 // so only the ratios between models/kinds matter. Values track public API list prices.
 
-export interface ModelWeights {
+interface ModelWeights {
   input: number;
   output: number;
   cacheRead: number;

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -29,7 +29,7 @@ const DEFAULT: ModelWeights = TABLE[1]!.w; // sonnet-like
 
 const warned = new Set<string>();
 
-export function weightsFor(model: string): ModelWeights {
+function weightsFor(model: string): ModelWeights {
   for (const { match, w } of TABLE) if (match.test(model)) return w;
   if (!warned.has(model)) {
     warned.add(model);

--- a/src/pty-demux.mjs
+++ b/src/pty-demux.mjs
@@ -14,35 +14,46 @@ export function createDemux({ onInput, onResize }) {
   // transiently-dead pty), so only forward genuine size changes.
   let lastC = -1;
   let lastR = -1;
+
+  // Consume any complete resize frames at the head of the buffer. Returns true
+  // if at least one frame was consumed (buffer advanced).
+  function consumeResizes() {
+    let any = false;
+    let nl;
+    while (buf.startsWith("\x00resize:") && (nl = buf.indexOf("\n")) !== -1) {
+      const [, c, r] = buf.slice(0, nl).split(":");
+      buf = buf.slice(nl + 1);
+      const cols = Number(c) || 100;
+      const rows = Number(r) || 30;
+      if (cols !== lastC || rows !== lastR) {
+        lastC = cols;
+        lastR = rows;
+        onResize(cols, rows);
+      }
+      any = true;
+    }
+    return any;
+  }
+
+  // Forward the leading run of input, stopping at the next NUL (which begins a
+  // control frame). A bare leading NUL with no frame yet is held until more
+  // bytes arrive. Returns true if input was forwarded (buffer advanced).
+  function forwardInput() {
+    if (!buf || buf.startsWith("\x00")) return false;
+    const nul = buf.indexOf("\x00");
+    onInput(nul === -1 ? buf : buf.slice(0, nul));
+    buf = nul === -1 ? "" : buf.slice(nul);
+    return true;
+  }
+
   return {
     feed(chunk) {
       buf += chunk;
       let progressed = true;
       while (progressed) {
-        progressed = false;
-        // consume any complete resize frames at the head of the buffer
-        let nl;
-        while (buf.startsWith("\x00resize:") && (nl = buf.indexOf("\n")) !== -1) {
-          const [, c, r] = buf.slice(0, nl).split(":");
-          buf = buf.slice(nl + 1);
-          const cols = Number(c) || 100;
-          const rows = Number(r) || 30;
-          if (cols !== lastC || rows !== lastR) {
-            lastC = cols;
-            lastR = rows;
-            onResize(cols, rows);
-          }
-          progressed = true;
-        }
-        // forward the leading run of input, stopping at the next NUL (which
-        // begins a control frame). A bare leading NUL with no frame yet is held
-        // until more bytes arrive.
-        if (buf && !buf.startsWith("\x00")) {
-          const nul = buf.indexOf("\x00");
-          onInput(nul === -1 ? buf : buf.slice(0, nul));
-          buf = nul === -1 ? "" : buf.slice(nul);
-          progressed = true;
-        }
+        const resized = consumeResizes();
+        const forwarded = forwardInput();
+        progressed = resized || forwarded;
       }
     },
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -104,6 +104,15 @@ function checkOrigin(req: Request): Response | null {
   return null;
 }
 
+// Shared `Content-Type: application/json` guard. Returns the 415 Response when
+// the header is absent/wrong, or null to proceed — same message everywhere.
+function requireJsonContentType(req: Request): Response | null {
+  if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
+    return json({ error: "Content-Type must be application/json" }, 415);
+  }
+  return null;
+}
+
 // ── per-resource route handlers ────────────────────────────────────────────
 // Each handler matches its own resource group and returns a Response when it
 // owns the request, or `null` to fall through to the next handler — mirroring
@@ -121,46 +130,49 @@ function handleGitSnapshot({ req, parts, deps }: Ctx): Response | null {
   return null;
 }
 
+async function pushSubscribe(req: Request, deps: AppDeps): Promise<Response> {
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+  const body = (await req.json().catch(() => null)) as {
+    endpoint?: unknown;
+    keys?: { p256dh?: unknown; auth?: unknown };
+    locale?: unknown;
+  } | null;
+  if (
+    !body ||
+    typeof body.endpoint !== "string" ||
+    typeof body.keys?.p256dh !== "string" ||
+    typeof body.keys?.auth !== "string"
+  ) {
+    return json({ error: "body must be a PushSubscription" }, 400);
+  }
+  deps.push?.subscribe(
+    {
+      endpoint: body.endpoint,
+      keys: { p256dh: body.keys.p256dh, auth: body.keys.auth },
+      locale: typeof body.locale === "string" ? body.locale : undefined,
+    },
+    req.headers.get("User-Agent") ?? "",
+  );
+  return json({ ok: true });
+}
+
+async function pushUnsubscribe(req: Request, deps: AppDeps): Promise<Response> {
+  const body = (await req.json().catch(() => null)) as { endpoint?: unknown } | null;
+  if (!body || typeof body.endpoint !== "string") {
+    return json({ error: "body must be {endpoint: string}" }, 400);
+  }
+  deps.push?.unsubscribe(body.endpoint);
+  return json({ ok: true });
+}
+
 async function handlePush({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (parts[0] === "api" && parts[1] === "push") {
     if (req.method === "GET" && parts[2] === "vapid") {
       return json({ publicKey: deps.push?.publicKey() ?? null });
     }
-    if (req.method === "POST" && parts[2] === "subscribe") {
-      if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-        return json({ error: "Content-Type must be application/json" }, 415);
-      }
-      const body = (await req.json().catch(() => null)) as {
-        endpoint?: unknown;
-        keys?: { p256dh?: unknown; auth?: unknown };
-        locale?: unknown;
-      } | null;
-      if (
-        !body ||
-        typeof body.endpoint !== "string" ||
-        typeof body.keys?.p256dh !== "string" ||
-        typeof body.keys?.auth !== "string"
-      ) {
-        return json({ error: "body must be a PushSubscription" }, 400);
-      }
-      deps.push?.subscribe(
-        {
-          endpoint: body.endpoint,
-          keys: { p256dh: body.keys.p256dh, auth: body.keys.auth },
-          locale: typeof body.locale === "string" ? body.locale : undefined,
-        },
-        req.headers.get("User-Agent") ?? "",
-      );
-      return json({ ok: true });
-    }
-    if (req.method === "POST" && parts[2] === "unsubscribe") {
-      const body = (await req.json().catch(() => null)) as { endpoint?: unknown } | null;
-      if (!body || typeof body.endpoint !== "string") {
-        return json({ error: "body must be {endpoint: string}" }, 400);
-      }
-      deps.push?.unsubscribe(body.endpoint);
-      return json({ ok: true });
-    }
+    if (req.method === "POST" && parts[2] === "subscribe") return pushSubscribe(req, deps);
+    if (req.method === "POST" && parts[2] === "unsubscribe") return pushUnsubscribe(req, deps);
   }
   return null;
 }
@@ -168,9 +180,8 @@ async function handlePush({ req, parts, deps }: Ctx): Promise<Response | null> {
 // POST /api/sessions — create a session.
 async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "POST" && !parts[2])) return null;
-  if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-    return json({ error: "Content-Type must be application/json" }, 415);
-  }
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
   const body = await req.json().catch(() => null);
   const result = validateCreate(body, config.repoRoot);
   if (!result.ok) return json({ error: result.error }, 400);
@@ -189,34 +200,42 @@ async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response 
   return json(s, 201);
 }
 
+async function sessionUsageRead(id: string, deps: AppDeps): Promise<Response> {
+  const s = deps.store.get(id);
+  return s ? json(await sessionUsage(s)) : json({ error: "not found" }, 404);
+}
+
+async function sessionActivityRead(id: string, deps: AppDeps): Promise<Response> {
+  const s = deps.store.get(id);
+  if (!s) return json({ error: "not found" }, 404);
+  // pre-feature session (no pinned id) → no transcript to read
+  const path = s.claudeSessionId ? jsonlPathFor(s.worktreePath, s.claudeSessionId) : "";
+  return json(path ? await sessionActivity(path) : []);
+}
+
+function sessionDiffRead(id: string, deps: AppDeps): Response {
+  const s = deps.store.get(id);
+  if (!s) return json({ error: "not found" }, 404);
+  try {
+    return json(computeDiff(s.worktreePath, s.baseBranch, s.branch));
+  } catch (e) {
+    return json({ error: e instanceof Error ? e.message : "diff failed" }, 500);
+  }
+}
+
+function sessionRead(id: string, deps: AppDeps): Response {
+  const s = deps.store.get(id);
+  return s ? json(s) : json({ error: "not found" }, 404);
+}
+
 // GET reads on /api/sessions[/:id[/usage|/activity|/diff]].
 async function handleSessionReads({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (req.method !== "GET") return null;
   if (!parts[2]) return json(deps.store.list({ activeOnly: true }));
-  if (parts[3] === "usage") {
-    const s = deps.store.get(parts[2]);
-    return s ? json(await sessionUsage(s)) : json({ error: "not found" }, 404);
-  }
-  if (parts[3] === "activity") {
-    const s = deps.store.get(parts[2]);
-    if (!s) return json({ error: "not found" }, 404);
-    // pre-feature session (no pinned id) → no transcript to read
-    const path = s.claudeSessionId ? jsonlPathFor(s.worktreePath, s.claudeSessionId) : "";
-    return json(path ? await sessionActivity(path) : []);
-  }
-  if (parts[3] === "diff") {
-    const s = deps.store.get(parts[2]);
-    if (!s) return json({ error: "not found" }, 404);
-    try {
-      return json(computeDiff(s.worktreePath, s.baseBranch, s.branch));
-    } catch (e) {
-      return json({ error: e instanceof Error ? e.message : "diff failed" }, 500);
-    }
-  }
-  if (!parts[3]) {
-    const s = deps.store.get(parts[2]);
-    return s ? json(s) : json({ error: "not found" }, 404);
-  }
+  if (parts[3] === "usage") return sessionUsageRead(parts[2], deps);
+  if (parts[3] === "activity") return sessionActivityRead(parts[2], deps);
+  if (parts[3] === "diff") return sessionDiffRead(parts[2], deps);
+  if (!parts[3]) return sessionRead(parts[2], deps);
   return null;
 }
 
@@ -232,9 +251,8 @@ function handleSessionDelete({ req, parts, deps }: Ctx): Response | null {
 // POST /api/sessions/:id/reply — steer a running session.
 async function handleSessionReply({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "POST" && parts[2] && parts[3] === "reply")) return null;
-  if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-    return json({ error: "Content-Type must be application/json" }, 415);
-  }
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
   const body = await req.json().catch(() => null);
   if (!body || typeof (body as { text?: unknown }).text !== "string") {
     return json({ error: "body must be {text: string}" }, 400);
@@ -281,61 +299,92 @@ async function handleSessions(ctx: Ctx): Promise<Response | null> {
 }
 
 // ── git host (forge) actions: /api/sessions/:id/git[/pr|/merge|/redeploy] ──
-async function handleSessionGit({ req, parts, deps }: Ctx): Promise<Response | null> {
-  if (parts[0] === "api" && parts[1] === "sessions" && parts[2] && parts[3] === "git") {
-    const session = deps.store.get(parts[2]);
-    if (!session) return json({ error: "not found" }, 404);
-    const forge = deps.resolveForge?.(session.repoPath) ?? null;
-    if (!forge) return json({ error: "no forge for this repo" }, 404);
-    const head = session.branch ?? "";
-    try {
-      if (req.method === "GET" && !parts[4]) {
-        return json({ kind: forge.kind, ...(await forge.prStatus(head)) });
-      }
-      if (req.method === "POST" && parts[4] === "pr") {
-        const body = (await req.json().catch(() => ({}))) as { title?: string; body?: string };
-        const status = await forge.openPr({
-          head,
-          base: session.baseBranch,
-          title: body.title?.trim() || session.name,
-          body: body.body ?? session.prompt,
-        });
-        const git: GitState = { kind: forge.kind, ...status };
-        deps.prCache?.set(session.id, git);
-        deps.events.emit("session:git", { id: session.id, git });
-        return json(status);
-      }
-      if (req.method === "POST" && parts[4] === "merge") {
-        const body = (await req.json().catch(() => ({}))) as {
-          method?: MergeMethod;
-          deleteBranch?: boolean;
-        };
-        const cur = await forge.prStatus(head);
-        if (cur.state !== "open" || !cur.number) {
-          return json({ error: "no open PR to merge" }, 409);
-        }
-        await forge.merge(cur.number, {
-          method: body.method ?? forge.mergeMethod,
-          deleteBranch: body.deleteBranch ?? true,
-        });
-        const status = await forge.prStatus(head);
-        const git: GitState = { kind: forge.kind, ...status };
-        deps.prCache?.set(session.id, git);
-        deps.events.emit("session:git", { id: session.id, git });
-        return json(status);
-      }
-      if (req.method === "POST" && parts[4] === "redeploy") {
-        if (!forge.deployWorkflow) {
-          return json({ error: "no deploy workflow configured" }, 400);
-        }
-        await forge.redeploy({ workflow: forge.deployWorkflow, ref: session.baseBranch });
-        return json({ ok: true });
-      }
-    } catch (e) {
-      return json({ error: e instanceof Error ? e.message : "forge error" }, 502);
-    }
+async function forgeOpenPr(
+  forge: GitForge,
+  session: Session,
+  req: Request,
+  deps: AppDeps,
+): Promise<Response> {
+  const head = session.branch ?? "";
+  const body = (await req.json().catch(() => ({}))) as { title?: string; body?: string };
+  const status = await forge.openPr({
+    head,
+    base: session.baseBranch,
+    title: body.title?.trim() || session.name,
+    body: body.body ?? session.prompt,
+  });
+  const git: GitState = { kind: forge.kind, ...status };
+  deps.prCache?.set(session.id, git);
+  deps.events.emit("session:git", { id: session.id, git });
+  return json(status);
+}
+
+async function forgeMerge(
+  forge: GitForge,
+  session: Session,
+  req: Request,
+  deps: AppDeps,
+): Promise<Response> {
+  const head = session.branch ?? "";
+  const body = (await req.json().catch(() => ({}))) as {
+    method?: MergeMethod;
+    deleteBranch?: boolean;
+  };
+  const cur = await forge.prStatus(head);
+  if (cur.state !== "open" || !cur.number) {
+    return json({ error: "no open PR to merge" }, 409);
+  }
+  await forge.merge(cur.number, {
+    method: body.method ?? forge.mergeMethod,
+    deleteBranch: body.deleteBranch ?? true,
+  });
+  const status = await forge.prStatus(head);
+  const git: GitState = { kind: forge.kind, ...status };
+  deps.prCache?.set(session.id, git);
+  deps.events.emit("session:git", { id: session.id, git });
+  return json(status);
+}
+
+async function forgeRedeploy(forge: GitForge, session: Session): Promise<Response> {
+  if (!forge.deployWorkflow) {
+    return json({ error: "no deploy workflow configured" }, 400);
+  }
+  await forge.redeploy({ workflow: forge.deployWorkflow, ref: session.baseBranch });
+  return json({ ok: true });
+}
+
+async function dispatchForgeAction(
+  forge: GitForge,
+  session: Session,
+  ctx: Ctx,
+): Promise<Response | null> {
+  const { req, parts, deps } = ctx;
+  if (req.method === "GET") {
+    if (!parts[4]) return json({ kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) });
+    return null;
+  }
+  if (req.method === "POST") {
+    if (parts[4] === "pr") return forgeOpenPr(forge, session, req, deps);
+    if (parts[4] === "merge") return forgeMerge(forge, session, req, deps);
+    if (parts[4] === "redeploy") return forgeRedeploy(forge, session);
   }
   return null;
+}
+
+async function handleSessionGit(ctx: Ctx): Promise<Response | null> {
+  const { parts, deps } = ctx;
+  if (!(parts[0] === "api" && parts[1] === "sessions" && parts[2] && parts[3] === "git")) {
+    return null;
+  }
+  const session = deps.store.get(parts[2]);
+  if (!session) return json({ error: "not found" }, 404);
+  const forge = deps.resolveForge?.(session.repoPath) ?? null;
+  if (!forge) return json({ error: "no forge for this repo" }, 404);
+  try {
+    return await dispatchForgeAction(forge, session, ctx);
+  } catch (e) {
+    return json({ error: e instanceof Error ? e.message : "forge error" }, 502);
+  }
 }
 
 function handleUsageLimits({ req, parts, deps }: Ctx): Response | null {
@@ -351,26 +400,30 @@ function handleUsageLimits({ req, parts, deps }: Ctx): Response | null {
 }
 
 // ── self-update: status + trigger ──────────────────────────────────────
+function updateStatus(deps: AppDeps): Response {
+  return json(
+    deps.updates?.current() ?? {
+      behind: 0,
+      current: null,
+      latest: null,
+      commits: [],
+      checkedAt: Date.now(),
+    },
+  );
+}
+
+function updateApply(deps: AppDeps): Response {
+  if (!deps.updates) return json({ error: "updates not available" }, 503);
+  const status = deps.updates.current();
+  if (!status || status.behind <= 0) return json({ error: "no update available" }, 409);
+  const r = deps.updates.apply();
+  return json({ ok: r.started }, r.started ? 202 : 409);
+}
+
 function handleUpdate({ req, parts, deps }: Ctx): Response | null {
   if (parts[0] === "api" && parts[1] === "update" && !parts[2]) {
-    if (req.method === "GET") {
-      return json(
-        deps.updates?.current() ?? {
-          behind: 0,
-          current: null,
-          latest: null,
-          commits: [],
-          checkedAt: Date.now(),
-        },
-      );
-    }
-    if (req.method === "POST") {
-      if (!deps.updates) return json({ error: "updates not available" }, 503);
-      const status = deps.updates.current();
-      if (!status || status.behind <= 0) return json({ error: "no update available" }, 409);
-      const r = deps.updates.apply();
-      return json({ ok: r.started }, r.started ? 202 : 409);
-    }
+    if (req.method === "GET") return updateStatus(deps);
+    if (req.method === "POST") return updateApply(deps);
   }
   return null;
 }
@@ -449,9 +502,8 @@ async function handleSteers({ req, parts, deps }: Ctx): Promise<Response | null>
   if (parts[0] === "api" && parts[1] === "steers" && !parts[2]) {
     if (req.method === "GET") return json(loadSteers(deps.store));
     if (req.method === "PUT") {
-      if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-        return json({ error: "Content-Type must be application/json" }, 415);
-      }
+      const ctErr = requireJsonContentType(req);
+      if (ctErr) return ctErr;
       const body = await req.json().catch(() => null);
       const steers = validateSteers(body);
       if (!steers) return json({ error: "invalid steers payload" }, 400);
@@ -467,9 +519,8 @@ async function handleProjectIcons({ req, parts, deps }: Ctx): Promise<Response |
   if (parts[0] === "api" && parts[1] === "project-icons" && !parts[2]) {
     if (req.method === "GET") return json(loadIcons(deps.store));
     if (req.method === "PUT") {
-      if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-        return json({ error: "Content-Type must be application/json" }, 415);
-      }
+      const ctErr = requireJsonContentType(req);
+      if (ctErr) return ctErr;
       const body = await req.json().catch(() => null);
       const patch = validateIconPatch(body);
       if (!patch) return json({ error: "invalid project-icon payload" }, 400);
@@ -485,9 +536,8 @@ async function handleProjectIcons({ req, parts, deps }: Ctx): Promise<Response |
 async function handleBroadcast({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (parts[0] === "api" && parts[1] === "broadcast" && !parts[2]) {
     if (req.method === "POST") {
-      if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-        return json({ error: "Content-Type must be application/json" }, 415);
-      }
+      const ctErr = requireJsonContentType(req);
+      if (ctErr) return ctErr;
       const body = await req.json().catch(() => null);
       const parsed = validateBroadcast(body);
       if (!parsed) return json({ error: "body must be {text: string, ids: string[]}" }, 400);
@@ -530,27 +580,27 @@ async function handleIssues({ req, parts, url, deps }: Ctx): Promise<Response | 
   return null;
 }
 
+function todoRead(repoParam: string): Response {
+  const r = readTodo(repoParam, config.repoRoot);
+  if (!r.ok) return json({ error: "invalid repo path" }, 400);
+  return json(r);
+}
+
+async function todoWrite(repoParam: string, req: Request): Promise<Response> {
+  const body = await req.json().catch(() => null);
+  if (body === null || typeof body !== "object" || typeof (body as any).content !== "string") {
+    return json({ error: "body must be {content: string}" }, 400);
+  }
+  const ok = writeTodo(repoParam, config.repoRoot, (body as any).content);
+  if (!ok) return json({ error: "invalid repo path or content too large" }, 400);
+  return json({ ok: true });
+}
+
 async function handleTodo({ req, parts, url }: Ctx): Promise<Response | null> {
   if (parts[0] === "api" && parts[1] === "todo" && !parts[2]) {
     const repoParam = url.searchParams.get("repo") ?? "";
-    if (req.method === "GET") {
-      const r = readTodo(repoParam, config.repoRoot);
-      if (!r.ok) return json({ error: "invalid repo path" }, 400);
-      return json(r);
-    }
-    if (req.method === "PUT") {
-      const body = await req.json().catch(() => null);
-      if (
-        body === null ||
-        typeof body !== "object" ||
-        typeof (body as any).content !== "string"
-      ) {
-        return json({ error: "body must be {content: string}" }, 400);
-      }
-      const ok = writeTodo(repoParam, config.repoRoot, (body as any).content);
-      if (!ok) return json({ error: "invalid repo path or content too large" }, 400);
-      return json({ ok: true });
-    }
+    if (req.method === "GET") return todoRead(repoParam);
+    if (req.method === "PUT") return todoWrite(repoParam, req);
   }
   return null;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -360,7 +360,8 @@ async function dispatchForgeAction(
 ): Promise<Response | null> {
   const { req, parts, deps } = ctx;
   if (req.method === "GET") {
-    if (!parts[4]) return json({ kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) });
+    if (!parts[4])
+      return json({ kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) });
     return null;
   }
   if (req.method === "POST") {
@@ -388,12 +389,7 @@ async function handleSessionGit(ctx: Ctx): Promise<Response | null> {
 }
 
 function handleUsageLimits({ req, parts, deps }: Ctx): Response | null {
-  if (
-    req.method === "GET" &&
-    parts[0] === "api" &&
-    parts[1] === "usage" &&
-    parts[2] === "limits"
-  ) {
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "usage" && parts[2] === "limits") {
     return json(deps.usageLimits.limits(Date.now()));
   }
   return null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -506,7 +506,7 @@ type WsData =
 // The client parks (shows a take-over prompt) instead of reconnecting — without
 // it, two devices on the same session ping-pong herdr's --takeover forever.
 // Keep in sync with PTY_SUPERSEDED_CODE in ui/src/lib/pty.ts.
-export const PTY_SUPERSEDED_CODE = 4000;
+const PTY_SUPERSEDED_CODE = 4000;
 
 // A pty WS closed with this code means "this session has ended" — its herdr
 // agent is gone (the user quit claude / ctrl-c'd). The client stops reconnecting

--- a/src/server.ts
+++ b/src/server.ts
@@ -104,6 +104,478 @@ function checkOrigin(req: Request): Response | null {
   return null;
 }
 
+// ── per-resource route handlers ────────────────────────────────────────────
+// Each handler matches its own resource group and returns a Response when it
+// owns the request, or `null` to fall through to the next handler — mirroring
+// the original sequential `if`-guard chain exactly. Ordering is significant:
+// some groups share a `parts[1]` prefix (e.g. `sessions`), and a handler must
+// return `null` (not a 404) for sub-routes it doesn't own so a later handler
+// can claim them.
+
+type Ctx = { req: Request; parts: string[]; url: URL; deps: AppDeps };
+
+function handleGitSnapshot({ req, parts, deps }: Ctx): Response | null {
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "git" && !parts[2]) {
+    return json(deps.prCache?.snapshot() ?? {});
+  }
+  return null;
+}
+
+async function handlePush({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (parts[0] === "api" && parts[1] === "push") {
+    if (req.method === "GET" && parts[2] === "vapid") {
+      return json({ publicKey: deps.push?.publicKey() ?? null });
+    }
+    if (req.method === "POST" && parts[2] === "subscribe") {
+      if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
+        return json({ error: "Content-Type must be application/json" }, 415);
+      }
+      const body = (await req.json().catch(() => null)) as {
+        endpoint?: unknown;
+        keys?: { p256dh?: unknown; auth?: unknown };
+        locale?: unknown;
+      } | null;
+      if (
+        !body ||
+        typeof body.endpoint !== "string" ||
+        typeof body.keys?.p256dh !== "string" ||
+        typeof body.keys?.auth !== "string"
+      ) {
+        return json({ error: "body must be a PushSubscription" }, 400);
+      }
+      deps.push?.subscribe(
+        {
+          endpoint: body.endpoint,
+          keys: { p256dh: body.keys.p256dh, auth: body.keys.auth },
+          locale: typeof body.locale === "string" ? body.locale : undefined,
+        },
+        req.headers.get("User-Agent") ?? "",
+      );
+      return json({ ok: true });
+    }
+    if (req.method === "POST" && parts[2] === "unsubscribe") {
+      const body = (await req.json().catch(() => null)) as { endpoint?: unknown } | null;
+      if (!body || typeof body.endpoint !== "string") {
+        return json({ error: "body must be {endpoint: string}" }, 400);
+      }
+      deps.push?.unsubscribe(body.endpoint);
+      return json({ ok: true });
+    }
+  }
+  return null;
+}
+
+// POST /api/sessions — create a session.
+async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(req.method === "POST" && !parts[2])) return null;
+  if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
+    return json({ error: "Content-Type must be application/json" }, 415);
+  }
+  const body = await req.json().catch(() => null);
+  const result = validateCreate(body, config.repoRoot);
+  if (!result.ok) return json({ error: result.error }, 400);
+  let s;
+  try {
+    s = await deps.service.create(result.value);
+  } catch (e) {
+    // create shells out to herdr (and git); surface the real reason instead of a
+    // bare 500 so the New Task dialog can show it. 409 ⇒ a name still collided
+    // (a slip past uniqueName under a race), anything else ⇒ 502 (herdr/git failed).
+    const msg = e instanceof Error ? e.message : "create failed";
+    const taken = /agent_name_taken/.test(msg);
+    return json({ error: taken ? "task name already in use, retry" : msg }, taken ? 409 : 502);
+  }
+  deps.events.emit("session:new", s);
+  return json(s, 201);
+}
+
+// GET reads on /api/sessions[/:id[/usage|/activity|/diff]].
+async function handleSessionReads({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (req.method !== "GET") return null;
+  if (!parts[2]) return json(deps.store.list({ activeOnly: true }));
+  if (parts[3] === "usage") {
+    const s = deps.store.get(parts[2]);
+    return s ? json(await sessionUsage(s)) : json({ error: "not found" }, 404);
+  }
+  if (parts[3] === "activity") {
+    const s = deps.store.get(parts[2]);
+    if (!s) return json({ error: "not found" }, 404);
+    // pre-feature session (no pinned id) → no transcript to read
+    const path = s.claudeSessionId ? jsonlPathFor(s.worktreePath, s.claudeSessionId) : "";
+    return json(path ? await sessionActivity(path) : []);
+  }
+  if (parts[3] === "diff") {
+    const s = deps.store.get(parts[2]);
+    if (!s) return json({ error: "not found" }, 404);
+    try {
+      return json(computeDiff(s.worktreePath, s.baseBranch, s.branch));
+    } catch (e) {
+      return json({ error: e instanceof Error ? e.message : "diff failed" }, 500);
+    }
+  }
+  if (!parts[3]) {
+    const s = deps.store.get(parts[2]);
+    return s ? json(s) : json({ error: "not found" }, 404);
+  }
+  return null;
+}
+
+// DELETE /api/sessions/:id — archive.
+function handleSessionDelete({ req, parts, deps }: Ctx): Response | null {
+  if (!(req.method === "DELETE" && parts[2])) return null;
+  deps.service.archive(parts[2]);
+  deps.prCache?.drop(parts[2]);
+  deps.events.emit("session:archived", { id: parts[2] });
+  return json({ ok: true });
+}
+
+// POST /api/sessions/:id/reply — steer a running session.
+async function handleSessionReply({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(req.method === "POST" && parts[2] && parts[3] === "reply")) return null;
+  if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
+    return json({ error: "Content-Type must be application/json" }, 415);
+  }
+  const body = await req.json().catch(() => null);
+  if (!body || typeof (body as { text?: unknown }).text !== "string") {
+    return json({ error: "body must be {text: string}" }, 400);
+  }
+  const ok = deps.service.reply(parts[2], (body as { text: string }).text);
+  return ok ? json({ ok: true }) : json({ error: "not found" }, 404);
+}
+
+// POST /api/sessions/:id/resume — resume a finished session in a fresh agent.
+function handleSessionResume({ req, parts, deps }: Ctx): Response | null {
+  if (!(req.method === "POST" && parts[2] && parts[3] === "resume")) return null;
+  const s = deps.service.resume(parts[2]);
+  if (!s) return json({ error: "cannot resume" }, 409);
+  // flip the badge back to running + nudge clients to re-attach to the fresh agent
+  deps.events.emit("session:status", { id: s.id, status: s.status });
+  return json(s);
+}
+
+// POST /api/sessions/:id/dismiss-stall — acknowledge a stall flag.
+function handleSessionDismissStall({ req, parts, deps }: Ctx): Response | null {
+  if (!(req.method === "POST" && parts[2] && parts[3] === "dismiss-stall")) return null;
+  const ok = deps.poller?.acknowledgeStall(parts[2]) ?? false;
+  return ok ? json({ ok: true }) : json({ error: "no stall to dismiss" }, 404);
+}
+
+// Sessions core: dispatch to the create / read / delete / reply sub-handlers,
+// preserving the original inner guard order. Returns null for anything those
+// don't claim (e.g. `…/git` sub-routes), so handleSessionGit can pick it up.
+async function handleSessions(ctx: Ctx): Promise<Response | null> {
+  const { parts } = ctx;
+  if (parts[0] !== "api" || parts[1] !== "sessions") return null;
+  for (const sub of [
+    handleSessionCreate,
+    handleSessionReads,
+    handleSessionDelete,
+    handleSessionReply,
+    handleSessionResume,
+    handleSessionDismissStall,
+  ]) {
+    const res = await sub(ctx);
+    if (res) return res;
+  }
+  return null;
+}
+
+// ── git host (forge) actions: /api/sessions/:id/git[/pr|/merge|/redeploy] ──
+async function handleSessionGit({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (parts[0] === "api" && parts[1] === "sessions" && parts[2] && parts[3] === "git") {
+    const session = deps.store.get(parts[2]);
+    if (!session) return json({ error: "not found" }, 404);
+    const forge = deps.resolveForge?.(session.repoPath) ?? null;
+    if (!forge) return json({ error: "no forge for this repo" }, 404);
+    const head = session.branch ?? "";
+    try {
+      if (req.method === "GET" && !parts[4]) {
+        return json({ kind: forge.kind, ...(await forge.prStatus(head)) });
+      }
+      if (req.method === "POST" && parts[4] === "pr") {
+        const body = (await req.json().catch(() => ({}))) as { title?: string; body?: string };
+        const status = await forge.openPr({
+          head,
+          base: session.baseBranch,
+          title: body.title?.trim() || session.name,
+          body: body.body ?? session.prompt,
+        });
+        const git: GitState = { kind: forge.kind, ...status };
+        deps.prCache?.set(session.id, git);
+        deps.events.emit("session:git", { id: session.id, git });
+        return json(status);
+      }
+      if (req.method === "POST" && parts[4] === "merge") {
+        const body = (await req.json().catch(() => ({}))) as {
+          method?: MergeMethod;
+          deleteBranch?: boolean;
+        };
+        const cur = await forge.prStatus(head);
+        if (cur.state !== "open" || !cur.number) {
+          return json({ error: "no open PR to merge" }, 409);
+        }
+        await forge.merge(cur.number, {
+          method: body.method ?? forge.mergeMethod,
+          deleteBranch: body.deleteBranch ?? true,
+        });
+        const status = await forge.prStatus(head);
+        const git: GitState = { kind: forge.kind, ...status };
+        deps.prCache?.set(session.id, git);
+        deps.events.emit("session:git", { id: session.id, git });
+        return json(status);
+      }
+      if (req.method === "POST" && parts[4] === "redeploy") {
+        if (!forge.deployWorkflow) {
+          return json({ error: "no deploy workflow configured" }, 400);
+        }
+        await forge.redeploy({ workflow: forge.deployWorkflow, ref: session.baseBranch });
+        return json({ ok: true });
+      }
+    } catch (e) {
+      return json({ error: e instanceof Error ? e.message : "forge error" }, 502);
+    }
+  }
+  return null;
+}
+
+function handleUsageLimits({ req, parts, deps }: Ctx): Response | null {
+  if (
+    req.method === "GET" &&
+    parts[0] === "api" &&
+    parts[1] === "usage" &&
+    parts[2] === "limits"
+  ) {
+    return json(deps.usageLimits.limits(Date.now()));
+  }
+  return null;
+}
+
+// ── self-update: status + trigger ──────────────────────────────────────
+function handleUpdate({ req, parts, deps }: Ctx): Response | null {
+  if (parts[0] === "api" && parts[1] === "update" && !parts[2]) {
+    if (req.method === "GET") {
+      return json(
+        deps.updates?.current() ?? {
+          behind: 0,
+          current: null,
+          latest: null,
+          commits: [],
+          checkedAt: Date.now(),
+        },
+      );
+    }
+    if (req.method === "POST") {
+      if (!deps.updates) return json({ error: "updates not available" }, 503);
+      const status = deps.updates.current();
+      if (!status || status.behind <= 0) return json({ error: "no update available" }, 409);
+      const r = deps.updates.apply();
+      return json({ ok: r.started }, r.started ? 202 : 409);
+    }
+  }
+  return null;
+}
+
+const HERDR_UPDATE_IDLE = {
+  current: null,
+  latest: null,
+  updateAvailable: false,
+  notes: null,
+  checkedAt: 0,
+} as const;
+
+// ── herdr update: status + (destructive) apply ─────────────────────────
+function handleHerdrUpdate({ req, parts, deps }: Ctx): Response | null {
+  if (!(parts[0] === "api" && parts[1] === "herdr-update" && !parts[2])) return null;
+  if (req.method === "GET") {
+    return json(deps.herdrUpdates?.current() ?? { ...HERDR_UPDATE_IDLE, checkedAt: Date.now() });
+  }
+  if (req.method !== "POST") return null;
+  if (!deps.herdrUpdates) return json({ error: "herdr updates not available" }, 503);
+  if (!deps.herdrUpdates.current()?.updateAvailable) {
+    return json({ error: "no update available" }, 409);
+  }
+  const r = deps.herdrUpdates.apply();
+  return json({ ok: r.started }, r.started ? 202 : 409);
+}
+
+function handleUploads({ req, parts, deps }: Ctx): Promise<Response> | null {
+  if (parts[0] === "api" && parts[1] === "uploads" && !parts[2]) {
+    if (req.method === "POST") {
+      return handleUpload(req, { store: deps.store, repoRoot: config.repoRoot });
+    }
+  }
+  return null;
+}
+
+function handleRepos({ req, parts, deps }: Ctx): Response | null {
+  if (parts[0] === "api" && parts[1] === "repos" && !parts[2]) {
+    if (req.method === "GET") {
+      const lastUsed = deps.store.lastUsedByRepo();
+      const repos = listRepos(config.repoRoot).map((r) => ({
+        ...r,
+        lastUsedAt: lastUsed[r.path],
+      }));
+      return json(repos);
+    }
+  }
+  return null;
+}
+
+// ── settings: read/update the repo root (persisted, applied at runtime) ──
+async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (parts[0] === "api" && parts[1] === "settings" && !parts[2]) {
+    if (req.method === "GET") {
+      return json({
+        repoRoot: config.repoRoot,
+        repoRootDisplay: collapseHome(config.repoRoot),
+      });
+    }
+    if (req.method === "PUT") {
+      const body = (await req.json().catch(() => null)) as { repoRoot?: unknown } | null;
+      const root = validateRoot(body?.repoRoot, config.rootCeiling);
+      if (!root) {
+        return json({ error: "repoRoot must be an existing directory within the root" }, 400);
+      }
+      config.repoRoot = root; // live: every later read picks it up
+      deps.store.setSetting("repoRoot", root); // persist across restarts
+      return json({ repoRoot: root, repoRootDisplay: collapseHome(root) });
+    }
+  }
+  return null;
+}
+
+// ── saved steers (canned prompts): list / replace ──
+async function handleSteers({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (parts[0] === "api" && parts[1] === "steers" && !parts[2]) {
+    if (req.method === "GET") return json(loadSteers(deps.store));
+    if (req.method === "PUT") {
+      if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
+        return json({ error: "Content-Type must be application/json" }, 415);
+      }
+      const body = await req.json().catch(() => null);
+      const steers = validateSteers(body);
+      if (!steers) return json({ error: "invalid steers payload" }, 400);
+      saveSteers(deps.store, steers);
+      return json(steers);
+    }
+  }
+  return null;
+}
+
+// ── per-project icons: read full map / patch one entry ──
+async function handleProjectIcons({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (parts[0] === "api" && parts[1] === "project-icons" && !parts[2]) {
+    if (req.method === "GET") return json(loadIcons(deps.store));
+    if (req.method === "PUT") {
+      if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
+        return json({ error: "Content-Type must be application/json" }, 415);
+      }
+      const body = await req.json().catch(() => null);
+      const patch = validateIconPatch(body);
+      if (!patch) return json({ error: "invalid project-icon payload" }, 400);
+      const map = setIcon(deps.store, patch.path, patch.emoji);
+      deps.events.emit("project-icons:update", map);
+      return json(map);
+    }
+  }
+  return null;
+}
+
+// ── broadcast a steer to many sessions ──
+async function handleBroadcast({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (parts[0] === "api" && parts[1] === "broadcast" && !parts[2]) {
+    if (req.method === "POST") {
+      if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
+        return json({ error: "Content-Type must be application/json" }, 415);
+      }
+      const body = await req.json().catch(() => null);
+      const parsed = validateBroadcast(body);
+      if (!parsed) return json({ error: "body must be {text: string, ids: string[]}" }, 400);
+      return json(deps.service.broadcast(parsed.ids, parsed.text));
+    }
+  }
+  return null;
+}
+
+// ── filesystem browser: list sub-directories for the root picker ──
+function handleFsDirs({ req, parts, url }: Ctx): Response | null {
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "fs" && parts[2] === "dirs") {
+    return json(listDirs(url.searchParams.get("path") ?? "", config.rootCeiling));
+  }
+  return null;
+}
+
+function handleBranches({ req, parts, url }: Ctx): Response | null {
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "branches" && !parts[2]) {
+    const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
+    if (!dir) return json({ error: "invalid repo" }, 400);
+    return json(listBranches(dir));
+  }
+  return null;
+}
+
+async function handleIssues({ req, parts, url, deps }: Ctx): Promise<Response | null> {
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "issues" && !parts[2]) {
+    const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
+    if (!dir) return json({ error: "invalid repo" }, 400);
+    const forge = deps.resolveForge?.(dir) ?? null;
+    if (!forge) return json({ slug: null, issues: [] });
+    try {
+      return json({ slug: forge.slug, issues: await forge.listIssues() });
+    } catch {
+      // missing/un-authed CLI or network error → graceful empty (matches prior behavior)
+      return json({ slug: forge.slug, issues: [] });
+    }
+  }
+  return null;
+}
+
+async function handleTodo({ req, parts, url }: Ctx): Promise<Response | null> {
+  if (parts[0] === "api" && parts[1] === "todo" && !parts[2]) {
+    const repoParam = url.searchParams.get("repo") ?? "";
+    if (req.method === "GET") {
+      const r = readTodo(repoParam, config.repoRoot);
+      if (!r.ok) return json({ error: "invalid repo path" }, 400);
+      return json(r);
+    }
+    if (req.method === "PUT") {
+      const body = await req.json().catch(() => null);
+      if (
+        body === null ||
+        typeof body !== "object" ||
+        typeof (body as any).content !== "string"
+      ) {
+        return json({ error: "body must be {content: string}" }, 400);
+      }
+      const ok = writeTodo(repoParam, config.repoRoot, (body as any).content);
+      if (!ok) return json({ error: "invalid repo path or content too large" }, 400);
+      return json({ ok: true });
+    }
+  }
+  return null;
+}
+
+// Ordered dispatch chain — preserves the original guard sequence verbatim.
+const ROUTE_HANDLERS = [
+  handleGitSnapshot,
+  handlePush,
+  handleSessions,
+  handleSessionGit,
+  handleUsageLimits,
+  handleUpdate,
+  handleHerdrUpdate,
+  handleUploads,
+  handleRepos,
+  handleSettings,
+  handleSteers,
+  handleProjectIcons,
+  handleBroadcast,
+  handleFsDirs,
+  handleBranches,
+  handleIssues,
+  handleTodo,
+] as const;
+
 /** Returns an object with a `fetch(Request)` method — unit-testable without a port. */
 export function makeApp(deps: AppDeps) {
   const app = {
@@ -116,364 +588,11 @@ export function makeApp(deps: AppDeps) {
 
       const url = new URL(req.url);
       const parts = url.pathname.split("/").filter(Boolean); // ["api","sessions",":id"]
+      const ctx: Ctx = { req, parts, url, deps };
 
-      if (req.method === "GET" && parts[0] === "api" && parts[1] === "git" && !parts[2]) {
-        return json(deps.prCache?.snapshot() ?? {});
-      }
-
-      if (parts[0] === "api" && parts[1] === "push") {
-        if (req.method === "GET" && parts[2] === "vapid") {
-          return json({ publicKey: deps.push?.publicKey() ?? null });
-        }
-        if (req.method === "POST" && parts[2] === "subscribe") {
-          if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-            return json({ error: "Content-Type must be application/json" }, 415);
-          }
-          const body = (await req.json().catch(() => null)) as {
-            endpoint?: unknown;
-            keys?: { p256dh?: unknown; auth?: unknown };
-            locale?: unknown;
-          } | null;
-          if (
-            !body ||
-            typeof body.endpoint !== "string" ||
-            typeof body.keys?.p256dh !== "string" ||
-            typeof body.keys?.auth !== "string"
-          ) {
-            return json({ error: "body must be a PushSubscription" }, 400);
-          }
-          deps.push?.subscribe(
-            {
-              endpoint: body.endpoint,
-              keys: { p256dh: body.keys.p256dh, auth: body.keys.auth },
-              locale: typeof body.locale === "string" ? body.locale : undefined,
-            },
-            req.headers.get("User-Agent") ?? "",
-          );
-          return json({ ok: true });
-        }
-        if (req.method === "POST" && parts[2] === "unsubscribe") {
-          const body = (await req.json().catch(() => null)) as { endpoint?: unknown } | null;
-          if (!body || typeof body.endpoint !== "string") {
-            return json({ error: "body must be {endpoint: string}" }, 400);
-          }
-          deps.push?.unsubscribe(body.endpoint);
-          return json({ ok: true });
-        }
-      }
-
-      if (parts[0] === "api" && parts[1] === "sessions") {
-        if (req.method === "POST" && !parts[2]) {
-          if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-            return json({ error: "Content-Type must be application/json" }, 415);
-          }
-          const body = await req.json().catch(() => null);
-          const result = validateCreate(body, config.repoRoot);
-          if (!result.ok) return json({ error: result.error }, 400);
-          let s;
-          try {
-            s = await deps.service.create(result.value);
-          } catch (e) {
-            // create shells out to herdr (and git); surface the real reason instead of a
-            // bare 500 so the New Task dialog can show it. 409 ⇒ a name still collided
-            // (a slip past uniqueName under a race), anything else ⇒ 502 (herdr/git failed).
-            const msg = e instanceof Error ? e.message : "create failed";
-            const taken = /agent_name_taken/.test(msg);
-            return json(
-              { error: taken ? "task name already in use, retry" : msg },
-              taken ? 409 : 502,
-            );
-          }
-          deps.events.emit("session:new", s);
-          return json(s, 201);
-        }
-        if (req.method === "GET" && !parts[2]) return json(deps.store.list({ activeOnly: true }));
-        if (req.method === "GET" && parts[2] && parts[3] === "usage") {
-          const s = deps.store.get(parts[2]);
-          return s ? json(await sessionUsage(s)) : json({ error: "not found" }, 404);
-        }
-        if (req.method === "GET" && parts[2] && parts[3] === "activity") {
-          const s = deps.store.get(parts[2]);
-          if (!s) return json({ error: "not found" }, 404);
-          // pre-feature session (no pinned id) → no transcript to read
-          const path = s.claudeSessionId ? jsonlPathFor(s.worktreePath, s.claudeSessionId) : "";
-          return json(path ? await sessionActivity(path) : []);
-        }
-        if (req.method === "GET" && parts[2] && parts[3] === "diff") {
-          const s = deps.store.get(parts[2]);
-          if (!s) return json({ error: "not found" }, 404);
-          try {
-            return json(computeDiff(s.worktreePath, s.baseBranch, s.branch));
-          } catch (e) {
-            return json({ error: e instanceof Error ? e.message : "diff failed" }, 500);
-          }
-        }
-        if (req.method === "GET" && parts[2] && !parts[3]) {
-          const s = deps.store.get(parts[2]);
-          return s ? json(s) : json({ error: "not found" }, 404);
-        }
-        if (req.method === "DELETE" && parts[2]) {
-          deps.service.archive(parts[2]);
-          deps.prCache?.drop(parts[2]);
-          deps.events.emit("session:archived", { id: parts[2] });
-          return json({ ok: true });
-        }
-        if (req.method === "POST" && parts[2] && parts[3] === "reply") {
-          if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-            return json({ error: "Content-Type must be application/json" }, 415);
-          }
-          const body = await req.json().catch(() => null);
-          if (!body || typeof (body as { text?: unknown }).text !== "string") {
-            return json({ error: "body must be {text: string}" }, 400);
-          }
-          const ok = deps.service.reply(parts[2], (body as { text: string }).text);
-          return ok ? json({ ok: true }) : json({ error: "not found" }, 404);
-        }
-        if (req.method === "POST" && parts[2] && parts[3] === "resume") {
-          const s = deps.service.resume(parts[2]);
-          if (!s) return json({ error: "cannot resume" }, 409);
-          // flip the badge back to running + nudge clients to re-attach to the fresh agent
-          deps.events.emit("session:status", { id: s.id, status: s.status });
-          return json(s);
-        }
-        if (req.method === "POST" && parts[2] && parts[3] === "dismiss-stall") {
-          const ok = deps.poller?.acknowledgeStall(parts[2]) ?? false;
-          return ok ? json({ ok: true }) : json({ error: "no stall to dismiss" }, 404);
-        }
-      }
-      // ── git host (forge) actions: /api/sessions/:id/git[/pr|/merge|/redeploy] ──
-      if (parts[0] === "api" && parts[1] === "sessions" && parts[2] && parts[3] === "git") {
-        const session = deps.store.get(parts[2]);
-        if (!session) return json({ error: "not found" }, 404);
-        const forge = deps.resolveForge?.(session.repoPath) ?? null;
-        if (!forge) return json({ error: "no forge for this repo" }, 404);
-        const head = session.branch ?? "";
-        try {
-          if (req.method === "GET" && !parts[4]) {
-            return json({ kind: forge.kind, ...(await forge.prStatus(head)) });
-          }
-          if (req.method === "POST" && parts[4] === "pr") {
-            const body = (await req.json().catch(() => ({}))) as { title?: string; body?: string };
-            const status = await forge.openPr({
-              head,
-              base: session.baseBranch,
-              title: body.title?.trim() || session.name,
-              body: body.body ?? session.prompt,
-            });
-            const git: GitState = { kind: forge.kind, ...status };
-            deps.prCache?.set(session.id, git);
-            deps.events.emit("session:git", { id: session.id, git });
-            return json(status);
-          }
-          if (req.method === "POST" && parts[4] === "merge") {
-            const body = (await req.json().catch(() => ({}))) as {
-              method?: MergeMethod;
-              deleteBranch?: boolean;
-            };
-            const cur = await forge.prStatus(head);
-            if (cur.state !== "open" || !cur.number) {
-              return json({ error: "no open PR to merge" }, 409);
-            }
-            await forge.merge(cur.number, {
-              method: body.method ?? forge.mergeMethod,
-              deleteBranch: body.deleteBranch ?? true,
-            });
-            const status = await forge.prStatus(head);
-            const git: GitState = { kind: forge.kind, ...status };
-            deps.prCache?.set(session.id, git);
-            deps.events.emit("session:git", { id: session.id, git });
-            return json(status);
-          }
-          if (req.method === "POST" && parts[4] === "redeploy") {
-            if (!forge.deployWorkflow) {
-              return json({ error: "no deploy workflow configured" }, 400);
-            }
-            await forge.redeploy({ workflow: forge.deployWorkflow, ref: session.baseBranch });
-            return json({ ok: true });
-          }
-        } catch (e) {
-          return json({ error: e instanceof Error ? e.message : "forge error" }, 502);
-        }
-      }
-
-      if (
-        req.method === "GET" &&
-        parts[0] === "api" &&
-        parts[1] === "usage" &&
-        parts[2] === "limits"
-      ) {
-        return json(deps.usageLimits.limits(Date.now()));
-      }
-
-      // ── self-update: status + trigger ──────────────────────────────────────
-      if (parts[0] === "api" && parts[1] === "update" && !parts[2]) {
-        if (req.method === "GET") {
-          return json(
-            deps.updates?.current() ?? {
-              behind: 0,
-              current: null,
-              latest: null,
-              commits: [],
-              checkedAt: Date.now(),
-            },
-          );
-        }
-        if (req.method === "POST") {
-          if (!deps.updates) return json({ error: "updates not available" }, 503);
-          const status = deps.updates.current();
-          if (!status || status.behind <= 0) return json({ error: "no update available" }, 409);
-          const r = deps.updates.apply();
-          return json({ ok: r.started }, r.started ? 202 : 409);
-        }
-      }
-
-      // ── herdr update: status + (destructive) apply ─────────────────────────
-      if (parts[0] === "api" && parts[1] === "herdr-update" && !parts[2]) {
-        if (req.method === "GET") {
-          return json(
-            deps.herdrUpdates?.current() ?? {
-              current: null,
-              latest: null,
-              updateAvailable: false,
-              notes: null,
-              checkedAt: Date.now(),
-            },
-          );
-        }
-        if (req.method === "POST") {
-          if (!deps.herdrUpdates) return json({ error: "herdr updates not available" }, 503);
-          if (!deps.herdrUpdates.current()?.updateAvailable)
-            return json({ error: "no update available" }, 409);
-          const r = deps.herdrUpdates.apply();
-          return json({ ok: r.started }, r.started ? 202 : 409);
-        }
-      }
-
-      if (parts[0] === "api" && parts[1] === "uploads" && !parts[2]) {
-        if (req.method === "POST") {
-          return handleUpload(req, { store: deps.store, repoRoot: config.repoRoot });
-        }
-      }
-
-      if (parts[0] === "api" && parts[1] === "repos" && !parts[2]) {
-        if (req.method === "GET") {
-          const lastUsed = deps.store.lastUsedByRepo();
-          const repos = listRepos(config.repoRoot).map((r) => ({
-            ...r,
-            lastUsedAt: lastUsed[r.path],
-          }));
-          return json(repos);
-        }
-      }
-
-      // ── settings: read/update the repo root (persisted, applied at runtime) ──
-      if (parts[0] === "api" && parts[1] === "settings" && !parts[2]) {
-        if (req.method === "GET") {
-          return json({
-            repoRoot: config.repoRoot,
-            repoRootDisplay: collapseHome(config.repoRoot),
-          });
-        }
-        if (req.method === "PUT") {
-          const body = (await req.json().catch(() => null)) as { repoRoot?: unknown } | null;
-          const root = validateRoot(body?.repoRoot, config.rootCeiling);
-          if (!root) {
-            return json({ error: "repoRoot must be an existing directory within the root" }, 400);
-          }
-          config.repoRoot = root; // live: every later read picks it up
-          deps.store.setSetting("repoRoot", root); // persist across restarts
-          return json({ repoRoot: root, repoRootDisplay: collapseHome(root) });
-        }
-      }
-
-      // ── saved steers (canned prompts): list / replace ──
-      if (parts[0] === "api" && parts[1] === "steers" && !parts[2]) {
-        if (req.method === "GET") return json(loadSteers(deps.store));
-        if (req.method === "PUT") {
-          if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-            return json({ error: "Content-Type must be application/json" }, 415);
-          }
-          const body = await req.json().catch(() => null);
-          const steers = validateSteers(body);
-          if (!steers) return json({ error: "invalid steers payload" }, 400);
-          saveSteers(deps.store, steers);
-          return json(steers);
-        }
-      }
-
-      // ── per-project icons: read full map / patch one entry ──
-      if (parts[0] === "api" && parts[1] === "project-icons" && !parts[2]) {
-        if (req.method === "GET") return json(loadIcons(deps.store));
-        if (req.method === "PUT") {
-          if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-            return json({ error: "Content-Type must be application/json" }, 415);
-          }
-          const body = await req.json().catch(() => null);
-          const patch = validateIconPatch(body);
-          if (!patch) return json({ error: "invalid project-icon payload" }, 400);
-          const map = setIcon(deps.store, patch.path, patch.emoji);
-          deps.events.emit("project-icons:update", map);
-          return json(map);
-        }
-      }
-
-      // ── broadcast a steer to many sessions ──
-      if (parts[0] === "api" && parts[1] === "broadcast" && !parts[2]) {
-        if (req.method === "POST") {
-          if (req.headers.get("content-type")?.split(";")[0]?.trim() !== "application/json") {
-            return json({ error: "Content-Type must be application/json" }, 415);
-          }
-          const body = await req.json().catch(() => null);
-          const parsed = validateBroadcast(body);
-          if (!parsed) return json({ error: "body must be {text: string, ids: string[]}" }, 400);
-          return json(deps.service.broadcast(parsed.ids, parsed.text));
-        }
-      }
-
-      // ── filesystem browser: list sub-directories for the root picker ──
-      if (req.method === "GET" && parts[0] === "api" && parts[1] === "fs" && parts[2] === "dirs") {
-        return json(listDirs(url.searchParams.get("path") ?? "", config.rootCeiling));
-      }
-
-      if (req.method === "GET" && parts[0] === "api" && parts[1] === "branches" && !parts[2]) {
-        const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
-        if (!dir) return json({ error: "invalid repo" }, 400);
-        return json(listBranches(dir));
-      }
-
-      if (req.method === "GET" && parts[0] === "api" && parts[1] === "issues" && !parts[2]) {
-        const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
-        if (!dir) return json({ error: "invalid repo" }, 400);
-        const forge = deps.resolveForge?.(dir) ?? null;
-        if (!forge) return json({ slug: null, issues: [] });
-        try {
-          return json({ slug: forge.slug, issues: await forge.listIssues() });
-        } catch {
-          // missing/un-authed CLI or network error → graceful empty (matches prior behavior)
-          return json({ slug: forge.slug, issues: [] });
-        }
-      }
-
-      if (parts[0] === "api" && parts[1] === "todo" && !parts[2]) {
-        const repoParam = url.searchParams.get("repo") ?? "";
-        if (req.method === "GET") {
-          const r = readTodo(repoParam, config.repoRoot);
-          if (!r.ok) return json({ error: "invalid repo path" }, 400);
-          return json(r);
-        }
-        if (req.method === "PUT") {
-          const body = await req.json().catch(() => null);
-          if (
-            body === null ||
-            typeof body !== "object" ||
-            typeof (body as any).content !== "string"
-          ) {
-            return json({ error: "body must be {content: string}" }, 400);
-          }
-          const ok = writeTodo(repoParam, config.repoRoot, (body as any).content);
-          if (!ok) return json({ error: "invalid repo path or content too large" }, 400);
-          return json({ ok: true });
-        }
+      for (const handle of ROUTE_HANDLERS) {
+        const res = await handle(ctx);
+        if (res) return res;
       }
 
       if (url.pathname.startsWith("/api")) return json({ error: "not found" }, 404);

--- a/src/usage-limits.ts
+++ b/src/usage-limits.ts
@@ -2,7 +2,7 @@ import type { AccountUsageIndex } from "./usage";
 
 export type WindowKey = "session5h" | "week";
 
-export const PERIOD_MS: Record<WindowKey, number> = {
+const PERIOD_MS: Record<WindowKey, number> = {
   session5h: 5 * 60 * 60 * 1000,
   week: 7 * 24 * 60 * 60 * 1000,
 };

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -138,33 +138,39 @@ export class AccountUsageIndex {
     for (const key of this.files.keys()) if (!live.has(key)) this.files.delete(key);
 
     const cutoff = now - WEEK_MS - 60_000;
-    for (const path of paths) {
-      let size: number;
-      try {
-        size = statSync(path).size;
-      } catch {
-        continue;
-      }
-      let st = this.files.get(path);
-      if (!st || size < st.offset) {
-        st = { size, offset: 0, leftover: "", records: [] };
-        this.files.set(path, st);
-      }
-      if (size > st.offset) {
-        const chunk = await Bun.file(path).slice(st.offset, size).text();
-        st.offset = size;
-        st.size = size;
-        const parts = (st.leftover + chunk).split("\n");
-        st.leftover = parts.pop() ?? "";
-        for (const line of parts) {
-          const r = parseLine(line);
-          if (!r || !r.ts) continue;
-          st.records.push({ ts: r.ts, units: weightedUnits(r, r.model) });
-        }
-      }
-      if (st.records.length && st.records[0]!.ts < cutoff) {
-        st.records = st.records.filter((r) => r.ts >= cutoff);
-      }
+    for (const path of paths) await this.ingestFile(path, cutoff);
+  }
+
+  /** Read appended bytes of one file into its FileState, then prune stale records. */
+  private async ingestFile(path: string, cutoff: number): Promise<void> {
+    let size: number;
+    try {
+      size = statSync(path).size;
+    } catch {
+      return;
+    }
+    let st = this.files.get(path);
+    if (!st || size < st.offset) {
+      st = { size, offset: 0, leftover: "", records: [] };
+      this.files.set(path, st);
+    }
+    if (size > st.offset) await this.appendChunk(st, path, size);
+    if (st.records.length && st.records[0]!.ts < cutoff) {
+      st.records = st.records.filter((r) => r.ts >= cutoff);
+    }
+  }
+
+  /** Read [offset, size) of a file and fold its complete lines into `st`. */
+  private async appendChunk(st: FileState, path: string, size: number): Promise<void> {
+    const chunk = await Bun.file(path).slice(st.offset, size).text();
+    st.offset = size;
+    st.size = size;
+    const parts = (st.leftover + chunk).split("\n");
+    st.leftover = parts.pop() ?? "";
+    for (const line of parts) {
+      const r = parseLine(line);
+      if (!r || !r.ts) continue;
+      st.records.push({ ts: r.ts, units: weightedUnits(r, r.model) });
     }
   }
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -21,6 +21,97 @@ const err = (error: string): Err => ({ ok: false, error });
 const BRANCH_RE = /^(?!-)[A-Za-z0-9._/-]{1,200}$/;
 const ALLOWED_KEYS = new Set(["repoPath", "baseBranch", "prompt", "model", "images"]);
 
+/** A field-validation helper either fails with an error or yields a parsed value. */
+type FieldErr = { ok: false; error: string };
+type FieldOk<T> = { ok: true; value: T };
+type Field<T> = FieldOk<T> | FieldErr;
+
+const field = <T>(value: T): FieldOk<T> => ({ ok: true, value });
+
+/** prompt — required non-empty string, trimmed, ≤ 8000 chars. */
+function validatePrompt(value: unknown): Field<string> {
+  if (typeof value !== "string") return err("prompt must be a string");
+  const prompt = value.trim();
+  if (prompt.length === 0) return err("prompt must not be empty");
+  if (prompt.length > 8000) return err("prompt must be ≤ 8000 chars");
+  return field(prompt);
+}
+
+/** baseBranch — required string matching the safe branch pattern. */
+function validateBaseBranch(value: unknown): Field<string> {
+  if (typeof value !== "string") return err("baseBranch must be a string");
+  if (!BRANCH_RE.test(value)) return err("baseBranch contains invalid characters");
+  return field(value);
+}
+
+/** model — optional; absent/null/"default" → null (claude's own default, no --model flag). */
+function validateModel(value: unknown): Field<string | null> {
+  if (value == null || value === "default") return field(null);
+  if (typeof value !== "string") return err("model must be a string");
+  if (!(MODELS as readonly string[]).includes(value)) return err("unknown model");
+  return field(value);
+}
+
+/** repoPath — required non-empty string, confined to repoRoot, existing directory. */
+function validateRepoPath(value: unknown, root: string): Field<string> {
+  if (typeof value !== "string" || value.length === 0) {
+    return err("repoPath must be a non-empty string");
+  }
+  const resolved = resolve(expandHome(value));
+  const inside = resolved === root || resolved.startsWith(root + sep);
+  if (!inside) return err("repoPath must be inside the configured repoRoot");
+  try {
+    if (!statSync(resolved).isDirectory()) return err("repoPath must be a directory");
+  } catch {
+    return err("repoPath does not exist");
+  }
+  return field(resolved);
+}
+
+/** A single image entry — must resolve inside the staging dir and be a file. */
+function validateImageEntry(it: unknown, stagingReal: string): Field<string> {
+  if (typeof it !== "string") return err("each image must be a string path");
+  let real: string;
+  try {
+    real = realpathSync(resolve(it));
+  } catch {
+    return err("image does not exist");
+  }
+  const inside = real === stagingReal || real.startsWith(stagingReal + sep);
+  if (!inside) return err("image must be inside the staging dir");
+  try {
+    if (!statSync(real).isFile()) return err("image must be a file");
+  } catch {
+    return err("image does not exist");
+  }
+  return field(real);
+}
+
+/** images — optional array of staged upload paths, confined to the staging dir. */
+function validateImages(value: unknown, root: string): Field<string[]> {
+  const images: string[] = [];
+  if (value == null) return field(images);
+  if (!Array.isArray(value)) return err("images must be an array");
+  if (value.length > 10) return err("images must be ≤ 10 entries");
+  // an empty list needs no confinement — don't require a staging dir to exist
+  // (the staging dir is created lazily on first upload; a fresh repoRoot has none)
+  if (value.length === 0) return field(images);
+
+  let stagingReal: string;
+  try {
+    stagingReal = realpathSync(stagingDir(root));
+  } catch {
+    return err("no staged uploads exist");
+  }
+  for (const it of value) {
+    const entry = validateImageEntry(it, stagingReal);
+    if (!entry.ok) return entry;
+    images.push(entry.value);
+  }
+  if (new Set(images).size !== images.length) return err("duplicate image paths");
+  return field(images);
+}
+
 /** Pure validator — no side-effects beyond fs.statSync for the repoPath check. */
 export function validateCreate(body: unknown, repoRoot: string): Result {
   if (body === null || typeof body !== "object" || Array.isArray(body)) {
@@ -32,78 +123,31 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
     if (!ALLOWED_KEYS.has(key)) return err(`unknown key: ${key}`);
   }
 
-  // prompt
-  if (typeof obj.prompt !== "string") return err("prompt must be a string");
-  const prompt = obj.prompt.trim();
-  if (prompt.length === 0) return err("prompt must not be empty");
-  if (prompt.length > 8000) return err("prompt must be ≤ 8000 chars");
+  const prompt = validatePrompt(obj.prompt);
+  if (!prompt.ok) return prompt;
 
-  // baseBranch
-  if (typeof obj.baseBranch !== "string") return err("baseBranch must be a string");
-  if (!BRANCH_RE.test(obj.baseBranch)) return err("baseBranch contains invalid characters");
+  const baseBranch = validateBaseBranch(obj.baseBranch);
+  if (!baseBranch.ok) return baseBranch;
 
-  // model — optional; absent/null/"default" → null (claude's own default, no --model flag)
-  let model: string | null = null;
-  if (obj.model != null && obj.model !== "default") {
-    if (typeof obj.model !== "string") return err("model must be a string");
-    if (!(MODELS as readonly string[]).includes(obj.model)) return err("unknown model");
-    model = obj.model;
-  }
+  const model = validateModel(obj.model);
+  if (!model.ok) return model;
 
-  // repoPath
-  if (typeof obj.repoPath !== "string" || obj.repoPath.length === 0) {
-    return err("repoPath must be a non-empty string");
-  }
-  const resolved = resolve(expandHome(obj.repoPath));
   const root = resolve(expandHome(repoRoot));
-  const inside = resolved === root || resolved.startsWith(root + sep);
-  if (!inside) return err("repoPath must be inside the configured repoRoot");
+  const repoPath = validateRepoPath(obj.repoPath, root);
+  if (!repoPath.ok) return repoPath;
 
-  try {
-    const stat = statSync(resolved);
-    if (!stat.isDirectory()) return err("repoPath must be a directory");
-  } catch {
-    return err("repoPath does not exist");
-  }
-
-  // images — optional array of staged upload paths, confined to the staging dir
-  const images: string[] = [];
-  if (obj.images != null) {
-    if (!Array.isArray(obj.images)) return err("images must be an array");
-    if (obj.images.length > 10) return err("images must be ≤ 10 entries");
-    // an empty list needs no confinement — don't require a staging dir to exist
-    // (the staging dir is created lazily on first upload; a fresh repoRoot has none)
-    if (obj.images.length > 0) {
-      let stagingReal: string;
-      try {
-        stagingReal = realpathSync(stagingDir(root));
-      } catch {
-        return err("no staged uploads exist");
-      }
-      for (const it of obj.images) {
-        if (typeof it !== "string") return err("each image must be a string path");
-        let real: string;
-        try {
-          real = realpathSync(resolve(it));
-        } catch {
-          return err("image does not exist");
-        }
-        const inside = real === stagingReal || real.startsWith(stagingReal + sep);
-        if (!inside) return err("image must be inside the staging dir");
-        try {
-          if (!statSync(real).isFile()) return err("image must be a file");
-        } catch {
-          return err("image does not exist");
-        }
-        images.push(real);
-      }
-      if (new Set(images).size !== images.length) return err("duplicate image paths");
-    }
-  }
+  const images = validateImages(obj.images, root);
+  if (!images.ok) return images;
 
   return {
     ok: true,
-    value: { repoPath: resolved, baseBranch: obj.baseBranch, prompt, model, images },
+    value: {
+      repoPath: repoPath.value,
+      baseBranch: baseBranch.value,
+      prompt: prompt.value,
+      model: model.value,
+      images: images.value,
+    },
   };
 }
 
@@ -183,20 +227,27 @@ const STEER_LABEL_MAX = 60;
 const STEER_TEXT_MAX = 4000;
 const STEER_MAX = 40;
 
+/** Validate + normalize a single steer item. Returns null on any violation. */
+function validateSteerItem(it: unknown): Steer | null {
+  if (it === null || typeof it !== "object" || Array.isArray(it)) return null;
+  const o = it as Record<string, unknown>;
+  if (typeof o.label !== "string" || typeof o.text !== "string") return null;
+  const label = o.label.trim();
+  const text = o.text.trim();
+  if (label.length === 0 || label.length > STEER_LABEL_MAX) return null;
+  if (text.length === 0 || text.length > STEER_TEXT_MAX) return null;
+  const id = typeof o.id === "string" && o.id.length > 0 ? o.id : randomUUID();
+  return { id, label, text };
+}
+
 /** Validate + normalize a PUT /api/steers payload. Returns null on any violation. */
 export function validateSteers(body: unknown): Steer[] | null {
   if (!Array.isArray(body) || body.length > STEER_MAX) return null;
   const out: Steer[] = [];
   for (const it of body) {
-    if (it === null || typeof it !== "object" || Array.isArray(it)) return null;
-    const o = it as Record<string, unknown>;
-    if (typeof o.label !== "string" || typeof o.text !== "string") return null;
-    const label = o.label.trim();
-    const text = o.text.trim();
-    if (label.length === 0 || label.length > STEER_LABEL_MAX) return null;
-    if (text.length === 0 || text.length > STEER_TEXT_MAX) return null;
-    const id = typeof o.id === "string" && o.id.length > 0 ? o.id : randomUUID();
-    out.push({ id, label, text });
+    const item = validateSteerItem(it);
+    if (item === null) return null;
+    out.push(item);
   }
   return out;
 }

--- a/ui/src/lib/index.ts
+++ b/ui/src/lib/index.ts
@@ -1,1 +1,0 @@
-// place files you want to import through the `$lib` alias in this folder.

--- a/ui/src/lib/todo.ts
+++ b/ui/src/lib/todo.ts
@@ -6,7 +6,7 @@
 export const ITEM_RE = /^(\s*)-\s\[( |x|X)\]\s+(.*)$/;
 const DONE_HEADING_RE = /^#{1,6}\s+done\b/i;
 
-export function isItem(line: string): boolean {
+function isItem(line: string): boolean {
   return ITEM_RE.test(line);
 }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -32,11 +32,6 @@ export interface Issue {
   url: string;
   labels: string[];
 }
-export interface TodoDoc {
-  exists: boolean;
-  content: string;
-}
-
 export type BlockShape = "menu" | "yes-no" | "awaiting-input" | "stall";
 export interface BlockOption {
   label: string;


### PR DESCRIPTION
## What

Adopts [Fallow](https://docs.fallow.tools) as a code-quality gate — closing the gap vs `sveltekit-template`, which already ships a fallow CI audit but Shepherd didn't.

## Why

Fallow finds unused code, complexity hotspots, duplication, and circular deps. The sibling `sveltekit-template` enforces it in CI; Shepherd had no equivalent. This brings parity and a green baseline.

## Changes

**Config** — `.fallowrc.jsonc` (deliberate, not defaults):
- `entry`: both packages (root server `src/index.ts` + `pty-attach.mjs`, `test/**` roots, SvelteKit routes/app-shell, build configs). `bun test` has no auto-discovery plugin, so test entries are explicit.
- `dynamicallyLoaded`: `ui/static/sw.js` (loaded via `navigator.serviceWorker.register`, invisible to static analysis).
- `ignoreDependencies`: `tailwindcss` (CSS `@import` + vite plugin, not an ESM import).
- `rules.unused-class-member: off` — flagged methods (forge/herdr/poller/push/store) are interface/DI dispatch fallow can't trace, all test-exercised.
- `rules.duplicate-exports: off` — server (`src/forge/types.ts`) and client (`ui/src/lib/types.ts`) intentionally mirror shared shapes (no shared build).
- `duplicates.ignore`: forge adapters (parallel impls of two unrelated REST APIs — skill §8).
- `health`: cyclomatic 20 / cognitive 15 (defaults, met after refactor); `maxCrap 1000` (coverage-driven, ramp-up deferred).

**Dead code** — un-exported in-file-only symbols (forge/index, usage-limits, todo, ModelWeights), removed an unused type, deleted the empty `ui/src/lib/index.ts` barrel.

**Complexity refactor** (behaviour-preserving, all 338 root + 78 ui tests pass unchanged) — split the 9 functions over threshold:
- `server.ts`: monolithic `makeApp.fetch` (cyclomatic **176**) → per-resource `handleX(ctx)` handlers via a `ROUTE_HANDLERS` dispatch array, then further split the over-threshold handlers (push, session reads, forge git, update, todo) + a shared `requireJsonContentType` guard.
- `validate.ts`: `validateCreate` (cyc 34) / `validateSteers` → per-field validators.
- `diff.ts`: `parseUnifiedDiff` (cog 48) → file-header / hunk-header / body-line helpers.
- `activity.ts`: `summarize` → lookup table; `parseActivity` → staged helpers.
- `usage.ts` `refresh`, `poller.ts` `tick`, `pty-demux.mjs` `feed` → extracted helpers.

**CI gate** — `.github/workflows/ci.yml`: `actions/checkout` gets `fetch-depth: 0`; new `Fallow audit (PR delta)` step on PRs (`fallow audit --base origin/<base> --fail-on-issues`). Mirrored in `.husky/pre-push` (guarded on `origin/main`), matching the repo's "pre-push mirrors CI" convention.

## Verification

- `bun run lint` · `bun run typecheck` ✓
- root `bun test ./test` → **338 pass / 0 fail**
- `cd ui`: `bun run check` · `check:i18n` (183 keys, EN↔DE parity) · `bun run test` (78 pass) · `bun run build` ✓
- `bunx fallow`: dead-code **0** · high-complexity **0**
- `bunx fallow audit --base origin/main --fail-on-issues` → **exit 0** (4 delta dupes are intentional type/forge mirrors — warnings, non-blocking)

release-please is handled separately on `shepherd/set-up-release-please`; not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)