### PR TITLE
fix(topbar): route self-update badge title through m.* (i18n)

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -210,7 +210,9 @@
         class="update-badge"
         class:mobile
         onclick={() => onupdate?.()}
-        title="{update!.behind} {update!.behind === 1 ? 'neuer Commit' : 'neue Commits'} auf main"
+        title="{update!.behind} {update!.behind === 1
+          ? m.updatemodal_commits_one()
+          : m.updatemodal_commits_other()}"
       >
         <span class="up-dot">▲</span>
         {#if !mobile}<span class="up-label">Update</span>{/if}


### PR DESCRIPTION
## Summary
- Self-update badge `title` in `TopBar.svelte` hardcoded German ("neuer Commit"/"neue Commits"/"auf main") instead of routing through `m.*`, unlike the herdr badge beside it.
- Reuses existing `m.updatemodal_commits_one()`/`m.updatemodal_commits_other()` keys (identical "new commit(s) on main" / "neue Commits auf main" text already used by `UpdateModal.svelte`) — no new keys needed.

## Verification
- `bun run check` — 0 errors
- `bun run check:i18n` — 2 locales in parity (299 keys each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)