### PR TITLE
fix(drain): close stale-cache claim race for multi-person queue sharing + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,47 +22,35 @@ full rationale.
 
 ## Sharing a repo's queue across people
 
-Several people can drive the **same repo's** auto-drain queue together — each on their **own**
-Claude subscription. This is the multi-person form of the ToS model above: not one shared account,
-but **N independent single-operator instances**. Each person runs their own Shepherd against their
-own `~/.claude` login; no token relay, no impersonation. The shared GitHub/Gitea repo is the only
-thing in common.
+Several people can drive the same repo's auto-drain queue together, each on their own Claude
+subscription. This is the multi-person form of the ToS model above — not one shared account but N
+independent single-operator instances, each running against its own `~/.claude` login (no token
+relay, no impersonation). The shared git-host repo is the only thing in common; the `shepherd:active`
+label keeps two instances off the same issue.
 
-**How the work splits (it is _not_ a capacity-weighted load balancer).** Each instance drains
-**greedily** up to its own `maxAuto` and its own `usageCeilingPct`, and claims issues **first-come
-by polling timing** — whoever's drain pumps first stamps the `shepherd:active` label first and gets
-the issue. Below the ceiling, issues split by _when each instance happens to poll_, not by who has
-more headroom. The `usageCeilingPct` is a **hard per-operator STOP**, not a balancer: when an
-instance reaches its ceiling it simply stops spawning and leaves the rest of the queue to the others.
+How the work splits: each instance drains greedily up to its own `maxAuto` and `usageCeilingPct`,
+claiming issues first-come by polling timing (whoever pumps first stamps `shepherd:active` first).
+It is not a capacity-weighted load balancer — below the ceiling, issues split by when each instance
+happens to poll, not by who has more headroom. `usageCeilingPct` is a hard per-operator stop: an
+instance that hits its ceiling stops spawning and leaves the rest to the others. So "Patrick is at
+80%, Kai isn't" just means Patrick's ceiling stops his instance (or he turns auto-drain off) and
+Kai's keeps pulling up to Kai's own ceiling — nobody lends capacity.
 
-So the "Patrick is at 80%, Kai isn't" hand-off works like this: Patrick sets his `usageCeilingPct`
-so **his** instance stops (or flips auto-drain off) — and from then on only **Kai's** instance pulls
-the labeled issues, up to **Kai's** own ceiling. Nobody "lends" capacity; the work just keeps flowing
-on the instance that's still draining. "Only if you have the time/limit" is exactly the auto-drain
-toggle plus the ceiling.
+Setup, per person:
 
