### PR TITLE
feat(backlog): Backlog Deep Dive — Launchpad für die leere Übersicht

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dist/
 
 # Transient agent worktrees (Claude Code isolation checkouts)
 /.claude/worktrees/
+.shaping/
+.squad/

--- a/src/backlog.ts
+++ b/src/backlog.ts
@@ -1,0 +1,132 @@
+import { execFileSync } from "node:child_process";
+import { parseRemote } from "./forge/remote";
+import { detectForge } from "./forge";
+import type { GhRunner } from "./forge/github";
+import type { ForgeMap } from "./forge/types";
+
+export interface RepoCounts {
+  openIssues: number | null;
+  openPRs: number | null;
+}
+
+interface CacheEntry {
+  at: number;
+  value: RepoCounts;
+}
+
+const TTL_MS = 60_000;
+
+const NULL_COUNTS: RepoCounts = { openIssues: null, openPRs: null };
+
+function originUrl(repoDir: string): string | null {
+  try {
+    return execFileSync("git", ["-C", repoDir, "remote", "get-url", "origin"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+export class CountsService {
+  /** Resolved forge per repoPath, null = not a supported forge. Immutable once set. */
+  private readonly forgeCache = new Map<string, ReturnType<typeof detectForge>>();
+  /** TTL read-through cache: repoPath → {at, value}. */
+  private readonly cache = new Map<string, CacheEntry>();
+  /** Single-flight: repoPath → in-flight Promise. */
+  private readonly inflight = new Map<string, Promise<RepoCounts>>();
+
+  constructor(
+    private readonly forges: ForgeMap,
+    private readonly run: GhRunner,
+    private readonly fetchFn: typeof fetch = fetch,
+  ) {}
+
+  async counts(repoPath: string): Promise<RepoCounts> {
+    const entry = this.cache.get(repoPath);
+    if (entry && Date.now() - entry.at < TTL_MS) return entry.value;
+
+    const existing = this.inflight.get(repoPath);
+    if (existing) return existing;
+
+    const promise = this.fetch(repoPath).then(
+      (v) => {
+        this.cache.set(repoPath, { at: Date.now(), value: v });
+        this.inflight.delete(repoPath);
+        return v;
+      },
+      () => {
+        this.inflight.delete(repoPath);
+        this.cache.set(repoPath, { at: Date.now(), value: NULL_COUNTS });
+        return NULL_COUNTS;
+      },
+    );
+    this.inflight.set(repoPath, promise);
+    return promise;
+  }
+
+  private resolveForge(repoPath: string): ReturnType<typeof detectForge> {
+    if (!this.forgeCache.has(repoPath)) {
+      this.forgeCache.set(repoPath, detectForge(repoPath, this.forges));
+    }
+    return this.forgeCache.get(repoPath)!;
+  }
+
+  private async fetch(repoPath: string): Promise<RepoCounts> {
+    const forge = this.resolveForge(repoPath);
+    if (!forge) return NULL_COUNTS;
+
+    if (forge.kind === "github") {
+      return this.fetchGitHub(forge.slug!);
+    }
+    return this.fetchGitea(forge.slug!, repoPath);
+  }
+
+  private fetchGitHub(slug: string): RepoCounts {
+    const [owner, name] = slug.split("/");
+    const query = `query{repository(owner:"${owner}",name:"${name}"){issues(states:OPEN){totalCount} pullRequests(states:OPEN){totalCount}}}`;
+    const out = this.run(["api", "graphql", "-f", `query=${query}`]);
+    const json = JSON.parse(out) as {
+      data?: {
+        repository?: {
+          issues?: { totalCount?: number };
+          pullRequests?: { totalCount?: number };
+        };
+      };
+    };
+    const repo = json.data?.repository;
+    const issues = repo?.issues?.totalCount;
+    const prs = repo?.pullRequests?.totalCount;
+    return {
+      openIssues: typeof issues === "number" ? issues : null,
+      openPRs: typeof prs === "number" ? prs : null,
+    };
+  }
+
+  private async fetchGitea(slug: string, repoPath: string): Promise<RepoCounts> {
+    const url = originUrl(repoPath);
+    if (!url) return NULL_COUNTS;
+    const remote = parseRemote(url);
+    if (!remote) return NULL_COUNTS;
+
+    const cfg = this.forges[remote.host] ?? {};
+    const base = (cfg.baseUrl ?? "").replace(/\/+$/, "");
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (cfg.token) headers.Authorization = `token ${cfg.token}`;
+
+    const res = await this.fetchFn(`${base}/api/v1/repos/${slug}`, { headers });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`gitea GET /api/v1/repos/${slug} → ${res.status}: ${text}`);
+    }
+    const data = (await res.json()) as {
+      open_issues_count?: number;
+      open_pr_counter?: number;
+    };
+    return {
+      openIssues: typeof data.open_issues_count === "number" ? data.open_issues_count : null,
+      openPRs: typeof data.open_pr_counter === "number" ? data.open_pr_counter : null,
+    };
+  }
+}

--- a/src/backlog.ts
+++ b/src/backlog.ts
@@ -85,8 +85,16 @@ export class CountsService {
 
   private fetchGitHub(slug: string): RepoCounts {
     const [owner, name] = slug.split("/");
-    const query = `query{repository(owner:"${owner}",name:"${name}"){issues(states:OPEN){totalCount} pullRequests(states:OPEN){totalCount}}}`;
-    const out = this.run(["api", "graphql", "-f", `query=${query}`]);
+    const out = this.run([
+      "api",
+      "graphql",
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `name=${name}`,
+      "-f",
+      "query=query($owner:String!,$name:String!){repository(owner:$owner,name:$name){issues(states:OPEN){totalCount} pullRequests(states:OPEN){totalCount}}}",
+    ]);
     const json = JSON.parse(out) as {
       data?: {
         repository?: {

--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -82,14 +82,19 @@ export class GiteaForge implements GitForge {
       body?: string;
       html_url: string;
       labels?: Array<{ name: string }>;
+      created_at?: string;
     }>;
-    return (raw ?? []).map((i) => ({
-      number: i.number,
-      title: i.title,
-      body: i.body ?? "",
-      url: i.html_url,
-      labels: (i.labels ?? []).map((l) => l.name),
-    }));
+    return (raw ?? []).map((i) => {
+      const ts = Date.parse(i.created_at ?? "");
+      return {
+        number: i.number,
+        title: i.title,
+        body: i.body ?? "",
+        url: i.html_url,
+        labels: (i.labels ?? []).map((l) => l.name),
+        createdAt: Number.isFinite(ts) ? ts : Date.now(),
+      };
+    });
   }
 
   private async checksFor(sha: string | undefined): Promise<ChecksState> {

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -58,7 +58,7 @@ export class GithubForge implements GitForge {
       "--state",
       "open",
       "--json",
-      "number,title,body,url,labels",
+      "number,title,body,url,labels,createdAt",
       "--limit",
       "50",
     ]);
@@ -68,14 +68,19 @@ export class GithubForge implements GitForge {
       body?: string;
       url: string;
       labels?: Array<{ name: string }>;
+      createdAt?: string;
     }>;
-    return raw.map((i) => ({
-      number: i.number,
-      title: i.title,
-      body: i.body ?? "",
-      url: i.url,
-      labels: (i.labels ?? []).map((l) => l.name),
-    }));
+    return raw.map((i) => {
+      const ts = Date.parse(i.createdAt ?? "");
+      return {
+        number: i.number,
+        title: i.title,
+        body: i.body ?? "",
+        url: i.url,
+        labels: (i.labels ?? []).map((l) => l.name),
+        createdAt: Number.isFinite(ts) ? ts : Date.now(),
+      };
+    });
   }
 
   async prStatus(headBranch: string): Promise<PrStatus> {

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -4,6 +4,7 @@ export interface Issue {
   body: string;
   url: string;
   labels: string[];
+  createdAt: number;
 }
 
 export type ForgeKind = "github" | "gitea";

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ import { UpdateService } from "./update";
 import { HerdrUpdateService } from "./herdr-update";
 import { PushService, attachPush, attachReviewPush } from "./push";
 import { ReviewService } from "./review";
+import { CountsService } from "./backlog";
+import { execFileSync } from "node:child_process";
 
 mkdirSync(dirname(config.dbPath), { recursive: true });
 
@@ -148,6 +150,10 @@ setInterval(checkHerdrUpdate, 6 * 60 * 60 * 1000);
 // forge resolution: detect a repo's GitHub/Gitea host from its `origin` remote.
 // Per-host config (tokens, gitea base URLs) loads from config.forges (SHEPHERD_FORGES);
 // github.com works through the operator's existing `gh` CLI auth, so an absent file is fine.
+const ghRunner = (args: string[]) =>
+  execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+const backlog = new CountsService(config.forges, ghRunner);
+
 const server = serve(
   {
     store,
@@ -165,6 +171,7 @@ const server = serve(
       snapshot: () => reviewService.snapshot(),
       reviewing: () => reviewService.reviewingIds(),
     },
+    backlog,
   },
   config.port,
 );

--- a/src/server.ts
+++ b/src/server.ts
@@ -661,15 +661,18 @@ async function handleBacklog({ req, parts, deps }: Ctx): Promise<Response | null
   // Fetch counts for all forge repos in parallel
   const countsArr = await Promise.all(forgeRepos.map((r) => deps.backlog!.counts(r.path)));
 
-  const projects = forgeRepos.map((r, i) => ({
-    path: r.path,
-    display: r.display,
-    slug: r.forge.slug,
-    kind: r.forge.kind,
-    lastUsedAt: lastUsed[r.path] ?? null,
-    openIssues: countsArr[i].openIssues,
-    openPRs: countsArr[i].openPRs,
-  }));
+  const projects = forgeRepos.map((r, i) => {
+    const counts = countsArr[i]!;
+    return {
+      path: r.path,
+      display: r.display,
+      slug: r.forge.slug,
+      kind: r.forge.kind,
+      lastUsedAt: lastUsed[r.path] ?? null,
+      openIssues: counts.openIssues,
+      openPRs: counts.openPRs,
+    };
+  });
 
   // Sort: descending openIssues (null → -1), tie-break path ascending
   projects.sort((a, b) => {
@@ -691,7 +694,7 @@ async function handleBacklog({ req, parts, deps }: Ctx): Promise<Response | null
       });
       pinnedPath = pinned.path;
     } else {
-      pinnedPath = projects[0].path;
+      pinnedPath = projects[0]!.path;
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import type { GitForge, GitState, MergeMethod } from "./forge/types";
 import type { PrCache } from "./pr-poller";
 import type { PushService } from "./push";
 import type { StatusPoller } from "./poller";
+import type { CountsService } from "./backlog";
 import { join, normalize } from "node:path";
 import type { ServerWebSocket } from "bun";
 
@@ -83,6 +84,8 @@ export interface AppDeps {
     snapshot(): Record<string, import("./types").ReviewVerdict>;
     reviewing?(): string[];
   };
+  /** Backlog counts service; absent in tests that don't exercise it. */
+  backlog?: Pick<CountsService, "counts">;
 }
 
 const sessionUsage = (s: Session) =>
@@ -639,6 +642,70 @@ async function handleIssues({ req, parts, url, deps }: Ctx): Promise<Response | 
   return null;
 }
 
+async function handleBacklog({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (req.method !== "GET" || parts[0] !== "api" || parts[1] !== "backlog" || parts[2]) return null;
+  if (!deps.backlog) {
+    return json({ pinnedPath: null, projects: [], totals: { openIssues: 0, openPRs: 0 } });
+  }
+  const repos = listRepos(config.repoRoot);
+  const lastUsed = deps.store.lastUsedByRepo();
+
+  // Keep only forge-backed repos
+  const forgeRepos = repos
+    .map((r) => {
+      const forge = deps.resolveForge?.(r.path) ?? null;
+      return forge ? { ...r, forge } : null;
+    })
+    .filter((r): r is NonNullable<typeof r> => r !== null);
+
+  // Fetch counts for all forge repos in parallel
+  const countsArr = await Promise.all(forgeRepos.map((r) => deps.backlog!.counts(r.path)));
+
+  const projects = forgeRepos.map((r, i) => ({
+    path: r.path,
+    display: r.display,
+    slug: r.forge.slug,
+    kind: r.forge.kind,
+    lastUsedAt: lastUsed[r.path] ?? null,
+    openIssues: countsArr[i].openIssues,
+    openPRs: countsArr[i].openPRs,
+  }));
+
+  // Sort: descending openIssues (null → -1), tie-break path ascending
+  projects.sort((a, b) => {
+    const ai = a.openIssues ?? -1;
+    const bi = b.openIssues ?? -1;
+    if (bi !== ai) return bi - ai;
+    return a.path < b.path ? -1 : a.path > b.path ? 1 : 0;
+  });
+
+  // Pin: project with max lastUsedAt; tie-break lowest path; if none have lastUsedAt → first after sort
+  let pinnedPath: string | null = null;
+  if (projects.length > 0) {
+    const withUsed = projects.filter((p) => p.lastUsedAt !== null);
+    if (withUsed.length > 0) {
+      const pinned = withUsed.reduce((best, cur) => {
+        if (cur.lastUsedAt! > best.lastUsedAt!) return cur;
+        if (cur.lastUsedAt! === best.lastUsedAt! && cur.path < best.path) return cur;
+        return best;
+      });
+      pinnedPath = pinned.path;
+    } else {
+      pinnedPath = projects[0].path;
+    }
+  }
+
+  // Totals: sum non-null values
+  let totalIssues = 0;
+  let totalPRs = 0;
+  for (const p of projects) {
+    if (p.openIssues !== null) totalIssues += p.openIssues;
+    if (p.openPRs !== null) totalPRs += p.openPRs;
+  }
+
+  return json({ pinnedPath, projects, totals: { openIssues: totalIssues, openPRs: totalPRs } });
+}
+
 function todoRead(repoParam: string): Response {
   const r = readTodo(repoParam, config.repoRoot);
   if (!r.ok) return json({ error: "invalid repo path" }, 400);
@@ -684,6 +751,7 @@ const ROUTE_HANDLERS = [
   handleFsDirs,
   handleBranches,
   handleIssues,
+  handleBacklog,
   handleTodo,
 ] as const;
 

--- a/test/backlog.test.ts
+++ b/test/backlog.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for CountsService (src/backlog.ts).
+ *
+ * Forge resolution shells out to `git remote get-url origin`, so each test
+ * that exercises GitHub/Gitea paths sets up a temp git repo with the desired
+ * remote URL. This mirrors how test/forge-detect.test.ts handles git-backed
+ * detection.
+ */
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { CountsService } from "../src/backlog";
+import type { GhRunner } from "../src/forge/github";
+import type { ForgeMap } from "../src/forge/types";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "backlog-test-"));
+}
+
+/**
+ * Initialise a bare git repo at `dir` with `origin` set to `remoteUrl`.
+ * Returns `dir` for convenience.
+ */
+function gitInit(dir: string, remoteUrl: string): string {
+  mkdirSync(dir, { recursive: true });
+  spawnSync("git", ["init", "-q"], { cwd: dir });
+  spawnSync("git", ["remote", "add", "origin", remoteUrl], { cwd: dir });
+  return dir;
+}
+
+/** A recording fake GhRunner. */
+function fakeRunner(response: string): { run: GhRunner; calls: string[][] } {
+  const calls: string[][] = [];
+  const run: GhRunner = (args) => {
+    calls.push(args);
+    return response;
+  };
+  return { run, calls };
+}
+
+/** Build a fake fetch that always returns the given JSON object with status 200. */
+function fakeFetch(json: unknown) {
+  let callCount = 0;
+  const fn = async (): Promise<Response> => {
+    callCount++;
+    return new Response(JSON.stringify(json), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return {
+    fn: fn as unknown as typeof fetch,
+    get callCount() {
+      return callCount;
+    },
+  };
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+let tmpBase: string;
+
+beforeEach(() => {
+  tmpBase = makeTmpDir();
+});
+
+afterEach(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+});
+
+// 1. GitHub repo: runner returns canned graphql JSON → {openIssues:24, openPRs:3}
+test("CountsService: GitHub repo returns openIssues and openPRs from graphql", async () => {
+  const repoDir = gitInit(join(tmpBase, "gh-repo"), "https://github.com/myorg/myrepo");
+  const forges: ForgeMap = {}; // github.com is auto-detected
+
+  const graphqlResponse = JSON.stringify({
+    data: {
+      repository: {
+        issues: { totalCount: 24 },
+        pullRequests: { totalCount: 3 },
+      },
+    },
+  });
+  const { run } = fakeRunner(graphqlResponse);
+  const svc = new CountsService(forges, run);
+
+  const result = await svc.counts(repoDir);
+  expect(result.openIssues).toBe(24);
+  expect(result.openPRs).toBe(3);
+});
+
+// 2. Gitea repo: fetchFn returns gitea API shape → {openIssues:5, openPRs:1}
+test("CountsService: Gitea repo returns openIssues and openPRs from REST API", async () => {
+  const repoDir = gitInit(join(tmpBase, "gitea-repo"), "https://git.example.com/team/proj");
+  const forges: ForgeMap = {
+    "git.example.com": {
+      type: "gitea",
+      baseUrl: "https://git.example.com",
+      token: "tok",
+    },
+  };
+
+  const { fn } = fakeFetch({ open_issues_count: 5, open_pr_counter: 1 });
+  const run: GhRunner = () => "";
+  const svc = new CountsService(forges, run, fn);
+
+  const result = await svc.counts(repoDir);
+  expect(result.openIssues).toBe(5);
+  expect(result.openPRs).toBe(1);
+});
+
+// 3. 60s TTL: two calls within the window invoke runner ONCE
+test("CountsService: TTL caches result — second call within window skips runner", async () => {
+  const repoDir = gitInit(join(tmpBase, "gh-ttl"), "https://github.com/o/r");
+  const forges: ForgeMap = {};
+
+  const graphqlResponse = JSON.stringify({
+    data: { repository: { issues: { totalCount: 10 }, pullRequests: { totalCount: 2 } } },
+  });
+  const { run, calls } = fakeRunner(graphqlResponse);
+  const svc = new CountsService(forges, run);
+
+  await svc.counts(repoDir);
+  await svc.counts(repoDir);
+
+  // Runner should only have been called once (the "api graphql" call)
+  const graphqlCalls = calls.filter((c) => c.includes("graphql"));
+  expect(graphqlCalls.length).toBe(1);
+});
+
+// 4. Single-flight: two concurrent calls share one in-flight request
+test("CountsService: single-flight — concurrent calls share one in-flight promise", async () => {
+  const repoDir = gitInit(join(tmpBase, "gh-sf"), "https://github.com/o/r2");
+  const forges: ForgeMap = {};
+
+  const calls: string[][] = [];
+  const run: GhRunner = (args) => {
+    calls.push(args);
+    // Synchronously block until we resolve — simulate a slow response
+    // We actually need sync return from GhRunner, so we return immediately
+    // but track that it was only invoked once.
+    return JSON.stringify({
+      data: { repository: { issues: { totalCount: 7 }, pullRequests: { totalCount: 0 } } },
+    });
+  };
+
+  // Fire two concurrent calls before the first can cache
+  // We need to clear any cache first by using a fresh service
+  const svc = new CountsService(forges, run);
+  const [r1, r2] = await Promise.all([svc.counts(repoDir), svc.counts(repoDir)]);
+
+  expect(r1.openIssues).toBe(7);
+  expect(r2.openIssues).toBe(7);
+  // graphql runner invoked exactly once
+  const graphqlCalls = calls.filter((c) => c.includes("graphql"));
+  expect(graphqlCalls.length).toBe(1);
+});
+
+// 5. Fault isolation: a runner that throws → null counts; sibling still resolves
+test("CountsService: fault isolation — throwing runner yields null counts, not 0", async () => {
+  const failDir = gitInit(join(tmpBase, "fail-repo"), "https://github.com/bad/repo");
+  const goodDir = gitInit(join(tmpBase, "good-repo"), "https://github.com/good/repo");
+  const forges: ForgeMap = {};
+
+  const run: GhRunner = (args) => {
+    const q = args.find((a) => a.startsWith("query=")) ?? "";
+    if (q.includes('"bad"')) throw new Error("gh auth failed");
+    return JSON.stringify({
+      data: { repository: { issues: { totalCount: 3 }, pullRequests: { totalCount: 1 } } },
+    });
+  };
+
+  const svc = new CountsService(forges, run);
+
+  const failResult = await svc.counts(failDir);
+  expect(failResult.openIssues).toBeNull();
+  expect(failResult.openPRs).toBeNull();
+
+  const goodResult = await svc.counts(goodDir);
+  expect(goodResult.openIssues).toBe(3);
+  expect(goodResult.openPRs).toBe(1);
+});
+
+// 6. Failure never coerces to 0 — explicitly null
+test("CountsService: failure yields null not 0", async () => {
+  const repoDir = gitInit(join(tmpBase, "throws"), "https://github.com/boom/repo");
+  const forges: ForgeMap = {};
+
+  const run: GhRunner = () => {
+    throw new Error("network error");
+  };
+  const svc = new CountsService(forges, run);
+
+  const result = await svc.counts(repoDir);
+  expect(result.openIssues).toBeNull();
+  expect(result.openPRs).toBeNull();
+  // Explicitly not 0
+  expect(result.openIssues).not.toBe(0);
+  expect(result.openPRs).not.toBe(0);
+});
+
+// 7. Non-forge repo (no git remote) → null counts
+test("CountsService: repo with no origin → null counts (not a throw)", async () => {
+  const repoDir = join(tmpBase, "no-remote");
+  mkdirSync(repoDir);
+  spawnSync("git", ["init", "-q"], { cwd: repoDir });
+  // No remote set
+
+  const forges: ForgeMap = {};
+  const run: GhRunner = () => "";
+  const svc = new CountsService(forges, run);
+
+  const result = await svc.counts(repoDir);
+  expect(result.openIssues).toBeNull();
+  expect(result.openPRs).toBeNull();
+});

--- a/test/backlog.test.ts
+++ b/test/backlog.test.ts
@@ -167,8 +167,9 @@ test("CountsService: fault isolation — throwing runner yields null counts, not
   const forges: ForgeMap = {};
 
   const run: GhRunner = (args) => {
-    const q = args.find((a) => a.startsWith("query=")) ?? "";
-    if (q.includes('"bad"')) throw new Error("gh auth failed");
+    // With gh variables, owner is passed as a separate -F arg: "owner=<value>"
+    const ownerArg = args.find((a) => a.startsWith("owner=")) ?? "";
+    if (ownerArg === "owner=bad") throw new Error("gh auth failed");
     return JSON.stringify({
       data: { repository: { issues: { totalCount: 3 }, pullRequests: { totalCount: 1 } } },
     });
@@ -203,7 +204,32 @@ test("CountsService: failure yields null not 0", async () => {
   expect(result.openPRs).not.toBe(0);
 });
 
-// 7. Non-forge repo (no git remote) → null counts
+// 7. TTL expiry: second call after TTL elapses re-invokes the runner
+test("CountsService: TTL expiry — call after 60s window re-fetches from runner", async () => {
+  const repoDir = gitInit(join(tmpBase, "gh-ttl-expire"), "https://github.com/o/ttl-expire");
+  const forges: ForgeMap = {};
+
+  const graphqlResponse = JSON.stringify({
+    data: { repository: { issues: { totalCount: 5 }, pullRequests: { totalCount: 1 } } },
+  });
+  const { run, calls } = fakeRunner(graphqlResponse);
+  const svc = new CountsService(forges, run);
+
+  // First fetch — populates cache
+  await svc.counts(repoDir);
+
+  // Backdate the cache entry's `at` field to simulate TTL expiry (> 60 000 ms ago)
+  const entry = (svc as any).cache.get(repoDir);
+  entry.at = Date.now() - 61_000;
+
+  // Second fetch — cache is stale, runner should be called again
+  await svc.counts(repoDir);
+
+  const graphqlCalls = calls.filter((c) => c.includes("graphql"));
+  expect(graphqlCalls.length).toBe(2);
+});
+
+// 8. Non-forge repo (no git remote) → null counts
 test("CountsService: repo with no origin → null counts (not a throw)", async () => {
   const repoDir = join(tmpBase, "no-remote");
   mkdirSync(repoDir);

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -38,6 +38,8 @@ test("GiteaForge.kind + slug", () => {
   expect(forge.slug).toBe("team/proj");
 });
 
+const GITEA_ISSUE_CREATED_AT = "2024-02-01T12:00:00Z";
+
 test("GiteaForge.listIssues: maps gitea issues, filters out PRs via type=issues", async () => {
   const { fn, calls } = fakeFetch({
     "GET /api/v1/repos/team/proj/issues?state=open&type=issues&limit=50": {
@@ -48,6 +50,7 @@ test("GiteaForge.listIssues: maps gitea issues, filters out PRs via type=issues"
           body: "desc",
           html_url: "https://git.example.com/team/proj/issues/3",
           labels: [{ name: "bug" }, { name: "p1" }],
+          created_at: GITEA_ISSUE_CREATED_AT,
         },
       ],
     },
@@ -61,6 +64,7 @@ test("GiteaForge.listIssues: maps gitea issues, filters out PRs via type=issues"
       body: "desc",
       url: "https://git.example.com/team/proj/issues/3",
       labels: ["bug", "p1"],
+      createdAt: Date.parse(GITEA_ISSUE_CREATED_AT),
     },
   ]);
   expect(calls[0]!.headers.get("Authorization")).toBe("token secret");
@@ -190,6 +194,77 @@ test("GiteaForge.postReview: POSTs review and returns url from html_url", async 
   expect(post.method).toBe("POST");
   expect(post.url).toContain("/api/v1/repos/team/proj/pulls/7/reviews");
   expect(post.body).toEqual({ event: "REQUEST_CHANGES", body: "nope" });
+});
+
+test("GiteaForge.listIssues: createdAt is parsed to a finite ms number from ISO string", async () => {
+  const isoDate = "2024-06-01T08:00:00Z";
+  const expectedMs = Date.parse(isoDate);
+  const { fn } = fakeFetch({
+    "GET /api/v1/repos/team/proj/issues?state=open&type=issues&limit=50": {
+      json: [
+        {
+          number: 5,
+          title: "Issue",
+          body: "body",
+          html_url: "https://git.example.com/team/proj/issues/5",
+          labels: [],
+          created_at: isoDate,
+        },
+      ],
+    },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const issues = await forge.listIssues();
+  expect(issues[0]!.createdAt).toBe(expectedMs);
+  expect(Number.isFinite(issues[0]!.createdAt)).toBe(true);
+});
+
+test("GiteaForge.listIssues: missing created_at falls back to Date.now() (finite number)", async () => {
+  const before = Date.now();
+  const { fn } = fakeFetch({
+    "GET /api/v1/repos/team/proj/issues?state=open&type=issues&limit=50": {
+      json: [
+        {
+          number: 6,
+          title: "Issue2",
+          body: "",
+          html_url: "u6",
+          labels: [],
+          // no created_at
+        },
+      ],
+    },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const issues = await forge.listIssues();
+  const after = Date.now();
+  expect(Number.isFinite(issues[0]!.createdAt)).toBe(true);
+  expect(issues[0]!.createdAt).toBeGreaterThanOrEqual(before);
+  expect(issues[0]!.createdAt).toBeLessThanOrEqual(after);
+});
+
+test("GiteaForge.listIssues: invalid created_at string falls back to Date.now()", async () => {
+  const before = Date.now();
+  const { fn } = fakeFetch({
+    "GET /api/v1/repos/team/proj/issues?state=open&type=issues&limit=50": {
+      json: [
+        {
+          number: 7,
+          title: "Issue3",
+          body: "",
+          html_url: "u7",
+          labels: [],
+          created_at: "bogus-date",
+        },
+      ],
+    },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const issues = await forge.listIssues();
+  const after = Date.now();
+  expect(Number.isFinite(issues[0]!.createdAt)).toBe(true);
+  expect(issues[0]!.createdAt).toBeGreaterThanOrEqual(before);
+  expect(issues[0]!.createdAt).toBeLessThanOrEqual(after);
 });
 
 test("GiteaForge.prStatus: surfaces head SHA from PR head.sha", async () => {

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -13,8 +13,16 @@ function fakeRunner(responses: Record<string, string>) {
   return { run, calls };
 }
 
+const ISSUE_CREATED_AT = "2024-01-01T00:00:00Z";
 const ISSUES_JSON = JSON.stringify([
-  { number: 1, title: "Fix crash", body: "boom", url: "u1", labels: [{ name: "bug" }] },
+  {
+    number: 1,
+    title: "Fix crash",
+    body: "boom",
+    url: "u1",
+    labels: [{ name: "bug" }],
+    createdAt: ISSUE_CREATED_AT,
+  },
 ]);
 
 test("GithubForge.listIssues: parses gh issue list output", async () => {
@@ -22,7 +30,14 @@ test("GithubForge.listIssues: parses gh issue list output", async () => {
   const forge = new GithubForge("o/r", { deployWorkflow: "deploy.yml" }, run);
   const issues = await forge.listIssues();
   expect(issues).toEqual([
-    { number: 1, title: "Fix crash", body: "boom", url: "u1", labels: ["bug"] },
+    {
+      number: 1,
+      title: "Fix crash",
+      body: "boom",
+      url: "u1",
+      labels: ["bug"],
+      createdAt: Date.parse(ISSUE_CREATED_AT),
+    },
   ]);
 });
 
@@ -129,6 +144,48 @@ test("GithubForge.prStatus: surfaces head SHA from headRefOid", async () => {
   const st = await forge.prStatus("feature");
   expect(st.headSha).toBe("abc123");
   expect(calls[0]!.join(" ")).toContain("headRefOid");
+});
+
+test("GithubForge.listIssues: createdAt is parsed to a finite ms number from ISO string", async () => {
+  const isoDate = "2024-03-15T10:30:00Z";
+  const expectedMs = Date.parse(isoDate);
+  const issuesJson = JSON.stringify([
+    { number: 1, title: "T", body: "b", url: "u", labels: [], createdAt: isoDate },
+  ]);
+  const { run } = fakeRunner({ "issue list": issuesJson });
+  const forge = new GithubForge("o/r", {}, run);
+  const issues = await forge.listIssues();
+  expect(issues[0]!.createdAt).toBe(expectedMs);
+  expect(Number.isFinite(issues[0]!.createdAt)).toBe(true);
+});
+
+test("GithubForge.listIssues: missing createdAt falls back to Date.now() (finite number)", async () => {
+  const before = Date.now();
+  const issuesJson = JSON.stringify([
+    { number: 2, title: "T2", body: "", url: "u2", labels: [] },
+    // no createdAt field
+  ]);
+  const { run } = fakeRunner({ "issue list": issuesJson });
+  const forge = new GithubForge("o/r", {}, run);
+  const issues = await forge.listIssues();
+  const after = Date.now();
+  expect(Number.isFinite(issues[0]!.createdAt)).toBe(true);
+  expect(issues[0]!.createdAt).toBeGreaterThanOrEqual(before);
+  expect(issues[0]!.createdAt).toBeLessThanOrEqual(after);
+});
+
+test("GithubForge.listIssues: invalid createdAt string falls back to Date.now() (finite)", async () => {
+  const before = Date.now();
+  const issuesJson = JSON.stringify([
+    { number: 3, title: "T3", body: "", url: "u3", labels: [], createdAt: "not-a-date" },
+  ]);
+  const { run } = fakeRunner({ "issue list": issuesJson });
+  const forge = new GithubForge("o/r", {}, run);
+  const issues = await forge.listIssues();
+  const after = Date.now();
+  expect(Number.isFinite(issues[0]!.createdAt)).toBe(true);
+  expect(issues[0]!.createdAt).toBeGreaterThanOrEqual(before);
+  expect(issues[0]!.createdAt).toBeLessThanOrEqual(after);
 });
 
 test("GithubForge.postReview: request-changes falls back to pr comment when review is rejected", async () => {

--- a/test/server-backlog.test.ts
+++ b/test/server-backlog.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Integration tests for GET /api/backlog (handleBacklog in src/server.ts).
+ *
+ * handleBacklog calls listRepos(config.repoRoot) which scans one level deep
+ * in the actual repoRoot. We must therefore create test repos as direct
+ * children of config.repoRoot, and make resolveForge return null for every
+ * repo path that isn't one of ours so that other repos in the tree are
+ * silently excluded.
+ *
+ * Pattern mirrors test/server-issues.test.ts.
+ */
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { makeApp, type AppDeps } from "../src/server";
+import type { SessionStore } from "../src/store";
+import type { SessionService } from "../src/service";
+import type { EventHub } from "../src/events";
+import type { GitForge } from "../src/forge/types";
+import type { RepoCounts } from "../src/backlog";
+import { config } from "../src/config";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * repoA and repoB are direct children of config.repoRoot, so listRepos() finds
+ * them.  repoNonForge is also a direct child but resolveForge returns null for
+ * it, which is the forge-exclusion case we want to test.
+ *
+ * Naming avoids collisions between parallel test runs via mkdtempSync prefixes.
+ */
+let repoA: string;
+let repoB: string;
+let repoNonForge: string;
+
+beforeEach(() => {
+  // Each test gets fresh, uniquely-named directories so they never cross-contaminate.
+  repoA = mkdtempSync(join(config.repoRoot, "blt-alpha-"));
+  repoB = mkdtempSync(join(config.repoRoot, "blt-beta-"));
+  repoNonForge = mkdtempSync(join(config.repoRoot, "blt-zeta-"));
+});
+
+afterEach(() => {
+  rmSync(repoA, { recursive: true, force: true });
+  rmSync(repoB, { recursive: true, force: true });
+  rmSync(repoNonForge, { recursive: true, force: true });
+});
+
+function fakeForge(slug: string, kind: "github" | "gitea" = "github"): GitForge {
+  return {
+    kind,
+    slug,
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }),
+    openPr: async () => ({ state: "none", checks: "none", deployConfigured: false }),
+    merge: async () => {},
+    redeploy: async () => {},
+    postReview: async () => ({}),
+  };
+}
+
+/**
+ * Build AppDeps. `resolveForge` recognises only repoA and repoB; all others
+ * (including repoNonForge and whatever else is in repoRoot) get null.
+ * `backlogCounts` maps repoPath → RepoCounts; `lastUsed` maps repoPath → ms.
+ */
+function makeDeps(
+  backlogCounts: Record<string, RepoCounts>,
+  lastUsed: Record<string, number> = {},
+  overrideForge?: AppDeps["resolveForge"],
+): AppDeps {
+  return {
+    store: {
+      lastUsedByRepo: () => lastUsed,
+    } as unknown as SessionStore,
+    service: {} as SessionService,
+    events: { emit: () => {} } as unknown as EventHub,
+    usageLimits: { limits: () => ({}) } as never,
+    resolveForge:
+      overrideForge ??
+      ((path) => {
+        if (path === repoA) return fakeForge("org/alpha");
+        if (path === repoB) return fakeForge("org/beta");
+        return null;
+      }),
+    backlog: {
+      counts: async (path: string): Promise<RepoCounts> =>
+        backlogCounts[path] ?? { openIssues: null, openPRs: null },
+    },
+  };
+}
+
+function req(): Request {
+  return new Request("http://localhost/api/backlog");
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+test("GET /api/backlog returns 200 with projects array", async () => {
+  const app = makeApp(
+    makeDeps({ [repoA]: { openIssues: 5, openPRs: 1 }, [repoB]: { openIssues: 2, openPRs: 0 } }),
+  );
+  const res = await app.fetch(req());
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(Array.isArray(body.projects)).toBe(true);
+});
+
+test("GET /api/backlog excludes non-forge repos", async () => {
+  const app = makeApp(makeDeps({ [repoA]: { openIssues: 1, openPRs: 0 } }));
+  const body = await app.fetch(req()).then((r) => r.json());
+  const paths = body.projects.map((p: { path: string }) => p.path);
+  // repoNonForge must not appear
+  expect(paths).not.toContain(repoNonForge);
+  // Our two forge repos appear
+  expect(paths).toContain(repoA);
+  expect(paths).toContain(repoB);
+});
+
+test("GET /api/backlog sorts by openIssues descending, null last", async () => {
+  const app = makeApp(
+    makeDeps({
+      [repoA]: { openIssues: 3, openPRs: 0 },
+      [repoB]: { openIssues: null, openPRs: null },
+    }),
+  );
+  const body = await app.fetch(req()).then((r) => r.json());
+  const projects = body.projects as { path: string; openIssues: number | null }[];
+  const idxA = projects.findIndex((p) => p.path === repoA);
+  const idxB = projects.findIndex((p) => p.path === repoB);
+  // repoA (3) should come before repoB (null)
+  expect(idxA).toBeGreaterThanOrEqual(0);
+  expect(idxB).toBeGreaterThanOrEqual(0);
+  expect(idxA).toBeLessThan(idxB);
+});
+
+test("GET /api/backlog sort: higher issue count before lower", async () => {
+  const app = makeApp(
+    makeDeps({
+      [repoA]: { openIssues: 1, openPRs: 0 },
+      [repoB]: { openIssues: 10, openPRs: 0 },
+    }),
+  );
+  const body = await app.fetch(req()).then((r) => r.json());
+  const projects = body.projects as { path: string }[];
+  const idxA = projects.findIndex((p) => p.path === repoA);
+  const idxB = projects.findIndex((p) => p.path === repoB);
+  // B (10) comes before A (1)
+  expect(idxB).toBeLessThan(idxA);
+});
+
+test("GET /api/backlog pinnedPath = max lastUsedAt", async () => {
+  const app = makeApp(
+    makeDeps(
+      { [repoA]: { openIssues: 5, openPRs: 0 }, [repoB]: { openIssues: 2, openPRs: 0 } },
+      { [repoA]: 100, [repoB]: 200 }, // B was used most recently
+    ),
+  );
+  const body = await app.fetch(req()).then((r) => r.json());
+  expect(body.pinnedPath).toBe(repoB);
+});
+
+test("GET /api/backlog pinnedPath is included in projects array", async () => {
+  const app = makeApp(
+    makeDeps(
+      { [repoA]: { openIssues: 5, openPRs: 0 }, [repoB]: { openIssues: 2, openPRs: 0 } },
+      { [repoA]: 100, [repoB]: 200 },
+    ),
+  );
+  const body = await app.fetch(req()).then((r) => r.json());
+  const paths = body.projects.map((p: { path: string }) => p.path);
+  expect(paths).toContain(body.pinnedPath);
+});
+
+test("GET /api/backlog null counts pass through as null, not 0", async () => {
+  const app = makeApp(makeDeps({ [repoA]: { openIssues: null, openPRs: null } }));
+  const body = await app.fetch(req()).then((r) => r.json());
+  const projA = body.projects.find((p: { path: string }) => p.path === repoA);
+  expect(projA).toBeDefined();
+  expect(projA.openIssues).toBeNull();
+  expect(projA.openPRs).toBeNull();
+});
+
+test("GET /api/backlog totals skip null counts", async () => {
+  const app = makeApp(
+    makeDeps({
+      [repoA]: { openIssues: 5, openPRs: 2 },
+      [repoB]: { openIssues: null, openPRs: null },
+    }),
+  );
+  const body = await app.fetch(req()).then((r) => r.json());
+  // Only non-null values count toward totals
+  expect(body.totals.openIssues).toBe(5);
+  expect(body.totals.openPRs).toBe(2);
+});
+
+test("GET /api/backlog totals sum non-null from both repos", async () => {
+  const app = makeApp(
+    makeDeps({
+      [repoA]: { openIssues: 4, openPRs: 1 },
+      [repoB]: { openIssues: 6, openPRs: 3 },
+    }),
+  );
+  const body = await app.fetch(req()).then((r) => r.json());
+  expect(body.totals.openIssues).toBe(10);
+  expect(body.totals.openPRs).toBe(4);
+});
+
+test("GET /api/backlog with deps.backlog absent → empty payload", async () => {
+  const deps: AppDeps = {
+    store: { lastUsedByRepo: () => ({}) } as unknown as SessionStore,
+    service: {} as SessionService,
+    events: { emit: () => {} } as unknown as EventHub,
+    usageLimits: { limits: () => ({}) } as never,
+    // no backlog
+  };
+  const app = makeApp(deps);
+  const res = await app.fetch(req());
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({
+    pinnedPath: null,
+    projects: [],
+    totals: { openIssues: 0, openPRs: 0 },
+  });
+});
+
+test("GET /api/backlog pinnedPath falls back to first sorted project when no lastUsedAt", async () => {
+  const app = makeApp(
+    makeDeps(
+      {
+        [repoA]: { openIssues: 10, openPRs: 0 },
+        [repoB]: { openIssues: 1, openPRs: 0 },
+      },
+      {}, // no lastUsedAt for any repo
+    ),
+  );
+  const body = await app.fetch(req()).then((r) => r.json());
+  // With no lastUsedAt, pinnedPath falls back to the first project after sort (most issues = repoA)
+  expect(body.pinnedPath).toBe(repoA);
+});

--- a/test/server-issues.test.ts
+++ b/test/server-issues.test.ts
@@ -18,7 +18,14 @@ beforeEach(() => {
 });
 afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
 
-const ISSUE: Issue = { number: 1, title: "Bug", body: "boom", url: "u1", labels: ["bug"] };
+const ISSUE: Issue = {
+  number: 1,
+  title: "Bug",
+  body: "boom",
+  url: "u1",
+  labels: ["bug"],
+  createdAt: 1_700_000_000_000,
+};
 
 function fakeForge(over: Partial<GitForge> = {}): GitForge {
   return {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -251,5 +251,14 @@
   "updatemodal_exit_code": "Exit-Code {code}",
   "updatemodal_deploy_log": "Deploy-Ausgabe",
   "updatemodal_unreachable": "Server zu lange nicht erreichbar — das Update ist möglicherweise fehlgeschlagen. App neu laden oder Logs prüfen.",
-  "updatemodal_retry": "Erneut versuchen"
+  "updatemodal_retry": "Erneut versuchen",
+  "backlog_tab_issues": "Issues",
+  "backlog_tab_prs": "PRs",
+  "backlog_tab_issues_count": "Issues · {count}",
+  "backlog_tab_prs_count": "PRs · {count}",
+  "backlog_pinned_label": "Angeheftet",
+  "backlog_open_since_days": "{days} T",
+  "backlog_prs_soon": "PR-Details folgen bald",
+  "backlog_loading": "Backlog wird geladen…",
+  "backlog_no_forge_repos": "Keine Forge-Projekte"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -260,5 +260,6 @@
   "backlog_open_since_days": "{days} T",
   "backlog_prs_soon": "PR-Details folgen bald",
   "backlog_loading": "Backlog wird geladen…",
-  "backlog_no_forge_repos": "Keine Forge-Projekte"
+  "backlog_no_forge_repos": "Keine Forge-Projekte",
+  "backlog_select_a_project": "Projekt auswählen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -251,5 +251,14 @@
   "updatemodal_exit_code": "Exit code {code}",
   "updatemodal_deploy_log": "Deploy output",
   "updatemodal_unreachable": "The server stayed unreachable for too long — the update may have failed. Reload the app or check the logs.",
-  "updatemodal_retry": "Retry"
+  "updatemodal_retry": "Retry",
+  "backlog_tab_issues": "Issues",
+  "backlog_tab_prs": "PRs",
+  "backlog_tab_issues_count": "Issues · {count}",
+  "backlog_tab_prs_count": "PRs · {count}",
+  "backlog_pinned_label": "Pinned",
+  "backlog_open_since_days": "{days} d",
+  "backlog_prs_soon": "PR details coming soon",
+  "backlog_loading": "Loading backlog…",
+  "backlog_no_forge_repos": "No forge-backed projects"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -260,5 +260,6 @@
   "backlog_open_since_days": "{days} d",
   "backlog_prs_soon": "PR details coming soon",
   "backlog_loading": "Loading backlog…",
-  "backlog_no_forge_repos": "No forge-backed projects"
+  "backlog_no_forge_repos": "No forge-backed projects",
+  "backlog_select_a_project": "Select a project"
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -19,6 +19,7 @@ import type {
   ProjectIcons,
   ReviewVerdict,
   RepoConfig,
+  BacklogPayload,
 } from "./types";
 
 const JSON_HEADERS = { "content-type": "application/json" };
@@ -348,6 +349,12 @@ export async function getReviews(): Promise<Record<string, ReviewVerdict>> {
 export async function getReviewingIds(): Promise<string[]> {
   const r = await fetch("/api/reviews/inflight");
   if (!r.ok) throw new Error(`reviewing failed: ${r.status}`);
+  return r.json();
+}
+
+export async function getBacklog(): Promise<BacklogPayload> {
+  const r = await fetch("/api/backlog");
+  if (!r.ok) throw await failed(r, "backlog");
   return r.json();
 }
 

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import type { BacklogPayload } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import ProjectBacklogList from "./ProjectBacklogList.svelte";
@@ -14,6 +15,8 @@
     onissue: (repoPath: string, prompt: string) => void;
   } = $props();
 
+  const BACKLOG_FILTER: string[] = ["bug", "enhancement"];
+
   type Tab = "issues" | "prs";
   let activeTab = $state<Tab>("issues");
 
@@ -21,9 +24,13 @@
   // user selection is not clobbered (only set when currently null).
   let selectedPath = $state<string | null>(null);
 
+  // Use untrack to read selectedPath without subscribing to it, so that
+  // dismissDetail() (which sets selectedPath = null) does not re-fire this
+  // effect and immediately re-seed the overlay from pinnedPath.
   $effect(() => {
-    if (payload?.pinnedPath && selectedPath === null) {
-      selectedPath = payload.pinnedPath;
+    const pinned = payload?.pinnedPath;
+    if (pinned && untrack(() => selectedPath === null)) {
+      selectedPath = pinned;
     }
   });
 
@@ -98,7 +105,7 @@
                 }}
                 bodyPreview
                 age
-                filterLabels={["bug", "enhancement"]}
+                filterLabels={BACKLOG_FILTER}
               />
             </div>
           </div>
@@ -123,11 +130,11 @@
                 }}
                 bodyPreview
                 age
-                filterLabels={["bug", "enhancement"]}
+                filterLabels={BACKLOG_FILTER}
               />
             {:else}
               <div class="detail-empty">
-                <span class="detail-empty-label">{m.backlog_no_forge_repos()}</span>
+                <span class="detail-empty-label">{m.backlog_select_a_project()}</span>
               </div>
             {/if}
           </div>

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -1,0 +1,363 @@
+<script lang="ts">
+  import type { BacklogPayload } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import ProjectBacklogList from "./ProjectBacklogList.svelte";
+  import IssuesPanel from "./IssuesPanel.svelte";
+
+  let {
+    payload,
+    mobile,
+    onissue,
+  }: {
+    payload: BacklogPayload | null;
+    mobile: boolean;
+    onissue: (repoPath: string, prompt: string) => void;
+  } = $props();
+
+  type Tab = "issues" | "prs";
+  let activeTab = $state<Tab>("issues");
+
+  // selectedPath: initialized from pinnedPath once payload arrives;
+  // user selection is not clobbered (only set when currently null).
+  let selectedPath = $state<string | null>(null);
+
+  $effect(() => {
+    if (payload?.pinnedPath && selectedPath === null) {
+      selectedPath = payload.pinnedPath;
+    }
+  });
+
+  // On mobile, a set selectedPath means the detail overlay is open.
+  // Clearing it goes back to the project list.
+  function dismissDetail() {
+    selectedPath = null;
+  }
+</script>
+
+<div class="backlog-view" class:mobile>
+  {#if payload === null}
+    <!-- loading state -->
+    <div class="state-full">
+      <span class="skeleton-pulse">{m.backlog_loading()}</span>
+    </div>
+  {:else if payload.projects.length === 0}
+    <!-- intentional empty state -->
+    <div class="state-full">
+      <span class="empty-label">{m.backlog_no_forge_repos()}</span>
+    </div>
+  {:else}
+    <!-- tab bar -->
+    <div class="tab-bar">
+      <button
+        class="tab-btn"
+        class:active={activeTab === "issues"}
+        type="button"
+        onclick={() => (activeTab = "issues")}
+      >
+        {m.backlog_tab_issues_count({ count: payload.totals.openIssues })}
+      </button>
+      <button
+        class="tab-btn"
+        class:active={activeTab === "prs"}
+        type="button"
+        onclick={() => (activeTab = "prs")}
+      >
+        {m.backlog_tab_prs_count({ count: payload.totals.openPRs })}
+      </button>
+    </div>
+
+    <!-- tab content -->
+    {#if activeTab === "issues"}
+      {#if mobile}
+        <!-- mobile: full-width list; selected project opens overlay -->
+        <div class="mobile-master">
+          <ProjectBacklogList
+            projects={payload.projects}
+            pinnedPath={payload.pinnedPath}
+            {selectedPath}
+            onselect={(p) => (selectedPath = p)}
+          />
+        </div>
+        {#if selectedPath !== null}
+          <div class="mobile-detail-overlay" role="dialog" aria-modal="true">
+            <div class="overlay-head">
+              <button
+                class="overlay-close"
+                type="button"
+                onclick={dismissDetail}
+                aria-label={m.common_close()}
+              >
+                ‹ {m.common_close()}
+              </button>
+            </div>
+            <div class="overlay-body">
+              <IssuesPanel
+                repoPath={selectedPath}
+                onnewtask={(prompt) => {
+                  onissue(selectedPath!, prompt);
+                }}
+                bodyPreview
+                age
+                filterLabels={["bug", "enhancement"]}
+              />
+            </div>
+          </div>
+        {/if}
+      {:else}
+        <!-- desktop: side-by-side master + detail -->
+        <div class="desktop-split">
+          <div class="master-pane">
+            <ProjectBacklogList
+              projects={payload.projects}
+              pinnedPath={payload.pinnedPath}
+              {selectedPath}
+              onselect={(p) => (selectedPath = p)}
+            />
+          </div>
+          <div class="detail-pane">
+            {#if selectedPath !== null}
+              <IssuesPanel
+                repoPath={selectedPath}
+                onnewtask={(prompt) => {
+                  onissue(selectedPath!, prompt);
+                }}
+                bodyPreview
+                age
+                filterLabels={["bug", "enhancement"]}
+              />
+            {:else}
+              <div class="detail-empty">
+                <span class="detail-empty-label">{m.backlog_no_forge_repos()}</span>
+              </div>
+            {/if}
+          </div>
+        </div>
+      {/if}
+    {:else}
+      <!-- PRs tab: placeholder, intentional empty state -->
+      <div class="prs-tab">
+        <div class="prs-count">{payload.totals.openPRs}</div>
+        <div class="prs-soon">{m.backlog_prs_soon()}</div>
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .backlog-view {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background: var(--color-inset);
+    font-family: var(--font-mono);
+    overflow: hidden;
+  }
+
+  /* ── loading / empty full-area states ── */
+  .state-full {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .skeleton-pulse {
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-faint);
+    animation: pulse 1.6s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 0.4;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+
+  .empty-label {
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-faint);
+  }
+
+  /* ── tab bar ── */
+  .tab-bar {
+    display: flex;
+    gap: 2px;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--color-line);
+    background: var(--color-head);
+    flex-shrink: 0;
+  }
+
+  .tab-btn {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      color 0.12s,
+      border-color 0.12s;
+  }
+
+  .tab-btn:hover {
+    color: var(--color-ink);
+  }
+
+  .tab-btn.active {
+    color: var(--color-ink-bright);
+    border-color: var(--color-line-bright);
+    background: var(--color-inset);
+  }
+
+  /* ── desktop split layout ── */
+  .desktop-split {
+    display: grid;
+    grid-template-columns: minmax(220px, 300px) 1fr;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .master-pane {
+    border-right: 1px solid var(--color-line);
+    overflow-y: auto;
+    padding: 6px 4px;
+  }
+
+  .master-pane::-webkit-scrollbar {
+    width: 4px;
+  }
+  .master-pane::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .master-pane::-webkit-scrollbar-thumb {
+    background: var(--color-faint);
+    border-radius: 2px;
+  }
+
+  .detail-pane {
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .detail-empty {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .detail-empty-label {
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-faint);
+  }
+
+  /* ── mobile layout ── */
+  .mobile-master {
+    flex: 1;
+    overflow-y: auto;
+    padding: 6px 4px;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .mobile-master::-webkit-scrollbar {
+    width: 4px;
+  }
+  .mobile-master::-webkit-scrollbar-thumb {
+    background: var(--color-faint);
+    border-radius: 2px;
+  }
+
+  /* full-area overlay (stacks above the list) */
+  .mobile-detail-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    background: var(--color-inset);
+  }
+
+  /* BacklogView must be position:relative so the overlay is contained */
+  .backlog-view.mobile {
+    position: relative;
+  }
+
+  .overlay-head {
+    display: flex;
+    align-items: center;
+    padding: 6px 10px;
+    background: var(--color-head);
+    border-bottom: 1px solid var(--color-line);
+    flex-shrink: 0;
+    min-height: 44px;
+  }
+
+  .overlay-close {
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    padding: 6px 12px;
+    cursor: pointer;
+    min-height: 40px;
+    touch-action: manipulation;
+  }
+
+  .overlay-close:hover {
+    background: var(--color-hover);
+  }
+
+  .overlay-body {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ── PRs placeholder tab ── */
+  .prs-tab {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+  }
+
+  .prs-count {
+    font-size: 36px;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-ink-bright);
+    line-height: 1;
+    letter-spacing: -0.02em;
+  }
+
+  .prs-soon {
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 4px 10px;
+  }
+</style>

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -6,9 +6,15 @@
   let {
     repoPath,
     onnewtask,
+    bodyPreview = false,
+    age = false,
+    filterLabels = undefined,
   }: {
     repoPath: string;
     onnewtask: (prompt: string) => void;
+    bodyPreview?: boolean;
+    age?: boolean;
+    filterLabels?: string[];
   } = $props();
 
   let issues = $state<Issue[]>([]);
@@ -29,6 +35,12 @@
         loading = false;
       });
   });
+
+  const visibleIssues = $derived(
+    filterLabels && filterLabels.length > 0
+      ? issues.filter((issue) => issue.labels.some((l) => filterLabels!.includes(l)))
+      : issues,
+  );
 </script>
 
 <div class="issues-panel">
@@ -41,10 +53,10 @@
       <div class="muted">{m.common_loading()}</div>
     {:else if slug === null}
       <div class="muted">{m.issuespanel_no_host()}</div>
-    {:else if issues.length === 0}
+    {:else if visibleIssues.length === 0}
       <div class="muted">{m.common_no_open_issues()}</div>
     {:else}
-      {#each issues as issue (issue.number)}
+      {#each visibleIssues as issue (issue.number)}
         <div class="issue-row">
           <div class="issue-top">
             <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an app route -->
@@ -64,11 +76,21 @@
             >
             <!-- eslint-enable svelte/no-navigation-without-resolve -->
           </div>
-          {#if issue.labels.length > 0}
+          {#if bodyPreview && issue.body}
+            <div class="body-preview">{issue.body}</div>
+          {/if}
+          {#if issue.labels.length > 0 || age}
             <div class="label-row">
               {#each issue.labels as label (label)}
                 <span class="label-chip">{label}</span>
               {/each}
+              {#if age}
+                <span class="age-chip"
+                  >{m.backlog_open_since_days({
+                    days: Math.floor((Date.now() - issue.createdAt) / 86_400_000),
+                  })}</span
+                >
+              {/if}
             </div>
           {/if}
           <div class="issue-actions">
@@ -180,6 +202,25 @@
     border: 1px solid var(--color-line);
     border-radius: 2px;
     padding: 1px 5px;
+  }
+
+  .body-preview {
+    font-size: 11px;
+    color: var(--color-muted);
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    word-break: break-word;
+  }
+
+  .age-chip {
+    font-size: 9.5px;
+    letter-spacing: 0.1em;
+    color: var(--color-faint);
+    padding: 1px 0;
   }
 
   .issue-actions {

--- a/ui/src/lib/components/ProjectBacklogList.svelte
+++ b/ui/src/lib/components/ProjectBacklogList.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import type { BacklogProject } from "$lib/types";
+  import ProjectRow from "./ProjectRow.svelte";
+
+  let {
+    projects,
+    pinnedPath,
+    selectedPath,
+    onselect,
+  }: {
+    projects: BacklogProject[];
+    pinnedPath: string | null;
+    selectedPath: string | null;
+    onselect: (path: string) => void;
+  } = $props();
+</script>
+
+<div class="project-list">
+  {#each projects as project (project.path)}
+    <ProjectRow
+      {project}
+      pinned={project.path === pinnedPath}
+      selected={project.path === selectedPath}
+      onselect={() => onselect(project.path)}
+    />
+  {/each}
+</div>
+
+<style>
+  .project-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+</style>

--- a/ui/src/lib/components/ProjectRow.svelte
+++ b/ui/src/lib/components/ProjectRow.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import type { BacklogProject } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    project,
+    pinned,
+    selected,
+    onselect,
+  }: {
+    project: BacklogProject;
+    pinned: boolean;
+    selected: boolean;
+    onselect: () => void;
+  } = $props();
+
+  const displayName = $derived(project.display || project.slug || project.path);
+</script>
+
+<button class="project-row" class:sel={selected} onclick={onselect} type="button">
+  <div class="row-main">
+    <span class="row-name">{displayName}</span>
+    {#if pinned}
+      <span class="pinned-badge">{m.backlog_pinned_label()}</span>
+    {/if}
+  </div>
+  <div class="row-counts">
+    <span class="count-item">
+      {project.openIssues ?? "—"}
+      {m.backlog_tab_issues()}
+    </span>
+    <span class="sep">·</span>
+    <span class="count-item">
+      {project.openPRs ?? "—"}
+      {m.backlog_tab_prs()}
+    </span>
+  </div>
+</button>
+
+<style>
+  .project-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+    min-height: 44px;
+    padding: 8px 12px;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    font-family: var(--font-mono);
+    text-align: left;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      background 0.12s;
+  }
+
+  .project-row:hover {
+    border-color: var(--color-line);
+    background: var(--color-hover);
+  }
+
+  .project-row.sel {
+    border-color: var(--color-line-bright);
+    background: var(--color-sel);
+  }
+
+  .row-main {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .row-name {
+    color: var(--color-ink-bright);
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: 0.03em;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .pinned-badge {
+    font-size: 9px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-amber);
+    border: 1px solid var(--color-amber);
+    border-radius: 2px;
+    padding: 1px 5px;
+    flex-shrink: 0;
+  }
+
+  .row-counts {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+    font-size: 11px;
+    color: var(--color-muted);
+    letter-spacing: 0.04em;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .sep {
+    color: var(--color-faint);
+  }
+</style>

--- a/ui/src/lib/components/backlog-view.test.ts
+++ b/ui/src/lib/components/backlog-view.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for BacklogView logic (backlog-view.ts).
+ *
+ * BacklogView.svelte has no @testing-library/svelte available in this test
+ * suite. We test the extracted pure-logic helpers following the pr-badge.test.ts
+ * pattern.
+ *
+ * Coverage note: tab switching (Svelte state), DOM rendering, and the
+ * `$effect` selectedPath initialisation are not covered here; they require DOM
+ * rendering infrastructure not present. The assertions below verify the display
+ * logic (null → "—", pinned detection, tab label strings) that the template
+ * delegates to these functions.
+ */
+import { describe, it, expect } from "vitest";
+import { formatCount, isPinned, issuesTabLabel, prsTabLabel } from "./backlog-view";
+import type { BacklogPayload, BacklogProject } from "$lib/types";
+
+function project(path: string, openIssues: number | null, openPRs: number | null): BacklogProject {
+  return { path, display: path, slug: "org/repo", kind: "github", openIssues, openPRs };
+}
+
+function payload(
+  projects: BacklogProject[],
+  pinnedPath: string | null = null,
+  totals = { openIssues: 0, openPRs: 0 },
+): BacklogPayload {
+  return { pinnedPath, projects, totals };
+}
+
+describe("formatCount", () => {
+  it("returns the number as-is for non-null counts", () => {
+    expect(formatCount(0)).toBe(0);
+    expect(formatCount(5)).toBe(5);
+    expect(formatCount(42)).toBe(42);
+  });
+
+  it("returns '—' for null counts (the em-dash placeholder)", () => {
+    expect(formatCount(null)).toBe("—");
+  });
+});
+
+describe("isPinned", () => {
+  it("returns true when project path matches pinnedPath", () => {
+    const p = project("/repos/alpha", 3, 1);
+    expect(isPinned(p, "/repos/alpha")).toBe(true);
+  });
+
+  it("returns false when project path differs from pinnedPath", () => {
+    const p = project("/repos/alpha", 3, 1);
+    expect(isPinned(p, "/repos/beta")).toBe(false);
+  });
+
+  it("returns false when pinnedPath is null", () => {
+    const p = project("/repos/alpha", 3, 1);
+    expect(isPinned(p, null)).toBe(false);
+  });
+});
+
+describe("issuesTabLabel", () => {
+  it("includes the openIssues total count from the payload", () => {
+    const p = payload([], null, { openIssues: 24, openPRs: 3 });
+    const label = issuesTabLabel(p);
+    expect(label).toContain("24");
+    // Mirrors m.backlog_tab_issues_count({ count: payload.totals.openIssues })
+    expect(label).toMatch(/Issues\s*·\s*24/);
+  });
+
+  it("shows 0 when no issues", () => {
+    const p = payload([], null, { openIssues: 0, openPRs: 0 });
+    expect(issuesTabLabel(p)).toContain("0");
+  });
+});
+
+describe("prsTabLabel", () => {
+  it("includes the openPRs total count from the payload", () => {
+    const p = payload([], null, { openIssues: 24, openPRs: 3 });
+    const label = prsTabLabel(p);
+    expect(label).toContain("3");
+    // Mirrors m.backlog_tab_prs_count({ count: payload.totals.openPRs })
+    expect(label).toMatch(/PRs\s*·\s*3/);
+  });
+
+  it("shows 0 when no PRs", () => {
+    const p = payload([], null, { openIssues: 10, openPRs: 0 });
+    expect(prsTabLabel(p)).toContain("0");
+  });
+});
+
+describe("BacklogView display logic — integration of helpers", () => {
+  it("project with null openIssues renders as '—'", () => {
+    const p = project("/repos/null-proj", null, null);
+    expect(formatCount(p.openIssues)).toBe("—");
+    expect(formatCount(p.openPRs)).toBe("—");
+  });
+
+  it("pinned project is identified correctly", () => {
+    const pinnedPath = "/repos/alpha";
+    const alpha = project(pinnedPath, 10, 2);
+    const beta = project("/repos/beta", 3, 1);
+    const pl = payload([alpha, beta], pinnedPath);
+
+    expect(isPinned(alpha, pl.pinnedPath)).toBe(true);
+    expect(isPinned(beta, pl.pinnedPath)).toBe(false);
+  });
+
+  it("tab labels contain both issue and PR totals from payload", () => {
+    const pl = payload([], "/repos/alpha", { openIssues: 15, openPRs: 7 });
+    expect(issuesTabLabel(pl)).toContain("15");
+    expect(prsTabLabel(pl)).toContain("7");
+  });
+
+  /**
+   * PRs tab shows backlog_prs_soon placeholder (not a spinner).
+   *
+   * The PRs tab in BacklogView.svelte renders `.prs-soon` with
+   * m.backlog_prs_soon() = "PR details coming soon" and does NOT render a
+   * loading spinner class. We assert the message key value here since
+   * the full message catalog is available via the paraglide runtime.
+   */
+  it("backlog_prs_soon message key yields a non-empty string (placeholder, not spinner)", async () => {
+    // Import the compiled paraglide message directly.
+    const { backlog_prs_soon } = await import("$lib/paraglide/messages");
+    const text = backlog_prs_soon();
+    expect(typeof text).toBe("string");
+    expect(text.length).toBeGreaterThan(0);
+    // Must not look like a loading/spinner label
+    expect(text.toLowerCase()).not.toContain("loading");
+    expect(text.toLowerCase()).not.toContain("spinner");
+  });
+});

--- a/ui/src/lib/components/backlog-view.ts
+++ b/ui/src/lib/components/backlog-view.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure logic extracted from BacklogView.svelte and ProjectRow.svelte —
+ * unit-testable without a DOM.
+ */
+import type { BacklogPayload, BacklogProject } from "$lib/types";
+
+/**
+ * Format a count for display: number as-is, null as the em-dash placeholder
+ * `—` (matches `{project.openIssues ?? "—"}` in ProjectRow.svelte).
+ */
+export function formatCount(count: number | null): string | number {
+  return count ?? "—";
+}
+
+/**
+ * Returns true if the given project's path matches the pinnedPath.
+ */
+export function isPinned(project: BacklogProject, pinnedPath: string | null): boolean {
+  return project.path === pinnedPath;
+}
+
+/**
+ * Build the Issues tab label that BacklogView renders.
+ * Mirrors: m.backlog_tab_issues_count({ count: payload.totals.openIssues })
+ */
+export function issuesTabLabel(payload: BacklogPayload): string {
+  return `Issues · ${payload.totals.openIssues}`;
+}
+
+/**
+ * Build the PRs tab label that BacklogView renders.
+ * Mirrors: m.backlog_tab_prs_count({ count: payload.totals.openPRs })
+ */
+export function prsTabLabel(payload: BacklogPayload): string {
+  return `PRs · ${payload.totals.openPRs}`;
+}

--- a/ui/src/lib/components/issues-panel.test.ts
+++ b/ui/src/lib/components/issues-panel.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for IssuesPanel logic (issues-panel.ts).
+ *
+ * IssuesPanel.svelte has no @testing-library/svelte available, so we test
+ * the extracted pure-logic companions following the pr-badge.test.ts pattern.
+ *
+ * Coverage note: the component's internal fetch (listIssues) and Svelte
+ * reactivity are not covered here; that requires DOM rendering infrastructure
+ * not present in this test suite.
+ */
+import { describe, it, expect } from "vitest";
+import { filterIssues, issueAgeDays } from "./issues-panel";
+import type { Issue } from "$lib/types";
+
+function issue(number: number, labels: string[], createdAt = 0): Issue {
+  return { number, title: `Issue ${number}`, body: "body", url: "u", labels, createdAt };
+}
+
+describe("filterIssues", () => {
+  it("returns all issues when filterLabels is undefined", () => {
+    const issues = [issue(1, ["bug"]), issue(2, ["feature"])];
+    expect(filterIssues(issues, undefined)).toEqual(issues);
+  });
+
+  it("returns all issues when filterLabels is empty array", () => {
+    const issues = [issue(1, ["bug"]), issue(2, [])];
+    expect(filterIssues(issues, [])).toEqual(issues);
+  });
+
+  it("keeps issues that have at least one label in filterLabels (OR semantics)", () => {
+    const issues = [
+      issue(1, ["bug"]),
+      issue(2, ["enhancement"]),
+      issue(3, ["documentation"]),
+      issue(4, ["bug", "enhancement"]),
+    ];
+    const visible = filterIssues(issues, ["bug", "enhancement"]);
+    expect(visible.map((i) => i.number)).toEqual([1, 2, 4]);
+    expect(visible.map((i) => i.number)).not.toContain(3);
+  });
+
+  it("excludes issues that have no matching labels", () => {
+    const issues = [issue(1, ["documentation"]), issue(2, ["question"])];
+    const visible = filterIssues(issues, ["bug"]);
+    expect(visible).toHaveLength(0);
+  });
+
+  it("works when an issue has multiple labels and only one matches", () => {
+    const issues = [issue(1, ["bug", "wontfix"])];
+    const visible = filterIssues(issues, ["bug", "enhancement"]);
+    expect(visible).toHaveLength(1);
+  });
+
+  it("preserves stale-guard safety: does not mutate the input array", () => {
+    const issues = [issue(1, ["bug"])];
+    const copy = [...issues];
+    filterIssues(issues, ["bug"]);
+    expect(issues).toEqual(copy);
+  });
+});
+
+describe("issueAgeDays", () => {
+  it("returns 0 for a just-created issue (same ms)", () => {
+    const now = Date.now();
+    expect(issueAgeDays(now, now)).toBe(0);
+  });
+
+  it("returns the correct number of whole days", () => {
+    const now = 1_000_000_000_000; // arbitrary fixed point
+    const threeDaysAgo = now - 3 * 86_400_000;
+    expect(issueAgeDays(threeDaysAgo, now)).toBe(3);
+  });
+
+  it("floors fractional days", () => {
+    const now = 1_000_000_000_000;
+    const almostTwoDays = now - (2 * 86_400_000 - 1);
+    expect(issueAgeDays(almostTwoDays, now)).toBe(1);
+  });
+
+  it("returns 0 (clamped) if createdAt is somehow in the future", () => {
+    const now = 1_000_000_000_000;
+    expect(issueAgeDays(now + 86_400_000, now)).toBe(0);
+  });
+
+  it("derives days matching the backlog_open_since_days usage in the template", () => {
+    // Template: Math.floor((Date.now() - issue.createdAt) / 86_400_000)
+    const now = 1_700_000_000_000;
+    const createdAt = now - 7 * 86_400_000;
+    expect(issueAgeDays(createdAt, now)).toBe(7);
+  });
+});

--- a/ui/src/lib/components/issues-panel.ts
+++ b/ui/src/lib/components/issues-panel.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure logic extracted from IssuesPanel.svelte — unit-testable without a DOM.
+ */
+import type { Issue } from "$lib/types";
+
+/**
+ * Filter issues to those that have at least one label in `filterLabels` (OR
+ * semantics). When `filterLabels` is empty or absent every issue is visible.
+ */
+export function filterIssues(issues: Issue[], filterLabels: string[] | undefined): Issue[] {
+  if (!filterLabels || filterLabels.length === 0) return issues;
+  return issues.filter((issue) => issue.labels.some((l) => filterLabels.includes(l)));
+}
+
+/**
+ * Compute the age in whole days relative to `now` (defaults to Date.now()).
+ * Returns a non-negative integer.
+ */
+export function issueAgeDays(createdAt: number, now = Date.now()): number {
+  return Math.max(0, Math.floor((now - createdAt) / 86_400_000));
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -32,6 +32,7 @@ export interface Issue {
   body: string;
   url: string;
   labels: string[];
+  createdAt: number;
 }
 export type BlockShape = "menu" | "yes-no" | "awaiting-input" | "stall";
 export interface BlockOption {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -165,6 +165,22 @@ export interface HerdrUpdateStatus {
 /** repoPath → emoji map for per-project icons. */
 export type ProjectIcons = Record<string, string>;
 
+// ── backlog ────────────────────────────────────────────────────────────────
+export interface BacklogProject {
+  path: string;
+  display: string;
+  slug: string | null;
+  kind: "github" | "gitea";
+  lastUsedAt?: number;
+  openIssues: number | null;
+  openPRs: number | null;
+}
+export interface BacklogPayload {
+  pinnedPath: string | null;
+  projects: BacklogProject[];
+  totals: { openIssues: number; openPRs: number };
+}
+
 export type WsEvent =
   | { event: "session:new"; data: Session }
   | { event: "session:status"; data: { id: string; status: SessionStatus } }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -13,8 +13,9 @@
     getUpdateLog,
     getHerdrUpdate,
     gitStates,
+    getBacklog,
   } from "$lib/api";
-  import type { DeployState } from "$lib/types";
+  import type { DeployState, BacklogPayload } from "$lib/types";
   import { sortBlocked } from "$lib/triage";
   import { steers } from "$lib/steers.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
@@ -28,6 +29,7 @@
   import BroadcastDialog from "$lib/components/BroadcastDialog.svelte";
   import ActionBar from "$lib/components/ActionBar.svelte";
   import HerdGrid from "$lib/components/HerdGrid.svelte";
+  import BacklogView from "$lib/components/BacklogView.svelte";
   import UpdateModal from "$lib/components/UpdateModal.svelte";
   import HerdrUpdateModal from "$lib/components/HerdrUpdateModal.svelte";
   import { registerSW, onSelectSession } from "$lib/push";
@@ -52,8 +54,26 @@
   let nowMs = $state(Date.now());
   let composeRepoPath = $state<string | null>(null);
   let composePrompt = $state("");
+  let backlog = $state<BacklogPayload | null>(null);
 
   const selected = $derived(store.sessions.find((s) => s.id === selectedId) ?? null);
+
+  // Fetch backlog only when the overview is empty. Reading store.sessions.length
+  // inside the effect body makes Svelte track it; backlog is written but never
+  // read here, so it cannot re-trigger the effect → no loop.
+  $effect(() => {
+    if (store.sessions.length === 0) {
+      getBacklog()
+        .then((p) => (backlog = p))
+        .catch(() => {});
+    }
+  });
+
+  function onissue(repoPath: string, prompt: string) {
+    composeRepoPath = repoPath;
+    composePrompt = prompt;
+    showNew = true;
+  }
 
   const mobile = new MediaQuery("max-width: 768px");
   // touch-primary device (e.g. unfolded foldable wider than the mobile breakpoint):
@@ -235,6 +255,9 @@
           onnew={() => (showNew = true)}
           git={store.git}
         />
+        {#if store.sessions.length === 0}
+          <BacklogView payload={backlog} mobile={true} {onissue} />
+        {/if}
       </div>
       <ActionBar onnew={() => (showNew = true)} mobile={mobile.current} />
     {:else if selected}
@@ -283,7 +306,9 @@
         onnew={() => (showNew = true)}
         git={store.git}
       />
-      {#if selected}
+      {#if store.sessions.length === 0}
+        <BacklogView payload={backlog} mobile={false} {onissue} />
+      {:else if selected}
         <Viewport
           session={selected}
           touch={touch.current}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -65,7 +65,9 @@
     if (store.sessions.length === 0) {
       getBacklog()
         .then((p) => (backlog = p))
-        .catch(() => {});
+        .catch(() => {
+          backlog = { pinnedPath: null, projects: [], totals: { openIssues: 0, openPRs: 0 } };
+        });
     }
   });
 


### PR DESCRIPTION
## Summary
- Verwandelt den strikt-leeren Shepherd-Screen (`sessions.length === 0`) in ein **cross-projektweites Launchpad**: Forge-Projekte nach offener Issue-Zahl sortiert (zuletzt bearbeitetes gepinnt), je Zeile Issue- **und** PR-Count.
- Klick auf Projekt → dessen `bug`+`enhancement`-Issues mit **Body-Vorschau, Label-Chips und „offen seit N Tagen"**; Klick auf Issue → bestehender **Neue-Aufgabe-Dialog vorausgefüllt**.
- Tabs **Issues | PRs** — PR-*Counts* jetzt, PR-Detailliste bewusst als Folge-Scope (No-Go).
- Ziel: leeres Wochen-Limit nutzen, Agenten ohne Repo-für-Repo-Suche mit gespeicherten/Kunden-Issues beschäftigen.

## Changes
**Server (herdr)**
- `src/backlog.ts` — neue `CountsService`: per-Repo `gh api graphql` (`issues(states:OPEN)`/`pullRequests(states:OPEN)` totalCount; **nicht** REST `open_issues_count`), **fault-isoliert** (ein kaputtes Repo nullt nur seine Zeile), 60s-TTL-Read-Through + Single-Flight, `detectForge` pro Pfad gecacht. Gitea via `/api/v1/repos/{slug}` (`open_issues_count` + `open_pr_counter`).
- `GET /api/backlog` (`src/server.ts`, `src/index.ts`) — `{ pinnedPath, projects[], totals }`; forge-only, server-sortiert (desc openIssues, `null` zuletzt), Pin = max `lastUsedAt` und **bleibt** in der Liste, totals überspringen `null`.
- `Issue.createdAt` durch beide Forge-Treiber + Typen.

**UI (SvelteKit, Svelte 5 Runes)**
- Neu: `BacklogView`, `ProjectBacklogList`, `ProjectRow`. `IssuesPanel` erweitert (optionale `bodyPreview`/`age`/`filterLabels`, Stale-Guard erhalten, Viewport-Nutzung unverändert).
- `+page.svelte`: expliziter `{#if sessions.length === 0}`-Outer-Branch (kein Mid-Session-Leak in „nichts ausgewählt") + `onissue`-Prefill (verbatim `onnewtask`-Wiring, `NewTask.svelte` unangetastet).
- `getBacklog()`-Client; **258 i18n-Keys EN=DE** (Parität-Gate grün).

## Acceptance Criteria
Alle 32 Kriterien **PASSED** (PM-Verifikation). Gates: root `lint` + `typecheck` + `test` (446), `cd ui && check` (0 errors) + `check:i18n` (258 Parität) + `test` (138) — alle grün. Branch linear off `origin/main`.

## Out of Scope (No-Gos)
PR-Detailliste/Drilldown, Readiness-Scoring, manuelles Pin-UI, GraphQL-`nodes`-Batch/node_id-Cache, SWR/Background-Revalidate, Gitea-ETag, On-Disk-Cache.

## Test Instructions
1. Alle Sessions **archivieren** → Backlog erscheint (Desktop: rechter Pane; Mobil: unter leerem Herd).
2. Projektliste = nur Forge-Repos, nach Issue-Count absteigend, ein „Angeheftet"-Projekt (auch in Sortierung sichtbar).
3. Projekt klicken → `bug`+`enhancement`-Issues mit Body-Vorschau + „N T".
4. Issue klicken → New-Task vorausgefüllt (`${title}\n\n${body}`, Repo gewählt). Session anlegen → Backlog verschwindet.
5. PRs-Tab → Count + „PR-Details folgen bald" (kein Spinner, keine Liste).
6. No-Leak: ≥1 Session aber nichts ausgewählt → normale „nichts ausgewählt"-Meldung, **nicht** Backlog.
7. Mobil: Issue-Overlay öffnen → „‹ Schließen" → bleibt geschlossen (Regression-Guard).

Closes #120

Generated by `/squad` with Claude Code