### PR TITLE
fix(viewport): let bottom button bars scroll without triggering agent swipe

### DIFF
--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -49,7 +49,7 @@
   }
 </script>
 
-<div class="steer-bar" role="toolbar" aria-label={m.steerbar_toolbar_aria()}>
+<div class="steer-bar" role="toolbar" aria-label={m.steerbar_toolbar_aria()} data-swipe-ignore>
   <button
     type="button"
     class="chip bc"

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -732,8 +732,16 @@
     let locked = false; // recognised as an actionable horizontal swipe
     const onStart = (e: TouchEvent) => {
       if (e.touches.length !== 1) return;
-      // don't hijack text selection / cursor placement in editable fields
-      if ((e.target as Element | null)?.closest("input, textarea, [contenteditable]")) return;
+      // don't hijack text selection / cursor placement in editable fields, nor the
+      // horizontally-scrollable bottom bars (steer chips, control keys, compose) —
+      // those overflow off-screen on a phone and the operator scrolls them sideways
+      // to reach a hidden button; only the terminal pane itself pages between agents.
+      if (
+        (e.target as Element | null)?.closest(
+          "input, textarea, [contenteditable], [data-swipe-ignore]",
+        )
+      )
+        return;
       startX = e.touches[0].clientX;
       startY = e.touches[0].clientY;
       armed = true;
@@ -1103,7 +1111,7 @@
   <!-- control-key bar: any touch device (incl. unfolded foldables wider than the
        mobile breakpoint) gets it, since there's no hardware keyboard to steer with -->
   {#if (mobile || touch) && tab === "term"}
-    <div class="ctrl-row" bind:this={ctrlRowEl}>
+    <div class="ctrl-row" bind:this={ctrlRowEl} data-swipe-ignore>
       <!-- Esc/Tab frozen on the left edge; the arrows + ^-keys scroll in the
            middle; attach/dictate/Enter frozen on the right. There's no compose
            chip — swipe up from this row to summon the compose sheet. -->


### PR DESCRIPTION
## Problem

The terminal pane swipe (swipe left/right to page between agents), added in a recent PR, is bound on the whole `.viewport` in the **capture phase**. So a horizontal drag that *starts on the bottom button bars* was captured as an agent switch instead of scrolling those bars.

On a phone the steer chips and control keys (cursor, up arrow, left/right keys, …) overflow off-screen — they're horizontally scrollable (`overflow-x: auto`) precisely so the operator can scroll them sideways to reach a hidden button. But that sideways scroll was being hijacked into a terminal switch.

## Fix

The swipe handler already excluded editable fields (`input, textarea, [contenteditable]`). Extend that exclusion to also skip `[data-swipe-ignore]`, and mark the scrollable bottom bars with it:

- `Viewport.svelte` — `onStart` bails on `[data-swipe-ignore]`; the gesture never arms, `preventDefault` never fires, native horizontal scroll works.
- `data-swipe-ignore` added to: `.ctrl-row` (ControlBar + attach/enter), `.steer-bar` (SteerBar), `.compose` (ComposeBar).

## Result

- **Swipe over the terminal pane** → still pages between agents (unchanged).
- **Swipe over the button bars** → now scrolls the buttons sideways instead of switching agents.

Existing tap-vs-drag logic in SteerBar/ControlBar is untouched.

## Test plan

- [x] `cd ui && bun run check` — 0 errors
- [ ] On iPhone: swipe the control-key / steer bars sideways → bar scrolls, no agent switch
- [ ] On iPhone: swipe over the terminal pane → still switches agents