### PR TITLE
fix(ui): hide the To-Do tab unless the repo has a TODO.md

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -14,6 +14,7 @@
   import { dialog } from "$lib/a11yDialog";
   import {
     getSessionUsage,
+    getTodo,
     uploadImage,
     resumeSession as apiResumeSession,
     renameSession,
@@ -327,6 +328,32 @@
       alive = false;
       clearInterval(t);
     };
+  });
+
+  // The To-Do tab only earns its place when the repo actually has a TODO.md — an
+  // empty "add your first item" tab is just noise. Poll per-session (mirrors the
+  // usage loop above) so the tab appears live when the agent writes TODO.md
+  // mid-session and drops away if it's removed. null = not yet resolved → tab
+  // stays hidden until we know.
+  let todoExists = $state<boolean | null>(null);
+  $effect(() => {
+    const rp = session.repoPath;
+    todoExists = null;
+    let alive = true;
+    const load = () =>
+      getTodo(rp)
+        .then((r) => alive && (todoExists = r.exists))
+        .catch(() => {});
+    load();
+    const t = setInterval(load, 5000);
+    return () => {
+      alive = false;
+      clearInterval(t);
+    };
+  });
+  // Don't strand the operator on a To-Do tab that just vanished (TODO.md removed).
+  $effect(() => {
+    if (todoExists === false && tab === "todo") tab = "term";
   });
 
   // once a PR exists (open or merged) the session has delivered its work — surface
@@ -1444,9 +1471,13 @@
         <button class="tab-btn" class:active={tab === "term"} onclick={() => (tab = "term")}
           >{m.viewport_terminal_tab()}</button
         >
-        <button class="tab-btn" class:active={tab === "todo"} onclick={() => (tab = "todo")}
-          >{m.viewport_todo_tab()}</button
-        >
+        {#if todoExists}
+          <!-- only when the repo has a TODO.md (server-resolved); skips the empty
+               "add your first item" tab so the strip stays meaningful. -->
+          <button class="tab-btn" class:active={tab === "todo"} onclick={() => (tab = "todo")}
+            >{m.viewport_todo_tab()}</button
+          >
+        {/if}
         <button class="tab-btn" class:active={tab === "issues"} onclick={() => (tab = "issues")}
           >{m.viewport_issues_tab()}</button
         >


### PR DESCRIPTION
## Was

Die **To-Do**-Tab im Session-Viewport wird jetzt nur noch angezeigt, wenn das Repo tatsächlich eine `TODO.md` hat. Vorher war die Tab immer da und zeigte bei fehlender Datei nur den leeren Hinweis *„Noch kein TODO.md. Ersten Eintrag hinzufügen"* — das war Rauschen in der Tab-Leiste.

## Wie

- `Viewport.svelte` löst die `TODO.md`-Existenz pro Session über `getTodo(repoPath)` auf und pollt alle 5 s (gleiches Muster wie der bestehende Usage-Loop). So erscheint die Tab **live**, sobald der Agent mitten in der Session eine `TODO.md` schreibt, und verschwindet wieder, wenn die Datei entfernt wird.
- Solange die Existenz noch nicht aufgelöst ist (`null`), bleibt die Tab versteckt.
- Wird die `TODO.md` entfernt, während die To-Do-Tab offen ist, fällt der Viewport auf das Terminal zurück (kein gestrandeter Tab).

Spiegelt exakt das bereits etablierte Verhalten in `PromptSources.svelte`, das die To-Do-Tab im New-Task-Flow ebenso ausblendet.

## Notizen

- Kein neuer User-facing Capability — nur das Entfernen einer leeren Tab, daher `fix(ui)` und kein Feature-Catalog-Eintrag.
- Keine neuen i18n-Keys (bestehender `viewport_todo_tab` wird weiterverwendet).
- `cd ui && bun run check` → 0 errors / 0 warnings.

[no-feature-entry]