### PR TITLE
feat(backlog): push live counts over WS so overview never goes stale

### DIFF
--- a/src/backlog-poller.ts
+++ b/src/backlog-poller.ts
@@ -26,11 +26,20 @@ export class BacklogPoller {
     private resolveForge: (repoPath: string) => unknown | null,
     private warm: (repoPath: string) => Promise<RepoCounts>,
     private intervalMs = 45_000,
+    /**
+     * Fired once per tick after every repo's counts are warm. Lets the caller
+     * push the freshly-warmed overview to clients (a `backlog:update` WS frame)
+     * so a long-open dashboard stays live instead of showing a fetch-once
+     * snapshot. Best-effort: a throwing hook is swallowed so the broadcast can
+     * never sink the warm cadence.
+     */
+    private onWarmed?: () => void | Promise<void>,
   ) {}
 
   async tick(): Promise<void> {
     const forgeRepos = this.listRepos().filter((r) => this.isForgeBacked(r.path));
     await Promise.all(forgeRepos.map((r) => this.warm(r.path).catch(() => null)));
+    if (this.onWarmed) await Promise.resolve(this.onWarmed()).catch(() => null);
   }
 
   private isForgeBacked(path: string): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { StatusPoller } from "./poller";
 import { PrPoller } from "./pr-poller";
 import { reconcile } from "./reconcile";
 import { reapOrphanTabs } from "./tab-reaper";
-import { serve } from "./server";
+import { serve, buildBacklogPayload } from "./server";
 import { detectForge } from "./forge";
 import { AccountUsageIndex } from "./usage";
 import { UsageLimitsService } from "./usage-limits";
@@ -239,10 +239,26 @@ const backlog = new CountsService(config.forges, ghRunnerAsync);
 // keep the backlog counts cache warm so the overview's first paint is instant
 // instead of blocking on per-repo gh/Gitea calls. Warm shortly after boot, then
 // on a cadence below the cache's 60s TTL so the request path always hits warm.
+// After each warm, push the freshly-built overview to every connected client so
+// a long-open dashboard's issue/PR counts stay live instead of frozen at the
+// fetch-once snapshot the page loaded with. `counts` reads the just-warmed cache
+// (no extra gh round-trip), so this is the same payload GET /api/backlog returns.
+const broadcastBacklog = async () =>
+  events.emit(
+    "backlog:update",
+    await buildBacklogPayload({
+      counts: (p) => backlog.counts(p),
+      resolveForge,
+      lastUsedByRepo: () => store.lastUsedByRepo(),
+      repoRoot: config.repoRoot,
+    }),
+  );
 const backlogPoller = new BacklogPoller(
   () => listRepos(config.repoRoot),
   resolveForge,
   (dir) => backlog.refresh(dir),
+  45_000,
+  broadcastBacklog,
 );
 setTimeout(() => void backlogPoller.tick(), 3_000);
 backlogPoller.start();

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,7 +34,7 @@ import type { PrCache } from "./pr-poller";
 import type { PushService } from "./push";
 import type { Presence } from "./presence";
 import type { StatusPoller } from "./poller";
-import type { CountsService } from "./backlog";
+import type { CountsService, RepoCounts } from "./backlog";
 import { join, normalize } from "node:path";
 import { homedir } from "node:os";
 import type { ServerWebSocket } from "bun";
@@ -1014,18 +1014,52 @@ async function handlePrMerge({ req, parts, deps }: Ctx): Promise<Response | null
   }
 }
 
