### PR TITLE
feat(slash): recognize commands mid-text, not just at prompt start

### DIFF
--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -4,7 +4,7 @@
   import { getLocale } from "$lib/i18n";
   import { insertNewlineAt } from "$lib/compose";
   import { getCommands } from "$lib/api";
-  import { matchSlashTrigger, filterCommands } from "$lib/slash";
+  import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
   import type { SlashCommand } from "$lib/types";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
   import { steers } from "$lib/steers.svelte";
@@ -75,17 +75,20 @@
     }
   }
 
-  // Replace the leading `/query` token with the chosen command, leaving a
-  // trailing space so the user can type arguments straight away.
+  // Replace the typed `/query` token with the chosen command and hoist it to the
+  // front — Claude only runs a *leading* slash command, so a command typed mid-text
+  // becomes the leading command with the surrounding text as its argument. Caret
+  // lands past `/name ` so the user can type arguments straight away.
   function pickCommand(cmd: SlashCommand) {
     const caret = ta?.selectionStart ?? value.length;
-    const insert = `/${cmd.name} `;
-    value = insert + value.slice(caret);
+    const start = matchSlashTrigger(value, caret)?.start ?? 0;
+    const next = applyCommandPick(value, start, caret, cmd.name);
+    value = next.value;
     slashOpen = false;
     queueMicrotask(() => {
       autogrow();
       ta?.focus();
-      ta?.setSelectionRange(insert.length, insert.length);
+      ta?.setSelectionRange(next.caret, next.caret);
     });
   }
 

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -3,7 +3,7 @@
   import { listRepos, listBranches, getCommands, uploadImage } from "$lib/api";
   import { handleImagePaste } from "$lib/clipboard";
   import { MODELS, type Issue, type IssueRef, type RepoEntry, type SlashCommand } from "$lib/types";
-  import { matchSlashTrigger, filterCommands } from "$lib/slash";
+  import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
   import RepoSelect from "./RepoSelect.svelte";
   import PromptSources from "./PromptSources.svelte";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
@@ -207,17 +207,20 @@
     refreshSlash();
   }
 
-  // Replace the leading `/query` token with the chosen command, leaving a trailing
-  // space so the user can type arguments straight away.
+  // Replace the typed `/query` token with the chosen command and hoist it to the
+  // front of the prompt — Claude only runs a *leading* slash command, so a command
+  // typed mid-text becomes the leading command with the surrounding text as its
+  // argument. Caret lands past `/name ` so the user can type arguments straight away.
   function pickCommand(cmd: SlashCommand) {
     const caret = promptInput?.selectionStart ?? prompt.length;
-    const insert = `/${cmd.name} `;
-    prompt = insert + prompt.slice(caret);
+    const start = matchSlashTrigger(prompt, caret)?.start ?? 0;
+    const next = applyCommandPick(prompt, start, caret, cmd.name);
+    prompt = next.value;
     slashOpen = false;
     queueMicrotask(() => {
       autogrow();
       promptInput?.focus();
-      promptInput?.setSelectionRange(insert.length, insert.length);
+      promptInput?.setSelectionRange(next.caret, next.caret);
     });
   }
 

--- a/ui/src/lib/slash.test.ts
+++ b/ui/src/lib/slash.test.ts
@@ -1,33 +1,70 @@
 import { describe, it, expect } from "vitest";
