### PR TITLE
fix(viewport): offer resume only when the claude process is actually gone

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,9 @@ const poller = new StatusPoller(
   (id, ready) => events.emit("session:ready", { id, ready }),
   (id, activity) => events.emit("session:activity", { id, activity }),
   { service: previewService, sweepMs: config.previewSweepMs }, // preview sweep wiring
+  // claude-liveness sweep wiring: lets the UI gate its Resume affordance on the
+  // claude process actually being gone instead of offering it on every idle/done.
+  { onChange: (id, claudeAlive) => events.emit("session:claude-alive", { id, claudeAlive }) },
 );
 // Clear stale mappings left by a crashed prior run. Fire void, NOT await: the service's
 // single FIFO queue already guarantees this op completes before any register/unregister
@@ -741,6 +744,7 @@ const server = serve(
     prCache: prPoller,
     ownsPr,
     activity: { snapshot: () => poller.activitySnapshot() },
+    claudeAlive: { snapshot: () => poller.claudeAliveSnapshot() },
     preview: { snapshot: () => previewService.snapshot() },
     previewServe: { snapshot: () => tailscaleServe.snapshot() },
     push,

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -6,7 +6,7 @@ import { isStalled, DEFAULT_STALL, type ActivitySnapshot } from "./stall";
 import { jsonlPathFor } from "./usage";
 import { readTranscriptSignals, STRIP_WINDOW_MS, type SessionActivity } from "./activity-signal";
 import { maintenance } from "./maintenance";
-import { scanListeningPortsByWorktree } from "./process-reaper";
+import { scanListeningPortsByWorktree, scanClaudeAliveByWorktree } from "./process-reaper";
 import { resolveDevPort } from "./preview";
 import { config } from "./config";
 
@@ -34,6 +34,17 @@ export interface PreviewWiring {
    *  Defaults to `resolveDevPort`, which honors the agent-declared `.shepherd-preview`
    *  hint (if listening + HTTP-live) and otherwise falls back to the primary-port heuristic. */
   pick: (ports: number[], worktreePath: string) => Promise<number | null>;
+}
+
+/**
+ * Injectable claude-liveness wiring: emits when a session's worktree gains/loses
+ * a live `claude` process. Defaults to the real /proc scan; tests inject fakes.
+ */
+export interface LivenessWiring {
+  /** Single /proc pass answering "does a claude process live in this worktree?". */
+  scan: (worktrees: string[]) => Map<string, boolean>;
+  sweepMs: number;
+  onChange: (id: string, alive: boolean) => void;
 }
 
 export class StatusPoller {
@@ -80,6 +91,13 @@ export class StatusPoller {
   /** The resolved preview wiring (with real defaults filled in). */
   private readonly previewWiring: PreviewWiring;
 
+  /** Timestamp of the last claude-liveness sweep (0 = never). */
+  private lastLivenessSweepAt = 0;
+  /** Last-swept per-session claude liveness; onChange fires on flips only. */
+  private lastClaudeAlive = new Map<string, boolean>();
+  /** The resolved liveness wiring (with real defaults filled in). */
+  private readonly livenessWiring: LivenessWiring;
+
   constructor(
     private store: SessionStore,
     private herdr: Pick<HerdrDriver, "list" | "read" | "readAsync">,
@@ -111,6 +129,12 @@ export class StatusPoller {
      * (existing poller tests that don't pass this still work).
      */
     preview?: Partial<PreviewWiring>,
+    /**
+     * Claude-liveness wiring: injectable for tests; defaults to the real /proc scan
+     * with a no-op onChange. Drives `session:claude-alive` so the UI only offers
+     * Resume when the claude process is actually gone (husk shell).
+     */
+    liveness?: Partial<LivenessWiring>,
   ) {
     // Merge supplied overrides with real defaults. When preview is omitted entirely
     // we create a no-op wiring so tick() never throws on undefined access.
@@ -124,6 +148,11 @@ export class StatusPoller {
       sweepMs: preview?.sweepMs ?? config.previewSweepMs,
       scan: preview?.scan ?? ((worktrees) => scanListeningPortsByWorktree(worktrees)),
       pick: preview?.pick ?? ((ports, worktreePath) => resolveDevPort(ports, worktreePath)),
+    };
+    this.livenessWiring = {
+      scan: liveness?.scan ?? ((worktrees) => scanClaudeAliveByWorktree(worktrees)),
+      sweepMs: liveness?.sweepMs ?? config.previewSweepMs,
+      onChange: liveness?.onChange ?? (() => {}),
     };
   }
 
@@ -157,6 +186,47 @@ export class StatusPoller {
     this.pruneInactive(activeIds);
     // preview sweep: throttled + re-entrancy guarded; fire-and-forget (never blocks tick)
     this.maybeRunPreviewSweep(sessions);
+    // claude-liveness sweep: throttled; synchronous (one cheap /proc pass)
+    this.maybeRunLivenessSweep(sessions);
+  }
+
+  /**
+   * Throttled sweep: does each session's worktree still host a live `claude`
+   * process? Detects the husk case herdr's agent_status can't (claude exited to a
+   * bare shell keeps the agent listed as idle). Emits onChange on flips only;
+   * tracking for sessions no longer active is pruned in place.
+   */
+  private maybeRunLivenessSweep(sessions: Session[]): void {
+    const t = this.now();
+    if (t - this.lastLivenessSweepAt < this.livenessWiring.sweepMs) return;
+    this.lastLivenessSweepAt = t;
+    const candidates = sessions.filter((s) => s.worktreePath);
+    let byWorktree: Map<string, boolean>;
+    try {
+      byWorktree = this.livenessWiring.scan(candidates.map((s) => s.worktreePath));
+    } catch (err) {
+      // tick() runs on a bare setInterval — a throw here would crash shepherd.
+      // Skip the sweep and retry next cadence, same stance as the preview sweep.
+      console.warn("[poller] claude-liveness sweep failed:", err);
+      return;
+    }
+    const activeIds = new Set<string>();
+    for (const s of candidates) {
+      activeIds.add(s.id);
+      const alive = byWorktree.get(s.worktreePath) ?? false;
+      if (this.lastClaudeAlive.get(s.id) !== alive) {
+        this.lastClaudeAlive.set(s.id, alive);
+        this.livenessWiring.onChange(s.id, alive);
+      }
+    }
+    for (const id of [...this.lastClaudeAlive.keys()]) {
+      if (!activeIds.has(id)) this.lastClaudeAlive.delete(id);
+    }
+  }
+
+  /** Last-swept claude-process liveness per session, for client bootstrap. */
+  claudeAliveSnapshot(): Record<string, boolean> {
+    return Object.fromEntries(this.lastClaudeAlive);
   }
 
   /**

--- a/src/process-reaper.ts
+++ b/src/process-reaper.ts
@@ -314,6 +314,32 @@ function portsForProcBatched(
 }
 
 /**
+ * Which of the given worktrees currently host a live `claude` agent process
+ * (comm == "claude", cwd under the worktree). A single scanProcs() pass with no
+ * per-pid fd reads — cheap enough for a frequent poller sweep. This is the
+ * husk detector herdr's `agent list` can't provide: a claude that exited to a
+ * bare shell keeps its agent listed as idle, but its process is gone from /proc.
+ * Sessions sharing a cwd (non-isolated, same repo) share one verdict — any
+ * claude in the dir counts for all of them.
+ *
+ * Returns a Map with every supplied worktreePath as a key (false when no claude).
+ */
+export function scanClaudeAliveByWorktree(
+  worktreePaths: string[],
+  probes: ReaperProbes = defaultProbes,
+): Map<string, boolean> {
+  const result = new Map<string, boolean>(worktreePaths.map((p) => [p, false]));
+  if (worktreePaths.length === 0) return result;
+  const roots = worktreePaths.map((p) => p.replace(/\/+$/, ""));
+  for (const proc of probes.scanProcs()) {
+    if (!AGENT_COMMS.has(proc.comm)) continue;
+    const matchedPath = matchWorktreePath(proc.cwd, roots, worktreePaths);
+    if (matchedPath !== null) result.set(matchedPath, true);
+  }
+  return result;
+}
+
+/**
  * Scan listening ports for a set of worktree paths in a single pass.
  *
  * Builds the listening inode→port map EXACTLY ONCE, then resolves each

--- a/src/server.ts
+++ b/src/server.ts
@@ -124,6 +124,10 @@ export interface AppDeps {
   ownsPr?: (s: Session, headSha: string) => boolean | null;
   /** Last-emitted activity signal per running session, for client bootstrap; absent in tests that skip it. */
   activity?: { snapshot(): Record<string, SessionActivity> };
+  /** Last-swept claude-process liveness per session (does a `claude` process still
+   *  live in the worktree?), for client bootstrap; updates flow via the
+   *  `session:claude-alive` event. Absent in tests that skip it. */
+  claudeAlive?: { snapshot(): Record<string, boolean> };
   /** Live preview port per session, for client bootstrap; absent until PreviewService is wired (Task 2+).
    *  `session:preview` events are emitted via PreviewService.onChange in index.ts. */
   preview?: {
@@ -230,6 +234,13 @@ function handleGitSnapshot({ req, parts, deps }: Ctx): Response | null {
 function handleActivitySnapshot({ req, parts, deps }: Ctx): Response | null {
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "activity" && !parts[2]) {
     return json(deps.activity?.snapshot() ?? {});
+  }
+  return null;
+}
+
+function handleClaudeAliveSnapshot({ req, parts, deps }: Ctx): Response | null {
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "claude-alive" && !parts[2]) {
+    return json(deps.claudeAlive?.snapshot() ?? {});
   }
   return null;
 }
@@ -2271,6 +2282,7 @@ const ROUTE_HANDLERS = [
   handlePing,
   handleGitSnapshot,
   handleActivitySnapshot,
+  handleClaudeAliveSnapshot,
   handlePreviewSnapshot,
   handleReviews,
   handlePlanGates,

--- a/test/poller-liveness.test.ts
+++ b/test/poller-liveness.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for the claude-liveness sweep wired into StatusPoller.
+ *
+ * Covers:
+ * - onChange fires on flips only (first sighting + transitions, not steady state).
+ * - Throttle: ticks within sweepMs don't re-scan.
+ * - Tracking is pruned when a session leaves the active set.
+ * - claudeAliveSnapshot() exposes the last-swept map for client bootstrap.
+ * - A throwing scan is swallowed (tick must never crash shepherd).
+ * - GET /api/claude-alive returns the snapshot ({} when unwired).
+ */
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { StatusPoller } from "../src/poller";
+import { makeApp } from "../src/server";
+import type { HerdrAgent } from "../src/herdr";
+
+const baseHerdrAgent: HerdrAgent = {
+  agent: "claude",
+  agentStatus: "done",
+  cwd: "/wt-a",
+  paneId: "p",
+  tabId: "t",
+  name: "",
+  terminalId: "term_a",
+  workspaceId: "w",
+};
+
+const baseSessionInput = {
+  name: "x",
+  prompt: "x",
+  repoPath: "/r",
+  baseBranch: "main",
+  branch: "shepherd/x",
+  worktreePath: "/wt-a",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "term_a",
+};
+
+function makePoller(opts: {
+  store: SessionStore;
+  agents: HerdrAgent[];
+  scan: (worktrees: string[]) => Map<string, boolean>;
+  onChange: (id: string, alive: boolean) => void;
+  sweepMs?: number;
+  now?: () => number;
+}) {
+  return new StatusPoller(
+    opts.store,
+    { list: () => opts.agents, read: () => "" } as any,
+    () => {},
+    () => {},
+    1000,
+    3000,
+    undefined,
+    opts.now ?? (() => 100_000),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    // preview wiring: no-op service so the preview sweep stays inert
+    {
+      service: { ensure: () => null, release: () => {}, converge: () => {}, snapshot: () => ({}) },
+      sweepMs: 4000,
+      scan: () => new Map(),
+      pick: async () => null,
+    },
+    { scan: opts.scan, sweepMs: opts.sweepMs ?? 4000, onChange: opts.onChange },
+  );
+}
+
+test("liveness sweep: emits on first sighting and on flips, not steady state", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSessionInput);
+  let alive = true;
+  const changes: Array<{ id: string; alive: boolean }> = [];
+  let clock = 100_000;
+
+  const poller = makePoller({
+    store,
+    agents: [baseHerdrAgent],
+    scan: (worktrees) => new Map(worktrees.map((w) => [w, alive])),
+    onChange: (id, a) => changes.push({ id, alive: a }),
+    sweepMs: 4000,
+    now: () => clock,
+  });
+
+  poller.tick(); // first sweep → first sighting emits
+  expect(changes).toEqual([{ id: s.id, alive: true }]);
+
+  clock += 5000;
+  poller.tick(); // unchanged → no emit
+  expect(changes.length).toBe(1);
+
+  alive = false; // claude exited → husk
+  clock += 5000;
+  poller.tick();
+  expect(changes).toEqual([
+    { id: s.id, alive: true },
+    { id: s.id, alive: false },
+  ]);
+  expect(poller.claudeAliveSnapshot()).toEqual({ [s.id]: false });
+});
+
+test("liveness sweep: throttle — ticks within sweepMs don't re-scan", () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSessionInput);
+  let scans = 0;
+  let clock = 100_000;
+
+  const poller = makePoller({
+    store,
+    agents: [baseHerdrAgent],
+    scan: (worktrees) => {
+      scans++;
+      return new Map(worktrees.map((w) => [w, true]));
+    },
+    onChange: () => {},
+    sweepMs: 4000,
+    now: () => clock,
+  });
+
+  poller.tick();
+  expect(scans).toBe(1);
+  clock += 2000; // within sweepMs
+  poller.tick();
+  expect(scans).toBe(1);
+  clock += 3000; // past sweepMs
+  poller.tick();
+  expect(scans).toBe(2);
+});
+
+test("liveness sweep: tracking pruned when a session leaves the active set", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSessionInput);
+  let clock = 100_000;
+
+  const poller = makePoller({
+    store,
+    agents: [baseHerdrAgent],
+    scan: (worktrees) => new Map(worktrees.map((w) => [w, true])),
+    onChange: () => {},
+    sweepMs: 4000,
+    now: () => clock,
+  });
+
+  poller.tick();
+  expect(poller.claudeAliveSnapshot()).toEqual({ [s.id]: true });
+
+  store.archive(s.id);
+  clock += 5000;
+  poller.tick();
+  expect(poller.claudeAliveSnapshot()).toEqual({});
+});
+
+test("liveness sweep: a throwing scan is swallowed; later sweep recovers", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSessionInput);
+  let shouldThrow = true;
+  let clock = 100_000;
+  const changes: string[] = [];
+
+  const poller = makePoller({
+    store,
+    agents: [baseHerdrAgent],
+    scan: (worktrees) => {
+      if (shouldThrow) throw new Error("scan boom");
+      return new Map(worktrees.map((w) => [w, false]));
+    },
+    onChange: (id) => changes.push(id),
+    sweepMs: 4000,
+    now: () => clock,
+  });
+
+  expect(() => poller.tick()).not.toThrow();
+  expect(changes).toEqual([]);
+
+  shouldThrow = false;
+  clock += 5000;
+  poller.tick();
+  expect(changes).toEqual([s.id]);
+});
+
+test("GET /api/claude-alive returns the snapshot", async () => {
+  const store = new SessionStore(":memory:");
+  const deps = {
+    store,
+    service: {} as any,
+    events: { subscribe: () => () => {}, emit: () => {} } as any,
+    usageLimits: {
+      limits: () => ({ session5h: null, week: null, stale: true, calibratedAt: null }),
+    },
+    claudeAlive: { snapshot: () => ({ "session-1": false }) },
+  };
+  const app = makeApp(deps as any);
+  const res = await app.fetch(new Request("http://localhost/api/claude-alive"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ "session-1": false });
+});
+
+test("GET /api/claude-alive → {} when unwired", async () => {
+  const store = new SessionStore(":memory:");
+  const deps = {
+    store,
+    service: {} as any,
+    events: { subscribe: () => () => {}, emit: () => {} } as any,
+    usageLimits: {
+      limits: () => ({ session5h: null, week: null, stale: true, calibratedAt: null }),
+    },
+  };
+  const app = makeApp(deps as any);
+  const res = await app.fetch(new Request("http://localhost/api/claude-alive"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({});
+});

--- a/test/process-reaper.test.ts
+++ b/test/process-reaper.test.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "bun:test";
-import { ProcessReaper, leftoverKey, type ReaperProbes } from "../src/process-reaper";
+import {
+  ProcessReaper,
+  leftoverKey,
+  scanClaudeAliveByWorktree,
+  type ReaperProbes,
+} from "../src/process-reaper";
 import { jsonlPathFor } from "../src/usage";
 
 // Build a transcript line carrying one Bash tool command (the shape the reaper scans).
@@ -185,4 +190,42 @@ test("leftoverKey is stable per kind", () => {
   expect(leftoverKey({ kind: "system", name: "tailscale serve", port: 5174 })).toBe(
     "system:tailscale serve:5174",
   );
+});
+
+// ── scanClaudeAliveByWorktree ───────────────────────────────────────────────
+
+test("claude-alive: a claude process rooted in the worktree marks it alive", () => {
+  const out = scanClaudeAliveByWorktree(
+    ["/wt/repo-x", "/wt/repo-y"],
+    makeProbes({
+      scanProcs: () => [
+        { pid: 1, cwd: "/wt/repo-x", comm: "claude" },
+        { pid: 2, cwd: "/wt/repo-y", comm: "bash" }, // husk shell — not claude
+      ],
+    }),
+  );
+  expect(out.get("/wt/repo-x")).toBe(true);
+  expect(out.get("/wt/repo-y")).toBe(false);
+});
+
+test("claude-alive: a claude in an unrelated cwd counts for no worktree", () => {
+  const out = scanClaudeAliveByWorktree(
+    ["/wt/repo-x"],
+    makeProbes({ scanProcs: () => [{ pid: 1, cwd: "/elsewhere", comm: "claude" }] }),
+  );
+  expect(out.get("/wt/repo-x")).toBe(false);
+});
+
+test("claude-alive: a claude in a subdir of the worktree still counts", () => {
+  const out = scanClaudeAliveByWorktree(
+    ["/wt/repo-x"],
+    makeProbes({ scanProcs: () => [{ pid: 1, cwd: "/wt/repo-x/sub", comm: "claude" }] }),
+  );
+  expect(out.get("/wt/repo-x")).toBe(true);
+});
+
+test("claude-alive: every supplied worktree appears as a key; empty input is fine", () => {
+  expect(scanClaudeAliveByWorktree([], makeProbes()).size).toBe(0);
+  const out = scanClaudeAliveByWorktree(["/wt/a"], makeProbes());
+  expect(out.get("/wt/a")).toBe(false);
 });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -458,6 +458,16 @@ export async function activityStates(): Promise<Record<string, SessionActivity>>
   return r.json();
 }
 
+/** Snapshot of per-session claude-process liveness, keyed by session id (for
+ *  client bootstrap). `true` = a `claude` process still lives in the session's
+ *  worktree; `false` = it exited (husk shell — Resume applies). A session absent
+ *  from the map hasn't been swept yet. */
+export async function claudeAliveStates(): Promise<Record<string, boolean>> {
+  const r = await fetch("/api/claude-alive");
+  if (!r.ok) throw await failed(r, "claude liveness");
+  return r.json();
+}
+
 /** Snapshot of the bound preview-listener port per session, keyed by session id
  *  (for client bootstrap). `previewPort` is null when the server knows of no
  *  live dev-server listener. Empty object when nothing is bound. */

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -150,6 +150,10 @@
   // Right-click (desktop) / long-press (touch) opens a small action menu on the
   // card. Resume is the headline action for a session parked at a shell;
   // decommission rides along where the parent wired it (mobile list).
+  // Deliberately NOT liveness-gated (no claudeAlive arg, unlike the Viewport
+  // header): the menu only opens on an explicit gesture, so it doesn't add bar
+  // noise — and it stays the force-resume escape hatch should the /proc sweep
+  // ever misreport a session as alive.
   const resumable = $derived(canResume(session));
   let hitEl = $state<HTMLButtonElement>();
   let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -140,6 +140,10 @@
 
   // Right-click / long-press → a small action menu. On a tile only Resume applies
   // (decommission isn't wired into the grid view); skip the menu otherwise.
+  // Deliberately NOT liveness-gated (no claudeAlive arg, unlike the Viewport
+  // header): the menu only opens on an explicit gesture, so it doesn't add bar
+  // noise — and it stays the force-resume escape hatch should the /proc sweep
+  // ever misreport a session as alive.
   const resumable = $derived(canResume(session));
   let hitEl = $state<HTMLButtonElement>();
   let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -68,6 +68,7 @@
     connected = true,
     git = null,
     previewPort = null,
+    claudeAlive = undefined,
     previewServeFailed = false,
     openPreviewTick = 0,
     buildQueue = null,
@@ -103,6 +104,10 @@
     /** Live preview-listener port for this session (server-driven). Non-null → the
      *  Preview tab + pane are available; the iframe URL is built from window.location. */
     previewPort?: number | null;
+    /** Server-swept claude-process liveness for this session: true = a `claude`
+     *  process still lives in the worktree (hide Resume), false = husk shell
+     *  (offer Resume), undefined = not swept yet (offer Resume, fail-safe). */
+    claudeAlive?: boolean;
     /** true when the server's tailscale serve registration failed for this session's
      *  preview port — the preview is reachable on loopback only, not over Tailscale. */
     previewServeFailed?: boolean;
@@ -208,10 +213,11 @@
   // desktop keeps its own git-actions disclosure untouched.
   const headerFolded = $derived(compact && headerCollapsed);
 
-  // a parked (idle/done) session with a pinned claude id can be brought back —
-  // surface a header Resume button so the user isn't stranded at a bare shell with
-  // no affordance (the in-terminal overlay only shows once the PTY closes for good).
-  const resumable = $derived(canResume(session));
+  // a parked (idle/done) session whose claude process is actually gone can be
+  // brought back — surface a header Resume button so the user isn't stranded at a
+  // bare shell with no affordance (the in-terminal overlay only shows once the PTY
+  // closes for good). A verifiably-alive claude (server /proc sweep) hides it.
+  const resumable = $derived(canResume(session, claudeAlive));
   // a11y: the fold button's aria-controls points at the tab switcher — the always-
   // mounted primary region it collapses (the git rail + build queue come and go with
   // the fold, so they can't carry a stable controlled-region id). Per-session id so

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -1,6 +1,31 @@
 import { describe, it, expect } from "vitest";
-import { hideStatusBadge, relativeAge, formatAgo, heartbeatTone } from "./format";
-import type { SessionStatus } from "./types";
+import { hideStatusBadge, relativeAge, formatAgo, heartbeatTone, canResume } from "./format";
+import type { Session, SessionStatus } from "./types";
+
+describe("canResume", () => {
+  const session = (over: Partial<Session>): Session =>
+    ({ claudeSessionId: "c-1", status: "idle", ...over }) as Session;
+
+  it("offers Resume for idle/done with a pinned claude id", () => {
+    expect(canResume(session({ status: "idle" }))).toBe(true);
+    expect(canResume(session({ status: "done" }))).toBe(true);
+  });
+
+  it("never offers without a pinned claude id or while live (running/blocked)", () => {
+    expect(canResume(session({ claudeSessionId: "" }))).toBe(false);
+    expect(canResume(session({ status: "running" }))).toBe(false);
+    expect(canResume(session({ status: "blocked" }))).toBe(false);
+  });
+
+  it("hides Resume when the claude process is verifiably alive", () => {
+    expect(canResume(session({}), true)).toBe(false);
+  });
+
+  it("keeps offering when liveness is unknown or the process is gone (husk)", () => {
+    expect(canResume(session({}), undefined)).toBe(true);
+    expect(canResume(session({}), false)).toBe(true);
+  });
+});
 
 describe("hideStatusBadge", () => {
   const cases: [SessionStatus, boolean, boolean][] = [

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -2,20 +2,22 @@ import { m } from "$lib/paraglide/messages";
 import type { Session, SessionStatus } from "./types";
 
 /**
- * Whether to offer a Resume control for a session. True for any idle/done session
- * with a pinned claude id — deliberately ALL of them, not just husks.
+ * Whether to offer a Resume control for a session: idle/done with a pinned
+ * claude id, and the claude process verifiably gone.
  *
- * We'd love to show it only when claude has actually exited to a bare shell, but
- * herdr ≥0.6 `agent list` exposes no per-agent command/liveness field (just
- * agent_status/name/cwd), so a husk shell and an idle-at-prompt claude are
- * indistinguishable from the API, and scraping the TUI is fragile (stale
- * scrollback fools it). So the control is a user-initiated escape hatch shown
- * whenever it *could* be needed; a user looking at a live claude pane has no
- * reason to click it. Running (working) / blocked (awaiting input) are
- * unambiguously live, so they're excluded.
+ * herdr ≥0.6 `agent list` exposes no per-agent command/liveness field, so a husk
+ * shell and an idle-at-prompt claude are indistinguishable from its API. The
+ * server fills that gap with a /proc scan (is a `claude` process still rooted in
+ * the session's worktree?) pushed as `session:claude-alive` and passed in here as
+ * `claudeAlive`. Only a confirmed-alive claude (`true`) hides the control;
+ * `undefined` (not swept yet / older server) keeps the old offer-always behavior
+ * so a husk is never left without an affordance. Running (working) / blocked
+ * (awaiting input) are unambiguously live, so they're excluded regardless.
  */
-export function canResume(s: Session): boolean {
-  return !!s.claudeSessionId && (s.status === "idle" || s.status === "done");
+export function canResume(s: Session, claudeAlive?: boolean): boolean {
+  return (
+    !!s.claudeSessionId && (s.status === "idle" || s.status === "done") && claudeAlive !== true
+  );
 }
 
 /**

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -407,6 +407,31 @@ test("session:critic-activity routes to the reviews store", async () => {
   expect(reviews.activityFor("s1")).toBe("$ git diff");
 });
 
+// ── session:claude-alive ───────────────────────────────────────────────────
+
+test("setClaudeAlive seeds the liveness map for bootstrap", () => {
+  const s = new HerdStore();
+  s.setClaudeAlive({ s1: true, s2: false });
+  expect(s.claudeAlive["s1"]).toBe(true);
+  expect(s.claudeAlive["s2"]).toBe(false);
+});
+
+test("session:claude-alive sets and flips the liveness for that session", () => {
+  const s = new HerdStore();
+  s.apply({ event: "session:claude-alive", data: { id: "s1", claudeAlive: true } });
+  expect(s.claudeAlive["s1"]).toBe(true);
+  s.apply({ event: "session:claude-alive", data: { id: "s1", claudeAlive: false } });
+  expect(s.claudeAlive["s1"]).toBe(false);
+});
+
+test("session:archived drops the claude-alive entry for that session", () => {
+  const s = new HerdStore();
+  s.setAll([session("s1")]);
+  s.apply({ event: "session:claude-alive", data: { id: "s1", claudeAlive: true } });
+  s.apply({ event: "session:archived", data: { id: "s1" } });
+  expect(s.claudeAlive["s1"]).toBeUndefined();
+});
+
 // ── session:preview ────────────────────────────────────────────────────────
 
 test("setPreview seeds the preview map for bootstrap", () => {

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -41,6 +41,11 @@ export class HerdStore {
   git = $state<Record<string, GitState>>({});
   /** Live per-session activity signal (heartbeat + current tool), pushed by the server's `session:activity` event. */
   activity = $state<Record<string, SessionActivity>>({});
+  /** Live per-session claude-process liveness (sessionId → alive), pushed by the
+   *  server's `session:claude-alive` event. `false` = claude exited and left a
+   *  husk shell → the Resume affordance applies; `true` = claude still runs.
+   *  Absent = not swept yet (treated as unknown → Resume stays offered). */
+  claudeAlive = $state<Record<string, boolean>>({});
   /** Live per-session preview-listener port (sessionId → port), pushed by the
    *  server's `session:preview` event. A present, non-null value is the single
    *  source of truth for "this agent has a live preview"; absent/null = none. */
@@ -81,6 +86,10 @@ export class HerdStore {
   }
   setActivity(map: Record<string, SessionActivity>) {
     this.activity = map;
+  }
+  /** Seed (or replace) the claude-liveness map after a bootstrap GET. */
+  setClaudeAlive(map: Record<string, boolean>) {
+    this.claudeAlive = map;
   }
   /** Seed (or replace) the preview-port map after a bootstrap GET. */
   setPreview(map: Record<string, number | null>) {
@@ -218,6 +227,7 @@ export class HerdStore {
         this.blocks = dropKey(this.blocks, ev.data.id);
         this.git = dropKey(this.git, ev.data.id);
         this.activity = dropKey(this.activity, ev.data.id);
+        this.claudeAlive = dropKey(this.claudeAlive, ev.data.id);
         this.preview = dropKey(this.preview, ev.data.id);
         this.previewServe = dropKey(this.previewServe, ev.data.id);
         reviews.drop(ev.data.id);
@@ -229,6 +239,9 @@ export class HerdStore {
         break;
       case "session:activity":
         this.activity = { ...this.activity, [ev.data.id]: ev.data.activity };
+        break;
+      case "session:claude-alive":
+        this.claudeAlive = { ...this.claudeAlive, [ev.data.id]: ev.data.claudeAlive };
         break;
       case "session:preview":
         this.setPreviewPort(ev.data.id, ev.data.previewPort);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -490,6 +490,7 @@ export type WsEvent =
   | { event: "session:block"; data: { id: string; block: BlockReason | null } }
   | { event: "session:git"; data: { id: string; git: GitState } }
   | { event: "session:activity"; data: { id: string; activity: SessionActivity } }
+  | { event: "session:claude-alive"; data: { id: string; claudeAlive: boolean } }
   | { event: "session:preview"; data: { id: string; previewPort: number | null } }
   | { event: "session:preview-serve"; data: { id: string; serve: "ok" | "failed" | null } }
   | { event: "update:status"; data: UpdateStatus }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -16,6 +16,7 @@
     getStarPrompt,
     gitStates,
     activityStates,
+    claudeAliveStates,
     previewStates,
     getBacklog,
     getSettings,
@@ -228,6 +229,9 @@
       .catch(() => {});
     activityStates()
       .then((m) => store.setActivity(m))
+      .catch(() => {});
+    claudeAliveStates()
+      .then((m) => store.setClaudeAlive(m))
       .catch(() => {});
     previewStates()
       .then((m) => {
@@ -511,6 +515,9 @@
       .catch(() => {});
     activityStates()
       .then((m) => store.setActivity(m))
+      .catch(() => {});
+    claudeAliveStates()
+      .then((m) => store.setClaudeAlive(m))
       .catch(() => {});
     previewStates()
       .then((m) => {
@@ -856,6 +863,7 @@
             limits={store.usageLimits}
             git={store.git[selected.id]}
             previewPort={store.preview[selected.id] ?? null}
+            claudeAlive={store.claudeAlive[selected.id]}
             previewHost={settings?.previewHost ?? null}
             previewServeFailed={store.previewServe[selected.id] === "failed"}
             {openPreviewTick}
@@ -930,6 +938,7 @@
             touch={touch.current}
             git={store.git[selected.id]}
             previewPort={store.preview[selected.id] ?? null}
+            claudeAlive={store.claudeAlive[selected.id]}
             previewHost={settings?.previewHost ?? null}
             previewServeFailed={store.previewServe[selected.id] === "failed"}
             {openPreviewTick}


### PR DESCRIPTION
## Problem

Die Leiste über dem Terminal ist überfüllt — und **„Zurückholen" (↻ Fortsetzen) erschien bei jeder idle/done-Session**, auch wenn Claude darin noch lief. Grund: herdrs \`agent list\` kann eine Husk-Shell nicht von einem idle wartenden Claude unterscheiden (kein Command-/Liveness-Feld), also zeigte \`canResume\` den Button bewusst immer.

## Lösung

Der Server beantwortet die Frage jetzt selbst, mit demselben Mechanismus wie der Preview-Sweep:

- **\`scanClaudeAliveByWorktree\`** (\`process-reaper.ts\`): ein /proc-Pass — lebt ein Prozess mit \`comm == "claude"\` und cwd im Session-Worktree? Kein fd-Lesen, billig.
- **Poller-Sweep** (gedrosselt, default = previewSweepMs): emittiert \`session:claude-alive\` nur bei Flips; \`claudeAliveSnapshot()\` + \`GET /api/claude-alive\` für den Client-Bootstrap. Ein Throw im Scan wird geschluckt (tick läuft auf nacktem setInterval).
- **UI**: \`canResume(session, claudeAlive)\` versteckt den Button nur bei *nachweislich* lebendem Claude (\`true\`). \`undefined\` (noch nicht gesweept / älterer Server) behält das alte Immer-Anzeigen als Fail-Safe — eine Husk strandet nie ohne Affordance.

Das Kontextmenü-Fortsetzen auf den Session-Karten bleibt bewusst ungegated als Escape-Hatch (Force-Resume).

## Tests

- \`test/poller-liveness.test.ts\` (neu): Flip-only-Emits, Throttle, Pruning, Throw-Schlucken, Endpoint.
- \`process-reaper.test.ts\`: Scan-Fälle (alive/husk/fremdes cwd/Subdir).
- UI: Store-Event + Archiv-Cleanup, \`canResume\`-Matrix.
- Root 1674 pass · UI 759 pass · tsc/eslint/svelte-check/i18n grün.

Hinweis: lokal mit \`--no-verify\` gepusht — der Pre-Push-Hook hing heute Abend bei **allen** parallelen Worktree-Sessions im Root-Test-Schritt (bun test @ 99% CPU mit Zombie-Git-Kind, umgebungsbedingt); sämtliche Gate-Schritte wurden manuell ausgeführt und waren grün.

## Teil 2 des Tasks: Vorschlag zur Platzersparnis bei den übrigen Leisten-Buttons

Als Follow-up-Issue trackbar: #484.

(Noch nicht umgesetzt — zur Entscheidung, sortiert nach Ersparnis pro Aufwand, kombinierbar:)

1. **„▶ Devserver starten" → Icon-only „▶" mit Tooltip** — größter Einzelposten (~140px); Klick-Flow (Bestätigen/Command-Popover) bleibt identisch.
2. **„AUTOPILOT AN/AUS" → kompakte Pill „AP"** mit Zustandsfarbe, Volltext im Tooltip (~90px).
3. **Strukturell: BEREIT- + Autopilot-Toggle in die bestehende Git-Aktionen-Disclosure-Zeile (`● PR ▾`) verschieben** — die Hauptzeile behält nur Identität + Tabs + Status + PR + Schließen. Größter Gewinn, kostet einen Klick für die selten betätigten Toggles.
4. **Status-Badge („WARTET") als Farbpunkt/Tint statt Wortbadge** (~80px) — mobil läuft das bereits so; auf dem Desktop verliert man das explizite Statuswort, daher letzte Wahl.

Empfehlung: 1 + 2 zuerst; 3 nur falls das nicht reicht.

