### PR TITLE
feat(whats-new): show release version and date per entry

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -826,5 +826,7 @@
   "fable_arrival_try": "Fable 5 ausprobieren",
   "fable_arrival_dismiss": "Vielleicht später",
   "feat_preview_tailscale_title": "Automatische Vorschau-Freigabe",
-  "feat_preview_tailscale_body": "Live-Vorschauen registrieren sich jetzt automatisch über Tailscale, sobald der Dev-Server eines Agenten startet — und melden sich beim Stoppen wieder ab, sodass nur tatsächlich genutzte Ports freigegeben werden. Kein einmaliges tailscale-serve-Port-Setup mehr."
+  "feat_preview_tailscale_body": "Live-Vorschauen registrieren sich jetzt automatisch über Tailscale, sobald der Dev-Server eines Agenten startet — und melden sich beim Stoppen wieder ab, sodass nur tatsächlich genutzte Ports freigegeben werden. Kein einmaliges tailscale-serve-Port-Setup mehr.",
+  "feat_whatsnew_versiondate_title": "Jede Neuerung ist jetzt datiert und versioniert",
+  "feat_whatsnew_versiondate_body": "Jeder Eintrag in diesem „Was ist neu“-Bereich trägt jetzt die Release-Version, mit der er ausgeliefert wurde, sowie das Datum dieses Releases — so siehst du auf einen Blick, wie aktuell jede Änderung ist und welche Version sie eingeführt hat."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -826,5 +826,7 @@
   "fable_arrival_try": "Try Fable 5",
   "fable_arrival_dismiss": "Maybe later",
   "feat_preview_tailscale_title": "Automatic preview exposure",
-  "feat_preview_tailscale_body": "Live previews now register themselves over Tailscale automatically as each agent's dev server comes up — and unregister when it stops, so only in-use ports are exposed. No more one-time tailscale serve port setup."
+  "feat_preview_tailscale_body": "Live previews now register themselves over Tailscale automatically as each agent's dev server comes up — and unregister when it stops, so only in-use ports are exposed. No more one-time tailscale serve port setup.",
+  "feat_whatsnew_versiondate_title": "Each update is now dated and versioned",
+  "feat_whatsnew_versiondate_body": "Every entry in this What's-New drawer now carries the release version it shipped in and the date that release went out, so you can see at a glance how recent each change is and which version introduced it."
 }

