### PR TITLE
fix(backlog): refresh counters + headline after merging a PR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { mkdirSync, realpathSync } from "node:fs";
 import { dirname } from "node:path";
 import { config, SESSION_RETENTION_MS, SESSION_RETENTION_KEEP } from "./config";
 import { SessionStore } from "./store";
@@ -453,8 +453,27 @@ const server = serve(
     // After a backlog merge, force-refresh the repo's counts past the read-TTL and
     // re-broadcast the overview so the merged PR (and any auto-closed linked issue)
     // leaves the counters + headline at once, not on the next ~45s warm tick.
+    //
+    // `dir` is safeRepoDir's realpath-resolved form, but the warmer +
+    // buildBacklogPayload key the counts cache by listRepos' raw join(repoRoot,
+    // name) path. Under a symlinked repoRoot/repo those diverge, so refreshing by
+    // `dir` would write a phantom key and the broadcast would re-read stale counts.
+    // Match the repo back to its listRepos entry by realpath and refresh that exact
+    // key (falling back to `dir` for a repo not under the enumerated root).
+    //
+    // Opportunistic: CountsService.load single-flights, so this refresh can
+    // piggyback on an in-flight pre-merge warm fetch and broadcast slightly stale
+    // counts; the next warm tick reconciles. Acceptable for a freshness nudge.
     refreshBacklog: async (dir) => {
-      await backlog.refresh(dir);
+      const realpathOr = (p: string) => {
+        try {
+          return realpathSync(p);
+        } catch {
+          return p;
+        }
+      };
+      const match = listRepos(config.repoRoot).find((r) => realpathOr(r.path) === dir);
+      await backlog.refresh(match?.path ?? dir);
       await broadcastBacklog();
     },
     distiller,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, realpathSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { config, SESSION_RETENTION_MS, SESSION_RETENTION_KEEP } from "./config";
 import { SessionStore } from "./store";
@@ -32,7 +32,7 @@ import { tailLines } from "./blocked";
 import { CountsService } from "./backlog";
 import { BacklogPoller } from "./backlog-poller";
 import { ProcessReaper } from "./process-reaper";
-import { listRepos } from "./repos";
+import { listRepos, listReposPathForReal } from "./repos";
 import { DistillerService, defaultScratch } from "./distiller";
 import { Promoter } from "./promote";
 import { attachSignalCapture } from "./signals";
@@ -465,15 +465,7 @@ const server = serve(
     // piggyback on an in-flight pre-merge warm fetch and broadcast slightly stale
     // counts; the next warm tick reconciles. Acceptable for a freshness nudge.
     refreshBacklog: async (dir) => {
-      const realpathOr = (p: string) => {
-        try {
-          return realpathSync(p);
-        } catch {
-          return p;
-        }
-      };
-      const match = listRepos(config.repoRoot).find((r) => realpathOr(r.path) === dir);
-      await backlog.refresh(match?.path ?? dir);
+      await backlog.refresh(listReposPathForReal(dir, config.repoRoot));
       await broadcastBacklog();
     },
     distiller,

--- a/src/index.ts
+++ b/src/index.ts
@@ -450,6 +450,13 @@ const server = serve(
       reviewing: () => reviewService.reviewingIds(),
     },
     backlog,
+    // After a backlog merge, force-refresh the repo's counts past the read-TTL and
+    // re-broadcast the overview so the merged PR (and any auto-closed linked issue)
+    // leaves the counters + headline at once, not on the next ~45s warm tick.
+    refreshBacklog: async (dir) => {
+      await backlog.refresh(dir);
+      await broadcastBacklog();
+    },
     distiller,
     promoter,
     drain: { snapshot: () => drain.snapshot(), queue: (repoPath) => drain.queue(repoPath) },

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -1,4 +1,12 @@
-import { readdirSync, readFileSync, writeFileSync, existsSync, statSync, lstatSync } from "node:fs";
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  statSync,
+  lstatSync,
+  realpathSync,
+} from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join, resolve, sep } from "node:path";
 import { homedir } from "node:os";
