### PR TITLE
feat: sync package.json version w/ release-please + show in footer

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,8 +17,8 @@ export default [
   {
     files: ["**/*.svelte", "**/*.svelte.ts", "**/*.svelte.js"],
     languageOptions: {
-      // __GIT_SHA__ is injected at build time via ui/vite.config.ts `define`
-      globals: { ...globals.browser, __GIT_SHA__: "readonly" },
+      // __GIT_SHA__ / __APP_VERSION__ are injected at build time via ui/vite.config.ts `define`
+      globals: { ...globals.browser, __GIT_SHA__: "readonly", __APP_VERSION__: "readonly" },
       parserOptions: {
         parser: ts.parser,
         extraFileExtensions: [".svelte"],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "shepherd",
+  "version": "1.2.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,7 +18,8 @@
   ],
   "packages": {
     ".": {
-      "package-name": "shepherd"
+      "package-name": "shepherd",
+      "extra-files": [{ "type": "json", "path": "package.json", "jsonpath": "$.version" }]
     }
   }
 }

--- a/ui/src/app.d.ts
+++ b/ui/src/app.d.ts
@@ -3,6 +3,7 @@
 declare global {
   // injected at build time by vite.config.ts (`define`)
   const __GIT_SHA__: string;
+  const __APP_VERSION__: string;
 
   namespace App {
     // interface Error {}

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -6,6 +6,7 @@
   const REPO = "erwins-enkel/shepherd";
   const REPO_URL = `https://github.com/${REPO}`;
   const sha = __GIT_SHA__;
+  const version = __APP_VERSION__;
   const commitUrl = sha === "unknown" ? REPO_URL : `https://github.com/${REPO}/commit/${sha}`;
 
   const THEMES: { pref: ThemePref; glyph: string; label: () => string }[] = [
@@ -50,6 +51,8 @@
       <div class="meta">
         <a class="repo" href={REPO_URL} target="_blank" rel="external noreferrer noopener">{REPO}</a
         >
+        <span class="dot">·</span>
+        <span class="version">v{version}</span>
         <span class="dot">·</span>
         <a
           class="sha"
@@ -123,6 +126,9 @@
   .sha {
     color: var(--color-muted);
     text-decoration: none;
+  }
+  .version {
+    color: var(--color-muted);
   }
   .sha {
     color: var(--color-ink);

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { paraglideVitePlugin } from "@inlang/paraglide-js";
 import { sveltekit } from "@sveltejs/kit/vite";
 import tailwindcss from "@tailwindcss/vite";
@@ -12,9 +14,19 @@ function gitSha(): string {
   }
 }
 
+function appVersion(): string {
+  try {
+    const pkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
+    return JSON.parse(readFileSync(pkgPath, "utf8")).version ?? "dev";
+  } catch {
+    return "dev";
+  }
+}
+
 export default defineConfig({
   define: {
     __GIT_SHA__: JSON.stringify(gitSha()),
+    __APP_VERSION__: JSON.stringify(appVersion()),
   },
   plugins: [
     paraglideVitePlugin({


### PR DESCRIPTION
## What

Keep `package.json` version in lockstep with release-please, and surface it in the footer.

- **Version sync** — added `"version"` to `package.json` (matches the `1.2.0` manifest) and an `extra-files` entry in `release-please-config.json` so each release bumps it alongside the manifest/CHANGELOG. `release-type: simple` doesn't touch `package.json` on its own.
- **Footer** — `vite.config.ts` reads the root `package.json` into a new `__APP_VERSION__` build define; `ActionBar.svelte` renders `v{version}` in front of the SHA. Declared the global in `app.d.ts` and registered it in `eslint.config.js`.

Footer now reads: `erwins-enkel/shepherd · v1.2.0 · <sha>`.

## Validation

- `cd ui && bun run check` — 0 errors
- root `bun run lint` — clean
- UI build injects `v1.2.0` into the client bundle

Note: release-please picks up the new `extra-files` config on the next release PR; the version is treated as a data value, so it's intentionally not routed through i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)