### PR TITLE
feat(ui): show repo + task in top bar on phone detail view

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -127,6 +127,7 @@
   "topbar_theme_cycle": "Design: {label} — zum Wechseln tippen",
   "topbar_theme_cycle_aria": "Design: {label}",
   "topbar_settings_aria": "Einstellungen",
+  "topbar_detail_context_aria": "Repo {repo}, aktuelle Session {name}",
   "triage_close_aria": "Schließen",
   "triage_empty": "Keine Agenten warten auf dich.",
   "triage_stall_note": "Still — seit einer Weile keine Aktivität. Möglicherweise hängt er; anstoßen oder Terminal öffnen.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -127,6 +127,7 @@
   "topbar_theme_cycle": "Theme: {label} — tap to cycle",
   "topbar_theme_cycle_aria": "Theme: {label}",
   "topbar_settings_aria": "settings",
+  "topbar_detail_context_aria": "Repo {repo}, current session {name}",
   "triage_close_aria": "Close",
   "triage_empty": "No agents are waiting on you.",
   "triage_stall_note": "Quiet — no activity for a while. May be stuck; nudge it or open the terminal.",

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Session, UsageLimits, UpdateStatus, HerdrUpdateStatus } from "$lib/types";
   import { formatReset } from "$lib/format";
+  import { projectIcons } from "$lib/projectIcons.svelte";
   import { gaugeList, hotterGauge, type GaugeKey } from "./usage-gauges";
   import { m } from "$lib/paraglide/messages";
 
@@ -18,6 +19,8 @@
     onupdate,
     herdrUpdate = null,
     onherdrupdate,
+    screen = "list",
+    detailSession = null,
   }: {
     sessions: Session[];
     nowMs: number;
@@ -32,7 +35,19 @@
     onupdate?: () => void;
     herdrUpdate?: HerdrUpdateStatus | null;
     onherdrupdate?: () => void;
+    /** mobile single-column screen — drives the contextual header swap */
+    screen?: "list" | "detail";
+    detailSession?: Session | null;
   } = $props();
+
+  // On a phone in the session detail view, the SHEPHERD branding is dead chrome —
+  // swap it for the one orientation cue otherwise absent there: which repo + task
+  // this terminal belongs to. (The session list, where the repo shows, is hidden.)
+  const inDetail = $derived(mobile && screen === "detail" && !!detailSession);
+  const repoName = $derived(
+    detailSession ? (detailSession.repoPath.split("/").filter(Boolean).at(-1) ?? "") : "",
+  );
+  const repoIcon = $derived(detailSession ? projectIcons.iconFor(detailSession.repoPath) : null);
 
   const updateAvailable = $derived(!!update && update.behind > 0);
   const herdrUpdateAvailable = $derived(!!herdrUpdate && herdrUpdate.updateAvailable);
@@ -84,41 +99,52 @@
 
 <svelte:window onkeydown={dismissOnEscape} onclick={dismissOnOutside} />
 
