### PR TITLE
feat(extension): capture delivery targets + URL→repo routing

### DIFF
--- a/docs/superpowers/plans/2026-06-08-shepherd-capture-delivery-routing.md
+++ b/docs/superpowers/plans/2026-06-08-shepherd-capture-delivery-routing.md
@@ -1,0 +1,222 @@
+# Shepherd Capture — Delivery & Routing (#341) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Shepherd Capture two delivery targets — the existing spawn-now **session** plus a new **GitHub-issue** path — and route a capture to the right repo automatically via configurable **URL→repo rules**, instead of one fixed `repoPath`.
+
+**Architecture:** Reuse Phase-1's pure-core + thin-glue split.
+- **Server (root):** a new optional forge method `createIssue` (GitHub via `gh issue create`, Gitea via the issues REST API) behind a new `POST /api/issues` route that mirrors `handleSessionCreate`'s repo-confinement + JSON guards. Bun-tested.
+- **Extension:** a new pure `routing.ts` (`resolveRepo`) + extended `transport.ts` (`fileIssue`) + `config`/`types`, vitest-tested; popup gains a delivery-target picker + issue-title field + computed effective-repo line; options gains a URL→repo rules editor. EN+DE catalogs extended.
+
+**Tech Stack:** TypeScript, Bun (root), Svelte 5 + Tailwind 4.1 + Paraglide + vitest (extension), `gh`/Gitea REST (forge).
+
+**Out of scope (later):** embedding the screenshot *into* a GitHub issue (GitHub markdown can't reference the confined local upload path; the issue body carries the metadata/signals context block only, the screenshot stays a spawn-now-only attachment — documented in the popup). Element picker / full-page stitch (#342), keyboard shortcut / toolbar icons (#343).
+
+---
+
+## File Structure
+
+```
+src/
+  forge/types.ts        # +createIssue?(o:{title,body}) → {number,url}            (Task 1)
+  forge/github.ts       # implement createIssue via `gh issue create`            (Task 1)
+  forge/gitea.ts        # implement createIssue via POST /repos/:slug/issues      (Task 1)
+  server.ts             # +handleIssueCreate (POST /api/issues), register it      (Task 2)
+test/
+  server-issues.test.ts # NEW: POST /api/issues happy + 400 paths                (Task 2)
+
+extension/src/
+  lib/types.ts          # +RoutingRule, +DeliveryTarget, extend CaptureConfig /
+                        #  SpawnPayload (repoPath override) / WorkerRequest        (Task 3)
+  lib/routing.ts        # NEW pure: resolveRepo(url, rules, fallback)              (Task 4)
+  lib/config.ts         # +routingRules default + merge                           (Task 5)
+  lib/transport.ts      # +fileIssue(); thread repoPath override into spawnNow     (Task 6)
+  background.ts         # +"file-issue" worker branch; pass repoPath through        (Task 7)
+  popup/Popup.svelte    # delivery picker + title field + effective-repo line      (Task 8)
+  options/Options.svelte# URL→repo rules editor                                    (Task 9)
+extension/messages/{en,de}.json  # +delivery/routing/issue keys                    (Task 10)
+extension/test/
+  routing.test.ts       # NEW: resolveRepo                                         (Task 4)
+  transport.test.ts     # extend: fileIssue                                        (Task 6)
+extension/README.md     # delivery targets + routing rules + manual checklist      (Task 11)
+```
+
+Run server tasks from repo root (`bun install`, `bun run lint`, `bun test ./test`). Run extension tasks from `extension/` (`bun install`, `bun run check`, `bun run check:i18n`, `bun run test`).
+
+---
+
+### Task 1: Forge `createIssue`
+
+**Files:** `src/forge/types.ts`, `src/forge/github.ts`, `src/forge/gitea.ts`
+
+- [ ] **types.ts** — add to `GitForge`, alongside the other optional write methods (keep it optional, gated like `comment?`/`closeIssue?`):
+  ```ts
+  /** Open a new issue (capture-extension delivery path). Returns the created
+   *  issue's number + URL. Optional: hosts without an issue-create API omit it
+   *  and POST /api/issues 400s. */
+  createIssue?(o: { title: string; body: string }): Promise<{ number: number; url: string }>;
+  ```
+- [ ] **github.ts** — implement via the existing `this.run` (`gh`):
+  - `gh issue create --repo <slug> --title <title> --body <body>` prints the new issue URL on stdout.
+  - Parse `number` from the trailing `/<n>` of the URL; return `{ number, url }` (trimmed).
+- [ ] **gitea.ts** — implement via the existing `this.req` helper: `POST /api/v1/repos/<slug>/issues` with `{ title, body }`; map response `{ number, html_url }` → `{ number, url }`.
+- [ ] **Verify:** `bun run lint` + `bunx tsc --noEmit` clean.
+
+**Note:** model `createIssue` on the existing `openPr` (github) / `closeIssue` (gitea) shapes — same runner/req, same error propagation (no try/catch; let it throw so the route maps it to 502).
+
+---
+
+### Task 2: `POST /api/issues` route + tests
+
+**Files:** `src/server.ts`, `test/server-issues.test.ts`
+
+- [ ] Add `handleIssueCreate({ req, parts, deps })` modeled on `handleSessionCreate` + `handleActionsRerun`:
+  - Match `POST` + `parts[0]==="api"` + `parts[1]==="issues"` + `!parts[2]`; else `return null`.
+  - `requireJsonContentType(req)` guard.
+  - Body `{ repo, title, body }`. `safeRepoDir(body.repo ?? "", config.repoRoot)` → 400 `invalid repo` if falsy.
+  - Validate `title`: non-empty trimmed string ≤ 200 chars → 400 else. `body`: string ≤ 16000 chars (empty allowed) → 400 else.
+  - `const forge = deps.resolveForge?.(dir) ?? null;` → `if (!forge?.createIssue) return json({ error: "issues unavailable for repo" }, 400);`
+  - `try { const issue = await forge.createIssue({ title, body }); return json({ ...issue, slug: forge.slug }, 201); } catch (e) { return json({ error: e instanceof Error ? e.message : "issue create failed" }, 502); }`
+- [ ] Register `handleIssueCreate` in `ROUTE_HANDLERS` (next to `handleIssues`).
+- [ ] **test/server-issues.test.ts** (model on `test/server-backlog.test.ts`'s `fakeForge`/`buildDeps`):
+  - 201: POST valid `{ repo, title, body }` to a forge whose `createIssue` returns `{ number: 7, url }` → body has `number`, `url`, `slug`.
+  - 400: invalid/out-of-root repo; missing/blank title; forge without `createIssue`.
+  - 502: `createIssue` throws.
+- [ ] **Verify:** `bun test ./test` green; `bun run lint` clean.
+
+---
+
+### Task 3: Extension types
+
+**File:** `extension/src/lib/types.ts`
+
+- [ ] Add:
+  ```ts
+  /** One URL→repo routing rule. `pattern` is a glob (`*` wildcards) matched
+   *  case-insensitively against the captured tab's full URL; first match wins. */
+  export interface RoutingRule { pattern: string; repoPath: string; }
+  /** Where a capture is delivered. */
+  export type DeliveryTarget = "session" | "issue";
+  ```
+- [ ] Extend `CaptureConfig` with `routingRules: RoutingRule[]`.
+- [ ] Extend `SpawnPayload` with `repoPath: string` (the routing-resolved effective repo; replaces the implicit `config.repoPath` at spawn time).
+- [ ] Add issue request to the envelope:
+  ```ts
+  | { type: "file-issue"; payload: { repoPath: string; title: string; prompt: string; metadata: PageMetadata; signals?: CapturedSignals } }
+  ```
+  and the response `| { ok: true; type: "issue"; number: number; url: string }`.
+- [ ] **Verify:** `cd extension && bun run check` (will fail until later tasks compile callers — acceptable mid-plan; final verify in Task 8/9).
+
+---
+
+### Task 4: `routing.ts` (pure) + tests
+
+**Files:** `extension/src/lib/routing.ts` (new), `extension/test/routing.test.ts` (new)
+
+- [ ] `resolveRepo(url: string, rules: RoutingRule[], fallback: string): string`:
+  - For each rule in order: skip if `pattern.trim()` or `repoPath.trim()` empty; convert glob → anchored case-insensitive regex (escape regex metachars, `*` → `.*`); if it matches `url`, return `rule.repoPath`.
+  - No match → `fallback`.
+  - Guard against an invalid pattern throwing (treat as no-match).
+- [ ] **routing.test.ts:** exact host match wins; `*` wildcard; first-match-wins ordering; empty pattern skipped; no-match → fallback; case-insensitive.
+- [ ] **Verify:** `cd extension && bun run test` green for this file.
+
+---
+
+### Task 5: config defaults
+
+**File:** `extension/src/lib/config.ts`
+
+- [ ] Add `routingRules: []` to `DEFAULT_CONFIG`.
+- [ ] In `loadConfig`, carry `routingRules` through (it's covered by the existing `...stored` spread; just ensure the default is present so a never-saved config has `[]`). No deep-merge needed (array replace is correct).
+
+---
+
+### Task 6: transport `fileIssue` + repo override + tests
+
+**Files:** `extension/src/lib/transport.ts`, `extension/test/transport.test.ts`
+
+- [ ] Thread the effective repo: add `repoPath: string` to `SpawnInput`; in `createSession` use `input.repoPath` instead of `config.repoPath`. Update `spawnNow` signature/caller accordingly.
+- [ ] Add:
+  ```ts
+  /** File the capture as a GitHub/Gitea issue: title + (prompt + context block) body.
+   *  No screenshot upload — a remote issue can't reference the confined local path. */
+  export async function fileIssue(fetchFn, config, input: {
+    repoPath: string; title: string; prompt: string; metadata: PageMetadata; signals?: CapturedSignals;
+  }): Promise<{ number: number; url: string }>
+  ```
+  - `body = \`${input.prompt}\n\n${formatContextBlock(input.metadata, input.signals)}\``.
+  - POST `${config.baseUrl}/api/issues` with `application/json` + auth headers, `{ repo: input.repoPath, title: input.title, body }`.
+  - Reuse `ensureOk`/`kindForStatus`/the `unreachable` catch exactly like `createSession`.
+  - Parse `{ number, url }`; throw `TransportError("unknown", …)` if either missing.
+- [ ] **transport.test.ts:** extend the existing fetch-stub style — `fileIssue` posts the right URL/body and returns `{number,url}`; a 400 surfaces `invalid`; an unreachable fetch surfaces `unreachable`.
+- [ ] **Verify:** `cd extension && bun run test` green.
+
+---
+
+### Task 7: background worker branch
+
+**File:** `extension/src/background.ts`
+
+- [ ] In the `onMessage` handler add a `req.type === "file-issue"` branch: `loadConfig()`, call `fileIssue(fetch, config, req.payload)`, `sendResponse({ ok: true, type: "issue", number, url })`. `TransportError` maps as in the spawn branch.
+- [ ] Update the existing `spawn` branch to pass `repoPath: req.payload.repoPath` into `spawnNow`.
+
+---
+
+### Task 8: popup delivery picker + title + effective repo
+
+**File:** `extension/src/popup/Popup.svelte`
+
+- [ ] Compute `let effectiveRepo = $derived(capture ? resolveRepo(capture.metadata.url, config?.routingRules ?? [], config?.repoPath ?? "") : (config?.repoPath ?? ""))`.
+- [ ] Replace the static repo line (`m.popup_repo_label`) with one showing `effectiveRepo`; when it differs from `config.repoPath`, append a subtle "(routed)" hint (`m.popup_repo_routed`).
+- [ ] Add a delivery-target control (two radios or a `<select>`): `m.popup_target_session` (default) / `m.popup_target_issue`, bound to `let target = $state<DeliveryTarget>("session")`.
+- [ ] When `target === "issue"`: show a title `<input>` bound to `issueTitle`, prefilled once from `capture.metadata.title`. The screenshot/attach checkbox stays visible but a note (`m.popup_issue_no_screenshot`) clarifies it's session-only; disable the screenshot checkbox in issue mode.
+- [ ] `submit()` branches on `target`:
+  - `session` → existing spawn, now with `repoPath: effectiveRepo`.
+  - `issue` → require non-empty `issueTitle` (else `m.popup_issue_empty_title` error); send `{ type: "file-issue", payload: { repoPath: effectiveRepo, title: issueTitle, prompt, metadata, signals } }`; on success set `done` view showing `m.popup_issue_success({ number })` as a link to `url`.
+- [ ] Keep the existing empty-prompt guard for both targets.
+- [ ] **Verify:** `cd extension && bun run check` clean.
+
+---
+
+### Task 9: options routing-rules editor
+
+**File:** `extension/src/options/Options.svelte`
+
+- [ ] Add a "Routing rules" `<fieldset>` (mirrors the Signals one): legend `m.options_routing_title`, hint `m.options_routing_hint`.
+- [ ] Render `config.routingRules` as rows, each with a `pattern` input (`m.options_routing_pattern_ph`), a `repoPath` input (`m.options_routing_repo_ph`), and a remove button (`m.options_routing_remove`, `aria-label`).
+- [ ] An "Add rule" button (`m.options_routing_add`) appends `{ pattern: "", repoPath: "" }`.
+- [ ] Rules persist with the rest of the form on **Save** (already `saveConfig(config)`); drop fully-empty rows (both fields blank) on save so the list stays clean.
+- [ ] **Verify:** `cd extension && bun run check` clean.
+
+---
+
+### Task 10: i18n catalogs
+
+**Files:** `extension/messages/en.json`, `extension/messages/de.json`
+
+- [ ] Add every new key to **both** catalogs (EN + DE), snake_case, `popup_`/`options_` prefixed:
+  `popup_target_label`, `popup_target_session`, `popup_target_issue`, `popup_repo_routed`,
+  `popup_issue_title_label`, `popup_issue_no_screenshot`, `popup_issue_empty_title`,
+  `popup_issue_success` (`{number}`), `options_routing_title`, `options_routing_hint`,
+  `options_routing_pattern_ph`, `options_routing_repo_ph`, `options_routing_add`,
+  `options_routing_remove`.
+- [ ] **Verify:** `cd extension && bun run check:i18n` passes (key-set parity).
+
+---
+
+### Task 11: README + final verification
+
+**File:** `extension/README.md`
+
+- [ ] Document the two delivery targets + the URL→repo rules (format, first-match-wins, glob) + the screenshot-not-in-issues caveat. Extend the manual load-unpacked checklist with: file-as-issue happy path, a routing rule overriding the default repo, and the issue-title required guard.
+- [ ] **Final verify (both packages):**
+  - Root: `bun run lint` && `bunx tsc --noEmit` && `bun test ./test`.
+  - Extension: `bun run check` && `bun run check:i18n` && `bun run test` && `bun run lint`.
+
+---
+
+## Unresolved questions
+
+1. Screenshot-in-issue omitted (can't embed confined local path) — accept body-only issues? **Assumed yes.**
+2. Routing match = glob on full URL, first-match-wins — vs host-only? **Assumed full-URL glob** (more flexible, host is a substring case).
+3. `createIssue` optional + per-forge gated (GitHub + Gitea both implemented) — vs GitHub-only? **Assumed both.**

--- a/extension/README.md
+++ b/extension/README.md
@@ -66,7 +66,7 @@ enter the fenced context block, so a crafted page can't break out of the fence.
 - **Spawn session** (default) — the Phase-1 path: uploads the screenshot (when
   attached) and spawns a live Shepherd session whose prompt is your text plus the
   fenced context block.
-- **GitHub issue** — files the capture as an issue (title + body) on the target
+- **Issue** — files the capture as an issue (title + body) on the target
   repo's forge (GitHub via `gh`, Gitea via its API) instead of spawning. The issue
   body is your prompt plus the same fenced metadata/signals block. The popup shows
   an **Issue title** field (prefilled from the page title; required). A screenshot

--- a/extension/README.md
+++ b/extension/README.md
@@ -34,9 +34,10 @@ Open the extension's **options** (right-click the icon → Options) and set:
     it once and captures file against your remote core. Revoke any time from
     `chrome://extensions`. Any other host is rejected.
 - **Token** — required only if the server runs with `SHEPHERD_TOKEN` set.
-- **Repo path** — must resolve inside the server's `SHEPHERD_REPO_ROOT`
-  (e.g. `~/Work/my-repo`).
+- **Repo path** — the default target repo; must resolve inside the server's
+  `SHEPHERD_REPO_ROOT` (e.g. `~/Work/my-repo`).
 - **Base branch**, **Model** (optional).
+- **Routing rules** (optional) — see [Delivery & routing](#delivery--routing).
 
 ## Signals
 
@@ -57,6 +58,32 @@ popup; set defaults in **Options**:
 
 All page-derived strings are sanitized (newline/backtick-neutralized) before they
 enter the fenced context block, so a crafted page can't break out of the fence.
+
+## Delivery & routing
+
+**Delivery target** (picked per-capture in the popup):
+
+- **Spawn session** (default) — the Phase-1 path: uploads the screenshot (when
+  attached) and spawns a live Shepherd session whose prompt is your text plus the
+  fenced context block.
+- **GitHub issue** — files the capture as an issue (title + body) on the target
+  repo's forge (GitHub via `gh`, Gitea via its API) instead of spawning. The issue
+  body is your prompt plus the same fenced metadata/signals block. The popup shows
+  an **Issue title** field (prefilled from the page title; required). A screenshot
+  is **not** embedded — a remote issue can't reference the confined local upload
+  path — so the attach checkbox is disabled in issue mode; the metadata and signals
+  still ride in the body.
+
+**URL→repo rules** (optional, in **Options**): map a captured tab's URL to a target
+repo so a capture files against the right project automatically instead of the
+single default **Repo path**. Each rule is a `pattern → repo path` pair:
+
+- The **pattern** is a glob (`*` wildcards) matched case-insensitively against the
+  tab's full URL, e.g. `https://app.example.com/*` or `*staging.example.com*`.
+- Rules are evaluated top-to-bottom; the **first match wins**. No match falls back
+  to the default **Repo path**.
+- The popup shows the resolved repo and a **(routed)** hint when a rule overrode the
+  default. Routing applies to both delivery targets.
 
 ## Server setup (one-time)
 
@@ -108,8 +135,16 @@ If you skip this, spawn-now returns `403` and the popup shows the
       **Save** shows Chrome's host-access prompt once; accepting saves, and a
       capture files against the remote core. (Entering a non-localhost,
       non-`ts.net` host shows the "unsupported host" message and doesn't save.)
+- [ ] Selecting **GitHub issue** as the delivery target shows the title field
+      (prefilled from the page title) and disables the screenshot checkbox; filing
+      with a non-empty title opens an issue on the target repo and the popup shows
+      `Filed issue #N` linking to it. Clearing the title and filing shows the
+      "enter an issue title" message instead.
+- [ ] Adding a routing rule whose pattern matches the current tab (e.g.
+      `https://github.com/*` → a different repo) makes the popup show that repo with
+      a **(routed)** hint, and the capture files against it; a non-matching tab falls
+      back to the default repo.
 
 ## Out of scope (later phases — see issue #338)
 
-GitHub-issue delivery path, URL→repo rules, element picker, full-page stitch,
-keyboard shortcut, toolbar icons.
+Element picker, full-page stitch (#342); keyboard shortcut, toolbar icons (#343).

--- a/extension/messages/de.json
+++ b/extension/messages/de.json
@@ -60,6 +60,7 @@
   "popup_issue_title_label": "Issue-Titel",
   "popup_issue_no_screenshot": "Screenshots werden nicht in Issues eingebettet – Metadaten & Signale stehen im Issue-Text.",
   "popup_issue_empty_title": "Gib einen Issue-Titel ein.",
+  "popup_issue_title_too_long": "Der Issue-Titel darf höchstens 200 Zeichen lang sein.",
   "popup_issue_success": "Issue #{number} angelegt.",
   "options_routing_title": "Routing-Regeln",
   "options_routing_hint": "Ordne die URL eines erfassten Tabs einem Ziel-Repository zu. Muster sind Globs (*-Platzhalter), die gegen die vollständige URL geprüft werden; der erste Treffer gewinnt, sonst wird das Repository oben verwendet.",

--- a/extension/messages/de.json
+++ b/extension/messages/de.json
@@ -52,5 +52,19 @@
   "options_signals_a11y_label": "Bei der Erfassung einen Barrierefreiheits-Audit (axe-core) ausführen",
   "options_recorder_label": "Konsolenfehler & fehlgeschlagene Netzwerkanfragen aufzeichnen",
   "options_recorder_allsites_note": "Die Aufzeichnung liest Konsolenausgaben und Netzwerkfehler auf jeder besuchten Seite – einschließlich vollständiger Anfrage-URLs (Query-Strings können Tokens enthalten) – und übermittelt sie mit der Aufgabe an Shepherd. Aktiviere sie nur bei Bedarf; beim Ausschalten wird die Alle-Seiten-Berechtigung entzogen.",
-  "options_recorder_denied": "Berechtigung verweigert – Aufzeichnung bleibt aus."
+  "options_recorder_denied": "Berechtigung verweigert – Aufzeichnung bleibt aus.",
+  "popup_target_label": "Ausliefern als",
+  "popup_target_session": "Sitzung starten",
+  "popup_target_issue": "GitHub-Issue",
+  "popup_repo_routed": "(geroutet)",
+  "popup_issue_title_label": "Issue-Titel",
+  "popup_issue_no_screenshot": "Screenshots werden nicht in Issues eingebettet – Metadaten & Signale stehen im Issue-Text.",
+  "popup_issue_empty_title": "Gib einen Issue-Titel ein.",
+  "popup_issue_success": "Issue #{number} angelegt.",
+  "options_routing_title": "Routing-Regeln",
+  "options_routing_hint": "Ordne die URL eines erfassten Tabs einem Ziel-Repository zu. Muster sind Globs (*-Platzhalter), die gegen die vollständige URL geprüft werden; der erste Treffer gewinnt, sonst wird das Repository oben verwendet.",
+  "options_routing_pattern_ph": "https://app.example.com/*",
+  "options_routing_repo_ph": "~/Work/my-repo",
+  "options_routing_add": "Regel hinzufügen",
+  "options_routing_remove": "Entfernen"
 }

--- a/extension/messages/de.json
+++ b/extension/messages/de.json
@@ -61,6 +61,7 @@
   "popup_issue_no_screenshot": "Screenshots werden nicht in Issues eingebettet – Metadaten & Signale stehen im Issue-Text.",
   "popup_issue_empty_title": "Gib einen Issue-Titel ein.",
   "popup_issue_title_too_long": "Der Issue-Titel darf höchstens 200 Zeichen lang sein.",
+  "popup_issue_body_too_long": "Das Issue ist zu lang – kürze den Prompt oder deaktiviere einige Signale.",
   "popup_issue_success": "Issue #{number} angelegt.",
   "options_routing_title": "Routing-Regeln",
   "options_routing_hint": "Ordne die URL eines erfassten Tabs einem Ziel-Repository zu. Muster sind Globs (*-Platzhalter), die gegen die vollständige URL geprüft werden; der erste Treffer gewinnt, sonst wird das Repository oben verwendet.",

--- a/extension/messages/de.json
+++ b/extension/messages/de.json
@@ -55,7 +55,7 @@
   "options_recorder_denied": "Berechtigung verweigert – Aufzeichnung bleibt aus.",
   "popup_target_label": "Ausliefern als",
   "popup_target_session": "Sitzung starten",
-  "popup_target_issue": "GitHub-Issue",
+  "popup_target_issue": "Issue",
   "popup_repo_routed": "(geroutet)",
   "popup_issue_title_label": "Issue-Titel",
   "popup_issue_no_screenshot": "Screenshots werden nicht in Issues eingebettet – Metadaten & Signale stehen im Issue-Text.",

--- a/extension/messages/en.json
+++ b/extension/messages/en.json
@@ -55,7 +55,7 @@
   "options_recorder_denied": "Permission denied — recording stays off.",
   "popup_target_label": "Deliver as",
   "popup_target_session": "Spawn session",
-  "popup_target_issue": "GitHub issue",
+  "popup_target_issue": "Issue",
   "popup_repo_routed": "(routed)",
   "popup_issue_title_label": "Issue title",
   "popup_issue_no_screenshot": "Screenshots aren't embedded in issues — the metadata & signals go in the issue body.",

--- a/extension/messages/en.json
+++ b/extension/messages/en.json
@@ -52,5 +52,19 @@
   "options_signals_a11y_label": "Run an accessibility (axe-core) audit on capture",
   "options_recorder_label": "Record console errors & failed network requests",
   "options_recorder_allsites_note": "Recording reads console output and network failures on every site you visit, including full request URLs (query strings may contain tokens), and forwards them to Shepherd in the task. Enable only while you need it; turn it off to revoke the all-sites permission.",
-  "options_recorder_denied": "Permission denied — recording stays off."
+  "options_recorder_denied": "Permission denied — recording stays off.",
+  "popup_target_label": "Deliver as",
+  "popup_target_session": "Spawn session",
+  "popup_target_issue": "GitHub issue",
+  "popup_repo_routed": "(routed)",
+  "popup_issue_title_label": "Issue title",
+  "popup_issue_no_screenshot": "Screenshots aren't embedded in issues — the metadata & signals go in the issue body.",
+  "popup_issue_empty_title": "Enter an issue title.",
+  "popup_issue_success": "Filed issue #{number}.",
+  "options_routing_title": "Routing rules",
+  "options_routing_hint": "Map a captured tab's URL to a target repo. Patterns are globs (* wildcards) matched against the full URL; first match wins, otherwise the repo above is used.",
+  "options_routing_pattern_ph": "https://app.example.com/*",
+  "options_routing_repo_ph": "~/Work/my-repo",
+  "options_routing_add": "Add rule",
+  "options_routing_remove": "Remove"
 }

--- a/extension/messages/en.json
+++ b/extension/messages/en.json
@@ -61,6 +61,7 @@
   "popup_issue_no_screenshot": "Screenshots aren't embedded in issues — the metadata & signals go in the issue body.",
   "popup_issue_empty_title": "Enter an issue title.",
   "popup_issue_title_too_long": "Issue title must be 200 characters or fewer.",
+  "popup_issue_body_too_long": "The issue is too long — trim the prompt or turn off some signals.",
   "popup_issue_success": "Filed issue #{number}.",
   "options_routing_title": "Routing rules",
   "options_routing_hint": "Map a captured tab's URL to a target repo. Patterns are globs (* wildcards) matched against the full URL; first match wins, otherwise the repo above is used.",

--- a/extension/messages/en.json
+++ b/extension/messages/en.json
@@ -60,6 +60,7 @@
   "popup_issue_title_label": "Issue title",
   "popup_issue_no_screenshot": "Screenshots aren't embedded in issues — the metadata & signals go in the issue body.",
   "popup_issue_empty_title": "Enter an issue title.",
+  "popup_issue_title_too_long": "Issue title must be 200 characters or fewer.",
   "popup_issue_success": "Filed issue #{number}.",
   "options_routing_title": "Routing rules",
   "options_routing_hint": "Map a captured tab's URL to a target repo. Patterns are globs (* wildcards) matched against the full URL; first match wins, otherwise the repo above is used.",

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,7 +1,7 @@
 import { summarizeAxeResults, type AxeResults } from "./lib/a11y";
 import { buildMetadata, dataUrlToBlob, type PageInfo } from "./lib/capture";
 import { loadConfig } from "./lib/config";
-import { spawnNow } from "./lib/transport";
+import { fileIssue, spawnNow } from "./lib/transport";
 import {
   TransportError,
   type CaptureResult,
@@ -160,8 +160,15 @@ chrome.runtime.onMessage.addListener(
               ? dataUrlToBlob(req.payload.screenshotDataUrl)
               : undefined,
             signals: req.payload.signals,
+            repoPath: req.payload.repoPath,
           });
           sendResponse({ ok: true, type: "spawn", desig });
+          return;
+        }
+        if (req.type === "file-issue") {
+          const config = await loadConfig();
+          const { number, url } = await fileIssue((u, init) => fetch(u, init), config, req.payload);
+          sendResponse({ ok: true, type: "issue", number, url });
           return;
         }
       } catch (err) {

--- a/extension/src/lib/config.ts
+++ b/extension/src/lib/config.ts
@@ -10,6 +10,7 @@ export const DEFAULT_CONFIG: CaptureConfig = {
   baseBranch: "main",
   model: "default",
   signals: { screenshot: true, console: false, network: false, a11y: false },
+  routingRules: [],
 };
 
 /** Load config from chrome.storage.local, merged over defaults (signals deep-merged). */

--- a/extension/src/lib/routing.ts
+++ b/extension/src/lib/routing.ts
@@ -1,0 +1,29 @@
+import type { RoutingRule } from "./types";
+
+/** Escape every regex metacharacter so a glob is matched literally except `*`. */
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Resolve a capture's effective repo from its URL. Rules are tried in order;
+ * each `pattern` is a glob (`*` = any run of chars) matched anchored and
+ * case-insensitively against the full URL. The first match's `repoPath` wins;
+ * with no match (or no rules) the `fallback` repo is returned. Blank-field rules
+ * are skipped, and a pattern that can't compile to a RegExp is treated as a
+ * no-match rather than throwing.
+ */
+export function resolveRepo(url: string, rules: RoutingRule[], fallback: string): string {
+  for (const rule of rules) {
+    if (rule.pattern.trim() === "" || rule.repoPath.trim() === "") continue;
+    // Escape first, THEN open up the (now-escaped) `*` into `.*` so only the
+    // glob wildcard is special — every other char is literal.
+    const source = "^" + escapeRegex(rule.pattern).replace(/\\\*/g, ".*") + "$";
+    try {
+      if (new RegExp(source, "i").test(url)) return rule.repoPath;
+    } catch {
+      /* invalid pattern → no match */
+    }
+  }
+  return fallback;
+}

--- a/extension/src/lib/transport.ts
+++ b/extension/src/lib/transport.ts
@@ -17,6 +17,8 @@ interface SpawnInput {
   /** When false (or no screenshot), skip /api/uploads and send images:[]. */
   attachScreenshot: boolean;
   signals?: CapturedSignals;
+  /** Routing-resolved effective repo; overrides `config.repoPath` at spawn. */
+  repoPath: string;
 }
 
 function kindForStatus(status: number): TransportErrorKind {
@@ -81,11 +83,12 @@ async function uploadScreenshot(
 async function createSession(
   fetchFn: FetchFn,
   config: CaptureConfig,
+  repoPath: string,
   prompt: string,
   images: string[],
 ): Promise<string> {
   const payload: Record<string, unknown> = {
-    repoPath: config.repoPath,
+    repoPath,
     baseBranch: config.baseBranch,
     prompt,
     images,
@@ -126,5 +129,39 @@ export async function spawnNow(
     images.push(await uploadScreenshot(fetchFn, config, input.screenshot));
   }
   const prompt = `${input.prompt}\n\n${formatContextBlock(input.metadata, input.signals)}`;
-  return createSession(fetchFn, config, prompt, images);
+  return createSession(fetchFn, config, input.repoPath, prompt, images);
+}
+
+/** File the capture as a GitHub/Gitea issue: title + (prompt + context block) body.
+ *  No screenshot upload — a remote issue can't reference the confined local path. */
+export async function fileIssue(
+  fetchFn: FetchFn,
+  config: CaptureConfig,
+  input: {
+    repoPath: string;
+    title: string;
+    prompt: string;
+    metadata: PageMetadata;
+    signals?: CapturedSignals;
+  },
+): Promise<{ number: number; url: string }> {
+  const body = `${input.prompt}\n\n${formatContextBlock(input.metadata, input.signals)}`;
+
+  let res: Response;
+  try {
+    res = await fetchFn(`${config.baseUrl}/api/issues`, {
+      method: "POST",
+      // Same fixed application/json as createSession — see the 415 note there.
+      headers: { "Content-Type": "application/json", ...authHeaders(config.token) },
+      body: JSON.stringify({ repo: input.repoPath, title: input.title, body }),
+    });
+  } catch {
+    throw new TransportError("unreachable", null, "could not reach Shepherd");
+  }
+  await ensureOk(res);
+  const parsed = (await res.json()) as { number?: number; url?: string };
+  if (parsed.number === undefined || !parsed.url) {
+    throw new TransportError("unknown", res.status, "issue returned no number/url");
+  }
+  return { number: parsed.number, url: parsed.url };
 }

--- a/extension/src/lib/transport.ts
+++ b/extension/src/lib/transport.ts
@@ -9,6 +9,25 @@ import type { CapturedSignals } from "./signals";
 
 export type FetchFn = (input: string, init: any) => Promise<Response>;
 
+/** Issue title / body caps — mirror the server's POST /api/issues limits so the
+ *  popup can pre-validate and show a clear message instead of a generic 'invalid'.
+ *  The server stays the authority; these only drive client-side UX. */
+export const MAX_ISSUE_TITLE_LEN = 200;
+export const MAX_ISSUE_BODY_LEN = 16000;
+
+/**
+ * Compose the issue body sent to POST /api/issues: the user's prompt plus the
+ * fenced metadata/signals context block. Exported so the popup pre-validates the
+ * exact string fileIssue() sends — one source of truth, no length-check drift.
+ */
+export function composeIssueBody(
+  prompt: string,
+  metadata: PageMetadata,
+  signals?: CapturedSignals,
+): string {
+  return `${prompt}\n\n${formatContextBlock(metadata, signals)}`;
+}
+
 interface SpawnInput {
   prompt: string;
   metadata: PageMetadata;
@@ -145,7 +164,7 @@ export async function fileIssue(
     signals?: CapturedSignals;
   },
 ): Promise<{ number: number; url: string }> {
-  const body = `${input.prompt}\n\n${formatContextBlock(input.metadata, input.signals)}`;
+  const body = composeIssueBody(input.prompt, input.metadata, input.signals);
 
   let res: Response;
   try {

--- a/extension/src/lib/types.ts
+++ b/extension/src/lib/types.ts
@@ -28,6 +28,16 @@ export interface CaptureResult {
   signalErrors?: GatherSignal[];
 }
 
+/** One URL→repo routing rule. `pattern` is a glob (`*` wildcards) matched
+ *  case-insensitively against the captured tab's full URL; first match wins. */
+export interface RoutingRule {
+  pattern: string;
+  repoPath: string;
+}
+
+/** Where a capture is delivered. */
+export type DeliveryTarget = "session" | "issue";
+
 /** Persisted extension config (chrome.storage.local; never synced). */
 export interface CaptureConfig {
   baseUrl: string;
@@ -37,6 +47,8 @@ export interface CaptureConfig {
   model: "opus" | "sonnet" | "haiku" | "default";
   /** Per-signal toggles; persisted defaults, overridable per-capture in the popup. */
   signals: SignalToggles;
+  /** URL→repo rules; first match overrides `repoPath`. Empty = always fall back. */
+  routingRules: RoutingRule[];
 }
 
 /** What the popup sends the background worker to spawn a session. */
@@ -47,6 +59,8 @@ export interface SpawnPayload {
   /** Whether to upload + attach the screenshot. */
   attachScreenshot: boolean;
   signals?: CapturedSignals;
+  /** Routing-resolved effective repo (overrides `config.repoPath` at spawn). */
+  repoPath: string;
 }
 
 /**
@@ -78,9 +92,20 @@ export class TransportError extends Error {
 /** Discriminated message envelope: popup/options <-> background worker. */
 export type WorkerRequest =
   | { type: "capture"; toggles: SignalToggles }
-  | { type: "spawn"; payload: SpawnPayload };
+  | { type: "spawn"; payload: SpawnPayload }
+  | {
+      type: "file-issue";
+      payload: {
+        repoPath: string;
+        title: string;
+        prompt: string;
+        metadata: PageMetadata;
+        signals?: CapturedSignals;
+      };
+    };
 
 export type WorkerResponse =
   | { ok: true; type: "capture"; result: CaptureResult }
   | { ok: true; type: "spawn"; desig: string }
+  | { ok: true; type: "issue"; number: number; url: string }
   | { ok: false; errorKind: TransportErrorKind | "capture"; message: string };

--- a/extension/src/options/Options.svelte
+++ b/extension/src/options/Options.svelte
@@ -156,7 +156,7 @@
       <legend class="text-gray-600">{m.options_routing_title()}</legend>
       <span class="text-xs text-gray-500">{m.options_routing_hint()}</span>
 
-      {#each config.routingRules as rule, i (i)}
+      {#each config.routingRules as rule (rule)}
         <div class="flex items-center gap-2">
           <input
             class="min-w-0 flex-1 rounded border border-gray-300 px-2 py-1"
@@ -174,7 +174,7 @@
             type="button"
             class="shrink-0 text-red-600"
             aria-label={m.options_routing_remove()}
-            onclick={() => (config.routingRules = config.routingRules.filter((_, j) => j !== i))}
+            onclick={() => (config.routingRules = config.routingRules.filter((r) => r !== rule))}
           >
             {m.options_routing_remove()}
           </button>

--- a/extension/src/options/Options.svelte
+++ b/extension/src/options/Options.svelte
@@ -68,9 +68,11 @@
       hostDenied = true;
       return;
     }
-    // Drop fully-empty routing rows so the saved list stays clean.
+    // Drop incomplete routing rows (either field blank). resolveRepo skips a rule
+    // missing a pattern or a repoPath anyway, so persisting a half-filled row would
+    // be a silently-dead rule — require both fields to keep one.
     config.routingRules = config.routingRules.filter(
-      (r) => r.pattern.trim() !== "" || r.repoPath.trim() !== "",
+      (r) => r.pattern.trim() !== "" && r.repoPath.trim() !== "",
     );
     const prevBaseUrl = (await loadConfig()).baseUrl;
     await saveConfig(config);

--- a/extension/src/options/Options.svelte
+++ b/extension/src/options/Options.svelte
@@ -68,6 +68,10 @@
       hostDenied = true;
       return;
     }
+    // Drop fully-empty routing rows so the saved list stays clean.
+    config.routingRules = config.routingRules.filter(
+      (r) => r.pattern.trim() !== "" || r.repoPath.trim() !== "",
+    );
     const prevBaseUrl = (await loadConfig()).baseUrl;
     await saveConfig(config);
     // Release the previous remote host's grant if we've switched hosts (remove
@@ -146,6 +150,45 @@
         <input type="checkbox" checked={config.signals.a11y} onchange={toggleA11y} />
         <span>{m.options_signals_a11y_label()}</span>
       </label>
+    </fieldset>
+
+    <fieldset class="mt-2 flex flex-col gap-2 border-t border-gray-200 pt-3">
+      <legend class="text-gray-600">{m.options_routing_title()}</legend>
+      <span class="text-xs text-gray-500">{m.options_routing_hint()}</span>
+
+      {#each config.routingRules as rule, i (i)}
+        <div class="flex items-center gap-2">
+          <input
+            class="min-w-0 flex-1 rounded border border-gray-300 px-2 py-1"
+            type="text"
+            bind:value={rule.pattern}
+            placeholder={m.options_routing_pattern_ph()}
+          />
+          <input
+            class="min-w-0 flex-1 rounded border border-gray-300 px-2 py-1"
+            type="text"
+            bind:value={rule.repoPath}
+            placeholder={m.options_routing_repo_ph()}
+          />
+          <button
+            type="button"
+            class="shrink-0 text-red-600"
+            aria-label={m.options_routing_remove()}
+            onclick={() => (config.routingRules = config.routingRules.filter((_, j) => j !== i))}
+          >
+            {m.options_routing_remove()}
+          </button>
+        </div>
+      {/each}
+
+      <button
+        type="button"
+        class="self-start text-blue-600 underline"
+        onclick={() =>
+          (config.routingRules = [...config.routingRules, { pattern: "", repoPath: "" }])}
+      >
+        {m.options_routing_add()}
+      </button>
     </fieldset>
 
     <div class="mt-2 flex items-center gap-3">

--- a/extension/src/popup/Popup.svelte
+++ b/extension/src/popup/Popup.svelte
@@ -157,6 +157,13 @@
       view = "error";
       return;
     }
+    // Mirror the server's title cap (POST /api/issues, ≤ 200) so an over-long
+    // title gets a clear inline message instead of a generic 'invalid' rejection.
+    if (target === "issue" && issueTitle.trim().length > 200) {
+      errorMsg = m.popup_issue_title_too_long();
+      view = "error";
+      return;
+    }
     view = "submitting";
     const req: WorkerRequest =
       target === "issue"

--- a/extension/src/popup/Popup.svelte
+++ b/extension/src/popup/Popup.svelte
@@ -4,6 +4,7 @@
   import { hasAllUrls } from "../lib/recorder-control";
   import { hasHostPermission, requestHostPermission } from "../lib/remote-host";
   import { resolveRepo } from "../lib/routing";
+  import { composeIssueBody, MAX_ISSUE_BODY_LEN, MAX_ISSUE_TITLE_LEN } from "../lib/transport";
   import type {
     CaptureConfig,
     CaptureResult,
@@ -157,10 +158,20 @@
       view = "error";
       return;
     }
-    // Mirror the server's title cap (POST /api/issues, ≤ 200) so an over-long
-    // title gets a clear inline message instead of a generic 'invalid' rejection.
-    if (target === "issue" && issueTitle.trim().length > 200) {
+    // Mirror the server's POST /api/issues caps so an over-long title or body
+    // gets a clear inline message instead of a generic 'invalid' rejection. The
+    // body is prompt + the fenced context block, so large signals can blow the
+    // cap even with a short prompt — validate the exact string fileIssue() sends.
+    if (target === "issue" && issueTitle.trim().length > MAX_ISSUE_TITLE_LEN) {
       errorMsg = m.popup_issue_title_too_long();
+      view = "error";
+      return;
+    }
+    if (
+      target === "issue" &&
+      composeIssueBody(prompt, capture.metadata, capture.signals).length > MAX_ISSUE_BODY_LEN
+    ) {
+      errorMsg = m.popup_issue_body_too_long();
       view = "error";
       return;
     }

--- a/extension/src/popup/Popup.svelte
+++ b/extension/src/popup/Popup.svelte
@@ -24,6 +24,7 @@
   let errorMsg = $state("");
   let target = $state<DeliveryTarget>("session");
   let issueTitle = $state("");
+  let titlePrefilled = $state(false);
   let issueUrl = $state("");
   let issueNumber = $state(0);
   let doneKind = $state<"session" | "issue">("session");
@@ -134,10 +135,14 @@
       : (config?.repoPath ?? ""),
   );
 
-  // Prefill the issue title from the page title once it's available, leaving any
-  // user edit intact (only fills while still blank).
+  // Prefill the issue title from the page title once, the first time a capture is
+  // available. A one-shot flag (not an `=== ""` guard) so a user who deliberately
+  // clears the field isn't refilled on the next reactive tick.
   $effect(() => {
-    if (issueTitle === "" && capture?.metadata.title) issueTitle = capture.metadata.title;
+    if (!titlePrefilled && capture?.metadata.title) {
+      issueTitle = capture.metadata.title;
+      titlePrefilled = true;
+    }
   });
 
   async function submit() {

--- a/extension/src/popup/Popup.svelte
+++ b/extension/src/popup/Popup.svelte
@@ -3,9 +3,11 @@
   import { isConfigured, loadConfig } from "../lib/config";
   import { hasAllUrls } from "../lib/recorder-control";
   import { hasHostPermission, requestHostPermission } from "../lib/remote-host";
+  import { resolveRepo } from "../lib/routing";
   import type {
     CaptureConfig,
     CaptureResult,
+    DeliveryTarget,
     TransportErrorKind,
     WorkerRequest,
     WorkerResponse,
@@ -20,6 +22,11 @@
   let prompt = $state("");
   let desig = $state("");
   let errorMsg = $state("");
+  let target = $state<DeliveryTarget>("session");
+  let issueTitle = $state("");
+  let issueUrl = $state("");
+  let issueNumber = $state(0);
+  let doneKind = $state<"session" | "issue">("session");
   let toggles = $state<SignalToggles>({
     screenshot: true,
     console: false,
@@ -119,6 +126,20 @@
 
   let summary = $derived(signalSummary(capture?.signals));
 
+  // Routing-resolved effective repo: a matching rule overrides the configured
+  // repoPath; with no capture or no match it falls back to the configured repo.
+  let effectiveRepo = $derived(
+    capture
+      ? resolveRepo(capture.metadata.url, config?.routingRules ?? [], config?.repoPath ?? "")
+      : (config?.repoPath ?? ""),
+  );
+
+  // Prefill the issue title from the page title once it's available, leaving any
+  // user edit intact (only fills while still blank).
+  $effect(() => {
+    if (issueTitle === "" && capture?.metadata.title) issueTitle = capture.metadata.title;
+  });
+
   async function submit() {
     if (!capture) return;
     if (prompt.trim() === "") {
@@ -126,19 +147,44 @@
       view = "error";
       return;
     }
+    if (target === "issue" && issueTitle.trim() === "") {
+      errorMsg = m.popup_issue_empty_title();
+      view = "error";
+      return;
+    }
     view = "submitting";
-    const res = await send({
-      type: "spawn",
-      payload: {
-        prompt,
-        metadata: capture.metadata,
-        screenshotDataUrl: capture.screenshotDataUrl,
-        attachScreenshot: toggles.screenshot,
-        signals: capture.signals,
-      },
-    });
+    const req: WorkerRequest =
+      target === "issue"
+        ? {
+            type: "file-issue",
+            payload: {
+              repoPath: effectiveRepo,
+              title: issueTitle,
+              prompt,
+              metadata: capture.metadata,
+              signals: capture.signals,
+            },
+          }
+        : {
+            type: "spawn",
+            payload: {
+              prompt,
+              metadata: capture.metadata,
+              screenshotDataUrl: capture.screenshotDataUrl,
+              attachScreenshot: toggles.screenshot,
+              signals: capture.signals,
+              repoPath: effectiveRepo,
+            },
+          };
+    const res = await send(req);
     if (res.ok && res.type === "spawn") {
       desig = res.desig;
+      doneKind = "session";
+      view = "done";
+    } else if (res.ok && res.type === "issue") {
+      issueNumber = res.number;
+      issueUrl = res.url;
+      doneKind = "issue";
       view = "done";
     } else if (!res.ok) {
       errorMsg = localizeError(res.errorKind, res.message);
@@ -168,7 +214,15 @@
       {m.popup_grant_host()}
     </button>
   {:else if view === "done"}
-    <p class="rounded bg-green-50 px-3 py-2 text-green-700">{m.popup_success({ desig })}</p>
+    {#if doneKind === "issue"}
+      <p class="rounded bg-green-50 px-3 py-2 text-green-700">
+        <a class="underline" href={issueUrl} target="_blank" rel="noreferrer">
+          {m.popup_issue_success({ number: issueNumber })}
+        </a>
+      </p>
+    {:else}
+      <p class="rounded bg-green-50 px-3 py-2 text-green-700">{m.popup_success({ desig })}</p>
+    {/if}
   {:else if capture}
     <img
       class="w-full rounded border border-gray-200"
@@ -183,12 +237,34 @@
       <span>{capture.metadata.viewportW}×{capture.metadata.viewportH}</span>
     </div>
 
+    <label class="flex flex-col gap-1 text-xs text-gray-600">
+      <span>{m.popup_target_label()}</span>
+      <select class="rounded border border-gray-300 px-2 py-1 text-gray-900" bind:value={target}>
+        <option value="session">{m.popup_target_session()}</option>
+        <option value="issue">{m.popup_target_issue()}</option>
+      </select>
+    </label>
+
+    {#if target === "issue"}
+      <label class="flex flex-col gap-1 text-xs text-gray-600">
+        <span>{m.popup_issue_title_label()}</span>
+        <input
+          class="rounded border border-gray-300 px-2 py-1 text-gray-900"
+          type="text"
+          bind:value={issueTitle}
+        />
+      </label>
+    {/if}
+
     <fieldset class="flex flex-col gap-1 text-xs text-gray-600">
       <span>{m.popup_attach_label()}</span>
-      <label class="flex items-center gap-2">
-        <input type="checkbox" bind:checked={toggles.screenshot} />
+      <label class="flex items-center gap-2" class:opacity-50={target === "issue"}>
+        <input type="checkbox" bind:checked={toggles.screenshot} disabled={target === "issue"} />
         <span>{m.signal_screenshot()}</span>
       </label>
+      {#if target === "issue"}
+        <span class="text-gray-500">{m.popup_issue_no_screenshot()}</span>
+      {/if}
       <label class="flex items-center gap-2">
         <input
           type="checkbox"
@@ -245,7 +321,10 @@
     </label>
 
     <p class="text-xs text-gray-500">
-      {m.popup_repo_label()}: <span class="font-mono">{config?.repoPath}</span>
+      {m.popup_repo_label()}: <span class="font-mono">{effectiveRepo}</span>
+      {#if effectiveRepo !== config?.repoPath}
+        <span class="text-gray-400">{m.popup_repo_routed()}</span>
+      {/if}
     </p>
 
     {#if view === "error"}

--- a/extension/test/config.test.ts
+++ b/extension/test/config.test.ts
@@ -44,10 +44,21 @@ describe("config", () => {
       baseBranch: "main",
       model: "sonnet",
       signals: { screenshot: true, console: true, network: false, a11y: true },
+      routingRules: [],
     });
     const cfg = await loadConfig();
     expect(cfg.repoPath).toBe("~/Work/x");
     expect(cfg.model).toBe("sonnet");
+  });
+
+  it("defaults routingRules to an empty array and round-trips stored rules", async () => {
+    expect((await loadConfig()).routingRules).toEqual([]);
+    installChromeStub({
+      captureConfig: { routingRules: [{ pattern: "https://x/*", repoPath: "~/Work/x" }] },
+    });
+    expect((await loadConfig()).routingRules).toEqual([
+      { pattern: "https://x/*", repoPath: "~/Work/x" },
+    ]);
   });
 
   it("isConfigured is false until baseUrl + repoPath are set", async () => {
@@ -90,6 +101,7 @@ describe("config", () => {
       baseBranch: "dev",
       model: "opus",
       signals: { screenshot: true, console: false, network: false, a11y: false },
+      routingRules: [],
     });
     await saveSignals({ screenshot: false, console: true, network: true, a11y: true });
     const cfg = await loadConfig();

--- a/extension/test/routing.test.ts
+++ b/extension/test/routing.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { resolveRepo } from "../src/lib/routing";
+import type { RoutingRule } from "../src/lib/types";
+
+const rule = (pattern: string, repoPath: string): RoutingRule => ({ pattern, repoPath });
+
+describe("resolveRepo", () => {
+  it("matches an exact full URL", () => {
+    const rules = [rule("https://github.com/acme/web", "~/Work/web")];
+    expect(resolveRepo("https://github.com/acme/web", rules, "~/fallback")).toBe("~/Work/web");
+  });
+
+  it("matches with a `*` wildcard", () => {
+    const rules = [rule("https://github.com/*", "~/Work/gh")];
+    expect(resolveRepo("https://github.com/acme/web/issues/3", rules, "~/fallback")).toBe(
+      "~/Work/gh",
+    );
+  });
+
+  it("returns the first matching rule when several match", () => {
+    const rules = [rule("https://github.com/*", "~/Work/first"), rule("*", "~/Work/second")];
+    expect(resolveRepo("https://github.com/acme/web", rules, "~/fallback")).toBe("~/Work/first");
+  });
+
+  it("skips a rule with a blank pattern (or blank repo)", () => {
+    const rules = [
+      rule("   ", "~/Work/skipped"),
+      rule("https://github.com/*", "   "),
+      rule("https://github.com/*", "~/Work/kept"),
+    ];
+    expect(resolveRepo("https://github.com/acme/web", rules, "~/fallback")).toBe("~/Work/kept");
+  });
+
+  it("falls back when nothing matches", () => {
+    const rules = [rule("https://gitlab.com/*", "~/Work/gl")];
+    expect(resolveRepo("https://github.com/acme/web", rules, "~/fallback")).toBe("~/fallback");
+  });
+
+  it("matches case-insensitively", () => {
+    const rules = [rule("https://GitHub.com/Acme/*", "~/Work/ci")];
+    expect(resolveRepo("https://github.com/acme/web", rules, "~/fallback")).toBe("~/Work/ci");
+  });
+
+  it("does not let glob metacharacters in the URL bleed through (literal dots)", () => {
+    // `.` in the pattern is literal, so a different char must not satisfy it.
+    const rules = [rule("https://a.b/*", "~/Work/dot")];
+    expect(resolveRepo("https://axb/whatever", rules, "~/fallback")).toBe("~/fallback");
+  });
+});

--- a/extension/test/transport.test.ts
+++ b/extension/test/transport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { spawnNow } from "../src/lib/transport";
+import { fileIssue, spawnNow } from "../src/lib/transport";
 import { TransportError, type CaptureConfig, type PageMetadata } from "../src/lib/types";
 import type { CapturedSignals } from "../src/lib/signals";
 
@@ -10,6 +10,7 @@ const CONFIG: CaptureConfig = {
   baseBranch: "main",
   model: "opus",
   signals: { screenshot: true, console: false, network: false, a11y: false },
+  routingRules: [],
 };
 
 const META: PageMetadata = {
@@ -44,6 +45,7 @@ describe("spawnNow", () => {
       metadata: META,
       screenshot: blob(),
       attachScreenshot: true,
+      repoPath: "~/Work/foo",
     });
 
     expect(desig).toBe("TASK-42");
@@ -82,6 +84,7 @@ describe("spawnNow", () => {
         metadata: META,
         screenshot: blob(),
         attachScreenshot: true,
+        repoPath: "~/Work/foo",
       },
     );
 
@@ -104,6 +107,7 @@ describe("spawnNow", () => {
         metadata: META,
         screenshot: blob(),
         attachScreenshot: true,
+        repoPath: "~/Work/foo",
       }),
     ).rejects.toMatchObject({ kind });
     expect(fetchFn).toHaveBeenCalledTimes(1); // never reaches session create
@@ -117,6 +121,7 @@ describe("spawnNow", () => {
         metadata: META,
         screenshot: blob(),
         attachScreenshot: true,
+        repoPath: "~/Work/foo",
       }),
     ).rejects.toMatchObject({ kind: "unreachable" });
   });
@@ -132,6 +137,7 @@ describe("spawnNow", () => {
         metadata: META,
         screenshot: blob(),
         attachScreenshot: true,
+        repoPath: "~/Work/foo",
       }),
     ).rejects.toBeInstanceOf(TransportError);
   });
@@ -146,6 +152,7 @@ describe("spawnNow", () => {
       metadata: META,
       attachScreenshot: false,
       signals,
+      repoPath: "~/Work/foo",
     });
     expect(desig).toBe("TASK-9");
     expect(fetchFn).toHaveBeenCalledTimes(1); // sessions only — no /api/uploads
@@ -155,5 +162,83 @@ describe("spawnNow", () => {
     expect(sent.images).toEqual([]);
     expect(sent.prompt).toContain("Console (1):"); // signals reached the prompt
     expect(sent.prompt).toContain("boom");
+  });
+
+  it("sends the routing-resolved repoPath, not config.repoPath", async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonRes({ desig: "TASK-3" }, 201));
+    await spawnNow(fetchFn, CONFIG, {
+      prompt: "p",
+      metadata: META,
+      attachScreenshot: false,
+      repoPath: "~/Work/routed",
+    });
+    expect(JSON.parse(fetchFn.mock.calls[0][1].body).repoPath).toBe("~/Work/routed");
+  });
+});
+
+describe("fileIssue", () => {
+  it("posts to /api/issues with repo+title+context body and returns {number,url}", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonRes({ number: 7, url: "https://github.com/acme/web/issues/7" }, 201),
+      );
+
+    const result = await fileIssue(fetchFn, CONFIG, {
+      repoPath: "~/Work/routed",
+      title: "Button is broken",
+      prompt: "Fix the button",
+      metadata: META,
+    });
+
+    expect(result).toEqual({ number: 7, url: "https://github.com/acme/web/issues/7" });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe("http://localhost:7330/api/issues");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(init.headers.Authorization).toBe("Bearer secret");
+    const sent = JSON.parse(init.body);
+    expect(sent.repo).toBe("~/Work/routed");
+    expect(sent.title).toBe("Button is broken");
+    expect(sent.body).toContain("Fix the button");
+    expect(sent.body).toContain("```text");
+    expect(sent.body).toContain("URL: https://example.com");
+  });
+
+  it("maps a 400 to TransportError kind 'invalid'", async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonRes({ error: "invalid repo" }, 400));
+    await expect(
+      fileIssue(fetchFn, CONFIG, {
+        repoPath: "~/Work/x",
+        title: "t",
+        prompt: "p",
+        metadata: META,
+      }),
+    ).rejects.toMatchObject({ kind: "invalid" });
+  });
+
+  it("maps an unreachable fetch to kind 'unreachable'", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    await expect(
+      fileIssue(fetchFn, CONFIG, {
+        repoPath: "~/Work/x",
+        title: "t",
+        prompt: "p",
+        metadata: META,
+      }),
+    ).rejects.toMatchObject({ kind: "unreachable" });
+  });
+
+  it("throws when the response is missing number or url", async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonRes({ number: 7 }, 201));
+    await expect(
+      fileIssue(fetchFn, CONFIG, {
+        repoPath: "~/Work/x",
+        title: "t",
+        prompt: "p",
+        metadata: META,
+      }),
+    ).rejects.toBeInstanceOf(TransportError);
   });
 });

--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -272,6 +272,14 @@ export class GiteaForge implements GitForge {
     return this.toStatus(pr);
   }
 
+  async createIssue(o: { title: string; body: string }): Promise<{ number: number; url: string }> {
+    const issue = (await this.req("POST", `/api/v1/repos/${this.slug}/issues`, {
+      title: o.title,
+      body: o.body,
+    })) as { number: number; html_url: string };
+    return { number: issue.number, url: issue.html_url };
+  }
+
   async merge(prNumber: number, o: MergeInput): Promise<void> {
     await this.req("POST", `/api/v1/repos/${this.slug}/pulls/${prNumber}/merge`, {
       Do: o.method,

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -364,6 +364,23 @@ export class GithubForge implements GitForge {
     return this.prStatus(o.head);
   }
 
+  async createIssue(o: { title: string; body: string }): Promise<{ number: number; url: string }> {
+    // `gh issue create` echoes the new issue's URL on stdout (…/issues/<n>).
+    const url = this.run([
+      "issue",
+      "create",
+      "--repo",
+      this.slug,
+      "--title",
+      o.title,
+      "--body",
+      o.body,
+    ]).trim();
+    const n = Number(url.match(/\/(\d+)\s*$/)?.[1]);
+    if (!Number.isInteger(n)) throw new Error(`could not parse issue number from URL: ${url}`);
+    return { number: n, url };
+  }
+
   async renameBranch(oldBranch: string, newBranch: string): Promise<void> {
     // GitHub's rename-branch endpoint moves the ref AND retargets every open PR and
     // branch-protection rule onto the new name, so a session's open PR follows along.

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -206,6 +206,10 @@ export interface GitForge {
   /** Remove a label from an issue (best-effort; releases the drain's claim when an
    *  auto session is abandoned, returning the issue to the pool). Optional. */
   removeIssueLabel?(issueNumber: number, label: string): Promise<void>;
+  /** Open a new issue (capture-extension delivery path). Returns the created
+   *  issue's number + URL. Optional: hosts without an issue-create API omit it
+   *  and POST /api/issues 400s. */
+  createIssue?(o: { title: string; body: string }): Promise<{ number: number; url: string }>;
 }
 
 /** Per-host configuration loaded from ~/.shepherd/forges.json. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -1468,6 +1468,38 @@ async function handleIssues({ req, parts, url, deps }: Ctx): Promise<Response | 
   return null;
 }
 
+// POST /api/issues — open a new issue on a repo's forge (capture-extension
+// delivery path). Coexists with handleIssues' GET on the same path.
+async function handleIssueCreate({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (req.method !== "POST" || parts[0] !== "api" || parts[1] !== "issues" || parts[2]) return null;
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+  const body = (await req.json().catch(() => null)) as {
+    repo?: string;
+    title?: string;
+    body?: string;
+  } | null;
+  if (!body) return json({ error: "invalid json" }, 400);
+  const dir = safeRepoDir(body.repo ?? "", config.repoRoot);
+  if (!dir) return json({ error: "invalid repo" }, 400);
+  const title = body.title;
+  if (typeof title !== "string" || !title.trim() || title.length > 200) {
+    return json({ error: "title must be a non-empty string ≤ 200 chars" }, 400);
+  }
+  const issueBody = body.body;
+  if (typeof issueBody !== "string" || issueBody.length > 16000) {
+    return json({ error: "body must be a string ≤ 16000 chars" }, 400);
+  }
+  const forge = deps.resolveForge?.(dir) ?? null;
+  if (!forge?.createIssue) return json({ error: "issues unavailable for repo" }, 400);
+  try {
+    const issue = await forge.createIssue({ title: title.trim(), body: issueBody });
+    return json({ ...issue, slug: forge.slug }, 201);
+  } catch (e) {
+    return json({ error: e instanceof Error ? e.message : "issue create failed" }, 502);
+  }
+}
+
 /**
  * Collapse worktrees / multiple clones of the same repo: dedupe by forge identity
  * (kind + owner/repo slug) so each repo appears once, not once per directory.
@@ -1902,6 +1934,7 @@ const ROUTE_HANDLERS = [
   handleFsDirs,
   handleBranches,
   handleIssues,
+  handleIssueCreate,
   handlePrsList,
   handleActionsList,
   handleActionsRerun,

--- a/test/server-issues.test.ts
+++ b/test/server-issues.test.ts
@@ -95,3 +95,102 @@ test("GET /api/issues?repo outside root → 400", async () => {
   const res = await app.fetch(req("/etc"));
   expect(res.status).toBe(400);
 });
+
+// ── POST /api/issues (handleIssueCreate) ─────────────────────────────────────
+
+function postIssue(
+  app: ReturnType<typeof makeApp>,
+  body: unknown,
+  headers?: HeadersInit,
+): Promise<Response> {
+  return app.fetch(
+    new Request("http://localhost/api/issues", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+test("POST /api/issues 201 happy path returns number, url, slug", async () => {
+  const created = { number: 7, url: "https://github.com/o/r/issues/7" };
+  const forge = fakeForge({ slug: "o/r", createIssue: async () => created });
+  const app = makeApp(makeDeps((p) => (p === repoDir ? forge : null)));
+  const res = await postIssue(app, { repo: repoDir, title: "Hello", body: "world" });
+  expect(res.status).toBe(201);
+  const out = await res.json();
+  expect(out.number).toBe(7);
+  expect(out.url).toBe(created.url);
+  expect(out.slug).toBe("o/r");
+});
+
+test("POST /api/issues passes trimmed title + body to the forge", async () => {
+  const calls: { title: string; body: string }[] = [];
+  const forge = fakeForge({
+    createIssue: async (o) => {
+      calls.push(o);
+      return { number: 1, url: "u" };
+    },
+  });
+  const app = makeApp(makeDeps((p) => (p === repoDir ? forge : null)));
+  await postIssue(app, { repo: repoDir, title: "  spaced  ", body: "ctx" });
+  expect(calls[0]).toEqual({ title: "spaced", body: "ctx" });
+});
+
+test("POST /api/issues out-of-root repo → 400 invalid repo", async () => {
+  const forge = fakeForge({ createIssue: async () => ({ number: 1, url: "u" }) });
+  const app = makeApp(makeDeps((p) => (p === repoDir ? forge : null)));
+  const res = await postIssue(app, { repo: "/etc/passwd", title: "x", body: "" });
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toBe("invalid repo");
+});
+
+test("POST /api/issues unknown repo (resolveForge null) → 400", async () => {
+  const app = makeApp(makeDeps(() => null));
+  const res = await postIssue(app, { repo: repoDir, title: "x", body: "" });
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toBe("issues unavailable for repo");
+});
+
+test("POST /api/issues blank title → 400", async () => {
+  const forge = fakeForge({ createIssue: async () => ({ number: 1, url: "u" }) });
+  const app = makeApp(makeDeps((p) => (p === repoDir ? forge : null)));
+  const res = await postIssue(app, { repo: repoDir, title: "   ", body: "" });
+  expect(res.status).toBe(400);
+});
+
+test("POST /api/issues missing title → 400", async () => {
+  const forge = fakeForge({ createIssue: async () => ({ number: 1, url: "u" }) });
+  const app = makeApp(makeDeps((p) => (p === repoDir ? forge : null)));
+  const res = await postIssue(app, { repo: repoDir, body: "" });
+  expect(res.status).toBe(400);
+});
+
+test("POST /api/issues forge without createIssue → 400", async () => {
+  const forge = fakeForge(); // no createIssue
+  const app = makeApp(makeDeps((p) => (p === repoDir ? forge : null)));
+  const res = await postIssue(app, { repo: repoDir, title: "x", body: "" });
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toBe("issues unavailable for repo");
+});
+
+test("POST /api/issues createIssue throws → 502 with message", async () => {
+  const forge = fakeForge({
+    createIssue: async () => {
+      throw new Error("boom");
+    },
+  });
+  const app = makeApp(makeDeps((p) => (p === repoDir ? forge : null)));
+  const res = await postIssue(app, { repo: repoDir, title: "x", body: "" });
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toBe("boom");
+});
+
+test("POST /api/issues without JSON content type → 415", async () => {
+  const forge = fakeForge({ createIssue: async () => ({ number: 1, url: "u" }) });
+  const app = makeApp(makeDeps((p) => (p === repoDir ? forge : null)));
+  const res = await app.fetch(
+    new Request("http://localhost/api/issues", { method: "POST", body: "{}" }),
+  );
+  expect(res.status).toBe(415);
+});


### PR DESCRIPTION
Implements **#341** (the delivery & routing slice of the Shepherd Capture roadmap, #338): a second delivery target plus automatic repo routing.

## What

### GitHub-issue delivery path
The popup now offers two delivery targets — **Spawn session** (the Phase-1 path) and **GitHub issue**. Filing as an issue posts `title + body` to the target repo's forge instead of spawning a session; the body is the user's prompt plus the same sanitized fenced metadata/signals context block.

- **Server:** new optional forge method `createIssue` — GitHub via `gh issue create`, Gitea via the issues REST API — behind a new `POST /api/issues` route that mirrors `handleSessionCreate`'s repo-confinement (`safeRepoDir`) + JSON guards. Fails closed: `400` for a bad/out-of-root repo, blank title, or a forge with no issue-create API; `502` on forge failure.
- **Screenshot caveat:** not embedded in issues — a remote issue can't reference the confined local `/api/uploads` path — so the attach checkbox is disabled in issue mode and a note explains it. Metadata + signals still ride in the body.

### URL→repo rules
Options gains a rules editor mapping a captured tab's URL to a target repo, so a capture files against the right project instead of the single default **Repo path**.

- Pure `routing.ts` `resolveRepo`: each rule is a `pattern → repoPath` pair; the pattern is a glob (`*` wildcards) matched case-insensitively against the full URL, **first match wins**, else the default repo. Applies to both delivery targets.
- The popup shows the resolved repo with a **(routed)** hint when a rule overrode the default.

## Notes
- Reuses the existing `formatContextBlock` / `sanitize()` seam for the issue body (prompt-injection / fence-breakout defense).
- The extension ships no `ui/src` UX, so the feature-catalog gate doesn't arm and no catalog entry applies (the catalog is the Shepherd app's What's-New, not the extension's).
- EN+DE catalogs kept in parity (`check:i18n`).

## Test plan
- **Root:** `bun run lint` ✓, `bunx tsc --noEmit` ✓, `bun test ./test` ✓ (1182 tests; new `test/server-issues.test.ts` POST coverage: 201 happy path, 400 bad-repo/blank-title/no-createIssue, 502 forge failure).
- **Extension:** `bun run check` ✓ (0 errors), `bun run check:i18n` ✓ (67 keys, parity), `bun run test` ✓ (60 tests; new `routing.test.ts`, extended `transport.test.ts`/`config.test.ts`), `bun run lint` ✓.
- **Fallow** delta audit vs main: ✓ no issues in changed files.

Plan: `docs/superpowers/plans/2026-06-08-shepherd-capture-delivery-routing.md`. Manual load-unpacked checklist extended in `extension/README.md`.

Refs #338. Closes #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)