### PR TITLE
fix(gitrail): close findings panel after sending review to agent

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -72,7 +72,6 @@
   "gitrail_critic_on_title": "Kritiker ist an: Ein automatischer Reviewer prüft den Diff jedes Pull Requests und fordert Änderungen an oder hinterlässt Kommentare. Klicken, um ihn für dieses Repository auszuschalten.",
   "gitrail_critic_off_title": "Kritiker ist aus: Anschalten, damit ein automatischer Reviewer den Diff jedes Pull Requests prüft und Änderungen anfordert oder Kommentare hinterlässt. Klicken, um ihn für dieses Repository einzuschalten.",
   "gitrail_send_review": "↩ Review an Agent",
-  "gitrail_review_sent": "gesendet ✓",
   "gitrail_send_review_failed": "Senden fehlgeschlagen",
   "gitrail_review_title": "Kritiker-Befunde",
   "gitrail_ready": "Bereit",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -72,7 +72,6 @@
   "gitrail_critic_on_title": "Critic is on: an automated reviewer inspects each pull request's diff and requests changes or leaves comments. Click to turn it off for this repository.",
   "gitrail_critic_off_title": "Critic is off: turn it on to have an automated reviewer inspect each pull request's diff and request changes or leave comments. Click to turn it on for this repository.",
   "gitrail_send_review": "↩ Send review to agent",
-  "gitrail_review_sent": "sent ✓",
   "gitrail_send_review_failed": "send failed",
   "gitrail_review_title": "Critic findings",
   "gitrail_ready": "Ready",

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -166,14 +166,12 @@
     if (!verdict?.body) return;
     try {
       await replySession(sessionId, `Address this code review feedback:\n\n${verdict.body}`);
-      reviewFlash = m.gitrail_review_sent();
-      reviewFlashErr = false;
-      showReview = false; // dismiss findings panel once the review is on its way
+      showReview = false; // panel closing is the success feedback; dismiss it
     } catch {
       reviewFlash = m.gitrail_send_review_failed();
       reviewFlashErr = true;
+      setTimeout(() => (reviewFlash = null), 1500);
     }
-    setTimeout(() => (reviewFlash = null), 1500);
   }
 </script>
 

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -168,6 +168,7 @@
       await replySession(sessionId, `Address this code review feedback:\n\n${verdict.body}`);
       reviewFlash = m.gitrail_review_sent();
       reviewFlashErr = false;
+      showReview = false; // dismiss findings panel once the review is on its way
     } catch {
       reviewFlash = m.gitrail_send_review_failed();
       reviewFlashErr = true;


### PR DESCRIPTION
## What

The critic-findings popover stayed open after clicking **Send review to agent**. Now it dismisses on a successful send.

## Why

Once the review is on its way to the agent, the panel has served its purpose — leaving it open is dead UI.

## Behavior

- Success → `showReview = false`, panel closes.
- Error → panel stays open so the failure flash remains visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)