### PR TITLE
feat(extension): Shepherd Capture — connection & pairing UX

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -21,7 +21,9 @@ bun run check:i18n # EN+DE catalog parity
 1. `bun run build`.
 2. Chrome → `chrome://extensions` → enable **Developer mode** → **Load unpacked**
    → select `extension/dist`.
-3. Copy the extension's **ID** shown on the card — you need it for the server.
+3. The extension's **ID** is now fixed at `bflahkibnmcbijbhelmpjbohpfhlbaig`
+   (pinned by the manifest `key`), so it no longer drifts per directory/machine —
+   set the server allowlist (below) once. The card shows the same ID.
 
 ## Open the popup
 
@@ -111,10 +113,11 @@ single default **Repo path**. Each rule is a `pattern → repo path` pair:
 
 The extension's `fetch` sends `Origin: chrome-extension://<id>`. Shepherd's origin
 guard allowlists by the URL **hostname**, which for that origin is the **raw
-extension ID**. Add it to the server's allowlist:
+extension ID**. The ID is fixed at `bflahkibnmcbijbhelmpjbohpfhlbaig` (pinned by
+the manifest `key`), so set this once — it won't drift between loads:
 
 ```bash
-SHEPHERD_ALLOWED_HOSTS="<your-extension-id>" bun run start
+SHEPHERD_ALLOWED_HOSTS="bflahkibnmcbijbhelmpjbohpfhlbaig" bun run start
 ```
 
 If you skip this, spawn-now returns `403` and the popup shows the

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -31,6 +31,12 @@ export default defineManifest({
   // allowlist entry is set once and never drifts per directory/machine. This is
   // the base64 DER SPKI of an RSA keypair; only the public half lives here (the
   // private key is kept out of the repo, needed only to re-pack a .crx later).
+  //
+  // Re-derive the ID from this key to confirm it matches the README/allowlist:
+  //   node -e 'const c=require("crypto"),der=Buffer.from(KEY,"base64"); \
+  //     console.log([...c.createHash("sha256").update(der).digest("hex").slice(0,32)] \
+  //       .map(h=>String.fromCharCode(97+parseInt(h,16))).join(""))'
+  // (SHA-256 of the DER bytes → first 16 bytes → each hex nibble 0-f mapped to a-p.)
   key: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAso7Zwr/ekV8ZuPryegqmJNFxRCCrM32ddBctJz9Z4+j6MA4vdOKi8wgCj5nphcBgxQaQxltQE2HrEJ80g2UdthQlQ59qDO7aTWvoPzxcNssASgPWlNJyzGzhyokxO3VdCSGp4z6brlHa0x2MRrfxWOTUvLgDH44h5pKXhc/tn2G/dlLvaQ5YY0IijQD194GhaFLPmdj9f2PEsEV9D16wCo/qbREW8lvIE9WsFZHgJIIvMakl7udzzq8RBz2wkXltGuM1ZPo5oX0YoIlM9KZ+6CjiGrrcgNcm/q6Lwx98TWnums23Qq/MBrOFelhRalgHZvwU4zjic64RoGnMQU+5twIDAQAB",
   default_locale: "en",
   description: "__MSG_ext_description__",

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -26,6 +26,12 @@ export default defineManifest({
   manifest_version: 3,
   name: "Shepherd Capture",
   version: "0.0.1",
+  // Pins the unpacked-load extension ID to a constant
+  // (bflahkibnmcbijbhelmpjbohpfhlbaig) so the server's SHEPHERD_ALLOWED_HOSTS
+  // allowlist entry is set once and never drifts per directory/machine. This is
+  // the base64 DER SPKI of an RSA keypair; only the public half lives here (the
+  // private key is kept out of the repo, needed only to re-pack a .crx later).
+  key: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAso7Zwr/ekV8ZuPryegqmJNFxRCCrM32ddBctJz9Z4+j6MA4vdOKi8wgCj5nphcBgxQaQxltQE2HrEJ80g2UdthQlQ59qDO7aTWvoPzxcNssASgPWlNJyzGzhyokxO3VdCSGp4z6brlHa0x2MRrfxWOTUvLgDH44h5pKXhc/tn2G/dlLvaQ5YY0IijQD194GhaFLPmdj9f2PEsEV9D16wCo/qbREW8lvIE9WsFZHgJIIvMakl7udzzq8RBz2wkXltGuM1ZPo5oX0YoIlM9KZ+6CjiGrrcgNcm/q6Lwx98TWnums23Qq/MBrOFelhRalgHZvwU4zjic64RoGnMQU+5twIDAQAB",
   default_locale: "en",
   description: "__MSG_ext_description__",
   icons: {

--- a/extension/messages/de.json
+++ b/extension/messages/de.json
@@ -75,5 +75,14 @@
   "options_routing_pattern_ph": "https://app.example.com/*",
   "options_routing_repo_ph": "~/Work/my-repo",
   "options_routing_add": "Regel hinzufügen",
-  "options_routing_remove": "Entfernen"
+  "options_routing_remove": "Entfernen",
+  "options_test_connection": "Verbindung testen",
+  "options_testing": "Teste…",
+  "options_conn_ok": "Verbindung OK — Shepherd ist erreichbar.",
+  "options_pairing_title": "Kopplung",
+  "options_pairing_hint": "Shepherd lässt anhand der reinen Erweiterungs-ID zu (dem Hostnamen des Anfrage-Ursprungs). Füge diese ID zu SHEPHERD_ALLOWED_HOSTS hinzu, damit der Server Erfassungen dieser Erweiterung akzeptiert.",
+  "options_extension_id_label": "Erweiterungs-ID",
+  "options_pairing_command_label": "Server-Befehl",
+  "options_copy": "Kopieren",
+  "options_copied": "Kopiert"
 }

--- a/extension/messages/de.json
+++ b/extension/messages/de.json
@@ -87,5 +87,6 @@
   "options_extension_id_label": "Erweiterungs-ID",
   "options_pairing_command_label": "Server-Befehl",
   "options_copy": "Kopieren",
-  "options_copied": "Kopiert"
+  "options_copied": "Kopiert",
+  "options_copy_failed": "Kopieren fehlgeschlagen — manuell markieren und kopieren"
 }

--- a/extension/messages/de.json
+++ b/extension/messages/de.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "popup_title": "Shepherd Capture",
+  "popup_conn_checking": "Wird geprüft…",
+  "popup_conn_linked": "Verbunden",
+  "popup_conn_unlinked": "Nicht verbunden",
   "popup_capturing": "Seite wird erfasst…",
   "popup_prompt_label": "Aufgabe",
   "popup_prompt_placeholder": "Aufgabe beschreiben (was ist falsch, was ist zu tun)…",

--- a/extension/messages/en.json
+++ b/extension/messages/en.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "popup_title": "Shepherd Capture",
+  "popup_conn_checking": "Checking…",
+  "popup_conn_linked": "Linked",
+  "popup_conn_unlinked": "Not linked",
   "popup_capturing": "Capturing this page…",
   "popup_prompt_label": "Task",
   "popup_prompt_placeholder": "Describe the task (what's wrong, what to do)…",

--- a/extension/messages/en.json
+++ b/extension/messages/en.json
@@ -75,5 +75,14 @@
   "options_routing_pattern_ph": "https://app.example.com/*",
   "options_routing_repo_ph": "~/Work/my-repo",
   "options_routing_add": "Add rule",
-  "options_routing_remove": "Remove"
+  "options_routing_remove": "Remove",
+  "options_test_connection": "Test connection",
+  "options_testing": "Testing…",
+  "options_conn_ok": "Connection OK — Shepherd is reachable.",
+  "options_pairing_title": "Pairing",
+  "options_pairing_hint": "Shepherd allowlists by the raw extension ID (the request origin's hostname). Add this ID to SHEPHERD_ALLOWED_HOSTS so the server accepts captures from this extension.",
+  "options_extension_id_label": "Extension ID",
+  "options_pairing_command_label": "Server command",
+  "options_copy": "Copy",
+  "options_copied": "Copied"
 }

--- a/extension/messages/en.json
+++ b/extension/messages/en.json
@@ -87,5 +87,6 @@
   "options_extension_id_label": "Extension ID",
   "options_pairing_command_label": "Server command",
   "options_copy": "Copy",
-  "options_copied": "Copied"
+  "options_copied": "Copied",
+  "options_copy_failed": "Copy failed — select and copy manually"
 }

--- a/extension/src/lib/localize-error.ts
+++ b/extension/src/lib/localize-error.ts
@@ -1,0 +1,34 @@
+import { m } from "./paraglide/messages";
+import type { TransportErrorKind } from "./types";
+
+/**
+ * Map a transport failure (`TransportErrorKind`, or the popup-only `"capture"`
+ * pseudo-kind) to a localized, user-facing message. Shared by the popup and the
+ * options page so both surface failures through ONE classification path — no
+ * duplicated switch that can drift. `unreachable` interpolates `baseUrl`;
+ * `invalid`/`unknown` interpolate the server's `message` detail.
+ */
+export function localizeError(
+  kind: TransportErrorKind | "capture",
+  message: string,
+  baseUrl: string,
+): string {
+  switch (kind) {
+    case "origin":
+      return m.err_origin();
+    case "auth":
+      return m.err_auth();
+    case "invalid":
+      return m.err_invalid({ message });
+    case "too_large":
+      return m.err_too_large();
+    case "unsupported":
+      return m.err_unsupported();
+    case "unreachable":
+      return m.err_unreachable({ baseUrl });
+    case "capture":
+      return m.popup_cant_capture();
+    default:
+      return m.err_unknown({ message });
+  }
+}

--- a/extension/src/lib/transport.ts
+++ b/extension/src/lib/transport.ts
@@ -74,6 +74,26 @@ async function ensureOk(res: Response): Promise<void> {
   throw new TransportError(kindForStatus(res.status), res.status, detail || `HTTP ${res.status}`);
 }
 
+/**
+ * Probe POST /api/ping to verify the configured base URL + token reach a
+ * Shepherd core that accepts this origin. Resolves on 2xx; otherwise the
+ * response maps via the shared `kindForStatus` (403→origin, 401→auth, …) and a
+ * network failure becomes `unreachable` — the same classification the popup
+ * shows. Used by the options/popup connection-status UX.
+ */
+export async function ping(fetchFn: FetchFn, config: CaptureConfig): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetchFn(`${config.baseUrl}/api/ping`, {
+      method: "POST",
+      headers: authHeaders(config.token),
+    });
+  } catch {
+    throw new TransportError("unreachable", null, "could not reach Shepherd");
+  }
+  await ensureOk(res);
+}
+
 /** POST the PNG to /api/uploads; return the confined staging path. */
 async function uploadScreenshot(
   fetchFn: FetchFn,

--- a/extension/src/options/Options.svelte
+++ b/extension/src/options/Options.svelte
@@ -26,6 +26,7 @@
   const extensionId = chrome.runtime.id;
   const pairingCommand = `SHEPHERD_ALLOWED_HOSTS=${extensionId} bun run start`;
   let copied = $state(false);
+  let copyFailed = $state(false);
 
   loadConfig().then((c) => (config = c));
   hasAllUrls().then((on) => (recorderOn = on));
@@ -144,9 +145,18 @@
   }
 
   async function copyExtensionId() {
-    await navigator.clipboard.writeText(extensionId);
-    copied = true;
-    setTimeout(() => (copied = false), 1500);
+    copied = false;
+    copyFailed = false;
+    try {
+      await navigator.clipboard.writeText(extensionId);
+      copied = true;
+      setTimeout(() => (copied = false), 1500);
+    } catch {
+      // clipboard write can reject (denied permission / non-secure context);
+      // fail-closed with visible feedback rather than a silent no-op.
+      copyFailed = true;
+      setTimeout(() => (copyFailed = false), 3000);
+    }
   }
 </script>
 
