### PR TITLE
feat(steerbar): collapse broadcast chip to icon-only on mobile

### DIFF
--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -57,7 +57,8 @@
     onpointermove={move}
     onpointercancel={cancel}
     onpointerup={(e) => tap(e, onbroadcast)}
-    aria-label={m.steerbar_broadcast_aria()}>📡 {m.steerbar_broadcast()}</button
+    aria-label={m.steerbar_broadcast_aria()}
+    >📡<span class="bc-label"> {m.steerbar_broadcast()}</span></button
   >
   {#each steers.list as s (s.id)}
     <button
@@ -114,6 +115,15 @@
   .chip.bc {
     color: var(--color-amber);
     border-color: var(--color-amber);
+  }
+  /* on mobile the broadcast chip collapses to just its 📡 icon to reclaim space */
+  @media (max-width: 768px) {
+    .chip.bc {
+      padding: 0 12px;
+    }
+    .bc-label {
+      display: none;
+    }
   }
   .flash {
     align-self: center;


### PR DESCRIPTION
On mobile (≤768px), the broadcast chip now renders just the 📡 icon — the "Broadcast" text label is hidden via CSS to reclaim horizontal space in the steer bar. Desktop keeps the full "📡 Broadcast".

The `aria-label` is unchanged, so the accessible name stays intact for screen readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)