### PR TITLE
fix(ui): wrap detail header controls as a cluster on mobile

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1026,45 +1026,49 @@
         <span class="gt-caret" aria-hidden="true">{gitOpen ? "▴" : "▾"}</span>
       </button>
     {/if}
-    {#if renaming}
-      <span class="rename-edit">
-        <input
-          bind:this={renameInput}
-          class="rename-input"
-          class:err={renameError}
-          bind:value={renameDraft}
-          placeholder={m.viewport_rename_placeholder()}
-          aria-label={m.viewport_rename_aria()}
-          onkeydown={onRenameKey}
-          onblur={commitRename}
-        />
-        {#if renameError}<span class="rename-err" title={renameError}>{renameError}</span>{/if}
-      </span>
-    {:else}
-      <button
-        class="rename-btn"
-        type="button"
-        onclick={startRename}
-        title={m.viewport_rename_aria()}
-        aria-label={m.viewport_rename_aria()}>✎</button
-      >
-      {#if renameNote}<span class="rename-note">{renameNote}</span>{/if}
-    {/if}
-    <button
-      class="decom"
-      class:armed
-      class:ready={prReady && !armed}
-      type="button"
-      onclick={decommission}
-      title={prReady ? m.viewport_decommission_ready_title() : m.viewport_decommission_title()}
-      aria-label={prReady ? m.viewport_decommission_ready_aria() : m.viewport_decommission_aria()}
-    >
-      {#if compact}
-        {armed ? "✓" : "✕"}
+    <!-- trailing controls: on compact/phone they group + wrap together as a
+         right-aligned cluster so the close button never orphans to its own row -->
+    <div class="vp-actions">
+      {#if renaming}
+        <span class="rename-edit">
+          <input
+            bind:this={renameInput}
+            class="rename-input"
+            class:err={renameError}
+            bind:value={renameDraft}
+            placeholder={m.viewport_rename_placeholder()}
+            aria-label={m.viewport_rename_aria()}
+            onkeydown={onRenameKey}
+            onblur={commitRename}
+          />
+          {#if renameError}<span class="rename-err" title={renameError}>{renameError}</span>{/if}
+        </span>
       {:else}
-        {armed ? m.viewport_confirm_decommission() : m.viewport_decommission()}
+        <button
+          class="rename-btn"
+          type="button"
+          onclick={startRename}
+          title={m.viewport_rename_aria()}
+          aria-label={m.viewport_rename_aria()}>✎</button
+        >
+        {#if renameNote}<span class="rename-note">{renameNote}</span>{/if}
       {/if}
-    </button>
+      <button
+        class="decom"
+        class:armed
+        class:ready={prReady && !armed}
+        type="button"
+        onclick={decommission}
+        title={prReady ? m.viewport_decommission_ready_title() : m.viewport_decommission_title()}
+        aria-label={prReady ? m.viewport_decommission_ready_aria() : m.viewport_decommission_aria()}
+      >
+        {#if compact}
+          {armed ? "✓" : "✕"}
+        {:else}
+          {armed ? m.viewport_confirm_decommission() : m.viewport_decommission()}
+        {/if}
+      </button>
+    </div>
   </div>
 
   <!-- the git rail gets its own strip when there's no room for it inline:
@@ -1388,6 +1392,13 @@
 
   .spacer {
     flex: 1;
+  }
+
+  /* desktop: transparent to layout — rename + decom flow inline as before.
+     compact/phone override (see .vp-head.mobile .vp-actions) turns this into a
+     real flex cluster so the two trailing controls wrap together. */
+  .vp-actions {
+    display: contents;
   }
 
   .status-badge {
@@ -1889,6 +1900,17 @@
     flex-wrap: wrap;
     row-gap: 6px;
     padding: 8px 10px;
+  }
+  /* group the trailing controls (rename ✎ + close ✕) into one cluster that
+     wraps as a unit and stays right-aligned — margin-left:auto pins it to the
+     right edge of whichever row it lands on, so the close button can no longer
+     orphan to the left of its own line when the identity row gets crowded */
+  .vp-head.mobile .vp-actions {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    margin-left: auto;
+    flex-shrink: 0;
   }
   /* let the task name claim the free space instead of splitting it with the
      spacer; its flex-grow still pushes the status badge + decom to the right */


### PR DESCRIPTION
## Problem

On the phone detail header, when the identity row (`🚧 repo · session-name`) gets crowded, the close button (✕) wrapped onto its own line **alone on the left** — the spacer that right-aligns the controls stayed on row 1, so the orphaned ✕ looked broken.

![before](https://github.com/erwins-enkel/shepherd) <!-- screenshot in issue -->

## Fix

Group the two trailing controls (rename ✎ + close ✕) into one `.vp-actions` cluster:

- **Desktop:** `display: contents` → zero layout change, controls flow inline exactly as before.
- **Compact / phone:** `display: flex; margin-left: auto; flex-shrink: 0` → the cluster wraps as a single unit and pins to the right edge of whichever row it lands on. The close button can no longer orphan.

CSS-only on the mobile path. No new strings, desktop untouched.

## Verification

- `cd ui && bun run check` → 0 errors
- prettier-clean, eslint-clean (lint-staged on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)