### PR TITLE
fix(viewport): surface ready-to-merge toggle on desktop

### DIFF
--- a/docs/superpowers/plans/2026-06-03-ready-toggle-visible-desktop.md
+++ b/docs/superpowers/plans/2026-06-03-ready-toggle-visible-desktop.md
@@ -1,0 +1,270 @@
+# Ready Toggle Visible On Desktop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the per-session Ready (ready-to-merge) toggle visible in the desktop primary header row, restoring the mobile/unfolded parity that #188's git-rail disclosure removed.
+
+**Architecture:** Add a `showReady` prop to `GitRail` so a parent can suppress the rail's own Ready toggle. In `Viewport`, render the Ready toggle directly in the always-visible desktop primary header row (gated by a derived that mirrors GitRail's exact condition, using the already-populated `git` prop), and pass `showReady={compact}` to the disclosure `GitRail` so the toggle is never double-rendered on desktop.
+
+**Tech Stack:** SvelteKit, Svelte 5 (runes), TypeScript, Paraglide JS i18n, Tailwind/scoped CSS. Package manager `bun`. Checks: `bun run check`, eslint, `bun run check:i18n` (all run from `ui/`).
+
+---
+
+## Context for the engineer
+
+- Two-package repo. All work here is in `ui/`. A fresh worktree has **no** `node_modules` — run `cd ui && bun install` first.
+- The Ready toggle currently lives only inside `GitRail.svelte` (`GitRail.svelte:323`), gated by:
+  ```svelte
+  {#if (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
+  ```
+- `Viewport.svelte` mounts `GitRail` only when `{#if compact || gitOpen}` (`Viewport.svelte:1112`).
+  - `compact = mobile || touch` (`Viewport.svelte:142`) → true on phone + unfolded fold.
+  - `gitOpen` is the desktop "Git actions" disclosure, default `false` (`Viewport.svelte:95`).
+  - So on desktop the rail (and Ready) is hidden until disclosure opens — the bug.
+- `Viewport` already receives `git` as a prop (`Viewport.svelte:56,83`), fed from `store.git[id]` at both call sites (`src/routes/+page.svelte:571,624`). So `git?.state` is reliable on desktop.
+- `session.readyToMerge` is the flag; `setReadyToMerge(id, ready)` (`src/lib/api.ts:260`) is the action — already used by GitRail.
+- Messages already exist in **both** `messages/en.json` and `messages/de.json` (lines 104-107): `gitrail_ready`, `gitrail_ready_on_title`, `gitrail_ready_off_title`, `gitrail_ready_aria`. **No new keys needed.**
+
+### Testing note (read before Task 1)
+
+This repo has **no component-mount tests** for `Viewport`/`GitRail` — `Viewport` imports `@xterm/xterm`, which does not mount cleanly under the vitest/jsdom setup, and the existing component tests (`pr-badge.test.ts`, `critic-badge.test.ts`, …) cover **pure helpers only**. The Ready-visibility change is a 4-condition boolean `$derived` plus markup; extracting a module solely to unit-test inline boolean logic would be over-engineering against the established pattern.
+
+Therefore verification for this plan is: **type-check (`bun run check`) + eslint + i18n parity gate + a manual visual check in the running app.** Each implementation step still ends in a commit. If during execution you find a clean, established way to assert visibility without mounting xterm, add it — but do not introduce a new test harness just for this.
+
+---
+
+## File Structure
+
+- **Modify** `ui/src/lib/components/GitRail.svelte` — add `showReady` prop; gate the existing Ready `{#if}` on it. (No new responsibility; just makes the rail's Ready toggle suppressible.)
+- **Modify** `ui/src/lib/components/Viewport.svelte` — import `setReadyToMerge`; add `readyVisible` derived; render the desktop primary-row Ready toggle; add `.ready-toggle` styles; pass `showReady={compact}` to the disclosure `GitRail`.
+
+No new files. No new i18n keys.
+
+---
+
+## Task 1: Make GitRail's Ready toggle suppressible
+
+**Files:**
+- Modify: `ui/src/lib/components/GitRail.svelte` (props block ~9-25; Ready `{#if}` line 323)
+
+- [ ] **Step 1: Add the `showReady` prop**
+
+In the destructured props (currently lines 9-25), add `showReady` with a default of `true` and its type. The block becomes:
+
+```svelte
+  let {
+    sessionId,
+    repoPath = "",
+    name = "",
+    prompt = "",
+    mobile = false,
+    ready = false,
+    status = "idle",
+    showReady = true,
+  }: {
+    sessionId: string;
+    repoPath?: string;
+    name?: string;
+    prompt?: string;
+    mobile?: boolean;
+    ready?: boolean;
+    status?: SessionStatus;
+    showReady?: boolean;
+  } = $props();
+```
+
+- [ ] **Step 2: Gate the Ready toggle on `showReady`**
+
+Change the Ready toggle condition (line 323) from:
+
+```svelte
+      {#if (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
+```
+
+to:
+
+```svelte
+      {#if showReady && (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd ui && bun run check`
+Expected: PASS (0 errors). `showReady` defaults `true`, so every existing `<GitRail>` usage is unchanged behaviourally.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/lib/components/GitRail.svelte
+git commit -m "feat(gitrail): add showReady prop to suppress rail's ready toggle"
+```
+
+---
+
+## Task 2: Render the Ready toggle in Viewport's desktop primary row
+
+**Files:**
+- Modify: `ui/src/lib/components/Viewport.svelte` (import block 13-19; derived near 236; `{#if !compact}` block 1045-1063; `<GitRail>` at 1114-1122; styles near `.git-toggle` 1483-1523)
+
+- [ ] **Step 1: Import `setReadyToMerge`**
+
+Extend the existing `$lib/api` import (lines 13-19) to include `setReadyToMerge`:
+
+```svelte
+  import {
+    getSessionUsage,
+    uploadImage,
+    resumeSession as apiResumeSession,
+    renameSession,
+    getLeftovers,
+    setReadyToMerge,
+  } from "$lib/api";
+```
+
+- [ ] **Step 2: Add the `readyVisible` derived**
+
+Immediately after the `prReady` derived (line 236), add a desktop-only gate that mirrors GitRail's exact condition. Insert:
+
+```svelte
+  // desktop parity for the rail's Ready toggle: #188 moved the git rail behind the
+  // "Git actions" disclosure, hiding ready-to-merge on desktop while mobile (always-on
+  // rail) still showed it. Surface just this one high-frequency control in the primary
+  // row. Gate mirrors GitRail's own ({git open || already ready} & not running/blocked),
+  // desktop-only — on compact the rail itself still owns the toggle (see showReady below).
+  const readyVisible = $derived(
+    !compact &&
+      (git?.state === "open" || session.readyToMerge) &&
+      session.status !== "running" &&
+      session.status !== "blocked",
+  );
+```
+
+- [ ] **Step 3: Render the toggle in the `{#if !compact}` block**
+
+Inside the existing `{#if !compact}` block, immediately **after** the closing `</button>` of `.git-toggle` (line 1062) and **before** the block's `{/if}` (line 1063), add:
+
+```svelte
+      {#if readyVisible}
+        <!-- desktop: the ready-to-merge toggle graduates out of the git-actions
+             disclosure into the always-visible primary row (mobile shows it in the
+             rail unconditionally). Gate + action mirror GitRail's ready toggle. -->
+        <button
+          class="ready-toggle"
+          class:on={session.readyToMerge}
+          type="button"
+          aria-pressed={session.readyToMerge}
+          aria-label={m.gitrail_ready_aria()}
+          title={session.readyToMerge ? m.gitrail_ready_on_title() : m.gitrail_ready_off_title()}
+          onclick={() => setReadyToMerge(session.id, !session.readyToMerge)}
+        >
+          {session.readyToMerge ? "✓ " : ""}{m.gitrail_ready()}
+        </button>
+      {/if}
+```
+
+- [ ] **Step 4: Suppress the rail's own Ready toggle on desktop**
+
+In the disclosure `<GitRail>` (lines 1114-1122), add `showReady={compact}` so the rail shows Ready only on compact layouts (where the primary-row toggle is hidden), preventing a double-render when the desktop disclosure is open. The element becomes:
+
+```svelte
+      <GitRail
+        sessionId={session.id}
+        repoPath={session.repoPath}
+        name={session.name}
+        prompt={session.prompt}
+        ready={session.readyToMerge}
+        status={session.status}
+        showReady={compact}
+        mobile
+      />
+```
+
+- [ ] **Step 5: Add `.ready-toggle` styles**
+
+After the `.git-toggle` style rules (immediately following line 1523, the closing of the `.gt-caret` ruleset), add styling consistent with `.git-toggle`, plus a green "on" state mirroring GitRail's `.ready-on` (marked-ready = done/green):
+
+```svelte
+  .ready-toggle {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 2px 7px;
+    cursor: pointer;
+    transition:
+      color 0.12s,
+      border-color 0.12s,
+      background 0.12s;
+  }
+  .ready-toggle:hover {
+    color: var(--color-ink);
+  }
+  .ready-toggle.on {
+    color: var(--color-green);
+    border-color: color-mix(in srgb, var(--color-green) 55%, transparent);
+  }
+```
+
+- [ ] **Step 6: Type-check, lint, i18n**
+
+Run: `cd ui && bun run check && bun run lint && bun run check:i18n`
+Expected: all PASS. (No new message keys; `check:i18n` confirms EN/DE parity is intact.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ui/src/lib/components/Viewport.svelte
+git commit -m "feat(viewport): surface ready-to-merge toggle in desktop header row"
+```
+
+---
+
+## Task 3: Visual verification in the running app
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build/serve and exercise the desktop layout**
+
+Run the UI (project's standard dev/preview path) and, in a **non-touch desktop** viewport, select a session:
+- **No PR, not ready:** Ready toggle absent from header (gate false). Correct.
+- **Open PR (or `readyToMerge` already true):** Ready toggle visible in the primary header row beside "Git actions".
+- **Running / blocked status:** Ready toggle absent. Correct.
+
+- [ ] **Step 2: Confirm no double-render**
+
+With an open PR on desktop, click "Git actions" to open the disclosure. Expected: exactly **one** Ready toggle (the header-row one); the rail shows PR/CI/merge/critic/verdict but **no** Ready toggle.
+
+- [ ] **Step 3: Confirm toggle works + state reflects**
+
+Click the header Ready toggle. Expected: `setReadyToMerge` fires; on the next session refresh the button gains the `✓ ` prefix + green `.on` styling and its `title` switches to `gitrail_ready_on_title`; clicking again clears it. Behaviour matches the mobile rail toggle.
+
+- [ ] **Step 4: Confirm mobile/unfolded unchanged**
+
+In a phone / unfolded-fold (compact) viewport: Ready toggle still appears **in the rail** (via `showReady={compact}` → `true`), and is **not** duplicated in the header (gate `!compact` → false).
+
+- [ ] **Step 5: Mark verification complete**
+
+No commit (no file changes). If any check fails, return to the relevant task — do not claim completion without observing the expected behaviour.
+
+---
+
+## Self-Review
+
+- **Spec coverage:**
+  - GitRail `showReady` prop + gate → Task 1. ✓
+  - Viewport import `setReadyToMerge` → Task 2 Step 1. ✓
+  - `readyVisible` derived mirroring GitRail's gate, desktop-only → Task 2 Step 2. ✓
+  - Primary-row Ready toggle with aria/title/action/label → Task 2 Step 3. ✓
+  - `showReady={compact}` to suppress double-render → Task 2 Step 4. ✓
+  - `.ready-toggle` styling incl. green "on" → Task 2 Step 5. ✓
+  - i18n reuse, no new keys, parity gate → Task 2 Step 6. ✓
+  - Visual verification of all scenarios from spec → Task 3. ✓
+- **Placeholder scan:** none — every code step shows complete code; commands have expected outcomes.
+- **Type consistency:** prop name `showReady` consistent (Task 1 ↔ Task 2 Step 4); class `.ready-toggle` / `.ready-toggle.on` consistent (markup Step 3 ↔ styles Step 5); `setReadyToMerge(session.id, !session.readyToMerge)` matches `api.ts:260` signature `(id: string, ready: boolean)`. ✓

--- a/docs/superpowers/specs/2026-06-03-ready-toggle-visible-desktop-design.md
+++ b/docs/superpowers/specs/2026-06-03-ready-toggle-visible-desktop-design.md
@@ -1,0 +1,124 @@
+# Ready toggle visible on desktop — design
+
+**Date:** 2026-06-03
+**Branch:** `shepherd/ready-toggle-visible-desktop`
+
+## Problem
+
+The per-session **Ready** toggle (mark a session ready-to-merge) is not visible on
+desktop, but works on mobile and on unfolded foldables.
+
+### Root cause
+
+PR #188 (`feat(viewport): group desktop git rail behind a PR disclosure`) moved the
+full desktop git rail — PR / CI / merge / critic / **ready** / verdict — behind a
+"Git actions" disclosure toggle to declutter the header.
+
+The rail (a `<GitRail>`) is mounted by `Viewport.svelte` only when
+`{#if compact || gitOpen}` (`Viewport.svelte:1112`), where:
+
+- `compact = mobile || touch` (`Viewport.svelte:142`)
+- `gitOpen` is the desktop disclosure state, default `false` (`Viewport.svelte:95`)
+
+Consequences:
+
+- **Mobile / unfolded fold** → `compact = true` → the rail (and its Ready toggle) is
+  always mounted and visible. The Ready toggle works.
+- **Desktop** → `compact = false`, `gitOpen` defaults `false` → the rail is hidden
+  until the operator clicks "Git actions". The Ready toggle is effectively invisible.
+
+This is not clipped CSS or a responsive `hidden` class — it is the disclosure burying
+the Ready toggle on desktop while mobile shows the rail unconditionally.
+
+The Ready toggle inside `GitRail.svelte:323` is gated by:
+
+```svelte
+{#if (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
+```
+
+## Chosen approach — Approach A: graduate the Ready toggle to the desktop primary row
+
+Render the Ready toggle directly in the always-visible desktop primary header row,
+beside the "Git actions" disclosure. The heavier git actions (PR create, CI, merge,
+critic, verdict) stay behind the disclosure.
+
+This restores mobile parity for the single high-frequency operator control while
+preserving #188's declutter intent for the rest of the rail.
+
+Rejected alternatives:
+
+- **B — always show the full rail on desktop:** re-clutters the header; effectively
+  reverts #188.
+- **C — auto-open the disclosure when ready-relevant:** pops a full extra header row and
+  the toggle stays indirect.
+
+## Data flow (already in place)
+
+- `Viewport` receives `git` as a prop, fed from `store.git[selected.id]` in both
+  desktop and mobile call sites (`+page.svelte:571,624`). So `git?.state` reliably
+  reflects PR state on desktop — the desktop gate can mirror `GitRail`'s gate exactly.
+- `session.readyToMerge` is the ready flag; `setReadyToMerge(id, ready)`
+  (`api.ts:260`) is the toggle action, already used by `GitRail`.
+- The Ready toggle's messages (`gitrail_ready`, `gitrail_ready_aria`,
+  `gitrail_ready_on_title`, `gitrail_ready_off_title`) exist in both `en.json` and
+  `de.json` and are reused as-is.
+
+## Changes
+
+### 1. `ui/src/lib/components/GitRail.svelte`
+
+- Add a `showReady = true` prop (typed `showReady?: boolean`).
+- Extend the Ready `{#if}` (line 323) with `&& showReady`, so a parent can suppress the
+  rail's own Ready toggle when it renders the toggle elsewhere.
+
+### 2. `ui/src/lib/components/Viewport.svelte`
+
+- Import `setReadyToMerge` from `$lib/api`.
+- Add a derived gate, desktop-only, mirroring `GitRail`'s condition:
+
+  ```ts
+  const readyVisible = $derived(
+    !compact &&
+      (git?.state === "open" || session.readyToMerge) &&
+      session.status !== "running" &&
+      session.status !== "blocked",
+  );
+  ```
+
+- Inside the existing `{#if !compact}` block (beside `git-toggle`, ~line 1050), render a
+  Ready toggle when `readyVisible`:
+  - `aria-pressed={session.readyToMerge}`, `aria-label={m.gitrail_ready_aria()}`,
+    `title` switching on `gitrail_ready_on_title` / `gitrail_ready_off_title` — state
+    folded into label/title.
+  - `onclick={() => setReadyToMerge(session.id, !session.readyToMerge)}`.
+  - Label `{session.readyToMerge ? "✓ " : ""}{m.gitrail_ready()}`.
+  - Class `.ready-toggle` styled consistently with `.git-toggle`, with a green "on"
+    treatment when `session.readyToMerge` (matches `GitRail`'s `.ready-on` semantics:
+    marked-ready = done/green).
+- Pass `showReady={compact}` to the disclosure `<GitRail>` (line 1114), so the rail
+  renders Ready only on compact layouts — never double-rendering on desktop when the
+  disclosure is open.
+
+## i18n
+
+No new keys. Reuses existing `gitrail_ready*` keys, present and matched in `en.json`
+and `de.json`. Catalog-parity gate (`bun run check:i18n`) unaffected.
+
+## Verification
+
+- `cd ui && bun install` (fresh worktree), then `bun run check`, lint, `bun run
+  check:i18n`.
+- Visual check in the running app:
+  - **Desktop** (non-touch): Ready toggle visible in the primary header row when the
+    session has an open PR or is already ready; not shown while running/blocked.
+  - **Desktop, disclosure open**: exactly one Ready toggle (in the header row), none
+    inside the rail.
+  - **Mobile / unfolded**: unchanged — Ready toggle still in the rail, no duplicate in
+    the header.
+  - Toggling on desktop flips `session.readyToMerge` and updates the on/off styling +
+    title, consistent with the mobile rail toggle.
+
+## Out of scope
+
+- Restructuring the disclosure or moving other rail controls.
+- Any change to the server-side ready-to-merge semantics.

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -14,6 +14,7 @@
     mobile = false,
     ready = false,
     status = "idle",
+    showReady = true,
   }: {
     sessionId: string;
     repoPath?: string;
@@ -22,6 +23,7 @@
     mobile?: boolean;
     ready?: boolean;
     status?: SessionStatus;
+    showReady?: boolean;
   } = $props();
 
   let git = $state<GitState | null>(null);
@@ -320,7 +322,7 @@
           🎓<span class="crit-dot" class:on={learningsOn} aria-hidden="true"></span>
         </button>
       {/if}
-      {#if (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
+      {#if showReady && (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
         <button
           class={["gbtn", { "ready-on": ready }]}
           type="button"

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { gitState, openPr, mergePr, redeploy, replySession, setReadyToMerge } from "$lib/api";
+  import { gitState, openPr, mergePr, redeploy, replySession } from "$lib/api";
   import type { GitState, SessionStatus } from "$lib/types";
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
   import { reviews, repoConfig } from "$lib/reviews.svelte";
   import { criticBadgeLabel } from "./critic-badge";
+  import ReadyToggle from "./ReadyToggle.svelte";
 
   let {
     sessionId,
@@ -323,16 +324,7 @@
         </button>
       {/if}
       {#if showReady && (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
-        <button
-          class={["gbtn", { "ready-on": ready }]}
-          type="button"
-          aria-pressed={ready}
-          aria-label={m.gitrail_ready_aria()}
-          title={ready ? m.gitrail_ready_on_title() : m.gitrail_ready_off_title()}
-          onclick={() => setReadyToMerge(sessionId, !ready)}
-        >
-          {ready ? "✓ " : ""}{m.gitrail_ready()}
-        </button>
+        <ReadyToggle {sessionId} {ready} variant="rail" />
       {/if}
       {#if verdict}
         <button
@@ -468,15 +460,6 @@
   .gbtn.armed {
     border-color: var(--color-amber);
     color: var(--color-amber);
-  }
-  /* ready toggle when active: green "on" look (parked / done) */
-  .gbtn.ready-on {
-    border-color: var(--color-green);
-    color: var(--color-green);
-  }
-  .gbtn.ready-on:hover:not(:disabled) {
-    border-color: var(--color-green);
-    color: var(--color-green);
   }
   /* critic actively reviewing: amber outline (layout via .crit-toggle) */
   .gbtn.reviewing {

--- a/ui/src/lib/components/ReadyToggle.svelte
+++ b/ui/src/lib/components/ReadyToggle.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  // Single source for the per-session ready-to-merge toggle. Used by GitRail (the
+  // mobile/unfolded git rail, variant="rail") and Viewport's desktop primary header
+  // row (variant="bar"). Keeping the a11y label, on/off title, action and label text
+  // here means the two placements can't drift; only the visual variant differs so each
+  // matches its row's chrome (rail mirrors .gbtn; bar mirrors .git-toggle). The
+  // *visibility gate* stays with each parent — its data source differs (GitRail's own
+  // fetched git vs Viewport's git prop + desktop-only !compact).
+  import { setReadyToMerge } from "$lib/api";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    sessionId,
+    ready = false,
+    variant = "rail",
+  }: {
+    sessionId: string;
+    ready?: boolean;
+    variant?: "rail" | "bar";
+  } = $props();
+</script>
+
+<button
+  class={["ready-toggle", variant, { on: ready }]}
+  type="button"
+  aria-pressed={ready}
+  aria-label={m.gitrail_ready_aria()}
+  title={ready ? m.gitrail_ready_on_title() : m.gitrail_ready_off_title()}
+  onclick={() => setReadyToMerge(sessionId, !ready)}
+>
+  {ready ? "✓ " : ""}{m.gitrail_ready()}
+</button>
+
+<style>
+  .ready-toggle {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  /* rail variant: matches the sibling .gbtn buttons in the GitRail rail */
+  .ready-toggle.rail {
+    font-size: 10.5px;
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+  }
+  .ready-toggle.rail:hover {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  /* bar variant: matches the .git-toggle disclosure in Viewport's primary row */
+  .ready-toggle.bar {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    border-color: var(--color-line-bright);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 2px 7px;
+  }
+  .ready-toggle.bar:hover {
+    color: var(--color-ink);
+  }
+  /* active = marked ready: green "on" look (parked / done) */
+  .ready-toggle.on {
+    color: var(--color-green);
+    border-color: var(--color-green);
+  }
+  .ready-toggle.bar.on {
+    border-color: color-mix(in srgb, var(--color-green) 55%, transparent);
+  }
+  .ready-toggle.rail.on:hover {
+    border-color: var(--color-green);
+    color: var(--color-green);
+  }
+</style>

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -16,6 +16,7 @@
     resumeSession as apiResumeSession,
     renameSession,
     getLeftovers,
+    setReadyToMerge,
   } from "$lib/api";
   import { imageFilesFromItems } from "$lib/clipboard";
   import { composeKeystrokes } from "$lib/compose";
@@ -234,6 +235,18 @@
   // the decommission button as a bright "ready to clean up the worktree" nudge so the
   // operator can wrap the session without hunting for the otherwise-faint ✕.
   const prReady = $derived(git?.state === "open" || git?.state === "merged");
+
+  // desktop parity for the rail's Ready toggle: #188 moved the git rail behind the
+  // "Git actions" disclosure, hiding ready-to-merge on desktop while mobile (always-on
+  // rail) still showed it. Surface just this one high-frequency control in the primary
+  // row. Gate mirrors GitRail's own ({git open || already ready} & not running/blocked),
+  // desktop-only — on compact the rail itself still owns the toggle (see showReady below).
+  const readyVisible = $derived(
+    !compact &&
+      (git?.state === "open" || session.readyToMerge) &&
+      session.status !== "running" &&
+      session.status !== "blocked",
+  );
 
   // two-step decommission: first click arms, second (within 3s) fires; disarms on unit change
   let armed = $state(false);
@@ -1060,6 +1073,22 @@
         <span class="gt-label">{m.viewport_git_actions()}</span>
         <span class="gt-caret" aria-hidden="true">{gitOpen ? "▴" : "▾"}</span>
       </button>
+      {#if readyVisible}
+        <!-- desktop: the ready-to-merge toggle graduates out of the git-actions
+             disclosure into the always-visible primary row (mobile shows it in the
+             rail unconditionally). Gate + action mirror GitRail's ready toggle. -->
+        <button
+          class="ready-toggle"
+          class:on={session.readyToMerge}
+          type="button"
+          aria-pressed={session.readyToMerge}
+          aria-label={m.gitrail_ready_aria()}
+          title={session.readyToMerge ? m.gitrail_ready_on_title() : m.gitrail_ready_off_title()}
+          onclick={() => setReadyToMerge(session.id, !session.readyToMerge)}
+        >
+          {session.readyToMerge ? "✓ " : ""}{m.gitrail_ready()}
+        </button>
+      {/if}
     {/if}
     <!-- trailing controls: on compact/phone they group + wrap together as a
          right-aligned cluster so the close button never orphans to its own row -->
@@ -1118,6 +1147,7 @@
         prompt={session.prompt}
         ready={session.readyToMerge}
         status={session.status}
+        showReady={compact}
         mobile
       />
     </div>
@@ -1520,6 +1550,32 @@
   .git-toggle.open .gt-caret,
   .git-toggle.ready .gt-caret {
     color: currentColor;
+  }
+  .ready-toggle {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 2px 7px;
+    cursor: pointer;
+    transition:
+      color 0.12s,
+      border-color 0.12s,
+      background 0.12s;
+  }
+  .ready-toggle:hover {
+    color: var(--color-ink);
+  }
+  .ready-toggle.on {
+    color: var(--color-green);
+    border-color: color-mix(in srgb, var(--color-green) 55%, transparent);
   }
 
   /* phone merged header: repo · session (subsumes the now-hidden top bar) */

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -16,7 +16,6 @@
     resumeSession as apiResumeSession,
     renameSession,
     getLeftovers,
-    setReadyToMerge,
   } from "$lib/api";
   import { imageFilesFromItems } from "$lib/clipboard";
   import { composeKeystrokes } from "$lib/compose";
@@ -31,6 +30,7 @@
   import { lockAxis, paneSwipeAction, isSwipeUp, type Axis } from "./swipe";
   import ComposeBar from "$lib/components/ComposeBar.svelte";
   import GitRail from "$lib/components/GitRail.svelte";
+  import ReadyToggle from "$lib/components/ReadyToggle.svelte";
   import SteerBar from "$lib/components/SteerBar.svelte";
   import LeftoverDialog from "$lib/components/LeftoverDialog.svelte";
   import { m } from "$lib/paraglide/messages";
@@ -1076,18 +1076,8 @@
       {#if readyVisible}
         <!-- desktop: the ready-to-merge toggle graduates out of the git-actions
              disclosure into the always-visible primary row (mobile shows it in the
-             rail unconditionally). Gate + action mirror GitRail's ready toggle. -->
-        <button
-          class="ready-toggle"
-          class:on={session.readyToMerge}
-          type="button"
-          aria-pressed={session.readyToMerge}
-          aria-label={m.gitrail_ready_aria()}
-          title={session.readyToMerge ? m.gitrail_ready_on_title() : m.gitrail_ready_off_title()}
-          onclick={() => setReadyToMerge(session.id, !session.readyToMerge)}
-        >
-          {session.readyToMerge ? "✓ " : ""}{m.gitrail_ready()}
-        </button>
+             rail unconditionally via GitRail). Shared component → no drift. -->
+        <ReadyToggle sessionId={session.id} ready={session.readyToMerge} variant="bar" />
       {/if}
     {/if}
     <!-- trailing controls: on compact/phone they group + wrap together as a
@@ -1550,32 +1540,6 @@
   .git-toggle.open .gt-caret,
   .git-toggle.ready .gt-caret {
     color: currentColor;
-  }
-  .ready-toggle {
-    display: inline-flex;
-    align-items: center;
-    flex-shrink: 0;
-    background: transparent;
-    border: 1px solid var(--color-line-bright);
-    border-radius: 2px;
-    color: var(--color-muted);
-    font-family: var(--font-mono);
-    font-size: 10px;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    padding: 2px 7px;
-    cursor: pointer;
-    transition:
-      color 0.12s,
-      border-color 0.12s,
-      background 0.12s;
-  }
-  .ready-toggle:hover {
-    color: var(--color-ink);
-  }
-  .ready-toggle.on {
-    color: var(--color-green);
-    border-color: color-mix(in srgb, var(--color-green) 55%, transparent);
   }
 
   /* phone merged header: repo · session (subsumes the now-hidden top bar) */


### PR DESCRIPTION
## Problem
Per-session **Ready** (ready-to-merge) toggle invisible on desktop; works on mobile/unfolded fold.

**Root cause:** #188 grouped the desktop git rail behind the "Git actions" disclosure. The rail (incl. Ready toggle) mounts only `{#if compact || gitOpen}` (`Viewport.svelte`). Mobile/unfolded → `compact=true` → always shown; desktop → hidden until the disclosure is opened.

## Fix (graduate just the Ready toggle to the desktop primary row)
- `GitRail`: add `showReady` prop (default `true`) gating its own Ready toggle.
- `Viewport`: render the Ready toggle in the always-visible desktop header row (gate mirrors GitRail's: PR open *or* already ready, and not running/blocked); pass `showReady={compact}` to the disclosure rail so it never double-renders on desktop.
- No new i18n keys — reuses `gitrail_ready*` (EN+DE in parity). State folded into `aria-pressed` + on/off `title`.

## Verification
- `bun run check` 0 errors · `lint` clean · `check:i18n` parity · `bun run build` ✓
- Browser harness confirmed: desktop+open-PR → `READY` shown; desktop/no-PR → absent; already-ready → `✓ READY` green; compact → no header toggle (stays in rail, no duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
