### PR TITLE
fix(reaper): don't flag the shepherd server itself on session close (#89)

### DIFF
--- a/src/process-reaper.ts
+++ b/src/process-reaper.ts
@@ -206,8 +206,13 @@ export class ProcessReaper {
   constructor(private probes: ReaperProbes = defaultProbes) {}
 
   /** Detect surviving leftovers for a session (classes 2 + 3). */
-  detect(s: { worktreePath: string; claudeSessionId: string }): Leftover[] {
-    return [...this.scanWorktreeProcs(s.worktreePath), ...this.scanSystemSideEffects(s)];
+  detect(s: { worktreePath: string; claudeSessionId: string; isolated: boolean }): Leftover[] {
+    // Non-isolated sessions never got a private worktree — their `worktreePath` IS
+    // the shared repo root, where the shepherd server itself (and other unrelated
+    // long-running servers) are rooted. A cwd scan there flags processes that merely
+    // share the dir, not ones the session launched, so skip class 2 entirely.
+    const procs = s.isolated ? this.scanWorktreeProcs(s.worktreePath) : [];
+    return [...procs, ...this.scanSystemSideEffects(s)];
   }
 
   /** Class 2 — processes living in the worktree that listen on a port. */
@@ -215,6 +220,9 @@ export class ProcessReaper {
     const root = worktreePath.replace(/\/+$/, "");
     const out: Leftover[] = [];
     for (const p of this.probes.scanProcs()) {
+      // Never offer to reap ourselves: the shepherd server runs in the worktree's
+      // own repo and listens on a port, so without this it could surface itself.
+      if (p.pid === process.pid) continue;
       if (!isUnder(p.cwd, root) || AGENT_COMMS.has(p.comm)) continue;
       const ports = this.probes.portsForPid(p.pid);
       if (ports.length === 0) continue; // no listener ⇒ a transient child, not a server

--- a/test/process-reaper.test.ts
+++ b/test/process-reaper.test.ts
@@ -22,7 +22,7 @@ function makeProbes(over: Partial<ReaperProbes> = {}): ReaperProbes {
   };
 }
 
-const session = { worktreePath: "/wt/repo-x", claudeSessionId: "sess-1" };
+const session = { worktreePath: "/wt/repo-x", claudeSessionId: "sess-1", isolated: true };
 
 test("class 2: a listening process under the worktree is detected", () => {
   const reaper = new ProcessReaper(
@@ -62,6 +62,31 @@ test("class 2: processes outside the worktree are ignored", () => {
     makeProbes({
       scanProcs: () => [{ pid: 7, cwd: "/wt/other-repo", comm: "vite" }],
       portsForPid: () => [3000],
+    }),
+  );
+  expect(reaper.detect(session)).toEqual([]);
+});
+
+test("class 2: a non-isolated session (worktreePath == repo root) never cwd-scans — the shepherd server isn't reaped", () => {
+  // Non-isolated sessions share the repo root as their "worktree"; the shepherd
+  // server's own cwd IS that root and it listens on a port. Scanning by cwd would
+  // flag the server itself. The scan must be skipped entirely when !isolated.
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [{ pid: 7330, cwd: "/repo", comm: "bun" }],
+      portsForPid: () => [7330],
+    }),
+  );
+  expect(
+    reaper.detect({ worktreePath: "/repo", claudeSessionId: "sess-1", isolated: false }),
+  ).toEqual([]);
+});
+
+test("class 2: the reaper never offers its own process (self-pid)", () => {
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [{ pid: process.pid, cwd: "/wt/repo-x", comm: "bun" }],
+      portsForPid: () => [7330], // even listening, the server must not reap itself
     }),
   );
   expect(reaper.detect(session)).toEqual([]);


### PR DESCRIPTION
## Problem

The systemd-launched shepherd `bun` server was repeatedly flagged as a "leftover subprocess" on session decommission — "launched from that session," which it wasn't.

Leftover detection (`ProcessReaper.scanWorktreeProcs`) matches processes by **cwd-under-worktree + listening port**, with the only self-exclusion being `comm === "claude"`. It never checks real parentage, so "shares the worktree dir" is misread as "was launched by the session."

Two cases mis-flag the server (cwd == repo root via systemd `WorkingDirectory=%h/Work/tank`, listening on its port):

1. **Non-isolated sessions** — `worktree.ts` sets `worktreePath = repoPath` when there's no private worktree, so the scan runs against the *shared repo root* where the server (and other unrelated long-running servers) live. `archive()` already special-cases non-isolated sessions (skips `worktree.remove`); `detect()` didn't.
2. **Self** — nothing excluded the server's own pid, so it could offer to kill itself.

## Fix (defense-in-depth)

- Skip the class-2 cwd scan entirely when `!isolated` (class-3 transcript/tailscale scan still runs — it's evidence-based, not cwd-based).
- Exclude `process.pid` in `scanWorktreeProcs` so the server can never reap itself.
- Thread `isolated` through `detect()`'s input (the `SessionRow` already carries it).

## Tests

Added two regression tests (non-isolated repo-root scan skipped; self-pid never offered). Full suite: **539 pass / 0 fail**, tsc clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)