### PR TITLE
feat(ui): foldable header on mobile to reclaim terminal space

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -398,6 +398,8 @@
   "viewport_git_actions_state_clear": "bereit zum Mergen",
   "viewport_git_actions_title_state": "PR, Merge, Kritiker & Merge-Freigabe — {state}",
   "viewport_git_actions_aria_state": "PR- und Merge-Aktionen ein-/ausblenden — {state}",
+  "viewport_fold_aria": "Kopfbereich einklappen — Tabs und PR-Aktionen ausblenden für mehr Terminal-Platz",
+  "viewport_unfold_aria": "Kopfbereich ausklappen — Tabs und PR-Aktionen anzeigen",
   "diff_refresh": "Diff aktualisieren",
   "diff_error": "Diff konnte nicht geladen werden.",
   "diff_empty": "Keine Änderungen ggü. {base}",
@@ -708,5 +710,7 @@
   "prspanel_launch_train": "Merge-Train starten",
   "prspanel_merge_train_prompt": "Führe einen Merge-Train für die Pull Requests aus, die ich ausgewählt habe. Prüfe jeden auf Korrektheit und Produkt-Fit, schlage eine sichere Merge-Reihenfolge vor und halte vor jedem Merge für meine Freigabe an — prüfe danach nach jedem Merge die Warteschlange erneut, denn main bewegt sich unter dir.\n\nAusgewählte PRs:\n{prs}\n\nWenn dieses Repo einen /merge-train-Befehl oder -Skill bereitstellt, nutze ihn. Andernfalls arbeite den Train selbst ab:\n1. Erfasse für jeden PR den Status mit gh (CI-Rollup, Mergebarkeit/Konflikte, wie weit hinter main, und welche Dateien sich mit anderen PRs dieser Liste überschneiden).\n2. Verschiebe jeden PR, der CI-rot, konfliktbehaftet, gate-fehlerhaft oder nicht erwünscht ist, mit einer einzeiligen Begründung auf eine separate Halteliste — merge niemals an einem roten Gate vorbei.\n3. Ordne den Rest: am kleinsten und unabhängigsten zuerst; überschneiden sich zwei, sequenziere sie so, dass der riskantere auf den anderen rebased; release-please-PRs zuletzt.\n4. Präsentiere die nummerierte Merge-Reihenfolge plus die Halteliste und WARTE auf meine Freigabe.\n5. Nach Freigabe merge in Reihenfolge: erst auf das aktuelle main rebasen (niemals main in den Branch mergen), grüne Gates bestätigen, dann gh pr merge --squash --delete-branch, und vor dem nächsten die verbleibenden PRs erneut gegen main prüfen.",
   "feat_backlog_pr_merge_train_title": "Merge-Train aus ausgewählten PRs starten",
-  "feat_backlog_pr_merge_train_body": "Mehrere offene PRs im Backlog-PRs-Tab eines Repos auswählen und einen Merge-Train starten, der auf genau diese PRs beschränkt ist."
+  "feat_backlog_pr_merge_train_body": "Mehrere offene PRs im Backlog-PRs-Tab eines Repos auswählen und einen Merge-Train starten, der auf genau diese PRs beschränkt ist.",
+  "feat_header_fold_title": "Kopfbereich einklappen für mehr Terminal",
+  "feat_header_fold_body": "Tippe auf dem Mobilgerät auf den Pfeil im Session-Kopf, um Tabs und PR-Leiste einzuklappen und den Platz dem Terminal zu geben. Deine Wahl bleibt über Sessions hinweg erhalten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -398,6 +398,8 @@
   "viewport_git_actions_state_clear": "ready to merge",
   "viewport_git_actions_title_state": "PR, merge, critic & ready-to-merge actions — {state}",
   "viewport_git_actions_aria_state": "Toggle PR and merge actions — {state}",
+  "viewport_fold_aria": "Collapse header — hide tabs and PR actions for more terminal space",
+  "viewport_unfold_aria": "Expand header — show tabs and PR actions",
   "diff_refresh": "Refresh diff",
   "diff_error": "Couldn't load the diff.",
   "diff_empty": "No changes vs {base}",
