### PR TITLE
feat(viewport): tappable pulsing "add notes" key on mobile

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -238,6 +238,7 @@
   "leftover_terminate": "Beenden & schließen",
   "viewport_upload_failed": "Upload fehlgeschlagen — zum Wiederholen tippen",
   "viewport_attach_image": "Bild anhängen",
+  "viewport_notes_aria": "Notiz hinzufügen — {key} drücken",
   "viewport_type_steer_hint": "⌁ tippen zum Steuern",
   "viewport_detach_hint": "⇥ trennen",
   "viewport_select_hint": "{key} zum Markieren ziehen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -238,6 +238,7 @@
   "leftover_terminate": "Terminate & close",
   "viewport_upload_failed": "Upload failed — tap to retry",
   "viewport_attach_image": "Attach image",
+  "viewport_notes_aria": "Add notes — press {key}",
   "viewport_type_steer_hint": "⌁ type to steer",
   "viewport_detach_hint": "⇥ detach",
   "viewport_select_hint": "{key} drag to select",

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -20,6 +20,7 @@
   import { imageFilesFromItems } from "$lib/clipboard";
   import { composeKeystrokes } from "$lib/compose";
   import { shouldForwardEscape } from "$lib/terminalEscape";
+  import { detectNotesKey } from "$lib/notesAffordance";
   import TodoPanel from "$lib/components/TodoPanel.svelte";
   import IssuesPanel from "$lib/components/IssuesPanel.svelte";
   import ActivityFeed from "$lib/components/ActivityFeed.svelte";
@@ -116,6 +117,10 @@
   // buffer switch, and a jump-to-bottom.
   let scrollDepth = 0;
   let dragging = $state(false);
+  // The key to press for Claude's "add notes" prompt option, scraped live from
+  // the painted screen (null when the prompt isn't offering it). On a phone
+  // there's no keyboard to press it, so we surface a tappable control row button.
+  let notesKey = $state<string | null>(null);
   let uploading = $state(false);
   let uploadFailed = $state(false);
   let fileInput = $state<HTMLInputElement>();
@@ -449,6 +454,7 @@
     parked = false; // fresh attach for this unit
     scrolledUp = false; // fresh terminal starts pinned to the bottom
     scrollDepth = 0;
+    notesKey = null; // no prompt scraped yet on this fresh terminal
 
     // initial palette: non-reactive DOM read so this effect doesn't depend on
     // theme.resolved (which would recreate the whole terminal — and its PTY —
@@ -681,6 +687,23 @@
       recomputeScrolled();
     });
 
+    // Surface Claude Code's "press n to add notes" prompt option as a tappable
+    // control-row key — on a phone there's no keyboard to press it, so the
+    // dialog's notes branch is otherwise unreachable. The hint lives only in the
+    // painted screen, so re-scan the visible rows on each render (cheap: bounded
+    // by term.rows, and onRender already coalesces a write burst into one frame).
+    // Visible viewport only, so a prompt scrolled out of view stops lighting it.
+    const scanNotesAffordance = () => {
+      if (!(mobile || touch)) return; // the button only exists in the touch row
+      const b = term.buffer.active;
+      let text = "";
+      for (let i = 0; i < term.rows; i++) {
+        text += (b.getLine(b.viewportY + i)?.translateToString(true) ?? "") + "\n";
+      }
+      notesKey = detectNotesKey(text);
+    };
+    const renderSub = term.onRender(scanNotesAffordance);
+
     // desktop wheel observer for the alternate screen, where onScroll never fires.
     // Touch is tracked directly in onTouchMove, so ignore the synthetic wheels it
     // dispatches (isTrusted=false) to avoid double-counting; only real wheels here.
@@ -704,6 +727,7 @@
       el?.removeEventListener("wheel", onWheelTrack, { capture: true });
       scrollSub.dispose();
       bufSub.dispose();
+      renderSub.dispose();
       ro.disconnect();
       c.close();
       conn = undefined;
