### PR TITLE
fix(preview): reach live preview when the HUD is fronted on a different Tailscale identity than the agents (#447)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,29 @@ certificates enabled):
 for p in $(seq 8001 8016); do tailscale serve --bg --https=$p 127.0.0.1:$p; done
 ```
 
+**Automated alternative:** set `SHEPHERD_PREVIEW_AUTO_SERVE=1` and Shepherd runs that same
+`tailscale serve --bg --https=<port> 127.0.0.1:<port>` loop over the configured slot range at
+startup. The same prerequisite applies — tailnet HTTPS certificates must be provisioned, or the
+loop fails. Without this flag (the default) the operator must run the manual loop above; the
+iframe URL fix alone makes the preview target the correct host but does **not** make the slot
+ports tailnet-reachable.
+
 > **Funnel vs Serve:** the 443/8443/10000 port restriction applies to **Funnel** only. `tailscale serve`
 > (tailnet-internal) accepts arbitrary HTTPS ports — the snippet above uses that.
+> **Never add the preview slot range (8001–8016) to a Tailscale Service's advertised port list.**
+> A Service requires every member host to advertise all listed ports; ephemeral preview ports
+> would silently drop the node from rotation and take the HUD down.
+
+**Split-front / `previewHost`:** the preview iframe URL is built from the **agent node's own
+tailnet hostname** (server-reported `previewHost`), not the operator's connection host. This means
+the preview works when the HUD is fronted under a different Tailscale identity than the agent node
+— e.g. a Tailscale Service `svc:shepherd` at `:443` while agents run on `backontop`. The slot is
+served at the node, so the iframe correctly targets `https://backontop.<tailnet>.ts.net:<port>`
+rather than the Service address. On localhost dev and single-host tailnets behavior is unchanged.
+
+**Scope / precondition:** the operator's browser must be on the tailnet, and tailnet ACLs must
+permit operator→agent-node traffic on the slot ports. This does **not** help a Funnel /
+public-fronted HUD — the agent node's MagicDNS hostname is unresolvable off-tailnet.
 
 **Startup validation:** Shepherd hard-fails at startup if the configured preview range overlaps the
 HUD's local listen port (`SHEPHERD_PORT`, default 7330) or its public served port (443). Choose a

--- a/src/config.ts
+++ b/src/config.ts
@@ -247,6 +247,18 @@ export const config = {
   previewPortCount: Number(process.env.SHEPHERD_PREVIEW_PORT_COUNT ?? 16),
   // Throttle cadence for the preview sweep (ms); mitigates /proc scan cost.
   previewSweepMs: Number(process.env.SHEPHERD_PREVIEW_SWEEP_MS ?? 4000),
+  // The agent node's own tailnet hostname (e.g. "mynode.ts.net"), resolved ONCE
+  // at startup and stored here. When the HUD is fronted on a different host/identity
+  // than the agent node (e.g. a Tailscale Service), the preview URL must target THIS
+  // node's host — not the operator's connection host — to remain reachable from the
+  // tailnet. Null when tailscale is absent or the hostname cannot be resolved.
+  previewHost: null as string | null,
+  // Opt-in (default OFF): when true AND tailscale is present, shepherd runs
+  // `tailscale serve --bg --https=<port>` for every slot in the preview range at
+  // startup so ephemeral slots are tailnet-reachable without manual setup.
+  // With this off, the operator must manually `tailscale serve` each slot (see README).
+  // Requires tailnet HTTPS certificates to be enabled for the node.
+  previewAutoServe: process.env.SHEPHERD_PREVIEW_AUTO_SERVE === "1",
 };
 
 // Session housekeeping retention thresholds (the daily sweep's policy). The single

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ import { maintenance } from "./maintenance";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { startLoopLagSampler, logRemainingOnLoopBlockers } from "./instrument";
+import { resolveNodeHost, serveRange } from "./tailscale";
 
 const execFileAsync = promisify(execFile);
 
@@ -114,6 +115,7 @@ if (savedPlan !== null)
 // Discover the public served port by parsing `tailscale serve status`; default
 // to 443 when tailscale is unavailable or the mapping isn't found. The parser
 // is pure and injected here so it's testable without tailscale.
+// Also resolve this node's tailnet hostname for split-front preview URL construction.
 {
   let servedPort = 443;
   try {
@@ -123,12 +125,26 @@ if (savedPlan !== null)
   } catch {
     // tailscale not available or not set up — default to 443
   }
+  // Resolve the node's own tailnet hostname (null when tailscale is absent).
+  config.previewHost = await resolveNodeHost();
   validatePreviewPortRange({
     previewPortBase: config.previewPortBase,
     previewPortCount: config.previewPortCount,
     localPort: config.port,
     servedPort,
   });
+  // Opt-in: register all preview slots with `tailscale serve` so they're tailnet-reachable.
+  // Fired void — serveRange sequences the 16 shells internally to avoid serve-config write
+  // races; no need to block boot on it.
+  if (config.previewAutoServe && config.previewHost) {
+    void serveRange(config.previewPortBase, config.previewPortCount).catch((err) =>
+      console.warn("[preview] serveRange failed:", err),
+    );
+  } else if (config.previewAutoServe && !config.previewHost) {
+    console.warn(
+      "[preview] SHEPHERD_PREVIEW_AUTO_SERVE=1 but the node's tailnet host could not be resolved (is tailscale running?); previews will be unreachable.",
+    );
+  }
 }
 
 // drop abandoned New-Task uploads (attached but never submitted) older than 24h

--- a/src/server.ts
+++ b/src/server.ts
@@ -1460,6 +1460,10 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       // instead of hardcoding a mirror of the server constants.
       sessionRetentionDays: SESSION_RETENTION_DAYS,
       sessionRetentionKeep: SESSION_RETENTION_KEEP,
+      // display-only: the agent node's own tailnet hostname; the UI builds preview iframe
+      // URLs from it when the HUD is fronted on a different host than the agent node.
+      // Null when tailscale is absent → UI falls back to the operator's connection host.
+      previewHost: config.previewHost,
     });
   }
   if (req.method === "PUT") {

--- a/src/tailscale.ts
+++ b/src/tailscale.ts
@@ -1,0 +1,80 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { timedAsync } from "./instrument";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Minimal runner type — injectable for unit tests.
+ * Mirrors the promisify(execFile) surface we actually use.
+ */
+export type TailscaleRunner = (args: string[]) => Promise<{ stdout: string }>;
+
+const defaultRun: TailscaleRunner = (args) =>
+  timedAsync("tailscale " + args[0], () => execFileAsync("tailscale", args, { encoding: "utf8" }));
+
+// ── resolveNodeHost ───────────────────────────────────────────────────────────
+
+/**
+ * Returns this node's own Tailscale hostname (e.g. `"backontop.chicken-beardie.ts.net"`)
+ * by parsing `tailscale status --json`.
+ *
+ * WHY: when Shepherd's HUD is fronted by a Tailscale Service identity (a different
+ * DNS name than the machine's own node), `Self.DNSName` is the only reliable way to
+ * construct preview URLs that resolve from the tailnet — the Service front may live
+ * under a different hostname entirely.
+ *
+ * Returns `null` on any failure (binary absent, daemon not running, JSON malformed,
+ * `Self`/`Self.DNSName` missing or empty). Never throws.
+ */
+export async function resolveNodeHost(run: TailscaleRunner = defaultRun): Promise<string | null> {
+  try {
+    const { stdout } = await run(["status", "--json"]);
+    const parsed: unknown = JSON.parse(stdout);
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      !("Self" in parsed) ||
+      parsed.Self === null ||
+      typeof parsed.Self !== "object" ||
+      !("DNSName" in parsed.Self) ||
+      typeof parsed.Self.DNSName !== "string" ||
+      parsed.Self.DNSName === ""
+    ) {
+      return null;
+    }
+    // Strip trailing dot: "backontop.chicken-beardie.ts.net." → "backontop.chicken-beardie.ts.net"
+    return parsed.Self.DNSName.replace(/\.$/, "");
+  } catch {
+    return null;
+  }
+}
+
+// ── serveRange ────────────────────────────────────────────────────────────────
+
+/**
+ * Registers each port in `[base, base + count)` with `tailscale serve --bg --https=<port>`.
+ *
+ * WHY sequential: `tailscale serve` does a read-modify-write on tailscaled's shared
+ * serve config. Concurrent execs can race and lose each other's writes — one port's
+ * config entry silently disappears. The `for` loop with `await` inside prevents that.
+ *
+ * WHY `--bg` and bare `127.0.0.1:<port>` target (no `--yes`, no `http://` prefix):
+ * this is the form proven to work in README.md:231 and matched by the reaper at
+ * src/process-reaper.ts:110 (`/\btailscale\s+serve\b/.test(cmd) && /--bg\b/.test(cmd)`).
+ *
+ * Best-effort: a failing port logs a warning and the loop continues.
+ */
+export async function serveRange(
+  base: number,
+  count: number,
+  run: TailscaleRunner = defaultRun,
+): Promise<void> {
+  for (let port = base; port < base + count; port++) {
+    try {
+      await run(["serve", "--bg", `--https=${port}`, `127.0.0.1:${port}`]);
+    } catch (err) {
+      console.warn(`[tailscale] serveRange: failed to serve port ${port}:`, err);
+    }
+  }
+}

