### PR TITLE
feat(critic): dimmed FINAL badge while agent addresses last review round

### DIFF
--- a/docs/superpowers/plans/2026-06-03-critic-badge-final-round-state.md
+++ b/docs/superpowers/plans/2026-06-03-critic-badge-final-round-state.md
@@ -1,0 +1,623 @@
+# Tri-state Critic Badge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the critic badge's single `stalled` state into "final round in flight" (dimmed `FINAL`) vs. genuinely stalled (orange `STALLED`), so a session isn't shown as stalled while the agent is still addressing the last allowed round.
+
+**Architecture:** Server tags each verdict with `finalRoundPending` (true only when the cap-th steer was *just* delivered: `addressRound > priorRound && addressRound >= cap`). A surfaced `finalRoundTimeoutMs` lets the UI escalate an abandoned final round to orange after 15 min. The UI badge derives a 3-way status (`round` | `final` | `stalled`) from those fields plus a shared coarse clock.
+
+**Tech Stack:** Bun + TypeScript (server), bun:sqlite (store), SvelteKit + Svelte 5 runes (UI), Paraglide JS (i18n).
+
+**Deviation from spec (intentional):** `finalRoundTimeoutMs` is **stored as a column** (set by `buildVerdict` from the constant), mirroring how `addressCap` is persisted — rather than injected at read-time. This avoids coupling `store.ts` to `review.ts`'s constant. A stale 15-min value on reload is harmless (it only shifts when an already-pending badge escalates).
+
+---
+
+### Task 1: Server — verdict fields, constant, and `finalRoundPending` logic
+
+**Files:**
+- Modify: `src/types.ts` (ReviewVerdict interface)
+- Modify: `src/review.ts` (constant ~line 70, `buildVerdict` ~line 430, `finalize` ~line 364)
+- Test: `test/review.test.ts`
+
+- [ ] **Step 1: Add the two fields to the server `ReviewVerdict` type**
+
+In `src/types.ts`, find the `ReviewVerdict` interface (the block with `addressRound` / `addressCap` / `errorRound`, ~lines 109-125) and add, right after the `errorRound` line:
+
+```ts
+  errorRound: number; // consecutive critic error verdicts (0 on real verdict)
+  finalRoundPending: boolean; // cap-th steer just delivered, no re-review yet → dimmed FINAL badge
+  finalRoundTimeoutMs: number; // live abandonment timeout; surfaced so the UI never hardcodes it
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+In `test/review.test.ts`, after the existing `"round cap reached: holds the round..."` test (~line 450), add:
+
+```ts
+test("advancing into the cap marks the final round pending (not yet stalled)", async () => {
+  const { deps: d, reviews } = makeDeps(
+    {
+      readVerdict: () => ({
+        decision: "request-changes",
+        summary: "still broken",
+        body: "b",
+        findings: ["still broken"],
+      }),
+    },
+    { autoAddressEnabled: true },
+  );
+  reviews["s1"] = priorReview({ addressRound: 2 }); // one try left; cap is 3
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.addressRound).toBe(3); // advanced into the cap
+  expect(reviews["s1"]?.finalRoundPending).toBe(true); // steer just delivered, agent working it
+});
+
+test("holding at the cap is a confirmed stall, not pending", async () => {
+  const { deps: d, reviews } = makeDeps(
+    {
+      readVerdict: () => ({
+        decision: "request-changes",
+        summary: "still broken",
+        body: "b",
+        findings: ["still broken"],
+      }),
+    },
+    { autoAddressEnabled: true },
+  );
+  reviews["s1"] = priorReview({ addressRound: 3 }); // already at cap → held, no steer
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.addressRound).toBe(3);
+  expect(reviews["s1"]?.finalRoundPending).toBe(false); // gave up → orange, not dimmed
+});
+
+test("clean verdict is never final-round-pending", async () => {
+  const { deps: d, reviews } = makeDeps(
+    { readVerdict: () => ({ decision: "comment", summary: "lgtm", body: "b", findings: [] }) },
+    { autoAddressEnabled: true },
+  );
+  reviews["s1"] = priorReview({ addressRound: 2 });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.finalRoundPending).toBe(false);
+});
+```
+
+> Note: `priorReview(...)` is the existing helper in this file. If it does not already set `finalRoundPending`/`finalRoundTimeoutMs`, add safe defaults to it (Step 5).
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `bun test ./test/review.test.ts`
+Expected: the 3 new tests FAIL (`finalRoundPending` is `undefined`).
+
+- [ ] **Step 4: Add the constant and initialize the fields in `buildVerdict`**
+
+In `src/review.ts`, near `const DEFAULT_CAP = 3;` (~line 70), add:
+
+```ts
+// How long a delivered final round may run before the badge escalates from dimmed
+// FINAL to orange STALLED on its own (covers an agent that abandons the last round
+// without re-pushing). Surfaced per-verdict as `finalRoundTimeoutMs` so the UI reads
+// the live value instead of mirroring this number.
+const DEFAULT_FINAL_ROUND_TIMEOUT_MS = 15 * 60_000;
+```
+
+In `buildVerdict`'s returned object (~lines 430-442), add the two fields next to `errorRound`:
+
+```ts
+      errorRound: 0, // finalize() overwrites on an error verdict
+      finalRoundPending: false, // finalize() sets this on a real verdict
+      finalRoundTimeoutMs: DEFAULT_FINAL_ROUND_TIMEOUT_MS, // live escalation timeout
+```
+
+- [ ] **Step 5: Set `finalRoundPending` in `finalize` and patch the test helper**
+
+In `src/review.ts` `finalize`, in the real-verdict `else` branch, immediately after
+`verdict.addressRound = this.runAutoAddress(f, verdict);` (~line 364) add:
+
+```ts
+        verdict.addressRound = this.runAutoAddress(f, verdict); // errorRound stays 0 on a real verdict
+        // The cap-th steer was just delivered when the round ADVANCES into the cap
+        // (priorRound < cap → addressRound === cap). The agent is now addressing that
+        // final round → dimmed FINAL badge, not orange. A round HELD at the cap
+        // (addressRound === priorRound) means that final round already failed re-review
+        // → confirmed stall. Error verdicts hold the round, so they stay false here.
+        verdict.finalRoundPending =
+          verdict.findings.length > 0 &&
+          verdict.addressRound >= this.cap &&
+          verdict.addressRound > f.priorRound;
+```
+
+The error branch leaves `verdict.finalRoundPending` at its `false` default — no change needed there.
+
+In `test/review.test.ts`, find the `priorReview` helper and ensure it provides the new
+fields (add only if missing):
+
+```ts
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 15 * 60_000,
+```
+
+Also add the same two fields to the two inline verdict literals in this file (the
+`forget` test ~line 288 and the `clean verdict` test ~line 392) so they satisfy the type.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `bun test ./test/review.test.ts`
+Expected: PASS (all, including the 3 new tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/types.ts src/review.ts test/review.test.ts
+git commit -m "feat(critic): tag verdicts with finalRoundPending + timeout"
+```
+
+---
+
+### Task 2: Store — persist the new fields
+
+**Files:**
+- Modify: `src/store.ts` (schema ~line 115, migration ~line 123, `hydrateReview` ~line 388, `getReview`/`putReview`/`snapshotReviews` ~lines 400-452)
+- Test: `test/store.test.ts` (if present; otherwise add assertions in `test/review.test.ts` round-trip — see Step 2)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/store.test.ts` (create the `import { Store } ...` mirroring the file's existing tests; if the file is absent, place this in `test/review.test.ts` instead):
+
+```ts
+test("putReview round-trips finalRoundPending + finalRoundTimeoutMs", () => {
+  const store = new Store(":memory:");
+  store.putReview({
+    sessionId: "s1",
+    headSha: "abc",
+    decision: "changes_requested",
+    summary: "",
+    body: "",
+    findings: ["x"],
+    addressRound: 3,
+    addressCap: 3,
+    errorRound: 0,
+    finalRoundPending: true,
+    finalRoundTimeoutMs: 900_000,
+    seenNoteIds: [],
+    updatedAt: 1,
+  });
+  const got = store.getReview("s1");
+  expect(got?.finalRoundPending).toBe(true);
+  expect(got?.finalRoundTimeoutMs).toBe(900_000);
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `bun test ./test/store.test.ts` (or `./test/review.test.ts` if you placed it there)
+Expected: FAIL — `finalRoundPending` comes back `undefined` (column not stored).
+
+- [ ] **Step 3: Add columns to the schema + migration**
+
+In `src/store.ts`, in the `CREATE TABLE IF NOT EXISTS reviews` block (~lines 115-121), add the
+two columns before `url TEXT, updatedAt INTEGER NOT NULL)`:
+
+```sql
+      seenNoteIds TEXT NOT NULL DEFAULT '[]',
+      finalRoundPending INTEGER NOT NULL DEFAULT 0,
+      finalRoundTimeoutMs INTEGER NOT NULL DEFAULT 900000,
+      url TEXT, updatedAt INTEGER NOT NULL)`);
+```
+
+In the migration block (~after line 138, alongside the other `if (!reviewCols.some(...))` guards), add:
+
+```ts
+    if (!reviewCols.some((c) => c.name === "finalRoundPending")) {
+      this.db.run(`ALTER TABLE reviews ADD COLUMN finalRoundPending INTEGER NOT NULL DEFAULT 0`);
+    }
+    // 900000ms = 15min; one-time backfill for pre-existing rows, not an ongoing mirror —
+    // live rows carry ReviewService's DEFAULT_FINAL_ROUND_TIMEOUT_MS.
+    if (!reviewCols.some((c) => c.name === "finalRoundTimeoutMs")) {
+      this.db.run(
+        `ALTER TABLE reviews ADD COLUMN finalRoundTimeoutMs INTEGER NOT NULL DEFAULT 900000`,
+      );
+    }
+```
+
+- [ ] **Step 4: Hydrate + read + write the new columns**
+
+In `hydrateReview` (~line 388), add coercion (SQLite stores the bool as 0/1):
+
+```ts
+      errorRound: r.errorRound ?? 0,
+      finalRoundPending: !!r.finalRoundPending,
+      finalRoundTimeoutMs: r.finalRoundTimeoutMs ?? 900_000,
+```
+
+In `getReview` (~line 403) and `snapshotReviews` (~line 445) SELECT lists, add the columns:
+
+```sql
+        `SELECT sessionId, headSha, decision, summary, body, findings, addressRound,
+                addressCap, errorRound, finalRoundPending, finalRoundTimeoutMs,
+                seenNoteIds, url, updatedAt
+              FROM reviews WHERE sessionId = ?`,
+```
+
+(and the same column additions in the `snapshotReviews` SELECT.)
+
+In `putReview` (~lines 412-435): add the columns to the INSERT list, the `VALUES` `?`
+count, the `ON CONFLICT ... DO UPDATE SET`, and the bound-params array:
+
+```ts
+      `INSERT INTO reviews (sessionId, headSha, decision, summary, body, findings, addressRound,
+         addressCap, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+       ON CONFLICT(sessionId) DO UPDATE SET headSha=excluded.headSha, decision=excluded.decision,
+         summary=excluded.summary, body=excluded.body, findings=excluded.findings,
+         addressRound=excluded.addressRound, addressCap=excluded.addressCap,
+         errorRound=excluded.errorRound, finalRoundPending=excluded.finalRoundPending,
+         finalRoundTimeoutMs=excluded.finalRoundTimeoutMs, seenNoteIds=excluded.seenNoteIds,
+         url=excluded.url, updatedAt=excluded.updatedAt`,
+```
+
+Params array — add after `v.errorRound ?? 0,`:
+
+```ts
+        v.errorRound ?? 0,
+        v.finalRoundPending ? 1 : 0,
+        v.finalRoundTimeoutMs ?? 900_000,
+```
+
+- [ ] **Step 5: Run it to verify it passes**
+
+Run: `bun test ./test/store.test.ts` (or wherever you placed the test)
+Expected: PASS.
+
+- [ ] **Step 6: Run the full server suite (guard against regressions)**
+
+Run: `bun test ./test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/store.ts test/store.test.ts
+git commit -m "feat(critic): persist finalRoundPending + finalRoundTimeoutMs"
+```
+
+---
+
+### Task 3: UI type mirror
+
+**Files:**
+- Modify: `ui/src/lib/types.ts` (ReviewVerdict, ~lines 128-140)
+
+- [ ] **Step 1: Add the fields to the UI `ReviewVerdict`**
+
+In `ui/src/lib/types.ts`, the `ReviewVerdict` interface is a slimmer mirror than the
+server's (no `errorRound`/`seenNoteIds`). Add the two fields after `addressCap`:
+
+```ts
+  addressCap: number; // server's streak cap for this run — the badge reads it instead of mirroring
+  finalRoundPending: boolean; // cap-th steer just delivered, no re-review yet → dimmed FINAL badge
+  finalRoundTimeoutMs: number; // live abandonment timeout (ms); UI escalates FINAL→STALLED after this
+  url?: string;
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd ui && bun run check`
+Expected: PASS (no consumers reference the fields yet; the interface just gains them).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/src/lib/types.ts
+git commit -m "feat(critic): mirror finalRound fields in UI verdict type"
+```
+
+---
+
+### Task 4: Shared coarse clock store
+
+**Files:**
+- Create: `ui/src/lib/now.svelte.ts`
+
+- [ ] **Step 1: Create the clock store**
+
+```ts
+// ui/src/lib/now.svelte.ts
+// Shared coarse wall-clock: a single 30s tick drives time-based UI (e.g. the critic
+// badge escalating an abandoned final round from dimmed FINAL to orange STALLED)
+// without each component spinning up its own interval. Read `clock.current` inside a
+// $derived to make that computation re-run on each tick.
+class Clock {
+  current = $state(Date.now());
+  constructor() {
+    setInterval(() => (this.current = Date.now()), 30_000);
+  }
+}
+export const clock = new Clock();
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd ui && bun run check`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/src/lib/now.svelte.ts
+git commit -m "feat(ui): shared 30s clock store for time-based badges"
+```
+
+---
+
+### Task 5: Tri-state badge logic
+
+**Files:**
+- Modify: `ui/src/lib/components/critic-badge.ts`
+- Test: `ui/src/lib/components/critic-badge.test.ts` (create)
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `ui/src/lib/components/critic-badge.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { addressRoundInfo } from "./critic-badge";
+import type { ReviewVerdict } from "$lib/types";
+
+const base: ReviewVerdict = {
+  sessionId: "s1",
+  headSha: "abc",
+  decision: "changes_requested",
+  summary: "",
+  body: "",
+  findings: ["x"],
+  addressRound: 0,
+  addressCap: 3,
+  finalRoundPending: false,
+  finalRoundTimeoutMs: 900_000,
+  updatedAt: 1_000_000,
+};
+const v = (p: Partial<ReviewVerdict>): ReviewVerdict => ({ ...base, ...p });
+
+describe("addressRoundInfo", () => {
+  it("returns null when no streak is in progress", () => {
+    expect(addressRoundInfo(v({ addressRound: 0 }), 2_000_000)).toBeNull();
+  });
+
+  it("below the cap is an in-progress round", () => {
+    expect(addressRoundInfo(v({ addressRound: 2 }), 2_000_000)).toEqual({
+      round: 2,
+      cap: 3,
+      status: "round",
+    });
+  });
+
+  it("at the cap but pending (within timeout) is the dimmed final round", () => {
+    const r = addressRoundInfo(
+      v({ addressRound: 3, finalRoundPending: true, updatedAt: 1_000_000 }),
+      1_000_000 + 60_000, // 1 min later, well under 15 min
+    );
+    expect(r).toEqual({ round: 3, cap: 3, status: "final" });
+  });
+
+  it("at the cap, held (not pending) is a confirmed stall", () => {
+    expect(
+      addressRoundInfo(v({ addressRound: 3, finalRoundPending: false }), 2_000_000),
+    ).toEqual({ round: 3, cap: 3, status: "stalled" });
+  });
+
+  it("a pending final round past its timeout escalates to stalled", () => {
+    const r = addressRoundInfo(
+      v({ addressRound: 3, finalRoundPending: true, updatedAt: 1_000_000 }),
+      1_000_000 + 900_000 + 1, // just past 15 min
+    );
+    expect(r).toEqual({ round: 3, cap: 3, status: "stalled" });
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd ui && bun run test critic-badge` (vitest name filter)
+Expected: FAIL — current `addressRoundInfo` returns `{ stalled }`, takes one arg, and has no `status`.
+
+- [ ] **Step 3: Rewrite `addressRoundInfo`**
+
+Replace the `addressRoundInfo` function in `ui/src/lib/components/critic-badge.ts` (lines 17-29) with:
+
+```ts
+export type AddressStatus = "round" | "final" | "stalled";
+
+/**
+ * Auto-address streak state for the badge, or null when no streak is in progress.
+ * The cap comes off the verdict (`addressCap`) — the server's live value — so the badge
+ * math never drifts from a hardcoded mirror.
+ *  - "round":   below the cap, agent addressing findings, more rounds left (blue).
+ *  - "final":   cap-th steer just delivered (`finalRoundPending`), agent addressing the
+ *               last allowed round (dimmed). Escalates to "stalled" after the verdict's
+ *               `finalRoundTimeoutMs` if no re-review lands (agent abandoned it).
+ *  - "stalled": cap reached and that final round already failed re-review, OR the pending
+ *               final round timed out → needs a human (orange).
+ * `now` is the current time (ms); pass a reactive clock so the timeout escalation is live.
+ */
+export function addressRoundInfo(
+  v: ReviewVerdict | undefined,
+  now: number,
+): { round: number; cap: number; status: AddressStatus } | null {
+  if (!v || v.addressRound <= 0 || v.findings.length === 0) return null;
+  const cap = v.addressCap;
+  const round = v.addressRound;
+  if (round < cap) return { round, cap, status: "round" };
+  // At/over the cap. A held round (not pending) is a confirmed stall.
+  if (!v.finalRoundPending) return { round, cap, status: "stalled" };
+  // Pending: `updatedAt` is the final-steer delivery time — putReview runs once per
+  // review cycle, and the next putReview is the re-review that clears finalRoundPending,
+  // so updatedAt stays frozen at delivery while pending. (If anything ever bumps updatedAt
+  // mid-cycle, switch to an explicit finalRoundDeliveredAt field.)
+  if (now - v.updatedAt > v.finalRoundTimeoutMs) return { round, cap, status: "stalled" };
+  return { round, cap, status: "final" };
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `cd ui && bun run test critic-badge` (vitest name filter)
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/lib/components/critic-badge.ts ui/src/lib/components/critic-badge.test.ts
+git commit -m "feat(critic): tri-state badge status (round/final/stalled)"
+```
+
+---
+
+### Task 6: i18n keys (EN + DE)
+
+**Files:**
+- Modify: `ui/messages/en.json`
+- Modify: `ui/messages/de.json`
+
+- [ ] **Step 1: Add the EN keys**
+
+In `ui/messages/en.json`, next to `criticbadge_stalled` (~line 320), add:
+
+```json
+  "criticbadge_final": "FINAL {round}/{cap}",
+  "criticbadge_final_title": "Addressing the last allowed round — no more rounds after this.",
+```
+
+- [ ] **Step 2: Add the DE keys**
+
+In `ui/messages/de.json`, at the matching location (~line 320), add:
+
+```json
+  "criticbadge_final": "FINALE {round}/{cap}",
+  "criticbadge_final_title": "Bearbeitet die letzte erlaubte Runde — danach folgt keine weitere.",
+```
+
+- [ ] **Step 3: Verify catalog parity**
+
+Run: `cd ui && bun run check:i18n`
+Expected: PASS (identical, non-empty key sets across en/de).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/messages/en.json ui/messages/de.json
+git commit -m "feat(i18n): critic FINAL badge strings (en+de)"
+```
+
+---
+
+### Task 7: Render the tri-state badge
+
+**Files:**
+- Modify: `ui/src/lib/components/CriticBadge.svelte`
+
+- [ ] **Step 1: Wire the clock into the derived status**
+
+In `ui/src/lib/components/CriticBadge.svelte` `<script>`, add the import and pass the clock:
+
+```ts
+  import { reviews } from "$lib/reviews.svelte";
+  import { criticBadgeLabel, addressRoundInfo } from "./critic-badge";
+  import { clock } from "$lib/now.svelte";
+  import { m } from "$lib/paraglide/messages";
+
+  let { sessionId }: { sessionId: string } = $props();
+  const reviewing = $derived(reviews.isReviewing(sessionId));
+  const verdict = $derived(reviews.map[sessionId]);
+  const label = $derived(criticBadgeLabel(verdict));
+  const round = $derived(addressRoundInfo(verdict, clock.current));
+```
+
+- [ ] **Step 2: Replace the round render block with three branches**
+
+Replace the `{#if round}` block (lines 23-37) with:
+
+```svelte
+{#if round}
+  {#if round.status === "stalled"}
+    <span
+      class="critic-badge critic-stalled"
+      title={m.criticbadge_stalled_title({ cap: round.cap })}
+      >{m.criticbadge_stalled({ round: round.round, cap: round.cap })}</span
+    >
+  {:else if round.status === "final"}
+    <span
+      class="critic-badge critic-final"
+      title={m.criticbadge_final_title()}
+      >{m.criticbadge_final({ round: round.round, cap: round.cap })}</span
+    >
+  {:else}
+    <span
+      class="critic-badge critic-round"
+      title={m.criticbadge_round_title({ round: round.round, cap: round.cap })}
+      >{m.criticbadge_round({ round: round.round, cap: round.cap })}</span
+    >
+  {/if}
+{/if}
+```
+
+- [ ] **Step 3: Add the dimmed `.critic-final` style**
+
+In the `<style>` block, after `.critic-round { ... }` (~line 61), add:
+
+```css
+  /* final allowed round in flight: agent is addressing it — recessive vs. both the
+     blue in-progress rounds and the orange confirmed stall. */
+  .critic-final {
+    border-color: var(--color-line);
+    color: var(--color-faint);
+  }
+```
+
+- [ ] **Step 4: Type-check + run UI tests**
+
+Run: `cd ui && bun run check && bun run test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/lib/components/CriticBadge.svelte
+git commit -m "feat(critic): render dimmed FINAL badge for in-flight last round"
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Root server checks**
+
+Run: `bun run lint && bunx tsc --noEmit && bun test ./test`
+Expected: PASS.
+
+- [ ] **Step 2: UI checks**
+
+Run: `cd ui && bun run check && bun run check:i18n && bun run test`
+Expected: PASS.
+
+- [ ] **Step 3: Confirm no other consumer of the old `addressRoundInfo` signature**
+
+Run: `grep -rn "addressRoundInfo" ui/src`
+Expected: only `critic-badge.ts` (definition + test) and `CriticBadge.svelte` (call with two args).
+
+---
+
+## Verification against the spec
+
+- §1 server flag + constant → Task 1. §2 types → Tasks 1 (server) + 3 (UI). §3 persistence → Task 2. §4 UI status fn → Task 5. §5 render + clock → Tasks 4 + 7. §6 i18n → Task 6. §7 tests → Tasks 1, 2, 5. Full-suite gate → Task 8.
+- Decisions honored: word `FINAL` (Task 6), 15-min timeout (`DEFAULT_FINAL_ROUND_TIMEOUT_MS`, Task 1), reuse `updatedAt` as delivery time (Task 5 comment), self-escalation after timeout (Task 5 logic + Task 4 clock).
+
+## Unresolved questions
+
+None.

--- a/docs/superpowers/specs/2026-06-03-critic-badge-final-round-state-design.md
+++ b/docs/superpowers/specs/2026-06-03-critic-badge-final-round-state-design.md
@@ -1,0 +1,182 @@
+# Tri-state critic badge: distinguish "final round in flight" from "stalled"
+
+**Date:** 2026-06-03
+**Status:** Approved design, pre-implementation
+
+## Problem
+
+When the auto-review (critic) address loop hits its round cap (default 3), the
+session's critic badge immediately flips to orange `STALLED 3/3`. But that flip
+happens **at the instant the 3rd (last allowed) steer is delivered** — i.e. right
+when the task agent *starts* addressing that final round. The feedback **is** fed
+back and processed; the loop simply won't spawn a 4th round. So the orange badge
+fires one review too early: it screams "needs a human" while the agent is still
+working the last allowed round.
+
+### Root cause
+
+The UI computes stalled (`ui/src/lib/components/critic-badge.ts:28`) as:
+
+```
+stalled = addressRound >= cap && findings.length > 0
+```
+
+This single expression conflates two genuinely distinct states:
+
+| State | How it arises (`runAutoAddress`, `src/review.ts:393-416`) | Today's badge |
+| --- | --- | --- |
+| **Final round in flight** — cap-th steer just delivered, agent addressing it, outcome unknown | round *advanced into* cap (e.g. `priorRound 2 → 3`, delivered) | orange (wrong) |
+| **Genuinely stalled** — final round already failed, loop holds with no steer | round *held at* cap (`priorRound 3 → 3`, `line 403`) | orange (right) |
+
+The server knows which case it is (advanced vs. held) but never tells the UI, so
+the UI can't draw them apart from a single verdict snapshot. The fix is a new
+verdict field, which also keeps us compliant with the project rule against the UI
+mirroring server-only state.
+
+## Design
+
+Tri-state escalation ladder for the badge:
+
+```
+ROUND 1/3   (blue)    rounds remaining, agent addressing findings
+ROUND 2/3   (blue)
+FINAL 3/3   (dimmed)   last allowed round delivered, agent addressing it
+STALLED 3/3 (orange)   confirmed stuck (final round failed, OR abandoned) — needs a human
+```
+
+Orange now means exactly "we exhausted the rounds AND the last one didn't clear
+it" (or the agent abandoned it). The agent is never shown as stalled while it's
+mid-processing a delivered round.
+
+### 1. Server — `src/review.ts`
+
+Add a constant near `DEFAULT_CAP`:
+
+```ts
+const DEFAULT_FINAL_ROUND_TIMEOUT_MS = 15 * 60_000; // abandoned final round → orange
+```
+
+In `finalize()`, after `verdict.addressRound = this.runAutoAddress(f, verdict)`,
+set the new flag:
+
+```ts
+verdict.finalRoundPending =
+  verdict.findings.length > 0 &&
+  verdict.addressRound >= this.cap &&
+  verdict.addressRound > f.priorRound; // advanced INTO cap = steer just delivered
+```
+
+Behavior across paths:
+
+- **Advanced into cap** (e.g. `2 → 3`, delivered): `pending = true` → dimmed FINAL.
+- **Held at cap** (`3 → 3`, no steer, `line 403`): `addressRound === priorRound`,
+  not `>`, so `pending = false` → orange (confirmed stall).
+- **Error verdict** (`line 333-334`, `addressRound = priorRound`): not advanced →
+  `pending = false`. Error streaks keep their own `errorRound` stall signal.
+- **Clean** (`findings.length === 0`): `addressRound = 0` → `pending = false`.
+- **Any cap**, incl. `cap = 1`: first findings → deliver → `0 → 1`, `1 >= 1`,
+  `1 > 0` → `pending = true`. One dimmed final round even at cap 1.
+- **Undelivered steer at cap-1** (dead pane): `runAutoAddress` returns `priorRound`
+  unchanged, so round never reaches cap → stays blue `ROUND`; the dead pane is
+  caught by the independent activity-stall poller.
+
+### 2. Types — `src/types.ts` + `ui/src/lib/types.ts`
+
+Add to `ReviewVerdict`:
+
+```ts
+finalRoundPending: boolean;   // cap-th steer delivered, no re-review yet → dimmed FINAL
+finalRoundTimeoutMs: number;  // live abandonment-timeout, surfaced so UI never hardcodes it
+```
+
+`finalRoundTimeoutMs` follows the `addressCap` precedent: the UI reads the live
+server value off the payload instead of mirroring a constant that could drift.
+
+### 3. Persistence — `src/store.ts`
+
+- New column: `finalRoundPending INTEGER NOT NULL DEFAULT 0` (0/1). Persisted so a
+  page reload restores the correct badge state. Read/write in `putReview` /
+  `getReview` alongside `addressRound`.
+- `finalRoundTimeoutMs` is **not** stored. It is a current-config constant, only
+  meaningful while pending, and always wants the live value — so it is injected at
+  the read/serialization boundary from the review engine's constant, avoiding a
+  migration for a constant.
+
+### 4. UI badge state — `ui/src/lib/components/critic-badge.ts`
+
+`addressRoundInfo` returns a discriminated status instead of a bare `stalled`
+boolean. `now` is the current time from a reactive clock (see §5):
+
+```ts
+type AddressStatus = "round" | "final" | "stalled";
+
+export function addressRoundInfo(
+  v: ReviewVerdict | undefined,
+  now: number,
+): { round: number; cap: number; status: AddressStatus } | null {
+  if (!v || v.addressRound <= 0 || v.findings.length === 0) return null;
+  const cap = v.addressCap;
+  const round = v.addressRound;
+  if (round < cap) return { round, cap, status: "round" };
+  // At/over cap:
+  if (!v.finalRoundPending) return { round, cap, status: "stalled" }; // failed re-review
+  // updatedAt == final-steer delivery time: putReview runs once per review cycle,
+  // and the next putReview is the re-review that clears `finalRoundPending`, so
+  // updatedAt is frozen at delivery while pending. If anything ever bumps updatedAt
+  // mid-cycle, promote to an explicit finalRoundDeliveredAt field.
+  if (now - v.updatedAt > v.finalRoundTimeoutMs) return { round, cap, status: "stalled" }; // abandoned
+  return { round, cap, status: "final" };
+}
+```
+
+### 5. Render — `ui/src/lib/components/CriticBadge.svelte`
+
+Three render branches keyed off `status`:
+
+- `round` → existing blue `.critic-round`, text `criticbadge_round`/current.
+- `final` → new `.critic-final`, dimmed muted token, normal weight, text
+  `criticbadge_final` ("FINAL {round}/{cap}"), tooltip `criticbadge_final_title`.
+- `stalled` → existing orange `.critic-stalled`, text `criticbadge_stalled`.
+
+`.critic-final` uses a muted color token (e.g. `var(--color-muted)` / subdued
+border) — visibly recessive vs. both blue and orange.
+
+**Reactive clock:** the timeout branch needs `now` to advance so an abandoned
+final round flips to orange without a server round-trip. Reuse an existing shared
+`now`/tick store if the app has one (used for relative timestamps); otherwise add
+a single shared store backed by a 30s `setInterval`. Do **not** create a
+per-badge interval.
+
+### 6. i18n — `ui/messages/en.json` + `ui/messages/de.json`
+
+Add (both catalogs, snake_case, component-prefixed):
+
+- `criticbadge_final` — EN `"FINAL {round}/{cap}"`, DE e.g. `"FINALE {round}/{cap}"`.
+- `criticbadge_final_title` — EN: "Addressing the last allowed round — no more
+  rounds after this." DE equivalent.
+
+Catalog parity gate (`cd ui && bun run check:i18n`) must pass.
+
+### 7. Tests
+
+- **`src/review` test:** `finalRoundPending` is `true` when a steer advances the
+  round into the cap; `false` on held-at-cap, error verdict, and clean verdict.
+  Cover `cap = 1`.
+- **`ui critic-badge.ts` unit:** all four outcomes of `addressRoundInfo` —
+  `round` (below cap), `final` (pending, within timeout), `stalled` via failed
+  re-review (`!pending`), `stalled` via abandonment (pending, `now - updatedAt >
+  timeout`). Include the timeout boundary.
+
+## Decisions
+
+- **Badge word:** `FINAL`.
+- **Abandonment timeout:** 15 min (`DEFAULT_FINAL_ROUND_TIMEOUT_MS`).
+- **Delivery timestamp:** reuse `verdict.updatedAt` (documented dependency); no new
+  field unless something bumps `updatedAt` mid-cycle.
+- **Escalation model:** dimmed FINAL self-escalates to orange after the timeout
+  (chosen over relying solely on the 8-min activity-stall poller), so the critic
+  badge itself always reaches "needs a human".
+
+## Open questions
+
+None outstanding.

--- a/src/review.ts
+++ b/src/review.ts
@@ -69,6 +69,11 @@ const VERDICT_FILE = ".shepherd-review.json";
 // reads it off the payload instead of mirroring this number (which would silently drift
 // if `deps.cap` ever varies per deployment).
 const DEFAULT_CAP = 3;
+// How long a delivered final round may run before the badge escalates from dimmed
+// FINAL to orange STALLED on its own (covers an agent that abandons the last round
+// without re-pushing). Surfaced per-verdict as `finalRoundTimeoutMs` so the UI reads
+// the live value instead of mirroring this number.
+const DEFAULT_FINAL_ROUND_TIMEOUT_MS = 15 * 60_000;
 
 interface InFlight {
   sessionId: string;
@@ -457,6 +462,16 @@ export class ReviewService {
       console.warn(`[review] postReview failed for ${f.sessionId}:`, err);
     }
     verdict.addressRound = this.runAutoAddress(f, verdict); // reached only when the PR is open
+    // The cap-th steer was just delivered when the round ADVANCES into the cap
+    // (priorRound < cap → addressRound === cap). The agent is now addressing that
+    // final round → dimmed FINAL badge, not orange. A round HELD at the cap
+    // (addressRound === priorRound) means that final round already failed re-review
+    // → confirmed stall. A moot/closed PR returns above before this, leaving the
+    // buildVerdict default false. Error verdicts hold the round, so they stay false too.
+    verdict.finalRoundPending =
+      verdict.findings.length > 0 &&
+      verdict.addressRound >= this.cap &&
+      verdict.addressRound > f.priorRound;
     if (verdict.decision === "changes_requested") {
       this.deps.store.addSignal({
         repoPath: f.repoPath,
@@ -530,6 +545,8 @@ export class ReviewService {
       addressRound: 0, // publishVerdict() overwrites with the streak round (finalize()'s error path holds priorRound)
       addressCap: this.cap, // surface the live cap so the UI badge need not mirror it
       errorRound: 0, // finalize() overwrites on an error verdict
+      finalRoundPending: false, // finalize() sets this on a real verdict
+      finalRoundTimeoutMs: DEFAULT_FINAL_ROUND_TIMEOUT_MS, // live escalation timeout
       seenNoteIds: f.seenNoteIds, // carry the per-round note dedup set forward
       updatedAt: this.now(),
     };

--- a/src/store.ts
+++ b/src/store.ts
@@ -536,9 +536,6 @@ export class SessionStore implements CapStore {
     })();
   }
 
-  // ── learnings ─────────────────────────────────────────────────────────────
-  /** Add columns laid after the original `learnings` table for existing DBs.
-   *  Idempotent: each column is only added when PRAGMA shows it absent. */
   // migrate reviews that predate the auto-address loop columns
   private migrateReviewColumns(): void {
     const cols = this.db.query(`PRAGMA table_info(reviews)`).all() as { name: string }[];
@@ -562,6 +559,9 @@ export class SessionStore implements CapStore {
     add("finalRoundTimeoutMs", `finalRoundTimeoutMs INTEGER NOT NULL DEFAULT 900000`);
   }
 
+  // ── learnings ─────────────────────────────────────────────────────────────
+  /** Add columns laid after the original `learnings` table for existing DBs.
+   *  Idempotent: each column is only added when PRAGMA shows it absent. */
   private migrateLearningsColumns(): void {
     const cols = this.db.query(`PRAGMA table_info(learnings)`).all() as { name: string }[];
     if (!cols.some((c) => c.name === "promotedPrUrl")) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -119,32 +119,10 @@ export class SessionStore implements CapStore {
       findings TEXT NOT NULL DEFAULT '[]', addressRound INTEGER NOT NULL DEFAULT 0,
       addressCap INTEGER NOT NULL DEFAULT 3, errorRound INTEGER NOT NULL DEFAULT 0,
       seenNoteIds TEXT NOT NULL DEFAULT '[]',
+      finalRoundPending INTEGER NOT NULL DEFAULT 0,
+      finalRoundTimeoutMs INTEGER NOT NULL DEFAULT 900000,
       url TEXT, updatedAt INTEGER NOT NULL)`);
-    // migrate reviews that predate the auto-address loop columns
-    const reviewCols = this.db.query(`PRAGMA table_info(reviews)`).all() as { name: string }[];
-    if (!reviewCols.some((c) => c.name === "findings")) {
-      this.db.run(`ALTER TABLE reviews ADD COLUMN findings TEXT NOT NULL DEFAULT '[]'`);
-    }
-    if (!reviewCols.some((c) => c.name === "addressRound")) {
-      this.db.run(`ALTER TABLE reviews ADD COLUMN addressRound INTEGER NOT NULL DEFAULT 0`);
-    }
-    // addressCap's DEFAULT 3 only backfills pre-#247 rows; every live row carries
-    // ReviewService's actual cap, so the literal here is a one-time migration value, not
-    // an ongoing mirror. errorRound/seenNoteIds back the error-escalation + note dedup.
-    if (!reviewCols.some((c) => c.name === "addressCap")) {
-      this.db.run(`ALTER TABLE reviews ADD COLUMN addressCap INTEGER NOT NULL DEFAULT 3`);
-    }
-    if (!reviewCols.some((c) => c.name === "errorRound")) {
-      this.db.run(`ALTER TABLE reviews ADD COLUMN errorRound INTEGER NOT NULL DEFAULT 0`);
-    }
-    if (!reviewCols.some((c) => c.name === "seenNoteIds")) {
-      this.db.run(`ALTER TABLE reviews ADD COLUMN seenNoteIds TEXT NOT NULL DEFAULT '[]'`);
-    }
-    // patchId backs rebase-skip: pre-existing rows backfill to '' (unknown), so the
-    // next head change reviews once and records the fingerprint going forward.
-    if (!reviewCols.some((c) => c.name === "patchId")) {
-      this.db.run(`ALTER TABLE reviews ADD COLUMN patchId TEXT NOT NULL DEFAULT ''`);
-    }
+    this.migrateReviewColumns();
     this.db.run(`CREATE TABLE IF NOT EXISTS signals (
       id TEXT PRIMARY KEY, repoPath TEXT NOT NULL, sessionId TEXT,
       kind TEXT NOT NULL, payload TEXT NOT NULL, ts INTEGER NOT NULL)`);
@@ -399,6 +377,8 @@ export class SessionStore implements CapStore {
       addressRound: r.addressRound ?? 0,
       addressCap: r.addressCap ?? 3,
       errorRound: r.errorRound ?? 0,
+      finalRoundPending: !!r.finalRoundPending,
+      finalRoundTimeoutMs: r.finalRoundTimeoutMs ?? 900_000,
       seenNoteIds: parseFindings(r.seenNoteIds), // same string[] JSON shape as findings
       url: r.url ?? undefined,
     } as ReviewVerdict;
@@ -408,7 +388,7 @@ export class SessionStore implements CapStore {
     const r = this.db
       .query(
         `SELECT sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-                addressCap, errorRound, seenNoteIds, url, updatedAt
+                addressCap, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt
               FROM reviews WHERE sessionId = ?`,
       )
       .get(sessionId) as any;
@@ -418,13 +398,14 @@ export class SessionStore implements CapStore {
   putReview(v: ReviewVerdict): void {
     this.db.run(
       `INSERT INTO reviews (sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-         addressCap, errorRound, seenNoteIds, url, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+         addressCap, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET headSha=excluded.headSha, patchId=excluded.patchId,
          decision=excluded.decision,
          summary=excluded.summary, body=excluded.body, findings=excluded.findings,
          addressRound=excluded.addressRound, addressCap=excluded.addressCap,
-         errorRound=excluded.errorRound, seenNoteIds=excluded.seenNoteIds,
+         errorRound=excluded.errorRound, finalRoundPending=excluded.finalRoundPending,
+         finalRoundTimeoutMs=excluded.finalRoundTimeoutMs, seenNoteIds=excluded.seenNoteIds,
          url=excluded.url, updatedAt=excluded.updatedAt`,
       [
         v.sessionId,
@@ -437,6 +418,8 @@ export class SessionStore implements CapStore {
         v.addressRound ?? 0,
         v.addressCap ?? 3,
         v.errorRound ?? 0,
+        v.finalRoundPending ? 1 : 0,
+        v.finalRoundTimeoutMs ?? 900_000,
         JSON.stringify(v.seenNoteIds ?? []),
         v.url ?? null,
         v.updatedAt,
@@ -463,7 +446,7 @@ export class SessionStore implements CapStore {
     const rows = this.db
       .query(
         `SELECT sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-                addressCap, errorRound, seenNoteIds, url, updatedAt FROM reviews`,
+                addressCap, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt FROM reviews`,
       )
       .all() as any[];
     const out: Record<string, ReviewVerdict> = {};
@@ -556,6 +539,29 @@ export class SessionStore implements CapStore {
   // ── learnings ─────────────────────────────────────────────────────────────
   /** Add columns laid after the original `learnings` table for existing DBs.
    *  Idempotent: each column is only added when PRAGMA shows it absent. */
+  // migrate reviews that predate the auto-address loop columns
+  private migrateReviewColumns(): void {
+    const cols = this.db.query(`PRAGMA table_info(reviews)`).all() as { name: string }[];
+    const add = (name: string, ddl: string) => {
+      if (!cols.some((c) => c.name === name)) this.db.run(`ALTER TABLE reviews ADD COLUMN ${ddl}`);
+    };
+    add("findings", `findings TEXT NOT NULL DEFAULT '[]'`);
+    add("addressRound", `addressRound INTEGER NOT NULL DEFAULT 0`);
+    // addressCap's DEFAULT 3 only backfills pre-#247 rows; every live row carries
+    // ReviewService's actual cap, so the literal here is a one-time migration value, not
+    // an ongoing mirror. errorRound/seenNoteIds back the error-escalation + note dedup.
+    add("addressCap", `addressCap INTEGER NOT NULL DEFAULT 3`);
+    add("errorRound", `errorRound INTEGER NOT NULL DEFAULT 0`);
+    add("seenNoteIds", `seenNoteIds TEXT NOT NULL DEFAULT '[]'`);
+    // patchId backs rebase-skip: pre-existing rows backfill to '' (unknown), so the
+    // next head change reviews once and records the fingerprint going forward.
+    add("patchId", `patchId TEXT NOT NULL DEFAULT ''`);
+    add("finalRoundPending", `finalRoundPending INTEGER NOT NULL DEFAULT 0`);
+    // 900000ms = 15min; one-time backfill for pre-existing rows, not an ongoing mirror —
+    // live rows carry ReviewService's DEFAULT_FINAL_ROUND_TIMEOUT_MS.
+    add("finalRoundTimeoutMs", `finalRoundTimeoutMs INTEGER NOT NULL DEFAULT 900000`);
+  }
+
   private migrateLearningsColumns(): void {
     const cols = this.db.query(`PRAGMA table_info(learnings)`).all() as { name: string }[];
     if (!cols.some((c) => c.name === "promotedPrUrl")) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,8 @@ export interface ReviewVerdict {
   addressRound: number; // auto-address steers spent on the current findings streak (0 = clean/reset)
   addressCap: number; // the streak cap this run used — surfaced so the UI badge math need not mirror it
   errorRound: number; // consecutive critic error/timeout verdicts (separate no-progress counter; 0 on any real verdict)
+  finalRoundPending: boolean; // cap-th steer just delivered, no re-review yet → dimmed FINAL badge
+  finalRoundTimeoutMs: number; // live abandonment timeout; surfaced so the UI never hardcodes it
   seenNoteIds: string[]; // ids of author notes already fed to the critic, so each is injected only once
   url?: string; // posted PR-review URL, when the host returns one
   updatedAt: number;

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -315,6 +315,8 @@ test("forget reaps an in-flight critic and drops the stored review", () => {
     addressRound: 0,
     addressCap: 3,
     errorRound: 0,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 15 * 60_000,
     seenNoteIds: [],
     updatedAt: 1,
   };
@@ -511,6 +513,8 @@ test("clean verdict (no findings) stops the loop and resets the round", async ()
     addressRound: 2,
     addressCap: 3,
     errorRound: 0,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 15 * 60_000,
     seenNoteIds: [],
     updatedAt: 1,
   };
@@ -550,6 +554,8 @@ test("round cap reached: holds the round, posts the review + signal, does not st
     addressRound: 3, // == cap: the agent has had its 3 tries
     addressCap: 3,
     errorRound: 0,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 15 * 60_000,
     seenNoteIds: [],
     updatedAt: 1,
   };
@@ -630,6 +636,58 @@ test("PR closed (not merged) before finalize: also fully inert", async () => {
   expect(rec.event).toBeUndefined(); // closed PR → review not posted
 });
 
+test("advancing into the cap marks the final round pending (not yet stalled)", async () => {
+  const { deps: d, reviews } = makeDeps(
+    {
+      readVerdict: () => ({
+        decision: "request-changes",
+        summary: "still broken",
+        body: "b",
+        findings: ["still broken"],
+      }),
+    },
+    { autoAddressEnabled: true },
+  );
+  reviews["s1"] = priorReview({ addressRound: 2 }); // one try left; cap is 3
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.addressRound).toBe(3);
+  expect(reviews["s1"]?.finalRoundPending).toBe(true);
+});
+
+test("holding at the cap is a confirmed stall, not pending", async () => {
+  const { deps: d, reviews } = makeDeps(
+    {
+      readVerdict: () => ({
+        decision: "request-changes",
+        summary: "still broken",
+        body: "b",
+        findings: ["still broken"],
+      }),
+    },
+    { autoAddressEnabled: true },
+  );
+  reviews["s1"] = priorReview({ addressRound: 3 });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.addressRound).toBe(3);
+  expect(reviews["s1"]?.finalRoundPending).toBe(false);
+});
+
+test("clean verdict is never final-round-pending", async () => {
+  const { deps: d, reviews } = makeDeps(
+    { readVerdict: () => ({ decision: "comment", summary: "lgtm", body: "b", findings: [] }) },
+    { autoAddressEnabled: true },
+  );
+  reviews["s1"] = priorReview({ addressRound: 2 });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.finalRoundPending).toBe(false);
+});
+
 test("dead agent pane: steer attempted but the round does not advance", async () => {
   const {
     deps: d,
@@ -660,6 +718,8 @@ function priorReview(over: Partial<ReviewVerdict> = {}): ReviewVerdict {
     addressRound: 1,
     addressCap: 3,
     errorRound: 0,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 15 * 60_000,
     seenNoteIds: [],
     updatedAt: 1,
     ...over,

--- a/test/server-reviews.test.ts
+++ b/test/server-reviews.test.ts
@@ -46,6 +46,8 @@ test("GET /api/reviews returns snapshot when reviewCache is present", async () =
     addressRound: 0,
     addressCap: 3,
     errorRound: 0,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 900_000,
     seenNoteIds: [],
     updatedAt: 1000,
   };

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -152,6 +152,7 @@ test("putReview round-trips finalRoundPending + finalRoundTimeoutMs", () => {
   store.putReview({
     sessionId: "s1",
     headSha: "abc",
+    patchId: "",
     decision: "changes_requested",
     summary: "",
     body: "",

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -81,6 +81,8 @@ test("reviews: upsert + read by session, snapshot all", () => {
     addressRound: 1,
     addressCap: 3,
     errorRound: 0,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 900_000,
     seenNoteIds: ["c1", "c2"],
     url: "u",
     updatedAt: 100,
@@ -116,6 +118,8 @@ test("reviews: findings/addressRound/addressCap/errorRound/seenNoteIds default w
   expect(r?.errorRound).toBe(0);
   expect(r?.seenNoteIds).toEqual([]);
   expect(r?.patchId).toBe(""); // pre-rebase-skip rows backfill to '' (unknown → always reviews)
+  expect(r?.finalRoundPending).toBe(false); // backfilled to the migration default
+  expect(r?.finalRoundTimeoutMs).toBe(900_000);
 });
 
 test("bumpReviewHead: re-points head + updatedAt, leaves the verdict otherwise intact", () => {
@@ -131,6 +135,8 @@ test("bumpReviewHead: re-points head + updatedAt, leaves the verdict otherwise i
     addressRound: 2,
     addressCap: 3,
     errorRound: 0,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 900_000,
     seenNoteIds: ["c1"],
     url: "u",
     updatedAt: 100,
@@ -139,6 +145,28 @@ test("bumpReviewHead: re-points head + updatedAt, leaves the verdict otherwise i
   store.bumpReviewHead("s1", "def", 200);
   // identical-content rebase: head + clock move, everything else (incl. patchId) holds
   expect(store.getReview("s1")).toEqual({ ...v, headSha: "def", updatedAt: 200 });
+});
+
+test("putReview round-trips finalRoundPending + finalRoundTimeoutMs", () => {
+  const store = new SessionStore(":memory:");
+  store.putReview({
+    sessionId: "s1",
+    headSha: "abc",
+    decision: "changes_requested",
+    summary: "",
+    body: "",
+    findings: ["x"],
+    addressRound: 3,
+    addressCap: 3,
+    errorRound: 0,
+    finalRoundPending: true,
+    finalRoundTimeoutMs: 900_000,
+    seenNoteIds: [],
+    updatedAt: 1,
+  });
+  const got = store.getReview("s1");
+  expect(got?.finalRoundPending).toBe(true);
+  expect(got?.finalRoundTimeoutMs).toBe(900_000);
 });
 
 test("readyToMerge: defaults false on create, round-trips through update", () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -328,6 +328,8 @@
   "criticbadge_round_title": "Kritiker-Befunde werden bearbeitet — Runde {round} von {cap}",
   "criticbadge_stalled": "STECKT {round}/{cap}",
   "criticbadge_stalled_title": "Auto-Bearbeitung hat nach {cap} Runden mit offenen Befunden aufgegeben — braucht einen Menschen.",
+  "criticbadge_final": "FINALE {round}/{cap}",
+  "criticbadge_final_title": "Bearbeitet die letzte erlaubte Runde — danach folgt keine weitere.",
   "viewport_decommission_title": "Agent stoppen + Worktree entfernen",
   "viewport_decommission_ready_title": "PR steht. Session schließen & Worktree aufräumen",
   "viewport_decommission_ready_aria": "PR bereit. Einheit stilllegen und Worktree aufräumen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -328,6 +328,8 @@
   "criticbadge_round_title": "Auto-addressing critic findings — round {round} of {cap}",
   "criticbadge_stalled": "STALLED {round}/{cap}",
   "criticbadge_stalled_title": "Auto-address gave up after {cap} rounds with findings still open — needs a human.",
+  "criticbadge_final": "FINAL {round}/{cap}",
+  "criticbadge_final_title": "Addressing the last allowed round — no more rounds after this.",
   "viewport_decommission_title": "stop agent + remove worktree",
   "viewport_decommission_ready_title": "PR is up. Close this session & clean up its worktree",
   "viewport_decommission_ready_aria": "PR ready. Decommission unit and clean up worktree",

--- a/ui/src/lib/components/CriticBadge.svelte
+++ b/ui/src/lib/components/CriticBadge.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { reviews } from "$lib/reviews.svelte";
   import { criticBadgeLabel, addressRoundInfo } from "./critic-badge";
+  import { clock } from "$lib/now.svelte";
   import { m } from "$lib/paraglide/messages";
 
   let { sessionId }: { sessionId: string } = $props();
   const reviewing = $derived(reviews.isReviewing(sessionId));
   const verdict = $derived(reviews.map[sessionId]);
   const label = $derived(criticBadgeLabel(verdict));
-  const round = $derived(addressRoundInfo(verdict));
+  const round = $derived(addressRoundInfo(verdict, clock.current));
 </script>
 
 {#if reviewing}
@@ -21,11 +22,15 @@
   >
 {/if}
 {#if round}
-  {#if round.stalled}
+  {#if round.status === "stalled"}
     <span
       class="critic-badge critic-stalled"
       title={m.criticbadge_stalled_title({ cap: round.cap })}
       >{m.criticbadge_stalled({ round: round.round, cap: round.cap })}</span
+    >
+  {:else if round.status === "final"}
+    <span class="critic-badge critic-final" title={m.criticbadge_final_title()}
+      >{m.criticbadge_final({ round: round.round, cap: round.cap })}</span
     >
   {:else}
     <span
@@ -58,6 +63,12 @@
   .critic-round {
     border-color: var(--color-blue);
     color: var(--color-blue);
+  }
+  /* final allowed round in flight: agent is addressing it — recessive vs. both the
+     blue in-progress rounds and the orange confirmed stall. */
+  .critic-final {
+    border-color: var(--color-line);
+    color: var(--color-faint);
   }
   /* auto-address gave up at the cap — needs a human */
   .critic-stalled {

--- a/ui/src/lib/components/critic-badge.test.ts
+++ b/ui/src/lib/components/critic-badge.test.ts
@@ -1,52 +1,62 @@
 import { describe, it, expect } from "vitest";
 import { criticBadgeLabel, addressRoundInfo } from "./critic-badge";
-import type { ReviewVerdict } from "../types";
+import type { ReviewVerdict } from "$lib/types";
 
-const v = (
-  decision: ReviewVerdict["decision"],
-  over: Partial<ReviewVerdict> = {},
-): ReviewVerdict => ({
-  sessionId: "s",
-  headSha: "h",
-  decision,
+const base: ReviewVerdict = {
+  sessionId: "s1",
+  headSha: "abc",
+  decision: "changes_requested",
   summary: "",
   body: "",
-  findings: [],
+  findings: ["x"],
   addressRound: 0,
   addressCap: 3,
   finalRoundPending: false,
   finalRoundTimeoutMs: 900_000,
-  updatedAt: 0,
-  ...over,
-});
+  updatedAt: 1_000_000,
+};
+const v = (p: Partial<ReviewVerdict>): ReviewVerdict => ({ ...base, ...p });
 
 describe("criticBadgeLabel", () => {
   it("returns null when there is no verdict", () => expect(criticBadgeLabel(undefined)).toBeNull());
   it("maps changes_requested", () =>
-    expect(criticBadgeLabel(v("changes_requested"))).not.toBeNull());
-  it("maps commented", () => expect(criticBadgeLabel(v("commented"))).not.toBeNull());
-  it("maps error", () => expect(criticBadgeLabel(v("error"))).not.toBeNull());
+    expect(criticBadgeLabel(v({ decision: "changes_requested" }))).not.toBeNull());
+  it("maps commented", () => expect(criticBadgeLabel(v({ decision: "commented" }))).not.toBeNull());
+  it("maps error", () => expect(criticBadgeLabel(v({ decision: "error" }))).not.toBeNull());
 });
 
 describe("addressRoundInfo", () => {
-  it("is null with no verdict", () => expect(addressRoundInfo(undefined)).toBeNull());
-  it("is null when no auto-address round is in progress", () =>
-    expect(addressRoundInfo(v("commented", { addressRound: 0 }))).toBeNull());
-  it("reports the round while addressing under the cap", () => {
-    const info = addressRoundInfo(v("changes_requested", { addressRound: 1, findings: ["x"] }));
-    expect(info).toEqual({ round: 1, cap: 3, stalled: false });
+  it("returns null when no streak is in progress", () => {
+    expect(addressRoundInfo(v({ addressRound: 0 }), 2_000_000)).toBeNull();
   });
-  it("flags stalled when the round hits the cap with findings still open", () => {
-    const info = addressRoundInfo(
-      v("changes_requested", { addressRound: 3, addressCap: 3, findings: ["still broken"] }),
-    );
-    expect(info?.stalled).toBe(true);
+  it("below the cap is an in-progress round", () => {
+    expect(addressRoundInfo(v({ addressRound: 2 }), 2_000_000)).toEqual({
+      round: 2,
+      cap: 3,
+      status: "round",
+    });
   });
-  it("reads the cap off the verdict, not a hardcoded mirror", () => {
-    // a deployment with a wider cap surfaces it on the verdict — badge math follows
-    const info = addressRoundInfo(
-      v("changes_requested", { addressRound: 4, addressCap: 5, findings: ["x"] }),
-    );
-    expect(info).toEqual({ round: 4, cap: 5, stalled: false });
+  it("at the cap but pending (within timeout) is the dimmed final round", () => {
+    expect(
+      addressRoundInfo(
+        v({ addressRound: 3, finalRoundPending: true, updatedAt: 1_000_000 }),
+        1_000_000 + 60_000,
+      ),
+    ).toEqual({ round: 3, cap: 3, status: "final" });
+  });
+  it("at the cap, held (not pending) is a confirmed stall", () => {
+    expect(addressRoundInfo(v({ addressRound: 3, finalRoundPending: false }), 2_000_000)).toEqual({
+      round: 3,
+      cap: 3,
+      status: "stalled",
+    });
+  });
+  it("a pending final round past its timeout escalates to stalled", () => {
+    expect(
+      addressRoundInfo(
+        v({ addressRound: 3, finalRoundPending: true, updatedAt: 1_000_000 }),
+        1_000_000 + 900_000 + 1,
+      ),
+    ).toEqual({ round: 3, cap: 3, status: "stalled" });
   });
 });

--- a/ui/src/lib/components/critic-badge.test.ts
+++ b/ui/src/lib/components/critic-badge.test.ts
@@ -59,4 +59,17 @@ describe("addressRoundInfo", () => {
       ),
     ).toEqual({ round: 3, cap: 3, status: "stalled" });
   });
+  it("a transient error verdict mid-streak keeps showing the in-progress round (no flicker)", () => {
+    // error verdict holds the round (addressRound > 0) but carries no findings
+    expect(addressRoundInfo(v({ addressRound: 2, findings: [] }), 2_000_000)).toEqual({
+      round: 2,
+      cap: 3,
+      status: "round",
+    });
+  });
+  it("a transient error verdict AT the cap is not mis-escalated to stalled", () => {
+    expect(
+      addressRoundInfo(v({ addressRound: 3, findings: [], finalRoundPending: false }), 2_000_000),
+    ).toEqual({ round: 3, cap: 3, status: "round" });
+  });
 });

--- a/ui/src/lib/components/critic-badge.test.ts
+++ b/ui/src/lib/components/critic-badge.test.ts
@@ -14,6 +14,8 @@ const v = (
   findings: [],
   addressRound: 0,
   addressCap: 3,
+  finalRoundPending: false,
+  finalRoundTimeoutMs: 900_000,
   updatedAt: 0,
   ...over,
 });

--- a/ui/src/lib/components/critic-badge.ts
+++ b/ui/src/lib/components/critic-badge.ts
@@ -20,7 +20,8 @@ export type AddressStatus = "round" | "final" | "stalled";
  * Auto-address streak state for the badge, or null when no streak is in progress.
  * The cap comes off the verdict (`addressCap`) — the server's live value — so the badge
  * math never drifts from a hardcoded mirror.
- *  - "round":   below the cap, agent addressing findings, more rounds left (blue).
+ *  - "round":   below the cap, agent addressing findings, more rounds left (blue). Also
+ *               covers a transient error verdict that holds the streak with no findings.
  *  - "final":   cap-th steer just delivered (`finalRoundPending`), agent addressing the
  *               last allowed round (dimmed). Escalates to "stalled" after the verdict's
  *               `finalRoundTimeoutMs` if no re-review lands (agent abandoned it).
@@ -32,16 +33,25 @@ export function addressRoundInfo(
   v: ReviewVerdict | undefined,
   now: number,
 ): { round: number; cap: number; status: AddressStatus } | null {
-  if (!v || v.addressRound <= 0 || v.findings.length === 0) return null;
+  if (!v || v.addressRound <= 0) return null;
   const cap = v.addressCap;
   const round = v.addressRound;
-  if (round < cap) return { round, cap, status: "round" };
-  // At/over the cap. A held round (not pending) is a confirmed stall.
+  // No findings while the streak is held = a transient error verdict (critic produced
+  // nothing this pass; the round is preserved). Show the in-progress counter rather than
+  // flicker it out or mis-escalate — final/stalled require a real verdict with outstanding
+  // findings, which the next re-review restores.
+  if (round < cap || v.findings.length === 0) return { round, cap, status: "round" };
+  // At/over the cap with findings still open. A held round (not pending) is a confirmed stall.
   if (!v.finalRoundPending) return { round, cap, status: "stalled" };
   // Pending: `updatedAt` is the final-steer delivery time — putReview runs once per
   // review cycle, and the next putReview is the re-review that clears finalRoundPending,
   // so updatedAt stays frozen at delivery while pending. (If anything ever bumps updatedAt
   // mid-cycle, switch to an explicit finalRoundDeliveredAt field.)
+  //
+  // Clock-skew note: this compares the browser clock (`now`) against the server-stamped
+  // `updatedAt`. The 15-min `finalRoundTimeoutMs` dwarfs realistic client/server skew, and
+  // a mistimed flip only changes cosmetic badge colour (dimmed FINAL ↔ orange STALLED) for
+  // a few seconds — it drives no server behaviour — so server-relative time isn't worth it.
   if (now - v.updatedAt > v.finalRoundTimeoutMs) return { round, cap, status: "stalled" };
   return { round, cap, status: "final" };
 }

--- a/ui/src/lib/components/critic-badge.ts
+++ b/ui/src/lib/components/critic-badge.ts
@@ -14,16 +14,34 @@ export function criticBadgeLabel(v: ReviewVerdict | undefined): string | null {
   }
 }
 
+export type AddressStatus = "round" | "final" | "stalled";
+
 /**
  * Auto-address streak state for the badge, or null when no streak is in progress.
  * The cap comes off the verdict (`addressCap`) — the server's live value — so the badge
  * math never drifts from a hardcoded mirror.
- * `stalled` = the loop hit its cap with findings still open → it gave up, needs a human.
+ *  - "round":   below the cap, agent addressing findings, more rounds left (blue).
+ *  - "final":   cap-th steer just delivered (`finalRoundPending`), agent addressing the
+ *               last allowed round (dimmed). Escalates to "stalled" after the verdict's
+ *               `finalRoundTimeoutMs` if no re-review lands (agent abandoned it).
+ *  - "stalled": cap reached and that final round already failed re-review, OR the pending
+ *               final round timed out → needs a human (orange).
+ * `now` is the current time (ms); pass a reactive clock so the timeout escalation is live.
  */
 export function addressRoundInfo(
   v: ReviewVerdict | undefined,
-): { round: number; cap: number; stalled: boolean } | null {
-  if (!v || v.addressRound <= 0) return null;
+  now: number,
+): { round: number; cap: number; status: AddressStatus } | null {
+  if (!v || v.addressRound <= 0 || v.findings.length === 0) return null;
   const cap = v.addressCap;
-  return { round: v.addressRound, cap, stalled: v.addressRound >= cap && v.findings.length > 0 };
+  const round = v.addressRound;
+  if (round < cap) return { round, cap, status: "round" };
+  // At/over the cap. A held round (not pending) is a confirmed stall.
+  if (!v.finalRoundPending) return { round, cap, status: "stalled" };
+  // Pending: `updatedAt` is the final-steer delivery time — putReview runs once per
+  // review cycle, and the next putReview is the re-review that clears finalRoundPending,
+  // so updatedAt stays frozen at delivery while pending. (If anything ever bumps updatedAt
+  // mid-cycle, switch to an explicit finalRoundDeliveredAt field.)
+  if (now - v.updatedAt > v.finalRoundTimeoutMs) return { round, cap, status: "stalled" };
+  return { round, cap, status: "final" };
 }

--- a/ui/src/lib/now.svelte.ts
+++ b/ui/src/lib/now.svelte.ts
@@ -1,0 +1,11 @@
+// Shared coarse wall-clock: a single 30s tick drives time-based UI (e.g. the critic
+// badge escalating an abandoned final round from dimmed FINAL to orange STALLED)
+// without each component spinning up its own interval. Read `clock.current` inside a
+// $derived to make that computation re-run on each tick.
+class Clock {
+  current = $state(Date.now());
+  constructor() {
+    setInterval(() => (this.current = Date.now()), 30_000);
+  }
+}
+export const clock = new Clock();

--- a/ui/src/lib/reviews.svelte.test.ts
+++ b/ui/src/lib/reviews.svelte.test.ts
@@ -20,6 +20,8 @@ const verdict = (id: string): ReviewVerdict => ({
   findings: [],
   addressRound: 0,
   addressCap: 3,
+  finalRoundPending: false,
+  finalRoundTimeoutMs: 900_000,
   updatedAt: 0,
 });
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -141,6 +141,8 @@ export interface ReviewVerdict {
   findings: string[]; // discrete actionable items; [] = nothing to address
   addressRound: number; // auto-address steers spent on the current findings streak
   addressCap: number; // server's streak cap for this run — the badge reads it instead of mirroring
+  finalRoundPending: boolean; // cap-th steer just delivered, no re-review yet → dimmed FINAL badge
+  finalRoundTimeoutMs: number; // live abandonment timeout (ms); UI escalates FINAL→STALLED after this
   url?: string;
   updatedAt: number;
 }


### PR DESCRIPTION
## Problem

When the critic auto-review loop hits its round cap (default 3), the session badge flips to orange `STALLED 3/3` **the instant the final allowed steer is delivered** — i.e. while the agent is still addressing that last round. The feedback *is* fed back and processed; the loop just won't spawn a 4th round. So the orange "needs a human" signal fired one review too early.

Root cause: the UI computed `stalled = addressRound >= cap && findings.length > 0`, which conflates two distinct states — "final round just delivered, agent working it" vs. "final round already failed, no moves left." The server knew which (round *advanced into* cap vs. *held at* cap) but never told the UI.

## Change

The badge is now tri-state:

| Round | Before | Now |
|---|---|---|
| 1/3, 2/3 | `ROUND` (blue) | `ROUND` (blue) |
| 3rd steer **just delivered**, agent working it | `STALLED` ⚠️ | **`FINAL 3/3` (dimmed)** |
| 3rd round **failed** re-review, loop gives up | `STALLED` (orange) | `STALLED` (orange) |
| 3rd round **abandoned** (no re-push for 15 min) | stuck dimmed forever | `STALLED` (orange) |

**Server:** `finalize()`/`publishVerdict()` tag each verdict `finalRoundPending = findings>0 && addressRound>=cap && addressRound>priorRound` (advanced-into-cap = steer just delivered; held-at-cap = real stall). New `DEFAULT_FINAL_ROUND_TIMEOUT_MS = 15min`, surfaced per-verdict as `finalRoundTimeoutMs` so the UI reads the live value rather than mirroring a constant. Both fields persisted (idempotent migrations, extracted into `migrateReviewColumns()`).

**UI:** `addressRoundInfo` now returns `status: "round" | "final" | "stalled"`; abandonment escalation is driven by a shared 30s `clock` store (`now.svelte.ts`). Dimmed `.critic-final` style + `criticbadge_final`/`_title` keys in EN + DE.

## Tests

- Server: `finalRoundPending` true on advance-into-cap, false on held-at-cap / error / clean; store round-trips both fields.
- UI: all four `addressRoundInfo` branches incl. the timeout boundary.
- Full suites green: root 796 pass, UI 270 pass, tsc + lint + i18n parity + branch hygiene + fallow all clean.

Design + plan: `docs/superpowers/specs/2026-06-03-critic-badge-final-round-state-design.md`, `docs/superpowers/plans/2026-06-03-critic-badge-final-round-state.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
