### PR TITLE
feat(ui): compact mobile new-task dialog + 'next needs you' header jump

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -142,6 +142,8 @@
   "triage_batch_label": "An {count} ausgewählte antworten:",
   "viewport_back_aria": "Zurück zum Herd",
   "viewport_back_button": "‹ Herd",
+  "viewport_next_needs_you": "Wartet ›",
+  "viewport_next_needs_you_aria": "Zur nächsten Sitzung springen, die auf deine Antwort wartet",
   "viewport_usage_title": "{input} rein · {output} raus · {cacheRead} Cache gelesen · {cacheWrite} Cache geschrieben",
   "viewport_tokens_label": "{tokens} tok",
   "viewport_terminal_tab": "Terminal",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -142,6 +142,8 @@
   "triage_batch_label": "Reply to {count} selected:",
   "viewport_back_aria": "Back to herd",
   "viewport_back_button": "‹ Herd",
+  "viewport_next_needs_you": "Needs you ›",
+  "viewport_next_needs_you_aria": "Jump to the next session waiting for your reply",
   "viewport_usage_title": "{input} in · {output} out · {cacheRead} cache read · {cacheWrite} cache write",
   "viewport_tokens_label": "{tokens} tok",
   "viewport_terminal_tab": "Terminal",

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -407,10 +407,30 @@
     .run {
       min-height: 44px;
     }
+    /* Compact head on phones: the "New Task" title is redundant once the
+       sheet is open and the prompt label is obvious from the placeholder.
+       Drop both and float the close ✕ into the corner so the prompt leads
+       the sheet and we don't burn 2–3 rows above the fold. */
+    .chead {
+      margin-bottom: 0;
+    }
+    .chead .micro {
+      display: none;
+    }
     .x {
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      z-index: 1;
       min-width: 44px;
       min-height: 44px;
       font-size: 16px;
+    }
+    label[for="nt-prompt"] {
+      display: none;
+    }
+    textarea {
+      padding-right: 44px; /* keep typed text clear of the floating ✕ */
     }
   }
 

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -26,6 +26,8 @@
     onnewtask,
     onarchive,
     onback,
+    onnextneedsyou,
+    nextNeedsYou = 0,
     onbroadcast,
     mobile = false,
     touch = false,
@@ -35,6 +37,10 @@
     onnewtask?: (repoPath: string, prompt: string) => void;
     onarchive?: (id: string) => void;
     onback?: () => void;
+    /** Jump to the next session waiting for a reply (header shortcut). */
+    onnextneedsyou?: () => void;
+    /** How many *other* sessions are waiting on the operator; gates the button. */
+    nextNeedsYou?: number;
     onbroadcast?: () => void;
     mobile?: boolean;
     touch?: boolean;
@@ -384,6 +390,17 @@
       <button class="back" type="button" onclick={onback} aria-label={m.viewport_back_aria()}
         >{m.viewport_back_button()}</button
       >
+    {/if}
+    {#if onnextneedsyou && nextNeedsYou > 0}
+      <button
+        class="next-yu"
+        type="button"
+        onclick={onnextneedsyou}
+        aria-label={m.viewport_next_needs_you_aria()}
+      >
+        {m.viewport_next_needs_you()}
+        <span class="nyu-count">{nextNeedsYou}</span>
+      </button>
     {/if}
     <span class="desig">{session.desig}</span>
     {#if compact}
@@ -797,6 +814,36 @@
   .back:hover {
     background: var(--color-hover);
   }
+  /* amber accent: this jumps to a session that's actively waiting on the operator */
+  .next-yu {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: transparent;
+    border: 1px solid var(--color-amber);
+    border-radius: 2px;
+    color: var(--color-amber);
+    font: inherit;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    padding: 4px 9px;
+    cursor: pointer;
+    flex-shrink: 0;
+    box-shadow: inset 0 0 18px -12px var(--color-amber);
+  }
+  .next-yu:hover {
+    background: var(--color-hover);
+  }
+  .nyu-count {
+    font-size: 10px;
+    line-height: 1;
+    min-width: 15px;
+    text-align: center;
+    padding: 2px 4px;
+    border-radius: 999px;
+    background: var(--color-amber);
+    color: var(--color-bg);
+  }
 
   /* dedicated git-rail strip for compact layouts (mobile + unfolded fold) */
   .vp-git-strip {
@@ -836,6 +883,7 @@
   }
   /* finger-sized header controls on touch layouts (≥40px) */
   .vp-head.mobile .back,
+  .vp-head.mobile .next-yu,
   .vp-head.mobile .decom {
     min-height: 40px;
     padding: 8px 12px;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -64,6 +64,26 @@
     if (mobile.current) mobileScreen = "detail";
   }
 
+  // sessions waiting on the operator other than the one on screen — gates the
+  // header "needs you" jump and tells the operator how many remain.
+  const otherNeedsYou = $derived(blockedEntries.filter((e) => e.session.id !== selectedId));
+
+  // Jump to the next waiting session: walk blockedEntries (oldest-first, same set
+  // as the NEEDS YOU badge) starting after the current one, wrapping around.
+  function jumpNextNeedsYou() {
+    const entries = blockedEntries;
+    if (entries.length === 0) return;
+    const idx = entries.findIndex((e) => e.session.id === selectedId);
+    const start = idx === -1 ? 0 : idx + 1;
+    for (let i = 0; i < entries.length; i++) {
+      const e = entries[(start + i) % entries.length];
+      if (e.session.id !== selectedId) {
+        selectUnit(e.session.id);
+        return;
+      }
+    }
+  }
+
   // if the selected unit disappears while in mobile detail, fall back to the list
   $effect(() => {
     if (mobile.current && mobileScreen === "detail" && !selected) {
@@ -164,6 +184,8 @@
           mobile={mobile.current}
           {onarchive}
           onback={() => (mobileScreen = "list")}
+          nextNeedsYou={otherNeedsYou.length}
+          onnextneedsyou={jumpNextNeedsYou}
           onbroadcast={() => (showBroadcast = true)}
           onnewtask={(repoPath, prompt) => {
             composeRepoPath = repoPath;


### PR DESCRIPTION
Two mobile-focused UI improvements (iPhone 14 framing).

## 1. Compact New Task dialog (≤768px)
The redundant **NEUE AUFGABE** title and **PROMPT** label are hidden on phones, and the close ✕ floats into the top-right corner — the prompt textarea now leads the sheet instead of burning 2–3 rows above the fold. Desktop is unchanged (title + label stay). CSS-only, no i18n change.

## 2. "Wartet ›" jump button in the mobile Viewport header
Next to the back button, a shortcut jumps to the next session waiting on the operator:
- Cycles `blockedEntries` (same set as the **NEEDS YOU** badge), oldest-first, starting after the current session and wrapping around.
- Only renders when ≥1 *other* session is waiting, with a count badge.
- Mobile-only, mirroring the back button.
- 2 new i18n keys (EN + DE).

## Checks
- i18n parity ✓ (215 keys each)
- `bun run check` — 0 errors
- 87/87 UI tests green