### PR TITLE
fix: reattach sessions to herdr agents after a daemon restart

### DIFF
--- a/docs/superpowers/plans/2026-06-04-session-reattach-after-herdr-restart.md
+++ b/docs/superpowers/plans/2026-06-04-session-reattach-after-herdr-restart.md
@@ -177,26 +177,54 @@ export function matchAgents(
   sessions: { id: string; herdrAgentId: string; worktreePath: string; name: string }[],
   agents: HerdrAgent[],
 ): Map<string, HerdrAgent | null> {
-  const exactOwner = new Map<string, string>(); // terminalId → owning session id
+  const out = new Map<string, HerdrAgent | null>();
+  const taken = new Set<string>(); // claimed terminalIds
+  const matched = new Set<string>(); // resolved session ids
+
+  // Pass 1 — exact terminalId (stable-within-a-daemon fast path).
   for (const s of sessions) {
     const a = agents.find((x) => x.terminalId === s.herdrAgentId);
-    if (a) exactOwner.set(a.terminalId, s.id);
+    if (a && !taken.has(a.terminalId)) {
+      out.set(s.id, a);
+      taken.add(a.terminalId);
+      matched.add(s.id);
+    }
   }
-  const taken = new Set<string>();
-  const out = new Map<string, HerdrAgent | null>();
-  for (const s of sessions) {
-    const candidates = agents.filter((a) => {
-      if (taken.has(a.terminalId)) return false;
-      const owner = exactOwner.get(a.terminalId);
-      return owner === undefined || owner === s.id;
-    });
-    const a = matchAgent(s, candidates);
+
+  // Frozen before pass 2 so claim order can't shift contention.
+  const remaining = sessions.filter((s) => !matched.has(s.id));
+  const sessionsPerCwd = new Map<string, number>();
+  for (const s of remaining) {
+    sessionsPerCwd.set(s.worktreePath, (sessionsPerCwd.get(s.worktreePath) ?? 0) + 1);
+  }
+
+  // Pass 2 — cwd fallback for stale ids. When 2+ still-unmatched sessions share a cwd,
+  // only an exact agent-NAME match is safe (else a dead session steals a live sibling's
+  // agent). A SOLE session at its cwd adopts its lone agent via matchAgent regardless of
+  // name, so an isolated session whose name drifted from its agent still re-pairs.
+  for (const s of remaining) {
+    const candidates = agents.filter((a) => !taken.has(a.terminalId));
+    let a: HerdrAgent | null;
+    if ((sessionsPerCwd.get(s.worktreePath) ?? 0) > 1) {
+      const byName = candidates.filter((c) => c.cwd === s.worktreePath && c.name === s.name);
+      a = byName.length === 1 ? byName[0]! : null;
+    } else {
+      a = matchAgent(s, candidates);
+    }
     out.set(s.id, a);
     if (a) taken.add(a.terminalId);
   }
+
   return out;
 }
 ```
+
+> **Review fix:** the originally-planned `exactOwner`-only version still let a dead
+> session steal a live sibling's agent when **all** terminalIds are stale (the herdr
+> restart case): with no exact owners, a lone same-cwd agent went to whichever session
+> iterated first, ignoring the name. The version above name-disambiguates whenever
+> sessions contend for a cwd, while a sole session still adopts its lone agent regardless
+> of name (so a renamed isolated session re-pairs).
 
 - [ ] **Step 4:** Run `bun test ./test/herdr.test.ts` — expect PASS (matchAgent + matchAgents + pre-existing all green).
 

--- a/docs/superpowers/plans/2026-06-04-session-reattach-after-herdr-restart.md
+++ b/docs/superpowers/plans/2026-06-04-session-reattach-after-herdr-restart.md
@@ -111,7 +111,108 @@ git commit -m "feat(herdr): stable matchAgent (cwd fallback, name tiebreak)"
 
 ---
 
-### Task 2: `reconcile()` adopts the live agent on boot
+> **Plan revision (during execution):** Per-session `matchAgent` is insufficient when
+> two **active** sessions share a cwd (non-isolated same-repo, or the existing reconcile
+> test's two-sessions-at-`/wt` fixture): a *dead* session's cwd fallback would steal a
+> *live* sibling's agent, flipping the dead one to "running" on every tick. So all three
+> call sites must arbitrate across sessions: an agent held by one session via an exact
+> terminalId match is off-limits to another session's cwd fallback, and each live agent
+> is adopted by at most one session. To keep this DRY it lives in ONE helper,
+> `matchAgents(sessions, agents)` (Task 1b), used by reconcile, poller, and resume.
+> `matchAgent` stays as the per-session resolver over a candidate list.
+
+### Task 1b: `matchAgents` cross-session arbitration helper
+
+**Files:**
+- Modify: `src/herdr.ts` (add below `matchAgent`)
+- Test: `test/herdr.test.ts`
+
+- [ ] **Step 1: Write the failing tests** — append to `test/herdr.test.ts` (reuse the `mkAgent` helper from the matchAgent tests):
+
+```ts
+import { matchAgents } from "../src/herdr";
+
+test("matchAgents: a dead session cannot steal a live sibling's exact-id agent at the same cwd", () => {
+  const live = { id: "L", herdrAgentId: "term_live", worktreePath: "/wt", name: "x" };
+  const dead = { id: "D", herdrAgentId: "term_dead", worktreePath: "/wt", name: "x" };
+  const agents = [mkAgent({ terminalId: "term_live", cwd: "/wt", name: "x" })];
+  const m = matchAgents([live, dead], agents);
+  expect(m.get("L")?.terminalId).toBe("term_live");
+  expect(m.get("D")).toBeNull();
+});
+
+test("matchAgents: each live agent is adopted by at most one session", () => {
+  const a = { id: "A", herdrAgentId: "stale_a", worktreePath: "/wt", name: "alpha" };
+  const b = { id: "B", herdrAgentId: "stale_b", worktreePath: "/wt", name: "beta" };
+  const agents = [
+    mkAgent({ terminalId: "fresh_a", cwd: "/wt", name: "alpha" }),
+    mkAgent({ terminalId: "fresh_b", cwd: "/wt", name: "beta" }),
+  ];
+  const m = matchAgents([a, b], agents);
+  expect(m.get("A")?.terminalId).toBe("fresh_a");
+  expect(m.get("B")?.terminalId).toBe("fresh_b");
+});
+
+test("matchAgents: stale terminalId adopts the fresh agent at the same cwd", () => {
+  const s = { id: "S", herdrAgentId: "stale", worktreePath: "/wt/z", name: "x" };
+  const m = matchAgents([s], [mkAgent({ terminalId: "fresh", cwd: "/wt/z", name: "x" })]);
+  expect(m.get("S")?.terminalId).toBe("fresh");
+});
+```
+
+- [ ] **Step 2:** Run `bun test ./test/herdr.test.ts` — expect FAIL (`matchAgents` not exported).
+
+- [ ] **Step 3: Implement** — in `src/herdr.ts`, add directly below `matchAgent`:
+
+```ts
+/**
+ * Resolve EVERY active session to its live herdr agent at once, arbitrating
+ * cross-session collisions: an agent held by one session via an exact terminalId match
+ * is off-limits to another session's cwd fallback, and each agent is adopted by at most
+ * one session. Without this, two active sessions sharing a cwd (non-isolated same-repo)
+ * would have a dead one steal a live one's agent. Returns sessionId → matched agent
+ * (or null). Per-session resolution still goes through `matchAgent`.
+ */
+export function matchAgents(
+  sessions: { id: string; herdrAgentId: string; worktreePath: string; name: string }[],
+  agents: HerdrAgent[],
+): Map<string, HerdrAgent | null> {
+  const exactOwner = new Map<string, string>(); // terminalId → owning session id
+  for (const s of sessions) {
+    const a = agents.find((x) => x.terminalId === s.herdrAgentId);
+    if (a) exactOwner.set(a.terminalId, s.id);
+  }
+  const taken = new Set<string>();
+  const out = new Map<string, HerdrAgent | null>();
+  for (const s of sessions) {
+    const candidates = agents.filter((a) => {
+      if (taken.has(a.terminalId)) return false;
+      const owner = exactOwner.get(a.terminalId);
+      return owner === undefined || owner === s.id;
+    });
+    const a = matchAgent(s, candidates);
+    out.set(s.id, a);
+    if (a) taken.add(a.terminalId);
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4:** Run `bun test ./test/herdr.test.ts` — expect PASS (matchAgent + matchAgents + pre-existing all green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/herdr.ts test/herdr.test.ts
+git commit -m "feat(herdr): matchAgents cross-session arbitration helper"
+```
+
+---
+
+### Task 2: `reconcile()` adopts the live agent on boot (via `matchAgents`)
+
+> Already partially implemented inline; this task refactors it to use the shared
+> `matchAgents` helper so the arbitration logic isn't duplicated.
 
 **Files:**
 - Modify: `src/reconcile.ts`
@@ -152,18 +253,19 @@ test("reconcile re-pairs a session whose terminalId went stale but agent is live
 Run: `bun test ./test/reconcile.test.ts`
 Expected: FAIL — session marked `done` and `herdrAgentId` still `term_stale` (current terminalId-only lookup misses).
 
-- [ ] **Step 3: Rewrite `reconcile()` to use `matchAgent` + adopt**
+- [ ] **Step 3: Rewrite `reconcile()` to use `matchAgents` + adopt**
 
 Replace the entire body of `src/reconcile.ts` with:
 
 ```ts
 import type { SessionStore } from "./store";
-import { mapState, matchAgent, type HerdrDriver } from "./herdr";
+import { mapState, matchAgents, type HerdrDriver } from "./herdr";
 
 export function reconcile(store: SessionStore, herdr: Pick<HerdrDriver, "list">): void {
-  const agents = herdr.list();
-  for (const s of store.list({ activeOnly: true })) {
-    const agent = matchAgent(s, agents);
+  const sessions = store.list({ activeOnly: true });
+  const matched = matchAgents(sessions, herdr.list());
+  for (const s of sessions) {
+    const agent = matched.get(s.id) ?? null;
     if (!agent) store.update(s.id, { status: "done", lastState: "done" });
     else
       store.update(s.id, {
@@ -255,21 +357,22 @@ Expected: FIRST test FAILS — current `byTerm.get(s.herdrAgentId)` misses `term
 
 - [ ] **Step 3a: Switch `tick()` to the matcher**
 
-In `src/poller.ts`, update the import line (add `matchAgent`):
+In `src/poller.ts`, update the import line (add `matchAgents`):
 
 ```ts
-import { mapState, matchAgent, type HerdrDriver, type HerdrAgent } from "./herdr";
+import { mapState, matchAgents, type HerdrDriver, type HerdrAgent } from "./herdr";
 ```
 
-Replace the `tick()` body:
+Replace the `tick()` body (note `matchAgents` arbitrates across all active sessions in one pass, so a dead session can't steal a live sibling's agent):
 
 ```ts
   tick(): void {
-    const agents = this.herdr.list();
+    const sessions = this.store.list({ activeOnly: true });
+    const matched = matchAgents(sessions, this.herdr.list());
     const activeIds = new Set<string>();
-    for (const s of this.store.list({ activeOnly: true })) {
+    for (const s of sessions) {
       activeIds.add(s.id);
-      const agent = matchAgent(s, agents);
+      const agent = matched.get(s.id) ?? null;
       if (!agent) this.reapGone(s);
       else this.reconcileAgent(s, agent);
     }
@@ -373,14 +476,16 @@ test("resume adopts a live agent found by cwd under a new terminalId — no dupl
 Run: `bun test ./test/service.test.ts`
 Expected: FAIL — current liveness check is terminalId-only, so it misses `term_fresh`, calls `herdr.start` (startCalls === 1) and re-points to `term_should_not_happen`.
 
-- [ ] **Step 3: Use `matchAgent` in `resume()`**
+- [ ] **Step 3: Use `matchAgents` in `resume()`**
 
-In `src/service.ts`, add `matchAgent` to the herdr import (find the existing `from "./herdr"` import and include it). Then replace the liveness lines in `resume()`:
+In `src/service.ts`, add `matchAgents` to the herdr import (find the existing `from "./herdr"` import and include it). Then replace the liveness lines in `resume()`. Resolve across ALL active sessions (not just `s`) so resume can't adopt an agent that belongs to a live sibling sharing `s`'s cwd:
 
 ```ts
     const s = this.deps.store.get(id);
     if (!s || s.status === "archived" || !s.claudeSessionId) return null;
-    const agent = matchAgent(s, this.deps.herdr.list());
+    const agent =
+      matchAgents(this.deps.store.list({ activeOnly: true }), this.deps.herdr.list()).get(id) ??
+      null;
     if (agent) {
       // Already live (idle at the prompt, or restored by a herdr restart under a new
       // terminalId). Adopt the fresh id if it drifted; never spawn a second claude.

--- a/docs/superpowers/plans/2026-06-04-session-reattach-after-herdr-restart.md
+++ b/docs/superpowers/plans/2026-06-04-session-reattach-after-herdr-restart.md
@@ -1,0 +1,437 @@
+# Session reattach after herdr restart — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-pair a session with its live herdr agent by a stable key (worktree cwd, name tiebreak) and adopt the new terminalId, so a herdr daemon restart self-heals instead of orphaning every session as "done" and instead of spawning duplicate `claude --resume` processes.
+
+**Architecture:** One pure matcher `matchAgent(session, agents)` in `herdr.ts` replaces the three terminalId-only lookups: `reconcile()` (boot), `StatusPoller.tick()` (live), and `SessionService.resume()` (UI Resume). terminalId stays the fast path; on a miss it falls back to `cwd === worktreePath` (name tiebreak when a cwd is shared). On a cwd match the new terminalId is persisted to `herdrAgentId`.
+
+**Tech Stack:** TypeScript, Bun test runner. Root package (`bun test ./test`).
+
+---
+
+### Task 1: `matchAgent` pure matcher in `herdr.ts`
+
+**Files:**
+- Modify: `src/herdr.ts` (add exported function near `mapState`)
+- Test: `test/herdr.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/herdr.test.ts`:
+
+```ts
+import { matchAgent } from "../src/herdr";
+
+const mkAgent = (over: Partial<import("../src/herdr").HerdrAgent>) =>
+  ({
+    agent: "claude",
+    agentStatus: "working",
+    cwd: "/wt/a",
+    name: "",
+    paneId: "p",
+    tabId: "t",
+    terminalId: "term_x",
+    workspaceId: "w",
+    ...over,
+  }) as import("../src/herdr").HerdrAgent;
+
+const sess = { herdrAgentId: "term_old", worktreePath: "/wt/a", name: "alpha" };
+
+test("matchAgent: terminalId fast path wins even if cwd differs", () => {
+  const a = mkAgent({ terminalId: "term_old", cwd: "/elsewhere" });
+  expect(matchAgent(sess, [a, mkAgent({ terminalId: "term_x" })])).toBe(a);
+});
+
+test("matchAgent: falls back to a single cwd match and ignores the stale id", () => {
+  const a = mkAgent({ terminalId: "term_new", cwd: "/wt/a" });
+  expect(matchAgent(sess, [a])).toBe(a);
+});
+
+test("matchAgent: cwd shared by 2+ agents → disambiguate by name", () => {
+  const a = mkAgent({ terminalId: "t1", cwd: "/wt/a", name: "alpha" });
+  const b = mkAgent({ terminalId: "t2", cwd: "/wt/a", name: "beta" });
+  expect(matchAgent(sess, [a, b])).toBe(a);
+});
+
+test("matchAgent: cwd ambiguous AND name ambiguous → null", () => {
+  const a = mkAgent({ terminalId: "t1", cwd: "/wt/a", name: "alpha" });
+  const b = mkAgent({ terminalId: "t2", cwd: "/wt/a", name: "alpha" });
+  expect(matchAgent(sess, [a, b])).toBeNull();
+});
+
+test("matchAgent: no terminalId and no cwd match → null", () => {
+  expect(matchAgent(sess, [mkAgent({ terminalId: "t9", cwd: "/other" })])).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test ./test/herdr.test.ts`
+Expected: FAIL — `matchAgent` is not exported / not a function.
+
+- [ ] **Step 3: Implement `matchAgent`**
+
+In `src/herdr.ts`, add directly below the `mapState` function:
+
+```ts
+/**
+ * Resolve a session to its live herdr agent by a STABLE key. terminalId is the fast
+ * path but is volatile across a herdr daemon restart, so on a miss we fall back to the
+ * immutable worktree cwd. A cwd shared by 2+ agents (non-isolated same-repo sessions)
+ * is disambiguated by agent name; still ambiguous → no match (never risk mis-pairing).
+ */
+export function matchAgent(
+  s: { herdrAgentId: string; worktreePath: string; name: string },
+  agents: HerdrAgent[],
+): HerdrAgent | null {
+  const byId = agents.find((a) => a.terminalId === s.herdrAgentId);
+  if (byId) return byId;
+  const byCwd = agents.filter((a) => a.cwd === s.worktreePath);
+  if (byCwd.length === 1) return byCwd[0]!;
+  if (byCwd.length > 1) {
+    const byName = byCwd.filter((a) => a.name === s.name);
+    if (byName.length === 1) return byName[0]!;
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test ./test/herdr.test.ts`
+Expected: PASS (all matchAgent tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/herdr.ts test/herdr.test.ts
+git commit -m "feat(herdr): stable matchAgent (cwd fallback, name tiebreak)"
+```
+
+---
+
+### Task 2: `reconcile()` adopts the live agent on boot
+
+**Files:**
+- Modify: `src/reconcile.ts`
+- Test: `test/reconcile.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/reconcile.test.ts`:
+
+```ts
+test("reconcile re-pairs a session whose terminalId went stale but agent is live at the same cwd", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({ ...base, worktreePath: "/wt/z", herdrAgentId: "term_stale" });
+
+  reconcile(store, {
+    list: () => [
+      {
+        name: "x",
+        terminalId: "term_fresh",
+        agentStatus: "working",
+        agent: "claude",
+        cwd: "/wt/z",
+        paneId: "p",
+        tabId: "t",
+        workspaceId: "w",
+      },
+    ],
+  } as any);
+
+  const out = store.get(s.id);
+  expect(out?.status).toBe("running");
+  expect(out?.herdrAgentId).toBe("term_fresh"); // adopted the new id
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/reconcile.test.ts`
+Expected: FAIL — session marked `done` and `herdrAgentId` still `term_stale` (current terminalId-only lookup misses).
+
+- [ ] **Step 3: Rewrite `reconcile()` to use `matchAgent` + adopt**
+
+Replace the entire body of `src/reconcile.ts` with:
+
+```ts
+import type { SessionStore } from "./store";
+import { mapState, matchAgent, type HerdrDriver } from "./herdr";
+
+export function reconcile(store: SessionStore, herdr: Pick<HerdrDriver, "list">): void {
+  const agents = herdr.list();
+  for (const s of store.list({ activeOnly: true })) {
+    const agent = matchAgent(s, agents);
+    if (!agent) store.update(s.id, { status: "done", lastState: "done" });
+    else
+      store.update(s.id, {
+        status: mapState(agent.agentStatus),
+        lastState: agent.agentStatus,
+        herdrAgentId: agent.terminalId, // re-point if the daemon reassigned it (no-op when same)
+      });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test ./test/reconcile.test.ts`
+Expected: PASS (new test + the existing "marks gone as done" / "running" tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/reconcile.ts test/reconcile.test.ts
+git commit -m "fix(reconcile): adopt live agent by cwd, re-point stale terminalId on boot"
+```
+
+---
+
+### Task 3: `StatusPoller.tick()` adopts live agents (self-heal mid-session)
+
+**Files:**
+- Modify: `src/poller.ts` (`tick` + `reconcileAgent`)
+- Test: `test/poller.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/poller.test.ts`:
+
+```ts
+test("tick adopts a resurrected agent by cwd, re-points the id, emits, and does NOT reap", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({ ...baseSession, worktreePath: "/wt", herdrAgentId: "term_stale" });
+  const emitted: { id: string; status: string }[] = [];
+
+  const agents: HerdrAgent[] = [
+    {
+      agent: "claude",
+      agentStatus: "working",
+      cwd: "/wt",
+      paneId: "p",
+      tabId: "t",
+      name: "x",
+      terminalId: "term_fresh",
+      workspaceId: "w",
+    },
+  ];
+
+  const poller = new StatusPoller(
+    store,
+    { list: () => agents, read: () => "" } as any,
+    (id, status) => emitted.push({ id, status }),
+    () => {},
+  );
+
+  poller.tick();
+  const out = store.get(s.id);
+  expect(out?.herdrAgentId).toBe("term_fresh"); // adopted, not reaped
+  expect(out?.status).toBe("running");
+  expect(emitted).toContainEqual({ id: s.id, status: "running" });
+});
+
+test("tick reaps when neither terminalId nor cwd matches a live agent", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({ ...baseSession, worktreePath: "/wt", herdrAgentId: "term_stale" });
+
+  const poller = new StatusPoller(
+    store,
+    { list: () => [], read: () => "" } as any,
+    () => {},
+    () => {},
+  );
+
+  poller.tick();
+  expect(store.get(s.id)?.status).toBe("done");
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test ./test/poller.test.ts`
+Expected: FIRST test FAILS — current `byTerm.get(s.herdrAgentId)` misses `term_stale`, so `reapGone` sets `done` and id stays `term_stale`. (Second test already passes.)
+
+- [ ] **Step 3a: Switch `tick()` to the matcher**
+
+In `src/poller.ts`, update the import line (add `matchAgent`):
+
+```ts
+import { mapState, matchAgent, type HerdrDriver, type HerdrAgent } from "./herdr";
+```
+
+Replace the `tick()` body:
+
+```ts
+  tick(): void {
+    const agents = this.herdr.list();
+    const activeIds = new Set<string>();
+    for (const s of this.store.list({ activeOnly: true })) {
+      activeIds.add(s.id);
+      const agent = matchAgent(s, agents);
+      if (!agent) this.reapGone(s);
+      else this.reconcileAgent(s, agent);
+    }
+    this.pruneInactive(activeIds);
+  }
+```
+
+- [ ] **Step 3b: Adopt the new terminalId inside `reconcileAgent`**
+
+Replace the `reconcileAgent` method body so it persists + emits when the id changed, and uses the fresh id for downstream block/probe handling:
+
+```ts
+  /** Sync a live agent's status into the store and route its block/stall handling. */
+  private reconcileAgent(s: Session, agent: HerdrAgent): void {
+    const status = mapState(agent.agentStatus);
+    const idChanged = agent.terminalId !== s.herdrAgentId;
+    if (idChanged || status !== s.status || agent.agentStatus !== s.lastState) {
+      this.store.update(s.id, {
+        status,
+        lastState: agent.agentStatus,
+        ...(idChanged ? { herdrAgentId: agent.terminalId } : {}),
+      });
+      this.onChange(s.id, status); // nudge clients to re-attach the PTY to the fresh terminal
+    }
+    if (idChanged) s = { ...s, herdrAgentId: agent.terminalId };
+    // There's a next action again → drop the manual "ready to merge" parking so
+    // the row rejoins the active group. Sticky otherwise (idle/done keep it).
+    if ((status === "running" || status === "blocked") && s.readyToMerge) {
+      this.store.update(s.id, { readyToMerge: false });
+      this.onReady(s.id, false);
+    }
+    if (status === "blocked") this.maybeClassify(s.id, s.herdrAgentId);
+    else if (status === "running") this.maybeProbe(s);
+    else this.clearBlock(s.id);
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test ./test/poller.test.ts`
+Expected: PASS (new adopt + reap tests, and all existing poller tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/poller.ts test/poller.test.ts
+git commit -m "fix(poller): adopt resurrected agents by cwd instead of reaping them"
+```
+
+---
+
+### Task 4: `SessionService.resume()` adopts instead of duplicate-spawning
+
+**Files:**
+- Modify: `src/service.ts` (`resume`)
+- Test: `test/service.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/service.test.ts` (uses the existing `resumable` helper + `SessionStore` already imported in that file):
+
+```ts
+test("resume adopts a live agent found by cwd under a new terminalId — no duplicate spawn", () => {
+  const store = new SessionStore(":memory:");
+  let startCalls = 0;
+  const svc = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    herdr: {
+      start: () => {
+        startCalls++;
+        return { terminalId: "term_should_not_happen" } as any;
+      },
+      list: () => [
+        {
+          agent: "claude",
+          agentStatus: "working",
+          cwd: "/wt/x",
+          name: "x",
+          paneId: "p",
+          tabId: "t",
+          terminalId: "term_fresh",
+          workspaceId: "w",
+        },
+      ],
+      stop: () => {},
+      send: () => {},
+    } as any,
+  });
+  const s = resumable(store, { model: "opus" }); // worktreePath "/wt/x", herdrAgentId "term_old"
+
+  const out = svc.resume(s.id);
+  expect(startCalls).toBe(0); // agent already live → must NOT respawn
+  expect(out?.herdrAgentId).toBe("term_fresh"); // adopted the new id
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/service.test.ts`
+Expected: FAIL — current liveness check is terminalId-only, so it misses `term_fresh`, calls `herdr.start` (startCalls === 1) and re-points to `term_should_not_happen`.
+
+- [ ] **Step 3: Use `matchAgent` in `resume()`**
+
+In `src/service.ts`, add `matchAgent` to the herdr import (find the existing `from "./herdr"` import and include it). Then replace the liveness lines in `resume()`:
+
+```ts
+    const s = this.deps.store.get(id);
+    if (!s || s.status === "archived" || !s.claudeSessionId) return null;
+    const agent = matchAgent(s, this.deps.herdr.list());
+    if (agent) {
+      // Already live (idle at the prompt, or restored by a herdr restart under a new
+      // terminalId). Adopt the fresh id if it drifted; never spawn a second claude.
+      if (agent.terminalId !== s.herdrAgentId) {
+        this.deps.store.update(id, { herdrAgentId: agent.terminalId });
+        return this.deps.store.get(id);
+      }
+      return s;
+    }
+    const argv = ["claude", "--dangerously-skip-permissions", "--resume", s.claudeSessionId];
+```
+
+(Leave the rest of `resume()` — the argv build, `herdr.start`, and the post-spawn `store.update` — unchanged.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test ./test/service.test.ts`
+Expected: PASS (new adopt test + the existing "respawns claude --resume" / "omits --model" tests still green — those use `list: () => []`, so they still spawn).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/service.ts test/service.test.ts
+git commit -m "fix(service): resume adopts a live agent by cwd, never double-spawns"
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Lint**
+
+Run: `bun run lint`
+Expected: no errors.
+
+- [ ] **Step 2: Full root test suite**
+
+Run: `bun test ./test`
+Expected: all green (no regressions in reconcile/poller/service/herdr or elsewhere).
+
+- [ ] **Step 3: Type check**
+
+Run: `bunx tsc --noEmit`
+Expected: no errors.
+
+---
+
+## Notes for the implementer
+
+- This is a **root-package** (server) change only — no `ui/` changes. The `session:status` event the poller already emits is what nudges the open UI to re-attach its PTY (the server resolves the terminal from `s.herdrAgentId` at attach time, so adopting the new id in the store is sufficient).
+- `matchAgent` only ever sees **active** sessions (callers iterate `activeOnly` / `resume` guards on archived), and archived sessions' worktrees are removed, so a cwd collision with an archived session can't happen.
+- Do not change worktree/cwd computation or the `claude --resume` argv — out of scope.

--- a/docs/superpowers/specs/2026-06-04-session-reattach-after-herdr-restart-design.md
+++ b/docs/superpowers/specs/2026-06-04-session-reattach-after-herdr-restart-design.md
@@ -1,0 +1,126 @@
+# Session reattach after herdr restart
+
+## Problem
+
+When the herdr daemon restarts (notably a `herdr update`), herdr faithfully restores
+every agent at its correct `cwd` (the session worktree) — but assigns each a **new**
+`terminal_id`. Shepherd pairs a session row to its herdr agent **solely** by
+`terminalId === session.herdrAgentId`. So after a herdr restart every session's stored
+id goes stale at once, and shepherd can no longer find any of its live agents.
+
+Consequences:
+
+- `reconcile()` (boot) marks every active session `done` — they're alive in herdr but
+  shepherd shows them dead.
+- `poller.tick()` never recovers: it also keys on the stale terminalId, so `reapGone()`
+  keeps them `done`.
+- `service.resume()` (UI "Resume") checks liveness by terminalId too, so it spawns a
+  **duplicate** `claude --resume` even though the agent is already live.
+
+The earlier "resumes in the wrong folder" hypothesis is a red herring: verified that DB
+`worktreePath`s are correct, the Claude `*.jsonl` session files live in the matching
+`~/.claude/projects/<encoded-worktree>/` folders, `claude --resume <id>` from the
+worktree works, and live herdr agents have the correct cwd. The folder is right; only
+the session↔agent mapping is lost.
+
+### Live evidence (at time of investigation)
+
+| session | live `terminal_id` | DB `herdrAgentId` | DB status |
+|---|---|---|---|
+| session-resume-folder-bug | `term_653680b4248d09` | `term_65367fd8ef91914` | done |
+| session-activity-heartbeats | `term_653680b4248cd8` | `term_653674fa21acb23` | done |
+| herdr-shepherd-502 | `term_653680b4248c37` | `term_65367380add9c1c` | done |
+
+All three alive + working in herdr at the right cwd; DB holds the old ids, all `done`.
+
+## Goal
+
+Re-pair a session with its live herdr agent using a **stable** key, and adopt the new
+terminalId — so a herdr restart self-heals instead of orphaning every session. No
+duplicate `claude --resume` when the agent is already live.
+
+Non-goals: changing how worktrees/cwd are computed, changing the resume command itself,
+changing herdr.
+
+## Design
+
+### Stable matcher
+
+`terminalId` is volatile across herdr restarts. `worktreePath` (== herdr agent `cwd`) is
+**immutable** for the session's life and is preserved by herdr on resume — the most
+robust key. The agent `name` can drift (LLM renamer; `relabel` is best-effort), so it is
+only a tiebreaker.
+
+Add a matcher (in `herdr.ts`) that resolves a session to a live agent:
+
+```
+matchAgent(session, agents):
+  1. terminalId fast path: agent.terminalId === session.herdrAgentId  → that agent
+  2. cwd fallback: agents where agent.cwd === session.worktreePath
+       - exactly one        → that agent
+       - 2+ (non-isolated same-repo): narrow to name === session.name
+            - exactly one   → that agent
+            - else          → null  (ambiguous; do not risk mis-pairing)
+  3. none                   → null
+```
+
+Pure function over `(session, HerdrAgent[])` — trivially unit-testable, no I/O.
+
+### Adoption
+
+When the matcher resolves a session via the **cwd fallback** (terminalId differs),
+"adopt": persist `herdrAgentId = agent.terminalId`. This is the one-line re-pairing that
+makes everything downstream key on the fresh id again.
+
+### Call-site changes
+
+1. **`reconcile.ts` (boot).** For each active session, `matchAgent` against the live
+   list. On match: `store.update(status: mapState(agent.agentStatus),
+   lastState: agent.agentStatus, herdrAgentId: agent.terminalId)`. On no match: mark
+   `done` (unchanged). This alone fixes the mass-`done` after a herdr update. (Runs
+   before the event bus / server start, so no event emit here — boot state is the source
+   of truth for the first client load.)
+
+2. **`poller.ts` (`tick`).** Replace the `byTerm.get(s.herdrAgentId)` lookup with
+   `matchAgent(s, agents)`. When matched via cwd fallback (id changed), update
+   `herdrAgentId` and emit `session:status` (via existing `onChange`) so connected
+   clients re-attach their PTY to the new terminal. When matched (any path), proceed to
+   `reconcileAgent` as today. Only `reapGone()` when the matcher returns null. Build the
+   agent list once per tick (as now) and pass it to the matcher; keep the existing
+   single `herdr.list()` call.
+
+3. **`service.resume()` (`service.ts`).** Replace the terminalId-only liveness check
+   (`list().some(a => a.terminalId === s.herdrAgentId)`) with `matchAgent`. If a live
+   agent is found:
+     - adopt its terminalId if changed (`store.update`),
+     - return the (updated) session — no respawn.
+   Only build + run the `claude --resume` argv when the matcher returns null.
+
+### Edge cases
+
+- **Non-isolated sessions sharing a repoPath cwd.** Disambiguated by name; if still
+  ambiguous, left as-is (no adoption) rather than risk pairing the wrong session.
+- **Archived sessions.** Not iterated (callers use `activeOnly` / skip archived) and
+  their worktrees are removed, so their cwd can't collide with an active session's.
+- **Helper agents** (`__usage_probe__`, review husks) have unrelated cwds, so a
+  worktreePath match can't accidentally grab them.
+- **terminalId still valid** (shepherd restart, herdr did NOT restart): fast path hits,
+  behavior identical to today.
+
+## Testing
+
+- `matchAgent` unit tests: terminalId fast path; cwd fallback single match; cwd
+  ambiguous → name tiebreak; cwd ambiguous + name ambiguous → null; no match → null.
+- `reconcile`: stale terminalId but live agent at same cwd → status synced from live
+  agent AND `herdrAgentId` re-pointed (regression for the mass-`done` bug). No live agent
+  → `done`.
+- `poller.tick`: terminalId miss + cwd hit → adopts new id, emits `session:status`, does
+  NOT `reapGone`. terminalId+cwd both miss → `reapGone` → `done`.
+- `service.resume`: live agent under a *new* terminalId → adopts, returns session, does
+  NOT call `herdr.start` (no duplicate spawn). Truly dead → spawns `claude --resume` as
+  today.
+
+## Out of scope
+
+Worktree/cwd computation, the resume command, herdr internals, UI changes beyond the
+already-emitted `session:status` event.

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -62,6 +62,22 @@ export function matchAgent(
 }
 
 /**
+ * Pick the cwd-fallback agent for one still-unmatched session from the untaken
+ * candidates. When the session contends for its cwd with another active session, only
+ * an unambiguous agent-NAME match is safe; a sole session adopts its lone cwd agent via
+ * `matchAgent` regardless of name (so a renamed isolated session still re-pairs).
+ */
+function pickByCwd(
+  s: { herdrAgentId: string; worktreePath: string; name: string },
+  candidates: HerdrAgent[],
+  contended: boolean,
+): HerdrAgent | null {
+  if (!contended) return matchAgent(s, candidates);
+  const byName = candidates.filter((c) => c.cwd === s.worktreePath && c.name === s.name);
+  return byName.length === 1 ? byName[0]! : null;
+}
+
+/**
  * Resolve EVERY active session to its live herdr agent at once, arbitrating
  * cross-session collisions so a dead session can't steal a live sibling's agent.
  *
@@ -98,13 +114,7 @@ export function matchAgents(
 
   for (const s of remaining) {
     const candidates = agents.filter((a) => !taken.has(a.terminalId));
-    let a: HerdrAgent | null;
-    if ((sessionsPerCwd.get(s.worktreePath) ?? 0) > 1) {
-      const byName = candidates.filter((c) => c.cwd === s.worktreePath && c.name === s.name);
-      a = byName.length === 1 ? byName[0]! : null;
-    } else {
-      a = matchAgent(s, candidates);
-    }
+    const a = pickByCwd(s, candidates, (sessionsPerCwd.get(s.worktreePath) ?? 0) > 1);
     out.set(s.id, a);
     if (a) taken.add(a.terminalId);
   }

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -63,33 +63,52 @@ export function matchAgent(
 
 /**
  * Resolve EVERY active session to its live herdr agent at once, arbitrating
- * cross-session collisions: an agent held by one session via an exact terminalId match
- * is off-limits to another session's cwd fallback, and each agent is adopted by at most
- * one session. Without this, two active sessions sharing a cwd (non-isolated same-repo)
- * would have a dead one steal a live one's agent. Returns sessionId → matched agent
- * (or null). Per-session resolution still goes through `matchAgent`.
+ * cross-session collisions so a dead session can't steal a live sibling's agent.
+ *
+ * Pass 1 — exact terminalId (the stable-within-a-daemon fast path).
+ * Pass 2 — cwd fallback for stale ids (e.g. after a herdr daemon restart). When 2+
+ *   still-unmatched sessions share a cwd (non-isolated same-repo), only an exact
+ *   agent-NAME match is safe. A session that is the SOLE one at its cwd adopts its lone
+ *   agent via `matchAgent` regardless of name, so an isolated session whose name drifted
+ *   from its herdr agent still re-pairs. Each agent is adopted by at most one session.
  */
 export function matchAgents(
   sessions: { id: string; herdrAgentId: string; worktreePath: string; name: string }[],
   agents: HerdrAgent[],
 ): Map<string, HerdrAgent | null> {
-  const exactOwner = new Map<string, string>(); // terminalId → owning session id
+  const out = new Map<string, HerdrAgent | null>();
+  const taken = new Set<string>(); // claimed terminalIds
+  const matched = new Set<string>(); // resolved session ids
+
   for (const s of sessions) {
     const a = agents.find((x) => x.terminalId === s.herdrAgentId);
-    if (a) exactOwner.set(a.terminalId, s.id);
+    if (a && !taken.has(a.terminalId)) {
+      out.set(s.id, a);
+      taken.add(a.terminalId);
+      matched.add(s.id);
+    }
   }
-  const taken = new Set<string>();
-  const out = new Map<string, HerdrAgent | null>();
-  for (const s of sessions) {
-    const candidates = agents.filter((a) => {
-      if (taken.has(a.terminalId)) return false;
-      const owner = exactOwner.get(a.terminalId);
-      return owner === undefined || owner === s.id;
-    });
-    const a = matchAgent(s, candidates);
+
+  // Frozen before pass 2 so claim order can't shift contention.
+  const remaining = sessions.filter((s) => !matched.has(s.id));
+  const sessionsPerCwd = new Map<string, number>();
+  for (const s of remaining) {
+    sessionsPerCwd.set(s.worktreePath, (sessionsPerCwd.get(s.worktreePath) ?? 0) + 1);
+  }
+
+  for (const s of remaining) {
+    const candidates = agents.filter((a) => !taken.has(a.terminalId));
+    let a: HerdrAgent | null;
+    if ((sessionsPerCwd.get(s.worktreePath) ?? 0) > 1) {
+      const byName = candidates.filter((c) => c.cwd === s.worktreePath && c.name === s.name);
+      a = byName.length === 1 ? byName[0]! : null;
+    } else {
+      a = matchAgent(s, candidates);
+    }
     out.set(s.id, a);
     if (a) taken.add(a.terminalId);
   }
+
   return out;
 }
 

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -61,6 +61,38 @@ export function matchAgent(
   return null;
 }
 
+/**
+ * Resolve EVERY active session to its live herdr agent at once, arbitrating
+ * cross-session collisions: an agent held by one session via an exact terminalId match
+ * is off-limits to another session's cwd fallback, and each agent is adopted by at most
+ * one session. Without this, two active sessions sharing a cwd (non-isolated same-repo)
+ * would have a dead one steal a live one's agent. Returns sessionId → matched agent
+ * (or null). Per-session resolution still goes through `matchAgent`.
+ */
+export function matchAgents(
+  sessions: { id: string; herdrAgentId: string; worktreePath: string; name: string }[],
+  agents: HerdrAgent[],
+): Map<string, HerdrAgent | null> {
+  const exactOwner = new Map<string, string>(); // terminalId → owning session id
+  for (const s of sessions) {
+    const a = agents.find((x) => x.terminalId === s.herdrAgentId);
+    if (a) exactOwner.set(a.terminalId, s.id);
+  }
+  const taken = new Set<string>();
+  const out = new Map<string, HerdrAgent | null>();
+  for (const s of sessions) {
+    const candidates = agents.filter((a) => {
+      if (taken.has(a.terminalId)) return false;
+      const owner = exactOwner.get(a.terminalId);
+      return owner === undefined || owner === s.id;
+    });
+    const a = matchAgent(s, candidates);
+    out.set(s.id, a);
+    if (a) taken.add(a.terminalId);
+  }
+  return out;
+}
+
 export class HerdrDriver {
   constructor(private runner: Runner = defaultRunner) {}
 

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -40,6 +40,27 @@ export function mapState(s: HerdrState): SessionStatus {
   }
 }
 
+/**
+ * Resolve a session to its live herdr agent by a STABLE key. terminalId is the fast
+ * path but is volatile across a herdr daemon restart, so on a miss we fall back to the
+ * immutable worktree cwd. A cwd shared by 2+ agents (non-isolated same-repo sessions)
+ * is disambiguated by agent name; still ambiguous → no match (never risk mis-pairing).
+ */
+export function matchAgent(
+  s: { herdrAgentId: string; worktreePath: string; name: string },
+  agents: HerdrAgent[],
+): HerdrAgent | null {
+  const byId = agents.find((a) => a.terminalId === s.herdrAgentId);
+  if (byId) return byId;
+  const byCwd = agents.filter((a) => a.cwd === s.worktreePath);
+  if (byCwd.length === 1) return byCwd[0]!;
+  if (byCwd.length > 1) {
+    const byName = byCwd.filter((a) => a.name === s.name);
+    if (byName.length === 1) return byName[0]!;
+  }
+  return null;
+}
+
 export class HerdrDriver {
   constructor(private runner: Runner = defaultRunner) {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { dirname } from "node:path";
 import { config, SESSION_RETENTION_MS, SESSION_RETENTION_KEEP } from "./config";
 import { SessionStore } from "./store";
 import { WorktreeMgr } from "./worktree";
-import { HerdrDriver } from "./herdr";
+import { HerdrDriver, matchAgent } from "./herdr";
 import { generateName } from "./namer";
 import { llmName } from "./namer-llm";
 import { EventHub } from "./events";
@@ -224,11 +224,13 @@ const autopilot = new AutopilotService({
   resume: (id) => service.resume(id),
   paneAlive: (id) => {
     const s = store.get(id);
-    return !!s && herdr.list().some((a) => a.terminalId === s.herdrAgentId);
+    return !!s && matchAgent(s, herdr.list()) !== null;
   },
   readTail: (id) => {
     const s = store.get(id);
-    return s ? tailLines(herdr.read(s.herdrAgentId, "visible")) : [];
+    if (!s) return [];
+    const live = matchAgent(s, herdr.list());
+    return live ? tailLines(herdr.read(live.terminalId, "visible")) : [];
   },
   // Any PR (open/merged/closed) stands autopilot down — only a session with NO PR yet is its
   // territory. `state` is "none" when no PR exists; anything else means one does.

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1,6 +1,6 @@
 import type { SessionStore } from "./store";
 import type { Session } from "./types";
-import { mapState, type HerdrDriver, type HerdrAgent } from "./herdr";
+import { mapState, matchAgents, type HerdrDriver, type HerdrAgent } from "./herdr";
 import { classifyBlocked, tailLines, type BlockReason } from "./blocked";
 import { isStalled, DEFAULT_STALL, type ActivitySnapshot } from "./stall";
 import { jsonlPathFor } from "./usage";
@@ -47,11 +47,12 @@ export class StatusPoller {
   ) {}
 
   tick(): void {
-    const byTerm = new Map(this.herdr.list().map((a) => [a.terminalId, a]));
+    const sessions = this.store.list({ activeOnly: true });
+    const matched = matchAgents(sessions, this.herdr.list());
     const activeIds = new Set<string>();
-    for (const s of this.store.list({ activeOnly: true })) {
+    for (const s of sessions) {
       activeIds.add(s.id);
-      const agent = byTerm.get(s.herdrAgentId);
+      const agent = matched.get(s.id) ?? null;
       if (!agent) this.reapGone(s);
       else this.reconcileAgent(s, agent);
     }
@@ -75,10 +76,16 @@ export class StatusPoller {
   /** Sync a live agent's status into the store and route its block/stall handling. */
   private reconcileAgent(s: Session, agent: HerdrAgent): void {
     const status = mapState(agent.agentStatus);
-    if (status !== s.status || agent.agentStatus !== s.lastState) {
-      this.store.update(s.id, { status, lastState: agent.agentStatus });
-      this.onChange(s.id, status);
+    const idChanged = agent.terminalId !== s.herdrAgentId;
+    if (idChanged || status !== s.status || agent.agentStatus !== s.lastState) {
+      this.store.update(s.id, {
+        status,
+        lastState: agent.agentStatus,
+        ...(idChanged ? { herdrAgentId: agent.terminalId } : {}),
+      });
+      this.onChange(s.id, status); // nudge clients to re-attach the PTY to the fresh terminal
     }
+    if (idChanged) s = { ...s, herdrAgentId: agent.terminalId };
     // There's a next action again → drop the manual "ready to merge" parking so
     // the row rejoins the active group. Sticky otherwise (idle/done keep it).
     if ((status === "running" || status === "blocked") && s.readyToMerge) {

--- a/src/reconcile.ts
+++ b/src/reconcile.ts
@@ -1,11 +1,31 @@
 import type { SessionStore } from "./store";
-import { mapState, type HerdrDriver } from "./herdr";
+import { mapState, matchAgent, type HerdrDriver, type HerdrAgent } from "./herdr";
 
 export function reconcile(store: SessionStore, herdr: Pick<HerdrDriver, "list">): void {
-  const byTerm = new Map(herdr.list().map((a) => [a.terminalId, a]));
-  for (const s of store.list({ activeOnly: true })) {
-    const agent = byTerm.get(s.herdrAgentId);
+  const agents = herdr.list();
+  const sessions = store.list({ activeOnly: true });
+
+  // First pass: terminalId-exact matches; claim those agents so cwd fallback can't steal them.
+  const claimed = new Set<string>();
+  for (const s of sessions) {
+    const byId = agents.find((a) => a.terminalId === s.herdrAgentId);
+    if (byId) claimed.add(byId.terminalId);
+  }
+
+  // Second pass: full match (terminalId first, then cwd on unclaimed agents).
+  for (const s of sessions) {
+    const unclaimed = agents.filter(
+      (a) => !claimed.has(a.terminalId) || a.terminalId === s.herdrAgentId,
+    );
+    const agent: HerdrAgent | null = matchAgent(s, unclaimed);
     if (!agent) store.update(s.id, { status: "done", lastState: "done" });
-    else store.update(s.id, { status: mapState(agent.agentStatus), lastState: agent.agentStatus });
+    else {
+      if (!claimed.has(agent.terminalId)) claimed.add(agent.terminalId);
+      store.update(s.id, {
+        status: mapState(agent.agentStatus),
+        lastState: agent.agentStatus,
+        herdrAgentId: agent.terminalId, // re-point if the daemon reassigned it (no-op when same)
+      });
+    }
   }
 }

--- a/src/reconcile.ts
+++ b/src/reconcile.ts
@@ -1,31 +1,17 @@
 import type { SessionStore } from "./store";
-import { mapState, matchAgent, type HerdrDriver, type HerdrAgent } from "./herdr";
+import { mapState, matchAgents, type HerdrDriver } from "./herdr";
 
 export function reconcile(store: SessionStore, herdr: Pick<HerdrDriver, "list">): void {
-  const agents = herdr.list();
   const sessions = store.list({ activeOnly: true });
-
-  // First pass: terminalId-exact matches; claim those agents so cwd fallback can't steal them.
-  const claimed = new Set<string>();
+  const matched = matchAgents(sessions, herdr.list());
   for (const s of sessions) {
-    const byId = agents.find((a) => a.terminalId === s.herdrAgentId);
-    if (byId) claimed.add(byId.terminalId);
-  }
-
-  // Second pass: full match (terminalId first, then cwd on unclaimed agents).
-  for (const s of sessions) {
-    const unclaimed = agents.filter(
-      (a) => !claimed.has(a.terminalId) || a.terminalId === s.herdrAgentId,
-    );
-    const agent: HerdrAgent | null = matchAgent(s, unclaimed);
+    const agent = matched.get(s.id) ?? null;
     if (!agent) store.update(s.id, { status: "done", lastState: "done" });
-    else {
-      if (!claimed.has(agent.terminalId)) claimed.add(agent.terminalId);
+    else
       store.update(s.id, {
         status: mapState(agent.agentStatus),
         lastState: agent.agentStatus,
         herdrAgentId: agent.terminalId, // re-point if the daemon reassigned it (no-op when same)
       });
-    }
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1696,6 +1696,25 @@ const PTY_SUPERSEDED_CODE = 4000;
 // Keep in sync with PTY_GONE_CODE in ui/src/lib/pty.ts.
 export const PTY_GONE_CODE = 4001;
 
+/**
+ * The terminalId to attach a PTY to, or null when the session's herdr agent is truly
+ * gone (caller should close the socket). Resolves by STABLE key (cwd) so a herdr restart
+ * that reassigned terminalIds doesn't strand the attach on the stored-at-upgrade id. A
+ * herdr CLI hiccup (list throws) or no herdr at all falls back to the stored id rather
+ * than closing a live session.
+ */
+function livePtyTerminalId(
+  cur: Session,
+  herdr: Pick<HerdrDriver, "list"> | undefined,
+): string | null {
+  if (!herdr) return cur.herdrAgentId;
+  try {
+    return matchAgent(cur, herdr.list())?.terminalId ?? null;
+  } catch {
+    return cur.herdrAgentId; // herdr hiccup — attach optimistically with the stored id
+  }
+}
+
 export function serve(deps: AppDeps, port: number) {
   const app = makeApp(deps);
   // current owning socket per terminal — a single owner avoids the takeover war
@@ -1763,21 +1782,11 @@ export function serve(deps: AppDeps, port: number) {
             return;
           }
           // Resolve the live agent by STABLE key (cwd), not the id captured at upgrade:
-          // a herdr restart reassigns terminalIds, so the stored one can be briefly stale
-          // until the poller adopts the fresh id. A herdr CLI hiccup (list throws) or no
-          // herdr at all must not strand a live session, so fall back to the stored id.
-          let tid = cur.herdrAgentId;
-          if (deps.herdr) {
-            try {
-              const live = matchAgent(cur, deps.herdr.list());
-              if (!live) {
-                ws.close(PTY_GONE_CODE, "ended");
-                return;
-              }
-              tid = live.terminalId;
-            } catch {
-              /* herdr CLI hiccup — attach optimistically with the stored id */
-            }
+          // a herdr restart reassigns terminalIds, so the stored one can be briefly stale.
+          const tid = livePtyTerminalId(cur, deps.herdr);
+          if (tid === null) {
+            ws.close(PTY_GONE_CODE, "ended");
+            return;
           }
           ws.data.terminalId = tid; // keep close()'s ptyOwners cleanup keyed on the same id
           // single owner per terminal: claim it, then bump the previous owner

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import type { UpdateService } from "./update";
 import type { HerdrUpdateService } from "./herdr-update";
 import type { Session, LearningStatus } from "./types";
 import type { HerdrDriver } from "./herdr";
+import { matchAgent } from "./herdr";
 import type { GitForge, GitState, MergeMethod } from "./forge/types";
 import { DEPENDABOT_REBASE_COMMAND } from "./forge/types";
 import type { PrCache } from "./pr-poller";
@@ -1761,19 +1762,26 @@ export function serve(deps: AppDeps, port: number) {
             ws.close(PTY_GONE_CODE, "ended");
             return;
           }
-          let agentLive: boolean;
-          try {
-            agentLive = deps.herdr?.list().some((a) => a.terminalId === cur.herdrAgentId) ?? true;
-          } catch {
-            agentLive = true; // a herdr CLI hiccup shouldn't strand a live session
+          // Resolve the live agent by STABLE key (cwd), not the id captured at upgrade:
+          // a herdr restart reassigns terminalIds, so the stored one can be briefly stale
+          // until the poller adopts the fresh id. A herdr CLI hiccup (list throws) or no
+          // herdr at all must not strand a live session, so fall back to the stored id.
+          let tid = cur.herdrAgentId;
+          if (deps.herdr) {
+            try {
+              const live = matchAgent(cur, deps.herdr.list());
+              if (!live) {
+                ws.close(PTY_GONE_CODE, "ended");
+                return;
+              }
+              tid = live.terminalId;
+            } catch {
+              /* herdr CLI hiccup — attach optimistically with the stored id */
+            }
           }
-          if (!agentLive) {
-            ws.close(PTY_GONE_CODE, "ended");
-            return;
-          }
+          ws.data.terminalId = tid; // keep close()'s ptyOwners cleanup keyed on the same id
           // single owner per terminal: claim it, then bump the previous owner
           // with a "superseded" close so it parks instead of fighting back.
-          const tid = ws.data.terminalId;
           const prev = ptyOwners.get(tid);
           ptyOwners.set(tid, ws);
           if (prev && prev !== ws) prev.close(PTY_SUPERSEDED_CODE, "superseded");

--- a/src/service.ts
+++ b/src/service.ts
@@ -3,6 +3,7 @@ import type { SessionStore } from "./store";
 import type { EventHub } from "./events";
 import type { WorktreeMgr } from "./worktree";
 import type { HerdrDriver } from "./herdr";
+import { matchAgents } from "./herdr";
 import { config } from "./config";
 import type { CreateSessionInput, Session } from "./types";
 import { moveStagedIntoWorktree } from "./uploads";
@@ -266,14 +267,24 @@ export class SessionService {
   resume(id: string): Session | null {
     const s = this.deps.store.get(id);
     if (!s || s.status === "archived" || !s.claudeSessionId) return null;
-    const live = this.deps.herdr.list().some((a) => a.terminalId === s.herdrAgentId);
-    if (live) return s;
+    const agent =
+      matchAgents(this.deps.store.list({ activeOnly: true }), this.deps.herdr.list()).get(id) ??
+      null;
+    if (agent) {
+      // Already live (idle at the prompt, or restored by a herdr restart under a new
+      // terminalId). Adopt the fresh id if it drifted; never spawn a second claude.
+      if (agent.terminalId !== s.herdrAgentId) {
+        this.deps.store.update(id, { herdrAgentId: agent.terminalId });
+        return this.deps.store.get(id);
+      }
+      return s;
+    }
     const argv = ["claude", "--dangerously-skip-permissions", "--resume", s.claudeSessionId];
     argv.push("--settings", spawnSettingsOverlay());
     if (s.model) argv.push("--model", s.model);
-    const agent = this.deps.herdr.start(s.name, s.worktreePath, argv);
+    const spawned = this.deps.herdr.start(s.name, s.worktreePath, argv);
     this.deps.store.update(id, {
-      herdrAgentId: agent.terminalId,
+      herdrAgentId: spawned.terminalId,
       status: "running",
       lastState: "idle",
     });

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -277,3 +277,20 @@ test("matchAgents: stale terminalId adopts the fresh agent at the same cwd", () 
   const m = matchAgents([s], [mkAgent({ terminalId: "fresh", cwd: "/wt/z", name: "x" })]);
   expect(m.get("S")?.terminalId).toBe("fresh");
 });
+
+test("matchAgents: across a herdr restart (all ids stale), a dead session can't steal the live one's agent by shared cwd", () => {
+  // Two non-isolated sessions at the same repo cwd; herdr reassigned every terminalId.
+  const dead = { id: "D", herdrAgentId: "old_d", worktreePath: "/repo", name: "dead-task" };
+  const live = { id: "L", herdrAgentId: "old_l", worktreePath: "/repo", name: "live-task" };
+  const agents = [mkAgent({ terminalId: "fresh_l", cwd: "/repo", name: "live-task" })];
+  const m = matchAgents([dead, live], agents); // dead listed first — must NOT win
+  expect(m.get("L")?.terminalId).toBe("fresh_l");
+  expect(m.get("D")).toBeNull();
+});
+
+test("matchAgents: a sole session at its cwd re-pairs even when its name drifted from the agent", () => {
+  // isolated session, unique cwd, herdr agent name no longer matches (relabel had failed).
+  const s = { id: "S", herdrAgentId: "stale", worktreePath: "/wt/uniq", name: "new-name" };
+  const m = matchAgents([s], [mkAgent({ terminalId: "fresh", cwd: "/wt/uniq", name: "old-name" })]);
+  expect(m.get("S")?.terminalId).toBe("fresh");
+});

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { HerdrDriver, mapState, matchAgent, type HerdrAgent } from "../src/herdr";
+import { HerdrDriver, mapState, matchAgent, matchAgents, type HerdrAgent } from "../src/herdr";
 
 const FIXTURE = JSON.stringify({
   result: {
@@ -249,4 +249,31 @@ test("matchAgent: cwd ambiguous AND name ambiguous → null", () => {
 
 test("matchAgent: no terminalId and no cwd match → null", () => {
   expect(matchAgent(sess, [mkAgent({ terminalId: "t9", cwd: "/other" })])).toBeNull();
+});
+
+test("matchAgents: a dead session cannot steal a live sibling's exact-id agent at the same cwd", () => {
+  const live = { id: "L", herdrAgentId: "term_live", worktreePath: "/wt", name: "x" };
+  const dead = { id: "D", herdrAgentId: "term_dead", worktreePath: "/wt", name: "x" };
+  const agents = [mkAgent({ terminalId: "term_live", cwd: "/wt", name: "x" })];
+  const m = matchAgents([live, dead], agents);
+  expect(m.get("L")?.terminalId).toBe("term_live");
+  expect(m.get("D")).toBeNull();
+});
+
+test("matchAgents: each live agent is adopted by at most one session", () => {
+  const a = { id: "A", herdrAgentId: "stale_a", worktreePath: "/wt", name: "alpha" };
+  const b = { id: "B", herdrAgentId: "stale_b", worktreePath: "/wt", name: "beta" };
+  const agents = [
+    mkAgent({ terminalId: "fresh_a", cwd: "/wt", name: "alpha" }),
+    mkAgent({ terminalId: "fresh_b", cwd: "/wt", name: "beta" }),
+  ];
+  const m = matchAgents([a, b], agents);
+  expect(m.get("A")?.terminalId).toBe("fresh_a");
+  expect(m.get("B")?.terminalId).toBe("fresh_b");
+});
+
+test("matchAgents: stale terminalId adopts the fresh agent at the same cwd", () => {
+  const s = { id: "S", herdrAgentId: "stale", worktreePath: "/wt/z", name: "x" };
+  const m = matchAgents([s], [mkAgent({ terminalId: "fresh", cwd: "/wt/z", name: "x" })]);
+  expect(m.get("S")?.terminalId).toBe("fresh");
 });

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { HerdrDriver, mapState } from "../src/herdr";
+import { HerdrDriver, mapState, matchAgent, type HerdrAgent } from "../src/herdr";
 
 const FIXTURE = JSON.stringify({
   result: {
@@ -208,4 +208,45 @@ test("mapState maps herdr states to shepherd status", () => {
   expect(mapState("done")).toBe("done");
   expect(mapState("idle")).toBe("idle");
   expect(mapState("unknown")).toBe("idle");
+});
+
+const mkAgent = (over: Partial<HerdrAgent>) =>
+  ({
+    agent: "claude",
+    agentStatus: "working",
+    cwd: "/wt/a",
+    name: "",
+    paneId: "p",
+    tabId: "t",
+    terminalId: "term_x",
+    workspaceId: "w",
+    ...over,
+  }) as HerdrAgent;
+
+const sess = { herdrAgentId: "term_old", worktreePath: "/wt/a", name: "alpha" };
+
+test("matchAgent: terminalId fast path wins even if cwd differs", () => {
+  const a = mkAgent({ terminalId: "term_old", cwd: "/elsewhere" });
+  expect(matchAgent(sess, [a, mkAgent({ terminalId: "term_x" })])).toBe(a);
+});
+
+test("matchAgent: falls back to a single cwd match and ignores the stale id", () => {
+  const a = mkAgent({ terminalId: "term_new", cwd: "/wt/a" });
+  expect(matchAgent(sess, [a])).toBe(a);
+});
+
+test("matchAgent: cwd shared by 2+ agents → disambiguate by name", () => {
+  const a = mkAgent({ terminalId: "t1", cwd: "/wt/a", name: "alpha" });
+  const b = mkAgent({ terminalId: "t2", cwd: "/wt/a", name: "beta" });
+  expect(matchAgent(sess, [a, b])).toBe(a);
+});
+
+test("matchAgent: cwd ambiguous AND name ambiguous → null", () => {
+  const a = mkAgent({ terminalId: "t1", cwd: "/wt/a", name: "alpha" });
+  const b = mkAgent({ terminalId: "t2", cwd: "/wt/a", name: "alpha" });
+  expect(matchAgent(sess, [a, b])).toBeNull();
+});
+
+test("matchAgent: no terminalId and no cwd match → null", () => {
+  expect(matchAgent(sess, [mkAgent({ terminalId: "t9", cwd: "/other" })])).toBeNull();
 });

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -734,6 +734,53 @@ test("pruneInactive clears activity tracking for a running-only session that goe
   expect(activities).toHaveLength(2);
 });
 
+test("tick adopts a resurrected agent by cwd, re-points the id, emits, and does NOT reap", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({ ...baseSession, worktreePath: "/wt", herdrAgentId: "term_stale" });
+  const emitted: { id: string; status: string }[] = [];
+
+  const agents: HerdrAgent[] = [
+    {
+      agent: "claude",
+      agentStatus: "working",
+      cwd: "/wt",
+      paneId: "p",
+      tabId: "t",
+      name: "x",
+      terminalId: "term_fresh",
+      workspaceId: "w",
+    },
+  ];
+
+  const poller = new StatusPoller(
+    store,
+    { list: () => agents, read: () => "" } as any,
+    (id, status) => emitted.push({ id, status }),
+    () => {},
+  );
+
+  poller.tick();
+  const out = store.get(s.id);
+  expect(out?.herdrAgentId).toBe("term_fresh"); // adopted, not reaped
+  expect(out?.status).toBe("running");
+  expect(emitted).toContainEqual({ id: s.id, status: "running" });
+});
+
+test("tick reaps when neither terminalId nor cwd matches a live agent", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({ ...baseSession, worktreePath: "/wt", herdrAgentId: "term_stale" });
+
+  const poller = new StatusPoller(
+    store,
+    { list: () => [], read: () => "" } as any,
+    () => {},
+    () => {},
+  );
+
+  poller.tick();
+  expect(store.get(s.id)?.status).toBe("done");
+});
+
 test("activitySnapshot returns last emitted signal, pruned when the session goes away", () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);

--- a/test/reconcile.test.ts
+++ b/test/reconcile.test.ts
@@ -36,3 +36,27 @@ test("reconcile marks sessions whose herdr agent is gone as done", () => {
   expect(store.get(live.id)?.status).toBe("running");
   expect(store.get(dead.id)?.status).toBe("done");
 });
+
+test("reconcile re-pairs a session whose terminalId went stale but agent is live at the same cwd", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({ ...base, worktreePath: "/wt/z", herdrAgentId: "term_stale" });
+
+  reconcile(store, {
+    list: () => [
+      {
+        name: "x",
+        terminalId: "term_fresh",
+        agentStatus: "working",
+        agent: "claude",
+        cwd: "/wt/z",
+        paneId: "p",
+        tabId: "t",
+        workspaceId: "w",
+      },
+    ],
+  } as any);
+
+  const out = store.get(s.id);
+  expect(out?.status).toBe("running");
+  expect(out?.herdrAgentId).toBe("term_fresh"); // adopted the new id
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1492,6 +1492,41 @@ test("create injects only the planned house rules and drops the over-budget ones
   expect(injectedCount).toBeLessThan(40);
 });
 
+test("resume adopts a live agent found by cwd under a new terminalId — no duplicate spawn", () => {
+  const store = new SessionStore(":memory:");
+  let startCalls = 0;
+  const svc = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    herdr: {
+      start: () => {
+        startCalls++;
+        return { terminalId: "term_should_not_happen" } as any;
+      },
+      list: () => [
+        {
+          agent: "claude",
+          agentStatus: "working",
+          cwd: "/wt/x",
+          name: "x",
+          paneId: "p",
+          tabId: "t",
+          terminalId: "term_fresh",
+          workspaceId: "w",
+        },
+      ],
+      stop: () => {},
+      send: () => {},
+    } as any,
+  });
+  const s = resumable(store, { model: "opus" }); // worktreePath "/wt/x", herdrAgentId "term_old"
+
+  const out = svc.resume(s.id);
+  expect(startCalls).toBe(0); // agent already live → must NOT respawn
+  expect(out?.herdrAgentId).toBe("term_fresh"); // adopted the new id
+});
+
 test("archiveMany isolates a failing session: others still clear, the failed id is excluded", () => {
   const store = new SessionStore(":memory:");
   const detect = (): any[] => [];


### PR DESCRIPTION
## Problem

Session resume broke after a herdr daemon restart (e.g. `herdr update`). herdr faithfully restores every agent at its correct worktree cwd, but assigns each a **new** `terminal_id`. Shepherd paired each session row to its agent **solely** by `terminalId === session.herdrAgentId`, so on a restart every session's id went stale at once:

- `reconcile()` marked every active session `done` — alive in herdr, shown dead in shepherd.
- the poller never recovered (same terminalId-only lookup).
- `resume()`'s liveness check also keyed on terminalId, so it spawned a **duplicate** `claude --resume`.

(The "wrong folder" hunch was a red herring — the cwd was always correct; only the session↔agent mapping was lost.)

## Fix

Match by a **stable** key instead of the volatile terminalId:

- `matchAgent(session, agents)` — terminalId fast path → immutable worktree-cwd fallback → name tiebreak.
- `matchAgents(sessions, agents)` — resolves all active sessions at once and arbitrates cross-session collisions: an agent held via exact terminalId is off-limits to another session's cwd fallback; when 2+ sessions share a cwd (non-isolated same-repo) only an unambiguous name match is taken, while a sole session adopts its lone agent regardless of name (so a renamed isolated session still re-pairs).
- `reconcile()`, `StatusPoller.tick()`, and `SessionService.resume()` all route through `matchAgents` and **adopt** the new terminalId (re-point `herdrAgentId`) instead of marking sessions done / double-spawning. The poller emits `session:status` so the UI re-attaches its PTY to the fresh terminal.

Server-only change; no UI changes.

## Test Plan

- [x] `bun test ./test` — 1031 pass / 0 fail
- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bunx fallow audit --base origin/main` — no findings
- [x] New unit tests: matchAgent/matchAgents (incl. all-ids-stale restart + renamed-isolated re-pair), reconcile adopt-on-boot, poller adopt-not-reap + reap-when-truly-gone, resume adopt-no-double-spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)