### PR TITLE
feat(ui): desktop decommission for non-ready sessions

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -890,5 +890,5 @@
   "feat_stepper_legend_title": "Aufgabenleiste zeigt alle Pipeline-Stufen",
   "feat_stepper_legend_body": "Der Fortschrittsbalken jeder Session-Karte durchläuft jetzt fünf Stufen — Planung, Implementierung, PR, Review und Bereit — wobei das PR-Segment nach CI-Status und das Review-Segment nach Review-Ergebnis eingefärbt wird. Auf dem Desktop zeigt ein Hover über die Leiste eine Stufenlegende.",
   "feat_desktop_decom_title": "Überall am Desktop stilllegen",
-  "feat_desktop_decom_body": "Fahre über eine Session-Zeile, um ein ✕ einzublenden, oder nutze das jetzt immer sichtbare ✕ im Session-Header — zwei Klicks (aktivieren, bestätigen) legen jede Session still, ob PR vorhanden oder nicht. Rechtsklick auf eine Zeile öffnet das vollständige Menü."
+  "feat_desktop_decom_body": "Fahre über eine Session-Zeile, um ein ✕ einzublenden, oder nutze die jetzt immer sichtbare Stilllegen-Schaltfläche im Session-Header — zwei Klicks (aktivieren, bestätigen) legen jede Session still, ob PR vorhanden oder nicht. Rechtsklick auf eine Zeile öffnet das vollständige Menü."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -888,5 +888,7 @@
   "feat_herd_keynav_anywhere_title": "Session-Wechsel aus dem Terminal heraus",
   "feat_herd_keynav_anywhere_body": "Du kannst jetzt Sessions wechseln, während du im Terminal tippst: Alt (⌥ auf dem Mac) + j/k, g oder 1–9 wechselt die Session, ohne die Tastatur zu verlassen — Shepherd fängt diese Kombinationen ab, sodass diese Tastenkombinationen nie das Terminal des Agenten erreichen. Ohne Terminalfokus kannst du j/k/g/1–9 jetzt frei verketten (der Wechsel zieht den Fokus nicht mehr zurück), und Enter gibt den Fokus wieder ans Terminal ab.",
   "feat_stepper_legend_title": "Aufgabenleiste zeigt alle Pipeline-Stufen",
-  "feat_stepper_legend_body": "Der Fortschrittsbalken jeder Session-Karte durchläuft jetzt fünf Stufen — Planung, Implementierung, PR, Review und Bereit — wobei das PR-Segment nach CI-Status und das Review-Segment nach Review-Ergebnis eingefärbt wird. Auf dem Desktop zeigt ein Hover über die Leiste eine Stufenlegende."
+  "feat_stepper_legend_body": "Der Fortschrittsbalken jeder Session-Karte durchläuft jetzt fünf Stufen — Planung, Implementierung, PR, Review und Bereit — wobei das PR-Segment nach CI-Status und das Review-Segment nach Review-Ergebnis eingefärbt wird. Auf dem Desktop zeigt ein Hover über die Leiste eine Stufenlegende.",
+  "feat_desktop_decom_title": "Überall am Desktop stilllegen",
+  "feat_desktop_decom_body": "Fahre über eine Session-Zeile, um ein ✕ einzublenden, oder nutze das jetzt immer sichtbare ✕ im Session-Header — zwei Klicks (aktivieren, bestätigen) legen jede Session still, ob PR vorhanden oder nicht. Rechtsklick auf eine Zeile öffnet das vollständige Menü."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -890,5 +890,5 @@
   "feat_stepper_legend_title": "Task bar shows each pipeline stage",
   "feat_stepper_legend_body": "Each session card's progress bar now tracks five stages — Planning, Implementing, PR, Review, and Ready — with the PR segment tinted by CI status and the Review segment by the review verdict. Hover the bar on desktop to see a stage legend.",
   "feat_desktop_decom_title": "Decommission from anywhere on desktop",
