### PR TITLE
feat(push): warn once per window when 5h usage crosses 80%

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,14 @@ import { validateRoot } from "./dirs";
 import { UpdateService } from "./update";
 import { HerdrUpdateService } from "./herdr-update";
 import { StarPromptService } from "./star-prompt";
-import { PushService, attachPush, attachReviewPush, attachGitPush, attachMergePush } from "./push";
+import {
+  PushService,
+  attachPush,
+  attachReviewPush,
+  attachGitPush,
+  attachMergePush,
+  attachUsagePush,
+} from "./push";
 import { Presence } from "./presence";
 import { ReviewService } from "./review";
 import { PlanGateService } from "./plan-gate";
@@ -659,6 +666,7 @@ setTimeout(runDailySweep, 10_000); // once shortly after boot
 setInterval(runDailySweep, 24 * 60 * 60 * 1000);
 
 // recompute live limit % from local JSONL ~every 30s; push to clients
+attachUsagePush(events, store, push);
 setInterval(async () => {
   await accountIndex.refresh(Date.now());
   events.emit("usage:limits", usageLimits.limits(Date.now()));

--- a/src/push.ts
+++ b/src/push.ts
@@ -17,7 +17,8 @@ export interface PushPayload {
     | "review-human"
     | "autopilot"
     | "autopilot-done"
-    | "merge_attention";
+    | "merge_attention"
+    | "usage_limit";
   tag: string;
 }
 
@@ -34,6 +35,7 @@ const KIND_CATEGORY: Record<PushPayload["kind"], PushCategory> = {
   "review-human": "reviews",
   ci: "ci",
   merge_attention: "ci",
+  usage_limit: "agent",
 };
 
 /** A notification described by intent, not text — localized per device at send time. */
@@ -46,7 +48,8 @@ export interface NotifyInput {
     | "review-human"
     | "autopilot"
     | "autopilot-done"
-    | "merge_attention";
+    | "merge_attention"
+    | "usage_limit";
   sessionId: string;
   tag: string;
   name: string;
@@ -63,6 +66,10 @@ export interface NotifyInput {
   mergeState?: "merge_error" | "rebase_cap";
   /** For kind "merge_attention": the desig of the session that needs attention. */
   desig?: string;
+  /** For kind "usage_limit": percent of the 5-hour window already used. */
+  pct?: number;
+  /** For kind "usage_limit": epoch ms when the window resets. */
+  resetAt?: number;
   /** Overrides the cooldown key (default `${kind}:${sessionId}`). */
   cooldownKey?: string;
 }
@@ -106,6 +113,9 @@ const NOTIFY_TEXT = {
     mergeErrorBody: (desig: string) => `${desig}: the merge train needs your help`,
     rebaseCapTitle: "Rebase limit reached",
     rebaseCapBody: (desig: string) => `${desig}: too many rebase attempts — over to you`,
+    usageLimitTitle: (pct: number) => `5-hour limit at ${pct}%`,
+    usageLimitBody: (time: string | null) =>
+      time ? `Approaching the usage cap — resets at ${time}.` : "Approaching the usage cap.",
   },
   de: {
     doneTitle: (name: string) => `${name} — wartet`,
@@ -134,6 +144,9 @@ const NOTIFY_TEXT = {
     mergeErrorBody: (desig: string) => `${desig}: der Merge-Train braucht deine Hilfe`,
     rebaseCapTitle: "Rebase-Limit erreicht",
     rebaseCapBody: (desig: string) => `${desig}: zu viele Rebase-Versuche — du bist dran`,
+    usageLimitTitle: (pct: number) => `5-Stunden-Limit bei ${pct} %`,
+    usageLimitBody: (time: string | null) =>
+      time ? `Limit fast erreicht — Reset um ${time}.` : "Limit fast erreicht.",
   },
 } as const;
 
@@ -170,6 +183,15 @@ export function blockSummary(reason: BlockReason, locale: string = "en"): string
     default:
       return t.other;
   }
+}
+
+/** Locale-formatted clock time of a window reset, or null without an anchor. */
+function resetTimeLabel(resetAt: number | undefined, locale: NotifyLocale): string | null {
+  if (resetAt === undefined) return null;
+  return new Intl.DateTimeFormat(locale === "de" ? "de-DE" : "en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(resetAt));
 }
 
 /** Build the device-facing payload for a notification in the subscriber's locale. */
@@ -212,6 +234,12 @@ export function buildPayload(input: NotifyInput, locale: string): PushPayload {
       }
       return { ...base, title: t.mergeErrorTitle, body: t.mergeErrorBody(desig) };
     }
+    case "usage_limit":
+      return {
+        ...base,
+        title: t.usageLimitTitle(input.pct ?? 0),
+        body: t.usageLimitBody(resetTimeLabel(input.resetAt, asLocale(locale))),
+      };
     default:
       return {
         ...base,
@@ -271,13 +299,14 @@ export class PushService {
     this.store.deletePushSub(endpoint);
   }
 
-  async notify(input: NotifyInput): Promise<void> {
+  /** Returns true when at least one device actually received the push. */
+  async notify(input: NotifyInput): Promise<boolean> {
     // Suppress while the app is actively in use: the live UI already surfaces
     // every status change, so an OS banner is pure noise. Decided server-side —
     // by simply not sending — because a service worker can't reliably drop a
     // push under userVisibleOnly:true (Android substitutes its own banner). We
     // don't touch the cooldown clock here: nothing was sent.
-    if (this.isActive()) return;
+    if (this.isActive()) return false;
     const cooldownMs = config.pushCooldownMs;
     const key = input.cooldownKey ?? `${input.kind}:${input.sessionId}`;
     const t = this.now();
@@ -286,7 +315,7 @@ export class PushService {
     // kinds (done vs blocked) live under separate keys and never collapse.
     if (cooldownMs > 0) {
       const last = this.lastNotified.get(key);
-      if (last !== undefined && t - last < cooldownMs) return;
+      if (last !== undefined && t - last < cooldownMs) return false;
     }
     const category = KIND_CATEGORY[input.kind];
     let sent = false;
@@ -297,6 +326,7 @@ export class PushService {
       if (await this.deliver(row, input)) sent = true;
     }
     if (sent && cooldownMs > 0) this.lastNotified.set(key, t);
+    return sent;
   }
 
   /** Send one notification; prune dead subs, log diagnostics. Returns true if delivered. */
@@ -399,6 +429,45 @@ export function attachMergePush(events: EventHub, push: PushService): void {
         cooldownKey: `${state}:${target}`,
       })
       .catch((err) => console.warn("[push] merge_attention notify failed:", err));
+  });
+}
+
+/** Warn when the 5-hour usage window crosses this percentage. */
+export const USAGE_WARN_PCT = 80;
+/** Setting key holding the resetAt of the 5h window already warned about. */
+const USAGE_WARNED_KEY = "usageWarnedResetAt5h";
+
+/** Push once per 5-hour window when usage crosses the warning threshold. */
+export function attachUsagePush(
+  events: EventHub,
+  store: SessionStore,
+  push: PushService,
+  now: () => number = () => Date.now(),
+): void {
+  events.subscribe((event, data) => {
+    if (event !== "usage:limits") return;
+    const { session5h } = data as { session5h: { pct: number; resetAt: number } | null };
+    if (!session5h || session5h.pct < USAGE_WARN_PCT) return;
+    // One warning per window: the stored resetAt marks the window already warned.
+    // Persisted (not in-memory) so the post-merge redeploys don't re-announce it.
+    const warned = Number(store.getSetting(USAGE_WARNED_KEY) ?? 0);
+    if (now() < warned) return;
+    void push
+      .notify({
+        kind: "usage_limit",
+        sessionId: "",
+        tag: "usage-5h",
+        name: "5h",
+        pct: session5h.pct,
+        resetAt: session5h.resetAt,
+        cooldownKey: "usage_limit:5h",
+      })
+      .then((sent) => {
+        // Only mark the window once a device heard it: a push suppressed while
+        // the app is active retries next tick and fires when the user steps away.
+        if (sent) store.setSetting(USAGE_WARNED_KEY, String(session5h.resetAt));
+      })
+      .catch((err) => console.warn("[push] usage_limit notify failed:", err));
   });
 }
 

