### PR TITLE
fix(ui): HUD UI audit fixes — light theme, mobile iOS, perf, design doctrine

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -217,7 +217,7 @@ Shadows are permitted in exactly one situation: a summoned overlay. Bottom sheet
 
 ### Status Pip (signature)
 
-- A 9px circle filled with the status color (amber / red / slate). The "working" pip pulses via an expanding box-shadow halo (`pip-pulse`, 1.5s ease-out). A ready-to-ship agent shows a bare green check glyph instead of a filled dot — green is reserved for that actionable-complete state. A WAITING (`done`) agent is parked, not complete, so it shares the idle slate hue but takes a hollow ring instead of idle's solid dot. Status never relies on hue alone: position, the pulse, the check glyph, the hollow-vs-solid ring, and the WORKING / WAITING / IDLE / BLOCKED label all carry meaning.
+- A 9px circle filled with the status color (amber / red / slate). The "working" pip pulses via an expanding, fading halo (`pip-pulse`, 1.5s ease-out — a compositor-only transform/opacity pseudo-element, not an animated box-shadow). A ready-to-ship agent shows a bare green check glyph instead of a filled dot — green is reserved for that actionable-complete state. A WAITING (`done`) agent is parked, not complete, so it shares the idle slate hue but takes a hollow ring instead of idle's solid dot. Status never relies on hue alone: position, the pulse, the check glyph, the hollow-vs-solid ring, and the WORKING / WAITING / IDLE / BLOCKED label all carry meaning.
 
 ### Live Terminal (signature)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -179,18 +179,19 @@ The hierarchy above is realized as a 6-rung type scale, the single source of tru
 
 This system is flat by doctrine. Depth is built from tonal layering, not shadow: the four ground values (inset #070a09 < panel-2 #0c100f < panel #0f1413 < head #0a0f0d) step against each other, and 1px hairlines (#1b2422, brightening to #2c3835 on focus or hover) draw every boundary. At rest there are no drop shadows and no glassmorphism. The only ambient light in the system is the faint radial glow at the top of the page and the inset amber glow on a primary button.
 
-Shadows are permitted in exactly one situation: a summoned overlay. Bottom sheets and modals that rise over the live terminal carry a single soft shadow to lift them off the busy backdrop, paired with a subtle backdrop blur. That shadow is a response to state (the sheet was invoked), never a resting decoration.
+Shadows are permitted in exactly one situation: a summoned overlay. Bottom sheets and modals that rise over the live terminal carry a single soft shadow to lift them off the busy backdrop, paired with a subtle backdrop blur. The same logic extends to small anchored surfaces summoned by interaction — tooltips, dropdowns, context menus, popovers. In every case the shadow is a response to state (the surface was invoked), never a resting decoration.
 
 ### Shadow Vocabulary
 
 - **Sheet lift** (`box-shadow: 0 -8px 40px rgba(0,0,0,0.5)`): The rising compose / bottom-sheet overlay, anchored to the bottom edge.
+- **Popover lift** (`box-shadow: 0 6px 24px rgba(0,0,0,0.45)`, nearby variants tolerated): Small anchored surfaces summoned by interaction — tooltips, dropdowns, context menus, anchored popovers. Invoked, not resting. The `rgba(0,0,0)` base is intentionally theme-static: it reads correctly on both themes, and being near-invisible on the dark ground is fine — tonal steps carry depth there.
 - **Action inset glow** (`box-shadow: inset 0 0 18px -10px var(--color-amber)`): The amber primary/active button. An internal glow, not an outer drop.
 
 ### Named Rules
 
 **The Flat Panel Rule.** Surfaces are flat and square at rest. Depth comes from tonal value and hairlines. A drop shadow on a resting panel is prohibited; if you reach for one, you are missing a tonal step.
 
-**The Earned Shadow Rule.** Shadows appear only as a response to invocation (a sheet or modal rising over the terminal). No shadow exists to make a static element look "lifted."
+**The Earned Shadow Rule.** Shadows appear only as a response to invocation (a sheet or modal rising over the terminal, or a popover/tooltip/menu summoned at its anchor). No shadow exists to make a static element look "lifted."
 
 ## 5. Components
 

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -276,6 +276,19 @@ button {
   touch-action: manipulation;
 }
 
+/* iOS zoom-on-focus guard: mobile Safari zooms the whole page when a focused
+   text control renders below 16px. Force every text-entry control to the 16px
+   rung (--fs-lg) on phones — systemic here so no individual component can
+   drift back under the threshold. The `:is()` wrapper deliberately lends the
+   bare `textarea`/`select` the input arm's specificity (0,3,1), so this beats
+   Svelte-scoped component rules like `.ep-search.svelte-x` (0,2,0) or
+   `textarea.svelte-x` (0,1,1) that set a smaller desktop size. */
+@media (max-width: 768px) {
+  :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]), textarea, select) {
+    font-size: var(--fs-lg);
+  }
+}
+
 /* ── Dialog backdrop ──────────────────────────────────────────────────────
    Canonical treatment for any blocking dialog/modal/drawer: a theme-aware dim
    (--color-scrim) plus a soft blur, so whatever is behind recedes and the

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -208,15 +208,22 @@ body {
 }
 
 /* motion (guarded) */
