### PR TITLE
feat(ui): on-demand dictation overlay, reclaim the input row

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -54,6 +54,8 @@
   "composebar_dictate": "🎤",
   "composebar_dictate_aria": "Diktieren",
   "composebar_dictate_stop_aria": "Diktat beenden",
+  "composebar_open_aria": "Nachricht verfassen oder diktieren",
+  "composebar_overlay_aria": "Nachricht verfassen",
   "gitrail_open_pr": "↟ Open PR",
   "gitrail_ci_status": "CI: {status}",
   "gitrail_confirm_merge": "bestätigen ✓",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -54,6 +54,8 @@
   "composebar_dictate": "🎤",
   "composebar_dictate_aria": "Dictate",
   "composebar_dictate_stop_aria": "Stop dictation",
+  "composebar_open_aria": "Compose or dictate a message",
+  "composebar_overlay_aria": "Compose message",
   "gitrail_open_pr": "↟ Open PR",
   "gitrail_ci_status": "CI: {status}",
   "gitrail_confirm_merge": "confirm ✓",

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -1,27 +1,40 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { m } from "$lib/paraglide/messages";
   import { getLocale } from "$lib/i18n";
   import { insertNewlineAt } from "$lib/compose";
 
-  // Mobile compose bar: a real <textarea> (not xterm's hidden one) so Android
-  // autocomplete / suggestions / double-space-period resolve natively in the
-  // field. We read its value once, on explicit submit — never diffing
+  // Centered compose overlay: a real <textarea> (not xterm's hidden one) so
+  // Android autocomplete / suggestions / double-space-period resolve natively
+  // in the field. We read its value once, on explicit submit — never diffing
   // per-keystroke into the PTY — so xterm's IME duplication bug can't occur.
-  // Presentational: owns its own text + newline editing, emits the composed
-  // string via onsend. The parent decides how to inject it into the terminal.
-  let { onsend }: { onsend: (text: string) => void } = $props();
+  // The overlay floats over the terminal with a blurred backdrop; the parent
+  // mounts it on demand (mic chip) and decides how to inject the composed text.
+  // Presentational: owns its own text + newline editing + dictation, emits the
+  // composed string via onsend and a dismissal via onclose.
+  let {
+    onsend,
+    onclose,
+    startDictation = false,
+  }: {
+    onsend: (text: string) => void;
+    onclose: () => void;
+    // open the overlay already listening (mic-chip entry); typing-only entries
+    // pass false so the keyboard comes up without recording
+    startDictation?: boolean;
+  } = $props();
 
   let value = $state("");
   let ta = $state<HTMLTextAreaElement>();
+  let overlayEl = $state<HTMLDivElement>();
 
   // In-browser dictation via the Web Speech API (Chrome/Android, Safari/iOS).
   // This is NOT the iOS keyboard's native dictation mic — no web API can summon
-  // that — but it's the standards-based equivalent: one tap starts listening and
-  // transcribes straight into this field, so there's no need to open the keyboard
-  // and find its mic. Known gap: WebKit doesn't expose it inside an iOS
-  // home-screen PWA (standalone display mode), only in the Safari browser tab —
-  // so the button hides itself when unsupported rather than appearing dead.
+  // that — but it's the standards-based equivalent: transcribes straight into
+  // this field. Known gap: WebKit doesn't expose it inside an iOS home-screen
+  // PWA (standalone display mode), only in the Safari browser tab. When
+  // unsupported the in-overlay mic toggle hides itself and the overlay is a
+  // plain type-and-send sheet — so the entry point never becomes a dead end.
   const SpeechRec: any =
     typeof window !== "undefined"
       ? ((window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition)
@@ -63,7 +76,34 @@
     listening = true;
   }
 
