### PR TITLE
fix(todo): drop wrapped continuation lines on completed-item cleanup

### DIFF
--- a/ui/src/lib/todo.test.ts
+++ b/ui/src/lib/todo.test.ts
@@ -95,4 +95,22 @@ describe("cleanupTodo", () => {
   it("returns empty string when only completed items remain", () => {
     expect(cleanupTodo("## Done\n\n- [x] one\n- [x] two\n")).toBe("");
   });
+
+  it("drops the wrapped continuation lines of a completed item (no orphans)", () => {
+    const doc = [
+      "# T",
+      "",
+      "- [x] done item — first line that soft-wraps",
+      "      second line of the done item",
+      "      third line of the done item",
+      "- [ ] open item — also wraps",
+      "      continuation of the OPEN item (must survive)",
+    ].join("\n");
+    const out = cleanupTodo(doc);
+    expect(out).not.toContain("second line of the done item");
+    expect(out).not.toContain("third line of the done item");
+    // the open item and its own continuation are untouched
+    expect(out).toContain("- [ ] open item — also wraps");
+    expect(out).toContain("continuation of the OPEN item (must survive)");
+  });
 });

--- a/ui/src/lib/todo.ts
+++ b/ui/src/lib/todo.ts
@@ -57,16 +57,30 @@ export function toggleItem(content: string, index: number): string {
 
 /**
  * Remove completed items and tidy the document:
- * - drop every `- [x]` line and an emptied `## Done` heading
+ * - drop every `- [x]` line *and its wrapped continuation lines* (the indented
+ *   soft-wrap that belongs to the dropped item), plus an emptied `## Done` heading
  * - strip trailing whitespace, collapse blank-line runs, single trailing newline
  * Returns "" if nothing remains.
  */
 export function cleanupTodo(content: string): string {
   const out: string[] = [];
+  // While inside a dropped `- [x]` item, also drop its indented continuation lines.
+  // A blank line, heading, or a new item ends the item and stops the dropping.
+  let droppingItem = false;
   for (const raw of content.split("\n")) {
     const line = raw.replace(/\s+$/, "");
-    if (isDone(line)) continue; // drop completed items
-    if (DONE_HEADING_RE.test(line)) continue; // drop the now-empty Done section
+    if (isItem(line)) {
+      droppingItem = isDone(line);
+      if (droppingItem) continue; // drop completed item
+      out.push(line);
+      continue;
+    }
+    if (DONE_HEADING_RE.test(line)) {
+      droppingItem = false;
+      continue; // drop the now-empty Done section
+    }
+    if (droppingItem && /^\s+\S/.test(line)) continue; // wrapped continuation of dropped item
+    droppingItem = false;
     if (line === "" && out[out.length - 1] === "") continue; // collapse blank runs
     out.push(line);
   }


### PR DESCRIPTION
The TODO panel's completed-item cleanup (`cleanupTodo`) removed each `- [x]` line but kept the item's indented soft-wrap continuation lines, leaving orphaned fragments mid-list (the malformation tidied manually in #77). Now tracks the dropped done-item and removes its continuation lines too; a blank line, heading, or new item ends the item, and **open** items' wrapped lines are preserved. New unit test covers it.