### PR TITLE
feat(backlog): pin the three most recently worked-on repos atop the repo list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -717,6 +717,7 @@ const broadcastBacklog = async () =>
       counts: (p) => backlog.counts(p),
       resolveForge,
       lastUsedByRepo: () => store.lastUsedByRepo(),
+      recentCountsByRepo: (since) => store.recentSessionCountsByRepo(since),
       repoRoot: config.repoRoot,
     }),
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -2103,6 +2103,9 @@ export interface BacklogProject {
   slug: string | null;
   kind: string;
   lastUsedAt: number | null;
+  /** Agents run on this repo in the last {@link RECENT_WINDOW_DAYS} days — same
+   *  metric the New Task repo picker pins its "recently worked on" group by. */
+  recentAgentCount: number | null;
   openIssues: number | null;
   openPRs: number | null;
   /** Workflows defined under .github/workflows; null for non-GitHub forges. */
@@ -2129,6 +2132,8 @@ export interface BacklogPayloadInputs {
   counts: (repoDir: string) => Promise<RepoCounts>;
   resolveForge: (repoDir: string) => GitForge | null;
   lastUsedByRepo: () => Record<string, number>;
+  /** repoPath → agents run since `since` (ms epoch) — store.recentSessionCountsByRepo. */
+  recentCountsByRepo: (since: number) => Record<string, number>;
   repoRoot: string;
 }
 
@@ -2141,6 +2146,11 @@ export interface BacklogPayloadInputs {
 export async function buildBacklogPayload(inputs: BacklogPayloadInputs): Promise<BacklogPayload> {
   const repos = listRepos(inputs.repoRoot);
   const lastUsed = inputs.lastUsedByRepo();
+  // Same window the repo picker's "recently worked on" group is computed over,
+  // so the backlog's recent-repos group ranks by identical criteria.
+  const recentCounts = inputs.recentCountsByRepo(
+    Date.now() - RECENT_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+  );
 
   // Keep only forge-backed repos
   const forgeRepos = repos
@@ -2164,6 +2174,7 @@ export async function buildBacklogPayload(inputs: BacklogPayloadInputs): Promise
       slug: r.forge.slug,
       kind: r.forge.kind,
       lastUsedAt: lastUsed[r.path] ?? null,
+      recentAgentCount: recentCounts[r.path] ?? null,
       openIssues: counts.openIssues,
       openPRs: counts.openPRs,
       // GitHub-only: the Actions panel is github-gated, so other forges get null
@@ -2227,6 +2238,7 @@ async function handleBacklog({ req, parts, deps }: Ctx): Promise<Response | null
       counts: (p) => backlog.counts(p),
       resolveForge: (p) => deps.resolveForge?.(p) ?? null,
       lastUsedByRepo: () => deps.store.lastUsedByRepo(),
+      recentCountsByRepo: (since) => deps.store.recentSessionCountsByRepo(since),
       repoRoot: config.repoRoot,
     }),
   );

