### PR TITLE
fix(plan-gate): give 'Review plan now' visible feedback

### DIFF
--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -151,12 +151,15 @@ export class PlanGateService {
     return createHash("sha256").update(plan).digest("hex");
   }
 
-  /** Decide whether `session`'s current plan warrants a fresh adversarial review, and start one. */
-  async consider(session: Session): Promise<void> {
-    if (session.planPhase !== "planning") return; // only gate before execution
-    if (this.inflight.has(session.id) || this.starting.has(session.id)) return; // in flight / mid-spawn
+  /** Decide whether `session`'s current plan warrants a fresh adversarial review, and start one.
+   *  Returns `true` iff a reviewer was actually spawned — `false` for every no-op (not planning,
+   *  in flight, no/unchanged plan, already approved). The on-demand "Review plan now" route relays
+   *  this so the UI can tell a real review from a silent dedupe instead of just blinking the button. */
+  async consider(session: Session): Promise<boolean> {
+    if (session.planPhase !== "planning") return false; // only gate before execution
+    if (this.inflight.has(session.id) || this.starting.has(session.id)) return false; // in flight / mid-spawn
     const plan = (this.readPlan(session.worktreePath) ?? "").trim();
-    if (!plan) return; // no plan written yet → nothing to review
+    if (!plan) return false; // no plan written yet → nothing to review
     // Claim the slot SYNCHRONOUSLY, before any await — hashPlan is async, so two concurrent
     // considers would otherwise both clear the guards above and double-spawn (orphaning the
     // first run's worktree + terminal). With the claim here, the second bails on the guard.
@@ -164,12 +167,12 @@ export class PlanGateService {
     try {
       const planHash = await PlanGateService.hashPlan(plan);
       const prior = this.deps.store.getPlanGate(session.id);
-      if (prior?.approved) return; // already cleared → execution allowed, don't re-review
+      if (prior?.approved) return false; // already cleared → execution allowed, don't re-review
       // Dedupe an unchanged plan — but NEVER skip past an `error` verdict. A timeout/unparseable
       // run produced no real verdict, so re-running it (e.g. via the "Review plan now" button) must
       // retry rather than no-op on the stale error. Mirrors review.ts rebaseSkip's error carve-out.
-      if (prior?.planHash === planHash && prior.decision !== "error") return;
-      await this.begin(session, plan, planHash, prior);
+      if (prior?.planHash === planHash && prior.decision !== "error") return false;
+      return await this.begin(session, plan, planHash, prior);
     } finally {
       this.starting.delete(session.id);
     }
@@ -180,7 +183,7 @@ export class PlanGateService {
     plan: string,
     planHash: string,
     prior: PlanGate | null,
-  ): Promise<void> {
+  ): Promise<boolean> {
     // Resolve the base SHA so the reviewer inspects a CLEAN copy of the codebase at the base
     // branch — never the live worktree (the planning agent is still editing it). baseSha's
     // default catches internally and falls back to the base ref / name, so this won't throw.
@@ -196,7 +199,7 @@ export class PlanGateService {
       wt = this.deps.worktree.createDetached(session.repoPath, session.baseBranch, sha, session.id);
     } catch (err) {
       console.warn(`[plan-gate] worktree failed for ${session.id}:`, err);
-      return;
+      return false;
     }
 
     const prompt = planReviewPrompt(session.prompt, plan, prior?.findings ?? []);
@@ -211,7 +214,7 @@ export class PlanGateService {
     } catch (err) {
       console.warn(`[plan-gate] spawn failed for ${session.id}:`, err);
       this.deps.worktree.remove(wt.worktreePath);
-      return;
+      return false;
     }
     this.inflight.set(session.id, {
       sessionId: session.id,
@@ -224,6 +227,7 @@ export class PlanGateService {
       startedAt: this.now(),
     });
     this.deps.onReviewing?.(session.id, true);
+    return true;
   }
 
   /** Finalize any in-flight plan review whose verdict file is ready or that timed out. */

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -9,6 +9,11 @@ import type { Session, PlanGate, PlanDecision } from "./types";
 import { readonlyReviewerArgv } from "./reviewer-argv";
 import { effectiveAutopilot } from "./effective-autopilot";
 
+/** Outcome of an on-demand `consider()`: a reviewer actually spawned, the request was a no-op
+ *  (plan unchanged / already approved / nothing to review), or a spawn attempt failed. The
+ *  review-plan route relays this so the UI can distinguish a silent dedupe from a real error. */
+export type PlanReviewTrigger = "started" | "skipped" | "error";
+
 /** The plan the planning agent writes in its LIVE session worktree; the reviewer reads its text. */
 const PLAN_FILE = ".shepherd-plan.md";
 
@@ -152,14 +157,15 @@ export class PlanGateService {
   }
 
   /** Decide whether `session`'s current plan warrants a fresh adversarial review, and start one.
-   *  Returns `true` iff a reviewer was actually spawned — `false` for every no-op (not planning,
-   *  in flight, no/unchanged plan, already approved). The on-demand "Review plan now" route relays
-   *  this so the UI can tell a real review from a silent dedupe instead of just blinking the button. */
-  async consider(session: Session): Promise<boolean> {
-    if (session.planPhase !== "planning") return false; // only gate before execution
-    if (this.inflight.has(session.id) || this.starting.has(session.id)) return false; // in flight / mid-spawn
+   *  Returns `"started"` iff a reviewer actually spawned, `"skipped"` for a no-op (not planning,
+   *  in flight, no/unchanged plan, already approved), or `"error"` if a spawn was attempted but
+   *  failed. The on-demand "Review plan now" route relays this so the UI can tell a real review
+   *  from a silent dedupe — and a genuine failure from either — instead of just blinking the button. */
+  async consider(session: Session): Promise<PlanReviewTrigger> {
+    if (session.planPhase !== "planning") return "skipped"; // only gate before execution
+    if (this.inflight.has(session.id) || this.starting.has(session.id)) return "skipped"; // in flight / mid-spawn
     const plan = (this.readPlan(session.worktreePath) ?? "").trim();
-    if (!plan) return false; // no plan written yet → nothing to review
+    if (!plan) return "skipped"; // no plan written yet → nothing to review
     // Claim the slot SYNCHRONOUSLY, before any await — hashPlan is async, so two concurrent
     // considers would otherwise both clear the guards above and double-spawn (orphaning the
     // first run's worktree + terminal). With the claim here, the second bails on the guard.
@@ -167,11 +173,11 @@ export class PlanGateService {
     try {
       const planHash = await PlanGateService.hashPlan(plan);
       const prior = this.deps.store.getPlanGate(session.id);
-      if (prior?.approved) return false; // already cleared → execution allowed, don't re-review
+      if (prior?.approved) return "skipped"; // already cleared → execution allowed, don't re-review
       // Dedupe an unchanged plan — but NEVER skip past an `error` verdict. A timeout/unparseable
       // run produced no real verdict, so re-running it (e.g. via the "Review plan now" button) must
       // retry rather than no-op on the stale error. Mirrors review.ts rebaseSkip's error carve-out.
-      if (prior?.planHash === planHash && prior.decision !== "error") return false;
+      if (prior?.planHash === planHash && prior.decision !== "error") return "skipped";
       return await this.begin(session, plan, planHash, prior);
     } finally {
       this.starting.delete(session.id);
@@ -183,7 +189,7 @@ export class PlanGateService {
     plan: string,
     planHash: string,
     prior: PlanGate | null,
-  ): Promise<boolean> {
+  ): Promise<PlanReviewTrigger> {
     // Resolve the base SHA so the reviewer inspects a CLEAN copy of the codebase at the base
     // branch — never the live worktree (the planning agent is still editing it). baseSha's
     // default catches internally and falls back to the base ref / name, so this won't throw.
@@ -199,7 +205,7 @@ export class PlanGateService {
       wt = this.deps.worktree.createDetached(session.repoPath, session.baseBranch, sha, session.id);
     } catch (err) {
       console.warn(`[plan-gate] worktree failed for ${session.id}:`, err);
-      return false;
+      return "error";
     }
 
     const prompt = planReviewPrompt(session.prompt, plan, prior?.findings ?? []);
@@ -214,7 +220,7 @@ export class PlanGateService {
     } catch (err) {
       console.warn(`[plan-gate] spawn failed for ${session.id}:`, err);
       this.deps.worktree.remove(wt.worktreePath);
-      return false;
+      return "error";
     }
     this.inflight.set(session.id, {
       sessionId: session.id,
@@ -227,7 +233,7 @@ export class PlanGateService {
       startedAt: this.now(),
     });
     this.deps.onReviewing?.(session.id, true);
-    return true;
+    return "started";
   }
 
   /** Finalize any in-flight plan review whose verdict file is ready or that timed out. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -125,7 +125,7 @@ export interface AppDeps {
   /** Trigger an adversarial plan review for a session on demand (the /review-plan route).
    *  Wired to PlanGateService.consider in index.ts; absent in tests that don't exercise it. */
   planGate?: {
-    consider(session: Session): Promise<void>;
+    consider(session: Session): Promise<boolean>;
   };
   /** Backlog counts service; absent in tests that don't exercise it. */
   backlog?: Pick<CountsService, "counts">;
@@ -821,12 +821,14 @@ function handleSessionGo({ req, parts, deps }: Ctx): Response | null {
 
 // POST /api/sessions/:id/review-plan — trigger an on-demand adversarial plan review.
 // 404 for an unknown id; 202 once the review is kicked off (consider() is fire-and-go).
+// `started` tells the caller whether a reviewer actually spawned or the plan was a silent
+// no-op (unchanged / already approved), so the UI can explain why nothing changed.
 async function handleSessionReviewPlan({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "POST" && parts[2] && parts[3] === "review-plan")) return null;
   const s = deps.store.get(parts[2]);
   if (!s) return json({ error: "not found" }, 404);
-  await deps.planGate?.consider(s);
-  return json({ ok: true }, 202);
+  const started = (await deps.planGate?.consider(s)) ?? false;
+  return json({ ok: true, started }, 202);
 }
 
 // Validate the rename body, returning the typed name or the error Response to send.

--- a/src/server.ts
+++ b/src/server.ts
@@ -125,7 +125,7 @@ export interface AppDeps {
   /** Trigger an adversarial plan review for a session on demand (the /review-plan route).
    *  Wired to PlanGateService.consider in index.ts; absent in tests that don't exercise it. */
   planGate?: {
-    consider(session: Session): Promise<boolean>;
+    consider(session: Session): Promise<import("./plan-gate").PlanReviewTrigger>;
   };
   /** Backlog counts service; absent in tests that don't exercise it. */
   backlog?: Pick<CountsService, "counts">;
@@ -821,14 +821,15 @@ function handleSessionGo({ req, parts, deps }: Ctx): Response | null {
 
 // POST /api/sessions/:id/review-plan — trigger an on-demand adversarial plan review.
 // 404 for an unknown id; 202 once the review is kicked off (consider() is fire-and-go).
-// `started` tells the caller whether a reviewer actually spawned or the plan was a silent
-// no-op (unchanged / already approved), so the UI can explain why nothing changed.
+// `status` tells the caller whether a reviewer actually spawned ("started"), the plan was a
+// silent no-op ("skipped" — unchanged / already approved), or a spawn attempt failed ("error"),
+// so the UI can explain why nothing changed without mislabelling a failure as an unchanged plan.
 async function handleSessionReviewPlan({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "POST" && parts[2] && parts[3] === "review-plan")) return null;
   const s = deps.store.get(parts[2]);
   if (!s) return json({ error: "not found" }, 404);
-  const started = (await deps.planGate?.consider(s)) ?? false;
-  return json({ ok: true, started }, 202);
+  const status = (await deps.planGate?.consider(s)) ?? "skipped";
+  return json({ ok: true, status }, 202);
 }
 
 // Validate the rename body, returning the typed name or the error Response to send.

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -60,35 +60,35 @@ const planningSession = () => ({
 
 test("consider spawns reviewer when a plan exists and is unreviewed", async () => {
   const h = harness();
-  const started = await h.svc.consider(planningSession() as any);
-  expect(started).toBe(true); // relayed to the on-demand route as { started: true }
+  const status = await h.svc.consider(planningSession() as any);
+  expect(status).toBe("started"); // relayed to the on-demand route as { status: "started" }
   expect(h.started.length).toBe(1);
   expect(h.started[0].argv[h.started[0].argv.length - 1]).toContain("PLAN TEXT");
   expect(h.svc.reviewingIds()).toEqual(["s1"]);
 });
 test("consider no-ops when plan missing/empty", async () => {
   const h = harness({ readPlan: () => null });
-  const started = await h.svc.consider(planningSession() as any);
-  expect(started).toBe(false);
+  const status = await h.svc.consider(planningSession() as any);
+  expect(status).toBe("skipped");
   expect(h.started.length).toBe(0);
 });
 test("consider no-ops when session is not in planning phase", async () => {
   const h = harness();
-  const started = await h.svc.consider({ ...planningSession(), planPhase: "executing" } as any);
-  expect(started).toBe(false);
+  const status = await h.svc.consider({ ...planningSession(), planPhase: "executing" } as any);
+  expect(status).toBe("skipped");
   expect(h.started.length).toBe(0);
 });
 test("consider dedupes an unchanged plan hash", async () => {
   const hash = await PlanGateService.hashPlan("PLAN TEXT");
   const h = harness({ store: { getPlanGate: () => ({ planHash: hash, approved: false }) } });
-  const started = await h.svc.consider(planningSession() as any);
-  expect(started).toBe(false); // the route reports started:false so the UI explains the no-op
+  const status = await h.svc.consider(planningSession() as any);
+  expect(status).toBe("skipped"); // route reports "skipped" so the UI explains the no-op
   expect(h.started.length).toBe(0);
 });
 test("consider no-ops when already approved", async () => {
   const h = harness({ store: { getPlanGate: () => ({ planHash: "other", approved: true }) } });
-  const started = await h.svc.consider(planningSession() as any);
-  expect(started).toBe(false);
+  const status = await h.svc.consider(planningSession() as any);
+  expect(status).toBe("skipped");
   expect(h.started.length).toBe(0);
 });
 test("consider re-reviews an error verdict even when the plan hash is unchanged", async () => {
@@ -96,9 +96,23 @@ test("consider re-reviews an error verdict even when the plan hash is unchanged"
   const h = harness({
     store: { getPlanGate: () => ({ planHash: hash, approved: false, decision: "error" }) },
   });
-  const started = await h.svc.consider(planningSession() as any);
-  expect(started).toBe(true);
+  const status = await h.svc.consider(planningSession() as any);
+  expect(status).toBe("started");
   expect(h.started.length).toBe(1); // an error verdict is retried, not deduped away
+});
+test("consider reports 'error' (not a dedupe) when the reviewer fails to spawn", async () => {
+  const h = harness({
+    herdr: {
+      start: () => {
+        throw new Error("spawn boom");
+      },
+      stop() {},
+    },
+  });
+  const status = await h.svc.consider(planningSession() as any);
+  expect(status).toBe("error"); // UI shows a failure note, not "plan unchanged"
+  expect(h.started.length).toBe(0);
+  expect(h.removed).toEqual(["/wt-detached"]); // the detached worktree is reaped on failure
 });
 test("consider won't double-spawn while one is in flight", async () => {
   const h = harness();

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -60,30 +60,35 @@ const planningSession = () => ({
 
 test("consider spawns reviewer when a plan exists and is unreviewed", async () => {
   const h = harness();
-  await h.svc.consider(planningSession() as any);
+  const started = await h.svc.consider(planningSession() as any);
+  expect(started).toBe(true); // relayed to the on-demand route as { started: true }
   expect(h.started.length).toBe(1);
   expect(h.started[0].argv[h.started[0].argv.length - 1]).toContain("PLAN TEXT");
   expect(h.svc.reviewingIds()).toEqual(["s1"]);
 });
 test("consider no-ops when plan missing/empty", async () => {
   const h = harness({ readPlan: () => null });
-  await h.svc.consider(planningSession() as any);
+  const started = await h.svc.consider(planningSession() as any);
+  expect(started).toBe(false);
   expect(h.started.length).toBe(0);
 });
 test("consider no-ops when session is not in planning phase", async () => {
   const h = harness();
-  await h.svc.consider({ ...planningSession(), planPhase: "executing" } as any);
+  const started = await h.svc.consider({ ...planningSession(), planPhase: "executing" } as any);
+  expect(started).toBe(false);
   expect(h.started.length).toBe(0);
 });
 test("consider dedupes an unchanged plan hash", async () => {
   const hash = await PlanGateService.hashPlan("PLAN TEXT");
   const h = harness({ store: { getPlanGate: () => ({ planHash: hash, approved: false }) } });
-  await h.svc.consider(planningSession() as any);
+  const started = await h.svc.consider(planningSession() as any);
+  expect(started).toBe(false); // the route reports started:false so the UI explains the no-op
   expect(h.started.length).toBe(0);
 });
 test("consider no-ops when already approved", async () => {
   const h = harness({ store: { getPlanGate: () => ({ planHash: "other", approved: true }) } });
-  await h.svc.consider(planningSession() as any);
+  const started = await h.svc.consider(planningSession() as any);
+  expect(started).toBe(false);
   expect(h.started.length).toBe(0);
 });
 test("consider re-reviews an error verdict even when the plan hash is unchanged", async () => {
@@ -91,7 +96,8 @@ test("consider re-reviews an error verdict even when the plan hash is unchanged"
   const h = harness({
     store: { getPlanGate: () => ({ planHash: hash, approved: false, decision: "error" }) },
   });
-  await h.svc.consider(planningSession() as any);
+  const started = await h.svc.consider(planningSession() as any);
+  expect(started).toBe(true);
   expect(h.started.length).toBe(1); // an error verdict is retried, not deduped away
 });
 test("consider won't double-spawn while one is in flight", async () => {

--- a/test/server-plan-gate.test.ts
+++ b/test/server-plan-gate.test.ts
@@ -108,13 +108,13 @@ test("POST /api/sessions/:id/go → 409 when releasePlanGate returns false", asy
 
 // ── POST /api/sessions/:id/review-plan ──────────────────────────────────────
 
-test("POST /api/sessions/:id/review-plan → 202, calls consider, relays started:true", async () => {
+test("POST /api/sessions/:id/review-plan → 202, calls consider, relays status:started", async () => {
   const considered: Session[] = [];
   const { app, store } = harness({
     planGate: {
       consider: async (s: Session) => {
         considered.push(s);
-        return true; // a reviewer was spawned
+        return "started" as const; // a reviewer was spawned
       },
     },
   });
@@ -137,15 +137,15 @@ test("POST /api/sessions/:id/review-plan → 202, calls consider, relays started
     new Request(`http://x/api/sessions/${id}/review-plan`, { method: "POST" }),
   );
   expect(res.status).toBe(202);
-  expect(await res.json()).toEqual({ ok: true, started: true });
+  expect(await res.json()).toEqual({ ok: true, status: "started" });
   expect(considered.length).toBe(1);
   expect(considered[0]!.id).toBe(id);
 });
 
-test("POST /api/sessions/:id/review-plan → started:false when consider deduped", async () => {
+test("POST /api/sessions/:id/review-plan → status:skipped when consider deduped", async () => {
   const { app, store } = harness({
     planGate: {
-      consider: async () => false, // unchanged plan / already approved → no-op
+      consider: async () => "skipped" as const, // unchanged plan / already approved → no-op
     },
   });
   const seeded = store.create({
@@ -165,7 +165,7 @@ test("POST /api/sessions/:id/review-plan → started:false when consider deduped
     new Request(`http://x/api/sessions/${seeded.id}/review-plan`, { method: "POST" }),
   );
   expect(res.status).toBe(202);
-  expect(await res.json()).toEqual({ ok: true, started: false });
+  expect(await res.json()).toEqual({ ok: true, status: "skipped" });
 });
 
 test("POST /api/sessions/:id/review-plan → 404 for unknown id", async () => {
@@ -174,7 +174,7 @@ test("POST /api/sessions/:id/review-plan → 404 for unknown id", async () => {
     planGate: {
       consider: async () => {
         called = true;
-        return true;
+        return "started" as const;
       },
     },
   });

--- a/test/server-plan-gate.test.ts
+++ b/test/server-plan-gate.test.ts
@@ -108,12 +108,13 @@ test("POST /api/sessions/:id/go → 409 when releasePlanGate returns false", asy
 
 // ── POST /api/sessions/:id/review-plan ──────────────────────────────────────
 
-test("POST /api/sessions/:id/review-plan → 202 and calls planGate.consider", async () => {
+test("POST /api/sessions/:id/review-plan → 202, calls consider, relays started:true", async () => {
   const considered: Session[] = [];
   const { app, store } = harness({
     planGate: {
       consider: async (s: Session) => {
         considered.push(s);
+        return true; // a reviewer was spawned
       },
     },
   });
@@ -136,9 +137,35 @@ test("POST /api/sessions/:id/review-plan → 202 and calls planGate.consider", a
     new Request(`http://x/api/sessions/${id}/review-plan`, { method: "POST" }),
   );
   expect(res.status).toBe(202);
-  expect(await res.json()).toEqual({ ok: true });
+  expect(await res.json()).toEqual({ ok: true, started: true });
   expect(considered.length).toBe(1);
   expect(considered[0]!.id).toBe(id);
+});
+
+test("POST /api/sessions/:id/review-plan → started:false when consider deduped", async () => {
+  const { app, store } = harness({
+    planGate: {
+      consider: async () => false, // unchanged plan / already approved → no-op
+    },
+  });
+  const seeded = store.create({
+    name: "y",
+    prompt: "go",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/y",
+    worktreePath: join(repoDir, "wt2"),
+    isolated: true,
+    herdrSession: "sess-y",
+    herdrAgentId: "term_y",
+    claudeSessionId: "claude-y",
+    model: null,
+  });
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${seeded.id}/review-plan`, { method: "POST" }),
+  );
+  expect(res.status).toBe(202);
+  expect(await res.json()).toEqual({ ok: true, started: false });
 });
 
 test("POST /api/sessions/:id/review-plan → 404 for unknown id", async () => {
@@ -147,6 +174,7 @@ test("POST /api/sessions/:id/review-plan → 404 for unknown id", async () => {
     planGate: {
       consider: async () => {
         called = true;
+        return true;
       },
     },
   });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -451,6 +451,7 @@
   "planpanel_review_now": "Plan jetzt prüfen",
   "planpanel_reviewing": "Prüfe Plan…",
   "planpanel_review_unchanged": "Plan seit der letzten Prüfung unverändert — keine erneute Prüfung nötig.",
+  "planpanel_review_failed": "Prüfung konnte nicht gestartet werden — bitte erneut versuchen.",
   "viewport_decommission_title": "Agent stoppen + Worktree entfernen",
   "viewport_decommission_ready_title": "PR steht. Session schließen & Worktree aufräumen",
   "viewport_decommission_ready_aria": "PR bereit. Einheit stilllegen und Worktree aufräumen",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -449,6 +449,8 @@
   "planpanel_findings": "Angeforderte Änderungen",
   "planpanel_go": "Los — Ausführung starten",
   "planpanel_review_now": "Plan jetzt prüfen",
+  "planpanel_reviewing": "Prüfe Plan…",
+  "planpanel_review_unchanged": "Plan seit der letzten Prüfung unverändert — keine erneute Prüfung nötig.",
   "viewport_decommission_title": "Agent stoppen + Worktree entfernen",
   "viewport_decommission_ready_title": "PR steht. Session schließen & Worktree aufräumen",
   "viewport_decommission_ready_aria": "PR bereit. Einheit stilllegen und Worktree aufräumen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -449,6 +449,8 @@
   "planpanel_findings": "Requested changes",
   "planpanel_go": "Go — start execution",
   "planpanel_review_now": "Review plan now",
+  "planpanel_reviewing": "Reviewing…",
+  "planpanel_review_unchanged": "Plan unchanged since the last review — nothing to re-check.",
   "viewport_decommission_title": "stop agent + remove worktree",
   "viewport_decommission_ready_title": "PR is up. Close this session & clean up its worktree",
   "viewport_decommission_ready_aria": "PR ready. Decommission unit and clean up worktree",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -451,6 +451,7 @@
   "planpanel_review_now": "Review plan now",
   "planpanel_reviewing": "Reviewing…",
   "planpanel_review_unchanged": "Plan unchanged since the last review — nothing to re-check.",
+  "planpanel_review_failed": "Couldn't start the review — please try again.",
   "viewport_decommission_title": "stop agent + remove worktree",
   "viewport_decommission_ready_title": "PR is up. Close this session & clean up its worktree",
   "viewport_decommission_ready_aria": "PR ready. Decommission unit and clean up worktree",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -599,14 +599,19 @@ export async function releasePlanGate(id: string): Promise<boolean> {
   return r.ok;
 }
 
+/** Outcome of an on-demand plan review trigger: a reviewer spawned, the request was a silent
+ *  no-op (plan unchanged / already approved), or a spawn attempt failed. Mirrors the server's
+ *  PlanReviewTrigger so the UI can distinguish a dedupe from a genuine error. */
+export type PlanReviewTrigger = "started" | "skipped" | "error";
+
 /** Trigger an on-demand plan review (202). Fire-and-forget; verdict returns via WS.
- *  `started` is false when the server deduped the request (plan unchanged / already approved),
- *  so the caller can tell a real review from a silent no-op. */
-export async function reviewPlan(id: string): Promise<{ started: boolean }> {
+ *  Returns the trigger outcome so the caller can tell a real review from a silent dedupe
+ *  ("skipped") and a genuine spawn failure ("error"). */
+export async function reviewPlan(id: string): Promise<PlanReviewTrigger> {
   const r = await fetch(`/api/sessions/${id}/review-plan`, JSON_POST());
   if (!r.ok) throw await failed(r, "review-plan");
-  const body = (await r.json().catch(() => ({}))) as { started?: boolean };
-  return { started: !!body.started };
+  const body = (await r.json().catch(() => ({}))) as { status?: PlanReviewTrigger };
+  return body.status ?? "skipped";
 }
 
 export async function getBacklog(): Promise<BacklogPayload> {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -599,10 +599,14 @@ export async function releasePlanGate(id: string): Promise<boolean> {
   return r.ok;
 }
 
-/** Trigger an on-demand plan review (202). Fire-and-forget; verdict returns via WS. */
-export async function reviewPlan(id: string): Promise<void> {
+/** Trigger an on-demand plan review (202). Fire-and-forget; verdict returns via WS.
+ *  `started` is false when the server deduped the request (plan unchanged / already approved),
+ *  so the caller can tell a real review from a silent no-op. */
+export async function reviewPlan(id: string): Promise<{ started: boolean }> {
   const r = await fetch(`/api/sessions/${id}/review-plan`, JSON_POST());
   if (!r.ok) throw await failed(r, "review-plan");
+  const body = (await r.json().catch(() => ({}))) as { started?: boolean };
+  return { started: !!body.started };
 }
 
 export async function getBacklog(): Promise<BacklogPayload> {

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -47,17 +47,41 @@
   });
 
   let busy = $state(false);
+  // Set on a "started" trigger to bridge the window between the HTTP reply and the WS `reviewing`
+  // flag: the server emits `reviewing` before replying, but if that message lags the response the
+  // button would briefly flip back to "Review plan now" (a reprise of the original blink). Held
+  // until `reviewing` is observed, with a backstop timeout so a lost event can't wedge the spinner.
+  let awaitingReview = $state(false);
   // Outcome of the last manual review trigger that produced no live run, so the panel can explain
   // why nothing changed: "unchanged" = server deduped (plan unchanged / already approved),
-  // "error" = the reviewer failed to spawn. Without this the button would just blink and leave the
-  // operator guessing. null = no note (fresh page, or a real review is/was in flight).
+  // "error" = the reviewer failed to spawn. Auto-dismissed so it can't go stale between clicks.
+  // null = no note (fresh page, or a real review is/was in flight).
   let outcome = $state<"unchanged" | "error" | null>(null);
   // A review is visibly in flight from the click until the WS reviewing flag clears.
-  const inFlight = $derived(busy || reviewing);
+  const inFlight = $derived(busy || reviewing || awaitingReview);
 
-  // A live review supersedes any prior no-op/error note.
+  // Once the WS `reviewing` flag takes over the in-flight indicator, drop the bridge and any
+  // stale no-op/error note — a real run supersedes both.
   $effect(() => {
-    if (reviewing) outcome = null;
+    if (reviewing) {
+      awaitingReview = false;
+      outcome = null;
+    }
+  });
+
+  // Backstop: if the `reviewing` event never arrives (lost/late), don't wedge the spinner.
+  $effect(() => {
+    if (!awaitingReview) return;
+    const t = setTimeout(() => (awaitingReview = false), 4000);
+    return () => clearTimeout(t);
+  });
+
+  // The note is a transient confirmation, not persistent state — expire it so it can't linger
+  // and contradict a plan that changed since.
+  $effect(() => {
+    if (!outcome) return;
+    const t = setTimeout(() => (outcome = null), 6000);
+    return () => clearTimeout(t);
   });
 
   async function go() {
@@ -77,9 +101,10 @@
     outcome = null;
     try {
       const status = await reviewPlan(session.id);
-      // "started" → the WS reviewing flag drives the in-flight indicator; no note needed.
+      // "started" → bridge to the WS reviewing flag so the spinner doesn't blink back.
       // "skipped" → unchanged plan / already approved; "error" → spawn failed.
-      if (status === "skipped" && !reviewing) outcome = "unchanged";
+      if (status === "started") awaitingReview = true;
+      else if (status === "skipped" && !reviewing) outcome = "unchanged";
       else if (status === "error") outcome = "error";
     } catch {
       // The trigger request itself failed (network / non-2xx) — surface it like a spawn failure.

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -47,16 +47,17 @@
   });
 
   let busy = $state(false);
-  // True after a manual review that the server deduped (plan unchanged / already approved): the
-  // reviewer never spawned, so `reviewing` stays false and the verdict won't change — without this
-  // the button would just blink and leave the operator wondering whether anything happened.
-  let unchanged = $state(false);
+  // Outcome of the last manual review trigger that produced no live run, so the panel can explain
+  // why nothing changed: "unchanged" = server deduped (plan unchanged / already approved),
+  // "error" = the reviewer failed to spawn. Without this the button would just blink and leave the
+  // operator guessing. null = no note (fresh page, or a real review is/was in flight).
+  let outcome = $state<"unchanged" | "error" | null>(null);
   // A review is visibly in flight from the click until the WS reviewing flag clears.
   const inFlight = $derived(busy || reviewing);
 
-  // A live review (or a fresh verdict landing) supersedes the "unchanged" note.
+  // A live review supersedes any prior no-op/error note.
   $effect(() => {
-    if (reviewing) unchanged = false;
+    if (reviewing) outcome = null;
   });
 
   async function go() {
@@ -73,13 +74,16 @@
   async function review() {
     if (inFlight || !canReviewNow) return;
     busy = true;
-    unchanged = false;
+    outcome = null;
     try {
-      const { started } = await reviewPlan(session.id);
-      // Server deduped the unchanged plan — flag it so the panel explains the no-op.
-      if (!started && !reviewing) unchanged = true;
+      const status = await reviewPlan(session.id);
+      // "started" → the WS reviewing flag drives the in-flight indicator; no note needed.
+      // "skipped" → unchanged plan / already approved; "error" → spawn failed.
+      if (status === "skipped" && !reviewing) outcome = "unchanged";
+      else if (status === "error") outcome = "error";
     } catch {
-      /* verdict arrives via WS; surfacing the error here is out of scope */
+      // The trigger request itself failed (network / non-2xx) — surface it like a spawn failure.
+      outcome = "error";
     } finally {
       busy = false;
     }
@@ -135,8 +139,10 @@
       </section>
     {/if}
 
-    {#if unchanged}
+    {#if outcome === "unchanged"}
       <p class="note" role="status">{m.planpanel_review_unchanged()}</p>
+    {:else if outcome === "error"}
+      <p class="note err" role="alert">{m.planpanel_review_failed()}</p>
     {/if}
 
     <div class="actions">
@@ -280,6 +286,9 @@
     color: var(--color-muted);
     font-size: var(--fs-meta);
     text-align: right;
+  }
+  .note.err {
+    color: var(--color-red);
   }
   .review,
   .go {

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -47,6 +47,17 @@
   });
 
   let busy = $state(false);
+  // True after a manual review that the server deduped (plan unchanged / already approved): the
+  // reviewer never spawned, so `reviewing` stays false and the verdict won't change — without this
+  // the button would just blink and leave the operator wondering whether anything happened.
+  let unchanged = $state(false);
+  // A review is visibly in flight from the click until the WS reviewing flag clears.
+  const inFlight = $derived(busy || reviewing);
+
+  // A live review (or a fresh verdict landing) supersedes the "unchanged" note.
+  $effect(() => {
+    if (reviewing) unchanged = false;
+  });
 
   async function go() {
     if (busy || !releasable) return;
@@ -60,10 +71,13 @@
   }
 
   async function review() {
-    if (busy || !canReviewNow) return;
+    if (inFlight || !canReviewNow) return;
     busy = true;
+    unchanged = false;
     try {
-      await reviewPlan(session.id);
+      const { started } = await reviewPlan(session.id);
+      // Server deduped the unchanged plan — flag it so the panel explains the no-op.
+      if (!started && !reviewing) unchanged = true;
     } catch {
       /* verdict arrives via WS; surfacing the error here is out of scope */
     } finally {
@@ -121,10 +135,18 @@
       </section>
     {/if}
 
+    {#if unchanged}
+      <p class="note" role="status">{m.planpanel_review_unchanged()}</p>
+    {/if}
+
     <div class="actions">
       {#if canReviewNow}
-        <button type="button" class="review" onclick={review} disabled={busy || reviewing}>
-          {m.planpanel_review_now()}
+        <button type="button" class="review" onclick={review} disabled={inFlight}>
+          {#if inFlight}
+            <span class="rev-dot" aria-hidden="true"></span>{m.planpanel_reviewing()}
+          {:else}
+            {m.planpanel_review_now()}
+          {/if}
         </button>
       {/if}
       <button type="button" class="go" onclick={go} disabled={busy || !releasable}>
@@ -253,6 +275,12 @@
     justify-content: flex-end;
     margin-top: 2px;
   }
+  .note {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    text-align: right;
+  }
   .review,
   .go {
     border: 1px solid var(--color-line-bright);
@@ -265,6 +293,29 @@
     padding: 8px 14px;
     border-radius: 2px;
     cursor: pointer;
+  }
+  .review {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  /* plan reviewer running now: amber pulsing dot (mirrors PlanGateBadge) */
+  .rev-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-amber);
+    /* functional status motion — exempt from the reduced-motion blanket (app.css) */
+    animation: pp-pulse 1.1s ease-in-out infinite !important;
+  }
+  @keyframes pp-pulse {
+    0%,
+    100% {
+      opacity: 0.3;
+    }
+    50% {
+      opacity: 1;
+    }
   }
   .go {
     border-color: var(--color-green);


### PR DESCRIPTION
## Problem

Clicking **Plan jetzt prüfen** (*Review plan now*) in the plan panel only made the button blink briefly inactive then active again — with no sign anything happened.

Two distinct causes:

1. **Silent no-op.** When the plan was unchanged since the last non-error verdict, the server's `consider()` deduped and returned early — no reviewer spawned, no WS event — yet the `review-plan` route still returned `{ ok: true }`. The button toggled `busy` around the 202 and that was it. The operator had no way to know the plan was simply unchanged.
2. **No in-panel progress.** Even when a review *did* spawn, the pulsing `REVIEWING…` indicator lives on the badge *behind* the open dialog. Inside the `PlanPanel` the button just went faintly disabled with the same label — easy to miss.

## Fix

- `PlanGateService.consider()` / `begin()` now return whether a reviewer actually spawned.
- The `POST /api/sessions/:id/review-plan` route relays it as `{ ok, started }`; `reviewPlan()` in the API client returns `{ started }`.
- `PlanPanel` now:
  - shows a pulsing **Reviewing…** state on the button while a review is in flight (mirrors the badge's dot), and
  - shows a **"Plan unchanged since the last review — nothing to re-check"** note when the server deduped the request.

## Tests

- `test/plan-gate-service.test.ts`: assert `consider()` returns `true` on spawn, `false` on every no-op (missing plan, not planning, dedupe, already approved) and `true` on error-retry.
- `test/server-plan-gate.test.ts`: route relays `started: true` and `started: false`.
- Root lint + tests, UI `check`, `check:i18n` (parity), and 602 UI tests all green.

i18n: `planpanel_reviewing` + `planpanel_review_unchanged` added to both `en.json` and `de.json`.