### PR TITLE
feat(forge): list Gitea/Forgejo Actions runs in backlog tab (#234)

### DIFF
--- a/src/forge/checks.ts
+++ b/src/forge/checks.ts
@@ -40,6 +40,28 @@ export function mapStatusState(state?: string | null): ChecksState {
   }
 }
 
+/** Map Gitea/Forgejo's single native Actions status (the `tasks` endpoint's one
+ *  enum — there's no GitHub-style status+conclusion split): success → success;
+ *  failure / cancelled / canceled → failure; running / waiting / blocked /
+ *  cancelling → pending; skipped / unknown / anything else / empty → none. */
+export function mapGiteaActionStatus(status?: string | null): ChecksState {
+  switch ((status ?? "").toLowerCase()) {
+    case "success":
+      return "success";
+    case "failure":
+    case "cancelled":
+    case "canceled":
+      return "failure";
+    case "running":
+    case "waiting":
+    case "blocked":
+    case "cancelling":
+      return "pending";
+    default:
+      return "none";
+  }
+}
+
 /** A legacy StatusContext carries a context label + flat state (no lifecycle). */
 function isStatusContext(e: RollupEntry): boolean {
   return e.__typename === "StatusContext" || (e.name == null && e.context != null);

--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -1,4 +1,4 @@
-import { mapStatusState } from "./checks";
+import { mapGiteaActionStatus, mapStatusState } from "./checks";
 import type {
   ChecksState,
   ForgeConfig,
@@ -12,6 +12,7 @@ import type {
   PullRequest,
   RedeployInput,
   WorkflowJob,
+  WorkflowRun,
 } from "./types";
 
 interface GiteaPr {
@@ -34,6 +35,10 @@ interface GiteaPr {
  * pressure). A small pool keeps most of the parallel speedup without the burst.
  */
 const STATUS_FETCH_CONCURRENCY = 6;
+
+/** Cap on workflows surfaced in the Actions tab (one row per workflow, latest
+ *  run). Mirrors github.ts's own MAX_WORKFLOWS — the two packages don't share it. */
+const MAX_WORKFLOWS = 10;
 
 /** Order-preserving bounded-concurrency map: at most `limit` `fn`s run at once. */
 async function mapBounded<T, R>(
@@ -184,6 +189,53 @@ export class GiteaForge implements GitForge {
         checks,
         jobs,
       } satisfies PullRequest;
+    });
+  }
+
+  /** Latest run per workflow on the repo, for the backlog Actions tab. Reads the
+   *  `actions/tasks` endpoint — the only Actions API portable across Forgejo +
+   *  Gitea ≥1.23. Despite its name it lists *runs*, not jobs: there is no per-job
+   *  breakdown (so every `jobs` is empty) and no `conclusion` field — `status` is a
+   *  single native enum (mapped by {@link mapGiteaActionStatus}). We don't trust the
+   *  server's ordering: sort newest-first, then keep the latest run per workflow
+   *  (keyed on the displayed name, so the consumer's keyed list stays unique). */
+  async listWorkflowRuns(): Promise<WorkflowRun[]> {
+    const raw = (await this.req("GET", `/api/v1/repos/${this.slug}/actions/tasks?limit=50`)) as {
+      workflow_runs?: Array<{
+        id: number;
+        name?: string;
+        status?: string;
+        url?: string;
+        head_sha?: string;
+        workflow_id?: string;
+        created_at?: string;
+      }> | null;
+    } | null;
+
+    // Parse each created_at once and sort newest-first (don't assume server order).
+    const tasks = (raw?.workflow_runs ?? [])
+      .map((t) => ({ task: t, ts: Date.parse(t.created_at ?? "") }))
+      .sort((a, b) => (Number.isFinite(b.ts) ? b.ts : 0) - (Number.isFinite(a.ts) ? a.ts : 0));
+
+    // Dedup keeping the newest entry per workflow, keyed on the displayed name
+    // (name || workflow_id) so the keyed Actions list can't collide; then cap.
+    const newest = new Map<string, (typeof tasks)[number]>();
+    for (const entry of tasks) {
+      const key = entry.task.name || entry.task.workflow_id || "";
+      if (!newest.has(key)) newest.set(key, entry);
+    }
+    const selected = [...newest.values()].slice(0, MAX_WORKFLOWS);
+
+    return selected.map(({ task, ts }): WorkflowRun => {
+      return {
+        runId: task.id,
+        workflowName: task.name || (task.workflow_id ?? ""),
+        runUrl: task.url ?? "",
+        headSha: task.head_sha ?? "",
+        createdAt: Number.isFinite(ts) ? ts : Date.now(),
+        state: mapGiteaActionStatus(task.status),
+        jobs: [], // the tasks endpoint carries no per-job data
+      };
     });
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1240,22 +1240,35 @@ async function handlePrsList({ req, parts, url, deps }: Ctx): Promise<Response |
   }
 }
 
