### PR TITLE
fix(buildqueue): bound queue list so touch-scroll isn't trapped on mobile

### DIFF
--- a/ui/src/lib/components/BuildQueuePanel.svelte
+++ b/ui/src/lib/components/BuildQueuePanel.svelte
@@ -305,7 +305,6 @@
     max-height: 40vh;
     overflow-y: auto;
     overscroll-behavior: contain;
-    -webkit-overflow-scrolling: touch;
     touch-action: pan-y;
   }
 

--- a/ui/src/lib/components/BuildQueuePanel.svelte
+++ b/ui/src/lib/components/BuildQueuePanel.svelte
@@ -298,6 +298,15 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
+    /* The panel lives in an overflow:hidden flex column (Viewport). Without a
+       cap a long queue grows unbounded, crushes the terminal below, and offers
+       no scroll target — so touch gestures get trapped. Bound it and let the
+       list own its own vertical scroll. */
+    max-height: 40vh;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
   }
 
   .bqp-row {


### PR DESCRIPTION
## Problem

On mobile, the **BUILD-QUEUE** panel traps finger-gesture scrolling — you can't scroll the screen up/down. When the queue has several items, the panel swells to fill most of the screen, squashing the terminal into a thin strip, and there's nowhere to scroll.

(Reported from a mobile screenshot showing a ~7-item build queue covering the viewport.)

## Root cause

`BuildQueuePanel` renders inside `Viewport`'s `overflow: hidden` flex column. `.bqp-list` had **no height cap and no `overflow`**, so a long queue grows unbounded:

- It crushes the `.vp-body` terminal pane below.
- The list itself has no scroll boundary, so a touch swipe has no valid scroll target — the sibling terminal owns `touch-action: none`, and the root viewport is `overflow: hidden`. The gesture goes nowhere.

## Fix

Bound `.bqp-list` and let it own its own vertical scroll:

```css
max-height: 40vh;
overflow-y: auto;
overscroll-behavior: contain;   /* don't chain scroll into the trapped parent */
-webkit-overflow-scrolling: touch;
touch-action: pan-y;
```

A long queue now scrolls internally instead of eating the layout, and the gesture is no longer trapped. Applies to both the curation (editable) and approved (read-only) lists since they share the class.

## Notes
- CSS-only; no behavior/markup change, no new strings → no i18n or feature-catalog entry needed. `[no-feature-entry]`
- `cd ui && bun run check` passes (0 errors, 0 warnings).