### PR TITLE
fix(viewport): move mobile compose field below nav keys

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -515,7 +515,6 @@
   <!-- control-key bar: any touch device (incl. unfolded foldables wider than the
        mobile breakpoint) gets it, since there's no hardware keyboard to steer with -->
   {#if (mobile || touch) && tab === "term"}
-    <ComposeBar onsend={sendComposed} />
     <div class="ctrl-row">
       <button
         type="button"
@@ -529,6 +528,7 @@
       </button>
       <ControlBar onkey={(seq) => conn?.send(seq)} />
     </div>
+    <ComposeBar onsend={sendComposed} />
     <input
       bind:this={fileInput}
       type="file"


### PR DESCRIPTION
## Was

Auf Touch-Geräten (iPhone/Android) saß das Text-/Diktat-Eingabefeld **mittig** zwischen den Steuer-Buttons und den Esc/Tab/Pfeil-Navigationstasten. Das Feld wandert ans **untere Ende**, direkt über die einblendende Tastatur/Diktat — das übliche Chat-Muster.

**Reihenfolge vorher → nachher** (oben → unten):

| vorher | nachher |
| --- | --- |
| Kurzbefehle (📡 Broadcast · commit & push · …) | Kurzbefehle (📡 Broadcast · commit & push · …) |
| **Eingabe-/Diktatfeld** ← in der Mitte | Navigations-Tasten (📎 · Esc · Tab · Pfeile) |
| Navigations-Tasten (📎 · Esc · Tab · Pfeile) | **Eingabe-/Diktatfeld** ← unten |

Reine Reihenfolge-Umstellung im mobile/touch-Zweig von `Viewport.svelte` (`ComposeBar` nach unter die `ctrl-row` verschoben). Kein Verhalten geändert, gilt für alle Touch-Geräte.

## Tests

- `cd ui && bun run check` → 0 Fehler
- `cd ui && bun run test` → 87/87 passed