### PR TITLE
fix(ui): update modals — no row overlap on expand, full-height mobile sheet

### DIFF
--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -268,6 +268,10 @@
     margin-bottom: -8px;
   }
   .notes {
+    /* shrinkable flex child: without min-height long release notes refuse to
+       shrink below their content and push the actions off-screen */
+    flex: 0 1 auto;
+    min-height: 0;
     overflow-y: auto;
     border: 1px solid var(--color-line);
     background: var(--color-inset);
@@ -426,5 +430,50 @@
     color: var(--color-faint);
     border-color: var(--color-line);
     box-shadow: none;
+  }
+  /* phones: rise as a full-height sheet (same pattern as NewTask/UpdateModal)
+     so the release notes scroll internally and the actions stay pinned and
+     thumb-reachable above the home indicator */
+  @media (max-width: 768px) {
+    .overlay {
+      align-items: stretch;
+      justify-content: stretch;
+      padding: 0;
+    }
+    .card {
+      width: 100%;
+      max-height: none;
+      height: 100dvh;
+      border: 0;
+      padding: 16px 16px calc(14px + env(safe-area-inset-bottom));
+      animation: sheet-up 0.18s ease-out;
+    }
+    .bracket::before,
+    .bracket::after {
+      display: none;
+    }
+    .x {
+      min-width: 44px;
+      min-height: 44px;
+      margin: -14px -14px -10px 0; /* keep the glyph optically in the corner */
+    }
+    .later,
+    .run {
+      min-height: 44px;
+      flex: 1; /* two thumb-width targets instead of two slivers at the edge */
+    }
+    .actions {
+      margin-top: auto; /* pin to the bottom even when the notes are short */
+    }
+  }
+  @keyframes sheet-up {
+    from {
+      transform: translateY(12px);
+      opacity: 0.6;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
   }
 </style>

--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -445,7 +445,11 @@
       max-height: none;
       height: 100dvh;
       border: 0;
-      padding: 16px 16px calc(14px + env(safe-area-inset-bottom));
+      /* safe-area top: standalone-PWA status bar / Dynamic Island */
+      padding: calc(16px + env(safe-area-inset-top)) 16px calc(14px + env(safe-area-inset-bottom));
+      /* fallback when notes are absent or content exceeds the viewport
+         (landscape phones): scroll the card rather than clip the actions */
+      overflow-y: auto;
       animation: sheet-up 0.18s ease-out;
     }
     .bracket::before,
@@ -456,6 +460,9 @@
       min-width: 44px;
       min-height: 44px;
       margin: -14px -14px -10px 0; /* keep the glyph optically in the corner */
+    }
+    .notes {
+      flex-grow: 1; /* fill the sheet so the notes, not a void, own the space */
     }
     .later,
     .run {

--- a/ui/src/lib/components/UpdateModal.svelte
+++ b/ui/src/lib/components/UpdateModal.svelte
@@ -371,7 +371,11 @@
       max-height: none;
       height: 100dvh;
       border: 0;
-      padding: 16px 16px calc(14px + env(safe-area-inset-bottom));
+      /* safe-area top: standalone-PWA status bar / Dynamic Island */
+      padding: calc(16px + env(safe-area-inset-top)) 16px calc(14px + env(safe-area-inset-bottom));
+      /* fallback when even fully-shrunk content exceeds the viewport
+         (landscape phones): scroll the card rather than clip the actions */
+      overflow-y: auto;
       animation: sheet-up 0.18s ease-out;
     }
     .bracket::before,

--- a/ui/src/lib/components/UpdateModal.svelte
+++ b/ui/src/lib/components/UpdateModal.svelte
@@ -90,8 +90,13 @@
           title={c.subject}
           onclick={() => toggle(c.sha)}
         >
-          <span class="sha">{c.sha}</span>
-          <span class="subject">{c.subject}</span>
+          <!-- inner wrapper carries the flex layout: WebKit doesn't reliably
+               grow a <button> that is itself a flex container when a child
+               wraps, which painted the expanded subject over the next row -->
+          <span class="row">
+            <span class="sha">{c.sha}</span>
+            <span class="subject">{c.subject}</span>
+          </span>
         </button>
       {/each}
     </div>