--- a/test/server-backlog.test.ts
+++ b/test/server-backlog.test.ts
@@ -66,7 +66,8 @@ function fakeForge(slug: string, kind: "github" | "gitea" = "github"): GitForge 
 /**
  * Build AppDeps. `resolveForge` recognises only repoA and repoB; all others
  * (including repoNonForge and whatever else is in repoRoot) get null.
- * `backlogCounts` maps repoPath → RepoCounts; `lastUsed` maps repoPath → ms.
+ * `backlogCounts` maps repoPath → RepoCounts; `lastUsed` maps repoPath → ms;
+ * `recentCounts` maps repoPath → agents run in the recent window.
  */
 function makeDeps(
   backlogCounts: Record<
@@ -75,10 +76,12 @@ function makeDeps(
   >,
   lastUsed: Record<string, number> = {},
   overrideForge?: AppDeps["resolveForge"],
+  recentCounts: Record<string, number> = {},
 ): AppDeps {
   return {
     store: {
       lastUsedByRepo: () => lastUsed,
+      recentSessionCountsByRepo: () => recentCounts,
     } as unknown as SessionStore,
     service: {} as SessionService,
     events: { emit: () => {} } as unknown as EventHub,
@@ -231,7 +234,10 @@ test("buildBacklogPayload: surfaces per-repo ciStatus onto each project", async 
 
 test("GET /api/backlog with deps.backlog absent → empty payload", async () => {
   const deps: AppDeps = {
-    store: { lastUsedByRepo: () => ({}) } as unknown as SessionStore,
+    store: {
+      lastUsedByRepo: () => ({}),
+      recentSessionCountsByRepo: () => ({}),
+    } as unknown as SessionStore,
     service: {} as SessionService,
     events: { emit: () => {} } as unknown as EventHub,
     usageLimits: { limits: () => ({}) } as never,
@@ -295,4 +301,24 @@ test("GET /api/backlog pinnedPath falls back to first sorted project when no las
   const body = await app.fetch(req()).then((r) => r.json());
   // With no lastUsedAt, pinnedPath falls back to the first project after sort (most issues = repoA)
   expect(body.pinnedPath).toBe(repoA);
+});
+
+test("GET /api/backlog surfaces per-repo recentAgentCount (null when none)", async () => {
+  const app = makeApp(
+    makeDeps(
+      { [repoA]: { openIssues: 1, openPRs: 0 }, [repoB]: { openIssues: 1, openPRs: 0 } },
+      {},
+      undefined,
+      { [repoA]: 4 }, // repoB has no recent agents → null
+    ),
+  );
+  const body = await app.fetch(req()).then((r) => r.json());
+  const byPath = Object.fromEntries(
+    body.projects.map((p: { path: string; recentAgentCount: number | null }) => [
+      p.path,
+      p.recentAgentCount,
+    ]),
+  );
+  expect(byPath[repoA]).toBe(4);
+  expect(byPath[repoB]).toBeNull();
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -832,5 +832,7 @@
   "feat_preview_tailscale_title": "Automatische Vorschau-Freigabe",
   "feat_preview_tailscale_body": "Live-Vorschauen registrieren sich jetzt automatisch über Tailscale, sobald der Dev-Server eines Agenten startet — und melden sich beim Stoppen wieder ab, sodass nur tatsächlich genutzte Ports freigegeben werden. Kein einmaliges tailscale-serve-Port-Setup mehr.",
   "feat_whatsnew_versiondate_title": "Jede Neuerung ist jetzt datiert und versioniert",
-  "feat_whatsnew_versiondate_body": "Jeder Eintrag in diesem „Was ist neu“-Bereich trägt jetzt die Release-Version, mit der er ausgeliefert wurde, sowie das Datum dieses Releases — so siehst du auf einen Blick, wie aktuell jede Änderung ist und welche Version sie eingeführt hat."
+  "feat_whatsnew_versiondate_body": "Jeder Eintrag in diesem „Was ist neu“-Bereich trägt jetzt die Release-Version, mit der er ausgeliefert wurde, sowie das Datum dieses Releases — so siehst du auf einen Blick, wie aktuell jede Änderung ist und welche Version sie eingeführt hat.",
+  "feat_backlog_recent_repos_title": "Aktuelle Repos im Backlog angeheftet",
+  "feat_backlog_recent_repos_body": "Die Repo-Liste im Backlog beginnt jetzt mit den drei Repos, auf denen zuletzt die meisten Agenten liefen — sortiert nach denselben Kriterien wie die Gruppe „zuletzt bearbeitet“ im Repo-Picker von Neue Aufgabe."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -832,5 +832,7 @@
   "feat_preview_tailscale_title": "Automatic preview exposure",
   "feat_preview_tailscale_body": "Live previews now register themselves over Tailscale automatically as each agent's dev server comes up — and unregister when it stops, so only in-use ports are exposed. No more one-time tailscale serve port setup.",
   "feat_whatsnew_versiondate_title": "Each update is now dated and versioned",
-  "feat_whatsnew_versiondate_body": "Every entry in this What's-New drawer now carries the release version it shipped in and the date that release went out, so you can see at a glance how recent each change is and which version introduced it."
+  "feat_whatsnew_versiondate_body": "Every entry in this What's-New drawer now carries the release version it shipped in and the date that release went out, so you can see at a glance how recent each change is and which version introduced it.",
+  "feat_backlog_recent_repos_title": "Recent repos pinned in the backlog",
+  "feat_backlog_recent_repos_body": "The backlog's repo list now starts with the three repos you've recently run the most agents on — ranked by the same criteria as the New Task repo picker's \"recently worked on\" group."
 }

--- a/ui/src/lib/components/ProjectBacklogList.svelte
+++ b/ui/src/lib/components/ProjectBacklogList.svelte
@@ -2,6 +2,7 @@
   import type { BacklogProject } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import ProjectRow from "./ProjectRow.svelte";
+  import { partitionRecents } from "./backlog-view";
 
   let {
     projects,
@@ -24,6 +25,11 @@
     ontoggleprs: () => void;
     onselect: (path: string) => void;
   } = $props();
+
+  // "Recently worked on" group at the top — same ranking criteria as the New
+  // Task repo picker's pinned recents (see partitionRecents). Hoisted, not
+  // duplicated, so each repo keeps a single selectable row.
+  const grouped = $derived(partitionRecents(projects));
 </script>
 
 <div class="filter-bar">
@@ -55,7 +61,21 @@
   </div>
 {:else}
   <div class="project-list">
-    {#each projects as project (project.path)}
+    {#if grouped.recents.length > 0}
+      <div class="recent-label">{m.reposelect_recent_heading()}</div>
+      {#each grouped.recents as project (project.path)}
+        <ProjectRow
+          {project}
+          pinned={project.path === pinnedPath}
+          selected={project.path === selectedPath}
+          onselect={() => onselect(project.path)}
+        />
+      {/each}
+      {#if grouped.rest.length > 0}
+        <div class="recent-sep" role="presentation"></div>
+      {/if}
+    {/if}
+    {#each grouped.rest as project (project.path)}
       <ProjectRow
         {project}
         pinned={project.path === pinnedPath}
@@ -110,6 +130,22 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
+  }
+
+  /* "recently worked on" group heading + divider — mirrors the rs-group-label /
+     rs-group-sep recipe in RepoSelect so both recent-repo groups read alike. */
+  .recent-label {
+    padding: 6px 12px 4px;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+
+  .recent-sep {
+    height: 0;
+    border-top: 1px solid var(--color-line-bright);
+    margin: 4px 0;
   }
 
   .filter-empty {

--- a/ui/src/lib/components/backlog-view.test.ts
+++ b/ui/src/lib/components/backlog-view.test.ts
@@ -21,6 +21,8 @@ import {
   actionsTabLabel,
   actionsTabState,
   filterProjects,
+  partitionRecents,
+  RECENT_LIMIT,
 } from "./backlog-view";
 import type { BacklogPayload, BacklogProject } from "$lib/types";
 
@@ -242,6 +244,66 @@ describe("filterProjects", () => {
   it("returns an empty array when every project is excluded", () => {
     const allEmpty = [project("/repos/a", 0, 0), project("/repos/b", null, null)];
     expect(filterProjects(allEmpty, { hasIssues: true, hasPRs: true })).toEqual([]);
+  });
+});
+
+describe("partitionRecents", () => {
+  // Same ranking criteria as the New Task repo picker (RepoSelect): recent agent
+  // count desc, then lastUsedAt desc, then name asc — capped at RECENT_LIMIT.
+  function recentProject(
+    path: string,
+    recentAgentCount: number | null,
+    lastUsedAt?: number,
+  ): BacklogProject {
+    return { ...project(path, 0, 0), recentAgentCount, lastUsedAt };
+  }
+
+  it("hoists repos with recent agents, most agents first", () => {
+    const a = recentProject("/repos/a", 2);
+    const b = recentProject("/repos/b", 9);
+    const c = recentProject("/repos/c", null);
+    const { recents, rest } = partitionRecents([a, b, c]);
+    expect(recents).toEqual([b, a]);
+    expect(rest).toEqual([c]);
+  });
+
+  it("tie-breaks equal counts by most-recently-used", () => {
+    const older = recentProject("/repos/older", 3, 100);
+    const newer = recentProject("/repos/newer", 3, 200);
+    expect(partitionRecents([older, newer]).recents).toEqual([newer, older]);
+  });
+
+  it("tie-breaks equal count + lastUsedAt by name (path basename) ascending", () => {
+    const zeta = recentProject("/repos/zeta", 3, 100);
+    const alpha = recentProject("/repos/alpha", 3, 100);
+    expect(partitionRecents([zeta, alpha]).recents).toEqual([alpha, zeta]);
+  });
+
+  it("caps the group at RECENT_LIMIT and leaves the overflow in rest", () => {
+    const ps = [5, 4, 3, 2, 1].map((n, i) => recentProject(`/repos/p${i}`, n));
+    const { recents, rest } = partitionRecents(ps);
+    expect(RECENT_LIMIT).toBe(3);
+    expect(recents).toEqual(ps.slice(0, 3));
+    expect(rest).toEqual(ps.slice(3));
+  });
+
+  it("excludes zero/null/missing counts — no recent agents, no pin", () => {
+    const zero = recentProject("/repos/zero", 0);
+    const nul = recentProject("/repos/null", null);
+    const missing = project("/repos/missing", 1, 1);
+    const { recents, rest } = partitionRecents([zero, nul, missing]);
+    expect(recents).toEqual([]);
+    expect(rest).toEqual([zero, nul, missing]);
+  });
+
+  it("keeps rest in the original (server-sorted) order and never duplicates a repo", () => {
+    const a = recentProject("/repos/a", null);
+    const b = recentProject("/repos/b", 7);
+    const c = recentProject("/repos/c", null);
+    const { recents, rest } = partitionRecents([a, b, c]);
+    expect(rest).toEqual([a, c]);
+    const all = [...recents, ...rest].map((p) => p.path);
+    expect(new Set(all).size).toBe(all.length);
   });
 });
 

--- a/ui/src/lib/components/backlog-view.ts
+++ b/ui/src/lib/components/backlog-view.ts
@@ -89,6 +89,42 @@ export function actionsTabLabel(sel: BacklogProject | null): string {
   }
 }
 
+// How many repos the "recently worked on" group at the top of the backlog list
+// holds — same size as the repo picker's pinned shortcut group (RepoSelect).
+export const RECENT_LIMIT = 3;
+
+/** Repo name a row displays: path basename, falling back to slug/display —
+ *  mirrors ProjectRow so the recents tie-break sorts by the visible name. */
+function projectName(p: BacklogProject): string {
+  return p.path.replace(/\/+$/, "").split("/").pop() || p.slug || p.display;
+}
+
+/**
+ * Split the (already filtered) repo list into the "recently worked on" group
+ * and the rest. Ranking criteria are identical to RepoSelect's pinned recents:
+ * agents run in the recent window (desc), then most-recently-used (desc), then
+ * name (asc); only repos with at least one recent agent qualify, capped at
+ * {@link RECENT_LIMIT}. Unlike the picker (a transient dropdown that repeats
+ * pinned rows below), this persistent list hoists the recents — `rest` keeps
+ * the parent's order minus the hoisted entries, so no repo appears twice.
+ */
+export function partitionRecents(projects: readonly BacklogProject[]): {
+  recents: BacklogProject[];
+  rest: BacklogProject[];
+} {
+  const recents = projects
+    .filter((p) => (p.recentAgentCount ?? 0) > 0)
+    .sort(
+      (a, b) =>
+        (b.recentAgentCount ?? 0) - (a.recentAgentCount ?? 0) ||
+        (b.lastUsedAt ?? 0) - (a.lastUsedAt ?? 0) ||
+        projectName(a).localeCompare(projectName(b)),
+    )
+    .slice(0, RECENT_LIMIT);
+  const hoisted = new Set(recents.map((p) => p.path));
+  return { recents, rest: projects.filter((p) => !hoisted.has(p.path)) };
+}
+
 /**
  * Narrow the repo list by activity. Each active flag is a *required* predicate
  * (AND semantics): `hasIssues` keeps only repos with open issues, `hasPRs` only

--- a/ui/src/lib/components/backlog-view.ts
+++ b/ui/src/lib/components/backlog-view.ts
@@ -107,6 +107,13 @@ function projectName(p: BacklogProject): string {
  * {@link RECENT_LIMIT}. Unlike the picker (a transient dropdown that repeats
  * pinned rows below), this persistent list hoists the recents — `rest` keeps
  * the parent's order minus the hoisted entries, so no repo appears twice.
+ *
+ * Deliberate divergence from RepoSelect, which drops its recents group while
+ * the user types: there the filter is a *search* for one specific repo, so the
+ * shortcut only gets in the way. The backlog chips are persistent *scope*
+ * filters (has issues / has PRs) — running on the already-filtered list keeps
+ * the group useful while a scope is active, and never re-surfaces a repo the
+ * active chips exclude (which would break the filter's promise).
  */
 export function partitionRecents(projects: readonly BacklogProject[]): {
   recents: BacklogProject[];

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -307,4 +307,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_issue_search_title",
     bodyKey: "feat_issue_search_body",
   },
+  {
+    // No targetId: the backlog repo list only mounts on the Backlog view (not the
+    // default dashboard), so a coachmark anchor would usually be unmounted —
+    // surface via the What's-New drawer only.
+    id: "backlog-recent-repos",
+    sinceVersion: "1.22.0",
+    titleKey: "feat_backlog_recent_repos_title",
+    bodyKey: "feat_backlog_recent_repos_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -421,6 +421,9 @@ export interface BacklogProject {
   slug: string | null;
   kind: "github" | "gitea";
   lastUsedAt?: number;
+  /** Agents run on this repo in the server's recent window — same metric the
+   *  New Task repo picker pins its "recently worked on" group by. */
+  recentAgentCount?: number | null;
   openIssues: number | null;
   openPRs: number | null;
   /** Workflows defined under .github/workflows; null for non-GitHub forges. */


### PR DESCRIPTION
## Was

Die Repo-Liste im Backlog beginnt jetzt — wie der Repo-Picker in **Neue Aufgabe** (#469) — mit einer angehefteten Gruppe **„zuletzt bearbeitet"**: die drei Repos, auf denen im 3-Tage-Fenster die meisten Agenten liefen.

## Kriterien (identisch zum Repo-Picker)

1. Agents im Fenster (`recentAgentCount`) absteigend
2. Tie-Break: zuletzt genutzt (`lastUsedAt`) absteigend
3. Tie-Break: Name (Pfad-Basename) aufsteigend

Nur Repos mit mindestens einem Agenten im Fenster qualifizieren sich; Cap bei 3 (`RECENT_LIMIT`, wie `RepoSelect`).

## Wie

- **Server**: `buildBacklogPayload` reichert jedes Projekt um `recentAgentCount` an — aus `store.recentSessionCountsByRepo` über dasselbe `RECENT_WINDOW_DAYS = 3`-Fenster wie `GET /api/repos`. Beide Aufrufer (Request-Pfad + Backlog-Poller-Broadcast) liefern die neue Input-Funktion.
- **UI**: neuer Pure-Logic-Helper `partitionRecents` in `backlog-view.ts`; `ProjectBacklogList` hebt die Gruppe mit Überschrift (re-used i18n-Key `reposelect_recent_heading`) + Trenner an den Listenanfang. Anders als im Picker (Dropdown, wiederholt die Zeilen unten) wird **gehoben statt dupliziert** — jede Repo-Zeile bleibt einmalig selektierbar.
- Das bestehende „Angeheftet"-Badge (`pinnedPath`) und die Filter-Chips bleiben unverändert; die Gruppe respektiert aktive Filter.

## Tests

- `partitionRecents`: Ranking, Tie-Breaks, Cap, Null/Zero-Ausschluss, keine Duplikate (6 neue Vitest-Cases)
- Server: `recentAgentCount` im Payload (`test/server-backlog.test.ts`, Mock-Store erweitert)
- Gates: lint, typecheck, svelte-check, i18n-Parität, Feature-Katalog, Branch-Hygiene — alles grün (voller Pre-push-CI-Lauf)

Feature-Katalog-Eintrag `backlog-recent-repos` (sinceVersion 1.22.0) inkl. EN/DE-Keys.