### PR TITLE
fix(ui): terminal Shift+Enter newline + copyable selection

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -474,7 +474,7 @@
   "viewport_notes_aria": "Notiz hinzufügen: {key} drücken",
   "viewport_type_steer_hint": "⌁ tippen zum Steuern",
   "viewport_detach_hint": "⇥ trennen",
-  "viewport_select_hint": "{key} zum Markieren ziehen",
+  "viewport_select_hint": "{key} Ziehen zum Kopieren",
   "viewport_parked_title": "Auf anderem Gerät aktiv",
   "viewport_parked_sub": "Tippen zum Übernehmen",
   "viewport_session_ended": "── Sitzung beendet ──",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -474,7 +474,7 @@
   "viewport_notes_aria": "Add notes: press {key}",
   "viewport_type_steer_hint": "⌁ type to steer",
   "viewport_detach_hint": "⇥ detach",
-  "viewport_select_hint": "{key} drag to select",
+  "viewport_select_hint": "{key} drag to copy",
   "viewport_parked_title": "Active on another device",
   "viewport_parked_sub": "Tap to take over",
   "viewport_session_ended": "── session ended ──",

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -669,9 +669,12 @@
     };
 
     // Shift+Enter → newline: xterm emits a bare CR for both Enter and
-    // Shift+Enter, so Claude Code can't tell them apart and submits. Send a
-    // line feed (0x0A, same byte as Ctrl+J / chat:newline) instead and swallow
-    // xterm's default CR. keydown-only so the keyup doesn't double-send.
+    // Shift+Enter, so Claude Code can't tell them apart and submits. Returning
+    // false alone is insufficient — xterm then skips its own preventDefault and
+    // the browser's Enter keypress still makes xterm emit \r. We must call
+    // e.preventDefault() to suppress that keypress, then send a line feed
+    // (0x0A, same byte as Ctrl+J / chat:newline) instead. keydown-only so the
+    // keyup doesn't double-send.
     term.attachCustomKeyEventHandler((e) => {
       if (
         e.type === "keydown" &&
@@ -681,8 +684,22 @@
         !e.altKey &&
         !e.metaKey
       ) {
+        e.preventDefault();
         c.send("\n");
         return false;
+      }
+      // Ctrl+Shift+C: explicit copy. Ctrl+C in a focused terminal sends SIGINT to
+      // the agent rather than copying; this gives users an explicit copy shortcut.
+      // Read the selection before returning false — xterm hasn't cleared it yet.
+      if (e.type === "keydown" && e.ctrlKey && e.shiftKey && (e.key === "C" || e.key === "c")) {
+        const sel = term.getSelection();
+        if (sel) {
+          e.preventDefault();
+          navigator.clipboard?.writeText(sel)?.catch((err) => {
+            console.warn("ctrl+shift+c: clipboard write failed", err);
+          });
+          return false;
+        }
       }
       return true;
     });
@@ -745,6 +762,20 @@
       if (!dragged) term.focus();
     };
     el.addEventListener("click", onTap);
+
+    // copy-on-select: Ctrl+C in a focused terminal sends SIGINT to the agent rather
+    // than copying. Copy the xterm selection to the clipboard on mouseup so users can
+    // get selected text out. A plain click clears xterm's selection first, so
+    // getSelection() is empty on a non-drag click → no spurious copy.
+    const onCopyMouseUp = () => {
+      const sel = term.getSelection();
+      if (sel) {
+        navigator.clipboard?.writeText(sel)?.catch((err) => {
+          console.warn("copy-on-select: clipboard write failed", err);
+        });
+      }
+    };
+    el.addEventListener("mouseup", onCopyMouseUp);
 
     // Cmd/Ctrl+V of an image: xterm only pastes text, so a copied screenshot is
     // silently dropped. Intercept in the capture phase (before xterm's textarea
@@ -879,6 +910,7 @@
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("pageshow", onPageShow);
       el?.removeEventListener("click", onTap);
+      el?.removeEventListener("mouseup", onCopyMouseUp);
       el?.removeEventListener("paste", onPaste, true);
       el?.removeEventListener("touchstart", onTouchStart);
       el?.removeEventListener("touchmove", onTouchMove);

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -763,11 +763,23 @@
     };
     el.addEventListener("click", onTap);
 
