### PR TITLE
fix(theme): replace font-dependent toggle glyphs with inline SVG icons

### DIFF
--- a/ui/src/lib/components/ActionBar.svelte
+++ b/ui/src/lib/components/ActionBar.svelte
@@ -2,14 +2,19 @@
   import { theme, type ThemePref } from "$lib/theme.svelte";
   import { m } from "$lib/paraglide/messages";
   import LanguageSwitcher from "$lib/components/LanguageSwitcher.svelte";
+  import ThemeIcon from "$lib/components/ThemeIcon.svelte";
   import { REPO, REPO_URL, sha, version, commitUrl } from "$lib/build-info";
 
   // Two explicit theme choices; "system" stays the implicit default (followed on
   // first load + on OS changes until the operator picks one). The old third slot
-  // (◐ system) is repurposed as the standalone high-contrast / WCAG toggle below.
-  const THEMES: { pref: Exclude<ThemePref, "system">; glyph: string; label: () => string }[] = [
-    { pref: "dark", glyph: "☾", label: m.theme_dark },
-    { pref: "light", glyph: "☀", label: m.theme_light },
+  // (the "system" option) is repurposed as the standalone high-contrast / WCAG toggle below.
+  const THEMES: {
+    pref: Exclude<ThemePref, "system">;
+    icon: "moon" | "sun";
+    label: () => string;
+  }[] = [
+    { pref: "dark", icon: "moon", label: m.theme_dark },
+    { pref: "light", icon: "sun", label: m.theme_light },
   ];
 
   let {
@@ -98,7 +103,7 @@
               aria-pressed={theme.resolved === t.pref}
               title={m.actionbar_theme_option({ label: t.label() })}
               aria-label={m.actionbar_theme_option({ label: t.label() })}
-              onclick={() => theme.setPref(t.pref)}>{t.glyph}</button
+              onclick={() => theme.setPref(t.pref)}><ThemeIcon icon={t.icon} /></button
             >
           {/each}
         </div>
@@ -109,7 +114,7 @@
           aria-pressed={theme.contrast}
           title={m.actionbar_contrast_toggle()}
           aria-label={m.actionbar_contrast_toggle()}
-          onclick={() => theme.toggleContrast()}>◐</button
+          onclick={() => theme.toggleContrast()}><ThemeIcon icon="contrast" /></button
         >
         <LanguageSwitcher />
       </div>

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -12,6 +12,7 @@
   } from "$lib/api";
   import type { DirListing, HerdrUpdateStatus } from "$lib/types";
   import SteersEditor from "$lib/components/SteersEditor.svelte";
+  import ThemeIcon from "$lib/components/ThemeIcon.svelte";
   import { dialog } from "$lib/a11yDialog";
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
@@ -30,10 +31,10 @@
   // Theme picker — mobile only: the desktop switcher lives in the ActionBar,
   // but on phones the ActionBar hides it and it was dropped from the top bar,
   // so Settings (reachable via the gear from any mobile screen) is its home.
-  const THEMES: { pref: ThemePref; glyph: string; label: () => string }[] = [
-    { pref: "dark", glyph: "☾", label: m.theme_dark },
-    { pref: "light", glyph: "☀", label: m.theme_light },
-    { pref: "system", glyph: "◐", label: m.theme_system },
+  const THEMES: { pref: ThemePref; icon: "moon" | "sun" | "auto"; label: () => string }[] = [
+    { pref: "dark", icon: "moon", label: m.theme_dark },
+    { pref: "light", icon: "sun", label: m.theme_light },
+    { pref: "system", icon: "auto", label: m.theme_system },
   ];
 
   // Build/repo facts ($lib/build-info) come from the same source the desktop
@@ -552,7 +553,7 @@
               class:on={theme.pref === t.pref}
               aria-pressed={theme.pref === t.pref}
               aria-label={m.actionbar_theme_option({ label: t.label() })}
-              onclick={() => theme.setPref(t.pref)}>{t.glyph}</button
+              onclick={() => theme.setPref(t.pref)}><ThemeIcon icon={t.icon} /></button
             >
           {/each}
         </div>

--- a/ui/src/lib/components/ThemeIcon.svelte
+++ b/ui/src/lib/components/ThemeIcon.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  // Inline-SVG replacements for the old moon/sun/half-circle theme-toggle text
+  // glyphs (U+263E/U+2600/U+25D0), which rendered as tofu boxes on minimal font
+  // sets (e.g. Omarchy Linux + Chrome). "auto" (Settings' follow-system option) and
+  // "contrast" (ActionBar's WCAG toggle) share the half-filled-circle shape
+  // for now but stay distinct variants so call sites remain self-describing.
+  let { icon }: { icon: "moon" | "sun" | "auto" | "contrast" } = $props();
+</script>
+
+<svg viewBox="0 0 16 16" width="1em" height="1em" fill="currentColor" aria-hidden="true">
+  {#if icon === "moon"}
+    <path d="M14 8.53A6 6 0 1 1 7.47 2a4.67 4.67 0 0 0 6.53 6.53z" />
+  {:else if icon === "sun"}
+    <circle cx="8" cy="8" r="3.4" />
+    <path
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      d="M8 0.9v1.8M8 13.3v1.8M0.9 8h1.8M13.3 8h1.8M2.98 2.98l1.27 1.27M11.75 11.75l1.27 1.27M13.02 2.98l-1.27 1.27M4.25 11.75l-1.27 1.27"
+    />
+  {:else}
+    <circle cx="8" cy="8" r="6.25" fill="none" stroke="currentColor" stroke-width="1.5" />
+    <path d="M8 2.5a5.5 5.5 0 0 0 0 11z" />
+  {/if}
+</svg>
+
+<style>
+  svg {
+    vertical-align: -0.125em;
+  }
+</style>


### PR DESCRIPTION
## Problem

The light-theme toggle rendered as a tofu box on Omarchy Linux + Chrome: the toggle glyphs were raw Unicode characters (`☾ ☀ ◐`) rendered as button text, and `☀` (U+2600 BLACK SUN WITH RAYS, Miscellaneous Symbols block) has no coverage in Omarchy's minimal font set, so Chrome's fontconfig fallback drew a missing-glyph box.

## Fix

New `ui/src/lib/components/ThemeIcon.svelte` — a tiny presentational component rendering inline SVGs (`fill="currentColor"`, `1em`, `viewBox="0 0 16 16"`, `aria-hidden`) with four variants: `moon`, `sun`, `auto` (Settings' system theme-follow option) and `contrast` (ActionBar's high-contrast/WCAG toggle; shares the half-circle path with `auto` for now but stays a distinct, self-describing variant). Wired into both call sites:

- `ActionBar.svelte` — THEMES `glyph` → `icon`, contrast toggle `◐` → `<ThemeIcon icon="contrast" />`
- `Settings.svelte` — THEMES `glyph` → `icon` incl. `auto` for the system option

Inline SVG has zero font dependency, so this fixes the bug class (any minimal font set), not just the reported codepoint. The whole toggle family converts per the symmetric-case rule — mixing a font moon with an SVG sun in one segmented control would mismatch, and `☾` sits in the same at-risk Unicode block. No CSS-token, i18n, or behavior changes; icons inherit `currentColor` and scale via `1em` at both call-site sizes (`--fs-base` ActionBar, `--fs-lg` Settings).

## Verification

- `cd ui && bun run check` — 0 errors, 0 warnings (1842 files)
- `cd ui && bun run test` — 818/818 pass (note: no automated coverage exercises these toggles; the suite guards regressions elsewhere, so the fix itself was verified visually)
- Visual via dev server + browser: ActionBar toggle in dark and light themes (active accent applies, baselines aligned at `--fs-base`) and Settings → Device theme row at mobile width (`--fs-lg`, all three icons crisp and aligned)
- `grep -rn "☀\|☾" ui/src` — no matches
- Bugfix, no new UX → no feature-catalog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)