### PR TITLE
fix(ui): plan review pulses the automation pill + plan-gate toggle

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -95,7 +95,7 @@
   "drain_ceiling_label": "Grenze %",
   "automation_pill_label": "Automatisierung",
   "automation_pill_aria": "Repo-Automatisierung: {count} von {total} aktiv. Einstellungen öffnen.",
-  "automation_pill_reviewing_aria": "Critic prüft gerade. Repo-Automatisierungseinstellungen öffnen.",
+  "automation_pill_reviewing_aria": "Eine Prüfung läuft. Repo-Automatisierungseinstellungen öffnen.",
   "automation_panel_title": "Repo-Automatisierung",
   "automation_panel_subtitle": "Repo-weite Standardwerte — nicht nur dieser Task",
   "automation_group_review": "Code-Review",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -95,7 +95,7 @@
   "drain_ceiling_label": "Ceiling %",
   "automation_pill_label": "automation",
   "automation_pill_aria": "Repo automation: {count} of {total} on. Open settings.",
-  "automation_pill_reviewing_aria": "Critic is reviewing. Open repo automation settings.",
+  "automation_pill_reviewing_aria": "A review is in progress. Open repo automation settings.",
   "automation_panel_title": "Repo automation",
   "automation_panel_subtitle": "Repo-wide defaults — not this task alone",
   "automation_group_review": "Code review",

--- a/ui/src/lib/components/AutomationPanel.svelte
+++ b/ui/src/lib/components/AutomationPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { untrack } from "svelte";
   import { m } from "$lib/paraglide/messages";
-  import { reviews, repoConfig } from "$lib/reviews.svelte";
+  import { reviews, repoConfig, planGates } from "$lib/reviews.svelte";
   import { clampCap, clampCeiling, sanitizeLabel } from "./git-rail-drain";
   import type { Session } from "$lib/types";
 
@@ -13,6 +13,7 @@
 
   const flags = $derived(repoConfig.flags(repoPath));
   const reviewing = $derived(reviews.isReviewing(sessionId));
+  const planReviewing = $derived(planGates.isReviewing(sessionId));
 
   // The panel's switches are repo-level defaults; the plan gate is also a per-task
   // one-shot set at creation. Surface THIS task's actual gate phase so a tick in
@@ -121,10 +122,11 @@
       {/if}
     </div>
     <button
-      class={["sw", { on: flags.planGate }]}
+      class={["sw", { on: flags.planGate, reviewing: planReviewing }]}
       type="button"
       role="switch"
       aria-checked={flags.planGate}
+      aria-busy={planReviewing}
       aria-label={m.automation_plan_gate_name()}
       onclick={() => repoConfig.togglePlanGate(repoPath)}
     >

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -42,6 +42,10 @@ vi.mock("$lib/api", async (importOriginal) => {
 
 // Import the component AFTER the mock is registered.
 const { default: GitRail } = await import("./GitRail.svelte");
+// The plan-gate reviewing store drives the auto-pill pulse for plan reviews,
+// mirroring the critic (reviews) store. Imported from the same module the
+// component reads so toggling it reactively updates the rendered pill.
+const { planGates } = await import("$lib/reviews.svelte");
 
 // Deterministic measurement: pin the rail's font so CI (no Berkeley Mono) and
 // local agree. The rail mounts into a fixed-width host cell (a session row's git
@@ -290,5 +294,37 @@ describe("GitRail — controls stay within the cell", () => {
     await expect.element(screen.getByRole("button", { name: /confirm/i })).toBeVisible();
 
     assertControlsWithin(h);
+  });
+});
+
+describe("GitRail — plan review pulses the automation pill", () => {
+  afterEach(() => {
+    // store is module-global; clear so reviewing state can't leak between tests
+    planGates.drop(baseProps.sessionId);
+  });
+
+  it("toggles the .auto-pill reviewing class + aria-busy when a plan review is in flight", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    // rail (and the pill) only renders once the mocked gitState resolves on mount
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+
+    const pill = h.querySelector<HTMLButtonElement>("button.auto-pill");
+    expect(pill, "auto-pill present").not.toBeNull();
+    expect(pill!.classList.contains("reviewing"), "not pulsing initially").toBe(false);
+
+    // plan reviewer goes in flight → pill pulses
+    planGates.applyReviewing(baseProps.sessionId, true);
+    await expect.element(pill!).toHaveClass(/reviewing/);
+    expect(pill!.getAttribute("aria-busy")).toBe("true");
+
+    // plan review lands → pulse clears
+    planGates.applyReviewing(baseProps.sessionId, false);
+    await vi.waitFor(() =>
+      expect(pill!.classList.contains("reviewing"), "pulse cleared").toBe(false),
+    );
+    expect(pill!.getAttribute("aria-busy")).toBe("false");
   });
 });

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -3,7 +3,7 @@
   import type { GitState, Session, SessionStatus } from "$lib/types";
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
-  import { reviews, repoConfig } from "$lib/reviews.svelte";
+  import { reviews, repoConfig, planGates } from "$lib/reviews.svelte";
   import { criticChip, criticBadgeLabel } from "./critic-badge";
   import ReadyToggle from "./ReadyToggle.svelte";
   import AutomationPanel from "./AutomationPanel.svelte";
