### PR TITLE
feat(model): persistent operator-configurable default model

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { dirname, join } from "node:path";
 import { resolveNodeBin } from "./node-bin";
 import { loadForgeMap } from "./forge/load-config";
+import { normalizeDefaultModelSetting } from "./default-model";
 
 const dbPath = process.env.SHEPHERD_DB ?? `${process.env.HOME}/.shepherd/shepherd.db`;
 // forge map sits next to the db by default; SHEPHERD_FORGES overrides the path.
@@ -233,6 +234,11 @@ export const config = {
     PLAN_REVIEW_CYCLES_MAX,
     PLAN_REVIEW_CYCLES_DEFAULT,
   ),
+  // Default model for spawned agents. Persisted + UI-configurable. "auto" = unset seed
+  // (picker uses client promo fallback, drain falls back to no --model); an explicit
+  // value applies to both the New Task picker and drain/autopilot auto-spawns. Env seeds
+  // a fresh DB; absent/invalid → "auto".
+  defaultModel: normalizeDefaultModelSetting(process.env.SHEPHERD_DEFAULT_MODEL) ?? "auto",
   // Max consecutive auto-rebase attempts the merge train spends on a PR before pausing for the operator.
   autoMergeRebaseCap: Number(process.env.SHEPHERD_AUTOMERGE_REBASE_CAP ?? 5),
   // git host (forge) integration: per-host {type,baseUrl,token,deployWorkflow,mergeMethod}

--- a/src/default-model.ts
+++ b/src/default-model.ts
@@ -1,0 +1,38 @@
+/**
+ * Server-side source of truth for the persisted default-model SETTING value space
+ * and its mapping to a spawn flag.
+ *
+ * The SETTING space is: "auto" | "default" | <MODELS alias>.
+ *   - "auto"    = no operator preference; the UI New-Task picker uses the client-side
+ *                 Fable promo as its fallback, and drain falls back to no --model flag.
+ *   - "default" = explicit "no --model flag" for both the picker and drain.
+ *   - <alias>   = a specific model for both the picker and drain.
+ *
+ * The time-gated Fable promo is a SEPARATE, client-only New-Task-picker concern and
+ * deliberately lives only in the UI (ui/src/lib/fable-promo.ts). Drain must NEVER
+ * apply it — autonomous spawns must be deterministic and operator-controlled only.
+ */
+
+import { MODELS } from "./types";
+
+const SETTING_VALUES = new Set<string>(["auto", "default", ...MODELS]);
+
+/**
+ * Normalize an arbitrary value (env var, DB row, request body) to a valid
+ * SETTING string, or null if the value is unrecognised / wrong type.
+ * Accepted: "auto", "default", and each MODELS alias. Everything else → null.
+ */
+export function normalizeDefaultModelSetting(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return SETTING_VALUES.has(value) ? value : null;
+}
+
+/**
+ * Map a SETTING string to the spawn-ready model value passed to service.create().
+ * "auto" and "default" both resolve to null (no --model flag).
+ * Any model alias passes through unchanged.
+ */
+export function drainSpawnModel(setting: string): string | null {
+  if (setting === "auto" || setting === "default") return null;
+  return setting;
+}

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -12,6 +12,8 @@ import {
   type DrainDecision,
   type DrainRepoState,
 } from "./drain-core";