@@ -303,6 +313,9 @@
           {copied ? m.options_copied() : m.options_copy()}
         </button>
       </div>
+      {#if copyFailed}
+        <span class="text-xs text-red-600">{m.options_copy_failed()}</span>
+      {/if}
 
       <span class="text-gray-600">{m.options_pairing_command_label()}</span>
       <code class="block overflow-x-auto rounded bg-gray-100 px-2 py-1 text-xs"

--- a/extension/src/options/Options.svelte
+++ b/extension/src/options/Options.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { m } from "../lib/paraglide/messages";
   import { DEFAULT_CONFIG, loadConfig, saveConfig, saveSignals } from "../lib/config";
+  import { localizeError } from "../lib/localize-error";
   import { disableRecorder, enableRecorder, hasAllUrls } from "../lib/recorder-control";
   import { hostKind, releaseStaleHost, requestHostPermission } from "../lib/remote-host";
-  import type { CaptureConfig } from "../lib/types";
+  import { ping } from "../lib/transport";
+  import { TransportError, type CaptureConfig } from "../lib/types";
 
   let config = $state<CaptureConfig>({ ...DEFAULT_CONFIG });
   let saved = $state(false);
@@ -11,6 +13,19 @@
   let recorderDenied = $state(false);
   let hostDenied = $state(false);
   let hostUnsupported = $state(false);
+
+  // Connection-test state. `testing` disables the button; exactly one of
+  // testOk / testError is set after a run (fail-closed: any failure becomes a
+  // visible testError, never a silent success).
+  let testing = $state(false);
+  let testOk = $state(false);
+  let testError = $state("");
+
+  // The extension's own ID — the value to add to SHEPHERD_ALLOWED_HOSTS. Read at
+  // runtime (the manifest key pins it) rather than hardcoded.
+  const extensionId = chrome.runtime.id;
+  const pairingCommand = `SHEPHERD_ALLOWED_HOSTS=${extensionId} bun run start`;
+  let copied = $state(false);
 
   loadConfig().then((c) => (config = c));
   hasAllUrls().then((on) => (recorderOn = on));
@@ -81,6 +96,49 @@
     await releaseStaleHost(prevBaseUrl, config.baseUrl);
     saved = true;
     setTimeout(() => (saved = false), 1500);
+  }
+
+  // Ping the configured core and show inline status. Mirrors onSave's gesture
+  // handling: for a remote host, requestHostPermission MUST be the first await
+  // (a prior await would void the user gesture). A denied/unsupported host stops
+  // BEFORE ping — otherwise Chrome blocks the fetch and it misclassifies as
+  // "unreachable". All failures route through the shared localizeError path.
+  async function onTest(e: Event) {
+    e.preventDefault();
+    testOk = false;
+    testError = "";
+    const kind = hostKind(config.baseUrl);
+    if (kind === "unsupported") {
+      testError = m.options_host_unsupported();
+      return;
+    }
+    testing = true;
+    try {
+      if (kind === "remote" && !(await requestHostPermission(config.baseUrl))) {
+        testError = m.options_host_denied();
+        return;
+      }
+      await ping(fetch, config);
+      testOk = true;
+    } catch (err) {
+      if (err instanceof TransportError) {
+        testError = localizeError(err.kind, err.message, config.baseUrl);
+      } else {
+        testError = localizeError(
+          "unknown",
+          err instanceof Error ? err.message : "",
+          config.baseUrl,
+        );
+      }
+    } finally {
+      testing = false;
+    }
+  }
+
+  async function copyExtensionId() {
+    await navigator.clipboard.writeText(extensionId);
+    copied = true;
+    setTimeout(() => (copied = false), 1500);
   }
 </script>
 
