### PR TITLE
feat(herd): inline repo emoji replaces repo line on session cards

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -861,5 +861,7 @@
   "feat_preview_stop_title": "Vorschau stoppen, um RAM freizugeben",
   "feat_preview_stop_body": "Stoppe einen Vorschau-Devserver direkt aus dem Preview-Pane, um Arbeitsspeicher freizugeben. Operatoren können auch den optionalen Auto-Stop bei Inaktivität aktivieren (SHEPHERD_PREVIEW_IDLE_STOP_MS), um unbeobachtete, inaktive Vorschauen automatisch zu beenden.",
   "feat_card_repo_icon_title": "Repo-Emoji ersetzt die Repo-Zeile auf Karten",
-  "feat_card_repo_icon_body": "Hat ein Repo ein konfiguriertes Emoji, zeigen Session-Karten es jetzt direkt vor dem Session-Namen, statt eine ganze Zeile für den Repo-Namen zu verwenden — dichtere Karten, gleiche Repo-Erkennung auf einen Blick. Repos ohne Emoji behalten die gewohnte Repo-Zeile."
+  "feat_card_repo_icon_body": "Hat ein Repo ein konfiguriertes Emoji, zeigen Session-Karten es jetzt direkt vor dem Session-Namen, statt eine ganze Zeile für den Repo-Namen zu verwenden — dichtere Karten, gleiche Repo-Erkennung auf einen Blick. Beim Hover über das Emoji erscheint der Repo-Name; ein Klick zeigt nur noch die Sessions dieses Repos, ein weiterer Klick hebt den Filter auf. Repos ohne Emoji behalten die gewohnte Repo-Zeile.",
+  "unitrow_repo_filter_aria": "Nur Sessions von {repo} anzeigen",
+  "unitrow_repo_filter_clear_aria": "{repo}-Filter aufheben, alle Sessions anzeigen"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -859,5 +859,7 @@
   "feat_herd_keynav_title": "Tastaturnavigation durch die Herde",
   "feat_herd_keynav_body": "Erreiche jede Session ohne Maus: j/k (oder die Pfeiltasten) wechseln in Listenreihenfolge durch die Herde, 1–9 springt direkt zur n-ten Session und g springt zur nächsten Session, die dich braucht. Beim Tippen im Terminal oder in einem Formular bleiben die Tasten inaktiv.",
   "feat_preview_stop_title": "Vorschau stoppen, um RAM freizugeben",
-  "feat_preview_stop_body": "Stoppe einen Vorschau-Devserver direkt aus dem Preview-Pane, um Arbeitsspeicher freizugeben. Operatoren können auch den optionalen Auto-Stop bei Inaktivität aktivieren (SHEPHERD_PREVIEW_IDLE_STOP_MS), um unbeobachtete, inaktive Vorschauen automatisch zu beenden."
+  "feat_preview_stop_body": "Stoppe einen Vorschau-Devserver direkt aus dem Preview-Pane, um Arbeitsspeicher freizugeben. Operatoren können auch den optionalen Auto-Stop bei Inaktivität aktivieren (SHEPHERD_PREVIEW_IDLE_STOP_MS), um unbeobachtete, inaktive Vorschauen automatisch zu beenden.",
+  "feat_card_repo_icon_title": "Repo-Emoji ersetzt die Repo-Zeile auf Karten",
+  "feat_card_repo_icon_body": "Hat ein Repo ein konfiguriertes Emoji, zeigen Session-Karten es jetzt direkt vor dem Session-Namen, statt eine ganze Zeile für den Repo-Namen zu verwenden — dichtere Karten, gleiche Repo-Erkennung auf einen Blick. Repos ohne Emoji behalten die gewohnte Repo-Zeile."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -859,5 +859,7 @@
   "feat_herd_keynav_title": "Herd keyboard navigation",
   "feat_herd_keynav_body": "Reach any session without the mouse: j/k (or the arrow keys) cycle through the herd in rail order, 1–9 jump straight to the Nth session, and g hops to the next session that needs you. The keys stay out of the way while you type in the terminal or a form.",
   "feat_preview_stop_title": "Stop a preview to reclaim RAM",
