### PR TITLE
fix(a11y): row/tile clickable surface as overlay button, not a wrapping <button> (#412)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -23,6 +23,7 @@
   "common_needs_you": "BRAUCHT DICH · {count}",
   "common_no_open_issues": "keine offenen Issues",
   "main_no_unit_selected": "KEINE AUFGABE GEWÄHLT",
+  "unit_open_aria": "{name} öffnen",
   "emptyherd_title": "Leitstand, keine Einheiten",
   "emptyherd_lede": "Shepherd steuert einen Verbund aktiver Claude-Code-Sitzungen. Starte eine Aufgabe und sie bekommt ein eigenes Worktree, einen Branch und ein Terminal, das du direkt lenkst.",
   "emptyherd_spawn": "Erste Aufgabe starten",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -23,6 +23,7 @@
   "common_needs_you": "NEEDS YOU · {count}",
   "common_no_open_issues": "no open issues",
   "main_no_unit_selected": "NO TASK SELECTED",
+  "unit_open_aria": "Open {name}",
   "emptyherd_title": "Mission control, no units",
   "emptyherd_lede": "Shepherd runs a herd of live Claude Code sessions. Spawn a task and it gets its own worktree, branch, and terminal you steer in place.",
   "emptyherd_spawn": "Spawn first task",

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -165,7 +165,7 @@
           <HeartbeatStrip {activity} {nowMs} />
           {#if summary}
             <span class="act-sep" aria-hidden="true">·</span>
-            <span class="act-sum" title={summary}>{summary}</span>
+            <span class="act-sum">{summary}</span>
           {/if}
         </div>
       {/if}

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -133,6 +133,7 @@
       type="button"
       aria-label={m.unit_open_aria({ name: session.name })}
       aria-describedby="u-repo-{session.id} u-sub-{session.id} u-status-{session.id}"
+      title={session.repoPath}
       onclick={() => onselect(session.id)}
     ></button>
     <div class="pip-col">
@@ -147,7 +148,9 @@
       <div class="u-top">
         <span class="name">{session.name}</span>
       </div>
-      <div class="u-repo" id="u-repo-{session.id}" title={session.repoPath}>
+      <!-- repoPath tooltip lives on .unit-hit (overlay covers this line), so it
+           still surfaces on row hover; describedby reads this line's repo name -->
+      <div class="u-repo" id="u-repo-{session.id}">
         <span class="repo-glyph" class:emoji={repoIcon} aria-hidden="true">{repoIcon ?? "▣"}</span
         >{repoName}
       </div>

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -122,14 +122,19 @@
 </script>
 
 {#snippet row()}
-  <button
+  <div
     class="unit"
     class:sel={selected}
     class:decommissioning
     style="--rule:{session.readyToMerge ? 'var(--color-green)' : STATUS_COLOR[session.status]}"
-    onclick={() => onselect(session.id)}
-    type="button"
   >
+    <button
+      class="unit-hit"
+      type="button"
+      aria-label={m.unit_open_aria({ name: session.name })}
+      aria-describedby="u-repo-{session.id} u-sub-{session.id} u-status-{session.id}"
+      onclick={() => onselect(session.id)}
+    ></button>
     <div class="pip-col">
       <StatusPip
         status={session.status}
@@ -142,14 +147,14 @@
       <div class="u-top">
         <span class="name">{session.name}</span>
       </div>
-      <div class="u-repo" title={session.repoPath}>
+      <div class="u-repo" id="u-repo-{session.id}" title={session.repoPath}>
         <span class="repo-glyph" class:emoji={repoIcon} aria-hidden="true">{repoIcon ?? "▣"}</span
         >{repoName}
       </div>
-      <div class="u-sub">
+      <div class="u-sub" id="u-sub-{session.id}">
         {session.prompt}
         {#if session.status === "running"}
-          <span class="car">▏</span>
+          <span class="car" aria-hidden="true">▏</span>
         {/if}
       </div>
       {#if live}
@@ -169,11 +174,11 @@
       <PlanGateBadge {session} />
       <AutopilotBadge {session} />
       {#if isMerging(session, nowMs)}
-        <span class="badge merging">{m.status_merging()}</span>
+        <span class="badge merging" id="u-status-{session.id}">{m.status_merging()}</span>
       {:else if session.readyToMerge}
-        <span class="badge">{m.status_ready_to_merge()}</span>
+        <span class="badge" id="u-status-{session.id}">{m.status_ready_to_merge()}</span>
       {:else if !hideStatus}
-        <span class="badge">{statusLabel(session.status)}</span>
+        <span class="badge" id="u-status-{session.id}">{statusLabel(session.status)}</span>
       {/if}
       <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
     </div>
@@ -188,7 +193,7 @@
         </span>
       {/if}
     </span>
-  </button>
+  </div>
 {/snippet}
 
 {#if swipe}
@@ -249,6 +254,35 @@
      window — fade it so it visibly recedes; restored instantly on UNDO */
   .unit.decommissioning {
     opacity: 0.4;
+  }
+
+  /* Transparent overlay that IS the row's click/keyboard target — keeps the
+     card a <div> so the interactive PlanGate badge can sit as a sibling instead
+     of an (invalid) nested <button>. */
+  .unit-hit {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    border-radius: inherit;
+    font: inherit;
+    color: inherit;
+  }
+  .unit-hit:focus-visible {
+    outline: 1.5px solid var(--color-line-bright);
+    outline-offset: -1.5px;
+  }
+
+  /* Raise the interactive badge above the overlay so it's clickable. */
+  .u-right > :global(button),
+  .u-right > :global([role="button"]) {
+    position: relative;
+    z-index: 1;
   }
 
   :global(.unit + .unit),
@@ -314,6 +348,7 @@
     bottom: 8px;
     width: 1px;
     background: var(--rule, var(--color-faint));
+    pointer-events: none;
   }
 
   .unit:hover {
@@ -343,6 +378,7 @@
     border: 1px solid var(--color-line-bright);
     border-left: 0;
     border-top: 0;
+    pointer-events: none;
   }
 
   .pip-col {
@@ -465,12 +501,12 @@
         opacity 0.14s ease;
     }
     .unit:hover .act-sep,
-    .unit:focus-visible .act-sep {
+    .unit:focus-within .act-sep {
       display: inline;
       margin: 0 5px;
     }
     .unit:hover .act-sum,
-    .unit:focus-visible .act-sum {
+    .unit:focus-within .act-sum {
       max-width: 34ch;
       opacity: 1;
     }
@@ -582,7 +618,7 @@
        later in source → wins) so a hovered narrow row doesn't show a dangling
        "·" with no summary after it. */
     .unit:hover .act-sep,
-    .unit:focus-visible .act-sep {
+    .unit:focus-within .act-sep {
       display: none;
     }
     /* the strip IS the heartbeat here — keep it, just narrower. Scoped under

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -107,6 +107,21 @@
 
   const hideStatus = $derived(hideStatusBadge(session.status, reviews.isReviewing(session.id)));
 
+  // A status badge renders for merging / ready / a non-hidden status; only then
+  // does #u-status-{id} exist. Build the overlay's aria-describedby so it omits
+  // that id when no badge renders (reviewing && done/idle) — no dangling IDREF.
+  const describedBy = $derived(
+    [
+      `u-repo-${session.id}`,
+      `u-sub-${session.id}`,
+      isMerging(session, nowMs) || session.readyToMerge || !hideStatus
+        ? `u-status-${session.id}`
+        : null,
+    ]
+      .filter(Boolean)
+      .join(" "),
+  );
+
   // live signals (heartbeat + current tool) only make sense while the agent works
   const live = $derived(session.status === "running");
   // verbatim tool summary — NOT translated; shown as a quiet line when present
@@ -132,7 +147,7 @@
       class="unit-hit"
       type="button"
       aria-label={m.unit_open_aria({ name: session.name })}
-      aria-describedby="u-repo-{session.id} u-sub-{session.id} u-status-{session.id}"
+      aria-describedby={describedBy}
       title={session.repoPath}
       onclick={() => onselect(session.id)}
     ></button>

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -30,6 +30,18 @@
 
   const hideStatus = $derived(hideStatusBadge(session.status, reviews.isReviewing(session.id)));
 
+  // A status badge renders for ready / a non-hidden status; only then does
+  // #tile-status-{id} exist. Build the overlay's aria-describedby so it omits
+  // that id when no badge renders (reviewing && done/idle) — no dangling IDREF.
+  const describedBy = $derived(
+    [
+      session.readyToMerge || !hideStatus ? `tile-status-${session.id}` : null,
+      `tile-desig-${session.id}`,
+    ]
+      .filter(Boolean)
+      .join(" "),
+  );
+
   let el: HTMLDivElement | undefined = $state();
   let termRef = $state<Terminal | undefined>();
 
@@ -132,7 +144,7 @@
     class="tile-hit"
     type="button"
     aria-label={m.unit_open_aria({ name: session.name })}
-    aria-describedby="tile-status-{session.id} tile-desig-{session.id}"
+    aria-describedby={describedBy}
     onclick={() => onselect(session.id)}
   ></button>
   <div class="t-head">

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -123,13 +123,18 @@
   });
 </script>
 
-<button
+<div
   class="tile"
   class:sel={selected}
   style="--rule:{session.readyToMerge ? 'var(--color-green)' : STATUS_COLOR[session.status]}"
-  type="button"
-  onclick={() => onselect(session.id)}
 >
+  <button
+    class="tile-hit"
+    type="button"
+    aria-label={m.unit_open_aria({ name: session.name })}
+    aria-describedby="tile-status-{session.id} tile-desig-{session.id}"
+    onclick={() => onselect(session.id)}
+  ></button>
   <div class="t-head">
     <span class="name">{session.name}</span>
     <span class="spacer"></span>
@@ -142,18 +147,18 @@
     <AutopilotBadge {session} />
     <AutoPip {session} />
     {#if session.readyToMerge}
-      <span class="badge">{m.status_ready_to_merge()}</span>
+      <span class="badge" id="tile-status-{session.id}">{m.status_ready_to_merge()}</span>
     {:else if !hideStatus}
-      <span class="badge" class:alert={session.status === "blocked"}
+      <span class="badge" class:alert={session.status === "blocked"} id="tile-status-{session.id}"
         >{statusLabel(session.status)}</span
       >
     {/if}
-    <span class="desig">{session.desig}</span>
+    <span class="desig" id="tile-desig-{session.id}">{session.desig}</span>
   </div>
   <div class="t-body">
     <div class="t-mount" bind:this={el}></div>
   </div>
-</button>
+</div>
 
 <style>
   .tile {
@@ -181,6 +186,34 @@
     width: 1px;
     background: var(--rule, var(--color-faint));
     z-index: 2;
+    pointer-events: none;
+  }
+  /* Transparent overlay that IS the tile's click/keyboard target — keeps the
+     card a <div> so the interactive PlanGate badge can sit as a sibling instead
+     of an (invalid) nested <button>. */
+  .tile-hit {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    border-radius: inherit;
+    font: inherit;
+    color: inherit;
+  }
+  .tile-hit:focus-visible {
+    outline: 1.5px solid var(--color-line-bright);
+    outline-offset: -1.5px;
+  }
+  /* Raise the interactive badge above the overlay so it's clickable. */
+  .t-head > :global(button),
+  .t-head > :global([role="button"]) {
+    position: relative;
+    z-index: 1;
   }
   .tile:hover {
     border-color: var(--color-line-bright);

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -296,6 +296,11 @@
     position: relative;
     flex: 1;
     overflow: hidden;
+    /* The read-only monitor terminal is positioned (relative), so without this
+       it would paint above the .tile-hit overlay (same stack level, later in
+       source) and swallow body clicks. Let clicks fall through to the overlay so
+       the whole tile selects; the terminal needs no pointer interaction. */
+    pointer-events: none;
   }
   .t-mount {
     position: absolute;


### PR DESCRIPTION
Closes #412.

## Problem

`PlanGateBadge` renders a real `<button>` that was nested inside both `UnitRow`'s wrapping `<button class="unit">` and `UnitTile`'s `<button class="tile">`. Interactive content inside a `<button>` is invalid HTML: clicks can fail to deliver and ATs fold the inner text into the outer button's accessible name. This was the live violation on `main` today (independent of the still-unmerged Preview badge from #345, which would add a second interactive badge to the same strip).

## Fix

Per the approach suggested in the issue: the row/tile clickable surface is now an **absolutely-positioned overlay `<button>`** instead of a wrapping button.

- `.unit` / `.tile` demoted from `<button>` to `<div>` (layout/hover/sel styling unchanged).
- A transparent first-child `<button class="unit-hit" / "tile-hit">` (`position:absolute; inset:0; z-index:0`) carries the click + keyboard selection — clicking anywhere on the card still selects it.
- The interactive PlanGate badge is raised above the overlay (`.u-right`/`.t-head > button|[role=button]` → `z-index:1`), so it's now a valid DOM **sibling** of the hit button, not a descendant. The selector is forward-looking so #345's Preview badge works once it's a real button.
- Decorative pseudo-elements (`.unit::before`, `.unit.sel::after`, `.tile::before`) get `pointer-events:none` so they can't intercept clicks above the overlay.

## Accessibility

- Overlay button accessible name: new i18n key `unit_open_aria` → "Open {name}" / "{name} öffnen" (EN+DE).
- `aria-describedby` wires the existing visible text to the focusable control so it isn't orphaned: repo + prompt + status (UnitRow), status + designation (UnitTile). Blinking caret marked `aria-hidden`.
- The activity-line reveal moved from `.unit:focus-visible` → `.unit:focus-within` (focus now lives on the hit button).

## Known trade-offs (documented, accepted)

- Hover `title` tooltips on elements now under the overlay (e.g. `.u-repo` full path, badge tooltips) no longer appear; SR-exposed `aria-label`s are retained, and `.act-sum`'s summary is already revealed inline on hover.
- The tile's read-only monitor terminal (`disableStdin:true`) loses manual wheel-scrollback/selection under the overlay; the full interactive terminal is in the Viewport, reached by selecting.
- Minor: when a session is simultaneously *reviewing* + *done* (no status badge renders), the `*-status` `aria-describedby` IDREF dangles — harmless per WAI-ARIA (unresolved IDREFs are ignored; `aria-label` still names the control).

`PlanGateBadge` is unchanged (its `stopPropagation` is now a harmless no-op). `[no-feature-entry]` — this is a `fix(a11y)`, not a user-facing feature.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- `cd ui && bun run check:i18n` → 2 locales in parity
- `cd ui && bun run test` → 602 passed
- branch-hygiene + root lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)