### PR TITLE
feat(ui): launch a merge train from a backlog PR multi-selection

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -696,7 +696,7 @@
   "feat_backlog_repo_filter_title": "Repo-Liste filtern",
   "feat_backlog_repo_filter_body": "Grenze die Repo-Liste des Backlogs mit den neuen Umschalt-Chips auf Repos mit offenen Issues und/oder offenen PRs ein.",
   "feat_newtask_repo_first_title": "Repo steht jetzt oben im Neue-Aufgabe-Formular",
-  "feat_newtask_repo_first_body": "Das Repository, in dem die Aufgabe startet, steht jetzt oben im Neue-Aufgabe-Formular und wird auf dem „Erstellen & Starten”-Button genannt – so startest du nie versehentlich im falschen Repo.",
+  "feat_newtask_repo_first_body": "Das Repository, in dem die Aufgabe startet, steht jetzt oben im Neue-Aufgabe-Formular und wird auf dem „Erstellen & Starten“-Button genannt – so startest du nie versehentlich im falschen Repo.",
   "prspanel_select_pr": "PR #{number} auswählen",
   "prspanel_select_all": "Alle auswählen",
   "prspanel_clear_all": "Auswahl aufheben",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -696,5 +696,13 @@
   "feat_backlog_repo_filter_title": "Repo-Liste filtern",
   "feat_backlog_repo_filter_body": "Grenze die Repo-Liste des Backlogs mit den neuen Umschalt-Chips auf Repos mit offenen Issues und/oder offenen PRs ein.",
   "feat_newtask_repo_first_title": "Repo steht jetzt oben im Neue-Aufgabe-Formular",
-  "feat_newtask_repo_first_body": "Das Repository, in dem die Aufgabe startet, steht jetzt oben im Neue-Aufgabe-Formular und wird auf dem „Erstellen & Starten“-Button genannt – so startest du nie versehentlich im falschen Repo."
+  "feat_newtask_repo_first_body": "Das Repository, in dem die Aufgabe startet, steht jetzt oben im Neue-Aufgabe-Formular und wird auf dem „Erstellen & Starten”-Button genannt – so startest du nie versehentlich im falschen Repo.",
+  "prspanel_select_pr": "PR #{number} auswählen",
+  "prspanel_select_all": "Alle auswählen",
+  "prspanel_clear_all": "Auswahl aufheben",
+  "prspanel_selected_count": "{count} ausgewählt",
+  "prspanel_launch_train": "Merge-Train starten",
+  "prspanel_merge_train_prompt": "Führe einen Merge-Train für die Pull Requests aus, die ich ausgewählt habe. Prüfe jeden auf Korrektheit und Produkt-Fit, schlage eine sichere Merge-Reihenfolge vor und halte vor jedem Merge für meine Freigabe an — prüfe danach nach jedem Merge die Warteschlange erneut, denn main bewegt sich unter dir.\n\nAusgewählte PRs:\n{prs}\n\nWenn dieses Repo einen /merge-train-Befehl oder -Skill bereitstellt, nutze ihn. Andernfalls arbeite den Train selbst ab:\n1. Erfasse für jeden PR den Status mit gh (CI-Rollup, Mergebarkeit/Konflikte, wie weit hinter main, und welche Dateien sich mit anderen PRs dieser Liste überschneiden).\n2. Verschiebe jeden PR, der CI-rot, konfliktbehaftet, gate-fehlerhaft oder nicht erwünscht ist, mit einer einzeiligen Begründung auf eine separate Halteliste — merge niemals an einem roten Gate vorbei.\n3. Ordne den Rest: am kleinsten und unabhängigsten zuerst; überschneiden sich zwei, sequenziere sie so, dass der riskantere auf den anderen rebased; release-please-PRs zuletzt.\n4. Präsentiere die nummerierte Merge-Reihenfolge plus die Halteliste und WARTE auf meine Freigabe.\n5. Nach Freigabe merge in Reihenfolge: erst auf das aktuelle main rebasen (niemals main in den Branch mergen), grüne Gates bestätigen, dann gh pr merge --squash --delete-branch, und vor dem nächsten die verbleibenden PRs erneut gegen main prüfen.",
+  "feat_backlog_pr_merge_train_title": "Merge-Train aus ausgewählten PRs starten",
+  "feat_backlog_pr_merge_train_body": "Mehrere offene PRs im Backlog-PRs-Tab eines Repos auswählen und einen Merge-Train starten, der auf genau diese PRs beschränkt ist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -696,5 +696,13 @@
   "feat_backlog_repo_filter_title": "Filter the repo list",
   "feat_backlog_repo_filter_body": "Narrow the backlog's repo list to repos with open issues and/or open PRs using the new toggle chips.",
   "feat_newtask_repo_first_title": "Repo now leads the New Task form",
-  "feat_newtask_repo_first_body": "The repository you'll launch into now sits at the top of the New Task form and is named on the Create & Run button, so you never start a task against the wrong repo by accident."
+  "feat_newtask_repo_first_body": "The repository you'll launch into now sits at the top of the New Task form and is named on the Create & Run button, so you never start a task against the wrong repo by accident.",
+  "prspanel_select_pr": "Select PR #{number}",
+  "prspanel_select_all": "Select all",
+  "prspanel_clear_all": "Clear",
+  "prspanel_selected_count": "{count} selected",
+  "prspanel_launch_train": "Launch merge train",
+  "prspanel_merge_train_prompt": "Run a merge train for the pull requests I've selected. Review each for correctness and product-fit, propose a safe merge order, and stop for my approval before merging anything — then re-check the queue after every merge, because main moves under you.\n\nSelected PRs:\n{prs}\n\nIf this repo provides a /merge-train command or skill, use it. Otherwise work the train yourself:\n1. For each PR, gather status with gh (CI rollup, mergeability/conflicts, how far behind main, and which files overlap other PRs in this list).\n2. Move any PR that is CI-red, conflicting, gate-failing, or that we don't actually want into a separate hold list with a one-line reason — never merge past a red gate.\n3. Order the rest: smallest and most independent first; when two overlap, sequence them so the riskier one rebases onto the other; release-please PRs last.\n4. Present the numbered merge order plus the hold list and WAIT for my approval.\n5. On approval, merge in order: rebase onto latest main first (never merge main into the branch), confirm gates are green, then gh pr merge --squash --delete-branch, and re-check the remaining PRs against main before the next one.",
+  "feat_backlog_pr_merge_train_title": "Launch a merge train from selected PRs",
+  "feat_backlog_pr_merge_train_body": "Multi-select open PRs in a repo's backlog PRs tab and launch a merge train scoped to just those PRs."
 }

