### PR TITLE
fix(ui): retune blocked-header wash for light theme

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -67,6 +67,12 @@
   --status-done: var(--color-slate);
   --status-blocked: var(--color-red);
   --status-idle: var(--color-slate);
+
+  /* Header wash for an alert-by-exception (blocked / parked) session. On the
+     near-black ground a 24% red→head blend lands as a deep oxblood bezel that
+     reads as alarm; the same recipe is re-tuned for light below. */
+  --wash-blocked: color-mix(in srgb, var(--color-red) 24%, var(--color-head));
+  --wash-done: color-mix(in srgb, var(--color-slate) 24%, var(--color-head));
 }
 
 /* ── Light ────────────────────────────────────────────────────────────────────
@@ -100,6 +106,14 @@
 
   --scrim: rgba(20, 28, 25, 0.42);
   --term-fg: #2b3633;
+
+  /* sRGB-blending a midtone red toward near-white muddies into a dusty pink
+     that reads as consumer-chat softness, not an operator alarm. Hand-tune the
+     blocked wash in OKLCH instead: a clean, lightly-saturated alert rose, hue
+     aligned to --red (~23), the daylight sibling of the dark oxblood. Parked
+     (slate, near-neutral) blends cleanly enough to keep the srgb recipe. */
+  --wash-blocked: oklch(0.86 0.065 23);
+  --wash-done: color-mix(in srgb, var(--color-slate) 24%, var(--color-head));
 }
 
 html,

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -151,6 +151,11 @@
       ? STATUS_COLOR[session.status]
       : null,
   );
+  // The header background uses a per-theme wash token (--wash-blocked / -done)
+  // rather than mixing the status colour inline: a 24% red→head srgb blend that
+  // reads as a deep alarm bezel on the dark ground muddies into a dusty pink in
+  // light, so the light theme retunes the blocked wash in OKLCH (see app.css).
+  const tintWash = $derived(tintColor ? `var(--wash-${session.status})` : null);
   // Non-hue partner to the tint: a leading shape mark so blocked (!) vs done (✓)
   // never rests on colour alone (WCAG 1.4.1) — mirrors the StatusPip glyphs. Same
   // blocked/done-on-phone gate as the tint.
@@ -884,9 +889,7 @@
     class:mobile={compact}
     class:phone={mobile}
     class:working={working && !tintColor}
-    style:background={tintColor
-      ? `color-mix(in srgb, ${tintColor} 24%, var(--color-head))`
-      : undefined}
+    style:background={tintWash ?? undefined}
   >
     {#if onback}
       <button class="back" type="button" onclick={onback} aria-label={m.viewport_back_aria()}


### PR DESCRIPTION
## Problem

The blocked-session task header (mobile) tinted its background with one srgb recipe for both themes: `color-mix(in srgb, var(--red) 24%, var(--head))`. On the near-black dark ground that yields a rich oxblood alarm bezel, but in light mode it blends `#c2363b` into the near-white green-grey head and lands as a **muddy dusty-pink** — reads as consumer-chat softness (an explicit anti-reference), not an operator alarm.

Root cause: sRGB gamma-blending a midtone red toward near-white always muddies into that chalky-flesh zone. A single recipe can't serve both themes.

## Fix

Split the header tint into per-theme tokens:

- **`app.css`** — new `--wash-blocked` / `--wash-done`. Dark keeps the **exact** current srgb recipe (byte-identical, no regression). Light retunes blocked in OKLCH: `oklch(0.86 0.065 23)` — a clean, lightly-saturated alert rose, hue-aligned to `--red`, the daylight sibling of the dark oxblood. Parked/`done` (slate, near-neutral) blends cleanly so it keeps the srgb recipe.
- **`Viewport.svelte`** — header background reads `var(--wash-{status})` instead of mixing inline; the red `!` glyph still uses the full status color.

Value chosen by rendering six candidates against the real palettes and comparing in a browser; `0.86 0.065 23` beat the paler (candy) and more-salmon (loud) options.

Only light mode changes; dark renders identically. Affects only the mobile task header (the sole place the wash applies).

## Verification

- `bun run check` → 0 errors, 0 warnings
- `prettier --check` + eslint (lint-staged) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)