### PR TITLE
fix(ui): scrollable mobile backlog tab strip so close button never collides

### DIFF
--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -450,6 +450,7 @@
     border-bottom: 1px solid var(--color-line);
     flex-shrink: 0;
     min-height: 44px;
+    gap: 8px;
   }
 
   .overlay-close {
@@ -464,24 +465,36 @@
     cursor: pointer;
     min-height: 40px;
     touch-action: manipulation;
+    flex-shrink: 0;
   }
 
   .overlay-close:hover {
     background: var(--color-hover);
   }
 
-  /* Tab toggle relocated into the overlay header on mobile, pushed to the
-     right of the back/close button. Touch-sized to match .overlay-close. */
+  /* Tab strip sits after the fixed close button and scrolls horizontally when
+     tabs exceed the available width. Scrollbar is hidden (matches ControlBar
+     convention). */
   .overlay-tabs {
     display: flex;
     gap: 2px;
-    margin-left: auto;
+    flex: 1 1 0;
+    min-width: 0;
+    overflow-x: auto;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+
+  .overlay-tabs::-webkit-scrollbar {
+    display: none;
   }
 
   .overlay-tabs .tab-btn {
     min-height: 40px;
     padding: 0 12px;
     touch-action: manipulation;
+    flex-shrink: 0;
   }
 
   .overlay-body {


### PR DESCRIPTION
## Problem

On the mobile **BACKLOG** overlay, the "‹ close" button jams flush against the selected **Issues** tab, and the last tab (**Readiness**) spills off the right edge.

**Root cause:** `.overlay-head` is a single non-wrapping flex row — close button on the left, the four tabs pushed right via `margin-left: auto`. The tab labels (wider in German) plus the close button exceed phone width, so `margin-left: auto` collapses to zero: the close box touches the Issues tab and the trailing tab overflows.

## Fix

CSS-only, scoped to the mobile overlay (`BacklogView.svelte`). Convert the tab strip into a horizontally-scrollable bar with the close button frozen on the left and a guaranteed gap — mirroring the existing `ControlBar`/`SteerBar` pattern (`overflow-x: auto`, hidden scrollbar, `-webkit-overflow-scrolling: touch`).

- `.overlay-head`: `gap: 8px` (guaranteed separation between close button and tabs)
- `.overlay-close`: `flex-shrink: 0` (never compresses)
- `.overlay-tabs`: drop `margin-left: auto` → `flex: 1 1 0; min-width: 0; overflow-x: auto; white-space: nowrap; scrollbar-width: none` + hidden WebKit scrollbar
- `.overlay-tabs .tab-btn`: `flex-shrink: 0` (tabs keep full width; strip scrolls instead of squishing)
- Updated the now-stale comment to describe the scroll behavior

Desktop `.tab-bar` untouched. No markup/JS change. No new strings (no i18n change), bug fix not a feat (no feature-catalog entry).

## Verification

- `cd ui && bun run check` → 0 errors, 0 warnings
- Pre-push gates pass: branch hygiene, prettier, lint, typecheck, tests, build, fallow audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)