### PR TITLE
fix(mobile): keep the herd-list action bar on-screen (document-scroll shell)

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -187,7 +187,7 @@ body {
   color: var(--color-ink);
   font-family: var(--font-mono);
   margin: 0;
-  height: 100%;
+  min-height: 100%;
   font-size: var(--fs-base);
   letter-spacing: 0.02em;
   -webkit-font-smoothing: antialiased;

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -229,8 +229,18 @@
     background: var(--color-inset);
     border-color: var(--color-amber);
   }
+  /* Mobile list document-scrolls: margin-top:auto bottom-aligns the bar when
+     the list is short (no scroll); position:sticky pins it to the viewport
+     bottom while scrolling a long list. The two are complementary — removing
+     either breaks one of the two cases. padding-bottom clears the gesture-nav
+     safe-area inset. */
   .actions.mobile {
+    position: sticky;
+    bottom: 0;
+    z-index: 5;
+    margin-top: auto;
     padding: 10px;
+    padding-bottom: max(10px, env(safe-area-inset-bottom));
   }
   .actions.mobile .btn.primary {
     flex: 1;

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -229,16 +229,14 @@
     background: var(--color-inset);
     border-color: var(--color-amber);
   }
-  /* Mobile list document-scrolls: margin-top:auto bottom-aligns the bar when
-     the list is short (no scroll); position:sticky pins it to the viewport
-     bottom while scrolling a long list. The two are complementary — removing
-     either breaks one of the two cases. padding-bottom clears the gesture-nav
-     safe-area inset. */
+  /* Mobile list document-scrolls: the herd/backlog above flex-fills the viewport
+     when the list is short, keeping the bar at the bottom; position:sticky pins
+     the bar to the viewport bottom while scrolling a long list. padding-bottom
+     clears the gesture-nav safe-area inset. */
   .actions.mobile {
     position: sticky;
     bottom: 0;
     z-index: 5;
-    margin-top: auto;
     padding: 10px;
     padding-bottom: max(10px, env(safe-area-inset-bottom));
   }

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -16,6 +16,7 @@
     onquick = undefined,
     onpr,
     onadopt,
+    flow = false,
   }: {
     payload: BacklogPayload | null;
     mobile: boolean;
@@ -27,6 +28,9 @@
     onpr: (repoPath: string, pr: PullRequest) => void;
     /** Seed a New Task with the AI-readiness install prescription (Readiness tab). */
     onadopt: (repoPath: string, prompt: string) => void;
+    /** When true, renders at natural height for parent-page scrolling (mobile list);
+     *  default false preserves existing viewport-filling behavior. */
+    flow?: boolean;
   } = $props();
 
   type Tab = "issues" | "prs" | "actions" | "readiness";
@@ -97,7 +101,7 @@
   }
 </script>
 
