### PR TITLE
fix(ui): consistent heartbeat width on session cards

### DIFF
--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -146,6 +146,7 @@
   <div
     class="unit"
     class:sel={selected}
+    class:has-activity={live}
     class:decommissioning
     style="--rule:{session.readyToMerge ? 'var(--color-green)' : STATUS_COLOR[session.status]}"
   >
@@ -181,15 +182,6 @@
           <span class="car" aria-hidden="true">▏</span>
         {/if}
       </div>
-      {#if live}
-        <div class="u-activity">
-          <HeartbeatStrip {activity} {nowMs} />
-          {#if summary}
-            <span class="act-sep" aria-hidden="true">·</span>
-            <span class="act-sum">{summary}</span>
-          {/if}
-        </div>
-      {/if}
     </div>
 
     <div class="u-right">
@@ -230,6 +222,16 @@
       {/if}
       <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
     </div>
+
+    {#if live}
+      <div class="u-activity">
+        <HeartbeatStrip {activity} {nowMs} />
+        {#if summary}
+          <span class="act-sep" aria-hidden="true">·</span>
+          <span class="act-sum">{summary}</span>
+        {/if}
+      </div>
+    {/if}
 
     <span class="meta">
       <span class="meta-text"
@@ -296,6 +298,17 @@
     text-align: left;
     width: 100%;
     transition: opacity 0.18s ease;
+  }
+
+  /* Live rows insert a dedicated full-width `act` track between main and meta so
+     the heartbeat spans main+right (identical width on every card, independent of
+     the badge column). Non-live rows keep the 2-row template above — no extra
+     track / row-gap. */
+  .unit.has-activity {
+    grid-template-areas:
+      "pip main  right"
+      "pip act   act"
+      "pip meta  meta";
   }
 
   /* deferred decommission: row is doomed but still listed during the undo
@@ -502,10 +515,10 @@
      single-line, ellipsized — the priority signal for a working row without
      adding a colored badge. */
   .u-activity {
+    grid-area: act;
     display: flex;
     align-items: center;
     gap: 0;
-    margin-top: 3px;
     min-width: 0;
     font-size: 11px;
     line-height: 1.3;


### PR DESCRIPTION
## Was

Im Herd-Listen-Card (`UnitRow.svelte`) füllte der Heartbeat-Streifen die `u-main`-Spalte, deren Breite = Card − die `auto`-breite Badge-Spalte (`u-right`). Da der Badge-Inhalt pro Card variiert (`NO PR` vs `BUSY` vs `REWORK · n/m`), bekam **jede Card einen anders breiten Heartbeat** — die gemeldete Inkonsistenz.

## Fix

Der Heartbeat wandert in eine **eigene Grid-Zeile, die `main` + `right` überspannt** — er reicht damit über die volle Card-Breite und ist auf **jeder Card gleich breit**, unabhängig vom Badge-Inhalt. Das wahrt die volle-Breite-Absicht aus #332 ("priority glance signal").

- Neue Zeile per `class:has-activity={live}` gegated: nicht-laufende Rows behalten das 2-Zeilen-Grid → kein leerer Track / kein zusätzliches `row-gap`.
- `.u-activity` → `grid-area: act`, `margin-top: 3px` entfernt (das `row-gap: 3px` der Card liefert jetzt den Abstand, sonst doppelt), `min-width: 0` bleibt (Ellipsis des Hover-Summary).
- Strip-Width-Overrides (Default flex-grow + compact `@container` 64px) und Hover-Reveal unverändert.

## Scope / Kollision mit #443

Nur **eine Datei** geändert: `ui/src/lib/components/UnitRow.svelte`. PR #443 (repo-status filter) fasst nur `Herd.svelte`/`HerdGrid.svelte`/`QueueStrip.svelte`/`+page.svelte`/Catalog/Messages an — **disjunkte Dateimengen, keine geteilten Diff-Regionen**. #443s `Herd.svelte`-Diff lässt die `container: herd / inline-size`-Deklaration (von der das compact-Heartbeat-Override abhängt) unangetastet. Keine Datei-, Layout- oder Merge-Kollision.

## Checks

- `cd ui && bun run check` — 0 Fehler / 0 Warnungen (1740 Dateien)
- `cd ui && bun run test` — 672 passed (55 Test-Dateien)
- pre-push: fallow audit (delta) ✓, branch-hygiene ✓

Kein `feat` (reiner UI-Fix) → kein Feature-Catalog-Eintrag, keine neuen i18n-Keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)