### PR TITLE
feat(keynav): session switching that survives terminal focus

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -563,8 +563,9 @@
   "viewport_type_steer_hint": "⌁ tippen zum Steuern",
   "viewport_detach_hint": "⇥ trennen",
   "viewport_select_hint": "{key} Ziehen zum Kopieren",
-  "viewport_keynav_hint": "j/k/1–9 Session wechseln",
+  "viewport_keynav_hint": "j/k/1–9 Session wechseln ({key} aus dem Terminal)",
   "viewport_keynav_needsyou_hint": "g braucht dich",
+  "viewport_keynav_enter_hint": "↵ zurück zum Terminal",
   "viewport_parked_title": "Auf anderem Gerät aktiv",
   "viewport_parked_sub": "Tippen zum Übernehmen",
   "viewport_session_ended": "── Sitzung beendet ──",
@@ -875,5 +876,7 @@
   "settings_default_model_premium_warning": "Diese Modellstufe ist premium. Alle autonomen Drain- und Autopilot-Starts laufen unbeaufsichtigt auf diesem Kostenniveau.",
   "settings_default_model_save_failed": "Standardmodell konnte nicht geändert werden. Erneut versuchen.",
   "feat_default_model_title": "Konfigurierbares Standardmodell",
-  "feat_default_model_body": "Lege in Einstellungen → Session ein globales Standardmodell für jede neue Aufgabe und alle autonomen Drain-/Autopilot-Starts fest. Auto behält den Standard im Einführungszeitraum; Standard setzt Claudes eigenes Modell; oder wähle einen spezifischen Alias, um stets auf dieser Stufe zu starten."
+  "feat_default_model_body": "Lege in Einstellungen → Session ein globales Standardmodell für jede neue Aufgabe und alle autonomen Drain-/Autopilot-Starts fest. Auto behält den Standard im Einführungszeitraum; Standard setzt Claudes eigenes Modell; oder wähle einen spezifischen Alias, um stets auf dieser Stufe zu starten.",
+  "feat_herd_keynav_anywhere_title": "Session-Wechsel aus dem Terminal heraus",
+  "feat_herd_keynav_anywhere_body": "Du kannst jetzt Sessions wechseln, während du im Terminal tippst: Alt (⌥ auf dem Mac) + j/k, g oder 1–9 wechselt die Session, ohne die Tastatur zu verlassen — Shepherd fängt diese Kombinationen ab, sodass diese Tastenkombinationen nie das Terminal des Agenten erreichen. Ohne Terminalfokus kannst du j/k/g/1–9 jetzt frei verketten (der Wechsel zieht den Fokus nicht mehr zurück), und Enter gibt den Fokus wieder ans Terminal ab."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -563,8 +563,9 @@
   "viewport_type_steer_hint": "⌁ type to steer",
   "viewport_detach_hint": "⇥ detach",
   "viewport_select_hint": "{key} drag to copy",
-  "viewport_keynav_hint": "j/k/1–9 switch session",
+  "viewport_keynav_hint": "j/k/1–9 switch session ({key} from terminal)",
   "viewport_keynav_needsyou_hint": "g needs you",
+  "viewport_keynav_enter_hint": "↵ back to terminal",
   "viewport_parked_title": "Active on another device",
   "viewport_parked_sub": "Tap to take over",
   "viewport_session_ended": "── session ended ──",
@@ -875,5 +876,7 @@
   "settings_default_model_premium_warning": "This model tier is premium. All autonomous drain and autopilot spawns will run at this cost unattended.",
   "settings_default_model_save_failed": "Couldn't change default model. Retry.",
   "feat_default_model_title": "Operator-configurable default model",
-  "feat_default_model_body": "Set a global default model for every new task and all autonomous drain/autopilot spawns from Settings → Session. \"Auto\" keeps the launch-window default; \"default\" locks in Claude's own model; or pick a specific alias to always run that tier."
+  "feat_default_model_body": "Set a global default model for every new task and all autonomous drain/autopilot spawns from Settings → Session. \"Auto\" keeps the launch-window default; \"default\" locks in Claude's own model; or pick a specific alias to always run that tier.",
+  "feat_herd_keynav_anywhere_title": "Session switching from inside the terminal",
+  "feat_herd_keynav_anywhere_body": "Session switching now works while you're typing in the terminal: Alt (⌥ on Mac) + j/k, g, or 1–9 switches without leaving the keyboard — Shepherd captures these combos, so those key combinations never reach the agent's terminal. With the terminal unfocused, plain j/k/g/1–9 now chain freely (switching no longer pulls focus back), and Enter returns focus to the terminal."
 }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1310,15 +1310,17 @@
       // typing goes nowhere. Mobile keeps tap-to-focus so the soft keyboard
       // doesn't pop open on every selection. consumeAutoFocusTerm gates this:
       // a plain j/k keynav switch declines the focus (so the next plain key
