### PR TITLE
feat(herdr-update): render release notes as markdown

### DIFF
--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -23,6 +23,32 @@
   let error = $state<string | null>(null);
   let logEl = $state<HTMLPreElement | null>(null);
 
+  // Render the (GitHub release) notes as markdown, sanitized before @html.
+  // marked + DOMPurify are dynamically imported on first render so they stay
+  // off the critical path; the (browser-only) sanitizer never runs during SSR.
+  let renderedNotes = $state("");
+  $effect(() => {
+    const body = update.notes;
+    if (!body) {
+      renderedNotes = "";
+      return;
+    }
+    let alive = true;
+    Promise.all([import("marked"), import("dompurify")])
+      .then(([{ marked }, { default: DOMPurify }]) => {
+        if (alive)
+          renderedNotes = DOMPurify.sanitize(marked.parse(body, { async: false }) as string);
+      })
+      .catch((err) => {
+        // Markdown render is progressive enhancement; warn so a broken
+        // marked/dompurify load isn't swallowed silently.
+        console.warn("herdr release notes markdown render failed", err);
+      });
+    return () => {
+      alive = false;
+    };
+  });
+
   // herdr update restarts herdr (ending live panes) then restarts shepherd; the
   // store auto-reconnects once the new build is live, so we just hold the busy state.
   const busy = $derived(submitting);
