### PR TITLE
feat(ui): type-scale tokens, git-toggle status dot, persistent steer-fail toast

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -158,6 +158,17 @@ A desaturated, green-tinted monochrome ground with four reserved status accents.
 - **Label** (500, 11px, uppercase, +0.12em): Buttons, tab and status labels, toolbar chrome. The wide tracking and small caps read as machine labeling, not prose.
 - **Numeric** (400, 11px, +0.06em, tabular): Token counts, usage percentages, gauge readouts, SHAs. Tabular figures so digits never reflow as values tick.
 
+### Scale (implemented rung ladder)
+
+The hierarchy above is realized as a 6-rung type scale, the single source of truth for every font size. The rungs are CSS custom properties on `:root` in `app.css`; components read them as `var(--fs-*)` and never hardcode a px size. The ladder is anchored on the 11px (label / numeric) and 13px (title / body) defined above, with 10px as a deliberate floor so dense chrome never drops into sub-10px territory.
+
+- **micro** (`--fs-micro`, 10px): The floor. Dense chrome: pip captions, micro-badges, the tightest metadata.
+- **meta** (`--fs-meta`, 11px): Label and Numeric. Buttons, tab and status labels, counts, readouts.
+- **base** (`--fs-base`, 13px): Title and Body. The global base size and default running text.
+- **lg** (`--fs-lg`, 16px): Step-up emphasis: modal section heads, mobile inputs (also avoids iOS zoom-on-focus).
+- **xl** (`--fs-xl`, 20px): Prominent modal and empty-state headings.
+- **2xl** (`--fs-2xl`, 22px): The largest display step: update-modal hero and the like.
+
 ### Named Rules
 
 **The One Typeface Rule.** Everything is Berkeley Mono. A second family is forbidden; hierarchy is built from size, weight, case, and color only. The monospace grid is non-negotiable, it is what makes this an instrument.

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -59,6 +59,16 @@
   --scrim: rgba(3, 6, 5, 0.66);
   --term-fg: #c4d0cb;
 
+  /* Type scale — single source of truth. 6 deliberate rungs anchored on
+     DESIGN.md's 11px (label/numeric) + 13px (title/body); 10px is the floor for
+     dense chrome. Replaces ~16 drifted ad-hoc sizes. */
+  --fs-micro: 10px;
+  --fs-meta: 11px;
+  --fs-base: 13px;
+  --fs-lg: 16px;
+  --fs-xl: 20px;
+  --fs-2xl: 22px;
+
   --status-running: var(--color-amber);
   /* done = WAITING (finished turn, parked for the operator's next steer). It is
      NOT actionable-complete, so it must not read green/"ignore me" — it reads as
@@ -163,7 +173,7 @@ body {
   font-family: var(--font-mono);
   margin: 0;
   height: 100%;
-  font-size: 13px;
+  font-size: var(--fs-base);
   letter-spacing: 0.02em;
   -webkit-font-smoothing: antialiased;
 }

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -133,7 +133,7 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     cursor: pointer;
     background: transparent;
     white-space: nowrap;
@@ -157,7 +157,7 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.06em;
     font-variant-numeric: tabular-nums;
   }
@@ -194,7 +194,7 @@
     border: 0;
     border-left: 1px solid var(--color-line-bright);
     color: var(--color-muted);
-    font-size: 13px;
+    font-size: var(--fs-base);
     line-height: 1;
     padding: 4px 8px;
     cursor: pointer;
@@ -216,7 +216,7 @@
     border: 1px solid var(--color-line-bright);
     border-radius: 2px;
     color: var(--color-muted);
-    font-size: 13px;
+    font-size: var(--fs-base);
     line-height: 1;
     padding: 4px 8px;
     cursor: pointer;
@@ -236,11 +236,11 @@
     flex: 1;
     text-align: center;
     padding: 12px;
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   .actions.mobile .btn.backlog {
     padding: 12px 16px;
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
 
   /* Desktop-only hover tooltip surfacing the keyboard shortcut. Mirrors the
@@ -261,7 +261,7 @@
       border: 1px solid var(--color-line-bright);
       box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
       color: var(--color-ink-bright);
-      font-size: 10.5px;
+      font-size: var(--fs-meta);
       letter-spacing: 0.06em;
       text-transform: none;
       padding: 5px 9px;

--- a/ui/src/lib/components/ActionHistoryRow.svelte
+++ b/ui/src/lib/components/ActionHistoryRow.svelte
@@ -132,12 +132,12 @@
   }
 
   .hist-num {
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     color: var(--color-ink);
   }
   .hist-age,
   .hist-sha {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     color: var(--color-faint);
   }
   .hist-sha {
@@ -146,7 +146,7 @@
 
   .hist-caret {
     margin-left: auto;
-    font-size: 9px;
+    font-size: var(--fs-micro);
     color: var(--color-faint);
     transition: transform 0.12s;
   }
@@ -156,7 +156,7 @@
 
   .hist-link {
     flex-shrink: 0;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-faint);
     text-decoration: none;
     transition: color 0.12s;
@@ -178,7 +178,7 @@
     min-height: 12px;
   }
   .job-name {
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     color: var(--color-ink);
     text-decoration: none;
     overflow: hidden;
@@ -191,7 +191,7 @@
   }
 
   .muted {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-faint);
     padding: 2px 0 2px 13px;
   }

--- a/ui/src/lib/components/ActionRunRow.svelte
+++ b/ui/src/lib/components/ActionRunRow.svelte
@@ -243,7 +243,7 @@
 
   .wf-name {
     flex: 1;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     color: var(--color-ink-bright);
     overflow: hidden;
     white-space: nowrap;
@@ -252,7 +252,7 @@
 
   .wf-link {
     flex-shrink: 0;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-faint);
     text-decoration: none;
     transition: color 0.12s;
@@ -263,7 +263,7 @@
 
   .wf-err {
     flex-shrink: 0;
-    font-size: 9.5px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--color-red);
@@ -277,7 +277,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     padding: 2px 8px;
     cursor: pointer;
@@ -318,7 +318,7 @@
   }
 
   .job-name {
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     color: var(--color-ink);
     text-decoration: none;
     overflow: hidden;
@@ -376,7 +376,7 @@
     padding: 0;
     cursor: pointer;
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -387,7 +387,7 @@
   }
 
   .hist-caret {
-    font-size: 9px;
+    font-size: var(--fs-micro);
     color: var(--color-faint);
     transition: transform 0.12s;
   }
@@ -403,7 +403,7 @@
   }
 
   .hist-muted {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-faint);
     padding: 2px 0 2px 13px;
     text-align: left;
@@ -426,7 +426,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.08em;
     padding: 2px 8px;
     cursor: pointer;

--- a/ui/src/lib/components/ActionsPanel.svelte
+++ b/ui/src/lib/components/ActionsPanel.svelte
@@ -104,7 +104,7 @@
 
   .actions-header {
     padding: 6px 12px;
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -133,7 +133,7 @@
   }
 
   .muted {
-    font-size: 12px;
+    font-size: var(--fs-base);
     color: var(--color-faint);
     padding: 4px 0;
   }

--- a/ui/src/lib/components/ActivityFeed.svelte
+++ b/ui/src/lib/components/ActivityFeed.svelte
@@ -57,7 +57,7 @@
     height: 100%;
     overflow-y: auto;
     padding: 8px 10px;
-    font-size: 12px;
+    font-size: var(--fs-base);
     line-height: 1.5;
   }
   ul {

--- a/ui/src/lib/components/AutoPip.svelte
+++ b/ui/src/lib/components/AutoPip.svelte
@@ -18,7 +18,7 @@
 
 <style>
   .auto-pip {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 1px 6px;

--- a/ui/src/lib/components/AutomationPanel.svelte
+++ b/ui/src/lib/components/AutomationPanel.svelte
@@ -209,14 +209,14 @@
     overflow: hidden;
   }
   .auto-head {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--color-muted);
     padding: 10px 12px 4px;
   }
   .auto-group {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--color-amber);
@@ -238,11 +238,11 @@
   }
   .auto-name {
     font-family: var(--font-mono);
-    font-size: 13px;
+    font-size: var(--fs-base);
     color: var(--color-ink-bright);
   }
   .auto-desc {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
     margin-top: 2px;
   }
@@ -311,7 +311,7 @@
     gap: 8px;
   }
   .drain-label {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-ink);
     white-space: nowrap;
   }
@@ -323,7 +323,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 12px;
+    font-size: var(--fs-base);
     padding: 3px 6px;
     text-align: right;
   }

--- a/ui/src/lib/components/AutopilotBadge.svelte
+++ b/ui/src/lib/components/AutopilotBadge.svelte
@@ -18,7 +18,7 @@
 
 <style>
   .ap-paused {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 1px 6px;

--- a/ui/src/lib/components/BacklogOverlay.svelte
+++ b/ui/src/lib/components/BacklogOverlay.svelte
@@ -85,7 +85,7 @@
     border-bottom: 1px solid var(--color-line);
   }
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -97,7 +97,7 @@
     color: var(--color-muted);
     cursor: pointer;
     font: inherit;
-    font-size: 14px;
+    font-size: var(--fs-lg);
     line-height: 1;
     padding: 2px 6px;
   }

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -256,7 +256,7 @@
   }
 
   .skeleton-pulse {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--color-faint);
@@ -274,7 +274,7 @@
   }
 
   .empty-label {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--color-faint);
@@ -296,7 +296,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.1em;
     padding: 2px 8px;
     cursor: pointer;
@@ -366,7 +366,7 @@
   }
 
   .detail-empty-label {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--color-faint);
@@ -420,7 +420,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     padding: 6px 12px;
     cursor: pointer;

--- a/ui/src/lib/components/BroadcastDialog.svelte
+++ b/ui/src/lib/components/BroadcastDialog.svelte
@@ -182,7 +182,7 @@
     font: inherit;
   }
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -198,7 +198,7 @@
     color: var(--color-amber);
     cursor: pointer;
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
   }
   .targets {
     border: 1px solid var(--color-line);
@@ -216,7 +216,7 @@
     padding: 8px 10px;
     border-bottom: 1px solid var(--color-line);
     color: var(--color-ink-bright);
-    font-size: 13px;
+    font-size: var(--fs-base);
     cursor: pointer;
   }
   .target:last-child {
@@ -225,7 +225,7 @@
   .placeholder {
     padding: 14px 12px;
     color: var(--color-faint);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
   }
   .picks {
     display: flex;
@@ -238,7 +238,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font: inherit;
-    font-size: 12px;
+    font-size: var(--fs-base);
     padding: 5px 10px;
     cursor: pointer;
   }
@@ -252,13 +252,13 @@
     border-radius: 2px;
     color: var(--color-ink-bright);
     font: inherit;
-    font-size: 13px;
+    font-size: var(--fs-base);
     padding: 8px;
     resize: vertical;
   }
   .result {
     color: var(--color-amber);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     display: flex;
     align-items: center;
     gap: 8px;
@@ -273,7 +273,7 @@
     border-radius: 2px;
     color: var(--color-amber);
     font: inherit;
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.06em;
     padding: 3px 8px;
     cursor: pointer;
@@ -294,7 +294,7 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     cursor: pointer;
   }
   .run:disabled {

--- a/ui/src/lib/components/ClearMergedDialog.svelte
+++ b/ui/src/lib/components/ClearMergedDialog.svelte
@@ -93,7 +93,7 @@
     font: inherit;
   }
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -101,7 +101,7 @@
   .desc {
     margin: 0;
     color: var(--color-ink);
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     line-height: 1.4;
   }
   .rows {
@@ -120,14 +120,14 @@
     padding: 8px 10px;
     border-bottom: 1px solid var(--color-line);
     color: var(--color-ink-bright);
-    font-size: 13px;
+    font-size: var(--fs-base);
   }
   .row:last-child {
     border-bottom: 0;
   }
   .desig {
     font-family: var(--font-mono, monospace);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     color: var(--color-blue);
   }
@@ -140,7 +140,7 @@
   .warn {
     margin: 0;
     color: var(--color-amber);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     line-height: 1.4;
   }
   .actions {
@@ -158,7 +158,7 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     cursor: pointer;
   }
   .run {

--- a/ui/src/lib/components/CloneRepo.svelte
+++ b/ui/src/lib/components/CloneRepo.svelte
@@ -171,7 +171,7 @@
     font: inherit;
   }
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -182,7 +182,7 @@
     border: 1px solid var(--color-line);
     color: var(--color-ink-bright);
     font: inherit;
-    font-size: 13px;
+    font-size: var(--fs-base);
     padding: 8px 10px;
     border-radius: 2px;
     width: 100%;
@@ -193,14 +193,14 @@
     border-color: var(--color-line-bright);
   }
   .preview {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
     margin: 0;
     padding: 2px 0;
   }
   .err {
     color: var(--color-red);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     margin-top: 6px;
     display: flex;
     align-items: center;
@@ -213,7 +213,7 @@
     border-radius: 2px;
     color: var(--color-amber);
     font: inherit;
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.06em;
     padding: 3px 8px;
     cursor: pointer;
@@ -234,7 +234,7 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     cursor: pointer;
     box-shadow: inset 0 0 18px -10px var(--color-amber);
   }
@@ -257,7 +257,7 @@
       animation: sheet-up 0.18s ease-out;
     }
     input {
-      font-size: 16px; /* prevents iOS zoom-on-focus */
+      font-size: var(--fs-lg); /* prevents iOS zoom-on-focus */
       min-height: 44px;
     }
     .run {
@@ -277,7 +277,7 @@
       width: 44px;
       height: 44px;
       margin-right: -10px;
-      font-size: 16px;
+      font-size: var(--fs-lg);
     }
   }
 

