### PR TITLE
fix(ui): gear pip amber while working, red only when blocked

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -484,9 +484,11 @@
       {/if}
     {/if}
     <!-- The gear is now a menu button: it opens the e-stop (when something is
-         working) plus the Settings entry. A red pip on the gear is the only at-rest
-         cue that there's a herd to halt; the green herdr-update dot (mobile) shifts
-         to the opposite corner when both want the gear. -->
+         working) plus the Settings entry. A pip on the gear is the only at-rest
+         cue that there's a herd to halt: amber while agents simply work (matches the
+         working colour), escalating to red only when something is blocked — so red
+         keeps meaning "needs you", consistent with the rest of the bar. The green
+         herdr-update dot (mobile) shifts to the opposite corner when both want the gear. -->
     <div class="gear-wrap" bind:this={gearWrap}>
       <button
         bind:this={gearBtn}
@@ -498,7 +500,7 @@
         aria-haspopup="menu"
         aria-expanded={menuOpen}
         aria-label={working > 0 ? m.topbar_menu_aria() : m.topbar_settings_aria()}
-        >⚙{#if working > 0}<span class="halt-pip" aria-hidden="true"
+        >⚙{#if working > 0}<span class="halt-pip" class:alert={blocked > 0} aria-hidden="true"
           ></span>{/if}{#if herdrUpdateAvailable && mobile}<span
             class="gear-dot"
             class:shift={working > 0}
@@ -708,7 +710,9 @@
     margin: 3px 2px;
     background: var(--color-line);
   }
-  /* Red pip on the gear: the only at-rest cue that there's a herd to halt. */
+  /* Pip on the gear: the only at-rest cue that there's a herd to halt. Amber while
+     agents merely work; red (.alert) only when something is blocked, so red stays
+     reserved for "needs you" rather than the normal running state. */
   .halt-pip {
     position: absolute;
     top: 2px;
@@ -716,8 +720,11 @@
     width: 7px;
     height: 7px;
     border-radius: 50%;
-    background: var(--color-red);
+    background: var(--color-amber);
     box-shadow: 0 0 0 2px var(--color-panel);
+  }
+  .halt-pip.alert {
+    background: var(--color-red);
   }
   .learnings-badge {
     background: transparent;


### PR DESCRIPTION
## Why

The gear (cog) pip lit **red whenever agents were merely working** — the happy path. On the same top bar, red already means **blocked / something's wrong** (the blocked count + label). So the red pip:

- **collided semantically** — a glance couldn't tell "herd busy (fine)" from "agent blocked (act now)";
- **read as a notification badge** ("attention required") during normal operation → alarm fatigue, desensitizing you to the red that actually matters.

Red is correct for the **destructive moment** (the armed `Halt N?` confirm) — that's unchanged. It was the *ambient* pip that misused red.

## What

- Gear pip is now **amber** while agents work (matches the existing `working = amber` language).
- Escalates to **red only when `blocked > 0`** — so a red gear pip genuinely means "needs you," consistent with the rest of the bar.
- Pip **presence** stays tied to `working > 0`, matching the e-stop menu gate (the menu only offers halt when something is working), so the cue never promises an action the menu won't show.
- Comments updated to match the new behavior.

## Notes

- No new strings (pip is `aria-hidden`) → i18n unaffected.
- Refines an existing indicator; ships no new user-facing capability → no feature-catalog entry. `[no-feature-entry]`
- `cd ui && bun run check` clean; 469/469 UI tests pass; full pre-push gate (branch hygiene, prettier, eslint, tsc, svelte-check, i18n parity, fallow) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)