-<div class="backlog-view" class:mobile>
+<div class="backlog-view" class:mobile class:flow>
   {#if payload === null}
     <!-- loading state -->
     <div class="state-full">
@@ -475,6 +479,12 @@
   /* BacklogView must be position:relative so the overlay is contained */
   .backlog-view.mobile {
     position: relative;
+  }
+
+  /* flow mode: render at natural height for parent-page scrolling (mobile list) */
+  .backlog-view.flow {
+    height: auto;
+    overflow: visible;
   }
 
   .overlay-head {

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -20,6 +20,7 @@
     onmergetrain = undefined,
     standardCommandUnset = false,
     onsettings = undefined,
+    flow = false,
   }: {
     sessions: Session[];
     selectedId: string | null;
@@ -39,6 +40,9 @@
     // is set → surface a quiet nudge pointing at Settings.
     standardCommandUnset?: boolean;
     onsettings?: () => void;
+    // when true, the session list renders at natural height (no internal scroll)
+    // so the parent page can drive scrolling; default false preserves existing behavior
+    flow?: boolean;
   } = $props();
 
   // sidebar list filter: "all" or "ready" (only sessions not actively working —
@@ -89,7 +93,7 @@
       >
     </div>
   </div>
-  <div class="units">
+  <div class="units" class:flow>
     {#if sessions.length === 0}
       <EmptyHerd {onnew} {standardCommandUnset} {onsettings} />
     {:else if shown.length === 0}
@@ -389,6 +393,13 @@
     /* size context for UnitRow's container queries — lets rows adapt the
        designator to the actual sidebar width (compact vs desktop) */
     container: herd / inline-size;
+  }
+
+  /* flow mode: render at natural height for parent-page scrolling (mobile list) */
+  .units.flow {
+    overflow: visible;
+    flex: none;
+    min-height: auto;
   }
 
   .empty {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -633,33 +633,39 @@
 
 <svelte:window onkeydown={onShortcut} />
 
-<div class="shell" class:mobile={mobile.current}>
+<div
+  class="shell"
+  class:mobile={mobile.current}
+  class:list={mobile.current && mobileScreen === "list"}
+>
   <!-- On a phone in the terminal-focus screen the top bar is subsumed by the
        viewport's merged header (repo · session + back + status tint), so it's
        hidden there; settings + global chrome stay on the herd overview. -->
   {#if !(mobile.current && mobileScreen === "detail")}
-    <TopBar
-      sessions={store.sessions}
-      {nowMs}
-      connected={store.connected}
-      mobile={mobile.current}
-      touch={touch.current}
-      limits={store.usageLimits}
-      onsettings={() => (showSettings = true)}
-      onhalt={haltHerd}
-      needsYou={blockedEntries.length}
-      ontriage={() => (showTriage = true)}
-      learnings={learnings.items.length}
-      overBudget={overBudgetRules}
-      onlearnings={() => (showLearnings = true)}
-      update={store.update}
-      onupdate={() => (showUpdate = true)}
-      herdrUpdate={store.herdrUpdate}
-      onherdrupdate={() => (showHerdrUpdate = true)}
-      whatsNew={whatsNewDotOn}
-      onwhatsnew={() => (showWhatsNew = true)}
-    />
-    <QueueStrip drain={store.drain} autoMerge={store.autoMerge} />
+    <div class="chrome">
+      <TopBar
+        sessions={store.sessions}
+        {nowMs}
+        connected={store.connected}
+        mobile={mobile.current}
+        touch={touch.current}
+        limits={store.usageLimits}
+        onsettings={() => (showSettings = true)}
+        onhalt={haltHerd}
+        needsYou={blockedEntries.length}
+        ontriage={() => (showTriage = true)}
+        learnings={learnings.items.length}
+        overBudget={overBudgetRules}
+        onlearnings={() => (showLearnings = true)}
+        update={store.update}
+        onupdate={() => (showUpdate = true)}
+        herdrUpdate={store.herdrUpdate}
+        onherdrupdate={() => (showHerdrUpdate = true)}
+        whatsNew={whatsNewDotOn}
+        onwhatsnew={() => (showWhatsNew = true)}
+      />
+      <QueueStrip drain={store.drain} autoMerge={store.autoMerge} />
+    </div>
   {/if}
 
   <main id="main-content" class="main-region">
@@ -679,6 +685,7 @@
             {onmergetrain}
             {standardCommandUnset}
             onsettings={() => (showSettings = true)}
+            flow={true}
           />
           {#if store.sessions.length === 0}
             <BacklogView
@@ -688,6 +695,7 @@
               onquick={onquickissue}
               {onpr}
               {onadopt}
+              flow={true}
             />
           {/if}
         </div>
@@ -1039,5 +1047,38 @@
     padding: max(10px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right))
       max(10px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
     gap: 10px;
+  }
+
+  .chrome {
+    display: flex;
+    flex-direction: column;
+    gap: inherit;
+  }
+
+  /* Mobile list screen becomes a document-scroll app-shell: the shell grows with
+     content (min-height floor = one viewport), the middle flows at natural height
+     so the whole page scrolls, and the chrome/ActionBar are pinned. This keeps the
+     ActionBar reachable even if 100dvh is mis-measured taller than the real window. */
+  .shell.mobile.list {
+    height: auto;
+    min-height: 100dvh;
+    /* the sticky ActionBar owns the bottom safe-area inset, so drop the shell's
+       bottom padding to avoid a blank gap below the pinned bar */
+    padding-bottom: 0;
+  }
+  .shell.mobile.list .chrome {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    /* opaque base surface so list content scrolling underneath doesn't show
+       through the gap between TopBar and QueueStrip */
+    background: var(--color-bg);
+  }
+  .shell.mobile.list .main-region,
+  .shell.mobile.list .col {
+    /* min-height:auto (not 0): flex children still grow to fill the viewport when
+       the list is short, but are no longer capped — tall content overflows and the
+       document scrolls instead of trapping it in an inner scroller */
+    min-height: auto;
   }
 </style>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1062,8 +1062,10 @@
   .shell.mobile.list {
     height: auto;
     min-height: 100dvh;
-    /* the sticky ActionBar owns the bottom safe-area inset, so drop the shell's
-       bottom padding to avoid a blank gap below the pinned bar */
+    /* the pinned chrome/ActionBar own the top/bottom safe-area insets (see below),
+       so drop the shell's own top+bottom padding — otherwise a stuck header would
+       inset twice (notch + shell), and a blank gap would sit below the pinned bar */
+    padding-top: 0;
     padding-bottom: 0;
   }
   .shell.mobile.list .chrome {
@@ -1073,6 +1075,11 @@
     /* opaque base surface so list content scrolling underneath doesn't show
        through the gap between TopBar and QueueStrip */
     background: var(--color-bg);
+    /* own the top safe-area inset (mirrors the ActionBar's padding-bottom): keeps
+       the TopBar clear of the notch / Dynamic Island while the chrome is stuck at
+       top:0, with the opaque background filling the inset area. max(10px, …) keeps
+       the prior 10px breathing room on non-notched devices. */
+    padding-top: max(10px, env(safe-area-inset-top));
   }
   .shell.mobile.list .main-region,
   .shell.mobile.list .col {


### PR DESCRIPTION
## Problem

On the Android **installed PWA**, the mobile herd-list screen's bottom action bar (NEW TASK / BACKLOG) intermittently rendered **below the visible screen edge** and stayed there until the PWA was **force-killed and relaunched** — even with only a few sessions running.

## Root cause

The shell is a rigid `height: 100dvh` flex column with an **inner** herd scroller. When the computed `100dvh` renders taller than the real window, the bar is laid out below the visible edge, and the inner `.units`/backlog scroller **traps the touch gesture**, so the outer document can't be scrolled to reach the bar. A relaunch re-lays-out the shell at a correct height — which is why a force-kill was the only recovery. Session *count* is irrelevant because the list scrolls internally; the chrome/measurement is the driver.

We fix **reachability**, not the exact measurement cause, because the keyboard-staleness theory is weakened (no `interactive-widget` is set, so Android's default `resizes-visual` keeps `dvh` stable across the keyboard) and several candidate causes share the same symptom.

## Fix (mobile list screen only)

Turn the mobile list screen into a standard app-shell — **sticky top chrome, document-scrolling middle that flows at natural height, sticky bottom bar** — so the bar stays reachable regardless of why `100dvh` is off:

- `Herd` / `BacklogView`: new opt-in `flow` prop renders them at natural height (no inner scroll), so the **page** scrolls instead of a nested region trapping the gesture. Covers both the active-sessions (`Herd`) and 0-session (`BacklogView`) states.
- `ActionBar` (mobile): `position: sticky; bottom: 0` + `padding-bottom: max(10px, env(safe-area-inset-bottom))` so it pins to the visible viewport bottom and clears the Android gesture nav.
- `+page.svelte`: `list` state class on `.shell`; `TopBar`+`QueueStrip` wrapped in a `position: sticky; top: 0` `.chrome` header (so halt/triage/settings don't scroll off); `.shell` → `min-height: 100dvh; height: auto; padding-bottom: 0`; `.main-region`/`.col` `min-height: 0` → `auto` so short lists still fill the viewport while tall lists overflow to the document scroll.
- `app.css`: `html, body` `height: 100%` → `min-height: 100%` so the page can grow/scroll.

**Desktop and the mobile detail (terminal) screen are intentionally untouched** — every change is fenced to `.shell.mobile.list` or behind the `flow` props (default `false`). No new terminal refits, no keyboard interaction.

This is a `fix:` with no user-facing strings → no i18n keys and no feature-catalog entry.

## Residual limitation (not fully CSS-curable)

If the underlying defect is a genuinely **too-tall layout viewport** (content behind system UI with `env(safe-area-inset-bottom)` under-reported), `sticky bottom: 0` pins to that too-tall scrollport bottom and only the safe-area `padding-bottom` mitigates. Verification should distinguish "bar reachable/visible" (this fix's guarantee) from "bar still clipped behind system UI" (a deeper platform issue).

## Test plan

Automated (all green): `ui` `bun run check` (0/0), `check:i18n` (parity, 681 keys), `bun run test` (576 passed), root `bun run lint`, `bunx fallow audit` (no issues in changed files). Branch is linear off `origin/main`.

**Blocking — requires real Android-PWA confirmation before merge** (unreproducible in jsdom/desktop):
- [ ] **Few active sessions (short list):** NEW TASK / BACKLOG bar visible at the bottom **without scrolling**, no force-kill.
- [ ] **0 sessions (backlog/empty screen):** same — bar visible without scrolling.
- [ ] **Many active sessions (long list):** bar reachable by scrolling and stays pinned to the visible bottom.
- [ ] Top chrome (halt / triage / settings) stays visible & tappable while the list scrolls.
- [ ] Rotation: bar stays visible/reachable after rotating and back.
- [ ] Note whether any residual clipping behind system UI is observed (see limitation above).
- [ ] Sanity-check the `BacklogView` detail overlay (tapping into a project from the empty-state backlog) — it is `position: absolute; inset: 0` and now sizes to the flowed content; confirm acceptable.

If sticky misbehaves in the target Android WebView, the documented fallback is `position: fixed; bottom: 0` + reserved bottom padding (same residual caveat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)