### PR TITLE
fix(steer): bracketed-paste wrap so multi-line steers actually submit

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -324,8 +324,10 @@ export class SessionService {
    * embedded "\n" trips the heuristic — which is why short steers worked and reviews
    * didn't.) Wrapping the text in the bracketed-paste markers (ESC[200~ … ESC[201~)
    * gives an explicit paste-end, so the following CR is unambiguously Enter regardless
-   * of read boundaries — deterministic, no timing guesswork. Strip any stray end-marker
-   * from the payload so it can't close the paste early. Returns false if unknown.
+   * of read boundaries — deterministic, no timing guesswork. Strip any stray paste
+   * markers from the payload first: a leaked end-marker would close the paste early
+   * (turning the rest into live keystrokes), and a leaked start-marker is benign but
+   * dropped for symmetry. Returns false if unknown.
    */
   reply(id: string, text: string): boolean {
     const s = this.deps.store.get(id);
@@ -338,7 +340,7 @@ export class SessionService {
     });
     const PASTE_START = "\x1b[200~";
     const PASTE_END = "\x1b[201~";
-    const safe = text.replaceAll(PASTE_END, "");
+    const safe = text.replaceAll(PASTE_START, "").replaceAll(PASTE_END, "");
     this.deps.herdr.send(s.herdrAgentId, `${PASTE_START}${safe}${PASTE_END}`);
     this.deps.herdr.send(s.herdrAgentId, "\r");
     return true;

--- a/src/service.ts
+++ b/src/service.ts
@@ -313,13 +313,19 @@ export class SessionService {
   }
 
   /**
-   * Steer a session's live PTY (human-style): type the text, then submit it with
-   * a SEPARATE carriage return. The split is deliberate — herdr writes each `send`
-   * as one PTY chunk, so a multi-line steer (e.g. a pasted-in code review) glued to
-   * a trailing "\r" lands in Claude Code's input as a single paste-buffered blob and
-   * the CR is absorbed as just another newline, leaving the message typed-but-unsent.
-   * A discrete second write arrives as its own stdin chunk and registers as Enter, so
-   * one click both delivers and submits. Returns false if unknown.
+   * Steer a session's live PTY (human-style): deliver the text as a bracketed paste,
+   * then submit it with a carriage return.
+   *
+   * The wrap is load-bearing for multi-line steers (e.g. a pasted-in critic review).
+   * herdr does NOT bracket-wrap injected text, and back-to-back `send`s coalesce into a
+   * single PTY read — so a multi-line blob with a trailing "\r" reaches Claude Code as
+   * one chunk, trips its paste heuristic, and the CR is swallowed as just another
+   * newline: message typed-but-unsent. (Single-line steers escaped this because no
+   * embedded "\n" trips the heuristic — which is why short steers worked and reviews
+   * didn't.) Wrapping the text in the bracketed-paste markers (ESC[200~ … ESC[201~)
+   * gives an explicit paste-end, so the following CR is unambiguously Enter regardless
+   * of read boundaries — deterministic, no timing guesswork. Strip any stray end-marker
+   * from the payload so it can't close the paste early. Returns false if unknown.
    */
   reply(id: string, text: string): boolean {
     const s = this.deps.store.get(id);
@@ -330,7 +336,10 @@ export class SessionService {
       kind: "reply",
       payload: text,
     });
-    this.deps.herdr.send(s.herdrAgentId, text);
+    const PASTE_START = "\x1b[200~";
+    const PASTE_END = "\x1b[201~";
+    const safe = text.replaceAll(PASTE_END, "");
+    this.deps.herdr.send(s.herdrAgentId, `${PASTE_START}${safe}${PASTE_END}`);
     this.deps.herdr.send(s.herdrAgentId, "\r");
     return true;
   }

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -991,10 +991,11 @@ test("reply delivers the text as a bracketed paste, then submits with a carriage
   ]);
   expect(svc.reply("nope", "1")).toBe(false);
 
-  // A stray paste-end marker in the payload would close the paste early — strip it.
+  // Stray paste markers in the payload are stripped: a leaked end-marker would close
+  // the paste early; the start-marker is dropped for symmetry.
   sent.length = 0;
