### PR TITLE
fix(ui): desktop layout fills viewport width

### DIFF
--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -982,8 +982,10 @@
 
 <style>
   .shell {
-    max-width: 1480px;
-    margin: 0 auto;
+    /* No max-width cap: the desktop layout fills the viewport so widening the
+       browser scales the terminal column (1fr) instead of leaving dead space at
+       the sides. The session picker stays compact; the terminal absorbs the gain. */
+    width: 100%;
     /* max(base, inset): on devices/browsers without safe areas env() is 0 so the
        base padding wins (no regression); in an iOS standalone PWA the Dynamic Island
        (top) and home indicator (bottom) insets win. Everything flows inside .shell,
@@ -1053,7 +1055,6 @@
   }
 
   .shell.mobile {
-    max-width: none;
     padding: max(10px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right))
       max(10px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
     gap: 10px;


### PR DESCRIPTION
## Problem

Widening the browser on desktop left a growing band of dead space at the sides — "nichts skaliert mit" (see screenshot). The whole app stayed 1480px wide no matter how wide the window got.

## Cause

The `.shell` container was pinned to `max-width: 1480px` and centered with `margin: 0 auto`. The mobile shell already overrode this to `max-width: none`, but the desktop shell did not.

## Fix

Drop the desktop cap (`.shell` now `width: 100%`). The grid's terminal column is `1fr`, so it absorbs the extra width while the session picker stays compact (`minmax(300px, 360px)`). Removed the now-redundant `max-width: none` from `.shell.mobile`.

CSS-only, no behavior change beyond the width cap. `bun run check` passes (0 errors).