### PR TITLE
fix(viewport): show jump-to-bottom when the agent owns the scroll

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -107,15 +107,17 @@
   // recreating it (recreating would tear down the PTY socket)
   let termRef = $state<Terminal | undefined>();
   // true when the user has scrolled up away from the latest output → show a
-  // jump-to-bottom affordance bottom-right of the terminal. Two regimes:
-  //  • normal buffer (plain shell / classic Claude): xterm owns the scrollback,
-  //    so we read its viewport offset directly.
-  //  • alternate screen (Claude's fullscreen TUI): Claude owns the scroll and
-  //    xterm's viewport never moves, so we can't read a position. We approximate
-  //    it with a wheel/gesture accumulator (scrollDepth) and jump back with the
-  //    app's own Ctrl+End shortcut instead of moving xterm.
+  // jump-to-bottom affordance bottom-right of the terminal. Two regimes
+  // (see `agentOwnsScroll`):
+  //  • xterm owns the scrollback (plain shell, mouse-tracking off): read its
+  //    viewport offset directly.
+  //  • the agent owns the scroll (alternate screen, or mouse-tracking on the
+  //    normal buffer like Claude Code): it grabs the wheel and repaints its own
+  //    scrolled view, so xterm's viewport never moves and we can't read a
+  //    position. We approximate it with a wheel/gesture accumulator (scrollDepth)
+  //    and jump back with the app's own Ctrl+End shortcut instead of moving xterm.
   let scrolledUp = $state(false);
-  // px-ish accumulator of net upward scrolling while on the alternate screen;
+  // px-ish accumulator of net upward scrolling while the agent owns the scroll;
   // plain (non-reactive) — only `scrolledUp` drives the UI. Reset on re-attach,
   // buffer switch, and a jump-to-bottom.
   let scrollDepth = 0;
@@ -360,12 +362,22 @@
     conn?.takeover();
   }
 
