### PR TITLE
fix(queue-strip): show only repos with a running agent in the status band

### DIFF
--- a/ui/src/lib/components/QueueStrip.svelte
+++ b/ui/src/lib/components/QueueStrip.svelte
@@ -23,6 +23,7 @@
     autoMerge = {},
     items = [],
     injectable = [],
+    runningRepoPaths = new Set(),
     onlearnings,
     repoFilter = null,
     onrepofilter,
@@ -31,6 +32,8 @@
     autoMerge?: Record<string, AutoMergeStatus>;
     items?: Learning[];
     injectable?: RepoInjectable[];
+    // repo paths that currently have a running agent — the band lists only these.
+    runningRepoPaths?: Set<string>;
     onlearnings?: (repoPath: string) => void;
     // active herd repo filter (full repo path), or null when showing all repos
     repoFilter?: string | null;
@@ -38,7 +41,7 @@
     onrepofilter?: (repoPath: string | null) => void;
   } = $props();
 
-  const rows = $derived(repoStatusRows(drain, items, injectable));
+  const rows = $derived(repoStatusRows(drain, items, injectable, runningRepoPaths));
   const mergeRows = $derived(activeMergeTrain(autoMerge));
 
   // Lazy queue popover: at most one open at a time, fetched fresh on open.
@@ -230,7 +233,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 6px;
+    gap: 2px;
     margin: 0;
     padding: 0;
     list-style: none;

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -190,37 +190,69 @@ describe("mergeTrainLabel", () => {
 // ─── repoStatusRows (generalized per-repo band) ──────────────────────────────
 
 describe("repoStatusRows", () => {
-  it("unions enabled-drain repos with learnings repos, sorted by path", () => {
+  // shorthand for the running-agent set the band gates on
+  const running = (...paths: string[]) => new Set(paths);
+
+  it("lists running-agent repos, enriched with drain/learnings, sorted by path", () => {
     const rows = repoStatusRows(
       { z: drain({ repoPath: "/repos/z" }) },
       [learning({ repoPath: "/repos/a" })],
       [],
+      running("/repos/a", "/repos/z"),
     );
     expect(rows.map((r) => r.repoPath)).toEqual(["/repos/a", "/repos/z"]);
   });
 
-  it("an insight-only repo gets a row with drain:null and the proposal count", () => {
+  it("excludes a repo with an enabled drain but no running agent", () => {
+    const rows = repoStatusRows(
+      { a: drain({ repoPath: "/repos/a", inFlight: 0 }) },
+      [],
+      [],
+      running(),
+    );
+    expect(rows).toEqual([]);
+  });
+
+  it("excludes a repo with pending learnings but no running agent", () => {
+    const rows = repoStatusRows({}, [learning({ repoPath: "/repos/a" })], [], running());
+    expect(rows).toEqual([]);
+  });
+
+  it("a running repo with learnings gets the proposal count, drain:null when not drained", () => {
     const rows = repoStatusRows(
       {},
       [learning({ id: "1", repoPath: "/repos/a" }), learning({ id: "2", repoPath: "/repos/a" })],
       [],
+      running("/repos/a"),
     );
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ repoPath: "/repos/a", drain: null, insights: 2, curate: 0 });
   });
 
-  it("a drain-only repo has insights:0 and curate:0 and carries its drain", () => {
-    const rows = repoStatusRows({ a: drain({ repoPath: "/repos/a", inFlight: 1 }) }, [], []);
+  it("a running repo with a drain but no learnings carries its drain, insights:0", () => {
+    const rows = repoStatusRows(
+      { a: drain({ repoPath: "/repos/a", inFlight: 1 }) },
+      [],
+      [],
+      running("/repos/a"),
+    );
     expect(rows).toHaveLength(1);
     expect(rows[0].drain?.inFlight).toBe(1);
     expect(rows[0]).toMatchObject({ insights: 0, curate: 0 });
   });
 
-  it("a disabled drain never produces a row or leaks into an insight-only row", () => {
+  it("a running repo with neither drain nor learnings still gets a name-only row", () => {
+    const rows = repoStatusRows({}, [], [], running("/repos/a"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ repoPath: "/repos/a", drain: null, insights: 0, curate: 0 });
+  });
+
+  it("a disabled drain never leaks into a running repo's row", () => {
     const rows = repoStatusRows(
       { a: drain({ repoPath: "/repos/a", enabled: false, inFlight: 5 }) },
       [learning({ repoPath: "/repos/a" })],
       [],
+      running("/repos/a"),
     );
     expect(rows).toHaveLength(1);
     expect(rows[0].drain).toBeNull(); // disabled drain stays out of the row
@@ -231,6 +263,7 @@ describe("repoStatusRows", () => {
       {},
       [],
       [injectable({ repoPath: "/repos/a", rules: [rule(true), rule(false), rule(false)] })],
+      running("/repos/a"),
     );
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ insights: 0, curate: 2 });
@@ -241,8 +274,10 @@ describe("repoStatusRows", () => {
       {},
       [],
       [injectable({ repoPath: "/repos/a", enabled: false, rules: [rule(false)] })],
+      running("/repos/a"),
     );
-    expect(rows).toEqual([]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ insights: 0, curate: 0 });
   });
 
   it("proposals suppress the curate fallback (badge showed the count, not curate)", () => {
@@ -250,11 +285,12 @@ describe("repoStatusRows", () => {
       {},
       [learning({ repoPath: "/repos/a" })],
       [injectable({ repoPath: "/repos/a", rules: [rule(false)] })],
+      running("/repos/a"),
     );
     expect(rows[0]).toMatchObject({ insights: 1, curate: 0 });
   });
 
-  it("returns an empty list when nothing is drained, proposed, or over budget", () => {
-    expect(repoStatusRows({ a: drain({ enabled: false }) }, [], [])).toEqual([]);
+  it("returns an empty list when no repo has a running agent", () => {
+    expect(repoStatusRows({ a: drain({}) }, [learning({})], [], running())).toEqual([]);
   });
 });

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -9,8 +9,8 @@ export function enabledDrains(drain: Record<string, DrainStatus>): DrainStatus[]
 }
 
 /** One row in the generalized per-repo status band: the repo's drain (only when
- *  enabled), plus its learnings footprint. A row exists when the repo has an enabled
- *  drain OR something to surface in the learnings drawer (proposals or curate need). */
+ *  enabled), plus its learnings footprint. A row exists only when the repo currently
+ *  has a RUNNING agent; the drain/learnings data merely enriches that row. */
 export interface RepoStatusRow {
   repoPath: string;
   /** The enabled drain for this repo, or null for an insight-only row. */
@@ -29,16 +29,18 @@ function overBudgetCount(repo: RepoInjectable): number {
 }
 
 /**
- * Build the per-repo status rows for the QueueStrip's first band: the union of
- * repos with an ENABLED drain and repos with a learnings footprint (pending
- * proposals or an over-budget curate need). `drain` is taken only from
- * `enabledDrains` — a disabled drain entry never produces a row or leaks its
- * inflight/queue/popover into an insight-only row. Sorted by repoPath.
+ * Build the per-repo status rows for the QueueStrip's first band: one row per repo
+ * that currently has a RUNNING agent (`runningRepoPaths`). Each row is enriched with
+ * the repo's ENABLED drain (taken only from `enabledDrains` — a disabled drain entry
+ * never leaks its inflight/queue/popover) and its learnings footprint (pending
+ * proposals, or an over-budget curate need). A repo with an enabled drain or pending
+ * learnings but NO running agent gets no row. Sorted by repoPath.
  */
 export function repoStatusRows(
   drain: Record<string, DrainStatus>,
   items: Learning[],
   injectable: RepoInjectable[],
+  runningRepoPaths: Set<string>,
 ): RepoStatusRow[] {
   const drains = new Map(enabledDrains(drain).map((d) => [d.repoPath, d]));
 
@@ -51,13 +53,7 @@ export function repoStatusRows(
     if (n > 0) curateByRepo.set(r.repoPath, n);
   }
 
-  const repoPaths = new Set<string>([
-    ...drains.keys(),
-    ...insightsByRepo.keys(),
-    ...curateByRepo.keys(),
-  ]);
-
-  return [...repoPaths]
+  return [...runningRepoPaths]
     .map((repoPath) => {
       const insights = insightsByRepo.get(repoPath) ?? 0;
       return {

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -13,7 +13,8 @@ export function enabledDrains(drain: Record<string, DrainStatus>): DrainStatus[]
  *  has a RUNNING agent; the drain/learnings data merely enriches that row. */
 export interface RepoStatusRow {
   repoPath: string;
-  /** The enabled drain for this repo, or null for an insight-only row. */
+  /** The enabled drain for this repo, or null when the repo has no enabled drain
+   *  (a name-only or insight-only row). */
   drain: DrainStatus | null;
   /** Count of pending (proposed) learnings for this repo. */
   insights: number;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -113,20 +113,27 @@
   // When the learnings drawer is opened from a repo's status row, this carries that
   // repoPath so the drawer scrolls to the matching section; null = opened globally.
   let learningsRepo = $state<string | null>(null);
+  // Repos with at least one currently-running agent — the repo-status band lists only
+  // these (matches TopBar's "working" definition). Drives both the band rows and the
+  // filterable scope below.
+  const runningRepoPaths = $derived(
+    new Set(store.sessions.filter((s) => s.status === "running").map((s) => s.repoPath)),
+  );
   // Herd repo filter (full repo path) toggled from the repo-status band; null = all
-  // repos. Only repos that appear in the band (enabled drain or pending learnings) are
-  // filterable — the band IS the toggle, so a repo with agents but no drain/learnings
-  // can't be selected. Only narrows the herd list views — selection and global counts
+  // repos. Only repos that appear in the band (a running agent) are filterable — the
+  // band IS the toggle. Only narrows the herd list views — selection and global counts
   // stay whole.
   let repoFilter = $state<string | null>(null);
   // The band's filterable repos, so the toggle and the auto-clear guard agree on scope.
   const bandRepoPaths = $derived(
     new Set(
-      repoStatusRows(store.drain, learnings.items, learnings.injectable).map((r) => r.repoPath),
+      repoStatusRows(store.drain, learnings.items, learnings.injectable, runningRepoPaths).map(
+        (r) => r.repoPath,
+      ),
     ),
   );
   // A stale filter would otherwise strand the herd: when the filtered repo's band row
-  // disappears (drain disabled, learnings resolved) its toggle vanishes with no way to
+  // disappears (its last agent stopped running) its toggle vanishes with no way to
   // reset short of a reload. Clear it the moment its repo leaves the band.
   $effect(() => {
     if (repoFilter && !bandRepoPaths.has(repoFilter)) repoFilter = null;
@@ -759,6 +766,7 @@
         autoMerge={store.autoMerge}
         items={learnings.items}
         injectable={learnings.injectable}
+        {runningRepoPaths}
         onlearnings={(repoPath) => {
           learningsRepo = repoPath;
           showLearnings = true;


### PR DESCRIPTION
## Was

Die **REPO-STATUS**-Leiste oben im Dashboard listet jetzt nur noch Repos, die **aktuell einen laufenden Agent** haben.

### Problem
Bisher erschien ein Repo in der Leiste, sobald es einen aktivierten Auto-Merge-Drain *oder* offene Learnings hatte — unabhängig davon, ob gerade ein Agent läuft. Dadurch standen leere Repos (`0/1 AUTO · 0 in Warteschlange`, kein Agent — z. B. Annette) dauerhaft oben und verstopften die Übersicht.

### Fix
- Die Leiste wird auf Repos mit **mindestens einer laufenden Session** (`status === "running"`) gefiltert — dieselbe Definition, die `TopBar` für "working" nutzt.
- Drain-/Queue-/Learnings-Infos **bereichern** diese Zeilen weiterhin, erzeugen aber keine Zeile mehr für sich allein.
- Ein laufendes Repo ohne Drain/Learnings bekommt jetzt eine reine Namens-Zeile (und ist damit als Herd-Filter auswählbar — schließt eine alte Lücke).
- Hat kein Repo einen laufenden Agent, verschwindet die Leiste komplett.

### Spacing
Zeilenabstand der Leiste von `6px` → `2px` reduziert (Tap-Targets von 44px auf Touch bleiben unverändert), damit die Leiste kompakter liest.

## Test
- `bun run check` ✓ (0 Fehler)
- `bun run test queue-strip` ✓ (35 Tests, inkl. neuer Gating-Fälle)
- `bun run check:i18n` ✓ (keine neuen Strings)
- Branch-Hygiene ✓ (linear off main)
