### PR TITLE
fix(ui): exclude in-review sessions from Ready filter + merge-train

### DIFF
--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
 import Herd from "./Herd.svelte";
+import { reviews, planGates } from "$lib/reviews.svelte";
 import type { Session, GitState } from "$lib/types";
 
 function session(partial: Partial<Session> & { id: string }): Session {
@@ -126,5 +127,81 @@ describe("Herd merge-train link", () => {
       git: { a: openPr },
     });
     await expect.element(page.getByRole("button", { name: "Merge train" })).not.toBeInTheDocument();
+  });
+});
+
+describe("Herd Ready filter", () => {
+  // reviews/planGates are module singletons — clear any state set per test so it
+  // doesn't bleed into the next one.
+  afterEach(() => {
+    reviews.setReviewing("rev", false);
+    planGates.applyReviewing("pg", false);
+    reviews.setReviewing("rm", false);
+    reviews.setReviewing("only", false);
+  });
+
+  it("hides a critic-reviewing session under Ready but keeps a plain idle one", async () => {
+    reviews.setReviewing("rev", true);
+    render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "rev", name: "reviewing one" }),
+        session({ id: "idle", name: "idle one" }),
+      ],
+      git: {},
+    });
+    // both visible under All (default)
+    await expect.element(page.getByText("reviewing one")).toBeInTheDocument();
+    await expect.element(page.getByText("idle one")).toBeInTheDocument();
+    await page.getByRole("button", { name: "▤ Ready" }).click();
+    await expect.element(page.getByText("idle one")).toBeInTheDocument();
+    await expect.element(page.getByText("reviewing one")).not.toBeInTheDocument();
+  });
+
+  it("hides a plan-gate-reviewing session under Ready", async () => {
+    planGates.applyReviewing("pg", true);
+    render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "pg", name: "plan gate one" }),
+        session({ id: "idle", name: "idle one" }),
+      ],
+      git: {},
+    });
+    await page.getByRole("button", { name: "▤ Ready" }).click();
+    await expect.element(page.getByText("idle one")).toBeInTheDocument();
+    await expect.element(page.getByText("plan gate one")).not.toBeInTheDocument();
+  });
+
+  it("hides a readyToMerge + in-review session under Ready", async () => {
+    reviews.setReviewing("rm", true);
+    render(Herd, {
+      ...base,
+      sessions: [session({ id: "rm", name: "ready merging", readyToMerge: true })],
+      git: { rm: openPr },
+    });
+    await page.getByRole("button", { name: "▤ Ready" }).click();
+    await expect.element(page.getByText("ready merging")).not.toBeInTheDocument();
+  });
+
+  it("drops the Merge train link when the only ready+open-PR session is in review", async () => {
+    reviews.setReviewing("only", true);
+    render(Herd, {
+      ...base,
+      sessions: [session({ id: "only", name: "only one", readyToMerge: true })],
+      git: { only: openPr },
+      onmergetrain: () => {},
+    });
+    await expect.element(page.getByRole("button", { name: "Merge train" })).not.toBeInTheDocument();
+  });
+
+  it("keeps a plain idle non-review session visible under Ready", async () => {
+    render(Herd, {
+      ...base,
+      sessions: [session({ id: "plain", name: "plain idle" })],
+      git: {},
+    });
+    await page.getByRole("button", { name: "▤ Ready" }).click();
+    await expect.element(page.getByText("plain idle")).toBeInTheDocument();
   });
 });

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -45,11 +45,18 @@
     flow?: boolean;
   } = $props();
 
+  // a critic post-PR review or a pre-execution plan-gate review currently in flight —
+  // the reviewer is actively working the session, so it is NOT awaiting the operator.
+  const inReview = (id: string) => reviews.isReviewing(id) || planGates.isReviewing(id);
+
   // sidebar list filter: "all" or "ready" (only sessions not actively working —
-  // anything but a running agent: idle, blocked, done → awaiting the operator)
+  // anything but a running agent: idle, blocked, done → awaiting the operator;
+  // in-review sessions are excluded too, since a reviewer is actively working them)
   let filter = $state<"all" | "ready">("all");
   const shown = $derived(
-    filter === "ready" ? sessions.filter((s) => s.status !== "running") : sessions,
+    filter === "ready"
+      ? sessions.filter((s) => s.status !== "running" && !inReview(s.id))
+      : sessions,
   );
   // within the shown set, top→bottom by lifecycle stage: active rows first, then
   // PR-CI-running and critic-reviewing / plan-gate-reviewing in-flight groups, then
