### PR TITLE
fix(herdr-update): pass --handoff so protocol-bump updates survive running targets

### DIFF
--- a/src/herdr-update.ts
+++ b/src/herdr-update.ts
@@ -109,13 +109,21 @@ export class HerdrUpdateService {
    *  mid-update). `herdr update` must run outside a herdr session — the transient
    *  unit gets a clean environment, so it qualifies. It restarts the herdr server
    *  (ending live agent panes), after which we restart shepherd so it re-establishes
-   *  its herdr session and clients reconnect to a fresh build. */
+   *  its herdr session and clients reconnect to a fresh build.
+   *
+   *  `--handoff` is required because Shepherd itself runs as a live herdr target:
+   *  a protocol-bumping update (e.g. 0.6.5 proto 11 → 0.6.6 proto 12) refuses to
+   *  proceed while targets are running unless it can restart them. Without the
+   *  flag `herdr update` exits 1 ("one or more herdr targets must restart … run
+   *  from an interactive terminal, or stop those targets"), which can never be
+   *  satisfied from this non-interactive transient unit — so the update would
+   *  always fail. `--handoff` hands the running targets to the new version. */
   private defaultLaunch(): void {
     // forward our PATH: a transient --user unit gets a bare environment, but the
     // command needs herdr/systemctl, which live on the service's PATH.
     const args = ["--user", "--collect", "--unit=herdr-update"];
     if (process.env.PATH) args.push(`--setenv=PATH=${process.env.PATH}`);
-    args.push("bash", "-lc", "herdr update && systemctl --user restart shepherd");
+    args.push("bash", "-lc", "herdr update --handoff && systemctl --user restart shepherd");
     const child = spawn("systemd-run", args, { stdio: "ignore" });
     child.unref();
   }
@@ -130,13 +138,17 @@ export class HerdrUpdateService {
   apply(): { started: boolean } {
     if (this.applying) return { started: false };
     this.applying = true;
-    this.launch();
-    // Start streaming the journal output; wrapped so a failure never surfaces.
+    // Start streaming the journal BEFORE launching: `herdr update` runs inside the
+    // transient unit and emits its diagnostics (incl. the "update failed: …" line)
+    // within milliseconds. If we launched first, the `journalctl -f` tailer would
+    // attach too late and catch only systemd's trailing "Failed with result" lines,
+    // hiding the actual cause from the modal. Wrapped so a failure never surfaces.
     try {
       this.follow((line) => this.onLog(line));
     } catch {
       // follow implementation threw synchronously — ignore
     }
+    this.launch();
     return { started: true };
   }
 

--- a/test/herdr-update.test.ts
+++ b/test/herdr-update.test.ts
@@ -129,6 +129,17 @@ test("apply() calls follow and forwards lines to onLog", () => {
   expect(received).toEqual(["Fetching herdr 0.6.5...", "Installing..."]);
 });
 
+test("apply() starts follow before launch so early log lines aren't missed", () => {
+  const order: string[] = [];
+  const svc = new HerdrUpdateService({
+    launch: () => order.push("launch"),
+    onLog: () => {},
+    follow: () => order.push("follow"),
+  });
+  svc.apply();
+  expect(order).toEqual(["follow", "launch"]);
+});
+
 test("apply() does not start follow on second call", () => {
   let followCalls = 0;
   const svc = new HerdrUpdateService({


### PR DESCRIPTION
## Problem

Starting the in-app herdr update (0.6.5 → 0.6.6) always failed with:

```
code=exited, status=1/FAILURE
herdr-update.service: Failed with result 'exit-code'.
```

**Root cause:** 0.6.5 → 0.6.6 is a protocol bump (proto 11 → 12). `herdr update` refuses to proceed non-interactively while herdr targets are running, and Shepherd itself runs as a live target. The full journal — which the modal *didn't* show — revealed:

```
update failed: one or more herdr targets must restart for this update;
run `herdr update` from an interactive terminal, or stop those targets and run `herdr update` again
```

The transient unit runs `herdr update` non-interactively, so neither escape hatch can ever be satisfied — **this update path could never succeed.**

## Fix

1. **Pass `--handoff`** (`herdr update --help`'s only flag) so running targets are handed to the new version instead of aborting the update.
2. **Start the `journalctl` tailer before launching** the transient unit. herdr emits its diagnostics within milliseconds; attaching the follower *after* launch caught only systemd's trailing "Failed with result" lines and hid the real cause from the update modal. Now the actual `update failed: …` line reaches the modal.
3. **Test** locking the follow-before-launch ordering so the race can't regress.

Server-side only — no UI strings (the log lines come verbatim from herdr).

## Test

- `bun test test/herdr-update.test.ts` → 14 pass
- `bun run lint` → clean