### PR TITLE
fix(badge): lead MERGED badge with checkmark to match siblings

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -208,7 +208,7 @@
   "diff_stale": "Basis-Fetch fehlgeschlagen — Vergleich mit lokalem {base}",
   "activity_empty": "Noch keine Aktivität.",
   "prbadge_open": "PR #{number}",
-  "prbadge_merged": "GEMERGT ✓",
+  "prbadge_merged": "✓ GEMERGT",
   "prbadge_closed": "GESCHLOSSEN",
   "prbadge_none": "KEIN PR",
   "prbadge_review_approved": "Reviewer hat genehmigt",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -208,7 +208,7 @@
   "diff_stale": "Base fetch failed — comparing local {base}",
   "activity_empty": "No activity yet.",
   "prbadge_open": "PR #{number}",
-  "prbadge_merged": "MERGED ✓",
+  "prbadge_merged": "✓ MERGED",
   "prbadge_closed": "CLOSED",
   "prbadge_none": "NO PR",
   "prbadge_review_approved": "Reviewer approved",

--- a/ui/src/lib/components/pr-badge.test.ts
+++ b/ui/src/lib/components/pr-badge.test.ts
@@ -17,7 +17,7 @@ describe("prBadgeLabel", () => {
     expect(prBadgeLabel(git({ state: "open", number: 12 }))).toBe("PR #12");
   });
   it("labels a merged PR", () => {
-    expect(prBadgeLabel(git({ state: "merged", number: 12 }))).toBe("MERGED ✓");
+    expect(prBadgeLabel(git({ state: "merged", number: 12 }))).toBe("✓ MERGED");
   });
   it("labels a closed PR", () => {
     expect(prBadgeLabel(git({ state: "closed", number: 12 }))).toBe("CLOSED");


### PR DESCRIPTION
## What

On the unit card, the MERGED badge trailed its checkmark (`MERGED ✓`) while the title pip and the REVIEWED badge both lead with it (`✓ REVIEWED`). Two in front, one in the rear — looked off.

Moved the MERGED checkmark to the front so all three align:

- `prbadge_merged`: `MERGED ✓` → `✓ MERGED` (en), `GEMERGT ✓` → `✓ GEMERGT` (de)
- updated `pr-badge.test.ts` assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)