### PR TITLE
fix(push): suppress active-app banners server-side (works on Android)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { validateRoot } from "./dirs";
 import { UpdateService } from "./update";
 import { HerdrUpdateService } from "./herdr-update";
 import { PushService, attachPush, attachReviewPush } from "./push";
+import { Presence } from "./presence";
 import { ReviewService } from "./review";
 import { CountsService } from "./backlog";
 import { execFileSync } from "node:child_process";
@@ -65,8 +66,11 @@ const poller = new StatusPoller(
 );
 poller.start();
 
-// background Web Push: turn F3 state events into notifications for subscribed devices
-const push = new PushService(store);
+// background Web Push: turn F3 state events into notifications for subscribed devices.
+// Suppress while any window is actively in use — clients report focus/visibility
+// over /events into `presence`, and the push gate reads it.
+const presence = new Presence();
+const push = new PushService(store, undefined, undefined, undefined, () => presence.isActive());
 attachPush(events, store, push);
 
 // poll PR status for active sessions every 120s; push session:git on change so
@@ -166,6 +170,7 @@ const server = serve(
     resolveForge: (dir) => detectForge(dir, config.forges),
     prCache: prPoller,
     push,
+    presence,
     poller,
     reviewCache: {
       snapshot: () => reviewService.snapshot(),

--- a/src/presence.ts
+++ b/src/presence.ts
@@ -1,0 +1,25 @@
+// Tracks which connected clients are *actively in use* (a focused, visible
+// window) so push delivery can suppress OS banners while the live UI is already
+// showing the change. Focus/visibility is reported by the page over the /events
+// socket — page-context APIs are reliable across platforms, unlike a service
+// worker's WindowClient.focused, which mis-reports on Android.
+
+export class Presence {
+  private active = new Set<object>();
+
+  /** Record a client's active state. `client` is any stable per-connection key. */
+  set(client: object, active: boolean): void {
+    if (active) this.active.add(client);
+    else this.active.delete(client);
+  }
+
+  /** Forget a client entirely (call on disconnect). */
+  drop(client: object): void {
+    this.active.delete(client);
+  }
+
+  /** True while at least one client is actively in use. */
+  isActive(): boolean {
+    return this.active.size > 0;
+  }
+}

--- a/src/push.ts
+++ b/src/push.ts
@@ -103,6 +103,8 @@ export class PushService {
     private send: SendFn = defaultSend,
     genKeys: GenKeys = () => webpush.generateVAPIDKeys(),
     private now: () => number = () => Date.now(),
+    /** True while a window is actively in use; such pushes are suppressed. */
+    private isActive: () => boolean = () => false,
   ) {
     let pub = config.vapidPublic ?? store.getSetting("vapidPublic");
     let priv = config.vapidPrivate ?? store.getSetting("vapidPrivate");
@@ -142,6 +144,12 @@ export class PushService {
   }
 
   async notify(input: NotifyInput): Promise<void> {
+    // Suppress while the app is actively in use: the live UI already surfaces
+    // every status change, so an OS banner is pure noise. Decided server-side —
+    // by simply not sending — because a service worker can't reliably drop a
+    // push under userVisibleOnly:true (Android substitutes its own banner). We
+    // don't touch the cooldown clock here: nothing was sent.
+    if (this.isActive()) return;
     const cooldownMs = config.pushCooldownMs;
     const key = `${input.kind}:${input.sessionId}`;
     const t = this.now();

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import type { HerdrDriver } from "./herdr";
 import type { GitForge, GitState, MergeMethod } from "./forge/types";
 import type { PrCache } from "./pr-poller";
 import type { PushService } from "./push";
+import type { Presence } from "./presence";
 import type { StatusPoller } from "./poller";
 import type { CountsService } from "./backlog";
 import { join, normalize } from "node:path";
@@ -77,6 +78,8 @@ export interface AppDeps {
   prCache?: PrCache;
   /** Web Push delivery; absent in tests that don't exercise notifications. */
   push?: Pick<PushService, "publicKey" | "subscribe" | "unsubscribe">;
+  /** Active-window tracker fed by /events presence frames; gates push suppression. */
+  presence?: Pick<Presence, "set" | "drop">;
   /** Status poller; used to manually dismiss a stall flag. Absent in tests. */
   poller?: Pick<StatusPoller, "acknowledgeStall">;
   /** Snapshot of critic verdicts keyed by session id (+ in-flight run ids); absent in tests that skip it. */
@@ -906,12 +909,24 @@ export function serve(deps: AppDeps, port: number) {
         }
       },
       message(ws, msg) {
-        if (ws.data.kind !== "pty") return;
+        if (ws.data.kind === "events") {
+          // Presence frame: the page reports focus+visibility so push delivery
+          // can suppress OS banners while a window is actively in use.
+          try {
+            const m = JSON.parse(typeof msg === "string" ? msg : msg.toString());
+            if (m?.type === "presence") deps.presence?.set(ws, !!m.active);
+          } catch {
+            /* ignore malformed frames */
+          }
+          return;
+        }
         ws.data.bridge?.write(typeof msg === "string" ? msg : msg.toString());
       },
       close(ws) {
-        if (ws.data.kind === "events") (ws.data as any).unsub?.();
-        else {
+        if (ws.data.kind === "events") {
+          (ws.data as any).unsub?.();
+          deps.presence?.drop(ws);
+        } else {
           // only drop ownership if we're still the owner (a newer client may have
           // already claimed this terminal before our close fired)
           if (ptyOwners.get(ws.data.terminalId) === ws) ptyOwners.delete(ws.data.terminalId);

--- a/test/presence.test.ts
+++ b/test/presence.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test";
+import { Presence } from "../src/presence";
+
+test("a fresh tracker reports no active client", () => {
+  expect(new Presence().isActive()).toBe(false);
+});
+
+test("set(client, true) makes the tracker active; false clears it", () => {
+  const p = new Presence();
+  const a = {};
+  p.set(a, true);
+  expect(p.isActive()).toBe(true);
+  p.set(a, false);
+  expect(p.isActive()).toBe(false);
+});
+
+test("isActive is true while ANY client is active", () => {
+  const p = new Presence();
+  const a = {};
+  const b = {};
+  p.set(a, true);
+  p.set(b, false);
+  expect(p.isActive()).toBe(true); // a still active
+  p.set(a, false);
+  expect(p.isActive()).toBe(false); // both inactive now
+});
+
+test("drop removes a client even if it was active (disconnect)", () => {
+  const p = new Presence();
+  const a = {};
+  p.set(a, true);
+  p.drop(a);
+  expect(p.isActive()).toBe(false);
+});

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -64,6 +64,39 @@ test("notify sends to all subscriptions", async () => {
   expect(sent[0]).toContain('"title":"T — waiting"');
 });
 
+test("notify suppresses every send while a client reports it is active", async () => {
+  let count = 0;
+  const send: SendFn = async () => {
+    count++;
+    return {};
+  };
+  const store = new SessionStore(":memory:");
+  // 5th arg: presence gate — the app is in active use, so the live UI already
+  // shows this; an OS banner would be noise (and a SW can't drop it on Android).
+  const push = new PushService(store, send, keys, undefined, () => true);
+  store.putPushSub(sub("e1"), "");
+  await push.notify({ kind: "done", sessionId: "s1", tag: "s1", name: "T" });
+  await push.notify({ kind: "blocked", sessionId: "s2", tag: "s2", name: "T" });
+  expect(count).toBe(0);
+});
+
+test("notify sends normally once no client is active", async () => {
+  let active = true;
+  let count = 0;
+  const send: SendFn = async () => {
+    count++;
+    return {};
+  };
+  const store = new SessionStore(":memory:");
+  const push = new PushService(store, send, keys, undefined, () => active);
+  store.putPushSub(sub("e1"), "");
+  await push.notify({ kind: "done", sessionId: "s1", tag: "s1", name: "T" });
+  expect(count).toBe(0); // suppressed while active
+  active = false;
+  await push.notify({ kind: "done", sessionId: "s1", tag: "s1", name: "T" });
+  expect(count).toBe(1); // flows once active clears
+});
+
 test("notify prunes a subscription that returns 410", async () => {
   const send: SendFn = async (s) => {
     if (s.endpoint === "dead") throw Object.assign(new Error("gone"), { statusCode: 410 });

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -119,9 +119,24 @@ export class HerdStore {
   connect(makeWs: () => WebSocket = () => new WebSocket(wsUrl("/events"))): () => void {
     let ws: WebSocket | null = null;
     let stopped = false;
+    // Report whether this window is actively in use so the server can suppress
+    // push banners while it is (the live UI already shows the change). Page-context
+    // focus+visibility is reliable on Android, unlike a SW's WindowClient.focused.
+    const active = () =>
+      typeof document !== "undefined" &&
+      document.visibilityState === "visible" &&
+      document.hasFocus();
+    const reportPresence = () => {
+      if (ws?.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "presence", active: active() }));
+      }
+    };
     const open = () => {
       ws = makeWs();
-      ws.onopen = () => (this.connected = true);
+      ws.onopen = () => {
+        this.connected = true;
+        reportPresence();
+      };
       ws.onmessage = (e) => {
         try {
           this.apply(JSON.parse(e.data));
@@ -135,9 +150,19 @@ export class HerdStore {
       };
       ws.onerror = () => ws?.close();
     };
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", reportPresence);
+      window.addEventListener("focus", reportPresence);
+      window.addEventListener("blur", reportPresence);
+    }
     open();
     return () => {
       stopped = true;
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", reportPresence);
+        window.removeEventListener("focus", reportPresence);
+        window.removeEventListener("blur", reportPresence);
+      }
       ws?.close();
     };
   }

--- a/ui/static/sw.js
+++ b/ui/static/sw.js
@@ -25,30 +25,12 @@ self.addEventListener("push", (event) => {
       // event settle (which on mobile yields the browser's generic banner).
       const title = payload.title || "Shepherd";
 
-      // The in-app UI already surfaces every status change live, so an OS banner is
-      // pure noise while the user is actively in the app. Suppress whenever any window
-      // is focused AND visible. `focused` is the reliable "working here right now"
-      // signal — browsers don't report occlusion, so visibility alone would wrongly
-      // suppress a window buried behind another app. Requiring both keeps banners
-      // flowing when the app is minimized, in the background, or on an unfocused
-      // second monitor — exactly when push is useful.
-      //
-      // Desktop only: on mobile, a worker that receives a push without showing a
-      // notification gets the browser's generic banner instead — strictly worse
-      // than our real one — so mobile always shows. (#121 follow-up.)
-      //
-      // UA sniffing is the only signal available here — WorkerNavigator exposes no
-      // maxTouchPoints, so iPadOS in desktop mode (Macintosh UA) isn't detected and
-      // would still suppress when in-use. Negligible: iOS/iPadOS only delivers Web
-      // Push to an installed PWA, and the failure mode is a missed banner, not a bad one.
-      const ua = self.navigator && self.navigator.userAgent ? self.navigator.userAgent : "";
-      const isMobile = /Android|iPhone|iPad|iPod|Mobile/i.test(ua);
-      if (!isMobile) {
-        const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
-        const inUse = clients.some((c) => c.focused && c.visibilityState === "visible");
-        if (inUse) return;
-      }
-
+      // Always show — on every platform. Suppression-while-active is decided
+      // server-side (the server doesn't send a push while any window reports it's
+      // in use, via /events presence), so every push that reaches here is meant to
+      // be shown. A worker can't reliably drop a push under userVisibleOnly anyway:
+      // the browser substitutes its own generic banner, so suppressing here would
+      // be worse than useless on mobile. (Supersedes the SW-side gate of #121/#126.)
       const opts = {
         body: body ?? "",
         tag: tag ?? sessionId,


### PR DESCRIPTION
## Problem

Push banners fired on Android **while the app was actively in use**, despite the suppress-while-active feature. Root cause: #121 suppressed inside the service worker with `c.focused && c.visibilityState === "visible"`, but **`WindowClient.focused` is unreliable in a push handler on Android** — it reports `false` even for a foreground PWA, so nothing was ever suppressed. #126 worked around this by UA-sniffing and **always showing on mobile** — i.e. it gave up active-suppression on mobile entirely (a silent push otherwise triggers Android's generic `userVisibleOnly` fallback banner).

## Fix — decide it server-side

Suppression can't be done reliably in the SW under `userVisibleOnly: true`. So move the decision to where it can't be overridden by the platform: **don't send the push at all while a window is active.**

- **`src/presence.ts`** (new) — `Presence` tracker; `isActive()` true while any client reports an active (focused + visible) window.
- **`src/push.ts`** — `PushService.notify()` returns early while `isActive()` (gate before send; cooldown clock untouched since nothing was sent).
- **`ui/src/lib/store.svelte.ts`** — the page reports `{type:"presence", active}` over the existing `/events` socket on connect and on every `visibilitychange`/`focus`/`blur`. Page-context `document.hasFocus()` + `visibilityState` are reliable on Android (and correctly treat an occluded/unfocused desktop window as inactive).
- **`src/server.ts`** — `/events` WS parses presence frames → `presence.set(ws, …)`, and `drop(ws)` on disconnect.
- **`src/index.ts`** — wires `presence` into both the push gate and the WS.
- **`ui/static/sw.js`** — now **always** shows on every platform (keeps #126's hardened parse / title fallback / showNotification retry / badge-96). The SW-side suppression gate is removed — every push reaching the worker is meant to be shown, which also satisfies `userVisibleOnly` cleanly.

**Supersedes #126's mobile-always-show compromise** — mobile now actually suppresses while active.

### Tradeoff
Global: if **any** window (e.g. a focused desktop tab) is active, **all** devices stay silent — including a backgrounded phone. (Chosen deliberately over per-device presence.)

## Verification
- Root: `tsc` clean · **459 tests pass** (added `test/presence.test.ts` + 2 push-gate tests, TDD red→green) · branch hygiene linear.
- UI: `svelte-check` 0 errors · **139 tests pass** · i18n parity (no new strings).
- `eslint` + prettier clean.

**Residual risk:** the WS↔presence glue (server `message`/`close` handlers) has no automated integration test — the existing harness only exercises HTTP routes. Core logic (`Presence` + the gate) is unit-tested; the glue is thin and type-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)