### PR TITLE
feat(compose): enter inserts newline on mobile, drop redundant ↵ button

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -50,8 +50,6 @@
   "composebar_input_aria": "Nachricht verfassen — tippen oder diktieren, dann senden",
   "composebar_send": "Senden",
   "composebar_send_aria": "Nachricht senden",
-  "composebar_newline": "↵",
-  "composebar_newline_aria": "Zeilenumbruch einfügen",
   "composebar_dictate": "🎤",
   "composebar_dictate_aria": "Diktieren",
   "composebar_dictate_stop_aria": "Diktat beenden",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -50,8 +50,6 @@
   "composebar_input_aria": "Compose a message — type or dictate, then send",
   "composebar_send": "Send",
   "composebar_send_aria": "Send message",
-  "composebar_newline": "↵",
-  "composebar_newline_aria": "Insert newline",
   "composebar_dictate": "🎤",
   "composebar_dictate_aria": "Dictate",
   "composebar_dictate_stop_aria": "Stop dictation",

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -80,8 +80,9 @@
     queueMicrotask(autogrow); // shrink back after the binding clears
   }
 
-  // insert a literal newline at the caret without submitting — the mobile path
-  // for multi-line prompts (a soft keyboard has no Shift+Enter)
+  // insert a literal newline at the caret without submitting — Enter does this
+  // on the soft keyboard (which has no Shift+Enter), so multi-line prompts build
+  // naturally and Send is the sole submit
   function insertNewline() {
     const start = ta?.selectionStart ?? value.length;
     const end = ta?.selectionEnd ?? value.length;
@@ -95,19 +96,17 @@
     });
   }
 
+  // Enter inserts a newline (Send is the only submit). The compose bar is
+  // touch-only — desktop steers xterm directly — so there's no hardware-keyboard
+  // Enter-to-submit path to preserve here.
   function onKeydown(e: KeyboardEvent) {
     if (e.key !== "Enter") return;
     e.preventDefault();
-    if (e.shiftKey) insertNewline();
-    else submit();
+    insertNewline();
   }
 
   // pointerdown + preventDefault: fire instantly and never blur the textarea
   // (which would dismiss the mobile soft keyboard), matching ControlBar.
-  function tapNewline(e: PointerEvent) {
-    e.preventDefault();
-    insertNewline();
-  }
   function tapMic(e: PointerEvent) {
     e.preventDefault();
     toggleDictation();
@@ -125,6 +124,7 @@
     class="field"
     rows="1"
     inputmode="text"
+    enterkeyhint="enter"
     autocapitalize="sentences"
     autocomplete="on"
     spellcheck="true"
@@ -143,12 +143,6 @@
       onpointerdown={tapMic}>{m.composebar_dictate()}</button
     >
   {/if}
-  <button
-    type="button"
-    class="btn"
-    aria-label={m.composebar_newline_aria()}
-    onpointerdown={tapNewline}>{m.composebar_newline()}</button
-  >
   <button
     type="button"
     class="btn send"


### PR DESCRIPTION
## Problem

The mobile compose bar had a separate **`↵`** (insert-newline) button sitting beside **`Send`**. Its glyph collided visually with the ControlBar's **`⏎`** (raw-CR-to-terminal) key one row up — they read as duplicate "return" buttons and cluttered the bar.

They were never functional duplicates: `↵` edited the compose field (insert `\n`, no submit); `⏎` sends a raw CR straight to the PTY. The visual similarity was the whole problem.

## Change

- **Enter now inserts a newline** in the compose field (routed through the already-tested `insertNewlineAt`); **`Send` is the sole submit** — matching chat-app convention.
- **Removed the `↵` button** and its `tapNewline` handler.
- Added `enterkeyhint="enter"` so the soft-keyboard return key reads as newline.
- Dropped the orphaned `composebar_newline` / `composebar_newline_aria` keys from both EN + DE catalogs (parity gate passes, 246 keys each).
- ControlBar `⏎` stays — it's the genuinely-different raw-CR key, no longer competing with a near-identical `↵`.

## Why safe

`ComposeBar` renders **only** on touch/mobile (`(mobile || touch) && tab === "term"`). The desktop / hardware-keyboard path steers xterm's input directly and never mounts `ComposeBar` — so no Enter-to-submit path is affected.

## Verification

`bun run check` (0 errors) · `check:i18n` parity · 115 UI tests pass · eslint + prettier clean · pre-push gate (incl. Fallow) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)