### PR TITLE
fix(ui): rename repo-row drain indicator from 'auto' to 'agents'

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -151,7 +151,7 @@
   "signoff_authority_either": "Mensch oder Critic",
   "automation_signoff_needs_critic": "Critic / beide erfordern einen aktivierten Critic — nur menschliche Freigabe ist verfügbar.",
   "drain_strip_label": "Queue",
-  "drain_inflight": "{count}/{max} auto",
+  "drain_inflight": "{count}/{max} Agenten",
   "drain_queued": "{count} in Warteschlange",
   "drain_paused_blocked": "Pausiert: {desig} ist blockiert",
   "drain_paused_changes": "Pausiert: {desig} braucht Änderungen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -151,7 +151,7 @@
   "signoff_authority_either": "Human or Critic",
   "automation_signoff_needs_critic": "Critic / either need the Critic turned on — only human sign-off is available.",
   "drain_strip_label": "Drain",
-  "drain_inflight": "{count}/{max} auto",
+  "drain_inflight": "{count}/{max} agents",
   "drain_queued": "{count} queued",
   "drain_paused_blocked": "Paused: {desig} is blocked",
   "drain_paused_changes": "Paused: {desig} needs changes",


### PR DESCRIPTION
## Problem

Im Top-Bar zeigte die Repo-Status-Zeile `EPAMANO-SHOPIFY 0/1 auto`, während die Automation-Pille rechts `Automatisierung 8/8` zeigte — das las sich wie ein Widerspruch (gemeldet vom User).

Es ist **kein Datenbug**: die beiden Werte messen Verschiedenes.

| Anzeige | Key | Bedeutung |
|---|---|---|
| `0/1 auto` (Repo-Zeile) | `drain_inflight` = `{count}/{max} auto` | **laufende** Auto-Abarbeitungs-Agenten / max. parallel. `0/1` = 0 von max. 1 Agent läuft gerade. |
| `8/8 Automatisierung` (Pille) | `automation_pill_aria` | wie viele der 8 Automatik-**Schalter** an sind. `8/8` = alle an. |

Konsistent: Weil „Auto-Abarbeitung" Teil der 8/8 und eingeschaltet ist, erscheint die Repo-Zeile überhaupt (`QueueStrip` rendert nur Repos mit aktiviertem Drain). Das `0/1` ist nur die Live-Auslastung. Das Wort „auto" direkt neben „Automatisierung 8/8" ließ es wie eine Diskrepanz wirken.

## Fix

Reine Wording-Änderung in beiden Locales:

- `drain_inflight`: `{count}/{max} auto` → `{count}/{max} agents` (EN) / `{count}/{max} Agenten` (DE)

Die Zeile liest jetzt `EPAMANO-SHOPIFY 0/1 Agenten · 0 in Warteschlange` — klar als „laufende Agenten", keine Kollision mehr mit der Schalter-Zählung der Automation-Pille.

## Verifikation

- `check:i18n` ✓ (beide Locales in Parität)
- `bun run check` (svelte-check) ✓ 0 Fehler
- QueueStrip/GitRail-Tests ✓ 52 passed

Reines Wording-Fix, kein neues User-Feature → kein Feature-Catalog-Eintrag.

[no-feature-entry]