### PR TITLE
feat(spawn): research-first notice in unattended system prompt

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -90,6 +90,26 @@ const ENGINEERING_POSTURE =
   "loop until they actually pass — never declare work done before verifying against them.";
 
 /**
+ * Fixed, repo-independent standing guidance injected into every spawn (issue #347, sourced from
+ * the upstream Tank unattended prompt). Counterpart to ENGINEERING_POSTURE: that block stops the
+ * agent *over-building*; this one stops it building against a *stale or assumed* external API. Left
+ * uncorrected on an overnight/unattended run, the agent confidently scaffolds many files against a
+ * library version or pattern that's no longer current, with no human to catch it early — a cheap
+ * web search up front is high-leverage insurance against that.
+ *
+ * Deliberately scoped to non-trivial code against an external library/framework/API the agent isn't
+ * sure is current, so it doesn't fire a search on every trivial edit or well-known pattern. WebSearch
+ * is already allowed for task agents, so this adds no new permission prompt. Agent-facing prompt text
+ * (not operator UI), so fixed English — same precedent as the other notices.
+ */
+const RESEARCH_FIRST_NOTICE =
+  "Before writing non-trivial code against an external library, framework, or API — especially one " +
+  "you're not certain is current — do a quick web search to confirm the present best approach, then " +
+  "note in one or two lines what you found and why you chose it. Skip this for trivial edits and " +
+  "well-established patterns you're already confident about; it exists to stop you scaffolding many " +
+  "files against a stale or assumed API with no human to correct course.";
+
+/**
  * Seeded into the system prompt at spawn when the repo has autopilot on, so the agent knows
  * up front it's running unattended. Without it autopilot is purely reactive — the agent stops
  * to ask "commit + open a PR?", and a steer only lands after a stop is detected and classified
@@ -113,13 +133,16 @@ const AUTOPILOT_DIRECTIVE =
  * into the task on every spawn. They now live in the system prompt, each block XML-wrapped
  * so the agent can cleanly separate persistent guidance from the task in its human turn.
  * `houseRules` is the already-wrapped `<shepherd-house-rules>` block, or null when there are
- * none / learnings are disabled; the engineering-posture and branch-rename blocks always ride.
- * `autopilotActive` appends the autopilot directive (see above).
+ * none / learnings are disabled; the engineering-posture, research-first, and branch-rename blocks
+ * always ride. `autopilotActive` appends the autopilot directive (see above).
  */
 export function composeSystemPrompt(houseRules: string | null, autopilotActive = false): string {
   const posture = `<engineering-posture>\n${ENGINEERING_POSTURE}\n</engineering-posture>`;
+  const research = `<research-first-notice>\n${RESEARCH_FIRST_NOTICE}\n</research-first-notice>`;
   const branchNotice = `<branch-rename-notice>\n${BRANCH_RENAME_NOTICE}\n</branch-rename-notice>`;
-  const blocks = houseRules ? [posture, houseRules, branchNotice] : [posture, branchNotice];
+  const blocks = houseRules
+    ? [posture, research, houseRules, branchNotice]
+    : [posture, research, branchNotice];
   if (autopilotActive)
     blocks.push(`<autopilot-directive>\n${AUTOPILOT_DIRECTIVE}\n</autopilot-directive>`);
   return blocks.join("\n\n");

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1704,6 +1704,24 @@ test("composeSystemPrompt always injects the engineering-posture block, with or 
   expect(withoutRules).not.toContain(`<${HOUSE_RULES_TAG}>`);
 });
 
+test("composeSystemPrompt always injects the research-first notice, with or without house rules", () => {
+  // Fixed standing guidance (issue #347), not a per-repo learning, so it rides every spawn
+  // regardless of the learnings toggle / house-rules state — i.e. even when houseRules is null.
+  const withoutRules = composeSystemPrompt(null);
+  const withRules = composeSystemPrompt(
+    `<${HOUSE_RULES_TAG}>\nintro\n- Use bun\n</${HOUSE_RULES_TAG}>`,
+  );
+  for (const sp of [withoutRules, withRules]) {
+    expect(sp).toContain("<research-first-notice>");
+    expect(sp).toContain("</research-first-notice>");
+    // Scoped to non-trivial external API work, with the "note what you found" half intact.
+    expect(sp).toContain("do a quick web search to confirm the present best approach");
+    expect(sp).toContain("Skip this for trivial edits");
+  }
+  // Rides unconditionally, like the autopilot-independent posture/branch blocks.
+  expect(composeSystemPrompt(null, true)).toContain("<research-first-notice>");
+});
+
 test("resume adopts a live agent found by cwd under a new terminalId — no duplicate spawn", () => {
   const store = new SessionStore(":memory:");
   let startCalls = 0;


### PR DESCRIPTION
Closes #347.

## What

Adds a fixed `RESEARCH_FIRST_NOTICE` block to the spawn-time system prompt, riding every spawn via `composeSystemPrompt` alongside the existing engineering-posture and branch-rename blocks.

Sourced from the upstream Tank unattended prompt (Creator Magic livestream, ~17:14): before writing non-trivial code against an external library/API, do a quick web search to confirm the current best approach and note in a line or two what was found. Counterpart to `ENGINEERING_POSTURE` — that block stops the agent *over-building*; this one stops it building against a *stale or assumed* external API, the classic overnight/unattended failure mode where the agent confidently scaffolds many files the wrong way with no human to correct course early.

## Decisions (resolving the issue's open questions)

- **Standalone notice, not a house rule.** House rules are per-repo, learned, budget-limited and toggle-gated; this is fixed repo-independent standing guidance, so it lives in source like `ENGINEERING_POSTURE`/`BRANCH_RENAME_NOTICE`.
- **Unconditional** (rides every spawn, not autopilot-only), matching `ENGINEERING_POSTURE` which also targets the unattended failure mode. Acceptance requires it reach *every* spawned task agent.
- **Transcript only** — wording asks for "one or two lines"; no PR-body/task-log plumbing (keeps the change minimal).
- **Bounded** to non-trivial external lib/framework/API work the agent isn't sure is current, with an explicit "skip trivial edits / well-established patterns" clause so it doesn't fire a search on every edit.

## Acceptance

- [x] New instruction reaches every spawned task agent via `composeSystemPrompt`.
- [x] Phrased to fire on unfamiliar external libs/APIs, not trivial edits.
- [x] Pure system-prompt text (agent-facing, not user chrome) → exempt from i18n, same as the other notices. Server-only `feat`, touches no UI globs → feature-catalog gate not armed.
- [x] No new permission prompt / hang — `WebSearch` already allowed for task agents.

## Test

- New test `composeSystemPrompt always injects the research-first notice, with or without house rules` (asserts presence with/without house rules and under autopilot, plus the scoping wording).
- `bun test ./test/service.test.ts` 58 pass, root `bunx tsc --noEmit` clean, `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)