### PR TITLE
fix(ui): center-align readiness score in ring

### DIFF
--- a/ui/src/lib/components/ReadinessPanel.svelte
+++ b/ui/src/lib/components/ReadinessPanel.svelte
@@ -151,8 +151,10 @@
       <!-- score header -->
       <div class="score-head">
         <div class="score-ring {band}">
-          <span class="score-num">{report.score}</span>
-          <span class="score-pct">%</span>
+          <span class="score-figure">
+            <span class="score-num">{report.score}</span>
+            <span class="score-pct">%</span>
+          </span>
         </div>
         <div class="score-meta">
           <div class="score-label">{m.readiness_score_label()}</div>
@@ -281,13 +283,18 @@
   }
   .score-ring {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     justify-content: center;
     min-width: 64px;
     height: 64px;
     border-radius: 50%;
     border: 2px solid var(--color-line-bright);
     color: var(--color-ink-bright);
+  }
+  /* Keep the % on the number's baseline while the group sits centered in the ring. */
+  .score-figure {
+    display: flex;
+    align-items: baseline;
   }
   .score-ring.low {
     border-color: var(--color-red);


### PR DESCRIPTION
## What

The AI-readiness score (`32%`) sat in the **top** of its circular ring instead of vertically centered.

`.score-ring` used `align-items: baseline`, which places the flex line's baseline near the top of the 64px circle — pushing the glyphs up.

## Fix

Wrap the number + `%` in an inner `.score-figure` that keeps `align-items: baseline` (so the `%` stays on the number's baseline), and switch the ring itself to `align-items: center` so that group is vertically centered.

## Before / After

Center guide line marks the ring's vertical midpoint:

| baseline (before) | center (after) |
|---|---|
| `32%` top-aligned | `32%` centered, `%` still on baseline |

Verified by rendering the exact component markup + CSS (real design tokens) headless and screenshotting both variants. `cd ui && bun run check` passes (0 errors).

No new strings, no user-facing capability added — pure layout fix. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)