### PR TITLE
ci: local self-hosted runner for the closed-source phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,11 @@ concurrency:
 jobs:
   verify:
     name: verify
-    runs-on: ubuntu-latest
+    # Runner toggle for the closed-source phase: set the repo variable CI_RUNNER to
+    # 'self-hosted' to run on the local self-hosted runner (saves included minutes).
+    # Unset/empty falls back to ubuntu-latest. MUST be deleted before the repo goes
+    # public — a self-hosted runner on a public repo runs fork-PR code on the host.
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -10,7 +10,11 @@ on:
 jobs:
   branch-hygiene:
     name: branch hygiene
-    runs-on: ubuntu-latest
+    # Runner toggle for the closed-source phase: set the repo variable CI_RUNNER to
+    # 'self-hosted' to run on the local self-hosted runner (saves included minutes).
+    # Unset/empty falls back to ubuntu-latest. MUST be deleted before the repo goes
+    # public — a self-hosted runner on a public repo runs fork-PR code on the host.
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout PR head (the real branch tip, not the merge ref)
         uses: actions/checkout@v5

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,9 @@ concurrency:
 
 jobs:
   release-please:
+    # Intentionally NOT on the CI_RUNNER toggle (unlike verify + pr-hygiene): this
+    # runs only on push to main, is cheap, and must reliably cut releases even when
+    # the local self-hosted runner is down. See ci/self-hosted-runner/README.md.
     runs-on: ubuntu-latest
     steps:
       # Maintains a release PR that accrues a CHANGELOG from conventional

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ dist/
 # Plan-gate working artifacts written into the live worktree (never committed)
 .shepherd-plan.md
 .shepherd-plan-review.json
+
+# Self-hosted CI runner: never commit a filled-in env; keep the example tracked
+# (the global `.env.*` rule above would otherwise swallow .env.example).
+ci/self-hosted-runner/.env
+!ci/self-hosted-runner/.env.example

--- a/ci/self-hosted-runner/.env.example
+++ b/ci/self-hosted-runner/.env.example
@@ -1,0 +1,42 @@
+# Shepherd self-hosted CI runner — NON-SECRET configuration.
+#
+# Copy this to ~/.config/shepherd-ci-runner/.env and fill in RUNNER_DIR.
+# NEVER commit a filled-in .env (the repo .gitignore blocks ci/self-hosted-runner/.env,
+# but the deployed copy lives under ~/.config and is host-only on purpose).
+#
+# This file holds NO secrets — only paths and resource sizing. The registration
+# token is minted at unit start by mint-token.sh; the optional PAT (if used)
+# lives in a SEPARATE host-only pat.env (see the commented block at the bottom).
+
+# Absolute path to this checkout's ci/self-hosted-runner directory. The systemd
+# unit calls mint-token.sh / run-runner.sh from here.
+RUNNER_DIR=/path/to/shepherd/ci/self-hosted-runner
+
+# Target repo (owner/name) and its clone URL — repo-scoped runner.
+GH_REPO=erwins-enkel/shepherd
+REPO_URL=https://github.com/erwins-enkel/shepherd
+
+# Runner labels (comma-separated). Workflows target this with runs-on: self-hosted.
+RUNNER_LABELS=self-hosted
+
+# Locally-built image tag (see Dockerfile). Build with:
+#   docker build -t shepherd-ci-runner:local ci/self-hosted-runner/
+IMAGE=shepherd-ci-runner:local
+
+# Per-replica resource caps (suspenders to the shepherd-ci.slice host ceiling).
+RUNNER_CPUS=4
+RUNNER_MEMORY=8g
+
+# ---------------------------------------------------------------------------
+# OPTIONAL PAT fallback (only if the host `gh` is NOT already logged in).
+#
+# mint-token.sh mints the registration token via `gh`, which honors GH_TOKEN.
+# If you have no host `gh` login, provide a fine-grained PAT in a SEPARATE,
+# host-only file so it never lands in this non-secret .env:
+#
+#   ~/.config/shepherd-ci-runner/pat.env   (chmod 600, NEVER committed)
+#       GH_TOKEN=<fine-grained PAT, repo Administration: Read & Write>
+#
+# The unit loads it via an OPTIONAL `EnvironmentFile=-...pat.env`, so its
+# absence is fine when host `gh` is already authed.
+# ---------------------------------------------------------------------------

--- a/ci/self-hosted-runner/.env.example
+++ b/ci/self-hosted-runner/.env.example
@@ -27,6 +27,11 @@ IMAGE=shepherd-ci-runner:local
 RUNNER_CPUS=4
 RUNNER_MEMORY=8g
 
+# Optional: only needed for rootless Docker if you did NOT persist
+# `docker context use rootless`. Points the docker CLI (run from the user unit) at
+# the rootless socket instead of the rootful /var/run/docker.sock. See README §1.
+# DOCKER_HOST=unix:///run/user/1000/docker.sock
+
 # ---------------------------------------------------------------------------
 # OPTIONAL PAT fallback (only if the host `gh` is NOT already logged in).
 #

--- a/ci/self-hosted-runner/.env.example
+++ b/ci/self-hosted-runner/.env.example
@@ -30,6 +30,9 @@ RUNNER_MEMORY=8g
 # Optional: only needed for rootless Docker if you did NOT persist
 # `docker context use rootless`. Points the docker CLI (run from the user unit) at
 # the rootless socket instead of the rootful /var/run/docker.sock. See README §1.
+# Use a CONCRETE path (replace 1000 with your `id -u`) — EnvironmentFile does not
+# expand variables, so ${XDG_RUNTIME_DIR} would be passed literally. Or prefer the
+# systemd drop-in with %t (README §1), which is uid-independent.
 # DOCKER_HOST=unix:///run/user/1000/docker.sock
 
 # ---------------------------------------------------------------------------

