### PR TITLE
feat(ui): group session list by PR-running and reviewer-running stages

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -103,6 +103,8 @@
   "herd_all_hint": "▦ Alle",
   "herd_ready_filter": "▤ Bereit",
   "herd_ready_empty": "Nichts wartet. Alle sind beschäftigt",
+  "herd_pr_running_group": "PR läuft ({count})",
+  "herd_reviewer_running_group": "Review läuft ({count})",
   "herd_ready_group": "Bereit zum Mergen ({count})",
   "herd_merged_group": "Gemergt ({count})",
   "issuespanel_title": "ISSUES",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -103,6 +103,8 @@
   "herd_all_hint": "▦ All",
   "herd_ready_filter": "▤ Ready",
   "herd_ready_empty": "Nothing waiting. All hands working",
+  "herd_pr_running_group": "PR running ({count})",
+  "herd_reviewer_running_group": "Reviewing ({count})",
   "herd_ready_group": "Ready to merge ({count})",
   "herd_merged_group": "Merged ({count})",
   "issuespanel_title": "ISSUES",

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -3,6 +3,7 @@
   import UnitRow from "./UnitRow.svelte";
   import EmptyHerd from "./EmptyHerd.svelte";
   import { partitionSessions } from "./herd-partition";
+  import { reviews } from "$lib/reviews.svelte";
   import { m } from "$lib/paraglide/messages";
 
   let {
@@ -36,9 +37,11 @@
   const shown = $derived(
     filter === "ready" ? sessions.filter((s) => s.status !== "running") : sessions,
   );
-  // within the shown set: active rows on top; ready-to-merge ones parked in a
-  // green group below, merged-PR ones in a blue group at the very bottom
-  const partition = $derived(partitionSessions(shown, git));
+  // within the shown set, top→bottom by lifecycle stage: active rows first, then
+  // PR-CI-running and critic-reviewing in-flight groups, then the parked
+  // ready-to-merge (green) and landed merged (blue) groups at the bottom.
+  // reviews.reviewing is $state, so this re-derives on `session:reviewing` events.
+  const partition = $derived(partitionSessions(shown, git, (id) => reviews.isReviewing(id)));
 </script>
 
 <div class="panel bracket">
@@ -77,6 +80,36 @@
           {ondecommission}
         />
       {/each}
+      {#if partition.prRunning.length > 0}
+        <div class="pr-head micro">
+          {m.herd_pr_running_group({ count: partition.prRunning.length })}
+        </div>
+        {#each partition.prRunning as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            {ondecommission}
+          />
+        {/each}
+      {/if}
+      {#if partition.reviewerRunning.length > 0}
+        <div class="reviewing-head micro">
+          {m.herd_reviewer_running_group({ count: partition.reviewerRunning.length })}
+        </div>
+        {#each partition.reviewerRunning as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            {ondecommission}
+          />
+        {/each}
+      {/if}
       {#if partition.ready.length > 0}
         <div class="ready-head micro">{m.herd_ready_group({ count: partition.ready.length })}</div>
         {#each partition.ready as session (session.id)}
@@ -176,6 +209,18 @@
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
+  }
+
+  /* amber section headers for the in-flight stages (PR CI running, critic
+     reviewing) — amber mirrors the CI-pending dot and the critic badge */
+  .pr-head,
+  .reviewing-head {
+    display: flex;
+    align-items: center;
+    padding: 10px 8px 6px;
+    margin-top: 6px;
+    color: var(--color-amber);
+    border-top: 1px solid color-mix(in srgb, var(--color-amber) 30%, var(--color-line));
   }
 
   /* green section header for the parked "ready to merge" group */

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -26,8 +26,8 @@ function session(id: string, readyToMerge = false): Session {
   };
 }
 
-function git(state: GitState["state"]): GitState {
-  return { kind: "github", state, checks: "none", deployConfigured: false };
+function git(state: GitState["state"], checks: GitState["checks"] = "none"): GitState {
+  return { kind: "github", state, checks, deployConfigured: false };
 }
 
 test("ready sessions land in the ready group, active stay on top", () => {
@@ -76,4 +76,68 @@ test("all-active yields empty ready and merged groups", () => {
   expect(active).toHaveLength(2);
   expect(ready).toHaveLength(0);
   expect(merged).toHaveLength(0);
+});
+
+test("open PR with pending CI lands in the prRunning group", () => {
+  const list = [session("a"), session("p1"), session("b")];
+  const { active, prRunning } = partitionSessions(list, { p1: git("open", "pending") });
+  expect(active.map((s) => s.id)).toEqual(["a", "b"]);
+  expect(prRunning.map((s) => s.id)).toEqual(["p1"]);
+});
+
+test("open PR with non-pending CI stays active", () => {
+  const list = [session("s"), session("n")];
+  const { active, prRunning } = partitionSessions(list, {
+    s: git("open", "success"),
+    n: git("open", "none"),
+  });
+  expect(active.map((s) => s.id)).toEqual(["s", "n"]);
+  expect(prRunning).toHaveLength(0);
+});
+
+test("a session under review lands in the reviewerRunning group", () => {
+  const list = [session("a"), session("rv"), session("b")];
+  const { active, reviewerRunning } = partitionSessions(list, {}, (id) => id === "rv");
+  expect(active.map((s) => s.id)).toEqual(["a", "b"]);
+  expect(reviewerRunning.map((s) => s.id)).toEqual(["rv"]);
+});
+
+test("reviewing wins over pending CI when both apply", () => {
+  const list = [session("x")];
+  const { prRunning, reviewerRunning } = partitionSessions(
+    list,
+    { x: git("open", "pending") },
+    () => true,
+  );
+  expect(prRunning).toHaveLength(0);
+  expect(reviewerRunning.map((s) => s.id)).toEqual(["x"]);
+});
+
+test("merged and ready win over reviewing and pending CI", () => {
+  const list = [session("m"), session("r", true)];
+  const { ready, merged, prRunning, reviewerRunning } = partitionSessions(
+    list,
+    { m: git("merged", "pending"), r: git("open", "pending") },
+    () => true,
+  );
+  expect(merged.map((s) => s.id)).toEqual(["m"]);
+  expect(ready.map((s) => s.id)).toEqual(["r"]);
+  expect(prRunning).toHaveLength(0);
+  expect(reviewerRunning).toHaveLength(0);
+});
+
+test("preserves input order within the new stage groups", () => {
+  const list = [session("p1"), session("v1"), session("p2"), session("v2")];
+  const { prRunning, reviewerRunning } = partitionSessions(
+    list,
+    { p1: git("open", "pending"), p2: git("open", "pending") },
+    (id) => id.startsWith("v"),
+  );
+  expect(prRunning.map((s) => s.id)).toEqual(["p1", "p2"]);
+  expect(reviewerRunning.map((s) => s.id)).toEqual(["v1", "v2"]);
+});
+
+test("omitted reviewing predicate leaves reviewerRunning empty", () => {
+  const { reviewerRunning } = partitionSessions([session("a")], {});
+  expect(reviewerRunning).toHaveLength(0);
 });

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -1,24 +1,40 @@
 import type { Session, GitState } from "$lib/types";
 
-/** Split sessions into active (still in play), ready-to-merge (operator-parked),
- *  and merged (PR already landed) groups, preserving the input order within each.
- *  Merged wins over ready: once the PR is in, that's the final state. The ready
- *  and merged groups render below the active one as parked "done" sections. */
+/** Split sessions into stage groups, preserving input order within each:
+ *  - active: still in play, no later stage reached
+ *  - prRunning: open PR with CI checks in flight (`open` + `pending`)
+ *  - reviewerRunning: a critic run is in flight for the session
+ *  - ready: operator-parked "ready to merge"
+ *  - merged: PR already landed
+ *
+ *  First-match precedence (terminal states win; reviewing beats PR-running as the
+ *  later lifecycle stage): merged > ready > reviewerRunning > prRunning > active.
+ *  The groups render top→bottom as active → prRunning → reviewerRunning → ready →
+ *  merged, mirroring the session lifecycle. `isReviewing` is injected so this stays
+ *  a pure function (the caller wires it to the reviews store). */
 export function partitionSessions(
   sessions: Session[],
   git: Record<string, GitState>,
+  isReviewing: (id: string) => boolean = () => false,
 ): {
   active: Session[];
+  prRunning: Session[];
+  reviewerRunning: Session[];
   ready: Session[];
   merged: Session[];
 } {
   const active: Session[] = [];
+  const prRunning: Session[] = [];
+  const reviewerRunning: Session[] = [];
   const ready: Session[] = [];
   const merged: Session[] = [];
   for (const s of sessions) {
-    if (git[s.id]?.state === "merged") merged.push(s);
+    const g = git[s.id];
+    if (g?.state === "merged") merged.push(s);
     else if (s.readyToMerge) ready.push(s);
+    else if (isReviewing(s.id)) reviewerRunning.push(s);
+    else if (g?.state === "open" && g.checks === "pending") prRunning.push(s);
     else active.push(s);
   }
-  return { active, ready, merged };
+  return { active, prRunning, reviewerRunning, ready, merged };
 }


### PR DESCRIPTION
## What

Subdivides the herd session list's flat "active" block into in-flight **stage groups**, so PR-CI and critic activity cluster under their own headers instead of scattering as plain rows.

Render order, top → bottom (lifecycle):

**active** → **PR running** → **Reviewing** → ready (green) → merged (blue)

- **PR running** = open PR with CI checks in flight (`git.state === "open" && checks === "pending"`)
- **Reviewing** = critic run in flight (`reviews.isReviewing(id)`)

Both new headers are **amber**, matching the existing CI-pending dot and critic badge; green/blue terminal groups keep their hues.

## How

- `partitionSessions` now returns `{ active, prRunning, reviewerRunning, ready, merged }` and takes an injected `isReviewing` predicate (keeps it pure/testable). First-match precedence: `merged › ready › reviewerRunning › prRunning › active` — reviewing wins over PR-running as the later stage.
- `Herd.svelte` imports the `reviews` singleton and passes the predicate; `$derived` re-runs on `session:reviewing` WS events. Two new section headers mirror the existing `.ready-head`/`.merged-head` pattern.
- New i18n keys `herd_pr_running_group` / `herd_reviewer_running_group` in **both** EN + DE.

`UnitRow`, the badges, the all/ready filter, stores, and the backend are untouched.

## Tests

- `herd-partition.test.ts`: +7 cases (written test-first) — pending→prRunning, reviewing→reviewerRunning, reviewing-wins-over-pending, merged/ready win over both, open+success/none stay active, order preservation, default predicate. 13 partition tests pass.
- Full UI suite **210 pass** · `bun run check` **0 errors** · `check:i18n` parity (339 keys) · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)