### PR TITLE
chore(ci): branch-hygiene gate — reject non-linear / non-main-based PRs

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,0 +1,21 @@
+name: PR hygiene
+
+# Reject PRs whose branch isn't a clean, linear rebase off main (the
+# dev-integration pattern: a branch cut from a base that merged other feature
+# branches drags their commits + a bloated diff into the PR).
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  branch-hygiene:
+    name: branch hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head (the real branch tip, not the merge ref)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: No merge commits / linear off main
+        run: bash scripts/check-branch-hygiene.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -12,6 +12,9 @@ unset $(git rev-parse --local-env-vars) 2>/dev/null || true
 
 echo "▶ pre-push: lint · typecheck · tests · build"
 
+echo "→ branch hygiene (linear off main, no merge commits)"
+bash scripts/check-branch-hygiene.sh
+
 echo "→ prettier --check"
 bunx prettier --check .
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,16 @@ Shepherd worktrees start without `node_modules`. Install per package before lint
 
 Run both halves when a change spans server + UI.
 
+## Branch hygiene (one feature, linear off main)
+
+Every PR branch must be cut from the **latest `main`** and kept **linear**:
+
+- Branch from `origin/main` — never from another feature branch or a shared "dev-integration" branch.
+- **Rebase** onto main to update; never `git merge main` into your branch (no merge commits).
+- One feature per branch — only this change's commits.
+
+A branch that merges other branches drags their commits + a bloated diff into the PR. The gate `scripts/check-branch-hygiene.sh` fails any branch with merge commits relative to main; it runs in the **PR hygiene** CI workflow and the pre-push hook. To fix a polluted branch, re-create it off main with just your change (`git checkout -b <branch> origin/main` then cherry-pick / `rebase --onto origin/main`).
+
 ## Internationalization (REQUIRED for any UI work)
 
 The UI is fully internationalized with Paraglide JS (EN + DE). **Never hardcode user-facing text.** Every display string — labels, buttons, placeholders, `title`/`aria-label`, empty/error/loading states, toast text, and **server-side notification payloads** — must route through a message:

--- a/scripts/check-branch-hygiene.sh
+++ b/scripts/check-branch-hygiene.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Branch-hygiene gate: a feature branch must be a clean, linear rebase off main.
+#
+# The failure we keep hitting: a branch cut from a shared "dev-integration"
+# branch (which had *merged* several other feature branches) drags all those
+# unrelated commits + a huge diff into the PR. A clean branch off the latest
+# main is linear — it has NO merge commits — so that's the signal we gate on.
+#
+# Base defaults to origin/main; CI can override via $BASE_REF for non-main bases.
+set -euo pipefail
+
+BASE="${BASE_REF:-origin/main}"
+
+# Make sure we actually have the base ref to diff against (CI shallow clones).
+git fetch --quiet origin main 2>/dev/null || true
+
+merges="$(git rev-list --merges "${BASE}..HEAD" 2>/dev/null || true)"
+if [ -n "$merges" ]; then
+  echo "✗ branch hygiene: this branch contains merge commit(s) relative to ${BASE}:" >&2
+  git log --oneline --merges "${BASE}..HEAD" >&2 || true
+  cat >&2 <<'MSG'
+
+  Feature branches must be cut from the latest main and kept linear:
+    • branch from origin/main (not from another feature/dev-integration branch)
+    • rebase onto main — never `git merge main` into your branch
+    • one feature per branch, only this change's commits
+
+  Re-create the branch off main with just this change, then force-push:
+    git fetch origin
+    git checkout -b <branch> origin/main
+    git cherry-pick <your commits>   # or rebase --onto origin/main
+MSG
+  exit 1
+fi
+
+echo "✓ branch hygiene: linear off ${BASE} (no merge commits)"


### PR DESCRIPTION
Stops the recurring **dev-integration pollution** (#28, #29): a branch cut from a base that *merged* several feature branches drags their commits + a bloated diff into the PR.

A clean feature branch off the latest `main` is **linear** — no merge commits — so that's the signal. `scripts/check-branch-hygiene.sh` fails any branch with merge commits relative to `origin/main`, with a remediation message (branch off main, rebase, one feature per branch).

Wired into:
- **PR-hygiene CI workflow** (`pull_request`) — checks out the PR *head sha* (not the merge ref) so the merge-commit count is the branch's own.
- **pre-push hook** — same check locally.
- **CLAUDE.md** steering section.

Catches the merge-commit/dev-integration case outright. The milder "stacked on another open PR" case (linear, e.g. #79 on #72) self-resolves on rebase and is covered by the steering.

## Checks
Branch-hygiene check self-tested (passes on linear, fails on a synthetic merge commit). Full pre-push gate green.