### PR TITLE
feat(gitrail): render critic findings as markdown

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -8,6 +8,8 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
+        "dompurify": "^3.4.7",
+        "marked": "^18.0.4",
         "shiki": "^4.1.0",
         "svelte-dnd-action": "^0.9.69",
       },
@@ -293,6 +295,8 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "dompurify": ["dompurify@3.4.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
 
     "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
@@ -360,6 +364,8 @@
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@18.0.4", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA=="],
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,8 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "dompurify": "^3.4.7",
+    "marked": "^18.0.4",
     "shiki": "^4.1.0",
     "svelte-dnd-action": "^0.9.69"
   }

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -4,6 +4,8 @@
   import { m } from "$lib/paraglide/messages";
   import { reviews, repoConfig } from "$lib/reviews.svelte";
   import { criticBadgeLabel } from "./critic-badge";
+  import { marked } from "marked";
+  import DOMPurify from "dompurify";
 
   let {
     sessionId,
@@ -140,6 +142,13 @@
 
   const verdict = $derived(reviews.map[sessionId]);
   const verdictLabel = $derived(criticBadgeLabel(verdict));
+  // Render the (AI-authored) findings as markdown, sanitized before @html.
+  // Gated on showReview so DOMPurify (browser-only) never runs during SSR.
+  const renderedBody = $derived(
+    showReview && verdict?.body
+      ? DOMPurify.sanitize(marked.parse(verdict.body, { async: false }) as string)
+      : "",
+  );
   const criticOn = $derived(repoConfig.isEnabled(repoPath));
   const reviewing = $derived(reviews.isReviewing(sessionId));
   let reviewFlash = $state<string | null>(null);
@@ -305,7 +314,8 @@
         {#if verdict.summary}
           <p class="rv-summary">{verdict.summary}</p>
         {/if}
-        <pre class="rv-body">{verdict.body}</pre>
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized via DOMPurify above -->
+        <div class="rv-body">{@html renderedBody}</div>
       </div>
     {/if}
   </span>
@@ -566,11 +576,66 @@
     border: 1px solid var(--color-line);
     border-radius: 2px;
     color: var(--color-ink);
-    font-family: var(--font-mono);
     font-size: 12px;
     line-height: 1.5;
     padding: 6px 8px;
-    white-space: pre-wrap;
     overflow-wrap: anywhere;
+  }
+  /* markdown rendered via {@html} — children aren't scoped, so target globally */
+  .rv-body :global(> *:first-child) {
+    margin-top: 0;
+  }
+  .rv-body :global(> *:last-child) {
+    margin-bottom: 0;
+  }
+  .rv-body :global(p),
+  .rv-body :global(ul),
+  .rv-body :global(ol) {
+    margin: 0 0 8px;
+  }
+  .rv-body :global(ul),
+  .rv-body :global(ol) {
+    padding-left: 18px;
+  }
+  .rv-body :global(li) {
+    margin: 2px 0;
+  }
+  .rv-body :global(h1),
+  .rv-body :global(h2),
+  .rv-body :global(h3),
+  .rv-body :global(h4) {
+    margin: 12px 0 6px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-ink-bright);
+  }
+  .rv-body :global(a) {
+    color: var(--color-accent, var(--color-ink-bright));
+    text-decoration: underline;
+  }
+  .rv-body :global(code) {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    background: var(--color-line);
+    border-radius: 2px;
+    padding: 0 3px;
+  }
+  .rv-body :global(pre) {
+    margin: 0 0 8px;
+    padding: 6px 8px;
+    background: var(--color-bg, var(--color-line));
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    overflow-x: auto;
+  }
+  .rv-body :global(pre code) {
+    background: none;
+    padding: 0;
+  }
+  .rv-body :global(blockquote) {
+    margin: 0 0 8px;
+    padding-left: 8px;
+    border-left: 2px solid var(--color-line);
+    color: var(--color-muted);
   }
 </style>


### PR DESCRIPTION
## What

Critic/reviewer findings in the inline GitRail popover now render as **markdown** instead of plain monospace text.

## How

- Parse `verdict.body` with `marked`, sanitize the resulting HTML with `DOMPurify` before `{@html}`.
- Render gated on `showReview` so the browser-only sanitizer never runs during SSR.
- `<pre>` → `<div class="rv-body">` with prose CSS for headings, lists, links, inline/fenced code, and blockquotes (`:global()` since `@html` children aren't Svelte-scoped).

**Security:** findings are AI-critic output, so the HTML is DOMPurify-sanitized — the only `@html` in the verdict path.

## Verify

- `cd ui && bun run check` — 0 errors/warnings
- `bun run lint` (root, covers `ui/src`) — clean
- `check:i18n` — parity (no new strings; markdown body is pass-through data)
- UI tests — 139 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)