### PR TITLE
feat(ui): hint Shift/⌥-drag selects terminal text

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -194,6 +194,7 @@
   "viewport_attach_image": "Bild anhängen",
   "viewport_type_steer_hint": "⌁ tippen zum Steuern",
   "viewport_detach_hint": "⇥ trennen",
+  "viewport_select_hint": "{key} zum Markieren ziehen",
   "viewport_parked_title": "Auf anderem Gerät aktiv",
   "viewport_parked_sub": "Tippen zum Übernehmen",
   "viewport_session_ended": "── Sitzung beendet ──",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -194,6 +194,7 @@
   "viewport_attach_image": "Attach image",
   "viewport_type_steer_hint": "⌁ type to steer",
   "viewport_detach_hint": "⇥ detach",
+  "viewport_select_hint": "{key} drag to select",
   "viewport_parked_title": "Active on another device",
   "viewport_parked_sub": "Tap to take over",
   "viewport_session_ended": "── session ended ──",

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -83,6 +83,13 @@
   let uploading = $state(false);
   let uploadFailed = $state(false);
   let fileInput = $state<HTMLInputElement>();
+  // platform-correct modifier for the "force local selection" hint: xterm uses
+  // Shift on Linux/Windows, Option (⌥) on macOS while the agent holds the mouse.
+  // Guarded for SSR (no navigator) → renders the Shift glyph, corrects on hydrate.
+  const isMac = $derived(
+    typeof navigator !== "undefined" &&
+      /mac|iphone|ipad|ipod/i.test(navigator.platform || navigator.userAgent),
+  );
 
   // compact header: narrow mobile OR a touch device on the desktop layout (unfolded
   // foldables). Drops secondary fields + wraps so the decommission button never clips.
@@ -753,6 +760,8 @@
       <span>{m.viewport_type_steer_hint()}</span>
       <span class="sep">·</span>
       <span>{m.viewport_detach_hint()}</span>
+      <span class="sep">·</span>
+      <span>{m.viewport_select_hint({ key: isMac ? "⌥" : "⇧" })}</span>
     </div>
   {/if}
 </div>


### PR DESCRIPTION
## Why

Selecting terminal text on desktop felt broken — but it isn't. While Claude Code runs as a TUI with **mouse tracking on**, xterm forwards plain mouse drags to the agent, so local text selection requires a modifier: **Shift** (Linux/Windows) or **⌥** (macOS). That escape hatch was completely undiscoverable.

## What

Adds a third hint to the desktop terminal footer, alongside *type to steer* / *detach*:

> **⇧ drag to select**  (shows **⌥** on macOS)

- Desktop-only (the existing `!mobile` footer). Mobile has no modifier key and no native xterm selection, so it's correctly omitted.
- Platform modifier picked via SSR-safe `$derived` navigator check (renders ⇧ on server, corrects to ⌥ on macOS after hydration).
- New i18n keys `viewport_select_hint` in EN + DE.

No interaction/behavior change — purely an affordance. Considered making plain drag select, but that inverts the standard terminal convention and fights the agent's own mouse UI.

## Verification

- `cd ui && bun run check:i18n` — 242 keys in parity
- `cd ui && bun run check` — 0 errors / 0 warnings
- prettier + eslint clean (pre-commit/pre-push hooks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)