### PR TITLE
fix(hooks): auto-install extension/ deps in fresh worktrees

### DIFF
--- a/.claude/hooks/ensure-deps.sh
+++ b/.claude/hooks/ensure-deps.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SessionStart hook: install deps in fresh worktrees so agents never hit the
 # "missing node_modules" tax. Installs only when node_modules is absent, so
-# warm worktrees pay nothing. Root + ui/ are separate packages (own deps).
+# warm worktrees pay nothing. Root + ui/ + extension/ are separate packages (own deps).
 set -euo pipefail
 
 root="${CLAUDE_PROJECT_DIR:-$PWD}"
@@ -9,7 +9,7 @@ bun="$(command -v bun || true)"
 [ -n "$bun" ] || { echo '{"suppressOutput": true}'; exit 0; }
 
 installed=()
-for dir in "$root" "$root/ui"; do
+for dir in "$root" "$root/ui" "$root/extension"; do
   if [ -f "$dir/package.json" ] && [ ! -d "$dir/node_modules" ]; then
     ( cd "$dir" && "$bun" install ) >/dev/null 2>&1 && installed+=("$dir")
   fi


### PR DESCRIPTION
## What

The `ensure-deps` SessionStart hook (`.claude/hooks/ensure-deps.sh`) auto-installs deps in fresh worktrees so agents never hit the missing-`node_modules` tax. It only looped over `root` + `ui/`, but the repo now has a **third** package — `extension/` — with its own deps. Fresh worktrees still required a manual `cd extension && bun install`.

This adds `extension/` to the install loop (and updates the header comment to name all three packages).

```diff
-for dir in "$root" "$root/ui"; do
+for dir in "$root" "$root/ui" "$root/extension"; do
```

## Verification

Ran the hook live in a worktree where root + ui were warm but `extension/node_modules` was absent:

- Hook installed **only** `extension` and reported it via `systemMessage`
- Skipped already-installed root/ui (idempotent — warm worktrees still pay nothing)
- `extension/node_modules` present afterward

## Notes

- `deploy/update.sh` also installs only root + ui, but that's the server deploy path and the browser extension isn't part of the deployed server — left unchanged.
- No `feat`/UI changes; `[no-feature-entry]` applies (hook-only plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)