--- a/ui/src/lib/components/BacklogOverlay.svelte
+++ b/ui/src/lib/components/BacklogOverlay.svelte
@@ -11,6 +11,7 @@
     onquick = undefined,
     onpr,
     onadopt,
+    onlaunchtrain,
     onclose,
   }: {
     payload: BacklogPayload | null;
@@ -19,6 +20,7 @@
     onquick?: (repoPath: string, issue: Issue) => void;
     onpr: (repoPath: string, pr: PullRequest) => void;
     onadopt: (repoPath: string, prompt: string) => void;
+    onlaunchtrain: (repoPath: string, prs: PullRequest[]) => void;
     onclose: () => void;
   } = $props();
 </script>
@@ -44,7 +46,7 @@
       <button type="button" class="x" onclick={onclose} aria-label={m.common_close()}>✕</button>
     </div>
     <div class="body">
-      <BacklogView {payload} {mobile} {onissue} {onquick} {onpr} {onadopt} />
+      <BacklogView {payload} {mobile} {onissue} {onquick} {onpr} {onadopt} {onlaunchtrain} />
     </div>
   </div>
 </div>

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -16,6 +16,7 @@
     onquick = undefined,
     onpr,
     onadopt,
+    onlaunchtrain,
     flow = false,
   }: {
     payload: BacklogPayload | null;
@@ -28,6 +29,8 @@
     onpr: (repoPath: string, pr: PullRequest) => void;
     /** Seed a New Task with the AI-readiness install prescription (Readiness tab). */
     onadopt: (repoPath: string, prompt: string) => void;
+    /** Launch a merge train from a hand-picked PR multi-selection (PRs tab). */
+    onlaunchtrain: (repoPath: string, prs: PullRequest[]) => void;
     /** When true, renders at natural height for parent-page scrolling (mobile list);
      *  default false preserves existing viewport-filling behavior. */
     flow?: boolean;
@@ -200,7 +203,12 @@
               age
             />
           {:else if activeTab === "prs"}
-            <PrsPanel repoPath={selectedPath} onreview={(pr) => onpr(selectedPath!, pr)} age />
+            <PrsPanel
+              repoPath={selectedPath}
+              onreview={(pr) => onpr(selectedPath!, pr)}
+              {onlaunchtrain}
+              age
+            />
           {:else if activeTab === "actions"}
             <ActionsPanel repoPath={selectedPath} />
           {:else}
@@ -286,7 +294,12 @@
                 age
               />
             {:else if activeTab === "prs"}
-              <PrsPanel repoPath={selectedPath} onreview={(pr) => onpr(selectedPath!, pr)} age />
+              <PrsPanel
+                repoPath={selectedPath}
+                onreview={(pr) => onpr(selectedPath!, pr)}
+                {onlaunchtrain}
+                age
+              />
             {:else if activeTab === "actions"}
               <ActionsPanel repoPath={selectedPath} />
             {:else}

--- a/ui/src/lib/components/PrRow.svelte
+++ b/ui/src/lib/components/PrRow.svelte
@@ -11,6 +11,9 @@
     age = false,
     onreview,
     onmerged,
+    selectable = false,
+    selected = false,
+    ontoggle,
   }: {
     repoPath: string;
     pr: PullRequest;
@@ -18,6 +21,10 @@
     onreview: (pr: PullRequest) => void;
     /** Called after a successful merge so the parent can drop/refetch the row. */
     onmerged: (number: number) => void;
+    /** Render a leading multi-select checkbox (merge-train picking). */
+    selectable?: boolean;
+    selected?: boolean;
+    ontoggle?: () => void;
   } = $props();
 
   // Merge is outward-facing and hard to reverse, so it arms on first click and
@@ -113,126 +120,143 @@
   }
 </script>
 
