### PR TITLE
feat(prs): expand PR rollup dot into per-job CI breakdown (#233)

### DIFF
--- a/src/forge/checks.ts
+++ b/src/forge/checks.ts
@@ -1,4 +1,4 @@
-import type { CheckRun, ChecksState, RollupEntry, WorkflowJob } from "./types";
+import type { ChecksState, RollupEntry, WorkflowJob } from "./types";
 
 const FAILURE = new Set([
   "failure",
@@ -45,6 +45,12 @@ function isStatusContext(e: RollupEntry): boolean {
   return e.__typename === "StatusContext" || (e.name == null && e.context != null);
 }
 
+/** Resolve one rollup entry to a single state, reading the right fields for its
+ *  shape: a CheckRun's status/conclusion, or a StatusContext's flat state. */
+function entryState(e: RollupEntry): ChecksState {
+  return isStatusContext(e) ? mapStatusState(e.state) : mapCheckState(e.status, e.conclusion);
+}
+
 /** Map one rollup entry to a job, or null when it has no usable label. */
 function rollupEntryToJob(e: RollupEntry): WorkflowJob | null {
   if (isStatusContext(e)) {
@@ -67,13 +73,15 @@ export function jobsFromRollup(entries: ReadonlyArray<RollupEntry>): WorkflowJob
   return entries.map(rollupEntryToJob).filter((j): j is WorkflowJob => j != null);
 }
 
-/** Roll a list of forge-reported check runs into a single worst-of state
- *  (failure > pending > success > none). */
-export function rollupChecks(runs: ReadonlyArray<CheckRun>): ChecksState {
+/** Roll a list of `statusCheckRollup` entries into a single worst-of state
+ *  (failure > pending > success > none). Folds in legacy StatusContext entries
+ *  via {@link entryState}, so a repo running only commit statuses still rolls up
+ *  to a real state (not "none") and the PRs-tab dot — and its expand — show. */
+export function rollupChecks(runs: ReadonlyArray<RollupEntry>): ChecksState {
   let sawPending = false;
   let sawSuccess = false;
   for (const r of runs) {
-    const st = mapCheckState(r.status, r.conclusion);
+    const st = entryState(r);
     if (st === "failure") return "failure";
     if (st === "pending") sawPending = true;
     else if (st === "success") sawSuccess = true;

--- a/src/forge/checks.ts
+++ b/src/forge/checks.ts
@@ -1,4 +1,4 @@
-import type { CheckRun, ChecksState } from "./types";
+import type { CheckRun, ChecksState, RollupEntry, WorkflowJob } from "./types";
 
 const FAILURE = new Set([
   "failure",
@@ -19,6 +19,52 @@ export function mapCheckState(status?: string | null, conclusion?: string | null
   if (c === "success") return "success";
   if (FAILURE.has(c)) return "failure";
   return "none";
+}
+
+/** Map a coarse status-state string (GitHub StatusContext / Gitea combined +
+ *  per-context status) to a single state: success → success; pending / expected
+ *  / running → pending; failure / error → failure; anything else → none. */
+export function mapStatusState(state?: string | null): ChecksState {
+  switch ((state ?? "").toLowerCase()) {
+    case "success":
+      return "success";
+    case "pending":
+    case "expected":
+    case "running":
+      return "pending";
+    case "failure":
+    case "error":
+      return "failure";
+    default:
+      return "none";
+  }
+}
+
+/** A legacy StatusContext carries a context label + flat state (no lifecycle). */
+function isStatusContext(e: RollupEntry): boolean {
+  return e.__typename === "StatusContext" || (e.name == null && e.context != null);
+}
+
+/** Map one rollup entry to a job, or null when it has no usable label. */
+function rollupEntryToJob(e: RollupEntry): WorkflowJob | null {
+  if (isStatusContext(e)) {
+    const name = e.context ?? "";
+    return name ? { name, state: mapStatusState(e.state), url: e.targetUrl || undefined } : null;
+  }
+  const base = e.name ?? "";
+  if (!base) return null;
+  // A flat PR check list spans workflows, so qualify the job with its workflow
+  // ("CI / lint") the way GitHub's own checks UI does.
+  const name = e.workflowName ? `${e.workflowName} / ${base}` : base;
+  return { name, state: mapCheckState(e.status, e.conclusion), url: e.detailsUrl || undefined };
+}
+
+/** Expand GitHub's `statusCheckRollup` into one {@link WorkflowJob} per check.
+ *  CheckRuns (Actions jobs) carry a workflow + job name and a status/conclusion;
+ *  legacy StatusContexts carry a context label and a flat state. Entries without
+ *  a usable label are dropped. */
+export function jobsFromRollup(entries: ReadonlyArray<RollupEntry>): WorkflowJob[] {
+  return entries.map(rollupEntryToJob).filter((j): j is WorkflowJob => j != null);
 }
 
 /** Roll a list of forge-reported check runs into a single worst-of state

--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -1,3 +1,4 @@
+import { mapStatusState } from "./checks";
 import type {
   ChecksState,
   ForgeConfig,
@@ -10,6 +11,7 @@ import type {
   PrStatus,
   PullRequest,
   RedeployInput,
+  WorkflowJob,
 } from "./types";
 
 interface GiteaPr {
@@ -49,22 +51,6 @@ async function mapBounded<T, R>(
   };
   await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
   return out;
-}
-
-/** Map Gitea's server-computed combined commit status to our worst-of rollup. */
-function mapCombinedStatus(state: string | undefined): ChecksState {
-  switch ((state ?? "").toLowerCase()) {
-    case "success":
-      return "success";
-    case "pending":
-    case "running":
-      return "pending";
-    case "failure":
-    case "error":
-      return "failure";
-    default:
-      return "none";
-  }
 }
 
 /** Gitea/Forgejo forge driven through the /api/v1 REST API (API-compatible). */
@@ -130,12 +116,28 @@ export class GiteaForge implements GitForge {
     });
   }
 
-  private async checksFor(sha: string | undefined): Promise<ChecksState> {
-    if (!sha) return "none";
+  /** One combined-status call yields both the worst-of rollup (top-level `state`)
+   *  and the per-context breakdown (`statuses[]`) for the PRs-tab expand view. */
+  private async commitChecks(
+    sha: string | undefined,
+  ): Promise<{ checks: ChecksState; jobs: WorkflowJob[] }> {
+    if (!sha) return { checks: "none", jobs: [] };
     const status = (await this.req("GET", `/api/v1/repos/${this.slug}/commits/${sha}/status`)) as {
       state?: string;
+      statuses?: Array<{ status?: string; context?: string; target_url?: string }>;
     } | null;
-    return mapCombinedStatus(status?.state);
+    const jobs: WorkflowJob[] = (status?.statuses ?? [])
+      .filter((s) => s.context)
+      .map((s) => ({
+        name: s.context ?? "",
+        state: mapStatusState(s.status),
+        url: s.target_url || undefined,
+      }));
+    return { checks: mapStatusState(status?.state), jobs };
+  }
+
+  private async checksFor(sha: string | undefined): Promise<ChecksState> {
+    return (await this.commitChecks(sha)).checks;
   }
 
   private async toStatus(pr: GiteaPr): Promise<PrStatus> {
@@ -167,7 +169,10 @@ export class GiteaForge implements GitForge {
     // swallow it to "none" so one bad PR can't reject the whole list.
     return mapBounded(prs ?? [], STATUS_FETCH_CONCURRENCY, async (pr) => {
       const ts = Date.parse(pr.created_at ?? "");
-      const checks = await this.checksFor(pr.head?.sha).catch((): ChecksState => "none");
+      const { checks, jobs } = await this.commitChecks(pr.head?.sha).catch(() => ({
+        checks: "none" as ChecksState,
+        jobs: [] as WorkflowJob[],
+      }));
       return {
         number: pr.number,
         title: pr.title ?? "",
@@ -177,6 +182,7 @@ export class GiteaForge implements GitForge {
         isDraft: pr.draft ?? false,
         mergeable: pr.mergeable ?? null,
         checks,
+        jobs,
       } satisfies PullRequest;
     });
   }

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -1,8 +1,7 @@
 import { execFileSync } from "node:child_process";
-import { mapCheckState, rollupChecks } from "./checks";
+import { jobsFromRollup, mapCheckState, rollupChecks } from "./checks";
 import { CRITIC_REVIEW_MARKER } from "./types";
 import type {
-  CheckRun,
   ForgeConfig,
   GitForge,
   Issue,
@@ -14,6 +13,7 @@ import type {
   PrStatus,
   PullRequest,
   RedeployInput,
+  RollupEntry,
   WorkflowJob,
   WorkflowRun,
 } from "./types";
@@ -63,7 +63,7 @@ interface GhPr {
   title: string;
   state: string; // OPEN | MERGED | CLOSED
   mergeable?: string; // MERGEABLE | CONFLICTING | UNKNOWN
-  statusCheckRollup?: CheckRun[];
+  statusCheckRollup?: RollupEntry[];
   headRefOid?: string;
   reviews?: GhReview[];
 }
@@ -157,6 +157,7 @@ export class GithubForge implements GitForge {
         isDraft: p.isDraft ?? false,
         mergeable: mapMergeable(p.mergeable),
         checks: rollupChecks(p.statusCheckRollup ?? []),
+        jobs: jobsFromRollup(p.statusCheckRollup ?? []),
         latestReview: latestHumanReview(p.reviews),
       };
     });

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -185,16 +185,10 @@ export interface ForgeConfig {
 
 export type ForgeMap = Record<string, ForgeConfig>;
 
-/** One forge-reported check run: a lifecycle status + (when complete) a conclusion. */
-export interface CheckRun {
-  status?: string | null;
-  conclusion?: string | null;
-}
-
 /** One raw entry in GitHub's `statusCheckRollup`: either a modern CheckRun (an
- *  Actions job) or a legacy StatusContext (a commit status). The two shapes are
- *  disjoint, so every field is optional and {@link jobsFromRollup} branches on
- *  `__typename` to read the right ones. */
+ *  Actions job — lifecycle status + conclusion) or a legacy StatusContext (a
+ *  commit status — a flat state). The two shapes are disjoint, so every field is
+ *  optional and the checks helpers branch on `__typename` to read the right ones. */
 export interface RollupEntry {
   __typename?: string;
   // CheckRun

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -56,6 +56,10 @@ export interface PullRequest {
   mergeable: boolean | null;
   /** Worst-of CI rollup over the head commit. */
   checks: ChecksState;
+  /** Per-check breakdown of the head commit (one entry per CI job / status
+   *  context), powering the PRs tab's expand-the-dot view. Empty when the host
+   *  reports no checks. */
+  jobs: WorkflowJob[];
   /** Newest *human* review (critic-marked reviews excluded), or undefined. */
   latestReview?: PrReview;
 }
@@ -185,4 +189,22 @@ export type ForgeMap = Record<string, ForgeConfig>;
 export interface CheckRun {
   status?: string | null;
   conclusion?: string | null;
+}
+
+/** One raw entry in GitHub's `statusCheckRollup`: either a modern CheckRun (an
+ *  Actions job) or a legacy StatusContext (a commit status). The two shapes are
+ *  disjoint, so every field is optional and {@link jobsFromRollup} branches on
+ *  `__typename` to read the right ones. */
+export interface RollupEntry {
+  __typename?: string;
+  // CheckRun
+  name?: string | null;
+  workflowName?: string | null;
+  status?: string | null;
+  conclusion?: string | null;
+  detailsUrl?: string | null;
+  // StatusContext
+  context?: string | null;
+  state?: string | null;
+  targetUrl?: string | null;
 }

--- a/test/forge/checks.test.ts
+++ b/test/forge/checks.test.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "bun:test";
-import { mapCheckState, rollupChecks } from "../../src/forge/checks";
+import {
+  jobsFromRollup,
+  mapCheckState,
+  mapStatusState,
+  rollupChecks,
+} from "../../src/forge/checks";
 
 test("mapCheckState: incomplete status → pending", () => {
   expect(mapCheckState("in_progress", null)).toBe("pending");
@@ -80,4 +85,53 @@ test("rollupChecks: only neutral/skipped → none", () => {
 test("rollupChecks: case-insensitive conclusions", () => {
   expect(rollupChecks([{ status: "COMPLETED", conclusion: "SUCCESS" }])).toBe("success");
   expect(rollupChecks([{ status: "Completed", conclusion: "Failure" }])).toBe("failure");
+});
+
+test("mapStatusState: maps the coarse StatusContext/Gitea vocab", () => {
+  expect(mapStatusState("SUCCESS")).toBe("success");
+  expect(mapStatusState("pending")).toBe("pending");
+  expect(mapStatusState("expected")).toBe("pending");
+  expect(mapStatusState("running")).toBe("pending");
+  expect(mapStatusState("failure")).toBe("failure");
+  expect(mapStatusState("error")).toBe("failure");
+  expect(mapStatusState("")).toBe("none");
+  expect(mapStatusState(null)).toBe("none");
+});
+
+test("jobsFromRollup: CheckRun entries are qualified with their workflow name", () => {
+  expect(
+    jobsFromRollup([
+      {
+        __typename: "CheckRun",
+        name: "lint",
+        workflowName: "CI",
+        status: "completed",
+        conclusion: "success",
+        detailsUrl: "https://gh/a",
+      },
+      {
+        __typename: "CheckRun",
+        name: "build",
+        status: "in_progress",
+        conclusion: null,
+      },
+    ]),
+  ).toEqual([
+    { name: "CI / lint", state: "success", url: "https://gh/a" },
+    { name: "build", state: "pending", url: undefined },
+  ]);
+});
+
+test("jobsFromRollup: legacy StatusContext entries map context + state + targetUrl", () => {
+  expect(
+    jobsFromRollup([
+      { __typename: "StatusContext", context: "netlify", state: "FAILURE", targetUrl: "https://n" },
+    ]),
+  ).toEqual([{ name: "netlify", state: "failure", url: "https://n" }]);
+});
+
+test("jobsFromRollup: entries without a usable label are dropped", () => {
+  expect(
+    jobsFromRollup([{ __typename: "CheckRun", status: "completed", conclusion: "success" }]),
+  ).toEqual([]);
 });

--- a/test/forge/checks.test.ts
+++ b/test/forge/checks.test.ts
@@ -87,6 +87,20 @@ test("rollupChecks: case-insensitive conclusions", () => {
   expect(rollupChecks([{ status: "Completed", conclusion: "Failure" }])).toBe("failure");
 });
 
+test("rollupChecks: folds in legacy StatusContext entries (not 'none')", () => {
+  // A repo running only commit statuses (no Actions) — must still roll up to a
+  // real state so the PRs-tab dot (and its expand) appear.
+  expect(
+    rollupChecks([{ __typename: "StatusContext", context: "ci/circleci", state: "SUCCESS" }]),
+  ).toBe("success");
+  expect(
+    rollupChecks([
+      { __typename: "StatusContext", context: "ci/circleci", state: "SUCCESS" },
+      { __typename: "StatusContext", context: "netlify", state: "FAILURE" },
+    ]),
+  ).toBe("failure");
+});
+
 test("mapStatusState: maps the coarse StatusContext/Gitea vocab", () => {
   expect(mapStatusState("SUCCESS")).toBe("success");
   expect(mapStatusState("pending")).toBe("pending");

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -48,7 +48,15 @@ test("GiteaForge.listPullRequests: maps open PRs and fans out per-PR checks", as
         },
       ],
     },
-    "GET /api/v1/repos/team/proj/commits/deadbeef/status": { json: { state: "success" } },
+    "GET /api/v1/repos/team/proj/commits/deadbeef/status": {
+      json: {
+        state: "success",
+        statuses: [
+          { status: "success", context: "build", target_url: "https://git.example.com/build" },
+          { status: "success", context: "test", target_url: "" },
+        ],
+      },
+    },
   });
   const forge = new GiteaForge("team/proj", CFG, fn);
   const prs = await forge.listPullRequests();
@@ -62,6 +70,10 @@ test("GiteaForge.listPullRequests: maps open PRs and fans out per-PR checks", as
       isDraft: false,
       mergeable: true,
       checks: "success",
+      jobs: [
+        { name: "build", state: "success", url: "https://git.example.com/build" },
+        { name: "test", state: "success", url: undefined },
+      ],
     },
   ]);
   // list call + one commit-status call

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -41,7 +41,7 @@ test("GithubForge.listIssues: parses gh issue list output", async () => {
   ]);
 });
 
-test("GithubForge.listPullRequests: maps author, draft, mergeable, checks, review", async () => {
+test("GithubForge.listPullRequests: maps author, draft, mergeable, checks, jobs, review", async () => {
   const prsJson = JSON.stringify([
     {
       number: 7,
@@ -51,7 +51,30 @@ test("GithubForge.listPullRequests: maps author, draft, mergeable, checks, revie
       createdAt: "2024-02-02T00:00:00Z",
       isDraft: true,
       mergeable: "CONFLICTING",
-      statusCheckRollup: [{ status: "COMPLETED", conclusion: "FAILURE" }],
+      statusCheckRollup: [
+        {
+          __typename: "CheckRun",
+          name: "lint",
+          workflowName: "CI",
+          status: "COMPLETED",
+          conclusion: "SUCCESS",
+          detailsUrl: "https://gh/job/a",
+        },
+        {
+          __typename: "CheckRun",
+          name: "test",
+          workflowName: "CI",
+          status: "COMPLETED",
+          conclusion: "FAILURE",
+          detailsUrl: "https://gh/job/b",
+        },
+        {
+          __typename: "StatusContext",
+          context: "netlify/deploy",
+          state: "PENDING",
+          targetUrl: "https://netlify/x",
+        },
+      ],
       reviews: [
         {
           author: { login: "bob" },
@@ -73,7 +96,12 @@ test("GithubForge.listPullRequests: maps author, draft, mergeable, checks, revie
       createdAt: Date.parse("2024-02-02T00:00:00Z"),
       isDraft: true,
       mergeable: false,
-      checks: "failure",
+      checks: "failure", // worst-of over the three checks
+      jobs: [
+        { name: "CI / lint", state: "success", url: "https://gh/job/a" },
+        { name: "CI / test", state: "failure", url: "https://gh/job/b" },
+        { name: "netlify/deploy", state: "pending", url: "https://netlify/x" },
+      ],
       latestReview: {
         state: "changes_requested",
         author: "bob",

--- a/test/server-prs.test.ts
+++ b/test/server-prs.test.ts
@@ -27,6 +27,7 @@ const PR: PullRequest = {
   isDraft: false,
   mergeable: true,
   checks: "success",
+  jobs: [{ name: "CI / test", state: "success", url: "https://gh/job/1" }],
   latestReview: { state: "approved", author: "bob", submittedAt: 1_700_000_100_000 },
 };
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -442,6 +442,8 @@
   "prspanel_merging": "merge läuft…",
   "prspanel_merge_failed": "Merge fehlgeschlagen",
   "prspanel_merge_blocked_title": "Konflikte vor dem Merge auflösen",
+  "prspanel_jobs_show": "CI-Jobs anzeigen",
+  "prspanel_jobs_hide": "CI-Jobs ausblenden",
   "newtask_pr_review_template": "Prüfe PR #{number} wie beschrieben.\n{url}",
   "backlog_loading": "Backlog wird geladen…",
   "backlog_no_forge_repos": "Keine Forge-Projekte",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -442,6 +442,8 @@
   "prspanel_merging": "merging…",
   "prspanel_merge_failed": "merge failed",
   "prspanel_merge_blocked_title": "resolve conflicts before merging",
+  "prspanel_jobs_show": "show CI jobs",
+  "prspanel_jobs_hide": "hide CI jobs",
   "newtask_pr_review_template": "Review PR #{number} as described.\n{url}",
   "backlog_loading": "Loading backlog…",
   "backlog_no_forge_repos": "No forge-backed projects",

--- a/ui/src/lib/components/PrRow.svelte
+++ b/ui/src/lib/components/PrRow.svelte
@@ -42,6 +42,9 @@
   // The toggle replaces the plain dot, so its label must still announce the
   // aggregate CI state ("CI: failure") alongside the show/hide action.
   const ciToggleLabel = $derived(`${ciStatus} · ${ciToggleTitle}`);
+  // Ties the toggle to the region it reveals (aria-controls ↔ id) for the
+  // standard disclosure pattern.
+  const jobsId = $derived(`pr-jobs-${pr.number}`);
   const reviewTitle = $derived(
     pr.latestReview?.state === "approved"
       ? m.prbadge_review_approved()
@@ -108,6 +111,7 @@
           class:expanded
           onclick={() => (expanded = !expanded)}
           aria-expanded={expanded}
+          aria-controls={jobsId}
           title={ciToggleLabel}
           aria-label={ciToggleLabel}
         >
@@ -136,7 +140,7 @@
   </div>
 
   {#if expanded && hasJobs}
-    <div class="pr-jobs">
+    <div class="pr-jobs" id={jobsId}>
       <!-- key includes the index: a matrix build can repeat a check name on one
            head commit, which would otherwise collide in the keyed each. -->
       {#each pr.jobs as job, i (job.name + " " + i)}

--- a/ui/src/lib/components/PrRow.svelte
+++ b/ui/src/lib/components/PrRow.svelte
@@ -39,6 +39,9 @@
 
   const ciStatus = $derived(m.gitrail_ci_status({ status: pr.checks }));
   const ciToggleTitle = $derived(expanded ? m.prspanel_jobs_hide() : m.prspanel_jobs_show());
+  // The toggle replaces the plain dot, so its label must still announce the
+  // aggregate CI state ("CI: failure") alongside the show/hide action.
+  const ciToggleLabel = $derived(`${ciStatus} · ${ciToggleTitle}`);
   const reviewTitle = $derived(
     pr.latestReview?.state === "approved"
       ? m.prbadge_review_approved()
@@ -106,7 +109,7 @@
           onclick={() => (expanded = !expanded)}
           aria-expanded={expanded}
           title={ciToggleTitle}
-          aria-label={ciToggleTitle}
+          aria-label={ciToggleLabel}
         >
           <span class="dot dot-{pr.checks}"></span>
           <span class="caret" aria-hidden="true">▸</span>

--- a/ui/src/lib/components/PrRow.svelte
+++ b/ui/src/lib/components/PrRow.svelte
@@ -108,7 +108,7 @@
           class:expanded
           onclick={() => (expanded = !expanded)}
           aria-expanded={expanded}
-          title={ciToggleTitle}
+          title={ciToggleLabel}
           aria-label={ciToggleLabel}
         >
           <span class="dot dot-{pr.checks}"></span>

--- a/ui/src/lib/components/PrRow.svelte
+++ b/ui/src/lib/components/PrRow.svelte
@@ -27,12 +27,18 @@
   let failed = $state(false);
   let disarmTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // The worst-of rollup dot expands into the head commit's individual CI jobs.
+  // Default collapsed so a long PR list stays scannable.
+  let expanded = $state(false);
+  const hasJobs = $derived(pr.jobs.length > 0);
+
   // A PR with conflicts can't merge. Drafts have no merge button, and some hosts
   // (Gitea) report mergeable:false for every draft — so don't read that as a real
   // conflict on a draft, or the row shows a bogus "conflicts" chip.
   const blocked = $derived(pr.mergeable === false && !pr.isDraft);
 
   const ciStatus = $derived(m.gitrail_ci_status({ status: pr.checks }));
+  const ciToggleTitle = $derived(expanded ? m.prspanel_jobs_hide() : m.prspanel_jobs_show());
   const reviewTitle = $derived(
     pr.latestReview?.state === "approved"
       ? m.prbadge_review_approved()
@@ -92,7 +98,22 @@
 
   <div class="pr-meta">
     {#if pr.checks !== "none"}
-      <span class="dot dot-{pr.checks}" title={ciStatus} aria-label={ciStatus}></span>
+      {#if hasJobs}
+        <button
+          type="button"
+          class="ci-toggle"
+          class:expanded
+          onclick={() => (expanded = !expanded)}
+          aria-expanded={expanded}
+          title={ciToggleTitle}
+          aria-label={ciToggleTitle}
+        >
+          <span class="dot dot-{pr.checks}"></span>
+          <span class="caret" aria-hidden="true">▸</span>
+        </button>
+      {:else}
+        <span class="dot dot-{pr.checks}" title={ciStatus} aria-label={ciStatus}></span>
+      {/if}
     {/if}
     {#if pr.latestReview}
       <span class="rdot rdot-{pr.latestReview.state}" title={reviewTitle} aria-label={reviewTitle}
@@ -110,6 +131,35 @@
       >
     {/if}
   </div>
+
+  {#if expanded && hasJobs}
+    <div class="pr-jobs">
+      <!-- key includes the index: a matrix build can repeat a check name on one
+           head commit, which would otherwise collide in the keyed each. -->
+      {#each pr.jobs as job, i (job.name + " " + i)}
+        <div class="job">
+          <span
+            class="dot dot-{job.state}"
+            title={m.gitrail_ci_status({ status: job.state })}
+            aria-label={m.gitrail_ci_status({ status: job.state })}
+          ></span>
+          {#if job.url}
+            <!-- eslint-disable svelte/no-navigation-without-resolve -- external forge URL -->
+            <a
+              class="job-name"
+              href={job.url}
+              target="_blank"
+              rel="noopener"
+              title={m.actionspanel_job_link()}>{job.name}</a
+            >
+            <!-- eslint-enable svelte/no-navigation-without-resolve -->
+          {:else}
+            <span class="job-name">{job.name}</span>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
 
   <div class="pr-actions">
     {#if failed}<span class="merge-err">{m.prspanel_merge_failed()}</span>{/if}
@@ -217,6 +267,62 @@
     background: var(--color-red);
   }
 
+  /* The rollup dot doubles as the expand control when the head commit has jobs:
+     a bare button so the dot keeps its exact size/hue, plus a hairline caret. */
+  .ci-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    color: var(--color-faint);
+  }
+  .ci-toggle:hover .caret {
+    color: var(--color-ink-bright);
+  }
+
+  .caret {
+    font-size: 8px;
+    line-height: 1;
+    color: var(--color-faint);
+    transition:
+      transform 0.12s,
+      color 0.12s;
+  }
+  .ci-toggle.expanded .caret {
+    transform: rotate(90deg);
+  }
+
+  .pr-jobs {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding-left: 13px;
+  }
+
+  .job {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    min-height: 12px;
+  }
+
+  .job-name {
+    font-size: 11.5px;
+    color: var(--color-ink);
+    text-decoration: none;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    transition: color 0.12s;
+  }
+  a.job-name:hover {
+    color: var(--color-ink-bright);
+  }
+
   .rdot {
     width: 6px;
     height: 6px;
@@ -317,6 +423,12 @@
     .merge-btn {
       min-height: 40px;
       padding: 2px 14px;
+    }
+    /* Enlarge the dot's hit area to a real tap target without growing the dot. */
+    .ci-toggle {
+      min-height: 32px;
+      min-width: 32px;
+      justify-content: center;
     }
   }
 </style>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -97,6 +97,8 @@ export interface PullRequest {
   /** null = host still computing mergeability. */
   mergeable: boolean | null;
   checks: ChecksState;
+  /** Per-check breakdown of the head commit, expanded from the rollup dot. */
+  jobs: WorkflowJob[];
   latestReview?: {
     state: "approved" | "changes_requested" | "commented";
     author: string;


### PR DESCRIPTION
Closes #233.

## What

The PRs tab showed one worst-of CI dot per PR. It now expands into the head commit's individual job statuses, reusing the per-job model from the Actions tab.

## How

- **`PullRequest.jobs: WorkflowJob[]`** — built from the head-commit checks **each forge already fetches**, so there's no new subprocess fan-out:
  - **GitHub**: `statusCheckRollup` already lists every CheckRun + legacy StatusContext (`jobsFromRollup`). CheckRuns are qualified with their workflow (`CI / lint`) like GitHub's own checks UI.
  - **Gitea**: the same `/commits/{sha}/status` response carries a `statuses[]` array. Shared `mapStatusState` replaces the old `mapCombinedStatus`.
- **`PrRow.svelte`**: the rollup dot becomes a click-to-expand toggle (default collapsed, caret rotates), revealing the per-job list — reusing the Actions tab's job vocabulary/styles. New i18n keys `prspanel_jobs_show/hide` (EN+DE).

Both forges covered (GitHub **and** Gitea), per the house rule on fixing the whole class.

## Tests

- Forge unit tests for both forges + `jobsFromRollup`/`mapStatusState`.
- Full suite green: 754 root / 262 UI, lint clean, i18n parity, Fallow audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)