### PR TITLE
feat(compose): on-demand compose sheet — swipe-up + one-tap dictate

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -55,6 +55,8 @@
   "composebar_dictate": "🎤",
   "composebar_dictate_aria": "Diktieren",
   "composebar_dictate_stop_aria": "Diktat beenden",
+  "composebar_open_aria": "Nachricht verfassen oder diktieren",
+  "composebar_overlay_aria": "Nachricht verfassen",
   "gitrail_open_pr": "↟ Open PR",
   "gitrail_ci_status": "CI: {status}",
   "gitrail_confirm_merge": "bestätigen ✓",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -55,7 +55,6 @@
   "composebar_dictate": "🎤",
   "composebar_dictate_aria": "Diktieren",
   "composebar_dictate_stop_aria": "Diktat beenden",
-  "composebar_open_aria": "Nachricht verfassen oder diktieren",
   "composebar_overlay_aria": "Nachricht verfassen",
   "gitrail_open_pr": "↟ Open PR",
   "gitrail_ci_status": "CI: {status}",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -55,6 +55,8 @@
   "composebar_dictate": "🎤",
   "composebar_dictate_aria": "Dictate",
   "composebar_dictate_stop_aria": "Stop dictation",
+  "composebar_open_aria": "Compose or dictate a message",
+  "composebar_overlay_aria": "Compose message",
   "gitrail_open_pr": "↟ Open PR",
   "gitrail_ci_status": "CI: {status}",
   "gitrail_confirm_merge": "confirm ✓",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -55,7 +55,6 @@
   "composebar_dictate": "🎤",
   "composebar_dictate_aria": "Dictate",
   "composebar_dictate_stop_aria": "Stop dictation",
-  "composebar_open_aria": "Compose or dictate a message",
   "composebar_overlay_aria": "Compose message",
   "gitrail_open_pr": "↟ Open PR",
   "gitrail_ci_status": "CI: {status}",

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -7,6 +7,7 @@
   import { matchSlashTrigger, filterCommands } from "$lib/slash";
   import type { SlashCommand } from "$lib/types";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
+  import { steers } from "$lib/steers.svelte";
 
   // Centered compose overlay: a real <textarea> (not xterm's hidden one) so
   // Android autocomplete / suggestions / double-space-period resolve natively
@@ -86,6 +87,49 @@
       ta?.focus();
       ta?.setSelectionRange(insert.length, insert.length);
     });
+  }
+
+  // Canned steers (same presets as the SteerBar) drop into the field as an
+  // editable draft rather than firing straight off — the compose sheet is a
+  // "compose then Send" surface, so a steer is a starting point you can tweak.
+  // Set when empty, append on a new line otherwise so a typed message is kept.
+  function applySteer(text: string) {
+    value = value.trim() ? value.trimEnd() + "\n" + text : text;
+    slashOpen = false;
+    queueMicrotask(() => {
+      autogrow();
+      ta?.focus();
+      const end = value.length;
+      ta?.setSelectionRange(end, end);
+    });
+  }
+
+  // Tap-vs-drag for the horizontally-scrolling steer row (mirrors SteerBar): arm
+  // on pointerdown, disarm once movement passes slop (a scroll) or the browser
+  // takes the gesture, and only insert on a clean tap — so scrolling the row
+  // never fires a chip.
+  const STEER_SLOP = 10;
+  let steerArmed: number | null = null;
+  let steerSX = 0;
+  let steerSY = 0;
+  function steerDown(e: PointerEvent) {
+    steerArmed = e.pointerId;
+    steerSX = e.clientX;
+    steerSY = e.clientY;
+  }
+  function steerMove(e: PointerEvent) {
+    if (steerArmed !== e.pointerId) return;
+    if (Math.abs(e.clientX - steerSX) > STEER_SLOP || Math.abs(e.clientY - steerSY) > STEER_SLOP)
+      steerArmed = null;
+  }
+  function steerCancel(e: PointerEvent) {
+    if (steerArmed === e.pointerId) steerArmed = null;
+  }
+  function steerTap(e: PointerEvent, text: string) {
+    if (steerArmed !== e.pointerId) return;
+    steerArmed = null;
+    e.preventDefault();
+    applySteer(text);
   }
 
   // In-browser dictation via the Web Speech API (Chrome/Android, Safari/iOS).
@@ -309,6 +353,21 @@
         />
       {/if}
     </div>