-  onDestroy(() => recog?.stop());
+  // Keep the sheet centered in the *visible* viewport — i.e. the area above the
+  // soft keyboard — so the field and Send button never hide behind it. The
+  // visualViewport shrinks/offsets when the keyboard opens; we mirror it onto
+  // the overlay so flex-centering targets the on-screen region, not the full
+  // (keyboard-occluded) window.
+  function syncViewport() {
+    const vv = typeof window !== "undefined" ? window.visualViewport : null;
+    if (!vv || !overlayEl) return;
+    overlayEl.style.height = `${vv.height}px`;
+    overlayEl.style.transform = `translateY(${vv.offsetTop}px)`;
+  }
+
+  onMount(() => {
+    syncViewport();
+    window.visualViewport?.addEventListener("resize", syncViewport);
+    window.visualViewport?.addEventListener("scroll", syncViewport);
+    // focus brings up the keyboard for typing; with the mic entry the user can
+    // still edit the transcript inline
+    ta?.focus();
+    autogrow();
+    if (startDictation && speechSupported) toggleDictation();
+  });
+
+  onDestroy(() => {
+    recog?.stop();
+    window.visualViewport?.removeEventListener("resize", syncViewport);
+    window.visualViewport?.removeEventListener("scroll", syncViewport);
+  });
 
   // grow with content (1 line → capped by CSS max-height, then scrolls)
   function autogrow() {
@@ -77,12 +117,18 @@
     listening = false;
     onsend(value);
     value = "";
-    queueMicrotask(autogrow); // shrink back after the binding clears
+    onclose();
+  }
+
+  function cancel() {
+    recog?.stop();
+    listening = false;
+    onclose();
   }
 
   // insert a literal newline at the caret without submitting — Enter does this
   // on the soft keyboard (which has no Shift+Enter), so multi-line prompts build
-  // naturally and Send is the sole submit
+  // naturally and Send is the sole submit. Escape dismisses the overlay.
   function insertNewline() {
     const start = ta?.selectionStart ?? value.length;
     const end = ta?.selectionEnd ?? value.length;
@@ -96,10 +142,12 @@
     });
   }
 
-  // Enter inserts a newline (Send is the only submit). The compose bar is
-  // touch-only — desktop steers xterm directly — so there's no hardware-keyboard
-  // Enter-to-submit path to preserve here.
   function onKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      cancel();
+      return;
+    }
     if (e.key !== "Enter") return;
     e.preventDefault();
     insertNewline();
@@ -115,66 +163,144 @@
     e.preventDefault();
     submit();
   }
+  // dismiss when tapping the dimmed backdrop, but not when tapping the sheet
+  function tapBackdrop(e: PointerEvent) {
+    if (e.target === e.currentTarget) {
+      e.preventDefault();
+      cancel();
+    }
+  }
 </script>
 