--- a/ui/src/lib/components/Coachmark.svelte
+++ b/ui/src/lib/components/Coachmark.svelte
@@ -137,7 +137,7 @@
 
   .coachmark-title {
     margin: 0;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     font-weight: 600;
     letter-spacing: 0.06em;
     text-transform: uppercase;
@@ -146,7 +146,7 @@
 
   .coachmark-body {
     margin: 0;
-    font-size: 12px;
+    font-size: var(--fs-base);
     line-height: 1.5;
     color: var(--color-muted);
   }
@@ -155,7 +155,7 @@
     align-self: flex-end;
     margin-top: 2px;
     padding: 3px 10px;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     font-weight: 500;
     background: var(--color-accent, #5f6ad2);
     color: #fff;

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -455,7 +455,7 @@
     border: none;
     border-radius: 2px;
     color: var(--color-faint);
-    font-size: 15px;
+    font-size: var(--fs-lg);
     cursor: pointer;
     touch-action: manipulation;
     user-select: none;
@@ -488,7 +488,7 @@
     font-family: var(--font-mono);
     /* a touch smaller for density; under the 16px iOS no-zoom threshold, an
        accepted tradeoff since the overlay is centered and not edge-pinned */
-    font-size: 14px;
+    font-size: var(--fs-lg);
     line-height: 1.4;
     overflow-y: auto;
   }
@@ -526,7 +526,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     cursor: pointer;
     touch-action: pan-x;
     user-select: none;
@@ -554,7 +554,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 15px;
+    font-size: var(--fs-lg);
     cursor: pointer;
     touch-action: manipulation;
     user-select: none;
@@ -572,7 +572,7 @@
     border-color: var(--color-ink);
   }
   .btn.mic {
-    font-size: 16px;
+    font-size: var(--fs-lg);
     line-height: 1;
   }
   /* while listening: highlighted + a soft pulse so it reads as "recording" */

--- a/ui/src/lib/components/ControlBar.svelte
+++ b/ui/src/lib/components/ControlBar.svelte
@@ -141,7 +141,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 14px;
+    font-size: var(--fs-lg);
     letter-spacing: 0.04em;
     cursor: pointer;
     touch-action: manipulation;

--- a/ui/src/lib/components/CriticBadge.svelte
+++ b/ui/src/lib/components/CriticBadge.svelte
@@ -43,7 +43,7 @@
 
 <style>
   .critic-badge {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 1px 6px;

--- a/ui/src/lib/components/DiffFileBlock.svelte
+++ b/ui/src/lib/components/DiffFileBlock.svelte
@@ -120,7 +120,7 @@
     border: 0;
     cursor: pointer;
     font-family: var(--font-mono);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     color: var(--color-ink);
     text-align: left;
   }
@@ -172,11 +172,11 @@
     margin: 0;
     padding: 6px 10px;
     color: var(--color-muted);
-    font-size: 11px;
+    font-size: var(--fs-meta);
   }
   .hunks {
     overflow-x: auto;
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     line-height: 1.5;
   }
   .hunk-head {

--- a/ui/src/lib/components/DiffPanel.svelte
+++ b/ui/src/lib/components/DiffPanel.svelte
@@ -92,7 +92,7 @@
     padding: 5px 10px;
     border-bottom: 1px solid var(--color-line);
     background: var(--color-head);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     flex-shrink: 0;
   }
   .summary {
@@ -107,7 +107,7 @@
   }
   .stale {
     color: var(--color-amber);
-    font-size: 11px;
+    font-size: var(--fs-meta);
   }
   .spacer {
     flex: 1;
@@ -118,7 +118,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font: inherit;
-    font-size: 12px;
+    font-size: var(--fs-base);
     padding: 1px 8px;
     cursor: pointer;
   }
@@ -134,6 +134,6 @@
     color: var(--color-muted);
     margin: 0;
     padding: 4px 0;
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
 </style>

--- a/ui/src/lib/components/EmojiPicker.svelte
+++ b/ui/src/lib/components/EmojiPicker.svelte
@@ -151,7 +151,7 @@
     border: 1px solid var(--color-line);
     color: var(--color-ink-bright);
     font: inherit;
-    font-size: 12px;
+    font-size: var(--fs-base);
     padding: 6px 8px;
     border-radius: 2px;
   }
@@ -173,7 +173,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 16px;
+    font-size: var(--fs-lg);
     background: transparent;
     border: 0;
     border-radius: 2px;
@@ -205,7 +205,7 @@
     border: 1px solid var(--color-line);
     color: var(--color-ink-bright);
     font: inherit;
-    font-size: 16px; /* prevents iOS zoom-on-focus; also fits emoji */
+    font-size: var(--fs-lg); /* prevents iOS zoom-on-focus; also fits emoji */
     padding: 4px 7px;
     border-radius: 2px;
   }
@@ -218,7 +218,7 @@
     border: 1px solid var(--color-line-bright);
     color: var(--color-muted);
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     padding: 0 8px;
     border-radius: 2px;
     cursor: pointer;

--- a/ui/src/lib/components/EmptyHerd.svelte
+++ b/ui/src/lib/components/EmptyHerd.svelte
@@ -72,7 +72,7 @@
   }
 
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
   }
@@ -85,7 +85,7 @@
   .lede {
     margin: 0;
     color: var(--color-faint);
-    font-size: 12px;
+    font-size: var(--fs-base);
     line-height: 1.55;
   }
 
@@ -102,7 +102,7 @@
     background: transparent;
     color: var(--color-amber);
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     cursor: pointer;
@@ -113,7 +113,7 @@
     box-shadow: inset 0 0 24px -10px var(--color-amber);
   }
   .spawn span {
-    font-size: 13px;
+    font-size: var(--fs-base);
   }
 
   .verbs {
@@ -136,14 +136,14 @@
   .verb dd {
     margin: 0;
     color: var(--color-faint);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     line-height: 1.5;
   }
 
   .nudge {
     margin: 0;
     color: var(--color-faint);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     line-height: 1.5;
   }
   .nudge-link {
@@ -151,7 +151,7 @@
     background: none;
     padding: 0;
     font: inherit;
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     color: var(--color-amber);
     cursor: pointer;
     text-decoration: underline;

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -491,7 +491,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     padding: 2px 8px;
     white-space: nowrap;
@@ -580,7 +580,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     padding: 2px 8px;
@@ -614,10 +614,10 @@
   .rail.mobile .gbtn {
     min-height: 40px;
     padding: 6px 14px;
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   .rail.mobile .prlink {
-    font-size: 13px;
+    font-size: var(--fs-base);
     padding: 4px 2px;
   }
   .rail.mobile .dot {
@@ -626,7 +626,7 @@
   }
 
   .prlink {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
     text-decoration: none;
   }
@@ -635,7 +635,7 @@
   }
 
   .merged {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-slate);
   }
 
@@ -661,7 +661,7 @@
 
   .err,
   .ok {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     max-width: 160px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -699,7 +699,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 12px;
+    font-size: var(--fs-base);
     padding: 4px 6px;
     resize: vertical;
   }
@@ -752,7 +752,7 @@
     flex-shrink: 0;
   }
   .rv-label {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     white-space: nowrap;
@@ -771,7 +771,7 @@
     color: var(--color-faint);
   }
   .rv-prlink {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
     text-decoration: none;
   }