--- a/ui/src/app.d.ts
+++ b/ui/src/app.d.ts
@@ -4,6 +4,7 @@ declare global {
   // injected at build time by vite.config.ts (`define`)
   const __GIT_SHA__: string;
   const __APP_VERSION__: string;
+  const __RELEASE_DATES__: Record<string, string>;
 
   namespace App {
     // interface Error {}

--- a/ui/src/lib/build-info.ts
+++ b/ui/src/lib/build-info.ts
@@ -4,5 +4,8 @@ export const REPO = "erwins-enkel/shepherd";
 export const REPO_URL = `https://github.com/${REPO}`;
 export const sha = __GIT_SHA__;
 export const version = __APP_VERSION__;
+// Release tag → date (`{ "1.20.0": "2026-06-09", … }`), keyed without leading `v`.
+// Used by the What's-New drawer to date each entry's `sinceVersion`.
+export const releaseDates = __RELEASE_DATES__;
 // `__GIT_SHA__` defaults to "unknown" when git is unavailable; fall back to the repo.
 export const commitUrl = sha === "unknown" ? REPO_URL : `https://github.com/${REPO}/commit/${sha}`;

--- a/ui/src/lib/components/WhatsNew.svelte
+++ b/ui/src/lib/components/WhatsNew.svelte
@@ -67,11 +67,12 @@
     {:else}
       <ul class="list">
         {#each entries as entry (entry.id)}
+          {@const date = entryDate(entry.sinceVersion)}
           <li class="entry">
             <div class="entry-meta">
               <span class="entry-version">v{entry.sinceVersion}</span>
-              {#if entryDate(entry.sinceVersion)}
-                <span class="entry-date">{entryDate(entry.sinceVersion)}</span>
+              {#if date}
+                <span class="entry-date">{date}</span>
               {/if}
             </div>
             <h3 class="entry-title">

--- a/ui/src/lib/components/WhatsNew.svelte
+++ b/ui/src/lib/components/WhatsNew.svelte
@@ -2,6 +2,8 @@
   import { fly } from "svelte/transition";
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
+  import { getLocale } from "$lib/i18n";
+  import { releaseDates } from "$lib/build-info";
   import type { FeatureAnnouncement } from "$lib/feature-announcements";
 
   let {
@@ -22,6 +24,21 @@
   function dismiss() {
     ondismiss();
     onclose();
+  }
+
+  // Localized release date for an entry's `sinceVersion`, or "" if the version
+  // isn't tagged yet (e.g. the in-development release) — then only the version
+  // badge shows. Date is data formatted via Intl, so it needs no message key.
+  function entryDate(sinceVersion: string): string {
+    const iso = releaseDates[sinceVersion];
+    if (!iso) return "";
+    const d = new Date(`${iso}T00:00:00`);
+    if (Number.isNaN(d.getTime())) return "";
+    return new Intl.DateTimeFormat(getLocale() === "de" ? "de-DE" : "en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(d);
   }
 </script>
 
@@ -51,6 +68,12 @@
       <ul class="list">
         {#each entries as entry (entry.id)}
           <li class="entry">
+            <div class="entry-meta">
+              <span class="entry-version">v{entry.sinceVersion}</span>
+              {#if entryDate(entry.sinceVersion)}
+                <span class="entry-date">{entryDate(entry.sinceVersion)}</span>
+              {/if}
+            </div>
             <h3 class="entry-title">
               {(m as unknown as Record<string, () => string>)[entry.titleKey]()}
             </h3>
@@ -131,6 +154,21 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
+  }
+  .entry-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: var(--fs-meta);
+    letter-spacing: 0.06em;
+  }
+  .entry-version {
+    color: var(--color-amber);
+    font-variant-numeric: tabular-nums;
+    text-transform: uppercase;
+  }
+  .entry-date {
+    color: var(--color-muted);
   }
   .entry-title {
     margin: 0;

--- a/ui/src/lib/components/WhatsNew.svelte
+++ b/ui/src/lib/components/WhatsNew.svelte
@@ -166,7 +166,6 @@
   .entry-version {
     color: var(--color-amber);
     font-variant-numeric: tabular-nums;
-    text-transform: uppercase;
   }
   .entry-date {
     color: var(--color-muted);

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -288,4 +288,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_preview_tailscale_title",
     bodyKey: "feat_preview_tailscale_body",
   },
+  {
+    // No targetId: the version/date stamps live inside this very drawer, which is
+    // not a persistent chrome anchor — surface via the What's-New drawer only.
+    // 1.21.0 is already tagged, so this ships in the next release (1.22.0):
+    // computeNewEntries only surfaces entries with sinceVersion > lastSeen.
+    id: "whatsnew-version-date",
+    sinceVersion: "1.22.0",
+    titleKey: "feat_whatsnew_versiondate_title",
+    bodyKey: "feat_whatsnew_versiondate_body",
+  },
 ];

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -25,10 +25,33 @@ function appVersion(): string {
   }
 }
 
+// Map each release tag to its date (`{ "1.20.0": "2026-06-09", … }`) so the
+// What's-New drawer can show when an entry's `sinceVersion` shipped. Keyed
+// without the leading `v` to match `FeatureAnnouncement.sinceVersion`. Empty
+// map when git is unavailable — the drawer falls back to version-only.
+function releaseDates(): Record<string, string> {
+  try {
+    const out = execFileSync(
+      "git",
+      ["tag", "--list", "v*.*.*", "--format=%(refname:short) %(creatordate:short)"],
+      { encoding: "utf8" },
+    );
+    const map: Record<string, string> = {};
+    for (const line of out.split("\n")) {
+      const [tag, date] = line.trim().split(/\s+/);
+      if (tag && date) map[tag.replace(/^v/, "")] = date;
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
 export default defineConfig({
   define: {
     __GIT_SHA__: JSON.stringify(gitSha()),
     __APP_VERSION__: JSON.stringify(appVersion()),
+    __RELEASE_DATES__: JSON.stringify(releaseDates()),
   },
   plugins: [
     paraglideVitePlugin({


### PR DESCRIPTION
## Was

In der **„Was ist neu“**-Schublade trägt jetzt jeder Eintrag eine Meta-Zeile mit der Release-**Version** (`v1.21.0`) und dem **Datum**, an dem dieses Release herauskam.

> Aufgegriffen aus dem Screenshot-Feedback: *„cool wäre hier noch versionsinfrmation je eintrag … und datum“*.

## Wie

- **Versions-Badge:** kommt direkt aus dem bereits vorhandenen `sinceVersion` jedes Katalog-Eintrags — keine neue Datenpflege.
- **Datum:** zur Build-Zeit aus den Git-Release-Tags injiziert (`vite.config.ts` → `__RELEASE_DATES__`), analog zu `__GIT_SHA__`/`__APP_VERSION__`. Map `Version → Datum` (`{ "1.20.0": "2026-06-09", … }`), gespeist aus `git tag … --format='%(refname:short) %(creatordate:short)'`. **Null Wartungsaufwand** — neue Releases datieren sich automatisch.
- **Graceful degradation:** ist git nicht verfügbar oder die Version (noch) nicht getaggt (z. B. das gerade in Arbeit befindliche Release), bleibt die Map leer bzw. der Eintrag ohne Datum — der Versions-Badge erscheint trotzdem.
- Datum wird über `Intl.DateTimeFormat` lokalisiert (EN/DE), Version + Datum sind Daten → keine hardcodierten Chrome-Strings.
- Styling rein über Design-System-Tokens (`--color-amber`, `--color-muted`, `--fs-meta`).

## Feature-Discovery

Katalog-Eintrag `whatsnew-version-date` (+ EN/DE-Keys) in derselben PR ergänzt — Gate erfüllt.

## Checks

- `bun run check` ✅ · `bun run check:i18n` ✅ (812 Keys, Parität) · `bun run test` ✅ (731 Tests)
- `check-feature-catalog.sh` ✅ · `check-branch-hygiene.sh` ✅