### PR TITLE
feat(ui): show per-repo learnings in the repo status row, drop top-bar badge

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -122,7 +122,7 @@
   "automation_plan_gate_desc": "Plan vor dem Agentenlauf prüfen + kontradiktorisch hinterfragen",
   "automation_plan_gate_task_planning": "Dieser Task: Gate aktiv — Planung",
   "automation_plan_gate_task_executing": "Dieser Task: Plan genehmigt — Ausführung",
-  "drain_strip_label": "Queue",
+  "repo_status_label": "Repo-Status",
   "drain_inflight": "{count}/{max} auto",
   "drain_queued": "{count} in Warteschlange",
   "drain_paused_blocked": "Pausiert: {desig} ist blockiert",
@@ -712,5 +712,7 @@
   "feat_backlog_pr_merge_train_title": "Merge-Train aus ausgewählten PRs starten",
   "feat_backlog_pr_merge_train_body": "Mehrere offene PRs im Backlog-PRs-Tab eines Repos auswählen und einen Merge-Train starten, der auf genau diese PRs beschränkt ist.",
   "feat_header_fold_title": "Kopfbereich einklappen für mehr Terminal",
-  "feat_header_fold_body": "Tippe auf dem Mobilgerät auf den Pfeil im Session-Kopf, um Tabs und PR-Leiste einzuklappen und den Platz dem Terminal zu geben. Deine Wahl bleibt über Sessions hinweg erhalten."
+  "feat_header_fold_body": "Tippe auf dem Mobilgerät auf den Pfeil im Session-Kopf, um Tabs und PR-Leiste einzuklappen und den Platz dem Terminal zu geben. Deine Wahl bleibt über Sessions hinweg erhalten.",
+  "feat_learnings_per_repo_title": "Erkenntnisse in der Repo-Zeile",
+  "feat_learnings_per_repo_body": "Der Glühbirnen-Zähler ist aus der oberen Leiste in die Status-Zeile jedes Repos gewandert — neben dessen Automatismus-Status. So erscheinen die vorgeschlagenen Hausregeln eines Repos genau dort, wo auch seine übrige Aktivität sichtbar ist. Klick auf die 💡 öffnet den Drawer bei diesem Repo."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -122,7 +122,7 @@
   "automation_plan_gate_desc": "Grill + adversarial plan review before the agent runs",
   "automation_plan_gate_task_planning": "This task: gate active — planning",
   "automation_plan_gate_task_executing": "This task: plan approved — executing",
-  "drain_strip_label": "Drain",
+  "repo_status_label": "Repo status",
   "drain_inflight": "{count}/{max} auto",
   "drain_queued": "{count} queued",
   "drain_paused_blocked": "Paused: {desig} is blocked",
@@ -712,5 +712,7 @@
   "feat_backlog_pr_merge_train_title": "Launch a merge train from selected PRs",
   "feat_backlog_pr_merge_train_body": "Multi-select open PRs in a repo's backlog PRs tab and launch a merge train scoped to just those PRs.",
   "feat_header_fold_title": "Fold the header for more terminal",
