### PR TITLE
feat(ui): design-system reference page + agent directive vs UI drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,17 @@ Every PR branch must be cut from the **latest `main`** and kept **linear**:
 
 A branch that merges other branches drags their commits + a bloated diff into the PR. The gate `scripts/check-branch-hygiene.sh` fails any branch with merge commits relative to main; it runs in the **PR hygiene** CI workflow and the pre-push hook. To fix a polluted branch, re-create it off main with just your change (`git checkout -b <branch> origin/main` then cherry-pick / `rebase --onto origin/main`).
 
+## Design system (REQUIRED for any UI work)
+
+The UI has a **semantic token layer** (`ui/src/app.css` — `--color-*` surfaces/text/accents, the `--fs-*` type scale, `--status-*`/`--wash-*`) and a live reference page that documents it plus the canonical component recipes: **`/design-system`** (`ui/src/routes/design-system/+page.svelte`). It exists to stop **design drift** — every session re-inventing buttons, spacing and colors. Before authoring any UI:
+
+1. **Consult `/design-system` first.** It renders the live tokens (swatches read straight off `app.css`, so they can't drift) plus the button / form-field / badge / panel / scrim recipes, each with a when-to-use note and copy-paste markup.
+2. **Use the tokens, never literals.** Every color is `var(--color-*)`; every font size is `var(--fs-*)`. **Never** introduce a raw hex, `rgba()`, or ad-hoc `px` font size — if you reach for one, the token you need already exists (or belongs in `app.css`).
+3. **Reuse a recipe before authoring a new component.** Match the existing `.gbtn` / field / `.badge` / `.panel` conventions; don't grow a per-element Tailwind utility stack for headings or buttons.
+4. Accent hues are **semantic, not decorative** — pick by meaning. `--color-green` is reserved for genuinely actionable-complete (READY); a finished-but-parked session is slate (`--status-done`), never green.
+
+The `/design-system` page is a developer/agent-facing internal reference (unlinked from the app), so it is **exempt from i18n** and the feature catalog. No automated gate flags off-token colors yet — this directive + review are the enforcement.
+
 ## Internationalization (REQUIRED for any UI work)
 
 The UI is fully internationalized with Paraglide JS (EN + DE). **Never hardcode user-facing text.** Every display string — labels, buttons, placeholders, `title`/`aria-label`, empty/error/loading states, toast text, and **server-side notification payloads** — must route through a message:

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -1,0 +1,584 @@
+<script lang="ts">
+  // Design-system reference (issue #352). A live, single-page catalog of the
+  // token layer (app.css) + the canonical component recipes the rest of the UI
+  // follows, each with a when-to-use note and copy-paste markup. Its purpose is
+  // to stop "design drift" — unattended agents re-inventing buttons/spacing/
+  // colors every session. The CLAUDE.md "Design system" directive points agents
+  // here before they author any UI.
+  //
+  // This is a developer/agent-facing INTERNAL reference, not end-user chrome, so
+  // it is deliberately exempt from i18n (it is unlinked from the app and only
+  // reached by navigating to /design-system directly) — see CLAUDE.md, which
+  // marks a dev-only styleguide as exempt. Swatches/type rows render straight
+  // off the live `var(--color-*)` / `var(--fs-*)` tokens, so this page can never
+  // drift from the real theme: change app.css and this updates with it.
+  import { onMount } from "svelte";
+  import { theme } from "$lib/theme.svelte";
+
+  onMount(() => theme.init());
+
+  type Token = { name: string; note: string };
+
+  // Surfaces, lines and text colors — the structural palette. Names map 1:1 to
+  // the `--color-*` theme tokens in app.css (single source of truth).
+  const surfaces: Token[] = [
+    { name: "bg", note: "App background (under the radial glow)" },
+    { name: "glow", note: "Top-center radial glow toward bg" },
+    { name: "panel", note: "Primary raised surface (cards, sheets)" },
+    { name: "panel-2", note: "Secondary panel, slightly recessed" },
+    { name: "head", note: "Header / chrome bars" },
+    { name: "inset", note: "Sunken surface (inputs, terminals)" },
+    { name: "hover", note: "Row/control hover fill" },
+    { name: "sel", note: "Selected / active fill" },
+    { name: "line", note: "Default hairline border" },
+    { name: "line-bright", note: "Emphasized border / divider" },
+  ];
+
+  const textTokens: Token[] = [
+    { name: "ink", note: "Body text (~12:1 on bg, AA+)" },
+    { name: "ink-bright", note: "Headings / emphasized text" },
+    { name: "muted", note: "Secondary text, labels (~5.5:1)" },
+    { name: "faint", note: "Tertiary / disabled-ish text" },
+  ];
+
+  // Accents carry meaning — never pick a hue for looks; pick it for what it
+  // signals. See the status tokens below for the running/done/blocked mapping.
+  const accents: Token[] = [
+    { name: "amber", note: "Running / armed / primary action" },
+    { name: "green", note: "READY / actionable-complete only" },
+    { name: "red", note: "Blocked / destructive / error" },
+    { name: "blue", note: "Informational accent" },
+    { name: "slate", note: "Idle / parked (neutral, not 'done')" },
+  ];
+
+  // Type scale — the six deliberate rungs in app.css. Never hardcode a px size;
+  // reach for the nearest rung.
+  const typeScale: { name: string; px: string; note: string }[] = [
+    { name: "fs-micro", px: "10px", note: "Dense chrome floor (badges)" },
+    { name: "fs-meta", px: "11px", note: "Labels, numerics, buttons" },
+    { name: "fs-base", px: "13px", note: "Body / titles (default)" },
+    { name: "fs-lg", px: "16px", note: "Section heading" },
+    { name: "fs-xl", px: "20px", note: "Page heading" },
+    { name: "fs-2xl", px: "22px", note: "Hero / largest" },
+  ];
+
+  // Status tokens encode session state. The hue choices are load-bearing — the
+  // notes spell out the non-obvious ones (done ≠ green; green is reserved).
+  const statuses: { name: string; note: string }[] = [
+    { name: "status-running", note: "Work in progress (amber)" },
+    {
+      name: "status-done",
+      note: "WAITING / parked for the next steer — NOT actionable-complete, so it reads slate, never green",
+    },
+    { name: "status-blocked", note: "Blocked / needs the operator (red)" },
+    { name: "status-idle", note: "Idle, no active turn (slate)" },
+  ];
+
+  // Canonical markup blocks. Rendered as escaped text inside <pre>, so agents
+  // (and humans) can copy the exact convention rather than re-deriving it.
+  const btnMarkup = `<button class="gbtn">Action</button>
+<button class="gbtn primary">Primary</button>
+<button class="gbtn" disabled>Disabled</button>
+
+/* canonical recipe — all colors via tokens, never raw hex */
+.gbtn {
+  background: transparent;
+  border: 1px solid var(--color-line);
+  border-radius: 2px;
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: 0.08em;
+  padding: 2px 8px;
+}
+.gbtn:hover:not(:disabled) { border-color: var(--color-amber); color: var(--color-amber); }
+.gbtn:disabled { opacity: 0.4; cursor: not-allowed; }
+.gbtn.primary { border-color: var(--color-amber); color: var(--color-amber); }`;
+
+  const fieldMarkup = `<input type="text" placeholder="…" />
+<select>…</select>
+<textarea></textarea>
+
+/* one recipe for text input, select and textarea */
+input, select, textarea {
+  background: var(--color-inset);
+  border: 1px solid var(--color-line);
+  color: var(--color-ink-bright);
+  font: inherit;
+  font-size: var(--fs-base);
+  padding: 8px 10px;
+  border-radius: 2px;
+}`;
+
+  const badgeMarkup = `<span class="badge">OPEN</span>
+
+.badge {
+  font-size: var(--fs-micro);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border: 1px solid var(--color-line);
+  border-radius: 2px;
+  color: var(--color-muted);
+}
+/* state colors come from the accent/status tokens, applied to color + border */`;
+
+  const panelMarkup = `<section class="panel">…</section>
+
+.panel {
+  background: var(--color-panel);
+  border: 1px solid var(--color-line);
+  border-radius: 2px;
+}
+/* recessed child surface (input wells, terminals): var(--color-inset) */`;
+
+  const scrimMarkup = `<div class="scrim"><!-- dialog --></div>
+
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: var(--color-scrim); /* theme-aware dim, never a raw rgba() */
+}`;
+</script>
+
+<svelte:head>
+  <title>Shepherd · Design system</title>
+</svelte:head>
+
+<main id="main-content" class="ds">
+  <header class="ds-head">
+    <div>
+      <h1>Design system</h1>
+      <p class="lede">
+        The token layer + canonical component recipes the Shepherd UI follows. Consult this before
+        authoring any UI: use the <code>--color-*</code> / <code>--fs-*</code> tokens, reuse a
+        recipe below, and never introduce raw hex or ad-hoc sizes. Swatches render live from
+        <code>app.css</code>, so this page tracks the real theme.
+      </p>
+    </div>
+    <div class="ds-toggles">
+      <button class="gbtn" onclick={() => theme.cycle()}>Theme: {theme.pref}</button>
+      <button class="gbtn" class:primary={theme.contrast} onclick={() => theme.toggleContrast()}>
+        Contrast: {theme.contrast ? "high" : "normal"}
+      </button>
+    </div>
+  </header>
+
+  <!-- ── Foundations ──────────────────────────────────────────────────── -->
+  <section class="panel">
+    <h2>Color · surfaces &amp; lines</h2>
+    <p class="when">
+      Build with these for any background, border or fill — never a literal hex. Surfaces nest bg →
+      panel → inset; borders use line / line-bright.
+    </p>
+    <div class="swatches">
+      {#each surfaces as t (t.name)}
+        <figure class="swatch">
+          <span class="chip" style="background: var(--color-{t.name})"></span>
+          <figcaption><code>--color-{t.name}</code><span>{t.note}</span></figcaption>
+        </figure>
+      {/each}
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>Color · text</h2>
+    <p class="when">
+      Pick by hierarchy: ink for body, ink-bright to emphasize, muted/faint to recede.
+    </p>
+    <div class="swatches">
+      {#each textTokens as t (t.name)}
+        <figure class="swatch">
+          <span class="text-sample" style="color: var(--color-{t.name})">Aa</span>
+          <figcaption><code>--color-{t.name}</code><span>{t.note}</span></figcaption>
+        </figure>
+      {/each}
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>Color · accents</h2>
+    <p class="when">
+      Hues are semantic, not decorative — choose by meaning. <strong>Green is reserved</strong> for genuinely
+      actionable-complete (READY); a finished-but-parked session is slate, not green.
+    </p>
+    <div class="swatches">
+      {#each accents as t (t.name)}
+        <figure class="swatch">
+          <span class="chip" style="background: var(--color-{t.name})"></span>
+          <figcaption><code>--color-{t.name}</code><span>{t.note}</span></figcaption>
+        </figure>
+      {/each}
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>Type scale</h2>
+    <p class="when">
+      Six rungs — anchor on fs-base (13px). Reach for the nearest rung; never invent a size.
+    </p>
+    <ul class="type-list">
+      {#each typeScale as t (t.name)}
+        <li>
+          <span class="type-demo" style="font-size: var(--{t.name})">Shepherd</span>
+          <code>--{t.name}</code><span class="px">{t.px}</span><span class="note">{t.note}</span>
+        </li>
+      {/each}
+    </ul>
+  </section>
+
+  <section class="panel">
+    <h2>Status tokens</h2>
+    <p class="when">
+      Session state → hue. Driven by app.css <code>--status-*</code>; read the notes — the mapping
+      is load-bearing.
+    </p>
+    <ul class="status-list">
+      {#each statuses as s (s.name)}
+        <li>
+          <span class="status-dot" style="background: var(--{s.name})"></span>
+          <code>--{s.name}</code><span class="note">{s.note}</span>
+        </li>
+      {/each}
+    </ul>
+  </section>
+
+  <!-- ── Component recipes ────────────────────────────────────────────── -->
+  <section class="panel">
+    <h2>Buttons</h2>
+    <p class="when">
+      <strong>When:</strong> any in-chrome action. Base <code>.gbtn</code> is the default; add
+      <code>.primary</code> for the single emphasized action in a group. <strong>When not:</strong>
+      destructive actions get a red treatment + confirmation, not a plain button.
+    </p>
+    <div class="demo">
+      <button class="gbtn">Action</button>
+      <button class="gbtn primary">Primary</button>
+      <button class="gbtn" disabled>Disabled</button>
+    </div>
+    <pre><code>{btnMarkup}</code></pre>
+  </section>
+
+  <section class="panel">
+    <h2>Form fields</h2>
+    <p class="when">
+      <strong>When:</strong> text input, select (dropdown) and textarea all share one recipe — a
+      sunken <code>--color-inset</code> well with a <code>--color-line</code> border.
+      <strong>When not:</strong> boolean choices use a toggle/checkbox, not a select.
+    </p>
+    <div class="demo demo-col">
+      <input type="text" placeholder="Prompt…" />
+      <select><option>main</option><option>develop</option></select>
+      <textarea placeholder="Longer text…"></textarea>
+    </div>
+    <pre><code>{fieldMarkup}</code></pre>
+  </section>
+
+  <section class="panel">
+    <h2>Badges &amp; pills</h2>
+    <p class="when">
+      <strong>When:</strong> a compact, read-only status label (PR state, CI, critic verdict). Color
+      comes from the accent/status tokens. <strong>When not:</strong> if it's clickable it's a button,
+      not a badge.
+    </p>
+    <div class="demo">
+      <span class="badge">OPEN</span>
+      <span class="badge" style="color: var(--color-green); border-color: var(--color-green)"
+        >READY</span
+      >
+      <span class="badge" style="color: var(--color-red); border-color: var(--color-red)"
+        >BLOCKED</span
+      >
+    </div>
+    <pre><code>{badgeMarkup}</code></pre>
+  </section>
+
+  <section class="panel">
+    <h2>Panels &amp; surfaces</h2>
+    <p class="when">
+      <strong>When:</strong> group related content on a raised <code>--color-panel</code> surface;
+      nest inputs/terminals on the recessed <code>--color-inset</code>. The app shell layers head →
+      panel → inset for depth.
+    </p>
+    <div class="demo">
+      <div class="mini-panel">
+        panel
+        <div class="mini-inset">inset</div>
+      </div>
+    </div>
+    <pre><code>{panelMarkup}</code></pre>
+  </section>
+
+  <section class="panel">
+    <h2>Modal &amp; scrim</h2>
+    <p class="when">
+      <strong>When:</strong> a blocking dialog dims the app behind a <code>--color-scrim</code>
+      overlay (theme-aware — never a raw <code>rgba()</code>). The dialog itself is a
+      <code>.panel</code>.
+    </p>
+    <div class="demo">
+      <div class="scrim-demo">
+        <span class="scrim-fill"></span>
+        <div class="mini-panel dialog">Dialog</div>
+      </div>
+    </div>
+    <pre><code>{scrimMarkup}</code></pre>
+  </section>
+</main>
+
+<style>
+  .ds {
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 28px 20px 80px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+  .ds-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  h1 {
+    font-size: var(--fs-xl);
+    color: var(--color-ink-bright);
+    margin: 0 0 6px;
+    letter-spacing: 0.04em;
+  }
+  h2 {
+    font-size: var(--fs-lg);
+    color: var(--color-ink-bright);
+    margin: 0 0 8px;
+    letter-spacing: 0.04em;
+  }
+  .lede {
+    margin: 0;
+    max-width: 60ch;
+    color: var(--color-muted);
+    line-height: 1.6;
+  }
+  .ds-toggles {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+  code {
+    color: var(--color-ink-bright);
+    background: var(--color-inset);
+    padding: 0 4px;
+    border-radius: 2px;
+  }
+  .when {
+    margin: 0 0 14px;
+    color: var(--color-muted);
+    line-height: 1.6;
+    max-width: 70ch;
+  }
+  .when strong {
+    color: var(--color-ink);
+  }
+
+  .panel {
+    background: var(--color-panel);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 18px 20px;
+  }
+
+  /* swatches */
+  .swatches {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 12px;
+  }
+  .swatch {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 0;
+  }
+  .chip {
+    width: 34px;
+    height: 34px;
+    border-radius: 2px;
+    border: 1px solid var(--color-line);
+    flex-shrink: 0;
+  }
+  .text-sample {
+    width: 34px;
+    height: 34px;
+    display: grid;
+    place-items: center;
+    font-size: var(--fs-lg);
+    flex-shrink: 0;
+  }
+  figcaption {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: var(--fs-meta);
+  }
+  figcaption span {
+    color: var(--color-faint);
+  }
+
+  /* type scale */
+  .type-list,
+  .status-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .type-list li,
+  .status-list li {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+  }
+  .type-demo {
+    color: var(--color-ink-bright);
+    min-width: 130px;
+  }
+  .px {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+  }
+  .note {
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+  }
+  .status-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    align-self: center;
+  }
+
+  /* component demos */
+  .demo {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+  .demo-col {
+    flex-direction: column;
+    align-items: stretch;
+    max-width: 320px;
+  }
+
+  /* canonical recipes mirrored locally (documentation), all token-driven */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .gbtn.primary {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  input,
+  select,
+  textarea {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    padding: 8px 10px;
+    border-radius: 2px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  textarea {
+    resize: none;
+    min-height: 70px;
+  }
+  .badge {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 1px 6px;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+  }
+  .mini-panel {
+    background: var(--color-panel-2);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 14px;
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+  }
+  .mini-inset {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 10px;
+    margin-top: 8px;
+    color: var(--color-faint);
+  }
+  .scrim-demo {
+    position: relative;
+    width: 240px;
+    height: 120px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    overflow: hidden;
+    display: grid;
+    place-items: center;
+  }
+  .scrim-fill {
+    position: absolute;
+    inset: 0;
+    background: var(--color-scrim);
+  }
+  .dialog {
+    position: relative;
+    z-index: 1;
+    background: var(--color-panel);
+  }
+
+  pre {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 12px 14px;
+    overflow-x: auto;
+    margin: 0;
+  }
+  pre code {
+    background: none;
+    padding: 0;
+    color: var(--color-ink);
+    font-size: var(--fs-meta);
+    line-height: 1.6;
+  }
+</style>

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -12,10 +12,9 @@
   // marks a dev-only styleguide as exempt. Swatches/type rows render straight
   // off the live `var(--color-*)` / `var(--fs-*)` tokens, so this page can never
   // drift from the real theme: change app.css and this updates with it.
-  import { onMount } from "svelte";
+  // +layout.svelte already inits the theme globally for every route; the toggles
+  // below just read/drive the shared controller.
   import { theme } from "$lib/theme.svelte";
-
-  onMount(() => theme.init());
 
   type Token = { name: string; note: string };
 


### PR DESCRIPTION
Closes #352.

## What

Half the design-system fix already existed (mature `--color-*` / `--fs-*` / `--status-*` token layer in `ui/src/app.css`). This adds the two missing halves to stop **design drift** — unattended agents re-inventing buttons/spacing/colors every session:

1. **Live reference page** — `ui/src/routes/design-system/+page.svelte`, served at `/design-system`. Renders the token layer (color surfaces/text/accents, the six `--fs-*` type rungs, `--status-*`) **straight off the live CSS vars**, so it can't drift from the real theme — plus the canonical **button / form-field / badge / panel / scrim** recipes, each with a when-to-use note and copy-paste markup. Dark/light + high-contrast toggles let you verify tokens re-theme.
2. **Agent directive** — new "Design system (REQUIRED for any UI work)" section in `CLAUDE.md`: consult `/design-system` first, use the tokens (never raw hex/`rgba()`/ad-hoc px), reuse a recipe before authoring a new component, treat accent hues as semantic (green reserved for READY).

## Acceptance (#352)

- [x] A reference route renders the shared component recipes from the live `app.css` tokens.
- [x] Each entry has a one-line when-to-use + canonical markup.
- [x] A CLAUDE.md directive instructs agents to consult it and use tokens (no raw hex / ad-hoc styles).
- [x] No new hardcoded color/spacing literals — every color is `var(--color-*)`, every size `var(--fs-*)`.

## Open-question decisions

- **Dev-only vs real route → internal, unlinked route, i18n-exempt.** It's a developer/agent reference (only reached by navigating to `/design-system`), which CLAUDE.md marks as exempt from i18n. Keeps the i18n surface clean while still rendering live.
- **Directive home → project `CLAUDE.md`, not the spawn house rules.** The spawn `ENGINEERING_POSTURE` block is repo-independent and injects into *every* managed repo; a "consult Shepherd's `/design-system` + use `--color-*`" rule is Shepherd-specific and would be noise elsewhere. `CLAUDE.md` is the Shepherd-repo-scoped channel.
- **Raw-hex lint/gate → deferred** (issue marks optional). Directive + review for now; a heuristic gate flagging off-token colors in `ui/src/lib/components/**` is a sensible follow-up.

## Notes

- Internal dev/agent reference, no end-user UX → exempt from the feature catalog via `[no-feature-entry]` (gate skips loudly) and from i18n.
- Verified: `bun run check` (0 errors), `check:i18n` (parity), `bun run build`, prettier/eslint via lint-staged, branch-hygiene + feature-catalog gates all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)