### PR TITLE
fix(plan-gate): isolate plan-reviewer worktree per session

### DIFF
--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -188,9 +188,12 @@ export class PlanGateService {
 
     // Disposable detached worktree at the base: read-only codebase inspection that can't race
     // the live planning agent. The plan TEXT travels inline in the prompt, not via this tree.
+    // Key the path on session.id: every session detaches at the SAME base sha, so without this
+    // discriminator concurrent plan reviews would share one worktree path and read each other's
+    // verdict file (cross-session findings). See createDetached's `slug` doc.
     let wt;
     try {
-      wt = this.deps.worktree.createDetached(session.repoPath, session.baseBranch, sha);
+      wt = this.deps.worktree.createDetached(session.repoPath, session.baseBranch, sha, session.id);
     } catch (err) {
       console.warn(`[plan-gate] worktree failed for ${session.id}:`, err);
       return;

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -235,14 +235,27 @@ export class WorktreeMgr {
 
   /** Detached worktree at a specific commit, fetching it from origin first so a
    *  PR head pushed by the agent is present even when the local repo is behind.
-   *  Used by the critic to review the exact PR head. */
-  createDetached(repoPath: string, branch: string, sha: string): WorktreeResult {
+   *  Used by the critic to review the exact PR head.
+   *
+   *  `slug` disambiguates the worktree path when callers do NOT have a unique sha to key
+   *  on. The PR critic detaches at the PR head sha (unique per PR), so it omits `slug` and
+   *  the path stays `…-review-<sha>` — reused-on-restart to reclaim an interrupted run. The
+   *  plan reviewer, however, detaches every session at the SAME base-branch sha, so without
+   *  a slug all concurrent plan reviews in a repo would collide on one path: a second begin()
+   *  would blow away the first's live worktree, and both inflight records would then read the
+   *  same `.shepherd-plan-review.json` — delivering one session's plan findings to another.
+   *  Passing the session id as `slug` gives each its own path. */
+  createDetached(repoPath: string, branch: string, sha: string, slug?: string): WorktreeResult {
     if (!/^[0-9a-fA-F]{7,40}$/.test(sha)) throw new Error("invalid sha");
     // same refname grammar as create(); rejecting a leading "-" also blocks argv
     // flag-smuggling into the `git fetch` below (the `--` is belt-and-suspenders)
     if (!/^(?!-)[A-Za-z0-9._/-]{1,200}$/.test(branch)) throw new Error("invalid branch");
+    // flat filesystem-safe token only — no `/` (subdirs) and no `.` (so no `..` traversal);
+    // a session UUID satisfies this.
+    if (slug !== undefined && !/^[A-Za-z0-9_-]{1,128}$/.test(slug)) throw new Error("invalid slug");
     const parent = join(dirname(repoPath), ".shepherd-worktrees");
-    const worktreePath = join(parent, `${basename(repoPath)}-review-${sha.slice(0, 8)}`);
+    const tag = slug ? `${slug}-${sha.slice(0, 8)}` : sha.slice(0, 8);
+    const worktreePath = join(parent, `${basename(repoPath)}-review-${tag}`);
     mkdirSync(parent, { recursive: true });
     try {
       // best-effort: pull the PR head into the local object store (no-op if local)

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -207,6 +207,45 @@ test("createDetached: rejects a branch that could smuggle a git flag", () => {
   expect(() => mgr.createDetached(repo, "-x", sha)).toThrow("invalid branch");
 });
 
+test("createDetached: distinct slugs at the SAME sha get distinct worktrees (no plan-review collision)", () => {
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+  execFileSync("git", ["checkout", "-b", "feat/x"], { cwd: repo });
+  writeFileSync(join(repo, "feat.txt"), "hello");
+  execFileSync("git", ["add", "feat.txt"], { cwd: repo });
+  execFileSync("git", ["commit", "-q", "-m", "feat commit"], { cwd: repo, env });
+  const sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo }).toString().trim();
+
+  const mgr = new WorktreeMgr();
+  // Two sessions' plan reviews both detach at the same base sha — they must NOT share a path,
+  // else a second begin() destroys the first's worktree and both read one verdict file.
+  const a = mgr.createDetached(repo, "feat/x", sha, "session-aaaa");
+  const b = mgr.createDetached(repo, "feat/x", sha, "session-bbbb");
+  expect(a.worktreePath).not.toBe(b.worktreePath);
+  expect(existsSync(a.worktreePath)).toBe(true);
+  expect(existsSync(b.worktreePath)).toBe(true);
+  // a slugless detach (the PR critic) stays distinct from the slugged ones too
+  const c = mgr.createDetached(repo, "feat/x", sha);
+  expect(c.worktreePath).not.toBe(a.worktreePath);
+  expect(c.worktreePath).not.toBe(b.worktreePath);
+
+  mgr.remove(a.worktreePath);
+  mgr.remove(b.worktreePath);
+  mgr.remove(c.worktreePath);
+});
+
+test("createDetached: rejects a slug that could escape the worktree dir", () => {
+  const mgr = new WorktreeMgr();
+  const sha = "0".repeat(40);
+  expect(() => mgr.createDetached(repo, "main", sha, "../escape")).toThrow("invalid slug");
+  expect(() => mgr.createDetached(repo, "main", sha, "a/b")).toThrow("invalid slug");
+});
+
 test("commitsAhead: 0 when branch tip == base, >0 after a commit", () => {
   execFileSync("git", ["checkout", "-b", "feat"], { cwd: repo, stdio: "pipe" });
   const wt = new WorktreeMgr();


### PR DESCRIPTION
## Problem

Eine Session bekommt Plan-Reviewer-Findings, die in Wirklichkeit den Plan einer **anderen** Session reviewt haben — die Findings „gehören woanders hin". Reproduziert in mehreren parallelen Autopilot-Sessions: eine Session zum Modal-Backdrop-Blur erhielt Findings über einen völlig fremden Plan (Queue-Strip/Auto-Drain, `inFlight`, `autoSessions`, „Teil A"), die in ihrem eigenen `.shepherd-plan.md` nirgends vorkamen.

## Ursache

`WorktreeMgr.createDetached` bildet den Pfad der wegwerfbaren Reviewer-Worktree aus `<repo>-review-<sha[0:8]>`.

- Der **PR-Critic** detacht auf den **PR-Head-SHA** → eindeutig pro PR. ✅
- Der **Plan-Reviewer** detacht jede Session auf **denselben Base-Branch-SHA** (`main`). ❌

Damit kollidieren alle gleichzeitig laufenden Plan-Reviews eines Repos auf **einem** Pfad:

1. Session A startet → Worktree `…-review-<mainSHA>`, Reviewer A schreibt sein Verdict dorthin.
2. Session B startet → gleicher Pfad. `createDetached` entfernt (`if (existsSync) this.remove`) A's **noch laufende** Worktree und legt sie neu an. Beide `inflight`-Records zeigen nun auf denselben `worktreePath`.
3. `tick()` liest `.shepherd-plan-review.json` aus dem geteilten Pfad → A bekommt das Verdict, das B's Plan reviewt hat (Cross-Session-Leak).

## Fix

Optionaler `slug`-Parameter an `createDetached`; das Plan-Gate übergibt `session.id`, sodass jede Plan-Review ihren eigenen Worktree-Pfad bekommt (`…-review-<sessionId>-<sha>`). Der PR-Critic bleibt unverändert (sein Head-SHA-Pfad ist bereits eindeutig und sein Restart-Reclaim hängt daran). `slug` wird streng validiert (`[A-Za-z0-9_-]`, kein `/`, kein `..`).

## Tests

- Neuer Regressionstest: zwei Slugs am **selben SHA** ergeben **getrennte** Worktrees; ein slugloser Detach (Critic) bleibt zusätzlich distinkt.
- Neuer Negativtest: traversal-/subdir-Slug wird abgelehnt.
- `bun run lint` grün, alle Server-Tests (`bun test test/`) grün.

[no-feature-entry] — server-seitiger Bugfix, keine user-facing UX.