--- a/src/push.ts
+++ b/src/push.ts
@@ -444,6 +444,11 @@ export function attachUsagePush(
   push: PushService,
   now: () => number = () => Date.now(),
 ): void {
+  // The warned marker is read sync but persisted in notify's .then, so an emit
+  // landing while a notify is still in flight would re-read the stale marker and
+  // could double-warn the same window. Emits are ~30s apart, far wider than push
+  // delivery — but don't rely on that spacing: skip while one is pending.
+  let inFlight = false;
   events.subscribe((event, data) => {
     if (event !== "usage:limits") return;
     const { session5h } = data as { session5h: { pct: number; resetAt: number } | null };
@@ -451,7 +456,8 @@ export function attachUsagePush(
     // One warning per window: the stored resetAt marks the window already warned.
     // Persisted (not in-memory) so the post-merge redeploys don't re-announce it.
     const warned = Number(store.getSetting(USAGE_WARNED_KEY) ?? 0);
-    if (now() < warned) return;
+    if (inFlight || now() < warned) return;
+    inFlight = true;
     void push
       .notify({
         kind: "usage_limit",
@@ -467,7 +473,10 @@ export function attachUsagePush(
         // the app is active retries next tick and fires when the user steps away.
         if (sent) store.setSetting(USAGE_WARNED_KEY, String(session5h.resetAt));
       })
-      .catch((err) => console.warn("[push] usage_limit notify failed:", err));
+      .catch((err) => console.warn("[push] usage_limit notify failed:", err))
+      .finally(() => {
+        inFlight = false;
+      });
   });
 }
 

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -630,6 +630,30 @@ test("attachUsagePush retries while the push is suppressed, marks only on delive
   expect(calls.length).toBe(3);
 });
 
+test("attachUsagePush does not double-warn when an emit lands mid-delivery", async () => {
+  const calls: any[] = [];
+  let release!: (sent: boolean) => void;
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = (p: any) => {
+    calls.push(p);
+    return new Promise<boolean>((r) => {
+      release = r;
+    });
+  };
+  const events = new EventHub();
+  attachUsagePush(events, store, push, () => 1_000);
+
+  events.emit("usage:limits", limitsEvent(85, 10_000)); // notify in flight
+  events.emit("usage:limits", limitsEvent(86, 10_000)); // marker not persisted yet → must skip
+  expect(calls.length).toBe(1);
+
+  release(true); // delivery completes, window marked
+  await tick();
+  events.emit("usage:limits", limitsEvent(87, 10_000)); // marked → still no second call
+  await tick();
+  expect(calls.length).toBe(1);
+});
+
 test("attachMergePush notifies on merge_error and rebase_cap, ignores other states", async () => {
   const calls: any[] = [];
   const { push } = svc(async () => ({}));

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -7,8 +7,10 @@ import {
   attachReviewPush,
   attachGitPush,
   attachMergePush,
+  attachUsagePush,
   blockSummary,
   buildPayload,
+  USAGE_WARN_PCT,
   type NotifyInput,
   type SendFn,
 } from "../src/push";
@@ -501,6 +503,131 @@ test("merge_attention routes to ci category", async () => {
     desig: "TASK-07",
   });
   expect(sent).toEqual(["only-ci"]);
+});
+
+test("buildPayload usage_limit localizes EN+DE and includes the reset time", () => {
+  const n: NotifyInput = {
+    kind: "usage_limit",
+    sessionId: "",
+    tag: "usage-5h",
+    name: "5h",
+    pct: 85,
+    resetAt: Date.UTC(2026, 5, 9, 19, 30),
+  };
+  const en = buildPayload(n, "en");
+  expect(en.title).toBe("5-hour limit at 85%");
+  expect(en.body).toMatch(/^Approaching the usage cap — resets at .+\.$/);
+  const de = buildPayload(n, "de");
+  expect(de.title).toBe("5-Stunden-Limit bei 85 %");
+  expect(de.body).toMatch(/^Limit fast erreicht — Reset um .+\.$/);
+  // no resetAt → body without the time suffix
+  const bare = buildPayload({ ...n, resetAt: undefined }, "en");
+  expect(bare.body).toBe("Approaching the usage cap.");
+});
+
+test("usage_limit routes to agent category", async () => {
+  const sent: string[] = [];
+  const send: SendFn = async (s) => {
+    sent.push(s.endpoint);
+    return {};
+  };
+  const { store, push } = svc(send);
+  store.putPushSub(sub("agent-on"), "");
+  store.putPushSub(sub("agent-off"), "");
+  store.setPushPrefs("agent-off", { agent: false, reviews: true, ci: true });
+  await push.notify({ kind: "usage_limit", sessionId: "", tag: "usage-5h", name: "5h", pct: 90 });
+  expect(sent).toEqual(["agent-on"]);
+});
+
+const limitsEvent = (pct: number, resetAt: number) => ({
+  session5h: { pct, resetAt },
+  week: null,
+  stale: false,
+  calibratedAt: 1,
+});
+
+/** Flush the notify→then→setSetting chain (plain microtasks aren't enough). */
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+test("attachUsagePush fires once per window at the threshold, re-arms after reset", async () => {
+  const calls: any[] = [];
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => {
+    calls.push(p);
+    return true; // delivered
+  };
+  const events = new EventHub();
+  let t = 1_000;
+  attachUsagePush(events, store, push, () => t);
+
+  const resetAt = 10_000;
+  events.emit("usage:limits", limitsEvent(USAGE_WARN_PCT - 1, resetAt)); // below → no fire
+  events.emit("usage:limits", limitsEvent(USAGE_WARN_PCT, resetAt)); // crossing → fire
+  await tick();
+  events.emit("usage:limits", limitsEvent(92, resetAt)); // same window → suppressed
+  events.emit("usage:limits", { session5h: null, week: null, stale: false, calibratedAt: 1 });
+  await tick();
+  expect(calls.length).toBe(1);
+  expect(calls[0]).toMatchObject({
+    kind: "usage_limit",
+    tag: "usage-5h",
+    pct: USAGE_WARN_PCT,
+    resetAt,
+    cooldownKey: "usage_limit:5h",
+  });
+
+  // window reset: now passes the stored resetAt and the next crossing fires again
+  t = 11_000;
+  events.emit("usage:limits", limitsEvent(81, 21_000));
+  await tick();
+  expect(calls.length).toBe(2);
+  expect(calls[1]).toMatchObject({ pct: 81, resetAt: 21_000 });
+});
+
+test("attachUsagePush survives a restart without re-announcing (persisted marker)", async () => {
+  const calls: any[] = [];
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => {
+    calls.push(p);
+    return true;
+  };
+  let events = new EventHub();
+  attachUsagePush(events, store, push, () => 1_000);
+  events.emit("usage:limits", limitsEvent(85, 10_000));
+  await tick();
+  expect(calls.length).toBe(1);
+
+  // "restart": fresh hub + fresh attach over the SAME store — marker persists
+  events = new EventHub();
+  attachUsagePush(events, store, push, () => 2_000);
+  events.emit("usage:limits", limitsEvent(85, 10_000));
+  await tick();
+  expect(calls.length).toBe(1);
+});
+
+test("attachUsagePush retries while the push is suppressed, marks only on delivery", async () => {
+  const calls: any[] = [];
+  let delivered = false;
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => {
+    calls.push(p);
+    return delivered;
+  };
+  const events = new EventHub();
+  attachUsagePush(events, store, push, () => 1_000);
+
+  events.emit("usage:limits", limitsEvent(85, 10_000)); // suppressed (e.g. app active)
+  await tick();
+  events.emit("usage:limits", limitsEvent(86, 10_000)); // still over → retried
+  await tick();
+  expect(calls.length).toBe(2);
+
+  delivered = true;
+  events.emit("usage:limits", limitsEvent(87, 10_000)); // delivered → window marked
+  await tick();
+  events.emit("usage:limits", limitsEvent(88, 10_000)); // marked → no more calls
+  await tick();
+  expect(calls.length).toBe(3);
 });
 
 test("attachMergePush notifies on merge_error and rebase_cap, ignores other states", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -890,5 +890,7 @@
   "feat_stepper_legend_title": "Aufgabenleiste zeigt alle Pipeline-Stufen",
   "feat_stepper_legend_body": "Der Fortschrittsbalken jeder Session-Karte durchläuft jetzt fünf Stufen — Planung, Implementierung, PR, Review und Bereit — wobei das PR-Segment nach CI-Status und das Review-Segment nach Review-Ergebnis eingefärbt wird. Auf dem Desktop zeigt ein Hover über die Leiste eine Stufenlegende.",
   "feat_desktop_decom_title": "Überall am Desktop stilllegen",
-  "feat_desktop_decom_body": "Fahre über eine Session-Zeile, um ein ✕ einzublenden, oder nutze die jetzt immer sichtbare Stilllegen-Schaltfläche im Session-Header — zwei Klicks (aktivieren, bestätigen) legen jede Session still, ob PR vorhanden oder nicht. Rechtsklick auf eine Zeile öffnet das vollständige Menü."
+  "feat_desktop_decom_body": "Fahre über eine Session-Zeile, um ein ✕ einzublenden, oder nutze die jetzt immer sichtbare Stilllegen-Schaltfläche im Session-Header — zwei Klicks (aktivieren, bestätigen) legen jede Session still, ob PR vorhanden oder nicht. Rechtsklick auf eine Zeile öffnet das vollständige Menü.",
+  "feat_usage_limit_push_title": "Nutzungslimit-Warnung",
+  "feat_usage_limit_push_body": "Shepherd schickt jetzt eine Push-Benachrichtigung, sobald das 5-Stunden-Limit 80 % überschreitet — einmal pro Fenster, damit du rechtzeitig reagieren kannst, bevor das Limit erreicht ist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -890,5 +890,7 @@
   "feat_stepper_legend_title": "Task bar shows each pipeline stage",
   "feat_stepper_legend_body": "Each session card's progress bar now tracks five stages — Planning, Implementing, PR, Review, and Ready — with the PR segment tinted by CI status and the Review segment by the review verdict. Hover the bar on desktop to see a stage legend.",
   "feat_desktop_decom_title": "Decommission from anywhere on desktop",
-  "feat_desktop_decom_body": "Hover a session row to reveal a ✕, or use the decommission control now always visible in the session header — two clicks (arm, confirm) decommission any session, PR or not. Right-click a row for the full menu."
+  "feat_desktop_decom_body": "Hover a session row to reveal a ✕, or use the decommission control now always visible in the session header — two clicks (arm, confirm) decommission any session, PR or not. Right-click a row for the full menu.",
+  "feat_usage_limit_push_title": "Usage limit warning",
+  "feat_usage_limit_push_body": "Shepherd now sends a push notification when the 5-hour Claude usage window crosses 80% — once per window, so you can wind down or queue work before hitting the cap."
 }

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -418,4 +418,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_desktop_decom_title",
     bodyKey: "feat_desktop_decom_body",
   },
