### PR TITLE
feat(ui): tappable URLs in the terminal pane (mobile)

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -6,6 +6,7 @@
       "name": "ui",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-web-links": "0.12.0",
         "@xterm/xterm": "^6.0.0",
         "shiki": "^4.1.0",
         "svelte-dnd-action": "^0.9.69",
@@ -241,6 +242,8 @@
     "@vitest/utils": ["@vitest/utils@4.1.7", "", { "dependencies": { "@vitest/pretty-format": "4.1.7", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/addon-web-links": ["@xterm/addon-web-links@0.12.0", "", {}, "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="],
 
     "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "shiki": "^4.1.0",
     "svelte-dnd-action": "^0.9.69"

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2,6 +2,7 @@
   import "@xterm/xterm/css/xterm.css";
   import { Terminal } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
+  import { WebLinksAddon } from "@xterm/addon-web-links";
   import type { Session, SessionUsage } from "$lib/types";
   import { elapsed, STATUS_COLOR, statusLabel, formatTokens } from "$lib/format";
   import { connectPty, type PtyConn } from "$lib/pty";
@@ -201,6 +202,16 @@
 
     const fit = new FitAddon();
     term.loadAddon(fit);
+    // Linkify URLs in the terminal so they're tappable — on a phone a plain-text
+    // URL can't be opened at all (no text-selection affordance inside xterm's
+    // canvas), and even on desktop a click beats copy-paste. Plain tap/click
+    // opens in a new tab; noopener so the opened page can't reach back via
+    // window.opener.
+    term.loadAddon(
+      new WebLinksAddon((_event, uri) => {
+        window.open(uri, "_blank", "noopener,noreferrer");
+      }),
+    );
     term.open(el);
     fit.fit();
 


### PR DESCRIPTION
## Problem

URLs printed by the agent in the **Terminal** pane render as plain canvas text via xterm.js — no anchor element, no text selection. On a phone there's no way to open such a URL at all (reported from iPhone: "URL is shown but I can't tap it").

## Fix

Wire up the official **`@xterm/addon-web-links`** in `Viewport.svelte`. xterm now detects URLs, underlines them on hover, and a tap/click opens them in a new tab with `noopener,noreferrer`.

```svelte
term.loadAddon(
  new WebLinksAddon((_event, uri) => {
    window.open(uri, "_blank", "noopener,noreferrer");
  }),
);
```

## Dependency

Adds `@xterm/addon-web-links@^0.12.0`. Chose `0.12.0` over `0.11.0` deliberately — `0.11.0` still declares peer `@xterm/xterm@^5` and would warn against the repo's xterm 6.

## Verification

- `bun run check` — 0 errors
- `bun run test` — 87/87 pass
- `bun run check:i18n` — locales in parity (no new strings)
- `bun run build` — clean production build