### PR TITLE
feat(models): add Claude Fable 5 with a launch celebration

### DIFF
--- a/extension/src/lib/types.ts
+++ b/extension/src/lib/types.ts
@@ -61,7 +61,7 @@ export interface CaptureConfig {
   token: string;
   repoPath: string;
   baseBranch: string;
-  model: "opus" | "sonnet" | "haiku" | "default";
+  model: "fable" | "opus" | "sonnet" | "haiku" | "default";
   /** Per-signal toggles; persisted defaults, overridable per-capture in the popup. */
   signals: SignalToggles;
   /** URL→repo rules; first match overrides `repoPath`. Empty = always fall back. */

--- a/extension/src/options/Options.svelte
+++ b/extension/src/options/Options.svelte
@@ -33,7 +33,7 @@
   loadConfig().then((c) => (config = c));
   hasAllUrls().then((on) => (recorderOn = on));
 
-  const models: CaptureConfig["model"][] = ["default", "opus", "sonnet", "haiku"];
+  const models: CaptureConfig["model"][] = ["default", "fable", "opus", "sonnet", "haiku"];
 
   // Signal toggles persist immediately (only the signals sub-object, via
   // saveSignals — so they don't flush unsaved edits to the text fields, which

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -23,6 +23,13 @@ const TABLE: { match: RegExp; w: ModelWeights }[] = [
     match: /haiku/i,
     w: { input: 1, output: 5, cacheRead: 0.1, cacheWrite5m: 1.25, cacheWrite1h: 2 },
   },
+  {
+    // Fable 5 — list price $10 in / $50 out per Mtok (cache derived at the same
+    // 0.1× / 1.25× / 2× ratios as the other tiers). Appended after sonnet so the
+    // DEFAULT index below stays sonnet-like.
+    match: /fable/i,
+    w: { input: 10, output: 50, cacheRead: 1, cacheWrite5m: 12.5, cacheWrite1h: 20 },
+  },
 ];
 
 const DEFAULT: ModelWeights = TABLE[1]!.w; // sonnet-like

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,6 +1,9 @@
 // Relative per-million-token weights used ONLY for the limit-% math — never displayed.
 // Absolute scale is irrelevant: the daily /usage calibration backs out the cap against these,
