### PR TITLE
fix(ui): make terminal jump-to-bottom button more prominent on desktop

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2531,17 +2531,17 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 30px;
-    height: 30px;
+    width: 38px;
+    height: 38px;
     border-radius: 50%;
     border: 1px solid var(--color-line-bright);
-    background: color-mix(in srgb, var(--color-head) 90%, transparent);
+    background: color-mix(in srgb, var(--color-head) 96%, transparent);
     backdrop-filter: blur(2px);
-    color: var(--color-ink);
-    font-size: var(--fs-lg);
+    color: var(--color-ink-bright);
+    font-size: var(--fs-xl);
     line-height: 1;
     cursor: pointer;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 3px 12px rgba(0, 0, 0, 0.45);
     transition:
       background 0.12s ease,
       color 0.12s ease,
@@ -2556,7 +2556,7 @@
   /* Coarse pointers (touch): grow the free-floating affordance to a ≥44px tap
      target. It sits in the terminal corner with room to spare, so enlarging the
      element itself is simplest — stays round, stays flat. Desktop (fine pointer)
-     keeps the dense 30px glyph. */
+     keeps the 38px glyph. */
   @media (pointer: coarse) {
     .scroll-bottom {
       min-width: 44px;


### PR DESCRIPTION
## Was & warum

Auf Mobile fällt der „Zum-Ende-springen"-Button (rund, ↓, unten rechts im Terminal) sofort auf. Auf dem Desktop **schien er zu fehlen** — tatsächlich war er schon da, aber mit 30px und niedrigem Kontrast in der Ecke eines breiten Terminals leicht zu übersehen.

Der Auslöser und das Verhalten waren auf beiden Layouts identisch (nicht mobile-gegated; es gibt sogar einen eigenen Desktop-Maus-Rad-Observer). Das Problem war reine **Auffindbarkeit**, nicht Funktion.

## Änderung (rein CSS, `.scroll-bottom` in `Viewport.svelte`)

- Fine-Pointer-Größe **30px → 38px**
- Glyph-Kontrast: `--color-ink` → `--color-ink-bright`, `--fs-lg` → `--fs-xl`
- Hintergrund deckender (90% → 96%), kräftigerer Schatten
- Touch-Ziel unverändert (≥44px); gleicher Auslöser (erscheint beim Hochscrollen)

## Verifikation

- Mit echtem Headless-Browser bei Desktop-Breite (1400px) bestätigt: nach Hochscrollen im Terminal erscheint der Button unten rechts, jetzt 38px / `--fs-xl`, klickbar, nichts verdeckt ihn.
- `cd ui && bun run check` → 0 Fehler, 0 Warnungen.

Keine neue Capability → kein Feature-Catalog-Eintrag nötig (Auffindbarkeits-Tweak eines bestehenden Features). Keine neuen i18n-Keys (nutzt `viewport_scroll_to_bottom`).