### PR TITLE
feat(ui): add ^U quick-tap shortcut to control palette

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -54,6 +54,7 @@
   "controlkey_arrow_down": "Pfeil runter",
   "controlkey_ctrl_a": "Strg A, Zeilenanfang",
   "controlkey_ctrl_e": "Strg E, Zeilenende",
+  "controlkey_ctrl_u": "Strg U, Zeile bis Anfang löschen",
   "controlkey_ctrl_c": "Strg C, unterbrechen",
   "controlkey_ctrl_d": "Strg D, Dateiende",
   "actionbar_new_task": "+ Neue Aufgabe",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -54,6 +54,7 @@
   "controlkey_arrow_down": "Arrow down",
   "controlkey_ctrl_a": "Ctrl A, start of line",
   "controlkey_ctrl_e": "Ctrl E, end of line",
+  "controlkey_ctrl_u": "Ctrl U, clear line to start",
   "controlkey_ctrl_c": "Ctrl C, interrupt",
   "controlkey_ctrl_d": "Ctrl D, end of file",
   "actionbar_new_task": "+ New Task",

--- a/ui/src/lib/controlKeys.test.ts
+++ b/ui/src/lib/controlKeys.test.ts
@@ -14,6 +14,7 @@ const EXPECTED: Record<string, string> = {
   "↓": "\x1b[B",
   "^A": "\x01",
   "^E": "\x05",
+  "^U": "\x15",
   "^C": "\x03",
   "^D": "\x04",
 };

--- a/ui/src/lib/controlKeys.ts
+++ b/ui/src/lib/controlKeys.ts
@@ -36,6 +36,7 @@ export function controlKeys(): ControlKey[] {
     { label: "↓", aria: m.controlkey_arrow_down(), seq: "\x1b[B", group: "nav" },
     { label: "^A", aria: m.controlkey_ctrl_a(), seq: "\x01", group: "signal" },
     { label: "^E", aria: m.controlkey_ctrl_e(), seq: "\x05", group: "signal" },
+    { label: "^U", aria: m.controlkey_ctrl_u(), seq: "\x15", group: "signal" },
     { label: "^C", aria: m.controlkey_ctrl_c(), seq: "\x03", group: "signal", tone: "danger" },
     { label: "^D", aria: m.controlkey_ctrl_d(), seq: "\x04", group: "signal" },
   ];


### PR DESCRIPTION
## What

Adds **^U** (Ctrl-U, kill-line-to-start, byte `\x15`) to the mobile steering bar's quick-tap control palette, alongside the existing `^A`/`^E` readline-style line-edit keys in the `signal` group.

## Changes

- `ui/src/lib/controlKeys.ts` — append `^U` → `\x15` (single source of truth for the palette).
- `ui/src/lib/controlKeys.test.ts` — add the byte-guard entry so the exact control code can't silently drift.
- `ui/messages/{en,de}.json` — `controlkey_ctrl_u` aria string, EN + DE in parity.

## Verification

- `bun run test src/lib/controlKeys.test.ts` — 5 passing
- `bun run check:i18n` — 2 locales in parity
- `bun run check` — 0 errors / 0 warnings

This extends an existing palette via its documented single-source-of-truth array; it touches `ui/src/lib/` (not `components/`/`routes/`), so the feature-catalog gate does not arm. The addition is one button on an existing surface — no new discovery entry warranted. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)