@@ -708,5 +710,7 @@
   "prspanel_launch_train": "Launch merge train",
   "prspanel_merge_train_prompt": "Run a merge train for the pull requests I've selected. Review each for correctness and product-fit, propose a safe merge order, and stop for my approval before merging anything — then re-check the queue after every merge, because main moves under you.\n\nSelected PRs:\n{prs}\n\nIf this repo provides a /merge-train command or skill, use it. Otherwise work the train yourself:\n1. For each PR, gather status with gh (CI rollup, mergeability/conflicts, how far behind main, and which files overlap other PRs in this list).\n2. Move any PR that is CI-red, conflicting, gate-failing, or that we don't actually want into a separate hold list with a one-line reason — never merge past a red gate.\n3. Order the rest: smallest and most independent first; when two overlap, sequence them so the riskier one rebases onto the other; release-please PRs last.\n4. Present the numbered merge order plus the hold list and WAIT for my approval.\n5. On approval, merge in order: rebase onto latest main first (never merge main into the branch), confirm gates are green, then gh pr merge --squash --delete-branch, and re-check the remaining PRs against main before the next one.",
   "feat_backlog_pr_merge_train_title": "Launch a merge train from selected PRs",
-  "feat_backlog_pr_merge_train_body": "Multi-select open PRs in a repo's backlog PRs tab and launch a merge train scoped to just those PRs."
+  "feat_backlog_pr_merge_train_body": "Multi-select open PRs in a repo's backlog PRs tab and launch a merge train scoped to just those PRs.",
+  "feat_header_fold_title": "Fold the header for more terminal",
+  "feat_header_fold_body": "On mobile, tap the chevron in the session header to collapse the tabs and PR rail and hand that space to the terminal. Your choice sticks across sessions."
 }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -187,6 +187,19 @@
   // the fold only applies on the compact layout (it's the mobile space-saver);
   // desktop keeps its own git-actions disclosure untouched.
   const headerFolded = $derived(compact && headerCollapsed);
+  // a11y: the fold button's aria-controls points at the tab switcher — the always-
+  // mounted primary region it collapses (the git rail + build queue come and go with
+  // the fold, so they can't carry a stable controlled-region id). Per-session id so
+  // it stays unique if ever more than one viewport mounts.
+  const foldRegionId = $derived(`vp-fold-region-${session.id}`);
+
+  function toggleFold() {
+    headerCollapsed = !headerCollapsed;
+    // folding hides the tab switcher, so a non-terminal tab would be stranded with no
+    // way back except unfolding — and its panel would keep filling the body, reclaiming
+    // nothing. Land on the terminal (the view this fold exists to enlarge).
+    if (headerCollapsed) tab = "term";
+  }
 
   // phone merged header: the repo + session that used to live in the top bar
   const repoName = $derived(session.repoPath.split("/").filter(Boolean).at(-1) ?? "");
@@ -1213,7 +1226,7 @@
       {@render renameControl()}
     {/if}
     <div class="spacer"></div>
-    <div class="tab-group" class:mobile={compact} class:folded={headerFolded}>
+    <div id={foldRegionId} class="tab-group" class:mobile={compact} class:folded={headerFolded}>
       <button class="tab-btn" class:active={tab === "term"} onclick={() => (tab = "term")}
         >{m.viewport_terminal_tab()}</button
       >
@@ -1329,11 +1342,17 @@
           class="vp-fold"
           type="button"
           aria-expanded={!headerCollapsed}
+          aria-controls={foldRegionId}
           aria-label={headerCollapsed ? m.viewport_unfold_aria() : m.viewport_fold_aria()}
           title={headerCollapsed ? m.viewport_unfold_aria() : m.viewport_fold_aria()}
-          onclick={() => (headerCollapsed = !headerCollapsed)}
+          onclick={toggleFold}
         >
