### PR TITLE
feat(ui): WCAG high-contrast toggle in footer theme controls

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -57,6 +57,7 @@
   "actionbar_focus_mode": "Fokus ⌖",
   "actionbar_theme_group_aria": "Darstellung",
   "actionbar_theme_option": "{label}-Design",
+  "actionbar_contrast_toggle": "Hoher Kontrast (bessere Lesbarkeit)",
   "actionbar_commit_title": "commit {sha}",
   "actionbar_repo_link": "{repo} auf GitHub",
   "lang_switcher_aria": "Sprache",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -57,6 +57,7 @@
   "actionbar_focus_mode": "Focus ⌖",
   "actionbar_theme_group_aria": "Theme",
   "actionbar_theme_option": "{label} theme",
+  "actionbar_contrast_toggle": "High contrast (better readability)",
   "actionbar_commit_title": "commit {sha}",
   "actionbar_repo_link": "{repo} on GitHub",
   "lang_switcher_aria": "Language",

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -116,6 +116,44 @@
   --wash-done: color-mix(in srgb, var(--color-slate) 24%, var(--color-head));
 }
 
+/* ── High contrast (WCAG / "Brillenträger") ──────────────────────────────────
+   An accessibility *layer* toggled independently of dark/light (data-contrast),
+   so it composes with whichever theme is resolved. It overrides only the
+   low-contrast tokens — secondary/muted text, the faint hairlines, the dim
+   status accents — pushing them toward the foreground so every pair clears WCAG
+   AAA. Body text (--ink) is already AAA; this rescues the greys (--muted/
+   --faint), the near-invisible --line hairlines, and the muted slate/amber.
+
+   Both blocks are scoped to [data-theme][data-contrast] (specificity 0,2,0) so
+   they beat the base :root / [data-theme="light"] blocks (0,1,0) regardless of
+   source order — the theme JS always sets data-theme to the resolved value. */
+[data-theme="dark"][data-contrast="high"] {
+  --line: #3a4744;
+  --line-bright: #586a64;
+
+  --ink: #eef4f0;
+  --ink-bright: #ffffff;
+  --muted: #d6e0db;
+  --faint: #9fb0aa;
+
+  --amber: #ffc266;
+  --slate: #8a9893;
+  --term-fg: #eef4f0;
+}
+[data-theme="light"][data-contrast="high"] {
+  --line: #9aa8a2;
+  --line-bright: #7c8b85;
+
+  --ink: #161d1b;
+  --ink-bright: #000000;
+  --muted: #2f3b37;
+  --faint: #4d5a55;
+
+  --amber: #7a4a00;
+  --slate: #3c4946;
+  --term-fg: #161d1b;
+}
+
 html,
 body {
   background:

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -25,6 +25,8 @@
             pref === "dark" ||
             (pref !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
           document.documentElement.dataset.theme = dark ? "dark" : "light";
+          if (localStorage.getItem("shepherd:contrast") === "high")
+            document.documentElement.dataset.contrast = "high";
         } catch (e) {
           document.documentElement.dataset.theme = "dark";
         }

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -4,10 +4,12 @@
   import LanguageSwitcher from "$lib/components/LanguageSwitcher.svelte";
   import { REPO, REPO_URL, sha, version, commitUrl } from "$lib/build-info";
 
-  const THEMES: { pref: ThemePref; glyph: string; label: () => string }[] = [
+  // Two explicit theme choices; "system" stays the implicit default (followed on
+  // first load + on OS changes until the operator picks one). The old third slot
+  // (◐ system) is repurposed as the standalone high-contrast / WCAG toggle below.
+  const THEMES: { pref: Exclude<ThemePref, "system">; glyph: string; label: () => string }[] = [
     { pref: "dark", glyph: "☾", label: m.theme_dark },
     { pref: "light", glyph: "☀", label: m.theme_light },
-    { pref: "system", glyph: "◐", label: m.theme_system },
   ];
 
   let {
@@ -78,14 +80,23 @@
             <button
               type="button"
               class="t-opt"
-              class:on={theme.pref === t.pref}
-              aria-pressed={theme.pref === t.pref}
+              class:on={theme.resolved === t.pref}
+              aria-pressed={theme.resolved === t.pref}
               title={m.actionbar_theme_option({ label: t.label() })}
               aria-label={m.actionbar_theme_option({ label: t.label() })}
               onclick={() => theme.setPref(t.pref)}>{t.glyph}</button
             >
           {/each}
         </div>
+        <button
+          type="button"
+          class="contrast-toggle"
+          class:on={theme.contrast}
+          aria-pressed={theme.contrast}
+          title={m.actionbar_contrast_toggle()}
+          aria-label={m.actionbar_contrast_toggle()}
+          onclick={() => theme.toggleContrast()}>◐</button
+        >
         <LanguageSwitcher />
       </div>
     {/if}
@@ -183,6 +194,26 @@
   .t-opt.on {
     color: var(--color-amber);
     background: var(--color-inset);
+  }
+  /* High-contrast (WCAG) toggle — standalone so screen readers don't read it as
+     part of the theme radio group; styled to match the .t-opt seg buttons. */
+  .contrast-toggle {
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-size: 13px;
+    line-height: 1;
+    padding: 4px 8px;
+    cursor: pointer;
+  }
+  .contrast-toggle:hover {
+    color: var(--color-ink-bright);
+  }
+  .contrast-toggle.on {
+    color: var(--color-amber);
+    background: var(--color-inset);
+    border-color: var(--color-amber);
   }
   .actions.mobile {
     padding: 10px;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -757,10 +757,11 @@
   // repaint the live terminal when the active theme changes (no recreation)
   $effect(() => {
     const resolved = theme.resolved;
+    const highContrast = theme.contrast;
     const term = termRef;
     if (!term) return;
     term.options.theme = xtermTheme(resolved);
-    term.options.minimumContrastRatio = xtermMinContrast(resolved);
+    term.options.minimumContrastRatio = xtermMinContrast(resolved, highContrast);
     term.refresh(0, Math.max(0, term.rows - 1));
   });
 

--- a/ui/src/lib/theme.svelte.ts
+++ b/ui/src/lib/theme.svelte.ts
@@ -8,6 +8,7 @@ export type ThemePref = "dark" | "light" | "system";
 export type Resolved = "dark" | "light";
 
 const STORAGE_KEY = "shepherd:theme";
+const CONTRAST_KEY = "shepherd:contrast";
 const DARK_QUERY = "(prefers-color-scheme: dark)";
 
 function readPref(): ThemePref {
@@ -20,6 +21,15 @@ function readPref(): ThemePref {
   return "system";
 }
 
+function readContrast(): boolean {
+  try {
+    return localStorage.getItem(CONTRAST_KEY) === "high";
+  } catch {
+    /* localStorage unavailable (SSR / privacy mode) */
+    return false;
+  }
+}
+
 function systemPrefersDark(): boolean {
   return typeof matchMedia !== "undefined" ? matchMedia(DARK_QUERY).matches : true;
 }
@@ -27,6 +37,11 @@ function systemPrefersDark(): boolean {
 class ThemeController {
   pref = $state<ThemePref>(readPref());
   systemDark = $state<boolean>(systemPrefersDark());
+
+  // High-contrast (WCAG / "Brillenträger") is a separate accessibility *layer*,
+  // not a theme: it composes on top of whichever dark/light theme is resolved,
+  // strengthening the low-contrast greys/hairlines via [data-contrast="high"].
+  contrast = $state<boolean>(readContrast());
 
   resolved = $derived<Resolved>(
     this.pref === "system" ? (this.systemDark ? "dark" : "light") : this.pref,
@@ -48,9 +63,27 @@ class ThemeController {
     this.setPref(this.pref === "dark" ? "light" : this.pref === "light" ? "system" : "dark");
   }
 
+  /** Persist + apply the high-contrast layer (independent of dark/light). */
+  setContrast(on: boolean) {
+    this.contrast = on;
+    try {
+      localStorage.setItem(CONTRAST_KEY, on ? "high" : "off");
+    } catch {
+      /* ignore — preference just won't survive reload */
+    }
+    this.#apply();
+  }
+
+  toggleContrast() {
+    this.setContrast(!this.contrast);
+  }
+
   #apply() {
     if (typeof document !== "undefined") {
-      document.documentElement.dataset.theme = this.resolved;
+      const root = document.documentElement;
+      root.dataset.theme = this.resolved;
+      if (this.contrast) root.dataset.contrast = "high";
+      else delete root.dataset.contrast;
     }
   }
 
@@ -104,7 +137,12 @@ export function xtermTheme(resolved: Resolved): { background: string; foreground
  *
  * Dark mode is already legible — `1` disables enforcement (xterm's no-op fast
  * path), so this never touches the dark palette.
+ *
+ * When the high-contrast layer is on, the floor jumps to `7` in *both* themes so
+ * the terminal's dim secondary lines are lifted to ~3.5:1 even on the dark
+ * palette — matching the WCAG boost the app chrome gets via [data-contrast].
  */
-export function xtermMinContrast(resolved: Resolved): number {
+export function xtermMinContrast(resolved: Resolved, highContrast = theme.contrast): number {
+  if (highContrast) return 7;
   return resolved === "light" ? 7 : 1;
 }


### PR DESCRIPTION
## Was

Der dritte Footer-Button (◐) war bisher **System** — er übernahm nur die OS-Einstellung, also „passierte nichts", wenn das OS bereits dunkel war. Das hat verwirrt.

Umgebaut zu dem, was eigentlich gemeint war: ein **WCAG-Hochkontrast-Schalter für bessere Lesbarkeit (Brillenträger)**.

## Verhalten

- **System bleibt der implizite Default** — beim Laden wird die OS-Einstellung gewählt und Theme-Wechsel des OS werden weiter verfolgt, bis der Operator explizit wählt.
- Damit reichen **2 Theme-Buttons** (☾ Dark / ☀ Light); der freigewordene dritte Slot (◐) wird zum **Hochkontrast-Toggle**.
- Hochkontrast ist ein **Layer, kein Theme**: er legt sich über das aufgelöste Dark/Light-Theme (`data-contrast="high"`) und hebt nur die kontrastschwachen Tokens an — `muted`/`faint`-Grautöne, Hairlines, gedämpfte Status-Akzente — bis WCAG AAA erreicht ist. Der xterm-Terminalboden wird in beiden Themes auf 7 angehoben, solange der Layer aktiv ist.
- Präferenz ist **persistent** (`shepherd:contrast`) und wird **vor First Paint** im Inline-Skript in `app.html` angewandt (kein Flash).

## Geändert

| Datei | Änderung |
|-------|----------|
| `theme.svelte.ts` | unabhängiger `contrast`-State + Persistenz + xterm-Kontrastanhebung |
| `app.html` | Pre-paint-Apply (kein Flash) |
| `app.css` | Hochkontrast-Token-Layer (dark + light) |
| `ActionBar.svelte` | 2 Theme-Buttons (Highlight nach `resolved`) + ◐-Toggle |
| `Viewport.svelte` | Terminal-Repaint bei Kontrast-Wechsel |
| `messages/{en,de}.json` | i18n-Key `actionbar_contrast_toggle` |

## Checks

- `bun run check` → 0 Fehler / 0 Warnungen
- `check:i18n` → EN/DE in Parität (374 Keys)
- pre-push hygiene/i18n grün

## Offen / Follow-up

Toggle ist aktuell nur in der **Desktop-ActionBar**. Mobile (TopBar/Settings) hat ihn noch nicht — separat nachziehbar, falls gewünscht.