### PR TITLE
feat(drain): autopilot never merges — retire ready PRs for human merge

### DIFF
--- a/docs/superpowers/specs/2026-06-03-autopilot-never-merges-design.md
+++ b/docs/superpowers/specs/2026-06-03-autopilot-never-merges-design.md
@@ -1,0 +1,196 @@
+# Autopilot never performs merges
+
+**Date:** 2026-06-03
+**Status:** Design — pending implementation plan
+
+## Problem
+
+The self-draining work queue ("autopilot" / backlog drain, PR #300) currently
+**performs merges**. When an auto-spawned session's PR is open + CI-green +
+critic-approved, the decision core (`drain-core.ts` `computeNext`) returns a
+`merge` decision and `DrainService.doMerge` (`drain.ts`) calls `forge.merge(...)`.
+That is the only autopilot merge path — `autopilot.ts` (pre-PR steering) never
+merges, and the `/api/sessions/:id/git/merge` + `/api/prs/merge` endpoints are
+human-triggered.
+
+The merge decision must be **human-owned**. Autopilot should drive work all the
+way to a green, critic-approved PR and then **stop** — retire the agent, free the
+slot, and leave the merge to a human.
+
+## Goal
+
+Autopilot drives an auto-session to a green + critic-approved PR, then:
+
+1. **Never merges** — `forge.merge` is never invoked by the drain.
+2. **Retires the agent** — stops the herdr pane, removes the worktree, archives
+   the session (no idle-pane pile-up).
+3. **Frees the slot and keeps draining** — the archived session no longer counts
+   toward `maxAuto`, so the drain spawns the next backlog item. The whole backlog
+   drains into a pile of ready-to-merge PRs awaiting human merge.
+4. **Leaves a clean, mergeable PR** — discoverable in the backlog **PRs tab**;
+   merging it (in shepherd or on the forge directly) **auto-closes the linked
+   issue**, and a closed issue can never re-spawn.
+
+### Non-goals
+
+- Reviving a retired agent if CI later breaks or changes are requested after
+  handoff — the human re-engages manually.
+- Changing the manual merge endpoints or `autopilot.ts`.
+
+## Approach
+
+Replace the drain's `merge` action with a `retire` action: instead of merging a
+ready PR, **archive the session** (the existing post-merge teardown, minus the
+merge) and **guarantee the PR links its issue** so the eventual human merge
+auto-closes it.
+
+This is deliberately close to today's merge flow — it swaps `forge.merge` for
+`archive` and adds an issue-link guarantee. Archiving already removes the session
+from `autoSessions` (the cap basis), so the slot frees with no new flag, no new
+session status, and no kept-alive rows.
+
+### Why issue auto-close (not shepherd-observed close)
+
+Today the issue is closed by `drain.onGit`'s merged branch (`closeIssue`), which
+requires the pr-poller to still be watching the PR. Archiving drops the session
+from the poller, so an archived-then-merged PR would never be observed → issue
+leak + re-spawn after the 30-day session prune.
+
+Instead, we make the **PR body carry `Closes #N`**. The forge auto-closes the
+issue on merge with zero shepherd involvement, and a closed issue drops out of
+`listIssues` so it is never re-selected as a drain candidate — killing both the
+leak and the dedup problem at the source.
+
+Shepherd currently only appends the issue to the agent's *prompt* (`service.ts`),
+so whether the PR says `Closes #N` is up to the agent. We make it **guaranteed**:
+at retire time, shepherd ensures the PR body contains the closing keyword before
+archiving.
+
+## Components
+
+### 1. `src/drain-core.ts` — decision core
+
+- Remove the `{ kind: "merge"; sessionId; prNumber }` variant from
+  `DrainDecision`; add `{ kind: "retire"; sessionId; prNumber }`.
+- `computeNext`: step 1 ("merge gate") becomes the **retire gate** — the first
+  `mergeable()` session returns `{ kind: "retire", ... }` instead of
+  `{ kind: "merge", ... }`. Priority is unchanged (completing in-flight work beats
+  starting new work). All other steps (trouble → cap → usage → spawn) unchanged.
+- `mergeable()` predicate is **unchanged**: open + CI green + host-mergeable +
+  critic not blocking, and (critic on) a clean verdict for the current head. So
+  retire still happens only on a green, *approved* PR.
+- No cap/flag changes needed: archived sessions are already excluded from
+  `autoSessions` in `buildState`, so retiring frees the slot automatically.
+
+### 2. `src/drain.ts` — side-effect harness
+
+- Replace `doMerge` → `doRetire(repoPath, decision)`:
+  1. Look up the session; if it has an `issueNumber`, **best-effort** call
+     `forge.ensureIssueLink(prNumber, issueNumber)` (append `Closes #N` if
+     absent). On failure: `console.warn` and continue (don't block teardown).
+  2. `service.archive(sessionId)` — stops the pane (`herdr.stop`), removes the
+     worktree, archives the row.
+  3. `dropPrCache(sessionId)` + `emitArchived(sessionId)`.
+  - Do **not** call `closeIssue` here (the PR isn't merged yet; the link handles
+    closing on the human merge).
+- Remove the `merging` set and the per-pump `attemptedMerge` guard's merge
+  semantics. Archive is synchronous, so the retired session drops out of
+  `autoSessions` on the next `buildState` and can't be re-selected. Keep a small
+  per-pump `attemptedRetire` set as a backstop (mirrors the old guard).
+- `onGit` merged branch: **kept as-is** (still `closeIssue` + `archive` +
+  `dropPrCache` + `emitArchived`). It now only fires for the race where a human
+  merges a green auto-PR *before* the drain retires it (or a critic-off instant
+  path). Idempotent and harmless.
+- `onGit` open branch, `onArchived`, `onStatus`, `onReview`, `tick`: unchanged
+  except for dropping the removed `merging.delete(...)` / `merging.has(...)`
+  references.
+
+### 3. Forge — `src/forge/types.ts`, `github.ts`, `gitea.ts`
+
+New optional method on `GitForge`:
+
+```ts
+ensureIssueLink?(prNumber: number, issueNumber: number): Promise<void>;
+```
+
+Idempotent — appends a `Closes #N` line to the PR body only if no closing keyword
+for `#issueNumber` is already present.
+
+- **GitHub** (`github.ts`): read body via `gh pr view <n> --json body`; if it
+  lacks `Closes #N` (case-insensitive, allow `Close/Closes/Closed/Fix/Fixes/
+  Fixed/Resolve/Resolves/Resolved`), `gh pr edit <n> --repo <slug>
+  --body "<body>\n\nCloses #<n>"`.
+- **Gitea** (`gitea.ts`): `GET /repos/{slug}/pulls/{n}` for the body; if absent,
+  `PATCH` with the appended body.
+
+### 4. Persistence / status
+
+**None.** No new column, no new `SessionStatus`. Archiving handles slot-freeing
+and lifecycle exactly as the merge path did.
+
+### 5. UI
+
+- **No new UI.** Ready PRs surface in the existing backlog **PRs tab**
+  (`PrsPanel.svelte` / `PrRow.svelte`, backed by `forge.listPullRequests()` and
+  the `/api/prs/merge` action). The human merges from there or on the forge.
+- Auto-sessions archive on ready, so they leave the Herd session list — matching
+  today's behavior where merged auto-sessions archived out.
+- **No new i18n strings.** (`ensureIssueLink` writes the literal forge keyword
+  `Closes #N`, which is forge syntax, not app chrome — not translated.)
+
+### 6. Untouched
+
+- Manual merge endpoints `/api/sessions/:id/git/merge` and `/api/prs/merge` — the
+  human's merge paths.
+- `src/autopilot.ts` — pre-PR steering, never merged.
+- Per-repo config (`autoDrainEnabled`, `criticEnabled`, `maxAuto`, …) — unchanged;
+  `mergeMethod` still used by the manual merge endpoints.
+
+## Data flow (happy path)
+
+```
+backlog issue (autoLabel)
+  → drain spawns auto-session (issueRef in prompt)
+  → agent works, opens PR
+  → CI green + critic approves  ⇒  mergeable()
+  → computeNext → { kind: "retire" }
+  → doRetire:
+       ensureIssueLink(pr, issue)   // PR body now says "Closes #N"
+       service.archive(session)     // pane stopped, worktree removed, row archived
+       dropPrCache + emitArchived   // slot freed
+  → drain spawns next candidate (loop continues until cap/empty)
+  ...
+  → human merges the PR (PRs tab / shepherd UI / forge)
+  → forge auto-closes the linked issue
+  → closed issue drops from listIssues → never re-spawned
+```
+
+## Error handling & accepted edges
+
+- **`ensureIssueLink` fails** (forge error): logged, retire proceeds. The issue
+  won't auto-close → manual cleanup; rare.
+- **Ready PR left unmerged past the session prune** (30 days / 250 newest,
+  `SESSION_RETENTION_*`): the archived session is deleted, its issue mapping
+  vanishes, and the still-open labeled issue can re-spawn a duplicate. Accepted as
+  rare (operator is expected to clear ready PRs well within the window).
+- **Human merges before retire** (race): handled by the kept `onGit` merged branch
+  (closeIssue + archive). Idempotent.
+
+## Testing
+
+- `test/drain-core` (or equivalent): mergeable session yields `retire` (not
+  `merge`); after a retired (archived) session, the slot frees and the next
+  candidate spawns; trouble/cap/usage/spawn ordering preserved.
+- `test/drain`: `doRetire` calls `ensureIssueLink` + `service.archive` +
+  `dropPrCache` + `emitArchived`, and **never** calls `forge.merge` or
+  `closeIssue`; `onGit` merged still closes the issue (pre-retire race). Remove
+  all auto-merge assertions.
+- Forge: `ensureIssueLink` idempotency (no double-append; appends when missing).
+
+## Open questions
+
+- ensureIssueLink: append `Closes #N` even if the agent already wrote a *different*
+  closing ref? (Plan: only skip when a closing keyword for *this* issue is present;
+  otherwise append.) OK?
+- 30-day-unmerged re-spawn edge: leave as accepted, or add a cheap guard later
+  (e.g. skip candidates that already have an open PR linking them)? Default: leave.

--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -61,7 +61,7 @@ export interface DrainRepoState {
  *  ENABLED we additionally require a clean verdict for the CURRENT head — so a first-time
  *  auto PR can't be retired in the same CI-green tick the critic fires on, before it's posted
  *  a verdict. */
-function mergeable(s: AutoSessionView, criticEnabled: boolean): boolean {
+function readyToRetire(s: AutoSessionView, criticEnabled: boolean): boolean {
   const g = s.git;
   if (!g || g.state !== "open" || g.checks !== "success" || g.mergeable !== true || !g.number) {
     return false;
@@ -86,8 +86,8 @@ function mergeable(s: AutoSessionView, criticEnabled: boolean): boolean {
 export function computeNext(state: DrainRepoState): DrainDecision {
   if (!state.enabled) return { kind: "hold", reason: { code: "disabled" } };
 
-  // 1. Retire gate — first mergeable session wins (hand-off before we consider trouble).
-  const toRetire = state.autoSessions.find((s) => mergeable(s, state.criticEnabled));
+  // 1. Retire gate — first retire-ready session wins (hand-off before we consider trouble).
+  const toRetire = state.autoSessions.find((s) => readyToRetire(s, state.criticEnabled));
   if (toRetire) {
     return { kind: "retire", sessionId: toRetire.id, prNumber: toRetire.git!.number! };
   }

--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -6,7 +6,7 @@ import type { SessionStatus, ReviewDecision } from "./types";
  *  sibling so operators don't have to wire up two labels). */
 export const PRIORITY_LABEL = "shepherd:priority";
 
-/** Why the drain is holding rather than spawning/merging — surfaced on `drain:status`. */
+/** Why the drain is holding rather than spawning/retiring — surfaced on `drain:status`. */
 export interface HoldReason {
   code:
     | "disabled" // per-repo toggle off

--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -22,7 +22,7 @@ export interface HoldReason {
 
 export type DrainDecision =
   | { kind: "spawn"; issue: Issue }
-  | { kind: "merge"; sessionId: string; prNumber: number }
+  | { kind: "retire"; sessionId: string; prNumber: number }
   | { kind: "hold"; reason: HoldReason };
 
 /** The slice of an auto session the decision core reasons over. */
@@ -56,10 +56,11 @@ export interface DrainRepoState {
   candidates: Issue[];
 }
 
-/** True when this session's PR can be auto-merged: open, CI green, host-mergeable, and
- *  the critic is not blocking/uncertain. With the critic ENABLED we additionally require
- *  a clean verdict for the CURRENT head — so a first-time auto PR can't merge in the same
- *  CI-green tick the critic fires on, before it's posted a verdict. */
+/** True when this session's PR is ready to be retired / handed off for a human to merge:
+ *  open, CI green, host-mergeable, and the critic is not blocking/uncertain. With the critic
+ *  ENABLED we additionally require a clean verdict for the CURRENT head — so a first-time
+ *  auto PR can't be retired in the same CI-green tick the critic fires on, before it's posted
+ *  a verdict. */
 function mergeable(s: AutoSessionView, criticEnabled: boolean): boolean {
   const g = s.git;
   if (!g || g.state !== "open" || g.checks !== "success" || g.mergeable !== true || !g.number) {
@@ -78,20 +79,20 @@ function mergeable(s: AutoSessionView, criticEnabled: boolean): boolean {
  * highest-priority next action. The harness applies it, re-reads state, and calls
  * again — so spawns fill up to maxAuto and the loop ends on a `hold`.
  *
- * Priority: completing in-flight work (merge) beats starting new work (spawn), and
- * a green PR still merges even while a sibling agent is in trouble (trouble only
+ * Priority: completing in-flight work (retire/hand-off) beats starting new work (spawn), and
+ * a ready PR is still retired even while a sibling agent is in trouble (trouble only
  * halts NEW spawns).
  */
 export function computeNext(state: DrainRepoState): DrainDecision {
   if (!state.enabled) return { kind: "hold", reason: { code: "disabled" } };
 
-  // 1. Merge gate — first mergeable session wins (frees a slot before we consider trouble).
-  const toMerge = state.autoSessions.find((s) => mergeable(s, state.criticEnabled));
-  if (toMerge) {
-    return { kind: "merge", sessionId: toMerge.id, prNumber: toMerge.git!.number! };
+  // 1. Retire gate — first mergeable session wins (hand-off before we consider trouble).
+  const toRetire = state.autoSessions.find((s) => mergeable(s, state.criticEnabled));
+  if (toRetire) {
+    return { kind: "retire", sessionId: toRetire.id, prNumber: toRetire.git!.number! };
   }
 
-  // 2. Trouble → halt new spawns (in-flight agents keep running; merges above still pass).
+  // 2. Trouble → halt new spawns (in-flight agents keep running; retires above still pass).
   const blocked = state.autoSessions.find((s) => s.status === "blocked");
   if (blocked) return { kind: "hold", reason: { code: "blocked", detail: blocked.desig } };
   const cr = state.autoSessions.find((s) => s.reviewDecision === "changes_requested");

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -225,7 +225,17 @@ export class DrainService {
         );
       }
     }
-    this.deps.service.archive(decision.sessionId);
+    // Isolate teardown: a worktree-remove / archive throw must not abort the
+    // whole pump (which would skip remaining spawns/retires this tick). On
+    // failure we warn and defer — the session stays live and mergeable, so the
+    // next tick retries; we must NOT drop the pr-cache or emit "archived" for a
+    // session that didn't actually archive.
+    try {
+      this.deps.service.archive(decision.sessionId);
+    } catch (err) {
+      console.warn(`[drain] archive failed for ${decision.sessionId}:`, err);
+      return;
+    }
     this.deps.dropPrCache(decision.sessionId);
     this.deps.emitArchived(decision.sessionId);
   }

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -16,7 +16,7 @@ export interface DrainStatus {
   enabled: boolean;
   /** Held on trouble (blocked / changes_requested / error) — an operator banner. */
   paused: boolean;
-  /** The HoldReason.code when holding; null while active (spawning/merging). */
+  /** The HoldReason.code when holding; null while active (spawning/retiring). */
   reason: string | null;
   /** HoldReason.detail (a desig or pct) when holding; else null. */
   detail: string | null;
@@ -58,19 +58,20 @@ export interface DrainDeps {
 /**
  * Side-effect harness for the self-draining work queue. It assembles a
  * {@link DrainRepoState} per repo, calls the pure {@link computeNext} core, and
- * applies the returned decision (spawn / merge / hold), looping until the core
+ * applies the returned decision (spawn / retire / hold), looping until the core
  * holds. Driven by pr-poller events (onGit/onStatus), the archive event
  * (onArchived), and a periodic tick().
+ *
+ * The drain NEVER merges PRs. A ready session is retired (session archived,
+ * pane stopped, worktree removed) and its open, issue-linked PR is left for a
+ * human to merge. Archiving frees the concurrency slot so the next backlog item
+ * can spawn. When the human merges, the `Closes #N` link auto-closes the issue,
+ * preventing re-spawn.
  */
 export class DrainService {
   // repoPath lock held across the whole async pump — a concurrent pump for the
-  // same repo bails immediately so we never double-spawn/double-merge.
+  // same repo bails immediately so we never double-spawn/double-retire.
   private pumping = new Set<string>();
-  // sessionIds whose forge.merge SUCCEEDED but whose merged state the pr-poller
-  // hasn't reported yet. buildState forces their `git` to null so computeNext
-  // can't re-emit the merge (the PR still reads "open" until the next poll),
-  // while they STILL count toward the cap. Cleared in onGit when merged observed.
-  private merging = new Set<string>();
   private issuesCache = new Map<string, { issues: Issue[]; ts: number }>();
   private now: () => number;
   private issuesTtlMs: number;
@@ -85,7 +86,7 @@ export class DrainService {
   private async buildState(repoPath: string): Promise<DrainRepoState> {
     const cfg = this.deps.store.getRepoConfig(repoPath);
     // ALL sessions (incl. archived) for dedup: an issue drained once stays mapped via
-    // its archived session, so a merged-but-still-open issue isn't re-pulled (bounded by
+    // its archived session, so a retired-but-not-yet-merged issue isn't re-pulled (bounded by
     // session retention). autoSessions/cap use only the non-archived subset.
     const allRepoSessions = this.deps.store.list().filter((s) => s.repoPath === repoPath);
     const snapshot = this.deps.prCache.snapshot();
@@ -96,9 +97,7 @@ export class DrainService {
         desig: s.desig,
         issueNumber: s.issueNumber,
         status: s.status,
-        // mid-merge (merge fired, not yet observed merged) → null so computeNext
-        // won't re-emit the merge; the session still counts toward the cap.
-        git: this.merging.has(s.id) ? null : (snapshot[s.id] ?? null),
+        git: snapshot[s.id] ?? null,
         reviewDecision: this.deps.store.getReview(s.id)?.decision ?? null,
         reviewHeadSha: this.deps.store.getReview(s.id)?.headSha ?? null,
       }));
@@ -167,11 +166,12 @@ export class DrainService {
     if (this.pumping.has(repoPath)) return; // a drain for this repo is already running
     this.pumping.add(repoPath);
     try {
-      // Per-pump guard: each session is merge-attempted at most once per pump
-      // invocation. If a merge throws and computeNext re-selects the same session,
-      // we break instead of retrying — leaving it for the next pump/tick.
-      const attemptedMerge = new Set<string>();
-      // Hard iteration cap as a runaway backstop; each spawn/merge changes state,
+      // Per-pump guard: each session is retire-attempted at most once per pump
+      // invocation. service.archive takes effect immediately, so the next buildState
+      // sees the session as archived and won't re-select it — but if computeNext
+      // somehow re-selects the same session anyway, we break rather than loop.
+      const attemptedRetire = new Set<string>();
+      // Hard iteration cap as a runaway backstop; each spawn/retire changes state,
       // so a well-behaved drain ends on a hold well before this.
       for (let i = 0; i < 100; i++) {
         let decision: DrainDecision;
@@ -183,10 +183,10 @@ export class DrainService {
           console.warn(`[drain] pump iteration failed for ${repoPath}:`, err);
           break; // don't spin on a bad iteration
         }
-        if (decision.kind === "merge") {
-          if (attemptedMerge.has(decision.sessionId)) break; // already tried this pump; defer to next tick
-          attemptedMerge.add(decision.sessionId);
-          await this.doMerge(repoPath, decision);
+        if (decision.kind === "retire") {
+          if (attemptedRetire.has(decision.sessionId)) break; // already tried this pump; defer to next tick
+          attemptedRetire.add(decision.sessionId);
+          await this.doRetire(repoPath, decision);
           continue;
         }
         if (decision.kind === "spawn") {
@@ -200,25 +200,34 @@ export class DrainService {
     }
   }
 
-  private async doMerge(
+  /**
+   * Retire a ready session: ensure the PR links its issue (so the forge
+   * auto-closes the issue when a human merges), then archive the session
+   * (stops the pane, removes the worktree, marks the row archived). The open,
+   * linked PR is left for a human to merge — the drain never merges.
+   * Archiving frees the concurrency slot so the next backlog item can spawn.
+   */
+  private async doRetire(
     repoPath: string,
-    decision: Extract<DrainDecision, { kind: "merge" }>,
+    decision: Extract<DrainDecision, { kind: "retire" }>,
   ): Promise<void> {
     const forge = this.deps.resolveForge(repoPath);
     if (!forge) return;
-    // Claim BEFORE the await: the next loop iteration must see this session as
-    // mid-merge (git → null) so it can't double-merge the still-"open" PR.
-    this.merging.add(decision.sessionId);
-    try {
-      await forge.merge(decision.prNumber, { method: forge.mergeMethod, deleteBranch: true });
-      // SUCCESS → leave it in `merging`; onGit clears it when the merged state lands.
-      // The slot stays consumed until the pr-poller reports "merged" (frees on its signal, not self-recovering).
-      // Issue close happens in onGit's merged branch — covers drain-initiated AND out-of-band merges.
-    } catch (err) {
-      console.warn(`[drain] merge failed for ${decision.sessionId}:`, err);
-      // A throw (race / conflict) → remove so a later poll can retry the merge.
-      this.merging.delete(decision.sessionId);
+    const s = this.deps.store.get(decision.sessionId);
+    // Best-effort issue link: a failure must NOT block teardown.
+    if (s?.issueNumber != null) {
+      try {
+        await forge.ensureIssueLink?.(decision.prNumber, s.issueNumber);
+      } catch (err) {
+        console.warn(
+          `[drain] ensureIssueLink pr#${decision.prNumber} issue#${s.issueNumber} failed for ${decision.sessionId}:`,
+          err,
+        );
+      }
     }
+    this.deps.service.archive(decision.sessionId);
+    this.deps.dropPrCache(decision.sessionId);
+    this.deps.emitArchived(decision.sessionId);
   }
 
   private async doSpawn(
@@ -258,14 +267,13 @@ export class DrainService {
     const s = this.deps.store.get(id);
     if (!s || !s.auto) return; // drain only manages auto sessions
     if (git.state === "merged") {
-      // Clear the merge guard and reap — regardless of whether drain is still
-      // enabled (avoid leaking a merged auto session). Do NOT pump here: the
+      // Reap on any observed merge — drain-initiated retire, manual, or GitHub
+      // auto-merge all land here via the pr-poller. Do NOT pump here: the
       // emitted session:archived routes to onArchived, the single advance path.
-      this.merging.delete(id);
-      // Retire the backlog issue on ANY merge — drain-initiated, manual, or GitHub
-      // auto-merge all land here via the pr-poller. Best-effort: the merge is done, so
-      // a close failure must not block teardown. (closeIssue is idempotent, so a drain
-      // merge that the poller later re-confirms can't double-close harmfully.)
+      // Best-effort: the merge is done, so a close failure must not block teardown.
+      // closeIssue is idempotent, so this path (human merges a still-tracked session)
+      // and the doRetire path (drain retires first, then human merges — poller no longer
+      // tracks it) are independent and safe.
       if (s.issueNumber != null) {
         try {
           await this.deps.resolveForge(s.repoPath)?.closeIssue?.(s.issueNumber);
@@ -278,17 +286,16 @@ export class DrainService {
       this.deps.emitArchived(id);
       return;
     }
-    // open/green/other → the merge gate may now fire (e.g. CI just went green).
-    // Skip drain-disabled repos — no spawn/merge there, just WS noise.
+    // open/green/other → the retire gate may now fire (e.g. CI just went green).
+    // Skip drain-disabled repos — no spawn/retire there, just WS noise.
     if (!this.deps.store.getRepoConfig(s.repoPath).autoDrainEnabled) return;
     await this.pump(s.repoPath);
   }
 
-  /** A session was archived (merged auto session, or a manual archive). The
+  /** A session was archived (retired auto session, or a manual archive). The
    *  single advance step: a freed slot lets the next candidate spawn. Skips
    *  drain-disabled repos so a manual archive there doesn't pump/emit. */
   async onArchived(id: string): Promise<void> {
-    this.merging.delete(id); // harmless no-op if not present; clears any stale merge guard
     const s = this.deps.store.get(id); // archived rows still return → repoPath available
     if (!s) return;
     if (!this.deps.store.getRepoConfig(s.repoPath).autoDrainEnabled) return;
@@ -304,7 +311,7 @@ export class DrainService {
   }
 
   /** A critic verdict landed for a session. A clean verdict for the current head
-   *  may now unblock the merge gate — pump promptly rather than waiting for the tick. */
+   *  may now unblock the retire gate — pump promptly rather than waiting for the tick. */
   async onReview(id: string): Promise<void> {
     const s = this.deps.store.get(id);
     if (!s) return;
@@ -320,7 +327,7 @@ export class DrainService {
   }
 
   /** Client bootstrap: a status per drain-enabled repo, WITHOUT applying side
-   *  effects (no spawn/merge, no `merging` mutation). Disabled repos are skipped. */
+   *  effects (no spawn/retire). Disabled repos are skipped. */
   async snapshot(): Promise<DrainStatus[]> {
     const out: DrainStatus[] = [];
     for (const repoPath of this.deps.repos()) {

--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -285,6 +285,20 @@ export class GiteaForge implements GitForge {
     });
   }
 
+  async ensureIssueLink(prNumber: number, issueNumber: number): Promise<void> {
+    const pr = (await this.req("GET", `/api/v1/repos/${this.slug}/pulls/${prNumber}`)) as {
+      body?: string | null;
+    } | null;
+    const body = pr?.body ?? "";
+    const pattern = new RegExp(
+      `\\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\\s+#${issueNumber}\\b`,
+      "i",
+    );
+    if (pattern.test(body)) return;
+    const newBody = body ? `${body}\n\nCloses #${issueNumber}` : `Closes #${issueNumber}`;
+    await this.req("PATCH", `/api/v1/repos/${this.slug}/pulls/${prNumber}`, { body: newBody });
+  }
+
   async redeploy(o: RedeployInput): Promise<void> {
     await this.req(
       "POST",

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -393,6 +393,27 @@ export class GithubForge implements GitForge {
     this.run(["pr", "comment", String(prNumber), "--repo", this.slug, "--body", body]);
   }
 
+  async ensureIssueLink(prNumber: number, issueNumber: number): Promise<void> {
+    const body = this.run([
+      "pr",
+      "view",
+      String(prNumber),
+      "--repo",
+      this.slug,
+      "--json",
+      "body",
+      "-q",
+      ".body // empty",
+    ]).trim();
+    const pattern = new RegExp(
+      `\\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\\s+#${issueNumber}\\b`,
+      "i",
+    );
+    if (pattern.test(body)) return;
+    const newBody = body ? `${body}\n\nCloses #${issueNumber}` : `Closes #${issueNumber}`;
+    this.run(["pr", "edit", String(prNumber), "--repo", this.slug, "--body", newBody]);
+  }
+
   async redeploy(o: RedeployInput): Promise<void> {
     this.run(["workflow", "run", o.workflow, "--repo", this.slug, "--ref", o.ref]);
   }

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -193,6 +193,11 @@ export interface GitForge {
   /** Close an issue by number (best-effort; used by the drain to retire a backlog
    *  issue once its auto PR merges). Optional: hosts without an issues-close API omit it. */
   closeIssue?(issueNumber: number): Promise<void>;
+  /** Ensure the PR body links the issue so the forge auto-closes it on merge.
+   *  Idempotent: appends a `Closes #<issueNumber>` line only when no closing
+   *  keyword for that issue is already present. Best-effort; optional (hosts
+   *  without a PR-body edit API omit it). */
+  ensureIssueLink?(prNumber: number, issueNumber: number): Promise<void>;
 }
 
 /** Per-host configuration loaded from ~/.shepherd/forges.json. */

--- a/test/drain-core.test.ts
+++ b/test/drain-core.test.ts
@@ -136,26 +136,26 @@ describe("computeNext", () => {
     expect(d).toEqual({ kind: "hold", reason: { code: "empty" } });
   });
 
-  test("merge: open+green+mergeable, no blocking review → merge", () => {
+  test("retire: open+green+mergeable, no blocking review → retire", () => {
     const d = computeNext(
       state({
         maxAuto: 2,
         autoSessions: [autoSession({ id: "sX", git: MERGEABLE, reviewDecision: null })],
       }),
     );
-    expect(d).toEqual({ kind: "merge", sessionId: "sX", prNumber: 7 });
+    expect(d).toEqual({ kind: "retire", sessionId: "sX", prNumber: 7 });
   });
 
-  test("merge: commented review still merges", () => {
+  test("retire: commented review still retires", () => {
     const d = computeNext(
       state({
         autoSessions: [autoSession({ id: "sX", git: MERGEABLE, reviewDecision: "commented" })],
       }),
     );
-    expect(d.kind).toBe("merge");
+    expect(d.kind).toBe("retire");
   });
 
-  test("merge takes priority over spawning a fresh item", () => {
+  test("retire takes priority over spawning a fresh item", () => {
     const d = computeNext(
       state({
         maxAuto: 3,
@@ -163,10 +163,10 @@ describe("computeNext", () => {
         candidates: [issue(2)],
       }),
     );
-    expect(d.kind).toBe("merge");
+    expect(d.kind).toBe("retire");
   });
 
-  test("merge still allowed while a different session is in trouble", () => {
+  test("retire still allowed while a different session is in trouble", () => {
     const d = computeNext(
       state({
         autoSessions: [
@@ -175,10 +175,10 @@ describe("computeNext", () => {
         ],
       }),
     );
-    expect(d).toEqual({ kind: "merge", sessionId: "ok", prNumber: 7 });
+    expect(d).toEqual({ kind: "retire", sessionId: "ok", prNumber: 7 });
   });
 
-  test("no merge when that session's critic requested changes", () => {
+  test("no retire when that session's critic requested changes", () => {
     const d = computeNext(
       state({
         autoSessions: [
@@ -195,7 +195,7 @@ describe("computeNext", () => {
     expect((d as any).reason.code).toBe("changes_requested");
   });
 
-  test("no merge when critic verdict is error", () => {
+  test("no retire when critic verdict is error", () => {
     const d = computeNext(
       state({
         autoSessions: [
@@ -207,16 +207,16 @@ describe("computeNext", () => {
     expect((d as any).reason.code).toBe("error");
   });
 
-  test("no merge when mergeable is false/null", () => {
+  test("no retire when mergeable is false/null", () => {
     const notYet: GitState = { ...MERGEABLE, mergeable: null };
     const d = computeNext(state({ autoSessions: [autoSession({ id: "sX", git: notYet })] }));
-    expect(d.kind).not.toBe("merge");
+    expect(d.kind).not.toBe("retire");
   });
 
-  test("no merge when checks are not success", () => {
+  test("no retire when checks are not success", () => {
     const pending: GitState = { ...MERGEABLE, checks: "pending" };
     const d = computeNext(state({ autoSessions: [autoSession({ id: "sX", git: pending })] }));
-    expect(d.kind).not.toBe("merge");
+    expect(d.kind).not.toBe("retire");
   });
 
   test("critic on + no verdict yet → hold (don't merge unreviewed)", () => {
@@ -229,7 +229,7 @@ describe("computeNext", () => {
     expect(d.kind).toBe("hold");
   });
 
-  test("critic on + commented verdict for current head → merge", () => {
+  test("critic on + commented verdict for current head → retire", () => {
     const d = computeNext(
       state({
         criticEnabled: true,
@@ -243,7 +243,7 @@ describe("computeNext", () => {
         ],
       }),
     );
-    expect(d).toEqual({ kind: "merge", sessionId: "sX", prNumber: 7 });
+    expect(d).toEqual({ kind: "retire", sessionId: "sX", prNumber: 7 });
   });
 
   test("critic on + verdict for an older head → hold (re-review pending)", () => {
@@ -263,14 +263,14 @@ describe("computeNext", () => {
     expect(d.kind).toBe("hold");
   });
 
-  test("critic off + no verdict → still merge (CI-green sole gate)", () => {
+  test("critic off + no verdict → still retire (CI-green sole gate)", () => {
     const d = computeNext(
       state({
         criticEnabled: false,
         autoSessions: [autoSession({ id: "sX", git: MERGEABLE, reviewDecision: null })],
       }),
     );
-    expect(d).toEqual({ kind: "merge", sessionId: "sX", prNumber: 7 });
+    expect(d).toEqual({ kind: "retire", sessionId: "sX", prNumber: 7 });
   });
 });
 

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -90,6 +90,7 @@ function makeHarness(
     usageCeilingPct?: number;
     mergeImpl?: () => Promise<void>;
     listIssuesImpl?: () => Promise<Issue[]>;
+    archiveImpl?: (id: string) => number;
     onArchived?: (h: Harness, id: string) => void;
   } = {},
 ): Harness {
@@ -137,6 +138,7 @@ function makeHarness(
       });
     },
     archive: (id: string): number => {
+      if (opts.archiveImpl) return opts.archiveImpl(id);
       store.archive(id);
       return 1;
     },
@@ -275,6 +277,47 @@ test("retire gate: ready session → retired once; forge.merge never called; ens
   await h.drain.pump(REPO);
   expect(h.forgeRec.links).toHaveLength(1); // not called again
   expect(h.archived).toHaveLength(1); // not emitted again
+});
+
+test("retire: archive failure is isolated — warns and defers, does not drop pr-cache / emit archived", async () => {
+  let throwOnArchive = true;
+  const h = makeHarness({
+    maxAuto: 1,
+    issues: [],
+    archiveImpl: (id) => {
+      if (throwOnArchive) throw new Error("worktree.remove failed");
+      h.store.archive(id);
+      return 1;
+    },
+  });
+  const s = h.store.create({
+    name: "auto",
+    prompt: "p",
+    repoPath: REPO,
+    baseBranch: "main",
+    branch: "shepherd/auto-7",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: true,
+    issueNumber: 7,
+  });
+  h.prCache[s.id] = openGreen(7);
+  h.setReview(s.id, "commented", "sha-7");
+  // archive throws → pump must not bubble it (defer to next tick)
+  await h.drain.pump(REPO);
+  // link was attempted, but teardown was NOT completed on a non-archived session
+  expect(h.forgeRec.links).toEqual([{ prNumber: 7, issueNumber: 7 }]);
+  expect(h.store.get(s.id)?.status).not.toBe("archived");
+  expect(h.dropped).toHaveLength(0);
+  expect(h.archived).toHaveLength(0);
+  // next tick: archive now succeeds → retire completes
+  throwOnArchive = false;
+  await h.drain.pump(REPO);
+  expect(h.store.get(s.id)?.status).toBe("archived");
+  expect(h.dropped).toEqual([s.id]);
+  expect(h.archived).toEqual([s.id]);
 });
 
 test("critic enabled + no verdict yet → holds, does not retire (gate not bypassed)", async () => {

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -23,6 +23,7 @@ const NO_USAGE: UsageLimitsType = { session5h: null, week: null, stale: false, c
 
 interface ForgeRec {
   merges: { prNumber: number; method: MergeMethod; deleteBranch: boolean }[];
+  links: { prNumber: number; issueNumber: number }[];
   listIssuesCalls: number;
   closedIssues: number[];
 }
@@ -34,6 +35,7 @@ function fakeForge(
     merge?: () => Promise<void>;
     listIssues?: () => Promise<Issue[]>;
     closeIssue?: (n: number) => Promise<void>;
+    ensureIssueLink?: (prNumber: number, issueNumber: number) => Promise<void>;
   } = {},
 ): GitForge {
   return {
@@ -59,6 +61,10 @@ function fakeForge(
     closeIssue: async (issueNumber: number) => {
       rec.closedIssues.push(issueNumber);
       if (opts.closeIssue) await opts.closeIssue(issueNumber);
+    },
+    ensureIssueLink: async (prNumber: number, issueNumber: number) => {
+      rec.links.push({ prNumber, issueNumber });
+      if (opts.ensureIssueLink) await opts.ensureIssueLink(prNumber, issueNumber);
     },
   };
 }
@@ -99,7 +105,7 @@ function makeHarness(
     usageCeilingPct: opts.usageCeilingPct ?? 80,
   });
 
-  const forgeRec: ForgeRec = { merges: [], listIssuesCalls: 0, closedIssues: [] };
+  const forgeRec: ForgeRec = { merges: [], links: [], listIssuesCalls: 0, closedIssues: [] };
   const forge = fakeForge(opts.issues ?? [], forgeRec, {
     merge: opts.mergeImpl,
     listIssues: opts.listIssuesImpl,
@@ -237,7 +243,7 @@ test("dedupe: an existing session mapped to #1 → spawns #2 next, not #1", asyn
   expect(h.creates[0]!.issueRef?.number).toBe(2);
 });
 
-test("auto-merge gate: mergeable session → merges once; immediate second pump does not re-merge", async () => {
+test("retire gate: ready session → retired once; forge.merge never called; ensureIssueLink + archive + emitArchived fire", async () => {
   const h = makeHarness({ maxAuto: 1, issues: [] });
   const s = h.store.create({
     name: "auto",
@@ -256,13 +262,22 @@ test("auto-merge gate: mergeable session → merges once; immediate second pump 
   // critic enabled (repo default) → seed a clean verdict for the current head so the gate opens
   h.setReview(s.id, "commented", "sha-7");
   await h.drain.pump(REPO);
-  expect(h.forgeRec.merges).toEqual([{ prNumber: 7, method: "squash", deleteBranch: true }]);
-  // second pump: still in `merging` (pr-poller hasn't reported merged), git → null → no re-merge
+  // drain never merges
+  expect(h.forgeRec.merges).toHaveLength(0);
+  // issue link ensured
+  expect(h.forgeRec.links).toEqual([{ prNumber: 7, issueNumber: 7 }]);
+  // session archived
+  expect(h.store.get(s.id)?.status).toBe("archived");
+  // emitArchived and dropPrCache fired
+  expect(h.archived).toEqual([s.id]);
+  expect(h.dropped).toEqual([s.id]);
+  // second pump: session archived → no longer in autoSessions → no retire
   await h.drain.pump(REPO);
-  expect(h.forgeRec.merges).toHaveLength(1);
+  expect(h.forgeRec.links).toHaveLength(1); // not called again
+  expect(h.archived).toHaveLength(1); // not emitted again
 });
 
-test("critic enabled + no verdict yet → holds, does not merge (gate not bypassed)", async () => {
+test("critic enabled + no verdict yet → holds, does not retire (gate not bypassed)", async () => {
   const h = makeHarness({ maxAuto: 1, issues: [] });
   const s = h.store.create({
     name: "auto",
@@ -281,9 +296,12 @@ test("critic enabled + no verdict yet → holds, does not merge (gate not bypass
   // no verdict seeded → critic-on gate holds
   await h.drain.pump(REPO);
   expect(h.forgeRec.merges).toHaveLength(0);
+  expect(h.forgeRec.links).toHaveLength(0);
+  expect(h.archived).toHaveLength(0);
+  expect(h.store.get(s.id)?.status).not.toBe("archived");
 });
 
-test("onReview triggers a pump: a clean verdict landing causes the merge", async () => {
+test("onReview triggers a pump: a clean verdict landing causes retire (archive + ensureIssueLink)", async () => {
   const h = makeHarness({ maxAuto: 1, issues: [] });
   const s = h.store.create({
     name: "auto",
@@ -299,10 +317,13 @@ test("onReview triggers a pump: a clean verdict landing causes the merge", async
     issueNumber: 7,
   });
   h.prCache[s.id] = openGreen(7);
-  // verdict lands now (matching head) → onReview pumps → merge fires
+  // verdict lands now (matching head) → onReview pumps → retire fires
   h.setReview(s.id, "commented", "sha-7");
   await h.drain.onReview(s.id);
-  expect(h.forgeRec.merges).toEqual([{ prNumber: 7, method: "squash", deleteBranch: true }]);
+  expect(h.forgeRec.merges).toHaveLength(0);
+  expect(h.forgeRec.links).toEqual([{ prNumber: 7, issueNumber: 7 }]);
+  expect(h.store.get(s.id)?.status).toBe("archived");
+  expect(h.archived).toEqual([s.id]);
 });
 
 test("re-spawn guard: a merged+archived auto session for #N keeps #N out of candidates", async () => {
@@ -320,7 +341,7 @@ test("re-spawn guard: a merged+archived auto session for #N keeps #N out of cand
     auto: true,
     issueNumber: 7,
   });
-  // simulate the merged → archived lifecycle: its issueNumber must stay mapped
+  // simulate the retired → archived lifecycle: its issueNumber must stay mapped
   h.store.archive(s.id);
   await h.drain.pump(REPO);
   // issue #7 still open+labeled, but already drained → not re-spawned
@@ -351,7 +372,7 @@ test("drain-disabled repo: a manual archive does not pump / emit drain:status", 
   expect(h.statuses).toHaveLength(0);
 });
 
-test("no merge when review decision is changes_requested (and status is paused)", async () => {
+test("no retire when review decision is changes_requested (status paused)", async () => {
   const h = makeHarness({ maxAuto: 1, issues: [] });
   const s = h.store.create({
     name: "auto",
@@ -370,12 +391,14 @@ test("no merge when review decision is changes_requested (and status is paused)"
   h.setReview(s.id, "changes_requested");
   await h.drain.pump(REPO);
   expect(h.forgeRec.merges).toHaveLength(0);
+  expect(h.forgeRec.links).toHaveLength(0);
+  expect(h.archived).toHaveLength(0);
   const last = h.statuses.at(-1)!;
   expect(last.paused).toBe(true);
   expect(last.reason).toBe("changes_requested");
 });
 
-test("no merge when mergeable !== true", async () => {
+test("no retire when mergeable !== true", async () => {
   const h = makeHarness({ maxAuto: 1, issues: [] });
   const s = h.store.create({
     name: "auto",
@@ -393,6 +416,8 @@ test("no merge when mergeable !== true", async () => {
   h.prCache[s.id] = openGreen(7, false);
   await h.drain.pump(REPO);
   expect(h.forgeRec.merges).toHaveLength(0);
+  expect(h.forgeRec.links).toHaveLength(0);
+  expect(h.archived).toHaveLength(0);
 });
 
 test("usage ceiling hold → status paused (usage banner reachable)", async () => {
@@ -458,18 +483,12 @@ test("pumping lock: an in-flight pump makes a concurrent pump return immediately
   expect(h.creates).toHaveLength(1); // exactly one spawn for the single slot
 });
 
-test("merge-throw → retry: failed merge defers to next pump (at most one attempt per pump)", async () => {
-  let callCount = 0;
-  const h = makeHarness({
-    maxAuto: 1,
-    issues: [],
-    mergeImpl: async () => {
-      callCount++;
-      if (callCount === 1) throw new Error("conflict");
-      // second call succeeds
-    },
-  });
-  const s = h.store.create({
+test("ensureIssueLink failure is best-effort: retire still archives and emits even if link throws", async () => {
+  const h = makeHarness({ maxAuto: 1, issues: [] });
+  // override ensureIssueLink to throw
+  const store = h.store;
+  const forgeRec = h.forgeRec;
+  const s = store.create({
     name: "auto",
     prompt: "p",
     repoPath: REPO,
@@ -483,18 +502,38 @@ test("merge-throw → retry: failed merge defers to next pump (at most one attem
     issueNumber: 7,
   });
   h.prCache[s.id] = openGreen(7);
-  h.setReview(s.id, "commented", "sha-7"); // clean verdict for current head opens the gate
-  // first pump: merge throws on first attempt → id removed from merging →
-  // attemptedMerge guard fires → breaks without retrying in the same pump
-  await h.drain.pump(REPO);
-  expect(h.forgeRec.merges).toHaveLength(1); // attempted exactly once; NOT retried same pump
-  // second pump: fresh attemptedMerge; id not in merging (throw cleared it) →
-  // merge is retried and succeeds
-  await h.drain.pump(REPO);
-  expect(h.forgeRec.merges).toHaveLength(2); // retried across pumps; total 2 calls
-  // third pump: id now in merging (success); git → null → no further merge
-  await h.drain.pump(REPO);
-  expect(h.forgeRec.merges).toHaveLength(2); // no third attempt
+  h.setReview(s.id, "commented", "sha-7");
+
+  // Build a drain that uses a forge where ensureIssueLink throws
+  const throwingForge = fakeForge([], forgeRec, {
+    ensureIssueLink: async () => {
+      throw new Error("link failed");
+    },
+  });
+  const drain2 = new DrainService({
+    store,
+    service: {
+      create: async () => {
+        throw new Error("should not spawn");
+      },
+      archive: (id: string): number => {
+        store.archive(id);
+        return 1;
+      },
+    },
+    resolveForge: () => throwingForge,
+    prCache: { snapshot: () => h.prCache },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    emitStatus: () => {},
+    emitArchived: (id) => h.archived.push(id),
+    dropPrCache: (id) => h.dropped.push(id),
+  });
+  await drain2.pump(REPO);
+  // Link failed but teardown still ran
+  expect(store.get(s.id)?.status).toBe("archived");
+  expect(h.archived).toEqual([s.id]);
+  expect(h.dropped).toEqual([s.id]);
 });
 
 test("tick + snapshot over repos: only drain-enabled repo is acted on and reported", async () => {
@@ -521,7 +560,7 @@ test("tick + snapshot over repos: only drain-enabled repo is acted on and report
     usageCeilingPct: 80,
   });
 
-  const forgeRec: ForgeRec = { merges: [], listIssuesCalls: 0, closedIssues: [] };
+  const forgeRec: ForgeRec = { merges: [], links: [], listIssuesCalls: 0, closedIssues: [] };
   const forge = fakeForge([issue(1)], forgeRec);
   const creates: CreateSessionInput[] = [];
   const statuses: DrainStatus[] = [];
@@ -579,33 +618,7 @@ test("tick + snapshot over repos: only drain-enabled repo is acted on and report
   expect(creates.length).toBe(createsAfterSnapshot);
 });
 
-test("closeIssue called once with issueNumber when onGit observes merged state", async () => {
-  const h = makeHarness({ maxAuto: 1, issues: [] });
-  const s = h.store.create({
-    name: "auto",
-    prompt: "p",
-    repoPath: REPO,
-    baseBranch: "main",
-    branch: "shepherd/auto-7",
-    worktreePath: "/wt",
-    isolated: true,
-    herdrSession: "default",
-    herdrAgentId: "t",
-    auto: true,
-    issueNumber: 7,
-  });
-  // drain-initiated merge: pump fires doMerge, then poller reports merged
-  h.prCache[s.id] = openGreen(7);
-  h.setReview(s.id, "commented", "sha-7");
-  await h.drain.pump(REPO);
-  expect(h.forgeRec.merges).toHaveLength(1);
-  // doMerge no longer closes — close happens in onGit when merged observed
-  expect(h.forgeRec.closedIssues).toHaveLength(0);
-  await h.drain.onGit(s.id, { ...openGreen(7), state: "merged" });
-  expect(h.forgeRec.closedIssues).toEqual([7]);
-});
-
-test("out-of-band merge: onGit(merged) without prior doMerge closes issue and archives", async () => {
+test("out-of-band merge: onGit(merged) without prior retire closes issue and archives", async () => {
   const h = makeHarness({ maxAuto: 1, issues: [] });
   const s = h.store.create({
     name: "auto",
@@ -620,10 +633,10 @@ test("out-of-band merge: onGit(merged) without prior doMerge closes issue and ar
     auto: true,
     issueNumber: 42,
   });
-  // No pump / doMerge — simulate a human or GitHub auto-merge observed by the poller
+  // No pump / doRetire — simulate a human or GitHub auto-merge observed by the poller
   await h.drain.onGit(s.id, { ...openGreen(42), state: "merged" });
   expect(h.forgeRec.merges).toHaveLength(0); // drain never called forge.merge
-  expect(h.forgeRec.closedIssues).toEqual([42]); // issue still closed
+  expect(h.forgeRec.closedIssues).toEqual([42]); // issue closed
   expect(h.store.get(s.id)?.status).toBe("archived");
   expect(h.archived).toEqual([s.id]);
   expect(h.dropped).toEqual([s.id]);
@@ -649,33 +662,27 @@ test("closeIssue not called when session has issueNumber === null (onGit merged 
   expect(h.store.get(s.id)?.status).toBe("archived");
 });
 
-test("closeIssue not called when merge throws (no merged observed → onGit merged never runs)", async () => {
-  const h = makeHarness({
-    maxAuto: 1,
-    issues: [],
-    mergeImpl: async () => {
-      throw new Error("conflict");
-    },
-  });
+test("ensureIssueLink not called when session has issueNumber === null", async () => {
+  const h = makeHarness({ maxAuto: 1, issues: [] });
   const s = h.store.create({
     name: "auto",
     prompt: "p",
     repoPath: REPO,
     baseBranch: "main",
-    branch: "shepherd/auto-7",
+    branch: "shepherd/auto-no-issue",
     worktreePath: "/wt",
     isolated: true,
     herdrSession: "default",
     herdrAgentId: "t",
     auto: true,
-    issueNumber: 7,
+    issueNumber: null,
   });
-  h.prCache[s.id] = openGreen(7);
-  h.setReview(s.id, "commented", "sha-7");
+  h.prCache[s.id] = openGreen(99);
+  h.setReview(s.id, "commented", "sha-99");
   await h.drain.pump(REPO);
-  expect(h.forgeRec.merges).toHaveLength(1); // attempted
-  // merge failed → not in merging → onGit(merged) never called → no close
-  expect(h.forgeRec.closedIssues).toHaveLength(0);
+  // session archived but no link attempted
+  expect(h.forgeRec.links).toHaveLength(0);
+  expect(h.store.get(s.id)?.status).toBe("archived");
 });
 
 // ── queue(): the actual backlog issues behind DrainStatus.queued ──────────────

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -416,6 +416,58 @@ test("GiteaForge.closeIssue: PATCHes the issue state to closed", async () => {
   expect(patch.body).toEqual({ state: "closed" });
 });
 
+test("GiteaForge.ensureIssueLink: appends Closes #N when body has no link", async () => {
+  const { fn, calls } = fakeFetch({
+    "GET /api/v1/repos/team/proj/pulls/7": { json: { body: "Some PR description" } },
+    "PATCH /api/v1/repos/team/proj/pulls/7": { status: 200, json: {} },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await forge.ensureIssueLink!(7, 3);
+  const patch = calls.find((c) => c.method === "PATCH")!;
+  expect(patch).toBeDefined();
+  expect(patch.body).toEqual({ body: "Some PR description\n\nCloses #3" });
+});
+
+test("GiteaForge.ensureIssueLink: appends to empty body without leading newlines", async () => {
+  const { fn, calls } = fakeFetch({
+    "GET /api/v1/repos/team/proj/pulls/7": { json: { body: "" } },
+    "PATCH /api/v1/repos/team/proj/pulls/7": { status: 200, json: {} },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await forge.ensureIssueLink!(7, 3);
+  const patch = calls.find((c) => c.method === "PATCH")!;
+  expect(patch.body).toEqual({ body: "Closes #3" });
+});
+
+test("GiteaForge.ensureIssueLink: no-op when body already contains Closes #N", async () => {
+  const { fn, calls } = fakeFetch({
+    "GET /api/v1/repos/team/proj/pulls/7": { json: { body: "Description\n\nCloses #3" } },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await forge.ensureIssueLink!(7, 3);
+  expect(calls.find((c) => c.method === "PATCH")).toBeUndefined();
+});
+
+test("GiteaForge.ensureIssueLink: no-op when body contains a different closing keyword (Fixes #N)", async () => {
+  const { fn, calls } = fakeFetch({
+    "GET /api/v1/repos/team/proj/pulls/7": { json: { body: "Description\n\nFixes #3" } },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await forge.ensureIssueLink!(7, 3);
+  expect(calls.find((c) => c.method === "PATCH")).toBeUndefined();
+});
+
+test("GiteaForge.ensureIssueLink: does not treat Closes #15 as a link for issue #1", async () => {
+  const { fn, calls } = fakeFetch({
+    "GET /api/v1/repos/team/proj/pulls/7": { json: { body: "Description\n\nCloses #15" } },
+    "PATCH /api/v1/repos/team/proj/pulls/7": { status: 200, json: {} },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  await forge.ensureIssueLink!(7, 1);
+  // #15 should NOT match issue #1 — PATCH must be called
+  expect(calls.find((c) => c.method === "PATCH")).toBeDefined();
+});
+
 const ACTIONS_TASKS = "GET /api/v1/repos/team/proj/actions/tasks?limit=50";
 
 test("GiteaForge.listWorkflowRuns: dedups to newest run per workflow, newest-first", async () => {

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -651,3 +651,96 @@ test("GithubForge.listWorkflowRunHistory: no default branch → []", async () =>
     [],
   );
 });
+
+test("GithubForge.ensureIssueLink: appends Closes #N when body has no link", async () => {
+  const calls: string[][] = [];
+  const run = (args: string[]): string => {
+    calls.push(args);
+    if (args[0] === "pr" && args[1] === "view") return "Some PR description";
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+  await forge.ensureIssueLink!(7, 3);
+  const editCall = calls.find((c) => c[0] === "pr" && c[1] === "edit")!;
+  expect(editCall).toBeDefined();
+  expect(editCall).toContain("--body");
+  const bodyIdx = editCall.indexOf("--body");
+  expect(editCall[bodyIdx + 1]).toBe("Some PR description\n\nCloses #3");
+});
+
+test("GithubForge.ensureIssueLink: appends to empty body without leading newlines", async () => {
+  const calls: string[][] = [];
+  const run = (args: string[]): string => {
+    calls.push(args);
+    if (args[0] === "pr" && args[1] === "view") return "";
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+  await forge.ensureIssueLink!(7, 3);
+  const editCall = calls.find((c) => c[0] === "pr" && c[1] === "edit")!;
+  const bodyIdx = editCall.indexOf("--body");
+  expect(editCall[bodyIdx + 1]).toBe("Closes #3");
+});
+
+test("GithubForge.ensureIssueLink: no-op when body already contains Closes #N", async () => {
+  const calls: string[][] = [];
+  const run = (args: string[]): string => {
+    calls.push(args);
+    if (args[0] === "pr" && args[1] === "view") return "Description\n\nCloses #3";
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+  await forge.ensureIssueLink!(7, 3);
+  expect(calls.find((c) => c[0] === "pr" && c[1] === "edit")).toBeUndefined();
+});
+
+test("GithubForge.ensureIssueLink: no-op when body contains a different closing keyword (Fixes #N)", async () => {
+  const calls: string[][] = [];
+  const run = (args: string[]): string => {
+    calls.push(args);
+    if (args[0] === "pr" && args[1] === "view") return "Description\n\nFixes #3";
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+  await forge.ensureIssueLink!(7, 3);
+  expect(calls.find((c) => c[0] === "pr" && c[1] === "edit")).toBeUndefined();
+});
+
+test("GithubForge.ensureIssueLink: does not treat Closes #15 as a link for issue #1", async () => {
+  const calls: string[][] = [];
+  const run = (args: string[]): string => {
+    calls.push(args);
+    if (args[0] === "pr" && args[1] === "view") return "Description\n\nCloses #15";
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+  await forge.ensureIssueLink!(7, 1);
+  // #15 should NOT match issue #1 — edit must be called
+  expect(calls.find((c) => c[0] === "pr" && c[1] === "edit")).toBeDefined();
+});
+
+test("GithubForge.ensureIssueLink: null body (gh serializes body-less PR as literal 'null') → Closes #N only", async () => {
+  // `gh pr view --json body -q '.body // empty'` returns empty string for a null body.
+  // The old query `.body` returned the literal string "null", which corrupted the body.
+  const calls: string[][] = [];
+  const run = (args: string[]): string => {
+    calls.push(args);
+    // Simulate the fixed jq query: `.body // empty` returns "" for a null body.
+    // The -q arg is at index args.indexOf("-q") + 1; verify the query is correct.
+    if (args[0] === "pr" && args[1] === "view") {
+      const qIdx = args.indexOf("-q");
+      const query = qIdx >= 0 ? args[qIdx + 1] : "";
+      // With the old broken query `.body`, gh would emit "null" (jq serializes JSON null).
+      // With the fixed query `.body // empty`, gh emits "" (empty output → trims to "").
+      // We simulate what the fixed gh+jq produces: empty string.
+      return query === ".body // empty" ? "" : "null";
+    }
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+  await forge.ensureIssueLink!(7, 3);
+  const editCall = calls.find((c) => c[0] === "pr" && c[1] === "edit")!;
+  expect(editCall).toBeDefined();
+  const bodyIdx = editCall.indexOf("--body");
+  expect(editCall[bodyIdx + 1]).toBe("Closes #3");
+});


### PR DESCRIPTION
## Why

The self-draining work queue ("autopilot") used to **auto-merge** PRs: when an auto-spawned session's PR was open + CI-green + critic-approved, the drain called `forge.merge`. The merge decision should be **human-owned**. Autopilot should drive work to a ready PR and then **stop**.

## What

The drain now **retires** a ready session instead of merging it:

- `computeNext` returns a `retire` decision (was `merge`) for a mergeable session — same gate (open + CI green + host-mergeable + critic-approved), same priority.
- `doRetire` (was `doMerge`): guarantees the PR body links its issue (new `forge.ensureIssueLink` appends `Closes #N`), then **archives** the session — stops the pane, removes the worktree, frees the cap slot — and leaves the open PR for a human. It **never** calls `forge.merge`.
- Archiving frees the slot, so the drain keeps draining the backlog into ready-to-merge PRs.
- When the human merges (shepherd PRs tab or the forge directly), the forge **auto-closes** the linked issue → it can never be re-spawned. The `onGit(merged)` branch is kept for the human-merges-before-retire race.
- The `merging` in-flight guard is removed (archive is synchronous, so it's obsolete).

**Untouched:** manual merge endpoints (`/api/sessions/:id/git/merge`, `/api/prs/merge`) and `autopilot.ts` (pre-PR steering). Server-only — no UI/i18n changes.

## Accepted edges (per spec)

- A ready PR left unmerged past the 30-day/250 session prune could re-spawn its still-open issue (rare).
- `ensureIssueLink` is best-effort (warn + continue on forge error).

Design spec: `docs/superpowers/specs/2026-06-03-autopilot-never-merges-design.md`

## Tests

- `drain-core`: retire (not merge) across all gate permutations.
- `drain`: asserts `forge.merge` never called; `ensureIssueLink` + archive + emit fire; idempotent second pump; null-issueNumber skip; best-effort link-failure teardown; onGit(merged) race path.
- `forge`: `ensureIssueLink` idempotency, empty/null body, different-keyword skip, `#1`≠`#15` boundary.

`bunx tsc --noEmit`, `bun run lint`, `bun test ./test` (946 pass / 0 fail) all green; branch linear off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)