### PR TITLE
chore: point repo paths at ~/Work/shepherd (renamed from ~/Work/tank)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -54,7 +54,7 @@ monitoring + light steering on the go.
 
 ## 5. Architecture
 
-Greenfield app in `~/Work/tank/`. Thin orchestrator over existing infra.
+Greenfield app in `~/Work/shepherd/`. Thin orchestrator over existing infra.
 
 ```
 ┌─ Shepherd Web/PWA (SvelteKit5 + Bun + Tailwind4) ─┐      browser + mobile

--- a/deploy/shepherd.service
+++ b/deploy/shepherd.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=%h/Work/tank
+WorkingDirectory=%h/Work/shepherd
 ExecStart=%h/.bun/bin/bun run src/index.ts
 Restart=on-failure
 RestartSec=2

--- a/docs/superpowers/plans/2026-05-30-shepherd-v5-responsive.md
+++ b/docs/superpowers/plans/2026-05-30-shepherd-v5-responsive.md
@@ -680,8 +680,8 @@ git commit -m "feat(ui): touch scroll + tap sizing in todo/issues panels"
 
 - [ ] **Step 1: Full check + build**
 
-Run: `cd ~/Work/tank && bun run test && bun run lint && bunx tsc --noEmit`
-Run: `cd ~/Work/tank/ui && bun run check && bun run test && bun run build`
+Run: `cd ~/Work/shepherd && bun run test && bun run lint && bunx tsc --noEmit`
+Run: `cd ~/Work/shepherd/ui && bun run check && bun run test && bun run build`
 Expected: all PASS.
 
 - [ ] **Step 2: Boot an instance with a real (bash-backed) session**

--- a/docs/superpowers/plans/2026-05-30-tank-v1-core.md
+++ b/docs/superpowers/plans/2026-05-30-tank-v1-core.md
@@ -60,7 +60,7 @@ tank/
 - [ ] **Step 1: Init spike workspace + node-pty**
 
 ```bash
-cd ~/Work/tank
+cd ~/Work/shepherd
 mkdir -p spike && cd spike
 bun init -y
 bun add node-pty
@@ -168,7 +168,7 @@ Open http://localhost:7331. Expected: you see the `bash` prompt; typing `echo hi
 ```bash
 herdr agent list   # find the spike-probe terminal_id
 # stop it via its session, then:
-rm -rf ~/Work/tank/spike
+rm -rf ~/Work/shepherd/spike
 git add -A && git commit -m "chore: p0 spike validated pty bridge (removed)"
 ```
 
@@ -183,7 +183,7 @@ git add -A && git commit -m "chore: p0 spike validated pty bridge (removed)"
 - [ ] **Step 1: Initialize and add deps**
 
 ```bash
-cd ~/Work/tank
+cd ~/Work/shepherd
 bun init -y
 bun add node-pty
 bun add -d typescript @types/node eslint @eslint/js typescript-eslint prettier husky lint-staged

--- a/docs/superpowers/plans/2026-05-30-tank-v2-hud-ui.md
+++ b/docs/superpowers/plans/2026-05-30-tank-v2-hud-ui.md
@@ -61,7 +61,7 @@ tank/
 - [ ] **Step 1: Scaffold**
 
 ```bash
-cd ~/Work/tank
+cd ~/Work/shepherd
 bunx sv create ui --template minimal --types ts --no-add-ons --no-install
 cd ui && bun install
 bun add -d @tailwindcss/vite @sveltejs/adapter-static
@@ -128,7 +128,7 @@ Verify: `cd ui && bun run dev` boots without error (Ctrl-C after confirming). Ru
 - [ ] **Step 6: Commit**
 
 ```bash
-cd ~/Work/tank
+cd ~/Work/shepherd
 echo "ui/build/" >> .gitignore
 git add -A && git commit -m "chore(ui): scaffold sveltekit5 spa (tailwind4, xterm, adapter-static)"
 ```
@@ -647,8 +647,8 @@ git add src/server.ts test/server.test.ts && git commit -m "feat: backend serves
 - [ ] **Step 1: Build UI + boot backend on a temp DB/port**
 
 ```bash
-cd ~/Work/tank/ui && bun run build
-cd ~/Work/tank && SHEPHERD_DB=/tmp/tank-e2e.db SHEPHERD_PORT=7346 SHEPHERD_REPO_ROOT=/tmp bun run src/index.ts &
+cd ~/Work/shepherd/ui && bun run build
+cd ~/Work/shepherd && SHEPHERD_DB=/tmp/tank-e2e.db SHEPHERD_PORT=7346 SHEPHERD_REPO_ROOT=/tmp bun run src/index.ts &
 sleep 1.5
 ```
 