--- a/test/tailscale.test.ts
+++ b/test/tailscale.test.ts
@@ -1,0 +1,168 @@
+import { test, expect, describe } from "bun:test";
+import { resolveNodeHost, serveRange } from "../src/tailscale";
+
+// ── resolveNodeHost ───────────────────────────────────────────────────────────
+
+const REALISTIC_STATUS = JSON.stringify({
+  Self: {
+    HostName: "backontop",
+    DNSName: "backontop.chicken-beardie.ts.net.",
+    OS: "linux",
+    TailscaleIPs: ["100.64.0.1"],
+    Online: true,
+  },
+  Peers: {},
+  MagicDNSSuffix: "chicken-beardie.ts.net",
+  CurrentTailnet: {},
+});
+
+describe("resolveNodeHost", () => {
+  test("parses Self.DNSName and strips trailing dot", async () => {
+    const run = async () => ({ stdout: REALISTIC_STATUS });
+    const result = await resolveNodeHost(run);
+    expect(result).toBe("backontop.chicken-beardie.ts.net");
+  });
+
+  test("returns null when runner rejects (tailscale absent / not running)", async () => {
+    const run = async (): Promise<{ stdout: string }> => {
+      throw new Error("spawn tailscale ENOENT");
+    };
+    const result = await resolveNodeHost(run);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when stdout is not valid JSON", async () => {
+    const run = async () => ({ stdout: "not json at all" });
+    const result = await resolveNodeHost(run);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when Self is missing", async () => {
+    const run = async () => ({ stdout: JSON.stringify({ MagicDNSSuffix: "ts.net" }) });
+    const result = await resolveNodeHost(run);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when Self.DNSName is missing", async () => {
+    const run = async () => ({
+      stdout: JSON.stringify({ Self: { HostName: "backontop" } }),
+    });
+    const result = await resolveNodeHost(run);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when Self.DNSName is empty string", async () => {
+    const run = async () => ({ stdout: JSON.stringify({ Self: { DNSName: "" } }) });
+    const result = await resolveNodeHost(run);
+    expect(result).toBeNull();
+  });
+});
+
+// ── serveRange: argv ──────────────────────────────────────────────────────────
+
+describe("serveRange argv", () => {
+  test("issues correct argv for each port in range — no --yes, bare 127.0.0.1:<port> target", async () => {
+    const calls: Array<string[]> = [];
+    const run = async (args: string[]) => {
+      calls.push(args);
+      return { stdout: "" };
+    };
+
+    await serveRange(8001, 3, run);
+
+    expect(calls).toHaveLength(3);
+
+    expect(calls[0]).toEqual(["serve", "--bg", "--https=8001", "127.0.0.1:8001"]);
+    expect(calls[1]).toEqual(["serve", "--bg", "--https=8002", "127.0.0.1:8002"]);
+    expect(calls[2]).toEqual(["serve", "--bg", "--https=8003", "127.0.0.1:8003"]);
+
+    // Explicit guard: no --yes anywhere
+    for (const args of calls) {
+      expect(args).not.toContain("--yes");
+    }
+    // Explicit guard: target is bare 127.0.0.1:<port>, no http:// prefix
+    for (const args of calls) {
+      const target = args[args.length - 1]!;
+      expect(target).toMatch(/^127\.0\.0\.1:\d+$/);
+      expect(target).not.toContain("http://");
+    }
+  });
+});
+
+// ── serveRange: sequential execution ─────────────────────────────────────────
+//
+// Recording order alone would also pass a broken concurrent impl. We gate on
+// resolution: the fake runner returns a deferred promise per port that we resolve
+// manually, then assert that run(N+1) has NOT been called until run(N) resolves.
+
+/** Drain the microtask queue several times to let `await` chains advance. */
+async function flushMicrotasks(n = 5): Promise<void> {
+  for (let i = 0; i < n; i++) await Promise.resolve();
+}
+
+describe("serveRange sequential execution", () => {
+  test("does NOT invoke port N+1 until port N's promise resolves", async () => {
+    type Resolver = (value: { stdout: string }) => void;
+    const resolvers: Resolver[] = [];
+    const invocationOrder: number[] = [];
+
+    const run = async (args: string[]): Promise<{ stdout: string }> => {
+      // Extract port number from --https=<port>
+      const httpsArg = args.find((a) => a.startsWith("--https="));
+      const port = Number(httpsArg?.slice("--https=".length));
+      invocationOrder.push(port);
+      return new Promise<{ stdout: string }>((resolve) => {
+        resolvers.push(resolve);
+      });
+    };
+
+    // Start serveRange — do NOT await yet
+    const done = serveRange(8001, 3, run);
+
+    // Port 8001 should be invoked immediately; drain the queue to let the loop start
+    await flushMicrotasks();
+
+    expect(invocationOrder).toEqual([8001]);
+
+    // Resolve port 8001; drain so the loop resumes and invokes 8002
+    resolvers[0]!({ stdout: "" });
+    await flushMicrotasks();
+
+    expect(invocationOrder).toEqual([8001, 8002]);
+
+    // Resolve port 8002; drain so the loop resumes and invokes 8003
+    resolvers[1]!({ stdout: "" });
+    await flushMicrotasks();
+
+    expect(invocationOrder).toEqual([8001, 8002, 8003]);
+
+    // Resolve port 8003; loop ends, serveRange resolves
+    resolvers[2]!({ stdout: "" });
+    await done;
+
+    expect(invocationOrder).toEqual([8001, 8002, 8003]);
+  });
+});
+
+// ── serveRange: best-effort (one failure doesn't abort) ──────────────────────
+
+describe("serveRange best-effort", () => {
+  test("continues after a failing port and attempts all ports", async () => {
+    const calls: number[] = [];
+
+    const run = async (args: string[]): Promise<{ stdout: string }> => {
+      const httpsArg = args.find((a) => a.startsWith("--https="));
+      const port = Number(httpsArg?.slice("--https=".length));
+      calls.push(port);
+      if (port === 8002) throw new Error("serve config write failed");
+      return { stdout: "" };
+    };
+
+    // serveRange must resolve (not reject) even when one port throws
+    await expect(serveRange(8001, 3, run)).resolves.toBeUndefined();
+
+    // All three ports were attempted despite port 8002 failing
+    expect(calls).toHaveLength(3);
+    expect(calls).toEqual([8001, 8002, 8003]);
+  });
+});

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -41,6 +41,7 @@
   import BuildQueuePanel from "$lib/components/BuildQueuePanel.svelte";
   import type { BuildQueue } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { buildPreviewUrl } from "$lib/previewUrl";
 
   // Enter pinned in the thumb zone — locale-reactive for its accessible name.
   const enter = $derived(enterKey());
