### PR TITLE
feat(namer): keep 3 topical words to cut slug collisions

### DIFF
--- a/src/namer.ts
+++ b/src/namer.ts
@@ -224,10 +224,12 @@ function transliterate(s: string): string {
 
 /**
  * Turn arbitrary prompt text into a short, human-readable kebab-case slug.
- * Transliterates accents, strips filler words, and keeps the first 1–2 topical
- * words — so the name reads like a marker ("scrollen-mausrad") rather than the
- * raw opening of a sentence. Falls back to the raw words if filtering wiped
- * everything (a prompt made entirely of stopwords), and to "" if truly empty.
+ * Transliterates accents, strips filler words, and keeps the first 1–3 topical
+ * words — so the name reads like a marker ("scrollen-mausrad-geht") rather than
+ * the raw opening of a sentence. Three words (vs two) markedly lowers the chance
+ * two distinct prompts collide on the same slug. Falls back to the raw words if
+ * filtering wiped everything (a prompt made entirely of stopwords), and to "" if
+ * truly empty.
  */
 export function normalize(s: string): string {
   const words = transliterate(s)
@@ -237,13 +239,13 @@ export function normalize(s: string): string {
     .split(/\s+/)
     .filter(Boolean);
   const meaningful = words.filter((w) => w.length > 1 && !STOPWORDS.has(w));
-  return (meaningful.length ? meaningful : words).slice(0, 2).join("-");
+  return (meaningful.length ? meaningful : words).slice(0, 3).join("-");
 }
 
 /**
  * Derive a session name from a task prompt. Pure and deterministic — no network,
  * no local model. The salient words of a task prompt are already in the prompt,
- * so a heuristic slug matches or beats a local LLM for a 1–2 word name
+ * so a heuristic slug matches or beats a local LLM for a 1–3 word name
  * (benchmarked in PR #83) without the RAM/latency cost.
  */
 export function generateName(prompt: string): string {

--- a/test/namer.test.ts
+++ b/test/namer.test.ts
@@ -1,9 +1,9 @@
 import { test, expect } from "bun:test";
 import { generateName, normalize } from "../src/namer";
 
-test("normalize → lowercase kebab, max 2 topical words", () => {
-  expect(normalize("Flatten-Repo-Button-Addition Extra")).toBe("flatten-repo");
-  expect(normalize("Add status lights to cards")).toBe("status-lights");
+test("normalize → lowercase kebab, max 3 topical words", () => {
+  expect(normalize("Flatten-Repo-Button-Addition Extra")).toBe("flatten-repo-button");
+  expect(normalize("Add status lights to cards")).toBe("status-lights-cards");
 });
 
 test("normalize transliterates umlauts before slugging", () => {
@@ -15,12 +15,12 @@ test("normalize transliterates umlauts before slugging", () => {
 });
 
 test("normalize drops filler words and German exclamations", () => {
-  expect(normalize("Mist. Scrollen mit dem Mausrad geht nicht")).toBe("scrollen-mausrad");
+  expect(normalize("Mist. Scrollen mit dem Mausrad geht nicht")).toBe("scrollen-mausrad-geht");
 });
 
 test("normalize falls back to raw words when all words are stopwords", () => {
-  // every token is a stopword → keep the raw first two rather than ""
-  expect(normalize("und der die")).toBe("und-der");
+  // every token is a stopword → keep the raw first three rather than ""
+  expect(normalize("und der die")).toBe("und-der-die");
 });
 
 test("normalize returns empty string for symbol-only input", () => {


### PR DESCRIPTION
## What

Bump the prompt→name slug from the first **2** topical words to the first **3**.

## Why

Two-word slugs collide too readily across distinct prompts. A third word sharply lowers clash odds, so fewer sessions fall back to the `-2`/`-3` numeric suffix (`service.ts` `uniqueName`). The slug still drives the worktree path + branch, so this keeps those readable and more distinct too.

## Changes

- `src/namer.ts` — `normalize()` keeps `slice(0, 3)`; comments updated.
- `test/namer.test.ts` — expectations updated (`flatten-repo-button`, `status-lights-cards`, `scrollen-mausrad-geht`, `und-der-die`).

## Verification

- `bun run lint` clean
- `bun test ./test/namer.test.ts` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)