-<div class="compose">
-  <textarea
-    bind:this={ta}
-    bind:value
-    class="field"
-    rows="1"
-    inputmode="text"
-    enterkeyhint="enter"
-    autocapitalize="sentences"
-    autocomplete="on"
-    spellcheck="true"
-    placeholder={m.composebar_placeholder()}
-    aria-label={m.composebar_input_aria()}
-    onkeydown={onKeydown}
-    oninput={autogrow}
-  ></textarea>
-  {#if speechSupported}
+<div
+  class="overlay"
+  bind:this={overlayEl}
+  role="dialog"
+  aria-modal="true"
+  aria-label={m.composebar_overlay_aria()}
+  tabindex="-1"
+  onpointerdown={tapBackdrop}
+>
+  <div class="sheet">
     <button
       type="button"
-      class="btn mic"
-      class:listening
-      aria-label={listening ? m.composebar_dictate_stop_aria() : m.composebar_dictate_aria()}
-      aria-pressed={listening}
-      onpointerdown={tapMic}>{m.composebar_dictate()}</button
+      class="close"
+      aria-label={m.common_close()}
+      onpointerdown={(e) => {
+        e.preventDefault();
+        cancel();
+      }}>✕</button
     >
-  {/if}
-  <button
-    type="button"
-    class="btn send"
-    aria-label={m.composebar_send_aria()}
-    onpointerdown={tapSend}>{m.composebar_send()}</button
-  >
+    <textarea
+      bind:this={ta}
+      bind:value
+      class="field"
+      rows="1"
+      inputmode="text"
+      enterkeyhint="enter"
+      autocapitalize="sentences"
+      autocomplete="on"
+      spellcheck="true"
+      placeholder={m.composebar_placeholder()}
+      aria-label={m.composebar_input_aria()}
+      onkeydown={onKeydown}
+      oninput={autogrow}
+    ></textarea>
+    <div class="actions">
+      {#if speechSupported}
+        <button
+          type="button"
+          class="btn mic"
+          class:listening
+          aria-label={listening ? m.composebar_dictate_stop_aria() : m.composebar_dictate_aria()}
+          aria-pressed={listening}
+          onpointerdown={tapMic}>{m.composebar_dictate()}</button
+        >
+      {/if}
+      <button
+        type="button"
+        class="btn send"
+        aria-label={m.composebar_send_aria()}
+        onpointerdown={tapSend}>{m.composebar_send()}</button
+      >
+    </div>
+  </div>
 </div>
 
 <style>
-  .compose {
+  /* full-screen blurred backdrop — the terminal shimmers through, dimmed, while
+     the sheet stays legible. height/transform are set in JS to track the
+     visual viewport so the sheet centers above the keyboard. */
+  .overlay {
+    position: fixed;
+    left: 0;
+    top: 0;
+    right: 0;
+    z-index: 50;
     display: flex;
-    align-items: flex-end;
-    gap: 4px;
-    padding: 6px 10px;
-    background: var(--color-head);
-    border-top: 1px solid var(--color-line);
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(0, 0, 0, 0.45);
+    -webkit-backdrop-filter: blur(3px);
+    backdrop-filter: blur(3px);
+  }
+
+  .sheet {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+    max-width: 560px;
+    padding: 14px;
+    /* nearly opaque so the dictated text reads clearly over the busy terminal */
+    background: color-mix(in srgb, var(--color-head) 94%, transparent);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 8px;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+  }
+
+  .close {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-radius: 3px;
+    color: var(--color-faint);
+    font-size: 15px;
+    cursor: pointer;
+    touch-action: manipulation;
+    user-select: none;
+  }
+  .close:active {
+    color: var(--color-ink);
+    background: var(--color-inset);
   }
 
   .field {
     flex: 1 1 auto;
     min-width: 0;
-    min-height: 40px;
-    max-height: 120px; /* ~5 lines, then scroll */
+    min-height: 64px; /* starts a touch taller, then autogrows with content */
+    max-height: 40vh; /* generous in the overlay, then scroll */
+    margin-top: 4px;
     resize: none;
-    padding: 9px 10px;
+    padding: 10px 12px;
     background: var(--color-inset);
     border: 1px solid var(--color-line-bright);
     border-radius: 3px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 16px; /* ≥16px stops iOS focus-zoom */
-    line-height: 1.3;
+    /* a touch smaller for density; under the 16px iOS no-zoom threshold, an
+       accepted tradeoff since the overlay is centered and not edge-pinned */
+    font-size: 14px;
+    line-height: 1.4;
     overflow-y: auto;
   }
   .field::placeholder {
@@ -185,16 +311,22 @@
     border-color: var(--color-ink);
   }
 
+  .actions {
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+  }
+
   .btn {
     flex: 0 0 auto;
     min-width: 44px;
-    height: 40px;
+    height: 44px;
     background: var(--color-inset);
     border: 1px solid var(--color-line-bright);
     border-radius: 3px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 14px;
+    font-size: 15px;
     cursor: pointer;
     touch-action: manipulation;
     user-select: none;
@@ -202,8 +334,9 @@
       background 0.08s,
       border-color 0.08s;
   }
-  /* the primary action gets a touch more weight */
+  /* Send is the primary action — full width, weighted */
   .btn.send {
+    flex: 1 1 auto;
     background: var(--color-line-bright);
   }
   .btn:active {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -273,6 +273,10 @@
     conn?.send(composeKeystrokes(text));
   }
 
+  // the compose overlay is summoned on demand from the mic chip in the ctrl-row,
+  // reclaiming the row the old always-on input bar used to occupy
+  let composeOpen = $state(false);
+
   $effect(() => {
     const id = unitId;
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive dep
@@ -908,8 +912,8 @@
   {#if (mobile || touch) && tab === "term"}
     <div class="ctrl-row">
       <ControlBar onkey={(seq) => conn?.send(seq)} />
-      <!-- pinned right, in the one-thumb reach zone: attach then Enter, always
-           visible so the primary action never scrolls off -->
+      <!-- pinned right, in the one-thumb reach zone: attach, mic, then Enter,
+           always visible so the primary actions never scroll off -->
       <button
         type="button"
         class="attach"
@@ -922,6 +926,16 @@
       </button>
       <button
         type="button"
+        class="mic"
+        title={m.composebar_open_aria()}
+        aria-label={m.composebar_open_aria()}
+        onpointerdown={(e) => {
+          e.preventDefault();
+          composeOpen = true;
+        }}>{m.composebar_dictate()}</button
+      >
+      <button
+        type="button"
         class="enter"
         aria-label={enter.aria}
         onpointerup={(e) => {
@@ -930,7 +944,13 @@
         }}>{enter.label}</button
       >
     </div>
-    <ComposeBar onsend={sendComposed} />
+    {#if composeOpen}
+      <ComposeBar
+        onsend={sendComposed}
+        onclose={() => (composeOpen = false)}
+        startDictation={true}
+      />
+    {/if}
     <input
       bind:this={fileInput}
       type="file"
@@ -1530,6 +1550,7 @@
     background: var(--color-head);
     border-top: 1px solid var(--color-line);
   }
+  .ctrl-row .mic,
   .ctrl-row .attach,
   .ctrl-row .enter {
     flex: 0 0 auto;
@@ -1547,6 +1568,7 @@
       background 0.08s,
       border-color 0.08s;
   }
+  .ctrl-row .mic:active,
   .ctrl-row .attach:active,
   .ctrl-row .enter:active {
     background: var(--color-line-bright);


### PR DESCRIPTION
## Was & Warum

Die immer sichtbare Compose-Leiste (Textfeld + Senden) kostete auf Touch-Viewports eine komplette Zeile. Seit es das 🎤-Diktat gibt, brauchen wir die Dauer-Leiste nicht mehr. Sie wird durch einen **🎤-Chip in der Steuerungszeile** ersetzt — die Zeile geht ans Terminal zurück.

## Verhalten

- **Tap aufs 🎤** → mittiges **Overlay** über dem Terminal, **geblurtes/abgedunkeltes Backdrop** (Terminal schimmert durch, Feld bleibt lesbar).
- **Diktat startet automatisch**, Text füllt sich live ins Feld; frei editier- und tippbar.
- **Senden-Button unter dem Feld** (volle Breite), kleines 🎤 zum Pause/Weiter, ✕ + Backdrop-Tap zum Abbrechen.
- Feld **über der Soft-Tastatur verankert** (visualViewport), damit Senden nie verdeckt wird.
- Feld startet etwas höher und **wächst dynamisch** mit dem Inhalt; etwas kleinere Schrift für Dichte.
- 🎤-Chip sitzt **zwischen 📎 und ⏎** in der Daumen-Zone.

## Robustheit

- **iOS-PWA ohne Web Speech API:** Chip ist immer da und öffnet das Overlay; ohne Speech-Support kommt einfach das Tipp-Feld hoch (kein Diktat-Autostart, in-Overlay-Mic versteckt) → kein toter Einstieg.

## Checks

- `bun run check` — 0 Fehler / 0 Warnings
- `bun run check:i18n` — 272 Keys in Parität (EN + DE)
- `bun run test` — 162 passed

Neue i18n-Keys: `composebar_open_aria`, `composebar_overlay_aria` (EN + DE).