### PR TITLE
fix(ui): center close ✕ in its gutter on new-task sheet (mobile)

### DIFF
--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -419,11 +419,14 @@
     }
     .x {
       position: absolute;
-      top: 6px;
-      right: 6px;
+      top: 0;
+      right: 0;
       z-index: 1;
-      min-width: 44px;
-      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 44px;
+      height: 44px;
       font-size: 16px;
     }
     label[for="nt-prompt"] {


### PR DESCRIPTION
## What

On mobile the new-task sheet's close ✕ was pinned at `top: 6px; right: 6px` — jammed into the card corner while the textarea below reserved a 44px right gutter for it. The two didn't line up, so the ✕ read as shoved against the edge.

Anchor the 44×44 tap target flush to the corner (`top: 0; right: 0`) and center the glyph inside it with flexbox. Now the ✕ sits centered in the textarea's reserved gutter.

## Test

- `cd ui && bun run check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)