### PR TITLE
fix: merge-train sessions stuck on pulsing 'merging' tag, never flip to merged

### DIFF
--- a/src/automerge.ts
+++ b/src/automerge.ts
@@ -49,6 +49,10 @@ export interface AutoMergeDeps {
     archive(id: string): number;
     reply(id: string, text: string): boolean;
     resume(id: string): unknown;
+    /** Clear the session's merge-train mark + credit the train tracker. Called directly
+     *  here because an autonomous merge emits no session:git event for the normal
+     *  resolveMerging path; a no-op unless the session was merge-train-flagged. */
+    resolveMerging(id: string, didMerge: boolean): void;
   };
   resolveForge: (repoPath: string) => GitForge | null;
   worktree: Pick<WorktreeMgr, "behindBase">;
@@ -288,6 +292,10 @@ export class AutoMergeService {
     this.mergeFail.delete(sessionId); // success clears any backoff
     // Clear the behind-cache so sibling sessions get a fresh read now that main has moved.
     this.behindCache.clear();
+    // Autonomous merge emits no session:git event, so clear the merge-train mark and
+    // credit the train tracker directly (the poller-driven resolveMerging never fires
+    // for this path). No-op unless the session was merge-train-flagged.
+    this.deps.service.resolveMerging(sessionId, true);
     await settleMergedSession(s, {
       resolveForge: this.deps.resolveForge,
       archive: (id) => this.deps.service.archive(id),

--- a/src/index.ts
+++ b/src/index.ts
@@ -522,7 +522,7 @@ setInterval(() => {
 
 const autoMerge = new AutoMergeService({
   store,
-  service, // archive, reply, resume
+  service, // archive, reply, resume, resolveMerging
   resolveForge,
   worktree, // has behindBase
   prCache: prPoller,

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -39,6 +39,28 @@ export function guardStaleTerminal(
   return git;
 }
 
+/** Whether a terminal (`merged`/`closed`) `raw` is this session's genuine PR transition and should
+ *  bypass `guardStaleTerminal` (which would mis-downgrade it to "none" when the merge train
+ *  rebased/force-pushed the head out of the session's worktree, so the ownership check can't see it).
+ *  Returns false immediately for any non-terminal `raw` — `guardStaleTerminal` is a no-op off-terminal
+ *  anyway, and this prevents a malformed `{state:"none"}` from ever being trusted.
+ *  True (for a terminal `raw`) when either:
+ *   - `marked`  — the session is currently merge-train-flagged (mergingSince set): a marked session
+ *                 always had an open PR, so its terminal result is the train landing it (this holds
+ *                 even when the PR was never cached open — the cold-cache case); or
+ *   - `prev` already cached THIS PR (same number, non-"none" state) — a PR we already owned.
+ *  When this returns false, `raw` may be a reused-branch-name collision and must run through
+ *  `guardStaleTerminal`. */
+export function trustsTerminal(
+  prev: GitState | undefined,
+  raw: GitState,
+  marked: boolean,
+): boolean {
+  if (raw.state !== "merged" && raw.state !== "closed") return false; // guardStaleTerminal is a no-op off-terminal anyway
+  if (marked) return true;
+  return !!prev && prev.number != null && prev.number === raw.number && prev.state !== "none";
+}
+
 /**
  * Polls PR status for active sessions and caches it in memory. One `gh` process
  * runs at a time (sequential awaits) to bound the synchronous `execFileSync`
@@ -172,9 +194,13 @@ export class PrPoller implements PrCache {
     const forge = s.branch ? this.resolveForge(s.repoPath) : null;
     if (!forge || !s.branch) return; // no PR possible — leave uncached
     const me = (await forge.currentUser?.()) ?? null;
+    const prev = this.cache.get(s.id);
+    const marked = s.mergingSince != null;
+    const guard = (raw: GitState): GitState =>
+      trustsTerminal(prev, raw, marked) ? raw : this.rejectStaleTerminal(s, raw);
     let git: GitState;
     try {
-      git = this.rejectStaleTerminal(s, { kind: forge.kind, ...(await forge.prStatus(s.branch)) });
+      git = guard({ kind: forge.kind, ...(await forge.prStatus(s.branch)) });
     } catch {
       return; // transient gh failure → keep last cached value
     }
@@ -186,7 +212,7 @@ export class PrPoller implements PrCache {
       const live = this.reconcileBranch(s);
       if (live) {
         try {
-          git = this.rejectStaleTerminal(s, { kind: forge.kind, ...(await forge.prStatus(live)) });
+          git = guard({ kind: forge.kind, ...(await forge.prStatus(live)) });
         } catch {
           return;
         }
@@ -195,7 +221,6 @@ export class PrPoller implements PrCache {
     // Who's up (open+green): computed from .shepherd/roles.json + the operator's
     // login, so the herd can show "waiting on scoop" instead of "your turn".
     git = annotateHandoff(git, s.repoPath, me);
-    const prev = this.cache.get(s.id);
     if (
       !prev ||
       prev.state !== git.state ||

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -7,6 +7,9 @@ import { annotateHandoff } from "./repo-roles";
  *  updates from PR actions. `PrPoller` implements it. */
 export interface PrCache {
   snapshot(): Record<string, GitState>;
+  /** Read one session's cached state without materializing the whole map — O(1) for
+   *  per-request callers (e.g. GET /git) that only need a single key. */
+  get(id: string): GitState | undefined;
   set(id: string, git: GitState): void;
   drop(id: string): void;
 }
@@ -47,7 +50,10 @@ export function guardStaleTerminal(
  *  True (for a terminal `raw`) when either:
  *   - `marked`  — the session is currently merge-train-flagged (mergingSince set): a marked session
  *                 always had an open PR, so its terminal result is the train landing it (this holds
- *                 even when the PR was never cached open — the cold-cache case); or
+ *                 even when the PR was never cached open — the cold-cache case). NOTE this trusts ANY
+ *                 terminal result while marked, relying on the invariant that `setMerging` only flags
+ *                 `readyToMerge` sessions whose own PR is genuinely open (see `collectReadyPrs`); were
+ *                 that invariant to break, a name-collision terminal hit could be trusted here; or
  *   - `prev` already cached THIS PR (same number, non-"none" state) — a PR we already owned.
  *  When this returns false, `raw` may be a reused-branch-name collision and must run through
  *  `guardStaleTerminal`. */
@@ -271,6 +277,9 @@ export class PrPoller implements PrCache {
 
   snapshot(): Record<string, GitState> {
     return Object.fromEntries(this.cache);
+  }
+  get(id: string): GitState | undefined {
+    return this.cache.get(id);
   }
   set(id: string, git: GitState): void {
     this.cache.set(id, git);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1358,7 +1358,7 @@ async function dispatchForgeAction(
       // merged/closed PR when the session is merge-train-flagged or the cache already
       // owned this PR, else drop a reused-branch-name collision to "none" so GitRail and
       // the list overview agree.
-      const prev = deps.prCache?.snapshot()[session.id];
+      const prev = deps.prCache?.get(session.id);
       const trusted = trustsTerminal(prev, git, session.mergingSince != null);
       return json(
         trusted

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,7 +49,7 @@ import type { HerdrDriver } from "./herdr";
 import { matchAgent } from "./herdr";
 import type { GitForge, GitState, MergeMethod } from "./forge/types";
 import { DEPENDABOT_REBASE_COMMAND } from "./forge/types";
-import { type PrCache, guardStaleTerminal } from "./pr-poller";
+import { type PrCache, guardStaleTerminal, trustsTerminal } from "./pr-poller";
 import {
   readRepoRoles,
   writeRepoRoles,
@@ -1354,9 +1354,17 @@ async function dispatchForgeAction(
         session.repoPath,
         me,
       );
-      // Same guard as the background poller: a merged/closed PR matched only by a
-      // reused branch name is dropped to "none" so GitRail and the list agree.
-      return json(guardStaleTerminal(git, (headSha) => deps.ownsPr?.(session, headSha) ?? null));
+      // Same trust logic as the background poller (trustsTerminal): keep a genuinely-
+      // merged/closed PR when the session is merge-train-flagged or the cache already
+      // owned this PR, else drop a reused-branch-name collision to "none" so GitRail and
+      // the list overview agree.
+      const prev = deps.prCache?.snapshot()[session.id];
+      const trusted = trustsTerminal(prev, git, session.mergingSince != null);
+      return json(
+        trusted
+          ? git
+          : guardStaleTerminal(git, (headSha) => deps.ownsPr?.(session, headSha) ?? null),
+      );
     }
     return null;
   }

--- a/test/automerge.test.ts
+++ b/test/automerge.test.ts
@@ -32,7 +32,12 @@ function deps(over: Partial<AutoMergeDeps> = {}): AutoMergeDeps {
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
     } as any,
-    service: { archive: mock(() => 1), reply: mock(() => true), resume: mock(() => true) } as any,
+    service: {
+      archive: mock(() => 1),
+      reply: mock(() => true),
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
     resolveForge: () =>
       ({
         kind: "github",
@@ -60,15 +65,17 @@ function deps(over: Partial<AutoMergeDeps> = {}): AutoMergeDeps {
 test("ready PR → forge.merge called with squash + delete-branch, then archived", async () => {
   const merge = mock(async () => {});
   const archive = mock(() => 1);
+  const resolveMerging = mock(() => {});
   const d = deps({
     resolveForge: () =>
       ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
-    service: { archive, reply: mock(() => true), resume: mock(() => true) } as any,
+    service: { archive, reply: mock(() => true), resume: mock(() => true), resolveMerging } as any,
   });
   const svc = new AutoMergeService(d);
   await svc.pump("/r");
   expect((merge as any).mock.calls[0]).toEqual([7, { method: "squash", deleteBranch: true }]);
   expect(archive.mock.calls.length).toBe(1);
+  expect((resolveMerging as any).mock.calls).toEqual([["s1", true]]);
 });
 
 test("behind → steers a rebase + bumps the counter, does NOT merge", async () => {
@@ -77,7 +84,12 @@ test("behind → steers a rebase + bumps the counter, does NOT merge", async () 
   const merge = mock(async () => {});
   const d = deps({
     worktree: { behindBase: async () => true } as any,
-    service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
+    service: {
+      archive: mock(() => 1),
+      reply,
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
     resolveForge: () =>
       ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
   });
@@ -96,6 +108,7 @@ test("behind → steers a rebase + bumps the counter, does NOT merge", async () 
 
 test("forge.merge throws (non-conflict) → fail-closed: not archived", async () => {
   const archive = mock(() => 1);
+  const resolveMerging = mock(() => {});
   const d = deps({
     resolveForge: () =>
       ({
@@ -106,11 +119,12 @@ test("forge.merge throws (non-conflict) → fail-closed: not archived", async ()
         },
         closeIssue: mock(async () => {}),
       }) as any,
-    service: { archive, reply: mock(() => true), resume: mock(() => true) } as any,
+    service: { archive, reply: mock(() => true), resume: mock(() => true), resolveMerging } as any,
   });
   const svc = new AutoMergeService(d);
   await svc.pump("/r");
   expect(archive.mock.calls.length).toBe(0);
+  expect(resolveMerging.mock.calls.length).toBe(0);
 });
 
 test("dead pane → resume attempted before steer; counter bumped once resumed", async () => {
@@ -120,7 +134,7 @@ test("dead pane → resume attempted before steer; counter bumped once resumed",
   const d = deps({
     worktree: { behindBase: async () => true } as any,
     paneAlive: () => false,
-    service: { archive: mock(() => 1), reply, resume } as any,
+    service: { archive: mock(() => 1), reply, resume, resolveMerging: mock(() => {}) } as any,
   });
   d.store.setAutoMergeState = setState as any;
   const svc = new AutoMergeService(d);
@@ -135,7 +149,12 @@ test("rebase steer fails to deliver → counter NOT bumped", async () => {
   const setState = mock(() => {});
   const d = deps({
     worktree: { behindBase: async () => true } as any,
-    service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
+    service: {
+      archive: mock(() => 1),
+      reply,
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
   });
   d.store.setAutoMergeState = setState as any;
   const svc = new AutoMergeService(d);
@@ -177,7 +196,7 @@ test("multi-session: merges ready A then steers rebase for behind B", async () =
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
     } as any,
-    service: { archive, reply, resume: mock(() => true) } as any,
+    service: { archive, reply, resume: mock(() => true), resolveMerging: mock(() => {}) } as any,
     resolveForge: () =>
       ({
         kind: "github",
@@ -247,7 +266,12 @@ test("rebase_cap: behind session at cap → no reply steer, emitStatus rebase_ca
       setAutopilotState: mock(() => {}),
     } as any,
     worktree: { behindBase: async () => true } as any,
-    service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
+    service: {
+      archive: mock(() => 1),
+      reply,
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
     emitStatus,
     rebaseCap: 5,
   });
@@ -280,7 +304,12 @@ test("reset-on-progress: behind=false + mergeable=true → rebaseCount reset to 
     worktree: { behindBase: async () => false } as any,
     resolveForge: () =>
       ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
-    service: { archive: mock(() => 1), reply: mock(() => true), resume: mock(() => true) } as any,
+    service: {
+      archive: mock(() => 1),
+      reply: mock(() => true),
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
   });
   const svc = new AutoMergeService(d);
   await svc.pump("/r");
@@ -313,7 +342,12 @@ test("reset-on-progress NEGATIVE: behind=false + mergeable=false → counter NOT
         s1: { state: "open", checks: "success", mergeable: false, number: 7, headSha: "h1" },
       }),
     } as any,
-    service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
+    service: {
+      archive: mock(() => 1),
+      reply,
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
   });
   const svc = new AutoMergeService(d);
   await svc.pump("/r");
@@ -334,7 +368,12 @@ test("behind cache: two pumps with frozen clock call behindBase only once", asyn
 
   const d = deps({
     worktree: { behindBase } as any,
-    service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
+    service: {
+      archive: mock(() => 1),
+      reply,
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
     now: () => nowVal,
     behindTtlMs: 10_000,
   });
@@ -376,7 +415,12 @@ test("tick: skips repo with no full-auto session (no merge/steer)", async () => 
         merge,
         closeIssue: mock(async () => {}),
       }) as any,
-    service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
+    service: {
+      archive: mock(() => 1),
+      reply,
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
   });
 
   const svc = new AutoMergeService(d);
@@ -405,7 +449,12 @@ test("per-session override true + repo default false → merges (repoHasFullAuto
     } as any,
     resolveForge: () =>
       ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
-    service: { archive, reply: mock(() => true), resume: mock(() => true) } as any,
+    service: {
+      archive,
+      reply: mock(() => true),
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
   });
   const svc = new AutoMergeService(d);
   await svc.tick();
@@ -435,7 +484,12 @@ test("rebase outstanding: same head not re-steered / not re-bumped on a second p
       setAutopilotState: mock(() => {}),
     } as any,
     worktree: { behindBase: async () => true } as any,
-    service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
+    service: {
+      archive: mock(() => 1),
+      reply,
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
   });
   const svc = new AutoMergeService(d);
   await svc.pump("/r");
@@ -479,7 +533,12 @@ test("merge-error backoff: after CAP failures the stuck PR is skipped, a ready s
       setAutopilotState: mock(() => {}),
     } as any,
     resolveForge: () => forge as any,
-    service: { archive, reply: mock(() => true), resume: mock(() => true) } as any,
+    service: {
+      archive,
+      reply: mock(() => true),
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
     prCache: {
       snapshot: () => ({
         sA: { state: "open", checks: "success", mergeable: true, number: 7, headSha: "hA" },
@@ -552,7 +611,12 @@ test("rebase steer references origin/<baseBranch> from the session", async () =>
       setAutopilotState: mock(() => {}),
     } as any,
     worktree: { behindBase: async () => true } as any,
-    service: { archive: mock(() => 1), reply, resume: mock(() => true) } as any,
+    service: {
+      archive: mock(() => 1),
+      reply,
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
   });
   const svc = new AutoMergeService(d);
   await svc.pump("/r");

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "bun:test";
 import { SessionStore } from "../src/store";
-import { PrPoller } from "../src/pr-poller";
+import { PrPoller, trustsTerminal } from "../src/pr-poller";
 import type { GitForge, PrStatus } from "../src/forge/types";
 
 const baseSession = {
@@ -570,4 +570,139 @@ test("prunes cache entries for sessions no longer active", async () => {
   store.archive(s.id);
   await poller.tick(); // session no longer active → pruned
   expect(poller.snapshot()[s.id]).toBeUndefined();
+});
+
+// ── trustsTerminal unit tests ─────────────────────────────────────────────────
+
+test("trustsTerminal: signal (a) cold cache + marked → true", () => {
+  expect(
+    trustsTerminal(
+      undefined,
+      { kind: "github", state: "merged", number: 5, checks: "none", deployConfigured: false },
+      true,
+    ),
+  ).toBe(true);
+});
+
+test("trustsTerminal: marked but state none → false (terminal-state gate)", () => {
+  const noneState = {
+    kind: "github" as const,
+    state: "none" as const,
+    checks: "none" as const,
+    deployConfigured: false,
+  };
+  expect(trustsTerminal(undefined, noneState, true)).toBe(false);
+});
+
+test("trustsTerminal: marked but state open (non-terminal) → false (terminal-state gate)", () => {
+  expect(
+    trustsTerminal(
+      undefined,
+      { kind: "github", state: "open", number: 7, checks: "pending", deployConfigured: false },
+      true,
+    ),
+  ).toBe(false);
+});
+
+test("trustsTerminal: signal (b) prev open #7, raw merged #7, unmarked → true", () => {
+  expect(
+    trustsTerminal(
+      { kind: "github", state: "open", number: 7, checks: "pending", deployConfigured: false },
+      { kind: "github", state: "merged", number: 7, checks: "success", deployConfigured: false },
+      false,
+    ),
+  ).toBe(true);
+});
+
+test("trustsTerminal: no prev, raw merged #7, unmarked → false", () => {
+  expect(
+    trustsTerminal(
+      undefined,
+      { kind: "github", state: "merged", number: 7, checks: "success", deployConfigured: false },
+      false,
+    ),
+  ).toBe(false);
+});
+
+test("trustsTerminal: prev none, raw merged #7, unmarked → false", () => {
+  expect(
+    trustsTerminal(
+      { kind: "github", state: "none", checks: "none", deployConfigured: false },
+      { kind: "github", state: "merged", number: 7, checks: "success", deployConfigured: false },
+      false,
+    ),
+  ).toBe(false);
+});
+
+test("trustsTerminal: prev open #7, raw merged #8 (mismatched number), unmarked → false", () => {
+  expect(
+    trustsTerminal(
+      { kind: "github", state: "open", number: 7, checks: "pending", deployConfigured: false },
+      { kind: "github", state: "merged", number: 8, checks: "success", deployConfigured: false },
+      false,
+    ),
+  ).toBe(false);
+});
+
+// ── refresh integration tests ─────────────────────────────────────────────────
+
+test("refresh signal (b): prior-owned PR transitions to merged, bypasses guard when ownsPr=false", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession); // unmarked (mergingSince=null by default)
+  const emitted: { state: string; number?: number }[] = [];
+  let cur: PrStatus = OPEN; // number 7
+  const poller = new PrPoller(
+    store,
+    () => forgeReturning(() => cur),
+    (_id, git) => emitted.push({ state: git.state, number: git.number }),
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => false, // ownsPr always returns false
+  );
+
+  await poller.tick(); // first tick caches open #7 (emits #1)
+  expect(emitted).toHaveLength(1);
+  expect(emitted[0]!.state).toBe("open");
+
+  // same PR number 7 now transitions to merged
+  cur = {
+    state: "merged",
+    number: 7,
+    checks: "success",
+    headSha: "newsha",
+    deployConfigured: false,
+  };
+  await poller.tick(); // prev cache owns #7, so trust the terminal result
+  expect(emitted).toHaveLength(2);
+  expect(emitted[1]!.state).toBe("merged"); // NOT "none"
+  expect(emitted[1]!.number).toBe(7);
+  expect(poller.snapshot()[s.id]?.state).toBe("merged");
+});
+
+test("refresh signal (a): cold cache + marked, ownsPr=false → merged passes through", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  // Mark the session as merge-train-flagged BEFORE any poll
+  store.update(s.id, { mergingSince: Date.now(), mergingTrainId: "t" });
+  const emitted: { state: string; number?: number }[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forgeReturning(() => MERGED), // number 344, headSha "deadbee"
+    (_id, git) => emitted.push({ state: git.state, number: git.number }),
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => false, // ownsPr always returns false
+  );
+
+  await poller.tick(); // cold cache, but marked → trust the terminal
+  expect(emitted).toHaveLength(1);
+  expect(emitted[0]!.state).toBe("merged"); // NOT "none"
+  expect(emitted[0]!.number).toBe(344);
+  expect(poller.snapshot()[s.id]?.state).toBe("merged");
 });

--- a/test/rename.test.ts
+++ b/test/rename.test.ts
@@ -167,6 +167,7 @@ function makeDeps(opts: {
   }
   const prCache: PrCache = {
     snapshot: () => snap,
+    get: (id) => snap[id],
     set: (id) => cacheWrites.push(id),
     drop: (id) => cacheWrites.push(`drop:${id}`),
   };

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -91,6 +91,7 @@ function makeDeps(
   const snap: Record<string, GitState> = {};
   const prCache: PrCache = {
     snapshot: () => snap,
+    get: (id: string) => snap[id],
     set: (id: string) => cacheWrites.push(id),
     drop: (id: string) => cacheWrites.push(`drop:${id}`),
   };
@@ -256,16 +257,17 @@ test("GET git trusts a merged PR when cache already showed it open (signal b)", 
   });
   const deps = Object.assign(makeDeps(f), { ownsPr: () => false });
   const baseCache = deps.prCache!;
+  // Seed the prior cached state as an OPEN PR #5; the GET handler reads it via get().
+  const seeded: GitState = {
+    kind: "gitea",
+    state: "open",
+    number: 5,
+    checks: "success",
+    deployConfigured: true,
+  };
   deps.prCache = {
-    snapshot: () => ({
-      s1: {
-        kind: "gitea",
-        state: "open",
-        number: 5,
-        checks: "success",
-        deployConfigured: true,
-      } as any,
-    }),
+    snapshot: () => ({ s1: seeded }),
+    get: (id) => (id === "s1" ? seeded : undefined),
     set: baseCache.set,
     drop: baseCache.drop,
   };

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -244,6 +244,59 @@ test("GET /api/git returns the prCache snapshot", async () => {
   expect(await res.json()).toEqual({});
 });
 
+test("GET git trusts a merged PR when cache already showed it open (signal b)", async () => {
+  const f = fakeForge({
+    prStatus: async () => ({
+      state: "merged",
+      number: 5,
+      headSha: "newsha",
+      checks: "success",
+      deployConfigured: true,
+    }),
+  });
+  const deps = Object.assign(makeDeps(f), { ownsPr: () => false });
+  const baseCache = deps.prCache!;
+  deps.prCache = {
+    snapshot: () => ({
+      s1: {
+        kind: "gitea",
+        state: "open",
+        number: 5,
+        checks: "success",
+        deployConfigured: true,
+      } as any,
+    }),
+    set: baseCache.set,
+    drop: baseCache.drop,
+  };
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.state).toBe("merged");
+  expect(body.number).toBe(5);
+});
+
+test("GET git trusts a merged PR when session is merge-train-flagged, cold cache (signal a)", async () => {
+  const f = fakeForge({
+    prStatus: async () => ({
+      state: "merged",
+      number: 344,
+      headSha: "somesha",
+      checks: "success",
+      deployConfigured: true,
+    }),
+  });
+  const mergeTrainSession = { ...SESSION, mergingSince: Date.now(), mergingTrainId: "t" };
+  const deps = Object.assign(makeDeps(f, mergeTrainSession), { ownsPr: () => false });
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.state).toBe("merged");
+  expect(body.number).toBe(344);
+});
+
 test("GET /api/activity returns the activity snapshot", async () => {
   const snap = { s1: { lastActivityTs: 123, summary: "edited poller.ts" } };
   const deps = Object.assign(makeDeps(fakeForge()), { activity: { snapshot: () => snap } });


### PR DESCRIPTION
## Problem

During a merge train, member sessions get the pulsing **MERGING** badge, then lose their PR association and never flip to **merged** — the badge sticks until the 30-min TTL sweep.

## Root cause

The merge-train prompt rebases each branch onto main (**force-push**, new head SHA) then `gh pr merge --squash --delete-branch`. The rebase happens in the orchestrator's checkout, so the **member session's own worktree never fetches the new head SHA**.

When the poller reads the merged PR (`gh pr list --head <branch>` → `state:"merged"`, new `headRefOid`), `guardStaleTerminal`'s ownership check `git cat-file -e <sha>` in the member worktree returns `false` (the rebased commit isn't there). That guard — meant to reject *reused-branch-name collisions* — then rewrites the genuinely-merged PR to `state:"none"`.

The merge mark is only ever cleared by `resolveMerging`, which fires only on a `session:git` event of state `merged`/`closed`. Because the state was rewritten to `none`, `resolveMerging` never runs → the mark sticks and the PR badge disappears. Without the rebase (head SHA unchanged) the check passes — which is why this is specific to the merge train.

## Fix

1. **`pr-poller.ts`** — new pure `trustsTerminal(prev, raw, marked)`: trust a terminal (`merged`/`closed`) result, bypassing `guardStaleTerminal`, when **either** the session is merge-train-flagged (`mergingSince`, robust even cold-cache) **or** the prior cache already owned this PR number. The collision guard is preserved for the case it exists for — a session that never opened a PR.
2. **`server.ts`** — the on-demand GET `/api/sessions/:id/git` applies the same `trustsTerminal`, so the detail view (GitRail) and the list overview agree; neither can return a stuck `none`.
3. **`automerge.ts`** — `AutoMergeService.doMerge` merges autonomously (emits no `session:git`), so it now calls `service.resolveMerging(sessionId, true)` on a successful merge to clear the mark + credit the train tracker. Idempotent/defensive — a no-op unless the session was merge-train-flagged.

## Testing

- `pr-poller.test.ts`: `trustsTerminal` unit cases (both signals, terminal-state gate, negatives); `refresh` regressions for signal (a) cold-cache+marked and signal (b) prior-owned (seeded via a two-poll stateful forge), both asserting `merged` with `ownsPr=false`; existing collision-guard test still downgrades to `none`.
- `server-git.test.ts`: GET returns `merged` (not `none`) for both signals; collision case still `none`.
- `automerge.test.ts`: `doMerge` calls `resolveMerging(id, true)` on success, **0** calls on the fail-closed path.
- Full root suite (1653 pass), `tsc --noEmit`, lint, and `fallow audit` all clean.

`[no-feature-entry]` — server/internal-plumbing fix, no new user-facing UX or strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