-async function handleBacklog({ req, parts, deps }: Ctx): Promise<Response | null> {
-  if (req.method !== "GET" || parts[0] !== "api" || parts[1] !== "backlog" || parts[2]) return null;
-  if (!deps.backlog) {
-    return json({ pinnedPath: null, projects: [], totals: { openIssues: 0, openPRs: 0 } });
-  }
-  const repos = listRepos(config.repoRoot);
-  const lastUsed = deps.store.lastUsedByRepo();
+/** Per-repo row in the backlog overview. */
+export interface BacklogProject {
+  path: string;
+  display: string;
+  slug: string | null;
+  kind: string;
+  lastUsedAt: number | null;
+  openIssues: number | null;
+  openPRs: number | null;
+}
+export interface BacklogPayload {
+  pinnedPath: string | null;
+  projects: BacklogProject[];
+  totals: { openIssues: number; openPRs: number };
+}
+
+/** What an empty/unconfigured backlog looks like — also the no-forge fast path. */
+const EMPTY_BACKLOG: BacklogPayload = {
+  pinnedPath: null,
+  projects: [],
+  totals: { openIssues: 0, openPRs: 0 },
+};
+
+/** Inputs for {@link buildBacklogPayload} — kept narrow so both the request path
+ *  (AppDeps) and the background poller (index.ts locals) can supply them. */
+export interface BacklogPayloadInputs {
+  counts: (repoDir: string) => Promise<RepoCounts>;
+  resolveForge: (repoDir: string) => GitForge | null;
+  lastUsedByRepo: () => Record<string, number>;
+  repoRoot: string;
+}
+
+/**
+ * Build the backlog overview payload: forge-backed repos under `repoRoot`,
+ * deduped by forge slug, with open issue/PR counts, a pinned project, and
+ * totals. Shared by GET /api/backlog and the poller's `backlog:update`
+ * broadcast so both emit byte-identical snapshots.
+ */
+export async function buildBacklogPayload(inputs: BacklogPayloadInputs): Promise<BacklogPayload> {
+  const repos = listRepos(inputs.repoRoot);
+  const lastUsed = inputs.lastUsedByRepo();
 
   // Keep only forge-backed repos
   const forgeRepos = repos
     .map((r) => {
-      const forge = deps.resolveForge?.(r.path) ?? null;
+      const forge = inputs.resolveForge(r.path);
       return forge ? { ...r, forge } : null;
     })
     .filter((r): r is NonNullable<typeof r> => r !== null);
@@ -1034,9 +1068,9 @@ async function handleBacklog({ req, parts, deps }: Ctx): Promise<Response | null
   const uniqueRepos = dedupeReposByForge(forgeRepos, lastUsed);
 
   // Fetch counts for the deduped repos in parallel
-  const countsArr = await Promise.all(uniqueRepos.map((r) => deps.backlog!.counts(r.path)));
+  const countsArr = await Promise.all(uniqueRepos.map((r) => inputs.counts(r.path)));
 
-  const projects = uniqueRepos.map((r, i) => {
+  const projects: BacklogProject[] = uniqueRepos.map((r, i) => {
     const counts = countsArr[i]!;
     return {
       path: r.path,
@@ -1081,7 +1115,21 @@ async function handleBacklog({ req, parts, deps }: Ctx): Promise<Response | null
     if (p.openPRs !== null) totalPRs += p.openPRs;
   }
 
-  return json({ pinnedPath, projects, totals: { openIssues: totalIssues, openPRs: totalPRs } });
+  return { pinnedPath, projects, totals: { openIssues: totalIssues, openPRs: totalPRs } };
+}
+
+async function handleBacklog({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (req.method !== "GET" || parts[0] !== "api" || parts[1] !== "backlog" || parts[2]) return null;
+  if (!deps.backlog) return json(EMPTY_BACKLOG);
+  const backlog = deps.backlog;
+  return json(
+    await buildBacklogPayload({
+      counts: (p) => backlog.counts(p),
+      resolveForge: (p) => deps.resolveForge?.(p) ?? null,
+      lastUsedByRepo: () => deps.store.lastUsedByRepo(),
+      repoRoot: config.repoRoot,
+    }),
+  );
 }
 
 function todoRead(repoParam: string): Response {

--- a/test/backlog-poller.test.ts
+++ b/test/backlog-poller.test.ts
@@ -73,6 +73,42 @@ test("empty repo list is a no-op", async () => {
   expect(calls).toBe(0);
 });
 
+test("calls onWarmed once after warming completes each tick", async () => {
+  const order: string[] = [];
+  const poller = new BacklogPoller(
+    () => [{ path: "/a" }, { path: "/b" }],
+    () => ({ kind: "github", slug: "o/r" }),
+    async (p) => {
+      order.push(`warm:${p}`);
+      return { openIssues: 1, openPRs: 0 };
+    },
+    60_000,
+    async () => {
+      order.push("warmed");
+    },
+  );
+
+  await poller.tick();
+
+  // both warms happen before the single broadcast hook
+  expect(order).toEqual(["warm:/a", "warm:/b", "warmed"]);
+});
+
+test("a throwing onWarmed does not sink the tick", async () => {
+  const poller = new BacklogPoller(
+    () => [{ path: "/a" }],
+    () => ({ kind: "github", slug: "o/r" }),
+    async () => ({ openIssues: 1, openPRs: 0 }),
+    60_000,
+    async () => {
+      throw new Error("broadcast boom");
+    },
+  );
+
+  await poller.tick(); // must resolve, not reject
+  expect(true).toBe(true);
+});
+
 test("start/stop manage the interval timer without throwing", () => {
   const poller = new BacklogPoller(
     () => [],

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "vitest";
 import { HerdStore } from "./store.svelte";
-import type { GitState, Session } from "./types";
+import type { BacklogPayload, GitState, Session } from "./types";
 
 const GIT: GitState = {
   kind: "github",
@@ -54,6 +54,29 @@ test("session:ready patches the target session's readyToMerge", () => {
   expect(s.byId("s2")?.readyToMerge).toBe(false);
   s.apply({ event: "session:ready", data: { id: "s1", ready: false } });
   expect(s.byId("s1")?.readyToMerge).toBe(false);
+});
+
+test("backlog:update replaces the backlog snapshot so the overview stays live", () => {
+  const s = new HerdStore();
+  expect(s.backlog).toBeNull();
+
+  const stale: BacklogPayload = {
+    pinnedPath: "/r",
+    projects: [],
+    totals: { openIssues: 2, openPRs: 0 },
+  };
+  s.apply({ event: "backlog:update", data: stale });
+  expect(s.backlog?.totals.openIssues).toBe(2);
+
+  // a later push (server poller warmed fresher counts) overwrites the snapshot
+  const fresh: BacklogPayload = {
+    pinnedPath: "/r",
+    projects: [],
+    totals: { openIssues: 4, openPRs: 1 },
+  };
+  s.apply({ event: "backlog:update", data: fresh });
+  expect(s.backlog?.totals.openIssues).toBe(4);
+  expect(s.backlog?.totals.openPRs).toBe(1);
 });
 
 test("session:archived drops the git entry", () => {

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -5,6 +5,8 @@ import type {
   UpdateStatus,
   HerdrUpdateStatus,
   GitState,
+  BacklogPayload,
+  BlockReason,
 } from "./types";
 import type { BlockState } from "./triage";
 import { projectIcons } from "./projectIcons.svelte";
@@ -20,6 +22,12 @@ export class HerdStore {
   herdrUpdate = $state<HerdrUpdateStatus | null>(null);
   herdrUpdateLog = $state<string[]>([]);
   git = $state<Record<string, GitState>>({});
+  /** Live backlog overview, pushed over the WS by the server's warm poller
+   *  (`backlog:update`, ~every 45s). Stays null until the first push arrives —
+   *  the page's instant first paint comes from a separate one-shot GET
+   *  /api/backlog into page-local state, not from here; each push thereafter
+   *  keeps the open dashboard live. */
+  backlog = $state<BacklogPayload | null>(null);
   /** true once the user has confirmed an update; cleared by the reload it triggers */
   updating = $state(false);
   /** SHA we booted on; a different `current` after an update means a fresh build is live */
@@ -61,6 +69,17 @@ export class HerdStore {
     this.update = u;
   }
 
+  /** Set or clear a session's block (null reason clears). Extracted from apply()
+   *  to keep that dispatch switch under the complexity gate. */
+  private setBlock(id: string, reason: BlockReason | null) {
+    if (!reason) {
+      this.blocks = dropKey(this.blocks, id);
+      return;
+    }
+    const prev = this.blocks[id];
+    this.blocks = { ...this.blocks, [id]: { reason, since: prev?.since ?? Date.now() } };
+  }
+
   apply(ev: WsEvent) {
     switch (ev.event) {
       case "session:new":
@@ -90,18 +109,9 @@ export class HerdStore {
       case "session:git":
         this.git = { ...this.git, [ev.data.id]: ev.data.git };
         break;
-      case "session:block": {
-        if (!ev.data.block) {
-          this.blocks = dropKey(this.blocks, ev.data.id);
-          break;
-        }
-        const prev = this.blocks[ev.data.id];
-        this.blocks = {
-          ...this.blocks,
-          [ev.data.id]: { reason: ev.data.block, since: prev?.since ?? Date.now() },
-        };
+      case "session:block":
+        this.setBlock(ev.data.id, ev.data.block);
         break;
-      }
       case "usage:limits":
         this.usageLimits = ev.data;
         break;
@@ -125,6 +135,9 @@ export class HerdStore {
         break;
       case "learnings:update":
         learnings.apply(ev.data);
+        break;
+      case "backlog:update":
+        this.backlog = ev.data;
         break;
     }
   }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -242,7 +242,8 @@ export type WsEvent =
   | { event: "project-icons:update"; data: ProjectIcons }
   | { event: "session:review"; data: { id: string; review: ReviewVerdict | null } }
   | { event: "session:reviewing"; data: { id: string; reviewing: boolean } }
-  | { event: "learnings:update"; data: { pending: number } };
+  | { event: "learnings:update"; data: { pending: number } }
+  | { event: "backlog:update"; data: BacklogPayload };
 
 export interface CreateInput {
   repoPath: string;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -119,6 +119,12 @@
         });
     }
   });
+  // The fetch above is a one-shot for fast first paint; the server's warm poller
+  // then pushes a backlog:update over the WS every ~45s. Mirror each push so a
+  // long-open dashboard's counts stay live instead of frozen at load time.
+  $effect(() => {
+    if (store.backlog) backlog = store.backlog;
+  });
 
   function onissue(repoPath: string, issue: Issue) {
     composeRepoPath = repoPath;


### PR DESCRIPTION
## Problem

The backlog overview showed a **stale open-issue count** (e.g. `2`) long after new issues were opened. Verified the **server was never stale** — `/api/backlog` returns the correct count live, kept warm by the 45s `BacklogPoller`.

The staleness was **purely client-side**: sessions stream live over the `/events` WebSocket, but the **backlog counts did not ride that channel and had no client polling**. The UI fetched `/api/backlog` once into `$state` and the tab badge read that frozen snapshot. On a mission-control dashboard left open all day, the counts never moved.

## Fix — push counts over the existing WS

Reuse the warm poller (it already computes fresh counts every tick):

- **`src/server.ts`** — extract the `/api/backlog` payload logic into exported `buildBacklogPayload()` so the HTTP route and the broadcast emit identical snapshots.
- **`src/backlog-poller.ts`** — best-effort `onWarmed` hook fired after each warm tick (a throwing hook can't sink the cadence).
- **`src/index.ts`** — wire `onWarmed` → `events.emit("backlog:update", payload)` (first push ~3s after boot, then every 45s).
- **client** (`types.ts`, `store.svelte.ts`, `+page.svelte`) — `backlog:update` event, `store.backlog` state, and a one-line effect mirroring each push into the view. Initial fetch stays for instant first paint; pushes keep it live thereafter.

An open dashboard now self-heals within ~45s of any issue/PR change — no reopen, no reload.

Also extracted the `session:block` case in `store.apply()` into a `setBlock()` helper to keep the dispatch switch under the complexity gate after adding the new case.

## Tests

- `backlog-poller`: `onWarmed` fires once after warming; a throwing hook doesn't sink the tick.
- `store`: `backlog:update` replaces the snapshot (stale → fresh).
- `buildBacklogPayload` regression-covered by existing `/api/backlog` route tests.

All gates green: root `tsc`/`eslint`/`bun test` (637 pass), UI `check` (incl. i18n parity) + `vitest` (221 pass), Fallow audit.

No new user-facing strings → no i18n catalog changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)