### PR TITLE
feat(herd): group merged-PR sessions in their own section

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -85,6 +85,7 @@
   "herd_ready_empty": "Nichts wartet — alle sind beschäftigt",
   "herd_empty": "Keine Aufgaben — + Neue Aufgabe",
   "herd_ready_group": "Bereit zum Mergen ({count})",
+  "herd_merged_group": "Gemergt ({count})",
   "issuespanel_title": "ISSUES",
   "issuespanel_title_with_slug": "ISSUES · {slug}",
   "issuespanel_no_host": "kein Git-Host für dieses Repo konfiguriert",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -85,6 +85,7 @@
   "herd_ready_empty": "Nothing waiting — all hands working",
   "herd_empty": "No tasks — + New Task",
   "herd_ready_group": "Ready to merge ({count})",
+  "herd_merged_group": "Merged ({count})",
   "issuespanel_title": "ISSUES",
   "issuespanel_title_with_slug": "ISSUES · {slug}",
   "issuespanel_no_host": "no git host configured for this repo",

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -30,8 +30,8 @@
     filter === "ready" ? sessions.filter((s) => s.status !== "running") : sessions,
   );
   // within the shown set: active rows on top; ready-to-merge ones parked in a
-  // green group at the bottom
-  const partition = $derived(partitionSessions(shown));
+  // green group below, merged-PR ones in a blue group at the very bottom
+  const partition = $derived(partitionSessions(shown, git));
 </script>
 
 <div class="panel bracket">