-      // still chains instead of vanishing into the PTY). The consume runs
-      // unconditionally on every desktop rebuild — exact one-shot, even when a
-      // non-term tab is active, so a stale `false` can't survive into a later
-      // resumeEpoch-driven rebuild (resume / re-attach must auto-focus exactly
-      // as before); the tab gate only decides whether the consumed intent
-      // results in a focus. Read inside the rAF callback (like mobile/touch/
-      // tab) — async, so no new tracked dep on this terminal effect; the
-      // consumed flag itself is a plain non-reactive let upstairs.
-      if (!mobile && !touch && consumeAutoFocusTerm() && tab === "term") term.focus();
+      // still chains instead of vanishing into the PTY). The consume comes
+      // FIRST so every rebuild — any layout, any active tab — consumes the
+      // one-shot: a stale `false` can't survive into a later resumeEpoch-driven
+      // rebuild (resume / re-attach must auto-focus exactly as before), and a
+      // coarse-pointer desktop-width device (where onShortcut still runs — its
+      // bail is width-based) can't park one either. The layout/tab guards only
+      // decide whether the consumed intent results in a focus. Read inside the
+      // rAF callback (like mobile/touch/tab) — async, so no new tracked dep on
+      // this terminal effect; the consumed flag itself is a plain non-reactive
+      // let upstairs.
+      if (consumeAutoFocusTerm() && !mobile && !touch && tab === "term") term.focus();
     });
 
     const ro = new ResizeObserver(() => {
@@ -2199,8 +2201,12 @@
       <span>{m.viewport_keynav_hint({ key: isMac ? "⌥" : "Alt" })}</span>
       <span class="sep">·</span>
       <span>{m.viewport_keynav_needsyou_hint()}</span>
-      <span class="sep">·</span>
-      <span>{m.viewport_keynav_enter_hint()}</span>
+      <!-- Enter only hands focus back on the terminal tab (focusTerminal
+           no-ops elsewhere), so don't advertise it on other tabs -->
+      {#if tab === "term"}
+        <span class="sep">·</span>
+        <span>{m.viewport_keynav_enter_hint()}</span>
+      {/if}
     </div>
   {/if}
 </div>

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -140,7 +140,8 @@
     /** One-shot gate for the mount auto-focus: the page records whether the selection
      *  that remounted this terminal *wants* the keyboard (click / Alt-combo / Enter →
      *  yes; plain j/k chaining → no), and this consumes that intent — read it, reset
-     *  it to true, return it. Default keeps standalone usages auto-focusing as before. */
+     *  it to true, return it. The always-true default merely keeps the prop optional
+     *  (tests / future callers). */
     consumeAutoFocusTerm?: () => boolean;
   } = $props();
 
@@ -1309,12 +1310,15 @@
       // typing goes nowhere. Mobile keeps tap-to-focus so the soft keyboard
       // doesn't pop open on every selection. consumeAutoFocusTerm gates this:
       // a plain j/k keynav switch declines the focus (so the next plain key
-      // still chains instead of vanishing into the PTY) and the consume resets
-      // the intent to true, so resumeEpoch-driven rebuilds (resume / re-attach)
-      // auto-focus exactly as before. Read inside the rAF callback (like
-      // mobile/touch/tab) — async, so no new tracked dep on this terminal
-      // effect; the consumed flag itself is a plain non-reactive let upstairs.
-      if (!mobile && !touch && tab === "term" && consumeAutoFocusTerm()) term.focus();
+      // still chains instead of vanishing into the PTY). The consume runs
+      // unconditionally on every desktop rebuild — exact one-shot, even when a
+      // non-term tab is active, so a stale `false` can't survive into a later
+      // resumeEpoch-driven rebuild (resume / re-attach must auto-focus exactly
+      // as before); the tab gate only decides whether the consumed intent
+      // results in a focus. Read inside the rAF callback (like mobile/touch/
+      // tab) — async, so no new tracked dep on this terminal effect; the
+      // consumed flag itself is a plain non-reactive let upstairs.
+      if (!mobile && !touch && consumeAutoFocusTerm() && tab === "term") term.focus();
     });
 
     const ro = new ResizeObserver(() => {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2196,9 +2196,11 @@
       <span class="sep">·</span>
       <span>{m.viewport_select_hint({ key: isMac ? "⌥" : "⇧" })}</span>
       <span class="sep">·</span>
-      <span>{m.viewport_keynav_hint()}</span>
+      <span>{m.viewport_keynav_hint({ key: isMac ? "⌥" : "Alt" })}</span>
       <span class="sep">·</span>
       <span>{m.viewport_keynav_needsyou_hint()}</span>
+      <span class="sep">·</span>
+      <span>{m.viewport_keynav_enter_hint()}</span>
     </div>
   {/if}
 </div>

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -34,6 +34,7 @@
   import { imageFilesFromItems } from "$lib/clipboard";
   import { composeKeystrokes } from "$lib/compose";
   import { shouldForwardEscape } from "$lib/terminalEscape";
+  import { altComboKey } from "./herd-keynav";
   import { detectNotesKey } from "$lib/notesAffordance";
   import { isScrolledAwayFromBottom } from "$lib/scrollAffordance";
   import { pollWhileVisible } from "$lib/visibility";
@@ -82,6 +83,7 @@
     onSeedBuildQueue,
     previewHost = null,
     workingBlocked = {},
+    consumeAutoFocusTerm = () => true,
   }: {
     session: Session;
     onarchive?: (id: string, reap?: string[]) => void;
@@ -135,6 +137,11 @@
      *  the derived `dStatus`; behavioral reads (resume self-heal, preview confirm
      *  arm) stay on the raw `session.status`. */
     workingBlocked?: Record<string, boolean>;
+    /** One-shot gate for the mount auto-focus: the page records whether the selection
+     *  that remounted this terminal *wants* the keyboard (click / Alt-combo / Enter →
+     *  yes; plain j/k chaining → no), and this consumes that intent — read it, reset
+     *  it to true, return it. Default keeps standalone usages auto-focusing as before. */
+    consumeAutoFocusTerm?: () => boolean;
   } = $props();
 
   // Display-side status for every header/status render below (see display-status.ts).
@@ -187,6 +194,14 @@
   // mirror the live terminal so the theme effect can repaint it without
   // recreating it (recreating would tear down the PTY socket)
   let termRef = $state<Terminal | undefined>();
+
+  /** Hand the keyboard to the live terminal — the page's Enter shortcut calls this
+   *  so plain-key navigation (which deliberately keeps focus *out* of the PTY, see
+   *  consumeAutoFocusTerm) has a way back in. Term tab only: focusing the hidden
+   *  textarea of a display:none terminal would strand the keyboard invisibly. */
+  export function focusTerminal() {
+    if (tab === "term") termRef?.focus();
+  }
   // true when the user has scrolled up away from the latest output → show a
   // jump-to-bottom affordance bottom-right of the terminal. Two regimes
   // (see `agentOwnsScroll`):
@@ -1112,6 +1127,26 @@
         c.send("\n");
         return false;
       }
