### PR TITLE
fix(ui): make CI-pending dot actually pulse (opacity blink)

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -124,6 +124,17 @@ body {
     box-shadow: 0 0 0 0 transparent;
   }
 }
+/* in-progress dot: opacity blink (reads clearly at small size, clip-proof,
+   matches the critic reviewing dots — unlike the faint pip-pulse halo) */
+@keyframes dot-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 1;
+  }
+}
 @keyframes blink {
   50% {
     opacity: 0;

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -485,7 +485,7 @@
   .dot-pending {
     background: var(--color-amber);
     /* CI running — pulse like every other in-progress indicator */
-    animation: pip-pulse 1.5s ease-out infinite;
+    animation: dot-pulse 1.1s ease-in-out infinite;
   }
   .dot-success {
     background: var(--color-green, #5ad19a);

--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -57,7 +57,7 @@
   .dot-pending {
     background: var(--color-amber);
     /* CI running — pulse like every other in-progress indicator */
-    animation: pip-pulse 1.5s ease-out infinite;
+    animation: dot-pulse 1.1s ease-in-out infinite;
   }
   .dot-success {
     background: var(--color-green, #5ad19a);


### PR DESCRIPTION
## Problem

The CI-pending dot doesn't visibly pulse — neither in the session list nor the detail pane — despite #149 adding a pulse animation.

## Root cause (investigated, not guessed)

Ruled out the obvious suspects with evidence:

| Suspect | Verdict |
| --- | --- |
| `checks` never becomes `"pending"` | ❌ `rollupChecks()` returns it + broadcasts (tested) |
| Missing base `box-shadow` breaks the keyframe | ❌ frozen-frame repro: identical with/without — keyframe sets `box-shadow` at every stop |
| Svelte mangles the global `pip-pulse` ref | ❌ compiled CSS emits it verbatim |

#149 *works* — it just used the wrong primitive. `pip-pulse` is a faint expanding `box-shadow` halo: near-invisible on a 6–7px dot, low-contrast against dark/amber chrome, and clipped by `.t-head { overflow: hidden }` in the tile view. The dot's own fill never changes.

## Fix

Switch the CI-pending dot to `dot-pulse` — an **opacity blink** (`0.35 ↔ 1`), the same readable, clip-proof, size-independent mechanism the critic in-progress dots already use. The dot itself goes dim→bright.

- `ui/src/app.css` — new global `@keyframes dot-pulse`
- `ui/src/lib/components/PrBadge.svelte` — session-list dot
- `ui/src/lib/components/GitRail.svelte` — detail-pane dot

## Verification

- `bun run check` (svelte-check): 0 errors / 0 warnings
- `prettier --check`: clean
- Compiled CSS resolves `dot-pulse` to the global keyframe (GitRail's local `rev-pulse` untouched)
- Browser repro confirms clear dim→bright pulse vs. the near-invisible old halo

`StatusPip` left on `pip-pulse` (out of scope; same subtlety if we want it changed later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)