### PR TITLE
fix(gitrail): match Ready toggle height to Reviewed chip on touch rail

### DIFF
--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -356,7 +356,7 @@
         </button>
       {/if}
       {#if showReady && (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
-        <ReadyToggle {sessionId} {ready} variant="rail" />
+        <ReadyToggle {sessionId} {ready} variant="rail" {mobile} />
       {/if}
       <!-- while re-reviewing: keep the prior findings reachable (hasFindings ⇒ verdict body exists,
            so the showReview popover below still has content); otherwise a plain status chip. -->

--- a/ui/src/lib/components/ReadyToggle.svelte
+++ b/ui/src/lib/components/ReadyToggle.svelte
@@ -13,15 +13,19 @@
     sessionId,
     ready = false,
     variant = "rail",
+    mobile = false,
   }: {
     sessionId: string;
     ready?: boolean;
     variant?: "rail" | "bar";
+    // touch layout: rail-only enlargement so the toggle matches the ≥40px
+    // .gbtn / .verdict-chip siblings instead of rendering half-height next to them.
+    mobile?: boolean;
   } = $props();
 </script>
 
 <button
-  class={["ready-toggle", variant, { on: ready }]}
+  class={["ready-toggle", variant, { on: ready, mobile: mobile && variant === "rail" }]}
   type="button"
   aria-pressed={ready}
   aria-label={m.gitrail_ready_aria()}
@@ -53,6 +57,15 @@
   .ready-toggle.rail:hover {
     border-color: var(--color-amber);
     color: var(--color-amber);
+  }
+  /* touch rail: match the ≥40px .gbtn / button.verdict-chip siblings so the
+     toggle isn't a half-height odd-one-out beside the Reviewed chip */
+  .ready-toggle.rail.mobile {
+    display: inline-flex;
+    align-items: center;
+    min-height: 40px;
+    padding: 6px 14px;
+    font-size: var(--fs-base);
   }
   /* bar variant: matches the .git-toggle disclosure in Viewport's primary row */
   .ready-toggle.bar {


### PR DESCRIPTION
## Problem
On the touch git rail the **Ready** toggle rendered noticeably shorter than the **Reviewed** chip beside it (see report screenshot) — they looked mismatched.

## Cause
`.rail.mobile` enlarges `.gbtn` and `button.verdict-chip` to a ≥40px tap target, but `ReadyToggle` is its own component (neither class), so it never picked up the enlargement and stayed half-height.

## Fix
Thread `mobile` from `GitRail` into `ReadyToggle` and add a `.ready-toggle.rail.mobile` rule mirroring the sibling touch sizing (`min-height: 40px; padding: 6px 14px; font-size: var(--fs-base)`). Rail-only — the desktop `bar` variant is unaffected.

`cd ui && bun run check` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)