### PR TITLE
fix(ci): install Node 20 in the self-hosted runner image

### DIFF
--- a/ci/self-hosted-runner/Dockerfile
+++ b/ci/self-hosted-runner/Dockerfile
@@ -26,13 +26,24 @@ FROM myoung34/github-runner@sha256:067d61600d8ea770ce4940002bd817972282b4b691b04
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 
-# The base ships node (v18) but no npm/npx, and Playwright's CLI is driven via
-# npx. Install npm so `npx playwright install` is available at build time.
+# Install Node 20 (NodeSource), replacing the base image's Node 18.
+#
+# WHY Node 20 specifically (not the base's v18, and not just "any npm"):
+#   This node is used at JOB RUNTIME, not only at build time. The ui `check` step
+#   runs `paraglide-js compile`, whose `.bin` shim is `#!/usr/bin/env node`, so it
+#   executes under the CONTAINER's node. paraglide-js/inlang load a WASM SQLite that
+#   needs the global Web Crypto API; on Node 18 it aborts with
+#   "ReferenceError: crypto is not defined" (Aborted(initRandomDevice)). GitHub's
+#   ubuntu-latest ships Node 20, where it works — so the runner must match it, or
+#   every ui-touching PR fails here while passing on hosted runners. NodeSource
+#   nodejs also provides npm/npx for the Playwright bake below.
 # `playwright install --with-deps` needs root + apt; the base image's default
 # user is root, which is what we want for the build steps.
 USER root
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends npm \
+    && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
     && PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright \
        npx --yes playwright@1.60.0 install --with-deps chromium \
     && apt-get clean \


### PR DESCRIPTION
## Problem

The self-hosted runner (PR #405) shipped an image based on `myoung34/github-runner`, which carries **Node 18**. The `ui` `check` step runs `paraglide-js compile`, whose `.bin` shim is `#!/usr/bin/env node` → it executes under the **container's** node. paraglide-js/inlang load a WASM SQLite that needs the global Web Crypto API; Node 18 lacks it and aborts:

```
Aborted(initRandomDevice)
[paraglide-js] Error: Failed to create new inlang project: ReferenceError: crypto is not defined
```

GitHub's `ubuntu-latest` ships Node 20, so this passed on hosted runners but **failed on every `ui`-touching PR on the self-hosted runner** — caught on PR #415's first real self-hosted run.

## Fix

Install **Node 20 (NodeSource)** in the image, replacing the base's Node 18, so the container matches `ubuntu-latest`. NodeSource `nodejs` also provides the npm/npx used for the Playwright bake.

## Verification (in the rebuilt image, on the rootless daemon)

- Reproduced the failure under Node 18: `paraglide-js compile` → `crypto is not defined`.
- Under Node 20: `paraglide-js compile` succeeds and `cd ui && bun run check` → **0 errors, 0 warnings**.
- Rebuilt image reports `node v20.20.2`, chromium still baked at `/opt/ms-playwright`.

## Operational note

`CI_RUNNER` is currently **deleted** (CI is back on `ubuntu-latest`) so this PR's own CI runs on hosted runners and nobody is blocked. After this merges I'll pull, rebuild the local image, restart the runner units (so they recreate from the fixed image), re-set `CI_RUNNER=self-hosted`, and validate on a real run before declaring it live again.

[no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)