### PR TITLE
fix(terminal): allow text selection in xterm while an agent's TUI is active

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -190,6 +190,12 @@
       theme: xtermTheme(initialTheme),
       minimumContrastRatio: xtermMinContrast(initialTheme),
       cursorBlink: true,
+      // Claude Code runs as a TUI with mouse tracking on, which hands mouse drags
+      // to the app instead of selecting text. xterm lets a modifier force local
+      // selection anyway — Shift on Linux/Windows, Option (⌥) on macOS — but the
+      // macOS path only works when this option is enabled (default off). Without
+      // it, Mac users can't select terminal text at all while an agent is running.
+      macOptionClickForcesSelection: true,
     });
     termRef = term;
 


### PR DESCRIPTION
## Problem
Text konnte überall in der Shepherd-UI markiert werden — nur **nicht im Terminal-Pane**, während eine Session mit laufendem Claude Code (oder einem anderen TUI) offen war. Auf macOS ging weder `Shift`- noch `Option`-Drag.

## Ursache
Claude Code läuft als TUI mit aktivem **Mouse-Tracking** — xterm.js reicht Maus-Drags dann an die App weiter statt Text zu selektieren. xterm.js erlaubt eine Modifier-Taste, um lokale Selektion zu erzwingen (Shift auf Linux/Windows, **Option auf macOS**) — der macOS-Pfad funktioniert aber nur, wenn `macOptionClickForcesSelection` gesetzt ist. Default ist `false`, und Shepherd setzte die Option nicht → Mac-User konnten bei laufender Session gar nicht markieren.

## Fix
`macOptionClickForcesSelection: true` in den xterm-`Terminal`-Optionen (`Viewport.svelte`).

## Verhalten danach
- **macOS:** `⌥ Option` halten + ziehen → Selektion, dann ⌘C.
- **Linux/Windows:** `Shift` + ziehen (war schon korrekt).

## Test
Lokal im Dev-Server gegen laufendes herdr verifiziert: Option+Drag selektiert jetzt korrekt im Terminal während aktiver Claude-Code-Session. `bun run check` grün (0 Fehler).