### PR TITLE
fix(ui): show issue title in new-task picker by capping labels at 3

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -107,6 +107,7 @@
   "promptsources_issues_tab": "Issues",
   "promptsources_no_todos": "keine offenen TODO-Einträge",
   "promptsources_no_github": "kein GitHub-Upstream",
+  "promptsources_more_labels": "+{count}",
   "reposelect_placeholder": "Repo auswählen…",
   "reposelect_filter_placeholder": "filtern…",
   "reposelect_no_matches": "keine Treffer",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -107,6 +107,7 @@
   "promptsources_issues_tab": "Issues",
   "promptsources_no_todos": "no open TODO items",
   "promptsources_no_github": "no GitHub upstream",
+  "promptsources_more_labels": "+{count}",
   "reposelect_placeholder": "select a repo…",
   "reposelect_filter_placeholder": "filter…",
   "reposelect_no_matches": "no matches",

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -109,9 +109,14 @@
           <span class="row-text">{i.title}</span>
           {#if i.labels.length > 0}
             <span class="chips">
-              {#each i.labels as lbl (lbl)}
+              {#each i.labels.slice(0, 3) as lbl (lbl)}
                 <span class="chip">{lbl}</span>
               {/each}
+              {#if i.labels.length > 3}
+                <span class="chip chip-more" title={i.labels.slice(3).join(", ")}>
+                  {m.promptsources_more_labels({ count: i.labels.length - 3 })}
+                </span>
+              {/if}
             </span>
           {/if}
         </button>
@@ -262,5 +267,11 @@
     border: 1px solid var(--color-faint);
     border-radius: 2px;
     padding: 0 4px;
+  }
+
+  .chip-more {
+    color: var(--color-muted);
+    border-color: transparent;
+    cursor: default;
   }
 </style>


### PR DESCRIPTION
## Problem

In the New Task dialog's issue picker (**ÜBERNEHMEN AUS → ISSUES**), issue rows showed only `#number` and the label chips — **the issue title was missing**. The issues themselves have titles (e.g. #276 = "docs: Pekaway/VanPi integration guide…"); it was a pure display bug.

## Cause

In `PromptSources.svelte` each row lays out `#number → title → chips` as flex items:

- `.row-text` (title): `flex: 1; overflow: hidden`
- `.chips`: `flex-shrink: 0`

Issues with many labels (5–6) let the non-shrinking chips consume the full row width, collapsing the title to **0px**. Issues with few labels still showed their title.

## Fix

Cap visible labels at **3**, with a `+N` overflow badge (remaining label names in a `title` tooltip). The title now always has room.

- `PromptSources.svelte` — `labels.slice(0, 3)` + `+N` badge + `.chip-more` style
- `messages/{en,de}.json` — new key `promptsources_more_labels: "+{count}"`

## Verification

- `cd ui && bun run check:i18n` → 2 locales in parity (270 keys)
- `cd ui && bun run check` → 0 errors, 0 warnings