### PR TITLE
perf(topbar): gauge fill via scaleX instead of width

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -159,7 +159,8 @@
             <span class="g-bar"
               ><span
                 class="g-fill"
-                style="width:{hotter.w.pct}%;background:{gaugeColor(hotter.w.pct)}"
+                style="transform:scaleX({Math.min(Math.max(hotter.w.pct, 0), 100) /
+                  100});background:{gaugeColor(hotter.w.pct)}"
               ></span></span
             >
             <span class="g-pct" style="color:{gaugeColor(hotter.w.pct)}">{hotter.w.pct}%</span>
@@ -178,7 +179,10 @@
                 <div class="gauge-pop-row">
                   <span class="g-label micro">{g.label}</span>
                   <span class="g-bar g-bar-wide"
-                    ><span class="g-fill" style="width:{g.w.pct}%;background:{gaugeColor(g.w.pct)}"
+                    ><span
+                      class="g-fill"
+                      style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
+                        100});background:{gaugeColor(g.w.pct)}"
                     ></span></span
                   >
                   <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
@@ -198,7 +202,10 @@
           <div class="gauge tip" data-tip={tip} aria-label={tip}>
             <span class="g-label micro">{g.label}</span>
             <span class="g-bar"
-              ><span class="g-fill" style="width:{g.w.pct}%;background:{gaugeColor(g.w.pct)}"
+              ><span
+                class="g-fill"
+                style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
+                  100});background:{gaugeColor(g.w.pct)}"
               ></span></span
             >
             <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
@@ -389,8 +396,10 @@
   }
   .g-fill {
     display: block;
+    width: 100%;
     height: 100%;
-    transition: width 0.6s ease;
+    transform-origin: left;
+    transition: transform 0.6s ease;
   }
   .g-pct {
     font-size: 11.5px;


### PR DESCRIPTION
## What

Convert the usage/context gauge fill (`.g-fill`) in `TopBar.svelte` from an animated `width` to a transform-based fill.

- Fill is now `width: 100%` with `transform-origin: left`, driven by `transform: scaleX(<pct/100>)` (clamped 0..1).
- Transition changed from `width 0.6s ease` to `transform 0.6s ease` (same timing/feel).
- All three inline sites converted consistently: collapsed hotter gauge, popover rows, inline gauges.

## Why

Animating `width` triggers layout/reflow on every frame — the impeccable detector flagged this as `layout-transition` (the only finding). `scaleX` from the left edge is compositor-friendly and reflow-free.

## Behavior

No visual change: still a left-anchored bar filling to the percentage. Track `overflow: hidden` styles untouched. The global `prefers-reduced-motion` guard already disables the transition. Gauge percentage logic unchanged — only the render path.

## Validation

- `cd ui && bun run check` → 0 errors
- `cd ui && bun run test` → 199 passed (usage-gauges tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)