--- a/ci/self-hosted-runner/Dockerfile
+++ b/ci/self-hosted-runner/Dockerfile
@@ -1,0 +1,47 @@
+# Shepherd self-hosted CI runner image.
+#
+# Base: myoung34/github-runner, pinned by digest (the `ubuntu-noble` tag at build time).
+# Pinning by digest keeps the runner build reproducible and prevents a moved tag from
+# silently swapping the base out from under us.
+FROM myoung34/github-runner@sha256:067d61600d8ea770ce4940002bd817972282b4b691b047dd0c20fa3762489f71
+
+# ---------------------------------------------------------------------------
+# Bake Playwright's Chromium + system deps READ-ONLY into the image layer.
+#
+# WHY a baked image layer, not a shared volume:
+#   This runner executes UNTRUSTED PR code, one fresh `docker run --rm` per job.
+#   A shared writable browser cache volume would be a cross-job cache-poisoning
+#   vector — job A could tamper with the browsers job B later runs. Baking the
+#   browsers into the image at build time (a trusted step) means every --rm job
+#   inherits its own copy-on-write copy of a known-good cache. No shared state.
+#
+# WHY this is only a warm-cache optimization (self-healing on drift):
+#   PLAYWRIGHT_BROWSERS_PATH is exported below, so an in-job `playwright install`
+#   resolves to the same path and finds the baked browsers already present —
+#   a fast no-op when versions match. If ui/package.json's Playwright version
+#   drifts from the baked 1.60.0, the in-job install simply re-downloads the
+#   matching build into the ephemeral container layer. Drift therefore costs a
+#   one-time download, never a build/job failure — so we do NOT pin-check here.
+# ---------------------------------------------------------------------------
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+
+# The base ships node (v18) but no npm/npx, and Playwright's CLI is driven via
+# npx. Install npm so `npx playwright install` is available at build time.
+# `playwright install --with-deps` needs root + apt; the base image's default
+# user is root, which is what we want for the build steps.
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends npm \
+    && PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright \
+       npx --yes playwright@1.60.0 install --with-deps chromium \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Browsers are baked read-only for every job; widen perms so the in-job
+# (possibly non-root) playwright can still read/no-op against them.
+RUN chmod -R a+rX /opt/ms-playwright
+
+# Do NOT override ENTRYPOINT / CMD / USER / WORKDIR — inherit the base
+# (/entrypoint.sh + ./bin/Runner.Listener) so the container still behaves as a
+# normal GitHub Actions runner.

--- a/ci/self-hosted-runner/README.md
+++ b/ci/self-hosted-runner/README.md
@@ -248,9 +248,13 @@ run concurrently. More replicas raise the host load ceiling — keep an eye on t
   Docker (daemon in the user systemd tree). Under **rootful** Docker the containers land
   in the system tree, so this user slice does **not** enforce — install the slice as a
   system unit (`/etc/systemd/system`) for the belt there, or rely on the per-container
-  `--cpus`/`--memory` caps. Tune both together: per-replica caps × replicas should sit at
-  or under the slice. (CPU is capped below the aggregate; `MemoryMax` only equals it —
-  lower it for real prod memory headroom, per the comment in `shepherd-ci.slice`.)
+  `--cpus`/`--memory` caps. It further requires the docker daemon to use the **systemd
+  cgroup driver** (`native.cgroupdriver=systemd`, the default here; check
+  `docker info | grep "Cgroup Driver"`) — under the `cgroupfs` driver the `.slice` name is
+  a literal cgroup path, not this systemd unit, so the belt won't engage even rootless.
+  Tune both together: per-replica caps × replicas should sit at or under the slice. (CPU is
+  capped below the aggregate; `MemoryMax` only equals it — lower it for real prod memory
+  headroom, per the comment in `shepherd-ci.slice`.)
 
 ### Playwright version-sync
 

