### PR TITLE
fix(ui): quiet halt button + two-step arm→confirm

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -542,6 +542,8 @@
   "broadcast_textarea_aria": "Steer-Nachricht",
   "halt_all": "Herde stoppen",
   "halt_all_aria": "Herde stoppen — alle {count} laufenden Agenten unterbrechen",
+  "halt_arm": "{count} stoppen?",
+  "halt_arm_aria": "Stopp bestätigen — erneut aktivieren, um alle {count} laufenden Agenten zu unterbrechen",
   "halt_confirm": "{count} laufende Agenten werden gestoppt…",
   "halt_done": "{count} Agenten gestoppt",
   "halt_failed": "Stopp fehlgeschlagen — keine Agenten unterbrochen. Erneut versuchen.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -542,6 +542,8 @@
   "broadcast_textarea_aria": "Steer message",
   "halt_all": "Halt herd",
   "halt_all_aria": "Halt the herd — interrupt all {count} running agents",
+  "halt_arm": "Halt {count}?",
+  "halt_arm_aria": "Confirm halt — activate again to interrupt all {count} running agents",
   "halt_confirm": "Halting {count} running agents…",
   "halt_done": "Halted {count} agents",
   "halt_failed": "Halt failed — no agents interrupted. Retry.",

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -492,13 +492,17 @@
     color: var(--color-red);
     border-color: var(--color-red);
   }
+  /* Pinned to --fs-lg (not 1em) so the glyph stays the same size when arming drops
+     the button font-size to --fs-meta — keeps the icon visually stable on the morph. */
   .halt-icon {
-    width: 1em;
-    height: 1em;
+    width: var(--fs-lg);
+    height: var(--fs-lg);
     display: block;
   }
   /* Armed (first activation): the single moment it goes loud — a filled red "Halt N?"
-     confirm pill. A second activation commits; Escape / outside-tap / timeout disarm. */
+     confirm pill. A second activation commits; Escape / outside-tap / timeout disarm.
+     Vertical padding stays 5px (matching rest) so arming only grows width for the
+     label rather than nudging the row height. */
   .halt.armed {
     padding: 5px 11px;
     background: color-mix(in srgb, var(--color-red) 22%, transparent);

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -107,11 +107,43 @@
     if (!touch || !hotter) popoverOpen = false;
   });
 
+  // Two-step arm→confirm for the emergency stop: the first activation arms the red
+  // "Halt N?" pill, a second commits (onhalt). It auto-disarms after a few seconds,
+  // on Escape, on an outside tap, or once nothing is left running — so a stray tap on
+  // a rarely-used control can never halt the fleet on its own.
+  let armed = $state(false);
+  let armTimer: ReturnType<typeof setTimeout> | undefined;
+  let haltBtn = $state<HTMLButtonElement | null>(null);
+  function disarmHalt() {
+    armed = false;
+    clearTimeout(armTimer);
+  }
+  function clickHalt() {
+    if (!armed) {
+      armed = true;
+      clearTimeout(armTimer);
+      armTimer = setTimeout(() => (armed = false), 4000);
+    } else {
+      disarmHalt();
+      onhalt?.();
+    }
+  }
+  // Drop the armed state if the herd goes quiet underneath it (agents finished), so a
+  // later run doesn't surface a pre-armed button.
+  $effect(() => {
+    if (working === 0) disarmHalt();
+  });
+  // Destroy-only cleanup (no tracked reads → runs once): never leak the disarm timer.
+  $effect(() => () => clearTimeout(armTimer));
+
   function dismissOnEscape(e: KeyboardEvent) {
-    if (popoverOpen && e.key === "Escape") popoverOpen = false;
+    if (e.key !== "Escape") return;
+    if (popoverOpen) popoverOpen = false;
+    if (armed) disarmHalt();
   }
   function dismissOnOutside(e: MouseEvent) {
     if (popoverOpen && gaugeWrap && !gaugeWrap.contains(e.target as Node)) popoverOpen = false;
+    if (armed && haltBtn && !haltBtn.contains(e.target as Node)) disarmHalt();
   }
 </script>
 
