### PR TITLE
fix(gitignore): stop ignoring docs/superpowers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,7 @@ dist/
 *.db-wal
 .DS_Store
 
-# Planning docs / brainstorm artifacts — not part of the shipped app
-/docs/superpowers/
+# Superpowers tool state (planning docs in /docs/superpowers/ ARE tracked)
 .superpowers/
 
 # Transient agent worktrees (Claude Code isolation checkouts)


### PR DESCRIPTION
## Problem

`.gitignore` had `/docs/superpowers/`, but 19 planning docs (plans + specs) in that directory are **already tracked**. The rule meant any *new* plan or spec created there was silently dropped from `git status` — easy to lose work.

## Fix

Remove the `/docs/superpowers/` ignore rule. New docs in that dir are now tracked like the existing 19.

`.superpowers/` (superpowers tool state, not docs) stays ignored.

## Verify

```
$ git check-ignore -v docs/superpowers/plans/NEW-FILE-TEST.md; echo $?
1   # no longer ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)