### PR TITLE
fix(push): valid default VAPID subject + 403 diagnostics + per-session debounce

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,8 @@ export const config = {
   // `mailto:shepherd@localhost`) with HTTP 403 BadJwtToken. Default to a valid
   // https URL; override with SHEPHERD_VAPID_SUBJECT (any valid https:/mailto: URL).
   vapidSubject: process.env.SHEPHERD_VAPID_SUBJECT ?? "https://github.com/erwins-enkel/shepherd",
+  // collapse repeat per-session pushes within this window (ms); 0 disables.
+  pushCooldownMs: Number(process.env.SHEPHERD_PUSH_COOLDOWN_MS ?? 120000),
   // git host (forge) integration: per-host {type,baseUrl,token,deployWorkflow,mergeMethod}
   forgesPath,
   forges: loadForgeMap(forgesPath),

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,7 +39,10 @@ export const config = {
   // are unset; provide them via env to pin a stable key pair across DB resets.
   vapidPublic: process.env.SHEPHERD_VAPID_PUBLIC ?? null,
   vapidPrivate: process.env.SHEPHERD_VAPID_PRIVATE ?? null,
-  vapidSubject: process.env.SHEPHERD_VAPID_SUBJECT ?? "mailto:shepherd@localhost",
+  // Apple/iOS rejects pushes whose VAPID subject is a non-routable URL (e.g.
+  // `mailto:shepherd@localhost`) with HTTP 403 BadJwtToken. Default to a valid
+  // https URL; override with SHEPHERD_VAPID_SUBJECT (any valid https:/mailto: URL).
+  vapidSubject: process.env.SHEPHERD_VAPID_SUBJECT ?? "https://github.com/erwins-enkel/shepherd",
   // git host (forge) integration: per-host {type,baseUrl,token,deployWorkflow,mergeMethod}
   forgesPath,
   forges: loadForgeMap(forgesPath),

--- a/src/push.ts
+++ b/src/push.ts
@@ -88,11 +88,14 @@ export function buildPayload(input: NotifyInput, locale: string): PushPayload {
 
 export class PushService {
   private pub: string;
+  /** Last *successful-send* timestamp per `${kind}:${sessionId}`, for cooldown debouncing. */
+  private lastNotified = new Map<string, number>();
 
   constructor(
     private store: SessionStore,
     private send: SendFn = defaultSend,
     genKeys: GenKeys = () => webpush.generateVAPIDKeys(),
+    private now: () => number = () => Date.now(),
   ) {
     let pub = config.vapidPublic ?? store.getSetting("vapidPublic");
     let priv = config.vapidPrivate ?? store.getSetting("vapidPrivate");
@@ -132,9 +135,21 @@ export class PushService {
   }
 
   async notify(input: NotifyInput): Promise<void> {
-    for (const row of this.store.listPushSubs()) {
-      await this.deliver(row, input);
+    const cooldownMs = config.pushCooldownMs;
+    const key = `${input.kind}:${input.sessionId}`;
+    const t = this.now();
+    // Suppress repeats within the window of the last send that actually fired; a
+    // sustained flap stays suppressed until a full quiet window passes. Distinct
+    // kinds (done vs blocked) live under separate keys and never collapse.
+    if (cooldownMs > 0) {
+      const last = this.lastNotified.get(key);
+      if (last !== undefined && t - last < cooldownMs) return;
     }
+    let sent = false;
+    for (const row of this.store.listPushSubs()) {
+      if (await this.deliver(row, input)) sent = true;
+    }
+    if (sent && cooldownMs > 0) this.lastNotified.set(key, t);
   }
 
   /** Send one notification; prune dead subs, log diagnostics. Returns true if delivered. */

--- a/src/push.ts
+++ b/src/push.ts
@@ -1,6 +1,6 @@
 import webpush from "web-push";
 import { config } from "./config";
-import type { SessionStore, PushSubInput } from "./store";
+import type { SessionStore, PushSubInput, StoredPushSub } from "./store";
 import type { EventHub } from "./events";
 import type { BlockReason } from "./blocked";
 
@@ -104,8 +104,16 @@ export class PushService {
       store.setSetting("vapidPrivate", priv);
     }
     this.pub = pub;
+    const subject = config.vapidSubject;
+    if (subject.includes("localhost") || !/^(mailto:|https:\/\/)/.test(subject)) {
+      console.warn(
+        `[push] VAPID subject ${JSON.stringify(subject)} is invalid — Apple/iOS will ` +
+          "reject pushes with HTTP 403 BadJwtToken. Set SHEPHERD_VAPID_SUBJECT to a " +
+          "valid https: or mailto: URL (e.g. https://example.com or mailto:you@example.com).",
+      );
+    }
     try {
-      webpush.setVapidDetails(config.vapidSubject, pub, priv);
+      webpush.setVapidDetails(subject, pub, priv);
     } catch (err) {
       console.warn("[push] setVapidDetails failed:", err);
     }
@@ -125,19 +133,43 @@ export class PushService {
 
   async notify(input: NotifyInput): Promise<void> {
     for (const row of this.store.listPushSubs()) {
-      const sub: PushSubInput = {
-        endpoint: row.endpoint,
-        keys: { p256dh: row.p256dh, auth: row.auth },
-      };
-      const data = JSON.stringify(buildPayload(input, row.locale));
-      try {
-        const r = await this.send(sub, data);
-        if (r?.statusCode === 404 || r?.statusCode === 410) this.store.deletePushSub(row.endpoint);
-      } catch (err) {
-        const code = (err as { statusCode?: number })?.statusCode;
-        if (code === 404 || code === 410) this.store.deletePushSub(row.endpoint);
-        else console.warn(`[push] send failed for ${row.endpoint}:`, code ?? err);
+      await this.deliver(row, input);
+    }
+  }
+
+  /** Send one notification; prune dead subs, log diagnostics. Returns true if delivered. */
+  private async deliver(row: StoredPushSub, input: NotifyInput): Promise<boolean> {
+    const sub: PushSubInput = {
+      endpoint: row.endpoint,
+      keys: { p256dh: row.p256dh, auth: row.auth },
+    };
+    const data = JSON.stringify(buildPayload(input, row.locale));
+    try {
+      const code = (await this.send(sub, data))?.statusCode;
+      if (code === 404 || code === 410) {
+        this.store.deletePushSub(row.endpoint);
+        return false;
       }
+      return true;
+    } catch (err) {
+      this.onSendError(row.endpoint, (err as { statusCode?: number })?.statusCode, err);
+      return false;
+    }
+  }
+
+  /** Prune gone subs (404/410); surface the 403 BadJwtToken misconfig distinctly. */
+  private onSendError(endpoint: string, code: number | undefined, err: unknown): void {
+    if (code === 404 || code === 410) {
+      this.store.deletePushSub(endpoint);
+    } else if (code === 403) {
+      console.warn(
+        `[push] 403 for ${endpoint} — likely an invalid VAPID subject ` +
+          `(Apple BadJwtToken). Check SHEPHERD_VAPID_SUBJECT (currently ` +
+          `${JSON.stringify(config.vapidSubject)}); it must be a valid https: ` +
+          "or mailto: URL with no localhost.",
+      );
+    } else {
+      console.warn(`[push] send failed for ${endpoint}:`, code ?? err);
     }
   }
 }

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -20,6 +20,14 @@ function svc(send: SendFn) {
   return { store, push };
 }
 
+/** A service with an injected clock + one "e1" subscription, for debounce tests. */
+function svcAt(send: SendFn, now: () => number) {
+  const store = new SessionStore(":memory:");
+  const push = new PushService(store, send, keys, now);
+  store.putPushSub(sub("e1"), "");
+  return { store, push };
+}
+
 test("generates and persists VAPID keys when settings empty", () => {
   const store = new SessionStore(":memory:");
   new PushService(store, async () => ({}), keys);
@@ -102,6 +110,50 @@ test("attachPush pushes on session:block with a reason, ignores null", async () 
   await Promise.resolve();
   expect(calls.length).toBe(1);
   expect(calls[0]).toMatchObject({ kind: "blocked", sessionId: "z" });
+});
+
+test("notify debounces repeats within the cooldown window, fires again after it", async () => {
+  let count = 0;
+  let t = 0;
+  const send: SendFn = async () => {
+    count++;
+    return {};
+  };
+  const { push } = svcAt(send, () => t);
+
+  const n: NotifyInput = { kind: "done", sessionId: "s1", tag: "s1", name: "T" };
+  await push.notify(n); // sends
+  t = 1; // 1ms later — well within the 120s default window
+  await push.notify(n); // suppressed
+  t = 60_000; // still inside the window
+  await push.notify(n); // suppressed
+  expect(count).toBe(1);
+
+  t = 200_000; // past the 120s default window
+  await push.notify(n); // sends again
+  expect(count).toBe(2);
+});
+
+test("notify does not collapse different kinds for the same session", async () => {
+  const sent: string[] = [];
+  const send: SendFn = async (_s, payload) => {
+    sent.push(payload);
+    return {};
+  };
+  const { push } = svcAt(send, () => 0); // frozen clock
+
+  await push.notify({ kind: "done", sessionId: "s1", tag: "s1", name: "T" });
+  await push.notify({
+    kind: "blocked",
+    sessionId: "s1",
+    tag: "s1",
+    name: "T",
+    reason: { shape: "yes-no", options: [], tail: [] },
+  });
+  // both fire even at the same instant: done and blocked use distinct keys
+  expect(sent.length).toBe(2);
+  expect(sent[0]).toContain('"kind":"done"');
+  expect(sent[1]).toContain('"kind":"blocked"');
 });
 
 test("blockSummary maps shapes to human text", () => {


### PR DESCRIPTION
## Why

Shepherd's Web Push never reached iOS. The default VAPID subject `mailto:shepherd@localhost` is rejected by Apple's push gateway with **HTTP 403 `BadJwtToken`** — Apple requires a syntactically valid `https:`/`mailto:` subject, and `localhost` is not a valid routable host. Any valid subject works (verified live: `https://shepherd.erwins-enkel.dev` -> 201).

The failure was also invisible: the only signal was a generic `console.warn` deep inside `notify()`, so the misconfiguration looked like silence.

Separately, when an agent finishes multiple turns the "done" push fires once per running->done transition, flooding the lock screen with repeated per-session notifications.

## What changed

1. **Valid default VAPID subject** (`src/config.ts`) — default is now `https://github.com/erwins-enkel/shepherd` instead of `mailto:shepherd@localhost`. The `SHEPHERD_VAPID_SUBJECT` env override is unchanged.

2. **Diagnostics for invalid subject / 403** (`src/push.ts`):
   - The `PushService` constructor validates the resolved subject and emits a clear, actionable `console.warn` if it contains `localhost` or isn't an `https:`/`mailto:` URL (naming the 403 BadJwtToken consequence and the env var to set).
   - A `403` send error now produces a distinct, actionable warning pointing at the likely cause (invalid VAPID subject) instead of the generic "send failed" line. Existing 404/410 pruning is unchanged.
   - The per-subscription send/prune/log path was extracted into `deliver()` + `onSendError()` helpers, keeping `notify()` small and within the repo's fallow complexity gate.

3. **Per-session notification debounce** (`src/config.ts`, `src/push.ts`):
   - New `pushCooldownMs` config, driven by **`SHEPHERD_PUSH_COOLDOWN_MS`** (default `120000` ms; `0` disables).
   - `PushService` injects a clock `now: () => number` (default `Date.now`), mirroring `StatusPoller`'s `deps.now` pattern. Existing positional constructor params (`send`, `genKeys`) are preserved, so `new PushService(store)` / `new PushService(store, send)` callers and tests keep working.
   - `notify()` keeps a `Map` keyed by `` `${kind}:${sessionId}` `` of the last send-that-actually-fired; repeats within the cooldown return early without sending and without refreshing the timestamp (a sustained flap stays suppressed until a full quiet window passes). Distinct kinds (`done` vs `blocked`) never collapse into each other.

## Env

- `SHEPHERD_VAPID_SUBJECT` — already supported; now defaults to a valid URL.
- `SHEPHERD_PUSH_COOLDOWN_MS` — **new**; collapses repeat per-session pushes within the window (ms). Default `120000`, `0` disables.

## Tests

Added to `test/push.test.ts` using an injected clock and a counting `send` (via a small `svcAt` helper):
- Repeat `notify({kind:"done", sessionId:"s1"})` within the window sends once; advancing `now` past the window sends again.
- `done` and `blocked` for the same session both fire (no cross-kind collapse).

Verified through the full pre-push CI mirror: `bun run lint`, `bun run typecheck`, UI `svelte-check`, i18n parity, root tests (369 pass / 0 fail), UI tests (87 pass), UI build, and the fallow delta audit (complexity 0, duplication 0) all green.

No UI changes (no new user-facing strings; the i18n catalog gate doesn't apply). Notification copy stays server-side in `NOTIFY_TEXT` (EN+DE), unchanged.