@@ -155,25 +187,26 @@
   {/if}
   <div class="rightside">
     {#if working > 0}
-      <!-- The big red button: a single always-reachable control that interrupts the
-           current turn on every live working agent at once. Only shown when something
-           is actually running, so it never reads as an idle decoration. Desktop carries
-           the label; phones collapse to the 🛑 glyph + working count (full text stays
-           as the aria-label). -->
+      <!-- Emergency stop: interrupts every live working agent at once. Only shown while
+           something is running. Quiet by default (gear-weight: neutral outline, muted
+           octagon) so a near-never-pressed control doesn't dominate the bar — it reveals
+           its red only on intent (hover/focus) and once armed. One activation arms the
+           "Halt N?" confirm pill, a second commits (full intent stays in the aria-label). -->
       <button
+        bind:this={haltBtn}
         class="halt"
-        class:compact={mobile || compactBadges}
+        class:armed
         type="button"
-        onclick={() => onhalt?.()}
-        aria-label={m.halt_all_aria({ count: working })}
-        title={m.halt_all_aria({ count: working })}
+        onclick={clickHalt}
+        aria-label={armed
+          ? m.halt_arm_aria({ count: working })
+          : m.halt_all_aria({ count: working })}
+        title={armed ? undefined : m.halt_all()}
       >
-        <span class="halt-icon" aria-hidden="true">🛑</span>
-        {#if mobile || compactBadges}
-          <span class="halt-n">{working}</span>
-        {:else}
-          <span class="halt-label">{m.halt_all()}</span>
-        {/if}
+        <svg class="halt-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M8 2 H16 L22 8 V16 L16 22 H8 L2 16 V8 Z" fill="currentColor" />
+        </svg>
+        {#if armed}<span class="halt-label">{m.halt_arm({ count: working })}</span>{/if}
       </button>
     {/if}
     {#if needsYou > 0}
@@ -433,44 +466,50 @@
     white-space: nowrap;
     flex-shrink: 0;
   }
-  /* Emergency stop: the most consequential control in the bar, so it carries the
-     strongest red and a filled body (not just an outline) to read as a real button,
-     not a passive badge. The 🛑 glyph anchors it apart from the red NEEDS-YOU chip. */
+  /* Emergency stop: consequential but almost never pressed, so it stays quiet by
+     default — gear-weight (neutral outline, muted octagon glyph), not a filled red
+     block — and only reveals its red on intent (hover/focus) or once armed. That keeps
+     it from dominating the bar or bulging the row's height next to the text tallies. */
   .halt {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 6px;
-    background: color-mix(in srgb, var(--color-red) 22%, transparent);
-    border: 1px solid var(--color-red);
-    color: var(--color-red);
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
     font: inherit;
-    font-size: var(--fs-meta);
-    padding: 5px 11px;
+    font-size: var(--fs-lg);
+    line-height: 1;
+    padding: 5px 8px;
     border-radius: 2px;
     cursor: pointer;
     white-space: nowrap;
     flex-shrink: 0;
   }
-  .halt:hover {
-    background: color-mix(in srgb, var(--color-red) 32%, transparent);
+  .halt:hover,
+  .halt:focus-visible {
+    color: var(--color-red);
+    border-color: var(--color-red);
   }
   .halt-icon {
-    font-size: var(--fs-base);
-    line-height: 1;
+    width: 1em;
+    height: 1em;
+    display: block;
   }
-  .halt-n {
-    font-weight: 600;
+  /* Armed (first activation): the single moment it goes loud — a filled red "Halt N?"
+     confirm pill. A second activation commits; Escape / outside-tap / timeout disarm. */
+  .halt.armed {
+    padding: 5px 11px;
+    background: color-mix(in srgb, var(--color-red) 22%, transparent);
+    border-color: var(--color-red);
+    color: var(--color-red);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+  .halt-label {
     font-variant-numeric: tabular-nums;
-  }
-  /* Phone: collapse to a 🛑 + count chip so it holds line 1 with the other controls. */
-  .halt.compact {
-    justify-content: center;
-    min-width: 44px;
-    gap: 4px;
-    padding: 8px 10px;
-    letter-spacing: 0;
   }
   .learnings-badge {
     background: transparent;
@@ -876,7 +915,6 @@
   @media (pointer: coarse) {
     .gear,
     .halt,
-    .halt.compact,
     .needsyou,
     .needsyou.compact,
     .learnings-badge,

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -213,10 +213,10 @@ export class HerdStore {
         break;
       case "halt:done":
         // Fleet-wide stop landed: confirm the reach to EVERY connected operator (the
-        // event fans out to all clients, not just the one who fired it). The undo toast
-        // that armed the halt is a different tone+key ('halt-herd'), so this is the only
-        // "Halted N" toast; the 'halt-done' key just dedupes back-to-back halts (and the
-        // echo to the firing client) into one row instead of stacking.
+        // event fans out to all clients, not just the one who fired it). The shared
+        // 'halt-done' key means this confirm supersedes the firing client's interim
+        // "Halting N…" toast in place (haltHerd posts it under the same key), and also
+        // dedupes back-to-back halts / the echo to the firer into one row.
         toasts.info(m.halt_done({ count: ev.data.halted }), { key: "halt-done" });
         break;
     }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -464,6 +464,7 @@
     apiHalt().catch(() => {
       toasts.info(m.halt_failed(), {
         alert: true,
+        duration: null, // stay until the operator retries/closes — a failed fleet-halt must not vanish
         key: "halt-done",
         action: { label: m.common_retry(), run: () => haltHerd() },
       });

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -449,29 +449,23 @@
     });
   }
 
-  // Fleet-wide emergency stop. Interrupting every working agent is consequential and
-  // not server-side reversible, so — like decommission — we DEFER it behind an undo
-  // window rather than firing on the first tap: one tap arms a 5s undo toast, and the
-  // POST only goes out when that window expires un-cancelled. The "Halted N" confirm
-  // rides in solely on the `halt:done` WS event (its 'halt-done' key dedupes WS echoes /
-  // back-to-back halts into one row). A failed POST re-toasts with a Retry that re-defers.
+  // Fleet-wide emergency stop. Interrupting every working agent is consequential, so
+  // the guard against an accidental tap is the TopBar's two-step arm→confirm gesture
+  // (first activation arms the red "Halt N?" pill, a second commits) — by the time
+  // onhalt fires here the operator has already confirmed, so we POST straight away.
+  // An interim "Halting N…" toast gives immediate feedback; the "Halted N" confirm
+  // rides in on the `halt:done` WS event (all connected clients). A failed POST
+  // replaces the interim toast with a Retry (keyed 'halt-herd' so it supersedes it).
   function haltHerd() {
     const count = store.sessions.filter((s) => s.status === "running").length;
     if (count === 0) return; // nothing to halt; the control is hidden in this state anyway
-    toasts.undo(m.halt_confirm({ count }), {
-      undoLabel: m.common_undo(),
-      key: "halt-herd",
-      onCommit: async () => {
-        try {
-          await apiHalt();
-          // success confirm arrives via the halt:done WS event (all connected clients)
-        } catch {
-          toasts.info(m.halt_failed(), {
-            alert: true,
-            action: { label: m.common_retry(), run: () => haltHerd() },
-          });
-        }
-      },
+    toasts.info(m.halt_confirm({ count }), { key: "halt-herd" });
+    apiHalt().catch(() => {
+      toasts.info(m.halt_failed(), {
+        alert: true,
+        key: "halt-herd",
+        action: { label: m.common_retry(), run: () => haltHerd() },
+      });
     });
   }
 

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -454,16 +454,17 @@
   // (first activation arms the red "Halt N?" pill, a second commits) — by the time
   // onhalt fires here the operator has already confirmed, so we POST straight away.
   // An interim "Halting N…" toast gives immediate feedback; the "Halted N" confirm
-  // rides in on the `halt:done` WS event (all connected clients). A failed POST
-  // replaces the interim toast with a Retry (keyed 'halt-herd' so it supersedes it).
+  // rides in on the `halt:done` WS event (all connected clients). All three toasts
+  // share the 'halt-done' key so each supersedes the last in place (interim →
+  // Halted N on success, or interim → Retry on failure) rather than stacking.
   function haltHerd() {
     const count = store.sessions.filter((s) => s.status === "running").length;
     if (count === 0) return; // nothing to halt; the control is hidden in this state anyway
-    toasts.info(m.halt_confirm({ count }), { key: "halt-herd" });
+    toasts.info(m.halt_confirm({ count }), { key: "halt-done" });
     apiHalt().catch(() => {
       toasts.info(m.halt_failed(), {
         alert: true,
-        key: "halt-herd",
+        key: "halt-done",
         action: { label: m.common_retry(), run: () => haltHerd() },
       });
     });


### PR DESCRIPTION
## Why

The red **HALT** button broke the top-bar layout again: on touch it renders as a filled **44×44 red block** — far too dominant for a control that's almost never pressed, and taller than the plain-text status tallies beside it, so it bulged the row's vertical rhythm. It also had no explicit confirmation (only a silent 5s undo-toast).

Per the design agreed with the operator: make it **quiet at rest, red only on intent**, and replace the implicit undo with an explicit **two-step arm→confirm**.

## What

- **Rest state** — gear-weight: transparent bg, `--color-line-bright` outline, muted **monochrome stop-octagon** (inline SVG `currentColor`, replaces the un-recolorable 🛑 emoji). Sits in the row rhythm; no more bulge. Hover/focus → border + icon turn `--color-red`.
- **Two-step arm→confirm** (lives in `TopBar`): first activation arms a red **"Halt N?"** pill (the one intentional moment it goes loud); a second commits. Auto-disarms on ~4s timeout, Escape, outside-tap, or the herd going idle. `onhalt` fires only on the confirmed second activation.
- `haltHerd` in `+page.svelte` drops the `toasts.undo` deferral and POSTs straight away (intent already confirmed in the bar); interim "Halting N…" toast, "Halted N" still via the `halt:done` WS event, failure → Retry.
- i18n: new `halt_arm` / `halt_arm_aria` keys (EN+DE); reuses `halt_all_aria` (rest aria) / `halt_all` (tooltip) / `halt_confirm` / `halt_done` / `halt_failed`.

## Feature discovery

`[no-feature-entry]` — this refines the already-shipped halt feature. Its What's-New / coachmark catalog entry (`feat_halt_*`) is owned by the halt-herd-announcement branch (PR #328), whose body copy already describes this confirm gesture. Adding one here would double-announce and conflict on merge.

## Checks

- `bun run check` (svelte-check) — 0 errors
- `bun run test` — 427 passed
- `bun run lint` (root eslint) — clean
- `bun run check:i18n` — 2 locales in parity (554 keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)