### PR TITLE
feat(herd): rename auto post-agent group "Waiting for merge" → "Your turn"

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -119,7 +119,7 @@
   "herd_ci_running_group": "CI läuft ({count})",
   "herd_ci_failed_group": "CI fehlgeschlagen ({count})",
   "herd_reviewer_running_group": "Review läuft ({count})",
-  "herd_awaiting_merge_group": "Wartet auf Merge ({count})",
+  "herd_awaiting_merge_group": "Du bist dran ({count})",
   "herd_ready_group": "Bereit zum Mergen ({count})",
   "herd_merged_group": "Gemergt ({count})",
   "herd_clear_merged_action": "Alle räumen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -119,7 +119,7 @@
   "herd_ci_running_group": "CI running ({count})",
   "herd_ci_failed_group": "CI failed ({count})",
   "herd_reviewer_running_group": "Reviewing ({count})",
-  "herd_awaiting_merge_group": "Waiting for merge ({count})",
+  "herd_awaiting_merge_group": "Your turn ({count})",
   "herd_ready_group": "Ready to merge ({count})",
   "herd_merged_group": "Merged ({count})",
   "herd_clear_merged_action": "Clear all",

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -14,7 +14,7 @@ import type { Session, GitState } from "$lib/types";
  *  as the later in-flight stage):
  *    merged > ready > reviewerRunning > ciRunning > ciFailed > awaitingMerge > active.
  *  An open PR with `none` checks (no CI reported yet) stays in `active` to avoid
- *  flicker into "waiting for merge" before CI registers as pending.
+ *  flicker into the "Your turn" group before CI registers as pending.
  *  The groups render top→bottom as active → ciRunning → ciFailed → reviewerRunning →
  *  awaitingMerge → ready → merged, mirroring the session lifecycle. `isReviewing` is
  *  injected so this stays a pure function (the caller wires it to the reviews store). */


### PR DESCRIPTION
## Why
The auto post-agent stage **"Waiting for merge"** sat too close to the manual **"Ready to merge"** group: both say *merge*, and the only real difference is whether the operator has acted. It also doubled the `WAITING` status badge (`status_done`).

No merge-based name can fully separate the two (both mean "a human will merge this"), so the fix names the **human-intent / handoff axis** instead.

## What
`herd_awaiting_merge_group` label:
- EN: `Waiting for merge ({count})` → **`Your turn ({count})`**
- DE: `Wartet auf Merge ({count})` → **`Du bist dran ({count})`**

Chose "Your turn" over "Awaiting you" because `herd_ready_title` already uses *"awaiting you"* for the broader ready-filter (idle/blocked/done) — reusing it would spawn a new collision. "Your turn" also dodges the AI-critic's *Reviewing / Reviewer / REVIEWED* vocabulary (ruling out "Needs review") and the critic's "approves" overlap (ruling out "Awaiting approval").

- Internal `awaitingMerge` partition id kept — it precisely names the *system state*; the label is the human framing.
- Updated the stale `herd-partition.ts` comment that quoted the old label.

## Verify
- `cd ui && bun run check:i18n` → ✓ 2 locales in parity (432 keys)
- `bun run test src/lib/components/herd-partition.test.ts` → ✓ 16/16

🤖 Generated with [Claude Code](https://claude.com/claude-code)