### PR TITLE
feat(ui): make the in-app update reliable & readable on mobile

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -240,5 +240,6 @@
   "updatemodal_deploy_failed": "Das Update konnte nicht abgeschlossen werden — der Deploy ist abgebrochen, bevor der Server neu gestartet wurde.",
   "updatemodal_exit_code": "Exit-Code {code}",
   "updatemodal_deploy_log": "Deploy-Ausgabe",
+  "updatemodal_unreachable": "Server zu lange nicht erreichbar — das Update ist möglicherweise fehlgeschlagen. App neu laden oder Logs prüfen.",
   "updatemodal_retry": "Erneut versuchen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -240,5 +240,6 @@
   "updatemodal_deploy_failed": "The update could not be completed — the deploy stopped before the server restarted.",
   "updatemodal_exit_code": "Exit code {code}",
   "updatemodal_deploy_log": "Deploy output",
+  "updatemodal_unreachable": "The server stayed unreachable for too long — the update may have failed. Reload the app or check the logs.",
   "updatemodal_retry": "Retry"
 }

--- a/ui/src/lib/components/UpdateModal.svelte
+++ b/ui/src/lib/components/UpdateModal.svelte
@@ -20,6 +20,11 @@
 
   let submitting = $state(false);
   let error = $state<string | null>(null);
+  // commit subjects truncate to one line by default; tapping a row expands it to
+  // the full width so the whole message is readable — on a phone the single line
+  // otherwise cuts off with an ellipsis and you never see the end
+  let expanded = $state<Record<string, boolean>>({});
+  const toggle = (sha: string) => (expanded[sha] = !expanded[sha]);
 
   const failed = $derived(deploy?.phase === "failed");
 
@@ -36,6 +41,9 @@
   }
 
   const busy = $derived(submitting || updating);
+  // while the deploy is in flight, show its captured output so the user sees
+  // real progress (install → build → restart) instead of a frozen spinner
+  const liveLog = $derived(busy && !failed && deploy?.log ? deploy.log : null);
 </script>
 
 <div