@@ -66,6 +67,7 @@
     openPreviewTick = 0,
     buildQueue = null,
     onSeedBuildQueue,
+    previewHost = null,
   }: {
     session: Session;
     onnewtask?: (repoPath: string, issue: Issue) => void;
@@ -102,6 +104,9 @@
     buildQueue?: BuildQueue | null;
     /** Called when the panel bootstrap-GETs or mutates a queue, to seed the store. */
     onSeedBuildQueue?: (q: BuildQueue) => void;
+    /** The agent node's own tailnet host; preview URLs build from it when the HUD is
+     *  fronted on a different host. Null → fall back to the operator's connection host. */
+    previewHost?: string | null;
   } = $props();
 
   let el: HTMLDivElement | undefined = $state();
@@ -288,13 +293,14 @@
   // server bound a reverse-proxy listener for this session's dev server. Single
   // source of truth for both the tab and the pane — no iframe-load inference.
   const hasPreview = $derived(previewPort != null);
-  // Build the URL from how the operator actually connected (Tailscale https host
-  // or localhost dev) + the assigned port — a distinct origin, so the app is
-  // same-origin to its own backend (the frame keeps `allow-same-origin`; see the
-  // sandbox note on the iframe). SSR-guarded.
+  // Build the iframe URL via the helper, which branches on loopback vs. split-front:
+  // when previewHost is set (agent node's own tailnet host differs from the operator's
+  // connection host), the URL targets previewHost directly so the iframe doesn't hit a
+  // port that only exists on the agent node. Falls back to loc.hostname when null
+  // (single-host deployment). SSR-guarded.
   const previewUrl = $derived(
-    hasPreview && typeof location !== "undefined"
-      ? `${location.protocol}//${location.hostname}:${previewPort}/`
+    hasPreview && previewPort != null && typeof location !== "undefined"
+      ? buildPreviewUrl(previewHost, location, previewPort)
       : null,
   );
 

