### PR TITLE
fix(pr-poller): recognize PRs after an agent renames its branch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,8 +132,15 @@ attachPush(events, store, push);
 
 // poll PR status for active sessions every 120s; push session:git on change so
 // the list overview badges stay current without opening each session's detail.
-const prPoller = new PrPoller(store, resolveForge, (id, git) =>
-  events.emit("session:git", { id, git }),
+const prPoller = new PrPoller(
+  store,
+  resolveForge,
+  (id, git) => events.emit("session:git", { id, git }),
+  undefined,
+  undefined,
+  // on a "no PR" miss, adopt the agent's renamed worktree branch so its open PR
+  // is recognized instead of staying invisible against the stale stored branch
+  (s) => service.syncWorktreeBranch(s.id),
 );
 setTimeout(() => void prPoller.tick(), 3_000); // warm the cache shortly after boot
 prPoller.start();

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -29,6 +29,10 @@ export class PrPoller implements PrCache {
     /** Coalescing window for `pollSession` — bursts of status flips near a
      *  turn's end collapse into one `gh` call. */
     private pollDelayMs = 1000,
+    /** Called when the stored branch yields no PR: re-resolves the session's live
+     *  worktree branch (an agent may have renamed it), persists the adoption, and
+     *  returns the new branch to retry against — or null when nothing changed. */
+    private reconcileBranch: (s: Session) => string | null = () => null,
   ) {}
 
   async tick(): Promise<void> {
@@ -52,6 +56,18 @@ export class PrPoller implements PrCache {
       git = { kind: forge.kind, ...(await forge.prStatus(s.branch)) };
     } catch {
       return; // transient gh failure → keep last cached value
+    }
+    // No PR for the stored branch — the agent may have renamed the worktree's
+    // branch out from under us. Adopt the live branch and retry against it.
+    if (git.state === "none") {
+      const live = this.reconcileBranch(s);
+      if (live) {
+        try {
+          git = { kind: forge.kind, ...(await forge.prStatus(live)) };
+        } catch {
+          return;
+        }
+      }
     }
     const prev = this.cache.get(s.id);
     if (

--- a/src/service.ts
+++ b/src/service.ts
@@ -13,7 +13,7 @@ export interface ServiceDeps {
   store: SessionStore;
   worktree: Pick<
     WorktreeMgr,
-    "create" | "remove" | "renameBranch" | "branchExists" | "commitsAhead"
+    "create" | "remove" | "renameBranch" | "branchExists" | "commitsAhead" | "currentBranch"
   >;
   herdr: Pick<HerdrDriver, "start" | "list" | "stop" | "send" | "relabel">;
   namer: (prompt: string) => string | Promise<string>;
@@ -243,6 +243,42 @@ export class SessionService {
   /** Whether a local branch already exists — the server's pre-flight check before a rename. */
   branchExists(repoPath: string, branch: string): boolean {
     return this.deps.worktree.branchExists(repoPath, branch);
+  }
+
+  /**
+   * Reconcile a session's stored branch with the one actually checked out in its
+   * worktree. An agent that runs `git checkout -b` / `git branch -m` renames the
+   * branch out from under us, so the stored `branch` goes stale and PR detection
+   * (which queries `gh pr list --head <branch>`) silently misses the opened PR.
+   * Called by the PR poller on a "no PR found" miss. When the live branch differs,
+   * adopt it (re-point `branch`) — that alone is what restores PR recognition.
+   * Returns the adopted branch (so the poller can re-query), or null when nothing
+   * changed / it can't be determined.
+   *
+   * The display `name` follows only when it still trivially mirrors the *old* branch
+   * (i.e. was auto-derived). A name that already diverged is a chosen name — a manual
+   * rename or an LLM refine — and outranks a raw branch slug, the same precedence
+   * `refineNameInBackground` enforces. When it does follow, it's de-duped through
+   * `uniqueName` like the other automatic rename paths so it can't clash with a
+   * sibling's tab label.
+   */
+  syncWorktreeBranch(id: string): string | null {
+    const s = this.deps.store.get(id);
+    if (!s || !s.isolated || !s.branch) return null;
+    const live = this.deps.worktree.currentBranch(s.worktreePath);
+    if (!live || live === s.branch) return null;
+    const nameMirrorsBranch = s.name === s.branch.replace(/^shepherd\//, "");
+    const label = nameMirrorsBranch ? this.uniqueName(live.replace(/^shepherd\//, "")) : null;
+    this.deps.store.update(id, label ? { name: label, branch: live } : { branch: live });
+    if (label) {
+      try {
+        this.deps.herdr.relabel(s.herdrAgentId, label);
+      } catch {
+        /* tab may be gone — branch adoption still stands */
+      }
+    }
+    this.deps.events?.emit("session:renamed", { id, name: label ?? s.name, branch: live });
+    return live;
   }
 
   rename(id: string, slug: string, opts: { renameLocalBranch: boolean }): Session | null {

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -65,6 +65,23 @@ export class WorktreeMgr {
     execFileSync("git", ["branch", "-m", oldBranch, newBranch], { cwd: repoPath, stdio: "pipe" });
   }
 
+  /** The branch currently checked out in `worktreePath`, or null when HEAD is
+   *  detached or the path isn't a readable git worktree. This is the source of
+   *  truth for which branch a session's PR will come from — an agent that runs
+   *  `git checkout -b` / `git branch -m` moves it out from under the stored value. */
+  currentBranch(worktreePath: string): string | null {
+    try {
+      const out = execFileSync("git", ["symbolic-ref", "--quiet", "--short", "HEAD"], {
+        cwd: worktreePath,
+        stdio: "pipe",
+        encoding: "utf8",
+      });
+      return out.trim() || null;
+    } catch {
+      return null; // detached HEAD or not a worktree
+    }
+  }
+
   /** Commits on `branch` not yet on `baseBranch` (`git rev-list --count base..branch`).
    *  0 means the branch tip still equals base — the "nothing committed yet" window in
    *  which an auto-rename can safely move the branch. Returns a large number on any

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -226,6 +226,83 @@ test("emits when only the latest review changes", async () => {
   expect(emitted.length).toBe(2);
 });
 
+function forgeByBranch(byBranch: Record<string, PrStatus>): GitForge {
+  return {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus: async (head: string) => byBranch[head] ?? NONE,
+    openPr: async () => NONE,
+    merge: async () => {},
+    redeploy: async () => {},
+    postReview: async () => ({}),
+  };
+}
+
+test("reconciles to the live worktree branch when the stored branch has no PR", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession); // stored branch shepherd/x has no PR
+  const emitted: { id: string; state: string; number?: number }[] = [];
+  let reconcileCalls = 0;
+  const poller = new PrPoller(
+    store,
+    () => forgeByBranch({ "shepherd/renamed": OPEN }), // PR lives on the renamed branch
+    (id, git) => emitted.push({ id, state: git.state, number: git.number }),
+    120_000,
+    1000,
+    (sess) => {
+      reconcileCalls++;
+      expect(sess.id).toBe(s.id);
+      return "shepherd/renamed"; // agent renamed the worktree branch
+    },
+  );
+
+  await poller.tick();
+  expect(reconcileCalls).toBe(1);
+  expect(emitted).toEqual([{ id: s.id, state: "open", number: 7 }]);
+});
+
+test("does not reconcile when the stored branch already has a PR", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  let reconcileCalls = 0;
+  const poller = new PrPoller(
+    store,
+    () => forgeReturning(() => OPEN),
+    () => {},
+    120_000,
+    1000,
+    () => {
+      reconcileCalls++;
+      return "shepherd/renamed";
+    },
+  );
+
+  await poller.tick();
+  expect(reconcileCalls).toBe(0); // stored branch matched → no reconcile attempt
+});
+
+test("leaves state none when reconcile finds no other branch", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const emitted: { state: string }[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forgeReturning(() => NONE),
+    (_id, git) => emitted.push({ state: git.state }),
+    120_000,
+    1000,
+    () => null, // nothing to adopt
+  );
+
+  await poller.tick();
+  expect(emitted).toEqual([{ state: "none" }]);
+  expect(poller.snapshot()[s.id]?.state).toBe("none");
+});
+
 test("prunes cache entries for sessions no longer active", async () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -93,6 +93,159 @@ test("setReadyToMerge persists the flag and emits session:ready", () => {
   expect(emitted[1]).toEqual({ event: "session:ready", data: { id: s.id, ready: false } });
 });
 
+test("syncWorktreeBranch adopts the agent's renamed branch, syncs name + tab, emits", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({
+    name: "view-refresh",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/view-refresh",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+  });
+  const emitted: { event: string; data: unknown }[] = [];
+  const relabels: { id: string; label: string }[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { currentBranch: () => "shepherd/refresh-on-wake" } as any,
+    herdr: {
+      relabel: (id: string, label: string) => relabels.push({ id, label }),
+      list: () => [],
+    } as any,
+    events: { emit: (event, data) => emitted.push({ event, data }) },
+  });
+
+  const adopted = service.syncWorktreeBranch(s.id);
+  expect(adopted).toBe("shepherd/refresh-on-wake");
+  const row = store.get(s.id)!;
+  expect(row.branch).toBe("shepherd/refresh-on-wake");
+  expect(row.name).toBe("refresh-on-wake"); // shepherd/ prefix stripped for display
+  expect(relabels).toEqual([{ id: "term_a", label: "refresh-on-wake" }]);
+  expect(emitted).toEqual([
+    {
+      event: "session:renamed",
+      data: { id: s.id, name: "refresh-on-wake", branch: "shepherd/refresh-on-wake" },
+    },
+  ]);
+});
+
+test("syncWorktreeBranch adopts the branch but preserves a chosen display name", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({
+    name: "nice-human-name", // diverged from the branch slug → a chosen name
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/view-refresh",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+  });
+  const emitted: { event: string; data: unknown }[] = [];
+  const relabels: unknown[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { currentBranch: () => "shepherd/refresh-on-wake" } as any,
+    herdr: { relabel: (...a: unknown[]) => relabels.push(a), list: () => [] } as any,
+    events: { emit: (event, data) => emitted.push({ event, data }) },
+  });
+
+  expect(service.syncWorktreeBranch(s.id)).toBe("shepherd/refresh-on-wake");
+  const row = store.get(s.id)!;
+  expect(row.branch).toBe("shepherd/refresh-on-wake"); // branch adopted (fixes PR recognition)
+  expect(row.name).toBe("nice-human-name"); // chosen name outranks the raw branch slug
+  expect(relabels).toHaveLength(0); // tab label left alone
+  expect(emitted).toEqual([
+    {
+      event: "session:renamed",
+      data: { id: s.id, name: "nice-human-name", branch: "shepherd/refresh-on-wake" },
+    },
+  ]);
+});
+
+test("syncWorktreeBranch de-dupes the adopted name against live tab labels", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({
+    name: "view-refresh",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/view-refresh",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+  });
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { currentBranch: () => "shepherd/refresh-on-wake" } as any,
+    // a sibling already owns the bare slug → uniqueName suffixes it
+    herdr: { relabel: () => {}, list: () => [{ name: "refresh-on-wake" }] } as any,
+  });
+
+  expect(service.syncWorktreeBranch(s.id)).toBe("shepherd/refresh-on-wake");
+  const row = store.get(s.id)!;
+  expect(row.branch).toBe("shepherd/refresh-on-wake"); // branch still the live one
+  expect(row.name).toBe("refresh-on-wake-2"); // display name de-duped
+});
+
+test("syncWorktreeBranch is a no-op when the live branch matches the stored one", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({
+    name: "x",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+  });
+  const emitted: unknown[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { currentBranch: () => "shepherd/x" } as any,
+    herdr: { relabel: () => {} } as any,
+    events: { emit: (...args: unknown[]) => emitted.push(args) },
+  });
+
+  expect(service.syncWorktreeBranch(s.id)).toBeNull();
+  expect(store.get(s.id)?.name).toBe("x");
+  expect(emitted).toHaveLength(0);
+});
+
+test("syncWorktreeBranch returns null on a detached HEAD (currentBranch null)", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({
+    name: "x",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+  });
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { currentBranch: () => null } as any,
+    herdr: { relabel: () => {} } as any,
+  });
+  expect(service.syncWorktreeBranch(s.id)).toBeNull();
+  expect(store.get(s.id)?.branch).toBe("shepherd/x");
+});
+
 test("spawnSettingsOverlay pins remoteControlAtStartup from config (default off)", () => {
   const prev = config.remoteControlAtStartup;
   try {
@@ -545,6 +698,7 @@ test("archive without a reaper just closes the session (no leftover handling)", 
       branchExists: () => false,
       renameBranch: () => {},
       commitsAhead: () => 0,
+      currentBranch: () => null,
     },
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {} } as any,
   });
@@ -584,6 +738,7 @@ test("leftovers proxies to the reaper for the session; [] for unknown id", () =>
       branchExists: () => false,
       renameBranch: () => {},
       commitsAhead: () => 0,
+      currentBranch: () => null,
     },
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {} } as any,
     reaper: { detect: detect as any, reap: () => {} },
@@ -625,6 +780,7 @@ test("archive reaps only the selected leftovers, re-detected (no trusting raw cl
       branchExists: () => false,
       renameBranch: () => {},
       commitsAhead: () => 0,
+      currentBranch: () => null,
     },
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {} } as any,
     reaper: {
@@ -663,6 +819,7 @@ test("archive with no reap keys never calls the reaper", () => {
       branchExists: () => false,
       renameBranch: () => {},
       commitsAhead: () => 0,
+      currentBranch: () => null,
     },
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {} } as any,
     reaper: {

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -37,6 +37,26 @@ test("create makes an isolated worktree on a shepherd/ branch", () => {
   expect(branches).toContain("shepherd/repo-flatten");
 });
 
+test("currentBranch reports the worktree's checked-out branch and follows a rename", () => {
+  const wt = new WorktreeMgr();
+  const r = wt.create(repo, "main", "view-refresh");
+  expect(wt.currentBranch(r.worktreePath)).toBe("shepherd/view-refresh");
+  // agent renames the branch out from under the stored value
+  execFileSync("git", ["branch", "-m", "shepherd/view-refresh", "shepherd/refresh-on-wake"], {
+    cwd: r.worktreePath,
+  });
+  expect(wt.currentBranch(r.worktreePath)).toBe("shepherd/refresh-on-wake");
+  wt.remove(r.worktreePath);
+});
+
+test("currentBranch returns null on a detached HEAD", () => {
+  const wt = new WorktreeMgr();
+  const sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo }).toString().trim();
+  const r = wt.createDetached(repo, "main", sha);
+  expect(wt.currentBranch(r.worktreePath)).toBeNull();
+  wt.remove(r.worktreePath);
+});
+
 test("remove force-deletes the workspace even when git worktree remove refuses", () => {
   const wt = new WorktreeMgr();
   // a populated dir inside the repo that git does NOT track as a worktree:


### PR DESCRIPTION
## Problem

Shepherd sometimes fails to recognize an opened PR (e.g. **TASK-173**, session still open). Root cause: PR detection runs `gh pr list --head <session.branch>`, but `session.branch` is written **only** at session create and on a *user-initiated* rename. When the **agent** renames its own branch (`git checkout -b` / `git branch -m`) before opening the PR, the stored branch goes stale and the lookup silently misses.

Evidence for TASK-173:

| | value |
|---|---|
| `session.branch` (stored) | `shepherd/mobile-view-refresh` |
| worktree HEAD / pushed branch | `shepherd/mobile-refresh-on-wake` |
| PR #252 head | `shepherd/mobile-refresh-on-wake` |
| `gh pr list --head shepherd/mobile-view-refresh` | `[]` → never recognized |

## Fix

Lazy reconcile on miss: when the stored branch yields no PR, the poller re-resolves the session's **live worktree HEAD branch**, adopts it (re-points `branch`, syncs display `name` + herdr tab, emits `session:renamed`), **persists** it, and retries the lookup. Self-healing — also unsticks already-stuck sessions on the next poll.

- `WorktreeMgr.currentBranch()` — reads the worktree's checked-out branch (null on detached HEAD)
- `SessionService.syncWorktreeBranch()` — adopt + persist + relabel + emit
- `PrPoller` — new `reconcileBranch` callback, invoked only on a `state: "none"` result

Server-only; reuses the existing `session:renamed` event, so no UI/i18n changes.

## Tests

Added coverage: poller reconciles on miss / skips when stored branch already has a PR / leaves `none` when nothing to adopt; `currentBranch` follows a rename + null on detached HEAD; `syncWorktreeBranch` adopts+emits / no-op when unchanged / null on detached HEAD. Full root suite green (683 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)