### PR TITLE
feat(preview): dynamic tailscale serve registration for preview ports (#403)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,20 +113,21 @@ include the public hostname (see below).
 
 All via environment variables (`src/config.ts`):
 
-| Variable                      | Default                         | Purpose                                                                         |
-| ----------------------------- | ------------------------------- | ------------------------------------------------------------------------------- |
-| `SHEPHERD_PORT`               | `7330`                          | HTTP/WS listen port                                                             |
-| `SHEPHERD_HOST`               | `127.0.0.1`                     | Bind address; loopback-only by default (set `0.0.0.0` to expose all NICs)       |
-| `SHEPHERD_DB`                 | `~/.shepherd/shepherd.db`       | SQLite session store path                                                       |
-| `SHEPHERD_REPO_ROOT`          | `~` (home)                      | Repos must live under this root (spawn is confined to it)                       |
-| `SHEPHERD_ALLOWED_HOSTS`      | `localhost,127.0.0.1,::1,[::1]` | Comma-separated origin hostnames allowed for writes + WS (CSRF/CSWSH guard)     |
-| `SHEPHERD_TOKEN`              | _(none)_                        | When set, require `Authorization: Bearer <token>`                               |
-| `HERDR_BIN`                   | `herdr`                         | Path to the herdr binary                                                        |
-| `HERDR_SESSION`               | `default`                       | herdr session name                                                              |
-| `SHEPHERD_FORGES`             | `~/.shepherd/forges.json`       | Path to the git-host config (see [Git host integration](#git-host-integration)) |
-| `SHEPHERD_PREVIEW_PORT_BASE`  | `8001`                          | First port in the live-preview range (each agent's preview gets one port)       |
-| `SHEPHERD_PREVIEW_PORT_COUNT` | `16`                            | Size of the preview range and maximum concurrent previews                       |
-| `SHEPHERD_PREVIEW_SWEEP_MS`   | `4000`                          | Cadence (ms) of the dev-port detection sweep across active sessions             |
+| Variable                      | Default                         | Purpose                                                                                                                  |
+| ----------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `SHEPHERD_PORT`               | `7330`                          | HTTP/WS listen port                                                                                                      |
+| `SHEPHERD_HOST`               | `127.0.0.1`                     | Bind address; loopback-only by default (set `0.0.0.0` to expose all NICs)                                                |
+| `SHEPHERD_DB`                 | `~/.shepherd/shepherd.db`       | SQLite session store path                                                                                                |
+| `SHEPHERD_REPO_ROOT`          | `~` (home)                      | Repos must live under this root (spawn is confined to it)                                                                |
+| `SHEPHERD_ALLOWED_HOSTS`      | `localhost,127.0.0.1,::1,[::1]` | Comma-separated origin hostnames allowed for writes + WS (CSRF/CSWSH guard)                                              |
+| `SHEPHERD_TOKEN`              | _(none)_                        | When set, require `Authorization: Bearer <token>`                                                                        |
+| `HERDR_BIN`                   | `herdr`                         | Path to the herdr binary                                                                                                 |
+| `HERDR_SESSION`               | `default`                       | herdr session name                                                                                                       |
+| `SHEPHERD_FORGES`             | `~/.shepherd/forges.json`       | Path to the git-host config (see [Git host integration](#git-host-integration))                                          |
+| `SHEPHERD_PREVIEW_PORT_BASE`  | `8001`                          | First port in the live-preview range (each agent's preview gets one port)                                                |
+| `SHEPHERD_PREVIEW_PORT_COUNT` | `16`                            | Size of the preview range and maximum concurrent previews                                                                |
+| `SHEPHERD_PREVIEW_SWEEP_MS`   | `4000`                          | Cadence (ms) of the dev-port detection sweep across active sessions                                                      |
+| `SHEPHERD_PREVIEW_AUTO_SERVE` | `true`                          | Dynamically register/unregister `tailscale serve` mappings as previews bind/tear down; set `0` to map the range manually |
 
 A few runtime toggles live in the SQLite `settings` table (`~/.shepherd/shepherd.db`) rather than env:
 
@@ -230,19 +231,20 @@ agent's own app fetches (reads, writes, storage, HMR) are same-origin and work w
 rewriting. The HUD's origin check rejects preview-port origins for state-changing requests, so a
 previewed app cannot forge `/api` calls.
 
-**One-time setup** — map the preview port range over Tailscale (prerequisite: tailnet HTTPS
-certificates enabled):
+**Tailscale exposure is automatic and dynamic** (default on — `SHEPHERD_PREVIEW_AUTO_SERVE`, set `0`
+to opt out). As each preview listener binds a slot, Shepherd registers a
+`tailscale serve --bg --https=<port> 127.0.0.1:<port>` mapping for it and removes it on teardown —
+zero operator setup, and only in-use ports are exposed. Stale mappings are cleared at startup and on
+shutdown. Prerequisites: tailnet HTTPS certificates enabled, and the service's user set as the
+Tailscale operator (`tailscale set --operator=$USER`) so it can run `tailscale serve` without sudo.
+When the node's tailnet host can't be resolved (tailscale absent/down), Shepherd skips registration
+and logs a warning — previews still work on loopback.
+
+To map the range manually instead, set `SHEPHERD_PREVIEW_AUTO_SERVE=0` and run the loop once:
 
 ```bash
 for p in $(seq 8001 8016); do tailscale serve --bg --https=$p 127.0.0.1:$p; done
 ```
-
-**Automated alternative:** set `SHEPHERD_PREVIEW_AUTO_SERVE=1` and Shepherd runs that same
-`tailscale serve --bg --https=<port> 127.0.0.1:<port>` loop over the configured slot range at
-startup. The same prerequisite applies — tailnet HTTPS certificates must be provisioned, or the
-loop fails. Without this flag (the default) the operator must run the manual loop above; the
-iframe URL fix alone makes the preview target the correct host but does **not** make the slot
-ports tailnet-reachable.
 
 > **Funnel vs Serve:** the 443/8443/10000 port restriction applies to **Funnel** only. `tailscale serve`
 > (tailnet-internal) accepts arbitrary HTTPS ports — the snippet above uses that.
@@ -276,8 +278,10 @@ per-origin cookie isolation is tracked in [#398](https://github.com/erwins-enkel
 
 **Caveats:**
 
-- **Blank pane?** Ensure the port is mapped via `tailscale serve`. Shepherd cannot detect this; the
-  pane shows a setup hint and an **Open in new tab** link as a fallback.
+- **Blank pane?** With auto-registration on (the default), a failed `tailscale serve` registration
+  shows a degraded (amber) Preview badge and a note in the pane — the app is still reachable on
+  loopback, so use the **Open in new tab** link. (With `SHEPHERD_PREVIEW_AUTO_SERVE=0`, ensure the
+  port is mapped manually.)
 - **App refuses to frame?** Some apps emit a `frame-ancestors` CSP via an in-HTML `<meta>` tag
   (SvelteKit can do this); response-header stripping cannot remove it. Use the **Open in new tab**
   link — safe because the preview runs on its own origin, not the HUD's.
@@ -285,7 +289,7 @@ per-origin cookie isolation is tracked in [#398](https://github.com/erwins-enkel
   `hmr.clientPort` in the app's Vite config to the preview port Shepherd assigned. Page-load and
   manual refresh always work regardless.
 
-**Follow-ups:** multi-port apps (#396), idle-stop (#399), dynamic `tailscale serve` registration (#403), subdomain/full isolation (#398).
+**Follow-ups:** multi-port apps (#396), idle-stop (#399), subdomain/full isolation (#398).
 
 Install the unit (`deploy/shepherd.service`):
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -253,12 +253,14 @@ export const config = {
   // node's host — not the operator's connection host — to remain reachable from the
   // tailnet. Null when tailscale is absent or the hostname cannot be resolved.
   previewHost: null as string | null,
-  // Opt-in (default OFF): when true AND tailscale is present, shepherd runs
-  // `tailscale serve --bg --https=<port>` for every slot in the preview range at
-  // startup so ephemeral slots are tailnet-reachable without manual setup.
-  // With this off, the operator must manually `tailscale serve` each slot (see README).
+  // Dynamic per-slot tailscale serve registration (default ON): when true AND
+  // tailscale is present (previewHost resolved), shepherd registers
+  // `tailscale serve --bg --https=<port>` as each preview listener binds and
+  // removes it on teardown — only in-use ports are exposed.
+  // No-ops when tailscale/previewHost is absent. Set SHEPHERD_PREVIEW_AUTO_SERVE=0
+  // to map the range manually (e.g. via `tailscale serve --bg --https=<port>`).
   // Requires tailnet HTTPS certificates to be enabled for the node.
-  previewAutoServe: process.env.SHEPHERD_PREVIEW_AUTO_SERVE === "1",
+  previewAutoServe: process.env.SHEPHERD_PREVIEW_AUTO_SERVE !== "0",
 };
 
 // Session housekeeping retention thresholds (the daily sweep's policy). The single

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
   validatePreviewPortRange,
 } from "./config";
 import { SessionStore } from "./store";
-import type { Session, SessionPreviewEvent } from "./types";
+import type { Session, SessionPreviewEvent, SessionPreviewServeEvent } from "./types";
 import { WorktreeMgr } from "./worktree";
 import { HerdrDriver, matchAgent } from "./herdr";
 import { generateName } from "./namer";
@@ -58,7 +58,7 @@ import { maintenance } from "./maintenance";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { startLoopLagSampler, logRemainingOnLoopBlockers } from "./instrument";
-import { resolveNodeHost, serveRange } from "./tailscale";
+import { resolveNodeHost, TailscaleServeService } from "./tailscale";
 
 const execFileAsync = promisify(execFile);
 
@@ -134,16 +134,9 @@ if (savedPlan !== null)
     localPort: config.port,
     servedPort,
   });
-  // Opt-in: register all preview slots with `tailscale serve` so they're tailnet-reachable.
-  // Fired void — serveRange sequences the 16 shells internally to avoid serve-config write
-  // races; no need to block boot on it.
-  if (config.previewAutoServe && config.previewHost) {
-    void serveRange(config.previewPortBase, config.previewPortCount).catch((err) =>
-      console.warn("[preview] serveRange failed:", err),
-    );
-  } else if (config.previewAutoServe && !config.previewHost) {
+  if (config.previewAutoServe && !config.previewHost) {
     console.warn(
-      "[preview] SHEPHERD_PREVIEW_AUTO_SERVE=1 but the node's tailnet host could not be resolved (is tailscale running?); previews will be unreachable.",
+      "[preview] dynamic tailscale serve registration is enabled but the node's tailnet host could not be resolved (is tailscale running?); previews won't be tailnet-reachable.",
     );
   }
 }
@@ -212,6 +205,14 @@ const previewService = new PreviewService({
     events.emit("session:preview", { id, previewPort } satisfies SessionPreviewEvent),
 });
 
+const tailscaleServe = new TailscaleServeService({
+  base: config.previewPortBase,
+  count: config.previewPortCount,
+  enabled: config.previewAutoServe && config.previewHost != null,
+  onChange: (id, _previewPort, serve) =>
+    events.emit("session:preview-serve", { id, serve } satisfies SessionPreviewServeEvent),
+});
+
 const poller = new StatusPoller(
   store,
   herdr,
@@ -228,6 +229,7 @@ const poller = new StatusPoller(
   (id, activity) => events.emit("session:activity", { id, activity }),
   { service: previewService, sweepMs: config.previewSweepMs }, // preview sweep wiring
 );
+await tailscaleServe.reconcileStartup();
 poller.start();
 
 // background Web Push: turn F3 state events into notifications for subscribed devices.
@@ -265,6 +267,17 @@ events.subscribe((event, data) => {
   if (event !== "session:status") return;
   const { id, status } = data as { id: string; status: string };
   if (status !== "running") prPoller.pollSession(id);
+});
+
+// Drive tailscale serve mappings: register when a preview port binds, unregister
+// on teardown. Listens on session:preview (NOT session:preview-serve to avoid
+// feedback loops). No-op when previewAutoServe disabled or previewHost unresolved.
+events.subscribe((event, data) => {
+  if (event !== "session:preview") return;
+  const { id, previewPort } = data as SessionPreviewEvent;
+  const op =
+    previewPort != null ? tailscaleServe.register(id, previewPort) : tailscaleServe.unregister(id);
+  void op.catch((err) => console.warn("[tailscale-serve] (un)register failed:", err));
 });
 
 // A PR in a merge train just landed (or was closed) → drop its "Merging" mark
@@ -722,6 +735,7 @@ const server = serve(
     ownsPr,
     activity: { snapshot: () => poller.activitySnapshot() },
     preview: { snapshot: () => previewService.snapshot() },
+    previewServe: { snapshot: () => tailscaleServe.snapshot() },
     push,
     presence,
     poller,
@@ -762,13 +776,17 @@ const server = serve(
 );
 console.log(`shepherd core on http://localhost:${server.port}`);
 
-// Best-effort teardown of preview listeners on process exit / SIGTERM.
-process.on("exit", () => previewService.stopAll());
+// Best-effort teardown of preview listeners and tailscale mappings on process exit / SIGTERM.
+process.on("exit", () => {
+  previewService.stopAll();
+  tailscaleServe.stopAll();
+});
 // Registering ANY SIGTERM handler overrides Bun's default terminate-on-signal, so we
 // must exit explicitly — otherwise `systemctl stop/restart shepherd` hangs until the
 // stop-timeout SIGKILL. Tear down, then exit (the `exit` handler's second stopAll is a
 // no-op since stopAll is idempotent).
 process.on("SIGTERM", () => {
   previewService.stopAll();
+  tailscaleServe.stopAll();
   process.exit(0);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,7 +229,14 @@ const poller = new StatusPoller(
   (id, activity) => events.emit("session:activity", { id, activity }),
   { service: previewService, sweepMs: config.previewSweepMs }, // preview sweep wiring
 );
-await tailscaleServe.reconcileStartup();
+// Clear stale mappings left by a crashed prior run. Fire void, NOT await: the service's
+// single FIFO queue already guarantees this op completes before any register/unregister
+// enqueued after poller.start(), so awaiting only risks stalling boot up to count×5s
+// (16 ports × 5s timeout ≈ 80s) when tailscaled is unresponsive. Reconcile swallows its
+// own per-port failures; the .catch is a belt-and-suspenders guard on the queue chain.
+void tailscaleServe
+  .reconcileStartup()
+  .catch((err) => console.warn("[tailscale-serve] startup reconcile failed:", err));
 poller.start();
 
 // background Web Push: turn F3 state events into notifications for subscribed devices.

--- a/src/server.ts
+++ b/src/server.ts
@@ -129,6 +129,9 @@ export interface AppDeps {
   preview?: {
     snapshot(): Record<string, SessionPreviewState>;
   };
+  /** Tailscale serve registration status per session slot; absent when auto-serve is
+   *  disabled or tailscale is unavailable. Merged into /api/preview responses. */
+  previewServe?: { snapshot(): Record<string, "ok" | "failed"> };
   /** Web Push delivery; absent in tests that don't exercise notifications. */
   push?: Pick<PushService, "publicKey" | "subscribe" | "unsubscribe">;
   /** Active-window tracker fed by /events presence frames; gates push suppression. */
@@ -233,7 +236,13 @@ function handleActivitySnapshot({ req, parts, deps }: Ctx): Response | null {
 
 function handlePreviewSnapshot({ req, parts, deps }: Ctx): Response | null {
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "preview" && !parts[2]) {
-    return json(deps.preview?.snapshot() ?? {});
+    const preview = deps.preview?.snapshot() ?? {};
+    const serve = deps.previewServe?.snapshot() ?? {};
+    const merged: Record<string, SessionPreviewState> = {};
+    for (const [id, st] of Object.entries(preview)) {
+      merged[id] = serve[id] ? { ...st, serve: serve[id] } : st;
+    }
+    return json(merged);
   }
   return null;
 }

--- a/src/tailscale.ts
+++ b/src/tailscale.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { timedAsync } from "./instrument";
+import { execFileSync, timedAsync } from "./instrument";
 
 const execFileAsync = promisify(execFile);
 
@@ -11,7 +11,9 @@ const execFileAsync = promisify(execFile);
 export type TailscaleRunner = (args: string[]) => Promise<{ stdout: string }>;
 
 const defaultRun: TailscaleRunner = (args) =>
-  timedAsync("tailscale " + args[0], () => execFileAsync("tailscale", args, { encoding: "utf8" }));
+  timedAsync("tailscale " + args[0], () =>
+    execFileAsync("tailscale", args, { encoding: "utf8", timeout: 5000 }),
+  );
 
 // ── resolveNodeHost ───────────────────────────────────────────────────────────
 
@@ -50,31 +52,123 @@ export async function resolveNodeHost(run: TailscaleRunner = defaultRun): Promis
   }
 }
 
-// ── serveRange ────────────────────────────────────────────────────────────────
+// ── TailscaleServeService ─────────────────────────────────────────────────────
+
+export type ServeState = "ok" | "failed";
+export type TailscaleRunnerSync = (args: string[]) => void;
+
+const SYNC_TIMEOUT_MS = 3000;
+const defaultRunSync: TailscaleRunnerSync = (args) => {
+  execFileSync("tailscale", args, { timeout: SYNC_TIMEOUT_MS, stdio: "ignore" });
+};
+
+export interface TailscaleServeOpts {
+  base: number;
+  count: number;
+  /** true = config.previewAutoServe && config.previewHost != null */
+  readonly enabled: boolean;
+  /** Fires after a register/unregister settles, so the change can be surfaced
+   *  (wiring emits it as session:preview-serve). serve: "ok"|"failed" on register, null on release. */
+  onChange?: (id: string, previewPort: number | null, serve: ServeState | null) => void;
+  /** Async hot path; default defaultRun */
+  run?: TailscaleRunner;
+  /** Sync shutdown path; default defaultRunSync */
+  runSync?: TailscaleRunnerSync;
+}
 
 /**
- * Registers each port in `[base, base + count)` with `tailscale serve --bg --https=<port>`.
- *
- * WHY sequential: `tailscale serve` does a read-modify-write on tailscaled's shared
- * serve config. Concurrent execs can race and lose each other's writes — one port's
- * config entry silently disappears. The `for` loop with `await` inside prevents that.
- *
- * WHY `--bg` and bare `127.0.0.1:<port>` target (no `--yes`, no `http://` prefix):
- * this is the form proven to work in README.md:231 and matched by the reaper at
- * src/process-reaper.ts:110 (`/\btailscale\s+serve\b/.test(cmd) && /--bg\b/.test(cmd)`).
- *
- * Best-effort: a failing port logs a warning and the loop continues.
+ * Dynamically (un)registers per-slot `tailscale serve` mappings as preview
+ * listeners bind/tear down. ALL mutations run through ONE sequential queue
+ * because `tailscale serve` read-modify-writes shared config — concurrent
+ * execs race and lose entries (see serveRange history / removed eager path).
  */
-export async function serveRange(
-  base: number,
-  count: number,
-  run: TailscaleRunner = defaultRun,
-): Promise<void> {
-  for (let port = base; port < base + count; port++) {
+export class TailscaleServeService {
+  private byId = new Map<string, { port: number; state: ServeState }>();
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(private opts: TailscaleServeOpts) {}
+
+  private get run() {
+    return this.opts.run ?? defaultRun;
+  }
+
+  private enqueue(op: () => Promise<void>): Promise<void> {
+    const next = this.queue.catch(() => {}).then(op);
+    this.queue = next;
+    return next;
+  }
+
+  private fire(id: string, port: number | null, serve: ServeState | null) {
     try {
-      await run(["serve", "--bg", `--https=${port}`, `127.0.0.1:${port}`]);
+      this.opts.onChange?.(id, port, serve);
     } catch (err) {
-      console.warn(`[tailscale] serveRange: failed to serve port ${port}:`, err);
+      console.warn(`[tailscale-serve] onChange threw for ${id}:`, err);
     }
+  }
+
+  register(id: string, port: number): Promise<void> {
+    if (!this.opts.enabled) return Promise.resolve();
+    return this.enqueue(async () => {
+      try {
+        await this.run(["serve", "--bg", `--https=${port}`, `127.0.0.1:${port}`]);
+        this.byId.set(id, { port, state: "ok" });
+        this.fire(id, port, "ok");
+      } catch (err) {
+        console.warn(`[tailscale-serve] register failed for ${id} port ${port}:`, err);
+        this.byId.set(id, { port, state: "failed" });
+        this.fire(id, port, "failed");
+      }
+    });
+  }
+
+  unregister(id: string): Promise<void> {
+    if (!this.opts.enabled) return Promise.resolve();
+    return this.enqueue(async () => {
+      const entry = this.byId.get(id);
+      if (!entry) return;
+      try {
+        await this.run(["serve", `--https=${entry.port}`, "off"]);
+      } catch (err) {
+        console.warn(`[tailscale-serve] unregister failed for ${id} port ${entry.port}:`, err);
+      }
+      this.byId.delete(id);
+      this.fire(id, null, null);
+    });
+  }
+
+  /**
+   * Clear the whole preview range at boot (recover stale mappings from a crashed
+   * prior run). One queued op running the offs sequentially; tolerates per-port failure.
+   */
+  reconcileStartup(): Promise<void> {
+    if (!this.opts.enabled) return Promise.resolve();
+    return this.enqueue(async () => {
+      for (let port = this.opts.base; port < this.opts.base + this.opts.count; port++) {
+        try {
+          await this.run(["serve", `--https=${port}`, "off"]);
+        } catch {
+          /* benign */
+        }
+      }
+    });
+  }
+
+  /** Synchronous shutdown teardown (process exit/SIGTERM): off only what we registered. */
+  stopAll(): void {
+    if (!this.opts.enabled) return;
+    const runSync = this.opts.runSync ?? defaultRunSync;
+    for (const { port } of this.byId.values()) {
+      try {
+        runSync(["serve", `--https=${port}`, "off"]);
+      } catch {
+        /* best effort */
+      }
+    }
+    this.byId.clear();
+  }
+
+  snapshot(): Record<string, ServeState> {
+    if (!this.opts.enabled) return {};
+    return Object.fromEntries([...this.byId].map(([id, e]) => [id, e.state]));
   }
 }

--- a/src/tailscale.ts
+++ b/src/tailscale.ts
@@ -57,7 +57,10 @@ export async function resolveNodeHost(run: TailscaleRunner = defaultRun): Promis
 export type ServeState = "ok" | "failed";
 export type TailscaleRunnerSync = (args: string[]) => void;
 
-const SYNC_TIMEOUT_MS = 3000;
+// Kept tight on purpose: a healthy local `tailscale serve … off` is sub-second, so this
+// only bites when tailscaled hangs — exactly when we want to bail fast on shutdown rather
+// than block `systemctl stop`. Anything skipped self-heals on the next boot's reconcile.
+const SYNC_TIMEOUT_MS = 1500;
 const defaultRunSync: TailscaleRunnerSync = (args) => {
   execFileSync("tailscale", args, { timeout: SYNC_TIMEOUT_MS, stdio: "ignore" });
 };
@@ -139,9 +142,19 @@ export class TailscaleServeService {
   /**
    * Clear the whole preview range at boot (recover stale mappings from a crashed
    * prior run). One queued op running the offs sequentially; tolerates per-port failure.
+   * NOTE: this also removes any pre-existing MANUAL `tailscale serve` mappings in the
+   * range — by design, since with SHEPHERD_PREVIEW_AUTO_SERVE on (default) Shepherd owns
+   * the range and registers slots dynamically. The startup log below makes that explicit
+   * so the ownership transfer isn't silent for operators upgrading from a manual setup.
    */
   reconcileStartup(): Promise<void> {
     if (!this.opts.enabled) return Promise.resolve();
+    const last = this.opts.base + this.opts.count - 1;
+    console.info(
+      `[tailscale-serve] clearing preview range ${this.opts.base}-${last} for dynamic ` +
+        `management (removes any manual \`tailscale serve\` mappings in this range; set ` +
+        `SHEPHERD_PREVIEW_AUTO_SERVE=0 to manage the range manually instead)`,
+    );
     return this.enqueue(async () => {
       for (let port = this.opts.base; port < this.opts.base + this.opts.count; port++) {
         try {
@@ -153,7 +166,14 @@ export class TailscaleServeService {
     });
   }
 
-  /** Synchronous shutdown teardown (process exit/SIGTERM): off only what we registered. */
+  /**
+   * Synchronous shutdown teardown (process exit/SIGTERM): off only the slots we
+   * registered (≤ active previews, capped at `count`). Worst-case wall time is
+   * registered-slots × SYNC_TIMEOUT_MS (≤ 16 × 1.5s = 24s) and only approaches that
+   * if tailscaled is hung; a healthy daemon offs each slot in well under a second.
+   * Best-effort: any slot that errors/times out is skipped and self-heals on the next
+   * boot's reconcileStartup (which clears the whole range), so we never block exit on it.
+   */
   stopAll(): void {
     if (!this.opts.enabled) return;
     const runSync = this.opts.runSync ?? defaultRunSync;

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,6 +246,17 @@ export interface SessionPreviewEvent {
  */
 export interface SessionPreviewState {
   previewPort: number | null;
+  /** Tailscale serve registration status for this slot; absent when not managed
+   *  (auto disabled / tailscale absent) or no mapping yet. "failed" → degraded. */
+  serve?: "ok" | "failed";
+}
+
+/** Emitted by TailscaleServeService when a slot's `tailscale serve` mapping
+ *  settles. Distinct from SessionPreviewEvent to avoid a register/emit feedback
+ *  loop. serve: "ok"|"failed" after register, null after release. */
+export interface SessionPreviewServeEvent {
+  id: string;
+  serve: "ok" | "failed" | null;
 }
 
 // ── learnings flywheel ────────────────────────────────────────────────────────

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1671,3 +1671,42 @@ test("claimLinkedIssue swallows an addIssueLabel rejection", async () => {
   } as unknown as GitForge;
   await expect(claimLinkedIssue(forge, 42)).resolves.toBeUndefined();
 });
+
+// ── GET /api/preview — serve status merge ─────────────────────────────────────
+
+test("GET /api/preview merges serve status into preview snapshot", async () => {
+  const deps = makeDeps() as AppDeps;
+  deps.preview = {
+    snapshot: () => ({
+      s1: { previewPort: 8001 },
+      s2: { previewPort: 8002 },
+    }),
+  };
+  (deps as any).previewServe = {
+    snapshot: () => ({ s1: "failed" }),
+  };
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://x/api/preview"));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Record<string, { previewPort: number; serve?: string }>;
+  expect(body.s1).toEqual({ previewPort: 8001, serve: "failed" });
+  // s2 has no serve entry — field should be absent
+  expect(body.s2).toEqual({ previewPort: 8002 });
+  expect((body.s2 as any).serve).toBeUndefined();
+});
+
+test("GET /api/preview without previewServe dep returns unchanged snapshot (back-compat)", async () => {
+  const deps = makeDeps() as AppDeps;
+  deps.preview = {
+    snapshot: () => ({
+      s1: { previewPort: 8001 },
+    }),
+  };
+  // previewServe intentionally absent
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://x/api/preview"));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Record<string, { previewPort: number; serve?: string }>;
+  expect(body.s1).toEqual({ previewPort: 8001 });
+  expect((body.s1 as any).serve).toBeUndefined();
+});

--- a/test/tailscale.test.ts
+++ b/test/tailscale.test.ts
@@ -1,5 +1,10 @@
 import { test, expect, describe } from "bun:test";
-import { resolveNodeHost, serveRange } from "../src/tailscale";
+import {
+  resolveNodeHost,
+  TailscaleServeService,
+  type TailscaleRunner,
+  type TailscaleRunnerSync,
+} from "../src/tailscale";
 
 // ── resolveNodeHost ───────────────────────────────────────────────────────────
 
@@ -58,111 +63,266 @@ describe("resolveNodeHost", () => {
   });
 });
 
-// ── serveRange: argv ──────────────────────────────────────────────────────────
+// ── TailscaleServeService helpers ─────────────────────────────────────────────
 
-describe("serveRange argv", () => {
-  test("issues correct argv for each port in range — no --yes, bare 127.0.0.1:<port> target", async () => {
-    const calls: Array<string[]> = [];
-    const run = async (args: string[]) => {
-      calls.push(args);
-      return { stdout: "" };
-    };
-
-    await serveRange(8001, 3, run);
-
-    expect(calls).toHaveLength(3);
-
-    expect(calls[0]).toEqual(["serve", "--bg", "--https=8001", "127.0.0.1:8001"]);
-    expect(calls[1]).toEqual(["serve", "--bg", "--https=8002", "127.0.0.1:8002"]);
-    expect(calls[2]).toEqual(["serve", "--bg", "--https=8003", "127.0.0.1:8003"]);
-
-    // Explicit guard: no --yes anywhere
-    for (const args of calls) {
-      expect(args).not.toContain("--yes");
-    }
-    // Explicit guard: target is bare 127.0.0.1:<port>, no http:// prefix
-    for (const args of calls) {
-      const target = args[args.length - 1]!;
-      expect(target).toMatch(/^127\.0\.0\.1:\d+$/);
-      expect(target).not.toContain("http://");
-    }
-  });
-});
-
-// ── serveRange: sequential execution ─────────────────────────────────────────
-//
-// Recording order alone would also pass a broken concurrent impl. We gate on
-// resolution: the fake runner returns a deferred promise per port that we resolve
-// manually, then assert that run(N+1) has NOT been called until run(N) resolves.
-
-/** Drain the microtask queue several times to let `await` chains advance. */
+/** Drain microtask queue N times to let `await` chains advance. */
 async function flushMicrotasks(n = 5): Promise<void> {
   for (let i = 0; i < n; i++) await Promise.resolve();
 }
 
-describe("serveRange sequential execution", () => {
-  test("does NOT invoke port N+1 until port N's promise resolves", async () => {
-    type Resolver = (value: { stdout: string }) => void;
+function makeRun(rejectPorts: Set<number> = new Set()): {
+  calls: string[][];
+  run: TailscaleRunner;
+} {
+  const calls: string[][] = [];
+  const run: TailscaleRunner = async (args) => {
+    calls.push(args);
+    const portArg = args.find((a) => a.startsWith("--https="));
+    const port = portArg ? parseInt(portArg.split("=")[1]!, 10) : NaN;
+    if (rejectPorts.has(port)) throw new Error(`fake run failure on port ${port}`);
+    return { stdout: "" };
+  };
+  return { calls, run };
+}
+
+function makeRunSync(rejectPorts: Set<number> = new Set()): {
+  calls: string[][];
+  runSync: TailscaleRunnerSync;
+} {
+  const calls: string[][] = [];
+  const runSync: TailscaleRunnerSync = (args) => {
+    calls.push(args);
+    const portArg = args.find((a) => a.startsWith("--https="));
+    const port = portArg ? parseInt(portArg.split("=")[1]!, 10) : NaN;
+    if (rejectPorts.has(port)) throw new Error(`fake runSync failure on port ${port}`);
+  };
+  return { calls, runSync };
+}
+
+function makeDeferred(): { resolve: () => void; promise: Promise<void> } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => (resolve = r));
+  return { resolve, promise };
+}
+
+// ── TailscaleServeService ─────────────────────────────────────────────────────
+
+describe("TailscaleServeService", () => {
+  // 1. register-ok: correct argv, onChange("ok"), snapshot
+  test("register: argv correct, onChange ok, snapshot", async () => {
+    const changes: Array<[string, number | null, string | null]> = [];
+    const { calls, run } = makeRun();
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      onChange: (id, port, serve) => changes.push([id, port, serve]),
+      run,
+    });
+
+    await svc.register("s1", 8001);
+
+    expect(calls).toEqual([["serve", "--bg", "--https=8001", "127.0.0.1:8001"]]);
+    // No --yes anywhere
+    expect(calls[0]).not.toContain("--yes");
+    expect(changes).toEqual([["s1", 8001, "ok"]]);
+    expect(svc.snapshot()).toEqual({ s1: "ok" });
+  });
+
+  // 2. unregister after register: correct argv, onChange(null,null), snapshot empty
+  test("unregister after register: argv correct, onChange null, snapshot empty", async () => {
+    const changes: Array<[string, number | null, string | null]> = [];
+    const { calls, run } = makeRun();
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      onChange: (id, port, serve) => changes.push([id, port, serve]),
+      run,
+    });
+
+    await svc.register("s1", 8001);
+    await svc.unregister("s1");
+
+    expect(calls[1]).toEqual(["serve", "--https=8001", "off"]);
+    expect(changes[1]).toEqual(["s1", null, null]);
+    expect(svc.snapshot()).toEqual({});
+  });
+
+  // 3. register failure: onChange("failed"), snapshot "failed", no throw
+  test("register failure: onChange failed, snapshot failed, no throw", async () => {
+    const changes: Array<[string, number | null, string | null]> = [];
+    const { run } = makeRun(new Set([8001]));
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      onChange: (id, port, serve) => changes.push([id, port, serve]),
+      run,
+    });
+
+    await expect(svc.register("s1", 8001)).resolves.toBeUndefined();
+
+    expect(changes).toEqual([["s1", 8001, "failed"]]);
+    expect(svc.snapshot()).toEqual({ s1: "failed" });
+  });
+
+  // 4. unregister unknown id: no exec, no onChange
+  test("unregister unknown id: no exec, no onChange", async () => {
+    const changes: Array<unknown> = [];
+    const { calls, run } = makeRun();
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      onChange: (...args) => changes.push(args),
+      run,
+    });
+
+    await svc.unregister("s1");
+
+    expect(calls).toEqual([]);
+    expect(changes).toEqual([]);
+  });
+
+  // 5. disabled: all no-op, snapshot {}
+  test("disabled: all ops no-op, snapshot empty", async () => {
+    const changes: Array<unknown> = [];
+    const { calls: asyncCalls, run } = makeRun();
+    const { calls: syncCalls, runSync } = makeRunSync();
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 3,
+      enabled: false,
+      onChange: (...args) => changes.push(args),
+      run,
+      runSync,
+    });
+
+    await svc.register("s1", 8001);
+    await svc.unregister("s1");
+    await svc.reconcileStartup();
+    svc.stopAll();
+
+    expect(asyncCalls).toEqual([]);
+    expect(syncCalls).toEqual([]);
+    expect(changes).toEqual([]);
+    expect(svc.snapshot()).toEqual({});
+  });
+
+  // 6. reconcileStartup: offs entire range sequentially, tolerates a throwing port
+  test("reconcileStartup: offs each port in range; sequential; tolerates failure", async () => {
+    // sequentiality: port 8002 rejects — but all 3 ports should be attempted
+    const { calls, run } = makeRun(new Set([8002]));
+    const svc = new TailscaleServeService({ base: 8001, count: 3, enabled: true, run });
+
+    await expect(svc.reconcileStartup()).resolves.toBeUndefined();
+
+    const offCalls = calls.filter((a) => a.includes("off"));
+    const ports = offCalls.map((a) => {
+      const arg = a.find((x) => x.startsWith("--https="))!;
+      return parseInt(arg.split("=")[1]!, 10);
+    });
+    expect(ports.sort((a, b) => a - b)).toEqual([8001, 8002, 8003]);
+  });
+
+  // 6b. reconcileStartup sequential: port N+1 not called until port N resolves
+  test("reconcileStartup sequential: N+1 not called until N resolves", async () => {
+    type Resolver = () => void;
     const resolvers: Resolver[] = [];
     const invocationOrder: number[] = [];
 
-    const run = async (args: string[]): Promise<{ stdout: string }> => {
-      // Extract port number from --https=<port>
+    const run: TailscaleRunner = async (args) => {
       const httpsArg = args.find((a) => a.startsWith("--https="));
       const port = Number(httpsArg?.slice("--https=".length));
       invocationOrder.push(port);
       return new Promise<{ stdout: string }>((resolve) => {
-        resolvers.push(resolve);
+        resolvers.push(() => resolve({ stdout: "" }));
       });
     };
 
-    // Start serveRange — do NOT await yet
-    const done = serveRange(8001, 3, run);
+    const svc = new TailscaleServeService({ base: 8001, count: 3, enabled: true, run });
+    const done = svc.reconcileStartup();
 
-    // Port 8001 should be invoked immediately; drain the queue to let the loop start
     await flushMicrotasks();
-
     expect(invocationOrder).toEqual([8001]);
 
-    // Resolve port 8001; drain so the loop resumes and invokes 8002
-    resolvers[0]!({ stdout: "" });
+    resolvers[0]!();
     await flushMicrotasks();
-
     expect(invocationOrder).toEqual([8001, 8002]);
 
-    // Resolve port 8002; drain so the loop resumes and invokes 8003
-    resolvers[1]!({ stdout: "" });
+    resolvers[1]!();
     await flushMicrotasks();
-
     expect(invocationOrder).toEqual([8001, 8002, 8003]);
 
-    // Resolve port 8003; loop ends, serveRange resolves
-    resolvers[2]!({ stdout: "" });
+    resolvers[2]!();
     await done;
-
     expect(invocationOrder).toEqual([8001, 8002, 8003]);
   });
-});
 
-// ── serveRange: best-effort (one failure doesn't abort) ──────────────────────
+  // 7. stopAll: runSync off per registered port; throwing runSync doesn't stop rest; cleared; idempotent
+  test("stopAll: runSync per port, throws tolerated, clears, idempotent", async () => {
+    const { run } = makeRun();
+    const { calls: syncCalls, runSync } = makeRunSync(new Set([8002]));
+    const svc = new TailscaleServeService({
+      base: 8001,
+      count: 5,
+      enabled: true,
+      run,
+      runSync,
+    });
 
-describe("serveRange best-effort", () => {
-  test("continues after a failing port and attempts all ports", async () => {
-    const calls: number[] = [];
+    await svc.register("s1", 8001);
+    await svc.register("s2", 8002);
+    await svc.register("s3", 8003);
 
-    const run = async (args: string[]): Promise<{ stdout: string }> => {
+    expect(() => svc.stopAll()).not.toThrow();
+
+    const syncPorts = syncCalls.map((a) => {
+      const arg = a.find((x) => x.startsWith("--https="))!;
+      return parseInt(arg.split("=")[1]!, 10);
+    });
+    expect(syncPorts.sort((a, b) => a - b)).toEqual([8001, 8002, 8003]);
+    expect(svc.snapshot()).toEqual({});
+
+    // Second call is a no-op
+    const countBefore = syncCalls.length;
+    svc.stopAll();
+    expect(syncCalls.length).toBe(countBefore);
+  });
+
+  // 8. global serialization: two registers back-to-back must not run concurrently
+  test("global serialization: s2 run not called until s1 run resolves", async () => {
+    const order: string[] = [];
+    const deferred = makeDeferred();
+
+    const run: TailscaleRunner = async (args) => {
+      const isRegister = args.includes("--bg");
       const httpsArg = args.find((a) => a.startsWith("--https="));
-      const port = Number(httpsArg?.slice("--https=".length));
-      calls.push(port);
-      if (port === 8002) throw new Error("serve config write failed");
+      const port = httpsArg?.slice("--https=".length) ?? "?";
+      if (isRegister && port === "8001") {
+        order.push("s1-exec-start");
+        await deferred.promise;
+        order.push("s1-exec-done");
+      } else if (isRegister && port === "8002") {
+        order.push("s2-exec");
+      }
       return { stdout: "" };
     };
 
-    // serveRange must resolve (not reject) even when one port throws
-    await expect(serveRange(8001, 3, run)).resolves.toBeUndefined();
+    const svc = new TailscaleServeService({ base: 8001, count: 5, enabled: true, run });
 
-    // All three ports were attempted despite port 8002 failing
-    expect(calls).toHaveLength(3);
-    expect(calls).toEqual([8001, 8002, 8003]);
+    const p1 = svc.register("s1", 8001);
+    const p2 = svc.register("s2", 8002);
+
+    // Yield so queue starts; s1 is blocked, s2 must not have started yet
+    await flushMicrotasks();
+    expect(order).toEqual(["s1-exec-start"]);
+
+    deferred.resolve();
+    await p1;
+    await p2;
+
+    expect(order).toEqual(["s1-exec-start", "s1-exec-done", "s2-exec"]);
   });
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -824,5 +824,7 @@
   "fable_arrival_title": "Fable 5 ist gelandet",
   "fable_arrival_body": "Anthropics leistungsstärkstes Modell ist jetzt in Shepherd verfügbar. Wähle „fable“ unter Neuer Task für die anspruchsvollsten Aufgaben. Es ist die Premium-Stufe — höhere Token-Kosten als Opus — heb es dir also für die Aufgaben auf, die es wert sind.",
   "fable_arrival_try": "Fable 5 ausprobieren",
-  "fable_arrival_dismiss": "Vielleicht später"
+  "fable_arrival_dismiss": "Vielleicht später",
+  "feat_preview_tailscale_title": "Automatische Vorschau-Freigabe",
+  "feat_preview_tailscale_body": "Live-Vorschauen registrieren sich jetzt automatisch über Tailscale, sobald der Dev-Server eines Agenten startet — und melden sich beim Stoppen wieder ab, sodass nur tatsächlich genutzte Ports freigegeben werden. Kein einmaliges tailscale-serve-Port-Setup mehr."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -451,6 +451,8 @@
   "viewport_preview_command_placeholder": "z.B. npm run dev",
   "viewport_preview_command_send": "Senden",
   "unitrow_preview_badge": "Vorschau",
+  "unitrow_preview_badge_degraded": "Vorschau — Tailscale-Registrierung fehlgeschlagen; nur über Loopback erreichbar",
+  "viewport_preview_serve_failed": "Tailscale-Registrierung für diesen Vorschau-Port fehlgeschlagen — nur über Loopback erreichbar. Nutze 'In neuem Tab öffnen', wenn der Frame leer bleibt.",
   "viewport_git_actions": "PR",
   "viewport_git_actions_title": "PR, Merge, Kritiker & Merge-Freigabe",
   "viewport_git_actions_aria": "PR- und Merge-Aktionen ein-/ausblenden",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -824,5 +824,7 @@
   "fable_arrival_title": "Fable 5 has arrived",
   "fable_arrival_body": "Anthropic's most powerful model is now available in Shepherd. Pick \"fable\" in New Task for the most demanding work. It's the premium tier — higher token costs than Opus — so save it for the tasks that earn it.",
   "fable_arrival_try": "Try Fable 5",
-  "fable_arrival_dismiss": "Maybe later"
+  "fable_arrival_dismiss": "Maybe later",
+  "feat_preview_tailscale_title": "Automatic preview exposure",
+  "feat_preview_tailscale_body": "Live previews now register themselves over Tailscale automatically as each agent's dev server comes up — and unregister when it stops, so only in-use ports are exposed. No more one-time tailscale serve port setup."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -451,6 +451,8 @@
   "viewport_preview_command_placeholder": "e.g. npm run dev",
   "viewport_preview_command_send": "Send",
   "unitrow_preview_badge": "Preview",
+  "unitrow_preview_badge_degraded": "Preview — Tailscale registration failed; reachable on loopback only",
+  "viewport_preview_serve_failed": "Tailscale registration failed for this preview port — it's reachable on loopback only. Use Open in new tab if the frame is blank.",
   "viewport_git_actions": "PR",
   "viewport_git_actions_title": "PR, merge, critic & ready-to-merge actions",
   "viewport_git_actions_aria": "Toggle PR and merge actions",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -461,7 +461,9 @@ export async function activityStates(): Promise<Record<string, SessionActivity>>
 /** Snapshot of the bound preview-listener port per session, keyed by session id
  *  (for client bootstrap). `previewPort` is null when the server knows of no
  *  live dev-server listener. Empty object when nothing is bound. */
-export async function previewStates(): Promise<Record<string, { previewPort: number | null }>> {
+export async function previewStates(): Promise<
+  Record<string, { previewPort: number | null; serve?: "ok" | "failed" }>
+> {
   const r = await fetch("/api/preview");
   if (!r.ok) throw await failed(r, "preview states");
   return r.json();

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -16,6 +16,7 @@
     git,
     activity,
     preview = {},
+    previewServe = {},
     onpreview = undefined,
     ondecommission,
     onclearmerged = undefined,
@@ -34,6 +35,8 @@
     activity: Record<string, SessionActivity>;
     // live sessionId → preview-listener port; a non-null entry surfaces the row's Preview badge
     preview?: Record<string, number | null>;
+    // live sessionId → tailscale-serve registration status; "failed" surfaces degraded badge
+    previewServe?: Record<string, "ok" | "failed">;
     // a row's Preview badge was clicked → select the session + open its Viewport preview pane
     onpreview?: (id: string) => void;
     // when provided, rows gain left-swipe-to-decommission (mobile list)
@@ -140,6 +143,7 @@
           git={git[session.id]}
           activity={activity[session.id]}
           previewPort={preview[session.id] ?? null}
+          previewServeFailed={previewServe[session.id] === "failed"}
           {onpreview}
           {ondecommission}
         />
@@ -157,6 +161,7 @@
             git={git[session.id]}
             activity={activity[session.id]}
             previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
           />
@@ -175,6 +180,7 @@
             git={git[session.id]}
             activity={activity[session.id]}
             previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
           />
@@ -193,6 +199,7 @@
             git={git[session.id]}
             activity={activity[session.id]}
             previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
           />
@@ -269,6 +276,7 @@
             git={git[session.id]}
             activity={activity[session.id]}
             previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
           />
@@ -287,6 +295,7 @@
             git={git[session.id]}
             activity={activity[session.id]}
             previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
           />
@@ -313,6 +322,7 @@
             git={git[session.id]}
             activity={activity[session.id]}
             previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
           />
@@ -339,6 +349,7 @@
             git={git[session.id]}
             activity={activity[session.id]}
             previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
           />

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -40,6 +40,7 @@
     git,
     activity,
     previewPort = null,
+    previewServeFailed = false,
     onpreview,
     ondecommission,
   }: {
@@ -52,6 +53,8 @@
     activity?: SessionActivity;
     // live preview-listener port; non-null surfaces the Preview badge (server-driven, no iframe inference)
     previewPort?: number | null;
+    // true when the server's tailscale serve registration failed; surfaces a degraded (amber) badge
+    previewServeFailed?: boolean;
     // Preview badge clicked → select this session + open its Viewport preview pane
     onpreview?: (id: string) => void;
     // when provided, the row gains a left-swipe-to-decommission gesture (mobile)
@@ -231,9 +234,12 @@
              stopPropagation so the row's select doesn't also fire. -->
         <span
           class="preview-badge"
+          class:preview-badge--degraded={previewServeFailed}
           role="button"
           tabindex="0"
-          title={m.unitrow_preview_badge()}
+          title={previewServeFailed
+            ? m.unitrow_preview_badge_degraded()
+            : m.unitrow_preview_badge()}
           onclick={(e) => {
             e.stopPropagation();
             onpreview?.(session.id);
@@ -673,6 +679,18 @@
   .preview-badge:hover,
   .preview-badge:focus-visible {
     background: color-mix(in srgb, var(--color-blue) 14%, transparent);
+  }
+
+  /* Degraded: the slot's tailscale serve mapping failed to register — the preview
+     still works on loopback but isn't exposed over Tailscale. Amber = attention/
+     degraded (not red, which is reserved for a blocked session). */
+  .preview-badge--degraded {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .preview-badge--degraded:hover,
+  .preview-badge--degraded:focus-visible {
+    background: color-mix(in srgb, var(--color-amber) 14%, transparent);
   }
 
   /* MERGING: the one colored, moving badge — amber + pulse marks the in-flight

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -67,6 +67,7 @@
     connected = true,
     git = null,
     previewPort = null,
+    previewServeFailed = false,
     openPreviewTick = 0,
     buildQueue = null,
     onSeedBuildQueue,
@@ -101,6 +102,9 @@
     /** Live preview-listener port for this session (server-driven). Non-null → the
      *  Preview tab + pane are available; the iframe URL is built from window.location. */
     previewPort?: number | null;
+    /** true when the server's tailscale serve registration failed for this session's
+     *  preview port — the preview is reachable on loopback only, not over Tailscale. */
+    previewServeFailed?: boolean;
     /** Monotonic tick bumped by a row's Preview-badge click → switch to the Preview tab. */
     openPreviewTick?: number;
     /** Current build queue for this session; updated live by WS queue:update events. */
@@ -1777,6 +1781,9 @@
           sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals allow-downloads"
         ></iframe>
         <div class="preview-foot">
+          {#if previewServeFailed}
+            <span class="preview-serve-failed">{m.viewport_preview_serve_failed()}</span>
+          {/if}
           <!-- Persistent static setup hint (NOT an auto-detected error): a blank
                frame usually means the preview port isn't tailscale-served yet, or the
                app refuses to frame via in-HTML CSP — both handled by open-in-new-tab. -->
@@ -2854,6 +2861,15 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  /* Degraded state: tailscale serve registration failed; mirrors preview-hint sizing
+     but uses amber (attention/degraded) to call out the registration failure. */
+  .preview-serve-failed {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--color-amber);
   }
   .preview-open {
     margin-left: auto;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -278,4 +278,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_fable_title",
     bodyKey: "feat_fable_body",
   },
+  {
+    // No targetId: operator-facing infra (zero manual tailscale serve setup); the only
+    // UI trace is a degraded Preview badge on failure — surface via the What's-New drawer only.
+    // Ships in the next release (1.21.0); 1.20.0 is already tagged so a 1.20.0 entry
+    // would never surface (computeNewEntries only shows sinceVersion > lastSeen).
+    id: "preview-tailscale-auto",
+    sinceVersion: "1.21.0",
+    titleKey: "feat_preview_tailscale_title",
+    bodyKey: "feat_preview_tailscale_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -446,6 +446,44 @@ test("session:archived drops the preview entry for that session", () => {
   expect(s.preview["s1"]).toBeUndefined();
 });
 
+// ── session:preview-serve ──────────────────────────────────────────────────
+
+test("setPreviewServe seeds the previewServe map for bootstrap", () => {
+  const s = new HerdStore();
+  s.setPreviewServe({ s1: "ok", s2: "failed" });
+  expect(s.previewServe["s1"]).toBe("ok");
+  expect(s.previewServe["s2"]).toBe("failed");
+});
+
+test("session:preview-serve with 'failed' sets the entry", () => {
+  const s = new HerdStore();
+  s.apply({ event: "session:preview-serve", data: { id: "s1", serve: "failed" } });
+  expect(s.previewServe["s1"]).toBe("failed");
+});
+
+test("session:preview-serve with 'ok' sets the entry", () => {
+  const s = new HerdStore();
+  s.apply({ event: "session:preview-serve", data: { id: "s1", serve: "ok" } });
+  expect(s.previewServe["s1"]).toBe("ok");
+});
+
+test("session:preview-serve with null drops the entry", () => {
+  const s = new HerdStore();
+  s.apply({ event: "session:preview-serve", data: { id: "s1", serve: "failed" } });
+  expect(s.previewServe["s1"]).toBe("failed");
+  s.apply({ event: "session:preview-serve", data: { id: "s1", serve: null } });
+  expect(s.previewServe["s1"]).toBeUndefined();
+});
+
+test("session:archived drops the previewServe entry for that session", () => {
+  const s = new HerdStore();
+  s.setAll([session("s1")]);
+  s.apply({ event: "session:preview-serve", data: { id: "s1", serve: "failed" } });
+  expect(s.previewServe["s1"]).toBe("failed");
+  s.apply({ event: "session:archived", data: { id: "s1" } });
+  expect(s.previewServe["s1"]).toBeUndefined();
+});
+
 test("session:merging sets and clears the mark", () => {
   const s = new HerdStore();
   s.setAll([session("s1"), session("s2")]);

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -45,6 +45,12 @@ export class HerdStore {
    *  server's `session:preview` event. A present, non-null value is the single
    *  source of truth for "this agent has a live preview"; absent/null = none. */
   preview = $state<Record<string, number | null>>({});
+  /** Live per-session tailscale-serve registration status (sessionId → "ok"|"failed"),
+   *  pushed by the server's `session:preview-serve` event and merged from the
+   *  /api/preview bootstrap. "failed" → the preview is reachable on loopback only
+   *  (Tailscale exposure didn't register); surfaced as a degraded Preview badge/pane.
+   *  Absent = not managed (auto off / tailscale absent) or no mapping yet. */
+  previewServe = $state<Record<string, "ok" | "failed">>({});
   /** Live backlog overview, pushed over the WS by the server's warm poller
    *  (`backlog:update`, ~every 45s). Stays null until the first push arrives —
    *  the page's instant first paint comes from a separate one-shot GET
@@ -79,6 +85,10 @@ export class HerdStore {
   /** Seed (or replace) the preview-port map after a bootstrap GET. */
   setPreview(map: Record<string, number | null>) {
     this.preview = map;
+  }
+  /** Seed (or replace) the preview-serve map after a bootstrap GET. */
+  setPreviewServe(map: Record<string, "ok" | "failed">) {
+    this.previewServe = map;
   }
   setDrain(list: DrainStatus[]) {
     this.drain = Object.fromEntries(list.map((d) => [d.repoPath, d]));
@@ -137,6 +147,14 @@ export class HerdStore {
   private setPreviewPort(id: string, port: number | null) {
     if (port == null) this.preview = dropKey(this.preview, id);
     else this.preview = { ...this.preview, [id]: port };
+  }
+
+  /** Set or clear a session's tailscale-serve registration status. null drops the
+   *  entry (not managed or cleared); "ok"/"failed" merges it in. Extracted from
+   *  apply() to keep that dispatch switch under the complexity gate. */
+  private setServe(id: string, serve: "ok" | "failed" | null) {
+    if (serve == null) this.previewServe = dropKey(this.previewServe, id);
+    else this.previewServe = { ...this.previewServe, [id]: serve };
   }
 
   /** Patch a session's name + branch, then surface the rename (esp. the async
@@ -201,6 +219,7 @@ export class HerdStore {
         this.git = dropKey(this.git, ev.data.id);
         this.activity = dropKey(this.activity, ev.data.id);
         this.preview = dropKey(this.preview, ev.data.id);
+        this.previewServe = dropKey(this.previewServe, ev.data.id);
         reviews.drop(ev.data.id);
         planGates.drop(ev.data.id);
         this.clearDraftReconcileToast(ev.data.id);
@@ -213,6 +232,9 @@ export class HerdStore {
         break;
       case "session:preview":
         this.setPreviewPort(ev.data.id, ev.data.previewPort);
+        break;
+      case "session:preview-serve":
+        this.setServe(ev.data.id, ev.data.serve);
         break;
       case "session:block":
         this.setBlock(ev.data.id, ev.data.block);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -491,6 +491,7 @@ export type WsEvent =
   | { event: "session:git"; data: { id: string; git: GitState } }
   | { event: "session:activity"; data: { id: string; activity: SessionActivity } }
   | { event: "session:preview"; data: { id: string; previewPort: number | null } }
+  | { event: "session:preview-serve"; data: { id: string; serve: "ok" | "failed" | null } }
   | { event: "update:status"; data: UpdateStatus }
   | { event: "herdr-update:status"; data: HerdrUpdateStatus }
   | { event: "star-prompt:status"; data: StarPromptStatus }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -88,12 +88,21 @@
   // Viewport so it switches to its Preview tab. A counter (not a boolean) so a
   // repeat click on the already-selected session still re-triggers the open.
   let openPreviewTick = $state(0);
-  // Flatten the /api/preview snapshot ({ id: { previewPort } }) into the store's
-  // flat sessionId → port|null map.
+  // Flatten the /api/preview snapshot ({ id: { previewPort, serve? } }) into the
+  // store's flat sessionId → port|null map (unchanged shape; serve is separate).
   function flattenPreview(
-    map: Record<string, { previewPort: number | null }>,
+    map: Record<string, { previewPort: number | null; serve?: "ok" | "failed" }>,
   ): Record<string, number | null> {
     return Object.fromEntries(Object.entries(map).map(([id, v]) => [id, v.previewPort]));
+  }
+  // Extract the tailscale-serve registration status from the /api/preview snapshot
+  // into the store's sessionId → "ok"|"failed" map (absent = not managed / no mapping).
+  function extractServe(
+    map: Record<string, { previewPort: number | null; serve?: "ok" | "failed" }>,
+  ): Record<string, "ok" | "failed"> {
+    return Object.fromEntries(
+      Object.entries(map).flatMap(([id, v]) => (v.serve ? [[id, v.serve]] : [])),
+    );
   }
   // A row asked to open its live preview: select the session, then bump the tick
   // so the Viewport flips to its Preview tab (after its own unit-switch reset).
@@ -221,7 +230,10 @@
       .then((m) => store.setActivity(m))
       .catch(() => {});
     previewStates()
-      .then((m) => store.setPreview(flattenPreview(m)))
+      .then((m) => {
+        store.setPreview(flattenPreview(m));
+        store.setPreviewServe(extractServe(m));
+      })
       .catch(() => {});
     getBacklog()
       .then((p) => (backlog = p))
@@ -501,7 +513,10 @@
       .then((m) => store.setActivity(m))
       .catch(() => {});
     previewStates()
-      .then((m) => store.setPreview(flattenPreview(m)))
+      .then((m) => {
+        store.setPreview(flattenPreview(m));
+        store.setPreviewServe(extractServe(m));
+      })
       .catch(() => {});
     getDrain()
       .then((l) => store.setDrain(l))
@@ -805,6 +820,7 @@
             git={store.git}
             activity={store.activity}
             preview={store.preview}
+            previewServe={store.previewServe}
             onpreview={openPreview}
             ondecommission={onarchive}
             {onclearmerged}
@@ -841,6 +857,7 @@
             git={store.git[selected.id]}
             previewPort={store.preview[selected.id] ?? null}
             previewHost={settings?.previewHost ?? null}
+            previewServeFailed={store.previewServe[selected.id] === "failed"}
             {openPreviewTick}
             buildQueue={store.buildQueues[selected.id] ?? null}
             onSeedBuildQueue={(q) => store.setBuildQueue(q)}
@@ -890,6 +907,7 @@
           git={store.git}
           activity={store.activity}
           preview={store.preview}
+          previewServe={store.previewServe}
           onpreview={openPreview}
           {onclearmerged}
           {onmergetrain}
@@ -913,6 +931,7 @@
             git={store.git[selected.id]}
             previewPort={store.preview[selected.id] ?? null}
             previewHost={settings?.previewHost ?? null}
+            previewServeFailed={store.previewServe[selected.id] === "failed"}
             {openPreviewTick}
             buildQueue={store.buildQueues[selected.id] ?? null}
             onSeedBuildQueue={(q) => store.setBuildQueue(q)}


### PR DESCRIPTION
Closes #403. Follow-up to #345 (per-agent preview ports) and #446/#452 (operator "Start dev server" + split-front preview URLs / eager `serveRange`).

## What

Replaces the **eager whole-range** `tailscale serve` registration at startup (#452's `serveRange`) with **dynamic per-slot** registration: Shepherd registers a `tailscale serve --bg --https=<port> 127.0.0.1:<port>` mapping the moment a preview listener binds a slot, and removes it (`--https=<port> off`) on teardown — zero operator setup, and **only in-use ports are exposed**.

- **Gated by the existing `SHEPHERD_PREVIEW_AUTO_SERVE`** flag, now flipped to **default ON** (set `0` to map the range manually). No-ops when the node's tailnet host can't be resolved (tailscale absent/down) — previews still work on loopback.
- **Cleanup:** the whole preview range is cleared at startup (recover stale mappings from a crashed prior run) and registered slots are torn down on shutdown (`exit` + `SIGTERM`).
- **Race-safe:** every serve mutation (register, unregister, each reconcile off) funnels through **one global sequential queue** — `tailscale serve` read-modify-writes tailscaled's shared config, so concurrent execs race and silently drop each other's entries (the same hard-won lesson that made #452's `serveRange` sequential).
- **Degraded surfacing:** a failed registration shows an amber (degraded) Preview badge + a note in the preview pane — the app is still reachable on loopback (fail-open). Driven by a live `session:preview-serve` WS event and merged into the `/api/preview` bootstrap.

The dynamic logic lives in `src/tailscale.ts` alongside `resolveNodeHost` (the old `serveRange` is removed; `resolveNodeHost`/`buildPreviewUrl`/`previewHost` from #452 are preserved).

## Decisions (with the maintainer)
- Replace eager with dynamic (only in-use ports exposed).
- Reuse `SHEPHERD_PREVIEW_AUTO_SERVE`, flipped to default ON.
- Drop `--yes`, matching #452's proven argv + the reaper/README form.

## Verification
- Root: `bunx tsc --noEmit` clean · `bun test ./test` 1662 pass · `bun run lint` clean
- UI: `bun run check` 0 errors · `bun run test` 733 pass · `bun run check:i18n` parity (812 keys)
- `scripts/check-branch-hygiene.sh` ✓ · `scripts/check-feature-catalog.sh` ✓ · `bunx fallow audit --base origin/main --fail-on-issues` exit 0 (dead-code 0, complexity 0)
- New unit tests: `TailscaleServeService` (global serialization proof, reconcile sequencing, fail-closed, stopAll idempotency) in `test/tailscale.test.ts`; `/api/preview` merge in `test/server.test.ts`; store `previewServe` in `ui/.../store.svelte.test.ts`.

What's-New catalog entry `preview-tailscale-auto` (1.20.0) added; README preview section reframed from manual/eager setup to automatic dynamic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)