-          <span aria-hidden="true">{headerCollapsed ? "▾" : "▴"}</span>
+          <!-- chevron points the way the secondary chrome moves, per the user's
+               explicit "Pfeil nach unten" request: ▾ while expanded (tap to fold it
+               down/away), ▴ once folded (tap to bring it back up). This intentionally
+               inverts the desktop git-toggle's disclosure caret, which is a separate
+               control that never co-renders with this one. -->
+          <span aria-hidden="true">{headerCollapsed ? "▴" : "▾"}</span>
         </button>
       {/if}
       <button

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -107,6 +107,27 @@
   // desktop only: reveals the git rail (PR / merge / critic / ready / verdict) as a
   // second header row, so the primary strip stays uncrowded until the operator asks
   let gitOpen = $state(false);
+  // mobile/compact only: folds the secondary header chrome (tabs + git rail +
+  // build queue) into the first identity line so the terminal reclaims the
+  // vertical space. Persisted globally → restored to the operator's last choice.
+  const COLLAPSE_KEY = "shepherd-vp-header-collapsed";
+  let headerCollapsed = $state(
+    typeof localStorage !== "undefined" &&
+      (() => {
+        try {
+          return localStorage.getItem(COLLAPSE_KEY) === "1";
+        } catch {
+          return false;
+        }
+      })(),
+  );
+  $effect(() => {
+    try {
+      localStorage.setItem(COLLAPSE_KEY, headerCollapsed ? "1" : "0");
+    } catch {
+      /* localStorage unavailable (private mode) — fold stays in-memory only */
+    }
+  });
   let conn = $state<PtyConn | undefined>();
   // true when another device took over this terminal — show a take-over prompt
   let parked = $state(false);
@@ -163,6 +184,9 @@
   // compact header: narrow mobile OR a touch device on the desktop layout (unfolded
   // foldables). Drops secondary fields + wraps so the decommission button never clips.
   const compact = $derived(mobile || touch);
+  // the fold only applies on the compact layout (it's the mobile space-saver);
+  // desktop keeps its own git-actions disclosure untouched.
+  const headerFolded = $derived(compact && headerCollapsed);
 
   // phone merged header: the repo + session that used to live in the top bar
   const repoName = $derived(session.repoPath.split("/").filter(Boolean).at(-1) ?? "");
@@ -1189,7 +1213,7 @@
       {@render renameControl()}
     {/if}
     <div class="spacer"></div>
-    <div class="tab-group" class:mobile={compact}>
+    <div class="tab-group" class:mobile={compact} class:folded={headerFolded}>
       <button class="tab-btn" class:active={tab === "term"} onclick={() => (tab = "term")}
         >{m.viewport_terminal_tab()}</button
       >
