### PR TITLE
fix(extension): tolerate non-array routingRules so capture doesn't crash

### DIFF
--- a/extension/src/lib/config.ts
+++ b/extension/src/lib/config.ts
@@ -21,6 +21,11 @@ export async function loadConfig(): Promise<CaptureConfig> {
     ...DEFAULT_CONFIG,
     ...stored,
     signals: { ...DEFAULT_CONFIG.signals, ...(stored.signals ?? {}) },
+    // routingRules is the single source consumers iterate (resolveRepo, the
+    // options `{#each}`). A spread leaves a stored non-array (corrupt/legacy
+    // data) in place — `??` only catches null/undefined — which would crash the
+    // popup's effectiveRepo derived with "is not iterable". Coerce to an array.
+    routingRules: Array.isArray(stored.routingRules) ? stored.routingRules : [],
   };
 }
 

--- a/extension/src/lib/config.ts
+++ b/extension/src/lib/config.ts
@@ -20,7 +20,15 @@ export async function loadConfig(): Promise<CaptureConfig> {
   return {
     ...DEFAULT_CONFIG,
     ...stored,
-    signals: { ...DEFAULT_CONFIG.signals, ...(stored.signals ?? {}) },
+    // Only spread a real object over the signal defaults; a stored non-object
+    // (corrupt/legacy data) can't throw but would spread garbage keys (e.g. a
+    // string → {0:"…"}). Symmetric with the routingRules coercion below.
+    signals: {
+      ...DEFAULT_CONFIG.signals,
+      ...(stored.signals && typeof stored.signals === "object" && !Array.isArray(stored.signals)
+        ? stored.signals
+        : {}),
+    },
     // routingRules is the single source consumers iterate (resolveRepo, the
     // options `{#each}`). A spread leaves a stored non-array (corrupt/legacy
     // data) in place — `??` only catches null/undefined — which would crash the

--- a/extension/src/lib/routing.ts
+++ b/extension/src/lib/routing.ts
@@ -11,9 +11,11 @@ function escapeRegex(value: string): string {
  * case-insensitively against the full URL. The first match's `repoPath` wins;
  * with no match (or no rules) the `fallback` repo is returned. Blank-field rules
  * are skipped, and a pattern that can't compile to a RegExp is treated as a
- * no-match rather than throwing.
+ * no-match rather than throwing. A non-array `rules` (corrupt/legacy storage) is
+ * treated as no rules, so the `for…of` can never throw "is not iterable".
  */
 export function resolveRepo(url: string, rules: RoutingRule[], fallback: string): string {
+  if (!Array.isArray(rules)) return fallback;
   for (const rule of rules) {
     if (rule.pattern.trim() === "" || rule.repoPath.trim() === "") continue;
     // Escape first, THEN open up the (now-escaped) `*` into `.*` so only the

--- a/extension/test/config.test.ts
+++ b/extension/test/config.test.ts
@@ -102,6 +102,14 @@ describe("config", () => {
     expect(cfg.routingRules).toEqual([]);
   });
 
+  it("ignores a non-object stored signals, falling back to the defaults", async () => {
+    // A non-object can't throw but would spread garbage keys (a string →
+    // {0:"…"}); coerce to {} so the toggles stay the clean default shape.
+    installChromeStub({ captureConfig: { signals: "screenshot" } });
+    const cfg = await loadConfig();
+    expect(cfg.signals).toEqual(DEFAULT_CONFIG.signals);
+  });
+
   it("preserves a valid stored routingRules array", async () => {
     const rules = [{ pattern: "https://github.com/*", repoPath: "~/Work/gh" }];
     installChromeStub({ captureConfig: { routingRules: rules } });

--- a/extension/test/config.test.ts
+++ b/extension/test/config.test.ts
@@ -93,6 +93,22 @@ describe("config", () => {
     expect(cfg.signals).toEqual({ screenshot: true, console: false, network: false, a11y: true });
   });
 
+  it("coerces a non-array stored routingRules to an empty array", async () => {
+    // A stored non-array (corrupt/legacy data) must not reach consumers that
+    // iterate it (resolveRepo, the options `{#each}`) — `??` only catches
+    // null/undefined, so a truthy non-array would otherwise slip through.
+    installChromeStub({ captureConfig: { routingRules: { 0: { pattern: "*", repoPath: "x" } } } });
+    const cfg = await loadConfig();
+    expect(cfg.routingRules).toEqual([]);
+  });
+
+  it("preserves a valid stored routingRules array", async () => {
+    const rules = [{ pattern: "https://github.com/*", repoPath: "~/Work/gh" }];
+    installChromeStub({ captureConfig: { routingRules: rules } });
+    const cfg = await loadConfig();
+    expect(cfg.routingRules).toEqual(rules);
+  });
+
   it("saveSignals persists signals only, leaving other stored fields untouched", async () => {
     await saveConfig({
       baseUrl: "http://localhost:7330",

--- a/extension/test/routing.test.ts
+++ b/extension/test/routing.test.ts
@@ -46,4 +46,15 @@ describe("resolveRepo", () => {
     const rules = [rule("https://a.b/*", "~/Work/dot")];
     expect(resolveRepo("https://axb/whatever", rules, "~/fallback")).toBe("~/fallback");
   });
+
+  it("falls back (does not throw) when `rules` is not an array", () => {
+    // Corrupt/legacy storage can hand us a non-array; `for...of` would throw
+    // "is not iterable" and crash the popup's effectiveRepo derived. Treat a
+    // non-array as no rules and return the fallback instead.
+    const bad = { 0: rule("*", "~/Work/x") } as unknown as RoutingRule[];
+    expect(resolveRepo("https://github.com/acme/web", bad, "~/fallback")).toBe("~/fallback");
+    expect(resolveRepo("https://x", null as unknown as RoutingRule[], "~/fallback")).toBe(
+      "~/fallback",
+    );
+  });
 });


### PR DESCRIPTION
## Problem

Capture was broken: the popup got stuck on **"Capturing this page…"** and `chrome://extensions` logged `Uncaught TypeError: t is not iterable` (frame `assets/remote-host-*.js`, anonymous function).

## Root cause

`routingRules` is new in #379. `loadConfig` only defaults a **missing** key to `[]`; a stored **non-array** value (stale data from an earlier dev build of the routing feature, or hand-edited storage) passes straight through `config?.routingRules ?? []` — `??` only catches `null`/`undefined` — into `resolveRepo`'s `for (const rule of rules)`, which throws *"is not iterable"* (`rules` minifies to `t`).

The throw fires inside the popup's `effectiveRepo` `$derived` during the capture-view render, so Chrome reports the Svelte effect-flush frame in the shared `remote-host` chunk rather than `resolveRepo` itself — matching the reported stack exactly.

Reproduced deterministically by driving the real built popup bundle with a non-array `routingRules`: `TypeError: t is not iterable` at the minified `resolveRepo`.

## Fix

- **`loadConfig`** (single source of truth) coerces a non-array `routingRules` to `[]`. This protects every consumer at once — the popup, the options `{#each config.routingRules}`, and `onSave`'s `.filter`. The user's already-stored bad value is normalized on the next read, so capture recovers with no migration step.
- **`resolveRepo`** guards `Array.isArray(rules)` (defense in depth) — a non-array yields the fallback repo instead of throwing.

## Tests

- `routing.test.ts`: non-array / null `rules` → fallback, no throw.
- `config.test.ts`: non-array stored `routingRules` coerced to `[]`; valid array preserved.

All 63 extension tests pass; `svelte-check` clean; production build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)