+      // Alt+J/K/G/arrows/1-9: session-switch combos must work *while the terminal
+      // owns the keyboard* — that's the whole point of the modifier. Suppress them
+      // from the PTY here (altComboKey is the same code→key map the window
+      // shortcut handler acts on, so the two sides can't drift). Like Shift+Enter
+      // above, returning false alone only stops xterm's own keydown handling — the
+      // browser's follow-up keypress would still make xterm emit the Meta/ESC-
+      // prefixed bytes — so e.preventDefault() is required for NO bytes to reach
+      // the agent. preventDefault does not stop propagation: the keydown still
+      // bubbles to the window, where +page.svelte's onShortcut performs the
+      // actual switch. keydown-only; the keyup is inert for these combos.
+      if (
+        e.type === "keydown" &&
+        e.altKey &&
+        !e.ctrlKey &&
+        !e.metaKey &&
+        altComboKey(e.code) !== null
+      ) {
+        e.preventDefault();
+        return false;
+      }
       // Ctrl+Shift+C: explicit copy. Ctrl+C in a focused terminal sends SIGINT to
       // the agent rather than copying; this gives users an explicit copy shortcut.
       // Read the selection before returning false — xterm hasn't cleared it yet.
@@ -1272,8 +1307,14 @@
       // desktop: selecting a unit hands the keyboard straight to its terminal —
       // clicking a sidebar card otherwise leaves focus on the card button, so
       // typing goes nowhere. Mobile keeps tap-to-focus so the soft keyboard
