### PR TITLE
feat(ui): highlight shepherd:active label in New Task issue list

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -807,5 +807,7 @@
   "feat_draft_mode_title": "Entwurfs-PRs mit Freigabesteuerung",
   "feat_draft_mode_body": "Aktiviere den Entwurfsmodus, damit jeder neue PR als Entwurf geöffnet wird — er bleibt aus der Merge-Queue heraus, bis er freigegeben ist. Wähle, wer ihn promoten darf: ein Mensch, der Critic oder beide. Schließt Voll-Auto-Merge aus.",
   "feat_preview_start_title": "Dev-Server direkt aus dem HUD starten",
-  "feat_preview_start_body": "Hat ein Agent noch keine Live-Vorschau, erscheint ein Start-Steuerelement in seinem Viewport. Ein Klick genügt, damit der Agent seinen Dev-Server startet — automatisch erkannt aus der package.json oder per eigenem Befehl — und du die laufende App sofort vorschauen kannst, ohne zu warten, bis der Agent selbst auf die Idee kommt."
+  "feat_preview_start_body": "Hat ein Agent noch keine Live-Vorschau, erscheint ein Start-Steuerelement in seinem Viewport. Ein Klick genügt, damit der Agent seinen Dev-Server startet — automatisch erkannt aus der package.json oder per eigenem Befehl — und du die laufende App sofort vorschauen kannst, ohne zu warten, bis der Agent selbst auf die Idee kommt.",
+  "feat_active_label_newtask_title": "Beanspruchte Issues fallen in Neue Aufgabe auf",
+  "feat_active_label_newtask_body": "Wenn du eine Neue Aufgabe aus einem GitHub-Issue erstellst, wird ein bereits von einem aktiven Shepherd-Agenten beanspruchtes Issue jetzt mit hervorgehobenem shepherd:active-Label angezeigt — zuerst gelistet und im Farbton laufender Sessions getönt — sodass du auf einen Blick siehst, an welchen Issues schon gearbeitet wird."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -807,5 +807,7 @@
   "feat_draft_mode_title": "Draft-mode PRs with sign-off control",
   "feat_draft_mode_body": "Turn on draft mode to open every new PR as a draft — it stays out of the merge queue until signed off. Choose who may promote it: a human, the critic, or either. Mutually exclusive with full-auto merge.",
   "feat_preview_start_title": "Start a dev server from the HUD",