-// GET /api/actions?repo= — latest GitHub Actions run per workflow on the default
-// branch, with per-job breakdown (backlog Actions-tab detail pane). GitHub only;
-// other forges report no runs and the tab shows a "GitHub only" state.
+// GET /api/actions?repo= — latest Actions run per workflow on the default branch
+// (backlog Actions-tab detail pane). Alongside the runs it reports three capability
+// flags (supportsActions / canRerun / canCancel) derived from which optional forge
+// methods exist, so the UI can gate the empty-state and rerun/cancel buttons
+// forge-agnostically rather than hardcoding `kind`. Forges without an Actions API
+// (e.g. Gitea lacks rerun/cancel) report no runs / the relevant flag false.
 async function handleActionsList({ req, parts, url, deps }: Ctx): Promise<Response | null> {
   if (req.method !== "GET" || parts[0] !== "api" || parts[1] !== "actions" || parts[2]) return null;
   const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
   if (!dir) return json({ error: "invalid repo" }, 400);
   const forge = deps.resolveForge?.(dir) ?? null;
+  const caps = {
+    supportsActions: Boolean(forge?.listWorkflowRuns),
+    canRerun: Boolean(forge?.rerunWorkflowRun),
+    canCancel: Boolean(forge?.cancelWorkflowRun),
+  };
   if (!forge?.listWorkflowRuns) {
-    return json({ slug: forge?.slug ?? null, kind: forge?.kind ?? null, runs: [] });
+    return json({ slug: forge?.slug ?? null, kind: forge?.kind ?? null, runs: [], ...caps });
   }
   try {
-    return json({ slug: forge.slug, kind: forge.kind, runs: await forge.listWorkflowRuns() });
+    return json({
+      slug: forge.slug,
+      kind: forge.kind,
+      runs: await forge.listWorkflowRuns(),
+      ...caps,
+    });
   } catch {
     // missing/un-authed CLI or network error → graceful empty (matches PRs path)
-    return json({ slug: forge.slug, kind: forge.kind, runs: [] });
+    return json({ slug: forge.slug, kind: forge.kind, runs: [], ...caps });
   }
 }
 

--- a/test/forge/checks.test.ts
+++ b/test/forge/checks.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import {
   jobsFromRollup,
   mapCheckState,
+  mapGiteaActionStatus,
   mapStatusState,
   rollupChecks,
 } from "../../src/forge/checks";
