### PR TITLE
perf(viewport): gate stray-Esc handler before DOM read + skip mid-IME

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -376,9 +376,14 @@
     // keep us off a dialog or a sibling input. Touch layouts already have the
     // on-screen Esc button, so this is desktop-only.
     const onWindowKeydown = (e: KeyboardEvent) => {
+      // Cheap event-only gate before touching the DOM: skip the querySelector +
+      // activeElement read on every non-Escape keystroke, and stand down during
+      // IME composition (Escape there cancels the candidate, not ours).
+      if (e.key !== "Escape" || e.isComposing) return;
       if (
         !shouldForwardEscape({
           key: e.key,
+          composing: e.isComposing,
           ctrlKey: e.ctrlKey,
           altKey: e.altKey,
           metaKey: e.metaKey,

--- a/ui/src/lib/terminalEscape.test.ts
+++ b/ui/src/lib/terminalEscape.test.ts
@@ -13,6 +13,7 @@ const terminalEl = { contains: (n: Element | null) => n === xtermTextarea };
 // flips exactly one field off this baseline.
 const ok = {
   key: "Escape",
+  composing: false,
   ctrlKey: false,
   altKey: false,
   metaKey: false,
@@ -47,6 +48,10 @@ describe("shouldForwardEscape", () => {
     expect(shouldForwardEscape({ ...ok, ctrlKey: true })).toBe(false);
     expect(shouldForwardEscape({ ...ok, altKey: true })).toBe(false);
     expect(shouldForwardEscape({ ...ok, metaKey: true })).toBe(false);
+  });
+
+  it("stands down mid-IME composition (Escape cancels the candidate)", () => {
+    expect(shouldForwardEscape({ ...ok, composing: true })).toBe(false);
   });
 
   it("defers when a sibling control owns focus (compose, steer, dialog field)", () => {

--- a/ui/src/lib/terminalEscape.ts
+++ b/ui/src/lib/terminalEscape.ts
@@ -19,6 +19,7 @@ export interface ForwardEscapeInput {
   ctrlKey: boolean;
   altKey: boolean;
   metaKey: boolean;
+  composing: boolean; // mid-IME composition — Escape cancels the candidate, not ours
   desktopKeyboard: boolean; // !mobile && !touch — the only layout lacking an Esc button
   termTabActive: boolean;
   live: boolean; // session attached, not parked/ended
@@ -36,6 +37,7 @@ export function shouldForwardEscape(i: ForwardEscapeInput): boolean {
 
   return (
     i.key === "Escape" &&
+    !i.composing &&
     !i.ctrlKey &&
     !i.altKey &&
     !i.metaKey &&


### PR DESCRIPTION
Follow-up to #118 review.

## Changes
- **DOM query on every keystroke** — `onWindowKeydown` now short-circuits on `e.key !== "Escape"` *before* building the input object, running `document.querySelector(".overlay, .drawer")`, or reading `document.activeElement`. Negligible per-keystroke cost, but cheaply avoided.
- **IME composition** — added an `e.isComposing` guard so a mid-composition Escape cancels the IME candidate (its native behavior) instead of being `preventDefault`'d and routed to the PTY. Modeled as a `composing` field on the `shouldForwardEscape` predicate so it's part of the tested contract.

## Tests
- New case: stands down mid-IME composition.
- `bun run check` clean, all 115 UI tests pass, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)