### PR TITLE
fix(ui): scope plan-gate reviews into the Herd "Reviewing" group

### DIFF
--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -4,7 +4,7 @@
   import EmptyHerd from "./EmptyHerd.svelte";
   import { partitionSessions } from "./herd-partition";
   import { collectReadyPrs } from "./merge-train";
-  import { reviews } from "$lib/reviews.svelte";
+  import { reviews, planGates } from "$lib/reviews.svelte";
   import { m } from "$lib/paraglide/messages";
 
   let {
@@ -48,12 +48,20 @@
     filter === "ready" ? sessions.filter((s) => s.status !== "running") : sessions,
   );
   // within the shown set, top→bottom by lifecycle stage: active rows first, then
-  // PR-CI-running and critic-reviewing in-flight groups, then the parked
-  // ready-to-merge (green) and landed merged (blue) groups at the bottom.
-  // reviews.reviewing is $state, so this re-derives on `session:reviewing` events.
+  // PR-CI-running and critic-reviewing / plan-gate-reviewing in-flight groups, then
+  // the parked ready-to-merge (green) and landed merged (blue) groups at the bottom.
+  // reviews.reviewing and planGates.reviewing are both $state, so this re-derives on
+  // `session:reviewing` and `session:plangate-reviewing` events respectively.
   // nowMs (the reactive clock tick) is threaded in so the Merging group re-partitions
   // as the per-session merge TTL elapses, matching the badge/pip which also use nowMs.
-  const partition = $derived(partitionSessions(shown, git, (id) => reviews.isReviewing(id), nowMs));
+  const partition = $derived(
+    partitionSessions(
+      shown,
+      git,
+      (id) => reviews.isReviewing(id) || planGates.isReviewing(id),
+      nowMs,
+    ),
+  );
   // ready-to-merge sessions that actually have an open PR — the merge-train link
   // only surfaces when there's something to run (fail-closed: no PR → no link).
   const readyPrCount = $derived(collectReadyPrs(shown, git).length);


### PR DESCRIPTION
## What

When a session's pre-execution **plan reviewer** (the plan gate) is in flight, pull that session into the Herd sidebar's existing **"Reviewing (N)"** group — exactly as a completed-feature critic review already does.

## Why

The Herd partition only fed `partitionSessions` the feature-critic predicate `reviews.isReviewing(id)`, never the parallel plan-gate signal `planGates.isReviewing(id)`. So a session under adversarial plan review stayed in `active` instead of being scoped into the "Reviewing" group — visibly inconsistent with feature reviews (the per-row `PlanGateBadge` already showed `REVIEWING…`; only the list-level grouping was missing).

## Change

One call site in `ui/src/lib/components/Herd.svelte`:
- import `planGates` alongside `reviews`
- OR `planGates.isReviewing(id)` into the partition predicate
- refresh the now-stale comment to cover both review sources (`session:reviewing` + `session:plangate-reviewing`)

Scoped to the **in-flight reviewer only** (`planGates.isReviewing`, not `planPhase`), mirroring feature review exactly — the session leaves the group when the reviewer stops. Reuses the existing "Reviewing" group (no new group/header/i18n key). The pure `partitionSessions` function is unchanged (predicate injected at the call site), so its tests are unaffected.

## Verification

- `cd ui && bun run check` — 0 errors, 0 warnings
- `bun test src/lib/components/herd-partition.test.ts` — 19 pass
- fallow pre-push delta audit — clean

[no-feature-entry] bugfix reusing an already-shipped group + badge; no new user-facing UX surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)