### PR TITLE
fix(ui): show jump-to-bottom when agent output lands below a hair-scrolled pane

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -22,6 +22,7 @@
   import { composeKeystrokes } from "$lib/compose";
   import { shouldForwardEscape } from "$lib/terminalEscape";
   import { detectNotesKey } from "$lib/notesAffordance";
+  import { isScrolledAwayFromBottom } from "$lib/scrollAffordance";
   import TodoPanel from "$lib/components/TodoPanel.svelte";
   import IssuesPanel from "$lib/components/IssuesPanel.svelte";
   import ActivityFeed from "$lib/components/ActivityFeed.svelte";
@@ -126,6 +127,12 @@
   // plain (non-reactive) — only `scrolledUp` drives the UI. Reset on re-attach,
   // buffer switch, and a jump-to-bottom.
   let scrollDepth = 0;
+  // agent-owned regime only: new output landed while the reader was scrolled up
+  // (any amount). xterm's viewport stays pinned there, so a sub-threshold nudge
+  // followed by fresh agent output — common while the pane is backgrounded —
+  // would otherwise never surface the jump-to-bottom button. Plain (non-reactive)
+  // like scrollDepth; cleared when the reader is back at the bottom or jumps down.
+  let contentBelowScroll = false;
   let dragging = $state(false);
   // The key to press for Claude's "add notes" prompt option, scraped live from
   // the painted screen (null when the prompt isn't offering it). On a phone
@@ -457,6 +464,7 @@
       term.scrollToBottom();
     }
     scrollDepth = 0;
+    contentBelowScroll = false;
     scrolledUp = false;
   }
 
@@ -557,6 +565,7 @@
     parked = false; // fresh attach for this unit
     scrolledUp = false; // fresh terminal starts pinned to the bottom
     scrollDepth = 0;
+    contentBelowScroll = false;
     notesKey = null; // no prompt scraped yet on this fresh terminal
 
     // initial palette: non-reactive DOM read so this effect doesn't depend on
@@ -780,20 +789,35 @@
     });
     ro.observe(el);
 
-    // track scroll position so we can offer a jump-to-bottom button. When the
-    // agent owns the scroll (alternate screen, or mouse-tracking on the normal
-    // buffer like Claude Code) it forwards wheel input to the app and xterm's
-    // viewport never moves, so we lean on the gesture accumulator. Otherwise the
-    // normal buffer carries scrollback → read xterm's viewport offset directly.
-    const SCROLL_UP_PX = 30; // small swipe / one wheel notch before the button shows
+    // track scroll position so we can offer a jump-to-bottom button. The two
+    // regimes (gesture accumulator vs. xterm viewport offset) and why content
+    // arrival matters are documented in `isScrolledAwayFromBottom`.
     const recomputeScrolled = () => {
       const b = term.buffer.active;
-      scrolledUp = agentOwnsScroll(term) ? scrollDepth > SCROLL_UP_PX : b.baseY - b.viewportY > 0;
+      if (scrollDepth === 0) contentBelowScroll = false; // back at the bottom → re-arm
+      scrolledUp = isScrolledAwayFromBottom({
+        agentOwnsScroll: agentOwnsScroll(term),
+        scrollDepth,
+        contentBelowScroll,
+        viewportOffsetLines: b.baseY - b.viewportY,
+      });
     };
     const scrollSub = term.onScroll(recomputeScrolled);
     const bufSub = term.buffer.onBufferChange(() => {
       scrollDepth = 0;
       recomputeScrolled();
+    });
+    // When the agent owns the scroll xterm's viewport never moves, so onScroll
+    // can't tell us the reader fell behind a fresh burst of agent output. Watch
+    // the write stream: if content lands while they're scrolled up at all (even a
+    // sub-threshold nudge), surface the jump-to-bottom button. This also fires
+    // while the term tab is backgrounded, so the button is already armed when the
+    // reader switches back. No-op in the xterm-owned regime (scrollDepth stays 0).
+    const writeSub = term.onWriteParsed(() => {
+      if (scrollDepth > 0 && !contentBelowScroll) {
+        contentBelowScroll = true;
+        recomputeScrolled();
+      }
     });
 
     // Surface Claude Code's "press n to add notes" prompt option as a tappable
