### PR TITLE
feat(triage): slide needs-you drawer out when all items are handled

### DIFF
--- a/ui/src/lib/components/TriageDrawer.svelte
+++ b/ui/src/lib/components/TriageDrawer.svelte
@@ -1,6 +1,17 @@
 <script lang="ts">
+  import { fly } from "svelte/transition";
   import type { BlockedEntry } from "$lib/triage";
   import { m } from "$lib/paraglide/messages";
+
+  // Slide the drawer in/out from the right edge. The {#if showTriage} guard in
+  // +page.svelte mounts/unmounts us, so this transition runs on both open and
+  // close (auto-close once every item is handled → it slides away). Svelte JS
+  // transitions don't honor the prefers-reduced-motion CSS media query, so drop
+  // the duration to 0 for users who opted out.
+  const reduceMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+  const slide = { x: 440, duration: reduceMotion ? 0 : 220, opacity: 1 };
 
   let {
     entries,
@@ -40,7 +51,7 @@
   }
 </script>
 
-<aside class="drawer">
+<aside class="drawer" transition:fly={slide}>
   <header>
     <span class="title">{m.common_needs_you({ count: entries.length })}</span>
     <button class="x" onclick={onclose} aria-label={m.triage_close_aria()}>✕</button>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -51,6 +51,11 @@
   // the WS and the store auto-reconnects, refreshing state once the new build is live.
   let herdrUpdating = $state(false);
   const blockedEntries = $derived(sortBlocked(store.sessions, store.blocks));
+  // Once every "needs you" item is handled the drawer has nothing left to show —
+  // close it so it slides out instead of lingering on an empty state.
+  $effect(() => {
+    if (showTriage && blockedEntries.length === 0) showTriage = false;
+  });
   let viewMode = $state<"focus" | "all">("focus");
   let nowMs = $state(Date.now());
   let composeRepoPath = $state<string | null>(null);


### PR DESCRIPTION
## Problem

When the desktop **BRAUCHT DICH** ("needs you") side panel is open and the operator handles the last blocked session, the panel stays open showing the empty *"Keine Agenten warten auf dich."* state. With nothing left to act on, the lingering panel makes no sense.

## Change

- **Auto-close** (`+page.svelte`): an `$effect` closes the triage drawer the moment `blockedEntries` empties while it's open.
- **Slide in/out** (`TriageDrawer.svelte`): the drawer now uses a `fly` transition from the right edge, so it slides in on open and slides away on close (including the new auto-close). Pure slide (no fade), 220 ms, drops to 0 ms under `prefers-reduced-motion` — Svelte JS transitions don't honor the CSS media query automatically.

During the slide-out the entries are already empty, so it briefly shows the "done" confirmation as it leaves — a nice beat rather than a lingering dead panel.

## Test

- `cd ui && bun run check` → 0 errors.
- Manual: open the drawer with ≥1 waiting agent, reply/dismiss until the count hits 0 → panel slides out to the right instead of staying open empty.