### PR TITLE
fix(ui): impeccable polish — input focus tokens + phantom-token fixes

### DIFF
--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -497,7 +497,7 @@
   }
   .field:focus {
     outline: none;
-    border-color: var(--color-ink);
+    border-color: var(--color-line-bright);
   }
 
   /* canned-steer row: scrolls horizontally so the presets never crowd the

--- a/ui/src/lib/components/EmojiPicker.svelte
+++ b/ui/src/lib/components/EmojiPicker.svelte
@@ -95,7 +95,7 @@
   }
   .ep-search:focus {
     outline: none;
-    border-color: var(--color-amber);
+    border-color: var(--color-line-bright);
   }
   .ep-grid {
     display: grid;

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -719,7 +719,7 @@
     color: var(--color-ink-bright);
   }
   .rv-body :global(a) {
-    color: var(--color-accent, var(--color-ink-bright));
+    color: var(--color-blue);
     text-decoration: underline;
   }
   .rv-body :global(code) {

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -545,7 +545,7 @@
   input:focus,
   select:focus {
     outline: none;
-    border-color: var(--color-amber);
+    border-color: var(--color-line-bright);
   }
   .err {
     color: var(--color-red);

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -324,7 +324,7 @@
 
   .cmd-filter:focus {
     outline: none;
-    border-color: var(--color-amber);
+    border-color: var(--color-line-bright);
   }
 
   .cmd-name {

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -172,7 +172,7 @@
 
   .rs-trigger:focus {
     outline: none;
-    border-color: var(--color-amber);
+    border-color: var(--color-line-bright);
   }
 
   .rs-trigger b {
@@ -232,7 +232,7 @@
 
   .rs-filter:focus {
     outline: none;
-    border-color: var(--color-amber);
+    border-color: var(--color-line-bright);
   }
 
   .rs-list {

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -742,7 +742,7 @@
   }
   .sc-input:focus {
     outline: none;
-    border-color: var(--color-amber);
+    border-color: var(--color-line-bright);
   }
   .sc .run {
     align-self: flex-start;

--- a/ui/src/lib/components/TodoPanel.svelte
+++ b/ui/src/lib/components/TodoPanel.svelte
@@ -286,7 +286,7 @@
   }
 
   .add-input:focus {
-    border-color: var(--color-green);
+    border-color: var(--color-line-bright);
   }
 
   .add-btn {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1650,8 +1650,8 @@
       border-color 0.12s;
   }
   .rename-btn:hover {
-    color: var(--color-fg);
-    border-color: color-mix(in srgb, var(--color-fg) 30%, transparent);
+    color: var(--color-ink);
+    border-color: color-mix(in srgb, var(--color-ink) 30%, transparent);
   }
 
   .rename-edit {
@@ -1662,9 +1662,9 @@
   }
   .rename-input {
     background: var(--color-bg);
-    border: 1px solid color-mix(in srgb, var(--color-fg) 35%, transparent);
+    border: 1px solid var(--color-line);
     border-radius: 2px;
-    color: var(--color-fg);
+    color: var(--color-ink-bright);
     font-family: var(--font-mono);
     font-size: 11px;
     padding: 2px 6px;
@@ -1673,7 +1673,7 @@
   }
   .rename-input:focus {
     outline: none;
-    border-color: var(--color-accent, var(--color-fg));
+    border-color: var(--color-line-bright);
   }
   .rename-input.err {
     border-color: var(--color-red);


### PR DESCRIPTION
`$impeccable polish` pass over the UI. The code was already well-crafted (audit landed in #198), so this is a tight, design-system-alignment pass — **CSS token references only, no logic**.

## Changes

**Input focus convention (9 inputs)**
Normalized every input `:focus` border to `--color-line-bright`, the treatment DESIGN.md actually documents. They had drifted to a mix of amber (×6), `--color-ink` (ComposeBar), and `--color-green` (TodoPanel). This restores **amber's scarcity** — reserved strictly for the action accent + "working" status per the Four-Light Rule.

**Phantom-token fixes** (found by diffing every `var(--color-*)` against the tokens defined in `app.css` — exactly two were undefined)
- **GitRail markdown links** referenced `var(--color-accent, …)` (undefined) and silently fell back to bright-ink. DESIGN.md: *"Cold Blue: links"* → now `--color-blue`. Links in PR review bodies now render in the system link color.
- **Viewport rename button + input** used `--color-fg` (undefined, **no fallback**) → broken hover brighten, input border, and input text. Aligned to conventions: faint→ink hover, `--color-line` hairline border, ink-bright editable text.

## Verification
- `bun run check` (svelte-check): 0 errors / 0 warnings
- `bun run check:i18n`: 2 locales in parity (352 keys)
- prettier `--check`: clean
- `bun run test` (vitest): 215 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)