### PR TITLE
fix(newtask): seed issue title into task prompt for sane session names

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -138,7 +138,7 @@
   "newtask_attach_image": "📎 Bild anhängen",
   "newtask_drop_hint": "oder Screenshots hier ablegen",
   "newtask_remove_image_aria": "entfernen",
-  "newtask_issue_prompt_template": "Bearbeite Issue #{number} wie beschrieben.",
+  "newtask_issue_prompt_template": "Bearbeite Issue #{number}: {title}",
   "newtask_issue_attached_label": "Angehängtes Issue",
   "newtask_issue_remove_aria": "Angehängtes Issue entfernen",
   "newtask_repo_label": "Repo",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -138,7 +138,7 @@
   "newtask_attach_image": "📎 Attach image",
   "newtask_drop_hint": "or drop screenshots here",
   "newtask_remove_image_aria": "remove",
-  "newtask_issue_prompt_template": "Work on issue #{number} as described.",
+  "newtask_issue_prompt_template": "Work on issue #{number}: {title}",
   "newtask_issue_attached_label": "Attached issue",
   "newtask_issue_remove_aria": "Remove attached issue",
   "newtask_repo_label": "Repo",

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -35,7 +35,7 @@
 
   /** Short editable seed so the user only adds deltas; the body rides out-of-band. */
   function issueTemplate(issue: Issue): string {
-    return m.newtask_issue_prompt_template({ number: issue.number });
+    return m.newtask_issue_prompt_template({ number: issue.number, title: issue.title });
   }
 
   // intentional one-time seed; NewTask remounts per open


### PR DESCRIPTION
## Problem

Starting a task from an issue seeded the prompt with boilerplate `Work on issue #{number} as described.`. The auto-namer derives the session name from that prompt, so with only the issue number to go on it produced nonsensical session names.

## Fix

Include the issue title verbatim in the seed template so the namer has real words to work with:

- `Work on issue #{number}: {title}` (EN)
- `Bearbeite Issue #{number}: {title}` (DE)

`NewTask.svelte`'s `issueTemplate()` now passes `issue.title` through. The title is data passed verbatim (interpolated param), the chrome stays translated. Issue body still rides out-of-band.

## Verification

- `cd ui && bun run check:i18n` → 2 locales in parity (432 keys)
- `cd ui && bun run check` → 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)