### PR TITLE
fix(steerbar): reliable gap between 📡 and broadcast label

### DIFF
--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -58,7 +58,7 @@
     onpointercancel={cancel}
     onpointerup={(e) => tap(e, onbroadcast)}
     aria-label={m.steerbar_broadcast_aria()}
-    >📡<span class="bc-label"> {m.steerbar_broadcast()}</span></button
+    >📡<span class="bc-label">{m.steerbar_broadcast()}</span></button
   >
   {#each steers.list as s (s.id)}
     <button
@@ -115,6 +115,9 @@
   .chip.bc {
     color: var(--color-amber);
     border-color: var(--color-amber);
+  }
+  .bc-label {
+    margin-left: 6px;
   }
   /* on mobile the broadcast chip collapses to just its 📡 icon to reclaim space */
   @media (max-width: 768px) {


### PR DESCRIPTION
## Problem
Missing space between the 📡 icon and the broadcast button label.

## Cause
The separator was leading whitespace inside the `<span>`, which collapses at render.

## Fix
Replace the in-text space with `margin-left: 6px` on `.bc-label`. The gap is now reliable and disappears cleanly on mobile where the label is `display: none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)