### PR TITLE
fix(ui): stop compact herd cards crushing the agent name

### DIFF
--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -136,10 +136,11 @@
         <span class="badge">{statusLabel(session.status)}</span>
       {/if}
       <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
-      <span class="meta"
-        ><span class="desig">{session.desig}</span> · {session.herdrSession || "—"}</span
-      >
     </div>
+
+    <span class="meta"
+      ><span class="desig">{session.desig}</span> · {session.herdrSession || "—"}</span
+    >
   </button>
 {/snippet}
 
@@ -176,7 +177,14 @@
     position: relative;
     display: grid;
     grid-template-columns: 14px 1fr auto;
-    gap: 12px;
+    /* meta (desig · session) drops to a full-width footer row so it no longer
+       fights the name for horizontal space — on a compact sidebar the right
+       rail used to win and crush the name to an ellipsis stub */
+    grid-template-areas:
+      "pip main right"
+      "pip meta meta";
+    column-gap: 12px;
+    row-gap: 3px;
     align-items: start;
     padding: 11px 13px 11px 14px;
     border: 1px solid transparent;
@@ -284,12 +292,14 @@
   }
 
   .pip-col {
+    grid-area: pip;
     display: flex;
     align-items: flex-start;
     padding-top: 5px;
   }
 
   .u-main {
+    grid-area: main;
     min-width: 0;
   }
 
@@ -357,6 +367,7 @@
   }
 
   .u-right {
+    grid-area: right;
     text-align: right;
     display: flex;
     flex-direction: column;
@@ -383,8 +394,13 @@
   }
 
   .meta {
+    grid-area: meta;
+    min-width: 0;
     color: var(--color-muted);
     font-size: 11.5px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
   /* the task designation is metadata, not the human marker — demoted to the
      quietest spot, the bottom-right meta line, next to the herdr session */
@@ -396,6 +412,19 @@
   @media (max-width: 768px) {
     .unit {
       min-height: 44px;
+    }
+  }
+
+  /* Compact sidebar (touch foldables, narrow picker): the meta footer already
+     frees the name from the right rail; here we trade the 2nd prompt line for
+     density so more agents stay visible without the card growing taller. */
+  @container herd (max-width: 300px) {
+    .unit {
+      column-gap: 9px;
+    }
+    .u-sub {
+      -webkit-line-clamp: 1;
+      line-clamp: 1;
     }
   }
 </style>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -552,7 +552,7 @@
   /* touch devices on the desktop layout (e.g. unfolded foldables): the picker
      would otherwise eat too much of a narrow-ish wide screen */
   .grid.compact {
-    grid-template-columns: minmax(220px, 260px) 1fr;
+    grid-template-columns: minmax(244px, 288px) 1fr;
     gap: 10px;
   }
   .grid-all {


### PR DESCRIPTION
## Problem

On the **compact** layout (touch foldables — `minmax(220px, 260px)` sidebar) the herd cards crush the agent name to an ellipsis stub: `impeccable-audit-ui` → `impe…`, `tank` → `tan`, prompt → `/impec` / `audi…`.

Root cause: `UnitRow` is a `14px | 1fr | auto` grid. The right rail (`auto`, `flex-shrink: 0`) was sized by its widest child — the meta line `TASK-NN · session` (~18ch) — so it won the width fight and starved the `1fr` name column. The recent UI batch (#185 confirm/undo, #188 PR disclosure, PR + critic badges) thickened that rail, which is why it regressed. `Herd.svelte` already set up `container: herd / inline-size` for exactly this adaptation, but the `@container` rules were never written.

## Fix

- **`UnitRow.svelte`** — move the `desig · session` meta line out of the right rail into a **full-width footer row** via `grid-template-areas`. It no longer competes with the name at any width and truncates with an ellipsis instead of forcing the rail wide.
- Add the missing `@container herd (max-width: 300px)` rule: tighten the gap and clamp the prompt to one line on a narrow sidebar so the footer row doesn't add height (density preserved).
- **`+page.svelte`** — nudge the compact picker floor `minmax(220px, 260px)` → `minmax(244px, 288px)`; the terminal still keeps the large majority of the pane.

Net: the name regains the full `1fr`, metadata sits in its proper quiet bottom slot, and the right rail holds only short tokens (PR / status / elapsed).

## Verification

- `cd ui && bun run check` — 0 errors
- prettier clean, `bun run check:i18n` — 2 locales in parity (no new strings)
- `bun run test` — 199/199 pass

Visual confirm on a populated herd pending (needs live session data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)