### PR TITLE
feat(herdr-update): persistent audit log + unconditional shepherd restart

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,12 @@ import { loadForgeMap } from "./forge/load-config";
 const dbPath = process.env.SHEPHERD_DB ?? `${process.env.HOME}/.shepherd/shepherd.db`;
 // forge map sits next to the db by default; SHEPHERD_FORGES overrides the path.
 const forgesPath = process.env.SHEPHERD_FORGES ?? join(dirname(dbPath), "forges.json");
+// persistent herdr-update audit log: one delimited block per `herdr update`,
+// written by the transient update unit itself (NOT shepherd) so the record
+// survives the shepherd restart the update triggers. Lives next to the db so a
+// post-mortem is `cat ~/.shepherd/herdr-update.log`; SHEPHERD_HERDR_UPDATE_LOG overrides.
+const herdrUpdateLogPath =
+  process.env.SHEPHERD_HERDR_UPDATE_LOG ?? join(dirname(dbPath), "herdr-update.log");
 
 export const config = {
   port: Number(process.env.SHEPHERD_PORT ?? 7330),
@@ -13,6 +19,7 @@ export const config = {
   host: process.env.SHEPHERD_HOST ?? "127.0.0.1",
   dbPath,
   herdrBin: process.env.HERDR_BIN ?? "herdr",
+  herdrUpdateLogPath,
   // node binary for the PTY attach helper (pty-attach.mjs). Resolved so a node
   // managed by mise/nvm/fnm still works when the launcher's PATH excludes it —
   // otherwise the helper can't spawn and every session pane stays black.

--- a/src/herdr-update.ts
+++ b/src/herdr-update.ts
@@ -36,6 +36,77 @@ export interface HerdrUpdateDeps {
 const SEMVER_RE = /(\d+\.\d+\.\d+)/;
 const LATEST_URL = "https://herdr.dev/latest.json";
 
+/** Prefix every step marker the update script echoes. Stable + greppable so the
+ *  operator can `journalctl --user -u herdr-update | grep '>>> herdr-update'` and
+ *  read the exact sequence (and exit code) even after shepherd has restarted. */
+export const UPDATE_LOG_PREFIX = ">>> herdr-update:";
+
+/** Versions are regex-captured (digits + dots) before they reach here, but they
+ *  ultimately originate from herdr.dev/latest.json — an external source. Strip
+ *  anything that isn't a version char before embedding in the shell program so a
+ *  poisoned payload can never inject commands. Empty → "unknown". */
+function sanitizeVersion(v: string | null | undefined): string {
+  const clean = (v ?? "").replace(/[^0-9.]/g, "");
+  return clean || "unknown";
+}
+
+/**
+ * The shell program the transient `herdr-update` unit runs. Extracted + exported
+ * so its sequencing is unit-testable without a live herdr release (the only way
+ * to exercise the real launch otherwise).
+ *
+ * Three guarantees, all learned from a stranded-502 incident and the operator's
+ * need to audit past updates while developing against them:
+ *
+ *  1. Every run appends ONE delimited block to `logPath` (default
+ *     ~/.shepherd/herdr-update.log) via `tee -a`: a `=== herdr-update <UTC>
+ *     <from> -> <to> ===` header, each step marker, raw `herdr update` output,
+ *     the exit code, and the restart result. The script writes this file
+ *     itself, NOT shepherd — so the record is COMPLETE even though shepherd
+ *     (and its live SSE log stream) goes down mid-update. `cat <logPath>` is the
+ *     durable post-mortem; the same lines still stream to the journal + modal.
+ *
+ *  2. Each step echoes a `UPDATE_LOG_PREFIX` marker BEFORE it runs, and the
+ *     `herdr update` exit code is echoed explicitly — so the log shows precisely
+ *     which step ran last and whether the update itself succeeded.
+ *
+ *  3. shepherd is restarted UNCONDITIONALLY — `herdr update; ...; restart`, NOT
+ *     `herdr update && restart`. The old `&&` short-circuited on a failed
+ *     update, leaving herdr stopped (we stop it first, see defaultLaunch) and
+ *     shepherd never bounced → a hard 502 until the operator manually ran
+ *     `herdr`. Always restarting self-heals: worst case shepherd comes back on
+ *     the old herdr version, which re-establishes the herdr server on startup.
+ */
+export function buildUpdateScript(
+  logPath: string,
+  from?: string | null,
+  to?: string | null,
+): string {
+  const f = sanitizeVersion(from);
+  const t = sanitizeVersion(to);
+  // single-quote the path for the shell; a literal `'` inside it (vanishingly
+  // unlikely in a home path) is escaped via the classic '\'' close-reopen trick.
+  const q = `'${logPath.replace(/'/g, "'\\''")}'`;
+  // The restart lives INSIDE the tee'd block so "restart issued" + its rc are
+  // recorded too. Restarting shepherd.service does not touch this separate
+  // transient unit, so the trailing lines still get written after shepherd dies.
+  return [
+    `LOG=${q}`,
+    'mkdir -p "$(dirname "$LOG")"',
+    "{",
+    `  echo "=== herdr-update $(date -u +%Y-%m-%dT%H:%M:%SZ) ${f} -> ${t} ==="`,
+    `  echo '${UPDATE_LOG_PREFIX} stopping herdr server'`,
+    "  herdr server stop || true",
+    `  echo '${UPDATE_LOG_PREFIX} running herdr update'`,
+    "  herdr update; rc=$?",
+    `  echo "${UPDATE_LOG_PREFIX} herdr update exited rc=$rc"`,
+    `  echo "${UPDATE_LOG_PREFIX} restarting shepherd (update rc=$rc)"`,
+    "  systemctl --user restart shepherd",
+    `  echo "${UPDATE_LOG_PREFIX} restart command returned $?"`,
+    '} 2>&1 | tee -a "$LOG"',
+  ].join("\n");
+}
+
 /**
  * Tracks whether a newer herdr (the external terminal multiplexer Shepherd
  * drives) is published upstream and, on demand, drives `herdr update` for the
@@ -122,7 +193,11 @@ export class HerdrUpdateService {
    *  which clears the targets, letting the non-interactive update proceed. The
    *  shepherd restart then brings up a fresh session on the new version. Stopping
    *  ends live agent panes, but `herdr update` is destructive by design anyway.
-   *  `|| true` so a "no server running" stop never blocks the update. */
+   *  `|| true` so a "no server running" stop never blocks the update.
+   *
+   *  The exact step sequencing (and why shepherd is always restarted) lives in
+   *  buildUpdateScript(); it echoes greppable markers into this transient unit's
+   *  journal so a post-mortem survives the shepherd restart. */
   private defaultLaunch(): void {
     // forward our PATH: a transient --user unit gets a bare environment, but the
     // command needs herdr/systemctl, which live on the service's PATH.
@@ -131,7 +206,7 @@ export class HerdrUpdateService {
     args.push(
       "bash",
       "-lc",
-      "herdr server stop || true; herdr update && systemctl --user restart shepherd",
+      buildUpdateScript(config.herdrUpdateLogPath, this.last?.current, this.last?.latest),
     );
     const child = spawn("systemd-run", args, { stdio: "ignore" });
     child.unref();
@@ -147,6 +222,15 @@ export class HerdrUpdateService {
   apply(): { started: boolean } {
     if (this.applying) return { started: false };
     this.applying = true;
+    // Breadcrumb in shepherd's OWN journal (`journalctl --user -u shepherd`): the
+    // SSE log stream and the transient-unit journal both go quiet the moment
+    // shepherd restarts, so this is the one record that ties the restart in
+    // shepherd's log back to a deliberate herdr update.
+    console.warn(
+      `[herdr-update] applying update ${this.last?.current ?? "?"} -> ${this.last?.latest ?? "?"}; ` +
+        `shepherd will restart (audit log: ${config.herdrUpdateLogPath}, ` +
+        "or journalctl --user -u herdr-update -n 50)",
+    );
     // Start streaming the journal BEFORE launching: `herdr update` runs inside the
     // transient unit and emits its diagnostics (incl. the "update failed: …" line)
     // within milliseconds. If we launched first, the `journalctl -f` tailer would

--- a/test/herdr-update.test.ts
+++ b/test/herdr-update.test.ts
@@ -1,5 +1,63 @@
 import { test, expect } from "bun:test";
-import { HerdrUpdateService, compareSemver } from "../src/herdr-update";
+import {
+  HerdrUpdateService,
+  buildUpdateScript,
+  compareSemver,
+  UPDATE_LOG_PREFIX,
+} from "../src/herdr-update";
+
+// ── buildUpdateScript: sequencing + logging (testable without a live release) ─
+const LOG = "/home/op/.shepherd/herdr-update.log";
+
+test("buildUpdateScript: stops herdr, updates, then ALWAYS restarts shepherd", () => {
+  const s = buildUpdateScript(LOG, "0.6.5", "0.6.6");
+  // ordering: stop must precede update, update must precede restart
+  const stop = s.indexOf("herdr server stop");
+  const update = s.indexOf("herdr update;");
+  const restart = s.indexOf("systemctl --user restart shepherd");
+  expect(stop).toBeGreaterThanOrEqual(0);
+  expect(update).toBeGreaterThan(stop);
+  expect(restart).toBeGreaterThan(update);
+});
+
+test("buildUpdateScript: restart is unconditional, NOT gated on update success", () => {
+  const s = buildUpdateScript(LOG, "0.6.5", "0.6.6");
+  // the stranded-502 regression: `herdr update && restart` skipped the restart on
+  // a failed update. Guard that the `&&` short-circuit never comes back.
+  expect(s).not.toContain("herdr update && systemctl");
+  expect(s).toContain("herdr update; rc=$?");
+});
+
+test("buildUpdateScript: echoes a greppable marker for every step + the exit code", () => {
+  const s = buildUpdateScript(LOG, "0.6.5", "0.6.6");
+  const markers = s.split("\n").filter((l) => l.includes(UPDATE_LOG_PREFIX));
+  // stopping / running / exited rc / restarting / restart-returned = 5 markers
+  expect(markers.length).toBe(5);
+  expect(s).toContain(`${UPDATE_LOG_PREFIX} herdr update exited rc=$rc`);
+});
+
+test("buildUpdateScript: appends a delimited, timestamped, versioned block to the audit log", () => {
+  const s = buildUpdateScript(LOG, "0.6.5", "0.6.6");
+  // single writer, append-only (tee -a) so prior updates are never clobbered
+  expect(s).toContain(`LOG='${LOG}'`);
+  expect(s).toContain('| tee -a "$LOG"');
+  // header carries a UTC timestamp + the from->to versions for at-a-glance scan
+  expect(s).toContain("=== herdr-update $(date -u +%Y-%m-%dT%H:%M:%SZ) 0.6.5 -> 0.6.6 ===");
+  // dir is created so a fresh ~/.shepherd never makes the first update silently drop its log
+  expect(s).toContain('mkdir -p "$(dirname "$LOG")"');
+});
+
+test("buildUpdateScript: sanitizes versions so an external payload can't inject shell", () => {
+  const s = buildUpdateScript(LOG, "0.6.5", '0.6.6"; rm -rf ~ #');
+  expect(s).not.toContain("rm -rf");
+  // stripped down to version chars
+  expect(s).toContain("0.6.5 -> 0.6.6 ===");
+});
+
+test("buildUpdateScript: missing versions degrade to 'unknown', never empty", () => {
+  const s = buildUpdateScript(LOG, null, undefined);
+  expect(s).toContain("unknown -> unknown ===");
+});
 
 // ── compareSemver ───────────────────────────────────────────────────────────
 test("compareSemver: orders major/minor/patch numerically", () => {


### PR DESCRIPTION
## Problem

A `herdr update` triggered from the UI intermittently left Shepherd unreachable with a **502** — recoverable only by manually running `herdr` in a console. The launch script was:

```
herdr server stop || true; herdr update && systemctl --user restart shepherd
```

The `&&` short-circuits: if `herdr update` exits non-zero, shepherd is **never restarted** — but `herdr server stop` already ran, so herdr is down and shepherd is stranded. Manually running `herdr` revived the server, which is why it "suddenly worked again." The live log also dies at that exact moment, because shepherd (the thing streaming it) is the casualty — so the incident left no inspectable trace.

## Changes

- **Persistent audit log** at `~/.shepherd/herdr-update.log` (`SHEPHERD_HERDR_UPDATE_LOG` overrides). Every update appends one delimited block: a UTC-timestamped `<from> -> <to>` header, each step marker, raw `herdr update` output, its exit code, and the restart result. The **transient `herdr-update` unit writes it via `tee -a`** — not shepherd — so the record is complete even while shepherd is down mid-restart. The same lines still stream to the journal and the modal.
- **Unconditional shepherd restart** (`herdr update; rc=$?; … ; restart` instead of `&&`). Self-heals the stranded-502: worst case shepherd comes back on the old herdr version and re-establishes the herdr server on startup. The update exit code is logged explicitly either way.
- **`buildUpdateScript()` extracted + version-sanitized.** `latest.json` is an external source, so versions are stripped to `[0-9.]` before embedding in the shell program (injection guard). Extraction makes the sequencing unit-testable without waiting for a real herdr release — the only way to exercise the real launch otherwise.
- **Server-side breadcrumb** in shepherd's own journal on `apply()`, pointing at both the audit log and `journalctl --user -u herdr-update`.

## Testing

- 6 new unit tests: step ordering, append-only audit block, header format, the unconditional-restart guard (so the `&&` regression can't return), version-sanitization against shell injection, and `unknown` fallback. All 20 herdr-update tests pass; lint clean.
- Generated bash validated end-to-end against stubbed `herdr`/`systemctl`: valid syntax, writes + appends the block, still streams to stdout.
- The 19 pre-existing failures in the full suite are unrelated (identical on a clean tree).

> Real end-to-end exercise still requires an actual new herdr release; `buildUpdateScript()` is the tested seam until then.
