### PR TITLE
fix(motion): keep work-happening pulses under prefers-reduced-motion

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -148,6 +148,11 @@ body {
     top: 100%;
   }
 }
+/* Blanket-disable decorative motion under reduced-motion. Functional status
+   indicators ("work happening": CI dot-pulse, pip-pulse, critic rev-pulse,
+   in-progress blink) intentionally override this with `animation: ... !important`
+   in their components — the pulse encodes state, not decoration, so suppressing
+   it would drop information rather than polish. */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/ui/src/lib/components/CriticBadge.svelte
+++ b/ui/src/lib/components/CriticBadge.svelte
@@ -54,7 +54,8 @@
     height: 6px;
     border-radius: 50%;
     background: var(--color-amber);
-    animation: rev-pulse 1.1s ease-in-out infinite;
+    /* functional status motion — exempt from the reduced-motion blanket (app.css) */
+    animation: rev-pulse 1.1s ease-in-out infinite !important;
   }
   @keyframes rev-pulse {
     0%,
@@ -63,12 +64,6 @@
     }
     50% {
       opacity: 1;
-    }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .rev-dot {
-      animation: none;
-      opacity: 0.9;
     }
   }
 </style>

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -411,7 +411,8 @@
   }
   .crit-dot.reviewing {
     background: var(--color-amber);
-    animation: rev-pulse 1.1s ease-in-out infinite;
+    /* functional status motion — exempt from the reduced-motion blanket (app.css) */
+    animation: rev-pulse 1.1s ease-in-out infinite !important;
   }
   @keyframes rev-pulse {
     0%,
@@ -420,12 +421,6 @@
     }
     50% {
       opacity: 1;
-    }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .crit-dot.reviewing {
-      animation: none;
-      opacity: 0.9;
     }
   }
   .gbtn.primary {
@@ -508,8 +503,9 @@
   }
   .dot-pending {
     background: var(--color-amber);
-    /* CI running — pulse like every other in-progress indicator */
-    animation: dot-pulse 1.1s ease-in-out infinite;
+    /* CI running — functional status motion, exempt from the reduced-motion
+       blanket (app.css): the pulse encodes "work happening", not decoration. */
+    animation: dot-pulse 1.1s ease-in-out infinite !important;
   }
   .dot-success {
     background: var(--color-green, #5ad19a);

--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -69,8 +69,10 @@
   }
   .dot-pending {
     background: var(--color-amber);
-    /* CI running — pulse like every other in-progress indicator */
-    animation: dot-pulse 1.1s ease-in-out infinite;
+    /* CI running — pulse like every other in-progress indicator.
+       Functional status motion: intentionally overrides the reduced-motion
+       blanket (app.css) — the pulse encodes "work happening", not decoration. */
+    animation: dot-pulse 1.1s ease-in-out infinite !important;
   }
   .dot-success {
     background: var(--color-green, #5ad19a);

--- a/ui/src/lib/components/StatusPip.svelte
+++ b/ui/src/lib/components/StatusPip.svelte
@@ -36,6 +36,7 @@
     font-weight: 700;
   }
   .pulse {
-    animation: pip-pulse 1.5s ease-out infinite;
+    /* functional status motion — exempt from the reduced-motion blanket (app.css) */
+    animation: pip-pulse 1.5s ease-out infinite !important;
   }
 </style>

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -352,7 +352,8 @@
 
   .car {
     color: var(--color-amber);
-    animation: blink 1.1s steps(1) infinite;
+    /* functional in-progress motion — exempt from the reduced-motion blanket (app.css) */
+    animation: blink 1.1s steps(1) infinite !important;
   }
 
   .u-right {


### PR DESCRIPTION
## Problem
On clients reporting `prefers-reduced-motion: reduce` (e.g. Firefox on some Linux/desktop setups), the **CI-pending dot showed static** — no "work happening" pulse. Mobile was fine (reduce-motion off there).

Root cause: the global blanket in `app.css` —
```css
@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation: none !important; } }
```
— kills **every** animation, including functional status indicators whose pulse *encodes state*, not decoration.

## Fix
Functional "work-happening" pulses now override the blanket with `!important` (the only way to beat a `!important` rule; also keeps Svelte-scoped `@keyframes` working):

- `dot-pulse` — CI pending (`PrBadge`, `GitRail`)
- `pip-pulse` — agent status (`StatusPip`)
- `rev-pulse` — critic reviewing (`CriticBadge`, `GitRail`) — also removed the now-contrary local `@media (reduced-motion)` blocks that pinned it to `opacity: 0.9`
- `blink` — in-progress (`UnitRow`)

Documented the convention at the `app.css` guard.

## Deliberately still honoring reduced-motion
Decorative / entrance / attention motion keeps its a11y suppression: `scan` scanline, sheet & scroll-in entrances, backlog skeleton `pulse`, and call-to-action pulses (`update-pulse`, `decom-ready-pulse`, `notes-pulse`, `micPulse`).

## Verification
`cd ui && bun run check` → 0 errors / 0 warnings; prettier + eslint clean (lint-staged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)