### PR TITLE
feat(ui): reclaim phone session-header height for the terminal

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -97,6 +97,7 @@
   "reposelect_filter_placeholder": "filtern…",
   "reposelect_no_matches": "keine Treffer",
   "settings_title": "Einstellungen",
+  "settings_herdr_update_label": "Herdr-Update verfügbar",
   "settings_push_title": "Push-Benachrichtigungen",
   "settings_push_unsupported": "In diesem Browser nicht unterstützt. Unter iOS zuerst Shepherd zum Startbildschirm hinzufügen.",
   "settings_push_denied": "In den Browser-Einstellungen blockiert. Benachrichtigungen für diese Seite wieder aktivieren und neu laden.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -97,6 +97,7 @@
   "reposelect_filter_placeholder": "filter…",
   "reposelect_no_matches": "no matches",
   "settings_title": "Settings",
+  "settings_herdr_update_label": "Herdr update available",
   "settings_push_title": "Push notifications",
   "settings_push_unsupported": "Not supported on this browser. On iOS, install Shepherd to your home screen first.",
   "settings_push_denied": "Blocked in browser settings. Re-enable notifications for this site, then reload.",

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { getSettings, putSettings, listDirs } from "$lib/api";
-  import type { DirListing } from "$lib/types";
+  import type { DirListing, HerdrUpdateStatus } from "$lib/types";
   import SteersEditor from "$lib/components/SteersEditor.svelte";
   import { m } from "$lib/paraglide/messages";
   import { pushState, enablePush, disablePush, type PushStatus } from "$lib/push";
@@ -16,7 +16,20 @@
     { pref: "system", glyph: "◐", label: m.theme_system },
   ];
 
-  let { onclose, onsaved }: { onclose?: () => void; onsaved?: (root: string) => void } = $props();
+  let {
+    onclose,
+    onsaved,
+    herdrUpdate = null,
+    onherdrupdate,
+  }: {
+    onclose?: () => void;
+    onsaved?: (root: string) => void;
+    herdrUpdate?: HerdrUpdateStatus | null;
+    onherdrupdate?: () => void;
+  } = $props();
+
+  // On a phone the HERDR badge folds into the gear; its update flow lands here.
+  const herdrUpdateAvailable = $derived(!!herdrUpdate && herdrUpdate.updateAvailable);
 
   let currentRoot = $state(""); // the persisted root (display form)
   let listing = $state<DirListing | null>(null);
@@ -99,6 +112,22 @@
         >✕</button
       >
     </div>
