### PR TITLE
fix(reconcile): guard startup reconcile when herdr is down (#315)

### DIFF
--- a/src/reconcile.ts
+++ b/src/reconcile.ts
@@ -3,7 +3,22 @@ import { mapState, matchAgents, type HerdrDriver } from "./herdr";
 
 export function reconcile(store: SessionStore, herdr: Pick<HerdrDriver, "list">): void {
   const sessions = store.list({ activeOnly: true });
-  const matched = matchAgents(sessions, herdr.list());
+  // herdr can be unreachable at startup (cold boot before herdr is up, or herdr was
+  // just stopped — e.g. by an update). `agent list` then THROWS. This runs once at
+  // top level with no surrounding try/catch, so an unhandled throw exits shepherd —
+  // and with systemd Restart=on-failure that becomes a crash-loop (#315): shepherd
+  // dies before its poller can bring herdr back, so it never recovers. Bail on any
+  // herdr failure WITHOUT touching session state (the agents are alive; herdr is just
+  // temporarily unreachable — reaping them all to "done" would be wrong). The 1s
+  // poller, which already skips ticks the same way, reconciles once herdr is reachable.
+  let agents: ReturnType<HerdrDriver["list"]>;
+  try {
+    agents = herdr.list();
+  } catch (err) {
+    console.warn("[reconcile] herdr list failed; skipping startup reconcile:", err);
+    return;
+  }
+  const matched = matchAgents(sessions, agents);
   for (const s of sessions) {
     const agent = matched.get(s.id) ?? null;
     if (!agent) store.update(s.id, { status: "done", lastState: "done" });

--- a/test/reconcile.test.ts
+++ b/test/reconcile.test.ts
@@ -37,6 +37,24 @@ test("reconcile marks sessions whose herdr agent is gone as done", () => {
   expect(store.get(dead.id)?.status).toBe("done");
 });
 
+test("reconcile degrades gracefully when herdr is down: no throw, session state untouched", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({ ...base, herdrAgentId: "term_live" });
+
+  // herdr server/socket down → `agent list` throws (the cold-boot crash-loop of #315).
+  expect(() =>
+    reconcile(store, {
+      list: () => {
+        throw new Error("Os { code: 2, kind: NotFound }");
+      },
+    } as any),
+  ).not.toThrow();
+
+  // must NOT reap a live session to "done" on a transient herdr hiccup — the
+  // 1s poller reconciles once herdr is reachable again.
+  expect(store.get(s.id)?.status).toBe("running");
+});
+
 test("reconcile re-pairs a session whose terminalId went stale but agent is live at the same cwd", () => {
   const store = new SessionStore(":memory:");
   const s = store.create({ ...base, worktreePath: "/wt/z", herdrAgentId: "term_stale" });


### PR DESCRIPTION
Fixes #315.

## Problem

On startup, `reconcile(store, herdr)` (`src/index.ts:89`) synchronously calls `herdr.list()` → `execFileSync("herdr", …)` with no guard. If herdr's server/socket is down (cold boot before herdr is up, or herdr just stopped — e.g. by an update), the CLI throws `Os { code: 2, kind: NotFound }`. Uncaught at top level → shepherd exits 1. With systemd `Restart=on-failure` this becomes a **crash-loop**: shepherd dies before its poller can bring herdr back, so it never recovers (observed live, 100+ restarts).

## Fix

Guard `herdr.list()` inside `reconcile()`: on any failure, **log + skip**, leaving session state untouched. The agents are alive — herdr is merely unreachable — so reaping them all to `done` would be wrong. The 1s `StatusPoller`, which already skips ticks the same way (`poller.ts:61-67`) and whose `reapGone`/`reconcileAgent` mirror `reconcile()`, reconciles everything once herdr is reachable again.

This is the only synchronous herdr call on the startup path; the other startup herdr touch (`reapOrphanTabs`) already runs inside a try/catch via `setTimeout`.

## Test

New `reconcile.test.ts` case: a throwing `herdr.list()` must not throw out of `reconcile()` and must leave a live session's status untouched (`running`, not reaped to `done`).

- `bun run lint` clean
- `bunx tsc --noEmit` clean
- `bun test ./test` — 1043 pass / 0 fail