### PR TITLE
fix(newtask): inset mobile prompt + align close button

### DIFF
--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -432,39 +432,34 @@
     }
     /* Compact head on phones: the "New Task" title is redundant once the
        sheet is open and the prompt label is obvious from the placeholder.
-       Drop both and float the close ✕ into the corner so the prompt leads
-       the sheet and we don't burn 2–3 rows above the fold. */
+       Drop both, leaving a single 44px row that holds only the close ✕ in the
+       top-right corner — in flow so it stays aligned with the inset fields
+       below rather than floating, detached, over the prompt. */
     .chead {
-      margin-bottom: 0;
+      margin-bottom: 6px;
+      min-height: 44px;
     }
     .chead .micro {
       display: none;
     }
     .x {
-      position: absolute;
-      top: 0;
-      right: 0;
-      z-index: 1;
       display: flex;
       align-items: center;
       justify-content: center;
       width: 44px;
       height: 44px;
+      margin-right: -10px; /* nudge the glyph toward the sheet edge */
       font-size: 16px;
     }
     label[for="nt-prompt"] {
       display: none;
     }
     textarea {
-      /* Stretch the prompt edge-to-edge by cancelling the card's 16px padding,
-         so the field uses the full phone width. */
-      margin-inline: -16px;
-      width: calc(100% + 32px);
-      border-left: 0;
-      border-right: 0;
-      border-radius: 0;
-      padding-right: 44px; /* keep typed text clear of the floating ✕ */
-      /* Comfortable starting size; auto-grow takes it up to 40dvh, then scrolls. */
+      /* Inset like every other field (REPO/BRANCH/MODEL) so the border stays
+         within the viewport. The earlier full-bleed breakout (negative margin +
+         calc width) pushed the border past the edge and left the ✕ visually
+         detached. Comfortable starting size; auto-grow takes it up to 40dvh,
+         then scrolls. */
       min-height: 120px;
       max-height: 40dvh;
       overflow-y: auto;


### PR DESCRIPTION
## What

On the Android/mobile new-task sheet the prompt **textarea broke out of the card padding to go full-bleed** (`margin-inline:-16px; width:calc(100% + 32px); border-left/right:0`), while every other field and the close `✕` stayed inset. That one mismatch caused both reported bugs:

- **Border stretched beyond the viewport** — full-bleed top/bottom borders ran to the screen edges and the negative-margin breakout produced horizontal overflow.
- **Crooked close button** — the `✕` (`right:0`, at the card padding edge) floated ~22px inboard of the full-bleed textarea's right edge, so it looked misaligned against the field it hovered over.

## Fix (mobile `@media` only)

- Inset the prompt textarea like REPO/BRANCH/MODEL — dropped the negative margin / `calc` width / border removals. Border now stays within the viewport with a normal bordered box.
- Put `✕` in flow in a single 44px header row (removed `position:absolute`) so it aligns with the inset field edges instead of floating detached over the prompt.

Desktop is untouched (all changes scoped to `@media (max-width: 768px)`).

## Verification

Reproduced and verified against the running component at a 360px viewport:

- Before: textarea full-bleed to screen edges, `✕` glyph 22px inboard of the bleed edge.
- After: `docScrollW == docClientW == 360` (no horizontal overflow); textarea inset 16px both sides; `✕` in its own row (top 16–60) above the textarea (top 72), no overlap.
- `cd ui && bun run check` → 0 errors; `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)