### PR TITLE
fix(topbar): collapse Learnings badge to icon+count on mobile

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -146,11 +146,16 @@
     {#if learnings > 0}
       <button
         class="learnings-badge"
+        class:compact={mobile}
         onclick={() => onlearnings?.()}
         aria-label={m.learnings_open_aria({ count: learnings })}
       >
-        {m.learnings_title()}
-        {learnings}
+        {#if mobile}
+          <span class="lr-icon" aria-hidden="true">✦</span><span class="lr-n">{learnings}</span>
+        {:else}
+          {m.learnings_title()}
+          {learnings}
+        {/if}
       </button>
     {/if}
     {#if touch}
@@ -657,6 +662,25 @@
     line-height: 1;
   }
   .needsyou.compact .ny-n {
+    font-weight: 600;
+  }
+  /* Phone: same collapse for the LEARNINGS badge — icon+count chip so it fits
+     on line 1 instead of widening the right-side controls into a second row.
+     Full label stays as the aria-label. */
+  .learnings-badge.compact {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    min-width: 44px;
+    padding: 8px 10px;
+    letter-spacing: 0;
+    font-variant-numeric: tabular-nums;
+  }
+  .learnings-badge.compact .lr-icon {
+    line-height: 1;
+  }
+  .learnings-badge.compact .lr-n {
     font-weight: 600;
   }
   .hud.mobile .update-badge {

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -697,6 +697,7 @@
     .needsyou,
     .needsyou.compact,
     .learnings-badge,
+    .learnings-badge.compact,
     .gauge-btn,
     .update-badge {
       min-height: 44px;


### PR DESCRIPTION
## Problem
On mobile, the **Learnings** badge rendered its full label + count (`Learnings 3` / DE `Erkenntnisse 3`). Being that wide, it pushed the right-side controls (gauge, clock, gear) onto a second row. The neighbouring **Needs-you** badge already collapses to a compact icon+count chip on mobile — Learnings didn't.

## Fix
Mirror the established `needsyou.compact` pattern for `learnings-badge`:
- On `mobile`: render `✦` glyph + count instead of the full label.
- Full label preserved as the `aria-label` (no i18n key changes).
- Added matching `.learnings-badge.compact` chip styles.

## Verification
- `bun run check` → 0 errors / 0 warnings
- `bun run check:i18n` → 2 locales in parity (410 keys)
- prettier + eslint clean (lint-staged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)