### PR TITLE
feat(preview): demand the tailnet HTTPS URL in the dev-server start steer

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -377,13 +377,21 @@ export const DRAFT_PR_NOTE =
  * Build the steer text sent to an agent to start its dev server in the background.
  * Must instruct the agent to run the command in the background so it does NOT block
  * on the dev server (a foreground dev server never exits and would hang the agent's
- * turn forever). Agent-facing prompt, NOT i18n'd.
+ * turn forever), and to report the tailnet HTTPS URL — operators reach previews over
+ * the tailnet, so a localhost-only confirmation is useless to them. The FQDN is
+ * resolved by the agent at runtime (never baked into this prompt — it would leak the
+ * operator's tailnet name into every transcript template). Agent-facing, NOT i18n'd.
  */
 export function PREVIEW_START_STEER(command: string): string {
   return (
     `Please run \`${command}\` in the background (use Claude Code's background run / append \`&\` so it ` +
     `does NOT block your turn — a foreground dev server never exits and would hang you forever). ` +
-    `Confirm the port it's listening on once it starts, then continue what you were doing.`
+    `Confirm the port it's listening on once it starts. Then ALWAYS report the tailnet HTTPS URL, ` +
+    `not just localhost: ensure the mapping \`tailscale serve --bg --https <port> http://localhost:<port>\` ` +
+    `is registered, resolve this node's MagicDNS name (e.g. \`tailscale status --json\` → Self.DNSName), ` +
+    `verify \`https://<fqdn>:<port>/\` responds, and include that URL in your confirmation. If tailscale ` +
+    `is unavailable on this machine, say so and report the local URL instead. ` +
+    `Then continue what you were doing.`
   );
 }
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2483,6 +2483,15 @@ test("startPreview: steer contains the command in backticks", () => {
   expect(steer).toContain("`cd ui && npm run dev`");
 });
 
+test("startPreview: steer demands the tailnet HTTPS URL, not just localhost", () => {
+  const steer = PREVIEW_START_STEER("bun run dev");
+  expect(steer).toContain("tailnet HTTPS URL");
+  expect(steer).toContain("tailscale serve --bg --https");
+  // FQDN must be resolved at runtime, never baked into the prompt
+  expect(steer).toContain("tailscale status --json");
+  expect(steer).not.toMatch(/\.ts\.net/);
+});
+
 test("startPreview: returns false for an unknown session id", () => {
   const { svc, sent } = makePreviewSvc({ terminalId: "term_p", liveIds: ["term_p"] });
   expect(svc.startPreview("nope", "bun run dev")).toBe(false);


### PR DESCRIPTION
## Summary

The `PREVIEW_START_STEER` prompt (sent to an agent when the operator starts a dev-server preview) only asked the agent to confirm the **port** — so agents reported `localhost:<port>` and stopped there. Operators reach previews **over the tailnet**, so that confirmation is useless without the tailnet URL.

The steer now additionally instructs the agent to:

1. ensure the HTTPS mapping is registered: `tailscale serve --bg --https <port> http://localhost:<port>`
2. resolve the node's MagicDNS name at runtime (`tailscale status --json` → `Self.DNSName`)
3. verify `https://<fqdn>:<port>/` responds and **include that URL in its confirmation**
4. fall back to the local URL (and say so) only when tailscale is unavailable

The FQDN is deliberately never baked into the prompt template — the operator's tailnet name must not leak into the repo. A test pins this (`expect(steer).not.toMatch(/\.ts\.net/)`).

Server-only prompt change, no UI surface — `[no-feature-entry]`.

## Verification

- `bun test test/service.test.ts` — 107/107 pass (incl. new steer assertion)
- `bun run lint` — clean