### PR TITLE
feat(ui): regroup mobile control bar for one-thumb usability

### DIFF
--- a/ui/src/lib/components/ControlBar.svelte
+++ b/ui/src/lib/components/ControlBar.svelte
@@ -1,8 +1,21 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
-  import { controlKeys } from "$lib/controlKeys";
+  import { controlKeys, type ControlKey } from "$lib/controlKeys";
 
   let { onkey }: { onkey: (seq: string) => void } = $props();
+
+  // Chunk the flat, group-ordered key list into runs of the same group so each
+  // run can render inside its own "well" (Gestalt common-region). Derived so it
+  // re-chunks if the locale (and thus the labels) changes.
+  const groups = $derived.by(() => {
+    const out: ControlKey[][] = [];
+    for (const k of controlKeys()) {
+      const last = out.at(-1);
+      if (last && last[0].group === k.group) last.push(k);
+      else out.push([k]);
+    }
+    return out;
+  });
 
   // Tap-vs-drag: the bar scrolls horizontally (overflow-x), so a finger that
   // lands on a key and drags to scroll must NOT fire it. Arm on pointerdown,
@@ -40,26 +53,32 @@
 </script>
 
 <div class="ctrl-bar" role="toolbar" aria-label={m.controlbar_toolbar_aria()}>