@@ -786,7 +786,7 @@
 
   .rv-summary {
     margin: 0;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-ink);
     /* pinned alongside head/footer; only .rv-body scrolls */
     flex-shrink: 0;
@@ -802,7 +802,7 @@
     border: 1px solid var(--color-line);
     border-radius: 2px;
     color: var(--color-ink);
-    font-size: 12px;
+    font-size: var(--fs-base);
     line-height: 1.5;
     padding: 6px 8px;
     overflow-wrap: anywhere;
@@ -831,7 +831,7 @@
   .rv-body :global(h3),
   .rv-body :global(h4) {
     margin: 12px 0 6px;
-    font-size: 12px;
+    font-size: var(--fs-base);
     font-weight: 600;
     color: var(--color-ink-bright);
   }
@@ -841,7 +841,7 @@
   }
   .rv-body :global(code) {
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     background: var(--color-line);
     border-radius: 2px;
     padding: 0 3px;

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -248,7 +248,7 @@
   }
 
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);

--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -217,7 +217,7 @@
     justify-content: space-between;
   }
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -227,7 +227,7 @@
     border: 0;
     color: var(--color-muted);
     cursor: pointer;
-    font-size: 13px;
+    font-size: var(--fs-base);
   }
   .summary {
     display: flex;
@@ -236,7 +236,7 @@
   }
   .summary .versions {
     color: var(--color-amber);
-    font-size: 20px;
+    font-size: var(--fs-xl);
     font-weight: 700;
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.04em;
@@ -249,7 +249,7 @@
     border: 1px solid var(--color-line);
     background: var(--color-inset);
     padding: 10px 12px;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     line-height: 1.5;
     color: var(--color-ink-bright);
     overflow-wrap: anywhere;
@@ -285,7 +285,7 @@
   .notes :global(h3),
   .notes :global(h4) {
     margin: 12px 0 6px;
-    font-size: 13px;
+    font-size: var(--fs-base);
     font-weight: 600;
     color: var(--color-ink-bright);
   }
@@ -295,7 +295,7 @@
   }
   .notes :global(code) {
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     background: var(--color-line);
     border-radius: 2px;
     padding: 0 3px;
@@ -326,7 +326,7 @@
     border: 1px solid var(--color-line-bright);
     background: color-mix(in srgb, var(--color-amber) 8%, transparent);
     padding: 10px 12px;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     line-height: 1.5;
     color: var(--color-ink-bright);
   }
@@ -335,13 +335,13 @@
     border: 1px solid var(--color-red);
     background: color-mix(in srgb, var(--color-red) 12%, transparent);
     padding: 10px 12px;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     line-height: 1.5;
     color: var(--color-red);
   }
   .status {
     color: var(--color-amber);
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   .log-label {
     margin-bottom: -8px;
@@ -354,7 +354,7 @@
     background: var(--color-inset);
     padding: 10px 12px;
     font-family: monospace;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     line-height: 1.5;
     color: var(--color-ink-bright);
     white-space: pre-wrap;
@@ -362,7 +362,7 @@
   }
   .err {
     color: var(--color-red);
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   .actions {
     display: flex;

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -119,7 +119,7 @@
 
   .issues-header {
     padding: 6px 12px;
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -164,7 +164,7 @@
   }
 
   .issue-num {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     color: var(--color-faint);
     flex-shrink: 0;
     text-decoration: none;
@@ -177,7 +177,7 @@
 
   .issue-title {
     flex: 1;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     color: var(--color-ink);
     line-height: 1.4;
     word-break: break-word;
@@ -196,7 +196,7 @@
   }
 
   .label-chip {
-    font-size: 9.5px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -206,7 +206,7 @@
   }
 
   .body-preview {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
     line-height: 1.4;
     display: -webkit-box;
@@ -218,7 +218,7 @@
   }
 
   .age-chip {
-    font-size: 9.5px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.1em;
     color: var(--color-faint);
     padding: 1px 0;
@@ -238,7 +238,7 @@
     border-radius: 2px;
     color: var(--color-amber);
     font-family: var(--font-mono);
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     padding: 2px 8px;
     cursor: pointer;
@@ -258,7 +258,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     padding: 2px 8px;
     cursor: pointer;
@@ -273,7 +273,7 @@
   }
 
   .muted {
-    font-size: 12px;
+    font-size: var(--fs-base);
     color: var(--color-faint);
     padding: 4px 0;
   }

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -189,7 +189,7 @@
   }
   .title {
     letter-spacing: 0.14em;
-    font-size: 12px;
+    font-size: var(--fs-base);
     text-transform: uppercase;
     color: var(--color-muted);
   }
@@ -198,11 +198,11 @@
     border: none;
     color: var(--color-muted);
     cursor: pointer;
-    font-size: 14px;
+    font-size: var(--fs-lg);
   }
   .empty {
     color: var(--color-muted);
-    font-size: 13px;
+    font-size: var(--fs-base);
     line-height: 1.5;
   }
   .group {
@@ -218,12 +218,12 @@
     padding-bottom: 4px;
   }
   .repo {
-    font-size: 12px;
+    font-size: var(--fs-base);
     color: var(--color-ink-bright);
     font-weight: 600;
   }
   .distill {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     background: none;
     border: 1px solid var(--color-line-bright);
     color: var(--color-muted);
@@ -245,17 +245,17 @@
     border: 1px solid var(--color-line);
     padding: 6px;
     font: inherit;
-    font-size: 13px;
+    font-size: var(--fs-base);
   }
   .why {
-    font-size: 12px;
+    font-size: var(--fs-base);
     color: var(--color-muted);
     line-height: 1.4;
   }
   .why span {
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    font-size: 10px;
+    font-size: var(--fs-micro);
   }
   .foot {
     display: flex;
@@ -263,7 +263,7 @@
     gap: 8px;
   }
   .evi {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
   }
   .spacer {
@@ -271,7 +271,7 @@
   }
   .dismiss,
   .approve {
-    font-size: 12px;
+    font-size: var(--fs-base);
     padding: 5px 12px;
     cursor: pointer;
     border: 1px solid var(--color-line-bright);
@@ -283,7 +283,7 @@
     color: var(--color-green);
   }
   .promote {
-    font-size: 12px;
+    font-size: var(--fs-base);
     padding: 5px 12px;
     cursor: pointer;
     border: 1px solid var(--color-green);
@@ -291,7 +291,7 @@
     color: var(--color-green);
   }
   .prlink {
-    font-size: 12px;
+    font-size: var(--fs-base);
     color: var(--color-green);
     text-decoration: none;
   }
@@ -310,13 +310,13 @@
     gap: 8px;
   }
   .ititle {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     text-transform: uppercase;
     letter-spacing: 0.1em;
     color: var(--color-muted);
   }
   .meter {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
     font-variant-numeric: tabular-nums;
   }
@@ -328,7 +328,7 @@
     gap: 6px;
   }
   .itext {
-    font-size: 13px;
+    font-size: var(--fs-base);
     color: var(--color-ink-bright);
     line-height: 1.4;
   }
@@ -338,7 +338,7 @@
     gap: 6px;
   }
   .chip {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     text-transform: uppercase;
     letter-spacing: 0.06em;
     padding: 2px 6px;
@@ -350,7 +350,7 @@
     color: var(--color-green);
   }
   .badge {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     padding: 2px 6px;
     border: 1px solid var(--color-line);
   }

--- a/ui/src/lib/components/LeftoverDialog.svelte
+++ b/ui/src/lib/components/LeftoverDialog.svelte
@@ -104,7 +104,7 @@
     font: inherit;
   }
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -112,7 +112,7 @@
   .desc {
     margin: 0;
     color: var(--color-ink);
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     line-height: 1.4;
   }
   .rows {
@@ -131,7 +131,7 @@
     padding: 8px 10px;
     border-bottom: 1px solid var(--color-line);
     color: var(--color-ink-bright);
-    font-size: 13px;
+    font-size: var(--fs-base);
     cursor: pointer;
   }
   .row:last-child {
@@ -143,7 +143,7 @@
   .port {
     margin-left: auto;
     color: var(--color-muted);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
   }
   .actions {
     display: flex;
@@ -160,7 +160,7 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     cursor: pointer;
   }
   .run {

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -509,7 +509,7 @@
     font: inherit;
   }
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -525,7 +525,7 @@
     border: 1px solid var(--color-line);
     color: var(--color-ink-bright);
     font: inherit;
-    font-size: 13px;
+    font-size: var(--fs-base);
     padding: 8px 10px;
     border-radius: 2px;
     width: 100%;
@@ -551,7 +551,7 @@
   }
   .err {
     color: var(--color-red);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     margin-top: 6px;
     display: flex;
     align-items: center;
@@ -564,7 +564,7 @@
     border-radius: 2px;
     color: var(--color-amber);
     font: inherit;
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.06em;
     padding: 3px 8px;
     cursor: pointer;
@@ -585,7 +585,7 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     cursor: pointer;
     box-shadow: inset 0 0 18px -10px var(--color-amber);
   }
