### PR TITLE
fix(controlbar): scroll Tab/Space so portrait scroll window isn't squeezed to 2 keys

### DIFF
--- a/ui/src/lib/components/ControlBar.svelte
+++ b/ui/src/lib/components/ControlBar.svelte
@@ -4,8 +4,8 @@
 
   // `include` renders only the listed groups (omit for all); `scroll=false`
   // fits content instead of growing+scrolling, for a fixed edge cluster. This
-  // lets the ctrl-row freeze Esc/Tab on the left and scroll the arrows + ^-keys
-  // in the middle, each as its own ControlBar.
+  // lets the ctrl-row freeze Esc on the left and scroll Tab/Space + arrows +
+  // ^-keys in the middle, each as its own ControlBar.
   let {
     onkey,
     include,
@@ -117,7 +117,7 @@
   }
 
   /* one "well" per group — faint common-region backing so the eye chunks
-     Esc/Tab · arrows · ^-signals into three units instead of one long row */
+     Tab/Space · arrows · ^-signals into three units instead of one long row */
   .group {
     display: flex;
     gap: 4px;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1203,11 +1203,14 @@
        mobile breakpoint) gets it, since there's no hardware keyboard to steer with -->
   {#if (mobile || touch) && tab === "term"}
     <div class="ctrl-row" bind:this={ctrlRowEl} data-swipe-ignore>
-      <!-- Esc/Tab frozen on the left edge; the arrows + ^-keys scroll in the
-           middle; attach/dictate/Enter frozen on the right. There's no compose
-           chip — swipe up from this row to summon the compose sheet. -->
-      <ControlBar onkey={(seq) => conn?.send(seq)} include={["edit"]} scroll={false} />
-      <ControlBar onkey={(seq) => conn?.send(seq)} include={["nav", "signal"]} />
+      <!-- Esc frozen on the left edge; Tab/Space + arrows + ^-keys scroll in the
+           middle; attach/dictate/Enter frozen on the right. Tab/Space ride along
+           in the scroll well so the frozen edge stays one button wide — on a
+           portrait phone a wider frozen cluster squeezed the scroll window to ~2
+           keys. There's no compose chip — swipe up from this row to summon the
+           compose sheet. -->
+      <ControlBar onkey={(seq) => conn?.send(seq)} include={["cancel"]} scroll={false} />
+      <ControlBar onkey={(seq) => conn?.send(seq)} include={["edit", "nav", "signal"]} />
       <!-- only while Claude's prompt offers it: a pulsing "add notes" key. There's
            no keyboard on a phone to press the letter, so this is the sole way into
            the dialog's notes branch; it pulses to catch the eye and vanishes once

--- a/ui/src/lib/controlKeys.ts
+++ b/ui/src/lib/controlKeys.ts
@@ -6,8 +6,9 @@ import { m } from "$lib/paraglide/messages";
 
 // Visual grouping for the bar: keys in the same group sit together in one
 // "well" (Gestalt common-region), with a wider gap between groups so a glance
-// tells which keys belong together.
-export type ControlGroup = "edit" | "nav" | "signal";
+// tells which keys belong together. "cancel" (Esc) is frozen on the left edge;
+// edit/nav/signal scroll in the middle (see ControlBar usage in Viewport).
+export type ControlGroup = "cancel" | "edit" | "nav" | "signal";
 
 // Optional colour accent carrying meaning (used sparingly so it stays a signal):
 // escape = the odd-one-out cancel key, danger = interrupts the process.
@@ -21,12 +22,12 @@ export interface ControlKey {
   tone?: ControlTone; // optional colour accent
 }
 
-// The scrolling palette, ordered by group. Enter is intentionally absent — it's
-// the primary affirmative action and lives pinned in the thumb zone, see
-// enterKey().
+// The control palette, ordered by group (Esc frozen left, the rest scroll in
+// the middle). Enter is intentionally absent — it's the primary affirmative
+// action and lives pinned in the thumb zone, see enterKey().
 export function controlKeys(): ControlKey[] {
   return [
-    { label: "Esc", aria: m.controlkey_escape(), seq: "\x1b", group: "edit", tone: "escape" },
+    { label: "Esc", aria: m.controlkey_escape(), seq: "\x1b", group: "cancel", tone: "escape" },
     { label: "Tab", aria: m.controlkey_tab(), seq: "\x09", group: "edit" },
     { label: "␣", aria: m.controlkey_space(), seq: " ", group: "edit" },
     { label: "←", aria: m.controlkey_arrow_left(), seq: "\x1b[D", group: "nav" },


### PR DESCRIPTION
## Problem

On a portrait phone the control-key bar froze **Esc / Tab / Space** on the left and pinned attach / dictate / Enter on the right. Those fixed clusters ate the row width, squeezing the middle scroll window to ~2 visible keys — too narrow to be useful.

## Fix

Move **Tab** and **Space** into the scrolling section; freeze only **Esc**. The frozen cluster shrinks from 3 buttons to 1, widening the scroll window by ~2 keys.

- `controlKeys.ts` — Esc gets its own new `cancel` group (Tab/Space stay in `edit`). Sequences/labels/arias unchanged.
- `Viewport.svelte` — frozen bar `include={["cancel"]}`; scroll bar `include={["edit","nav","signal"]}`.
- `ControlBar.svelte` — stale comment updated.

Scroll bar now: **Tab ␣** · **← → ↑ ↓** · **^A ^E ^C ^D**, with **Esc** frozen left and attach/dictate/⏎ frozen right.

## Verification

`bun run check` ✓ · `check:i18n` ✓ (parity, no new keys) · `bun run test` ✓ (233 passed) · prettier/eslint ✓ (pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)