### PR TITLE
fix(autopilot): recover red-CI PRs + seed directive so agents don't halt to ask

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -224,12 +224,13 @@ export class AutopilotService {
     if (!s || s.status === "archived" || !this.enabled(s)) return;
     if (!this.openSeen.has(id)) {
       this.openSeen.add(id);
-      // Critic handoff (the single handoff path: onPrOpen), once per PR-open — clear a pre-PR
-      // pause + reset the step budget for the post-PR phase. Skip it when CI is already red: a
-      // red PR that's paused was handed to the operator (e.g. a CI-fix cap pause that survived a
-      // restart), and re-engaging it would resume the thrash the cap stopped. The CI-fix loop
-      // below keeps the persisted budget in that case.
-      if (git.checks !== "failure") this.onPrOpen(id);
+      // Critic handoff (the single handoff path: onPrOpen), once per PR-open — clear pause + reset
+      // the step budget for the post-PR phase. Gated on NOT being paused: openSeen is in-memory,
+      // so after a restart the first poll of an already-open PR re-enters here; a deliberate pause
+      // (operator hand-back or a CI-fix cap pause, on a PR whose CI may since have gone green) must
+      // survive that, not be silently cleared. A red PR is skipped for the same reason and keeps
+      // its persisted CI-fix budget below.
+      if (git.checks !== "failure" && !s.autopilotPaused) this.onPrOpen(id);
     }
     if (git.checks === "failure") this.considerCi(s, git);
   }

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -1,6 +1,7 @@
 import type { SessionStore } from "./store";
 import type { Session, AutopilotVerdict } from "./types";
 import type { BlockReason } from "./blocked";
+import type { GitState } from "./forge/types";
 
 /**
  * Agent-facing steer templates. NOT UI chrome — never i18n'd (they are typed into the
@@ -18,6 +19,13 @@ export const OPEN_PR_STEER = [
   "You're in autopilot and you've stopped, but there's no pull request yet. Commit your",
   "work, push the branch, and open a PR (gh pr create). If something genuinely blocks that,",
   "say specifically what you need.",
+].join("\n");
+
+export const CI_FIX_STEER = [
+  "You're in autopilot and CI is failing on your open pull request. The critic won't review a",
+  "red PR, so this is on you: inspect the failing checks (`gh pr checks`, `gh run view --log-failed`),",
+  "fix the root cause, and push. Don't stop to ask — only surface if it's a genuine blocker you",
+  "can't resolve, and then say exactly what you need.",
 ].join("\n");
 
 /** Steers autopilot will only consider for these block shapes. menu/stall always surface. */