+    {#if steers.list.length > 0}
+      <div class="steers">
+        {#each steers.list as s (s.id)}
+          <button
+            type="button"
+            class="steer-chip"
+            title={s.text}
+            onpointerdown={steerDown}
+            onpointermove={steerMove}
+            onpointercancel={steerCancel}
+            onpointerup={(e) => steerTap(e, s.text)}>{s.label}</button
+          >
+        {/each}
+      </div>
+    {/if}
     <div class="actions">
       {#if speechSupported}
         <button
@@ -332,8 +391,9 @@
 
 <style>
   /* full-screen blurred backdrop — the terminal shimmers through, dimmed, while
-     the sheet stays legible. height/transform are set in JS to track the
-     visual viewport so the sheet centers above the keyboard. */
+     the sheet stays legible. height/transform are set in JS to track the visual
+     viewport so the sheet sits flush above the soft keyboard. align-items:flex-end
+     anchors the sheet to the bottom edge (a rising bottom sheet), not the center. */
   .overlay {
     position: fixed;
     left: 0;
@@ -341,9 +401,8 @@
     right: 0;
     z-index: 50;
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     justify-content: center;
-    padding: 16px;
     background: rgba(0, 0, 0, 0.45);
     -webkit-backdrop-filter: blur(3px);
     backdrop-filter: blur(3px);
@@ -355,13 +414,27 @@
     flex-direction: column;
     gap: 8px;
     width: 100%;
-    max-width: 560px;
-    padding: 14px;
-    /* nearly opaque so the dictated text reads clearly over the busy terminal */
+    padding: 12px 14px calc(12px + env(safe-area-inset-bottom));
+    /* nearly opaque so the composed text reads clearly over the busy terminal */
     background: color-mix(in srgb, var(--color-head) 94%, transparent);
-    border: 1px solid var(--color-line-bright);
-    border-radius: 8px;
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+    border-top: 1px solid var(--color-line-bright);
+    border-radius: 12px 12px 0 0;
+    box-shadow: 0 -8px 40px rgba(0, 0, 0, 0.5);
+    /* rise from the bottom edge when summoned */
+    animation: sheetRise 0.18s ease-out;
+  }
+  @keyframes sheetRise {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .sheet {
+      animation: none;
+    }
   }
 
   .close {
@@ -419,6 +492,42 @@
   }
   .field:focus {
     outline: none;
+    border-color: var(--color-ink);
+  }
+
+  /* canned-steer row: scrolls horizontally so the presets never crowd the
+     field or the Send button; hidden scrollbar like the SteerBar */
+  .steers {
+    display: flex;
+    gap: 6px;
+    overflow-x: auto;
+    white-space: nowrap;
+    min-width: 0;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .steers::-webkit-scrollbar {
+    display: none;
+  }
+  .steer-chip {
+    flex: 0 0 auto;
+    height: 34px;
+    padding: 0 12px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 3px;
+    color: var(--color-ink);
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    cursor: pointer;
+    touch-action: pan-x;
+    user-select: none;
+    transition:
+      background 0.08s,
+      border-color 0.08s;
+  }
+  .steer-chip:active {
+    background: var(--color-line-bright);
     border-color: var(--color-ink);
   }
 

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { m } from "$lib/paraglide/messages";
   import { getLocale } from "$lib/i18n";
   import { insertNewlineAt } from "$lib/compose";
@@ -8,18 +8,33 @@
   import type { SlashCommand } from "$lib/types";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
 
-  // Mobile compose bar: a real <textarea> (not xterm's hidden one) so Android
-  // autocomplete / suggestions / double-space-period resolve natively in the
-  // field. We read its value once, on explicit submit — never diffing
+  // Centered compose overlay: a real <textarea> (not xterm's hidden one) so
+  // Android autocomplete / suggestions / double-space-period resolve natively
+  // in the field. We read its value once, on explicit submit — never diffing
   // per-keystroke into the PTY — so xterm's IME duplication bug can't occur.
-  // Presentational: owns its own text + newline editing, emits the composed
-  // string via onsend. The parent decides how to inject it into the terminal.
+  // The overlay floats over the terminal with a blurred backdrop; the parent
+  // mounts it on demand (swipe-up / ✎ chip) and decides how to inject the text.
+  // Presentational: owns its own text + newline editing + dictation + slash
+  // picker, emits the composed string via onsend and a dismissal via onclose.
   // repoPath powers the inline slash-command picker (same /api/commands index
   // as New Task), so a leading `/` offers the session repo's commands.
-  let { onsend, repoPath }: { onsend: (text: string) => void; repoPath: string } = $props();
+  let {
+    onsend,
+    onclose,
+    repoPath,
+    startDictation = false,
+  }: {
+    onsend: (text: string) => void;
+    onclose: () => void;
+    repoPath: string;
+    // open the overlay already listening (mic entry); typing-only entries pass
+    // false so the keyboard comes up without recording
+    startDictation?: boolean;
+  } = $props();
 
   let value = $state("");
   let ta = $state<HTMLTextAreaElement>();
+  let overlayEl = $state<HTMLDivElement>();
 
   // ── inline slash-command autocomplete (mirrors NewTask, opens upward) ──
   let allCommands = $state<SlashCommand[]>([]);
@@ -75,11 +90,11 @@
 
   // In-browser dictation via the Web Speech API (Chrome/Android, Safari/iOS).
   // This is NOT the iOS keyboard's native dictation mic — no web API can summon
-  // that — but it's the standards-based equivalent: one tap starts listening and
-  // transcribes straight into this field, so there's no need to open the keyboard
-  // and find its mic. Known gap: WebKit doesn't expose it inside an iOS
-  // home-screen PWA (standalone display mode), only in the Safari browser tab —
-  // so the button hides itself when unsupported rather than appearing dead.
+  // that — but it's the standards-based equivalent: transcribes straight into
+  // this field. Known gap: WebKit doesn't expose it inside an iOS home-screen
+  // PWA (standalone display mode), only in the Safari browser tab. When
+  // unsupported the in-overlay mic toggle hides itself and the overlay is a
+  // plain type-and-send sheet — so the entry point never becomes a dead end.
   const SpeechRec: any =
     typeof window !== "undefined"
       ? ((window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition)
@@ -121,7 +136,34 @@
     listening = true;
   }
 
-  onDestroy(() => recog?.stop());
+  // Keep the sheet centered in the *visible* viewport — i.e. the area above the
+  // soft keyboard — so the field and Send button never hide behind it. The
+  // visualViewport shrinks/offsets when the keyboard opens; we mirror it onto
+  // the overlay so flex-centering targets the on-screen region, not the full
+  // (keyboard-occluded) window.
+  function syncViewport() {
+    const vv = typeof window !== "undefined" ? window.visualViewport : null;
+    if (!vv || !overlayEl) return;
+    overlayEl.style.height = `${vv.height}px`;
+    overlayEl.style.transform = `translateY(${vv.offsetTop}px)`;
+  }
+
+  onMount(() => {
+    syncViewport();
+    window.visualViewport?.addEventListener("resize", syncViewport);
+    window.visualViewport?.addEventListener("scroll", syncViewport);
+    // focus brings up the keyboard for typing; with the mic entry the user can
+    // still edit the transcript inline
+    ta?.focus();
+    autogrow();
+    if (startDictation && speechSupported) toggleDictation();
+  });
+
+  onDestroy(() => {
+    recog?.stop();
+    window.visualViewport?.removeEventListener("resize", syncViewport);
+    window.visualViewport?.removeEventListener("scroll", syncViewport);
+  });
 
   // grow with content (1 line → capped by CSS max-height, then scrolls)
   function autogrow() {
@@ -136,12 +178,18 @@
     slashOpen = false;
     onsend(value);
     value = "";
-    queueMicrotask(autogrow); // shrink back after the binding clears
+    onclose();
+  }
+
+  function cancel() {
+    recog?.stop();
+    listening = false;
+    onclose();
   }
 
   // insert a literal newline at the caret without submitting — Enter does this
   // on the soft keyboard (which has no Shift+Enter), so multi-line prompts build
-  // naturally and Send is the sole submit
+  // naturally and Send is the sole submit. Escape dismisses the overlay.
   function insertNewline() {
     const start = ta?.selectionStart ?? value.length;
     const end = ta?.selectionEnd ?? value.length;
@@ -155,11 +203,10 @@
     });
   }
 
-  // Enter inserts a newline (Send is the only submit). The compose bar is
-  // touch-only — desktop steers xterm directly — so there's no hardware-keyboard
-  // Enter-to-submit path to preserve here. While the slash menu is open it
-  // captures the navigation keys so arrows/Enter/Tab drive the picker (a paired
-  // hardware keyboard on a foldable/tablet); a tap on a row works regardless.
+  // Enter inserts a newline (Send is the only submit). While the slash menu is
+  // open it captures arrows/Enter/Tab/Escape to drive the picker (paired hardware
+  // keyboard on a foldable/tablet; a tap on a row works regardless). Escape with
+  // no menu open dismisses the whole overlay.
   function onKeydown(e: KeyboardEvent) {
     if (slashOpen && slashMatches.length > 0) {
       if (e.key === "ArrowDown") {
@@ -184,6 +231,11 @@
       slashOpen = false;
       return;
     }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      cancel();
+      return;
+    }
     if (e.key !== "Enter") return;
     e.preventDefault();
     insertNewline();
@@ -199,65 +251,140 @@
     e.preventDefault();
     submit();
   }
+  // dismiss when tapping the dimmed backdrop, but not when tapping the sheet
+  function tapBackdrop(e: PointerEvent) {
+    if (e.target === e.currentTarget) {
+      e.preventDefault();
+      cancel();
+    }
+  }
 </script>
 
-<div class="compose">
-  <div class="field-wrap">
-    <textarea
-      bind:this={ta}
-      bind:value
-      class="field"
-      rows="1"
-      inputmode="text"
-      enterkeyhint="enter"
-      autocapitalize="sentences"
-      autocomplete="on"
-      spellcheck="true"
-      placeholder={m.composebar_placeholder()}
-      aria-label={m.composebar_input_aria()}
-      onkeydown={onKeydown}
-      oninput={() => {
-        autogrow();
-        refreshSlash();
-      }}
-      onblur={() => (slashOpen = false)}
-    ></textarea>
-    {#if slashOpen}
-      <SlashCommandMenu
-        commands={slashMatches}
-        activeIndex={slashIndex}
-        placement="up"
-        onpick={pickCommand}
-        onhover={(i) => (slashIndex = i)}
-      />
-    {/if}
-  </div>
-  {#if speechSupported}
+<div
+  class="overlay"
+  bind:this={overlayEl}
+  role="dialog"
+  aria-modal="true"
+  aria-label={m.composebar_overlay_aria()}
+  tabindex="-1"
+  onpointerdown={tapBackdrop}
+>
+  <div class="sheet">
     <button
       type="button"
-      class="btn mic"
-      class:listening
-      aria-label={listening ? m.composebar_dictate_stop_aria() : m.composebar_dictate_aria()}
-      aria-pressed={listening}
-      onpointerdown={tapMic}>{m.composebar_dictate()}</button
+      class="close"
+      aria-label={m.common_close()}
+      onpointerdown={(e) => {
+        e.preventDefault();
+        cancel();
+      }}>✕</button
     >
-  {/if}
-  <button
-    type="button"
-    class="btn send"
-    aria-label={m.composebar_send_aria()}
-    onpointerdown={tapSend}>{m.composebar_send()}</button
-  >
+    <div class="field-wrap">
+      <textarea
+        bind:this={ta}
+        bind:value
+        class="field"
+        rows="1"
+        inputmode="text"
+        enterkeyhint="enter"
+        autocapitalize="sentences"
+        autocomplete="on"
+        spellcheck="true"
+        placeholder={m.composebar_placeholder()}
+        aria-label={m.composebar_input_aria()}
+        onkeydown={onKeydown}
+        oninput={() => {
+          autogrow();
+          refreshSlash();
+        }}
+        onblur={() => (slashOpen = false)}
+      ></textarea>
+      {#if slashOpen}
+        <SlashCommandMenu
+          commands={slashMatches}
+          activeIndex={slashIndex}
+          placement="up"
+          onpick={pickCommand}
+          onhover={(i) => (slashIndex = i)}
+        />
+      {/if}
+    </div>
+    <div class="actions">
+      {#if speechSupported}
+        <button
+          type="button"
+          class="btn mic"
+          class:listening
+          aria-label={listening ? m.composebar_dictate_stop_aria() : m.composebar_dictate_aria()}
+          aria-pressed={listening}
+          onpointerdown={tapMic}>{m.composebar_dictate()}</button
+        >
+      {/if}
+      <button
+        type="button"
+        class="btn send"
+        aria-label={m.composebar_send_aria()}
+        onpointerdown={tapSend}>{m.composebar_send()}</button
+      >
+    </div>
+  </div>
 </div>
 
 <style>
-  .compose {
+  /* full-screen blurred backdrop — the terminal shimmers through, dimmed, while
+     the sheet stays legible. height/transform are set in JS to track the
+     visual viewport so the sheet centers above the keyboard. */
+  .overlay {
+    position: fixed;
+    left: 0;
+    top: 0;
+    right: 0;
+    z-index: 50;
     display: flex;
-    align-items: flex-end;
-    gap: 4px;
-    padding: 6px 10px;
-    background: var(--color-head);
-    border-top: 1px solid var(--color-line);
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(0, 0, 0, 0.45);
+    -webkit-backdrop-filter: blur(3px);
+    backdrop-filter: blur(3px);
+  }
+
+  .sheet {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+    max-width: 560px;
+    padding: 14px;
+    /* nearly opaque so the dictated text reads clearly over the busy terminal */
+    background: color-mix(in srgb, var(--color-head) 94%, transparent);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 8px;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+  }
+
+  .close {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-radius: 3px;
+    color: var(--color-faint);
+    font-size: 15px;
+    cursor: pointer;
+    touch-action: manipulation;
+    user-select: none;
+  }
+  .close:active {
+    color: var(--color-ink);
+    background: var(--color-inset);
   }
 
   /* anchors the slash-command menu (positioned absolute) to the field */
@@ -271,17 +398,20 @@
   .field {
     flex: 1 1 auto;
     min-width: 0;
-    min-height: 40px;
-    max-height: 120px; /* ~5 lines, then scroll */
+    min-height: 64px; /* starts a touch taller, then autogrows with content */
+    max-height: 40vh; /* generous in the overlay, then scroll */
+    margin-top: 4px;
     resize: none;
-    padding: 9px 10px;
+    padding: 10px 12px;
     background: var(--color-inset);
     border: 1px solid var(--color-line-bright);
     border-radius: 3px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 16px; /* ≥16px stops iOS focus-zoom */
-    line-height: 1.3;
+    /* a touch smaller for density; under the 16px iOS no-zoom threshold, an
+       accepted tradeoff since the overlay is centered and not edge-pinned */
+    font-size: 14px;
+    line-height: 1.4;
     overflow-y: auto;
   }
   .field::placeholder {
@@ -292,16 +422,22 @@
     border-color: var(--color-ink);
   }
 
+  .actions {
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+  }
+
   .btn {
     flex: 0 0 auto;
     min-width: 44px;
-    height: 40px;
+    height: 44px;
     background: var(--color-inset);
     border: 1px solid var(--color-line-bright);
     border-radius: 3px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 14px;
+    font-size: 15px;
     cursor: pointer;
     touch-action: manipulation;
     user-select: none;
@@ -309,8 +445,9 @@
       background 0.08s,
       border-color 0.08s;
   }
-  /* the primary action gets a touch more weight */
+  /* Send is the primary action — full width, weighted */
   .btn.send {
+    flex: 1 1 auto;
     background: var(--color-line-bright);
   }
   .btn:active {

--- a/ui/src/lib/components/ControlBar.svelte
+++ b/ui/src/lib/components/ControlBar.svelte
@@ -1,8 +1,20 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
-  import { controlKeys, type ControlKey } from "$lib/controlKeys";
+  import { controlKeys, type ControlKey, type ControlGroup } from "$lib/controlKeys";
 
-  let { onkey }: { onkey: (seq: string) => void } = $props();
+  // `include` renders only the listed groups (omit for all); `scroll=false`
+  // fits content instead of growing+scrolling, for a fixed edge cluster. This
+  // lets the ctrl-row freeze Esc/Tab on the left and scroll the arrows + ^-keys
+  // in the middle, each as its own ControlBar.
+  let {
+    onkey,
+    include,
+    scroll = true,
+  }: {
+    onkey: (seq: string) => void;
+    include?: ControlGroup[];
+    scroll?: boolean;
+  } = $props();
 
   // Chunk the flat, group-ordered key list into runs of the same group so each
   // run can render inside its own "well" (Gestalt common-region). Derived so it
@@ -10,6 +22,7 @@
   const groups = $derived.by(() => {
     const out: ControlKey[][] = [];
     for (const k of controlKeys()) {
+      if (include && !(k.group && include.includes(k.group))) continue;
       const last = out.at(-1);
       if (last && last[0].group === k.group) last.push(k);
       else out.push([k]);
@@ -52,7 +65,12 @@
   }
 </script>
 
-<div class="ctrl-bar" role="toolbar" aria-label={m.controlbar_toolbar_aria()}>
+<div
+  class="ctrl-bar"
+  class:noscroll={!scroll}
+  role="toolbar"
+  aria-label={m.controlbar_toolbar_aria()}
+>
   {#each groups as group (group[0].group)}
     <div class="group" role="group">
       {#each group as k (k.seq)}
@@ -90,6 +108,12 @@
   }
   .ctrl-bar::-webkit-scrollbar {
     display: none;
+  }
+  /* fixed edge cluster (e.g. Esc/Tab): fit content, never grow or scroll */
+  .ctrl-bar.noscroll {
+    flex: 0 0 auto;
+    overflow: visible;
+    padding-right: 0;
   }
 
   /* one "well" per group — faint common-region backing so the eye chunks

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -362,6 +362,13 @@
     conn?.send(composeKeystrokes(text));
   }
 
+  // the compose overlay is summoned on demand (swipe-up from the ctrl-row gutter,
+  // or the ✎ chip), reclaiming the row the old always-on input bar occupied.
+  // composeDictate = open already listening (reserved for a dictation entry);
+  // the default compose-first entries leave it false so the keyboard comes up.
+  let composeOpen = $state(false);
+  let composeDictate = $state(false);
+
   $effect(() => {
     const id = unitId;
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive dep
@@ -1038,8 +1045,8 @@
   {#if (mobile || touch) && tab === "term"}
     <div class="ctrl-row">
       <ControlBar onkey={(seq) => conn?.send(seq)} />
-      <!-- pinned right, in the one-thumb reach zone: attach then Enter, always
-           visible so the primary action never scrolls off -->
+      <!-- pinned right, in the one-thumb reach zone: attach, mic, then Enter,
+           always visible so the primary actions never scroll off -->
       <button
         type="button"
         class="attach"
@@ -1052,6 +1059,16 @@
       </button>
       <button
         type="button"
+        class="mic"
+        title={m.composebar_open_aria()}
+        aria-label={m.composebar_open_aria()}
+        onpointerdown={(e) => {
+          e.preventDefault();
+          composeOpen = true;
+        }}>{m.composebar_dictate()}</button
+      >
+      <button
+        type="button"
         class="enter"
         aria-label={enter.aria}
         onpointerup={(e) => {
@@ -1060,7 +1077,14 @@
         }}>{enter.label}</button
       >
     </div>
-    <ComposeBar onsend={sendComposed} repoPath={session.repoPath} />
+    {#if composeOpen}
+      <ComposeBar
+        onsend={sendComposed}
+        onclose={() => (composeOpen = false)}
+        repoPath={session.repoPath}
+        startDictation={composeDictate}
+      />
+    {/if}
     <input
       bind:this={fileInput}
       type="file"
@@ -1755,6 +1779,7 @@
     background: var(--color-head);
     border-top: 1px solid var(--color-line);
   }
+  .ctrl-row .mic,
   .ctrl-row .attach,
   .ctrl-row .enter {
     flex: 0 0 auto;
@@ -1772,6 +1797,7 @@
       background 0.08s,
       border-color 0.08s;
   }
+  .ctrl-row .mic:active,
   .ctrl-row .attach:active,
   .ctrl-row .enter:active {
     background: var(--color-line-bright);

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -25,7 +25,7 @@
   import DiffPanel from "$lib/components/DiffPanel.svelte";
   import ControlBar from "$lib/components/ControlBar.svelte";
   import { enterKey } from "$lib/controlKeys";
-  import { lockAxis, paneSwipeAction, type Axis } from "./swipe";
+  import { lockAxis, paneSwipeAction, isSwipeUp, type Axis } from "./swipe";
   import ComposeBar from "$lib/components/ComposeBar.svelte";
   import GitRail from "$lib/components/GitRail.svelte";
   import SteerBar from "$lib/components/SteerBar.svelte";
@@ -364,10 +364,67 @@
 
   // the compose overlay is summoned on demand (swipe-up from the ctrl-row gutter,
   // or the ✎ chip), reclaiming the row the old always-on input bar occupied.
-  // composeDictate = open already listening (reserved for a dictation entry);
-  // the default compose-first entries leave it false so the keyboard comes up.
+  // composeDictate opens the sheet already listening — the one-tap 🎤 chip sets
+  // it; the compose-first entries (✎, swipe-up) leave it false so the keyboard
+  // comes up to type.
   let composeOpen = $state(false);
   let composeDictate = $state(false);
+  let ctrlRowEl: HTMLDivElement | undefined = $state();
+  function openCompose() {
+    composeDictate = false; // compose-first; the 🎤 lives inside the sheet too
+    composeOpen = true;
+  }
+  // one-tap dictate: opens the sheet already listening (preserves Kai's original
+  // affordance), a peer of the ✎ compose entry rather than a step inside it.
+  // Gated on Web Speech support so the chip never becomes a dead end where it's
+  // unavailable (e.g. an iOS home-screen PWA); the sheet's own 🎤 toggle hides
+  // itself there the same way.
+  const speechSupported =
+    typeof window !== "undefined" &&
+    !!(
+      (window as { SpeechRecognition?: unknown }).SpeechRecognition ??
+      (window as { webkitSpeechRecognition?: unknown }).webkitSpeechRecognition
+    );
+  function openDictate() {
+    composeDictate = true;
+    composeOpen = true;
+  }
+  // Swipe up from the ctrl-row gutter to summon the compose sheet — a bottom-edge
+  // gesture, so it never competes with the terminal's vertical scrollback (which
+  // lives above the row). isSwipeUp ignores chip taps and horizontal pane swipes.
+  // Listeners are bound in JS (not inline on the markup) so the row stays a plain
+  // static container — the chips remain the interactive elements.
+  $effect(() => {
+    const row = ctrlRowEl;
+    if (!row) return;
+    let sx = 0;
+    let sy = 0;
+    let dx = 0;
+    let dy = 0;
+    const start = (e: TouchEvent) => {
+      if (e.touches.length !== 1) return;
+      sx = e.touches[0].clientX;
+      sy = e.touches[0].clientY;
+      dx = dy = 0;
+    };
+    const move = (e: TouchEvent) => {
+      if (e.touches.length !== 1) return;
+      dx = e.touches[0].clientX - sx;
+      dy = e.touches[0].clientY - sy;
+    };
+    const end = () => {
+      if (isSwipeUp(dx, dy, 36)) openCompose();
+      dx = dy = 0;
+    };
+    row.addEventListener("touchstart", start, { passive: true });
+    row.addEventListener("touchmove", move, { passive: true });
+    row.addEventListener("touchend", end);
+    return () => {
+      row.removeEventListener("touchstart", start);
+      row.removeEventListener("touchmove", move);
+      row.removeEventListener("touchend", end);
+    };
+  });
 
   $effect(() => {
     const id = unitId;
@@ -1043,10 +1100,12 @@
   <!-- control-key bar: any touch device (incl. unfolded foldables wider than the
        mobile breakpoint) gets it, since there's no hardware keyboard to steer with -->
   {#if (mobile || touch) && tab === "term"}
-    <div class="ctrl-row">
-      <ControlBar onkey={(seq) => conn?.send(seq)} />
-      <!-- pinned right, in the one-thumb reach zone: attach, mic, then Enter,
-           always visible so the primary actions never scroll off -->
+    <div class="ctrl-row" bind:this={ctrlRowEl}>
+      <!-- Esc/Tab frozen on the left edge; the arrows + ^-keys scroll in the
+           middle; attach/dictate/Enter frozen on the right. There's no compose
+           chip — swipe up from this row to summon the compose sheet. -->
+      <ControlBar onkey={(seq) => conn?.send(seq)} include={["edit"]} scroll={false} />
+      <ControlBar onkey={(seq) => conn?.send(seq)} include={["nav", "signal"]} />
       <button
         type="button"
         class="attach"
@@ -1057,16 +1116,18 @@
       >
         {uploading ? "⏳" : uploadFailed ? "⚠" : "📎"}
       </button>
-      <button
-        type="button"
-        class="mic"
-        title={m.composebar_open_aria()}
-        aria-label={m.composebar_open_aria()}
-        onpointerdown={(e) => {
-          e.preventDefault();
-          composeOpen = true;
-        }}>{m.composebar_dictate()}</button
-      >
+      {#if speechSupported}
+        <button
+          type="button"
+          class="dictate"
+          title={m.composebar_dictate_aria()}
+          aria-label={m.composebar_dictate_aria()}
+          onpointerdown={(e) => {
+            e.preventDefault();
+            openDictate();
+          }}>{m.composebar_dictate()}</button
+        >
+      {/if}
       <button
         type="button"
         class="enter"
@@ -1779,7 +1840,7 @@
     background: var(--color-head);
     border-top: 1px solid var(--color-line);
   }
-  .ctrl-row .mic,
+  .ctrl-row .dictate,
   .ctrl-row .attach,
   .ctrl-row .enter {
     flex: 0 0 auto;
@@ -1797,7 +1858,7 @@
       background 0.08s,
       border-color 0.08s;
   }
-  .ctrl-row .mic:active,
+  .ctrl-row .dictate:active,
   .ctrl-row .attach:active,
   .ctrl-row .enter:active {
     background: var(--color-line-bright);

--- a/ui/src/lib/components/swipe.test.ts
+++ b/ui/src/lib/components/swipe.test.ts
@@ -7,6 +7,7 @@ import {
   snapOffset,
   pressDecom,
   paneSwipeAction,
+  isSwipeUp,
 } from "./swipe";
 
 describe("lockAxis", () => {
@@ -50,6 +51,16 @@ describe("paneSwipeAction (queue paging swipe)", () => {
     expect(paneSwipeAction(T, T, true, -1)).toBe("back"));
   it("rightward goes back when paging is unavailable", () =>
     expect(paneSwipeAction(T, T, false, -1)).toBe("back"));
+});
+
+describe("isSwipeUp (ctrl-row → compose sheet)", () => {
+  const T = 36;
+  it("recognises a clear upward swipe", () => expect(isSwipeUp(4, -T, T)).toBe(true));
+  it("ignores a short upward nudge (a tap on a chip)", () =>
+    expect(isSwipeUp(2, -10, T)).toBe(false));
+  it("ignores a downward swipe", () => expect(isSwipeUp(0, T, T)).toBe(false));
+  it("ignores a mostly-horizontal drag even if it clears threshold vertically", () =>
+    expect(isSwipeUp(-80, -T, T)).toBe(false));
 });
 
 describe("pressDecom (arm → confirm)", () => {

--- a/ui/src/lib/components/swipe.ts
+++ b/ui/src/lib/components/swipe.ts
@@ -60,6 +60,16 @@ export function paneSwipeAction(
   return "none";
 }
 
+/**
+ * Whether a released gesture is a deliberate upward swipe — used by the ctrl-row
+ * to summon the compose sheet. Requires clearing `threshold` upward (dy negative)
+ * AND being more vertical than horizontal, so a horizontal pane swipe or a small
+ * tap on a chip never triggers it.
+ */
+export function isSwipeUp(dx: number, dy: number, threshold: number): boolean {
+  return dy <= -threshold && Math.abs(dy) > Math.abs(dx);
+}
+
 /** Callbacks a host component supplies to drive the swipe action. */
 export interface SwipeCallbacks {
   /** Current slid offset (px, negative = open). */


### PR DESCRIPTION
Supersedes #162. Adopts that PR's on-demand compose overlay but recasts it **compose-first** and reconciles it with the slash-command autocomplete that landed in #165.

## What

- **On-demand compose sheet** rising from the bottom edge (full-width, top-rounded, slide-up; reduced-motion guarded; safe-area padded). Replaces the always-visible input bar, reclaiming the row for the terminal.
- **Two one-tap entries** in the control row: `🎤` opens the sheet *already listening* (preserves #162's one-tap dictate), and a **swipe-up** from the control-row gutter opens it compose-first (keyboard). The sheet also hosts a `🎤` toggle to dictate mid-compose.
- **Slash-command picker** (#165) wired into the sheet's textarea — type `/` for the repo + plugin commands.
- **Canned steers** (same presets as the SteerBar) available in the sheet; tapping one drops its text into the field as an editable draft (set if empty, append otherwise).
- **Control row restructured**: `Esc · Tab` frozen on the left, `← → ↑ ↓ ^A ^E ^C ^D` scroll in the middle, `📎 · 🎤 · ⏎` frozen on the right — so the edge keys never scroll off. (`ControlBar` gained `include`/`scroll` props, used twice.)

## Notes

- Swipe-up is bottom-edge-scoped (touch starting on the control row) so it never competes with terminal scrollback; `isSwipeUp` is a pure, tested helper that ignores chip taps and horizontal pane swipes.
- `🎤` chip hides itself where the Web Speech API is unavailable (e.g. iOS home-screen PWA), falling back to type-and-send.
- Reconciles the #162 ↔ #165 ComposeBar/Viewport conflict.

Validated locally: `bun run check` 0 errors, `bun run test` 191 pass (incl. new `isSwipeUp` cases), `check:i18n` parity, prettier, eslint, build. Iterated on-device via local-live deploy.

Co-authored with Kai Osthoff (original #162 overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)