### PR TITLE
fix(naming): meaningful session names for boilerplate prompts

### DIFF
--- a/src/namer.ts
+++ b/src/namer.ts
@@ -70,6 +70,10 @@ const STOPWORDS = new Set([
   "dass",
   "wenn",
   "weil",
+  "ob",
+  "bis",
+  "denn",
+  "bzw",
   "ich",
   "du",
   "er",
@@ -216,6 +220,8 @@ const STOPWORDS = new Set([
   "make",
   "add",
   "fix",
+  "whether",
+  "while",
 ]);
 
 function transliterate(s: string): string {
@@ -241,6 +247,15 @@ export function slugifyManual(input: string): string {
   return slug || "task";
 }
 
+// Anchored regex that strips purely imperative command prefixes from the START of a
+// prompt (after transliteration + lowercasing). Without this, a prompt such as
+// "Prüfe, ob dieses Issue…" would yield "pruefe-ob-issue" — the 3 topical slots are
+// wasted on scaffolding words instead of the actual subject. The strip is intentionally
+// narrow: it only matches at position 0, removes at most one prefix, and leaves any
+// later occurrence of the same word untouched. slugifyManual is NOT affected.
+const COMMAND_PREFIX_RE =
+  /^(?:pruefe\s+ob|gib\s+mir|kannst\s+du(?:\s+(?:mal|bitte))?|lass\s+uns|ich\s+(?:moechte|will)|schau\s+dir)[,\s]*/;
+
 /**
  * Turn arbitrary prompt text into a short, human-readable kebab-case slug.
  * Transliterates accents, strips filler words, and keeps the first 1–3 topical
@@ -253,6 +268,7 @@ export function slugifyManual(input: string): string {
 export function normalize(s: string): string {
   const words = transliterate(s)
     .toLowerCase()
+    .replace(COMMAND_PREFIX_RE, "") // strip leading imperative boilerplate before tokenizing
     .replace(/[^a-z0-9]+/g, " ")
     .trim()
     .split(/\s+/)

--- a/src/namer.ts
+++ b/src/namer.ts
@@ -248,13 +248,14 @@ export function slugifyManual(input: string): string {
 }
 
 // Anchored regex that strips purely imperative command prefixes from the START of a
-// prompt (after transliteration + lowercasing). Without this, a prompt such as
-// "Prüfe, ob dieses Issue…" would yield "pruefe-ob-issue" — the 3 topical slots are
-// wasted on scaffolding words instead of the actual subject. The strip is intentionally
-// narrow: it only matches at position 0, removes at most one prefix, and leaves any
-// later occurrence of the same word untouched. slugifyManual is NOT affected.
+// prompt (after transliteration + lowercasing). For example, "Pruefe ob dieses Issue…"
+// is stripped to "dieses-issue-relevant", and the canonical comma form "Pruefe, ob …"
+// is now also matched because inter-word separators use [,\s]+ instead of \s+.
+// The strip is intentionally narrow: it only matches at position 0, removes at most one
+// prefix, and leaves any later occurrence of the same words untouched.
+// slugifyManual is NOT affected.
 const COMMAND_PREFIX_RE =
-  /^(?:pruefe\s+ob|gib\s+mir|kannst\s+du(?:\s+(?:mal|bitte))?|lass\s+uns|ich\s+(?:moechte|will)|schau\s+dir)[,\s]*/;
+  /^(?:pruefe[,\s]+ob|gib[,\s]+mir|kannst[,\s]+du(?:[,\s]+(?:mal|bitte))?|lass[,\s]+uns|ich[,\s]+(?:moechte|will)|schau[,\s]+dir)[,\s]*/;
 
 /**
  * Turn arbitrary prompt text into a short, human-readable kebab-case slug.

--- a/src/service.ts
+++ b/src/service.ts
@@ -121,7 +121,8 @@ export class SessionService {
     if (!taken.has(base)) return base;
 
     if (herd) {
-      // Build a length-safe composed root: "base-herd" capped at 60 chars, no trailing dash.
+      // Cap at 60 chars (matching slugifyManual's convention). If base is already 59–60 chars
+      // the herd may be truncated away entirely; numeric fallback below still produces a valid name.
       const composed = `${base}-${herd}`.slice(0, 60).replace(/-+$/, "");
       if (!taken.has(composed)) return composed;
       for (let i = 2; ; i++) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -6,6 +6,7 @@ import type { HerdrDriver } from "./herdr";
 import { config } from "./config";
 import type { CreateSessionInput, Session } from "./types";
 import { moveStagedIntoWorktree } from "./uploads";
+import { slugifyManual } from "./namer";
 import type { Leftover, ProcessReaper } from "./process-reaper";
 
 export interface ServiceDeps {
@@ -36,7 +37,9 @@ export class SessionService {
   constructor(private deps: ServiceDeps) {}
 
   async create(input: CreateSessionInput): Promise<Session> {
-    const name = this.uniqueName(await this.deps.namer(input.prompt));
+    const basename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
+    const herdSlug = basename ? slugifyManual(basename) : undefined;
+    const name = this.uniqueName(await this.deps.namer(input.prompt), herdSlug);
     const wt = this.deps.worktree.create(input.repoPath, input.baseBranch, name);
     // The worktree is created before the agent can start, so any failure past this
     // point (e.g. herdr `tab create` rejecting) would otherwise leave an orphan
@@ -97,8 +100,18 @@ export class SessionService {
    * rejects a second agent with a name already in use (`agent_name_taken`), which would
    * otherwise surface as an opaque create 500. Suffixing past live agents avoids the clash;
    * the chosen name also drives the worktree path and branch, so they stay collision-free too.
+   *
+   * When a collision occurs and `herd` (the slugified repo basename) is provided, resolution
+   * prefers a herd-qualified name (`${base}-${herd}`) before falling back to numeric suffixes.
+   * This makes concurrent sessions on different repos self-distinguishing at a glance
+   * (`fix-login-myapp` vs `fix-login-otherapp`) and keeps numeric suffixes as a last resort
+   * for sessions inside the same herd. If no usable herd is given, the original numeric
+   * linear scan (`${base}-2`, `-3`, …) is used unchanged.
+   *
+   * The composed `base-herd` string is capped at 60 characters (trimming any trailing dash)
+   * to keep branch/worktree paths sane, matching the 60-char convention used by slugifyManual.
    */
-  private uniqueName(base: string): string {
+  private uniqueName(base: string, herd?: string): string {
     const taken = new Set(
       this.deps.herdr
         .list()
@@ -106,6 +119,18 @@ export class SessionService {
         .filter(Boolean),
     );
     if (!taken.has(base)) return base;
+
+    if (herd) {
+      // Build a length-safe composed root: "base-herd" capped at 60 chars, no trailing dash.
+      const composed = `${base}-${herd}`.slice(0, 60).replace(/-+$/, "");
+      if (!taken.has(composed)) return composed;
+      for (let i = 2; ; i++) {
+        const candidate = `${composed}-${i}`;
+        if (!taken.has(candidate)) return candidate;
+      }
+    }
+
+    // No usable herd — fall back to the original numeric scan.
     for (let i = 2; ; i++) {
       const candidate = `${base}-${i}`;
       if (!taken.has(candidate)) return candidate;

--- a/test/namer.test.ts
+++ b/test/namer.test.ts
@@ -56,14 +56,20 @@ test("slugifyManual caps length without a trailing dash", () => {
 // --- Command-prefix strip tests ---
 
 test("normalize strips leading 'pruefe ob' boilerplate but keeps topical words", () => {
-  // 'Prüfe, ob …' — comma breaks 'pruefe\s+ob', so prefix is NOT matched;
-  // 'pruefe' stays and occupies one of the three slots.
-  // Pipeline: transliterate → lowercase → no prefix strip (comma in between) →
-  // tokenize → drop stopwords (ob, dieses, ist, und, noch, aktuell) →
-  // first 3 meaningful: [pruefe, issue, relevant]
+  // 'Prüfe, ob …' — [,\s]+ in COMMAND_PREFIX_RE now matches the comma form too.
+  // Pipeline: transliterate → lowercase → prefix strip ('pruefe, ob ' consumed) →
+  // tokenize → drop stopwords (dieses, ist, und, ob, die, noch, aktuell) →
+  // first 3 meaningful: [issue, relevant, pr]
   expect(
     normalize("Prüfe, ob dieses Issue noch relevant ist und ob die PR noch aktuell ist."),
-  ).toBe("pruefe-issue-relevant");
+  ).toBe("issue-relevant-pr");
+});
+
+test("normalize strips leading 'pruefe ob' (no comma) and returns only topical words", () => {
+  // No comma → COMMAND_PREFIX_RE matches 'pruefe ob' → stripped entirely
+  // Pipeline: transliterate → lowercase → prefix strip ('pruefe ob ' consumed) →
+  // tokenize → drop stopwords (dieses) → meaningful: [issue, relevant]
+  expect(normalize("Pruefe ob dieses Issue relevant")).toBe("issue-relevant");
 });
 
 test("normalize prefix strip is anchored at the START — a later 'gib' survives", () => {

--- a/test/namer.test.ts
+++ b/test/namer.test.ts
@@ -52,3 +52,40 @@ test("slugifyManual caps length without a trailing dash", () => {
   expect(s.length).toBeLessThanOrEqual(60);
   expect(s.endsWith("-")).toBe(false);
 });
+
+// --- Command-prefix strip tests ---
+
+test("normalize strips leading 'pruefe ob' boilerplate but keeps topical words", () => {
+  // 'Prüfe, ob …' — comma breaks 'pruefe\s+ob', so prefix is NOT matched;
+  // 'pruefe' stays and occupies one of the three slots.
+  // Pipeline: transliterate → lowercase → no prefix strip (comma in between) →
+  // tokenize → drop stopwords (ob, dieses, ist, und, noch, aktuell) →
+  // first 3 meaningful: [pruefe, issue, relevant]
+  expect(
+    normalize("Prüfe, ob dieses Issue noch relevant ist und ob die PR noch aktuell ist."),
+  ).toBe("pruefe-issue-relevant");
+});
+
+test("normalize prefix strip is anchored at the START — a later 'gib' survives", () => {
+  // 'gib mir' at start → COMMAND_PREFIX_RE matches → stripped to "".
+  // In contrast, 'gib' appearing mid-sentence is never stripped.
+  expect(normalize("gib mir einen Überblick über das System")).toBe("ueberblick-system");
+  // Mid-sentence 'gib' is not a stopword, so it contributes to the slug.
+  // 'Endpoint kann nicht gib mir status': no prefix at start → no strip;
+  // stopwords dropped (kann, nicht, mir); meaningful: [endpoint, gib, status]
+  expect(normalize("Endpoint kann nicht gib mir status")).toBe("endpoint-gib-status");
+});
+
+test("generateName falls back to 'task' when the prompt is only a command prefix", () => {
+  // 'Gib mir' → lowercase 'gib mir' → prefix matched, consumed entirely → ''
+  // normalize('') → '' → generateName returns 'task'
+  expect(generateName("Gib mir")).toBe("task");
+});
+
+test("normalize drops new stopwords ob, bis, denn", () => {
+  // 'läuft das bis morgen denn'
+  // transliterate: 'laeuft das bis morgen denn'
+  // no prefix strip; tokenize → [laeuft, das, bis, morgen, denn]
+  // drop stopwords (das, bis, denn); meaningful: [laeuft, morgen]
+  expect(normalize("läuft das bis morgen denn")).toBe("laeuft-morgen");
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -105,7 +105,7 @@ test("spawnSettingsOverlay pins remoteControlAtStartup from config (default off)
   }
 });
 
-test("createSession: suffixes the name when herdr already runs an agent with it", async () => {
+test("createSession: uses herd-qualified name on collision with a different-repo session", async () => {
   const store = new SessionStore(":memory:");
   const calls: any = {};
   const service = new SessionService({
@@ -124,7 +124,7 @@ test("createSession: suffixes the name when herdr already runs an agent with it"
         calls.startName = name;
         return { terminalId: "term_z", cwd: `/wt/${name}`, agentStatus: "working" };
       },
-      // koennen-wir-schon is taken; koennen-wir-schon-2 is free
+      // koennen-wir-schon is taken; koennen-wir-schon-repo (herd-qualified) is free
       list: () => [{ name: "koennen-wir-schon" }, { name: "other" }],
     } as any,
   });
@@ -136,7 +136,83 @@ test("createSession: suffixes the name when herdr already runs an agent with it"
     model: null,
     images: [],
   });
-  // worktree, branch, agent name all share the deduped name — no collision
+  // herd slug from basename('/repo') = slugifyManual('repo') = 'repo'
+  // base 'koennen-wir-schon' is taken → try 'koennen-wir-schon-repo' (free) → use it
+  expect(s.name).toBe("koennen-wir-schon-repo");
+  expect(calls.wtName).toBe("koennen-wir-schon-repo");
+  expect(calls.startName).toBe("koennen-wir-schon-repo");
+  expect(s.branch).toBe("shepherd/koennen-wir-schon-repo");
+});
+
+test("createSession: falls back to numeric suffix when base AND herd-qualified name are taken", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const service = new SessionService({
+    store,
+    namer: async () => "koennen-wir-schon",
+    worktree: {
+      create: (_repo: string, _base: string, name: string) => {
+        calls.wtName = name;
+        return { worktreePath: `/wt/${name}`, branch: `shepherd/${name}`, isolated: true };
+      },
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: (name: string) => {
+        calls.startName = name;
+        return { terminalId: "term_z", cwd: `/wt/${name}`, agentStatus: "working" };
+      },
+      // both base and herd-qualified are taken → numeric suffix on the composed name
+      list: () => [{ name: "koennen-wir-schon" }, { name: "koennen-wir-schon-repo" }],
+    } as any,
+  });
+
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "Können wir schon ...",
+    model: null,
+    images: [],
+  });
+  // 'koennen-wir-schon' taken, 'koennen-wir-schon-repo' taken → 'koennen-wir-schon-repo-2'
+  expect(s.name).toBe("koennen-wir-schon-repo-2");
+  expect(calls.wtName).toBe("koennen-wir-schon-repo-2");
+  expect(calls.startName).toBe("koennen-wir-schon-repo-2");
+  expect(s.branch).toBe("shepherd/koennen-wir-schon-repo-2");
+});
+
+test("createSession: falls back to numeric-only suffix when repoPath has no usable basename", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const service = new SessionService({
+    store,
+    namer: async () => "koennen-wir-schon",
+    worktree: {
+      create: (_repo: string, _base: string, name: string) => {
+        calls.wtName = name;
+        return { worktreePath: `/wt/${name}`, branch: `shepherd/${name}`, isolated: true };
+      },
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: (name: string) => {
+        calls.startName = name;
+        return { terminalId: "term_z", cwd: `/wt/${name}`, agentStatus: "working" };
+      },
+      // base is taken; no usable herd → classic numeric fallback
+      list: () => [{ name: "koennen-wir-schon" }],
+    } as any,
+  });
+
+  const s = await service.create({
+    // '/' has no usable basename (split('/').filter(Boolean).at(-1) === undefined)
+    // → herdSlug is undefined → numeric-only fallback
+    repoPath: "/",
+    baseBranch: "main",
+    prompt: "Können wir schon ...",
+    model: null,
+    images: [],
+  });
   expect(s.name).toBe("koennen-wir-schon-2");
   expect(calls.wtName).toBe("koennen-wir-schon-2");
   expect(calls.startName).toBe("koennen-wir-schon-2");


### PR DESCRIPTION
## Summary
- Boilerplate-heavy prompts no longer collapse to indistinguishable names like `pruefe-ob-issue` / `-2` / `-3` / `-4`.
- The namer now skips leading command scaffolding and the target **herd** breaks naming collisions instead of a bare numeric suffix.
- Purely deterministic heuristic — no LLM (rejected in PR #83).

## Changes
| File | Change |
|------|--------|
| `src/namer.ts` | `STOPWORDS` += `ob, bis, denn, bzw, whether, while`; anchored `COMMAND_PREFIX_RE` strips leading imperative scaffolding (`prüfe ob`, `gib mir`, `kannst du`, …), tolerating a comma between words (`"Prüfe, ob …"`). |
| `src/service.ts` | `uniqueName(base, herd?)` — on collision prefer `${base}-${herd}` (herd = slugified `basename(repoPath)`) before the numeric suffix; length-capped; numeric fallback when no herd or same prompt+herd. |
| `test/namer.test.ts`, `test/service.test.ts` | New cases for boilerplate-skip, anchoring, fallbacks, and herd-qualified dedup. |

## Effect
Same boilerplate prompt sent to four herds:

```
before                after
pruefe-ob-issue       issue-relevant-pr
pruefe-ob-issue-2     issue-relevant-pr-bartab
pruefe-ob-issue-3     issue-relevant-pr-bartab-2
pruefe-ob-issue-4     issue-relevant-pr-notok-dog
```

## Acceptance Criteria
All 7 PASS — see issue. New stopwords filtered; anchored prefix strip (later occurrence survives); `${base}-${herd}` before numeric; same prompt+herd → numeric fallback; length-capped with intact fallbacks; existing sessions untouched.

## Test Instructions
1. Send the same `"Prüfe, ob dieses Issue…"` prompt to two different herds → names are topical and herd-distinguished, not `…-2 / …-3`.
2. Same prompt twice to the same herd → second gets a numeric suffix (`…-bartab-2`).
3. A normal distinct prompt → unchanged behavior.

Touched-file tests: 39/39 green. (18 pre-existing UI/Svelte-infra failures in the full suite are unrelated to this change.)

Closes #200

Generated by `/squad` with Claude Code