@@ -595,7 +595,7 @@
   }
   .kbd {
     font: inherit;
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.04em;
     text-transform: none;
     color: var(--color-amber);
@@ -621,7 +621,7 @@
     textarea,
     input,
     select {
-      font-size: 16px; /* prevents iOS zoom-on-focus */
+      font-size: var(--fs-lg); /* prevents iOS zoom-on-focus */
     }
     input,
     select,
@@ -647,7 +647,7 @@
       width: 44px;
       height: 44px;
       margin-right: -10px; /* nudge the glyph toward the sheet edge */
-      font-size: 16px;
+      font-size: var(--fs-lg);
     }
     label[for="nt-prompt"] {
       display: none;
@@ -690,7 +690,7 @@
     border: 1px solid var(--color-line-bright);
     color: var(--color-ink);
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.06em;
     padding: 6px 10px;
     border-radius: 2px;
@@ -701,7 +701,7 @@
     cursor: default;
   }
   .hint {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
   }
   .chips {
@@ -719,7 +719,7 @@
     border: 1px solid var(--color-line);
     border-radius: 2px;
     padding: 3px 7px;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-ink);
   }
   .chip-name {
@@ -745,11 +745,11 @@
     border: 1px solid var(--color-line);
     border-radius: 2px;
     background: var(--color-inset);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
   }
   .issue-ref-label {
     flex-shrink: 0;
-    font-size: 9.5px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.16em;
     text-transform: uppercase;
     color: var(--color-faint);

--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -36,7 +36,7 @@
 
 <style>
   .pr-badge {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 1px 6px;

--- a/ui/src/lib/components/PrRow.svelte
+++ b/ui/src/lib/components/PrRow.svelte
@@ -254,7 +254,7 @@
   }
 
   .pr-num {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     color: var(--color-faint);
     flex-shrink: 0;
     text-decoration: none;
@@ -267,7 +267,7 @@
 
   .pr-title {
     flex: 1;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     color: var(--color-ink);
     line-height: 1.4;
     word-break: break-word;
@@ -281,7 +281,7 @@
   /* DRAFT is metadata, not state — a neutral hairline chip, never a status hue. */
   .draft-chip {
     flex-shrink: 0;
-    font-size: 9.5px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     color: var(--color-faint);
@@ -337,7 +337,7 @@
   }
 
   .caret {
-    font-size: 8px;
+    font-size: var(--fs-micro);
     line-height: 1;
     color: var(--color-faint);
     transition:
@@ -363,7 +363,7 @@
   }
 
   .job-name {
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     color: var(--color-ink);
     text-decoration: none;
     overflow: hidden;
@@ -394,14 +394,14 @@
   }
 
   .conflict {
-    font-size: 9.5px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--color-red);
   }
 
   .author {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
     overflow: hidden;
     white-space: nowrap;
@@ -410,7 +410,7 @@
 
   .age-chip {
     margin-left: auto;
-    font-size: 9.5px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.1em;
     color: var(--color-faint);
     font-variant-numeric: tabular-nums;
@@ -436,7 +436,7 @@
   }
 
   .merge-err {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--color-red);
@@ -450,7 +450,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     padding: 2px 8px;
     cursor: pointer;
@@ -489,7 +489,7 @@
 
   /* "rebase requested" — a settled, non-alarming confirmation (muted, not red). */
   .rebase-note {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--color-muted);

--- a/ui/src/lib/components/ProjectRow.svelte
+++ b/ui/src/lib/components/ProjectRow.svelte
@@ -89,7 +89,7 @@
 
   .row-name {
     color: var(--color-ink-bright);
-    font-size: 13px;
+    font-size: var(--fs-base);
     font-weight: 500;
     letter-spacing: 0.03em;
     overflow: hidden;
@@ -98,7 +98,7 @@
   }
 
   .pinned-badge {
-    font-size: 9px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--color-amber);
@@ -113,7 +113,7 @@
     align-items: center;
     gap: 4px;
     flex-shrink: 0;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
     letter-spacing: 0.04em;
     font-variant-numeric: tabular-nums;

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -220,7 +220,7 @@
   }
 
   .seed-label {
-    font-size: 9.5px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-faint);
@@ -242,7 +242,7 @@
     border: 1px solid transparent;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.1em;
     text-transform: uppercase;
     padding: 2px 8px;
@@ -283,7 +283,7 @@
 
   .muted {
     font-family: var(--font-mono);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     color: var(--color-faint);
     padding: 6px 10px;
   }
@@ -296,7 +296,7 @@
     border: none;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 12px;
+    font-size: var(--fs-base);
     text-align: left;
     padding: 4px 10px;
     cursor: pointer;
@@ -315,13 +315,13 @@
   .row-marker {
     color: var(--color-faint);
     flex-shrink: 0;
-    font-size: 10px;
+    font-size: var(--fs-micro);
   }
 
   .issue-num {
     color: var(--color-muted);
     flex-shrink: 0;
-    font-size: 11px;
+    font-size: var(--fs-meta);
   }
 
   /* Sticky so it stays put while the (potentially long) command list scrolls. */
@@ -334,7 +334,7 @@
     border: 1px solid var(--color-line);
     color: var(--color-ink-bright);
     font-family: var(--font-mono);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     padding: 4px 8px;
     border-radius: 2px;
   }
@@ -367,7 +367,7 @@
   }
 
   .chip {
-    font-size: 9px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--color-slate);

--- a/ui/src/lib/components/PrsPanel.svelte
+++ b/ui/src/lib/components/PrsPanel.svelte
@@ -80,7 +80,7 @@
 
   .prs-header {
     padding: 6px 12px;
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -109,7 +109,7 @@
   }
 
   .muted {
-    font-size: 12px;
+    font-size: var(--fs-base);
     color: var(--color-faint);
     padding: 4px 0;
   }

--- a/ui/src/lib/components/QueueStrip.svelte
+++ b/ui/src/lib/components/QueueStrip.svelte
@@ -126,7 +126,7 @@
     font-family: var(--font-mono);
   }
   .qs-label {
-    font-size: 9.5px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.16em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -149,7 +149,7 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -219,13 +219,13 @@
     letter-spacing: normal;
   }
   .qs-pop-head {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--color-muted);
   }
   .qs-pop-state {
-    font-size: 12px;
+    font-size: var(--fs-base);
     color: var(--color-muted);
   }
   .qs-pop-fail {
@@ -248,7 +248,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     text-decoration: none;
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   .qs-pop-item:hover,
   .qs-pop-item:focus-visible {

--- a/ui/src/lib/components/ReadyToggle.svelte
+++ b/ui/src/lib/components/ReadyToggle.svelte
@@ -46,7 +46,7 @@
   }
   /* rail variant: matches the sibling .gbtn buttons in the GitRail rail */
   .ready-toggle.rail {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     padding: 2px 8px;
   }
@@ -60,7 +60,7 @@
     align-items: center;
     flex-shrink: 0;
     border-color: var(--color-line-bright);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 2px 7px;

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -177,7 +177,7 @@
     border: 1px solid var(--color-line);
     color: var(--color-ink-bright);
     font: inherit;
-    font-size: 13px;
+    font-size: var(--fs-base);
     padding: 8px 10px;
     border-radius: 2px;
     cursor: pointer;
@@ -206,7 +206,7 @@
 
   .rs-trigger .dim {
     color: var(--color-muted);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -221,7 +221,7 @@
   .chevron {
     margin-left: auto;
     color: var(--color-muted);
-    font-size: 10px;
+    font-size: var(--fs-micro);
   }
 
   .rs-panel {
@@ -244,7 +244,7 @@
     border-bottom: 1px solid var(--color-line);
     color: var(--color-ink-bright);
     font: inherit;
-    font-size: 12px;
+    font-size: var(--fs-base);
     padding: 7px 10px;
     border-radius: 0;
     flex-shrink: 0;
@@ -271,7 +271,7 @@
     padding: 7px 10px;
     cursor: pointer;
     border-bottom: 1px solid var(--color-line);
-    font-size: 13px;
+    font-size: var(--fs-base);
     color: var(--color-ink-bright);
     overflow: hidden;
   }
@@ -298,7 +298,7 @@
 
   .rs-row .dim {
     color: var(--color-muted);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -308,7 +308,7 @@
   .rs-empty {
     padding: 10px;
     color: var(--color-muted);
-    font-size: 12px;
+    font-size: var(--fs-base);
     font-style: italic;
     text-align: center;
   }
@@ -323,7 +323,7 @@
     border-top: 1px solid var(--color-line);
     background: transparent;
     font: inherit;
-    font-size: 13px;
+    font-size: var(--fs-base);
     color: var(--color-amber);
     text-align: left;
   }
@@ -334,7 +334,7 @@
 
   .rs-emoji {
     flex-shrink: 0;
-    font-size: 13px;
+    font-size: var(--fs-base);
     line-height: 1;
   }
   .rs-emoji-btn {
@@ -342,7 +342,7 @@
     background: transparent;
     border: 1px solid transparent;
     border-radius: 2px;
-    font-size: 14px;
+    font-size: var(--fs-lg);
     line-height: 1;
     padding: 1px 3px;
     cursor: pointer;
@@ -364,7 +364,7 @@
       min-height: 44px;
     }
     .rs-filter {
-      font-size: 16px; /* prevents iOS zoom-on-focus */
+      font-size: var(--fs-lg); /* prevents iOS zoom-on-focus */
     }
     .rs-row {
       min-height: 44px;

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -559,7 +559,7 @@
     margin-bottom: -1px;
     color: var(--color-muted);
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     font-weight: 500;
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -607,7 +607,7 @@
     font: inherit;
   }
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -628,7 +628,7 @@
   }
   .herdr-cta .hc-dot {
     color: var(--color-green);
-    font-size: 9px;
+    font-size: var(--fs-micro);
   }
   .herdr-cta .hc-text {
     display: flex;
@@ -639,17 +639,17 @@
   }
   .herdr-cta .hc-label {
     color: var(--color-green);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.14em;
     text-transform: uppercase;
   }
   .herdr-cta .hc-ver {
     color: var(--color-muted);
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   .herdr-cta .hc-chev {
     color: var(--color-green);
-    font-size: 18px;
+    font-size: var(--fs-xl);
     line-height: 1;
   }
   .cur {
@@ -663,7 +663,7 @@
   }
   .cur code {
     color: var(--color-amber);
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     word-break: break-all;
   }
   .path-label {
@@ -679,7 +679,7 @@
     border: 1px solid var(--color-line-bright);
     color: var(--color-ink);
     font: inherit;
-    font-size: 14px;
+    font-size: var(--fs-lg);
     line-height: 1;
     padding: 5px 9px;
     border-radius: 2px;
@@ -691,7 +691,7 @@
   }
   .here {
     color: var(--color-ink-bright);
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     word-break: break-all;
   }
   .list {
@@ -706,7 +706,7 @@
   .placeholder {
     padding: 14px 12px;
     color: var(--color-faint);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.06em;
   }
   .row {
@@ -718,7 +718,7 @@
     border-bottom: 1px solid var(--color-line);
     color: var(--color-ink-bright);
     font: inherit;
-    font-size: 13px;
+    font-size: var(--fs-base);
     text-align: left;
     padding: 9px 11px;
     cursor: pointer;
@@ -743,7 +743,7 @@
   }
   .err {
     color: var(--color-red);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     margin-top: 2px;
   }
   .run {
@@ -754,7 +754,7 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     cursor: pointer;
     box-shadow: inset 0 0 18px -10px var(--color-amber);
   }
@@ -773,7 +773,7 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     cursor: pointer;
   }
   .clone-trigger:hover {
@@ -792,7 +792,7 @@
   }
   .push .hint {
     color: var(--color-faint);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     margin: 0;
   }
   .cats {
@@ -811,7 +811,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     cursor: pointer;
   }
   .cat input {
@@ -824,7 +824,7 @@
   }
   .rc .hint {
     color: var(--color-faint);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     margin: 0;
   }
   .sc {
@@ -834,7 +834,7 @@
   }
   .sc .hint {
     color: var(--color-faint);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     margin: 0;
   }
   .sc-input {
@@ -846,7 +846,7 @@
     background: var(--color-inset);
     color: var(--color-ink-bright);
     font-family: var(--font-mono);
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     line-height: 1.5;
     padding: 8px 10px;
     border-radius: 2px;
@@ -904,7 +904,7 @@
     background: var(--color-ink-bright);
   }
   .toggle .state {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     color: var(--color-ink-bright);
@@ -926,7 +926,7 @@
     border: 0;
     border-left: 1px solid var(--color-line-bright);
     color: var(--color-muted);
-    font-size: 16px;
+    font-size: var(--fs-lg);
     line-height: 1;
     padding: 0 16px;
     min-height: 44px;
@@ -957,12 +957,12 @@
   }
   .about-grid dt {
     color: var(--color-faint);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.06em;
   }
   .about-grid dd {
     margin: 0;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     color: var(--color-ink-bright);
     word-break: break-all;
   }

--- a/ui/src/lib/components/SlashCommandMenu.svelte
+++ b/ui/src/lib/components/SlashCommandMenu.svelte
@@ -102,13 +102,13 @@
   .sc-name {
     font-family: var(--font-mono);
     font-weight: 600;
-    font-size: 13px;
+    font-size: var(--fs-base);
     color: var(--color-amber);
     white-space: nowrap;
   }
   .sc-hint {
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -118,7 +118,7 @@
   .sc-scope {
     margin-left: auto;
     flex-shrink: 0;
-    font-size: 9px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--color-slate);
@@ -127,7 +127,7 @@
     padding: 0 4px;
   }
   .sc-desc {
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-faint);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -138,7 +138,7 @@
     font-family: var(--font-mono);
     padding: 10px;
     color: var(--color-faint);
-    font-size: 12px;
+    font-size: var(--fs-base);
     font-style: italic;
     text-align: center;
   }
@@ -148,7 +148,7 @@
     }
     .sc-name,
     .sc-hint {
-      font-size: 14px;
+      font-size: var(--fs-lg);
     }
   }
 </style>