@@ -197,13 +255,51 @@
       <button class="rounded bg-gray-900 px-3 py-1.5 text-white" type="submit">
         {m.options_save()}
       </button>
+      <button
+        type="button"
+        class="rounded border border-gray-300 px-3 py-1.5 disabled:opacity-50"
+        onclick={onTest}
+        disabled={testing}
+      >
+        {testing ? m.options_testing() : m.options_test_connection()}
+      </button>
       {#if saved}<span class="text-green-600">{m.options_saved()}</span>{/if}
     </div>
+    {#if testOk}
+      <span class="text-xs text-green-600">{m.options_conn_ok()}</span>
+    {/if}
+    {#if testError}
+      <span class="text-xs text-red-600">{testError}</span>
+    {/if}
     {#if hostUnsupported}
       <span class="text-xs text-red-600">{m.options_host_unsupported()}</span>
     {/if}
     {#if hostDenied}
       <span class="text-xs text-red-600">{m.options_host_denied()}</span>
     {/if}
+
+    <fieldset class="mt-2 flex flex-col gap-2 border-t border-gray-200 pt-3">
+      <legend class="text-gray-600">{m.options_pairing_title()}</legend>
+      <span class="text-xs text-gray-500">{m.options_pairing_hint()}</span>
+
+      <span class="text-gray-600">{m.options_extension_id_label()}</span>
+      <div class="flex items-center gap-2">
+        <code class="min-w-0 flex-1 truncate rounded bg-gray-100 px-2 py-1 text-xs">
+          {extensionId}
+        </code>
+        <button
+          type="button"
+          class="shrink-0 rounded border border-gray-300 px-2 py-1"
+          onclick={copyExtensionId}
+        >
+          {copied ? m.options_copied() : m.options_copy()}
+        </button>
+      </div>
+
+      <span class="text-gray-600">{m.options_pairing_command_label()}</span>
+      <code class="block overflow-x-auto rounded bg-gray-100 px-2 py-1 text-xs"
+        >{pairingCommand}</code
+      >
+    </fieldset>
   </form>
 </main>

--- a/extension/src/options/Options.svelte
+++ b/extension/src/options/Options.svelte
@@ -71,8 +71,12 @@
   // any other host is rejected (not declared in the manifest).
   async function onSave(e: Event) {
     e.preventDefault();
+    // Clear the full shared status set so only this action's outcome shows.
+    saved = false;
     hostDenied = false;
     hostUnsupported = false;
+    testOk = false;
+    testError = "";
     const kind = hostKind(config.baseUrl);
     if (kind === "unsupported") {
       hostUnsupported = true;
@@ -105,6 +109,10 @@
   // "unreachable". All failures route through the shared localizeError path.
   async function onTest(e: Event) {
     e.preventDefault();
+    // Clear the full shared status set so only this action's outcome shows.
+    saved = false;
+    hostDenied = false;
+    hostUnsupported = false;
     testOk = false;
     testError = "";
     const kind = hostKind(config.baseUrl);

--- a/extension/src/popup/Popup.svelte
+++ b/extension/src/popup/Popup.svelte
@@ -6,7 +6,12 @@
   import { hasHostPermission, requestHostPermission } from "../lib/remote-host";
   import { resolveRepo } from "../lib/routing";
   import { takePendingCapture } from "../lib/picker-session";
-  import { composeIssueBody, MAX_ISSUE_BODY_LEN, MAX_ISSUE_TITLE_LEN } from "../lib/transport";
+  import {
+    composeIssueBody,
+    MAX_ISSUE_BODY_LEN,
+    MAX_ISSUE_TITLE_LEN,
+    ping,
+  } from "../lib/transport";
   import type {
     CaptureConfig,
     CaptureMode,
@@ -40,6 +45,27 @@
   let recorderAvailable = $state(false);
   let mode = $state<CaptureMode>("visible");
 
+  // Connection-status indicator: reflects whether the configured core is
+  // reachable + authorized, surfaced in the header without opening Options.
+  // "none" = not configured (indicator hidden — the needs-config view covers it).
+  type ConnState = "none" | "checking" | "linked" | "not-linked";
+  let conn = $state<ConnState>("none");
+
+  // Fire-and-forget reachability probe. STRICTLY non-blocking: this is kicked off
+  // WITHOUT await from init(), so it never delays config load, the screenshot, the
+  // popup becoming interactive, or gates capture. Fail-closed — any throw (a
+  // TransportError or otherwise) lands on "not-linked"; "linked" is only set on a
+  // resolved ping.
+  async function checkConnection(cfg: CaptureConfig) {
+    conn = "checking";
+    try {
+      await ping(fetch, cfg);
+      conn = "linked";
+    } catch {
+      conn = "not-linked";
+    }
+  }
+
   // Element captures arrive pre-gathered (signals run at pick time), so the
   // gather toggles are read-only — re-running them would replace the cropped
   // element with a fresh visible capture.
@@ -68,6 +94,9 @@
       view = "needs-config";
       return;
     }
+    // Kick off the connection probe fire-and-forget (no await): it updates `conn`
+    // when it settles and must never delay or gate the capture flow below.
+    void checkConnection(cfg);
     // A remote (ts.net) host's optional permission can be revoked from
     // chrome://extensions after it was configured; without it the spawn fetch
     // fails with a generic "unreachable". Detect it up front and offer a
@@ -286,7 +315,29 @@
 </script>
 
 <main class="flex w-[380px] flex-col gap-3 p-3 font-sans text-sm text-gray-900">
-  <h1 class="font-semibold">{m.popup_title()}</h1>
+  <div class="flex items-center justify-between gap-2">
+    <h1 class="font-semibold">{m.popup_title()}</h1>
+    {#if conn !== "none"}
+      {@const tone =
+        conn === "linked"
+          ? "text-green-700"
+          : conn === "not-linked"
+            ? "text-red-700"
+            : "text-gray-500"}
+      {@const dot =
+        conn === "linked" ? "bg-green-600" : conn === "not-linked" ? "bg-red-600" : "bg-gray-400"}
+      <span class={["flex items-center gap-1 text-xs", tone]}>
+        <span class={["h-2 w-2 rounded-full", dot]} aria-hidden="true"></span>
+        <span>
+          {conn === "linked"
+            ? m.popup_conn_linked()
+            : conn === "not-linked"
+              ? m.popup_conn_unlinked()
+              : m.popup_conn_checking()}
+        </span>
+      </span>
+    {/if}
+  </div>
 
   {#if view === "loading"}
     <p class="text-gray-500">{m.popup_capturing()}</p>

--- a/extension/src/popup/Popup.svelte
+++ b/extension/src/popup/Popup.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { m } from "../lib/paraglide/messages";
   import { isConfigured, loadConfig } from "../lib/config";
+  import { localizeError } from "../lib/localize-error";
   import { hasAllUrls } from "../lib/recorder-control";
   import { hasHostPermission, requestHostPermission } from "../lib/remote-host";
   import { resolveRepo } from "../lib/routing";
@@ -11,7 +12,6 @@
     CaptureMode,
     CaptureResult,
     DeliveryTarget,
-    TransportErrorKind,
     WorkerRequest,
     WorkerResponse,
   } from "../lib/types";
@@ -59,27 +59,6 @@
         void chrome.tabs.create({ url: chrome.runtime.getURL("options.html") });
       }
     });
-  }
-
-  function localizeError(kind: TransportErrorKind | "capture", message: string): string {
-    switch (kind) {
-      case "origin":
-        return m.err_origin();
-      case "auth":
-        return m.err_auth();
-      case "invalid":
-        return m.err_invalid({ message });
-      case "too_large":
-        return m.err_too_large();
-      case "unsupported":
-        return m.err_unsupported();
-      case "unreachable":
-        return m.err_unreachable({ baseUrl: config?.baseUrl ?? "" });
-      case "capture":
-        return m.popup_cant_capture();
-      default:
-        return m.err_unknown({ message });
-    }
   }
 
   async function init() {
@@ -160,7 +139,7 @@
       } else if (!res.ok) {
         // Injection failed (a restricted page — chrome://, the web store, …).
         // Surface it and keep the popup open instead of closing onto nothing.
-        errorMsg = localizeError(res.errorKind, res.message);
+        errorMsg = localizeError(res.errorKind, res.message, config?.baseUrl ?? "");
         view = "error";
       }
       return;
@@ -189,7 +168,7 @@
       capture = res.result;
       view = "ready";
     } else if (!res.ok) {
-      errorMsg = localizeError(res.errorKind, res.message);
+      errorMsg = localizeError(res.errorKind, res.message, config?.baseUrl ?? "");
       view = "error";
     }
   }
@@ -298,7 +277,7 @@
       doneKind = "issue";
       view = "done";
     } else if (!res.ok) {
-      errorMsg = localizeError(res.errorKind, res.message);
+      errorMsg = localizeError(res.errorKind, res.message, config?.baseUrl ?? "");
       view = "error";
     }
   }

--- a/extension/src/popup/Popup.svelte
+++ b/extension/src/popup/Popup.svelte
@@ -94,9 +94,6 @@
       view = "needs-config";
       return;
     }
