### PR TITLE
feat(badge): hide WAITING/IDLE status while critic is reviewing

### DIFF
--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -6,10 +6,11 @@
 
 <script lang="ts">
   import type { Session, GitState } from "$lib/types";
-  import { elapsed, STATUS_COLOR, statusLabel } from "$lib/format";
+  import { elapsed, STATUS_COLOR, statusLabel, hideStatusBadge } from "$lib/format";
   import StatusPip from "./StatusPip.svelte";
   import PrBadge from "./PrBadge.svelte";
   import CriticBadge from "./CriticBadge.svelte";
+  import { reviews } from "$lib/reviews.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { m } from "$lib/paraglide/messages";
   import { onDestroy } from "svelte";
@@ -94,6 +95,8 @@
     clearTimeout(armTimer);
     if (openRow === close) openRow = null;
   });
+
+  const hideStatus = $derived(hideStatusBadge(session.status, reviews.isReviewing(session.id)));
 </script>
 
 {#snippet row()}
@@ -127,7 +130,9 @@
     <div class="u-right">
       <PrBadge {git} />
       <CriticBadge sessionId={session.id} />
-      <span class="badge">{statusLabel(session.status)}</span>
+      {#if !hideStatus}
+        <span class="badge">{statusLabel(session.status)}</span>
+      {/if}
       <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
       <span class="meta"
         ><span class="desig">{session.desig}</span> · {session.herdrSession || "—"}</span

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -3,11 +3,12 @@
   import { Terminal } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
   import type { Session, GitState } from "$lib/types";
-  import { STATUS_COLOR, statusLabel, elapsed } from "$lib/format";
+  import { STATUS_COLOR, statusLabel, elapsed, hideStatusBadge } from "$lib/format";
   import { connectPty } from "$lib/pty";
   import { theme, xtermTheme } from "$lib/theme.svelte";
   import PrBadge from "./PrBadge.svelte";
   import CriticBadge from "./CriticBadge.svelte";
+  import { reviews } from "$lib/reviews.svelte";
 
   let {
     session,
@@ -22,6 +23,8 @@
     onselect: (id: string) => void;
     git?: GitState;
   } = $props();
+
+  const hideStatus = $derived(hideStatusBadge(session.status, reviews.isReviewing(session.id)));
 
   let el: HTMLDivElement | undefined = $state();
   let termRef = $state<Terminal | undefined>();
@@ -106,7 +109,9 @@
     {/if}
     <PrBadge {git} />
     <CriticBadge sessionId={session.id} />
-    <span class="badge">{statusLabel(session.status)}</span>
+    {#if !hideStatus}
+      <span class="badge">{statusLabel(session.status)}</span>
+    {/if}
     <span class="desig">{session.desig}</span>
   </div>
   <div class="t-body">

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { hideStatusBadge } from "./format";
+import type { SessionStatus } from "./types";
+
+describe("hideStatusBadge", () => {
+  const cases: [SessionStatus, boolean, boolean][] = [
+    // status, reviewing, hidden
+    ["done", true, true],
+    ["idle", true, true],
+    ["done", false, false],
+    ["idle", false, false],
+    ["running", true, false],
+    ["running", false, false],
+    ["blocked", true, false],
+    ["blocked", false, false],
+    ["archived", true, false],
+  ];
+
+  for (const [status, reviewing, hidden] of cases) {
+    it(`${status} + reviewing=${reviewing} → ${hidden ? "hidden" : "shown"}`, () =>
+      expect(hideStatusBadge(status, reviewing)).toBe(hidden));
+  }
+});

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -30,6 +30,15 @@ export const STATUS_COLOR: Record<SessionStatus, string> = {
   archived: "var(--status-idle)",
 };
 
+/**
+ * While a review is in flight, the WAITING/IDLE status badge is redundant noise
+ * next to REVIEWING… — both just say "nothing actionable yet". Hide it then.
+ * WORKING/BLOCKED stay visible: those are genuinely different signals.
+ */
+export function hideStatusBadge(s: SessionStatus, reviewing: boolean): boolean {
+  return reviewing && (s === "done" || s === "idle");
+}
+
 export function statusLabel(s: SessionStatus): string {
   switch (s) {
     case "running":


### PR DESCRIPTION
## What

When the critic is actively reviewing a PR, the agent card showed three badges in a row: `PR #145` + `REVIEWING…` + `WAITING`. The `WAITING` (and `IDLE`) badge is redundant noise next to `REVIEWING…` — both just tell the eye "nothing actionable yet," and `REVIEWING…` carries strictly more information.

Now the status badge is suppressed while a review is in flight **and** the agent is quiescent (`done`→WAITING / `idle`→IDLE). `WORKING` and `BLOCKED` stay visible — those are genuinely different signals.

## How

- New pure helper `hideStatusBadge(status, reviewing)` in `format.ts` — keeps the predicate testable and DRY across both cards.
- `UnitRow.svelte` + `UnitTile.svelte` read the existing `reviews` store and gate the badge via `{#if !hideStatus}`.
- Reactive instant swap — `WAITING` returns the moment the review finishes. No animation, no server/store/i18n changes.

## Truth table

| status | reviewing | badge |
| --- | --- | --- |
| done | yes | hidden |
| idle | yes | hidden |
| done/idle | no | WAITING/IDLE |
| running | any | WORKING |
| blocked | any | BLOCKED |

## Verify

- `cd ui && bun run check` → 0 errors
- `cd ui && bun run test` → 162 passed (incl. new 9-case truth table in `format.test.ts`)
- i18n parity intact (no new keys — only conditionally omits an existing string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)