+/* Expanding-fading halo for the working pip. Compositor-only (transform +
+   opacity, NOT box-shadow — animating box-shadow repaints every frame, ×N
+   pulsing pips across a large herd): the animated element is a pseudo-element
+   disc sized to the pip that scales out to the old 7px box-shadow spread
+   (9px pip + 2×7px ≈ scale 2.55) while fading. The 70% keyframe mirrors the
+   original spread timing: visible expansion for the first 70% of the cycle,
+   then a rest beat. */
 @keyframes pip-pulse {
   0% {
-    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-amber) 70%, transparent);
+    transform: scale(1);
+    opacity: 1;
   }
-  70% {
-    box-shadow: 0 0 0 7px transparent;
-  }
+  70%,
   100% {
-    box-shadow: 0 0 0 0 transparent;
+    transform: scale(2.55);
+    opacity: 0;
   }
 }
 /* in-progress dot: opacity blink (reads clearly at small size, clip-proof,

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -8,7 +8,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Shepherd" />
-    <meta name="theme-color" content="#0b0f0d" />
+    <meta name="theme-color" content="#0a0d0c" />
     <!-- viewport-fit=cover is required for env(safe-area-inset-*) to return non-zero
          values; without it iOS letterboxes content and the insets stay 0. Paired with
          apple-mobile-web-app-status-bar-style=black-translucent for a full-bleed dark shell. -->
@@ -28,7 +28,7 @@
           // Hexes mirror app.css --color-bg per theme (runtime setter in
           // theme.svelte.ts uses the same values).
           var meta = document.querySelector('meta[name="theme-color"]');
-          if (meta) meta.setAttribute("content", dark ? "#0b0f0d" : "#e7ebe9");
+          if (meta) meta.setAttribute("content", dark ? "#0a0d0c" : "#e7ebe9");
           if (localStorage.getItem("shepherd:contrast") === "high")
             document.documentElement.dataset.contrast = "high";
         } catch (e) {

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -25,6 +25,10 @@
             pref === "dark" ||
             (pref !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
           document.documentElement.dataset.theme = dark ? "dark" : "light";
+          // Hexes mirror app.css --color-bg per theme (runtime setter in
+          // theme.svelte.ts uses the same values).
+          var meta = document.querySelector('meta[name="theme-color"]');
+          if (meta) meta.setAttribute("content", dark ? "#0b0f0d" : "#e7ebe9");
           if (localStorage.getItem("shepherd:contrast") === "high")
             document.documentElement.dataset.contrast = "high";
         } catch (e) {

--- a/ui/src/lib/components/ActionsPanel.svelte
+++ b/ui/src/lib/components/ActionsPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { listWorkflowRuns } from "$lib/api";
+  import { pollWhileVisible } from "$lib/visibility";
   import type { WorkflowRun } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import ActionRunRow from "./ActionRunRow.svelte";
@@ -61,8 +62,8 @@
   $effect(() => {
     if (!hasPending) return;
     const rp = repoPath;
-    const timer = setInterval(() => load(rp, true), REFRESH_MS);
-    return () => clearInterval(timer);
+    // hidden-tab ticks are skipped, with a silent refresh on tab return
+    return pollWhileVisible(() => load(rp, true), REFRESH_MS);
   });
 </script>
 

--- a/ui/src/lib/components/ActivityFeed.svelte
+++ b/ui/src/lib/components/ActivityFeed.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getActivity } from "$lib/api";
+  import { pollWhileVisible } from "$lib/visibility";
   import { glyph, clock } from "$lib/activity";
   import type { ActivityEntry } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
@@ -25,10 +26,10 @@
         })
         .catch(() => {});
     load();
-    const t = setInterval(load, 5000);
+    const stop = pollWhileVisible(load, 5000); // skip hidden-tab ticks; refresh on return
     return () => {
       alive = false;
-      clearInterval(t);
+      stop();
     };
   });
 

--- a/ui/src/lib/components/AutomationPanel.svelte
+++ b/ui/src/lib/components/AutomationPanel.svelte
@@ -641,13 +641,13 @@
     color: var(--color-amber);
     border-color: var(--color-amber);
   }
-  /* the revealed long-form explanation: a quiet inset note, amber-keyed to its
-     open "ⓘ", with comfortable line length for a couple of sentences */
+  /* the revealed long-form explanation: a quiet tonal-step note (panel over the
+     popover's inset ground) with a full hairline border — no accent stripe */
   .auto-detail {
     margin: 6px 0 0;
     padding: 8px 10px;
     background: var(--color-panel);
-    border-left: 2px solid var(--color-amber);
+    border: 1px solid var(--color-line);
     border-radius: 2px;
     font-size: var(--fs-meta);
     line-height: 1.5;
@@ -671,7 +671,8 @@
     margin-top: 2px;
     width: 30px;
     height: 17px;
-    border-radius: 9px;
+    /* squared track + knob (2px, instrument hardware) — never pill-shaped */
+    border-radius: 2px;
     border: 1px solid var(--color-line);
     background: var(--color-faint);
     position: relative;
@@ -688,7 +689,7 @@
     left: 1px;
     width: 13px;
     height: 13px;
-    border-radius: 50%;
+    border-radius: 2px;
     background: var(--color-slate);
     transition:
       left 0.12s,

--- a/ui/src/lib/components/CardMenu.svelte
+++ b/ui/src/lib/components/CardMenu.svelte
@@ -130,6 +130,10 @@
     position: fixed;
     z-index: 60;
     min-width: 180px;
+    /* Never wider than the viewport minus the JS clamp's 8px margin per side,
+       so the position clamp above can always fit the menu on narrow phones
+       (long labels wrap instead of overflowing). */
+    max-width: calc(100vw - 16px);
     padding: 4px;
     background: var(--color-panel);
     border: 1px solid var(--color-line-bright);

--- a/ui/src/lib/components/CloneRepo.svelte
+++ b/ui/src/lib/components/CloneRepo.svelte
@@ -257,7 +257,7 @@
       animation: sheet-up 0.18s ease-out;
     }
     input {
-      font-size: var(--fs-lg); /* prevents iOS zoom-on-focus */
+      /* 16px no-zoom font-size comes from the global iOS guard in app.css */
       min-height: 44px;
     }
     .run {

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -486,8 +486,8 @@
     border-radius: 2px;
     color: var(--color-ink);
     font-family: var(--font-mono);
-    /* a touch smaller for density; under the 16px iOS no-zoom threshold, an
-       accepted tradeoff since the overlay is centered and not edge-pinned */
+    /* 16px — the iOS no-zoom minimum, so focusing the field never zooms the
+       page (kept at the threshold on desktop too for steering legibility) */
     font-size: var(--fs-lg);
     line-height: 1.4;
     overflow-y: auto;

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -408,7 +408,7 @@
     display: flex;
     align-items: flex-end;
     justify-content: center;
-    background: rgba(0, 0, 0, 0.45);
+    background: var(--color-scrim);
     -webkit-backdrop-filter: blur(3px);
     backdrop-filter: blur(3px);
   }

