### PR TITLE
fix(poller): restore per-agent heartbeat + stall after CC stopped live-writing transcripts

### DIFF
--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -1,7 +1,11 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { execFileSync } from "./instrument";
 import { config } from "./config";
 import { maintenance } from "./maintenance";
 import type { HerdrState, SessionStatus } from "./types";
+
+const execFileAsync = promisify(execFile);
 
 export interface HerdrAgent {
   agent: string;
@@ -25,6 +29,8 @@ export interface HerdrTab {
 }
 
 export type Runner = (args: string[]) => string;
+/** Async counterpart to `Runner` — spawns off Bun's single loop (no blocking). */
+export type AsyncRunner = (args: string[]) => Promise<string>;
 
 /** A herdr CLI call attempted while an update is in flight. Thrown WITHOUT
  *  spawning, so nothing resurrects the herdr server mid-update. */
@@ -53,6 +59,23 @@ export function makeHerdrRunner(exec: (args: string[]) => string): Runner {
 const defaultRunner: Runner = makeHerdrRunner((args) =>
   execFileSync(config.herdrBin, args, { encoding: "utf8", timeout: HERDR_TIMEOUT_MS }),
 );
+
+/** Async sibling of `makeHerdrRunner`: same maintenance guard, but the delegate
+ *  returns a promise so the spawn never blocks Bun's single loop. */
+export function makeHerdrAsyncRunner(exec: (args: string[]) => Promise<string>): AsyncRunner {
+  return async (args) => {
+    if (maintenance.active) throw new HerdrUnavailableError();
+    return exec(args);
+  };
+}
+
+const defaultAsyncRunner: AsyncRunner = makeHerdrAsyncRunner(async (args) => {
+  const { stdout } = await execFileAsync(config.herdrBin, args, {
+    encoding: "utf8",
+    timeout: HERDR_TIMEOUT_MS,
+  });
+  return stdout;
+});
 
 export function mapState(s: HerdrState): SessionStatus {
   switch (s) {
@@ -150,7 +173,10 @@ export function matchAgents(
 }
 
 export class HerdrDriver {
-  constructor(private runner: Runner = defaultRunner) {}
+  constructor(
+    private runner: Runner = defaultRunner,
+    private asyncRunner: AsyncRunner = defaultAsyncRunner,
+  ) {}
 
   list(): HerdrAgent[] {
     const parsed = JSON.parse(this.runner(["agent", "list"]));
@@ -259,9 +285,9 @@ export class HerdrDriver {
     this.runner(["agent", "send", target, text]);
   }
 
-  /** Read an agent's terminal buffer as plain text (default: the visible viewport). */
-  read(target: string, source: "visible" | "recent" = "visible", lines = 200): string {
-    const out = this.runner([
+  /** The `agent read` argv shared by the sync and async readers. */
+  private readArgs(target: string, source: "visible" | "recent", lines: number): string[] {
+    return [
       "agent",
       "read",
       target,
@@ -271,12 +297,36 @@ export class HerdrDriver {
       source,
       "--lines",
       String(lines),
-    ]);
+    ];
+  }
+
+  /** Extract the buffer text from a herdr `agent read` reply (raw output on a parse miss). */
+  private parseRead(out: string): string {
     try {
       return JSON.parse(out)?.result?.read?.text ?? "";
     } catch {
       return out;
     }
+  }
+
+  /** Read an agent's terminal buffer as plain text (default: the visible viewport). */
+  read(target: string, source: "visible" | "recent" = "visible", lines = 200): string {
+    return this.parseRead(this.runner(this.readArgs(target, source, lines)));
+  }
+
+  /**
+   * Async sibling of `read` — same args/timeout/maintenance guard, but spawns via
+   * `promisify(execFile)` so it never blocks Bun's single loop. Use this from the
+   * poll loop (the poller reads the visible buffer for EVERY running agent every
+   * probe cadence in the interim heartbeat path); the sync `read` would freeze the
+   * live web terminal under that fan-out.
+   */
+  async readAsync(
+    target: string,
+    source: "visible" | "recent" = "visible",
+    lines = 200,
+  ): Promise<string> {
+    return this.parseRead(await this.asyncRunner(this.readArgs(target, source, lines)));
   }
 
   /**

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -48,12 +48,12 @@ export class StatusPoller {
    *  still generating keeps its spinner/elapsed/token counter ticking, so the
    *  buffer changes between probes; a wedged or idle turn leaves it frozen. */
   private lastVisible = new Map<string, string>();
-  /** Interim terminal-diff state — used ONLY when the transcript probe yields
-   *  nothing (Claude Code 2.1.169 stopped writing the JSONL live during a
-   *  session). Kept separate from `lastVisible` (which belongs to
-   *  `evaluateStall`'s gate) so the two liveness diffs never trample each other;
-   *  this whole cluster goes dormant the moment the transcript starts producing
-   *  signals again. See `probeTerminalInterim`. */
+  /** Interim terminal-diff state — used whenever the transcript is NOT being
+   *  written live (an empty JSONL, or a resumed session inheriting a frozen old
+   *  one; see the liveness gate in `maybeProbe`). Kept separate from `lastVisible`
+   *  (which belongs to `evaluateStall`'s gate) so the two liveness diffs never
+   *  trample each other; this whole cluster is reset (`resetInterim`) the moment
+   *  the transcript starts live-writing again. See `probeTerminalInterim`. */
   private lastInterimVisible = new Map<string, string>();
   /** Per-session heartbeat ticks (ms epochs of probes where the visible buffer
    *  changed), windowed to STRIP_WINDOW_MS — drives the interim heat-strip. */
@@ -64,6 +64,13 @@ export class StatusPoller {
    *  fire-and-forget off the (synchronous) tick, so a slow read must not let the
    *  next cadence pile a second read on top; we skip while one is pending. */
   private interimInFlight = new Set<string>();
+  /** Per-session newest transcript-record ts seen on the PREVIOUS probe — the
+   *  liveness baseline that decides transcript-vs-interim each probe. A probe whose
+   *  newest record advanced past this is "live-writing" (use the transcript); one
+   *  that didn't (empty, or a resumed session inheriting a frozen old JSONL) falls
+   *  to the interim terminal-diff. First sighting (no baseline) counts as live so a
+   *  resumed agent auto-reactivates the transcript path before settling. */
+  private lastTranscriptTs = new Map<string, number>();
 
   /** Timestamp of the last completed preview sweep start (0 = never). */
   private lastPreviewSweepAt = 0;
@@ -202,6 +209,7 @@ export class StatusPoller {
       ...this.interimTicks.keys(),
       ...this.lastInterimChangeAt.keys(),
       ...this.interimInFlight.keys(),
+      ...this.lastTranscriptTs.keys(),
     ]);
     for (const id of tracked) {
       if (!activeIds.has(id)) {
@@ -215,6 +223,7 @@ export class StatusPoller {
         this.interimTicks.delete(id);
         this.lastInterimChangeAt.delete(id);
         this.interimInFlight.delete(id);
+        this.lastTranscriptTs.delete(id);
       }
     }
   }
@@ -265,25 +274,49 @@ export class StatusPoller {
       return; // best-effort; retry next cadence
     }
 
-    // ── interim path: transcript yielded NOTHING (the CC 2.1.169 case) ──
+    // ── transcript-liveness gate: use the transcript only while it's LIVE ──
     // Claude Code 2.1.169 stopped flushing the transcript JSONL live during a
-    // session (it now writes only on exit), so for every running agent the probe
-    // comes back empty → the heartbeat strip would render all-empty AND stall
-    // detection would be disabled (`evaluateStall` bails on a null snapshot
-    // BEFORE it ever reads the terminal). When BOTH signals are null we instead
-    // derive a coarse-but-live heartbeat + stall from the herdr "visible" buffer.
-    // This is NOT free: it adds ONE fresh `visible` read per running agent per
-    // probe cadence (the transcript path early-returned at zero reads in this
-    // 2.1.169 world). To keep that fan-out off Bun's single loop, the read is
-    // ASYNC (`readAsync`) and dispatched fire-and-forget — `tick()` never blocks
-    // on it. No Claude-Code-side hooks, works on already-running agents. This
-    // branch is mutually exclusive with the transcript path below: the instant
-    // Claude Code restores live transcript writes (signals become non-null) it
-    // goes dormant automatically and the original path runs.
-    if (signals.activity == null && signals.snapshot == null) {
+    // session (it now writes only on exit). Worse, a RESUMED session inherits its
+    // OLD frozen JSONL, so `parseActivity` returns stale entries → the probe comes
+    // back NON-null but its newest record never advances. A naive "both signals
+    // null" trigger therefore missed those stale-but-parseable transcripts and
+    // stranded the agent on a dead transcript path (its old `recentTs` drain to
+    // empty at `now`, so the heartbeat strip renders all-empty and stall detection
+    // is effectively disabled).
+    //
+    // So we don't ask "is the transcript empty?" but "is it being WRITTEN right
+    // now?" — does its newest record advance between probes. `newestTs` is the
+    // newest of the two signals; `liveWriting` is true on the FIRST sighting (no
+    // baseline yet — so a resumed agent still auto-reactivates the transcript path)
+    // and thereafter only when `newestTs` strictly advances past the prior probe.
+    //
+    //  • NOT live-writing (empty transcript OR a frozen/stale one) → derive a
+    //    coarse-but-live heartbeat + stall from the herdr "visible" buffer instead.
+    //    This adds ONE fresh `visible` read per such agent per probe cadence; to
+    //    keep that fan-out off Bun's single loop the read is ASYNC (`readAsync`)
+    //    and dispatched fire-and-forget — `tick()` never blocks on it. No
+    //    Claude-Code-side hooks; works on already-running agents.
+    //  • Live-writing → run the original transcript path (activity emit + stall
+    //    liveness gate). First, `resetInterim` clears any interim baseline left by
+    //    a prior interim episode, so a LATER re-entry into interim defers cleanly
+    //    off a fresh first sample rather than firing off a stale `lastInterimChangeAt`.
+    //
+    // Flipping to interim during a long live-writing generation gap (no new record
+    // for a while) is benign: the terminal-diff still shows the agent alive, and
+    // the transcript path resumes the instant a new record lands.
+    const newestTs = signals.activity?.lastActivityTs ?? signals.snapshot?.lastTs ?? null;
+    const prevTs = this.lastTranscriptTs.get(s.id);
+    const liveWriting = newestTs != null && (prevTs === undefined || newestTs > prevTs);
+    if (newestTs != null) this.lastTranscriptTs.set(s.id, newestTs);
+
+    if (!liveWriting) {
       void this.probeTerminalInterim(s, t);
       return;
     }
+
+    // transcript is live-writing → clear any stale interim baseline first, then the
+    // original transcript-driven activity emit + stall liveness gate.
+    this.resetInterim(s.id);
 
     // ── activity emit (deduped by signal content) ──
     if (signals.activity) {
@@ -295,9 +328,28 @@ export class StatusPoller {
   }
 
   /**
+   * Clear the interim terminal-diff baseline for a session (its change-baseline,
+   * heartbeat ticks, and last visible buffer). Called on every live-writing probe
+   * so a later re-entry into the interim path starts from a clean first sample
+   * (which defers one cycle) rather than firing off a stale `lastInterimChangeAt`
+   * carried over from a PRIOR interim episode (Finding 1).
+   *
+   * Deliberately does NOT touch `interimInFlight`: that flag self-clears in
+   * `probeTerminalInterim`'s `finally`, and an in-flight read completing after a
+   * reset simply finds no baseline → behaves as a fresh first sample, which is the
+   * correct (defer-not-fire) outcome.
+   */
+  private resetInterim(id: string): void {
+    this.lastInterimChangeAt.delete(id);
+    this.interimTicks.delete(id);
+    this.lastInterimVisible.delete(id);
+  }
+
+  /**
    * Interim heartbeat + stall, derived from the live terminal alone, for when the
-   * transcript probe yields nothing (Claude Code 2.1.169 no longer writes the
-   * JSONL live). Reads the visible buffer EXACTLY ONCE — and ASYNCHRONOUSLY, via
+   * transcript is not being written live (an empty JSONL, or a resumed session
+   * inheriting a frozen old one — see the liveness gate in `maybeProbe`). Reads
+   * the visible buffer EXACTLY ONCE — and ASYNCHRONOUSLY, via
    * `readAsync`, so the read never blocks Bun's single loop (it fans out across
    * every running agent each probe cadence). Dispatched fire-and-forget from the
    * synchronous `maybeProbe`; an `interimInFlight` guard skips a fresh dispatch

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -4,7 +4,7 @@ import { mapState, matchAgents, type HerdrDriver, type HerdrAgent } from "./herd
 import { classifyBlocked, tailLines, type BlockReason } from "./blocked";
 import { isStalled, DEFAULT_STALL, type ActivitySnapshot } from "./stall";
 import { jsonlPathFor } from "./usage";
-import { readTranscriptSignals, type SessionActivity } from "./activity-signal";
+import { readTranscriptSignals, STRIP_WINDOW_MS, type SessionActivity } from "./activity-signal";
 import { maintenance } from "./maintenance";
 import { scanListeningPortsByWorktree } from "./process-reaper";
 import { pickPrimaryPort } from "./preview";
@@ -48,6 +48,18 @@ export class StatusPoller {
    *  still generating keeps its spinner/elapsed/token counter ticking, so the
    *  buffer changes between probes; a wedged or idle turn leaves it frozen. */
   private lastVisible = new Map<string, string>();
+  /** Interim terminal-diff state — used ONLY when the transcript probe yields
+   *  nothing (Claude Code 2.1.169 stopped writing the JSONL live during a
+   *  session). Kept separate from `lastVisible` (which belongs to
+   *  `evaluateStall`'s gate) so the two liveness diffs never trample each other;
+   *  this whole cluster goes dormant the moment the transcript starts producing
+   *  signals again. See `probeTerminalInterim`. */
+  private lastInterimVisible = new Map<string, string>();
+  /** Per-session heartbeat ticks (ms epochs of probes where the visible buffer
+   *  changed), windowed to STRIP_WINDOW_MS — drives the interim heat-strip. */
+  private interimTicks = new Map<string, number[]>();
+  /** Per-session last time the interim visible buffer changed; the stall baseline. */
+  private lastInterimChangeAt = new Map<string, number>();
 
   /** Timestamp of the last completed preview sweep start (0 = never). */
   private lastPreviewSweepAt = 0;
@@ -182,6 +194,9 @@ export class StatusPoller {
       ...this.lastActivitySig.keys(),
       ...this.lastActivity.keys(),
       ...this.lastVisible.keys(),
+      ...this.lastInterimVisible.keys(),
+      ...this.interimTicks.keys(),
+      ...this.lastInterimChangeAt.keys(),
     ]);
     for (const id of tracked) {
       if (!activeIds.has(id)) {
@@ -191,6 +206,9 @@ export class StatusPoller {
         this.lastActivitySig.delete(id);
         this.lastActivity.delete(id);
         this.lastVisible.delete(id);
+        this.lastInterimVisible.delete(id);
+        this.interimTicks.delete(id);
+        this.lastInterimChangeAt.delete(id);
       }
     }
   }
@@ -241,18 +259,108 @@ export class StatusPoller {
       return; // best-effort; retry next cadence
     }
 
+    // ── interim path: transcript yielded NOTHING (the CC 2.1.169 case) ──
+    // Claude Code 2.1.169 stopped flushing the transcript JSONL live during a
+    // session (it now writes only on exit), so for every running agent the probe
+    // comes back empty → the heartbeat strip would render all-empty AND stall
+    // detection would be disabled (`evaluateStall` bails on a null snapshot
+    // BEFORE it ever reads the terminal). When BOTH signals are null we instead
+    // derive a coarse-but-live heartbeat + stall from the herdr "visible" buffer
+    // we already read elsewhere — no Claude-Code-side hooks, works on already-
+    // running agents. This branch is mutually exclusive with the transcript path
+    // below: the instant Claude Code restores live transcript writes (signals
+    // become non-null) it goes dormant automatically and the original path runs.
+    if (signals.activity == null && signals.snapshot == null) {
+      this.probeTerminalInterim(s, t);
+      return;
+    }
+
     // ── activity emit (deduped by signal content) ──
     if (signals.activity) {
-      const sig = JSON.stringify(signals.activity);
-      if (sig !== this.lastActivitySig.get(s.id)) {
-        this.lastActivitySig.set(s.id, sig);
-        this.lastActivity.set(s.id, signals.activity);
-        this.onActivity(s.id, signals.activity);
-      }
+      this.emitActivity(s.id, signals.activity);
     }
 
     // ── stall decision: transcript candidate + live-terminal liveness gate ──
     this.evaluateStall(s, t, signals.snapshot);
+  }
+
+  /**
+   * Interim heartbeat + stall, derived from the live terminal alone, for when the
+   * transcript probe yields nothing (Claude Code 2.1.169 no longer writes the
+   * JSONL live). Reads the visible buffer EXACTLY ONCE (house rule: one terminal
+   * read per probe per agent) and drives BOTH signals off that single read:
+   *
+   *  1. Heartbeat — a running agent mid-turn keeps its spinner/elapsed/token
+   *     counter ticking, so its visible buffer changes between ~7s probes. Each
+   *     change pushes a tick (windowed to STRIP_WINDOW_MS); the client ages the
+   *     strip live off its own clock, so an unchanged probe simply re-emits
+   *     nothing (the dedupe below) rather than re-pushing.
+   *  2. Stall — track the last time the buffer changed. Changed → clear any
+   *     stall and reset the baseline. Unchanged for >= stallMs (with a one-cycle
+   *     baseline deferral on the first sample) → fire (idempotent per episode).
+   *
+   * KNOWN LIMITATION: this interim stall is frozen-TUI-only. It does NOT detect a
+   * hung command whose elapsed timer keeps ticking (the buffer still changes, so
+   * it reads as "alive") — that needs the durable hook mechanism (a separate held
+   * task). It also can't carry a tool-use summary, so the heartbeat summary is
+   * null. Best-effort throughout: a throwing terminal read is swallowed and
+   * retried next cadence, never propagated out of the tick.
+   */
+  private probeTerminalInterim(s: Session, t: number): void {
+    let visible: string;
+    try {
+      visible = this.herdr.read(s.herdrAgentId, "visible");
+    } catch {
+      return; // can't assess this cycle → best-effort, retry next cadence
+    }
+    const id = s.id;
+    // A running agent must not carry a stale *non-stall* block sig left over from a
+    // prior blocked state (the old transcript path cleared this via
+    // evaluateStall→clearBlock). Drop it here so a blocked→running resume still
+    // emits its clear; leave a live stall sig alone (its own clearStall/fireStall
+    // logic below owns the once-per-episode guard).
+    if (this.lastSig.has(id) && this.lastSig.get(id) !== STALL_SIG) this.clearBlock(id);
+    const prev = this.lastInterimVisible.get(id);
+    const changed = prev !== undefined && visible !== prev;
+
+    // 1. heartbeat: a changed buffer is one live "tick"; window the list.
+    if (changed) {
+      const ticks = this.interimTicks.get(id) ?? [];
+      ticks.push(t);
+      const cutoff = t - STRIP_WINDOW_MS;
+      const windowed = ticks.filter((ts) => ts >= cutoff);
+      this.interimTicks.set(id, windowed);
+      // summary is null — the terminal diff can't name the tool-use; recentErrTs
+      // is always empty for the same reason. lastActivityTs = newest tick (or 0).
+      this.emitActivity(id, {
+        lastActivityTs: windowed.length ? windowed[windowed.length - 1]! : 0,
+        summary: null,
+        recentTs: windowed,
+        recentErrTs: [],
+      });
+    }
+
+    // 2. stall: a moving terminal is alive; a frozen one past stallMs is stalled.
+    if (changed) {
+      this.lastInterimChangeAt.set(id, t);
+      this.clearStall(id);
+    } else if (!this.lastInterimChangeAt.has(id)) {
+      // first sample (no baseline yet) → defer one cycle, never fire blind.
+      this.lastInterimChangeAt.set(id, t);
+    } else if (t - this.lastInterimChangeAt.get(id)! >= this.stallCfg.stallMs) {
+      this.fireStall(id, visible); // idempotent per episode
+    }
+
+    this.lastInterimVisible.set(id, visible);
+  }
+
+  /** Emit an activity signal, deduped by content so clients see only real changes. */
+  private emitActivity(id: string, activity: SessionActivity): void {
+    const sig = JSON.stringify(activity);
+    if (sig === this.lastActivitySig.get(id)) return;
+    this.lastActivitySig.set(id, sig);
+    this.lastActivity.set(id, activity);
+    this.onActivity(id, activity);
   }
 
   /**

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -60,6 +60,10 @@ export class StatusPoller {
   private interimTicks = new Map<string, number[]>();
   /** Per-session last time the interim visible buffer changed; the stall baseline. */
   private lastInterimChangeAt = new Map<string, number>();
+  /** Sessions whose interim terminal read is in flight — the read is dispatched
+   *  fire-and-forget off the (synchronous) tick, so a slow read must not let the
+   *  next cadence pile a second read on top; we skip while one is pending. */
+  private interimInFlight = new Set<string>();
 
   /** Timestamp of the last completed preview sweep start (0 = never). */
   private lastPreviewSweepAt = 0;
@@ -70,7 +74,7 @@ export class StatusPoller {
 
   constructor(
     private store: SessionStore,
-    private herdr: Pick<HerdrDriver, "list" | "read">,
+    private herdr: Pick<HerdrDriver, "list" | "read" | "readAsync">,
     private onChange: (id: string, status: string) => void,
     private onBlock: (id: string, block: BlockReason | null) => void,
     private intervalMs = 1000,
@@ -197,6 +201,7 @@ export class StatusPoller {
       ...this.lastInterimVisible.keys(),
       ...this.interimTicks.keys(),
       ...this.lastInterimChangeAt.keys(),
+      ...this.interimInFlight.keys(),
     ]);
     for (const id of tracked) {
       if (!activeIds.has(id)) {
@@ -209,6 +214,7 @@ export class StatusPoller {
         this.lastInterimVisible.delete(id);
         this.interimTicks.delete(id);
         this.lastInterimChangeAt.delete(id);
+        this.interimInFlight.delete(id);
       }
     }
   }
@@ -265,13 +271,17 @@ export class StatusPoller {
     // comes back empty → the heartbeat strip would render all-empty AND stall
     // detection would be disabled (`evaluateStall` bails on a null snapshot
     // BEFORE it ever reads the terminal). When BOTH signals are null we instead
-    // derive a coarse-but-live heartbeat + stall from the herdr "visible" buffer
-    // we already read elsewhere — no Claude-Code-side hooks, works on already-
-    // running agents. This branch is mutually exclusive with the transcript path
-    // below: the instant Claude Code restores live transcript writes (signals
-    // become non-null) it goes dormant automatically and the original path runs.
+    // derive a coarse-but-live heartbeat + stall from the herdr "visible" buffer.
+    // This is NOT free: it adds ONE fresh `visible` read per running agent per
+    // probe cadence (the transcript path early-returned at zero reads in this
+    // 2.1.169 world). To keep that fan-out off Bun's single loop, the read is
+    // ASYNC (`readAsync`) and dispatched fire-and-forget — `tick()` never blocks
+    // on it. No Claude-Code-side hooks, works on already-running agents. This
+    // branch is mutually exclusive with the transcript path below: the instant
+    // Claude Code restores live transcript writes (signals become non-null) it
+    // goes dormant automatically and the original path runs.
     if (signals.activity == null && signals.snapshot == null) {
-      this.probeTerminalInterim(s, t);
+      void this.probeTerminalInterim(s, t);
       return;
     }
 
@@ -287,8 +297,12 @@ export class StatusPoller {
   /**
    * Interim heartbeat + stall, derived from the live terminal alone, for when the
    * transcript probe yields nothing (Claude Code 2.1.169 no longer writes the
-   * JSONL live). Reads the visible buffer EXACTLY ONCE (house rule: one terminal
-   * read per probe per agent) and drives BOTH signals off that single read:
+   * JSONL live). Reads the visible buffer EXACTLY ONCE — and ASYNCHRONOUSLY, via
+   * `readAsync`, so the read never blocks Bun's single loop (it fans out across
+   * every running agent each probe cadence). Dispatched fire-and-forget from the
+   * synchronous `maybeProbe`; an `interimInFlight` guard skips a fresh dispatch
+   * while a prior read for the same session is still pending, so a slow read can't
+   * pile up. Drives BOTH signals off that single read:
    *
    *  1. Heartbeat — a running agent mid-turn keeps its spinner/elapsed/token
    *     counter ticking, so its visible buffer changes between ~7s probes. Each
@@ -306,52 +320,59 @@ export class StatusPoller {
    * null. Best-effort throughout: a throwing terminal read is swallowed and
    * retried next cadence, never propagated out of the tick.
    */
-  private probeTerminalInterim(s: Session, t: number): void {
-    let visible: string;
-    try {
-      visible = this.herdr.read(s.herdrAgentId, "visible");
-    } catch {
-      return; // can't assess this cycle → best-effort, retry next cadence
-    }
+  private async probeTerminalInterim(s: Session, t: number): Promise<void> {
     const id = s.id;
-    // A running agent must not carry a stale *non-stall* block sig left over from a
-    // prior blocked state (the old transcript path cleared this via
-    // evaluateStall→clearBlock). Drop it here so a blocked→running resume still
-    // emits its clear; leave a live stall sig alone (its own clearStall/fireStall
-    // logic below owns the once-per-episode guard).
-    if (this.lastSig.has(id) && this.lastSig.get(id) !== STALL_SIG) this.clearBlock(id);
-    const prev = this.lastInterimVisible.get(id);
-    const changed = prev !== undefined && visible !== prev;
+    if (this.interimInFlight.has(id)) return; // a prior read is still pending → skip
+    this.interimInFlight.add(id);
+    try {
+      let visible: string;
+      try {
+        visible = await this.herdr.readAsync(s.herdrAgentId, "visible");
+      } catch {
+        return; // can't assess this cycle → best-effort, retry next cadence
+      }
+      // A running agent must not carry a stale *non-stall* block sig left over from a
+      // prior blocked state (the old transcript path cleared this via
+      // evaluateStall→clearBlock). Drop it here so a blocked→running resume still
+      // emits its clear; leave a live stall sig alone (its own clearStall/fireStall
+      // logic below owns the once-per-episode guard).
+      if (this.lastSig.has(id) && this.lastSig.get(id) !== STALL_SIG) this.clearBlock(id);
+      const prev = this.lastInterimVisible.get(id);
+      const changed = prev !== undefined && visible !== prev;
 
-    // 1. heartbeat: a changed buffer is one live "tick"; window the list.
-    if (changed) {
-      const ticks = this.interimTicks.get(id) ?? [];
-      ticks.push(t);
-      const cutoff = t - STRIP_WINDOW_MS;
-      const windowed = ticks.filter((ts) => ts >= cutoff);
-      this.interimTicks.set(id, windowed);
-      // summary is null — the terminal diff can't name the tool-use; recentErrTs
-      // is always empty for the same reason. lastActivityTs = newest tick (or 0).
-      this.emitActivity(id, {
-        lastActivityTs: windowed.length ? windowed[windowed.length - 1]! : 0,
-        summary: null,
-        recentTs: windowed,
-        recentErrTs: [],
-      });
+      // 1. heartbeat: a changed buffer is one live "tick"; window the list.
+      if (changed) {
+        const ticks = this.interimTicks.get(id) ?? [];
+        ticks.push(t);
+        const cutoff = t - STRIP_WINDOW_MS;
+        const windowed = ticks.filter((ts) => ts >= cutoff);
+        this.interimTicks.set(id, windowed);
+        // summary is null — the terminal diff can't name the tool-use; recentErrTs
+        // is always empty for the same reason. lastActivityTs = newest tick (`t`
+        // was just pushed and survives the window, so `windowed` is never empty).
+        this.emitActivity(id, {
+          lastActivityTs: windowed[windowed.length - 1]!,
+          summary: null,
+          recentTs: windowed,
+          recentErrTs: [],
+        });
+      }
+
+      // 2. stall: a moving terminal is alive; a frozen one past stallMs is stalled.
+      if (changed) {
+        this.lastInterimChangeAt.set(id, t);
+        this.clearStall(id);
+      } else if (!this.lastInterimChangeAt.has(id)) {
+        // first sample (no baseline yet) → defer one cycle, never fire blind.
+        this.lastInterimChangeAt.set(id, t);
+      } else if (t - this.lastInterimChangeAt.get(id)! >= this.stallCfg.stallMs) {
+        this.fireStall(id, visible); // idempotent per episode
+      }
+
+      this.lastInterimVisible.set(id, visible);
+    } finally {
+      this.interimInFlight.delete(id);
     }
-
-    // 2. stall: a moving terminal is alive; a frozen one past stallMs is stalled.
-    if (changed) {
-      this.lastInterimChangeAt.set(id, t);
-      this.clearStall(id);
-    } else if (!this.lastInterimChangeAt.has(id)) {
-      // first sample (no baseline yet) → defer one cycle, never fire blind.
-      this.lastInterimChangeAt.set(id, t);
-    } else if (t - this.lastInterimChangeAt.get(id)! >= this.stallCfg.stallMs) {
-      this.fireStall(id, visible); // idempotent per episode
-    }
-
-    this.lastInterimVisible.set(id, visible);
   }
 
   /** Emit an activity signal, deduped by content so clients see only real changes. */

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -286,9 +286,16 @@ export class StatusPoller {
     //
     // So we don't ask "is the transcript empty?" but "is it being WRITTEN right
     // now?" — does its newest record advance between probes. `newestTs` is the
-    // newest of the two signals; `liveWriting` is true on the FIRST sighting (no
-    // baseline yet — so a resumed agent still auto-reactivates the transcript path)
-    // and thereafter only when `newestTs` strictly advances past the prior probe.
+    // newest of the two signals; `liveWriting` requires an EXISTING baseline AND a
+    // strict advance past it. A FIRST sighting (no baseline) is treated as NOT live
+    // so a resumed session engages the interim terminal-diff immediately, instead
+    // of taking the transcript path once and emitting one stale (already-out-of-
+    // window) transcript signal that leaves the heat-strip blank for ~1 cadence.
+    // Auto-reactivation is preserved regardless: `lastTranscriptTs` is recorded on
+    // EVERY probe (below, before the branch), so a genuinely live-writing transcript
+    // advances on its SECOND probe → flips to the transcript path then. The cost is
+    // one extra probe (~one cadence) on interim before a live transcript takes over
+    // — benign, the interim shows the agent alive meanwhile.
     //
     //  • NOT live-writing (empty transcript OR a frozen/stale one) → derive a
     //    coarse-but-live heartbeat + stall from the herdr "visible" buffer instead.
@@ -306,7 +313,7 @@ export class StatusPoller {
     // the transcript path resumes the instant a new record lands.
     const newestTs = signals.activity?.lastActivityTs ?? signals.snapshot?.lastTs ?? null;
     const prevTs = this.lastTranscriptTs.get(s.id);
-    const liveWriting = newestTs != null && (prevTs === undefined || newestTs > prevTs);
+    const liveWriting = newestTs != null && prevTs !== undefined && newestTs > prevTs;
     if (newestTs != null) this.lastTranscriptTs.set(s.id, newestTs);
 
     if (!liveWriting) {

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -317,3 +317,54 @@ test("runner delegates to exec when maintenance is inactive", () => {
   const runner = makeHerdrRunner(() => "ok");
   expect(runner(["agent", "list"])).toBe("ok");
 });
+
+import { makeHerdrAsyncRunner } from "../src/herdr";
+
+const READ_REPLY = JSON.stringify({ result: { type: "read", read: { text: "Computing… (3s)" } } });
+
+test("readAsync mirrors read's argv and parses the buffer text", async () => {
+  let captured: string[] = [];
+  const d = new HerdrDriver(
+    () => FIXTURE,
+    async (args) => {
+      captured = args;
+      return READ_REPLY;
+    },
+  );
+  const text = await d.readAsync("term_a", "visible", 200);
+  expect(text).toBe("Computing… (3s)");
+  expect(captured).toEqual([
+    "agent",
+    "read",
+    "term_a",
+    "--format",
+    "text",
+    "--source",
+    "visible",
+    "--lines",
+    "200",
+  ]);
+});
+
+test("readAsync returns raw output when the reply is unparseable", async () => {
+  const d = new HerdrDriver(
+    () => FIXTURE,
+    async () => "not json",
+  );
+  expect(await d.readAsync("term_a")).toBe("not json");
+});
+
+test("async runner throws fast (no spawn) while maintenance is active", async () => {
+  let spawned = 0;
+  const runner = makeHerdrAsyncRunner(async () => {
+    spawned++;
+    return "{}";
+  });
+  maintenance.begin();
+  try {
+    await expect(runner(["agent", "read"])).rejects.toBeInstanceOf(HerdrUnavailableError);
+    expect(spawned).toBe(0);
+  } finally {
+    maintenance.end();
+  }
+});

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -18,6 +18,12 @@ const baseSession = {
   herdrAgentId: "term_a",
 };
 
+/** A running agent with an empty transcript falls into the interim path, whose
+ *  terminal read is dispatched fire-and-forget (async `readAsync`) off the
+ *  synchronous tick — so its onActivity/onBlock effects (incl. the resume
+ *  block-clear) land on a later microtask. Flush a cycle before asserting them. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
 test("tick maps herdr state to status and emits only on change", () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);
@@ -56,7 +62,7 @@ test("tick maps herdr state to status and emits only on change", () => {
   expect(emitted.length).toBe(2);
 });
 
-test("emits onBlock with a classified reason for blocked sessions, clears on resume", () => {
+test("emits onBlock with a classified reason for blocked sessions, clears on resume", async () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);
   const blocks: { id: string; block: unknown }[] = [];
@@ -76,6 +82,9 @@ test("emits onBlock with a classified reason for blocked sessions, clears on res
       },
     ],
     read: () => "❯ 1. Yes\n  2. No",
+    // resume runs the interim path (no injected transcript probe → empty signals),
+    // whose block-clear is async; provide the async read so it fires
+    readAsync: () => Promise.resolve("❯ 1. Yes\n  2. No"),
   };
 
   let clock = 100_000;
@@ -103,6 +112,7 @@ test("emits onBlock with a classified reason for blocked sessions, clears on res
   agentStatus = "working";
   clock += 5000;
   poller.tick();
+  await flush();
   expect(blocks).toHaveLength(2);
   expect(blocks[1]).toEqual({ id: s.id, block: null });
 });
@@ -868,7 +878,8 @@ import { STRIP_WINDOW_MS } from "../src/activity-signal";
 
 /** A running agent whose transcript probe yields NOTHING (the CC 2.1.169 case):
  *  both snapshot and activity are null, so the poller falls back to the
- *  terminal-diff interim path. `read("visible")` returns whatever `visible` holds. */
+ *  terminal-diff interim path. `readAsync("visible")` resolves whatever `visible`
+ *  holds. */
 function interimHarness(opts: {
   store: SessionStore;
   visible: () => string;
@@ -891,6 +902,7 @@ function interimHarness(opts: {
       },
     ],
     read: () => opts.visible(),
+    readAsync: () => Promise.resolve(opts.visible()),
   };
   return new StatusPoller(
     opts.store,
@@ -909,7 +921,7 @@ function interimHarness(opts: {
   );
 }
 
-test("interim: empty transcript + changing terminal accrues heartbeat ticks, never stalls", () => {
+test("interim: empty transcript + changing terminal accrues heartbeat ticks, never stalls", async () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);
   const activities: { id: string; activity: any }[] = [];
@@ -927,6 +939,7 @@ test("interim: empty transcript + changing terminal accrues heartbeat ticks, nev
 
   // first probe: captures baseline, no change to diff against yet → no tick, no emit
   poller.tick();
+  await flush();
   expect(activities).toHaveLength(0);
 
   // subsequent probes: terminal changes each cadence → a tick accrues each time
@@ -934,6 +947,7 @@ test("interim: empty transcript + changing terminal accrues heartbeat ticks, nev
     frame += 7;
     clock += 7000;
     poller.tick();
+    await flush();
   }
   expect(blocks).toHaveLength(0); // moving terminal never stalls
   expect(activities.length).toBeGreaterThan(0);
@@ -945,7 +959,7 @@ test("interim: empty transcript + changing terminal accrues heartbeat ticks, nev
   expect(last.id ?? s.id).toBe(s.id);
 });
 
-test("interim: heartbeat ticks are windowed to STRIP_WINDOW_MS", () => {
+test("interim: heartbeat ticks are windowed to STRIP_WINDOW_MS", async () => {
   const store = new SessionStore(":memory:");
   store.create(baseSession);
   const activities: any[] = [];
@@ -960,6 +974,7 @@ test("interim: heartbeat ticks are windowed to STRIP_WINDOW_MS", () => {
   });
 
   poller.tick(); // baseline
+  await flush();
   // accrue ticks well past the window so the oldest must be dropped
   const totalSpan = STRIP_WINDOW_MS * 2;
   let elapsed = 0;
@@ -968,6 +983,7 @@ test("interim: heartbeat ticks are windowed to STRIP_WINDOW_MS", () => {
     clock += 7000;
     elapsed += 7000;
     poller.tick();
+    await flush();
   }
   const last = activities[activities.length - 1]!;
   for (const ts of last.recentTs) {
@@ -976,7 +992,7 @@ test("interim: heartbeat ticks are windowed to STRIP_WINDOW_MS", () => {
   }
 });
 
-test("interim: static terminal for ≥ stallMs fires a stall once, then clears when it moves again", () => {
+test("interim: static terminal for ≥ stallMs fires a stall once, then clears when it moves again", async () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);
   const blocks: { id: string; block: any }[] = [];
@@ -993,16 +1009,19 @@ test("interim: static terminal for ≥ stallMs fires a stall once, then clears w
 
   // first probe: baseline only — must NOT fire even though static
   poller.tick();
+  await flush();
   expect(blocks).toHaveLength(0);
 
   // still static, but not yet past stallMs → no fire
   clock += 7000;
   poller.tick();
+  await flush();
   expect(blocks).toHaveLength(0);
 
   // past stallMs of no change → stall fires once
   clock += 7000;
   poller.tick();
+  await flush();
   expect(blocks).toHaveLength(1);
   expect((blocks[0]!.block as any).shape).toBe("stall");
   expect((blocks[0]!.block as any).tail).toEqual(["frozen output"]);
@@ -1010,17 +1029,19 @@ test("interim: static terminal for ≥ stallMs fires a stall once, then clears w
   // still static past throttle → once per episode, no re-fire
   clock += 7000;
   poller.tick();
+  await flush();
   expect(blocks).toHaveLength(1);
 
   // terminal moves again → stall clears
   visible = "moving now";
   clock += 7000;
   poller.tick();
+  await flush();
   expect(blocks).toHaveLength(2);
   expect(blocks[1]).toEqual({ id: s.id, block: null });
 });
 
-test("interim: first static sample defers — does not fire immediately", () => {
+test("interim: first static sample defers — does not fire immediately", async () => {
   const store = new SessionStore(":memory:");
   store.create(baseSession);
   const blocks: unknown[] = [];
@@ -1036,10 +1057,11 @@ test("interim: first static sample defers — does not fire immediately", () => 
 
   // …the very first sample has no baseline to diff against → defer, no fire
   poller.tick();
+  await flush();
   expect(blocks).toHaveLength(0);
 });
 
-test("interim: terminal read throwing is best-effort — no throw, no emit", () => {
+test("interim: terminal read throwing is best-effort — no throw, no emit", async () => {
   const store = new SessionStore(":memory:");
   store.create(baseSession);
   const blocks: unknown[] = [];
@@ -1058,9 +1080,7 @@ test("interim: terminal read throwing is best-effort — no throw, no emit", () 
         workspaceId: "w",
       },
     ],
-    read: () => {
-      throw new Error("herdr down");
-    },
+    readAsync: () => Promise.reject(new Error("herdr down")),
   };
   const poller = new StatusPoller(
     store,
@@ -1079,11 +1099,78 @@ test("interim: terminal read throwing is best-effort — no throw, no emit", () 
   );
 
   expect(() => poller.tick()).not.toThrow();
+  await flush();
   expect(blocks).toHaveLength(0);
   expect(activities).toHaveLength(0);
 });
 
-test("interim path is NOT used when the transcript probe returns a non-null signal", () => {
+test("interim: a second probe while the first read is in flight does not start a second read", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  let reads = 0;
+  let resolveFirst!: (text: string) => void;
+
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working" as const,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    // first read hangs (caller controls when it resolves); count every call
+    readAsync: () => {
+      reads++;
+      return new Promise<string>((r) => {
+        resolveFirst = r;
+      });
+    },
+  };
+
+  let clock = 1_700_000_000_000;
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    () => {},
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    () => ({ snapshot: null, activity: null }),
+    { stallMs: 1, pendingStallMs: 1 },
+    7000,
+    () => {},
+    () => {},
+  );
+
+  // first tick dispatches a read that never resolves yet
+  poller.tick();
+  await flush();
+  expect(reads).toBe(1);
+
+  // advance past the throttle so the throttle alone wouldn't block a second probe,
+  // tick again → the in-flight guard must suppress a second read
+  clock += 7000;
+  poller.tick();
+  await flush();
+  expect(reads).toBe(1);
+
+  // let the first read finish → the next probe is free to read again
+  resolveFirst("done");
+  await flush();
+  clock += 7000;
+  poller.tick();
+  await flush();
+  expect(reads).toBe(2);
+});
+
+test("interim path is NOT used when the transcript probe returns a non-null signal", async () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);
   const activities: { id: string; activity: any }[] = [];
@@ -1103,9 +1190,15 @@ test("interim path is NOT used when the transcript probe returns a non-null sign
         workspaceId: "w",
       },
     ],
+    // a healthy (non-stalled) transcript signal must not read the terminal by
+    // EITHER path — the interim uses readAsync, evaluateStall the sync read
     read: () => {
-      visibleReads++; // a healthy (non-stalled) transcript signal must not read the terminal
+      visibleReads++;
       return "irrelevant";
+    },
+    readAsync: () => {
+      visibleReads++;
+      return Promise.resolve("irrelevant");
     },
   };
 
@@ -1136,6 +1229,7 @@ test("interim path is NOT used when the transcript probe returns a non-null sign
   poller.tick();
   clock += 7000;
   poller.tick();
+  await flush();
 
   // the transcript-driven emit still happens (real summary, not interim's null)
   expect(activities.length).toBeGreaterThan(0);
@@ -1327,6 +1421,7 @@ test("tick() is a no-op while maintenance is active (no herdr call, no reap)", (
       return [];
     },
     read: () => "",
+    readAsync: () => Promise.resolve(""),
   };
   const poller = new StatusPoller(
     store,
@@ -1361,6 +1456,7 @@ test("tick() swallows a herdr.list() throw (no crash, no reap)", () => {
       throw new Error("herdr list timed out"); // simulate HERDR_TIMEOUT_MS firing
     },
     read: () => "",
+    readAsync: () => Promise.resolve(""),
   };
   const poller = new StatusPoller(
     store,

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -268,7 +268,15 @@ test("flags a silent working agent with a FROZEN terminal as a stall, fires once
     7000, // probeCheckMs
   );
 
-  // first candidate probe only captures a terminal baseline — no emit yet
+  // priming probe: a first sighting (no baseline) is NOT live-writing, so it routes
+  // to interim and only RECORDS the transcript baseline (no readAsync injected → the
+  // interim read no-ops). The NEXT probe sees the newest record advance → transcript.
+  poller.tick();
+  expect(blocks).toHaveLength(0);
+
+  // first transcript-path probe (newest record advanced) only captures a terminal
+  // baseline — no emit yet
+  clock += 7000;
   poller.tick();
   expect(blocks).toHaveLength(0);
 
@@ -398,8 +406,14 @@ test("fires a stall for a hung command (pending past the ceiling) even when the 
     7000,
   );
 
+  // priming probe: first sighting (no baseline) → interim, just records the
+  // transcript baseline (no readAsync → no-op). Next probe advances → transcript path.
+  poller.tick();
+  expect(blocks).toHaveLength(0);
+
   // pending candidate fires immediately (no baseline defer) despite the moving terminal
   frame += 5;
+  clock += 7000;
   poller.tick();
   expect(blocks).toHaveLength(1);
   expect((blocks[0]!.block as any).shape).toBe("stall");
@@ -450,7 +464,9 @@ test("clears an emitted stall when the terminal resumes moving even before the t
     7000,
   );
 
-  poller.tick(); // baseline
+  poller.tick(); // priming: first sighting → interim, just records transcript baseline
+  clock += 7000;
+  poller.tick(); // first transcript probe → terminal baseline
   clock += 7000;
   poller.tick(); // frozen → stall fires
   expect(blocks).toHaveLength(1);
@@ -507,7 +523,10 @@ test("acknowledgeStall clears the flag without re-firing while still stalled", (
     7000, // probeCheckMs
   );
 
-  poller.tick(); // baseline capture, no emit yet
+  poller.tick(); // priming: first sighting → interim, just records transcript baseline
+  expect(blocks).toHaveLength(0);
+  clock += 7000;
+  poller.tick(); // first transcript probe → terminal baseline, no emit yet
   expect(blocks).toHaveLength(0);
   clock += 7000;
   poller.tick(); // frozen terminal → stall fires
@@ -687,7 +706,10 @@ test("maybeActivity emits via onActivity when the probe returns a signal", () =>
   store.create(baseSession);
   const activities: { id: string; activity: unknown }[] = [];
 
-  const clock = 100_000;
+  let clock = 100_000;
+  // newest-record ts must ADVANCE across probes for the transcript path to engage:
+  // the first sighting (no baseline) routes to interim, the second (advanced) probe
+  // takes the transcript path and emits.
   const signal = {
     lastActivityTs: 999,
     summary: "edited poller.ts",
@@ -703,13 +725,18 @@ test("maybeActivity emits via onActivity when the probe returns a signal", () =>
     3000,
     classifyBlocked,
     () => clock,
-    () => ({ snapshot: null, activity: signal }), // combined probe — same signal
+    () => ({ snapshot: null, activity: signal }), // combined probe tracks the (mutating) signal
     DEFAULT_STALL,
     7000, // probeCheckMs
     () => {}, // onReady
     (id, activity) => activities.push({ id, activity }),
   );
 
+  poller.tick(); // priming: first sighting → interim (constant terminal → no emit)
+  expect(activities).toHaveLength(0);
+
+  clock += 8000; // past throttle
+  signal.lastActivityTs = 1000; // newest record advanced → transcript path → emit
   poller.tick();
   expect(activities).toHaveLength(1);
   expect(activities[0]!.activity).toEqual(signal);
@@ -721,10 +748,11 @@ test("maybeActivity dedups identical signals — does not re-emit unchanged acti
   const activities: unknown[] = [];
 
   let clock = 100_000;
-  // signalA repeated = a transcript whose newest record did NOT advance between
-  // probes → the probe correctly flips to the interim terminal-diff path, where a
-  // constant `visible` buffer (runningHerdr.readAsync) emits nothing. signalB
-  // carries a newer lastActivityTs → live-writing again → transcript path re-emits.
+  // signal0 = the priming baseline (first sighting → interim, records lastTranscriptTs).
+  // signalA carries a NEWER ts → advances → transcript path emits. Repeating signalA
+  // (ts unchanged) → not advancing → interim path, constant terminal → no new emit.
+  // signalB carries a newer lastActivityTs → live-writing again → transcript path re-emits.
+  const signal0 = { lastActivityTs: 100, summary: "resumed", recentTs: [], recentErrTs: [] };
   const signalA = { lastActivityTs: 1234, summary: "$ bun test", recentTs: [], recentErrTs: [] };
   const signalB = {
     lastActivityTs: 5678,
@@ -732,7 +760,7 @@ test("maybeActivity dedups identical signals — does not re-emit unchanged acti
     recentTs: [],
     recentErrTs: [],
   };
-  let currentSignal: typeof signalA | typeof signalB = signalA;
+  let currentSignal: typeof signal0 | typeof signalA | typeof signalB = signal0;
 
   const poller = new StatusPoller(
     store,
@@ -750,7 +778,14 @@ test("maybeActivity dedups identical signals — does not re-emit unchanged acti
     (_id, activity) => activities.push(activity),
   );
 
-  poller.tick(); // first emit — signalA (first sighting counts as live-writing)
+  poller.tick(); // priming: first sighting → interim (constant terminal → no emit)
+  await flush();
+  expect(activities).toHaveLength(0);
+
+  // newest record advances → transcript path → first emit (signalA)
+  clock += 8000;
+  currentSignal = signalA;
+  poller.tick();
   await flush();
   expect(activities).toHaveLength(1);
 
@@ -806,17 +841,18 @@ test("maybeActivity respects activityCheckMs throttle", () => {
     (_id, activity) => activities.push(activity),
   );
 
-  poller.tick(); // probe called, signal emitted
+  poller.tick(); // probe called; first sighting → interim (constant terminal → no emit)
   expect(callCount).toBe(1);
-  expect(activities).toHaveLength(1);
+  expect(activities).toHaveLength(0);
 
   clock += 3000; // within probeCheckMs (7000) → throttled
   poller.tick();
   expect(callCount).toBe(1); // probe NOT called again yet
 
-  clock += 5000; // now past the 7000ms throttle
+  clock += 5000; // now past the 7000ms throttle; newest record advanced → transcript emit
   poller.tick();
   expect(callCount).toBe(2); // probe called again
+  expect(activities).toHaveLength(1);
 });
 
 test("maybeActivity skips emit when probe returns null", () => {
@@ -1251,15 +1287,24 @@ test("interim path is NOT used when the transcript probe returns a non-null sign
     (id, activity) => activities.push({ id, activity }),
   );
 
-  poller.tick();
-  clock += 7000;
-  poller.tick();
+  poller.tick(); // priming: first sighting → interim (records the transcript baseline)
   await flush();
+  // discount any terminal read from the priming interim probe; from here every probe
+  // sees the newest record advance → transcript path, which must never touch the terminal.
+  visibleReads = 0;
+  const activitiesBefore = activities.length;
+
+  for (let i = 0; i < 2; i++) {
+    clock += 7000;
+    poller.tick();
+    await flush();
+  }
 
   // the transcript-driven emit still happens (real summary, not interim's null)
-  expect(activities.length).toBeGreaterThan(0);
-  expect(activities[0]!.activity.summary).toBe("edited poller.ts");
-  expect(activities[0]!.id).toBe(s.id);
+  const transcriptEmits = activities.slice(activitiesBefore);
+  expect(transcriptEmits.length).toBeGreaterThan(0);
+  expect(transcriptEmits[0]!.activity.summary).toBe("edited poller.ts");
+  expect(transcriptEmits[0]!.id).toBe(s.id);
   // a non-stalled transcript snapshot clears the block path without reading the
   // terminal → the interim heartbeat/stall maps never get touched, no visible read
   expect(visibleReads).toBe(0);
@@ -1271,7 +1316,8 @@ test("interim engages when the transcript parses but its newest record is FROZEN
   // returns stale entries → signals come back NON-null but their newest record ts
   // never advances. The old "both signals null" trigger missed this and left the
   // session on the dead transcript path forever (strip stays empty). The liveness
-  // check must flip it to the interim terminal-diff after the first (baseline) probe.
+  // check must flip it to the interim terminal-diff — and since a first sighting (no
+  // baseline) is treated as NOT live-writing, that flip happens from the VERY FIRST probe.
   const store = new SessionStore(":memory:");
   store.create(baseSession);
   const activities: { id: string; activity: any }[] = [];
@@ -1321,13 +1367,13 @@ test("interim engages when the transcript parses but its newest record is FROZEN
     (id, activity) => activities.push({ id, activity }),
   );
 
-  // first probe: newest record never seen before → counts as live-writing, records
-  // the baseline, takes the transcript path once (no interim terminal read yet).
+  // first probe: no baseline → NOT live-writing → interim terminal-diff engages
+  // immediately, reading the live terminal (captures the change-baseline this cycle).
   poller.tick();
   await flush();
-  expect(visibleReads).toBe(0);
+  expect(visibleReads).toBe(1);
 
-  // subsequent probes: newest record did NOT advance → interim terminal-diff engages,
+  // subsequent probes: newest record still does NOT advance → interim stays engaged,
   // reading the (changing) live terminal and accruing heartbeat ticks.
   for (let i = 0; i < 3; i++) {
     frame += 7;
@@ -1341,6 +1387,70 @@ test("interim engages when the transcript parses but its newest record is FROZEN
   const last = activities[activities.length - 1]!.activity;
   expect(last.summary).toBeNull();
   expect(last.recentTs.length).toBeGreaterThan(0);
+});
+
+test("a resumed stale transcript engages the interim path on the FIRST probe (no baseline = not live)", async () => {
+  // A resumed session inherits an OLD frozen JSONL whose newest record is already
+  // outside the client strip window. The first-sighting gate must treat "no
+  // baseline" as NOT live-writing, so the very FIRST probe routes to the interim
+  // terminal-diff (engaging the live heat-strip immediately) rather than taking
+  // the transcript path once and emitting one stale, already-out-of-window signal.
+  // Reverting the gate (first sighting counts as live) makes this fail: probe 1
+  // would take the transcript path, read nothing async, and emit the stale signal.
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const activities: { id: string; activity: any }[] = [];
+  let visibleReads = 0;
+
+  const clock = 1_700_000_000_000;
+  // NON-null but constant (non-advancing) — the stale-resumed-JSONL shape.
+  const staleTs = clock - 600_000;
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working" as const,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => "irrelevant",
+    readAsync: () => {
+      visibleReads++;
+      return Promise.resolve("frozen output");
+    },
+  };
+
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    () => {},
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    () => ({
+      snapshot: { lastTs: staleTs, pending: false },
+      activity: { lastActivityTs: staleTs, summary: "old", recentTs: [], recentErrTs: [] },
+    }),
+    { stallMs: 1, pendingStallMs: 1 },
+    7000,
+    () => {},
+    (id, activity) => activities.push({ id, activity }),
+  );
+
+  // FIRST probe: no baseline → NOT live → interim engages (reads the terminal async).
+  poller.tick();
+  await flush(); // the interim read is async
+  expect(visibleReads).toBe(1); // interim path ran on probe 1
+  // and crucially the stale transcript activity was NOT emitted (its "old" summary
+  // would be out-of-window noise on the heat-strip).
+  expect(activities.some((a) => a.activity.summary === "old")).toBe(false);
 });
 
 test("a frozen resumed transcript with a frozen terminal fires an interim stall", async () => {
@@ -1389,14 +1499,11 @@ test("a frozen resumed transcript with a frozen terminal fires an interim stall"
     () => {},
   );
 
-  poller.tick(); // probe 1: transcript path (baseline), no interim read yet
-  await flush();
-  clock += 7000;
-  poller.tick(); // probe 2: interim engages, captures terminal baseline → defer
+  poller.tick(); // probe 1: no baseline → interim engages, captures terminal baseline → defer
   await flush();
   expect(blocks).toHaveLength(0);
   clock += 7000;
-  poller.tick(); // probe 3: terminal still frozen past stallMs → interim stall fires
+  poller.tick(); // probe 2: terminal still frozen past stallMs → interim stall fires
   await flush();
   expect(blocks).toHaveLength(1);
   expect((blocks[0]!.block as any).shape).toBe("stall");
@@ -1470,14 +1577,12 @@ test("a live-writing probe resets a stale interim stall baseline (Finding 1)", a
     () => {},
   );
 
-  // Episode 1 (interim): establish a stall baseline at clock C+7000, then fire.
-  poller.tick(); // probe 1: stale-frozen → transcript baseline, no interim read
+  // Episode 1 (interim): establish a stall baseline, then fire. A first sighting (no
+  // baseline) is NOT live-writing, so interim engages from probe 1.
+  poller.tick(); // probe 1: stale-frozen, no baseline → interim → terminal baseline (defer)
   await flush();
   clock += 7000;
-  poller.tick(); // probe 2: interim engages → terminal baseline (defer)
-  await flush();
-  clock += 7000;
-  poller.tick(); // probe 3: frozen past stallMs → interim stall fires
+  poller.tick(); // probe 2: frozen past stallMs → interim stall fires
   await flush();
   expect(blocks).toHaveLength(1);
   expect((blocks[0]!.block as any).shape).toBe("stall");
@@ -1544,7 +1649,10 @@ test("pruneInactive clears activity tracking for a running-only session that goe
     (_id, activity) => activities.push(activity),
   );
 
-  poller.tick(); // populates lastProbeAt + lastActivitySig
+  poller.tick(); // priming: first sighting → interim (no readAsync → no emit)
+  expect(activities).toHaveLength(0);
+  clock += 8000;
+  poller.tick(); // newest record advanced → transcript path → emit; populates the maps
   expect(activities).toHaveLength(1);
 
   // session is archived — poller sees empty store list → pruneInactive fires
@@ -1567,8 +1675,14 @@ test("pruneInactive clears activity tracking for a running-only session that goe
       workspaceId: "w",
     },
   ];
+  // prune cleared lastTranscriptTs too, so the resurrected session is a fresh first
+  // sighting → priming interim probe (no readAsync → no emit), then the advancing probe
+  // re-emits via the transcript path (proving the activity sig map was cleared by prune).
   clock += 8000;
-  poller.tick(); // must re-emit — activity sig map was cleared by prune
+  poller.tick(); // priming: first sighting post-resurrection → interim, no emit
+  expect(activities).toHaveLength(1);
+  clock += 8000;
+  poller.tick(); // newest record advanced → transcript path → must re-emit
   expect(activities).toHaveLength(2);
 });
 
@@ -1656,9 +1770,13 @@ test("activitySnapshot returns last emitted signal, pruned when the session goes
     () => {},
   );
 
-  poller.tick(); // probe emits → caches the signal
+  poller.tick(); // priming: first sighting → interim (no readAsync → no emit)
+  expect(poller.activitySnapshot()).toEqual({});
+
+  clock += 8000;
+  poller.tick(); // newest record advanced → transcript path emits → caches the signal
   expect(poller.activitySnapshot()).toEqual({
-    [s.id]: { lastActivityTs: 100_000, summary: "edited x.ts", recentTs: [], recentErrTs: [] },
+    [s.id]: { lastActivityTs: 108_000, summary: "edited x.ts", recentTs: [], recentErrTs: [] },
   });
 
   // session archived → next tick prunes it out of the snapshot too

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -223,8 +223,14 @@ test("flags a silent working agent with a FROZEN terminal as a stall, fires once
   const s = store.create(baseSession);
   const blocks: { id: string; block: unknown }[] = [];
 
-  // a frozen terminal — the visible buffer never changes between probes, so the
-  // liveness gate confirms the transcript-silence candidate as a genuine stall.
+  // Transcript-path stall (evaluateStall) test: the transcript stays LIVE-WRITING
+  // throughout (its newest record advances each probe = `clock - 600_000`, a fixed
+  // 10m-old gap that always reads as a silence candidate), so every probe runs the
+  // transcript path. The recovery is driven by the live TERMINAL moving (not a
+  // fresh transcript), which keeps the snapshot ts monotonic and avoids spuriously
+  // flipping to the interim path. A frozen terminal confirms the candidate; a
+  // moving one clears it and re-arms the episode.
+  let visible = "still chewing on it";
   const herdr = {
     list: (): HerdrAgent[] => [
       {
@@ -238,11 +244,10 @@ test("flags a silent working agent with a FROZEN terminal as a stall, fires once
         workspaceId: "w",
       },
     ],
-    read: () => "still chewing on it",
+    read: () => visible,
   };
 
   let clock = 1_700_000_000_000; // realistic ms epoch so a past lastTs stays positive
-  let stalled = true;
   const poller = new StatusPoller(
     store,
     herdr as any,
@@ -253,8 +258,10 @@ test("flags a silent working agent with a FROZEN terminal as a stall, fires once
     classifyBlocked,
     () => clock,
     // combined probe: one read → both signals. activity null here (stall-only test).
+    // lastTs always advances with the clock (live-writing) yet stays a 10m-old
+    // silence candidate, so the transcript path runs every probe.
     () => ({
-      snapshot: { lastTs: stalled ? clock - 600_000 : clock, pending: false },
+      snapshot: { lastTs: clock - 600_000, pending: false },
       activity: null,
     }),
     { stallMs: 1, pendingStallMs: 1 }, // 10m-old activity counts as stalled; fresh does not
@@ -282,15 +289,16 @@ test("flags a silent working agent with a FROZEN terminal as a stall, fires once
   poller.tick();
   expect(blocks).toHaveLength(1);
 
-  // transcript progresses → one clear, then re-arms for the next episode
-  stalled = false;
+  // terminal resumes moving (live generation) → the liveness gate clears the stall
+  // and resets the baseline, re-arming the episode.
+  visible = "Computing… (1s)";
   clock += 7000;
   poller.tick();
   expect(blocks).toHaveLength(2);
   expect(blocks[1]).toEqual({ id: s.id, block: null });
 
-  // stalled again: baseline was reset on resume, so the first probe defers again…
-  stalled = true;
+  // frozen again: baseline was reset on recovery, so the first probe defers again…
+  visible = "still chewing on it";
   clock += 7000;
   poller.tick();
   expect(blocks).toHaveLength(2);
@@ -461,6 +469,10 @@ test("acknowledgeStall clears the flag without re-firing while still stalled", (
   const s = store.create(baseSession);
   const blocks: { id: string; block: unknown }[] = [];
 
+  // transcript stays live-writing (lastTs always advances as a 10m-old silence
+  // candidate) → transcript path every probe; recovery is driven by the terminal
+  // moving, keeping the snapshot ts monotonic (no spurious interim flip).
+  let visible = "still chewing on it";
   const herdr = {
     list: (): HerdrAgent[] => [
       {
@@ -474,11 +486,10 @@ test("acknowledgeStall clears the flag without re-firing while still stalled", (
         workspaceId: "w",
       },
     ],
-    read: () => "still chewing on it",
+    read: () => visible,
   };
 
   let clock = 1_700_000_000_000;
-  let stalled = true;
   const poller = new StatusPoller(
     store,
     herdr as any,
@@ -489,7 +500,7 @@ test("acknowledgeStall clears the flag without re-firing while still stalled", (
     classifyBlocked,
     () => clock,
     () => ({
-      snapshot: { lastTs: stalled ? clock - 600_000 : clock, pending: false },
+      snapshot: { lastTs: clock - 600_000, pending: false },
       activity: null,
     }),
     { stallMs: 1, pendingStallMs: 1 },
@@ -513,14 +524,14 @@ test("acknowledgeStall clears the flag without re-firing while still stalled", (
   poller.tick();
   expect(blocks).toHaveLength(2);
 
-  // transcript progresses → episode re-arms; acknowledgeStall now no-ops (no live stall)
-  stalled = false;
+  // terminal moves → episode re-arms; acknowledgeStall now no-ops (no live stall)
+  visible = "Computing… (1s)";
   clock += 7000;
   poller.tick();
   expect(poller.acknowledgeStall(s.id)).toBe(false);
 
-  // a later stall fires again (baseline reset on resume → defer one probe, then fire)
-  stalled = true;
+  // a later stall fires again (baseline reset on recovery → defer one probe, then fire)
+  visible = "still chewing on it";
   clock += 7000;
   poller.tick();
   clock += 7000;
@@ -666,6 +677,9 @@ const runningHerdr = {
     },
   ],
   read: () => "",
+  // a constant visible buffer: when a probe flips to the interim path (transcript
+  // not advancing), the unchanged terminal produces no heartbeat tick → no emit.
+  readAsync: () => Promise.resolve("const"),
 };
 
 test("maybeActivity emits via onActivity when the probe returns a signal", () => {
@@ -701,12 +715,16 @@ test("maybeActivity emits via onActivity when the probe returns a signal", () =>
   expect(activities[0]!.activity).toEqual(signal);
 });
 
-test("maybeActivity dedups identical signals — does not re-emit unchanged activity", () => {
+test("maybeActivity dedups identical signals — does not re-emit unchanged activity", async () => {
   const store = new SessionStore(":memory:");
   store.create(baseSession);
   const activities: unknown[] = [];
 
   let clock = 100_000;
+  // signalA repeated = a transcript whose newest record did NOT advance between
+  // probes → the probe correctly flips to the interim terminal-diff path, where a
+  // constant `visible` buffer (runningHerdr.readAsync) emits nothing. signalB
+  // carries a newer lastActivityTs → live-writing again → transcript path re-emits.
   const signalA = { lastActivityTs: 1234, summary: "$ bun test", recentTs: [], recentErrTs: [] };
   const signalB = {
     lastActivityTs: 5678,
@@ -732,18 +750,22 @@ test("maybeActivity dedups identical signals — does not re-emit unchanged acti
     (_id, activity) => activities.push(activity),
   );
 
-  poller.tick(); // first emit — signalA
+  poller.tick(); // first emit — signalA (first sighting counts as live-writing)
+  await flush();
   expect(activities).toHaveLength(1);
 
-  // advance past throttle, same signal → dedup must suppress re-emit
+  // advance past throttle, SAME signal (ts unchanged) → not advancing → interim
+  // path, constant terminal → no new emit.
   clock += 8000;
   poller.tick();
+  await flush();
   expect(activities).toHaveLength(1);
 
-  // swap signal in place → same poller must detect the change and re-emit
+  // swap signal in place (newer ts) → live-writing again → transcript path re-emits
   clock += 8000;
   currentSignal = signalB;
   poller.tick();
+  await flush();
   expect(activities).toHaveLength(2);
   expect(activities[1]).toEqual(signalB);
 });
@@ -1203,12 +1225,6 @@ test("interim path is NOT used when the transcript probe returns a non-null sign
   };
 
   let clock = 1_700_000_000_000;
-  const transcriptSignal = {
-    lastActivityTs: 1234,
-    summary: "edited poller.ts",
-    recentTs: [1234],
-    recentErrTs: [],
-  };
   const poller = new StatusPoller(
     store,
     herdr as any,
@@ -1218,8 +1234,17 @@ test("interim path is NOT used when the transcript probe returns a non-null sign
     3000,
     classifyBlocked,
     () => clock,
-    // transcript yields data → existing path, interim path stays dormant
-    () => ({ snapshot: { lastTs: clock, pending: false }, activity: transcriptSignal }),
+    // transcript yields data and KEEPS advancing (newest record ts climbs with the
+    // clock = live-writing) → existing path, interim path stays dormant every probe.
+    () => ({
+      snapshot: { lastTs: clock, pending: false },
+      activity: {
+        lastActivityTs: clock,
+        summary: "edited poller.ts",
+        recentTs: [clock],
+        recentErrTs: [],
+      },
+    }),
     { stallMs: 1, pendingStallMs: 1 },
     7000,
     () => {},
@@ -1239,6 +1264,242 @@ test("interim path is NOT used when the transcript probe returns a non-null sign
   // terminal → the interim heartbeat/stall maps never get touched, no visible read
   expect(visibleReads).toBe(0);
   expect(blocks.every((b) => b === null || b === undefined)).toBe(true);
+});
+
+test("interim engages when the transcript parses but its newest record is FROZEN (resumed stale JSONL)", async () => {
+  // Finding 2: a resumed session inherits an OLD frozen JSONL, so parseActivity
+  // returns stale entries → signals come back NON-null but their newest record ts
+  // never advances. The old "both signals null" trigger missed this and left the
+  // session on the dead transcript path forever (strip stays empty). The liveness
+  // check must flip it to the interim terminal-diff after the first (baseline) probe.
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const activities: { id: string; activity: any }[] = [];
+  let visibleReads = 0;
+  let frame = 0;
+
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working" as const,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => "irrelevant",
+    // the interim path's heartbeat reads the live terminal (changing each cadence)
+    readAsync: () => {
+      visibleReads++;
+      return Promise.resolve(`Computing… (${frame}s)`);
+    },
+  };
+
+  let clock = 1_700_000_000_000;
+  // NON-null but FROZEN: lastActivityTs/lastTs are a fixed PAST value, never advancing.
+  const staleTs = clock - 600_000;
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    () => {},
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    () => ({
+      snapshot: { lastTs: staleTs, pending: false },
+      activity: { lastActivityTs: staleTs, summary: "old", recentTs: [], recentErrTs: [] },
+    }),
+    { stallMs: 1, pendingStallMs: 1 },
+    7000,
+    () => {},
+    (id, activity) => activities.push({ id, activity }),
+  );
+
+  // first probe: newest record never seen before → counts as live-writing, records
+  // the baseline, takes the transcript path once (no interim terminal read yet).
+  poller.tick();
+  await flush();
+  expect(visibleReads).toBe(0);
+
+  // subsequent probes: newest record did NOT advance → interim terminal-diff engages,
+  // reading the (changing) live terminal and accruing heartbeat ticks.
+  for (let i = 0; i < 3; i++) {
+    frame += 7;
+    clock += 7000;
+    poller.tick();
+    await flush();
+  }
+  expect(visibleReads).toBeGreaterThan(0);
+  // the heartbeat now comes from the terminal: a null summary (the diff can't name
+  // a tool-use) and non-empty recentTs.
+  const last = activities[activities.length - 1]!.activity;
+  expect(last.summary).toBeNull();
+  expect(last.recentTs.length).toBeGreaterThan(0);
+});
+
+test("a frozen resumed transcript with a frozen terminal fires an interim stall", async () => {
+  // The flip-to-interim must also own the stall for a stale-frozen transcript: a
+  // non-advancing JSONL + a frozen terminal is a real stall, surfaced by the
+  // interim frozen-TUI logic (with its first-sample baseline deferral).
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const blocks: { id: string; block: any }[] = [];
+
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working" as const,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => "frozen",
+    readAsync: () => Promise.resolve("frozen output"),
+  };
+
+  let clock = 1_700_000_000_000;
+  const staleTs = clock - 600_000;
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    () => ({
+      snapshot: { lastTs: staleTs, pending: false },
+      activity: { lastActivityTs: staleTs, summary: "old", recentTs: [], recentErrTs: [] },
+    }),
+    { stallMs: 5_000, pendingStallMs: 5_000 }, // < probe cadence so one frozen gap trips it
+    7000,
+    () => {},
+    () => {},
+  );
+
+  poller.tick(); // probe 1: transcript path (baseline), no interim read yet
+  await flush();
+  clock += 7000;
+  poller.tick(); // probe 2: interim engages, captures terminal baseline → defer
+  await flush();
+  expect(blocks).toHaveLength(0);
+  clock += 7000;
+  poller.tick(); // probe 3: terminal still frozen past stallMs → interim stall fires
+  await flush();
+  expect(blocks).toHaveLength(1);
+  expect((blocks[0]!.block as any).shape).toBe("stall");
+  expect((blocks[0]!.block as any).tail).toEqual(["frozen output"]);
+});
+
+test("a live-writing probe resets a stale interim stall baseline (Finding 1)", async () => {
+  // Finding 1: when the transcript path runs, nothing used to clear the interim
+  // baseline maps. A later re-entry into the interim path could then read a stale
+  // `lastInterimChangeAt` from a PRIOR interim episode and fire a false stall
+  // immediately, skipping the intended first-sample deferral. The fix calls
+  // resetInterim on every live-writing probe; this test drives the session into
+  // interim to set a stall baseline far in the past, runs ONE live-writing probe,
+  // then re-enters interim and asserts it DEFERS rather than firing off the old
+  // baseline — even though wall-clock minus that baseline far exceeds stallMs.
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const blocks: { id: string; block: any }[] = [];
+
+  let live = false; // toggles the transcript between frozen-stale and live-writing
+  let clock = 1_700_000_000_000;
+  const baseTs = clock;
+
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working" as const,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => "frozen",
+    // terminal stays frozen the whole time → the interim stall is driven purely by
+    // the change-baseline, which is exactly what resetInterim must clear.
+    readAsync: () => Promise.resolve("frozen terminal"),
+  };
+
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    // live=true → newest record advances (live-writing); live=false → frozen-stale
+    () =>
+      live
+        ? {
+            snapshot: { lastTs: clock, pending: false },
+            activity: { lastActivityTs: clock, summary: "live", recentTs: [], recentErrTs: [] },
+          }
+        : {
+            snapshot: { lastTs: baseTs - 600_000, pending: false },
+            activity: {
+              lastActivityTs: baseTs - 600_000,
+              summary: "old",
+              recentTs: [],
+              recentErrTs: [],
+            },
+          },
+    { stallMs: 5_000, pendingStallMs: 5_000 }, // < probe cadence so one frozen gap trips it
+    7000,
+    () => {},
+    () => {},
+  );
+
+  // Episode 1 (interim): establish a stall baseline at clock C+7000, then fire.
+  poller.tick(); // probe 1: stale-frozen → transcript baseline, no interim read
+  await flush();
+  clock += 7000;
+  poller.tick(); // probe 2: interim engages → terminal baseline (defer)
+  await flush();
+  clock += 7000;
+  poller.tick(); // probe 3: frozen past stallMs → interim stall fires
+  await flush();
+  expect(blocks).toHaveLength(1);
+  expect((blocks[0]!.block as any).shape).toBe("stall");
+
+  // One live-writing probe: newest record advances → transcript path → resetInterim
+  // clears lastInterimChangeAt/ticks/visible. A non-stalled snapshot also clears the
+  // stall block (the clear emit).
+  live = true;
+  clock += 7000;
+  poller.tick();
+  await flush();
+  const afterLive = blocks.length;
+  expect(blocks[afterLive - 1]).toEqual({ id: store.list()[0]!.id, block: null });
+
+  // Re-enter interim. The wall-clock gap from the OLD (episode-1) baseline far
+  // exceeds stallMs, so WITHOUT resetInterim this FIRST re-entry sample would fire
+  // immediately off the stale baseline. With the reset it has no baseline → defers.
+  live = false;
+  clock += 7000;
+  poller.tick(); // first interim sample post-reset → MUST defer, not fire
+  await flush();
+  expect(blocks.length).toBe(afterLive); // no new stall fired off the stale baseline
 });
 
 test("pruneInactive clears activity tracking for a running-only session that goes away", () => {

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -862,6 +862,291 @@ test("maybeActivity does not run for non-running (idle/blocked) sessions", () =>
   expect(activities).toHaveLength(0);
 });
 
+// ── interim terminal-diff path (transcript stopped live-writing) ───────────────
+
+import { STRIP_WINDOW_MS } from "../src/activity-signal";
+
+/** A running agent whose transcript probe yields NOTHING (the CC 2.1.169 case):
+ *  both snapshot and activity are null, so the poller falls back to the
+ *  terminal-diff interim path. `read("visible")` returns whatever `visible` holds. */
+function interimHarness(opts: {
+  store: SessionStore;
+  visible: () => string;
+  now: () => number;
+  stallCfg?: { stallMs: number; pendingStallMs: number };
+  onBlock?: (id: string, block: unknown) => void;
+  onActivity?: (id: string, activity: unknown) => void;
+}) {
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working" as const,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => opts.visible(),
+  };
+  return new StatusPoller(
+    opts.store,
+    herdr as any,
+    () => {},
+    (id, block) => opts.onBlock?.(id, block),
+    1000,
+    3000,
+    classifyBlocked,
+    opts.now,
+    () => ({ snapshot: null, activity: null }), // empty transcript → interim path
+    opts.stallCfg ?? { stallMs: 1, pendingStallMs: 1 },
+    7000, // probeCheckMs
+    () => {},
+    (id, activity) => opts.onActivity?.(id, activity),
+  );
+}
+
+test("interim: empty transcript + changing terminal accrues heartbeat ticks, never stalls", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const activities: { id: string; activity: any }[] = [];
+  const blocks: unknown[] = [];
+
+  let clock = 1_700_000_000_000;
+  let frame = 0;
+  const poller = interimHarness({
+    store,
+    visible: () => `Computing… (${frame}s)`,
+    now: () => clock,
+    onActivity: (id, activity) => activities.push({ id, activity }),
+    onBlock: (_id, block) => blocks.push(block),
+  });
+
+  // first probe: captures baseline, no change to diff against yet → no tick, no emit
+  poller.tick();
+  expect(activities).toHaveLength(0);
+
+  // subsequent probes: terminal changes each cadence → a tick accrues each time
+  for (let i = 0; i < 3; i++) {
+    frame += 7;
+    clock += 7000;
+    poller.tick();
+  }
+  expect(blocks).toHaveLength(0); // moving terminal never stalls
+  expect(activities.length).toBeGreaterThan(0);
+  const last = activities[activities.length - 1]!.activity;
+  expect(last.recentTs.length).toBeGreaterThan(0);
+  expect(last.summary).toBeNull();
+  expect(last.recentErrTs).toEqual([]);
+  expect(last.lastActivityTs).toBe(last.recentTs[last.recentTs.length - 1]);
+  expect(last.id ?? s.id).toBe(s.id);
+});
+
+test("interim: heartbeat ticks are windowed to STRIP_WINDOW_MS", () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const activities: any[] = [];
+
+  let clock = 1_700_000_000_000;
+  let frame = 0;
+  const poller = interimHarness({
+    store,
+    visible: () => `frame ${frame}`,
+    now: () => clock,
+    onActivity: (_id, activity) => activities.push(activity),
+  });
+
+  poller.tick(); // baseline
+  // accrue ticks well past the window so the oldest must be dropped
+  const totalSpan = STRIP_WINDOW_MS * 2;
+  let elapsed = 0;
+  while (elapsed < totalSpan) {
+    frame += 1;
+    clock += 7000;
+    elapsed += 7000;
+    poller.tick();
+  }
+  const last = activities[activities.length - 1]!;
+  for (const ts of last.recentTs) {
+    expect(ts).toBeGreaterThanOrEqual(clock - STRIP_WINDOW_MS);
+    expect(ts).toBeLessThanOrEqual(clock);
+  }
+});
+
+test("interim: static terminal for ≥ stallMs fires a stall once, then clears when it moves again", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const blocks: { id: string; block: any }[] = [];
+
+  let clock = 1_700_000_000_000;
+  let visible = "frozen output";
+  const poller = interimHarness({
+    store,
+    visible: () => visible,
+    now: () => clock,
+    stallCfg: { stallMs: 10_000, pendingStallMs: 10_000 },
+    onBlock: (id, block) => blocks.push({ id, block }),
+  });
+
+  // first probe: baseline only — must NOT fire even though static
+  poller.tick();
+  expect(blocks).toHaveLength(0);
+
+  // still static, but not yet past stallMs → no fire
+  clock += 7000;
+  poller.tick();
+  expect(blocks).toHaveLength(0);
+
+  // past stallMs of no change → stall fires once
+  clock += 7000;
+  poller.tick();
+  expect(blocks).toHaveLength(1);
+  expect((blocks[0]!.block as any).shape).toBe("stall");
+  expect((blocks[0]!.block as any).tail).toEqual(["frozen output"]);
+
+  // still static past throttle → once per episode, no re-fire
+  clock += 7000;
+  poller.tick();
+  expect(blocks).toHaveLength(1);
+
+  // terminal moves again → stall clears
+  visible = "moving now";
+  clock += 7000;
+  poller.tick();
+  expect(blocks).toHaveLength(2);
+  expect(blocks[1]).toEqual({ id: s.id, block: null });
+});
+
+test("interim: first static sample defers — does not fire immediately", () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const blocks: unknown[] = [];
+
+  const clock = 1_700_000_000_000;
+  const poller = interimHarness({
+    store,
+    visible: () => "static",
+    now: () => clock,
+    stallCfg: { stallMs: 1, pendingStallMs: 1 }, // even with a 1ms window…
+    onBlock: (_id, block) => blocks.push(block),
+  });
+
+  // …the very first sample has no baseline to diff against → defer, no fire
+  poller.tick();
+  expect(blocks).toHaveLength(0);
+});
+
+test("interim: terminal read throwing is best-effort — no throw, no emit", () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const blocks: unknown[] = [];
+  const activities: unknown[] = [];
+
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working" as const,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => {
+      throw new Error("herdr down");
+    },
+  };
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (_id, block) => blocks.push(block),
+    1000,
+    3000,
+    classifyBlocked,
+    () => 1_700_000_000_000,
+    () => ({ snapshot: null, activity: null }),
+    { stallMs: 1, pendingStallMs: 1 },
+    7000,
+    () => {},
+    (_id, activity) => activities.push(activity),
+  );
+
+  expect(() => poller.tick()).not.toThrow();
+  expect(blocks).toHaveLength(0);
+  expect(activities).toHaveLength(0);
+});
+
+test("interim path is NOT used when the transcript probe returns a non-null signal", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const activities: { id: string; activity: any }[] = [];
+  const blocks: unknown[] = [];
+  let visibleReads = 0;
+
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working" as const,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => {
+      visibleReads++; // a healthy (non-stalled) transcript signal must not read the terminal
+      return "irrelevant";
+    },
+  };
+
+  let clock = 1_700_000_000_000;
+  const transcriptSignal = {
+    lastActivityTs: 1234,
+    summary: "edited poller.ts",
+    recentTs: [1234],
+    recentErrTs: [],
+  };
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (_id, block) => blocks.push(block),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    // transcript yields data → existing path, interim path stays dormant
+    () => ({ snapshot: { lastTs: clock, pending: false }, activity: transcriptSignal }),
+    { stallMs: 1, pendingStallMs: 1 },
+    7000,
+    () => {},
+    (id, activity) => activities.push({ id, activity }),
+  );
+
+  poller.tick();
+  clock += 7000;
+  poller.tick();
+
+  // the transcript-driven emit still happens (real summary, not interim's null)
+  expect(activities.length).toBeGreaterThan(0);
+  expect(activities[0]!.activity.summary).toBe("edited poller.ts");
+  expect(activities[0]!.id).toBe(s.id);
+  // a non-stalled transcript snapshot clears the block path without reading the
+  // terminal → the interim heartbeat/stall maps never get touched, no visible read
+  expect(visibleReads).toBe(0);
+  expect(blocks.every((b) => b === null || b === undefined)).toBe(true);
+});
+
 test("pruneInactive clears activity tracking for a running-only session that goes away", () => {
   // A session that was only ever running (never blocked) populates lastProbeAt
   // and lastActivitySig but never lastSig — the old pruneInactive iterated only


### PR DESCRIPTION
## Why

Every running agent's **heartbeat strip is empty** and **stall detection is silently disabled**. Root cause is upstream, not our code: **Claude Code 2.1.169 stopped writing the session transcript JSONL live** (it now flushes only on exit). Shepherd derives the heartbeat strip, current-activity summary, and stall detection by polling that file (`jsonlPathFor` → `parseActivity`/`snapshotFrom`), so every running agent yields an empty signal:

- heartbeat `recentTs` is empty → strip renders all level-0 cells;
- `snapshotFrom([])` returns `null` → `evaluateStall` bails *before* the terminal read → stall is effectively **disabled** for fresh sessions (wedged agents go unflagged).

Verified on the live host (frozen `<id>.jsonl` after dozens of tool calls; zero live writes during a 35s watch; headless `-p` runs flush a full file on exit). Ruled out our same-day "collision fix" (#417) — it only touches reviewer worktree paths; a fresh session has the correct id+path yet a frozen transcript.

## What this PR does (interim restore)

Restores a **live signal from the herdr terminal buffer** Shepherd already has access to — no Claude-Code-side hooks, and it works on **already-running agents without respawn**:

- When the transcript signal is empty, `poller.ts` derives a coarse heartbeat from terminal-buffer-change ticks (windowed to `STRIP_WINDOW_MS` → `SessionActivity.recentTs`) and a **frozen-TUI stall** (fire when the visible buffer is unchanged ≥ `stallMs`, clear on change).
- The interim path is gated on an empty transcript, so it **auto-deactivates** if Claude Code restores live transcript writes.
- The terminal read is **async + non-blocking** (`herdr.readAsync` via `promisify(execFile)`, dispatched fire-and-forget with a per-session in-flight guard) so it never blocks the single poll loop (honours the no-sync-exec-on-loop rule from #437).

### Known limitation (by design)
The interim stall is **frozen-TUI-only** — it does not detect a hung command whose elapsed timer keeps ticking. Full-fidelity per-tool heartbeat (summary + error tinting) and hung-command stall require a durable hook-based sidecar, which is **deliberately deferred** (see below).

## Scope notes
- **Usage signals:** the per-session token gauge already fails closed (`Viewport` guards `usage.total > 0`, so a frozen transcript shows nothing, not a fake 0); the account-wide limit gauge undercounts in-flight tokens but self-corrects via the existing `/usage` recalibration and on session exit. No usage rework here — deferred to the durable path.
- **Deferred (held):** the durable Pre/PostToolUse hook sidecar (full fidelity) is **held** pending confirmation the CC 2.1.169 change is intentional (changelog/maintainer) or survives ≥3 days without a 2.1.170 fix. Plan: `.shepherd-plan.md`.
- **Follow-up:** file the upstream Claude Code bug.

Server-only fix; no user-facing feature added (restores existing behaviour) → no feature-catalog entry.

## Test
- New `test/poller.test.ts` cases: empty transcript + changing buffer → heartbeat ticks, no stall; static buffer ≥ stallMs → stall fires once, clears on change; first-sample baseline deferral; non-null transcript signal → interim path not used; async in-flight guard prevents overlapping reads.
- `test/herdr.test.ts`: `readAsync` argv/parse/timeout/maintenance-guard parity with sync `read`.
- Full root suite: 1483 pass / 1 skip / 0 fail. `tsc --noEmit`, `eslint`, and `fallow audit` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)