-  "feat_preview_stop_body": "Force-stop a previewed dev server from the preview pane to free its memory. Operators can also enable opt-in idle-stop (SHEPHERD_PREVIEW_IDLE_STOP_MS) to auto-stop idle, unwatched previews."
+  "feat_preview_stop_body": "Force-stop a previewed dev server from the preview pane to free its memory. Operators can also enable opt-in idle-stop (SHEPHERD_PREVIEW_IDLE_STOP_MS) to auto-stop idle, unwatched previews.",
+  "feat_card_repo_icon_title": "Repo emoji replaces the repo line on cards",
+  "feat_card_repo_icon_body": "When a repo has a configured emoji, session cards now show it right before the session name instead of spending a whole line on the repo name — denser cards, same at-a-glance repo identity. Repos without an emoji keep the familiar repo line."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -861,5 +861,7 @@
   "feat_preview_stop_title": "Stop a preview to reclaim RAM",
   "feat_preview_stop_body": "Force-stop a previewed dev server from the preview pane to free its memory. Operators can also enable opt-in idle-stop (SHEPHERD_PREVIEW_IDLE_STOP_MS) to auto-stop idle, unwatched previews.",
   "feat_card_repo_icon_title": "Repo emoji replaces the repo line on cards",
-  "feat_card_repo_icon_body": "When a repo has a configured emoji, session cards now show it right before the session name instead of spending a whole line on the repo name — denser cards, same at-a-glance repo identity. Repos without an emoji keep the familiar repo line."
+  "feat_card_repo_icon_body": "When a repo has a configured emoji, session cards now show it right before the session name instead of spending a whole line on the repo name — denser cards, same at-a-glance repo identity. Hover the emoji to see the repo name; click it to show only that repo's sessions, click again to clear the filter. Repos without an emoji keep the familiar repo line.",
+  "unitrow_repo_filter_aria": "Show only {repo} sessions",
+  "unitrow_repo_filter_clear_aria": "Clear the {repo} filter, show all sessions"
 }

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -25,6 +25,8 @@
     onsettings = undefined,
     flow = false,
     filteredRepo = null,
+    repoFilter = null,
+    onrepofilter = undefined,
     filter = $bindable("all"),
     statusFilter = null,
     onstatusfilter = undefined,
@@ -60,6 +62,10 @@
     // list is empty, show a neutral "no agents for this repo" note instead of the
     // first-run EmptyHerd nudge. null = unfiltered.
     filteredRepo?: string | null;
+    // full repoPath of the active repo filter — drives each row's inline-emoji
+    // pressed state; threaded with onrepofilter so the emoji toggles the filter
+    repoFilter?: string | null;
+    onrepofilter?: (repoPath: string | null) => void;
     // the all/ready list filter — bindable so the page-level keyboard navigation
     // can mirror exactly what the rail shows (herd-keynav's railOrder takes it)
     filter?: HerdFilter;
@@ -194,6 +200,8 @@
           previewServeFailed={previewServe[session.id] === "failed"}
           {onpreview}
           {ondecommission}
