### PR TITLE
feat(backlog): filter repo list by has-issues / has-PRs

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -579,6 +579,9 @@
   "backlog_loading": "Backlog wird geladen…",
   "backlog_no_forge_repos": "Keine Forge-Projekte",
   "backlog_select_a_project": "Projekt auswählen",
+  "backlog_filter_has_issues": "Hat Issues",
+  "backlog_filter_has_prs": "Hat PRs",
+  "backlog_filter_none_match": "Keine Repos entsprechen dem Filter",
   "a11y_skip_to_main": "Zum Hauptinhalt springen",
   "todopanel_add_aria": "Neuer To-do-Eintrag",
   "todopanel_item_aria": "Erledigt umschalten: {item}",
@@ -672,5 +675,7 @@
   "feat_buildqueue_title": "Agent-erstellte Build-Queue",
   "feat_buildqueue_body": "Aktiviere das Build-Queue-Flag für ein Repo, damit der Agent eine geordnete Schritt-Liste erstellt, bevor er startet. Du kuratierst die Schritte — bearbeiten, neu anordnen, löschen, hinzufügen — und klickst auf Freigeben & ausführen. Im Autopilot-Modus wird die Queue automatisch freigegeben.",
   "feat_plan_gate_title": "Plan-Gate",
-  "feat_plan_gate_body": "Aktiviere das Plan-Gate, um dich vor dem Start abzustimmen: Der Agent befragt dich und schreibt einen Plan, dann prüft ein zweiter Claude diesen kritisch, bis er standhält — nur ein freigegebener Plan läuft. Pro Aufgabe im Neue-Aufgabe-Dialog oder pro Repo im Automatisierungs-Panel einschaltbar."
+  "feat_plan_gate_body": "Aktiviere das Plan-Gate, um dich vor dem Start abzustimmen: Der Agent befragt dich und schreibt einen Plan, dann prüft ein zweiter Claude diesen kritisch, bis er standhält — nur ein freigegebener Plan läuft. Pro Aufgabe im Neue-Aufgabe-Dialog oder pro Repo im Automatisierungs-Panel einschaltbar.",
+  "feat_backlog_repo_filter_title": "Repo-Liste filtern",
+  "feat_backlog_repo_filter_body": "Grenze die Repo-Liste des Backlogs mit den neuen Umschalt-Chips auf Repos mit offenen Issues und/oder offenen PRs ein."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -579,6 +579,9 @@
   "backlog_loading": "Loading backlog…",
   "backlog_no_forge_repos": "No forge-backed projects",
   "backlog_select_a_project": "Select a project",
+  "backlog_filter_has_issues": "Has issues",
+  "backlog_filter_has_prs": "Has PRs",
+  "backlog_filter_none_match": "No repos match the filter",
   "a11y_skip_to_main": "Skip to main content",
   "todopanel_add_aria": "New to-do item",
   "todopanel_item_aria": "Toggle done: {item}",
@@ -672,5 +675,7 @@
   "feat_buildqueue_title": "Agent-authored build queue",
   "feat_buildqueue_body": "Enable the build queue flag on a repo to let the agent author an ordered step list before it runs. You curate the steps — edit, reorder, delete, add — then click Approve & run. Under autopilot the queue is auto-approved.",
   "feat_plan_gate_title": "Plan gate",
-  "feat_plan_gate_body": "Turn on the plan gate to align before the night starts: the agent grills you and writes a plan, then a second Claude adversarially reviews it until it holds up — only an approved plan runs. Enable it per task in New Task or per repo in the automation panel."
+  "feat_plan_gate_body": "Turn on the plan gate to align before the night starts: the agent grills you and writes a plan, then a second Claude adversarially reviews it until it holds up — only an approved plan runs. Enable it per task in New Task or per repo in the automation panel.",
+  "feat_backlog_repo_filter_title": "Filter the repo list",
+  "feat_backlog_repo_filter_body": "Narrow the backlog's repo list to repos with open issues and/or open PRs using the new toggle chips."
 }

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -7,7 +7,7 @@
   import PrsPanel from "./PrsPanel.svelte";
   import ActionsPanel from "./ActionsPanel.svelte";
   import ReadinessPanel from "./ReadinessPanel.svelte";
