### PR TITLE
fix(gitrail): wrap whole buttons on mobile instead of squeezing labels

### DIFF
--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -143,7 +143,7 @@
 </script>
 
 {#if git}
-  <span class="git-rail-wrap">
+  <span class="git-rail-wrap" class:mobile>
     <span class="rail" class:mobile>
       {#if git.state === "none"}
         <button class="gbtn" type="button" disabled={busy} onclick={startPr}
@@ -275,6 +275,7 @@
     font-size: 10.5px;
     letter-spacing: 0.08em;
     padding: 2px 8px;
+    white-space: nowrap;
     cursor: pointer;
     transition:
       border-color 0.12s,
@@ -327,9 +328,19 @@
     color: var(--color-amber);
   }
 
-  /* touch layouts: bigger tap targets + readable PR link/dot */
+  /* touch layouts: bigger tap targets + readable PR link/dot. fill the strip and
+     wrap whole buttons onto a new right-aligned row, rather than letting a single
+     nowrap rail overflow and squeeze button labels across lines */
+  .git-rail-wrap.mobile {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
   .rail.mobile {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     gap: 10px;
+    row-gap: 8px;
   }
   .rail.mobile .gbtn {
     min-height: 40px;


### PR DESCRIPTION
## Problem

With all git-rail actions active (PR link · CI dot · Merge · Critic · Send review to agent), the mobile git strip wrapped awkwardly — button labels broke mid-text (e.g. "↩ Send review / to agent").

## Cause

`.vp-git-strip` declared `flex-wrap: wrap`, but its only child was `.rail` — a `nowrap` `inline-flex`. So the strip's wrap never engaged: the rail overflowed and buttons shrank, breaking their labels across lines.

## Fix (CSS only)

- `.gbtn { white-space: nowrap }` — labels never break mid-text.
- On mobile: `.git-rail-wrap` fills the strip and `.rail` becomes `flex-wrap: wrap; justify-content: flex-end` — whole buttons wrap onto a clean, right-aligned second row.

Desktop is untouched (that mount gets no `mobile` prop).

## Validation

- `cd ui && bun run check` → 0 errors
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)