### PR TITLE
feat(announce): catalog entry for halt-the-herd e-stop (#327)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -132,7 +132,7 @@
   "feat_learnings_title": "Hausregeln für Agenten",
   "feat_learnings_body": "Destillierte Hausregeln aus früherer Agentenaktivität werden in jede neue Agent-Session injiziert, damit die Konventionen deines Teams automatisch weitergegeben werden.",
   "feat_halt_title": "Herde stoppen",
-  "feat_halt_body": "Ein einzelner roter Not-Stopp in der oberen Leiste unterbricht den aktuellen Zug aller laufenden Agenten auf einmal — deine jederzeit erreichbare Notbremse, wenn die Herde anhalten muss.",
+  "feat_halt_body": "Ein einzelner roter Not-Stopp in der oberen Leiste bringt die ganze Herde zum Stehen — bestätige ihn, und der aktuelle Zug jedes laufenden Agenten wird auf einmal unterbrochen. Deine jederzeit erreichbare Notbremse, wenn die Herde anhalten muss.",
   "gitrail_send_review": "↩ Review an Agent",
   "gitrail_send_review_failed": "Senden fehlgeschlagen",
   "gitrail_send_review_reviewing_title": "Critic prüft erneut — diese Anmerkungen werden gerade neu validiert",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -131,6 +131,8 @@
   "feat_auto_address_body": "Kritiker-Befunde gehen direkt zurück an den Agenten, der sie behebt und pusht, bis der Kritiker zufrieden ist oder das Runden-Limit erreicht wird.",
   "feat_learnings_title": "Hausregeln für Agenten",
   "feat_learnings_body": "Destillierte Hausregeln aus früherer Agentenaktivität werden in jede neue Agent-Session injiziert, damit die Konventionen deines Teams automatisch weitergegeben werden.",
+  "feat_halt_title": "Herde stoppen",
+  "feat_halt_body": "Ein einzelner roter Not-Stopp in der oberen Leiste unterbricht den aktuellen Zug aller laufenden Agenten auf einmal — deine jederzeit erreichbare Notbremse, wenn die Herde anhalten muss.",
   "gitrail_send_review": "↩ Review an Agent",
   "gitrail_send_review_failed": "Senden fehlgeschlagen",
   "gitrail_send_review_reviewing_title": "Critic prüft erneut — diese Anmerkungen werden gerade neu validiert",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -131,6 +131,8 @@
   "feat_auto_address_body": "Critic findings are fed straight back to the agent, which fixes them and pushes until the critic is clear or the round cap is hit.",
   "feat_learnings_title": "House rules for agents",
   "feat_learnings_body": "Distilled house rules from prior agent activity are injected into every new agent session, so your team's conventions propagate automatically.",
+  "feat_halt_title": "Halt the herd",
+  "feat_halt_body": "A single red e-stop in the top bar interrupts the current turn on every running agent at once — your always-reachable emergency brake when the herd needs to stand down.",
   "gitrail_send_review": "↩ Send review to agent",
   "gitrail_send_review_failed": "send failed",
   "gitrail_send_review_reviewing_title": "Critic is re-reviewing — these findings are being re-validated",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -132,7 +132,7 @@
   "feat_learnings_title": "House rules for agents",
   "feat_learnings_body": "Distilled house rules from prior agent activity are injected into every new agent session, so your team's conventions propagate automatically.",
   "feat_halt_title": "Halt the herd",
-  "feat_halt_body": "A single red e-stop in the top bar interrupts the current turn on every running agent at once — your always-reachable emergency brake when the herd needs to stand down.",
+  "feat_halt_body": "A single red emergency stop in the top bar brings the whole herd to a halt — confirm it and every running agent's current turn is interrupted at once. Your always-reachable brake for when the herd needs to stand down.",
   "gitrail_send_review": "↩ Send review to agent",
   "gitrail_send_review_failed": "send failed",
   "gitrail_send_review_reviewing_title": "Critic is re-reviewing — these findings are being re-validated",

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -37,4 +37,10 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_learnings_body",
     targetId: "learnings",
   },
+  {
+    id: "halt-the-herd",
+    sinceVersion: "1.15.0",
+    titleKey: "feat_halt_title",
+    bodyKey: "feat_halt_body",
+  },
 ];

--- a/ui/src/lib/feature-gate.test.ts
+++ b/ui/src/lib/feature-gate.test.ts
@@ -81,13 +81,18 @@ describe("computeNewEntries", () => {
     expect(computeNewEntries("1.9.0", "1.10.0", [])).toEqual([]);
   });
 
-  it("real catalog: upgrade from 1.9.0 → 1.10.0 shows all three seed entries", () => {
-    // sinceVersion "1.10.0" <= current "1.10.0" → included (upper-bound is inclusive)
+  it("real catalog: upgrade from 1.9.0 → 1.10.0 shows the three 1.10.0 seed entries", () => {
+    // sinceVersion "1.10.0" <= current "1.10.0" → included (upper-bound is inclusive);
+    // later entries (e.g. the 1.15.0 halt-the-herd e-stop) are future-dated → excluded.
     const result = computeNewEntries("1.9.0", "1.10.0", featureAnnouncements);
     expect(result.map((e) => e.id)).toEqual(
       expect.arrayContaining(["critic", "auto-address", "learnings"]),
     );
-    expect(result).toHaveLength(featureAnnouncements.length);
+    // exactly the entries whose sinceVersion falls in (1.9.0, 1.10.0]
+    expect(result).toHaveLength(
+      featureAnnouncements.filter((e) => e.sinceVersion === "1.10.0").length,
+    );
+    expect(result.find((e) => e.id === "halt-the-herd")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #327. Follow-up to #326 (the "Halt the herd" e-stop, shipped in 1.15.0).

The global 🛑 e-stop in the TopBar predated the #325 catalog-upkeep gate, so the What's-New drawer never announced it. This backfills the catalog entry.

## Changes
- **`feature-announcements.ts`**: append `halt-the-herd` entry (`sinceVersion: 1.15.0`, `feat_halt_title`/`feat_halt_body`).
- **`en.json` + `de.json`**: matching title/body keys (i18n parity).
- **`feature-gate.test.ts`**: the "upgrade 1.9.0 → 1.10.0" test asserted the result length equalled the *whole* catalog — only true while every entry was ≤1.10.0. Updated to derive the expected count from entries dated 1.10.0 and to assert the future-dated `halt-the-herd` entry is excluded.

## No coachmark / targetId
Deliberately omitted (the issue marks it optional). The coachmark machinery is bound to GitRail's automation pill — arming only iterates a hardcoded `PILL_FEATURE_IDS`, and `<Coachmark>` renders solely in GitRail. A `use:coachTarget` on the TopBar halt button would register a node that nothing ever arms or anchors against — dead config. The What's-New drawer surfaces every entry regardless of `targetId`, so the e-stop is announced.

## Verification
- `check:i18n` ✅ (554 keys, both locales in parity)
- `bun run check` ✅ (0 errors)
- `bun run test` ✅ (429 passed)
- `check-feature-catalog.sh` ✅
- `check-branch-hygiene.sh` ✅ (linear off main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)