### PR TITLE
fix(steerbar): align collapsed broadcast chip left edge with Esc key

### DIFF
--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -157,11 +157,15 @@
   }
   /* on mobile the broadcast chip collapses to just its 📡 icon to reclaim
      space; matches the ControlBar Esc key's box model (min-width 44px, no
-     horizontal padding) so the collapsed chip and Esc render an identical width */
+     horizontal padding) so the collapsed chip and Esc render an identical width.
+     Esc additionally sits inside a 3px-padded group "well", nudging its box that
+     far right of the bar edge — match it with an equal left margin so the two
+     left edges line up, not just the widths */
   @media (max-width: 768px) {
     .chip.bc {
       min-width: 44px;
       padding: 0;
+      margin-left: 3px;
     }
     .bc-label {
       display: none;


### PR DESCRIPTION
## Problem

PR #251 sized the collapsed 📡 broadcast chip to match the Esc key's **width**, but their **left edges** still drifted by 3px.

## Cause

ControlBar wraps each key group in a `.group` "well" with `padding: 3px`, so the Esc key's box starts 3px right of the bar edge (10px bar padding + 3px well = 13px). The broadcast chip is a direct child of `.steer-bar` with no well, so it starts at 10px.

## Fix

Add `margin-left: 3px` to the collapsed `.chip.bc` so it lines up with the Esc key's left edge — not just matches its width. CSS-only, no i18n keys touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)