### PR TITLE
feat(plan-gate): planning agent asks questions actively, not parked in the plan

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -237,16 +237,22 @@ function buildQueueDirective(args: {
  * Pre-execution PLAN GATE directives. When the plan gate is on for a session, one of these
  * REPLACES the autopilot directive during the planning phase — planning deliberately suppresses
  * autopilot so the agent stops to plan/grill instead of rushing to a PR. The interactive variant
- * grills a present human; the auto variant runs unattended (drain) and just writes the plan.
- * English, not i18n'd — agent-facing prompt text, same precedent as AUTOPILOT_DIRECTIVE.
+ * grills a present human ACTIVELY — clarifying questions are asked via AskUserQuestion / in the
+ * conversation, never parked as an open-questions list in the plan; the auto variant runs
+ * unattended (drain) and just writes the plan. English, not i18n'd — agent-facing prompt text,
+ * same precedent as AUTOPILOT_DIRECTIVE.
  */
 const PLAN_GATE_DIRECTIVE_INTERACTIVE =
   "You are in Shepherd's pre-execution PLAN GATE. Do NOT write or modify any product code yet.\n" +
   "1. Research the codebase enough to plan confidently.\n" +
-  "2. Grill the user: ask sharp, specific clarifying questions until you and the user are genuinely " +
-  "aligned on scope, approach, and success criteria. Misalignment now is the costliest failure.\n" +
+  "2. Ask the user actively — do NOT hide questions in the plan or a spec file. Use the AskUserQuestion " +
+  "tool for choice-style clarifications, and ask open-ended questions directly in the conversation. Keep " +
+  "asking sharp, specific questions until you and the user are genuinely aligned on scope, approach, and " +
+  "success criteria. Misalignment now is the costliest failure.\n" +
   "3. When aligned, write the plan to `.shepherd-plan.md` at the repo root (goal, approach, files, " +
-  "steps, risks, success criteria) and tell the user it's ready for review.\n" +
+  "steps, risks, success criteria) and tell the user it's ready for review. The plan must contain NO open / " +
+  "unresolved / TBD questions — resolve every question by asking first; it may still record stated " +
+  "assumptions and resolved decisions.\n" +
   "An adversarial reviewer will critique the plan; address its findings by revising `.shepherd-plan.md`. " +
   "Begin implementing ONLY after the plan is approved and you are told to execute.";
 const PLAN_GATE_DIRECTIVE_AUTO =

--- a/test/service-plan-gate.test.ts
+++ b/test/service-plan-gate.test.ts
@@ -25,3 +25,11 @@ test("interactive directive references both reviewer and not-implementing-yet", 
   expect(PLAN_GATE_DIRECTIVE_INTERACTIVE).toContain("reviewer");
   expect(PLAN_GATE_DIRECTIVE_INTERACTIVE.toLowerCase()).toContain("aligned");
 });
+test("interactive directive makes the agent ask actively, not park questions in the plan", () => {
+  // names AskUserQuestion as the choice-style mechanism (but not the exclusive channel)
+  expect(PLAN_GATE_DIRECTIVE_INTERACTIVE).toContain("AskUserQuestion");
+  // forbids parking open/unresolved questions in the plan file
+  expect(PLAN_GATE_DIRECTIVE_INTERACTIVE.toLowerCase()).toContain("unresolved");
+  // but explicitly still permits stated assumptions / resolved decisions
+  expect(PLAN_GATE_DIRECTIVE_INTERACTIVE.toLowerCase()).toContain("assumption");
+});


### PR DESCRIPTION
## What

When the **interactive** plan gate is active, the planning agent now asks clarifying questions **actively** instead of dumping an "Open Questions" section into `.shepherd-plan.md`.

Rewrites `PLAN_GATE_DIRECTIVE_INTERACTIVE` (`src/service.ts`) so it:
- names the **AskUserQuestion** tool for choice-style clarifications, and permits open-ended questions **directly in the conversation** (AskUserQuestion is the named tool, not the exclusive channel);
- bans open / unresolved / TBD questions in `.shepherd-plan.md`, while **explicitly still allowing** stated assumptions and resolved decisions;
- keeps the existing reviewer / aligned / not-implementing-yet semantics.

## Scope / non-goals

- **Auto variant untouched** — it's unattended (no human to ask).
- **No gate added.** This is best-effort prompt compliance. A `planReviewPrompt` check was deliberately rejected: that prompt is shared with the auto variant where stating assumptions is legitimate, so a blanket "reject any plan with questions" check would mis-fire. The adversarial reviewer already flags parked questions case-by-case.
- Agent-facing prompt text, explicitly **not** i18n'd → no catalog/i18n entry (`[no-feature-entry]`).

## Tests

Extended `test/service-plan-gate.test.ts`: asserts the directive names AskUserQuestion, forbids parked/unresolved questions, and still permits assumptions. Full root suite green (1643 pass, 0 fail), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)