### PR TITLE
fix(viewport): open mobile attach picker via onclick so it works on iOS

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -473,10 +473,7 @@
         class="attach"
         class:failed={uploadFailed}
         title={uploadFailed ? m.viewport_upload_failed() : m.viewport_attach_image()}
-        onpointerdown={(e) => {
-          e.preventDefault();
-          fileInput?.click();
-        }}
+        onclick={() => fileInput?.click()}
         aria-label={m.viewport_attach_image()}
       >
         {uploading ? "⏳" : uploadFailed ? "⚠" : "📎"}


### PR DESCRIPTION
## Problem

Im Trommelmodus (Terminal-Tab) reagierte die Büroklammer (Bild anhängen) auf iOS gar nicht — Antippen passierte nichts. Android funktionierte.

## Ursache

Der Button öffnete den Datei-Picker via `fileInput.click()` aus einem `onpointerdown`-Handler heraus, der `e.preventDefault()` aufrief. iOS Safari öffnet einen nativen File-Picker nur, wenn `input.click()` innerhalb einer **trusted click**-Geste läuft. `preventDefault()` auf `pointerdown` unterdrückt den nachfolgenden Klick und bricht die User-Aktivierungskette → iOS ignoriert den `.click()` stillschweigend.

Die Esc/Tab/Pfeil-Tasten daneben nutzen dasselbe Muster und funktionieren, weil sie nur `conn.send()` aufrufen (kein nativer Dialog, keine Gesten-Anforderung). Ihr `preventDefault()` ist Absicht, damit die Soft-Keyboard nicht zuklappt.

## Fix

Büroklammer auf schlichtes `onclick={() => fileInput?.click()}` umgestellt.

- **iOS Safari**: erfüllt jetzt die geforderte trusted-click-Geste → Picker öffnet.
- **Android Chrome**: war schon immer permissiver, `onclick` lief dort bereits → bleibt funktionsfähig.
- Kein Fokus-Verlust-Problem: der native Picker übernimmt beim Antippen ohnehin den ganzen Screen, es gibt also keinen Terminal-Fokus zu erhalten — `preventDefault()` war für die Büroklammer überflüssig.

## Test

- `cd ui && bun run check` → 0 errors, 0 warnings
- Die eigentliche Geste lässt sich nur am Gerät final bestätigen (iPhone + Android).