### PR TITLE
feat(service): inject Karpathy engineering posture into every spawn

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -54,18 +54,51 @@ const BRANCH_RENAME_NOTICE =
   "commits, and checked-out HEAD are unaffected — never treat a changed branch name as an error.";
 
 /**
+ * Universal engineering posture injected into every spawn (issue #349, adapted from the
+ * MIT-licensed Karpathy-style Claude Code skills). Unlike the `<shepherd-house-rules>` block
+ * — per-repo, learned, budget-limited and toggle-gated — this is fixed, repo-independent
+ * standing posture, so it lives in source and rides every spawn unconditionally.
+ *
+ * It biases the agent *against over-building*, the classic unattended-overnight failure mode
+ * the curated (defect-prevention) house rules don't cover. Scope notes baked into the wording:
+ *  - "Think before coding" is deliberately scoped to PRE-EXECUTION. Once running autonomously,
+ *    the autopilot don't-pause-to-ask rule still wins — the agent proceeds on stated assumptions.
+ *  - The dead-code clause harmonizes with the curated "don't ship dead code" rule: remove only
+ *    what YOUR change orphaned; surface (don't silently delete) pre-existing unrelated dead code.
+ * Agent-facing prompt text (not operator UI), so fixed English — same precedent as
+ * BRANCH_RENAME_NOTICE and the distiller/critic spawn prompts.
+ */
+const ENGINEERING_POSTURE =
+  "Standing engineering posture for every change — adopt it regardless of the task.\n" +
+  "- Think before coding (pre-execution only): before you start, state your key assumptions, " +
+  "surface genuine ambiguity and any clearly simpler approach, and name what's unclear. Resolve " +
+  "this up front — once you are executing autonomously, do NOT pause to ask; proceed on your stated assumptions.\n" +
+  "- Simplicity first: write the minimum code that solves the stated problem, nothing speculative. " +
+  "No features beyond what was asked, no abstractions for single-use code, no unrequested " +
+  "flexibility/config, no error handling for genuinely impossible cases. Test: would a senior " +
+  "engineer call this overcomplicated?\n" +
+  "- Surgical changes: touch only what the task requires — every changed line should trace to the " +
+  "request. Don't refactor working code, reformat, or polish adjacent code/comments; match existing " +
+  "style. Delete only the imports/vars/functions YOUR change orphaned; for pre-existing unrelated " +
+  "dead code, surface it rather than silently expanding the diff.\n" +
+  "- Goal-driven execution: turn the task into explicit, verifiable success criteria up front, then " +
+  "loop until they actually pass — never declare work done before verifying against them.";
+
+/**
  * Compose the spawn-time system prompt passed via a single `--append-system-prompt`
- * (the flag is last-wins, not repeatable, so both notices must share one value).
+ * (the flag is last-wins, not repeatable, so all blocks must share one value).
  *
  * House rules used to be prepended to the human prompt, which let standing guidance bleed
- * into the task on every spawn. They now live in the system prompt, each notice XML-wrapped
- * so the agent can cleanly separate persistent repo guidance from the task in its human turn.
+ * into the task on every spawn. They now live in the system prompt, each block XML-wrapped
+ * so the agent can cleanly separate persistent guidance from the task in its human turn.
  * `houseRules` is the already-wrapped `<shepherd-house-rules>` block, or null when there are
- * none / learnings are disabled.
+ * none / learnings are disabled; the engineering-posture and branch-rename blocks always ride.
  */
 export function composeSystemPrompt(houseRules: string | null): string {
+  const posture = `<engineering-posture>\n${ENGINEERING_POSTURE}\n</engineering-posture>`;
   const branchNotice = `<branch-rename-notice>\n${BRANCH_RENAME_NOTICE}\n</branch-rename-notice>`;
-  return houseRules ? `${houseRules}\n\n${branchNotice}` : branchNotice;
+  const blocks = houseRules ? [posture, houseRules, branchNotice] : [posture, branchNotice];
+  return blocks.join("\n\n");
 }
 
 export class SessionService {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -58,7 +58,7 @@ test("createSession: names, makes worktree, starts herdr, persists", async () =>
     "--settings",
     spawnSettingsOverlay(),
     "--append-system-prompt",
-    composeSystemPrompt(null), // no learnings → branch-rename notice only
+    composeSystemPrompt(null), // no learnings → engineering-posture + branch-rename notice, no house-rules block
     "flatten it",
   ]);
   expect(s.claudeSessionId).toMatch(/^[0-9a-f-]{36}$/);
@@ -439,7 +439,7 @@ test("createSession: passes --model and persists it when a model is chosen", asy
     "--settings",
     spawnSettingsOverlay(),
     "--append-system-prompt",
-    composeSystemPrompt(null), // no learnings → branch-rename notice only
+    composeSystemPrompt(null), // no learnings → engineering-posture + branch-rename notice, no house-rules block
     "--model",
     "opus",
     "go",
@@ -1559,7 +1559,7 @@ test("create omits the house-rules block when no active rules exist", async () =
     images: [],
   });
   expect(captured.argv!.at(-1)).toBe("do the thing");
