### PR TITLE
feat(namer): shorter, readable session names + demote TASK-NN on cards

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ const service = new SessionService({
   store,
   worktree,
   herdr,
-  namer: (p) => generateName(p),
+  namer: (p) => generateName(p).then((r) => r.name),
 });
 
 const accountIndex = new AccountUsageIndex();

--- a/src/namer.ts
+++ b/src/namer.ts
@@ -1,24 +1,268 @@
 import { config } from "./config";
 
+/** Result of naming a prompt. `source` lets callers/telemetry tell an AI-picked
+ *  name apart from the heuristic fallback (used when Ollama is down or the model
+ *  is missing) — the UI surfaces "fallback" so silent degradation is visible. */
+export interface NameResult {
+  name: string;
+  source: "ai" | "fallback";
+}
+
+// Map the accented letters German (and a few neighbours) prompts carry onto their
+// ASCII transliteration BEFORE we strip non-alphanumerics — otherwise "würde"
+// becomes the unreadable "w-rde" instead of "wuerde".
+const TRANSLIT: Record<string, string> = {
+  ä: "ae",
+  ö: "oe",
+  ü: "ue",
+  ß: "ss",
+  à: "a",
+  á: "a",
+  â: "a",
+  é: "e",
+  è: "e",
+  ê: "e",
+  í: "i",
+  ì: "i",
+  ó: "o",
+  ò: "o",
+  ô: "o",
+  ú: "u",
+  ù: "u",
+  ñ: "n",
+  ç: "c",
+};
+
+// Filler words (DE + EN) plus common German exclamations that carry no topical
+// meaning. Dropping them keeps the subject of the prompt, not the scaffolding:
+// "Mist. Scrollen mit dem Mausrad…" → "scrollen-mausrad", not "mist-scrollen-mit-dem".
+const STOPWORDS = new Set([
+  // German articles / pronouns / prepositions / particles
+  "der",
+  "die",
+  "das",
+  "den",
+  "dem",
+  "des",
+  "ein",
+  "eine",
+  "einen",
+  "einem",
+  "einer",
+  "eines",
+  "und",
+  "oder",
+  "aber",
+  "mit",
+  "fuer",
+  "von",
+  "vom",
+  "zu",
+  "zum",
+  "zur",
+  "im",
+  "in",
+  "an",
+  "auf",
+  "aus",
+  "bei",
+  "nach",
+  "ueber",
+  "unter",
+  "vor",
+  "durch",
+  "gegen",
+  "ohne",
+  "um",
+  "als",
+  "wie",
+  "so",
+  "dass",
+  "wenn",
+  "weil",
+  "ich",
+  "du",
+  "er",
+  "sie",
+  "es",
+  "wir",
+  "ihr",
+  "mich",
+  "dich",
+  "sich",
+  "uns",
+  "euch",
+  "mir",
+  "dir",
+  "ihm",
+  "ihn",
+  "ist",
+  "sind",
+  "war",
+  "waren",
+  "bin",
+  "bist",
+  "sein",
+  "seine",
+  "haben",
+  "hat",
+  "hatte",
+  "habe",
+  "werde",
+  "wird",
+  "wurde",
+  "worden",
+  "noch",
+  "schon",
+  "mal",
+  "bitte",
+  "gerne",
+  "gern",
+  "doch",
+  "etwas",
+  "nur",
+  "auch",
+  "nicht",
+  "kein",
+  "keine",
+  "dann",
+  "hier",
+  "da",
+  "dort",
+  "jetzt",
+  "man",
+  "moechte",
+  "wuerde",
+  "koennte",
+  "sollte",
+  "muss",
+  "kann",
+  "soll",
+  "will",
+  "diese",
+  "dieser",
+  "dieses",
+  "mein",
+  "meine",
+  "dein",
+  "deine",
+  "alle",
+  "alles",
+  // German exclamations / filler interjections
+  "mist",
+  "verdammt",
+  "hey",
+  "ok",
+  "okay",
+  "also",
+  "halt",
+  "eben",
+  "einfach",
+  "tja",
+  "naja",
+  "ach",
+  // English
+  "the",
+  "a",
+  "an",
+  "and",
+  "or",
+  "but",
+  "with",
+  "for",
+  "of",
+  "to",
+  "from",
+  "in",
+  "on",
+  "at",
+  "by",
+  "into",
+  "about",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "being",
+  "this",
+  "that",
+  "these",
+  "those",
+  "i",
+  "you",
+  "he",
+  "she",
+  "it",
+  "we",
+  "they",
+  "me",
+  "my",
+  "your",
+  "our",
+  "do",
+  "does",
+  "did",
+  "have",
+  "has",
+  "had",
+  "will",
+  "would",
+  "can",
+  "could",
+  "should",
+  "must",
+  "just",
+  "please",
+  "also",
+  "not",
+  "no",
+  "then",
+  "if",
+  "as",
+  "so",
+  "some",
+  "only",
+  "here",
+  "there",
+  "now",
+  "make",
+  "add",
+  "fix",
+  "please",
+]);
+
+function transliterate(s: string): string {
+  return s.replace(/[äöüßàáâéèêíìóòôúùñç]/gi, (c) => TRANSLIT[c.toLowerCase()] ?? c);
+}
+
+/**
+ * Turn arbitrary prompt text into a short, human-readable kebab-case slug.
+ * Transliterates accents, strips filler words, and keeps the first 1–2 topical
+ * words — so the name reads like a marker ("scrollen-mausrad") rather than the
+ * raw opening of a sentence. Falls back to the raw words if filtering wiped
+ * everything (a prompt made entirely of stopwords), and to "" if truly empty.
+ */
 export function normalize(s: string): string {
-  return s
-    .trim()
+  const words = transliterate(s)
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .split("-")
-    .filter(Boolean)
-    .slice(0, 4)
-    .join("-");
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  const meaningful = words.filter((w) => w.length > 1 && !STOPWORDS.has(w));
+  return (meaningful.length ? meaningful : words).slice(0, 2).join("-");
 }
 
 const PROMPT = (p: string) =>
