### PR TITLE
feat(herd): add READY sidebar filter (sessions not actively working)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -80,6 +80,8 @@
   "gitrail_review_title": "Kritiker-Befunde",
   "herd_title": "The Herd",
   "herd_all_hint": "▦ Alle",
+  "herd_ready_filter": "▤ Bereit",
+  "herd_ready_empty": "Nichts wartet — alle sind beschäftigt",
   "herd_empty": "Keine Aufgaben — + Neue Aufgabe",
   "issuespanel_title": "ISSUES",
   "issuespanel_title_with_slug": "ISSUES · {slug}",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -80,6 +80,8 @@
   "gitrail_review_title": "Critic findings",
   "herd_title": "The Herd",
   "herd_all_hint": "▦ All",
+  "herd_ready_filter": "▤ Ready",
+  "herd_ready_empty": "Nothing waiting — all hands working",
   "herd_empty": "No tasks — + New Task",
   "issuespanel_title": "ISSUES",
   "issuespanel_title_with_slug": "ISSUES · {slug}",

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -21,18 +21,42 @@
     // when provided, rows gain left-swipe-to-decommission (mobile list)
     ondecommission?: (id: string) => void;
   } = $props();
+
+  // sidebar list filter: "all" or "ready" (only sessions not actively working —
+  // anything but a running agent: idle, blocked, done → awaiting the operator)
+  let filter = $state<"all" | "ready">("all");
+  const shown = $derived(
+    filter === "ready" ? sessions.filter((s) => s.status !== "running") : sessions,
+  );
 </script>
 
 <div class="panel bracket">
   <div class="phead">
     <span class="micro">{m.herd_title()}</span>
-    <span class="right micro">{m.herd_all_hint()}</span>
+    <div class="right filters">
+      <button
+        type="button"
+        class="micro fbtn"
+        class:active={filter === "all"}
+        aria-pressed={filter === "all"}
+        onclick={() => (filter = "all")}>{m.herd_all_hint()}</button
+      >
+      <button
+        type="button"
+        class="micro fbtn"
+        class:active={filter === "ready"}
+        aria-pressed={filter === "ready"}
+        onclick={() => (filter = "ready")}>{m.herd_ready_filter()}</button
+      >
+    </div>
   </div>
   <div class="units">
     {#if sessions.length === 0}
       <button type="button" class="empty micro" onclick={onnew}>{m.herd_empty()}</button>
+    {:else if shown.length === 0}
+      <div class="empty micro static">{m.herd_ready_empty()}</div>
     {:else}
-      {#each sessions as session (session.id)}
+      {#each shown as session (session.id)}
         <UnitRow
           {session}
           selected={session.id === selectedId}
@@ -88,6 +112,25 @@
   .phead .right {
     margin-left: auto;
   }
+  .filters {
+    display: flex;
+    gap: 4px;
+  }
+  .fbtn {
+    border: 0;
+    background: none;
+    font-family: inherit;
+    cursor: pointer;
+    padding: 2px 5px;
+    color: var(--color-faint);
+    transition: color 0.12s ease;
+  }
+  .fbtn:hover {
+    color: var(--color-ink);
+  }
+  .fbtn.active {
+    color: var(--color-amber);
+  }
 
   .micro {
     font-size: 10.5px;
@@ -119,5 +162,11 @@
   }
   .empty:hover {
     color: var(--color-ink);
+  }
+  .empty.static {
+    cursor: default;
+  }
+  .empty.static:hover {
+    color: var(--color-faint);
   }
 </style>


### PR DESCRIPTION
## What

Adds a **READY** filter to the `THE HERD` sidebar header, next to the existing `ALL` toggle.

The header's `▦ All` was previously static text that did nothing. It's now a real two-button toggle:

```
THE HERD              ▦ ALL  ▤ READY
```

- **ALL** — every session (unchanged default).
- **READY** — only sessions that aren't actively working, i.e. `status !== "running"` (idle, blocked, done — awaiting the operator). "Actionable", but shorter.

When READY matches nothing but sessions exist, the list shows a static "Nothing waiting — all hands working" note instead of the new-task empty state.

## Scope

- Filter state is local to `Herd.svelte`, so it also applies to the mobile list view.
- The bottom `All ▦ / Focus ⌖` view-mode toggle in `ActionBar` is untouched — including the separately-dysfunctional grid `all` mode, which was explicitly out of scope.

## i18n

`herd_ready_filter` + `herd_ready_empty` added to both EN and DE catalogs (parity gate passes, 273 keys each).

## Checks

- `bun run check:i18n` ✓
- `bun run check` (svelte-check) ✓ 0 errors
- `bun run test` ✓ 153 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)