-  // System prompt carries only the branch-rename notice, no house-rules tag.
+  // System prompt carries posture + branch-rename notice, no house-rules tag.
   expect(sysPrompt(captured.argv!)).toBe(composeSystemPrompt(null));
 });
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1623,6 +1623,30 @@ test("create injects only the planned house rules and drops the over-budget ones
   expect(injectedCount).toBeLessThan(40);
 });
 
+test("composeSystemPrompt always injects the engineering-posture block, with or without house rules", () => {
+  // Posture is universal standing guidance (not a per-repo learning), so it must ride every
+  // spawn regardless of the learnings toggle / house-rules state — i.e. even when houseRules is null.
+  const withoutRules = composeSystemPrompt(null);
+  const withRules = composeSystemPrompt(
+    `<${HOUSE_RULES_TAG}>\nintro\n- Use bun\n</${HOUSE_RULES_TAG}>`,
+  );
+
+  for (const sp of [withoutRules, withRules]) {
+    expect(sp).toContain("<engineering-posture>");
+    expect(sp).toContain("</engineering-posture>");
+    // The four Karpathy principles, by their distinguishing wording.
+    expect(sp).toContain("Think before coding");
+    expect(sp).toContain("Simplicity first");
+    expect(sp).toContain("Surgical changes");
+    expect(sp).toContain("Goal-driven execution");
+    // Branch-rename notice still rides alongside.
+    expect(sp).toContain("<branch-rename-notice>");
+  }
+  // Repo house rules still appear when present, distinct from posture.
+  expect(withRules).toContain(`<${HOUSE_RULES_TAG}>`);
+  expect(withoutRules).not.toContain(`<${HOUSE_RULES_TAG}>`);
+});
+
 test("resume adopts a live agent found by cwd under a new terminalId — no duplicate spawn", () => {
   const store = new SessionStore(":memory:");
   let startCalls = 0;


### PR DESCRIPTION
Closes #349.

## What

Adds a fixed `<engineering-posture>` block to `composeSystemPrompt`, injected into **every** spawn's system prompt alongside the branch-rename notice. Four principles adapted (concise — posture, not a checklist) from the MIT-licensed [Karpathy-style Claude Code skills](https://github.com/multica-ai/andrej-karpathy-skills):

- **Think before coding** — state assumptions, surface ambiguity + simpler approaches, name what's unclear.
- **Simplicity first** — minimum code that solves the stated problem, nothing speculative.
- **Surgical changes** — touch only what the task requires; every changed line traces to the request.
- **Goal-driven execution** — define verifiable success criteria up front, loop until they pass.

## Why here, why a constant

The curated `<shepherd-house-rules>` block is per-repo, learned, budget-limited, and toggle-gated — and it's **entirely defect-prevention**; nothing biases against *over-building*, the classic unattended-overnight failure mode. This posture is **universal** (repo-independent, not a learning), so it lives in source and rides every spawn unconditionally, including when learnings are disabled.

## Acceptance criteria (issue #349)

- [x] Simplicity-First, Surgical, Goal-Driven posture added via `composeSystemPrompt`.
- [x] **Dead-code rule harmonized.** The Surgical clause scopes it: *"Delete only the imports/vars/functions YOUR change orphaned; for pre-existing unrelated dead code, surface it rather than silently expanding the diff."* This refines (doesn't contradict) the curated "don't ship dead code" learning — that rule targets dead code in your diff; this draws the your-change-vs-unrelated boundary, keeping PRs small for the critic. (Harmonization is by wording — the curated rule is a runtime DB learning, not source, so it isn't edited here.)
- [x] **"Think/ask" scoped to pre-execution.** Wording explicitly ends with: *"once you are executing autonomously, do NOT pause to ask; proceed on your stated assumptions"* — so it can't reintroduce autopilot pauses (`src/autopilot-llm.ts`).
- [x] Wording stays concise.

## Open questions — resolved (toward the minimal option, eating our own Simplicity-First dogfood)

- **Inline vs pull upstream skill** → inline constant. Matches our injection mechanism; pulling a multi-file skill would be heavyweight.
- **Add a success-criteria field to the task/queue model** → deferred. Acceptance needs only prompt text; a structural model change is out of scope and would violate Surgical/Simplicity. Goal-Driven lands as posture text for now.

## Scope / gates

Server-only (`src/service.ts`) — no UI paths, ships no user-facing UX, so the feature-catalog gate doesn't fire (no announcement entry needed). Agent-facing fixed English (same precedent as `BRANCH_RENAME_NOTICE`), so no i18n. New unit test asserts the posture block rides every spawn with or without house rules; full suite green (1061 tests), lint + tsc + ui/extension checks pass via the pre-push gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)