### PR TITLE
fix(viewport): route stray desktop Esc into the terminal

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -10,6 +10,7 @@
   import { getSessionUsage, uploadImage, resumeSession as apiResumeSession } from "$lib/api";
   import { imageFilesFromItems } from "$lib/clipboard";
   import { composeKeystrokes } from "$lib/compose";
+  import { shouldForwardEscape } from "$lib/terminalEscape";
   import TodoPanel from "$lib/components/TodoPanel.svelte";
   import IssuesPanel from "$lib/components/IssuesPanel.svelte";
   import ActivityFeed from "$lib/components/ActivityFeed.svelte";
@@ -323,6 +324,41 @@
       return true;
     });
 
+    // Desktop Escape rescue. xterm only emits the Escape byte while its hidden
+    // textarea is focused, but on desktop the keyboard often isn't there: focus
+    // drifts onto <body> (clicking header chrome, a re-attach, the browser's own
+    // focus handling — Arc was the reported case), and even with the textarea
+    // focused a browser quirk can swallow it. The window still gets the keydown,
+    // so whenever the terminal owns the keyboard we route a bare Escape into the
+    // PTY ourselves, suppress xterm's own handling (capture phase +
+    // stopImmediatePropagation) so the agent gets exactly one Escape, and
+    // reclaim focus for the next keystrokes. The guards in shouldForwardEscape
+    // keep us off a dialog or a sibling input. Touch layouts already have the
+    // on-screen Esc button, so this is desktop-only.
+    const onWindowKeydown = (e: KeyboardEvent) => {
+      if (
+        !shouldForwardEscape({
+          key: e.key,
+          ctrlKey: e.ctrlKey,
+          altKey: e.altKey,
+          metaKey: e.metaKey,
+          desktopKeyboard: !mobile && !touch,
+          termTabActive: tab === "term",
+          live: !parked && !ended,
+          overlayOpen: !!document.querySelector(".overlay, .drawer"),
+          active: document.activeElement,
+          body: document.body,
+          terminalEl: el ?? null,
+        })
+      )
+        return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      c.send("\x1b");
+      term.focus();
+    };
+    window.addEventListener("keydown", onWindowKeydown, true);
+
     // mobile freezes backgrounded tabs and drops the WS; nudge a reconnect when
     // the tab returns. pageshow+persisted covers iOS Safari's bfcache restore,
     // which doesn't always fire visibilitychange.