-    // Kick off the connection probe fire-and-forget (no await): it updates `conn`
-    // when it settles and must never delay or gate the capture flow below.
-    void checkConnection(cfg);
     // A remote (ts.net) host's optional permission can be revoked from
     // chrome://extensions after it was configured; without it the spawn fetch
     // fails with a generic "unreachable". Detect it up front and offer a
@@ -105,6 +102,13 @@
       view = "needs-host";
       return;
     }
+    // Kick off the connection probe fire-and-forget (no await): it updates `conn`
+    // when it settles and must never delay or gate the capture flow below. Gated
+    // on the host-permission check above so a revoked-permission remote host shows
+    // only the needs-host re-grant view, not a redundant "not-linked" badge — the
+    // probe would fail anyway (Chrome blocks the fetch without the grant). A
+    // successful re-grant re-runs init(), which then fires this probe.
+    void checkConnection(cfg);
     toggles = { ...cfg.signals };
     recorderAvailable = await hasAllUrls();
     if (!recorderAvailable) {

--- a/extension/test/transport.test.ts
+++ b/extension/test/transport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { fileIssue, spawnNow } from "../src/lib/transport";
+import { fileIssue, ping, spawnNow } from "../src/lib/transport";
 import { TransportError, type CaptureConfig, type PageMetadata } from "../src/lib/types";
 import type { CapturedSignals } from "../src/lib/signals";
 
@@ -240,5 +240,36 @@ describe("fileIssue", () => {
         metadata: META,
       }),
     ).rejects.toBeInstanceOf(TransportError);
