### PR TITLE
fix(controlbar): drop scrolling bar's left gutter so Esc→Tab gap isn't doubled

### DIFF
--- a/ui/src/lib/components/ControlBar.svelte
+++ b/ui/src/lib/components/ControlBar.svelte
@@ -96,7 +96,10 @@
     /* wide gap between groups; keys *within* a group sit tight (see .group) so
        proximity tells which keys belong together */
     gap: 10px;
-    padding: 6px 0 6px 10px;
+    /* no horizontal gutter by default — the leading frozen .noscroll bar owns the
+       left gutter (see below); a trailing scrolling bar must not repeat it or it
+       opens a double gap from the frozen edge (e.g. Esc→Tab) */
+    padding: 6px 0;
     overflow-x: auto;
     white-space: nowrap;
     /* take remaining row width and allow shrink-to-fit so the internal
@@ -109,11 +112,13 @@
   .ctrl-bar::-webkit-scrollbar {
     display: none;
   }
-  /* fixed edge cluster (e.g. Esc/Tab): fit content, never grow or scroll */
+  /* fixed edge cluster (e.g. Esc): fit content, never grow or scroll. Owns the
+     row's left gutter (10px) which — with the group's 3px well padding — lines
+     Esc's left edge up with the collapsed broadcast chip above it. */
   .ctrl-bar.noscroll {
     flex: 0 0 auto;
     overflow: visible;
-    padding-right: 0;
+    padding-left: 10px;
   }
 
   /* one "well" per group — faint common-region backing so the eye chunks


### PR DESCRIPTION
## Problem

After aligning the **Esc** key with the collapsed 📡 broadcast chip, there was too much room between **Esc** and **Tab** in the mobile control row.

## Cause

The `.ctrl-row` holds two `ControlBar`s: the frozen **Esc** bar (`scroll={false}`) and the scrolling **Tab/Space + arrows + ^-keys** bar. Both inherited the shared `.ctrl-bar` **10px left gutter**. That gutter is what (with the group's 3px well) aligns Esc to the broadcast chip — but the *trailing* scrolling bar repeated it on top of the `.ctrl-row` gap, opening ~22px between Esc and Tab vs. the normal ~16px inter-group gap.

## Fix

Move the left gutter off the shared `.ctrl-bar` base (now `padding: 6px 0`) onto `.noscroll` only.

- **Esc still aligns to the collapsed broadcast chip** — the frozen bar keeps its 10px gutter.
- **Esc→Tab gap is now the 6px `.ctrl-row` gap**, consistent with the gap between the Tab bar and the attach/dictate/Enter buttons.

Pure CSS in `ControlBar.svelte`. `cd ui && bun run check` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)