-  `Reply with ONLY a 2-4 word kebab-case task name, no punctuation, for this request:\n${p}`;
+  `Give a 1-2 word kebab-case slug naming the CORE TOPIC of this request. ` +
+  `Lowercase, no filler words, no punctuation, reply with ONLY the slug.\nRequest: ${p}`;
 
 export async function generateName(
   prompt: string,
   opts?: { model?: string; endpoint?: string; fetchImpl?: typeof fetch },
-): Promise<string> {
+): Promise<NameResult> {
   const f = opts?.fetchImpl ?? fetch;
   try {
     const res = await f(opts?.endpoint ?? config.ollamaEndpoint, {
@@ -29,9 +273,15 @@ export async function generateName(
         stream: false,
       }),
     });
-    const data = (await res.json()) as { response?: string };
-    return normalize(data.response ?? "") || normalize(prompt) || "task";
+    // a missing model returns 404 {error}; treat any non-2xx or error payload as
+    // "AI unavailable" so we fall through to the heuristic rather than naming a task "".
+    if (!res.ok) throw new Error(`ollama ${res.status}`);
+    const data = (await res.json()) as { response?: string; error?: string };
+    if (data.error) throw new Error(data.error);
+    const ai = normalize(data.response ?? "");
+    if (ai) return { name: ai, source: "ai" };
   } catch {
-    return normalize(prompt) || "task";
+    /* fall through to heuristic */
   }
+  return { name: normalize(prompt) || "task", source: "fallback" };
 }

--- a/test/namer.test.ts
+++ b/test/namer.test.ts
@@ -1,23 +1,51 @@
 import { test, expect } from "bun:test";
 import { generateName, normalize } from "../src/namer";
 