+          {repoFilter}
+          {onrepofilter}
         />
       {/each}
       {#if partition.ciRunning.length > 0}
@@ -212,6 +220,8 @@
             previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
+            {repoFilter}
+            {onrepofilter}
           />
         {/each}
       {/if}
@@ -231,6 +241,8 @@
             previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
+            {repoFilter}
+            {onrepofilter}
           />
         {/each}
       {/if}
@@ -250,6 +262,8 @@
             previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
+            {repoFilter}
+            {onrepofilter}
           />
         {/each}
       {/if}
@@ -271,6 +285,8 @@
             git={git[session.id]}
             activity={activity[session.id]}
             {ondecommission}
+            {repoFilter}
+            {onrepofilter}
           />
         {/each}
       {/if}
@@ -292,6 +308,8 @@
             git={git[session.id]}
             activity={activity[session.id]}
             {ondecommission}
+            {repoFilter}
+            {onrepofilter}
           />
         {/each}
       {/if}
@@ -308,6 +326,8 @@
             git={git[session.id]}
             activity={activity[session.id]}
             {ondecommission}
+            {repoFilter}
+            {onrepofilter}
           />
         {/each}
       {/if}
@@ -327,6 +347,8 @@
             previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
+            {repoFilter}
+            {onrepofilter}
           />
         {/each}
       {/if}
@@ -346,6 +368,8 @@
             previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
+            {repoFilter}
+            {onrepofilter}
           />
         {/each}
       {/if}
@@ -373,6 +397,8 @@
             previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
+            {repoFilter}
+            {onrepofilter}
           />
         {/each}
       {/if}
@@ -400,6 +426,8 @@
             previewServeFailed={previewServe[session.id] === "failed"}
             {onpreview}
             {ondecommission}
+            {repoFilter}
+            {onrepofilter}
           />
         {/each}
       {/if}

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -160,8 +160,8 @@ describe("UnitRow inline repo emoji filter", () => {
       nowMs: Date.now(),
       onselect: () => {},
     });
-    // still hover-titled with the repo name, but not a button
-    await expect.element(page.getByTitle("a", { exact: true })).toBeInTheDocument();
+    // the emoji still renders, but as plain decoration — no filter button
+    await expect.element(page.getByText("🐑")).toBeInTheDocument();
     await expect.element(page.getByRole("button", { name: /repo/i })).not.toBeInTheDocument();
   });
 });

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -3,6 +3,7 @@ import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
 import UnitRow from "./UnitRow.svelte";
