### PR TITLE
fix(viewport): keep swipe-up compose reachable on unfolded foldables

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1237,10 +1237,13 @@
     />
   {/if}
 
-  <!-- footer: keyboard-affordance hints — desktop / foldable only. On a phone
-       there's no Tab key and the back button already affords leaving, so the
-       row is pure overhead; dropping it hands the height back to the terminal -->
-  {#if !mobile}
+  <!-- footer: keyboard-affordance hints — true desktop only (mouse + hardware
+       keyboard). Any coarse-pointer device (phone OR unfolded foldable) has no
+       Tab key, so the hints are pure overhead; dropping it hands the height back
+       to the terminal AND keeps the ctrl-row the bottom-most element, so the
+       swipe-up-from-the-bottom-edge compose gesture lands on it (the footer would
+       otherwise sit below the row and swallow the gesture's start on foldables). -->
+  {#if !compact}
     <div class="vp-foot">
       <span>{m.viewport_type_steer_hint()}</span>
       <span class="sep">·</span>


### PR DESCRIPTION
## Problem

"Drag up from the bottom to reveal compose" doesn't work on an unfolded foldable — but works fine on a phone.

## Root cause

The compose swipe-up listeners are bound only to `.ctrl-row`. On an unfolded foldable (`mobile=false`, `touch=true`):

- `.ctrl-row` renders (gated `mobile || touch`) ✓
- `.vp-foot` keyboard-hint footer **also** renders (gated `!mobile`) and, as the last child of the flex-column viewport, sits at the very bottom edge *below* the ctrl-row.

So a bottom-edge swipe starts the finger on `.vp-foot` (no listeners) — `touchstart` never reaches the ctrl-row and compose never opens. On a phone the footer isn't rendered, the ctrl-row *is* the bottom edge, and the gesture works — hence fold-only.

The mismatch: footer gated `!mobile`, ctrl-row gated `mobile || touch`; they overlap on foldables.

## Fix

Gate the footer on `!compact` (`!mobile && !touch`) instead of `!mobile`. The footer is keyboard-affordance hints (type-to-steer, detach, ⇧/⌥-select) — pure overhead on any coarse-pointer/no-keyboard device, the same condition that summons the ctrl-row. Dropping it on foldables makes the ctrl-row bottom-most so the bottom-edge swipe lands on it.

One-line render-condition change; no logic or i18n keys touched.

## Verification

- `cd ui && bun run check` → 0 errors
- `bun run check:i18n` → 2 locales in parity
- swipe unit tests → 23 pass
- prettier clean

Manual check recommended: responsive devtools at a fold width (≥769px) + touch emulation — confirm swipe-up opens compose and losing the footer hints on foldables is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)