@@ -435,6 +471,7 @@
     el.addEventListener("wheel", onWheelTrack, { passive: true, capture: true });
 
     return () => {
+      window.removeEventListener("keydown", onWindowKeydown, true);
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("pageshow", onPageShow);
       el?.removeEventListener("click", onTap);

--- a/ui/src/lib/terminalEscape.test.ts
+++ b/ui/src/lib/terminalEscape.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { shouldForwardEscape } from "./terminalEscape";
+
+// Stand-ins; identity + a fake `contains` are all the predicate inspects.
+const body = {} as Element;
+const xtermTextarea = {} as Element; // lives inside the terminal element
+const siblingControl = {} as Element; // compose/steer/dialog field — outside it
+// terminalEl.contains() is true only for nodes inside the xterm mount.
+const terminalEl = { contains: (n: Element | null) => n === xtermTextarea };
+
+// The baseline: a bare Escape on the desktop hardware-keyboard layout, terminal
+// tab active, live session, no overlay, focus drifted to <body>. Each case
+// flips exactly one field off this baseline.
+const ok = {
+  key: "Escape",
+  ctrlKey: false,
+  altKey: false,
+  metaKey: false,
+  desktopKeyboard: true,
+  termTabActive: true,
+  live: true,
+  overlayOpen: false,
+  active: body,
+  body,
+  terminalEl,
+} as const;
+
+describe("shouldForwardEscape", () => {
+  it("forwards a stray body-focus Escape on desktop", () => {
+    expect(shouldForwardEscape({ ...ok })).toBe(true);
+  });
+
+  it("forwards when nothing is focused (active === null)", () => {
+    expect(shouldForwardEscape({ ...ok, active: null })).toBe(true);
+  });
+
+  it("forwards when focus is on the terminal's own textarea (swallowed-byte case)", () => {
+    expect(shouldForwardEscape({ ...ok, active: xtermTextarea })).toBe(true);
+  });
+
+  it("ignores non-Escape keys", () => {
+    expect(shouldForwardEscape({ ...ok, key: "a" })).toBe(false);
+    expect(shouldForwardEscape({ ...ok, key: "Enter" })).toBe(false);
+  });
+
+  it("ignores Escape with a modifier (leaves browser/app chords alone)", () => {
+    expect(shouldForwardEscape({ ...ok, ctrlKey: true })).toBe(false);
+    expect(shouldForwardEscape({ ...ok, altKey: true })).toBe(false);
+    expect(shouldForwardEscape({ ...ok, metaKey: true })).toBe(false);
+  });
+
+  it("defers when a sibling control owns focus (compose, steer, dialog field)", () => {
+    expect(shouldForwardEscape({ ...ok, active: siblingControl })).toBe(false);
+  });
+
+  it("does not fire on touch/mobile layouts (they have the Esc button)", () => {
+    expect(shouldForwardEscape({ ...ok, desktopKeyboard: false })).toBe(false);
+  });
+
+  it("only fires while the terminal tab is the active pane", () => {
+    expect(shouldForwardEscape({ ...ok, termTabActive: false })).toBe(false);
+  });
+
+  it("does nothing on a dead/parked session", () => {
+    expect(shouldForwardEscape({ ...ok, live: false })).toBe(false);
+  });
+
+  it("never steals Escape from an open modal/drawer overlay", () => {
+    expect(shouldForwardEscape({ ...ok, overlayOpen: true })).toBe(false);
+  });
+});

--- a/ui/src/lib/terminalEscape.ts
+++ b/ui/src/lib/terminalEscape.ts
@@ -1,0 +1,48 @@
+// Desktop focus can drift off xterm's hidden textarea onto <body> — clicking
+// header chrome, a re-render re-attaching the terminal, or the browser's own
+// focus handling (Arc was the reported case). xterm only emits the Escape byte
+// while its textarea is focused, so a drifted-focus Esc is silently dropped:
+// the window receives the `keydown` but nothing routes it into the PTY, and
+// Claude Code never sees the Escape. Even with the textarea focused, a browser
+// quirk can swallow the byte. This predicate decides whether a stray Escape
+// should be re-routed into the terminal — the caller then sends \x1b itself and
+// suppresses xterm's own handling so the agent gets exactly one Escape.
+//
+// It fires ONLY for a bare Escape on the desktop hardware-keyboard layout while
+// the terminal tab is the live, active pane and the keyboard belongs to the
+// terminal: focus is on <body>/nothing, or inside the terminal element itself.
+// When a sibling control owns focus — the compose/steer fields or a dialog
+// input — those live outside the terminal element, so we defer and they keep
+// their native Escape; likewise we stand down whenever an overlay is open.
+export interface ForwardEscapeInput {
+  key: string;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  desktopKeyboard: boolean; // !mobile && !touch — the only layout lacking an Esc button
+  termTabActive: boolean;
+  live: boolean; // session attached, not parked/ended
+  overlayOpen: boolean; // a modal/drawer is up and owns Escape
+  active: Element | null; // document.activeElement
+  body: Element | null; // document.body
+  terminalEl: { contains(node: Element | null): boolean } | null; // the xterm mount
+}
+
+export function shouldForwardEscape(i: ForwardEscapeInput): boolean {
+  const focusOwnedByTerminal =
+    i.active === null ||
+    i.active === i.body ||
+    (i.terminalEl !== null && i.terminalEl.contains(i.active));
+
+  return (
+    i.key === "Escape" &&
+    !i.ctrlKey &&
+    !i.altKey &&
+    !i.metaKey &&
+    i.desktopKeyboard &&
+    i.termTabActive &&
+    i.live &&
+    !i.overlayOpen &&
+    focusOwnedByTerminal
+  );
+}


### PR DESCRIPTION
## Problem
Hitting **Esc** on desktop (reported in Arc) didn't reach the agent. Diagnostic confirmed the page *does* receive the keydown (`KD "Escape"`) but `document.activeElement` is `<body>`, not xterm's hidden `<textarea>`. xterm only emits the Esc byte (`\x1b`) while that textarea is focused, so a body-focus Esc dies at the window — nothing routes it to the PTY. Desktop also has no fallback: the on-screen Esc button is gated to `(mobile || touch)`.

## Fix
Capture-phase `window` keydown handler in `Viewport`'s terminal effect. For a **bare Esc** while the terminal owns the keyboard, it sends `\x1b` to the PTY itself, `stopImmediatePropagation` so xterm doesn't also send it (single Esc to the agent), and reclaims focus for subsequent keystrokes.

Fires **only** when: bare Esc (no Ctrl/Alt/Meta), desktop hardware-keyboard layout, terminal tab active, live session, focus on `<body>`/nothing **or** inside the xterm element, and **no** modal/drawer overlay open. Covers both failure shapes (focus-on-`<body>` *and* textarea-focused-but-swallowed) while deferring to dialogs and the compose/steer fields.

Decision logic is a pure, unit-tested helper (`terminalEscape.ts`, 10 cases).

## Verification
- `cd ui && bun run check` — 0 errors
- `cd ui && bun run test` — 114 pass (10 new)
- No new user-facing strings → i18n gate N/A
- ⚠️ Live Arc behavior needs operator confirmation (couldn't reproduce Arc focus handling in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)