### PR TITLE
feat(autopilot): complete verdict for non-PR tasks (#358)

### DIFF
--- a/src/autopilot-llm.ts
+++ b/src/autopilot-llm.ts
@@ -8,7 +8,7 @@ import type { AutopilotVerdict, AutopilotKind } from "./types";
 /** The file the classifier agent writes its verdict JSON to, in its temp cwd. */
 export const VERDICT_FILE = ".shepherd-autopilot.json";
 
-const KINDS: AutopilotKind[] = ["gate", "question", "finished", "unknown"];
+const KINDS: AutopilotKind[] = ["gate", "question", "finished", "complete", "unknown"];
 /** Uncertain → surface. A wrongly-surfaced gate costs one click; a wrongly-answered
  *  question costs a bad product decision. */
 const SURFACE: AutopilotVerdict = { kind: "unknown", summary: "" };
@@ -51,11 +51,12 @@ export function classifierPrompt(tail: string[], taskPrompt: string): string {
     "Classify into exactly one `kind`:",
     '- "gate": a procedural/workflow stop the agent could resolve itself and the answer is obviously "yes, keep going" — e.g. "shall I write the spec first?", "ready to start implementing?", "want me to commit now?". Choose this ONLY when proceeding is clearly correct.',
     '- "question": a real decision that needs a human — a product/requirements fork, ambiguous intent, a choice between materially different approaches, or anything the agent should not decide unilaterally.',
-    '- "finished": the agent believes it is done or has nothing left to do, but has not opened a pull request yet.',
+    '- "finished": the agent has done code/implementation work whose deliverable is a pull request, believes it is done, but has not opened the PR yet. (It still needs to be driven to a PR.)',
+    '- "complete": the agent has fully delivered a task whose deliverable is NOT a pull request — research/investigation/analysis, creating a GitHub issue, or a one-off answer — and there is nothing to turn into a PR. Judge by the TASK: if it never asked for code changes, a finished agent is "complete", not "finished".',
     '- "unknown": you cannot confidently tell. When in doubt, use this — never guess "gate".',
     "",
     `Write your verdict as JSON to the file \`${VERDICT_FILE}\` in the current directory, with EXACTLY this shape, then stop:`,
-    '{"kind": "gate" | "question" | "finished" | "unknown", "summary": "<1-2 sentence plain description of what the agent is waiting for>"}',
+    '{"kind": "gate" | "question" | "finished" | "complete" | "unknown", "summary": "<1-2 sentence plain description of what the agent is waiting for, or for \\"complete\\" what it delivered>"}',
     "Do not read or modify any other file.",
   ].join("\n");
 }

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -52,6 +52,8 @@ export interface AutopilotDeps {
   refreshPr?: (id: string) => void;
   /** Fired when autopilot hands a session back for a genuine question / step-cap. */
   onPause: (id: string, question: string) => void;
+  /** Fired when autopilot marks a session complete (non-PR deliverable done). */
+  onComplete?: (id: string, summary: string) => void;
   /** Fired after any autopilot-field mutation (pause / clear) so the wiring can emit a live event. */
   onState?: (id: string) => void;
   stepCap?: number;
@@ -62,6 +64,8 @@ const DEFAULT_STEP_CAP = 10;
 const CAP_MESSAGE = "Autopilot reached its step limit without opening a PR — over to you.";
 /** Generic hand-back text when a question/unknown verdict carries no summary of its own. */
 const SURFACE_MESSAGE = "Autopilot paused for your input.";
+/** Non-alarming hand-back text when a `complete` verdict carries no summary of its own. */
+const COMPLETE_MESSAGE = "Autopilot finished — task complete, nothing to open as a PR.";
 
 export class AutopilotService {
   // Re-entrancy guard: classify() is async, so a second event for the same session must
@@ -92,6 +96,7 @@ export class AutopilotService {
     if (!s || s.status === "archived") return null;
     if (!this.enabled(s)) return null;
     if (s.autopilotPaused) return null; // already handed back; waits for operator
+    if (s.autopilotComplete) return null; // terminal: task delivered (non-PR), nothing to drive
     // A PR exists in ANY state → autopilot stands down: open is the critic loop's territory,
     // and merged/closed mean the pre-PR mission is over (work landed / human closed it) — never
     // steer such a session to open ANOTHER PR.
@@ -106,6 +111,15 @@ export class AutopilotService {
   private pause(s: Session, question: string): void {
     this.deps.store.setAutopilotState(s.id, { paused: true, question });
     this.deps.onPause(s.id, question);
+    this.deps.onState?.(s.id);
+  }
+
+  /** Mark the session complete — a clean terminal state for a non-PR deliverable. `summary`
+   *  is the resolved hand-back text (caller supplies COMPLETE_MESSAGE when the verdict has
+   *  none). Distinct from pause: it reads as "done", not "needs a decision". */
+  private markComplete(s: Session, summary: string): void {
+    this.deps.store.setAutopilotState(s.id, { complete: true, question: summary });
+    this.deps.onComplete?.(s.id, summary);
     this.deps.onState?.(s.id);
   }
 
@@ -131,6 +145,9 @@ export class AutopilotService {
         return;
       case "finished":
         this.driveSteer(s, OPEN_PR_STEER);
+        return;
+      case "complete":
+        this.markComplete(s, v.summary || COMPLETE_MESSAGE);
         return;
       default: // "question" | "unknown" → bias to surface
         this.pause(s, v.summary || SURFACE_MESSAGE);
@@ -182,9 +199,10 @@ export class AutopilotService {
     await this.consider(id, tail, `autopilot ${id}`);
   }
 
-  /** session:status "running" handler. A paused→running transition is the operator
-   *  answering: clear the pause and refresh the step budget. Non-paused running is a no-op
-   *  (autopilot's OWN gate-steers resume the agent — those must not reset the cap).
+  /** session:status "running" handler. A paused→running or complete→running transition is the
+   *  operator re-engaging the session: clear the hand-back and refresh the step budget. Running
+   *  while neither paused nor complete is a no-op (autopilot's OWN gate-steers resume the agent —
+   *  those must not reset the cap).
    *  Known limitation: a manual operator steer while the loop is active-but-NOT-paused also
    *  produces "running" and is indistinguishable from autopilot's own steer here, so it does
    *  NOT refresh the budget — a slight deviation from the design's "reset on manual intervene".
@@ -193,17 +211,27 @@ export class AutopilotService {
   onStatus(id: string, status: string): void {
     if (status !== "running") return;
     const s = this.deps.store.get(id);
-    if (!s || !s.autopilotPaused) return;
-    this.deps.store.setAutopilotState(id, { paused: false, question: null, stepCount: 0 });
+    if (!s || (!s.autopilotPaused && !s.autopilotComplete)) return;
+    this.deps.store.setAutopilotState(id, {
+      paused: false,
+      complete: false,
+      question: null,
+      stepCount: 0,
+    });
     this.deps.onState?.(id);
   }
 
-  /** The critic handoff: clear pause + reset the step budget. Invoked once per PR-open by
-   *  onGit (for a non-red PR) — the single place this transition is applied. */
+  /** The critic handoff: clear pause + complete + reset the step budget. Invoked once per PR-open
+   *  by onGit (for a non-red PR) — the single place this transition is applied. */
   onPrOpen(id: string): void {
     const s = this.deps.store.get(id);
     if (!s) return;
-    this.deps.store.setAutopilotState(id, { paused: false, question: null, stepCount: 0 });
+    this.deps.store.setAutopilotState(id, {
+      paused: false,
+      complete: false,
+      question: null,
+      stepCount: 0,
+    });
     this.deps.onState?.(id);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,12 +293,24 @@ const autopilot = new AutopilotService({
       summary: question,
     });
   },
+  onComplete: (id, summary) => {
+    const s = store.get(id);
+    if (!s) return;
+    void push.notify({
+      kind: "autopilot-done",
+      sessionId: id,
+      tag: id,
+      name: s.name,
+      summary,
+    });
+  },
   onState: (id) => {
     const s = store.get(id);
     if (s)
       events.emit("session:autopilot", {
         id,
         paused: s.autopilotPaused,
+        complete: s.autopilotComplete,
         question: s.autopilotQuestion,
         enabled: s.autopilotEnabled,
       });

--- a/src/push.ts
+++ b/src/push.ts
@@ -9,7 +9,7 @@ export interface PushPayload {
   title: string;
   body: string;
   sessionId: string;
-  kind: "blocked" | "done" | "review" | "ci" | "review-human" | "autopilot";
+  kind: "blocked" | "done" | "review" | "ci" | "review-human" | "autopilot" | "autopilot-done";
   tag: string;
 }
 
@@ -21,6 +21,7 @@ const KIND_CATEGORY: Record<PushPayload["kind"], PushCategory> = {
   blocked: "agent",
   done: "agent",
   autopilot: "agent",
+  "autopilot-done": "agent",
   review: "reviews",
   "review-human": "reviews",
   ci: "ci",
@@ -28,7 +29,7 @@ const KIND_CATEGORY: Record<PushPayload["kind"], PushCategory> = {
 
 /** A notification described by intent, not text — localized per device at send time. */
 export interface NotifyInput {
-  kind: "blocked" | "done" | "review" | "ci" | "review-human" | "autopilot";
+  kind: "blocked" | "done" | "review" | "ci" | "review-human" | "autopilot" | "autopilot-done";
   sessionId: string;
   tag: string;
   name: string;
@@ -39,7 +40,7 @@ export interface NotifyInput {
   ciState?: ChecksState;
   /** For kind "review-human": the human review state, selecting the body copy. */
   reviewState?: "approved" | "changes_requested" | "commented";
-  /** For kind "autopilot": the classifier's question summary (verbatim passthrough). */
+  /** For kind "autopilot"/"autopilot-done": the classifier's hand-back summary (verbatim). */
   summary?: string;
   /** Overrides the cooldown key (default `${kind}:${sessionId}`). */
   cooldownKey?: string;
@@ -78,6 +79,8 @@ const NOTIFY_TEXT = {
     humanCommented: "A reviewer left a comment.",
     autopilotTitle: (name: string) => `${name} — needs you`,
     autopilotFallback: "Autopilot paused for your input.",
+    autopilotDoneTitle: (name: string) => `${name} — complete`,
+    autopilotDoneFallback: "Autopilot finished — task complete, nothing to open as a PR.",
   },
   de: {
     doneTitle: (name: string) => `${name} — wartet`,
@@ -100,6 +103,8 @@ const NOTIFY_TEXT = {
     humanCommented: "Ein Reviewer hat einen Kommentar hinterlassen.",
     autopilotTitle: (name: string) => `${name} — braucht dich`,
     autopilotFallback: "Autopilot pausiert für deine Eingabe.",
+    autopilotDoneTitle: (name: string) => `${name} — fertig`,
+    autopilotDoneFallback: "Autopilot fertig — Aufgabe erledigt, kein PR zu öffnen.",
   },
 } as const;
 
@@ -164,6 +169,12 @@ export function buildPayload(input: NotifyInput, locale: string): PushPayload {
         ...base,
         title: t.autopilotTitle(input.name),
         body: input.summary && input.summary.trim() ? input.summary : t.autopilotFallback,
+      };
+    case "autopilot-done":
+      return {
+        ...base,
+        title: t.autopilotDoneTitle(input.name),
+        body: input.summary && input.summary.trim() ? input.summary : t.autopilotDoneFallback,
       };
     default:
       return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -851,6 +851,7 @@ async function handleSessionAutopilot({ req, parts, deps }: Ctx): Promise<Respon
     deps.events.emit("session:autopilot", {
       id: parts[2],
       paused: updated.autopilotPaused,
+      complete: updated.autopilotComplete,
       question: updated.autopilotQuestion,
       enabled: updated.autopilotEnabled,
     });

--- a/src/store.ts
+++ b/src/store.ts
@@ -78,6 +78,7 @@ type NewSession = Omit<
   | "autopilotEnabled"
   | "autopilotStepCount"
   | "autopilotPaused"
+  | "autopilotComplete"
   | "autopilotQuestion"
   | "auto"
   | "issueNumber"
@@ -90,7 +91,7 @@ type NewSession = Omit<
 
 const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePath,
   isolated, herdrSession, herdrAgentId, claudeSessionId, model, readyToMerge, status, lastState,
-  autopilotEnabled, autopilotStepCount, autopilotPaused, autopilotQuestion,
+  autopilotEnabled, autopilotStepCount, autopilotPaused, autopilotComplete, autopilotQuestion,
   auto, issueNumber,
   createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId`;
 
@@ -308,6 +309,7 @@ export class SessionStore implements CapStore {
       autopilotEnabled: null,
       autopilotStepCount: 0,
       autopilotPaused: false,
+      autopilotComplete: false,
       autopilotQuestion: null,
       auto: input.auto ?? false,
       issueNumber: input.issueNumber ?? null,
@@ -320,7 +322,7 @@ export class SessionStore implements CapStore {
       mergingTrainId: null,
     };
     this.db.run(
-      `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
       [
         s.id,
         s.desig,
@@ -341,6 +343,7 @@ export class SessionStore implements CapStore {
         null, // autopilotEnabled — inherit repo default
         0, // autopilotStepCount
         0, // autopilotPaused
+        0, // autopilotComplete
         null, // autopilotQuestion
         s.auto ? 1 : 0,
         s.issueNumber,
@@ -409,6 +412,7 @@ export class SessionStore implements CapStore {
       enabled?: boolean | null;
       stepCount?: number;
       paused?: boolean;
+      complete?: boolean;
       question?: string | null;
     },
   ): void {
@@ -417,13 +421,15 @@ export class SessionStore implements CapStore {
     const enabled = patch.enabled === undefined ? cur.autopilotEnabled : patch.enabled;
     const stepCount = patch.stepCount ?? cur.autopilotStepCount;
     const paused = patch.paused ?? cur.autopilotPaused;
+    const complete = patch.complete ?? cur.autopilotComplete;
     const question = patch.question === undefined ? cur.autopilotQuestion : patch.question;
     this.db.run(
-      `UPDATE sessions SET autopilotEnabled=?, autopilotStepCount=?, autopilotPaused=?, autopilotQuestion=?, updatedAt=? WHERE id=?`,
+      `UPDATE sessions SET autopilotEnabled=?, autopilotStepCount=?, autopilotPaused=?, autopilotComplete=?, autopilotQuestion=?, updatedAt=? WHERE id=?`,
       [
         enabled === null ? null : enabled ? 1 : 0,
         stepCount,
         paused ? 1 : 0,
+        complete ? 1 : 0,
         question,
         Date.now(),
         id,
@@ -648,6 +654,7 @@ export class SessionStore implements CapStore {
     add("autopilotEnabled", `autopilotEnabled INTEGER`);
     add("autopilotStepCount", `autopilotStepCount INTEGER NOT NULL DEFAULT 0`);
     add("autopilotPaused", `autopilotPaused INTEGER NOT NULL DEFAULT 0`);
+    add("autopilotComplete", `autopilotComplete INTEGER NOT NULL DEFAULT 0`);
     add("autopilotQuestion", `autopilotQuestion TEXT`);
     add("auto", `auto INTEGER NOT NULL DEFAULT 0`);
     add("issueNumber", `issueNumber INTEGER`);
@@ -899,6 +906,7 @@ export class SessionStore implements CapStore {
           : !!r.autopilotEnabled,
       autopilotStepCount: r.autopilotStepCount ?? 0,
       autopilotPaused: !!r.autopilotPaused,
+      autopilotComplete: !!r.autopilotComplete,
       autopilotQuestion: r.autopilotQuestion ?? null,
       auto: !!r.auto,
       issueNumber: r.issueNumber ?? null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,11 @@ export interface Session {
   autopilotStepCount: number;
   /** True when autopilot handed control back for a genuine question / step-cap. */
   autopilotPaused: boolean;
-  /** The classifier's 1–2 sentence summary of what the agent is waiting for; null when not paused. */
+  /** True when autopilot judged the task done with a non-PR deliverable (research / issue
+   *  creation / one-off answer) — a clean terminal "completed", distinct from a pause. */
+  autopilotComplete: boolean;
+  /** The classifier's 1–2 sentence hand-back summary — what the agent is waiting for (paused)
+   *  or what it delivered (complete); null in neither state. */
   autopilotQuestion: string | null;
   /** True when this session was auto-spawned by the drain queue. */
   auto: boolean;
@@ -151,11 +155,12 @@ export interface ReviewVerdict {
 }
 
 // ── autopilot mode ──────────────────────────────────────────────────────────
-export type AutopilotKind = "gate" | "question" | "finished" | "unknown";
+export type AutopilotKind = "gate" | "question" | "finished" | "complete" | "unknown";
 
 export interface AutopilotVerdict {
   kind: AutopilotKind;
-  /** 1–2 sentence plain-English description of what the agent is waiting for. */
+  /** 1–2 sentence plain-English description of what the agent is waiting for (or, for
+   *  "complete", what it delivered). */
   summary: string;
 }
 

--- a/test/autopilot-llm.test.ts
+++ b/test/autopilot-llm.test.ts
@@ -33,6 +33,15 @@ test("classifierPrompt embeds the tail + task and asks for the verdict file", ()
   expect(p).toContain(VERDICT_FILE);
   expect(p.toLowerCase()).toContain("gate");
   expect(p.toLowerCase()).toContain("question");
+  expect(p.toLowerCase()).toContain("complete");
+});
+
+test("classifyStop: parses a complete verdict (non-PR deliverable)", async () => {
+  const { deps } = makeDeps({
+    readVerdict: () => ({ kind: "complete", summary: "Created issue #345." }),
+  });
+  const v = await classifyStop(["Created the issue. Done."], "create an issue for X", deps, "l");
+  expect(v).toEqual({ kind: "complete", summary: "Created issue #345." });
 });
 
 test("classifyStop: parses a gate verdict; spawns haiku, dontAsk, Write-only", async () => {

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -24,6 +24,7 @@ function sess(over: Partial<Session> = {}): Session {
     autopilotEnabled: true,
     autopilotStepCount: 0,
     autopilotPaused: false,
+    autopilotComplete: false,
     autopilotQuestion: null,
     auto: false,
     issueNumber: null,
@@ -67,6 +68,7 @@ function harness(opts: {
           enabled?: boolean | null;
           stepCount?: number;
           paused?: boolean;
+          complete?: boolean;
           question?: string | null;
         },
       ) => {
@@ -75,6 +77,7 @@ function harness(opts: {
           autopilotEnabled: patch.enabled === undefined ? cur.autopilotEnabled : patch.enabled,
           autopilotStepCount: patch.stepCount ?? cur.autopilotStepCount,
           autopilotPaused: patch.paused ?? cur.autopilotPaused,
+          autopilotComplete: patch.complete ?? cur.autopilotComplete,
           autopilotQuestion: patch.question === undefined ? cur.autopilotQuestion : patch.question,
         };
       },
@@ -93,6 +96,7 @@ function harness(opts: {
     hasPr: () => opts.openPr ?? false,
     refreshPr: (id) => events.push({ refreshPr: id }),
     onPause: (id, q) => events.push({ pause: id, q }),
+    onComplete: (id, summary) => events.push({ complete: id, summary }),
     onState: (id) => events.push({ state: id }),
     stepCap: 10,
   });
@@ -112,6 +116,47 @@ test("finished verdict → open-PR steer", async () => {
   await h.svc.onBlock("s1", block(["I'm done."]));
   expect(h.events).toContainEqual({ steer: OPEN_PR_STEER });
   expect(h.state().autopilotStepCount).toBe(1);
+});
+
+test("complete verdict → markComplete + onComplete, no steer, not paused", async () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    verdict: { kind: "complete", summary: "Created issue #345." },
+  });
+  await h.svc.onDone("s1");
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  expect(h.events).toContainEqual({ complete: "s1", summary: "Created issue #345." });
+  expect(h.state().autopilotComplete).toBe(true);
+  expect(h.state().autopilotPaused).toBe(false);
+  expect(h.state().autopilotQuestion).toBe("Created issue #345.");
+});
+
+test("complete verdict with empty summary → COMPLETE_MESSAGE fallback", async () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    verdict: { kind: "complete", summary: "" },
+  });
+  await h.svc.onDone("s1");
+  const ev = h.events.find((e) => "complete" in e);
+  expect(ev.summary).toContain("task complete");
+  expect(h.state().autopilotComplete).toBe(true);
+});
+
+test("already complete → no re-classify (terminal)", async () => {
+  const h = harness({
+    session: sess({ autopilotComplete: true }),
+    verdict: { kind: "gate", summary: "x" },
+  });
+  await h.svc.onDone("s1");
+  expect(h.events.some((e) => "steer" in e || "complete" in e)).toBe(false);
+});
+
+test("onStatus running after complete clears it + resets steps", async () => {
+  const h = harness({ session: sess({ autopilotComplete: true, autopilotStepCount: 4 }) });
+  h.svc.onStatus("s1", "running");
+  expect(h.state().autopilotComplete).toBe(false);
+  expect(h.state().autopilotQuestion).toBeNull();
+  expect(h.state().autopilotStepCount).toBe(0);
 });
 
 test("question verdict → pause + onPause, no steer", async () => {

--- a/test/push-autopilot.test.ts
+++ b/test/push-autopilot.test.ts
@@ -25,3 +25,29 @@ test("autopilot payload falls back when summary empty", () => {
   expect(p.title).toContain("login");
   expect(p.body.length).toBeGreaterThan(0);
 });
+
+test("autopilot-done payload: title reads complete, body is the summary", () => {
+  const p = buildPayload(
+    {
+      kind: "autopilot-done",
+      sessionId: "s1",
+      tag: "s1",
+      name: "research",
+      summary: "Created issue #345.",
+    },
+    "en",
+  );
+  expect(p.kind).toBe("autopilot-done");
+  expect(p.title).toContain("research");
+  expect(p.title).toContain("complete");
+  expect(p.body).toContain("Created issue #345.");
+});
+
+test("autopilot-done payload falls back when summary empty", () => {
+  const p = buildPayload(
+    { kind: "autopilot-done", sessionId: "s1", tag: "s1", name: "research", summary: "" },
+    "de",
+  );
+  expect(p.title).toContain("research");
+  expect(p.body.length).toBeGreaterThan(0);
+});

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -25,6 +25,7 @@ function session(over: Partial<Session> = {}): Session {
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,
+    autopilotComplete: false,
     autopilotQuestion: null,
     auto: false,
     issueNumber: null,

--- a/test/server-diff.test.ts
+++ b/test/server-diff.test.ts
@@ -25,6 +25,7 @@ const SESSION: Session = {
   autopilotEnabled: null,
   autopilotStepCount: 0,
   autopilotPaused: false,
+  autopilotComplete: false,
   autopilotQuestion: null,
   auto: false,
   issueNumber: null,

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -29,6 +29,7 @@ const SESSION: Session = {
   autopilotEnabled: null,
   autopilotStepCount: 0,
   autopilotPaused: false,
+  autopilotComplete: false,
   autopilotQuestion: null,
   auto: false,
   issueNumber: null,

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -142,6 +142,8 @@
   "feat_review_cycles_body": "Lege fest, wie oft der Kritiker erneut prüft und einen Agenten anweist, Befunde zu beheben, bevor an dich eskaliert wird. Passe das globale Limit unter Einstellungen → Sitzung an.",
   "feat_merge_in_progress_title": "Merge-Train zeigt Fortschritt",
   "feat_merge_in_progress_body": "Wenn du einen Merge-Train startest, wandern die PRs, die er abarbeitet, mit einem bernsteinfarbenen Badge in eine Merge-läuft-Gruppe, statt in „Bereit zum Mergen“ zu bleiben — und jeder verschwindet, sobald er gemergt ist.",
+  "feat_autopilot_complete_title": "Autopilot schließt Nicht-PR-Aufgaben ab",
+  "feat_autopilot_complete_body": "Recherche, Issue-Erstellung und einmalige Antworten enden jetzt in einem sauberen Status „Fertig“ statt im irreführenden „Pausiert für Eingabe“ — Autopilot pausiert nur noch laut für eine echte Entscheidung.",
   "gitrail_send_review": "↩ Review an Agent",
   "gitrail_send_review_failed": "Senden fehlgeschlagen",
   "gitrail_send_review_reviewing_title": "Critic prüft erneut — diese Anmerkungen werden gerade neu validiert",
@@ -578,5 +580,7 @@
   "session_autopilot_off_label": "Autopilot aus",
   "session_autopilot_paused_label": "Braucht dich",
   "session_autopilot_paused_title": "Autopilot hat dies für eine Entscheidung zurückgegeben: {question}",
+  "session_autopilot_complete_label": "Fertig",
+  "session_autopilot_complete_title": "Autopilot fertig — Aufgabe erledigt, kein PR zu öffnen: {summary}",
   "session_autopilot_toggle_failed": "Autopilot für diese Session konnte nicht geändert werden. Erneut versuchen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -142,6 +142,8 @@
   "feat_review_cycles_body": "Set how many times the critic re-reviews and steers an agent to address findings before escalating to you. Adjust the global cap in Settings → Session.",
   "feat_merge_in_progress_title": "Merge train shows progress",
   "feat_merge_in_progress_body": "When you start a merge train, the PRs it's working through move into a Merging group with an amber badge instead of staying in Ready to merge — and each clears as it lands.",
+  "feat_autopilot_complete_title": "Autopilot completes non-PR tasks",
+  "feat_autopilot_complete_body": "Research, issue-creation, and one-off answers now end in a clean Complete state instead of a misleading \"paused for input\" — autopilot only pauses loudly for a real decision.",
   "gitrail_send_review": "↩ Send review to agent",
   "gitrail_send_review_failed": "send failed",
   "gitrail_send_review_reviewing_title": "Critic is re-reviewing — these findings are being re-validated",
@@ -578,5 +580,7 @@
   "session_autopilot_off_label": "Autopilot off",
   "session_autopilot_paused_label": "Needs you",
   "session_autopilot_paused_title": "Autopilot handed this back for a decision: {question}",
+  "session_autopilot_complete_label": "Complete",
+  "session_autopilot_complete_title": "Autopilot finished — task complete, nothing to open as a PR: {summary}",
   "session_autopilot_toggle_failed": "Couldn't change autopilot for this session. Try again."
 }

--- a/ui/src/lib/components/AutopilotBadge.svelte
+++ b/ui/src/lib/components/AutopilotBadge.svelte
@@ -14,10 +14,20 @@
   >
     {m.session_autopilot_paused_label()}
   </span>
+{:else if session.autopilotComplete}
+  <span
+    class="ap-complete"
+    title={m.session_autopilot_complete_title({ summary: session.autopilotQuestion ?? "" })}
+    role="img"
+    aria-label={m.session_autopilot_complete_label()}
+  >
+    {m.session_autopilot_complete_label()}
+  </span>
 {/if}
 
 <style>
-  .ap-paused {
+  .ap-paused,
+  .ap-complete {
     font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -27,5 +37,9 @@
     color: var(--color-amber);
     white-space: nowrap;
     font-weight: 600;
+  }
+  .ap-complete {
+    border-color: var(--color-green);
+    color: var(--color-green);
   }
 </style>

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -26,6 +26,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,
+    autopilotComplete: false,
     autopilotQuestion: null,
     auto: false,
     issueNumber: null,

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -26,6 +26,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,
+    autopilotComplete: false,
     autopilotQuestion: null,
     auto: false,
     issueNumber: null,

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -24,6 +24,7 @@ function session(id: string, readyToMerge = false, status: SessionStatus = "runn
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,
+    autopilotComplete: false,
     autopilotQuestion: null,
     auto: false,
     issueNumber: null,

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -29,6 +29,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,
+    autopilotComplete: false,
     autopilotQuestion: null,
     auto: false,
     issueNumber: null,

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -69,4 +69,12 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_merge_in_progress_title",
     bodyKey: "feat_merge_in_progress_body",
   },
+  {
+    // No targetId: the Complete badge only appears on a session autopilot has just finished,
+    // so a coachmark anchor would rarely be mounted — surface via the What's-New drawer only.
+    id: "autopilot-complete",
+    sinceVersion: "1.17.0",
+    titleKey: "feat_autopilot_complete_title",
+    bodyKey: "feat_autopilot_complete_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -33,6 +33,7 @@ function session(id: string): Session {
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,
+    autopilotComplete: false,
     autopilotQuestion: null,
     auto: false,
     issueNumber: null,
@@ -112,7 +113,7 @@ test("session:autopilot merges autopilot fields into the matching session", () =
   s.setAll([session("s1"), session("s2")]);
   s.apply({
     event: "session:autopilot",
-    data: { id: "s1", paused: true, question: "Which provider?", enabled: true },
+    data: { id: "s1", paused: true, complete: false, question: "Which provider?", enabled: true },
   });
   const a = s.byId("s1");
   const b = s.byId("s2");
@@ -120,12 +121,26 @@ test("session:autopilot merges autopilot fields into the matching session", () =
   expect(a?.autopilotQuestion).toBe("Which provider?");
   expect(a?.autopilotEnabled).toBe(true);
   expect(b?.autopilotPaused).toBe(false); // other sessions untouched
+  // complete path
+  s.apply({
+    event: "session:autopilot",
+    data: {
+      id: "s1",
+      paused: false,
+      complete: true,
+      question: "Created issue #345.",
+      enabled: true,
+    },
+  });
+  expect(s.byId("s1")?.autopilotComplete).toBe(true);
+  expect(s.byId("s1")?.autopilotPaused).toBe(false);
   // clear path
   s.apply({
     event: "session:autopilot",
-    data: { id: "s1", paused: false, question: null, enabled: null },
+    data: { id: "s1", paused: false, complete: false, question: null, enabled: null },
   });
   expect(s.byId("s1")?.autopilotPaused).toBe(false);
+  expect(s.byId("s1")?.autopilotComplete).toBe(false);
   expect(s.byId("s1")?.autopilotQuestion).toBeNull();
   expect(s.byId("s1")?.autopilotEnabled).toBeNull();
 });

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -145,6 +145,7 @@ export class HerdStore {
             ? {
                 ...s,
                 autopilotPaused: ev.data.paused,
+                autopilotComplete: ev.data.complete,
                 autopilotQuestion: ev.data.question,
                 autopilotEnabled: ev.data.enabled,
               }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -225,6 +225,9 @@ export interface Session {
   autopilotEnabled: boolean | null;
   autopilotStepCount: number;
   autopilotPaused: boolean;
+  /** True when autopilot judged the task done with a non-PR deliverable (research / issue
+   *  creation / one-off answer) — a clean "completed", distinct from a pause. */
+  autopilotComplete: boolean;
   autopilotQuestion: string | null;
   /** Whether this session was launched by the auto-drain queue. */
   auto: boolean;
@@ -331,7 +334,13 @@ export type WsEvent =
     }
   | {
       event: "session:autopilot";
-      data: { id: string; paused: boolean; question: string | null; enabled: boolean | null };
+      data: {
+        id: string;
+        paused: boolean;
+        complete: boolean;
+        question: string | null;
+        enabled: boolean | null;
+      };
     }
   | { event: "session:archived"; data: { id: string } }
   | { event: "session:renamed"; data: { id: string; name: string; branch: string | null } }

--- a/ui/test/store.test.ts
+++ b/ui/test/store.test.ts
@@ -23,6 +23,7 @@ const s = (id: string, status: any = "running"): Session => ({
   autopilotEnabled: null,
   autopilotStepCount: 0,
   autopilotPaused: false,
+  autopilotComplete: false,
   autopilotQuestion: null,
   auto: false,
   issueNumber: null,


### PR DESCRIPTION
Closes #358.

## Problem

Autopilot's whole model is **drive the work to an open PR**. Tasks whose deliverable is *not* a PR — research/investigation, issue creation, one-off answers — had no clean terminal state: a finished agent got classified `unknown` and landed in the generic **"Autopilot paused for your input."** That reads as a halt, and the operator couldn't tell "done, nothing to do" from "stuck, needs a decision". (Follow-up from #357; the TASK-254 case was *"create an issue"* → agent created #345 and stopped → spurious pause.)

## Change

New classifier verdict **`complete`**: the agent has fully delivered a task whose deliverable is NOT a PR, and there's nothing to turn into one. The classifier judges by the *task* — if it never asked for code changes, a finished agent is `complete`, not `finished`.

Dispatch marks the session **complete** — a clean terminal state distinct from a pause:
- new persisted `autopilotComplete` state (migration + create/hydrate/setAutopilotState)
- green **"Complete"** badge in the UI (vs amber "Needs you")
- a non-alarming `autopilot-done` push ("— complete") instead of the "— needs you" pause push
- `eligible()` stands down on a complete session (terminal); `onStatus` running / `onPrOpen` clear it when the operator re-engages

Unchanged: a code task with no PR still gets `finished` → driven to a PR; a genuine product/requirements `question` still pauses loudly.

## Acceptance (issue #358)

- ✅ research / issue-creation task ends as **completed**, not "paused for input"
- ✅ a genuine product/requirements question still pauses loudly
- ✅ a code task with no PR still gets driven to one

## Tests

- `complete` verdict → markComplete + onComplete, no steer, not paused; empty-summary fallback; already-complete is terminal; onStatus running clears it
- classifier parses `complete`; prompt advertises it
- `autopilot-done` push payload (title reads "complete", body is the summary)
- UI store merges `autopilotComplete`; all Session fixtures updated

Root: 1077 tests pass, tsc clean, lint clean. UI: 490 tests pass, svelte-check clean, i18n parity (EN+DE), feature catalog entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)