### PR TITLE
feat(ui): stack repo-status rows and make them a herd filter

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -131,6 +131,8 @@
   "automation_plan_gate_task_planning": "Dieser Task: Gate aktiv — Planung",
   "automation_plan_gate_task_executing": "Dieser Task: Plan genehmigt — Ausführung",
   "repo_status_label": "Repo-Status",
+  "repo_filter_apply_aria": "Herde auf Agenten von {repo} filtern",
+  "repo_filter_active_aria": "Nur Agenten von {repo} — klicken, um alle Repos anzuzeigen",
   "automation_info_aria": "Ausführliche Erklärung zu {name} anzeigen",
   "automation_critic_detail": "Ist der Kritiker an, beobachtet Shepherd jeden Pull Request, den ein Agent öffnet. Sobald dessen CI-Prüfungen vollständig durchlaufen (grün werden), startet ein eigener, nur-lesender Review-Agent in einer isolierten Kopie des Repos. Er liest den kompletten Diff des Pull Requests, sucht nach Bugs, Sicherheitsproblemen und allem, was die Aufgabe nicht wirklich erfüllt, und schreibt ein Urteil zurück — entweder „sieht gut aus“ oder eine Liste konkreter Befunde, jeweils mit Datei und Zeile. Der Review verändert deinen Code nie, er meldet nur. Ein Diff, der lediglich rebased und force-gepusht wurde, wird als identisch erkannt und nicht erneut geprüft.",
   "automation_autoaddress_detail": "Auto-Bearbeitung schließt den Kreis nach dem Kritiker. Immer wenn der Kritiker Befunde zurückgibt, bekommt der Agent, der den Pull Request geschrieben hat, automatisch eine saubere Liste davon und den Auftrag, sie zu beheben — du reichst nichts von Hand weiter. Der Agent pusht eine Korrektur, CI läuft erneut, der Kritiker prüft die neue Version noch einmal, und das wiederholt sich, bis die Befundliste leer zurückkommt. Damit das nicht endlos läuft, ist die Schleife begrenzt — standardmäßig 3 Runden, in den Einstellungen anpassbar. Hat der Agent auf dem PR bereits begründet, warum er einen Punkt ablehnt, wird diese Notiz beim nächsten Durchlauf an den Kritiker übergeben, damit derselbe Einwand nicht blind erneut erhoben wird. Das funktioniert nur, solange der Kritiker selbst eingeschaltet ist.",
@@ -192,6 +194,7 @@
   "herd_all_title": "Alle Sitzungen im Herd anzeigen",
   "herd_ready_title": "Nur Sitzungen anzeigen, die auf dich warten: inaktiv, blockiert oder fertig",
   "herd_ready_empty": "Nichts wartet. Alle sind beschäftigt",
+  "herd_repo_filter_empty": "Keine Agenten für {repo}.",
   "herd_ci_running_group": "CI läuft ({count})",
   "herd_ci_failed_group": "CI fehlgeschlagen ({count})",
   "herd_reviewer_running_group": "Review läuft ({count})",
@@ -771,5 +774,7 @@
   "feat_repo_roles_title": "Repo-Zuständigkeiten",
   "feat_repo_roles_body": "Lege im Automations-Panel fest, wer ein Repo reviewt und wer merged. Ist der Merge jemand anderes (z. B. ein Teammitglied, das PRs landet), zeigt ein grüner PR \"Warten auf …\" statt \"Du bist dran\".",
   "feat_backlog_active_highlight_title": "Sieh auf einen Blick, welche Issues schon beansprucht sind",