@@ -1299,6 +1323,18 @@
     <div class="vp-actions">
       {#if compact}
         {@render renameControl()}
+        <!-- mobile space-saver: folds the tabs + PR rail + build queue away so the
+             terminal claims the freed height. State persists across sessions. -->
+        <button
+          class="vp-fold"
+          type="button"
+          aria-expanded={!headerCollapsed}
+          aria-label={headerCollapsed ? m.viewport_unfold_aria() : m.viewport_fold_aria()}
+          title={headerCollapsed ? m.viewport_unfold_aria() : m.viewport_fold_aria()}
+          onclick={() => (headerCollapsed = !headerCollapsed)}
+        >
+          <span aria-hidden="true">{headerCollapsed ? "▾" : "▴"}</span>
+        </button>
       {/if}
       <button
         class="decom"
@@ -1321,7 +1357,7 @@
   <!-- the git rail gets its own strip when there's no room for it inline:
        always on compact layouts (mobile + unfolded fold, where the header wraps),
        and on desktop only while the PR disclosure toggle is open. -->
-  {#if compact || gitOpen}
+  {#if (compact && !headerCollapsed) || gitOpen}
     <div class="vp-git-strip">
       <GitRail
         sessionId={session.id}
@@ -1337,13 +1373,16 @@
     </div>
   {/if}
 
-  <!-- build queue panel: shown when the flag is on OR a queue already exists for this session -->
-  <BuildQueuePanel
-    sessionId={session.id}
-    enabled={repoConfig.flags(session.repoPath).buildQueue}
-    queue={buildQueue ?? null}
-    onbootstrap={(q) => onSeedBuildQueue?.(q)}
-  />
+  <!-- build queue panel: shown when the flag is on OR a queue already exists for this
+       session — folded away with the rest of the secondary chrome on mobile -->
+  {#if !headerFolded}
+    <BuildQueuePanel
+      sessionId={session.id}
+      enabled={repoConfig.flags(session.repoPath).buildQueue}
+      queue={buildQueue ?? null}
+      onbootstrap={(q) => onSeedBuildQueue?.(q)}
+    />
+  {/if}
 
   <!-- scan overlay + terminal (terminal stays mounted across tab switches) -->
   <div class="vp-body">
@@ -1694,6 +1733,35 @@
      real flex cluster so the two trailing controls wrap together. */
   .vp-actions {
     display: contents;
+  }
+
+  /* mobile fold toggle: a bare chevron in the trailing actions cluster that
+     hides/shows the secondary header chrome. Mirrors the .decom ghost styling
+     so the two trailing controls read as a set. */
+  .vp-fold {
+    flex-shrink: 0;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    color: var(--color-faint);
+    font-family: var(--font-mono);
+    font-size: var(--fs-base);
+    line-height: 1;
+    padding: 2px 7px;
+    cursor: pointer;
+    transition:
+      color 0.12s,
+      border-color 0.12s,
+      background 0.12s;
+  }
+  .vp-fold:hover {
+    color: var(--color-ink);
+    border-color: var(--color-line-bright);
+  }
+  /* folded tabs are display:none rather than removed from the DOM so the active
+     tab + terminal mount survive the toggle (no remount, no PTY teardown) */
+  .tab-group.folded {
+    display: none;
   }
 
   .status-badge {
@@ -2323,6 +2391,7 @@
   /* finger-sized header controls on touch layouts (≥40px) */
   .vp-head.mobile .back,
   .vp-head.mobile .next-yu,
+  .vp-head.mobile .vp-fold,
   .vp-head.mobile .decom {
     min-height: 40px;
     padding: 8px 12px;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -132,4 +132,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_backlog_pr_merge_train_title",
     bodyKey: "feat_backlog_pr_merge_train_body",
   },
+  {
+    // No targetId: the fold chevron only mounts on the compact/mobile layout, so a
+    // coachmark anchor would rarely be present on first view — surface via the
+    // What's-New drawer only.
+    id: "header-fold",
+    sinceVersion: "1.20.0",
+    titleKey: "feat_header_fold_title",
+    bodyKey: "feat_header_fold_body",
+  },
 ];


### PR DESCRIPTION
## Why

On mobile the session header stacks the **tab bar**, the **PR / automation rail** (PR #, Merge, Automation N/M, Ready, critic verdict) and the **build-queue panel** above the terminal. On a phone that chrome claims a big slice of the screen even though you mostly work *in* the terminal.

## What

A chevron toggle in the **first header line** (trailing actions cluster, beside the ✕ — mobile/compact layout only):

- **Fold** → hides the tabs, the git rail and the build-queue panel. The terminal's flex body grows into the freed height; the existing `ResizeObserver` refits xterm automatically.
- **Unfold** → restores them.
- The choice **persists globally** in `localStorage` (`shepherd-vp-header-collapsed`) and is restored on next visit — the view stays however you last left it.
- Chevron mirrors the existing git-toggle convention: `▴` when expanded (fold up), `▾` when collapsed (unfold down).

Desktop is untouched — it keeps its own git-actions disclosure.

## Notes

- Tabs are `display:none` when folded (not removed) so the active tab + terminal mount survive the toggle — no remount, no PTY teardown.
- New `.vp-fold` button reuses the `.decom` ghost-button recipe + design tokens; finger-sized (≥40px) on touch layouts.
- i18n: `viewport_fold_aria` / `viewport_unfold_aria` added to EN + DE.
- Feature catalog entry `header-fold` (since 1.20.0) + `feat_header_fold_*` messages added in the same PR.

Gates: `check:i18n` parity ✓, `svelte-check` 0 errors ✓, feature-catalog ✓, branch-hygiene ✓.