-import { matchSlashTrigger, filterCommands } from "./slash";
+import { matchSlashTrigger, filterCommands, applyCommandPick } from "./slash";
 import type { SlashCommand } from "./types";
 
 const cmd = (name: string): SlashCommand => ({ name, description: "", scope: "user" });
 
 describe("matchSlashTrigger", () => {
   it("triggers on a leading slash at the caret", () => {
-    expect(matchSlashTrigger("/cre", 4)).toEqual({ query: "cre" });
+    expect(matchSlashTrigger("/cre", 4)).toEqual({ query: "cre", start: 0 });
   });
 
   it("triggers with an empty query right after the slash", () => {
-    expect(matchSlashTrigger("/", 1)).toEqual({ query: "" });
+    expect(matchSlashTrigger("/", 1)).toEqual({ query: "", start: 0 });
   });
 
-  it("does not trigger when the slash is not at the start", () => {
-    expect(matchSlashTrigger("fix /foo", 8)).toBeNull();
+  it("triggers when the slash starts a token after a space (mid-text)", () => {
+    expect(matchSlashTrigger("fix /foo", 8)).toEqual({ query: "foo", start: 4 });
+  });
+
+  it("triggers when the slash starts a token after a newline", () => {
+    expect(matchSlashTrigger("ctx\n/sha", 8)).toEqual({ query: "sha", start: 4 });
   });
 
   it("does not trigger once a space ends the command token", () => {
     expect(matchSlashTrigger("/foo bar", 8)).toBeNull();
   });
 
+  it("does not trigger when the slash is mid-word (a path, not a token)", () => {
+    expect(matchSlashTrigger("a/foo", 5)).toBeNull();
+    expect(matchSlashTrigger("see src/foo", 11)).toBeNull();
+  });
+
   it("uses the text before the caret, not the whole string", () => {
     // caret sits inside the slash token even though more text follows
-    expect(matchSlashTrigger("/foobar", 4)).toEqual({ query: "foo" });
+    expect(matchSlashTrigger("/foobar", 4)).toEqual({ query: "foo", start: 0 });
   });
 
   it("does not trigger on empty input", () => {
     expect(matchSlashTrigger("", 0)).toBeNull();
+  });
+});
+
+describe("applyCommandPick", () => {
+  it("seeds the command on an otherwise-empty prompt", () => {
+    // user typed "/cr", caret at end, picks "create_plan"
+    expect(applyCommandPick("/cr", 0, 3, "create_plan")).toEqual({
+      value: "/create_plan ",
+      caret: 13,
+    });
+  });
+
+  it("hoists a mid-text command to the front, folding the rest into the argument", () => {
+    // "the names are bad /sh" → picks "shaping" → command leads, text becomes its arg
+    const text = "the names are bad /sh";
+    const trig = matchSlashTrigger(text, text.length)!;
+    expect(applyCommandPick(text, trig.start, text.length, "shaping")).toEqual({
+      value: "/shaping the names are bad",
+      caret: 9,
+    });
+  });
+
+  it("keeps text that follows the caret as part of the argument", () => {
+    // "/rev the diff", caret right after "/rev", picks "review"
+    expect(applyCommandPick("/rev the diff", 0, 4, "review")).toEqual({
+      value: "/review the diff",
+      caret: 8,
+    });
   });
 });
 

--- a/ui/src/lib/slash.ts
+++ b/ui/src/lib/slash.ts
@@ -1,20 +1,53 @@
 import type { SlashCommand } from "./types";
 
 /**
- * Detect a slash-command trigger from the text up to the caret. Claude only treats
- * a leading `/` as a command, so we trigger ONLY at the very start of the prompt:
- * the text before the caret must be `/` followed by zero or more non-space chars.
- * Returns the typed query (without the slash), or null when no trigger is active.
+ * Detect a slash-command trigger from the text up to the caret. A `/` triggers the
+ * picker when it begins a new token — at the very start of the prompt, or right after
+ * whitespace/newline — followed by zero or more non-space chars up to the caret.
+ * Returns the typed query (without the slash) and the index of the `/`, or null when
+ * no trigger is active.
  *
- *   matchSlashTrigger("/cre", 4)      → { query: "cre" }
- *   matchSlashTrigger("/", 1)         → { query: "" }
- *   matchSlashTrigger("fix /foo", 8)  → null   (not at start)
- *   matchSlashTrigger("/foo bar", 8)  → null   (space ends the token)
+ * The `/` must start a token: `a/foo` (a path, a mid-word slash) does not trigger.
+ * Claude only *runs* a slash command when it leads the prompt, so a command typed
+ * mid-text won't dispatch as-is — picking one hoists it to the front (see
+ * {@link applyCommandPick}).
+ *
+ *   matchSlashTrigger("/cre", 4)        → { query: "cre", start: 0 }
+ *   matchSlashTrigger("/", 1)           → { query: "", start: 0 }
+ *   matchSlashTrigger("fix /foo", 8)    → { query: "foo", start: 4 }
+ *   matchSlashTrigger("ctx\n/sha", 8)   → { query: "sha", start: 4 }
+ *   matchSlashTrigger("/foo bar", 8)    → null   (space ended the token)
+ *   matchSlashTrigger("a/foo", 5)       → null   (slash mid-word, not a token start)
  */
-export function matchSlashTrigger(text: string, caret: number): { query: string } | null {
+export function matchSlashTrigger(
+  text: string,
+  caret: number,
+): { query: string; start: number } | null {
   const before = text.slice(0, Math.max(0, caret));
-  const m = /^\/(\S*)$/.exec(before);
-  return m ? { query: m[1]! } : null;
+  const m = /(^|\s)\/(\S*)$/.exec(before);
+  if (!m) return null;
+  return { query: m[2]!, start: m.index + m[1]!.length };
+}
+
+/**
+ * Build the prompt after the user picks a command from the inline picker. Drops the
+ * typed `/query` token at `[start, caret)` and hoists `/name ` to the front so the
+ * command actually dispatches — Claude only runs a *leading* slash command. Any text
+ * the user wrote around the token becomes the command's argument. Returns the new
+ * text and the caret offset (just past the inserted `/name `, ready for args).
+ *
+ *   applyCommandPick("fix the bug /rev", 12, 16, "review")
+ *     → { value: "/review fix the bug", caret: 8 }
+ */
+export function applyCommandPick(
+  text: string,
+  start: number,
+  caret: number,
+  name: string,
+): { value: string; caret: number } {
+  const rest = (text.slice(0, start) + text.slice(caret)).trim();
+  const lead = `/${name} `;
+  return { value: lead + rest, caret: lead.length };
 }
 
 /**


### PR DESCRIPTION
## Problem

Slash-command recognition appeared broken on iOS: typing a command after some text (e.g. *"Die Namen … nicht gut /shaping"*) never popped the command picker. It wasn't iOS-specific — `matchSlashTrigger` triggered **only on a leading slash** (`^\/(\S*)$`), so any slash with text before it was ignored on every platform.

## Change

- **Trigger on a token boundary** — the picker now fires when `/` begins a token: at the start of the prompt **or** right after whitespace/newline. A mid-word slash (`a/foo`, `src/lib`) still does *not* trigger, so paths don't false-fire.
- **Hoist on pick** — `service.ts` passes the prompt as the argv to `claude`, which only runs a *leading* slash command. So picking a command now moves it to the front and folds the surrounding text into its argument:
  > `"Die Namen … nicht gut /shaping"` → pick → `"/shaping Die Namen … nicht gut"`

  This avoids the worse trap of "recognizing" a command that then never dispatches.
- Extracted the pick logic as a pure, unit-tested `applyCommandPick`; both inline pickers (`NewTask`, `ComposeBar`) share it.

## Verification

- `cd ui && bun run check` → 0 errors
- `cd ui && bun run test` → 204 passing (new cases: token-boundary triggers, newline, path non-trigger, `applyCommandPick` hoisting)
- Manually confirmed on an iOS device against the running app.