-<div class="pr-row">
-  <div class="pr-top">
-    <!-- eslint-disable svelte/no-navigation-without-resolve -- external forge URL, not an app route -->
-    <a class="pr-num" href={pr.url} target="_blank" rel="noopener" title={m.prspanel_open_link()}
-      >#{pr.number}</a
-    >
-    <a class="pr-title" href={pr.url} target="_blank" rel="noopener" title={m.prspanel_open_link()}
-      >{pr.title}</a
-    >
-    <!-- eslint-enable svelte/no-navigation-without-resolve -->
-    {#if pr.isDraft}<span class="draft-chip">{m.prspanel_draft()}</span>{/if}
-  </div>
-
-  <div class="pr-meta">
-    {#if pr.checks !== "none"}
-      {#if hasJobs}
-        <button
-          type="button"
-          class="ci-toggle"
-          class:expanded
-          onclick={() => (expanded = !expanded)}
-          aria-expanded={expanded}
-          aria-controls={jobsId}
-          title={ciToggleLabel}
-          aria-label={ciToggleLabel}
-        >
-          <span class="dot dot-{pr.checks}"></span>
-          <span class="caret" aria-hidden="true">▸</span>
-        </button>
-      {:else}
-        <span class="dot dot-{pr.checks}" title={ciStatus} aria-label={ciStatus}></span>
-      {/if}
-    {/if}
-    {#if pr.latestReview}
-      <span class="rdot rdot-{pr.latestReview.state}" title={reviewTitle} aria-label={reviewTitle}
-      ></span>
-    {/if}
-    {#if blocked}
-      <span class="conflict">{m.prspanel_conflicts()}</span>
-    {/if}
-    {#if pr.author}<span class="author">@{pr.author}</span>{/if}
-    {#if age}
-      <span class="age-chip"
-        >{m.backlog_open_since_days({
-          days: Math.floor((Date.now() - pr.createdAt) / 86_400_000),
-        })}</span
-      >
-    {/if}
-  </div>
-
-  {#if expanded && hasJobs}
-    <div class="pr-jobs" id={jobsId}>
-      <!-- key includes the index: a matrix build can repeat a check name on one
-           head commit, which would otherwise collide in the keyed each. -->
-      {#each pr.jobs as job, i (job.name + " " + i)}
-        <div class="job">
-          <span
-            class="dot dot-{job.state}"
-            title={m.gitrail_ci_status({ status: job.state })}
-            aria-label={m.gitrail_ci_status({ status: job.state })}
-          ></span>
-          {#if job.url}
-            <!-- eslint-disable svelte/no-navigation-without-resolve -- external forge URL -->
-            <a
-              class="job-name"
-              href={job.url}
-              target="_blank"
-              rel="noopener"
-              title={m.actionspanel_job_link()}>{job.name}</a
-            >
-            <!-- eslint-enable svelte/no-navigation-without-resolve -->
-          {:else}
-            <span class="job-name">{job.name}</span>
-          {/if}
-        </div>
-      {/each}
-    </div>
+<div class="pr-row" class:selectable>
+  {#if selectable}
+    <input
+      type="checkbox"
+      class="pr-pick"
+      checked={selected}
+      onchange={ontoggle}
+      aria-label={m.prspanel_select_pr({ number: pr.number })}
+    />
   {/if}
+  <div class="pr-body">
+    <div class="pr-top">
+      <!-- eslint-disable svelte/no-navigation-without-resolve -- external forge URL, not an app route -->
+      <a class="pr-num" href={pr.url} target="_blank" rel="noopener" title={m.prspanel_open_link()}
+        >#{pr.number}</a
+      >
+      <a
+        class="pr-title"
+        href={pr.url}
+        target="_blank"
+        rel="noopener"
+        title={m.prspanel_open_link()}>{pr.title}</a
+      >
+      <!-- eslint-enable svelte/no-navigation-without-resolve -->
+      {#if pr.isDraft}<span class="draft-chip">{m.prspanel_draft()}</span>{/if}
+    </div>
 
-  <div class="pr-actions">
-    <!-- Left-aligned status text. One container carries the margin-right:auto push
-         so co-occurring messages (e.g. a failed merge *and* a later rebase request)
-         stay flush-left as a group instead of fighting over the free space. -->
-    {#if failed || rebaseFailed || requested}
-      <div class="pr-status">
-        {#if failed}<span class="merge-err">{m.prspanel_merge_failed()}</span>{/if}
-        {#if rebaseFailed}<span class="merge-err">{m.prspanel_rebase_failed()}</span>{/if}
-        {#if requested}
-          <span class="rebase-note" role="status">{m.prspanel_rebase_requested()}</span>
+    <div class="pr-meta">
+      {#if pr.checks !== "none"}
+        {#if hasJobs}
+          <button
+            type="button"
+            class="ci-toggle"
+            class:expanded
+            onclick={() => (expanded = !expanded)}
+            aria-expanded={expanded}
+            aria-controls={jobsId}
+            title={ciToggleLabel}
+            aria-label={ciToggleLabel}
+          >
+            <span class="dot dot-{pr.checks}"></span>
+            <span class="caret" aria-hidden="true">▸</span>
+          </button>
+        {:else}
+          <span class="dot dot-{pr.checks}" title={ciStatus} aria-label={ciStatus}></span>
         {/if}
+      {/if}
+      {#if pr.latestReview}
+        <span class="rdot rdot-{pr.latestReview.state}" title={reviewTitle} aria-label={reviewTitle}
+        ></span>
+      {/if}
+      {#if blocked}
+        <span class="conflict">{m.prspanel_conflicts()}</span>
+      {/if}
+      {#if pr.author}<span class="author">@{pr.author}</span>{/if}
+      {#if age}
+        <span class="age-chip"
+          >{m.backlog_open_since_days({
+            days: Math.floor((Date.now() - pr.createdAt) / 86_400_000),
+          })}</span
+        >
+      {/if}
+    </div>
+
+    {#if expanded && hasJobs}
+      <div class="pr-jobs" id={jobsId}>
+        <!-- key includes the index: a matrix build can repeat a check name on one
+           head commit, which would otherwise collide in the keyed each. -->
+        {#each pr.jobs as job, i (job.name + " " + i)}
+          <div class="job">
+            <span
+              class="dot dot-{job.state}"
+              title={m.gitrail_ci_status({ status: job.state })}
+              aria-label={m.gitrail_ci_status({ status: job.state })}
+            ></span>
+            {#if job.url}
+              <!-- eslint-disable svelte/no-navigation-without-resolve -- external forge URL -->
+              <a
+                class="job-name"
+                href={job.url}
+                target="_blank"
+                rel="noopener"
+                title={m.actionspanel_job_link()}>{job.name}</a
+              >
+              <!-- eslint-enable svelte/no-navigation-without-resolve -->
+            {:else}
+              <span class="job-name">{job.name}</span>
+            {/if}
+          </div>
+        {/each}
       </div>
     {/if}
-    {#if offerRebase}
+
+    <div class="pr-actions">
+      <!-- Left-aligned status text. One container carries the margin-right:auto push
+         so co-occurring messages (e.g. a failed merge *and* a later rebase request)
+         stay flush-left as a group instead of fighting over the free space. -->
+      {#if failed || rebaseFailed || requested}
+        <div class="pr-status">
+          {#if failed}<span class="merge-err">{m.prspanel_merge_failed()}</span>{/if}
+          {#if rebaseFailed}<span class="merge-err">{m.prspanel_rebase_failed()}</span>{/if}
+          {#if requested}
+            <span class="rebase-note" role="status">{m.prspanel_rebase_requested()}</span>
+          {/if}
+        </div>
+      {/if}
+      {#if offerRebase}
+        <button
+          class="rebase-btn"
+          disabled={requesting}
+          onclick={onrebase}
+          title={m.prspanel_rebase_button_title()}
+        >
+          {requesting ? m.prspanel_requesting() : m.prspanel_rebase_button()}
+        </button>
+      {/if}
       <button
-        class="rebase-btn"
-        disabled={requesting}
-        onclick={onrebase}
-        title={m.prspanel_rebase_button_title()}
+        class="review-btn"
+        onclick={() => onreview(pr)}
+        title={m.prspanel_review_button_title()}>{m.prspanel_review_button()}</button
       >
-        {requesting ? m.prspanel_requesting() : m.prspanel_rebase_button()}
-      </button>
-    {/if}
-    <button class="review-btn" onclick={() => onreview(pr)} title={m.prspanel_review_button_title()}
-      >{m.prspanel_review_button()}</button
-    >
-    {#if !pr.isDraft}
-      <button
-        class="merge-btn"
-        class:armed
-        disabled={merging || blocked}
-        onclick={onmerge}
-        title={blocked ? m.prspanel_merge_blocked_title() : undefined}
-      >
-        {merging
-          ? m.prspanel_merging()
-          : armed
-            ? m.prspanel_merge_confirm()
-            : m.prspanel_merge_button()}
-      </button>
-    {/if}
+      {#if !pr.isDraft}
+        <button
+          class="merge-btn"
+          class:armed
+          disabled={merging || blocked}
+          onclick={onmerge}
+          title={blocked ? m.prspanel_merge_blocked_title() : undefined}
+        >
+          {merging
+            ? m.prspanel_merging()
+            : armed
+              ? m.prspanel_merge_confirm()
+              : m.prspanel_merge_button()}
+        </button>
+      {/if}
+    </div>
   </div>
 </div>
 
@@ -245,6 +269,33 @@
     border: 1px solid var(--color-line);
     border-radius: 2px;
     background: var(--color-inset);
+  }
+
+  /* Selectable rows put the pick checkbox at the leading edge, alongside the
+     row body, without disturbing the body's own vertical stack. */
+  .pr-row.selectable {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .pr-body {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  /* A real, distinct hit target ahead of the row's links/buttons — its own
+     accent on check so a picked row reads at a glance. */
+  .pr-pick {
+    flex-shrink: 0;
+    margin: 0;
+    width: 14px;
+    height: 14px;
+    accent-color: var(--color-amber);
+    cursor: pointer;
   }
 
   .pr-top {
@@ -507,6 +558,10 @@
       min-height: 32px;
       min-width: 32px;
       justify-content: center;
+    }
+    .pr-pick {
+      width: 20px;
+      height: 20px;
     }
   }
 </style>

--- a/ui/src/lib/components/PrsPanel.browser.test.ts
+++ b/ui/src/lib/components/PrsPanel.browser.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { PullRequest } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+import { listPullRequests } from "$lib/api";
+
+// Mock the API so the panel never hits the network; each test seeds the result.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    listPullRequests: vi.fn(),
+    mergeBacklogPr: vi.fn(async () => {}),
+    requestDependabotRebase: vi.fn(async () => {}),
+  };
+});
+
+const { default: PrsPanel } = await import("./PrsPanel.svelte");
+
+const mockList = vi.mocked(listPullRequests);
+
+function pr(number: number, title = `PR ${number}`): PullRequest {
+  return {
+    number,
+    title,
+    url: `https://example.com/pr/${number}`,
+    author: "octocat",
+    createdAt: 0,
+    isDraft: false,
+    mergeable: true,
+    checks: "success",
+    jobs: [],
+  };
+}
+
+function seed(prs: PullRequest[], slug = "acme/repo") {
+  mockList.mockResolvedValue({ slug, prs });
+}
+
+let fontStyle: HTMLStyleElement;
+beforeEach(() => {
+  fontStyle = document.createElement("style");
+  fontStyle.textContent = `:root {
+    --font-mono: ui-monospace, monospace;
+    --color-panel: #1a1a1a;
+    --color-line: #333;
+    --color-line-bright: #555;
+    --color-inset: #111;
+    --color-ink: #ccc;
+    --color-ink-bright: #fff;
+    --color-muted: #666;
+    --color-faint: #444;
+    --color-amber: #f5a623;
+    --color-green: #4caf50;
+    --color-red: #f44336;
+    --color-blue: #2196f3;
+    --fs-base: 13px;
+    --fs-meta: 12px;
+    --fs-micro: 10px;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  body { margin: 0; }`;
+  document.head.appendChild(fontStyle);
+  mockList.mockReset();
+});
+afterEach(() => {
+  fontStyle.remove();
+  document.body.innerHTML = "";
+});
+
+const noop = () => {};
+
+const launchBtn = () => page.getByRole("button", { name: m.prspanel_launch_train() });
+const checkbox = (n: number) =>
+  page.getByRole("checkbox", { name: m.prspanel_select_pr({ number: n }) });
+
+describe("PrsPanel launch-train toolbar", () => {
+  it("disables Launch with 0 and 1 selected, enables it with 2", async () => {
+    seed([pr(1), pr(2), pr(3)]);
+    render(PrsPanel, { repoPath: "/repo", onreview: noop, onlaunchtrain: noop });
+
+    // wait for the rows to load
+    await expect.element(checkbox(1)).toBeInTheDocument();
+
+    // 0 selected → disabled
+    await expect.element(launchBtn()).toBeDisabled();
+
+    // 1 selected → still disabled (a train needs >= 2 PRs)
+    await checkbox(1).click();
+    await expect.element(launchBtn()).toBeDisabled();
+
+    // 2 selected → enabled
+    await checkbox(2).click();
+    await expect.element(launchBtn()).toBeEnabled();
+  });
+
+  it("select-all selects every row, then clear deselects all", async () => {
+    seed([pr(1), pr(2), pr(3)]);
+    render(PrsPanel, { repoPath: "/repo", onreview: noop, onlaunchtrain: noop });
+    await expect.element(checkbox(1)).toBeInTheDocument();
+
+    await page.getByRole("button", { name: m.prspanel_select_all() }).click();
+    await expect.element(checkbox(1)).toBeChecked();
+    await expect.element(checkbox(2)).toBeChecked();
+    await expect.element(checkbox(3)).toBeChecked();
+    await expect.element(launchBtn()).toBeEnabled();
+
+    await page.getByRole("button", { name: m.prspanel_clear_all() }).click();
+    await expect.element(checkbox(1)).not.toBeChecked();
+    await expect.element(checkbox(2)).not.toBeChecked();
+    await expect.element(checkbox(3)).not.toBeChecked();
+    await expect.element(launchBtn()).toBeDisabled();
+  });
+
+  it("clears the selection when the repoPath prop changes", async () => {
+    seed([pr(1), pr(2)]);
+    const { rerender } = render(PrsPanel, {
+      repoPath: "/repo-a",
+      onreview: noop,
+      onlaunchtrain: noop,
+    });
+    await expect.element(checkbox(1)).toBeInTheDocument();
+
+    await checkbox(1).click();
+    await checkbox(2).click();
+    await expect.element(launchBtn()).toBeEnabled();
+
+    // new repo → selection must not leak across repos
+    seed([pr(1), pr(2)], "acme/other");
+    await rerender({ repoPath: "/repo-b", onreview: noop, onlaunchtrain: noop });
+    await expect.element(checkbox(1)).not.toBeChecked();
+    await expect.element(checkbox(2)).not.toBeChecked();
+    await expect.element(launchBtn()).toBeDisabled();
+  });
+
+  it("reconciles a selected row that leaves the list (phantom can't arm the gate)", async () => {
+    seed([pr(1), pr(2), pr(3)]);
+    render(PrsPanel, { repoPath: "/repo", onreview: noop, onlaunchtrain: noop });
+    await expect.element(checkbox(1)).toBeInTheDocument();
+
+    // select two — gate armed, count shows 2
+    await checkbox(1).click();
+    await checkbox(2).click();
+    await expect.element(launchBtn()).toBeEnabled();
+    await expect
+      .element(page.getByText(m.prspanel_selected_count({ count: 2 })))
+      .toBeInTheDocument();
+
+    // merge PR 2: the row leaves the list. The silent reload returns only 1 + 3,
+    // so the present-selection drops to {1} and the gate disarms.
+    seed([pr(1), pr(3)]);
+    // exact: the launch button's name ("Launch merge train") substring-matches
+    // "Merge", so without exact we'd grab the wrong control.
+    await page.getByRole("button", { name: m.prspanel_merge_button(), exact: true }).nth(1).click(); // arm PR 2 (rows in order 1,2,3)
+    await page.getByRole("button", { name: m.prspanel_merge_confirm(), exact: true }).click(); // confirm
+
+    await expect.element(checkbox(2)).not.toBeInTheDocument();
+    await expect
+      .element(page.getByText(m.prspanel_selected_count({ count: 1 })))
+      .toBeInTheDocument();
+    await expect.element(launchBtn()).toBeDisabled();
+  });
+
+  it("calls onlaunchtrain with the selected PRs in display order", async () => {
+    seed([pr(1, "first"), pr(2, "second"), pr(3, "third")]);
+    const onlaunchtrain = vi.fn();
+    render(PrsPanel, { repoPath: "/repo", onreview: noop, onlaunchtrain });
+    await expect.element(checkbox(1)).toBeInTheDocument();
+
+    // select out of order; payload must still be in display order (1, 3)
+    await checkbox(3).click();
+    await checkbox(1).click();
+    await launchBtn().click();
+
+    expect(onlaunchtrain).toHaveBeenCalledOnce();
+    const [repoPath, prs] = onlaunchtrain.mock.calls[0];
+    expect(repoPath).toBe("/repo");
+    expect(prs.map((p: PullRequest) => p.number)).toEqual([1, 3]);
+  });
+});

--- a/ui/src/lib/components/PrsPanel.svelte
+++ b/ui/src/lib/components/PrsPanel.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { untrack } from "svelte";
+  import { SvelteSet } from "svelte/reactivity";
   import { listPullRequests } from "$lib/api";
   import type { PullRequest } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
@@ -7,17 +9,37 @@
   let {
     repoPath,
     onreview,
+    onlaunchtrain,
     age = false,
   }: {
     repoPath: string;
     /** Open a review task seeded with this PR (mirrors the issue → task path). */
     onreview: (pr: PullRequest) => void;
+    /** Launch a merge train from the multi-selected PRs (in display order).
+     *  Optional so existing consumers keep compiling until Task 3 wires it. */
+    onlaunchtrain?: (repoPath: string, prs: PullRequest[]) => void;
     age?: boolean;
   } = $props();
 
   let prs = $state<PullRequest[]>([]);
   let slug = $state<string | null>(null);
   let loading = $state(true);
+
+  // Multi-select for launching a merge train. Holds PR numbers; the launch
+  // payload is always reconciled against the present list so a row that merged
+  // out from under the set can't keep a phantom number armed.
+  let selected = new SvelteSet<number>();
+  const presentSelected = $derived(prs.filter((p) => selected.has(p.number)));
+  const allSelected = $derived(prs.length > 0 && presentSelected.length === prs.length);
+
+  function toggle(n: number) {
+    if (selected.has(n)) selected.delete(n);
+    else selected.add(n);
+  }
+  function toggleAll() {
+    if (allSelected) selected.clear();
+    else for (const p of prs) selected.add(p.number);
+  }
 
   // `silent` reloads without flipping the full-panel loading placeholder — used
   // after a merge so the optimistic row removal stays visible while we reconcile.
@@ -37,13 +59,22 @@
   }
 
   $effect(() => {
-    load(repoPath);
+    // Re-run ONLY when the repo flips. `selected.clear()` reads the set's version
+    // internally, so running it (un-untracked) would make this effect a dependent
+    // of `selected` and a plain row-toggle would wrongly wipe the selection.
+    const rp = repoPath;
+    untrack(() => {
+      // Selection must never leak across repos — clear it whenever the repo flips.
+      selected.clear();
+      load(rp);
+    });
   });
 
   // Drop the merged row immediately; a silent reload reconciles the rest
   // (e.g. a stacked PR that just became mergeable) without flashing the list.
   function onmerged(number: number) {
     prs = prs.filter((p) => p.number !== number);
+    selected.delete(number); // keep the set from accumulating a now-gone number
     load(repoPath, true);
   }
 </script>
@@ -52,6 +83,23 @@
   <div class="prs-header">
     {#if slug}{m.prspanel_title_with_slug({ slug })}{:else}{m.prspanel_title()}{/if}
   </div>
+
+  {#if prs.length > 0}
+    <div class="prs-toolbar">
+      <button type="button" class="link" onclick={toggleAll}>
+        {allSelected ? m.prspanel_clear_all() : m.prspanel_select_all()}
+      </button>
+      <span class="count">{m.prspanel_selected_count({ count: presentSelected.length })}</span>
+      <button
+        type="button"
+        class="gbtn"
+        disabled={presentSelected.length < 2}
+        onclick={() => onlaunchtrain?.(repoPath, presentSelected)}
+      >
+        {m.prspanel_launch_train()}
+      </button>
+    </div>
+  {/if}
 
   <div class="prs-list">
     {#if loading}
@@ -62,7 +110,16 @@
       <div class="muted">{m.prspanel_no_open()}</div>
     {:else}
       {#each prs as pr (pr.number)}
-        <PrRow {repoPath} {pr} {age} {onreview} {onmerged} />
+        <PrRow
+          {repoPath}
+          {pr}
+          {age}
+          {onreview}
+          {onmerged}
+          selectable
+          selected={selected.has(pr.number)}
+          ontoggle={() => toggle(pr.number)}
+        />
       {/each}
     {/if}
   </div>
@@ -86,6 +143,56 @@
     color: var(--color-muted);
     border-bottom: 1px solid var(--color-line);
     flex-shrink: 0;
+  }
+
+  /* Pinned launch toolbar: a sibling of the scroller (never a row inside it) so
+     it stays reachable with a long PR list — matches the header's chrome. */
+  .prs-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--color-line);
+    flex-shrink: 0;
+  }
+
+  .prs-toolbar .link {
+    background: transparent;
+    border: 0;
+    color: var(--color-amber);
+    cursor: pointer;
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+  }
+
+  .prs-toolbar .count {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    margin-right: auto;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 
   .prs-list {

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -5,6 +5,7 @@ import {
   mergeTrainCreateInput,
   pickTrainRepo,
   isMerging,
+  sessionsForPrNumbers,
   MERGE_STALE_MS,
 } from "./merge-train";
 import type { Session, GitState } from "$lib/types";
@@ -168,22 +169,16 @@ describe("collectReadyPrs", () => {
 describe("formatReadyPrs", () => {
   it("formats one bullet per PR with number, title and url", () => {
     const out = formatReadyPrs([
-      { sessionId: "s1", number: 11, title: "feat: a", url: "https://h/pull/11", repoPath: "/r" },
-      { sessionId: "s2", number: 22, title: "fix: b", url: "https://h/pull/22", repoPath: "/r" },
+      { number: 11, title: "feat: a", url: "https://h/pull/11" },
+      { number: 22, title: "fix: b", url: "https://h/pull/22" },
     ]);
     expect(out).toBe("- #11 feat: a — https://h/pull/11\n- #22 fix: b — https://h/pull/22");
   });
 
   it("omits an empty title and an empty url gracefully", () => {
-    expect(
-      formatReadyPrs([{ sessionId: "s", number: 9, title: "", url: "", repoPath: "/r" }]),
-    ).toBe("- #9");
-    expect(
-      formatReadyPrs([{ sessionId: "s", number: 9, title: "t", url: "", repoPath: "/r" }]),
-    ).toBe("- #9 t");
-    expect(
-      formatReadyPrs([{ sessionId: "s", number: 9, title: "", url: "u", repoPath: "/r" }]),
-    ).toBe("- #9 — u");
+    expect(formatReadyPrs([{ number: 9, title: "", url: "" }])).toBe("- #9");
+    expect(formatReadyPrs([{ number: 9, title: "t", url: "" }])).toBe("- #9 t");
+    expect(formatReadyPrs([{ number: 9, title: "", url: "u" }])).toBe("- #9 — u");
   });
 });
 
@@ -251,4 +246,114 @@ test("isMerging: true when marked and within TTL, false when null or stale", () 
   expect(isMerging(make(null), now)).toBe(false);
   expect(isMerging(make(now - 1000), now)).toBe(true);
   expect(isMerging(make(now - MERGE_STALE_MS - 1), now)).toBe(false);
+});
+
+describe("sessionsForPrNumbers", () => {
+  const repoA = "/repo/a";
+  const repoB = "/repo/b";
+
+  it("returns session ids for ready PRs matching repo and numbers", () => {
+    const sessions = [
+      session({ id: "a", readyToMerge: true, repoPath: repoA }),
+      session({ id: "b", readyToMerge: true, repoPath: repoA }),
+    ];
+    const git: Record<string, GitState> = {
+      a: openPr(11, "feat: a", "https://h/pull/11"),
+      b: openPr(22, "feat: b", "https://h/pull/22"),
+    };
+    expect(sessionsForPrNumbers(repoA, [11, 22], sessions, git)).toEqual(["a", "b"]);
+  });
+
+  it("excludes sessions from a different repo", () => {
+    const sessions = [
+      session({ id: "a", readyToMerge: true, repoPath: repoA }),
+      session({ id: "b", readyToMerge: true, repoPath: repoB }),
+    ];
+    const git: Record<string, GitState> = {
+      a: openPr(11, "feat: a", "https://h/pull/11"),
+      b: openPr(22, "feat: b", "https://h/pull/22"),
+    };
+    expect(sessionsForPrNumbers(repoA, [11, 22], sessions, git)).toEqual(["a"]);
+  });
+
+  it("excludes sessions not readyToMerge", () => {
+    const sessions = [
+      session({ id: "a", readyToMerge: true, repoPath: repoA }),
+      session({ id: "b", readyToMerge: false, repoPath: repoA }),
+    ];
+    const git: Record<string, GitState> = {
+      a: openPr(11, "feat: a", "https://h/pull/11"),
+      b: openPr(22, "feat: b", "https://h/pull/22"),
+    };
+    expect(sessionsForPrNumbers(repoA, [11, 22], sessions, git)).toEqual(["a"]);
+  });
+
+  it("excludes sessions where isReviewing returns true", () => {
+    const sessions = [
+      session({ id: "a", readyToMerge: true, repoPath: repoA }),
+      session({ id: "b", readyToMerge: true, repoPath: repoA }),
+    ];
+    const git: Record<string, GitState> = {
+      a: openPr(11, "feat: a", "https://h/pull/11"),
+      b: openPr(22, "feat: b", "https://h/pull/22"),
+    };
+    expect(sessionsForPrNumbers(repoA, [11, 22], sessions, git, (id) => id === "a")).toEqual(["b"]);
+  });
+
+  it("returns empty array when no numbers match", () => {
+    const sessions = [session({ id: "a", readyToMerge: true, repoPath: repoA })];
+    const git: Record<string, GitState> = {
+      a: openPr(11, "feat: a", "https://h/pull/11"),
+    };
+    expect(sessionsForPrNumbers(repoA, [99, 100], sessions, git)).toEqual([]);
+  });
+
+  it("returns empty array for an empty numbers list", () => {
+    const sessions = [session({ id: "a", readyToMerge: true, repoPath: repoA })];
+    const git: Record<string, GitState> = {
+      a: openPr(11, "feat: a", "https://h/pull/11"),
+    };
+    expect(sessionsForPrNumbers(repoA, [], sessions, git)).toEqual([]);
+  });
+});
+
+describe("mergeTrainCreateInput with handpicked param", () => {
+  // A session-less item (e.g. a PullRequest from the PRs panel with no sessionId)
+  const prsNoSession = [
+    { number: 11, title: "feat: a", url: "https://h/pull/11" },
+    { number: 22, title: "fix: b", url: "https://h/pull/22" },
+  ];
+
+  it("accepts Pick<ReadyPr> items without sessionId", () => {
+    const input = mergeTrainCreateInput("/repo/a", "main", prsNoSession);
+    expect(typeof input.prompt).toBe("string");
+    expect(input.prompt.length).toBeGreaterThan(0);
+  });
+
+  it("default (handpicked=false) uses herd framing (flagged ready)", () => {
+    const input = mergeTrainCreateInput("/repo/a", "main", prsNoSession, false);
+    expect(input.prompt).toContain("flagged ready to merge");
+    expect(input.prompt).toContain("Ready-to-merge PRs:");
+  });
+
+  it("handpicked=true uses selected framing", () => {
+    const input = mergeTrainCreateInput("/repo/a", "main", prsNoSession, true);
+    expect(input.prompt).toContain("I've selected");
+    expect(input.prompt).toContain("Selected PRs:");
+  });
+
+  it("handpicked=true and false produce different prompts", () => {
+    const defaultInput = mergeTrainCreateInput("/repo/a", "main", prsNoSession, false);
+    const handpickedInput = mergeTrainCreateInput("/repo/a", "main", prsNoSession, true);
+    expect(defaultInput.prompt).not.toBe(handpickedInput.prompt);
+  });
+
+  it("always skips plan gate regardless of handpicked", () => {
+    expect(mergeTrainCreateInput("/repo/a", "main", prsNoSession, false).planGateEnabled).toBe(
+      false,
+    );
+    expect(mergeTrainCreateInput("/repo/a", "main", prsNoSession, true).planGateEnabled).toBe(
+      false,
+    );
+  });
 });

--- a/ui/src/lib/components/merge-train.ts
+++ b/ui/src/lib/components/merge-train.ts
@@ -53,7 +53,7 @@ export function collectReadyPrs(
 
 /** Render the PR list for the kickoff prompt: one `- #<n> <title> — <url>`
  *  bullet per PR, gracefully dropping an absent title or url. */
-export function formatReadyPrs(prs: ReadyPr[]): string {
+export function formatReadyPrs(prs: Pick<ReadyPr, "number" | "title" | "url">[]): string {
   return prs
     .map((p) => {
       let line = `- #${p.number}`;
@@ -92,19 +92,48 @@ export function pickTrainRepo(prs: ReadyPr[]): {
 }
 
 /** Build the `createSession` input for a merge-train kickoff. Pure (no I/O, no
- *  side effects) so the gate-skip invariant is locked by `merge-train.test.ts`. */
+ *  side effects) so the gate-skip invariant is locked by `merge-train.test.ts`.
+ *
+ *  Two framings:
+ *  - `handpicked=false` (default): the PRs were operator-flagged readyToMerge —
+ *    uses `herd_merge_train_prompt` which says "I've flagged ready to merge".
+ *  - `handpicked=true`: the user hand-selected PRs from the backlog PRs panel —
+ *    uses `prspanel_merge_train_prompt` which says "I've selected", making no
+ *    false claim about readiness status. */
 export function mergeTrainCreateInput(
   repoPath: string,
   baseBranch: string,
-  prs: ReadyPr[],
+  prs: Pick<ReadyPr, "number" | "title" | "url">[],
+  handpicked = false,
 ): CreateInput {
+  const formatted = formatReadyPrs(prs);
   return {
     repoPath,
     baseBranch,
-    prompt: m.herd_merge_train_prompt({ prs: formatReadyPrs(prs) }),
+    prompt: handpicked
+      ? m.prspanel_merge_train_prompt({ prs: formatted })
+      : m.herd_merge_train_prompt({ prs: formatted }),
     model: null,
     // Merge train is a procedural land-the-queue task, never a feature plan —
     // always skip the plan gate regardless of the per-repo toggle.
     planGateEnabled: false,
   };
+}
+
+/** Return the `sessionId`s of ready-to-merge sessions whose open PR number is
+ *  in `numbers` AND whose `repoPath` matches.
+ *
+ *  Selects **only `readyToMerge`** sessions (mirroring `onmergetrain`), so an
+ *  in-progress session's PR not appearing here is deliberate, not a bug. */
+export function sessionsForPrNumbers(
+  repoPath: string,
+  numbers: number[],
+  sessions: Session[],
+  git: Record<string, GitState>,
+  isReviewing: (id: string) => boolean = () => false,
+): string[] {
+  const numberSet = new Set(numbers);
+  return collectReadyPrs(sessions, git, isReviewing)
+    .filter((p) => p.repoPath === repoPath && numberSet.has(p.number))
+    .map((p) => p.sessionId);
 }

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -125,7 +125,10 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     // No targetId: the multi-select controls live inside the PRs tab which is
     // only mounted when a repo is selected; coachmark anchor added in a later task.
     id: "backlog-pr-merge-train",
-    sinceVersion: "1.19.0",
+    // v1.19.0 is already tagged, so this feature ships in the next release (1.20.0).
+    // computeNewEntries only surfaces entries with lastSeen < sinceVersion, so a
+    // 1.19.0 entry would never reach users who already saw the 1.19.0 drawer.
+    sinceVersion: "1.20.0",
     titleKey: "feat_backlog_pr_merge_train_title",
     bodyKey: "feat_backlog_pr_merge_train_body",
   },

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -121,4 +121,12 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_newtask_repo_first_body",
     targetId: "nt-repo",
   },
+  {
+    // No targetId: the multi-select controls live inside the PRs tab which is
+    // only mounted when a repo is selected; coachmark anchor added in a later task.
+    id: "backlog-pr-merge-train",
+    sinceVersion: "1.19.0",
+    titleKey: "feat_backlog_pr_merge_train_title",
+    bodyKey: "feat_backlog_pr_merge_train_body",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -51,6 +51,7 @@
     collectReadyPrs,
     mergeTrainCreateInput,
     pickTrainRepo,
+    sessionsForPrNumbers,
   } from "$lib/components/merge-train";
   import Viewport from "$lib/components/Viewport.svelte";
   import NewTask from "$lib/components/NewTask.svelte";
@@ -295,6 +296,37 @@
       if (mobile.current) mobileScreen = "detail";
       if (otherRepoCount > 0)
         toasts.info(m.toast_merge_train_other_repos({ count: otherRepoCount }));
+    } catch {
+      toasts.info(m.toast_merge_train_failed());
+    }
+  }
+
+  /** Launch a merge train scoped to a hand-picked set of PRs from the backlog
+   *  PRs panel. Unlike onmergetrain (which auto-collects ready sessions), the
+   *  operator chose these PRs directly, so the kickoff prompt uses the
+   *  hand-picked framing. Matching ready-to-merge sessions are marked "merging";
+   *  backlog-only PRs (no session) still ride along in the prompt. */
+  async function onlaunchtrain(repoPath: string, prs: PullRequest[]) {
+    if (prs.length < 2) return; // UI gates at >=2; defensive guard
+    const br = await listBranches(repoPath).catch(() => null);
+    const baseBranch = br?.current ?? br?.branches[0] ?? "main";
+    try {
+      const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs, true));
+      selectedId = s.id;
+      // Mark any ready-to-merge sessions whose open PR is in this selection as
+      // "merging" (same coupling as onmergetrain). Composed review predicate
+      // matches onmergetrain. Fire-and-forget + fail-soft; skip when none match.
+      const ids = sessionsForPrNumbers(
+        repoPath,
+        prs.map((p) => p.number),
+        store.sessions,
+        store.git,
+        (id) => reviews.isReviewing(id) || planGates.isReviewing(id),
+      );
+      if (ids.length > 0)
+        startMergeTrain(ids, s.id).catch(() => toasts.info(m.toast_merge_train_mark_failed()));
+      showBacklog = false;
+      if (mobile.current) mobileScreen = "detail";
     } catch {
       toasts.info(m.toast_merge_train_failed());
     }
@@ -709,6 +741,7 @@
               onquick={onquickissue}
               {onpr}
               {onadopt}
+              {onlaunchtrain}
               flow={true}
             />
           {/if}
@@ -784,6 +817,7 @@
             onquick={onquickissue}
             {onpr}
             {onadopt}
+            {onlaunchtrain}
           />
         {:else if selected}
           <Viewport
@@ -978,6 +1012,7 @@
     onquick={onquickissue}
     {onpr}
     {onadopt}
+    {onlaunchtrain}
     onclose={() => (showBacklog = false)}
   />
 {/if}


### PR DESCRIPTION
## What

Adds the ability to hand-pick multiple open PRs in a repo's **PRs** tab on the backlog page and launch a merge train scoped to exactly those PRs — complementing the existing herd-level "Ready to merge" launch (`onmergetrain`), which auto-collects all ready-to-merge sessions across the herd and picks one repo by majority.

## How it works

1. Each open PR row in the backlog PRs panel gains a checkbox. A pinned toolbar (select-all/clear + selected count + **Launch merge train**) sits above the scrolling list; the launch button arms at **2+** selected PRs.
2. Launching creates a merge-train session scoped to that repo, listing the selected PRs (in display order), switches to the new session, and marks any matching ready-to-merge sessions "merging" (same coupling as the herd-level launch).
3. The kickoff prompt uses a **hand-picked** framing (`prspanel_merge_train_prompt`: "the pull requests I've selected" / "Selected PRs:") — it makes no false "flagged ready" claim, since the operator may pick drafts or not-yet-ready PRs. The agent still hold-lists CI-red/conflicting PRs.

## Key design points

- **Selection reconciled against the live PR list** — `presentSelected = prs.filter(p => selected.has(p.number))` drives the count, gate, and launch payload, and `onmerged` prunes the set, so a row merged via the per-row button can't leave a phantom number arming the gate. Selection clears on repo switch.
- **Session coupling** via a new pure helper `sessionsForPrNumbers(...)` (built on `collectReadyPrs`) — marks only `readyToMerge` sessions whose open PR is in the selection; pure backlog PRs with no session still ride along in the prompt (train launches even when zero sessions match).
- Reuses `mergeTrainCreateInput` (param type relaxed to a `Pick`, plus a `handpicked` flag) and `startMergeTrain` — **no new server endpoints**.

## Scope of changes

- `merge-train.ts` — `handpicked` prompt flag + `sessionsForPrNumbers` helper + relaxed param types
- `PrRow.svelte` / `PrsPanel.svelte` — checkbox + multi-select state + pinned launch toolbar
- `BacklogView.svelte` / `BacklogOverlay.svelte` / `+page.svelte` — thread `onlaunchtrain` + handler
- i18n: new EN+DE keys (parity passing); feature-announcements entry (`backlog-pr-merge-train`, 1.19.0)
- Tests: `merge-train.test.ts` unit coverage + new `PrsPanel.browser.test.ts`

## Verification

- `cd ui && bun run check` — 0 errors / 0 warnings
- `cd ui && bun run test` — 620 passed (incl. 5 new browser tests + new unit tests)
- `bun run check:i18n` — EN/DE parity (705 keys)
- `bunx fallow audit --base origin/main` — 0 new dead code / complexity issues
- branch-hygiene + feature-catalog gates pass; branch linear off main

🤖 Generated with [Claude Code](https://claude.com/claude-code)