@@ -73,6 +73,21 @@
       {#if partition.ready.length > 0}
         <div class="ready-head micro">{m.herd_ready_group({ count: partition.ready.length })}</div>
         {#each partition.ready as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            {ondecommission}
+          />
+        {/each}
+      {/if}
+      {#if partition.merged.length > 0}
+        <div class="merged-head micro">
+          {m.herd_merged_group({ count: partition.merged.length })}
+        </div>
+        {#each partition.merged as session (session.id)}
           <UnitRow
             {session}
             selected={session.id === selectedId}
@@ -164,6 +179,16 @@
     margin-top: 6px;
     color: var(--color-green);
     border-top: 1px solid color-mix(in srgb, var(--color-green) 30%, var(--color-line));
+  }
+
+  /* blue section header for the landed "merged PR" group */
+  .merged-head {
+    display: flex;
+    align-items: center;
+    padding: 10px 8px 6px;
+    margin-top: 6px;
+    color: var(--color-blue);
+    border-top: 1px solid color-mix(in srgb, var(--color-blue) 30%, var(--color-line));
   }
 
   .units {

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "vitest";
 import { partitionSessions } from "./herd-partition";
-import type { Session } from "$lib/types";
+import type { Session, GitState } from "$lib/types";
 
 function session(id: string, readyToMerge = false): Session {
   return {
@@ -26,22 +26,54 @@ function session(id: string, readyToMerge = false): Session {
   };
 }
 
+function git(state: GitState["state"]): GitState {
+  return { kind: "github", state, checks: "none", deployConfigured: false };
+}
+
 test("ready sessions land in the ready group, active stay on top", () => {
   const list = [session("a"), session("r1", true), session("b"), session("r2", true), session("c")];
-  const { active, ready } = partitionSessions(list);
+  const { active, ready, merged } = partitionSessions(list, {});
   expect(active.map((s) => s.id)).toEqual(["a", "b", "c"]);
   expect(ready.map((s) => s.id)).toEqual(["r1", "r2"]);
+  expect(merged).toHaveLength(0);
+});
+
+test("merged-PR sessions land in the merged group", () => {
+  const list = [session("a"), session("m1"), session("b")];
+  const { active, ready, merged } = partitionSessions(list, { m1: git("merged") });
+  expect(active.map((s) => s.id)).toEqual(["a", "b"]);
+  expect(ready).toHaveLength(0);
+  expect(merged.map((s) => s.id)).toEqual(["m1"]);
+});
+
+test("merged wins over ready when both apply", () => {
+  const list = [session("x", true)];
+  const { ready, merged } = partitionSessions(list, { x: git("merged") });
+  expect(ready).toHaveLength(0);
+  expect(merged.map((s) => s.id)).toEqual(["x"]);
+});
+
+test("non-merged PR states leave the session in its base group", () => {
+  const list = [session("a"), session("r1", true)];
+  const { active, ready, merged } = partitionSessions(list, {
+    a: git("open"),
+    r1: git("open"),
+  });
+  expect(active.map((s) => s.id)).toEqual(["a"]);
+  expect(ready.map((s) => s.id)).toEqual(["r1"]);
+  expect(merged).toHaveLength(0);
 });
 
 test("preserves input order within each group", () => {
   const list = [session("r1", true), session("a"), session("r2", true), session("b")];
-  const { active, ready } = partitionSessions(list);
+  const { active, ready } = partitionSessions(list, {});
   expect(active.map((s) => s.id)).toEqual(["a", "b"]);
   expect(ready.map((s) => s.id)).toEqual(["r1", "r2"]);
 });
 
-test("all-active yields an empty ready group", () => {
-  const { active, ready } = partitionSessions([session("a"), session("b")]);
+test("all-active yields empty ready and merged groups", () => {
+  const { active, ready, merged } = partitionSessions([session("a"), session("b")], {});
   expect(active).toHaveLength(2);
   expect(ready).toHaveLength(0);
+  expect(merged).toHaveLength(0);
 });

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -1,14 +1,24 @@
-import type { Session } from "$lib/types";
+import type { Session, GitState } from "$lib/types";
 
-/** Split sessions into active (not ready) and ready-to-merge groups, preserving
- *  the input order within each group. The ready group renders below the active
- *  one as a parked "done" section. */
-export function partitionSessions(sessions: Session[]): {
+/** Split sessions into active (still in play), ready-to-merge (operator-parked),
+ *  and merged (PR already landed) groups, preserving the input order within each.
+ *  Merged wins over ready: once the PR is in, that's the final state. The ready
+ *  and merged groups render below the active one as parked "done" sections. */
+export function partitionSessions(
+  sessions: Session[],
+  git: Record<string, GitState>,
+): {
   active: Session[];
   ready: Session[];
+  merged: Session[];
 } {
   const active: Session[] = [];
   const ready: Session[] = [];
-  for (const s of sessions) (s.readyToMerge ? ready : active).push(s);
-  return { active, ready };
+  const merged: Session[] = [];
+  for (const s of sessions) {
+    if (git[s.id]?.state === "merged") merged.push(s);
+    else if (s.readyToMerge) ready.push(s);
+    else active.push(s);
+  }
+  return { active, ready, merged };
 }


### PR DESCRIPTION
## What

Merged-PR sessions now break out into their own group in the herd sidebar, mirroring the existing **Ready to merge** group.

Grouping precedence (active → ready → merged, parked at the bottom):
- `git.state === "merged"` → **Merged** group (blue header)
- else `readyToMerge` → **Ready to merge** group (green header)
- else → **active**

Merged wins over ready — once the PR has landed, that's the final state. Input order is preserved within each group.

## Changes

- `herd-partition.ts` — `partitionSessions` now takes live `git` state and returns a third `merged` group.
- `Herd.svelte` — renders the new `.merged-head` section (blue, `--color-blue`) below the ready group.
- `en.json` / `de.json` — new `herd_merged_group` key (`Merged ({count})` / `Gemergt ({count})`); i18n parity gate passes.
- `herd-partition.test.ts` — added cases for merged grouping, merged-wins-over-ready, and non-merged PR states.

No DB/server changes — merged state already comes live from `GitState.state`.

## Verification

- `bun run check` — 0 errors
- `bun run check:i18n` — locales in parity
- `bun run test` (partition suite) — 6 passing

> Note: used **blue** for the merged header since the palette has no purple. Easy to swap for a dedicated violet token if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)