@@ -837,6 +861,7 @@
       el?.removeEventListener("wheel", onWheelTrack, { capture: true });
       scrollSub.dispose();
       bufSub.dispose();
+      writeSub.dispose();
       renderSub.dispose();
       ro.disconnect();
       c.close();

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -812,9 +812,10 @@
     // the write stream: if content lands while they're scrolled up at all (even a
     // sub-threshold nudge), surface the jump-to-bottom button. This also fires
     // while the term tab is backgrounded, so the button is already armed when the
-    // reader switches back. No-op in the xterm-owned regime (scrollDepth stays 0).
+    // reader switches back. Agent-owned regime only — xterm-owned scroll already
+    // tracks writes via onScroll.
     const writeSub = term.onWriteParsed(() => {
-      if (scrollDepth > 0 && !contentBelowScroll) {
+      if (agentOwnsScroll(term) && scrollDepth > 0 && !contentBelowScroll) {
         contentBelowScroll = true;
         recomputeScrolled();
       }

--- a/ui/src/lib/scrollAffordance.test.ts
+++ b/ui/src/lib/scrollAffordance.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { isScrolledAwayFromBottom, SCROLL_UP_PX } from "./scrollAffordance";
+
+const base = {
+  agentOwnsScroll: false,
+  scrollDepth: 0,
+  contentBelowScroll: false,
+  viewportOffsetLines: 0,
+};
+
+describe("isScrolledAwayFromBottom — xterm owns the scrollback", () => {
+  it("pinned to the bottom → no button", () => {
+    expect(isScrolledAwayFromBottom({ ...base, viewportOffsetLines: 0 })).toBe(false);
+  });
+
+  it("scrolled up any whole line → button", () => {
+    expect(isScrolledAwayFromBottom({ ...base, viewportOffsetLines: 1 })).toBe(true);
+  });
+
+  it("ignores the gesture accumulator in this regime", () => {
+    // scrollDepth is only fed while the agent owns the scroll; here it stays 0
+    expect(isScrolledAwayFromBottom({ ...base, viewportOffsetLines: 0, scrollDepth: 999 })).toBe(
+      false,
+    );
+  });
+});
+
+describe("isScrolledAwayFromBottom — agent owns the scroll", () => {
+  const agent = { ...base, agentOwnsScroll: true };
+
+  it("pinned to the bottom → no button", () => {
+    expect(isScrolledAwayFromBottom({ ...agent, scrollDepth: 0 })).toBe(false);
+  });
+
+  it("deliberate scroll past the threshold → button immediately", () => {
+    expect(isScrolledAwayFromBottom({ ...agent, scrollDepth: SCROLL_UP_PX + 1 })).toBe(true);
+  });
+
+  it("a sub-threshold nudge alone → no button (anti-flicker on a quiet pane)", () => {
+    expect(isScrolledAwayFromBottom({ ...agent, scrollDepth: 12 })).toBe(false);
+  });
+
+  it("the reported bug: nudged up a hair, then new content arrives below → button", () => {
+    expect(isScrolledAwayFromBottom({ ...agent, scrollDepth: 12, contentBelowScroll: true })).toBe(
+      true,
+    );
+  });
+
+  it("content-below only counts while scrolled up — back at the bottom re-arms it", () => {
+    // caller clears contentBelowScroll once scrollDepth returns to 0
+    expect(isScrolledAwayFromBottom({ ...agent, scrollDepth: 0, contentBelowScroll: false })).toBe(
+      false,
+    );
+  });
+});

--- a/ui/src/lib/scrollAffordance.ts
+++ b/ui/src/lib/scrollAffordance.ts
@@ -1,0 +1,39 @@
+// Decides whether the terminal's jump-to-bottom button should show — i.e. the
+// reader is parked above the latest output. There are two scroll regimes (see
+// `agentOwnsScroll` in Viewport.svelte) and the signal differs between them:
+//
+//  • xterm owns the scrollback (plain shell, mouse-tracking off): the normal
+//    buffer carries scrollback and xterm's viewport actually moves, so we read
+//    its line offset directly. xterm fires `onScroll` on every write, so this
+//    stays accurate as new content streams in — any whole-line offset shows it.
+//
+//  • the agent owns the scroll (alternate screen, or mouse-tracking on the
+//    normal buffer like Claude Code): the app grabs the wheel and repaints its
+//    own scrolled view, so xterm's viewport never moves and we have no position
+//    to read — only the user's gesture accumulator (`scrollDepth`). A deliberate
+//    scroll past the threshold shows the button immediately. But a sub-threshold
+//    nudge ("scrolled up just a hair") moves the viewport nowhere we can see, so
+//    if the agent then prints new output below the reader — common while the
+//    pane is backgrounded — the gesture total alone never reveals it. The caller
+//    watches the write stream and sets `contentBelowScroll` once content lands
+//    while the reader is scrolled up at all, which surfaces the button too.
+export const SCROLL_UP_PX = 30; // small swipe / one wheel notch before the button shows
+
+export interface ScrollAffordanceState {
+  agentOwnsScroll: boolean;
+  // agent-owned regime: px-ish accumulator of net upward scrolling
+  scrollDepth: number;
+  // agent-owned regime: new output arrived while the reader was scrolled up
+  // (any amount), so they're now parked above the latest even if the gesture
+  // never crossed SCROLL_UP_PX
+  contentBelowScroll: boolean;
+  // xterm-owned regime: viewport line offset from the latest row (baseY - viewportY)
+  viewportOffsetLines: number;
+}
+
+export function isScrolledAwayFromBottom(s: ScrollAffordanceState): boolean {
+  if (s.agentOwnsScroll) {
+    return s.scrollDepth > SCROLL_UP_PX || s.contentBelowScroll;
+  }
+  return s.viewportOffsetLines > 0;
+}


### PR DESCRIPTION
## Problem

The terminal's jump-to-bottom button didn't appear when **new content arrived in a pane that wasn't in focus** and the reader had **scrolled up just a hair**.

## Root cause

There are two scroll regimes (`agentOwnsScroll` in `Viewport.svelte`):

- **xterm owns the scrollback** (plain shell): xterm's viewport actually moves and `onScroll` fires on every write, so `scrolledUp` (`baseY − viewportY > 0`) stays accurate as content streams in. *No bug here* — verified by reproducing in the Chromium test env: after scrolling up one line, `baseY−viewportY` grew 1→6 as five lines were written and five `onScroll` events fired.

- **the agent owns the scroll** (Claude Code's mouse-tracking TUI — `mouseTrackingMode: vt200`): the app grabs the wheel and repaints its own scrolled view, so **xterm's viewport never moves**. `scrolledUp` rode entirely on the gesture accumulator `scrollDepth` and was **blind to content arrival**. So a sub-threshold nudge (≤ `SCROLL_UP_PX`) followed by a burst of agent output — typically while the term tab was backgrounded — left the reader parked above the latest output with no button.

## Fix

Subscribe to `term.onWriteParsed`: when content lands while the reader is scrolled up *at all* (`scrollDepth > 0`), set a `contentBelowScroll` flag that surfaces the button — even when the gesture never crossed the threshold. It fires while the tab is hidden too, so the button is already armed when the reader switches back. The flag is cleared when they return to the bottom (`scrollDepth === 0`) or jump down.

The 30px anti-flicker threshold is preserved for a fresh nudge on a *quiet* pane (no button until content actually arrives). The xterm-owned regime is unchanged (the write hook is a no-op there since `scrollDepth` stays 0).

The show/hide decision is extracted into a pure, documented predicate `isScrolledAwayFromBottom` (mirroring `terminalEscape.ts` / `notesAffordance.ts`) with unit tests covering both regimes and the reported scenario.

## Verification

- `src/lib/scrollAffordance.test.ts` — 8 cases, both regimes + the bug scenario, pass
- `bun run check` (svelte-check) — 0 errors
- `bun run check:i18n` — parity OK (no new strings)
- full node test project — 495/495 pass
- prettier/eslint clean (lint-staged on commit)

Bug fix, no new user-facing surface → no feature-catalog entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)