### PR TITLE
feat(ui): show what the critic is doing live in the badge tooltip

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,7 @@ const reviewService = new ReviewService({
   resolveForge,
   onChange: (id, verdict) => events.emit("session:review", { id, review: verdict }),
   onReviewing: (id, reviewing) => events.emit("session:reviewing", { id, reviewing }),
+  onActivity: (id, summary) => events.emit("session:critic-activity", { id, summary }),
   // auto-address: steer critic findings straight into the task agent's PTY (same path
   // as a human "send review to agent"). Gated per-repo by autoAddressEnabled; the
   // round cap below stops it ping-ponging forever.

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -56,7 +56,7 @@ export function planReviewPrompt(task: string, plan: string, priorFindings: stri
 /** The read-only plan reviewer's argv — the PR critic's exact hardening, shared via one builder
  *  (the plan text is UNTRUSTED, so it gets the same injection-contained sandbox). */
 export function reviewerArgv(model: string | null, prompt: string): string[] {
-  return readonlyReviewerArgv(model, prompt);
+  return readonlyReviewerArgv(model, prompt).argv;
 }
 
 // How long an in-flight plan review may run before tick() (Task 6) gives up on the verdict.

--- a/src/review.ts
+++ b/src/review.ts
@@ -10,6 +10,8 @@ import type { GitForge, GitState } from "./forge/types";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "./forge/types";
 import type { ReviewVerdict, ReviewDecision, Session } from "./types";
 import { readonlyReviewerArgv } from "./reviewer-argv";
+import { jsonlPathFor } from "./usage";
+import { readActivitySignal } from "./activity-signal";
 
 const execFileAsync = promisify(execFile);
 
@@ -88,6 +90,7 @@ interface InFlight {
   repoPath: string;
   worktreePath: string;
   terminalId: string;
+  criticSessionId: string; // the critic's claude session id → locates its transcript for live activity
   startedAt: number;
   priorRound: number; // auto-address steers already spent on this findings streak
   priorErrorRound: number; // consecutive critic error/timeout verdicts before this run
@@ -114,6 +117,14 @@ export interface ReviewServiceDeps {
   /** Fired when a critic run starts (true) and when it ends (false) for a session. */
   onReviewing?: (id: string, reviewing: boolean) => void;
   /**
+   * Fired each tick a critic is still running, with its latest *meaningful* tool-use
+   * summary (e.g. "$ git diff", "read review.ts") — surfaced live in the UI badge
+   * tooltip so the operator can see what the critic is doing, not just that it's busy.
+   * Only fired when a summary is available; the run-ended (onReviewing false) signal
+   * clears it client-side.
+   */
+  onActivity?: (id: string, summary: string) => void;
+  /**
    * Steer critic findings into a session's live PTY (typically SessionService.reply).
    * Returns false (or throws — both treated as not-delivered) when the steer can't
    * land; only a true return advances the round. Absent → the auto-address loop is
@@ -134,6 +145,9 @@ export interface ReviewServiceDeps {
   /** Injectable content fingerprint of `git diff base...HEAD` in the worktree (default:
    *  real `git patch-id`). Returns null when there's no diff or git fails → never skips. */
   computePatchId?: (worktreePath: string, base: string) => Promise<string | null>;
+  /** Injectable reader for the critic's latest tool-use summary (default: parse its JSONL
+   *  transcript via readActivitySignal). null = no parseable activity yet. */
+  readActivity?: (worktreePath: string, criticSessionId: string) => string | null;
 }
 
 interface RawVerdict {
@@ -160,6 +174,7 @@ export class ReviewService {
   }
   private readVerdict: (worktreePath: string) => RawVerdict | null;
   private computePatchId: (worktreePath: string, base: string) => Promise<string | null>;
+  private readActivity: (worktreePath: string, criticSessionId: string) => string | null;
 
   constructor(private deps: ReviewServiceDeps) {
     this.now = deps.now ?? Date.now;
@@ -169,6 +184,7 @@ export class ReviewService {
     this.capFn = typeof cap === "function" ? cap : () => cap ?? DEFAULT_CAP;
     this.readVerdict = deps.readVerdict ?? defaultReadVerdict;
     this.computePatchId = deps.computePatchId ?? defaultComputePatchId;
+    this.readActivity = deps.readActivity ?? defaultReadActivity;
   }
 
   /** Decide whether `git` warrants a fresh critic run for `session`, and start one. */
@@ -225,7 +241,11 @@ export class ReviewService {
       return;
     }
 
-    const argv = this.criticArgv(session, prior?.findings ?? [], authorNotes);
+    const { argv, sessionId: criticSessionId } = this.criticArgv(
+      session,
+      prior?.findings ?? [],
+      authorNotes,
+    );
     let terminalId: string;
     try {
       terminalId = this.deps.herdr.start(
@@ -247,6 +267,7 @@ export class ReviewService {
       repoPath: session.repoPath,
       worktreePath: wt.worktreePath,
       terminalId,
+      criticSessionId,
       startedAt: this.now(),
       priorRound: prior?.addressRound ?? 0,
       priorErrorRound: prior?.errorRound ?? 0,
@@ -313,7 +334,11 @@ export class ReviewService {
    *  to run commands or escape its worktree. `dontAsk` auto-denies anything off the allowlist
    *  (an unattended PTY would otherwise hang on a permission prompt); the allowlist is
    *  read-only inspection + read-only git + writing files in its own disposable worktree. */
-  private criticArgv(session: Session, priorFindings: string[], authorNotes: string[]): string[] {
+  private criticArgv(
+    session: Session,
+    priorFindings: string[],
+    authorNotes: string[],
+  ): { argv: string[]; sessionId: string } {
     // Shared with the plan reviewer: same read-only injection-contained sandbox (the PR diff is
     // UNTRUSTED). The prompt is the only critic-specific part.
     return readonlyReviewerArgv(
@@ -360,7 +385,14 @@ export class ReviewService {
       if (f.finalizing) continue; // already being finalized by an overlapping tick
       const raw = this.readVerdict(f.worktreePath);
       const timedOut = this.now() - f.startedAt > this.timeoutMs;
-      if (!raw && !timedOut) continue;
+      if (!raw && !timedOut) {
+        // still running, no verdict yet — surface what the critic is doing right now.
+        // Emit every tick (not only on change) so a reloaded client repopulates within
+        // one tick; the client dedups identical summaries to stay quiet.
+        const summary = this.readActivity(f.worktreePath, f.criticSessionId);
+        if (summary) this.deps.onActivity?.(f.sessionId, summary);
+        continue;
+      }
       f.finalizing = true; // stay claimed in `inflight` so consider() won't re-spawn mid-finalize
       // Always drop the entry, even if finalize throws — otherwise it stays
       // `finalizing=true` and every later tick `continue`s past it, wedging the
@@ -611,6 +643,13 @@ async function defaultComputePatchId(worktreePath: string, base: string): Promis
   } catch {
     return null; // git missing / bad base / empty → don't skip
   }
+}
+
+/** Latest meaningful tool-use summary from the critic's JSONL transcript (its claude
+ *  session id forces a predictable path under the disposable worktree). null when the
+ *  transcript is missing or has no parseable activity yet. */
+function defaultReadActivity(worktreePath: string, criticSessionId: string): string | null {
+  return readActivitySignal(jsonlPathFor(worktreePath, criticSessionId))?.summary ?? null;
 }
 
 function defaultReadVerdict(worktreePath: string): RawVerdict | null {

--- a/src/reviewer-argv.ts
+++ b/src/reviewer-argv.ts
@@ -8,11 +8,18 @@ import { randomUUID } from "node:crypto";
  *  inspection + read-only git + writing files in its own disposable worktree. The sandbox is also
  *  MCP-isolated via --safe-mode (no MCP servers load, so no "trust this server?" prompt can hang
  *  the unattended pane — dontAsk does not suppress that gate). */
-export function readonlyReviewerArgv(model: string | null, prompt: string): string[] {
+export function readonlyReviewerArgv(
+  model: string | null,
+  prompt: string,
+): { argv: string[]; sessionId: string } {
+  // The reviewer's claude session id, forced so the transcript lands at a path we can
+  // predict (jsonlPathFor(worktree, sessionId)) — that's how the critic's live tool-use
+  // gets surfaced in the UI badge tooltip. Returned to the caller alongside the argv.
+  const sessionId = randomUUID();
   const argv = [
     "claude",
     "--session-id",
-    randomUUID(),
+    sessionId,
     // Run the reviewer in a CLEAN context. It's a fresh `claude` startup, so it
     // would otherwise inherit the user's global hooks + plugins — notably the
     // superpowers SessionStart hook, which injects a forceful "you MUST invoke
@@ -65,5 +72,5 @@ export function readonlyReviewerArgv(model: string | null, prompt: string): stri
   // with no task, and hangs until timeout (every review). Don't reorder.
   argv.push("--permission-mode", "dontAsk");
   argv.push(prompt);
-  return argv;
+  return { argv, sessionId };
 }

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -210,6 +210,45 @@ test("onReviewing fires false when an in-flight critic is forgotten", async () =
   ]);
 });
 
+test("onActivity surfaces the running critic's latest tool-use while no verdict yet", async () => {
+  const acts: { id: string; summary: string }[] = [];
+  const { deps: d } = makeDeps({
+    readVerdict: () => null, // still running — no verdict file yet
+    readActivity: () => "$ git diff main...HEAD",
+    onActivity: (id: string, summary: string) => acts.push({ id, summary }),
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(acts).toEqual([{ id: "s1", summary: "$ git diff main...HEAD" }]);
+});
+
+test("onActivity stays silent when the critic has no parseable activity yet", async () => {
+  const acts: unknown[] = [];
+  const { deps: d } = makeDeps({
+    readVerdict: () => null,
+    readActivity: () => null, // transcript missing / nothing parseable
+    onActivity: (id: string, summary: string) => acts.push({ id, summary }),
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(acts).toEqual([]);
+});
+
+test("onActivity does not fire on the tick that finalizes the verdict", async () => {
+  const acts: unknown[] = [];
+  const { deps: d } = makeDeps({
+    // verdict present → this tick finalizes rather than reporting activity
+    readActivity: () => "$ git diff",
+    onActivity: (id: string, summary: string) => acts.push({ id, summary }),
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(acts).toEqual([]);
+});
+
 test("critic spawns read-only: no skip-permissions, dontAsk + scoped allowlist", async () => {
   const { deps: d, started } = makeDeps({});
   await new ReviewService(d as any).consider(session(), OPEN_GREEN);

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -442,6 +442,7 @@
   "criticbadge_title": "Kritiker-Review für diesen PR-Stand",
   "criticbadge_reviewing": "PRÜFT…",
   "criticbadge_reviewing_title": "Kritiker prüft diese Sitzung",
+  "criticbadge_reviewing_activity_title": "Kritiker prüft — gerade: {activity}",
   "criticbadge_round": "↻ {round}/{cap}",
   "criticbadge_round_title": "Kritiker-Befunde werden bearbeitet — Runde {round} von {cap}",
   "criticbadge_stalled": "STECKT {round}/{cap}",
@@ -736,5 +737,7 @@
   "feat_update_checkout_title": "Lokalen Checkout nach Merge aktualisieren",
   "feat_update_checkout_body": "Wenn du einen PR über einen der Merge-Buttons der App mergst, bietet ein Toast an, den lokalen Default-Branch des Repos per Fast-Forward auf den frisch gemergten Stand zu bringen — kein manuelles Pull nötig.",
   "feat_automation_help_title": "Jede Automatisierung erklärt",
-  "feat_automation_help_body": "Jeder Schalter im Automatisierungs-Panel hat jetzt ein anklickbares „ⓘ“, das eine ausführliche, verständliche Erklärung öffnet — was die Funktion macht, wie sie arbeitet und wann genau sie auslöst. So versteht jeder, nicht nur das Team, den Kritiker, das Plan-Gate, Autopilot, Auto-Abarbeitung und den Rest, bevor er sie einschaltet."
+  "feat_automation_help_body": "Jeder Schalter im Automatisierungs-Panel hat jetzt ein anklickbares „ⓘ“, das eine ausführliche, verständliche Erklärung öffnet — was die Funktion macht, wie sie arbeitet und wann genau sie auslöst. So versteht jeder, nicht nur das Team, den Kritiker, das Plan-Gate, Autopilot, Auto-Abarbeitung und den Rest, bevor er sie einschaltet.",
+  "feat_critic_activity_title": "Sieh dem Kritiker live bei der Arbeit zu",
+  "feat_critic_activity_body": "Der PR-Kritiker läuft als eigene Claude-Code-Session. Fahr mit der Maus über das PRÜFT-Badge und sieh seine letzte Aktion live – „$ git diff“, „read review.ts“ – statt nur, dass er beschäftigt ist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -442,6 +442,7 @@
   "criticbadge_title": "Critic review for this PR head",
   "criticbadge_reviewing": "REVIEWING…",
   "criticbadge_reviewing_title": "Critic is reviewing this session",
+  "criticbadge_reviewing_activity_title": "Critic is reviewing — now: {activity}",
   "criticbadge_round": "↻ {round}/{cap}",
   "criticbadge_round_title": "Auto-addressing critic findings — round {round} of {cap}",
   "criticbadge_stalled": "STALLED {round}/{cap}",
@@ -736,5 +737,7 @@
   "feat_update_checkout_title": "Update local checkout after merge",
   "feat_update_checkout_body": "When you merge a PR from one of the app's merge buttons, a toast offers to fast-forward that repo's local default branch to the freshly merged state — no manual pull needed.",
   "feat_automation_help_title": "Explain each automation",
-  "feat_automation_help_body": "Every switch in the automation panel now has a clickable \"ⓘ\" that opens a thorough, plain-language explanation of what that function does, how it works, and exactly when it fires — so anyone, not just the team, can understand the Critic, Plan gate, Autopilot, Auto-Drain and the rest before turning them on."
+  "feat_automation_help_body": "Every switch in the automation panel now has a clickable \"ⓘ\" that opens a thorough, plain-language explanation of what that function does, how it works, and exactly when it fires — so anyone, not just the team, can understand the Critic, Plan gate, Autopilot, Auto-Drain and the rest before turning them on.",
+  "feat_critic_activity_title": "See what the critic is doing live",
+  "feat_critic_activity_body": "The PR critic runs as its own Claude Code session. Hover the REVIEWING badge to see its latest action live — “$ git diff”, “read review.ts” — instead of just that it's busy."
 }

--- a/ui/src/lib/components/CriticBadge.svelte
+++ b/ui/src/lib/components/CriticBadge.svelte
@@ -9,6 +9,9 @@
   const verdict = $derived(reviews.map[sessionId]);
   const chip = $derived(criticChip(verdict, reviewing));
   const round = $derived(addressRoundInfo(verdict, clock.current));
+  // latest tool-use of the in-flight critic (its own claude session) — shows what it's
+  // doing right now; falls back to the generic line until the first tool-use lands.
+  const activity = $derived(reviews.activityFor(sessionId));
 </script>
 
 {#snippet addrSuffix(r: NonNullable<typeof round>)}
@@ -29,7 +32,12 @@
 {/snippet}
 
 {#if chip.kind === "reviewing"}
-  <span class="critic-badge critic-reviewing" title={m.criticbadge_reviewing_title()}>
+  <span
+    class="critic-badge critic-reviewing"
+    title={activity
+      ? m.criticbadge_reviewing_activity_title({ activity })
+      : m.criticbadge_reviewing_title()}
+  >
     <span class="rev-dot" aria-hidden="true"
     ></span>{m.criticbadge_reviewing()}{#if round}{@render addrSuffix(round)}{/if}
   </span>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -167,4 +167,12 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_automation_help_title",
     bodyKey: "feat_automation_help_body",
   },
+  {
+    // No targetId: the critic badge only renders while a PR critic is actively reviewing,
+    // so a coachmark anchor would rarely be mounted — surface via the What's-New drawer only.
+    id: "critic-live-activity",
+    sinceVersion: "1.20.0",
+    titleKey: "feat_critic_activity_title",
+    bodyKey: "feat_critic_activity_body",
+  },
 ];

--- a/ui/src/lib/reviews.svelte.test.ts
+++ b/ui/src/lib/reviews.svelte.test.ts
@@ -44,6 +44,7 @@ const verdict = (id: string): ReviewVerdict => ({
 beforeEach(() => {
   reviews.map = {};
   reviews.reviewing = {};
+  reviews.activity = {};
   repoConfig.enabled = {};
   repoConfig.autoAddress = {};
   repoConfig.learnings = {};
@@ -97,6 +98,36 @@ test("drop is a no-op for unknown id", () => {
   reviews.map = { s1: verdict("s1") };
   reviews.drop("s2");
   expect(reviews.map["s1"]).toBeDefined();
+});
+
+test("setActivity records the critic's latest tool-use", () => {
+  reviews.setActivity("s1", "$ git diff main...HEAD");
+  expect(reviews.activityFor("s1")).toBe("$ git diff main...HEAD");
+});
+
+test("activityFor returns null for an unknown id", () => {
+  expect(reviews.activityFor("nope")).toBeNull();
+});
+
+test("ending the review (setReviewing false) clears its live activity", () => {
+  reviews.setReviewing("s1", true);
+  reviews.setActivity("s1", "read review.ts");
+  reviews.setReviewing("s1", false);
+  expect(reviews.activityFor("s1")).toBeNull();
+});
+
+test("applying a verdict clears the live activity too", () => {
+  reviews.setReviewing("s1", true);
+  reviews.setActivity("s1", "read review.ts");
+  reviews.apply({ id: "s1", review: verdict("s1") });
+  expect(reviews.activityFor("s1")).toBeNull();
+});
+
+test("setActivity ignores an unchanged value (no reactive churn)", () => {
+  reviews.setActivity("s1", "$ git log");
+  const before = reviews.activity;
+  reviews.setActivity("s1", "$ git log"); // identical → same object reference kept
+  expect(reviews.activity).toBe(before);
 });
 
 test("repoConfig.isEnabled returns true for unknown repo (default-on)", () => {

--- a/ui/src/lib/reviews.svelte.ts
+++ b/ui/src/lib/reviews.svelte.ts
@@ -15,6 +15,9 @@ class ReviewsStore {
   map = $state<Record<string, ReviewVerdict>>({});
   // session ids with a critic run currently in flight; driven by `session:reviewing`
   reviewing = $state<Record<string, boolean>>({});
+  // latest tool-use summary of the in-flight critic, keyed by session id; driven by
+  // `session:critic-activity`. Surfaced in the badge tooltip; cleared when the run ends.
+  activity = $state<Record<string, string>>({});
 
   async load() {
     try {
@@ -48,7 +51,26 @@ class ReviewsStore {
       const copy = { ...this.reviewing };
       delete copy[id];
       this.reviewing = copy;
+      this.clearActivity(id); // run ended → its live activity is stale
     }
+  }
+
+  /** Record the in-flight critic's latest tool-use summary; ignores an unchanged value
+   *  so the server re-emitting the same line every tick causes no reactive churn. */
+  setActivity(id: string, summary: string) {
+    if (this.activity[id] === summary) return;
+    this.activity = { ...this.activity, [id]: summary };
+  }
+
+  private clearActivity(id: string) {
+    if (!(id in this.activity)) return;
+    const copy = { ...this.activity };
+    delete copy[id];
+    this.activity = copy;
+  }
+
+  activityFor(id: string): string | null {
+    return this.activity[id] ?? null;
   }
 
   isReviewing(id: string): boolean {

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -396,6 +396,14 @@ test("session:activity replaces an existing entry (latest wins)", () => {
   expect(s.activity["s1"]?.summary).toBe("$ bun test");
 });
 
+test("session:critic-activity routes to the reviews store", async () => {
+  const { reviews } = await import("./reviews.svelte");
+  reviews.activity = {};
+  const s = new HerdStore();
+  s.apply({ event: "session:critic-activity", data: { id: "s1", summary: "$ git diff" } });
+  expect(reviews.activityFor("s1")).toBe("$ git diff");
+});
+
 test("session:merging sets and clears the mark", () => {
   const s = new HerdStore();
   s.setAll([session("s1"), session("s2")]);

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -195,6 +195,9 @@ export class HerdStore {
       case "session:reviewing":
         reviews.setReviewing(ev.data.id, ev.data.reviewing);
         break;
+      case "session:critic-activity":
+        reviews.setActivity(ev.data.id, ev.data.summary);
+        break;
       case "session:plangate":
         // Emitted two ways: a fresh verdict carries `gate`; a phase flip carries `planPhase`.
         if (ev.data.gate) planGates.apply(ev.data.id, ev.data.gate);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -459,6 +459,7 @@ export type WsEvent =
   | { event: "project-icons:update"; data: ProjectIcons }
   | { event: "session:review"; data: { id: string; review: ReviewVerdict | null } }
   | { event: "session:reviewing"; data: { id: string; reviewing: boolean } }
+  | { event: "session:critic-activity"; data: { id: string; summary: string } }
   | {
       event: "session:plangate";
       // Emitted two ways: a fresh verdict carries `gate`; a phase flip carries `planPhase`.


### PR DESCRIPTION
## Was & Warum

> *„Ich kann hier zwar sehen, dass der Kritiker etwas prüft, aber nicht **was**. Wäre es nicht cool, wenn wir mit der Maus drüberfahren und sehen, was der Kritiker gerade macht?“*

Genau — und ja, der Kritiker **ist** eine eigene Claude-Code-Session, die einzeln in einem Wegwerf-Worktree läuft (`herdr.start(...)` mit eigener `--session-id`). Diese Session schreibt bereits ein Transkript, das Shepherd für normale Sessions in Tool-Use-Zeilen parst (`"$ git diff"`, `"read review.ts"` …) — nur wurde das Kritiker-Transkript bisher **nirgends** angezapft. Der `PRÜFT…`-Tooltip sagte stur „Kritiker prüft diese Sitzung“.

Dieser PR zieht die Live-Aktivität des Kritikers in den Tooltip:

- **`readonlyReviewerArgv`** gibt jetzt die erzwungene Claude-Session-ID zurück → der Transkriptpfad des Kritikers ist vorhersagbar (`jsonlPathFor`).
- **`ReviewService.tick()`** (läuft eh alle 15 s) liest pro laufendem Kritiker die letzte sinnvolle Tool-Use-Zeile über den vorhandenen `activity-signal`-Parser und emittiert sie als neues Event `session:critic-activity`. Emittiert jede Runde (nicht nur bei Änderung), damit ein neugeladener Client innerhalb einer Runde wieder befüllt ist — der Client dedupliziert identische Zeilen.
- **`reviews`-Store** cached die Zeile pro Session und löscht sie, wenn der Lauf endet; **`CriticBadge`** zeigt sie im `title`-Attribut und fällt auf den generischen Satz zurück, bis der erste Tool-Use landet.

Tooltip vorher: *„Kritiker prüft diese Sitzung“* → nachher: *„Kritiker prüft — gerade: $ git diff main...HEAD“*.

## Scope

Bewusst nur der **PR-Kritiker** (das Badge im Screenshot). Das Plan-Gate-Badge (`PRÜFUNG…`) teilt sich die Mechanik, bleibt aber ein Follow-up, um den Diff chirurgisch zu halten.

## Tests
- `test/review.test.ts`: 3 neue Tests (Aktivität emittiert während Lauf, still ohne parsebare Aktivität, nicht beim Finalisieren) — 74 pass.
- `ui/.../reviews.svelte.test.ts` + `store.svelte.test.ts`: setActivity/activityFor/Clear-on-end + Event-Dispatch — alle UI-Tests grün (604+).
- Lint, `check:i18n` (EN/DE-Parität, 700 Keys), `svelte-check` (0 Fehler), branch-hygiene + feature-catalog Gates: alle grün.
- Feature-Katalog-Eintrag `critic-live-activity` (1.20.0) + EN/DE-Strings ergänzt.