-  {#each controlKeys() as k (k.seq)}
-    <button
-      type="button"
-      class="key"
-      aria-label={k.aria}
-      onpointerdown={down}
-      onpointermove={move}
-      onpointercancel={cancel}
-      onpointerup={(e) => tap(e, k.seq)}>{k.label}</button
-    >
+  {#each groups as group (group[0].group)}
+    <div class="group" role="group">
+      {#each group as k (k.seq)}
+        <button
+          type="button"
+          class="key"
+          class:escape={k.tone === "escape"}
+          class:danger={k.tone === "danger"}
+          aria-label={k.aria}
+          onpointerdown={down}
+          onpointermove={move}
+          onpointercancel={cancel}
+          onpointerup={(e) => tap(e, k.seq)}>{k.label}</button
+        >
+      {/each}
+    </div>
   {/each}
 </div>
 
 <style>
   .ctrl-bar {
     display: flex;
-    gap: 4px;
-    padding: 6px 10px;
-    background: var(--color-head);
-    border-top: 1px solid var(--color-line);
+    /* wide gap between groups; keys *within* a group sit tight (see .group) so
+       proximity tells which keys belong together */
+    gap: 10px;
+    padding: 6px 0 6px 10px;
     overflow-x: auto;
     white-space: nowrap;
     /* take remaining row width and allow shrink-to-fit so the internal
@@ -73,13 +92,24 @@
     display: none;
   }
 
+  /* one "well" per group — faint common-region backing so the eye chunks
+     Esc/Tab · arrows · ^-signals into three units instead of one long row */
+  .group {
+    display: flex;
+    gap: 4px;
+    flex: 0 0 auto;
+    padding: 3px;
+    background: color-mix(in srgb, var(--color-ink) 5%, transparent);
+    border-radius: 7px;
+  }
+
   .key {
     flex: 0 0 auto;
-    min-width: 42px;
-    height: 40px;
+    min-width: 44px;
+    height: 44px;
     background: var(--color-inset);
     border: 1px solid var(--color-line-bright);
-    border-radius: 3px;
+    border-radius: 4px;
     color: var(--color-ink);
     font-family: var(--font-mono);
     font-size: 14px;
@@ -95,5 +125,28 @@
   .key:active {
     background: var(--color-line-bright);
     border-color: var(--color-ink);
+  }
+
+  /* Esc — the odd-one-out cancel key, marked with a calm distinct accent so it
+     reads as "special" without screaming for attention */
+  .key.escape {
+    color: var(--color-blue);
+    border-color: color-mix(in srgb, var(--color-blue) 55%, var(--color-line-bright));
+    background: color-mix(in srgb, var(--color-blue) 12%, var(--color-inset));
+  }
+  .key.escape:active {
+    background: color-mix(in srgb, var(--color-blue) 28%, var(--color-inset));
+    border-color: var(--color-blue);
+  }
+
+  /* ^C — interrupts the running process; a caution tint so it isn't hit blind */
+  .key.danger {
+    color: var(--color-red);
+    border-color: color-mix(in srgb, var(--color-red) 50%, var(--color-line-bright));
+    background: color-mix(in srgb, var(--color-red) 11%, var(--color-inset));
+  }
+  .key.danger:active {
+    background: color-mix(in srgb, var(--color-red) 26%, var(--color-inset));
+    border-color: var(--color-red);
   }
 </style>

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -18,10 +18,14 @@
   import ActivityFeed from "$lib/components/ActivityFeed.svelte";
   import DiffPanel from "$lib/components/DiffPanel.svelte";
   import ControlBar from "$lib/components/ControlBar.svelte";
+  import { enterKey } from "$lib/controlKeys";
   import ComposeBar from "$lib/components/ComposeBar.svelte";
   import GitRail from "$lib/components/GitRail.svelte";
   import SteerBar from "$lib/components/SteerBar.svelte";
   import { m } from "$lib/paraglide/messages";
+
+  // Enter pinned in the thumb zone — locale-reactive for its accessible name.
+  const enter = $derived(enterKey());
 
   let {
     session,
@@ -823,6 +827,9 @@
        mobile breakpoint) gets it, since there's no hardware keyboard to steer with -->
   {#if (mobile || touch) && tab === "term"}
     <div class="ctrl-row">
+      <ControlBar onkey={(seq) => conn?.send(seq)} />
+      <!-- pinned right, in the one-thumb reach zone: attach then Enter, always
+           visible so the primary action never scrolls off -->
       <button
         type="button"
         class="attach"
@@ -833,7 +840,15 @@
       >
         {uploading ? "⏳" : uploadFailed ? "⚠" : "📎"}
       </button>
-      <ControlBar onkey={(seq) => conn?.send(seq)} />
+      <button
+        type="button"
+        class="enter"
+        aria-label={enter.aria}
+        onpointerup={(e) => {
+          e.preventDefault();
+          conn?.send(enter.seq);
+        }}>{enter.label}</button
+      >
     </div>
     <ComposeBar onsend={sendComposed} />
     <input
@@ -1420,27 +1435,52 @@
     outline: 2px dashed var(--color-amber);
     outline-offset: -4px;
   }
+  /* one unified bar across the whole row (scroll palette + pinned actions) */
   .ctrl-row {
     display: flex;
-    align-items: stretch;
-    gap: 4px;
+    align-items: center;
+    gap: 6px;
+    padding-right: 10px;
+    background: var(--color-head);
+    border-top: 1px solid var(--color-line);
   }
-  .ctrl-row .attach {
+  .ctrl-row .attach,
+  .ctrl-row .enter {
     flex: 0 0 auto;
     min-width: 44px;
-    height: 40px;
-    margin: 6px 0 6px 10px;
+    height: 44px;
     background: var(--color-inset);
     border: 1px solid var(--color-line-bright);
-    border-radius: 3px;
+    border-radius: 4px;
     color: var(--color-ink);
     font-size: 16px;
     cursor: pointer;
     touch-action: manipulation;
     user-select: none;
+    transition:
+      background 0.08s,
+      border-color 0.08s;
+  }
+  .ctrl-row .attach:active,
+  .ctrl-row .enter:active {
+    background: var(--color-line-bright);
+    border-color: var(--color-ink);
   }
   .ctrl-row .attach.failed {
     border-color: var(--color-red);
     color: var(--color-red);
+  }
+  /* Enter — the single affirmative "do it" key, the only filled accent in the
+     row so it reads as the primary action */
+  .ctrl-row .enter {
+    font-family: var(--font-mono);
+    font-size: 18px;
+    color: var(--color-green);
+    border-color: color-mix(in srgb, var(--color-green) 60%, var(--color-line-bright));
+    background: color-mix(in srgb, var(--color-green) 18%, var(--color-inset));
+  }
+  .ctrl-row .enter:active {
+    background: color-mix(in srgb, var(--color-green) 34%, var(--color-inset));
+    border-color: var(--color-green);
   }
 </style>

--- a/ui/src/lib/controlKeys.test.ts
+++ b/ui/src/lib/controlKeys.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { controlKeys } from "./controlKeys";
+import { controlKeys, enterKey } from "./controlKeys";
 
 // Guard the byte sequences against silent drift — these are the actual control
-// codes a real terminal sends; a wrong byte steers the agent wrong.
+// codes a real terminal sends; a wrong byte steers the agent wrong. Enter lives
+// apart (enterKey), pinned in the thumb zone — guarded separately below.
 const EXPECTED: Record<string, string> = {
   Esc: "\x1b",
   Tab: "\x09",
-  "⏎": "\x0d",
   "←": "\x1b[D",
   "→": "\x1b[C",
   "↑": "\x1b[A",
@@ -32,5 +32,20 @@ describe("controlKeys", () => {
   it("has no duplicate labels", () => {
     const labels = controlKeys().map((k) => k.label);
     expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it("assigns every palette key to a visual group", () => {
+    for (const k of controlKeys()) {
+      expect(k.group).toBeTruthy();
+    }
+  });
+});
+
+describe("enterKey", () => {
+  it("is the carriage-return sequence with an accessible name", () => {
+    const enter = enterKey();
+    expect(enter.label).toBe("⏎");
+    expect(enter.seq).toBe("\x0d");
+    expect(enter.aria.trim().length).toBeGreaterThan(0);
   });
 });

--- a/ui/src/lib/controlKeys.ts
+++ b/ui/src/lib/controlKeys.ts
@@ -4,24 +4,44 @@
 
 import { m } from "$lib/paraglide/messages";
 
+// Visual grouping for the bar: keys in the same group sit together in one
+// "well" (Gestalt common-region), with a wider gap between groups so a glance
+// tells which keys belong together.
+export type ControlGroup = "edit" | "nav" | "signal";
+
+// Optional colour accent carrying meaning (used sparingly so it stays a signal):
+// escape = the odd-one-out cancel key, danger = interrupts the process.
+export type ControlTone = "escape" | "danger" | "enter";
+
 export interface ControlKey {
   label: string; // visible button text
   aria: string; // accessible name
   seq: string; // exact bytes sent to the PTY
+  group?: ControlGroup; // visual grouping (omit for the pinned Enter)
+  tone?: ControlTone; // optional colour accent
 }
 
+// The scrolling palette, ordered by group. Enter is intentionally absent — it's
+// the primary affirmative action and lives pinned in the thumb zone, see
+// enterKey().
 export function controlKeys(): ControlKey[] {
   return [
-    { label: "Esc", aria: m.controlkey_escape(), seq: "\x1b" },
-    { label: "Tab", aria: m.controlkey_tab(), seq: "\x09" },
-    { label: "⏎", aria: m.controlkey_enter(), seq: "\x0d" },
-    { label: "←", aria: m.controlkey_arrow_left(), seq: "\x1b[D" },
-    { label: "→", aria: m.controlkey_arrow_right(), seq: "\x1b[C" },
-    { label: "↑", aria: m.controlkey_arrow_up(), seq: "\x1b[A" },
-    { label: "↓", aria: m.controlkey_arrow_down(), seq: "\x1b[B" },
-    { label: "^A", aria: m.controlkey_ctrl_a(), seq: "\x01" },
-    { label: "^E", aria: m.controlkey_ctrl_e(), seq: "\x05" },
-    { label: "^C", aria: m.controlkey_ctrl_c(), seq: "\x03" },
-    { label: "^D", aria: m.controlkey_ctrl_d(), seq: "\x04" },
+    { label: "Esc", aria: m.controlkey_escape(), seq: "\x1b", group: "edit", tone: "escape" },
+    { label: "Tab", aria: m.controlkey_tab(), seq: "\x09", group: "edit" },
+    { label: "←", aria: m.controlkey_arrow_left(), seq: "\x1b[D", group: "nav" },
+    { label: "→", aria: m.controlkey_arrow_right(), seq: "\x1b[C", group: "nav" },
+    { label: "↑", aria: m.controlkey_arrow_up(), seq: "\x1b[A", group: "nav" },
+    { label: "↓", aria: m.controlkey_arrow_down(), seq: "\x1b[B", group: "nav" },
+    { label: "^A", aria: m.controlkey_ctrl_a(), seq: "\x01", group: "signal" },
+    { label: "^E", aria: m.controlkey_ctrl_e(), seq: "\x05", group: "signal" },
+    { label: "^C", aria: m.controlkey_ctrl_c(), seq: "\x03", group: "signal", tone: "danger" },
+    { label: "^D", aria: m.controlkey_ctrl_d(), seq: "\x04", group: "signal" },
   ];
+}
+
+// Enter is the most-pressed key in a terminal and the affirmative "do it" — it's
+// pinned bottom-right (the easiest one-thumb reach zone) next to attach, outside
+// the scrolling palette so it's always visible and never scrolls off.
+export function enterKey(): ControlKey {
+  return { label: "⏎", aria: m.controlkey_enter(), seq: "\x0d", tone: "enter" };
 }


### PR DESCRIPTION
## Was & Warum

Die mobile Steuer-Tastenzeile (📎 · Esc/Tab · ⏎ · Pfeile · ^A/^E/^C/^D) war eine flache, gleichförmige Scroll-Reihe — kein Gruppierung, Primäraktion mittendrin und teils im Overflow versteckt. Diese PR wendet bewährte Mobile-UI-Prinzipien auf genau diese eine Zeile an.

## Änderungen

- **Gestalt-Gruppierung:** Scroll-Palette in drei dezent hinterlegte „Wells" geteilt — **Steuern** (Esc, Tab) · **Navigation** (← → ↑ ↓) · **Signale** (^A ^E ^C ^D). Enger Abstand innerhalb, größerer zwischen den Gruppen.
- **Daumenzone:** 📎 + ⏎ rechts **fixiert** (außerhalb des Scrolls), Enter ganz rechts. Primäraktion scrollt nie weg.
- **Farbe = Bedeutung (sparsam):** Esc blau (Abbruch/Sonderfall), ^C rot (interrupt), ⏎ grün gefüllt als einzige Primäraktion.
- **Trefferfläche:** 40 → 44px (HIG-Minimum); einheitlicher Leisten-Hintergrund + Top-Trennlinie über die ganze Zeile.
- **Refactor:** Enter aus `controlKeys()` in `enterKey()` ausgelagert für den fixierten Slot.

Enter sendet weiter `\r` über denselben PTY-Pfad und hält per `preventDefault` auf `pointerup` die Soft-Tastatur offen (kein Terminal-Blur).

## Layout

```
┌─ scroll: 3 gruppierte Wells ────────────┐ ┌ fix rechts ┐
│ [Esc][Tab]  [←][→][↑][↓]  [^A^E^C^D]     │  [📎] [⏎]
└──────────────────────────────────────────┘ └────────────┘
```

## Tests

- `controlKeys.test.ts`: angepasst, 5/5 grün (inkl. neuer Guards für Gruppen + `enterKey`)
- `bun run check`: 0 Fehler · `bun run check:i18n`: in Parität (keine neuen Keys nötig)