### PR TITLE
feat(mobile): swipe session row to decommission with confirm

### DIFF
--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -10,6 +10,7 @@
     onselect,
     onnew,
     git,
+    ondecommission,
   }: {
     sessions: Session[];
     selectedId: string | null;
@@ -17,6 +18,8 @@
     onselect: (id: string) => void;
     onnew: () => void;
     git: Record<string, GitState>;
+    // when provided, rows gain left-swipe-to-decommission (mobile list)
+    ondecommission?: (id: string) => void;
   } = $props();
 </script>
 
@@ -36,6 +39,7 @@
           {nowMs}
           {onselect}
           git={git[session.id]}
+          {ondecommission}
         />
       {/each}
     {/if}

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -69,9 +69,6 @@
   }
 
   const swipeCb: SwipeCallbacks = {
-    get enabled() {
-      return swipe;
-    },
     current: () => offset,
     onOffset: (px) => (offset = px),
     onDragging: (b) => (dragging = b),
@@ -140,7 +137,7 @@
 {/snippet}
 
 {#if swipe}
-  <div class="swipe-wrap">
+  <div class="swipe-wrap" style="--reveal:{REVEAL_PX}px">
     <div class="reveal" aria-hidden={offset === 0}>
       <button
         class="decom"
@@ -201,7 +198,7 @@
   .reveal {
     position: absolute;
     inset: 0 0 0 auto;
-    width: 104px; /* must equal REVEAL_PX in swipe.ts */
+    width: var(--reveal); /* set from REVEAL_PX (swipe.ts) — single source of truth */
     display: flex;
     align-items: stretch;
     justify-content: stretch;

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -1,3 +1,9 @@
+<script module lang="ts">
+  // Single-open invariant across every row: the close-fn of the currently open
+  // row. Opening another row closes this one first.
+  let openRow: (() => void) | null = $state(null);
+</script>
+
 <script lang="ts">
   import type { Session, GitState } from "$lib/types";
   import { elapsed, STATUS_COLOR, statusLabel } from "$lib/format";
@@ -5,6 +11,16 @@
   import PrBadge from "./PrBadge.svelte";
   import CriticBadge from "./CriticBadge.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
+  import { m } from "$lib/paraglide/messages";
+  import { onDestroy } from "svelte";
+  import {
+    REVEAL_PX,
+    snapOffset,
+    pressDecom,
+    swipeGesture,
+    type SwipeCallbacks,
+    type DecomState,
+  } from "./swipe";
 
   let {
     session,
@@ -12,56 +28,144 @@
     nowMs,
     onselect,
     git,
+    ondecommission,
   }: {
     session: Session;
     selected: boolean;
     nowMs: number;
     onselect: (id: string) => void;
     git?: GitState;
+    // when provided, the row gains a left-swipe-to-decommission gesture (mobile)
+    ondecommission?: (id: string) => void;
   } = $props();
 
   // repo the unit works in — the last path segment of its repoPath (e.g. "community-map")
   const repoName = $derived(session.repoPath.split("/").filter(Boolean).at(-1) ?? session.repoPath);
   const repoIcon = $derived(projectIcons.iconFor(session.repoPath));
+
+  const swipe = $derived(!!ondecommission);
+
+  // gesture state
+  let offset = $state(0); // px the row is slid left (negative); 0 = closed
+  let dragging = $state(false); // finger down + tracking x → suppress snap transition
+
+  // arm/confirm state for the revealed action
+  let decom = $state<DecomState>("idle");
+  let armTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function disarm() {
+    clearTimeout(armTimer);
+    decom = "idle";
+  }
+  function close() {
+    offset = 0;
+    disarm();
+    if (openRow === close) openRow = null;
+  }
+  function openReveal() {
+    if (openRow && openRow !== close) openRow();
+    offset = -REVEAL_PX;
+    openRow = close;
+  }
+
+  const swipeCb: SwipeCallbacks = {
+    get enabled() {
+      return swipe;
+    },
+    current: () => offset,
+    onOffset: (px) => (offset = px),
+    onDragging: (b) => (dragging = b),
+    onRelease: () => (snapOffset(offset) === -REVEAL_PX ? openReveal() : close()),
+    requestClose: close,
+  };
+
+  function pressDecommission() {
+    const { state, fire } = pressDecom(decom);
+    decom = state;
+    if (state === "armed") {
+      clearTimeout(armTimer);
+      armTimer = setTimeout(disarm, 3000);
+    }
+    if (fire) {
+      clearTimeout(armTimer);
+      ondecommission?.(session.id);
+      close(); // row will drop from the store; close defensively
+    }
+  }
+
+  onDestroy(() => {
+    clearTimeout(armTimer);
+    if (openRow === close) openRow = null;
+  });
 </script>
 
-<button
-  class="unit"
-  class:sel={selected}
-  style="--rule:{STATUS_COLOR[session.status]}"
-  onclick={() => onselect(session.id)}
-  type="button"
->
-  <div class="pip-col">
-    <StatusPip status={session.status} />
-  </div>
+{#snippet row()}
+  <button
+    class="unit"
+    class:sel={selected}
+    style="--rule:{STATUS_COLOR[session.status]}"
+    onclick={() => onselect(session.id)}
+    type="button"
+  >
+    <div class="pip-col">
+      <StatusPip status={session.status} />
+    </div>
 
-  <div class="u-main">
-    <div class="u-top">
-      <span class="name">{session.name}</span>
+    <div class="u-main">
+      <div class="u-top">
+        <span class="name">{session.name}</span>
+      </div>
+      <div class="u-repo" title={session.repoPath}>
+        <span class="repo-glyph" class:emoji={repoIcon} aria-hidden="true">{repoIcon ?? "▣"}</span
+        >{repoName}
+      </div>
+      <div class="u-sub">
+        {session.prompt}
+        {#if session.status === "running"}
+          <span class="car">▏</span>
+        {/if}
+      </div>
     </div>
-    <div class="u-repo" title={session.repoPath}>
-      <span class="repo-glyph" class:emoji={repoIcon} aria-hidden="true">{repoIcon ?? "▣"}</span
-      >{repoName}
-    </div>
-    <div class="u-sub">
-      {session.prompt}
-      {#if session.status === "running"}
-        <span class="car">▏</span>
-      {/if}
-    </div>
-  </div>
 
-  <div class="u-right">
-    <PrBadge {git} />
-    <CriticBadge sessionId={session.id} />
-    <span class="badge">{statusLabel(session.status)}</span>
-    <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
-    <span class="meta"
-      ><span class="desig">{session.desig}</span> · {session.herdrSession || "—"}</span
+    <div class="u-right">
+      <PrBadge {git} />
+      <CriticBadge sessionId={session.id} />
+      <span class="badge">{statusLabel(session.status)}</span>
+      <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
+      <span class="meta"
+        ><span class="desig">{session.desig}</span> · {session.herdrSession || "—"}</span
+      >
+    </div>
+  </button>
+{/snippet}
+
+{#if swipe}
+  <div class="swipe-wrap">
+    <div class="reveal" aria-hidden={offset === 0}>
+      <button
+        class="decom"
+        class:armed={decom === "armed"}
+        type="button"
+        tabindex={offset === 0 ? -1 : 0}
+        onclick={pressDecommission}
+        title={m.viewport_decommission_title()}
+        aria-label={m.viewport_decommission_aria()}
+      >
+        {decom === "armed" ? m.viewport_confirm_decommission() : m.viewport_decommission()}
+      </button>
+    </div>
+    <div
+      class="slider"
+      class:dragging
+      style="transform:translateX({offset}px)"
+      use:swipeGesture={swipeCb}
     >
+      {@render row()}
+    </div>
   </div>
-</button>
+{:else}
+  {@render row()}
+{/if}
 
 <style>
   .unit {
@@ -81,8 +185,59 @@
     width: 100%;
   }
 
-  :global(.unit + .unit) {
+  :global(.unit + .unit),
+  :global(.swipe-wrap + .swipe-wrap) {
     margin-top: 2px;
+  }
+
+  /* swipe-to-decommission (mobile): the row slides left over a destructive
+     action revealed behind it. */
+  .swipe-wrap {
+    position: relative;
+    overflow: hidden;
+    border-radius: 2px;
+  }
+
+  .reveal {
+    position: absolute;
+    inset: 0 0 0 auto;
+    width: 104px; /* must equal REVEAL_PX in swipe.ts */
+    display: flex;
+    align-items: stretch;
+    justify-content: stretch;
+    background: color-mix(in srgb, var(--color-red) 16%, var(--color-panel));
+  }
+
+  .reveal .decom {
+    flex: 1;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: var(--color-red);
+    font-family: inherit;
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    line-height: 1.3;
+    text-transform: uppercase;
+    cursor: pointer;
+    padding: 6px;
+  }
+  .reveal .decom.armed {
+    background: color-mix(in srgb, var(--color-red) 26%, transparent);
+    color: var(--color-ink-bright);
+    font-weight: 600;
+  }
+
+  .slider {
+    position: relative;
+    background: var(--color-panel);
+    /* vertical pans scroll the list natively; horizontal pans are ours */
+    touch-action: pan-y;
+    transition: transform 0.18s ease;
+    will-change: transform;
+  }
+  .slider.dragging {
+    transition: none;
   }
 
   .unit::before {

--- a/ui/src/lib/components/swipe.test.ts
+++ b/ui/src/lib/components/swipe.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { REVEAL_PX, OPEN_RATIO, lockAxis, clampOffset, snapOffset, pressDecom } from "./swipe";
+
+describe("lockAxis", () => {
+  it("stays unlocked until movement exceeds slop", () => expect(lockAxis(4, 3, 10)).toBeNull());
+  it("locks horizontal when dx dominates past slop", () => expect(lockAxis(20, 3, 10)).toBe("x"));
+  it("locks vertical when dy dominates past slop", () => expect(lockAxis(3, 20, 10)).toBe("y"));
+  it("a vertical-dominant move never locks to x (scroll wins ties toward y)", () =>
+    expect(lockAxis(12, 12, 10)).toBe("y"));
+});
+
+describe("clampOffset", () => {
+  it("clamps rightward drag (positive) to 0 — left-only reveal", () =>
+    expect(clampOffset(40)).toBe(0));
+  it("passes a partial left drag through", () => expect(clampOffset(-30)).toBe(-30));
+  it("clamps past the reveal width", () => expect(clampOffset(-9999)).toBe(-REVEAL_PX));
+});
+
+describe("snapOffset", () => {
+  it("snaps closed below the open ratio", () =>
+    expect(snapOffset(-(REVEAL_PX * OPEN_RATIO) + 1)).toBe(0));
+  it("snaps open at/after the open ratio", () =>
+    expect(snapOffset(-(REVEAL_PX * OPEN_RATIO))).toBe(-REVEAL_PX));
+  it("snaps a full drag open", () => expect(snapOffset(-REVEAL_PX)).toBe(-REVEAL_PX));
+});
+
+describe("pressDecom (arm → confirm)", () => {
+  it("first press arms, does not fire", () =>
+    expect(pressDecom("idle")).toEqual({ state: "armed", fire: false }));
+  it("second press (while armed) fires and resets to idle", () =>
+    expect(pressDecom("armed")).toEqual({ state: "idle", fire: true }));
+});

--- a/ui/src/lib/components/swipe.ts
+++ b/ui/src/lib/components/swipe.ts
@@ -40,8 +40,6 @@ export function snapOffset(
 
 /** Callbacks a host component supplies to drive the swipe action. */
 export interface SwipeCallbacks {
-  /** Gesture is active (false → action is inert). */
-  enabled: boolean;
   /** Current slid offset (px, negative = open). */
   current: () => number;
   /** Live offset during a horizontal drag. */
@@ -70,7 +68,6 @@ export function swipeGesture(node: HTMLElement, callbacks: SwipeCallbacks) {
   let dragged = false; // a horizontal drag occurred in the current pointer sequence
 
   function down(e: PointerEvent) {
-    if (!cb.enabled) return;
     pid = e.pointerId;
     startX = e.clientX;
     startY = e.clientY;
@@ -79,7 +76,7 @@ export function swipeGesture(node: HTMLElement, callbacks: SwipeCallbacks) {
     dragged = false;
   }
   function move(e: PointerEvent) {
-    if (!cb.enabled || pid !== e.pointerId) return;
+    if (pid !== e.pointerId) return;
     const dx = e.clientX - startX;
     const dy = e.clientY - startY;
     if (axis === null) {
@@ -96,14 +93,13 @@ export function swipeGesture(node: HTMLElement, callbacks: SwipeCallbacks) {
     }
   }
   function up(e: PointerEvent) {
-    if (!cb.enabled || pid !== e.pointerId) return;
+    if (pid !== e.pointerId) return;
     if (axis === "x") cb.onRelease();
     cb.onDragging(false);
     axis = null;
     pid = null;
   }
   function clickCapture(e: MouseEvent) {
-    if (!cb.enabled) return;
     const open = cb.current() !== 0;
     if (dragged || open) {
       e.preventDefault();

--- a/ui/src/lib/components/swipe.ts
+++ b/ui/src/lib/components/swipe.ts
@@ -1,0 +1,144 @@
+/**
+ * Pure state machine for the mobile session-list swipe-to-decommission gesture.
+ * Kept framework-free so it can be unit-tested without a DOM; UnitRow.svelte owns
+ * the pointer wiring, transform, and timers.
+ */
+
+/** Width of the revealed decommission action, in px. */
+export const REVEAL_PX = 104;
+/** Movement (px) before the gesture commits to an axis. */
+const SLOP_PX = 10;
+/** Fraction of REVEAL_PX past which a release snaps the row open. */
+export const OPEN_RATIO = 0.4;
+
+export type Axis = "x" | "y" | null;
+
+/**
+ * Lock the gesture axis once movement exceeds slop; null until then.
+ * Ties favour "y" so an ambiguous diagonal lets the list keep scrolling.
+ */
+export function lockAxis(dx: number, dy: number, slop: number = SLOP_PX): Axis {
+  if (Math.abs(dx) < slop && Math.abs(dy) < slop) return null;
+  return Math.abs(dx) > Math.abs(dy) ? "x" : "y";
+}
+
+/** Clamp a raw horizontal offset to the left-only reveal range [-reveal, 0]. */
+export function clampOffset(px: number, reveal: number = REVEAL_PX): number {
+  if (px > 0) return 0;
+  if (px < -reveal) return -reveal;
+  return px;
+}
+
+/** Target offset after release: snap open past the ratio, else closed. */
+export function snapOffset(
+  offset: number,
+  reveal: number = REVEAL_PX,
+  ratio: number = OPEN_RATIO,
+): number {
+  return offset <= -reveal * ratio ? -reveal : 0;
+}
+
+/** Callbacks a host component supplies to drive the swipe action. */
+export interface SwipeCallbacks {
+  /** Gesture is active (false → action is inert). */
+  enabled: boolean;
+  /** Current slid offset (px, negative = open). */
+  current: () => number;
+  /** Live offset during a horizontal drag. */
+  onOffset: (px: number) => void;
+  /** Toggled while a horizontal drag is in progress (host suppresses the snap transition). */
+  onDragging: (dragging: boolean) => void;
+  /** Finger lifted after a horizontal drag — host snaps open or closed. */
+  onRelease: () => void;
+  /** Host should close an open row (tapped while open). */
+  requestClose: () => void;
+}
+
+/**
+ * Svelte action: left-swipe gesture on a row. Owns pointer tracking and the
+ * capture-phase click that swallows the row's select tap after a drag or while
+ * open. Kept off the markup as inline handlers so static-element a11y rules
+ * stay satisfied — the real interactive elements are the inner buttons.
+ */
+export function swipeGesture(node: HTMLElement, callbacks: SwipeCallbacks) {
+  let cb = callbacks;
+  let axis: Axis = null;
+  let pid: number | null = null;
+  let startX = 0;
+  let startY = 0;
+  let startOffset = 0;
+  let dragged = false; // a horizontal drag occurred in the current pointer sequence
+
+  function down(e: PointerEvent) {
+    if (!cb.enabled) return;
+    pid = e.pointerId;
+    startX = e.clientX;
+    startY = e.clientY;
+    startOffset = cb.current();
+    axis = null;
+    dragged = false;
+  }
+  function move(e: PointerEvent) {
+    if (!cb.enabled || pid !== e.pointerId) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    if (axis === null) {
+      axis = lockAxis(dx, dy);
+      if (axis === "x") {
+        dragged = true;
+        cb.onDragging(true);
+        node.setPointerCapture(pid);
+      }
+    }
+    if (axis === "x") {
+      e.preventDefault();
+      cb.onOffset(clampOffset(startOffset + dx));
+    }
+  }
+  function up(e: PointerEvent) {
+    if (!cb.enabled || pid !== e.pointerId) return;
+    if (axis === "x") cb.onRelease();
+    cb.onDragging(false);
+    axis = null;
+    pid = null;
+  }
+  function clickCapture(e: MouseEvent) {
+    if (!cb.enabled) return;
+    const open = cb.current() !== 0;
+    if (dragged || open) {
+      e.preventDefault();
+      e.stopPropagation();
+      dragged = false;
+      if (open) cb.requestClose();
+    }
+  }
+
+  node.addEventListener("pointerdown", down);
+  node.addEventListener("pointermove", move);
+  node.addEventListener("pointerup", up);
+  node.addEventListener("pointercancel", up);
+  node.addEventListener("click", clickCapture, true);
+
+  return {
+    update(next: SwipeCallbacks) {
+      cb = next;
+    },
+    destroy() {
+      node.removeEventListener("pointerdown", down);
+      node.removeEventListener("pointermove", move);
+      node.removeEventListener("pointerup", up);
+      node.removeEventListener("pointercancel", up);
+      node.removeEventListener("click", clickCapture, true);
+    },
+  };
+}
+
+export type DecomState = "idle" | "armed";
+
+/**
+ * Two-step arm/confirm press (mirrors Viewport's decommission). First press arms;
+ * a second press while armed fires the action and resets.
+ */
+export function pressDecom(state: DecomState): { state: DecomState; fire: boolean } {
+  return state === "armed" ? { state: "idle", fire: true } : { state: "armed", fire: false };
+}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -257,6 +257,7 @@
           onselect={(id) => selectUnit(id)}
           onnew={() => (showNew = true)}
           git={store.git}
+          ondecommission={onarchive}
         />
         {#if store.sessions.length === 0}
           <BacklogView payload={backlog} mobile={true} {onissue} />


### PR DESCRIPTION
## What

Adds a **left-swipe gesture on mobile** to the session list: swipe a row to reveal a destructive action, then confirm to decommission the session — without opening it first.

## How

- Swipe a session row left → red **decommission** action slides into view.
- Inline arm/confirm (matches the existing `Viewport` pattern): first tap arms (`✕ decommission` → `confirm ✕`), second tap archives. Auto-disarms after 3 s.
- Archives via the existing `onarchive` → `archiveSession` (DELETE) path — no server changes.
- Axis-locked: vertical pans still scroll the list natively (`touch-action: pan-y`); only horizontal drags engage the gesture. Single-open invariant (opening one row closes another).
- **Desktop is untouched** — the gesture only wires up when `ondecommission` is passed, which happens solely in the mobile list branch. Row markup is shared via a snippet so the desktop path renders identically.

## Implementation

- `swipe.ts` (new) — framework-free gesture state machine (`lockAxis`, `clampOffset`, `snapOffset`, `pressDecom`) + a `swipeGesture` Svelte action owning pointer tracking and the capture-phase click that swallows the select tap after a drag.
- `swipe.test.ts` (new) — 12 unit tests.
- `UnitRow.svelte` — snippet refactor + swipe wrapper/reveal/arm-confirm.
- `Herd.svelte` / `+page.svelte` — forward/pass the optional `ondecommission` prop (mobile only).
- Reuses existing decommission i18n keys — **no new catalog keys**.

## Verification

- `bun run check` → 0 errors / 0 warnings
- `bun run check:i18n` → locales in parity
- `bun run test` → 24 files, 151 tests pass (incl. 12 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)