### PR TITLE
feat(drain): label linked issues shepherd:active on task creation

### DIFF
--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -8,15 +8,18 @@ export const PRIORITY_LABEL = "shepherd:priority";
 
 /** The drain stamps this label on an issue when it claims it (spawns an auto
  *  session) and keeps it through retire — a ready PR awaiting human merge is still
- *  "taken". It is the ONLY cross-instance coordination point: a second shepherd
- *  draining the same forge filters claimed issues out (see {@link selectCandidates}),
- *  so two instances don't take the same issue, and a retired-but-unmerged issue is
- *  not re-spawned. A constant (not the per-repo `autoLabel`) so every instance agrees
- *  on it without sharing config. The window is narrowed, not eliminated — two
- *  instances listing within the claim's set-up latency can still race; local dedup
- *  then prevents a single instance double-spawning. Released only when the work is
- *  abandoned (manual archive, no merge); a human merge auto-closes the issue, retiring
- *  the claim with it. */
+ *  "taken". The SAME label is also stamped when a human links an issue at task
+ *  creation (via the create route) and released when that session is archived, so a
+ *  manually-linked issue is claimed too. It is the ONLY cross-instance coordination
+ *  point: a second shepherd draining the same forge filters claimed issues out (see
+ *  {@link selectCandidates}), so neither a second shepherd NOR the local drain takes
+ *  an already-claimed issue (auto or manually-linked), and a retired-but-unmerged
+ *  issue is not re-spawned. A constant (not the per-repo `autoLabel`) so every
+ *  instance agrees on it without sharing config. The window is narrowed, not
+ *  eliminated — two instances listing within the claim's set-up latency can still
+ *  race; local dedup then prevents a single instance double-spawning. Released only
+ *  when the work is abandoned (manual archive, no merge); a human merge auto-closes
+ *  the issue, retiring the claim with it. */
 export const ACTIVE_LABEL = "shepherd:active";
 
 /** Why the drain is holding rather than spawning/retiring — surfaced on `drain:status`. */

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -361,6 +361,10 @@ export class DrainService {
     // normally handed off with its claim kept. Unconditional of the drain toggle
     // (mirrors onGit's closeIssue) so a disabled-mid-flight session still frees its
     // claim. A session without an issueNumber never set a claim, so it's skipped.
+    // A legacy manual session created before issue-link stamping carries an
+    // issueNumber but never had the label applied; the remove is then a harmless
+    // idempotent no-op (best-effort, swallowed below) — not worth a per-session
+    // "was-stamped" flag to suppress.
     if (!retainClaim && s.issueNumber != null) {
       try {
         await this.deps.resolveForge(s.repoPath)?.removeIssueLabel?.(s.issueNumber, ACTIVE_LABEL);

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -344,21 +344,24 @@ export class DrainService {
     const retainClaim = this.retainClaimOnArchive.delete(id); // true → retire, or merged-but-close-failed
     const s = this.deps.store.get(id); // archived rows still return → repoPath available
     if (!s) return;
-    // Drop the host claim label for an auto session UNLESS it was retired (ready PR
-    // still open) or merged-but-close-failed (issue still open) — those keep the
-    // claim. The remaining case is an ABANDON (manual archive of a session that never
-    // retired), which re-queues the issue. NOTE: the abandoning instance still maps
-    // this issue via its own archived session, so the release re-queues it for OTHER
-    // instances — and for this one only after its archived session is pruned.
+    // Drop the host claim label for ANY archived session holding a claim — whether
+    // the drain stamped it (auto spawn) or a human stamped it by linking an issue at
+    // task creation (via the create route). Release fires UNLESS retainClaim is set:
+    // a retire (ready PR still open) or merged-but-close-failed (issue still open),
+    // both of which keep the claim. The remaining case is an ABANDON (manual archive
+    // of a session that never retired), which re-queues the issue. NOTE: the
+    // abandoning instance still maps this issue via its own archived session, so the
+    // release re-queues it for OTHER instances — and for this one only after its
+    // archived session is pruned.
     // CAVEAT: an abandon does not inspect PR state, so manually archiving a session
-    // that already opened a PR (without going through the retire path) releases the
-    // claim and lets another instance spawn a DUPLICATE against that still-open PR.
-    // Accepted: a manual archive is a deliberate "drop this" signal, and the retire
-    // path (not manual archive) is how a ready PR is normally handed off with its
-    // claim kept. Unconditional of the drain toggle (mirrors onGit's closeIssue) so a
-    // disabled-mid-flight session still frees its claim. Non-auto sessions never set
-    // a claim, so they're skipped.
-    if (!retainClaim && s.auto && s.issueNumber != null) {
+    // (auto OR a manually-linked one) that already opened a PR — without going through
+    // the retire path — releases the claim and lets another instance / the drain spawn
+    // a DUPLICATE against that still-open PR. Accepted: a manual archive is a deliberate
+    // "drop this" signal, and the retire path (not manual archive) is how a ready PR is
+    // normally handed off with its claim kept. Unconditional of the drain toggle
+    // (mirrors onGit's closeIssue) so a disabled-mid-flight session still frees its
+    // claim. A session without an issueNumber never set a claim, so it's skipped.
+    if (!retainClaim && s.issueNumber != null) {
       try {
         await this.deps.resolveForge(s.repoPath)?.removeIssueLabel?.(s.issueNumber, ACTIVE_LABEL);
       } catch (err) {

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -457,7 +457,7 @@ export class GithubForge implements GitForge {
         "--color",
         "5319e7",
         "--description",
-        "Claimed by a Shepherd auto-drain session",
+        "Claimed by a Shepherd session (auto-drain or linked issue)",
       ]);
     } catch {
       // already exists (or a transient gh error) — ignore.

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,6 +50,7 @@ import type { Presence } from "./presence";
 import type { StatusPoller } from "./poller";
 import type { SessionActivity } from "./activity-signal";
 import type { DrainStatus, QueuedItem } from "./drain";
+import { ACTIVE_LABEL } from "./drain-core";
 import { countDefinedWorkflows, type CountsService, type RepoCounts } from "./backlog";
 import { join, normalize } from "node:path";
 import { homedir } from "node:os";
@@ -647,6 +648,17 @@ async function handlePush(ctx: Ctx): Promise<Response | null> {
   return route ? route.run(ctx) : null;
 }
 
+/** Best-effort: stamp the drain claim label on a manually-linked issue so the board shows it's
+ *  being worked and the drain won't double-spawn it. Fire-and-forget — failures must never affect
+ *  the create response. Mirrors doSpawn's best-effort claim for the auto path. */
+export async function claimLinkedIssue(forge: GitForge | null, issueNumber: number): Promise<void> {
+  try {
+    await forge?.addIssueLabel?.(issueNumber, ACTIVE_LABEL);
+  } catch (err) {
+    console.warn(`[create] claim label for issue #${issueNumber} failed:`, err);
+  }
+}
+
 // POST /api/sessions — create a session.
 async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "POST" && !parts[2])) return null;
@@ -667,6 +679,17 @@ async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response 
     return json({ error: taken ? "task name already in use, retry" : msg }, taken ? 409 : 502);
   }
   deps.events.emit("session:new", s);
+  // A human linked an issue: stamp the drain claim so the board reflects it's being
+  // worked and the drain won't double-spawn it. Deferred (macrotask) + best-effort:
+  // addIssueLabel shells out synchronously via execFileSync, so merely not awaiting
+  // would still block this tick — setTimeout(0) lets json(s, 201) flush first.
+  if (result.value.issueRef) {
+    const { repoPath, issueRef } = result.value;
+    setTimeout(
+      () => void claimLinkedIssue(deps.resolveForge?.(repoPath) ?? null, issueRef.number),
+      0,
+    );
+  }
   return json(s, 201);
 }
 

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -969,7 +969,9 @@ test("merge on a forge WITHOUT closeIssue retains the claim — the issue stays 
   expect(h.forgeRec.removed).toHaveLength(0); // claim kept: issue is still open
 });
 
-test("archiving a NON-auto session never touches labels", async () => {
+test("archiving a manually-linked (non-auto) session releases its claim", async () => {
+  // A human linking an issue at task creation stamps the claim (via the create
+  // route), so archiving that manual session must ALSO release it.
   const h = makeHarness({ maxAuto: 1, issues: [] });
   const s = h.store.create({
     name: "manual",
@@ -983,6 +985,26 @@ test("archiving a NON-auto session never touches labels", async () => {
     herdrAgentId: "t",
     auto: false,
     issueNumber: 5,
+  });
+  h.store.archive(s.id);
+  await h.drain.onArchived(s.id);
+  expect(h.forgeRec.removed).toEqual([{ number: 5, label: ACTIVE_LABEL }]);
+});
+
+test("archiving a non-auto session WITHOUT an issue never touches labels", async () => {
+  const h = makeHarness({ maxAuto: 1, issues: [] });
+  const s = h.store.create({
+    name: "manual",
+    prompt: "p",
+    repoPath: REPO,
+    baseBranch: "main",
+    branch: "feature/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: false,
+    issueNumber: null,
   });
   h.store.archive(s.id);
   await h.drain.onArchived(s.id);

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -5,8 +5,10 @@ import { stagingDir } from "../src/uploads";
 import { SessionStore } from "../src/store";
 import { SessionService } from "../src/service";
 import { EventHub } from "../src/events";
-import { makeApp, serve, PTY_GONE_CODE, type AppDeps } from "../src/server";
+import { makeApp, serve, PTY_GONE_CODE, claimLinkedIssue, type AppDeps } from "../src/server";
+import type { GitForge } from "../src/forge/types";
 import { config } from "../src/config";
+import { ACTIVE_LABEL } from "../src/drain-core";
 
 // Create a real tmp dir inside config.repoRoot so validation passes
 let tmpRoot: string;
@@ -1465,4 +1467,33 @@ test("PUT /api/sessions/:id/automerge emits session:automerge with the new overr
     event: "session:automerge",
     data: { id, enabled: true },
   });
+});
+
+test("claimLinkedIssue stamps the active label on the linked issue", async () => {
+  const calls: { number: number; label: string }[] = [];
+  const forge = {
+    addIssueLabel: async (number: number, label: string) => {
+      calls.push({ number, label });
+    },
+  } as unknown as GitForge;
+  await claimLinkedIssue(forge, 42);
+  expect(calls).toEqual([{ number: 42, label: ACTIVE_LABEL }]);
+});
+
+test("claimLinkedIssue is a no-op without a forge", async () => {
+  await expect(claimLinkedIssue(null, 42)).resolves.toBeUndefined();
+});
+
+test("claimLinkedIssue tolerates a forge lacking addIssueLabel", async () => {
+  const forge = {} as unknown as GitForge;
+  await expect(claimLinkedIssue(forge, 42)).resolves.toBeUndefined();
+});
+
+test("claimLinkedIssue swallows an addIssueLabel rejection", async () => {
+  const forge = {
+    addIssueLabel: async () => {
+      throw new Error("label api boom");
+    },
+  } as unknown as GitForge;
+  await expect(claimLinkedIssue(forge, 42)).resolves.toBeUndefined();
 });


### PR DESCRIPTION
## What

When a user **manually links a GitHub issue to a task on creation** (`POST /api/sessions` with an `issueRef`), Shepherd now stamps the linked issue with the existing **`shepherd:active`** claim label on the forge, and **releases it when the session is archived**. Previously only auto-drain claimed issues — a human-linked issue got no label, so the board didn't show it was being worked and the drain could spawn a *second* session against it.

## Design decision — reuse `shepherd:active` (not a new `shepherd:implementing`)

The original task wording suggested `shepherd:implementing`. At the plan gate this was put to the author as an explicit choice, and **reusing the existing `shepherd:active` was chosen deliberately**:

- It already means exactly "a Shepherd session has claimed this issue" — one concept, not two overlapping "in progress" states.
- **Drain de-dup comes for free**: `selectCandidates()` already excludes `shepherd:active`, so a manually-linked (now-claimed) issue won't be auto-spawned. A distinct label would need its own exclusion wiring (easy to forget) and its own removal plumbing.
- The release lifecycle already exists in `drain.onArchived` — a distinct label would duplicate it.

A separate `shepherd:implementing` state was considered and rejected as redundant. (If a human-readable board label is wanted later, the cleaner move is renaming the single constant project-wide, not maintaining two claim labels.)

## How

- **`src/server.ts`** — new best-effort, exported `claimLinkedIssue(forge, issueNumber)` helper; `handleSessionCreate` schedules it via `setTimeout(…, 0)` after the response is built. The defer is load-bearing: `addIssueLabel` shells out to `gh` via synchronous `execFileSync`, so deferring keeps the two `gh` calls off the interactive New-Task response path. Fire-and-forget — failures `console.warn` and can never affect the create response. Stamps only on the manual route (auto-drain calls `service.create()` in-process, bypassing it).
- **`src/drain.ts`** — `onArchived` release un-gated from `s.auto` so manual sessions also release the claim. Safe & symmetric: the only path that sets a manual session's `issueNumber` is the create route, which now also stamps the label. Comment block rewritten to match.
- **`src/forge/github.ts`** — `ensureLabel` description generalized to "Claimed by a Shepherd session (auto-drain or linked issue)".
- **`src/drain-core.ts`** — `ACTIVE_LABEL` docstring updated to cover the manual-link stamp/release.

### Accepted behavior changes
- **Re-arm on manual archive**: archiving a manual session in a drain-enabled repo releases `shepherd:active`, which can re-arm a drain spawn — the existing abandon CAVEAT (archiving a session with an open PR invites a duplicate) now extends to manually-linked issues. Accepted: a manual archive is a deliberate "drop this" signal.
- **Legacy-session no-op remove**: `onArchived` now issues a `removeIssueLabel` for any non-auto session with an `issueNumber`, including legacy sessions created *before* link-stamping that never carried the label. The remove is a harmless, idempotent, best-effort no-op (swallowed with a `console.warn` at worst). Suppressing it would require a per-session "was-stamped" flag, which isn't worth it for a transient pre-deploy edge — noted in-code at the release site.

## Tests
- `test/server.test.ts` — `claimLinkedIssue`: stamps `shepherd:active`; null forge no-op; missing `addIssueLabel` tolerated; swallows rejection.
- `test/drain.test.ts` — archiving a manual (`auto:false`) session with an `issueNumber` now releases `shepherd:active`; manual-without-issue touches nothing; auto-retire `retainClaim` path still keeps the claim (regression guard).

`bun test ./test` → 1305 pass / 0 fail · `bun run lint` clean · `bunx tsc --noEmit` clean · fallow audit clean on changed files.

Server-only — no `ui/` touch, so no i18n keys or feature-catalog entry required (the label + its description are forge-side, not app UI chrome). `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