--- a/ui/src/lib/components/StatusPip.svelte
+++ b/ui/src/lib/components/StatusPip.svelte
@@ -60,7 +60,7 @@
     background: none;
     box-shadow: none;
     color: var(--c);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     line-height: 1;
     font-weight: 700;
   }
@@ -87,7 +87,7 @@
        token inverts to dark there and would tank the contrast. White maximizes
        it (~5:1 on the darkened red above). */
     color: #fff;
-    font-size: 12px;
+    font-size: var(--fs-base);
     line-height: 1;
     font-weight: 800;
   }

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -66,12 +66,15 @@
   // Route the failure through a persistent toast (duration: null, stays until
   // retried or closed) with an inline Retry (retry re-runs send(), so a repeated
   // failure re-toasts), announced assertively (alert) so a screen-reader
-  // operator hears it promptly. Replaces a self-clearing flash easily missed.
+  // operator hears it promptly. Keyed per focused agent so repeated failures
+  // collapse into one toast (Retry targets the latest) instead of stacking.
+  // Replaces a self-clearing flash easily missed.
   function send(text: string) {
     replySession(focusedId, text).catch(() => {
       toasts.info(m.steerbar_send_failed(), {
         duration: null,
         alert: true,
+        key: `steer-fail:${focusedId}`,
         action: { label: m.common_retry(), run: () => send(text) },
       });
     });

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -63,12 +63,15 @@
   }
 
   // Steering is the product's core risky action: a failed send must not vanish.
-  // Route the failure through the persistent toast store with an inline Retry
-  // (retry re-runs send(), so a repeated failure re-toasts) instead of a
-  // self-clearing flash the operator can easily miss.
+  // Route the failure through a persistent toast (duration: null, stays until
+  // retried or closed) with an inline Retry (retry re-runs send(), so a repeated
+  // failure re-toasts), announced assertively (alert) so a screen-reader
+  // operator hears it promptly. Replaces a self-clearing flash easily missed.
   function send(text: string) {
     replySession(focusedId, text).catch(() => {
       toasts.info(m.steerbar_send_failed(), {
+        duration: null,
+        alert: true,
         action: { label: m.common_retry(), run: () => send(text) },
       });
     });

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { steers } from "$lib/steers.svelte";
   import { replySession } from "$lib/api";
+  import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
 
   let { focusedId, onbroadcast }: { focusedId: string; onbroadcast: () => void } = $props();
-
-  let flash = $state<string | null>(null);
 
   // One-time coachmark: the steer chips are tap-to-send and the leading 📡 chip
   // broadcasts to many sessions — neither affordance is obvious on first sight.
@@ -63,10 +62,15 @@
     action();
   }
 
+  // Steering is the product's core risky action: a failed send must not vanish.
+  // Route the failure through the persistent toast store with an inline Retry
+  // (retry re-runs send(), so a repeated failure re-toasts) instead of a
+  // self-clearing flash the operator can easily miss.
   function send(text: string) {
     replySession(focusedId, text).catch(() => {
-      flash = m.steerbar_send_failed();
-      setTimeout(() => (flash = null), 1500);
+      toasts.info(m.steerbar_send_failed(), {
+        action: { label: m.common_retry(), run: () => send(text) },
+      });
     });
   }
 </script>
@@ -105,7 +109,6 @@
       onpointerup={(e) => tap(e, () => send(s.text))}>{s.label}</button
     >
   {/each}
-  {#if flash}<span class="flash" role="alert">{flash}</span>{/if}
 </div>
 
 <style>
@@ -136,7 +139,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     cursor: pointer;
     touch-action: manipulation;
     user-select: none;
@@ -177,13 +180,6 @@
       display: none;
     }
   }