--- a/ci/self-hosted-runner/README.md
+++ b/ci/self-hosted-runner/README.md
@@ -1,0 +1,269 @@
+# Shepherd self-hosted CI runner
+
+A locally-hosted GitHub Actions runner for `erwins-enkel/shepherd`, so CI for this
+**private** repo stops burning the account's included Actions minutes. The workflows
+(`.github/workflows/ci.yml`, `pr-hygiene.yml`) target it via
+`runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}` — set the repo Actions variable
+`CI_RUNNER=self-hosted` to route jobs here, delete it to fall straight back to
+GitHub-hosted runners.
+
+## What & why — the cost trade-off
+
+GitHub-hosted minutes for a private repo cost roughly **$0.008/min** (Linux, 2-core).
+Buying minutes is the **zero-risk fallback**: no host to secure, no untrusted code on
+our hardware. The _safer_ self-host target is a **separate / throwaway host** that
+runs nothing else of value. This runner instead runs **beside production Shepherd on
+the same box** — a deliberate decision to avoid standing up a second machine. That
+co-tenancy is the entire reason the security model below is strict: untrusted PR code
+executes a few namespaces away from prod. If that ever feels like too much risk, the
+exit is one command (`gh variable delete CI_RUNNER`) and you're back on hosted minutes.
+
+## Security model
+
+This runner executes **untrusted PR code** (anything a contributor pushes to a branch),
+one fresh container per job. The posture:
+
+- **Ephemeral, one job per container.** `EPHEMERAL=true` + `docker run --rm`: the
+  runner deregisters and the container is destroyed after a single job. The systemd
+  unit restarts to register a fresh container + fresh token for the next job. No state
+  survives a job.
+- **No shared writable cache.** Playwright's browsers are **baked read-only into the
+  image** (`Dockerfile`), so every job gets its own copy-on-write copy of a known-good
+  cache — no cross-job cache-poisoning volume.
+- **Network isolation — CONDITIONED on prod binding loopback.** The container runs on
+  the default `bridge` network (never `--network host`). Production Shepherd defaults
+  to `host = 127.0.0.1` (`src/config.ts:38`), and a bridge container **cannot** reach
+  host loopback services. **FOOTGUN:** a `0.0.0.0`-bound service IS reachable from the
+  container via the `docker0` gateway IP. So `SHEPHERD_HOST=0.0.0.0` (the
+  `src/config.ts:37` escape hatch) **defeats this isolation** — and the **herdr server's
+  bind must be loopback too**, for the same reason. Keep both on loopback. (See the
+  optional defense-in-depth firewall rule under Prerequisites for bind-independent
+  isolation.)
+- **Unprivileged, no socket.** No `--privileged`, no docker-socket mount, no
+  `--pid host`. Untrusted code can't reach the daemon or other containers.
+- **Host-minted token; PAT never enters the container.** `mint-token.sh` mints a
+  short-lived **registration token** on the host (via host `gh` login or an optional
+  host-only `pat.env`). Only that token crosses into the container as `RUNNER_TOKEN`;
+  the admin PAT never does. **Residual:** the registration token is a container env
+  var, so job steps can read it until it expires. Accepted — it's not the admin PAT,
+  it's ~1h TTL, and the runner is ephemeral.
+- **Root-in-container → prefer rootless Docker.** The myoung34 base runs the container
+  **as root**, and the in-job `playwright install --with-deps` uses passwordless sudo
+  (so we can't add `--security-opt no-new-privileges`). Under **rootful** Docker
+  (the daemon as installed on this box today) container-root is a real escalation
+  surface. Under **rootless** Docker, container-root maps to an unprivileged _host_
+  uid — a much smaller blast radius. **Rootless Docker is recommended on this shared
+  host.**
+
+## Prerequisites
+
+### 1. Docker — rootless recommended
+
+Rootless Docker maps container-root to your unprivileged host user, shrinking the blast
+radius of untrusted root-in-container code (see Security model). Install/enable it per
+the [rootless docs](https://docs.docker.com/engine/security/rootless/).
+
+**Verify the resource caps actually enforce.** `--cpus`/`--memory` are no-ops unless the
+kernel cgroup controllers are delegated. Confirm a memory cap really lands:
+
+```sh
+docker run --rm --memory=64m alpine cat /sys/fs/cgroup/memory.max
+```
+
+This must print `67108864` (64 MiB). If it prints `max`, the cap is **not** enforced —
+delegate the cgroup controllers (rootless: enable `cpu`/`memory` delegation for your
+user, e.g. via a `systemd` drop-in on `user@.service`) before trusting the slice /
+`--memory` limits.
+
+### 2. Linger, so user units run at boot
+
+User systemd units only run while you're logged in unless linger is enabled:
+
+```sh
+loginctl enable-linger "$USER"
+```
+
+### 3. Assert prod binds loopback
+
+The network isolation above only holds if nothing this runner could reach is bound to
+`0.0.0.0`. Before enabling the runner, confirm:
+
+- **Shepherd:** `SHEPHERD_HOST` is **unset or `127.0.0.1`** (never `0.0.0.0`).
+- **herdr server:** likewise bound to loopback.
+
+Optional **defense in depth** (makes isolation bind-independent): a firewall rule that
+**drops traffic from the docker bridge subnet to the `docker0` gateway IP**, so even a
+`0.0.0.0`-bound service can't be reached from a container. Example (adjust subnet/IP to
+your `docker0`):
+
+```sh
+# Drop bridge-subnet -> docker0-gateway (host) traffic.
+sudo iptables -I DOCKER-USER -s 172.17.0.0/16 -d 172.17.0.1 -j DROP
+```
+
+## Setup
+
+Run these in order. **Do not set `CI_RUNNER` until a runner is live** — see the last
+step's warning.
+
+1. **Build the image** (the `IMAGE` tag in `.env`):
+
+   ```sh
+   docker build -t shepherd-ci-runner:local ci/self-hosted-runner/
+   ```
+
+2. **Create the host-only config** and fill in `RUNNER_DIR` (the absolute path to _this_
+   checkout's `ci/self-hosted-runner` directory):
+
+   ```sh
+   mkdir -p ~/.config/shepherd-ci-runner
+   cp ci/self-hosted-runner/.env.example ~/.config/shepherd-ci-runner/.env
+   $EDITOR ~/.config/shepherd-ci-runner/.env   # set RUNNER_DIR
+   ```
+
+   If the host has **no** `gh` login, also create the optional, host-only PAT file
+   (fine-grained PAT, repo Administration: Read & Write), **chmod 600**, never committed:
+
+   ```sh
+   printf 'GH_TOKEN=<fine-grained-PAT>\n' > ~/.config/shepherd-ci-runner/pat.env
+   chmod 600 ~/.config/shepherd-ci-runner/pat.env
+   ```
+
+3. **Install the units** into the user systemd dir (symlink to keep them tracking the
+   checkout, or copy):
+
+   ```sh
+   mkdir -p ~/.config/systemd/user
+   ln -sf "$PWD"/ci/self-hosted-runner/shepherd-ci-runner@.service          ~/.config/systemd/user/
+   ln -sf "$PWD"/ci/self-hosted-runner/shepherd-ci.slice                    ~/.config/systemd/user/
+   ln -sf "$PWD"/ci/self-hosted-runner/shepherd-ci-runner-watchdog.service  ~/.config/systemd/user/
+   ln -sf "$PWD"/ci/self-hosted-runner/shepherd-ci-runner-watchdog.timer    ~/.config/systemd/user/
+   systemctl --user daemon-reload
+   ```
+
+4. **Start the runner replica(s).** One replica handles jobs serially; add `@2` so the
+   `verify` and `pr-hygiene` jobs can run in parallel:
+
+   ```sh
+   systemctl --user enable --now shepherd-ci-runner@1   # runner-1
+   systemctl --user enable --now shepherd-ci-runner@2   # runner-2 (parallel verify + hygiene)
+   ```
+
+5. **Start the watchdog timer:**
+
+   ```sh
+   systemctl --user enable --now shepherd-ci-runner-watchdog.timer
+   ```
+
+6. **Verify the runner is live** in the repo UI: **Settings → Actions → Runners** should
+   show the runner(s) as **Idle**.
+
+7. **Only then** route CI to it:
+
+   ```sh
+   gh variable set CI_RUNNER --body self-hosted
+   ```
+
+   > ⚠️ Setting `CI_RUNNER` **before** a runner is live and Idle would make every PR job
+   > queue against a label nothing serves — all PR CI hangs pending. Confirm **Idle**
+   > first.
+
+## ⚠️ MANDATORY public-repo cutover
+
+> **Before making this repo public, run `gh variable delete CI_RUNNER`.**
+>
+> A self-hosted runner attached to a **public** repo executes **fork-PR code on this
+> host** — any internet stranger's pull request runs on your machine, beside production.
+> This is GitHub's own loud warning, and here it's non-negotiable. Delete the variable
+> (reverting CI to GitHub-hosted runners) **before** the repo goes public, and tear the
+> runner down if it won't be re-privatized.
+
+## Outage runbook
+
+**Symptom:** PR checks are stuck **pending** (queued, spinner, never go red). Because
+`CI_RUNNER` is set, the workflows no longer fall back to GitHub-hosted runners — GitHub
+just waits indefinitely for a matching self-hosted runner that isn't there. A pending
+check is invisible (no red X), so nothing pages you on its own. The **watchdog timer**
+is the thing that alerts you (journal + desktop toast).
+
+**Immediate fix — restore CI instantly:**
+
+```sh
+gh variable delete CI_RUNNER
+```
+
+This reverts every workflow to `ubuntu-latest` on the next run; re-run the stuck jobs and
+they go to GitHub-hosted runners. **Then** repair the runner at leisure and, once it shows
+**Idle** again, re-set the variable:
+
+```sh
+systemctl --user status 'shepherd-ci-runner@*' shepherd-ci-runner-watchdog.service
+journalctl --user -u shepherd-ci-runner-watchdog.service -n 50
+# ...fix the underlying issue (image, docker, gh auth, network)...
+gh variable set CI_RUNNER --body self-hosted
+```
+
+To inspect what the watchdog saw:
+
+```sh
+systemctl --user list-timers shepherd-ci-runner-watchdog.timer
+journalctl --user -u shepherd-ci-runner-watchdog.service -f
+```
+
+## Operations
+
+### Replicas
+
+`@1` alone runs jobs serially. Add `@2` so `ci.yml`'s `verify` and `pr-hygiene.yml` can
+run concurrently. More replicas raise the host load ceiling — keep an eye on the slice.
+
+### Resource tuning
+
+- Per-replica caps live in `~/.config/shepherd-ci-runner/.env`: `RUNNER_CPUS` (default
+  `4`) and `RUNNER_MEMORY` (default `8g`) become the container's `--cpus`/`--memory`
+  (the _suspenders_).
+- The host-wide ceiling is `shepherd-ci.slice` (`CPUQuota=600%`, `MemoryMax=16G`) — the
+  enforcing _belt_ that caps **all** replicas combined, leaving prod Shepherd + the OS
+  headroom on the shared box. Tune both together: per-replica caps × replicas should sit
+  at or under the slice.
+
+### Playwright version-sync
+
+The image bakes a specific Playwright build (`1.60.0` at time of writing). If
+`ui/package.json` bumps Playwright, **rebuild the image** so the warm cache matches:
+
+```sh
+docker build -t shepherd-ci-runner:local ci/self-hosted-runner/
+```
+
+It **self-heals at runtime if it drifts** — the in-job `playwright install` re-downloads
+the matching build into the ephemeral container, so drift costs a one-time download per
+job, never a failure. Rebuilding just restores the fast no-op.
+
+### Disk housekeeping
+
+Ephemeral `--rm` containers don't accumulate, but image layers and dangling build cache
+do over time:
+
+```sh
+docker system prune          # dangling images + build cache
+docker image prune -a        # also unused tagged images (heavier)
+```
+
+### Teardown
+
+```sh
+# 1. Revert CI to GitHub-hosted FIRST, so removing the runner doesn't strand pending jobs.
+gh variable delete CI_RUNNER
+
+# 2. Stop + disable the units.
+systemctl --user disable --now shepherd-ci-runner@1 shepherd-ci-runner@2
+systemctl --user disable --now shepherd-ci-runner-watchdog.timer
+
+# 3. Remove any lingering runner registrations from the repo
+#    (Settings → Actions → Runners, or via gh api repos/erwins-enkel/shepherd/actions/runners).
+
+# 4. Reclaim disk.
+docker image rm shepherd-ci-runner:local
+docker system prune -a --volumes
+```

--- a/ci/self-hosted-runner/README.md
+++ b/ci/self-hosted-runner/README.md
@@ -70,8 +70,18 @@ default to the rootless socket — otherwise it talks to the rootful `/var/run/d
 
 - `docker context use rootless` — writes `~/.docker`, which the units read because they
   set `HOME=%h`. Recommended (one-time, nothing per-unit). Confirm with `docker context show`.
-- or add `DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock` to your `.env` — the unit
-  loads it via `EnvironmentFile`, so `run-runner.sh`'s `docker` inherits it.
+- or a systemd drop-in (`systemctl --user edit shepherd-ci-runner@.service`) with
+
+  ```ini
+  [Service]
+  Environment=DOCKER_HOST=unix://%t/docker.sock
+  ```
+
+  `%t` is expanded by systemd to your runtime dir. **Do not** put
+  `DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock` in `.env` — `EnvironmentFile` passes
+  values literally and never expands variables, so `docker` would receive a literal
+  `${XDG_RUNTIME_DIR}`. A concrete literal path in `.env` works
+  (`DOCKER_HOST=unix:///run/user/<your-uid>/docker.sock`).
 
 **Verify the resource caps actually enforce.** `--cpus`/`--memory` are no-ops unless the
 kernel cgroup controllers are delegated. Confirm a memory cap really lands:
@@ -232,10 +242,15 @@ run concurrently. More replicas raise the host load ceiling — keep an eye on t
 - Per-replica caps live in `~/.config/shepherd-ci-runner/.env`: `RUNNER_CPUS` (default
   `4`) and `RUNNER_MEMORY` (default `8g`) become the container's `--cpus`/`--memory`
   (the _suspenders_).
-- The host-wide ceiling is `shepherd-ci.slice` (`CPUQuota=600%`, `MemoryMax=16G`) — the
-  enforcing _belt_ that caps **all** replicas combined, leaving prod Shepherd + the OS
-  headroom on the shared box. Tune both together: per-replica caps × replicas should sit
-  at or under the slice.
+- The host-wide ceiling is `shepherd-ci.slice` (`CPUQuota=600%`, `MemoryMax=16G`) — a
+  _belt_ meant to cap **all** replicas combined. `run-runner.sh` binds containers to it
+  with `--cgroup-parent=shepherd-ci.slice`, but that only takes effect under **rootless**
+  Docker (daemon in the user systemd tree). Under **rootful** Docker the containers land
+  in the system tree, so this user slice does **not** enforce — install the slice as a
+  system unit (`/etc/systemd/system`) for the belt there, or rely on the per-container
+  `--cpus`/`--memory` caps. Tune both together: per-replica caps × replicas should sit at
+  or under the slice. (CPU is capped below the aggregate; `MemoryMax` only equals it —
+  lower it for real prod memory headroom, per the comment in `shepherd-ci.slice`.)
 
 ### Playwright version-sync
 

--- a/ci/self-hosted-runner/README.md
+++ b/ci/self-hosted-runner/README.md
@@ -35,7 +35,7 @@ one fresh container per job. The posture:
   to `host = 127.0.0.1` (`src/config.ts:38`), and a bridge container **cannot** reach
   host loopback services. **FOOTGUN:** a `0.0.0.0`-bound service IS reachable from the
   container via the `docker0` gateway IP. So `SHEPHERD_HOST=0.0.0.0` (the
-  `src/config.ts:37` escape hatch) **defeats this isolation** — and the **herdr server's
+  `src/config.ts:38` escape hatch) **defeats this isolation** — and the **herdr server's
   bind must be loopback too**, for the same reason. Keep both on loopback. (See the
   optional defense-in-depth firewall rule under Prerequisites for bind-independent
   isolation.)

--- a/ci/self-hosted-runner/README.md
+++ b/ci/self-hosted-runner/README.md
@@ -63,6 +63,16 @@ Rootless Docker maps container-root to your unprivileged host user, shrinking th
 radius of untrusted root-in-container code (see Security model). Install/enable it per
 the [rootless docs](https://docs.docker.com/engine/security/rootless/).
 
+**Make the rootless socket resolvable under systemd user units.** The units set
+`XDG_RUNTIME_DIR=%t` but do **not** set `DOCKER_HOST`, so the `docker` CLI must already
+default to the rootless socket — otherwise it talks to the rootful `/var/run/docker.sock`
+(or fails), silently defeating the rootless recommendation. Persist one of:
+
+- `docker context use rootless` — writes `~/.docker`, which the units read because they
+  set `HOME=%h`. Recommended (one-time, nothing per-unit). Confirm with `docker context show`.
+- or add `DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock` to your `.env` — the unit
+  loads it via `EnvironmentFile`, so `run-runner.sh`'s `docker` inherits it.
+
 **Verify the resource caps actually enforce.** `--cpus`/`--memory` are no-ops unless the
 kernel cgroup controllers are delegated. Confirm a memory cap really lands:
 

--- a/ci/self-hosted-runner/mint-token.sh
+++ b/ci/self-hosted-runner/mint-token.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Mint a short-lived GitHub Actions runner REGISTRATION token on the host and
+# write it (mode 0600) to $RUNNER_TOKEN_FILE for run-runner.sh to hand the
+# container via RUNNER_TOKEN.
+#
+# WHY mint on the host: the admin credential (host `gh` login, or a fine-grained
+# PAT in pat.env via GH_TOKEN) NEVER enters the container. Only this ephemeral,
+# short-lived registration token does — see run-runner.sh.
+#
+# FAIL CLOSED: if the token is empty/unmintable we exit non-zero and write
+# nothing, so the unit can refuse to start a tokenless runner.
+set -euo pipefail
+
+: "${GH_REPO:?GH_REPO must be set (owner/name) — provided by the unit EnvironmentFile}"
+: "${RUNNER_TOKEN_FILE:?RUNNER_TOKEN_FILE must be set — provided by the unit via %t}"
+
+# `gh` resolves auth from GH_TOKEN (optional pat.env) or the host login.
+# -q .token extracts just the token string from the API response.
+token="$(gh api -X POST "repos/${GH_REPO}/actions/runners/registration-token" -q .token)"
+
+if [[ -z "${token}" ]]; then
+  echo "mint-token: registration token was empty — refusing to start a tokenless runner" >&2
+  exit 1
+fi
+
+# Write restrictively (umask first so the create itself is 0600, no race window).
+umask 077
+printf '%s' "${token}" >"${RUNNER_TOKEN_FILE}"
+echo "mint-token: wrote registration token to ${RUNNER_TOKEN_FILE}"

--- a/ci/self-hosted-runner/run-runner.sh
+++ b/ci/self-hosted-runner/run-runner.sh
@@ -10,7 +10,11 @@
 #   - default bridge network, NEVER --network host / --pid host
 #   - NO docker socket mount, NOT --privileged
 #   - --shm-size=1g so Chromium doesn't OOM on the default 64M /dev/shm
-#   - per-replica --cpus / --memory caps
+#   - per-replica --cpus / --memory caps, plus --cgroup-parent=shepherd-ci.slice so the
+#     container's cgroup nests under the slice's combined host ceiling. NB: this only
+#     binds the container to OUR slice under rootless Docker, where the daemon places
+#     containers in the user systemd tree. Under rootful Docker the daemon uses the
+#     system tree, so the (user) shepherd-ci.slice won't govern it — see README.
 #   - only the short-lived RUNNER_TOKEN crosses in — never a PAT
 #   - NO --security-opt no-new-privileges: the in-job
 #     `playwright install --with-deps` needs the image's passwordless sudo.
@@ -51,6 +55,7 @@ exec docker run --rm \
   --shm-size=1g \
   --cpus="${RUNNER_CPUS}" \
   --memory="${RUNNER_MEMORY}" \
+  --cgroup-parent=shepherd-ci.slice \
   -e RUNNER_SCOPE=repo \
   -e REPO_URL="${REPO_URL}" \
   -e RUNNER_NAME="${runner_name}" \

--- a/ci/self-hosted-runner/run-runner.sh
+++ b/ci/self-hosted-runner/run-runner.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Launch ONE ephemeral, hardened self-hosted runner container.
+#
+# Usage: run-runner.sh <runner-name>   (the unit passes runner-%i, e.g. runner-1)
+#
+# The docker invocation lives here rather than inline in the unit so it stays
+# testable (`bash -n`, shellcheck) and free of systemd quoting traps.
+#
+# Security posture (this runs UNTRUSTED PR code, one fresh --rm container/job):
+#   - default bridge network, NEVER --network host / --pid host
+#   - NO docker socket mount, NOT --privileged
+#   - --shm-size=1g so Chromium doesn't OOM on the default 64M /dev/shm
+#   - per-replica --cpus / --memory caps
+#   - only the short-lived RUNNER_TOKEN crosses in — never a PAT
+#   - NO --security-opt no-new-privileges: the in-job
+#     `playwright install --with-deps` needs the image's passwordless sudo.
+#     TRADEOFF: the container therefore runs as root and untrusted PR code can
+#     `sudo` to root INSIDE its namespace. That escalation is contained by the
+#     unprivileged / no-docker-socket / non-privileged boundary above — which is
+#     exactly why rootless Docker is recommended for this on a shared host.
+set -euo pipefail
+
+runner_name="${1:?usage: run-runner.sh <runner-name>}"
+
+: "${RUNNER_TOKEN_FILE:?RUNNER_TOKEN_FILE must be set — provided by the unit via %t}"
+: "${REPO_URL:?REPO_URL must be set — provided by the unit EnvironmentFile}"
+: "${IMAGE:?IMAGE must be set — provided by the unit EnvironmentFile}"
+: "${RUNNER_LABELS:?RUNNER_LABELS must be set — provided by the unit EnvironmentFile}"
+: "${RUNNER_CPUS:?RUNNER_CPUS must be set — provided by the unit EnvironmentFile}"
+: "${RUNNER_MEMORY:?RUNNER_MEMORY must be set — provided by the unit EnvironmentFile}"
+
+# Read the host-minted registration token (mint-token.sh ran in ExecStartPre).
+# Fail closed: no readable, non-empty token => no container.
+if [[ ! -s "${RUNNER_TOKEN_FILE}" ]]; then
+  echo "run-runner: ${RUNNER_TOKEN_FILE} missing or empty — refusing to start" >&2
+  exit 1
+fi
+# Export so docker reads it from our environment (bare `-e RUNNER_TOKEN`) rather
+# than as an argv element — keeping the token out of `ps auxww`/`/proc/<pid>/cmdline`
+# where any local user could read it for the token's ~1h life.
+export RUNNER_TOKEN="$(cat "${RUNNER_TOKEN_FILE}")"
+if [[ -z "${RUNNER_TOKEN}" ]]; then
+  echo "run-runner: registration token empty — refusing to start" >&2
+  exit 1
+fi
+
+# exec so the container is PID 1 under systemd — Restart/stop act on it directly.
+exec docker run --rm \
+  --name "shepherd-ci-${runner_name}" \
+  --network bridge \
+  --shm-size=1g \
+  --cpus="${RUNNER_CPUS}" \
+  --memory="${RUNNER_MEMORY}" \
+  -e RUNNER_SCOPE=repo \
+  -e REPO_URL="${REPO_URL}" \
+  -e RUNNER_NAME="${runner_name}" \
+  -e RUNNER_TOKEN \
+  -e LABELS="${RUNNER_LABELS}" \
+  -e EPHEMERAL=true \
+  -e DISABLE_AUTO_UPDATE=true \
+  -e RUNNER_WORKDIR=/_work \
+  "${IMAGE}"

--- a/ci/self-hosted-runner/runner-liveness.sh
+++ b/ci/self-hosted-runner/runner-liveness.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Shepherd self-hosted CI runner — liveness watchdog.
+#
+# WHY this exists: once the repo sets the `CI_RUNNER` Actions variable, the
+# workflows' `runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}` resolves to the
+# self-hosted label and GitHub's hosted runners are NO LONGER a failover. If our
+# runner is silently down, PR jobs don't go red — they sit QUEUED/pending forever
+# (GitHub waits indefinitely for a matching runner). A pending-but-not-failed
+# check is invisible on the PR; nobody gets paged. This watchdog is what surfaces
+# that: it runs on a timer, fails visibly in the journal when the runner is gone,
+# and best-effort desktop-notifies the operator. The outage runbook (README) is
+# then: `gh variable delete CI_RUNNER` to instantly revert to hosted runners,
+# repair the runner, re-set the variable.
+#
+# It checks BOTH halves of "the runner is actually serving":
+#   (a) GitHub agrees at least one registered runner is `online`, AND
+#   (b) at least one local `shepherd-ci-runner@*.service` instance is up.
+# Both must hold; either failing means jobs can't be picked up.
+#
+# WHY DEBOUNCE: the runner is EPHEMERAL=true — after each job the container
+# deregisters from GitHub and exits, the unit restarts (RestartSec=5s) and
+# re-registers for the next job. So during active CI there's a LEGITIMATE brief
+# window where GitHub reports 0 `online` and the local unit is `activating`
+# (mid-restart), not failed. A single-shot check would fire a false "runner down"
+# alert in that window, and a flappy watchdog trains the operator to ignore it —
+# defeating its purpose. So a first down-read is NOT alerted: we sleep one short
+# interval and RE-CHECK. We alert (stderr + best-effort notify-send + exit 1)
+# ONLY if it's still down on the second read. This rides out the per-job restart
+# gap (RestartSec=5s + container spawn + token mint) while still catching a
+# genuinely-down runner within one 5-min timer tick. Relatedly, the local check
+# accepts `activating` AS WELL AS `active` — a unit mid-restart is up, not failed.
+set -euo pipefail
+
+# Seconds to wait before re-checking a first down-read. Long enough to outlast
+# the per-job restart gap (5s RestartSec + container spawn + token mint), short
+# enough to alert well within one 5-min timer tick.
+RECHECK_DELAY="${RECHECK_DELAY:-15}"
+
+# GH_REPO (owner/name) comes from the same EnvironmentFile the runner units load
+# (~/.config/shepherd-ci-runner/.env). gh resolves auth from the host login or the
+# optional pat.env GH_TOKEN — same credential path as mint-token.sh.
+: "${GH_REPO:?GH_REPO must be set (owner/name) — provided by the unit EnvironmentFile}"
+
+fail() {
+  # Message lands on stderr -> the systemd journal for this oneshot unit.
+  echo "runner-liveness: $1" >&2
+  # Best-effort desktop alert. notify-send may be absent (headless host) or have
+  # no bus to talk to; never let that turn a real failure into a different error
+  # or, worse, mask it — so swallow its exit entirely. The journal is the source
+  # of truth; the toast is a courtesy.
+  notify-send -u critical "Shepherd CI runner DOWN" "$1" 2>/dev/null || true
+  exit 1
+}
+
+# probe: run both halves once. Echoes a one-line summary to stdout and returns 0
+# if healthy; on the first failing check it echoes a describing-WHICH-failed
+# message to stdout and returns 1. It never exits the script — the caller decides
+# whether a single failure is the (debounced) first read or the confirming second.
+probe() {
+  local online_count active_local
+
+  # (a) Ask GitHub how many registered runners report `online`. A repo-scoped
+  # query; `--jq` filters to online runners and counts them. A gh error
+  # (auth/network) is itself a failing read — we report it and let the debounce
+  # re-check decide, rather than aborting the whole script.
+  if ! online_count="$(gh api "repos/${GH_REPO}/actions/runners" \
+    --jq '[.runners[] | select(.status == "online")] | length' 2>/dev/null)"; then
+    echo "could not query GitHub runners for ${GH_REPO} (gh api failed — auth or network?)"
+    return 1
+  fi
+  if [[ -z "${online_count}" || "${online_count}" -lt 1 ]]; then
+    echo "no runner reports 'online' to GitHub for ${GH_REPO} — PR jobs will queue pending, not fail"
+    return 1
+  fi
+
+  # (b) Confirm at least one local runner instance is up. We count instances in
+  # EITHER `active` OR `activating`: an ephemeral runner mid-restart (RestartSec
+  # gap between jobs) sits in `activating` and is up, not failed. list-units over
+  # the template's instances, filtered to both states, counted line-per-unit;
+  # `|| true` stops a zero match from tripping `set -e`.
+  active_local="$(systemctl --user list-units 'shepherd-ci-runner@*.service' \
+    --state=active,activating --no-legend --plain 2>/dev/null | grep -c . || true)"
+  if [[ -z "${active_local}" || "${active_local}" -lt 1 ]]; then
+    echo "no shepherd-ci-runner@*.service instance is active/activating locally — the runner host unit is down"
+    return 1
+  fi
+
+  echo "OK — ${online_count} runner(s) online at GitHub, ${active_local} local instance(s) active/activating"
+  return 0
+}
+
+# Debounce: a single down-read may just be the normal per-job restart window
+# (ephemeral runner deregistered + unit restarting). Don't alert on it — sleep
+# and re-check. Alert only if STILL down on the second read.
+if status="$(probe)"; then
+  echo "runner-liveness: ${status}"
+  exit 0
+fi
+
+echo "runner-liveness: first read DOWN (${status}); re-checking in ${RECHECK_DELAY}s to ride out the ephemeral per-job restart gap…" >&2
+sleep "${RECHECK_DELAY}"
+
+if status="$(probe)"; then
+  echo "runner-liveness: recovered on re-check — was a transient per-job restart window, not an outage"
+  exit 0
+fi
+
+# Still down after the debounce delay — this is a real outage.
+fail "${status}"

--- a/ci/self-hosted-runner/shepherd-ci-runner-watchdog.service
+++ b/ci/self-hosted-runner/shepherd-ci-runner-watchdog.service
@@ -1,0 +1,25 @@
+# Shepherd self-hosted CI runner — liveness watchdog (oneshot).
+#
+# Driven by shepherd-ci-runner-watchdog.timer, NOT enabled directly (no [Install]).
+# Each activation runs runner-liveness.sh once: green -> exit 0, runner down ->
+# exit non-zero so this unit shows `failed` (and the journal carries the reason).
+# See runner-liveness.sh for WHY a down runner is invisible without this.
+[Unit]
+Description=Shepherd self-hosted CI runner liveness check
+Documentation=https://github.com/erwins-enkel/shepherd
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+
+# Mirror the runner unit's environment so host `gh` (and notify-send) resolve under
+# the user manager's minimal env.
+Environment=HOME=%h
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+# Same non-secret config the runner units load — provides GH_REPO + RUNNER_DIR.
+# Optional PAT (leading `-` => absence ok) so `gh` can auth on a host without login.
+EnvironmentFile=%h/.config/shepherd-ci-runner/.env
+EnvironmentFile=-%h/.config/shepherd-ci-runner/pat.env
+
+ExecStart=/usr/bin/env bash ${RUNNER_DIR}/runner-liveness.sh

--- a/ci/self-hosted-runner/shepherd-ci-runner-watchdog.timer
+++ b/ci/self-hosted-runner/shepherd-ci-runner-watchdog.timer
@@ -1,0 +1,20 @@
+# Shepherd self-hosted CI runner — watchdog timer.
+#
+# Periodically fires shepherd-ci-runner-watchdog.service so a silently-down runner
+# (PR jobs queueing pending, never red) gets surfaced in the journal + a desktop
+# toast within a few minutes. Enable with:
+#   systemctl --user enable --now shepherd-ci-runner-watchdog.timer
+[Unit]
+Description=Periodic liveness check for the Shepherd self-hosted CI runner
+Documentation=https://github.com/erwins-enkel/shepherd
+
+[Timer]
+# First check shortly after boot (let the runner units + network settle), then
+# every 5 minutes. Persistent=true runs a missed check on resume if the host was
+# asleep/off across a scheduled tick.
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ci/self-hosted-runner/shepherd-ci-runner@.service
+++ b/ci/self-hosted-runner/shepherd-ci-runner@.service
@@ -1,0 +1,73 @@
+# Shepherd self-hosted CI runner — systemd USER template unit.
+#
+# One instance per replica: `runner-1`, `runner-2` (the %i instance name).
+#   systemctl --user start shepherd-ci-runner@1.service   # -> runner-1
+#
+# Each start mints a fresh registration token on the host (admin credential
+# never enters the container) and runs ONE ephemeral --rm runner container.
+# EPHEMERAL=true means the runner deregisters after a single job, so Restart
+# brings up a fresh container + fresh token for the next job.
+[Unit]
+Description=Shepherd self-hosted CI runner (runner-%i)
+Documentation=https://github.com/erwins-enkel/shepherd
+After=network-online.target docker.service
+Wants=network-online.target
+# Disable systemd's start rate limiter. With EPHEMERAL=true the runner exits 0
+# after EVERY job and we restart to register for the next one — that clean
+# success-restart IS the normal per-job loop, so the rate limiter would count
+# legitimate restarts and trip (~5 jobs) then silently stop restarting, bricking
+# the runner. RestartSec (below) is what actually prevents a tight loop during a
+# sustained registration failure (GitHub outage): the unit just retries every
+# RestartSec instead of being held failed.
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+
+# Mirror shepherd.service conventions: explicit HOME + PATH so host `gh` and
+# `docker` (in /usr/bin) resolve under the user manager's minimal environment.
+Environment=HOME=%h
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+# Where to deal docker its --user runtime socket (rootless / user docker).
+Environment=XDG_RUNTIME_DIR=%t
+
+# Per-instance token path under the runtime dir (%t = /run/user/<uid>): tmpfs,
+# 0700-owned by the user, wiped on logout — a good home for a short-lived token.
+Environment=RUNNER_TOKEN_FILE=%t/shepherd-ci-runner-%i.token
+
+# Non-secret config (required) + optional host-only PAT (leading `-` => absence ok).
+EnvironmentFile=%h/.config/shepherd-ci-runner/.env
+EnvironmentFile=-%h/.config/shepherd-ci-runner/pat.env
+
+# Clear any stale container left by an unclean prior stop (SIGKILL after a stop
+# timeout, daemon restart): the fixed --name would otherwise block the next run
+# with a name conflict. Leading `-` so a no-op (already gone) doesn't fail us.
+ExecStartPre=-/usr/bin/docker rm -f shepherd-ci-runner-%i
+
+# Mint the registration token on the host BEFORE the container starts.
+# If minting fails (empty token / GitHub down) this exits non-zero and ExecStart
+# never runs — fail closed, no tokenless container.
+ExecStartPre=/usr/bin/env bash ${RUNNER_DIR}/mint-token.sh
+
+# Launch the single hardened, ephemeral runner container for this replica.
+ExecStart=/usr/bin/env bash ${RUNNER_DIR}/run-runner.sh runner-%i
+
+# Best-effort: drop the minted token from the runtime dir once the job ends.
+ExecStopPost=/usr/bin/env rm -f ${RUNNER_TOKEN_FILE}
+# Best-effort: remove the container too, so an unclean stop can't strand it and
+# block the next start on a --name conflict. Leading `-` so a no-op is fine.
+ExecStopPost=-/usr/bin/docker rm -f shepherd-ci-runner-%i
+
+# Success-restart is the normal per-job loop (EPHEMERAL exits 0 after each job),
+# so the start rate limiter is OFF (StartLimitIntervalSec=0 above). On a sustained
+# registration failure RestartSec is the only brake: the unit retries every 5s
+# rather than hammering GitHub in a tight loop.
+Restart=always
+RestartSec=5s
+
+# Host-level resource ceiling shared by all runner replicas (belt to the
+# per-container --cpus/--memory suspenders).
+Slice=shepherd-ci.slice
+
+[Install]
+WantedBy=default.target

--- a/ci/self-hosted-runner/shepherd-ci.slice
+++ b/ci/self-hosted-runner/shepherd-ci.slice
@@ -1,8 +1,16 @@
 # Host-level resource ceiling for ALL Shepherd CI runner replicas.
 #
 # This is the enforcing belt to the per-container `--cpus`/`--memory` suspenders
-# in run-runner.sh: even if both replicas spike, the slice caps their combined
-# CPU + memory so production shepherd.service keeps headroom on the same box.
+# in run-runner.sh: when both replicas spike, the slice caps their combined CPU +
+# memory so production shepherd.service keeps headroom on the same box.
+#
+# IMPORTANT: this only binds the containers when run-runner.sh passes
+# `--cgroup-parent=shepherd-ci.slice` (it does) AND the daemon places containers in
+# the USER systemd tree — i.e. ROOTLESS Docker. Under rootful Docker the daemon uses
+# the system tree and would create an unrelated, unlimited shepherd-ci.slice there;
+# to get the belt under rootful, install this slice as a SYSTEM unit
+# (/etc/systemd/system) instead. Without --cgroup-parent the containers run under the
+# daemon's own cgroup and this slice governs nothing.
 #
 # Sizing (tune for the host): with default per-replica caps of 4 CPUs / 8G and
 # two replicas, the worst case is ~800% CPU / 16G.

--- a/ci/self-hosted-runner/shepherd-ci.slice
+++ b/ci/self-hosted-runner/shepherd-ci.slice
@@ -12,6 +12,11 @@
 # (/etc/systemd/system) instead. Without --cgroup-parent the containers run under the
 # daemon's own cgroup and this slice governs nothing.
 #
+# It ALSO requires the docker daemon to use the systemd cgroup driver
+# (native.cgroupdriver=systemd, the default here). Under the cgroupfs driver the
+# `.slice` name is treated as a literal cgroup path, not this systemd unit, so the
+# belt won't engage even rootless.
+#
 # Sizing (tune for the host): with default per-replica caps of 4 CPUs / 8G and
 # two replicas, the worst case is ~800% CPU / 16G.
 #   - CPUQuota=600% is deliberately BELOW the 800% aggregate, so the two runners

--- a/ci/self-hosted-runner/shepherd-ci.slice
+++ b/ci/self-hosted-runner/shepherd-ci.slice
@@ -5,9 +5,13 @@
 # CPU + memory so production shepherd.service keeps headroom on the same box.
 #
 # Sizing (tune for the host): with default per-replica caps of 4 CPUs / 8G and
-# two replicas, the worst case is ~800% CPU / 16G. We deliberately cap BELOW
-# that aggregate so the two runners can't simultaneously max out and starve
-# prod — 600% CPU and 16G total leave room for shepherd + the OS.
+# two replicas, the worst case is ~800% CPU / 16G.
+#   - CPUQuota=600% is deliberately BELOW the 800% aggregate, so the two runners
+#     can't pin every core and starve prod.
+#   - MemoryMax=16G equals the aggregate (2x8G): a hard host ceiling that stops the
+#     runners overcommitting past their combined caps, but it does NOT by itself
+#     reserve memory headroom for prod. On a RAM-constrained box, LOWER this
+#     (e.g. 12G) to carve out an explicit reserve for shepherd + the OS.
 [Slice]
 CPUQuota=600%
 MemoryMax=16G

--- a/ci/self-hosted-runner/shepherd-ci.slice
+++ b/ci/self-hosted-runner/shepherd-ci.slice
@@ -1,0 +1,13 @@
+# Host-level resource ceiling for ALL Shepherd CI runner replicas.
+#
+# This is the enforcing belt to the per-container `--cpus`/`--memory` suspenders
+# in run-runner.sh: even if both replicas spike, the slice caps their combined
+# CPU + memory so production shepherd.service keeps headroom on the same box.
+#
+# Sizing (tune for the host): with default per-replica caps of 4 CPUs / 8G and
+# two replicas, the worst case is ~800% CPU / 16G. We deliberately cap BELOW
+# that aggregate so the two runners can't simultaneously max out and starve
+# prod — 600% CPU and 16G total leave room for shepherd + the OS.
+[Slice]
+CPUQuota=600%
+MemoryMax=16G


### PR DESCRIPTION
## Why

We keep exhausting the **included GitHub Actions minutes** while the repo is private. This adds an opt-in **local self-hosted runner** that runs the two heavy PR jobs (`verify` + `branch-hygiene`) on a Docker container on our own box — self-hosted runners don't draw from included minutes. When the repo goes open source, GitHub-hosted runners become free again and we flip back by deleting one repo variable.

Cheapest alternative considered: just buying minutes (~$0.008/min) — zero-risk, kept as the documented fallback. We self-host because the exhaustion is recurring and the phase is temporary. Full trade-off in the README.

## The toggle (only change to existing CI)

`verify` and `branch-hygiene` now use `runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}`.

- **Variable unset (today): CI is byte-for-byte identical to before** — this PR's own CI runs on `ubuntu-latest`.
- Set `CI_RUNNER=self-hosted` → routes to the local runner.
- **Going open source = delete the variable.** `release-please` is untouched (push-to-main only, cheap).

## What's in `ci/self-hosted-runner/`

- **`Dockerfile`** — `FROM myoung34/github-runner@sha256:067d616…` (digest-pinned), bakes Playwright 1.60.0 chromium **read-only into the image layer** (trusted warm cache; no shared writable cache to poison across jobs; self-heals on version drift).
- **`mint-token.sh` / `run-runner.sh`** — host mints a short-lived registration token via `gh` and passes only that in; the **admin PAT never enters the container**. `run-runner.sh` assembles the hardened `docker run`.
- **`shepherd-ci-runner@.service`** (systemd **user** template, mirrors `shepherd.service`) — ephemeral `--rm` container per job, stable `runner-%i` names, per-job re-register loop (rate-limiter off, `RestartSec=5s`), stale-container cleanup.
- **`shepherd-ci.slice`** — host-level CPU/mem ceiling (belt to the per-container `--cpus`/`--memory` suspenders).
- **`runner-liveness.sh` + watchdog `.service`/`.timer`** — alerts when no runner is `online` (debounced to ride out the ephemeral per-job restart gap), because setting `CI_RUNNER` removes GitHub-hosted failover.
- **`README.md`** — full operator guide (prereqs, setup, runbook, teardown).

## Security model (runs untrusted PR code beside prod `shepherd.service`)

- **Ephemeral** `--rm` per job, **no shared writable state** (no cross-job cache poisoning).
- **Network-isolated on the default bridge** — no `--network host`/`--pid host`, no docker-socket, not `--privileged`. This holds **only because prod binds loopback** (`src/config.ts:38`); `SHEPHERD_HOST=0.0.0.0` would defeat it (documented + asserted in prereqs).
- **Admin PAT never in any container** (host-minted registration token only). Residual: the short-lived token is readable in job env until it expires — accepted (not the PAT; ~1h TTL).
- **Container runs as root** (myoung34 default) → **rootless Docker recommended** so container-root maps to an unprivileged host uid. Documented.
- `--shm-size=1g` (Chromium OOM), verified-enforcing resource caps.

## ⚠️ Not done by this PR (intentional — post-merge bring-up)

This PR is the **artifacts only**. It does **not** set `CI_RUNNER` or start any runner — doing so before a runner is live would hang all PR CI (including this one). Bring-up (build image, install units, set the variable **after** the runner shows Idle) is the README's setup section.

**Mandatory before the repo goes public: `gh variable delete CI_RUNNER`** — a self-hosted runner on a public repo runs fork-PR code on the host.

## Decisions taken (sensible defaults, none product-level)

Accepted the token-in-env residual (bespoke `unset` entrypoint documented as the stricter option); template supports 2 replicas; `--cpus=4 --memory=8g`; targets the currently-installed rootful Docker while recommending rootless; firewall DROP documented but not shipped in v1; dir `ci/self-hosted-runner/`.

## Notes

- No user-facing UX → i18n + feature-catalog gates correctly don't apply (commits are `ci:`).
- Branch is linear off main; hygiene + prettier gates pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)