@@ -38,6 +46,30 @@ export function listRepos(repoRoot: string): RepoEntry[] {
       }
     })
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Map a realpath-resolved repo dir (e.g. from {@link safeRepoDir}, which follows
+ * symlinks) back to the path form {@link listRepos} enumerates — the raw
+ * `join(repoRoot, name)`. That raw form is the key the backlog counts cache and
+ * `buildBacklogPayload` read by, so a caller holding the realpath (the merge
+ * path) must reconcile to it or it writes/reads a *different* cache key under a
+ * symlinked repoRoot/repo — silently operating on a phantom entry.
+ *
+ * Matches by realpath-comparing each enumerated repo against `realDir`. Returns
+ * `realDir` unchanged when nothing matches (e.g. a repo outside repoRoot), so the
+ * caller still refreshes a sane key rather than dropping the request.
+ */
+export function listReposPathForReal(realDir: string, repoRoot: string): string {
+  const realpathOr = (p: string): string => {
+    try {
+      return realpathSync(p);
+    } catch {
+      return p; // broken symlink / vanished entry — can't match, skip past it
+    }
+  };
+  const match = listRepos(repoRoot).find((r) => realpathOr(r.path) === realDir);
+  return match?.path ?? realDir;
 }
 
 const TODO = "TODO.md";

--- a/src/server.ts
+++ b/src/server.ts
@@ -100,6 +100,11 @@ export interface AppDeps {
   };
   /** Backlog counts service; absent in tests that don't exercise it. */
   backlog?: Pick<CountsService, "counts">;
+  /** Force-refresh one repo's backlog counts (bypassing the read-TTL) and push the
+   *  rebuilt overview to every client. Fired after a mutation that changes a repo's
+   *  open issue/PR counts (e.g. a merge) so the counters + headline drop the item
+   *  immediately instead of lingering until the next warm poll. Absent in tests. */
+  refreshBacklog?: (repoDir: string) => Promise<void>;
   /** Learning distiller — manual trigger for the proposal pass over a repo's transcripts.
    *  Optional so environments/tests that don't wire it still type-check; the route
    *  no-ops the trigger when absent. Wired to the real DistillerService in index.ts. */
@@ -1449,6 +1454,11 @@ async function handlePrMerge({ req, parts, deps }: Ctx): Promise<Response | null
       method: body.method ?? forge.mergeMethod,
       deleteBranch: body.deleteBranch ?? true,
     });