-  "feat_desktop_decom_body": "Hover a session row to reveal a ✕, or use the ✕ now always visible in the session header — two clicks (arm, confirm) decommission any session, PR or not. Right-click a row for the full menu."
+  "feat_desktop_decom_body": "Hover a session row to reveal a ✕, or use the decommission control now always visible in the session header — two clicks (arm, confirm) decommission any session, PR or not. Right-click a row for the full menu."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -888,5 +888,7 @@
   "feat_herd_keynav_anywhere_title": "Session switching from inside the terminal",
   "feat_herd_keynav_anywhere_body": "Session switching now works while you're typing in the terminal: Alt (⌥ on Mac) + j/k, g, or 1–9 switches without leaving the keyboard — Shepherd captures these combos, so those key combinations never reach the agent's terminal. With the terminal unfocused, plain j/k/g/1–9 now chain freely (switching no longer pulls focus back), and Enter returns focus to the terminal.",
   "feat_stepper_legend_title": "Task bar shows each pipeline stage",
-  "feat_stepper_legend_body": "Each session card's progress bar now tracks five stages — Planning, Implementing, PR, Review, and Ready — with the PR segment tinted by CI status and the Review segment by the review verdict. Hover the bar on desktop to see a stage legend."
+  "feat_stepper_legend_body": "Each session card's progress bar now tracks five stages — Planning, Implementing, PR, Review, and Ready — with the PR segment tinted by CI status and the Review segment by the review verdict. Hover the bar on desktop to see a stage legend.",
+  "feat_desktop_decom_title": "Decommission from anywhere on desktop",
+  "feat_desktop_decom_body": "Hover a session row to reveal a ✕, or use the ✕ now always visible in the session header — two clicks (arm, confirm) decommission any session, PR or not. Right-click a row for the full menu."
 }

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -219,3 +219,44 @@ describe("UnitRow working-while-blocked (full working treatment)", () => {
     expect(document.body.querySelector(".car"), "no typing caret").toBeNull();
   });
 });
