### PR TITLE
fix(ui): resolve P1 & P2 findings from $impeccable audit (a11y, theming, responsive)

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -149,6 +149,14 @@
   --amber: #ffc266;
   --slate: #8a9893;
   --term-fg: #eef4f0;
+
+  /* Status/info hues are read as text & borders for meaning (ready/blocked/info),
+     so they must clear AAA too. Brighter, more-luminous siblings of the base
+     accents — kept in the green-tinted family — on the near-black --bg #0a0d0c:
+     green ~12.6:1, red ~7.8:1, blue ~9.7:1. */
+  --green: #7ee3b4;
+  --red: #ff7a7e;
+  --blue: #7fbdf0;
 }
 [data-theme="light"][data-contrast="high"] {
   --line: #9aa8a2;
@@ -162,6 +170,13 @@
   --amber: #7a4a00;
   --slate: #3c4946;
   --term-fg: #161d1b;
+
+  /* Darker siblings of the base accents — same green-tinted family — so the
+     status/info text & borders clear AAA on the near-white --panel #f7f9f8:
+     green ~7.4:1, red ~7.5:1, blue ~7.2:1. */
+  --green: #0c5e3a;
+  --red: #9a2429;
+  --blue: #1c5590;
 }
 
 html,

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -236,10 +236,12 @@
     flex: 1;
     text-align: center;
     padding: 12px;
+    min-height: 44px;
     font-size: var(--fs-base);
   }
   .actions.mobile .btn.backlog {
     padding: 12px 16px;
+    min-height: 44px;
     font-size: var(--fs-base);
   }
 

--- a/ui/src/lib/components/BroadcastDialog.svelte
+++ b/ui/src/lib/components/BroadcastDialog.svelte
@@ -303,9 +303,10 @@
     cursor: not-allowed;
     color: var(--color-faint);
     border-color: var(--color-line);
+    box-shadow: none;
   }
   /* armed: the same inset-glow confirm state used for decommission/merge */