@@ -58,17 +65,11 @@
   // `session:reviewing` and `session:plangate-reviewing` events respectively.
   // nowMs (the reactive clock tick) is threaded in so the Merging group re-partitions
   // as the per-session merge TTL elapses, matching the badge/pip which also use nowMs.
-  const partition = $derived(
-    partitionSessions(
-      shown,
-      git,
-      (id) => reviews.isReviewing(id) || planGates.isReviewing(id),
-      nowMs,
-    ),
-  );
+  const partition = $derived(partitionSessions(shown, git, inReview, nowMs));
   // ready-to-merge sessions that actually have an open PR — the merge-train link
   // only surfaces when there's something to run (fail-closed: no PR → no link).
-  const readyPrCount = $derived(collectReadyPrs(shown, git).length);
+  // In-review sessions are excluded so the link's count matches the launch action.
+  const readyPrCount = $derived(collectReadyPrs(shown, git, inReview).length);
 </script>
 
 <div class="panel bracket">

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -100,6 +100,69 @@ describe("collectReadyPrs", () => {
       { sessionId: "a", number: 9, title: "", url: "", repoPath: "/repo/a" },
     ]);
   });
+
+  it("excludes an in-review ready-to-merge session with an open PR", () => {
+    const sessions = [session({ id: "a", readyToMerge: true, repoPath: "/repo/a" })];
+    const git: Record<string, GitState> = { a: openPr(11, "feat: a", "https://h/pull/11") };
+    // review in flight → not settled, drop it even though the PR is open
+    expect(collectReadyPrs(sessions, git, (id) => id === "a")).toEqual([]);
+  });
+
+  it("includes the same session once its review clears (predicate false)", () => {
+    const sessions = [session({ id: "a", readyToMerge: true, repoPath: "/repo/a" })];
+    const git: Record<string, GitState> = { a: openPr(11, "feat: a", "https://h/pull/11") };
+    expect(collectReadyPrs(sessions, git, () => false)).toEqual([
+      {
+        sessionId: "a",
+        number: 11,
+        title: "feat: a",
+        url: "https://h/pull/11",
+        repoPath: "/repo/a",
+      },
+    ]);
+  });
+
+  it("count==action: display subset and full set agree on dropping the in-review PR", () => {
+    // display path (Herd.svelte) collects from a filtered `shown` subset; the
+    // action path (+page.svelte) collects from the full session list. With the
+    // same predicate both must drop the in-review session so the link can never
+    // advertise a train target the click then merges.
+    const inReview = session({ id: "a", readyToMerge: true, repoPath: "/repo/a" });
+    const settled = session({ id: "b", readyToMerge: true, repoPath: "/repo/a" });
+    const full = [inReview, settled];
+    const subset = [settled]; // `a` filtered out of the displayed list
+    const git: Record<string, GitState> = {
+      a: openPr(11, "feat: a", "https://h/pull/11"),
+      b: openPr(22, "feat: b", "https://h/pull/22"),
+    };
+    const isReviewing = (id: string) => id === "a";
+    const expected = [
+      {
+        sessionId: "b",
+        number: 22,
+        title: "feat: b",
+        url: "https://h/pull/22",
+        repoPath: "/repo/a",
+      },
+    ];
+    expect(collectReadyPrs(full, git, isReviewing)).toEqual(expected);
+    expect(collectReadyPrs(subset, git, isReviewing)).toEqual(expected);
+  });
+
+  it("default 2-arg call keeps current behavior (no review exclusion)", () => {
+    const sessions = [session({ id: "a", readyToMerge: true, repoPath: "/repo/a" })];
+    const git: Record<string, GitState> = { a: openPr(11, "feat: a", "https://h/pull/11") };
+    // omitting the predicate defaults to () => false → in-review state irrelevant
+    expect(collectReadyPrs(sessions, git)).toEqual([
+      {
+        sessionId: "a",
+        number: 11,
+        title: "feat: a",
+        url: "https://h/pull/11",
+        repoPath: "/repo/a",
+      },
+    ]);
+  });
 });
 
 describe("formatReadyPrs", () => {

--- a/ui/src/lib/components/merge-train.ts
+++ b/ui/src/lib/components/merge-train.ts
@@ -24,11 +24,20 @@ export interface ReadyPr {
 /** Ready-to-merge sessions that currently have an OPEN PR — the merge-train
  *  targets. Mirrors the `ready` partition (operator-parked `readyToMerge`),
  *  intersected with an open PR from git state so already-merged or PR-less
- *  parked sessions drop out (merged wins, fail-closed: no PR → nothing to run). */
-export function collectReadyPrs(sessions: Session[], git: Record<string, GitState>): ReadyPr[] {
+ *  parked sessions drop out (merged wins, fail-closed: no PR → nothing to run).
+ *  Sessions whose review is still in flight (`isReviewing`) are also excluded —
+ *  the work isn't settled, so the train must neither count nor land them; the
+ *  injected predicate (mirrors `partitionSessions`) keeps the link's count and
+ *  the launch action in agreement. Default `() => false` preserves 2-arg callers. */
+export function collectReadyPrs(
+  sessions: Session[],
+  git: Record<string, GitState>,
+  isReviewing: (id: string) => boolean = () => false,
+): ReadyPr[] {
   const out: ReadyPr[] = [];
   for (const s of sessions) {
     if (!s.readyToMerge) continue;
+    if (isReviewing(s.id)) continue; // review in flight → not settled, don't run the train over it
     const g = git[s.id];
     if (g?.state !== "open" || g.number == null) continue;
     out.push({

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -267,7 +267,11 @@
   // the repo with the most and surface a fail-loud notice for the rest rather
   // than silently folding them in. Mirrors onquickissue for branch + create.
   async function onmergetrain() {
-    const ready = collectReadyPrs(store.sessions, store.git);
+    const ready = collectReadyPrs(
+      store.sessions,
+      store.git,
+      (id) => reviews.isReviewing(id) || planGates.isReviewing(id),
+    );
     const { repoPath, prs, otherRepoCount } = pickTrainRepo(ready);
     if (!repoPath || prs.length === 0) {
       toasts.info(m.toast_merge_train_no_prs());


### PR DESCRIPTION
## Problem

The Herd sidebar **Ready** filter (`All | Ready`) is meant to show only sessions *awaiting the operator* ("idle, blocked, or done"). It filtered on `status !== "running"` alone, so a session whose **review was in flight** — critic post-PR review or pre-execution plan-gate review, where the agent is idle but a reviewer is actively working — still leaked into the Ready list.

Filtering only the *display* would have exposed a worse bug: the merge-train link count (`Herd.svelte`, filtered `shown`) and the merge-train launch action (`+page.svelte`, full `store.sessions`) source PRs from **different** sets. So a hidden in-review `readyToMerge` PR would drop from the link yet still get merged on click — the opposite of "don't act on in-review work".

## Fix

- `collectReadyPrs` (`merge-train.ts`) gains an injected `isReviewing` predicate (mirroring `partitionSessions`) and skips in-review sessions — exclusion now lives in the collector, so the link count and the launch action are derived identically (**count == action**, fail-closed: the train never lands a PR whose review is still in flight).
- `Herd.svelte` extracts a single `inReview` predicate (`reviews.isReviewing(id) || planGates.isReviewing(id)`) and reuses it across the Ready filter, `partitionSessions`, and `readyPrCount`.
- `+page.svelte` `onmergetrain` passes the same predicate.

Scope: both critic **and** plan-gate reviews. A session that is both `readyToMerge` **and** in review is hidden from the Ready filter and excluded from the train (work isn't settled until review clears). The `All` view row display is unchanged.

## Tests

- `merge-train.test.ts`: in-review exclusion, predicate-false inclusion, **count == action invariant** (full set vs. display subset agree on dropping the in-review PR), default-2-arg backward compat.
- `Herd.browser.test.ts` (`Herd Ready filter` block): critic-review hidden, plan-gate-review hidden, `readyToMerge`+in-review hidden, merge-train link dropped when the only ready+open-PR session is in review, plus a sanity case. `afterEach` clears the singleton review stores to prevent cross-test bleed.

`cd ui && bun run check` → 0 errors/0 warnings. `bun run test` → 588 passed.

## Notes

- No user-facing string changes. The `herd_ready_title` tooltip still reads "idle, blocked, or done" — a consciously-accepted minor imprecision (some idle sessions are now excluded) rather than EN+DE catalog churn. Easy to reword if preferred. `[no-feature-entry]` — this is a `fix:`, no feature-catalog entry.
- Out of scope (flagged by review, not a regression here): the server-side full-auto merge train (`AutoMergeService`) is a separate path with its own gates and is not touched by this UI fix. Worth a follow-up check if "never land an in-review PR" should hold there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
