### PR TITLE
fix(gitrail): keep review send-to-agent button reachable on short viewports

### DIFF
--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -683,6 +683,8 @@
     margin: 0;
     font-size: 11px;
     color: var(--color-ink);
+    /* pinned alongside head/footer; only .rv-body scrolls */
+    flex-shrink: 0;
   }
   .rv-body {
     margin: 0;

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -629,6 +629,10 @@
     padding: 8px;
     width: min(480px, 90vw);
     max-height: 60vh;
+    /* clip to the box so the scrollable body — not the popover — absorbs
+       overflow; without this the action footer escapes below max-height and,
+       on short (unfolded-fold) viewports, lands off-screen + unreachable */
+    overflow: hidden;
     background: var(--color-inset);
     border: 1px solid var(--color-line);
     border-radius: 2px;
@@ -639,6 +643,8 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    /* head + footer stay pinned; only .rv-body scrolls */
+    flex-shrink: 0;
   }
   .rv-label {
     font-size: 10px;
@@ -680,6 +686,10 @@
   }
   .rv-body {
     margin: 0;
+    /* the lone scroller: min-height:0 lets it shrink within the flex column
+       (default min-height:auto would refuse, pushing the footer out of view) */
+    flex: 1 1 auto;
+    min-height: 0;
     overflow: auto;
     background: var(--color-panel);
     border: 1px solid var(--color-line);
@@ -774,5 +784,7 @@
     margin-top: 4px;
     padding-top: 6px;
     border-top: 1px solid var(--color-line);
+    /* pinned footer: never compressed away by a tall body */
+    flex-shrink: 0;
   }
 </style>


### PR DESCRIPTION
## Problem
On unfolded-fold / compact layouts the critic **review popover**'s *Send review to agent* button was unreachable — it rendered off-screen.

## Root cause
`.review-pop` is a `flex column` capped at `max-height: 60vh`. The `.rv-body` markdown region had `overflow: auto` but the default `min-height: auto`, so it refused to shrink and expanded to full content height. With `.review-pop` having no `overflow` (default `visible`), the trailing `.review-actions` footer was pushed *past* the 60vh box. On a short viewport (unfolded fold, where the git rail sits as a lower second header row) that overflow landed off-screen → button unreachable. Tall phone-portrait viewports masked it because the overflow stayed on-screen.

## Fix (CSS-only)
- `.review-pop` → `overflow: hidden` (clip to box)
- `.rv-body` → `flex: 1 1 auto; min-height: 0` (lone internal scroller)
- `.review-head` + `.review-actions` → `flex-shrink: 0` (head + send button stay pinned)

The header and Send-to-agent button now stay fixed while the review body scrolls inside, at any viewport height.

## Verification
- `bun run check` → 0 errors / 0 warnings
- `prettier --check` → clean
- `check:i18n` → locales in parity (no strings touched)

Layout-only change; verified via static gates + reasoning. Worth an eyeball on a real short/compact viewport before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)