### PR TITLE
feat(learnings): inject house rules via system prompt, XML-wrapped

### DIFF
--- a/src/house-rules.ts
+++ b/src/house-rules.ts
@@ -22,7 +22,7 @@ export interface HouseRulesPlan {
   injected: Learning[]; // priority order, fit within budget
   dropped: Learning[]; // over budget, priority order
   budgetChars: number;
-  usedChars: number; // exact rendered length of the block (header + bullets)
+  usedChars: number; // exact rendered length of the block (XML tag + intro + bullets)
 }
 
 /** Priority sort: lastEvidenceAt desc (nulls last), tie-break updatedAt desc.
@@ -56,7 +56,7 @@ export function planHouseRulesInjection(rules: Learning[], budgetChars: number):
     }
   }
   // No rule made the cut → the block renders to null, so report 0 chars used
-  // (not the bare header length) to keep the drawer's budget meter truthful.
+  // (not the bare overhead) to keep the drawer's budget meter truthful.
   return { injected, dropped, budgetChars, usedChars: injected.length === 0 ? 0 : used };
 }
 

--- a/src/house-rules.ts
+++ b/src/house-rules.ts
@@ -1,9 +1,22 @@
 import type { Learning } from "./types";
 
-/** Header for the Shepherd-curated house-rules block prepended to every agent prompt.
- *  Agent-facing prompt text (not operator UI), so it is a fixed English constant —
- *  same precedent as the distiller/critic spawn prompts. */
-export const HOUSE_RULES_HEADER = "## Project house rules (curated by Shepherd)";
+/** XML tag wrapping the Shepherd-curated house-rules block. The block is injected into
+ *  every agent's *system prompt* (not the human turn — see service.ts), so the tag lets the
+ *  agent tell standing guidance apart from the task it is handed. Agent-facing prompt text
+ *  (not operator UI), so fixed English — same precedent as the distiller/critic spawn
+ *  prompts and BRANCH_RENAME_NOTICE. */
+export const HOUSE_RULES_TAG = "shepherd-house-rules";
+
+/** Intro line inside the tag, stating what the rules are and that they are not the task. */
+const HOUSE_RULES_INTRO =
+  "Project house rules curated by Shepherd — standing guidance for this repo. " +
+  "Apply throughout the session; this is not the task itself.";
+
+/** Fixed char overhead of the rendered block, independent of rule count:
+ *  `<tag>\n` + `intro\n` + (rules) + `\n</tag>`. Used as the budget base so the meter
+ *  (usedChars) stays exactly equal to renderHouseRulesBlock(...).length. */
+export const HOUSE_RULES_OVERHEAD =
+  `<${HOUSE_RULES_TAG}>`.length + HOUSE_RULES_INTRO.length + `</${HOUSE_RULES_TAG}>`.length + 2;
 
 export interface HouseRulesPlan {
   injected: Learning[]; // priority order, fit within budget
@@ -32,7 +45,7 @@ export function planHouseRulesInjection(rules: Learning[], budgetChars: number):
   const ordered = prioritize(rules);
   const injected: Learning[] = [];
   const dropped: Learning[] = [];
-  let used = HOUSE_RULES_HEADER.length;
+  let used = HOUSE_RULES_OVERHEAD;
   for (const r of ordered) {
     const cost = ("- " + r.rule + "\n").length;
     if (used + cost <= budgetChars) {
@@ -47,8 +60,9 @@ export function planHouseRulesInjection(rules: Learning[], budgetChars: number):
   return { injected, dropped, budgetChars, usedChars: injected.length === 0 ? 0 : used };
 }
 
-/** Renders the injected rules into the prompt block, or null when none. */
+/** Renders the injected rules into the XML-wrapped block, or null when none. */
 export function renderHouseRulesBlock(injected: Learning[]): string | null {
   if (injected.length === 0) return null;
-  return `${HOUSE_RULES_HEADER}\n${injected.map((r) => `- ${r.rule}`).join("\n")}`;
+  const body = injected.map((r) => `- ${r.rule}`).join("\n");
+  return `<${HOUSE_RULES_TAG}>\n${HOUSE_RULES_INTRO}\n${body}\n</${HOUSE_RULES_TAG}>`;
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -47,16 +47,32 @@ export function spawnSettingsOverlay(): string {
  * Pre-warning it at spawn removes the surprise at the source. Not user-facing chrome
  * (it's an instruction to the agent), so no i18n.
  */
-export const BRANCH_RENAME_NOTICE =
+const BRANCH_RENAME_NOTICE =
   "Shepherd may rename this session's git branch shortly after startup to a clearer, " +
   "prompt-derived name (via `git branch -m`). This is expected: your working tree, " +
   "commits, and checked-out HEAD are unaffected — never treat a changed branch name as an error.";
 
+/**
+ * Compose the spawn-time system prompt passed via a single `--append-system-prompt`
+ * (the flag is last-wins, not repeatable, so both notices must share one value).
+ *
+ * House rules used to be prepended to the human prompt, which let standing guidance bleed
+ * into the task on every spawn. They now live in the system prompt, each notice XML-wrapped
+ * so the agent can cleanly separate persistent repo guidance from the task in its human turn.
+ * `houseRules` is the already-wrapped `<shepherd-house-rules>` block, or null when there are
+ * none / learnings are disabled.
+ */
+export function composeSystemPrompt(houseRules: string | null): string {
+  const branchNotice = `<branch-rename-notice>\n${BRANCH_RENAME_NOTICE}\n</branch-rename-notice>`;
+  return houseRules ? `${houseRules}\n\n${branchNotice}` : branchNotice;
+}
+
 export class SessionService {
   constructor(private deps: ServiceDeps) {}
 
-  /** Active+promoted rules for the repo as a delimited prompt block, or null when
-   *  none / learnings disabled. Prepended to every new agent's prompt (spec §4a). */
+  /** Active+promoted rules for the repo as an XML-wrapped block, or null when
+   *  none / learnings disabled. Injected into every new agent's system prompt
+   *  (via composeSystemPrompt), not the human turn. */
   private houseRules(repoPath: string): string | null {
     if (!this.deps.store.getRepoConfig(repoPath).learningsEnabled) return null;
     const { injected } = planHouseRulesInjection(
@@ -90,14 +106,14 @@ export class SessionService {
         promptArg = `${promptArg}\n\nGitHub Issue #${r.number}: ${r.title}\n${r.url}\n\n${r.body}`;
       }
 
-      // Prepend Shepherd-curated house rules so every spawn (manual AND auto-spawned,
-      // e.g. the work-queue drain #222) inherits the repo's learned corrections.
+      // Shepherd-curated house rules go into the system prompt (not the human turn) so every
+      // spawn (manual AND auto-spawned, e.g. the work-queue drain #222) inherits the repo's
+      // learned corrections without the rules bleeding into the task text.
       const houseRules = this.houseRules(input.repoPath);
-      if (houseRules) promptArg = `${houseRules}\n\n${promptArg}`;
 
       const argv = ["claude", "--dangerously-skip-permissions", "--session-id", claudeSessionId];
       argv.push("--settings", spawnSettingsOverlay());
-      argv.push("--append-system-prompt", BRANCH_RENAME_NOTICE);
+      argv.push("--append-system-prompt", composeSystemPrompt(houseRules));
       if (input.model) argv.push("--model", input.model);
       argv.push(promptArg);
       const agent = this.deps.herdr.start(name, wt.worktreePath, argv);

--- a/test/house-rules.test.ts
+++ b/test/house-rules.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
 import {
-  HOUSE_RULES_HEADER,
+  HOUSE_RULES_OVERHEAD,
+  HOUSE_RULES_TAG,
   planHouseRulesInjection,
   renderHouseRulesBlock,
 } from "../src/house-rules";
@@ -35,7 +36,7 @@ test("priority: lastEvidenceAt desc with nulls last, tie-break updatedAt desc", 
 test("greedy fill picks rules that fit within budget", () => {
   const a = rule({ id: "a", rule: "x".repeat(20), lastEvidenceAt: 300 });
   const b = rule({ id: "b", rule: "y".repeat(20), lastEvidenceAt: 200 });
-  const budget = HOUSE_RULES_HEADER.length + "- ".length + 20 + "\n".length; // header + exactly one rule
+  const budget = HOUSE_RULES_OVERHEAD + "- ".length + 20 + "\n".length; // overhead + exactly one rule
   const plan = planHouseRulesInjection([a, b], budget);
   expect(plan.injected.map((r) => r.id)).toEqual(["a"]);
   expect(plan.dropped.map((r) => r.id)).toEqual(["b"]);
@@ -45,7 +46,7 @@ test("greedy continues past overflow: a later shorter rule still fits (non-prefi
   // priority order: big (highest), small (lowest). big overflows, small fits.
   const big = rule({ id: "big", rule: "x".repeat(500), lastEvidenceAt: 300 });
   const small = rule({ id: "small", rule: "ok", lastEvidenceAt: 100 });
-  const budget = HOUSE_RULES_HEADER.length + ("- " + "ok" + "\n").length + 10; // room for small only
+  const budget = HOUSE_RULES_OVERHEAD + ("- " + "ok" + "\n").length + 10; // room for small only
   const plan = planHouseRulesInjection([big, small], budget);
   expect(plan.injected.map((r) => r.id)).toEqual(["small"]);
   expect(plan.dropped.map((r) => r.id)).toEqual(["big"]);
@@ -53,17 +54,17 @@ test("greedy continues past overflow: a later shorter rule still fits (non-prefi
 
 test("exact-fit boundary is included", () => {
   const a = rule({ id: "a", rule: "abcde", lastEvidenceAt: 1 });
-  const budget = HOUSE_RULES_HEADER.length + ("- " + "abcde" + "\n").length;
+  const budget = HOUSE_RULES_OVERHEAD + ("- " + "abcde" + "\n").length;
   const plan = planHouseRulesInjection([a], budget);
   expect(plan.injected.map((r) => r.id)).toEqual(["a"]);
 });
 
-test("header alone exceeds budget → empty / null, usedChars 0", () => {
+test("block overhead alone exceeds budget → empty / null, usedChars 0", () => {
   const a = rule({ id: "a", rule: "anything" });
-  const plan = planHouseRulesInjection([a], HOUSE_RULES_HEADER.length - 1);
+  const plan = planHouseRulesInjection([a], HOUSE_RULES_OVERHEAD - 1);
   expect(plan.injected).toEqual([]);
-  // usedChars must report 0 (not the bare header length) so the meter matches the
-  // null block — nothing is actually prepended.
+  // usedChars must report 0 (not the bare overhead) so the meter matches the
+  // null block — nothing is actually injected.
   expect(plan.usedChars).toBe(0);
   expect(renderHouseRulesBlock(plan.injected)).toBeNull();
 });
@@ -85,4 +86,14 @@ test("usedChars equals rendered block length for a multi-rule plan", () => {
   const block = renderHouseRulesBlock(plan.injected)!;
   expect(block).not.toBeNull();
   expect(plan.usedChars).toBe(block.length);
+});
+
+test("rendered block is wrapped in the XML tag, one bullet per rule", () => {
+  const a = rule({ id: "a", rule: "use bun" });
+  const b = rule({ id: "b", rule: "rebase, do not merge" });
+  const block = renderHouseRulesBlock([a, b])!;
+  expect(block.startsWith(`<${HOUSE_RULES_TAG}>\n`)).toBe(true);
+  expect(block.endsWith(`\n</${HOUSE_RULES_TAG}>`)).toBe(true);
+  expect(block).toContain("- use bun");
+  expect(block).toContain("- rebase, do not merge");
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
 import { SessionStore } from "../src/store";
-import { SessionService, spawnSettingsOverlay, BRANCH_RENAME_NOTICE } from "../src/service";
+import { SessionService, spawnSettingsOverlay, composeSystemPrompt } from "../src/service";
+import { HOUSE_RULES_TAG } from "../src/house-rules";
 import { config } from "../src/config";
 
 test("createSession: names, makes worktree, starts herdr, persists", async () => {
@@ -57,7 +58,7 @@ test("createSession: names, makes worktree, starts herdr, persists", async () =>
     "--settings",
     spawnSettingsOverlay(),
     "--append-system-prompt",
-    BRANCH_RENAME_NOTICE,
+    composeSystemPrompt(null), // no learnings → branch-rename notice only
     "flatten it",
   ]);
   expect(s.claudeSessionId).toMatch(/^[0-9a-f-]{36}$/);
@@ -438,7 +439,7 @@ test("createSession: passes --model and persists it when a model is chosen", asy
     "--settings",
     spawnSettingsOverlay(),
     "--append-system-prompt",
-    BRANCH_RENAME_NOTICE,
+    composeSystemPrompt(null), // no learnings → branch-rename notice only
     "--model",
     "opus",
     "go",
@@ -1312,7 +1313,22 @@ function injectDeps(store: SessionStore, captured: { argv?: string[] }) {
   };
 }
 
-test("create prepends active+promoted house rules to the prompt", async () => {
+/** The value passed to --append-system-prompt (the flag's following argv element). */
+function sysPrompt(argv: string[]): string {
+  const i = argv.indexOf("--append-system-prompt");
+  return argv[i + 1]!;
+}
+
+/** Just the <shepherd-house-rules>…</shepherd-house-rules> slice of the system prompt. */
+function houseRulesBlock(argv: string[]): string {
+  const sp = sysPrompt(argv);
+  const open = `<${HOUSE_RULES_TAG}>`;
+  const close = `</${HOUSE_RULES_TAG}>`;
+  const start = sp.indexOf(open);
+  return sp.slice(start, sp.indexOf(close) + close.length);
+}
+
+test("create injects active+promoted house rules into the system prompt, task stays clean", async () => {
   const store = new SessionStore(":memory:");
   const a = store.addLearning({
     repoPath: "/repo",
@@ -1330,10 +1346,12 @@ test("create prepends active+promoted house rules to the prompt", async () => {
     model: null,
     images: [],
   });
-  const promptArg = captured.argv!.at(-1)!;
-  expect(promptArg).toContain("Project house rules");
-  expect(promptArg).toContain("- Use bun, not npm");
-  expect(promptArg.endsWith("do the thing")).toBe(true); // user text stays last
+  // Rules ride the system prompt, XML-wrapped — not the human turn.
+  const sp = sysPrompt(captured.argv!);
+  expect(sp).toContain(`<${HOUSE_RULES_TAG}>`);
+  expect(sp).toContain("- Use bun, not npm");
+  // The human prompt (last argv) is exactly the user's task — no rules bleed in.
+  expect(captured.argv!.at(-1)).toBe("do the thing");
 });
 
 test("create omits the house-rules block when no active rules exist", async () => {
@@ -1349,6 +1367,8 @@ test("create omits the house-rules block when no active rules exist", async () =
     images: [],
   });
   expect(captured.argv!.at(-1)).toBe("do the thing");
+  // System prompt carries only the branch-rename notice, no house-rules tag.
+  expect(sysPrompt(captured.argv!)).toBe(composeSystemPrompt(null));
 });
 
 test("create omits house rules when learnings disabled for the repo", async () => {
@@ -1370,6 +1390,7 @@ test("create omits house rules when learnings disabled for the repo", async () =
     images: [],
   });
   expect(captured.argv!.at(-1)).toBe("do the thing");
+  expect(sysPrompt(captured.argv!)).toBe(composeSystemPrompt(null));
 });
 
 test("create injects only the planned house rules and drops the over-budget ones", async () => {
@@ -1394,11 +1415,10 @@ test("create injects only the planned house rules and drops the over-budget ones
     model: null,
     images: [],
   });
-  const promptArg = captured.argv!.at(-1)!;
-  expect(promptArg).toContain("Project house rules");
-  expect(promptArg.endsWith("do the thing")).toBe(true);
-  // Block (everything before the user text) must stay within the 4000-char budget.
-  const block = promptArg.slice(0, promptArg.indexOf("\n\ndo the thing"));
+  // Human prompt stays clean; rules live in the system prompt.
+  expect(captured.argv!.at(-1)).toBe("do the thing");
+  const block = houseRulesBlock(captured.argv!);
+  // Block (XML-wrapped) must stay within the 4000-char budget.
   expect(block.length).toBeLessThanOrEqual(4000);
   // Some rules injected, some dropped (not all 40 fit).
   const injectedCount = (block.match(/^- /gm) ?? []).length;


### PR DESCRIPTION
## Problem

The task wording asked to *investigate* alternative ways to inject learnings, since they're visible on every task start and "should at least be wrapped in an XML tag." Reframing the root cause: house rules weren't just untagged — they were **prepended to the human prompt** (`src/service.ts`), so standing repo guidance bled into the *task message itself* on every spawn.

## Change

Move house rules out of the human turn into the **system prompt**, XML-wrapped.

- **`src/house-rules.ts`** — `renderHouseRulesBlock` now emits a `<shepherd-house-rules>` block with an intro line ("standing guidance … not the task itself"). Budget base (`HOUSE_RULES_OVERHEAD`) tracks the new fixed tag/intro overhead so the drawer invariant `usedChars === rendered.length` stays exact.
- **`src/service.ts`** — new `composeSystemPrompt()` folds the house-rules block + the branch-rename notice into **one** `--append-system-prompt` value (the flag is *last-wins, not repeatable* — verified), each wrapped in its own XML tag. The human prompt now carries only the user's task.

## Why the system prompt

House rules are persistent agent instructions, not task content. The system prompt is where the existing branch-rename notice already lives, it persists for the whole session (not just turn 1), and it keeps the task turn clean — directly addressing "visible on every task start."

## Verification

- `bun run lint` clean · `bunx tsc --noEmit` clean
- `bun test ./test` — 784 pass, 1 skip, 0 fail
- `bunx fallow dead-code` — no issues
- No UI / i18n impact (rules are agent-facing English, no catalog change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)