### PR TITLE
fix(queue-strip): hide repo-status band when it carries no value; stop full-width stretch

### DIFF
--- a/ui/src/lib/components/QueueStrip.svelte
+++ b/ui/src/lib/components/QueueStrip.svelte
@@ -1,11 +1,5 @@
 <script lang="ts">
-  import type {
-    AutoMergeStatus,
-    DrainStatus,
-    Learning,
-    QueuedItem,
-    RepoInjectable,
-  } from "$lib/types";
+  import type { AutoMergeStatus, DrainStatus, QueuedItem } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { getDrainQueue } from "$lib/api";
   import { basename } from "./learnings-drawer";
@@ -16,33 +10,25 @@
     mergeTrainLabel,
     pausedText,
     queueOpenable,
-    repoStatusRows,
   } from "./queue-strip";
+  import type { RepoStatusRow } from "./queue-strip";
 
   let {
-    drain,
+    // precomputed repo-status rows (single source lives in +page); the band lists these.
+    rows = [],
     autoMerge = {},
-    items = [],
-    injectable = [],
-    runningRepoPaths = new Set(),
     onlearnings,
     repoFilter = null,
     onrepofilter,
   }: {
-    drain: Record<string, DrainStatus>;
+    rows?: RepoStatusRow[];
     autoMerge?: Record<string, AutoMergeStatus>;
-    items?: Learning[];
-    injectable?: RepoInjectable[];
-    // repo paths that currently have a running agent — the band lists only these.
-    runningRepoPaths?: Set<string>;
     onlearnings?: (repoPath: string) => void;
     // active herd repo filter (full repo path), or null when showing all repos
     repoFilter?: string | null;
     // toggle the herd filter for a repo; null clears it. Absent → repo names are inert.
     onrepofilter?: (repoPath: string | null) => void;
   } = $props();
-
-  const rows = $derived(repoStatusRows(drain, items, injectable, runningRepoPaths));
   const mergeRows = $derived(activeMergeTrain(autoMerge));
   // Only render when the band carries value (info row, or ≥2 repos so the herd
   // filter is useful); a single bare name-only row is suppressed.

