### PR TITLE
docs: add impeccable PRODUCT.md + DESIGN.md design context

### DIFF
--- a/DESIGN.json
+++ b/DESIGN.json
@@ -1,0 +1,287 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-06-01T00:00:00Z",
+  "title": "Design System: Shepherd",
+  "extensions": {
+    "colorMeta": {
+      "amber": {
+        "role": "primary",
+        "displayName": "Signal Amber",
+        "canonical": "#e8a13a",
+        "tonalRamp": [
+          "#2a1c08",
+          "#4a3210",
+          "#6e4a16",
+          "#966420",
+          "#be832b",
+          "#e8a13a",
+          "#f0bb6e",
+          "#f7d6a4"
+        ]
+      },
+      "green": {
+        "role": "secondary",
+        "displayName": "Phosphor Green",
+        "canonical": "#5ad19a",
+        "tonalRamp": [
+          "#0c2a1e",
+          "#134434",
+          "#1c624b",
+          "#277f62",
+          "#34a07b",
+          "#5ad19a",
+          "#8fe0bb",
+          "#bdeed8"
+        ]
+      },
+      "red": {
+        "role": "secondary",
+        "displayName": "Alert Red",
+        "canonical": "#e5484d",
+        "tonalRamp": [
+          "#2e0d0f",
+          "#4d171a",
+          "#6f2125",
+          "#962b30",
+          "#be383d",
+          "#e5484d",
+          "#ee7a7e",
+          "#f5acae"
+        ]
+      },
+      "blue": {
+        "role": "secondary",
+        "displayName": "Cold Blue",
+        "canonical": "#4a90d9",
+        "tonalRamp": [
+          "#0d1c2c",
+          "#16314d",
+          "#20486f",
+          "#2b6096",
+          "#357abe",
+          "#4a90d9",
+          "#7eb0e4",
+          "#aecdee"
+        ]
+      },
+      "slate": {
+        "role": "secondary",
+        "displayName": "Idle Slate",
+        "canonical": "#566460",
+        "tonalRamp": [
+          "#181d1b",
+          "#262e2b",
+          "#36403c",
+          "#46524d",
+          "#56645f",
+          "#6b7873",
+          "#8a958f",
+          "#aeb6b1"
+        ]
+      },
+      "bg": {
+        "role": "neutral",
+        "displayName": "Deep Pine Black",
+        "canonical": "#0a0d0c",
+        "tonalRamp": [
+          "#0a0d0c",
+          "#0f1413",
+          "#18211e",
+          "#2c3835",
+          "#4a5752",
+          "#7c8c86",
+          "#b0bcb6",
+          "#e7ebe9"
+        ]
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Phosphor Ink",
+        "canonical": "#c4d0cb",
+        "tonalRamp": [
+          "#1b201e",
+          "#2c3531",
+          "#404b46",
+          "#57655f",
+          "#7c8c86",
+          "#a0aea8",
+          "#c4d0cb",
+          "#eef4f0"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "title": {
+        "displayName": "Title",
+        "purpose": "Panel/section headers and the value the operator scans for."
+      },
+      "body": { "displayName": "Body", "purpose": "Default running text and terminal output." },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Buttons, tabs, status labels, toolbar chrome (uppercase, wide-tracked)."
+      },
+      "numeric": {
+        "displayName": "Numeric",
+        "purpose": "Tabular figures for counts, gauges, percentages, SHAs."
+      }
+    },
+    "shadows": [
+      {
+        "name": "sheet-lift",
+        "value": "0 -8px 40px rgba(0,0,0,0.5)",
+        "purpose": "Rising compose / bottom-sheet overlay lifted off the live terminal."
+      },
+      {
+        "name": "action-inset-glow",
+        "value": "inset 0 0 18px -10px var(--color-amber)",
+        "purpose": "Amber primary/active button internal glow (never an outer drop)."
+      }
+    ],
+    "motion": [
+      {
+        "name": "pip-pulse",
+        "value": "1.5s ease-out infinite",
+        "purpose": "Expanding halo on the working (amber) status pip."
+      },
+      {
+        "name": "dot-pulse",
+        "value": "opacity 0.35->1, blink",
+        "purpose": "In-progress dot, opacity blink (clip-proof at small size)."
+      },
+      {
+        "name": "scan",
+        "value": "8s linear infinite",
+        "purpose": "Amber scanline sweep over the live terminal (ambient texture)."
+      },
+      {
+        "name": "sheet-rise",
+        "value": "0.18s ease-out",
+        "purpose": "Bottom sheet rising from the bottom edge when summoned."
+      }
+    ],
+    "breakpoints": [
+      { "name": "mobile", "value": "phone, one-handed steering surface" },
+      { "name": "desktop", "value": "wide HUD with persistent live terminal pane" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Default Button",
+      "kind": "button",
+      "refersTo": "button",
+      "description": "Outline ghost button: transparent fill, hairline border, uppercase wide-tracked label.",
+      "html": "<button class=\"ds-btn\">OPEN PR</button>",
+      "css": ".ds-btn { background: transparent; color: var(--color-ink); border: 1px solid var(--color-line-bright); border-radius: 2px; padding: 7px 14px; font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; cursor: pointer; transition: background 0.15s, border-color 0.15s; } .ds-btn:hover { background: var(--color-hover); border-color: var(--color-ink); } .ds-btn:focus-visible { outline: none; border-color: var(--color-ink-bright); }"
+    },
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Amber primary: ghost geometry with amber border/text and an inset glow. Never a solid fill.",
+      "html": "<button class=\"ds-btn-primary\">MERGE</button>",
+      "css": ".ds-btn-primary { background: transparent; color: var(--color-amber); border: 1px solid var(--color-amber); border-radius: 2px; padding: 7px 14px; font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; cursor: pointer; box-shadow: inset 0 0 18px -10px var(--color-amber); transition: background 0.15s; } .ds-btn-primary:hover { background: var(--color-hover); } .ds-btn-primary:focus-visible { outline: none; box-shadow: inset 0 0 18px -8px var(--color-amber); }"
+    },
+    {
+      "name": "Input Field",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Recessed inset field with a hairline border; focus brightens the border, no glow ring.",
+      "html": "<input class=\"ds-input\" placeholder=\"new task…\" />",
+      "css": ".ds-input { background: var(--color-inset); color: var(--color-ink); border: 1px solid var(--color-line); border-radius: 2px; padding: 10px 12px; font-family: var(--font-mono, ui-monospace, monospace); font-size: 13px; letter-spacing: 0.02em; width: 100%; box-sizing: border-box; } .ds-input::placeholder { color: var(--color-faint); } .ds-input:focus { outline: none; border-color: var(--color-line-bright); }"
+    },
+    {
+      "name": "Status Pip",
+      "kind": "custom",
+      "refersTo": "pip",
+      "description": "9px status dot (amber working / green done / red blocked / slate idle); working pulses a halo.",
+      "html": "<span class=\"ds-pip ds-pip-working\"></span><span class=\"ds-pip ds-pip-blocked\"></span><span class=\"ds-pip-ready\">✓</span>",
+      "css": ".ds-pip { width: 9px; height: 9px; border-radius: 50%; display: inline-block; margin-right: 10px; vertical-align: middle; } .ds-pip-working { background: var(--color-amber); animation: ds-pip-pulse 1.5s ease-out infinite; } .ds-pip-blocked { background: var(--color-red); } .ds-pip-ready { color: var(--color-green); font-size: 10px; font-weight: 700; line-height: 1; } @keyframes ds-pip-pulse { 0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-amber) 70%, transparent); } 70% { box-shadow: 0 0 0 7px transparent; } 100% { box-shadow: 0 0 0 0 transparent; } } @media (prefers-reduced-motion: reduce) { .ds-pip-working { animation: none; } }"
+    },
+    {
+      "name": "Toolbar Panel",
+      "kind": "card",
+      "refersTo": "panel",
+      "description": "Flat, square panel separated by a hairline. The structural surface of the HUD; no radius, no shadow.",
+      "html": "<div class=\"ds-panel\"><span class=\"ds-panel-title\">VIEWPORT</span><span class=\"ds-panel-meta\">1280 tok</span></div>",
+      "css": ".ds-panel { display: flex; align-items: center; gap: 10px; background: var(--color-panel); border: 1px solid var(--color-line); border-radius: 0; padding: 10px 14px; font-family: var(--font-mono, ui-monospace, monospace); } .ds-panel-title { color: var(--color-ink-bright); font-size: 13px; font-weight: 600; letter-spacing: 0.02em; } .ds-panel-meta { margin-left: auto; color: var(--color-muted); font-size: 11px; letter-spacing: 0.06em; font-variant-numeric: tabular-nums; }"
+    },
+    {
+      "name": "Nav Tab",
+      "kind": "nav",
+      "refersTo": "button",
+      "description": "Uppercase wide-tracked tab label; active state marked by amber text + border, never a filled tab.",
+      "html": "<nav class=\"ds-tabs\"><button class=\"ds-tab ds-tab-active\">HERD</button><button class=\"ds-tab\">COMMANDS</button><button class=\"ds-tab\">USAGE</button></nav>",
+      "css": ".ds-tabs { display: flex; gap: 4px; } .ds-tab { background: transparent; color: var(--color-muted); border: 1px solid transparent; border-radius: 2px; padding: 6px 14px; font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; cursor: pointer; transition: color 0.15s; } .ds-tab:hover { color: var(--color-ink); } .ds-tab-active { color: var(--color-amber); border-color: var(--color-amber); }"
+    },
+    {
+      "name": "Compose Sheet",
+      "kind": "custom",
+      "refersTo": "compose-sheet",
+      "description": "Mobile bottom sheet for steering: nearly opaque head surface, 12px top radius, rises with a soft lift.",
+      "html": "<div class=\"ds-sheet\"><textarea class=\"ds-sheet-ta\" placeholder=\"steer…\"></textarea></div>",
+      "css": ".ds-sheet { background: color-mix(in srgb, var(--color-head) 94%, transparent); border-top: 1px solid var(--color-line-bright); border-radius: 12px 12px 0 0; box-shadow: 0 -8px 40px rgba(0,0,0,0.5); padding: 12px 14px; } .ds-sheet-ta { width: 100%; box-sizing: border-box; background: var(--color-inset); color: var(--color-ink); border: 1px solid var(--color-line); border-radius: 2px; padding: 10px 12px; font-family: var(--font-mono, ui-monospace, monospace); font-size: 13px; resize: none; } .ds-sheet-ta:focus { outline: none; border-color: var(--color-line-bright); }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Phosphor Watchfloor",
+    "overview": "Shepherd is the dim room where one operator watches a herd of live agents at 2am. The interface is an instrument panel, not a dashboard: a near-black, green-tinted ground with text glowing like phosphor on a CRT, status lights that mean something, and gauges that read at a glance. Everything is monospace because everything here is, literally, a terminal. The system is dense and quiet. Surfaces are flat and square, separated by hairline strokes and shifts in tonal value rather than shadows or cards. Color is rationed: the ground and chrome are desaturated greens and grays, and saturation is spent almost entirely on the four status lights and the single amber action. When nothing needs the operator, the screen is calm to the point of being recessive. When an agent is blocked, the red pip is unmistakable.",
+    "keyCharacteristics": [
+      "Monospace everywhere (Berkeley Mono); hierarchy from weight, case, and color, never a second typeface.",
+      "Near-black green-phosphor ground; chroma reserved for four status lights plus one amber action.",
+      "Flat, square panels separated by tonal layering and 1px hairlines; no shadows at rest.",
+      "Dense, telemetry-first layout that reads at a glance and survives on a phone in one hand.",
+      "Calm by default, alarm when earned: the blocked state is the loudest thing on screen."
+    ],
+    "rules": [
+      {
+        "name": "The Four-Light Rule",
+        "body": "Status speaks in exactly four colors: amber (working), green (done/ready), red (blocked), slate (idle). These hues are reserved for state; no decorative element may borrow a status color.",
+        "section": "colors"
+      },
+      {
+        "name": "The Quiet Ground Rule",
+        "body": "The surface is desaturated green-black; visible chroma stays at or below ~10% of any screen, spent on status lights and the one amber action.",
+        "section": "colors"
+      },
+      {
+        "name": "The One Typeface Rule",
+        "body": "Everything is Berkeley Mono. A second family is forbidden; hierarchy is built from size, weight, case, and color only.",
+        "section": "typography"
+      },
+      {
+        "name": "The Tabular Rule",
+        "body": "Every numeral that updates in place uses tabular figures so digits hold their column and a ticking value reads as motion, not jitter.",
+        "section": "typography"
+      },
+      {
+        "name": "The Flat Panel Rule",
+        "body": "Surfaces are flat and square at rest. Depth comes from tonal value and hairlines; a drop shadow on a resting panel is prohibited.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Earned Shadow Rule",
+        "body": "Shadows appear only as a response to invocation (a sheet or modal rising over the terminal), never as resting decoration.",
+        "section": "elevation"
+      }
+    ],
+    "dos": [
+      "Do keep everything in Berkeley Mono. Build hierarchy from size, weight, case, and ink brightness (Faint Moss -> Muted Sage -> Phosphor Ink -> Bright Phosphor).",
+      "Do reserve the four status colors (amber / green / red / slate) strictly for agent state.",
+      "Do build depth with tonal layering and 1px hairlines (inset < panel-2 < panel < head).",
+      "Do keep structural panels square (0 radius) and reserve the 2px radius for buttons and chips; 12px is only for rising bottom sheets.",
+      "Do use tabular figures for any number that updates in place.",
+      "Do keep the screen calm at rest and make the blocked (red) state the loudest thing on it.",
+      "Do pair every status color with a non-color cue (position, pulse, check glyph, or label), and keep touch targets thumb-reachable; phone steering is first-class."
+    ],
+    "donts": [
+      "Don't make it a generic SaaS dashboard: no rounded-card grids, pastel gradients, hero-metric tiles, or Inter-on-white.",
+      "Don't make it a consumer chat app: no bubbly, emoji-forward, soft-and-friendly coziness.",
+      "Don't make it an enterprise admin panel: no heavy gray chrome, Bootstrap-era toolbars, or density-without-elegance.",
+      "Don't make it crypto/gamer neon: no glow-on-black spectacle, RGB accents, or glassmorphism.",
+      "Don't put a drop shadow on a resting surface, or round a structural panel.",
+      "Don't use a colored side-stripe (border-left/border-right > 1px) as an accent.",
+      "Don't spend a status hue on decoration, or let visible chroma climb above ~10% of a screen at rest.",
+      "Don't fill the primary button solid amber. It is an outline ghost with an inset glow."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,240 @@
+---
+name: Shepherd
+description: Self-hosted mission control for interactive Claude Code, a terminal-native green-phosphor HUD.
+colors:
+  bg: "#0a0d0c"
+  glow: "#0d1211"
+  panel: "#0f1413"
+  panel-2: "#0c100f"
+  head: "#0a0f0d"
+  inset: "#070a09"
+  hover: "#0c1110"
+  sel: "#18211e"
+  line: "#1b2422"
+  line-bright: "#2c3835"
+  ink: "#c4d0cb"
+  ink-bright: "#eef4f0"
+  muted: "#7c8c86"
+  faint: "#4a5752"
+  amber: "#e8a13a"
+  green: "#5ad19a"
+  red: "#e5484d"
+  blue: "#4a90d9"
+  slate: "#566460"
+typography:
+  title:
+    fontFamily: "Berkeley Mono, JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace"
+    fontSize: "13px"
+    fontWeight: 600
+    lineHeight: 1.35
+    letterSpacing: "0.02em"
+  body:
+    fontFamily: "Berkeley Mono, JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace"
+    fontSize: "13px"
+    fontWeight: 400
+    lineHeight: 1.45
+    letterSpacing: "0.02em"
+  label:
+    fontFamily: "Berkeley Mono, JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace"
+    fontSize: "11px"
+    fontWeight: 500
+    lineHeight: 1.2
+    letterSpacing: "0.12em"
+  numeric:
+    fontFamily: "Berkeley Mono, JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace"
+    fontSize: "11px"
+    fontWeight: 400
+    lineHeight: 1.2
+    letterSpacing: "0.06em"
+    fontFeature: "tnum"
+rounded:
+  sm: "2px"
+  md: "3px"
+  lg: "12px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "12px"
+  lg: "16px"
+components:
+  panel:
+    backgroundColor: "{colors.panel}"
+    textColor: "{colors.ink}"
+    rounded: "0"
+    padding: "10px 14px"
+  button:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    typography: "{typography.label}"
+    rounded: "{rounded.sm}"
+    padding: "7px 14px"
+  button-hover:
+    backgroundColor: "{colors.hover}"
+    textColor: "{colors.ink}"
+  button-primary:
+    backgroundColor: "transparent"
+    textColor: "{colors.amber}"
+    typography: "{typography.label}"
+    rounded: "{rounded.sm}"
+    padding: "7px 14px"
+  input:
+    backgroundColor: "{colors.inset}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.sm}"
+    padding: "10px 12px"
+  pip:
+    backgroundColor: "{colors.amber}"
+    size: "9px"
+    rounded: "50%"
+  compose-sheet:
+    backgroundColor: "{colors.head}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.lg}"
+    padding: "12px 14px"
+---
+
+# Design System: Shepherd
+
+## 1. Overview
+
+**Creative North Star: "The Phosphor Watchfloor"**
+
+Shepherd is the dim room where one operator watches a herd of live agents at 2am. The interface is an instrument panel, not a dashboard: a near-black, green-tinted ground with text glowing like phosphor on a CRT, status lights that mean something, and gauges that read at a glance. Everything is monospace because everything here is, literally, a terminal. The aesthetic is earned, not styled: it reads like mission telemetry or an aircraft glass cockpit, where every mark on screen is a measurement and decoration is a liability.
+
+The system is dense and quiet. Surfaces are flat and square, separated by hairline strokes and shifts in tonal value rather than shadows or cards. Color is rationed: the ground and chrome are desaturated greens and grays, and saturation is spent almost entirely on the four status lights and the single amber action. When nothing needs the operator, the screen is calm to the point of being recessive. When an agent is blocked, the red pip is unmistakable. That contrast between calm and alarm is the whole design.
+
+This system explicitly rejects four families. It is not a **generic SaaS dashboard** (no rounded-card grids, pastel gradients, hero-metric tiles, or Inter-on-white). It is not a **consumer chat app** (no bubbly, emoji-forward, soft coziness). It is not an **enterprise admin panel** (no heavy gray chrome or density-without-elegance). It is not **crypto or gamer neon** (no glow-on-black spectacle, RGB, or glassmorphism for its own sake). If a mark on screen is not telemetry, it does not belong.
+
+**Key Characteristics:**
+
+- Monospace everywhere (Berkeley Mono); hierarchy from weight, case, and color, never a second typeface.
+- Near-black green-phosphor ground; chroma reserved for four status lights plus one amber action.
+- Flat, square panels separated by tonal layering and 1px hairlines; no shadows at rest.
+- Dense, telemetry-first layout that reads at a glance and survives on a phone in one hand.
+- Calm by default, alarm when earned: the blocked state is the loudest thing on screen.
+
+## 2. Colors
+
+A desaturated, green-tinted monochrome ground with four reserved status accents. Dark is the default theme; a luminance-inverted light theme shares the same green-tinted family for daytime use.
+
+### Primary
+
+- **Signal Amber** (#e8a13a): The single action accent and the "working" status light. Carries the primary button (as an outline + inset glow, never a fill), active toolbar states, and the slow scanline wash over the live terminal. Its scarcity is what makes it read as "act here."
+
+### Secondary
+
+- **Phosphor Green** (#5ad19a): The "done" and "ready" light, and the ready check glyph. Means go / parked / complete.
+- **Alert Red** (#e5484d): The "blocked, needs you" light. The loudest color in the system; it appears only when an agent is waiting on the operator.
+- **Cold Blue** (#4a90d9): Informational accent and links. Never a status light; keeps "info" distinct from "state."
+- **Idle Slate** (#566460): The "idle / dormant" light. A near-neutral so a quiet agent recedes rather than nags.
+
+### Neutral
+
+- **Deep Pine Black** (#0a0d0c): The app ground, lifted by a faint radial glow (#0d1211) at the top.
+- **Console Panel** (#0f1413) / **panel-2** (#0c100f) / **head** (#0a0f0d) / **inset** (#070a09): The tonal layering vocabulary. Depth is built by stepping these values, not by stacking shadows.
+- **Phosphor Ink** (#c4d0cb): Body text, ~12:1 on the ground.
+- **Bright Phosphor** (#eef4f0): Emphasis text, titles, the value the eye should land on.
+- **Muted Sage** (#7c8c86): Secondary text and metadata, ~5.5:1 (AA).
+- **Faint Moss** (#4a5752): De-emphasized labels, disabled glyphs, the quietest legible step.
+- **Hairline** (#1b2422) / **Bright Hairline** (#2c3835): The 1px strokes that separate every flat panel.
+
+### Named Rules
+
+**The Four-Light Rule.** Status speaks in exactly four colors: amber (working), green (done/ready), red (blocked), slate (idle). These hues are reserved for state. No decorative element may borrow a status color, or it dilutes the only signal that must never be missed.
+
+**The Quiet Ground Rule.** The surface is desaturated green-black; visible chroma stays at or below ~10% of any screen, spent on status lights and the one amber action. If the screen looks colorful at rest, color has leaked out of its lane.
+
+## 3. Typography
+
+**Display / Body / Label Font:** Berkeley Mono (with JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace).
+
+**Character:** One monospaced typeface carries the entire system. The grid of a fixed-width face is the point: it makes the UI read as a terminal and keeps columns, gauges, and code aligned. Personality comes from weight, case, letter-spacing, and ink brightness, not from contrast between families. Base size is a deliberate 13px, tight and instrument-like.
+
+### Hierarchy
+
+- **Title** (600, 13px, 1.35, +0.02em): Panel and section headers, the agent designation, the value the operator scans for. Brighter ink (Bright Phosphor) does as much work as the weight.
+- **Body** (400, 13px, 1.45, +0.02em): Default running text and terminal output. The global base; +0.02em tracking opens the mono just enough to breathe.
+- **Label** (500, 11px, uppercase, +0.12em): Buttons, tab and status labels, toolbar chrome. The wide tracking and small caps read as machine labeling, not prose.
+- **Numeric** (400, 11px, +0.06em, tabular): Token counts, usage percentages, gauge readouts, SHAs. Tabular figures so digits never reflow as values tick.
+
+### Named Rules
+
+**The One Typeface Rule.** Everything is Berkeley Mono. A second family is forbidden; hierarchy is built from size, weight, case, and color only. The monospace grid is non-negotiable, it is what makes this an instrument.
+
+**The Tabular Rule.** Every numeral that updates in place (tokens, gauges, counts, percentages) uses tabular figures. Digits must hold their column so a ticking value reads as motion, not jitter.
+
+## 4. Elevation
+
+This system is flat by doctrine. Depth is built from tonal layering, not shadow: the four ground values (inset #070a09 < panel-2 #0c100f < panel #0f1413 < head #0a0f0d) step against each other, and 1px hairlines (#1b2422, brightening to #2c3835 on focus or hover) draw every boundary. At rest there are no drop shadows and no glassmorphism. The only ambient light in the system is the faint radial glow at the top of the page and the inset amber glow on a primary button.
+
+Shadows are permitted in exactly one situation: a summoned overlay. Bottom sheets and modals that rise over the live terminal carry a single soft shadow to lift them off the busy backdrop, paired with a subtle backdrop blur. That shadow is a response to state (the sheet was invoked), never a resting decoration.
+
+### Shadow Vocabulary
+
+- **Sheet lift** (`box-shadow: 0 -8px 40px rgba(0,0,0,0.5)`): The rising compose / bottom-sheet overlay, anchored to the bottom edge.
+- **Action inset glow** (`box-shadow: inset 0 0 18px -10px var(--color-amber)`): The amber primary/active button. An internal glow, not an outer drop.
+
+### Named Rules
+
+**The Flat Panel Rule.** Surfaces are flat and square at rest. Depth comes from tonal value and hairlines. A drop shadow on a resting panel is prohibited; if you reach for one, you are missing a tonal step.
+
+**The Earned Shadow Rule.** Shadows appear only as a response to invocation (a sheet or modal rising over the terminal). No shadow exists to make a static element look "lifted."
+
+## 5. Components
+
+### Buttons
+
+- **Shape:** Gently squared (2px radius). Square enough to read as instrument hardware, never pill-shaped.
+- **Default:** Outline ghost. Transparent fill, 1px Bright Hairline border, Phosphor Ink text, uppercase 11px label at +0.12em, padding 7px 14px.
+- **Primary / Active:** Same ghost geometry, but border and text switch to Signal Amber with an inset amber glow (`inset 0 0 18px -10px`). The amber primary is never a solid amber fill; the glow does the emphasis.
+- **Hover:** Background lifts to `hover` (#0c1110); border brightens. No motion beyond the tonal shift.
+
+### Inputs / Fields
+
+- **Style:** Recessed. `inset` (#070a09) background, 1px Hairline border, 2px radius, padding ~10px 12px, Body type.
+- **Focus:** Border brightens to Bright Hairline. No outer glow ring; the system stays flat.
+- **Compose sheet:** On mobile, text entry is a bottom sheet on `head` at 94% opacity, 12px top radius, rising with a 0.18s ease-out and a 3px backdrop blur over the dimmed terminal.
+
+### Panels / Containers
+
+- **Corner Style:** Square (0 radius). Structural surfaces do not round.
+- **Background:** `panel` / `head` over the `bg` ground; nested regions step down to `panel-2` / `inset`.
+- **Border:** 1px Hairline on all sides. Never a single colored side-stripe.
+- **Shadow Strategy:** None at rest (see Elevation).
+- **Internal Padding:** 10px 14px is the standard toolbar/panel inset; gaps of 8 to 10px between controls.
+
+### Status Pip (signature)
+
+- A 9px circle filled with the status color (amber / green / red / slate). The "working" pip pulses via an expanding box-shadow halo (`pip-pulse`, 1.5s ease-out). A "ready" agent shows a bare green check glyph instead of a filled dot, so "parked, no next action" reads distinctly from a `done` session. Status never relies on hue alone: position, the pulse, and the check glyph all carry meaning, and labels accompany it wherever it stands in for state.
+
+### Live Terminal (signature)
+
+- A full xterm.js pane on the `bg` ground, fed real PTY bytes. A single amber scanline (a 4%-opacity amber band) sweeps top to bottom over 8s (`scan`), the one piece of ambient motion in the system. It is texture, not noise: low enough opacity to never compete with the terminal text.
+
+### Navigation / Tabs
+
+- Uppercase 11px labels at +0.12em, Muted Sage at rest, brightening to Phosphor Ink or Signal Amber when active. The active tab is marked by amber text plus border, not by a filled tab background.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** keep everything in Berkeley Mono. Build hierarchy from size, weight, case, and ink brightness (Faint Moss -> Muted Sage -> Phosphor Ink -> Bright Phosphor).
+- **Do** reserve the four status colors (amber / green / red / slate) strictly for agent state. The Four-Light Rule is the most important rule in the system.
+- **Do** build depth with tonal layering and 1px hairlines (inset < panel-2 < panel < head). If a panel needs separation, step the value or brighten the hairline.
+- **Do** keep structural panels square (0 radius) and reserve the 2px radius for buttons and chips; 12px is only for rising bottom sheets.
+- **Do** use tabular figures for any number that updates in place.
+- **Do** keep the screen calm at rest and make the blocked (red) state the loudest thing on it. Spend attention only on what is actionable.
+- **Do** pair every status color with a non-color cue (position, pulse, check glyph, or label), and keep touch targets thumb-reachable; phone steering is first-class.
+
+### Don't:
+
+- **Don't** make it a **generic SaaS dashboard**: no rounded-card grids, pastel gradients, hero-metric tiles, or Inter-on-white.
+- **Don't** make it a **consumer chat app**: no bubbly, emoji-forward, soft-and-friendly Slack/Discord coziness.
+- **Don't** make it an **enterprise admin panel**: no heavy gray chrome, Bootstrap-era toolbars, or density-without-elegance.
+- **Don't** make it **crypto/gamer neon**: no glow-on-black spectacle, RGB accents, or glassmorphism. Style must never outrun signal.
+- **Don't** put a drop shadow on a resting surface, or round a structural panel. Flat and square is the doctrine.
+- **Don't** use a colored side-stripe (`border-left`/`border-right` > 1px) as an accent. Use a full hairline, a tonal tint, or a leading pip instead.
+- **Don't** spend a status hue on decoration, or let visible chroma climb above ~10% of a screen at rest.
+- **Don't** fill the primary button solid amber. It is an outline ghost with an inset glow.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,50 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Solo power-user on a Claude Max/Pro subscription, running many `claude` agents at once and acting as their single operator. Desktop is the primary surface (a wide HUD with a live terminal pane); mobile is for monitoring the herd and light steering on the go. The operator is technical, lives in a terminal, and reaches for Shepherd to stop being the bottleneck across a dozen parallel sessions. Context is often long and unattended: glancing at status between other work, or checking in at 2am to see who is blocked.
+
+The job to be done: parallelize many real interactive `claude` sessions without losing oversight, and steer any of them the moment they need a human, from wherever the operator is.
+
+## Product Purpose
+
+Shepherd is self-hosted mission control for **interactive** Claude Code. It spawns genuine `claude` sessions in isolated git worktrees (via `herdr`), bridges each PTY to a browser terminal, and lets one operator observe and steer a whole herd in parallel.
+
+The defining constraint is the ToS-compliance model, not a footnote: Shepherd only **observes** (reads the terminal and agent status) and **steers** (injects keystrokes into the live pane). It never uses the Agent SDK or `claude -p`. If a feature cannot be done by typing into a real terminal, it does not ship. This constraint shapes the product's soul, and the UI should make that interactive-terminal reality felt, not hidden behind abstraction.
+
+Success looks like: one operator confidently running many agents, knowing at a glance who is working, who is idle, and who is blocked and needs them; reaching the right session and steering it in seconds; and trusting the tool enough to leave it running.
+
+## Brand Personality
+
+Terminal-native instrument. Three words: **technical, composed, earned.**
+
+Voice and tone are spare and precise, the register of an operator talking to an operator. No marketing warmth, no hand-holding, no exclamation. Labels are short and literal; the interface assumes competence. It reads like mission telemetry or aircraft instrumentation: monospace, dense, phosphor-green, status pips and gauges that mean something. Personality comes from restraint and fitness for purpose, not from decoration. The product earns trust by being quiet until something needs attention, then making that signal unmistakable.
+
+## Anti-references
+
+This must NOT look like any of the following:
+
+- **Generic SaaS dashboard.** No cards-everywhere layouts, pastel gradients, hero-metric tiles, or Inter-on-white. The Vercel/Linear-clone reflex is the enemy.
+- **Consumer chat app.** No bubbly, emoji-forward, soft-and-friendly Slack/Discord coziness that undercuts the operator-tool seriousness.
+- **Enterprise admin panel.** No heavy chrome, dense gray Bootstrap-era toolbars, or Jira-style density-without-elegance.
+- **Crypto/gamer neon.** No glowing neon-on-black, RGB accents, glassmorphism, or sci-fi overdrive. Style must never outrun signal.
+
+The throughline: every pixel is telemetry. Nothing decorative, nothing that makes a serious tool look like a toy or a template.
+
+## Design Principles
+
+1. **Instrument, not dashboard.** Every element is telemetry that earns its place. No decorative chrome, no hero metrics, no cards for their own sake. If it does not help the operator observe or steer, it does not belong on screen.
+2. **Quiet until it needs you.** The interface stays calm and low-noise by default; the blocked / needs-you state is unmistakable. Attention is a budget, spend it only on what is actionable.
+3. **Steer like a human at a terminal.** The ToS model is the product, not a limitation to abstract away. The UI mirrors genuine interactive terminal use (observe the real pane, type to steer) and should make that reality legible rather than papering over it.
+4. **Density with legibility.** Pack many agents into one pane without sacrificing per-agent readability. It has to work at 2am in a dim room and on a phone with one thumb. Contrast and hierarchy carry the load, not size.
+5. **Remove the operator as bottleneck.** One operator, many agents, no choke point. Design for parallel oversight at a glance and fast routing to the one session that needs a human now.
+
+## Accessibility & Inclusion
+
+- Baseline **WCAG 2.1 AA** contrast across both dark (default) and light themes, already established in the runtime palette (`--ink` ~12:1, `--muted` ~5.5:1 on `--bg`).
+- **Mobile and touch:** phone steering is a first-class use case. Comfortable hit areas and thumb-reachable controls on small screens; the live terminal and steer controls must be usable one-handed.
+- **Status must not rely on hue alone.** Status (working / idle / blocked / done) is the core signal; it is already paired with position and pips, and should keep a non-color cue (shape, icon, or label) wherever it carries meaning.


### PR DESCRIPTION
Adds the impeccable design-context files so future design work (and impeccable's own variant/critique/polish commands) stays on-brand instead of drifting to generic AI output.

## What

- **PRODUCT.md** (strategic) — product register; solo Max/Pro operator; ToS-shaped purpose; *terminal-native instrument* personality (technical, composed, earned); four anti-references; 5 design principles.
- **DESIGN.md** + **DESIGN.json** (visual) — scanned from `src/app.css` + components, not invented:
  - Phosphor-green HUD palette (real hex tokens, dark theme canonical)
  - Berkeley Mono hierarchy (one typeface; weight/case/color do the work)
  - Flat, square panels; tonal layering + 1px hairlines; no resting shadows
  - Four reserved status lights (amber/green/red/slate)
  - Six Named Rules + Do's/Don'ts carrying the PRODUCT.md anti-references verbatim
  - Sidecar with tonal ramps, motion/shadow tokens, and 7 self-contained component snippets for the live panel

Docs only; no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)