### PR TITLE
refactor(namer): drop Ollama, heuristic-only session names

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Shepherd core  ──  Bun + TypeScript (src/)
 - `herdr` on `PATH` — manages the interactive `claude` panes (owns the PTYs)
 - The `claude` CLI, logged in with your Max/Pro subscription
 - Node.js — for the PTY helper subprocess
-- _(optional)_ A local [Ollama](https://ollama.com) for auto-naming sessions (falls back gracefully)
 
 ## Quick start
 
@@ -68,19 +67,17 @@ include the public hostname (see below).
 
 All via environment variables (`src/config.ts`):
 
-| Variable                 | Default                               | Purpose                                                                         |
-| ------------------------ | ------------------------------------- | ------------------------------------------------------------------------------- |
-| `SHEPHERD_PORT`          | `7330`                                | HTTP/WS listen port                                                             |
-| `SHEPHERD_HOST`          | `127.0.0.1`                           | Bind address; loopback-only by default (set `0.0.0.0` to expose all NICs)       |
-| `SHEPHERD_DB`            | `~/.shepherd/shepherd.db`             | SQLite session store path                                                       |
-| `SHEPHERD_REPO_ROOT`     | `~` (home)                            | Repos must live under this root (spawn is confined to it)                       |
-| `SHEPHERD_ALLOWED_HOSTS` | `localhost,127.0.0.1,::1,[::1]`       | Comma-separated origin hostnames allowed for writes + WS (CSRF/CSWSH guard)     |
-| `SHEPHERD_TOKEN`         | _(none)_                              | When set, require `Authorization: Bearer <token>`                               |
-| `HERDR_BIN`              | `herdr`                               | Path to the herdr binary                                                        |
-| `HERDR_SESSION`          | `default`                             | herdr session name                                                              |
-| `SHEPHERD_NAMER_MODEL`   | `mistral-small3.1:latest`             | Ollama model used to name sessions                                              |
-| `OLLAMA_URL`             | `http://localhost:11434/api/generate` | Ollama endpoint                                                                 |
-| `SHEPHERD_FORGES`        | `~/.shepherd/forges.json`             | Path to the git-host config (see [Git host integration](#git-host-integration)) |
+| Variable                 | Default                         | Purpose                                                                         |
+| ------------------------ | ------------------------------- | ------------------------------------------------------------------------------- |
+| `SHEPHERD_PORT`          | `7330`                          | HTTP/WS listen port                                                             |
+| `SHEPHERD_HOST`          | `127.0.0.1`                     | Bind address; loopback-only by default (set `0.0.0.0` to expose all NICs)       |
+| `SHEPHERD_DB`            | `~/.shepherd/shepherd.db`       | SQLite session store path                                                       |
+| `SHEPHERD_REPO_ROOT`     | `~` (home)                      | Repos must live under this root (spawn is confined to it)                       |
+| `SHEPHERD_ALLOWED_HOSTS` | `localhost,127.0.0.1,::1,[::1]` | Comma-separated origin hostnames allowed for writes + WS (CSRF/CSWSH guard)     |
+| `SHEPHERD_TOKEN`         | _(none)_                        | When set, require `Authorization: Bearer <token>`                               |
+| `HERDR_BIN`              | `herdr`                         | Path to the herdr binary                                                        |
+| `HERDR_SESSION`          | `default`                       | herdr session name                                                              |
+| `SHEPHERD_FORGES`        | `~/.shepherd/forges.json`       | Path to the git-host config (see [Git host integration](#git-host-integration)) |
 
 ### Git host integration
 
@@ -145,7 +142,7 @@ restart the core (it serves the SPA statically).
 ## Deployment
 
 Shepherd runs as a **systemd user service** (as your own user, so it keeps your `claude`
-subscription login, `~/Work`, herdr, and ollama). It binds to **loopback only**
+subscription login, `~/Work`, and herdr). It binds to **loopback only**
 (`SHEPHERD_HOST=127.0.0.1`); reach it over the network by putting it behind a trusted proxy —
 e.g. Tailscale:
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,8 +18,6 @@ export const config = {
   // otherwise the helper can't spawn and every session pane stays black.
   nodeBin: resolveNodeBin({ override: process.env.SHEPHERD_NODE_BIN }),
   herdrSession: process.env.HERDR_SESSION ?? "default",
-  ollamaModel: process.env.SHEPHERD_NAMER_MODEL ?? "mistral-small3.1:latest",
-  ollamaEndpoint: process.env.OLLAMA_URL ?? "http://localhost:11434/api/generate",
   // usage tracking: where Claude Code writes its session JSONL
   claudeProjectsDir:
     process.env.CLAUDE_PROJECTS_DIR ??

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ const service = new SessionService({
   store,
   worktree,
   herdr,
-  namer: (p) => generateName(p).then((r) => r.name),
+  namer: generateName,
 });
 
 const accountIndex = new AccountUsageIndex();

--- a/src/namer.ts
+++ b/src/namer.ts
@@ -1,13 +1,3 @@
-import { config } from "./config";
-
-/** Result of naming a prompt. `source` lets callers/telemetry tell an AI-picked
- *  name apart from the heuristic fallback (used when Ollama is down or the model
- *  is missing) — the UI surfaces "fallback" so silent degradation is visible. */
-export interface NameResult {
-  name: string;
-  source: "ai" | "fallback";
-}
-
 // Map the accented letters German (and a few neighbours) prompts carry onto their
 // ASCII transliteration BEFORE we strip non-alphanumerics — otherwise "würde"
 // becomes the unreadable "w-rde" instead of "wuerde".
@@ -173,7 +163,6 @@ const STOPWORDS = new Set([
   "of",
   "to",
   "from",
-  "in",
   "on",
   "at",
   "by",
@@ -215,22 +204,18 @@ const STOPWORDS = new Set([
   "must",
   "just",
   "please",
-  "also",
   "not",
   "no",
   "then",
   "if",
   "as",
-  "so",
   "some",
   "only",
-  "here",
   "there",
   "now",
   "make",
   "add",
   "fix",
-  "please",
 ]);
 
 function transliterate(s: string): string {
@@ -255,33 +240,12 @@ export function normalize(s: string): string {
   return (meaningful.length ? meaningful : words).slice(0, 2).join("-");
 }
 
-const PROMPT = (p: string) =>
-  `Give a 1-2 word kebab-case slug naming the CORE TOPIC of this request. ` +
-  `Lowercase, no filler words, no punctuation, reply with ONLY the slug.\nRequest: ${p}`;
-
-export async function generateName(
-  prompt: string,
-  opts?: { model?: string; endpoint?: string; fetchImpl?: typeof fetch },
-): Promise<NameResult> {
-  const f = opts?.fetchImpl ?? fetch;
-  try {
-    const res = await f(opts?.endpoint ?? config.ollamaEndpoint, {
-      method: "POST",
-      body: JSON.stringify({
-        model: opts?.model ?? config.ollamaModel,
-        prompt: PROMPT(prompt),
-        stream: false,
-      }),
-    });
-    // a missing model returns 404 {error}; treat any non-2xx or error payload as
-    // "AI unavailable" so we fall through to the heuristic rather than naming a task "".
-    if (!res.ok) throw new Error(`ollama ${res.status}`);
-    const data = (await res.json()) as { response?: string; error?: string };
-    if (data.error) throw new Error(data.error);
-    const ai = normalize(data.response ?? "");
-    if (ai) return { name: ai, source: "ai" };
-  } catch {
-    /* fall through to heuristic */
-  }
-  return { name: normalize(prompt) || "task", source: "fallback" };
+/**
+ * Derive a session name from a task prompt. Pure and deterministic — no network,
+ * no local model. The salient words of a task prompt are already in the prompt,
+ * so a heuristic slug matches or beats a local LLM for a 1–2 word name
+ * (benchmarked in PR #83) without the RAM/latency cost.
+ */
+export function generateName(prompt: string): string {
+  return normalize(prompt) || "task";
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -10,7 +10,7 @@ export interface ServiceDeps {
   store: SessionStore;
   worktree: Pick<WorktreeMgr, "create" | "remove">;
   herdr: Pick<HerdrDriver, "start" | "list" | "stop" | "send">;
-  namer: (prompt: string) => Promise<string>;
+  namer: (prompt: string) => string | Promise<string>;
   /** Inject point for tests; defaults to the real fs move. */
   moveUploads?: (images: string[], worktreePath: string) => string[];
 }

--- a/test/namer.test.ts
+++ b/test/namer.test.ts
@@ -1,51 +1,33 @@
 import { test, expect } from "bun:test";
 import { generateName, normalize } from "../src/namer";
 
-test("normalize → lowercase kebab, keeps first 2 meaningful words", () => {
+test("normalize → lowercase kebab, max 2 topical words", () => {
   expect(normalize("Flatten-Repo-Button-Addition Extra")).toBe("flatten-repo");
-  expect(normalize("  Make a FAVICON!! ")).toBe("favicon"); // "make"/"a" are filler
+  expect(normalize("Add status lights to cards")).toBe("status-lights");
 });
 
-test("normalize drops filler and keeps the topic", () => {
-  // the motivating case: a conversational German prompt → its core, not its opening
-  expect(normalize("Mist. Scrollen mit dem Mausrad im Terminal geht nicht")).toBe(
-    "scrollen-mausrad",
-  );
+test("normalize transliterates umlauts before slugging", () => {
+  // umlauts in topical words survive as readable ascii ("w-rde" would be the bug)
+  expect(normalize("Größe ändern")).toBe("groesse-aendern");
+  // transliteration runs BEFORE the stopword lookup: "würde" → "wuerde" matches
+  // the ascii stopword and is dropped, leaving the one topical word.
+  expect(normalize("Ich würde gerne scrollen")).toBe("scrollen");
 });
 
-test("normalize transliterates umlauts instead of destroying them", () => {
-  expect(normalize("Türgriffe übernehmen")).toBe("tuergriffe-uebernehmen");
-  expect(normalize("Größe anpassen")).toBe("groesse-anpassen");
+test("normalize drops filler words and German exclamations", () => {
+  expect(normalize("Mist. Scrollen mit dem Mausrad geht nicht")).toBe("scrollen-mausrad");
 });
 
-test("normalize falls back to raw words when everything is filler", () => {
-  // all stopwords → keep the raw words rather than returning ""
-  expect(normalize("ich würde mich")).toBe("ich-wuerde");
+test("normalize falls back to raw words when all words are stopwords", () => {
+  // every token is a stopword → keep the raw first two rather than ""
+  expect(normalize("und der die")).toBe("und-der");
 });
 
-test("generateName uses ollama response and marks it ai", async () => {
-  const fake = async () => new Response(JSON.stringify({ response: "Repo Flatten Feature" }));
-  expect(await generateName("flatten the repo", { fetchImpl: fake as any })).toEqual({
-    name: "repo-flatten",
-    source: "ai",
-  });
+test("normalize returns empty string for symbol-only input", () => {
+  expect(normalize("!!! ??? ...")).toBe("");
 });
 
-test("generateName falls back to prompt heuristic on failure", async () => {
-  const fake = async () => {
-    throw new Error("ollama down");
-  };
-  expect(await generateName("Add status lights to cards", { fetchImpl: fake as any })).toEqual({
-    name: "status-lights",
-    source: "fallback",
-  });
-});
-
-test("generateName falls back when the model is missing (404 / error payload)", async () => {
-  const missing = async () =>
-    new Response(JSON.stringify({ error: "model 'x' not found" }), { status: 404 });
-  expect(await generateName("Add a screenshot paste", { fetchImpl: missing as any })).toEqual({
-    name: "screenshot-paste",
-    source: "fallback",
-  });
+test("generateName slugs the prompt, defaulting to 'task' when empty", () => {
+  expect(generateName("Flatten the repo")).toBe("flatten-repo");
+  expect(generateName("!!!")).toBe("task");
 });


### PR DESCRIPTION
## Why

Session auto-naming made an optional HTTP call to a local Ollama (`mistral-small3.1:latest`) just to turn a task prompt into a 1–2 word kebab-case slug — words that are *already in the prompt*. PR #83's own benchmark found a 3B model clearly worse than the heuristic and `qwen2.5:7b` only tying it, at ~5 GB RAM + per-name latency. So the LLM call is pure cost with no quality upside.

This removes the Ollama dependency entirely and names sessions with a pure deterministic heuristic.

## What

- **`src/namer.ts`** — `generateName` is now synchronous heuristic-only (no `fetch`, no `config` import). `normalize()` transliterates accents (`würde→wuerde`, before slugging, so no more `w-rde`), strips DE+EN filler words + German exclamations, and keeps the first 1–2 *topical* words. Empty/symbol-only → `"task"`.
- **`src/config.ts`** — drop `ollamaModel` / `ollamaEndpoint` (+ `SHEPHERD_NAMER_MODEL` / `OLLAMA_URL` env).
- **`src/service.ts`** — `namer` dep type widened to `(p: string) => string | Promise<string>` (keeps async test injections valid).
- **`src/index.ts`** — callsite simplified to `namer: generateName`.
- **`README.md`** — removed the optional-Ollama dependency bullet, both env-table rows, and "ollama" from the systemd prose.

## Relationship to #83

Supersedes the **namer portion** of #83 (adopts its proven heuristic *and* removes the Ollama call #83 left in front of it). #83's independent UI-card demotion is untouched.

## Documented limitation

Stopword list is DE+EN only (matches the app's i18n). Non-DE/EN prompts degrade to "first 2 raw words" — Ollama was nominally multilingual but lost on quality in #83's benchmark, and this is a DE/EN tool, so no real compromise.

## Verification

- `bunx tsc --noEmit` clean · `bun run lint` clean · `bun test ./test` → 366 pass / 0 fail (6 new namer tests: transliteration-before-stopword, filler dropping, all-stopword raw fallback, empty→`task`)
- `grep -rin ollama src/ test/ README.md` → no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)