### PR TITLE
fix(ui): merge train always skips the plan gate

### DIFF
--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, test } from "vitest";
 import {
   collectReadyPrs,
   formatReadyPrs,
+  mergeTrainCreateInput,
   pickTrainRepo,
   isMerging,
   MERGE_STALE_MS,
@@ -148,6 +149,32 @@ describe("pickTrainRepo", () => {
 
   it("returns null repo for an empty list", () => {
     expect(pickTrainRepo([])).toEqual({ repoPath: null, prs: [], otherRepoCount: 0 });
+  });
+});
+
+describe("mergeTrainCreateInput", () => {
+  const prs = [
+    {
+      sessionId: "s1",
+      number: 11,
+      title: "feat: a",
+      url: "https://h/pull/11",
+      repoPath: "/repo/a",
+    },
+    { sessionId: "s2", number: 22, title: "fix: b", url: "https://h/pull/22", repoPath: "/repo/a" },
+  ];
+
+  it("always skips the plan gate (planGateEnabled === false)", () => {
+    expect(mergeTrainCreateInput("/repo/a", "main", prs).planGateEnabled).toBe(false);
+  });
+
+  it("passes through repoPath/baseBranch with null model and a non-empty prompt", () => {
+    const input = mergeTrainCreateInput("/repo/a", "main", prs);
+    expect(input.repoPath).toBe("/repo/a");
+    expect(input.baseBranch).toBe("main");
+    expect(input.model).toBeNull();
+    expect(typeof input.prompt).toBe("string");
+    expect(input.prompt.length).toBeGreaterThan(0);
   });
 });
 

--- a/ui/src/lib/components/merge-train.ts
+++ b/ui/src/lib/components/merge-train.ts
@@ -1,4 +1,5 @@
-import type { Session, GitState } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+import type { Session, GitState, CreateInput } from "$lib/types";
 
 /** Merge-train marks older than this read as stale (the row falls back to its
  *  prior state) so a stuck PR never sticks visually even if the server's TTL
@@ -79,4 +80,22 @@ export function pickTrainRepo(prs: ReadyPr[]): {
     }
   }
   return { repoPath: bestRepo, prs: best, otherRepoCount: prs.length - best.length };
+}
+
+/** Build the `createSession` input for a merge-train kickoff. Pure (no I/O, no
+ *  side effects) so the gate-skip invariant is locked by `merge-train.test.ts`. */
+export function mergeTrainCreateInput(
+  repoPath: string,
+  baseBranch: string,
+  prs: ReadyPr[],
+): CreateInput {
+  return {
+    repoPath,
+    baseBranch,
+    prompt: m.herd_merge_train_prompt({ prs: formatReadyPrs(prs) }),
+    model: null,
+    // Merge train is a procedural land-the-queue task, never a feature plan —
+    // always skip the plan gate regardless of the per-repo toggle.
+    planGateEnabled: false,
+  };
 }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -47,7 +47,11 @@
   import LearningsDrawer from "$lib/components/LearningsDrawer.svelte";
   import { basename } from "$lib/components/learnings-drawer";
   import Herd from "$lib/components/Herd.svelte";
-  import { collectReadyPrs, formatReadyPrs, pickTrainRepo } from "$lib/components/merge-train";
+  import {
+    collectReadyPrs,
+    mergeTrainCreateInput,
+    pickTrainRepo,
+  } from "$lib/components/merge-train";
   import Viewport from "$lib/components/Viewport.svelte";
   import NewTask from "$lib/components/NewTask.svelte";
   import Settings from "$lib/components/Settings.svelte";
@@ -262,12 +266,7 @@
     const br = await listBranches(repoPath).catch(() => null);
     const baseBranch = br?.current ?? br?.branches[0] ?? "main";
     try {
-      const s = await createSession({
-        repoPath,
-        baseBranch,
-        prompt: m.herd_merge_train_prompt({ prs: formatReadyPrs(prs) }),
-        model: null,
-      });
+      const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs));
       selectedId = s.id;
       // Mark this repo's ready PR-sessions as "merging" so the list shows them
       // in-flight. Derived from the same scoped `prs` array the train works


### PR DESCRIPTION
## What

The merge-train skill — launched by the **Run merge train** button in the Ready-to-merge group (`onmergetrain()` in `ui/src/routes/+page.svelte`) — spawned its session via `createSession(...)` **without** `planGateEnabled`. So it inherited the per-repo plan-gate toggle and could be wrongly subjected to the pre-execution plan gate (grill + adversarial plan review, which can stall and escalate to a human).

A merge train is a procedural "review the queue and land PRs" task, never a feature plan. It must skip the plan gate **regardless of the per-repo toggle or any default**.

## Change

- New pure helper `mergeTrainCreateInput(repoPath, baseBranch, prs)` in `ui/src/lib/components/merge-train.ts` builds the train's `createSession` input and hardcodes `planGateEnabled: false`. Server-side this resolves `planGateOn = input.planGateEnabled ?? repoConfig.planGateEnabled` → `false`, so the session is born with `planPhase: null` and goes straight to executing.
- `onmergetrain()` now calls the helper instead of inlining the object — single source of truth for the launch input.
- Regression test in `merge-train.test.ts` asserts `mergeTrainCreateInput(...).planGateEnabled === false` (the gate-skip proof) plus the rest of the contract (`model` null, non-empty `prompt`, passthrough of repo/base). The invariant is now enforced on every `bun run test`, not by a comment + manual check.

The other two `createSession` callers (`onquickissue`, the NewTask handler) are untouched. The `QueueStrip`/`AutoMergeService` "merge train" is a status display that never *creates* sessions, so it has no plan-gate interaction.

## Notes

- No type/validation/API changes — `CreateInput` already accepts `planGateEnabled?: boolean | null`.
- No new i18n strings; `check:i18n` unaffected.
- Labeled `fix` (restores intended behavior of an existing feature; ships no new user-facing surface) → no feature-announcement catalog entry required.

## Verify

- `cd ui && bun run check` → 0 errors, 0 warnings
- `cd ui && bun run test` → 578 passed (incl. 2 new `mergeTrainCreateInput` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)