--- a/docs/superpowers/plans/2026-06-03-periodic-branch-pruning.md
+++ b/docs/superpowers/plans/2026-06-03-periodic-branch-pruning.md
@@ -169,7 +169,7 @@ test("keeps the branch when the forge errors or is absent", async () => {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cd /home/patrick/Work/tank && bun test ./test/branch-pruner.test.ts`
+Run: `cd /home/patrick/Work/shepherd && bun test ./test/branch-pruner.test.ts`
 Expected: FAIL — `Cannot find module "../src/branch-pruner"`.
 
 - [ ] **Step 3: Implement `BranchPruner`**
@@ -315,18 +315,18 @@ export class BranchPruner {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cd /home/patrick/Work/tank && bun test ./test/branch-pruner.test.ts`
+Run: `cd /home/patrick/Work/shepherd && bun test ./test/branch-pruner.test.ts`
 Expected: PASS — all 5 tests green.
 
 - [ ] **Step 5: Lint + typecheck**
 
-Run: `cd /home/patrick/Work/tank && bun run lint && bunx tsc --noEmit`
+Run: `cd /home/patrick/Work/shepherd && bun run lint && bunx tsc --noEmit`
 Expected: no errors.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-cd /home/patrick/Work/tank
+cd /home/patrick/Work/shepherd
 git add src/branch-pruner.ts test/branch-pruner.test.ts
 git commit -m "feat(prune): BranchPruner deletes merged shepherd/* orphan branches"
 ```
@@ -363,18 +363,18 @@ branchPruner.start();
 
 - [ ] **Step 3: Typecheck + lint**
 
-Run: `cd /home/patrick/Work/tank && bunx tsc --noEmit && bun run lint`
+Run: `cd /home/patrick/Work/shepherd && bunx tsc --noEmit && bun run lint`
 Expected: no errors.
 
 - [ ] **Step 4: Full server test suite (no regressions)**
 
-Run: `cd /home/patrick/Work/tank && bun test ./test`
+Run: `cd /home/patrick/Work/shepherd && bun test ./test`
 Expected: PASS (existing suite + the new branch-pruner tests).
 
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /home/patrick/Work/tank
+cd /home/patrick/Work/shepherd
 git add src/index.ts
 git commit -m "feat(prune): run BranchPruner hourly on server boot"
 ```
@@ -390,7 +390,7 @@ git commit -m "feat(prune): run BranchPruner hourly on server boot"
 In a scratch git repo, simulate the squash-merge residue and confirm the sweep removes it while sparing live work:
 
 ```bash
-cd /home/patrick/Work/tank
+cd /home/patrick/Work/shepherd
 bun test ./test/branch-pruner.test.ts   # automated proof of all branch cases
 ```
 

--- a/docs/superpowers/specs/2026-05-30-tank-design.md
+++ b/docs/superpowers/specs/2026-05-30-tank-design.md
@@ -41,7 +41,7 @@ terminal use on a subscription but restricts programmatic use (Agent SDK / `clau
 
 ## 2. Architecture
 
-Single self-contained app in `~/Work/tank/`: one **Bun/TS server process** that serves a
+Single self-contained app in `~/Work/shepherd/`: one **Bun/TS server process** that serves a
 **SvelteKit 5** UI, a REST API, and two WebSocket channels.
 
 ```


### PR DESCRIPTION
Local repo dir was renamed `~/Work/tank` → `~/Work/shepherd` (live systemd unit, `~/.shepherd/shepherd.db`, and git worktrees already migrated out-of-band). This updates the **committed** path references so the repo matches:

- **`deploy/shepherd.service`** — `WorkingDirectory=%h/Work/shepherd` (this template regenerates the installed unit)
- **`PRD.md`** + **`docs/superpowers/` plans/specs** — `cd`/run snippets

`test/validate.test.ts` is intentionally left: its `~/Work/tank` is a generic `expandHome` fixture, not a project-location reference.

Docs-only + service template; pre-commit prettier reformatted the touched markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)