### PR TITLE
fix(ui): align bun.lock with package.json so installs stay idempotent

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -6,7 +6,7 @@
       "name": "ui",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
-        "@xterm/addon-web-links": "0.12.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "shiki": "^4.1.0",
         "svelte-dnd-action": "^0.9.69",


### PR DESCRIPTION
## Problem

`ui/package.json` pins `@xterm/addon-web-links` at `"^0.12.0"`, but the committed `ui/bun.lock` recorded the dependency spec as the **exact** `"0.12.0"`. Every `bun install` rewrites the spec back to `"^0.12.0"`, so the lockfile is **always left dirty**:

```diff
-        "@xterm/addon-web-links": "0.12.0",
+        "@xterm/addon-web-links": "^0.12.0",
```

On the deploy box this broke self-update outright: `deploy/update.sh --pull` refuses a non-clean tree, so the install-dirtied lockfile aborted the pull with `✗ --pull needs a clean tree` — which the UI showed as a bare **`error 409`** (the symptom #97 makes legible).

## Fix

Commit the drift-free lockfile (regenerated via `bun install`) so the recorded spec matches `package.json`. Installs are now a **no-op** and leave the tree clean across deploys.

- **Resolved version is unchanged** (`0.12.0`); only the spec string is aligned — no dependency/behavior change.
- Verified idempotent: two consecutive `bun install` runs produce no further diff.

## Relation to #97

Complementary. **This PR removes the trigger** (the always-dirty tree that blocked `--pull`); **#97 makes any future failure legible** (shows the real deploy log + exit code instead of `error 409`). Both are worth landing.