--- a/ui/src/lib/components/DiffFileBlock.svelte
+++ b/ui/src/lib/components/DiffFileBlock.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import type { DiffFile } from "$lib/types";
+  import { theme, type Resolved } from "$lib/theme.svelte";
 
   let { file }: { file: DiffFile } = $props();
 
   let open = $state(false);
   // per-line highlighted HTML for the whole file, in render order (null until loaded)
   let html = $state<string[] | null>(null);
+  // which resolved theme `html` was rendered for — a theme switch invalidates it
+  // (Shiki emits concrete foreground hexes, so dark-tuned HTML is illegible on light)
+  let htmlTheme = $state<Resolved | null>(null);
 
   const STATUS_GLYPH: Record<DiffFile["status"], string> = {
     added: "A",
@@ -19,18 +23,26 @@
   // lazily highlight the first time this file is expanded (one Shiki call per
   // file). The highlighter (and Shiki) is dynamically imported here so it stays
   // off the first-paint critical path — only pulled in on user expand.
+  // Re-runs on theme switch (resolved is read up front as a dependency) so stale
+  // dark-colored lines never linger on a light surface, and vice versa.
   $effect(() => {
-    if (!open || html || file.binary || file.truncated || flatLines.length === 0) return;
+    const resolved = theme.resolved;
+    if (!open || file.binary || file.truncated || flatLines.length === 0) return;
+    if (html && htmlTheme === resolved) return;
     let alive = true;
     import("$lib/highlight")
       .then(({ highlightLines }) =>
         highlightLines(
           flatLines.map((l) => l.content),
           file.path,
+          resolved,
         ),
       )
       .then((h) => {
-        if (alive) html = h;
+        if (alive) {
+          html = h;
+          htmlTheme = resolved;
+        }
       })
       .catch((err) => {
         // Highlighting is progressive enhancement — fall back to the plain diff,

--- a/ui/src/lib/components/DiffPanel.svelte
+++ b/ui/src/lib/components/DiffPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getDiff } from "$lib/api";
+  import { pollWhileVisible } from "$lib/visibility";
   import { diffTotals } from "$lib/diff";
   import type { DiffResult } from "$lib/types";
   import DiffFileBlock from "$lib/components/DiffFileBlock.svelte";
@@ -37,10 +38,10 @@
     failed = false;
     alive = true;
     load();
-    const t = setInterval(load, 15000);
+    const stop = pollWhileVisible(load, 15000); // skip hidden-tab ticks; refresh on return
     return () => {
       alive = false;
-      clearInterval(t);
+      stop();
     };
   });
 

--- a/ui/src/lib/components/EmojiPicker.svelte
+++ b/ui/src/lib/components/EmojiPicker.svelte
@@ -124,6 +124,7 @@
       class="ep-custom"
       class:bad={custom.length > 0 && !customOk}
       placeholder={m.emojipicker_custom()}
+      aria-label={m.emojipicker_custom()}
       type="text"
       autocomplete="off"
       onkeydown={(e) => {

--- a/ui/src/lib/components/EmojiPicker.svelte
+++ b/ui/src/lib/components/EmojiPicker.svelte
@@ -149,6 +149,14 @@
     padding: 8px;
     width: 240px;
   }
+  /* Anchored popover (absolutely positioned, left-pinned by its host): on
+     narrow phones cap the fixed width so it never spills past the right
+     viewport edge — the grid's 1fr columns shrink gracefully. */
+  @media (max-width: 768px) {
+    .ep {
+      width: min(240px, calc(100vw - 16px));
+    }
+  }
   .ep-search {
     width: 100%;
     box-sizing: border-box;

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -13,6 +13,7 @@
   import { featureAnnouncements } from "$lib/feature-announcements";
   import Coachmark from "$lib/components/Coachmark.svelte";
   import { offerUpdateMain } from "$lib/pull-offer";
+  import { pollWhileVisible } from "$lib/visibility";
 
   let {
     sessionId,
@@ -92,11 +93,11 @@
     showReview = false;
     showAutomation = false;
     load(id);
-    // light poll only while a PR is open (CI/merge state can change)
-    const t = setInterval(() => {
+    // light poll only while a PR is open (CI/merge state can change);
+    // hidden-tab ticks are skipped, with a refresh on tab return
+    return pollWhileVisible(() => {
       if (git?.state === "open") load(id);
     }, 15000);
-    return () => clearInterval(t);
   });
 
   function startPr() {

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -718,11 +718,8 @@
       overflow-y: auto;
       animation: sheet-up 0.18s ease-out;
     }
-    textarea,
-    input,
-    select {
-      font-size: var(--fs-lg); /* prevents iOS zoom-on-focus */
-    }
+    /* 16px no-zoom font-size for textarea/input/select comes from the global
+       iOS guard in app.css */
     input,
     select,
     .run {

--- a/ui/src/lib/components/ReadinessPanel.svelte
+++ b/ui/src/lib/components/ReadinessPanel.svelte
@@ -310,7 +310,7 @@
     color: var(--color-green);
   }
   .score-num {
-    font-size: 1.5rem;
+    font-size: var(--fs-2xl);
     font-weight: 600;
   }
   .score-pct {
@@ -379,7 +379,7 @@
   }
   .dot {
     line-height: 1.4;
-    font-size: 0.7rem;
+    font-size: var(--fs-meta);
   }
   .dot.present {
     color: var(--color-green);

--- a/ui/src/lib/components/ReadinessPanel.svelte
+++ b/ui/src/lib/components/ReadinessPanel.svelte
@@ -301,13 +301,13 @@
     color: var(--color-red);
   }
   .score-ring.fair {
-    border-color: var(--color-amber, #d2a64a);
-    color: var(--color-amber, #d2a64a);
+    border-color: var(--color-amber);
+    color: var(--color-amber);
   }
   .score-ring.good,
   .score-ring.strong {
-    border-color: var(--color-green, #5aa86b);
-    color: var(--color-green, #5aa86b);
+    border-color: var(--color-green);
+    color: var(--color-green);
   }
   .score-num {
     font-size: 1.5rem;
@@ -338,11 +338,11 @@
     color: var(--color-red);
   }
   .score-band.fair {
-    color: var(--color-amber, #d2a64a);
+    color: var(--color-amber);
   }
   .score-band.good,
   .score-band.strong {
-    color: var(--color-green, #5aa86b);
+    color: var(--color-green);
   }
   .score-summary {
     font-size: var(--fs-meta);
@@ -382,7 +382,7 @@
     font-size: 0.7rem;
   }
   .dot.present {
-    color: var(--color-green, #5aa86b);
+    color: var(--color-green);
   }
   .dot.absent {
     color: var(--color-faint);
@@ -409,7 +409,7 @@
   .all-covered {
     padding: 12px 0;
     font-size: var(--fs-base);
-    color: var(--color-green, #5aa86b);
+    color: var(--color-green);
     border-bottom: 1px solid var(--color-line);
   }
 
@@ -451,7 +451,7 @@
   }
   .merge-note {
     font-size: var(--fs-meta);
-    color: var(--color-amber, #d2a64a);
+    color: var(--color-amber);
     margin-bottom: 6px;
   }
   .claudemd {

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -531,9 +531,7 @@
     .rs-trigger {
       min-height: 44px;
     }
-    .rs-filter {
-      font-size: var(--fs-lg); /* prevents iOS zoom-on-focus */
-    }
+    /* .rs-filter's 16px no-zoom font-size comes from the global iOS guard in app.css */
     .rs-row {
       min-height: 44px;
     }

--- a/ui/src/lib/components/StatusPip.svelte
+++ b/ui/src/lib/components/StatusPip.svelte
@@ -109,6 +109,9 @@
     inset: 0;
     border-radius: 50%;
     background: color-mix(in srgb, var(--c) 70%, transparent);
+    /* the scaled halo must never intercept clicks meant for neighbors (the
+       box-shadow it replaced was hit-transparent) */
+    pointer-events: none;
     /* functional status motion — exempt from the reduced-motion blanket (app.css) */
     animation: pip-pulse 1.5s ease-out infinite !important;
   }

--- a/ui/src/lib/components/StatusPip.svelte
+++ b/ui/src/lib/components/StatusPip.svelte
@@ -52,7 +52,6 @@
     border-radius: 50%;
     background: var(--c);
     display: inline-block;
-    box-shadow: 0 0 0 0 var(--c);
   }
   /* done (WAITING): a hollow ring reads as "parked", distinct from idle's solid
      slate dot even though both share the slate hue */
@@ -67,7 +66,6 @@
     align-items: center;
     justify-content: center;
     background: none;
-    box-shadow: none;
     color: var(--c);
     font-size: var(--fs-micro);
     line-height: 1;
@@ -87,7 +85,6 @@
        hits ~3.9:1, just shy of WCAG AA 4.5:1 for the 12px glyph; the deeper red
        clears ~5:1 in both themes and reads as a stronger alarm, not weaker. */
     background: color-mix(in srgb, var(--c) 88%, #000);
-    box-shadow: none;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -101,6 +98,17 @@
     font-weight: 800;
   }
   .pulse {
+    position: relative;
+  }
+  /* expanding-fading halo: a same-color translucent disc behind/over the solid
+     pip (only solid pips pulse, so the same-hue wash over the dot is invisible),
+     scaled + faded on the compositor — no per-frame box-shadow repaints */
+  .pulse::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--c) 70%, transparent);
     /* functional status motion — exempt from the reduced-motion blanket (app.css) */
     animation: pip-pulse 1.5s ease-out infinite !important;
   }

--- a/ui/src/lib/components/Stepper.svelte
+++ b/ui/src/lib/components/Stepper.svelte
@@ -106,7 +106,7 @@
     outline-offset: 1px;
   }
   .chip {
-    font-size: 10px;
+    font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 1px 6px;

--- a/ui/src/lib/components/TodoPanel.svelte
+++ b/ui/src/lib/components/TodoPanel.svelte
@@ -328,9 +328,7 @@
       width: 6px;
       height: 10px;
     }
-    .add-input {
-      font-size: var(--fs-lg); /* prevents iOS zoom-on-focus */
-    }
+    /* .add-input's 16px no-zoom font-size comes from the global iOS guard in app.css */
     .add-btn {
       min-height: 40px;
     }

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -740,9 +740,9 @@
     align-items: center;
     gap: 6px;
     padding: 5px 11px;
-    background: color-mix(in srgb, var(--color-blue, #4a9eff) 14%, transparent);
-    border: 1px solid var(--color-blue, #4a9eff);
-    color: var(--color-blue, #4a9eff);
+    background: color-mix(in srgb, var(--color-blue) 14%, transparent);
+    border: 1px solid var(--color-blue);
+    color: var(--color-blue);
     cursor: pointer;
     font: inherit;
     font-size: var(--fs-meta);
@@ -751,7 +751,7 @@
     border-radius: 2px;
   }
   .whatsnew-badge:hover {
-    background: color-mix(in srgb, var(--color-blue, #4a9eff) 22%, transparent);
+    background: color-mix(in srgb, var(--color-blue) 22%, transparent);
   }
   .whatsnew-badge .wn-dot {
     font-size: var(--fs-micro);
@@ -778,7 +778,7 @@
     width: 9px;
     height: 9px;
     border-radius: 50%;
-    background: var(--color-blue, #4a9eff);
+    background: var(--color-blue);
     box-shadow: 0 0 0 2px var(--color-panel);
   }
   .gauges {

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -584,7 +584,7 @@
     align-items: center;
     gap: 0;
     min-width: 0;
-    font-size: 11px;
+    font-size: var(--fs-meta);
     line-height: 1.3;
     color: var(--color-muted);
   }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -27,6 +27,7 @@
   import { shouldForwardEscape } from "$lib/terminalEscape";
   import { detectNotesKey } from "$lib/notesAffordance";
   import { isScrolledAwayFromBottom } from "$lib/scrollAffordance";
+  import { pollWhileVisible } from "$lib/visibility";
   import TodoPanel from "$lib/components/TodoPanel.svelte";
   import IssuesPanel from "$lib/components/IssuesPanel.svelte";
   import ActivityFeed from "$lib/components/ActivityFeed.svelte";
@@ -297,10 +298,10 @@
   // null model = claude's own default (shepherd passed no --model flag)
   const modelLabel = $derived(session.model ?? "default");
 
-  // session:status events replace the Session object on every state change of the
-  // running unit, so the `session` prop reference churns while its id stays put.
-  // Derive the id: a $derived only notifies dependents when its *value* changes,
-  // so effects keyed on it re-run on an actual unit switch — not on status churn.
+  // The `session` prop is re-resolved from the store whenever the sessions
+  // state changes, so its reference can churn while the id stays put. Derive
+  // the id: a $derived only notifies dependents when its *value* changes, so
+  // effects keyed on it re-run on an actual unit switch — not on churn.
   const unitId = $derived(session.id);
 
   // Live preview availability is purely server-driven: a non-null port means the
@@ -329,10 +330,10 @@
         .then((u) => alive && (usage = u))
         .catch(() => {});
     load();
-    const t = setInterval(load, 5000);
+    const stop = pollWhileVisible(load, 5000); // skip hidden-tab ticks; refresh on return
     return () => {
       alive = false;
-      clearInterval(t);
+      stop();
     };
   });
 

--- a/ui/src/lib/highlight.ts
+++ b/ui/src/lib/highlight.ts
@@ -6,8 +6,9 @@ import {
 } from "shiki";
 import { langFromPath } from "./diff";
 
-// Hand-tuned dark theme matching the HUD palette (Shiki needs concrete hex, not
-// CSS vars). Mirrors app.css --ink/--muted/--amber/--green/--blue/--red.
+// Hand-tuned themes matching the HUD palette (Shiki needs concrete hex, not
+// CSS vars). Each mirrors app.css --ink/--muted/--amber/--green/--blue/--red
+// for its [data-theme] block.
 const SHEPHERD_DARK = {
   name: "shepherd-dark",
   type: "dark" as const,
@@ -25,6 +26,27 @@ const SHEPHERD_DARK = {
     },
     { scope: ["variable", "meta.definition.variable"], settings: { foreground: "#c4d0cb" } },
     { scope: ["invalid", "keyword.operator"], settings: { foreground: "#e5484d" } },
+  ],
+};
+
+// Light counterpart — mirrors app.css [data-theme="light"] tokens.
+const SHEPHERD_LIGHT = {
+  name: "shepherd-light",
+  type: "light" as const,
+  colors: { "editor.background": "#f7f9f8", "editor.foreground": "#2b3633" },
+  settings: [
+    { settings: { foreground: "#2b3633" } }, // --ink
+    { scope: ["comment"], settings: { foreground: "#5a6862" } }, // --muted
+    { scope: ["string", "constant.other.symbol"], settings: { foreground: "#1d8a5d" } }, // --green
+    { scope: ["constant.numeric", "constant.language"], settings: { foreground: "#a8680a" } }, // --amber
+    { scope: ["keyword", "storage", "storage.type"], settings: { foreground: "#2f6fb0" } }, // --blue
+    { scope: ["entity.name.function", "support.function"], settings: { foreground: "#a8680a" } }, // --amber
+    {
+      scope: ["entity.name.type", "support.type", "support.class"],
+      settings: { foreground: "#1d8a5d" }, // --green
+    },
+    { scope: ["variable", "meta.definition.variable"], settings: { foreground: "#2b3633" } }, // --ink
+    { scope: ["invalid", "keyword.operator"], settings: { foreground: "#c2363b" } }, // --red
   ],
 };
 
@@ -48,7 +70,7 @@ let hlPromise: Promise<Highlighter> | null = null;
 function getHighlighter(): Promise<Highlighter> {
   if (!hlPromise) {
     hlPromise = createHighlighter({
-      themes: [SHEPHERD_DARK as ThemeRegistrationAny],
+      themes: [SHEPHERD_DARK as ThemeRegistrationAny, SHEPHERD_LIGHT as ThemeRegistrationAny],
       langs: LANGS,
     });
   }
@@ -64,15 +86,21 @@ function escapeHtml(s: string): string {
  * One Shiki call per file: join with \n, tokenize once, map tokens back per line.
  * Unknown language → escaped plain text (the +/- coloring still applies in CSS).
  * Per-line tokenization caveat (multi-line constructs) is accepted for review.
+ * `theme` is the resolved app theme — callers pass it so the emitted
+ * foreground-only colors match the surface they paint over.
  */
-export async function highlightLines(contents: string[], path: string): Promise<string[]> {
+export async function highlightLines(
+  contents: string[],
+  path: string,
+  theme: "dark" | "light" = "dark",
+): Promise<string[]> {
   const lang = langFromPath(path);
   if (lang === "text") return contents.map(escapeHtml);
   try {
     const hl = await getHighlighter();
     const { tokens } = hl.codeToTokens(contents.join("\n"), {
       lang: lang as BundledLanguage,
-      theme: "shepherd-dark",
+      theme: theme === "light" ? "shepherd-light" : "shepherd-dark",
     });
     return tokens.map((line) =>
       line

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -175,8 +175,18 @@ export class HerdStore {
    *  dispatch switch under the complexity gate. */
   private applyRenamed(id: string, name: string, branch: string | null) {
     const prevName = this.byId(id)?.name;
-    this.sessions = this.sessions.map((s) => (s.id === id ? { ...s, name, branch } : s));
+    this.patchSession(id, { name, branch });
     if (prevName !== undefined && prevName !== name) toasts.info(m.toast_renamed({ name }));
+  }
+
+  /** Mutate a session's fields in place. `sessions` is a deeply-reactive $state
+   *  proxy, so property writes give fine-grained updates without replacing the
+   *  array (which would re-run every keyed {#each} row for a one-session
+   *  change). Full-array replacement is reserved for events that change the SET
+   *  of sessions (session:new / session:archived / setAll). */
+  private patchSession(id: string, patch: Partial<Session>) {
+    const s = this.byId(id);
+    if (s) Object.assign(s, patch);
   }
 
   apply(ev: WsEvent) {
@@ -185,42 +195,30 @@ export class HerdStore {
         if (!this.byId(ev.data.id)) this.sessions = [...this.sessions, ev.data];
         break;
       case "session:status":
-        this.sessions = this.sessions.map((s) =>
-          s.id === ev.data.id ? { ...s, status: ev.data.status } : s,
-        );
+        this.patchSession(ev.data.id, { status: ev.data.status });
         break;
       case "session:renamed":
         this.applyRenamed(ev.data.id, ev.data.name, ev.data.branch);
         break;
       case "session:ready":
-        this.sessions = this.sessions.map((s) =>
-          s.id === ev.data.id ? { ...s, readyToMerge: ev.data.ready } : s,
-        );
+        this.patchSession(ev.data.id, { readyToMerge: ev.data.ready });
         break;
       case "session:merging":
-        this.sessions = this.sessions.map((s) =>
-          s.id === ev.data.id
-            ? { ...s, mergingSince: ev.data.since, mergingTrainId: ev.data.trainId }
-            : s,
-        );
+        this.patchSession(ev.data.id, {
+          mergingSince: ev.data.since,
+          mergingTrainId: ev.data.trainId,
+        });
         break;
       case "session:autopilot":
-        this.sessions = this.sessions.map((s) =>
-          s.id === ev.data.id
-            ? {
-                ...s,
-                autopilotPaused: ev.data.paused,
-                autopilotComplete: ev.data.complete,
-                autopilotQuestion: ev.data.question,
-                autopilotEnabled: ev.data.enabled,
-              }
-            : s,
-        );
+        this.patchSession(ev.data.id, {
+          autopilotPaused: ev.data.paused,
+          autopilotComplete: ev.data.complete,
+          autopilotQuestion: ev.data.question,
+          autopilotEnabled: ev.data.enabled,
+        });
         break;
       case "session:automerge":
-        this.sessions = this.sessions.map((s) =>
-          s.id === ev.data.id ? { ...s, autoMergeEnabled: ev.data.enabled } : s,
-        );
+        this.patchSession(ev.data.id, { autoMergeEnabled: ev.data.enabled });
         break;
       case "session:archived":
         this.sessions = this.sessions.filter((s) => s.id !== ev.data.id);
@@ -277,10 +275,7 @@ export class HerdStore {
       case "session:plangate":
         // Emitted two ways: a fresh verdict carries `gate`; a phase flip carries `planPhase`.
         if (ev.data.gate) planGates.apply(ev.data.id, ev.data.gate);
-        if (ev.data.planPhase)
-          this.sessions = this.sessions.map((s) =>
-            s.id === ev.data.id ? { ...s, planPhase: ev.data.planPhase! } : s,
-          );
+        if (ev.data.planPhase) this.patchSession(ev.data.id, { planPhase: ev.data.planPhase });
         return true;
       case "session:plangate-reviewing":
         planGates.applyReviewing(ev.data.id, ev.data.reviewing);

--- a/ui/src/lib/theme.svelte.ts
+++ b/ui/src/lib/theme.svelte.ts
@@ -86,7 +86,7 @@ class ThemeController {
       // Hexes mirror app.css --color-bg per theme (same values as the
       // pre-paint script in app.html).
       const meta = document.querySelector('meta[name="theme-color"]');
-      if (meta) meta.setAttribute("content", this.resolved === "dark" ? "#0b0f0d" : "#e7ebe9");
+      if (meta) meta.setAttribute("content", this.resolved === "dark" ? "#0a0d0c" : "#e7ebe9");
       if (this.contrast) root.dataset.contrast = "high";
       else delete root.dataset.contrast;
     }

--- a/ui/src/lib/theme.svelte.ts
+++ b/ui/src/lib/theme.svelte.ts
@@ -82,6 +82,11 @@ class ThemeController {
     if (typeof document !== "undefined") {
       const root = document.documentElement;
       root.dataset.theme = this.resolved;
+      // Keep browser chrome (PWA title bar, mobile status bar) in sync.
+      // Hexes mirror app.css --color-bg per theme (same values as the
+      // pre-paint script in app.html).
+      const meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) meta.setAttribute("content", this.resolved === "dark" ? "#0b0f0d" : "#e7ebe9");
       if (this.contrast) root.dataset.contrast = "high";
       else delete root.dataset.contrast;
     }

--- a/ui/src/lib/visibility.test.ts
+++ b/ui/src/lib/visibility.test.ts
@@ -1,0 +1,67 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { pollWhileVisible } from "./visibility";
+
+// minimal document stub: `hidden` flag + visibilitychange listeners
+function stubDoc(state: { hidden: boolean }) {
+  const handlers: (() => void)[] = [];
+  (globalThis as unknown as { document: unknown }).document = {
+    get hidden() {
+      return state.hidden;
+    },
+    addEventListener: (_t: string, h: () => void) => handlers.push(h),
+    removeEventListener: (_t: string, h: () => void) => {
+      const i = handlers.indexOf(h);
+      if (i >= 0) handlers.splice(i, 1);
+    },
+  };
+  return { fire: () => [...handlers].forEach((h) => h()), handlers };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  delete (globalThis as unknown as { document?: unknown }).document;
+});
+
+test("ticks fire while the tab is visible", () => {
+  stubDoc({ hidden: false });
+  const fn = vi.fn();
+  const stop = pollWhileVisible(fn, 1000);
+  vi.advanceTimersByTime(3000);
+  expect(fn).toHaveBeenCalledTimes(3);
+  stop();
+});
+
+test("ticks are skipped while the tab is hidden; return fires an immediate refresh", () => {
+  const state = { hidden: true };
+  const doc = stubDoc(state);
+  const fn = vi.fn();
+  const stop = pollWhileVisible(fn, 1000);
+  vi.advanceTimersByTime(5000); // hidden: no network ticks
+  expect(fn).not.toHaveBeenCalled();
+  state.hidden = false;
+  doc.fire(); // visibilitychange → visible: immediate refresh, not interval-stale
+  expect(fn).toHaveBeenCalledTimes(1);
+  vi.advanceTimersByTime(1000); // cadence resumes
+  expect(fn).toHaveBeenCalledTimes(2);
+  stop();
+});
+
+test("a hidden→hidden visibilitychange does not refresh", () => {
+  const doc = stubDoc({ hidden: true });
+  const fn = vi.fn();
+  const stop = pollWhileVisible(fn, 1000);
+  doc.fire();
+  expect(fn).not.toHaveBeenCalled();
+  stop();
+});
+
+test("the disposer stops ticks and detaches the listener", () => {
+  const doc = stubDoc({ hidden: false });
+  const fn = vi.fn();
+  const stop = pollWhileVisible(fn, 1000);
+  stop();
+  vi.advanceTimersByTime(3000);
+  expect(fn).not.toHaveBeenCalled();
+  expect(doc.handlers).toHaveLength(0);
+});

--- a/ui/src/lib/visibility.ts
+++ b/ui/src/lib/visibility.ts
@@ -1,0 +1,22 @@
+/**
+ * Drive a network poller only while the tab is visible: interval ticks are
+ * skipped while `document.hidden` (a backgrounded HUD shouldn't keep hitting
+ * the server), and returning to the tab fires an immediate `fn()` so the
+ * operator sees fresh data instead of up-to-one-interval-stale data.
+ *
+ * The caller performs its own initial load (some pollers tick conditionally);
+ * this only owns the recurring cadence. Returns a disposer.
+ */
+export function pollWhileVisible(fn: () => void, ms: number): () => void {
+  const timer = setInterval(() => {
+    if (!document.hidden) fn();
+  }, ms);
+  const onVisibility = () => {
+    if (!document.hidden) fn();
+  };
+  document.addEventListener("visibilitychange", onVisibility);
+  return () => {
+    clearInterval(timer);
+    document.removeEventListener("visibilitychange", onVisibility);
+  };
+}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -587,11 +587,11 @@
 
   // elapsed-time tick: only run while there's at least one session — an empty
   // herd has no elapsed clocks to drive, so don't write nowMs every second.
-  // Gate on a $derived boolean, not store.sessions.length directly: session:status
-  // (and renamed/ready/new) reassign store.sessions, which would re-run an effect
-  // that read it and recreate the interval mid-second — under heavy status traffic
-  // the 1s tick could stutter or stall, freezing every elapsed clock. A $derived
-  // only propagates on the empty↔non-empty flip, so the interval is made once.
+  // Gate on a $derived boolean, not store.sessions.length directly: session:new
+  // and session:archived reassign store.sessions, which would re-run an effect
+  // that read it and recreate the interval mid-add/remove — under churn the 1s
+  // tick could stutter, freezing every elapsed clock. A $derived only propagates
+  // on the empty↔non-empty flip, so the interval is made once.
   const hasSessions = $derived(store.sessions.length > 0);
   $effect(() => {
     if (!hasSessions) return;


### PR DESCRIPTION
## Summary

Implements all four recommendation batches from an \`/impeccable audit\` of the HUD UI (scored 15/20; 0 P0, 5 P1, 8 P2 findings). One commit per batch, subagent-executed.

### 1. Harden (`d7939f78`) — light-theme robustness + a11y
- **Light-theme diff syntax highlighting**: added a `SHEPHERD_LIGHT` Shiki theme mirroring the light app.css tokens; `highlightLines` selects per resolved theme and `DiffFileBlock` re-highlights on theme switch (dark-tuned foregrounds were ~1.4:1 on the light diff background).
- **Dynamic meta theme-color**: pre-paint script + runtime theme apply both set browser-chrome color per theme (was hardcoded dark).
- **Drifted `var()` fallbacks** stripped in ReadinessPanel (9×) and TopBar (5×) — fallback hexes matched neither theme.
- **EmojiPicker custom-emoji input** gets an `aria-label` (reused `emojipicker_custom` key).

### 2. Adapt (`f6b152d9`) — mobile/iOS
- **Systemic iOS no-zoom rule** in app.css: all text-entry controls ≥16px under 768px, with an `:is()` wrapper so it outranks Svelte-scoped component rules; removed four now-redundant per-component overrides. Fixes verified zoom-on-focus bugs in EmojiPicker search and BroadcastDialog textarea and closes the bug class.
- **EmojiPicker** popover width capped to viewport on narrow phones; **CardMenu** capped so its JS viewport clamp always fits 360px screens.

### 3. Optimize (`2f4c3e0d`) — perf
- **pip-pulse** now animates transform/opacity on a `::after` halo (compositor-only) instead of box-shadow (per-frame repaint × every working pip); same 1.5s ease-out visual, reduced-motion exemption preserved.
- **Session store** patches the matching session in place (deep `$state` proxy) for status/ready/merging/autopilot/automerge/renamed/planPhase events instead of replacing the whole array per event.
- **Visibility-gated polling** via new `pollWhileVisible` helper (with unit test): ActivityFeed, Viewport usage, DiffPanel, GitRail and ActionsPanel pollers skip hidden-tab ticks and refresh immediately on tab return.

### 4. Polish (`5f4bb512`) — design doctrine
- Removed the banned 2px amber side-stripe on AutomationPanel's detail callout (full 1px hairline instead); squared the 9px pill toggle to the 2px control radius.
- Replaced the last four off-ladder font sizes with `--fs-*` tokens (sweep confirms zero ad-hoc sizes remain in components).
- ComposeBar scrim now uses the canonical `var(--color-scrim)` token.
- DESIGN.md: codified the **Popover lift** shadow exception (anchored, invoked surfaces) so the Earned Shadow Rule matches the ~15 existing popovers.

## Validation
- `cd ui && bun run check`: 1803 files, 0 errors / 0 warnings
- `bun run check:i18n`: EN+DE parity (827 keys)
- `bun run test`: 756/756 passed
- `bunx fallow audit --base origin/main --fail-on-issues`: clean
- Branch hygiene: linear off latest main, no merge commits

No `feat` commits — fixes/perf/style only, so no feature-catalog entry is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)