### PR TITLE
feat(ui): keyboard shortcuts for New Task (n) and Backlog (b)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -55,6 +55,7 @@
   "controlkey_ctrl_d": "Strg D, Dateiende",
   "actionbar_new_task": "+ Neue Aufgabe",
   "actionbar_backlog": "Backlog",
+  "actionbar_shortcut_hint": "Kürzel: {key}",
   "actionbar_all_mode": "Alle ▦",
   "actionbar_focus_mode": "Fokus ⌖",
   "actionbar_theme_group_aria": "Darstellung",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -55,6 +55,7 @@
   "controlkey_ctrl_d": "Ctrl D, end of file",
   "actionbar_new_task": "+ New Task",
   "actionbar_backlog": "Backlog",
+  "actionbar_shortcut_hint": "Shortcut: {key}",
   "actionbar_all_mode": "All ▦",
   "actionbar_focus_mode": "Focus ⌖",
   "actionbar_theme_group_aria": "Theme",

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -31,9 +31,23 @@
 
 {#if !(desktopOnly && mobile)}
   <div class="actions" class:mobile>
-    <button class="btn primary" type="button" onclick={onnew}>{m.actionbar_new_task()}</button>
+    <button
+      class="btn primary"
+      class:tip={!mobile}
+      type="button"
+      onclick={onnew}
+      data-tip={!mobile ? m.actionbar_shortcut_hint({ key: "N" }) : undefined}
+      aria-keyshortcuts={!mobile ? "n" : undefined}>{m.actionbar_new_task()}</button
+    >
     {#if onbacklog}
-      <button class="btn backlog" type="button" onclick={onbacklog}>{m.actionbar_backlog()}</button>
+      <button
+        class="btn backlog"
+        class:tip={!mobile}
+        type="button"
+        onclick={onbacklog}
+        data-tip={!mobile ? m.actionbar_shortcut_hint({ key: "B" }) : undefined}
+        aria-keyshortcuts={!mobile ? "b" : undefined}>{m.actionbar_backlog()}</button
+      >
     {/if}
     {#if !mobile}
       <button
@@ -227,5 +241,43 @@
   .actions.mobile .btn.backlog {
     padding: 12px 16px;
     font-size: 12px;
+  }
+
+  /* Desktop-only hover tooltip surfacing the keyboard shortcut. Mirrors the
+     TopBar .tip styling, but opens ABOVE the button since the ActionBar sits at
+     the bottom edge (a tooltip below would clip off-screen). Never shown on
+     touch/mobile, where the shortcut doesn't apply. */
+  @media (hover: hover) and (pointer: fine) {
+    .tip {
+      position: relative;
+    }
+    .tip::after {
+      content: attr(data-tip);
+      position: absolute;
+      bottom: calc(100% + 9px);
+      left: 0;
+      white-space: nowrap;
+      background: linear-gradient(180deg, var(--color-panel), var(--color-panel-2));
+      border: 1px solid var(--color-line-bright);
+      box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
+      color: var(--color-ink-bright);
+      font-size: 10.5px;
+      letter-spacing: 0.06em;
+      text-transform: none;
+      padding: 5px 9px;
+      border-radius: 2px;
+      pointer-events: none;
+      opacity: 0;
+      transform: translateY(3px);
+      transition:
+        opacity 0.12s ease,
+        transform 0.12s ease;
+      z-index: 50;
+    }
+    .tip:hover::after,
+    .tip:focus-visible::after {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
 </style>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -187,6 +187,48 @@
     if (mobile.current) mobileScreen = "detail";
   }
 
+  // true when focus sits in something that consumes typing — a form field or the
+  // PTY terminal (xterm holds focus in a hidden <textarea>, so the TEXTAREA check
+  // covers it). Single-key shortcuts must stay silent there so they never eat a
+  // keystroke the user meant for the terminal or an input.
+  function isTyping(el: EventTarget | null): boolean {
+    if (!(el instanceof HTMLElement)) return false;
+    const tag = el.tagName;
+    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable;
+  }
+
+  // Global single-key shortcuts (no modifier → zero browser/terminal conflict,
+  // works on every platform). Desktop only, and suppressed while typing or while
+  // any modal/overlay is open so a stray "n"/"b" can't stack dialogs.
+  function onShortcut(e: KeyboardEvent) {
+    if (mobile.current) return;
+    if (e.metaKey || e.ctrlKey || e.altKey || e.repeat || e.isComposing) return;
+    if (isTyping(e.target)) return;
+    if (
+      showNew ||
+      showSettings ||
+      showBacklog ||
+      showBroadcast ||
+      showTriage ||
+      showUpdate ||
+      showHerdrUpdate
+    )
+      return;
+    switch (e.key.toLowerCase()) {
+      case "n":
+        e.preventDefault();
+        showNew = true;
+        break;
+      case "b":
+        // mirror the ActionBar gate: backlog only exists once there are sessions
+        if (store.sessions.length > 0) {
+          e.preventDefault();
+          showBacklog = true;
+        }
+        break;
+    }
+  }
+
   // sessions waiting on the operator other than the one on screen — gates the
   // header "needs you" jump and tells the operator how many remain.
   const otherNeedsYou = $derived(blockedEntries.filter((e) => e.session.id !== selectedId));
@@ -411,6 +453,8 @@
     if (deployPollTimer) clearTimeout(deployPollTimer);
   }
 </script>
+
+<svelte:window onkeydown={onShortcut} />
 
 <div class="shell" class:mobile={mobile.current}>
   <!-- On a phone in the terminal-focus screen the top bar is subsumed by the


### PR DESCRIPTION
## Was

Desktop-Mode hatte keine Tastatur-Möglichkeit, die Top-Level-Aktionen zu öffnen. Dieser PR fügt globale Shortcuts hinzu:

| Taste | Aktion |
|-------|--------|
| `n` | Neue Aufgabe |
| `b` | Backlog (nur wenn Sessions existieren — spiegelt die Button-Bedingung) |

## Warum Einzeltasten (kein Cmd/Ctrl)

Plattformübergreifend browser-sicher. Blanke Buchstaben werden von Browsern nie belegt (anders als `Ctrl/Cmd+N` = neues Fenster, `+J` = Downloads, `+L/K` = Adressleiste) und kollidieren nicht mit den Terminal-Signalen (`Ctrl+C/A/E/D`), die der `Viewport`-PTY durchreicht. Das ist das Muster von GitHub/Linear/Notion.

## Guards

Der `keydown`-Handler in `+page.svelte` ignoriert die Tasten, wenn:
- der Fokus in einem Eingabefeld liegt — **inkl. Terminal** (xterm hält den Fokus in einem versteckten `<textarea>`, von der `TEXTAREA`-Prüfung mit abgedeckt → eine ins Terminal getippte „n" wird nie geschluckt),
- ein Modifier (`Cmd/Ctrl/Alt`) gedrückt ist, der Key repeatet oder eine IME-Komposition läuft,
- bereits ein Modal/Overlay offen ist (kein Dialog-Stacking),
- mobiles Layout aktiv ist (desktop-only).

## Tooltips

Beide ActionBar-Buttons zeigen beim Hover das Kürzel an (`Shortcut: N` / DE `Kürzel: B`). Optik 1:1 vom bestehenden `.tip`/`data-tip`-Muster der TopBar, nur oberhalb positioniert (ActionBar sitzt unten). Nur auf Hover/Pointer-Geräten sichtbar; auf Touch/Mobile per Media-Query ausgeblendet. Zusätzlich `aria-keyshortcuts` für Screenreader.

## i18n

Neuer Key `actionbar_shortcut_hint` in EN + DE.

## Checks

- `bun run check` → 0 Fehler/Warnungen
- `bun run check:i18n` → 2 Locales in Parität
- Prettier → clean