### PR TITLE
docs(readme): highlight local slash-command surface as a differentiator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ live pane). Auth is the operator's own login; no token relay, no impersonation, 
 If a feature can't be done by typing into a real terminal, it doesn't ship. See `PRD.md` for the
 full rationale.
 
+## Your `/commands` come with you
+
+Because Shepherd attaches to a **genuine interactive `claude` session** running against your own
+`~/.claude`, every slash command you already use locally is available — your project and user
+commands, installed plugins, skills, and the relevant built-ins. The cloud Claude Code (web at
+claude.ai/code, the mobile app) runs in a managed environment that doesn't carry your local command
+setup, so this surface simply isn't there.
+
+The New Task prompt makes it first-class: type `/` at the start and a filtered dropdown of your
+actual commands appears (the same index the Commands tab uses), each row showing its
+`argument-hint` and source (project · user · plugin · builtin). Arrow keys + Enter/Tab to pick, Esc
+to close — so you don't switch tabs or memorize names. It's the full local Claude Code experience,
+driven from your browser or phone.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## What

Adds a new README section **"Your \`/commands\` come with you"** (right after the ToS compliance model) that highlights a key differentiator: because Shepherd attaches to a *genuine interactive* \`claude\` session against your own \`~/.claude\`, all your local slash commands (project · user · plugin · builtin + skills) are available — something the cloud Claude Code (web/app) doesn't carry.

## Why

The interactive-terminal model isn't just a ToS constraint, it's a feature: your full local command surface comes along. The New Task prompt makes it first-class via the inline \`/\` autocomplete (#157). Worth calling out in the project overview.

## Notes

- Docs-only change.
- Placed after the ToS section because that's where the causal link lives — *because* it's a real terminal, your commands work.