-**Setup, per person:**
+1. Run your own instance logged into your own `~/.claude`.
+2. Use a separate `~/.claude` login (in practice: a separate machine or `HOME`). Usage is scraped
+   locally from `~/.claude` (`src/usage.ts`), so two instances sharing one login see the same usage
+   and their ceilings move in lockstep — the per-person hand-off then doesn't work.
+3. Register the same repo with auto-drain on and the same `autoLabel` (default `shepherd:auto`),
+   pointed at the shared git host (see [Git host integration](#git-host-integration)).
+4. Set your own `usageCeilingPct` and `maxAuto`.
 
-1. Run your own Shepherd instance, logged into your **own** `~/.claude`.
-2. **Separate `~/.claude` logins are required for per-person usage isolation.** Shepherd scrapes
-   usage **locally from `~/.claude`** (`src/usage.ts`), so two instances sharing one `~/.claude` see
-   the **same** usage and their ceilings move in lockstep — the "Patrick stops, Kai keeps going"
-   hand-off then does **not** work. In practice this means a **separate machine or a separate home /
-   `HOME` directory per person**, each with its own `claude` login.
-3. Register the **same** repo and turn **auto-drain on** for it.
-4. Use the **same** `autoLabel` (default `shepherd:auto`) so everyone's drain selects the same
-   backlog, and point at the shared git-host repo (see [Git host integration](#git-host-integration)).
-5. Set your **own** `usageCeilingPct` to taste — that's your personal "only while I have limit" stop.
-6. Set `maxAuto` to your own capacity.
+Done for the day? Turn auto-drain off (or shut the machine down) and your instance pulls nothing.
 
-**Behavior & guarantees:** "I'm done for the day" = flip auto-drain off (or shut the machine down) →
-your instance pulls nothing. The shared `shepherd:active` label keeps two instances off the same
-issue: an issue another instance has claimed is filtered out of everyone else's candidate set.
-
-**Known edge:** in the rare case where two instances grab the **exact same** issue in the same
-instant — before either claim is visible to the other — both can spawn against it (two PRs; a human
-closes one). A pre-spawn re-check narrows this window to the truly-simultaneous case; it is not yet
-eliminated.
+Known edge: if two instances grab the exact same issue in the same instant — before either claim is
+visible to the other — both can spawn against it (two PRs; a human closes one). A pre-spawn re-check
+narrows this to the truly-simultaneous case but does not eliminate it.
 
 ## Your `/commands` come with you
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,50 @@ live pane). Auth is the operator's own login; no token relay, no impersonation, 
 If a feature can't be done by typing into a real terminal, it doesn't ship. See `PRD.md` for the
 full rationale.
 
+## Sharing a repo's queue across people
+
+Several people can drive the **same repo's** auto-drain queue together — each on their **own**
+Claude subscription. This is the multi-person form of the ToS model above: not one shared account,
+but **N independent single-operator instances**. Each person runs their own Shepherd against their
+own `~/.claude` login; no token relay, no impersonation. The shared GitHub/Gitea repo is the only
+thing in common.
+
+**How the work splits (it is _not_ a capacity-weighted load balancer).** Each instance drains
+**greedily** up to its own `maxAuto` and its own `usageCeilingPct`, and claims issues **first-come
+by polling timing** — whoever's drain pumps first stamps the `shepherd:active` label first and gets
+the issue. Below the ceiling, issues split by _when each instance happens to poll_, not by who has
+more headroom. The `usageCeilingPct` is a **hard per-operator STOP**, not a balancer: when an
+instance reaches its ceiling it simply stops spawning and leaves the rest of the queue to the others.
+
+So the "Patrick is at 80%, Kai isn't" hand-off works like this: Patrick sets his `usageCeilingPct`
+so **his** instance stops (or flips auto-drain off) — and from then on only **Kai's** instance pulls
+the labeled issues, up to **Kai's** own ceiling. Nobody "lends" capacity; the work just keeps flowing
+on the instance that's still draining. "Only if you have the time/limit" is exactly the auto-drain
+toggle plus the ceiling.
+
+**Setup, per person:**
+
+1. Run your own Shepherd instance, logged into your **own** `~/.claude`.
+2. **Separate `~/.claude` logins are required for per-person usage isolation.** Shepherd scrapes
+   usage **locally from `~/.claude`** (`src/usage.ts`), so two instances sharing one `~/.claude` see
+   the **same** usage and their ceilings move in lockstep — the "Patrick stops, Kai keeps going"
+   hand-off then does **not** work. In practice this means a **separate machine or a separate home /
+   `HOME` directory per person**, each with its own `claude` login.
+3. Register the **same** repo and turn **auto-drain on** for it.
+4. Use the **same** `autoLabel` (default `shepherd:auto`) so everyone's drain selects the same
+   backlog, and point at the shared git-host repo (see [Git host integration](#git-host-integration)).
+5. Set your **own** `usageCeilingPct` to taste — that's your personal "only while I have limit" stop.
+6. Set `maxAuto` to your own capacity.
+
+**Behavior & guarantees:** "I'm done for the day" = flip auto-drain off (or shut the machine down) →
+your instance pulls nothing. The shared `shepherd:active` label keeps two instances off the same
+issue: an issue another instance has claimed is filtered out of everyone else's candidate set.
+
+**Known edge:** in the rare case where two instances grab the **exact same** issue in the same
+instant — before either claim is visible to the other — both can spawn against it (two PRs; a human
+closes one). A pre-spawn re-check narrows this window to the truly-simultaneous case; it is not yet
+eliminated.
+
 ## Your `/commands` come with you
 
 Because Shepherd attaches to a **genuine interactive `claude` session** running against your own

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -271,6 +271,24 @@ export class DrainService {
     const forge = this.deps.resolveForge(repoPath);
     if (!forge) return;
     const { number, url, title, body } = decision.issue;
+    // Pre-spawn claim re-check (closes the stale-cache race). The candidate came
+    // from the short-TTL issuesCache, which can be up to issuesTtlMs old — long
+    // enough for a SECOND instance to have stamped ACTIVE_LABEL since. A fresh,
+    // uncached single-issue read catches that: if the claim is already present, an
+    // earlier instance owns it, so yield without spawning (and without releasing
+    // its label). Best-effort and optional: a host without getIssue, or a null
+    // (gone/unreadable) read, falls through to spawn — local dedup still applies.
+    // NOTE: this narrows, it does not eliminate, the window — two instances reading
+    // fresh-and-unclaimed in the same instant still both stamp (see drain-core's
+    // ACTIVE_LABEL note). That residual is accepted; closing it fully needs a
+    // server-ordered claim (out of scope here).
+    try {
+      const fresh = await forge.getIssue?.(number);
+      if (fresh?.labels.includes(ACTIVE_LABEL)) return;
+    } catch (err) {
+      console.warn(`[drain] pre-spawn re-check for issue #${number} failed:`, err);
+      // fall through to spawn — best-effort, never stall the drain.
+    }
     // Claim the issue on the host BEFORE spawning. The active label is the only
     // cross-instance signal, so stamp it first to shrink the window in which a
     // second shepherd grabs the same issue. Best-effort: a claim failure (label

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -282,6 +282,11 @@ export class DrainService {
     // fresh-and-unclaimed in the same instant still both stamp (see drain-core's
     // ACTIVE_LABEL note). That residual is accepted; closing it fully needs a
     // server-ordered claim (out of scope here).
+    // SCOPE: the re-check inspects ONLY the claim label (ACTIVE_LABEL), not whether
+    // the opt-in autoLabel is still present. A candidate another operator un-labeled
+    // (opted out) between the cached list read and now is NOT caught here — it still
+    // spawns. Re-validating the opt-in is a separate concern from the claim race this
+    // closes, and the next tick's fresh listIssues drops a de-labeled issue anyway.
     try {
       const fresh = await forge.getIssue?.(number);
       if (fresh?.labels.includes(ACTIVE_LABEL)) return;

--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -121,6 +121,34 @@ export class GiteaForge implements GitForge {
     });
   }
 
+  async getIssue(issueNumber: number): Promise<Issue | null> {
+    // Fresh, uncached single-issue read for the drain's pre-spawn claim re-check
+    // (see GitForge.getIssue). Best-effort: a gone/closed issue or a transient error
+    // yields null so the caller falls back to spawning, never loses the issue.
+    try {
+      const i = (await this.req("GET", `/api/v1/repos/${this.slug}/issues/${issueNumber}`)) as {
+        number: number;
+        title: string;
+        body?: string;
+        html_url: string;
+        labels?: Array<{ name: string }>;
+        created_at?: string;
+      } | null;
+      if (!i) return null;
+      const ts = Date.parse(i.created_at ?? "");
+      return {
+        number: i.number,
+        title: i.title,
+        body: i.body ?? "",
+        url: i.html_url,
+        labels: (i.labels ?? []).map((l) => l.name),
+        createdAt: Number.isFinite(ts) ? ts : Date.now(),
+      };
+    } catch {
+      return null;
+    }
+  }
+
   /** One combined-status call yields both the worst-of rollup (top-level `state`)
    *  and the per-context breakdown (`statuses[]`) for the PRs-tab expand view. */
   private async commitChecks(

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -129,6 +129,9 @@ export class GithubForge implements GitForge {
     // Fresh, uncached single-issue read for the drain's pre-spawn claim re-check
     // (see GitForge.getIssue). Best-effort: a gone/closed issue or a transient gh
     // error yields null so the caller falls back to spawning, never loses the issue.
+    // COST: one synchronous `gh issue view` subprocess per spawn candidate per pump
+    // (this.run is execFileSync). The drain spawns at most maxAuto per pump, so the
+    // fan-out is bounded and small; not worth caching/batching for the claim re-check.
     try {
       const out = this.run([
         "issue",

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -125,6 +125,43 @@ export class GithubForge implements GitForge {
     });
   }
 
+  async getIssue(issueNumber: number): Promise<Issue | null> {
+    // Fresh, uncached single-issue read for the drain's pre-spawn claim re-check
+    // (see GitForge.getIssue). Best-effort: a gone/closed issue or a transient gh
+    // error yields null so the caller falls back to spawning, never loses the issue.
+    try {
+      const out = this.run([
+        "issue",
+        "view",
+        String(issueNumber),
+        "--repo",
+        this.slug,
+        "--json",
+        "number,title,body,url,labels,createdAt",
+      ]);
+      const i = JSON.parse(out || "null") as {
+        number: number;
+        title: string;
+        body?: string;
+        url: string;
+        labels?: Array<{ name: string }>;
+        createdAt?: string;
+      } | null;
+      if (!i) return null;
+      const ts = Date.parse(i.createdAt ?? "");
+      return {
+        number: i.number,
+        title: i.title,
+        body: i.body ?? "",
+        url: i.url,
+        labels: (i.labels ?? []).map((l) => l.name),
+        createdAt: Number.isFinite(ts) ? ts : Date.now(),
+      };
+    } catch {
+      return null;
+    }
+  }
+
   async listPullRequests(): Promise<PullRequest[]> {
     const out = this.run([
       "pr",

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -206,6 +206,14 @@ export interface GitForge {
   /** Remove a label from an issue (best-effort; releases the drain's claim when an
    *  auto session is abandoned, returning the issue to the pool). Optional. */
   removeIssueLabel?(issueNumber: number, label: string): Promise<void>;
+  /** Fetch ONE issue fresh (UNCACHED) by number, for the drain's pre-spawn claim
+   *  re-check. The cached `listIssues` view a candidate is selected from can be up to
+   *  `issuesTtlMs` stale, so a second instance may still see an issue another instance
+   *  stamped `ACTIVE_LABEL` on seconds ago. A fresh single-issue read closes that
+   *  stale-cache window: if it already carries the claim, the spawn is yielded. Returns
+   *  null when the issue is gone/unreadable. Best-effort and optional — hosts without it
+   *  (or a transient failure → null) fall back to the cached candidate set + local dedup. */
+  getIssue?(issueNumber: number): Promise<Issue | null>;
   /** Open a new issue (capture-extension delivery path). Returns the created
    *  issue's number + URL. Optional: hosts without an issue-create API omit it
    *  and POST /api/issues 400s. */

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -29,6 +29,7 @@ interface ForgeRec {
   closedIssues: number[];
   added: { number: number; label: string }[];
   removed: { number: number; label: string }[];
+  getIssueCalls: number[];
 }
 
 function fakeForge(
@@ -40,7 +41,9 @@ function fakeForge(
     closeIssue?: (n: number) => Promise<void>;
     ensureIssueLink?: (prNumber: number, issueNumber: number) => Promise<void>;
     addIssueLabel?: (n: number, label: string) => Promise<void>;
+    getIssue?: (n: number) => Promise<Issue | null>;
     omitCloseIssue?: boolean;
+    omitGetIssue?: boolean;
   } = {},
 ): GitForge {
   return {
@@ -81,6 +84,17 @@ function fakeForge(
     removeIssueLabel: async (number: number, label: string) => {
       rec.removed.push({ number, label });
     },
+    // omitGetIssue models a forge that doesn't implement the optional method (the
+    // pre-spawn re-check then degrades to the cached candidate set + local dedup).
+    // The default returns the fresh issue from the same list source, so an
+    // unclaimed candidate spawns as before.
+    getIssue: opts.omitGetIssue
+      ? undefined
+      : async (number: number) => {
+          rec.getIssueCalls.push(number);
+          if (opts.getIssue) return opts.getIssue(number);
+          return issues.find((i) => i.number === number) ?? null;
+        },
   };
 }
 
@@ -109,7 +123,9 @@ function makeHarness(
     onArchived?: (h: Harness, id: string) => void;
     addIssueLabelImpl?: (n: number, label: string) => Promise<void>;
     closeIssueImpl?: (n: number) => Promise<void>;
+    getIssueImpl?: (n: number) => Promise<Issue | null>;
     omitCloseIssue?: boolean;
+    omitGetIssue?: boolean;
     createImpl?: () => Promise<void>;
   } = {},
 ): Harness {
@@ -135,13 +151,16 @@ function makeHarness(
     closedIssues: [],
     added: [],
     removed: [],
+    getIssueCalls: [],
   };
   const forge = fakeForge(opts.issues ?? [], forgeRec, {
     merge: opts.mergeImpl,
     listIssues: opts.listIssuesImpl,
     addIssueLabel: opts.addIssueLabelImpl,
     closeIssue: opts.closeIssueImpl,
+    getIssue: opts.getIssueImpl,
     omitCloseIssue: opts.omitCloseIssue,
+    omitGetIssue: opts.omitGetIssue,
   });
 
   const prCache: Record<string, GitState> = {};
@@ -649,6 +668,7 @@ test("tick + snapshot over repos: only drain-enabled repo is acted on and report
     closedIssues: [],
     added: [],
     removed: [],
+    getIssueCalls: [],
   };
   const forge = fakeForge([issue(1)], forgeRec);
   const creates: CreateSessionInput[] = [];
@@ -817,6 +837,48 @@ test("queue: [] when drain disabled, never hits the forge", async () => {
 
 test("spawn claims the issue: stamps ACTIVE_LABEL on the host", async () => {
   const h = makeHarness({ maxAuto: 1, issues: [issue(1)] });
+  await h.drain.pump(REPO);
+  expect(h.creates).toHaveLength(1);
+  expect(h.forgeRec.added).toEqual([{ number: 1, label: ACTIVE_LABEL }]);
+});
+
+test("pre-spawn re-check: a fresh read showing ACTIVE_LABEL (claimed by another instance) yields — no spawn, no stamp", async () => {
+  // The cached candidate list still shows #1 unclaimed, but a fresh read reveals
+  // another instance stamped it since (the stale-cache race). doSpawn must yield.
+  const h = makeHarness({
+    maxAuto: 1,
+    issues: [issue(1)],
+    getIssueImpl: async (n) => issue(n, { labels: ["shepherd:auto", ACTIVE_LABEL] }),
+  });
+  await h.drain.pump(REPO);
+  expect(h.creates).toHaveLength(0); // did not spawn
+  expect(h.forgeRec.added).toHaveLength(0); // did not even stamp its own claim
+  expect(h.forgeRec.getIssueCalls).toContain(1); // the re-check actually ran
+});
+
+test("pre-spawn re-check: a fresh read showing the issue unclaimed spawns normally (stamp + create)", async () => {
+  const h = makeHarness({ maxAuto: 1, issues: [issue(1)] });
+  await h.drain.pump(REPO);
+  expect(h.forgeRec.getIssueCalls).toContain(1); // re-check consulted
+  expect(h.creates).toHaveLength(1);
+  expect(h.forgeRec.added).toEqual([{ number: 1, label: ACTIVE_LABEL }]);
+});
+
+test("pre-spawn re-check is best-effort: getIssue throwing still spawns (drain never stalls)", async () => {
+  const h = makeHarness({
+    maxAuto: 1,
+    issues: [issue(1)],
+    getIssueImpl: async () => {
+      throw new Error("getIssue boom");
+    },
+  });
+  await h.drain.pump(REPO);
+  expect(h.creates).toHaveLength(1); // fell through to spawn
+  expect(h.forgeRec.added).toEqual([{ number: 1, label: ACTIVE_LABEL }]);
+});
+
+test("pre-spawn re-check on a forge WITHOUT getIssue degrades to spawning (no regress)", async () => {
+  const h = makeHarness({ maxAuto: 1, issues: [issue(1)], omitGetIssue: true });
   await h.drain.pump(REPO);
   expect(h.creates).toHaveLength(1);
   expect(h.forgeRec.added).toEqual([{ number: 1, label: ACTIVE_LABEL }]);


### PR DESCRIPTION
## Was & warum

Beantwortet die Frage „kann man die Queue nutzen, damit bei mehreren Leuten am selben Repo die Arbeit zu dem fließt, der noch Limit frei hat?" — **ja, und es funktioniert bereits**: N unabhängige Single-Operator-Instanzen, je eigenes `~/.claude`-Login, koordiniert über das geteilte `shepherd:active`-Label. Kein Account-Sharing, ToS-konform.

Zwei Lieferobjekte:

### 1. Doku (primär) — `docs(readme)`
Neue README-Sektion „Sharing a repo's queue across people":
- **Verteilung präzise:** gieriges Drainen bis zum eigenen `maxAuto`/`usageCeilingPct`, **first-come nach Polling-Timing** — **kein** kapazitätsgewichteter Load-Balancer. Das Ceiling ist ein **harter Pro-Operator-STOP**. Patrick-80%/Kai-Beispiel entsprechend formuliert.
- **Login-Isolation als Pflicht:** Usage wird lokal aus `~/.claude` gescrapt (`src/usage.ts`) → getrennte Ceilings brauchen getrennte Logins (separate Maschine/Home), sonst laufen sie im Gleichschritt.

### 2. Race-Härtung (B1) — `fix(drain)`
Der Claim war best-effort: `doSpawn` stempelte `ACTIVE_LABEL` und spawnte, aber der Kandidat kam aus dem bis zu 10s alten `issuesCache` → eine zweite Instanz konnte eine veraltete Liste lesen und ein bereits geclaimtes Issue doppelt spawnen.

- Neues optionales `GitForge.getIssue` (uncached Single-Issue-Read), GitHub + Gitea.
- `doSpawn` macht **vor** dem Stempeln einen frischen Claim-Recheck: ist `ACTIVE_LABEL` schon da → yield ohne Spawn.
- Durchgehend best-effort: Host ohne `getIssue` oder transienter Fehler → fällt auf Spawn zurück (lokales Dedup greift weiter).
- **Verkleinert** das Race-Fenster auf den echten Gleichzeitigkeitsfall, eliminiert es nicht (im Code + README ehrlich benannt). Der vollständige Server-geordnete Claim (B2, Nonce-Kommentar-Lease) wurde geplant, aber als unverhältnismäßig für ein nie beobachtetes Race zurückgestellt.

## Tests
- 4 neue Drain-Tests: Recheck yieldet bei bereits-geclaimtem Issue; spawnt bei unclaimed; best-effort bei werfendem `getIssue`; Degrade ohne `getIssue`.
- `bun run lint` ✓ · `bun test ./test` → 1326 pass / 0 fail ✓

## Scope
Reine Server-Plumbing- + Doku-Änderung, keine user-facing UI → kein i18n, kein Feature-Catalog-Eintrag.
