### PR TITLE
feat(namer): pre-warn agent + toast when branch auto-renames

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -38,6 +38,19 @@ export function spawnSettingsOverlay(): string {
   return JSON.stringify({ remoteControlAtStartup: config.remoteControlAtStartup });
 }
 
+/**
+ * Appended to every spawned session's system prompt. The async namer
+ * (`refineNameInBackground`) can `git branch -m` the session branch 10–60s after
+ * start — while the agent is already working — so an agent that inspects git state
+ * mid-task would otherwise read the changed branch name as an error (cf. TASK-177).
+ * Pre-warning it at spawn removes the surprise at the source. Not user-facing chrome
+ * (it's an instruction to the agent), so no i18n.
+ */
+export const BRANCH_RENAME_NOTICE =
+  "Shepherd may rename this session's git branch shortly after startup to a clearer, " +
+  "prompt-derived name (via `git branch -m`). This is expected: your working tree, " +
+  "commits, and checked-out HEAD are unaffected — never treat a changed branch name as an error.";
+
 export class SessionService {
   constructor(private deps: ServiceDeps) {}
 
@@ -67,6 +80,7 @@ export class SessionService {
 
       const argv = ["claude", "--dangerously-skip-permissions", "--session-id", claudeSessionId];
       argv.push("--settings", spawnSettingsOverlay());
+      argv.push("--append-system-prompt", BRANCH_RENAME_NOTICE);
       if (input.model) argv.push("--model", input.model);
       argv.push(promptArg);
       const agent = this.deps.herdr.start(name, wt.worktreePath, argv);

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "bun:test";
 import { SessionStore } from "../src/store";
-import { SessionService, spawnSettingsOverlay } from "../src/service";
+import { SessionService, spawnSettingsOverlay, BRANCH_RENAME_NOTICE } from "../src/service";
 import { config } from "../src/config";
 
 test("createSession: names, makes worktree, starts herdr, persists", async () => {
@@ -56,6 +56,8 @@ test("createSession: names, makes worktree, starts herdr, persists", async () =>
     s.claudeSessionId,
     "--settings",
     spawnSettingsOverlay(),
+    "--append-system-prompt",
+    BRANCH_RENAME_NOTICE,
     "flatten it",
   ]);
   expect(s.claudeSessionId).toMatch(/^[0-9a-f-]{36}$/);
@@ -435,6 +437,8 @@ test("createSession: passes --model and persists it when a model is chosen", asy
     s.claudeSessionId,
     "--settings",
     spawnSettingsOverlay(),
+    "--append-system-prompt",
+    BRANCH_RENAME_NOTICE,
     "--model",
     "opus",
     "go",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -369,6 +369,7 @@
   "toast_cleared_merged": "{count} gemergte Sessions aufgeräumt",
   "toast_clear_merged_failed": "Gemergte Sessions konnten nicht aufgeräumt werden",
   "toast_merged": "{name} gemergt",
+  "toast_renamed": "Umbenannt in {name}",
   "emojipicker_search": "Emoji suchen…",
   "emojipicker_custom": "Emoji einfügen",
   "emojipicker_clear": "Symbol entfernen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -369,6 +369,7 @@
   "toast_cleared_merged": "Cleared {count} merged sessions",
   "toast_clear_merged_failed": "Couldn't clear merged sessions",
   "toast_merged": "Merged {name}",
+  "toast_renamed": "Renamed to {name}",
   "emojipicker_search": "search emoji…",
   "emojipicker_custom": "paste any emoji",
   "emojipicker_clear": "remove icon",

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -113,6 +113,20 @@ test("session:renamed surfaces a toast naming the new name", () => {
   expect(toasts.items.some((t) => t.text.includes("fresh"))).toBe(true);
 });
 
+test("session:renamed adopts a new branch silently when the display name is unchanged", () => {
+  // contingency path (syncWorktreeBranch) re-emits with the same name when only the
+  // branch moved — no visible change, so no "Renamed to <same name>" toast noise.
+  toasts.items = [];
+  const s = new HerdStore();
+  s.setAll([session("s1")]); // name "n"
+  s.apply({
+    event: "session:renamed",
+    data: { id: "s1", name: "n", branch: "shepherd/adopted" },
+  });
+  expect(s.sessions.find((x) => x.id === "s1")?.branch).toBe("shepherd/adopted"); // still adopted
+  expect(toasts.items).toHaveLength(0); // but no toast
+});
+
 // ---- /events WS reconnect (mobile background-drop / wake recovery) ----
 // The live stream is delta-only; a frozen mobile tab drops the socket and the
 // onclose backoff timer is frozen with it. connect() must resume the stream on

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, vi, afterEach } from "vitest";
 import { HerdStore } from "./store.svelte";
+import { toasts } from "./toasts.svelte";
 import type { BacklogPayload, GitState, Session } from "./types";
 
 const GIT: GitState = {
@@ -99,6 +100,17 @@ test("session:renamed patches the name + branch of the matching session", () => 
   expect(a?.name).toBe("fresh");
   expect(a?.branch).toBe("shepherd/fresh");
   expect(b?.name).toBe("n"); // other sessions untouched
+});
+
+test("session:renamed surfaces a toast naming the new name", () => {
+  toasts.items = [];
+  const s = new HerdStore();
+  s.setAll([session("s1")]);
+  s.apply({
+    event: "session:renamed",
+    data: { id: "s1", name: "fresh", branch: "shepherd/fresh" },
+  });
+  expect(toasts.items.some((t) => t.text.includes("fresh"))).toBe(true);
 });
 
 // ---- /events WS reconnect (mobile background-drop / wake recovery) ----

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -12,6 +12,8 @@ import type { BlockState } from "./triage";
 import { projectIcons } from "./projectIcons.svelte";
 import { reviews } from "./reviews.svelte";
 import { learnings } from "./learnings.svelte";
+import { toasts } from "./toasts.svelte";
+import { m } from "$lib/paraglide/messages";
 
 export class HerdStore {
   sessions = $state<Session[]>([]);
@@ -94,6 +96,9 @@ export class HerdStore {
         this.sessions = this.sessions.map((s) =>
           s.id === ev.data.id ? { ...s, name: ev.data.name, branch: ev.data.branch } : s,
         );
+        // Surface the rename (esp. the async namer's auto-rename, which lands while
+        // the agent is already working) so the row changing under the user is explained.
+        toasts.info(m.toast_renamed({ name: ev.data.name }));
         break;
       case "session:ready":
         this.sessions = this.sessions.map((s) =>

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -82,6 +82,19 @@ export class HerdStore {
     this.blocks = { ...this.blocks, [id]: { reason, since: prev?.since ?? Date.now() } };
   }
 
+  /** Patch a session's name + branch, then surface the rename (esp. the async
+   *  namer's auto-rename, which lands while the agent is already working) so the
+   *  row changing under the user is explained. Toasts only when the visible name
+   *  actually changed: the contingency path (syncWorktreeBranch) re-emits with an
+   *  unchanged name when only the branch moved, which would otherwise read as a
+   *  "Renamed to <same name>" non-event. Extracted from apply() to keep that
+   *  dispatch switch under the complexity gate. */
+  private applyRenamed(id: string, name: string, branch: string | null) {
+    const prevName = this.byId(id)?.name;
+    this.sessions = this.sessions.map((s) => (s.id === id ? { ...s, name, branch } : s));
+    if (prevName !== undefined && prevName !== name) toasts.info(m.toast_renamed({ name }));
+  }
+
   apply(ev: WsEvent) {
     switch (ev.event) {
       case "session:new":
@@ -93,12 +106,7 @@ export class HerdStore {
         );
         break;
       case "session:renamed":
-        this.sessions = this.sessions.map((s) =>
-          s.id === ev.data.id ? { ...s, name: ev.data.name, branch: ev.data.branch } : s,
-        );
-        // Surface the rename (esp. the async namer's auto-rename, which lands while
-        // the agent is already working) so the row changing under the user is explained.
-        toasts.info(m.toast_renamed({ name: ev.data.name }));
+        this.applyRenamed(ev.data.id, ev.data.name, ev.data.branch);
         break;
       case "session:ready":
         this.sessions = this.sessions.map((s) =>


### PR DESCRIPTION
## Problem

The async namer `git branch -m`s the session branch 10–60s after start — **while the agent is already working**. An agent that inspects git state mid-task reads the changed branch name as an error. Real case: **TASK-177** paused mid-investigation, nearly holding off a commit for fear of committing onto the wrong branch, until it reconciled via reflog. Correctness held (the rename goes through `service.rename()` → DB updated in lockstep), but it's a startling UX wrinkle.

## Fix (no behavior change to the rename itself)

- **Pre-warn the agent at spawn.** New `BRANCH_RENAME_NOTICE` appended via `--append-system-prompt` on every `create` spawn — tells the agent the branch may move and that HEAD / working tree / commits stay intact, so it never treats the change as an error. Kills the confusion at the source while keeping the nice comprehended branch names.
- **Surface the rename to the human.** `session:renamed` now fires a toast (`toast_renamed`, EN + DE) so the row changing under the user is explained.

## Notes

- Not added to `resume()` — the namer only fires via `scheduleRefine` in `create`, so a "may rename your branch" notice there would be false.
- The notice is an instruction to the agent (English-only, not UI chrome), so no i18n for it; the toast string is chrome and ships EN + DE.
- Toast also fires for user-initiated renames (same event) — harmless confirmation.

## Verification

Root: `tsc --noEmit` clean · `bun test ./test` 686 pass · lint clean.
UI: `bun run check` 0 errors · `bun run test` 234 pass · `check:i18n` parity (419 keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)