-    // copy-on-select: Ctrl+C in a focused terminal sends SIGINT to the agent rather
-    // than copying. Copy the xterm selection to the clipboard on mouseup so users can
-    // get selected text out. A plain click clears xterm's selection first, so
-    // getSelection() is empty on a non-drag click → no spurious copy.
-    const onCopyMouseUp = () => {
+    // copy-on-select: Ctrl+C in a focused terminal sends SIGINT to the agent
+    // rather than copying, so copy the xterm selection to the clipboard when a
+    // drag-select finishes. xterm tracks the drag with document-level listeners,
+    // so the pointer can be released outside the terminal element — listen for
+    // mouseup on the document (gated to drags that began in the terminal) rather
+    // than on el, so those releases still copy. The mousedown gate is capture-
+    // phase: xterm stops the mousedown from bubbling to el, so a bubble-phase
+    // listener never sees it — capture fires top-down before xterm can swallow
+    // it. A plain click clears xterm's selection first, so getSelection() is
+    // empty → no spurious copy.
+    let selectingInTerm = false;
+    const onTermMouseDown = () => {
+      selectingInTerm = true;
+    };
+    const onDocMouseUp = () => {
+      if (!selectingInTerm) return;
+      selectingInTerm = false;
       const sel = term.getSelection();
       if (sel) {
         navigator.clipboard?.writeText(sel)?.catch((err) => {
@@ -775,7 +787,8 @@
         });
       }
     };
-    el.addEventListener("mouseup", onCopyMouseUp);
+    el.addEventListener("mousedown", onTermMouseDown, true);
+    document.addEventListener("mouseup", onDocMouseUp);
 
     // Cmd/Ctrl+V of an image: xterm only pastes text, so a copied screenshot is
     // silently dropped. Intercept in the capture phase (before xterm's textarea
@@ -910,7 +923,8 @@
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("pageshow", onPageShow);
       el?.removeEventListener("click", onTap);
-      el?.removeEventListener("mouseup", onCopyMouseUp);
+      el?.removeEventListener("mousedown", onTermMouseDown, true);
+      document.removeEventListener("mouseup", onDocMouseUp);
       el?.removeEventListener("paste", onPaste, true);
       el?.removeEventListener("touchstart", onTouchStart);
       el?.removeEventListener("touchmove", onTouchMove);


### PR DESCRIPTION
Fixes two Terminal Pane (xterm.js `@xterm/xterm@6.0.0`) interaction bugs reported on Linux/Chromium while a Claude Code agent's TUI is active.

## 1. Shift+Enter submitted instead of inserting a newline
**Root cause (verified against xterm 6.0.0):** the custom key handler matched Shift+Enter, sent `\n`, and returned `false` — but returning `false` makes xterm skip its *own* `preventDefault`, so the browser still fired the Enter **keypress**, which xterm's keypress path turned into a bare `\r`. The agent received `\n` **and** `\r` → submit.

**Fix:** call `e.preventDefault()` in the handler to suppress that keypress. Now only `\n` (= Ctrl+J / `chat:newline`) is sent. Plain Enter still submits; handler stays keydown-only + modifier-guarded.

## 2. Selection couldn't be copied
Shift+drag already highlights (xterm's shift-bypass works — confirmed in the live app), but there was **no way to copy**: inside a focused terminal Ctrl+C is SIGINT to the agent, and the Viewport wired up no copy path.

**Fix:** 
- **copy-on-select** — write the selection to the clipboard on `mouseup` (a plain click clears the selection first, so no spurious copies);
- **Ctrl+Shift+C** — explicit copy of the current selection (reads it before xterm clears it; suppresses the keystroke so no stray bytes hit the agent);
- footer hint reworded `select` → `copy` (EN + DE).

Both clipboard calls are optional-chained (no-op in insecure contexts) and log on failure (no swallowed-error-as-success).

## Verification
- Reproduced + fixed against `@xterm/xterm@6.0.0` in a Playwright harness and confirmed in the **live running app**: Shift+Enter emits no `\r`; copy-on-select clipboard matches selection; Ctrl+Shift+C re-copies the selection.
- `cd ui && bun run check` (0 errors), `check:i18n` (parity), `bun run test` (602 passed).

No feature-catalog entry: this completes the existing selection feature rather than adding a new surface (`fix`).