-  "feat_preview_start_body": "When an agent has no live preview yet, a Start control appears on its Viewport. Click it to have the agent launch its dev server — auto-detected from package.json, or type the command yourself — then preview the running app without waiting for the agent to start one on its own."
+  "feat_preview_start_body": "When an agent has no live preview yet, a Start control appears on its Viewport. Click it to have the agent launch its dev server — auto-detected from package.json, or type the command yourself — then preview the running app without waiting for the agent to start one on its own.",
+  "feat_active_label_newtask_title": "Claimed issues stand out in New Task",
+  "feat_active_label_newtask_body": "When you seed a New Task from a GitHub issue, any issue already claimed by an active Shepherd agent now shows its shepherd:active label highlighted — surfaced first and tinted with the running-session hue — so you can tell at a glance which issues are already being worked on."
 }

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -193,12 +193,13 @@
       <div class="muted">{m.common_no_open_issues()}</div>
     {:else}
       {#each issues as i (i.number)}
+        {@const ordered = orderedLabels(i.labels)}
         <button class="row" type="button" onclick={() => onpickissue(i)}>
           <span class="issue-num">#{i.number}</span>
           <span class="row-text">{i.title}</span>
-          {#if i.labels.length > 0}
+          {#if ordered.length > 0}
             <span class="chips">
-              {#each orderedLabels(i.labels).slice(0, 3) as lbl (lbl)}
+              {#each ordered.slice(0, 3) as lbl (lbl)}
                 <span
                   class="chip"
                   class:active={lbl === ACTIVE_LABEL}
@@ -206,9 +207,9 @@
                   >{lbl}</span
                 >
               {/each}
-              {#if i.labels.length > 3}
-                <span class="chip chip-more" title={i.labels.slice(3).join(", ")}>
-                  {m.promptsources_more_labels({ count: i.labels.length - 3 })}
+              {#if ordered.length > 3}
+                <span class="chip chip-more" title={ordered.slice(3).join(", ")}>
+                  {m.promptsources_more_labels({ count: ordered.length - 3 })}
                 </span>
               {/if}
             </span>

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -27,6 +27,17 @@
 
   const OPEN_RE = /^\s*-\s\[ \]\s+(.*)$/;
 
+  // Label the drain stamps on a claimed issue (mirrors ACTIVE_LABEL in
+  // src/drain-core.ts and IssuesPanel.svelte). Surfaced first + highlighted so a
+  // taken issue reads as already-being-worked-on, same as the Issues panel.
+  const ACTIVE_LABEL = "shepherd:active";
+
+  // Active-first ordering so the claimed marker survives the 3-chip cap below.
+  const orderedLabels = (labels: string[]): string[] =>
+    labels.includes(ACTIVE_LABEL)
+      ? [ACTIVE_LABEL, ...labels.filter((l) => l !== ACTIVE_LABEL)]
+      : labels;
+
   // Resolve TODO.md eagerly per repo (independent of the active tab) so the To-Do
   // tab is hidden outright when the repo has no TODO.md, and the panel opens on
   // Issues instead of a dead empty To-Do tab.
@@ -187,8 +198,13 @@
           <span class="row-text">{i.title}</span>
           {#if i.labels.length > 0}
             <span class="chips">
-              {#each i.labels.slice(0, 3) as lbl (lbl)}
-                <span class="chip">{lbl}</span>
+              {#each orderedLabels(i.labels).slice(0, 3) as lbl (lbl)}
+                <span
+                  class="chip"
+                  class:active={lbl === ACTIVE_LABEL}
+                  title={lbl === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}
+                  >{lbl}</span
+                >
               {/each}
               {#if i.labels.length > 3}
                 <span class="chip chip-more" title={i.labels.slice(3).join(", ")}>
@@ -374,6 +390,14 @@
     border: 1px solid var(--color-faint);
     border-radius: 2px;
     padding: 0 4px;
+  }
+
+  /* shepherd:active — claimed work. Same semantic running/in-progress token as
+     IssuesPanel so a taken issue stands out with the running-session hue. */
+  .chip.active {
+    color: var(--status-running);
+    border-color: var(--status-running);
+    background: color-mix(in srgb, var(--status-running) 14%, transparent);
   }
 
   .chip-more {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -244,4 +244,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_preview_start_title",
     bodyKey: "feat_preview_start_body",
   },
+  {
+    // No targetId: the New Task prompt-sources issue list only mounts inside the open
+    // New Task dialog, so a coachmark anchor would usually be unmounted — surface via
+    // the What's-New drawer only.
+    id: "active-label-newtask",
+    sinceVersion: "1.20.0",
+    titleKey: "feat_active_label_newtask_title",
+    bodyKey: "feat_active_label_newtask_body",
+  },
 ];

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -249,7 +249,7 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     // New Task dialog, so a coachmark anchor would usually be unmounted — surface via
     // the What's-New drawer only.
     id: "active-label-newtask",
-    sinceVersion: "1.20.0",
+    sinceVersion: "1.21.0",
     titleKey: "feat_active_label_newtask_title",
     bodyKey: "feat_active_label_newtask_body",
   },


### PR DESCRIPTION
## What

In the **New Task** dialog's *Seed From → Issues* list (`PromptSources.svelte`), the `shepherd:active` label — stamped on an issue the drain has claimed — now renders highlighted instead of as a neutral grey chip:

- **Surfaced first** so the marker survives the 3-chip-per-row cap (it would otherwise hide behind `+N`).
- **Tinted with the running-session hue** (`--status-running`), matching the existing treatment in `IssuesPanel.svelte`.
- **Tooltip** reuses the existing `issuespanel_active_label_title` key.

This makes it obvious at a glance which issues are already being worked on, so you don't seed a duplicate task.

## Why

The Issues panel already highlights `shepherd:active`; the New Task issue picker did not. This brings the two in line ("**also** highlight it here").

## Changes

- `PromptSources.svelte` — `ACTIVE_LABEL` constant + active-first `orderedLabels()`, `class:active` chip styling reusing the `--status-running` recipe, tooltip.
- `feature-announcements.ts` + EN/DE catalogs — one What's-New entry (`active-label-newtask`).

## Verification

- `cd ui && bun run check` — 0 errors / 0 warnings
- `bun run check:i18n` — 810 keys in parity (EN+DE)
- feature-catalog + branch-hygiene gates pass; pre-push green

🤖 Generated with [Claude Code](https://claude.com/claude-code)