### PR TITLE
fix(poller): don't flip a session to MERGED on a reused branch name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   clampReviewCyclesCap,
 } from "./config";
 import { SessionStore } from "./store";
+import type { Session } from "./types";
 import { WorktreeMgr } from "./worktree";
 import { HerdrDriver, matchAgent } from "./herdr";
 import { generateName } from "./namer";
@@ -157,6 +158,10 @@ attachPush(events, store, push);
 
 // poll PR status for active sessions every 120s; push session:git on change so
 // the list overview badges stay current without opening each session's detail.
+// reject a merged/closed PR that `gh pr list --head <name>` matched only by a
+// reused branch name — its head commit won't be reachable from this branch's tip.
+// Shared by the background poller and the on-demand git endpoint so they agree.
+const ownsPr = (s: Session, headSha: string) => worktree.containsCommit(s.worktreePath, headSha);
 const prPoller = new PrPoller(
   store,
   resolveForge,
@@ -168,9 +173,7 @@ const prPoller = new PrPoller(
   (s) => service.syncWorktreeBranch(s.id),
   undefined,
   undefined,
-  // reject a merged/closed PR that `gh pr list --head <name>` matched only by a
-  // reused branch name — its head commit won't be reachable from this branch's tip
-  (s, headSha) => worktree.containsCommit(s.worktreePath, headSha),
+  ownsPr,
 );
 setTimeout(() => void prPoller.tick(), 3_000); // warm the cache shortly after boot
 prPoller.start();
@@ -572,6 +575,7 @@ const server = serve(
     herdr,
     resolveForge,
     prCache: prPoller,
+    ownsPr,
     activity: { snapshot: () => poller.activitySnapshot() },
     push,
     presence,

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,11 @@ const prPoller = new PrPoller(
   // on a "no PR" miss, adopt the agent's renamed worktree branch so its open PR
   // is recognized instead of staying invisible against the stale stored branch
   (s) => service.syncWorktreeBranch(s.id),
+  undefined,
+  undefined,
+  // reject a merged/closed PR that `gh pr list --head <name>` matched only by a
+  // reused branch name — its head commit won't be reachable from this branch's tip
+  (s, headSha) => worktree.containsCommit(s.worktreePath, headSha),
 );
 setTimeout(() => void prPoller.tick(), 3_000); // warm the cache shortly after boot
 prPoller.start();

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -131,6 +131,30 @@ export class PrPoller implements PrCache {
     }
   }
 
+  /** `gh pr list --head <branch>` matches by branch NAME only and `--state all`
+   *  includes history, so a prior, already-merged PR that reused this branch name
+   *  surfaces as a terminal hit even though this session opened no PR. Trust a
+   *  merged/closed PR only when its head commit is reachable from the session's
+   *  branch tip; otherwise it's a name collision — drop it back to "none" so the
+   *  row doesn't flip to a false MERGED. Applied to every poll result (stored and
+   *  adopted-live branch alike). Open PRs are the inherently-current one, so they
+   *  pass through untouched. */
+  private rejectStaleTerminal(s: Session, git: GitState): GitState {
+    if (
+      (git.state === "merged" || git.state === "closed") &&
+      git.headSha &&
+      this.ownsPr(s, git.headSha) === false
+    ) {
+      return {
+        kind: git.kind,
+        state: "none",
+        checks: "none",
+        deployConfigured: git.deployConfigured,
+      };
+    }
+    return git;
+  }
+
   /** Poll one session and emit `session:git` if its PR state moved. Shared by
    *  the full sweep and the targeted `pollSession` path. */
   private async refresh(s: Session): Promise<void> {
@@ -138,35 +162,19 @@ export class PrPoller implements PrCache {
     if (!forge || !s.branch) return; // no PR possible — leave uncached
     let git: GitState;
     try {
-      git = { kind: forge.kind, ...(await forge.prStatus(s.branch)) };
+      git = this.rejectStaleTerminal(s, { kind: forge.kind, ...(await forge.prStatus(s.branch)) });
     } catch {
       return; // transient gh failure → keep last cached value
     }
-    // `gh pr list --head <branch>` matches by branch NAME only and `--state all`
-    // includes history, so a prior, already-merged PR that reused this branch name
-    // surfaces as a terminal hit even though this session opened no PR. Trust a
-    // merged/closed PR only when its head commit is reachable from the session's
-    // branch tip; otherwise it's a name collision — drop it back to "none" so the
-    // reconcile path below runs and the row doesn't flip to a false MERGED.
-    if (
-      (git.state === "merged" || git.state === "closed") &&
-      git.headSha &&
-      this.ownsPr(s, git.headSha) === false
-    ) {
-      git = {
-        kind: forge.kind,
-        state: "none",
-        checks: "none",
-        deployConfigured: git.deployConfigured,
-      };
-    }
     // No PR for the stored branch — the agent may have renamed the worktree's
-    // branch out from under us. Adopt the live branch and retry against it.
+    // branch out from under us. Adopt the live branch and retry against it. The
+    // adopted branch is just as susceptible to a reused-name terminal hit, so run
+    // the same ownership guard over its status too.
     if (git.state === "none") {
       const live = this.reconcileBranch(s);
       if (live) {
         try {
-          git = { kind: forge.kind, ...(await forge.prStatus(live)) };
+          git = this.rejectStaleTerminal(s, { kind: forge.kind, ...(await forge.prStatus(live)) });
         } catch {
           return;
         }

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -72,6 +72,11 @@ export class PrPoller implements PrCache {
     private fastIntervalMs = 15_000,
     /** Max open PRs polled per fast tick; the rest rotate in on later ticks. */
     private fastBatch = 8,
+    /** Whether a name-matched terminal (merged/closed) PR's head commit actually
+     *  belongs to the session's branch. Guards against `gh pr list --head <name>`
+     *  returning a prior, already-merged PR that merely reused this branch name.
+     *  `false` → discard the stale PR; `true`/`null` → trust it. */
+    private ownsPr: (s: Session, headSha: string) => boolean | null = () => true,
   ) {}
 
   async tick(): Promise<void> {
@@ -136,6 +141,24 @@ export class PrPoller implements PrCache {
       git = { kind: forge.kind, ...(await forge.prStatus(s.branch)) };
     } catch {
       return; // transient gh failure → keep last cached value
+    }
+    // `gh pr list --head <branch>` matches by branch NAME only and `--state all`
+    // includes history, so a prior, already-merged PR that reused this branch name
+    // surfaces as a terminal hit even though this session opened no PR. Trust a
+    // merged/closed PR only when its head commit is reachable from the session's
+    // branch tip; otherwise it's a name collision — drop it back to "none" so the
+    // reconcile path below runs and the row doesn't flip to a false MERGED.
+    if (
+      (git.state === "merged" || git.state === "closed") &&
+      git.headSha &&
+      this.ownsPr(s, git.headSha) === false
+    ) {
+      git = {
+        kind: forge.kind,
+        state: "none",
+        checks: "none",
+        deployConfigured: git.deployConfigured,
+      };
     }
     // No PR for the stored branch — the agent may have renamed the worktree's
     // branch out from under us. Adopt the live branch and retry against it.

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -10,6 +10,34 @@ export interface PrCache {
   drop(id: string): void;
 }
 
+/** `gh pr list --head <branch>` matches by branch NAME only and `--state all`
+ *  includes history, so a prior, already-merged PR that reused this branch name
+ *  surfaces as a terminal hit even though the session opened no PR. Trust a
+ *  merged/closed PR only when its head commit is reachable from the session's
+ *  branch tip (`owns(headSha)` — true/false/null when unknowable); otherwise it's
+ *  a name collision, so drop it to "none" rather than flip the row to a false
+ *  MERGED. Open PRs are the inherently-current one and pass through untouched.
+ *  Pure + shared so the background poller and the on-demand GET endpoint guard
+ *  identically — the list overview and GitRail can't disagree. */
+export function guardStaleTerminal(
+  git: GitState,
+  owns: (headSha: string) => boolean | null,
+): GitState {
+  if (
+    (git.state === "merged" || git.state === "closed") &&
+    git.headSha &&
+    owns(git.headSha) === false
+  ) {
+    return {
+      kind: git.kind,
+      state: "none",
+      checks: "none",
+      deployConfigured: git.deployConfigured,
+    };
+  }
+  return git;
+}
+
 /**
  * Polls PR status for active sessions and caches it in memory. One `gh` process
  * runs at a time (sequential awaits) to bound the synchronous `execFileSync`
@@ -131,28 +159,10 @@ export class PrPoller implements PrCache {
     }
   }
 
-  /** `gh pr list --head <branch>` matches by branch NAME only and `--state all`
-   *  includes history, so a prior, already-merged PR that reused this branch name
-   *  surfaces as a terminal hit even though this session opened no PR. Trust a
-   *  merged/closed PR only when its head commit is reachable from the session's
-   *  branch tip; otherwise it's a name collision — drop it back to "none" so the
-   *  row doesn't flip to a false MERGED. Applied to every poll result (stored and
-   *  adopted-live branch alike). Open PRs are the inherently-current one, so they
-   *  pass through untouched. */
+  /** Reject a reused-name terminal PR for `s` via the shared `guardStaleTerminal`.
+   *  Applied to every poll result (stored and adopted-live branch alike). */
   private rejectStaleTerminal(s: Session, git: GitState): GitState {
-    if (
-      (git.state === "merged" || git.state === "closed") &&
-      git.headSha &&
-      this.ownsPr(s, git.headSha) === false
-    ) {
-      return {
-        kind: git.kind,
-        state: "none",
-        checks: "none",
-        deployConfigured: git.deployConfigured,
-      };
-    }
-    return git;
+    return guardStaleTerminal(git, (headSha) => this.ownsPr(s, headSha));
   }
 
   /** Poll one session and emit `session:git` if its PR state moved. Shared by

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,7 +44,7 @@ import type { HerdrDriver } from "./herdr";
 import { matchAgent } from "./herdr";
 import type { GitForge, GitState, MergeMethod } from "./forge/types";
 import { DEPENDABOT_REBASE_COMMAND } from "./forge/types";
-import type { PrCache } from "./pr-poller";
+import { type PrCache, guardStaleTerminal } from "./pr-poller";
 import type { PushService } from "./push";
 import type { Presence } from "./presence";
 import type { StatusPoller } from "./poller";
@@ -95,6 +95,11 @@ export interface AppDeps {
   /** In-memory PR-status cache surfaced in the list overview; absent in tests
    *  that don't exercise it. */
   prCache?: PrCache;
+  /** Whether a name-matched terminal PR's head commit belongs to the session's
+   *  branch — same guard the poller injects, so the on-demand git endpoint can't
+   *  flip GitRail to a false MERGED on a reused-name collision. Absent → unguarded
+   *  (tests). */
+  ownsPr?: (s: Session, headSha: string) => boolean | null;
   /** Last-emitted activity signal per running session, for client bootstrap; absent in tests that skip it. */
   activity?: { snapshot(): Record<string, SessionActivity> };
   /** Web Push delivery; absent in tests that don't exercise notifications. */
@@ -1104,8 +1109,12 @@ async function dispatchForgeAction(
 ): Promise<Response | null> {
   const { req, parts, deps } = ctx;
   if (req.method === "GET") {
-    if (!parts[4])
-      return json({ kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) });
+    if (!parts[4]) {
+      const git: GitState = { kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) };
+      // Same guard as the background poller: a merged/closed PR matched only by a
+      // reused branch name is dropped to "none" so GitRail and the list agree.
+      return json(guardStaleTerminal(git, (headSha) => deps.ownsPr?.(session, headSha) ?? null));
+    }
     return null;
   }
   if (req.method === "POST") {

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -147,6 +147,39 @@ export class WorktreeMgr {
     return null; // no usable base ref → unknown
   }
 
+  /** Whether `sha` is reachable from the branch tip checked out at `worktreePath`
+   *  — i.e. the commit genuinely belongs to this session's branch. Used to reject
+   *  a PR that `gh pr list --head <name>` matched purely on branch NAME: a prior,
+   *  already-merged PR that reused this branch name reports a head commit that this
+   *  freshly-cut branch does not contain. Returns:
+   *    true  → `sha` is HEAD or an ancestor of it (this branch's own commit)
+   *    false → `sha` is absent locally OR not an ancestor (a foreign / stale PR)
+   *    null  → unknowable (bad worktree / git error) → caller keeps the PR as-is
+   */
+  containsCommit(worktreePath: string, sha: string): boolean | null {
+    if (!/^[0-9a-fA-F]{7,64}$/.test(sha)) return null;
+    try {
+      execFileSync("git", ["cat-file", "-e", `${sha}^{commit}`], {
+        cwd: worktreePath,
+        stdio: "pipe",
+      });
+    } catch {
+      return false; // object not in this worktree's store → not our branch's commit
+    }
+    try {
+      execFileSync("git", ["merge-base", "--is-ancestor", sha, "HEAD"], {
+        cwd: worktreePath,
+        stdio: "pipe",
+      });
+      return true; // reachable from HEAD → this session's own commit
+    } catch (err) {
+      // exit 1 = "not an ancestor" → foreign commit; any other exit (e.g. 128, a
+      // bad worktree) is unknowable → null (caller leaves the PR untouched).
+      if ((err as { status?: number }).status === 1) return false;
+      return null;
+    }
+  }
+
   remove(worktreePath: string, opts?: { branch?: string | null; baseBranch?: string }): void {
     let mainRepo: string | null = null;
     if (existsSync(worktreePath)) {

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -154,7 +154,20 @@ export class WorktreeMgr {
    *  freshly-cut branch does not contain. Returns:
    *    true  → `sha` is HEAD or an ancestor of it (this branch's own commit)
    *    false → `sha` is absent locally OR not an ancestor (a foreign / stale PR)
-   *    null  → unknowable (bad worktree / git error) → caller keeps the PR as-is
+   *    null  → unknowable (worktree unusable / git couldn't run) → caller keeps the PR
+   *
+   *  Two known limitations of the reachability test:
+   *  - **Assumes squash/rebase merges** (this repo's policy — merge commits are
+   *    disabled). Under those, a merged feature commit is NOT an ancestor of main,
+   *    so a reused-name branch cut from main fails to reach the old PR head → the
+   *    collision is caught. On a repo using plain *merge commits*, the old PR's
+   *    head stays reachable from main, so a fresh same-name branch would still
+   *    "own" it and the collision would slip through.
+   *  - **Transient false-negative after a self-rebase.** If a session's own PR
+   *    merges and the still-active branch is then rebased/reset, the PR head is no
+   *    longer an ancestor of HEAD, so a genuine MERGED is dropped to `none`. Rare
+   *    (a session usually archives once its PR lands) and self-heals once the PR
+   *    head returns to the history; acceptable versus the false-MERGED it prevents.
    */
   containsCommit(worktreePath: string, sha: string): boolean | null {
     if (!/^[0-9a-fA-F]{7,64}$/.test(sha)) return null;
@@ -163,8 +176,12 @@ export class WorktreeMgr {
         cwd: worktreePath,
         stdio: "pipe",
       });
-    } catch {
-      return false; // object not in this worktree's store → not our branch's commit
+    } catch (err) {
+      // git ran and reported the object missing (numeric exit) → a clean miss, the
+      // commit isn't in this branch's store → false. No exit code means git never
+      // ran (e.g. ENOENT on an unusable worktree cwd) → unknowable → null, so the
+      // caller doesn't mistake a broken worktree for a foreign PR.
+      return typeof (err as { status?: number }).status === "number" ? false : null;
     }
     try {
       execFileSync("git", ["merge-base", "--is-ancestor", sha, "HEAD"], {
@@ -173,10 +190,9 @@ export class WorktreeMgr {
       });
       return true; // reachable from HEAD → this session's own commit
     } catch (err) {
-      // exit 1 = "not an ancestor" → foreign commit; any other exit (e.g. 128, a
-      // bad worktree) is unknowable → null (caller leaves the PR untouched).
-      if ((err as { status?: number }).status === 1) return false;
-      return null;
+      // exit 1 = "not an ancestor" → foreign commit; any other exit (e.g. 128) or a
+      // spawn failure is unknowable → null (caller leaves the PR untouched).
+      return (err as { status?: number }).status === 1 ? false : null;
     }
   }
 

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -312,6 +312,99 @@ const OPEN_PENDING: PrStatus = {
   deployConfigured: false,
 };
 
+const MERGED: PrStatus = {
+  state: "merged",
+  number: 344,
+  checks: "success",
+  headSha: "deadbee",
+  deployConfigured: false,
+};
+
+test("discards a merged PR whose head commit isn't on this session's branch (name collision)", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const emitted: { state: string; number?: number }[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forgeReturning(() => MERGED), // a stale, name-matched merged PR
+    (_id, git) => emitted.push({ state: git.state, number: git.number }),
+    120_000,
+    1000,
+    () => null, // no other branch to adopt
+    15_000,
+    8,
+    () => false, // head commit does NOT belong to this session's branch
+  );
+
+  await poller.tick();
+  // the false MERGED is dropped to none — the row stays in "active", not "merged"
+  expect(emitted).toEqual([{ state: "none", number: undefined }]);
+  expect(poller.snapshot()[s.id]?.state).toBe("none");
+});
+
+test("keeps a merged PR whose head commit is on this session's branch", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const emitted: { state: string; number?: number }[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forgeReturning(() => MERGED),
+    (_id, git) => emitted.push({ state: git.state, number: git.number }),
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => true, // genuinely this session's own merged PR
+  );
+
+  await poller.tick();
+  expect(emitted).toEqual([{ state: "merged", number: 344 }]);
+});
+
+test("keeps a merged PR when ownership is unknowable (null) rather than hiding it", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const emitted: { state: string }[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forgeReturning(() => MERGED),
+    (_id, git) => emitted.push({ state: git.state }),
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => null, // bad worktree / git error → don't mask a real merge
+  );
+
+  await poller.tick();
+  expect(emitted).toEqual([{ state: "merged" }]);
+});
+
+test("never runs the ownership check for an open PR (name match is current)", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  let ownsCalls = 0;
+  const poller = new PrPoller(
+    store,
+    () => forgeReturning(() => OPEN),
+    () => {},
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => {
+      ownsCalls++;
+      return false;
+    },
+  );
+
+  await poller.tick();
+  expect(ownsCalls).toBe(0); // open PRs are inherently the live one — no guard needed
+});
+
 test("fast tick re-polls only open PRs — accelerating in-flight CI", async () => {
   const store = new SessionStore(":memory:");
   store.create({ ...baseSession, branch: "shepherd/a" }); // open PR (CI running)

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -405,6 +405,29 @@ test("never runs the ownership check for an open PR (name match is current)", as
   expect(ownsCalls).toBe(0); // open PRs are inherently the live one — no guard needed
 });
 
+test("applies the ownership guard to an adopted live branch's terminal PR too", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession); // stored branch shepherd/x has no PR
+  const emitted: { state: string; number?: number }[] = [];
+  const poller = new PrPoller(
+    store,
+    // stored branch → none, forcing reconcile; adopted branch → a stale merged PR
+    () => forgeByBranch({ "shepherd/renamed": MERGED }),
+    (_id, git) => emitted.push({ state: git.state, number: git.number }),
+    120_000,
+    1000,
+    () => "shepherd/renamed", // agent renamed the worktree branch
+    15_000,
+    8,
+    () => false, // the adopted branch's merged head isn't this session's commit
+  );
+
+  await poller.tick();
+  // the reused-name merged hit on the adopted branch is rejected, not re-introduced
+  expect(emitted).toEqual([{ state: "none", number: undefined }]);
+  expect(poller.snapshot()[s.id]?.state).toBe("none");
+});
+
 test("fast tick re-polls only open PRs — accelerating in-flight CI", async () => {
   const store = new SessionStore(":memory:");
   store.create({ ...baseSession, branch: "shepherd/a" }); // open PR (CI running)

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -127,6 +127,45 @@ test("GET /api/sessions/:id/git → kind + PrStatus", async () => {
   expect(f.log).toContain("status:shepherd/add-feature");
 });
 
+test("GET git drops a merged PR whose head isn't on the session's branch (name collision)", async () => {
+  const f = fakeForge({
+    prStatus: async () => ({
+      state: "merged",
+      number: 344,
+      checks: "success",
+      headSha: "deadbee",
+      deployConfigured: true,
+    }),
+  });
+  // ownsPr says the merged head doesn't belong to this branch → guard to none, so
+  // GitRail matches the (guarded) list overview instead of flashing a false MERGED.
+  const deps = Object.assign(makeDeps(f), { ownsPr: () => false });
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.state).toBe("none");
+  expect(body.number).toBeUndefined();
+});
+
+test("GET git keeps a merged PR owned by the session's branch", async () => {
+  const f = fakeForge({
+    prStatus: async () => ({
+      state: "merged",
+      number: 5,
+      checks: "success",
+      headSha: "deadbee",
+      deployConfigured: true,
+    }),
+  });
+  const deps = Object.assign(makeDeps(f), { ownsPr: () => true });
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  const body = await res.json();
+  expect(body.state).toBe("merged");
+  expect(body.number).toBe(5);
+});
+
 test("GET git → 404 when no forge for repo", async () => {
   const app = makeApp(makeDeps(null));
   const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -90,6 +90,14 @@ test("containsCommit distinguishes this branch's commits from a foreign (name-co
   wt.remove(r.worktreePath);
 });
 
+test("containsCommit returns null (not false) when the worktree path is unusable", () => {
+  const wt = new WorktreeMgr();
+  // git can't run against a non-existent cwd → spawn failure, no exit code. This
+  // must be unknowable (null), not a clean miss (false): a broken worktree is not
+  // evidence the commit is foreign.
+  expect(wt.containsCommit(join(repo, "does-not-exist"), "a".repeat(40))).toBeNull();
+});
+
 test("remove force-deletes the workspace even when git worktree remove refuses", () => {
   const wt = new WorktreeMgr();
   // a populated dir inside the repo that git does NOT track as a worktree:

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -57,6 +57,39 @@ test("currentBranch returns null on a detached HEAD", () => {
   wt.remove(r.worktreePath);
 });
 
+test("containsCommit distinguishes this branch's commits from a foreign (name-collision) head", () => {
+  const gitEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+  const wt = new WorktreeMgr();
+
+  // A "foreign" commit on a branch that this session's branch will NOT contain —
+  // stand-in for a prior, already-merged PR's head that reused the branch name.
+  execFileSync("git", ["checkout", "-q", "-b", "old-feature"], { cwd: repo });
+  writeFileSync(join(repo, "old.txt"), "old");
+  execFileSync("git", ["add", "old.txt"], { cwd: repo });
+  execFileSync("git", ["commit", "-q", "-m", "old work"], { cwd: repo, env: gitEnv });
+  const foreignSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo }).toString().trim();
+  execFileSync("git", ["checkout", "-q", "main"], { cwd: repo });
+
+  // Fresh session worktree cut from main — it never contained `foreignSha`.
+  const r = wt.create(repo, "main", "capture-signals");
+  const ownSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: r.worktreePath })
+    .toString()
+    .trim();
+
+  expect(wt.containsCommit(r.worktreePath, ownSha)).toBe(true); // own branch tip
+  expect(wt.containsCommit(r.worktreePath, foreignSha)).toBe(false); // foreign PR head
+  expect(wt.containsCommit(r.worktreePath, "0".repeat(40))).toBe(false); // absent object
+  expect(wt.containsCommit(r.worktreePath, "nonsense!")).toBeNull(); // malformed → unknown
+
+  wt.remove(r.worktreePath);
+});
+
 test("remove force-deletes the workspace even when git worktree remove refuses", () => {
   const wt = new WorktreeMgr();
   // a populated dir inside the repo that git does NOT track as a worktree:


### PR DESCRIPTION
## Why

A just-started session was filed under **MERGED** in the herd list despite having opened no PR. Confirmed live: the session's worktree branch is `shepherd/shepherd-capture-signals`, and a prior, already-merged **#344** used that exact head branch.

The PR poller resolves state with `gh pr list --head <branch> --state all --limit 1` (`src/forge/github.ts`). `--head` matches **by branch name only** and `--state all` includes history, so it returned the long-merged #344. `prStatus` reported `state: "merged"`, the poller cached it, and `partitionSessions` filed the session under MERGED on `git.state === "merged"`.

This is a branch-name collision — worktrees always name the branch `shepherd/${name}` (`src/worktree.ts`), so any session whose name repeats a previously-merged one inherits that PR's terminal state. The PR numbers in the agent's terminal output are unrelated — nothing scans transcript text for merge state.

## Fix

Trust a merged/closed PR only when its head commit is actually reachable from the session's branch tip:

- `WorktreeMgr.containsCommit(worktreePath, sha)` — `true` if `sha` is HEAD or an ancestor, `false` if absent locally or not an ancestor (a foreign/stale PR), `null` on git error.
- The poller injects this as `ownsPr`; on a merged/closed hit whose head commit isn't owned, it drops the result back to `none` so the row stays active. Open PRs are inherently the live one (a branch has at most one), so they skip the check. `null` (unknowable) keeps the PR to avoid masking a real merge.

## Tests

- `pr-poller`: discards a foreign merged PR → `none`; keeps an owned merged PR; keeps it on `null`; never runs the check for open PRs.
- `worktree`: `containsCommit` distinguishes own branch tip (true) from a foreign head, absent object, and malformed sha.

Full root suite (1177), tsc, lint, and `fallow audit` all green.

[no-feature-entry] server-only poller fix, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)