### PR TITLE
feat(newtask): inline slash-command autocomplete in prompt field

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,13 +1,21 @@
 import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-/** An installed slash command surfaced in the New Task "Commands" tab. A skill
- *  (`.claude/skills/<name>/SKILL.md`) or a command file (`.claude/commands/<name>.md`),
- *  invokable from the prompt as `/<name>`. */
+/** Where a discovered slash command came from — drives the row badge and dedupe
+ *  precedence (project > user > plugin > builtin). Skills are folded into
+ *  project/user by location; plugin = installed plugin command/skill. */
+export type SlashCommandScope = "project" | "user" | "plugin" | "builtin";
+
+/** An installed slash command surfaced in the New Task "Commands" tab and the
+ *  inline `/` autocomplete. A skill (`.claude/skills/<name>/SKILL.md`), a command
+ *  file (`.claude/commands/<name>.md`), an installed plugin command/skill, or a
+ *  built-in — invokable from the prompt as `/<name>`. */
 export interface SlashCommand {
   name: string;
   description: string;
-  scope: "project" | "user";
+  scope: SlashCommandScope;
+  /** Front-matter `argument-hint` (e.g. "<ticket>"), shown dimmed after the name. */
+  argumentHint?: string;
 }
 
 // Descriptions ride to the client only to label rows; cap them so a verbose
@@ -17,6 +25,7 @@ const MAX_DESC = 280;
 interface Frontmatter {
   name?: string;
   description?: string;
+  "argument-hint"?: string;
 }
 
 /** Index of the closing `---` fence, or -1 when the front-matter is unterminated. */