-  .run.armed {
+  .run.armed:not(:disabled) {
     box-shadow: inset 0 0 22px -10px var(--color-amber);
     background: var(--color-hover);
   }

--- a/ui/src/lib/components/BroadcastDialog.svelte
+++ b/ui/src/lib/components/BroadcastDialog.svelte
@@ -282,8 +282,9 @@
     border-color: var(--color-amber);
   }
   .retry:disabled {
-    opacity: 0.5;
-    cursor: default;
+    opacity: 0.6;
+    cursor: not-allowed;
+    color: var(--color-faint);
   }
   .run {
     margin-top: 4px;
@@ -298,8 +299,10 @@
     cursor: pointer;
   }
   .run:disabled {
-    opacity: 0.5;
-    cursor: default;
+    opacity: 0.6;
+    cursor: not-allowed;
+    color: var(--color-faint);
+    border-color: var(--color-line);
   }
   /* armed: the same inset-glow confirm state used for decommission/merge */
   .run.armed {

--- a/ui/src/lib/components/Coachmark.svelte
+++ b/ui/src/lib/components/Coachmark.svelte
@@ -127,7 +127,7 @@
 
     background: var(--color-inset);
     border: 1px solid var(--color-line);
-    border-radius: 4px;
+    border-radius: 2px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
 
     /* Reset browser popover defaults */
@@ -157,15 +157,15 @@
     padding: 3px 10px;
     font-size: var(--fs-meta);
     font-weight: 500;
-    background: var(--color-accent, #5f6ad2);
-    color: #fff;
-    border: none;
-    border-radius: 3px;
+    background: transparent;
+    color: var(--color-ink);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
     cursor: pointer;
   }
 
   .coachmark-btn:hover {
-    opacity: 0.85;
+    background: var(--color-hover);
   }
 
   /* Entrance slide-in. The global blanket in app.css already suppresses this with

--- a/ui/src/lib/components/EmojiPicker.svelte
+++ b/ui/src/lib/components/EmojiPicker.svelte
@@ -87,6 +87,7 @@
     bind:value={query}
     class="ep-search"
     placeholder={m.emojipicker_search()}
+    aria-label={m.emojipicker_search()}
     type="text"
     role="combobox"
     aria-expanded="true"

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -542,7 +542,7 @@
     width: 5px;
     height: 5px;
     border-radius: 50%;
-    background: var(--color-accent, #5f6ad2);
+    background: var(--color-blue);
     flex-shrink: 0;
     animation: new-pip-pulse 2s ease-in-out infinite;
   }

--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -393,6 +393,9 @@
   }
   .run:disabled {
     opacity: 0.6;
-    cursor: default;
+    cursor: not-allowed;
+    color: var(--color-faint);
+    border-color: var(--color-line);
+    box-shadow: none;
   }
 </style>

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -590,8 +590,11 @@
     box-shadow: inset 0 0 18px -10px var(--color-amber);
   }
   .run:disabled {
-    opacity: 0.5;
-    cursor: default;
+    opacity: 0.6;
+    cursor: not-allowed;
+    color: var(--color-faint);
+    border-color: var(--color-line);
+    box-shadow: none;
   }
   .kbd {
     font: inherit;

--- a/ui/src/lib/components/QueueStrip.svelte
+++ b/ui/src/lib/components/QueueStrip.svelte
@@ -194,7 +194,7 @@
     letter-spacing: 0.04em;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 320px;
+    max-width: min(320px, 50vw);
   }
 
   /* queue popover — chrome mirrors GitRail's .pr-pop, anchored under the row */

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -133,19 +133,24 @@
   </button>
 
   {#if open}
-    <div class="rs-panel" role="listbox">
+    <div class="rs-panel">
       <input
         bind:this={filterInput}
         bind:value={filter}
         class="rs-filter"
         placeholder={m.reposelect_filter_placeholder()}
+        aria-label={m.reposelect_filter_placeholder()}
         type="text"
         autocomplete="off"
         spellcheck="false"
+        role="combobox"
+        aria-expanded="true"
+        aria-controls="rs-listbox"
+        aria-autocomplete="list"
         aria-activedescendant={shown.length ? `rs-opt-${activeIdx}` : undefined}
         onkeydown={onFilterKey}
       />
-      <ul class="rs-list" bind:this={listEl}>
+      <ul class="rs-list" id="rs-listbox" role="listbox" bind:this={listEl}>
         {#each shown as r, i (r.path)}
           <li
             id={`rs-opt-${i}`}
@@ -177,7 +182,7 @@
           </li>
         {/each}
         {#if shown.length === 0}
-          <li class="rs-empty">{m.reposelect_no_matches()}</li>
+          <li class="rs-empty" role="presentation">{m.reposelect_no_matches()}</li>
         {/if}
       </ul>
       {#if onclone}

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -153,7 +153,7 @@
             class:active={r.path === value}
             class:kbd-active={i === activeIdx}
             role="option"
-            aria-selected={r.path === value}
+            aria-selected={i === activeIdx}
             tabindex="-1"
             onclick={() => pick(r.path)}
             onkeydown={(e) => {

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -181,10 +181,15 @@
             <span class="dim">{r.display}</span>
           </li>
         {/each}
-        {#if shown.length === 0}
-          <li class="rs-empty" role="presentation">{m.reposelect_no_matches()}</li>
-        {/if}
       </ul>
+      <!-- Live region (always mounted + in the a11y tree while open) so screen
+           readers hear when a filter yields zero results. Lives outside the
+           listbox so that owns only role=option rows; only the text toggles
+           (reliable announce), and the .filled padding keeps the empty state at
+           zero visual footprint. -->
+      <div class="rs-empty" class:filled={shown.length === 0} role="status" aria-live="polite">
+        {shown.length === 0 ? m.reposelect_no_matches() : ""}
+      </div>
       {#if onclone}
         <button
           type="button"
@@ -356,11 +361,13 @@
   }
 
   .rs-empty {
-    padding: 10px;
     color: var(--color-muted);
     font-size: var(--fs-base);
     font-style: italic;
     text-align: center;
+  }
+  .rs-empty.filled {
+    padding: 10px;
   }
 
   .rs-clone-row {

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -16,6 +16,11 @@
   let filter = $state("");
   let root = $state<HTMLElement | null>(null);
   let filterInput = $state<HTMLInputElement | null>(null);
+  let listEl = $state<HTMLUListElement | null>(null);
+
+  // Roving keyboard cursor: the filter input keeps DOM focus while open, so it
+  // drives a virtual active row (aria-activedescendant) the way EmojiPicker does.
+  let activeIdx = $state(0);
 
   // repo path whose emoji picker is currently open (null = none)
   let pickerFor = $state<string | null>(null);
@@ -49,6 +54,41 @@
       filterInput.focus();
     }
   });
+
+  // Reset the cursor to the top whenever the filtered list changes (open/typing).
+  $effect(() => {
+    void shown;
+    activeIdx = 0;
+  });
+
+  // Keyboard-driven row navigation from the focused filter input.
+  function onFilterKey(e: KeyboardEvent) {
+    if (shown.length === 0) return;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        activeIdx = Math.min(activeIdx + 1, shown.length - 1);
+        scrollActiveIntoView();
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        activeIdx = Math.max(activeIdx - 1, 0);
+        scrollActiveIntoView();
+        break;
+      case "Enter": {
+        e.preventDefault();
+        const r = shown[activeIdx];
+        if (r) pick(r.path);
+        break;
+      }
+      // Escape falls through to the window handler that closes the panel.
+    }
+  }
+
+  function scrollActiveIntoView() {
+    const row = listEl?.children[activeIdx] as HTMLElement | undefined;
+    row?.scrollIntoView({ block: "nearest" });
+  }
 
   $effect(() => {
     function onKeydown(e: KeyboardEvent) {
@@ -102,12 +142,16 @@
         type="text"
         autocomplete="off"
         spellcheck="false"
+        aria-activedescendant={shown.length ? `rs-opt-${activeIdx}` : undefined}
+        onkeydown={onFilterKey}
       />
-      <ul class="rs-list">
-        {#each shown as r (r.path)}
+      <ul class="rs-list" bind:this={listEl}>
+        {#each shown as r, i (r.path)}
           <li
+            id={`rs-opt-${i}`}
             class="rs-row"
             class:active={r.path === value}
+            class:kbd-active={i === activeIdx}
             role="option"
             aria-selected={r.path === value}
             tabindex="-1"
@@ -288,7 +332,8 @@
     border-bottom: 0;
   }
 
-  .rs-row:hover {
+  .rs-row:hover,
+  .rs-row.kbd-active {
     background: var(--color-hover);
   }
 

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -554,6 +554,7 @@
     right: 0;
     z-index: 50;
     min-width: 200px;
+    max-width: min(280px, 85vw);
     background: linear-gradient(180deg, var(--color-panel), var(--color-panel-2));
     border: 1px solid var(--color-line-bright);
     border-radius: 2px;

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -430,6 +430,14 @@
     }
   }
 
+  /* Touch devices at any width (landscape foldables, tablets) get the same
+     44px row floor — the width-based rule above misses coarse pointers > 768px. */
+  @media (pointer: coarse) {
+    .unit {
+      min-height: 44px;
+    }
+  }
+
   /* Compact sidebar (touch foldables, narrow picker): the meta footer already
      frees the name from the right rail; here we trade the 2nd prompt line for
      density so more agents stay visible without the card growing taller. */

--- a/ui/src/lib/components/UpdateModal.svelte
+++ b/ui/src/lib/components/UpdateModal.svelte
@@ -338,6 +338,9 @@
   }
   .run:disabled {
     opacity: 0.6;
-    cursor: default;
+    cursor: not-allowed;
+    color: var(--color-faint);
+    border-color: var(--color-line);
+    box-shadow: none;
   }
 </style>

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -568,6 +568,10 @@
       theme: xtermTheme(initialTheme),
       minimumContrastRatio: xtermMinContrast(initialTheme),
       cursorBlink: true,
+      // Mirror terminal output into xterm's hidden ARIA live region so screen
+      // readers can follow the live agent session (the .term-mount region label
+      // alone names the area but exposes none of its scrolling content).
+      screenReaderMode: true,
       // Claude Code runs as a TUI with mouse tracking on, which hands mouse drags
       // to the app instead of selecting text. xterm lets a modifier force local
       // selection anyway — Shift on Linux/Windows, Option (⌥) on macOS — but the


### PR DESCRIPTION
Fixes all P1 and P2 findings from an `$impeccable audit` of the UI. CSS + ARIA + one xterm option; no behavior changes beyond keyboard nav. Each fix was spec- and quality-reviewed; a final cross-cutting review confirmed coherence. `bun run check`, `check:i18n` (522 keys parity), 377 UI tests, and the delta Fallow audit (`--base origin/main --fail-on-issues`) all pass; branch rebased linear on main.

## P1
- **Off-palette `--color-accent` phantom token** — never defined, so `Coachmark` + `GitRail .new-dot` always rendered an off-palette indigo (`#5f6ad2`). Coachmark button → neutral ghost (doctrine ghost-button spec); `.new-dot` → `var(--color-blue)` (the info accent). Breaks the Four-Light Rule no longer.
- **High-contrast layer missing status hues** — added `--green/--red/--blue` overrides to both `data-contrast="high"` blocks; each clears WCAG AAA (≈7:1) as text on its surface (verified: 7.2–12.6:1).
- **Live terminal opaque to screen readers** — `Viewport` xterm now `screenReaderMode: true` (mirrors output into an ARIA live region).
- **EmojiPicker search had no accessible name** — added `aria-label` (placeholder ≠ name).
- *(Settings tablist was flagged but already correct — audit false positive, confirmed.)*

## P2
- **RepoSelect listbox had no keyboard nav** — roving cursor on the filter input (↑/↓/Enter), `aria-activedescendant` + per-row ids + active-visual + scroll-into-view; `aria-selected` follows the cursor, matching `EmojiPicker`/`SlashCommandMenu`.
- **Disabled buttons relied on opacity alone** — `BroadcastDialog`/`NewTask`/`UpdateModal`/`HerdrUpdateModal` `.run:disabled` now neutralize the action-amber (→ `--color-faint`/`--color-line`, glow removed) + `cursor: not-allowed`, so disabled reads as disabled under high-contrast. Also guarded `.run.armed:not(:disabled)` so the armed glow can't bleed onto a disabled broadcast button.
- **Sub-44px touch targets** — `ActionBar` mobile buttons + `UnitRow` (`@media (pointer: coarse)`) get a 44px floor.
- **Popover width overflow** — `QueueStrip` pause text `min(320px, 50vw)`; `TopBar` gauge popover `max-width: min(280px, 85vw)`.

## Not changed (verified non-issues)
- GitRail `.pr-pop` already has `max-width: 90vw` (no overflow bug).
- DiffFileBlock `.hunks` overflow is already contained (`.file` is `display:block; overflow:hidden`).
- StatusPip `#000`/`#fff` are documented, contrast-tested deliberate exceptions (always-red badge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)