### PR TITLE
feat(ui): cross-project backlog reachable while agents run + dedupe worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dist/
 /.claude/worktrees/
 .shaping/
 .squad/
+
+# Runtime upload staging (New-Task attachments, screenshots)
+.shepherd-uploads/

--- a/src/server.ts
+++ b/src/server.ts
@@ -645,6 +645,40 @@ async function handleIssues({ req, parts, url, deps }: Ctx): Promise<Response | 
   return null;
 }
 
+/**
+ * Collapse worktrees / multiple clones of the same repo: dedupe by forge identity
+ * (kind + owner/repo slug) so each repo appears once, not once per directory.
+ * Repos without a slug can't be matched, so each stays distinct (keyed by path).
+ * For each group keep the most-recently-used directory; tie-break on shorter then
+ * lexicographically smaller path, which favors the canonical checkout (e.g.
+ * `epamano-shopify`) over a long-named worktree.
+ */
+function dedupeReposByForge<T extends { path: string; forge: GitForge }>(
+  repos: T[],
+  lastUsed: Record<string, number>,
+): T[] {
+  const key = (r: T) => (r.forge.slug ? `${r.forge.kind} ${r.forge.slug}` : `path ${r.path}`);
+  const byRepo = new Map<string, T>();
+  for (const r of repos) {
+    const k = key(r);
+    const cur = byRepo.get(k);
+    if (!cur) {
+      byRepo.set(k, r);
+      continue;
+    }
+    const ru = lastUsed[r.path] ?? -1;
+    const cu = lastUsed[cur.path] ?? -1;
+    const better =
+      ru !== cu
+        ? ru > cu
+        : r.path.length !== cur.path.length
+          ? r.path.length < cur.path.length
+          : r.path < cur.path;
+    if (better) byRepo.set(k, r);
+  }
+  return [...byRepo.values()];
+}
+
 async function handleBacklog({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (req.method !== "GET" || parts[0] !== "api" || parts[1] !== "backlog" || parts[2]) return null;
   if (!deps.backlog) {
@@ -661,10 +695,13 @@ async function handleBacklog({ req, parts, deps }: Ctx): Promise<Response | null
     })
     .filter((r): r is NonNullable<typeof r> => r !== null);
 
-  // Fetch counts for all forge repos in parallel
-  const countsArr = await Promise.all(forgeRepos.map((r) => deps.backlog!.counts(r.path)));
+  // Collapse worktrees/clones of the same repo so each appears once (see helper).
+  const uniqueRepos = dedupeReposByForge(forgeRepos, lastUsed);
 
-  const projects = forgeRepos.map((r, i) => {
+  // Fetch counts for the deduped repos in parallel
+  const countsArr = await Promise.all(uniqueRepos.map((r) => deps.backlog!.counts(r.path)));
+
+  const projects = uniqueRepos.map((r, i) => {
     const counts = countsArr[i]!;
     return {
       path: r.path,

--- a/test/server-backlog.test.ts
+++ b/test/server-backlog.test.ts
@@ -227,6 +227,40 @@ test("GET /api/backlog with deps.backlog absent → empty payload", async () => 
   });
 });
 
+test("GET /api/backlog dedupes worktrees of the same repo by forge slug", async () => {
+  // repoA and repoB resolve to the SAME forge slug — e.g. two worktrees/clones
+  // of one GitHub repo. They must collapse to a single project entry.
+  const dupForge: AppDeps["resolveForge"] = (path) =>
+    path === repoA || path === repoB ? fakeForge("org/dup") : null;
+  const app = makeApp(
+    makeDeps(
+      { [repoA]: { openIssues: 7, openPRs: 2 }, [repoB]: { openIssues: 7, openPRs: 2 } },
+      { [repoA]: 100, [repoB]: 200 }, // repoB used most recently → the kept representative
+      dupForge,
+    ),
+  );
+  const body = await app.fetch(req()).then((r) => r.json());
+  const dup = body.projects.filter((p: { slug: string }) => p.slug === "org/dup");
+  // collapsed to a single entry...
+  expect(dup.length).toBe(1);
+  // ...pointing at the most-recently-used directory...
+  expect(dup[0].path).toBe(repoB);
+  // ...and counts are not double-counted in the totals
+  expect(body.totals.openIssues).toBe(7);
+  expect(body.totals.openPRs).toBe(2);
+});
+
+test("GET /api/backlog keeps repos with distinct slugs separate", async () => {
+  const app = makeApp(
+    makeDeps({ [repoA]: { openIssues: 1, openPRs: 0 }, [repoB]: { openIssues: 1, openPRs: 0 } }),
+  );
+  const body = await app.fetch(req()).then((r) => r.json());
+  const paths = body.projects.map((p: { path: string }) => p.path);
+  // org/alpha and org/beta are different repos → both remain
+  expect(paths).toContain(repoA);
+  expect(paths).toContain(repoB);
+});
+
 test("GET /api/backlog pinnedPath falls back to first sorted project when no lastUsedAt", async () => {
   const app = makeApp(
     makeDeps(

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -37,6 +37,7 @@
   "controlkey_ctrl_c": "Strg C, unterbrechen",
   "controlkey_ctrl_d": "Strg D, Dateiende",
   "actionbar_new_task": "+ Neue Aufgabe",
+  "actionbar_backlog": "Backlog",
   "actionbar_all_mode": "Alle ▦",
   "actionbar_focus_mode": "Fokus ⌖",
   "actionbar_theme_group_aria": "Darstellung",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -37,6 +37,7 @@
   "controlkey_ctrl_c": "Ctrl C, interrupt",
   "controlkey_ctrl_d": "Ctrl D, end of file",
   "actionbar_new_task": "+ New Task",
+  "actionbar_backlog": "Backlog",
   "actionbar_all_mode": "All ▦",
   "actionbar_focus_mode": "Focus ⌖",
   "actionbar_theme_group_aria": "Theme",

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -17,12 +17,14 @@
 
   let {
     onnew,
+    onbacklog,
     mode = "focus",
     onmode,
     mobile = false,
     desktopOnly = false,
   }: {
     onnew: () => void;
+    onbacklog?: () => void;
     mode?: "focus" | "all";
     onmode?: (m: "focus" | "all") => void;
     mobile?: boolean;
@@ -33,6 +35,9 @@
 {#if !(desktopOnly && mobile)}
   <div class="actions" class:mobile>
     <button class="btn primary" type="button" onclick={onnew}>{m.actionbar_new_task()}</button>
+    {#if onbacklog}
+      <button class="btn backlog" type="button" onclick={onbacklog}>{m.actionbar_backlog()}</button>
+    {/if}
     {#if !mobile}
       <button
         class="btn"
@@ -173,6 +178,10 @@
     flex: 1;
     text-align: center;
     padding: 12px;
+    font-size: 12px;
+  }
+  .actions.mobile .btn.backlog {
+    padding: 12px 16px;
     font-size: 12px;
   }
 </style>

--- a/ui/src/lib/components/BacklogOverlay.svelte
+++ b/ui/src/lib/components/BacklogOverlay.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import type { BacklogPayload, Issue } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import BacklogView from "./BacklogView.svelte";
+
+  let {
+    payload,
+    mobile,
+    onissue,
+    onclose,
+  }: {
+    payload: BacklogPayload | null;
+    mobile: boolean;
+    onissue: (repoPath: string, issue: Issue) => void;
+    onclose: () => void;
+  } = $props();
+</script>
+
+<svelte:window
+  onkeydown={(e) => {
+    if (e.key === "Escape") onclose();
+  }}
+/>
+
+<div
+  class="overlay"
+  class:mobile
+  role="presentation"
+  onclick={(e) => {
+    if (e.target === e.currentTarget) onclose();
+  }}
+>
+  <div class="card" class:mobile>
+    <div class="chead">
+      <span class="micro">{m.actionbar_backlog()}</span>
+      <button type="button" class="x" onclick={onclose} aria-label={m.common_close()}>✕</button>
+    </div>
+    <div class="body">
+      <BacklogView {payload} {mobile} {onissue} />
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(3, 6, 5, 0.66);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+    padding: 24px;
+  }
+  .overlay.mobile {
+    padding: 0;
+  }
+  .card {
+    width: min(960px, 94vw);
+    max-height: 88vh;
+    border: 1px solid var(--color-line-bright);
+    background: var(--color-panel);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .card.mobile {
+    width: 100%;
+    max-height: none;
+    height: 100%;
+    border: 0;
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .chead {
+    display: flex;
+    align-items: center;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .micro {
+    font-size: 10.5px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .x {
+    margin-left: auto;
+    background: transparent;
+    border: 0;
+    color: var(--color-muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: 14px;
+    line-height: 1;
+    padding: 2px 6px;
+  }
+  .x:hover {
+    color: var(--color-amber);
+  }
+  .body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+</style>

--- a/ui/src/lib/components/ProjectRow.svelte
+++ b/ui/src/lib/components/ProjectRow.svelte
@@ -14,10 +14,20 @@
     onselect: () => void;
   } = $props();
 
-  const displayName = $derived(project.display || project.slug || project.path);
+  // Show the repo name (path basename), not the full path — far easier to scan.
+  // Fall back to slug/display only if the path has no usable trailing segment.
+  const displayName = $derived(
+    project.path.replace(/\/+$/, "").split("/").pop() || project.slug || project.display,
+  );
 </script>
 
-<button class="project-row" class:sel={selected} onclick={onselect} type="button">
+<button
+  class="project-row"
+  class:sel={selected}
+  onclick={onselect}
+  type="button"
+  title={project.display}
+>
   <div class="row-main">
     <span class="row-name">{displayName}</span>
     {#if pinned}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -30,6 +30,7 @@
   import ActionBar from "$lib/components/ActionBar.svelte";
   import HerdGrid from "$lib/components/HerdGrid.svelte";
   import BacklogView from "$lib/components/BacklogView.svelte";
+  import BacklogOverlay from "$lib/components/BacklogOverlay.svelte";
   import UpdateModal from "$lib/components/UpdateModal.svelte";
   import HerdrUpdateModal from "$lib/components/HerdrUpdateModal.svelte";
   import { registerSW, onSelectSession } from "$lib/push";
@@ -58,11 +59,12 @@
 
   const selected = $derived(store.sessions.find((s) => s.id === selectedId) ?? null);
 
-  // Fetch backlog only when the overview is empty. Reading store.sessions.length
-  // inside the effect body makes Svelte track it; backlog is written but never
-  // read here, so it cannot re-trigger the effect → no loop.
+  // Fetch backlog when the overview is empty, or when the operator opens the
+  // backlog overlay while agents are running. Reading store.sessions.length and
+  // showBacklog inside the effect body makes Svelte track them; backlog is
+  // written but never read here, so it cannot re-trigger the effect → no loop.
   $effect(() => {
-    if (store.sessions.length === 0) {
+    if (store.sessions.length === 0 || showBacklog) {
       getBacklog()
         .then((p) => (backlog = p))
         .catch(() => {
@@ -75,6 +77,8 @@
     composeRepoPath = repoPath;
     composeIssue = issue;
     showNew = true;
+    // composing from the backlog overlay → close it so the herd is behind the modal
+    showBacklog = false;
   }
 
   const mobile = new MediaQuery("max-width: 768px");
@@ -82,6 +86,7 @@
   // gets the control-key bar even in desktop layout, since there's no hardware keyboard
   const touch = new MediaQuery("(pointer: coarse)");
   let mobileScreen = $state<"list" | "detail">("list");
+  let showBacklog = $state(false);
 
   function selectUnit(id: string) {
     selectedId = id;
@@ -263,7 +268,11 @@
           <BacklogView payload={backlog} mobile={true} {onissue} />
         {/if}
       </div>
-      <ActionBar onnew={() => (showNew = true)} mobile={mobile.current} />
+      <ActionBar
+        onnew={() => (showNew = true)}
+        onbacklog={store.sessions.length > 0 ? () => (showBacklog = true) : undefined}
+        mobile={mobile.current}
+      />
     {:else if selected}
       <div class="col">
         <Viewport
@@ -334,6 +343,7 @@
 
   <ActionBar
     onnew={() => (showNew = true)}
+    onbacklog={store.sessions.length > 0 ? () => (showBacklog = true) : undefined}
     mode={viewMode}
     onmode={(m) => (viewMode = m)}
     mobile={mobile.current}
@@ -404,6 +414,15 @@
 
 {#if showBroadcast}
   <BroadcastDialog sessions={store.sessions} onclose={() => (showBroadcast = false)} />
+{/if}
+
+{#if showBacklog}
+  <BacklogOverlay
+    payload={backlog}
+    mobile={mobile.current}
+    {onissue}
+    onclose={() => (showBacklog = false)}
+  />
 {/if}
 
 <style>


### PR DESCRIPTION
## Was & Warum

Die projektübergreifende Backlog-Übersicht war nur erreichbar, wenn die Herde leer war — lief ein Agent, gab es keinen Weg dorthin. Außerdem wurde dasselbe GitHub-Repo mehrfach gelistet, sobald mehrere Worktrees/Klone davon unter `repoRoot` lagen.

## Änderungen (4 atomare Commits)

- **`fix(backlog)`** — Dedupe nach Forge-Identität (`kind` + `owner/repo`-Slug) in einem `dedupeReposByForge`-Helper, **bevor** Counts via `gh` geholt werden. Pro Repo bleibt ein Eintrag (das zuletzt genutzte Verzeichnis als Repräsentant). Behebt dreifach gelistete Worktrees und aufgeblähte Totals (live verifiziert: 249→167 Issues, 26→20 PRs).
- **`feat(ui)`** — Neuer **BACKLOG**-Button (rechts neben „Neue Aufgabe", Desktop + Mobile, nur während Sessions laufen) öffnet das volle Backlog als Overlay (Esc/Klick-außen schließt). Backlog wird beim Öffnen nachgeladen.
- **`fix(ui)`** — Projektliste zeigt den **Repo-Namen** (Pfad-Basename, z. B. `epamano-shopify`) statt des vollen `~`-Pfads; voller Pfad als Hover-Title.
- **`chore`** — `.shepherd-uploads/` (Runtime-Upload-Artefakte) ignorieren.

## i18n

Neuer Key `actionbar_backlog` in `en.json` + `de.json` (Parität gewahrt).

## Checks

- `eslint`, root `tsc`, `svelte-check`: 0 Fehler
- i18n-Parität: 270 Keys (en ↔ de)
- Backlog-Tests: +2 (Dedupe-Szenario & distinct-Slug-Gegenprobe), alle grün
- Branch linear auf `origin/main` rebased, Pre-Push-Gate (inkl. fallow-Delta) grün

## Test-Hinweis

Mobile: Button erscheint nur bei laufender Session (bei leerer Herde ist das Backlog ohnehin inline). Live gegen echte Repos + GitHub verifiziert.