@@ -44,7 +53,7 @@ function parseFrontmatter(text: string): { fm: Frontmatter; body: string } {
   if (end === -1) return { fm: {}, body: text };
   const fm: Frontmatter = {};
   for (let i = 1; i < end; i++) {
-    const m = /^(name|description)\s*:\s*(.*)$/.exec(lines[i]!);
+    const m = /^(name|description|argument-hint)\s*:\s*(.*)$/.exec(lines[i]!);
     if (m) fm[m[1] as keyof Frontmatter] = unquote(m[2]!.trim());
   }
   return { fm, body: lines.slice(end + 1).join("\n") };
@@ -64,6 +73,7 @@ function readCommand(
   path: string,
   fallbackName: string,
   scope: SlashCommand["scope"],
+  prefix = "",
 ): SlashCommand | null {
   let text: string;
   try {
@@ -72,12 +82,13 @@ function readCommand(
     return null; // unreadable file → skip, don't fail the whole listing
   }
   const { fm, body } = parseFrontmatter(text);
-  const name = (fm.name?.trim() || fallbackName).trim();
-  if (!name) return null;
+  const bare = (fm.name?.trim() || fallbackName).trim();
+  if (!bare) return null;
   let description = (fm.description?.trim() || firstLine(body)).trim();
   if (description.length > MAX_DESC)
     description = description.slice(0, MAX_DESC - 1).trimEnd() + "…";
-  return { name, description, scope };
+  const argumentHint = fm["argument-hint"]?.trim() || undefined;
+  return { name: prefix + bare, description, scope, argumentHint };
 }
 
 function safeReaddir(dir: string): string[] {
@@ -88,13 +99,20 @@ function safeReaddir(dir: string): string[] {
   }
 }
 
-/** Scan one `.claude` dir for skills + commands, merging into `out` keyed by name. */
-function collect(claudeDir: string, scope: SlashCommand["scope"], out: Map<string, SlashCommand>) {
+/** Scan one `.claude`-shaped dir (a real `.claude` or a plugin install root) for
+ *  skills + commands, merging into `out` keyed by name. `prefix` namespaces plugin
+ *  entries (`fallow:` → `fallow:foo`) so they can't clash with bare user commands. */
+function collect(
+  claudeDir: string,
+  scope: SlashCommand["scope"],
+  out: Map<string, SlashCommand>,
+  prefix = "",
+) {
   const skillsDir = join(claudeDir, "skills");
   for (const entry of safeReaddir(skillsDir)) {
     const md = join(skillsDir, entry, "SKILL.md");
     if (!existsSync(md)) continue;
-    const cmd = readCommand(md, entry, scope);
+    const cmd = readCommand(md, entry, scope, prefix);
     if (cmd) out.set(cmd.name, cmd);
   }
   const cmdsDir = join(claudeDir, "commands");
@@ -106,16 +124,78 @@ function collect(claudeDir: string, scope: SlashCommand["scope"], out: Map<strin
     } catch {
       continue;
     }
-    const cmd = readCommand(file, entry.slice(0, -3), scope);
+    const cmd = readCommand(file, entry.slice(0, -3), scope, prefix);
     if (cmd) out.set(cmd.name, cmd);
   }
 }
 
-/** Discover installed slash commands for the New Task picker: user-scope skills +
- *  commands under `userClaudeDir`, then the repo's own `.claude` (project shadows
- *  user on a name clash). Sorted by name. `repoDir` null → user scope only. */
+/**
+ * Curated built-in slash commands that work as an initial prompt for a spawned
+ * session. Purely-interactive ones (/clear, /config, /model, /compact) are
+ * excluded — they do nothing useful as a first message. Maintained by hand.
+ */
+const BUILTINS: ReadonlyArray<{ name: string; description: string }> = [
+  { name: "init", description: "Initialize a new CLAUDE.md with codebase documentation" },
+  { name: "review", description: "Review a pull request" },
+  {
+    name: "security-review",
+    description: "Complete a security review of the pending changes on the current branch",
+  },
+  { name: "pr-comments", description: "Get comments from a GitHub pull request" },
+];
+
+/** Re-root an absolute installPath under the local `~/.claude`. installPath is
+ *  stored verbatim and may carry another machine's `$HOME` (settings sync across
+ *  machines), so anchor on the `.claude/` segment. */
+function rerootInstallPath(raw: string, userClaudeDir: string): string {
+  const norm = raw.replace(/\\/g, "/");
+  const idx = norm.indexOf(".claude/");
+  return idx >= 0 ? join(userClaudeDir, norm.slice(idx + ".claude/".length)) : raw;
+}
+
+/**
+ * Scan installed plugins (the authoritative `installed_plugins.json` — the
+ * marketplace tree holds the whole catalog, not what's enabled). Each plugin's
+ * commands + skills are namespaced `<plugin>:<name>`. Project-scoped plugins are
+ * included only for their own project dir.
+ */
+function collectPlugins(
+  userClaudeDir: string,
+  repoDir: string | null,
+  out: Map<string, SlashCommand>,
+) {
+  let text: string;
+  try {
+    text = readFileSync(join(userClaudeDir, "plugins", "installed_plugins.json"), "utf8");
+  } catch {
+    return; // no plugins installed → nothing to add
+  }
+  let parsed: { plugins?: Record<string, Array<Record<string, unknown>>> };
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return;
+  }
+  for (const [key, entries] of Object.entries(parsed.plugins ?? {})) {
+    const plugin = key.split("@")[0] || key;
+    for (const e of entries) {
+      if (typeof e.installPath !== "string") continue;
+      if (e.scope === "project" && typeof e.projectPath === "string" && e.projectPath !== repoDir)
+        continue;
+      collect(rerootInstallPath(e.installPath, userClaudeDir), "plugin", out, `${plugin}:`);
+    }
+  }
+}
+
+/** Discover installed slash commands for the New Task picker and inline `/`
+ *  autocomplete. Built in precedence order (lowest first, each later source
+ *  shadowing earlier on a name clash): builtin → plugin → user → project. Sorted
+ *  by name. `repoDir` null → no project layer. */
 export function listCommands(repoDir: string | null, userClaudeDir: string): SlashCommand[] {
   const out = new Map<string, SlashCommand>();
+  for (const b of BUILTINS)
+    out.set(b.name, { name: b.name, description: b.description, scope: "builtin" });
+  collectPlugins(userClaudeDir, repoDir, out);
   collect(userClaudeDir, "user", out);
   if (repoDir) collect(join(repoDir, ".claude"), "project", out);
   return [...out.values()].sort((a, b) => a.name.localeCompare(b.name));

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -43,9 +43,22 @@ afterEach(() => {
   rmSync(repo, { recursive: true, force: true });
 });
 
+/** Names contributed by skills/commands/plugins, with the always-present builtins
+ *  filtered out — keeps the file-scan assertions stable as builtins evolve. */
+function nonBuiltin(repoDir: string | null, claude: string) {
+  return listCommands(repoDir, claude)
+    .filter((c) => c.scope !== "builtin")
+    .map((c) => c.name);
+}
+
 test("merges user + project commands, sorted by name", () => {
-  const names = listCommands(repo, userClaude).map((c) => c.name);
-  expect(names).toEqual(["alpha-skill", "bar", "foo", "merge-train", "noname"]);
+  expect(nonBuiltin(repo, userClaude)).toEqual([
+    "alpha-skill",
+    "bar",
+    "foo",
+    "merge-train",
+    "noname",
+  ]);
 });
 
 test("skill name comes from front-matter, scope is user", () => {
@@ -78,14 +91,55 @@ test("non-.md files in commands are ignored", () => {
 });
 
 test("null repoDir → user scope only (no project commands)", () => {
-  const names = listCommands(null, userClaude).map((c) => c.name);
+  const names = nonBuiltin(null, userClaude);
   expect(names).toEqual(["alpha-skill", "bar", "foo", "noname"]);
   expect(names).not.toContain("merge-train");
 });
 
-test("missing dirs → empty, no throw", () => {
+test("missing dirs → builtins only, no throw", () => {
   const missing = join(userClaude, "does-not-exist");
-  expect(listCommands(null, missing)).toEqual([]);
+  const cmds = listCommands(null, missing);
+  expect(cmds.every((c) => c.scope === "builtin")).toBe(true);
+  expect(cmds.length).toBeGreaterThan(0);
+});
+
+// ── builtins, argument-hint, plugins (the enrichment over #147) ────────────────
+
+test("curated builtins are always present and scoped builtin", () => {
+  const cmds = listCommands(repo, userClaude);
+  const review = cmds.find((c) => c.name === "review");
+  expect(review?.scope).toBe("builtin");
+  expect(cmds.some((c) => c.name === "security-review" && c.scope === "builtin")).toBe(true);
+});
+
+test("front-matter argument-hint is surfaced", () => {
+  command(
+    userClaude,
+    "ticketed.md",
+    "---\ndescription: needs a ticket\nargument-hint: <ticket>\n---\n",
+  );
+  const cmd = listCommands(null, userClaude).find((c) => c.name === "ticketed");
+  expect(cmd?.argumentHint).toBe("<ticket>");
+});
+
+test("installed plugins are scanned, namespaced, and re-rooted from a foreign installPath", () => {
+  // plugin cache laid out under the user's .claude, but installPath carries a
+  // DIFFERENT machine's $HOME (settings sync) — must still resolve locally.
+  const rel = "plugins/cache/mkt/myplugin/1.0.0";
+  command(join(userClaude, rel), "deploy.md", "---\ndescription: plugin deploy\n---\n");
+  skill(join(userClaude, rel), "scan", "---\nname: scan\ndescription: plugin scan\n---\n");
+  mkdirSync(join(userClaude, "plugins"), { recursive: true });
+  writeFileSync(
+    join(userClaude, "plugins", "installed_plugins.json"),
+    JSON.stringify({
+      plugins: {
+        "myplugin@mkt": [{ scope: "user", installPath: `/Users/someone/.claude/${rel}` }],
+      },
+    }),
+  );
+  const cmds = listCommands(null, userClaude);
+  expect(cmds.find((c) => c.name === "myplugin:deploy")?.scope).toBe("plugin");
+  expect(cmds.find((c) => c.name === "myplugin:scan")?.scope).toBe("plugin");
 });
 
 test("over-long description is truncated with an ellipsis", () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -108,6 +108,8 @@
   "promptsources_more_labels": "+{count}",
   "promptsources_no_commands": "keine installierten Befehle",
   "promptsources_commands_filter": "Befehle filtern…",
+  "slash_menu_label": "Slash-Befehle",
+  "slash_menu_empty": "keine passenden Befehle",
   "reposelect_placeholder": "Repo auswählen…",
   "reposelect_filter_placeholder": "filtern…",
   "reposelect_no_matches": "keine Treffer",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -108,6 +108,8 @@
   "promptsources_more_labels": "+{count}",
   "promptsources_no_commands": "no installed commands",
   "promptsources_commands_filter": "filter commands…",
+  "slash_menu_label": "slash commands",
+  "slash_menu_empty": "no matching commands",
   "reposelect_placeholder": "select a repo…",
   "reposelect_filter_placeholder": "filter…",
   "reposelect_no_matches": "no matches",

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { listRepos, listBranches, uploadImage } from "$lib/api";
+  import { listRepos, listBranches, getCommands, uploadImage } from "$lib/api";
   import { handleImagePaste } from "$lib/clipboard";
-  import { MODELS, type Issue, type IssueRef, type RepoEntry } from "$lib/types";
+  import { MODELS, type Issue, type IssueRef, type RepoEntry, type SlashCommand } from "$lib/types";
+  import { matchSlashTrigger, filterCommands } from "$lib/slash";
   import RepoSelect from "./RepoSelect.svelte";
   import PromptSources from "./PromptSources.svelte";
+  import SlashCommandMenu from "./SlashCommandMenu.svelte";
   import { m } from "$lib/paraglide/messages";
 
   let {
@@ -55,6 +57,13 @@
   let promptInput = $state<HTMLTextAreaElement>();
   let isMac = $state(false);
 
+  // ── inline slash-command autocomplete (reuses the /api/commands index) ──
+  let allCommands = $state<SlashCommand[]>([]);
+  let slashOpen = $state(false);
+  let slashQuery = $state("");
+  let slashIndex = $state(0);
+  const slashMatches = $derived(slashOpen ? filterCommands(allCommands, slashQuery) : []);
+
   /** Default to the most-recently-used repo; fall back to the first in the list. */
   function defaultRepoPath(list: RepoEntry[]): string {
     let best: RepoEntry | undefined;
@@ -99,6 +108,23 @@
       })
       .catch(() => {
         branches = [];
+      });
+  });
+
+  // (re)load the slash-command list when the target repo changes — a repo's own
+  // .claude/commands + .claude/skills layer on top of the global/user/plugin ones.
+  $effect(() => {
+    const rp = repoPath;
+    if (!rp) {
+      allCommands = [];
+      return;
+    }
+    getCommands(rp)
+      .then((r) => {
+        if (rp === repoPath) allCommands = r.commands;
+      })
+      .catch(() => {
+        if (rp === repoPath) allCommands = [];
       });
   });
 
@@ -153,11 +179,64 @@
     promptInput.style.height = `${promptInput.scrollHeight}px`;
   }
 
-  // Cmd/Ctrl+Enter submits from the prompt textarea (plain Enter inserts a newline)
+  // Open/refresh the slash menu from the caret position, or close it when the text
+  // before the caret is no longer a leading `/token`.
+  function refreshSlash() {
+    const caret = promptInput?.selectionStart ?? prompt.length;
+    const trigger = matchSlashTrigger(prompt, caret);
+    if (trigger) {
+      slashOpen = true;
+      slashQuery = trigger.query;
+      slashIndex = 0;
+    } else {
+      slashOpen = false;
+    }
+  }
+
+  function onPromptInput() {
+    autogrow();
+    refreshSlash();
+  }
+
+  // Replace the leading `/query` token with the chosen command, leaving a trailing
+  // space so the user can type arguments straight away.
+  function pickCommand(cmd: SlashCommand) {
+    const caret = promptInput?.selectionStart ?? prompt.length;
+    const insert = `/${cmd.name} `;
+    prompt = insert + prompt.slice(caret);
+    slashOpen = false;
+    queueMicrotask(() => {
+      autogrow();
+      promptInput?.focus();
+      promptInput?.setSelectionRange(insert.length, insert.length);
+    });
+  }
+
+  // Cmd/Ctrl+Enter submits (plain Enter inserts a newline). While the slash menu is
+  // open it captures the navigation keys so arrows/Enter/Tab drive the picker.
   function onPromptKeydown(e: KeyboardEvent) {
     if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
       e.preventDefault();
       submit(e);
+      return;
+    }
+    if (slashOpen && slashMatches.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        slashIndex = (slashIndex + 1) % slashMatches.length;
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        slashIndex = (slashIndex - 1 + slashMatches.length) % slashMatches.length;
+      } else if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        pickCommand(slashMatches[slashIndex]!);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        slashOpen = false;
+      }
+    } else if (slashOpen && e.key === "Escape") {
+      e.preventDefault();
+      slashOpen = false;
     }
   }
 
@@ -217,16 +296,27 @@
     </div>
 
     <label class="micro" for="nt-prompt">{m.newtask_prompt_label()}</label>
-    <textarea
-      id="nt-prompt"
-      bind:this={promptInput}
-      bind:value={prompt}
-      rows="3"
-      placeholder={m.newtask_prompt_placeholder()}
-      oninput={autogrow}
-      onkeydown={onPromptKeydown}
-      required
-    ></textarea>
+    <div class="prompt-wrap">
+      <textarea
+        id="nt-prompt"
+        bind:this={promptInput}
+        bind:value={prompt}
+        rows="3"
+        placeholder={m.newtask_prompt_placeholder()}
+        oninput={onPromptInput}
+        onkeydown={onPromptKeydown}
+        onblur={() => (slashOpen = false)}
+        required
+      ></textarea>
+      {#if slashOpen}
+        <SlashCommandMenu
+          commands={slashMatches}
+          activeIndex={slashIndex}
+          onpick={pickCommand}
+          onhover={(i) => (slashIndex = i)}
+        />
+      {/if}
+    </div>
     <div class="attach-row">
       <button type="button" class="attach" onclick={() => fileInput?.click()} disabled={uploading}>
         {uploading ? m.newtask_uploading() : m.newtask_attach_image()}
@@ -392,6 +482,9 @@
     color: var(--color-muted);
     margin-top: 6px;
   }
+  .prompt-wrap {
+    position: relative;
+  }
   textarea,
   input,
   select {
@@ -402,6 +495,8 @@
     font-size: 13px;
     padding: 8px 10px;
     border-radius: 2px;
+    width: 100%;
+    box-sizing: border-box;
   }
   textarea {
     /* JS auto-grows the height with content; cap it here and then scroll,

--- a/ui/src/lib/components/SlashCommandMenu.svelte
+++ b/ui/src/lib/components/SlashCommandMenu.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  import type { SlashCommand } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    commands,
+    activeIndex,
+    onpick,
+    onhover,
+  }: {
+    commands: SlashCommand[];
+    activeIndex: number;
+    onpick: (cmd: SlashCommand) => void;
+    onhover: (index: number) => void;
+  } = $props();
+
+  // Keep the highlighted row in view as the user arrows through the list.
+  let listEl = $state<HTMLUListElement | null>(null);
+  $effect(() => {
+    const row = listEl?.children[activeIndex] as HTMLElement | undefined;
+    row?.scrollIntoView({ block: "nearest" });
+  });
+</script>
+
+<div class="sc-panel" role="presentation">
+  {#if commands.length === 0}
+    <div class="sc-empty">{m.slash_menu_empty()}</div>
+  {:else}
+    <ul class="sc-list" bind:this={listEl} role="listbox" aria-label={m.slash_menu_label()}>
+      {#each commands as cmd, i (cmd.scope + ":" + cmd.name)}
+        <li
+          class="sc-row"
+          class:active={i === activeIndex}
+          role="option"
+          aria-selected={i === activeIndex}
+          tabindex="-1"
+          onmousedown={(e) => {
+            e.preventDefault(); // keep focus in the textarea
+            onpick(cmd);
+          }}
+          onmousemove={() => onhover(i)}
+        >
+          <div class="sc-line">
+            <span class="sc-name">/{cmd.name}</span>
+            {#if cmd.argumentHint}<span class="sc-hint">{cmd.argumentHint}</span>{/if}
+            <!-- raw source tag, matching the Commands-tab chip convention -->
+            {#if cmd.scope !== "project"}<span class="sc-scope">{cmd.scope}</span>{/if}
+          </div>
+          {#if cmd.description}<div class="sc-desc">{cmd.description}</div>{/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .sc-panel {
+    position: absolute;
+    z-index: 40;
+    top: calc(100% + 2px);
+    left: 0;
+    right: 0;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.55);
+  }
+  .sc-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 260px;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+  .sc-row {
+    padding: 6px 10px;
+    cursor: pointer;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .sc-row:last-child {
+    border-bottom: 0;
+  }
+  .sc-row.active,
+  .sc-row:hover {
+    background: var(--color-hover);
+  }
+  .sc-line {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .sc-name {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--color-amber);
+    white-space: nowrap;
+  }
+  .sc-hint {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .sc-scope {
+    margin-left: auto;
+    flex-shrink: 0;
+    font-size: 9px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-slate);
+    border: 1px solid var(--color-faint);
+    border-radius: 2px;
+    padding: 0 4px;
+  }
+  .sc-desc {
+    font-size: 11px;
+    color: var(--color-faint);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-top: 2px;
+  }
+  .sc-empty {
+    font-family: var(--font-mono);
+    padding: 10px;
+    color: var(--color-faint);
+    font-size: 12px;
+    font-style: italic;
+    text-align: center;
+  }
+  @media (max-width: 768px) {
+    .sc-row {
+      min-height: 44px;
+    }
+    .sc-name,
+    .sc-hint {
+      font-size: 14px;
+    }
+  }
+</style>

--- a/ui/src/lib/slash.test.ts
+++ b/ui/src/lib/slash.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { matchSlashTrigger, filterCommands } from "./slash";
+import type { SlashCommand } from "./types";
+
+const cmd = (name: string): SlashCommand => ({ name, description: "", scope: "user" });
+
+describe("matchSlashTrigger", () => {
+  it("triggers on a leading slash at the caret", () => {
+    expect(matchSlashTrigger("/cre", 4)).toEqual({ query: "cre" });
+  });
+
+  it("triggers with an empty query right after the slash", () => {
+    expect(matchSlashTrigger("/", 1)).toEqual({ query: "" });
+  });
+
+  it("does not trigger when the slash is not at the start", () => {
+    expect(matchSlashTrigger("fix /foo", 8)).toBeNull();
+  });
+
+  it("does not trigger once a space ends the command token", () => {
+    expect(matchSlashTrigger("/foo bar", 8)).toBeNull();
+  });
+
+  it("uses the text before the caret, not the whole string", () => {
+    // caret sits inside the slash token even though more text follows
+    expect(matchSlashTrigger("/foobar", 4)).toEqual({ query: "foo" });
+  });
+
+  it("does not trigger on empty input", () => {
+    expect(matchSlashTrigger("", 0)).toBeNull();
+  });
+});
+
+describe("filterCommands", () => {
+  const list = [cmd("deploy"), cmd("create_plan"), cmd("git:commit"), cmd("review")];
+
+  it("returns everything for an empty query", () => {
+    expect(filterCommands(list, "")).toEqual(list);
+  });
+
+  it("is case-insensitive", () => {
+    expect(filterCommands(list, "DEP").map((c) => c.name)).toEqual(["deploy"]);
+  });
+
+  it("ranks prefix matches above mid-name substring matches", () => {
+    // "co" is a prefix of nothing, a substring of "git:commit" only
+    expect(filterCommands(list, "co").map((c) => c.name)).toEqual(["git:commit"]);
+    // "re" prefixes "review"; also a substring of "create_plan"
+    expect(filterCommands(list, "re").map((c) => c.name)).toEqual(["review", "create_plan"]);
+  });
+
+  it("drops non-matches", () => {
+    expect(filterCommands(list, "zzz")).toEqual([]);
+  });
+});

--- a/ui/src/lib/slash.ts
+++ b/ui/src/lib/slash.ts
@@ -1,0 +1,36 @@
+import type { SlashCommand } from "./types";
+
+/**
+ * Detect a slash-command trigger from the text up to the caret. Claude only treats
+ * a leading `/` as a command, so we trigger ONLY at the very start of the prompt:
+ * the text before the caret must be `/` followed by zero or more non-space chars.
+ * Returns the typed query (without the slash), or null when no trigger is active.
+ *
+ *   matchSlashTrigger("/cre", 4)      → { query: "cre" }
+ *   matchSlashTrigger("/", 1)         → { query: "" }
+ *   matchSlashTrigger("fix /foo", 8)  → null   (not at start)
+ *   matchSlashTrigger("/foo bar", 8)  → null   (space ends the token)
+ */
+export function matchSlashTrigger(text: string, caret: number): { query: string } | null {
+  const before = text.slice(0, Math.max(0, caret));
+  const m = /^\/(\S*)$/.exec(before);
+  return m ? { query: m[1]! } : null;
+}
+
+/**
+ * Filter commands by the typed query (case-insensitive). Empty query → all.
+ * Prefix matches rank above mid-name substring matches; ties keep input order
+ * (the list arrives already sorted by name).
+ */
+export function filterCommands(commands: SlashCommand[], query: string): SlashCommand[] {
+  const q = query.toLowerCase();
+  if (!q) return commands;
+  const prefix: SlashCommand[] = [];
+  const substr: SlashCommand[] = [];
+  for (const c of commands) {
+    const name = c.name.toLowerCase();
+    if (name.startsWith(q)) prefix.push(c);
+    else if (name.includes(q)) substr.push(c);
+  }
+  return [...prefix, ...substr];
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -44,10 +44,13 @@ export interface IssueRef {
 }
 /** An installed slash command (skill or command file) surfaced in the New Task
  *  "Commands" tab; picking one seeds the prompt with `/<name> `. */
+export type SlashCommandScope = "project" | "user" | "plugin" | "builtin";
 export interface SlashCommand {
   name: string;
   description: string;
-  scope: "project" | "user";
+  scope: SlashCommandScope;
+  /** Front-matter `argument-hint` (e.g. "<ticket>"), shown dimmed after the name. */
+  argumentHint?: string;
 }
 
 export type BlockShape = "menu" | "yes-no" | "awaiting-input" | "stall";


### PR DESCRIPTION
## Why

In the New Task prompt you can already seed a command from the **Commands tab** (#147). But typing `/` directly in the prompt field — the way Claude Code itself works — gave no recognition. This adds that inline autocomplete, building on #147's existing `/api/commands` index rather than duplicating it.

## What

**Inline `/` autocomplete** (`feat(newtask)`)
- Type `/` at the **start** of the prompt → filtered dropdown of available commands.
- `↑/↓` navigate, `Enter`/`Tab` pick, `Esc` closes; `Cmd/Ctrl+Enter` still submits.
- Picking inserts `/<name> ` and drops the caret after it for arguments.
- Each row shows the `argument-hint` and a source tag (user / plugin / built-in).
- Pure trigger/filter logic in `slash.ts` (slash only at prompt start), unit-tested; dropdown is `SlashCommandMenu`.

**Scanner enrichment** (`feat(commands)`) — also improves the existing Commands tab:
- Installed **plugins** (commands + skills) via `plugins/installed_plugins.json`, namespaced `<plugin>:<name>`. `installPath` is re-rooted to the local `~/.claude` because synced settings can carry another machine's `$HOME`.
- Curated **built-ins** (`/init`, `/review`, `/security-review`, `/pr-comments`); interactive-only ones excluded.
- Front-matter **`argument-hint`** carried through on `SlashCommand`.
- Scope widened to `project | user | plugin | builtin`; precedence builtin < plugin < user < project (project still shadows).

## Notes

- Started against a stale `main` with a parallel server implementation; rebased onto latest `main` and the duplicate server code was dropped in favour of reusing #147.
- Future idea (not in this PR): user-defined text-expansion shortcuts in the same prompt field.

## Tests / gates
- Root: `bun test` (incl. extended `test/commands.test.ts` — plugins, builtins, argument-hint, re-rooting), `bun run lint`, `bun run typecheck` ✓
- UI: `bun run test` (incl. `slash.test.ts`), `bun run check`, `bun run check:i18n` (EN+DE parity) ✓
- `fallow audit --base origin/main --fail-on-issues`: no issues ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)