-      // doesn't pop open on every selection.
-      if (!mobile && !touch && tab === "term") term.focus();
+      // doesn't pop open on every selection. consumeAutoFocusTerm gates this:
+      // a plain j/k keynav switch declines the focus (so the next plain key
+      // still chains instead of vanishing into the PTY) and the consume resets
+      // the intent to true, so resumeEpoch-driven rebuilds (resume / re-attach)
+      // auto-focus exactly as before. Read inside the rAF callback (like
+      // mobile/touch/tab) — async, so no new tracked dep on this terminal
+      // effect; the consumed flag itself is a plain non-reactive let upstairs.
+      if (!mobile && !touch && tab === "term" && consumeAutoFocusTerm()) term.focus();
     });
 
     const ro = new ResizeObserver(() => {

--- a/ui/src/lib/components/herd-keynav.test.ts
+++ b/ui/src/lib/components/herd-keynav.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "vitest";
-import { railOrder, cycleId, nthId, nextNeedsYou } from "./herd-keynav";
+import { railOrder, cycleId, nthId, nextNeedsYou, altComboKey } from "./herd-keynav";
 import type { Session, GitState, SessionStatus } from "$lib/types";
 
 function session(id: string, readyToMerge = false, status: SessionStatus = "running"): Session {
@@ -123,4 +123,31 @@ test("nextNeedsYou cycles among blocked sessions, wrapping", () => {
 test("nextNeedsYou is a no-op (null) when none are blocked or only the current one is", () => {
   expect(nextNeedsYou([], "a")).toBeNull();
   expect(nextNeedsYou(["a"], "a")).toBeNull();
+});
+
+// altComboKey — physical KeyboardEvent.code → keynav key vocabulary
+
+test("altComboKey maps j/k/g letter codes", () => {
+  expect(altComboKey("KeyJ")).toBe("j");
+  expect(altComboKey("KeyK")).toBe("k");
+  expect(altComboKey("KeyG")).toBe("g");
+});
+
+test("altComboKey maps arrow codes", () => {
+  expect(altComboKey("ArrowDown")).toBe("arrowdown");
+  expect(altComboKey("ArrowUp")).toBe("arrowup");
+});
+
+test("altComboKey maps Digit1–Digit9 to '1'–'9'", () => {
+  for (let n = 1; n <= 9; n++) {
+    expect(altComboKey(`Digit${n}`)).toBe(String(n));
+  }
+});
+
+test("altComboKey returns null for non-combo codes", () => {
+  expect(altComboKey("KeyN")).toBeNull();
+  expect(altComboKey("Digit0")).toBeNull();
+  expect(altComboKey("Numpad1")).toBeNull();
+  expect(altComboKey("Escape")).toBeNull();
+  expect(altComboKey("")).toBeNull();
 });

--- a/ui/src/lib/components/herd-keynav.ts
+++ b/ui/src/lib/components/herd-keynav.ts
@@ -64,7 +64,14 @@ export function nthId(order: string[], n: number): string | null {
  *  shortcut handler in +page.svelte (to act on the combo) and xterm's
  *  `attachCustomKeyEventHandler` in Viewport.svelte (to suppress the key from
  *  reaching the PTY). Matching on physical `e.code`, not `e.key`, because macOS
- *  Option+J produces "∆" and other layouts vary. */
+ *  Option+J produces "∆" and other layouts vary.
+ *
+ *  Numpad1–9 are deliberately NOT mapped (asymmetric with the plain-key tier,
+ *  which keys off `e.key` and so accepts numpad digits): Alt+numpad-digit is
+ *  the Windows OS alt-code input method for typing special characters into the
+ *  terminal, and `e.code` reports Numpad1–9 regardless of NumLock — mapping
+ *  them would both shadow alt-code entry and ghost-match when the key isn't a
+ *  digit at all. */
 export function altComboKey(code: string): string | null {
   if (code === "KeyJ") return "j";
   if (code === "KeyK") return "k";

--- a/ui/src/lib/components/herd-keynav.ts
+++ b/ui/src/lib/components/herd-keynav.ts
@@ -56,6 +56,26 @@ export function nthId(order: string[], n: number): string | null {
   return Number.isInteger(n) && n >= 1 && n <= order.length ? order[n - 1] : null;
 }
 
+/** Maps a physical `KeyboardEvent.code` to the keynav key vocabulary string used
+ *  by the page-level shortcut handler (lowercase `e.key`-style), or null if the
+ *  code is not part of the Alt+key session-switch combo set.
+ *
+ *  Single source of truth for Alt+key combos — consumed by BOTH the window
+ *  shortcut handler in +page.svelte (to act on the combo) and xterm's
+ *  `attachCustomKeyEventHandler` in Viewport.svelte (to suppress the key from
+ *  reaching the PTY). Matching on physical `e.code`, not `e.key`, because macOS
+ *  Option+J produces "∆" and other layouts vary. */
+export function altComboKey(code: string): string | null {
+  if (code === "KeyJ") return "j";
+  if (code === "KeyK") return "k";
+  if (code === "KeyG") return "g";
+  if (code === "ArrowDown") return "arrowdown";
+  if (code === "ArrowUp") return "arrowup";
+  const digitMatch = /^Digit([1-9])$/.exec(code);
+  if (digitMatch) return digitMatch[1];
+  return null;
+}
+
 /** Next blocked session after `currentId` in `blockedIds` (oldest-first, the
  *  NEEDS-YOU set), wrapping around; cycles among several, skips the current one.
  *  Null when none are blocked or the only blocked session is already selected. */

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -391,4 +391,12 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_viewport_repo_icon_title",
     bodyKey: "feat_viewport_repo_icon_body",
   },
+  {
+    // No targetId: keyboard shortcuts are invisible chrome (documented in the
+    // viewport footer hint line) — surface via the What's-New drawer only.
+    id: "herd-keynav-anywhere",
+    sinceVersion: "1.23.0",
+    titleKey: "feat_herd_keynav_anywhere_title",
+    bodyKey: "feat_herd_keynav_anywhere_body",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -52,7 +52,13 @@
   import LearningsDrawer from "$lib/components/LearningsDrawer.svelte";
   import { basename } from "$lib/components/learnings-drawer";
   import Herd from "$lib/components/Herd.svelte";
-  import { railOrder, cycleId, nthId, nextNeedsYou } from "$lib/components/herd-keynav";
+  import {
+    railOrder,
+    cycleId,
+    nthId,
+    nextNeedsYou,
+    altComboKey,
+  } from "$lib/components/herd-keynav";
   import type { HerdFilter } from "$lib/components/herd-partition";
   import {
     collectReadyPrs,
@@ -442,7 +448,24 @@
   let mobileScreen = $state<"list" | "detail">("list");
   let showBacklog = $state(false);
 
-  function selectUnit(id: string) {
+  // Whether the *next* terminal remount should grab the keyboard. Deliberately a
+  // plain (non-reactive) let, NOT $state: it's never rendered, and Viewport
+  // consumes it inside its terminal-rebuild $effect — a tracked read there would
+  // re-create the terminal (and drop scrollback) whenever this flips. One-shot:
+  // Viewport's consume resets it to true, so resumeEpoch-driven rebuilds
+  // (resume / re-attach, no selection change) keep auto-focusing.
+  let keynavFocusIntent = true;
+
+  // bind:this on the desktop Viewport, so the Enter shortcut can hand the
+  // keyboard back to the terminal that plain-key navigation kept it out of.
+  let viewportRef: Viewport | undefined = $state();
+
+  function selectUnit(id: string, focusTerm = true) {
+    // only a *real* switch remounts the terminal and consumes the intent; a
+    // self-selection (e.g. plain j wrapping back to the only visible session)
+    // must not park a stale `false` that would suppress a later
+    // resumeEpoch-driven auto-focus.
+    if (id !== selectedId) keynavFocusIntent = focusTerm;
     selectedId = id;
     if (mobile.current) mobileScreen = "detail";
   }
@@ -481,9 +504,10 @@
 
   // Keyboard-driven selection: route through the same selectUnit a rail click
   // uses, then keep the now-selected row visible in the rail's scroll area.
-  function keyNavSelect(id: string | null) {
+  // focusTerm = whether the remounted terminal should grab the keyboard.
+  function keyNavSelect(id: string | null, focusTerm = true) {
     if (!id) return;
-    selectUnit(id);
+    selectUnit(id, focusTerm);
     document
       .querySelector(`[data-unit-id="${CSS.escape(id)}"]`)
       ?.scrollIntoView({ block: "nearest" });
@@ -495,17 +519,20 @@
   // g jumps to the next session that needs you (cycling among blocked ones,
   // silently a no-op when nothing is blocked), 1-9 select the Nth visible
   // session in rail order. Returns true when the key belonged to keynav.
-  function handleHerdKeyNav(key: string, e: KeyboardEvent): boolean {
+  // focusTerm follows the keystroke's origin: plain keys pass false so focus
+  // stays out of the terminal and the next plain key still chains; Alt combos
+  // pass true only when fired from inside the terminal (focus follows origin).
+  function handleHerdKeyNav(key: string, e: KeyboardEvent, focusTerm = true): boolean {
     switch (key) {
       case "j":
       case "arrowdown":
         e.preventDefault();
-        keyNavSelect(cycleId(railIds(), selectedId, 1));
+        keyNavSelect(cycleId(railIds(), selectedId, 1), focusTerm);
         return true;
       case "k":
       case "arrowup":
         e.preventDefault();
-        keyNavSelect(cycleId(railIds(), selectedId, -1));
+        keyNavSelect(cycleId(railIds(), selectedId, -1), focusTerm);
         return true;
       case "g":
         e.preventDefault();
@@ -514,6 +541,7 @@
             blockedEntries.map((entry) => entry.session.id),
             selectedId,
           ),
+          focusTerm,
         );
         return true;
       default:
@@ -521,7 +549,7 @@
           const id = nthId(railIds(), Number(key));
           if (id) {
             e.preventDefault();
-            keyNavSelect(id);
+            keyNavSelect(id, focusTerm);
           }
           return true;
         }
@@ -529,13 +557,19 @@
     }
   }
 
-  // Global single-key shortcuts (no modifier → zero browser/terminal conflict,
-  // works on every platform). Desktop only, and suppressed while typing or while
-  // any modal/overlay is open so a stray "n"/"b" can't stack dialogs.
+  // Global shortcuts, two tiers. Plain single keys (n/b + keynav) are suppressed
+  // while typing — they must never eat a keystroke meant for an input or the
+  // terminal. Alt+J/K/G/arrows/1-9 are the work-everywhere session switchers:
+  // they deliberately SKIP the typing guard so they fire even while xterm holds
+  // focus (Viewport's attachCustomKeyEventHandler suppresses the same combos —
+  // via the shared altComboKey map — from reaching the PTY). Desktop only, and
+  // every tier is suppressed while a modal/overlay is open so a stray key can't
+  // stack dialogs or switch sessions under one.
   function onShortcut(e: KeyboardEvent) {
     if (mobile.current) return;
-    if (e.metaKey || e.ctrlKey || e.altKey || e.repeat || e.isComposing) return;
-    if (isTyping(e.target)) return;
+    // no auto-repeat anywhere (plain or Alt) — held j must not machine-gun
+    // through sessions; and stand down during IME composition.
+    if (e.repeat || e.isComposing) return;
     if (
       showNew ||
       showSettings ||
@@ -547,6 +581,21 @@
       showWhatsNew
     )
       return;
+    if (e.altKey && !e.ctrlKey && !e.metaKey) {
+      // physical e.code, not e.key: macOS Option+J types "∆" (see altComboKey)
+      const mapped = altComboKey(e.code);
+      if (mapped !== null) {
+        // focus follows origin: Alt from inside the terminal keeps the operator
+        // in terminal flow (focus the new session's terminal); Alt from anywhere
+        // else leaves focus out so plain-key navigation still chains after.
+        const fromTerminal = e.target instanceof HTMLElement && e.target.closest(".xterm") !== null;
+        handleHerdKeyNav(mapped, e, fromTerminal);
+        return;
+      }
+      // not a combo key → fall through to the modifier bail below, untouched
+    }
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (isTyping(e.target)) return;
     const key = e.key.toLowerCase();
     switch (key) {
       case "n":
@@ -560,8 +609,19 @@
           showBacklog = true;
         }
         break;
+      case "enter":
+        // hand the keyboard back to the terminal after chained plain-key
+        // navigation. Deliberately narrow — body-focused only: a focused
+        // rail-card button keeps native Enter→click activation.
+        if (e.target === document.body) {
+          e.preventDefault();
+          viewportRef?.focusTerminal();
+        }
+        break;
       default:
-        handleHerdKeyNav(key, e);
+        // plain keynav keeps focus OUT of the new terminal so the next plain
+        // key chains (j j j…) instead of vanishing into the PTY; Enter opts in.
+        handleHerdKeyNav(key, e, false);
     }
   }
 
@@ -990,6 +1050,11 @@
             queue={blockedEntries.map((e) => e.session.id)}
             switchOrder={store.sessions.map((s) => s.id)}
             onnavigate={(id) => selectUnit(id)}
+            consumeAutoFocusTerm={() => {
+              const v = keynavFocusIntent;
+              keynavFocusIntent = true;
+              return v;
+            }}
             {onarchive}
             workingBlocked={store.workingBlocked}
             onback={() => (mobileScreen = "list")}
@@ -1055,6 +1120,7 @@
           />
         {:else if selected}
           <Viewport
+            bind:this={viewportRef}
             session={selected}
             touch={touch.current}
             git={store.git[selected.id]}
@@ -1069,6 +1135,11 @@
             queue={blockedEntries.map((e) => e.session.id)}
             switchOrder={store.sessions.map((s) => s.id)}
             onnavigate={(id) => selectUnit(id)}
+            consumeAutoFocusTerm={() => {
+              const v = keynavFocusIntent;
+              keynavFocusIntent = true;
+              return v;
+            }}
             {onarchive}
             workingBlocked={store.workingBlocked}
             onbroadcast={() => (showBroadcast = true)}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -449,12 +449,23 @@
   let showBacklog = $state(false);
 
   // Whether the *next* terminal remount should grab the keyboard. Deliberately a
-  // plain (non-reactive) let, NOT $state: it's never rendered, and Viewport
-  // consumes it inside its terminal-rebuild $effect — a tracked read there would
-  // re-create the terminal (and drop scrollback) whenever this flips. One-shot:
-  // Viewport's consume resets it to true, so resumeEpoch-driven rebuilds
-  // (resume / re-attach, no selection change) keep auto-focusing.
+  // plain (non-reactive) let, NOT $state: nothing renders it and the consumer
+  // (Viewport's mount rAF) reads it imperatively, so reactivity buys nothing —
+  // and keeping it out of $state guards against any future tracked read in
+  // Viewport's terminal-rebuild $effect re-creating the terminal (and dropping
+  // scrollback) whenever this flips. One-shot: Viewport's consume resets it to
+  // true, so resumeEpoch-driven rebuilds (resume / re-attach, no selection
+  // change) keep auto-focusing.
   let keynavFocusIntent = true;
+
+  // One-shot consume of keynavFocusIntent — read it, reset it to true, return
+  // it. Passed to both Viewport instances (focus + compact layouts) as their
+  // consumeAutoFocusTerm prop.
+  function consumeAutoFocusTerm(): boolean {
+    const v = keynavFocusIntent;
+    keynavFocusIntent = true;
+    return v;
+  }
 
   // bind:this on the desktop Viewport, so the Enter shortcut can hand the
   // keyboard back to the terminal that plain-key navigation kept it out of.
@@ -522,7 +533,7 @@
   // focusTerm follows the keystroke's origin: plain keys pass false so focus
   // stays out of the terminal and the next plain key still chains; Alt combos
   // pass true only when fired from inside the terminal (focus follows origin).
-  function handleHerdKeyNav(key: string, e: KeyboardEvent, focusTerm = true): boolean {
+  function handleHerdKeyNav(key: string, e: KeyboardEvent, focusTerm: boolean): boolean {
     switch (key) {
       case "j":
       case "arrowdown":
@@ -557,20 +568,10 @@
     }
   }
 
-  // Global shortcuts, two tiers. Plain single keys (n/b + keynav) are suppressed
-  // while typing — they must never eat a keystroke meant for an input or the
-  // terminal. Alt+J/K/G/arrows/1-9 are the work-everywhere session switchers:
-  // they deliberately SKIP the typing guard so they fire even while xterm holds
-  // focus (Viewport's attachCustomKeyEventHandler suppresses the same combos —
-  // via the shared altComboKey map — from reaching the PTY). Desktop only, and
-  // every tier is suppressed while a modal/overlay is open so a stray key can't
-  // stack dialogs or switch sessions under one.
-  function onShortcut(e: KeyboardEvent) {
-    if (mobile.current) return;
-    // no auto-repeat anywhere (plain or Alt) — held j must not machine-gun
-    // through sessions; and stand down during IME composition.
-    if (e.repeat || e.isComposing) return;
-    if (
+  // Every shortcut tier stands down while a modal/overlay is open, so a stray
+  // key can't stack dialogs or switch sessions under one.
+  function anyOverlayOpen(): boolean {
+    return (
       showNew ||
       showSettings ||
       showBacklog ||
@@ -579,21 +580,40 @@
       showUpdate ||
       showHerdrUpdate ||
       showWhatsNew
-    )
-      return;
-    if (e.altKey && !e.ctrlKey && !e.metaKey) {
-      // physical e.code, not e.key: macOS Option+J types "∆" (see altComboKey)
-      const mapped = altComboKey(e.code);
-      if (mapped !== null) {
-        // focus follows origin: Alt from inside the terminal keeps the operator
-        // in terminal flow (focus the new session's terminal); Alt from anywhere
-        // else leaves focus out so plain-key navigation still chains after.
-        const fromTerminal = e.target instanceof HTMLElement && e.target.closest(".xterm") !== null;
-        handleHerdKeyNav(mapped, e, fromTerminal);
-        return;
-      }
-      // not a combo key → fall through to the modifier bail below, untouched
-    }
+    );
+  }
+
+  // The Alt tier of onShortcut: Alt+J/K/G/arrows/1-9 are the work-everywhere
+  // session switchers — they deliberately SKIP the typing guard so they fire
+  // even while xterm holds focus (Viewport's attachCustomKeyEventHandler
+  // suppresses the same combos — via the shared altComboKey map — from reaching
+  // the PTY). Returns true when the key was consumed; false (Alt held but not a
+  // combo key, or other modifier mixes) falls through to onShortcut's modifier
+  // bail, untouched.
+  function handleAltCombo(e: KeyboardEvent): boolean {
+    if (!e.altKey || e.ctrlKey || e.metaKey) return false;
+    // physical e.code, not e.key: macOS Option+J types "∆" (see altComboKey)
+    const mapped = altComboKey(e.code);
+    if (mapped === null) return false;
+    // focus follows origin: Alt from inside the terminal keeps the operator
+    // in terminal flow (focus the new session's terminal); Alt from anywhere
+    // else leaves focus out so plain-key navigation still chains after.
+    const fromTerminal = e.target instanceof HTMLElement && e.target.closest(".xterm") !== null;
+    handleHerdKeyNav(mapped, e, fromTerminal);
+    return true;
+  }
+
+  // Global shortcuts, two tiers: the Alt combos (handleAltCombo) and plain
+  // single keys (n/b + keynav), which are suppressed while typing — they must
+  // never eat a keystroke meant for an input or the terminal. Desktop only,
+  // and suppressed under any open modal/overlay (anyOverlayOpen).
+  function onShortcut(e: KeyboardEvent) {
+    if (mobile.current) return;
+    // no auto-repeat anywhere (plain or Alt) — held j must not machine-gun
+    // through sessions; and stand down during IME composition.
+    if (e.repeat || e.isComposing) return;
+    if (anyOverlayOpen()) return;
+    if (handleAltCombo(e)) return;
     if (e.metaKey || e.ctrlKey || e.altKey) return;
     if (isTyping(e.target)) return;
     const key = e.key.toLowerCase();
@@ -1050,11 +1070,7 @@
             queue={blockedEntries.map((e) => e.session.id)}
             switchOrder={store.sessions.map((s) => s.id)}
             onnavigate={(id) => selectUnit(id)}
-            consumeAutoFocusTerm={() => {
-              const v = keynavFocusIntent;
-              keynavFocusIntent = true;
-              return v;
-            }}
+            {consumeAutoFocusTerm}
             {onarchive}
             workingBlocked={store.workingBlocked}
             onback={() => (mobileScreen = "list")}
@@ -1135,11 +1151,7 @@
             queue={blockedEntries.map((e) => e.session.id)}
             switchOrder={store.sessions.map((s) => s.id)}
             onnavigate={(id) => selectUnit(id)}
-            consumeAutoFocusTerm={() => {
-              const v = keynavFocusIntent;
-              keynavFocusIntent = true;
-              return v;
-            }}
+            {consumeAutoFocusTerm}
             {onarchive}
             workingBlocked={store.workingBlocked}
             onbroadcast={() => (showBroadcast = true)}


### PR DESCRIPTION
## Problem

The `j/k/1–9` / `g` session shortcuts were dead whenever the terminal had focus (xterm holds the keyboard in a hidden textarea, so the typing guard swallowed everything), and after unfocusing, a single `j` worked but the new session's terminal immediately stole focus back — chained keyboard navigation was impossible by design.

## What changed

Two complementary mechanisms (per the approved `.shepherd-plan.md`):

1. **Alt combos work everywhere** — `Alt(⌥)+J/K`, `Alt+G`, `Alt+↑/↓`, `Alt+1–9` switch sessions even while typing in the terminal. Matched on physical `e.code` (macOS ⌥ dead-chars safe) via a single shared mapping (`altComboKey` in `herd-keynav.ts`) used by both the window handler (act) and xterm's `attachCustomKeyEventHandler` (suppress: `preventDefault()` + `return false`, following the Shift+Enter precedent) — the combos never reach the PTY, all other Alt keys still do. AltGr (ctrl+alt) falls through untouched.
2. **Plain keys chain** — a keyboard-driven switch no longer pulls focus into the new terminal (focus follows origin: Alt from inside the terminal keeps you typing; plain keys from outside keep focus out), so `j j k g 3` chains freely. **Enter** (from body) hands focus back to the terminal. Click behavior unchanged. Focus intent is a one-shot non-reactive flag consumed per terminal rebuild, so `resumeEpoch` rebuilds and self-selections keep today's auto-focus; no new tracked reads in the scrollback-destroying terminal `$effect`.

Discoverability: updated `vp-foot` hints (`j/k/1–9 switch session (⌥/Alt from terminal)`, `↵ back to terminal`) and a What's-New entry `herd-keynav-anywhere` (1.23.0) whose body states the Alt-shadowing trade-off explicitly. EN+DE.

## Verified

- Unit: new `altComboKey` tests; full UI suite 833/833; `check`, `check:i18n`, fallow audit, branch hygiene, feature catalog all green.
- **Live browser verification** against the real backend (vite proxy + CDP keyboard, WebSocket spy on `/pty`): Alt+J/K/5/G from a focused terminal switch with focus-follows-origin and **zero bytes sent to the PTY**; plain `j j k` chain with focus pinned to body; Enter focuses the terminal; click-driven switching still auto-focuses; normal typing and unmapped `Alt+B` still reach the PTY; new footer hints render.

## Known limitations (accepted in plan review)

- Firefox/Linux may keep `Alt+1–9` for browser-tab switching (j/k/g/arrows unaffected).
- TUIs lose exactly the mapped Alt codes (e.g. readline `M-j`, Alt+digit args) — deliberate, documented in the What's-New body.
- Enter-to-focus fires only when focus is parked on `<body>`; other focusables keep native Enter activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)