### PR TITLE
fix(critic): produce verdicts — fix arg-swallow, dontAsk Write, hook derail

### DIFF
--- a/src/review.ts
+++ b/src/review.ts
@@ -90,16 +90,27 @@ export class ReviewService {
     }
     // Read-only critic — deliberately NOT --dangerously-skip-permissions. It
     // inspects an UNTRUSTED PR diff, so a prompt-injection hidden in that diff
-    // must not be able to run commands or edit files. `dontAsk` auto-denies
-    // anything off the allowlist (an unattended PTY would otherwise hang on a
-    // permission prompt); the allowlist is read-only inspection + read-only git
-    // + writing ONLY its own verdict file. Keep in sync with VERDICT_FILE.
+    // must not be able to run commands or escape its worktree. `dontAsk`
+    // auto-denies anything off the allowlist (an unattended PTY would otherwise
+    // hang on a permission prompt); the allowlist is read-only inspection +
+    // read-only git + writing files in its own disposable worktree.
     const argv = [
       "claude",
       "--session-id",
       randomUUID(),
-      "--permission-mode",
-      "dontAsk",
+      // Run the critic in a CLEAN context. It's a fresh `claude` startup, so it
+      // would otherwise inherit the user's global hooks + plugins — notably the
+      // superpowers SessionStart hook, which injects a forceful "you MUST invoke
+      // a skill" preamble. Skill isn't on the allowlist, so dontAsk denies it and
+      // the agent thrashes instead of reviewing. disableAllHooks strips every
+      // inherited hook (also gsd/herdr/ensure-deps — none of which the critic
+      // needs); --disable-slash-commands removes skills entirely.
+      // NOT --bare: it refuses OAuth/keychain auth (strictly ANTHROPIC_API_KEY),
+      // and shepherd runs on subscription OAuth with no API key — --bare would
+      // break the critic's auth. --settings keeps OAuth while disabling hooks.
+      "--settings",
+      '{"disableAllHooks":true}',
+      "--disable-slash-commands",
       "--allowedTools",
       "Read",
       "Grep",
@@ -108,9 +119,22 @@ export class ReviewService {
       "Bash(git log *)",
       "Bash(git show *)",
       "Bash(git status)",
-      `Write(${VERDICT_FILE})`,
+      // Bare `Write` — NOT Write(<path>). Path-scoped Write rules are silently
+      // denied under --permission-mode dontAsk (every scoped form fails to match),
+      // so a scoped rule would block the verdict write and the critic could never
+      // finish → timeout. Bare Write is an acceptable widening: the worktree is
+      // detached + disposable (removed right after the review) and the agent still
+      // can't exec, commit, push, or reach anything outside it (no general Bash,
+      // no Edit, no network).
+      "Write",
     ];
     if (this.deps.model) argv.push("--model", this.deps.model);
+    // --permission-mode LAST: `--allowedTools <tools...>` is variadic and eats
+    // every following token until the next flag. The task prompt is a trailing
+    // positional, so a single-value flag MUST sit between the allowlist and the
+    // prompt — otherwise `claude` folds the prompt into the allowlist, launches
+    // with no task, and hangs until timeout (every review). Don't reorder.
+    argv.push("--permission-mode", "dontAsk");
     argv.push(reviewPrompt(session.baseBranch, session.prompt));
     let terminalId: string;
     try {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -122,11 +122,37 @@ test("critic spawns read-only: no skip-permissions, dontAsk + scoped allowlist",
   expect(argv).not.toContain("--dangerously-skip-permissions");
   expect(argv[argv.indexOf("--permission-mode") + 1]).toBe("dontAsk");
   expect(argv).toContain("Read");
-  expect(argv).toContain("Write(.shepherd-review.json)");
-  // no broad write/edit/bash capability (only path-/subcommand-scoped entries)
-  expect(argv).not.toContain("Write");
+  // bare `Write`: path-scoped Write rules are silently denied under dontAsk, so
+  // the verdict file could never be written with a scoped rule. Safety still
+  // holds — disposable worktree, no exec/commit/network (asserted below).
+  expect(argv).toContain("Write");
   expect(argv).not.toContain("Edit");
-  expect(argv).not.toContain("Bash");
+  expect(argv).not.toContain("Bash"); // only subcommand-scoped Bash(git ...) entries
+  // clean context: the critic must not inherit the user's hooks/plugins/skills
+  // (e.g. superpowers' SessionStart "invoke a skill" preamble → Skill denied →
+  // thrash). NOT --bare (it would break subscription-OAuth auth).
+  expect(argv).not.toContain("--bare");
+  expect(argv).toContain("--disable-slash-commands");
+  expect(argv[argv.indexOf("--settings") + 1]).toBe('{"disableAllHooks":true}');
+});
+
+test("task prompt survives the variadic allowlist (not swallowed → no task → timeout)", () => {
+  const { deps: d, started } = makeDeps({});
+  new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  const argv = started[0]!.argv;
+  // `--allowedTools <tools...>` is variadic: it greedily eats every following
+  // token until the next flag. The task prompt is the trailing positional, so a
+  // single-value flag MUST sit between the allowlist and the prompt — otherwise
+  // the real `claude` CLI folds the prompt into the allowlist and the critic
+  // launches with no task, hanging until the 10-min timeout (every review).
+  expect(argv.at(-1)).toBe(reviewPrompt("main", "do the thing"));
+  expect(argv.at(-3)).toBe("--permission-mode");
+  expect(argv.at(-2)).toBe("dontAsk");
+  // nothing between the allowlist and the prompt may be a bare allowlist entry:
+  // a flag must terminate the variadic first.
+  const afterAllow = argv.slice(argv.indexOf("--allowedTools") + 1, argv.length - 1);
+  const firstFlag = afterAllow.findIndex((a) => a.startsWith("--"));
+  expect(firstFlag).toBeGreaterThanOrEqual(0);
 });
 
 test("does not review the same head twice", async () => {


### PR DESCRIPTION
## Problem

Critic reviews **always time out** — every PR review records `error` / "critic did not produce a verdict" after the 10-min timeout, regardless of diff size (TASK-76: a 3-line diff). Tellingly, **no critic transcript is ever created**, meaning the spawned `claude` never starts a real session.

## Root cause — three layered CLI failures, each fatal alone

1. **Arg-swallow (the active cause).** `--allowedTools <tools...>` is a *variadic* flag — it consumes every following token until the next `-`flag. The task prompt was appended as a trailing positional with `--allowedTools` as the last flag, so `claude` folded the prompt **into the allowlist** and launched with no task → hung until timeout (and never initialised a transcript). The optional `--model` flag would have shielded it, but it's never passed.
2. **Verdict write denied.** Path-scoped `Write(.shepherd-review.json)` is **silently denied under `--permission-mode dontAsk`** — verified that every scoped form (`Write(**)`, `Write(//**)`, exact abs path) is denied; only bare `Write` is honored. So the critic could never save its verdict.
3. **Hook derail.** A fresh `claude` inherits the user's global hooks/plugins — incl. the superpowers SessionStart hook that injects a forceful "you MUST invoke a skill" preamble. `Skill` isn't on the allowlist, so `dontAsk` denies it and the agent thrashes.

## Fix (`src/review.ts`)

- Move `--permission-mode dontAsk` **last**, between the variadic allowlist and the positional prompt.
- Use **bare `Write`** (acceptable: detached, disposable worktree; no exec/commit/push/network).
- Add `--settings '{"disableAllHooks":true}' --disable-slash-commands` for a clean context. **Not `--bare`** — it refuses OAuth/keychain (strictly `ANTHROPIC_API_KEY`), and shepherd authenticates via subscription OAuth with no API key, so `--bare` would break auth.

Each non-obvious CLI behavior is documented in a code comment to prevent regression.

## Verification

- **End-to-end against the real `claude` CLI**: exact production argv (no model, real `reviewPrompt`, real OAuth, hooks disabled) over a planted 3-line bug → correctly returns `request-changes` with a real review body and writes `.shepherd-review.json`.
- Regression tests added for argv ordering + isolation flags; existing read-only spawn test updated.
- Full suite green: **414 tests / 0 fail**, lint + `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)