### PR TITLE
fix(ui): move PR CI dot left of badge so right column aligns

### DIFF
--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -11,7 +11,6 @@
 
 {#if label}
   <span class="pr-wrap">
-    <span class="pr-badge pr-{git!.state}">{label}</span>
     {#if showCi}
       <span
         class="dot dot-{git!.checks}"
@@ -19,6 +18,7 @@
         aria-label={m.gitrail_ci_status({ status: git!.checks })}
       ></span>
     {/if}
+    <span class="pr-badge pr-{git!.state}">{label}</span>
   </span>
 {/if}
 


### PR DESCRIPTION
## What

In the session list (`UnitRow`), `.u-right` is a right-aligned column — every row's right edge lines up against the column edge. The PR badge was the exception: `PrBadge` rendered `[badge] gap [dot]`, so the **dot** hit the column edge and the badge sat inset by 12px (7px dot + 5px gap) from the status badge / elapsed / meta below it. That inset made the card's right block read as ragged.

## Fix

Reorder `PrBadge` to `[dot] gap [badge]`. The badge's right edge now aligns with everything else in the column; the CI dot tucks into the existing 12px grid gap on its left. `align-items: center` on `.pr-wrap` still vertically centers the dot.

GitRail (detail panel) keeps dot-after-link — it's a left-aligned horizontal strip where that flow reads naturally. This is the context-correct mirror for the right-aligned list.

Markup-only reorder: no new strings, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)