### PR TITLE
feat(ui): autofocus prompt field when new-task dialog opens

### DIFF
--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -41,6 +41,7 @@
   let dragging = $state(false);
   let uploading = $state(false);
   let fileInput = $state<HTMLInputElement>();
+  let promptInput = $state<HTMLTextAreaElement>();
   let isMac = $state(false);
 
   /** Default to the most-recently-used repo; fall back to the first in the list. */
@@ -62,6 +63,10 @@
         if (!repoPath && r.length > 0) repoPath = defaultRepoPath(r);
       })
       .catch(() => {});
+    // Focus the prompt so the user can type immediately when the dialog opens.
+    // Move the caret to the end so a seeded initialPrompt stays editable inline.
+    promptInput?.focus();
+    promptInput?.setSelectionRange(prompt.length, prompt.length);
     // Paste anywhere in the modal (the textarea need not be focused first).
     window.addEventListener("paste", onPaste);
     return () => window.removeEventListener("paste", onPaste);
@@ -176,6 +181,7 @@
     <label class="micro" for="nt-prompt">{m.newtask_prompt_label()}</label>
     <textarea
       id="nt-prompt"
+      bind:this={promptInput}
       bind:value={prompt}
       rows="3"
       placeholder={m.newtask_prompt_placeholder()}


### PR DESCRIPTION
## Was

Beim Öffnen des „Neue Aufgabe"-Dialogs (und nach einem Screenshot-Upload) stand der Cursor bisher nicht im Prompt-Feld — man musste erst reinklicken, um loszuschreiben.

## Änderung

In `NewTask.svelte`:
- `bind:this={promptInput}` aufs Prompt-Textarea.
- Beim `onMount` wird das Feld fokussiert → Cursor steht sofort drin.
- Der Caret landet am Textende, falls ein Prompt vorbefüllt ist (z.B. aus Issues/To-Do-Quellen), sodass man nahtlos weiterschreiben kann.

Der Bild-Upload (Button / Paste) läuft separat und stiehlt den Fokus nicht.

## Check

`cd ui && bun run check` → 0 Fehler.