+
+describe("UnitRow fine-pointer decommission ✕", () => {
+  // vitest browser mode runs a real fine-pointer browser, so coarse.current is
+  // false and the hover ✕ (not the swipe reveal) is the affordance under test.
+  it("renders the ✕ button only when ondecommission is wired", async () => {
+    render(UnitRow, {
+      session: session({ id: "d0" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expect
+      .element(page.getByRole("button", { name: "decommission unit" }))
+      .not.toBeInTheDocument();
+  });
+
+  it("two-step: first click arms (no fire), second click decommissions — never selects the row", async () => {
+    let decommissioned: string | null = null;
+    let selects = 0;
+    render(UnitRow, {
+      session: session({ id: "d1" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => selects++,
+      ondecommission: (id: string) => (decommissioned = id),
+    });
+    const decom = page.getByRole("button", { name: "decommission unit" });
+    await expect.element(decom).toBeInTheDocument();
+    // the idle ✕ is invisible AND pointer-inert (pointer-events: none) — real CSS
+    // applies here, so reveal it the way a user would: hover the row first, which
+    // re-enables pointer events via the (hover:hover)+(pointer:fine) reveal rule
+    await page.getByRole("button", { name: "Open task one" }).hover();
+    await decom.click();
+    expect(decommissioned).toBe(null); // armed, not fired
+    // arming swaps the label to the confirm state; the second click fires
+    await page.getByRole("button", { name: "confirm ✕" }).click();
+    expect(decommissioned).toBe("d1");
+    // the ✕ sits above the row overlay as a sibling — the row select never fires
+    expect(selects).toBe(0);
+  });
+});

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -798,9 +798,12 @@
   /* Fine-pointer decommission ✕: opacity (not display) keeps it keyboard-
      focusable while invisible — and the invisible button's reserved in-flow slot
      at the top of every row's .u-right column is deliberate (rows stay aligned,
-     the button stays focusable); revealed on row hover/focus-within (hover-capable
-     fine pointers only, so touch layouts never show a ghost button) and forced
-     visible while armed. Idle = quiet faint glyph; armed = red ✕? echoing the
+     the button stays focusable); while invisible it's also click-inert
+     (pointer-events: none) so the invisible corner can't be tapped on
+     fine-pointer-but-hoverless hardware; revealed on row hover/focus-within
+     (hover-capable fine pointers only, so touch layouts never show a ghost
+     button) and forced visible while armed — every reveal state restores
+     pointer-events. Idle = quiet faint glyph; armed = red ✕? echoing the
      swipe reveal's .decom.armed treatment. */
   .row-decom {
     margin: 0;
@@ -814,18 +817,21 @@
     line-height: 1.3;
     cursor: pointer;
     opacity: 0;
+    pointer-events: none;
     transition: opacity 0.14s ease;
   }
   @media (hover: hover) and (pointer: fine) {
     .unit:hover .row-decom,
     .unit:focus-within .row-decom {
       opacity: 1;
+      pointer-events: auto;
     }
   }
   /* outside the hover/fine gate: a keyboard-focused button must never be
      invisible on fine-pointer-but-hoverless hardware */
   .row-decom:focus-visible {
     opacity: 1;
+    pointer-events: auto;
   }
   .row-decom:hover,
   .row-decom:focus-visible {
@@ -833,6 +839,7 @@
   }
   .row-decom.armed {
     opacity: 1;
+    pointer-events: auto;
     background: color-mix(in srgb, var(--color-red) 26%, transparent);
     color: var(--color-red);
     font-weight: 600;

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -1,7 +1,17 @@
 <script module lang="ts">
+  import { MediaQuery } from "svelte/reactivity";
+
   // Single-open invariant across every row: the close-fn of the currently open
   // row. Opening another row closes this one first.
   let openRow: (() => void) | null = $state(null);
+
+  // Exactly one row-level decommission affordance per device: primary-coarse
+  // pointers get the swipe-to-reveal gesture, primary-fine pointers (incl.
+  // touchscreen laptops) the hover ✕ button — never both. `(pointer: coarse)`
+  // matches the app's layout gates (+page.svelte `touch`, the reveal CSS's
+  // `(hover: hover) and (pointer: fine)`). Module-level so N rows share one
+  // matchMedia listener.
+  const coarse = new MediaQuery("(pointer: coarse)");
 </script>
 
 <script lang="ts">
@@ -61,7 +71,9 @@
     previewServeFailed?: boolean;
     // Preview badge clicked → select this session + open its Viewport preview pane
     onpreview?: (id: string) => void;
-    // when provided, the row gains a left-swipe-to-decommission gesture (mobile)
+    // when provided, the row gains a decommission affordance — coarse pointers get
+    // the left-swipe gesture, fine pointers a hover-revealed ✕ button, and the
+    // right-click / long-press CardMenu offers it on both
     ondecommission?: (id: string) => void;
     // active page-level repo filter (full repoPath); drives the icon's pressed state
     repoFilter?: string | null;
@@ -85,7 +97,7 @@
     onrepofilter?.(repoFiltered ? null : session.repoPath);
   }
 
-  const swipe = $derived(!!ondecommission);
+  const swipe = $derived(!!ondecommission && coarse.current);
 
   // gesture state
   let offset = $state(0); // px the row is slid left (negative); 0 = closed
@@ -169,7 +181,7 @@
 
   // Right-click (desktop) / long-press (touch) opens a small action menu on the
   // card. Resume is the headline action for a session parked at a shell;
-  // decommission rides along where the parent wired it (mobile list).
+  // decommission rides along wherever the parent wired it.
   // Deliberately NOT liveness-gated (no claudeAlive arg, unlike the Viewport
   // header): the menu only opens on an explicit gesture, so it doesn't add bar
   // noise — and it stays the force-resume escape hatch should the /proc sweep
@@ -291,6 +303,28 @@
     </div>
 
     <div class="u-right">
+      {#if ondecommission && !coarse.current}
+        <!-- Fine-pointer decommission: hover/focus-revealed ✕ in the top-right
+             corner, same two-step arm/confirm as the swipe reveal. A real <button>
+             is valid here — .u-right is a sibling of the .unit-hit overlay, not
+             nested inside it, and the existing .u-right > button z-index rule
+             raises it above the overlay; its click never reaches the row select,
+             so no propagation concern. -->
+        <button
+          class="row-decom"
+          class:armed={decom === "armed"}
+          type="button"
+          onclick={pressDecommission}
+          title={decom === "armed"
+            ? m.viewport_confirm_decommission()
+            : m.viewport_decommission_title()}
+          aria-label={decom === "armed"
+            ? m.viewport_confirm_decommission()
+            : m.viewport_decommission_aria()}
+        >
+          {decom === "armed" ? "✕?" : "✕"}
+        </button>
+      {/if}
       {#if previewPort != null}
         <!-- Live preview available (server reports a bound listener). Selecting +
              opening the pane is an action distinct from the row's own select, so
@@ -481,8 +515,8 @@
     margin-top: 2px;
   }
 
-  /* swipe-to-decommission (mobile): the row slides left over a destructive
-     action revealed behind it. */
+  /* swipe-to-decommission (coarse pointer): the row slides left over a
+     destructive action revealed behind it. */
   .swipe-wrap {
     position: relative;
     overflow: hidden;
@@ -759,6 +793,49 @@
     gap: 4px;
     align-items: flex-end;
     flex-shrink: 0;
+  }
+
+  /* Fine-pointer decommission ✕: opacity (not display) keeps it keyboard-
+     focusable while invisible — and the invisible button's reserved in-flow slot
+     at the top of every row's .u-right column is deliberate (rows stay aligned,
+     the button stays focusable); revealed on row hover/focus-within (hover-capable
+     fine pointers only, so touch layouts never show a ghost button) and forced
+     visible while armed. Idle = quiet faint glyph; armed = red ✕? echoing the
+     swipe reveal's .decom.armed treatment. */
+  .row-decom {
+    margin: 0;
+    padding: 0 2px;
+    border: 0;
+    border-radius: 2px;
+    background: transparent;
+    color: var(--color-faint);
+    font: inherit;
+    font-size: var(--fs-meta);
+    line-height: 1.3;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.14s ease;
+  }
+  @media (hover: hover) and (pointer: fine) {
+    .unit:hover .row-decom,
+    .unit:focus-within .row-decom {
+      opacity: 1;
+    }
+  }
+  /* outside the hover/fine gate: a keyboard-focused button must never be
+     invisible on fine-pointer-but-hoverless hardware */
+  .row-decom:focus-visible {
+    opacity: 1;
+  }
+  .row-decom:hover,
+  .row-decom:focus-visible {
+    color: var(--color-red);
+  }
+  .row-decom.armed {
+    opacity: 1;
+    background: color-mix(in srgb, var(--color-red) 26%, transparent);
+    color: var(--color-red);
+    font-weight: 600;
   }
 
   /* Quiet muted text, not a colored pill — the StatusPip (left) already encodes

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2764,7 +2764,7 @@
   /* quiet variant: the pre-PR desktop inline ✕. Rest ink stays the base .decom
      faint; hover/armed inherit the red destructive treatment above. Glyph-only,
      so drop the word-mark letter-spacing and size it like the neighboring
-     rename ✎ — the class stays on while armed so arming never shifts layout
+     rename ✎ — the class stays on while armed so arming keeps the same metrics
      (only .decom.armed's colors take over). */
   .decom.quiet {
     font-size: var(--fs-meta);

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1804,10 +1804,10 @@
     {/if}
     {#if !compact}
       <!-- desktop: the full git rail (PR / CI / merge / critic / ready / verdict)
-           plus the session-lifecycle controls (ready / autopilot / decommission)
-           live one disclosure away — this toggle reveals them as a second header
-           row (.vp-git-strip), keeping the primary line down to identity + tabs
-           + status. -->
+           plus the autopilot toggle live one disclosure away — this toggle reveals
+           them as a second header row (.vp-git-strip), keeping the primary line
+           down to identity + tabs + status. Decommission is NOT in here on
+           desktop: it sits inline in the actions cluster (quiet ✕ / green nudge). -->
       <button
         class="git-toggle"
         class:open={gitOpen}
@@ -1892,8 +1892,8 @@
       {#if prReady}
         <!-- earned prominence: once a PR exists the work is delivered, so the
              decommission nudge surfaces inline (green, arms red on click) — one
-             obvious click+confirm away. Until then the control lives in the git
-             strip with the rest of the lifecycle cluster. -->
+             obvious click+confirm away. Before that, desktop shows the quiet
+             icon-only ✕ below; compact keeps the labelled control in the git strip. -->
         <button
           class="decom"
           class:armed
@@ -1911,6 +1911,21 @@
             {armed ? m.viewport_confirm_decommission() : m.viewport_decommission()}
           {/if}
         </button>
+      {:else if !compact}
+        <!-- no PR yet → desktop still keeps decommission one click away, but quiet:
+             a faint icon-only ✕ (the green nudge is earned by delivering a PR).
+             Compact layouts keep the labelled control in the git strip instead.
+             Same glyph rule as above: armed = red ✕?, never ✓. -->
+        <button
+          class="decom quiet"
+          class:armed
+          type="button"
+          onclick={decommission}
+          title={armed ? m.viewport_confirm_decommission() : m.viewport_decommission_title()}
+          aria-label={armed ? m.viewport_confirm_decommission() : m.viewport_decommission_aria()}
+        >
+          {armed ? "✕?" : "✕"}
+        </button>
       {/if}
     </div>
   </div>
@@ -1919,7 +1934,8 @@
        always on compact layouts (mobile + unfolded fold, where the header wraps),
        and on desktop only while the PR disclosure toggle is open. The strip is
        the session-lifecycle surface, so the lifecycle cluster (ready — inside
-       GitRail — autopilot, decommission) lives here too, off the identity row. -->
+       GitRail — autopilot, plus decommission on compact) lives here too, off the
+       identity row; on desktop decommission stays inline in the actions cluster. -->
   {#if (compact && !headerCollapsed) || gitOpen}
     <div class="vp-git-strip">
       <GitRail
@@ -1951,9 +1967,11 @@
         >
           {autopilotEffective ? m.session_autopilot_on_label() : m.session_autopilot_off_label()}
         </button>
-        {#if !prReady}
-          <!-- the rare destructive action, parked at the strip's far edge; once a
-               PR is up it graduates to the identity row as the green ready nudge -->
+        {#if compact && !prReady}
+          <!-- compact only: the rare destructive action, parked at the strip's far
+               edge; once a PR is up it graduates to the identity row as the green
+               ready nudge. Desktop always renders decommission inline in the
+               actions cluster, so it never duplicates here. -->
           <button
             class="decom"
             class:armed
@@ -2374,7 +2392,8 @@
     flex: 1;
   }
 
-  /* desktop: transparent to layout — resume + the decom-ready nudge flow inline.
+  /* desktop: transparent to layout — resume + the decom control (quiet ✕ or
+     ready nudge) flow inline.
      compact/phone override (see .vp-head.mobile .vp-actions) turns this into a
      real flex cluster so the trailing controls wrap together. */
   .vp-actions {
@@ -2695,10 +2714,11 @@
     font-size: var(--fs-meta);
   }
 
-  /* PR delivered → the work is done. The decommission control graduates from the
-     git strip onto the identity row as a bright, gently pulsing green call-to-action
-     so wrapping up the session reads as the obvious next step. Hover/armed below
-     still override it red (destructive confirm). */
+  /* PR delivered → the work is done. The decommission control graduates from its
+     quiet form (faint inline ✕ on desktop, strip button on compact) into a bright,
+     gently pulsing green call-to-action on the identity row so wrapping up the
+     session reads as the obvious next step. Hover/armed below still override it
+     red (destructive confirm). */
   .decom.ready {
     color: var(--color-green);
     border-color: color-mix(in srgb, var(--color-green) 40%, transparent);
@@ -2739,6 +2759,18 @@
     color: var(--color-red);
     border-color: var(--color-red);
     background: color-mix(in srgb, var(--color-red) 12%, transparent);
+  }
+
+  /* quiet variant: the pre-PR desktop inline ✕. Rest ink stays the base .decom
+     faint; hover/armed inherit the red destructive treatment above. Glyph-only,
+     so drop the word-mark letter-spacing and size it like the neighboring
+     rename ✎ — the class stays on while armed so arming never shifts layout
+     (only .decom.armed's colors take over). */
+  .decom.quiet {
+    font-size: var(--fs-meta);
+    letter-spacing: 0;
+    line-height: 1;
+    padding: 2px 6px;
   }
 
   /* rename: pencil affordance + inline editor — next to the task name on desktop,

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -418,5 +418,4 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_desktop_decom_title",
     bodyKey: "feat_desktop_decom_body",
   },
-
 ];

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -409,4 +409,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_stepper_legend_title",
     bodyKey: "feat_stepper_legend_body",
   },
+  {
+    // No targetId: the hover ✕ on session-list rows is revealed on hover (not
+    // persistently mounted) and the header ✕ only renders for non-PR-ready sessions,
+    // so both anchors are conditionally present — surface via the What's-New drawer only.
+    id: "desktop-decommission",
+    sinceVersion: "1.23.0",
+    titleKey: "feat_desktop_decom_title",
+    bodyKey: "feat_desktop_decom_body",
+  },
+
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1117,6 +1117,7 @@
           preview={store.preview}
           previewServe={store.previewServe}
           onpreview={openPreview}
+          ondecommission={onarchive}
           {onclearmerged}
           {onmergetrain}
           {standardCommandUnset}


### PR DESCRIPTION
## Problem

Desktop had no discoverable way to decommission a session without an open PR: the sidebar rows had no affordance at all (mobile has swipe + long-press), and the Viewport's ✕ for non-ready sessions was buried inside the collapsed "Git actions" disclosure.

## Changes

- **Hover ✕ on sidebar rows (desktop):** `ondecommission` is now wired to the desktop Herd; on primary-fine-pointer devices each row gets a hover/focus-revealed ✕ with the existing two-step arm/confirm (`✕` → red `✕?`, 3s disarm) and the same undo-toast flow as mobile swipe. Right-click rows now also offer Decommission via the existing CardMenu.
- **Swipe gated by pointer type:** the swipe gesture now requires `(pointer: coarse)` (matches the app's layout gates) — mice never get a drag-slide row; mobile behavior unchanged.
- **Always-inline quiet ✕ in the Viewport header:** non-PR-ready sessions on desktop show a faint icon-only decommission button at all times (arms red); the git-strip placement is now compact-only so desktop never renders two controls. PR-ready green nudge unchanged.
- **Discovery + i18n:** `desktop-decommission` catalog entry (`sinceVersion: 1.23.0`) with EN/DE keys; all button labels reuse existing decommission keys.

## Verification

- `cd ui && bun run check` — 0 errors/warnings; `bun run test` — 825/825; `check:i18n` — EN/DE parity (866 keys)
- `check-branch-hygiene.sh`, `check-feature-catalog.sh`, `fallow audit --base origin/main` — all green
- Rebased onto latest main (incl. the UnitRow repo-emoji change, #493) with no semantic conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)