@@ -110,6 +111,29 @@ test("mapStatusState: maps the coarse StatusContext/Gitea vocab", () => {
   expect(mapStatusState("error")).toBe("failure");
   expect(mapStatusState("")).toBe("none");
   expect(mapStatusState(null)).toBe("none");
+});
+
+test("mapGiteaActionStatus: maps the native Actions tasks enum", () => {
+  expect(mapGiteaActionStatus("success")).toBe("success");
+  expect(mapGiteaActionStatus("failure")).toBe("failure");
+  expect(mapGiteaActionStatus("cancelled")).toBe("failure");
+  expect(mapGiteaActionStatus("canceled")).toBe("failure");
+  expect(mapGiteaActionStatus("running")).toBe("pending");
+  expect(mapGiteaActionStatus("waiting")).toBe("pending");
+  expect(mapGiteaActionStatus("blocked")).toBe("pending");
+  expect(mapGiteaActionStatus("cancelling")).toBe("pending");
+  expect(mapGiteaActionStatus("skipped")).toBe("none");
+  expect(mapGiteaActionStatus("unknown")).toBe("none");
+});
+
+test("mapGiteaActionStatus: case-insensitive + empty/nullish/unrecognized → none", () => {
+  expect(mapGiteaActionStatus("SUCCESS")).toBe("success");
+  expect(mapGiteaActionStatus("Failure")).toBe("failure");
+  expect(mapGiteaActionStatus("RUNNING")).toBe("pending");
+  expect(mapGiteaActionStatus("")).toBe("none");
+  expect(mapGiteaActionStatus(null)).toBe("none");
+  expect(mapGiteaActionStatus(undefined)).toBe("none");
+  expect(mapGiteaActionStatus("bogus")).toBe("none");
 });
 
 test("jobsFromRollup: CheckRun entries are qualified with their workflow name", () => {

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -416,6 +416,209 @@ test("GiteaForge.closeIssue: PATCHes the issue state to closed", async () => {
   expect(patch.body).toEqual({ state: "closed" });
 });
 
+const ACTIONS_TASKS = "GET /api/v1/repos/team/proj/actions/tasks?limit=50";
+
+test("GiteaForge.listWorkflowRuns: dedups to newest run per workflow, newest-first", async () => {
+  const { fn } = fakeFetch({
+    [ACTIONS_TASKS]: {
+      json: {
+        workflow_runs: [
+          // older CI run (should be dropped in favor of the newer one below)
+          {
+            id: 1,
+            name: "CI",
+            run_number: 1,
+            status: "failure",
+            url: "https://git.example.com/team/proj/actions/runs/1",
+            head_sha: "old",
+            workflow_id: "ci.yaml",
+            created_at: "2024-01-01T00:00:00Z",
+          },
+          // newest Deploy run
+          {
+            id: 3,
+            name: "Deploy",
+            run_number: 2,
+            status: "running",
+            url: "https://git.example.com/team/proj/actions/runs/3",
+            head_sha: "dep",
+            workflow_id: "deploy.yaml",
+            created_at: "2024-03-03T00:00:00Z",
+          },
+          // newer CI run
+          {
+            id: 2,
+            name: "CI",
+            run_number: 2,
+            status: "success",
+            url: "https://git.example.com/team/proj/actions/runs/2",
+            head_sha: "new",
+            workflow_id: "ci.yaml",
+            created_at: "2024-02-02T00:00:00Z",
+          },
+        ],
+        total_count: 3,
+      },
+    },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const runs = await forge.listWorkflowRuns!();
+  expect(runs).toEqual([
+    {
+      runId: 3,
+      workflowName: "Deploy",
+      runUrl: "https://git.example.com/team/proj/actions/runs/3",
+      headSha: "dep",
+      createdAt: Date.parse("2024-03-03T00:00:00Z"),
+      state: "pending",
+      jobs: [],
+    },
+    {
+      runId: 2,
+      workflowName: "CI",
+      runUrl: "https://git.example.com/team/proj/actions/runs/2",
+      headSha: "new",
+      createdAt: Date.parse("2024-02-02T00:00:00Z"),
+      state: "success",
+      jobs: [],
+    },
+  ]);
+});
+
+test("GiteaForge.listWorkflowRuns: maps native statuses to ChecksState", async () => {
+  const mk = (id: number, name: string, status: string, created_at: string) => ({
+    id,
+    name,
+    status,
+    url: `https://git.example.com/r/${id}`,
+    head_sha: `s${id}`,
+    workflow_id: `${name}.yaml`,
+    created_at,
+  });
+  const { fn } = fakeFetch({
+    [ACTIONS_TASKS]: {
+      json: {
+        workflow_runs: [
+          mk(1, "A", "success", "2024-01-04T00:00:00Z"),
+          mk(2, "B", "running", "2024-01-03T00:00:00Z"),
+          mk(3, "C", "waiting", "2024-01-02T00:00:00Z"),
+          mk(4, "D", "cancelled", "2024-01-01T00:00:00Z"),
+        ],
+        total_count: 4,
+      },
+    },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const runs = await forge.listWorkflowRuns!();
+  expect(runs.map((r) => [r.workflowName, r.state])).toEqual([
+    ["A", "success"],
+    ["B", "pending"],
+    ["C", "pending"],
+    ["D", "failure"],
+  ]);
+});
+
+test("GiteaForge.listWorkflowRuns: empty workflow_runs → []", async () => {
+  const { fn } = fakeFetch({
+    [ACTIONS_TASKS]: { json: { workflow_runs: [], total_count: 0 } },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  expect(await forge.listWorkflowRuns!()).toEqual([]);
+});
+
+test("GiteaForge.listWorkflowRuns: missing workflow_runs key → []", async () => {
+  const { fn } = fakeFetch({
+    [ACTIONS_TASKS]: { json: { total_count: 0 } },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  expect(await forge.listWorkflowRuns!()).toEqual([]);
+});
+
+test("GiteaForge.listWorkflowRuns: caps at 10 distinct workflows", async () => {
+  const workflow_runs = Array.from({ length: 25 }, (_, i) => ({
+    id: i + 1,
+    name: `wf-${i + 1}`,
+    status: "success",
+    url: `https://git.example.com/r/${i + 1}`,
+    head_sha: `s${i + 1}`,
+    workflow_id: `wf-${i + 1}.yaml`,
+    // ascending time so newest is the last (wf-25); cap keeps the 10 newest
+    created_at: `2024-01-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+  }));
+  const { fn } = fakeFetch({
+    [ACTIONS_TASKS]: { json: { workflow_runs, total_count: 25 } },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const runs = await forge.listWorkflowRuns!();
+  expect(runs.length).toBe(10);
+  // newest-first, so the 10 highest-numbered workflows
+  expect(runs.map((r) => r.workflowName)).toEqual([
+    "wf-25",
+    "wf-24",
+    "wf-23",
+    "wf-22",
+    "wf-21",
+    "wf-20",
+    "wf-19",
+    "wf-18",
+    "wf-17",
+    "wf-16",
+  ]);
+});
+
+test("GiteaForge.listWorkflowRuns: every run has jobs: [] (no per-job data)", async () => {
+  const { fn } = fakeFetch({
+    [ACTIONS_TASKS]: {
+      json: {
+        workflow_runs: [
+          {
+            id: 1,
+            name: "CI",
+            status: "success",
+            url: "u",
+            head_sha: "s",
+            workflow_id: "ci.yaml",
+            created_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+        total_count: 1,
+      },
+    },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const runs = await forge.listWorkflowRuns!();
+  expect(runs.every((r) => Array.isArray(r.jobs) && r.jobs.length === 0)).toBe(true);
+});
+
+test("GiteaForge.listWorkflowRuns: keys dedup on workflow_id when name is missing, unparseable created_at falls back to now", async () => {
+  const before = Date.now();
+  const { fn } = fakeFetch({
+    [ACTIONS_TASKS]: {
+      json: {
+        workflow_runs: [
+          {
+            id: 1,
+            name: "",
+            status: "success",
+            url: "u1",
+            head_sha: "s1",
+            workflow_id: "ci.yaml",
+            created_at: "bogus",
+          },
+        ],
+        total_count: 1,
+      },
+    },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const runs = await forge.listWorkflowRuns!();
+  const after = Date.now();
+  expect(runs.length).toBe(1);
+  expect(runs[0]!.workflowName).toBe("ci.yaml");
+  expect(runs[0]!.createdAt).toBeGreaterThanOrEqual(before);
+  expect(runs[0]!.createdAt).toBeLessThanOrEqual(after);
+});
+
 test("GiteaForge.prStatus: surfaces head SHA from PR head.sha", async () => {
   const { fn } = fakeFetch({
     "GET /api/v1/repos/team/proj/pulls?state=all&limit=50": {

--- a/test/server-actions.test.ts
+++ b/test/server-actions.test.ts
@@ -72,28 +72,70 @@ function postReq(path: string, body: unknown): Request {
   });
 }
 
-test("GET /api/actions resolves via the forge → {slug, kind, runs}", async () => {
+test("GET /api/actions resolves via the forge → {slug, kind, runs, capability flags}", async () => {
+  // fakeForge() has listWorkflowRuns but no rerun/cancel → supportsActions only.
   const app = makeApp(makeDeps(() => fakeForge()));
   const res = await app.fetch(getReq(repoDir));
   expect(res.status).toBe(200);
-  expect(await res.json()).toEqual({ slug: "team/proj", kind: "github", runs: [RUN] });
+  expect(await res.json()).toEqual({
+    slug: "team/proj",
+    kind: "github",
+    runs: [RUN],
+    supportsActions: true,
+    canRerun: false,
+    canCancel: false,
+  });
 });
 
-test("GET /api/actions with no forge → empty, null slug/kind", async () => {
+test("GET /api/actions: full GitHub forge (rerun+cancel) → all caps true", async () => {
+  const app = makeApp(
+    makeDeps(() =>
+      fakeForge({
+        rerunWorkflowRun: async () => {},
+        cancelWorkflowRun: async () => {},
+      }),
+    ),
+  );
+  const res = await app.fetch(getReq(repoDir));
+  expect(await res.json()).toEqual({
+    slug: "team/proj",
+    kind: "github",
+    runs: [RUN],
+    supportsActions: true,
+    canRerun: true,
+    canCancel: true,
+  });
+});
+
+test("GET /api/actions with no forge → empty, null slug/kind, all caps false", async () => {
   const app = makeApp(makeDeps(() => null));
   const res = await app.fetch(getReq(repoDir));
-  expect(await res.json()).toEqual({ slug: null, kind: null, runs: [] });
+  expect(await res.json()).toEqual({
+    slug: null,
+    kind: null,
+    runs: [],
+    supportsActions: false,
+    canRerun: false,
+    canCancel: false,
+  });
 });
 
-test("GET /api/actions for a forge without listWorkflowRuns (e.g. gitea) → empty", async () => {
+test("GET /api/actions for a forge without listWorkflowRuns (e.g. gitea) → empty, supportsActions false", async () => {
   const app = makeApp(
     makeDeps(() => fakeForge({ kind: "gitea", slug: "team/proj", listWorkflowRuns: undefined })),
   );
   const res = await app.fetch(getReq(repoDir));
-  expect(await res.json()).toEqual({ slug: "team/proj", kind: "gitea", runs: [] });
+  expect(await res.json()).toEqual({
+    slug: "team/proj",
+    kind: "gitea",
+    runs: [],
+    supportsActions: false,
+    canRerun: false,
+    canCancel: false,
+  });
 });
 
-test("GET /api/actions swallows forge errors → empty runs", async () => {
+test("GET /api/actions swallows forge errors → empty runs, caps still reflect the forge", async () => {
   const app = makeApp(
     makeDeps(() =>
       fakeForge({
@@ -104,7 +146,14 @@ test("GET /api/actions swallows forge errors → empty runs", async () => {
     ),
   );
   const res = await app.fetch(getReq(repoDir));
-  expect(await res.json()).toEqual({ slug: "team/proj", kind: "github", runs: [] });
+  expect(await res.json()).toEqual({
+    slug: "team/proj",
+    kind: "github",
+    runs: [],
+    supportsActions: true,
+    canRerun: false,
+    canCancel: false,
+  });
 });
 
 test("GET /api/actions?repo outside root → 400", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -462,7 +462,7 @@
   "backlog_tab_actions_failing": "Actions · fehlerhaft",
   "actionspanel_title": "ACTIONS",
   "actionspanel_title_with_slug": "ACTIONS · {slug}",
-  "actionspanel_github_only": "Actions sind nur für GitHub-Repos verfügbar",
+  "actionspanel_unavailable": "Actions sind für dieses Repository nicht verfügbar",
   "actionspanel_no_runs": "keine aktuellen Workflow-Läufe",
   "actionspanel_run_link": "Lauf öffnen",
   "actionspanel_job_link": "Job öffnen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -462,7 +462,7 @@
   "backlog_tab_actions_failing": "Actions · failing",
   "actionspanel_title": "ACTIONS",
   "actionspanel_title_with_slug": "ACTIONS · {slug}",
-  "actionspanel_github_only": "Actions are only available for GitHub repos",
+  "actionspanel_unavailable": "Actions are not available for this repository",
   "actionspanel_no_runs": "no recent workflow runs",
   "actionspanel_run_link": "open run",
   "actionspanel_job_link": "open job",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -307,11 +307,18 @@ export async function listPullRequests(
   return r.json();
 }
 
-/** Latest GitHub Actions run per workflow on a repo's default branch, with
- *  per-job breakdown. `kind !== "github"` → the repo has no Actions to show. */
-export async function listWorkflowRuns(
-  repoPath: string,
-): Promise<{ slug: string | null; kind: ForgeKind | null; runs: WorkflowRun[] }> {
+/** Latest Actions run per workflow on a repo's default branch (any forge that
+ *  supports Actions — GitHub + Gitea/Forgejo), with per-job breakdown where the
+ *  forge exposes one. The caller gates UI on the capability flags:
+ *  `supportsActions` (can list runs), `canRerun` / `canCancel` (REST controls). */
+export async function listWorkflowRuns(repoPath: string): Promise<{
+  slug: string | null;
+  kind: ForgeKind | null;
+  runs: WorkflowRun[];
+  supportsActions: boolean;
+  canRerun: boolean;
+  canCancel: boolean;
+}> {
   const r = await fetch(`/api/actions?repo=${encodeURIComponent(repoPath)}`);
   if (!r.ok) throw await failed(r, "actions");
   return r.json();

--- a/ui/src/lib/components/ActionRunRow.svelte
+++ b/ui/src/lib/components/ActionRunRow.svelte
@@ -7,10 +7,16 @@
   let {
     repoPath,
     run,
+    rerunnable,
+    cancelable,
     onchanged,
   }: {
     repoPath: string;
     run: WorkflowRun;
+    /** Forge exposes a REST re-run control (GitHub yes, Gitea no). */
+    rerunnable: boolean;
+    /** Forge exposes a REST cancel control (GitHub yes, Gitea no). */
+    cancelable: boolean;
     /** Called after a re-run/cancel lands so the parent can re-poll live state. */
     onchanged: () => void;
   } = $props();
@@ -86,7 +92,7 @@
     >
     <!-- eslint-enable svelte/no-navigation-without-resolve -->
     {#if failed}<span class="wf-err">{m.actionspanel_action_failed()}</span>{/if}
-    {#if canCancel}
+    {#if cancelable && canCancel}
       <button
         class="act-btn"
         class:armed={armed === "cancel"}
@@ -96,7 +102,7 @@
       >
         {armed === "cancel" ? m.actionspanel_cancel_confirm() : m.actionspanel_cancel()}
       </button>
-    {:else if canRerun}
+    {:else if rerunnable && canRerun}
       <button
         class="act-btn"
         class:armed={armed === "rerun"}

--- a/ui/src/lib/components/ActionsPanel.svelte
+++ b/ui/src/lib/components/ActionsPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { listWorkflowRuns } from "$lib/api";
-  import type { ForgeKind, WorkflowRun } from "$lib/types";
+  import type { WorkflowRun } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import ActionRunRow from "./ActionRunRow.svelte";
 
@@ -8,8 +8,13 @@
 
   let runs = $state<WorkflowRun[]>([]);
   let slug = $state<string | null>(null);
-  let kind = $state<ForgeKind | null>(null);
   let loading = $state(true);
+  // Server-reported forge capabilities. `supportsActions` defaults true so the
+  // first load doesn't flash the "unavailable" message before the response lands;
+  // the rerun/cancel controls default off until the forge confirms it has them.
+  let supportsActions = $state(true);
+  let canRerun = $state(false);
+  let canCancel = $state(false);
 
   // Any in-flight run or job keeps the silent poll alive. Once everything has
   // settled (all green/red), there is nothing left to update, so we stop
@@ -26,8 +31,10 @@
       .then((r) => {
         if (rp !== repoPath) return; // stale response for a since-changed repo
         slug = r.slug;
-        kind = r.kind;
         runs = r.runs;
+        supportsActions = r.supportsActions;
+        canRerun = r.canRerun;
+        canCancel = r.canCancel;
         loading = false;
       })
       .catch(() => {
@@ -67,13 +74,19 @@
   <div class="actions-list">
     {#if loading}
       <div class="muted">{m.common_loading()}</div>
-    {:else if kind !== "github"}
-      <div class="muted">{m.actionspanel_github_only()}</div>
+    {:else if !supportsActions}
+      <div class="muted">{m.actionspanel_unavailable()}</div>
     {:else if runs.length === 0}
       <div class="muted">{m.actionspanel_no_runs()}</div>
     {:else}
       {#each runs as run (run.workflowName)}
-        <ActionRunRow {repoPath} {run} onchanged={() => load(repoPath, true)} />
+        <ActionRunRow
+          {repoPath}
+          {run}
+          rerunnable={canRerun}
+          cancelable={canCancel}
+          onchanged={() => load(repoPath, true)}
+        />
       {/each}
     {/if}
   </div>


### PR DESCRIPTION
Closes #234. Follow-up to the GitHub-only v1 Actions backlog tab.

## What
Implements `listWorkflowRuns` for `GiteaForge` so the backlog **Actions** tab works for Gitea/Forgejo hosts too.

## How
- **`GiteaForge.listWorkflowRuns()`** reads `GET /api/v1/repos/{slug}/actions/tasks?limit=50` — the only Actions-listing endpoint portable across **all Forgejo + Gitea ≥1.23**. Despite its name it returns *runs*. It sorts newest-first (server order isn't trusted), dedups to the latest run per workflow (keyed on display name → keeps the UI's keyed list unique), and caps at 10.
- **No per-job breakdown, no rerun, no cancel** for Gitea — the `tasks` endpoint carries no job data, and released Gitea/Forgejo expose no REST rerun/cancel. The GitHub-compatible `runs`/`jobs`/rerun endpoints are unreleased-Gitea-only and absent from Forgejo, so they're out of scope. Gitea runs render read-only (state dot + name + link).
- **`mapGiteaActionStatus`** maps Gitea's single native status enum (`running`/`waiting`/`blocked`/`cancelling` → pending, `cancelled`/`failure` → failure, `success` → success, `skipped`/`unknown` → none) — the existing GitHub status+conclusion mapper doesn't fit.
- **Server `/api/actions`** now reports `supportsActions` / `canRerun` / `canCancel` capability flags (from which optional forge methods exist). The UI gates the empty-state and the rerun/cancel buttons on these flags **forge-agnostically** instead of hardcoding `kind === "github"`.
- The old "Actions are only available for GitHub repos" empty-state becomes a capability-driven "Actions are not available for this repository" (EN + DE).

## Tests
- `GiteaForge.listWorkflowRuns`: dedup/newest-per-workflow, native-status mapping, newest-first ordering, empty list, cap-at-10, empty `jobs`.
- `mapGiteaActionStatus` enum coverage.
- `/api/actions` capability-flag assertions updated.

## Verification
- Root: `bunx tsc --noEmit` clean · `bun test ./test` 936 pass / 0 fail · `bun run lint` clean
- UI: `bun run check` 0 errors · `bun run check:i18n` 2 locales in parity (509 keys) · `bun run test` 357 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)