### PR TITLE
fix(viewport): unify "needs you" call-out with TopBar badge

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -162,7 +162,7 @@
   "triage_open_console_aria": "Volle Konsole von {desig} öffnen",
   "viewport_back_aria": "Zurück zum Herd",
   "viewport_back_button": "‹ Herd",
-  "viewport_next_needs_you": "Wartet ›",
+  "viewport_next_needs_you": "Wartet · {count}",
   "viewport_next_needs_you_aria": "Zur nächsten Sitzung springen, die auf deine Antwort wartet",
   "viewport_queue_prev_aria": "Vorherige wartende Session",
   "viewport_queue_next_aria": "Nächste wartende Session",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -162,7 +162,7 @@
   "triage_open_console_aria": "Open the full console for {desig}",
   "viewport_back_aria": "Back to herd",
   "viewport_back_button": "‹ Herd",
-  "viewport_next_needs_you": "Needs you ›",
+  "viewport_next_needs_you": "Needs you · {count}",
   "viewport_next_needs_you_aria": "Jump to the next session waiting for your reply",
   "viewport_queue_prev_aria": "Previous waiting session",
   "viewport_queue_next_aria": "Next waiting session",

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -587,12 +587,17 @@
     {#if onnextneedsyou && nextNeedsYou > 0}
       <button
         class="next-yu"
+        class:compact
         type="button"
         onclick={onnextneedsyou}
         aria-label={m.viewport_next_needs_you_aria()}
       >
-        {m.viewport_next_needs_you()}
-        <span class="nyu-count">{nextNeedsYou}</span>
+        {#if compact}
+          <span class="ny-icon" aria-hidden="true">!</span><span class="ny-n">{nextNeedsYou}</span>
+        {:else}
+          {m.viewport_next_needs_you({ count: nextNeedsYou })}
+        {/if}
+        <span class="nyu-arrow" aria-hidden="true">›</span>
       </button>
     {/if}
     {#if showQueueNav}
@@ -1240,35 +1245,46 @@
   .back:hover {
     background: var(--color-hover);
   }
-  /* amber accent: this jumps to a session that's actively waiting on the operator */
+  /* red highlight: mirrors the TopBar "needs you" badge — jumps to the next session
+     actively waiting on the operator. */
   .next-yu {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    background: transparent;
-    border: 1px solid var(--color-amber);
-    border-radius: 2px;
-    color: var(--color-amber);
+    background: color-mix(in srgb, var(--color-red) 18%, transparent);
+    border: 1px solid var(--color-red);
+    color: var(--color-red);
     font: inherit;
     font-size: 11px;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.14em;
     padding: 4px 9px;
     cursor: pointer;
     flex-shrink: 0;
-    box-shadow: inset 0 0 18px -12px var(--color-amber);
+    white-space: nowrap;
   }
   .next-yu:hover {
-    background: var(--color-hover);
+    background: color-mix(in srgb, var(--color-red) 28%, transparent);
   }
-  .nyu-count {
-    font-size: 10px;
+  .nyu-arrow {
+    font-size: 13px;
     line-height: 1;
-    min-width: 15px;
-    text-align: center;
-    padding: 2px 4px;
-    border-radius: 999px;
-    background: var(--color-amber);
-    color: var(--color-bg);
+    letter-spacing: 0;
+  }
+  /* phone/touch: collapse to an icon+count chip (full label drops to the aria-label),
+     matching the TopBar compact badge instead of carrying the full word. */
+  .next-yu.compact {
+    justify-content: center;
+    gap: 4px;
+    min-width: 40px;
+    letter-spacing: 0;
+    font-variant-numeric: tabular-nums;
+  }
+  .next-yu.compact .ny-icon {
+    font-weight: 700;
+    line-height: 1;
+  }
+  .next-yu.compact .ny-n {
+    font-weight: 600;
   }
 
   /* ‹ n/total › paging through the "needs you" queue — compact layouts only */


### PR DESCRIPTION
## What

The "needs you" call-out in the detail-pane (Viewport) header was styled out of step with the TopBar badge:

- **amber**, while the overview badge is **red**
- showed the **full label even on mobile**, while the TopBar collapses to an icon+count chip

This unifies the detail-pane control with the TopBar's red highlight.

## Changes

- Recolor `.next-yu` amber → **red**, matching the TopBar badge's tint (`color-mix(red 18%)`), border, tracking, and square corners (drops the amber glow).
- Drop the count *pill* in favor of inline `· {count}`, mirroring the overview's `NEEDS YOU · {count}`.
- On phone/touch, collapse to the same `! n` chip the TopBar uses (full label → `aria-label`).
- Keep the trailing `›` (now literal markup, language-agnostic) so the **jump-to-next** meaning survives the collapse — that's what distinguishes it from the triage badge.
- i18n: `viewport_next_needs_you` `"Needs you ›"` → `"Needs you · {count}"` (`"Wartet ›"` → `"Wartet · {count}"`); arrow moved out of the string.

Result: desktop `Needs you · 3 ›`, mobile `! 3 ›` — visually a sibling of the TopBar's `NEEDS YOU · 3` / `! 3`.

## Verification

- `check:i18n`: 2 locales in parity (262 keys)
- `svelte-check`: 0 errors, 0 warnings
- prettier: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)