-  .flash {
-    align-self: center;
-    color: var(--color-red);
-    font-size: 11px;
-    padding-left: 6px;
-  }
-
   /* one-time steer hint: flat, square, hairline-bordered, muted ink — sits
      directly above the steer row, no shadow or glow at rest */
   .coach {
@@ -195,7 +191,7 @@
     border-top: 1px solid var(--color-line);
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     line-height: 1.35;
   }
   .coach-text {
@@ -210,7 +206,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     cursor: pointer;
     touch-action: manipulation;
     transition:

--- a/ui/src/lib/components/SteersEditor.svelte
+++ b/ui/src/lib/components/SteersEditor.svelte
@@ -122,7 +122,7 @@
     padding-top: 10px;
   }
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -159,7 +159,7 @@
     border-radius: 2px;
     color: var(--color-ink-bright);
     font: inherit;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     padding: 6px 8px;
   }
   .srow .label {
@@ -182,12 +182,12 @@
   }
   .placeholder {
     color: var(--color-faint);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     padding: 6px 2px;
   }
   .err {
     color: var(--color-red);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
   }
   .actions {
     display: flex;
@@ -200,7 +200,7 @@
     background: transparent;
     color: var(--color-ink);
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     padding: 8px 12px;

--- a/ui/src/lib/components/Toasts.svelte
+++ b/ui/src/lib/components/Toasts.svelte
@@ -6,7 +6,7 @@
 {#if toasts.items.length}
   <div class="toasts" aria-live="polite" aria-atomic="false">
     {#each toasts.items as t (t.id)}
-      <div class="toast" class:is-undo={t.tone === "undo"} role="status">
+      <div class="toast" class:is-undo={t.tone === "undo"} role={t.alert ? "alert" : "status"}>
         <span class="msg">{t.text}</span>
         {#if t.tone === "undo"}
           <button type="button" class="undo" onclick={() => toasts.cancel(t.id)}>

--- a/ui/src/lib/components/Toasts.svelte
+++ b/ui/src/lib/components/Toasts.svelte
@@ -66,7 +66,7 @@
   }
   .msg {
     color: var(--color-ink-bright);
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     letter-spacing: 0.02em;
   }
   .undo {
@@ -78,7 +78,7 @@
     border-radius: 2px;
     color: var(--color-amber);
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 5px 10px;
@@ -107,7 +107,7 @@
     border: 0;
     color: var(--color-muted);
     font: inherit;
-    font-size: 12px;
+    font-size: var(--fs-base);
     cursor: pointer;
     padding: 2px 4px;
   }

--- a/ui/src/lib/components/TodoPanel.svelte
+++ b/ui/src/lib/components/TodoPanel.svelte
@@ -129,7 +129,7 @@
     justify-content: space-between;
     gap: 8px;
     padding: 6px 12px;
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -143,7 +143,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 9.5px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 2px 7px;
@@ -224,7 +224,7 @@
   }
 
   .item-label {
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     color: var(--color-ink);
     line-height: 1.5;
     word-break: break-word;
@@ -241,21 +241,21 @@
   }
 
   .line-heading {
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     color: var(--color-ink-bright);
     font-weight: bold;
     padding: 4px 0 2px;
   }
 
   .line-plain {
-    font-size: 12px;
+    font-size: var(--fs-base);
     color: var(--color-muted);
     padding: 1px 0;
   }
 
   .muted,
   .empty-hint {
-    font-size: 12px;
+    font-size: var(--fs-base);
     color: var(--color-faint);
     padding: 4px 0;
   }
@@ -275,7 +275,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    font-size: 12px;
+    font-size: var(--fs-base);
     padding: 5px 8px;
     outline: none;
     transition: border-color 0.15s;
@@ -295,7 +295,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     padding: 5px 10px;
     cursor: pointer;
@@ -329,7 +329,7 @@
       height: 10px;
     }
     .add-input {
-      font-size: 16px; /* prevents iOS zoom-on-focus */
+      font-size: var(--fs-lg); /* prevents iOS zoom-on-focus */
     }
     .add-btn {
       min-height: 40px;

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -345,7 +345,7 @@
     font-weight: 700;
     letter-spacing: 0.34em;
     color: var(--color-ink-bright);
-    font-size: 15px;
+    font-size: var(--fs-lg);
     flex-shrink: 0;
   }
   .logo b {
@@ -357,7 +357,7 @@
     background: var(--color-line-bright);
   }
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -381,7 +381,7 @@
     border: 1px solid var(--color-red);
     color: var(--color-red);
     letter-spacing: 0.14em;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     padding: 5px 10px;
     cursor: pointer;
     white-space: nowrap;
@@ -392,7 +392,7 @@
     border: 1px solid var(--color-line-bright);
     color: var(--color-muted);
     letter-spacing: 0.14em;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     padding: 5px 10px;
     cursor: pointer;
     white-space: nowrap;
@@ -418,7 +418,7 @@
     background: transparent;
     border: 1px solid var(--color-line-bright);
     color: var(--color-muted);
-    font-size: 14px;
+    font-size: var(--fs-lg);
     line-height: 1;
     padding: 5px 8px;
     border-radius: 2px;
@@ -454,7 +454,7 @@
     color: var(--color-blue, #4a9eff);
     cursor: pointer;
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     border-radius: 2px;
@@ -463,7 +463,7 @@
     background: color-mix(in srgb, var(--color-blue, #4a9eff) 22%, transparent);
   }
   .whatsnew-badge .wn-dot {
-    font-size: 8px;
+    font-size: var(--fs-micro);
   }
   /* Phone-only: bare pip button, no label — mirrors .gear-dot folded pattern. */
   .whatsnew-dot-btn {
@@ -471,7 +471,7 @@
     background: transparent;
     border: 1px solid var(--color-line-bright);
     color: var(--color-muted);
-    font-size: 14px;
+    font-size: var(--fs-lg);
     line-height: 1;
     padding: 5px 8px;
     border-radius: 2px;
@@ -522,7 +522,7 @@
     transition: transform 0.6s ease;
   }
   .g-pct {
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     min-width: 30px;
     text-align: right;
   }
@@ -602,14 +602,14 @@
     color: var(--color-amber);
     cursor: pointer;
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     border-radius: 2px;
     animation: update-pulse 2.4s ease-in-out infinite;
   }
   .update-badge .up-dot {
-    font-size: 8px;
+    font-size: var(--fs-micro);
   }
   .update-badge .up-n {
     font-variant-numeric: tabular-nums;
@@ -669,7 +669,7 @@
     padding: 10px 12px;
   }
   .hud.mobile .logo {
-    font-size: 13px;
+    font-size: var(--fs-base);
     letter-spacing: 0.12em;
   }
   .tallies.compact {
@@ -680,7 +680,7 @@
     flex-shrink: 0;
   }
   .tallies.compact .cdot {
-    font-size: 9px;
+    font-size: var(--fs-micro);
   }
   .tallies.compact .csep {
     color: var(--color-faint);
@@ -709,7 +709,7 @@
     min-height: 44px;
     min-width: 44px;
     padding: 5px 11px;
-    font-size: 16px;
+    font-size: var(--fs-lg);
   }
   .hud.mobile .gauge-btn {
     padding: 0 6px;
@@ -806,7 +806,7 @@
       border: 1px solid var(--color-line-bright);
       box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
       color: var(--color-ink-bright);
-      font-size: 10.5px;
+      font-size: var(--fs-meta);
       letter-spacing: 0.06em;
       text-transform: none;
       padding: 5px 9px;

--- a/ui/src/lib/components/TriageDrawer.svelte
+++ b/ui/src/lib/components/TriageDrawer.svelte
@@ -176,7 +176,7 @@
   .title {
     color: var(--color-red);
     letter-spacing: 0.18em;
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   .x {
     background: none;
@@ -185,11 +185,11 @@
     cursor: pointer;
     min-width: 40px;
     min-height: 40px;
-    font-size: 15px;
+    font-size: var(--fs-lg);
   }
   .empty {
     color: var(--color-muted);
-    font-size: 13px;
+    font-size: var(--fs-base);
   }
   .row {
     border: 1px solid var(--color-line);
@@ -217,7 +217,7 @@
   .waited {
     color: var(--color-amber);
     font-variant-numeric: tabular-nums;
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   .stall-head {
     display: flex;
@@ -227,13 +227,13 @@
   .stall-note {
     margin: 0;
     color: var(--color-amber);
-    font-size: 12px;
+    font-size: var(--fs-base);
     flex: 1;
   }
   .dismiss {
     min-height: 32px;
     padding: 4px 10px;
-    font-size: 12px;
+    font-size: var(--fs-base);
     color: var(--color-muted);
   }
   .tail {
@@ -242,7 +242,7 @@
     background: var(--color-inset);
     color: var(--color-term-fg);
     border: 1px solid var(--color-line);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     line-height: 1.4;
     white-space: pre-wrap;
     word-break: break-word;
@@ -297,7 +297,7 @@
   .batch {
     border-top: 1px solid var(--color-line);
     padding-top: 10px;
-    font-size: 12px;
+    font-size: var(--fs-base);
     color: var(--color-muted);
   }
 </style>

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -242,7 +242,7 @@
     background: transparent;
     color: var(--color-red);
     font-family: inherit;
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     line-height: 1.3;
     text-transform: uppercase;
@@ -341,7 +341,7 @@
     gap: 5px;
     margin-top: 3px;
     color: var(--color-ink);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.04em;
     overflow: hidden;
     white-space: nowrap;
@@ -353,17 +353,17 @@
        remaining contributor to the "orange wall". Muted: it's a repo marker,
        not a state signal. (Only tints the `▣` fallback; emoji icons self-color.) */
     color: var(--color-muted);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     flex-shrink: 0;
   }
   .repo-glyph.emoji {
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
 
   .u-sub {
     color: var(--color-muted);
     margin-top: 3px;
-    font-size: 12px;
+    font-size: var(--fs-base);
     line-height: 1.35;
     /* wrap to a 2nd line — fills the vertical space the right column
        (badge / elapsed / meta) already occupies, then ellipsis */
@@ -395,7 +395,7 @@
      status by color + pulse, so an outlined `--rule`-tinted badge here just
      duplicated that hue (amber for running) and added to the orange wall. */
   .badge {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -412,7 +412,7 @@
     grid-area: meta;
     min-width: 0;
     color: var(--color-muted);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -201,7 +201,7 @@
   }
   /* designation is metadata: demoted to the end of the header, quietest tone */
   .desig {
-    font-size: 9.5px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--color-faint);
@@ -209,7 +209,7 @@
   }
   .name {
     color: var(--color-ink-bright);
-    font-size: 12px;
+    font-size: var(--fs-base);
     font-weight: 500;
     letter-spacing: 0.04em;
     min-width: 0;
@@ -223,13 +223,13 @@
     color: var(--color-ink);
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.08em;
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
   }
   /* Quiet muted text, not a colored pill — the stripe (left) already encodes
      status by hue, so an outlined `--rule`-tinted badge here triple-stacked the
      same color. Matches UnitRow's demoted badge. */
   .badge {
-    font-size: 9px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--color-muted);

--- a/ui/src/lib/components/UpdateModal.svelte
+++ b/ui/src/lib/components/UpdateModal.svelte
@@ -188,7 +188,7 @@
     justify-content: space-between;
   }
   .micro {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -198,7 +198,7 @@
     border: 0;
     color: var(--color-muted);
     cursor: pointer;
-    font-size: 13px;
+    font-size: var(--fs-base);
   }
   .summary {
     display: flex;
@@ -207,7 +207,7 @@
   }
   .summary .count {
     color: var(--color-amber);
-    font-size: 22px;
+    font-size: var(--fs-2xl);
     font-weight: 700;
     font-variant-numeric: tabular-nums;
   }
@@ -236,7 +236,7 @@
     border: 0;
     text-align: left;
     font-family: inherit;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     color: inherit;
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
@@ -281,11 +281,11 @@
   }
   .status {
     color: var(--color-amber);
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   .err {
     color: var(--color-red);
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   .failure {
     display: flex;
@@ -308,7 +308,7 @@
     border: 1px solid var(--color-line);
     background: var(--color-inset);
     color: var(--color-ink-bright);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     line-height: 1.45;
     white-space: pre-wrap;
     word-break: break-word;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1134,6 +1134,7 @@
           ? m.viewport_git_actions_aria_state({ state: gitToggleState })
           : m.viewport_git_actions_aria()}
       >
+        <span class="gt-dot" aria-hidden="true"></span>
         <span class="gt-label">{m.viewport_git_actions()}</span>
         <span class="gt-caret" aria-hidden="true">{gitOpen ? "▴" : "▾"}</span>
       </button>
@@ -1438,7 +1439,7 @@
     padding: 6px 12px;
     background: var(--color-head);
     border-bottom: 1px solid var(--color-line);
-    font-size: 11.5px;
+    font-size: var(--fs-meta);
     flex-shrink: 0;
     white-space: nowrap;
     /* not overflow:hidden — the Open-PR popover drops below the header and must
@@ -1477,7 +1478,7 @@
   }
 
   .desig {
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
@@ -1521,7 +1522,7 @@
     display: flex;
     gap: 10px;
     justify-content: space-between;
-    font-size: 11px;
+    font-size: var(--fs-meta);
   }
   .dp-k {
     color: var(--color-muted);
@@ -1535,7 +1536,7 @@
      hidden, so the desig number alone can't identify the session */
   .vp-name {
     color: var(--color-ink);
-    font-size: 12px;
+    font-size: var(--fs-base);
     /* flex-basis 0 (not auto) so the name's content width doesn't drive the
        wrap calc on mobile — otherwise a long name reserves the whole row and
        pushes the decommission button onto the next line. It absorbs the slack
@@ -1549,7 +1550,7 @@
 
   .branch {
     color: var(--color-ink);
-    font-size: 12px;
+    font-size: var(--fs-base);
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 22ch;
@@ -1571,7 +1572,7 @@
   }
 
   .status-badge {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     padding: 2px 7px;
@@ -1594,7 +1595,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 2px 7px;
@@ -1621,9 +1622,22 @@
     border-color: color-mix(in srgb, var(--color-green) 55%, transparent);
     box-shadow: inset 0 0 18px -10px var(--color-green);
   }
+  .gt-dot {
+    flex: 0 0 auto;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-faint);
+  }
+  .git-toggle.attention .gt-dot {
+    background: var(--color-amber);
+  }
+  .git-toggle.clear .gt-dot {
+    background: var(--color-green);
+  }
   .gt-caret {
     color: var(--color-faint);
-    font-size: 9px;
+    font-size: var(--fs-micro);
     line-height: 1;
   }
   .git-toggle.open .gt-caret,
@@ -1642,7 +1656,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 2px 7px;
@@ -1673,16 +1687,16 @@
   }
   .ctx-glyph {
     color: var(--color-amber);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     flex-shrink: 0;
   }
   .ctx-glyph.emoji {
-    font-size: 14px;
+    font-size: var(--fs-lg);
   }
   .ctx-repo {
     color: var(--color-ink-bright);
     font-weight: 600;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     letter-spacing: 0.02em;
     white-space: nowrap;
     flex-shrink: 0;
@@ -1696,7 +1710,7 @@
   }
   .ctx-name {
     color: var(--color-ink);
-    font-size: 12px;
+    font-size: var(--fs-base);
     min-width: 0;
     /* ellipsize well before the row fills, ceding width to the close button */
     max-width: 34vw;
@@ -1728,7 +1742,7 @@
   /* phone: connection lost — a lone red dot (alert by exception) */
   .vp-offline {
     color: var(--color-red);
-    font-size: 9px;
+    font-size: var(--fs-micro);
     flex-shrink: 0;
   }
 
@@ -1737,7 +1751,7 @@
   .vp-status-glyph {
     flex-shrink: 0;
     font-weight: 700;
-    font-size: 13px;
+    font-size: var(--fs-base);
     line-height: 1;
     margin-right: 1px;
   }
@@ -1763,7 +1777,7 @@
     border-radius: 2px;
     color: var(--color-faint);
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 2px 7px;
@@ -1826,7 +1840,7 @@
     border: 1px solid transparent;
     border-radius: 2px;
     color: var(--color-faint);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     line-height: 1;
     padding: 2px 6px;
     cursor: pointer;
@@ -1851,7 +1865,7 @@
     border-radius: 2px;
     color: var(--color-ink-bright);
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     padding: 2px 6px;
     width: 14ch;
     max-width: 40vw;
@@ -1865,7 +1879,7 @@
   }
   .rename-err {
     color: var(--color-red);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1873,7 +1887,7 @@
   }
   .rename-note {
     color: var(--color-faint);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1936,17 +1950,17 @@
   }
   .parked-icon {
     color: var(--color-amber);
-    font-size: 22px;
+    font-size: var(--fs-2xl);
     line-height: 1;
   }
   .parked-title {
     color: var(--color-ink-bright);
     letter-spacing: 0.08em;
-    font-size: 13px;
+    font-size: var(--fs-base);
   }
   .parked-sub {
     color: var(--color-muted);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.14em;
     text-transform: uppercase;
   }
@@ -1972,7 +1986,7 @@
     background: color-mix(in srgb, var(--color-head) 90%, transparent);
     backdrop-filter: blur(2px);
     color: var(--color-ink);
-    font-size: 15px;
+    font-size: var(--fs-lg);
     line-height: 1;
     cursor: pointer;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
@@ -2030,7 +2044,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     padding: 4px 9px;
     cursor: pointer;
@@ -2049,7 +2063,7 @@
     border: 1px solid var(--color-red);
     color: var(--color-red);
     font: inherit;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.14em;
     padding: 4px 9px;
     cursor: pointer;
@@ -2060,7 +2074,7 @@
     background: color-mix(in srgb, var(--color-red) 28%, transparent);
   }
   .nyu-arrow {
-    font-size: 13px;
+    font-size: var(--fs-base);
     line-height: 1;
     letter-spacing: 0;
   }
@@ -2094,7 +2108,7 @@
     border-radius: 2px;
     color: var(--color-ink);
     font: inherit;
-    font-size: 15px;
+    font-size: var(--fs-lg);
     line-height: 1;
     min-width: 40px;
     min-height: 40px;
@@ -2106,7 +2120,7 @@
   .queue-pos {
     color: var(--color-amber);
     font-variant-numeric: tabular-nums;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     min-width: 28px;
     text-align: center;
   }
@@ -2178,7 +2192,7 @@
     flex: 1;
     text-align: center;
     padding: 10px 6px;
-    font-size: 11px;
+    font-size: var(--fs-meta);
   }
   /* finger-sized header controls on touch layouts (≥40px) */
   .vp-head.mobile .back,
@@ -2186,11 +2200,11 @@
   .vp-head.mobile .decom {
     min-height: 40px;
     padding: 8px 12px;
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   /* phone: the back control is a bare chevron — size it up to read as an icon */
   .vp-head.phone .back {
-    font-size: 20px;
+    font-size: var(--fs-xl);
     line-height: 1;
     padding: 6px 12px;
   }
@@ -2201,7 +2215,7 @@
     border-radius: 2px;
     color: var(--color-muted);
     font-family: var(--font-mono);
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.1em;
     padding: 2px 8px;
     cursor: pointer;
@@ -2233,7 +2247,7 @@
     padding: 5px 12px;
     background: var(--color-head);
     border-top: 1px solid var(--color-line);
-    font-size: 11px;
+    font-size: var(--fs-meta);
     color: var(--color-muted);
     flex-shrink: 0;
   }
@@ -2261,7 +2275,7 @@
     border: 1px solid var(--color-line-bright);
     border-radius: 2px;
     color: var(--color-ink);
-    font-size: 16px;
+    font-size: var(--fs-lg);
     cursor: pointer;
     touch-action: manipulation;
     user-select: none;
@@ -2283,7 +2297,7 @@
      row so it reads as the primary action */
   .ctrl-row .enter {
     font-family: var(--font-mono);
-    font-size: 18px;
+    font-size: var(--fs-xl);
     color: var(--color-green);
     border-color: color-mix(in srgb, var(--color-green) 60%, var(--color-line-bright));
     background: color-mix(in srgb, var(--color-green) 18%, var(--color-inset));
@@ -2303,7 +2317,7 @@
     padding: 0 10px;
     border-radius: 2px;
     font-family: var(--font-mono);
-    font-size: 14px;
+    font-size: var(--fs-lg);
     letter-spacing: 0.04em;
     white-space: nowrap;
     cursor: pointer;

--- a/ui/src/lib/components/WhatsNew.svelte
+++ b/ui/src/lib/components/WhatsNew.svelte
@@ -98,7 +98,7 @@
   }
   .title {
     letter-spacing: 0.14em;
-    font-size: 12px;
+    font-size: var(--fs-base);
     text-transform: uppercase;
     color: var(--color-muted);
   }
@@ -107,11 +107,11 @@
     border: none;
     color: var(--color-muted);
     cursor: pointer;
-    font-size: 14px;
+    font-size: var(--fs-lg);
   }
   .empty {
     color: var(--color-muted);
-    font-size: 13px;
+    font-size: var(--fs-base);
     line-height: 1.5;
     flex: 1;
   }
@@ -134,14 +134,14 @@
   }
   .entry-title {
     margin: 0;
-    font-size: 13px;
+    font-size: var(--fs-base);
     font-weight: 600;
     color: var(--color-ink-bright);
     letter-spacing: 0.04em;
   }
   .entry-body {
     margin: 0;
-    font-size: 12.5px;
+    font-size: var(--fs-base);
     color: var(--color-muted);
     line-height: 1.5;
   }
@@ -161,7 +161,7 @@
     cursor: pointer;
     letter-spacing: 0.06em;
     box-shadow: inset 0 0 18px -10px var(--color-amber);
-    font-size: 12px;
+    font-size: var(--fs-base);
   }
   .dismiss:focus-visible {
     outline: 1px solid var(--color-amber);

--- a/ui/src/lib/toasts.svelte.ts
+++ b/ui/src/lib/toasts.svelte.ts
@@ -22,12 +22,19 @@ interface Toast {
   key?: string;
   /** Optional inline action on an info toast (e.g. Retry); runs via act(). */
   actionLabel?: string;
+  /** Assertive announcement (role="alert") for failures; default polite. */
+  alert?: boolean;
 }
 
 interface InfoOpts {
-  duration?: number;
+  /** Auto-dismiss delay in ms (default 4000). Pass `null` to stay until the
+   *  operator retries or closes it (use for failures that must not vanish). */
+  duration?: number | null;
   /** An inline action button (e.g. Retry on a failed operation). */
   action?: { label: string; run: () => void };
+  /** Announce assertively (role="alert") rather than politely. For failures
+   *  that must reach a screen-reader operator promptly. */
+  alert?: boolean;
 }
 
 interface UndoOpts {
@@ -51,15 +58,22 @@ class ToastStore {
   #actions = new Map<number, () => void>();
   #keyed = new Map<string, number>();
 
-  /** Transient confirmation; auto-dismisses after `duration` ms. */
+  /** Confirmation toast. Auto-dismisses after `duration` ms (default 4000);
+   *  pass `duration: null` for a persistent toast that stays until retried or
+   *  closed. `alert: true` announces it assertively (role="alert"). */
   info(text: string, opts: InfoOpts = {}): number {
     const id = ++this.#seq;
-    this.items = [...this.items, { id, tone: "info", text, actionLabel: opts.action?.label }];
+    this.items = [
+      ...this.items,
+      { id, tone: "info", text, actionLabel: opts.action?.label, alert: opts.alert },
+    ];
     if (opts.action) this.#actions.set(id, opts.action.run);
-    this.#timers.set(
-      id,
-      setTimeout(() => this.#drop(id), opts.duration ?? 4000),
-    );
+    if (opts.duration !== null) {
+      this.#timers.set(
+        id,
+        setTimeout(() => this.#drop(id), opts.duration ?? 4000),
+      );
+    }
     return id;
   }
 

--- a/ui/src/lib/toasts.svelte.ts
+++ b/ui/src/lib/toasts.svelte.ts
@@ -59,7 +59,16 @@ class ToastStore {
   #commits = new Map<number, () => void | Promise<void>>();
   #undos = new Map<number, () => void>();
   #actions = new Map<number, () => void>();
+  // Caller key -> toast id. Namespaced by tone (#kk) so an info and an undo
+  // toast may safely reuse the same caller key without cross-mutating state.
   #keyed = new Map<string, number>();
+
+  /** Internal dedupe key: tone-prefixed so info/undo keys never collide. The
+   *  distinct "info"/"undo" prefix makes any cross-tone match impossible
+   *  whatever the caller key contains. */
+  #kk(tone: ToastTone, key: string): string {
+    return `${tone}:${key}`;
+  }
 
   /** Confirmation toast. Auto-dismisses after `duration` ms (default 4000);
    *  pass `duration: null` for a persistent toast that stays until retried or
@@ -68,8 +77,8 @@ class ToastStore {
     // Keyed dedupe: a repeated info with the same key refreshes the existing
     // toast (text / action / announcement / timer) instead of stacking another,
     // so e.g. repeated steer failures to one agent collapse to a single toast.
-    if (opts.key !== undefined && this.#keyed.has(opts.key)) {
-      const prev = this.#keyed.get(opts.key)!;
+    if (opts.key !== undefined && this.#keyed.has(this.#kk("info", opts.key))) {
+      const prev = this.#keyed.get(this.#kk("info", opts.key))!;
       this.#clearTimer(prev);
       if (opts.action) this.#actions.set(prev, opts.action.run);
       else this.#actions.delete(prev);
@@ -85,7 +94,7 @@ class ToastStore {
       { id, tone: "info", text, actionLabel: opts.action?.label, alert: opts.alert, key: opts.key },
     ];
     if (opts.action) this.#actions.set(id, opts.action.run);
-    if (opts.key !== undefined) this.#keyed.set(opts.key, id);
+    if (opts.key !== undefined) this.#keyed.set(this.#kk("info", opts.key), id);
     this.#armInfo(id, opts.duration);
     return id;
   }
@@ -113,8 +122,8 @@ class ToastStore {
 
     // Same target re-armed within its window: reset the timer + callbacks rather
     // than stacking two commits for one entity.
-    if (opts.key && this.#keyed.has(opts.key)) {
-      const prev = this.#keyed.get(opts.key)!;
+    if (opts.key && this.#keyed.has(this.#kk("undo", opts.key))) {
+      const prev = this.#keyed.get(this.#kk("undo", opts.key))!;
       this.#clearTimer(prev);
       this.#commits.set(prev, opts.onCommit);
       if (opts.onUndo) this.#undos.set(prev, opts.onUndo);
@@ -129,7 +138,7 @@ class ToastStore {
     ];
     this.#commits.set(id, opts.onCommit);
     if (opts.onUndo) this.#undos.set(id, opts.onUndo);
-    if (opts.key) this.#keyed.set(opts.key, id);
+    if (opts.key) this.#keyed.set(this.#kk("undo", opts.key), id);
     this.#arm(id, duration);
     return id;
   }

--- a/ui/src/lib/toasts.svelte.ts
+++ b/ui/src/lib/toasts.svelte.ts
@@ -18,7 +18,7 @@ interface Toast {
   undoLabel?: string;
   /** Window length, fed to the depleting-bar animation (undo toasts only). */
   durationMs?: number;
-  /** Dedupe key (undo toasts only); also lets the UI find the deferred target. */
+  /** Dedupe key; on undo toasts it also lets the UI find the deferred target. */
   key?: string;
   /** Optional inline action on an info toast (e.g. Retry); runs via act(). */
   actionLabel?: string;
@@ -35,6 +35,9 @@ interface InfoOpts {
   /** Announce assertively (role="alert") rather than politely. For failures
    *  that must reach a screen-reader operator promptly. */
   alert?: boolean;
+  /** Dedupe key: a repeated info with the same key refreshes the existing toast
+   *  instead of stacking another (e.g. repeated failures to one target). */
+  key?: string;
 }
 
 interface UndoOpts {
@@ -62,19 +65,39 @@ class ToastStore {
    *  pass `duration: null` for a persistent toast that stays until retried or
    *  closed. `alert: true` announces it assertively (role="alert"). */
   info(text: string, opts: InfoOpts = {}): number {
+    // Keyed dedupe: a repeated info with the same key refreshes the existing
+    // toast (text / action / announcement / timer) instead of stacking another,
+    // so e.g. repeated steer failures to one agent collapse to a single toast.
+    if (opts.key !== undefined && this.#keyed.has(opts.key)) {
+      const prev = this.#keyed.get(opts.key)!;
+      this.#clearTimer(prev);
+      if (opts.action) this.#actions.set(prev, opts.action.run);
+      else this.#actions.delete(prev);
+      this.items = this.items.map((t) =>
+        t.id === prev ? { ...t, text, actionLabel: opts.action?.label, alert: opts.alert } : t,
+      );
+      this.#armInfo(prev, opts.duration);
+      return prev;
+    }
     const id = ++this.#seq;
     this.items = [
       ...this.items,
-      { id, tone: "info", text, actionLabel: opts.action?.label, alert: opts.alert },
+      { id, tone: "info", text, actionLabel: opts.action?.label, alert: opts.alert, key: opts.key },
     ];
     if (opts.action) this.#actions.set(id, opts.action.run);
-    if (opts.duration !== null) {
-      this.#timers.set(
-        id,
-        setTimeout(() => this.#drop(id), opts.duration ?? 4000),
-      );
-    }
+    if (opts.key !== undefined) this.#keyed.set(opts.key, id);
+    this.#armInfo(id, opts.duration);
     return id;
+  }
+
+  /** Arm an info toast's auto-dismiss timer. `null` duration = persistent (stays
+   *  until the operator retries or closes it). */
+  #armInfo(id: number, duration: number | null | undefined) {
+    if (duration === null) return;
+    this.#timers.set(
+      id,
+      setTimeout(() => this.#drop(id), duration ?? 4000),
+    );
   }
 
   /** Inline action (e.g. Retry) pressed on an info toast: run it and dismiss. */

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -28,7 +28,7 @@
     background: var(--color-panel);
     border: 1px solid var(--color-amber);
     color: var(--color-amber);
-    font-size: 12px;
+    font-size: var(--fs-base);
     letter-spacing: 0.08em;
     text-decoration: none;
     transition: transform 0.12s ease-out;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -893,7 +893,7 @@
     align-items: center;
     justify-content: center;
     color: var(--color-faint);
-    font-size: 10.5px;
+    font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
   }


### PR DESCRIPTION
From an **impeccable UI critique** (`/impeccable critique UI`). The HUD scored **36/40 (Exceptional)** with a clear "not AI-generated" verdict; these are the top three actionable refinements (user-selected scope: P1-P3, leading with the type scale).

## P3 · Type scale (lead)
The implemented font sizes had drifted into ~16 ad-hoc `px` steps (8 to 22px), with **eight of them crammed into the 9.5-13px band**, plus sub-10px text. DESIGN.md documents only 13px (title/body) and 11px (label/numeric).

- New **6-rung token ladder** in `app.css` `:root`: `--fs-micro 10 / --fs-meta 11 / --fs-base 13 / --fs-lg 16 / --fs-xl 20 / --fs-2xl 22`, anchored on DESIGN.md's 11/13.
- Migrated **343 `font-size` declarations across 53 files** to tokens (single source of truth, no more scattered magic numbers).
- **Lifted the sub-10px floor** (8/9/9.5px to 10px). Documented the ladder in `DESIGN.md` §3.

## P2 · Merge-readiness at a glance
The collapsed `GIT ACTIONS ▾` toggle already tinted its label amber/green by rolled-up PR verdict, but text-color is the weakest encoding from across a dense watchfloor.

- Added a small **leading status dot** to the toggle: **green** = ready to merge, **amber** = needs you, **neutral** otherwise.
- Color is not the only cue: dot is `aria-hidden`, state stays in the existing localized `title`/`aria-label`. Reuses status-hue vars only.

## P1 · Steer failures don't vanish
A failed steer previously showed only a **1.5s self-clearing flash**, so the operator could miss it and assume the command landed (steering is the product's core risky action).

- Routes the failure through the **persistent toast store with an inline Retry** (mirrors the existing failed-archive/clear-merged pattern). Reused the existing `common_retry` key (no catalog change).
- Note: broadcast already routes through `BroadcastDialog` (a confirm step), and Esc covers per-steer interrupt/undo, so no extra steer guard was added.

## Verification
- `bun run check` (svelte-check + tsc): 0 errors / 0 warnings
- `bun run check:i18n`: 2 locales in parity (522 keys)
- UI tests: **377 passed** (38 files)
- Fallow delta audit (`--base origin/main --fail-on-issues`): **no issues in changed files** (listed dup families are pre-existing/inherited)
- Branch rebased onto latest `main`, linear, one feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)