### PR TITLE
feat(controlbar): add Space key to mobile control bar

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -42,6 +42,7 @@
   "theme_system": "System",
   "controlkey_escape": "Escape",
   "controlkey_tab": "Tab",
+  "controlkey_space": "Leertaste",
   "controlkey_enter": "Enter, absenden",
   "controlkey_arrow_left": "Pfeil links",
   "controlkey_arrow_right": "Pfeil rechts",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -42,6 +42,7 @@
   "theme_system": "System",
   "controlkey_escape": "Escape",
   "controlkey_tab": "Tab",
+  "controlkey_space": "Space",
   "controlkey_enter": "Enter, submit",
   "controlkey_arrow_left": "Arrow left",
   "controlkey_arrow_right": "Arrow right",

--- a/ui/src/lib/controlKeys.test.ts
+++ b/ui/src/lib/controlKeys.test.ts
@@ -7,6 +7,7 @@ import { controlKeys, enterKey } from "./controlKeys";
 const EXPECTED: Record<string, string> = {
   Esc: "\x1b",
   Tab: "\x09",
+  "␣": " ",
   "←": "\x1b[D",
   "→": "\x1b[C",
   "↑": "\x1b[A",

--- a/ui/src/lib/controlKeys.ts
+++ b/ui/src/lib/controlKeys.ts
@@ -28,6 +28,7 @@ export function controlKeys(): ControlKey[] {
   return [
     { label: "Esc", aria: m.controlkey_escape(), seq: "\x1b", group: "edit", tone: "escape" },
     { label: "Tab", aria: m.controlkey_tab(), seq: "\x09", group: "edit" },
+    { label: "␣", aria: m.controlkey_space(), seq: " ", group: "edit" },
     { label: "←", aria: m.controlkey_arrow_left(), seq: "\x1b[D", group: "nav" },
     { label: "→", aria: m.controlkey_arrow_right(), seq: "\x1b[C", group: "nav" },
     { label: "↑", aria: m.controlkey_arrow_up(), seq: "\x1b[A", group: "nav" },


### PR DESCRIPTION
## What

Adds a **Space** key (`␣`) to the mobile control bar, alongside Esc/Tab in the frozen "edit" cluster. Sends a literal space byte (`0x20`) to the PTY.

## Why

On a touch device there's no hardware keyboard to steer with. Space is a common terminal key — pagers (`less`/`man`) page down on it, TUI dialogs toggle on it — and was previously unreachable from the control bar.

## How

- New entry in `controlKeys()` (`group: "edit"`), so it renders in the left frozen cluster with Esc/Tab.
- i18n aria label `controlkey_space` added to both EN ("Space") and DE ("Leertaste") — catalog parity gate green.
- Extended the `controlKeys` seq-guard test (`␣ → " "`).

## Checks

- `bun run test controlKeys` ✓ (5 passed)
- `bun run check` ✓ (0 errors)
- `bun run check:i18n` ✓ (374 keys, 2 locales in parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)