### PR TITLE
fix(backlog): scope tab counts to selected repo + add Actions count

### DIFF
--- a/src/backlog.ts
+++ b/src/backlog.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
 import { parseRemote } from "./forge/remote";
 import { detectForge } from "./forge";
 import type { ForgeMap } from "./forge/types";
@@ -58,6 +60,27 @@ class Semaphore {
         next(); // hand the slot off — keep `active`
       else this.active--; // no waiter — free the slot
     }
+  }
+}
+
+/**
+ * Number of workflows *defined* in a repo working copy — the count shown on the
+ * backlog Actions tab. "Defined" = files directly under `.github/workflows`
+ * ending in `.yml`/`.yaml`. Read from the local checkout, so it adds zero
+ * GitHub API pressure to the rate-limited counts warmer (unlike issue/PR counts,
+ * which hit the forge). Missing dir / unreadable → 0.
+ *
+ * Deliberately diverges from ActionsPanel, which lists workflow *runs* from
+ * GitHub: a never-run (or non-default-branch) workflow still counts here but
+ * has no run row there, so the badge can read higher than the panel.
+ */
+export function countDefinedWorkflows(repoDir: string): number {
+  try {
+    return readdirSync(join(repoDir, ".github", "workflows"), { withFileTypes: true }).filter(
+      (e) => e.isFile() && /\.ya?ml$/i.test(e.name),
+    ).length;
+  } catch {
+    return 0;
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,7 +35,7 @@ import type { PrCache } from "./pr-poller";
 import type { PushService } from "./push";
 import type { Presence } from "./presence";
 import type { StatusPoller } from "./poller";
-import type { CountsService, RepoCounts } from "./backlog";
+import { countDefinedWorkflows, type CountsService, type RepoCounts } from "./backlog";
 import { join, normalize } from "node:path";
 import { homedir } from "node:os";
 import type { ServerWebSocket } from "bun";
@@ -1062,6 +1062,8 @@ export interface BacklogProject {
   lastUsedAt: number | null;
   openIssues: number | null;
   openPRs: number | null;
+  /** Workflows defined under .github/workflows; null for non-GitHub forges. */
+  workflows: number | null;
 }
 export interface BacklogPayload {
   pinnedPath: string | null;
@@ -1119,6 +1121,9 @@ export async function buildBacklogPayload(inputs: BacklogPayloadInputs): Promise
       lastUsedAt: lastUsed[r.path] ?? null,
       openIssues: counts.openIssues,
       openPRs: counts.openPRs,
+      // GitHub-only: the Actions panel is github-gated, so other forges get null
+      // (plain "Actions" label) rather than a count that has no panel behind it.
+      workflows: r.forge.kind === "github" ? countDefinedWorkflows(r.path) : null,
     };
   });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -383,6 +383,7 @@
   "backlog_tab_issues_count": "Issues · {count}",
   "backlog_tab_prs_count": "PRs · {count}",
   "backlog_tab_actions": "Actions",
+  "backlog_tab_actions_count": "Actions · {count}",
   "actionspanel_title": "ACTIONS",
   "actionspanel_title_with_slug": "ACTIONS · {slug}",
   "actionspanel_github_only": "Actions sind nur für GitHub-Repos verfügbar",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -383,6 +383,7 @@
   "backlog_tab_issues_count": "Issues · {count}",
   "backlog_tab_prs_count": "PRs · {count}",
   "backlog_tab_actions": "Actions",
+  "backlog_tab_actions_count": "Actions · {count}",
   "actionspanel_title": "ACTIONS",
   "actionspanel_title_with_slug": "ACTIONS · {slug}",
   "actionspanel_github_only": "Actions are only available for GitHub repos",

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -32,6 +32,13 @@
   // Shared across tabs so switching Issues ↔ PRs keeps the chosen project.
   let selectedPath = $state<string | null>(null);
 
+  // Tab badges count the SELECTED repo's items — the same repo the detail pane
+  // shows — not the all-repos `payload.totals` (which made "PRs · 5" sit over a
+  // repo with no open PRs). null when nothing is selected → bare tab labels.
+  let selected = $derived(
+    selectedPath === null ? null : (payload?.projects.find((p) => p.path === selectedPath) ?? null),
+  );
+
   // Use untrack to read selectedPath without subscribing to it, so that
   // dismissDetail() (which sets selectedPath = null) does not re-fire this
   // effect and immediately re-seed the overlay from pinnedPath.
