### PR TITLE
feat(critic): #247 follow-up polish for auto-address loop

### DIFF
--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -370,12 +370,17 @@ export class GithubForge implements GitForge {
     ]);
     const parsed = JSON.parse(out || "{}") as {
       comments?: {
+        id?: string | null;
+        url?: string | null;
         author?: { login?: string } | null;
         body?: string | null;
         createdAt?: string | null;
       }[];
     };
     return (parsed.comments ?? []).map((c) => ({
+      // gh exposes a node `id`; fall back to the comment url (also unique) so the
+      // per-round dedup always has a stable key even if one field is absent.
+      id: c.id ?? c.url ?? "",
       author: c.author?.login ?? "",
       body: c.body ?? "",
       createdAt: c.createdAt ? Date.parse(c.createdAt) : 0,

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -23,6 +23,10 @@ export const AUTHOR_RESPONSE_MARKER = "<!-- shepherd-author-note -->";
 
 /** One issue comment on a PR (author responses to review rounds). */
 export interface PrComment {
+  /** Host-stable comment id, used to inject each author note into the critic exactly
+   *  once (scoped to the round it responded to) rather than re-feeding every marked
+   *  comment on every re-review. Empty when the host can't supply one. */
+  id: string;
   author: string;
   body: string;
   createdAt: number; // epoch ms

--- a/src/review.ts
+++ b/src/review.ts
@@ -336,7 +336,10 @@ export class ReviewService {
         // freshly-fetched notes — roll the seen set back so they re-inject next round
         // instead of being silently swallowed by an error pass.
         verdict.seenNoteIds = f.priorSeenNoteIds;
-        if (verdict.errorRound === this.cap) {
+        // Escalate once, when the streak first reaches the cap. `>=` with a crossing guard
+        // (not `=== cap`) so a cap lowered between runs still fires rather than being
+        // stepped over, while errors past the cap don't re-signal every tick.
+        if (verdict.errorRound >= this.cap && f.priorErrorRound < this.cap) {
           this.deps.store.addSignal({
             repoPath: f.repoPath,
             sessionId: f.sessionId,
@@ -398,9 +401,11 @@ export class ReviewService {
     // this streak rather than resetting — the cap bounds total agent churn per PR, which
     // is fine for the prototype. Revisit if per-issue rounds become the intended model.
     if (f.priorRound >= this.cap) return f.priorRound; // gave up → hold (stalled badge persists)
-    // A dead pane makes herdr.send (execFileSync) throw rather than return false, so a
-    // throw counts as not-delivered too — the round must not advance on a steer that
-    // never landed, and the throw must not strand finalize().
+    // autoAddress (SessionService.reply) liveness-checks the pane and returns false for a
+    // dead one, so a steer that can't land normally reports false. A throw is now only a
+    // narrow race — the pane dies between the liveness check and herdr.send — and still
+    // counts as not-delivered: the round must not advance on a steer that never landed,
+    // and the throw must not strand finalize().
     let delivered = false;
     try {
       delivered = this.deps.autoAddress!(f.sessionId, steerText(verdict.findings, f.prNumber));

--- a/src/review.ts
+++ b/src/review.ts
@@ -63,10 +63,10 @@ function steerText(findings: string[], prNumber: number): string {
 }
 
 const VERDICT_FILE = ".shepherd-review.json";
-// Max auto-address steers per outstanding-findings streak. The UI mirrors this as
-// CRITIC_ROUND_CAP (ui/.../critic-badge.ts) for the round/stalled badge math; if this
-// ever becomes a per-deployment `deps.cap`, surface it in the verdict/config payload and
-// drop the UI constant rather than letting the two drift.
+// Max auto-address steers per outstanding-findings streak, and the same ceiling for the
+// consecutive-error counter. Surfaced on every verdict as `addressCap`, so the UI badge
+// reads it off the payload instead of mirroring this number (which would silently drift
+// if `deps.cap` ever varies per deployment).
 const DEFAULT_CAP = 3;
 
 interface InFlight {
@@ -78,6 +78,9 @@ interface InFlight {
   terminalId: string;
   startedAt: number;
   priorRound: number; // auto-address steers already spent on this findings streak
+  priorErrorRound: number; // consecutive critic error/timeout verdicts before this run
+  priorSeenNoteIds: string[]; // seen-note set carried in (before this run's fetch)
+  seenNoteIds: string[]; // priorSeen + notes fed to THIS run's critic; only "consumed" on a real verdict
   finalizing?: boolean;
 }
 
@@ -156,16 +159,27 @@ export class ReviewService {
     const prior = this.deps.store.getReview(session.id);
     const priorFindings = prior?.findings ?? [];
     const priorRound = prior?.addressRound ?? 0;
+    const priorErrorRound = prior?.errorRound ?? 0;
     // On a re-review under auto-address, pull the author's PR notes so a justified
     // decline isn't blindly re-raised. Gated on autoAddressEnabled (the path that
     // creates those notes) so critic-only repos make no extra forge call. This is
     // the one async step; a first review skips it and stays fully synchronous.
+    //
+    // Inject only notes NOT already shown to the critic on an earlier round (tracked
+    // by comment id, carried on the prior verdict): each note responded to one round's
+    // findings, so re-feeding every marked comment every round would grow the prompt
+    // unboundedly and resurrect stale justifications. Id-based — never timestamp-based:
+    // the host clock and GitHub's comment clock can skew and drop a valid decline.
+    const priorSeenNoteIds = prior?.seenNoteIds ?? [];
+    let seenNoteIds = priorSeenNoteIds;
     let authorNotes: string[] = [];
     if (
       priorFindings.length &&
       this.deps.store.getRepoConfig(session.repoPath).autoAddressEnabled
     ) {
-      authorNotes = await this.fetchAuthorNotes(session.repoPath, git.number!);
+      const fresh = await this.fetchAuthorNotes(session.repoPath, git.number!, priorSeenNoteIds);
+      authorNotes = fresh.notes;
+      seenNoteIds = [...priorSeenNoteIds, ...fresh.ids];
     }
     // forget() (session archived) may have fired during the await above; it clears our
     // `starting` claim as a tombstone. Abort before allocating a worktree/critic so we
@@ -247,25 +261,42 @@ export class ReviewService {
       terminalId,
       startedAt: this.now(),
       priorRound,
+      priorErrorRound,
+      priorSeenNoteIds,
+      seenNoteIds,
     });
     this.deps.onReviewing?.(session.id, true);
   }
 
-  /** Read the author's marked decline notes back off the PR (best-effort; [] on any
-   *  failure, on a host without a comments API, or when nothing is marked). The
-   *  marker is stripped so only the author's reasoning reaches the critic prompt. */
-  private async fetchAuthorNotes(repoPath: string, prNumber: number): Promise<string[]> {
+  /** Read the author's marked decline notes back off the PR, restricted to comments not
+   *  already fed to the critic on an earlier round (`seenIds`). Returns the stripped note
+   *  bodies and the ids that backed them (so the caller can mark them seen). Best-effort:
+   *  empty on any failure, on a host without a comments API, or when nothing new is marked.
+   *  The marker is stripped so only the author's reasoning reaches the critic prompt. */
+  private async fetchAuthorNotes(
+    repoPath: string,
+    prNumber: number,
+    seenIds: string[],
+  ): Promise<{ notes: string[]; ids: string[] }> {
     const forge = this.deps.resolveForge(repoPath);
-    if (!forge?.listPrComments) return [];
+    if (!forge?.listPrComments) return { notes: [], ids: [] };
     try {
+      const seen = new Set(seenIds);
       const comments = await forge.listPrComments(prNumber);
-      return comments
-        .filter((c) => c.body.includes(AUTHOR_RESPONSE_MARKER))
-        .map((c) => c.body.split(AUTHOR_RESPONSE_MARKER).join("").trim())
-        .filter(Boolean);
+      const notes: string[] = [];
+      const ids: string[] = [];
+      for (const c of comments) {
+        if (!c.body.includes(AUTHOR_RESPONSE_MARKER)) continue;
+        if (c.id && seen.has(c.id)) continue; // already shown on an earlier round
+        const note = c.body.split(AUTHOR_RESPONSE_MARKER).join("").trim();
+        if (!note) continue;
+        notes.push(note);
+        if (c.id) ids.push(c.id); // id-less hosts: note still injected, just not deduped
+      }
+      return { notes, ids };
     } catch (err) {
       console.warn(`[review] listPrComments failed for ${repoPath}#${prNumber}:`, err);
-      return [];
+      return { notes: [], ids: [] };
     }
   }
 
@@ -293,7 +324,27 @@ export class ReviewService {
     // (a forge/store/steer failure must not strand them).
     try {
       const verdict = this.buildVerdict(f, raw);
-      if (verdict.decision !== "error") {
+      if (verdict.decision === "error") {
+        // A transient critic failure (timeout / unparseable verdict) posts nothing and
+        // has no findings to steer. Don't let it pose as "clean": count it on a separate
+        // no-progress streak so a flapping critic still escalates instead of looping
+        // forever, and preserve the findings round (those findings are still outstanding,
+        // just un-reverified this push).
+        verdict.errorRound = f.priorErrorRound + 1;
+        verdict.addressRound = f.priorRound;
+        // The critic never produced a verdict, so it didn't actually consider this run's
+        // freshly-fetched notes — roll the seen set back so they re-inject next round
+        // instead of being silently swallowed by an error pass.
+        verdict.seenNoteIds = f.priorSeenNoteIds;
+        if (verdict.errorRound === this.cap) {
+          this.deps.store.addSignal({
+            repoPath: f.repoPath,
+            sessionId: f.sessionId,
+            kind: "stall",
+            payload: `critic produced ${verdict.errorRound} consecutive error verdicts for this PR — auto-address can't make progress`,
+          });
+        }
+      } else {
         const forge = this.deps.resolveForge(f.repoPath);
         if (forge) {
           try {
@@ -307,8 +358,8 @@ export class ReviewService {
             console.warn(`[review] postReview failed for ${f.sessionId}:`, err);
           }
         }
+        verdict.addressRound = this.runAutoAddress(f, verdict); // errorRound stays 0 on a real verdict
       }
-      verdict.addressRound = this.runAutoAddress(f, verdict);
       this.deps.store.putReview(verdict);
       if (verdict.decision === "changes_requested") {
         this.deps.store.addSignal({
@@ -328,7 +379,9 @@ export class ReviewService {
 
   /**
    * Close the loop: feed the verdict's findings back to the task agent and return the
-   * new streak round. Empty findings = clean → reset to 0. Otherwise, if auto-address
+   * new streak round. Only real (non-error) verdicts reach here — error verdicts are
+   * counted on the separate no-progress streak in finalize(). Empty findings = clean
+   * (e.g. a "comment" verdict with nothing left to fix) → reset to 0. Otherwise, if auto-address
    * is enabled and the prior round is under the cap, steer once and advance — but only
    * if the steer actually reached the agent (a dead/unreachable pane holds the round).
    * At/over the cap we stop steering and leave the round in place; the posted review,
@@ -377,6 +430,9 @@ export class ReviewService {
       body: raw && typeof raw.body === "string" ? raw.body : "",
       findings,
       addressRound: 0, // finalize() overwrites with the streak round
+      addressCap: this.cap, // surface the live cap so the UI badge need not mirror it
+      errorRound: 0, // finalize() overwrites on an error verdict
+      seenNoteIds: f.seenNoteIds, // carry the per-round note dedup set forward
       updatedAt: this.now(),
     };
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -512,6 +512,10 @@ async function handleSessionReply({ req, parts, deps }: Ctx): Promise<Response |
   if (!body || typeof (body as { text?: unknown }).text !== "string") {
     return json({ error: "body must be {text: string}" }, 400);
   }
+  // reply() returns false for an unknown id, a dead pane, OR a transient herdr-unreachable
+  // (it can't confirm liveness, so it can't deliver) — all collapse to 404 here. The last
+  // case is rare and "couldn't deliver" is honest; differentiating would need a richer
+  // return than the boolean that broadcast()/auto-address also rely on.
   const ok = deps.service.reply(parts[2], (body as { text: string }).text);
   return ok ? json({ ok: true }) : json({ error: "not found" }, 404);
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -341,11 +341,40 @@ export class SessionService {
    * of read boundaries — deterministic, no timing guesswork. Strip any stray paste
    * markers from the payload first: a leaked end-marker would close the paste early
    * (turning the rest into live keystrokes), and a leaked start-marker is benign but
-   * dropped for symmetry. Returns false if unknown.
+   * dropped for symmetry. Returns false when the session is unknown OR its pane is dead
+   * (claude exited / terminal reaped) — a live store row can still back a dead pane,
+   * which would make herdr.send throw. The up-front liveness check keeps reply an honest,
+   * non-throwing boolean for human steers, and hands the auto-address loop a clean
+   * "not delivered" instead of relying on it to catch the throw downstream.
    */
   reply(id: string, text: string): boolean {
+    return this.replyToLive(id, text, this.liveTerminalIds());
+  }
+
+  /** Fan a steer out to many sessions (human-style). Skips unknown ids and dead panes.
+   *  Lists herdr's live agents ONCE up front rather than per id, so a wide fan-out
+   *  doesn't spawn one blocking `herdr agent list` per target. */
+  broadcast(ids: string[], text: string): { sent: number; total: number } {
+    const live = this.liveTerminalIds();
+    let sent = 0;
+    for (const id of ids) if (this.replyToLive(id, text, live)) sent++;
+    return { sent, total: ids.length };
+  }
+
+  /** Terminal ids herdr currently lists as live. Empty when herdr can't be reached, so
+   *  callers treat an unlisted agent as a dead pane (the steer won't land). */
+  private liveTerminalIds(): Set<string> {
+    try {
+      return new Set(this.deps.herdr.list().map((a) => a.terminalId));
+    } catch {
+      return new Set();
+    }
+  }
+
+  /** Steer one session against a pre-fetched live set. False on unknown id or dead pane. */
+  private replyToLive(id: string, text: string, live: Set<string>): boolean {
     const s = this.deps.store.get(id);
-    if (!s) return false;
+    if (!s || !live.has(s.herdrAgentId)) return false; // unknown, or live-in-store / dead-pane
     this.deps.store.addSignal({
       repoPath: s.repoPath,
       sessionId: s.id,
@@ -358,13 +387,6 @@ export class SessionService {
     this.deps.herdr.send(s.herdrAgentId, `${PASTE_START}${safe}${PASTE_END}`);
     this.deps.herdr.send(s.herdrAgentId, "\r");
     return true;
-  }
-
-  /** Fan a steer out to many sessions (human-style). Skips unknown ids. */
-  broadcast(ids: string[], text: string): { sent: number; total: number } {
-    let sent = 0;
-    for (const id of ids) if (this.reply(id, text)) sent++;
-    return { sent, total: ids.length };
   }
 
   /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -116,6 +116,8 @@ export class SessionStore implements CapStore {
       sessionId TEXT PRIMARY KEY, headSha TEXT NOT NULL, decision TEXT NOT NULL,
       summary TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '',
       findings TEXT NOT NULL DEFAULT '[]', addressRound INTEGER NOT NULL DEFAULT 0,
+      addressCap INTEGER NOT NULL DEFAULT 3, errorRound INTEGER NOT NULL DEFAULT 0,
+      seenNoteIds TEXT NOT NULL DEFAULT '[]',
       url TEXT, updatedAt INTEGER NOT NULL)`);
     // migrate reviews that predate the auto-address loop columns
     const reviewCols = this.db.query(`PRAGMA table_info(reviews)`).all() as { name: string }[];
@@ -124,6 +126,18 @@ export class SessionStore implements CapStore {
     }
     if (!reviewCols.some((c) => c.name === "addressRound")) {
       this.db.run(`ALTER TABLE reviews ADD COLUMN addressRound INTEGER NOT NULL DEFAULT 0`);
+    }
+    // addressCap's DEFAULT 3 only backfills pre-#247 rows; every live row carries
+    // ReviewService's actual cap, so the literal here is a one-time migration value, not
+    // an ongoing mirror. errorRound/seenNoteIds back the error-escalation + note dedup.
+    if (!reviewCols.some((c) => c.name === "addressCap")) {
+      this.db.run(`ALTER TABLE reviews ADD COLUMN addressCap INTEGER NOT NULL DEFAULT 3`);
+    }
+    if (!reviewCols.some((c) => c.name === "errorRound")) {
+      this.db.run(`ALTER TABLE reviews ADD COLUMN errorRound INTEGER NOT NULL DEFAULT 0`);
+    }
+    if (!reviewCols.some((c) => c.name === "seenNoteIds")) {
+      this.db.run(`ALTER TABLE reviews ADD COLUMN seenNoteIds TEXT NOT NULL DEFAULT '[]'`);
     }
     this.db.run(`CREATE TABLE IF NOT EXISTS signals (
       id TEXT PRIMARY KEY, repoPath TEXT NOT NULL, sessionId TEXT,
@@ -374,6 +388,9 @@ export class SessionStore implements CapStore {
       ...r,
       findings: parseFindings(r.findings),
       addressRound: r.addressRound ?? 0,
+      addressCap: r.addressCap ?? 3,
+      errorRound: r.errorRound ?? 0,
+      seenNoteIds: parseFindings(r.seenNoteIds), // same string[] JSON shape as findings
       url: r.url ?? undefined,
     } as ReviewVerdict;
   }
@@ -381,7 +398,8 @@ export class SessionStore implements CapStore {
   getReview(sessionId: string): ReviewVerdict | null {
     const r = this.db
       .query(
-        `SELECT sessionId, headSha, decision, summary, body, findings, addressRound, url, updatedAt
+        `SELECT sessionId, headSha, decision, summary, body, findings, addressRound,
+                addressCap, errorRound, seenNoteIds, url, updatedAt
               FROM reviews WHERE sessionId = ?`,
       )
       .get(sessionId) as any;
@@ -390,11 +408,14 @@ export class SessionStore implements CapStore {
 
   putReview(v: ReviewVerdict): void {
     this.db.run(
-      `INSERT INTO reviews (sessionId, headSha, decision, summary, body, findings, addressRound, url, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?,?)
+      `INSERT INTO reviews (sessionId, headSha, decision, summary, body, findings, addressRound,
+         addressCap, errorRound, seenNoteIds, url, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET headSha=excluded.headSha, decision=excluded.decision,
          summary=excluded.summary, body=excluded.body, findings=excluded.findings,
-         addressRound=excluded.addressRound, url=excluded.url, updatedAt=excluded.updatedAt`,
+         addressRound=excluded.addressRound, addressCap=excluded.addressCap,
+         errorRound=excluded.errorRound, seenNoteIds=excluded.seenNoteIds,
+         url=excluded.url, updatedAt=excluded.updatedAt`,
       [
         v.sessionId,
         v.headSha,
@@ -403,6 +424,9 @@ export class SessionStore implements CapStore {
         v.body,
         JSON.stringify(v.findings ?? []),
         v.addressRound ?? 0,
+        v.addressCap ?? 3,
+        v.errorRound ?? 0,
+        JSON.stringify(v.seenNoteIds ?? []),
         v.url ?? null,
         v.updatedAt,
       ],
@@ -416,7 +440,8 @@ export class SessionStore implements CapStore {
   snapshotReviews(): Record<string, ReviewVerdict> {
     const rows = this.db
       .query(
-        `SELECT sessionId, headSha, decision, summary, body, findings, addressRound, url, updatedAt FROM reviews`,
+        `SELECT sessionId, headSha, decision, summary, body, findings, addressRound,
+                addressCap, errorRound, seenNoteIds, url, updatedAt FROM reviews`,
       )
       .all() as any[];
     const out: Record<string, ReviewVerdict> = {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,9 @@ export interface ReviewVerdict {
   body: string; // full markdown findings (seeds the steer-back)
   findings: string[]; // discrete actionable items; [] = nothing to address (loop terminates)
   addressRound: number; // auto-address steers spent on the current findings streak (0 = clean/reset)
+  addressCap: number; // the streak cap this run used — surfaced so the UI badge math need not mirror it
+  errorRound: number; // consecutive critic error/timeout verdicts (separate no-progress counter; 0 on any real verdict)
+  seenNoteIds: string[]; // ids of author notes already fed to the critic, so each is injected only once
   url?: string; // posted PR-review URL, when the host returns one
   updatedAt: number;
 }

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -459,19 +459,30 @@ test("GithubForge.postReview: request-changes falls back to pr comment when revi
   expect(calls[1]).toEqual(["pr", "comment", "7", "--repo", "o/r", "--body", "nope"]);
 });
 
-test("GithubForge.listPrComments: parses author/body/createdAt from gh pr view", async () => {
+test("GithubForge.listPrComments: parses id/author/body/createdAt from gh pr view", async () => {
   const COMMENTS_JSON = JSON.stringify({
     comments: [
-      { author: { login: "alice" }, body: "first", createdAt: "2024-02-02T00:00:00Z" },
-      { author: { login: "bob" }, body: "second", createdAt: "2024-02-03T00:00:00Z" },
+      { id: "IC_1", author: { login: "alice" }, body: "first", createdAt: "2024-02-02T00:00:00Z" },
+      // no id → falls back to the comment url so per-round dedup still has a stable key
+      {
+        url: "https://gh/c/2",
+        author: { login: "bob" },
+        body: "second",
+        createdAt: "2024-02-03T00:00:00Z",
+      },
     ],
   });
   const { run, calls } = fakeRunner({ "pr view": COMMENTS_JSON });
   const forge = new GithubForge("o/r", {}, run);
   const comments = await forge.listPrComments(7);
   expect(comments).toEqual([
-    { author: "alice", body: "first", createdAt: Date.parse("2024-02-02T00:00:00Z") },
-    { author: "bob", body: "second", createdAt: Date.parse("2024-02-03T00:00:00Z") },
+    { id: "IC_1", author: "alice", body: "first", createdAt: Date.parse("2024-02-02T00:00:00Z") },
+    {
+      id: "https://gh/c/2",
+      author: "bob",
+      body: "second",
+      createdAt: Date.parse("2024-02-03T00:00:00Z"),
+    },
   ]);
   expect(calls[0]).toEqual(["pr", "view", "7", "--repo", "o/r", "--json", "comments"]);
 });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -292,6 +292,9 @@ test("forget reaps an in-flight critic and drops the stored review", () => {
     body: "",
     findings: [],
     addressRound: 0,
+    addressCap: 3,
+    errorRound: 0,
+    seenNoteIds: [],
     updatedAt: 1,
   };
   svc.forget("s1");
@@ -393,6 +396,9 @@ test("clean verdict (no findings) stops the loop and resets the round", async ()
     body: "",
     findings: ["was broken"],
     addressRound: 2,
+    addressCap: 3,
+    errorRound: 0,
+    seenNoteIds: [],
     updatedAt: 1,
   };
   const svc = new ReviewService(d as any);
@@ -428,6 +434,9 @@ test("round cap reached: holds the round, posts the review + signal, does not st
     body: "",
     findings: ["still broken"],
     addressRound: 3, // == cap: the agent has had its 3 tries
+    addressCap: 3,
+    errorRound: 0,
+    seenNoteIds: [],
     updatedAt: 1,
   };
   const svc = new ReviewService(d as any);
@@ -466,6 +475,9 @@ function priorReview(over: Partial<ReviewVerdict> = {}): ReviewVerdict {
     body: "",
     findings: ["fix the race in worker.ts"],
     addressRound: 1,
+    addressCap: 3,
+    errorRound: 0,
+    seenNoteIds: [],
     updatedAt: 1,
     ...over,
   };
@@ -504,8 +516,9 @@ test("re-review fetches the author's PR notes and injects them into the prompt",
     {
       autoAddressEnabled: true,
       comments: [
-        { author: "me", body: "unrelated chatter", createdAt: 1 },
+        { id: "c1", author: "me", body: "unrelated chatter", createdAt: 1 },
         {
+          id: "c2",
           author: "me",
           body: `${AUTHOR_RESPONSE_MARKER} #2 is intentional: it mirrors the spec`,
           createdAt: 2,
@@ -581,4 +594,118 @@ test("forget() during the re-review await aborts the spawn (no critic for an arc
   await p;
   expect(started).toHaveLength(0); // begin saw the forget and aborted before spawning
   expect(svc.reviewingIds()).toEqual([]); // nothing left in flight
+});
+
+// ── follow-up polish (#247) ─────────────────────────────────────────────────────
+
+test("verdict surfaces the configured cap so the UI need not mirror it", async () => {
+  const { deps: d, reviews } = makeDeps({ cap: 5 });
+  const svc = new ReviewService(d as any);
+  svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.addressCap).toBe(5); // ReviewService({cap}) → verdict payload
+});
+
+test("re-review injects only author notes not already shown on an earlier round", async () => {
+  const {
+    deps: d,
+    reviews,
+    started,
+  } = makeDeps(
+    {},
+    {
+      autoAddressEnabled: true,
+      comments: [
+        {
+          id: "c2",
+          author: "me",
+          body: `${AUTHOR_RESPONSE_MARKER} round-1 note (already seen)`,
+          createdAt: 1,
+        },
+        {
+          id: "c3",
+          author: "me",
+          body: `${AUTHOR_RESPONSE_MARKER} round-2 note (new)`,
+          createdAt: 2,
+        },
+      ],
+    },
+  );
+  // a streak already injected c2 on the previous round
+  reviews["s1"] = priorReview({ seenNoteIds: ["c2"] });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  const prompt = started[0]!.argv.at(-1)!;
+  expect(prompt).toContain("round-2 note (new)"); // the fresh note reaches the critic
+  expect(prompt).not.toContain("round-1 note (already seen)"); // the stale one does not re-feed
+  await svc.tick();
+  expect(reviews["s1"]?.seenNoteIds).toEqual(["c2", "c3"]); // dedup set carried forward
+});
+
+test("consecutive critic errors escalate via a stall signal at the cap", async () => {
+  const {
+    deps: d,
+    reviews,
+    signals,
+  } = makeDeps({ readVerdict: () => ({ decision: "junk", summary: "boom", body: "" }) });
+  // two errors already on the no-progress streak; this one hits cap (3)
+  reviews["s1"] = priorReview({ errorRound: 2, addressRound: 1 });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.decision).toBe("error");
+  expect(reviews["s1"]?.errorRound).toBe(3); // separate counter advanced
+  expect(reviews["s1"]?.addressRound).toBe(1); // findings streak preserved, NOT reset to clean
+  expect(signals.some((s) => s.kind === "stall")).toBe(true); // escalates to the human
+});
+
+test("a critic error below the cap bumps the error streak without escalating", async () => {
+  const {
+    deps: d,
+    reviews,
+    signals,
+  } = makeDeps({ readVerdict: () => ({ decision: "junk", summary: "boom", body: "" }) });
+  reviews["s1"] = priorReview({ errorRound: 0, addressRound: 2 });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.errorRound).toBe(1);
+  expect(reviews["s1"]?.addressRound).toBe(2); // preserved
+  expect(signals.some((s) => s.kind === "stall")).toBe(false); // not yet at the cap
+});
+
+test("a real verdict resets the error streak", async () => {
+  const { deps: d, reviews } = makeDeps(
+    { readVerdict: () => ({ decision: "comment", summary: "ok", body: "b", findings: [] }) },
+    { autoAddressEnabled: true },
+  );
+  reviews["s1"] = priorReview({ errorRound: 2 });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.errorRound).toBe(0); // any successful verdict clears the no-progress streak
+});
+
+test("an error verdict does not consume freshly-fetched author notes (re-inject next round)", async () => {
+  const {
+    deps: d,
+    reviews,
+    started,
+  } = makeDeps(
+    { readVerdict: () => ({ decision: "junk", summary: "boom", body: "" }) },
+    {
+      autoAddressEnabled: true,
+      comments: [
+        { id: "c9", author: "me", body: `${AUTHOR_RESPONSE_MARKER} a fresh note`, createdAt: 1 },
+      ],
+    },
+  );
+  reviews["s1"] = priorReview({ seenNoteIds: [] }); // re-review fetches + injects c9
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  expect(started[0]!.argv.at(-1)).toContain("a fresh note"); // the note reached the (doomed) critic
+  await svc.tick();
+  expect(reviews["s1"]?.decision).toBe("error");
+  // the errored critic never produced a verdict on c9, so it must NOT be marked seen
+  expect(reviews["s1"]?.seenNoteIds).toEqual([]);
 });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -659,6 +659,21 @@ test("consecutive critic errors escalate via a stall signal at the cap", async (
   expect(signals.some((s) => s.kind === "stall")).toBe(true); // escalates to the human
 });
 
+test("errors past the cap do not re-signal (escalates once, on crossing)", async () => {
+  const {
+    deps: d,
+    reviews,
+    signals,
+  } = makeDeps({ readVerdict: () => ({ decision: "junk", summary: "boom", body: "" }) });
+  // already over the cap (escalated on an earlier round) — a further error must stay quiet
+  reviews["s1"] = priorReview({ errorRound: 3 });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.errorRound).toBe(4); // counter keeps climbing
+  expect(signals.some((s) => s.kind === "stall")).toBe(false); // but the loud signal fired once, on crossing
+});
+
 test("a critic error below the cap bumps the error streak without escalating", async () => {
   const {
     deps: d,

--- a/test/server-reviews.test.ts
+++ b/test/server-reviews.test.ts
@@ -43,6 +43,9 @@ test("GET /api/reviews returns snapshot when reviewCache is present", async () =
     body: "Full body here",
     findings: [],
     addressRound: 0,
+    addressCap: 3,
+    errorRound: 0,
+    seenNoteIds: [],
     updatedAt: 1000,
   };
   const { app } = harness({ snapshot: () => ({ "sess-1": verdict }) });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -20,7 +20,9 @@ beforeEach(() => {
 
 afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
 
-function makeDeps(): AppDeps {
+// liveTerminals: terminal ids herdr should report as live (drives reply()'s pane-liveness
+// check). Defaults to none — resume/most tests assume the started pane is already dead.
+function makeDeps(liveTerminals: string[] = []): AppDeps {
   const store = new SessionStore(":memory:");
   const events = new EventHub();
   const service = new SessionService({
@@ -40,7 +42,7 @@ function makeDeps(): AppDeps {
         tabId: "t",
         workspaceId: "w",
       }),
-      list: () => [],
+      list: () => liveTerminals.map((terminalId) => ({ terminalId })),
       stop: () => {},
       send: () => {},
     } as any,
@@ -626,7 +628,7 @@ test("POST /api/uploads rejects a non-image", async () => {
 });
 
 test("POST /api/sessions/:id/reply types into the agent and 404s unknown ids", async () => {
-  const app = harness();
+  const app = makeApp(makeDeps(["term_x"])); // created session's pane (term_x) reads as live
   const created = await (
     await postSessions(app, { repoPath: validRepo, baseBranch: "main", prompt: "go" })
   ).json();

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -978,7 +978,7 @@ test("reply delivers the text as a bracketed paste, then submits with a carriage
     worktree: { create: () => ({}) as any, remove: () => {} } as any,
     herdr: {
       start: () => ({}) as any,
-      list: () => [],
+      list: () => [{ terminalId: "term_z" }], // pane is live
       stop: () => {},
       send: (target: string, text: string) => sent.push({ target, text }),
     } as any,
@@ -1000,6 +1000,37 @@ test("reply delivers the text as a bracketed paste, then submits with a carriage
   sent.length = 0;
   expect(svc.reply(s.id, "a\x1b[201~b\x1b[200~c")).toBe(true);
   expect(sent[0]).toEqual({ target: "term_z", text: "\x1b[200~abc\x1b[201~" });
+});
+
+test("reply returns false for a live-in-store session whose pane is dead (no throw, no send)", () => {
+  const sent: unknown[] = [];
+  const store = new SessionStore(":memory:");
+  const s = store.create({
+    name: "x",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_dead",
+  });
+  const svc = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    herdr: {
+      start: () => ({}) as any,
+      list: () => [{ terminalId: "term_other" }], // session's pane is NOT listed → dead
+      stop: () => {},
+      send: () => sent.push("sent"),
+    } as any,
+  });
+  // honest boolean instead of letting herdr.send throw, and no steer is attempted
+  expect(svc.reply(s.id, "hi")).toBe(false);
+  expect(sent).toEqual([]);
+  expect(store.listSignals("/r").length).toBe(0); // undelivered steer records no signal
 });
 
 test("broadcast fans the text out to known sessions, skips unknown ids", () => {
@@ -1025,7 +1056,7 @@ test("broadcast fans the text out to known sessions, skips unknown ids", () => {
     worktree: { create: () => ({}) as any, remove: () => {} } as any,
     herdr: {
       start: () => ({}) as any,
-      list: () => [],
+      list: () => [{ terminalId: "term_a" }, { terminalId: "term_b" }], // both panes live
       stop: () => {},
       send: (target: string, text: string) => sent.push({ target, text }),
     } as any,

--- a/test/signal-capture.test.ts
+++ b/test/signal-capture.test.ts
@@ -7,7 +7,8 @@ function deps(store: SessionStore) {
   return {
     store,
     worktree: {} as any,
-    herdr: { send: () => {} } as any,
+    // reply() now liveness-checks the pane before sending; list the session's agent live.
+    herdr: { send: () => {}, list: () => [{ terminalId: "t1" }] } as any,
     namer: (p: string) => p,
   };
 }

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
 import { SessionStore } from "../src/store";
+import type { ReviewVerdict } from "../src/types";
 
 function mk() {
   return new SessionStore(":memory:");
@@ -77,6 +78,9 @@ test("reviews: upsert + read by session, snapshot all", () => {
     body: "## findings",
     findings: ["fix the off-by-one", "handle the null case"],
     addressRound: 1,
+    addressCap: 3,
+    errorRound: 0,
+    seenNoteIds: ["c1", "c2"],
     url: "u",
     updatedAt: 100,
   };
@@ -91,8 +95,9 @@ test("reviews: upsert + read by session, snapshot all", () => {
   expect(store.getReview("s1")).toBeNull();
 });
 
-test("reviews: findings + addressRound default to [] / 0 when absent", () => {
+test("reviews: findings/addressRound/addressCap/errorRound/seenNoteIds default when absent", () => {
   const store = new SessionStore(":memory:");
+  // a verdict row written before the #247 columns existed (missing the new fields)
   store.putReview({
     sessionId: "s2",
     headSha: "abc",
@@ -102,10 +107,13 @@ test("reviews: findings + addressRound default to [] / 0 when absent", () => {
     findings: [],
     addressRound: 0,
     updatedAt: 1,
-  });
+  } as unknown as ReviewVerdict);
   const r = store.getReview("s2");
   expect(r?.findings).toEqual([]);
   expect(r?.addressRound).toBe(0);
+  expect(r?.addressCap).toBe(3); // backfilled to the migration default
+  expect(r?.errorRound).toBe(0);
+  expect(r?.seenNoteIds).toEqual([]);
 });
 
 test("readyToMerge: defaults false on create, round-trips through update", () => {

--- a/ui/src/lib/components/critic-badge.test.ts
+++ b/ui/src/lib/components/critic-badge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { criticBadgeLabel, addressRoundInfo, CRITIC_ROUND_CAP } from "./critic-badge";
+import { criticBadgeLabel, addressRoundInfo } from "./critic-badge";
 import type { ReviewVerdict } from "../types";
 
 const v = (
@@ -13,6 +13,7 @@ const v = (
   body: "",
   findings: [],
   addressRound: 0,
+  addressCap: 3,
   updatedAt: 0,
   ...over,
 });
@@ -31,12 +32,19 @@ describe("addressRoundInfo", () => {
     expect(addressRoundInfo(v("commented", { addressRound: 0 }))).toBeNull());
   it("reports the round while addressing under the cap", () => {
     const info = addressRoundInfo(v("changes_requested", { addressRound: 1, findings: ["x"] }));
-    expect(info).toEqual({ round: 1, cap: CRITIC_ROUND_CAP, stalled: false });
+    expect(info).toEqual({ round: 1, cap: 3, stalled: false });
   });
   it("flags stalled when the round hits the cap with findings still open", () => {
     const info = addressRoundInfo(
-      v("changes_requested", { addressRound: CRITIC_ROUND_CAP, findings: ["still broken"] }),
+      v("changes_requested", { addressRound: 3, addressCap: 3, findings: ["still broken"] }),
     );
     expect(info?.stalled).toBe(true);
+  });
+  it("reads the cap off the verdict, not a hardcoded mirror", () => {
+    // a deployment with a wider cap surfaces it on the verdict — badge math follows
+    const info = addressRoundInfo(
+      v("changes_requested", { addressRound: 4, addressCap: 5, findings: ["x"] }),
+    );
+    expect(info).toEqual({ round: 4, cap: 5, stalled: false });
   });
 });

--- a/ui/src/lib/components/critic-badge.ts
+++ b/ui/src/lib/components/critic-badge.ts
@@ -1,9 +1,6 @@
 import type { ReviewVerdict } from "../types";
 import { m } from "$lib/paraglide/messages";
 
-/** Max auto-address rounds before the loop gives up (mirrors the server's DEFAULT_CAP). */
-export const CRITIC_ROUND_CAP = 3;
-
 /** Badge text for a critic verdict, or null when there is none to show. */
 export function criticBadgeLabel(v: ReviewVerdict | undefined): string | null {
   if (!v) return null;
@@ -19,12 +16,14 @@ export function criticBadgeLabel(v: ReviewVerdict | undefined): string | null {
 
 /**
  * Auto-address streak state for the badge, or null when no streak is in progress.
+ * The cap comes off the verdict (`addressCap`) — the server's live value — so the badge
+ * math never drifts from a hardcoded mirror.
  * `stalled` = the loop hit its cap with findings still open → it gave up, needs a human.
  */
 export function addressRoundInfo(
   v: ReviewVerdict | undefined,
-  cap: number = CRITIC_ROUND_CAP,
 ): { round: number; cap: number; stalled: boolean } | null {
   if (!v || v.addressRound <= 0) return null;
+  const cap = v.addressCap;
   return { round: v.addressRound, cap, stalled: v.addressRound >= cap && v.findings.length > 0 };
 }

--- a/ui/src/lib/reviews.svelte.test.ts
+++ b/ui/src/lib/reviews.svelte.test.ts
@@ -19,6 +19,7 @@ const verdict = (id: string): ReviewVerdict => ({
   body: "test body",
   findings: [],
   addressRound: 0,
+  addressCap: 3,
   updatedAt: 0,
 });
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -130,6 +130,7 @@ export interface ReviewVerdict {
   body: string;
   findings: string[]; // discrete actionable items; [] = nothing to address
   addressRound: number; // auto-address steers spent on the current findings streak
+  addressCap: number; // server's streak cap for this run — the badge reads it instead of mirroring
   url?: string;
   updatedAt: number;
 }


### PR DESCRIPTION
Closes #247 (items 1, 2, 4, 6). Items 3 & 5 are intentionally deferred — see below.

Leftover polish from the #243 auto-address-critic loop reviews. None blocked the prototype; this tightens correctness around the loop's edges.

## What changed

### 1. Author notes scoped to *this round* (highest value)
`fetchAuthorNotes` re-fed **every** `AUTHOR_RESPONSE_MARKER` comment on every re-review — unbounded prompt growth + resurrected stale justifications. Now each note is injected exactly once, tracked by **comment id** (carried on the verdict as `seenNoteIds`), never by timestamp (host `now()` vs GitHub's comment clock can skew and drop a valid decline). On an **error** pass the seen-set is rolled back, so a doomed critic doesn't silently swallow a note it never actually processed. `PrComment` gained an `id` (gh node id, falling back to comment url).

### 2. Surface the round cap instead of mirroring it
UI `CRITIC_ROUND_CAP` hardcoded `3` to match the server's `DEFAULT_CAP`. The cap now rides down on the verdict payload (`addressCap`) and the badge reads it off there — the UI constant is gone, so `ReviewService({cap})` can vary per deployment without the badge math drifting.

### 4. Repeated critic `error`/timeout verdicts now escalate
An `error` verdict has empty findings, which reset the streak to `0` — a flapping critic could loop forever without hitting the cap. Added a **separate `errorRound` counter**: it advances on each consecutive error, emits a `stall` signal once at the cap (escalation to the human/learnings), and an error now **preserves** the findings streak instead of masquerading as "clean".

### 6. `service.reply` dead-pane contract
`reply` returned `false` only on a store miss; a live-in-store/dead-pane session made `herdr.send` throw (and 500'd human steers via the endpoint). It now liveness-checks the pane up front → honest, non-throwing boolean. `broadcast` lists herdr **once** rather than per id, so a wide fan-out doesn't spawn one blocking `agent list` per target.

## Deferred (per the issue)
- **Item 3** (a fresh unrelated finding counts toward the same streak) — explicitly "fine as churn-per-PR"; the existing comment in `runAutoAddress` still documents it.
- **Item 5** (PR-comment injection surface) — only relevant if shepherd opens to *external* PRs; the prompt already frames notes as unverified + judged-against-diff, which is correct for own/controlled PRs.

## Persistence / migration
`reviews` table gained `addressCap` / `errorRound` / `seenNoteIds` columns with idempotent `ALTER` migrations (pre-existing rows backfill to defaults and refresh on the next push).

## Verification
- Root: `bun run lint`, `bunx tsc --noEmit`, `bun test ./test` (728 pass)
- UI: `bun run check` (0 errors), `bun run test` (251 pass), `bun run check:i18n` (parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)