+  });
+});
+
+describe("ping", () => {
+  it("POSTs to /api/ping with bearer auth and resolves on 200", async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonRes({}, 200));
+    await expect(ping(fetchFn, CONFIG)).resolves.toBeUndefined();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe("http://localhost:7330/api/ping");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer secret");
+  });
+
+  it("omits Authorization when no token", async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonRes({}, 200));
+    await ping(fetchFn, { ...CONFIG, token: "" });
+    expect(fetchFn.mock.calls[0][1].headers.Authorization).toBeUndefined();
+  });
+
+  it.each([
+    [403, "origin"],
+    [401, "auth"],
+  ])("maps status %i to TransportError kind %s", async (status, kind) => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonRes({ error: "no" }, status));
+    await expect(ping(fetchFn, CONFIG)).rejects.toMatchObject({ kind });
+  });
+
+  it("maps a network throw to 'unreachable'", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    await expect(ping(fetchFn, CONFIG)).rejects.toMatchObject({ kind: "unreachable" });
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1929,8 +1929,19 @@ async function handleTodo({ req, parts, url }: Ctx): Promise<Response | null> {
   return null;
 }
 
+// ── reachability probe: lets the Capture extension verify connection (auth +
+// origin-allowlist) before first capture. Pure no-op — rides the global
+// checkAuth→checkOrigin guards, so a bad token 401s and a disallowed origin
+// 403s exactly as a real capture POST would; only 200s when both pass. MUST be
+// POST: checkOrigin skips GET/HEAD, so a GET ping couldn't reproduce the 403.
+function handlePing({ req, parts }: Ctx): Response | null {
+  if (req.method !== "POST" || parts[0] !== "api" || parts[1] !== "ping" || parts[2]) return null;
+  return json({ ok: true });
+}
+
 // Ordered dispatch chain — preserves the original guard sequence verbatim.
 const ROUTE_HANDLERS = [
+  handlePing,
   handleGitSnapshot,
   handleActivitySnapshot,
   handleReviews,

--- a/test/server-ping.test.ts
+++ b/test/server-ping.test.ts
@@ -1,0 +1,71 @@
+import { test, expect, afterEach } from "bun:test";
+import { SessionStore } from "../src/store";
+import { SessionService } from "../src/service";
+import { EventHub } from "../src/events";
+import { makeApp, type AppDeps } from "../src/server";
+import { config } from "../src/config";
+
+// Minimal deps — /api/ping is a pure liveness probe and touches no repo/session state.
+function makeDeps(): AppDeps {
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({ worktreePath: "/wt", branch: "shepherd/x", isolated: true }),
+      remove: () => {},
+    } as any,
+    herdr: { start: () => ({}), list: () => [], stop: () => {}, send: () => {} } as any,
+    events,
+  });
+  const usageLimits = {
+    limits: () => ({ session5h: null, week: null, stale: true, calibratedAt: null }),
+  };
+  return { store, service, events, usageLimits, distiller: { distillNow: () => {} } };
+}
+
+const harness = () => makeApp(makeDeps());
+
+function ping(app: ReturnType<typeof makeApp>, headers?: HeadersInit) {
+  return app.fetch(new Request("http://x/api/ping", { method: "POST", headers }));
+}
+
+// Restore any config we mutate so tests stay isolated.
+const origToken = config.token;
+afterEach(() => {
+  config.token = origToken;
+});
+
+test("POST /api/ping with allowlisted Origin → 200 {ok:true}", async () => {
+  // A real allowlisted Origin — not omitted — so we actually exercise the allowlist
+  // rather than the no-browser bypass (validate.ts originAllowed).
+  const res = await ping(harness(), { Origin: "http://localhost:7330" });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+});
+
+test("POST /api/ping with disallowed Origin → 403", async () => {
+  const res = await ping(harness(), { Origin: "chrome-extension://not-allowed" });
+  expect(res.status).toBe(403);
+});
+
+test("POST /api/ping with bad token → 401 (before origin check)", async () => {
+  config.token = "secret-token";
+  // Bad token + allowlisted origin still 401: checkAuth runs before checkOrigin.
+  const res = await ping(harness(), {
+    Origin: "http://localhost:7330",
+    Authorization: "Bearer wrong",
+  });
+  expect(res.status).toBe(401);
+});
+
+test("POST /api/ping with valid token + allowlisted Origin → 200", async () => {
+  config.token = "secret-token";
+  const res = await ping(harness(), {
+    Origin: "http://localhost:7330",
+    Authorization: "Bearer secret-token",
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+});


### PR DESCRIPTION
Closes #374. Closes #338 (capstone of the deferred Capture scope — siblings #341/#342/#343 already merged). Refs #343, #373.

Makes linking the Capture extension to a Shepherd core obvious and verifiable **before first capture**, instead of discovering failure only on a `403`/`401`/unreachable at spawn time.

## What's in it

**1. `POST /api/ping` reachability probe** (`src/server.ts`)
A minimal origin-guarded no-op returning `200 {ok:true}`. It rides the existing global `checkAuth`→`checkOrigin` chain, so it reproduces the *same* outcomes a real capture (a POST) hits: `200` reachable, `403` origin-rejected, `401` auth.

> **Why a new endpoint** (the issue floated reusing a GET/HEAD): the origin guard `checkOrigin` only runs on POST/PUT/DELETE — a GET/HEAD ping bypasses it and can **never** reproduce the `403` the user actually hits. So the probe must be a POST through the same guards. Server test sends a real allowlisted `Origin` for the 200 case (omitting it would trivially pass via the no-browser bypass) and a non-allowlisted one for 403.

**2. Shared `localizeError` + transport `ping()`** (`extension/src/lib/`)
`ping()` reuses the existing `ensureOk`/`kindForStatus` (403→origin, 401→auth, throw→unreachable) — identical classification to real capture. The inline `localizeError` was extracted out of `Popup.svelte` into `src/lib/localize-error.ts` so **both** UI surfaces classify through one path (no duplicated switch).

**3. Stable extension ID** (`manifest.config.ts`, `README.md`)
Pinned via a manifest `key` (public SPKI baked in; private key not committed). The ID is now the constant **`bflahkibnmcbijbhelmpjbohpfhlbaig`** across reloads/directories/machines, so the `SHEPHERD_ALLOWED_HOSTS` entry is set once. Verified the `key` survives `@crxjs/vite-plugin` into the production `dist/manifest.json`; README documents that production ID.

**4. Options: test-connection + pairing helper** (`Options.svelte`)
- "Test connection" button → `ping()`, inline status (reachable / 403-origin / 401-auth / unreachable). For remote (ts.net) baseUrls it requests host permission as the first await on click, so a remote core can be tested before Save without Chrome blocking it (misreading as unreachable). Fail-closed: every failure renders explicitly; success only on a resolved ping.
- Pairing helper: shows `chrome.runtime.id`, a copy button, the exact `SHEPHERD_ALLOWED_HOSTS=<id> bun run start` command, and explains the allowlist is keyed by the raw extension ID.
- Status flags reset symmetrically across Save/Test so contradictory banners can't stack.

**5. Popup connection indicator** (`Popup.svelte`)
A linked / not-linked / checking dot+label in the header, driven by a **fire-and-forget** `ping()` — never awaited on the render path, never blocks or delays capture or the screenshot thumbnail. Fail-closed (any error → not-linked).

## Notes
- New Options/popup chrome routed through Paraglide with matching EN+DE keys (`check:i18n` green at 88 keys).
- No `feature-announcements.ts` entry: this ships user-facing UX in `extension/` only (no `ui/src/**`), so that catalog gate doesn't fire — confirmed by `scripts/check-feature-catalog.sh`.

## Verification
- root: `bun run lint` clean, `bun test ./test` 1304 pass / 0 fail (incl. new `test/server-ping.test.ts`).
- extension: `bun run check` 0 errors, `bun run test` 79 pass, `bun run check:i18n` parity, `bun run build` green (key preserved in `dist/`).
- Branch rebased onto latest `main` (linear, no merge commits); branch-hygiene + fallow pre-push gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)