### PR TITLE
chore(ci): make .fallowrc.jsonc strict-JSON parseable for fallow 2.66

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -27,7 +27,7 @@
     "ui/vite.config.ts",
     "ui/scripts/**/*.mjs",
     "eslint.config.js",
-    "commitlint.config.js",
+    "commitlint.config.js"
   ],
 
   // sw.js is the service worker: never imported statically — the browser fetches
@@ -52,7 +52,7 @@
     // deliberately keep parallel copies of shared shapes (PrStatus, MergeMethod,
     // …) because they don't share a build; the duplicate-export reports on those
     // mirrors are intentional.
-    "duplicate-exports": "off",
+    "duplicate-exports": "off"
   },
 
   // Generated / codegen, plus the parallel forge adapters. GiteaForge.prStatus
@@ -66,8 +66,8 @@
       "**/scripts/**",
       "**/build/**",
       "**/src/forge/gitea.ts",
-      "**/src/forge/github.ts",
-    ],
+      "**/src/forge/github.ts"
+    ]
   },
 
   // Cyclomatic/cognitive kept at fallow defaults (20/15) — the codebase sits
@@ -86,7 +86,7 @@
       "**/scripts/**",
       "**/*.test.ts",
       "**/*.spec.ts",
-      "**/*.svelte.test.ts",
-    ],
-  },
+      "**/*.svelte.test.ts"
+    ]
+  }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,8 @@
   "trailingComma": "all",
   "tailwindStylesheet": "./ui/src/app.css",
   "plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
-  "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+  "overrides": [
+    { "files": "*.svelte", "options": { "parser": "svelte" } },
+    { "files": "*.jsonc", "options": { "trailingComma": "none" } }
+  ]
 }


### PR DESCRIPTION
## Why

`fallow` is invoked **unpinned** (`bunx fallow`) in both the pre-push hook and `ci.yml`. fallow **2.66.0** tightened its config parser to reject trailing commas — which `.fallowrc.jsonc` was full of and which were tolerated when #73 landed. The auto-update silently wedged the **fallow audit gate on every push / PR**, repo-wide. This is not caused by any feature change.

## What

- **Remove the trailing commas** from `.fallowrc.jsonc` so it parses as strict JSON. No behavioural change — same entries, rules, duplicates and health config.
- Prettier's `trailingComma: "all"` would just re-add them on the next `prettier --write`, so add a **`*.jsonc` override** (`trailingComma: "none"`) to `.prettierrc`. `.fallowrc.jsonc` is the only tracked `.jsonc` file, so the override is scoped and safe. Prettier `--check` and fallow now agree.

## ⚠️ Merge note — this PR's own fallow check will be red

`fallow audit --base origin/main` parses **main's *old* (still-broken) config** to build the delta baseline, so it exits 2 on this branch — a chicken-and-egg. It clears the moment this lands on main. **Please merge with a one-time override of the failing fallow check.** Once merged, every other branch's fallow audit parses the baseline fine again.

## Verified locally
- `prettier --check .fallowrc.jsonc .prettierrc` → clean
- `bunx fallow` loads the working-tree config with no error (only the base-cache copy from old main fails, as described above)

## Follow-up (not in this PR)
Consider pinning `bunx fallow@<version>` in the hook + CI so a future fallow release can't wedge the gate again.