### PR TITLE
feat(emoji): expand repo icon set + ranked search + keyboard nav

### DIFF
--- a/ui/src/lib/components/EmojiPicker.svelte
+++ b/ui/src/lib/components/EmojiPicker.svelte
@@ -13,9 +13,13 @@
     onclose: () => void;
   } = $props();
 
+  const COLS = 7;
+
   let query = $state("");
   let custom = $state("");
+  let active = $state(0);
   let searchInput = $state<HTMLInputElement | null>(null);
+  let cells: HTMLButtonElement[] = [];
 
   const shown = $derived(searchEmoji(query));
   const customOk = $derived(isSingleEmoji(custom));
@@ -23,6 +27,49 @@
   $effect(() => {
     searchInput?.focus();
   });
+
+  // Keep the keyboard cursor visible as it moves through the grid.
+  $effect(() => {
+    cells[active]?.scrollIntoView({ block: "nearest" });
+  });
+
+  function move(delta: number) {
+    if (shown.length === 0) return;
+    active = Math.min(Math.max(active + delta, 0), shown.length - 1);
+  }
+
+  function onSearchKey(e: KeyboardEvent) {
+    const caret = searchInput?.selectionStart ?? 0;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        move(COLS);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        move(-COLS);
+        break;
+      // ←/→ edit the text first; only steer the grid once the caret is at an edge.
+      case "ArrowRight":
+        if (caret >= query.length) {
+          e.preventDefault();
+          move(1);
+        }
+        break;
+      case "ArrowLeft":
+        if (caret <= 0) {
+          e.preventDefault();
+          move(-1);
+        }
+        break;
+      case "Enter": {
+        e.preventDefault();
+        const pick = shown[active];
+        if (pick) onpick(pick.char);
+        break;
+      }
+    }
+  }
 
   function commitCustom() {
     if (customOk) {
@@ -39,15 +86,26 @@
     class="ep-search"
     placeholder={m.emojipicker_search()}
     type="text"
+    role="combobox"
+    aria-expanded="true"
+    aria-controls="ep-grid"
+    aria-activedescendant={shown.length ? `ep-cell-${active}` : undefined}
     autocomplete="off"
     spellcheck="false"
+    oninput={() => (active = 0)}
+    onkeydown={onSearchKey}
   />
-  <div class="ep-grid">
-    {#each shown as e (e.char)}
+  <div class="ep-grid" id="ep-grid" role="listbox">
+    {#each shown as e, i (e.char)}
       <button
+        bind:this={cells[i]}
+        id={`ep-cell-${i}`}
         type="button"
         class="ep-cell"
         class:on={e.char === value}
+        class:active={i === active}
+        role="option"
+        aria-selected={i === active}
         title={e.keywords}
         onclick={() => onpick(e.char)}
       >
@@ -123,6 +181,12 @@
   .ep-cell.on {
     outline: 1.5px solid var(--color-line-bright);
     background: var(--color-sel);
+  }
+  /* Keyboard cursor — defined after .on so it wins when a cell is both. */
+  .ep-cell.active {
+    background: var(--color-hover);
+    outline: 1.5px solid var(--color-amber);
+    outline-offset: -1.5px;
   }
   .ep-foot {
     display: flex;

--- a/ui/src/lib/components/EmojiPicker.svelte
+++ b/ui/src/lib/components/EmojiPicker.svelte
@@ -13,6 +13,8 @@
     onclose: () => void;
   } = $props();
 
+  // Single source of truth for the grid width: drives both the arrow-key row
+  // jump and the CSS column count (via the --ep-cols custom property below).
   const COLS = 7;
 
   let query = $state("");
@@ -89,13 +91,14 @@
     role="combobox"
     aria-expanded="true"
     aria-controls="ep-grid"
+    aria-autocomplete="list"
     aria-activedescendant={shown.length ? `ep-cell-${active}` : undefined}
     autocomplete="off"
     spellcheck="false"
     oninput={() => (active = 0)}
     onkeydown={onSearchKey}
   />
-  <div class="ep-grid" id="ep-grid" role="listbox">
+  <div class="ep-grid" id="ep-grid" role="listbox" style="--ep-cols: {COLS}">
     {#each shown as e, i (e.char)}
       <button
         bind:this={cells[i]}
@@ -106,6 +109,7 @@
         class:active={i === active}
         role="option"
         aria-selected={i === active}
+        tabindex={-1}
         title={e.keywords}
         onclick={() => onpick(e.char)}
       >
@@ -157,7 +161,8 @@
   }
   .ep-grid {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    /* Column count is set inline from the COLS constant (keeps JS row-jump in sync). */
+    grid-template-columns: repeat(var(--ep-cols, 7), 1fr);
     gap: 2px;
     margin-top: 7px;
     max-height: 180px;

--- a/ui/src/lib/emoji.test.ts
+++ b/ui/src/lib/emoji.test.ts
@@ -3,8 +3,13 @@ import { EMOJI, isSingleEmoji, searchEmoji } from "./emoji";
 
 describe("emoji helpers", () => {
   it("ships a non-trivial curated set", () => {
-    expect(EMOJI.length).toBeGreaterThan(40);
+    expect(EMOJI.length).toBeGreaterThan(100);
     expect(EMOJI.every((e) => typeof e.char === "string" && e.char.length > 0)).toBe(true);
+  });
+
+  it("has no duplicate chars (picker keys the grid by char)", () => {
+    const chars = EMOJI.map((e) => e.char);
+    expect(new Set(chars).size).toBe(chars.length);
   });
 
   it("isSingleEmoji accepts a single emoji incl. ZWJ sequences", () => {
@@ -24,5 +29,12 @@ describe("emoji helpers", () => {
     expect(searchEmoji("").length).toBe(EMOJI.length);
     const rocket = searchEmoji("rocket");
     expect(rocket.some((e) => e.char === "🚀")).toBe(true);
+  });
+
+  it("searchEmoji ranks exact/prefix matches above mid-substring matches", () => {
+    const r = searchEmoji("lock").map((e) => e.char);
+    expect(r[0]).toBe("🔐"); // exact word "lock"
+    // "locked" (prefix) outranks "unlocked" (mid-substring)
+    expect(r.indexOf("🔒")).toBeLessThan(r.indexOf("🔓"));
   });
 });

--- a/ui/src/lib/emoji.ts
+++ b/ui/src/lib/emoji.ts
@@ -84,6 +84,80 @@ export const EMOJI: EmojiEntry[] = [
   { char: "🎛️", keywords: "control dashboard knobs hud" },
   { char: "🛎️", keywords: "bell service desk support" },
   { char: "🦄", keywords: "unicorn special rare magic" },
+  // Languages / runtimes / platforms
+  { char: "🐍", keywords: "python snake script" },
+  { char: "☕", keywords: "coffee java jvm kotlin scala" },
+  { char: "💎", keywords: "gem ruby rails jewel precious" },
+  { char: "🦀", keywords: "crab rust systems" },
+  { char: "🐹", keywords: "gopher go golang hamster" },
+  { char: "🐘", keywords: "elephant php postgres database" },
+  { char: "🐧", keywords: "penguin linux os unix" },
+  { char: "🍎", keywords: "apple mac ios swift fruit" },
+  { char: "🪟", keywords: "window windows os pane" },
+  // Status / signals
+  { char: "✅", keywords: "check done complete pass success green" },
+  { char: "❌", keywords: "cross fail error no red" },
+  { char: "⚠️", keywords: "warning caution alert danger" },
+  { char: "❗", keywords: "exclamation important alert urgent" },
+  { char: "❓", keywords: "question help unknown support" },
+  { char: "🟢", keywords: "green online healthy ok status up" },
+  { char: "🔴", keywords: "red offline down error status" },
+  { char: "🟡", keywords: "yellow degraded warn pending status" },
+  { char: "⏳", keywords: "hourglass pending wait queue loading" },
+  { char: "⏱️", keywords: "stopwatch timer performance benchmark latency" },
+  // Ops / incident / infra
+  { char: "🧯", keywords: "extinguisher incident firefight emergency" },
+  { char: "🆘", keywords: "sos help emergency alert oncall" },
+  { char: "🚨", keywords: "siren alert incident alarm pager" },
+  { char: "🔌", keywords: "plug connect integration adapter power" },
+  { char: "🔋", keywords: "battery power energy charge capacity" },
+  { char: "⚓", keywords: "anchor kubernetes stable base deploy" },
+  { char: "🪣", keywords: "bucket s3 storage object container" },
+  // Data / files / storage
+  { char: "📁", keywords: "folder directory files" },
+  { char: "📂", keywords: "folder open directory browse" },
+  { char: "🗂️", keywords: "dividers organize folders index" },
+  { char: "🧊", keywords: "ice cache cold freeze frozen" },
+  { char: "🌊", keywords: "wave stream flow pipeline data" },
+  { char: "🔗", keywords: "link url chain reference dependency" },
+  { char: "🧲", keywords: "magnet attract fetch pull scrape" },
+  // Money / business
+  { char: "💰", keywords: "money cost budget billing finance" },
+  { char: "💳", keywords: "card payment billing checkout subscription" },
+  { char: "🪙", keywords: "coin token crypto currency credits" },
+  { char: "🏦", keywords: "bank finance institution account" },
+  { char: "🛒", keywords: "cart shop ecommerce store checkout" },
+  { char: "🧮", keywords: "abacus compute calculate count math" },
+  { char: "⚖️", keywords: "scale balance license legal compare" },
+  // People / collaboration
+  { char: "👤", keywords: "user person profile account" },
+  { char: "👥", keywords: "users team group members" },
+  { char: "🤝", keywords: "handshake deal partner merge agreement" },
+  { char: "🧙", keywords: "wizard magic setup onboarding automation" },
+  { char: "🦉", keywords: "owl wisdom knowledge night insight" },
+  // Media / capture
+  { char: "🎥", keywords: "video camera record stream capture" },
+  { char: "📷", keywords: "camera photo snapshot capture" },
+  { char: "📸", keywords: "camera screenshot flash snapshot" },
+  { char: "🎬", keywords: "clapper film action start scene" },
+  { char: "🎮", keywords: "game controller play gaming demo" },
+  // Search / tools / misc
+  { char: "🔍", keywords: "search find magnify lookup query" },
+  { char: "🔎", keywords: "search find zoom inspect detail" },
+  { char: "🪛", keywords: "screwdriver tool fix config tweak" },
+  { char: "✂️", keywords: "scissors cut clip trim snippet" },
+  { char: "📐", keywords: "ruler measure design geometry layout" },
+  { char: "📌", keywords: "pushpin pin mark important sticky" },
+  { char: "🔖", keywords: "bookmark save mark tag reference" },
+  { char: "💥", keywords: "explosion crash boom break error" },
+  { char: "🪐", keywords: "planet space orbit saturn cosmos" },
+  { char: "☄️", keywords: "comet fast streak speed space" },
+  { char: "🐝", keywords: "bee busy worker swarm queue" },
+  { char: "🍀", keywords: "clover luck lucky four fortune" },
+  { char: "🦋", keywords: "butterfly transform migrate change" },
+  { char: "⭐", keywords: "star favorite featured highlight" },
+  { char: "🏆", keywords: "trophy award win achievement milestone" },
+  { char: "🎉", keywords: "party celebrate launch release ship" },
 ];
 
 const _segmenter = new Intl.Segmenter();
@@ -98,9 +172,29 @@ export function isSingleEmoji(s: string): boolean {
   return /\p{Extended_Pictographic}/u.test(t);
 }
 
-/** Filter the curated set by keyword/char; empty query returns the whole set. */
+/** Relevance score for `e` against query `q` (lowercased) / `raw` (trimmed, original case).
+ *  Higher = better: exact char > exact word > word-prefix > mid-substring. 0 = no match. */
+function rankEmoji(e: EmojiEntry, q: string, raw: string): number {
+  if (e.char === raw) return 1000;
+  let best = 0;
+  for (const t of e.keywords.split(" ")) {
+    if (t === q) best = Math.max(best, 100);
+    else if (t.startsWith(q)) best = Math.max(best, 50);
+    else if (t.includes(q)) best = Math.max(best, 10);
+  }
+  // Fallback: query spans a token boundary (e.g. "auth token").
+  if (best === 0 && e.keywords.includes(q)) return 5;
+  return best;
+}
+
+/** Filter the curated set by keyword/char; empty query returns the whole set.
+ *  Matches are ranked: exact char, then exact word, word-prefix, then mid-substring. */
 export function searchEmoji(query: string): EmojiEntry[] {
-  const q = query.trim().toLowerCase();
+  const raw = query.trim();
+  const q = raw.toLowerCase();
   if (q === "") return EMOJI;
-  return EMOJI.filter((e) => e.keywords.includes(q) || e.char === query.trim());
+  return EMOJI.map((e, i) => ({ e, s: rankEmoji(e, q, raw), i }))
+    .filter((x) => x.s > 0)
+    .sort((a, b) => b.s - a.s || a.i - b.i)
+    .map((x) => x.e);
 }


### PR DESCRIPTION
## What

Expands the icon set users can assign to repos, and makes the picker easier to drive.

### Icon set (`ui/src/lib/emoji.ts`)
- Curated set grows **79 → 145**, all distinct & software/project-relevant: languages/runtimes (🐍☕💎🦀🐹🐘🐧🍎🪟), status signals (✅❌⚠️🟢🔴🟡⏳), ops/incident (🧯🆘🚨🔌⚓🪣), data/storage (📁📂🗂️🧊🌊🔗🧲), money/business (💰💳🪙🏦🛒⚖️), people (👤👥🤝🧙🦉), media (🎥📷📸🎬🎮), tools/misc (🔍🔎🪛✂️📐📌🔖💥🪐☄️🐝🍀🦋⭐🏆🎉).
- No UI changes needed for the bigger set — the grid already scrolls and search filters it.

### Ranked search (`searchEmoji`)
- Results are now scored, not filter-ordered: **exact char > exact keyword > word-prefix > mid-substring** (token-boundary fallback). Ties keep curated order.
- e.g. `lock` → 🔐 (exact) before 🔒 (prefix "locked") before 🔓 (substring "unlocked").

### Keyboard nav (`EmojiPicker.svelte`)
- **↑/↓** move by row, **Enter** picks the highlighted cell.
- **←/→** edit the search text and only steer the grid once the caret is at an edge — typo-fixing still works.
- Active cell gets an amber cursor outline (distinct from the blue "assigned" outline) and auto-scrolls into view; typing resets the cursor to the top result.
- Proper combobox/listbox ARIA (`aria-activedescendant`, `aria-selected`) for screen readers.

## Tests
- New guards: duplicate-`char` (picker keys the grid by char) + ranking order; set-size floor bumped to >100.
- `bun run test` 6/6, `bun run check` 0 errors (i18n parity gate included — no new strings), prettier + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)