### PR TITLE
fix(push): suppress notifications while the app is in active use

### DIFF
--- a/ui/src/lib/push.ts
+++ b/ui/src/lib/push.ts
@@ -89,13 +89,6 @@ export async function disablePush(): Promise<void> {
   }).catch(() => {});
 }
 
-/** Tell the service worker which session this tab is currently viewing (for
- *  focused-tab suppression of "done" notifications). */
-export function setActiveSession(id: string | null): void {
-  if (!supported()) return;
-  navigator.serviceWorker.controller?.postMessage({ type: "active-session", id });
-}
-
 /** Subscribe to "select-session" messages posted by the SW on notification click.
  *  Returns a disposer. */
 export function onSelectSession(cb: (id: string) => void): () => void {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -30,7 +30,7 @@
   import HerdGrid from "$lib/components/HerdGrid.svelte";
   import UpdateModal from "$lib/components/UpdateModal.svelte";
   import HerdrUpdateModal from "$lib/components/HerdrUpdateModal.svelte";
-  import { registerSW, setActiveSession, onSelectSession } from "$lib/push";
+  import { registerSW, onSelectSession } from "$lib/push";
   import { m } from "$lib/paraglide/messages";
 
   const store = new HerdStore();
@@ -54,10 +54,6 @@
   let composePrompt = $state("");
 
   const selected = $derived(store.sessions.find((s) => s.id === selectedId) ?? null);
-
-  $effect(() => {
-    setActiveSession(selectedId);
-  });
 
   const mobile = new MediaQuery("max-width: 768px");
   // touch-primary device (e.g. unfolded foldable wider than the mobile breakpoint):

--- a/ui/static/sw.js
+++ b/ui/static/sw.js
@@ -1,18 +1,8 @@
 // Shepherd service worker — Web Push only (no offline caching, by design).
 // Keep payload shape in sync with PushPayload in src/push.ts.
 
-// clientId -> the session id that client is currently viewing
-const activeSessions = new Map();
-
 self.addEventListener("install", () => self.skipWaiting());
 self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
-
-self.addEventListener("message", (event) => {
-  const data = event.data || {};
-  if (data.type === "active-session" && event.source) {
-    activeSessions.set(event.source.id, data.id ?? null);
-  }
-});
 
 self.addEventListener("push", (event) => {
   let payload;
@@ -21,20 +11,22 @@ self.addEventListener("push", (event) => {
   } catch {
     payload = {};
   }
-  const { title, body, sessionId, kind, tag } = payload;
+  const { title, body, sessionId, tag } = payload;
   if (!title) return;
 
   event.waitUntil(
     (async () => {
-      // Suppress a "done" banner if a focused, visible tab is already on that session.
-      if (kind === "done") {
-        const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
-        const onIt = clients.some(
-          (c) =>
-            c.focused && c.visibilityState === "visible" && activeSessions.get(c.id) === sessionId,
-        );
-        if (onIt) return;
-      }
+      // The in-app UI already surfaces every status change live, so an OS banner is
+      // pure noise while the user is actively in the app. Suppress whenever any window
+      // is focused AND visible. `focused` is the reliable "working here right now"
+      // signal — browsers don't report occlusion, so visibility alone would wrongly
+      // suppress a window buried behind another app. Requiring both keeps banners
+      // flowing when the app is minimized, in the background, or on an unfocused
+      // second monitor — exactly when push is useful.
+      const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+      const inUse = clients.some((c) => c.focused && c.visibilityState === "visible");
+      if (inUse) return;
+
       await self.registration.showNotification(title, {
         body: body ?? "",
         tag: tag ?? sessionId,


### PR DESCRIPTION
## Problem

Push-Benachrichtigungen kamen auch, während man **aktiv in der PWA arbeitet** — reines Rauschen, da die In-App-UI jeden Statuswechsel ohnehin live anzeigt.

Der alte Service Worker unterdrückte Banner nur bei `kind === "done"` und nur, wenn ein Tab genau *diese* Session offen hatte. `blocked`/`review` feuerten immer, und „done" einer anderen Session kam ebenfalls durch.

## Lösung

Jeder Push wird unterdrückt, sobald **irgendein** Fenster-Client `focused && visible` ist — für alle Notification-Arten.

`focused` ist das verlässliche „arbeite gerade hier"-Signal: Browser melden keine Verdeckung (occlusion), d.h. Sichtbarkeit allein würde ein hinter dem IDE liegendes Fenster fälschlich als „sichtbar" werten und den Push unterdrücken. Mit `focused` als Kriterium kommen Banner weiterhin, wenn die App minimiert, im Hintergrund oder auf einem unfokussierten zweiten Monitor ist.

| Zustand | Banner? |
|---|---|
| Aktiv in der App | ❌ unterdrückt |
| App minimiert / Hintergrund-Tab | ✅ kommt |
| App hinter anderem Fenster (verdeckt) | ✅ kommt |
| App auf 2. Monitor, unfokussiert | ✅ kommt |

Die nun überflüssige Per-Session-Mechanik (`activeSessions` / `setActiveSession`) wurde entfernt.

## Geänderte Dateien
- `ui/static/sw.js` — globale Unterdrückung für alle Notification-Arten
- `ui/src/lib/push.ts` — toter `setActiveSession`-Helfer entfernt
- `ui/src/routes/+page.svelte` — überflüssiges `$effect` + Import entfernt

## Checks
- `bun run check` — 0 errors
- `bun run check:i18n` — 2 locales in parity
- `bun run test` — 114 passed