@@ -67,15 +75,26 @@
 
     <div class="commits">
       {#each update.commits as c (c.sha)}
-        <div class="commit">
+        <button
+          type="button"
+          class="commit"
+          class:expanded={expanded[c.sha]}
+          aria-expanded={!!expanded[c.sha]}
+          title={c.subject}
+          onclick={() => toggle(c.sha)}
+        >
           <span class="sha">{c.sha}</span>
           <span class="subject">{c.subject}</span>
-        </div>
+        </button>
       {/each}
     </div>
 
     {#if busy}
       <div class="status">{m.updatemodal_status()}</div>
+    {/if}
+    {#if liveLog}
+      <div class="loghead micro">{m.updatemodal_deploy_log()}</div>
+      <pre class="log">{liveLog}</pre>
     {/if}
     {#if error}<div class="err">{error}</div>{/if}
 
@@ -200,8 +219,22 @@
   .commit {
     display: flex;
     gap: 9px;
-    align-items: baseline;
+    align-items: flex-start;
+    width: 100%;
+    margin: 0;
+    padding: 2px 0;
+    background: transparent;
+    border: 0;
+    text-align: left;
+    font-family: inherit;
     font-size: 12.5px;
+    color: inherit;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .commit:focus-visible {
+    outline: 1px solid var(--color-line-bright);
+    outline-offset: 2px;
   }
   .commit .sha {
     color: var(--color-amber);
@@ -213,6 +246,29 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  /* tapped open → wrap the full subject across the available width */
+  .commit.expanded .subject {
+    white-space: normal;
+    overflow: visible;
+    word-break: break-word;
+  }
+  /* touch devices: roomier rows so a single commit is easy to hit and read */
+  @media (pointer: coarse) {
+    .commit {
+      padding: 8px 0;
+      min-height: 34px;
+      align-items: center;
+    }
+    .commit.expanded {
+      align-items: flex-start;
+    }
+    .commits {
+      gap: 0;
+    }
+    .commit + .commit {
+      border-top: 1px solid var(--color-line);
+    }
   }
   .status {
     color: var(--color-amber);

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -40,8 +40,8 @@
   let showBroadcast = $state(false);
   let showTriage = $state(false);
   let showUpdate = $state(false);
-  // set when a launched deploy reports failure → modal shows the captured reason
-  let deployFailure = $state<DeployState | null>(null);
+  // live state of a launched deploy → modal tails its log + surfaces failures
+  let deploy = $state<DeployState | null>(null);
   let deployPollTimer: ReturnType<typeof setTimeout> | null = null;
   let showHerdrUpdate = $state(false);
   // set once the operator confirms the herdr update; herdr+shepherd restart drops
@@ -153,39 +153,55 @@
     selectedId = store.sessions.find((s) => s.id !== id)?.id ?? null;
   }
 
-  // The deploy runs detached and only restarts the server on success — on a
-  // success the store reloads (new SHA); on a failure nothing else fires, so we
-  // poll the captured deploy log and surface the reason in the modal.
+  // The deploy runs detached: it builds, restarts the server, and only then —
+  // after the new process answers a health check — writes its success marker.
+  // So a readable `done` GUARANTEES the new build is already live. We poll the
+  // captured log to drive the modal (live progress + failures) and, on `done`,
+  // reload immediately rather than waiting for the update:status broadcast,
+  // which the server only re-emits every 5 min (and a phone's WS often misses
+  // on reconnect) — that lag is why the modal used to sit frozen until a manual
+  // app restart.
   function watchDeploy() {
     if (deployPollTimer) clearTimeout(deployPollTimer);
-    const startedAt = Date.now();
+    let lastReachable = Date.now(); // last time the server answered the log poll
     const tick = async () => {
       try {
         const st = await getUpdateLog();
+        lastReachable = Date.now();
+        deploy = st; // feed the modal the live, tailing log
+        if (st.phase === "done") {
+          // new server is up and healthy → pull the freshly built UI assets
+          location.reload();
+          return;
+        }
         if (st.phase === "failed") {
-          deployFailure = st;
           store.updating = false; // unstick the spinner so the user can read + retry
           return;
         }
-        if (st.phase === "done") return; // success → SHA change reloads the page
       } catch {
-        /* transient (e.g. server mid-restart) — keep polling */
+        // server is briefly unreachable mid-restart — expected, keep polling.
+        // But if it stays unreachable far longer than a restart should take,
+        // stop guessing and tell the user, so the modal can't wedge forever.
+        if (Date.now() - lastReachable > 3 * 60_000) {
+          deploy = { phase: "failed", exitCode: null, log: m.updatemodal_unreachable() };
+          store.updating = false;
+          return;
+        }
       }
-      if (Date.now() - startedAt > 5 * 60_000) return; // give up after 5 min
-      deployPollTimer = setTimeout(tick, 2000);
+      deployPollTimer = setTimeout(tick, 1500);
     };
-    deployPollTimer = setTimeout(tick, 2000);
+    deployPollTimer = setTimeout(tick, 1500);
   }
 
   function onUpdateConfirm() {
-    deployFailure = null;
+    deploy = null;
     store.beginUpdate();
     watchDeploy();
   }
 
   function closeUpdate() {
     showUpdate = false;
-    deployFailure = null;
+    deploy = null;
     if (deployPollTimer) clearTimeout(deployPollTimer);
   }
 </script>
@@ -313,7 +329,7 @@
   <UpdateModal
     update={store.update}
     updating={store.updating}
-    deploy={deployFailure}
+    {deploy}
     onconfirm={onUpdateConfirm}
     onclose={closeUpdate}
   />


### PR DESCRIPTION
## Problem

On the phone, after tapping **Aktualisieren** the update modal sat **frozen** — no progress, no reload. The page only reloaded when an `update:status` WS broadcast arrived carrying a new SHA, but the server re-emits that only **3 s after boot and then every 5 minutes**, and a PWA's socket often misses the post-boot one on reconnect. Result: you had to kill and relaunch the iOS PWA by hand to get the new build.

## Fix

- **Auto-reload on `done`.** `watchDeploy()` now reloads the moment the deploy log reports `phase: "done"`. The deploy script (`deploy/update.sh`) writes its success marker only *after* it restarts the unit and health-checks `/api/sessions` → 200, so a readable `done` guarantees the new server is already live — the right instant to reload, no WS-broadcast lag.
- **Visible progress.** The modal now tails the **live deploy log** while updating (install → build → restart), instead of showing it only on failure.
- **No more wedging.** The poll gives up only if the server stays unreachable for >3 min (longer than any restart), surfacing a clear message (`updatemodal_unreachable`, EN + DE) rather than spinning forever.
- **Readable commit rows (mobile).** Each commit row is now tappable: a tap expands the subject to **full width** so the whole message is readable instead of a truncated `…` one-liner. Touch devices get roomier tap targets + dividers; desktop stays compact with a hover tooltip.

## Checks

- `cd ui && bun run check` — 0 errors
- `cd ui && bun run check:i18n` — 2 locales in parity (242 keys)
- `cd ui && bun run test` — 101/101 pass

Verified live preview on iOS via Tailscale.