### PR TITLE
feat(actionbar): collapse source link to GitHub icon, keep buttons single-line

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -44,6 +44,7 @@
   "actionbar_theme_group_aria": "Darstellung",
   "actionbar_theme_option": "{label}-Design",
   "actionbar_commit_title": "commit {sha}",
+  "actionbar_repo_link": "{repo} auf GitHub",
   "lang_switcher_aria": "Sprache",
   "lang_english": "English",
   "lang_german": "Deutsch",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -44,6 +44,7 @@
   "actionbar_theme_group_aria": "Theme",
   "actionbar_theme_option": "{label} theme",
   "actionbar_commit_title": "commit {sha}",
+  "actionbar_repo_link": "{repo} on GitHub",
   "lang_switcher_aria": "Language",
   "lang_english": "English",
   "lang_german": "Deutsch",

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -54,8 +54,20 @@
         onclick={() => onmode?.("focus")}>{m.actionbar_focus_mode()}</button
       >
       <div class="meta">
-        <a class="repo" href={REPO_URL} target="_blank" rel="external noreferrer noopener">{REPO}</a
+        <a
+          class="repo"
+          href={REPO_URL}
+          target="_blank"
+          rel="external noreferrer noopener"
+          title={m.actionbar_repo_link({ repo: REPO })}
+          aria-label={m.actionbar_repo_link({ repo: REPO })}
         >
+          <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+            <path
+              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+            />
+          </svg>
+        </a>
         <span class="dot">·</span>
         <span class="version">v{version}</span>
         <span class="dot">·</span>
@@ -104,6 +116,8 @@
     font-size: 11px;
     cursor: pointer;
     background: transparent;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
   .btn.primary {
     border-color: var(--color-amber);
@@ -131,6 +145,10 @@
   .sha {
     color: var(--color-muted);
     text-decoration: none;
+  }
+  .repo {
+    display: inline-flex;
+    align-items: center;
   }
   .version {
     color: var(--color-muted);


### PR DESCRIPTION
## What
- Collapse the `erwins-enkel/shepherd` source link in the lower-left action bar into a GitHub mark icon (14px inline SVG). Still links to the repo; carries a translated `title`/`aria-label` (`actionbar_repo_link`, added to EN+DE).
- Lower-left buttons (`+ New Task`, `Backlog`, `All`, `Focus`) never wrap to two lines: added `white-space: nowrap` + `flex-shrink: 0` to `.btn`.

## Why
Reclaims horizontal space in the footer and prevents the buttons from wrapping at narrow widths.

## Checks
- `cd ui && bun run check` ✓
- `cd ui && bun run check:i18n` ✓ (locales in parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)