### PR TITLE
fix(ui): pulse CI-pending dot like other in-progress indicators

### DIFF
--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -439,6 +439,8 @@
   }
   .dot-pending {
     background: var(--color-amber);
+    /* CI running — pulse like every other in-progress indicator */
+    animation: pip-pulse 1.5s ease-out infinite;
   }
   .dot-success {
     background: var(--color-blue, #4a90d9);

--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -60,6 +60,8 @@
   }
   .dot-pending {
     background: var(--color-amber);
+    /* CI running — pulse like every other in-progress indicator */
+    animation: pip-pulse 1.5s ease-out infinite;
   }
   .dot-success {
     background: var(--color-blue, #4a90d9);


### PR DESCRIPTION
## What

The CI status dot's `pending` state (amber, = CI checks actively running) was the **only** running/working indicator in the UI that didn't animate. Every other in-progress indicator already pulses:

- session `running` StatusPip (amber ring)
- critic review dot
- running car glyph

Now `.dot-pending` pulses with the canonical `pip-pulse` animation — the same amber ring StatusPip uses for `running` — so both circular "in-progress" pips read identically. Applied in both places the dot appears: `GitRail.svelte` (detail panel) and its `PrBadge.svelte` mirror (list).

## Left static (deliberately — not "running" states)

Connection dot (a state, not progress), gear/HERDR update dots (informational, calm green by design), success/failure CI dots (terminal), and mobile tally glyphs (count legend markers).

## Notes

- Global `prefers-reduced-motion` guard in `app.css` already disables the animation for reduced-motion users — no per-component guard needed.
- `cd ui && bun run check` passes (0 errors, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)