### PR TITLE
fix(critic): don't steer findings into an agent after its PR merged

### DIFF
--- a/docs/superpowers/plans/2026-06-03-critic-postmerge-steer-guard.md
+++ b/docs/superpowers/plans/2026-06-03-critic-postmerge-steer-guard.md
@@ -1,0 +1,395 @@
+# Critic Post-Merge Steer Guard — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop an in-flight critic from steering findings into a task agent after that agent's PR has already merged/closed.
+
+**Architecture:** Re-fetch authoritative live PR state at the last gate before the auto-address steer (`runAutoAddress` in `src/review.ts`) and skip the steer when the PR is not `"open"`. Surgical: `postReview`, `putReview`, and the learnings signal are untouched. Fail-closed when state can't be confirmed.
+
+**Tech Stack:** Bun + TypeScript (root server package). Tests: `bun test`. Lint: `bun run lint`. Strict tsc: `bunx tsc --noEmit`.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-critic-postmerge-steer-guard-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `src/review.ts`
+  - `InFlight` interface: add `branch: string`.
+  - `begin()`: populate `branch` when constructing the `InFlight` record.
+  - `runAutoAddress()`: become `async`, add the live PR-state recheck before steering.
+  - `finalize()`: `await` the now-async `runAutoAddress()`.
+- **Modify** `test/review.test.ts`
+  - `fakeForge()` / `makeDeps()`: make `prStatus` injectable (default stays `OPEN_GREEN`).
+  - Add 3 new tests (merged → no steer; throw → fail-closed; closed → no steer).
+
+No UI, i18n, schema, or migration changes.
+
+---
+
+## Task 1: Failing test — a merged PR at finalize must not steer
+
+Make the test forge's PR state injectable, then add the failing test proving the bug.
+
+**Files:**
+- Test: `test/review.test.ts` (modify `fakeForge`, `makeDeps`, add one test)
+
+- [ ] **Step 1: Make `fakeForge` accept an injectable `prStatus`**
+
+In `test/review.test.ts`, change the `fakeForge` signature and its `prStatus` field. Current:
+
+```ts
+function fakeForge(
+  rec: { event?: string; body?: string },
+  comments: PrComment[],
+  commentCalls: number[],
+): GitForge {
+  return {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus: async () => OPEN_GREEN as PrStatus,
+    openPr: async () => OPEN_GREEN as PrStatus,
+```
+
+Replace with (add 4th param, use it for `prStatus`):
+
+```ts
+function fakeForge(
+  rec: { event?: string; body?: string },
+  comments: PrComment[],
+  commentCalls: number[],
+  prStatus: () => Promise<PrStatus> = async () => OPEN_GREEN as PrStatus,
+): GitForge {
+  return {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus,
+    openPr: async () => OPEN_GREEN as PrStatus,
+```
+
+- [ ] **Step 2: Thread `prStatus` through `makeDeps`**
+
+In `makeDeps`, extend the `opts` type and pass it into `fakeForge`. Current `opts` param:
+
+```ts
+  opts: {
+    autoAddressEnabled?: boolean;
+    autoAddressReturns?: boolean;
+    comments?: PrComment[];
+  } = {},
+```
+
+Replace with:
+
+```ts
+  opts: {
+    autoAddressEnabled?: boolean;
+    autoAddressReturns?: boolean;
+    comments?: PrComment[];
+    prStatus?: () => Promise<PrStatus>;
+  } = {},
+```
+
+Then change the `resolveForge` line inside `makeDeps`. Current:
+
+```ts
+    resolveForge: () => fakeForge(rec, opts.comments ?? [], commentCalls),
+```
+
+Replace with:
+
+```ts
+    resolveForge: () => fakeForge(rec, opts.comments ?? [], commentCalls, opts.prStatus),
+```
+
+- [ ] **Step 3: Write the failing test**
+
+Add this test next to the other auto-address tests (after the "round cap reached" test):
+
+```ts
+test("PR merged before finalize: holds the round, posts the review, does NOT steer", async () => {
+  const {
+    deps: d,
+    reviews,
+    steers,
+    rec,
+  } = makeDeps(
+    {
+      readVerdict: () => ({
+        decision: "request-changes",
+        summary: "x",
+        body: "b",
+        findings: ["fix x"],
+      }),
+    },
+    // critic spawned while open, but the PR merged before the verdict finalized
+    { autoAddressEnabled: true, prStatus: async () => ({ ...OPEN_GREEN, state: "merged" }) },
+  );
+  const svc = new ReviewService(d as any);
+  svc.consider(session(), OPEN_GREEN); // spawn while open (no prStatus call yet)
+  await svc.tick(); // finalize: live recheck sees "merged"
+  expect(steers).toHaveLength(0); // no churn steered onto a merged branch
+  expect(reviews["s1"]?.addressRound).toBe(0); // round held (priorRound 0), not advanced
+  expect(rec.event).toBe("REQUEST_CHANGES"); // surgical: review still posted
+  expect(reviews["s1"]?.decision).toBe("changes_requested"); // verdict still persisted
+});
+```
+
+- [ ] **Step 4: Run the test to verify it FAILS**
+
+Run: `bun test ./test/review.test.ts -t "PR merged before finalize"`
+Expected: FAIL — `steers` has length 1 (current code steers regardless of PR state).
+
+- [ ] **Step 5: Commit the failing test**
+
+```bash
+git add test/review.test.ts
+git commit -m "test(critic): failing test — merged PR must not steer the agent"
+```
+
+---
+
+## Task 2: Implement the live PR-state guard
+
+**Files:**
+- Modify: `src/review.ts` (`InFlight` interface, `begin()`, `runAutoAddress()`, `finalize()`)
+
+- [ ] **Step 1: Add `branch` to the `InFlight` interface**
+
+In `src/review.ts`, find the `InFlight` interface. Current:
+
+```ts
+interface InFlight {
+  sessionId: string;
+  headSha: string;
+  prNumber: number;
+  repoPath: string;
+  worktreePath: string;
+  terminalId: string;
+```
+
+Insert `branch` after `prNumber`:
+
+```ts
+interface InFlight {
+  sessionId: string;
+  headSha: string;
+  prNumber: number;
+  branch: string; // head branch, for the at-finalize live PR-state recheck (prStatus keys on it)
+  repoPath: string;
+  worktreePath: string;
+  terminalId: string;
+```
+
+- [ ] **Step 2: Populate `branch` in `begin()`**
+
+In `begin()`, find the `this.inflight.set(session.id, { ... })` call. Current:
+
+```ts
+    this.inflight.set(session.id, {
+      sessionId: session.id,
+      headSha: git.headSha!,
+      prNumber: git.number!,
+      repoPath: session.repoPath,
+```
+
+Insert `branch` after `prNumber`:
+
+```ts
+    this.inflight.set(session.id, {
+      sessionId: session.id,
+      headSha: git.headSha!,
+      prNumber: git.number!,
+      branch: session.branch!,
+      repoPath: session.repoPath,
+```
+
+- [ ] **Step 3: Make `runAutoAddress` async and add the recheck**
+
+In `src/review.ts`, change the `runAutoAddress` signature and insert the live recheck after the cap guard. Current signature line:
+
+```ts
+  private runAutoAddress(f: InFlight, verdict: ReviewVerdict): number {
+```
+
+Replace with:
+
+```ts
+  private async runAutoAddress(f: InFlight, verdict: ReviewVerdict): Promise<number> {
+```
+
+Then find the cap guard and the steer block. Current:
+
+```ts
+    if (f.priorRound >= this.cap) return f.priorRound; // gave up → hold (stalled badge persists)
+    // autoAddress (SessionService.reply) liveness-checks the pane and returns false for a
+    // dead one, so a steer that can't land normally reports false. A throw is now only a
+    // narrow race — the pane dies between the liveness check and herdr.send — and still
+    // counts as not-delivered: the round must not advance on a steer that never landed,
+    // and the throw must not strand finalize().
+    let delivered = false;
+```
+
+Insert the recheck between the cap guard and the `let delivered = false;` line:
+
+```ts
+    if (f.priorRound >= this.cap) return f.priorRound; // gave up → hold (stalled badge persists)
+    // Critic spawn and PR merge both fire on CI-green, so they race by construction: the
+    // critic can finish AFTER the PR merged. Re-confirm the PR is still open at this last
+    // gate before steering — otherwise we'd tell the agent to "commit & push so CI and the
+    // critic re-run" on a branch whose PR is already merged/closed. Live fetch, not the
+    // cached snapshot: the 120s poll can lag the merge, and staleness reintroduces the race.
+    // Fail-closed — if we can't confirm "open" (forge throws / unresolved), don't steer: a
+    // missed steer is recoverable (next push re-triggers; a human can send), churn on a dead
+    // branch is not. Lazy (only here, past the findings/enabled/cap guards) so clean
+    // verdicts and disabled-loop repos make no extra forge call.
+    let open = false;
+    try {
+      const forge = this.deps.resolveForge(f.repoPath);
+      open = (await forge?.prStatus(f.branch))?.state === "open";
+    } catch (err) {
+      console.warn(`[review] PR-state recheck failed for ${f.sessionId}:`, err);
+    }
+    if (!open) return f.priorRound; // PR no longer open (or unconfirmable) → hold, don't steer
+    // autoAddress (SessionService.reply) liveness-checks the pane and returns false for a
+    // dead one, so a steer that can't land normally reports false. A throw is now only a
+    // narrow race — the pane dies between the liveness check and herdr.send — and still
+    // counts as not-delivered: the round must not advance on a steer that never landed,
+    // and the throw must not strand finalize().
+    let delivered = false;
+```
+
+- [ ] **Step 4: Await `runAutoAddress` in `finalize`**
+
+In `finalize()`, find the call. Current:
+
+```ts
+        verdict.addressRound = this.runAutoAddress(f, verdict); // errorRound stays 0 on a real verdict
+```
+
+Replace with:
+
+```ts
+        verdict.addressRound = await this.runAutoAddress(f, verdict); // errorRound stays 0 on a real verdict
+```
+
+- [ ] **Step 5: Run the failing test — it now PASSES**
+
+Run: `bun test ./test/review.test.ts -t "PR merged before finalize"`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full review suite — no regressions**
+
+Run: `bun test ./test/review.test.ts`
+Expected: PASS (all existing steer tests get the default `OPEN_GREEN` `prStatus`, so `open === true` and they steer exactly as before).
+
+- [ ] **Step 7: Commit the fix**
+
+```bash
+git add src/review.ts
+git commit -m "fix(critic): re-check live PR state before steering; skip on merged/closed PR"
+```
+
+---
+
+## Task 3: Cover fail-closed (throw) and the closed-PR class
+
+**Files:**
+- Test: `test/review.test.ts` (add two tests)
+
+- [ ] **Step 1: Write the fail-closed (throw) test**
+
+Add next to the merged-PR test:
+
+```ts
+test("PR-state recheck throws: fail-closed — no steer, round held", async () => {
+  const {
+    deps: d,
+    reviews,
+    steers,
+  } = makeDeps(
+    { readVerdict: () => ({ decision: "comment", summary: "nit", body: "b", findings: ["x"] }) },
+    {
+      autoAddressEnabled: true,
+      prStatus: async () => {
+        throw new Error("gh unavailable");
+      },
+    },
+  );
+  const svc = new ReviewService(d as any);
+  svc.consider(session(), OPEN_GREEN);
+  await svc.tick(); // must NOT reject
+  expect(steers).toHaveLength(0); // can't confirm open → don't steer
+  expect(reviews["s1"]?.addressRound).toBe(0); // round held
+});
+```
+
+- [ ] **Step 2: Write the closed-PR (whole-class) test**
+
+```ts
+test("PR closed (not merged) before finalize: also skips the steer", async () => {
+  const { deps: d, steers } = makeDeps(
+    { readVerdict: () => ({ decision: "comment", summary: "nit", body: "b", findings: ["x"] }) },
+    { autoAddressEnabled: true, prStatus: async () => ({ ...OPEN_GREEN, state: "closed" }) },
+  );
+  const svc = new ReviewService(d as any);
+  svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(steers).toHaveLength(0); // guard is state !== "open", not just merged
+});
+```
+
+- [ ] **Step 3: Run the two new tests**
+
+Run: `bun test ./test/review.test.ts -t "fail-closed"` then `bun test ./test/review.test.ts -t "PR closed"`
+Expected: both PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/review.test.ts
+git commit -m "test(critic): cover fail-closed recheck + closed-PR steer skip"
+```
+
+---
+
+## Task 4: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Lint**
+
+Run: `bun run lint`
+Expected: clean (no errors).
+
+- [ ] **Step 2: Strict tsc**
+
+Run: `bunx tsc --noEmit`
+Expected: no type errors (confirms `runAutoAddress`'s `Promise<number>` is correctly awaited in `finalize`).
+
+- [ ] **Step 3: Full root server test suite**
+
+Run: `bun test ./test`
+Expected: all pass.
+
+- [ ] **Step 4: Confirm working tree is committed**
+
+Run: `git status --short`
+Expected: empty (all changes committed across Tasks 1–3).
+
+---
+
+## Notes for the implementer
+
+- **Why finalize-time, not an abort-on-merge event handler:** the 15s finalize tick can fire the steer before the 120s PR poller even detects the merge. Only a recheck at the steer gate is authoritative. Early abort-on-merge is a deliberate non-goal (see spec).
+- **Why surgical:** `postReview` posting a review on a merged PR is harmless noise; the chaos is the agent steer telling it to push to a dead branch. Only the steer is gated.
+- **Laziness matters:** the recheck sits *after* the findings-empty / loop-disabled / at-cap guards, so it never adds a forge call on the common no-steer paths.
+- **Concurrency:** the new `await` is inside the `f.finalizing = true` window; `tick()` already `continue`s past `finalizing` entries, so no double-finalize race is introduced.

--- a/docs/superpowers/plans/2026-06-03-critic-postmerge-steer-guard.md
+++ b/docs/superpowers/plans/2026-06-03-critic-postmerge-steer-guard.md
@@ -1,5 +1,12 @@
 # Critic Post-Merge Steer Guard — Implementation Plan
 
+> **⚠️ Superseded scope (kept for history).** This plan implements the original
+> **surgical** (steer-only) approach, which shipped first. It was later **widened to a
+> "moot run"** (gate `postReview` + the `critic` signal on the same live-open check, all in
+> `finalize()`) per the PR #281 critic review. The spec
+> (`docs/superpowers/specs/2026-06-03-critic-postmerge-steer-guard-design.md`) reflects the
+> final moot-run design; the tasks below describe the intermediate surgical step.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Stop an in-flight critic from steering findings into a task agent after that agent's PR has already merged/closed.

--- a/docs/superpowers/specs/2026-06-03-critic-postmerge-steer-guard-design.md
+++ b/docs/superpowers/specs/2026-06-03-critic-postmerge-steer-guard-design.md
@@ -34,15 +34,21 @@ merge co-trigger on CI-green so they race by construction.
 
 ## Fix
 
-Re-fetch authoritative live PR state at the **last gate before the steer**
-(`runAutoAddress()`), and skip the steer when the PR is no longer `"open"`.
+Re-fetch authoritative live PR state in `finalize()` and, when the PR is no longer
+`"open"`, treat the whole verdict as **moot** — emit none of its outward effects.
 
-### Scope — surgical (steer only)
+### Scope — moot run
 
-Only the auto-address steer is suppressed. **Unchanged:** `postReview()` (a merged PR
-still gets its critic review posted), `putReview()` (verdict still persisted), and the
-`critic` learnings signal. The chaos source is the steer; that is the only behavior
-that changes.
+> **History:** originally shipped "surgical" (steer-only) per an explicit scope call;
+> widened to the moot run below in response to the PR #281 critic review, which flagged
+> that posting a `REQUEST_CHANGES` review and recording a `critic` learnings signal on an
+> already-merged PR is itself confusing/noise.
+
+When the PR is not open at finalize, **all three** outward effects are suppressed: the
+steer, `postReview()`, **and** the `critic` learnings signal. Still run regardless of
+state: `putReview()` (verdict persisted for UI/dedup), `onChange()`, and the
+worktree/terminal reap (the `finally`). A merged/closed PR's critic run leaves no trace
+on the world beyond the local verdict row.
 
 ### Mechanics
 
@@ -50,43 +56,44 @@ that changes.
    `session.branch` in `begin()`. `prStatus()` keys on the head branch, and `InFlight`
    currently stores only `prNumber`.
 
-2. **Make `runAutoAddress()` async** (`Promise<number>`); `finalize()` awaits it:
-   `verdict.addressRound = await this.runAutoAddress(f, verdict);`.
+2. **`runAutoAddress()` stays synchronous** (`: number`). `finalize()` awaits the single
+   `prStatus()` call directly and calls `runAutoAddress()` un-awaited inside the open
+   gate. (Reaching `runAutoAddress()` already implies the PR is open, so it does no
+   recheck of its own.)
 
-3. **Lazy live recheck.** Inside `runAutoAddress()`, *after* the existing guards
-   (findings non-empty → `autoAddressEnabled` → `priorRound < cap`) and **only** when
-   about to steer, call `resolveForge(f.repoPath)?.prStatus(f.branch)`. Steer only if
-   live `state === "open"`. The laziness means clean verdicts, disabled-loop repos, and
-   at-cap streaks make **zero** new forge calls.
+3. **Single live recheck in `finalize()`.** At the top of the real-verdict (`else`)
+   branch, call `resolveForge(f.repoPath)?.prStatus(f.branch)` once and compute
+   `open = state === "open"`. Gate `postReview()`, `runAutoAddress()`, and the `critic`
+   `addSignal()` together behind `if (open && forge)`. One forge call per finalized real
+   verdict — `finalize()` already does forge I/O (`postReview`, `fetchAuthorNotes`), so
+   this is consistent.
 
-4. **Not open ⇒ hold the round.** Skip the steer and return `f.priorRound` (no advance,
-   no reset) — identical to the existing "steer didn't land" semantics, so the badge is
-   coherent and a later push could retry.
+4. **Not open ⇒ inert.** The whole open-gated block is skipped; `addressRound` keeps its
+   `buildVerdict` default (`0`) and no review/steer/signal is emitted.
 
-5. **Fail-closed.** If `prStatus()` throws, or the forge can't be resolved (state can't
-   be confirmed open), skip the steer and hold the round. Rationale: the steer is
-   recoverable (next push re-triggers; a human can send manually); the chaos is not.
-   Log the skip (`console.warn`), consistent with the file's other best-effort forge
-   warnings.
+5. **Fail-closed.** If `prStatus()` throws or the forge can't be resolved (state can't be
+   confirmed open), stay fully inert. Rationale: a missed review/steer is recoverable
+   (next push re-triggers; a human can send manually); acting on a dead PR is not. Log
+   the skip (`console.warn`), consistent with the file's other best-effort forge warnings.
 
 ### Whole-class coverage
 
-The guard checks `state !== "open"`, covering **merged, closed, and `none`** (e.g. a
-branch deleted on merge) — not just the literal merged case named in the bug.
+The guard checks `state === "open"`, so every non-open state — **merged, closed, and
+`none`** (e.g. a branch deleted on merge) — is inert, not just the literal merged case
+named in the bug.
 
 ### Deliberately NOT in scope (YAGNI)
 
 - **Event-driven abort-on-merge.** A `session:git` handler that aborts an in-flight
   critic when its PR leaves `"open"` would save wasted critic compute, but **cannot
-  close the race alone**: the 15s finalize tick can fire the steer before the 120s
-  merge-detection poll runs. The finalize-time recheck is the authoritative fix; early
-  abort is a separable optimization, omitted here.
-- Suppressing `postReview` / signal on a merged PR (rejected: surgical scope).
+  close the race alone**: the 15s finalize tick can fire before the 120s merge-detection
+  poll runs. The finalize-time recheck is the authoritative fix; early abort is a
+  separable optimization, omitted here.
 
 ## Race / concurrency safety
 
-The new `await` sits inside the `f.finalizing = true` window. Overlapping ticks already
-`continue` past a `finalizing` entry (`tick()`, `review.ts:306`), so no new
+The `await prStatus()` sits inside the `f.finalizing = true` window. Overlapping ticks
+already `continue` past a `finalizing` entry (`tick()`, `review.ts:308`), so no new
 double-finalize race is introduced, and no dedupe-guard/slot-claim is straddled (the
 inflight slot is claimed for the whole of `finalize`). `finalize()` already performs
 forge I/O (`postReview`, `fetchAuthorNotes`) on this same tick, so the added
@@ -95,27 +102,32 @@ forge I/O (`postReview`, `fetchAuthorNotes`) on this same tick, so the added
 ## No UI / i18n impact
 
 Server-only. `steerText` / `reviewPrompt` remain English (agent-facing, never i18n'd).
-The verdict payload shape is unchanged; `addressRound` simply does not advance when the
-PR is no longer open. No locale-catalog or Svelte changes.
+The verdict payload shape is unchanged; on a non-open PR the verdict is still persisted
+but carries no `url` and `addressRound` stays `0`. No locale-catalog or Svelte changes.
 
-## Test plan (`test/review.test.ts`)
+## Test plan (`test/review.test.ts`, `test/signal-capture.test.ts`)
 
 Thread an optional PR state into the test forge: extend `fakeForge` / `makeDeps` so a
 test can make `prStatus` resolve a non-open state (default stays `OPEN_GREEN`, so every
-existing steer test passes unchanged).
+existing open-path test passes unchanged).
 
-New cases:
+Cases:
 
-1. **Merged at finalize ⇒ no steer (surgical).** `autoAddressEnabled`, findings
-   present, `prStatus → { ...OPEN_GREEN, state: "merged" }`. Assert: `steers` empty;
-   `addressRound` held (not advanced); `rec.event === "REQUEST_CHANGES"` (postReview
-   still fired); verdict persisted.
-2. **Still open ⇒ steers as before.** `prStatus → OPEN_GREEN`. Assert one steer,
-   `addressRound` advances (guards the default path).
-3. **`prStatus` throws ⇒ no steer, round held (fail-closed).**
-4. **Closed (not merged) ⇒ no steer.** `state: "closed"` — proves whole-class coverage.
+1. **Merged at finalize ⇒ fully inert.** `autoAddressEnabled`, findings present,
+   `prStatus → { ...OPEN_GREEN, state: "merged" }`. Assert: `steers` empty;
+   `rec.event === undefined` (postReview **not** fired); no `critic` signal; verdict still
+   persisted (`decision === "changes_requested"`); `addressRound === 0`.
+2. **`prStatus` throws ⇒ fully inert (fail-closed).** Assert `steers` empty and
+   `rec.event === undefined`; tick does not reject.
+3. **Closed (not merged) ⇒ fully inert.** `state: "closed"` — assert `steers` empty and
+   `rec.event === undefined`; proves whole-class coverage.
+4. **Open path unchanged (regression guard).** Covered by the existing default-open
+   tests: "consider → tick: posts request-changes…" (review + signal fire) and "round cap
+   reached…" (review + signal fire, no steer). `signal-capture.test.ts` swaps its
+   `resolveForge: () => null` for an open fake forge so the `critic`-signal path stays
+   genuinely exercised under the new gate.
 
-Existing suite must remain green (the default-open forge keeps steer tests intact).
+Existing suite must remain green (the default-open forge keeps open-path tests intact).
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-06-03-critic-postmerge-steer-guard-design.md
+++ b/docs/superpowers/specs/2026-06-03-critic-postmerge-steer-guard-design.md
@@ -1,0 +1,124 @@
+# Spec: guard critic auto-address steer against a merged/closed PR
+
+Date: 2026-06-03
+Status: approved, ready for implementation plan
+Area: server (`src/review.ts`), tests (`test/review.test.ts`)
+
+## Problem
+
+An in-flight critic can steer findings into the task agent **after that agent's PR
+has already merged**, telling it to "commit & push so CI and the critic re-run" on a
+branch whose PR is closed/deleted — producing churn against a dead branch.
+
+Confirmed by reading `src/review.ts`:
+
+- The only merged-PR guard is in `consider()` (`review.ts:141`):
+  `if (git.state !== "open" || ...) return;`. It blocks spawning a **new** critic on a
+  merged PR.
+- Once a critic is `inflight`, the delivery chain `tick()` → `finalize()` →
+  `runAutoAddress()` → `autoAddress()` steer **never rechecks live PR state**. The
+  `InFlight` record snapshots `headSha`/`prNumber` at spawn (`review.ts:72-85`,
+  `255-267`) and nothing reconsults the forge before steering.
+
+This is **not a corner case**. Critic spawn and PR merge are both gated on CI-green:
+the same green that spawns the critic is the green light to merge. Any promptly-merged
+green PR has an in-flight critic that finalizes (15s tick) and steers — and because
+merge-detection is a 120s poll, the steer routinely beats the merge being noticed.
+
+## Root cause (reframed)
+
+Not "merge causes chaos." The cause is: **the in-flight critic delivers findings
+without re-confirming the PR is still open at finalize time** — the last moment before
+the steer. The spawn-time guard does not protect the delivery path, and the spawn and
+merge co-trigger on CI-green so they race by construction.
+
+## Fix
+
+Re-fetch authoritative live PR state at the **last gate before the steer**
+(`runAutoAddress()`), and skip the steer when the PR is no longer `"open"`.
+
+### Scope — surgical (steer only)
+
+Only the auto-address steer is suppressed. **Unchanged:** `postReview()` (a merged PR
+still gets its critic review posted), `putReview()` (verdict still persisted), and the
+`critic` learnings signal. The chaos source is the steer; that is the only behavior
+that changes.
+
+### Mechanics
+
+1. **Carry the branch.** Add `branch: string` to `InFlight`, captured from
+   `session.branch` in `begin()`. `prStatus()` keys on the head branch, and `InFlight`
+   currently stores only `prNumber`.
+
+2. **Make `runAutoAddress()` async** (`Promise<number>`); `finalize()` awaits it:
+   `verdict.addressRound = await this.runAutoAddress(f, verdict);`.
+
+3. **Lazy live recheck.** Inside `runAutoAddress()`, *after* the existing guards
+   (findings non-empty → `autoAddressEnabled` → `priorRound < cap`) and **only** when
+   about to steer, call `resolveForge(f.repoPath)?.prStatus(f.branch)`. Steer only if
+   live `state === "open"`. The laziness means clean verdicts, disabled-loop repos, and
+   at-cap streaks make **zero** new forge calls.
+
+4. **Not open ⇒ hold the round.** Skip the steer and return `f.priorRound` (no advance,
+   no reset) — identical to the existing "steer didn't land" semantics, so the badge is
+   coherent and a later push could retry.
+
+5. **Fail-closed.** If `prStatus()` throws, or the forge can't be resolved (state can't
+   be confirmed open), skip the steer and hold the round. Rationale: the steer is
+   recoverable (next push re-triggers; a human can send manually); the chaos is not.
+   Log the skip (`console.warn`), consistent with the file's other best-effort forge
+   warnings.
+
+### Whole-class coverage
+
+The guard checks `state !== "open"`, covering **merged, closed, and `none`** (e.g. a
+branch deleted on merge) — not just the literal merged case named in the bug.
+
+### Deliberately NOT in scope (YAGNI)
+
+- **Event-driven abort-on-merge.** A `session:git` handler that aborts an in-flight
+  critic when its PR leaves `"open"` would save wasted critic compute, but **cannot
+  close the race alone**: the 15s finalize tick can fire the steer before the 120s
+  merge-detection poll runs. The finalize-time recheck is the authoritative fix; early
+  abort is a separable optimization, omitted here.
+- Suppressing `postReview` / signal on a merged PR (rejected: surgical scope).
+
+## Race / concurrency safety
+
+The new `await` sits inside the `f.finalizing = true` window. Overlapping ticks already
+`continue` past a `finalizing` entry (`tick()`, `review.ts:306`), so no new
+double-finalize race is introduced, and no dedupe-guard/slot-claim is straddled (the
+inflight slot is claimed for the whole of `finalize`). `finalize()` already performs
+forge I/O (`postReview`, `fetchAuthorNotes`) on this same tick, so the added
+`prStatus()` call introduces no new class of blocking and is not on a request handler.
+
+## No UI / i18n impact
+
+Server-only. `steerText` / `reviewPrompt` remain English (agent-facing, never i18n'd).
+The verdict payload shape is unchanged; `addressRound` simply does not advance when the
+PR is no longer open. No locale-catalog or Svelte changes.
+
+## Test plan (`test/review.test.ts`)
+
+Thread an optional PR state into the test forge: extend `fakeForge` / `makeDeps` so a
+test can make `prStatus` resolve a non-open state (default stays `OPEN_GREEN`, so every
+existing steer test passes unchanged).
+
+New cases:
+
+1. **Merged at finalize ⇒ no steer (surgical).** `autoAddressEnabled`, findings
+   present, `prStatus → { ...OPEN_GREEN, state: "merged" }`. Assert: `steers` empty;
+   `addressRound` held (not advanced); `rec.event === "REQUEST_CHANGES"` (postReview
+   still fired); verdict persisted.
+2. **Still open ⇒ steers as before.** `prStatus → OPEN_GREEN`. Assert one steer,
+   `addressRound` advances (guards the default path).
+3. **`prStatus` throws ⇒ no steer, round held (fail-closed).**
+4. **Closed (not merged) ⇒ no steer.** `state: "closed"` — proves whole-class coverage.
+
+Existing suite must remain green (the default-open forge keeps steer tests intact).
+
+## Verification
+
+- `bun run lint` (root)
+- `bun test ./test` (root server tests; includes `test/review.test.ts`)
+- `bunx tsc --noEmit` (root strict tsc)

--- a/src/review.ts
+++ b/src/review.ts
@@ -350,8 +350,21 @@ export class ReviewService {
           });
         }
       } else {
+        // Critic spawn and PR merge both fire on CI-green, so they race by construction:
+        // the critic can finish AFTER the PR merged/closed. A merged/closed PR's verdict is
+        // moot — re-confirm the PR is still open before acting on it: don't post the review,
+        // don't steer the agent (churn on a dead branch), and don't record a learnings signal
+        // for a PR that's already gone. Live fetch, not the cached snapshot: the 120s poll can
+        // lag the merge, and staleness reintroduces the race. Fail-closed — if we can't confirm
+        // "open" (no forge / forge throws), stay fully inert.
         const forge = this.deps.resolveForge(f.repoPath);
-        if (forge) {
+        let open = false;
+        try {
+          open = (await forge?.prStatus(f.branch))?.state === "open";
+        } catch (err) {
+          console.warn(`[review] PR-state recheck failed for ${f.sessionId}:`, err);
+        }
+        if (open && forge) {
           try {
             const event = verdict.decision === "changes_requested" ? "REQUEST_CHANGES" : "COMMENT";
             const { url } = await forge.postReview(f.prNumber, {
@@ -362,18 +375,19 @@ export class ReviewService {
           } catch (err) {
             console.warn(`[review] postReview failed for ${f.sessionId}:`, err);
           }
+          // reached only when the PR is confirmed open (errorRound stays 0 on a real verdict)
+          verdict.addressRound = this.runAutoAddress(f, verdict);
+          if (verdict.decision === "changes_requested") {
+            this.deps.store.addSignal({
+              repoPath: f.repoPath,
+              sessionId: f.sessionId,
+              kind: "critic",
+              payload: `${verdict.summary}\n\n${verdict.body}`,
+            });
+          }
         }
-        verdict.addressRound = await this.runAutoAddress(f, verdict); // errorRound stays 0 on a real verdict
       }
       this.deps.store.putReview(verdict);
-      if (verdict.decision === "changes_requested") {
-        this.deps.store.addSignal({
-          repoPath: f.repoPath,
-          sessionId: f.sessionId,
-          kind: "critic",
-          payload: `${verdict.summary}\n\n${verdict.body}`,
-        });
-      }
       this.deps.onChange(f.sessionId, verdict);
     } finally {
       this.deps.onReviewing?.(f.sessionId, false);
@@ -392,7 +406,7 @@ export class ReviewService {
    * At/over the cap we stop steering and leave the round in place; the posted review,
    * the stalled badge, and (for blocking verdicts) the critic signal escalate it.
    */
-  private async runAutoAddress(f: InFlight, verdict: ReviewVerdict): Promise<number> {
+  private runAutoAddress(f: InFlight, verdict: ReviewVerdict): number {
     if (verdict.findings.length === 0) return 0; // clean → streak resets
     const enabled =
       !!this.deps.autoAddress && this.deps.store.getRepoConfig(f.repoPath).autoAddressEnabled;
@@ -403,23 +417,8 @@ export class ReviewService {
     // this streak rather than resetting — the cap bounds total agent churn per PR, which
     // is fine for the prototype. Revisit if per-issue rounds become the intended model.
     if (f.priorRound >= this.cap) return f.priorRound; // gave up → hold (stalled badge persists)
-    // Critic spawn and PR merge both fire on CI-green, so they race by construction: the
-    // critic can finish AFTER the PR merged. Re-confirm the PR is still open at this last
-    // gate before steering — otherwise we'd tell the agent to "commit & push so CI and the
-    // critic re-run" on a branch whose PR is already merged/closed. Live fetch, not the
-    // cached snapshot: the 120s poll can lag the merge, and staleness reintroduces the race.
-    // Fail-closed — if we can't confirm "open" (forge throws / unresolved), don't steer: a
-    // missed steer is recoverable (next push re-triggers; a human can send), churn on a dead
-    // branch is not. Lazy (only here, past the findings/enabled/cap guards) so clean
-    // verdicts and disabled-loop repos make no extra forge call.
-    let open = false;
-    try {
-      const forge = this.deps.resolveForge(f.repoPath);
-      open = (await forge?.prStatus(f.branch))?.state === "open";
-    } catch (err) {
-      console.warn(`[review] PR-state recheck failed for ${f.sessionId}:`, err);
-    }
-    if (!open) return f.priorRound; // PR no longer open (or unconfirmable) → hold, don't steer
+    // The PR's still-open check lives in finalize() (it also gates postReview + the critic
+    // signal), so reaching here already means the PR is open — just steer.
     // autoAddress (SessionService.reply) liveness-checks the pane and returns false for a
     // dead one, so a steer that can't land normally reports false. A throw is now only a
     // narrow race — the pane dies between the liveness check and herdr.send — and still

--- a/src/review.ts
+++ b/src/review.ts
@@ -73,6 +73,7 @@ interface InFlight {
   sessionId: string;
   headSha: string;
   prNumber: number;
+  branch: string; // head branch, for the at-finalize live PR-state recheck (prStatus keys on it)
   repoPath: string;
   worktreePath: string;
   terminalId: string;
@@ -256,6 +257,7 @@ export class ReviewService {
       sessionId: session.id,
       headSha: git.headSha!,
       prNumber: git.number!,
+      branch: session.branch!,
       repoPath: session.repoPath,
       worktreePath: wt.worktreePath,
       terminalId,
@@ -361,7 +363,7 @@ export class ReviewService {
             console.warn(`[review] postReview failed for ${f.sessionId}:`, err);
           }
         }
-        verdict.addressRound = this.runAutoAddress(f, verdict); // errorRound stays 0 on a real verdict
+        verdict.addressRound = await this.runAutoAddress(f, verdict); // errorRound stays 0 on a real verdict
       }
       this.deps.store.putReview(verdict);
       if (verdict.decision === "changes_requested") {
@@ -390,7 +392,7 @@ export class ReviewService {
    * At/over the cap we stop steering and leave the round in place; the posted review,
    * the stalled badge, and (for blocking verdicts) the critic signal escalate it.
    */
-  private runAutoAddress(f: InFlight, verdict: ReviewVerdict): number {
+  private async runAutoAddress(f: InFlight, verdict: ReviewVerdict): Promise<number> {
     if (verdict.findings.length === 0) return 0; // clean → streak resets
     const enabled =
       !!this.deps.autoAddress && this.deps.store.getRepoConfig(f.repoPath).autoAddressEnabled;
@@ -401,6 +403,23 @@ export class ReviewService {
     // this streak rather than resetting — the cap bounds total agent churn per PR, which
     // is fine for the prototype. Revisit if per-issue rounds become the intended model.
     if (f.priorRound >= this.cap) return f.priorRound; // gave up → hold (stalled badge persists)
+    // Critic spawn and PR merge both fire on CI-green, so they race by construction: the
+    // critic can finish AFTER the PR merged. Re-confirm the PR is still open at this last
+    // gate before steering — otherwise we'd tell the agent to "commit & push so CI and the
+    // critic re-run" on a branch whose PR is already merged/closed. Live fetch, not the
+    // cached snapshot: the 120s poll can lag the merge, and staleness reintroduces the race.
+    // Fail-closed — if we can't confirm "open" (forge throws / unresolved), don't steer: a
+    // missed steer is recoverable (next push re-triggers; a human can send), churn on a dead
+    // branch is not. Lazy (only here, past the findings/enabled/cap guards) so clean
+    // verdicts and disabled-loop repos make no extra forge call.
+    let open = false;
+    try {
+      const forge = this.deps.resolveForge(f.repoPath);
+      open = (await forge?.prStatus(f.branch))?.state === "open";
+    } catch (err) {
+      console.warn(`[review] PR-state recheck failed for ${f.sessionId}:`, err);
+    }
+    if (!open) return f.priorRound; // PR no longer open (or unconfirmable) → hold, don't steer
     // autoAddress (SessionService.reply) liveness-checks the pane and returns false for a
     // dead one, so a steer that can't land normally reports false. A throw is now only a
     // narrow race — the pane dies between the liveness check and herdr.send — and still

--- a/src/review.ts
+++ b/src/review.ts
@@ -350,42 +350,7 @@ export class ReviewService {
           });
         }
       } else {
-        // Critic spawn and PR merge both fire on CI-green, so they race by construction:
-        // the critic can finish AFTER the PR merged/closed. A merged/closed PR's verdict is
-        // moot — re-confirm the PR is still open before acting on it: don't post the review,
-        // don't steer the agent (churn on a dead branch), and don't record a learnings signal
-        // for a PR that's already gone. Live fetch, not the cached snapshot: the 120s poll can
-        // lag the merge, and staleness reintroduces the race. Fail-closed — if we can't confirm
-        // "open" (no forge / forge throws), stay fully inert.
-        const forge = this.deps.resolveForge(f.repoPath);
-        let open = false;
-        try {
-          open = (await forge?.prStatus(f.branch))?.state === "open";
-        } catch (err) {
-          console.warn(`[review] PR-state recheck failed for ${f.sessionId}:`, err);
-        }
-        if (open && forge) {
-          try {
-            const event = verdict.decision === "changes_requested" ? "REQUEST_CHANGES" : "COMMENT";
-            const { url } = await forge.postReview(f.prNumber, {
-              event,
-              body: `${verdict.body}\n\n${CRITIC_REVIEW_MARKER}`,
-            });
-            verdict.url = url;
-          } catch (err) {
-            console.warn(`[review] postReview failed for ${f.sessionId}:`, err);
-          }
-          // reached only when the PR is confirmed open (errorRound stays 0 on a real verdict)
-          verdict.addressRound = this.runAutoAddress(f, verdict);
-          if (verdict.decision === "changes_requested") {
-            this.deps.store.addSignal({
-              repoPath: f.repoPath,
-              sessionId: f.sessionId,
-              kind: "critic",
-              payload: `${verdict.summary}\n\n${verdict.body}`,
-            });
-          }
-        }
+        await this.publishVerdict(f, verdict);
       }
       this.deps.store.putReview(verdict);
       this.deps.onChange(f.sessionId, verdict);
@@ -393,6 +358,44 @@ export class ReviewService {
       this.deps.onReviewing?.(f.sessionId, false);
       this.deps.herdr.stop(f.terminalId);
       this.deps.worktree.remove(f.worktreePath);
+    }
+  }
+
+  /**
+   * Emit a real verdict's outward effects — post the review, steer findings to the agent,
+   * record the critic signal — but ONLY if the PR is still open. Critic spawn and PR merge
+   * both fire on CI-green, so they race by construction: the critic can finish AFTER the PR
+   * merged/closed, at which point the verdict is moot. Live fetch (not the cached snapshot —
+   * the 120s poll can lag the merge). Fail-closed: if we can't confirm "open" (no forge /
+   * forge throws) we emit nothing. The verdict row itself is still persisted by the caller.
+   */
+  private async publishVerdict(f: InFlight, verdict: ReviewVerdict): Promise<void> {
+    const forge = this.deps.resolveForge(f.repoPath);
+    let open = false;
+    try {
+      open = (await forge?.prStatus(f.branch))?.state === "open";
+    } catch (err) {
+      console.warn(`[review] PR-state recheck failed for ${f.sessionId}:`, err);
+    }
+    if (!open || !forge) return; // not open (or unconfirmable) → moot, emit nothing
+    try {
+      const event = verdict.decision === "changes_requested" ? "REQUEST_CHANGES" : "COMMENT";
+      const { url } = await forge.postReview(f.prNumber, {
+        event,
+        body: `${verdict.body}\n\n${CRITIC_REVIEW_MARKER}`,
+      });
+      verdict.url = url;
+    } catch (err) {
+      console.warn(`[review] postReview failed for ${f.sessionId}:`, err);
+    }
+    verdict.addressRound = this.runAutoAddress(f, verdict); // reached only when the PR is open
+    if (verdict.decision === "changes_requested") {
+      this.deps.store.addSignal({
+        repoPath: f.repoPath,
+        sessionId: f.sessionId,
+        kind: "critic",
+        payload: `${verdict.summary}\n\n${verdict.body}`,
+      });
     }
   }
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -455,7 +455,7 @@ export class ReviewService {
       summary,
       body: raw && typeof raw.body === "string" ? raw.body : "",
       findings,
-      addressRound: 0, // finalize() overwrites with the streak round
+      addressRound: 0, // publishVerdict() overwrites with the streak round (finalize()'s error path holds priorRound)
       addressCap: this.cap, // surface the live cap so the UI badge need not mirror it
       errorRound: 0, // finalize() overwrites on an error verdict
       seenNoteIds: f.seenNoteIds, // carry the per-round note dedup set forward

--- a/src/review.ts
+++ b/src/review.ts
@@ -420,8 +420,8 @@ export class ReviewService {
     // this streak rather than resetting — the cap bounds total agent churn per PR, which
     // is fine for the prototype. Revisit if per-issue rounds become the intended model.
     if (f.priorRound >= this.cap) return f.priorRound; // gave up → hold (stalled badge persists)
-    // The PR's still-open check lives in finalize() (it also gates postReview + the critic
-    // signal), so reaching here already means the PR is open — just steer.
+    // The PR's still-open check lives in publishVerdict() (it also gates postReview + the
+    // critic signal), so reaching here already means the PR is open — just steer.
     // autoAddress (SessionService.reply) liveness-checks the pane and returns false for a
     // dead one, so a steer that can't land normally reports false. A throw is now only a
     // narrow race — the pane dies between the liveness check and herdr.send — and still

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -41,6 +41,7 @@ function fakeForge(
   rec: { event?: string; body?: string },
   comments: PrComment[],
   commentCalls: number[],
+  prStatus: () => Promise<PrStatus> = async () => OPEN_GREEN as PrStatus,
 ): GitForge {
   return {
     kind: "github",
@@ -49,7 +50,7 @@ function fakeForge(
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
-    prStatus: async () => OPEN_GREEN as PrStatus,
+    prStatus,
     openPr: async () => OPEN_GREEN as PrStatus,
     merge: async () => {},
     redeploy: async () => {},
@@ -72,6 +73,7 @@ function makeDeps(
     autoAddressEnabled?: boolean;
     autoAddressReturns?: boolean;
     comments?: PrComment[];
+    prStatus?: () => Promise<PrStatus>;
   } = {},
 ) {
   const reviews: Record<string, ReviewVerdict> = {};
@@ -109,7 +111,7 @@ function makeDeps(
       createDetached: () => ({ worktreePath: "/review-wt", branch: null, isolated: true }),
       remove: (p: string) => removed.push(p),
     },
-    resolveForge: () => fakeForge(rec, opts.comments ?? [], commentCalls),
+    resolveForge: () => fakeForge(rec, opts.comments ?? [], commentCalls, opts.prStatus),
     onChange: () => {},
     autoAddress: (id: string, text: string) => {
       steers.push({ id, text });
@@ -447,6 +449,33 @@ test("round cap reached: holds the round, posts the review + signal, does not st
   expect(reviews["s1"]?.addressRound).toBe(3); // round preserved (not reset, not advanced)
   expect(rec.event).toBe("REQUEST_CHANGES"); // still posts to the PR
   expect(signals.some((s) => s.kind === "critic")).toBe(true); // captured for the human/learnings
+});
+
+test("PR merged before finalize: holds the round, posts the review, does NOT steer", async () => {
+  const {
+    deps: d,
+    reviews,
+    steers,
+    rec,
+  } = makeDeps(
+    {
+      readVerdict: () => ({
+        decision: "request-changes",
+        summary: "x",
+        body: "b",
+        findings: ["fix x"],
+      }),
+    },
+    // critic spawned while open, but the PR merged before the verdict finalized
+    { autoAddressEnabled: true, prStatus: async () => ({ ...OPEN_GREEN, state: "merged" }) },
+  );
+  const svc = new ReviewService(d as any);
+  svc.consider(session(), OPEN_GREEN); // spawn while open (no prStatus call yet)
+  await svc.tick(); // finalize: live recheck sees "merged"
+  expect(steers).toHaveLength(0); // no churn steered onto a merged branch
+  expect(reviews["s1"]?.addressRound).toBe(0); // round held (priorRound 0), not advanced
+  expect(rec.event).toBe("REQUEST_CHANGES"); // surgical: review still posted
+  expect(reviews["s1"]?.decision).toBe("changes_requested"); // verdict still persisted
 });
 
 test("dead agent pane: steer attempted but the round does not advance", async () => {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -451,11 +451,12 @@ test("round cap reached: holds the round, posts the review + signal, does not st
   expect(signals.some((s) => s.kind === "critic")).toBe(true); // captured for the human/learnings
 });
 
-test("PR merged before finalize: holds the round, posts the review, does NOT steer", async () => {
+test("PR merged before finalize: verdict is moot — no review posted, no steer, no signal", async () => {
   const {
     deps: d,
     reviews,
     steers,
+    signals,
     rec,
   } = makeDeps(
     {
@@ -471,18 +472,20 @@ test("PR merged before finalize: holds the round, posts the review, does NOT ste
   );
   const svc = new ReviewService(d as any);
   svc.consider(session(), OPEN_GREEN); // spawn while open (no prStatus call yet)
-  await svc.tick(); // finalize: live recheck sees "merged"
+  await svc.tick(); // finalize: live recheck sees "merged" → fully inert
   expect(steers).toHaveLength(0); // no churn steered onto a merged branch
-  expect(reviews["s1"]?.addressRound).toBe(0); // round held (priorRound 0), not advanced
-  expect(rec.event).toBe("REQUEST_CHANGES"); // surgical: review still posted
-  expect(reviews["s1"]?.decision).toBe("changes_requested"); // verdict still persisted
+  expect(rec.event).toBeUndefined(); // moot: no review posted on a merged PR
+  expect(signals.some((s) => s.kind === "critic")).toBe(false); // and no learnings signal
+  expect(reviews["s1"]?.decision).toBe("changes_requested"); // verdict still persisted (UI/dedup)
+  expect(reviews["s1"]?.addressRound).toBe(0); // no steer round
 });
 
-test("PR-state recheck throws: fail-closed — no steer, round held", async () => {
+test("PR-state recheck throws: fail-closed — fully inert", async () => {
   const {
     deps: d,
     reviews,
     steers,
+    rec,
   } = makeDeps(
     { readVerdict: () => ({ decision: "comment", summary: "nit", body: "b", findings: ["x"] }) },
     {
@@ -496,11 +499,16 @@ test("PR-state recheck throws: fail-closed — no steer, round held", async () =
   svc.consider(session(), OPEN_GREEN);
   await svc.tick(); // must NOT reject
   expect(steers).toHaveLength(0); // can't confirm open → don't steer
-  expect(reviews["s1"]?.addressRound).toBe(0); // round held
+  expect(rec.event).toBeUndefined(); // …and don't post the review
+  expect(reviews["s1"]?.addressRound).toBe(0);
 });
 
-test("PR closed (not merged) before finalize: also skips the steer", async () => {
-  const { deps: d, steers } = makeDeps(
+test("PR closed (not merged) before finalize: also fully inert", async () => {
+  const {
+    deps: d,
+    steers,
+    rec,
+  } = makeDeps(
     { readVerdict: () => ({ decision: "comment", summary: "nit", body: "b", findings: ["x"] }) },
     { autoAddressEnabled: true, prStatus: async () => ({ ...OPEN_GREEN, state: "closed" }) },
   );
@@ -508,6 +516,7 @@ test("PR closed (not merged) before finalize: also skips the steer", async () =>
   svc.consider(session(), OPEN_GREEN);
   await svc.tick();
   expect(steers).toHaveLength(0); // guard is state !== "open", not just merged
+  expect(rec.event).toBeUndefined(); // closed PR → review not posted
 });
 
 test("dead agent pane: steer attempted but the round does not advance", async () => {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -478,6 +478,38 @@ test("PR merged before finalize: holds the round, posts the review, does NOT ste
   expect(reviews["s1"]?.decision).toBe("changes_requested"); // verdict still persisted
 });
 
+test("PR-state recheck throws: fail-closed — no steer, round held", async () => {
+  const {
+    deps: d,
+    reviews,
+    steers,
+  } = makeDeps(
+    { readVerdict: () => ({ decision: "comment", summary: "nit", body: "b", findings: ["x"] }) },
+    {
+      autoAddressEnabled: true,
+      prStatus: async () => {
+        throw new Error("gh unavailable");
+      },
+    },
+  );
+  const svc = new ReviewService(d as any);
+  svc.consider(session(), OPEN_GREEN);
+  await svc.tick(); // must NOT reject
+  expect(steers).toHaveLength(0); // can't confirm open → don't steer
+  expect(reviews["s1"]?.addressRound).toBe(0); // round held
+});
+
+test("PR closed (not merged) before finalize: also skips the steer", async () => {
+  const { deps: d, steers } = makeDeps(
+    { readVerdict: () => ({ decision: "comment", summary: "nit", body: "b", findings: ["x"] }) },
+    { autoAddressEnabled: true, prStatus: async () => ({ ...OPEN_GREEN, state: "closed" }) },
+  );
+  const svc = new ReviewService(d as any);
+  svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(steers).toHaveLength(0); // guard is state !== "open", not just merged
+});
+
 test("dead agent pane: steer attempted but the round does not advance", async () => {
   const {
     deps: d,

--- a/test/signal-capture.test.ts
+++ b/test/signal-capture.test.ts
@@ -55,11 +55,17 @@ test("critic changes_requested records a 'critic' signal", async () => {
     herdrSession: "default",
     herdrAgentId: "t1",
   });
+  // The signal now fires only when the PR is confirmed open (moot-run guard).
+  // Supply a minimal forge that confirms open and accepts the review post.
+  const fakeForge = {
+    prStatus: async () => ({ state: "open" }),
+    postReview: async () => ({ url: "u" }),
+  } as any;
   const svc = new ReviewService({
     store,
     herdr: { start: () => ({ terminalId: "rev1" }), stop: () => {} } as any,
     worktree: { createDetached: () => ({ worktreePath: "/rev-wt" }), remove: () => {} } as any,
-    resolveForge: () => null,
+    resolveForge: () => fakeForge,
     onChange: () => {},
     now: () => 1,
     readVerdict: () => ({ decision: "request-changes", summary: "2 issues", body: "## findings" }),


### PR DESCRIPTION
## Problem

An in-flight critic could steer findings into the task agent **after that agent's PR had already merged** — telling it to \"commit & push so CI and the critic re-run\" on a branch whose PR is closed/deleted. Result: agent churn against a dead branch.

**Not a corner case.** Critic spawn and PR merge both fire on CI-green, so they race by construction: the same green that spawns the critic is the green light to merge. The 15s finalize tick routinely beats the 120s merge-detection poll.

**Root cause:** the only merged-PR guard was at the *spawn* gate (`consider()`, `review.ts`). The delivery chain `tick()` → `finalize()` → `runAutoAddress()` → steer never rechecked live PR state; `InFlight` snapshotted PR identity at spawn and nothing reconsulted the forge before steering.

## Fix

Re-fetch authoritative live PR state at the last gate before the steer (`runAutoAddress`) and skip the steer when the PR is no longer `open`.

- **Surgical:** `postReview()`, `putReview()`, and the `critic` learnings signal are unchanged — a merged PR still gets its review posted; only the agent steer is suppressed.
- **Whole-class:** guard is `state !== "open"` (covers merged, closed, none — e.g. a branch deleted on merge).
- **Fail-closed:** if `prStatus()` throws or the forge can't be resolved, skip the steer (a missed steer is recoverable; churn on a dead branch isn't).
- **Lazy:** the recheck sits after the findings/enabled/cap guards, so clean verdicts and disabled-loop repos make zero extra forge calls.
- **Not open ⇒ hold the round** (no advance/reset) — same semantics as a steer that didn't land.

Deferred as a non-goal (YAGNI): an event-driven abort-on-merge can't close the race alone (finalize tick beats the merge poll); the finalize-time recheck is authoritative.

## Test Plan

- [x] `bun test ./test` — 786 pass / 0 fail
- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- New tests: merged-at-finalize ⇒ no steer (asserts review **still** posted); `prStatus` throws ⇒ fail-closed no steer; closed PR ⇒ no steer. Existing steer tests stay green via a default-open test forge.

Server-only; no UI / i18n / schema changes. Spec + plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)