+import { projectIcons } from "$lib/projectIcons.svelte";
 import type { Session } from "$lib/types";
 
 function session(partial: Partial<Session> & { id: string }): Session {
@@ -112,5 +113,55 @@ describe("UnitRow preview badge", () => {
     expect(previewed).toBe("p3");
     // the badge stops propagation, so the row's own select doesn't also fire
     expect(selects).toBe(0);
+  });
+});
+
+describe("UnitRow inline repo emoji filter", () => {
+  // The emoji's title carries the repo name (hover reveal); match it precisely.
+  it("clicking the emoji sets the repo filter without selecting the row", async () => {
+    projectIcons.apply({ "/repo/a": "🐑" });
+    let filtered: string | null | undefined;
+    let selects = 0;
+    render(UnitRow, {
+      session: session({ id: "f1" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => selects++,
+      repoFilter: null,
+      onrepofilter: (p: string | null) => (filtered = p),
+    });
+    await page.getByTitle("a", { exact: true }).click();
+    expect(filtered).toBe("/repo/a");
+    expect(selects).toBe(0);
+  });
+
+  it("clicking the emoji again (filter active) clears the filter", async () => {
+    projectIcons.apply({ "/repo/a": "🐑" });
+    let filtered: string | null | undefined;
+    render(UnitRow, {
+      session: session({ id: "f2" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      repoFilter: "/repo/a",
+      onrepofilter: (p: string | null) => (filtered = p),
+    });
+    const icon = page.getByTitle("a", { exact: true });
+    await expect.element(icon).toHaveAttribute("aria-pressed", "true");
+    await icon.click();
+    expect(filtered).toBe(null);
+  });
+
+  it("renders a non-interactive emoji when no onrepofilter is wired", async () => {
+    projectIcons.apply({ "/repo/a": "🐑" });
+    render(UnitRow, {
+      session: session({ id: "f3" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    // still hover-titled with the repo name, but not a button
+    await expect.element(page.getByTitle("a", { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByRole("button", { name: /repo/i })).not.toBeInTheDocument();
   });
 });

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -254,7 +254,10 @@
             }}>{repoIcon}</span
           >
         {:else if repoIcon}
-          <span class="name-icon" title={repoName} aria-hidden="true">{repoIcon}</span>
+          <!-- no title here: the .unit-hit overlay covers this span, so its own
+               tooltip could never surface — the overlay's repoPath title serves
+               the hover instead -->
+          <span class="name-icon" aria-hidden="true">{repoIcon}</span>
         {/if}
         <span class="name">{session.name}</span>
       </div>

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -214,14 +214,23 @@
 
     <div class="u-main">
       <div class="u-top">
+        {#if repoIcon}
+          <span class="name-icon" aria-hidden="true">{repoIcon}</span>
+        {/if}
         <span class="name">{session.name}</span>
       </div>
-      <!-- repoPath tooltip lives on .unit-hit (overlay covers this line), so it
-           still surfaces on row hover; describedby reads this line's repo name -->
-      <div class="u-repo" id="u-repo-{session.id}">
-        <span class="repo-glyph" class:emoji={repoIcon} aria-hidden="true">{repoIcon ?? "▣"}</span
-        >{repoName}
-      </div>
+      <!-- A configured project emoji identifies the repo on its own, so it moves
+           in front of the name and the repo line is dropped to save a row — but
+           stays sr-only so the aria-describedby chain keeps announcing the repo.
+           repoPath tooltip lives on .unit-hit (overlay covers this area), so it
+           still surfaces on row hover either way. -->
+      {#if repoIcon}
+        <span class="sr-only" id="u-repo-{session.id}">{repoName}</span>
+      {:else}
+        <div class="u-repo" id="u-repo-{session.id}">
+          <span class="repo-glyph" aria-hidden="true">▣</span>{repoName}
+        </div>
+      {/if}
       <div class="u-sub" id="u-sub-{session.id}">
         {session.prompt}
         {#if session.status === "running"}
@@ -526,6 +535,22 @@
     min-width: 0;
   }
 
+  /* configured project emoji standing in for the repo line */
+  .name-icon {
+    flex: none;
+    margin-right: 6px;
+    font-size: var(--fs-base);
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
   .name {
     color: var(--color-ink-bright);
     font-weight: 500;
@@ -550,15 +575,12 @@
     max-width: 34ch;
   }
   .repo-glyph {
-    /* Renders on every row regardless of status — amber here was the biggest
-       remaining contributor to the "orange wall". Muted: it's a repo marker,
-       not a state signal. (Only tints the `▣` fallback; emoji icons self-color.) */
+    /* Renders on every icon-less row regardless of status — amber here was the
+       biggest remaining contributor to the "orange wall". Muted: it's a repo
+       marker, not a state signal. */
     color: var(--color-muted);
     font-size: var(--fs-micro);
     flex-shrink: 0;
-  }
-  .repo-glyph.emoji {
-    font-size: var(--fs-base);
   }
 
   .u-sub {

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -43,6 +43,8 @@
     previewServeFailed = false,
     onpreview,
     ondecommission,
+    repoFilter = null,
+    onrepofilter,
   }: {
     session: Session;
     selected: boolean;
@@ -59,11 +61,20 @@
     onpreview?: (id: string) => void;
     // when provided, the row gains a left-swipe-to-decommission gesture (mobile)
     ondecommission?: (id: string) => void;
+    // active page-level repo filter (full repoPath); drives the icon's pressed state
+    repoFilter?: string | null;
+    // when provided, clicking the inline repo emoji toggles the repo filter:
+    // a path sets it, null clears (same contract as QueueStrip's band toggle)
+    onrepofilter?: (repoPath: string | null) => void;
   } = $props();
 
   // repo the unit works in — the last path segment of its repoPath (e.g. "community-map")
   const repoName = $derived(session.repoPath.split("/").filter(Boolean).at(-1) ?? session.repoPath);
   const repoIcon = $derived(projectIcons.iconFor(session.repoPath));
+  const repoFiltered = $derived(repoFilter === session.repoPath);
+  function toggleRepoFilter() {
+    onrepofilter?.(repoFiltered ? null : session.repoPath);
+  }
 
   const swipe = $derived(!!ondecommission);
 
@@ -214,8 +225,36 @@
 
     <div class="u-main">
       <div class="u-top">
-        {#if repoIcon}
-          <span class="name-icon" aria-hidden="true">{repoIcon}</span>
+        {#if repoIcon && onrepofilter}
+          <!-- The emoji doubles as the repo-filter toggle: hover names the repo,
+               click narrows the herd to it, click again clears. role=button (not a
+               nested <button> — the row overlay is a sibling button) raised above
+               the .unit-hit overlay like the preview badge, with stopPropagation so
+               the row's own select doesn't also fire. -->
+          <span
+            class="name-icon actionable"
+            class:filtered={repoFiltered}
+            role="button"
+            tabindex="0"
+            title={repoName}
+            aria-pressed={repoFiltered}
+            aria-label={repoFiltered
+              ? m.unitrow_repo_filter_clear_aria({ repo: repoName })
+              : m.unitrow_repo_filter_aria({ repo: repoName })}
+            onclick={(e) => {
+              e.stopPropagation();
+              toggleRepoFilter();
+            }}
+            onkeydown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.stopPropagation();
+                toggleRepoFilter();
+              }
+            }}>{repoIcon}</span
+          >
+        {:else if repoIcon}
+          <span class="name-icon" title={repoName} aria-hidden="true">{repoIcon}</span>
         {/if}
         <span class="name">{session.name}</span>
       </div>
@@ -540,6 +579,28 @@
     flex: none;
     margin-right: 6px;
     font-size: var(--fs-base);
+  }
+  /* interactive variant: the emoji toggles the repo filter — raised above the
+     .unit-hit overlay (same pattern as the preview badge) so it's hover/clickable */
+  .name-icon.actionable {
+    position: relative;
+    z-index: 1;
+    cursor: pointer;
+    padding: 0 3px;
+    margin-left: -3px;
+    border-radius: 2px;
+  }
+  .name-icon.actionable:hover {
+    background: var(--color-hover);
+  }
+  .name-icon.actionable:focus-visible {
+    outline: 1.5px solid var(--color-line-bright);
+    outline-offset: 0;
+  }
+  /* active filter: a quiet amber underline marks the icon as the engaged toggle
+     (matches the .fbtn active accent in the herd head) without adding a new hue */
+  .name-icon.actionable.filtered {
+    box-shadow: 0 1px 0 0 var(--color-amber);
   }
 
   /* Visually hidden but available to screen readers (matches GitRail.svelte) */

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -542,13 +542,17 @@
     font-size: var(--fs-base);
   }
 
+  /* Visually hidden but available to screen readers (matches GitRail.svelte) */
   .sr-only {
     position: absolute;
     width: 1px;
     height: 1px;
+    padding: 0;
+    margin: -1px;
     overflow: hidden;
-    clip: rect(0 0 0 0);
+    clip: rect(0, 0, 0, 0);
     white-space: nowrap;
+    border: 0;
   }
 
   .name {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -357,4 +357,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_preview_stop_title",
     bodyKey: "feat_preview_stop_body",
   },
+  {
+    // No targetId: the inline emoji only mounts on cards whose repo has a
+    // configured icon, so an anchor isn't guaranteed to exist — surface via the
+    // What's-New drawer only. v1.22.0 is already tagged → ships in 1.23.0.
+    id: "card-repo-icon-inline",
+    sinceVersion: "1.23.0",
+    titleKey: "feat_card_repo_icon_title",
+    bodyKey: "feat_card_repo_icon_body",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -132,10 +132,9 @@
   const runningRepoPaths = $derived(
     new Set(store.sessions.filter((s) => s.status === "running").map((s) => s.repoPath)),
   );
-  // Herd repo filter (full repo path) toggled from the repo-status band; null = all
-  // repos. Only repos that appear in the band (a running agent) are filterable — the
-  // band IS the toggle. Only narrows the herd list views — selection and global counts
-  // stay whole.
+  // Herd repo filter (full repo path), toggled from the repo-status band or from a
+  // card's inline repo emoji; null = all repos. Only narrows the herd list views —
+  // selection and global counts stay whole.
   let repoFilter = $state<string | null>(null);
   // Single source for the repo-status band: computed once here, passed to QueueStrip as
   // `rows` and reused for bandRepoPaths so band visibility and filter scope can't drift.
@@ -147,11 +146,18 @@
   const bandRepoPaths = $derived(
     new Set(bandHasValue(bandRows) ? bandRows.map((r) => r.repoPath) : []),
   );
-  // A stale filter would otherwise strand the herd: when the filtered repo's band row
-  // disappears (its last agent stopped running) its toggle vanishes with no way to
-  // reset short of a reload. Clear it the moment its repo leaves the band.
+  // A stale filter would otherwise strand the herd: with no visible toggle left for
+  // the filtered repo there is no way to reset short of a reload. A toggle exists
+  // while the repo has a band row, OR while it has a configured emoji AND a live
+  // session (the card's inline emoji un-toggles — icon-less repos have no card
+  // toggle, so for them the band remains the only one); clear the moment all are gone.
   $effect(() => {
-    if (repoFilter && !bandRepoPaths.has(repoFilter)) repoFilter = null;
+    if (
+      repoFilter &&
+      !bandRepoPaths.has(repoFilter) &&
+      !(projectIcons.iconFor(repoFilter) && store.sessions.some((s) => s.repoPath === repoFilter))
+    )
+      repoFilter = null;
   });
   // Session-status filter toggled from the TopBar tallies; null = all statuses.
   // Independent of the repo filter — both compose into herdSessions below. Sticky
@@ -903,6 +909,8 @@
           <Herd
             sessions={herdSessions}
             filteredRepo={repoFilterName}
+            {repoFilter}
+            onrepofilter={(repoPath) => (repoFilter = repoPath)}
             {statusFilter}
             onstatusfilter={(s) => (statusFilter = s)}
             {selectedId}
@@ -996,6 +1004,8 @@
         <Herd
           sessions={herdSessions}
           filteredRepo={repoFilterName}
+          {repoFilter}
+          onrepofilter={(repoPath) => (repoFilter = repoPath)}
           {statusFilter}
           onstatusfilter={(s) => (statusFilter = s)}
           {selectedId}


### PR DESCRIPTION
## Summary

When a repo has a **configured project emoji**, the session card now shows that emoji directly **before the session name** and drops the dedicated repo line — the emoji alone identifies the repo, so each card saves a full row. Repos **without** a configured icon keep the existing `▣` + repo-name line unchanged.

The inline emoji is also **interactive**:

- **Hover** reveals the repo name (title tooltip).
- **Click** narrows the herd to that repo's sessions; **click again** clears the filter (toggle, `aria-pressed`).

## Details

- `UnitRow.svelte`: with `repoIcon` set, render the emoji inline in `.u-top` and replace the `.u-repo` line with an `sr-only` span carrying the repo name — the `aria-describedby` chain (`u-repo-{id}`) keeps announcing the repo to screen readers, and the `repoPath` tooltip on the row overlay is unaffected. When `onrepofilter` is wired, the emoji becomes a `role=button` toggle raised above the row's click overlay (same pattern as the preview badge, with stopPropagation + Enter/Space).
- Filtering reuses the **existing page-level `repoFilter`** that the repo-status band (QueueStrip) already toggles — same `set-path / clear-null` contract, threaded through `Herd` to every row.
- The stale-filter auto-clear in `+page.svelte` is widened: a filter survives while the repo has a band row **or** a configured emoji + live session (the card emoji is the visible un-toggle). Icon-less repos keep the old clear-on-band-exit behavior, so the filter can never strand.
- Feature catalog entry `card-repo-icon-inline` (1.23.0, What's-New drawer only) + EN/DE message keys incl. toggle aria labels.

## Verification

- `bun run check:i18n` — 2 locales in parity (864 keys each)
- `bun run check` — 0 errors, 0 warnings
- `bun run test` — 823/823 passed (3 new browser tests: click sets filter without selecting the row, second click clears, non-wired emoji stays non-interactive)