### PR TITLE
fix(newtask): preselect the active repo filter when composing a task

### DIFF
--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1017,9 +1017,11 @@
 {/if}
 
 {#if showNew}
+  <!-- Preselect: explicit backlog/PR context first, else the repo the herd is
+       currently filtered to, else NewTask falls back to the most-recently-used repo. -->
   <NewTask
     {onsubmit}
-    initialRepoPath={composeRepoPath ?? undefined}
+    initialRepoPath={composeRepoPath ?? repoFilter ?? undefined}
     initialIssue={composeIssue ?? undefined}
     initialPrompt={composePrompt ?? undefined}
     onclose={() => {


### PR DESCRIPTION
## Problem

Mit dem Herd auf ein Repo gefiltert (z. B. `epamano-shopify`) öffnete `+ Neue Aufgabe` den Dialog trotzdem auf dem zuletzt benutzten Repo (oft `shepherd`). Der aktive Filter wurde bei der Repo-Vorauswahl ignoriert.

## Fix

In `ui/src/routes/+page.svelte` schiebt der `initialRepoPath` des NewTask-Dialogs jetzt den aktiven Filter als Fallback ein:

```svelte
initialRepoPath={composeRepoPath ?? repoFilter ?? undefined}
```

Präzedenz:
1. **Backlog-/PR-Kontext** (`composeRepoPath`) — unverändert höchste Priorität
2. **Aktiver Repo-Filter** (`repoFilter`) — neu: filtert der Herd auf ein Repo, wird die Aufgabe dort erstellt
3. **Kein Filter** → NewTask fällt wie bisher auf das zuletzt benutzte Repo zurück (`defaultRepoPath`)

## Verifikation

- `cd ui && bun run check` → 0 Fehler, 0 Warnungen
- Reine Logik-/Präzedenz-Änderung, keine neuen UI-Strings → i18n unberührt

[no-feature-entry] — Verfeinerung bestehenden Verhaltens, kein neues Discovery-würdiges Feature.