### PR TITLE
docs(readme): drop stale tank/ directory note

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ like a human at a terminal. Around those sessions it adds the engineering discip
 agent work otherwise erodes: every plan and PR faces adversarial review, and nothing merges while
 behind its base — a stale PR is rebased and re-verified first.
 
-> The repo directory is `tank/` for historical reasons; the product is **Shepherd**.
-
 ## Opinionated by design
 
 Running many agents is the easy half; keeping their output shippable is the actual product.


### PR DESCRIPTION
## Why

The only remaining "tank" reference in `README.md` was a historical note:

> The repo directory is `tank/` for historical reasons; the product is **Shepherd**.

It has been there verbatim since the README was first added (`245f639c docs: add README`), but it is now **factually stale** — the repo no longer lives in `tank/`:

- main worktree: `~/Work/shepherd`
- remote: `erwins-enkel/shepherd`

The note describes a directory name that no longer exists, so it's just leftover cruft from the Tank→Shepherd rename. Removed it.

## Change

- Delete the one-line stale `tank/` directory note (and its surrounding blank line).

No user-facing UX, no new strings → `[no-feature-entry]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)