### PR TITLE
feat(ui): repo selector leads New Task form + named on submit

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -208,6 +208,7 @@
   "newtask_model_default": "Standard",
   "newtask_spawning": "Wird gestartet…",
   "newtask_submit": "Erstellen & Starten",
+  "newtask_submit_in_repo": "Erstellen & Starten in {repo}",
   "newtask_upload_failed": "Bild-Upload fehlgeschlagen: {reason}. Anhängen erneut versuchen.",
   "newtask_create_failed": "Erstellen fehlgeschlagen: {reason}. Repo und Base-Branch prüfen, dann erneut versuchen.",
   "promptsources_title": "Übernehmen aus",
@@ -680,5 +681,7 @@
   "feat_plan_gate_title": "Plan-Gate",
   "feat_plan_gate_body": "Aktiviere das Plan-Gate, um dich vor dem Start abzustimmen: Der Agent befragt dich und schreibt einen Plan, dann prüft ein zweiter Claude diesen kritisch, bis er standhält — nur ein freigegebener Plan läuft. Pro Aufgabe im Neue-Aufgabe-Dialog oder pro Repo im Automatisierungs-Panel einschaltbar.",
   "feat_backlog_repo_filter_title": "Repo-Liste filtern",
-  "feat_backlog_repo_filter_body": "Grenze die Repo-Liste des Backlogs mit den neuen Umschalt-Chips auf Repos mit offenen Issues und/oder offenen PRs ein."
+  "feat_backlog_repo_filter_body": "Grenze die Repo-Liste des Backlogs mit den neuen Umschalt-Chips auf Repos mit offenen Issues und/oder offenen PRs ein.",
+  "feat_newtask_repo_first_title": "Repo steht jetzt oben im Neue-Aufgabe-Formular",
+  "feat_newtask_repo_first_body": "Das Repository, in dem die Aufgabe startet, steht jetzt oben im Neue-Aufgabe-Formular und wird auf dem „Erstellen & Starten“-Button genannt – so startest du nie versehentlich im falschen Repo."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -208,6 +208,7 @@
   "newtask_model_default": "default",
   "newtask_spawning": "Spawning…",
   "newtask_submit": "Create & Run",
+  "newtask_submit_in_repo": "Create & Run in {repo}",
   "newtask_upload_failed": "Image upload failed: {reason}. Retry the attach.",
   "newtask_create_failed": "Create failed: {reason}. Check repo and base branch, then retry.",
   "promptsources_title": "Seed From",
@@ -680,5 +681,7 @@
   "feat_plan_gate_title": "Plan gate",
   "feat_plan_gate_body": "Turn on the plan gate to align before the night starts: the agent grills you and writes a plan, then a second Claude adversarially reviews it until it holds up — only an approved plan runs. Enable it per task in New Task or per repo in the automation panel.",
   "feat_backlog_repo_filter_title": "Filter the repo list",
-  "feat_backlog_repo_filter_body": "Narrow the backlog's repo list to repos with open issues and/or open PRs using the new toggle chips."
+  "feat_backlog_repo_filter_body": "Narrow the backlog's repo list to repos with open issues and/or open PRs using the new toggle chips.",
+  "feat_newtask_repo_first_title": "Repo now leads the New Task form",
+  "feat_newtask_repo_first_body": "The repository you'll launch into now sits at the top of the New Task form and is named on the Create & Run button, so you never start a task against the wrong repo by accident."
 }

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -66,6 +66,8 @@
     return msg || fallback;
   }
   let repos = $state<RepoEntry[]>([]);
+  // Echoed on the submit button so the destination repo is visible at commit time.
+  const selectedRepoName = $derived(repos.find((r) => r.path === repoPath)?.name ?? "");
   let branches = $state<string[]>([]);
   let images = $state<{ path: string; name: string }[]>([]);
   let dragging = $state(false);
@@ -341,6 +343,11 @@
       >
     </div>
 
+    <div class="repo-field" use:coachTarget={"nt-repo"}>
+      <label class="micro" for="nt-repo">{m.newtask_repo_label()}</label>
+      <RepoSelect {repos} value={repoPath} onchange={(p) => (repoPath = p)} {onclone} />
+    </div>
+
     <label class="micro" for="nt-prompt">{m.newtask_prompt_label()}</label>
     <div class="prompt-wrap">
       <textarea
@@ -430,9 +437,6 @@
       />
     {/if}
 
-    <label class="micro" for="nt-repo">{m.newtask_repo_label()}</label>
-    <RepoSelect {repos} value={repoPath} onchange={(p) => (repoPath = p)} {onclone} />
-
     <label class="micro" for="nt-base">{m.newtask_branch_label()}</label>
     {#if branches.length > 0}
       <select id="nt-base" bind:value={baseBranch}>
@@ -475,7 +479,13 @@
       disabled={submitting}
       title={isMac ? "⌘ + Enter" : "Ctrl + Enter"}
     >
-      <span>{submitting ? m.newtask_spawning() : m.newtask_submit()}</span>
+      <span
+        >{submitting
+          ? m.newtask_spawning()
+          : selectedRepoName
+            ? m.newtask_submit_in_repo({ repo: selectedRepoName })
+            : m.newtask_submit()}</span
+      >
       {#if !submitting}
         <kbd class="kbd">{isMac ? "⌘↵" : "Ctrl+↵"}</kbd>
       {/if}
@@ -499,6 +509,11 @@
     border: 1px solid var(--color-line-bright);
     background: var(--color-panel);
     padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .repo-field {
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -643,6 +658,12 @@
     font-size: var(--fs-meta);
     cursor: pointer;
     box-shadow: inset 0 0 18px -10px var(--color-amber);
+  }
+  .run span {
+    max-width: 28ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .run:disabled {
     opacity: 0.6;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -114,4 +114,11 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_backlog_repo_filter_title",
     bodyKey: "feat_backlog_repo_filter_body",
   },
+  {
+    id: "new-task-repo-first",
+    sinceVersion: "1.19.0",
+    titleKey: "feat_newtask_repo_first_title",
+    bodyKey: "feat_newtask_repo_first_body",
+    targetId: "nt-repo",
+  },
 ];


### PR DESCRIPTION
## Why

Working across several repos, it's easy to launch a task against the **wrong repository**: the last-used repo is auto-selected, the repo selector sits *below* the prompt (field #5), and the ⌘↵ submit shortcut fires from inside the textarea — so you commit without ever seeing the destination.

## UX eval (three failure reinforcers)

1. **Implicit default** — last-used repo auto-picked, presented like a deliberate choice.
2. **Below the prompt** — repo is outside the top-down reading path.
3. **Blind commit** — ⌘↵ submits from the textarea; the eye never reaches the repo field. *(the real killer — moving the field up alone wouldn't catch it)*

## What this does

- **Repo selector moves to the top** of the New Task form (scope-before-content): `Repo → Prompt → … → submit`.
- **Submit button names the destination** — `Create & Run in <repo>` — so the target is visible at the exact moment of commit (catches the ⌘↵ path). Falls back to `Create & Run` when no repo is selected; long names ellipsize.
- Auto-select of the last-used repo is **kept** — the visibility + named-commit changes carry the safety, not removal of the convenience.

## Notes

- New i18n key `newtask_submit_in_repo` (EN + DE).
- What's-New catalog entry `new-task-repo-first` + coachmark anchored on the repo control (`nt-repo`).
- Surgical: one component + i18n + catalog. No new components or design tokens.

## Test plan

- `cd ui && bun run check` — 0 errors
- `cd ui && bun run check:i18n` — EN/DE parity
- `cd ui && bun run test` — 581 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)