### PR TITLE
feat(merge-train): offer local-checkout update after a merge-train run completes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,10 @@ const service = new SessionService({
     : undefined,
   events,
   reaper: new ProcessReaper(),
+  // Fast-poll a queue member to surface its merge promptly when the train session
+  // archives before the 120s PR sweep credits it (the merge-train completion race).
+  // prPoller is defined below; this closure is only invoked at runtime, after init.
+  refreshPr: (id) => prPoller.pollSession(id),
 });
 
 const accountIndex = new AccountUsageIndex();
@@ -211,11 +215,13 @@ events.subscribe((event, data) => {
 
 // A PR in a merge train just landed (or was closed) → drop its "Merging" mark
 // so the row resolves out of the Merging group one-by-one as the train works.
-// session:git fires on any git change; clearMerging no-ops when not marked.
+// session:git fires on any git change; resolveMerging clears the mark and
+// credits the train tracker, no-opping when the session isn't marked / untracked.
 events.subscribe((event, data) => {
   if (event !== "session:git") return;
   const { id, git } = data as { id: string; git: import("./forge/types").GitState };
-  if (git.state === "merged" || git.state === "closed") service.clearMerging(id);
+  if (git.state === "merged" || git.state === "closed")
+    service.resolveMerging(id, git.state === "merged");
 });
 
 // The train session itself was archived → clear any of its PRs still marked

--- a/src/service.ts
+++ b/src/service.ts
@@ -309,11 +309,11 @@ export class SessionService {
       repoPath: string;
       merged: boolean;
       archived: boolean;
-      // Last activity (launch, a member resolving, or archive) — NOT launch time.
-      // The TTL sweep evicts on inactivity off this, so a long train that keeps
-      // landing PRs (or has just archived awaiting a late credit) is never dropped
-      // mid-run; only a genuinely stuck/abandoned train is reclaimed.
-      lastTouch: number;
+      // null while the train is still running — a LIVE entry is never swept (however
+      // long the run / a slow first CI takes), only cleaned when the train archives.
+      // Set to archive time when the train archives awaiting a late credit; the TTL
+      // sweep then reclaims it once that post-archive window lapses.
+      awaitingSince: number | null;
       members: Set<string>;
     }
   >();
@@ -839,7 +839,7 @@ export class SessionService {
         repoPath,
         merged: false,
         archived: false,
-        lastTouch: since,
+        awaitingSince: null,
         members,
       });
     }
