### PR TITLE
fix(ui): scroll mobile viewport tabs, pin Start-dev-server control

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2914,8 +2914,10 @@
     min-width: 220px;
   }
   /* phone: the preview slot is pinned at the row's right edge, so a left:0
-     popover would open rightward off-screen — flip it to right-anchored.
-     Stays position:absolute (ancestors overflow:visible), so it's unclipped. */
+     popover would open rightward off-screen — flip it to right-anchored and
+     width-cap it so it drops inside the (overflow:hidden) .viewport box instead
+     of past the viewport edge. It lives in the pinned .preview-start-wrap, not
+     the .tab-scroll scroller, so the strip's overflow-x:auto never clips it. */
   .vp-head.mobile .preview-cmd-pop {
     left: auto;
     right: 0;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1436,21 +1436,23 @@
     {/if}
     <div class="spacer"></div>
     <div id={foldRegionId} class="tab-group" class:mobile={compact} class:folded={headerFolded}>
-      <button class="tab-btn" class:active={tab === "term"} onclick={() => (tab = "term")}
-        >{m.viewport_terminal_tab()}</button
-      >
-      <button class="tab-btn" class:active={tab === "todo"} onclick={() => (tab = "todo")}
-        >{m.viewport_todo_tab()}</button
-      >
-      <button class="tab-btn" class:active={tab === "issues"} onclick={() => (tab = "issues")}
-        >{m.viewport_issues_tab()}</button
-      >
-      <button class="tab-btn" class:active={tab === "activity"} onclick={() => (tab = "activity")}
-        >{m.viewport_activity_tab()}</button
-      >
-      <button class="tab-btn" class:active={tab === "diff"} onclick={() => (tab = "diff")}
-        >{m.viewport_diff_tab()}</button
-      >
+      <div class="tab-scroll">
+        <button class="tab-btn" class:active={tab === "term"} onclick={() => (tab = "term")}
+          >{m.viewport_terminal_tab()}</button
+        >
+        <button class="tab-btn" class:active={tab === "todo"} onclick={() => (tab = "todo")}
+          >{m.viewport_todo_tab()}</button
+        >
+        <button class="tab-btn" class:active={tab === "issues"} onclick={() => (tab = "issues")}
+          >{m.viewport_issues_tab()}</button
+        >
+        <button class="tab-btn" class:active={tab === "activity"} onclick={() => (tab = "activity")}
+          >{m.viewport_activity_tab()}</button
+        >
+        <button class="tab-btn" class:active={tab === "diff"} onclick={() => (tab = "diff")}
+          >{m.viewport_diff_tab()}</button
+        >
+      </div>
       {#if hasPreview}
         <!-- only while the server reports a bound preview listener (single source of
              truth: the live port). Disappears when the dev server stops. -->
@@ -2590,6 +2592,13 @@
     gap: 2px;
   }
 
+  /* transparent pass-through on desktop (matches .tab-group's flex/gap so the
+     desktop layout is visually identical); scrolls on compact/mobile below */
+  .tab-scroll {
+    display: flex;
+    gap: 2px;
+  }
+
   .back {
     background: transparent;
     border: 1px solid var(--color-line-bright);
@@ -2740,11 +2749,34 @@
     flex-basis: 100%;
     gap: 4px;
   }
+  /* phone: nav tabs scroll horizontally so the pinned preview slot (Preview tab
+     / Start-dev-server control) stays visible at the row's right edge.
+     Matches BacklogView's .overlay-tabs idiom (hidden scrollbar). */
+  .tab-group.mobile .tab-scroll {
+    flex: 1 1 0;
+    min-width: 0;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .tab-group.mobile .tab-scroll::-webkit-scrollbar {
+    display: none;
+  }
   .vp-head.mobile .tab-btn {
-    flex: 1;
     text-align: center;
     padding: 10px 6px;
     font-size: var(--fs-meta);
+  }
+  /* grow:1 fills the strip when tabs fit (no dead gap, large tap targets);
+     shrink:0 + basis:auto forces overflow→scroll when they don't */
+  .vp-head.mobile .tab-scroll .tab-btn {
+    flex: 1 0 auto;
+  }
+  /* keep the preview slot (Preview tab / Start control) pinned + always visible */
+  .tab-group.mobile .preview-start-wrap,
+  .tab-group.mobile .preview-tab {
+    flex-shrink: 0;
   }
   /* finger-sized header controls on touch layouts (≥40px) */
   .vp-head.mobile .back,
@@ -2880,6 +2912,14 @@
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
     white-space: nowrap;
     min-width: 220px;
+  }
+  /* phone: the preview slot is pinned at the row's right edge, so a left:0
+     popover would open rightward off-screen — flip it to right-anchored.
+     Stays position:absolute (ancestors overflow:visible), so it's unclipped. */
+  .vp-head.mobile .preview-cmd-pop {
+    left: auto;
+    right: 0;
+    max-width: calc(100vw - 16px);
   }
   .pcp-label {
     font-size: var(--fs-meta);


### PR DESCRIPTION
## Problem

On phones the Viewport header's tab row clipped the **`▶ Start dev server`** control to `Start de…` — the 5 nav tabs (`flex:1`) plus the long, content-sized Start control overflowed the 100%-wide row and the label was cut by `.viewport`'s `overflow:hidden`. (Reported with a screenshot showing `Diff ▸ Start de`.)

## Fix

Scroll the **nav tabs** horizontally and **pin the preview slot** (the `Preview` tab when a dev server is running, or the `Start dev server` control otherwise) always-visible at the row's right. Pure CSS + a small markup restructure — **zero JS**.

- Wrap the 5 nav tabs in an inner `.tab-scroll` strip; on mobile it's `overflow-x:auto` with a hidden scrollbar (matches the existing `BacklogView .overlay-tabs` idiom).
- Nav tabs use `flex:1 0 auto`: **grow to fill** the strip when they fit (no dead gap, finger-sized targets), **overflow→scroll** when they don't.
- Preview slot pinned `flex-shrink:0` outside the scroller → full label always visible.
- The command-input popover stays **`position:absolute`** (ancestors `overflow:visible`, so it's *not* clipped); it flips to `right:0` on mobile so it opens leftward and stays on-screen now that its anchor sits at the row's right edge.

### Why not scroll the whole row?

`overflow-x:auto` forces `overflow-y` to compute to `auto`, which would clip the popover that drops below the row — forcing a `position:fixed` workaround and a chain of edge cases (soft-keyboard viewport resize, scroll/resize/rotate detachment, the transient `.viewport` swipe `translateX` re-rooting the fixed element under `overflow:hidden`). Scrolling only the nav tabs keeps the popover's ancestor at `overflow:visible` and avoids all of it.

## Scope

- Single file: `ui/src/lib/components/Viewport.svelte`. All behavioral CSS scoped to `.tab-group.mobile` / `.vp-head.mobile` (`compact = mobile || touch`); desktop layout unchanged.
- No i18n changes (full labels retained). `fix:` not `feat`, ships no new user-facing capability → no feature-catalog entry.

## Verification

- `cd ui && bun run check` — 0 errors, 0 warnings (1781 files), pre/post-rebase onto latest `main`.
- Spec-compliance review ✅ and code-quality review ✅ (flex/overflow mechanics + CSS specificity verified; popover stays absolute and on-screen; desktop spacing unchanged — no gap doubling).
- Static verification only — please use the HUD **live preview** at phone width to confirm visually: the full `▶ Start dev server` label is reachable, nav tabs scroll, and (when an agent needs a manual command) the command popover opens fully on-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)