### PR TITLE
feat(drain): claim issues with a label to coordinate across instances

### DIFF
--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -6,6 +6,19 @@ import type { SessionStatus, ReviewDecision } from "./types";
  *  sibling so operators don't have to wire up two labels). */
 export const PRIORITY_LABEL = "shepherd:priority";
 
+/** The drain stamps this label on an issue when it claims it (spawns an auto
+ *  session) and keeps it through retire — a ready PR awaiting human merge is still
+ *  "taken". It is the ONLY cross-instance coordination point: a second shepherd
+ *  draining the same forge filters claimed issues out (see {@link selectCandidates}),
+ *  so two instances don't take the same issue, and a retired-but-unmerged issue is
+ *  not re-spawned. A constant (not the per-repo `autoLabel`) so every instance agrees
+ *  on it without sharing config. The window is narrowed, not eliminated — two
+ *  instances listing within the claim's set-up latency can still race; local dedup
+ *  then prevents a single instance double-spawning. Released only when the work is
+ *  abandoned (manual archive, no merge); a human merge auto-closes the issue, retiring
+ *  the claim with it. */
+export const ACTIVE_LABEL = "shepherd:active";
+
 /** Why the drain is holding rather than spawning/retiring — surfaced on `drain:status`. */
 export interface HoldReason {
   code:
@@ -117,12 +130,17 @@ export function computeNext(state: DrainRepoState): DrainDecision {
 }
 
 /**
- * Filter issues to those carrying `autoLabel`, then order: priority-labeled first
- * (each group by issue number ascending = oldest first). A priority label without
- * the auto label is ignored — the auto label is the opt-in.
+ * Filter issues to those carrying `autoLabel` and NOT already claimed
+ * ({@link ACTIVE_LABEL}), then order: priority-labeled first (each group by issue
+ * number ascending = oldest first). A priority label without the auto label is
+ * ignored — the auto label is the opt-in. Excluding claimed issues is what keeps a
+ * second shepherd instance from re-taking an issue this (or another) instance is
+ * already working or has a ready PR open for.
  */
 export function selectCandidates(issues: Issue[], autoLabel: string): Issue[] {
-  const eligible = issues.filter((i) => i.labels.includes(autoLabel));
+  const eligible = issues.filter(
+    (i) => i.labels.includes(autoLabel) && !i.labels.includes(ACTIVE_LABEL),
+  );
   const prio = (i: Issue) => (i.labels.includes(PRIORITY_LABEL) ? 0 : 1);
   return eligible.sort((a, b) => prio(a) - prio(b) || a.number - b.number);
 }

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -362,7 +362,12 @@ export class DrainService {
     // retired), which re-queues the issue. NOTE: the abandoning instance still maps
     // this issue via its own archived session, so the release re-queues it for OTHER
     // instances — and for this one only after its archived session is pruned.
-    // Unconditional of the drain toggle (mirrors onGit's closeIssue) so a
+    // CAVEAT: an abandon does not inspect PR state, so manually archiving a session
+    // that already opened a PR (without going through the retire path) releases the
+    // claim and lets another instance spawn a DUPLICATE against that still-open PR.
+    // Accepted: a manual archive is a deliberate "drop this" signal, and the retire
+    // path (not manual archive) is how a ready PR is normally handed off with its
+    // claim kept. Unconditional of the drain toggle (mirrors onGit's closeIssue) so a
     // disabled-mid-flight session still frees its claim. Non-auto sessions never set
     // a claim, so they're skipped.
     if (!retainClaim && s.auto && s.issueNumber != null) {

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -3,6 +3,7 @@ import type { GitForge, GitState, Issue } from "./forge/types";
 import type { CreateSessionInput, Session } from "./types";
 import type { UsageLimits } from "./usage-limits";
 import {
+  ACTIVE_LABEL,
   computeNext,
   selectCandidates,
   type AutoSessionView,
@@ -72,6 +73,13 @@ export class DrainService {
   // repoPath lock held across the whole async pump — a concurrent pump for the
   // same repo bails immediately so we never double-spawn/double-retire.
   private pumping = new Set<string>();
+  // sessionIds whose claim label onArchived must NOT release. Populated in doRetire
+  // (a ready PR stays open → keep the claim so no instance re-spawns it; the human
+  // merge auto-closes the issue, retiring the claim) and in onGit ONLY for a merge
+  // whose closeIssue FAILED (issue still open → keep the claim). A plain abandon
+  // (manual archive, never retired) is absent here, so onArchived drops the label
+  // and re-queues the issue. Consumed (deleted) in onArchived.
+  private retainClaimOnArchive = new Set<string>();
   private issuesCache = new Map<string, { issues: Issue[]; ts: number }>();
   private now: () => number;
   private issuesTtlMs: number;
@@ -171,6 +179,11 @@ export class DrainService {
       // sees the session as archived and won't re-select it — but if computeNext
       // somehow re-selects the same session anyway, we break rather than loop.
       const attemptedRetire = new Set<string>();
+      // Same guard for spawns: a successful spawn maps the issue (so it won't be
+      // re-selected), but a FAILED spawn leaves it unmapped — without this the loop
+      // would re-pick the same failing issue every iteration up to the cap, churning
+      // its claim label on each try. Break instead and let the next tick retry.
+      const attemptedSpawn = new Set<number>();
       // Hard iteration cap as a runaway backstop; each spawn/retire changes state,
       // so a well-behaved drain ends on a hold well before this.
       for (let i = 0; i < 100; i++) {
@@ -190,6 +203,8 @@ export class DrainService {
           continue;
         }
         if (decision.kind === "spawn") {
+          if (attemptedSpawn.has(decision.issue.number)) break; // already tried this pump; defer to next tick
+          attemptedSpawn.add(decision.issue.number);
           await this.doSpawn(repoPath, decision);
           continue;
         }
@@ -236,6 +251,12 @@ export class DrainService {
       console.warn(`[drain] archive failed for ${decision.sessionId}:`, err);
       return;
     }
+    // The PR is left OPEN for a human to merge, so the issue stays open and claimed.
+    // Mark the archive as a retire so onArchived KEEPS the claim — releasing it here
+    // would let another instance re-spawn an issue that already has a ready PR. The
+    // human merge auto-closes the issue (`Closes #N`), retiring the claim with it.
+    // Set before emitArchived so a synchronous onArchived sees it.
+    this.retainClaimOnArchive.add(decision.sessionId);
     this.deps.dropPrCache(decision.sessionId);
     this.deps.emitArchived(decision.sessionId);
   }
@@ -246,27 +267,39 @@ export class DrainService {
   ): Promise<void> {
     const forge = this.deps.resolveForge(repoPath);
     if (!forge) return;
+    const { number, url, title, body } = decision.issue;
+    // Claim the issue on the host BEFORE spawning. The active label is the only
+    // cross-instance signal, so stamp it first to shrink the window in which a
+    // second shepherd grabs the same issue. Best-effort: a claim failure (label
+    // API hiccup) must not stall the drain — we still spawn and lean on local
+    // dedup. (Re-)claiming is idempotent.
+    try {
+      await forge.addIssueLabel?.(number, ACTIVE_LABEL);
+    } catch (err) {
+      console.warn(`[drain] claim label for issue #${number} failed:`, err);
+    }
     try {
       const base = await forge.defaultBranch();
       await this.deps.service.create({
         repoPath,
         baseBranch: base,
-        prompt: decision.issue.title,
+        prompt: title,
         model: null,
         images: [],
         auto: true,
-        issueRef: {
-          number: decision.issue.number,
-          url: decision.issue.url,
-          title: decision.issue.title,
-          body: decision.issue.body,
-        },
+        issueRef: { number, url, title, body },
       });
       // The new auto session appears in the next buildState → counts toward the
       // cap AND mappedIssueNumbers, so the loop won't re-spawn this issue and
       // naturally stops at cap.
     } catch (err) {
-      console.warn(`[drain] spawn failed for issue #${decision.issue.number}:`, err);
+      console.warn(`[drain] spawn failed for issue #${number}:`, err);
+      // Release the claim so the unspawned issue returns to the pool (best-effort).
+      try {
+        await forge.removeIssueLabel?.(number, ACTIVE_LABEL);
+      } catch (rerr) {
+        console.warn(`[drain] release label for issue #${number} failed:`, rerr);
+      }
     }
   }
 
@@ -277,56 +310,94 @@ export class DrainService {
     const s = this.deps.store.get(id);
     if (!s || !s.auto) return; // drain only manages auto sessions
     if (git.state === "merged") {
-      // Reap on any observed merge — drain-initiated retire, manual, or GitHub
-      // auto-merge all land here via the pr-poller. Do NOT pump here: the
-      // emitted session:archived routes to onArchived, the single advance path.
-      // Best-effort: the merge is done, so a close failure must not block teardown.
-      // closeIssue is idempotent, so this path (human merges a still-tracked session)
-      // and the doRetire path (drain retires first, then human merges — poller no longer
-      // tracks it) are independent and safe.
-      if (s.issueNumber != null) {
-        try {
-          await this.deps.resolveForge(s.repoPath)?.closeIssue?.(s.issueNumber);
-        } catch (err) {
-          console.warn(`[drain] closeIssue #${s.issueNumber} failed for ${id}:`, err);
-        }
-      }
-      this.deps.service.archive(id);
-      this.deps.dropPrCache(id);
-      this.deps.emitArchived(id);
+      await this.reapMerged(s, id);
       return;
     }
     // open/green/other → the retire gate may now fire (e.g. CI just went green).
     // Skip drain-disabled repos — no spawn/retire there, just WS noise.
-    if (!this.deps.store.getRepoConfig(s.repoPath).autoDrainEnabled) return;
-    await this.pump(s.repoPath);
+    await this.pumpIfEnabled(s.repoPath);
+  }
+
+  /** Reap a session whose PR was observed merged out-of-band — a human or GitHub
+   *  auto-merge the poller STILL tracked (the retire path drops the pr-cache first,
+   *  so this fires only for a merge that beat the retire). Closes the backlog issue
+   *  and settles its claim, then archives. Does NOT pump — the emitted
+   *  session:archived routes to onArchived, the single advance path. Best-effort:
+   *  the merge is done, so a close failure must not block teardown. */
+  private async reapMerged(s: Session, id: string): Promise<void> {
+    let closed = false; // true ONLY after a closeIssue actually lands
+    if (s.issueNumber != null) {
+      const forge = this.deps.resolveForge(s.repoPath);
+      // Gate on the method existing: a forge without closeIssue leaves the issue
+      // OPEN, so we must not treat it as closed (see the claim-retain note below).
+      if (forge?.closeIssue) {
+        try {
+          await forge.closeIssue(s.issueNumber);
+          closed = true;
+        } catch (err) {
+          console.warn(`[drain] closeIssue #${s.issueNumber} failed for ${id}:`, err);
+        }
+      }
+      // The issue closed → its claim is moot, so let onArchived drop the now-stale
+      // label. If it did NOT close (close failed, or no closeIssue method), retain
+      // the claim: the issue is still open and merged, so the label is what stops
+      // any instance re-spawning already-merged work.
+      if (!closed) this.retainClaimOnArchive.add(id);
+    }
+    this.deps.service.archive(id);
+    this.deps.dropPrCache(id);
+    this.deps.emitArchived(id);
   }
 
   /** A session was archived (retired auto session, or a manual archive). The
    *  single advance step: a freed slot lets the next candidate spawn. Skips
    *  drain-disabled repos so a manual archive there doesn't pump/emit. */
   async onArchived(id: string): Promise<void> {
+    const retainClaim = this.retainClaimOnArchive.delete(id); // true → retire, or merged-but-close-failed
     const s = this.deps.store.get(id); // archived rows still return → repoPath available
     if (!s) return;
-    if (!this.deps.store.getRepoConfig(s.repoPath).autoDrainEnabled) return;
-    await this.pump(s.repoPath);
+    // Drop the host claim label for an auto session UNLESS it was retired (ready PR
+    // still open) or merged-but-close-failed (issue still open) — those keep the
+    // claim. The remaining case is an ABANDON (manual archive of a session that never
+    // retired), which re-queues the issue. NOTE: the abandoning instance still maps
+    // this issue via its own archived session, so the release re-queues it for OTHER
+    // instances — and for this one only after its archived session is pruned.
+    // Unconditional of the drain toggle (mirrors onGit's closeIssue) so a
+    // disabled-mid-flight session still frees its claim. Non-auto sessions never set
+    // a claim, so they're skipped.
+    if (!retainClaim && s.auto && s.issueNumber != null) {
+      try {
+        await this.deps.resolveForge(s.repoPath)?.removeIssueLabel?.(s.issueNumber, ACTIVE_LABEL);
+      } catch (err) {
+        console.warn(`[drain] release label #${s.issueNumber} for ${id} failed:`, err);
+      }
+    }
+    await this.pumpIfEnabled(s.repoPath);
   }
 
   /** A session's status changed. Pump its repo, skipping drain-disabled repos. */
   async onStatus(id: string): Promise<void> {
-    const s = this.deps.store.get(id);
-    if (!s) return;
-    if (!this.deps.store.getRepoConfig(s.repoPath).autoDrainEnabled) return;
-    await this.pump(s.repoPath);
+    await this.pumpForSession(id);
   }
 
   /** A critic verdict landed for a session. A clean verdict for the current head
    *  may now unblock the retire gate — pump promptly rather than waiting for the tick. */
   async onReview(id: string): Promise<void> {
+    await this.pumpForSession(id);
+  }
+
+  /** Pump a session's repo, skipping when the session is gone. The shared body of
+   *  the status/review event handlers. */
+  private async pumpForSession(id: string): Promise<void> {
     const s = this.deps.store.get(id);
     if (!s) return;
-    if (!this.deps.store.getRepoConfig(s.repoPath).autoDrainEnabled) return;
-    await this.pump(s.repoPath);
+    await this.pumpIfEnabled(s.repoPath);
+  }
+
+  /** Pump a repo unless its drain toggle is off — the shared tail of every handler. */
+  private async pumpIfEnabled(repoPath: string): Promise<void> {
+    if (!this.deps.store.getRepoConfig(repoPath).autoDrainEnabled) return;
+    await this.pump(repoPath);
   }
 
   /** Periodic sweep (~30s): catches newly-labeled issues + resumed usage windows. */

--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -319,11 +319,20 @@ export class GiteaForge implements GitForge {
   async addIssueLabel(issueNumber: number, label: string): Promise<void> {
     let id = await this.findLabelId(label);
     if (id == null) {
-      const created = (await this.req("POST", `/api/v1/repos/${this.slug}/labels`, {
-        name: label,
-        color: "#5319e7",
-      })) as { id: number };
-      id = created.id;
+      // Create the label — but a concurrent first-ever claim on another instance
+      // may have created it between our lookup and now (409 duplicate name). Re-
+      // resolve on any create failure rather than throwing the claim out; only a
+      // genuine failure (still absent) propagates. Mirrors GithubForge.ensureLabel.
+      try {
+        const created = (await this.req("POST", `/api/v1/repos/${this.slug}/labels`, {
+          name: label,
+          color: "#5319e7",
+        })) as { id: number };
+        id = created.id;
+      } catch (err) {
+        id = await this.findLabelId(label);
+        if (id == null) throw err;
+      }
     }
     await this.req("POST", `/api/v1/repos/${this.slug}/issues/${issueNumber}/labels`, {
       labels: [id],

--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -299,6 +299,43 @@ export class GiteaForge implements GitForge {
     await this.req("PATCH", `/api/v1/repos/${this.slug}/pulls/${prNumber}`, { body: newBody });
   }
 
+  /** Gitea's issue-label API keys on numeric label IDs, so resolve (or create) the
+   *  label by name first. Paginated, unlike listIssues' bounded truncation: missing
+   *  an existing label here would make addIssueLabel attempt a duplicate create
+   *  (409), so walk every page (50-page / 5000-label backstop against a runaway). */
+  private async findLabelId(name: string): Promise<number | null> {
+    for (let page = 1; page <= 50; page++) {
+      const batch = ((await this.req(
+        "GET",
+        `/api/v1/repos/${this.slug}/labels?limit=100&page=${page}`,
+      )) ?? []) as Array<{ id: number; name: string }>;
+      const found = batch.find((l) => l.name === name);
+      if (found) return found.id;
+      if (batch.length < 100) break; // short page → last page
+    }
+    return null;
+  }
+
+  async addIssueLabel(issueNumber: number, label: string): Promise<void> {
+    let id = await this.findLabelId(label);
+    if (id == null) {
+      const created = (await this.req("POST", `/api/v1/repos/${this.slug}/labels`, {
+        name: label,
+        color: "#5319e7",
+      })) as { id: number };
+      id = created.id;
+    }
+    await this.req("POST", `/api/v1/repos/${this.slug}/issues/${issueNumber}/labels`, {
+      labels: [id],
+    });
+  }
+
+  async removeIssueLabel(issueNumber: number, label: string): Promise<void> {
+    const id = await this.findLabelId(label);
+    if (id == null) return; // never defined → nothing applied to remove
+    await this.req("DELETE", `/api/v1/repos/${this.slug}/issues/${issueNumber}/labels/${id}`);
+  }
+
   async redeploy(o: RedeployInput): Promise<void> {
     await this.req(
       "POST",

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -414,6 +414,39 @@ export class GithubForge implements GitForge {
     this.run(["pr", "edit", String(prNumber), "--repo", this.slug, "--body", newBody]);
   }
 
+  async addIssueLabel(issueNumber: number, label: string): Promise<void> {
+    // `gh issue edit --add-label` 422s on a label the repo hasn't defined. The
+    // operator creates the opt-in label, but the claim label is ours — create it
+    // first (ignoring "already exists") so the claim doesn't fail on a fresh repo.
+    this.ensureLabel(label);
+    this.run(["issue", "edit", String(issueNumber), "--repo", this.slug, "--add-label", label]);
+  }
+
+  async removeIssueLabel(issueNumber: number, label: string): Promise<void> {
+    this.run(["issue", "edit", String(issueNumber), "--repo", this.slug, "--remove-label", label]);
+  }
+
+  /** Best-effort create-if-missing for a repo label. No `--force`, so an existing
+   *  label the operator may have recolored is left untouched; the throw on "already
+   *  exists" is swallowed and a real failure surfaces on the subsequent --add-label. */
+  private ensureLabel(label: string): void {
+    try {
+      this.run([
+        "label",
+        "create",
+        label,
+        "--repo",
+        this.slug,
+        "--color",
+        "5319e7",
+        "--description",
+        "Claimed by a Shepherd auto-drain session",
+      ]);
+    } catch {
+      // already exists (or a transient gh error) — ignore.
+    }
+  }
+
   async redeploy(o: RedeployInput): Promise<void> {
     this.run(["workflow", "run", o.workflow, "--repo", this.slug, "--ref", o.ref]);
   }

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -198,6 +198,14 @@ export interface GitForge {
    *  keyword for that issue is already present. Best-effort; optional (hosts
    *  without a PR-body edit API omit it). */
   ensureIssueLink?(prNumber: number, issueNumber: number): Promise<void>;
+  /** Stamp a label on an issue, creating it on the host if absent (best-effort; the
+   *  drain claims a backlog issue with `ACTIVE_LABEL` when it spawns, so a second
+   *  shepherd instance skips it). Optional: hosts without a label API omit it and
+   *  claims degrade to single-instance local dedup. */
+  addIssueLabel?(issueNumber: number, label: string): Promise<void>;
+  /** Remove a label from an issue (best-effort; releases the drain's claim when an
+   *  auto session is abandoned, returning the issue to the pool). Optional. */
+  removeIssueLabel?(issueNumber: number, label: string): Promise<void>;
 }
 
 /** Per-host configuration loaded from ~/.shepherd/forges.json. */

--- a/test/drain-core.test.ts
+++ b/test/drain-core.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test";
-import { computeNext, selectCandidates, PRIORITY_LABEL } from "../src/drain-core";
+import { computeNext, selectCandidates, PRIORITY_LABEL, ACTIVE_LABEL } from "../src/drain-core";
 import type { DrainRepoState, AutoSessionView } from "../src/drain-core";
 import type { Issue, GitState } from "../src/forge/types";
 
@@ -301,5 +301,21 @@ describe("selectCandidates", () => {
   test("a priority label without the auto label is ignored", () => {
     const out = selectCandidates([issue(3, [PRIORITY_LABEL])], AUTO_LABEL);
     expect(out).toEqual([]);
+  });
+
+  test("claimed (active-labeled) issues are excluded — another instance has them", () => {
+    const out = selectCandidates(
+      [issue(1), issue(2, [AUTO_LABEL, ACTIVE_LABEL]), issue(3)],
+      AUTO_LABEL,
+    );
+    expect(out.map((i) => i.number)).toEqual([1, 3]);
+  });
+
+  test("a claimed priority issue is skipped, ceding it to the claiming instance", () => {
+    const out = selectCandidates(
+      [issue(5), issue(2, [AUTO_LABEL, PRIORITY_LABEL, ACTIVE_LABEL])],
+      AUTO_LABEL,
+    );
+    expect(out.map((i) => i.number)).toEqual([5]);
   });
 });

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
 import { DrainService, type DrainStatus } from "../src/drain";
+import { ACTIVE_LABEL } from "../src/drain-core";
 import { SessionStore } from "../src/store";
 import type { GitForge, GitState, Issue, MergeMethod, PrStatus } from "../src/forge/types";
 import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
@@ -26,6 +27,8 @@ interface ForgeRec {
   links: { prNumber: number; issueNumber: number }[];
   listIssuesCalls: number;
   closedIssues: number[];
+  added: { number: number; label: string }[];
+  removed: { number: number; label: string }[];
 }
 
 function fakeForge(
@@ -36,6 +39,8 @@ function fakeForge(
     listIssues?: () => Promise<Issue[]>;
     closeIssue?: (n: number) => Promise<void>;
     ensureIssueLink?: (prNumber: number, issueNumber: number) => Promise<void>;
+    addIssueLabel?: (n: number, label: string) => Promise<void>;
+    omitCloseIssue?: boolean;
   } = {},
 ): GitForge {
   return {
@@ -58,13 +63,23 @@ function fakeForge(
     },
     redeploy: async () => {},
     postReview: async () => ({}),
-    closeIssue: async (issueNumber: number) => {
-      rec.closedIssues.push(issueNumber);
-      if (opts.closeIssue) await opts.closeIssue(issueNumber);
-    },
+    // omitCloseIssue models a forge that doesn't implement the optional method.
+    closeIssue: opts.omitCloseIssue
+      ? undefined
+      : async (issueNumber: number) => {
+          rec.closedIssues.push(issueNumber);
+          if (opts.closeIssue) await opts.closeIssue(issueNumber);
+        },
     ensureIssueLink: async (prNumber: number, issueNumber: number) => {
       rec.links.push({ prNumber, issueNumber });
       if (opts.ensureIssueLink) await opts.ensureIssueLink(prNumber, issueNumber);
+    },
+    addIssueLabel: async (number: number, label: string) => {
+      if (opts.addIssueLabel) await opts.addIssueLabel(number, label);
+      rec.added.push({ number, label });
+    },
+    removeIssueLabel: async (number: number, label: string) => {
+      rec.removed.push({ number, label });
     },
   };
 }
@@ -92,6 +107,10 @@ function makeHarness(
     listIssuesImpl?: () => Promise<Issue[]>;
     archiveImpl?: (id: string) => number;
     onArchived?: (h: Harness, id: string) => void;
+    addIssueLabelImpl?: (n: number, label: string) => Promise<void>;
+    closeIssueImpl?: (n: number) => Promise<void>;
+    omitCloseIssue?: boolean;
+    createImpl?: () => Promise<void>;
   } = {},
 ): Harness {
   const store = new SessionStore(":memory:");
@@ -106,10 +125,20 @@ function makeHarness(
     usageCeilingPct: opts.usageCeilingPct ?? 80,
   });
 
-  const forgeRec: ForgeRec = { merges: [], links: [], listIssuesCalls: 0, closedIssues: [] };
+  const forgeRec: ForgeRec = {
+    merges: [],
+    links: [],
+    listIssuesCalls: 0,
+    closedIssues: [],
+    added: [],
+    removed: [],
+  };
   const forge = fakeForge(opts.issues ?? [], forgeRec, {
     merge: opts.mergeImpl,
     listIssues: opts.listIssuesImpl,
+    addIssueLabel: opts.addIssueLabelImpl,
+    closeIssue: opts.closeIssueImpl,
+    omitCloseIssue: opts.omitCloseIssue,
   });
 
   const prCache: Record<string, GitState> = {};
@@ -123,6 +152,7 @@ function makeHarness(
   const service = {
     create: async (input: CreateSessionInput): Promise<Session> => {
       creates.push(input);
+      if (opts.createImpl) await opts.createImpl();
       return store.create({
         name: "auto",
         prompt: input.prompt,
@@ -603,7 +633,14 @@ test("tick + snapshot over repos: only drain-enabled repo is acted on and report
     usageCeilingPct: 80,
   });
 
-  const forgeRec: ForgeRec = { merges: [], links: [], listIssuesCalls: 0, closedIssues: [] };
+  const forgeRec: ForgeRec = {
+    merges: [],
+    links: [],
+    listIssuesCalls: 0,
+    closedIssues: [],
+    added: [],
+    removed: [],
+  };
   const forge = fakeForge([issue(1)], forgeRec);
   const creates: CreateSessionInput[] = [];
   const statuses: DrainStatus[] = [];
@@ -765,4 +802,180 @@ test("queue: [] when drain disabled, never hits the forge", async () => {
   const q = await h.drain.queue(REPO);
   expect(q).toEqual([]);
   expect(h.forgeRec.listIssuesCalls).toBe(0);
+});
+
+// ── claim-label coordination (multi-instance) ───────────────────────────────────
+
+test("spawn claims the issue: stamps ACTIVE_LABEL on the host", async () => {
+  const h = makeHarness({ maxAuto: 1, issues: [issue(1)] });
+  await h.drain.pump(REPO);
+  expect(h.creates).toHaveLength(1);
+  expect(h.forgeRec.added).toEqual([{ number: 1, label: ACTIVE_LABEL }]);
+});
+
+test("spawn failure releases the claim so the issue returns to the pool", async () => {
+  const h = makeHarness({
+    maxAuto: 1,
+    issues: [issue(1)],
+    createImpl: async () => {
+      throw new Error("create boom");
+    },
+  });
+  await h.drain.pump(REPO);
+  // claimed, then released on the create throw; no session persisted
+  expect(h.forgeRec.added.some((a) => a.number === 1 && a.label === ACTIVE_LABEL)).toBe(true);
+  expect(h.forgeRec.removed.some((r) => r.number === 1 && r.label === ACTIVE_LABEL)).toBe(true);
+  expect(h.store.list().filter((s) => s.status !== "archived")).toHaveLength(0);
+});
+
+test("retire KEEPS the claim: a ready PR is left open, so the issue stays claimed until a human merges", async () => {
+  const advances: Promise<void>[] = [];
+  const h = makeHarness({
+    maxAuto: 1,
+    issues: [],
+    onArchived: (hh, id) => advances.push(hh.drain.onArchived(id)),
+  });
+  const s = h.store.create({
+    name: "auto",
+    prompt: "p",
+    repoPath: REPO,
+    baseBranch: "main",
+    branch: "shepherd/auto-7",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: true,
+    issueNumber: 7,
+  });
+  h.prCache[s.id] = openGreen(7);
+  h.setReview(s.id, "commented", "sha-7");
+  await h.drain.pump(REPO);
+  await Promise.all(advances);
+  // retired (archived + link ensured), but the claim is NOT released — the open PR's
+  // issue must stay claimed so no instance re-spawns it before the human merges.
+  expect(h.store.get(s.id)?.status).toBe("archived");
+  expect(h.forgeRec.links).toEqual([{ prNumber: 7, issueNumber: 7 }]);
+  expect(h.forgeRec.removed).toHaveLength(0);
+});
+
+test("abandon (manual archive of an auto session) releases the claim → re-queue", async () => {
+  const h = makeHarness({ maxAuto: 1, issues: [] });
+  const s = h.store.create({
+    name: "auto",
+    prompt: "p",
+    repoPath: REPO,
+    baseBranch: "main",
+    branch: "shepherd/auto-5",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: true,
+    issueNumber: 5,
+  });
+  h.store.archive(s.id);
+  await h.drain.onArchived(s.id);
+  expect(h.forgeRec.removed).toEqual([{ number: 5, label: ACTIVE_LABEL }]);
+});
+
+test("out-of-band clean merge: closes the issue and drops the now-moot claim (so a reopen isn't skipped)", async () => {
+  const advances: Promise<void>[] = [];
+  const h = makeHarness({
+    maxAuto: 1,
+    issues: [],
+    onArchived: (hh, id) => advances.push(hh.drain.onArchived(id)),
+  });
+  const s = h.store.create({
+    name: "auto",
+    prompt: "p",
+    repoPath: REPO,
+    baseBranch: "main",
+    branch: "shepherd/auto-7",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: true,
+    issueNumber: 7,
+  });
+  await h.drain.onGit(s.id, { ...openGreen(7), state: "merged" });
+  await Promise.all(advances);
+  expect(h.forgeRec.closedIssues).toEqual([7]); // merged → closed
+  expect(h.forgeRec.removed).toEqual([{ number: 7, label: ACTIVE_LABEL }]); // claim cleaned up
+});
+
+test("merge with a FAILED close retains the claim — a still-open merged issue can't be re-spawned", async () => {
+  const advances: Promise<void>[] = [];
+  const h = makeHarness({
+    maxAuto: 1,
+    issues: [],
+    closeIssueImpl: async () => {
+      throw new Error("close boom");
+    },
+    onArchived: (hh, id) => advances.push(hh.drain.onArchived(id)),
+  });
+  const s = h.store.create({
+    name: "auto",
+    prompt: "p",
+    repoPath: REPO,
+    baseBranch: "main",
+    branch: "shepherd/auto-7",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: true,
+    issueNumber: 7,
+  });
+  await h.drain.onGit(s.id, { ...openGreen(7), state: "merged" });
+  await Promise.all(advances);
+  expect(h.forgeRec.removed).toHaveLength(0); // claim kept: close failed, issue still open
+});
+
+test("merge on a forge WITHOUT closeIssue retains the claim — the issue stays open", async () => {
+  const advances: Promise<void>[] = [];
+  const h = makeHarness({
+    maxAuto: 1,
+    issues: [],
+    omitCloseIssue: true, // forge omits the optional closeIssue method
+    onArchived: (hh, id) => advances.push(hh.drain.onArchived(id)),
+  });
+  const s = h.store.create({
+    name: "auto",
+    prompt: "p",
+    repoPath: REPO,
+    baseBranch: "main",
+    branch: "shepherd/auto-7",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: true,
+    issueNumber: 7,
+  });
+  await h.drain.onGit(s.id, { ...openGreen(7), state: "merged" });
+  await Promise.all(advances);
+  expect(h.forgeRec.closedIssues).toHaveLength(0); // never closed (no method)
+  expect(h.forgeRec.removed).toHaveLength(0); // claim kept: issue is still open
+});
+
+test("archiving a NON-auto session never touches labels", async () => {
+  const h = makeHarness({ maxAuto: 1, issues: [] });
+  const s = h.store.create({
+    name: "manual",
+    prompt: "p",
+    repoPath: REPO,
+    baseBranch: "main",
+    branch: "feature/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: false,
+    issueNumber: 5,
+  });
+  h.store.archive(s.id);
+  await h.drain.onArchived(s.id);
+  expect(h.forgeRec.removed).toHaveLength(0);
 });

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -416,6 +416,79 @@ test("GiteaForge.closeIssue: PATCHes the issue state to closed", async () => {
   expect(patch.body).toEqual({ state: "closed" });
 });
 
+test("GiteaForge.addIssueLabel: resolves the label id by name, then POSTs it", async () => {
+  const { fn, calls } = fakeFetch({
+    "GET /api/v1/repos/team/proj/labels?limit=100&page=1": {
+      json: [
+        { id: 11, name: "bug" },
+        { id: 42, name: "shepherd:active" },
+      ],
+    },
+    "POST /api/v1/repos/team/proj/issues/7/labels": { status: 200, json: {} },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await forge.addIssueLabel(7, "shepherd:active");
+  const post = calls.find((c) => c.method === "POST")!;
+  expect(post.url).toContain("/issues/7/labels");
+  expect(post.body).toEqual({ labels: [42] });
+});
+
+test("GiteaForge.addIssueLabel: creates the label when the repo lacks it", async () => {
+  const { fn, calls } = fakeFetch({
+    "GET /api/v1/repos/team/proj/labels?limit=100&page=1": { json: [] },
+    "POST /api/v1/repos/team/proj/labels": {
+      status: 201,
+      json: { id: 99, name: "shepherd:active" },
+    },
+    "POST /api/v1/repos/team/proj/issues/7/labels": { status: 200, json: {} },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await forge.addIssueLabel(7, "shepherd:active");
+  const create = calls.find((c) => c.method === "POST" && c.url.endsWith("/labels"))!;
+  expect(create.body).toEqual({ name: "shepherd:active", color: "#5319e7" });
+  const apply = calls.find((c) => c.method === "POST" && c.url.includes("/issues/7/labels"))!;
+  expect(apply.body).toEqual({ labels: [99] });
+});
+
+test("GiteaForge.addIssueLabel: paginates past a full first page to find the label (no spurious create)", async () => {
+  const firstPage = Array.from({ length: 100 }, (_, i) => ({ id: i + 1, name: `label-${i}` }));
+  const { fn, calls } = fakeFetch({
+    "GET /api/v1/repos/team/proj/labels?limit=100&page=1": { json: firstPage },
+    "GET /api/v1/repos/team/proj/labels?limit=100&page=2": {
+      json: [{ id: 777, name: "shepherd:active" }],
+    },
+    "POST /api/v1/repos/team/proj/issues/7/labels": { status: 200, json: {} },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await forge.addIssueLabel(7, "shepherd:active");
+  // resolved on page 2 → no label-create POST (the repo /labels collection), apply uses the found id
+  expect(calls.some((c) => c.method === "POST" && c.url.endsWith("/proj/labels"))).toBe(false);
+  const apply = calls.find((c) => c.method === "POST" && c.url.includes("/issues/7/labels"))!;
+  expect(apply.body).toEqual({ labels: [777] });
+});
+
+test("GiteaForge.removeIssueLabel: DELETEs the resolved label id off the issue", async () => {
+  const { fn, calls } = fakeFetch({
+    "GET /api/v1/repos/team/proj/labels?limit=100&page=1": {
+      json: [{ id: 42, name: "shepherd:active" }],
+    },
+    "DELETE /api/v1/repos/team/proj/issues/7/labels/42": { status: 204 },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await forge.removeIssueLabel(7, "shepherd:active");
+  const del = calls.find((c) => c.method === "DELETE")!;
+  expect(del.url).toContain("/issues/7/labels/42");
+});
+
+test("GiteaForge.removeIssueLabel: no-op when the repo never defined the label", async () => {
+  const { fn, calls } = fakeFetch({
+    "GET /api/v1/repos/team/proj/labels?limit=100&page=1": { json: [] },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await forge.removeIssueLabel(7, "shepherd:active");
+  expect(calls.some((c) => c.method === "DELETE")).toBe(false);
+});
+
 test("GiteaForge.ensureIssueLink: appends Closes #N when body has no link", async () => {
   const { fn, calls } = fakeFetch({
     "GET /api/v1/repos/team/proj/pulls/7": { json: { body: "Some PR description" } },

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -450,6 +450,42 @@ test("GiteaForge.addIssueLabel: creates the label when the repo lacks it", async
   expect(apply.body).toEqual({ labels: [99] });
 });
 
+test("GiteaForge.addIssueLabel: a concurrent create (409) re-resolves the id instead of throwing", async () => {
+  // First lookup misses; a sibling instance creates the label; our create 409s; we
+  // re-resolve and apply the id another instance just minted.
+  const calls: { method: string; url: string; body: unknown }[] = [];
+  let labelLookups = 0;
+  const fn = (async (input: string | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    calls.push({ method, url, body });
+    const json = (v: unknown, status = 200) =>
+      new Response(JSON.stringify(v), { status, headers: { "content-type": "application/json" } });
+    if (method === "GET" && url.includes("/labels?limit=")) {
+      // miss on the first lookup, hit on the post-conflict re-resolve
+      return json(labelLookups++ === 0 ? [] : [{ id: 55, name: "shepherd:active" }]);
+    }
+    if (method === "POST" && url.endsWith("/proj/labels")) return json({ message: "exists" }, 409);
+    if (method === "POST" && url.includes("/issues/7/labels")) return json({});
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await forge.addIssueLabel(7, "shepherd:active"); // must not throw
+  const apply = calls.find((c) => c.method === "POST" && c.url.includes("/issues/7/labels"))!;
+  expect(apply.body).toEqual({ labels: [55] }); // re-resolved id applied
+});
+
+test("GiteaForge.addIssueLabel: a create failure with the label still absent propagates", async () => {
+  const { fn } = fakeFetch({
+    "GET /api/v1/repos/team/proj/labels?limit=100&page=1": { json: [] },
+    "POST /api/v1/repos/team/proj/labels": { status: 500, json: { message: "boom" } },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await expect(forge.addIssueLabel(7, "shepherd:active")).rejects.toThrow();
+});
+
 test("GiteaForge.addIssueLabel: paginates past a full first page to find the label (no spurious create)", async () => {
   const firstPage = Array.from({ length: 100 }, (_, i) => ({ id: i + 1, name: `label-${i}` }));
   const { fn, calls } = fakeFetch({

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -177,6 +177,49 @@ test("GithubForge.redeploy: invokes gh workflow run with ref", async () => {
   expect(args).toContain("main");
 });
 
+test("GithubForge.addIssueLabel: ensures the label exists, then adds it", async () => {
+  const { run, calls } = fakeRunner({});
+  const forge = new GithubForge("o/r", {}, run);
+  await forge.addIssueLabel(7, "shepherd:active");
+  expect(calls[0]!.slice(0, 3)).toEqual(["label", "create", "shepherd:active"]);
+  expect(calls[1]).toEqual([
+    "issue",
+    "edit",
+    "7",
+    "--repo",
+    "o/r",
+    "--add-label",
+    "shepherd:active",
+  ]);
+});
+
+test("GithubForge.addIssueLabel: a pre-existing label (label create throws) still adds", async () => {
+  const calls: string[][] = [];
+  const run = (args: string[]): string => {
+    calls.push(args);
+    if (args[0] === "label" && args[1] === "create") throw new Error("label already exists");
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+  await forge.addIssueLabel(7, "shepherd:active"); // must not throw
+  expect(calls.some((c) => c[0] === "issue" && c.includes("--add-label"))).toBe(true);
+});
+
+test("GithubForge.removeIssueLabel: gh issue edit --remove-label", async () => {
+  const { run, calls } = fakeRunner({});
+  const forge = new GithubForge("o/r", {}, run);
+  await forge.removeIssueLabel(7, "shepherd:active");
+  expect(calls[0]).toEqual([
+    "issue",
+    "edit",
+    "7",
+    "--repo",
+    "o/r",
+    "--remove-label",
+    "shepherd:active",
+  ]);
+});
+
 test("GithubForge.kind + slug", () => {
   const forge = new GithubForge("o/r", {}, () => "");
   expect(forge.kind).toBe("github");


### PR DESCRIPTION
## What

Auto-drain **claims** an issue on the forge before working it, so multiple Shepherd instances draining the same repo don't take the same issue. Reworked onto the **retire model** (#309): the drain never merges, so the claim is **kept through retire** and released only on abandon.

- When the drain spawns an auto session, it stamps **`shepherd:active`** on the issue (creating the repo label if missing).
- `selectCandidates` excludes issues bearing `shepherd:active` — a second instance (or a restart) skips claimed work, and a retired-but-unmerged issue isn't re-spawned.

`shepherd:active` is a constant sibling to `shepherd:priority`, so every instance agrees on it without sharing config. The window is narrowed, not eliminated (two instances listing within the claim's set-up latency can still race); local dedup then prevents a single instance double-spawning.

## Claim lifecycle (retire model)

| Event | Claim label |
| --- | --- |
| Spawn | **added** before `service.create` |
| Spawn create fails | **removed** (issue returns to the pool) |
| **Retire** (ready PR left open for a human) | **kept** — the issue+PR stay open, so the claim is what stops any instance re-spawning it; the human merge auto-closes the issue (`Closes #N`, ensured by #309), retiring the claim with it |
| Out-of-band merge, clean close | issue closed → drop the now-moot label (so a reopen isn't permanently skipped) |
| Out-of-band merge, close FAILED / no `closeIssue` | **kept** — issue still open, claim guards already-merged work |
| Abandon (manual archive, never retired) | **removed** → re-queued for any instance |

Retire-vs-abandon is distinguished via a `retainClaimOnArchive` guard set populated in `doRetire` (and in `onGit` only for a merge whose close failed), consumed in `onArchived`.

## Notes

- New optional forge methods `addIssueLabel` / `removeIssueLabel`, implemented for **GitHub** (`gh label create` + `gh issue edit --add/--remove-label`) and **Gitea** (resolve/create label id, then POST/DELETE issue labels). All best-effort: a label-API hiccup never stalls the drain.
- Per-pump `attemptedSpawn` guard so a persistently-failing spawn no longer re-loops to the iteration cap (and no longer churns its claim label each iteration).
- Extracted `reapMerged` / `pumpForSession` / `pumpIfEnabled` to keep `onGit` under the complexity bar and drop the `onStatus`/`onReview` clone (delta Fallow audit clean).
- Server-only change; no UI/i18n strings.

## Tests

`drain-core` (claimed-issue exclusion), `drain` (claim on spawn, release on create-failure, **retire keeps the claim**, release on abandon, clean-merge drops it, close-fail / no-closeIssue retain, non-auto archive untouched), `forge/github`, `forge/gitea` (label create-if-missing, pagination). Full root suite green (987 pass), tsc + eslint + prettier + delta Fallow audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)