@@ -1130,6 +1154,21 @@
            chip — swipe up from this row to summon the compose sheet. -->
       <ControlBar onkey={(seq) => conn?.send(seq)} include={["edit"]} scroll={false} />
       <ControlBar onkey={(seq) => conn?.send(seq)} include={["nav", "signal"]} />
+      <!-- only while Claude's prompt offers it: a pulsing "add notes" key. There's
+           no keyboard on a phone to press the letter, so this is the sole way into
+           the dialog's notes branch; it pulses to catch the eye and vanishes once
+           the prompt does -->
+      {#if notesKey}
+        <button
+          type="button"
+          class="notes"
+          aria-label={m.viewport_notes_aria({ key: notesKey })}
+          onpointerup={(e) => {
+            e.preventDefault();
+            if (notesKey) conn?.send(notesKey);
+          }}>📝 {notesKey.toUpperCase()}</button
+        >
+      {/if}
       <button
         type="button"
         class="attach"
@@ -1918,5 +1957,43 @@
   .ctrl-row .enter:active {
     background: color-mix(in srgb, var(--color-green) 34%, var(--color-inset));
     border-color: var(--color-green);
+  }
+  /* "add notes" affordance — only mounted while Claude's prompt offers it. Amber
+     (the same attention hue as the running pip) plus a soft halo pulse so it's
+     noticed on a phone where there's no keyboard to press the key directly. The
+     global prefers-reduced-motion guard stills the animation. */
+  .ctrl-row .notes {
+    flex: 0 0 auto;
+    min-width: 44px;
+    height: 44px;
+    padding: 0 10px;
+    border-radius: 4px;
+    font-family: var(--font-mono);
+    font-size: 14px;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+    cursor: pointer;
+    touch-action: manipulation;
+    user-select: none;
+    color: var(--color-amber);
+    border: 1px solid color-mix(in srgb, var(--color-amber) 60%, var(--color-line-bright));
+    background: color-mix(in srgb, var(--color-amber) 16%, var(--color-inset));
+    animation: notes-pulse 1.5s ease-in-out infinite;
+    transition:
+      background 0.08s,
+      border-color 0.08s;
+  }
+  .ctrl-row .notes:active {
+    background: color-mix(in srgb, var(--color-amber) 32%, var(--color-inset));
+    border-color: var(--color-amber);
+  }
+  @keyframes notes-pulse {
+    0%,
+    100% {
+      box-shadow: 0 0 0 0 transparent;
+    }
+    50% {
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-amber) 30%, transparent);
+    }
   }
 </style>

--- a/ui/src/lib/notesAffordance.test.ts
+++ b/ui/src/lib/notesAffordance.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { detectNotesKey } from "./notesAffordance";
+
+describe("detectNotesKey", () => {
+  it("detects the inline 'press n to add notes' hint", () => {
+    expect(detectNotesKey("Notes: press n to add notes")).toBe("n");
+  });
+
+  it("detects the footer 'n to add notes' hint", () => {
+    expect(
+      detectNotesKey(
+        "Enter to select · ↑/↓ to navigate · n to add notes · Tab to switch · Esc to cancel",
+      ),
+    ).toBe("n");
+  });
+
+  it("finds the hint anywhere in a multi-line viewport scrape", () => {
+    const screen = [
+      "1. Auf NewTask-Dialog zurückfallen",
+      "2. Button ausgrauen/ausblenden",
+      "",
+      "Notes: press n to add notes",
+      "",
+      "Chat about this",
+    ].join("\n");
+    expect(detectNotesKey(screen)).toBe("n");
+  });
+
+  it("returns the key verbatim when the prompt uses a different letter", () => {
+    expect(detectNotesKey("press a to add notes")).toBe("a");
+  });
+
+  it("matches case-insensitively but preserves the displayed casing", () => {
+    expect(detectNotesKey("N to add notes")).toBe("N");
+  });
+
+  it("returns null when no notes affordance is present", () => {
+    expect(detectNotesKey("Enter to select · ↑/↓ to navigate · Esc to cancel")).toBe(null);
+  });
+
+  it("returns null for empty input", () => {
+    expect(detectNotesKey("")).toBe(null);
+  });
+
+  it("does not match unrelated prose containing 'notes'", () => {
+    expect(detectNotesKey("These are release notes for the project")).toBe(null);
+  });
+});

