### PR TITLE
fix(settings): scroll full-screen settings card on mobile

### DIFF
--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -576,8 +576,7 @@
       overflow-y: auto;
     }
     .list {
-      max-height: none;
-      flex: 1;
+      max-height: 50vh;
     }
     .row,
     .up,


### PR DESCRIPTION
## Problem

On mobile the full-screen settings card is a scroll container (`height: 100dvh; overflow-y: auto`), but `.list` had `flex: 1`. The folder list stretched to fill the viewport, so the flex layout fit all content to exactly one screen — nothing overflowed, the card never scrolled, and the Push / Remote Control / Saved Steers sections were pushed off the bottom and unreachable.

## Fix

Drop `flex: 1` and cap the list at `50vh` on mobile. The list is bounded again and the whole card scrolls as one document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)