### PR TITLE
fix(poller): gate stall on live-terminal liveness, not transcript-silence alone

### DIFF
--- a/src/poller.ts
+++ b/src/poller.ts
@@ -166,6 +166,9 @@ export class StatusPoller {
    * We confirm with a live-terminal liveness diff: a turn still generating keeps
    * its spinner/elapsed/token counter ticking, so the visible buffer changes
    * between probes; only a frozen buffer + a silent transcript is a real stall.
+   * The diff applies ONLY to the pure-generation case (!pending) — a tool still
+   * running past `pendingStallMs` is a hung command whose elapsed timer also
+   * ticks, so it bypasses the gate and fires directly.
    * Surfaces as a "needs you" reason; fires once per episode (guarded by
    * `lastSig === STALL_SIG`) until the turn progresses, then re-arms.
    *
@@ -197,37 +200,70 @@ export class StatusPoller {
     }
 
     // ── stall decision: transcript candidate + live-terminal liveness gate ──
-    const snap = signals.snapshot;
+    this.evaluateStall(s, t, signals.snapshot);
+  }
+
+  /**
+   * Confirm or clear a stall for a running agent from its transcript snapshot.
+   * No candidate (transcript progressing) → clear any stall + reset baseline.
+   * A candidate reads the live terminal once (for the tail and the liveness diff).
+   * The diff applies ONLY to pure-generation candidates (`!pending`): a hung
+   * command (pending past the ceiling) keeps its "esc to interrupt" timer ticking,
+   * so it bypasses the gate and fires directly.
+   */
+  private evaluateStall(s: Session, t: number, snap: ActivitySnapshot | null): void {
     if (!snap || !isStalled(snap, t, this.stallCfg)) {
       this.clearBlock(s.id); // transcript progressed → clear any stall + reset baseline
       return;
     }
-    // Transcript silent past the window → stall *candidate*. Confirm against the
-    // live terminal: a turn still generating keeps ticking, so its visible buffer
-    // changes between probes; a wedged/idle turn leaves it frozen.
     let visible: string;
     try {
       visible = this.herdr.read(s.herdrAgentId, "visible");
     } catch {
-      return; // can't assess liveness this cycle → best-effort, retry next cadence
+      return; // can't assess this cycle → best-effort, retry next cadence
     }
-    const prev = this.lastVisible.get(s.id);
-    this.lastVisible.set(s.id, visible);
-    if (prev === undefined) return; // no baseline yet → defer one probe to compare
-    if (visible !== prev) {
-      // terminal still moving → the turn is alive, not stalled. Clear a stall that
-      // recovered; keep the fresh baseline (already set) for the next comparison.
-      if (this.lastSig.get(s.id) === STALL_SIG) {
-        this.lastSig.delete(s.id);
-        this.lastReadAt.delete(s.id);
-        this.onBlock(s.id, null);
-      }
+    // Pure-generation candidate: a terminal still ticking (or no baseline yet) is
+    // not a stall this cycle — clear one that recovered and wait. Pending (hung
+    // command) skips the gate and fires directly.
+    // NOTE: this is deliberately a "TUI alive" check, not "model progressing" —
+    // the buffer includes the client-side elapsed-seconds timer, so any rendering
+    // TUI reads as alive. That's the intended conservative tradeoff: it only fires
+    // when the TUI is fully frozen, which is exactly the false positive being fixed
+    // (a long generation turn whose TUI keeps rendering must NOT flag).
+    if (!snap.pending && this.sampleTerminal(s.id, visible) !== "frozen") {
+      this.clearStall(s.id);
       return;
     }
-    // transcript silent AND terminal frozen → genuine stall.
-    if (this.lastSig.get(s.id) === STALL_SIG) return; // already announced this episode
-    this.lastSig.set(s.id, STALL_SIG);
-    this.onBlock(s.id, { shape: "stall", options: [], tail: tailLines(visible) });
+    this.fireStall(s.id, visible);
+  }
+
+  /**
+   * Record the current visible buffer as the new liveness baseline and report how
+   * it compares to the previous sample. A turn still generating keeps its
+   * spinner/elapsed/token counter ticking, so the buffer moves between probes; a
+   * wedged/idle turn leaves it frozen. "fresh" on the first probe of an episode —
+   * nothing to compare against yet, so the caller defers one cycle.
+   */
+  private sampleTerminal(id: string, visible: string): "fresh" | "moving" | "frozen" {
+    const prev = this.lastVisible.get(id);
+    this.lastVisible.set(id, visible);
+    if (prev === undefined) return "fresh";
+    return visible === prev ? "frozen" : "moving";
+  }
+
+  /** Clear a live stall flag (no-op if none); leaves the terminal baseline intact. */
+  private clearStall(id: string): void {
+    if (this.lastSig.get(id) !== STALL_SIG) return;
+    this.lastSig.delete(id);
+    this.lastReadAt.delete(id);
+    this.onBlock(id, null);
+  }
+
+  /** Emit a stall block once per episode (guarded by `lastSig === STALL_SIG`). */
+  private fireStall(id: string, visible: string): void {
+    if (this.lastSig.get(id) === STALL_SIG) return; // already announced this episode
+    this.lastSig.set(id, STALL_SIG);
+    this.onBlock(id, { shape: "stall", options: [], tail: tailLines(visible) });
   }
 
   /** Read + classify a blocked agent at most every `reclassifyMs`; emit only on change. */

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -19,6 +19,12 @@ export class StatusPoller {
   private lastProbeAt = new Map<string, number>();
   private lastActivitySig = new Map<string, string>();
   private lastActivity = new Map<string, SessionActivity>();
+  /** Last visible-terminal buffer per stall-candidate session, for the liveness
+   *  diff. A transcript gone silent past the stall window only makes a turn a
+   *  *candidate*; comparing the live terminal across probes confirms it. A turn
+   *  still generating keeps its spinner/elapsed/token counter ticking, so the
+   *  buffer changes between probes; a wedged or idle turn leaves it frozen. */
+  private lastVisible = new Map<string, string>();
 
   constructor(
     private store: SessionStore,
@@ -123,6 +129,7 @@ export class StatusPoller {
       ...this.lastProbeAt.keys(),
       ...this.lastActivitySig.keys(),
       ...this.lastActivity.keys(),
+      ...this.lastVisible.keys(),
     ]);
     for (const id of tracked) {
       if (!activeIds.has(id)) {
@@ -131,6 +138,7 @@ export class StatusPoller {
         this.lastProbeAt.delete(id);
         this.lastActivitySig.delete(id);
         this.lastActivity.delete(id);
+        this.lastVisible.delete(id);
       }
     }
   }
@@ -150,10 +158,16 @@ export class StatusPoller {
    * Activity: emit the heartbeat/summary signal, deduped by content so clients
    * only receive genuine changes; a null signal (no transcript yet) is skipped.
    *
-   * Stall: flag a working agent gone silent — no new tool-use within the stall
-   * window (a tool still running is excluded until the hung-command ceiling).
+   * Stall: a working agent whose transcript has gone silent past the stall
+   * window (no new tool-use; a running tool is excluded until the hung-command
+   * ceiling) is only a *candidate*. A long pure-generation turn (writing a plan,
+   * deep thinking) emits no tool-use and flushes nothing to the transcript until
+   * it completes, so it looks identical to a wedged turn on the transcript alone.
+   * We confirm with a live-terminal liveness diff: a turn still generating keeps
+   * its spinner/elapsed/token counter ticking, so the visible buffer changes
+   * between probes; only a frozen buffer + a silent transcript is a real stall.
    * Surfaces as a "needs you" reason; fires once per episode (guarded by
-   * `lastSig === STALL_SIG`) until activity resumes, then re-arms.
+   * `lastSig === STALL_SIG`) until the turn progresses, then re-arms.
    *
    * Note: stall detection now runs at the (faster) `probeCheckMs` cadence rather
    * than the old 30s stall cadence. This only improves detection latency — the
@@ -182,21 +196,38 @@ export class StatusPoller {
       }
     }
 
-    // ── stall decision (identical to the former maybeStall) ──
+    // ── stall decision: transcript candidate + live-terminal liveness gate ──
     const snap = signals.snapshot;
     if (!snap || !isStalled(snap, t, this.stallCfg)) {
-      this.clearBlock(s.id); // activity resumed (or never stalled) → re-arm
+      this.clearBlock(s.id); // transcript progressed → clear any stall + reset baseline
       return;
     }
+    // Transcript silent past the window → stall *candidate*. Confirm against the
+    // live terminal: a turn still generating keeps ticking, so its visible buffer
+    // changes between probes; a wedged/idle turn leaves it frozen.
+    let visible: string;
+    try {
+      visible = this.herdr.read(s.herdrAgentId, "visible");
+    } catch {
+      return; // can't assess liveness this cycle → best-effort, retry next cadence
+    }
+    const prev = this.lastVisible.get(s.id);
+    this.lastVisible.set(s.id, visible);
+    if (prev === undefined) return; // no baseline yet → defer one probe to compare
+    if (visible !== prev) {
+      // terminal still moving → the turn is alive, not stalled. Clear a stall that
+      // recovered; keep the fresh baseline (already set) for the next comparison.
+      if (this.lastSig.get(s.id) === STALL_SIG) {
+        this.lastSig.delete(s.id);
+        this.lastReadAt.delete(s.id);
+        this.onBlock(s.id, null);
+      }
+      return;
+    }
+    // transcript silent AND terminal frozen → genuine stall.
     if (this.lastSig.get(s.id) === STALL_SIG) return; // already announced this episode
     this.lastSig.set(s.id, STALL_SIG);
-    let tail: string[] = [];
-    try {
-      tail = tailLines(this.herdr.read(s.herdrAgentId, "visible"));
-    } catch {
-      // terminal read is best-effort context; an empty tail still flags the stall
-    }
-    this.onBlock(s.id, { shape: "stall", options: [], tail });
+    this.onBlock(s.id, { shape: "stall", options: [], tail: tailLines(visible) });
   }
 
   /** Read + classify a blocked agent at most every `reclassifyMs`; emit only on change. */
