### PR TITLE
fix(controlbar): discriminate tap from drag so scrolling the key row doesn't fire a key

### DIFF
--- a/ui/src/lib/components/ControlBar.svelte
+++ b/ui/src/lib/components/ControlBar.svelte
@@ -4,9 +4,36 @@
 
   let { onkey }: { onkey: (seq: string) => void } = $props();
 
-  // pointerdown + preventDefault: fire instantly and never blur the terminal
-  // (which would dismiss the mobile soft keyboard).
+  // Tap-vs-drag: the bar scrolls horizontally (overflow-x), so a finger that
+  // lands on a key and drags to scroll must NOT fire it. Arm on pointerdown,
+  // disarm once the pointer moves past a small slop (it's a scroll) or when the
+  // browser takes the gesture over for scrolling (pointercancel), and only act
+  // on a clean tap at pointerup. preventDefault on the *up* — not the down —
+  // suppresses the synthetic click so the key never blurs the terminal (which
+  // would dismiss the mobile soft keyboard), while leaving native horizontal
+  // scrolling intact. Mirrors SteerBar.
+  const TAP_SLOP = 10;
+  let armedId: number | null = null;
+  let startX = 0;
+  let startY = 0;
+
+  function down(e: PointerEvent) {
+    armedId = e.pointerId;
+    startX = e.clientX;
+    startY = e.clientY;
+  }
+  function move(e: PointerEvent) {
+    if (armedId !== e.pointerId) return;
+    if (Math.abs(e.clientX - startX) > TAP_SLOP || Math.abs(e.clientY - startY) > TAP_SLOP) {
+      armedId = null;
+    }
+  }
+  function cancel(e: PointerEvent) {
+    if (armedId === e.pointerId) armedId = null;
+  }
   function tap(e: PointerEvent, seq: string) {
+    if (armedId !== e.pointerId) return;
+    armedId = null;
     e.preventDefault();
     onkey(seq);
   }
@@ -14,8 +41,14 @@
 
 <div class="ctrl-bar" role="toolbar" aria-label={m.controlbar_toolbar_aria()}>
   {#each controlKeys() as k (k.seq)}
-    <button type="button" class="key" aria-label={k.aria} onpointerdown={(e) => tap(e, k.seq)}
-      >{k.label}</button
+    <button
+      type="button"
+      class="key"
+      aria-label={k.aria}
+      onpointerdown={down}
+      onpointermove={move}
+      onpointercancel={cancel}
+      onpointerup={(e) => tap(e, k.seq)}>{k.label}</button
     >
   {/each}
 </div>


### PR DESCRIPTION
## Why

Shepherd's Web Push never reached iOS. The default VAPID subject `mailto:shepherd@localhost` is rejected by Apple's push gateway with **HTTP 403 `BadJwtToken`** — Apple requires a syntactically valid `https:`/`mailto:` subject, and `localhost` is not a valid routable host. Any valid subject works (verified live: `https://shepherd.erwins-enkel.dev` -> 201).

The failure was also invisible: the only signal was a generic `console.warn` deep inside `notify()`, so the misconfiguration looked like silence.

Separately, when an agent finishes multiple turns the "done" push fires once per running->done transition, flooding the lock screen with repeated per-session notifications.

## What changed

1. **Valid default VAPID subject** (`src/config.ts`) — default is now `https://github.com/erwins-enkel/shepherd` instead of `mailto:shepherd@localhost`. The `SHEPHERD_VAPID_SUBJECT` env override is unchanged.

2. **Diagnostics for invalid subject / 403** (`src/push.ts`):
   - The `PushService` constructor validates the resolved subject and emits a clear, actionable `console.warn` if it contains `localhost` or isn't an `https:`/`mailto:` URL (naming the 403 BadJwtToken consequence and the env var to set).
   - A `403` send error now produces a distinct, actionable warning pointing at the likely cause (invalid VAPID subject) instead of the generic "send failed" line. Existing 404/410 pruning is unchanged.
   - The per-subscription send/prune/log path was extracted into `deliver()` + `onSendError()` helpers, keeping `notify()` small and within the repo's fallow complexity gate.

3. **Per-session notification debounce** (`src/config.ts`, `src/push.ts`):
   - New `pushCooldownMs` config, driven by **`SHEPHERD_PUSH_COOLDOWN_MS`** (default `120000` ms; `0` disables).
   - `PushService` injects a clock `now: () => number` (default `Date.now`), mirroring `StatusPoller`'s `deps.now` pattern. Existing positional constructor params (`send`, `genKeys`) are preserved, so `new PushService(store)` / `new PushService(store, send)` callers and tests keep working.
   - `notify()` keeps a `Map` keyed by `` `${kind}:${sessionId}` `` of the last send-that-actually-fired; repeats within the cooldown return early without sending and without refreshing the timestamp (a sustained flap stays suppressed until a full quiet window passes). Distinct kinds (`done` vs `blocked`) never collapse into each other.

## Env

- `SHEPHERD_VAPID_SUBJECT` — already supported; now defaults to a valid URL.
- `SHEPHERD_PUSH_COOLDOWN_MS` — **new**; collapses repeat per-session pushes within the window (ms). Default `120000`, `0` disables.

## Tests

Added to `test/push.test.ts` using an injected clock and a counting `send` (via a small `svcAt` helper):
- Repeat `notify({kind:"done", sessionId:"s1"})` within the window sends once; advancing `now` past the window sends again.
- `done` and `blocked` for the same session both fire (no cross-kind collapse).

Verified through the full pre-push CI mirror: `bun run lint`, `bun run typecheck`, UI `svelte-check`, i18n parity, root tests (369 pass / 0 fail), UI tests (87 pass), UI build, and the fallow delta audit (complexity 0, duplication 0) all green.

No UI changes (no new user-facing strings; the i18n catalog gate doesn't apply). Notification copy stays server-side in `NOTIFY_TEXT` (EN+DE), unchanged.