-  "feat_backlog_active_highlight_body": "Issues, die ein Shepherd-Agent beansprucht hat, tragen das Label „shepherd:active“. In der Issue-Liste des Backlogs hebt es sich jetzt in Amber ab, sodass du beanspruchte von freier Arbeit auf einen Blick unterscheidest, statt jedes Chip zu lesen."
+  "feat_backlog_active_highlight_body": "Issues, die ein Shepherd-Agent beansprucht hat, tragen das Label „shepherd:active“. In der Issue-Liste des Backlogs hebt es sich jetzt in Amber ab, sodass du beanspruchte von freier Arbeit auf einen Blick unterscheidest, statt jedes Chip zu lesen.",
+  "feat_repo_filter_title": "Herde nach Repo filtern",
+  "feat_repo_filter_body": "Das Repo-Status-Band stapelt jetzt ein Repo pro Zeile. Klicke einen Repo-Namen an, um darunter nur dessen Agenten zu zeigen; erneut klicken zeigt wieder alle Repos."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -131,6 +131,8 @@
   "automation_plan_gate_task_planning": "This task: gate active — planning",
   "automation_plan_gate_task_executing": "This task: plan approved — executing",
   "repo_status_label": "Repo status",
+  "repo_filter_apply_aria": "Filter the herd to {repo} agents only",
+  "repo_filter_active_aria": "Showing {repo} agents only — click to show all repos",
   "automation_info_aria": "Show a detailed explanation of {name}",
   "automation_critic_detail": "With the Critic on, Shepherd watches every pull request an agent opens. The moment its CI checks all pass (turn green), a separate, read-only review agent starts up in an isolated copy of the repo. It reads the pull request's full diff, hunts for bugs, security problems and anything that doesn't actually satisfy the task, and writes back a verdict — either \"looks good\" or a list of concrete findings, each tied to a file and line. The review never edits your code; it only reports. A diff that was merely rebased and force-pushed is recognised as identical and is not reviewed twice.",
   "automation_autoaddress_detail": "Auto-Address closes the loop after the Critic. Whenever the Critic returns findings, the agent that wrote the pull request is automatically handed a tidy list of them and asked to fix them — you don't relay anything by hand. The agent pushes a fix, CI runs again, the Critic re-reviews the new version, and the cycle repeats until the findings list comes back empty. To stop it running forever, the loop is capped — three rounds by default, adjustable in Settings. If the agent already explained on the PR why it declined a point, that note is passed to the Critic on the next pass so the same objection isn't raised blindly again. This only works while the Critic itself is on.",
@@ -192,6 +194,7 @@
   "herd_all_title": "Show every session in the herd",
   "herd_ready_title": "Show only sessions awaiting you: idle, blocked, or done",
   "herd_ready_empty": "Nothing waiting. All hands working",
+  "herd_repo_filter_empty": "No agents for {repo}.",
   "herd_ci_running_group": "CI running ({count})",
   "herd_ci_failed_group": "CI failed ({count})",
   "herd_reviewer_running_group": "Reviewing ({count})",
@@ -771,5 +774,7 @@
   "feat_repo_roles_title": "Repo responsibilities",
   "feat_repo_roles_body": "Set who reviews and who merges a repo in its automation panel. When the merger is someone else (e.g. a teammate who lands PRs), a green PR reads \"Waiting on them\" instead of \"Your turn\".",
   "feat_backlog_active_highlight_title": "See at a glance which issues are already claimed",
-  "feat_backlog_active_highlight_body": "Issues a Shepherd agent has claimed carry a “shepherd:active” label. In the backlog's issue list it now stands out in amber, so you can tell taken work from free work at a glance instead of reading every chip."
+  "feat_backlog_active_highlight_body": "Issues a Shepherd agent has claimed carry a “shepherd:active” label. In the backlog's issue list it now stands out in amber, so you can tell taken work from free work at a glance instead of reading every chip.",
+  "feat_repo_filter_title": "Filter the herd by repo",
+  "feat_repo_filter_body": "The repo-status band now stacks one repo per line. Click a repo name to show only its agents in the herd below; click it again to show every repo."
 }

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -23,6 +23,7 @@
     standardCommandUnset = false,
     onsettings = undefined,
     flow = false,
