### PR TITLE
fix(gitrail): make learning toggle reflect on/off state

### DIFF
--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -310,7 +310,7 @@
       {/if}
       {#if repoPath}
         <button
-          class={["gbtn", "learn-toggle"]}
+          class={["gbtn", "crit-toggle"]}
           type="button"
           aria-label={m.gitrail_learnings_toggle_aria()}
           aria-pressed={learningsOn}


### PR DESCRIPTION
## Problem
The 🎓 "Learning" toggle in the session detail pane (GitRail) never visually reflected its enabled/disabled state.

## Root cause
The button carried a `learn-toggle` class that **has no CSS rule defined**. Its critic/auto-address siblings use `crit-toggle`, which sets `display: inline-flex`. Per the comment at `GitRail.svelte:484`, that inline-flex is what lets the `.crit-dot` status span render at all — *"an empty inline span ignores width/height"*. Without it the dot collapsed to 0×0 and was invisible, so the green/faint on/off indicator never appeared. `aria-pressed`/`title` flipped correctly; only the visible cue was missing.

## Fix
Swap the orphan `learn-toggle` class for `crit-toggle` so the learning toggle reuses the same inline-flex layout as its siblings. No other references to `learn-toggle` existed (verified across `ui/` + `src/`).

## Verification
- `cd ui && bun run check` — 0 errors
- `bun run test src/lib/reviews.svelte.test.ts` — 21 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)