+  // The agent owns the scroll whenever it drives a full-screen view and pins
+  // xterm's viewport at the bottom: either the alternate screen (classic TUI) or
+  // mouse-tracking on the normal buffer. Claude Code does the latter — it stays
+  // on the normal buffer (keeping scrollback) but grabs the wheel and repaints
+  // its own scrolled view, so xterm's viewport never moves. In both regimes we
+  // can't read a scroll position from xterm; we lean on the gesture accumulator
+  // (scrollDepth) and jump back with the app's own shortcut instead.
+  const agentOwnsScroll = (term: Terminal): boolean =>
+    term.buffer.active.type === "alternate" || term.modes.mouseTrackingMode !== "none";
+
   function scrollToBottom() {
     const term = termRef;
     if (!term) return;
-    if (term.buffer.active.type === "alternate") {
-      // Claude's fullscreen TUI owns the scroll; xterm can't move it. Ctrl+End is
-      // its documented "jump to latest + re-enable auto-follow" shortcut and is
+    if (agentOwnsScroll(term)) {
+      // The agent owns the scroll; xterm can't move it. Ctrl+End is Claude's
+      // documented "jump to latest + re-enable auto-follow" shortcut and is
       // never interpreted as prompt text.
       conn?.send("\x1b[1;5F");
     } else {
@@ -637,12 +649,13 @@
     };
     el.addEventListener("paste", onPaste, true);
 
-    // Claude Code runs as a full-screen TUI on the alternate screen (no
-    // scrollback) with mouse tracking on: scrolling means sending wheel input
-    // to the app, which is what the mouse wheel does on desktop. Touch emits no
-    // wheel events, so translate one-finger drags into wheel events on xterm's
-    // screen — xterm then forwards them per the active mode (to the app when
-    // mouse-tracking, otherwise its own scrollback). Matches desktop in both.
+    // Claude Code runs as a full-screen TUI with mouse tracking on (it stays on
+    // the normal buffer, keeping scrollback, but grabs the wheel): scrolling
+    // means sending wheel input to the app, which is what the mouse wheel does on
+    // desktop. Touch emits no wheel events, so translate one-finger drags into
+    // wheel events on xterm's screen — xterm then forwards them per the active
+    // mode (to the app when mouse-tracking, otherwise its own scrollback).
+    // Matches desktop in both.
     let lastY: number | null = null;
     const onTouchStart = (e: TouchEvent) => {
       if (e.touches.length !== 1) return;
@@ -655,9 +668,10 @@
       const dy = lastY - y; // drag down → wheel up (reveal older), natural scroll
       lastY = y;
       if (Math.abs(dy) > 2) dragged = true;
-      // on the alternate screen xterm's viewport never moves (onScroll won't fire),
-      // so track the gesture directly: dy<0 = scrolling up → grow the depth.
-      if (term.buffer.active.type === "alternate") {
+      // when the agent owns the scroll xterm's viewport never moves (onScroll
+      // won't fire), so track the gesture directly: dy<0 = scrolling up → grow
+      // the depth.
+      if (agentOwnsScroll(term)) {
         scrollDepth = Math.max(0, scrollDepth - dy);
       }
       recomputeScrolled();
@@ -689,15 +703,15 @@
     });
     ro.observe(el);
 
-    // track scroll position so we can offer a jump-to-bottom button. The normal
-    // buffer carries scrollback → read xterm's viewport offset. The alternate
-    // screen (Claude's fullscreen TUI) has no xterm scrollback and forwards wheel
-    // input to the app, so xterm's viewport never moves; there we lean on the
-    // wheel accumulator instead.
+    // track scroll position so we can offer a jump-to-bottom button. When the
+    // agent owns the scroll (alternate screen, or mouse-tracking on the normal
+    // buffer like Claude Code) it forwards wheel input to the app and xterm's
+    // viewport never moves, so we lean on the gesture accumulator. Otherwise the
+    // normal buffer carries scrollback → read xterm's viewport offset directly.
     const SCROLL_UP_PX = 30; // small swipe / one wheel notch before the button shows
     const recomputeScrolled = () => {
       const b = term.buffer.active;
-      scrolledUp = b.type === "normal" ? b.baseY - b.viewportY > 0 : scrollDepth > SCROLL_UP_PX;
+      scrolledUp = agentOwnsScroll(term) ? scrollDepth > SCROLL_UP_PX : b.baseY - b.viewportY > 0;
     };
     const scrollSub = term.onScroll(recomputeScrolled);
     const bufSub = term.buffer.onBufferChange(() => {
@@ -722,12 +736,13 @@
     };
     const renderSub = term.onRender(scanNotesAffordance);
 
-    // desktop wheel observer for the alternate screen, where onScroll never fires.
-    // Touch is tracked directly in onTouchMove, so ignore the synthetic wheels it
-    // dispatches (isTrusted=false) to avoid double-counting; only real wheels here.
-    // deltaY<0 = scrolling up (reveal older) → grow depth; >0 = toward latest.
+    // desktop wheel observer for when the agent owns the scroll, where onScroll
+    // never fires. Touch is tracked directly in onTouchMove, so ignore the
+    // synthetic wheels it dispatches (isTrusted=false) to avoid double-counting;
+    // only real wheels here. deltaY<0 = scrolling up (reveal older) → grow depth;
+    // >0 = toward latest.
     const onWheelTrack = (e: WheelEvent) => {
-      if (!e.isTrusted || term.buffer.active.type !== "alternate") return;
+      if (!e.isTrusted || !agentOwnsScroll(term)) return;
       scrollDepth = Math.max(0, scrollDepth - e.deltaY);
       recomputeScrolled();
     };


### PR DESCRIPTION
## Problem

The terminal's "jump to latest" button (↓, bottom-right) never appears in Claude Code sessions on mobile (and desktop). Scroll up into the middle of the transcript and there's no affordance to get back to the bottom.

## Root cause

The scrolled-up detection had two regimes:
- **normal buffer** → read xterm's viewport offset (`baseY - viewportY > 0`)
- **alternate screen** → use a gesture/wheel accumulator (`scrollDepth`)

The code assumed *Claude Code runs as a full-screen TUI on the alternate screen*. That's no longer true — verified against the live session via `herdr agent read --source recent`, which returns the full scrollback, i.e. Claude Code stays on the **normal buffer** but with **mouse tracking on**: it grabs the wheel and repaints its own scrolled view while xterm's viewport stays pinned at the bottom.

So `baseY - viewportY` is always `0`, and the `scrollDepth` branch only ran for `buffer.type === "alternate"` — never true for Claude Code. The whole app-owned-scroll path was dead for Claude sessions.

## Fix

Key the regime off **whether the agent owns the scroll** rather than the alternate screen:

```ts
const agentOwnsScroll = (term) =>
  term.buffer.active.type === "alternate" || term.modes.mouseTrackingMode !== "none";
```

Used in `recomputeScrolled`, `onTouchMove`, the desktop wheel tracker, and `scrollToBottom`. When mouse tracking is off (plain shell) it falls back to the existing xterm-viewport path → no behaviour change there. When it's on (Claude Code) the `scrollDepth` accumulator now runs, so the button shows on scroll-up and tapping it sends Claude's Ctrl+End (jump to latest).

## Checks
- `bun run check` (svelte-check): 0 errors
- `bun run check:i18n`: locales in parity (no new string — reuses existing key)
- `bun run test`: 220/220 pass