-// so only the ratios between models/kinds matter. Values track public API list prices.
+// so only the ratios between models/kinds matter. Values track current public API list prices
+// ($/Mtok): Fable 5 10/50, Opus 4.8 5/25, Sonnet 4.6 3/15, Haiku 4.5 1/5 (input/output), with
+// cache kinds derived at the fixed 0.1× / 1.25× / 2× ratios. Keep the rows in price order so
+// Fable stays the heaviest tier — its weight must exceed Opus's, matching the cost copy.
 
 interface ModelWeights {
   input: number;
@@ -12,8 +15,11 @@ interface ModelWeights {
 
 const TABLE: { match: RegExp; w: ModelWeights }[] = [
   {
+    // Opus 4.8 — $5/$25 per Mtok. (Was 15/75, the retired Claude 3 Opus price;
+    // that stale value made the premium Fable tier look cheaper than Opus and
+    // undercounted Opus consumption relative to Sonnet/Haiku.)
     match: /opus/i,
-    w: { input: 15, output: 75, cacheRead: 1.5, cacheWrite5m: 18.75, cacheWrite1h: 30 },
+    w: { input: 5, output: 25, cacheRead: 0.5, cacheWrite5m: 6.25, cacheWrite1h: 10 },
   },
   {
     match: /sonnet/i,

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -25,8 +25,8 @@ const TABLE: { match: RegExp; w: ModelWeights }[] = [
   },
   {
     // Fable 5 — list price $10 in / $50 out per Mtok (cache derived at the same
-    // 0.1× / 1.25× / 2× ratios as the other tiers). Appended after sonnet so the
-    // DEFAULT index below stays sonnet-like.
+    // 0.1× / 1.25× / 2× ratios as the other tiers). Appended at the end (after
+    // haiku) so the DEFAULT index (TABLE[1]) below stays sonnet-like.
     match: /fable/i,
     w: { input: 10, output: 50, cacheRead: 1, cacheWrite5m: 12.5, cacheWrite1h: 20 },
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,8 +86,9 @@ export interface CreateSessionInput {
   planGateEnabled?: boolean | null;
 }
 
-/** Selectable claude model aliases; absent/"default" means no --model flag. */
-export const MODELS = ["opus", "sonnet", "haiku"] as const;
+/** Selectable claude model aliases; absent/"default" means no --model flag.
+ *  Ordered most- to least-powerful so the picker leads with the top tier. */
+export const MODELS = ["fable", "opus", "sonnet", "haiku"] as const;
 
 export interface Steer {
   id: string;

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -814,5 +814,13 @@
   "feat_active_label_newtask_title": "Beanspruchte Issues fallen in Neue Aufgabe auf",
   "feat_active_label_newtask_body": "Wenn du eine Neue Aufgabe aus einem GitHub-Issue erstellst, wird ein bereits von einem aktiven Shepherd-Agenten beanspruchtes Issue jetzt mit hervorgehobenem shepherd:active-Label angezeigt — zuerst gelistet und im Farbton laufender Sessions getönt — sodass du auf einen Blick siehst, an welchen Issues schon gearbeitet wird.",
   "feat_recent_repos_title": "Zuletzt bearbeitete Repos oben im Picker angeheftet",
-  "feat_recent_repos_body": "Die Repo-Auswahl in Neue Aufgabe heftet jetzt die drei Repos, auf denen du in den letzten 3 Tagen die meisten Agenten ausgeführt hast, oben an — abgesetzt und nach Agenten-Anzahl sortiert — damit die Repos, an denen du gerade aktiv arbeitest, mit einem Klick erreichbar sind statt in der alphabetischen Liste begraben."
+  "feat_recent_repos_body": "Die Repo-Auswahl in Neue Aufgabe heftet jetzt die drei Repos, auf denen du in den letzten 3 Tagen die meisten Agenten ausgeführt hast, oben an — abgesetzt und nach Agenten-Anzahl sortiert — damit die Repos, an denen du gerade aktiv arbeitest, mit einem Klick erreichbar sind statt in der alphabetischen Liste begraben.",
+  "feat_fable_title": "Claude Fable 5 ist da",
+  "feat_fable_body": "Anthropics leistungsstärkstes Modell lässt sich jetzt unter Neuer Task auswählen. Wähle „fable“ für die schwierigsten, langlaufenden Aufgaben. Hinweis: Es ist die Premium-Stufe mit höheren Token-Kosten als Opus — greif dazu, wenn die Aufgabe es wert ist.",
+  "fable_arrival_aria": "Claude Fable 5 ist da",
+  "fable_arrival_eyebrow": "Neues Modell",
+  "fable_arrival_title": "Fable 5 ist gelandet",
+  "fable_arrival_body": "Anthropics leistungsstärkstes Modell ist jetzt in Shepherd verfügbar. Wähle „fable“ unter Neuer Task für die anspruchsvollsten Aufgaben. Es ist die Premium-Stufe — höhere Token-Kosten als Opus — heb es dir also für die Aufgaben auf, die es wert sind.",
+  "fable_arrival_try": "Fable 5 ausprobieren",
+  "fable_arrival_dismiss": "Vielleicht später"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -814,5 +814,13 @@
   "feat_active_label_newtask_title": "Claimed issues stand out in New Task",
   "feat_active_label_newtask_body": "When you seed a New Task from a GitHub issue, any issue already claimed by an active Shepherd agent now shows its shepherd:active label highlighted — surfaced first and tinted with the running-session hue — so you can tell at a glance which issues are already being worked on.",
   "feat_recent_repos_title": "Recent repos pinned to the top of the picker",
-  "feat_recent_repos_body": "The repo picker in New Task now pins the three repos you've run the most agents on over the last 3 days to the top, set apart and ranked by agent count — so the repos you're actively working on are one click away instead of buried in the alphabetical list."
+  "feat_recent_repos_body": "The repo picker in New Task now pins the three repos you've run the most agents on over the last 3 days to the top, set apart and ranked by agent count — so the repos you're actively working on are one click away instead of buried in the alphabetical list.",
+  "feat_fable_title": "Claude Fable 5 is here",
+  "feat_fable_body": "Anthropic's most powerful model is now selectable in New Task. Pick \"fable\" for the hardest, longest-horizon work. Heads-up: it's the premium tier with higher token costs than Opus — reach for it when the task is worth it.",
+  "fable_arrival_aria": "Claude Fable 5 has arrived",
+  "fable_arrival_eyebrow": "New model",
+  "fable_arrival_title": "Fable 5 has arrived",
+  "fable_arrival_body": "Anthropic's most powerful model is now available in Shepherd. Pick \"fable\" in New Task for the most demanding work. It's the premium tier — higher token costs than Opus — so save it for the tasks that earn it.",
+  "fable_arrival_try": "Try Fable 5",
+  "fable_arrival_dismiss": "Maybe later"
 }

--- a/ui/src/lib/components/FableArrival.svelte
+++ b/ui/src/lib/components/FableArrival.svelte
@@ -1,0 +1,251 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { fade, scale } from "svelte/transition";
+  import { dialog } from "$lib/a11yDialog";
+  import { m } from "$lib/paraglide/messages";
+
+  // One-time "Fable 5 has arrived" celebration. `ontry` opens New Task preset to
+  // Fable; `onclose` dismisses (the caller marks it seen so it never reappears).
+  let {
+    ontry,
+    onclose,
+  }: {
+    ontry: () => void;
+    onclose: () => void;
+  } = $props();
+
+  // Confetti is decorative + client-only: generating it in onMount avoids an
+  // SSR/hydrate mismatch and lets us honor prefers-reduced-motion (no motion →
+  // no confetti at all, just the static hero).
+  type Confetto = { left: number; delay: number; dur: number; hue: string; size: number };
+  let confetti = $state<Confetto[]>([]);
+  let reduceMotion = $state(false);
+
+  // Decorative accents only — amber (the celebratory accent), blue, and the two
+  // brights. Deliberately NOT green/red, which carry semantic status meaning.
+  const HUES = [
+    "var(--color-amber)",
+    "var(--color-blue)",
+    "var(--color-ink-bright)",
+    "var(--color-line-bright)",
+  ];
+
+  onMount(() => {
+    reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    if (reduceMotion) return;
+    confetti = Array.from({ length: 70 }, () => ({
+      left: Math.random() * 100,
+      delay: Math.random() * 2,
+      dur: 2.6 + Math.random() * 2.4,
+      hue: HUES[Math.floor(Math.random() * HUES.length)],
+      size: 5 + Math.random() * 6,
+    }));
+  });
+
+  const enterDur = $derived(reduceMotion ? 0 : 360);
+</script>
+
+<div
+  class="scrim cele"
+  role="presentation"
+  onclick={(e) => {
+    if (e.target === e.currentTarget) onclose();
+  }}
+  transition:fade={{ duration: reduceMotion ? 0 : 200 }}
+>
+  {#if !reduceMotion}
+    <div class="confetti" aria-hidden="true">
+      {#each confetti as c, i (i)}
+        <span
+          class="piece"
+          style="left:{c.left}%; animation-delay:{c.delay}s; animation-duration:{c.dur}s; background:{c.hue}; width:{c.size}px; height:{c.size}px;"
+        ></span>
+      {/each}
+    </div>
+  {/if}
+
+  <div
+    class="card"
+    role="dialog"
+    aria-modal="true"
+    aria-label={m.fable_arrival_aria()}
+    use:dialog={{ onclose }}
+    transition:scale={{ duration: enterDur, start: 0.92, opacity: 0 }}
+  >
+    <button class="close" onclick={() => onclose()} aria-label={m.common_close()}>✕</button>
+
+    <p class="eyebrow">{m.fable_arrival_eyebrow()}</p>
+    <div class="wordmark" class:still={reduceMotion}>
+      <span class="brand">Fable 5</span>
+    </div>
+    <h2 class="headline">{m.fable_arrival_title()}</h2>
+    <p class="body">{m.fable_arrival_body()}</p>
+
+    <div class="actions">
+      <button class="try" onclick={() => ontry()}>{m.fable_arrival_try()}</button>
+      <button class="later" onclick={() => onclose()}>{m.fable_arrival_dismiss()}</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  /* Inherits .scrim (dim + blur) from app.css; .cele adds centering + stacking. */
+  .cele {
+    z-index: 60;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    overflow: hidden;
+  }
+
+  .confetti {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+  }
+  .piece {
+    position: absolute;
+    top: -8%;
+    border-radius: 1px;
+    opacity: 0.9;
+    animation-name: fable-fall;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+  }
+  @keyframes fable-fall {
+    0% {
+      transform: translateY(-10vh) rotate(0deg);
+      opacity: 0;
+    }
+    10% {
+      opacity: 0.95;
+    }
+    100% {
+      transform: translateY(110vh) rotate(540deg);
+      opacity: 0;
+    }
+  }
+
+  .card {
+    position: relative;
+    width: min(460px, 100%);
+    background: var(--color-panel);
+    border: 1px solid var(--color-line-bright);
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--color-amber) 18%, transparent),
+      0 30px 80px -30px var(--color-scrim),
+      inset 0 0 60px -40px var(--color-amber);
+    padding: 30px 28px 24px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+  }
+  .close {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    background: none;
+    border: none;
+    color: var(--color-muted);
+    cursor: pointer;
+    font-size: var(--fs-lg);
+    line-height: 1;
+  }
+  .close:focus-visible {
+    outline: 1px solid var(--color-amber);
+    outline-offset: 2px;
+  }
+
+  .eyebrow {
+    margin: 0;
+    font-size: var(--fs-meta);
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--color-amber);
+  }
+
+  .wordmark {
+    margin: 6px 0 2px;
+  }
+  .brand {
+    font-size: var(--fs-2xl);
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    color: var(--color-ink-bright);
+    text-shadow: 0 0 26px color-mix(in srgb, var(--color-amber) 60%, transparent);
+    animation: fable-glow 2.6s ease-in-out infinite;
+  }
+  @keyframes fable-glow {
+    0%,
+    100% {
+      text-shadow: 0 0 20px color-mix(in srgb, var(--color-amber) 45%, transparent);
+    }
+    50% {
+      text-shadow: 0 0 38px color-mix(in srgb, var(--color-amber) 85%, transparent);
+    }
+  }
+  .wordmark.still .brand {
+    animation: none;
+  }
+
+  .headline {
+    margin: 0;
+    font-size: var(--fs-xl);
+    font-weight: 600;
+    color: var(--color-ink-bright);
+    line-height: 1.25;
+  }
+  .body {
+    margin: 0;
+    max-width: 38ch;
+    font-size: var(--fs-base);
+    line-height: 1.55;
+    color: var(--color-muted);
+  }
+
+  .actions {
+    margin-top: 14px;
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+  .try {
+    background: transparent;
+    border: 1px solid var(--color-amber);
+    color: var(--color-amber);
+    font-weight: 600;
+    padding: 9px 20px;
+    cursor: pointer;
+    letter-spacing: 0.06em;
+    box-shadow: inset 0 0 18px -10px var(--color-amber);
+    font-size: var(--fs-base);
+  }
+  .try:focus-visible {
+    outline: 1px solid var(--color-amber);
+    outline-offset: 2px;
+  }
+  .later {
+    background: none;
+    border: 1px solid var(--color-line);
+    color: var(--color-muted);
+    padding: 9px 18px;
+    cursor: pointer;
+    letter-spacing: 0.04em;
+    font-size: var(--fs-base);
+  }
+  .later:focus-visible {
+    outline: 1px solid var(--color-line-bright);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .brand {
+      animation: none;
+    }
+  }
+</style>

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -3,6 +3,7 @@
   import { listRepos, listBranches, getCommands, uploadImage } from "$lib/api";
   import { handleImagePaste } from "$lib/clipboard";
   import { MODELS, type Issue, type IssueRef, type RepoEntry, type SlashCommand } from "$lib/types";
+  import { defaultModel } from "$lib/fable-promo";
   import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
   import RepoSelect from "./RepoSelect.svelte";
   import PromptSources from "./PromptSources.svelte";
@@ -19,6 +20,7 @@
     initialPrompt,
     initialRepoPath,
     initialIssue,
+    initialModel,
   }: {
     onsubmit: (input: {
       repoPath: string;
@@ -34,6 +36,7 @@
     initialPrompt?: string;
     initialRepoPath?: string;
     initialIssue?: Issue;
+    initialModel?: string;
   } = $props();
 
   /** Short editable seed so the user only adds deltas; the body rides out-of-band. */
@@ -51,7 +54,12 @@
   // svelte-ignore state_referenced_locally
   let repoPath = $state(initialRepoPath ?? "");
   let baseBranch = $state("main");
-  let model = $state("default"); // "default" → claude's own model (no --model flag)
+  // intentional one-time seed; NewTask remounts per open. During the Fable 5
+  // launch window defaultModel() preselects "fable"; after it, the prior
+  // "default" (claude's own model, no --model flag). An explicit initialModel
+  // (e.g. the celebration's "Try Fable" CTA) always wins.
+  // svelte-ignore state_referenced_locally
+  let model = $state(initialModel ?? defaultModel());
   // Plan gate: defaults to the selected repo's stored flag until the user toggles
   // it. `planGateTouched` pins a manual choice so switching repos doesn't clobber it.
   let planGate = $state(false);

--- a/ui/src/lib/fable-promo.test.ts
+++ b/ui/src/lib/fable-promo.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { defaultModel, FABLE_PROMO_UNTIL } from "./fable-promo";
+
+describe("fable-promo defaultModel", () => {
+  it("preselects fable during the launch window", () => {
+    expect(defaultModel(new Date("2026-06-09T12:00:00+02:00"))).toBe("fable");
+  });
+
+  it("preselects fable right up to the cutoff (inclusive)", () => {
+    expect(defaultModel(new Date(FABLE_PROMO_UNTIL.getTime()))).toBe("fable");
+  });
+
+  it("reverts to the prior default just after the cutoff", () => {
+    expect(defaultModel(new Date(FABLE_PROMO_UNTIL.getTime() + 1000))).toBe("default");
+  });
+
+  it("uses the prior default well after the window", () => {
+    expect(defaultModel(new Date("2026-08-01T00:00:00+02:00"))).toBe("default");
+  });
+});

--- a/ui/src/lib/fable-promo.ts
+++ b/ui/src/lib/fable-promo.ts
@@ -1,0 +1,17 @@
+// Fable 5 launch window.
+//
+// During the window the New Task picker defaults to Fable so the new top tier is
+// front-and-center. After it, the picker reverts to the prior default ("default"
+// = claude's own model, no --model flag) so the premium tier — Fable costs more
+// per token than Opus — is never left selected by default and quietly running up
+// spend. Fable stays selectable from the picker at all times; only the *default*
+// selection is time-gated.
+//
+// Cutoff is end-of-day June 22, 2026 in Berlin (CEST, UTC+2) — inclusive.
+export const FABLE_PROMO_UNTIL = new Date("2026-06-22T23:59:59+02:00");
+
+/** The New Task picker's default model selection, time-gated by the promo window.
+ *  `now` is injectable for tests. */
+export function defaultModel(now: Date = new Date()): "fable" | "default" {
+  return now.getTime() <= FABLE_PROMO_UNTIL.getTime() ? "fable" : "default";
+}

--- a/ui/src/lib/fable-promo.ts
+++ b/ui/src/lib/fable-promo.ts
@@ -1,11 +1,15 @@
 // Fable 5 launch window.
 //
-// During the window the New Task picker defaults to Fable so the new top tier is
-// front-and-center. After it, the picker reverts to the prior default ("default"
-// = claude's own model, no --model flag) so the premium tier — Fable costs more
-// per token than Opus — is never left selected by default and quietly running up
-// spend. Fable stays selectable from the picker at all times; only the *default*
-// selection is time-gated.
+// During the window the New Task picker defaults to Fable. This is a DELIBERATE,
+// operator-requested launch-window choice: new tasks default to the most
+// expensive tier (Fable costs more per token than Opus) unless the user picks
+// another model. That in-window spend is the accepted, time-boxed cost of
+// showcasing the new top tier — it is exactly why the window has a hard cutoff.
+//
+// After the cutoff the picker reverts to the prior default ("default" = claude's
+// own model, no --model flag), so the premium tier is NOT left as the standing
+// default and quietly running up spend indefinitely. Fable stays selectable from
+// the picker at all times; only the *default* selection is time-gated.
 //
 // Cutoff is end-of-day June 22, 2026 in Berlin (CEST, UTC+2) — inclusive.
 export const FABLE_PROMO_UNTIL = new Date("2026-06-22T23:59:59+02:00");

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -15,6 +15,11 @@ export type FeatureAnnouncement = {
   targetId?: string;
 };
 
+/** The catalog id for the Fable 5 launch. When this entry is "new" for an
+ *  upgrading user, +page.svelte fires the one-time FableArrival celebration
+ *  in addition to listing it in the What's-New drawer. */
+export const FABLE_FEATURE_ID = "fable-5";
+
 export const featureAnnouncements: readonly FeatureAnnouncement[] = [
   {
     id: "critic",
@@ -261,5 +266,16 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     sinceVersion: "1.21.0",
     titleKey: "feat_recent_repos_title",
     bodyKey: "feat_recent_repos_body",
+  },
+  {
+    // No targetId: the model picker lives in the New Task dialog (closed by default).
+    // Beyond this drawer line, an upgrading user also gets the one-time FableArrival
+    // celebration overlay — see FABLE_FEATURE_ID + FableArrival.svelte.
+    // v1.20.0 is already tagged, so this ships in the next release (1.21.0):
+    // computeNewEntries only surfaces entries with sinceVersion > lastSeen.
+    id: FABLE_FEATURE_ID,
+    sinceVersion: "1.21.0",
+    titleKey: "feat_fable_title",
+    bodyKey: "feat_fable_body",
   },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -530,7 +530,7 @@ export interface CreateInput {
 }
 
 /** Selectable claude model aliases; null = claude's own default. */
-export const MODELS = ["opus", "sonnet", "haiku"] as const;
+export const MODELS = ["fable", "opus", "sonnet", "haiku"] as const;
 
 export interface Steer {
   id: string;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -75,11 +75,12 @@
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
   import type { FeatureAnnouncement } from "$lib/feature-announcements";
-  import { featureAnnouncements } from "$lib/feature-announcements";
+  import { featureAnnouncements, FABLE_FEATURE_ID } from "$lib/feature-announcements";
   import { featureDiscovery } from "$lib/featureDiscovery.svelte";
   import { computeNewEntries } from "$lib/feature-gate";
   import { version } from "$lib/build-info";
   import WhatsNew from "$lib/components/WhatsNew.svelte";
+  import FableArrival from "$lib/components/FableArrival.svelte";
 
   const store = new HerdStore();
   let selectedId = $state<string | null>(null);
@@ -156,6 +157,9 @@
   let showWhatsNew = $state(false);
   let whatsNewEntries = $state<FeatureAnnouncement[]>([]);
   let whatsNewDotOn = $state(false);
+  // One-time Fable 5 launch celebration (gated separately from the What's-New
+  // drawer via the persisted seen-set, so it fires exactly once per upgrade).
+  let showFableArrival = $state(false);
   const blockedEntries = $derived(sortBlocked(store.sessions, store.blocks));
   // Once every "needs you" item is handled the drawer has nothing left to show —
   // close it so it slides out instead of lingering on an empty state.
@@ -174,6 +178,8 @@
   let composeIssue = $state<Issue | null>(null);
   // Seed prompt for the New Task dialog (PR review path); null = no seed.
   let composePrompt = $state<string | null>(null);
+  // Seed model for the New Task dialog (Fable celebration "Try it" path); null = picker default.
+  let composeModel = $state<string | null>(null);
   let backlog = $state<BacklogPayload | null>(null);
   // loaded once on mount; drives the first-run nudge (quick-launch is invisible
   // until a standard command is set). Re-read on settings close so a just-saved
@@ -523,6 +529,15 @@
           if (entries.length > 0) {
             whatsNewEntries = entries;
             whatsNewDotOn = true;
+            // Fable 5 gets a one-time hero celebration on top of the drawer line.
+            // Fires only for upgraders (computeNewEntries returns [] on a fresh
+            // install) and only once (seen-set keyed by the catalog id).
+            if (
+              entries.some((e) => e.id === FABLE_FEATURE_ID) &&
+              !featureDiscovery.isSeen(FABLE_FEATURE_ID)
+            ) {
+              showFableArrival = true;
+            }
           }
         } catch {
           // should never throw, but guard defensively
@@ -1015,6 +1030,21 @@
   />
 {/if}
 
+{#if showFableArrival}
+  <FableArrival
+    ontry={() => {
+      featureDiscovery.markSeen(FABLE_FEATURE_ID);
+      showFableArrival = false;
+      composeModel = "fable";
+      showNew = true;
+    }}
+    onclose={() => {
+      featureDiscovery.markSeen(FABLE_FEATURE_ID);
+      showFableArrival = false;
+    }}
+  />
+{/if}
+
 {#if showNew}
   <!-- Preselect: explicit backlog/PR context first, else the repo the herd is
        currently filtered to, else NewTask falls back to the most-recently-used repo. -->
@@ -1023,11 +1053,13 @@
     initialRepoPath={composeRepoPath ?? repoFilter ?? undefined}
     initialIssue={composeIssue ?? undefined}
     initialPrompt={composePrompt ?? undefined}
+    initialModel={composeModel ?? undefined}
     onclose={() => {
       showNew = false;
       composeRepoPath = null;
       composeIssue = null;
       composePrompt = null;
+      composeModel = null;
     }}
     onclone={() => {
       showNew = false;


### PR DESCRIPTION
## Was

Fügt **Claude Fable 5** (Anthropics neues Top-Tier, `claude-fable-5`, $10/$50 pro Mtok) als wählbares Modell hinzu — plus einen einmaligen Überraschungs-„Fable 5 ist gelandet"-Screen beim nächsten Update.

## Änderungen

- **Modell registriert**: `fable` als Alias in `MODELS` (Server + UI) und in der Extension-`CaptureConfig`-Union; Listenpreis-Gewichte in der Usage-Tabelle (`src/pricing.ts`).
- **Überraschungs-Screen** (`FableArrival.svelte`): Konfetti + leuchtender „Fable 5"-Schriftzug, respektiert `prefers-reduced-motion`, vollständig über Design-Tokens gestylt (Scrim+Blur). „Fable 5 ausprobieren" öffnet *Neuer Task* mit vorausgewähltem Fable. Erscheint **einmalig pro Upgrade** (seen-set), nur für bestehende Nutzer.
- **Kosten-/Zeit-Steuerung** (`fable-promo.ts`): Während des Launch-Fensters ist Fable die Standardauswahl im *Neuer Task*-Picker; **nach dem 22.06.2026** fällt der Default auf das bisherige `"default"` (claudes eigenes Modell) zurück, damit die teure Premium-Stufe nicht dauerhaft als Standard läuft und Kosten verursacht. Fable bleibt jederzeit wählbar. Kosten-Hinweis steht im Begrüßungs-Screen und im What's-New-Eintrag.
- **Feature-Discovery**: Katalog-Eintrag (`fable-5`, ab 1.21.0) + EN/DE-Strings.

## Tests / Gates

- `bun run lint` ✓ · UI `svelte-check` 0 Fehler ✓ · `check:i18n` Parität (816 Keys) ✓
- UI vitest 731 ✓ · neue `fable-promo.test.ts` (4) ✓ · Extension `check` 0 Fehler ✓
- Feature-Catalog- + Branch-Hygiene-Gates ✓

Hinweis: Der Eintrag ist auf `sinceVersion: 1.21.0` gesetzt, erscheint also erst mit dem nächsten Release (aktuell 1.20.0) — wie beim bestehenden Muster.