+
+    {#if herdrUpdateAvailable}
+      <button type="button" class="herdr-cta" onclick={() => onherdrupdate?.()}>
+        <span class="hc-dot" aria-hidden="true">▲</span>
+        <span class="hc-text">
+          <span class="hc-label">{m.settings_herdr_update_label()}</span>
+          <span class="hc-ver"
+            >{m.topbar_herdr_update_title({
+              current: herdrUpdate!.current ?? "?",
+              latest: herdrUpdate!.latest ?? "?",
+            })}</span
+          >
+        </span>
+        <span class="hc-chev" aria-hidden="true">›</span>
+      </button>
+    {/if}
 
     <div class="cur">
       <span class="micro">{m.settings_current_root_label()}</span>
@@ -239,6 +268,46 @@
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
+  }
+  /* Folded HERDR-update entry point (green, matching the badge it replaces). */
+  .herdr-cta {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    text-align: left;
+    border: 1px solid var(--color-green);
+    background: color-mix(in srgb, var(--color-green) 12%, transparent);
+    border-radius: 2px;
+    padding: 10px 12px;
+    cursor: pointer;
+    font: inherit;
+    color: var(--color-ink-bright);
+  }
+  .herdr-cta .hc-dot {
+    color: var(--color-green);
+    font-size: 9px;
+  }
+  .herdr-cta .hc-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
+  }
+  .herdr-cta .hc-label {
+    color: var(--color-green);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+  .herdr-cta .hc-ver {
+    color: var(--color-muted);
+    font-size: 12px;
+  }
+  .herdr-cta .hc-chev {
+    color: var(--color-green);
+    font-size: 18px;
+    line-height: 1;
   }
   .cur {
     display: flex;

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -243,10 +243,11 @@
         <span class="up-n">{update!.behind}</span>
       </button>
     {/if}
-    {#if herdrUpdateAvailable}
+    <!-- Desktop keeps the inline HERDR badge; on a phone it folds into the gear
+         (green dot below) to free a slot in the single-row control cluster. -->
+    {#if herdrUpdateAvailable && !mobile}
       <button
         class="update-badge herdr"
-        class:mobile
         onclick={() => onherdrupdate?.()}
         title={m.topbar_herdr_update_title({
           current: herdrUpdate!.current ?? "?",
@@ -259,10 +260,13 @@
     {/if}
     <button
       class="gear tip"
+      class:has-update={herdrUpdateAvailable && mobile}
       type="button"
       onclick={() => onsettings?.()}
       data-tip={m.settings_title()}
-      aria-label={m.topbar_settings_aria()}>⚙</button
+      aria-label={m.topbar_settings_aria()}
+      >⚙{#if herdrUpdateAvailable && mobile}<span class="gear-dot" aria-hidden="true"
+        ></span>{/if}</button
     >
   </div>
 </div>
@@ -307,15 +311,13 @@
   .logo b {
     color: var(--color-amber);
   }
-  /* Detail-view contextual header (phone only): repo glyph + repo name · task.
-     Sits where the logo would; the leading pad clears the floating corner dot. */
+  /* Detail-view contextual header (phone only): repo glyph + repo name · task. */
   .context {
     display: flex;
     align-items: center;
     gap: 7px;
     min-width: 0;
     flex: 1 1 auto;
-    padding-left: 12px;
     overflow: hidden;
   }
   .ctx-glyph {
@@ -345,6 +347,10 @@
     color: var(--color-ink);
     font-size: 12px;
     min-width: 0;
+    /* cap the name so a long task never eats the row and forces the control
+       cluster to wrap — it ellipsizes well before then, ceding width to the
+       terminal below */
+    max-width: 42vw;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -392,6 +398,7 @@
     gap: 16px;
   }
   .gear {
+    position: relative;
     background: transparent;
     border: 1px solid var(--color-line-bright);
     color: var(--color-muted);
@@ -404,6 +411,21 @@
   .gear:hover {
     color: var(--color-amber);
     border-color: var(--color-amber);
+  }
+  /* phone-only: the folded HERDR-update cue — a green pip on the gear that mirrors
+     the calm green of the desktop badge and rings against the panel to stay legible */
+  .gear-dot {
+    position: absolute;
+    top: 3px;
+    right: 3px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--color-green);
+    box-shadow: 0 0 0 2px var(--color-panel);
+  }
+  .gear.has-update {
+    border-color: var(--color-green);
   }
   .gauges {
     display: flex;
@@ -590,14 +612,12 @@
   .tallies.compact .csep {
     color: var(--color-faint);
   }
-  /* Mobile: the connection dot floats in the top-left corner, out of the flex
-     flow, so it stays visible without consuming a slot in the control row. The
-     numeric time is hidden to save space. */
+  /* Mobile: drop the numeric time and let the bare connection dot ride inline at
+     the head of the right-side cluster (order:-1) — vertically centred with the
+     gauge/gear instead of floating off-centre in the corner. */
   .hud.mobile .clock {
-    position: absolute;
-    top: 4px;
-    left: 5px;
-    z-index: 2;
+    order: -1;
+    gap: 0;
   }
   .hud.mobile .clock .time {
     display: none;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -343,7 +343,14 @@
 {/if}
 
 {#if showSettings}
-  <Settings onclose={() => (showSettings = false)} />
+  <Settings
+    onclose={() => (showSettings = false)}
+    herdrUpdate={store.herdrUpdate}
+    onherdrupdate={() => {
+      showSettings = false;
+      showHerdrUpdate = true;
+    }}
+  />
 {/if}
 
 {#if showBroadcast}


### PR DESCRIPTION
Space optimization on the **mobile session detail view** — collapses the TopBar from two rows to one and hands the recovered vertical height back to the terminal.

## Changes
- **Task name capped** — `.ctx-name` gets `max-width: 42vw` so a long task ellipsizes instead of monopolizing the bar and forcing the control cluster to wrap.
- **HERDR badge folds into the cog** — on phones the inline `HERDR` badge is gone; the gear wears a green pip + border when a herdr update is available. Tapping it opens **Settings**, which now shows a green tappable "Herdr update available" banner that opens the existing `HerdrUpdateModal`. Desktop keeps the inline badge unchanged.
- **Connection dot re-homed** — from an off-centre top-left corner float to an inline, vertically-centred status light leading the right-side cluster (`order: -1`). Dropped the `.context` left-pad hack that only existed to clear the old floating dot.

## i18n
- New key `settings_herdr_update_label` in both `en.json` + `de.json` (parity gate green).

## Verification
- `cd ui && bun run check` — svelte-check 0 errors
- `cd ui && bun run check:i18n` — 227 keys, 2 locales in parity
- `cd ui && bun run test` — 87 pass · root `bun test` — 373 pass
- prettier clean

Not yet rendered on a live mobile viewport — layout reasoned + statically verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)