-test("normalize → lowercase kebab, max 4 words", () => {
-  expect(normalize("Flatten-Repo-Button-Addition Extra")).toBe("flatten-repo-button-addition");
-  expect(normalize("  Make a FAVICON!! ")).toBe("make-a-favicon");
+test("normalize → lowercase kebab, keeps first 2 meaningful words", () => {
+  expect(normalize("Flatten-Repo-Button-Addition Extra")).toBe("flatten-repo");
+  expect(normalize("  Make a FAVICON!! ")).toBe("favicon"); // "make"/"a" are filler
 });
 
-test("generateName uses ollama response", async () => {
-  const fake = async () => new Response(JSON.stringify({ response: "Repo Flatten Feature" }));
-  expect(await generateName("flatten the repo", { fetchImpl: fake as any })).toBe(
-    "repo-flatten-feature",
+test("normalize drops filler and keeps the topic", () => {
+  // the motivating case: a conversational German prompt → its core, not its opening
+  expect(normalize("Mist. Scrollen mit dem Mausrad im Terminal geht nicht")).toBe(
+    "scrollen-mausrad",
   );
 });
 
-test("generateName falls back to prompt on failure", async () => {
+test("normalize transliterates umlauts instead of destroying them", () => {
+  expect(normalize("Türgriffe übernehmen")).toBe("tuergriffe-uebernehmen");
+  expect(normalize("Größe anpassen")).toBe("groesse-anpassen");
+});
+
+test("normalize falls back to raw words when everything is filler", () => {
+  // all stopwords → keep the raw words rather than returning ""
+  expect(normalize("ich würde mich")).toBe("ich-wuerde");
+});
+
+test("generateName uses ollama response and marks it ai", async () => {
+  const fake = async () => new Response(JSON.stringify({ response: "Repo Flatten Feature" }));
+  expect(await generateName("flatten the repo", { fetchImpl: fake as any })).toEqual({
+    name: "repo-flatten",
+    source: "ai",
+  });
+});
+
+test("generateName falls back to prompt heuristic on failure", async () => {
   const fake = async () => {
     throw new Error("ollama down");
   };
-  expect(await generateName("Add status lights to cards", { fetchImpl: fake as any })).toBe(
-    "add-status-lights-to",
-  );
+  expect(await generateName("Add status lights to cards", { fetchImpl: fake as any })).toEqual({
+    name: "status-lights",
+    source: "fallback",
+  });
+});
+
+test("generateName falls back when the model is missing (404 / error payload)", async () => {
+  const missing = async () =>
+    new Response(JSON.stringify({ error: "model 'x' not found" }), { status: 404 });
+  expect(await generateName("Add a screenshot paste", { fetchImpl: missing as any })).toEqual({
+    name: "screenshot-paste",
+    source: "fallback",
+  });
 });

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -19,12 +19,6 @@
     git?: GitState;
   } = $props();
 
-  // split "TASK-07" into the constant stem ("TASK-") and disambiguating number ("07")
-  // so the stem can collapse on a cramped sidebar, leaving the unit name room to breathe
-  const desigParts = $derived(session.desig.match(/^(.*?)(\d+)$/));
-  const desigStem = $derived(desigParts?.[1] ?? "");
-  const desigNum = $derived(desigParts?.[2] ?? session.desig);
-
   // repo the unit works in — the last path segment of its repoPath (e.g. "community-map")
   const repoName = $derived(session.repoPath.split("/").filter(Boolean).at(-1) ?? session.repoPath);
   const repoIcon = $derived(projectIcons.iconFor(session.repoPath));
@@ -43,7 +37,6 @@
 
   <div class="u-main">
     <div class="u-top">
-      <span class="desig micro"><span class="desig-stem">{desigStem}</span>{desigNum}</span>
       <span class="name">{session.name}</span>
     </div>
     <div class="u-repo" title={session.repoPath}>
@@ -62,7 +55,9 @@
     <PrBadge {git} />
     <span class="badge">{statusLabel(session.status)}</span>
     <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
-    <span class="meta">{session.herdrSession || "—"}</span>
+    <span class="meta"
+      ><span class="desig">{session.desig}</span> · {session.herdrSession || "—"}</span
+    >
   </div>
 </button>
 
@@ -142,18 +137,6 @@
     align-items: baseline;
     gap: 0;
     min-width: 0;
-  }
-
-  .micro {
-    font-size: 10.5px;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: var(--color-muted);
-  }
-
-  .desig {
-    margin-right: 9px;
-    flex-shrink: 0;
   }
 
   .name {
@@ -238,14 +221,11 @@
     color: var(--color-muted);
     font-size: 11.5px;
   }
-
-  /* cramped sidebar (compact touch layout, narrow phones): drop the constant
-     "TASK-" stem and keep just the number, handing the reclaimed width to the
-     name. The wide desktop sidebar (>=300px) stays above this threshold. */
-  @container herd (max-width: 270px) {
-    .desig-stem {
-      display: none;
-    }
+  /* the task designation is metadata, not the human marker — demoted to the
+     quietest spot, the bottom-right meta line, next to the herdr session */
+  .meta .desig {
+    color: var(--color-faint);
+    letter-spacing: 0.1em;
   }
 
   @media (max-width: 768px) {

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -98,7 +98,6 @@
   onclick={() => onselect(session.id)}
 >
   <div class="t-head">
-    <span class="desig">{session.desig}</span>
     <span class="name">{session.name}</span>
     <span class="spacer"></span>
     {#if session.status === "running"}
@@ -106,6 +105,7 @@
     {/if}
     <PrBadge {git} />
     <span class="badge">{statusLabel(session.status)}</span>
+    <span class="desig">{session.desig}</span>
   </div>
   <div class="t-body">
     <div class="t-mount" bind:this={el}></div>
@@ -158,17 +158,20 @@
     white-space: nowrap;
     overflow: hidden;
   }
+  /* designation is metadata: demoted to the end of the header, quietest tone */
   .desig {
-    font-size: 10px;
-    letter-spacing: 0.16em;
+    font-size: 9.5px;
+    letter-spacing: 0.14em;
     text-transform: uppercase;
-    color: var(--color-muted);
+    color: var(--color-faint);
+    flex-shrink: 0;
   }
   .name {
     color: var(--color-ink-bright);
     font-size: 12px;
     font-weight: 500;
     letter-spacing: 0.04em;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
   }


### PR DESCRIPTION
## Why

Session names like `mist-scrollen-m…` (and the broken `ich-w-rde-mich`, where the umlaut was destroyed) are hard to read and not the marker a human actually works with. And `TASK-NN` sat in the most prominent slot of every herd card, even though the *name* is what we navigate by.

## What

Two atomic commits:

1. **`feat(namer): generate shorter, readable session names`**
   - Transliterate umlauts (`ü→ue`) before slugging — no more `ich-w-rde-mich`.
   - Drop DE/EN filler words + German exclamations, keep the first 1–2 **topical** words. `"Mist. Scrollen mit dem Mausrad…"` → `scrollen-mausrad`, not `mist-scrollen-mit-dem`.
   - `generateName` returns `{ name, source }` so callers can tell an AI name from the heuristic fallback.

2. **`feat(ui): demote task designation from the card's leading slot`**
   - The **name** now leads each herd card; `TASK-NN` moves to the quietest spot (bottom-right meta line in the list, end of header in the grid), small and muted.

## Note on AI naming

An earlier draft added an Ollama-namer health hint. While building it I measured the local model output against this heuristic: a 3B model was clearly *worse* (mashed casing, butchered German umlauts), and even `qwen2.5:7b` only *tied* it — at the cost of ~5 GB RAM + per-name inference latency. For a 1–2 word slug the deterministic heuristic wins, so the AI-status surface was dropped; names now rely on the (good) heuristic when Ollama is absent.

## Notes
- New names apply to **newly created** sessions; existing sessions keep their stored names.
- Rebased onto current `main` (incl. #71/#77/#81).

## Verification
- Root `test/`: 357 pass · lint clean (new `namer` tests cover umlauts, stopwords, AI-vs-fallback)
- UI: vitest pass · `svelte-check` 0/0 · `check:i18n` 204/204 parity