### PR TITLE
fix(store): monotonic task designations — never reuse a number after prune

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -26,6 +26,9 @@ function parseFindings(raw: unknown): string[] {
   }
 }
 
+/** Designation prefix for task sessions, e.g. "TASK-07". Single source for the prefix + its SUBSTR offset. */
+const DESIG_PREFIX = "TASK-";
+
 /** Allowed learning status transitions (spec §3). Terminal states have no exits. */
 const LEARNING_TRANSITIONS: Record<LearningStatus, LearningStatus[]> = {
   proposed: ["active", "dismissed"],
@@ -137,6 +140,17 @@ export class SessionStore implements CapStore {
       auto INTEGER NOT NULL DEFAULT 0, issueNumber INTEGER,
       createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL, archivedAt INTEGER)`);
     this.migrateSessionColumns();
+    this.db.run(`CREATE TABLE IF NOT EXISTS task_seq (
+      id INTEGER PRIMARY KEY CHECK (id = 1), next INTEGER NOT NULL)`);
+    // Seed once from the high-water mark of existing desigs (TASK-NN) + 1, or 1 on a fresh DB.
+    // SUBSTR offset strips the fixed DESIG_PREFIX; SQLite SUBSTR is 1-based so offset = prefix.length + 1.
+    // INSERT OR IGNORE keeps this idempotent.
+    // NB: this guarantees no *future* reuse but does not de-duplicate desig collisions a pre-fix
+    // DB may already hold (the old COUNT(*) scheme reused numbers after a prune). We deliberately
+    // don't renumber historical rows: a desig is stamped into that task's already-created branch
+    // name + PR title, so rewriting it would desync the label from its real-world artifacts.
+    this.db.run(`INSERT OR IGNORE INTO task_seq (id, next)
+      VALUES (1, (SELECT COALESCE(MAX(CAST(SUBSTR(desig, ${DESIG_PREFIX.length + 1}) AS INTEGER)), 0) + 1 FROM sessions))`);
     this.db.run(`CREATE TABLE IF NOT EXISTS usage_caps (
       window TEXT PRIMARY KEY, cap REAL NOT NULL, resetAt INTEGER NOT NULL,
       pct INTEGER NOT NULL, scrapedAt INTEGER NOT NULL)`);
@@ -353,75 +367,83 @@ export class SessionStore implements CapStore {
     return changes > 0;
   }
 
+  private nextDesignationSeq(): number {
+    const row = this.db.query(`SELECT next FROM task_seq WHERE id = 1`).get() as { next: number };
+    this.db.run(`UPDATE task_seq SET next = next + 1 WHERE id = 1`);
+    return row.next;
+  }
+
   create(input: NewSession): Session {
-    const now = Date.now();
-    const n = (this.db.query(`SELECT COUNT(*) AS c FROM sessions`).get() as { c: number }).c;
-    const s: Session = {
-      ...input,
-      model: input.model ?? null,
-      claudeSessionId: input.claudeSessionId ?? "",
-      id: input.id ?? randomUUID(),
-      desig: `TASK-${String(n + 1).padStart(2, "0")}`,
-      readyToMerge: false,
-      autopilotEnabled: null,
-      autopilotStepCount: 0,
-      autopilotPaused: false,
-      autopilotComplete: false,
-      autopilotQuestion: null,
-      planGateEnabled: input.planGateEnabled ?? null,
-      planPhase: input.planPhase ?? null,
-      autoMergeEnabled: null,
-      autoMergeRebaseCount: 0,
-      autoMergeRebaseHead: null,
-      auto: input.auto ?? false,
-      issueNumber: input.issueNumber ?? null,
-      status: "running",
-      lastState: "idle",
-      createdAt: now,
-      updatedAt: now,
-      archivedAt: null,
-      mergingSince: null,
-      mergingTrainId: null,
-    };
-    this.db.run(
-      `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-      [
-        s.id,
-        s.desig,
-        s.name,
-        s.prompt,
-        s.repoPath,
-        s.baseBranch,
-        s.branch,
-        s.worktreePath,
-        s.isolated ? 1 : 0,
-        s.herdrSession,
-        s.herdrAgentId,
-        s.claudeSessionId,
-        s.model,
-        s.readyToMerge ? 1 : 0,
-        s.status,
-        s.lastState,
-        null, // autopilotEnabled — inherit repo default
-        0, // autopilotStepCount
-        0, // autopilotPaused
-        0, // autopilotComplete
-        null, // autopilotQuestion
-        s.planGateEnabled === null ? null : s.planGateEnabled ? 1 : 0, // planGateEnabled — inherit repo default
-        s.planPhase, // planPhase — null = gate off
-        null, // autoMergeEnabled — inherit repo default
-        0, // autoMergeRebaseCount
-        null, // autoMergeRebaseHead — none outstanding
-        s.auto ? 1 : 0,
-        s.issueNumber,
-        s.createdAt,
-        s.updatedAt,
-        s.archivedAt,
-        s.mergingSince,
-        s.mergingTrainId,
-      ],
-    );
-    return s;
+    return this.db.transaction(() => {
+      const now = Date.now();
+      const seq = this.nextDesignationSeq();
+      const s: Session = {
+        ...input,
+        model: input.model ?? null,
+        claudeSessionId: input.claudeSessionId ?? "",
+        id: input.id ?? randomUUID(),
+        desig: `${DESIG_PREFIX}${String(seq).padStart(2, "0")}`,
+        readyToMerge: false,
+        autopilotEnabled: null,
+        autopilotStepCount: 0,
+        autopilotPaused: false,
+        autopilotComplete: false,
+        autopilotQuestion: null,
+        planGateEnabled: input.planGateEnabled ?? null,
+        planPhase: input.planPhase ?? null,
+        autoMergeEnabled: null,
+        autoMergeRebaseCount: 0,
+        autoMergeRebaseHead: null,
+        auto: input.auto ?? false,
+        issueNumber: input.issueNumber ?? null,
+        status: "running",
+        lastState: "idle",
+        createdAt: now,
+        updatedAt: now,
+        archivedAt: null,
+        mergingSince: null,
+        mergingTrainId: null,
+      };
+      this.db.run(
+        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        [
+          s.id,
+          s.desig,
+          s.name,
+          s.prompt,
+          s.repoPath,
+          s.baseBranch,
+          s.branch,
+          s.worktreePath,
+          s.isolated ? 1 : 0,
+          s.herdrSession,
+          s.herdrAgentId,
+          s.claudeSessionId,
+          s.model,
+          s.readyToMerge ? 1 : 0,
+          s.status,
+          s.lastState,
+          null, // autopilotEnabled — inherit repo default
+          0, // autopilotStepCount
+          0, // autopilotPaused
+          0, // autopilotComplete
+          null, // autopilotQuestion
+          s.planGateEnabled === null ? null : s.planGateEnabled ? 1 : 0, // planGateEnabled — inherit repo default
+          s.planPhase, // planPhase — null = gate off
+          null, // autoMergeEnabled — inherit repo default
+          0, // autoMergeRebaseCount
+          null, // autoMergeRebaseHead — none outstanding
+          s.auto ? 1 : 0,
+          s.issueNumber,
+          s.createdAt,
+          s.updatedAt,
+          s.archivedAt,
+          s.mergingSince,
+          s.mergingTrainId,
+        ],
+      );
+      return s;
+    })();
   }
 
   get(id: string): Session | null {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import { SessionStore } from "../src/store";
 import type { ReviewVerdict } from "../src/types";
 
@@ -437,4 +441,49 @@ test("session: autoMergeEnabled override + rebase count round-trip", () => {
   expect(store.get(s.id)!.autoMergeRebaseHead).toBe("deadbeef");
   store.setAutoMergeState(s.id, { rebaseHead: null });
   expect(store.get(s.id)!.autoMergeRebaseHead).toBeNull();
+});
+
+test("desig: no reuse after prune — counter is strictly monotonic", async () => {
+  const s = mk();
+  const a = s.create(base);
+  expect(a.desig).toBe("TASK-01");
+  s.archive(a.id);
+  // negative maxAgeMs makes cutoff land in the future → the just-archived row is within the age
+  // window AND keepNewest:0 evicts it by rank; confirm it's gone
+  const removed = s.pruneArchivedSessions({ maxAgeMs: -Number.MAX_SAFE_INTEGER, keepNewest: 0 });
+  expect(removed).toBe(1);
+  expect(s.get(a.id)).toBeNull();
+  // pre-fix: COUNT(*) would drop to 0 → next desig is TASK-01 again (collision)
+  const b = s.create({ ...base, herdrAgentId: "term_2" });
+  expect(b.desig).toBe("TASK-02");
+});
+
+test("desig: seed from pre-existing DB high-water mark", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-store-seed-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    // Pre-populate a raw DB with desig='TASK-09' so the seed subquery finds max=9.
+    // Use the full sessions schema so migrateSessionColumns + INSERT in create() work.
+    const raw = new Database(dbPath);
+    raw.run(`CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, desig TEXT NOT NULL, name TEXT NOT NULL, prompt TEXT NOT NULL,
+      repoPath TEXT NOT NULL, baseBranch TEXT NOT NULL, branch TEXT,
+      worktreePath TEXT NOT NULL, isolated INTEGER NOT NULL,
+      herdrSession TEXT NOT NULL, herdrAgentId TEXT NOT NULL,
+      claudeSessionId TEXT NOT NULL DEFAULT '',
+      model TEXT, status TEXT NOT NULL, lastState TEXT NOT NULL,
+      auto INTEGER NOT NULL DEFAULT 0, issueNumber INTEGER,
+      createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL, archivedAt INTEGER)`);
+    raw.run(
+      `INSERT INTO sessions (id, desig, name, prompt, repoPath, baseBranch, worktreePath, isolated, herdrSession, herdrAgentId, status, lastState, createdAt, updatedAt)
+       VALUES ('s1', 'TASK-09', 'old', 'old', '/r', 'main', '/wt', 1, 'default', 'term_0', 'archived', 'idle', 1, 1)`,
+    );
+    raw.close();
+
+    const store = new SessionStore(dbPath);
+    const s = store.create(base);
+    expect(s.desig).toBe("TASK-10");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Problem

Task designations (`desig`, e.g. `TASK-07`) were minted from `SELECT COUNT(*) FROM sessions` (`store.ts`). Archiving ("decommissioning") keeps the row, so count is stable — **but** the daily `pruneArchivedSessions` *deletes* old archived rows. After a prune the count drops and the next spawn **reuses a freed number**, so `desig` is no longer unique. `desig` is the human-facing identity label across operator banners, push notifications, and review/plan-gate/drain/merge holds, so collisions are confusing (a live `TASK-07` sharing a number with an archived `TASK-07` whose PR still references it).

## Fix

Strictly monotonic, **global** counter (per the agreed decision):

- New single-row `task_seq(id=1, next INTEGER)` table, created in the constructor after `migrateSessionColumns()`, **seeded once** (`INSERT OR IGNORE`) from the high-water mark of existing designations (`MAX(CAST(SUBSTR(desig, …)…)) + 1`, or `1` on a fresh DB) so pre-existing DBs keep numbering without colliding.
- `nextDesignationSeq()` reserves and increments the counter; `create()` is wrapped in a transaction so reservation + INSERT are atomic (a failed insert rolls the counter back — no wasted numbers).
- Numbering is now independent of `COUNT(*)`, archive, and prune. `pruneArchivedSessions` is unchanged and no longer affects numbering.
- `TASK-` prefix + its `SUBSTR` offset factored into one `DESIG_PREFIX` constant (single source of truth).

## Tests (`test/store.test.ts`)

- Existing sequential `TASK-01`/`TASK-02` test still passes (fresh DB starts at `TASK-01`).
- **No reuse after prune:** create → archive → hard-delete via prune → next create yields the *next* number, not the freed one (the regression).
- **Seed from a pre-existing DB:** a file-backed DB already holding `TASK-09` → first new create yields `TASK-10`.

## Validation

`bun run lint` · `bun test ./test` (1507 pass) · `bunx tsc --noEmit` — all clean. Branch hygiene + fallow audit gates pass (dead code 0, complexity 0).

Server-internal plumbing, no user-facing UX → `[no-feature-entry]` (feature-catalog opt-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)