@@ -865,10 +865,9 @@ export class SessionService {
    * `isolated`/`trainId` before clearing, since the mark must be cleared either way.
    * Emits only via the LATE-CREDIT path: if the train already archived awaiting a
    * merge, this credit completes it. A credit while the train is still live never
-   * emits — the offer fires on run completion, not first merge. `now` injectable
-   * for tests; a resolution counts as train activity (refreshes the TTL clock).
+   * emits — the offer fires on run completion, not first merge.
    */
-  resolveMerging(id: string, didMerge: boolean, now: number = Date.now()): void {
+  resolveMerging(id: string, didMerge: boolean): void {
     const isolated = this.deps.store.get(id)?.isolated ?? false;
     this.clearMerging(id);
     const trainId = this.#memberToTrain.get(id);
@@ -877,7 +876,6 @@ export class SessionService {
     this.#memberToTrain.delete(id);
     if (!entry) return;
     entry.members.delete(id);
-    entry.lastTouch = now; // the train is actively landing PRs → don't let the sweep reclaim it
     entry.merged ||= didMerge && isolated;
     if (entry.archived && entry.merged) this.#finalizeTrain(trainId, entry.repoPath);
   }
@@ -889,9 +887,9 @@ export class SessionService {
    * still-tracked member via `refreshPr` so a poller-gated merge surfaces within
    * seconds and routes through `resolveMerging` → late-credit emit. A deferred
    * entry whose late credit never arrives is reclaimed by `sweepStaleMerging` with
-   * no emit, `MERGE_STALE_MS` after this archive (the clock restarts here, so the
-   * await window is independent of how long the run itself took). `now` injectable
-   * for tests.
+   * no emit, `MERGE_STALE_MS` after this archive — the await window starts HERE, so
+   * it is independent of how long the run itself took (a slow/long run is never
+   * reclaimed mid-flight; only the post-archive wait is bounded). `now` injectable.
    */
   clearMergingForTrain(trainId: string, now: number = Date.now()): void {
     for (const s of this.deps.store.list({ activeOnly: true })) {
@@ -900,7 +898,7 @@ export class SessionService {
     const entry = this.#trainOffers.get(trainId);
     if (!entry) return; // untracked train → no-op (unchanged behaviour)
     entry.archived = true;
-    entry.lastTouch = now; // restart the TTL clock for the post-archive await window
+    entry.awaitingSince = now; // start the post-archive await window (only awaiting entries are swept)
     if (entry.merged) {
       this.#finalizeTrain(trainId, entry.repoPath);
       return;
@@ -923,13 +921,14 @@ export class SessionService {
         this.clearMerging(s.id);
       }
     }
-    // Evict INACTIVE completion-tracker entries directly (NOT via activeOnly, which
-    // excludes archived trains). Keyed off `lastTouch`, not launch time, so a long
-    // train still actively landing PRs — or one just archived awaiting a late
-    // credit — keeps its entry; only a stuck/abandoned train is reclaimed. No emit
-    // on eviction — fail-safe no-offer.
+    // Reclaim only AWAITING entries (train archived, awaiting a late credit) once
+    // their post-archive window lapses — directly, NOT via activeOnly (which excludes
+    // archived trains). A still-running train (awaitingSince null) is NEVER swept,
+    // however long its run / first-PR CI takes; it's cleaned only when it archives.
+    // Total entries stay bounded: live ones track live train sessions, awaiting ones
+    // lapse after TTL. No emit on eviction — fail-safe no-offer.
     for (const [trainId, entry] of this.#trainOffers) {
-      if (now - entry.lastTouch > MERGE_STALE_MS) {
+      if (entry.awaitingSince !== null && now - entry.awaitingSince > MERGE_STALE_MS) {
         for (const id of entry.members) this.#memberToTrain.delete(id);
         this.#trainOffers.delete(trainId);
       }

--- a/src/service.ts
+++ b/src/service.ts
@@ -309,7 +309,11 @@ export class SessionService {
       repoPath: string;
       merged: boolean;
       archived: boolean;
-      createdAt: number;
+      // Last activity (launch, a member resolving, or archive) — NOT launch time.
+      // The TTL sweep evicts on inactivity off this, so a long train that keeps
+      // landing PRs (or has just archived awaiting a late credit) is never dropped
+      // mid-run; only a genuinely stuck/abandoned train is reclaimed.
+      lastTouch: number;
       members: Set<string>;
     }
   >();
@@ -835,7 +839,7 @@ export class SessionService {
         repoPath,
         merged: false,
         archived: false,
-        createdAt: since,
+        lastTouch: since,
         members,
       });
     }
@@ -861,9 +865,10 @@ export class SessionService {
    * `isolated`/`trainId` before clearing, since the mark must be cleared either way.
    * Emits only via the LATE-CREDIT path: if the train already archived awaiting a
    * merge, this credit completes it. A credit while the train is still live never
-   * emits — the offer fires on run completion, not first merge.
+   * emits — the offer fires on run completion, not first merge. `now` injectable
+   * for tests; a resolution counts as train activity (refreshes the TTL clock).
    */
-  resolveMerging(id: string, didMerge: boolean): void {
+  resolveMerging(id: string, didMerge: boolean, now: number = Date.now()): void {
     const isolated = this.deps.store.get(id)?.isolated ?? false;
     this.clearMerging(id);
     const trainId = this.#memberToTrain.get(id);
@@ -872,6 +877,7 @@ export class SessionService {
     this.#memberToTrain.delete(id);
     if (!entry) return;
     entry.members.delete(id);
+    entry.lastTouch = now; // the train is actively landing PRs → don't let the sweep reclaim it
     entry.merged ||= didMerge && isolated;
     if (entry.archived && entry.merged) this.#finalizeTrain(trainId, entry.repoPath);
   }
@@ -881,16 +887,20 @@ export class SessionService {
    * marked (unchanged), then drive the offer. If a merge was already credited →
    * emit + finalize now. Else DEFER: mark the entry archived and fast-poll each
    * still-tracked member via `refreshPr` so a poller-gated merge surfaces within
-   * seconds and routes through `resolveMerging` → late-credit emit. A never-merging
-   * deferred entry is reclaimed by `sweepStaleMerging` with no emit.
+   * seconds and routes through `resolveMerging` → late-credit emit. A deferred
+   * entry whose late credit never arrives is reclaimed by `sweepStaleMerging` with
+   * no emit, `MERGE_STALE_MS` after this archive (the clock restarts here, so the
+   * await window is independent of how long the run itself took). `now` injectable
+   * for tests.
    */
-  clearMergingForTrain(trainId: string): void {
+  clearMergingForTrain(trainId: string, now: number = Date.now()): void {
     for (const s of this.deps.store.list({ activeOnly: true })) {
       if (s.mergingTrainId === trainId) this.clearMerging(s.id);
     }
     const entry = this.#trainOffers.get(trainId);
     if (!entry) return; // untracked train → no-op (unchanged behaviour)
     entry.archived = true;
+    entry.lastTouch = now; // restart the TTL clock for the post-archive await window
     if (entry.merged) {
       this.#finalizeTrain(trainId, entry.repoPath);
       return;
@@ -913,10 +923,13 @@ export class SessionService {
         this.clearMerging(s.id);
       }
     }
-    // Evict stale completion-tracker entries directly (NOT via activeOnly, which
-    // excludes archived trains). No emit on TTL eviction — fail-safe no-offer.
+    // Evict INACTIVE completion-tracker entries directly (NOT via activeOnly, which
+    // excludes archived trains). Keyed off `lastTouch`, not launch time, so a long
+    // train still actively landing PRs — or one just archived awaiting a late
+    // credit — keeps its entry; only a stuck/abandoned train is reclaimed. No emit
+    // on eviction — fail-safe no-offer.
     for (const [trainId, entry] of this.#trainOffers) {
-      if (now - entry.createdAt > MERGE_STALE_MS) {
+      if (now - entry.lastTouch > MERGE_STALE_MS) {
         for (const id of entry.members) this.#memberToTrain.delete(id);
         this.#trainOffers.delete(trainId);
       }

--- a/src/service.ts
+++ b/src/service.ts
@@ -32,6 +32,10 @@ export interface ServiceDeps {
   moveUploads?: (images: string[], worktreePath: string) => string[];
   /** Detects/terminates leftover subprocesses at close; absent in tests that skip it. */
   reaper?: Pick<ProcessReaper, "detect" | "reap">;
+  /** Fast-poll one session's PR (= prPoller.pollSession), to nudge merge detection
+   *  when a merge train archives before the 120s sweep surfaces its members' merges.
+   *  Fire-and-forget, debounced, no-ops on archived sessions. Absent → no nudge. */
+  refreshPr?: (id: string) => void;
 }
 
 /**
@@ -286,6 +290,30 @@ function agentBaseUrl(): string {
 
 export class SessionService {
   constructor(private deps: ServiceDeps) {}
+
+  /**
+   * Merge-train completion tracker (issue #426). A train that lands ≥1 of its
+   * queue PRs should offer a local-checkout fast-forward once, per repo. We track
+   * each launched train so we can emit `mergetrain:landed` exactly when the run
+   * COMPLETES (the train session archives) — not on the first member merge.
+   *
+   * `memberToTrain` is the crux of race-safety: a member's merge-credit is looked
+   * up by THIS map, never by the session's `mergingTrainId` field, because
+   * `clearMergingForTrain` nulls that field at train archive — so a member that
+   * merges AFTER the train archived (the poller-gated race) would otherwise be
+   * unmappable to its train and its credit lost.
+   */
+  #trainOffers = new Map<
+    string,
+    {
+      repoPath: string;
+      merged: boolean;
+      archived: boolean;
+      createdAt: number;
+      members: Set<string>;
+    }
+  >();
+  #memberToTrain = new Map<string, string>();
 
   /**
    * Build the human-turn prompt: the user's text plus any attached images and the
@@ -788,10 +816,28 @@ export class SessionService {
    */
   setMerging(ids: string[], trainId: string): void {
     const since = Date.now();
+    const members = new Set<string>();
+    let repoPath: string | null = null;
     for (const id of ids) {
-      if (!this.deps.store.get(id)) continue;
+      const s = this.deps.store.get(id);
+      if (!s) continue;
       this.deps.store.update(id, { mergingSince: since, mergingTrainId: trainId });
       this.deps.events?.emit("session:merging", { id, since, trainId });
+      // Register the resolvable member for the completion tracker. repoPath is read
+      // off the FIRST resolvable member (never a skipped id) — the train is per-repo.
+      members.add(id);
+      this.#memberToTrain.set(id, trainId);
+      if (repoPath === null) repoPath = s.repoPath;
+    }
+    // No resolvable member → create no entry (so repoPath is never read off a skip).
+    if (repoPath !== null) {
+      this.#trainOffers.set(trainId, {
+        repoPath,
+        merged: false,
+        archived: false,
+        createdAt: since,
+        members,
+      });
     }
   }
 
@@ -803,11 +849,61 @@ export class SessionService {
     this.deps.events?.emit("session:merging", { id, since: null, trainId: null });
   }
 
-  /** Clear every session marked by a given train (its session was archived). */
+  /**
+   * A queue member's PR resolved (`session:git` merged/closed). Replaces the bare
+   * per-member `clearMerging` call: clears the UI mark exactly as before, then
+   * credits the completion tracker. Credit is keyed by `#memberToTrain` (NOT the
+   * session's `mergingTrainId`, which archive may already have nulled).
+   *
+   * A merge only counts toward the offer when the session is `isolated` — a
+   * non-isolated session works in the canonical clone, so its fast-forward would
+   * always report `wrong_branch` (mirrors the parent feature's guard). We read
+   * `isolated`/`trainId` before clearing, since the mark must be cleared either way.
+   * Emits only via the LATE-CREDIT path: if the train already archived awaiting a
+   * merge, this credit completes it. A credit while the train is still live never
+   * emits — the offer fires on run completion, not first merge.
+   */
+  resolveMerging(id: string, didMerge: boolean): void {
+    const isolated = this.deps.store.get(id)?.isolated ?? false;
+    this.clearMerging(id);
+    const trainId = this.#memberToTrain.get(id);
+    if (trainId === undefined) return; // untracked → behaves exactly like the old clearMerging
+    const entry = this.#trainOffers.get(trainId);
+    this.#memberToTrain.delete(id);
+    if (!entry) return;
+    entry.members.delete(id);
+    entry.merged ||= didMerge && isolated;
+    if (entry.archived && entry.merged) this.#finalizeTrain(trainId, entry.repoPath);
+  }
+
+  /**
+   * The train session was archived (run complete). Clear any of its members still
+   * marked (unchanged), then drive the offer. If a merge was already credited →
+   * emit + finalize now. Else DEFER: mark the entry archived and fast-poll each
+   * still-tracked member via `refreshPr` so a poller-gated merge surfaces within
+   * seconds and routes through `resolveMerging` → late-credit emit. A never-merging
+   * deferred entry is reclaimed by `sweepStaleMerging` with no emit.
+   */
   clearMergingForTrain(trainId: string): void {
     for (const s of this.deps.store.list({ activeOnly: true })) {
       if (s.mergingTrainId === trainId) this.clearMerging(s.id);
     }
+    const entry = this.#trainOffers.get(trainId);
+    if (!entry) return; // untracked train → no-op (unchanged behaviour)
+    entry.archived = true;
+    if (entry.merged) {
+      this.#finalizeTrain(trainId, entry.repoPath);
+      return;
+    }
+    for (const id of entry.members) this.deps.refreshPr?.(id);
+  }
+
+  /** Emit `mergetrain:landed` once (caller has decided merged) and drop all tracker state. */
+  #finalizeTrain(trainId: string, repoPath: string): void {
+    this.deps.events?.emit("mergetrain:landed", { repoPath });
+    const entry = this.#trainOffers.get(trainId);
+    if (entry) for (const id of entry.members) this.#memberToTrain.delete(id);
+    this.#trainOffers.delete(trainId);
   }
 
   /** Backstop: clear marks older than MERGE_STALE_MS. `now` injectable for tests. */
@@ -815,6 +911,14 @@ export class SessionService {
     for (const s of this.deps.store.list({ activeOnly: true })) {
       if (s.mergingSince !== null && now - s.mergingSince > MERGE_STALE_MS) {
         this.clearMerging(s.id);
+      }
+    }
+    // Evict stale completion-tracker entries directly (NOT via activeOnly, which
+    // excludes archived trains). No emit on TTL eviction — fail-safe no-offer.
+    for (const [trainId, entry] of this.#trainOffers) {
+      if (now - entry.createdAt > MERGE_STALE_MS) {
+        for (const id of entry.members) this.#memberToTrain.delete(id);
+        this.#trainOffers.delete(trainId);
       }
     }
   }

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,6 +16,13 @@ import { planHouseRulesInjection, renderHouseRulesBlock } from "./house-rules";
  *  "Merging" forever. Mirrored in ui/src/lib/components/merge-train.ts. */
 export const MERGE_STALE_MS = 30 * 60_000;
 
+/** Absolute backstop for a STILL-RUNNING merge-train completion-tracker entry: a
+ *  train session that dies without ever emitting `session:archived` would orphan
+ *  its live entry forever, so the sweep reclaims a live entry this long after launch.
+ *  Set far beyond any realistic run (no merge train runs for a day) so it can only
+ *  reclaim a genuinely dead train, never one still landing PRs. */
+export const TRAIN_TRACKER_MAX_MS = 24 * 60 * 60_000;
+
 export interface ServiceDeps {
   store: SessionStore;
   worktree: Pick<
@@ -309,11 +316,14 @@ export class SessionService {
       repoPath: string;
       merged: boolean;
       archived: boolean;
-      // null while the train is still running — a LIVE entry is never swept (however
-      // long the run / a slow first CI takes), only cleaned when the train archives.
-      // Set to archive time when the train archives awaiting a late credit; the TTL
-      // sweep then reclaims it once that post-archive window lapses.
+      // null while the train is still running — a LIVE entry is never swept on the
+      // normal path (however long the run / a slow first CI takes), only cleaned when
+      // the train archives; the sole exception is the TRAIN_TRACKER_MAX_MS absolute
+      // backstop below, for a train that died without a session:archived. Set to
+      // archive time when the train archives awaiting a late credit; the sweep then
+      // reclaims it once that post-archive window lapses.
       awaitingSince: number | null;
+      launchedAt: number; // for the dead-train absolute backstop only
       members: Set<string>;
     }
   >();
@@ -840,6 +850,7 @@ export class SessionService {
         merged: false,
         archived: false,
         awaitingSince: null,
+        launchedAt: since,
         members,
       });
     }
@@ -896,7 +907,7 @@ export class SessionService {
       if (s.mergingTrainId === trainId) this.clearMerging(s.id);
     }
     const entry = this.#trainOffers.get(trainId);
-    if (!entry) return; // untracked train → no-op (unchanged behaviour)
+    if (!entry || entry.archived) return; // untracked, or a repeat archive → keep the await window monotonic
     entry.archived = true;
     entry.awaitingSince = now; // start the post-archive await window (only awaiting entries are swept)
     if (entry.merged) {
@@ -921,14 +932,18 @@ export class SessionService {
         this.clearMerging(s.id);
       }
     }
-    // Reclaim only AWAITING entries (train archived, awaiting a late credit) once
-    // their post-archive window lapses — directly, NOT via activeOnly (which excludes
-    // archived trains). A still-running train (awaitingSince null) is NEVER swept,
-    // however long its run / first-PR CI takes; it's cleaned only when it archives.
-    // Total entries stay bounded: live ones track live train sessions, awaiting ones
-    // lapse after TTL. No emit on eviction — fail-safe no-offer.
+    // Reclaim tracker entries directly (NOT via activeOnly, which excludes archived
+    // trains). Two cases, both no-emit (fail-safe no-offer):
+    //  - AWAITING (archived, awaiting a late credit): once the post-archive window lapses.
+    //  - LIVE (awaitingSince null): NEVER on a normal run, however long it takes — only
+    //    the TRAIN_TRACKER_MAX_MS absolute backstop, which bounds an entry orphaned by a
+    //    train that died without a session:archived. Real runs finish far inside it.
     for (const [trainId, entry] of this.#trainOffers) {
-      if (entry.awaitingSince !== null && now - entry.awaitingSince > MERGE_STALE_MS) {
+      const awaitingStale =
+        entry.awaitingSince !== null && now - entry.awaitingSince > MERGE_STALE_MS;
+      const deadTrainOrphan =
+        entry.awaitingSince === null && now - entry.launchedAt > TRAIN_TRACKER_MAX_MS;
+      if (awaitingStale || deadTrainOrphan) {
         for (const id of entry.members) this.#memberToTrain.delete(id);
         this.#trainOffers.delete(trainId);
       }

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1804,6 +1804,7 @@ test("archiveMany isolates a failing session: others still clear, the failed id 
 function mergeSvc() {
   const store = new SessionStore(":memory:");
   const emitted: { event: string; data: any }[] = [];
+  const refreshed: string[] = [];
   const service = new SessionService({
     store,
     namer: async () => "n",
@@ -1825,8 +1826,9 @@ function mergeSvc() {
       stop: () => {},
     } as any,
     events: { emit: (event: string, data: unknown) => emitted.push({ event, data }) } as any,
+    refreshPr: (id: string) => refreshed.push(id),
   });
-  return { store, service, emitted };
+  return { store, service, emitted, refreshed };
 }
 
 async function mkSession(service: SessionService) {
@@ -1883,6 +1885,140 @@ test("sweepStaleMerging clears marks older than the TTL, keeps fresh ones", asyn
   service.sweepStaleMerging(now);
   expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
   service.sweepStaleMerging(now + MERGE_STALE_MS + 1);
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+});
+
+// ── mergetrain:landed completion tracker ──────────────────────────────────────
+
+function landed(emitted: { event: string; data: any }[]) {
+  return emitted.filter((e) => e.event === "mergetrain:landed");
+}
+
+test("merge-before-archive: member merges, then train archives → one mergetrain:landed", async () => {
+  const { service, emitted } = mergeSvc();
+  const a = await mkSession(service); // repoPath "/r", isolated
+  service.setMerging([a.id], "train-X");
+  service.resolveMerging(a.id, true); // credited, but no emit yet (train still live)
+  expect(landed(emitted)).toHaveLength(0);
+  service.clearMergingForTrain("train-X");
+  const ev = landed(emitted);
+  expect(ev).toHaveLength(1);
+  expect(ev[0]!.data).toEqual({ repoPath: "/r" });
+  // idempotence: a second archive call is a no-op (entry already finalized)
+  service.clearMergingForTrain("train-X");
+  expect(landed(emitted)).toHaveLength(1);
+});
+
+test("archive-before-merge (the race): archive defers + nudges, late merge fires once", async () => {
+  const { service, emitted, refreshed } = mergeSvc();
+  const a = await mkSession(service);
+  const b = await mkSession(service);
+  service.setMerging([a.id, b.id], "train-R");
+  service.clearMergingForTrain("train-R"); // archives first, merged still false
+  expect(landed(emitted)).toHaveLength(0); // deferred — no emit yet
+  expect(refreshed.sort()).toEqual([a.id, b.id].sort()); // nudged each live member
+  service.resolveMerging(a.id, true); // late credit → fires
+  const ev = landed(emitted);
+  expect(ev).toHaveLength(1);
+  expect(ev[0]!.data).toEqual({ repoPath: "/r" });
+  // entry cleared: a later resolve for the other member does not re-fire
+  service.resolveMerging(b.id, true);
+  expect(landed(emitted)).toHaveLength(1);
+});
+
+test("nothing merged: all resolve false, archive, TTL sweep → never emits", async () => {
+  const { service, emitted } = mergeSvc();
+  const a = await mkSession(service);
+  service.setMerging([a.id], "train-N");
+  service.resolveMerging(a.id, false);
+  service.clearMergingForTrain("train-N");
+  expect(landed(emitted)).toHaveLength(0);
+  service.sweepStaleMerging(Date.now() + MERGE_STALE_MS + 1);
+  expect(landed(emitted)).toHaveLength(0);
+});
+
+test("isolated guard: a sole non-isolated merged member never emits", async () => {
+  const store = new SessionStore(":memory:");
+  const emitted: { event: string; data: any }[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "n",
+    worktree: {
+      create: () => ({ worktreePath: "/wt", branch: null, isolated: false }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => ({
+        terminalId: "t",
+        cwd: "/",
+        agent: "claude",
+        agentStatus: "idle",
+        paneId: "p",
+        tabId: "x",
+        workspaceId: "w",
+      }),
+      list: () => [],
+      stop: () => {},
+    } as any,
+    events: { emit: (event: string, data: unknown) => emitted.push({ event, data }) } as any,
+  });
+  const a = await mkSession(service); // non-isolated (worktree mock)
+  expect(store.get(a.id)!.isolated).toBe(false);
+  service.setMerging([a.id], "train-NI");
+  service.resolveMerging(a.id, true); // not credited (non-isolated)
+  expect(landed(emitted)).toHaveLength(0);
+  service.clearMergingForTrain("train-NI"); // archive with merged still false
+  expect(landed(emitted)).toHaveLength(0);
+});
+
+test("pre-archive credit alone does not emit (fires on completion, not first merge)", async () => {
+  const { service, emitted } = mergeSvc();
+  const a = await mkSession(service);
+  service.setMerging([a.id], "train-P");
+  service.resolveMerging(a.id, true);
+  expect(landed(emitted)).toHaveLength(0); // train still live
+});
+
+test("sweep eviction: stale awaiting entry evicted with no emit; fresh entry untouched", async () => {
+  const { service, emitted } = mergeSvc();
+  const a = await mkSession(service);
+  service.setMerging([a.id], "train-S");
+  service.clearMergingForTrain("train-S"); // archived, merged false → awaiting
+  // evict by age; verify no emit and that the memberToTrain row is cleared
+  service.sweepStaleMerging(Date.now() + MERGE_STALE_MS + 1);
+  expect(landed(emitted)).toHaveLength(0);
+  // a later credit can no longer fire (entry + memberToTrain row gone)
+  service.resolveMerging(a.id, true);
+  expect(landed(emitted)).toHaveLength(0);
+
+  // fresh entry is untouched by a sweep at the same `now`
+  const b = await mkSession(service);
+  service.setMerging([b.id], "train-F");
+  service.sweepStaleMerging(Date.now()); // fresh, well within TTL
+  service.clearMergingForTrain("train-F"); // would only fire if entry survived
+  // merged false so still no emit, but entry must still exist (not evicted):
+  service.resolveMerging(b.id, true);
+  expect(landed(emitted)).toHaveLength(1);
+});
+
+test("setMerging with all-unknown ids creates no entry; later archive is a no-op", async () => {
+  const { service, emitted } = mergeSvc();
+  service.setMerging(["ghost"], "train-G"); // no resolvable member
+  expect(() => service.clearMergingForTrain("train-G")).not.toThrow();
+  expect(landed(emitted)).toHaveLength(0);
+});
+
+test("untracked passthrough: resolveMerging/clearMergingForTrain on unknown ids no-op, still clear marks", async () => {
+  const { store, service, emitted } = mergeSvc();
+  const a = await mkSession(service);
+  // resolveMerging on a session never registered with a train: clears mark, no emit
+  service.setMerging([a.id], "train-U");
+  // simulate an untracked member by resolving a truly unknown id
+  expect(() => service.resolveMerging("nobody", true)).not.toThrow();
+  expect(() => service.clearMergingForTrain("no-such-train")).not.toThrow();
+  expect(landed(emitted)).toHaveLength(0);
+  // marks for the real session still clearable via resolveMerging
+  service.resolveMerging(a.id, false);
   expect(store.get(a.id)!.mergingSince).toBeNull();
 });
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1991,31 +1991,27 @@ test("sweep eviction: stale awaiting entry evicted with no emit; fresh entry unt
   service.resolveMerging(a.id, true);
   expect(landed(emitted)).toHaveLength(0);
 
-  // fresh entry is untouched by a sweep at the same `now`
+  // a LIVE (un-archived) entry is never swept — even by a sweep far past launch+TTL
   const b = await mkSession(service);
   service.setMerging([b.id], "train-F");
-  service.sweepStaleMerging(Date.now()); // fresh, well within TTL
+  service.sweepStaleMerging(Date.now() + 10 * MERGE_STALE_MS); // live → not evicted
   service.clearMergingForTrain("train-F"); // would only fire if entry survived
   // merged false so still no emit, but entry must still exist (not evicted):
   service.resolveMerging(b.id, true);
   expect(landed(emitted)).toHaveLength(1);
 });
 
-test("long active run: member activity refreshes the TTL clock, so a >TTL run isn't evicted mid-run", async () => {
+test("slow/long run: a still-running train is never swept, however long it takes (no activity, no archive)", async () => {
   const { service, emitted } = mergeSvc();
   const a = await mkSession(service);
-  const b = await mkSession(service);
-  service.setMerging([a.id, b.id], "train-L"); // lastTouch ≈ launch (t0)
+  service.setMerging([a.id], "train-Slow"); // live; first PR's CI is slow — no member has resolved yet
   const t0 = Date.now();
-  // The run outlives MERGE_STALE_MS, but a member lands just before the window
-  // elapses → refreshes lastTouch (and credits the merge).
-  service.resolveMerging(a.id, true, t0 + MERGE_STALE_MS - 1);
-  // A sweep past launch+TTL would have evicted a launch-time entry; lastTouch was
-  // refreshed, so it survives (the bug the PR critic flagged).
-  service.sweepStaleMerging(t0 + MERGE_STALE_MS + 1);
-  expect(landed(emitted)).toHaveLength(0); // still live, not yet archived
-  // The train finally archives long after launch → the entry is intact and fires.
-  service.clearMergingForTrain("train-L", t0 + MERGE_STALE_MS + 2);
+  // The critic's case: no member activity and no archive for well past MERGE_STALE_MS.
+  // A live entry must NOT be reclaimed (a launch-/activity-keyed TTL would drop it here).
+  service.sweepStaleMerging(t0 + 5 * MERGE_STALE_MS);
+  // The first PR finally lands, then the train archives → entry intact, fires once.
+  service.resolveMerging(a.id, true);
+  service.clearMergingForTrain("train-Slow", t0 + 5 * MERGE_STALE_MS + 1);
   expect(landed(emitted)).toHaveLength(1);
 });
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -5,6 +5,7 @@ import {
   spawnSettingsOverlay,
   composeSystemPrompt,
   MERGE_STALE_MS,
+  TRAIN_TRACKER_MAX_MS,
 } from "../src/service";
 import { HOUSE_RULES_TAG } from "../src/house-rules";
 import { config } from "../src/config";
@@ -2013,6 +2014,39 @@ test("slow/long run: a still-running train is never swept, however long it takes
   service.resolveMerging(a.id, true);
   service.clearMergingForTrain("train-Slow", t0 + 5 * MERGE_STALE_MS + 1);
   expect(landed(emitted)).toHaveLength(1);
+});
+
+test("repeat archive is idempotent: doesn't restart the await window or re-nudge members", async () => {
+  const { service, emitted, refreshed } = mergeSvc();
+  const a = await mkSession(service);
+  service.setMerging([a.id], "train-Re");
+  const t0 = Date.now();
+  service.clearMergingForTrain("train-Re", t0); // archived, awaiting (merged false) → window starts at t0
+  // A second session:archived for the same train must be ignored — it must NOT
+  // restart the await window or fire refreshPr again.
+  service.clearMergingForTrain("train-Re", t0 + MERGE_STALE_MS / 2);
+  expect(refreshed).toEqual([a.id]); // nudged exactly once across both calls
+  // Window stays anchored at t0, so a sweep at t0+TTL+1 evicts (it would NOT have if reset).
+  service.sweepStaleMerging(t0 + MERGE_STALE_MS + 1);
+  service.resolveMerging(a.id, true); // entry gone → no late credit
+  expect(landed(emitted)).toHaveLength(0);
+});
+
+test("dead-train backstop: a live entry orphaned past TRAIN_TRACKER_MAX_MS is reclaimed (no emit)", async () => {
+  const { service, emitted } = mergeSvc();
+  const a = await mkSession(service);
+  // `base` is captured BEFORE setMerging, so launchedAt >= base; the ±1min margins
+  // dwarf any sub-ms drift, keeping the boundary checks non-flaky.
+  const base = Date.now();
+  service.setMerging([a.id], "train-Dead"); // launchedAt ≈ base; train session then dies w/o session:archived
+  // Below the backstop while live → NOT reclaimed.
+  service.sweepStaleMerging(base + TRAIN_TRACKER_MAX_MS - 60_000);
+  // Past the backstop → reclaimed with no emit (no session:archived ever arrived).
+  service.sweepStaleMerging(base + TRAIN_TRACKER_MAX_MS + 60_000);
+  // Entry gone: a later merge + archive can no longer fire an offer.
+  service.resolveMerging(a.id, true);
+  service.clearMergingForTrain("train-Dead", base + TRAIN_TRACKER_MAX_MS + 120_000);
+  expect(landed(emitted)).toHaveLength(0);
 });
 
 test("setMerging with all-unknown ids creates no entry; later archive is a no-op", async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2001,6 +2001,24 @@ test("sweep eviction: stale awaiting entry evicted with no emit; fresh entry unt
   expect(landed(emitted)).toHaveLength(1);
 });
 
+test("long active run: member activity refreshes the TTL clock, so a >TTL run isn't evicted mid-run", async () => {
+  const { service, emitted } = mergeSvc();
+  const a = await mkSession(service);
+  const b = await mkSession(service);
+  service.setMerging([a.id, b.id], "train-L"); // lastTouch ≈ launch (t0)
+  const t0 = Date.now();
+  // The run outlives MERGE_STALE_MS, but a member lands just before the window
+  // elapses → refreshes lastTouch (and credits the merge).
+  service.resolveMerging(a.id, true, t0 + MERGE_STALE_MS - 1);
+  // A sweep past launch+TTL would have evicted a launch-time entry; lastTouch was
+  // refreshed, so it survives (the bug the PR critic flagged).
+  service.sweepStaleMerging(t0 + MERGE_STALE_MS + 1);
+  expect(landed(emitted)).toHaveLength(0); // still live, not yet archived
+  // The train finally archives long after launch → the entry is intact and fires.
+  service.clearMergingForTrain("train-L", t0 + MERGE_STALE_MS + 2);
+  expect(landed(emitted)).toHaveLength(1);
+});
+
 test("setMerging with all-unknown ids creates no entry; later archive is a no-op", async () => {
   const { service, emitted } = mergeSvc();
   service.setMerging(["ghost"], "train-G"); // no resolvable member

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -1,6 +1,9 @@
 import { test, expect, vi, afterEach } from "vitest";
 import { HerdStore } from "./store.svelte";
 import { toasts } from "./toasts.svelte";
+
+vi.mock("./pull-offer", () => ({ offerUpdateMain: vi.fn() }));
+import { offerUpdateMain } from "./pull-offer";
 import type {
   AutoMergeStatus,
   BacklogPayload,
@@ -497,4 +500,14 @@ test("setBuildQueue does not clobber other sessions", () => {
   s.setBuildQueue(other);
   expect(s.buildQueues["s1"]).toEqual(QUEUE);
   expect(s.buildQueues["s2"]).toEqual(other);
+});
+
+// ── mergetrain:landed ──────────────────────────────────────────────────────
+
+test("mergetrain:landed calls offerUpdateMain with the repoPath", () => {
+  vi.mocked(offerUpdateMain).mockClear();
+  const s = new HerdStore();
+  s.apply({ event: "mergetrain:landed", data: { repoPath: "/repos/my-project" } });
+  expect(offerUpdateMain).toHaveBeenCalledOnce();
+  expect(offerUpdateMain).toHaveBeenCalledWith("/repos/my-project");
 });

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -18,6 +18,7 @@ import { reviews, planGates } from "./reviews.svelte";
 import { learnings } from "./learnings.svelte";
 import { toasts } from "./toasts.svelte";
 import { m } from "$lib/paraglide/messages";
+import { offerUpdateMain } from "./pull-offer";
 
 export class HerdStore {
   sessions = $state<Session[]>([]);
@@ -264,6 +265,9 @@ export class HerdStore {
         // "Halting N…" toast in place (haltHerd posts it under the same key), and also
         // dedupes back-to-back halts / the echo to the firer into one row.
         toasts.info(m.halt_done({ count: ev.data.halted }), { key: "halt-done" });
+        break;
+      case "mergetrain:landed":
+        offerUpdateMain(ev.data.repoPath);
         break;
     }
   }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -471,7 +471,8 @@ export type WsEvent =
   | { event: "automerge:status"; data: AutoMergeStatus }
   | { event: "session:automerge"; data: { id: string; enabled: boolean | null } }
   | { event: "queue:update"; data: BuildQueue }
-  | { event: "halt:done"; data: { halted: number } };
+  | { event: "halt:done"; data: { halted: number } }
+  | { event: "mergetrain:landed"; data: { repoPath: string } };
 
 export interface CreateInput {
   repoPath: string;


### PR DESCRIPTION
Closes #426. Follow-up to #427, which offers a one-click fast-forward of a repo's local default-branch checkout after a **manual** merge (`GitRail` session merge + `PrRow` backlog merge) via `offerUpdateMain` / `POST /api/repos/pull`. That feature deliberately excluded the **merge-train** button, which doesn't merge synchronously — it spawns an agent session that lands the queue itself via `gh`, outside the app's merge endpoints, so the existing toast hook can't fire. This PR covers that case.

## What

After a spawned merge-train session lands its queue of PRs, the user is offered (once, per repo) to fast-forward that repo's local default branch — reusing `offerUpdateMain` / `pullRepo`, **no new server pull endpoint**.

## How

Server detects completion from the existing `mergingTrainId` lifecycle and emits a new WS event `mergetrain:landed { repoPath }`; the client store turns that into `offerUpdateMain(repoPath)` (the same persistent, per-repo-deduped toast as #427).

**The credit-vs-emit race (why this isn't a one-liner).** A merged queue member is only credited when its PR's `session:git merged` is observed — poller-gated (120 s) — while the train session can auto-archive promptly in autopilot. A naive *emit-iff-merged-then-delete-at-archive* would read `merged === false` and drop the offer forever. So:

- Two in-memory maps on `SessionService`: `trainOffers` (per-train `{repoPath, merged, archived, createdAt, members}`) and `memberToTrain` (credit lookup **decoupled** from the `mergingTrainId` field, which `clearMergingForTrain` nulls at archive).
- On the train's `session:archived`, `clearMergingForTrain` **defers** the no-merge decision and **nudges** detection by fast-polling still-live members (`refreshPr` → `prPoller.pollSession`); a later `session:git merged` routes through `resolveMerging` to a **late-credit emit**.
- Isolated-only credit (mirrors #427 — a non-isolated checkout sits on a feature branch, so a fast-forward would always report `wrong_branch`).
- `sweepStaleMerging` evicts never-completing entries (TTL) with **no** emit; both maps are bounded.

Server-side detection means the offer survives a mid-train page reload.

## Acceptance

- ✅ After a train lands its PRs, the user is offered once to fast-forward — both merge-before-archive and the inverted archive-before-merge race fire exactly one offer.
- ✅ No offer when the train merged nothing (closed-only / non-isolated / all-unknown-ids / TTL-evicted paths emit nothing).
- ✅ Reuses `offerUpdateMain` / `pullRepo`; no new endpoint; no new i18n keys (`toast_update_main_*` already shipped in #427).

## Tests

- `test/service.test.ts` — tracker: merge-before-archive (+ idempotent re-archive), the archive-before-merge race (asserts `refreshPr` per live member + single late emit), nothing-merged, isolated guard, pre-archive-no-emit, sweep eviction (stale evicted no-emit, fresh untouched), all-unknown-ids no-entry, untracked passthrough.
- `ui/src/lib/store.svelte.test.ts` — `mergetrain:landed` → `offerUpdateMain(repoPath)` once.

All gates green: root lint / tsc / `bun test ./test` (1347 pass), `ui` check / vitest (638 pass) / `check:i18n` (725-key parity), branch hygiene, fallow audit (dead 0, complexity 0; duplication warn-only on a pre-existing `session:git` subscriber pattern).

No feature-catalog entry — feature already announced by #427 (`[no-feature-entry]` opt-out, gate skips loudly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)