@@ -205,6 +205,7 @@
 
   const verdict = $derived(reviews.map[sessionId]);
   const reviewing = $derived(reviews.isReviewing(sessionId));
+  const pillReviewing = $derived(reviewing || planGates.isReviewing(sessionId));
   const chip = $derived(criticChip(verdict, reviewing));
   // Render the (AI-authored) findings as markdown, sanitized before @html.
   // marked + DOMPurify are dynamically imported on first render so they stay off
@@ -337,12 +338,12 @@
 
       {#if repoPath}
         <button
-          class={["gbtn", "auto-pill", { reviewing, armed: showAutomation }]}
+          class={["gbtn", "auto-pill", { reviewing: pillReviewing, armed: showAutomation }]}
           type="button"
           aria-haspopup="dialog"
           aria-expanded={showAutomation}
-          aria-busy={reviewing}
-          aria-label={reviewing
+          aria-busy={pillReviewing}
+          aria-label={pillReviewing
             ? m.automation_pill_reviewing_aria()
             : m.automation_pill_aria({ count: autoCount, total: AUTOMATION_TOTAL })}
           use:coachTarget={"critic"}


### PR DESCRIPTION
## What

An in-progress **plan review** now pulses the automation UI on the task detail page exactly like an in-progress **PR/critic review** already does — so you can see a plan review running at a glance.

Two spots reacted to `reviews.isReviewing` (PR/critic review) but not to `planGates.isReviewing` (plan review):

- **`auto-pill`** button (the entry button on the task detail page) — now pulses on *either* review via `pillReviewing = reviewing || planGates.isReviewing(sessionId)`.
- **🪧 plan-gate switch** inside the automation panel — now pulses on plan review (mirrors the 🔍 critic switch, which pulses on PR review).

Each in-panel switch reflects its own review type (symmetric); the outer pill is the aggregate entry point.

## How

Purely presentational — the plan-gate reviewing state was **already fully wired** end-to-end (`planGates.isReviewing`, the `session:plangate-reviewing` WS event, bootstrap on load). This just visualizes it:

- `GitRail.svelte` — add `planGates` import + `pillReviewing` derived; swap the three pill spots (class token, `aria-busy`, `aria-label`). The critic chip keeps its critic-only `reviewing` derived, unchanged.
- `AutomationPanel.svelte` — add `planGates` import + `planReviewing` derived; plan-gate switch gains `reviewing: planReviewing` + `aria-busy`.
- i18n — reworded the existing `automation_pill_reviewing_aria` key (EN + DE) from "Critic is reviewing…" to a review-type-neutral "A review is in progress…", since the pill now pulses for both. No new key; catalog parity preserved.
- Test — `GitRail.browser.test.ts` gains a case asserting the `.auto-pill` gains/clears the `reviewing` class + `aria-busy` as `planGates.applyReviewing` toggles.

No store/server/event changes. Reuses existing CSS (`.sw.reviewing` / `.gbtn.reviewing`). Labeled `fix` (visual parity for an existing feature, not a new capability) — no feature-announcements entry needed.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- `cd ui && bun run check:i18n` → 2 locales in parity (681 keys each)
- `cd ui && bun run test` → 579 passed, incl. the new plan-review-pulse assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)