### PR TITLE
feat: add Fable 5 to model picker

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -65,13 +65,13 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 `POST /api/sessions`, `Content-Type: application/json`. Validated by
 `validateCreate` (`src/validate.ts`); unknown keys are rejected.
 
-| Field        | Type                                    | Required | Notes                                                                        |
-| ------------ | --------------------------------------- | -------- | ---------------------------------------------------------------------------- |
-| `repoPath`   | string                                  | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
-| `baseBranch` | string                                  | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
-| `prompt`     | string                                  | ✅       | The task instructions; 1–8000 chars                                          |
-| `model`      | `"opus" \| "sonnet" \| "haiku" \| null` | —        | Omit/`null` = Claude's default                                               |
-| `images`     | `string[]`                              | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
+| Field        | Type                                               | Required | Notes                                                                        |
+| ------------ | -------------------------------------------------- | -------- | ---------------------------------------------------------------------------- |
+| `repoPath`   | string                                             | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
+| `baseBranch` | string                                             | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
+| `prompt`     | string                                             | ✅       | The task instructions; 1–8000 chars                                          |
+| `model`      | `"fable" \| "opus" \| "sonnet" \| "haiku" \| null` | —        | Omit/`null` = Claude's default                                               |
+| `images`     | `string[]`                                         | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
 
 ### Responses
 

--- a/extension/src/lib/types.ts
+++ b/extension/src/lib/types.ts
@@ -61,7 +61,7 @@ export interface CaptureConfig {
   token: string;
   repoPath: string;
   baseBranch: string;
-  model: "opus" | "sonnet" | "haiku" | "default";
+  model: "fable" | "opus" | "sonnet" | "haiku" | "default";
   /** Per-signal toggles; persisted defaults, overridable per-capture in the popup. */
   signals: SignalToggles;
   /** URL→repo rules; first match overrides `repoPath`. Empty = always fall back. */

--- a/extension/src/options/Options.svelte
+++ b/extension/src/options/Options.svelte
@@ -33,7 +33,7 @@
   loadConfig().then((c) => (config = c));
   hasAllUrls().then((on) => (recorderOn = on));
 
-  const models: CaptureConfig["model"][] = ["default", "opus", "sonnet", "haiku"];
+  const models: CaptureConfig["model"][] = ["default", "fable", "opus", "sonnet", "haiku"];
 
   // Signal toggles persist immediately (only the signals sub-object, via
   // saveSignals — so they don't flush unsaved edits to the text fields, which

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -23,6 +23,11 @@ const TABLE: { match: RegExp; w: ModelWeights }[] = [
     match: /haiku/i,
     w: { input: 1, output: 5, cacheRead: 0.1, cacheWrite5m: 1.25, cacheWrite1h: 2 },
   },
+  {
+    // Fable 5: mirrors opus deliberately, pending a verified Fable/Opus list-price ratio.
+    match: /fable/i,
+    w: { input: 15, output: 75, cacheRead: 1.5, cacheWrite5m: 18.75, cacheWrite1h: 30 },
+  },
 ];
 
 const DEFAULT: ModelWeights = TABLE[1]!.w; // sonnet-like

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,8 +86,8 @@ export interface CreateSessionInput {
   planGateEnabled?: boolean | null;
 }
 
