### PR TITLE
feat(ui): show merge-train PRs as Merging in the session list

### DIFF
--- a/docs/superpowers/plans/2026-06-08-merge-train-in-progress-marker.md
+++ b/docs/superpowers/plans/2026-06-08-merge-train-in-progress-marker.md
@@ -1,0 +1,1205 @@
+# Merge-train "Merging" in-progress marker — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the "Merge train" shortcut launches a train session, mark that repo's ready PRs as **Merging** — their own amber-pulsing badge + list group — and clear the mark per-PR as each lands.
+
+**Architecture:** The train runs client-side as an agent session, so the client tells the server which PR-sessions it scoped in (`POST /api/merge-train/start`). The server stamps each session with a transient `mergingSince` timestamp + `mergingTrainId`, persists it (SQLite), and broadcasts `session:merging`. Clearing is server-owned: per-PR when the poller sees the PR merge/close, whole-set when the train session is archived, and a 30-min TTL backstop. The UI mirrors the fields, renders a "Merging" partition group above "Ready to merge", and shows an amber MERGING badge.
+
+**Tech Stack:** Bun + TypeScript server (`src/`), SvelteKit 5 + Paraglide i18n UI (`ui/`), `bun test` (server) / vitest (`cd ui && bun run test`).
+
+**Design doc:** `docs/superpowers/specs/2026-06-08-merge-train-in-progress-marker-design.md`
+
+**Reference: a sibling unmerged branch ships an `AutoMergeService` (#362, server-side full-auto merge). It is NOT in this tree and is a different mechanism — do not couple to it.** This feature is solely about the agent-session shortcut (#359).
+
+**Constants:** TTL = `30 * 60_000` ms (30 min), defined once per package: `MERGE_STALE_MS` in `src/service.ts` (server) and again in `ui/src/lib/components/merge-train.ts` (UI). They live in separate packages and cannot share an import; keep both values identical.
+
+---
+
+## Task 1: Server — `mergingSince`/`mergingTrainId` on Session + store persistence
+
+**Files:**
+- Modify: `src/types.ts:36` (Session interface)
+- Modify: `src/store.ts` (NewSession omit `64-87`, COLS `89-93`, create `296-348`, update `363-385`, migrate `621-633`, hydrate `870-886`)
+- Test: `test/store.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/store.test.ts`:
+
+```typescript
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+
+function newInput() {
+  return {
+    name: "n",
+    prompt: "p",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "a",
+  };
+}
+
+test("merging fields default null and round-trip through update", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(newInput());
+  expect(s.mergingSince).toBeNull();
+  expect(s.mergingTrainId).toBeNull();
+
+  store.update(s.id, { mergingSince: 1234, mergingTrainId: "train-1" });
+  const got = store.get(s.id)!;
+  expect(got.mergingSince).toBe(1234);
+  expect(got.mergingTrainId).toBe("train-1");
+
+  // a later unrelated update preserves them (mirrors readyToMerge survival)
+  store.update(s.id, { status: "idle" });
+  const after = store.get(s.id)!;
+  expect(after.mergingSince).toBe(1234);
+  expect(after.mergingTrainId).toBe("train-1");
+
+  store.update(s.id, { mergingSince: null, mergingTrainId: null });
+  const cleared = store.get(s.id)!;
+  expect(cleared.mergingSince).toBeNull();
+  expect(cleared.mergingTrainId).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/store.test.ts`
+Expected: FAIL — `mergingSince` is `undefined` / property not persisted.
+
+- [ ] **Step 3: Add the fields to the Session type**
+
+In `src/types.ts`, inside `interface Session`, immediately after the `readyToMerge` line (`19`):
+
+```typescript
+  readyToMerge: boolean; // manually-toggled "parked / done" flag; orthogonal to status
+  /** Epoch ms when a launched merge train marked this PR-session as in-flight;
+   *  null when not in a train. Transient: cleared on merge/close, train archive,
+   *  or the TTL sweep. */
+  mergingSince: number | null;
+  /** Id of the merge-train session that owns this mark (clears the whole set when
+   *  that session is archived). Null when not merging. */
+  mergingTrainId: string | null;
+```
+
+- [ ] **Step 4: Persist in the store**
+
+In `src/store.ts`:
+
+(a) `NewSession` omit list (`64-87`) — add both fields to the `Omit<...>` union so callers can't pass them:
+
+```typescript
+  | "readyToMerge"
+  | "mergingSince"
+  | "mergingTrainId"
+```
+
+(b) `COLS` (`89-93`) — append the two columns at the very end:
+
+```typescript
+const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePath,
+  isolated, herdrSession, herdrAgentId, claudeSessionId, model, readyToMerge, status, lastState,
+  autopilotEnabled, autopilotStepCount, autopilotPaused, autopilotQuestion,
+  auto, issueNumber,
+  createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId`;
+```
+
+(c) `create()` — set defaults on the object (after `archivedAt: null,` at `316`):
+
+```typescript
+      archivedAt: null,
+      mergingSince: null,
+      mergingTrainId: null,
+```
+
+Bump the placeholder count from 25 to 27 `?` in the INSERT (`319`):
+
+```typescript
+      `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+```
+
+and append the two values after `s.archivedAt,` (`345`):
+
+```typescript
+        s.archivedAt,
+        s.mergingSince,
+        s.mergingTrainId,
+```
+
+(d) `update()` (`363-385`) — widen the patch `Pick<>` and the UPDATE statement:
+
+```typescript
+  update(
+    id: string,
+    patch: Partial<
+      Pick<
+        Session,
+        | "name"
+        | "status"
+        | "lastState"
+        | "branch"
+        | "herdrAgentId"
+        | "readyToMerge"
+        | "mergingSince"
+        | "mergingTrainId"
+      >
+    >,
+  ) {
+    const cur = this.get(id);
+    if (!cur) return;
+    const next = { ...cur, ...patch, updatedAt: Date.now() };
+    this.db.run(
+      `UPDATE sessions SET name=?, status=?, lastState=?, branch=?, herdrAgentId=?, readyToMerge=?, mergingSince=?, mergingTrainId=?, updatedAt=? WHERE id=?`,
+      [
+        next.name,
+        next.status,
+        next.lastState,
+        next.branch,
+        next.herdrAgentId,
+        next.readyToMerge ? 1 : 0,
+        next.mergingSince,
+        next.mergingTrainId,
+        next.updatedAt,
+        id,
+      ],
+    );
+  }
+```
+
+(e) `migrateSessionColumns()` (after the `autopilotQuestion` add at `633`):
+
+```typescript
+    add("autopilotQuestion", `autopilotQuestion TEXT`);
+    add("mergingSince", `mergingSince INTEGER`);
+    add("mergingTrainId", `mergingTrainId TEXT`);
+```
+
+(f) `hydrate()` (`870-886`) — add explicit normalization before the closing `} as Session;`:
+
+```typescript
+      auto: !!r.auto,
+      issueNumber: r.issueNumber ?? null,
+      mergingSince: r.mergingSince ?? null,
+      mergingTrainId: r.mergingTrainId ?? null,
+    } as Session;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test ./test/store.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types.ts src/store.ts test/store.test.ts
+git commit -m "feat(store): persist transient mergingSince/mergingTrainId on Session"
+```
+
+---
+
+## Task 2: Server — service set/clear/sweep methods + `session:merging` emit
+
+**Files:**
+- Modify: `src/service.ts` (add `MERGE_STALE_MS` export near top of file; add methods after `setReadyToMerge` at `465`)
+- Test: `test/service.test.ts`
+
+The service already exposes `this.deps.store` (with `update`/`get`/`list`) and `this.deps.events?.emit`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/service.test.ts`:
+
+```typescript
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { SessionService, MERGE_STALE_MS } from "../src/service";
+
+function svc() {
+  const store = new SessionStore(":memory:");
+  const emitted: { event: string; data: any }[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "n",
+    worktree: { create: () => ({ worktreePath: "/wt", branch: "b", isolated: true }), remove: () => {} } as any,
+    herdr: { start: () => ({ terminalId: "t", cwd: "/", agent: "claude", agentStatus: "idle", paneId: "p", tabId: "x", workspaceId: "w" }), list: () => [], stop: () => {} } as any,
+    events: { emit: (event: string, data: unknown) => emitted.push({ event, data }) } as any,
+  });
+  return { store, service, emitted };
+}
+
+async function mk(store: SessionStore, service: SessionService) {
+  return service.create({ repoPath: "/r", baseBranch: "main", prompt: "p", model: null, images: [] });
+}
+
+test("setMerging stamps each id and emits session:merging; skips unknown ids", async () => {
+  const { store, service, emitted } = svc();
+  const a = await mk(store, service);
+  service.setMerging([a.id, "ghost"], "train-9");
+  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
+  expect(store.get(a.id)!.mergingTrainId).toBe("train-9");
+  const ev = emitted.filter((e) => e.event === "session:merging");
+  expect(ev).toHaveLength(1); // ghost skipped
+  expect(ev[0].data).toMatchObject({ id: a.id });
+  expect(typeof ev[0].data.since).toBe("number");
+});
+
+test("clearMerging nulls the fields and emits since:null; no-op when not merging", async () => {
+  const { store, service, emitted } = svc();
+  const a = await mk(store, service);
+  service.clearMerging(a.id); // not merging → no event
+  expect(emitted.filter((e) => e.event === "session:merging")).toHaveLength(0);
+  service.setMerging([a.id], "t1");
+  service.clearMerging(a.id);
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+  expect(store.get(a.id)!.mergingTrainId).toBeNull();
+  const last = emitted.filter((e) => e.event === "session:merging").at(-1)!;
+  expect(last.data).toEqual({ id: a.id, since: null });
+});
+
+test("clearMergingForTrain clears every member of one train, leaves others", async () => {
+  const { store, service } = svc();
+  const a = await mk(store, service);
+  const b = await mk(store, service);
+  service.setMerging([a.id], "train-A");
+  service.setMerging([b.id], "train-B");
+  service.clearMergingForTrain("train-A");
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+  expect(store.get(b.id)!.mergingSince).toBeGreaterThan(0);
+});
+
+test("sweepStaleMerging clears marks older than the TTL, keeps fresh ones", async () => {
+  const { store, service } = svc();
+  const a = await mk(store, service);
+  service.setMerging([a.id], "t");
+  const now = Date.now();
+  // not stale yet
+  service.sweepStaleMerging(now);
+  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
+  // far in the future → stale
+  service.sweepStaleMerging(now + MERGE_STALE_MS + 1);
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/service.test.ts`
+Expected: FAIL — `MERGE_STALE_MS` / `setMerging` not exported.
+
+- [ ] **Step 3: Implement the service methods**
+
+In `src/service.ts`, add the constant near the top of the file (after the imports, before the class):
+
+```typescript
+/** A merge-train mark older than this is treated as stale and swept, so a
+ *  rejected/held-back PR (never merged, train never archived) can't stay
+ *  "Merging" forever. Mirrored in ui/src/lib/components/merge-train.ts. */
+export const MERGE_STALE_MS = 30 * 60_000;
+```
+
+Then add these methods right after `setReadyToMerge` (`465`):
+
+```typescript
+  /**
+   * Mark each session as part of a launched merge train (the client passes the
+   * scoped ready-PR ids). Stamps `mergingSince`/`mergingTrainId`, persists, and
+   * pushes `session:merging` so every client patches the row live. Unknown ids
+   * are skipped (best-effort: the set is cosmetic, never load-bearing).
+   */
+  setMerging(ids: string[], trainId: string): void {
+    const since = Date.now();
+    for (const id of ids) {
+      if (!this.deps.store.get(id)) continue;
+      this.deps.store.update(id, { mergingSince: since, mergingTrainId: trainId });
+      this.deps.events?.emit("session:merging", { id, since });
+    }
+  }
+
+  /** Clear one session's merge-train mark. No-op (no event) when not marked. */
+  clearMerging(id: string): void {
+    const s = this.deps.store.get(id);
+    if (!s || s.mergingSince === null) return;
+    this.deps.store.update(id, { mergingSince: null, mergingTrainId: null });
+    this.deps.events?.emit("session:merging", { id, since: null });
+  }
+
+  /** Clear every session marked by a given train (its session was archived). */
+  clearMergingForTrain(trainId: string): void {
+    for (const s of this.deps.store.list({ activeOnly: true })) {
+      if (s.mergingTrainId === trainId) this.clearMerging(s.id);
+    }
+  }
+
+  /** Backstop: clear marks older than MERGE_STALE_MS. `now` injectable for tests. */
+  sweepStaleMerging(now: number = Date.now()): void {
+    for (const s of this.deps.store.list({ activeOnly: true })) {
+      if (s.mergingSince !== null && now - s.mergingSince > MERGE_STALE_MS) {
+        this.clearMerging(s.id);
+      }
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/service.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/service.ts test/service.test.ts
+git commit -m "feat(service): merge-train set/clear/sweep + session:merging event"
+```
+
+---
+
+## Task 3: Server — `POST /api/merge-train/start` endpoint
+
+**Files:**
+- Modify: `src/server.ts` (add `handleMergeTrain` near `handleHalt` at `1209`; register in the handler array at `1648-1677`)
+- Test: `test/server.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Look at an existing handler test in `test/server.test.ts` for the harness (how it builds `deps` + dispatches a `Request`). Add a test mirroring that harness; the assertion logic is:
+
+```typescript
+import { test, expect } from "bun:test";
+// ...reuse this file's existing makeDeps()/handle() helpers...
+
+test("POST /api/merge-train/start marks the given sessions", async () => {
+  const { deps, handle } = makeServer(); // existing helper in this file
+  const a = deps.store.create({
+    name: "n", prompt: "p", repoPath: "/r", baseBranch: "main",
+    branch: "b", worktreePath: "/wt", isolated: true,
+    herdrSession: "default", herdrAgentId: "h",
+  });
+  const res = await handle(
+    new Request("http://x/api/merge-train/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ids: [a.id], trainId: "train-7" }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  expect(deps.store.get(a.id)!.mergingTrainId).toBe("train-7");
+});
+
+test("POST /api/merge-train/start rejects a bad body", async () => {
+  const { handle } = makeServer();
+  const res = await handle(
+    new Request("http://x/api/merge-train/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ids: "nope" }),
+    }),
+  );
+  expect(res.status).toBe(400);
+});
+```
+
+> If `test/server.test.ts` exposes its deps/dispatch helper under a different name, use that name — the behavior asserted (200 + mark set, 400 on bad body) is what matters. Match the harness used by the existing `handleSessionReady` / autopilot tests in this file or `test/server-autopilot.test.ts`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/server.test.ts`
+Expected: FAIL — route returns 404 (handler not registered).
+
+- [ ] **Step 3: Implement the handler**
+
+In `src/server.ts`, add after `handleHalt` (`1218`):
+
+```typescript
+// POST /api/merge-train/start — mark a launched train's ready PRs as "merging".
+// The train itself runs client-side as an agent session; this only flags the
+// scoped PR-sessions so the list shows them in-flight. Body: {ids, trainId}.
+async function handleMergeTrain({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(parts[0] === "api" && parts[1] === "merge-train" && parts[2] === "start" && !parts[3]))
+    return null;
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+  const body = (await req.json().catch(() => null)) as
+    | { ids?: unknown; trainId?: unknown }
+    | null;
+  if (
+    !body ||
+    !Array.isArray(body.ids) ||
+    !body.ids.every((x) => typeof x === "string") ||
+    typeof body.trainId !== "string"
+  ) {
+    return json({ error: "body must be {ids: string[], trainId: string}" }, 400);
+  }
+  deps.service.setMerging(body.ids as string[], body.trainId);
+  return json({ ok: true });
+}
+```
+
+Register it in the handler array (`1648-1677`), next to `handleHalt`:
+
+```typescript
+  handleBroadcast,
+  handleHalt,
+  handleMergeTrain,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/server.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server.ts test/server.test.ts
+git commit -m "feat(server): POST /api/merge-train/start marks scoped PRs merging"
+```
+
+---
+
+## Task 4: Server — wire clearing (poll merge, train archive, TTL sweep)
+
+**Files:**
+- Modify: `src/index.ts` (add two `events.subscribe` blocks + one interval, near the existing `session:status` subscriber at `163-167`)
+
+This is integration glue; the logic it calls is unit-tested in Task 2. No new unit test — verified by `bun run lint` + the existing suite staying green, then manual smoke in Task 15.
+
+- [ ] **Step 1: Add the subscribers + sweep**
+
+In `src/index.ts`, after the existing `session:status` subscriber block (ends `167`):
+
+```typescript
+// A PR in a merge train just landed (or was closed) → drop its "Merging" mark
+// so the row resolves out of the Merging group one-by-one as the train works.
+// session:git fires on any git change; clearMerging no-ops when not marked.
+events.subscribe((event, data) => {
+  if (event !== "session:git") return;
+  const { id, git } = data as { id: string; git: GitState };
+  if (git.state === "merged" || git.state === "closed") service.clearMerging(id);
+});
+
+// The train session itself was archived → clear any of its PRs still marked
+// (e.g. ones it held back / rejected and never merged). Keyed on archive (a
+// terminal state), NOT done/idle — a Claude pane reports done at the train's
+// approval gate, where clearing would wipe the marks mid-train.
+events.subscribe((event, data) => {
+  if (event !== "session:archived") return;
+  service.clearMergingForTrain((data as { id: string }).id);
+});
+
+// Backstop sweep: drop marks older than the TTL so a stuck/rejected PR can't
+// stay "Merging" forever when neither of the above fires.
+setInterval(() => service.sweepStaleMerging(), 60_000);
+```
+
+Ensure `GitState` is imported in `src/index.ts` (it may already be). If not, add it to the forge types import:
+
+```typescript
+import type { GitState } from "./forge/types";
+```
+
+- [ ] **Step 2: Verify it compiles + suite stays green**
+
+Run: `bunx tsc --noEmit && bun test ./test`
+Expected: PASS (no type errors; existing tests unaffected).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat(server): clear merging mark on merge/close, train archive, TTL"
+```
+
+---
+
+## Task 5: UI — mirror fields on Session + `session:merging` WsEvent
+
+**Files:**
+- Modify: `ui/src/lib/types.ts` (Session `197-226`, WsEvent `313-334`)
+- Modify test factories: `ui/src/lib/components/herd-partition.test.ts:5-33`, `ui/src/lib/components/merge-train.test.ts`, `ui/src/lib/store.svelte.test.ts`
+
+- [ ] **Step 1: Add the fields + event**
+
+In `ui/src/lib/types.ts`, after `readyToMerge` in `interface Session` (`213`):
+
+```typescript
+  readyToMerge: boolean;
+  /** Epoch ms when a merge train marked this PR-session in-flight; null when not.
+   *  Transient — cleared server-side on merge/close, train archive, or TTL. */
+  mergingSince: number | null;
+  /** Id of the owning merge-train session; null when not merging. */
+  mergingTrainId: string | null;
+```
+
+In the `WsEvent` union, after the `session:ready` line (`316`):
+
+```typescript
+  | { event: "session:ready"; data: { id: string; ready: boolean } }
+  | { event: "session:merging"; data: { id: string; since: number | null } }
+```
+
+- [ ] **Step 2: Update the test session factories**
+
+In each of the three test files, add the two fields to the `Session` literal returned by the local `session(...)` helper (so it still satisfies the type). e.g. in `herd-partition.test.ts` after `readyToMerge,` (`21`):
+
+```typescript
+    readyToMerge,
+    mergingSince: null,
+    mergingTrainId: null,
+```
+
+Apply the same two lines to the session factory in `merge-train.test.ts` and `ui/src/lib/store.svelte.test.ts` (wherever each builds a full `Session`).
+
+- [ ] **Step 3: Verify type-check passes**
+
+Run: `cd ui && bun run check`
+Expected: PASS (no missing-property errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/lib/types.ts ui/src/lib/components/herd-partition.test.ts ui/src/lib/components/merge-train.test.ts ui/src/lib/store.svelte.test.ts
+git commit -m "feat(ui): mirror mergingSince/mergingTrainId + session:merging event"
+```
+
+---
+
+## Task 6: UI — store applies `session:merging`; `api.startMergeTrain`
+
+**Files:**
+- Modify: `ui/src/lib/store.svelte.ts` (apply switch, after `session:ready` at `134`)
+- Modify: `ui/src/lib/api.ts` (after `setReadyToMerge` at `295`)
+- Test: `ui/src/lib/store.svelte.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `ui/src/lib/store.svelte.test.ts` (match the file's existing store-construction + `apply` style):
+
+```typescript
+test("session:merging sets and clears the mark", () => {
+  const store = makeStore([session("a")]); // existing helper in this file
+  store.apply({ event: "session:merging", data: { id: "a", since: 111 } });
+  expect(store.byId("a")!.mergingSince).toBe(111);
+  store.apply({ event: "session:merging", data: { id: "a", since: null } });
+  expect(store.byId("a")!.mergingSince).toBeNull();
+  expect(store.byId("a")!.mergingTrainId).toBeNull();
+});
+```
+
+> Use whatever store factory + accessor this test file already uses (`makeStore`, `byId`, etc.). The assertion is: a `since` number sets `mergingSince`; `since: null` clears both `mergingSince` and `mergingTrainId`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ui && bun run test -- store.svelte`
+Expected: FAIL — `session:merging` falls through to the global handler, no patch applied.
+
+- [ ] **Step 3: Implement the apply case**
+
+In `ui/src/lib/store.svelte.ts`, after the `session:ready` case (`130-134`):
+
+```typescript
+      case "session:merging":
+        this.sessions = this.sessions.map((s) =>
+          s.id === ev.data.id
+            ? {
+                ...s,
+                mergingSince: ev.data.since,
+                mergingTrainId: ev.data.since === null ? null : s.mergingTrainId,
+              }
+            : s,
+        );
+        break;
+```
+
+- [ ] **Step 4: Add the api client function**
+
+In `ui/src/lib/api.ts`, after `setReadyToMerge` (`295`):
+
+```typescript
+/** Flag a launched merge train's scoped ready PRs as "merging". Fire-and-forget
+ *  shape like setReadyToMerge — live state returns via the session:merging WS
+ *  event; marking is cosmetic, so a failure must not abort the train launch. */
+export async function startMergeTrain(ids: string[], trainId: string): Promise<void> {
+  const r = await fetch("/api/merge-train/start", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ ids, trainId }),
+  });
+  if (!r.ok) throw await failed(r, "merge-train");
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd ui && bun run test -- store.svelte`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/lib/store.svelte.ts ui/src/lib/api.ts ui/src/lib/store.svelte.test.ts
+git commit -m "feat(ui): apply session:merging + startMergeTrain client"
+```
+
+---
+
+## Task 7: UI — `isMerging` helper + `MERGE_STALE_MS`
+
+**Files:**
+- Modify: `ui/src/lib/components/merge-train.ts` (top of file)
+- Test: `ui/src/lib/components/merge-train.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `ui/src/lib/components/merge-train.test.ts`:
+
+```typescript
+import { isMerging, MERGE_STALE_MS } from "./merge-train";
+
+function mergingSession(mergingSince: number | null): Session {
+  return { ...session("m"), mergingSince, mergingTrainId: mergingSince ? "t" : null };
+}
+
+test("isMerging: true when marked and within TTL, false when null or stale", () => {
+  const now = 1_000_000_000;
+  expect(isMerging(mergingSession(null), now)).toBe(false);
+  expect(isMerging(mergingSession(now - 1000), now)).toBe(true);
+  expect(isMerging(mergingSession(now - MERGE_STALE_MS - 1), now)).toBe(false);
+});
+```
+
+> Reuse the existing `session(...)` factory in this test file (the one updated in Task 5). If it isn't exported/shared, add a minimal local factory with the full `Session` shape.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ui && bun run test -- merge-train`
+Expected: FAIL — `isMerging` not exported.
+
+- [ ] **Step 3: Implement**
+
+At the top of `ui/src/lib/components/merge-train.ts`, after the import line (`1`):
+
+```typescript
+import type { Session, GitState } from "$lib/types";
+
+/** Merge-train marks older than this read as stale (the row falls back to its
+ *  prior state) so a stuck PR never sticks visually even if the server's TTL
+ *  sweep is briefly behind. Mirrors MERGE_STALE_MS in src/service.ts. */
+export const MERGE_STALE_MS = 30 * 60_000;
+
+/** True when a session is in a currently-running merge train: marked and the
+ *  mark is still within the TTL. `now` injectable for tests. */
+export function isMerging(s: Session, now: number = Date.now()): boolean {
+  return s.mergingSince !== null && now - s.mergingSince < MERGE_STALE_MS;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ui && bun run test -- merge-train`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/lib/components/merge-train.ts ui/src/lib/components/merge-train.test.ts
+git commit -m "feat(ui): isMerging helper + MERGE_STALE_MS"
+```
+
+---
+
+## Task 8: UI — partition `merging` bucket above `ready`
+
+**Files:**
+- Modify: `ui/src/lib/components/herd-partition.ts` (`26-63` + doc comment `1-25`)
+- Test: `ui/src/lib/components/herd-partition.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `ui/src/lib/components/herd-partition.test.ts`:
+
+```typescript
+test("merging sessions land in merging, pulled out of ready; merged still wins", () => {
+  const now = 1_000_000_000;
+  const m1 = { ...session("m1", true), mergingSince: now - 1000, mergingTrainId: "t" };
+  const m2 = { ...session("m2", true), mergingSince: now - 1000, mergingTrainId: "t" };
+  const list = [session("r1", true), m1, m2];
+  const { ready, merging } = partitionSessions(list, { m2: git("merged") }, () => false, now);
+  expect(merging.map((s) => s.id)).toEqual(["m1"]); // m2 merged → merged group
+  expect(ready.map((s) => s.id)).toEqual(["r1"]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ui && bun run test -- herd-partition`
+Expected: FAIL — `merging` not in the returned shape / extra arg ignored.
+
+- [ ] **Step 3: Implement**
+
+In `ui/src/lib/components/herd-partition.ts`, import `isMerging`:
+
+```typescript
+import type { Session, GitState } from "$lib/types";
+import { isMerging } from "./merge-train";
+```
+
+Add a `now` param (so the TTL is testable), the `merging` array to the return type and locals, and the branch above `ready`:
+
+```typescript
+export function partitionSessions(
+  sessions: Session[],
+  git: Record<string, GitState>,
+  isReviewing: (id: string) => boolean = () => false,
+  now: number = Date.now(),
+): {
+  active: Session[];
+  ciRunning: Session[];
+  ciFailed: Session[];
+  reviewerRunning: Session[];
+  awaitingMerge: Session[];
+  merging: Session[];
+  ready: Session[];
+  merged: Session[];
+} {
+  const active: Session[] = [];
+  const ciRunning: Session[] = [];
+  const ciFailed: Session[] = [];
+  const reviewerRunning: Session[] = [];
+  const awaitingMerge: Session[] = [];
+  const merging: Session[] = [];
+  const ready: Session[] = [];
+  const merged: Session[] = [];
+  for (const s of sessions) {
+    const g = git[s.id];
+    if (g?.state === "merged") merged.push(s);
+    else if (isMerging(s, now)) merging.push(s);
+    else if (s.readyToMerge) ready.push(s);
+    else if (isReviewing(s.id)) reviewerRunning.push(s);
+    else if (g?.state === "open" && g.checks === "pending") ciRunning.push(s);
+    else if (g?.state === "open" && g.checks === "failure") ciFailed.push(s);
+    else if (
+      g?.state === "open" &&
+      g.checks === "success" &&
+      s.status !== "running" &&
+      s.status !== "blocked"
+    )
+      awaitingMerge.push(s);
+    else active.push(s);
+  }
+  return { active, ciRunning, ciFailed, reviewerRunning, awaitingMerge, merging, ready, merged };
+}
+```
+
+Update the doc comment (`1-25`): add `merging` to the group list and the precedence line so it reads `merged > merging > ready > reviewerRunning > ciRunning > ciFailed > awaitingMerge > active`, and the render-order line to `… awaitingMerge → merging → ready → merged`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ui && bun run test -- herd-partition`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/lib/components/herd-partition.ts ui/src/lib/components/herd-partition.test.ts
+git commit -m "feat(ui): partition merging group above ready-to-merge"
+```
+
+---
+
+## Task 9: UI — MERGING badge + amber pip + `status_merging` key
+
+**Files:**
+- Modify: `ui/src/lib/components/UnitRow.svelte` (badge `160-168`, import `9`, pip `131-132`, badge CSS `489-495`)
+- Modify: `ui/src/lib/components/StatusPip.svelte` (props + render + style)
+- Modify: `ui/messages/en.json` + `ui/messages/de.json`
+- Test: `ui/src/lib/components/UnitRow.browser.test.ts` (create if absent, else extend)
+
+- [ ] **Step 1: Add the i18n key (both locales)**
+
+In `ui/messages/en.json`, next to `status_ready_to_merge` (`42`):
+
+```json
+  "status_ready_to_merge": "READY",
+  "status_merging": "MERGING",
+```
+
+In `ui/messages/de.json`, add the same key alongside its `status_ready_to_merge`:
+
+```json
+  "status_merging": "MERGE LÄUFT",
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add a browser test asserting the MERGING badge renders for a merging session. Mirror the harness in `ui/src/lib/components/Herd.browser.test.ts` (render a `UnitRow` with a session whose `mergingSince` is recent), then:
+
+```typescript
+import { render } from "vitest-browser-svelte";
+import UnitRow from "./UnitRow.svelte";
+
+it("shows MERGING for a merging session, not READY", async () => {
+  const s = { ...baseSession(), readyToMerge: true, mergingSince: Date.now(), mergingTrainId: "t" };
+  const screen = render(UnitRow, { session: s, selected: false, nowMs: Date.now(), onselect: () => {} });
+  await expect.element(screen.getByText("MERGING")).toBeInTheDocument();
+  expect(screen.container.textContent).not.toContain("READY");
+});
+```
+
+> Use the same render harness / `baseSession()` shape the existing browser tests use. The assertion: a recently-marked merging session shows MERGING and not READY.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd ui && bun run test -- UnitRow`
+Expected: FAIL — still renders READY.
+
+- [ ] **Step 4: Implement the badge branch**
+
+In `ui/src/lib/components/UnitRow.svelte`, import `isMerging` (`9` area):
+
+```typescript
+  import { elapsed, STATUS_COLOR, statusLabel, hideStatusBadge } from "$lib/format";
+  import { isMerging } from "./merge-train";
+```
+
+Replace the badge block (`164-168`) so merging wins ahead of ready:
+
+```svelte
+      {#if isMerging(session, nowMs)}
+        <span class="badge merging">{m.status_merging()}</span>
+      {:else if session.readyToMerge}
+        <span class="badge">{m.status_ready_to_merge()}</span>
+      {:else if !hideStatus}
+        <span class="badge">{statusLabel(session.status)}</span>
+      {/if}
+```
+
+Pass merging to the pip (`131-132`):
+
+```svelte
+    <div class="pip-col">
+      <StatusPip status={session.status} ready={session.readyToMerge} merging={isMerging(session, nowMs)} />
+    </div>
+```
+
+Add the amber pulsing badge style after the `.badge` rule (`489-495`):
+
+```css
+  /* MERGING: the one colored, moving badge — amber + pulse marks the in-flight
+     merge train, louder than the quiet muted text badges around it. */
+  .badge.merging {
+    color: var(--color-amber);
+    animation: pip-pulse 1.5s ease-out infinite;
+  }
+```
+
+- [ ] **Step 5: Implement the pip variant**
+
+In `ui/src/lib/components/StatusPip.svelte`, add the `merging` prop (`5`) and let it take priority — an amber pulsing dot:
+
+```svelte
+  let {
+    status,
+    ready = false,
+    merging = false,
+  }: { status: SessionStatus; ready?: boolean; merging?: boolean } = $props();
+  const color = $derived(
+    merging ? "var(--color-amber)" : ready ? "var(--color-green)" : STATUS_COLOR[status],
+  );
+```
+
+In the markup, add a first branch before the `{#if ready}`:
+
+```svelte
+{#if merging}
+  <span class="pip pulse" style="--c:{color}" role="img" aria-label={label} title={label}></span>
+{:else if ready}
+  <span class="pip check" style="--c:{color}" aria-hidden="true">✓</span>
+{:else if status === "blocked"}
+```
+
+(The `label` derivation already exists; reuse it.)
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd ui && bun run test -- UnitRow`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ui/src/lib/components/UnitRow.svelte ui/src/lib/components/StatusPip.svelte ui/messages/en.json ui/messages/de.json ui/src/lib/components/UnitRow.browser.test.ts
+git commit -m "feat(ui): amber pulsing MERGING badge + pip"
+```
+
+---
+
+## Task 10: UI — "Merging" group in Herd.svelte + `herd_merging_group` key
+
+**Files:**
+- Modify: `ui/src/lib/components/Herd.svelte` (group block before `ready` at `162`, style after `.awaiting-head,.ready-head` at `308-316`)
+- Modify: `ui/messages/en.json` + `ui/messages/de.json`
+- Test: `ui/src/lib/components/Herd.browser.test.ts`
+
+- [ ] **Step 1: Add the i18n key (both locales)**
+
+In `ui/messages/en.json`, next to `herd_ready_group` (`163`):
+
+```json
+  "herd_merging_group": "Merging ({count})",
+```
+
+In `ui/messages/de.json`, next to its `herd_ready_group`:
+
+```json
+  "herd_merging_group": "Merge läuft ({count})",
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `ui/src/lib/components/Herd.browser.test.ts`:
+
+```typescript
+it("renders a Merging group for in-train sessions", async () => {
+  const s = { ...baseSession("m1"), readyToMerge: true, mergingSince: Date.now(), mergingTrainId: "t" };
+  const screen = render(Herd, {
+    sessions: [s],
+    selectedId: null,
+    nowMs: Date.now(),
+    onselect: () => {},
+    onnew: () => {},
+    git: { m1: { kind: "github", state: "open", checks: "success", deployConfigured: false } },
+    activity: {},
+  });
+  await expect.element(screen.getByText(/Merging \(1\)/)).toBeInTheDocument();
+});
+```
+
+> Reuse this file's existing render harness + `baseSession`.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd ui && bun run test -- Herd`
+Expected: FAIL — no Merging group.
+
+- [ ] **Step 4: Implement the group block**
+
+In `ui/src/lib/components/Herd.svelte`, insert before the `{#if partition.ready.length > 0}` block (`163`):
+
+```svelte
+      {#if partition.merging.length > 0}
+        <div class="merging-head micro">
+          {m.herd_merging_group({ count: partition.merging.length })}
+        </div>
+        {#each partition.merging as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            activity={activity[session.id]}
+            {ondecommission}
+          />
+        {/each}
+      {/if}
+```
+
+Add the amber header style. Extend the existing amber-header rule selector (`286-287`) to include `.merging-head`:
+
+```css
+  .ci-head,
+  .reviewing-head,
+  .merging-head {
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd ui && bun run test -- Herd`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/lib/components/Herd.svelte ui/messages/en.json ui/messages/de.json ui/src/lib/components/Herd.browser.test.ts
+git commit -m "feat(ui): Merging group above Ready-to-merge"
+```
+
+---
+
+## Task 11: UI — fire `startMergeTrain` from `onmergetrain`
+
+**Files:**
+- Modify: `ui/src/routes/+page.svelte` (`onmergetrain` `243-267`, import `48`)
+
+`+page.svelte` is integration glue (no direct unit test). The store/api/badge pieces are tested above; this is verified by the manual smoke in Task 15.
+
+- [ ] **Step 1: Implement the wiring**
+
+In `ui/src/routes/+page.svelte`, add `startMergeTrain` to the api import (`48` is the merge-train helpers import; the api functions are imported elsewhere — add to the `$lib/api` import):
+
+```typescript
+import { /* …existing… */ createSession, startMergeTrain } from "$lib/api";
+```
+
+> Add `startMergeTrain` to whichever existing `from "$lib/api"` import statement already brings in `createSession`.
+
+In `onmergetrain`, after `selectedId = s.id;` (`259`), mark the scoped PRs. The `prs` list (`ReadyPr[]`) carries PR numbers, not session ids — re-derive the session ids from the same scoped repo so the mark targets exactly the train's sessions:
+
+```typescript
+      const s = await createSession({
+        repoPath,
+        baseBranch,
+        prompt: m.herd_merge_train_prompt({ prs: formatReadyPrs(prs) }),
+        model: null,
+      });
+      selectedId = s.id;
+      // Mark this repo's ready PR-sessions as "merging" so the list shows them
+      // in-flight. Fire-and-forget + fail-soft: a marking error must not abort
+      // the launch — the train (session s) is already running. The scoped set is
+      // the ready-to-merge sessions in this repo with an open PR.
+      const ids = store.sessions
+        .filter((x) => x.repoPath === repoPath && x.readyToMerge && store.git[x.id]?.state === "open")
+        .map((x) => x.id);
+      startMergeTrain(ids, s.id).catch(() => toasts.info(m.toast_merge_train_mark_failed()));
+      showBacklog = false;
+      if (mobile.current) mobileScreen = "detail";
+```
+
+- [ ] **Step 2: Add the fail-soft toast key (both locales)**
+
+In `ui/messages/en.json`, next to `toast_merge_train_failed`:
+
+```json
+  "toast_merge_train_mark_failed": "Merge train started, but marking its PRs failed.",
+```
+
+In `ui/messages/de.json`:
+
+```json
+  "toast_merge_train_mark_failed": "Merge-Train gestartet, aber das Markieren der PRs ist fehlgeschlagen.",
+```
+
+- [ ] **Step 3: Verify type-check + lint**
+
+Run: `cd ui && bun run check && bun run lint`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/routes/+page.svelte ui/messages/en.json ui/messages/de.json
+git commit -m "feat(ui): mark scoped PRs merging when the train launches"
+```
+
+---
+
+## Task 12: Feature-discovery catalog entry
+
+**Files:**
+- Modify: `ui/src/lib/feature-announcements.ts` (`18-58`)
+- Modify: `ui/messages/en.json` + `ui/messages/de.json`
+
+- [ ] **Step 1: Add the catalog entry**
+
+In `ui/src/lib/feature-announcements.ts`, append to `featureAnnouncements` (after the `merge-train-shortcut` entry at `57`):
+
+```typescript
+  {
+    id: "merge-train-in-progress",
+    sinceVersion: "1.17.0",
+    titleKey: "feat_merge_in_progress_title",
+    bodyKey: "feat_merge_in_progress_body",
+  },
+```
+
+> Confirm `sinceVersion`: root `package.json` is `1.16.0`; the merge-train-shortcut entry already targets `1.17.0`, so this ships in the same `1.17.0` line. If the next release tag has moved by implementation time, match the merge-train-shortcut entry's `sinceVersion`.
+
+- [ ] **Step 2: Add the message keys (both locales)**
+
+In `ui/messages/en.json`, next to `feat_merge_train_body` (`139`):
+
+```json
+  "feat_merge_in_progress_title": "Merge train shows progress",
+  "feat_merge_in_progress_body": "When you start a merge train, the PRs it's working through move into a Merging group with an amber badge instead of staying in Ready to merge — and each clears as it lands.",
+```
+
+In `ui/messages/de.json`, next to its `feat_merge_train_body`:
+
+```json
+  "feat_merge_in_progress_title": "Merge-Train zeigt Fortschritt",
+  "feat_merge_in_progress_body": "Wenn du einen Merge-Train startest, wandern die PRs, die er abarbeitet, mit einem bernsteinfarbenen Badge in eine Merge-läuft-Gruppe statt in „Bereit zum Mergen“ zu bleiben — und jeder verschwindet, sobald er gemergt ist.",
+```
+
+- [ ] **Step 3: Verify the i18n + catalog gates**
+
+Run: `cd ui && bun run check:i18n` then `cd .. && bash scripts/check-feature-catalog.sh`
+Expected: both PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/lib/feature-announcements.ts ui/messages/en.json ui/messages/de.json
+git commit -m "feat(ui): announce merge-train progress in feature catalog"
+```
+
+---
+
+## Task 13: Full verification + rebase
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Install deps if missing (fresh worktree)**
+
+```bash
+bun install && (cd ui && bun install)
+```
+
+- [ ] **Step 2: Server gates**
+
+Run: `bunx tsc --noEmit && bun run lint && bun test ./test`
+Expected: all PASS.
+
+- [ ] **Step 3: UI gates**
+
+Run: `cd ui && bun run check && bun run lint && bun run test`
+Expected: all PASS (includes `check:i18n` if wired into `check`; if not, run `bun run check:i18n` separately).
+
+- [ ] **Step 4: Feature-catalog + branch-hygiene gates**
+
+Run: `bash scripts/check-feature-catalog.sh && bash scripts/check-branch-hygiene.sh`
+Expected: both PASS.
+
+- [ ] **Step 5: Rebase onto latest main (shared main has advanced to #360+)**
+
+```bash
+git fetch origin
+git rebase origin/main
+bun install && (cd ui && bun install)   # reinstall after rebase (new deps on main)
+```
+Re-run Steps 2–4 after the rebase. Resolve any conflicts (most likely in `ui/messages/*.json`, `feature-announcements.ts`, `src/server.ts` handler array, `src/store.ts` COLS — all additive).
+
+- [ ] **Step 6: Manual smoke (real app)**
+
+Use the `verify` skill / `bun run update` to run the live app: park ≥2 PRs as ready-to-merge in one repo, click **Merge train**, confirm the parked PRs jump to a **Merging** group with an amber pulsing badge while the train session runs, and that each row leaves the group as its PR merges.
+
+- [ ] **Step 7: Open the PR**
+
+Only after all gates pass. PR title: `feat(ui): show merge-train PRs as Merging in the session list`.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** data model (T1), server set/clear/sweep + event (T2), endpoint (T3), three clear triggers (T4), UI types/event (T5), store+api (T6), `isMerging`/TTL (T7), partition group + precedence (T8), badge+pip (T9), group render (T10), launch wiring (T11), i18n keys folded into T9/T10/T11/T12, feature catalog (T12), gates+rebase (T13). All spec sections map to a task.
+- **Type consistency:** `setMerging(ids, trainId)` / `clearMerging(id)` / `clearMergingForTrain(trainId)` / `sweepStaleMerging(now?)`; `startMergeTrain(ids, trainId)`; `isMerging(s, now?)`; `partitionSessions(…, now?)` returns `{…, merging, ready, …}`; event `session:merging {id, since}`; fields `mergingSince`/`mergingTrainId`. Names consistent across server + UI.
+- **Constant:** `MERGE_STALE_MS = 30*60_000` duplicated in `src/service.ts` and `ui/src/lib/components/merge-train.ts` (cross-package; kept identical — noted in both doc comments).

--- a/docs/superpowers/specs/2026-06-08-merge-train-in-progress-marker-design.md
+++ b/docs/superpowers/specs/2026-06-08-merge-train-in-progress-marker-design.md
@@ -1,0 +1,160 @@
+# Merge-train "Merging" in-progress marker
+
+**Date:** 2026-06-08
+**Status:** Approved (design)
+
+## Problem
+
+The "Merge train" shortcut (in the Ready-to-merge group header, #359) launches a
+new agent session that merges the repo's ready PRs in sequence. While that train
+runs, the PRs it is working through keep their green **READY** badge and stay in
+the "Ready to merge" group. The operator gets no signal that those PRs are now
+in flight — they look identical to PRs nobody has touched, and a second train or
+manual merge could be kicked off against the same set.
+
+Mark the PRs that a launched train is working through as **Merging**: pull them
+into their own group with an amber, pulsing badge, and clear the mark per-PR as
+each one actually lands.
+
+## Mechanism constraint
+
+The train runs **entirely client-side** as a Claude agent session — the server
+never learns a train is in flight on its own. So the client, which already knows
+exactly which PR-sessions it scoped into the train (`collectReadyPrs` /
+`pickTrainRepo`), must tell the server. The server is then authoritative:
+persists the mark, broadcasts it, and owns clearing. This gives refresh
+resilience and cross-device sync (chosen over a client-only store).
+
+## Data model
+
+Two transient fields on `Session` (both server `src/types.ts` and UI
+`ui/src/lib/types.ts`), mirroring the existing `readyToMerge` / `autopilotQuestion`
+nullable-transient patterns:
+
+- `mergingSince: number | null` — epoch ms when the train marked this PR; `null`
+  when not merging.
+- `mergingTrainId: string | null` — id of the merge-train session that owns this
+  mark. Powers set-clearing when that train session is archived (see Clear #2).
+
+### Persistence (`src/store.ts`)
+
+Follow the `readyToMerge` column exactly:
+- `migrateSessionColumns()`: `ALTER TABLE sessions ADD COLUMN mergingSince INTEGER`
+  and `... mergingTrainId TEXT` (both nullable, no default).
+- Insert defaults: `mergingSince = null`, `mergingTrainId = null`.
+- `update()` patch `Pick<>`: add both fields, and include them in the `UPDATE`
+  statement column list.
+- `hydrate()`: `mergingSince: r.mergingSince ?? null`, `mergingTrainId: r.mergingTrainId ?? null`.
+- `NewSession` omit list: add both.
+
+## Server flow
+
+### Set
+- **Service** (`src/service.ts`): `setMerging(ids: string[], trainId: string)` —
+  for each id `store.update(id, { mergingSince: Date.now(), mergingTrainId: trainId })`
+  and `events.emit("session:merging", { id, since })`.
+- **Endpoint** (`src/server.ts`): `POST /api/merge-train/start`, body
+  `{ ids: string[]; trainId: string }`. Validate JSON content-type + shape
+  (mirror `handleSessionReady`). Unknown ids are skipped (not an error — the set
+  is best-effort). Returns `{ ok: true }`.
+
+### Clear
+A single helper `clearMerging(id)` does `store.update(id, { mergingSince: null,
+mergingTrainId: null })` + `emit("session:merging", { id, since: null })`. Three
+triggers, in order of how they fire in practice:
+
+1. **Per-PR on merge (primary, visible):** subscriber on `session:git` — when a
+   session that has `mergingSince` set transitions to `git.state === "merged"`
+   or `"closed"`, `clearMerging(id)`. PRs visibly resolve one-by-one as the
+   train works. (Lives alongside the existing `session:git` consumers; covers
+   all sessions, not just `auto` ones like `drain.onGit`.)
+2. **Train archived (straggler set-clear):** subscriber on `session:archived` —
+   clear every session whose `mergingTrainId` equals the archived session's id.
+   Keyed on **archived** (a terminal state), deliberately **not** `done`/idle:
+   a Claude pane reports `done` when it finishes a turn and sits at the train's
+   human approval gate — clearing there would wipe the marks mid-train.
+3. **TTL backstop:** `PrPoller.tick()` sweep — any session with `mergingSince`
+   older than `MERGE_STALE_MS` (30 min) gets `clearMerging`. Guarantees a
+   rejected/held-back PR (never merged, train never archived) can't stay marked
+   forever. 30 min comfortably exceeds a slow real train (sequential merges +
+   re-check + approval gate); it only bounds rejected-PR cleanup latency.
+
+### Broadcast
+One event reused for set and clear: `session:merging` `{ id, since: number | null }`
+(`null` = cleared). Flows through the existing `EventHub → WebSocket` pipeline
+(`src/events.ts`, `src/server.ts` `/events`). Add `session:merging` to the
+server `WsEvent` union.
+
+## UI flow
+
+### Launch wiring (`ui/src/routes/+page.svelte` `onmergetrain`)
+After `createSession(...)` resolves, call `api.startMergeTrain(prSessionIds, train.id)`
+with the ids from the already-collected `prs` list. Marking failure is
+**fail-soft**: toast the error, the train still runs — only the badges are
+degraded. (The train launch itself is the load-bearing action; marking is
+cosmetic.)
+
+### Client (`ui/src/lib/api.ts`, types, store)
+- `api.startMergeTrain(ids: string[], trainId: string): Promise<void>` — `POST`
+  to `/api/merge-train/start`, fire-and-forget shape like `setReadyToMerge`.
+- `ui/src/lib/types.ts`: add the two `Session` fields; add `session:merging` to
+  the `WsEvent` union.
+- `ui/src/lib/store.svelte.ts`: handle `session:merging` — patch the row's
+  `mergingSince` (and clear `mergingTrainId` when `since` is null). No refetch,
+  same as `session:ready`.
+- `isMerging(s)` helper (in `merge-train.ts`): `s.mergingSince != null &&
+  Date.now() - s.mergingSince < MERGE_STALE_MS`. The client-side staleness guard
+  mirrors the server TTL so a stale flag never renders even if the server sweep
+  is briefly behind.
+
+### Partition (`ui/src/lib/components/herd-partition.ts`)
+Add a `merging` bucket. Priority: `merged > merging > ready > reviewerRunning >
+ciRunning > ciFailed > awaitingMerge > active`. `else if (isMerging(s))` sits
+**above** the `readyToMerge` branch so in-train PRs are pulled out of "Ready to
+merge". (A PR that has actually merged still wins the `merged` bucket — and its
+mark is cleared by Clear #1 anyway.)
+
+### Render
+- **Group** (`ui/src/lib/components/Herd.svelte`): a new "Merging" group section
+  rendered above "Ready to merge", mirroring the ready group's markup (header +
+  count + rows). Header copy: **"Merging"**.
+- **Badge** (`ui/src/lib/components/UnitRow.svelte`): an amber, pulsing
+  **MERGING** badge, branched ahead of the `readyToMerge` → READY branch
+  (`{#if isMerging(session)} … {:else if session.readyToMerge} …`).
+- **Color/pip** (`ui/src/lib/format.ts`): amber for the merging state; pip
+  variant with a subtle pulse (reuse the existing "working" amber + pulse
+  treatment for visual consistency).
+
+## House-rule obligations (same PR)
+
+- **i18n** (`ui/messages/en.json` + `de.json`, parity enforced by `check:i18n`):
+  - `status_merging` — the badge label.
+  - `herd_merging_group` — the group header ("Merging").
+  - a count key if the group header shows a count (match how the ready group does it).
+- **Feature catalog** (`ui/src/lib/feature-announcements.ts`): one
+  `FeatureAnnouncement` (stable kebab `id`, `sinceVersion` = the shipping
+  release, `titleKey` + `bodyKey`), plus those two message keys in both locales.
+  This is user-facing UI, so the catalog gate requires it.
+
+## Out of scope / YAGNI
+
+- No "cancel merge train" control. (Marks clear via merge / archive / TTL.)
+- No server-side execution of the train; it stays a client-launched agent session.
+- No per-PR progress beyond merged/not — the badge is binary "in this train".
+
+## Testing
+
+- **Server unit:** `setMerging` stamps + emits for each id and skips unknowns;
+  `session:git` merged/closed clears one PR; `session:archived` clears the whole
+  train set by `mergingTrainId`; TTL sweep clears a session past `MERGE_STALE_MS`
+  and leaves a fresh one. Persistence round-trip (set → hydrate) keeps the fields.
+- **UI unit:** `isMerging` respects the TTL boundary; `herd-partition` routes a
+  merging session into the merging bucket and out of ready, and a merged session
+  still wins `merged`; store applies `session:merging` set and clear.
+- **i18n/catalog gates:** `cd ui && bun run check:i18n` and
+  `scripts/check-feature-catalog.sh` pass.
+
+## Open questions
+
+None — TTL 30 min, amber pulse badge, header "Merging", dedicated
+`POST /api/merge-train/start` endpoint all confirmed.

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,28 @@ events.subscribe((event, data) => {
   if (status !== "running") prPoller.pollSession(id);
 });
 
+// A PR in a merge train just landed (or was closed) → drop its "Merging" mark
+// so the row resolves out of the Merging group one-by-one as the train works.
+// session:git fires on any git change; clearMerging no-ops when not marked.
+events.subscribe((event, data) => {
+  if (event !== "session:git") return;
+  const { id, git } = data as { id: string; git: import("./forge/types").GitState };
+  if (git.state === "merged" || git.state === "closed") service.clearMerging(id);
+});
+
+// The train session itself was archived → clear any of its PRs still marked
+// (e.g. ones it held back / rejected and never merged). Keyed on archive (a
+// terminal state), NOT done/idle — a Claude pane reports done at the train's
+// approval gate, where clearing would wipe the marks mid-train.
+events.subscribe((event, data) => {
+  if (event !== "session:archived") return;
+  service.clearMergingForTrain((data as { id: string }).id);
+});
+
+// Backstop sweep: drop marks older than the TTL so a stuck/rejected PR can't
+// stay "Merging" forever when neither of the above fires.
+setInterval(() => service.sweepStaleMerging(), 60_000);
+
 // Hourly: delete local shepherd/* branches whose PR has merged. The merge train
 // squash-merges, so the at-archive ancestry prune (worktree.ts) never catches
 // them and they pile up — and at merge time the session still holds the worktree

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,11 @@ events.subscribe((event, data) => {
 });
 
 // Backstop sweep: drop marks older than the TTL so a stuck/rejected PR can't
-// stay "Merging" forever when neither of the above fires.
+// stay "Merging" forever when neither of the above fires. Expected dwell: a PR
+// the train holds back (never merged, train not yet archived) keeps the amber
+// MERGING badge until the operator archives the train session, else up to
+// MERGE_STALE_MS (~30 min). There is no per-PR "rejected" signal — an accepted
+// cosmetic trade-off, fine while held-back PRs are rare; revisit if they aren't.
 setInterval(() => service.sweepStaleMerging(), 60_000);
 
 // Hourly: delete local shepherd/* branches whose PR has merged. The merge train

--- a/src/server.ts
+++ b/src/server.ts
@@ -1232,6 +1232,28 @@ async function handleBroadcast({ req, parts, deps }: Ctx): Promise<Response | nu
   return null;
 }
 
+// POST /api/merge-train/start — mark a launched train's ready PRs as "merging".
+// The train itself runs client-side as an agent session; this only flags the
+// scoped PR-sessions so the list shows them in-flight. Body: {ids, trainId}.
+async function handleMergeTrain({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(parts[0] === "api" && parts[1] === "merge-train" && parts[2] === "start" && !parts[3]))
+    return null;
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+  const body = (await req.json().catch(() => null)) as { ids?: unknown; trainId?: unknown } | null;
+  if (
+    !body ||
+    !Array.isArray(body.ids) ||
+    !body.ids.every((x) => typeof x === "string") ||
+    typeof body.trainId !== "string"
+  ) {
+    return json({ error: "body must be {ids: string[], trainId: string}" }, 400);
+  }
+  deps.service.setMerging(body.ids as string[], body.trainId);
+  return json({ ok: true });
+}
+
 // ── halt the herd: interrupt every live working agent at once ──
 function handleHalt({ req, parts, deps }: Ctx): Response | null {
   if (parts[0] !== "api" || parts[1] !== "halt" || parts[2]) return null;
@@ -1692,6 +1714,7 @@ const ROUTE_HANDLERS = [
   handleSteers,
   handleProjectIcons,
   handleBroadcast,
+  handleMergeTrain,
   handleHalt,
   handleFsDirs,
   handleBranches,

--- a/src/service.ts
+++ b/src/service.ts
@@ -11,6 +11,11 @@ import { slugifyManual } from "./namer";
 import type { Leftover, ProcessReaper } from "./process-reaper";
 import { planHouseRulesInjection, renderHouseRulesBlock } from "./house-rules";
 
+/** A merge-train mark older than this is treated as stale and swept, so a
+ *  rejected/held-back PR (never merged, train never archived) can't stay
+ *  "Merging" forever. Mirrored in ui/src/lib/components/merge-train.ts. */
+export const MERGE_STALE_MS = 30 * 60_000;
+
 export interface ServiceDeps {
   store: SessionStore;
   worktree: Pick<
@@ -495,6 +500,45 @@ export class SessionService {
   setReadyToMerge(id: string, ready: boolean): void {
     this.deps.store.update(id, { readyToMerge: ready });
     this.deps.events?.emit("session:ready", { id, ready });
+  }
+
+  /**
+   * Mark each session as part of a launched merge train (the client passes the
+   * scoped ready-PR ids). Stamps `mergingSince`/`mergingTrainId`, persists, and
+   * pushes `session:merging` so every client patches the row live. Unknown ids
+   * are skipped (best-effort: the set is cosmetic, never load-bearing).
+   */
+  setMerging(ids: string[], trainId: string): void {
+    const since = Date.now();
+    for (const id of ids) {
+      if (!this.deps.store.get(id)) continue;
+      this.deps.store.update(id, { mergingSince: since, mergingTrainId: trainId });
+      this.deps.events?.emit("session:merging", { id, since });
+    }
+  }
+
+  /** Clear one session's merge-train mark. No-op (no event) when not marked. */
+  clearMerging(id: string): void {
+    const s = this.deps.store.get(id);
+    if (!s || s.mergingSince === null) return;
+    this.deps.store.update(id, { mergingSince: null, mergingTrainId: null });
+    this.deps.events?.emit("session:merging", { id, since: null });
+  }
+
+  /** Clear every session marked by a given train (its session was archived). */
+  clearMergingForTrain(trainId: string): void {
+    for (const s of this.deps.store.list({ activeOnly: true })) {
+      if (s.mergingTrainId === trainId) this.clearMerging(s.id);
+    }
+  }
+
+  /** Backstop: clear marks older than MERGE_STALE_MS. `now` injectable for tests. */
+  sweepStaleMerging(now: number = Date.now()): void {
+    for (const s of this.deps.store.list({ activeOnly: true })) {
+      if (s.mergingSince !== null && now - s.mergingSince > MERGE_STALE_MS) {
+        this.clearMerging(s.id);
+      }
+    }
   }
 
   /** Leftover subprocesses/proxies that would survive this session's close; [] when none. */

--- a/src/service.ts
+++ b/src/service.ts
@@ -505,15 +505,16 @@ export class SessionService {
   /**
    * Mark each session as part of a launched merge train (the client passes the
    * scoped ready-PR ids). Stamps `mergingSince`/`mergingTrainId`, persists, and
-   * pushes `session:merging` so every client patches the row live. Unknown ids
-   * are skipped (best-effort: the set is cosmetic, never load-bearing).
+   * pushes `session:merging` (carrying `trainId` so the live patch matches a
+   * refetch — the field is server state mirrored on the client). Unknown ids are
+   * skipped (best-effort: the set is cosmetic, never load-bearing).
    */
   setMerging(ids: string[], trainId: string): void {
     const since = Date.now();
     for (const id of ids) {
       if (!this.deps.store.get(id)) continue;
       this.deps.store.update(id, { mergingSince: since, mergingTrainId: trainId });
-      this.deps.events?.emit("session:merging", { id, since });
+      this.deps.events?.emit("session:merging", { id, since, trainId });
     }
   }
 
@@ -522,7 +523,7 @@ export class SessionService {
     const s = this.deps.store.get(id);
     if (!s || s.mergingSince === null) return;
     this.deps.store.update(id, { mergingSince: null, mergingTrainId: null });
-    this.deps.events?.emit("session:merging", { id, since: null });
+    this.deps.events?.emit("session:merging", { id, since: null, trainId: null });
   }
 
   /** Clear every session marked by a given train (its session was archived). */

--- a/src/store.ts
+++ b/src/store.ts
@@ -73,6 +73,8 @@ type NewSession = Omit<
   | "model"
   | "claudeSessionId"
   | "readyToMerge"
+  | "mergingSince"
+  | "mergingTrainId"
   | "autopilotEnabled"
   | "autopilotStepCount"
   | "autopilotPaused"
@@ -90,7 +92,7 @@ const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePat
   isolated, herdrSession, herdrAgentId, claudeSessionId, model, readyToMerge, status, lastState,
   autopilotEnabled, autopilotStepCount, autopilotPaused, autopilotQuestion,
   auto, issueNumber,
-  createdAt, updatedAt, archivedAt`;
+  createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId`;
 
 export class SessionStore implements CapStore {
   private db: Database;
@@ -314,9 +316,11 @@ export class SessionStore implements CapStore {
       createdAt: now,
       updatedAt: now,
       archivedAt: null,
+      mergingSince: null,
+      mergingTrainId: null,
     };
     this.db.run(
-      `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
       [
         s.id,
         s.desig,
@@ -343,6 +347,8 @@ export class SessionStore implements CapStore {
         s.createdAt,
         s.updatedAt,
         s.archivedAt,
+        s.mergingSince,
+        s.mergingTrainId,
       ],
     );
     return s;
@@ -363,14 +369,24 @@ export class SessionStore implements CapStore {
   update(
     id: string,
     patch: Partial<
-      Pick<Session, "name" | "status" | "lastState" | "branch" | "herdrAgentId" | "readyToMerge">
+      Pick<
+        Session,
+        | "name"
+        | "status"
+        | "lastState"
+        | "branch"
+        | "herdrAgentId"
+        | "readyToMerge"
+        | "mergingSince"
+        | "mergingTrainId"
+      >
     >,
   ) {
     const cur = this.get(id);
     if (!cur) return;
     const next = { ...cur, ...patch, updatedAt: Date.now() };
     this.db.run(
-      `UPDATE sessions SET name=?, status=?, lastState=?, branch=?, herdrAgentId=?, readyToMerge=?, updatedAt=? WHERE id=?`,
+      `UPDATE sessions SET name=?, status=?, lastState=?, branch=?, herdrAgentId=?, readyToMerge=?, mergingSince=?, mergingTrainId=?, updatedAt=? WHERE id=?`,
       [
         next.name,
         next.status,
@@ -378,6 +394,8 @@ export class SessionStore implements CapStore {
         next.branch,
         next.herdrAgentId,
         next.readyToMerge ? 1 : 0,
+        next.mergingSince,
+        next.mergingTrainId,
         next.updatedAt,
         id,
       ],
@@ -633,6 +651,8 @@ export class SessionStore implements CapStore {
     add("autopilotQuestion", `autopilotQuestion TEXT`);
     add("auto", `auto INTEGER NOT NULL DEFAULT 0`);
     add("issueNumber", `issueNumber INTEGER`);
+    add("mergingSince", `mergingSince INTEGER`);
+    add("mergingTrainId", `mergingTrainId TEXT`);
   }
 
   // migrate repo_config that predates these opt-in columns. auto-address defaults
@@ -882,6 +902,8 @@ export class SessionStore implements CapStore {
       autopilotQuestion: r.autopilotQuestion ?? null,
       auto: !!r.auto,
       issueNumber: r.issueNumber ?? null,
+      mergingSince: r.mergingSince ?? null,
+      mergingTrainId: r.mergingTrainId ?? null,
     } as Session;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,13 @@ export interface Session {
 
   model: string | null; // claude --model alias; null = claude's own default (no flag)
   readyToMerge: boolean; // manually-toggled "parked / done" flag; orthogonal to status
+  /** Epoch ms when a launched merge train marked this PR-session as in-flight;
+   *  null when not in a train. Transient: cleared on merge/close, train archive,
+   *  or the TTL sweep. */
+  mergingSince: number | null;
+  /** Id of the merge-train session that owns this mark (clears the whole set when
+   *  that session is archived). Null when not merging. */
+  mergingTrainId: string | null;
   /** Autopilot opt-in: true/false override, or null to inherit the repo default. */
   autopilotEnabled: boolean | null;
   /** Count of auto-steers autopilot has spent on this session (runaway guard; reset on PR-open / operator reply). */

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -19,6 +19,8 @@ function sess(over: Partial<Session> = {}): Session {
     claudeSessionId: "cs",
     model: null,
     readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
     autopilotEnabled: true,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -20,6 +20,8 @@ function session(over: Partial<Session> = {}): Session {
     claudeSessionId: "c",
     model: null,
     readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/test/server-diff.test.ts
+++ b/test/server-diff.test.ts
@@ -20,6 +20,8 @@ const SESSION: Session = {
   claudeSessionId: "c1",
   model: null,
   readyToMerge: false,
+  mergingSince: null,
+  mergingTrainId: null,
   autopilotEnabled: null,
   autopilotStepCount: 0,
   autopilotPaused: false,

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -24,6 +24,8 @@ const SESSION: Session = {
   claudeSessionId: "c1",
   model: null,
   readyToMerge: false,
+  mergingSince: null,
+  mergingTrainId: null,
   autopilotEnabled: null,
   autopilotStepCount: 0,
   autopilotPaused: false,

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1309,3 +1309,43 @@ test("POST /api/repos with foreign Origin → 403", async () => {
   );
   expect(res.status).toBe(403);
 });
+
+// ── POST /api/merge-train/start ───────────────────────────────────────────────
+
+test("POST /api/merge-train/start marks sessions as merging", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const s = deps.store.create({
+    name: "x",
+    prompt: "go",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt/x",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_z",
+  });
+  const res = await app.fetch(
+    new Request("http://x/api/merge-train/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ids: [s.id], trainId: "train-7" }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+  expect(deps.store.get(s.id)!.mergingTrainId).toBe("train-7");
+});
+
+test("POST /api/merge-train/start with invalid body → 400", async () => {
+  const app = harness();
+  const res = await app.fetch(
+    new Request("http://x/api/merge-train/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ids: "nope" }),
+    }),
+  );
+  expect(res.status).toBe(400);
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1773,7 +1773,7 @@ test("setMerging stamps each id and emits session:merging; skips unknown ids", a
   expect(store.get(a.id)!.mergingTrainId).toBe("train-9");
   const ev = emitted.filter((e) => e.event === "session:merging");
   expect(ev).toHaveLength(1);
-  expect(ev[0]!.data).toMatchObject({ id: a.id });
+  expect(ev[0]!.data).toMatchObject({ id: a.id, trainId: "train-9" });
   expect(typeof ev[0]!.data.since).toBe("number");
 });
 
@@ -1787,7 +1787,7 @@ test("clearMerging nulls the fields and emits since:null; no-op when not merging
   expect(store.get(a.id)!.mergingSince).toBeNull();
   expect(store.get(a.id)!.mergingTrainId).toBeNull();
   const last = emitted.filter((e) => e.event === "session:merging").at(-1)!;
-  expect(last.data).toEqual({ id: a.id, since: null });
+  expect(last.data).toEqual({ id: a.id, since: null, trainId: null });
 });
 
 test("clearMergingForTrain clears every member of one train, leaves others", async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1,6 +1,11 @@
 import { test, expect } from "bun:test";
 import { SessionStore } from "../src/store";
-import { SessionService, spawnSettingsOverlay, composeSystemPrompt } from "../src/service";
+import {
+  SessionService,
+  spawnSettingsOverlay,
+  composeSystemPrompt,
+  MERGE_STALE_MS,
+} from "../src/service";
 import { HOUSE_RULES_TAG } from "../src/house-rules";
 import { config } from "../src/config";
 
@@ -1720,4 +1725,89 @@ test("archiveMany isolates a failing session: others still clear, the failed id 
   expect(store.get(a.id)?.status).toBe("archived");
   expect(store.get(c.id)?.status).toBe("archived");
   expect(store.get(b.id)?.status).not.toBe("archived"); // b stays active (teardown threw)
+});
+
+function mergeSvc() {
+  const store = new SessionStore(":memory:");
+  const emitted: { event: string; data: any }[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "n",
+    worktree: {
+      create: () => ({ worktreePath: "/wt", branch: "b", isolated: true }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => ({
+        terminalId: "t",
+        cwd: "/",
+        agent: "claude",
+        agentStatus: "idle",
+        paneId: "p",
+        tabId: "x",
+        workspaceId: "w",
+      }),
+      list: () => [],
+      stop: () => {},
+    } as any,
+    events: { emit: (event: string, data: unknown) => emitted.push({ event, data }) } as any,
+  });
+  return { store, service, emitted };
+}
+
+async function mkSession(service: SessionService) {
+  return service.create({
+    repoPath: "/r",
+    baseBranch: "main",
+    prompt: "p",
+    model: null,
+    images: [],
+  });
+}
+
+test("setMerging stamps each id and emits session:merging; skips unknown ids", async () => {
+  const { store, service, emitted } = mergeSvc();
+  const a = await mkSession(service);
+  service.setMerging([a.id, "ghost"], "train-9");
+  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
+  expect(store.get(a.id)!.mergingTrainId).toBe("train-9");
+  const ev = emitted.filter((e) => e.event === "session:merging");
+  expect(ev).toHaveLength(1);
+  expect(ev[0]!.data).toMatchObject({ id: a.id });
+  expect(typeof ev[0]!.data.since).toBe("number");
+});
+
+test("clearMerging nulls the fields and emits since:null; no-op when not merging", async () => {
+  const { store, service, emitted } = mergeSvc();
+  const a = await mkSession(service);
+  service.clearMerging(a.id);
+  expect(emitted.filter((e) => e.event === "session:merging")).toHaveLength(0);
+  service.setMerging([a.id], "t1");
+  service.clearMerging(a.id);
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+  expect(store.get(a.id)!.mergingTrainId).toBeNull();
+  const last = emitted.filter((e) => e.event === "session:merging").at(-1)!;
+  expect(last.data).toEqual({ id: a.id, since: null });
+});
+
+test("clearMergingForTrain clears every member of one train, leaves others", async () => {
+  const { store, service } = mergeSvc();
+  const a = await mkSession(service);
+  const b = await mkSession(service);
+  service.setMerging([a.id], "train-A");
+  service.setMerging([b.id], "train-B");
+  service.clearMergingForTrain("train-A");
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+  expect(store.get(b.id)!.mergingSince).toBeGreaterThan(0);
+});
+
+test("sweepStaleMerging clears marks older than the TTL, keeps fresh ones", async () => {
+  const { store, service } = mergeSvc();
+  const a = await mkSession(service);
+  service.setMerging([a.id], "t");
+  const now = Date.now();
+  service.sweepStaleMerging(now);
+  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
+  service.sweepStaleMerging(now + MERGE_STALE_MS + 1);
+  expect(store.get(a.id)!.mergingSince).toBeNull();
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -350,3 +350,40 @@ test("pruneArchivedSessions: legacy archived row with null archivedAt expires vi
   expect(removed).toBe(1);
   expect(s.get(a.id)).toBeNull();
 });
+
+function newMergeInput() {
+  return {
+    name: "n",
+    prompt: "p",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "a",
+  };
+}
+
+test("merging fields default null and round-trip through update", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(newMergeInput());
+  expect(s.mergingSince).toBeNull();
+  expect(s.mergingTrainId).toBeNull();
+
+  store.update(s.id, { mergingSince: 1234, mergingTrainId: "train-1" });
+  const got = store.get(s.id)!;
+  expect(got.mergingSince).toBe(1234);
+  expect(got.mergingTrainId).toBe("train-1");
+
+  // a later unrelated update preserves them (mirrors readyToMerge survival)
+  store.update(s.id, { status: "idle" });
+  const after = store.get(s.id)!;
+  expect(after.mergingSince).toBe(1234);
+  expect(after.mergingTrainId).toBe("train-1");
+
+  store.update(s.id, { mergingSince: null, mergingTrainId: null });
+  const cleared = store.get(s.id)!;
+  expect(cleared.mergingSince).toBeNull();
+  expect(cleared.mergingTrainId).toBeNull();
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -40,6 +40,7 @@
   "status_done": "WARTET",
   "status_archived": "ARCHIVIERT",
   "status_ready_to_merge": "BEREIT",
+  "status_merging": "MERGE LÄUFT",
   "theme_dark": "Dunkel",
   "theme_light": "Hell",
   "theme_system": "System",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -485,6 +485,7 @@
   "toast_merge_train_no_prs": "Keine merge-bereiten PRs für einen Merge-Train vorhanden",
   "toast_merge_train_other_repos": "{count} merge-bereite PRs in anderen Repos wurden ausgelassen — starte dort einen separaten Merge-Train",
   "toast_merge_train_failed": "Merge-Train konnte nicht gestartet werden",
+  "toast_merge_train_mark_failed": "Merge-Train gestartet, aber das Markieren der PRs ist fehlgeschlagen.",
   "toast_merged": "{name} gemergt",
   "toast_renamed": "Umbenannt in {name}",
   "emojipicker_search": "Emoji suchen…",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -163,6 +163,7 @@
   "herd_ci_failed_group": "CI fehlgeschlagen ({count})",
   "herd_reviewer_running_group": "Review läuft ({count})",
   "herd_awaiting_merge_group": "Du bist dran ({count})",
+  "herd_merging_group": "Merge läuft ({count})",
   "herd_ready_group": "Bereit zum Mergen ({count})",
   "herd_merged_group": "Gemergt ({count})",
   "herd_clear_merged_action": "Alle räumen",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -140,6 +140,8 @@
   "feat_merge_train_body": "Die Gruppe „Bereit zum Mergen“ hat jetzt einen Merge-Train-Link, der eine Session startet, die die dort geparkten PRs abarbeitet, eine sichere Merge-Reihenfolge vorschlägt und nach deiner Freigabe merged.",
   "feat_review_cycles_title": "Review-Zyklen anpassen",
   "feat_review_cycles_body": "Lege fest, wie oft der Kritiker erneut prüft und einen Agenten anweist, Befunde zu beheben, bevor an dich eskaliert wird. Passe das globale Limit unter Einstellungen → Sitzung an.",
+  "feat_merge_in_progress_title": "Merge-Train zeigt Fortschritt",
+  "feat_merge_in_progress_body": "Wenn du einen Merge-Train startest, wandern die PRs, die er abarbeitet, mit einem bernsteinfarbenen Badge in eine Merge-läuft-Gruppe, statt in „Bereit zum Mergen“ zu bleiben — und jeder verschwindet, sobald er gemergt ist.",
   "gitrail_send_review": "↩ Review an Agent",
   "gitrail_send_review_failed": "Senden fehlgeschlagen",
   "gitrail_send_review_reviewing_title": "Critic prüft erneut — diese Anmerkungen werden gerade neu validiert",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -40,6 +40,7 @@
   "status_done": "WAITING",
   "status_archived": "ARCHIVED",
   "status_ready_to_merge": "READY",
+  "status_merging": "MERGING",
   "theme_dark": "Dark",
   "theme_light": "Light",
   "theme_system": "System",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -485,6 +485,7 @@
   "toast_merge_train_no_prs": "No ready-to-merge PRs to run a merge train on",
   "toast_merge_train_other_repos": "{count} ready-to-merge PRs in other repos were left out — run a separate merge train there",
   "toast_merge_train_failed": "Couldn't start the merge train",
+  "toast_merge_train_mark_failed": "Merge train started, but marking its PRs failed.",
   "toast_merged": "Merged {name}",
   "toast_renamed": "Renamed to {name}",
   "emojipicker_search": "search emoji…",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -163,6 +163,7 @@
   "herd_ci_failed_group": "CI failed ({count})",
   "herd_reviewer_running_group": "Reviewing ({count})",
   "herd_awaiting_merge_group": "Your turn ({count})",
+  "herd_merging_group": "Merging ({count})",
   "herd_ready_group": "Ready to merge ({count})",
   "herd_merged_group": "Merged ({count})",
   "herd_clear_merged_action": "Clear all",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -140,6 +140,8 @@
   "feat_merge_train_body": "The Ready-to-merge group now has a Merge train link that spins up a session to work through the PRs you've parked there, propose a safe merge order, and merge on your approval.",
   "feat_review_cycles_title": "Tune review cycles",
   "feat_review_cycles_body": "Set how many times the critic re-reviews and steers an agent to address findings before escalating to you. Adjust the global cap in Settings → Session.",
+  "feat_merge_in_progress_title": "Merge train shows progress",
+  "feat_merge_in_progress_body": "When you start a merge train, the PRs it's working through move into a Merging group with an amber badge instead of staying in Ready to merge — and each clears as it lands.",
   "gitrail_send_review": "↩ Send review to agent",
   "gitrail_send_review_failed": "send failed",
   "gitrail_send_review_reviewing_title": "Critic is re-reviewing — these findings are being re-validated",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -270,6 +270,18 @@ export async function setReadyToMerge(id: string, ready: boolean): Promise<void>
   if (!r.ok) throw await failed(r, "ready");
 }
 
+/** Flag a launched merge train's scoped ready PRs as "merging". Fire-and-forget
+ *  shape like setReadyToMerge — live state returns via the session:merging WS
+ *  event; marking is cosmetic, so a failure must not abort the train launch. */
+export async function startMergeTrain(ids: string[], trainId: string): Promise<void> {
+  const r = await fetch("/api/merge-train/start", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ ids, trainId }),
+  });
+  if (!r.ok) throw await failed(r, "merge-train");
+}
+
 export async function listIssues(
   repoPath: string,
 ): Promise<{ slug: string | null; issues: Issue[] }> {

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -56,6 +56,30 @@ const base = {
   activity: {},
 };
 
+describe("Herd merging group", () => {
+  it("renders a Merging group for in-train sessions", async () => {
+    const merging = session({
+      id: "m1",
+      readyToMerge: true,
+      mergingSince: Date.now(),
+      mergingTrainId: "t",
+    });
+    render(Herd, {
+      ...base,
+      sessions: [merging],
+      git: {
+        m1: {
+          kind: "github",
+          state: "open",
+          checks: "success",
+          deployConfigured: false,
+        } as GitState,
+      },
+    });
+    await expect.element(page.getByText(/Merging \(1\)/i)).toBeInTheDocument();
+  });
+});
+
 describe("Herd merge-train link", () => {
   it("shows the Merge train link when a ready-to-merge session has an open PR", async () => {
     render(Herd, {

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -21,6 +21,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     model: null,
     status: "idle",
     readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -160,6 +160,22 @@
           />
         {/each}
       {/if}
+      {#if partition.merging.length > 0}
+        <div class="merging-head micro">
+          {m.herd_merging_group({ count: partition.merging.length })}
+        </div>
+        {#each partition.merging as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            activity={activity[session.id]}
+            {ondecommission}
+          />
+        {/each}
+      {/if}
       {#if partition.ready.length > 0}
         <div class="ready-head micro">
           {m.herd_ready_group({ count: partition.ready.length })}
@@ -284,7 +300,8 @@
   /* amber section headers for the in-flight stages (PR CI running, critic
      reviewing) — amber mirrors the CI-pending dot and the critic badge */
   .ci-head,
-  .reviewing-head {
+  .reviewing-head,
+  .merging-head {
     display: flex;
     align-items: center;
     padding: 10px 8px 6px;

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -51,7 +51,9 @@
   // PR-CI-running and critic-reviewing in-flight groups, then the parked
   // ready-to-merge (green) and landed merged (blue) groups at the bottom.
   // reviews.reviewing is $state, so this re-derives on `session:reviewing` events.
-  const partition = $derived(partitionSessions(shown, git, (id) => reviews.isReviewing(id)));
+  // nowMs (the reactive clock tick) is threaded in so the Merging group re-partitions
+  // as the per-session merge TTL elapses, matching the badge/pip which also use nowMs.
+  const partition = $derived(partitionSessions(shown, git, (id) => reviews.isReviewing(id), nowMs));
   // ready-to-merge sessions that actually have an open PR — the merge-train link
   // only surfaces when there's something to run (fail-closed: no PR → no link).
   const readyPrCount = $derived(collectReadyPrs(shown, git).length);

--- a/ui/src/lib/components/StatusPip.svelte
+++ b/ui/src/lib/components/StatusPip.svelte
@@ -2,12 +2,19 @@
   import type { SessionStatus } from "$lib/types";
   import { STATUS_COLOR, statusLabel } from "$lib/format";
   import { m } from "$lib/paraglide/messages";
-  let { status, ready = false }: { status: SessionStatus; ready?: boolean } = $props();
+  let {
+    status,
+    ready = false,
+    merging = false,
+  }: { status: SessionStatus; ready?: boolean; merging?: boolean } = $props();
   // ready overrides status: a green ✓ reads as "parked, actionable-complete".
   // The check (green) is reserved for readyToMerge; a `done`/WAITING session is
   // NOT complete (it's parked for the operator's next steer), so its pip is the
   // quiet idle slate (--status-done === --color-slate), not green.
-  const color = $derived(ready ? "var(--color-green)" : STATUS_COLOR[status]);
+  // merging takes priority over ready: amber pulse signals in-flight merge train.
+  const color = $derived(
+    merging ? "var(--color-amber)" : ready ? "var(--color-green)" : STATUS_COLOR[status],
+  );
   // done (WAITING) and idle share slate, so hue alone can't separate them.
   // Give done a hollow ring (a parked marker) vs idle's solid dot — a non-color
   // cue on top of the distinct WAITING/IDLE label.
@@ -17,7 +24,9 @@
   const label = $derived(m.statuspip_status_aria({ status: statusLabel(status) }));
 </script>
 
-{#if ready}
+{#if merging}
+  <span class="pip pulse" style="--c:{color}" role="img" aria-label={label} title={label}></span>
+{:else if ready}
   <span class="pip check" style="--c:{color}" aria-hidden="true">✓</span>
 {:else if status === "blocked"}
   <!-- blocked: a filled red alarm badge — loud enough to catch the eye in a long

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import UnitRow from "./UnitRow.svelte";
+import type { Session } from "$lib/types";
+
+function session(partial: Partial<Session> & { id: string }): Session {
+  return {
+    desig: "TASK-01",
+    name: "task one",
+    prompt: "p",
+    repoPath: "/repo/a",
+    baseBranch: "main",
+    branch: "feat/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "h",
+    herdrAgentId: "ha",
+    claudeSessionId: "cs",
+    model: null,
+    status: "idle",
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotQuestion: null,
+    auto: false,
+    issueNumber: null,
+    lastState: "",
+    createdAt: 0,
+    updatedAt: 0,
+    archivedAt: null,
+    ...partial,
+  };
+}
+
+describe("UnitRow merging badge", () => {
+  it("shows MERGING for a merging session, not READY", async () => {
+    const now = Date.now();
+    render(UnitRow, {
+      session: session({
+        id: "a",
+        readyToMerge: true,
+        mergingSince: now - 1000,
+        mergingTrainId: "t",
+      }),
+      selected: false,
+      nowMs: now,
+      onselect: () => {},
+    });
+    await expect.element(page.getByText("MERGING")).toBeInTheDocument();
+    await expect.element(page.getByText("READY")).not.toBeInTheDocument();
+  });
+
+  it("shows READY for a ready-to-merge session that is not merging", async () => {
+    render(UnitRow, {
+      session: session({ id: "b", readyToMerge: true }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expect.element(page.getByText("READY")).toBeInTheDocument();
+    await expect.element(page.getByText("MERGING")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -7,6 +7,7 @@
 <script lang="ts">
   import type { Session, GitState, SessionActivity } from "$lib/types";
   import { elapsed, STATUS_COLOR, statusLabel, hideStatusBadge } from "$lib/format";
+  import { isMerging } from "./merge-train";
   import StatusPip from "./StatusPip.svelte";
   import PrBadge from "./PrBadge.svelte";
   import CriticBadge from "./CriticBadge.svelte";
@@ -129,7 +130,11 @@
     type="button"
   >
     <div class="pip-col">
-      <StatusPip status={session.status} ready={session.readyToMerge} />
+      <StatusPip
+        status={session.status}
+        ready={session.readyToMerge}
+        merging={isMerging(session, nowMs)}
+      />
     </div>
 
     <div class="u-main">
@@ -161,7 +166,9 @@
       <PrBadge {git} />
       <CriticBadge sessionId={session.id} />
       <AutopilotBadge {session} />
-      {#if session.readyToMerge}
+      {#if isMerging(session, nowMs)}
+        <span class="badge merging">{m.status_merging()}</span>
+      {:else if session.readyToMerge}
         <span class="badge">{m.status_ready_to_merge()}</span>
       {:else if !hideStatus}
         <span class="badge">{statusLabel(session.status)}</span>
@@ -492,6 +499,13 @@
     text-transform: uppercase;
     color: var(--color-muted);
     white-space: nowrap;
+  }
+
+  /* MERGING: the one colored, moving badge — amber + pulse marks the in-flight
+     merge train, louder than the quiet muted text badges around it. */
+  .badge.merging {
+    color: var(--color-amber);
+    animation: pip-pulse 1.5s ease-out infinite;
   }
 
   .elapsed {

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -19,6 +19,8 @@ function session(id: string, readyToMerge = false, status: SessionStatus = "runn
     model: null,
     status,
     readyToMerge,
+    mergingSince: null,
+    mergingTrainId: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -192,3 +192,13 @@ test("omitted reviewing predicate leaves reviewerRunning empty", () => {
   const { reviewerRunning } = partitionSessions([session("a")], {});
   expect(reviewerRunning).toHaveLength(0);
 });
+
+test("merging sessions land in merging, pulled out of ready; merged still wins", () => {
+  const now = 1_000_000_000;
+  const m1 = { ...session("m1", true), mergingSince: now - 1000, mergingTrainId: "t" };
+  const m2 = { ...session("m2", true), mergingSince: now - 1000, mergingTrainId: "t" };
+  const list = [session("r1", true), m1, m2];
+  const { ready, merging } = partitionSessions(list, { m2: git("merged") }, () => false, now);
+  expect(merging.map((s) => s.id)).toEqual(["m1"]); // m2 merged → merged group
+  expect(ready.map((s) => s.id)).toEqual(["r1"]);
+});

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -1,4 +1,5 @@
 import type { Session, GitState } from "$lib/types";
+import { isMerging } from "./merge-train";
 
 /** Split sessions into stage groups, preserving input order within each:
  *  - active: still in play, no later stage reached
@@ -12,27 +13,30 @@ import type { Session, GitState } from "$lib/types";
  *    steered findings back (with the PR's green CI now stale), or blocked awaiting
  *    operator input — so it stays in `active` rather than flicker into "waiting for
  *    merge" / get buried when it actually needs attention.
+ *  - merging: PR-sessions a launched merge train is working through (marked + within TTL)
  *  - ready: operator-parked "ready to merge"
  *  - merged: PR already landed
  *
  *  First-match precedence (terminal states win; reviewing beats the CI/merge stages
  *  as the later in-flight stage):
- *    merged > ready > reviewerRunning > ciRunning > ciFailed > awaitingMerge > active.
+ *    merged > merging > ready > reviewerRunning > ciRunning > ciFailed > awaitingMerge > active.
  *  An open PR with `none` checks (no CI reported yet) stays in `active` to avoid
  *  flicker into the "Your turn" group before CI registers as pending.
  *  The groups render top→bottom as active → ciRunning → ciFailed → reviewerRunning →
- *  awaitingMerge → ready → merged, mirroring the session lifecycle. `isReviewing` is
+ *  awaitingMerge → merging → ready → merged, mirroring the session lifecycle. `isReviewing` is
  *  injected so this stays a pure function (the caller wires it to the reviews store). */
 export function partitionSessions(
   sessions: Session[],
   git: Record<string, GitState>,
   isReviewing: (id: string) => boolean = () => false,
+  now: number = Date.now(),
 ): {
   active: Session[];
   ciRunning: Session[];
   ciFailed: Session[];
   reviewerRunning: Session[];
   awaitingMerge: Session[];
+  merging: Session[];
   ready: Session[];
   merged: Session[];
 } {
@@ -41,11 +45,13 @@ export function partitionSessions(
   const ciFailed: Session[] = [];
   const reviewerRunning: Session[] = [];
   const awaitingMerge: Session[] = [];
+  const merging: Session[] = [];
   const ready: Session[] = [];
   const merged: Session[] = [];
   for (const s of sessions) {
     const g = git[s.id];
     if (g?.state === "merged") merged.push(s);
+    else if (isMerging(s, now)) merging.push(s);
     else if (s.readyToMerge) ready.push(s);
     else if (isReviewing(s.id)) reviewerRunning.push(s);
     else if (g?.state === "open" && g.checks === "pending") ciRunning.push(s);
@@ -59,5 +65,5 @@ export function partitionSessions(
       awaitingMerge.push(s);
     else active.push(s);
   }
-  return { active, ciRunning, ciFailed, reviewerRunning, awaitingMerge, ready, merged };
+  return { active, ciRunning, ciFailed, reviewerRunning, awaitingMerge, merging, ready, merged };
 }

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -67,7 +67,13 @@ describe("collectReadyPrs", () => {
     };
     const prs = collectReadyPrs(sessions, git);
     expect(prs).toEqual([
-      { number: 11, title: "feat: a", url: "https://h/pull/11", repoPath: "/repo/a" },
+      {
+        sessionId: "a",
+        number: 11,
+        title: "feat: a",
+        url: "https://h/pull/11",
+        repoPath: "/repo/a",
+      },
     ]);
   });
 
@@ -85,7 +91,7 @@ describe("collectReadyPrs", () => {
       a: { kind: "github", state: "open", number: 9, checks: "success", deployConfigured: false },
     };
     expect(collectReadyPrs(sessions, git)).toEqual([
-      { number: 9, title: "", url: "", repoPath: "/repo/a" },
+      { sessionId: "a", number: 9, title: "", url: "", repoPath: "/repo/a" },
     ]);
   });
 });
@@ -93,25 +99,31 @@ describe("collectReadyPrs", () => {
 describe("formatReadyPrs", () => {
   it("formats one bullet per PR with number, title and url", () => {
     const out = formatReadyPrs([
-      { number: 11, title: "feat: a", url: "https://h/pull/11", repoPath: "/r" },
-      { number: 22, title: "fix: b", url: "https://h/pull/22", repoPath: "/r" },
+      { sessionId: "s1", number: 11, title: "feat: a", url: "https://h/pull/11", repoPath: "/r" },
+      { sessionId: "s2", number: 22, title: "fix: b", url: "https://h/pull/22", repoPath: "/r" },
     ]);
     expect(out).toBe("- #11 feat: a — https://h/pull/11\n- #22 fix: b — https://h/pull/22");
   });
 
   it("omits an empty title and an empty url gracefully", () => {
-    expect(formatReadyPrs([{ number: 9, title: "", url: "", repoPath: "/r" }])).toBe("- #9");
-    expect(formatReadyPrs([{ number: 9, title: "t", url: "", repoPath: "/r" }])).toBe("- #9 t");
-    expect(formatReadyPrs([{ number: 9, title: "", url: "u", repoPath: "/r" }])).toBe("- #9 — u");
+    expect(
+      formatReadyPrs([{ sessionId: "s", number: 9, title: "", url: "", repoPath: "/r" }]),
+    ).toBe("- #9");
+    expect(
+      formatReadyPrs([{ sessionId: "s", number: 9, title: "t", url: "", repoPath: "/r" }]),
+    ).toBe("- #9 t");
+    expect(
+      formatReadyPrs([{ sessionId: "s", number: 9, title: "", url: "u", repoPath: "/r" }]),
+    ).toBe("- #9 — u");
   });
 });
 
 describe("pickTrainRepo", () => {
   it("picks the repo with the most ready PRs and scopes to it", () => {
     const prs = [
-      { number: 1, title: "a", url: "u1", repoPath: "/repo/a" },
-      { number: 2, title: "b", url: "u2", repoPath: "/repo/b" },
-      { number: 3, title: "c", url: "u3", repoPath: "/repo/a" },
+      { sessionId: "s1", number: 1, title: "a", url: "u1", repoPath: "/repo/a" },
+      { sessionId: "s2", number: 2, title: "b", url: "u2", repoPath: "/repo/b" },
+      { sessionId: "s3", number: 3, title: "c", url: "u3", repoPath: "/repo/a" },
     ];
     const r = pickTrainRepo(prs);
     expect(r.repoPath).toBe("/repo/a");
@@ -121,8 +133,8 @@ describe("pickTrainRepo", () => {
 
   it("reports zero other-repo PRs when all share a repo", () => {
     const prs = [
-      { number: 1, title: "a", url: "u1", repoPath: "/repo/a" },
-      { number: 2, title: "b", url: "u2", repoPath: "/repo/a" },
+      { sessionId: "s1", number: 1, title: "a", url: "u1", repoPath: "/repo/a" },
+      { sessionId: "s2", number: 2, title: "b", url: "u2", repoPath: "/repo/a" },
     ];
     const r = pickTrainRepo(prs);
     expect(r.repoPath).toBe("/repo/a");

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { collectReadyPrs, formatReadyPrs, pickTrainRepo } from "./merge-train";
+import { describe, it, expect, test } from "vitest";
+import {
+  collectReadyPrs,
+  formatReadyPrs,
+  pickTrainRepo,
+  isMerging,
+  MERGE_STALE_MS,
+} from "./merge-train";
 import type { Session, GitState } from "$lib/types";
 
 function session(partial: Partial<Session> & { id: string }): Session {
@@ -126,4 +132,16 @@ describe("pickTrainRepo", () => {
   it("returns null repo for an empty list", () => {
     expect(pickTrainRepo([])).toEqual({ repoPath: null, prs: [], otherRepoCount: 0 });
   });
+});
+
+test("isMerging: true when marked and within TTL, false when null or stale", () => {
+  const now = 1_000_000_000;
+  const make = (mergingSince: number | null) => ({
+    ...session({ id: "m" }),
+    mergingSince,
+    mergingTrainId: mergingSince ? "t" : null,
+  });
+  expect(isMerging(make(null), now)).toBe(false);
+  expect(isMerging(make(now - 1000), now)).toBe(true);
+  expect(isMerging(make(now - MERGE_STALE_MS - 1), now)).toBe(false);
 });

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -18,6 +18,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     model: null,
     status: "idle",
     readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/merge-train.ts
+++ b/ui/src/lib/components/merge-train.ts
@@ -13,6 +13,7 @@ export function isMerging(s: Session, now: number = Date.now()): boolean {
 
 /** A ready-to-merge session's open PR, the unit a merge train works through. */
 export interface ReadyPr {
+  sessionId: string;
   number: number;
   title: string;
   url: string;
@@ -29,7 +30,13 @@ export function collectReadyPrs(sessions: Session[], git: Record<string, GitStat
     if (!s.readyToMerge) continue;
     const g = git[s.id];
     if (g?.state !== "open" || g.number == null) continue;
-    out.push({ number: g.number, title: g.title ?? "", url: g.url ?? "", repoPath: s.repoPath });
+    out.push({
+      sessionId: s.id,
+      number: g.number,
+      title: g.title ?? "",
+      url: g.url ?? "",
+      repoPath: s.repoPath,
+    });
   }
   return out;
 }

--- a/ui/src/lib/components/merge-train.ts
+++ b/ui/src/lib/components/merge-train.ts
@@ -1,5 +1,16 @@
 import type { Session, GitState } from "$lib/types";
 
+/** Merge-train marks older than this read as stale (the row falls back to its
+ *  prior state) so a stuck PR never sticks visually even if the server's TTL
+ *  sweep is briefly behind. Mirrors MERGE_STALE_MS in src/service.ts. */
+export const MERGE_STALE_MS = 30 * 60_000;
+
+/** True when a session is in a currently-running merge train: marked and the
+ *  mark is still within the TTL. `now` injectable for tests. */
+export function isMerging(s: Session, now: number = Date.now()): boolean {
+  return s.mergingSince !== null && now - s.mergingSince < MERGE_STALE_MS;
+}
+
 /** A ready-to-merge session's open PR, the unit a merge train works through. */
 export interface ReadyPr {
   number: number;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -63,4 +63,10 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_review_cycles_title",
     bodyKey: "feat_review_cycles_body",
   },
+  {
+    id: "merge-train-in-progress",
+    sinceVersion: "1.17.0",
+    titleKey: "feat_merge_in_progress_title",
+    bodyKey: "feat_merge_in_progress_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -372,10 +372,11 @@ test("session:activity replaces an existing entry (latest wins)", () => {
 test("session:merging sets and clears the mark", () => {
   const s = new HerdStore();
   s.setAll([session("s1"), session("s2")]);
-  s.apply({ event: "session:merging", data: { id: "s1", since: 111 } });
+  s.apply({ event: "session:merging", data: { id: "s1", since: 111, trainId: "train-1" } });
   expect(s.byId("s1")?.mergingSince).toBe(111);
+  expect(s.byId("s1")?.mergingTrainId).toBe("train-1"); // trainId carried live, not left null
   expect(s.byId("s2")?.mergingSince).toBeNull(); // other sessions untouched
-  s.apply({ event: "session:merging", data: { id: "s1", since: null } });
+  s.apply({ event: "session:merging", data: { id: "s1", since: null, trainId: null } });
   expect(s.byId("s1")?.mergingSince).toBeNull();
   expect(s.byId("s1")?.mergingTrainId).toBeNull();
 });

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -369,6 +369,17 @@ test("session:activity replaces an existing entry (latest wins)", () => {
   expect(s.activity["s1"]?.summary).toBe("$ bun test");
 });
 
+test("session:merging sets and clears the mark", () => {
+  const s = new HerdStore();
+  s.setAll([session("s1"), session("s2")]);
+  s.apply({ event: "session:merging", data: { id: "s1", since: 111 } });
+  expect(s.byId("s1")?.mergingSince).toBe(111);
+  expect(s.byId("s2")?.mergingSince).toBeNull(); // other sessions untouched
+  s.apply({ event: "session:merging", data: { id: "s1", since: null } });
+  expect(s.byId("s1")?.mergingSince).toBeNull();
+  expect(s.byId("s1")?.mergingTrainId).toBeNull();
+});
+
 test("session:archived drops the activity entry for that session", () => {
   const s = new HerdStore();
   s.setAll([session("s1")]);

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -28,6 +28,8 @@ function session(id: string): Session {
     model: null,
     status: "running",
     readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -132,6 +132,17 @@ export class HerdStore {
           s.id === ev.data.id ? { ...s, readyToMerge: ev.data.ready } : s,
         );
         break;
+      case "session:merging":
+        this.sessions = this.sessions.map((s) =>
+          s.id === ev.data.id
+            ? {
+                ...s,
+                mergingSince: ev.data.since,
+                mergingTrainId: ev.data.since === null ? null : s.mergingTrainId,
+              }
+            : s,
+        );
+        break;
       case "session:autopilot":
         this.sessions = this.sessions.map((s) =>
           s.id === ev.data.id

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -135,11 +135,7 @@ export class HerdStore {
       case "session:merging":
         this.sessions = this.sessions.map((s) =>
           s.id === ev.data.id
-            ? {
-                ...s,
-                mergingSince: ev.data.since,
-                mergingTrainId: ev.data.since === null ? null : s.mergingTrainId,
-              }
+            ? { ...s, mergingSince: ev.data.since, mergingTrainId: ev.data.trainId }
             : s,
         );
         break;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -217,6 +217,11 @@ export interface Session {
   status: SessionStatus;
   /** Operator-set "parked / done" flag, orthogonal to status. Default false. */
   readyToMerge: boolean;
+  /** Epoch ms when a merge train marked this PR-session in-flight; null when not.
+   *  Transient — cleared server-side on merge/close, train archive, or TTL. */
+  mergingSince: number | null;
+  /** Id of the owning merge-train session; null when not merging. */
+  mergingTrainId: string | null;
   autopilotEnabled: boolean | null;
   autopilotStepCount: number;
   autopilotPaused: boolean;
@@ -320,6 +325,7 @@ export type WsEvent =
   | { event: "session:new"; data: Session }
   | { event: "session:status"; data: { id: string; status: SessionStatus } }
   | { event: "session:ready"; data: { id: string; ready: boolean } }
+  | { event: "session:merging"; data: { id: string; since: number | null } }
   | {
       event: "session:autopilot";
       data: { id: string; paused: boolean; question: string | null; enabled: boolean | null };

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -325,7 +325,10 @@ export type WsEvent =
   | { event: "session:new"; data: Session }
   | { event: "session:status"; data: { id: string; status: SessionStatus } }
   | { event: "session:ready"; data: { id: string; ready: boolean } }
-  | { event: "session:merging"; data: { id: string; since: number | null } }
+  | {
+      event: "session:merging";
+      data: { id: string; since: number | null; trainId: string | null };
+    }
   | {
       event: "session:autopilot";
       data: { id: string; paused: boolean; question: string | null; enabled: boolean | null };

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -5,6 +5,7 @@
   import {
     listSessions,
     createSession,
+    startMergeTrain,
     archiveSession,
     getUsageLimits,
     replySession,
@@ -257,6 +258,15 @@
         model: null,
       });
       selectedId = s.id;
+      // Mark this repo's ready PR-sessions as "merging" so the list shows them
+      // in-flight. Fire-and-forget + fail-soft: a marking error must not abort
+      // the launch — the train (session s) is already running.
+      const ids = store.sessions
+        .filter(
+          (x) => x.repoPath === repoPath && x.readyToMerge && store.git[x.id]?.state === "open",
+        )
+        .map((x) => x.id);
+      startMergeTrain(ids, s.id).catch(() => toasts.info(m.toast_merge_train_mark_failed()));
       showBacklog = false;
       if (mobile.current) mobileScreen = "detail";
       if (otherRepoCount > 0)

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -259,14 +259,14 @@
       });
       selectedId = s.id;
       // Mark this repo's ready PR-sessions as "merging" so the list shows them
-      // in-flight. Fire-and-forget + fail-soft: a marking error must not abort
-      // the launch — the train (session s) is already running.
-      const ids = store.sessions
-        .filter(
-          (x) => x.repoPath === repoPath && x.readyToMerge && store.git[x.id]?.state === "open",
-        )
-        .map((x) => x.id);
-      startMergeTrain(ids, s.id).catch(() => toasts.info(m.toast_merge_train_mark_failed()));
+      // in-flight. Derived from the same scoped `prs` array the train works
+      // through — single source of truth, no separate filter needed.
+      // Fire-and-forget + fail-soft: a marking error must not abort the launch —
+      // the train (session s) is already running.
+      startMergeTrain(
+        prs.map((p) => p.sessionId),
+        s.id,
+      ).catch(() => toasts.info(m.toast_merge_train_mark_failed()));
       showBacklog = false;
       if (mobile.current) mobileScreen = "detail";
       if (otherRepoCount > 0)

--- a/ui/test/store.test.ts
+++ b/ui/test/store.test.ts
@@ -18,6 +18,8 @@ const s = (id: string, status: any = "running"): Session => ({
   model: null,
   status,
   readyToMerge: false,
+  mergingSince: null,
+  mergingTrainId: null,
   autopilotEnabled: null,
   autopilotStepCount: 0,
   autopilotPaused: false,


### PR DESCRIPTION
## What

When you launch the **Merge train** shortcut from the Ready-to-merge group, the PRs that train works through now show as **Merging** in the session list — pulled into their own group with an amber, pulsing badge — instead of staying as "Ready to merge". Each PR clears back out as it actually lands.

Before, in-train PRs looked identical to ones nobody had touched, so a second train (or a manual merge) could be fired at the same set with no signal anything was in flight.

## How

The train runs client-side as an agent session, so the client tells the server which PR-sessions it scoped in; the server is then authoritative.

**Server**
- Two transient `Session` fields — `mergingSince` (epoch ms) + `mergingTrainId` — persisted in SQLite, mirroring `readyToMerge`.
- `POST /api/merge-train/start {ids, trainId}` → `service.setMerging(...)`, broadcast via a new `session:merging` WS event.
- **Three clear triggers:** per-PR when the poller sees the PR go `merged`/`closed` (primary, visible); whole-set when the train **session is archived** (keyed on archive, *not* idle/done — a Claude pane reports done at the approval gate); and a 30-min TTL backstop sweep for rejected/held-back PRs.

**UI**
- Mirrors the fields + `session:merging` event; store patches the row live.
- `isMerging()` TTL guard (mirrors the server TTL so a stale flag never renders).
- New **Merging** partition group above Ready-to-merge (`merged > merging > ready > …`); amber pulsing **MERGING** badge + pip.
- `onmergetrain` marks the exact scoped set (`ReadyPr.sessionId`, single source of truth) — fail-soft: a marking error never aborts the train launch.

**House-rule obligations**
- i18n keys added to both `en.json` + `de.json` (`check:i18n` parity holds).
- One `feature-announcements.ts` catalog entry (`merge-train-in-progress`) + its keys.

## Testing
- Server: store round-trip, service set/clear/clear-for-train/TTL-sweep, endpoint (200 + persisted, 400 bad body). `bun test ./test` → 1077 pass.
- UI: `isMerging` TTL boundary, partition routing (merging out of ready; merged still wins), store apply, UnitRow MERGING badge, Herd Merging group. `cd ui && bun run test` → 496 pass.
- Gates: `bun run check`, `check:i18n` (parity), root lint, branch-hygiene, feature-catalog — all green. Rebased onto latest `origin/main`.

Design + plan: `docs/superpowers/specs/2026-06-08-merge-train-in-progress-marker-design.md`, `docs/superpowers/plans/2026-06-08-merge-train-in-progress-marker.md`.

Note: a separate unmerged branch ships a server-side `AutoMergeService` (#362) — a different mechanism; this PR is scoped to the agent-session shortcut only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)