### PR TITLE
feat(ui): dim a session while its decommission undo is offered

### DIFF
--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -11,6 +11,7 @@
   import PrBadge from "./PrBadge.svelte";
   import CriticBadge from "./CriticBadge.svelte";
   import { reviews } from "$lib/reviews.svelte";
+  import { toasts } from "$lib/toasts.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { m } from "$lib/paraglide/messages";
   import { onDestroy } from "svelte";
@@ -97,12 +98,17 @@
   });
 
   const hideStatus = $derived(hideStatusBadge(session.status, reviews.isReviewing(session.id)));
+
+  // Decommission is deferred behind an undo window: while it's open, the row is
+  // doomed-but-still-present. Dim it so the operator sees it's on its way out.
+  const decommissioning = $derived(toasts.pendingUndo(session.id));
 </script>
 
 {#snippet row()}
   <button
     class="unit"
     class:sel={selected}
+    class:decommissioning
     style="--rule:{session.readyToMerge ? 'var(--color-green)' : STATUS_COLOR[session.status]}"
     onclick={() => onselect(session.id)}
     type="button"
@@ -195,6 +201,13 @@
     font: inherit;
     text-align: left;
     width: 100%;
+    transition: opacity 0.18s ease;
+  }
+
+  /* deferred decommission: row is doomed but still listed during the undo
+     window — fade it so it visibly recedes; restored instantly on UNDO */
+  .unit.decommissioning {
+    opacity: 0.4;
   }
 
   :global(.unit + .unit),

--- a/ui/src/lib/toasts.svelte.test.ts
+++ b/ui/src/lib/toasts.svelte.test.ts
@@ -1,0 +1,50 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { toasts } from "./toasts.svelte";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // start each test from a clean queue
+  for (const t of [...toasts.items]) toasts.close(t.id);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("pendingUndo tracks a keyed undo across its window", () => {
+  expect(toasts.pendingUndo("s1")).toBe(false);
+
+  toasts.undo("decommissioned", { undoLabel: "UNDO", key: "s1", onCommit: () => {} });
+  expect(toasts.pendingUndo("s1")).toBe(true);
+  expect(toasts.pendingUndo("s2")).toBe(false);
+});
+
+test("pendingUndo clears when the window expires (commit fires)", async () => {
+  const onCommit = vi.fn();
+  toasts.undo("decommissioned", { undoLabel: "UNDO", key: "s1", onCommit, duration: 5000 });
+  expect(toasts.pendingUndo("s1")).toBe(true);
+
+  await vi.advanceTimersByTimeAsync(5000);
+  expect(onCommit).toHaveBeenCalledOnce();
+  expect(toasts.pendingUndo("s1")).toBe(false);
+});
+
+test("pendingUndo clears when UNDO is pressed", () => {
+  const onUndo = vi.fn();
+  const id = toasts.undo("decommissioned", {
+    undoLabel: "UNDO",
+    key: "s1",
+    onCommit: () => {},
+    onUndo,
+  });
+  expect(toasts.pendingUndo("s1")).toBe(true);
+
+  toasts.cancel(id);
+  expect(onUndo).toHaveBeenCalledOnce();
+  expect(toasts.pendingUndo("s1")).toBe(false);
+});
+
+test("an unkeyed undo is not matched by pendingUndo", () => {
+  toasts.undo("generic", { undoLabel: "UNDO", onCommit: () => {} });
+  expect(toasts.pendingUndo("s1")).toBe(false);
+});

--- a/ui/src/lib/toasts.svelte.ts
+++ b/ui/src/lib/toasts.svelte.ts
@@ -18,6 +18,8 @@ interface Toast {
   undoLabel?: string;
   /** Window length, fed to the depleting-bar animation (undo toasts only). */
   durationMs?: number;
+  /** Dedupe key (undo toasts only); also lets the UI find the deferred target. */
+  key?: string;
   /** Optional inline action on an info toast (e.g. Retry); runs via act(). */
   actionLabel?: string;
 }
@@ -86,7 +88,7 @@ class ToastStore {
     const id = ++this.#seq;
     this.items = [
       ...this.items,
-      { id, tone: "undo", text, undoLabel: opts.undoLabel, durationMs: duration },
+      { id, tone: "undo", text, undoLabel: opts.undoLabel, durationMs: duration, key: opts.key },
     ];
     this.#commits.set(id, opts.onCommit);
     if (opts.onUndo) this.#undos.set(id, opts.onUndo);
@@ -105,6 +107,11 @@ class ToastStore {
   /** Dismiss an info toast (no commit attached). */
   close(id: number): void {
     this.#drop(id);
+  }
+
+  /** Is a destructive action against `key` currently deferred in its undo window? */
+  pendingUndo(key: string): boolean {
+    return this.items.some((t) => t.tone === "undo" && t.key === key);
   }
 
   #arm(id: number, duration: number) {


### PR DESCRIPTION
## What

While a session's decommission undo window is open, its sidebar row dims (opacity 0.4, smooth fade), then snaps back instantly if **UNDO** is pressed.

Decommission is deferred behind the undo toast — the row stays listed but doomed until the window expires. This makes that liminal state visible instead of leaving a still-normal-looking row that's about to vanish.

## How

- `toasts.svelte.ts` — expose the dedupe `key` on the public `Toast` item and add a reactive `pendingUndo(key)` query. Since `items` is `$state`, rows dim/un-dim automatically as the undo toast arms, expires (commit), or is cancelled (undo).
- `UnitRow.svelte` — `decommissioning = $derived(toasts.pendingUndo(session.id))` → `class:decommissioning` → `.unit.decommissioning { opacity: 0.4 }`. Same store-import pattern the row already uses for `reviews`.
- `toasts.svelte.test.ts` — new coverage for `pendingUndo` across arm → expire → cancel, plus the unkeyed case.

The decommissioned row is never the selected one (`onarchive` moves focus off it before arming the toast), so the dim never fights the `.sel` highlight.

## Verify

- `bun run check` — 0 errors
- `check:i18n` — parity holds (purely visual, no new strings)
- prettier clean
- 203 UI tests pass (4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)