### PR TITLE
fix(topbar): enlarge gear icon and drop its border

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -465,7 +465,6 @@
       <button
         bind:this={gearBtn}
         class="gear tip"
-        class:has-update={herdrUpdateAvailable && mobile}
         type="button"
         onclick={toggleMenu}
         data-tip={working > 0 ? m.topbar_menu_aria() : m.settings_title()}
@@ -707,9 +706,9 @@
   .gear {
     position: relative;
     background: transparent;
-    border: 1px solid var(--color-line-bright);
+    border: none;
     color: var(--color-muted);
-    font-size: var(--fs-lg);
+    font-size: var(--fs-xl);
     line-height: 1;
     padding: 5px 8px;
     border-radius: 2px;
@@ -717,7 +716,6 @@
   }
   .gear:hover {
     color: var(--color-amber);
-    border-color: var(--color-amber);
   }
   /* phone-only: the folded HERDR-update cue — a green pip on the gear that mirrors
      the calm green of the desktop badge and rings against the panel to stay legible */
@@ -736,9 +734,6 @@
   .gear-dot.shift {
     top: auto;
     bottom: 3px;
-  }
-  .gear.has-update {
-    border-color: var(--color-green);
   }
   /* What's New affordance — blue accent, distinct from green (herdr) and amber (app-update). */
   .whatsnew-badge {
@@ -1007,7 +1002,7 @@
     min-height: 44px;
     min-width: 44px;
     padding: 5px 11px;
-    font-size: var(--fs-lg);
+    font-size: var(--fs-xl);
   }
   .hud.mobile .gauge-btn {
     padding: 0 6px;

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -711,7 +711,6 @@
     font-size: var(--fs-xl);
     line-height: 1;
     padding: 5px 8px;
-    border-radius: 2px;
     cursor: pointer;
   }
   .gear:hover {


### PR DESCRIPTION
## Summary
The settings gear in the top bar sat in a bordered box that no other control next to it (clock, badges-as-pips) shares, and the glyph itself was small. This makes it consistent:

- Gear glyph bumped one step on the type scale: `--fs-lg` (16px) → `--fs-xl` (20px), desktop and mobile.
- Bordered frame removed (`border: 1px solid var(--color-line-bright)` → none); hover keeps the amber glyph tint, just without the border recolor.
- Dropped the now-borderless `.gear.has-update` border tint and its `class:has-update` binding — the green `.gear-dot` pip renders under the exact same condition (`herdrUpdateAvailable && mobile`) and remains the update cue.

Touch targets are unchanged: the 44px `min-width`/`min-height` floors for `.hud.mobile .gear` and the `pointer: coarse` block stay as-is.

## Test plan
- `cd ui && bun run check` — 0 errors, 0 warnings.
- Visual: gear renders larger, frameless, hover turns it amber; mobile herdr-update pip still shows.