+import { config } from "./config";
+import { drainSpawnModel } from "./default-model";
 
 /** Live per-repo drain status pushed to the client (and used for bootstrap). */
 export interface DrainStatus {
@@ -314,11 +316,14 @@ export class DrainService {
     }
     try {
       const base = await forge.defaultBranch();
+      // Auto-spawns honor an explicit operator default-model; when unset ("auto")
+      // they fall back to no --model flag (Claude's own default). The Fable promo
+      // is a client-only UI concern and is NEVER applied to autonomous spawns.
       await this.deps.service.create({
         repoPath,
         baseBranch: base,
         prompt: title,
-        model: null,
+        model: drainSpawnModel(config.defaultModel),
         images: [],
         auto: true,
         issueRef: { number, url, title, body },

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { startLoopLagSampler, logRemainingOnLoopBlockers } from "./instrument";
 import { resolveNodeHost, TailscaleServeService } from "./tailscale";
+import { normalizeDefaultModelSetting } from "./default-model";
 
 const execFileAsync = promisify(execFile);
 
@@ -111,6 +112,13 @@ if (savedPlan !== null)
     PLAN_REVIEW_CYCLES_MAX,
     config.planReviewCyclesCap,
   );
+// a UI-chosen default model (persisted) overrides the env seed; absent → keep the
+// config default. Corrupt/unknown values are ignored (keep the seed rather than clobber).
+const savedDm = store.getSetting("defaultModel");
+if (savedDm !== null) {
+  const v = normalizeDefaultModelSetting(savedDm);
+  if (v !== null) config.defaultModel = v;
+}
 
 // ── preview port range startup validation (hard-fail) ──────────────────────
 // Discover the public served port by parsing `tailscale serve status`; default

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,6 +68,7 @@ import { join, normalize } from "node:path";
 import { homedir } from "node:os";
 import type { ServerWebSocket } from "bun";
 import { markPtyEvent } from "./instrument";
+import { normalizeDefaultModelSetting } from "./default-model";
 
 const UI_DIR = join(import.meta.dir, "..", "ui", "build");
 
@@ -1614,6 +1615,8 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       // URLs from it when the HUD is fronted on a different host than the agent node.
       // Null when tailscale is absent → UI falls back to the operator's connection host.
       previewHost: config.previewHost,
+      // raw configured default model; "auto" = unset/seed; client resolves promo itself.
+      defaultModel: config.defaultModel,
     });
   }
   if (req.method === "PUT") {
@@ -1638,6 +1641,7 @@ const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response]
   ["sessionHousekeepingEnabled", putSessionHousekeeping],
   ["prReviewCyclesCap", putPrReviewCyclesCap],
   ["planReviewCyclesCap", putPlanReviewCyclesCap],
+  ["defaultModel", putDefaultModel],
 ];
 
 // max length for the persisted standard command; mirrors the 8000-char human-prompt
