### PR TITLE
fix(ui): drop redundant frozen elapsed timer from session detail header

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -4,7 +4,7 @@
   import { FitAddon } from "@xterm/addon-fit";
   import { WebLinksAddon } from "@xterm/addon-web-links";
   import type { Session, SessionUsage } from "$lib/types";
-  import { elapsed, STATUS_COLOR, statusLabel, formatTokens } from "$lib/format";
+  import { STATUS_COLOR, statusLabel, formatTokens } from "$lib/format";
   import { connectPty, type PtyConn } from "$lib/pty";
   import { theme, xtermTheme, xtermMinContrast } from "$lib/theme.svelte";
   import { getSessionUsage, uploadImage, resumeSession as apiResumeSession } from "$lib/api";
@@ -22,7 +22,6 @@
 
   let {
     session,
-    nowMs = Date.now(),
     onnewtask,
     onarchive,
     onback,
@@ -35,7 +34,6 @@
     onnavigate,
   }: {
     session: Session;
-    nowMs?: number;
     onnewtask?: (repoPath: string, prompt: string) => void;
     onarchive?: (id: string) => void;
     onback?: () => void;
@@ -554,9 +552,6 @@
       {#if session.status === "running"}⠿{/if}
       {statusLabel(session.status)}
     </span>
-    {#if session.status === "running" && !compact}
-      <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
-    {/if}
     {#if !compact}
       <GitRail
         sessionId={session.id}
@@ -800,13 +795,6 @@
     border: 1px solid;
     border-radius: 2px;
     flex-shrink: 0;
-  }
-
-  .elapsed {
-    color: var(--color-ink);
-    font-variant-numeric: tabular-nums;
-    letter-spacing: 0.08em;
-    font-size: 11px;
   }
 
   .decom {


### PR DESCRIPTION
## Problem

The elapsed-time timer was duplicated: in every session-list row **and** in the session detail header. The header copy had two issues:

- **Frozen** — it never ticked. `nowMs` was never passed to `<Viewport>`, so it fell back to the prop default `Date.now()`, evaluated once at mount.
- **Redundant** — it only rendered on the desktop split layout (`running && !compact`), exactly when the list row for the same session (which *does* tick) sits right beside it. On mobile/compact it was hidden entirely.

## Fix

Remove the header timer. The list/grid timers remain the single ticking source, driven by the page-level `setInterval` → `nowMs`. The selected session's elapsed time now appears in exactly one place, ticking, with no frozen duplicate.

Also drops the now-unused `nowMs` prop, `elapsed` import, and `.elapsed` style from `Viewport.svelte`.

## Verification

`cd ui && bun run check` → 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)