### PR TITLE
fix(ui): stop overusing amber on unit cards

### DIFF
--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -38,10 +38,9 @@
     white-space: nowrap;
     color: var(--color-muted);
   }
-  .pr-open {
-    border-color: var(--color-amber);
-    color: var(--color-amber);
-  }
+  /* `pr-open` is the brightest PR state via the default muted styling — no hue.
+     Amber is reserved for the one actionable badge (critic CHANGES); PR
+     existence is an identifier, and CI health is carried by the dot beside it. */
   .pr-merged {
     color: var(--color-slate);
   }

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -354,14 +354,14 @@
     flex-shrink: 0;
   }
 
+  /* Quiet muted text, not a colored pill — the StatusPip (left) already encodes
+     status by color + pulse, so an outlined `--rule`-tinted badge here just
+     duplicated that hue (amber for running) and added to the orange wall. */
   .badge {
     font-size: 10px;
     letter-spacing: 0.14em;
     text-transform: uppercase;
-    padding: 2px 7px;
-    border: 1px solid var(--rule);
-    color: var(--rule);
-    border-radius: 2px;
+    color: var(--color-muted);
     white-space: nowrap;
   }
 

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -317,7 +317,10 @@
     max-width: 34ch;
   }
   .repo-glyph {
-    color: var(--color-amber);
+    /* Renders on every row regardless of status — amber here was the biggest
+       remaining contributor to the "orange wall". Muted: it's a repo marker,
+       not a state signal. (Only tints the `▣` fallback; emoji icons self-color.) */
+    color: var(--color-muted);
     font-size: 10px;
     flex-shrink: 0;
   }


### PR DESCRIPTION
## Problem

Amber (\`--amber\`) was doing four unrelated jobs at once on a unit card — PR open, critic CHANGES, agent running, CI pending — all rendered as identical orange outlined pills, stacked. Nothing read as more or less important; amber stopped signaling anything.

## Fix — make amber mean one thing: "needs your action"

Semantic re-map, CSS-only:

- **PR badge → muted.** A PR number is an identifier, not an alert. Dropped the \`.pr-open\` amber override; open PRs use the default muted pill, and the blue CI dot beside it still carries PR health.
- **Status badge → quiet muted text, no pill.** The pulsing StatusPip on the left already encodes status by color + motion; the \`--rule\`-tinted badge just duplicated that hue (amber for running).
- **Critic CHANGES stays amber** — now the sole accent on the card, so it actually pops.

## Result

\`\`\`
●  PR #148      ← muted pill + blue CI dot
⚠  CHANGES      ← amber, the only accent
   WORKING      ← muted text, no pill
\`\`\`

No new strings — no i18n impact. \`cd ui && bun run check\` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)