### PR TITLE
fix(ui): MERGING badge pulses text, not a bleeding halo

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -229,6 +229,17 @@ body {
     transform: translateY(100%);
   }
 }
+/* in-flight MERGING text pulse — dims and restores amber opacity; clip-proof
+   (no box-shadow halo), so it never bleeds into adjacent badges. */
+@keyframes merge-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
 /* Blanket-disable decorative motion under reduced-motion. Functional status
    indicators ("work happening": CI dot-pulse, pip-pulse, critic rev-pulse,
    in-progress blink) intentionally override this with `animation: ... !important`

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -507,7 +507,7 @@
      merge train, louder than the quiet muted text badges around it. */
   .badge.merging {
     color: var(--color-amber);
-    animation: pip-pulse 1.5s ease-out infinite;
+    animation: merge-pulse 1.5s ease-in-out infinite;
   }
 
   .elapsed {


### PR DESCRIPTION
## Problem

The pulsing **MERGING** badge in a task card sat flush against the badge directly above it (STALLED, READY, or a plain status label) — no visible gap.

## Root cause

MERGING is a padding-less text `<span class="badge merging">` animated with the `pip-pulse` keyframe, which paints an amber `box-shadow` halo that expands to **7px** in every direction. `pip-pulse` was designed for the round `StatusPip` dot, where an expanding halo reads correctly. On a rectangular, background-less text badge the 7px halo overflows the `.u-right` column's **4px** badge gap and bleeds up into the neighbouring badge — looking flush. (`app.css` already noted this halo isn't clip-proof.)

## Fix

Pulse the **text**, not a halo. Added a single-purpose `@keyframes merge-pulse` (amber text opacity `1 ⇄ 0.55`, no `box-shadow`) and pointed `.badge.merging` at it. Clip-proof, no bleed, still the loudest badge in the column — loudness is carried by the amber hue against muted neighbours, with the pulse as a secondary signal.

- `.badge.merging` keeps `color: var(--color-amber)` and **no** `!important`, so under `prefers-reduced-motion` it falls back to static amber (unchanged) — the colour still encodes the in-flight-merge state.
- `merge-pulse` is intentionally **not** added to the reduced-motion overrides comment (that list documents `!important` exemptions; `merge-pulse` is suppressed, not exempt).

`StatusPip` still uses `pip-pulse` on its dot (correct usage, untouched).

## Scope

Pure visual fix, two files (`ui/src/app.css`, `ui/src/lib/components/UnitRow.svelte`). No new user-facing strings (no i18n change) and not a `feat` (no feature-catalog entry). `cd ui && bun run check` clean; existing UnitRow tests pass.

Criteria 1-3 are visual and confirmed by manual eyeball — `bun run check` cannot detect a spacing/halo regression. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)