@@ -59,6 +67,13 @@ export class AutopilotService {
   // Re-entrancy guard: classify() is async, so a second event for the same session must
   // not start a second spawn (mirrors ReviewService.starting).
   private pending = new Set<string>();
+  // Post-PR CI-red recovery state (onGit). `openSeen` fires the critic handoff (pause-clear +
+  // budget reset) exactly once per PR-open, so the 120s git poll doesn't keep zeroing the
+  // step budget the CI-fix loop is spending. `ciNudged` maps a session to the head SHA we last
+  // steered for a red CI, so a still-failing head isn't re-nudged every poll — only a fresh
+  // push (new head) that still fails earns another steer.
+  private openSeen = new Set<string>();
+  private ciNudged = new Map<string, string>();
   private stepCap: number;
 
   constructor(private deps: AutopilotDeps) {
@@ -189,5 +204,55 @@ export class AutopilotService {
     if (!s) return;
     this.deps.store.setAutopilotState(id, { paused: false, question: null, stepCount: 0 });
     this.deps.onState?.(id);
+  }
+
+  /** session:git handler. Two jobs, both keyed off the PR's live state:
+   *  1. PR-open transition (none/closed → open): hand off to the critic loop once (onPrOpen).
+   *  2. Open PR with FAILING CI: the dead zone — the critic only reviews a green PR and pre-PR
+   *     autopilot has stood down (a PR exists), so nobody steers a red PR. Drive the task agent
+   *     to fix its own CI. Replaces the old `if (open) onPrOpen` wiring in index.ts. */
+  onGit(id: string, git: GitState): void {
+    if (git.state !== "open") {
+      // PR gone (none/merged/closed): drop the per-PR dedup so a future PR-open re-arms both
+      // the handoff reset and the CI-fix nudge.
+      this.openSeen.delete(id);
+      this.ciNudged.delete(id);
+      return;
+    }
+    const s = this.deps.store.get(id);
+    if (!s || s.status === "archived" || !this.enabled(s)) return;
+    if (!this.openSeen.has(id)) {
+      this.openSeen.add(id);
+      // Handoff, once per PR-open. Reset the step budget so the post-PR CI-fix loop starts fresh
+      // (it must not inherit the pre-PR gate loop's spend). Clear a pre-PR pause ONLY when CI is
+      // not red: a red PR that's already paused was handed to the operator (e.g. a CI-fix cap
+      // pause that survived a restart) — don't silently re-engage it.
+      const clearPause = git.checks !== "failure";
+      this.deps.store.setAutopilotState(id, {
+        stepCount: 0,
+        ...(clearPause ? { paused: false, question: null } : {}),
+      });
+      this.deps.onState?.(id);
+    }
+    if (git.checks === "failure") this.considerCi(id, git);
+  }
+
+  /** Open PR + red CI → steer the task agent to fix it. Synchronous (no classify needed: a red
+   *  rollup is already an actionable verdict). Deduped per head SHA, gated by autopilot
+   *  enablement / pause / archive, and bounded by the same step cap as the gate loop. */
+  private considerCi(id: string, git: GitState): void {
+    const s = this.deps.store.get(id);
+    if (!s || s.status === "archived") return;
+    if (!this.enabled(s)) return;
+    if (s.autopilotPaused) return; // already handed back; waits for operator
+    if (this.pending.has(id)) return; // a classify (gate/done path) is mid-flight
+    if (!git.headSha) return; // can't dedup a headless rollup → skip rather than spam
+    if (this.ciNudged.get(id) === git.headSha) return; // already nudged this exact red head
+    if (s.autopilotStepCount >= this.stepCap) {
+      this.pause(s, CAP_MESSAGE); // runaway guard — stop thrashing CI, surface to operator
+      return;
+    }
+    this.ciNudged.set(id, git.headSha);
+    this.driveSteer(s, CI_FIX_STEER);
   }
 }

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -198,7 +198,8 @@ export class AutopilotService {
     this.deps.onState?.(id);
   }
 
-  /** A PR opened → hand off to the critic loop. Clear pause + reset the step budget. */
+  /** The critic handoff: clear pause + reset the step budget. Invoked once per PR-open by
+   *  onGit (for a non-red PR) — the single place this transition is applied. */
   onPrOpen(id: string): void {
     const s = this.deps.store.get(id);
     if (!s) return;
@@ -223,36 +224,30 @@ export class AutopilotService {
     if (!s || s.status === "archived" || !this.enabled(s)) return;
     if (!this.openSeen.has(id)) {
       this.openSeen.add(id);
-      // Handoff, once per PR-open. Reset the step budget so the post-PR CI-fix loop starts fresh
-      // (it must not inherit the pre-PR gate loop's spend). Clear a pre-PR pause ONLY when CI is
-      // not red: a red PR that's already paused was handed to the operator (e.g. a CI-fix cap
-      // pause that survived a restart) — don't silently re-engage it.
-      const clearPause = git.checks !== "failure";
-      this.deps.store.setAutopilotState(id, {
-        stepCount: 0,
-        ...(clearPause ? { paused: false, question: null } : {}),
-      });
-      this.deps.onState?.(id);
+      // Critic handoff (the single handoff path: onPrOpen), once per PR-open — clear a pre-PR
+      // pause + reset the step budget for the post-PR phase. Skip it when CI is already red: a
+      // red PR that's paused was handed to the operator (e.g. a CI-fix cap pause that survived a
+      // restart), and re-engaging it would resume the thrash the cap stopped. The CI-fix loop
+      // below keeps the persisted budget in that case.
+      if (git.checks !== "failure") this.onPrOpen(id);
     }
-    if (git.checks === "failure") this.considerCi(id, git);
+    if (git.checks === "failure") this.considerCi(s, git);
   }
 
   /** Open PR + red CI → steer the task agent to fix it. Synchronous (no classify needed: a red
-   *  rollup is already an actionable verdict). Deduped per head SHA, gated by autopilot
-   *  enablement / pause / archive, and bounded by the same step cap as the gate loop. */
-  private considerCi(id: string, git: GitState): void {
-    const s = this.deps.store.get(id);
-    if (!s || s.status === "archived") return;
-    if (!this.enabled(s)) return;
+   *  rollup is already an actionable verdict). The caller (onGit) has already checked
+   *  existence / archive / enablement; here we gate on pause + per-head dedup and bound it by
+   *  the same step cap as the gate loop. */
+  private considerCi(s: Session, git: GitState): void {
     if (s.autopilotPaused) return; // already handed back; waits for operator
-    if (this.pending.has(id)) return; // a classify (gate/done path) is mid-flight
+    if (this.pending.has(s.id)) return; // a classify (gate/done path) is mid-flight
     if (!git.headSha) return; // can't dedup a headless rollup → skip rather than spam
-    if (this.ciNudged.get(id) === git.headSha) return; // already nudged this exact red head
+    if (this.ciNudged.get(s.id) === git.headSha) return; // already nudged this exact red head
     if (s.autopilotStepCount >= this.stepCap) {
       this.pause(s, CAP_MESSAGE); // runaway guard — stop thrashing CI, surface to operator
       return;
     }
-    this.ciNudged.set(id, git.headSha);
+    this.ciNudged.set(s.id, git.headSha);
     this.driveSteer(s, CI_FIX_STEER);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,7 +318,9 @@ events.subscribe((event, data) => {
       void autopilot.onDone(id).catch((err) => console.warn("[autopilot] onDone:", err));
   } else if (event === "session:git") {
     const { id, git } = data as { id: string; git: import("./forge/types").GitState };
-    if (git.state === "open") autopilot.onPrOpen(id); // handoff to the critic loop
+    // PR-open handoff to the critic loop AND red-CI recovery (the critic skips a red PR, so
+    // autopilot drives the agent to fix its own failing checks).
+    autopilot.onGit(id, git);
   }
 });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -90,6 +90,22 @@ const ENGINEERING_POSTURE =
   "loop until they actually pass — never declare work done before verifying against them.";
 
 /**
+ * Seeded into the system prompt at spawn when the repo has autopilot on, so the agent knows
+ * up front it's running unattended. Without it autopilot is purely reactive — the agent stops
+ * to ask "commit + open a PR?", and a steer only lands after a stop is detected and classified
+ * (which the operator routinely beats by answering manually). Stating the contract up front
+ * stops the procedural halt at the source. Deliberately conditional ("for a code change…") so a
+ * research / issue-creation task isn't pushed to open a meaningless PR. Not user-facing chrome
+ * (an instruction to the agent), so no i18n.
+ */
+const AUTOPILOT_DIRECTIVE =
+  "You are running unattended in Shepherd autopilot. Do not stop to ask for permission on " +
+  "procedural or workflow steps — writing a spec or plan, committing, pushing, or opening a " +
+  "pull request. Make a reasonable decision and keep going until the task's deliverable is " +
+  "complete; for a code change that means an open PR (`gh pr create`). Only stop to ask when " +
+  "you hit a genuine product or requirements decision that only a human can make.";
+
+/**
  * Compose the spawn-time system prompt passed via a single `--append-system-prompt`
  * (the flag is last-wins, not repeatable, so all blocks must share one value).
  *
@@ -98,11 +114,14 @@ const ENGINEERING_POSTURE =
  * so the agent can cleanly separate persistent guidance from the task in its human turn.
  * `houseRules` is the already-wrapped `<shepherd-house-rules>` block, or null when there are
  * none / learnings are disabled; the engineering-posture and branch-rename blocks always ride.
+ * `autopilotActive` appends the autopilot directive (see above).
  */
-export function composeSystemPrompt(houseRules: string | null): string {
+export function composeSystemPrompt(houseRules: string | null, autopilotActive = false): string {
   const posture = `<engineering-posture>\n${ENGINEERING_POSTURE}\n</engineering-posture>`;
   const branchNotice = `<branch-rename-notice>\n${BRANCH_RENAME_NOTICE}\n</branch-rename-notice>`;
   const blocks = houseRules ? [posture, houseRules, branchNotice] : [posture, branchNotice];
+  if (autopilotActive)
+    blocks.push(`<autopilot-directive>\n${AUTOPILOT_DIRECTIVE}\n</autopilot-directive>`);
   return blocks.join("\n\n");
 }
 
@@ -147,12 +166,15 @@ export class SessionService {
 
       // Shepherd-curated house rules go into the system prompt (not the human turn) so every
       // spawn (manual AND auto-spawned, e.g. the work-queue drain #222) inherits the repo's
-      // learned corrections without the rules bleeding into the task text.
+      // learned corrections without the rules bleeding into the task text. The autopilot
+      // directive rides the same prompt when the repo has autopilot on, so the agent drives to a
+      // PR without stopping for procedural gates instead of waiting for a reactive steer.
       const houseRules = this.houseRules(input.repoPath);
+      const autopilotActive = this.deps.store.getRepoConfig(input.repoPath).autopilotEnabled;
 
       const argv = ["claude", "--dangerously-skip-permissions", "--session-id", claudeSessionId];
       argv.push("--settings", spawnSettingsOverlay());
-      argv.push("--append-system-prompt", composeSystemPrompt(houseRules));
+      argv.push("--append-system-prompt", composeSystemPrompt(houseRules, autopilotActive));
       if (input.model) argv.push("--model", input.model);
       argv.push(promptArg);
       const agent = this.deps.herdr.start(name, wt.worktreePath, argv);

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -398,14 +398,23 @@ test("step cap stops CI-fix thrash and pauses to the operator", () => {
   expect(h.state().autopilotPaused).toBe(true);
 });
 
-test("PR open clears a prior pre-PR pause and resets the step budget (handoff)", () => {
+test("a green PR-open hands off to the critic (clears a stale pause + resets budget)", () => {
+  const h = harness({ session: sess({ autopilotStepCount: 4 }), repoEnabled: true });
+  h.svc.onGit("s1", git({ checks: "success" }));
+  expect(h.state().autopilotStepCount).toBe(0);
+});
+
+test("a deliberate pause survives a PR-open handoff (in-memory openSeen lost on restart)", () => {
+  // After a restart openSeen is empty, so the first poll of an already-open green PR re-enters
+  // the handoff. An operator's pause (or a CI-fix cap pause whose CI since went green) must NOT
+  // be silently cleared and the session re-engaged.
   const h = harness({
-    session: sess({ autopilotPaused: true, autopilotStepCount: 4 }),
+    session: sess({ autopilotPaused: true, autopilotStepCount: 7 }),
     repoEnabled: true,
   });
   h.svc.onGit("s1", git({ checks: "success" }));
-  expect(h.state().autopilotPaused).toBe(false);
-  expect(h.state().autopilotStepCount).toBe(0);
+  expect(h.state().autopilotPaused).toBe(true);
+  expect(h.state().autopilotStepCount).toBe(7);
 });
 
 test("handoff reset fires once per PR-open, not every poll (preserves CI-fix budget)", () => {

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -314,3 +314,112 @@ test("re-entrant onBlock during an in-flight classify spawns + steers only once"
   expect(classifyCalls).toBe(1);
   expect(events.filter((e) => "steer" in e).length).toBe(1);
 });
+
+// ───────────────────────── CI-red recovery (onGit) ─────────────────────────
+// The post-PR dead zone: once a PR is open the critic owns review, but it only runs
+// on green CI (review.ts) and pre-PR autopilot has stood down (hasPr). A PR sitting on
+// red CI is steered by nobody. onGit closes that gap: open + checks "failure" → drive
+// the task agent to fix the failing checks (dedup per head, step-capped).
+import { CI_FIX_STEER } from "../src/autopilot";
+import type { GitState } from "../src/forge/types";
+
+function git(over: Partial<GitState> = {}): GitState {
+  return {
+    kind: "github",
+    state: "open",
+    checks: "failure",
+    headSha: "sha1",
+    number: 7,
+    deployConfigured: false,
+    ...over,
+  };
+}
+
+test("open PR + failing CI → CI-fix steer + step++", () => {
+  const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
+  h.svc.onGit("s1", git());
+  expect(h.events).toContainEqual({ steer: CI_FIX_STEER });
+  expect(h.state().autopilotStepCount).toBe(1);
+});
+
+test("same failing head is nudged only once", () => {
+  const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
+  h.svc.onGit("s1", git({ headSha: "sha1" }));
+  h.svc.onGit("s1", git({ headSha: "sha1" })); // next poll, same red head
+  expect(h.events.filter((e) => "steer" in e).length).toBe(1);
+  expect(h.state().autopilotStepCount).toBe(1);
+});
+
+test("a new failing head (agent pushed a fix that still fails) re-steers", () => {
+  const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
+  h.svc.onGit("s1", git({ headSha: "sha1" }));
+  h.svc.onGit("s1", git({ headSha: "sha2" }));
+  expect(h.events.filter((e) => "steer" in e).length).toBe(2);
+  expect(h.state().autopilotStepCount).toBe(2);
+});
+
+test("green CI never triggers a CI-fix steer", () => {
+  const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
+  h.svc.onGit("s1", git({ checks: "success" }));
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+});
+
+test("pending CI never triggers a CI-fix steer", () => {
+  const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
+  h.svc.onGit("s1", git({ checks: "pending" }));
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+});
+
+test("CI-fix recovery is gated by autopilot enablement", () => {
+  const h = harness({ session: sess({ autopilotEnabled: null }), repoEnabled: false });
+  h.svc.onGit("s1", git());
+  expect(h.events.length).toBe(0);
+});
+
+test("a paused session is not CI-steered (already handed to the operator)", () => {
+  const h = harness({ session: sess({ autopilotPaused: true }), repoEnabled: true });
+  h.svc.onGit("s1", git());
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+});
+
+test("CI-fix recovery resumes a dead pane before steering", () => {
+  const h = harness({ session: sess({ status: "running" }), repoEnabled: true, paneAlive: false });
+  h.svc.onGit("s1", git());
+  expect(h.events).toContainEqual({ resume: true });
+  expect(h.events).toContainEqual({ steer: CI_FIX_STEER });
+});
+
+test("step cap stops CI-fix thrash and pauses to the operator", () => {
+  const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
+  // The first call is the open transition (resets the budget); each distinct red head then
+  // burns one step. With stepCap 10, the 11th distinct failing head surfaces instead of steering.
+  for (let i = 0; i <= 10; i++) h.svc.onGit("s1", git({ headSha: "sha" + i }));
+  expect(h.events.filter((e) => "steer" in e).length).toBe(10);
+  expect(h.state().autopilotPaused).toBe(true);
+});
+
+test("PR open clears a prior pre-PR pause and resets the step budget (handoff)", () => {
+  const h = harness({
+    session: sess({ autopilotPaused: true, autopilotStepCount: 4 }),
+    repoEnabled: true,
+  });
+  h.svc.onGit("s1", git({ checks: "success" }));
+  expect(h.state().autopilotPaused).toBe(false);
+  expect(h.state().autopilotStepCount).toBe(0);
+});
+
+test("handoff reset fires once per PR-open, not every poll (preserves CI-fix budget)", () => {
+  const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
+  h.svc.onGit("s1", git({ checks: "success", headSha: "sha1" })); // open transition → reset
+  h.svc.onGit("s1", git({ checks: "failure", headSha: "sha1" })); // red → step 1
+  h.svc.onGit("s1", git({ checks: "failure", headSha: "sha1" })); // same red head, no reset, no re-steer
+  expect(h.state().autopilotStepCount).toBe(1);
+});
+
+test("PR closing/merging clears CI dedup so a reopened red head can re-steer", () => {
+  const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
+  h.svc.onGit("s1", git({ headSha: "sha1" })); // steer 1
+  h.svc.onGit("s1", git({ state: "merged", checks: "success" })); // clears dedup + openSeen
+  h.svc.onGit("s1", git({ headSha: "sha1" })); // open again, same head → steer 2
+  expect(h.events.filter((e) => "steer" in e).length).toBe(2);
+});

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -391,8 +391,9 @@ test("CI-fix recovery resumes a dead pane before steering", () => {
 
 test("step cap stops CI-fix thrash and pauses to the operator", () => {
   const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
-  // The first call is the open transition (resets the budget); each distinct red head then
-  // burns one step. With stepCap 10, the 11th distinct failing head surfaces instead of steering.
+  // The session starts at step 0; each distinct red head burns one step (the red CI skips the
+  // onPrOpen handoff, so there's no budget reset). With stepCap 10, the 11th distinct failing
+  // head surfaces (pauses) instead of steering.
   for (let i = 0; i <= 10; i++) h.svc.onGit("s1", git({ headSha: "sha" + i }));
   expect(h.events.filter((e) => "steer" in e).length).toBe(10);
   expect(h.state().autopilotPaused).toBe(true);

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1595,6 +1595,56 @@ test("create omits house rules when learnings disabled for the repo", async () =
   expect(sysPrompt(captured.argv!)).toBe(composeSystemPrompt(null));
 });
 
+test("composeSystemPrompt adds the autopilot directive only when active", () => {
+  expect(composeSystemPrompt(null)).not.toContain("<autopilot-directive>");
+  expect(composeSystemPrompt(null, false)).not.toContain("<autopilot-directive>");
+  const on = composeSystemPrompt(null, true);
+  expect(on).toContain("<autopilot-directive>");
+  expect(on).toContain("Shepherd autopilot");
+  expect(on).toContain("<branch-rename-notice>"); // still present alongside
+});
+
+test("create seeds the autopilot directive when the repo has autopilot on", async () => {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig("/repo", {
+    criticEnabled: true,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: true,
+    autoDrainEnabled: false,
+    maxAuto: 1,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+  });
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(injectDeps(store, captured) as any);
+  await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "do the thing",
+    model: null,
+    images: [],
+  });
+  // The agent learns up front it's unattended, so it won't stop to ask "commit + open a PR?".
+  expect(sysPrompt(captured.argv!)).toContain("<autopilot-directive>");
+  // The human turn stays exactly the user's task — the directive rides the system prompt.
+  expect(captured.argv!.at(-1)).toBe("do the thing");
+});
+
+test("create omits the autopilot directive when the repo has autopilot off", async () => {
+  const store = new SessionStore(":memory:");
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(injectDeps(store, captured) as any);
+  await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "do the thing",
+    model: null,
+    images: [],
+  });
+  expect(sysPrompt(captured.argv!)).not.toContain("<autopilot-directive>");
+});
+
 test("create injects only the planned house rules and drops the over-budget ones", async () => {
   const store = new SessionStore(":memory:");
   // Many 160-char rules so the combined block blows past the default 4000-char budget


### PR DESCRIPTION
## Why

Reading the transcripts for the most-recent TASK-253/254/255 runs (all inherit `autopilotEnabled = NULL` → repo autopilot **on**) surfaced two ways autopilot lets a task stall:

**A. "Want me to commit + open a PR?" halt.** `extension-subdir-auto-install` finished its fix and stopped to ask *"Want me to commit + open a PR for this?"* — the next turn is a bare `yes` (a **human**, not autopilot; autopilot steers are the multi-line `PROCEED_STEER`/`OPEN_PR_STEER`). DB confirms `autopilotStepCount = 0`: autopilot never steered it. Autopilot is purely **reactive** — it classifies + steers only *after* a stop is detected, which the operator routinely beats by answering manually.

**B. Red-CI dead zone (the structural one).** The critic runs **only** on green CI (`review.ts:160`, `git.checks === "success"`), and pre-PR autopilot **stands down the moment a PR exists** (`autopilot.ts` `eligible()` → `hasPr`). Red CI only fires a push **notification** to the human (`push.ts`). So a PR sitting on failing CI is steered by *nobody* — "tasks just won't continue even though autopilot is active," exactly as reported.

(The third transcript, `shepherd-sandboxes`, was a *create-an-issue* task — it correctly created #345 and paused; there's no PR to drive to. Left as-is.)

## What

- **`AutopilotService.onGit(id, git)`** — on `state === "open" && checks === "failure"`, steer the task agent to fix its own CI (`CI_FIX_STEER`: inspect `gh pr checks` / `gh run view --log-failed`, fix, push). Deduped per head SHA (no re-nudge every 120s poll — only a fresh push that still fails earns another steer), bounded by the same step cap (thrash → pause to operator), resumes a dead pane first. Replaces the open-only `onPrOpen` call in `index.ts`; the PR-open handoff now fires once per open (not every poll) and won't clobber a deliberate pause on restart.
- **Spawn-time `<autopilot-directive>`** — when the repo has autopilot on, seed the directive into the `--append-system-prompt` system prompt so the agent knows up front it's unattended and drives to a PR without stopping for procedural gates. Conditional wording ("for a code change that means an open PR") keeps non-PR tasks (research / issue creation) safe.

## Tests

- `test/autopilot.test.ts` — 12 new `onGit` cases: red-CI steer + step++, per-head dedup, re-steer on new failing head, green/pending no-op, enablement/pause gating, dead-pane resume, step-cap → pause, once-per-open handoff, PR-close clears dedup.
- `test/service.test.ts` — `composeSystemPrompt` directive on/off + `create` seeds/omits it by repo autopilot state.
- Full root suite green (1074 pass / 0 fail), tsc + lint clean.

Agent-facing steer/directive text is intentionally **not** i18n'd (matches the existing `PROCEED_STEER`/`OPEN_PR_STEER` convention); no UI touched, so i18n + feature-catalog gates are N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)