+  {
+    // No targetId: the feature is a server-sent push notification (fires when the app
+    // is closed/inactive), so there is no anchor element — What's-New drawer only.
+    // Bumped from 1.22.0 → 1.23.0 on merge-train rebase: 1.22.0 is already tagged, so
+    // computeNewEntries (sinceVersion > lastSeen) would never surface a 1.22.0 entry.
+    id: "usage-limit-push",
+    sinceVersion: "1.23.0",
+    titleKey: "feat_usage_limit_push_title",
+    bodyKey: "feat_usage_limit_push_body",
+  },
 ];


### PR DESCRIPTION
## Summary

Sends a push notification as soon as the **5-hour Claude usage window crosses 80%** — so you can wind down or queue work deliberately before hitting the cap, instead of discovering it mid-session.


- New `usage_limit` notify kind in `src/push.ts` (EN+DE copy, routed to the **Agent** push category), body includes the locale-formatted reset time ("resets at 9:30 PM" / "Reset um 21:30").
- `attachUsagePush()` hooks the existing `usage:limits` event (recomputed every 30s) — no new polling.
- **Once per window:** the warned window's `resetAt` is persisted in settings, so the frequent post-merge redeploys don't re-announce it; after the window resets, the next crossing warns again.
- A send suppressed while the app is actively in use (existing presence gate) retries on the next tick and fires once the user steps away — to make that possible, `PushService.notify` now reports whether anything was actually delivered (`Promise<boolean>`, all existing callers unaffected).
- Feature-catalog entry (`usage-limit-push`, since 1.22.0) + EN/DE What's-New copy.

## Test plan

- `test/push.test.ts`: payload localization (EN/DE, with/without reset time), category routing, once-per-window edge-trigger, re-arm after window reset, restart persistence, retry-while-suppressed semantics — root suite 1669/1669 green.
- UI: svelte-check 0 errors, `check:i18n` parity (829 keys), vitest 754/754.
- Full pre-push gate (lint, typecheck, builds, fallow delta audit) green.
