### PR TITLE
fix(viewport): keep phone header identity row on one line

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2010,10 +2010,27 @@
   .vp-head.mobile .spacer {
     display: none;
   }
-  /* phone drops the task name (it moved to the top bar), so the spacer comes back
-     to keep the status badge + decommission right-aligned */
+  /* phone: the identity cluster (back · ✓ · repo · title) MUST stay on one line.
+     The repo·title block becomes the row's grower (flex-basis:0 → its hypothetical
+     width is 0, so flex line-breaking never overflows and wraps the trailing
+     actions — or the title itself — onto a second row). It fills the gap to the
+     pinned-right actions and the title ellipsizes inside whatever width is left,
+     instead of forcing a wrap when repo + title get long. */
+  .vp-head.phone .desig-wrap.ctx {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+  .vp-head.phone .ctx-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    /* drop the fixed vw cap on phone — flex + ellipsis size it to the free space */
+    max-width: none;
+  }
+  /* the ctx block is now the sole grower pinning the actions right; the standalone
+     spacer would otherwise split the free space and starve the title's width */
   .vp-head.phone .spacer {
     display: block;
+    flex: 0;
   }
   .tab-group.mobile {
     order: 10;


### PR DESCRIPTION
## Problem
On narrow phones the merged session-detail header wrapped onto a **second row** when the repo name + session title got long — exactly the case the user hit with `enkels-web · tech-stack-abstimmung`. The first line (`‹ ✓ repo · title`) should always stay a single line and abbreviate the title with `…` instead.

## Cause
`.vp-head` is a wrapping flexbox on phones. The `repo · title` block (`.desig-wrap.ctx`) used `flex: 0 1 auto` (large *hypothetical* width during flex line-breaking) and `.ctx-name` had a fixed `max-width: 34vw`. So when the title was long, the browser saw the row overflow and `flex-wrap` pushed the trailing actions (or the title) onto a second line rather than truncating.

## Fix (CSS only, scoped to `.vp-head.phone`)
Standard truncate-in-flex pattern:
- `.desig-wrap.ctx` → `flex: 1 1 0` (hypothetical width 0 → never triggers a wrap; grows into the gap before the right-pinned actions)
- `.ctx-name` → `flex: 1 1 auto; min-width: 0; max-width: none` (ellipsizes to the real available width)
- `.vp-head.phone .spacer` → `flex: 0` (ctx is now the sole grower; the standalone spacer would otherwise split the free width and starve the title)

Desktop/foldable layouts are untouched.

## Verification
Driven against the live `enkels-web / tech-stack-abstimmung` session at mobile widths:
- **375px:** `‹ ✓ enkels-web · tech-stac…` — one line, tabs wrap to line 2 ✅
- **320px (iPhone SE):** truncates harder to `te…`, still one line ✅
- `cd ui && bun run check` → 0 errors