### PR TITLE
feat(gitrail): explanatory tooltip for the critic toggle

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -72,6 +72,8 @@
   "gitrail_critic_reviewing": "🔍 Prüft…",
   "gitrail_critic_reviewing_aria": "Kritiker prüft diesen Pull Request",
   "gitrail_critic_toggle_aria": "Kritiker-Review für dieses Repository umschalten",
+  "gitrail_critic_on_title": "Kritiker ist an: Ein automatischer Reviewer prüft den Diff jedes Pull Requests und fordert Änderungen an oder hinterlässt Kommentare. Klicken, um ihn für dieses Repository auszuschalten.",
+  "gitrail_critic_off_title": "Kritiker ist aus: Anschalten, damit ein automatischer Reviewer den Diff jedes Pull Requests prüft und Änderungen anfordert oder Kommentare hinterlässt. Klicken, um ihn für dieses Repository einzuschalten.",
   "gitrail_send_review": "↩ Review an Agent",
   "gitrail_review_sent": "gesendet ✓",
   "gitrail_send_review_failed": "Senden fehlgeschlagen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -72,6 +72,8 @@
   "gitrail_critic_reviewing": "🔍 Reviewing…",
   "gitrail_critic_reviewing_aria": "Critic is reviewing this pull request",
   "gitrail_critic_toggle_aria": "Toggle critic review for this repository",
+  "gitrail_critic_on_title": "Critic is on: an automated reviewer inspects each pull request's diff and requests changes or leaves comments. Click to turn it off for this repository.",
+  "gitrail_critic_off_title": "Critic is off: turn it on to have an automated reviewer inspect each pull request's diff and request changes or leave comments. Click to turn it on for this repository.",
   "gitrail_send_review": "↩ Send review to agent",
   "gitrail_review_sent": "sent ✓",
   "gitrail_send_review_failed": "send failed",

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -195,7 +195,11 @@
             ? m.gitrail_critic_reviewing_aria()
             : m.gitrail_critic_toggle_aria()}
           aria-busy={reviewing}
-          title={reviewing ? m.gitrail_critic_reviewing_aria() : undefined}
+          title={reviewing
+            ? m.gitrail_critic_reviewing_aria()
+            : criticOn
+              ? m.gitrail_critic_on_title()
+              : m.gitrail_critic_off_title()}
           onclick={() => repoConfig.toggle(repoPath)}
         >
           {#if reviewing}<span class="rev-dot" aria-hidden="true"></span>{/if}


### PR DESCRIPTION
## What

The terminal's top-right **Critic on/off** toggle (`🔍 Kritiker an/aus`) had no tooltip in its idle on/off state — only while actively reviewing. Desktop users hovering the button couldn't learn what it does.

This adds a state-aware `title` tooltip that explains the critic is an automated PR reviewer (inspects each PR's diff, requests changes or comments) and what clicking will do.

## Changes

- `ui/messages/{en,de}.json`: new keys `gitrail_critic_on_title` / `gitrail_critic_off_title` (EN + DE, catalogs in parity)
- `ui/src/lib/components/GitRail.svelte`: `title` now resolves to the explanatory text in the idle state, keeping the "Reviewing…" hint while a review runs

## Checks

- `cd ui && bun run check:i18n` ✓ (2 locales, 264 keys each, in parity)
- `cd ui && bun run check` ✓ (0 errors, 0 warnings)