### PR TITLE
fix: eliminate intermittent 1-3s web-terminal input freezes (event-loop starvation)

### DIFF
--- a/src/activity-signal.ts
+++ b/src/activity-signal.ts
@@ -1,5 +1,4 @@
-import { readFileSync } from "node:fs";
-import { parseActivity, latestRecordTs, type ActivityEntry } from "./activity";
+import { parseActivity, latestRecordTs, readTranscriptTail, type ActivityEntry } from "./activity";
 import { snapshotFrom, DEFAULT_STALL, type ActivitySnapshot } from "./stall";
 
 /** Per-agent liveness + current-activity signal pushed to UI clients. */
@@ -77,11 +76,13 @@ export function signalFromText(text: string): SessionActivity | null {
  * Synchronously derive an activity signal from a session JSONL transcript.
  * Missing/unreadable file → null ("no signal yet"). Also returns null when the
  * transcript has no parseable records at all (e.g. a brand-new session).
+ * Reads only the tail of the file (bounded by MAX_TAIL_BYTES) to avoid blocking
+ * the event loop on large transcripts.
  */
 export function readActivitySignal(path: string): SessionActivity | null {
   let text: string;
   try {
-    text = readFileSync(path, "utf8");
+    text = readTranscriptTail(path);
   } catch {
     return null;
   }
@@ -91,7 +92,7 @@ export function readActivitySignal(path: string): SessionActivity | null {
 /**
  * Read a session JSONL transcript ONCE and derive BOTH the stall snapshot and
  * the activity signal from a SINGLE parse — the per-tick probe for a running
- * agent. Missing/unreadable file → both null. One `readFileSync`, one
+ * agent. Missing/unreadable file → both null. One tail-bounded read, one
  * `parseActivity`, one `latestRecordTs`, both builders fed from the result —
  * no duplicate disk read or in-memory parse per tick.
  */
@@ -101,7 +102,7 @@ export function readTranscriptSignals(path: string): {
 } {
   let text: string;
   try {
-    text = readFileSync(path, "utf8");
+    text = readTranscriptTail(path);
   } catch {
     return { snapshot: null, activity: null };
   }

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -1,3 +1,5 @@
+import { openSync, fstatSync, readSync, closeSync } from "node:fs";
+import { timed } from "./instrument";
 import { eachJsonlObject } from "./jsonl";
 
 export interface ActivityEntry {
@@ -121,6 +123,43 @@ function collectEntries(records: ParsedRecord[], errored: Map<string, boolean>):
     }
   }
   return entries;
+}
+
+/**
+ * 512 KB is far larger than the stall window's worth of JSONL records (a few
+ * hundred bytes each × the last few hundred turns), so signal accuracy is fully
+ * preserved while bounding the bytes fed to JSON.parse on every poll tick.
+ */
+export const MAX_TAIL_BYTES = 512 * 1024;
+
+/**
+ * Read only the last `maxBytes` bytes of a JSONL transcript file.
+ *
+ * When the file is larger than `maxBytes` the read starts mid-file; the leading
+ * partial line (up to and including the first `\n`) is dropped so a truncated
+ * record is never fed to the parser. When the whole file fits, the content is
+ * returned intact. Throws on read errors (e.g. missing file) so callers can
+ * handle with their existing try/catch → null patterns.
+ */
+export function readTranscriptTail(path: string, maxBytes = MAX_TAIL_BYTES): string {
+  return timed(`transcript-tail ${basename(path)}`, () => {
+    const fd = openSync(path, "r");
+    try {
+      const { size } = fstatSync(fd);
+      const readBytes = Math.min(size, maxBytes);
+      const buf = Buffer.allocUnsafe(readBytes);
+      readSync(fd, buf, 0, readBytes, size - readBytes);
+      const text = buf.toString("utf8");
+      // started mid-file → drop the leading partial line
+      if (size > maxBytes) {
+        const nl = text.indexOf("\n");
+        return nl === -1 ? "" : text.slice(nl + 1);
+      }
+      return text;
+    } finally {
+      closeSync(fd);
+    }
+  });
 }
 
 /**

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -148,8 +148,8 @@ export function readTranscriptTail(path: string, maxBytes = MAX_TAIL_BYTES): str
       const { size } = fstatSync(fd);
       const readBytes = Math.min(size, maxBytes);
       const buf = Buffer.allocUnsafe(readBytes);
-      readSync(fd, buf, 0, readBytes, size - readBytes);
-      const text = buf.toString("utf8");
+      const n = readSync(fd, buf, 0, readBytes, size - readBytes);
+      const text = buf.subarray(0, n).toString("utf8");
       // started mid-file → drop the leading partial line
       if (size > maxBytes) {
         const nl = text.indexOf("\n");

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -129,6 +129,13 @@ function collectEntries(records: ParsedRecord[], errored: Map<string, boolean>):
  * 512 KB is far larger than the stall window's worth of JSONL records (a few
  * hundred bytes each × the last few hundred turns), so signal accuracy is fully
  * preserved while bounding the bytes fed to JSON.parse on every poll tick.
+ *
+ * Scope note: this bounds the per-call cost, but the read+parse is still
+ * SYNCHRONOUS and runs once per poll tick per *running* session, so total
+ * on-loop cost still scales with the number of concurrent running sessions. It's
+ * a bounded mitigation (each call is small + fast), not a full off-loop move; if
+ * session counts ever make even the bounded parses add up, move the probe to an
+ * async read + worker/streamed parse.
  */
 export const MAX_TAIL_BYTES = 512 * 1024;
 
@@ -140,6 +147,12 @@ export const MAX_TAIL_BYTES = 512 * 1024;
  * record is never fed to the parser. When the whole file fits, the content is
  * returned intact. Throws on read errors (e.g. missing file) so callers can
  * handle with their existing try/catch → null patterns.
+ *
+ * Degradation edge: if the tail window contains NO newline — a single JSONL
+ * record larger than `maxBytes` (pathological; a multi-hundred-KB tool result) —
+ * the leading-partial drop yields "" and the caller gets a null signal for this
+ * tick. This is acceptable and transient: it self-heals as soon as a newer
+ * complete record lands (the next record's bytes bring a `\n` into the window).
  */
 export function readTranscriptTail(path: string, maxBytes = MAX_TAIL_BYTES): string {
   return timed(`transcript-tail ${basename(path)}`, () => {
@@ -150,7 +163,9 @@ export function readTranscriptTail(path: string, maxBytes = MAX_TAIL_BYTES): str
       const buf = Buffer.allocUnsafe(readBytes);
       const n = readSync(fd, buf, 0, readBytes, size - readBytes);
       const text = buf.subarray(0, n).toString("utf8");
-      // started mid-file → drop the leading partial line
+      // started mid-file → drop the leading partial line. nl === -1 means the
+      // whole window is one partial record (a single record > maxBytes): yield ""
+      // → null signal this tick, self-healing once a newer complete record lands.
       if (size > maxBytes) {
         const nl = text.indexOf("\n");
         return nl === -1 ? "" : text.slice(nl + 1);

--- a/src/automerge.ts
+++ b/src/automerge.ts
@@ -83,11 +83,11 @@ export class AutoMergeService {
   /** behindBase() shells out to `git fetch`; cache per (worktree,base) for a short TTL so a
    *  burst of poller events / client snapshots doesn't fan out one fetch per open PR each time.
    *  Cleared on a successful merge so siblings get a fresh read once main moves. */
-  private cachedBehind(worktreePath: string, baseBranch: string): boolean | null {
+  private async cachedBehind(worktreePath: string, baseBranch: string): Promise<boolean | null> {
     const key = `${worktreePath}\0${baseBranch}`;
     const hit = this.behindCache.get(key);
     if (hit && this.now() - hit.ts < this.behindTtlMs) return hit.behind;
-    const behind = this.deps.worktree.behindBase(worktreePath, baseBranch);
+    const behind = await this.deps.worktree.behindBase(worktreePath, baseBranch);
     this.behindCache.set(key, { behind, ts: this.now() });
     return behind;
   }
@@ -118,11 +118,11 @@ export class AutoMergeService {
   }
 
   /** Project one full-auto session + its cached PR snapshot into the core's view. */
-  private toView(s: Session, git: GitState | null): MergeSessionView {
+  private async toView(s: Session, git: GitState | null): Promise<MergeSessionView> {
     const headSha = git?.headSha ?? null;
     const behind =
       git?.state === "open" && s.worktreePath && s.branch
-        ? this.cachedBehind(s.worktreePath, s.baseBranch)
+        ? await this.cachedBehind(s.worktreePath, s.baseBranch)
         : null;
     const review = this.deps.store.getReview(s.id);
     return {
@@ -142,13 +142,15 @@ export class AutoMergeService {
     };
   }
 
-  private buildState(repoPath: string): MergeRepoState {
+  private async buildState(repoPath: string): Promise<MergeRepoState> {
     const cfg = this.deps.store.getRepoConfig(repoPath);
     const snapshot = this.deps.prCache.snapshot();
-    const sessions: MergeSessionView[] = this.deps.store
-      .list()
-      .filter((s) => s.repoPath === repoPath && s.status !== "archived" && this.fullAuto(s))
-      .map((s) => this.toView(s, snapshot[s.id] ?? null));
+    const sessions: MergeSessionView[] = await Promise.all(
+      this.deps.store
+        .list()
+        .filter((s) => s.repoPath === repoPath && s.status !== "archived" && this.fullAuto(s))
+        .map((s) => this.toView(s, snapshot[s.id] ?? null)),
+    );
     return {
       enabled: sessions.length > 0,
       criticEnabled: cfg.criticEnabled,
@@ -224,7 +226,7 @@ export class AutoMergeService {
       for (let i = 0; i < 100; i++) {
         let state: MergeRepoState;
         try {
-          state = this.buildState(repoPath);
+          state = await this.buildState(repoPath);
         } catch (err) {
           console.warn(`[automerge] build/compute failed for ${repoPath}:`, err);
           break;
@@ -333,11 +335,11 @@ export class AutoMergeService {
   }
 
   /** Client bootstrap: a status per full-auto-active repo, no side effects. */
-  snapshot(): AutoMergeStatus[] {
+  async snapshot(): Promise<AutoMergeStatus[]> {
     const out: AutoMergeStatus[] = [];
     for (const repoPath of this.deps.repos()) {
       if (!this.repoHasFullAuto(repoPath)) continue;
-      const d = computeMerge(this.buildState(repoPath));
+      const d = computeMerge(await this.buildState(repoPath));
       const reason = d.kind === "hold" ? (d.reason.code === "idle" ? null : d.reason.code) : d.kind;
       const detail = d.kind === "hold" ? (d.reason.detail ?? null) : null;
       const sessionId = d.kind === "hold" ? (d.reason.sessionId ?? null) : d.sessionId;

--- a/src/backlog.ts
+++ b/src/backlog.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "./instrument";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { parseRemote } from "./forge/remote";

--- a/src/branch-pruner.ts
+++ b/src/branch-pruner.ts
@@ -1,5 +1,5 @@
 // src/branch-pruner.ts
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "./instrument";
 import type { SessionStore } from "./store";
 import type { GitForge } from "./forge/types";
 
@@ -35,13 +35,11 @@ export class BranchPruner {
      *  again. Defaults to none (tests / callers that don't wire it). */
     private extraRepos: () => string[] = () => [],
     private intervalMs = 60 * 60 * 1000,
-    /** Max forge lookups per sweep. Each `forge.prStatus` is a blocking
-     *  `execFileSync("gh")` (see github.ts), so an unbounded first sweep over a
-     *  large accumulated backlog would stall the event loop; capping bounds the
-     *  blocking and lets the backlog drain across subsequent hourly ticks.
-     *  Residual: even capped, up to this many sequential `gh` calls still run per
-     *  tick, so under high gh latency the loop can briefly block for their sum —
-     *  lower this to trade slower backlog drain for shorter stalls. */
+    /** Max forge lookups per sweep. Each `forge.prStatus` is an async `gh`
+     *  subprocess (non-blocking). This cap bounds the number of concurrent/
+     *  sequential `gh` calls per tick (and associated GitHub API load), not
+     *  event-loop stall time. Raise to drain faster, lower to reduce API pressure;
+     *  the backlog drains across subsequent hourly ticks regardless. */
     private maxChecksPerTick = 20,
   ) {}
 

--- a/src/branches.ts
+++ b/src/branches.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "./instrument";
 
 export interface BranchList {
   branches: string[];

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,8 +1,19 @@
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { timedAsync } from "./instrument";
 import type { DiffFile, DiffHunk, DiffResult } from "./types";
+
+const execFileAsync = promisify(execFile);
 
 /** Files with more than this many diff lines render as a stub ("view in terminal"). */
 const MAX_FILE_LINES = 2000;
+
+/**
+ * Global cap on total add/del/ctx lines parsed across all files in one diff.
+ * Bounds CPU time on pathological diffs (e.g. 64 MiB of generated code).
+ * ~100k lines covers the vast majority of real PRs while limiting worst-case parse time.
+ */
+const MAX_TOTAL_LINES = 100_000;
 
 /** Strip git's a//b/ prefix; map /dev/null to "". */
 function stripPrefix(p: string): string {
@@ -95,7 +106,8 @@ function appendBodyLine(cur: DiffFile, hunk: DiffHunk, cursor: LineCursor, raw: 
  * Parse `git diff --no-color` unified output into structured files.
  * Handles added / modified / deleted / renamed / binary, computes +/- counts,
  * and assigns 1-based old/new line numbers. Files over MAX_FILE_LINES keep their
- * counts but drop hunk bodies (truncated=true).
+ * counts but drop hunk bodies (truncated=true). Once total lines across all files
+ * exceeds MAX_TOTAL_LINES, the current file is marked truncated and parsing stops.
  */
 export function parseUnifiedDiff(text: string): DiffFile[] {
   const files: DiffFile[] = [];
@@ -103,6 +115,7 @@ export function parseUnifiedDiff(text: string): DiffFile[] {
   let hunk: DiffHunk | null = null;
   const cursor: LineCursor = { oldNo: 0, newNo: 0 };
   let lineCount = 0; // add/del/ctx lines accumulated for cur
+  let totalLines = 0; // global tally across all files
 
   const finishFile = () => {
     if (!cur) return;
@@ -122,6 +135,15 @@ export function parseUnifiedDiff(text: string): DiffFile[] {
       continue;
     }
     if (!cur) continue;
+
+    // Global cap: stop parsing body content once total lines are exhausted.
+    // Mark the current file truncated so the caller knows the result is partial.
+    if (totalLines >= MAX_TOTAL_LINES) {
+      cur.truncated = true;
+      cur.hunks = [];
+      continue;
+    }
+
     if (applyFileHeader(cur, raw)) continue;
 
     if (raw.startsWith("@@")) {
@@ -135,7 +157,10 @@ export function parseUnifiedDiff(text: string): DiffFile[] {
     if (!hunk) continue;
     if (raw.startsWith("\\")) continue; // "\ No newline at end of file"
 
-    if (appendBodyLine(cur, hunk, cursor, raw)) lineCount++;
+    if (appendBodyLine(cur, hunk, cursor, raw)) {
+      lineCount++;
+      totalLines++;
+    }
   }
   finishFile();
   return files;
@@ -144,9 +169,11 @@ export function parseUnifiedDiff(text: string): DiffFile[] {
 const REMOTE = "origin";
 const MAX_BUFFER = 64 * 1024 * 1024; // 64 MiB — large diffs exceed the 1 MiB default
 
-function refExists(cwd: string, ref: string): boolean {
+async function refExists(cwd: string, ref: string): Promise<boolean> {
   try {
-    execFileSync("git", ["rev-parse", "--verify", "--quiet", ref], { cwd, stdio: "pipe" });
+    await timedAsync("git rev-parse", () =>
+      execFileAsync("git", ["rev-parse", "--verify", "--quiet", ref], { cwd, encoding: "utf8" }),
+    );
     return true;
   } catch {
     return false;
@@ -158,15 +185,20 @@ function refExists(cwd: string, ref: string): boolean {
  * prefer origin/<base>; fall back to local <base> when the fetch fails or the
  * remote-tracking ref doesn't resolve. Returns the chosen ref + whether fetch failed.
  */
-function resolveBaseRef(cwd: string, base: string): { ref: string; fetchFailed: boolean } {
+async function resolveBaseRef(
+  cwd: string,
+  base: string,
+): Promise<{ ref: string; fetchFailed: boolean }> {
   let fetchFailed = false;
   try {
-    execFileSync("git", ["fetch", REMOTE, base], { cwd, stdio: "pipe" });
+    await timedAsync("git fetch", () =>
+      execFileAsync("git", ["fetch", REMOTE, base], { cwd, encoding: "utf8" }),
+    );
   } catch {
     fetchFailed = true;
   }
   const remoteRef = `${REMOTE}/${base}`;
-  if (refExists(cwd, remoteRef)) return { ref: remoteRef, fetchFailed };
+  if (await refExists(cwd, remoteRef)) return { ref: remoteRef, fetchFailed };
   return { ref: base, fetchFailed: true }; // no remote-tracking ref → local base
 }
 
@@ -175,17 +207,23 @@ function resolveBaseRef(cwd: string, base: string): { ref: string; fetchFailed: 
  * Uses three-dot `<baseRef>...HEAD` = merge-base→HEAD = "what would merge".
  * Non-isolated sessions (no branch) return an empty result for the empty state.
  */
-export function computeDiff(worktreePath: string, base: string, branch: string | null): DiffResult {
+export async function computeDiff(
+  worktreePath: string,
+  base: string,
+  branch: string | null,
+): Promise<DiffResult> {
   if (!branch) {
     return { base, baseRef: base, head: null, fetchFailed: false, truncated: false, files: [] };
   }
-  const { ref, fetchFailed } = resolveBaseRef(worktreePath, base);
-  const out = execFileSync("git", ["diff", "--no-color", `${ref}...HEAD`], {
-    cwd: worktreePath,
-    stdio: "pipe",
-    maxBuffer: MAX_BUFFER,
-  }).toString();
-  const files = parseUnifiedDiff(out);
+  const { ref, fetchFailed } = await resolveBaseRef(worktreePath, base);
+  const { stdout } = await timedAsync("git diff", () =>
+    execFileAsync("git", ["diff", "--no-color", `${ref}...HEAD`], {
+      cwd: worktreePath,
+      encoding: "utf8",
+      maxBuffer: MAX_BUFFER,
+    }),
+  );
+  const files = parseUnifiedDiff(stdout);
   return {
     base,
     baseRef: ref,

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -107,7 +107,9 @@ function appendBodyLine(cur: DiffFile, hunk: DiffHunk, cursor: LineCursor, raw: 
  * Handles added / modified / deleted / renamed / binary, computes +/- counts,
  * and assigns 1-based old/new line numbers. Files over MAX_FILE_LINES keep their
  * counts but drop hunk bodies (truncated=true). Once total lines across all files
- * exceeds MAX_TOTAL_LINES, the current file is marked truncated and parsing stops.
+ * exceeds MAX_TOTAL_LINES, further body-line accumulation is skipped; file-header
+ * and hunk-header lines are still processed so over-cap files carry correct
+ * status/path/rename metadata (O(files), not O(body-lines)).
  */
 export function parseUnifiedDiff(text: string): DiffFile[] {
   const files: DiffFile[] = [];
@@ -116,6 +118,7 @@ export function parseUnifiedDiff(text: string): DiffFile[] {
   const cursor: LineCursor = { oldNo: 0, newNo: 0 };
   let lineCount = 0; // add/del/ctx lines accumulated for cur
   let totalLines = 0; // global tally across all files
+  let capped = false; // true once MAX_TOTAL_LINES is reached
 
   const finishFile = () => {
     if (!cur) return;
@@ -136,30 +139,46 @@ export function parseUnifiedDiff(text: string): DiffFile[] {
     }
     if (!cur) continue;
 
-    // Global cap: stop parsing body content once total lines are exhausted.
-    // Mark the current file truncated so the caller knows the result is partial.
-    if (totalLines >= MAX_TOTAL_LINES) {
-      cur.truncated = true;
-      cur.hunks = [];
-      continue;
-    }
-
+    // Always process file-header and hunk-header lines — they are O(files), bounded
+    // by the 64 MiB input cap, and keep metadata (status/path/rename) accurate even
+    // for files beyond the global cap.
     if (applyFileHeader(cur, raw)) continue;
 
     if (raw.startsWith("@@")) {
       const start = parseHunkHeader(raw);
       cursor.oldNo = start.oldNo;
       cursor.newNo = start.newNo;
-      hunk = { header: raw, lines: [] };
-      cur.hunks.push(hunk);
+      // Under the cap: accumulate normally. Over the cap: hunk slot is not needed
+      // (body lines will be skipped), so don't push to cur.hunks.
+      if (!capped) {
+        hunk = { header: raw, lines: [] };
+        cur.hunks.push(hunk);
+      }
       continue;
     }
+
+    // Skip body-line accumulation once globally capped.
+    if (capped) {
+      // Mark this file truncated once, at the point of transition or on first visit.
+      if (!cur.truncated) {
+        cur.truncated = true;
+        cur.hunks = [];
+      }
+      continue;
+    }
+
     if (!hunk) continue;
     if (raw.startsWith("\\")) continue; // "\ No newline at end of file"
 
     if (appendBodyLine(cur, hunk, cursor, raw)) {
       lineCount++;
       totalLines++;
+      // Transition: cap hit on this line — mark current file and set flag.
+      if (totalLines >= MAX_TOTAL_LINES) {
+        capped = true;
+        cur.truncated = true;
+        cur.hunks = [];
+      }
     }
   }
   finishFile();

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -102,6 +102,79 @@ function appendBodyLine(cur: DiffFile, hunk: DiffHunk, cursor: LineCursor, raw: 
   return false;
 }
 
+/** Mutable parse state threaded through handleDiffLine. */
+interface ParseState {
+  files: DiffFile[];
+  cur: DiffFile | null;
+  hunk: DiffHunk | null;
+  cursor: LineCursor;
+  lineCount: number; // add/del/ctx lines accumulated for cur
+  totalLines: number; // global tally across all files
+  capped: boolean; // true once MAX_TOTAL_LINES is reached
+}
+
+/** Seal cur into files, marking truncated when over per-file cap. */
+function finishFile(state: ParseState): void {
+  if (!state.cur) return;
+  if (state.lineCount > MAX_FILE_LINES) {
+    state.cur.truncated = true;
+    state.cur.hunks = [];
+  }
+  state.files.push(state.cur);
+}
+
+/**
+ * Dispatch one raw diff line against the current parse state.
+ * Always processes file-header and hunk-header lines — O(files), not O(body-lines) —
+ * so over-cap files still carry correct status/path/rename metadata.
+ */
+function handleDiffLine(state: ParseState, raw: string): void {
+  if (raw.startsWith("diff --git ")) {
+    finishFile(state);
+    state.hunk = null;
+    state.lineCount = 0;
+    state.cur = startFile(raw);
+    return;
+  }
+  if (!state.cur) return;
+  if (applyFileHeader(state.cur, raw)) return;
+
+  if (raw.startsWith("@@")) {
+    const start = parseHunkHeader(raw);
+    state.cursor.oldNo = start.oldNo;
+    state.cursor.newNo = start.newNo;
+    // Under cap: accumulate. Over cap: body lines are skipped, no hunk slot needed.
+    if (!state.capped) {
+      state.hunk = { header: raw, lines: [] };
+      state.cur.hunks.push(state.hunk);
+    }
+    return;
+  }
+
+  // Skip body-line work once globally capped; mark file truncated on first visit.
+  if (state.capped) {
+    if (!state.cur.truncated) {
+      state.cur.truncated = true;
+      state.cur.hunks = [];
+    }
+    return;
+  }
+
+  if (!state.hunk) return;
+  if (raw.startsWith("\\")) return; // "\ No newline at end of file"
+
+  if (appendBodyLine(state.cur, state.hunk, state.cursor, raw)) {
+    state.lineCount++;
+    state.totalLines++;
+    // Transition: cap hit — mark current file and set flag.
+    if (state.totalLines >= MAX_TOTAL_LINES) {
+      state.capped = true;
+      state.cur.truncated = true;
+      state.cur.hunks = [];
+    }
+  }
+}
+
 /**
  * Parse `git diff --no-color` unified output into structured files.
  * Handles added / modified / deleted / renamed / binary, computes +/- counts,
@@ -112,77 +185,18 @@ function appendBodyLine(cur: DiffFile, hunk: DiffHunk, cursor: LineCursor, raw: 
  * status/path/rename metadata (O(files), not O(body-lines)).
  */
 export function parseUnifiedDiff(text: string): DiffFile[] {
-  const files: DiffFile[] = [];
-  let cur: DiffFile | null = null;
-  let hunk: DiffHunk | null = null;
-  const cursor: LineCursor = { oldNo: 0, newNo: 0 };
-  let lineCount = 0; // add/del/ctx lines accumulated for cur
-  let totalLines = 0; // global tally across all files
-  let capped = false; // true once MAX_TOTAL_LINES is reached
-
-  const finishFile = () => {
-    if (!cur) return;
-    if (lineCount > MAX_FILE_LINES) {
-      cur.truncated = true;
-      cur.hunks = [];
-    }
-    files.push(cur);
+  const state: ParseState = {
+    files: [],
+    cur: null,
+    hunk: null,
+    cursor: { oldNo: 0, newNo: 0 },
+    lineCount: 0,
+    totalLines: 0,
+    capped: false,
   };
-
-  for (const raw of text.split("\n")) {
-    if (raw.startsWith("diff --git ")) {
-      finishFile();
-      hunk = null;
-      lineCount = 0;
-      cur = startFile(raw);
-      continue;
-    }
-    if (!cur) continue;
-
-    // Always process file-header and hunk-header lines — they are O(files), bounded
-    // by the 64 MiB input cap, and keep metadata (status/path/rename) accurate even
-    // for files beyond the global cap.
-    if (applyFileHeader(cur, raw)) continue;
-
-    if (raw.startsWith("@@")) {
-      const start = parseHunkHeader(raw);
-      cursor.oldNo = start.oldNo;
-      cursor.newNo = start.newNo;
-      // Under the cap: accumulate normally. Over the cap: hunk slot is not needed
-      // (body lines will be skipped), so don't push to cur.hunks.
-      if (!capped) {
-        hunk = { header: raw, lines: [] };
-        cur.hunks.push(hunk);
-      }
-      continue;
-    }
-
-    // Skip body-line accumulation once globally capped.
-    if (capped) {
-      // Mark this file truncated once, at the point of transition or on first visit.
-      if (!cur.truncated) {
-        cur.truncated = true;
-        cur.hunks = [];
-      }
-      continue;
-    }
-
-    if (!hunk) continue;
-    if (raw.startsWith("\\")) continue; // "\ No newline at end of file"
-
-    if (appendBodyLine(cur, hunk, cursor, raw)) {
-      lineCount++;
-      totalLines++;
-      // Transition: cap hit on this line — mark current file and set flag.
-      if (totalLines >= MAX_TOTAL_LINES) {
-        capped = true;
-        cur.truncated = true;
-        cur.hunks = [];
-      }
-    }
-  }
-  finishFile();
-  return files;
+  for (const raw of text.split("\n")) handleDiffLine(state, raw);
+  finishFile(state);
+  return state.files;
 }
 
 const REMOTE = "origin";

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -136,11 +136,11 @@ export class GithubForge implements GitForge {
     // Fresh, uncached single-issue read for the drain's pre-spawn claim re-check
     // (see GitForge.getIssue). Best-effort: a gone/closed issue or a transient gh
     // error yields null so the caller falls back to spawning, never loses the issue.
-    // COST: one synchronous `gh issue view` subprocess per spawn candidate per pump
-    // (this.run is execFileSync). The drain spawns at most maxAuto per pump, so the
+    // COST: one `gh issue view` subprocess per spawn candidate per pump. `this.run`
+    // is async (non-blocking) and the drain spawns at most maxAuto per pump, so the
     // fan-out is bounded and small; not worth caching/batching for the claim re-check.
     try {
-      const out = this.run([
+      const out = await this.run([
         "issue",
         "view",
         String(issueNumber),

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -1,4 +1,6 @@
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { timedAsync } from "../instrument";
 import { jobsFromRollup, mapCheckState, rollupChecks } from "./checks";
 import { CRITIC_REVIEW_MARKER } from "./types";
 import type {
@@ -23,10 +25,15 @@ import type {
 const MAX_WORKFLOWS = 10;
 
 /** Runs `gh` with the given args and returns stdout. Injected in tests. */
-export type GhRunner = (args: string[]) => string;
+export type GhRunner = (args: string[]) => Promise<string>;
+
+const execFileAsync = promisify(execFile);
 
 const defaultRunner: GhRunner = (args) =>
-  execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  timedAsync(`gh ${args[0]}`, async () => {
+    const { stdout } = await execFileAsync("gh", args, { maxBuffer: 16 * 1024 * 1024 });
+    return stdout.toString();
+  });
 
 interface GhReview {
   author?: { login?: string } | null;
@@ -89,7 +96,7 @@ export class GithubForge implements GitForge {
   }
 
   async listIssues(): Promise<Issue[]> {
-    const out = this.run([
+    const out = await this.run([
       "issue",
       "list",
       "--repo",
@@ -166,7 +173,7 @@ export class GithubForge implements GitForge {
   }
 
   async listPullRequests(): Promise<PullRequest[]> {
-    const out = this.run([
+    const out = await this.run([
       "pr",
       "list",
       "--repo",
@@ -205,12 +212,12 @@ export class GithubForge implements GitForge {
 
   async listWorkflowRuns(): Promise<WorkflowRun[]> {
     // Resolve the default branch; CI health is read from its runs, not PR branches.
-    const repoOut = this.run(["repo", "view", this.slug, "--json", "defaultBranchRef"]);
+    const repoOut = await this.run(["repo", "view", this.slug, "--json", "defaultBranchRef"]);
     const branch = (JSON.parse(repoOut || "{}") as { defaultBranchRef?: { name?: string } })
       .defaultBranchRef?.name;
     if (!branch) return [];
 
-    const listOut = this.run([
+    const listOut = await this.run([
       "run",
       "list",
       "--repo",
@@ -241,9 +248,9 @@ export class GithubForge implements GitForge {
     }
     const selected = [...newest.values()].slice(0, MAX_WORKFLOWS);
 
-    // NB: `this.run` is `execFileSync`, so these job fetches run serially despite
-    // the `Promise.all` — the wrapper only awaits `listRunJobs`'s async signature
-    // (shared with the lazy history path), it does not parallelize the subprocesses.
+    // Fan out the per-run job fetches in parallel now that `this.run` is async.
+    // Serial was the old behaviour (execFileSync); the Promise.all here now truly
+    // parallelises the `gh run view` subprocess calls across the selected runs.
     const runs = await Promise.all(
       selected.map(async (r): Promise<WorkflowRun> => {
         const jobs = await this.listRunJobs(r.databaseId);
@@ -270,7 +277,15 @@ export class GithubForge implements GitForge {
    *  the four-light CI vocab. Shared by the latest-run listing and history-row
    *  expansion. */
   async listRunJobs(runId: number): Promise<WorkflowJob[]> {
-    const jobsOut = this.run(["run", "view", String(runId), "--repo", this.slug, "--json", "jobs"]);
+    const jobsOut = await this.run([
+      "run",
+      "view",
+      String(runId),
+      "--repo",
+      this.slug,
+      "--json",
+      "jobs",
+    ]);
     const parsed = JSON.parse(jobsOut || "{}") as {
       jobs?: Array<{
         name?: string;
@@ -292,7 +307,7 @@ export class GithubForge implements GitForge {
   async listWorkflowRunHistory(workflowId: number, o: { limit: number }): Promise<WorkflowRun[]> {
     const branch = await this.defaultBranch().catch(() => null);
     if (!branch) return [];
-    const listOut = this.run([
+    const listOut = await this.run([
       "run",
       "list",
       "--repo",
@@ -338,16 +353,16 @@ export class GithubForge implements GitForge {
     // `--failed` retries only the failed jobs (+ their dependents) of a failed run;
     // a fully green run has none, so the caller passes failedOnly:false there.
     if (o.failedOnly) args.push("--failed");
-    this.run(args);
+    await this.run(args);
   }
 
   async cancelWorkflowRun(runId: number): Promise<void> {
-    this.run(["run", "cancel", String(runId), "--repo", this.slug]);
+    await this.run(["run", "cancel", String(runId), "--repo", this.slug]);
   }
 
   async prStatus(headBranch: string): Promise<PrStatus> {
     const deployConfigured = Boolean(this.cfg.deployWorkflow);
-    const out = this.run([
+    const out = await this.run([
       "pr",
       "list",
       "--repo",
@@ -379,7 +394,7 @@ export class GithubForge implements GitForge {
   }
 
   async defaultBranch(): Promise<string> {
-    const out = this.run(["repo", "view", this.slug, "--json", "defaultBranchRef"]);
+    const out = await this.run(["repo", "view", this.slug, "--json", "defaultBranchRef"]);
     const name = (JSON.parse(out || "{}") as { defaultBranchRef?: { name?: string } })
       .defaultBranchRef?.name;
     if (!name) throw new Error("could not resolve default branch");
@@ -387,7 +402,7 @@ export class GithubForge implements GitForge {
   }
 
   async openPr(o: OpenPrInput): Promise<PrStatus> {
-    this.run([
+    await this.run([
       "pr",
       "create",
       "--repo",
@@ -406,16 +421,9 @@ export class GithubForge implements GitForge {
 
   async createIssue(o: { title: string; body: string }): Promise<{ number: number; url: string }> {
     // `gh issue create` echoes the new issue's URL on stdout (…/issues/<n>).
-    const url = this.run([
-      "issue",
-      "create",
-      "--repo",
-      this.slug,
-      "--title",
-      o.title,
-      "--body",
-      o.body,
-    ]).trim();
+    const url = (
+      await this.run(["issue", "create", "--repo", this.slug, "--title", o.title, "--body", o.body])
+    ).trim();
     const n = Number(url.match(/\/(\d+)\s*$/)?.[1]);
     if (!Number.isInteger(n)) throw new Error(`could not parse issue number from URL: ${url}`);
     return { number: n, url };
@@ -424,7 +432,7 @@ export class GithubForge implements GitForge {
   async renameBranch(oldBranch: string, newBranch: string): Promise<void> {
     // GitHub's rename-branch endpoint moves the ref AND retargets every open PR and
     // branch-protection rule onto the new name, so a session's open PR follows along.
-    this.run([
+    await this.run([
       "api",
       "--method",
       "POST",
@@ -439,56 +447,74 @@ export class GithubForge implements GitForge {
       o.method === "rebase" ? "--rebase" : o.method === "merge" ? "--merge" : "--squash";
     const args = ["pr", "merge", String(prNumber), "--repo", this.slug, method];
     if (o.deleteBranch) args.push("--delete-branch");
-    this.run(args);
+    await this.run(args);
   }
 
   async closeIssue(issueNumber: number): Promise<void> {
-    this.run(["issue", "close", String(issueNumber), "--repo", this.slug]);
+    await this.run(["issue", "close", String(issueNumber), "--repo", this.slug]);
   }
 
   async comment(prNumber: number, body: string): Promise<void> {
-    this.run(["pr", "comment", String(prNumber), "--repo", this.slug, "--body", body]);
+    await this.run(["pr", "comment", String(prNumber), "--repo", this.slug, "--body", body]);
   }
 
   async ensureIssueLink(prNumber: number, issueNumber: number): Promise<void> {
-    const body = this.run([
-      "pr",
-      "view",
-      String(prNumber),
-      "--repo",
-      this.slug,
-      "--json",
-      "body",
-      "-q",
-      ".body // empty",
-    ]).trim();
+    const body = (
+      await this.run([
+        "pr",
+        "view",
+        String(prNumber),
+        "--repo",
+        this.slug,
+        "--json",
+        "body",
+        "-q",
+        ".body // empty",
+      ])
+    ).trim();
     const pattern = new RegExp(
       `\\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\\s+#${issueNumber}\\b`,
       "i",
     );
     if (pattern.test(body)) return;
     const newBody = body ? `${body}\n\nCloses #${issueNumber}` : `Closes #${issueNumber}`;
-    this.run(["pr", "edit", String(prNumber), "--repo", this.slug, "--body", newBody]);
+    await this.run(["pr", "edit", String(prNumber), "--repo", this.slug, "--body", newBody]);
   }
 
   async addIssueLabel(issueNumber: number, label: string): Promise<void> {
     // `gh issue edit --add-label` 422s on a label the repo hasn't defined. The
     // operator creates the opt-in label, but the claim label is ours — create it
     // first (ignoring "already exists") so the claim doesn't fail on a fresh repo.
-    this.ensureLabel(label);
-    this.run(["issue", "edit", String(issueNumber), "--repo", this.slug, "--add-label", label]);
+    await this.ensureLabel(label);
+    await this.run([
+      "issue",
+      "edit",
+      String(issueNumber),
+      "--repo",
+      this.slug,
+      "--add-label",
+      label,
+    ]);
   }
 
   async removeIssueLabel(issueNumber: number, label: string): Promise<void> {
-    this.run(["issue", "edit", String(issueNumber), "--repo", this.slug, "--remove-label", label]);
+    await this.run([
+      "issue",
+      "edit",
+      String(issueNumber),
+      "--repo",
+      this.slug,
+      "--remove-label",
+      label,
+    ]);
   }
 
   /** Best-effort create-if-missing for a repo label. No `--force`, so an existing
    *  label the operator may have recolored is left untouched; the throw on "already
    *  exists" is swallowed and a real failure surfaces on the subsequent --add-label. */
-  private ensureLabel(label: string): void {
+  private async ensureLabel(label: string): Promise<void> {
     try {
-      this.run([
+      await this.run([
         "label",
         "create",
         label,
@@ -505,13 +531,13 @@ export class GithubForge implements GitForge {
   }
 
   async redeploy(o: RedeployInput): Promise<void> {
-    this.run(["workflow", "run", o.workflow, "--repo", this.slug, "--ref", o.ref]);
+    await this.run(["workflow", "run", o.workflow, "--repo", this.slug, "--ref", o.ref]);
   }
 
   async postReview(prNumber: number, o: PostReviewInput): Promise<{ url?: string }> {
     if (o.event === "REQUEST_CHANGES") {
       try {
-        this.run([
+        await this.run([
           "pr",
           "review",
           String(prNumber),
@@ -527,19 +553,13 @@ export class GithubForge implements GitForge {
         // critic share one gh identity — so this 422s on self-authored PRs. Fall
         // back to a plain PR comment so the findings still land on the host.
         // `gh pr comment` echoes the new comment's URL on stdout.
-        const url = this.run([
-          "pr",
-          "comment",
-          String(prNumber),
-          "--repo",
-          this.slug,
-          "--body",
-          o.body,
-        ]).trim();
+        const url = (
+          await this.run(["pr", "comment", String(prNumber), "--repo", this.slug, "--body", o.body])
+        ).trim();
         return { url: url || undefined };
       }
     }
-    this.run([
+    await this.run([
       "pr",
       "review",
       String(prNumber),
@@ -553,7 +573,7 @@ export class GithubForge implements GitForge {
   }
 
   async listPrComments(prNumber: number): Promise<PrComment[]> {
-    const out = this.run([
+    const out = await this.run([
       "pr",
       "view",
       String(prNumber),

--- a/src/forge/index.ts
+++ b/src/forge/index.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "../instrument";
 import { GithubForge } from "./github";
 import { GiteaForge } from "./gitea";
 import { parseRemote } from "./remote";

--- a/src/herdr-update.ts
+++ b/src/herdr-update.ts
@@ -1,4 +1,5 @@
-import { execFileSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
+import { execFileSync } from "./instrument";
 import { config } from "./config";
 import { maintenance as sharedMaintenance } from "./maintenance";
 import type { HerdrUpdateStatus } from "./types";

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "./instrument";
 import { config } from "./config";
 import { maintenance } from "./maintenance";
 import type { HerdrState, SessionStatus } from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,11 @@ import { attachSignalCapture } from "./signals";
 import { maintenance } from "./maintenance";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { startLoopLagSampler } from "./instrument";
 
 const execFileAsync = promisify(execFile);
+
+startLoopLagSampler(); // no-op unless SHEPHERD_PROFILE_LOOP=1
 
 mkdirSync(dirname(config.dbPath), { recursive: true });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -549,7 +549,7 @@ setInterval(calibrate, 24 * 60 * 60 * 1000);
 // watch origin/main for new commits and push the result to clients; the badge in
 // the UI keys off `behind > 0`, so it only appears when main has moved ahead.
 const updates = new UpdateService();
-const checkUpdates = () => events.emit("update:status", updates.check(Date.now()));
+const checkUpdates = async () => events.emit("update:status", await updates.check(Date.now()));
 setTimeout(checkUpdates, 3_000);
 setInterval(checkUpdates, 5 * 60 * 1000);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,11 +52,12 @@ import { attachSignalCapture } from "./signals";
 import { maintenance } from "./maintenance";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { startLoopLagSampler } from "./instrument";
+import { startLoopLagSampler, logRemainingOnLoopBlockers } from "./instrument";
 
 const execFileAsync = promisify(execFile);
 
 startLoopLagSampler(); // no-op unless SHEPHERD_PROFILE_LOOP=1
+logRemainingOnLoopBlockers(); // one-time operator map of intentionally-sync calls
 
 mkdirSync(dirname(config.dbPath), { recursive: true });
 

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -2,13 +2,8 @@
  * Profiling / instrumentation helpers — zero-cost when SHEPHERD_PROFILE_LOOP is unset.
  * Set SHEPHERD_PROFILE_LOOP=1 to enable event-loop-lag sampling and per-call timing.
  */
-import {
-  execFileSync as _execFileSync,
-  type ExecFileSyncOptionsWithStringEncoding,
-  type ExecFileSyncOptionsWithBufferEncoding,
-  type ExecFileSyncOptions,
-} from "node:child_process";
-import { readFileSync as _readFileSync } from "node:fs";
+import { execFileSync as nodeExecFileSync } from "node:child_process";
+import { readFileSync as nodeReadFileSync } from "node:fs";
 import { basename } from "node:path";
 
 /** Lazy — read inside each function so tests can toggle the env var. */
@@ -36,6 +31,7 @@ export function startLoopLagSampler(): () => void {
       console.warn(`[profile] loop-lag ${lag}ms`);
     }
   }, INTERVAL);
+  id.unref();
   return () => clearInterval(id);
 }
 
@@ -96,43 +92,27 @@ export async function timedAsync<T>(label: string, fn: () => Promise<T>): Promis
 
 // ── execFileSync passthrough ──────────────────────────────────────────────────
 
-function execLabel(file: string, args?: readonly string[]): string {
-  const sub = args?.[0];
-  return sub ? `${file} ${sub}` : file;
-}
-
-// Overloads mirror node:child_process execFileSync's primary call signatures.
-export function execFileSync(
-  file: string,
-  args: readonly string[],
-  options: ExecFileSyncOptionsWithStringEncoding,
-): string;
-export function execFileSync(
-  file: string,
-  args?: readonly string[],
-  options?: ExecFileSyncOptionsWithBufferEncoding | ExecFileSyncOptions,
-): Buffer;
-export function execFileSync(
-  file: string,
-  args?: readonly string[],
-  options?:
-    | ExecFileSyncOptionsWithStringEncoding
-    | ExecFileSyncOptionsWithBufferEncoding
-    | ExecFileSyncOptions,
-): string | Buffer {
-  const label = execLabel(file, args);
-  return timed(
-    label,
-    () => _execFileSync(file, args as string[], options as ExecFileSyncOptions) as string | Buffer,
-  );
-}
+export const execFileSync: typeof nodeExecFileSync = ((
+  ...args: Parameters<typeof nodeExecFileSync>
+) => {
+  const [file, second] = args;
+  const sub = Array.isArray(second) ? (second as string[])[0] : undefined;
+  const label = sub ? `${String(file)} ${sub}` : String(file);
+  return timed(label, () => nodeExecFileSync(...(args as Parameters<typeof nodeExecFileSync>)));
+}) as typeof nodeExecFileSync;
 
 // ── readFileSync passthrough ──────────────────────────────────────────────────
 
 /**
- * Drop-in for `readFileSync(path, "utf8")` — the pattern used in transcript hot paths.
- * Wraps in `timed` with label `readFileSync <basename>`.
+ * Faithful passthrough for node's `readFileSync`. Wraps in `timed` with label
+ * `readFileSync <basename>` (basename derived only when the first arg is a string).
  */
-export function readFileSync(path: string, encoding: "utf8" | BufferEncoding): string {
-  return timed(`readFileSync ${basename(path)}`, () => _readFileSync(path, encoding as "utf8"));
-}
+export const readFileSync: typeof nodeReadFileSync = ((
+  ...args: Parameters<typeof nodeReadFileSync>
+) => {
+  const first = args[0];
+  const name = typeof first === "string" ? basename(first) : "readFileSync";
+  return timed(`readFileSync ${name}`, () =>
+    nodeReadFileSync(...(args as Parameters<typeof nodeReadFileSync>)),
+  );
+}) as typeof nodeReadFileSync;

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -118,6 +118,28 @@ export function logRemainingOnLoopBlockers(): void {
   );
 }
 
+// ── PTY event gap tracker ─────────────────────────────────────────────────────
+
+let _lastPtyEventTime = 0;
+
+/**
+ * Record a PTY I/O event and log the wall-clock gap since the previous one.
+ * Logs `[profile] pty-gap <label> <N>ms` when the gap exceeds 150ms.
+ * No-op when profiling is off. Input and output events share one timeline so
+ * a large gap pinpoints where the loop was blocked.
+ */
+export function markPtyEvent(label: string): void {
+  if (!isProfiling()) return;
+  const now = Date.now();
+  if (_lastPtyEventTime !== 0) {
+    const gap = now - _lastPtyEventTime;
+    if (gap > LAG_THRESHOLD_MS) {
+      console.warn(`[profile] pty-gap ${label} ${gap}ms`);
+    }
+  }
+  _lastPtyEventTime = now;
+}
+
 // ── readFileSync passthrough ──────────────────────────────────────────────────
 
 /**

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -109,12 +109,12 @@ export const execFileSync: typeof nodeExecFileSync = ((
  */
 export function logRemainingOnLoopBlockers(): void {
   console.info(
-    "[profile] on-loop sync calls remaining (local/fast, instrumented):" +
+    "[shepherd] on-loop sync calls remaining (local/fast, instrumented):" +
       " herdr list/read (local daemon IPC)," +
       " local git in branch-pruner/repos/branches/worktree/plan-gate/review," +
       " herdr --version (herdr-update)," +
       " git remote get-url (forge/index, backlog)," +
-      " process-reaper kill.",
+      " process-reaper counter-command.",
   );
 }
 

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -101,6 +101,23 @@ export const execFileSync: typeof nodeExecFileSync = ((
   return timed(label, () => nodeExecFileSync(...(args as Parameters<typeof nodeExecFileSync>)));
 }) as typeof nodeExecFileSync;
 
+// ── startup blocker map ───────────────────────────────────────────────────────
+
+/**
+ * Emit a one-time operator map of sync calls intentionally left on the event
+ * loop (local/fast). Called once at startup regardless of the profile flag.
+ */
+export function logRemainingOnLoopBlockers(): void {
+  console.info(
+    "[profile] on-loop sync calls remaining (local/fast, instrumented):" +
+      " herdr list/read (local daemon IPC)," +
+      " local git in branch-pruner/repos/branches/worktree/plan-gate/review," +
+      " herdr --version (herdr-update)," +
+      " git remote get-url (forge/index, backlog)," +
+      " process-reaper kill.",
+  );
+}
+
 // ── readFileSync passthrough ──────────────────────────────────────────────────
 
 /**

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -127,6 +127,12 @@ let _lastPtyEventTime = 0;
  * Logs `[profile] pty-gap <label> <N>ms` when the gap exceeds 150ms.
  * No-op when profiling is off. Input and output events share one timeline so
  * a large gap pinpoints where the loop was blocked.
+ *
+ * NOTE: `_lastPtyEventTime` is a single shared timestamp across **all**
+ * concurrent PtyBridge instances (one per open terminal). That's intentional —
+ * it gives a loop-wide view good enough to spot broad stalls. The trade-off is
+ * that activity on terminal A resets the clock and can mask a gap on terminal B;
+ * for per-terminal accuracy you'd need a per-instance marker.
  */
 export function markPtyEvent(label: string): void {
   if (!isProfiling()) return;

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,0 +1,138 @@
+/**
+ * Profiling / instrumentation helpers — zero-cost when SHEPHERD_PROFILE_LOOP is unset.
+ * Set SHEPHERD_PROFILE_LOOP=1 to enable event-loop-lag sampling and per-call timing.
+ */
+import {
+  execFileSync as _execFileSync,
+  type ExecFileSyncOptionsWithStringEncoding,
+  type ExecFileSyncOptionsWithBufferEncoding,
+  type ExecFileSyncOptions,
+} from "node:child_process";
+import { readFileSync as _readFileSync } from "node:fs";
+import { basename } from "node:path";
+
+/** Lazy — read inside each function so tests can toggle the env var. */
+const isProfiling = () => process.env.SHEPHERD_PROFILE_LOOP === "1";
+
+const LAG_THRESHOLD_MS = 150;
+const TIMED_THRESHOLD_MS = 250;
+
+// ── loop-lag sampler ──────────────────────────────────────────────────────────
+
+/**
+ * Schedule a repeating timer that measures the gap between expected and actual
+ * fire time. Logs `[profile] loop-lag <N>ms` when the lag exceeds 150ms.
+ * Returns a stop function. No-op (no timer, no-op stop) when profiling is off.
+ */
+export function startLoopLagSampler(): () => void {
+  if (!isProfiling()) return () => {};
+  const INTERVAL = 50;
+  let last = Date.now();
+  const id = setInterval(() => {
+    const now = Date.now();
+    const lag = now - last - INTERVAL;
+    last = now;
+    if (lag > LAG_THRESHOLD_MS) {
+      console.warn(`[profile] loop-lag ${lag}ms`);
+    }
+  }, INTERVAL);
+  return () => clearInterval(id);
+}
+
+// ── synchronous timed wrapper ─────────────────────────────────────────────────
+
+/**
+ * Wrap a synchronous function with wall-time measurement.
+ * Logs `[profile] <label> <N>ms` when over 250ms. Always returns/re-throws as-is.
+ * When profiling is off, calls fn() directly with zero overhead.
+ */
+export function timed<T>(label: string, fn: () => T): T {
+  if (!isProfiling()) return fn();
+  const start = Date.now();
+  let threw = false;
+  let err: unknown;
+  let result: T;
+  try {
+    result = fn();
+  } catch (e) {
+    threw = true;
+    err = e;
+    result = undefined as unknown as T;
+  }
+  const ms = Date.now() - start;
+  if (ms > TIMED_THRESHOLD_MS) {
+    console.warn(`[profile] ${label} ${ms}ms`);
+  }
+  if (threw) throw err;
+  return result;
+}
+
+// ── async timed wrapper ───────────────────────────────────────────────────────
+
+/**
+ * Wrap an async function with wall-time measurement.
+ * Same threshold/log behavior as `timed`. When off, awaits fn() directly.
+ */
+export async function timedAsync<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  if (!isProfiling()) return fn();
+  const start = Date.now();
+  let threw = false;
+  let err: unknown;
+  let result: T;
+  try {
+    result = await fn();
+  } catch (e) {
+    threw = true;
+    err = e;
+    result = undefined as unknown as T;
+  }
+  const ms = Date.now() - start;
+  if (ms > TIMED_THRESHOLD_MS) {
+    console.warn(`[profile] ${label} ${ms}ms`);
+  }
+  if (threw) throw err;
+  return result;
+}
+
+// ── execFileSync passthrough ──────────────────────────────────────────────────
+
+function execLabel(file: string, args?: readonly string[]): string {
+  const sub = args?.[0];
+  return sub ? `${file} ${sub}` : file;
+}
+
+// Overloads mirror node:child_process execFileSync's primary call signatures.
+export function execFileSync(
+  file: string,
+  args: readonly string[],
+  options: ExecFileSyncOptionsWithStringEncoding,
+): string;
+export function execFileSync(
+  file: string,
+  args?: readonly string[],
+  options?: ExecFileSyncOptionsWithBufferEncoding | ExecFileSyncOptions,
+): Buffer;
+export function execFileSync(
+  file: string,
+  args?: readonly string[],
+  options?:
+    | ExecFileSyncOptionsWithStringEncoding
+    | ExecFileSyncOptionsWithBufferEncoding
+    | ExecFileSyncOptions,
+): string | Buffer {
+  const label = execLabel(file, args);
+  return timed(
+    label,
+    () => _execFileSync(file, args as string[], options as ExecFileSyncOptions) as string | Buffer,
+  );
+}
+
+// ── readFileSync passthrough ──────────────────────────────────────────────────
+
+/**
+ * Drop-in for `readFileSync(path, "utf8")` — the pattern used in transcript hot paths.
+ * Wraps in `timed` with label `readFileSync <basename>`.
+ */
+export function readFileSync(path: string, encoding: "utf8" | BufferEncoding): string {
+  return timed(`readFileSync ${basename(path)}`, () => _readFileSync(path, encoding as "utf8"));
+}

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -3,8 +3,6 @@
  * Set SHEPHERD_PROFILE_LOOP=1 to enable event-loop-lag sampling and per-call timing.
  */
 import { execFileSync as nodeExecFileSync } from "node:child_process";
-import { readFileSync as nodeReadFileSync } from "node:fs";
-import { basename } from "node:path";
 
 /** Lazy — read inside each function so tests can toggle the env var. */
 const isProfiling = () => process.env.SHEPHERD_PROFILE_LOOP === "1";
@@ -145,19 +143,3 @@ export function markPtyEvent(label: string): void {
   }
   _lastPtyEventTime = now;
 }
-
-// ── readFileSync passthrough ──────────────────────────────────────────────────
-
-/**
- * Faithful passthrough for node's `readFileSync`. Wraps in `timed` with label
- * `readFileSync <basename>` (basename derived only when the first arg is a string).
- */
-export const readFileSync: typeof nodeReadFileSync = ((
-  ...args: Parameters<typeof nodeReadFileSync>
-) => {
-  const first = args[0];
-  const name = typeof first === "string" ? basename(first) : "readFileSync";
-  return timed(`readFileSync ${name}`, () =>
-    nodeReadFileSync(...(args as Parameters<typeof nodeReadFileSync>)),
-  );
-}) as typeof nodeReadFileSync;

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -202,7 +202,12 @@ export class PlanGateService {
     // verdict file (cross-session findings). See createDetached's `slug` doc.
     let wt;
     try {
-      wt = this.deps.worktree.createDetached(session.repoPath, session.baseBranch, sha, session.id);
+      wt = await this.deps.worktree.createDetached(
+        session.repoPath,
+        session.baseBranch,
+        sha,
+        session.id,
+      );
     } catch (err) {
       console.warn(`[plan-gate] worktree failed for ${session.id}:`, err);
       return "error";

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "./instrument";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import type { WorktreeMgr } from "./worktree";

--- a/src/process-reaper.ts
+++ b/src/process-reaper.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readlinkSync, readFileSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "./instrument";
 import { jsonlPathFor } from "./usage";
 import { eachJsonlObject } from "./jsonl";
 

--- a/src/pty-bridge.ts
+++ b/src/pty-bridge.ts
@@ -1,5 +1,6 @@
 import { config } from "./config";
 import { isValidTerminalId } from "./validate";
+import { markPtyEvent } from "./instrument";
 
 export interface PtySocket {
   send(data: string | Uint8Array): void;
@@ -32,6 +33,7 @@ export class PtyBridge {
     ) as NodeProc;
     (async () => {
       for await (const chunk of this.proc!.stdout as ReadableStream<Uint8Array>) {
+        markPtyEvent("out");
         this.ws.send(chunk);
       }
     })();

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -7,7 +7,7 @@ import {
   lstatSync,
   realpathSync,
 } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "./instrument";
 import { join, resolve, sep } from "node:path";
 import { homedir } from "node:os";
 import { expandHome, safeRepoDir } from "./validate";

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { join } from "node:path";
-import { execFileSync } from "./instrument";
+import { execFileSync, timedAsync } from "./instrument";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
@@ -8,6 +10,8 @@ import type { GitForge, GitState } from "./forge/types";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "./forge/types";
 import type { ReviewVerdict, ReviewDecision, Session } from "./types";
 import { readonlyReviewerArgv } from "./reviewer-argv";
+
+const execFileAsync = promisify(execFile);
 
 /** Self-contained instructions for the critic agent. NOT UI chrome — never i18n'd. */
 export function reviewPrompt(
@@ -129,7 +133,7 @@ export interface ReviewServiceDeps {
   readVerdict?: (worktreePath: string) => RawVerdict | null;
   /** Injectable content fingerprint of `git diff base...HEAD` in the worktree (default:
    *  real `git patch-id`). Returns null when there's no diff or git fails → never skips. */
-  computePatchId?: (worktreePath: string, base: string) => string | null;
+  computePatchId?: (worktreePath: string, base: string) => Promise<string | null>;
 }
 
 interface RawVerdict {
@@ -155,7 +159,7 @@ export class ReviewService {
     return this.capFn();
   }
   private readVerdict: (worktreePath: string) => RawVerdict | null;
-  private computePatchId: (worktreePath: string, base: string) => string | null;
+  private computePatchId: (worktreePath: string, base: string) => Promise<string | null>;
 
   constructor(private deps: ReviewServiceDeps) {
     this.now = deps.now ?? Date.now;
@@ -200,7 +204,7 @@ export class ReviewService {
       return;
     }
 
-    const { patchId, skipped } = this.rebaseSkip(session, git, prior, wt.worktreePath);
+    const { patchId, skipped } = await this.rebaseSkip(session, git, prior, wt.worktreePath);
     if (skipped) return;
 
     // Notes are fetched lazily (only a re-review under auto-address needs them) so a first
@@ -268,13 +272,13 @@ export class ReviewService {
    * though buildVerdict no longer fingerprints error verdicts: this also covers error rows
    * persisted before that change.)
    */
-  private rebaseSkip(
+  private async rebaseSkip(
     session: Session,
     git: GitState,
     prior: ReviewVerdict | null,
     worktreePath: string,
-  ): { patchId: string; skipped: boolean } {
-    const patchId = this.computePatchId(worktreePath, session.baseBranch) ?? "";
+  ): Promise<{ patchId: string; skipped: boolean }> {
+    const patchId = (await this.computePatchId(worktreePath, session.baseBranch)) ?? "";
     if (patchId && prior?.patchId && prior.decision !== "error" && prior.patchId === patchId) {
       this.deps.store.bumpReviewHead(session.id, git.headSha!, this.now());
       this.deps.worktree.remove(worktreePath);
@@ -555,7 +559,7 @@ export class ReviewService {
  *  no-op. patch-id ignores line numbers, so it stays stable when the rebased-onto base
  *  shifts hunks elsewhere; it changes only when the branch's own changed lines or their
  *  context change. Null on no diff or any git failure → caller never skips (reviews). */
-function defaultComputePatchId(worktreePath: string, base: string): string | null {
+async function defaultComputePatchId(worktreePath: string, base: string): Promise<string | null> {
   try {
     // Diff against the CURRENT base, not a possibly-stale local ref. createDetached fetches
     // only the head branch, so local `main` can lag behind origin; on a rebase onto newer
@@ -568,13 +572,17 @@ function defaultComputePatchId(worktreePath: string, base: string): string | nul
     let ref = base;
     try {
       // `--` blocks flag-smuggling via a hostile branch name (mirrors createDetached).
-      execFileSync("git", ["fetch", "origin", "--", base], { cwd: worktreePath, stdio: "pipe" });
+      // Async so the fetch doesn't block the Bun event loop (and freeze the web terminal).
+      await timedAsync("git fetch", () =>
+        execFileAsync("git", ["fetch", "origin", "--", base], { cwd: worktreePath }),
+      );
       ref = "FETCH_HEAD";
     } catch {
       /* offline or no origin remote — fall through to the local base ref */
     }
     // 64 MiB ceiling: a real branch diff won't approach it; a runaway one just falls back
     // to null (review) rather than throwing.
+    // Local-only calls (no network I/O): stay synchronous.
     const diff = execFileSync("git", ["diff", `${ref}...HEAD`], {
       cwd: worktreePath,
       maxBuffer: 64 * 1024 * 1024,

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "./instrument";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import type { WorktreeMgr } from "./worktree";

--- a/src/review.ts
+++ b/src/review.ts
@@ -582,12 +582,16 @@ async function defaultComputePatchId(worktreePath: string, base: string): Promis
     }
     // 64 MiB ceiling: a real branch diff won't approach it; a runaway one just falls back
     // to null (review) rather than throwing.
-    // Local-only calls (no network I/O): stay synchronous.
-    const diff = execFileSync("git", ["diff", `${ref}...HEAD`], {
-      cwd: worktreePath,
-      maxBuffer: 64 * 1024 * 1024,
-      stdio: ["ignore", "pipe", "ignore"],
-    });
+    // Local but can read up to 64 MiB, so run it async too (mirrors computeDiff) to keep
+    // the critic poll off the Bun event loop. patch-id below stays sync: it needs the
+    // sync-only `input:` stdin option, and it only processes this already-bounded diff.
+    const { stdout: diff } = await timedAsync("git diff", () =>
+      execFileAsync("git", ["diff", `${ref}...HEAD`], {
+        cwd: worktreePath,
+        maxBuffer: 64 * 1024 * 1024,
+        encoding: "utf8",
+      }),
+    );
     if (!diff.length) return null; // no diff → nothing to fingerprint
     const out = execFileSync("git", ["patch-id", "--stable"], {
       cwd: worktreePath,

--- a/src/review.ts
+++ b/src/review.ts
@@ -583,8 +583,7 @@ async function defaultComputePatchId(worktreePath: string, base: string): Promis
     // 64 MiB ceiling: a real branch diff won't approach it; a runaway one just falls back
     // to null (review) rather than throwing.
     // Local but can read up to 64 MiB, so run it async too (mirrors computeDiff) to keep
-    // the critic poll off the Bun event loop. patch-id below stays sync: it needs the
-    // sync-only `input:` stdin option, and it only processes this already-bounded diff.
+    // the critic poll off the Bun event loop. (patch-id below stays sync — see its note.)
     const { stdout: diff } = await timedAsync("git diff", () =>
       execFileAsync("git", ["diff", `${ref}...HEAD`], {
         cwd: worktreePath,
@@ -593,6 +592,12 @@ async function defaultComputePatchId(worktreePath: string, base: string): Promis
       }),
     );
     if (!diff.length) return null; // no diff → nothing to fingerprint
+    // patch-id stays sync: it pipes the diff via the `input:` stdin option, which only
+    // execFileSync supports (promisify(execFile) has none). The sync stdin write is bounded
+    // by `diff` (capped at 64 MiB above) and is negligible for real PRs; only a pathological
+    // multi-MB diff would block the loop here. It's routed through the ./instrument timed
+    // wrapper, so if loop-lag profiling ever flags "git patch-id", convert it to a spawn with
+    // an async stdin write at that point — not worth the extra plumbing speculatively.
     const out = execFileSync("git", ["patch-id", "--stable"], {
       cwd: worktreePath,
       input: diff,

--- a/src/review.ts
+++ b/src/review.ts
@@ -194,7 +194,7 @@ export class ReviewService {
     // it's checked out), and it's exactly the tree the critic would review.
     let wt;
     try {
-      wt = this.deps.worktree.createDetached(session.repoPath, session.branch!, git.headSha!);
+      wt = await this.deps.worktree.createDetached(session.repoPath, session.branch!, git.headSha!);
     } catch (err) {
       console.warn(`[review] worktree failed for ${session.id}:`, err);
       return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -147,7 +147,7 @@ export interface AppDeps {
     queue(repoPath: string): Promise<QueuedItem[]>;
   };
   /** Full-auto merge train snapshot; absent in tests that don't exercise it. */
-  autoMerge?: { snapshot(): import("./automerge").AutoMergeStatus[] };
+  autoMerge?: { snapshot(): Promise<import("./automerge").AutoMergeStatus[]> };
 }
 
 const sessionUsage = (s: Session) =>
@@ -241,11 +241,11 @@ async function handleDrain({ req, parts, url, deps }: Ctx): Promise<Response | n
 }
 
 // GET /api/automerge — a status per auto-merge-enabled repo (client bootstrap).
-function handleAutoMerge({ req, parts, deps }: Ctx): Response | null {
+async function handleAutoMerge({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "GET" && parts[0] === "api" && parts[1] === "automerge" && !parts[2])) {
     return null;
   }
-  return json(deps.autoMerge?.snapshot() ?? []);
+  return json((await deps.autoMerge?.snapshot()) ?? []);
 }
 
 // maxAuto: finite integer ≥ 1; clamp > 20 to 20

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,6 +58,7 @@ import { countDefinedWorkflows, type CountsService, type RepoCounts } from "./ba
 import { join, normalize } from "node:path";
 import { homedir } from "node:os";
 import type { ServerWebSocket } from "bun";
+import { markPtyEvent } from "./instrument";
 
 const UI_DIR = join(import.meta.dir, "..", "ui", "build");
 
@@ -2207,6 +2208,7 @@ export function serve(deps: AppDeps, port: number) {
           }
           return;
         }
+        markPtyEvent("in");
         ws.data.bridge?.write(typeof msg === "string" ? msg : msg.toString());
       },
       close(ws) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -709,11 +709,11 @@ async function sessionActivityRead(id: string, deps: AppDeps): Promise<Response>
   return json(path ? await sessionActivity(path) : []);
 }
 
-function sessionDiffRead(id: string, deps: AppDeps): Response {
+async function sessionDiffRead(id: string, deps: AppDeps): Promise<Response> {
   const s = deps.store.get(id);
   if (!s) return json({ error: "not found" }, 404);
   try {
-    return json(computeDiff(s.worktreePath, s.baseBranch, s.branch));
+    return json(await computeDiff(s.worktreePath, s.baseBranch, s.branch));
   } catch (e) {
     return json({ error: e instanceof Error ? e.message : "diff failed" }, 500);
   }

--- a/src/stall.ts
+++ b/src/stall.ts
@@ -1,5 +1,4 @@
-import { readFileSync } from "node:fs";
-import { latestRecordTs, parseActivity, type ActivityEntry } from "./activity";
+import { latestRecordTs, parseActivity, readTranscriptTail, type ActivityEntry } from "./activity";
 
 /** A minimal read of a session's most-recent tool activity, for stall detection. */
 export interface ActivitySnapshot {
@@ -65,11 +64,13 @@ export function snapshotFromText(text: string): ActivitySnapshot | null {
 /**
  * Synchronously derive a snapshot from a session JSONL. Missing/unreadable
  * (e.g. a just-spawned session with no transcript) → null, treated as "no signal".
+ * Reads only the tail of the file (bounded by MAX_TAIL_BYTES) to avoid blocking
+ * the event loop on large transcripts.
  */
 export function readSnapshot(path: string): ActivitySnapshot | null {
   let text: string;
   try {
-    text = readFileSync(path, "utf8");
+    text = readTranscriptTail(path);
   } catch {
     return null;
   }

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,7 +1,11 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import { readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
+import { timedAsync } from "./instrument";
+
+const execFileAsync = promisify(execFile);
 
 export interface UpdateCommit {
   sha: string;
@@ -57,7 +61,7 @@ const EMPTY = (now: number): UpdateStatus => ({
 });
 
 /** Runs git inside a fixed repo dir and returns stdout; injectable for tests. */
-export type GitRunner = (args: string[]) => string;
+export type GitRunner = (args: string[]) => Promise<string>;
 
 export interface UpdateDeps {
   /** repo to check; defaults to the service working dir (the live deployment) */
@@ -103,11 +107,12 @@ export class UpdateService {
     this.limit = deps.limit ?? 20;
     this.git =
       deps.git ??
-      ((args) =>
-        execFileSync("git", ["-C", this.repoDir, ...args], {
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "ignore"],
-        }));
+      (async (args) => {
+        const { stdout } = await timedAsync(`git ${args[0] ?? ""}`, () =>
+          execFileAsync("git", ["-C", this.repoDir, ...args], { encoding: "utf8" }),
+        );
+        return stdout as string;
+      });
     this.launch = deps.launch ?? (() => this.defaultLaunch());
   }
 
@@ -184,17 +189,17 @@ export class UpdateService {
 
   /** Fetch origin and recompute how far behind the tracked branch we are. On any
    *  git/network failure, returns behind:0 (fail safe → no false update badge). */
-  check(now: number): UpdateStatus {
+  async check(now: number): Promise<UpdateStatus> {
     try {
       const remote = `origin/${this.branch}`;
-      this.git(["fetch", "--quiet", "origin", this.branch]);
-      const current = this.git(["rev-parse", "--short", "HEAD"]).trim() || null;
-      const latest = this.git(["rev-parse", "--short", remote]).trim() || null;
+      await this.git(["fetch", "--quiet", "origin", this.branch]);
+      const current = (await this.git(["rev-parse", "--short", "HEAD"])).trim() || null;
+      const latest = (await this.git(["rev-parse", "--short", remote])).trim() || null;
       const range = `HEAD..${remote}`;
-      const behind = Number(this.git(["rev-list", "--count", range]).trim()) || 0;
+      const behind = Number((await this.git(["rev-list", "--count", range])).trim()) || 0;
       const commits =
         behind > 0
-          ? this.git(["log", `--max-count=${this.limit}`, "--format=%h%x09%s", range])
+          ? (await this.git(["log", `--max-count=${this.limit}`, "--format=%h%x09%s", range]))
               .split("\n")
               .filter(Boolean)
               .map((line) => {

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,6 +1,10 @@
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { dirname, join, basename, resolve } from "node:path";
+import { promisify } from "node:util";
+import { timedAsync } from "./instrument";
+
+const execFileAsync = promisify(execFile);
 
 export interface WorktreeResult {
   worktreePath: string;
@@ -110,13 +114,12 @@ export class WorktreeMgr {
    *    true  → base has commits HEAD lacks (stale, rebase needed)
    *    null  → unknowable (bad worktree / git error) → caller treats as "do not merge"
    */
-  behindBase(worktreePath: string, baseBranch: string): boolean | null {
+  async behindBase(worktreePath: string, baseBranch: string): Promise<boolean | null> {
     if (!/^(?!-)[A-Za-z0-9._/-]{1,200}$/.test(baseBranch)) return null;
     try {
-      execFileSync("git", ["fetch", "origin", "--", baseBranch], {
-        cwd: worktreePath,
-        stdio: "pipe",
-      });
+      await timedAsync("git fetch", () =>
+        execFileAsync("git", ["fetch", "origin", "--", baseBranch], { cwd: worktreePath }),
+      );
     } catch {
       /* offline / no origin — compare against whatever base ref is local */
     }
@@ -245,7 +248,12 @@ export class WorktreeMgr {
    *  would blow away the first's live worktree, and both inflight records would then read the
    *  same `.shepherd-plan-review.json` — delivering one session's plan findings to another.
    *  Passing the session id as `slug` gives each its own path. */
-  createDetached(repoPath: string, branch: string, sha: string, slug?: string): WorktreeResult {
+  async createDetached(
+    repoPath: string,
+    branch: string,
+    sha: string,
+    slug?: string,
+  ): Promise<WorktreeResult> {
     if (!/^[0-9a-fA-F]{7,40}$/.test(sha)) throw new Error("invalid sha");
     // same refname grammar as create(); rejecting a leading "-" also blocks argv
     // flag-smuggling into the `git fetch` below (the `--` is belt-and-suspenders)
@@ -259,7 +267,9 @@ export class WorktreeMgr {
     mkdirSync(parent, { recursive: true });
     try {
       // best-effort: pull the PR head into the local object store (no-op if local)
-      execFileSync("git", ["fetch", "origin", "--", branch], { cwd: repoPath, stdio: "pipe" });
+      await timedAsync("git fetch", () =>
+        execFileAsync("git", ["fetch", "origin", "--", branch], { cwd: repoPath }),
+      );
     } catch {
       /* offline / no origin — the sha may already be local; let worktree add decide */
     }

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,4 +1,5 @@
-import { execFile, execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { execFileSync } from "./instrument";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { dirname, join, basename, resolve } from "node:path";
 import { promisify } from "node:util";

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -279,10 +279,13 @@ export class WorktreeMgr {
     // the same head isn't permanently blocked by `worktree add` hitting an
     // occupied directory.
     if (existsSync(worktreePath)) this.remove(worktreePath);
-    execFileSync("git", ["worktree", "add", "--detach", worktreePath, sha], {
-      cwd: repoPath,
-      stdio: "pipe",
-    });
+    // `worktree add --detach` is a full working-tree checkout — the heaviest local git op
+    // here — and createDetached runs on the plan-gate / critic background-poll path, so run
+    // it async to keep the checkout off the Bun event loop. (No stdin constraint, unlike
+    // patch-id, so execFileAsync works directly.)
+    await timedAsync("git worktree add", () =>
+      execFileAsync("git", ["worktree", "add", "--detach", worktreePath, sha], { cwd: repoPath }),
+    );
     return { worktreePath, branch: null, isolated: true };
   }
 

--- a/test/activity-signal.test.ts
+++ b/test/activity-signal.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../src/activity-signal";
 import { snapshotFromText } from "../src/stall";
 import type { ActivityEntry } from "../src/activity";
+import { MAX_TAIL_BYTES } from "../src/activity";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -300,7 +301,7 @@ test("readTranscriptSignals parity: signals from tail read equal signals from re
     // Verify the file is actually larger than MAX_TAIL_BYTES so the truncation
     // path is exercised (not the whole-file-fits path).
     const fileSize = statSync(path).size;
-    expect(fileSize).toBeGreaterThan(512 * 1024);
+    expect(fileSize).toBeGreaterThan(MAX_TAIL_BYTES);
 
     // Derive expected signals from ONLY the recent lines (what the tail should cover
     // after the filler is cut). The filler uses "2020-01-01" timestamps and
@@ -316,7 +317,8 @@ test("readTranscriptSignals parity: signals from tail read equal signals from re
     expect(snapshot).not.toBeNull();
     // heartbeat must match the recent records, not the filler's 2020 timestamp
     expect(activity!.lastActivityTs).toBe(expectedActivity!.lastActivityTs);
-    // summary must be from the recent edit/bash, not "$ echo filler-N"
+    // summary must be exactly the known recent tool — not any "$ echo filler-N" value
+    expect(activity!.summary).toBe("$ bun test");
     expect(activity!.summary).toBe(expectedActivity!.summary);
     // stall snapshot must reflect recent records only
     expect(snapshot!.lastTs).toBe(expectedSnapshot!.lastTs);

--- a/test/activity-signal.test.ts
+++ b/test/activity-signal.test.ts
@@ -10,6 +10,7 @@ import {
   readTranscriptSignals,
   STRIP_WINDOW_MS,
 } from "../src/activity-signal";
+import { snapshotFromText } from "../src/stall";
 import type { ActivityEntry } from "../src/activity";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -261,4 +262,52 @@ test("signalFrom: pending entries count in recentTs but never in recentErrTs", (
   const signal = signalFrom([entry("Bash", "$ in flight", last - 5_000, "pending")], last);
   expect(signal!.recentTs).toEqual([last - 5_000]);
   expect(signal!.recentErrTs).toEqual([]);
+});
+
+// ── parity: tail-bounded read produces same signals as a full parse ────────────
+
+test("readTranscriptSignals parity: signals from tail read equal signals from recent records only", () => {
+  const dir = mkdtempSync(join(tmpdir(), "parity-signal-"));
+  const path = join(dir, "parity.jsonl");
+  try {
+    // Build a transcript: 5 "old" tool lines that will be cropped by the tail cap,
+    // then 4 "recent" lines that must survive the tail read. Recent records all
+    // fall within the default MAX_TAIL_BYTES window so accuracy is preserved.
+    const oldLines: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      oldLines.push(
+        toolLine("Read", { file_path: `/old/file${i}.ts` }, `old${i}`, "2026-01-01T00:00:00.000Z"),
+      );
+      oldLines.push(resultLine(`old${i}`, "2026-01-01T00:00:01.000Z"));
+    }
+    const recentLines = [
+      toolLine("Edit", { file_path: "/a/server.ts" }, "r1", "2026-05-31T10:00:00.000Z"),
+      resultLine("r1", "2026-05-31T10:00:01.000Z"),
+      toolLine("Bash", { command: "bun test" }, "r2", "2026-05-31T10:01:00.000Z"),
+      resultLine("r2", "2026-05-31T10:05:00.000Z"),
+    ];
+
+    const fullContent = [...oldLines, ...recentLines].join("\n");
+    writeFileSync(path, fullContent);
+
+    // derive expected signals from ONLY the recent lines (what the tail should cover)
+    const recentText = recentLines.join("\n");
+    const expectedActivity = signalFromText(recentText);
+    const expectedSnapshot = snapshotFromText(recentText);
+
+    // actual read via readTranscriptSignals (uses readTranscriptTail internally)
+    const { snapshot, activity } = readTranscriptSignals(path);
+
+    expect(activity).not.toBeNull();
+    expect(snapshot).not.toBeNull();
+    // heartbeat must match
+    expect(activity!.lastActivityTs).toBe(expectedActivity!.lastActivityTs);
+    // summary must match
+    expect(activity!.summary).toBe(expectedActivity!.summary);
+    // stall snapshot must match
+    expect(snapshot!.lastTs).toBe(expectedSnapshot!.lastTs);
+    expect(snapshot!.pending).toBe(expectedSnapshot!.pending);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/test/activity-signal.test.ts
+++ b/test/activity-signal.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -270,15 +270,22 @@ test("readTranscriptSignals parity: signals from tail read equal signals from re
   const dir = mkdtempSync(join(tmpdir(), "parity-signal-"));
   const path = join(dir, "parity.jsonl");
   try {
-    // Build a transcript: 5 "old" tool lines that will be cropped by the tail cap,
-    // then 4 "recent" lines that must survive the tail read. Recent records all
-    // fall within the default MAX_TAIL_BYTES window so accuracy is preserved.
-    const oldLines: string[] = [];
-    for (let i = 0; i < 5; i++) {
-      oldLines.push(
-        toolLine("Read", { file_path: `/old/file${i}.ts` }, `old${i}`, "2026-01-01T00:00:00.000Z"),
+    // Build a transcript that EXCEEDS MAX_TAIL_BYTES (512 KB) so the tail read
+    // genuinely truncates the file. Filler records use a distinct old timestamp
+    // (2020-01-01) and a unique Bash command — if any filler leaked through the
+    // tail cut, lastActivityTs and summary would differ from the expected values,
+    // making the assertions non-tautological.
+    //
+    // Each filler pair (tool_use + tool_result) is ~400 B. We need > 512 KB of
+    // filler, so 1500 pairs ≈ 600 KB safely exceeds the cap. The recent records
+    // (< 2 KB) are appended last and must fully fit within the tail window.
+    const FILLER_PAIRS = 1500;
+    const fillerLines: string[] = [];
+    for (let i = 0; i < FILLER_PAIRS; i++) {
+      fillerLines.push(
+        toolLine("Bash", { command: `echo filler-${i}` }, `filler${i}`, "2020-01-01T00:00:00.000Z"),
       );
-      oldLines.push(resultLine(`old${i}`, "2026-01-01T00:00:01.000Z"));
+      fillerLines.push(resultLine(`filler${i}`, "2020-01-01T00:00:01.000Z"));
     }
     const recentLines = [
       toolLine("Edit", { file_path: "/a/server.ts" }, "r1", "2026-05-31T10:00:00.000Z"),
@@ -287,24 +294,31 @@ test("readTranscriptSignals parity: signals from tail read equal signals from re
       resultLine("r2", "2026-05-31T10:05:00.000Z"),
     ];
 
-    const fullContent = [...oldLines, ...recentLines].join("\n");
+    const fullContent = [...fillerLines, ...recentLines].join("\n");
     writeFileSync(path, fullContent);
 
-    // derive expected signals from ONLY the recent lines (what the tail should cover)
+    // Verify the file is actually larger than MAX_TAIL_BYTES so the truncation
+    // path is exercised (not the whole-file-fits path).
+    const fileSize = statSync(path).size;
+    expect(fileSize).toBeGreaterThan(512 * 1024);
+
+    // Derive expected signals from ONLY the recent lines (what the tail should cover
+    // after the filler is cut). The filler uses "2020-01-01" timestamps and
+    // "$ echo filler-N" summaries — distinct enough that leakage would be detected.
     const recentText = recentLines.join("\n");
     const expectedActivity = signalFromText(recentText);
     const expectedSnapshot = snapshotFromText(recentText);
 
-    // actual read via readTranscriptSignals (uses readTranscriptTail internally)
+    // actual read via readTranscriptSignals (uses readTranscriptTail + 512 KB cap)
     const { snapshot, activity } = readTranscriptSignals(path);
 
     expect(activity).not.toBeNull();
     expect(snapshot).not.toBeNull();
-    // heartbeat must match
+    // heartbeat must match the recent records, not the filler's 2020 timestamp
     expect(activity!.lastActivityTs).toBe(expectedActivity!.lastActivityTs);
-    // summary must match
+    // summary must be from the recent edit/bash, not "$ echo filler-N"
     expect(activity!.summary).toBe(expectedActivity!.summary);
-    // stall snapshot must match
+    // stall snapshot must reflect recent records only
     expect(snapshot!.lastTs).toBe(expectedSnapshot!.lastTs);
     expect(snapshot!.pending).toBe(expectedSnapshot!.pending);
   } finally {

--- a/test/activity.test.ts
+++ b/test/activity.test.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "bun:test";
-import { parseActivity, sessionActivity } from "../src/activity";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseActivity, readTranscriptTail, sessionActivity } from "../src/activity";
 
 function toolUse(name: string, input: unknown, id = "t1", ts = "2026-05-31T10:00:00.000Z"): string {
   return JSON.stringify({
@@ -118,4 +121,45 @@ test("skips malformed lines and blanks", () => {
 
 test("sessionActivity returns [] for a missing file", async () => {
   expect(await sessionActivity("/nonexistent/definitely-not-here.jsonl")).toEqual([]);
+});
+
+// ── readTranscriptTail ────────────────────────────────────────────────────────
+
+test("readTranscriptTail: file smaller than cap → whole content returned", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tail-"));
+  const path = join(dir, "small.jsonl");
+  try {
+    const content = "line1\nline2\nline3";
+    writeFileSync(path, content);
+    expect(readTranscriptTail(path, 1024)).toBe(content);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readTranscriptTail: file larger than cap → only tail returned, leading partial line dropped", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tail-"));
+  const path = join(dir, "big.jsonl");
+  try {
+    // build content: 10 full lines, each ~20 bytes
+    const lines = Array.from({ length: 10 }, (_, i) => `{"n":${i},"pad":"xxxxxxxxxx"}`);
+    const content = lines.join("\n") + "\n";
+    // cap at 60 bytes — starts mid-file; first partial line must be dropped
+    const cap = 60;
+    writeFileSync(path, content);
+    const tail = readTranscriptTail(path, cap);
+    // length is bounded: at most cap bytes (minus leading partial line)
+    expect(tail.length).toBeLessThanOrEqual(cap);
+    // must not start with a partial record — first char is '{' of a whole line
+    const firstLine = tail.split("\n")[0]!;
+    expect(() => JSON.parse(firstLine)).not.toThrow();
+    // must end with full content (last line present)
+    expect(tail).toContain(`{"n":9,"pad":"xxxxxxxxxx"}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readTranscriptTail: missing file throws", () => {
+  expect(() => readTranscriptTail(join(tmpdir(), "does-not-exist-tail-test.jsonl"))).toThrow();
 });

--- a/test/automerge.test.ts
+++ b/test/automerge.test.ts
@@ -40,7 +40,7 @@ function deps(over: Partial<AutoMergeDeps> = {}): AutoMergeDeps {
         merge: mock(async () => {}),
         closeIssue: mock(async () => {}),
       }) as any,
-    worktree: { behindBase: () => false } as any,
+    worktree: { behindBase: async () => false } as any,
     prCache: {
       snapshot: () => ({
         s1: { state: "open", checks: "success", mergeable: true, number: 7, headSha: "h1" },
@@ -76,7 +76,7 @@ test("behind → steers a rebase + bumps the counter, does NOT merge", async () 
   const setState = mock(() => {});
   const merge = mock(async () => {});
   const d = deps({
-    worktree: { behindBase: () => true } as any,
+    worktree: { behindBase: async () => true } as any,
     service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
     resolveForge: () =>
       ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
@@ -118,7 +118,7 @@ test("dead pane → resume attempted before steer; counter bumped once resumed",
   const resume = mock(() => true);
   const setState = mock(() => {});
   const d = deps({
-    worktree: { behindBase: () => true } as any,
+    worktree: { behindBase: async () => true } as any,
     paneAlive: () => false,
     service: { archive: mock(() => 1), reply, resume } as any,
   });
@@ -134,7 +134,7 @@ test("rebase steer fails to deliver → counter NOT bumped", async () => {
   const reply = mock(() => false);
   const setState = mock(() => {});
   const d = deps({
-    worktree: { behindBase: () => true } as any,
+    worktree: { behindBase: async () => true } as any,
     service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
   });
   d.store.setAutoMergeState = setState as any;
@@ -187,7 +187,7 @@ test("multi-session: merges ready A then steers rebase for behind B", async () =
       }) as any,
     // A is up-to-date (behind=false → ready to merge), B is behind → needs rebase
     worktree: {
-      behindBase: (wt: string) => (wt === "/wt" ? false : true),
+      behindBase: async (wt: string) => (wt === "/wt" ? false : true),
     } as any,
     prCache: {
       snapshot: () => ({
@@ -246,7 +246,7 @@ test("rebase_cap: behind session at cap → no reply steer, emitStatus rebase_ca
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
     } as any,
-    worktree: { behindBase: () => true } as any,
+    worktree: { behindBase: async () => true } as any,
     service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
     emitStatus,
     rebaseCap: 5,
@@ -277,7 +277,7 @@ test("reset-on-progress: behind=false + mergeable=true → rebaseCount reset to 
       setAutoMergeState: setState,
       setAutopilotState: mock(() => {}),
     } as any,
-    worktree: { behindBase: () => false } as any,
+    worktree: { behindBase: async () => false } as any,
     resolveForge: () =>
       ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
     service: { archive: mock(() => 1), reply: mock(() => true), resume: mock(() => true) } as any,
@@ -306,7 +306,7 @@ test("reset-on-progress NEGATIVE: behind=false + mergeable=false → counter NOT
       setAutoMergeState: setState,
       setAutopilotState: mock(() => {}),
     } as any,
-    worktree: { behindBase: () => false } as any,
+    worktree: { behindBase: async () => false } as any,
     // PR is open+green but mergeable=false (conflict)
     prCache: {
       snapshot: () => ({
@@ -329,7 +329,7 @@ test("reset-on-progress NEGATIVE: behind=false + mergeable=false → counter NOT
 
 test("behind cache: two pumps with frozen clock call behindBase only once", async () => {
   let nowVal = 1000;
-  const behindBase = mock(() => true);
+  const behindBase = mock(async () => true);
   const reply = mock(() => true);
 
   const d = deps({
@@ -434,7 +434,7 @@ test("rebase outstanding: same head not re-steered / not re-bumped on a second p
       setAutoMergeState: setState as any,
       setAutopilotState: mock(() => {}),
     } as any,
-    worktree: { behindBase: () => true } as any,
+    worktree: { behindBase: async () => true } as any,
     service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
   });
   const svc = new AutoMergeService(d);
@@ -525,7 +525,7 @@ test("status payload carries sessionId on rebase_cap hold", async () => {
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
     } as any,
-    worktree: { behindBase: () => true } as any,
+    worktree: { behindBase: async () => true } as any,
     emitStatus,
     rebaseCap: 5,
   });
@@ -551,7 +551,7 @@ test("rebase steer references origin/<baseBranch> from the session", async () =>
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
     } as any,
-    worktree: { behindBase: () => true } as any,
+    worktree: { behindBase: async () => true } as any,
     service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
   });
   const svc = new AutoMergeService(d);

--- a/test/backlog.test.ts
+++ b/test/backlog.test.ts
@@ -35,7 +35,7 @@ function gitInit(dir: string, remoteUrl: string): string {
 /** A recording fake GhRunner. */
 function fakeRunner(response: string): { run: GhRunner; calls: string[][] } {
   const calls: string[][] = [];
-  const run: GhRunner = (args) => {
+  const run: GhRunner = async (args) => {
     calls.push(args);
     return response;
   };
@@ -105,7 +105,7 @@ test("CountsService: Gitea repo returns openIssues and openPRs from REST API", a
   };
 
   const { fn } = fakeFetch({ open_issues_count: 5, open_pr_counter: 1 });
-  const run: GhRunner = () => "";
+  const run: GhRunner = async () => "";
   const svc = new CountsService(forges, run, fn);
 
   const result = await svc.counts(repoDir);
@@ -138,11 +138,8 @@ test("CountsService: single-flight — concurrent calls share one in-flight prom
   const forges: ForgeMap = {};
 
   const calls: string[][] = [];
-  const run: GhRunner = (args) => {
+  const run: GhRunner = async (args) => {
     calls.push(args);
-    // Synchronously block until we resolve — simulate a slow response
-    // We actually need sync return from GhRunner, so we return immediately
-    // but track that it was only invoked once.
     return JSON.stringify({
       data: { repository: { issues: { totalCount: 7 }, pullRequests: { totalCount: 0 } } },
     });
@@ -166,7 +163,7 @@ test("CountsService: fault isolation — throwing runner yields null counts, not
   const goodDir = gitInit(join(tmpBase, "good-repo"), "https://github.com/good/repo");
   const forges: ForgeMap = {};
 
-  const run: GhRunner = (args) => {
+  const run: GhRunner = async (args) => {
     // With gh variables, owner is passed as a separate -F arg: "owner=<value>"
     const ownerArg = args.find((a) => a.startsWith("owner=")) ?? "";
     if (ownerArg === "owner=bad") throw new Error("gh auth failed");
@@ -191,7 +188,7 @@ test("CountsService: failure yields null not 0", async () => {
   const repoDir = gitInit(join(tmpBase, "throws"), "https://github.com/boom/repo");
   const forges: ForgeMap = {};
 
-  const run: GhRunner = () => {
+  const run: GhRunner = async () => {
     throw new Error("network error");
   };
   const svc = new CountsService(forges, run);
@@ -295,7 +292,7 @@ test("CountsService: request-path failure still yields null (no preserve)", asyn
   const repoDir = gitInit(join(tmpBase, "gh-no-preserve"), "https://github.com/o/nopreserve");
   const forges: ForgeMap = {};
 
-  const run = (): string => {
+  const run = async (): Promise<string> => {
     throw new Error("down");
   };
   const svc = new CountsService(forges, run);
@@ -339,7 +336,7 @@ test("CountsService: repo with no origin → null counts (not a throw)", async (
   // No remote set
 
   const forges: ForgeMap = {};
-  const run: GhRunner = () => "";
+  const run: GhRunner = async () => "";
   const svc = new CountsService(forges, run);
 
   const result = await svc.counts(repoDir);
@@ -398,8 +395,8 @@ test("CountsService: maps SUCCESS → success and PENDING → pending", async ()
         },
       },
     });
-  const okSvc = new CountsService({}, () => mk("SUCCESS"));
-  const pendSvc = new CountsService({}, () => mk("PENDING"));
+  const okSvc = new CountsService({}, async () => mk("SUCCESS"));
+  const pendSvc = new CountsService({}, async () => mk("PENDING"));
   expect((await okSvc.counts(okDir)).ciStatus).toBe("success");
   expect((await pendSvc.counts(pendDir)).ciStatus).toBe("pending");
 });
@@ -431,6 +428,6 @@ test("CountsService: Gitea repo → ciStatus null", async () => {
     "git.example.com": { type: "gitea", baseUrl: "https://git.example.com", token: "tok" },
   };
   const { fn } = fakeFetch({ open_issues_count: 5, open_pr_counter: 1 });
-  const svc = new CountsService(forges, () => "", fn);
+  const svc = new CountsService(forges, async () => "", fn);
   expect((await svc.counts(repoDir)).ciStatus).toBeNull();
 });

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -100,7 +100,7 @@ test("parses multiple files in one diff", () => {
   expect(files.map((f) => f.path)).toEqual(["new.ts", "gone.ts"]);
 });
 
-test("truncates files over the line cap", () => {
+test("truncates files over the per-file line cap", () => {
   const big = Array.from({ length: 2100 }, (_, i) => `+line ${i}`).join("\n");
   const text = `diff --git a/big.ts b/big.ts
 --- /dev/null
@@ -112,6 +112,33 @@ ${big}
   expect(f.truncated).toBe(true);
   expect(f.hunks).toHaveLength(0);
   expect(f.additions).toBe(2100);
+});
+
+test("MAX_TOTAL_LINES: stops parsing after global cap, marks over-cap file truncated", () => {
+  // Each file has 1000 lines (under per-file cap of 2000). Generate 102 files →
+  // 102k total lines, exceeding MAX_TOTAL_LINES (100k). Files 1-100 parse clean;
+  // file 101+ gets marked truncated by the global cap.
+  const makeFile = (name: string, n: number) => {
+    const lines = Array.from({ length: n }, (_, i) => `+line ${i}`).join("\n");
+    return `diff --git a/${name} b/${name}\n--- /dev/null\n+++ b/${name}\n@@ -0,0 +1,${n} @@\n${lines}\n`;
+  };
+  const text = Array.from({ length: 102 }, (_, i) => makeFile(`file${i}.ts`, 1000)).join("");
+  const files = parseUnifiedDiff(text);
+  expect(files).toHaveLength(102);
+  // Files within the first 100k lines are untruncated
+  const cleanFiles = files.filter((f) => !f.truncated);
+  const truncatedFiles = files.filter((f) => f.truncated);
+  expect(cleanFiles.length).toBeGreaterThan(0);
+  expect(truncatedFiles.length).toBeGreaterThan(0);
+  // The truncated files have no hunks
+  for (const f of truncatedFiles) {
+    expect(f.hunks).toHaveLength(0);
+  }
+});
+
+test("MAX_TOTAL_LINES: small diff unaffected", () => {
+  const files = parseUnifiedDiff(ADDED + DELETED + MODIFIED);
+  expect(files.every((f) => !f.truncated)).toBe(true);
 });
 
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -133,7 +160,7 @@ const GIT_ENV = {
 const git = (cwd: string, ...args: string[]) =>
   execFileSync("git", args, { cwd, env: GIT_ENV, stdio: "pipe" }).toString();
 
-test("computeDiff: branch vs base shows committed changes, local fallback when no remote", () => {
+test("computeDiff: branch vs base shows committed changes, local fallback when no remote", async () => {
   const repo = mkdtempSync(join(tmpdir(), "shepherd-diff-"));
   try {
     git(repo, "init", "-q", "-b", "main");
@@ -145,7 +172,7 @@ test("computeDiff: branch vs base shows committed changes, local fallback when n
     git(repo, "add", "-A");
     git(repo, "commit", "-q", "-m", "feature change");
 
-    const r = computeDiff(repo, "main", "feature");
+    const r = await computeDiff(repo, "main", "feature");
     expect(r.head).toBe("feature");
     expect(r.fetchFailed).toBe(true);
     expect(r.baseRef).toBe("main");
@@ -157,7 +184,7 @@ test("computeDiff: branch vs base shows committed changes, local fallback when n
   }
 });
 
-test("computeDiff: diffs against origin/<base> when a remote exists", () => {
+test("computeDiff: diffs against origin/<base> when a remote exists", async () => {
   const remote = mkdtempSync(join(tmpdir(), "shepherd-remote-"));
   const repo = mkdtempSync(join(tmpdir(), "shepherd-diff-origin-"));
   try {
@@ -173,7 +200,7 @@ test("computeDiff: diffs against origin/<base> when a remote exists", () => {
     git(repo, "add", "-A");
     git(repo, "commit", "-q", "-m", "feature change");
 
-    const r = computeDiff(repo, "main", "feature");
+    const r = await computeDiff(repo, "main", "feature");
     expect(r.fetchFailed).toBe(false);
     expect(r.baseRef).toBe("origin/main");
     expect(r.files).toHaveLength(1);
@@ -184,8 +211,8 @@ test("computeDiff: diffs against origin/<base> when a remote exists", () => {
   }
 });
 
-test("computeDiff: non-isolated session (no branch) → empty result", () => {
-  const r = computeDiff("/nonexistent", "main", null);
+test("computeDiff: non-isolated session (no branch) → empty result", async () => {
+  const r = await computeDiff("/nonexistent", "main", null);
   expect(r.files).toEqual([]);
   expect(r.head).toBeNull();
   expect(r.fetchFailed).toBe(false);

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -116,11 +116,11 @@ ${big}
 
 test("MAX_TOTAL_LINES: stops parsing after global cap, marks over-cap file truncated", () => {
   // Each file has 1000 lines (under per-file cap of 2000). Generate 102 files →
-  // 102k total lines, exceeding MAX_TOTAL_LINES (100k). Files 1-100 parse clean;
-  // file 101+ gets marked truncated by the global cap.
+  // 102k total lines, exceeding MAX_TOTAL_LINES (100k). At least one file parses
+  // clean and at least one is marked truncated by the global cap.
   const makeFile = (name: string, n: number) => {
     const lines = Array.from({ length: n }, (_, i) => `+line ${i}`).join("\n");
-    return `diff --git a/${name} b/${name}\n--- /dev/null\n+++ b/${name}\n@@ -0,0 +1,${n} @@\n${lines}\n`;
+    return `diff --git a/${name} b/${name}\nnew file mode 100644\n--- /dev/null\n+++ b/${name}\n@@ -0,0 +1,${n} @@\n${lines}\n`;
   };
   const text = Array.from({ length: 102 }, (_, i) => makeFile(`file${i}.ts`, 1000)).join("");
   const files = parseUnifiedDiff(text);
@@ -130,9 +130,11 @@ test("MAX_TOTAL_LINES: stops parsing after global cap, marks over-cap file trunc
   const truncatedFiles = files.filter((f) => f.truncated);
   expect(cleanFiles.length).toBeGreaterThan(0);
   expect(truncatedFiles.length).toBeGreaterThan(0);
-  // The truncated files have no hunks
+  // The truncated files have no hunks but still carry correct status + path metadata
   for (const f of truncatedFiles) {
     expect(f.hunks).toHaveLength(0);
+    expect(f.status).toBe("added");
+    expect(f.path).toMatch(/^file\d+\.ts$/);
   }
 });
 

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -4,7 +4,7 @@ import { GithubForge } from "../../src/forge/github";
 // A recording fake `gh` runner. Returns canned stdout keyed by the subcommand.
 function fakeRunner(responses: Record<string, string>) {
   const calls: string[][] = [];
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     calls.push(args);
     const key = `${args[0]} ${args[1] ?? ""}`.trim();
     if (key in responses) return responses[key]!;
@@ -195,7 +195,7 @@ test("GithubForge.addIssueLabel: ensures the label exists, then adds it", async 
 
 test("GithubForge.addIssueLabel: a pre-existing label (label create throws) still adds", async () => {
   const calls: string[][] = [];
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     calls.push(args);
     if (args[0] === "label" && args[1] === "create") throw new Error("label already exists");
     return "";
@@ -221,7 +221,7 @@ test("GithubForge.removeIssueLabel: gh issue edit --remove-label", async () => {
 });
 
 test("GithubForge.kind + slug", () => {
-  const forge = new GithubForge("o/r", {}, () => "");
+  const forge = new GithubForge("o/r", {}, async () => "");
   expect(forge.kind).toBe("github");
   expect(forge.slug).toBe("o/r");
 });
@@ -438,7 +438,7 @@ test("GithubForge.listWorkflowRuns: newest run per workflow, jobs mapped, newest
     }),
   };
   const calls: string[][] = [];
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     calls.push(args);
     if (args[0] === "repo" && args[1] === "view")
       return JSON.stringify({ defaultBranchRef: { name: "main" } });
@@ -506,7 +506,7 @@ test("GithubForge.listWorkflowRuns: caps at 10 workflows", async () => {
     })),
   );
   let viewCalls = 0;
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     if (args[0] === "repo" && args[1] === "view")
       return JSON.stringify({ defaultBranchRef: { name: "main" } });
     if (args[0] === "run" && args[1] === "list") return runList;
@@ -543,7 +543,7 @@ test("GithubForge.postReview: request-changes falls back to pr comment when revi
   // GitHub 422s request-changes on a self-authored PR; emulate gh exiting non-zero
   // on the review call, then succeeding (and echoing the URL) on pr comment.
   const calls: string[][] = [];
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     calls.push(args);
     if (args[1] === "review") throw new Error("Can not request changes on your own pull request");
     return "https://github.com/o/r/pull/7#issuecomment-99\n";
@@ -604,7 +604,7 @@ test("GithubForge.comment: posts a PR comment via gh pr comment", async () => {
 });
 
 test("GithubForge.listRunJobs: maps a run's jobs to the four-light vocab", async () => {
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     if (args[0] === "run" && args[1] === "view" && args[2] === "200")
       return JSON.stringify({
         jobs: [
@@ -623,7 +623,7 @@ test("GithubForge.listRunJobs: maps a run's jobs to the four-light vocab", async
 
 test("GithubForge.listWorkflowRunHistory: filters by workflow + branch, jobs empty, newest-first", async () => {
   const calls: string[][] = [];
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     calls.push(args);
     if (args[0] === "repo" && args[1] === "view")
       return JSON.stringify({ defaultBranchRef: { name: "main" } });
@@ -689,7 +689,7 @@ test("GithubForge.listWorkflowRunHistory: filters by workflow + branch, jobs emp
 });
 
 test("GithubForge.listWorkflowRunHistory: no default branch → []", async () => {
-  const run = (args: string[]): string => (args[0] === "repo" ? "{}" : "");
+  const run = async (args: string[]): Promise<string> => (args[0] === "repo" ? "{}" : "");
   expect(await new GithubForge("o/r", {}, run).listWorkflowRunHistory(11, { limit: 10 })).toEqual(
     [],
   );
@@ -697,7 +697,7 @@ test("GithubForge.listWorkflowRunHistory: no default branch → []", async () =>
 
 test("GithubForge.ensureIssueLink: appends Closes #N when body has no link", async () => {
   const calls: string[][] = [];
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     calls.push(args);
     if (args[0] === "pr" && args[1] === "view") return "Some PR description";
     return "";
@@ -713,7 +713,7 @@ test("GithubForge.ensureIssueLink: appends Closes #N when body has no link", asy
 
 test("GithubForge.ensureIssueLink: appends to empty body without leading newlines", async () => {
   const calls: string[][] = [];
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     calls.push(args);
     if (args[0] === "pr" && args[1] === "view") return "";
     return "";
@@ -727,7 +727,7 @@ test("GithubForge.ensureIssueLink: appends to empty body without leading newline
 
 test("GithubForge.ensureIssueLink: no-op when body already contains Closes #N", async () => {
   const calls: string[][] = [];
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     calls.push(args);
     if (args[0] === "pr" && args[1] === "view") return "Description\n\nCloses #3";
     return "";
@@ -739,7 +739,7 @@ test("GithubForge.ensureIssueLink: no-op when body already contains Closes #N", 
 
 test("GithubForge.ensureIssueLink: no-op when body contains a different closing keyword (Fixes #N)", async () => {
   const calls: string[][] = [];
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     calls.push(args);
     if (args[0] === "pr" && args[1] === "view") return "Description\n\nFixes #3";
     return "";
@@ -751,7 +751,7 @@ test("GithubForge.ensureIssueLink: no-op when body contains a different closing 
 
 test("GithubForge.ensureIssueLink: does not treat Closes #15 as a link for issue #1", async () => {
   const calls: string[][] = [];
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     calls.push(args);
     if (args[0] === "pr" && args[1] === "view") return "Description\n\nCloses #15";
     return "";
@@ -766,7 +766,7 @@ test("GithubForge.ensureIssueLink: null body (gh serializes body-less PR as lite
   // `gh pr view --json body -q '.body // empty'` returns empty string for a null body.
   // The old query `.body` returned the literal string "null", which corrupted the body.
   const calls: string[][] = [];
-  const run = (args: string[]): string => {
+  const run = async (args: string[]): Promise<string> => {
     calls.push(args);
     // Simulate the fixed jq query: `.body // empty` returns "" for a null body.
     // The -q arg is at index args.indexOf("-q") + 1; verify the query is correct.
@@ -786,4 +786,12 @@ test("GithubForge.ensureIssueLink: null body (gh serializes body-less PR as lite
   expect(editCall).toBeDefined();
   const bodyIdx = editCall.indexOf("--body");
   expect(editCall[bodyIdx + 1]).toBe("Closes #3");
+});
+
+test("GithubForge: a rejecting runner propagates as a rejected promise (fail-closed)", async () => {
+  const run = async (): Promise<string> => {
+    throw new Error("gh: network error");
+  };
+  const forge = new GithubForge("o/r", {}, run);
+  await expect(forge.listIssues()).rejects.toThrow("gh: network error");
 });

--- a/test/instrument.test.ts
+++ b/test/instrument.test.ts
@@ -1,14 +1,5 @@
-import { test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import {
-  timed,
-  timedAsync,
-  execFileSync,
-  readFileSync,
-  startLoopLagSampler,
-} from "../src/instrument";
+import { test, expect } from "bun:test";
+import { timed, timedAsync, execFileSync, startLoopLagSampler } from "../src/instrument";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -300,49 +291,5 @@ test(
   "execFileSync re-throws on error (profile on)",
   withProfile(() => {
     expect(() => execFileSync("false", [], { stdio: "pipe" })).toThrow();
-  }),
-);
-
-// ── readFileSync passthrough ──────────────────────────────────────────────────
-
-let tmpDir: string;
-beforeEach(() => {
-  tmpDir = mkdtempSync(join(tmpdir(), "shepherd-instr-"));
-});
-afterEach(() => {
-  rmSync(tmpDir, { recursive: true, force: true });
-});
-
-test(
-  "readFileSync returns file content (profile off)",
-  withoutProfile(() => {
-    const p = join(tmpDir, "test.txt");
-    writeFileSync(p, "hello world");
-    const result = readFileSync(p, "utf8");
-    expect(result).toBe("hello world");
-  }),
-);
-
-test(
-  "readFileSync returns file content (profile on)",
-  withProfile(() => {
-    const p = join(tmpDir, "test.txt");
-    writeFileSync(p, "hello world");
-    const result = readFileSync(p, "utf8");
-    expect(result).toBe("hello world");
-  }),
-);
-
-test(
-  "readFileSync re-throws on missing file (profile off)",
-  withoutProfile(() => {
-    expect(() => readFileSync(join(tmpDir, "nope.txt"), "utf8")).toThrow();
-  }),
-);
-
-test(
-  "readFileSync re-throws on missing file (profile on)",
-  withProfile(() => {
-    expect(() => readFileSync(join(tmpDir, "nope.txt"), "utf8")).toThrow();
   }),
 );

--- a/test/instrument.test.ts
+++ b/test/instrument.test.ts
@@ -2,7 +2,13 @@ import { test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { timed, timedAsync, execFileSync, readFileSync } from "../src/instrument";
+import {
+  timed,
+  timedAsync,
+  execFileSync,
+  readFileSync,
+  startLoopLagSampler,
+} from "../src/instrument";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -197,6 +203,73 @@ test(
     expect(logs.filter((l) => l.includes("[profile]"))).toHaveLength(0);
   }),
 );
+
+// ── startLoopLagSampler ───────────────────────────────────────────────────────
+
+test(
+  "startLoopLagSampler returns a callable stop fn when profiling is off (no timer started)",
+  withoutProfile(() => {
+    const logs: unknown[] = [];
+    const orig = console.warn;
+    console.warn = (...args: unknown[]) => logs.push(args);
+    let stop: (() => void) | undefined;
+    try {
+      stop = startLoopLagSampler();
+    } finally {
+      console.warn = orig;
+    }
+    // Must be callable
+    expect(typeof stop).toBe("function");
+    expect(() => stop!()).not.toThrow();
+    // No timer means no logging
+    expect(logs).toHaveLength(0);
+  }),
+);
+
+test(
+  "startLoopLagSampler returns a callable stop fn when profiling is on",
+  withProfile(() => {
+    const stop = startLoopLagSampler();
+    expect(typeof stop).toBe("function");
+    // Clean up immediately so the interval doesn't outlive this test
+    stop();
+  }),
+);
+
+test(
+  "startLoopLagSampler stop fn clears the interval — no further logging after stop",
+  withProfile(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        const logs: string[] = [];
+        const orig = console.warn;
+        console.warn = (msg: unknown) => logs.push(String(msg));
+
+        const stop = startLoopLagSampler();
+        // Stop immediately — the interval must not fire after this
+        stop();
+        console.warn = orig;
+
+        const countAfterStop = logs.length;
+        // Wait long enough for one interval period (50ms) to pass
+        setTimeout(() => {
+          try {
+            expect(logs.length).toBe(countAfterStop);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        }, 120);
+      }),
+  ),
+);
+
+// (d) Asserting a specific >[profile] loop-lag< log line requires the interval
+// callback to observe a fabricated >150ms lag, which needs Date.now to return
+// different values for the *closure-captured* `last` assignment inside the
+// setInterval callback vs. the later `now` read. That sequence is non-trivial
+// to control from outside without adding a production seam (injecting a clock).
+// Skipped in favour of the behavioural coverage above.
 
 // ── execFileSync passthrough ──────────────────────────────────────────────────
 

--- a/test/instrument.test.ts
+++ b/test/instrument.test.ts
@@ -1,0 +1,275 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { timed, timedAsync, execFileSync, readFileSync } from "../src/instrument";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function withProfile(fn: () => void | Promise<void>): () => Promise<void> {
+  return async () => {
+    const prev = process.env.SHEPHERD_PROFILE_LOOP;
+    process.env.SHEPHERD_PROFILE_LOOP = "1";
+    try {
+      await fn();
+    } finally {
+      if (prev === undefined) delete process.env.SHEPHERD_PROFILE_LOOP;
+      else process.env.SHEPHERD_PROFILE_LOOP = prev;
+    }
+  };
+}
+
+function withoutProfile(fn: () => void | Promise<void>): () => Promise<void> {
+  return async () => {
+    const prev = process.env.SHEPHERD_PROFILE_LOOP;
+    delete process.env.SHEPHERD_PROFILE_LOOP;
+    try {
+      await fn();
+    } finally {
+      if (prev !== undefined) process.env.SHEPHERD_PROFILE_LOOP = prev;
+    }
+  };
+}
+
+// ── timed — return value ──────────────────────────────────────────────────────
+
+test(
+  "timed returns wrapped value (profile on)",
+  withProfile(() => {
+    const result = timed("test", () => 42);
+    expect(result).toBe(42);
+  }),
+);
+
+test(
+  "timed returns wrapped value (profile off)",
+  withoutProfile(() => {
+    const result = timed("test", () => 42);
+    expect(result).toBe(42);
+  }),
+);
+
+// ── timed — error re-throw ────────────────────────────────────────────────────
+
+test(
+  "timed re-throws errors (profile on)",
+  withProfile(() => {
+    const boom = new Error("boom");
+    expect(() =>
+      timed("test", () => {
+        throw boom;
+      }),
+    ).toThrow(boom);
+  }),
+);
+
+test(
+  "timed re-throws errors (profile off)",
+  withoutProfile(() => {
+    const boom = new Error("boom");
+    expect(() =>
+      timed("test", () => {
+        throw boom;
+      }),
+    ).toThrow(boom);
+  }),
+);
+
+// ── timedAsync — return value ─────────────────────────────────────────────────
+
+test(
+  "timedAsync returns wrapped value (profile on)",
+  withProfile(async () => {
+    const result = await timedAsync("test", async () => "hello");
+    expect(result).toBe("hello");
+  }),
+);
+
+test(
+  "timedAsync returns wrapped value (profile off)",
+  withoutProfile(async () => {
+    const result = await timedAsync("test", async () => "hello");
+    expect(result).toBe("hello");
+  }),
+);
+
+// ── timedAsync — error re-throw ───────────────────────────────────────────────
+
+test(
+  "timedAsync re-throws errors (profile on)",
+  withProfile(async () => {
+    const boom = new Error("async-boom");
+    await expect(
+      timedAsync("test", async () => {
+        throw boom;
+      }),
+    ).rejects.toThrow(boom);
+  }),
+);
+
+test(
+  "timedAsync re-throws errors (profile off)",
+  withoutProfile(async () => {
+    const boom = new Error("async-boom");
+    await expect(
+      timedAsync("test", async () => {
+        throw boom;
+      }),
+    ).rejects.toThrow(boom);
+  }),
+);
+
+// ── threshold: fast fn should not log ────────────────────────────────────────
+
+test(
+  "timed does not log for fast function (profile on)",
+  withProfile(() => {
+    const logs: unknown[] = [];
+    const orig = console.warn;
+    console.warn = (...args: unknown[]) => logs.push(args);
+    try {
+      timed("fast", () => 1);
+    } finally {
+      console.warn = orig;
+    }
+    expect(logs).toHaveLength(0);
+  }),
+);
+
+test(
+  "timedAsync does not log for fast async function (profile on)",
+  withProfile(async () => {
+    const logs: unknown[] = [];
+    const orig = console.warn;
+    console.warn = (...args: unknown[]) => logs.push(args);
+    try {
+      await timedAsync("fast-async", async () => 1);
+    } finally {
+      console.warn = orig;
+    }
+    expect(logs).toHaveLength(0);
+  }),
+);
+
+// ── threshold: slow fn should log ────────────────────────────────────────────
+
+test(
+  "timed logs when fn exceeds 250ms threshold (profile on)",
+  withProfile(async () => {
+    const logs: string[] = [];
+    const orig = console.warn;
+    console.warn = (msg: unknown) => logs.push(String(msg));
+    try {
+      // Simulate slow fn by overriding Date.now temporarily
+      let callCount = 0;
+      const origNow = Date.now;
+      Date.now = () => {
+        // first call = start, second call = after fn = start + 300ms
+        return callCount++ === 0 ? origNow() : origNow() + 300;
+      };
+      try {
+        timed("slow-op", () => "done");
+      } finally {
+        Date.now = origNow;
+      }
+    } finally {
+      console.warn = orig;
+    }
+    expect(logs.some((l) => l.includes("[profile]") && l.includes("slow-op"))).toBe(true);
+  }),
+);
+
+test(
+  "timed does not log when profiling is off (even if slow)",
+  withoutProfile(async () => {
+    const logs: string[] = [];
+    const orig = console.warn;
+    console.warn = (msg: unknown) => logs.push(String(msg));
+    let callCount = 0;
+    const origNow = Date.now;
+    Date.now = () => (callCount++ === 0 ? origNow() : origNow() + 300);
+    try {
+      timed("slow-off", () => "done");
+    } finally {
+      Date.now = origNow;
+      console.warn = orig;
+    }
+    expect(logs.filter((l) => l.includes("[profile]"))).toHaveLength(0);
+  }),
+);
+
+// ── execFileSync passthrough ──────────────────────────────────────────────────
+
+test(
+  "execFileSync passes through correctly (profile off)",
+  withoutProfile(() => {
+    const result = execFileSync("echo", ["hi"], { encoding: "utf8" });
+    expect(result.trim()).toBe("hi");
+  }),
+);
+
+test(
+  "execFileSync passes through correctly (profile on)",
+  withProfile(() => {
+    const result = execFileSync("echo", ["hi"], { encoding: "utf8" });
+    expect(result.trim()).toBe("hi");
+  }),
+);
+
+test(
+  "execFileSync re-throws on error (profile off)",
+  withoutProfile(() => {
+    expect(() => execFileSync("false", [], { stdio: "pipe" })).toThrow();
+  }),
+);
+
+test(
+  "execFileSync re-throws on error (profile on)",
+  withProfile(() => {
+    expect(() => execFileSync("false", [], { stdio: "pipe" })).toThrow();
+  }),
+);
+
+// ── readFileSync passthrough ──────────────────────────────────────────────────
+
+let tmpDir: string;
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "shepherd-instr-"));
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test(
+  "readFileSync returns file content (profile off)",
+  withoutProfile(() => {
+    const p = join(tmpDir, "test.txt");
+    writeFileSync(p, "hello world");
+    const result = readFileSync(p, "utf8");
+    expect(result).toBe("hello world");
+  }),
+);
+
+test(
+  "readFileSync returns file content (profile on)",
+  withProfile(() => {
+    const p = join(tmpDir, "test.txt");
+    writeFileSync(p, "hello world");
+    const result = readFileSync(p, "utf8");
+    expect(result).toBe("hello world");
+  }),
+);
+
+test(
+  "readFileSync re-throws on missing file (profile off)",
+  withoutProfile(() => {
+    expect(() => readFileSync(join(tmpDir, "nope.txt"), "utf8")).toThrow();
+  }),
+);
+
+test(
+  "readFileSync re-throws on missing file (profile on)",
+  withProfile(() => {
+    expect(() => readFileSync(join(tmpDir, "nope.txt"), "utf8")).toThrow();
+  }),
+);

--- a/test/no-sync-exec.test.ts
+++ b/test/no-sync-exec.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression guard: no src/ file may import `execFileSync` from "node:child_process".
+ * All blocking sync exec must route through ./instrument (or ../instrument) so it's
+ * profiled under SHEPHERD_PROFILE_LOOP=1.
+ *
+ * The only allowlisted file is src/instrument.ts itself (the wrapper definition).
+ */
+import { test, expect } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const SRC_ROOT = join(import.meta.dir, "..", "src");
+
+/** Walk a directory tree and return all .ts file paths. */
+function collectTs(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectTs(full));
+    } else if (entry.isFile() && entry.name.endsWith(".ts")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Matches any import statement that pulls `execFileSync` from "node:child_process".
+ * Handles: named import in a list, e.g.
+ *   import { execFileSync } from "node:child_process"
+ *   import { execFile, execFileSync, spawn } from "node:child_process"
+ */
+const PATTERN = /import\s*\{[^}]*\bexecFileSync\b[^}]*\}\s*from\s*["']node:child_process["']/;
+
+/** Allowlist: files permitted to import execFileSync from node:child_process. */
+const ALLOWLIST = new Set(["src/instrument.ts"]);
+
+test("no src file imports execFileSync from node:child_process (use ./instrument instead)", () => {
+  const violations: string[] = [];
+
+  for (const file of collectTs(SRC_ROOT)) {
+    const rel = relative(join(SRC_ROOT, ".."), file); // relative to repo root
+    if (ALLOWLIST.has(rel)) continue;
+
+    const src = readFileSync(file, "utf8");
+    if (PATTERN.test(src)) {
+      violations.push(rel);
+    }
+  }
+
+  expect(
+    violations,
+    [
+      "These files import execFileSync from node:child_process directly.",
+      "Import it from ./instrument (or ../instrument) instead, so it's profiled.",
+      "Violations:",
+      ...violations,
+    ].join("\n"),
+  ).toEqual([]);
+});

--- a/test/no-sync-exec.test.ts
+++ b/test/no-sync-exec.test.ts
@@ -27,14 +27,27 @@ function collectTs(dir: string): string[] {
 
 /**
  * Matches any import statement that pulls `execFileSync` from "node:child_process".
- * Handles: named import in a list, e.g.
+ * Handles single-line and multi-line named imports, e.g.
  *   import { execFileSync } from "node:child_process"
  *   import { execFile, execFileSync, spawn } from "node:child_process"
+ *   import {
+ *     execFileSync,
+ *   } from "node:child_process"
  */
-const PATTERN = /import\s*\{[^}]*\bexecFileSync\b[^}]*\}\s*from\s*["']node:child_process["']/;
+const PATTERN = /import\s*\{[\s\S]*?\bexecFileSync\b[\s\S]*?\}\s*from\s*["']node:child_process["']/;
 
 /** Allowlist: files permitted to import execFileSync from node:child_process. */
 const ALLOWLIST = new Set(["src/instrument.ts"]);
+
+test("PATTERN matches a multi-line execFileSync import (self-check)", () => {
+  const multiLine = `import {\n  execFileSync,\n} from "node:child_process"`;
+  expect(PATTERN.test(multiLine)).toBe(true);
+});
+
+test("PATTERN does not match an async execFile import (no false positive)", () => {
+  const asyncOnly = `import { execFile, spawn } from "node:child_process"`;
+  expect(PATTERN.test(asyncOnly)).toBe(false);
+});
 
 test("no src file imports execFileSync from node:child_process (use ./instrument instead)", () => {
   const violations: string[] = [];

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -29,7 +29,7 @@ function harness(over: any = {}) {
       stop() {},
     },
     worktree: {
-      createDetached: () => ({ worktreePath: "/wt-detached", branch: "main" }),
+      createDetached: async () => ({ worktreePath: "/wt-detached", branch: "main" }),
       remove: (p: string) => removed.push(p),
     },
     reply: () => true,

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -351,7 +351,7 @@ test("rebase with identical diff: skips the critic, re-points head, preserves th
     removed,
     bumped,
   } = makeDeps({
-    computePatchId: () => "pid-same",
+    computePatchId: async () => "pid-same",
   });
   // prior verdict was for head "old"; the branch is force-pushed/rebased to "newsha"
   // but its diff is identical → same patch-id.
@@ -367,7 +367,7 @@ test("rebase with identical diff: skips the critic, re-points head, preserves th
 });
 
 test("new commit (different diff): reviews and records the new fingerprint", async () => {
-  const { deps: d, reviews, started, bumped } = makeDeps({ computePatchId: () => "pid-new" });
+  const { deps: d, reviews, started, bumped } = makeDeps({ computePatchId: async () => "pid-new" });
   reviews["s1"] = priorReview({ patchId: "pid-old", headSha: "old" });
   const svc = new ReviewService(d as any);
   await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
@@ -378,7 +378,7 @@ test("new commit (different diff): reviews and records the new fingerprint", asy
 });
 
 test("first review records the fingerprint for later rebase-skip", async () => {
-  const { deps: d, reviews, started } = makeDeps({ computePatchId: () => "pid-first" });
+  const { deps: d, reviews, started } = makeDeps({ computePatchId: async () => "pid-first" });
   const svc = new ReviewService(d as any);
   await svc.consider(session(), OPEN_GREEN); // no prior
   expect(started).toHaveLength(1);
@@ -387,7 +387,7 @@ test("first review records the fingerprint for later rebase-skip", async () => {
 });
 
 test("unresolvable fingerprint never skips: reviews even with a prior verdict", async () => {
-  const { deps: d, reviews, started, bumped } = makeDeps({ computePatchId: () => null });
+  const { deps: d, reviews, started, bumped } = makeDeps({ computePatchId: async () => null });
   // prior has a real patch-id, but this run can't fingerprint (git failed / empty diff)
   reviews["s1"] = priorReview({ patchId: "pid-old", headSha: "old" });
   const svc = new ReviewService(d as any);
@@ -397,7 +397,12 @@ test("unresolvable fingerprint never skips: reviews even with a prior verdict", 
 });
 
 test("prior error verdict never rebase-skips (retries the transient failure)", async () => {
-  const { deps: d, reviews, started, bumped } = makeDeps({ computePatchId: () => "pid-same" });
+  const {
+    deps: d,
+    reviews,
+    started,
+    bumped,
+  } = makeDeps({ computePatchId: async () => "pid-same" });
   // an errored prior that (legacy row / defensive) still carries a matching fingerprint
   reviews["s1"] = priorReview({ decision: "error", patchId: "pid-same", headSha: "old" });
   const svc = new ReviewService(d as any);
@@ -408,7 +413,7 @@ test("prior error verdict never rebase-skips (retries the transient failure)", a
 
 test("error verdict records no fingerprint (so a later head always re-reviews)", async () => {
   const { deps: d, reviews } = makeDeps({
-    computePatchId: () => "pid-x",
+    computePatchId: async () => "pid-x",
     readVerdict: () => ({ decision: "bogus", summary: "?", body: "" }), // unparseable → error
   });
   const svc = new ReviewService(d as any);
@@ -424,7 +429,7 @@ test("rebase-skip short-circuits before any forge call (no author-notes fetch)",
     reviews,
     started,
     commentCalls,
-  } = makeDeps({ computePatchId: () => "pid-same" }, { autoAddressEnabled: true });
+  } = makeDeps({ computePatchId: async () => "pid-same" }, { autoAddressEnabled: true });
   reviews["s1"] = priorReview({ patchId: "pid-same", headSha: "old" }); // has findings
   const svc = new ReviewService(d as any);
   await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -128,7 +128,7 @@ function makeDeps(
       stop: (t: string) => stopped.push(t),
     },
     worktree: {
-      createDetached: () => ({ worktreePath: "/review-wt", branch: null, isolated: true }),
+      createDetached: async () => ({ worktreePath: "/review-wt", branch: null, isolated: true }),
       remove: (p: string) => removed.push(p),
     },
     resolveForge: () => fakeForge(rec, opts.comments ?? [], commentCalls, opts.prStatus),
@@ -166,7 +166,7 @@ test("reviewPrompt embeds base + task and asks for the verdict file", () => {
 test("consider → tick: posts request-changes, persists, reaps", async () => {
   const { deps: d, reviews, started, stopped, removed, rec } = makeDeps({});
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   expect(started).toHaveLength(1);
   expect(started[0]!.name).toBe("review TASK-01");
   await svc.tick();
@@ -187,7 +187,7 @@ test("onReviewing fires true on spawn and false on finalize", async () => {
     onReviewing: (id: string, reviewing: boolean) => events.push({ id, reviewing }),
   });
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   expect(events).toEqual([{ id: "s1", reviewing: true }]);
   await svc.tick();
   expect(events).toEqual([
@@ -196,13 +196,13 @@ test("onReviewing fires true on spawn and false on finalize", async () => {
   ]);
 });
 
-test("onReviewing fires false when an in-flight critic is forgotten", () => {
+test("onReviewing fires false when an in-flight critic is forgotten", async () => {
   const events: { id: string; reviewing: boolean }[] = [];
   const { deps: d } = makeDeps({
     onReviewing: (id: string, reviewing: boolean) => events.push({ id, reviewing }),
   });
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   svc.forget("s1");
   expect(events).toEqual([
     { id: "s1", reviewing: true },
@@ -210,9 +210,9 @@ test("onReviewing fires false when an in-flight critic is forgotten", () => {
   ]);
 });
 
-test("critic spawns read-only: no skip-permissions, dontAsk + scoped allowlist", () => {
+test("critic spawns read-only: no skip-permissions, dontAsk + scoped allowlist", async () => {
   const { deps: d, started } = makeDeps({});
-  new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
   const argv = started[0]!.argv;
   // an untrusted PR diff must not be able to escalate to command execution
   expect(argv).not.toContain("--dangerously-skip-permissions");
@@ -233,9 +233,9 @@ test("critic spawns read-only: no skip-permissions, dontAsk + scoped allowlist",
   expect(argv).toContain("--safe-mode");
 });
 
-test("task prompt survives the variadic allowlist (not swallowed → no task → timeout)", () => {
+test("task prompt survives the variadic allowlist (not swallowed → no task → timeout)", async () => {
   const { deps: d, started } = makeDeps({});
-  new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
   const argv = started[0]!.argv;
   // `--allowedTools <tools...>` is variadic: it greedily eats every following
   // token until the next flag. The task prompt is the trailing positional, so a
@@ -255,9 +255,9 @@ test("task prompt survives the variadic allowlist (not swallowed → no task →
 test("does not review the same head twice", async () => {
   const { deps: d, started } = makeDeps({});
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   await svc.tick();
-  svc.consider(session(), OPEN_GREEN); // same headSha already reviewed
+  await svc.consider(session(), OPEN_GREEN); // same headSha already reviewed
   expect(started).toHaveLength(1);
 });
 
@@ -297,7 +297,7 @@ test("timeout with no verdict → error verdict, still reaps", async () => {
     timeoutMs: 5000,
   });
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   t = 1000 + 6000;
   await svc.tick();
   expect(reviews["s1"]?.decision).toBe("error");
@@ -310,15 +310,15 @@ test("comment decision maps to COMMENT and never approves", async () => {
     readVerdict: () => ({ decision: "comment", summary: "ok", body: "lgtm-ish" }),
   });
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   await svc.tick();
   expect(rec.event).toBe("COMMENT");
 });
 
-test("forget reaps an in-flight critic and drops the stored review", () => {
+test("forget reaps an in-flight critic and drops the stored review", async () => {
   const { deps: d, reviews, stopped, removed } = makeDeps({});
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN); // now in-flight
+  await svc.consider(session(), OPEN_GREEN); // now in-flight
   reviews["s1"] = {
     sessionId: "s1",
     headSha: "abc",
@@ -472,7 +472,7 @@ test("auto-address on: feeds findings back to the agent and advances the round",
     { autoAddressEnabled: true },
   );
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   await svc.tick();
   // even a NON-blocking comment is steered back — "shouldn't get off easily"
   expect(steers).toHaveLength(1);
@@ -502,7 +502,7 @@ test("auto-address off: never steers even with findings", async () => {
     { autoAddressEnabled: false },
   );
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   await svc.tick();
   expect(steers).toHaveLength(0);
 });
@@ -603,7 +603,7 @@ test("PR merged before finalize: verdict is moot — no review posted, no steer,
     { autoAddressEnabled: true, prStatus: async () => ({ ...OPEN_GREEN, state: "merged" }) },
   );
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN); // spawn while open (no prStatus call yet)
+  await svc.consider(session(), OPEN_GREEN); // spawn while open (no prStatus call yet)
   await svc.tick(); // finalize: live recheck sees "merged" → fully inert
   expect(steers).toHaveLength(0); // no churn steered onto a merged branch
   expect(rec.event).toBeUndefined(); // moot: no review posted on a merged PR
@@ -628,7 +628,7 @@ test("PR-state recheck throws: fail-closed — fully inert", async () => {
     },
   );
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   await svc.tick(); // must NOT reject
   expect(steers).toHaveLength(0); // can't confirm open → don't steer
   expect(rec.event).toBeUndefined(); // …and don't post the review
@@ -645,7 +645,7 @@ test("PR closed (not merged) before finalize: also fully inert", async () => {
     { autoAddressEnabled: true, prStatus: async () => ({ ...OPEN_GREEN, state: "closed" }) },
   );
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   await svc.tick();
   expect(steers).toHaveLength(0); // guard is state !== "open", not just merged
   expect(rec.event).toBeUndefined(); // closed PR → review not posted
@@ -715,7 +715,7 @@ test("dead agent pane: steer attempted but the round does not advance", async ()
     { autoAddressEnabled: true, autoAddressReturns: false }, // reply() → false (pane gone)
   );
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   await svc.tick();
   expect(steers).toHaveLength(1); // attempted
   expect(reviews["s1"]?.addressRound).toBe(0); // but no progress was made
@@ -757,7 +757,7 @@ test("the steer tells the agent to post a declined finding as a PR comment", asy
     { autoAddressEnabled: true },
   );
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN); // first review (no prior) → sync spawn
+  await svc.consider(session(), OPEN_GREEN); // first review
   await svc.tick();
   expect(steers[0]!.text).toContain("gh pr comment 7"); // PR number from OPEN_GREEN.number
   expect(steers[0]!.text).toContain(AUTHOR_RESPONSE_MARKER);
@@ -794,9 +794,9 @@ test("re-review fetches the author's PR notes and injects them into the prompt",
   expect(prompt).not.toContain("unrelated chatter"); // unmarked comment ignored
 });
 
-test("first review does NOT fetch author notes", () => {
+test("first review does NOT fetch author notes", async () => {
   const { deps: d, commentCalls } = makeDeps({}, { autoAddressEnabled: true });
-  new ReviewService(d as any).consider(session(), OPEN_GREEN); // no prior → first review
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN); // no prior → first review
   expect(commentCalls).toEqual([]);
 });
 
@@ -825,7 +825,7 @@ test("steer that throws (dead pane) is not-delivered and still finalizes + reaps
     { autoAddressEnabled: true },
   );
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN); // first review (no prior) → sync spawn
+  await svc.consider(session(), OPEN_GREEN); // first review
   await svc.tick(); // must NOT reject
   expect(reviews["s1"]?.decision).toBe("commented"); // verdict persisted
   expect(reviews["s1"]?.addressRound).toBe(0); // throw = not delivered → round held
@@ -859,7 +859,7 @@ test("forget() during the re-review await aborts the spawn (no critic for an arc
 test("verdict surfaces the configured cap so the UI need not mirror it", async () => {
   const { deps: d, reviews } = makeDeps({ cap: 5 });
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   await svc.tick();
   expect(reviews["s1"]?.addressCap).toBe(5); // ReviewService({cap}) → verdict payload
 });
@@ -868,12 +868,12 @@ test("a cap thunk is resolved live so a settings change applies without a restar
   let live = 3; // stands in for config.prReviewCyclesCap
   const { deps: d, reviews } = makeDeps({ cap: () => live });
   const svc = new ReviewService(d as any);
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   await svc.tick();
   expect(reviews["s1"]?.addressCap).toBe(3); // first run reads the thunk's current value
   live = 7; // operator bumps the global setting mid-run
   delete reviews["s1"]; // force a fresh verdict on the next run
-  svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
   await svc.tick();
   expect(reviews["s1"]?.addressCap).toBe(7); // new cap takes effect, no reconstruction
 });

--- a/test/signal-capture.test.ts
+++ b/test/signal-capture.test.ts
@@ -64,13 +64,21 @@ test("critic changes_requested records a 'critic' signal", async () => {
   const svc = new ReviewService({
     store,
     herdr: { start: () => ({ terminalId: "rev1" }), stop: () => {} } as any,
-    worktree: { createDetached: () => ({ worktreePath: "/rev-wt" }), remove: () => {} } as any,
+    worktree: {
+      createDetached: async () => ({ worktreePath: "/rev-wt" }),
+      remove: () => {},
+    } as any,
     resolveForge: () => fakeForge,
     onChange: () => {},
     now: () => 1,
     readVerdict: () => ({ decision: "request-changes", summary: "2 issues", body: "## findings" }),
   });
-  svc.consider(session, { state: "open", checks: "success", headSha: "abc", number: 7 } as any);
+  await svc.consider(session, {
+    state: "open",
+    checks: "success",
+    headSha: "abc",
+    number: 7,
+  } as any);
   await svc.tick();
   const sigs = store.listSignals("/repo");
   expect(sigs.length).toBe(1);

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -11,7 +11,7 @@ function freshLog(): string {
 
 /** Build a git runner from a map of "joined args" → stdout. */
 function fakeGit(responses: Record<string, string>): GitRunner {
-  return (args) => {
+  return async (args) => {
     const key = args.join(" ");
     if (!(key in responses)) throw new Error(`unexpected git: ${key}`);
     return responses[key]!;
@@ -34,9 +34,9 @@ const BEHIND_TWO = {
     "def5678\tfeat(ui): add update badge\nbbb2222\tfix(server): guard route\n",
 };
 
-test("up to date → behind 0, no commits", () => {
+test("up to date → behind 0, no commits", async () => {
   const svc = new UpdateService({ git: fakeGit(UP_TO_DATE), launch: () => {} });
-  const s = svc.check(1000);
+  const s = await svc.check(1000);
   expect(s.behind).toBe(0);
   expect(s.commits).toEqual([]);
   expect(s.current).toBe("abc1234");
@@ -44,9 +44,9 @@ test("up to date → behind 0, no commits", () => {
   expect(s.error).toBeUndefined();
 });
 
-test("behind main → behind count + parsed commit list (newest first)", () => {
+test("behind main → behind count + parsed commit list (newest first)", async () => {
   const svc = new UpdateService({ git: fakeGit(BEHIND_TWO), launch: () => {} });
-  const s = svc.check(2000);
+  const s = await svc.check(2000);
   expect(s.behind).toBe(2);
   expect(s.current).toBe("abc1234");
   expect(s.latest).toBe("def5678");
@@ -56,7 +56,7 @@ test("behind main → behind count + parsed commit list (newest first)", () => {
   ]);
 });
 
-test("subjects containing tabs survive parsing", () => {
+test("subjects containing tabs survive parsing", async () => {
   const svc = new UpdateService({
     git: fakeGit({
       ...BEHIND_TWO,
@@ -65,27 +65,47 @@ test("subjects containing tabs survive parsing", () => {
     }),
     launch: () => {},
   });
-  const s = svc.check(3000);
+  const s = await svc.check(3000);
   expect(s.commits).toEqual([{ sha: "def5678", subject: "fix: a\tb\tc" }]);
 });
 
-test("git failure fails safe to behind 0 with an error", () => {
+test("git failure fails safe to behind 0 with an error", async () => {
   const svc = new UpdateService({
-    git: () => {
+    git: async () => {
       throw new Error("network down");
     },
     launch: () => {},
   });
-  const s = svc.check(4000);
+  const s = await svc.check(4000);
   expect(s.behind).toBe(0);
   expect(s.error).toContain("network down");
 });
 
-test("current() caches the last check", () => {
+test("current() caches the last check", async () => {
   const svc = new UpdateService({ git: fakeGit(BEHIND_TWO), launch: () => {} });
   expect(svc.current()).toBeNull();
-  svc.check(5000);
+  await svc.check(5000);
   expect(svc.current()?.behind).toBe(2);
+});
+
+test("rejecting async git runner fails safe: behind 0, error set, current preserved", async () => {
+  // First check succeeds so `current` is populated; second rejects so we can verify
+  // the fail-safe preserves the prior `current` value instead of wiping it.
+  let callCount = 0;
+  const svc = new UpdateService({
+    git: async (args) => {
+      if (callCount++ < 4) return fakeGit(UP_TO_DATE)(args); // first check succeeds
+      throw new Error("network timeout");
+    },
+    launch: () => {},
+  });
+  const first = await svc.check(1000);
+  expect(first.behind).toBe(0);
+  expect(first.current).toBe("abc1234");
+  const second = await svc.check(2000);
+  expect(second.behind).toBe(0);
+  expect(second.error).toContain("network timeout");
+  expect(second.current).toBe("abc1234"); // preserved from prior check
 });
 
 test("apply() launches once and guards double-launch with a reason", () => {

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -209,7 +209,7 @@ test("createDetached: rejects a branch that could smuggle a git flag", async () 
   await expect(mgr.createDetached(repo, "-x", sha)).rejects.toThrow("invalid branch");
 });
 
-test("createDetached: distinct slugs at the SAME sha get distinct worktrees (no plan-review collision)", () => {
+test("createDetached: distinct slugs at the SAME sha get distinct worktrees (no plan-review collision)", async () => {
   const env = {
     ...process.env,
     GIT_AUTHOR_NAME: "t",
@@ -226,13 +226,13 @@ test("createDetached: distinct slugs at the SAME sha get distinct worktrees (no 
   const mgr = new WorktreeMgr();
   // Two sessions' plan reviews both detach at the same base sha — they must NOT share a path,
   // else a second begin() destroys the first's worktree and both read one verdict file.
-  const a = mgr.createDetached(repo, "feat/x", sha, "session-aaaa");
-  const b = mgr.createDetached(repo, "feat/x", sha, "session-bbbb");
+  const a = await mgr.createDetached(repo, "feat/x", sha, "session-aaaa");
+  const b = await mgr.createDetached(repo, "feat/x", sha, "session-bbbb");
   expect(a.worktreePath).not.toBe(b.worktreePath);
   expect(existsSync(a.worktreePath)).toBe(true);
   expect(existsSync(b.worktreePath)).toBe(true);
   // a slugless detach (the PR critic) stays distinct from the slugged ones too
-  const c = mgr.createDetached(repo, "feat/x", sha);
+  const c = await mgr.createDetached(repo, "feat/x", sha);
   expect(c.worktreePath).not.toBe(a.worktreePath);
   expect(c.worktreePath).not.toBe(b.worktreePath);
 
@@ -241,11 +241,11 @@ test("createDetached: distinct slugs at the SAME sha get distinct worktrees (no 
   mgr.remove(c.worktreePath);
 });
 
-test("createDetached: rejects a slug that could escape the worktree dir", () => {
+test("createDetached: rejects a slug that could escape the worktree dir", async () => {
   const mgr = new WorktreeMgr();
   const sha = "0".repeat(40);
-  expect(() => mgr.createDetached(repo, "main", sha, "../escape")).toThrow("invalid slug");
-  expect(() => mgr.createDetached(repo, "main", sha, "a/b")).toThrow("invalid slug");
+  await expect(mgr.createDetached(repo, "main", sha, "../escape")).rejects.toThrow("invalid slug");
+  await expect(mgr.createDetached(repo, "main", sha, "a/b")).rejects.toThrow("invalid slug");
 });
 
 test("commitsAhead: 0 when branch tip == base, >0 after a commit", () => {

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -49,10 +49,10 @@ test("currentBranch reports the worktree's checked-out branch and follows a rena
   wt.remove(r.worktreePath);
 });
 
-test("currentBranch returns null on a detached HEAD", () => {
+test("currentBranch returns null on a detached HEAD", async () => {
   const wt = new WorktreeMgr();
   const sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo }).toString().trim();
-  const r = wt.createDetached(repo, "main", sha);
+  const r = await wt.createDetached(repo, "main", sha);
   expect(wt.currentBranch(r.worktreePath)).toBeNull();
   wt.remove(r.worktreePath);
 });
@@ -170,7 +170,7 @@ test("create with semicolon in baseBranch throws", () => {
   expect(() => wt.create(repo, "feat;rm -rf /", "x")).toThrow("invalid baseBranch");
 });
 
-test("createDetached: checks out a detached worktree at the given sha", () => {
+test("createDetached: checks out a detached worktree at the given sha", async () => {
   const env = {
     ...process.env,
     GIT_AUTHOR_NAME: "t",
@@ -186,7 +186,7 @@ test("createDetached: checks out a detached worktree at the given sha", () => {
   const sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo }).toString().trim();
 
   const mgr = new WorktreeMgr();
-  const wt = mgr.createDetached(repo, "feat/x", sha);
+  const wt = await mgr.createDetached(repo, "feat/x", sha);
 
   expect(existsSync(wt.worktreePath)).toBe(true);
   expect(wt.branch).toBeNull();
@@ -200,11 +200,13 @@ test("createDetached: checks out a detached worktree at the given sha", () => {
   expect(existsSync(wt.worktreePath)).toBe(false);
 });
 
-test("createDetached: rejects a branch that could smuggle a git flag", () => {
+test("createDetached: rejects a branch that could smuggle a git flag", async () => {
   const mgr = new WorktreeMgr();
   const sha = "0".repeat(40);
-  expect(() => mgr.createDetached(repo, "--upload-pack=evil", sha)).toThrow("invalid branch");
-  expect(() => mgr.createDetached(repo, "-x", sha)).toThrow("invalid branch");
+  await expect(mgr.createDetached(repo, "--upload-pack=evil", sha)).rejects.toThrow(
+    "invalid branch",
+  );
+  await expect(mgr.createDetached(repo, "-x", sha)).rejects.toThrow("invalid branch");
 });
 
 test("createDetached: distinct slugs at the SAME sha get distinct worktrees (no plan-review collision)", () => {
@@ -264,7 +266,7 @@ test("commitsAhead: 0 when branch tip == base, >0 after a commit", () => {
   expect(wt.commitsAhead(repo, "main", "feat")).toBe(1);
 });
 
-test("createDetached: reclaims a stale worktree path left by an interrupted run", () => {
+test("createDetached: reclaims a stale worktree path left by an interrupted run", async () => {
   const env = {
     ...process.env,
     GIT_AUTHOR_NAME: "t",
@@ -279,10 +281,10 @@ test("createDetached: reclaims a stale worktree path left by an interrupted run"
   const sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo }).toString().trim();
 
   const mgr = new WorktreeMgr();
-  const first = mgr.createDetached(repo, "feat/x", sha);
+  const first = await mgr.createDetached(repo, "feat/x", sha);
   // simulate a restart: the in-memory inflight record is gone but the worktree
   // dir + registration remain. A re-spawn for the same head must still succeed.
-  const second = mgr.createDetached(repo, "feat/x", sha);
+  const second = await mgr.createDetached(repo, "feat/x", sha);
   expect(second.worktreePath).toBe(first.worktreePath);
   expect(existsSync(second.worktreePath)).toBe(true);
   const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: second.worktreePath })
@@ -293,7 +295,7 @@ test("createDetached: reclaims a stale worktree path left by an interrupted run"
   mgr.remove(second.worktreePath);
 });
 
-test("behindBase: false when up-to-date, true when base advanced", () => {
+test("behindBase: false when up-to-date, true when base advanced", async () => {
   const dir = mkdtempSync(join(tmpdir(), "wt-"));
   execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir, stdio: "pipe" });
   execFileSync("git", ["config", "user.email", "t@t"], { cwd: dir, stdio: "pipe" });
@@ -307,13 +309,13 @@ test("behindBase: false when up-to-date, true when base advanced", () => {
   execFileSync("git", ["commit", "-qm", "feat"], { cwd: dir, stdio: "pipe" });
   const wt = new WorktreeMgr();
   // feat contains main's tip → up-to-date
-  expect(wt.behindBase(dir, "main")).toBe(false);
+  expect(await wt.behindBase(dir, "main")).toBe(false);
   // advance main beyond feat
   execFileSync("git", ["checkout", "-q", "main"], { cwd: dir, stdio: "pipe" });
   writeFileSync(join(dir, "c"), "1");
   execFileSync("git", ["add", "."], { cwd: dir, stdio: "pipe" });
   execFileSync("git", ["commit", "-qm", "main2"], { cwd: dir, stdio: "pipe" });
   execFileSync("git", ["checkout", "-q", "feat"], { cwd: dir, stdio: "pipe" });
-  expect(wt.behindBase(dir, "main")).toBe(true);
+  expect(await wt.behindBase(dir, "main")).toBe(true);
   rmSync(dir, { recursive: true, force: true });
 });

--- a/ui/src/lib/pty.ts
+++ b/ui/src/lib/pty.ts
@@ -77,9 +77,11 @@ export function connectPty(
   let fastFails = 0;
   const FAST_FAIL_MS = 4000;
   const MAX_FAST_FAILS = 8;
-  // echo RTT: timestamp of the last real input send (0 = none pending). First
-  // server message clears it, so an unsolicited server push (running process
-  // output) may clear it early — send→first-echo is approximate.
+  // echo RTT: timestamp of the last real input send (0 = none pending).
+  // Cleared by the first server message after a send, so measurement is
+  // send→first-server-message, not send→echo. A concurrent unsolicited server
+  // push (e.g. a running process emitting output) may clear it early —
+  // the measured RTT is approximate.
   let _pendingSendTime = 0;
 
   const open = () => {
@@ -94,7 +96,7 @@ export function connectPty(
     ws.onmessage = (e) => {
       if (_profileEnabled && _pendingSendTime !== 0) {
         const rtt = Date.now() - _pendingSendTime;
-        _pendingSendTime = 0;
+        _pendingSendTime = 0; // fast path — not logged; intentional: sub-threshold RTT clears pending state without noise
         if (rtt > ECHO_RTT_THRESHOLD_MS) {
           console.warn(`[profile] echo-rtt ${rtt}ms`);
         }

--- a/ui/src/lib/pty.ts
+++ b/ui/src/lib/pty.ts
@@ -1,5 +1,17 @@
 import { wsUrl } from "./store.svelte";
 
+// ── browser-side echo RTT profiling ──────────────────────────────────────────
+// Enabled by setting localStorage key "shepherd:profile" = "1".
+// Logs `[profile] echo-rtt <N>ms` to console.warn when RTT > 150ms.
+// All cost is skipped when the flag is off.
+const ECHO_RTT_THRESHOLD_MS = 150;
+let _profileEnabled = false;
+try {
+  _profileEnabled = localStorage.getItem("shepherd:profile") === "1";
+} catch {
+  /* localStorage unavailable (e.g. SSR or sandboxed context) */
+}
+
 // Server closes a pty WS with this code when a newer client takes over the
 // terminal. We park instead of reconnecting, so two devices on the same session
 // don't ping-pong the attach. Keep in sync with PTY_SUPERSEDED_CODE in src/server.ts.
@@ -65,6 +77,10 @@ export function connectPty(
   let fastFails = 0;
   const FAST_FAIL_MS = 4000;
   const MAX_FAST_FAILS = 8;
+  // echo RTT: timestamp of the last real input send (0 = none pending). First
+  // server message clears it, so an unsolicited server push (running process
+  // output) may clear it early — send→first-echo is approximate.
+  let _pendingSendTime = 0;
 
   const open = () => {
     parked = false;
@@ -75,8 +91,16 @@ export function connectPty(
     }
     ws = makeWs(`/pty/${id}?cols=${lastCols}&rows=${lastRows}`);
     ws.binaryType = "arraybuffer";
-    ws.onmessage = (e) =>
+    ws.onmessage = (e) => {
+      if (_profileEnabled && _pendingSendTime !== 0) {
+        const rtt = Date.now() - _pendingSendTime;
+        _pendingSendTime = 0;
+        if (rtt > ECHO_RTT_THRESHOLD_MS) {
+          console.warn(`[profile] echo-rtt ${rtt}ms`);
+        }
+      }
       onData(typeof e.data === "string" ? e.data : new TextDecoder().decode(e.data));
+    };
     ws.onopen = () => {
       openedAt = Date.now();
       if (everOpened) onReconnect();
@@ -117,7 +141,11 @@ export function connectPty(
   open();
 
   return {
-    send: (d) => ws.readyState === ws.OPEN && ws.send(d),
+    send: (d) => {
+      if (ws.readyState !== ws.OPEN) return;
+      ws.send(d);
+      if (_profileEnabled) _pendingSendTime = Date.now();
+    },
     resize: (c, r) => {
       lastCols = c;
       lastRows = r;


### PR DESCRIPTION
## Problem

Typing in Shepherd's **web** terminal pane occasionally froze for 1-3s — characters didn't appear until the freeze expired — while herdr attached directly on the host stayed snappy in every pane.

## Root cause

Shepherd's server is a **single-threaded Bun event loop**, and the web terminal's keystrokes/echo are pumped by it (WS `message` → `PtyBridge.write`; `for await (chunk of stdout) ws.send`). Several background callers ran **synchronous, blocking** `execFileSync` (gh/git/herdr) and whole-file `readFileSync` + `JSON.parse` *directly on that loop*. While any one was in flight the loop was frozen — it couldn't dispatch keystroke frames or pump PTY output. The call returned 1-3s later and everything flushed at once. herdr-on-host never traverses this loop, so it was unaffected.

## Fix

Convert the **network-bound** on-loop blockers to non-blocking async (reusing the existing `promisify(execFile)` pattern) and **bound the CPU-bound parses**:

- **Forge `gh`** → async `GhRunner` (internal-only; the `GitForge` interface was already `Promise`-returning, so zero caller ripple).
- **`diff.ts` request path** (`GET /api/sessions/:id/diff`) → async `git fetch`/`diff`/`rev-parse` + a `MAX_TOTAL_LINES` cap on `parseUnifiedDiff` (async git alone leaves the multi-MB parse blocking).
- **`UpdateService.check`** (5-min `git fetch origin main`), **`WorktreeMgr.behindBase`** (merge-train sweep), **`WorktreeMgr.createDetached`**, and **`review.ts` patch-id base fetch** (critic poll) → async network `git fetch`.
- **Transcript reads** (poller, every ~7s/agent) → `readTranscriptTail` reads only the last 512 KB so `JSON.parse` cost is bounded regardless of transcript size.
- StatusPoller's `herdr list/read` stay sync (local daemon IPC, fast) — instrumented, listed in the startup blocker log.

Plus **flag-gated profiling** (`SHEPHERD_PROFILE_LOOP=1`, browser `localStorage["shepherd:profile"]`) to confirm/triangulate freezes, zero-cost when off: an event-loop-lag sampler, `timed`/`timedAsync` wrappers, per-PTY WS frame timing, browser keypress→echo RTT, and a **regression guard** (`test/no-sync-exec.test.ts`) that fails if any blocking `execFileSync` is re-introduced outside the instrument wrapper.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test ./test` — 1356 pass, 0 fail
- [x] `cd ui && bun run check` (0/0) + `bun run test` (602 pass) + `check:i18n` parity
- [x] `bunx fallow audit --base origin/main --fail-on-issues` — exit 0, no new findings
- [ ] **Manual (Phase 0 confirmation, requires the operator):** deploy with `SHEPHERD_PROFILE_LOOP=1`, type continuously in a web pane for ≥60s (with an open PR active + across a 5-min update check + opening a large diff); confirm the loop-lag sampler shows no >150ms spikes attributable to the converted calls and no perceptible freeze.

`[no-feature-entry]` — ships no user-facing UX; this is a latency fix plus flag-gated developer instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)