-/** Selectable claude model aliases; absent/"default" means no --model flag. */
-export const MODELS = ["opus", "sonnet", "haiku"] as const;
+/** Selectable claude model aliases (Fable, Opus, Sonnet, Haiku); absent/"default" means no --model flag. */
+export const MODELS = ["fable", "opus", "sonnet", "haiku"] as const;
 
 export interface Steer {
   id: string;

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -809,5 +809,7 @@
   "feat_preview_start_title": "Dev-Server direkt aus dem HUD starten",
   "feat_preview_start_body": "Hat ein Agent noch keine Live-Vorschau, erscheint ein Start-Steuerelement in seinem Viewport. Ein Klick genügt, damit der Agent seinen Dev-Server startet — automatisch erkannt aus der package.json oder per eigenem Befehl — und du die laufende App sofort vorschauen kannst, ohne zu warten, bis der Agent selbst auf die Idee kommt.",
   "feat_active_label_newtask_title": "Beanspruchte Issues fallen in Neue Aufgabe auf",
-  "feat_active_label_newtask_body": "Wenn du eine Neue Aufgabe aus einem GitHub-Issue erstellst, wird ein bereits von einem aktiven Shepherd-Agenten beanspruchtes Issue jetzt mit hervorgehobenem shepherd:active-Label angezeigt — zuerst gelistet und im Farbton laufender Sessions getönt — sodass du auf einen Blick siehst, an welchen Issues schon gearbeitet wird."
+  "feat_active_label_newtask_body": "Wenn du eine Neue Aufgabe aus einem GitHub-Issue erstellst, wird ein bereits von einem aktiven Shepherd-Agenten beanspruchtes Issue jetzt mit hervorgehobenem shepherd:active-Label angezeigt — zuerst gelistet und im Farbton laufender Sessions getönt — sodass du auf einen Blick siehst, an welchen Issues schon gearbeitet wird.",
+  "feat_fable5_model_title": "Claude Fable 5",
+  "feat_fable5_model_body": "Wähle Fable 5 – Anthropics leistungsfähigstes Modell – beim Starten einer neuen Aufgabe."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -809,5 +809,7 @@
   "feat_preview_start_title": "Start a dev server from the HUD",
   "feat_preview_start_body": "When an agent has no live preview yet, a Start control appears on its Viewport. Click it to have the agent launch its dev server — auto-detected from package.json, or type the command yourself — then preview the running app without waiting for the agent to start one on its own.",
   "feat_active_label_newtask_title": "Claimed issues stand out in New Task",
-  "feat_active_label_newtask_body": "When you seed a New Task from a GitHub issue, any issue already claimed by an active Shepherd agent now shows its shepherd:active label highlighted — surfaced first and tinted with the running-session hue — so you can tell at a glance which issues are already being worked on."
+  "feat_active_label_newtask_body": "When you seed a New Task from a GitHub issue, any issue already claimed by an active Shepherd agent now shows its shepherd:active label highlighted — surfaced first and tinted with the running-session hue — so you can tell at a glance which issues are already being worked on.",
+  "feat_fable5_model_title": "Claude Fable 5",
+  "feat_fable5_model_body": "Pick Fable 5 — Anthropic's most capable model — when starting a new task."
 }

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -253,4 +253,10 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_active_label_newtask_title",
     bodyKey: "feat_active_label_newtask_body",
   },
+  {
+    id: "fable-5-model",
+    sinceVersion: "1.21.0",
+    titleKey: "feat_fable5_model_title",
+    bodyKey: "feat_fable5_model_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -527,8 +527,8 @@ export interface CreateInput {
   planGateEnabled?: boolean | null; // per-task plan-gate override; absent → inherit repo default
 }
 
-/** Selectable claude model aliases; null = claude's own default. */
-export const MODELS = ["opus", "sonnet", "haiku"] as const;
+/** Selectable claude model aliases (Fable, Opus, Sonnet, Haiku); null = claude's own default. */
+export const MODELS = ["fable", "opus", "sonnet", "haiku"] as const;
 
 export interface Steer {
   id: string;


### PR DESCRIPTION
## What

Adds **Claude Fable 5** (Anthropic's new top tier above Opus) as a selectable model — `fable` — in both model pickers: the HUD **New Task** picker and the Chrome **capture extension** options.

The installed `claude` CLI accepts `fable` as a `--model` alias (verified at runtime), so the bare alias flows through `MODELS` validation, both pickers, and the spawn (`src/service.ts` `--model` argv) with no special-casing. `NewTask.svelte` needed no edit — it iterates `MODELS` via `{#each}`, so the new option surfaces automatically.

## Changes

- **`MODELS`** gains `"fable"` (listed first, most-capable-first) in the server array (`src/types.ts`) and its manual UI mirror (`ui/src/lib/types.ts`).
- **`src/pricing.ts`** — appends a `/fable/i` usage-weight row **last** in `TABLE`. It is appended (not inserted first) on purpose: `DEFAULT = TABLE[1]!.w` is a positional reference to the sonnet row, so inserting first would silently make the unknown-model fallback ~5× heavier. Weights mirror the opus row pending a verified Fable/Opus list-price ratio (see note below).
- **Extension** — `CaptureConfig["model"]` union and the options `models` list gain `"fable"`.
- **Feature discovery** — one `feature-announcements.ts` entry (`fable-5-model`, `sinceVersion: 1.21.0`) + matching `feat_fable5_model_title`/`_body` keys in **both** `en.json` and `de.json` (parity).

## Pricing note (intentional approximation)

The fable weight row equals the opus row rather than fable's true list price. The real Fable/Opus list-price ratio could not be verified at authoring time, and the table is already internally inconsistent (opus row is ~3× the other rows' current-price scale). `= opus` is the assumption-free choice: it satisfies the only binding constraint ("the top tier must not weight below opus") for any value of the disputed prices, with bounded error (~0.5×–1.5×) versus a 3× over-weight risk for a 2× ratio. The usage cap is a soft, daily-recalibrated heuristic. **Follow-up:** revisit the row to the correct ratio once a citable Fable + current-Opus list price is available.

## Verification

All gates green: root `lint` + `bun test ./test` (1655, 0 fail) · ui `check` + `test` + `check:i18n` (parity, 812 keys) · extension `check` · branch-hygiene (linear) · feature-catalog. (2 pre-existing extension `$state`-proxy tests fail on the base branch too — browser-only, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)