### PR TITLE
fix(ui): resync reconciles critic + plan-gate reviewing latches

### DIFF
--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -140,10 +140,15 @@
   // Re-pull the REST-loaded state on tab return. The live /events stream is
   // delta-only: while a mobile tab is frozen (locked phone / backgrounded app)
   // the socket drops and every missed event is gone for good, so sessions, git,
-  // usage and backlog sit stale until a manual refresh. Resync the high-signal
-  // data when the tab comes back so launching from a notification or unlocking
-  // shows current state without one. Always fires — a half-open socket can read
-  // as connected, so we can't gate on store.connected.
+  // usage, backlog — and the critic/plan-gate verdicts plus their in-flight
+  // `reviewing` latches — sit stale until a manual refresh. The reviewing latch
+  // is the costly one: it only clears on a live `reviewing=false`/verdict event,
+  // so a server restart mid-review (which boots with an empty in-flight map and
+  // never re-emits the `false`) strands it `true`, pinning the card in the
+  // reviewing group until a full reload. Resync the high-signal data when the tab
+  // comes back so launching from a notification or unlocking shows current state
+  // without one. Always fires — a half-open socket can read as connected, so we
+  // can't gate on store.connected.
   function resync() {
     listSessions()
       .then((list) => store.setAll(list))
@@ -160,6 +165,11 @@
     getBacklog()
       .then((p) => (backlog = p))
       .catch(() => {});
+    // Reconcile critic + plan-gate verdicts and their reviewing latches from the
+    // server snapshot (both self-handle errors). load() re-fetches the /inflight
+    // ids, so a `reviewing=false` missed across a disconnect/restart is corrected.
+    reviews.load();
+    planGates.load();
   }
 
   // Fetch backlog when the overview is empty, or when the operator opens the


### PR DESCRIPTION
## Symptom

A CI-green PR whose critic already approved sat pinned in the **Reviewing** group of the herd and never moved to *awaiting merge*, even though server-side the review was long done. A full page reload fixed it.

## Root cause

The UI `reviewing` flag (`reviews.svelte.ts`, `PlanGateStore`/`ReviewsStore`) is a **delta-only latch**: set on `session:reviewing` / `session:plangate-reviewing` `true`, cleared only by a live `false` event or a landing verdict. The bootstrap that reconciles it from the server (`reviews.load()` / `planGates.load()`, which fetch `/api/reviews/inflight` + `/api/plan-gates/inflight`) runs **once on mount**.

`resync()` — the tab-return / visibility / pageshow refresh that exists precisely because the `/events` stream is delta-only and drops missed events while a tab is frozen — re-pulled sessions, git, usage and backlog **but not the review stores**. So when the server **restarts mid-review** (new process boots with an empty in-flight map → never re-emits `reviewing=false`, and the verdict fires while the tab is disconnected), the latch is stranded `true`. The partition (`herd-partition.ts`, `isReviewing = reviews.isReviewing(id) || planGates.isReviewing(id)`) then keeps the card in `reviewerRunning`, which outranks `awaitingMerge` — pinned until a full reload.

The plan gate (#375) added a second latch (`planGates`) with the same gap, making this much likelier to surface, since the plan-gate phase happens early — exactly when settings are being toggled / the server restarted.

## Fix

Add `reviews.load()` + `planGates.load()` to `resync()` so a tab-return / reconnect reconciles the critic + plan-gate verdicts and their in-flight latches from the authoritative server snapshot — a `reviewing=false` missed across a disconnect or restart is corrected without a manual reload. Both `load()`s self-handle errors (best-effort). Comment updated to document the latch hazard.

## Scope / testing

One file (`ui/src/routes/+page.svelte`), 2 added calls + comment. `fix:`, not a `feat` — no new strings (no i18n), no feature-catalog entry. `cd ui && bun run check` clean; full UI suite **576/576** pass. No `+page` unit-test harness exists (the page component isn't unit-tested — only the stores are, and `reviews.load()`/`planGates.load()` are already covered there), so this wiring change is verified by `check` + the existing store tests rather than a new test. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)