@@ -231,6 +262,7 @@ export class StatusPoller {
   }
 
   private clearBlock(id: string): void {
+    this.lastVisible.delete(id); // reset the stall liveness baseline regardless of block state
     if (!this.lastSig.has(id)) return;
     this.lastSig.delete(id);
     this.lastReadAt.delete(id);

--- a/src/stall.ts
+++ b/src/stall.ts
@@ -18,16 +18,22 @@ export interface StallConfig {
 }
 
 export const DEFAULT_STALL: StallConfig = {
-  // 8m of pure think/generate time with zero new tool-use is abnormal; the
-  // pending-guard below already excludes legitimate long-running commands, so
-  // this only fires on a genuinely wedged turn. Single knob, easy to tune.
+  // 8m of transcript silence (no new tool-use) makes a turn a stall *candidate*,
+  // not a confirmed stall: a long pure-generation turn (plan/deep-think) is also
+  // tool-silent. The poller confirms candidates with a live-terminal liveness
+  // diff before alarming; the pending-guard below excludes long-running commands.
   stallMs: 8 * 60_000,
   // a tool that has been "running" for 20m with no result is almost certainly a
   // hung command (the pending-guard would otherwise mask it forever).
   pendingStallMs: 20 * 60_000,
 };
 
-/** Pure stall decision for a *working* agent, given its latest activity snapshot. */
+/**
+ * Pure transcript-silence decision for a *working* agent: true when its latest
+ * snapshot shows no forward progress within the window. This is a stall
+ * *candidate* — the poller confirms it against the live terminal before alarming,
+ * since a long tool-silent generation turn trips this too.
+ */
 export function isStalled(snap: ActivitySnapshot, now: number, cfg: StallConfig): boolean {
   if (snap.lastTs <= 0) return false; // no tool activity to measure a gap against yet
   const gap = now - snap.lastTs;

--- a/src/stall.ts
+++ b/src/stall.ts
@@ -18,13 +18,15 @@ export interface StallConfig {
 }
 
 export const DEFAULT_STALL: StallConfig = {
-  // 8m of transcript silence (no new tool-use) makes a turn a stall *candidate*,
-  // not a confirmed stall: a long pure-generation turn (plan/deep-think) is also
-  // tool-silent. The poller confirms candidates with a live-terminal liveness
-  // diff before alarming; the pending-guard below excludes long-running commands.
+  // 8m of transcript silence with the last tool *finished* makes a turn a stall
+  // *candidate*, not a confirmed stall: a long pure-generation turn (plan/deep-
+  // think) is also tool-silent. The poller confirms these !pending candidates with
+  // a live-terminal liveness diff before alarming.
   stallMs: 8 * 60_000,
   // a tool that has been "running" for 20m with no result is almost certainly a
-  // hung command (the pending-guard would otherwise mask it forever).
+  // hung command. The poller fires these pending candidates directly, bypassing
+  // the liveness diff — a hung command's "esc to interrupt" timer keeps the
+  // terminal ticking, so the diff would otherwise mask the hang forever.
   pendingStallMs: 20 * 60_000,
 };
 

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -208,11 +208,13 @@ test("clears an active block when the agent disappears", () => {
   expect(blocks[blocks.length - 1]).toEqual({ id: s.id, block: null }); // block cleared
 });
 
-test("flags a silent working agent as a stall, fires once, re-arms on resume", () => {
+test("flags a silent working agent with a FROZEN terminal as a stall, fires once, re-arms on resume", () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);
   const blocks: { id: string; block: unknown }[] = [];
 
+  // a frozen terminal — the visible buffer never changes between probes, so the
+  // liveness gate confirms the transcript-silence candidate as a genuine stall.
   const herdr = {
     list: (): HerdrAgent[] => [
       {
@@ -249,6 +251,12 @@ test("flags a silent working agent as a stall, fires once, re-arms on resume", (
     7000, // probeCheckMs
   );
 
+  // first candidate probe only captures a terminal baseline — no emit yet
+  poller.tick();
+  expect(blocks).toHaveLength(0);
+
+  // next probe: terminal unchanged + transcript silent → stall fires
+  clock += 7000;
   poller.tick();
   expect(blocks).toHaveLength(1);
   expect((blocks[0]!.block as any).shape).toBe("stall");
@@ -264,18 +272,124 @@ test("flags a silent working agent as a stall, fires once, re-arms on resume", (
   poller.tick();
   expect(blocks).toHaveLength(1);
 
-  // activity resumes → one clear, then re-arms for the next episode
+  // transcript progresses → one clear, then re-arms for the next episode
   stalled = false;
   clock += 7000;
   poller.tick();
   expect(blocks).toHaveLength(2);
   expect(blocks[1]).toEqual({ id: s.id, block: null });
 
+  // stalled again: baseline was reset on resume, so the first probe defers again…
   stalled = true;
+  clock += 7000;
+  poller.tick();
+  expect(blocks).toHaveLength(2);
+  // …and the next confirms the frozen terminal → fires
   clock += 7000;
   poller.tick();
   expect(blocks).toHaveLength(3);
   expect((blocks[2]!.block as any).shape).toBe("stall");
+});
+
+test("does NOT flag a transcript-silent agent whose terminal is still moving (live generation)", () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const blocks: { id: string; block: unknown }[] = [];
+
+  // the agent is mid-generation: no tool-use (transcript silent) but the spinner /
+  // token counter ticks, so the visible buffer changes every probe.
+  let frame = 0;
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working" as const,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => `Computing… (${frame}s • ${frame}k tokens)`,
+  };
+
+  let clock = 1_700_000_000_000;
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    () => ({ snapshot: { lastTs: clock - 600_000, pending: false }, activity: null }),
+    { stallMs: 1, pendingStallMs: 1 },
+    7000,
+  );
+
+  // probe across several cadences — the terminal changes each time → never a stall
+  for (let i = 0; i < 4; i++) {
+    frame += 13;
+    poller.tick();
+    clock += 7000;
+  }
+  expect(blocks).toHaveLength(0);
+});
+
+test("clears an emitted stall when the terminal resumes moving even before the transcript catches up", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const blocks: { id: string; block: unknown }[] = [];
+
+  // transcript stays silent throughout (slow tool-less turn); only the terminal
+  // tells us whether the turn is alive.
+  let visible = "frozen";
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working" as const,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => visible,
+  };
+
+  let clock = 1_700_000_000_000;
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    () => ({ snapshot: { lastTs: clock - 600_000, pending: false }, activity: null }),
+    { stallMs: 1, pendingStallMs: 1 },
+    7000,
+  );
+
+  poller.tick(); // baseline
+  clock += 7000;
+  poller.tick(); // frozen → stall fires
+  expect(blocks).toHaveLength(1);
+  expect((blocks[0]!.block as any).shape).toBe("stall");
+
+  // terminal resumes ticking while the transcript is still silent → clear the stall
+  visible = "Computing… (601s)";
+  clock += 7000;
+  poller.tick();
+  expect(blocks).toHaveLength(2);
+  expect(blocks[1]).toEqual({ id: s.id, block: null });
 });
 
 test("acknowledgeStall clears the flag without re-firing while still stalled", () => {
@@ -318,7 +432,10 @@ test("acknowledgeStall clears the flag without re-firing while still stalled", (
     7000, // probeCheckMs
   );
 
-  poller.tick(); // stall fires
+  poller.tick(); // baseline capture, no emit yet
+  expect(blocks).toHaveLength(0);
+  clock += 7000;
+  poller.tick(); // frozen terminal → stall fires
   expect(blocks).toHaveLength(1);
   expect((blocks[0]!.block as any).shape).toBe("stall");
 
@@ -332,14 +449,16 @@ test("acknowledgeStall clears the flag without re-firing while still stalled", (
   poller.tick();
   expect(blocks).toHaveLength(2);
 
-  // activity resumes → episode re-arms; acknowledgeStall now no-ops (no live stall)
+  // transcript progresses → episode re-arms; acknowledgeStall now no-ops (no live stall)
   stalled = false;
   clock += 7000;
   poller.tick();
   expect(poller.acknowledgeStall(s.id)).toBe(false);
 
-  // a later stall fires again
+  // a later stall fires again (baseline reset on resume → defer one probe, then fire)
   stalled = true;
+  clock += 7000;
+  poller.tick();
   clock += 7000;
   poller.tick();
   expect((blocks[blocks.length - 1]!.block as any).shape).toBe("stall");

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -339,6 +339,60 @@ test("does NOT flag a transcript-silent agent whose terminal is still moving (li
   expect(blocks).toHaveLength(0);
 });
 
+test("fires a stall for a hung command (pending past the ceiling) even when the terminal keeps ticking", () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const blocks: { id: string; block: unknown }[] = [];
+
+  // a tool stuck "running" past pendingStallMs: its "esc to interrupt" elapsed
+  // timer keeps the visible buffer changing every probe. The liveness diff must
+  // NOT treat that motion as alive — the pending path bypasses the gate.
+  let frame = 0;
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working" as const,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => `$ slow-cmd  (esc to interrupt · ${frame}s)`,
+  };
+
+  let clock = 1_700_000_000_000;
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    // pending=true → the hung-command path; gap (600s) is past pendingStallMs (1ms)
+    () => ({ snapshot: { lastTs: clock - 600_000, pending: true }, activity: null }),
+    { stallMs: 1, pendingStallMs: 1 },
+    7000,
+  );
+
+  // pending candidate fires immediately (no baseline defer) despite the moving terminal
+  frame += 5;
+  poller.tick();
+  expect(blocks).toHaveLength(1);
+  expect((blocks[0]!.block as any).shape).toBe("stall");
+
+  // still hung + still ticking → once per episode, no re-fire / no false clear
+  frame += 5;
+  clock += 7000;
+  poller.tick();
+  expect(blocks).toHaveLength(1);
+});
+
 test("clears an emitted stall when the terminal resumes moving even before the transcript catches up", () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);


### PR DESCRIPTION
## Problem

A task showed **NEEDS YOU** while its agent was clearly working — mid-generation, "Computing… 43.9k tokens", writing an implementation plan.

Stall detection was **transcript-only**. A long pure-generation turn (writing a plan, deep thinking) emits no `tool_use` and flushes nothing to the JSONL transcript until the message completes, so `latestRecordTs` freezes. Once that gap crossed `stallMs` (8m), `isStalled` returned true and the poller emitted a `{shape:"stall"}` block → the card joined NEEDS YOU even though the model was actively burning tokens. herdr's `agentStatus` stays `"working"` the whole time and can't distinguish live-generation from wedged.

## Fix

`isStalled` is now only a **candidate** signal ("transcript silent past the window"). Before emitting a stall, the poller confirms it with a **live-terminal liveness diff** (`src/poller.ts` `maybeProbe`):

- compare the live herdr terminal buffer across probes;
- **buffer changed** (spinner / elapsed / token counter ticking) → turn is alive → suppress, and clear any stall that recovered;
- **buffer frozen** + transcript silent → genuine stall → emit.

Buffer comparison (not string-parsing) is version/i18n-proof. Details:

- First candidate probe captures a baseline and defers one ~7s cycle (negligible vs the 8m window).
- Terminal reads happen **only on already-suspect** (transcript-silent) sessions; the emit-time `tail` reuses the same read — no double read.
- A herdr read error skips the cycle (best-effort) — neither false-alarms nor false-clears.
- New `lastVisible` map pruned in `pruneInactive`, reset in `clearBlock`.
- Stale comments in `src/stall.ts` (the "8m of think-time is abnormal" claim + `isStalled` doc) corrected to candidate-vs-confirmed semantics.

### Accepted tradeoff

A hung in-flight LLM request whose spinner keeps ticking reads as "alive" — Claude Code's own retry/timeout handles that, and hung *tools* are still caught by the unchanged `pendingStallMs` (20m).

## Tests

- 2 new poller tests: live-generation (changing terminal) never flags; an emitted stall clears when the terminal resumes moving while the transcript is still silent.
- 2 existing stall tests updated for the baseline-capture cycle.
- `bun test ./test` → 1170 pass, 0 fail · `bun run lint` clean · `bunx tsc --noEmit` clean.

No UI/i18n/feature-catalog impact — server-only plumbing that makes an existing badge accurate. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)