-  "feat_header_fold_body": "On mobile, tap the chevron in the session header to collapse the tabs and PR rail and hand that space to the terminal. Your choice sticks across sessions."
+  "feat_header_fold_body": "On mobile, tap the chevron in the session header to collapse the tabs and PR rail and hand that space to the terminal. Your choice sticks across sessions.",
+  "feat_learnings_per_repo_title": "Learnings live on the repo row",
+  "feat_learnings_per_repo_body": "The lightbulb count moved off the top bar onto each repo's status row, next to its automation state — so a repo's proposed house rules show right where its other activity does. Click the 💡 to open the drawer at that repo."
 }

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -6,6 +6,7 @@
   import type { Learning, RepoInjectable, SignalKind } from "$lib/types";
   import {
     basename,
+    repoAnchorId,
     mergeRepoGroups,
     injectionBadge,
     injectedCount,
@@ -80,6 +81,7 @@
   let {
     items,
     injectable,
+    focusRepo = null,
     onapprove,
     ondismiss,
     ondistill,
@@ -88,6 +90,7 @@
   }: {
     items: Learning[];
     injectable: RepoInjectable[];
+    focusRepo?: string | null;
     onapprove: (id: string, rule: string) => void;
     ondismiss: (id: string) => void;
     ondistill: (repoPath: string) => void;
@@ -107,6 +110,16 @@
   const groups = $derived(mergeRepoGroups(items, injectable));
   // Empty only when there's nothing to curate in either view.
   const empty = $derived(groups.length === 0);
+
+  // Deep-link: when opened from a repo's status row, scroll that repo's section into
+  // view. Runs once on mount (a frame later, so the fly-in has laid out the sections).
+  $effect(() => {
+    if (!focusRepo) return;
+    const id = repoAnchorId(focusRepo);
+    requestAnimationFrame(() => {
+      document.getElementById(id)?.scrollIntoView({ block: "start" });
+    });
+  });
 </script>
 
 <div class="scrim" aria-hidden="true" onclick={() => onclose()}></div>
@@ -147,7 +160,7 @@
     <p class="empty">{m.learnings_empty()}</p>
   {:else}
     {#each groups as group (group.repoPath)}
-      <section class="group">
+      <section class="group" id={repoAnchorId(group.repoPath)}>
         <div class="ghead">
           <span class="repo">{basename(group.repoPath)}</span>
           <button

--- a/ui/src/lib/components/QueueStrip.svelte
+++ b/ui/src/lib/components/QueueStrip.svelte
@@ -359,4 +359,19 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
+  /* Coarse pointers: give the band's inline action buttons a ≥44px hit area
+     (mirrors the TopBar coarse-pointer pattern). The band reads a little taller on
+     touch, but the queued-count and learnings buttons clear the tap-target floor.
+     Desktop (pointer: fine) sizing is untouched, so the band stays compact there. */
+  @media (pointer: coarse) {
+    .qs-queued-btn,
+    .qs-insights {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 44px;
+      min-width: 44px;
+    }
+  }
 </style>

--- a/ui/src/lib/components/QueueStrip.svelte
+++ b/ui/src/lib/components/QueueStrip.svelte
@@ -1,28 +1,43 @@
 <script lang="ts">
-  import type { AutoMergeStatus, DrainStatus, QueuedItem } from "$lib/types";
+  import type {
+    AutoMergeStatus,
+    DrainStatus,
+    Learning,
+    QueuedItem,
+    RepoInjectable,
+  } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { getDrainQueue } from "$lib/api";
   import { basename } from "./learnings-drawer";
   import {
     activeMergeTrain,
-    enabledDrains,
     mergeTrainIsAttention,
     mergeTrainLabel,
     pausedText,
     queueOpenable,
+    repoStatusRows,
   } from "./queue-strip";
 
   let {
     drain,
     autoMerge = {},
-  }: { drain: Record<string, DrainStatus>; autoMerge?: Record<string, AutoMergeStatus> } = $props();
+    items = [],
+    injectable = [],
+    onlearnings,
+  }: {
+    drain: Record<string, DrainStatus>;
+    autoMerge?: Record<string, AutoMergeStatus>;
+    items?: Learning[];
+    injectable?: RepoInjectable[];
+    onlearnings?: (repoPath: string) => void;
+  } = $props();
 
-  const rows = $derived(enabledDrains(drain));
+  const rows = $derived(repoStatusRows(drain, items, injectable));
   const mergeRows = $derived(activeMergeTrain(autoMerge));
 
   // Lazy queue popover: at most one open at a time, fetched fresh on open.
   let openRepo = $state<string | null>(null);
-  let items = $state<QueuedItem[]>([]);
+  let queueItems = $state<QueuedItem[]>([]);
   let loading = $state(false);
   let failed = $state(false);
   let stripEl = $state<HTMLElement | null>(null);
@@ -34,12 +49,12 @@
     }
     const repo = d.repoPath;
     openRepo = repo;
-    items = [];
+    queueItems = [];
     failed = false;
     loading = true;
     try {
       const q = await getDrainQueue(repo);
-      if (openRepo === repo) items = q; // ignore a response for a since-switched popover
+      if (openRepo === repo) queueItems = q; // ignore a response for a since-switched popover
     } catch {
       if (openRepo === repo) failed = true;
     } finally {
@@ -58,32 +73,55 @@
 <svelte:window onkeydown={onWindowKeydown} onpointerdown={onWindowPointerdown} />
 
 {#if rows.length > 0}
-  <div class="queue-strip" role="status" aria-label={m.drain_strip_label()} bind:this={stripEl}>
-    <span class="qs-label">🚰 {m.drain_strip_label()}</span>
+  <div class="queue-strip" role="status" aria-label={m.repo_status_label()} bind:this={stripEl}>
+    <span class="qs-label">{m.repo_status_label()}</span>
     <ul class="qs-rows">
-      {#each rows as d (d.repoPath)}
-        <li class="qs-row" class:paused={d.paused}>
-          <span class="qs-repo">{basename(d.repoPath)}</span>
-          <span class="qs-inflight">{m.drain_inflight({ count: d.inFlight, max: d.max })}</span>
-          {#if queueOpenable(d)}
-            <button
-              type="button"
-              class="qs-queued qs-queued-btn"
-              aria-haspopup="dialog"
-              aria-expanded={openRepo === d.repoPath}
-              aria-label={m.drain_queue_open_aria({ count: d.queued, repo: basename(d.repoPath) })}
-              onclick={() => toggle(d)}
-            >
-              {m.drain_queued({ count: d.queued })}
-            </button>
-          {:else}
-            <span class="qs-queued">{m.drain_queued({ count: d.queued })}</span>
-          {/if}
-          {#if d.paused}
-            <span class="qs-pause" title={pausedText(d)}>{pausedText(d)}</span>
+      {#each rows as row (row.repoPath)}
+        <li class="qs-row" class:paused={row.drain?.paused}>
+          <span class="qs-repo">{basename(row.repoPath)}</span>
+          {#if row.drain}
+            {@const d = row.drain}
+            <span class="qs-inflight">{m.drain_inflight({ count: d.inFlight, max: d.max })}</span>
+            {#if queueOpenable(d)}
+              <button
+                type="button"
+                class="qs-queued qs-queued-btn"
+                aria-haspopup="dialog"
+                aria-expanded={openRepo === d.repoPath}
+                aria-label={m.drain_queue_open_aria({
+                  count: d.queued,
+                  repo: basename(d.repoPath),
+                })}
+                onclick={() => toggle(d)}
+              >
+                {m.drain_queued({ count: d.queued })}
+              </button>
+            {:else}
+              <span class="qs-queued">{m.drain_queued({ count: d.queued })}</span>
+            {/if}
+            {#if d.paused}
+              <span class="qs-pause" title={pausedText(d)}>{pausedText(d)}</span>
+            {/if}
           {/if}
 
-          {#if openRepo === d.repoPath}
+          {#if row.insights > 0 || row.curate > 0}
+            <button
+              type="button"
+              class="qs-insights"
+              title={m.learnings_badge_tip()}
+              aria-label={row.insights > 0
+                ? m.learnings_open_aria({ count: row.insights })
+                : m.learnings_open_curate_aria({ count: row.curate })}
+              onclick={() => onlearnings?.(row.repoPath)}
+            >
+              <span class="qs-insights-icon" aria-hidden="true">💡</span>{#if row.insights > 0}<span
+                  class="qs-insights-n">{row.insights}</span
+                >{/if}
+            </button>
+          {/if}
+
+          {#if row.drain && openRepo === row.repoPath}
+            {@const d = row.drain}
             <div
               class="qs-pop"
               role="dialog"
@@ -94,11 +132,11 @@
                 <div class="qs-pop-state">{m.common_loading()}</div>
               {:else if failed}
                 <div class="qs-pop-state qs-pop-fail">{m.drain_queue_error()}</div>
-              {:else if items.length === 0}
+              {:else if queueItems.length === 0}
                 <div class="qs-pop-state">{m.drain_queue_empty()}</div>
               {:else}
                 <ul class="qs-pop-list">
-                  {#each items as it (it.number)}
+                  {#each queueItems as it (it.number)}
                     <li>
                       <!-- eslint-disable svelte/no-navigation-without-resolve -- external forge URL, not an app route -->
                       <a
@@ -212,6 +250,28 @@
   .qs-queued-btn:hover,
   .qs-queued-btn:focus-visible {
     color: var(--color-ink-bright);
+  }
+  /* per-repo learnings entry point — 💡 + count, same inline-button chrome as the
+     queued button so the row reads as one band. */
+  .qs-insights {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font: inherit;
+    letter-spacing: inherit;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    color: var(--color-faint);
+  }
+  .qs-insights:hover,
+  .qs-insights:focus-visible {
+    color: var(--color-ink-bright);
+  }
+  .qs-insights-n {
+    font-variant-numeric: tabular-nums;
   }
   /* merge-train state: active tone (merging/rebasing) matches inflight color */
   .qs-mt-state {

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -53,7 +53,6 @@ interface Scenario {
 
 const allBadges = {
   needsYou: 3,
-  learnings: 5,
   update: { behind: 4 } as UpdateStatus,
   herdrUpdate: { updateAvailable: true } as HerdrUpdateStatus,
   whatsNew: true,
@@ -77,12 +76,11 @@ const SCENARIOS: Scenario[] = [
     props: { ...allBadges, ...sessionsProp(2) },
   },
   {
-    name: "touch-desktop 1000 — dual-update + learnings + needsYou + whatsNew",
+    name: "touch-desktop 1000 — dual-update + needsYou + whatsNew",
     mode: "touch-desktop",
     width: 1000,
     props: {
       needsYou: 2,
-      learnings: 3,
       update: { behind: 1 },
       herdrUpdate: { updateAvailable: true },
       whatsNew: true,
@@ -90,10 +88,10 @@ const SCENARIOS: Scenario[] = [
     },
   },
   {
-    name: "touch-desktop 1000 — lone learnings (#322 regression)",
+    name: "touch-desktop 1000 — lone needsYou (#322 regression)",
     mode: "touch-desktop",
     width: 1000,
-    props: { learnings: 4, ...sessionsProp(0) },
+    props: { needsYou: 4, ...sessionsProp(0) },
   },
   {
     name: "touch-desktop 960 — all badges (bracket)",
@@ -125,7 +123,7 @@ const SCENARIOS: Scenario[] = [
   // has usable < 1436 and may still clip; that sub-1480 edge is documented
   // out-of-scope — we do not assert the impossible for tiny desktop windows.)
   //
-  // FIXED (#322-desktop, then width-aware): with all five badges active the desktop
+  // FIXED (#322-desktop, then width-aware): with every badge active the desktop
   // bar's full-label content is ~1700px (with gauges: base 1055 + per-badge deltas;
   // the halt e-stop lives in the gear menu, not the bar) and had NO fallback — desktop never
   // compacted, so it overflowed 1436 on every monitor. Desktop compaction is now
@@ -145,7 +143,7 @@ const SCENARIOS: Scenario[] = [
   // with wide margin (the icon-collapsed cluster is far narrower than the full-label
   // form, which would be ~1751px).
   {
-    name: "desktop 1436 — all 6 badges + gauges (usable cap, compacts + fits)",
+    name: "desktop 1436 — all badges + gauges (usable cap, compacts + fits)",
     mode: "desktop",
     width: 1436,
     props: { ...allBadges, ...sessionsProp(2), limits: fullLimits },
@@ -159,7 +157,7 @@ const SCENARIOS: Scenario[] = [
   // ── Width-awareness: narrow desktop windows the old count-3 threshold MISSED ──
   // A ~1366px laptop gives the bar ~1322px usable; a ~1280px window ~1236px. With
   // the production-worst chrome (both usage gauges present), the full-label bar
-  // measures ~1333px for 2 badges (learnings + needsYou) and ~1450px for 3 — so it
+  // measures ~1333px for 2 badges (needsYou + update) and ~1450px for 3 — so it
   // overflows BOTH narrow widths even at just 2 badges, which the old count-3
   // threshold never compacted. Runtime measurement does. Each asserts the bar
   // compacts just enough to NOT overflow + keeps controls hittable. (Verified: with
@@ -169,7 +167,7 @@ const SCENARIOS: Scenario[] = [
     name: "desktop 1322 — 2 full-label badges + gauges (1366px laptop, measured compaction)",
     mode: "desktop",
     width: 1322,
-    props: { needsYou: 2, learnings: 3, limits: fullLimits, ...sessionsProp(0) },
+    props: { needsYou: 2, update: { behind: 3 }, limits: fullLimits, ...sessionsProp(0) },
   },
   {
     name: "desktop 1322 — 3 badges + gauges (1366px laptop, measured compaction)",
@@ -177,8 +175,8 @@ const SCENARIOS: Scenario[] = [
     width: 1322,
     props: {
       needsYou: 2,
-      learnings: 3,
       update: { behind: 2 },
+      herdrUpdate: { updateAvailable: true },
       limits: fullLimits,
       ...sessionsProp(0),
     },
@@ -187,7 +185,7 @@ const SCENARIOS: Scenario[] = [
     name: "desktop 1236 — 2 full-label badges + gauges (1280px window, measured compaction)",
     mode: "desktop",
     width: 1236,
-    props: { needsYou: 2, learnings: 3, limits: fullLimits, ...sessionsProp(0) },
+    props: { needsYou: 2, update: { behind: 3 }, limits: fullLimits, ...sessionsProp(0) },
   },
   {
     name: "desktop 1236 — 3 badges + gauges (1280px window, measured compaction)",
@@ -195,8 +193,8 @@ const SCENARIOS: Scenario[] = [
     width: 1236,
     props: {
       needsYou: 2,
-      learnings: 3,
       update: { behind: 2 },
+      herdrUpdate: { updateAvailable: true },
       limits: fullLimits,
       ...sessionsProp(0),
     },
@@ -292,17 +290,18 @@ describe("TopBar — no overflow, controls stay hittable", () => {
 
 describe("TopBar — wide desktop keeps full labels (measurement does NOT over-compact)", () => {
   // Width-awareness must not over-fire: at the TRUE usable cap (1436px = .shell
-  // 1480 - 2x22 padding) the WIDEST 2-badge selection (learnings + needsYou ~1354px
+  // 1480 - 2x22 padding) a wide 2-badge selection (needsYou + update ~1354px
   // incl. both usage gauges) STILL FITS, so the measured path must leave it FULL —
   // proving compaction triggers on real overflow, not merely on badge presence.
   // Settle the rAF first (the measurement might briefly flip), then assert it stays
   // non-compact. Plus a no-gauge variant. Both keep full labels AND fit 1436.
   //
-  // Asserts: (a) the learnings + needsYou badges are present and NOT collapsed to
-  // their .compact icon/count form (full labels showing), (b) no overflow, (c) all
-  // controls hittable - catching a future left-cluster or gap change that silently
-  // overflows the non-compact desktop path. (Sub-1436px desktop windows have less
-  // usable width and DO compact — covered by the narrow-desktop scenarios above.)
+  // Asserts: (a) the needsYou + update badges are present and showing their FULL
+  // labels (needsYou not in .compact form; the update badge still rendering its
+  // .up-label word), (b) no overflow, (c) all controls hittable - catching a future
+  // left-cluster or gap change that silently overflows the non-compact desktop path.
+  // (Sub-1436px desktop windows have less usable width and DO compact — covered by
+  // the narrow-desktop scenarios above.)
   const cases: Array<{ limits: UsageLimits | null; desc: string }> = [
     { limits: fullLimits, desc: "usable cap with gauges (worst-case chrome)" },
     { limits: null, desc: "usable cap no gauges" },
@@ -317,9 +316,9 @@ describe("TopBar — wide desktop keeps full labels (measurement does NOT over-c
         connected: true,
         mobile: false,
         touch: false,
-        // Widest 2-badge full-label combo (learnings + needsYou).
+        // Two full-label badges (needsYou + update).
         needsYou: 2,
-        learnings: 3,
+        update: { behind: 3 } as UpdateStatus,
         limits,
         ...sessionsProp(0),
       });
@@ -332,17 +331,18 @@ describe("TopBar — wide desktop keeps full labels (measurement does NOT over-c
       await nextFrame();
 
       // Full-label: both badges present and NOT in compact (icon/count) form.
-      const learnings = hud!.querySelector<HTMLElement>(".learnings-badge");
+      const update = hud!.querySelector<HTMLElement>(".update-badge");
       const needsYou = hud!.querySelector<HTMLElement>(".needsyou");
-      expect(learnings, "learnings badge present").not.toBeNull();
+      expect(update, "update badge present").not.toBeNull();
       expect(needsYou, "needsYou badge present").not.toBeNull();
-      expect(learnings!.classList.contains("compact"), "learnings NOT compact").toBe(false);
       expect(needsYou!.classList.contains("compact"), "needsYou NOT compact").toBe(false);
-      // The full word label renders inside the learnings badge (compact form omits it).
-      expect(learnings!.textContent ?? "", "learnings full label text").toContain(
-        m.learnings_title(),
+      // The full word label renders inside the update badge (compact form omits it).
+      const upLabel = update!.querySelector<HTMLElement>(".up-label");
+      expect(upLabel, "update full label present").not.toBeNull();
+      expect(upLabel!.textContent ?? "", "update full label text").toContain(
+        m.topbar_update_badge(),
       );
-      expect(learnings!.getBoundingClientRect().width, "learnings has width").toBeGreaterThan(0);
+      expect(update!.getBoundingClientRect().width, "update has width").toBeGreaterThan(0);
       expect(needsYou!.getBoundingClientRect().width, "needsYou has width").toBeGreaterThan(0);
 
       // Must still not overflow despite showing full labels.
@@ -378,7 +378,7 @@ describe("TopBar — pure resize decides from cached full width (no flicker)", (
       touch: false,
       // Widest 2-badge full-label chrome + both gauges (~1354px): fits 1436, overflows 1236.
       needsYou: 2,
-      learnings: 3,
+      update: { behind: 3 } as UpdateStatus,
       limits: fullLimits,
       ...sessionsProp(0),
     });
@@ -458,7 +458,7 @@ describe("TopBar — async gauge arrival re-measures (reactivity gap)", () => {
         mobile: false,
         touch: false,
         needsYou: 2,
-        learnings: 3,
+        update: { behind: 3 } as UpdateStatus,
         ...sessionsProp(0),
       });
       const hud = document.querySelector<HTMLElement>(".hud");

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -16,9 +16,6 @@
     onhalt,
     needsYou = 0,
     ontriage,
-    learnings = 0,
-    overBudget = 0,
-    onlearnings,
     update = null,
     onupdate,
     herdrUpdate = null,
@@ -36,9 +33,6 @@
     onhalt?: () => void;
     needsYou?: number;
     ontriage?: () => void;
-    learnings?: number;
-    overBudget?: number;
-    onlearnings?: () => void;
     update?: UpdateStatus | null;
     onupdate?: () => void;
     herdrUpdate?: HerdrUpdateStatus | null;
@@ -58,8 +52,6 @@
   const chrome = $derived({
     updateAvailable,
     herdrUpdateAvailable,
-    learnings,
-    overBudget,
     needsYou,
     whatsNew,
   });
@@ -326,27 +318,6 @@
           <span class="ny-icon" aria-hidden="true">!</span><span class="ny-n">{needsYou}</span>
         {:else}
           {m.common_needs_you({ count: needsYou })}
-        {/if}
-      </button>
-    {/if}
-    {#if learnings > 0 || overBudget > 0}
-      <button
-        class="learnings-badge tip tip-wide"
-        class:compact={mobile || compactBadges}
-        class:curate={learnings === 0}
-        onclick={() => onlearnings?.()}
-        data-tip={m.learnings_badge_tip()}
-        aria-label={learnings > 0
-          ? m.learnings_open_aria({ count: learnings })
-          : m.learnings_open_curate_aria({ count: overBudget })}
-      >
-        {#if mobile || compactBadges}
-          <span class="lr-icon" aria-hidden="true">💡</span>
-          {#if learnings > 0}<span class="lr-n">{learnings}</span>{/if}
-        {:else}
-          <span class="lr-icon" aria-hidden="true">💡</span>
-          {m.learnings_title()}
-          {#if learnings > 0}{learnings}{/if}
         {/if}
       </button>
     {/if}
@@ -727,32 +698,6 @@
   .halt-pip.alert {
     background: var(--color-red);
   }
-  .learnings-badge {
-    background: transparent;
-    border: 1px solid var(--color-line-bright);
-    color: var(--color-muted);
-    letter-spacing: 0.14em;
-    font-size: var(--fs-meta);
-    padding: 5px 10px;
-    cursor: pointer;
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-  .learnings-badge:hover {
-    color: var(--color-ink-bright);
-    border-color: var(--color-ink-bright);
-  }
-  /* Curate-only entry point (no pending proposals, just over-budget rules to prune):
-     a softer dashed border so it reads as informational rather than action-required. */
-  .learnings-badge.curate {
-    border-style: dashed;
-  }
-  /* Desktop: the 💡 leads the label; drop the badge's wide tracking on the glyph
-     so it sits snug against the word rather than floating off to its left. */
-  .learnings-badge:not(.compact) .lr-icon {
-    margin-right: 5px;
-    letter-spacing: 0;
-  }
   .rightside {
     margin-left: auto;
     display: flex;
@@ -1103,25 +1048,6 @@
   .needsyou.compact .ny-n {
     font-weight: 600;
   }
-  /* Phone: same collapse for the LEARNINGS badge — icon+count chip so it fits
-     on line 1 instead of widening the right-side controls into a second row.
-     Full label stays as the aria-label. */
-  .learnings-badge.compact {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 4px;
-    min-width: 44px;
-    padding: 8px 10px;
-    letter-spacing: 0;
-    font-variant-numeric: tabular-nums;
-  }
-  .learnings-badge.compact .lr-icon {
-    line-height: 1;
-  }
-  .learnings-badge.compact .lr-n {
-    font-weight: 600;
-  }
   .hud.mobile .update-badge {
     min-height: 44px;
   }
@@ -1135,8 +1061,6 @@
     .gear,
     .needsyou,
     .needsyou.compact,
-    .learnings-badge,
-    .learnings-badge.compact,
     .gauge-btn,
     .update-badge {
       min-height: 44px;
@@ -1180,14 +1104,6 @@
     .tip:focus-visible::after {
       opacity: 1;
       transform: translateY(0);
-    }
-    /* Wide variant for explanatory tooltips: let the sentence wrap instead of
-       forcing a single very-wide line. Right-anchored like the base .tip. */
-    .tip-wide::after {
-      white-space: normal;
-      width: max-content;
-      max-width: 260px;
-      line-height: 1.45;
     }
   }
 </style>

--- a/ui/src/lib/components/TopBarLimitsHarness.svelte
+++ b/ui/src/lib/components/TopBarLimitsHarness.svelte
@@ -11,7 +11,7 @@
 -->
 <script lang="ts">
   import TopBar from "./TopBar.svelte";
-  import type { Session, UsageLimits } from "$lib/types";
+  import type { Session, UsageLimits, UpdateStatus } from "$lib/types";
 
   let {
     sessions,
@@ -20,7 +20,7 @@
     mobile = false,
     touch = false,
     needsYou = 0,
-    learnings = 0,
+    update = null,
   }: {
     sessions: Session[];
     nowMs: number;
@@ -28,7 +28,7 @@
     mobile?: boolean;
     touch?: boolean;
     needsYou?: number;
-    learnings?: number;
+    update?: UpdateStatus | null;
   } = $props();
 
   // Starts null (no gauges) — the production first-paint state. The test flips it to a
@@ -50,7 +50,7 @@
   The host width is set by the test via document.body.style.width on this wrapper.
 -->
 <div class="shell-cap">
-  <TopBar {sessions} {nowMs} {connected} {mobile} {touch} {limits} {needsYou} {learnings} />
+  <TopBar {sessions} {nowMs} {connected} {mobile} {touch} {limits} {needsYou} {update} />
 </div>
 
 <style>

--- a/ui/src/lib/components/learnings-drawer.test.ts
+++ b/ui/src/lib/components/learnings-drawer.test.ts
@@ -49,11 +49,16 @@ describe("basename", () => {
 });
 
 describe("repoAnchorId", () => {
-  it("is a stable, DOM-id-safe slug of the full path", () => {
-    expect(repoAnchorId("/home/u/acme")).toBe("learnings-repo-home-u-acme");
+  it("is a DOM-id-safe slug of the full path with a disambiguating suffix", () => {
+    const id = repoAnchorId("/home/u/acme");
+    expect(id).toMatch(/^learnings-repo-home-u-acme-[a-z0-9]+$/);
   });
   it("distinguishes repos that share a basename (no collision)", () => {
     expect(repoAnchorId("/work/a/api")).not.toBe(repoAnchorId("/work/b/api"));
+  });
+  it("distinguishes paths that differ only in punctuation (injective slug)", () => {
+    // both slugify to "r-a-b"; the raw-path hash keeps the ids distinct
+    expect(repoAnchorId("/r/a-b")).not.toBe(repoAnchorId("/r/a/b"));
   });
   it("is deterministic for the same path", () => {
     expect(repoAnchorId("/x/Y/Z")).toBe(repoAnchorId("/x/Y/Z"));

--- a/ui/src/lib/components/learnings-drawer.test.ts
+++ b/ui/src/lib/components/learnings-drawer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, test } from "vitest";
 import {
   basename,
+  repoAnchorId,
   groupByRepo,
   mergeRepoGroups,
   injectionBadge,
@@ -45,6 +46,18 @@ function IR(
 describe("basename", () => {
   it("takes the last path segment", () => expect(basename("/home/u/acme")).toBe("acme"));
   it("tolerates trailing slash", () => expect(basename("/home/u/acme/")).toBe("acme"));
+});
+
+describe("repoAnchorId", () => {
+  it("is a stable, DOM-id-safe slug of the full path", () => {
+    expect(repoAnchorId("/home/u/acme")).toBe("learnings-repo-home-u-acme");
+  });
+  it("distinguishes repos that share a basename (no collision)", () => {
+    expect(repoAnchorId("/work/a/api")).not.toBe(repoAnchorId("/work/b/api"));
+  });
+  it("is deterministic for the same path", () => {
+    expect(repoAnchorId("/x/Y/Z")).toBe(repoAnchorId("/x/Y/Z"));
+  });
 });
 
 describe("groupByRepo", () => {

--- a/ui/src/lib/components/learnings-drawer.ts
+++ b/ui/src/lib/components/learnings-drawer.ts
@@ -6,13 +6,19 @@ export function basename(p: string): string {
 }
 
 /** Stable DOM anchor id for a repo's drawer section, derived from the FULL repoPath
- *  (not basename — two repos can share a basename, which would collide). Used to
- *  deep-link the drawer to a repo when opened from the per-repo status row. */
+ *  (not basename — two repos can share a basename, which would collide). A readable
+ *  slug carries the gist for debugging, and a djb2 hash of the RAW path disambiguates
+ *  paths that slugify identically (differ only in punctuation, e.g. `/r/a-b` vs
+ *  `/r/a/b`), so the id is injective. Used to deep-link the drawer to a repo when
+ *  opened from the per-repo status row. */
 export function repoAnchorId(repoPath: string): string {
-  return `learnings-repo-${repoPath
+  let h = 5381;
+  for (let i = 0; i < repoPath.length; i++) h = ((h << 5) + h + repoPath.charCodeAt(i)) >>> 0;
+  const slug = repoPath
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")}`;
+    .replace(/^-+|-+$/g, "");
+  return `learnings-repo-${slug}-${h.toString(36)}`;
 }
 
 /** Group learnings by repoPath, preserving first-seen order. */

--- a/ui/src/lib/components/learnings-drawer.ts
+++ b/ui/src/lib/components/learnings-drawer.ts
@@ -5,6 +5,16 @@ export function basename(p: string): string {
   return p.split("/").filter(Boolean).at(-1) ?? p;
 }
 
+/** Stable DOM anchor id for a repo's drawer section, derived from the FULL repoPath
+ *  (not basename — two repos can share a basename, which would collide). Used to
+ *  deep-link the drawer to a repo when opened from the per-repo status row. */
+export function repoAnchorId(repoPath: string): string {
+  return `learnings-repo-${repoPath
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")}`;
+}
+
 /** Group learnings by repoPath, preserving first-seen order. */
 export function groupByRepo(items: Learning[]): [string, Learning[]][] {
   const map = new Map<string, Learning[]>();

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -6,8 +6,9 @@ import {
   mergeTrainLabel,
   pausedText,
   queueOpenable,
+  repoStatusRows,
 } from "./queue-strip";
-import type { AutoMergeStatus, DrainStatus } from "../types";
+import type { AutoMergeStatus, DrainStatus, Learning, RepoInjectable } from "../types";
 
 function drain(over: Partial<DrainStatus>): DrainStatus {
   return {
@@ -19,6 +20,39 @@ function drain(over: Partial<DrainStatus>): DrainStatus {
     queued: 0,
     inFlight: 0,
     max: 1,
+    ...over,
+  };
+}
+
+function learning(over: Partial<Learning>): Learning {
+  return {
+    id: "l1",
+    repoPath: "/repos/a",
+    rule: "r",
+    rationale: "",
+    evidence: [],
+    status: "proposed",
+    evidenceCount: 0,
+    ineffectiveCount: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    lastEvidenceAt: null,
+    promotedPrUrl: null,
+    ...over,
+  };
+}
+
+function rule(injected: boolean): Learning & { injected: boolean } {
+  return { ...learning({}), injected };
+}
+
+function injectable(over: Partial<RepoInjectable>): RepoInjectable {
+  return {
+    repoPath: "/repos/a",
+    enabled: true,
+    budgetChars: 100,
+    usedChars: 0,
+    rules: [],
     ...over,
   };
 }
@@ -150,5 +184,77 @@ describe("mergeTrainLabel", () => {
   });
   it("merge_error label differs from merging label", () => {
     expect(mergeTrainLabel("merge_error")).not.toBe(mergeTrainLabel("merging"));
+  });
+});
+
+// ─── repoStatusRows (generalized per-repo band) ──────────────────────────────
+
+describe("repoStatusRows", () => {
+  it("unions enabled-drain repos with learnings repos, sorted by path", () => {
+    const rows = repoStatusRows(
+      { z: drain({ repoPath: "/repos/z" }) },
+      [learning({ repoPath: "/repos/a" })],
+      [],
+    );
+    expect(rows.map((r) => r.repoPath)).toEqual(["/repos/a", "/repos/z"]);
+  });
+
+  it("an insight-only repo gets a row with drain:null and the proposal count", () => {
+    const rows = repoStatusRows(
+      {},
+      [learning({ id: "1", repoPath: "/repos/a" }), learning({ id: "2", repoPath: "/repos/a" })],
+      [],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ repoPath: "/repos/a", drain: null, insights: 2, curate: 0 });
+  });
+
+  it("a drain-only repo has insights:0 and curate:0 and carries its drain", () => {
+    const rows = repoStatusRows({ a: drain({ repoPath: "/repos/a", inFlight: 1 }) }, [], []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].drain?.inFlight).toBe(1);
+    expect(rows[0]).toMatchObject({ insights: 0, curate: 0 });
+  });
+
+  it("a disabled drain never produces a row or leaks into an insight-only row", () => {
+    const rows = repoStatusRows(
+      { a: drain({ repoPath: "/repos/a", enabled: false, inFlight: 5 }) },
+      [learning({ repoPath: "/repos/a" })],
+      [],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].drain).toBeNull(); // disabled drain stays out of the row
+  });
+
+  it("curate counts over-budget rules of an enabled repo with no proposals", () => {
+    const rows = repoStatusRows(
+      {},
+      [],
+      [injectable({ repoPath: "/repos/a", rules: [rule(true), rule(false), rule(false)] })],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ insights: 0, curate: 2 });
+  });
+
+  it("a disabled injectable repo never curates (pruning can't help)", () => {
+    const rows = repoStatusRows(
+      {},
+      [],
+      [injectable({ repoPath: "/repos/a", enabled: false, rules: [rule(false)] })],
+    );
+    expect(rows).toEqual([]);
+  });
+
+  it("proposals suppress the curate fallback (badge showed the count, not curate)", () => {
+    const rows = repoStatusRows(
+      {},
+      [learning({ repoPath: "/repos/a" })],
+      [injectable({ repoPath: "/repos/a", rules: [rule(false)] })],
+    );
+    expect(rows[0]).toMatchObject({ insights: 1, curate: 0 });
+  });
+
+  it("returns an empty list when nothing is drained, proposed, or over budget", () => {
+    expect(repoStatusRows({ a: drain({ enabled: false }) }, [], [])).toEqual([]);
   });
 });

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -1,10 +1,72 @@
-import type { AutoMergeStatus, DrainStatus } from "../types";
+import type { AutoMergeStatus, DrainStatus, Learning, RepoInjectable } from "../types";
 import { m } from "$lib/paraglide/messages";
 
 /** Enabled drains only, sorted by repo path — the rows the QueueStrip renders. */
 export function enabledDrains(drain: Record<string, DrainStatus>): DrainStatus[] {
   return Object.values(drain)
     .filter((d) => d.enabled)
+    .sort((a, b) => a.repoPath.localeCompare(b.repoPath));
+}
+
+/** One row in the generalized per-repo status band: the repo's drain (only when
+ *  enabled), plus its learnings footprint. A row exists when the repo has an enabled
+ *  drain OR something to surface in the learnings drawer (proposals or curate need). */
+export interface RepoStatusRow {
+  repoPath: string;
+  /** The enabled drain for this repo, or null for an insight-only row. */
+  drain: DrainStatus | null;
+  /** Count of pending (proposed) learnings for this repo. */
+  insights: number;
+  /** Over-budget rule count surfaced ONLY when there are no proposals — the #253
+   *  "curate" case the old TopBar badge fell back to. 0 = nothing to curate. */
+  curate: number;
+}
+
+/** Count of an injectable repo's active rules that didn't fit its budget — only
+ *  meaningful when injection is enabled (pruning can free room; disabled → 0). */
+function overBudgetCount(repo: RepoInjectable): number {
+  return repo.enabled ? repo.rules.filter((r) => !r.injected).length : 0;
+}
+
+/**
+ * Build the per-repo status rows for the QueueStrip's first band: the union of
+ * repos with an ENABLED drain and repos with a learnings footprint (pending
+ * proposals or an over-budget curate need). `drain` is taken only from
+ * `enabledDrains` — a disabled drain entry never produces a row or leaks its
+ * inflight/queue/popover into an insight-only row. Sorted by repoPath.
+ */
+export function repoStatusRows(
+  drain: Record<string, DrainStatus>,
+  items: Learning[],
+  injectable: RepoInjectable[],
+): RepoStatusRow[] {
+  const drains = new Map(enabledDrains(drain).map((d) => [d.repoPath, d]));
+
+  const insightsByRepo = new Map<string, number>();
+  for (const l of items) insightsByRepo.set(l.repoPath, (insightsByRepo.get(l.repoPath) ?? 0) + 1);
+
+  const curateByRepo = new Map<string, number>();
+  for (const r of injectable) {
+    const n = overBudgetCount(r);
+    if (n > 0) curateByRepo.set(r.repoPath, n);
+  }
+
+  const repoPaths = new Set<string>([
+    ...drains.keys(),
+    ...insightsByRepo.keys(),
+    ...curateByRepo.keys(),
+  ]);
+
+  return [...repoPaths]
+    .map((repoPath) => {
+      const insights = insightsByRepo.get(repoPath) ?? 0;
+      return {
+        repoPath,
+        drain: drains.get(repoPath) ?? null,
+        insights,
+        curate: insights === 0 ? (curateByRepo.get(repoPath) ?? 0) : 0,
+      };
+    })
     .sort((a, b) => a.repoPath.localeCompare(b.repoPath));
 }
 

--- a/ui/src/lib/components/top-bar-layout.test.ts
+++ b/ui/src/lib/components/top-bar-layout.test.ts
@@ -8,18 +8,16 @@ import { badgeCount, topBarPlan, type Mode, type ChromeState } from "./top-bar-l
 
 const MODES: Mode[] = ["mobile", "touch-desktop", "desktop"];
 
-// Build every ChromeState from a 5-bit mask over the five badge-presence inputs.
+// Build every ChromeState from a 4-bit mask over the four badge-presence inputs.
 // The halt e-stop is NOT a bar badge (it lives in the gear menu), so it never
 // appears here.
-const ALL = 0b11111; // all five badges present
+const ALL = 0b1111; // all four badges present
 function stateFromMask(mask: number): ChromeState {
   return {
     updateAvailable: !!(mask & 1),
     herdrUpdateAvailable: !!(mask & 2),
-    learnings: mask & 4 ? 1 : 0,
-    overBudget: 0,
-    needsYou: mask & 8 ? 1 : 0,
-    whatsNew: !!(mask & 16),
+    needsYou: mask & 4 ? 1 : 0,
+    whatsNew: !!(mask & 8),
   };
 }
 
@@ -28,26 +26,21 @@ function expectedCount(s: ChromeState): number {
   return (
     (s.updateAvailable ? 1 : 0) +
     (s.herdrUpdateAvailable ? 1 : 0) +
-    (s.learnings > 0 || s.overBudget > 0 ? 1 : 0) +
     (s.needsYou > 0 ? 1 : 0) +
     (s.whatsNew ? 1 : 0)
   );
 }
 
 describe("badgeCount", () => {
-  it("counts each present badge once across all 32 presence combos", () => {
+  it("counts each present badge once across all 16 presence combos", () => {
     for (let mask = 0; mask <= ALL; mask++) {
       const s = stateFromMask(mask);
       expect(badgeCount(s)).toBe(expectedCount(s));
     }
   });
-
-  it("overBudget alone (no learnings) still counts the learnings badge", () => {
-    expect(badgeCount({ ...stateFromMask(0), overBudget: 3 })).toBe(1);
-  });
 });
 
-describe("topBarPlan — exhaustive 3 modes × 32 presence combos", () => {
+describe("topBarPlan — exhaustive 3 modes × 16 presence combos", () => {
   // Desktop compaction is measurement-driven (TopBar.svelte / TopBar.browser.test.ts),
   // so the pure layer always returns false for desktop here.
   it("hideClockTime only on touch-desktop (>=1 badge); desktop + mobile never", () => {
@@ -76,15 +69,15 @@ describe("topBarPlan — exhaustive 3 modes × 32 presence combos", () => {
 });
 
 describe("regression anchors (#322 / #247)", () => {
-  it("lone LEARNINGS on touch-desktop drops the clock but does NOT compact", () => {
-    const s = stateFromMask(0b00100); // learnings only
+  it("a lone badge on touch-desktop drops the clock but does NOT compact", () => {
+    const s = stateFromMask(0b0100); // needsYou only
     const plan = topBarPlan("touch-desktop", s);
     expect(plan.hideClockTime).toBe(true);
     expect(plan.compactBadges).toBe(false);
   });
 
   it("two badges on touch-desktop compact the row", () => {
-    const s = stateFromMask(0b01100); // learnings + needsYou
+    const s = stateFromMask(0b1100); // needsYou + whatsNew
     expect(topBarPlan("touch-desktop", s).compactBadges).toBe(true);
   });
 

--- a/ui/src/lib/components/top-bar-layout.ts
+++ b/ui/src/lib/components/top-bar-layout.ts
@@ -13,14 +13,12 @@
 
 export type Mode = "mobile" | "touch-desktop" | "desktop";
 
-/** The five already-computed badge-presence inputs the bar counts for crowding.
+/** The already-computed badge-presence inputs the bar counts for crowding.
  * The halt e-stop is NOT among them — it lives in the always-present gear menu,
  * never in the right-side cluster, so `working` doesn't affect bar crowding. */
 export interface ChromeState {
   updateAvailable: boolean;
   herdrUpdateAvailable: boolean;
-  learnings: number;
-  overBudget: number;
   needsYou: number;
   whatsNew: boolean;
 }
@@ -44,7 +42,6 @@ export function badgeCount(s: ChromeState): number {
   return (
     (s.updateAvailable ? 1 : 0) +
     (s.herdrUpdateAvailable ? 1 : 0) +
-    (s.learnings > 0 || s.overBudget > 0 ? 1 : 0) +
     (s.needsYou > 0 ? 1 : 0) +
     (s.whatsNew ? 1 : 0)
   );

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -141,4 +141,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_header_fold_title",
     bodyKey: "feat_header_fold_body",
   },
+  {
+    // No targetId: the repo-status band only renders when a repo has an active drain
+    // or pending learnings, so a coachmark anchor would often be unmounted — surface
+    // via the What's-New drawer only.
+    id: "learnings-per-repo",
+    sinceVersion: "1.20.0",
+    titleKey: "feat_learnings_per_repo_title",
+    bodyKey: "feat_learnings_per_repo_body",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -89,6 +89,9 @@
   let clearMergedLeftovers = $state(0);
   let showTriage = $state(false);
   let showLearnings = $state(false);
+  // When the learnings drawer is opened from a repo's status row, this carries that
+  // repoPath so the drawer scrolls to the matching section; null = opened globally.
+  let learningsRepo = $state<string | null>(null);
   let showUpdate = $state(false);
   // live state of a launched deploy → modal tails its log + surfaces failures
   let deploy = $state<DeployState | null>(null);
@@ -112,15 +115,6 @@
     if (showLearnings && learnings.items.length === 0 && learnings.injectable.length === 0)
       showLearnings = false;
   });
-  // Active/promoted rules that an enabled repo wants to inject but couldn't fit in
-  // the budget — the #253 case. Drives a TopBar entry point even with zero proposals
-  // (disabled repos are excluded: pruning won't help, re-enabling injection would).
-  const overBudgetRules = $derived(
-    learnings.injectable.reduce(
-      (n, repo) => n + (repo.enabled ? repo.rules.filter((r) => !r.injected).length : 0),
-      0,
-    ),
-  );
   let viewMode = $state<"focus" | "all">("focus");
   let nowMs = $state(Date.now());
   let composeRepoPath = $state<string | null>(null);
@@ -700,9 +694,6 @@
         onhalt={haltHerd}
         needsYou={blockedEntries.length}
         ontriage={() => (showTriage = true)}
-        learnings={learnings.items.length}
-        overBudget={overBudgetRules}
-        onlearnings={() => (showLearnings = true)}
         update={store.update}
         onupdate={() => (showUpdate = true)}
         herdrUpdate={store.herdrUpdate}
@@ -710,7 +701,16 @@
         whatsNew={whatsNewDotOn}
         onwhatsnew={() => (showWhatsNew = true)}
       />
-      <QueueStrip drain={store.drain} autoMerge={store.autoMerge} />
+      <QueueStrip
+        drain={store.drain}
+        autoMerge={store.autoMerge}
+        items={learnings.items}
+        injectable={learnings.injectable}
+        onlearnings={(repoPath) => {
+          learningsRepo = repoPath;
+          showLearnings = true;
+        }}
+      />
     </div>
   {/if}
 
@@ -872,6 +872,7 @@
     <LearningsDrawer
       items={learnings.items}
       injectable={learnings.injectable}
+      focusRepo={learningsRepo}
       onapprove={(id, rule) =>
         approveLearning(id, rule)
           .then(() => learnings.load())
@@ -891,7 +892,10 @@
             return learnings.load();
           })
           .catch(() => toasts.info(m.learnings_promote_failed()))}
-      onclose={() => (showLearnings = false)}
+      onclose={() => {
+        showLearnings = false;
+        learningsRepo = null;
+      }}
     />
   {/if}
 </div>


### PR DESCRIPTION
## Was & warum

Die **Erkenntnisse** (Learnings) waren bisher nur als globale 💡-Badge oben rechts in der Top-Bar sichtbar (Gesamtzahl über alle Repos). Die zugrunde liegenden Daten sind aber bereits **pro Repo** (jeder `Learning` trägt `repoPath`). Diese Änderung verlagert die Erkenntnisse an **eine** konsolidierte Stelle: in die linke per-Repo-Status-Zeile, direkt neben den Automatismus-Status — genau dort, wo die übrige Aktivität eines Repos sichtbar ist.

## Änderungen

- **QueueStrip verallgemeinert:** Das erste Band ist jetzt eine Repo-Status-Zeile. Pro Repo erscheint eine Zeile, wenn **entweder** ein Drain aktiv ist **oder** Erkenntnisse vorliegen (offene Vorschläge bzw. Over-Budget-Regeln zum Kuratieren). `💡 N` öffnet den Learnings-Drawer bei der Sektion dieses Repos.
- **Label neutralisiert:** `drain_strip_label` ("Drain"/"Queue", 🚰) → `repo_status_label` ("Repo status"/"Repo-Status"), da das Band nun beide Bedeutungen trägt.
- **Top-Bar-Badge entfernt:** inkl. Props/CSS und der learnings-Eingaben im responsiven Layout-Helper (`badgeCount`/`ChromeState`). Die Always-on-Präsenz wird nur **verlagert, nicht neu eingeführt** — die alte Badge erschien unter exakt derselben Bedingung.
- **Drawer-Deep-Link:** neuer `focusRepo`-Anker (stabiler Slug des **vollen** `repoPath`, nicht `basename` → keine Kollision bei gleichnamigen Repos).
- **Over-Budget/Curate-Fall (#253)** bleibt über die Repo-Zeile erreichbar.

## Tests / Checks

- Neue Helfer `repoStatusRows` + `repoAnchorId` mit Unit-Tests.
- TopBar-Layout- und Browser-Tests von der entfernten Badge umgestellt.
- Feature-Katalog-Eintrag (`learnings-per-repo`, since 1.20.0) + i18n (EN/DE) ergänzt.
- `bun run check` ✓ · `check:i18n` ✓ (696 Keys Parität) · `test:node` ✓ (547) · `test:browser` ✓ (65) · pre-push ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)