### PR TITLE
fix(ui): pin mobile action bar to viewport bottom

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -70,13 +70,18 @@
   --fs-2xl: 22px;
 
   /* Fixed mobile action bar (list screen) — single source so the bar's sizing
-     and the list's padding-bottom reservation can't drift. --mobile-actionbar-h
-     is the bar's height minus its bottom safe-area inset: the button touch
-     target + the bar's 10px top padding + 2px top/bottom border (buttons are
-     border-box via Tailwind preflight, so --mobile-actionbar-hit is the button's
-     full rendered height). */
+     and the list's padding-bottom reservation can't drift. The bar's own
+     padding + border are tokenized here and consumed in ActionBar.svelte, so
+     --mobile-actionbar-h (the bar's height minus its bottom safe-area inset =
+     button touch target + top padding + top/bottom border) stays bound to the
+     real bar. Buttons are border-box via Tailwind preflight, so
+     --mobile-actionbar-hit is the button's full rendered height. */
   --mobile-actionbar-hit: 44px;
-  --mobile-actionbar-h: calc(var(--mobile-actionbar-hit) + 12px);
+  --mobile-actionbar-pad: 10px;
+  --actionbar-border: 1px;
+  --mobile-actionbar-h: calc(
+    var(--mobile-actionbar-hit) + var(--mobile-actionbar-pad) + 2 * var(--actionbar-border)
+  );
 
   --status-running: var(--color-amber);
   /* done = WAITING (finished turn, parked for the operator's next steer). It is

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -69,6 +69,15 @@
   --fs-xl: 20px;
   --fs-2xl: 22px;
 
+  /* Fixed mobile action bar (list screen) — single source so the bar's sizing
+     and the list's padding-bottom reservation can't drift. --mobile-actionbar-h
+     is the bar's height minus its bottom safe-area inset: the button touch
+     target + the bar's 10px top padding + 2px top/bottom border (buttons are
+     border-box via Tailwind preflight, so --mobile-actionbar-hit is the button's
+     full rendered height). */
+  --mobile-actionbar-hit: 44px;
+  --mobile-actionbar-h: calc(var(--mobile-actionbar-hit) + 12px);
+
   --status-running: var(--color-amber);
   /* done = WAITING (finished turn, parked for the operator's next steer). It is
      NOT actionable-complete, so it must not read green/"ignore me" — it reads as

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -122,7 +122,7 @@
     display: flex;
     gap: 10px;
     align-items: center;
-    border: 1px solid var(--color-line);
+    border: var(--actionbar-border) solid var(--color-line);
     background: var(--color-panel);
     padding: 10px 14px;
   }
@@ -241,10 +241,10 @@
     right: 0;
     bottom: 0;
     z-index: 5;
-    padding: 10px;
-    padding-left: max(10px, env(safe-area-inset-left));
-    padding-right: max(10px, env(safe-area-inset-right));
-    padding-bottom: max(10px, env(safe-area-inset-bottom));
+    padding: var(--mobile-actionbar-pad);
+    padding-left: max(var(--mobile-actionbar-pad), env(safe-area-inset-left));
+    padding-right: max(var(--mobile-actionbar-pad), env(safe-area-inset-right));
+    padding-bottom: max(var(--mobile-actionbar-pad), env(safe-area-inset-bottom));
   }
   .actions.mobile .btn.primary {
     flex: 1;

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -250,12 +250,12 @@
     flex: 1;
     text-align: center;
     padding: 12px;
-    min-height: 44px;
+    min-height: var(--mobile-actionbar-hit);
     font-size: var(--fs-base);
   }
   .actions.mobile .btn.backlog {
     padding: 12px 16px;
-    min-height: 44px;
+    min-height: var(--mobile-actionbar-hit);
     font-size: var(--fs-base);
   }
 

--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -229,15 +229,21 @@
     background: var(--color-inset);
     border-color: var(--color-amber);
   }
-  /* Mobile list document-scrolls: the herd/backlog above flex-fills the viewport
-     when the list is short, keeping the bar at the bottom; position:sticky pins
-     the bar to the viewport bottom while scrolling a long list. padding-bottom
-     clears the gesture-nav safe-area inset. */
+  /* Mobile list document-scrolls. position:fixed pins the bar to the viewport
+     bottom unconditionally — sticky failed here because its containing block
+     (.main-region) doesn't span the full overflowing herd height, so the bar
+     came unstuck and scrolled away on long lists. The list reserves matching
+     padding-bottom (see .shell.mobile.list) so no row hides behind the bar.
+     Side + bottom insets clear the gesture-nav / landscape-notch safe areas. */
   .actions.mobile {
-    position: sticky;
+    position: fixed;
+    left: 0;
+    right: 0;
     bottom: 0;
     z-index: 5;
     padding: 10px;
+    padding-left: max(10px, env(safe-area-inset-left));
+    padding-right: max(10px, env(safe-area-inset-right));
     padding-bottom: max(10px, env(safe-area-inset-bottom));
   }
   .actions.mobile .btn.primary {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1078,7 +1078,9 @@
        (--mobile-actionbar-h + its own safe-area inset, both shared with the bar
        in app.css) so the last list row never hides behind it. */
     padding-top: 0;
-    padding-bottom: calc(var(--mobile-actionbar-h) + max(10px, env(safe-area-inset-bottom)));
+    padding-bottom: calc(
+      var(--mobile-actionbar-h) + max(var(--mobile-actionbar-pad), env(safe-area-inset-bottom))
+    );
   }
   .shell.mobile.list .chrome {
     position: sticky;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1074,10 +1074,11 @@
     min-height: 100dvh;
     /* the pinned chrome owns the top safe-area inset (see below), so drop the
        shell's own top padding — otherwise a stuck header would inset twice
-       (notch + shell). The bottom reserves room for the fixed ActionBar (~56px
-       bar + its own safe-area inset) so the last list row never hides behind it. */
+       (notch + shell). The bottom reserves room for the fixed ActionBar
+       (--mobile-actionbar-h + its own safe-area inset, both shared with the bar
+       in app.css) so the last list row never hides behind it. */
     padding-top: 0;
-    padding-bottom: calc(56px + max(10px, env(safe-area-inset-bottom)));
+    padding-bottom: calc(var(--mobile-actionbar-h) + max(10px, env(safe-area-inset-bottom)));
   }
   .shell.mobile.list .chrome {
     position: sticky;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1072,11 +1072,12 @@
   .shell.mobile.list {
     height: auto;
     min-height: 100dvh;
-    /* the pinned chrome/ActionBar own the top/bottom safe-area insets (see below),
-       so drop the shell's own top+bottom padding — otherwise a stuck header would
-       inset twice (notch + shell), and a blank gap would sit below the pinned bar */
+    /* the pinned chrome owns the top safe-area inset (see below), so drop the
+       shell's own top padding — otherwise a stuck header would inset twice
+       (notch + shell). The bottom reserves room for the fixed ActionBar (~56px
+       bar + its own safe-area inset) so the last list row never hides behind it. */
     padding-top: 0;
-    padding-bottom: 0;
+    padding-bottom: calc(56px + max(10px, env(safe-area-inset-bottom)));
   }
   .shell.mobile.list .chrome {
     position: sticky;


### PR DESCRIPTION
## Problem

On mobile, the bottom bar with **+ New Task** / **Backlog** was not staying put — it scrolled up together with the session list instead of being anchored to the bottom of the screen.

| Scrolled to top | Scrolled down |
|---|---|
| bar correctly at bottom | bar drifts up into the middle of the list, rows below it |

## Root cause

The mobile bar used `position: sticky; bottom: 0`. Its sticky containing block is `.main-region`, whose box does **not** span the full *overflowing* herd height on a long list (the herd renders at natural height with `overflow: visible` for document-scroll). Once you scroll past the short containing block, the sticky releases and the bar travels with the content.

## Fix

- Switch the **mobile** action bar to `position: fixed; left/right/bottom: 0` so it pins to the viewport bottom unconditionally (sticky containing-block fragility no longer matters). Added left/right safe-area insets for landscape notches.
- Reserve matching `padding-bottom` on `.shell.mobile.list` (~56px bar + its safe-area inset) so the last list row never hides behind the now-fixed bar.

Desktop action bar is untouched (`.actions.mobile` only).

## Verification

- `cd ui && bun run check` → 0 errors
- `bun run test` → 579 passed