### PR TITLE
feat(ui): show CI status dot in session list PR badge

### DIFF
--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -1,16 +1,33 @@
 <script lang="ts">
   import type { GitState } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
   import { prBadgeLabel } from "./pr-badge";
 
   let { git }: { git?: GitState } = $props();
   const label = $derived(prBadgeLabel(git));
+  // CI only matters on an open PR; `none` means no checks reported.
+  const showCi = $derived(git?.state === "open" && git.checks !== "none");
 </script>
 
 {#if label}
-  <span class="pr-badge pr-{git!.state}">{label}</span>
+  <span class="pr-wrap">
+    <span class="pr-badge pr-{git!.state}">{label}</span>
+    {#if showCi}
+      <span
+        class="dot dot-{git!.checks}"
+        title={m.gitrail_ci_status({ status: git!.checks })}
+        aria-label={m.gitrail_ci_status({ status: git!.checks })}
+      ></span>
+    {/if}
+  </span>
 {/if}
 
 <style>
+  .pr-wrap {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
   .pr-badge {
     font-size: 10px;
     letter-spacing: 0.12em;
@@ -31,5 +48,23 @@
   .pr-none,
   .pr-closed {
     color: var(--color-faint);
+  }
+
+  /* mirrors GitRail's CI dot so the list reads the same as the detail panel */
+  .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    display: inline-block;
+    background: var(--color-faint);
+  }
+  .dot-pending {
+    background: var(--color-amber);
+  }
+  .dot-success {
+    background: var(--color-blue, #4a90d9);
+  }
+  .dot-failure {
+    background: var(--color-red, #d9534f);
   }
 </style>


### PR DESCRIPTION
## What

Surfaces CI status in the session list. `git.checks` already reached the client and was stored, but only the detailed `GitRail` side panel rendered the CI dot — list rows (via `PrBadge`, shared by `UnitRow` + `UnitTile`) showed only PR state.

`PrBadge` now renders a CI dot next to the PR label when the PR is **open** and checks exist (`checks !== "none"`), reusing GitRail's exact dot styling (amber=pending, blue=success, red=failure).

## Notes

- No server changes — data flow was already complete.
- No new i18n keys: reuses existing `gitrail_ci_status` for `title`/`aria-label`; locale parity preserved.
- `svelte-check` 0 errors, `check:i18n` parity, 115 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)