### PR TITLE
fix(tab-reaper): reap orphaned distiller tabs

### DIFF
--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -8,6 +8,14 @@ import type { Signal } from "./types";
 
 const PROPOSALS_FILE = ".shepherd-learnings.json";
 
+/**
+ * Reserved herdr label for the ephemeral distiller agent. The underscores are load-bearing:
+ * prompt-derived session slugs are `[a-z0-9-]` only (see namer.ts), so no real session can
+ * collide. The orphan-tab reaper keys off this exact label — a bare "distill" would NOT be
+ * safe, since a user prompt slugs to exactly that and would get reaped (cf. {@link PROBE_NAME}).
+ */
+export const DISTILL_LABEL = "__distill__";
+
 interface RawRule {
   rule?: unknown;
   rationale?: unknown;
@@ -136,7 +144,7 @@ export class DistillerService {
     argv.push(distillPrompt());
     let terminalId: string;
     try {
-      terminalId = this.deps.herdr.start("distill", dir, argv).terminalId;
+      terminalId = this.deps.herdr.start(DISTILL_LABEL, dir, argv).terminalId;
     } catch (err) {
       console.warn(`[distill] spawn failed for ${repoPath}:`, err);
       this.deps.scratch.remove(dir);

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -1,5 +1,6 @@
 import type { HerdrDriver } from "./herdr";
 import { PROBE_NAME } from "./usage-probe";
+import { DISTILL_LABEL } from "./distiller";
 
 export type ReapableHerdr = Pick<HerdrDriver, "list" | "tabs" | "closeTab">;
 
@@ -8,12 +9,17 @@ export type ReapableHerdr = Pick<HerdrDriver, "list" | "tabs" | "closeTab">;
  *  being closed — e.g. a shepherd restart cleared the in-memory tracking).
  *
  *  All markers are collision-proof against user sessions, whose labels are prompt-derived
- *  `[a-z0-9-]` slugs: {@link PROBE_NAME} contains underscores, and the "review " / "name "
- *  prefixes contain a space — none is producible by a slug. (Reaping by a bare slug like
- *  "usage-probe" would be unsafe — a user prompt can slug to exactly that.) The "name "
- *  prefix is the background LLM namer's transient tab (`name TASK-NN`). */
+ *  `[a-z0-9-]` slugs: {@link PROBE_NAME} and {@link DISTILL_LABEL} contain underscores, and the
+ *  "review " / "name " prefixes contain a space — none is producible by a slug. (Reaping by a
+ *  bare slug like "usage-probe" or "distill" would be unsafe — a user prompt can slug to exactly
+ *  that.) The "name " prefix is the background LLM namer's transient tab (`name TASK-NN`). */
 function isShepherdHelperLabel(label: string): boolean {
-  return label === PROBE_NAME || label.startsWith("review ") || label.startsWith("name ");
+  return (
+    label === PROBE_NAME ||
+    label === DISTILL_LABEL ||
+    label.startsWith("review ") ||
+    label.startsWith("name ")
+  );
 }
 
 /** herdr tab ids are "workspace:N" with N a positional index. */
@@ -23,8 +29,8 @@ function tabNumber(tabId: string): number {
 }
 
 /**
- * Reconciliation sweep: close any usage-probe / review helper tab that no live agent
- * backs. The teardown paths (herdr.stop / start rollback) stop most leaks at the source;
+ * Reconciliation sweep: close any usage-probe / review / namer / distill helper tab that no
+ * live agent backs. The teardown paths (herdr.stop / start rollback) stop most leaks at the source;
  * this is the durable safety net for husks they can't reach — agents that crashed out of
  * `agent list`, or anything orphaned across a shepherd restart (which clears in-memory
  * review tracking). Returns the ids it closed.

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
 import { reapOrphanTabs, type ReapableHerdr } from "../src/tab-reaper";
 import { PROBE_NAME } from "../src/usage-probe";
+import { DISTILL_LABEL } from "../src/distiller";
 import type { HerdrAgent } from "../src/herdr";
 import type { HerdrTab } from "../src/herdr";
 
@@ -32,19 +33,20 @@ function fake(agents: HerdrAgent[], tabs: HerdrTab[]): { h: ReapableHerdr; close
   };
 }
 
-test("reaps probe + review + namer tabs that have no live agent", () => {
+test("reaps probe + review + namer + distill tabs that have no live agent", () => {
   const { h, closed } = fake(
-    [agent("term_live", "w:4")], // the one live agent
+    [agent("term_live", "w:5")], // the one live agent
     [
       tab("w:1", PROBE_NAME),
       tab("w:2", "review TASK-09"),
       tab("w:3", "name TASK-09"), // orphaned background-namer tab
-      tab("w:4", "addition-leaky"), // live session tab — backed by an agent
+      tab("w:4", DISTILL_LABEL), // orphaned distiller tab
+      tab("w:5", "addition-leaky"), // live session tab — backed by an agent
     ],
   );
   const got = reapOrphanTabs(h);
-  expect(new Set(got)).toEqual(new Set(["w:1", "w:2", "w:3"]));
-  expect(new Set(closed)).toEqual(new Set(["w:1", "w:2", "w:3"]));
+  expect(new Set(got)).toEqual(new Set(["w:1", "w:2", "w:3", "w:4"]));
+  expect(new Set(closed)).toEqual(new Set(["w:1", "w:2", "w:3", "w:4"]));
 });
 
 test("never reaps a labeled tab that still has a live agent (in-progress probe/review)", () => {
@@ -56,10 +58,15 @@ test("never reaps a labeled tab that still has a live agent (in-progress probe/r
   expect(closed).toEqual([]);
 });
 
-test("never touches non-shepherd tabs — incl. a user session slugged 'usage-probe'", () => {
-  // "usage-probe" is a producible prompt slug (normalize("usage probe") === "usage-probe"); an
-  // agentless tab with that label is a real user session, NOT a probe — must never be reaped.
-  const { h, closed } = fake([], [tab("w:1", "my editor"), tab("w:2", "usage-probe")]);
+test("never touches non-shepherd tabs — incl. user sessions slugged 'usage-probe' / 'distill'", () => {
+  // "usage-probe" and "distill" are producible prompt slugs (normalize("usage probe") ===
+  // "usage-probe"; slugifyManual("distill") === "distill"); an agentless tab with such a bare
+  // slug is a real user session, NOT a helper — must never be reaped. The helpers use the
+  // collision-proof __usage_probe__ / __distill__ markers instead.
+  const { h, closed } = fake(
+    [],
+    [tab("w:1", "my editor"), tab("w:2", "usage-probe"), tab("w:3", "distill")],
+  );
   reapOrphanTabs(h);
   expect(closed).toEqual([]);
 });


### PR DESCRIPTION
## Problem

The orphan-tab reaper (`src/tab-reaper.ts`) closes shepherd's short-lived helper tabs (usage probe, critic review, background namer) that no live agent backs — the durable safety net for husks that leak across a shepherd restart. The **distiller**'s helper tab was never in that set, so orphaned `distill` tabs accumulate.

## Fix

Add the distiller's tab to the reaper. But the label was the bare slug `"distill"`, and a one-word user prompt slugs to exactly that (`slugifyManual("distill") === "distill"`) — so a naive `label === "distill"` check would reintroduce the exact false-positive the reaper's docs + the existing `usage-probe` guard test forbid (wrongly closing a user session husk).

So the label is made **collision-proof first**, mirroring `PROBE_NAME`:
- `distiller.ts`: new exported `DISTILL_LABEL = "__distill__"` (underscores can't appear in a prompt slug); the herdr tab uses it instead of `"distill"`.
- `tab-reaper.ts`: `isShepherdHelperLabel` now also matches `DISTILL_LABEL`; docstrings updated.

## Tests

- Extended the reap test to include an orphaned `__distill__` tab.
- Extended the collision-safety guard test: a user session tab slugged `"distill"` (and `"usage-probe"`) is never reaped.
- Full root suite green (792 pass), lint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)