--- a/ui/src/lib/previewUrl.test.ts
+++ b/ui/src/lib/previewUrl.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { buildPreviewUrl } from "./previewUrl";
+
+const PORT = 8001;
+
+describe("buildPreviewUrl — loopback branch", () => {
+  it("localhost http → preserves http and localhost", () => {
+    expect(buildPreviewUrl(null, { protocol: "http:", hostname: "localhost" }, PORT)).toBe(
+      "http://localhost:8001/",
+    );
+  });
+
+  it("127.0.0.1 → uses location host+protocol", () => {
+    expect(buildPreviewUrl(null, { protocol: "http:", hostname: "127.0.0.1" }, PORT)).toBe(
+      "http://127.0.0.1:8001/",
+    );
+  });
+
+  it("::1 → uses location host+protocol", () => {
+    expect(buildPreviewUrl(null, { protocol: "http:", hostname: "::1" }, PORT)).toBe(
+      "http://::1:8001/",
+    );
+  });
+
+  it("[::1] → uses location host+protocol", () => {
+    expect(buildPreviewUrl(null, { protocol: "http:", hostname: "[::1]" }, PORT)).toBe(
+      "http://[::1]:8001/",
+    );
+  });
+
+  it("loopback wins even when previewHost is set", () => {
+    // Dev must stay on localhost; previewHost must be ignored.
+    expect(
+      buildPreviewUrl(
+        "backontop.chicken-beardie.ts.net",
+        { protocol: "http:", hostname: "localhost" },
+        PORT,
+      ),
+    ).toBe("http://localhost:8001/");
+  });
+});
+
+describe("buildPreviewUrl — previewHost branch (split-front fix)", () => {
+  it("non-loopback + previewHost → https://previewHost:port/", () => {
+    expect(
+      buildPreviewUrl(
+        "backontop.chicken-beardie.ts.net",
+        { protocol: "https:", hostname: "shepherd.chicken-beardie.ts.net" },
+        PORT,
+      ),
+    ).toBe("https://backontop.chicken-beardie.ts.net:8001/");
+  });
+
+  it("forces https on the previewHost branch even when loc.protocol is http", () => {
+    // Operator reached the HUD over http, but the node serves slots via
+    // tailscale serve --https (HTTPS-only) → the preview URL must still be https.
+    expect(
+      buildPreviewUrl(
+        "backontop.chicken-beardie.ts.net",
+        { protocol: "http:", hostname: "shepherd.chicken-beardie.ts.net" },
+        PORT,
+      ),
+    ).toBe("https://backontop.chicken-beardie.ts.net:8001/");
+  });
+
+  it("port is interpolated correctly", () => {
+    expect(
+      buildPreviewUrl(
+        "backontop.chicken-beardie.ts.net",
+        { protocol: "https:", hostname: "shepherd.chicken-beardie.ts.net" },
+        9999,
+      ),
+    ).toBe("https://backontop.chicken-beardie.ts.net:9999/");
+  });
+});
+
+describe("buildPreviewUrl — fallback branch", () => {
+  it("non-loopback + previewHost null → loc.protocol//loc.hostname:port/", () => {
+    expect(
+      buildPreviewUrl(
+        null,
+        { protocol: "https:", hostname: "backontop.chicken-beardie.ts.net" },
+        PORT,
+      ),
+    ).toBe("https://backontop.chicken-beardie.ts.net:8001/");
+  });
+
+  it("non-loopback + previewHost empty string → fallback (NOT https://:8001/)", () => {
+    const url = buildPreviewUrl(
+      "",
+      { protocol: "https:", hostname: "backontop.chicken-beardie.ts.net" },
+      PORT,
+    );
+    expect(url).toBe("https://backontop.chicken-beardie.ts.net:8001/");
+    // Explicit guard: empty previewHost must never produce `https://:port/`
+    expect(url).not.toContain("https://:");
+  });
+
+  it("non-loopback + previewHost null uses loc.protocol", () => {
+    expect(buildPreviewUrl(null, { protocol: "http:", hostname: "myhost.example.com" }, PORT)).toBe(
+      "http://myhost.example.com:8001/",
+    );
+  });
+});

