### PR TITLE
fix(status): relabel done state as WAITING/WARTET

### DIFF
--- a/src/push.ts
+++ b/src/push.ts
@@ -34,7 +34,7 @@ const defaultSend: SendFn = (sub, payload) =>
 type NotifyLocale = "en" | "de";
 const NOTIFY_TEXT = {
   en: {
-    doneTitle: (name: string) => `${name} — finished`,
+    doneTitle: (name: string) => `${name} — waiting`,
     doneBody: "Agent finished its turn.",
     blockedTitle: (name: string) => `${name} — needs you`,
     menu: "Waiting on a menu choice.",
@@ -43,7 +43,7 @@ const NOTIFY_TEXT = {
     other: "Waiting on your input.",
   },
   de: {
-    doneTitle: (name: string) => `${name} — fertig`,
+    doneTitle: (name: string) => `${name} — wartet`,
     doneBody: "Agent hat seinen Zug beendet.",
     blockedTitle: (name: string) => `${name} — braucht dich`,
     menu: "Wartet auf eine Menüauswahl.",

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -52,7 +52,7 @@ test("notify sends to all subscriptions", async () => {
   store.putPushSub(sub("e2"), "");
   await push.notify({ kind: "done", sessionId: "s1", tag: "s1", name: "T" });
   expect(sent.length).toBe(2);
-  expect(sent[0]).toContain('"title":"T — finished"');
+  expect(sent[0]).toContain('"title":"T — waiting"');
 });
 
 test("notify prunes a subscription that returns 410", async () => {
@@ -116,11 +116,11 @@ test("blockSummary maps shapes to human text", () => {
 test("buildPayload localizes title + body by subscriber locale", () => {
   const done: NotifyInput = { kind: "done", sessionId: "s", tag: "s", name: "Bob" };
   expect(buildPayload(done, "en")).toMatchObject({
-    title: "Bob — finished",
+    title: "Bob — waiting",
     body: "Agent finished its turn.",
   });
   expect(buildPayload(done, "de")).toMatchObject({
-    title: "Bob — fertig",
+    title: "Bob — wartet",
     body: "Agent hat seinen Zug beendet.",
   });
   // blocked body falls through to the localized block summary; unknown locale → en

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -19,7 +19,7 @@
   "status_working": "AKTIV",
   "status_idle": "INAKTIV",
   "status_blocked": "BLOCKIERT",
-  "status_done": "FERTIG",
+  "status_done": "WARTET",
   "status_archived": "ARCHIVIERT",
   "theme_dark": "Dunkel",
   "theme_light": "Hell",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -19,7 +19,7 @@
   "status_working": "WORKING",
   "status_idle": "IDLE",
   "status_blocked": "BLOCKED",
-  "status_done": "DONE",
+  "status_done": "WAITING",
   "status_archived": "ARCHIVED",
   "theme_dark": "Dark",
   "theme_light": "Light",


### PR DESCRIPTION
## Was

Das Status-Badge zeigte **FERTIG** / **DONE** (grün) für Sessions, deren herdr-Agent seinen Zug beendet hat. Das ist irreführend: Der Status bedeutet **nicht** „Aufgabe erledigt", sondern nur **kein aktiver Turn**.

## Warum

`done` wird an zwei Stellen gesetzt, beide ohne jede Inhalts-Analyse:

- **`reconcileAgent`** (`src/poller.ts:59`) — herdr meldet `agent_status: done`, sobald Claude seinen Zug beendet hat und am Prompt wartet. herdr kann „Task fertig" und „Claude hat geantwortet und wartet auf dich" nicht unterscheiden — für herdr ist beides „kein aktiver Turn".
- **`reapGone`** (`src/poller.ts:50`) — der Agent ist ganz aus `herdr agent list` verschwunden (Claude beendet / Strg-C).

Echtes „Task abgeschlossen" wird **nirgends** erkannt — dieses Signal existiert nicht. Der dominante Fall ist „wartet auf dich". Der Code sagt es selbst in `src/server.ts:739`:

> A "done" status only means the agent finished its turn (idle at the prompt)

`WARTET` / `WAITING` deckt beide Sub-Fälle ehrlich ab und sagt dir: du bist dran.

## Änderungen

- `ui/messages/{de,en}.json` — `status_done`: FERTIG/DONE → **WARTET/WAITING**
- `src/push.ts` — Push-Titel `— fertig`/`— finished` → `— wartet`/`— waiting` (Body „Agent hat seinen Zug beendet." war schon korrekt, unverändert)
- `test/push.test.ts` — Assertions angepasst

Das interne Status-Token `"done"` bleibt unverändert — reine Label-Änderung, keine Logik-Änderung.

## Tests

- UI vitest: 87/87 grün
- Root push-Tests: 9/9 grün
- i18n-Gate: 2 Locales in Parität (213 Keys)
- lint clean, svelte-check 0 errors