### PR TITLE
fix(steer): one-touch Send-review-to-agent — submit with a separate CR

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -129,11 +129,20 @@ export class SessionService {
     return this.deps.store.get(id);
   }
 
-  /** Type a reply into a session's live PTY (human-style steer). Returns false if unknown. */
+  /**
+   * Steer a session's live PTY (human-style): type the text, then submit it with
+   * a SEPARATE carriage return. The split is deliberate — herdr writes each `send`
+   * as one PTY chunk, so a multi-line steer (e.g. a pasted-in code review) glued to
+   * a trailing "\r" lands in Claude Code's input as a single paste-buffered blob and
+   * the CR is absorbed as just another newline, leaving the message typed-but-unsent.
+   * A discrete second write arrives as its own stdin chunk and registers as Enter, so
+   * one click both delivers and submits. Returns false if unknown.
+   */
   reply(id: string, text: string): boolean {
     const s = this.deps.store.get(id);
     if (!s) return false;
-    this.deps.herdr.send(s.herdrAgentId, text + "\r");
+    this.deps.herdr.send(s.herdrAgentId, text);
+    this.deps.herdr.send(s.herdrAgentId, "\r");
     return true;
   }
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -484,7 +484,7 @@ test("resume returns null for unknown, archived, or pre-feature sessions", () =>
   expect(svc.resume(preFeature.id)).toBeNull(); // nothing pinned to resume
 });
 
-test("reply types the text plus Enter into the agent's PTY", () => {
+test("reply types the text, then submits with a separate carriage return", () => {
   const sent: { target: string; text: string }[] = [];
   const store = new SessionStore(":memory:");
   const s = store.create({
@@ -511,7 +511,12 @@ test("reply types the text plus Enter into the agent's PTY", () => {
   });
 
   expect(svc.reply(s.id, "1")).toBe(true);
-  expect(sent).toEqual([{ target: "term_z", text: "1\r" }]);
+  // Enter is a discrete second write so Claude Code submits it instead of
+  // absorbing the CR into a paste-buffered multi-line blob.
+  expect(sent).toEqual([
+    { target: "term_z", text: "1" },
+    { target: "term_z", text: "\r" },
+  ]);
   expect(svc.reply("nope", "1")).toBe(false);
 });
 
@@ -547,7 +552,9 @@ test("broadcast fans the text out to known sessions, skips unknown ids", () => {
   const res = svc.broadcast([a.id, "ghost", b.id], "run tests");
   expect(res).toEqual({ sent: 2, total: 3 });
   expect(sent).toEqual([
-    { target: "term_a", text: "run tests\r" },
-    { target: "term_b", text: "run tests\r" },
+    { target: "term_a", text: "run tests" },
+    { target: "term_a", text: "\r" },
+    { target: "term_b", text: "run tests" },
+    { target: "term_b", text: "\r" },
   ]);
 });


### PR DESCRIPTION
## Problem
**Send review to agent** typed the review into the agent's prompt but left it **unsent** — you still had to press Enter yourself. Not one-touch.

## Cause
`service.reply` sent `text + "\r"` as a **single** herdr `agent send`. herdr writes each `send` as one PTY chunk, so Claude Code read the whole multi-line review as one paste-buffered blob and the trailing `\r` was absorbed as just another newline in the input box — typed, not submitted.

## Fix
Send the body and the carriage return as **two separate** `send` calls. The lone `\r` arrives as its own stdin chunk → registers as a discrete Enter → submits. No wall-clock delay needed; the chunk boundary is what makes Claude Code treat it as Enter rather than paste content.

```ts
this.deps.herdr.send(s.herdrAgentId, text);
this.deps.herdr.send(s.herdrAgentId, "\r");
```

One click now both delivers **and** runs the review. The shared `reply` path means broadcast steers and the blocked-triage one-tap reply get the same reliable submission. No UI change — the button already sent the full review text.

## Verification
- `bun test ./test` → 449 pass / 0 fail
- `bun run lint` clean · `bunx tsc --noEmit` clean
- Updated `service.test.ts` reply + broadcast to the two-write contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)