### PR TITLE
fix(review): isolate reviewer agents from MCP via --safe-mode

### DIFF
--- a/src/reviewer-argv.ts
+++ b/src/reviewer-argv.ts
@@ -5,7 +5,9 @@ import { randomUUID } from "node:crypto";
  *  or agent-written plan text), so a prompt-injection hidden there must not be able to run commands
  *  or escape its disposable worktree. `dontAsk` auto-denies anything off the allowlist (an
  *  unattended PTY would otherwise hang on a permission prompt); the allowlist is read-only
- *  inspection + read-only git + writing files in its own disposable worktree. */
+ *  inspection + read-only git + writing files in its own disposable worktree. The sandbox is also
+ *  MCP-isolated via --safe-mode (no MCP servers load, so no "trust this server?" prompt can hang
+ *  the unattended pane — dontAsk does not suppress that gate). */
 export function readonlyReviewerArgv(model: string | null, prompt: string): string[] {
   const argv = [
     "claude",
@@ -24,6 +26,20 @@ export function readonlyReviewerArgv(model: string | null, prompt: string): stri
     "--settings",
     '{"disableAllHooks":true}',
     "--disable-slash-commands",
+    // MCP isolation. A fresh `claude` startup loads MCP servers from THREE
+    // sources: file (.mcp.json / global ~/.claude.json), plugin-bundled, and
+    // claude.ai account connectors. A not-yet-trusted server triggers a "trust
+    // this MCP server?" prompt — a SEPARATE gate that dontAsk does NOT suppress;
+    // each review's fresh disposable-worktree path makes servers look "newly
+    // discovered", so the pane hangs invisibly to the Shepherd UI. --safe-mode
+    // disables ALL customizations incl. MCP servers (all three sources) while
+    // keeping Auth/tools/permissions normal — the OAuth-safe alternative to
+    // --bare (--strict-mcp-config would only cover the file class, insufficient).
+    // Must sit BEFORE --allowedTools: it's a boolean flag and --allowedTools is
+    // variadic, swallowing every following token until the next flag.
+    // Side effect (acceptable): safe-mode also stops auto-loading the repo
+    // CLAUDE.md — fine, the review/plan prompts are self-contained.
+    "--safe-mode",
     "--allowedTools",
     "Read",
     "Grep",

--- a/test/plan-gate-prompt.test.ts
+++ b/test/plan-gate-prompt.test.ts
@@ -25,6 +25,8 @@ test("reviewerArgv mirrors critic hardening: dontAsk last, no --bare, disableAll
   const tools = a.indexOf("--allowedTools");
   expect(tools).toBeGreaterThan(-1);
   expect(tools).toBeLessThan(dontAsk);
+  expect(a).toContain("--safe-mode");
+  expect(a.indexOf("--safe-mode")).toBeLessThan(a.indexOf("--allowedTools"));
 });
 test("reviewerArgv inserts --model when given", () => {
   const a = reviewerArgv("opus", "PROMPT");

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -230,6 +230,7 @@ test("critic spawns read-only: no skip-permissions, dontAsk + scoped allowlist",
   expect(argv).not.toContain("--bare");
   expect(argv).toContain("--disable-slash-commands");
   expect(argv[argv.indexOf("--settings") + 1]).toBe('{"disableAllHooks":true}');
+  expect(argv).toContain("--safe-mode");
 });
 
 test("task prompt survives the variadic allowlist (not swallowed → no task → timeout)", () => {


### PR DESCRIPTION
## Problem

A review herdr pane was seen hanging in the background, **invisible to the Shepherd UI/control pane**, waiting for approval of a newly-discovered MCP server.

Read-only adversarial reviewer agents (PR critic via `ReviewService`, plan reviewer via `PlanGateService`) are spawned through the shared `readonlyReviewerArgv()` and run unattended in a PTY with `--permission-mode dontAsk`. The catch: the **"Do you trust this MCP server?" prompt is a separate, earlier gate than tool-use permission** — `dontAsk` (and even `--dangerously-skip-permissions`) does **not** suppress it. So a not-yet-trusted MCP server blocks the pane on a prompt nothing can answer.

## Root cause

A fresh `claude` startup loads MCP servers from **three** sources:
1. **File-based** — `.mcp.json` / global `~/.claude.json` (this repo has none)
2. **Plugin-bundled** — e.g. `plugin:context7`, `plugin:resend`, `plugin:vercel`
3. **claude.ai account connectors** — Notion, M365, IT Glue, Gmail, Drive, Calendar…

Because the repo has no `.mcp.json`, the culprit is a **plugin/connector** server — and `--strict-mcp-config` only governs the *file* class, so it would **not** have fixed this. Each review also runs in a **fresh disposable worktree path**, so any untrusted server looks "newly discovered" and re-prompts.

Reviewers use a hardcoded read-only allowlist (Read/Grep/Glob/scoped-git/Write) and never call an MCP tool, so they should load **zero** MCP servers.

## Fix

Add **`--safe-mode`** to the shared reviewer argv. It disables *all* customizations including MCP servers (all three sources) while keeping **Auth, model selection, built-in tools, and permissions normal** — i.e. it preserves subscription **OAuth**, unlike `--bare` (which forces `ANTHROPIC_API_KEY` and is rejected here). Additive to the existing `--disable-slash-commands` + `--settings '{"disableAllHooks":true}'`. Placed **before** the variadic `--allowedTools` (a boolean flag would otherwise be swallowed). Acceptable side effect: safe-mode also stops auto-loading the repo CLAUDE.md — fine, the review/plan prompts are self-contained.

**Scope:** reviewers only. Task/session agents (`--dangerously-skip-permissions`) keep MCP — they may legitimately use it (context7 docs, etc.).

## Verification

- `bun test ./test` → 1309 pass / 1 skip / 0 fail. New assertions in `test/plan-gate-prompt.test.ts` (presence + ordering before `--allowedTools`) and `test/review.test.ts` (presence on the critic path).
- `bun run lint` → clean.
- **Manual PTY smoke test:** ran the real `readonlyReviewerArgv` output interactively under a PTY in a fresh worktree. The agent started cleanly under safe-mode (OAuth intact, no API key), ran `git show`, wrote its verdict file, and **finished with zero MCP/trust prompts in the transcript** — the previously-hanging path now completes.

[no-feature-entry] — server-side reviewer hardening, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)