### PR TITLE
fix(steerbar): match collapsed broadcast chip width to Esc key

### DIFF
--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -155,10 +155,13 @@
   .bc-label {
     margin-left: 6px;
   }
-  /* on mobile the broadcast chip collapses to just its 📡 icon to reclaim space */
+  /* on mobile the broadcast chip collapses to just its 📡 icon to reclaim
+     space; matches the ControlBar Esc key's box model (min-width 44px, no
+     horizontal padding) so the collapsed chip and Esc render an identical width */
   @media (max-width: 768px) {
     .chip.bc {
-      padding: 0 12px;
+      min-width: 44px;
+      padding: 0;
     }
     .bc-label {
       display: none;


### PR DESCRIPTION
## What

On mobile the broadcast chip collapses to just its 📡 icon. Its width was emoji-glyph-width + padding, which drifts by platform and didn't match the ControlBar **Esc** key sitting in the row below.

Give the collapsed chip the Esc key's box model (`min-width: 44px`, `padding: 0`, same 1px border, same content-box) so both render an identical 46px and center their single glyph.

Only the `max-width: 768px` breakpoint is touched — the expanded desktop chip with its label is unchanged.

## Test

`cd ui && bun run check` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)