### PR TITLE
fix(steerbar): align first steer chip under Tab key on mobile

### DIFF
--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -160,12 +160,18 @@
      horizontal padding) so the collapsed chip and Esc render an identical width.
      Esc additionally sits inside a 3px-padded group "well", nudging its box that
      far right of the bar edge — match it with an equal left margin so the two
-     left edges line up, not just the widths */
+     left edges line up, not just the widths.
+     The steer row also mirrors the ControlBar's *grouping*: 📡 plays Esc's part
+     (own box, frozen left) and the steer chips play the Tab/nav groups. To line
+     the first steer chip up under the Tab key, the 📡→first-chip channel must
+     equal the Esc→Tab channel (3px Esc-well + 6px ctrl-row gap + 3px Tab-well =
+     12px). The flex `gap` already gives 4px, so add the remaining 8px here. */
   @media (max-width: 768px) {
     .chip.bc {
       min-width: 44px;
       padding: 0;
       margin-left: 3px;
+      margin-right: 8px;
     }
     .bc-label {
       display: none;


### PR DESCRIPTION
## What

On a portrait phone the steer row is meant to mirror the control row directly below it: the collapsed **📡 broadcast** chip plays **Esc**'s part (own box, frozen left), and the steer chips play the **Tab**/nav groups.

The left edges of 📡 and Esc already line up. But the **gap after** the first box didn't:

| Channel | Make-up | First-chip left edge |
| --- | --- | --- |
| `Esc → Tab` | 3px Esc-well + 6px ctrl-row gap + 3px Tab-well = **12px** | x=69 |
| `📡 → commit & PR` (before) | 4px flex gap only | x=61 |

So the first steer button sat **8px left** of the `Tab` key it should align under (visible in the reference screenshot).

## Fix

Add `margin-right: 8px` to the collapsed `.chip.bc` (mobile only). Combined with the existing 4px flex `gap`, the broadcast→first-chip channel becomes 12px — lining the first steer chip up exactly under `Tab`. Pure CSS, mirrors the established `margin-left: 3px` left-edge alignment.

## Verify

- `cd ui && bun run check` → 0 errors
- prettier clean
- Geometry: 📡 right edge x=57 + 8px margin + 4px gap = first chip left x=69 = Tab left edge ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)