### PR TITLE
fix(readiness): detect JS/TS subprojects when package.json is not at the repo root

### DIFF
--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -7,7 +7,8 @@
 // it never executes the target repo's code.
 //
 // Scope: the JS/TS baseline we dogfood (presence of a package.json — at the
-// root or in a first-level subdirectory — gates applicability). Other stacks
+// root or exactly one directory level down — gates applicability; deeper
+// layouts like `apps/web/package.json` are not detected). Other stacks
 // (Python/ruff/mypy) are a later generalization.
 
 import { existsSync, readFileSync, readdirSync, type Dirent } from "node:fs";
@@ -208,6 +209,11 @@ export const GUARDRAILS: GuardrailDef[] = [
  * Package roots relative to `dir`: `""` when the root has a manifest, else
  * first-level subdirectories with one (mixed-stack repos whose JS/TS lives in
  * a subproject, e.g. `ui/` next to Python). Empty → not a JS/TS repo.
+ *
+ * Known limits, accepted to keep the scan cheap: detection descends exactly
+ * one level (`apps/web/package.json` is missed), and a root manifest
+ * short-circuits the subproject scan — a workspaces-only root whose tooling
+ * lives in subpackages is scored from the root manifest alone.
  */
 function findPackageRoots(dir: string): string[] {
   if (existsSync(join(dir, "package.json"))) return [""];
@@ -234,7 +240,8 @@ function collectManifest(file: string, deps: Set<string>, scripts: Record<string
   try {
     pkg = JSON.parse(readFileSync(file, "utf8"));
   } catch {
-    // Missing or malformed package.json: still a JS/TS repo, just no resolvable deps/scripts.
+    // Malformed package.json (findPackageRoots guarantees the file exists):
+    // still a JS/TS repo, just no resolvable deps/scripts.
   }
   for (const d of Object.keys(pkg.dependencies ?? {})) deps.add(d);
   for (const d of Object.keys(pkg.devDependencies ?? {})) deps.add(d);

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -6,10 +6,11 @@
 // we enforce inward. Detection is cheap, deterministic file/script inspection;
 // it never executes the target repo's code.
 //
-// Scope: the JS/TS baseline we dogfood (presence of package.json gates
-// applicability). Other stacks (Python/ruff/mypy) are a later generalization.
+// Scope: the JS/TS baseline we dogfood (presence of a package.json — at the
+// root or in a first-level subdirectory — gates applicability). Other stacks
+// (Python/ruff/mypy) are a later generalization.
 
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, type Dirent } from "node:fs";
 import { join } from "node:path";
 
 export type GuardrailId =
@@ -36,7 +37,7 @@ export interface GuardrailCheck {
 }
 
 export interface ReadinessReport {
-  /** False when the repo isn't a JS/TS project (no package.json) — baseline N/A. */
+  /** False when the repo isn't a JS/TS project (no package.json at the root or one level down) — baseline N/A. */
   applicable: boolean;
   /** Weighted percentage (0–100) of present guardrails, derived from `checks`. */
   score: number;
@@ -203,38 +204,69 @@ export const GUARDRAILS: GuardrailDef[] = [
   },
 ];
 
-function scanRepo(dir: string): RepoScan | null {
-  let raw: string;
+/**
+ * Package roots relative to `dir`: `""` when the root has a manifest, else
+ * first-level subdirectories with one (mixed-stack repos whose JS/TS lives in
+ * a subproject, e.g. `ui/` next to Python). Empty → not a JS/TS repo.
+ */
+function findPackageRoots(dir: string): string[] {
+  if (existsSync(join(dir, "package.json"))) return [""];
+  let entries: Dirent[];
   try {
-    raw = readFileSync(join(dir, "package.json"), "utf8");
+    entries = readdirSync(dir, { withFileTypes: true });
   } catch {
-    return null; // not a JS/TS repo → baseline N/A
+    return [];
   }
+  return entries
+    .filter((e) => e.isDirectory() && !e.name.startsWith(".") && e.name !== "node_modules")
+    .map((e) => e.name)
+    .filter((n) => existsSync(join(dir, n, "package.json")))
+    .sort();
+}
+
+/** Merges one package.json's deps + scripts into the accumulators (first script wins). */
+function collectManifest(file: string, deps: Set<string>, scripts: Record<string, string>) {
   let pkg: {
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
     scripts?: Record<string, string>;
   } = {};
   try {
-    pkg = JSON.parse(raw);
+    pkg = JSON.parse(readFileSync(file, "utf8"));
   } catch {
-    // Malformed package.json: still a JS/TS repo, just no resolvable deps/scripts.
+    // Missing or malformed package.json: still a JS/TS repo, just no resolvable deps/scripts.
   }
-  const deps = new Set([
-    ...Object.keys(pkg.dependencies ?? {}),
-    ...Object.keys(pkg.devDependencies ?? {}),
-  ]);
+  for (const d of Object.keys(pkg.dependencies ?? {})) deps.add(d);
+  for (const d of Object.keys(pkg.devDependencies ?? {})) deps.add(d);
+  for (const [name, cmd] of Object.entries(pkg.scripts ?? {})) scripts[name] ??= cmd;
+}
+
+function scanRepo(dir: string): RepoScan | null {
+  const pkgRoots = findPackageRoots(dir);
+  if (pkgRoots.length === 0) return null; // not a JS/TS repo → baseline N/A
+
+  const deps = new Set<string>();
+  const scripts: Record<string, string> = {};
+  for (const root of pkgRoots) collectManifest(join(dir, root, "package.json"), deps, scripts);
+
+  // Repo-level markers (.husky, .github/workflows, CLAUDE.md) stay at the
+  // root, so file checks span the repo root + each package dir.
+  const roots = pkgRoots[0] === "" ? pkgRoots : ["", ...pkgRoots];
   return {
     dir,
     deps,
-    scripts: pkg.scripts ?? {},
-    has: (rel) => existsSync(join(dir, rel)),
+    scripts,
+    has: (rel) => roots.some((root) => existsSync(join(dir, root, rel))),
     glob: (subdir, test) => {
-      try {
-        return readdirSync(join(dir, subdir)).filter(test);
-      } catch {
-        return [];
+      const names = new Set<string>();
+      for (const root of roots) {
+        try {
+          for (const n of readdirSync(join(dir, root, subdir)).filter(test)) names.add(n);
+        } catch {
+          // missing dir in this root
+        }
       }
+      return [...names];
     },
   };
 }

--- a/test/readiness.test.ts
+++ b/test/readiness.test.ts
@@ -32,6 +32,38 @@ test("a repo without package.json is not applicable to the JS/TS baseline", () =
   expect(r.score).toBe(0);
 });
 
+test("a mixed-stack repo with package.json only in a subdirectory is applicable", () => {
+  // epamano-shopify shape: Python at the root, the JS/TS app in a subproject.
+  write("scripts/changelog-gen.py", "print()");
+  write(
+    "category-ui/package.json",
+    JSON.stringify({
+      name: "category-ui",
+      scripts: { lint: "eslint .", test: "vitest" },
+      devDependencies: { eslint: "^10", typescript: "^6" },
+    }),
+  );
+  write("category-ui/tsconfig.json", "{}");
+  // Repo-level markers live at the root, not in the subproject.
+  write(".github/workflows/ci.yml", "name: ci");
+  write("CLAUDE.md", "# rules");
+
+  const r = analyzeReadiness(dir);
+  expect(r.applicable).toBe(true);
+  expect(present("linter", r)).toBe(true); // subpackage devDep + lint script
+  expect(present("type_checker", r)).toBe(true); // subpackage tsconfig.json
+  expect(present("test_runner", r)).toBe(true);
+  expect(present("ci", r)).toBe(true); // root-level workflow still counts
+  expect(r.hasAgentInstructions).toBe(true); // root-level CLAUDE.md still counts
+});
+
+test("node_modules and hidden directories never make a repo applicable", () => {
+  write("node_modules/package.json", JSON.stringify({ name: "leftpad" }));
+  write(".cache/package.json", JSON.stringify({ name: "tool" }));
+  const r = analyzeReadiness(dir);
+  expect(r.applicable).toBe(false);
+});
+
 test("a bare package.json scores low — every guardrail absent", () => {
   pkg({ name: "bare" });
   const r = analyzeReadiness(dir);


### PR DESCRIPTION
## Problem

The Backlog **Readiness** tab showed *"Kein JS/TS-Repo"* for `epamano-shopify`, even though the repo is primarily JS/TS. The analyzer's applicability gate (`scanRepo` in `src/readiness.ts`) only looked for a `package.json` **at the repo root** — in mixed-stack repos where the JS/TS app lives in a subdirectory (here: `category-ui/`, with Python only in `tests/` and `scripts/`), the whole baseline was declared not applicable.

## Fix

When the root has no `package.json`, fall back to first-level subdirectories (skipping hidden dirs and `node_modules`):

- `findPackageRoots()` resolves the package roots (root manifest wins; otherwise sorted subdirs with a manifest).
- Deps and scripts merge across all found subpackages (first script wins).
- File checks (`has`/`glob`) span the **repo root + each package dir**, so repo-level markers (`.github/workflows`, `CLAUDE.md`, `.husky`) still count while package-level markers (`tsconfig.json`, ESLint config, prettier) are found in the subproject.

Repos with a root `package.json` behave exactly as before (single root, no behavior change).

## Verification

- Against the real `/home/moe/projects/epamano-shopify`: `applicable: true`, score 78, evidence drawn from `category-ui/` (husky, tsconfig, prettier, commitlint) plus root-level `CLAUDE.md`.
- New tests: mixed-stack repo with subdirectory-only manifest is applicable (incl. root-level CI/CLAUDE.md detection); `node_modules`/hidden dirs never make a repo applicable.
- `bun run test` (1666 pass), lint, typecheck, fallow delta audit — all green.