--- a/ui/src/lib/components/QueueStrip.svelte
+++ b/ui/src/lib/components/QueueStrip.svelte
@@ -11,6 +11,7 @@
   import { basename } from "./learnings-drawer";
   import {
     activeMergeTrain,
+    bandHasValue,
     mergeTrainIsAttention,
     mergeTrainLabel,
     pausedText,
@@ -43,6 +44,9 @@
 
   const rows = $derived(repoStatusRows(drain, items, injectable, runningRepoPaths));
   const mergeRows = $derived(activeMergeTrain(autoMerge));
+  // Only render when the band carries value (info row, or ≥2 repos so the herd
+  // filter is useful); a single bare name-only row is suppressed.
+  const showBand = $derived(bandHasValue(rows));
 
   // Lazy queue popover: at most one open at a time, fetched fresh on open.
   let openRepo = $state<string | null>(null);
@@ -81,7 +85,7 @@
 
 <svelte:window onkeydown={onWindowKeydown} onpointerdown={onWindowPointerdown} />
 
-{#if rows.length > 0}
+{#if showBand}
   <div class="queue-strip" role="status" aria-label={m.repo_status_label()} bind:this={stripEl}>
     <span class="qs-label">{m.repo_status_label()}</span>
     <ul class="qs-rows">
@@ -216,6 +220,9 @@
     border-radius: 2px;
     background: var(--color-panel);
     font-family: var(--font-mono);
+    /* override the parent .chrome column's default align-items:stretch so the
+       band shrink-wraps its content instead of spanning the full viewport width */
+    align-self: flex-start;
   }
   .qs-label {
     font-size: var(--fs-micro);

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   activeMergeTrain,
+  bandHasValue,
   enabledDrains,
   mergeTrainIsAttention,
   mergeTrainLabel,
@@ -8,6 +9,7 @@ import {
   queueOpenable,
   repoStatusRows,
 } from "./queue-strip";
+import type { RepoStatusRow } from "./queue-strip";
 import type { AutoMergeStatus, DrainStatus, Learning, RepoInjectable } from "../types";
 
 function drain(over: Partial<DrainStatus>): DrainStatus {
@@ -292,5 +294,40 @@ describe("repoStatusRows", () => {
 
   it("returns an empty list when no repo has a running agent", () => {
     expect(repoStatusRows({ a: drain({}) }, [learning({})], [], running())).toEqual([]);
+  });
+});
+
+describe("bandHasValue", () => {
+  function row(over: Partial<RepoStatusRow>): RepoStatusRow {
+    return { repoPath: "/repos/a", drain: null, insights: 0, curate: 0, ...over };
+  }
+
+  it("single bare name-only row → false", () => {
+    expect(bandHasValue([row({ drain: null, insights: 0, curate: 0 })])).toBe(false);
+  });
+
+  it("single row with an enabled drain → true", () => {
+    expect(bandHasValue([row({ drain: drain({}), insights: 0, curate: 0 })])).toBe(true);
+  });
+
+  it("single row with insights → true", () => {
+    expect(bandHasValue([row({ drain: null, insights: 1, curate: 0 })])).toBe(true);
+  });
+
+  it("single row with curate (no insights) → true", () => {
+    expect(bandHasValue([row({ drain: null, insights: 0, curate: 2 })])).toBe(true);
+  });
+
+  it("two bare name-only rows → true", () => {
+    expect(
+      bandHasValue([
+        row({ repoPath: "/repos/a", drain: null, insights: 0, curate: 0 }),
+        row({ repoPath: "/repos/b", drain: null, insights: 0, curate: 0 }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("empty array → false", () => {
+    expect(bandHasValue([])).toBe(false);
   });
 });

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -67,6 +67,14 @@ export function repoStatusRows(
     .sort((a, b) => a.repoPath.localeCompare(b.repoPath));
 }
 
+/** Whether the repo-status band carries enough value to render: at least one row
+ *  has drain/queue/learnings info, OR ≥2 repos run (so the herd filter is useful).
+ *  A single bare name-only row is pure noise — hide the whole band. */
+export function bandHasValue(rows: RepoStatusRow[]): boolean {
+  if (rows.length >= 2) return true;
+  return rows.some((r) => r.drain !== null || r.insights > 0 || r.curate > 0);
+}
+
 /** Whether the `queued` indicator is an interactive trigger (opens the queue
  *  popover) rather than inert text — true only when something is actually queued. */
 export function queueOpenable(d: DrainStatus): boolean {

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -69,7 +69,10 @@ export function repoStatusRows(
 
 /** Whether the repo-status band carries enough value to render: at least one row
  *  has drain/queue/learnings info, OR ≥2 repos run (so the herd filter is useful).
- *  A single bare name-only row is pure noise — hide the whole band. */
+ *  The ≥2-rows case earns its space only because the band's repo-name buttons are
+ *  interactive herd filters — i.e. QueueStrip is given `onrepofilter`. Without that
+ *  the names are inert and ≥2 bare rows show nothing actionable. A single bare
+ *  name-only row is pure noise — hide the whole band. */
 export function bandHasValue(rows: RepoStatusRow[]): boolean {
   if (rows.length >= 2) return true;
   return rows.some((r) => r.drain !== null || r.insights > 0 || r.curate > 0);

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -64,7 +64,7 @@
   import ActionBar from "$lib/components/ActionBar.svelte";
   import HerdGrid from "$lib/components/HerdGrid.svelte";
   import QueueStrip from "$lib/components/QueueStrip.svelte";
-  import { repoStatusRows } from "$lib/components/queue-strip";
+  import { bandHasValue, repoStatusRows } from "$lib/components/queue-strip";
   import BacklogView from "$lib/components/BacklogView.svelte";
   import BacklogOverlay from "$lib/components/BacklogOverlay.svelte";
   import UpdateModal from "$lib/components/UpdateModal.svelte";
@@ -124,13 +124,14 @@
   // band IS the toggle. Only narrows the herd list views — selection and global counts
   // stay whole.
   let repoFilter = $state<string | null>(null);
-  // The band's filterable repos, so the toggle and the auto-clear guard agree on scope.
+  // Mirrors QueueStrip's own derived rows (same four inputs); kept here so +page can gate bandRepoPaths on band visibility without reaching into the child's state.
+  const bandRows = $derived(
+    repoStatusRows(store.drain, learnings.items, learnings.injectable, runningRepoPaths),
+  );
+  // Filterable repos = the band's rows, but ONLY while the band is actually shown. When the
+  // band hides (no value), this is empty so the stale-filter $effect below clears repoFilter.
   const bandRepoPaths = $derived(
-    new Set(
-      repoStatusRows(store.drain, learnings.items, learnings.injectable, runningRepoPaths).map(
-        (r) => r.repoPath,
-      ),
-    ),
+    new Set(bandHasValue(bandRows) ? bandRows.map((r) => r.repoPath) : []),
   );
   // A stale filter would otherwise strand the herd: when the filtered repo's band row
   // disappears (its last agent stopped running) its toggle vanishes with no way to

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -124,7 +124,8 @@
   // band IS the toggle. Only narrows the herd list views — selection and global counts
   // stay whole.
   let repoFilter = $state<string | null>(null);
-  // Mirrors QueueStrip's own derived rows (same four inputs); kept here so +page can gate bandRepoPaths on band visibility without reaching into the child's state.
+  // Single source for the repo-status band: computed once here, passed to QueueStrip as
+  // `rows` and reused for bandRepoPaths so band visibility and filter scope can't drift.
   const bandRows = $derived(
     repoStatusRows(store.drain, learnings.items, learnings.injectable, runningRepoPaths),
   );
@@ -763,11 +764,8 @@
         onwhatsnew={() => (showWhatsNew = true)}
       />
       <QueueStrip
-        drain={store.drain}
+        rows={bandRows}
         autoMerge={store.autoMerge}
-        items={learnings.items}
-        injectable={learnings.injectable}
-        {runningRepoPaths}
         onlearnings={(repoPath) => {
           learningsRepo = repoPath;
           showLearnings = true;


### PR DESCRIPTION
## Problem
On a foldable in its unfolded state, the **REPO STATUS** band (the `QueueStrip` repo-status band, directly below the real `<TopBar>` at `+page.svelte:746`) showed a tall, mostly-white bar that added almost no value.

Root cause — two issues:
1. The band renders one row per repo with a running agent. With a single repo and no drain/queue/learnings, the row collapses to a **name-only row**: a full bordered panel just to show one already-obvious repo name, whose only other job (herd-filter toggle) is a no-op with one repo.
2. Its parent `.chrome` is `flex-direction: column`, so the default `align-items: stretch` forced the band to **full width** — that stretch (not the row content) is the horizontal white space. On touch the `@media (pointer: coarse)` 44px tap target then inflates the empty row vertically.

The band + name-only rows + coarse-44px pattern were built by #432 (dropped the old top-bar badge into the band) and #443 (stacked rows + herd filter), then refined today by #459 (running-repo-only). So the fix targets `QueueStrip`, **not** `TopBar`.

## Fix
- **Hide when valueless:** new `bandHasValue(rows)` — render the repo-status band only when a row carries info (drain / queue / 💡) **or** ≥2 repos run (so the herd filter is meaningful). A single bare name-only repo → no band.
- **Stop the stretch everywhere it shows:** `align-self: flex-start` on the shared `.queue-strip` class so the band shrink-wraps its content instead of spanning the viewport. This intentionally also de-stretches the merge-train band (same class) — desirable, no behavior change.
- **No stranded filter:** `+page.svelte` `bandRepoPaths` yields an empty set when the band is hidden, so the existing stale-filter `$effect` clears a `repoFilter` orphaned by the band disappearing (e.g. running repos drop 2 → 1).

### Deliberate residuals
- The coarse-pointer 44px tap target is kept (a11y floor); with the width fix the visible band reads as a compact chip, not a white slab.
- A band of ≥2 bare name-only repos still renders — those repo-name buttons are functional herd filters, so the band earns its space.

## Tests
- `queue-strip.test.ts`: 6 `bandHasValue` cases (bare→false, drain→true, insights→true, curate-with-insights:0→true, two-bare→true, empty→false).
- `cd ui && bun run check` → 0 errors. `bun run test` → 737 tests pass.

No new i18n strings; no feature-catalog entry (this is a `fix`, removing noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)