-  expect(svc.reply(s.id, "a\x1b[201~b")).toBe(true);
-  expect(sent[0]).toEqual({ target: "term_z", text: "\x1b[200~ab\x1b[201~" });
+  expect(svc.reply(s.id, "a\x1b[201~b\x1b[200~c")).toBe(true);
+  expect(sent[0]).toEqual({ target: "term_z", text: "\x1b[200~abc\x1b[201~" });
 });
 
 test("broadcast fans the text out to known sessions, skips unknown ids", () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -954,7 +954,7 @@ test("resume returns null for unknown, archived, or pre-feature sessions", () =>
   expect(svc.resume(preFeature.id)).toBeNull(); // nothing pinned to resume
 });
 
-test("reply types the text, then submits with a separate carriage return", () => {
+test("reply delivers the text as a bracketed paste, then submits with a carriage return", () => {
   const sent: { target: string; text: string }[] = [];
   const store = new SessionStore(":memory:");
   const s = store.create({
@@ -981,13 +981,20 @@ test("reply types the text, then submits with a separate carriage return", () =>
   });
 
   expect(svc.reply(s.id, "1")).toBe(true);
-  // Enter is a discrete second write so Claude Code submits it instead of
-  // absorbing the CR into a paste-buffered multi-line blob.
+  // Wrapping in bracketed-paste markers gives an explicit paste-end, so the trailing
+  // CR registers as Enter even when herdr coalesces the two writes into one PTY read
+  // (a bare multi-line blob + "\r" trips Claude Code's paste heuristic and swallows
+  // the CR, leaving the message typed-but-unsent).
   expect(sent).toEqual([
-    { target: "term_z", text: "1" },
+    { target: "term_z", text: "\x1b[200~1\x1b[201~" },
     { target: "term_z", text: "\r" },
   ]);
   expect(svc.reply("nope", "1")).toBe(false);
+
+  // A stray paste-end marker in the payload would close the paste early — strip it.
+  sent.length = 0;
+  expect(svc.reply(s.id, "a\x1b[201~b")).toBe(true);
+  expect(sent[0]).toEqual({ target: "term_z", text: "\x1b[200~ab\x1b[201~" });
 });
 
 test("broadcast fans the text out to known sessions, skips unknown ids", () => {
@@ -1022,9 +1029,9 @@ test("broadcast fans the text out to known sessions, skips unknown ids", () => {
   const res = svc.broadcast([a.id, "ghost", b.id], "run tests");
   expect(res).toEqual({ sent: 2, total: 3 });
   expect(sent).toEqual([
-    { target: "term_a", text: "run tests" },
+    { target: "term_a", text: "\x1b[200~run tests\x1b[201~" },
     { target: "term_a", text: "\r" },
-    { target: "term_b", text: "run tests" },
+    { target: "term_b", text: "\x1b[200~run tests\x1b[201~" },
     { target: "term_b", text: "\r" },
   ]);
 });


### PR DESCRIPTION
## Problem

Auto-pasted critic reviews (and any multi-line steer) landed in the agent's Claude Code input box but were **never submitted** — typed-but-unsent. Short single-line steers worked fine, which masked the bug.

## Root cause (verified at the byte level)

A faithful raw-mode + bracketed-paste probe of the PTY revealed the prior fix's premise was wrong:

- **herdr does not bracket-wrap injected text**, even when the app has enabled DECSET 2004.
- **Back-to-back `herdr agent send` calls coalesce into a single PTY `read()`** — `send(text)` + `send("\r")` arrive as one chunk `b'…\r'`.

So a multi-line review + trailing `\r` reaches Claude Code as one blob, trips its time-based paste heuristic, and the CR is absorbed as just another newline. The old comment claimed the second write *"arrives as its own stdin chunk and registers as Enter"* — it doesn't. Single-line steers escaped this because no embedded `\n` trips the heuristic (why short steers worked and reviews didn't).

## Fix

Wrap the payload in bracketed-paste markers (`ESC[200~ … ESC[201~`) before the carriage return. The explicit paste-end makes the following CR unambiguously **Enter**, regardless of read boundaries — deterministic, no timing/sleep guesswork. Stray end-markers in the payload are stripped so they can't close the paste early.

This path (`reply()`) backs the auto-address loop, the manual "send review to agent" button, and broadcast steers — all three are fixed.

## Verification

- Reproduced the bug against a **live Claude Code agent**: multi-line text + separate `\r` → sat unsent in the input box.
- Confirmed the bracketed-paste fix **submits cleanly** against the same live agent (sent back-to-back/coalesced), input box returns empty.
- Updated `reply`/`broadcast` unit tests to assert the wrap + strip behavior.
- `bun run lint`, `bunx tsc --noEmit`, full root suite (720 pass / 0 fail) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)