@@ -217,6 +222,10 @@
     font-variant-numeric: tabular-nums;
   }
   .commits {
+    /* shrinkable flex child: without min-height the list refuses to shrink
+       below its content and 16 commits push the actions off-screen */
+    flex: 0 1 auto;
+    min-height: 0;
     overflow-y: auto;
     border: 1px solid var(--color-line);
     background: var(--color-inset);
@@ -226,9 +235,7 @@
     gap: 5px;
   }
   .commit {
-    display: flex;
-    gap: 9px;
-    align-items: flex-start;
+    display: block;
     width: 100%;
     margin: 0;
     padding: 2px 0;
@@ -241,6 +248,11 @@
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
   }
+  .commit .row {
+    display: flex;
+    gap: 9px;
+    align-items: flex-start;
+  }
   .commit:focus-visible {
     outline: 1px solid var(--color-line-bright);
     outline-offset: 2px;
@@ -252,6 +264,7 @@
   }
   .commit .subject {
     color: var(--color-ink-bright);
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -259,17 +272,18 @@
   /* tapped open → wrap the full subject across the available width */
   .commit.expanded .subject {
     white-space: normal;
-    overflow: visible;
     word-break: break-word;
   }
   /* touch devices: roomier rows so a single commit is easy to hit and read */
   @media (pointer: coarse) {
     .commit {
       padding: 8px 0;
-      min-height: 34px;
+    }
+    .commit .row {
+      min-height: 28px;
       align-items: center;
     }
-    .commit.expanded {
+    .commit.expanded .row {
       align-items: flex-start;
     }
     .commits {
@@ -342,5 +356,53 @@
     color: var(--color-faint);
     border-color: var(--color-line);
     box-shadow: none;
+  }
+  /* phones: rise as a full-height sheet (same pattern as NewTask) so the
+     commit list gets the whole screen and scrolls internally while the
+     actions stay pinned and thumb-reachable above the home indicator */
+  @media (max-width: 768px) {
+    .overlay {
+      align-items: stretch;
+      justify-content: stretch;
+      padding: 0;
+    }
+    .card {
+      width: 100%;
+      max-height: none;
+      height: 100dvh;
+      border: 0;
+      padding: 16px 16px calc(14px + env(safe-area-inset-bottom));
+      animation: sheet-up 0.18s ease-out;
+    }
+    .bracket::before,
+    .bracket::after {
+      display: none;
+    }
+    .x {
+      min-width: 44px;
+      min-height: 44px;
+      margin: -14px -14px -10px 0; /* keep the glyph optically in the corner */
+    }
+    .commits {
+      flex-grow: 1; /* fill the sheet so the list, not a void, owns the space */
+    }
+    .later,
+    .run {
+      min-height: 44px;
+      flex: 1; /* two thumb-width targets instead of two slivers at the edge */
+    }
+    .actions {
+      margin-top: auto; /* pin to the bottom even when few commits */
+    }
+  }
+  @keyframes sheet-up {
+    from {
+      transform: translateY(12px);
+      opacity: 0.6;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
   }
 </style>


### PR DESCRIPTION
## Problem

After updating, the **Update available** dialog broke on mobile (reported on iPhone 14, dark theme):

1. **Tapping a commit row painted its wrapped subject over the next row.** WebKit doesn't reliably grow a `<button>` that is itself a flex container when a child wraps — the expanded subject wrapped to multiple lines but the button kept its single-line height, so the overflow drew on top of the following commit.
2. **With 16 commits the dialog overflowed the viewport.** The commit list had `overflow-y: auto` but no `min-height: 0`, so the flex column couldn't shrink it into an internal scroll — the card simply ran past `80dvh`.

`HerdrUpdateModal` shares the same structure: long release notes would push its actions off-screen the same way.

## Fix

- Move the commit row's flex layout onto an inner `<span class="row">`; the `<button>` is `display: block` and grows correctly when the subject wraps (sidesteps the WebKit button-as-flex-container quirk).
- Make the commit list (and herdr release notes) shrinkable (`flex: 0 1 auto; min-height: 0`) so they scroll internally instead of overflowing the card.
- On phones (≤768px) both update modals rise as a **full-height sheet** — same pattern as NewTask (`sheet-up` 0.18s ease-out, border dropped, brackets hidden): the list fills and scrolls the screen, actions stay pinned above the home indicator (`env(safe-area-inset-bottom)`), Later/Update and the close ✕ get 44px touch targets.

## Verification

- Screenshots at iPhone 14 viewport (390×844, dark + light) with a long commit subject expanded: no overlap, 16 commits scroll internally, actions visible and pinned. Desktop (1280×800) unchanged.
- `bun run check` 0 errors, `check:i18n` 2 locales in parity (no new strings), `bun run test` 411/411 green.