### PR TITLE
fix(repo-select): make keyboard cursor visible in repo picker

### DIFF
--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -450,6 +450,8 @@
   }
   .rs-row.recent.kbd-active {
     background: var(--color-sel);
+    outline: 1.5px solid var(--color-amber);
+    outline-offset: -1.5px;
   }
   .rs-row.recent.active {
     background: color-mix(in srgb, var(--color-amber) 12%, var(--color-panel));

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -401,9 +401,16 @@
     border-bottom: 0;
   }
 
-  .rs-row:hover,
-  .rs-row.kbd-active {
+  .rs-row:hover {
     background: var(--color-hover);
+  }
+
+  /* Virtual keyboard cursor — same amber inset ring as EmojiPicker's .ep-cell.active;
+     a background shift alone is invisible on desktop (--hover ≈ --panel). */
+  .rs-row.kbd-active {
+    background: var(--color-sel);
+    outline: 1.5px solid var(--color-amber);
+    outline-offset: -1.5px;
   }
 
   .rs-row.active {
@@ -438,9 +445,11 @@
   .rs-row.recent {
     background: color-mix(in srgb, var(--color-amber) 5%, var(--color-panel));
   }
-  .rs-row.recent:hover,
-  .rs-row.recent.kbd-active {
+  .rs-row.recent:hover {
     background: var(--color-hover);
+  }
+  .rs-row.recent.kbd-active {
+    background: var(--color-sel);
   }
   .rs-row.recent.active {
     background: color-mix(in srgb, var(--color-amber) 12%, var(--color-panel));


### PR DESCRIPTION
## Problem

Beim Navigieren des Repo-Pickers mit den Pfeiltasten war auf dem Desktop kaum zu erkennen, welche Zeile gerade aktiv ist. Die `kbd-active`-Zeile bekam nur `--color-hover` (`#0c1110`) als Hintergrund — das ist sogar dunkler als der Panel-Hintergrund (`#0f1413`), der Kontrast also praktisch null.

## Fix

Übernimmt die bereits etablierte Konvention aus dem EmojiPicker (auf den der RepoSelect-Code als Vorbild für den virtuellen Cursor verweist):

- `kbd-active` bekommt `--color-sel` als Hintergrund (deutlich heller als das Panel) plus eine **amber Inset-Outline** (`1.5px`, `outline-offset: -1.5px`)
- Maus-Hover bleibt unverändert subtil (`--color-hover`)
- Gepinnte "Zuletzt"-Zeilen erhalten dieselbe Behandlung

Reine Token-Nutzung, keine neuen Literale; funktioniert in Dark- und Light-Theme.

## Verifikation

- `bun run check`: 0 Errors
- `bun run test`: 752/752 Tests grün