### PR TITLE
refactor(ui): rename "PR running" group to "CI running"

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -103,7 +103,7 @@
   "herd_all_hint": "▦ Alle",
   "herd_ready_filter": "▤ Bereit",
   "herd_ready_empty": "Nichts wartet. Alle sind beschäftigt",
-  "herd_pr_running_group": "PR läuft ({count})",
+  "herd_ci_running_group": "CI läuft ({count})",
   "herd_reviewer_running_group": "Review läuft ({count})",
   "herd_ready_group": "Bereit zum Mergen ({count})",
   "herd_merged_group": "Gemergt ({count})",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -103,7 +103,7 @@
   "herd_all_hint": "▦ All",
   "herd_ready_filter": "▤ Ready",
   "herd_ready_empty": "Nothing waiting. All hands working",
-  "herd_pr_running_group": "PR running ({count})",
+  "herd_ci_running_group": "CI running ({count})",
   "herd_reviewer_running_group": "Reviewing ({count})",
   "herd_ready_group": "Ready to merge ({count})",
   "herd_merged_group": "Merged ({count})",

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -80,11 +80,11 @@
           {ondecommission}
         />
       {/each}
-      {#if partition.prRunning.length > 0}
-        <div class="pr-head micro">
-          {m.herd_pr_running_group({ count: partition.prRunning.length })}
+      {#if partition.ciRunning.length > 0}
+        <div class="ci-head micro">
+          {m.herd_ci_running_group({ count: partition.ciRunning.length })}
         </div>
-        {#each partition.prRunning as session (session.id)}
+        {#each partition.ciRunning as session (session.id)}
           <UnitRow
             {session}
             selected={session.id === selectedId}
@@ -213,7 +213,7 @@
 
   /* amber section headers for the in-flight stages (PR CI running, critic
      reviewing) — amber mirrors the CI-pending dot and the critic badge */
-  .pr-head,
+  .ci-head,
   .reviewing-head {
     display: flex;
     align-items: center;

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -78,21 +78,21 @@ test("all-active yields empty ready and merged groups", () => {
   expect(merged).toHaveLength(0);
 });
 
-test("open PR with pending CI lands in the prRunning group", () => {
+test("open PR with pending CI lands in the ciRunning group", () => {
   const list = [session("a"), session("p1"), session("b")];
-  const { active, prRunning } = partitionSessions(list, { p1: git("open", "pending") });
+  const { active, ciRunning } = partitionSessions(list, { p1: git("open", "pending") });
   expect(active.map((s) => s.id)).toEqual(["a", "b"]);
-  expect(prRunning.map((s) => s.id)).toEqual(["p1"]);
+  expect(ciRunning.map((s) => s.id)).toEqual(["p1"]);
 });
 
 test("open PR with non-pending CI stays active", () => {
   const list = [session("s"), session("n")];
-  const { active, prRunning } = partitionSessions(list, {
+  const { active, ciRunning } = partitionSessions(list, {
     s: git("open", "success"),
     n: git("open", "none"),
   });
   expect(active.map((s) => s.id)).toEqual(["s", "n"]);
-  expect(prRunning).toHaveLength(0);
+  expect(ciRunning).toHaveLength(0);
 });
 
 test("a session under review lands in the reviewerRunning group", () => {
@@ -104,36 +104,36 @@ test("a session under review lands in the reviewerRunning group", () => {
 
 test("reviewing wins over pending CI when both apply", () => {
   const list = [session("x")];
-  const { prRunning, reviewerRunning } = partitionSessions(
+  const { ciRunning, reviewerRunning } = partitionSessions(
     list,
     { x: git("open", "pending") },
     () => true,
   );
-  expect(prRunning).toHaveLength(0);
+  expect(ciRunning).toHaveLength(0);
   expect(reviewerRunning.map((s) => s.id)).toEqual(["x"]);
 });
 
 test("merged and ready win over reviewing and pending CI", () => {
   const list = [session("m"), session("r", true)];
-  const { ready, merged, prRunning, reviewerRunning } = partitionSessions(
+  const { ready, merged, ciRunning, reviewerRunning } = partitionSessions(
     list,
     { m: git("merged", "pending"), r: git("open", "pending") },
     () => true,
   );
   expect(merged.map((s) => s.id)).toEqual(["m"]);
   expect(ready.map((s) => s.id)).toEqual(["r"]);
-  expect(prRunning).toHaveLength(0);
+  expect(ciRunning).toHaveLength(0);
   expect(reviewerRunning).toHaveLength(0);
 });
 
 test("preserves input order within the new stage groups", () => {
   const list = [session("p1"), session("v1"), session("p2"), session("v2")];
-  const { prRunning, reviewerRunning } = partitionSessions(
+  const { ciRunning, reviewerRunning } = partitionSessions(
     list,
     { p1: git("open", "pending"), p2: git("open", "pending") },
     (id) => id.startsWith("v"),
   );
-  expect(prRunning.map((s) => s.id)).toEqual(["p1", "p2"]);
+  expect(ciRunning.map((s) => s.id)).toEqual(["p1", "p2"]);
   expect(reviewerRunning.map((s) => s.id)).toEqual(["v1", "v2"]);
 });
 

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -2,14 +2,14 @@ import type { Session, GitState } from "$lib/types";
 
 /** Split sessions into stage groups, preserving input order within each:
  *  - active: still in play, no later stage reached
- *  - prRunning: open PR with CI checks in flight (`open` + `pending`)
+ *  - ciRunning: open PR with CI checks in flight (`open` + `pending`)
  *  - reviewerRunning: a critic run is in flight for the session
  *  - ready: operator-parked "ready to merge"
  *  - merged: PR already landed
  *
- *  First-match precedence (terminal states win; reviewing beats PR-running as the
- *  later lifecycle stage): merged > ready > reviewerRunning > prRunning > active.
- *  The groups render top→bottom as active → prRunning → reviewerRunning → ready →
+ *  First-match precedence (terminal states win; reviewing beats CI-running as the
+ *  later lifecycle stage): merged > ready > reviewerRunning > ciRunning > active.
+ *  The groups render top→bottom as active → ciRunning → reviewerRunning → ready →
  *  merged, mirroring the session lifecycle. `isReviewing` is injected so this stays
  *  a pure function (the caller wires it to the reviews store). */
 export function partitionSessions(
@@ -18,13 +18,13 @@ export function partitionSessions(
   isReviewing: (id: string) => boolean = () => false,
 ): {
   active: Session[];
-  prRunning: Session[];
+  ciRunning: Session[];
   reviewerRunning: Session[];
   ready: Session[];
   merged: Session[];
 } {
   const active: Session[] = [];
-  const prRunning: Session[] = [];
+  const ciRunning: Session[] = [];
   const reviewerRunning: Session[] = [];
   const ready: Session[] = [];
   const merged: Session[] = [];
@@ -33,8 +33,8 @@ export function partitionSessions(
     if (g?.state === "merged") merged.push(s);
     else if (s.readyToMerge) ready.push(s);
     else if (isReviewing(s.id)) reviewerRunning.push(s);
-    else if (g?.state === "open" && g.checks === "pending") prRunning.push(s);
+    else if (g?.state === "open" && g.checks === "pending") ciRunning.push(s);
     else active.push(s);
   }
-  return { active, prRunning, reviewerRunning, ready, merged };
+  return { active, ciRunning, reviewerRunning, ready, merged };
 }


### PR DESCRIPTION
Renames the session-list **"PR running"** stage group to **"CI running"**. The group holds open-PR sessions with CI checks in flight (`open` + `pending`), so "CI running" describes what's actually happening.

## Changes
- `herd-partition.ts` — `prRunning` → `ciRunning` (field, locals, return, doc comment)
- `Herd.svelte` — `partition.ciRunning`, `m.herd_ci_running_group`, `.pr-head` → `.ci-head`
- `en.json` / `de.json` — key `herd_pr_running_group` → `herd_ci_running_group`; "PR running" → "CI running" / "CI läuft"
- `herd-partition.test.ts` — updated destructuring + test name

## Verification
- `bun run check` — 0 errors
- `bun run check:i18n` — 2 locales in parity (352 keys)
- `bun run test` — 215 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)