### PR TITLE
fix(extension): open Capture options page reliably from popup

### DIFF
--- a/extension/src/popup/Popup.svelte
+++ b/extension/src/popup/Popup.svelte
@@ -41,6 +41,18 @@
     return chrome.runtime.sendMessage(req) as Promise<WorkerResponse>;
   }
 
+  // Open the options page. Called from the popup, openOptionsPage() can fail to
+  // find a tabbed window and reject with "Could not create an options page." —
+  // use the callback form (which consumes chrome.runtime.lastError instead of
+  // surfacing an uncaught rejection) and fall back to opening it in a tab.
+  function openOptions(): void {
+    chrome.runtime.openOptionsPage(() => {
+      if (chrome.runtime.lastError) {
+        void chrome.tabs.create({ url: chrome.runtime.getURL("options.html") });
+      }
+    });
+  }
+
   function localizeError(kind: TransportErrorKind | "capture", message: string): string {
     switch (kind) {
       case "origin":
@@ -225,10 +237,7 @@
     <p class="text-gray-500">{m.popup_capturing()}</p>
   {:else if view === "needs-config"}
     <p class="text-gray-600">{m.popup_no_config()}</p>
-    <button
-      class="self-start rounded bg-gray-900 px-3 py-1.5 text-white"
-      onclick={() => chrome.runtime.openOptionsPage()}
-    >
+    <button class="self-start rounded bg-gray-900 px-3 py-1.5 text-white" onclick={openOptions}>
       {m.popup_open_options()}
     </button>
   {:else if view === "needs-host"}
@@ -315,11 +324,7 @@
         <span>{m.signal_network()}</span>
       </label>
       {#if !recorderAvailable}
-        <button
-          type="button"
-          class="self-start text-blue-600 underline"
-          onclick={() => chrome.runtime.openOptionsPage()}
-        >
+        <button type="button" class="self-start text-blue-600 underline" onclick={openOptions}>
           {m.popup_signals_locked()}
         </button>
       {/if}


### PR DESCRIPTION
## Problem

Clicking **Settings** in the Capture extension popup did nothing and logged on the `chrome://extensions` Errors page:

> `Uncaught (in promise) Error: Could not create an options page.` (context: `index.html`)

## Root cause

`chrome.runtime.openOptionsPage()` invoked from a **popup** can fail to find a normal tabbed window to host the options page and rejects with this exact Chromium error. The promise form left the rejection uncaught (hence the logged error) and the page never opened. The manifest (`options_page: "options.html"`) and the built `dist/options.html` are both correct — this is the popup-context window-resolution failure path, not a missing/invalid options page.

## Fix

Route both popup settings buttons through a shared `openOptions()` helper that:
- uses the **callback** form of `openOptionsPage()` — consuming `chrome.runtime.lastError` instead of surfacing an uncaught promise rejection, and
- **falls back** to `chrome.tabs.create({ url: chrome.runtime.getURL("options.html") })`, which opens the options page reliably regardless of window context.

## Verification

- `bun run check` — 0 errors
- `bun run lint` — clean
- `bun test` — 60 pass / 0 fail

No new user-facing strings (no i18n keys); change is confined to `extension/`, so the UI feature-catalog gate doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)