### PR TITLE
feat: agent-declared `.shepherd-preview` port hint (#397)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ dist/
 .shepherd-plan.md
 .shepherd-plan-review.json
 
+# Agent-declared live-preview port hint (transient, never committed)
+.shepherd-preview
+
 # Self-hosted CI runner: never commit a filled-in env; keep the example tracked
 # (the global `.env.*` rule above would otherwise swallow .env.example).
 ci/self-hosted-runner/.env

--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ through Tailscale. Shepherd detects the port automatically (frontend servers lik
 take priority) and proxies HTTP and WebSocket (HMR) traffic through a dedicated loopback listener.
 Shepherd never starts or stops the agent's dev server — it is detect-and-proxy only.
 
+**Declaring the preview port explicitly:** A project or agent can drop a file named `.shepherd-preview`
+in the repo/worktree root containing a single bare port number (e.g. `3000`). Shepherd uses it
+only when that port is actually listening and answers HTTP — a stale or wrong hint self-heals by
+falling back to automatic detection. Useful for multi-listener apps or apps on uncommon ports. The
+file is optional; Shepherd is detect-and-proxy only regardless.
+
 **Routing: one port per agent, distinct origin.** Each preview is served on its own port
 (`SHEPHERD_PREVIEW_PORT_BASE`..+`COUNT`) via `tailscale serve`. Because each preview is a distinct
 web origin (`https://host.ts.net:8001` ≠ `https://host.ts.net:8002` ≠ the HUD at `:443`), the
@@ -258,8 +264,7 @@ per-origin cookie isolation is tracked in [#398](https://github.com/erwins-enkel
   `hmr.clientPort` in the app's Vite config to the preview port Shepherd assigned. Page-load and
   manual refresh always work regardless.
 
-**Follow-ups:** multi-port apps (#396), agent-declared port hint (`shepherd.preview`, #397),
-idle-stop (#399), dynamic `tailscale serve` registration (#403), subdomain/full isolation (#398).
+**Follow-ups:** multi-port apps (#396), idle-stop (#399), dynamic `tailscale serve` registration (#403), subdomain/full isolation (#398).
 
 Install the unit (`deploy/shepherd.service`):
 

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -7,7 +7,7 @@ import { jsonlPathFor } from "./usage";
 import { readTranscriptSignals, STRIP_WINDOW_MS, type SessionActivity } from "./activity-signal";
 import { maintenance } from "./maintenance";
 import { scanListeningPortsByWorktree } from "./process-reaper";
-import { pickPrimaryPort } from "./preview";
+import { resolveDevPort } from "./preview";
 import { config } from "./config";
 
 const STALL_SIG = "stall"; // fixed signature → a stall fires once per episode
@@ -30,9 +30,10 @@ export interface PreviewWiring {
   /** Batched /proc scan: builds the inode→port map ONCE and resolves all worktrees.
    *  Defaults to the real `scanListeningPortsByWorktree`. */
   scan: (worktrees: string[]) => Map<string, number[]>;
-  /** Pick the primary dev port from a set of listening ports.
-   *  Defaults to the real `pickPrimaryPort`. */
-  pick: (ports: number[]) => Promise<number | null>;
+  /** Pick the primary dev port from a set of listening ports for a given worktree.
+   *  Defaults to `resolveDevPort`, which honors the agent-declared `.shepherd-preview`
+   *  hint (if listening + HTTP-live) and otherwise falls back to the primary-port heuristic. */
+  pick: (ports: number[], worktreePath: string) => Promise<number | null>;
 }
 
 export class StatusPoller {
@@ -122,7 +123,7 @@ export class StatusPoller {
       },
       sweepMs: preview?.sweepMs ?? config.previewSweepMs,
       scan: preview?.scan ?? ((worktrees) => scanListeningPortsByWorktree(worktrees)),
-      pick: preview?.pick ?? ((ports) => pickPrimaryPort(ports)),
+      pick: preview?.pick ?? ((ports, worktreePath) => resolveDevPort(ports, worktreePath)),
     };
   }
 
@@ -591,7 +592,7 @@ export class StatusPoller {
     const active: Array<{ sessionId: string; devPort: number }> = [];
     for (const s of isolated) {
       const ports = portsMap.get(s.worktreePath) ?? [];
-      const devPort = await this.previewWiring.pick(ports);
+      const devPort = await this.previewWiring.pick(ports, s.worktreePath);
       if (devPort !== null) active.push({ sessionId: s.id, devPort });
     }
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+import { readFile as fsReadFile } from "node:fs/promises";
 import type { Server, ServerWebSocket } from "bun";
 import type { SessionPreviewState } from "./types";
 
@@ -37,6 +39,75 @@ async function defaultHttpProbe(port: number): Promise<boolean> {
   } finally {
     clearTimeout(timer);
   }
+}
+
+const PREVIEW_HINT_FILE = ".shepherd-preview";
+
+/**
+ * Read a `.shepherd-preview` hint file from the worktree root.
+ *
+ * Returns the declared port (integer in [1, 65535]) or null on any failure:
+ * missing/unreadable file, empty/whitespace content, content that is not a
+ * pure run of decimal digits (e.g. "3000abc", "3000 5173", "3000.5"), NaN,
+ * or out-of-range. Never throws.
+ *
+ * The file must contain only a base-10 port number (optionally surrounded by
+ * whitespace) — no trailing characters, no decimal points, no spaces between
+ * digits.
+ */
+async function readPreviewHint(
+  worktreePath: string,
+  readFile: (path: string, enc: "utf8") => Promise<string> = fsReadFile,
+): Promise<number | null> {
+  const hintPath = join(worktreePath, PREVIEW_HINT_FILE);
+  let text: string;
+  try {
+    text = await readFile(hintPath, "utf8");
+  } catch {
+    return null;
+  }
+  const trimmed = text.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const port = Number.parseInt(trimmed, 10);
+  if (port < 1 || port > 65535) return null;
+  return port;
+}
+
+/**
+ * Resolve the active dev port for a worktree, honoring an optional
+ * `.shepherd-preview` hint file.
+ *
+ * Honor rule: the hint is used ONLY when the declared port is in `ports`
+ * (confirmed listening) AND passes the HTTP liveness check — the same check
+ * `pickPrimaryPort` uses for non-curated ports (curated ports are trusted
+ * unprobed). This preserves every invariant from #345:
+ *   - never surface a dead port or a port owned by another process/worktree
+ *   - never surface a non-HTTP socket (DB port, debugger, etc.)
+ *   - the hint's purpose is to disambiguate WHICH live HTTP port wins over
+ *     the heuristic for multi-listener apps or apps on uncommon ports
+ *
+ * Falls through to `pickPrimaryPort` when the hint is absent, unreadable,
+ * not in `ports`, or not an HTTP server.
+ *
+ * @param ports        Listening ports for this worktree (from /proc scan).
+ * @param worktreePath Absolute path to the worktree root (hint file location).
+ * @param readFile     Injectable file reader (forwarded to readPreviewHint).
+ * @param httpProbe    Injectable HTTP liveness probe (default: real network call).
+ */
+export async function resolveDevPort(
+  ports: number[],
+  worktreePath: string,
+  readFile?: (path: string, enc: "utf8") => Promise<string>,
+  httpProbe: (port: number) => Promise<boolean> = defaultHttpProbe,
+): Promise<number | null> {
+  const hint = await readPreviewHint(worktreePath, readFile);
+  if (hint !== null && ports.includes(hint)) {
+    // Curated ports are trusted HTTP servers — no probe needed.
+    // Non-curated declared ports must still pass the HTTP probe to be surfaced.
+    if (CURATED_SET.has(hint) || (await httpProbe(hint))) return hint;
+    // Declared port is listening but not an HTTP server (DB/debugger) → ignore, fall through.
+  }
+  return pickPrimaryPort(ports, httpProbe);
 }
 
 /**

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -130,7 +130,14 @@ export async function resolveDevPort(
     // Curated ports are trusted HTTP servers — no probe needed.
     // Non-curated declared ports must still pass the HTTP probe to be surfaced.
     if (CURATED_SET.has(hint) || (await httpProbe(hint))) return hint;
-    // Declared port is listening but not an HTTP server (DB/debugger) → ignore, fall through.
+    // Declared port is listening but not an HTTP server (DB/debugger) — the probe just
+    // failed. Drop it from the fallback set so pickPrimaryPort doesn't re-probe the same
+    // known-dead port (a wasted ~500ms timeout when no curated port is present). The hint
+    // is always non-curated here (curated short-circuits above), so removing it is safe.
+    return pickPrimaryPort(
+      ports.filter((p) => p !== hint),
+      httpProbe,
+    );
   }
   return pickPrimaryPort(ports, httpProbe);
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { readFile as fsReadFile } from "node:fs/promises";
+import { open } from "node:fs/promises";
 import type { Server, ServerWebSocket } from "bun";
 import type { SessionPreviewState } from "./types";
 
@@ -44,6 +44,30 @@ async function defaultHttpProbe(port: number): Promise<boolean> {
 const PREVIEW_HINT_FILE = ".shepherd-preview";
 
 /**
+ * Max bytes read from a `.shepherd-preview` file. A valid hint is a short port
+ * number (≤5 digits) plus optional surrounding whitespace, so 64 bytes is ample.
+ * Capping the read keeps a pathologically large hint file from being slurped into
+ * memory on every preview sweep.
+ */
+const MAX_HINT_BYTES = 64;
+
+/**
+ * Default hint reader: reads at most MAX_HINT_BYTES from the file via a file
+ * handle, never the whole file. Matches the injectable
+ * `(path, enc) => Promise<string>` shape so tests can substitute a plain reader.
+ */
+async function readHintFileBounded(path: string, enc: "utf8"): Promise<string> {
+  const handle = await open(path, "r");
+  try {
+    const buf = Buffer.alloc(MAX_HINT_BYTES);
+    const { bytesRead } = await handle.read(buf, 0, MAX_HINT_BYTES, 0);
+    return buf.toString(enc, 0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
  * Read a `.shepherd-preview` hint file from the worktree root.
  *
  * Returns the declared port (integer in [1, 65535]) or null on any failure:
@@ -51,13 +75,14 @@ const PREVIEW_HINT_FILE = ".shepherd-preview";
  * pure run of decimal digits (e.g. "3000abc", "3000 5173", "3000.5"), NaN,
  * or out-of-range. Never throws.
  *
- * The file must contain only a base-10 port number (optionally surrounded by
- * whitespace) — no trailing characters, no decimal points, no spaces between
- * digits.
+ * Only the first MAX_HINT_BYTES of the file are read (see `readHintFileBounded`),
+ * so the file must put the port number (optionally surrounded by whitespace)
+ * within that prefix — no trailing characters, no decimal points, no spaces
+ * between digits.
  */
 async function readPreviewHint(
   worktreePath: string,
-  readFile: (path: string, enc: "utf8") => Promise<string> = fsReadFile,
+  readFile: (path: string, enc: "utf8") => Promise<string> = readHintFileBounded,
 ): Promise<number | null> {
   const hintPath = join(worktreePath, PREVIEW_HINT_FILE);
   let text: string;

--- a/src/service.ts
+++ b/src/service.ts
@@ -121,6 +121,24 @@ const RESEARCH_FIRST_NOTICE =
   "files against a stale or assumed API with no human to correct course.";
 
 /**
+ * Injected into the system prompt only for isolated sessions (worktree-backed). Non-isolated
+ * sessions share the main repo directory and have no dedicated worktree, so the file would be
+ * ambiguous and the hint would be misleading — it is intentionally omitted there.
+ *
+ * The hint is advisory and safe: Shepherd uses the declared port only when it is actually
+ * listening (auto-detection still fires otherwise), and it explicitly never starts or stops the
+ * dev server. Agent-facing prompt text (not operator UI), so fixed English — same precedent as
+ * BRANCH_RENAME_NOTICE and the other spawn-constant notices. No i18n.
+ */
+const PREVIEW_HINT_NOTICE =
+  "If you start a long-running dev server in this worktree and want Shepherd's live preview to " +
+  "target a specific port, write that port — a bare number, nothing else — to a file named " +
+  "`.shepherd-preview` in the repository root. Shepherd uses it only when that port is actually " +
+  "listening; otherwise it auto-detects the port. This is optional: skip it if you have no dev " +
+  "server or the default detection already targets the right port. Shepherd never starts or stops " +
+  "your dev server.";
+
+/**
  * Seeded into the system prompt at spawn when the repo has autopilot on, so the agent knows
  * up front it's running unattended. Without it autopilot is purely reactive — the agent stops
  * to ask "commit + open a PR?", and a steer only lands after a stop is detected and classified
@@ -260,12 +278,19 @@ const PLAN_GO_STEER =
  * plan-gate directive (interactive/auto) is appended INSTEAD of the autopilot directive, even when
  * `autopilotActive` is true — planning must suppress autopilot so the agent stops to plan/grill
  * rather than driving straight to a PR. `opts.buildQueue`, when set, appends the build-queue
- * directive — orthogonal to the plan-gate/autopilot choice, so it always rides.
+ * directive — orthogonal to the plan-gate/autopilot choice, so it always rides. `opts.previewHint`,
+ * when true, appends the preview-hint notice AFTER the build-queue block (or after the
+ * plan-gate/autopilot block when no build-queue is present) — isolated-only, orthogonal to all
+ * other options.
  */
 export function composeSystemPrompt(
   houseRules: string | null,
   autopilotActive = false,
-  opts: { planGate?: "interactive" | "auto"; buildQueue?: string | null } = {},
+  opts: {
+    planGate?: "interactive" | "auto";
+    buildQueue?: string | null;
+    previewHint?: boolean;
+  } = {},
 ): string {
   const posture = `<engineering-posture>\n${ENGINEERING_POSTURE}\n</engineering-posture>`;
   const research = `<research-first-notice>\n${RESEARCH_FIRST_NOTICE}\n</research-first-notice>`;
@@ -282,6 +307,11 @@ export function composeSystemPrompt(
   }
   // Build queue rides independently of the plan-gate/autopilot directive (orthogonal repo config).
   if (opts.buildQueue != null) blocks.push(`<build-queue>\n${opts.buildQueue}\n</build-queue>`);
+  // Preview hint rides last — isolated sessions only. Non-isolated sessions share the main repo dir
+  // and have no dedicated worktree, so the hint would be misleading there.
+  if (opts.previewHint) {
+    blocks.push(`<preview-hint-notice>\n${PREVIEW_HINT_NOTICE}\n</preview-hint-notice>`);
+  }
   return blocks.join("\n\n");
 }
 
@@ -364,13 +394,15 @@ export class SessionService {
    *  turn) so every spawn (manual AND auto-spawned, e.g. the work-queue drain #222) inherits the
    *  repo's learned corrections without bleeding into the task text. The autopilot directive rides
    *  the same prompt when the repo has autopilot on; the plan-gate directive when planGateOn; the
-   *  build-queue directive (baking the exact queue endpoint for `sessionId`) when buildQueueEnabled. */
+   *  build-queue directive (baking the exact queue endpoint for `sessionId`) when buildQueueEnabled;
+   *  and the preview-hint notice when the session is `isolated`. */
   private buildSpawnArgv(
     input: CreateSessionInput,
     claudeSessionId: string,
     sessionId: string,
     promptArg: string,
     planGateOn: boolean | undefined,
+    isolated: boolean,
   ): string[] {
     const repoConfig = this.deps.store.getRepoConfig(input.repoPath);
     const houseRules = this.houseRules(input.repoPath);
@@ -388,7 +420,11 @@ export class SessionService {
     argv.push("--settings", spawnSettingsOverlay());
     argv.push(
       "--append-system-prompt",
-      composeSystemPrompt(houseRules, autopilotActive, { planGate, buildQueue }),
+      composeSystemPrompt(houseRules, autopilotActive, {
+        planGate,
+        buildQueue,
+        previewHint: isolated,
+      }),
     );
     if (input.model) argv.push("--model", input.model);
     argv.push(promptArg);
@@ -415,7 +451,14 @@ export class SessionService {
       // suppresses autopilot — interactive grills a present human, auto (drain) just writes the
       // plan. Session-level override wins over the repo default.
       const planGateOn = input.planGateEnabled ?? repoConfig.planGateEnabled;
-      const argv = this.buildSpawnArgv(input, claudeSessionId, sessionId, promptArg, planGateOn);
+      const argv = this.buildSpawnArgv(
+        input,
+        claudeSessionId,
+        sessionId,
+        promptArg,
+        planGateOn,
+        wt.isolated,
+      );
       const agent = this.deps.herdr.start(name, wt.worktreePath, argv);
       const session = this.deps.store.create({
         id: sessionId,

--- a/test/poller-preview.test.ts
+++ b/test/poller-preview.test.ts
@@ -434,6 +434,52 @@ test("preview sweep: single scan per sweep regardless of session count", async (
   expect(scanCalls.count).toBe(1);
 });
 
+// ── pick receives worktreePath ────────────────────────────────────────────────
+
+test("preview sweep: pick is called with the session's worktreePath", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSessionInput); // worktreePath = "/wt-a"
+
+  const pickCalls: Array<{ ports: number[]; worktreePath: string }> = [];
+  const service = makePreviewService();
+  const clock = 100_000;
+
+  const poller = new StatusPoller(
+    store,
+    { list: () => [baseHerdrAgent], read: () => "" } as any,
+    () => {},
+    () => {},
+    1000,
+    3000,
+    undefined,
+    () => clock,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      service,
+      sweepMs: 4000,
+      scan: (worktrees) => {
+        const m = new Map<string, number[]>();
+        for (const wt of worktrees) m.set(wt, [5173]);
+        return m;
+      },
+      pick: async (ports, worktreePath) => {
+        pickCalls.push({ ports, worktreePath });
+        return 5173;
+      },
+    },
+  );
+
+  poller.tick();
+  await new Promise((r) => setTimeout(r, 10));
+
+  expect(pickCalls.length).toBeGreaterThanOrEqual(1);
+  expect(pickCalls[0]!.worktreePath).toBe(s.worktreePath);
+});
+
 // ── GET /api/preview server endpoint ─────────────────────────────────────────
 
 test("GET /api/preview returns the preview snapshot", async () => {

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -180,6 +180,20 @@ test("resolveDevPort: hint non-curated, in ports, probe fails → falls back to 
   expect(result).toBe(5173);
 });
 
+test("resolveDevPort: failed non-curated hint is NOT re-probed in the fallback", async () => {
+  // hint=9000 (non-curated, in ports), no curated port present so the fallback reaches
+  // the probe loop. 9000 fails its probe in the hint branch; it must be excluded from the
+  // fallback set so it isn't probed a second time. 9500 answers and wins.
+  const probed: number[] = [];
+  const probe = async (port: number): Promise<boolean> => {
+    probed.push(port);
+    return port === 9500;
+  };
+  const result = await resolveDevPort([9000, 9500], "/any", makeReadFile("9000"), probe);
+  expect(result).toBe(9500);
+  expect(probed.filter((p) => p === 9000).length).toBe(1); // probed once (hint branch), not re-probed
+});
+
 test("resolveDevPort: hint not in ports → falls back, hint port never probed", async () => {
   // hint=9000, ports=[5173] — 9000 not listening
   const probedPorts: number[] = [];

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "bun:test";
-import { pickPrimaryPort, sanitizeCloseCode, rewriteLoopbackLocation } from "../src/preview";
+import {
+  pickPrimaryPort,
+  sanitizeCloseCode,
+  rewriteLoopbackLocation,
+  resolveDevPort,
+} from "../src/preview";
 import { scanListeningPortsByWorktree, type ReaperProbes } from "../src/process-reaper";
 
 // ── pickPrimaryPort ───────────────────────────────────────────────────────────
@@ -84,6 +89,109 @@ test("pickPrimaryPort: mixed curated + non-curated → curated wins, no httpProb
 test("pickPrimaryPort: only non-curated, none answer HTTP → null", async () => {
   const result = await pickPrimaryPort([9229, 5678], noProbe);
   expect(result).toBeNull();
+});
+
+// ── readPreviewHint + resolveDevPort ──────────────────────────────────────────
+
+// Fake readFile helpers
+const rejectReadFile = async (): Promise<string> => {
+  throw new Error("ENOENT: no such file");
+};
+const makeReadFile = (content: string) => async (): Promise<string> => content;
+
+// These tests exercise readPreviewHint behaviour indirectly via resolveDevPort.
+test("resolveDevPort: valid port string '3000\\n' → hint honored (3000 curated, no probe)", async () => {
+  const result = await resolveDevPort([3000], "/any", makeReadFile("3000\n"), async () => true);
+  expect(result).toBe(3000);
+});
+
+test("resolveDevPort: non-numeric 'abc' hint → null (falls back to pickPrimaryPort)", async () => {
+  const result = await resolveDevPort([5173], "/any", makeReadFile("abc"), neverProbe);
+  expect(result).toBe(5173); // bad hint → falls back
+});
+
+test("resolveDevPort: out-of-range '0' hint → null (falls back)", async () => {
+  const result = await resolveDevPort([5173], "/any", makeReadFile("0"), neverProbe);
+  expect(result).toBe(5173);
+});
+
+test("resolveDevPort: out-of-range '70000' hint → null (falls back)", async () => {
+  const result = await resolveDevPort([5173], "/any", makeReadFile("70000"), neverProbe);
+  expect(result).toBe(5173);
+});
+
+test("resolveDevPort: surrounding whitespace '  5173  ' → hint honored (curated, no probe)", async () => {
+  let probeCount = 0;
+  const countingProbe = async (): Promise<boolean> => {
+    probeCount++;
+    return true;
+  };
+  const result = await resolveDevPort([5173], "/any", makeReadFile("  5173  "), countingProbe);
+  expect(result).toBe(5173);
+  expect(probeCount).toBe(0); // curated → no probe
+});
+
+test("resolveDevPort: junk-suffixed hint '3000abc' → rejected (falls back to pickPrimaryPort)", async () => {
+  // parseInt("3000abc") = 3000 but /^\d+$/ rejects it → hint is null → falls back
+  // Prove rejection: ports=[5173] so fallback picks 5173 (NOT 3000 via hint path)
+  let probeCount = 0;
+  const countingProbe = async (): Promise<boolean> => {
+    probeCount++;
+    return false;
+  };
+  const result = await resolveDevPort([5173], "/any", makeReadFile("3000abc"), countingProbe);
+  expect(result).toBe(5173); // curated 5173 returned via fallback (no probe)
+  expect(probeCount).toBe(0); // 3000 was NEVER probed (hint was rejected outright)
+});
+
+test("resolveDevPort: curated hint not in ports → falls back to pickPrimaryPort (ports.includes gate)", async () => {
+  // hint=3000 (curated), ports=[5173] — 3000 not listening → ignored
+  const result = await resolveDevPort([5173], "/any", makeReadFile("3000"), neverProbe);
+  expect(result).toBe(5173); // fallback picks curated 5173
+});
+
+test("resolveDevPort: hint curated, in ports → returns hint WITHOUT probing", async () => {
+  let probeCount = 0;
+  const countingProbe = async (): Promise<boolean> => {
+    probeCount++;
+    return true;
+  };
+  // hint=5173 (curated), ports=[3000, 5173]
+  const result = await resolveDevPort([3000, 5173], "/any", makeReadFile("5173"), countingProbe);
+  expect(result).toBe(5173);
+  expect(probeCount).toBe(0);
+});
+
+test("resolveDevPort: hint non-curated, in ports, probe passes → returns hint (wins over curated 5173)", async () => {
+  // hint=9000 (non-curated), ports=[9000, 5173]; probe passes for 9000
+  // Without the hint, pickPrimaryPort would return 5173. The hint overrides it.
+  const probe = async (port: number): Promise<boolean> => port === 9000;
+  const result = await resolveDevPort([9000, 5173], "/any", makeReadFile("9000"), probe);
+  expect(result).toBe(9000);
+});
+
+test("resolveDevPort: hint non-curated, in ports, probe fails → falls back to pickPrimaryPort (returns curated 5173)", async () => {
+  // hint=9000 (non-curated), probe fails for 9000; 5173 is curated → returned unprobed
+  const probe = async (port: number): Promise<boolean> => port !== 9000;
+  const result = await resolveDevPort([9000, 5173], "/any", makeReadFile("9000"), probe);
+  expect(result).toBe(5173);
+});
+
+test("resolveDevPort: hint not in ports → falls back, hint port never probed", async () => {
+  // hint=9000, ports=[5173] — 9000 not listening
+  const probedPorts: number[] = [];
+  const trackingProbe = async (port: number): Promise<boolean> => {
+    probedPorts.push(port);
+    return false;
+  };
+  const result = await resolveDevPort([5173], "/any", makeReadFile("9000"), trackingProbe);
+  expect(result).toBe(5173); // curated 5173 returned (no probe for curated)
+  expect(probedPorts).not.toContain(9000);
+});
+
+test("resolveDevPort: no hint (readFile rejects) → falls back to pickPrimaryPort", async () => {
+  const result = await resolveDevPort([5173], "/any", rejectReadFile, neverProbe);
+  expect(result).toBe(5173);
 });
 
 // ── sanitizeCloseCode ─────────────────────────────────────────────────────────

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -6,6 +6,9 @@ import {
   resolveDevPort,
 } from "../src/preview";
 import { scanListeningPortsByWorktree, type ReaperProbes } from "../src/process-reaper";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // ── pickPrimaryPort ───────────────────────────────────────────────────────────
 
@@ -192,6 +195,26 @@ test("resolveDevPort: hint not in ports → falls back, hint port never probed",
 test("resolveDevPort: no hint (readFile rejects) → falls back to pickPrimaryPort", async () => {
   const result = await resolveDevPort([5173], "/any", rejectReadFile, neverProbe);
   expect(result).toBe(5173);
+});
+
+// The DEFAULT reader (no injected readFile) reads at most MAX_HINT_BYTES (64) from
+// disk. This file's first 64 bytes are a clean non-curated port (9000) + whitespace,
+// with a stray "x" far past the cap. With the cap, the hint parses to 9000 and (probe
+// passing) wins over the curated 5173 the heuristic would otherwise pick. WITHOUT the
+// cap an unbounded read would see the trailing "x", reject the content as non-numeric,
+// and fall back to pickPrimaryPort → curated 5173 — so a 9000 result proves only the
+// bounded prefix was read.
+test("resolveDevPort: default reader caps the read at MAX_HINT_BYTES", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-preview-hint-"));
+  try {
+    writeFileSync(join(dir, ".shepherd-preview"), `9000${" ".repeat(200)}x`);
+    const alwaysLive = async (): Promise<boolean> => true;
+    // Default readFile (undefined) → bounded reader.
+    const result = await resolveDevPort([9000, 5173], dir, undefined, alwaysLive);
+    expect(result).toBe(9000);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // ── sanitizeCloseCode ─────────────────────────────────────────────────────────

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -64,7 +64,7 @@ test("createSession: names, makes worktree, starts herdr, persists", async () =>
     "--settings",
     spawnSettingsOverlay(),
     "--append-system-prompt",
-    composeSystemPrompt(null), // no learnings → engineering-posture + branch-rename notice, no house-rules block
+    composeSystemPrompt(null, false, { previewHint: true }), // no learnings → engineering-posture + branch-rename notice, no house-rules block
     "flatten it",
   ]);
   expect(s.claudeSessionId).toMatch(/^[0-9a-f-]{36}$/);
@@ -445,7 +445,7 @@ test("createSession: passes --model and persists it when a model is chosen", asy
     "--settings",
     spawnSettingsOverlay(),
     "--append-system-prompt",
-    composeSystemPrompt(null), // no learnings → engineering-posture + branch-rename notice, no house-rules block
+    composeSystemPrompt(null, false, { previewHint: true }), // no learnings → engineering-posture + branch-rename notice, no house-rules block
     "--model",
     "opus",
     "go",
@@ -1489,15 +1489,15 @@ test("archiveMany clears each session, reaping all its leftovers", () => {
   expect(store.get(b.id)?.status).toBe("archived");
 });
 
-function injectDeps(store: SessionStore, captured: { argv?: string[] }) {
+function injectDeps(store: SessionStore, captured: { argv?: string[] }, isolated = true) {
   return {
     store,
     namer: async () => "repo-task",
     worktree: {
       create: () => ({
         worktreePath: "/wt/repo-task",
-        branch: "shepherd/repo-task",
-        isolated: true,
+        branch: isolated ? "shepherd/repo-task" : null,
+        isolated,
       }),
       remove: () => {},
     } as any,
@@ -1566,7 +1566,7 @@ test("create omits the house-rules block when no active rules exist", async () =
   });
   expect(captured.argv!.at(-1)).toBe("do the thing");
   // System prompt carries posture + branch-rename notice, no house-rules tag.
-  expect(sysPrompt(captured.argv!)).toBe(composeSystemPrompt(null));
+  expect(sysPrompt(captured.argv!)).toBe(composeSystemPrompt(null, false, { previewHint: true }));
 });
 
 test("create omits house rules when learnings disabled for the repo", async () => {
@@ -1596,7 +1596,7 @@ test("create omits house rules when learnings disabled for the repo", async () =
     images: [],
   });
   expect(captured.argv!.at(-1)).toBe("do the thing");
-  expect(sysPrompt(captured.argv!)).toBe(composeSystemPrompt(null));
+  expect(sysPrompt(captured.argv!)).toBe(composeSystemPrompt(null, false, { previewHint: true }));
 });
 
 test("composeSystemPrompt adds the autopilot directive only when active", () => {
@@ -2100,6 +2100,64 @@ test("composeSystemPrompt places <build-queue> after branch-rename-notice (no au
   expect(branchPos).toBeGreaterThan(-1);
   expect(bqPos).toBeGreaterThan(branchPos);
   expect(sp).not.toContain("<autopilot-directive>");
+});
+
+test("composeSystemPrompt omits <preview-hint-notice> when previewHint is unset/false", () => {
+  expect(composeSystemPrompt(null)).not.toContain("<preview-hint-notice>");
+  expect(composeSystemPrompt(null, false)).not.toContain("<preview-hint-notice>");
+  expect(composeSystemPrompt(null, true)).not.toContain("<preview-hint-notice>");
+});
+
+test("composeSystemPrompt includes <preview-hint-notice> when previewHint is true", () => {
+  const sp = composeSystemPrompt(null, false, { previewHint: true });
+  expect(sp).toContain("<preview-hint-notice>");
+  expect(sp).toContain(".shepherd-preview");
+  expect(sp).toContain("</preview-hint-notice>");
+});
+
+test("composeSystemPrompt places <preview-hint-notice> after <build-queue> when both present", () => {
+  const sp = composeSystemPrompt(null, true, { buildQueue: "bq-text", previewHint: true });
+  const bqPos = sp.indexOf("<build-queue>");
+  const phPos = sp.indexOf("<preview-hint-notice>");
+  expect(bqPos).toBeGreaterThan(-1);
+  expect(phPos).toBeGreaterThan(bqPos);
+});
+
+test("composeSystemPrompt places <preview-hint-notice> after <branch-rename-notice> when no build-queue", () => {
+  const sp = composeSystemPrompt(null, false, { previewHint: true });
+  const branchPos = sp.indexOf("<branch-rename-notice>");
+  const phPos = sp.indexOf("<preview-hint-notice>");
+  expect(branchPos).toBeGreaterThan(-1);
+  expect(phPos).toBeGreaterThan(branchPos);
+  expect(sp).not.toContain("<build-queue>");
+});
+
+test("isolated spawn argv carries <preview-hint-notice> in system prompt", async () => {
+  const store = new SessionStore(":memory:");
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(injectDeps(store, captured) as any);
+  await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "do the thing",
+    model: null,
+    images: [],
+  });
+  expect(sysPrompt(captured.argv!)).toContain("<preview-hint-notice>");
+});
+
+test("non-isolated spawn argv does NOT carry <preview-hint-notice> in system prompt", async () => {
+  const store = new SessionStore(":memory:");
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(injectDeps(store, captured, false) as any);
+  await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "do the thing",
+    model: null,
+    images: [],
+  });
+  expect(sysPrompt(captured.argv!)).not.toContain("<preview-hint-notice>");
 });
 
 function buildQueueDeps(


### PR DESCRIPTION
Closes #397. Follow-up to #345 (auto-detect preview port via /proc scan).

## What

Let a project/agent **declare** the live-preview dev port explicitly by dropping a `.shepherd-preview` file (a bare port number, e.g. `3000`) in the worktree/repo root, instead of relying only on the auto-detect heuristic. Removes ambiguity for multi-listener apps and apps on uncommon ports.

## How

- **`src/preview.ts`** — new `resolveDevPort(ports, worktreePath, …)`: reads `.shepherd-preview` (async, validated `[1,65535]`, digit-only) and honors it **only when that port is actually listening in the worktree's /proc scan set AND is HTTP-live** (curated frontend ports trusted unprobed, exactly as `pickPrimaryPort`). Otherwise falls back to `pickPrimaryPort`. A stale/wrong hint self-heals.
- **`src/poller.ts`** — the live-preview sweep now resolves via `resolveDevPort`, threading each session's `worktreePath` into the `pick` wiring.
- **`src/service.ts`** — a `<preview-hint-notice>` rides the spawn system prompt for **isolated** sessions only, telling the agent it can declare the port.
- **`README.md` / `.gitignore`** — documents the convention; ignores the transient hint file in Shepherd's own repo.

## Invariants preserved (from #345)

- **No cross-worktree hijack:** the hint is honored only if the port is in *this* worktree's /proc scan set, which buckets ports by the owning process's `cwd` → a port owned by another worktree can never be honored.
- **No non-HTTP sockets surfaced:** non-curated declared ports must still pass the HTTP liveness probe (DB/debugger ports rejected → fall back).
- **Detect-and-proxy only**, proxy target always the session's own dev port.

## Naming / scope notes

- File is `.shepherd-preview` (dotfile, consistent with `.shepherd-name` / `.shepherd-review.json` / `.shepherd-plan.md`) — chosen over the issue title's literal `shepherd.preview` per maintainer sign-off during planning.
- `[no-feature-entry]`: ships **no new user-facing UI** (the Preview badge/pane already exist; this is server-side detection logic + agent steering + docs), so the feature-announcement catalog is intentionally skipped. No new i18n strings.

## Testing

- 1524 pass / 0 fail (root suite); lint, `tsc --noEmit`, and `fallow audit` all clean. New unit tests cover the resolver (curated-unprobed / probe-pass-wins / probe-fail-fallback / not-listening / no-hint / junk-suffix rejection), the poller worktreePath threading, and the isolated-only prompt gating (positive + negative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)