### PR TITLE
feat(ui): highlight shepherd:active label in backlog issue list

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -215,6 +215,7 @@
   "issuespanel_task_button": "+ Aufgabe",
   "issuespanel_quick_button": "⚡ Standard",
   "issuespanel_quick_button_title": "Standard-Befehl auf dieses Issue anwenden; überspringt den Aufgaben-Dialog",
+  "issuespanel_active_label_title": "Von einem aktiven Shepherd-Agenten beansprucht – an diesem Issue wird bereits gearbeitet",
   "newtask_title": "Neue Aufgabe",
   "newtask_prompt_label": "Prompt",
   "newtask_prompt_placeholder": "füge eine Funktion hinzu, die…",
@@ -759,5 +760,7 @@
   "feat_preview_title": "Live-App-Vorschau",
   "feat_preview_body": "Wenn der Dev-Server eines Agenten läuft, erscheint ein Vorschau-Badge in seiner Zeile. Beim Öffnen zeigt sich die laufende App in einem HUD-Pane — erreichbar von Desktop oder Handy über Tailscale.",
   "feat_repo_roles_title": "Repo-Zuständigkeiten",
-  "feat_repo_roles_body": "Lege im Automations-Panel fest, wer ein Repo reviewt und wer merged. Ist der Merge jemand anderes (z. B. ein Teammitglied, das PRs landet), zeigt ein grüner PR \"Warten auf …\" statt \"Du bist dran\"."
+  "feat_repo_roles_body": "Lege im Automations-Panel fest, wer ein Repo reviewt und wer merged. Ist der Merge jemand anderes (z. B. ein Teammitglied, das PRs landet), zeigt ein grüner PR \"Warten auf …\" statt \"Du bist dran\".",
+  "feat_backlog_active_highlight_title": "Sieh auf einen Blick, welche Issues schon beansprucht sind",
+  "feat_backlog_active_highlight_body": "Issues, die ein Shepherd-Agent beansprucht hat, tragen das Label „shepherd:active“. In der Issue-Liste des Backlogs hebt es sich jetzt in Amber ab, sodass du beanspruchte von freier Arbeit auf einen Blick unterscheidest, statt jedes Chip zu lesen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -215,6 +215,7 @@
   "issuespanel_task_button": "+ Task",
   "issuespanel_quick_button": "⚡ Standard",
   "issuespanel_quick_button_title": "Run the configured standard command on this issue; skips the New Task dialog",
+  "issuespanel_active_label_title": "Claimed by an active Shepherd agent — this issue is already being worked on",
   "newtask_title": "New Task",
   "newtask_prompt_label": "Prompt",
   "newtask_prompt_placeholder": "add a feature that…",
@@ -759,5 +760,7 @@
   "feat_preview_title": "Live app preview",
   "feat_preview_body": "When an agent's dev server is running, a Preview badge appears on its row. Opening it shows the live app in an in-HUD pane — reachable from desktop or phone over Tailscale.",
   "feat_repo_roles_title": "Repo responsibilities",
-  "feat_repo_roles_body": "Set who reviews and who merges a repo in its automation panel. When the merger is someone else (e.g. a teammate who lands PRs), a green PR reads \"Waiting on them\" instead of \"Your turn\"."
+  "feat_repo_roles_body": "Set who reviews and who merges a repo in its automation panel. When the merger is someone else (e.g. a teammate who lands PRs), a green PR reads \"Waiting on them\" instead of \"Your turn\".",
+  "feat_backlog_active_highlight_title": "See at a glance which issues are already claimed",
+  "feat_backlog_active_highlight_body": "Issues a Shepherd agent has claimed carry a “shepherd:active” label. In the backlog's issue list it now stands out in amber, so you can tell taken work from free work at a glance instead of reading every chip."
 }

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -3,6 +3,11 @@
   import type { Issue } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
 
+  // Mirrors ACTIVE_LABEL in src/drain-core.ts — the label the drain stamps on an
+  // issue it has claimed (auto session or human-linked task). Highlighted so a
+  // claimed issue reads as "already taken" at a glance in the backlog.
+  const ACTIVE_LABEL = "shepherd:active";
+
   let {
     repoPath,
     onnewtask,
@@ -78,7 +83,12 @@
           {#if issue.labels.length > 0 || age}
             <div class="label-row">
               {#each issue.labels as label (label)}
-                <span class="label-chip">{label}</span>
+                <span
+                  class="label-chip"
+                  class:active={label === ACTIVE_LABEL}
+                  title={label === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}
+                  >{label}</span
+                >
               {/each}
               {#if age}
                 <span class="age-chip"
@@ -203,6 +213,14 @@
     border: 1px solid var(--color-line);
     border-radius: 2px;
     padding: 1px 5px;
+  }
+
+  /* shepherd:active — claimed work. Amber per the design system's running/in-progress
+     hue (--status-running), so a taken issue stands out from neutral labels. */
+  .label-chip.active {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
+    background: color-mix(in srgb, var(--color-amber) 14%, transparent);
   }
 
   .body-preview {

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -215,12 +215,12 @@
     padding: 1px 5px;
   }
 
-  /* shepherd:active — claimed work. Amber per the design system's running/in-progress
-     hue (--status-running), so a taken issue stands out from neutral labels. */
+  /* shepherd:active — claimed work. Uses the semantic running/in-progress token so a
+     taken issue stands out from neutral labels with the same hue as running sessions. */
   .label-chip.active {
-    color: var(--color-amber);
-    border-color: var(--color-amber);
-    background: color-mix(in srgb, var(--color-amber) 14%, transparent);
+    color: var(--status-running);
+    border-color: var(--status-running);
+    background: color-mix(in srgb, var(--status-running) 14%, transparent);
   }
 
   .body-preview {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -193,4 +193,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_repo_roles_title",
     bodyKey: "feat_repo_roles_body",
   },
+  {
+    // No targetId: the highlighted chip only renders on issues currently claimed by a
+    // Shepherd agent, so a coachmark anchor would rarely be mounted — surface via the
+    // What's-New drawer only.
+    id: "backlog-active-highlight",
+    sinceVersion: "1.20.0",
+    titleKey: "feat_backlog_active_highlight_title",
+    bodyKey: "feat_backlog_active_highlight_body",
+  },
 ];


### PR DESCRIPTION
## What

The backlog's issue list renders every GitHub/Gitea label as a uniform neutral chip — including `shepherd:active`, the label the drain stamps on an issue it has claimed (auto session or human-linked task). That makes already-taken work indistinguishable from free work at a glance.

This highlights the `shepherd:active` chip in **amber** — the design system's running/in-progress hue (`--status-running` / `--color-amber`, per design-system rule #4) — with a matching border and a subtle wash, plus a tooltip explaining the claim. All other labels keep their neutral styling.

## Changes

- `IssuesPanel.svelte`: detect `shepherd:active` (local `ACTIVE_LABEL` const mirroring `src/drain-core.ts`, commented), apply `.label-chip.active` styling + a `title` tooltip only on that chip.
- `feature-announcements.ts`: What's-New catalog entry (`backlog-active-highlight`, since 1.20.0), drawer-only (the chip is rarely mounted, so no coachmark anchor).
- `en.json` / `de.json`: tooltip key + the two feature keys (parity verified).

## Verification

- `cd ui && bun run check:i18n` → 2 locales in parity
- `cd ui && bun run check` → 0 errors / 0 warnings
- `cd ui && bun run test` → 649 passed
- pre-push: lint-staged + fallow audit (no issues) + branch hygiene all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)