### PR TITLE
feat(ui): show in-progress critic badge in session list

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -186,6 +186,8 @@
   "criticbadge_commented": "✓ GEPRÜFT",
   "criticbadge_error": "REVIEW-FEHLER",
   "criticbadge_title": "Kritiker-Review für diesen PR-Stand",
+  "criticbadge_reviewing": "PRÜFT…",
+  "criticbadge_reviewing_title": "Kritiker prüft diese Sitzung",
   "viewport_decommission_title": "Agent stoppen + Worktree entfernen",
   "viewport_confirm_decommission": "bestätigen ✕",
   "viewport_decommission": "✕ stilllegen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -186,6 +186,8 @@
   "criticbadge_commented": "✓ REVIEWED",
   "criticbadge_error": "REVIEW ERR",
   "criticbadge_title": "Critic review for this PR head",
+  "criticbadge_reviewing": "REVIEWING…",
+  "criticbadge_reviewing_title": "Critic is reviewing this session",
   "viewport_decommission_title": "stop agent + remove worktree",
   "viewport_confirm_decommission": "confirm ✕",
   "viewport_decommission": "✕ decommission",

--- a/ui/src/lib/components/CriticBadge.svelte
+++ b/ui/src/lib/components/CriticBadge.svelte
@@ -4,11 +4,16 @@
   import { m } from "$lib/paraglide/messages";
 
   let { sessionId }: { sessionId: string } = $props();
+  const reviewing = $derived(reviews.isReviewing(sessionId));
   const verdict = $derived(reviews.map[sessionId]);
   const label = $derived(criticBadgeLabel(verdict));
 </script>
 
-{#if label}
+{#if reviewing}
+  <span class="critic-badge critic-reviewing" title={m.criticbadge_reviewing_title()}>
+    <span class="rev-dot" aria-hidden="true"></span>{m.criticbadge_reviewing()}
+  </span>
+{:else if label}
   <span
     class="critic-badge critic-{verdict!.decision}"
     title={verdict!.summary || m.criticbadge_title()}>{label}</span
@@ -35,5 +40,35 @@
   }
   .critic-error {
     color: var(--color-faint);
+  }
+  /* critic actively reviewing: amber outline + pulsing dot (mirrors GitRail) */
+  .critic-reviewing {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+  .rev-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-amber);
+    animation: rev-pulse 1.1s ease-in-out infinite;
+  }
+  @keyframes rev-pulse {
+    0%,
+    100% {
+      opacity: 0.3;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .rev-dot {
+      animation: none;
+      opacity: 0.9;
+    }
   }
 </style>


### PR DESCRIPTION
## Problem

The session list only showed a critic badge once the review **finished** (`✓ REVIEWED` / `⚠ CHANGES` / `REVIEW ERR`). The in-progress *"Reviewing…"* indicator existed solely in `GitRail` (the detail pane), so from the list you couldn't tell a critic run was underway.

## Fix

`CriticBadge.svelte` now reads `reviews.isReviewing(sessionId)` (the store already tracked it) and renders an amber, pulsing-dot **`REVIEWING…`** badge while a run is in flight, falling back to the verdict label once it lands. Styling + `prefers-reduced-motion` handling mirror GitRail's `.rev-dot`.

## i18n

Added `criticbadge_reviewing` + `criticbadge_reviewing_title` to both `en.json` and `de.json`.

## Validation

- `check:i18n` — 250 keys in parity
- `svelte-check` — 0 errors
- UI tests — 115 pass
- prettier/eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)