### PR TITLE
feat(ui): resume a parked session from a header button + card right-click

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1026,9 +1026,12 @@ async function handleSessionRename({ req, parts, deps }: Ctx): Promise<Response 
 }
 
 // POST /api/sessions/:id/resume — resume a finished session in a fresh agent.
-function handleSessionResume({ req, parts, deps }: Ctx): Response | null {
+// Body `{ force: true }` forces a fresh `claude --resume` even when a husk shell
+// still backs the worktree (claude exited but its herdr tab survived).
+async function handleSessionResume({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "POST" && parts[2] && parts[3] === "resume")) return null;
-  const s = deps.service.resume(parts[2]);
+  const body = (await req.json().catch(() => null)) as { force?: unknown } | null;
+  const s = deps.service.resume(parts[2], { force: body?.force === true });
   if (!s) return json({ error: "cannot resume" }, 409);
   // flip the badge back to running + nudge clients to re-attach to the fresh agent
   deps.events.emit("session:status", { id: s.id, status: s.status });

--- a/src/service.ts
+++ b/src/service.ts
@@ -576,6 +576,15 @@ export class SessionService {
    * "bring claude back" action (header / card-menu button) for the case the re-use
    * path can't see — claude exited but its herdr tab survived as a bare shell, so the
    * agent still lists as live (idle) and a plain resume would only re-adopt the shell.
+   *
+   * We force unconditionally rather than only on a detected husk because herdr ≥0.6
+   * `agent list` exposes no command/liveness field, so a husk shell and an idle
+   * claude are indistinguishable here (see ui canResume). The tradeoff: if invoked on
+   * a genuinely-live idle claude it respawns one needlessly, resetting that pane's
+   * terminal scrollback — but `--resume` restores the FULL conversation, so no work is
+   * lost, and the control is only surfaced/clicked when the user believes they're
+   * stranded. Guaranteeing the husk case works (always respawn) beats preserving
+   * scrollback in the rare misclick-on-live-claude case.
    */
   resume(id: string, opts: { force?: boolean } = {}): Session | null {
     const s = this.deps.store.get(id);

--- a/src/service.ts
+++ b/src/service.ts
@@ -570,14 +570,20 @@ export class SessionService {
    * If the herdr agent is still live (a "done" session that's merely idle at the
    * prompt), there's nothing to respawn — the current session is handed back so the
    * caller just re-attaches, avoiding a duplicate claude process.
+   *
+   * `force` overrides that re-use: it tears down whatever agent currently backs the
+   * worktree and spawns a fresh `claude --resume` regardless. This is the explicit
+   * "bring claude back" action (header / card-menu button) for the case the re-use
+   * path can't see — claude exited but its herdr tab survived as a bare shell, so the
+   * agent still lists as live (idle) and a plain resume would only re-adopt the shell.
    */
-  resume(id: string): Session | null {
+  resume(id: string, opts: { force?: boolean } = {}): Session | null {
     const s = this.deps.store.get(id);
     if (!s || s.status === "archived" || !s.claudeSessionId) return null;
     const agent =
       matchAgents(this.deps.store.list({ activeOnly: true }), this.deps.herdr.list()).get(id) ??
       null;
-    if (agent) {
+    if (agent && !opts.force) {
       // Already live (idle at the prompt, or restored by a herdr restart under a new
       // terminalId). Adopt the fresh id if it drifted; never spawn a second claude.
       if (agent.terminalId !== s.herdrAgentId) {
@@ -586,6 +592,9 @@ export class SessionService {
       }
       return s;
     }
+    // Forced respawn over a live agent: close the stale husk tab first so it doesn't
+    // leak alongside the fresh one. (No-op when the agent is already gone.)
+    if (agent) this.deps.herdr.stop(agent.terminalId);
     const argv = ["claude", "--dangerously-skip-permissions", "--resume", s.claudeSessionId];
     argv.push("--settings", spawnSettingsOverlay());
     if (s.model) argv.push("--model", s.model);

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1008,6 +1008,33 @@ test("resume re-uses a still-live agent instead of spawning a duplicate", () => 
   expect(out?.herdrAgentId).toBe("term_old");
 });
 
+test("resume force=true stops the live husk agent and respawns claude", () => {
+  const store = new SessionStore(":memory:");
+  let started = 0;
+  const stopped: string[] = [];
+  const svc = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    herdr: {
+      start: () => {
+        started++;
+        return { terminalId: "term_new", agentStatus: "working" } as any;
+      },
+      // agent still listed (claude exited but its herdr tab survives as a shell)
+      list: () => [{ terminalId: "term_old", cwd: "/wt/x", name: "x" }] as any,
+      stop: (id: string) => stopped.push(id),
+      send: () => {},
+    } as any,
+  });
+  const s = resumable(store);
+  const out = svc.resume(s.id, { force: true });
+  expect(stopped).toEqual(["term_old"]); // tore down the husk first
+  expect(started).toBe(1); // then respawned a fresh claude
+  expect(out?.herdrAgentId).toBe("term_new");
+  expect(out?.status).toBe("running");
+});
+
 test("resume returns null for unknown, archived, or pre-feature sessions", () => {
   const store = new SessionStore(":memory:");
   const svc = new SessionService({

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -529,6 +529,7 @@
   "viewport_resume_failed": "Konnte nicht fortsetzen. Nochmal tippen",
   "cardmenu_label": "Sitzungs-Aktionen",
   "cardmenu_resume": "Sitzung fortsetzen",
+  "cardmenu_decommission": "Stilllegen",
   "cardmenu_resume_short": "Fortsetzen",
   "cardmenu_resume_failed": "{name} konnte nicht fortgesetzt werden",
   "viewport_herdr_unreachable": "── herdr nicht erreichbar — Neuverbindung pausiert ──",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -527,6 +527,10 @@
   "viewport_resume_title": "Session zurückholen",
   "viewport_resume_sub": "Tippen zum Fortsetzen",
   "viewport_resume_failed": "Konnte nicht fortsetzen. Nochmal tippen",
+  "cardmenu_label": "Sitzungs-Aktionen",
+  "cardmenu_resume": "Sitzung fortsetzen",
+  "cardmenu_resume_short": "Fortsetzen",
+  "cardmenu_resume_failed": "{name} konnte nicht fortgesetzt werden",
   "viewport_herdr_unreachable": "── herdr nicht erreichbar — Neuverbindung pausiert ──",
   "viewport_reconnect_title": "Neu verbinden",
   "viewport_reconnect_sub": "herdr ist offline — tippen, sobald es zurück ist",
@@ -776,5 +780,7 @@
   "feat_backlog_active_highlight_title": "Sieh auf einen Blick, welche Issues schon beansprucht sind",
   "feat_backlog_active_highlight_body": "Issues, die ein Shepherd-Agent beansprucht hat, tragen das Label „shepherd:active“. In der Issue-Liste des Backlogs hebt es sich jetzt in Amber ab, sodass du beanspruchte von freier Arbeit auf einen Blick unterscheidest, statt jedes Chip zu lesen.",
   "feat_repo_filter_title": "Herde nach Repo filtern",
-  "feat_repo_filter_body": "Das Repo-Status-Band stapelt jetzt ein Repo pro Zeile. Klicke einen Repo-Namen an, um darunter nur dessen Agenten zu zeigen; erneut klicken zeigt wieder alle Repos."
+  "feat_repo_filter_body": "Das Repo-Status-Band stapelt jetzt ein Repo pro Zeile. Klicke einen Repo-Namen an, um darunter nur dessen Agenten zu zeigen; erneut klicken zeigt wieder alle Repos.",
+  "feat_resume_session_title": "Eine geparkte Session fortsetzen",
+  "feat_resume_session_body": "Wenn Claude sich beendet und die Session an einer nackten Shell zurücklässt (z. B. nach einem herdr-Neustart), stehst du nicht mehr ohne Weg zurück da. Im Session-Kopf erscheint jetzt ein ↻ Fortsetzen-Knopf – und ein Rechtsklick (oder langes Drücken) auf eine Session-Karte bietet Fortsetzen ebenfalls an –, der `claude --resume` neu startet und dich direkt zurück ins Gespräch bringt."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -529,6 +529,7 @@
   "viewport_resume_failed": "Couldn't resume. Tap to retry",
   "cardmenu_label": "Session actions",
   "cardmenu_resume": "Resume session",
+  "cardmenu_decommission": "Decommission",
   "cardmenu_resume_short": "Resume",
   "cardmenu_resume_failed": "Couldn't resume {name}",
   "viewport_herdr_unreachable": "── herdr unreachable — reconnect paused ──",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -527,6 +527,10 @@
   "viewport_resume_title": "Resume session",
   "viewport_resume_sub": "Tap to bring it back",
   "viewport_resume_failed": "Couldn't resume. Tap to retry",
+  "cardmenu_label": "Session actions",
+  "cardmenu_resume": "Resume session",
+  "cardmenu_resume_short": "Resume",
+  "cardmenu_resume_failed": "Couldn't resume {name}",
   "viewport_herdr_unreachable": "── herdr unreachable — reconnect paused ──",
   "viewport_reconnect_title": "Reconnect",
   "viewport_reconnect_sub": "herdr is down — tap once it's back",
@@ -776,5 +780,7 @@
   "feat_backlog_active_highlight_title": "See at a glance which issues are already claimed",
   "feat_backlog_active_highlight_body": "Issues a Shepherd agent has claimed carry a “shepherd:active” label. In the backlog's issue list it now stands out in amber, so you can tell taken work from free work at a glance instead of reading every chip.",
   "feat_repo_filter_title": "Filter the herd by repo",
-  "feat_repo_filter_body": "The repo-status band now stacks one repo per line. Click a repo name to show only its agents in the herd below; click it again to show every repo."
+  "feat_repo_filter_body": "The repo-status band now stacks one repo per line. Click a repo name to show only its agents in the herd below; click it again to show every repo.",
+  "feat_resume_session_title": "Resume a parked session",
+  "feat_resume_session_body": "When Claude exits and leaves a session sitting at a bare shell (e.g. after a herdr restart), it no longer strands you. A ↻ Resume button now appears in the session header — and right-clicking (or long-pressing) any session card offers Resume too — to respawn `claude --resume` and drop you straight back into the conversation."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -257,9 +257,18 @@ export async function replySession(id: string, text: string): Promise<void> {
   if (!r.ok) throw await failed(r, "reply");
 }
 
-/** Bring a finished session back — re-spawns `claude --resume` in its worktree. */
-export async function resumeSession(id: string): Promise<Session> {
-  const r = await fetch(`/api/sessions/${id}/resume`, { method: "POST" });
+/**
+ * Bring a finished session back — re-spawns `claude --resume` in its worktree.
+ * `force` tears down a surviving husk shell first, for the case claude exited but
+ * its herdr tab is still alive (so the session lists as idle, not gone).
+ */
+export async function resumeSession(id: string, force = false): Promise<Session> {
+  const init: RequestInit = { method: "POST" };
+  if (force) {
+    init.headers = JSON_HEADERS;
+    init.body = JSON.stringify({ force: true });
+  }
+  const r = await fetch(`/api/sessions/${id}/resume`, init);
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
     throw new Error((msg as { error?: string }).error ?? `resume failed: ${r.status}`);

--- a/ui/src/lib/components/CardMenu.svelte
+++ b/ui/src/lib/components/CardMenu.svelte
@@ -75,7 +75,7 @@
   {/if}
   {#if ondecommission}
     <button class="cm-item danger" type="button" role="menuitem" onclick={ondecommission}>
-      <span class="cm-icon" aria-hidden="true">✕</span>{m.viewport_decommission()}
+      <span class="cm-icon" aria-hidden="true">✕</span>{m.cardmenu_decommission()}
     </button>
   {/if}
 </div>

--- a/ui/src/lib/components/CardMenu.svelte
+++ b/ui/src/lib/components/CardMenu.svelte
@@ -38,8 +38,27 @@
     const left = Math.min(x, window.innerWidth - r.width - margin);
     const top = Math.min(y, window.innerHeight - r.height - margin);
     pos = { left: Math.max(margin, left), top: Math.max(margin, top) };
-    node.focus();
+    items()[0]?.focus(); // open with the first item focused, per the menu pattern
   });
+
+  // The menu items, in DOM order (only the ones actually rendered).
+  function items(): HTMLButtonElement[] {
+    return el ? Array.from(el.querySelectorAll<HTMLButtonElement>(".cm-item")) : [];
+  }
+  // Arrow / Home / End roving focus, as a role="menu" is expected to support.
+  function onNav(e: KeyboardEvent) {
+    const list = items();
+    if (list.length === 0) return;
+    const i = list.indexOf(document.activeElement as HTMLButtonElement);
+    let next: number;
+    if (e.key === "ArrowDown") next = (i + 1) % list.length;
+    else if (e.key === "ArrowUp") next = (i - 1 + list.length) % list.length;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = list.length - 1;
+    else return;
+    e.preventDefault();
+    list[next]!.focus();
+  }
 
   $effect(() => {
     function onKeydown(e: KeyboardEvent) {
@@ -67,14 +86,21 @@
   tabindex="-1"
   aria-label={m.cardmenu_label()}
   style="left:{pos?.left ?? x}px;top:{pos?.top ?? y}px"
+  onkeydown={onNav}
 >
   {#if resumable && onresume}
-    <button class="cm-item" type="button" role="menuitem" onclick={onresume}>
+    <button class="cm-item" type="button" role="menuitem" tabindex="-1" onclick={onresume}>
       <span class="cm-icon" aria-hidden="true">↻</span>{m.cardmenu_resume()}
     </button>
   {/if}
   {#if ondecommission}
-    <button class="cm-item danger" type="button" role="menuitem" onclick={ondecommission}>
+    <button
+      class="cm-item danger"
+      type="button"
+      role="menuitem"
+      tabindex="-1"
+      onclick={ondecommission}
+    >
       <span class="cm-icon" aria-hidden="true">✕</span>{m.cardmenu_decommission()}
     </button>
   {/if}

--- a/ui/src/lib/components/CardMenu.svelte
+++ b/ui/src/lib/components/CardMenu.svelte
@@ -10,6 +10,7 @@
     x,
     y,
     resumable,
+    opener,
     onresume,
     ondecommission,
     onclose,
@@ -19,6 +20,8 @@
     y: number;
     // whether the Resume action applies to this session right now
     resumable: boolean;
+    // the element that opened the menu (the card hit-target) — focus returns here on close
+    opener?: HTMLElement;
     onresume?: () => void;
     ondecommission?: () => void;
     onclose: () => void;
@@ -45,16 +48,21 @@
   function items(): HTMLButtonElement[] {
     return el ? Array.from(el.querySelectorAll<HTMLButtonElement>(".cm-item")) : [];
   }
-  // Arrow / Home / End roving focus, as a role="menu" is expected to support.
+  // Arrow / Home / End roving focus, as a role="menu" is expected to support. Tab
+  // is trapped (cycled like the arrows) so focus can't escape the open menu — the
+  // only ways out are Esc, an action, or an outside click, all of which close it.
   function onNav(e: KeyboardEvent) {
     const list = items();
     if (list.length === 0) return;
     const i = list.indexOf(document.activeElement as HTMLButtonElement);
+    const fwd = (i + 1) % list.length;
+    const back = (i - 1 + list.length) % list.length;
     let next: number;
-    if (e.key === "ArrowDown") next = (i + 1) % list.length;
-    else if (e.key === "ArrowUp") next = (i - 1 + list.length) % list.length;
+    if (e.key === "ArrowDown") next = fwd;
+    else if (e.key === "ArrowUp") next = back;
     else if (e.key === "Home") next = 0;
     else if (e.key === "End") next = list.length - 1;
+    else if (e.key === "Tab") next = e.shiftKey ? back : fwd;
     else return;
     e.preventDefault();
     list[next]!.focus();
@@ -75,6 +83,17 @@
       window.removeEventListener("keydown", onKeydown);
       window.removeEventListener("pointerdown", onPointer, true);
       window.removeEventListener("scroll", onclose, true);
+      // Every close path (Esc / action / outside-click / scroll) unmounts the menu,
+      // so returning focus to the trigger here covers them all. Deferred to a
+      // microtask so the browser has applied any click-driven focus first, then
+      // only restore when focus actually fell to <body> — an outside-click on a
+      // focusable element keeps its focus, an action that moved focus (e.g. into the
+      // resumed terminal) keeps that, and a decommissioned row's detached button
+      // no-ops via isConnected.
+      const target = opener;
+      queueMicrotask(() => {
+        if (target?.isConnected && document.activeElement === document.body) target.focus();
+      });
     };
   });
 </script>

--- a/ui/src/lib/components/CardMenu.svelte
+++ b/ui/src/lib/components/CardMenu.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+
+  // Small anchored, non-blocking context menu for a session card (right-click on
+  // desktop, long-press → native `contextmenu` on touch). Per the design system's
+  // popover rule it gets NO scrim/blur — it dismisses on outside-click, Esc or
+  // scroll instead. The card owns its open/close state and the resumable check;
+  // this component only positions + renders the actions it's handed.
+  let {
+    x,
+    y,
+    resumable,
+    onresume,
+    ondecommission,
+    onclose,
+  }: {
+    // viewport coordinates of the pointer/long-press that opened the menu
+    x: number;
+    y: number;
+    // whether the Resume action applies to this session right now
+    resumable: boolean;
+    onresume?: () => void;
+    ondecommission?: () => void;
+    onclose: () => void;
+  } = $props();
+
+  let el = $state<HTMLDivElement>();
+
+  // Clamp the menu inside the viewport so it never spills off the bottom/right
+  // edge when opened near them. Measured after mount; until then the template
+  // falls back to the raw pointer position (x/y).
+  let pos = $state<{ left: number; top: number } | null>(null);
+  $effect(() => {
+    const node = el;
+    if (!node) return;
+    const r = node.getBoundingClientRect();
+    const margin = 8;
+    const left = Math.min(x, window.innerWidth - r.width - margin);
+    const top = Math.min(y, window.innerHeight - r.height - margin);
+    pos = { left: Math.max(margin, left), top: Math.max(margin, top) };
+    node.focus();
+  });
+
+  $effect(() => {
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") onclose();
+    }
+    function onPointer(e: Event) {
+      if (el && !el.contains(e.target as Node)) onclose();
+    }
+    window.addEventListener("keydown", onKeydown);
+    // capture so we beat the card's own click; scroll dismisses (the anchor moves)
+    window.addEventListener("pointerdown", onPointer, true);
+    window.addEventListener("scroll", onclose, true);
+    return () => {
+      window.removeEventListener("keydown", onKeydown);
+      window.removeEventListener("pointerdown", onPointer, true);
+      window.removeEventListener("scroll", onclose, true);
+    };
+  });
+</script>
+
+<div
+  bind:this={el}
+  class="card-menu"
+  role="menu"
+  tabindex="-1"
+  aria-label={m.cardmenu_label()}
+  style="left:{pos?.left ?? x}px;top:{pos?.top ?? y}px"
+>
+  {#if resumable && onresume}
+    <button class="cm-item" type="button" role="menuitem" onclick={onresume}>
+      <span class="cm-icon" aria-hidden="true">↻</span>{m.cardmenu_resume()}
+    </button>
+  {/if}
+  {#if ondecommission}
+    <button class="cm-item danger" type="button" role="menuitem" onclick={ondecommission}>
+      <span class="cm-icon" aria-hidden="true">✕</span>{m.viewport_decommission()}
+    </button>
+  {/if}
+</div>
+
+<style>
+  .card-menu {
+    position: fixed;
+    z-index: 60;
+    min-width: 180px;
+    padding: 4px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 3px;
+    /* established popover shadow (matches AutomationPanel/RepoSelect) — no token exists */
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .card-menu:focus {
+    outline: none;
+  }
+  .cm-item {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    width: 100%;
+    padding: 8px 11px;
+    border: 0;
+    border-radius: 2px;
+    background: transparent;
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    text-align: left;
+    cursor: pointer;
+  }
+  .cm-item:hover,
+  .cm-item:focus-visible {
+    background: var(--color-hover);
+    outline: none;
+  }
+  .cm-item.danger {
+    color: var(--color-red);
+  }
+  .cm-item.danger:hover,
+  .cm-item.danger:focus-visible {
+    background: color-mix(in srgb, var(--color-red) 14%, var(--color-panel));
+  }
+  .cm-icon {
+    font-size: var(--fs-meta);
+    width: 1em;
+    text-align: center;
+    flex-shrink: 0;
+  }
+</style>

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -147,11 +147,11 @@
   // action menu on the card. Resume is the headline action for a session parked at
   // a shell; decommission rides along where the parent wired it (mobile list).
   const resumable = $derived(canResume(session));
-  let menu = $state<{ x: number; y: number } | null>(null);
+  let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
   function openMenu(e: MouseEvent) {
     if (!resumable && !ondecommission) return; // nothing to offer → leave native menu
     e.preventDefault();
-    menu = { x: e.clientX, y: e.clientY };
+    menu = { x: e.clientX, y: e.clientY, opener: e.currentTarget as HTMLElement };
   }
   async function resumeFromMenu() {
     menu = null;
@@ -306,6 +306,7 @@
     x={menu.x}
     y={menu.y}
     {resumable}
+    opener={menu.opener}
     onresume={resumeFromMenu}
     ondecommission={ondecommission ? decommissionFromMenu : undefined}
     onclose={() => (menu = null)}

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -6,7 +6,9 @@
 
 <script lang="ts">
   import type { Session, GitState, SessionActivity } from "$lib/types";
-  import { elapsed, STATUS_COLOR, statusLabel, hideStatusBadge } from "$lib/format";
+  import { elapsed, STATUS_COLOR, statusLabel, hideStatusBadge, canResume } from "$lib/format";
+  import { resumeSession } from "$lib/api";
+  import CardMenu from "./CardMenu.svelte";
   import { isMerging } from "./merge-train";
   import StatusPip from "./StatusPip.svelte";
   import PrBadge from "./PrBadge.svelte";
@@ -140,6 +142,30 @@
   // Decommission is deferred behind an undo window: while it's open, the row is
   // doomed-but-still-present. Dim it so the operator sees it's on its way out.
   const decommissioning = $derived(toasts.pendingUndo(session.id));
+
+  // Right-click (desktop) / long-press (touch → native contextmenu) opens a small
+  // action menu on the card. Resume is the headline action for a session parked at
+  // a shell; decommission rides along where the parent wired it (mobile list).
+  const resumable = $derived(canResume(session));
+  let menu = $state<{ x: number; y: number } | null>(null);
+  function openMenu(e: MouseEvent) {
+    if (!resumable && !ondecommission) return; // nothing to offer → leave native menu
+    e.preventDefault();
+    menu = { x: e.clientX, y: e.clientY };
+  }
+  async function resumeFromMenu() {
+    menu = null;
+    onselect(session.id); // focus it so the rebuilt terminal lands in view
+    try {
+      await resumeSession(session.id, true);
+    } catch {
+      toasts.info(m.cardmenu_resume_failed({ name: session.name }));
+    }
+  }
+  function decommissionFromMenu() {
+    menu = null;
+    ondecommission?.(session.id);
+  }
 </script>
 
 {#snippet row()}
@@ -157,6 +183,7 @@
       aria-describedby={describedBy}
       title={session.repoPath}
       onclick={() => onselect(session.id)}
+      oncontextmenu={openMenu}
     ></button>
     <div class="pip-col">
       <StatusPip
@@ -272,6 +299,17 @@
   </div>
 {:else}
   {@render row()}
+{/if}
+
+{#if menu}
+  <CardMenu
+    x={menu.x}
+    y={menu.y}
+    {resumable}
+    onresume={resumeFromMenu}
+    ondecommission={ondecommission ? decommissionFromMenu : undefined}
+    onclose={() => (menu = null)}
+  />
 {/if}
 
 <style>

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -140,11 +140,11 @@
   // Right-click / long-press → a small action menu. On a tile only Resume applies
   // (decommission isn't wired into the grid view); skip the menu otherwise.
   const resumable = $derived(canResume(session));
-  let menu = $state<{ x: number; y: number } | null>(null);
+  let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
   function openMenu(e: MouseEvent) {
     if (!resumable) return; // nothing to offer → leave the native menu
     e.preventDefault();
-    menu = { x: e.clientX, y: e.clientY };
+    menu = { x: e.clientX, y: e.clientY, opener: e.currentTarget as HTMLElement };
   }
   async function resumeFromMenu() {
     menu = null;
@@ -200,6 +200,7 @@
     x={menu.x}
     y={menu.y}
     {resumable}
+    opener={menu.opener}
     onresume={resumeFromMenu}
     onclose={() => (menu = null)}
   />

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -3,12 +3,15 @@
   import { Terminal } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
   import type { Session, GitState } from "$lib/types";
-  import { STATUS_COLOR, statusLabel, elapsed, hideStatusBadge } from "$lib/format";
+  import { STATUS_COLOR, statusLabel, elapsed, hideStatusBadge, canResume } from "$lib/format";
   import { connectPty } from "$lib/pty";
+  import { resumeSession } from "$lib/api";
   import { theme, xtermTheme } from "$lib/theme.svelte";
+  import CardMenu from "./CardMenu.svelte";
   import PrBadge from "./PrBadge.svelte";
   import CriticBadge from "./CriticBadge.svelte";
   import { reviews } from "$lib/reviews.svelte";
+  import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
   import AutopilotBadge from "./AutopilotBadge.svelte";
   import PlanGateBadge from "./PlanGateBadge.svelte";
@@ -133,6 +136,25 @@
     term.options.theme = xtermTheme(resolved);
     term.refresh(0, Math.max(0, term.rows - 1));
   });
+
+  // Right-click / long-press → a small action menu. On a tile only Resume applies
+  // (decommission isn't wired into the grid view); skip the menu otherwise.
+  const resumable = $derived(canResume(session));
+  let menu = $state<{ x: number; y: number } | null>(null);
+  function openMenu(e: MouseEvent) {
+    if (!resumable) return; // nothing to offer → leave the native menu
+    e.preventDefault();
+    menu = { x: e.clientX, y: e.clientY };
+  }
+  async function resumeFromMenu() {
+    menu = null;
+    onselect(session.id); // focus it so the rebuilt terminal lands in the viewport
+    try {
+      await resumeSession(session.id, true);
+    } catch {
+      toasts.info(m.cardmenu_resume_failed({ name: session.name }));
+    }
+  }
 </script>
 
 <div
@@ -146,6 +168,7 @@
     aria-label={m.unit_open_aria({ name: session.name })}
     aria-describedby={describedBy}
     onclick={() => onselect(session.id)}
+    oncontextmenu={openMenu}
   ></button>
   <div class="t-head">
     <span class="name">{session.name}</span>
@@ -171,6 +194,16 @@
     <div class="t-mount" bind:this={el}></div>
   </div>
 </div>
+
+{#if menu}
+  <CardMenu
+    x={menu.x}
+    y={menu.y}
+    {resumable}
+    onresume={resumeFromMenu}
+    onclose={() => (menu = null)}
+  />
+{/if}
 
 <style>
   .tile {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -4,7 +4,7 @@
   import { FitAddon } from "@xterm/addon-fit";
   import { WebLinksAddon } from "@xterm/addon-web-links";
   import type { GitState, Issue, Leftover, Session, SessionUsage, UsageLimits } from "$lib/types";
-  import { STATUS_COLOR, statusLabel, formatTokens } from "$lib/format";
+  import { STATUS_COLOR, statusLabel, formatTokens, canResume } from "$lib/format";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { hotterGauge } from "./usage-gauges";
   import { connectPty, type PtyConn } from "$lib/pty";
@@ -194,6 +194,11 @@
   // the fold only applies on the compact layout (it's the mobile space-saver);
   // desktop keeps its own git-actions disclosure untouched.
   const headerFolded = $derived(compact && headerCollapsed);
+
+  // a parked (idle/done) session with a pinned claude id can be brought back —
+  // surface a header Resume button so the user isn't stranded at a bare shell with
+  // no affordance (the in-terminal overlay only shows once the PTY closes for good).
+  const resumable = $derived(canResume(session));
   // a11y: the fold button's aria-controls points at the tab switcher — the always-
   // mounted primary region it collapses (the git rail + build queue come and go with
   // the fold, so they can't carry a stable controlled-region id). Per-session id so
@@ -558,14 +563,16 @@
   // bring a finished session back: ask the server to respawn `claude --resume` in
   // the worktree, then bump the epoch so the terminal effect rebuilds and attaches
   // to the fresh agent (the old PtyConn stopped for good on the ended-close).
-  async function resumeSession() {
+  // force=true (header button) tears down a surviving husk shell and respawns
+  // claude; force=false (the agent-gone overlay) just respawns into the empty tab.
+  async function resumeSession(force = false) {
     if (resuming) return;
     resuming = true;
     resumeFailed = false;
     try {
-      await apiResumeSession(session.id);
+      await apiResumeSession(session.id, force);
       ended = false;
-      resumeEpoch++;
+      resumeEpoch++; // rebuild the terminal + attach to the fresh agent
     } catch {
       resumeFailed = true;
     } finally {
@@ -1403,6 +1410,21 @@
           <span aria-hidden="true">{headerCollapsed ? "▴" : "▾"}</span>
         </button>
       {/if}
+      {#if resumable}
+        <!-- bring claude back when the session is parked (idle/done) — e.g. claude
+             exited to a shell after a herdr restart. Forces a fresh claude --resume. -->
+        <button
+          class="vp-resume"
+          type="button"
+          onclick={() => resumeSession(true)}
+          disabled={resuming}
+          title={m.viewport_resume_title()}
+          aria-label={m.viewport_resume_title()}
+        >
+          <span class="vp-resume-icon" aria-hidden="true">{resuming ? "⏳" : "↻"}</span>
+          {#if !compact}<span>{m.cardmenu_resume_short()}</span>{/if}
+        </button>
+      {/if}
       <button
         class="decom"
         class:armed
@@ -1498,7 +1520,12 @@
         <span class="parked-sub">{m.viewport_reconnect_sub()}</span>
       </button>
     {:else if ended && !parked && tab === "term" && session.claudeSessionId}
-      <button class="parked resume" type="button" onclick={resumeSession} disabled={resuming}>
+      <button
+        class="parked resume"
+        type="button"
+        onclick={() => resumeSession()}
+        disabled={resuming}
+      >
         <span class="parked-icon" aria-hidden="true">{resuming ? "⏳" : "↻"}</span>
         <span class="parked-title"
           >{resumeFailed ? m.viewport_resume_failed() : m.viewport_resume_title()}</span
@@ -2078,6 +2105,39 @@
       color 0.12s,
       border-color 0.12s,
       background 0.12s;
+  }
+
+  /* Resume: a quiet neutral action (not destructive, not "ready-complete" → no
+     green/red), brightening to ink on hover. Sits left of the decommission ✕. */
+  .vp-resume {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    color: var(--color-ink);
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 2px 7px;
+    cursor: pointer;
+    transition:
+      color 0.12s,
+      border-color 0.12s;
+  }
+  .vp-resume:hover {
+    color: var(--color-ink-bright);
+    border-color: var(--color-line-bright);
+  }
+  .vp-resume:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+  .vp-resume-icon {
+    font-size: var(--fs-meta);
   }
 
   /* PR delivered → the work is done. Lift the otherwise-faint ✕ into a bright,

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -220,4 +220,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_repo_filter_title",
     bodyKey: "feat_repo_filter_body",
   },
+  {
+    // No targetId: the Resume button + card menu only appear on a parked (idle/done)
+    // session, so a coachmark anchor would rarely be mounted — surface via the
+    // What's-New drawer only.
+    id: "resume-parked-session",
+    sinceVersion: "1.20.0",
+    titleKey: "feat_resume_session_title",
+    bodyKey: "feat_resume_session_body",
+  },
 ];

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,5 +1,15 @@
 import { m } from "$lib/paraglide/messages";
-import type { SessionStatus } from "./types";
+import type { Session, SessionStatus } from "./types";
+
+/**
+ * Whether a session can be brought back with `claude --resume`. True only when it
+ * has a pinned claude session id AND isn't actively engaged (idle or done) — the
+ * states where the user may be parked at a bare shell with no way back in.
+ * Running (claude working) and blocked (claude awaiting input) are live, so no.
+ */
+export function canResume(s: Session): boolean {
+  return !!s.claudeSessionId && (s.status === "idle" || s.status === "done");
+}
 
 /**
  * Live elapsed label for the session list, scaled so multi-day runs stay

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -2,10 +2,17 @@ import { m } from "$lib/paraglide/messages";
 import type { Session, SessionStatus } from "./types";
 
 /**
- * Whether a session can be brought back with `claude --resume`. True only when it
- * has a pinned claude session id AND isn't actively engaged (idle or done) — the
- * states where the user may be parked at a bare shell with no way back in.
- * Running (claude working) and blocked (claude awaiting input) are live, so no.
+ * Whether to offer a Resume control for a session. True for any idle/done session
+ * with a pinned claude id — deliberately ALL of them, not just husks.
+ *
+ * We'd love to show it only when claude has actually exited to a bare shell, but
+ * herdr ≥0.6 `agent list` exposes no per-agent command/liveness field (just
+ * agent_status/name/cwd), so a husk shell and an idle-at-prompt claude are
+ * indistinguishable from the API, and scraping the TUI is fragile (stale
+ * scrollback fools it). So the control is a user-initiated escape hatch shown
+ * whenever it *could* be needed; a user looking at a live claude pane has no
+ * reason to click it. Running (working) / blocked (awaiting input) are
+ * unambiguously live, so they're excluded.
  */
 export function canResume(s: Session): boolean {
   return !!s.claudeSessionId && (s.status === "idle" || s.status === "done");


### PR DESCRIPTION
## Why

After a herdr restart (e.g. the failed `0.6.5 → 0.6.8` update in `~/.shepherd/herdr-update.log`), Claude can exit while its herdr tab survives as a bare shell. The session then lists as **INAKTIV** sitting at a console prompt (`…shepherd/impressum-firmenname >`) with **no way back into the conversation**:

- the in-terminal "↻ Resume" overlay only fires once the PTY closes *for good* (`server.ts` closes with `PTY_GONE_CODE` only when herdr no longer lists the agent) — a live husk shell never triggers it;
- and even if reached, `service.resume()` saw the live (husk) agent and just re-adopted it instead of respawning Claude.

Reported live: *"Jetzt fehlt die Session, die abgebrochen wurde … wir bräuchten einen Button, um diese Session wiederherzustellen … auf der Karte mit Rechtsklick kann ich nichts machen."*

## What

- **Backend** — `service.resume(id, { force })`: `force` tears down the surviving husk agent (`herdr.stop`) and respawns `claude --resume` regardless of a live agent. `POST /api/sessions/:id/resume` reads `{ force }`. The existing agent-gone overlay keeps its non-forced path (no behaviour change there).
- **Header button** — a quiet `↻ Resume` button in the Viewport header for any **idle/done** session with a pinned `claudeSessionId` (`canResume()` helper). Forces a fresh resume and rebuilds the terminal via the proven `resumeEpoch` path.
- **Card right-click / long-press** — a new shared, non-blocking `CardMenu` popover (design-system anchored-popover recipe: no scrim, dismiss on outside-click / Esc / scroll). On a row it offers **Resume** (+ Decommission where wired); on a grid tile, Resume. Right-clicking force-resumes and selects the session.

## Scope

Manual button only — no auto-resume (per the product call). Surfaces semantic green/red are untouched; Resume reads as a neutral action.

## Tests / gates

- `bun test` — new `resume force=true stops the husk and respawns` test; service suite green.
- `bun run check` (svelte-check) 0 errors / 0 warnings · `check:i18n` parity (en+de) · branch-hygiene + feature-catalog gates pass.
- Feature-catalog entry `resume-parked-session` + EN/DE What's-New strings added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)