### PR TITLE
fix(ui): drain label field fits narrow screens (iPhone 14)

### DIFF
--- a/ui/src/lib/components/AutomationPanel.svelte
+++ b/ui/src/lib/components/AutomationPanel.svelte
@@ -166,7 +166,7 @@
       <label class="drain-field">
         <span class="drain-label">{m.drain_label_label()}</span>
         <input
-          class="num"
+          class="num txt"
           type="text"
           bind:value={drainLabel}
           aria-label={m.drain_label_label()}
@@ -326,5 +326,14 @@
     font-size: var(--fs-base);
     padding: 3px 6px;
     text-align: right;
+  }
+  /* The label is free text (e.g. "shepherd:auto") that overflows the fixed
+     numeric width on narrow screens — let it grow with the row and read from
+     the start instead of clipping the left side under right-alignment. */
+  .num.txt {
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
+    text-align: left;
   }
 </style>


### PR DESCRIPTION
## Problem
Auf schmalen Viewports (iPhone 14) wurde das **Label**-Feld im Automatisierungs-Block `Arbeitswarteschlange` abgeschnitten. Das Freitext-Label (Default `shepherd:auto`) teilte sich den festen **90px, rechtsbündigen** Zahlen-Input — dadurch wurde der Text links abgeschnitten und zeigte nur noch `shepherd:a`.

## Fix
Eigene `.txt`-Variante für den Label-Input: wächst mit der Zeile (`flex: 1 1 auto; width: auto; min-width: 0`) und ist linksbündig, sodass der Wert von vorne lesbar ist und die verfügbare Breite nutzt. Die Zahlenfelder (Limit/Grenze) bleiben schmal und rechtsbündig.

CSS-only; `bun run check` grün. Keine neuen Strings (i18n/Feature-Catalog exempt).