### PR TITLE
feat(critic): skip re-review on content-identical head changes (rebase-safe)

### DIFF
--- a/docs/superpowers/specs/2026-06-03-skip-critic-rebase-design.md
+++ b/docs/superpowers/specs/2026-06-03-skip-critic-rebase-design.md
@@ -38,6 +38,16 @@ token (the patch id). Rationale:
   when there are new commits, or when conflict resolution during the rebase
   altered the branch's content. Both genuinely warrant a fresh review.
 
+**Base currency (critical).** The three-dot `base...HEAD` diff is taken from the
+merge-base of `base` and `HEAD`. `createDetached` fetches only the *head* branch,
+so the local `base` (`main`) ref can lag origin. On a rebase onto newer main, a
+stale `base` would put the merge-base at the *old* main and fold everyone else's
+merges into the diff — the fingerprint would never match and the skip would
+silently never fire for the merge-train case it targets. So the fingerprint
+**fetches the base fresh and diffs against `FETCH_HEAD`**, making the merge-base
+the true current fork point (stable across a clean rebase). Offline / no origin →
+fall back to the local base ref (worst case: we review).
+
 Rejected alternatives:
 
 - **Raw `sha256` of the diff text** — not line-number invariant; a rebase that

--- a/docs/superpowers/specs/2026-06-03-skip-critic-rebase-design.md
+++ b/docs/superpowers/specs/2026-06-03-skip-critic-rebase-design.md
@@ -1,0 +1,144 @@
+# Skip critic re-review on content-identical head changes
+
+**Date:** 2026-06-03
+**Status:** Approved design, pending implementation
+
+## Problem
+
+The AI critic dedups on the PR **head SHA** (`src/review.ts:145`):
+`getReview(id)?.headSha === git.headSha`. A rebase or force-push changes
+the head SHA, so the PR poller (`src/pr-poller.ts:78`) sees a "new head",
+emits `session:git`, and `consider()` spawns a full critic run — even when
+the branch's changes are byte-for-byte identical.
+
+The motivating case: a **merge-train** force-pushing a rebase of a branch
+onto latest `main` before merge. The rebase incorporates new `main` but the
+branch's own changes are unchanged, yet the critic re-reviews from scratch.
+
+Detecting a rebase by **who pushed** / commit author is unreliable — the
+merge-train runs under the same user account as the human. The fix sidesteps
+identity entirely and asks: *did the content the critic would review change?*
+
+## Principle
+
+Dedup the critic on **what it reviews**, not on the head SHA. The critic
+reviews exactly `git diff <base>...HEAD` (`src/review.ts:20`) — the branch's
+own changes relative to its base. A content fingerprint of that diff is stable
+across a pure rebase and changes only when the branch's actual changes change.
+
+## Fingerprint: `git patch-id`
+
+Compute `git patch-id --stable` over `git diff <base>...HEAD`, take the first
+token (the patch id). Rationale:
+
+- patch-id deliberately **ignores line numbers**, so a rebase that only shifts
+  the branch's hunks (because new `main` edited code elsewhere in the same
+  files) still produces the same id.
+- It **does** hash the changed lines and their immediate context, so it differs
+  when there are new commits, or when conflict resolution during the rebase
+  altered the branch's content. Both genuinely warrant a fresh review.
+
+Rejected alternatives:
+
+- **Raw `sha256` of the diff text** — not line-number invariant; a rebase that
+  shifts hunk positions near the branch's edits would falsely re-review,
+  defeating the purpose.
+- **Topology / "is-ancestor" check** (fast-forward vs rebase) — looks at commit
+  graph shape, not content; can't distinguish a clean rebase from a rebase that
+  resolved conflicts. Also leans on the unreliable identity signal.
+
+## Flow (`src/review.ts` `begin()`)
+
+1. `createDetached(repoPath, branch, headSha)` — already happens; the worktree
+   resolves both head and base (proven: today's post-rebase reviews already run
+   `git diff base...HEAD` in this worktree successfully).
+2. Compute `patchId` in that worktree (via injected dep — see Testability).
+3. `prior = getReview(id)`. If `prior.patchId` is non-empty **and** equals the
+   new `patchId` → **skip**:
+   - `store.bumpReviewHead(id, headSha)` — update the stored head SHA only.
+   - `worktree.remove(...)`, return.
+   - The prior verdict (findings, rounds, posted review URL) stays intact:
+     outstanding findings still apply to identical content, and we must not
+     double-post a review.
+4. Else proceed exactly as today; thread `patchId` through `InFlight` →
+   `buildVerdict()` → `putReview()` so it persists with the verdict.
+5. **Reorder**: run steps 2–3 *before* the author-notes `gh` fetch
+   (`fetchAuthorNotes`, currently `review.ts:176-183`) so the skip path makes
+   zero forge calls.
+
+### Ordering & the `starting`/`forget` tombstone
+
+`begin()` claims `this.starting` before its first await (`consider()`,
+`review.ts:147`) and re-checks `this.starting.has(id)` after the await
+(`review.ts:187`) so an archived session aborts. After reordering, the only
+remaining await on the proceed path is `fetchAuthorNotes`. Keep a
+`starting`-tombstone re-check after that await before spawning, and ensure the
+worktree created in step 1 is removed on every early-return path (skip, abort,
+spawn failure).
+
+## Safety default
+
+If patch-id is empty (no diff) or the git call fails → **do not skip; review**.
+Never skip on uncertainty.
+
+## Skip scope (accepted tradeoff)
+
+The critic only reviews the branch diff, but it *can* grep the full worktree
+(including new `main` code). Skipping a rebase means it won't re-inspect the
+branch against the newer base. This is accepted because:
+
+- CI being green is already a precondition of any critic run (`review.ts:141`).
+- The first review covered these exact branch changes.
+- Cross-file semantic drift from new `main` (e.g. `main` removed a symbol the
+  branch uses in an untouched file) is an edge case CI green largely guards,
+  and is not reliably caught by a diff-focused review anyway.
+
+## Activation
+
+**Always-on. No per-repo toggle, no UI, no i18n strings.** This is a strictly
+correctness-preserving optimization: it skips only when the reviewed diff is
+provably identity-invariant-and-line-number-invariant, so it can never skip a
+real change. It reduces critic spend rather than adding a spendy/risky loop, so
+the house rule of gating auto-features behind a kill switch does not apply.
+
+## Persistence
+
+- `reviews` table (`src/store.ts:107-115`): add column
+  `patchId TEXT NOT NULL DEFAULT ''`. Existing DBs need an
+  `ALTER TABLE reviews ADD COLUMN patchId TEXT NOT NULL DEFAULT ''`, guarded to
+  run only when the column is absent (match the store's existing migration
+  pattern).
+- `ReviewVerdict` type (`src/types.ts`): add `patchId: string`.
+- `putReview` (`src/store.ts:411`): include `patchId`.
+- New store method `bumpReviewHead(sessionId, headSha)`:
+  `UPDATE reviews SET headSha = ?, updatedAt = ? WHERE sessionId = ?` — bumps the
+  head (and `updatedAt`) without touching `decision`/`findings`/rounds/`patchId`.
+
+## Testability
+
+Add an injectable dep to `ReviewServiceDeps`, mirroring the existing
+`readVerdict`:
+
+```
+computePatchId?: (worktreePath: string, base: string) => string | null;
+```
+
+Default implementation runs the real `git diff base...HEAD | git patch-id
+--stable` in the worktree. Unit tests inject a stub.
+
+### Test cases
+
+1. **Rebase (identical patch-id)** → no critic spawn; `bumpReviewHead` called
+   with new SHA; prior verdict (findings/decision/rounds) preserved.
+2. **New commit (different patch-id)** → critic spawns; new `patchId` persisted
+   on the verdict.
+3. **First review (no prior, or empty `prior.patchId`)** → spawns; stores
+   `patchId`.
+4. **patch-id empty / git failure** → reviews (safe default, no skip).
+5. **Skip path makes no forge calls** (author-notes fetch not invoked).
+
+## Out of scope
+
+- Per-repo toggle / UI / i18n (always-on by decision).
+- Changing what the critic reviews or how findings are steered.
+- Detecting rebases by author/committer metadata (rejected approach).

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
@@ -72,6 +73,7 @@ const DEFAULT_CAP = 3;
 interface InFlight {
   sessionId: string;
   headSha: string;
+  patchId: string; // fingerprint of this run's reviewed diff; persisted on the verdict for rebase-skip
   prNumber: number;
   branch: string; // head branch, for the at-finalize live PR-state recheck (prStatus keys on it)
   repoPath: string;
@@ -88,7 +90,13 @@ interface InFlight {
 export interface ReviewServiceDeps {
   store: Pick<
     SessionStore,
-    "getRepoConfig" | "getReview" | "putReview" | "dropReview" | "snapshotReviews" | "addSignal"
+    | "getRepoConfig"
+    | "getReview"
+    | "putReview"
+    | "bumpReviewHead"
+    | "dropReview"
+    | "snapshotReviews"
+    | "addSignal"
   >;
   herdr: Pick<HerdrDriver, "start" | "stop">;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove">;
@@ -109,6 +117,9 @@ export interface ReviewServiceDeps {
   timeoutMs?: number; // give up waiting on the verdict file
   /** Injectable verdict reader (default: read VERDICT_FILE from the worktree). */
   readVerdict?: (worktreePath: string) => RawVerdict | null;
+  /** Injectable content fingerprint of `git diff base...HEAD` in the worktree (default:
+   *  real `git patch-id`). Returns null when there's no diff or git fails → never skips. */
+  computePatchId?: (worktreePath: string, base: string) => string | null;
 }
 
 interface RawVerdict {
@@ -129,12 +140,14 @@ export class ReviewService {
   private timeoutMs: number;
   private cap: number;
   private readVerdict: (worktreePath: string) => RawVerdict | null;
+  private computePatchId: (worktreePath: string, base: string) => string | null;
 
   constructor(private deps: ReviewServiceDeps) {
     this.now = deps.now ?? Date.now;
     this.timeoutMs = deps.timeoutMs ?? 10 * 60 * 1000;
     this.cap = deps.cap ?? DEFAULT_CAP;
     this.readVerdict = deps.readVerdict ?? defaultReadVerdict;
+    this.computePatchId = deps.computePatchId ?? defaultComputePatchId;
   }
 
   /** Decide whether `git` warrants a fresh critic run for `session`, and start one. */
@@ -158,34 +171,10 @@ export class ReviewService {
     // carries this streak's accountability state: its findings get fed to the critic
     // to verify they were addressed, and its addressRound bounds the auto-address loop.
     const prior = this.deps.store.getReview(session.id);
-    const priorFindings = prior?.findings ?? [];
-    const priorRound = prior?.addressRound ?? 0;
-    const priorErrorRound = prior?.errorRound ?? 0;
-    // On a re-review under auto-address, pull the author's PR notes so a justified
-    // decline isn't blindly re-raised. Gated on autoAddressEnabled (the path that
-    // creates those notes) so critic-only repos make no extra forge call. This is
-    // the one async step; a first review skips it and stays fully synchronous.
-    //
-    // Inject only notes NOT already shown to the critic on an earlier round (tracked
-    // by comment id, carried on the prior verdict): each note responded to one round's
-    // findings, so re-feeding every marked comment every round would grow the prompt
-    // unboundedly and resurrect stale justifications. Id-based — never timestamp-based:
-    // the host clock and GitHub's comment clock can skew and drop a valid decline.
-    const priorSeenNoteIds = prior?.seenNoteIds ?? [];
-    let seenNoteIds = priorSeenNoteIds;
-    let authorNotes: string[] = [];
-    if (
-      priorFindings.length &&
-      this.deps.store.getRepoConfig(session.repoPath).autoAddressEnabled
-    ) {
-      const fresh = await this.fetchAuthorNotes(session.repoPath, git.number!, priorSeenNoteIds);
-      authorNotes = fresh.notes;
-      seenNoteIds = [...priorSeenNoteIds, ...fresh.ids];
-    }
-    // forget() (session archived) may have fired during the await above; it clears our
-    // `starting` claim as a tombstone. Abort before allocating a worktree/critic so we
-    // don't run for — and re-post a review + re-insert a verdict row for — a gone session.
-    if (!this.starting.has(session.id)) return;
+
+    // Allocate the disposable worktree at the PR head first: it's the cheap, reliable way
+    // to resolve both head + base locally (a force-pushed SHA may not be in the repo until
+    // it's checked out), and it's exactly the tree the critic would review.
     let wt;
     try {
       wt = this.deps.worktree.createDetached(session.repoPath, session.branch!, git.headSha!);
@@ -193,12 +182,111 @@ export class ReviewService {
       console.warn(`[review] worktree failed for ${session.id}:`, err);
       return;
     }
-    // Read-only critic — deliberately NOT --dangerously-skip-permissions. It
-    // inspects an UNTRUSTED PR diff, so a prompt-injection hidden in that diff
-    // must not be able to run commands or escape its worktree. `dontAsk`
-    // auto-denies anything off the allowlist (an unattended PTY would otherwise
-    // hang on a permission prompt); the allowlist is read-only inspection +
-    // read-only git + writing files in its own disposable worktree.
+
+    const { patchId, skipped } = this.rebaseSkip(session, git, prior, wt.worktreePath);
+    if (skipped) return;
+
+    // Notes are fetched lazily (only a re-review under auto-address needs them) so a first
+    // review / critic-only repo stays fully synchronous up to the spawn — the await below is
+    // never reached when `wantNotes` is false, so it doesn't suspend.
+    const wantNotes =
+      !!prior?.findings?.length &&
+      this.deps.store.getRepoConfig(session.repoPath).autoAddressEnabled;
+    const { seenNoteIds, authorNotes } = wantNotes
+      ? await this.gatherAuthorNotes(session, git, prior)
+      : { seenNoteIds: prior?.seenNoteIds ?? [], authorNotes: [] as string[] };
+    // forget() (session archived) may have fired during the await above; it clears our
+    // `starting` claim as a tombstone. Abort (reaping the worktree we allocated) before
+    // spawning so we don't run for — and re-post a review + re-insert a verdict row for —
+    // a gone session.
+    if (!this.starting.has(session.id)) {
+      this.deps.worktree.remove(wt.worktreePath);
+      return;
+    }
+
+    const argv = this.criticArgv(session, prior?.findings ?? [], authorNotes);
+    let terminalId: string;
+    try {
+      terminalId = this.deps.herdr.start(
+        `review ${session.desig}`,
+        wt.worktreePath,
+        argv,
+      ).terminalId;
+    } catch (err) {
+      console.warn(`[review] spawn failed for ${session.id}:`, err);
+      this.deps.worktree.remove(wt.worktreePath);
+      return;
+    }
+    this.inflight.set(session.id, {
+      sessionId: session.id,
+      headSha: git.headSha!,
+      patchId,
+      prNumber: git.number!,
+      branch: session.branch!,
+      repoPath: session.repoPath,
+      worktreePath: wt.worktreePath,
+      terminalId,
+      startedAt: this.now(),
+      priorRound: prior?.addressRound ?? 0,
+      priorErrorRound: prior?.errorRound ?? 0,
+      priorSeenNoteIds: prior?.seenNoteIds ?? [],
+      seenNoteIds,
+    });
+    this.deps.onReviewing?.(session.id, true);
+  }
+
+  /**
+   * Rebase-skip: dedup on WHAT the critic reviews (the branch diff `base...HEAD`), not on
+   * the head SHA. A rebase/force-push moves the SHA but leaves the branch's own diff
+   * identical, so its patch-id is stable (patch-id ignores line numbers — robust to the new
+   * base shifting hunks). Identical fingerprint → the prior verdict still holds: re-point it
+   * at the new head (so consider()'s SHA guard short-circuits next poll), reap the probe
+   * worktree, and skip the run — deliberately preserving findings/decision/rounds (those
+   * still apply, and we must not double-post). Empty/failed fingerprint ('' or null) → never
+   * skip; review. Returns the fingerprint (persisted on the verdict) + whether we skipped.
+   */
+  private rebaseSkip(
+    session: Session,
+    git: GitState,
+    prior: ReviewVerdict | null,
+    worktreePath: string,
+  ): { patchId: string; skipped: boolean } {
+    const patchId = this.computePatchId(worktreePath, session.baseBranch) ?? "";
+    if (patchId && prior?.patchId && prior.patchId === patchId) {
+      this.deps.store.bumpReviewHead(session.id, git.headSha!, this.now());
+      this.deps.worktree.remove(worktreePath);
+      return { patchId, skipped: true };
+    }
+    return { patchId, skipped: false };
+  }
+
+  /**
+   * Pull the author's PR notes for a re-review so a justified decline isn't blindly
+   * re-raised (caller gates this on a prior-with-findings under auto-address).
+   *
+   * Inject only notes NOT already shown to the critic on an earlier round (tracked by comment
+   * id, carried on the prior verdict): each note responded to one round's findings, so
+   * re-feeding every marked comment every round would grow the prompt unboundedly and
+   * resurrect stale justifications. Id-based — never timestamp-based: the host clock and
+   * GitHub's comment clock can skew and drop a valid decline. Returns the per-round seen-note
+   * set to carry forward plus the note bodies for the critic prompt.
+   */
+  private async gatherAuthorNotes(
+    session: Session,
+    git: GitState,
+    prior: ReviewVerdict | null,
+  ): Promise<{ seenNoteIds: string[]; authorNotes: string[] }> {
+    const priorSeenNoteIds = prior?.seenNoteIds ?? [];
+    const fresh = await this.fetchAuthorNotes(session.repoPath, git.number!, priorSeenNoteIds);
+    return { seenNoteIds: [...priorSeenNoteIds, ...fresh.ids], authorNotes: fresh.notes };
+  }
+
+  /** Build the read-only critic's argv — deliberately NOT --dangerously-skip-permissions. It
+   *  inspects an UNTRUSTED PR diff, so a prompt-injection hidden in that diff must not be able
+   *  to run commands or escape its worktree. `dontAsk` auto-denies anything off the allowlist
+   *  (an unattended PTY would otherwise hang on a permission prompt); the allowlist is
+   *  read-only inspection + read-only git + writing files in its own disposable worktree. */
+  private criticArgv(session: Session, priorFindings: string[], authorNotes: string[]): string[] {
     const argv = [
       "claude",
       "--session-id",
@@ -241,33 +329,7 @@ export class ReviewService {
     // with no task, and hangs until timeout (every review). Don't reorder.
     argv.push("--permission-mode", "dontAsk");
     argv.push(reviewPrompt(session.baseBranch, session.prompt, priorFindings, authorNotes));
-    let terminalId: string;
-    try {
-      terminalId = this.deps.herdr.start(
-        `review ${session.desig}`,
-        wt.worktreePath,
-        argv,
-      ).terminalId;
-    } catch (err) {
-      console.warn(`[review] spawn failed for ${session.id}:`, err);
-      this.deps.worktree.remove(wt.worktreePath);
-      return;
-    }
-    this.inflight.set(session.id, {
-      sessionId: session.id,
-      headSha: git.headSha!,
-      prNumber: git.number!,
-      branch: session.branch!,
-      repoPath: session.repoPath,
-      worktreePath: wt.worktreePath,
-      terminalId,
-      startedAt: this.now(),
-      priorRound,
-      priorErrorRound,
-      priorSeenNoteIds,
-      seenNoteIds,
-    });
-    this.deps.onReviewing?.(session.id, true);
+    return argv;
   }
 
   /** Read the author's marked decline notes back off the PR, restricted to comments not
@@ -451,6 +513,7 @@ export class ReviewService {
     return {
       sessionId: f.sessionId,
       headSha: f.headSha,
+      patchId: f.patchId, // fingerprint of this run's diff; a later identical head skips re-review
       decision: resolved,
       summary,
       body: raw && typeof raw.body === "string" ? raw.body : "",
@@ -484,6 +547,35 @@ export class ReviewService {
       this.deps.onReviewing?.(sessionId, false);
     }
     this.deps.store.dropReview(sessionId);
+  }
+}
+
+/** Fingerprint the branch diff with `git patch-id` so a rebase (same diff, new SHA) is a
+ *  no-op. patch-id ignores line numbers, so it stays stable when the rebased-onto base
+ *  shifts hunks elsewhere; it changes only when the branch's own changed lines or their
+ *  context change. Null on no diff or any git failure → caller never skips (reviews). */
+function defaultComputePatchId(worktreePath: string, base: string): string | null {
+  try {
+    // 64 MiB ceiling: a real branch diff won't approach it; a runaway one just falls back
+    // to null (review) rather than throwing.
+    const diff = execFileSync("git", ["diff", `${base}...HEAD`], {
+      cwd: worktreePath,
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    if (!diff.length) return null; // no diff → nothing to fingerprint
+    const out = execFileSync("git", ["patch-id", "--stable"], {
+      cwd: worktreePath,
+      input: diff,
+      maxBuffer: 1024 * 1024,
+      stdio: ["pipe", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+    const id = out.split(/\s+/)[0] ?? ""; // "<patch-id> <commit-id>" → take the patch-id
+    return id || null;
+  } catch {
+    return null; // git missing / bad base / empty → don't skip
   }
 }
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -556,9 +556,25 @@ export class ReviewService {
  *  context change. Null on no diff or any git failure → caller never skips (reviews). */
 function defaultComputePatchId(worktreePath: string, base: string): string | null {
   try {
+    // Diff against the CURRENT base, not a possibly-stale local ref. createDetached fetches
+    // only the head branch, so local `main` can lag behind origin; on a rebase onto newer
+    // main the three-dot merge-base would then sit at the OLD main and fold everyone else's
+    // merges (M_old..M_new) into `base...HEAD`. The fingerprint would never match the prior
+    // review and the skip would silently never fire — exactly the merge-train case it
+    // targets. So fetch the base fresh and diff against FETCH_HEAD: the merge-base becomes
+    // the true current fork point, which is stable across a clean rebase. Offline / no origin
+    // → fall back to the local base ref (best-effort; worst case we review).
+    let ref = base;
+    try {
+      // `--` blocks flag-smuggling via a hostile branch name (mirrors createDetached).
+      execFileSync("git", ["fetch", "origin", "--", base], { cwd: worktreePath, stdio: "pipe" });
+      ref = "FETCH_HEAD";
+    } catch {
+      /* offline or no origin remote — fall through to the local base ref */
+    }
     // 64 MiB ceiling: a real branch diff won't approach it; a runaway one just falls back
     // to null (review) rather than throwing.
-    const diff = execFileSync("git", ["diff", `${base}...HEAD`], {
+    const diff = execFileSync("git", ["diff", `${ref}...HEAD`], {
       cwd: worktreePath,
       maxBuffer: 64 * 1024 * 1024,
       stdio: ["ignore", "pipe", "ignore"],

--- a/src/review.ts
+++ b/src/review.ts
@@ -244,6 +244,12 @@ export class ReviewService {
    * worktree, and skip the run — deliberately preserving findings/decision/rounds (those
    * still apply, and we must not double-post). Empty/failed fingerprint ('' or null) → never
    * skip; review. Returns the fingerprint (persisted on the verdict) + whether we skipped.
+   *
+   * Never skip past an `error` verdict: a timeout/unparseable run produced no real verdict,
+   * so its decision is a transient failure to RETRY, not a result to preserve — inheriting it
+   * across an identical-diff rebase would freeze the PR on a stale error. (Defensive even
+   * though buildVerdict no longer fingerprints error verdicts: this also covers error rows
+   * persisted before that change.)
    */
   private rebaseSkip(
     session: Session,
@@ -252,7 +258,7 @@ export class ReviewService {
     worktreePath: string,
   ): { patchId: string; skipped: boolean } {
     const patchId = this.computePatchId(worktreePath, session.baseBranch) ?? "";
-    if (patchId && prior?.patchId && prior.patchId === patchId) {
+    if (patchId && prior?.patchId && prior.decision !== "error" && prior.patchId === patchId) {
       this.deps.store.bumpReviewHead(session.id, git.headSha!, this.now());
       this.deps.worktree.remove(worktreePath);
       return { patchId, skipped: true };
@@ -513,7 +519,10 @@ export class ReviewService {
     return {
       sessionId: f.sessionId,
       headSha: f.headSha,
-      patchId: f.patchId, // fingerprint of this run's diff; a later identical head skips re-review
+      // Fingerprint of this run's diff; a later identical head skips re-review. NOT recorded
+      // for an error verdict (timeout/unparseable): that's a transient failure to retry, so a
+      // content-identical rebase must re-review rather than inherit the stale error.
+      patchId: resolved === "error" ? "" : f.patchId,
       decision: resolved,
       summary,
       body: raw && typeof raw.body === "string" ? raw.body : "",

--- a/src/store.ts
+++ b/src/store.ts
@@ -113,7 +113,8 @@ export class SessionStore implements CapStore {
       this.db.run(`ALTER TABLE repo_config ADD COLUMN learningsEnabled INTEGER NOT NULL DEFAULT 1`);
     }
     this.db.run(`CREATE TABLE IF NOT EXISTS reviews (
-      sessionId TEXT PRIMARY KEY, headSha TEXT NOT NULL, decision TEXT NOT NULL,
+      sessionId TEXT PRIMARY KEY, headSha TEXT NOT NULL, patchId TEXT NOT NULL DEFAULT '',
+      decision TEXT NOT NULL,
       summary TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '',
       findings TEXT NOT NULL DEFAULT '[]', addressRound INTEGER NOT NULL DEFAULT 0,
       addressCap INTEGER NOT NULL DEFAULT 3, errorRound INTEGER NOT NULL DEFAULT 0,
@@ -138,6 +139,11 @@ export class SessionStore implements CapStore {
     }
     if (!reviewCols.some((c) => c.name === "seenNoteIds")) {
       this.db.run(`ALTER TABLE reviews ADD COLUMN seenNoteIds TEXT NOT NULL DEFAULT '[]'`);
+    }
+    // patchId backs rebase-skip: pre-existing rows backfill to '' (unknown), so the
+    // next head change reviews once and records the fingerprint going forward.
+    if (!reviewCols.some((c) => c.name === "patchId")) {
+      this.db.run(`ALTER TABLE reviews ADD COLUMN patchId TEXT NOT NULL DEFAULT ''`);
     }
     this.db.run(`CREATE TABLE IF NOT EXISTS signals (
       id TEXT PRIMARY KEY, repoPath TEXT NOT NULL, sessionId TEXT,
@@ -388,6 +394,7 @@ export class SessionStore implements CapStore {
   private hydrateReview(r: any): ReviewVerdict {
     return {
       ...r,
+      patchId: r.patchId ?? "",
       findings: parseFindings(r.findings),
       addressRound: r.addressRound ?? 0,
       addressCap: r.addressCap ?? 3,
@@ -400,7 +407,7 @@ export class SessionStore implements CapStore {
   getReview(sessionId: string): ReviewVerdict | null {
     const r = this.db
       .query(
-        `SELECT sessionId, headSha, decision, summary, body, findings, addressRound,
+        `SELECT sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
                 addressCap, errorRound, seenNoteIds, url, updatedAt
               FROM reviews WHERE sessionId = ?`,
       )
@@ -410,10 +417,11 @@ export class SessionStore implements CapStore {
 
   putReview(v: ReviewVerdict): void {
     this.db.run(
-      `INSERT INTO reviews (sessionId, headSha, decision, summary, body, findings, addressRound,
+      `INSERT INTO reviews (sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
          addressCap, errorRound, seenNoteIds, url, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
-       ON CONFLICT(sessionId) DO UPDATE SET headSha=excluded.headSha, decision=excluded.decision,
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+       ON CONFLICT(sessionId) DO UPDATE SET headSha=excluded.headSha, patchId=excluded.patchId,
+         decision=excluded.decision,
          summary=excluded.summary, body=excluded.body, findings=excluded.findings,
          addressRound=excluded.addressRound, addressCap=excluded.addressCap,
          errorRound=excluded.errorRound, seenNoteIds=excluded.seenNoteIds,
@@ -421,6 +429,7 @@ export class SessionStore implements CapStore {
       [
         v.sessionId,
         v.headSha,
+        v.patchId ?? "",
         v.decision,
         v.summary,
         v.body,
@@ -439,10 +448,21 @@ export class SessionStore implements CapStore {
     this.db.run(`DELETE FROM reviews WHERE sessionId = ?`, [sessionId]);
   }
 
+  /** Re-point an existing verdict at a new head without re-reviewing. Used when a head
+   *  change (rebase/force-push) leaves the reviewed diff content-identical (same patchId):
+   *  the prior decision/findings/rounds still apply, so only headSha + updatedAt move. */
+  bumpReviewHead(sessionId: string, headSha: string, updatedAt: number): void {
+    this.db.run(`UPDATE reviews SET headSha = ?, updatedAt = ? WHERE sessionId = ?`, [
+      headSha,
+      updatedAt,
+      sessionId,
+    ]);
+  }
+
   snapshotReviews(): Record<string, ReviewVerdict> {
     const rows = this.db
       .query(
-        `SELECT sessionId, headSha, decision, summary, body, findings, addressRound,
+        `SELECT sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
                 addressCap, errorRound, seenNoteIds, url, updatedAt FROM reviews`,
       )
       .all() as any[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,7 @@ export type ReviewDecision = "changes_requested" | "commented" | "error";
 export interface ReviewVerdict {
   sessionId: string;
   headSha: string; // PR head this verdict applies to
+  patchId: string; // git patch-id of `git diff base...HEAD`; dedups re-reviews across rebases (a pure rebase keeps it stable, so the head can change without re-reviewing). '' = unknown (always reviews)
   decision: ReviewDecision;
   summary: string; // <=100 char one-liner for the badge tooltip
   body: string; // full markdown findings (seeds the steer-back)

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -379,6 +379,28 @@ test("unresolvable fingerprint never skips: reviews even with a prior verdict", 
   expect(started).toHaveLength(1); // reviewed
 });
 
+test("prior error verdict never rebase-skips (retries the transient failure)", async () => {
+  const { deps: d, reviews, started, bumped } = makeDeps({ computePatchId: () => "pid-same" });
+  // an errored prior that (legacy row / defensive) still carries a matching fingerprint
+  reviews["s1"] = priorReview({ decision: "error", patchId: "pid-same", headSha: "old" });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(bumped).toHaveLength(0); // not skipped despite identical fingerprint
+  expect(started).toHaveLength(1); // re-reviewed instead of inheriting the stale error
+});
+
+test("error verdict records no fingerprint (so a later head always re-reviews)", async () => {
+  const { deps: d, reviews } = makeDeps({
+    computePatchId: () => "pid-x",
+    readVerdict: () => ({ decision: "bogus", summary: "?", body: "" }), // unparseable → error
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.decision).toBe("error");
+  expect(reviews["s1"]?.patchId).toBe(""); // no fingerprint persisted on a failed run
+});
+
 test("rebase-skip short-circuits before any forge call (no author-notes fetch)", async () => {
   const {
     deps: d,

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -80,6 +80,7 @@ function makeDeps(
   const started: { name: string; cwd: string; argv: string[] }[] = [];
   const stopped: string[] = [];
   const removed: string[] = [];
+  const bumped: { id: string; headSha: string }[] = []; // bumpReviewHead calls (rebase-skip)
   const steers: { id: string; text: string }[] = [];
   const signals: { kind: string; payload: string }[] = [];
   const commentCalls: number[] = []; // prNumbers passed to listPrComments
@@ -93,6 +94,11 @@ function makeDeps(
       getReview: (id: string) => reviews[id] ?? null,
       putReview: (v: ReviewVerdict) => {
         reviews[v.sessionId] = v;
+      },
+      bumpReviewHead: (id: string, headSha: string, updatedAt: number) => {
+        bumped.push({ id, headSha });
+        const r = reviews[id];
+        if (r) reviews[id] = { ...r, headSha, updatedAt };
       },
       dropReview: (id: string) => {
         delete reviews[id];
@@ -121,7 +127,18 @@ function makeDeps(
     readVerdict: () => ({ decision: "request-changes", summary: "2 issues", body: "## findings" }),
     ...over,
   };
-  return { deps: base, reviews, started, stopped, removed, steers, signals, commentCalls, rec };
+  return {
+    deps: base,
+    reviews,
+    started,
+    stopped,
+    removed,
+    bumped,
+    steers,
+    signals,
+    commentCalls,
+    rec,
+  };
 }
 
 test("reviewPrompt embeds base + task and asks for the verdict file", () => {
@@ -290,6 +307,7 @@ test("forget reaps an in-flight critic and drops the stored review", () => {
   reviews["s1"] = {
     sessionId: "s1",
     headSha: "abc",
+    patchId: "pid-abc",
     decision: "commented",
     summary: "",
     body: "",
@@ -304,6 +322,75 @@ test("forget reaps an in-flight critic and drops the stored review", () => {
   expect(stopped).toEqual(["rt"]); // critic terminal reaped
   expect(removed).toEqual(["/review-wt"]); // worktree removed
   expect(reviews["s1"]).toBeUndefined(); // stored verdict dropped
+});
+
+// ── rebase-skip (content-fingerprint dedup) ───────────────────────────────────
+
+test("rebase with identical diff: skips the critic, re-points head, preserves the verdict", async () => {
+  const {
+    deps: d,
+    reviews,
+    started,
+    removed,
+    bumped,
+  } = makeDeps({
+    computePatchId: () => "pid-same",
+  });
+  // prior verdict was for head "old"; the branch is force-pushed/rebased to "newsha"
+  // but its diff is identical → same patch-id.
+  reviews["s1"] = priorReview({ patchId: "pid-same", headSha: "old" });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(started).toHaveLength(0); // no critic spawned
+  expect(removed).toEqual(["/review-wt"]); // the probe worktree is reaped
+  expect(bumped).toEqual([{ id: "s1", headSha: "newsha" }]); // head re-pointed
+  // verdict otherwise intact: outstanding findings + patch-id survive (not re-posted)
+  expect(reviews["s1"]?.findings).toEqual(["fix the race in worker.ts"]);
+  expect(reviews["s1"]?.patchId).toBe("pid-same");
+});
+
+test("new commit (different diff): reviews and records the new fingerprint", async () => {
+  const { deps: d, reviews, started, bumped } = makeDeps({ computePatchId: () => "pid-new" });
+  reviews["s1"] = priorReview({ patchId: "pid-old", headSha: "old" });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(bumped).toHaveLength(0); // not a skip
+  expect(started).toHaveLength(1); // critic spawned
+  await svc.tick();
+  expect(reviews["s1"]?.patchId).toBe("pid-new"); // fingerprint persisted on the verdict
+});
+
+test("first review records the fingerprint for later rebase-skip", async () => {
+  const { deps: d, reviews, started } = makeDeps({ computePatchId: () => "pid-first" });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN); // no prior
+  expect(started).toHaveLength(1);
+  await svc.tick();
+  expect(reviews["s1"]?.patchId).toBe("pid-first");
+});
+
+test("unresolvable fingerprint never skips: reviews even with a prior verdict", async () => {
+  const { deps: d, reviews, started, bumped } = makeDeps({ computePatchId: () => null });
+  // prior has a real patch-id, but this run can't fingerprint (git failed / empty diff)
+  reviews["s1"] = priorReview({ patchId: "pid-old", headSha: "old" });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(bumped).toHaveLength(0); // safety default → do not skip
+  expect(started).toHaveLength(1); // reviewed
+});
+
+test("rebase-skip short-circuits before any forge call (no author-notes fetch)", async () => {
+  const {
+    deps: d,
+    reviews,
+    started,
+    commentCalls,
+  } = makeDeps({ computePatchId: () => "pid-same" }, { autoAddressEnabled: true });
+  reviews["s1"] = priorReview({ patchId: "pid-same", headSha: "old" }); // has findings
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(started).toHaveLength(0); // skipped
+  expect(commentCalls).toEqual([]); // skip happened before fetchAuthorNotes
 });
 
 // ── auto-address loop ─────────────────────────────────────────────────────────
@@ -394,6 +481,7 @@ test("clean verdict (no findings) stops the loop and resets the round", async ()
   reviews["s1"] = {
     sessionId: "s1",
     headSha: "old",
+    patchId: "pid-old",
     decision: "changes_requested",
     summary: "",
     body: "",
@@ -432,6 +520,7 @@ test("round cap reached: holds the round, posts the review + signal, does not st
   reviews["s1"] = {
     sessionId: "s1",
     headSha: "old",
+    patchId: "pid-old",
     decision: "changes_requested",
     summary: "",
     body: "",
@@ -541,6 +630,7 @@ function priorReview(over: Partial<ReviewVerdict> = {}): ReviewVerdict {
   return {
     sessionId: "s1",
     headSha: "old",
+    patchId: "pid-old",
     decision: "changes_requested",
     summary: "",
     body: "",

--- a/test/server-reviews.test.ts
+++ b/test/server-reviews.test.ts
@@ -38,6 +38,7 @@ test("GET /api/reviews returns snapshot when reviewCache is present", async () =
   const verdict: ReviewVerdict = {
     sessionId: "sess-1",
     headSha: "abc123",
+    patchId: "pid-abc123",
     decision: "commented",
     summary: "Looks good",
     body: "Full body here",

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -73,6 +73,7 @@ test("reviews: upsert + read by session, snapshot all", () => {
   const v = {
     sessionId: "s1",
     headSha: "abc",
+    patchId: "pid-abc",
     decision: "changes_requested" as const,
     summary: "2 issues",
     body: "## findings",
@@ -114,6 +115,30 @@ test("reviews: findings/addressRound/addressCap/errorRound/seenNoteIds default w
   expect(r?.addressCap).toBe(3); // backfilled to the migration default
   expect(r?.errorRound).toBe(0);
   expect(r?.seenNoteIds).toEqual([]);
+  expect(r?.patchId).toBe(""); // pre-rebase-skip rows backfill to '' (unknown → always reviews)
+});
+
+test("bumpReviewHead: re-points head + updatedAt, leaves the verdict otherwise intact", () => {
+  const store = new SessionStore(":memory:");
+  const v = {
+    sessionId: "s1",
+    headSha: "abc",
+    patchId: "pid-1",
+    decision: "changes_requested" as const,
+    summary: "still broken",
+    body: "## findings",
+    findings: ["fix the off-by-one"],
+    addressRound: 2,
+    addressCap: 3,
+    errorRound: 0,
+    seenNoteIds: ["c1"],
+    url: "u",
+    updatedAt: 100,
+  };
+  store.putReview(v);
+  store.bumpReviewHead("s1", "def", 200);
+  // identical-content rebase: head + clock move, everything else (incl. patchId) holds
+  expect(store.getReview("s1")).toEqual({ ...v, headSha: "def", updatedAt: 200 });
 });
 
 test("readyToMerge: defaults false on create, round-trips through update", () => {


### PR DESCRIPTION
## Problem

The critic dedups on the PR **head SHA**. A rebase/force-push (e.g. a merge-train rebasing a branch onto latest `main` before merge) moves the SHA but leaves the branch's own changes identical — yet the poller sees a "new head" and spawns a **full critic re-review** from scratch.

Detecting a rebase by *who pushed* / commit author is unreliable: the merge-train runs under the same user account as the human. So this sidesteps identity entirely and asks **"did the content the critic would review actually change?"**

## Approach

Dedup on a **content fingerprint** of what the critic reviews (`git diff base...HEAD`), not the head SHA:

- Fingerprint = `git patch-id --stable`. It deliberately **ignores line numbers**, so a rebase that only shifts the branch's hunks (because new `main` edited code elsewhere) still matches. It differs only when the branch's actual changed lines/context change — new commits, or conflict resolution during the rebase. Both genuinely warrant re-review.
- Identical fingerprint → re-point the prior verdict at the new head (`bumpReviewHead`) and **skip**, preserving the prior decision/findings/rounds (they still apply; we must not double-post).
- **Safety default:** empty/failed fingerprint → never skip; review.
- **Always-on, no toggle/UI/i18n** — strictly correctness-preserving (skips only provably-identical diffs), reduces spend rather than adding a loop.

## Changes

- **store**: `reviews.patchId` column (+ migration), `bumpReviewHead()`, persist `patchId` in put/get/snapshot.
- **review**: probe worktree + fingerprint **before** the author-notes fetch, so a skip makes **zero forge calls**; injectable `computePatchId` for tests; extracted `rebaseSkip`/`gatherAuthorNotes`/`criticArgv` helpers (keeps `begin()` under the complexity gate). Lazy note-fetch keeps the first-review path synchronous.

## Verification

- Root `tsc` + `eslint` clean; `bun test ./test` → **798 pass, 0 fail** (5 new skip-path tests + store round-trip).
- Real-git smoke test confirmed the premise: rebase-onto-moved-`main` → **stable** patch-id (skips); a new commit → **changed** patch-id (reviews).

Server-only; the UI keeps its own `ReviewVerdict` type and ignores the extra wire field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)