@@ -86,7 +112,8 @@
 
     {#if update.notes}
       <div class="notes-label micro">{m.herdrupdate_notes_label()}</div>
-      <pre class="notes">{update.notes}</pre>
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized via DOMPurify above -->
+      <div class="notes">{@html renderedNotes}</div>
     {/if}
 
     <div class="instructions">{m.herdrupdate_instructions()}</div>
@@ -196,17 +223,75 @@
     margin-bottom: -8px;
   }
   .notes {
-    margin: 0;
     overflow-y: auto;
     border: 1px solid var(--color-line);
     background: var(--color-inset);
     padding: 10px 12px;
-    font-family: inherit;
     font-size: 12.5px;
     line-height: 1.5;
     color: var(--color-ink-bright);
+    overflow-wrap: anywhere;
+  }
+  /* markdown rendered via {@html} — children aren't scoped, so target globally */
+  .notes :global(> *:first-child) {
+    margin-top: 0;
+  }
+  .notes :global(> *:last-child) {
+    margin-bottom: 0;
+  }
+  .notes :global(p),
+  .notes :global(ul),
+  .notes :global(ol) {
+    margin: 0 0 8px;
+  }
+  .notes :global(ul),
+  .notes :global(ol) {
+    padding-left: 18px;
+  }
+  .notes :global(li) {
+    margin: 2px 0;
+  }
+  .notes :global(h1),
+  .notes :global(h2),
+  .notes :global(h3),
+  .notes :global(h4) {
+    margin: 12px 0 6px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-ink-bright);
+  }
+  .notes :global(a) {
+    color: var(--color-blue);
+    text-decoration: underline;
+  }
+  .notes :global(code) {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    background: var(--color-line);
+    border-radius: 2px;
+    padding: 0 3px;
+    overflow-wrap: anywhere;
+  }
+  .notes :global(pre) {
+    margin: 0 0 8px;
+    padding: 6px 8px;
+    background: var(--color-bg, var(--color-line));
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
     white-space: pre-wrap;
+    overflow-wrap: anywhere;
     word-break: break-word;
+  }
+  .notes :global(pre code) {
+    background: none;
+    padding: 0;
+    overflow-wrap: anywhere;
+  }
+  .notes :global(blockquote) {
+    margin: 0 0 8px;
+    padding-left: 8px;
+    border-left: 2px solid var(--color-line);
+    color: var(--color-muted);
   }
   .instructions {
     border: 1px solid var(--color-line-bright);

--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -36,8 +36,17 @@
     let alive = true;
     Promise.all([import("marked"), import("dompurify")])
       .then(([{ marked }, { default: DOMPurify }]) => {
-        if (alive)
-          renderedNotes = DOMPurify.sanitize(marked.parse(body, { async: false }) as string);
+        // External release-note links must open out-of-app, not navigate the
+        // SPA away; force target/rel on every anchor during sanitize.
+        DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+          if (node.tagName === "A") {
+            node.setAttribute("target", "_blank");
+            node.setAttribute("rel", "noopener noreferrer");
+          }
+        });
+        const html = DOMPurify.sanitize(marked.parse(body, { async: false }) as string);
+        DOMPurify.removeAllHooks();
+        if (alive) renderedNotes = html;
       })
       .catch((err) => {
         // Markdown render is progressive enhancement; warn so a broken
@@ -112,8 +121,14 @@
 
     {#if update.notes}
       <div class="notes-label micro">{m.herdrupdate_notes_label()}</div>
-      <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized via DOMPurify above -->
-      <div class="notes">{@html renderedNotes}</div>
+      {#if renderedNotes}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized via DOMPurify above -->
+        <div class="notes">{@html renderedNotes}</div>
+      {:else}
+        <!-- Fallback before the markdown imports resolve, or if they fail:
+             show the raw notes as plain text rather than an empty box. -->
+        <pre class="notes notes-raw">{update.notes}</pre>
+      {/if}
     {/if}
 
     <div class="instructions">{m.herdrupdate_instructions()}</div>
@@ -231,6 +246,13 @@
     line-height: 1.5;
     color: var(--color-ink-bright);
     overflow-wrap: anywhere;
+  }
+  /* raw plain-text fallback (pre-resolve / render failure) */
+  .notes-raw {
+    margin: 0;
+    font-family: inherit;
+    white-space: pre-wrap;
+    word-break: break-word;
   }
   /* markdown rendered via {@html} — children aren't scoped, so target globally */
   .notes :global(> *:first-child) {

--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -44,8 +44,14 @@
             node.setAttribute("rel", "noopener noreferrer");
           }
         });
-        const html = DOMPurify.sanitize(marked.parse(body, { async: false }) as string);
-        DOMPurify.removeAllHooks();
+        let html: string;
+        try {
+          html = DOMPurify.sanitize(marked.parse(body, { async: false }) as string);
+        } finally {
+          // Always drop the hook, even if parse/sanitize throws, so it can't
+          // leak onto the next render.
+          DOMPurify.removeAllHooks();
+        }
         if (alive) renderedNotes = html;
       })
       .catch((err) => {

--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -48,9 +48,10 @@
         try {
           html = DOMPurify.sanitize(marked.parse(body, { async: false }) as string);
         } finally {
-          // Always drop the hook, even if parse/sanitize throws, so it can't
-          // leak onto the next render.
-          DOMPurify.removeAllHooks();
+          // Always drop our hook, even if parse/sanitize throws, so it can't
+          // leak onto the next render. Scoped to this event so we don't wipe
+          // any persistent hooks registered elsewhere on the shared singleton.
+          DOMPurify.removeHook("afterSanitizeAttributes");
         }
         if (alive) renderedNotes = html;
       })


### PR DESCRIPTION
## What
Herdr release notes in the update modal now render as **sanitized markdown** instead of raw `<pre>` text.

## Why
`update.notes` comes from `herdr.dev/latest.json` — release-please release notes, which are markdown. They were shown verbatim in a `<pre>`, so headings/lists/links rendered as literal `#`, `-`, `[]()`.

## How
- Parse `update.notes` with `marked`, sanitize with `DOMPurify`, render via `{@html}` — mirroring the existing `GitRail.svelte` review-body pattern (dynamic import off the critical path, browser-only so SSR never runs the sanitizer).
- Swapped `<pre class="notes">` → `<div class="notes">{@html renderedNotes}</div>`.
- Replaced `<pre>`-oriented `.notes` CSS with scoped `:global(...)` markdown child styles (headings, lists, links, code, pre, blockquote) matching `.rv-body`.

No new strings (reused `herdrupdate_notes_label`).

## Verification
- `cd ui && bun run check` → 0 errors / 0 warnings
- root `bun run lint` → clean
- `cd ui && bun run check:i18n` → 2 locales in parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)