--- a/ui/src/lib/notesAffordance.ts
+++ b/ui/src/lib/notesAffordance.ts
@@ -1,0 +1,21 @@
+// Detects Claude Code's "press n to add notes" affordance shown inside its
+// interactive multi-select prompts. The hint surfaces both inline ("Notes:
+// press n to add notes") and in the footer ("… · n to add notes · …").
+//
+// Why scrape the rendered screen: the PTY stream is opaque bytes and the UI
+// never models the prompt — the only place this affordance exists is the
+// painted text. On a phone there's no keyboard to press the key, so we turn the
+// detected key into a tappable control. Callers pass only the *visible* viewport
+// rows (not scrollback) so a prompt that has scrolled off doesn't keep it lit.
+
+// One letter, immediately followed by " to add notes". Anchored on a word
+// boundary so the leading "press " / "Notes: press " context can't smear the
+// capture. Case-insensitive for robustness; the key is returned verbatim so we
+// inject exactly what the prompt told the operator to press.
+const NOTES_HINT = /\b([a-z]) to add notes\b/i;
+
+/** The key to send (verbatim) when the notes affordance is visible, else null. */
+export function detectNotesKey(visibleText: string): string | null {
+  const match = NOTES_HINT.exec(visibleText);
+  return match ? match[1] : null;
+}


### PR DESCRIPTION
## Was

Claude Codes interaktive Auswahl-Dialoge bieten oft eine Option **„press n to add notes"** an. Auf dem Handy/Foldable gibt es aber keine Tastatur, um die Taste zu drücken — dieser Zweig war damit auf Touch-Geräten **unerreichbar**.

Dieser PR blendet in der Touch-Control-Row (links neben 📎/⏎) einen **pulsierenden 📝 N-Button** ein, solange der Hinweis im Terminal sichtbar ist. Ein Tap sendet die Taste direkt in den PTY.

## Verhalten

- Erscheint **nur**, solange der Hinweis tatsächlich im sichtbaren Terminal steht; verschwindet, sobald der Dialog weg ist oder weggescrollt wird.
- **Pulsiert sanft** (amber Halo, gleiche Aufmerksamkeitsfarbe wie der „running"-Pip); die globale `prefers-reduced-motion`-Regel stillt die Animation.
- Nur auf Touch-/Mobile-Layouts (lebt in derselben Reihe wie Esc/Tab/Pfeile).
- Sendet die im Hinweis genannte Taste **wortgetreu** — falls Claude mal einen anderen Buchstaben nutzt, stimmt er trotzdem.

## Technik

Die UI hat den Terminal-Text bisher nie gelesen. Der Hinweis existiert nur im gemalten Bild, daher scanne ich pro `term.onRender` die **sichtbaren** Buffer-Zeilen (`term.buffer.active`, begrenzt auf `term.rows`, von xterm pro Frame gebündelt → günstig). Scrollback bleibt außen vor, damit ein weggescrollter Dialog den Button nicht hängen lässt. Die Erkennung steckt in einer reinen Funktion `detectNotesKey()` und ist unit-getestet.

## Dateien

- `ui/src/lib/notesAffordance.ts` (neu) — reine Erkennungsfunktion
- `ui/src/lib/notesAffordance.test.ts` (neu) — 8 Tests
- `ui/src/lib/components/Viewport.svelte` — Buffer-Scan + Button + CSS
- `ui/messages/{en,de}.json` — i18n-Key `viewport_notes_aria`

## Checks

- `bun run check` — 0 Fehler/Warnungen
- `bun run check:i18n` — 288 Keys in Parität
- `bun run test` — 192 Tests grün (inkl. 8 neue)