### PR TITLE
fix(ui): stop truncating repo name on New Task submit button

### DIFF
--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -660,7 +660,7 @@
     box-shadow: inset 0 0 18px -10px var(--color-amber);
   }
   .run span {
-    max-width: 28ch;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -673,6 +673,7 @@
     box-shadow: none;
   }
   .kbd {
+    flex-shrink: 0;
     font: inherit;
     font-size: var(--fs-micro);
     letter-spacing: 0.04em;


### PR DESCRIPTION
## Problem

The New Task form's submit button — "CREATE & RUN IN {repo}", added by #420 as the enforcer of repo selection — truncated the repo name to ~6 visible chars (`CREATE & RUN IN SHEPHE…`) even though the button is full-width with ample room.

## Root cause

`.run` is a full-width flex child of the 520px `.card` (~488px of space), but its label `<span>` was capped at `max-width: 28ch`. Combined with the button's `text-transform: uppercase` + `letter-spacing: 0.12em`, 28 `ch` (zero-glyph widths) render as only ~22 spaced chars, so the string was cut mid-word despite the button having room for the whole thing.

## Fix (CSS-only, `NewTask.svelte`)

- `.run span`: drop the arbitrary `max-width: 28ch`; add `min-width: 0` so the flex item can shrink and `text-overflow: ellipsis` engages **only on genuine overflow**.
- `.kbd`: add `flex-shrink: 0` so the `Ctrl+↵` / `⌘↵` hint is never squeezed — only the label absorbs truncation.

No markup, message, or logic changes.

## Verification

- Repo names now render in full on the submit button; ellipsis is a graceful safety net for pathologically long names (kbd hint preserved).
- `cd ui && bun run check` passes (0 errors).

Pure CSS bugfix — no new user-facing capability or strings, so i18n (`check:i18n`) and feature-catalog gates are N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)