@@ -98,7 +105,9 @@
               type="button"
               onclick={() => (activeTab = "issues")}
             >
-              {m.backlog_tab_issues_count({ count: payload.totals.openIssues })}
+              {selected && selected.openIssues !== null
+                ? m.backlog_tab_issues_count({ count: selected.openIssues })
+                : m.backlog_tab_issues()}
             </button>
             <button
               class="tab-btn"
@@ -106,7 +115,9 @@
               type="button"
               onclick={() => (activeTab = "prs")}
             >
-              {m.backlog_tab_prs_count({ count: payload.totals.openPRs })}
+              {selected && selected.openPRs !== null
+                ? m.backlog_tab_prs_count({ count: selected.openPRs })
+                : m.backlog_tab_prs()}
             </button>
             <button
               class="tab-btn"
@@ -114,7 +125,9 @@
               type="button"
               onclick={() => (activeTab = "actions")}
             >
-              {m.backlog_tab_actions()}
+              {selected && selected.workflows !== null
+                ? m.backlog_tab_actions_count({ count: selected.workflows })
+                : m.backlog_tab_actions()}
             </button>
           </div>
         </div>
@@ -147,7 +160,9 @@
         type="button"
         onclick={() => (activeTab = "issues")}
       >
-        {m.backlog_tab_issues_count({ count: payload.totals.openIssues })}
+        {selected && selected.openIssues !== null
+          ? m.backlog_tab_issues_count({ count: selected.openIssues })
+          : m.backlog_tab_issues()}
       </button>
       <button
         class="tab-btn"
@@ -155,7 +170,9 @@
         type="button"
         onclick={() => (activeTab = "prs")}
       >
-        {m.backlog_tab_prs_count({ count: payload.totals.openPRs })}
+        {selected && selected.openPRs !== null
+          ? m.backlog_tab_prs_count({ count: selected.openPRs })
+          : m.backlog_tab_prs()}
       </button>
       <button
         class="tab-btn"
@@ -163,7 +180,9 @@
         type="button"
         onclick={() => (activeTab = "actions")}
       >
-        {m.backlog_tab_actions()}
+        {selected && selected.workflows !== null
+          ? m.backlog_tab_actions_count({ count: selected.workflows })
+          : m.backlog_tab_actions()}
       </button>
     </div>
 

--- a/ui/src/lib/components/backlog-view.test.ts
+++ b/ui/src/lib/components/backlog-view.test.ts
@@ -12,11 +12,23 @@
  * delegates to these functions.
  */
 import { describe, it, expect } from "vitest";
-import { formatCount, isPinned, issuesTabLabel, prsTabLabel } from "./backlog-view";
+import {
+  formatCount,
+  isPinned,
+  selectedProject,
+  issuesTabLabel,
+  prsTabLabel,
+  actionsTabLabel,
+} from "./backlog-view";
 import type { BacklogPayload, BacklogProject } from "$lib/types";
 
-function project(path: string, openIssues: number | null, openPRs: number | null): BacklogProject {
-  return { path, display: path, slug: "org/repo", kind: "github", openIssues, openPRs };
+function project(
+  path: string,
+  openIssues: number | null,
+  openPRs: number | null,
+  workflows: number | null = null,
+): BacklogProject {
+  return { path, display: path, slug: "org/repo", kind: "github", openIssues, openPRs, workflows };
 }
 
 function payload(
@@ -56,33 +68,80 @@ describe("isPinned", () => {
   });
 });
 