-<div class="hud bracket" class:mobile>
-  <div class="logo">SHEP<b>HERD</b></div>
-  {#if !mobile && !touch}
-    <!-- hidden on phones AND unfolded foldables: the label crowds the bar and
-         pushes the gear out on touch layouts narrower than a real desktop -->
-    <div class="sep"></div>
-    <div class="micro">Mission&nbsp;Control</div>
-  {/if}
-  <div class="sep"></div>
-  {#if mobile}
-    <div class="tallies compact">
-      <span class="n">{sessions.length}</span>
-      <span class="cdot" style="color:var(--color-amber)">●</span><span class="n">{working}</span>
-      <span class="csep">·</span><span class="n">{idle}</span>
-      <span class="cdot" style="color:var(--color-red)">!</span><span class="n">{blocked}</span>
+<div class="hud bracket" class:mobile class:detail={inDetail}>
+  {#if inDetail && detailSession}
+    <div
+      class="context"
+      aria-label={m.topbar_detail_context_aria({ repo: repoName, name: detailSession.name })}
+    >
+      <span class="ctx-glyph" class:emoji={repoIcon} aria-hidden="true">{repoIcon ?? "▣"}</span>
+      <span class="ctx-repo">{repoName}</span>
+      <span class="ctx-sep">·</span>
+      <span class="ctx-name">{detailSession.name}</span>
     </div>
   {:else}
-    <div class="tallies">
-      <div class="tally">
-        <span class="micro">{m.topbar_herd_label()}</span><span class="n">{sessions.length}</span>
+    <div class="logo">SHEP<b>HERD</b></div>
+    {#if !mobile && !touch}
+      <!-- hidden on phones AND unfolded foldables: the label crowds the bar and
+           pushes the gear out on touch layouts narrower than a real desktop -->
+      <div class="sep"></div>
+      <div class="micro">Mission&nbsp;Control</div>
+    {/if}
+    <div class="sep"></div>
+    {#if mobile}
+      <div class="tallies compact">
+        <span class="n">{sessions.length}</span>
+        <span class="cdot" style="color:var(--color-amber)">●</span><span class="n">{working}</span>
+        <span class="csep">·</span><span class="n">{idle}</span>
+        <span class="cdot" style="color:var(--color-red)">!</span><span class="n">{blocked}</span>
       </div>
-      <div class="tally">
-        <span class="micro" style="color:var(--color-amber)">{m.topbar_working_label()}</span><span
-          class="n">{working}</span
-        >
+    {:else}
+      <div class="tallies">
+        <div class="tally">
+          <span class="micro">{m.topbar_herd_label()}</span><span class="n">{sessions.length}</span>
+        </div>
+        <div class="tally">
+          <span class="micro" style="color:var(--color-amber)">{m.topbar_working_label()}</span
+          ><span class="n">{working}</span>
+        </div>
+        <div class="tally">
+          <span class="micro">{m.topbar_idle_label()}</span><span class="n">{idle}</span>
+        </div>
+        <div class="tally">
+          <span class="micro" style="color:var(--color-red)">{m.topbar_blocked_label()}</span><span
+            class="n">{blocked}</span
+          >
+        </div>
       </div>
-      <div class="tally">
-        <span class="micro">{m.topbar_idle_label()}</span><span class="n">{idle}</span>
-      </div>
-      <div class="tally">
-        <span class="micro" style="color:var(--color-red)">{m.topbar_blocked_label()}</span><span
-          class="n">{blocked}</span
-        >
-      </div>
-    </div>
+    {/if}
   {/if}
   <div class="rightside">
     {#if needsYou > 0}
@@ -280,6 +306,48 @@
   }
   .logo b {
     color: var(--color-amber);
+  }
+  /* Detail-view contextual header (phone only): repo glyph + repo name · task.
+     Sits where the logo would; the leading pad clears the floating corner dot. */
+  .context {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    flex: 1 1 auto;
+    padding-left: 12px;
+    overflow: hidden;
+  }
+  .ctx-glyph {
+    color: var(--color-amber);
+    font-size: 11px;
+    flex-shrink: 0;
+  }
+  .ctx-glyph.emoji {
+    font-size: 14px;
+  }
+  .ctx-repo {
+    color: var(--color-ink-bright);
+    font-weight: 600;
+    font-size: 13px;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    flex-shrink: 0;
+    max-width: 45%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .ctx-sep {
+    color: var(--color-faint);
+    flex-shrink: 0;
+  }
+  .ctx-name {
+    color: var(--color-ink);
+    font-size: 12px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .sep {
     width: 1px;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -451,7 +451,7 @@
 
 <div class="viewport">
   <!-- header -->
-  <div class="vp-head" class:mobile={compact}>
+  <div class="vp-head" class:mobile={compact} class:phone={mobile}>
     {#if onback}
       <button class="back" type="button" onclick={onback} aria-label={m.viewport_back_aria()}
         >{m.viewport_back_button()}</button
@@ -469,7 +469,9 @@
       </button>
     {/if}
     <span class="desig">{session.desig}</span>
-    {#if compact}
+    {#if compact && !mobile}
+      <!-- foldable/touch desktop only: on a phone the task name now lives in the
+           top bar (repo · task), so showing it here too would just duplicate it -->
       <span class="vp-name" title={session.name}>{session.name}</span>
     {/if}
     {#if !compact}
@@ -989,6 +991,11 @@
      spacer; its flex-grow still pushes the status badge + decom to the right */
   .vp-head.mobile .spacer {
     display: none;
+  }
+  /* phone drops the task name (it moved to the top bar), so the spacer comes back
+     to keep the status badge + decommission right-aligned */
+  .vp-head.phone .spacer {
+    display: block;
   }
   .tab-group.mobile {
     order: 10;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -162,6 +162,8 @@
     onupdate={() => (showUpdate = true)}
     herdrUpdate={store.herdrUpdate}
     onherdrupdate={() => (showHerdrUpdate = true)}
+    screen={mobileScreen}
+    detailSession={selected}
   />
 
   {#if mobile.current}


### PR DESCRIPTION
## What

On a **phone**, once you drill into a session the `SHEP·HERD` branding in the top bar is dead chrome — and the repo name is **absent entirely** in detail view (the session list, where it shows, is hidden). This swaps the logo + herd tallies for an orientation cue:

```
📁 shepherd · TASK-38 lest…
```

repo glyph (per-project emoji, `▣` fallback) + repo name · session title. Back out to the herd overview and the normal Mission-Control header returns. The right side (gauges, clock, ⚙, NEEDS-YOU) is untouched — global info you still want everywhere.

To avoid duplicating the title, the **viewport header is slimmed on phone**: it no longer repeats the task name (now in the top bar). On the unfolded-foldable touch layout — where the top bar still shows the logo — the name stays in the viewport header.

## Changes
- `TopBar.svelte` — `screen` / `detailSession` props, `inDetail` derivation, contextual header + CSS.
- `+page.svelte` — passes `mobileScreen` + `selected` to the top bar.
- `Viewport.svelte` — drops the duplicated name on phone (`compact && !mobile`); re-enables the header spacer there so the decommission button stays right-aligned.
- `en.json` / `de.json` — `topbar_detail_context_aria` (aria-label for the context region).

## Checks (local)
`check:i18n` ✓ (214 keys, en↔de parity) · `bun run check` (svelte-check) ✓ 0 errors · prettier ✓ · `bun run test` ✓ 87/87

## ⚠️ Depends on #95
The fallow audit gate is repo-wide broken (fallow 2.66.0 vs trailing commas in `.fallowrc.jsonc`). This branch's fallow check will be **red until #95 lands on main**. Merge order: **#95 first**, then rebase/merge this. Not caused by this change.