-  import { actionsTabState } from "./backlog-view";
+  import { actionsTabState, filterProjects } from "./backlog-view";
 
   let {
     payload,
@@ -37,6 +37,14 @@
   // Shared across tabs so switching Issues ↔ PRs keeps the chosen project.
   let selectedPath = $state<string | null>(null);
 
+  // Repo-list filter (chips live in ProjectBacklogList, state owned here so the
+  // selection effects below can stay in sync with what the list actually shows).
+  let hasIssues = $state(false);
+  let hasPRs = $state(false);
+  let visibleProjects = $derived(
+    payload ? filterProjects(payload.projects, { hasIssues, hasPRs }) : [],
+  );
+
   // Tab badges count the SELECTED repo's items — the same repo the detail pane
   // shows — not the all-repos `payload.totals` (which made "PRs · 5" sit over a
   // repo with no open PRs). null when nothing is selected → bare tab labels.
@@ -56,10 +64,29 @@
   // On mobile the detail is a full-screen overlay that hides the project list
   // and the tab toggle, so auto-seeding would drop the user straight into a
   // repo's items on load — skip it and let mobile open from the list on tap.
+  //
+  // Skip the seed when the filter currently hides the pinned repo — otherwise it
+  // would re-select a repo absent from the list (and fight the clear effect
+  // below on every poll). visibleProjects is read untracked so a filter toggle
+  // alone never auto-seeds; seeding stays tied to payload/pinned changes.
   $effect(() => {
     const pinned = payload?.pinnedPath;
-    if (pinned && !mobile && untrack(() => selectedPath === null)) {
+    if (
+      pinned &&
+      !mobile &&
+      untrack(() => selectedPath === null && visibleProjects.some((p) => p.path === pinned))
+    ) {
       selectedPath = pinned;
+    }
+  });
+
+  // Desktop: if an active filter hides the currently selected repo, drop the
+  // selection so the detail pane can't keep showing a repo that's no longer in
+  // the list. Mobile selects from the visible list and can't toggle filters
+  // while the detail overlay covers the list, so it never needs this.
+  $effect(() => {
+    if (!mobile && selectedPath !== null && !visibleProjects.some((p) => p.path === selectedPath)) {
+      selectedPath = null;
     }
   });
 
@@ -90,9 +117,13 @@
          since list and detail are never co-visible. -->
     <div class="mobile-master">
       <ProjectBacklogList
-        projects={payload.projects}
+        projects={visibleProjects}
         pinnedPath={payload.pinnedPath}
         {selectedPath}
+        {hasIssues}
+        {hasPRs}
+        ontoggleissues={() => (hasIssues = !hasIssues)}
+        ontoggleprs={() => (hasPRs = !hasPRs)}
         onselect={(p) => (selectedPath = p)}
       />
     </div>
@@ -182,9 +213,13 @@
     <div class="desktop-split">
       <div class="master-pane">
         <ProjectBacklogList
-          projects={payload.projects}
+          projects={visibleProjects}
           pinnedPath={payload.pinnedPath}
           {selectedPath}
+          {hasIssues}
+          {hasPRs}
+          ontoggleissues={() => (hasIssues = !hasIssues)}
+          ontoggleprs={() => (hasPRs = !hasPRs)}
           onselect={(p) => (selectedPath = p)}
         />
       </div>

--- a/ui/src/lib/components/ProjectBacklogList.svelte
+++ b/ui/src/lib/components/ProjectBacklogList.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { BacklogProject } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { filterProjects } from "./backlog-view";
   import ProjectRow from "./ProjectRow.svelte";
 
   let {
@@ -13,23 +15,108 @@
     selectedPath: string | null;
     onselect: (path: string) => void;
   } = $props();
+
+  let hasIssues = $state(false);
+  let hasPRs = $state(false);
+
+  const visible = $derived(filterProjects(projects, { hasIssues, hasPRs }));
 </script>
 
-<div class="project-list">
-  {#each projects as project (project.path)}
-    <ProjectRow
-      {project}
-      pinned={project.path === pinnedPath}
-      selected={project.path === selectedPath}
-      onselect={() => onselect(project.path)}
-    />
-  {/each}
+<div class="filter-bar">
+  <button
+    class="filter-chip"
+    class:active={hasIssues}
+    type="button"
+    aria-pressed={hasIssues}
+    onclick={() => (hasIssues = !hasIssues)}
+  >
+    {m.backlog_filter_has_issues()}
+  </button>
+  <button
+    class="filter-chip"
+    class:active={hasPRs}
+    type="button"
+    aria-pressed={hasPRs}
+    onclick={() => (hasPRs = !hasPRs)}
+  >
+    {m.backlog_filter_has_prs()}
+  </button>
 </div>
 
+{#if projects.length > 0 && visible.length === 0}
+  <div class="filter-empty">
+    <span class="filter-empty-label">{m.backlog_filter_none_match()}</span>
+  </div>
+{:else}
+  <div class="project-list">
+    {#each visible as project (project.path)}
+      <ProjectRow
+        {project}
+        pinned={project.path === pinnedPath}
+        selected={project.path === selectedPath}
+        onselect={() => onselect(project.path)}
+      />
+    {/each}
+  </div>
+{/if}
+
 <style>
+  .filter-bar {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    gap: 2px;
+    padding: 4px 4px 6px;
+    margin-bottom: 2px;
+    background: var(--color-inset);
+    border-bottom: 1px solid var(--color-line);
+  }
+
+  .filter-chip {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.1em;
+    padding: 0 10px;
+    min-height: 36px;
+    cursor: pointer;
+    touch-action: manipulation;
+    transition:
+      color 0.12s,
+      border-color 0.12s;
+  }
+
+  .filter-chip:hover {
+    color: var(--color-ink);
+  }
+
+  .filter-chip.active {
+    color: var(--color-ink-bright);
+    border-color: var(--color-line-bright);
+    background: var(--color-inset);
+  }
+
   .project-list {
     display: flex;
     flex-direction: column;
     gap: 2px;
+  }
+
+  .filter-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 8px;
+  }
+
+  .filter-empty-label {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-faint);
   }
 </style>

--- a/ui/src/lib/components/ProjectBacklogList.svelte
+++ b/ui/src/lib/components/ProjectBacklogList.svelte
@@ -1,25 +1,29 @@
 <script lang="ts">
   import type { BacklogProject } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { filterProjects } from "./backlog-view";
   import ProjectRow from "./ProjectRow.svelte";
 
   let {
     projects,
     pinnedPath,
     selectedPath,
+    hasIssues,
+    hasPRs,
+    ontoggleissues,
+    ontoggleprs,
     onselect,
   }: {
+    /** Already filtered by the parent (BacklogView) via filterProjects — the
+     *  parent owns the filter state so it can keep the selection in sync. */
     projects: BacklogProject[];
     pinnedPath: string | null;
     selectedPath: string | null;
+    hasIssues: boolean;
+    hasPRs: boolean;
+    ontoggleissues: () => void;
+    ontoggleprs: () => void;
     onselect: (path: string) => void;
   } = $props();
-
-  let hasIssues = $state(false);
-  let hasPRs = $state(false);
-
-  const visible = $derived(filterProjects(projects, { hasIssues, hasPRs }));
 </script>
 
 <div class="filter-bar">
@@ -28,7 +32,7 @@
     class:active={hasIssues}
     type="button"
     aria-pressed={hasIssues}
-    onclick={() => (hasIssues = !hasIssues)}
+    onclick={ontoggleissues}
   >
     {m.backlog_filter_has_issues()}
   </button>
@@ -37,19 +41,21 @@
     class:active={hasPRs}
     type="button"
     aria-pressed={hasPRs}
-    onclick={() => (hasPRs = !hasPRs)}
+    onclick={ontoggleprs}
   >
     {m.backlog_filter_has_prs()}
   </button>
 </div>
 
-{#if projects.length > 0 && visible.length === 0}
+<!-- The parent only renders this list when there are forge repos, so an empty
+     `projects` here always means the active filter matched nothing. -->
+{#if projects.length === 0}
   <div class="filter-empty">
     <span class="filter-empty-label">{m.backlog_filter_none_match()}</span>
   </div>
 {:else}
   <div class="project-list">
-    {#each visible as project (project.path)}
+    {#each projects as project (project.path)}
       <ProjectRow
         {project}
         pinned={project.path === pinnedPath}

--- a/ui/src/lib/components/backlog-view.test.ts
+++ b/ui/src/lib/components/backlog-view.test.ts
@@ -20,6 +20,7 @@ import {
   prsTabLabel,
   actionsTabLabel,
   actionsTabState,
+  filterProjects,
 } from "./backlog-view";
 import type { BacklogPayload, BacklogProject } from "$lib/types";
 
@@ -187,6 +188,60 @@ describe("actionsTabState (shared source of truth for tab + label)", () => {
 
   it("returns bare when workflows is null (non-github) and CI not failing", () => {
     expect(actionsTabState(project("/repos/a", 0, 0, null, null))).toEqual({ kind: "bare" });
+  });
+});
+
+describe("filterProjects", () => {
+  // Fixed corpus spanning every issues/PRs combination, incl. null and 0 counts.
+  const both = project("/repos/both", 3, 2); // issues>0 AND prs>0
+  const issuesOnly = project("/repos/issues-only", 5, 0); // issues>0, prs=0
+  const prsOnly = project("/repos/prs-only", 0, 4); // issues=0, prs>0
+  const neither = project("/repos/neither", 0, 0); // both 0
+  const nullIssues = project("/repos/null-issues", null, 6); // issues null, prs>0
+  const nullPRs = project("/repos/null-prs", 7, null); // issues>0, prs null
+  const projects = [both, issuesOnly, prsOnly, neither, nullIssues, nullPRs];
+
+  it("returns all projects unchanged when both flags are off", () => {
+    expect(filterProjects(projects, { hasIssues: false, hasPRs: false })).toEqual(projects);
+  });
+
+  it("keeps only projects with openIssues > 0 when hasIssues is on", () => {
+    expect(filterProjects(projects, { hasIssues: true, hasPRs: false })).toEqual([
+      both,
+      issuesOnly,
+      nullPRs,
+    ]);
+  });
+
+  it("keeps only projects with openPRs > 0 when hasPRs is on", () => {
+    expect(filterProjects(projects, { hasIssues: false, hasPRs: true })).toEqual([
+      both,
+      prsOnly,
+      nullIssues,
+    ]);
+  });
+
+  it("intersects (AND) when both flags are on — needs issues>0 AND prs>0", () => {
+    expect(filterProjects(projects, { hasIssues: true, hasPRs: true })).toEqual([both]);
+  });
+
+  it("fails closed on null/0 counts: null openIssues is excluded when hasIssues is on", () => {
+    const result = filterProjects(projects, { hasIssues: true, hasPRs: false });
+    expect(result).not.toContain(nullIssues); // null fails closed
+    expect(result).not.toContain(prsOnly); // 0 is not > 0
+    expect(result).not.toContain(neither);
+  });
+
+  it("fails closed on null/0 counts: null openPRs is excluded when hasPRs is on", () => {
+    const result = filterProjects(projects, { hasIssues: false, hasPRs: true });
+    expect(result).not.toContain(nullPRs); // null fails closed
+    expect(result).not.toContain(issuesOnly); // 0 is not > 0
+    expect(result).not.toContain(neither);
+  });
+
+  it("returns an empty array when every project is excluded", () => {
+    const allEmpty = [project("/repos/a", 0, 0), project("/repos/b", null, null)];
+    expect(filterProjects(allEmpty, { hasIssues: true, hasPRs: true })).toEqual([]);
   });
 });
 

--- a/ui/src/lib/components/backlog-view.ts
+++ b/ui/src/lib/components/backlog-view.ts
@@ -88,3 +88,22 @@ export function actionsTabLabel(sel: BacklogProject | null): string {
       return "Actions";
   }
 }
+
+/**
+ * Narrow the repo list by activity. Each active flag is a *required* predicate
+ * (AND semantics): `hasIssues` keeps only repos with open issues, `hasPRs` only
+ * repos with open PRs, and both together keep only their intersection. With
+ * both off, every project passes (an identity filter).
+ *
+ * Counts fail closed: `?? 0` maps an unknown count (`null`, e.g. a non-github
+ * forge or a not-yet-fetched repo) to 0, so only a count strictly `> 0`
+ * satisfies a flag — `null` and `0` are both excluded.
+ */
+export function filterProjects(
+  projects: readonly BacklogProject[],
+  opts: { hasIssues: boolean; hasPRs: boolean },
+): BacklogProject[] {
+  return projects.filter(
+    (p) => (!opts.hasIssues || (p.openIssues ?? 0) > 0) && (!opts.hasPRs || (p.openPRs ?? 0) > 0),
+  );
+}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -108,4 +108,10 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_plan_gate_body",
     targetId: "plan-gate",
   },
+  {
+    id: "backlog-repo-filter",
+    sinceVersion: "1.19.0",
+    titleKey: "feat_backlog_repo_filter_title",
+    bodyKey: "feat_backlog_repo_filter_body",
+  },
 ];


### PR DESCRIPTION
## What

Adds two toggle chips above the backlog **repo list** that narrow it to repos with **open issues** and/or **open PRs**.

- Chips: **Has issues** / **Has PRs**, independent toggles.
- **AND semantics:** a repo shows iff it passes *every active* chip. Neither active → all repos. Both active → repos with open issues **and** open PRs.
- **Null/0 counts fail closed** — a repo whose count is `null` (forge unavailable / not yet fetched) or `0` never satisfies a chip, mirroring the `—` already shown in the row.
- **Pinned repo obeys the filter** (no bypass).
- Sticky chip header (stays put while the list scrolls); fail-visible "no repos match" state.

## Feasibility note (the "optional AND filter" the request asked us to evaluate)

Trivially doable with **no backend work**: `BacklogProject` already carries `openIssues`/`openPRs` client-side in the `/api/backlog` payload, so AND is just `predA && predB` over in-memory data.

## How

- Pure predicate `filterProjects(projects, { hasIssues, hasPRs })` in `ui/src/lib/components/backlog-view.ts` (node-tested, TDD).
- `ProjectBacklogList.svelte` wires `$state` toggles → `$derived(filterProjects(...))` → list; design-system tokens only, `aria-pressed` chips.
- i18n EN+DE keys; feature-catalog entry (`backlog-repo-filter`, `sinceVersion 1.19.0`).

## Tests / gates

- `backlog-view.test.ts`: 7 new cases (off/issues/prs/AND/null-fail-closed/all-excluded). 576 tests pass.
- `bun run check` ✓ · `check:i18n` 678 keys parity ✓ · `check-feature-catalog.sh` ✓ · fallow delta audit clean ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)