--- a/ui/src/lib/previewUrl.ts
+++ b/ui/src/lib/previewUrl.ts
@@ -1,0 +1,44 @@
+/**
+ * Build the iframe URL for a live-preview slot.
+ *
+ * Three branches, evaluated in order:
+ *
+ * 1. **Loopback** — `loc.hostname` is localhost / 127.0.0.1 / ::1 / [::1]:
+ *    Use `loc.protocol//loc.hostname:port/`. Preserves http on local dev;
+ *    previewHost (if any) is intentionally ignored so the developer stays on
+ *    the machine they're actually running.
+ *
+ * 2. **previewHost set** (non-loopback):
+ *    Return `https://previewHost:port/`. HTTPS is hardcoded here because
+ *    `tailscale serve --https` is HTTPS-only — there is no HTTP listener on
+ *    the slot port. This is the split-front fix: when the HUD is fronted by a
+ *    different Tailscale identity (e.g. a Service `svc:shepherd`) than the
+ *    agent node (`backontop`), the iframe must target the agent node's OWN
+ *    tailnet hostname, not the operator's connection host. Using loc.hostname
+ *    in that case would hit a port that serves nothing → ERR_SSL_PROTOCOL_ERROR.
+ *
+ * 3. **Fallback** (non-loopback, no previewHost):
+ *    Use `loc.protocol//loc.hostname:port/`. Equivalent to today's single-host
+ *    case where the HUD host == the agent node.
+ */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+export function buildPreviewUrl(
+  previewHost: string | null,
+  loc: { protocol: string; hostname: string },
+  port: number,
+): string {
+  if (LOOPBACK_HOSTS.has(loc.hostname)) {
+    // Branch 1: loopback — dev stays on local host regardless of previewHost.
+    return `${loc.protocol}//${loc.hostname}:${port}/`;
+  }
+
+  if (previewHost) {
+    // Branch 2: agent node's own tailnet hostname available.
+    // HTTPS is hardcoded because tailscale serve --https is HTTPS-only.
+    return `https://${previewHost}:${port}/`;
+  }
+
+  // Branch 3: fallback — single-host deployment where HUD host == agent node.
+  return `${loc.protocol}//${loc.hostname}:${port}/`;
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -48,6 +48,10 @@ export interface Settings {
   sessionRetentionDays: number;
   /** Display-only: newest archived sessions kept regardless of age. */
   sessionRetentionKeep: number;
+  /** The agent node's own tailnet hostname; the UI builds preview iframe URLs from it
+   *  when the HUD is fronted on a different host than the node. Null when tailscale is
+   *  absent → fall back to the operator's own connection host. */
+  previewHost: string | null;
 }
 
 export interface DirEntry {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -818,6 +818,7 @@
             limits={store.usageLimits}
             git={store.git[selected.id]}
             previewPort={store.preview[selected.id] ?? null}
+            previewHost={settings?.previewHost ?? null}
             {openPreviewTick}
             buildQueue={store.buildQueues[selected.id] ?? null}
             onSeedBuildQueue={(q) => store.setBuildQueue(q)}
@@ -889,6 +890,7 @@
             touch={touch.current}
             git={store.git[selected.id]}
             previewPort={store.preview[selected.id] ?? null}
+            previewHost={settings?.previewHost ?? null}
             {openPreviewTick}
             buildQueue={store.buildQueues[selected.id] ?? null}
             onSeedBuildQueue={(q) => store.setBuildQueue(q)}


### PR DESCRIPTION
## Summary

Fixes #447 — the live-preview iframe failed to load (`ERR_SSL_PROTOCOL_ERROR`) when the HUD is reached under a **different Tailscale identity** than the node running the agents (e.g. HUD fronted by a Tailscale **Service** `svc:shepherd` while agents run on node `backontop`). Two distinct defects:

- **(A) Wrong host.** `Viewport.svelte` built the preview URL from `location.hostname` (the operator's own connection host) + the slot port. Under a split front the slot isn't served at the HUD's host → SSL error.
- **(B) Slots never served.** The ephemeral slot ports (8001–8016) bind `127.0.0.1` on the agent node but were never `tailscale serve`d, so they weren't tailnet-reachable at all.

## What changed

1. **Backend reports the node's own tailnet host.** `resolveNodeHost()` (new `src/tailscale.ts`) reads `tailscale status --json` → `Self.DNSName` (trailing dot stripped; `null` when tailscale is absent), resolved once at startup into `config.previewHost` and exposed in the `/api/settings` payload.
2. **UI builds the preview URL from that host.** New pure helper `buildPreviewUrl(previewHost, loc, port)` (unit-tested): loopback dev → unchanged `http://localhost:<slot>/`; otherwise prefers `https://<nodeHost>:<slot>/` (the node serves slots via `tailscale serve --https`, HTTPS-only); falls back to the operator's host when `previewHost` is null. A **distinct host is intentional and safe** — keeps the untrusted preview cross-origin to the HUD and host-scoped cookies isolate it (no HUD-path proxy, per the issue's security note).
3. **Opt-in auto-serve.** `SHEPHERD_PREVIEW_AUTO_SERVE=1` (default **off**) makes shepherd run the slot-range `tailscale serve --bg --https=<port> 127.0.0.1:<port>` loop once at startup (sequential, to avoid serve-config write races — the exact form from the README's manual setup). A startup `console.warn` fires if the flag is set but the node host couldn't be resolved.
4. **Docs.** The existing README "Live preview" section now documents the flag (with the tailnet-HTTPS-cert prerequisite carried over), the default-off behavior, the split-front `previewHost` behavior, the tailnet/ACL precondition, and a warning never to add the slot range to a Tailscale *Service* port list.

## Scope boundary

Requires the operator's browser to be **on the tailnet** and ACLs to permit `operator→node:<slot>`. Does **not** help a Funnel/public-fronted HUD (the agent node's MagicDNS host is unresolvable off-tailnet). With the flag off, the operator still serves slots manually — the URL/host fix alone targets the right host but doesn't make the slots reachable.

## Testing

- New: `test/tailscale.test.ts` (DNSName parse + null cases; `serveRange` argv; **deferred-promise sequentiality proof**), `ui/src/lib/previewUrl.test.ts` (all three branches incl. loopback-precedence, split-front headline, empty-string guard, https-forcing).
- Full suite green on the rebased base: root `tsc`/`lint` clean, **1539** root tests, UI `check` 0/0, i18n parity (784 keys), **687** UI tests. Branch-hygiene, fallow, and feature-catalog gates pass.

## Notes

`[no-feature-entry]`: this fixes the **existing, already-announced** live-preview feature for a split-front topology — it ships no new user-facing surface (only a corrected iframe URL + an opt-in operator env flag). The feature-catalog gate over-fires here at range level (server/lib-only `feat()` commits alongside a `fix()` commit touching `components/`), so it's opted out per CLAUDE.md.

Closes #447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
