### PR TITLE
fix(ui): scale session elapsed timer for multi-day runs

### DIFF
--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,9 +1,26 @@
 import { m } from "$lib/paraglide/messages";
 import type { SessionStatus } from "./types";
 
+/**
+ * Live elapsed label for the session list, scaled so multi-day runs stay
+ * readable instead of overflowing to `2880:34`:
+ *   - `<1h` → `MM:SS`  (live ticking timer, seconds shown)
+ *   - `<1d` → `Hh MMm` (seconds dropped once into hours)
+ *   - `≥1d` → `Dd HHh`
+ * Unit letters d/h/m and the `:` separator are tech notation, NOT translated
+ * (same precedent as `formatAgo`). Negative/0 → "00:00".
+ */
 export function elapsed(fromMs: number, nowMs: number): string {
   const s = Math.max(0, Math.floor((nowMs - fromMs) / 1000));
-  return `${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`;
+  const min = Math.floor(s / 60);
+  if (min < 60) {
+    return `${String(min).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`;
+  }
+  const h = Math.floor(min / 60);
+  if (h < 24) {
+    return `${h}h ${String(min % 60).padStart(2, "0")}m`;
+  }
+  return `${Math.floor(h / 24)}d ${String(h % 24).padStart(2, "0")}h`;
 }
 
 /**

--- a/ui/test/api.test.ts
+++ b/ui/test/api.test.ts
@@ -1,9 +1,23 @@
 import { test, expect } from "vitest";
 import { elapsed, statusLabel } from "../src/lib/format";
 
-test("elapsed formats mm:ss", () => {
-  expect(elapsed(0, 194_000)).toBe("03:14");
+test("elapsed shows mm:ss under an hour", () => {
   expect(elapsed(0, 0)).toBe("00:00");
+  expect(elapsed(0, 44_000)).toBe("00:44");
+  expect(elapsed(0, 194_000)).toBe("03:14");
+  expect(elapsed(0, 3_599_000)).toBe("59:59");
+});
+
+test("elapsed drops seconds and shows Hh MMm from one hour", () => {
+  expect(elapsed(0, 3_600_000)).toBe("1h 00m");
+  expect(elapsed(0, 18_194_000)).toBe("5h 03m");
+  expect(elapsed(0, 86_399_000)).toBe("23h 59m");
+});
+
+test("elapsed shows Dd HHh from one day", () => {
+  expect(elapsed(0, 86_400_000)).toBe("1d 00h");
+  expect(elapsed(0, 190_980_000)).toBe("2d 05h");
+  expect(elapsed(0, 1_201_200_000)).toBe("13d 21h");
 });
 
 test("statusLabel maps running→BUSY", () => {


### PR DESCRIPTION
## Problem

The session list elapsed timer used `elapsed()` which emitted **`MM:SS` with unbounded minutes**. For long-running sessions spanning days this overflows into nonsense — a 2-day session reads `2880:34`.

## Change

`elapsed()` now scales with duration (single shared formatter, so both `UnitRow` and `UnitTile` benefit):

| Duration | Format | Example |
| --- | --- | --- |
| `<1h` | `MM:SS` (live ticking, unchanged) | `03:14` |
| `<1d` | `Hh MMm` (seconds dropped once into hours) | `5h 03m` |
| `≥1d` | `Dd HHh` | `2d 05h`, `13d 21h` |

Unit letters `d/h/m` and the `:` separator are tech notation, intentionally **not** translated — same documented precedent as `formatAgo`/`relativeAge`, so no new i18n keys.

`[no-feature-entry]` — display polish on an existing timer, not a new user-facing capability.

## Verification

- `ui` `bun run test` → 471 passed (added tier coverage in `test/api.test.ts`)
- `ui` `bun run check` → 0 errors
- `check:i18n`, branch-hygiene, feature-catalog gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)