### PR TITLE
fix(viewport): mobile top bar wraps with long session names

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1559,7 +1559,7 @@
     font-size: 12px;
     min-width: 0;
     /* ellipsize well before the row fills, ceding width to the close button */
-    max-width: 42vw;
+    max-width: 34vw;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
## Problem

On phone, a long session name fills `.ctx-name`'s `42vw` cap, pushing the trailing actions (rename ✎ + close ✕) onto a second header row.

![before](attachment)

## Fix

Tighten the mobile session-name cap from `42vw` → `34vw` (~30px narrower on a 390px phone). The name ellipsizes sooner and cedes width to the close button — exactly the behavior the existing CSS comment already intended — so the trailing actions stay on the identity row.

One-line CSS value change in `ui/src/lib/components/Viewport.svelte`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)