+    // Detached, best-effort: the merge already succeeded, so a refresh/broadcast
+    // hiccup must not fail the response, and the GraphQL refetch must not delay the
+    // "merged" feedback. Pushes the merged PR (and any auto-closed linked issue) out
+    // of the backlog counters + headline now; the warm poller reconciles regardless.
+    void deps.refreshBacklog?.(dir).catch(() => {});
     return json({ ok: true });
   } catch (e) {
     return json({ error: e instanceof Error ? e.message : "merge failed" }, 502);

--- a/test/repos.test.ts
+++ b/test/repos.test.ts
@@ -3,7 +3,15 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, existsSync 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
-import { listRepos, readTodo, writeTodo, cloneRepo, classifyCloneError } from "../src/repos";
+import {
+  listRepos,
+  listReposPathForReal,
+  readTodo,
+  writeTodo,
+  cloneRepo,
+  classifyCloneError,
+} from "../src/repos";
+import { realpathSync } from "node:fs";
 
 let root: string;
 
@@ -28,6 +36,35 @@ test("listRepos returns sorted dirs, excludes file and dotdir", () => {
 
 test("listRepos returns [] for nonexistent root", () => {
   expect(listRepos(join(root, "nonexistent"))).toEqual([]);
+});
+
+// ── listReposPathForReal (post-merge backlog refresh key reconciliation) ───────
+
+test("listReposPathForReal maps a realpath back to listRepos' join(repoRoot, name) key", () => {
+  // A symlinked repoRoot is exactly where the merge path's realpath-resolved dir
+  // diverges from the raw join(repoRoot, name) the counts cache + buildBacklogPayload
+  // key by. linkRoot → root, so listRepos enumerates under linkRoot while the merge
+  // path (safeRepoDir) hands us the real path.
+  const linkRoot = join(tmpdir(), `shepherd-repos-link-${process.pid}-${root.split("-").pop()}`);
+  symlinkSync(root, linkRoot, "dir");
+  try {
+    const enumerated = join(linkRoot, "alpha"); // the key listRepos / readers use
+    const realDir = realpathSync(enumerated); // what safeRepoDir would yield
+    // Precondition: the two forms genuinely diverge under the symlink, so this
+    // test would fail if the reconciliation were a no-op.
+    expect(realDir).not.toBe(enumerated);
+
+    // The fix: realpath → the enumerated key the readers (and warmer) cache by, so
+    // refresh writes the same entry buildBacklogPayload later reads.
+    expect(listReposPathForReal(realDir, linkRoot)).toBe(enumerated);
+  } finally {
+    rmSync(linkRoot, { force: true });
+  }
+});
+
+test("listReposPathForReal returns the dir unchanged when no enumerated repo matches", () => {
+  const outside = join(tmpdir(), "definitely-not-under-repoRoot");
+  expect(listReposPathForReal(outside, root)).toBe(outside);
 });
 
 // ── readTodo ──────────────────────────────────────────────────────────────────

--- a/test/server-prs.test.ts
+++ b/test/server-prs.test.ts
@@ -133,6 +133,30 @@ test("POST /api/prs/merge merges the PR by number, defaulting method + deleteBra
   expect(merged!.opts).toEqual({ method: "squash", deleteBranch: true });
 });
 
+test("POST /api/prs/merge refreshes the backlog for the repo so counters/headline drop the PR", async () => {
+  const refreshed: string[] = [];
+  const deps = makeDeps(() => fakeForge());
+  deps.refreshBacklog = async (dir) => {
+    refreshed.push(dir);
+  };
+  const app = makeApp(deps);
+  const res = await app.fetch(mergeReq({ repo: repoDir, number: 12 }));
+  expect(res.status).toBe(200);
+  // Fired synchronously before the response resolves (detached refetch).
+  expect(refreshed).toEqual([repoDir]);
+});
+
+test("POST /api/prs/merge still succeeds when a backlog refresh rejects", async () => {
+  const deps = makeDeps(() => fakeForge());
+  deps.refreshBacklog = async () => {
+    throw new Error("gh graphql flaked");
+  };
+  const app = makeApp(deps);
+  const res = await app.fetch(mergeReq({ repo: repoDir, number: 12 }));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+});
+
 test("POST /api/prs/merge without a number → 400", async () => {
   const app = makeApp(makeDeps(() => fakeForge()));
   const res = await app.fetch(mergeReq({ repo: repoDir }));


### PR DESCRIPTION
## Problem

Merging a PR from the backlog panel optimistically drops the PR **row**, but the **counters** (`Issues · N` / `PRs · N`) and the headline above the detail pane don't update — the merged PR keeps being counted until the next warm poll (~45s). Those counts come from the separate `BacklogPayload`, which sits behind a 60s TTL cache, so even a naive client refetch would return the stale (higher) count.

## Fix

On a successful merge, `handlePrMerge` now fires a new optional `refreshBacklog(dir)` hook (`src/server.ts`):

- **Detached + best-effort** — the merge already succeeded, so a refetch hiccup can't fail the response, and the GraphQL refetch doesn't delay the "merged" feedback. A rejecting refresh still returns `{ ok: true }`.
- Wired in `src/index.ts` to `backlog.refresh(dir)` (force-refetch **past** the 60s TTL) → `broadcastBacklog()`, reusing the existing `backlog:update` WS frame every client already mirrors into its overview (`+page.svelte`). No client component changes needed — counters **and** headline update live on every open dashboard within a second or two.
- Because it rebuilds the **whole** overview, a PR that auto-closes a linked issue (`Fixes #N`) drops from the issues counter too.

## Tests

`test/server-prs.test.ts`:
- merge triggers `refreshBacklog` for the repo
- a rejecting `refreshBacklog` still yields `{ ok: true }`

Full root suite: 1061 pass / 0 fail. `tsc --noEmit` + lint clean.

Server-only change — no new user-facing strings (no i18n keys), no feature-catalog entry. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)