### PR TITLE
feat(namer): command-prefix strip, extra stopwords, herd-qualified collision names

### DIFF
--- a/src/namer.ts
+++ b/src/namer.ts
@@ -70,6 +70,10 @@ const STOPWORDS = new Set([
   "dass",
   "wenn",
   "weil",
+  "ob",
+  "bis",
+  "denn",
+  "bzw",
   "ich",
   "du",
   "er",
@@ -216,6 +220,8 @@ const STOPWORDS = new Set([
   "make",
   "add",
   "fix",
+  "whether",
+  "while",
   // Sentence-frame words prose leans on but that name nothing — "could you TAKE a
   // look WHERE…", "KOENNTEST du…". Always dropped; they carry no topic anywhere.
   "take",
@@ -370,6 +376,16 @@ export function slugifyManual(input: string): string {
   return slug || "task";
 }
 
+// Anchored regex that strips purely imperative command prefixes from the START of a
+// prompt (after transliteration + lowercasing). For example, "Pruefe ob dieses Issue…"
+// is stripped to "dieses-issue-relevant", and the canonical comma form "Pruefe, ob …"
+// is now also matched because inter-word separators use [,\s]+ instead of \s+.
+// The strip is intentionally narrow: it only matches at position 0, removes at most one
+// prefix, and leaves any later occurrence of the same words untouched.
+// slugifyManual is NOT affected.
+const COMMAND_PREFIX_RE =
+  /^(?:pruefe[,\s]+ob|gib[,\s]+mir|kannst[,\s]+du(?:[,\s]+(?:mal|bitte))?|lass[,\s]+uns|ich[,\s]+(?:moechte|will)|schau[,\s]+dir)[,\s]*/;
+
 /**
  * Turn arbitrary prompt text into a short, human-readable kebab-case slug.
  * Transliterates accents, drops stopwords, then selects by *specificity* rather
@@ -385,6 +401,7 @@ export function slugifyManual(input: string): string {
 export function normalize(s: string): string {
   const words = transliterate(s)
     .toLowerCase()
+    .replace(COMMAND_PREFIX_RE, "") // strip leading imperative boilerplate before tokenizing
     .replace(/[^a-z0-9]+/g, " ")
     .trim()
     .split(/\s+/)

--- a/src/service.ts
+++ b/src/service.ts
@@ -6,6 +6,7 @@ import type { HerdrDriver } from "./herdr";
 import { config } from "./config";
 import type { CreateSessionInput, Session } from "./types";
 import { moveStagedIntoWorktree } from "./uploads";
+import { slugifyManual } from "./namer";
 import type { Leftover, ProcessReaper } from "./process-reaper";
 
 export interface ServiceDeps {
@@ -36,7 +37,9 @@ export class SessionService {
   constructor(private deps: ServiceDeps) {}
 
   async create(input: CreateSessionInput): Promise<Session> {
-    const name = this.uniqueName(await this.deps.namer(input.prompt));
+    const basename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
+    const herdSlug = basename ? slugifyManual(basename) : undefined;
+    const name = this.uniqueName(await this.deps.namer(input.prompt), herdSlug);
     const wt = this.deps.worktree.create(input.repoPath, input.baseBranch, name);
     // The worktree is created before the agent can start, so any failure past this
     // point (e.g. herdr `tab create` rejecting) would otherwise leave an orphan
@@ -97,8 +100,18 @@ export class SessionService {
    * rejects a second agent with a name already in use (`agent_name_taken`), which would
    * otherwise surface as an opaque create 500. Suffixing past live agents avoids the clash;
    * the chosen name also drives the worktree path and branch, so they stay collision-free too.
+   *
+   * When a collision occurs and `herd` (the slugified repo basename) is provided, resolution
+   * prefers a herd-qualified name (`${base}-${herd}`) before falling back to numeric suffixes.
+   * This makes concurrent sessions on different repos self-distinguishing at a glance
+   * (`fix-login-myapp` vs `fix-login-otherapp`) and keeps numeric suffixes as a last resort
+   * for sessions inside the same herd. If no usable herd is given, the original numeric
+   * linear scan (`${base}-2`, `-3`, …) is used unchanged.
+   *
+   * The composed `base-herd` string is capped at 60 characters (trimming any trailing dash)
+   * to keep branch/worktree paths sane, matching the 60-char convention used by slugifyManual.
    */
-  private uniqueName(base: string): string {
+  private uniqueName(base: string, herd?: string): string {
     const taken = new Set(
       this.deps.herdr
         .list()
@@ -106,6 +119,19 @@ export class SessionService {
         .filter(Boolean),
     );
     if (!taken.has(base)) return base;
+
+    if (herd) {
+      // Cap at 60 chars (matching slugifyManual's convention). If base is already 59–60 chars
+      // the herd may be truncated away entirely; numeric fallback below still produces a valid name.
+      const composed = `${base}-${herd}`.slice(0, 60).replace(/-+$/, "");
+      if (!taken.has(composed)) return composed;
+      for (let i = 2; ; i++) {
+        const candidate = `${composed}-${i}`;
+        if (!taken.has(candidate)) return candidate;
+      }
+    }
+
+    // No usable herd — fall back to the original numeric scan.
     for (let i = 2; ; i++) {
       const candidate = `${base}-${i}`;
       if (!taken.has(candidate)) return candidate;

--- a/test/namer.test.ts
+++ b/test/namer.test.ts
@@ -83,3 +83,46 @@ test("slugifyManual caps length without a trailing dash", () => {
   expect(s.length).toBeLessThanOrEqual(60);
   expect(s.endsWith("-")).toBe(false);
 });
+
+// --- Command-prefix strip tests ---
+
+test("normalize strips leading 'pruefe ob' boilerplate but keeps topical words", () => {
+  // 'Prüfe, ob …' — [,\s]+ in COMMAND_PREFIX_RE now matches the comma form too.
+  // Pipeline: transliterate → lowercase → prefix strip ('pruefe, ob ' consumed) →
+  // tokenize → drop stopwords (dieses, ist, und, ob, die, noch) →
+  // meaningful: [issue, relevant, pr, aktuell]; #201's 4-word cap keeps all four.
+  expect(
+    normalize("Prüfe, ob dieses Issue noch relevant ist und ob die PR noch aktuell ist."),
+  ).toBe("issue-relevant-pr-aktuell");
+});
+
+test("normalize strips leading 'pruefe ob' (no comma) and returns only topical words", () => {
+  // No comma → COMMAND_PREFIX_RE matches 'pruefe ob' → stripped entirely
+  // Pipeline: transliterate → lowercase → prefix strip ('pruefe ob ' consumed) →
+  // tokenize → drop stopwords (dieses) → meaningful: [issue, relevant]
+  expect(normalize("Pruefe ob dieses Issue relevant")).toBe("issue-relevant");
+});
+
+test("normalize prefix strip is anchored at the START — a later 'gib' survives", () => {
+  // 'gib mir' at start → COMMAND_PREFIX_RE matches → stripped to "".
+  // In contrast, 'gib' appearing mid-sentence is never stripped.
+  expect(normalize("gib mir einen Überblick über das System")).toBe("ueberblick-system");
+  // Mid-sentence 'gib' is not a stopword, so it contributes to the slug.
+  // 'Endpoint kann nicht gib mir status': no prefix at start → no strip;
+  // stopwords dropped (kann, nicht, mir); meaningful: [endpoint, gib, status]
+  expect(normalize("Endpoint kann nicht gib mir status")).toBe("endpoint-gib-status");
+});
+
+test("generateName falls back to 'task' when the prompt is only a command prefix", () => {
+  // 'Gib mir' → lowercase 'gib mir' → prefix matched, consumed entirely → ''
+  // normalize('') → '' → generateName returns 'task'
+  expect(generateName("Gib mir")).toBe("task");
+});
+
+test("normalize drops new stopwords ob, bis, denn", () => {
+  // 'läuft das bis morgen denn'
+  // transliterate: 'laeuft das bis morgen denn'
+  // no prefix strip; tokenize → [laeuft, das, bis, morgen, denn]
+  // drop stopwords (das, bis, denn); meaningful: [laeuft, morgen]
+  expect(normalize("läuft das bis morgen denn")).toBe("laeuft-morgen");
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -105,7 +105,7 @@ test("spawnSettingsOverlay pins remoteControlAtStartup from config (default off)
   }
 });
 
-test("createSession: suffixes the name when herdr already runs an agent with it", async () => {
+test("createSession: uses herd-qualified name on collision with a different-repo session", async () => {
   const store = new SessionStore(":memory:");
   const calls: any = {};
   const service = new SessionService({
@@ -124,7 +124,7 @@ test("createSession: suffixes the name when herdr already runs an agent with it"
         calls.startName = name;
         return { terminalId: "term_z", cwd: `/wt/${name}`, agentStatus: "working" };
       },
-      // koennen-wir-schon is taken; koennen-wir-schon-2 is free
+      // koennen-wir-schon is taken; koennen-wir-schon-repo (herd-qualified) is free
       list: () => [{ name: "koennen-wir-schon" }, { name: "other" }],
     } as any,
   });
@@ -136,7 +136,83 @@ test("createSession: suffixes the name when herdr already runs an agent with it"
     model: null,
     images: [],
   });
-  // worktree, branch, agent name all share the deduped name — no collision
+  // herd slug from basename('/repo') = slugifyManual('repo') = 'repo'
+  // base 'koennen-wir-schon' is taken → try 'koennen-wir-schon-repo' (free) → use it
+  expect(s.name).toBe("koennen-wir-schon-repo");
+  expect(calls.wtName).toBe("koennen-wir-schon-repo");
+  expect(calls.startName).toBe("koennen-wir-schon-repo");
+  expect(s.branch).toBe("shepherd/koennen-wir-schon-repo");
+});
+
+test("createSession: falls back to numeric suffix when base AND herd-qualified name are taken", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const service = new SessionService({
+    store,
+    namer: async () => "koennen-wir-schon",
+    worktree: {
+      create: (_repo: string, _base: string, name: string) => {
+        calls.wtName = name;
+        return { worktreePath: `/wt/${name}`, branch: `shepherd/${name}`, isolated: true };
+      },
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: (name: string) => {
+        calls.startName = name;
+        return { terminalId: "term_z", cwd: `/wt/${name}`, agentStatus: "working" };
+      },
+      // both base and herd-qualified are taken → numeric suffix on the composed name
+      list: () => [{ name: "koennen-wir-schon" }, { name: "koennen-wir-schon-repo" }],
+    } as any,
+  });
+
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "Können wir schon ...",
+    model: null,
+    images: [],
+  });
+  // 'koennen-wir-schon' taken, 'koennen-wir-schon-repo' taken → 'koennen-wir-schon-repo-2'
+  expect(s.name).toBe("koennen-wir-schon-repo-2");
+  expect(calls.wtName).toBe("koennen-wir-schon-repo-2");
+  expect(calls.startName).toBe("koennen-wir-schon-repo-2");
+  expect(s.branch).toBe("shepherd/koennen-wir-schon-repo-2");
+});
+
+test("createSession: falls back to numeric-only suffix when repoPath has no usable basename", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const service = new SessionService({
+    store,
+    namer: async () => "koennen-wir-schon",
+    worktree: {
+      create: (_repo: string, _base: string, name: string) => {
+        calls.wtName = name;
+        return { worktreePath: `/wt/${name}`, branch: `shepherd/${name}`, isolated: true };
+      },
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: (name: string) => {
+        calls.startName = name;
+        return { terminalId: "term_z", cwd: `/wt/${name}`, agentStatus: "working" };
+      },
+      // base is taken; no usable herd → classic numeric fallback
+      list: () => [{ name: "koennen-wir-schon" }],
+    } as any,
+  });
+
+  const s = await service.create({
+    // '/' has no usable basename (split('/').filter(Boolean).at(-1) === undefined)
+    // → herdSlug is undefined → numeric-only fallback
+    repoPath: "/",
+    baseBranch: "main",
+    prompt: "Können wir schon ...",
+    model: null,
+    images: [],
+  });
   expect(s.name).toBe("koennen-wir-schon-2");
   expect(calls.wtName).toBe("koennen-wir-schon-2");
   expect(calls.startName).toBe("koennen-wir-schon-2");


### PR DESCRIPTION
## Summary

Derives the three meaningful additions from **#208** that survive **#201** (merged), rebased cleanly onto current `main`. #208 was `CONFLICTING` purely because #201's `namer.ts` rewrite collided with the same hunks — none of the conflicts were semantic. This branch is cut fresh from `main` so it's linear and conflict-free.

#201 changed *which surviving words win* (specificity over position). These three are orthogonal and #201 never touched them:

| Addition | File | Overlap with #201 |
|---|---|---|
| Stopwords `ob, bis, denn, bzw, whether, while` | `namer.ts` | None — all 6 absent on main |
| `COMMAND_PREFIX_RE` — strips leading imperative scaffolding (`prüfe ob`, `gib mir`, `kannst du`, `lass uns`, `ich möchte/will`, `schau dir`) before tokenizing | `namer.ts` | None — #201's specificity pass can't strip `gib`/`mir` (not stopwords) |
| Herd-qualified collision naming — `uniqueName(base, herd?)` prefers `\${base}-\${herd}` over `\${base}-2` | `service.ts` | Zero — #201 never opened `service.ts` |

## Effect

- `"Prüfe, ob dieses Issue…"` → `issue-relevant-pr-aktuell` instead of leaking `pruefe`/`ob` into the name.
- Concurrent sessions across repos self-distinguish: `fix-login-myapp` vs `fix-login-otherapp` instead of `fix-login` / `fix-login-2`. Numeric suffix stays as last resort within one herd.

## Notes vs. #208

- `COMMAND_PREFIX_RE` slots between `.toLowerCase()` and the non-alphanumeric replace in #201's rewritten `normalize()` — prefix strip runs before tokenization, composing orthogonally with #201's COMMON-tier logic.
- One ported namer expectation updated for #201's 3→4 word cap: `issue-relevant-pr` → `issue-relevant-pr-aktuell` (`aktuell` isn't a stopword, so the 4th slot now keeps it).

## Tests

Ported #208's 5 namer + 3 service tests. Root suite **570 pass / 0 fail**, lint + `tsc` clean.

Closes #200
Supersedes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)