### PR TITLE
fix: stop plan-gate and PR-critic badges from competing on a card

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -275,6 +275,23 @@ events.subscribe((event, data) => {
       .consider(s, git)
       .catch((err) => console.warn("[review] consider failed:", err));
 });
+
+// When a PR appears for a session that is still in the planning phase, auto-advance it to
+// "executing" so the plan-gate badge unlatches and autopilot stops standing down. This covers
+// the case where the operator reviewed the plan then steered the agent manually (without
+// clicking Go), so the agent wrote code and opened a PR while planPhase was still "planning".
+// PR-present = state !== "none" (open/merged/closed), mirroring autopilot's hasPr non-"none"
+// semantics — using "open"-only would leave a merged/closed-PR planning session latched.
+events.subscribe((event, data) => {
+  if (event !== "session:git") return;
+  const { id, git } = data as { id: string; git: import("./forge/types").GitState };
+  if (git.state === "none") return;
+  const advanced = service.advanceToExecutionOnPr(id);
+  // Only reap the plan reviewer when a real transition happened — avoids redundant
+  // work and log spam on every subsequent poll tick (mirrors how session:archived
+  // gates forget() on the id being present before calling it).
+  if (advanced) planGate.forget(id);
+});
 setInterval(() => {
   if (maintenance.active) return;
   void reviewService.tick();

--- a/src/service.ts
+++ b/src/service.ts
@@ -730,6 +730,16 @@ export class SessionService {
   }
 
   /**
+   * Shared phase→executing transition: flip planPhase to "executing" and push the change live.
+   * Used by both the Go release (releasePlanGate) and the PR auto-advance (advanceToExecutionOnPr).
+   * Callers are responsible for their own guards before calling this.
+   */
+  #enterExecution(id: string): void {
+    this.deps.store.setPlanPhase(id, "executing");
+    this.deps.events?.emit("session:plangate", { id, planPhase: "executing" });
+  }
+
+  /**
    * The "Go" gate: release an APPROVED planning session into autonomous execution. Strict —
    * only transitions when the session is in the planning phase AND its plan gate is approved
    * (the reviewer signed off). Flips planPhase → "executing", steers the agent to implement the
@@ -741,9 +751,31 @@ export class SessionService {
     const s = this.deps.store.get(id);
     if (!s || s.planPhase !== "planning") return false;
     if (!this.deps.store.getPlanGate(id)?.approved) return false;
-    this.deps.store.setPlanPhase(id, "executing");
+    this.#enterExecution(id);
     this.reply(id, PLAN_GO_STEER);
-    this.deps.events?.emit("session:plangate", { id, planPhase: "executing" });
+    return true;
+  }
+
+  /**
+   * Auto-advance a manually-driven (or otherwise un-released) planning session into execution
+   * once a PR appears. When the operator reviews the plan then steers the agent instead of
+   * clicking Go, the agent writes code and opens a PR while planPhase is still "planning" —
+   * leaving the plan-gate badge latched and making autopilot stand down (autopilot.ts eligible()
+   * suppresses planning sessions). This method detects that case: called when a PR is observed
+   * for a still-planning session, it flips planPhase → "executing" so the plan gate yields and
+   * autopilot stops standing down.
+   *
+   * Critically, it does NOT send PLAN_GO_STEER — the agent already executed; steering it to
+   * "implement the approved plan" would be wrong (the plan may not even be approved). Its caller
+   * mirrors autopilot's hasPr non-"none" semantics (open/merged/closed) so the two don't drift.
+   *
+   * Returns true when a real transition occurred (planPhase was "planning" and is now "executing"),
+   * false when the session is unknown or not in the planning phase (idempotent no-op).
+   */
+  advanceToExecutionOnPr(id: string): boolean {
+    const s = this.deps.store.get(id);
+    if (!s || s.planPhase !== "planning") return false;
+    this.#enterExecution(id);
     return true;
   }
 

--- a/test/service-advance-execution.test.ts
+++ b/test/service-advance-execution.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test";
+import { SessionService } from "../src/service";
+
+/** A full-enough Session row for the advance-execution path. */
+function sess(over: Record<string, unknown> = {}) {
+  return {
+    id: "s1",
+    name: "t",
+    prompt: "p",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/t",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t1",
+    planPhase: "planning",
+    ...over,
+  };
+}
+
+/**
+ * Build a SessionService whose store is a hand-rolled stub exposing only get/setPlanPhase,
+ * and a herdr whose pane is "live" (list includes the terminalId). Captures setPlanPhase,
+ * emit, and send calls for assertions.
+ */
+function harness(opts: { session: ReturnType<typeof sess> | null; paneLive?: boolean }) {
+  const setPhaseCalls: { id: string; phase: string }[] = [];
+  const emitted: { event: string; data: unknown }[] = [];
+  const sent: { target: string; text: string }[] = [];
+  const term = opts.session?.herdrAgentId ?? "t1";
+  const store = {
+    get: () => opts.session,
+    setPlanPhase: (id: string, phase: string) => setPhaseCalls.push({ id, phase }),
+    addSignal: () => {},
+  };
+  const svc = new SessionService({
+    store: store as any,
+    namer: async () => "x",
+    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    herdr: {
+      start: () => ({}) as any,
+      list: () => ((opts.paneLive ?? true) ? [{ terminalId: term }] : []),
+      stop: () => {},
+      send: (target: string, text: string) => sent.push({ target, text }),
+    } as any,
+    events: { emit: (event: string, data: unknown) => emitted.push({ event, data }) },
+  });
+  return { svc, setPhaseCalls, emitted, sent };
+}
+
+test("advanceToExecutionOnPr: planning session → returns true, flips phase, emits plangate event", () => {
+  const h = harness({ session: sess() });
+  expect(h.svc.advanceToExecutionOnPr("s1")).toBe(true);
+  expect(h.setPhaseCalls).toEqual([{ id: "s1", phase: "executing" }]);
+  expect(h.emitted).toContainEqual({
+    event: "session:plangate",
+    data: { id: "s1", planPhase: "executing" },
+  });
+});
+
+test("advanceToExecutionOnPr: does NOT send PLAN_GO_STEER (agent already executed)", () => {
+  const h = harness({ session: sess(), paneLive: true });
+  h.svc.advanceToExecutionOnPr("s1");
+  // No steer must be sent — the agent already executed and a Go steer would be wrong
+  expect(h.sent).toHaveLength(0);
+});
+
+test("advanceToExecutionOnPr: session already executing → returns false, no phase change, no event", () => {
+  const h = harness({ session: sess({ planPhase: "executing" }) });
+  expect(h.svc.advanceToExecutionOnPr("s1")).toBe(false);
+  expect(h.setPhaseCalls).toHaveLength(0);
+  expect(h.emitted).toHaveLength(0);
+  expect(h.sent).toHaveLength(0);
+});
+
+test("advanceToExecutionOnPr: planPhase null → returns false, no phase change, no event", () => {
+  const h = harness({ session: sess({ planPhase: null }) });
+  expect(h.svc.advanceToExecutionOnPr("s1")).toBe(false);
+  expect(h.setPhaseCalls).toHaveLength(0);
+  expect(h.emitted).toHaveLength(0);
+  expect(h.sent).toHaveLength(0);
+});
+
+test("advanceToExecutionOnPr: unknown id → returns false, no phase change, no event", () => {
+  const h = harness({ session: null });
+  expect(h.svc.advanceToExecutionOnPr("ghost")).toBe(false);
+  expect(h.setPhaseCalls).toHaveLength(0);
+  expect(h.emitted).toHaveLength(0);
+  expect(h.sent).toHaveLength(0);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -429,7 +429,7 @@
   "newtask_plan_gate_hint": "Plan vor dem Agentenlauf prüfen + kontradiktorisch hinterfragen",
   "plangate_planning": "PLANUNG",
   "plangate_reviewing": "PRÜFUNG…",
-  "plangate_changes": "ÄNDERUNGEN · {round}/{cap}",
+  "plangate_changes": "REWORK · {round}/{cap}",
   "plangate_ready": "BEREIT ✓",
   "plangate_error": "PRÜFFEHLER",
   "plangate_title": "Plan-Gate vor der Ausführung",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -429,7 +429,7 @@
   "newtask_plan_gate_hint": "Grill + adversarial plan review before the agent runs",
   "plangate_planning": "PLANNING",
   "plangate_reviewing": "REVIEWING…",
-  "plangate_changes": "CHANGES · {round}/{cap}",
+  "plangate_changes": "REWORK · {round}/{cap}",
   "plangate_ready": "READY ✓",
   "plangate_error": "REVIEW ERR",
   "plangate_title": "Pre-execution plan gate",

--- a/ui/src/lib/components/CriticBadge.browser.test.ts
+++ b/ui/src/lib/components/CriticBadge.browser.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { ReviewVerdict } from "$lib/types";
+
+// Mock api so the reviews store's load() never fires real network calls.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return { ...actual, getReviews: vi.fn(async () => ({})), getReviewingIds: vi.fn(async () => []) };
+});
+
+const { default: CriticBadge } = await import("./CriticBadge.svelte");
+const { reviews } = await import("$lib/reviews.svelte");
+
+const NOW = 2_000_000;
+
+const base: ReviewVerdict = {
+  sessionId: "s1",
+  headSha: "abc",
+  decision: "changes_requested",
+  summary: "",
+  body: "## findings",
+  findings: ["x"],
+  addressRound: 0,
+  addressCap: 5,
+  finalRoundPending: false,
+  finalRoundTimeoutMs: 900_000,
+  updatedAt: NOW - 60_000,
+};
+const v = (p: Partial<ReviewVerdict>): ReviewVerdict => ({ ...base, ...p });
+
+beforeEach(() => {
+  // reset store between tests
+  reviews.map = {};
+  reviews.reviewing = {};
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("CriticBadge composite badge", () => {
+  it("verdict + in-progress round → single badge containing both verdict and round suffix", async () => {
+    reviews.map = { s1: v({ addressRound: 1 }) };
+    render(CriticBadge, { sessionId: "s1" });
+
+    const badges = document.querySelectorAll(".critic-badge");
+    expect(badges.length, "exactly one .critic-badge").toBe(1);
+
+    // verdict text present
+    await expect.element(page.getByText(/CHANGES/)).toBeInTheDocument();
+    // round suffix present — m.criticbadge_round with round=1, cap=5 → "↻ 1/5"
+    await expect.element(page.getByText(/1\/5/)).toBeInTheDocument();
+  });
+
+  it("verdict with no address round → single badge, no suffix", async () => {
+    reviews.map = { s1: v({ addressRound: 0 }) };
+    render(CriticBadge, { sessionId: "s1" });
+
+    const badges = document.querySelectorAll(".critic-badge");
+    expect(badges.length, "exactly one .critic-badge").toBe(1);
+
+    await expect.element(page.getByText(/CHANGES/)).toBeInTheDocument();
+    // no round fraction visible
+    expect(document.querySelector(".addr")).toBeNull();
+  });
+
+  it("no verdict and no round → nothing rendered", async () => {
+    render(CriticBadge, { sessionId: "s1" });
+    const badges = document.querySelectorAll(".critic-badge");
+    expect(badges.length, "no badge when nothing to show").toBe(0);
+  });
+
+  it("reviewing state + round → single reviewing badge with round suffix", async () => {
+    reviews.map = { s1: v({ addressRound: 2 }) };
+    reviews.reviewing = { s1: true };
+    render(CriticBadge, { sessionId: "s1" });
+
+    const badges = document.querySelectorAll(".critic-badge");
+    expect(badges.length, "exactly one .critic-badge while reviewing").toBe(1);
+
+    await expect.element(page.getByText(/REVIEWING/)).toBeInTheDocument();
+    await expect.element(page.getByText(/2\/5/)).toBeInTheDocument();
+  });
+
+  it("commented verdict + stalled round → single composite badge", async () => {
+    // addressRound at cap, not pending → stalled status; decision "commented" → "REVIEWED" label.
+    // Both should appear in one composite .critic-badge, not two separate elements.
+    reviews.map = {
+      s1: v({
+        decision: "commented",
+        addressRound: 5,
+        addressCap: 5,
+        finalRoundPending: false,
+        findings: ["x"],
+      }),
+    };
+    render(CriticBadge, { sessionId: "s1" });
+
+    const badges = document.querySelectorAll(".critic-badge");
+    expect(badges.length, "exactly one .critic-badge for stalled").toBe(1);
+
+    await expect.element(page.getByText(/REVIEWED/)).toBeInTheDocument();
+    await expect.element(page.getByText(/STALLED/)).toBeInTheDocument();
+  });
+
+  it("verdict + final round → single composite badge with addr-final suffix", async () => {
+    // addressRound === addressCap, findings present, finalRoundPending true, updatedAt recent
+    // → addressRoundInfo returns status "final" (dim).
+    reviews.map = {
+      s1: v({
+        addressRound: 5,
+        addressCap: 5,
+        finalRoundPending: true,
+        findings: ["x"],
+        updatedAt: Date.now() - 1_000, // recent; well within finalRoundTimeoutMs (900_000)
+      }),
+    };
+    render(CriticBadge, { sessionId: "s1" });
+
+    const badges = document.querySelectorAll(".critic-badge");
+    expect(badges.length, "exactly one .critic-badge for final").toBe(1);
+
+    // verdict text present
+    await expect.element(page.getByText(/CHANGES/)).toBeInTheDocument();
+    // final suffix present — m.criticbadge_final with round=5, cap=5
+    await expect.element(page.getByText(/FINAL/)).toBeInTheDocument();
+    // suffix carries the dim class
+    const suffix = document.querySelector(".addr");
+    expect(suffix, "addr suffix rendered").not.toBeNull();
+    expect(suffix!.classList.contains("addr-final"), "addr-final class present").toBe(true);
+  });
+});

--- a/ui/src/lib/components/CriticBadge.svelte
+++ b/ui/src/lib/components/CriticBadge.svelte
@@ -11,34 +11,34 @@
   const round = $derived(addressRoundInfo(verdict, clock.current));
 </script>
 
+{#snippet addrSuffix(r: NonNullable<typeof round>)}
+  <span
+    class="addr addr-{r.status}"
+    title={r.status === "stalled"
+      ? m.criticbadge_stalled_title({ cap: r.cap })
+      : r.status === "final"
+        ? m.criticbadge_final_title()
+        : m.criticbadge_round_title({ round: r.round, cap: r.cap })}
+  >
+    · {r.status === "stalled"
+      ? m.criticbadge_stalled({ round: r.round, cap: r.cap })
+      : r.status === "final"
+        ? m.criticbadge_final({ round: r.round, cap: r.cap })
+        : m.criticbadge_round({ round: r.round, cap: r.cap })}</span
+  >
+{/snippet}
+
 {#if chip.kind === "reviewing"}
   <span class="critic-badge critic-reviewing" title={m.criticbadge_reviewing_title()}>
-    <span class="rev-dot" aria-hidden="true"></span>{m.criticbadge_reviewing()}
+    <span class="rev-dot" aria-hidden="true"
+    ></span>{m.criticbadge_reviewing()}{#if round}{@render addrSuffix(round)}{/if}
   </span>
 {:else if chip.kind === "verdict"}
   <span
     class="critic-badge critic-{chip.decision}"
-    title={verdict!.summary || m.criticbadge_title()}>{chip.label}</span
+    title={verdict!.summary || m.criticbadge_title()}
+    >{chip.label}{#if round}{@render addrSuffix(round)}{/if}</span
   >
-{/if}
-{#if round}
-  {#if round.status === "stalled"}
-    <span
-      class="critic-badge critic-stalled"
-      title={m.criticbadge_stalled_title({ cap: round.cap })}
-      >{m.criticbadge_stalled({ round: round.round, cap: round.cap })}</span
-    >
-  {:else if round.status === "final"}
-    <span class="critic-badge critic-final" title={m.criticbadge_final_title()}
-      >{m.criticbadge_final({ round: round.round, cap: round.cap })}</span
-    >
-  {:else}
-    <span
-      class="critic-badge critic-round"
-      title={m.criticbadge_round_title({ round: round.round, cap: round.cap })}
-      >{m.criticbadge_round({ round: round.round, cap: round.cap })}</span
-    >
-  {/if}
 {/if}
 
 <style>
@@ -58,23 +58,6 @@
   }
   .critic-commented {
     color: var(--color-blue);
-  }
-  /* auto-address streak in progress: agent is fixing the findings */
-  .critic-round {
-    border-color: var(--color-blue);
-    color: var(--color-blue);
-  }
-  /* final allowed round in flight: agent is addressing it — recessive vs. both the
-     blue in-progress rounds and the orange confirmed stall. */
-  .critic-final {
-    border-color: var(--color-line);
-    color: var(--color-faint);
-  }
-  /* auto-address gave up at the cap — needs a human */
-  .critic-stalled {
-    border-color: var(--color-amber);
-    color: var(--color-amber);
-    font-weight: 600;
   }
   .critic-error {
     color: var(--color-faint);
@@ -103,5 +86,18 @@
     50% {
       opacity: 1;
     }
+  }
+  /* auto-address suffix inside a composite badge */
+  .addr-round {
+    color: var(--color-blue);
+  }
+  /* final allowed round in flight: recessive vs. the blue in-progress and orange stalled */
+  .addr-final {
+    color: var(--color-faint);
+  }
+  /* auto-address gave up at the cap — needs a human */
+  .addr-stalled {
+    color: var(--color-amber);
+    font-weight: 600;
   }
 </style>

--- a/ui/src/lib/components/PlanGateBadge.test.ts
+++ b/ui/src/lib/components/PlanGateBadge.test.ts
@@ -27,6 +27,14 @@ describe("planGateChip", () => {
     expect(planGateChip(sess("executing"), gate({ approved: true }), false).kind).toBe("none");
   });
 
+  it("hides when executing even if changes_requested verdict still in gate cache (reconnect scenario)", () => {
+    // Simulates a client that reconnected after planPhase flipped to "executing":
+    // the gate cache is repopulated with a stale changes_requested verdict, but
+    // planPhase is persisted as "executing" — the badge must still be hidden.
+    const staleGate = gate({ decision: "changes_requested", round: 2, cap: 3, approved: false });
+    expect(planGateChip(sess("executing"), staleGate, false)).toEqual({ kind: "none" });
+  });
+
   it("reviewing wins over a stale verdict", () => {
     const chip = planGateChip(sess("planning"), gate({ approved: true }), true);
     expect(chip.kind).toBe("reviewing");

--- a/ui/src/lib/components/critic-badge.ts
+++ b/ui/src/lib/components/critic-badge.ts
@@ -22,7 +22,8 @@ export function criticBadgeLabel(v: ReviewVerdict | undefined): string | null {
  *                 so a consumer can keep the findings popover reachable during re-review.
  *  - "verdict":   not reviewing; show the verdict badge/label.
  *  - "none":      nothing to show.
- * The auto-address streak badges (addressRoundInfo) are independent and render alongside.
+ * The auto-address streak info (addressRoundInfo) renders as an inline suffix inside the same
+ * badge element via CriticBadge.svelte; the selector still returns it independently.
  */
 export type CriticChip =
   | { kind: "reviewing"; hasFindings: boolean }


### PR DESCRIPTION
## Problem

A session card could render **plan-gate** and **PR-critic** review badges at the same time — `CHANGES · 5/5` (plan gate) competing with `⚠ CHANGES` + `↻ 1/5` (PR critic). Root cause: `planPhase` only advanced `planning → executing` through the formal **"Go" release** (`releasePlanGate`). If an operator reviewed the plan and then drove the agent **manually** instead of clicking Go, the agent opened a PR while `planPhase` was still `"planning"` — so the plan-gate badge stayed latched competing with the live PR critic, and **autopilot wrongly stood down** (it suppresses on `planPhase === "planning"`) on a session that was actually executing.

## Fix (mutually exclusive by phase)

1. **Server — advance phase on PR (root cause).** New `SessionService.advanceToExecutionOnPr(id)` flips a still-`planning` session to `executing` when a PR appears. Triggered from a **dedicated `session:git` subscriber** (decoupled from autopilot wiring), with PR-presence mirroring autopilot's `hasPr` (`state !== "none"` — open/merged/closed, **not** `open`-only, which would leave merged/closed-PR sessions latched). Shared `setPlanPhase + emit` core factored into a private `#enterExecution` helper reused by `releasePlanGate`. **No plan-go steer** is sent (the agent already executed). On a real transition it reaps the stale plan gate (`planGate.forget`). This also frees autopilot.
2. **UI — relabel.** Plan-gate "changes" badge: `CHANGES · {round}/{cap}` → **`REWORK · {round}/{cap}`** (EN+DE), so it never reads identically to the critic's `⚠ CHANGES`.
3. **UI — collapse the critic family.** Verdict + auto-address round now render as **one** composite `.critic-badge` (verdict word + inline `· {round}/{cap}` suffix) instead of two sibling badges. Both signals preserved via color (verdict amber; suffix blue/dim/amber for round/final/stalled). Reuses existing i18n keys.

The plan-gate badge hides via the **persisted** `planPhase === "executing"` short-circuit in `planGateChip`, so the hide survives a refetch/reconnect — not dependent on clearing the client gate cache (a regression test pins this).

## Testing

- Root: `bun run lint` clean · `bunx tsc --noEmit` clean · `bun test ./test` → 1314 pass / 1 skip / 0 fail (new `test/service-advance-execution.test.ts`).
- UI: `bun run check` (svelte-check + i18n parity) 0 errors · vitest 586 pass (new `CriticBadge.browser.test.ts` for the composite badge incl. round/final/stalled; `PlanGateBadge.test.ts` reconnect-hide regression).
- `bunx fallow audit --base origin/main` clean (no new dead code / complexity).

## Residual risk

- **No realistic co-render window:** the critic verdict only exists once a PR is `open`, and the phase flip fires on the *same synchronous* `session:git` emit, before the async critic review begins — so the plan-gate badge is suppressed before any critic badge can appear. Brief pre-flip moments show *only* the plan-gate badge (never both); PR-poll cadence latency here is pre-existing.
- **Visual:** the composite badge layout is asserted structurally (one `.critic-badge`, correct text + `.addr-*` class) and uses design-system tokens only (no raw hex), but rendered appearance/spacing was not eyeballed.