+    filteredRepo = null,
   }: {
     sessions: Session[];
     selectedId: string | null;
@@ -49,6 +50,10 @@
     // when true, the session list renders at natural height (no internal scroll)
     // so the parent page can drive scrolling; default false preserves existing behavior
     flow?: boolean;
+    // basename of an active repo filter; when set and the (already-filtered) session
+    // list is empty, show a neutral "no agents for this repo" note instead of the
+    // first-run EmptyHerd nudge. null = unfiltered.
+    filteredRepo?: string | null;
   } = $props();
 
   // a critic post-PR review or a pre-execution plan-gate review currently in flight —
@@ -118,7 +123,11 @@
   </div>
   <div class="units" class:flow>
     {#if sessions.length === 0}
-      <EmptyHerd {onnew} {standardCommandUnset} {onsettings} />
+      {#if filteredRepo}
+        <div class="empty micro static">{m.herd_repo_filter_empty({ repo: filteredRepo })}</div>
+      {:else}
+        <EmptyHerd {onnew} {standardCommandUnset} {onsettings} />
+      {/if}
     {:else if shown.length === 0}
       <div class="empty micro static">{m.herd_ready_empty()}</div>
     {:else}

--- a/ui/src/lib/components/HerdGrid.svelte
+++ b/ui/src/lib/components/HerdGrid.svelte
@@ -2,6 +2,7 @@
   import type { Session, GitState } from "$lib/types";
   import UnitTile from "./UnitTile.svelte";
   import EmptyHerd from "./EmptyHerd.svelte";
+  import { m } from "$lib/paraglide/messages";
 
   let {
     sessions,
@@ -12,6 +13,7 @@
     git,
     standardCommandUnset = false,
     onsettings = undefined,
+    filteredRepo = null,
   }: {
     sessions: Session[];
     selectedId: string | null;
@@ -21,11 +23,17 @@
     git: Record<string, GitState>;
     standardCommandUnset?: boolean;
     onsettings?: () => void;
+    // basename of an active repo filter; empty + filtered → neutral note, not EmptyHerd
+    filteredRepo?: string | null;
   } = $props();
 </script>
 
 {#if sessions.length === 0}
-  <EmptyHerd {onnew} {standardCommandUnset} {onsettings} />
+  {#if filteredRepo}
+    <div class="grid-empty">{m.herd_repo_filter_empty({ repo: filteredRepo })}</div>
+  {:else}
+    <EmptyHerd {onnew} {standardCommandUnset} {onsettings} />
+  {/if}
 {:else}
   <div class="herd-grid">
     {#each sessions as session (session.id)}
@@ -50,5 +58,13 @@
     overflow: auto;
     padding: 2px;
     align-content: start;
+  }
+  .grid-empty {
+    padding: 24px 14px;
+    text-align: center;
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
   }
 </style>

--- a/ui/src/lib/components/QueueStrip.svelte
+++ b/ui/src/lib/components/QueueStrip.svelte
@@ -24,12 +24,18 @@
     items = [],
     injectable = [],
     onlearnings,
+    repoFilter = null,
+    onrepofilter,
   }: {
     drain: Record<string, DrainStatus>;
     autoMerge?: Record<string, AutoMergeStatus>;
     items?: Learning[];
     injectable?: RepoInjectable[];
     onlearnings?: (repoPath: string) => void;
+    // active herd repo filter (full repo path), or null when showing all repos
+    repoFilter?: string | null;
+    // toggle the herd filter for a repo; null clears it. Absent → repo names are inert.
+    onrepofilter?: (repoPath: string | null) => void;
   } = $props();
 
   const rows = $derived(repoStatusRows(drain, items, injectable));
@@ -78,7 +84,23 @@
     <ul class="qs-rows">
       {#each rows as row (row.repoPath)}
         <li class="qs-row" class:paused={row.drain?.paused}>
-          <span class="qs-repo">{basename(row.repoPath)}</span>
+          {#if onrepofilter}
+            {@const active = repoFilter === row.repoPath}
+            <button
+              type="button"
+              class="qs-repo qs-repo-btn"
+              class:active
+              aria-pressed={active}
+              aria-label={active
+                ? m.repo_filter_active_aria({ repo: basename(row.repoPath) })
+                : m.repo_filter_apply_aria({ repo: basename(row.repoPath) })}
+              onclick={() => onrepofilter(active ? null : row.repoPath)}
+            >
+              {basename(row.repoPath)}
+            </button>
+          {:else}
+            <span class="qs-repo">{basename(row.repoPath)}</span>
+          {/if}
           {#if row.drain}
             {@const d = row.drain}
             <span class="qs-inflight">{m.drain_inflight({ count: d.inFlight, max: d.max })}</span>
@@ -183,7 +205,7 @@
 <style>
   .queue-strip {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 12px;
     flex-wrap: wrap;
     padding: 5px 10px;
@@ -199,12 +221,16 @@
     color: var(--color-muted);
     white-space: nowrap;
     flex-shrink: 0;
+    /* top-aligned with the first stacked row */
+    padding-top: 2px;
   }
+  /* one repo per line — a clean vertical list instead of an inline wrap that
+     breaks mid-row at narrow widths */
   .qs-rows {
     display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 14px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
     margin: 0;
     padding: 0;
     list-style: none;
@@ -225,6 +251,28 @@
   .qs-repo {
     color: var(--color-ink-bright);
     font-weight: 500;
+  }
+  /* repo name doubles as the herd filter toggle — same inline-button chrome as the
+     queued/learnings buttons so the row reads as one band; amber when it's the
+     active filter, mirroring the herd's all/ready filter active tone. */
+  .qs-repo-btn {
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+  }
+  .qs-repo-btn:hover,
+  .qs-repo-btn:focus-visible {
+    color: var(--color-amber);
+  }
+  .qs-repo-btn.active {
+    color: var(--color-amber);
+    text-decoration: underline;
+    text-underline-offset: 3px;
   }
   .qs-inflight {
     color: var(--color-ink);
@@ -366,7 +414,8 @@
      Desktop (pointer: fine) sizing is untouched, so the band stays compact there. */
   @media (pointer: coarse) {
     .qs-queued-btn,
-    .qs-insights {
+    .qs-insights,
+    .qs-repo-btn {
       display: inline-flex;
       align-items: center;
       justify-content: center;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -211,4 +211,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_star_title",
     bodyKey: "feat_star_body",
   },
+  {
+    // No targetId: the repo-status band only renders when a repo has an active drain
+    // or pending learnings, so a coachmark anchor would often be unmounted — surface
+    // via the What's-New drawer only.
+    id: "repo-status-filter",
+    sinceVersion: "1.20.0",
+    titleKey: "feat_repo_filter_title",
+    bodyKey: "feat_repo_filter_body",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -64,6 +64,7 @@
   import ActionBar from "$lib/components/ActionBar.svelte";
   import HerdGrid from "$lib/components/HerdGrid.svelte";
   import QueueStrip from "$lib/components/QueueStrip.svelte";
+  import { repoStatusRows } from "$lib/components/queue-strip";
   import BacklogView from "$lib/components/BacklogView.svelte";
   import BacklogOverlay from "$lib/components/BacklogOverlay.svelte";
   import UpdateModal from "$lib/components/UpdateModal.svelte";
@@ -113,8 +114,23 @@
   // repoPath so the drawer scrolls to the matching section; null = opened globally.
   let learningsRepo = $state<string | null>(null);
   // Herd repo filter (full repo path) toggled from the repo-status band; null = all
-  // repos. Only narrows the herd list views — selection and global counts stay whole.
+  // repos. Only repos that appear in the band (enabled drain or pending learnings) are
+  // filterable — the band IS the toggle, so a repo with agents but no drain/learnings
+  // can't be selected. Only narrows the herd list views — selection and global counts
+  // stay whole.
   let repoFilter = $state<string | null>(null);
+  // The band's filterable repos, so the toggle and the auto-clear guard agree on scope.
+  const bandRepoPaths = $derived(
+    new Set(
+      repoStatusRows(store.drain, learnings.items, learnings.injectable).map((r) => r.repoPath),
+    ),
+  );
+  // A stale filter would otherwise strand the herd: when the filtered repo's band row
+  // disappears (drain disabled, learnings resolved) its toggle vanishes with no way to
+  // reset short of a reload. Clear it the moment its repo leaves the band.
+  $effect(() => {
+    if (repoFilter && !bandRepoPaths.has(repoFilter)) repoFilter = null;
+  });
   const herdSessions = $derived(
     repoFilter ? store.sessions.filter((s) => s.repoPath === repoFilter) : store.sessions,
   );

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -112,6 +112,14 @@
   // When the learnings drawer is opened from a repo's status row, this carries that
   // repoPath so the drawer scrolls to the matching section; null = opened globally.
   let learningsRepo = $state<string | null>(null);
+  // Herd repo filter (full repo path) toggled from the repo-status band; null = all
+  // repos. Only narrows the herd list views — selection and global counts stay whole.
+  let repoFilter = $state<string | null>(null);
+  const herdSessions = $derived(
+    repoFilter ? store.sessions.filter((s) => s.repoPath === repoFilter) : store.sessions,
+  );
+  // basename of the active filter for the herd's empty-state copy; null when unfiltered
+  const repoFilterName = $derived(repoFilter ? basename(repoFilter) : null);
   let showUpdate = $state(false);
   // live state of a launched deploy → modal tails its log + surfaces failures
   let deploy = $state<DeployState | null>(null);
@@ -739,6 +747,8 @@
           learningsRepo = repoPath;
           showLearnings = true;
         }}
+        {repoFilter}
+        onrepofilter={(repoPath) => (repoFilter = repoPath)}
       />
     </div>
   {/if}
@@ -748,7 +758,8 @@
       {#if mobileScreen === "list"}
         <div class="col">
           <Herd
-            sessions={store.sessions}
+            sessions={herdSessions}
+            filteredRepo={repoFilterName}
             {selectedId}
             {nowMs}
             onselect={(id) => selectUnit(id)}
@@ -814,7 +825,8 @@
     {:else if viewMode === "all"}
       <div class="grid-all">
         <HerdGrid
-          sessions={store.sessions}
+          sessions={herdSessions}
+          filteredRepo={repoFilterName}
           {selectedId}
           {nowMs}
           git={store.git}
@@ -830,7 +842,8 @@
     {:else}
       <div class="grid" class:compact={touch.current}>
         <Herd
-          sessions={store.sessions}
+          sessions={herdSessions}
+          filteredRepo={repoFilterName}
           {selectedId}
           {nowMs}
           onselect={(id) => selectUnit(id)}


### PR DESCRIPTION
## Was

Im Repo-Status-Band (oben, „REPO-STATUS") brachen die Repo-Zeilen bei schmaler Breite unsauber um — `flex-wrap` legte mehrere Repos in eine Zeile (z. B. `NOTOK.DOG … SHEPHERD 💡 2` zusammen). Jetzt steht **ein Repo pro Zeile**, sauber untereinander.

Zusätzlich ist jeder Repo-Name jetzt ein **Filter-Toggle**:
- Klick auf einen Repo-Namen → die Herde darunter zeigt nur noch dessen Agenten.
- Erneuter Klick (oder ein anderes Repo) → wieder alle Repos.

## Details

- Filter-State liegt in `+page.svelte` und verengt die mobile Liste, die Desktop-Fokusliste **und** die Grid-Ansicht. Auswahl und globale Zähler bleiben unverändert (ungefiltert).
- Aktives Repo wird im Band amber + unterstrichen hervorgehoben (`aria-pressed`).
- Ein gefiltertes Repo ohne Agenten zeigt einen neutralen Hinweis statt des First-Run-Empty-States.
- Touch: Repo-Toggle bekommt 44px-Tap-Target wie die anderen Band-Buttons.

## Checks

- `bun run check` (svelte-check) — 0 Fehler
- `bun run check:i18n` — EN/DE in Parität (745 Keys)
- `bun run test` — 649 passed
- Feature-Catalog-Gate: Eintrag `repo-status-filter` ergänzt (EN + DE)