-describe("issuesTabLabel", () => {
-  it("includes the openIssues total count from the payload", () => {
-    const p = payload([], null, { openIssues: 24, openPRs: 3 });
-    const label = issuesTabLabel(p);
-    expect(label).toContain("24");
-    // Mirrors m.backlog_tab_issues_count({ count: payload.totals.openIssues })
-    expect(label).toMatch(/Issues\s*·\s*24/);
+describe("selectedProject", () => {
+  it("returns null when nothing is selected", () => {
+    const pl = payload([project("/repos/alpha", 5, 1)]);
+    expect(selectedProject(pl, null)).toBeNull();
   });
 
-  it("shows 0 when no issues", () => {
-    const p = payload([], null, { openIssues: 0, openPRs: 0 });
-    expect(issuesTabLabel(p)).toContain("0");
+  it("returns the project whose path matches the selection", () => {
+    const alpha = project("/repos/alpha", 5, 1);
+    const beta = project("/repos/beta", 2, 0);
+    const pl = payload([alpha, beta]);
+    expect(selectedProject(pl, "/repos/beta")).toBe(beta);
+  });
+
+  it("returns null when the selected path is not among the projects", () => {
+    const pl = payload([project("/repos/alpha", 5, 1)]);
+    expect(selectedProject(pl, "/repos/ghost")).toBeNull();
+  });
+});
+
+describe("issuesTabLabel", () => {
+  it("scopes the count to the selected project, not the all-repos total", () => {
+    // Selected repo has 0 open issues even though other repos contribute to the
+    // aggregate — the badge must read the per-repo value (the reported bug).
+    const sel = project("/repos/alpha", 0, 0);
+    const label = issuesTabLabel(sel);
+    expect(label).toMatch(/Issues\s*·\s*0/);
+  });
+
+  it("includes the selected project's openIssues count", () => {
+    expect(issuesTabLabel(project("/repos/a", 24, 3))).toMatch(/Issues\s*·\s*24/);
+  });
+
+  it("drops the count (bare label) when nothing is selected", () => {
+    expect(issuesTabLabel(null)).toBe("Issues");
+  });
+
+  it("drops the count when the per-repo count is unknown (null)", () => {
+    expect(issuesTabLabel(project("/repos/a", null, null))).toBe("Issues");
   });
 });
 
 describe("prsTabLabel", () => {
-  it("includes the openPRs total count from the payload", () => {
-    const p = payload([], null, { openIssues: 24, openPRs: 3 });
-    const label = prsTabLabel(p);
-    expect(label).toContain("3");
-    // Mirrors m.backlog_tab_prs_count({ count: payload.totals.openPRs })
-    expect(label).toMatch(/PRs\s*·\s*3/);
+  it("includes the selected project's openPRs count", () => {
+    expect(prsTabLabel(project("/repos/a", 24, 3))).toMatch(/PRs\s*·\s*3/);
   });
 
-  it("shows 0 when no PRs", () => {
-    const p = payload([], null, { openIssues: 10, openPRs: 0 });
-    expect(prsTabLabel(p)).toContain("0");
+  it("scopes to the selected repo: 5 total but 0 here → 'PRs · 0'", () => {
+    expect(prsTabLabel(project("/repos/a", 0, 0))).toMatch(/PRs\s*·\s*0/);
+  });
+
+  it("drops the count (bare label) when nothing is selected", () => {
+    expect(prsTabLabel(null)).toBe("PRs");
+  });
+
+  it("drops the count when the per-repo count is unknown (null)", () => {
+    expect(prsTabLabel(project("/repos/a", null, null))).toBe("PRs");
+  });
+});
+
+describe("actionsTabLabel", () => {
+  it("shows the workflows-defined count for the selected project", () => {
+    expect(actionsTabLabel(project("/repos/a", 0, 0, 3))).toMatch(/Actions\s*·\s*3/);
+  });
+
+  it("shows 'Actions · 0' for a github repo with no workflow files", () => {
+    expect(actionsTabLabel(project("/repos/a", 0, 0, 0))).toMatch(/Actions\s*·\s*0/);
+  });
+
+  it("drops the count (bare label) when nothing is selected", () => {
+    expect(actionsTabLabel(null)).toBe("Actions");
+  });
+
+  it("drops the count for non-github forges (workflows null)", () => {
+    expect(actionsTabLabel(project("/repos/a", 0, 0, null))).toBe("Actions");
   });
 });
 
@@ -103,10 +162,13 @@ describe("BacklogView display logic — integration of helpers", () => {
     expect(isPinned(beta, pl.pinnedPath)).toBe(false);
   });
 
-  it("tab labels contain both issue and PR totals from payload", () => {
-    const pl = payload([], "/repos/alpha", { openIssues: 15, openPRs: 7 });
-    expect(issuesTabLabel(pl)).toContain("15");
-    expect(prsTabLabel(pl)).toContain("7");
+  it("tab labels reflect the selected project resolved from the payload", () => {
+    const alpha = project("/repos/alpha", 15, 7, 4);
+    const pl = payload([alpha], "/repos/alpha");
+    const sel = selectedProject(pl, "/repos/alpha");
+    expect(issuesTabLabel(sel)).toContain("15");
+    expect(prsTabLabel(sel)).toContain("7");
+    expect(actionsTabLabel(sel)).toContain("4");
   });
 
   /**

--- a/ui/src/lib/components/backlog-view.ts
+++ b/ui/src/lib/components/backlog-view.ts
@@ -20,17 +20,40 @@ export function isPinned(project: BacklogProject, pinnedPath: string | null): bo
 }
 
 /**
- * Build the Issues tab label that BacklogView renders.
- * Mirrors: m.backlog_tab_issues_count({ count: payload.totals.openIssues })
+ * The project whose items the detail pane shows, or null when nothing is
+ * selected. Tab badges scope their counts to this project — not to the
+ * all-repos `payload.totals`, which would mis-report a single repo's tab.
  */
-export function issuesTabLabel(payload: BacklogPayload): string {
-  return `Issues · ${payload.totals.openIssues}`;
+export function selectedProject(
+  payload: BacklogPayload,
+  selectedPath: string | null,
+): BacklogProject | null {
+  if (selectedPath === null) return null;
+  return payload.projects.find((p) => p.path === selectedPath) ?? null;
 }
 
 /**
- * Build the PRs tab label that BacklogView renders.
- * Mirrors: m.backlog_tab_prs_count({ count: payload.totals.openPRs })
+ * Build the Issues tab label that BacklogView renders for the selected project.
+ * No selection or unknown count → the bare "Issues" label (no number).
+ * Mirrors: count → m.backlog_tab_issues_count, else m.backlog_tab_issues.
  */
-export function prsTabLabel(payload: BacklogPayload): string {
-  return `PRs · ${payload.totals.openPRs}`;
+export function issuesTabLabel(sel: BacklogProject | null): string {
+  return sel && sel.openIssues !== null ? `Issues · ${sel.openIssues}` : "Issues";
+}
+
+/**
+ * Build the PRs tab label for the selected project.
+ * Mirrors: count → m.backlog_tab_prs_count, else m.backlog_tab_prs.
+ */
+export function prsTabLabel(sel: BacklogProject | null): string {
+  return sel && sel.openPRs !== null ? `PRs · ${sel.openPRs}` : "PRs";
+}
+
+/**
+ * Build the Actions tab label for the selected project. The count is the number
+ * of workflows defined (github-only; null on other forges → bare label).
+ * Mirrors: count → m.backlog_tab_actions_count, else m.backlog_tab_actions.
+ */
+export function actionsTabLabel(sel: BacklogProject | null): string {
+  return sel && sel.workflows !== null ? `Actions · ${sel.workflows}` : "Actions";
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -237,6 +237,8 @@ export interface BacklogProject {
   lastUsedAt?: number;
   openIssues: number | null;
   openPRs: number | null;
+  /** Workflows defined under .github/workflows; null for non-GitHub forges. */
+  workflows: number | null;
 }
 export interface BacklogPayload {
   pinnedPath: string | null;


### PR DESCRIPTION
## Problem

In the backlog Issues/PRs/Actions tab switcher, the count badges read `payload.totals` — the **sum across all pinned repos** — while the detail pane shows the **selected repo**. Result: erwins-enkel/shepherd's empty PR list sat under a global "PRs · 5" (two different scopes). The Actions tab had no count at all.

## Changes

- **Per-repo counts:** Issues/PRs badges now bind to the *selected* project's `openIssues`/`openPRs` (already carried in `payload.projects[]`), so the badge always matches the panel. No selection → bare "Issues"/"PRs" label (no misleading number). Mobile unaffected — its badges only render inside the per-repo overlay.
- **Actions count:** added `workflows: number | null` to `BacklogProject`, computed as the count of `.github/workflows/*.{yml,yaml}` files = "workflows defined". Read from the **local checkout** (no `gh` call → zero added GitHub API pressure on the rate-limited counts warmer, works offline). GitHub-only; other forges → `null` → bare "Actions", matching the panel's existing "GitHub only" state.

## Notes / tradeoff

The workflow count reflects whatever branch the repo is checked out on (= default branch for pinned repos in practice). Can switch to the remote API for authoritative default-branch semantics if preferred.

## Tests

- Root: 675 pass / 0 fail (lint + tsc clean)
- UI: 226 pass / 0 fail, svelte-check 0 errors, i18n parity (419 keys, EN+DE `backlog_tab_actions_count` added)
- New coverage in `backlog-view.test.ts`: per-repo scoping (5-total-but-0-here → "· 0"), null/no-selection → bare label, `actionsTabLabel` github/non-github/empty cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)