### PR TITLE
fix(toasts): auto-dismiss update-main offer after 15s, pause on hover/focus

### DIFF
--- a/ui/src/lib/components/Toasts.svelte
+++ b/ui/src/lib/components/Toasts.svelte
@@ -6,7 +6,17 @@
 {#if toasts.items.length}
   <div class="toasts" aria-live="polite" aria-atomic="false">
     {#each toasts.items as t (t.id)}
-      <div class="toast" class:is-undo={t.tone === "undo"} role={t.alert ? "alert" : "status"}>
+      <!-- hold()/release() pause timed info auto-dismiss while hovered or focused;
+           the store no-ops both for undo toasts, so attaching uniformly is safe. -->
+      <div
+        class="toast"
+        class:is-undo={t.tone === "undo"}
+        role={t.alert ? "alert" : "status"}
+        onpointerenter={() => toasts.hold(t.id)}
+        onpointerleave={() => toasts.release(t.id)}
+        onfocusin={() => toasts.hold(t.id)}
+        onfocusout={() => toasts.release(t.id)}
+      >
         <span class="msg">{t.text}</span>
         {#if t.tone === "undo"}
           <button type="button" class="undo" onclick={() => toasts.cancel(t.id)}>

--- a/ui/src/lib/pull-offer.test.ts
+++ b/ui/src/lib/pull-offer.test.ts
@@ -1,0 +1,57 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { toasts } from "./toasts.svelte";
+import { offerUpdateMain } from "./pull-offer";
+import { pullRepo } from "$lib/api";
+
+vi.mock("$lib/api", () => ({ pullRepo: vi.fn() }));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.mocked(pullRepo).mockReset();
+  // start each test from a clean queue (module-singleton store)
+  for (const t of [...toasts.items]) toasts.close(t.id);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("offer toast auto-dismisses after 15s when ignored", async () => {
+  offerUpdateMain("/repo/a");
+  expect(toasts.items).toHaveLength(1);
+
+  await vi.advanceTimersByTimeAsync(14_999);
+  expect(toasts.items).toHaveLength(1);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(toasts.items).toHaveLength(0);
+});
+
+test("re-offer for the same repo re-arms one toast, gone 15s after the second offer", async () => {
+  offerUpdateMain("/repo/a");
+  await vi.advanceTimersByTimeAsync(10_000);
+
+  offerUpdateMain("/repo/a");
+  expect(toasts.items).toHaveLength(1); // keyed dedupe: still exactly one
+
+  await vi.advanceTimersByTimeAsync(14_999); // 24.999s after the FIRST offer
+  expect(toasts.items).toHaveLength(1);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(toasts.items).toHaveLength(0);
+});
+
+test("failure toast from the offer's action stays persistent", async () => {
+  vi.mocked(pullRepo).mockResolvedValue({ ok: false, reason: "error" });
+
+  offerUpdateMain("/repo/a");
+  const offer = toasts.items.find((t) => t.key === "update-main-offer:/repo/a");
+  expect(offer).toBeDefined();
+  toasts.act(offer!.id); // drops the offer, runs pullRepo
+  await vi.advanceTimersByTimeAsync(0); // flush the async run
+
+  expect(pullRepo).toHaveBeenCalledWith("/repo/a", undefined);
+  expect(toasts.items).toHaveLength(1);
+  expect(toasts.items.find((t) => t.key === "update-main:/repo/a")).toBeDefined();
+
+  await vi.advanceTimersByTimeAsync(120_000); // far past 15s
+  expect(toasts.items).toHaveLength(1); // duration null: must not vanish
+});

--- a/ui/src/lib/pull-offer.ts
+++ b/ui/src/lib/pull-offer.ts
@@ -3,8 +3,8 @@ import { toasts } from "$lib/toasts.svelte";
 import { m } from "$lib/paraglide/messages";
 
 /** After a PR merge, offer a one-click fast-forward of the repo's local default-branch
- *  checkout. Persistent + per-repo deduped so the only path to the action doesn't
- *  expire and repeated merges to one repo collapse to a single offer. */
+ *  checkout. Auto-dismisses after 15s (paused while hovered/focused) and per-repo
+ *  deduped so repeated merges to one repo re-arm a single offer. */
 export function offerUpdateMain(repoPath: string, branch?: string): void {
   if (!repoPath) return;
 
@@ -44,7 +44,7 @@ export function offerUpdateMain(repoPath: string, branch?: string): void {
 
   toasts.info(m.toast_update_main_offer(), {
     action: { label: m.toast_update_main_action(), run: () => run() },
-    duration: null,
+    duration: 15_000,
     key: `update-main-offer:${repoPath}`,
   });
 }

--- a/ui/src/lib/toasts.svelte.test.ts
+++ b/ui/src/lib/toasts.svelte.test.ts
@@ -48,3 +48,82 @@ test("an unkeyed undo is not matched by pendingUndo", () => {
   toasts.undo("generic", { undoLabel: "UNDO", onCommit: () => {} });
   expect(toasts.pendingUndo("s1")).toBe(false);
 });
+
+test("hold() pauses a timed info toast past its deadline", async () => {
+  const id = toasts.info("saved", { duration: 4000 });
+  toasts.hold(id);
+
+  await vi.advanceTimersByTimeAsync(10_000);
+  expect(toasts.items.some((t) => t.id === id)).toBe(true);
+});
+
+test("release() resumes with the remaining time, not a fresh window", async () => {
+  const id = toasts.info("saved", { duration: 4000 });
+
+  await vi.advanceTimersByTimeAsync(1000); // 3s left
+  toasts.hold(id);
+  await vi.advanceTimersByTimeAsync(60_000); // held: clock irrelevant
+  toasts.release(id);
+
+  await vi.advanceTimersByTimeAsync(2999);
+  expect(toasts.items.some((t) => t.id === id)).toBe(true); // not earlier
+  await vi.advanceTimersByTimeAsync(1);
+  expect(toasts.items.some((t) => t.id === id)).toBe(false); // exactly the 3s remainder
+});
+
+test("holds are ref-counted: one release of two keeps the toast paused", async () => {
+  const id = toasts.info("saved", { duration: 4000 });
+  toasts.hold(id); // hover
+  toasts.hold(id); // + keyboard focus
+
+  toasts.release(id); // pointer leaves, still focused
+  await vi.advanceTimersByTimeAsync(10_000);
+  expect(toasts.items.some((t) => t.id === id)).toBe(true);
+
+  toasts.release(id); // focus leaves too
+  await vi.advanceTimersByTimeAsync(4000);
+  expect(toasts.items.some((t) => t.id === id)).toBe(false);
+});
+
+test("release() never goes below zero (stray release then hold still pauses)", async () => {
+  const id = toasts.info("saved", { duration: 4000 });
+  toasts.release(id); // stray — no hold outstanding
+  toasts.hold(id);
+
+  await vi.advanceTimersByTimeAsync(10_000);
+  expect(toasts.items.some((t) => t.id === id)).toBe(true);
+});
+
+test("hold() no-ops on a persistent info toast", async () => {
+  const id = toasts.info("failed", { duration: null });
+  toasts.hold(id);
+  toasts.release(id);
+
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(toasts.items.some((t) => t.id === id)).toBe(true); // still persistent
+});
+
+test("hold() no-ops on undo toasts: the commit deadline stands", async () => {
+  const onCommit = vi.fn();
+  const id = toasts.undo("decommissioned", { undoLabel: "UNDO", onCommit, duration: 5000 });
+  toasts.hold(id);
+
+  await vi.advanceTimersByTimeAsync(5000);
+  expect(onCommit).toHaveBeenCalledOnce();
+  expect(toasts.items.some((t) => t.id === id)).toBe(false);
+});
+
+test("keyed refresh while held doesn't re-arm under the pointer", async () => {
+  const id = toasts.info("failed", { key: "k1", duration: 4000 });
+  toasts.hold(id);
+
+  expect(toasts.info("failed again", { key: "k1", duration: 2000 })).toBe(id);
+  await vi.advanceTimersByTimeAsync(10_000);
+  expect(toasts.items.some((t) => t.id === id)).toBe(true); // still under the pointer
+
+  toasts.release(id);
+  await vi.advanceTimersByTimeAsync(1999);
+  expect(toasts.items.some((t) => t.id === id)).toBe(true);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(toasts.items.some((t) => t.id === id)).toBe(false); // refreshed duration applies
+});

--- a/ui/src/lib/toasts.svelte.ts
+++ b/ui/src/lib/toasts.svelte.ts
@@ -62,6 +62,13 @@ class ToastStore {
   // Caller key -> toast id. Namespaced by tone (#kk) so an info and an undo
   // toast may safely reuse the same caller key without cross-mutating state.
   #keyed = new Map<string, number>();
+  // Arming info for timed info toasts, so hold() can pause and release() can
+  // resume with the leftover time. While the timer runs, remaining counts from
+  // `at`; while held (no timer), `remaining` IS the time left.
+  #armed = new Map<number, { at: number; remaining: number }>();
+  // Hold REF-COUNTS (not booleans): hover and keyboard focus are independent
+  // holders that overlap, and neither leaving may re-arm while the other stays.
+  #holds = new Map<number, number>();
 
   /** Internal dedupe key: tone-prefixed so info/undo keys never collide. The
    *  distinct "info"/"undo" prefix makes any cross-tone match impossible
@@ -102,10 +109,52 @@ class ToastStore {
   /** Arm an info toast's auto-dismiss timer. `null` duration = persistent (stays
    *  until the operator retries or closes it). */
   #armInfo(id: number, duration: number | null | undefined) {
-    if (duration === null) return;
+    if (duration === null) {
+      this.#armed.delete(id); // a keyed refresh may turn a timed toast persistent
+      return;
+    }
+    const ms = duration ?? 4000;
+    this.#armed.set(id, { at: Date.now(), remaining: ms });
+    // Keyed refresh landing while held (hovered/focused): don't start a timer
+    // under the operator's pointer — release() arms the recorded duration.
+    if ((this.#holds.get(id) ?? 0) > 0) return;
     this.#timers.set(
       id,
-      setTimeout(() => this.#drop(id), duration ?? 4000),
+      setTimeout(() => this.#drop(id), ms),
+    );
+  }
+
+  /** Pause auto-dismiss while the operator hovers or focuses the toast. Counted,
+   *  not boolean: each holder (pointer, focus) pairs with its own release().
+   *  No-op for undo toasts — their window is a commit deadline synced to the
+   *  CSS depleting bar; pausing would desync bar and commit semantics. */
+  hold(id: number): void {
+    if (this.items.find((t) => t.id === id)?.tone !== "info") return;
+    const count = (this.#holds.get(id) ?? 0) + 1;
+    this.#holds.set(id, count);
+    if (count !== 1) return; // already paused by another holder
+    const armed = this.#armed.get(id);
+    if (!armed) return; // persistent: nothing to pause
+    this.#clearTimer(id);
+    armed.remaining = Math.max(0, armed.remaining - (Date.now() - armed.at));
+  }
+
+  /** Drop one hold; only when the LAST holder leaves does the leftover time
+   *  re-arm. No-op when nothing is held (the count never goes negative). */
+  release(id: number): void {
+    const count = this.#holds.get(id) ?? 0;
+    if (count === 0) return;
+    if (count > 1) {
+      this.#holds.set(id, count - 1);
+      return;
+    }
+    this.#holds.delete(id);
+    const armed = this.#armed.get(id);
+    if (!armed) return; // persistent — stays until closed
+    armed.at = Date.now();
+    this.#timers.set(
+      id,
+      setTimeout(() => this.#drop(id), armed.remaining),
     );
   }
 
@@ -184,6 +233,8 @@ class ToastStore {
     this.#commits.delete(id);
     this.#undos.delete(id);
     this.#actions.delete(id);
+    this.#armed.delete(id);
+    this.#holds.delete(id);
     for (const [k, v] of this.#keyed) if (v === id) this.#keyed.delete(k);
     this.items = this.items.filter((t) => t.id !== id);
   }


### PR DESCRIPTION
## What

The post-merge "Update main?" offer toast was persistent (`duration: null`), so missed offers piled up until manually closed. It now auto-dismisses after **15s** — and because the toast is the only UI path to its one-click pull, timed info toasts gain a **hover/focus pause** so the timer can't fire mid-interaction.

## How

- `ui/src/lib/toasts.svelte.ts`: ref-counted `hold(id)`/`release(id)` (hover + keyboard focus are independent holders; the timer only re-arms when the last holder releases). Pauses store remaining ms; keyed-dedupe refreshes landing while held don't re-arm under the pointer. No-op for persistent info toasts and for undo toasts (commit deadline + depleting bar stay in sync).
- `ui/src/lib/components/Toasts.svelte`: `pointerenter/leave` + `focusin/out` → `hold`/`release`.
- `ui/src/lib/pull-offer.ts`: offer `duration: null` → `15_000`; doc comment updated. The genuine-failure toast stays persistent (`duration: null` + `alert`); benign info toasts keep the 4s default.

## Tests

- Store: hold stops dismissal; release resumes with exact remaining; double-hold needs both releases; stray release never underflows; persistent/undo no-ops (undo still commits at deadline); keyed-refresh-while-held arms only after release.
- New `pull-offer.test.ts`: 15s dismiss boundary; same-repo re-offer re-arms a single toast; failure toast persists 120s+ after a failed pull.
- `cd ui && bun run check` 0 errors; vitest 837/837; fallow audit clean; no new strings (no i18n/catalog impact — behavior `fix`, not a `feat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)