@@ -1697,6 +1701,15 @@ function putPlanReviewCyclesCap(value: unknown, deps: Ctx["deps"]): Response {
   config.planReviewCyclesCap = cap; // live: the next plan-gate run reads it
   deps.store.setSetting("planReviewCyclesCap", String(cap)); // persist across restarts
   return json({ planReviewCyclesCap: config.planReviewCyclesCap });
+}
+
+// Validates via normalizeDefaultModelSetting; "auto" = unset/seed.
+function putDefaultModel(value: unknown, deps: Ctx["deps"]): Response {
+  const v = normalizeDefaultModelSetting(value);
+  if (v === null) return json({ error: "unknown model" }, 400);
+  config.defaultModel = v; // live: next drain spawn picks it up
+  deps.store.setSetting("defaultModel", v); // persist across restarts
+  return json({ defaultModel: config.defaultModel });
 }
 
 function putRepoRoot(value: unknown, deps: Ctx["deps"]): Response {

--- a/test/default-model.test.ts
+++ b/test/default-model.test.ts
@@ -1,0 +1,69 @@
+import { test, expect, describe } from "bun:test";
+import { normalizeDefaultModelSetting, drainSpawnModel } from "../src/default-model";
+import { MODELS } from "../src/types";
+
+describe("normalizeDefaultModelSetting", () => {
+  test("accepts 'auto'", () => {
+    expect(normalizeDefaultModelSetting("auto")).toBe("auto");
+  });
+
+  test("accepts 'default'", () => {
+    expect(normalizeDefaultModelSetting("default")).toBe("default");
+  });
+
+  test("accepts each MODELS alias", () => {
+    for (const alias of MODELS) {
+      expect(normalizeDefaultModelSetting(alias)).toBe(alias);
+    }
+  });
+
+  test("returns null for unknown string", () => {
+    expect(normalizeDefaultModelSetting("gpt4")).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(normalizeDefaultModelSetting("")).toBeNull();
+  });
+
+  test("returns null for null", () => {
+    expect(normalizeDefaultModelSetting(null)).toBeNull();
+  });
+
+  test("returns null for undefined", () => {
+    expect(normalizeDefaultModelSetting(undefined)).toBeNull();
+  });
+
+  test("returns null for number", () => {
+    expect(normalizeDefaultModelSetting(123)).toBeNull();
+  });
+
+  test("returns null for object", () => {
+    expect(normalizeDefaultModelSetting({})).toBeNull();
+  });
+});
+
+describe("drainSpawnModel", () => {
+  test("'auto' → null", () => {
+    expect(drainSpawnModel("auto")).toBeNull();
+  });
+
+  test("'default' → null", () => {
+    expect(drainSpawnModel("default")).toBeNull();
+  });
+
+  test("'fable' → 'fable'", () => {
+    expect(drainSpawnModel("fable")).toBe("fable");
+  });
+
+  test("'opus' → 'opus'", () => {
+    expect(drainSpawnModel("opus")).toBe("opus");
+  });
+
+  test("'sonnet' → 'sonnet'", () => {
+    expect(drainSpawnModel("sonnet")).toBe("sonnet");
+  });
+
+  test("'haiku' → 'haiku'", () => {
+    expect(drainSpawnModel("haiku")).toBe("haiku");
+  });
+});

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -15,6 +15,7 @@ let savedSc: string;
 let savedHk: boolean;
 let savedPrCap: number;
 let savedPlanCap: number;
+let savedDefaultModel: string;
 
 beforeEach(() => {
   // realpath so comparisons hold where tmpdir() is a symlink (macOS)
@@ -27,6 +28,7 @@ beforeEach(() => {
   savedHk = config.sessionHousekeepingEnabled;
   savedPrCap = config.prReviewCyclesCap;
   savedPlanCap = config.planReviewCyclesCap;
+  savedDefaultModel = config.defaultModel;
   // the ceiling is the immutable boundary; point it at our temp dir for the test so
   // dirs inside tmp validate and the dir browser is confined to tmp.
   config.rootCeiling = tmp;
@@ -40,6 +42,7 @@ afterEach(() => {
   config.sessionHousekeepingEnabled = savedHk;
   config.prReviewCyclesCap = savedPrCap;
   config.planReviewCyclesCap = savedPlanCap;
+  config.defaultModel = savedDefaultModel;
   rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -332,4 +335,53 @@ test("GET /api/fs/dirs?path=/ stays clamped to the ceiling (never escapes to '/'
   const body = await res.json();
   expect(body.path).toBe(tmp);
   expect(body.parent).toBeNull();
+});
+
+test("GET /api/settings includes defaultModel (raw, unresolved)", async () => {
+  config.defaultModel = "opus";
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/settings"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.defaultModel).toBe("opus");
+});
+
+test("PUT /api/settings sets defaultModel, persists, leaves repoRoot intact", async () => {
+  config.repoRoot = tmp;
+  config.defaultModel = "auto";
+  const { app, store } = harness();
+  const res = await put(app, { defaultModel: "fable" });
+  expect(res.status).toBe(200);
+  expect((await res.json()).defaultModel).toBe("fable");
+  expect(config.defaultModel).toBe("fable"); // live
+  expect(store.getSetting("defaultModel")).toBe("fable"); // persisted
+  expect(config.repoRoot).toBe(tmp); // a defaultModel patch must not touch the repo root
+  const got = await (await app.fetch(new Request("http://x/api/settings"))).json();
+  expect(got.defaultModel).toBe("fable");
+});
+
+test("PUT /api/settings accepts defaultModel 'auto' and 'default'", async () => {
+  const { app } = harness();
+  const r1 = await put(app, { defaultModel: "auto" });
+  expect(r1.status).toBe(200);
+  expect((await r1.json()).defaultModel).toBe("auto");
+  const r2 = await put(app, { defaultModel: "default" });
+  expect(r2.status).toBe(200);
+  expect((await r2.json()).defaultModel).toBe("default");
+});
+
+test("PUT /api/settings rejects an unknown defaultModel value", async () => {
+  const { app } = harness();
+  config.defaultModel = "auto";
+  const res = await put(app, { defaultModel: "gpt9" });
+  expect(res.status).toBe(400);
+  expect(config.defaultModel).toBe("auto"); // unchanged on failure
+});
+
+test("PUT /api/settings rejects a non-string defaultModel", async () => {
+  const { app } = harness();
+  config.defaultModel = "auto";
+  const res = await put(app, { defaultModel: 42 });
+  expect(res.status).toBe(400);
+  expect(config.defaultModel).toBe("auto"); // unchanged on failure
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -865,5 +865,12 @@
   "unitrow_repo_filter_aria": "Nur Sessions von {repo} anzeigen",
   "unitrow_repo_filter_clear_aria": "{repo}-Filter aufheben, alle Sessions anzeigen",
   "feat_slim_header_title": "Schlankere Session-Leiste",
-  "feat_slim_header_body": "Die Leiste über dem Terminal ist kompakter geworden: Der Dev-Server-Startknopf zeigt jetzt nur noch ein Icon, Autopilot und Status erscheinen als kompakte Pills bzw. Statussymbol. Der Issues-Tab der Session ist weg — GitHub-Issues finden sich im Backlog-Pane."
+  "feat_slim_header_body": "Die Leiste über dem Terminal ist kompakter geworden: Der Dev-Server-Startknopf zeigt jetzt nur noch ein Icon, Autopilot und Status erscheinen als kompakte Pills bzw. Statussymbol. Der Issues-Tab der Session ist weg — GitHub-Issues finden sich im Backlog-Pane.",
+  "settings_default_model_title": "Standardmodell",
+  "settings_default_model_hint": "Legt das Modell für jede neue Aufgabe und für autonome Drain-/Autopilot-Starts fest. Die Option Auto belässt autonome Starts auf Claudes eigenem Standard; der Standard im Einführungszeitraum ist die Fable-Promo, sofern aktiv, sonst Claudes eigener Standard. Ein explizites Modell lässt alle unbeaufsichtigten Starts auf dieser Stufe laufen.",
+  "settings_default_model_auto": "Auto (Standard im Einführungszeitraum)",
+  "settings_default_model_premium_warning": "Diese Modellstufe ist premium. Alle autonomen Drain- und Autopilot-Starts laufen unbeaufsichtigt auf diesem Kostenniveau.",
+  "settings_default_model_save_failed": "Standardmodell konnte nicht geändert werden. Erneut versuchen.",
+  "feat_default_model_title": "Konfigurierbares Standardmodell",
+  "feat_default_model_body": "Lege in Einstellungen → Session ein globales Standardmodell für jede neue Aufgabe und alle autonomen Drain-/Autopilot-Starts fest. Auto behält den Standard im Einführungszeitraum; Standard setzt Claudes eigenes Modell; oder wähle einen spezifischen Alias, um stets auf dieser Stufe zu starten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -865,5 +865,12 @@
   "unitrow_repo_filter_aria": "Show only {repo} sessions",
   "unitrow_repo_filter_clear_aria": "Clear the {repo} filter, show all sessions",
   "feat_slim_header_title": "Slimmer session toolbar",
-  "feat_slim_header_body": "The bar above the terminal is more compact: the dev-server start button is now icon-only, autopilot and status show as tight pills and a status glyph. GitHub Issues have moved out of a per-session Issues tab and now live in the Backlog pane instead."
+  "feat_slim_header_body": "The bar above the terminal is more compact: the dev-server start button is now icon-only, autopilot and status show as tight pills and a status glyph. GitHub Issues have moved out of a per-session Issues tab and now live in the Backlog pane instead.",
+  "settings_default_model_title": "Default model",
+  "settings_default_model_hint": "Sets the model for every new task and for autonomous drain/autopilot spawns. Auto keeps autonomous spawns on Claude's own default; the launch-window default is the Fable promo if active, otherwise Claude's own default. Choosing an explicit model makes all unattended spawns run that tier.",
+  "settings_default_model_auto": "Auto (launch-window default)",
+  "settings_default_model_premium_warning": "This model tier is premium. All autonomous drain and autopilot spawns will run at this cost unattended.",
+  "settings_default_model_save_failed": "Couldn't change default model. Retry.",
+  "feat_default_model_title": "Operator-configurable default model",
+  "feat_default_model_body": "Set a global default model for every new task and all autonomous drain/autopilot spawns from Settings → Session. \"Auto\" keeps the launch-window default; \"default\" locks in Claude's own model; or pick a specific alias to always run that tier."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -194,7 +194,8 @@ export const putPrReviewCyclesCap = (cap: number): Promise<{ prReviewCyclesCap: 
 export const putPlanReviewCyclesCap = (cap: number): Promise<{ planReviewCyclesCap: number }> =>
   patchSettings({ planReviewCyclesCap: cap });
 
-// Persist the operator's configured default model for the New Task picker.
+// Persist the operator's configured default model (drives the New Task picker
+// preselect and autonomous drain/autopilot auto-spawns).
 export const putDefaultModel = (model: string): Promise<{ defaultModel: string }> =>
   patchSettings<{ defaultModel: string }>({ defaultModel: model });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -194,6 +194,10 @@ export const putPrReviewCyclesCap = (cap: number): Promise<{ prReviewCyclesCap: 
 export const putPlanReviewCyclesCap = (cap: number): Promise<{ planReviewCyclesCap: number }> =>
   patchSettings({ planReviewCyclesCap: cap });
 
+// Persist the operator's configured default model for the New Task picker.
+export const putDefaultModel = (model: string): Promise<{ defaultModel: string }> =>
+  patchSettings<{ defaultModel: string }>({ defaultModel: model });
+
 export async function listDirs(path?: string): Promise<DirListing> {
   const q = path ? `?path=${encodeURIComponent(path)}` : "";
   const r = await fetch(`/api/fs/dirs${q}`);

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -3,7 +3,7 @@
   import { listRepos, listBranches, getCommands, uploadImage } from "$lib/api";
   import { handleImagePaste } from "$lib/clipboard";
   import { MODELS, type Issue, type IssueRef, type RepoEntry, type SlashCommand } from "$lib/types";
-  import { defaultModel } from "$lib/fable-promo";
+  import { promoDefaultModel } from "$lib/fable-promo";
   import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
   import RepoSelect from "./RepoSelect.svelte";
   import PromptSources from "./PromptSources.svelte";
@@ -21,6 +21,7 @@
     initialRepoPath,
     initialIssue,
     initialModel,
+    defaultModel,
   }: {
     onsubmit: (input: {
       repoPath: string;
@@ -37,6 +38,7 @@
     initialRepoPath?: string;
     initialIssue?: Issue;
     initialModel?: string;
+    defaultModel?: string;
   } = $props();
 
   /** Short editable seed so the user only adds deltas; the body rides out-of-band. */
@@ -54,12 +56,15 @@
   // svelte-ignore state_referenced_locally
   let repoPath = $state(initialRepoPath ?? "");
   let baseBranch = $state("main");
-  // intentional one-time seed; NewTask remounts per open. During the Fable 5
-  // launch window defaultModel() preselects "fable"; after it, the prior
-  // "default" (claude's own model, no --model flag). An explicit initialModel
-  // (e.g. the celebration's "Try Fable" CTA) always wins.
+  // Picker preselect precedence: explicit initialModel (e.g. the "Try Fable" CTA) wins;
+  // else the operator's configured default if it's an explicit model; else the fresh
+  // client promo (configured "auto", or settings not yet loaded). Resolved at mount,
+  // and NewTask remounts per open, so the promo cutoff is honored fresh each open.
+  function preselectModel(configured: string | undefined): string {
+    return configured && configured !== "auto" ? configured : promoDefaultModel();
+  }
   // svelte-ignore state_referenced_locally
-  let model = $state(initialModel ?? defaultModel());
+  let model = $state(initialModel ?? preselectModel(defaultModel));
   // Plan gate: defaults to the selected repo's stored flag until the user toggles
   // it. `planGateTouched` pins a manual choice so switching repos doesn't clobber it.
   let planGate = $state(false);

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -11,7 +11,7 @@
     putDefaultModel,
     listDirs,
   } from "$lib/api";
-  import { MODELS, type DirListing, type HerdrUpdateStatus } from "$lib/types";
+  import { MODELS, PREMIUM_MODELS, type DirListing, type HerdrUpdateStatus } from "$lib/types";
   import SteersEditor from "$lib/components/SteersEditor.svelte";
   import ThemeIcon from "$lib/components/ThemeIcon.svelte";
   import { dialog } from "$lib/a11yDialog";
@@ -125,7 +125,6 @@
   let defaultModel = $state("auto"); // raw default-model setting (auto|default|<alias>)
   let defaultModelSaved = "auto"; // last server-confirmed value, for revert on failure
   let defaultModelBusy = $state(false);
-  const PREMIUM_MODELS = ["fable", "opus"];
   const isPremiumModel = $derived(PREMIUM_MODELS.includes(defaultModel));
 
   async function saveStandardCommand() {

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -8,9 +8,10 @@
     putSessionHousekeeping,
     putPrReviewCyclesCap,
     putPlanReviewCyclesCap,
+    putDefaultModel,
     listDirs,
   } from "$lib/api";
-  import type { DirListing, HerdrUpdateStatus } from "$lib/types";
+  import { MODELS, type DirListing, type HerdrUpdateStatus } from "$lib/types";
   import SteersEditor from "$lib/components/SteersEditor.svelte";
   import ThemeIcon from "$lib/components/ThemeIcon.svelte";
   import { dialog } from "$lib/a11yDialog";
@@ -121,6 +122,11 @@
   let planReviewCyclesMax = $state(12);
   let planReviewCyclesSaved = 5; // last server-confirmed value, for revert on failure
   let planRcyBusy = $state(false);
+  let defaultModel = $state("auto"); // raw default-model setting (auto|default|<alias>)
+  let defaultModelSaved = "auto"; // last server-confirmed value, for revert on failure
+  let defaultModelBusy = $state(false);
+  const PREMIUM_MODELS = ["fable", "opus"];
+  const isPremiumModel = $derived(PREMIUM_MODELS.includes(defaultModel));
 
   async function saveStandardCommand() {
     if (scBusy) return;
@@ -188,6 +194,27 @@
       });
     } finally {
       planRcyBusy = false;
+    }
+  }
+
+  async function saveDefaultModel() {
+    if (defaultModelBusy) return;
+    defaultModelBusy = true;
+    try {
+      const r = await putDefaultModel(defaultModel);
+      defaultModel = r.defaultModel;
+      defaultModelSaved = r.defaultModel;
+    } catch {
+      // revert to the last server-confirmed value; surface the failure as a persistent,
+      // deduped alert so the no-op never looks like a save.
+      defaultModel = defaultModelSaved;
+      toasts.info(m.settings_default_model_save_failed(), {
+        key: "default-model",
+        duration: null,
+        alert: true,
+      });
+    } finally {
+      defaultModelBusy = false;
     }
   }
 
@@ -273,6 +300,8 @@
       planReviewCyclesMax = s.planReviewCyclesMax;
       planReviewCycles = s.planReviewCyclesCap;
       planReviewCyclesSaved = s.planReviewCyclesCap;
+      defaultModel = s.defaultModel;
+      defaultModelSaved = s.defaultModel;
       await browse(s.repoRoot);
     } catch {
       await browse();
@@ -531,6 +560,26 @@
             onchange={savePlanReviewCycles}
           />
         </label>
+      </div>
+      <div class="rc">
+        <span class="micro">{m.settings_default_model_title()}</span>
+        <p class="hint">{m.settings_default_model_hint()}</p>
+        <select
+          class="model-select"
+          bind:value={defaultModel}
+          disabled={defaultModelBusy}
+          aria-label={m.settings_default_model_title()}
+          onchange={saveDefaultModel}
+        >
+          <option value="auto">{m.settings_default_model_auto()}</option>
+          <option value="default">{m.newtask_model_default()}</option>
+          {#each MODELS as mdl (mdl)}
+            <option value={mdl}>{mdl}</option>
+          {/each}
+        </select>
+        {#if isPremiumModel}
+          <p class="premium-warn">{m.settings_default_model_premium_warning()}</p>
+        {/if}
       </div>
       <SteersEditor />
     </div>
@@ -1010,6 +1059,32 @@
   }
   .cycles .num:disabled {
     opacity: 0.5;
+  }
+  .model-select {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    padding: 8px 10px;
+    border-radius: 2px;
+    appearance: none;
+    cursor: pointer;
+    align-self: flex-start;
+  }
+  .model-select:focus {
+    outline: none;
+    border-color: var(--color-amber);
+  }
+  .model-select:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .premium-warn {
+    color: var(--color-amber);
+    font-size: var(--fs-meta);
+    margin: 0;
+    font-weight: 500;
   }
   .toggle {
     display: flex;

--- a/ui/src/lib/fable-promo.test.ts
+++ b/ui/src/lib/fable-promo.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { defaultModel, FABLE_PROMO_UNTIL } from "./fable-promo";
+import { promoDefaultModel, FABLE_PROMO_UNTIL } from "./fable-promo";
 
-describe("fable-promo defaultModel", () => {
+describe("fable-promo promoDefaultModel", () => {
   it("preselects fable during the launch window", () => {
-    expect(defaultModel(new Date("2026-06-09T12:00:00+02:00"))).toBe("fable");
+    expect(promoDefaultModel(new Date("2026-06-09T12:00:00+02:00"))).toBe("fable");
   });
 
   it("preselects fable right up to the cutoff (inclusive)", () => {
-    expect(defaultModel(new Date(FABLE_PROMO_UNTIL.getTime()))).toBe("fable");
+    expect(promoDefaultModel(new Date(FABLE_PROMO_UNTIL.getTime()))).toBe("fable");
   });
 
   it("reverts to the prior default just after the cutoff", () => {
-    expect(defaultModel(new Date(FABLE_PROMO_UNTIL.getTime() + 1000))).toBe("default");
+    expect(promoDefaultModel(new Date(FABLE_PROMO_UNTIL.getTime() + 1000))).toBe("default");
   });
 
   it("uses the prior default well after the window", () => {
-    expect(defaultModel(new Date("2026-08-01T00:00:00+02:00"))).toBe("default");
+    expect(promoDefaultModel(new Date("2026-08-01T00:00:00+02:00"))).toBe("default");
   });
 });

--- a/ui/src/lib/fable-promo.ts
+++ b/ui/src/lib/fable-promo.ts
@@ -14,8 +14,8 @@
 // Cutoff is end-of-day June 22, 2026 in Berlin (CEST, UTC+2) — inclusive.
 export const FABLE_PROMO_UNTIL = new Date("2026-06-22T23:59:59+02:00");
 
-/** The New Task picker's default model selection, time-gated by the promo window.
+/** The New Task picker's client-side promo default, time-gated by the launch window.
  *  `now` is injectable for tests. */
-export function defaultModel(now: Date = new Date()): "fable" | "default" {
+export function promoDefaultModel(now: Date = new Date()): "fable" | "default" {
   return now.getTime() <= FABLE_PROMO_UNTIL.getTime() ? "fable" : "default";
 }

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -374,4 +374,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_slim_header_title",
     bodyKey: "feat_slim_header_body",
   },
+  {
+    // No targetId: the control lives inside the Settings modal (closed by default),
+    // so a coachmark anchor would rarely be mounted — surface via the What's-New drawer only.
+    // v1.22.0 is already tagged, so this ships in the next release (1.23.0).
+    id: "default-model-setting",
+    sinceVersion: "1.23.0",
+    titleKey: "feat_default_model_title",
+    bodyKey: "feat_default_model_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -34,6 +34,9 @@ export interface Settings {
   standardCommand: string;
   /** Daily sweep that prunes old archived sessions; kill switch (default on). */
   sessionHousekeepingEnabled: boolean;
+  /** Raw configured default-model setting (auto|default|<alias>); the New Task
+   *  picker resolves `auto` via the client promo. */
+  defaultModel: string;
   /** Max PR-critic auto-address rounds before escalating to a human (global). */
   prReviewCyclesCap: number;
   /** Display-only: lower bound for prReviewCyclesCap (drives the stepper's min). */

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -540,6 +540,11 @@ export interface CreateInput {
 /** Selectable claude model aliases; null = claude's own default. */
 export const MODELS = ["fable", "opus", "sonnet", "haiku"] as const;
 
+/** The premium-priced tiers among MODELS. Selecting one as the default makes every
+ *  autonomous auto-spawn run that tier, so the Settings picker surfaces a cost warning.
+ *  Kept next to MODELS so adding a new premium model classifies it in one place. */
+export const PREMIUM_MODELS: readonly string[] = ["fable", "opus"];
+
 export interface Steer {
   id: string;
   label: string;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1172,6 +1172,7 @@
     initialIssue={composeIssue ?? undefined}
     initialPrompt={composePrompt ?? undefined}
     initialModel={composeModel ?? undefined}
+    defaultModel={settings?.defaultModel}
     onclose={() => {
       showNew = false;
       composeRepoPath = null;


### PR DESCRIPTION
## Why

The spawned-agent model "default" was **not a real setting** — it lived only in the client-side time-gated promo `ui/src/lib/fable-promo.ts`, which preselects `fable` in the New Task picker until 2026-06-22 then silently reverts to `default`. Nothing persisted or let an operator configure it; drain/autopilot hardcoded `model: null` and ignored it entirely.

This adds a **persistent, operator-configurable default model**, surfaced in Settings → SESSION, persisted in the SQLite settings table, applied to **both** the New Task picker and autonomous drain/autopilot auto-spawns.

## Behavior

Setting value space: `auto | default | fable | opus | sonnet | haiku` (`auto` = unset/seed). `default` everywhere = no `--model` flag (Claude's own model).

| Path | `auto` | `default` | a model |
| --- | --- | --- | --- |
| **New Task preselect** | promo (`fable` ≤ 2026-06-22, else `default`), resolved **client-side, fresh per open** | `default` | that model |
| **Drain auto-spawn** | `null` (no flag) — **promo never applied** | `null` | that model |

Design decisions (confirmed with the operator):
- The Fable promo stays **client-only** and is the fallback **only** for the human-facing New Task picker, **only** when `auto`. It is **never** applied to autonomous drain/autopilot spawns — the cost guard against silently running the premium tier unattended.
- An explicit (non-`auto`) default applies to **both** the picker and drain.
- Settings control carries an autonomous-spend caveat, plus an amber caution line when a premium alias (`fable`/`opus`) is selected.

## Changes

**Server**
- `src/default-model.ts` (new): `normalizeDefaultModelSetting` (single validator) + `drainSpawnModel` (`auto`/`default` → `null`). No promo/cutoff server-side.
- `src/config.ts`: `config.defaultModel` (env-seeded `SHEPHERD_DEFAULT_MODEL`, default `auto`).
- `src/index.ts`: boot override from the settings table (presence + validity guarded).
- `src/server.ts`: `GET /api/settings` returns raw `defaultModel`; `PUT` handler `putDefaultModel` validates/persists.
- `src/drain.ts`: auto-spawns use `drainSpawnModel(config.defaultModel)` instead of hardcoded `null`.

**UI**
- `fable-promo.ts`: kept; renamed export `defaultModel` → `promoDefaultModel`.
- `types.ts` / `api.ts`: `Settings.defaultModel` + `putDefaultModel`.
- `NewTask.svelte`: preselect precedence `initialModel` > explicit configured default > fresh client promo.
- `+page.svelte`: passes the **raw** setting (keeps the promo fresh client-side).
- `Settings.svelte`: SESSION-tab select + immediate-save/revert + cost warning.
- `feature-announcements.ts` + EN/DE catalogs: feature entry + i18n keys.

## Single source of truth
- Promo cutoff: **only** in `ui/src/lib/fable-promo.ts` (server never resolves it).
- Setting validator: **only** in `src/default-model.ts`.

## Verification
- Root: `bun run lint` clean, `bunx tsc --noEmit` clean, `bun test ./test` → 1737 pass / 0 fail.
- UI: `bun run check` 0 errors, `bun run check:i18n` parity (867 keys/locale), `bun run test` → 820 pass.
- Gates: branch-hygiene ✓, feature-catalog ✓, fallow audit ✓ (no new issues in changed files).
- New unit tests for the validator + `drainSpawnModel`; GET/PUT round-trip tests (accept `auto`/`default`/aliases, reject unknown/non-string with 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)