### PR TITLE
fix: stop false "needs you" badge + blocked display while the agent is actively working

### DIFF
--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -30,17 +30,19 @@ export function tailLines(text: string, n = TAIL_LINES): string[] {
 }
 
 // Active-turn spinner line, anchored: the line must START with a spinner/tool
-// glyph (·✢✳✶✻✽*+⎿), then carry an ellipsis directly followed by "(" + either an
+// glyph (·✢✳✶✻✽*⎿), then carry an ellipsis directly followed by "(" + either an
 // elapsed-time counter or the legacy "esc to interrupt" hint, e.g.
 // "✶ Bunning… (1m 13s · ↑ 1.3k tokens)" / "⎿  Running… (4s)" /
 // "✻ Imagining… (esc to interrupt)". The glyph anchor rejects prose quoting a
 // time mid-text ("the build finished… (3m 12s)"), queued-input lines
 // ("❯ retry… (2m 30s)"), and a bare "esc to interrupt" on a non-spinner line;
 // the `…(` adjacency rejects "… +5 lines (ctrl+o to expand)" and "(1M context)"
-// (no elapsed time). Accepted residual: `*`/`+` are also plausible
-// markdown-bullet leaders — kept because they are genuine spinner frames, and
-// suppression is scoped to the awaiting-input fallback + a display-only flag.
-const SPINNER_RE = /^\s*[·✢✳✶✻✽*+⎿].*?…\s*\((?:(?:\d+h\s*)?(?:\d+m\s*)?\d+s\b|esc to interrupt)/i;
+// (no elapsed time). `+` is excluded: zero occurrences as a spinner frame in
+// 889 production-captured tails, and a common markdown/diff line leader. `*`
+// IS a genuine production spinner frame and stays — its residual
+// markdown-bullet risk is covered by the poller's freshness gate (continued
+// suppression requires the buffer to advance between classify reads).
+const SPINNER_RE = /^\s*[·✢✳✶✻✽*⎿].*?…\s*\((?:(?:\d+h\s*)?(?:\d+m\s*)?\d+s\b|esc to interrupt)/i;
 
 /**
  * True when the terminal tail shows an actively-working Claude Code turn — a

--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -33,11 +33,13 @@ export function tailLines(text: string, n = TAIL_LINES): string[] {
 // glyph (·✢✳✶✻✽*+⎿), then carry an ellipsis directly followed by "(" + either an
 // elapsed-time counter or the legacy "esc to interrupt" hint, e.g.
 // "✶ Bunning… (1m 13s · ↑ 1.3k tokens)" / "⎿  Running… (4s)" /
-// "✻ Imagining… (esc to interrupt)". Verified against 856 production-captured
-// tails. The glyph anchor rejects prose quoting a time mid-text
-// ("the build finished… (3m 12s)"), queued-input lines ("❯ retry… (2m 30s)"),
-// and a bare "esc to interrupt" on a non-spinner line; the `…(` adjacency
-// rejects "… +5 lines (ctrl+o to expand)" and "(1M context)" (no elapsed time).
+// "✻ Imagining… (esc to interrupt)". The glyph anchor rejects prose quoting a
+// time mid-text ("the build finished… (3m 12s)"), queued-input lines
+// ("❯ retry… (2m 30s)"), and a bare "esc to interrupt" on a non-spinner line;
+// the `…(` adjacency rejects "… +5 lines (ctrl+o to expand)" and "(1M context)"
+// (no elapsed time). Accepted residual: `*`/`+` are also plausible
+// markdown-bullet leaders — kept because they are genuine spinner frames, and
+// suppression is scoped to the awaiting-input fallback + a display-only flag.
 const SPINNER_RE = /^\s*[·✢✳✶✻✽*+⎿].*?…\s*\((?:(?:\d+h\s*)?(?:\d+m\s*)?\d+s\b|esc to interrupt)/i;
 
 /**

--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -29,19 +29,23 @@ export function tailLines(text: string, n = TAIL_LINES): string[] {
     .slice(-n);
 }
 
-// Active-turn spinner line: an ellipsis directly followed by "(<elapsed time>",
-// e.g. "✶ Bunning… (1m 13s · ↑ 1.3k tokens)" / "⎿  Running… (4s)". Verified against
-// 856 production-captured tails; does NOT match "… +5 lines (ctrl+o to expand)"
-// (text between … and the paren) or "(1M context)" (no elapsed time).
-const SPINNER_RE = /…\s*\((?:\d+h\s*)?(?:\d+m\s*)?\d+s\b/;
-const INTERRUPT_HINT_RE = /esc to interrupt/i;
+// Active-turn spinner line, anchored: the line must START with a spinner/tool
+// glyph (·✢✳✶✻✽*+⎿), then carry an ellipsis directly followed by "(" + either an
+// elapsed-time counter or the legacy "esc to interrupt" hint, e.g.
+// "✶ Bunning… (1m 13s · ↑ 1.3k tokens)" / "⎿  Running… (4s)" /
+// "✻ Imagining… (esc to interrupt)". Verified against 856 production-captured
+// tails. The glyph anchor rejects prose quoting a time mid-text
+// ("the build finished… (3m 12s)"), queued-input lines ("❯ retry… (2m 30s)"),
+// and a bare "esc to interrupt" on a non-spinner line; the `…(` adjacency
+// rejects "… +5 lines (ctrl+o to expand)" and "(1M context)" (no elapsed time).
+const SPINNER_RE = /^\s*[·✢✳✶✻✽*+⎿].*?…\s*\((?:(?:\d+h\s*)?(?:\d+m\s*)?\d+s\b|esc to interrupt)/i;
 
 /**
- * True when the terminal tail shows an actively-working Claude Code turn —
- * a spinner line with an elapsed-time counter, or the legacy "esc to interrupt"
- * hint. Scans the same last-15-non-empty-lines window as `classifyBlocked`
- * (the spinner always sits just above the input box; this avoids matching
- * stale scrollback).
+ * True when the terminal tail shows an actively-working Claude Code turn — a
+ * glyph-anchored spinner line with an elapsed-time counter or the legacy
+ * "esc to interrupt" hint. Scans the same last-15-non-empty-lines window as
+ * `classifyBlocked` (the spinner always sits just above the input box; this
+ * avoids matching stale scrollback).
  *
  * Why this exists: herdr can latch `agent_status=blocked` after the user
  * answers a permission/elicitation dialog, reporting "blocked" for the rest
@@ -50,7 +54,7 @@ const INTERRUPT_HINT_RE = /esc to interrupt/i;
  * against that upstream herdr bug.
  */
 export function hasActiveSpinner(text: string): boolean {
-  return tailLines(text).some((l) => SPINNER_RE.test(l) || INTERRUPT_HINT_RE.test(l));
+  return tailLines(text).some((l) => SPINNER_RE.test(l));
 }
 
 /** Classify a blocked agent's terminal tail into an actionable shape. Never throws. */

--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -29,6 +29,30 @@ export function tailLines(text: string, n = TAIL_LINES): string[] {
     .slice(-n);
 }
 
+// Active-turn spinner line: an ellipsis directly followed by "(<elapsed time>",
+// e.g. "✶ Bunning… (1m 13s · ↑ 1.3k tokens)" / "⎿  Running… (4s)". Verified against
+// 856 production-captured tails; does NOT match "… +5 lines (ctrl+o to expand)"
+// (text between … and the paren) or "(1M context)" (no elapsed time).
+const SPINNER_RE = /…\s*\((?:\d+h\s*)?(?:\d+m\s*)?\d+s\b/;
+const INTERRUPT_HINT_RE = /esc to interrupt/i;
+
+/**
+ * True when the terminal tail shows an actively-working Claude Code turn —
+ * a spinner line with an elapsed-time counter, or the legacy "esc to interrupt"
+ * hint. Scans the same last-15-non-empty-lines window as `classifyBlocked`
+ * (the spinner always sits just above the input box; this avoids matching
+ * stale scrollback).
+ *
+ * Why this exists: herdr can latch `agent_status=blocked` after the user
+ * answers a permission/elicitation dialog, reporting "blocked" for the rest
+ * of the working turn. A "blocked" agent whose TUI shows a live turn spinner
+ * is actually working, not waiting on the user — this is a defensive guard
+ * against that upstream herdr bug.
+ */
+export function hasActiveSpinner(text: string): boolean {
+  return tailLines(text).some((l) => SPINNER_RE.test(l) || INTERRUPT_HINT_RE.test(l));
+}
+
 /** Classify a blocked agent's terminal tail into an actionable shape. Never throws. */
 export function classifyBlocked(text: string): BlockReason {
   const tail = tailLines(text);

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,9 @@ const poller = new StatusPoller(
   // claude-liveness sweep wiring: lets the UI gate its Resume affordance on the
   // claude process actually being gone instead of offering it on every idle/done.
   { onChange: (id, claudeAlive) => events.emit("session:claude-alive", { id, claudeAlive }) },
+  // working-while-blocked display flag: herdr latched "blocked" but the TUI shows a
+  // live turn spinner — the UI keeps working chrome instead of a false "needs you".
+  (id, working) => events.emit("session:working-blocked", { id, working }),
 );
 // Clear stale mappings left by a crashed prior run. Fire void, NOT await: the service's
 // single FIFO queue already guarantees this op completes before any register/unregister
@@ -761,6 +764,7 @@ const server = serve(
     ownsPr,
     activity: { snapshot: () => poller.activitySnapshot() },
     claudeAlive: { snapshot: () => poller.claudeAliveSnapshot() },
+    workingBlocked: { snapshot: () => poller.workingBlockedSnapshot() },
     preview: { snapshot: () => previewService.snapshot() },
     previewServe: { snapshot: () => tailscaleServe.snapshot() },
     push,

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -108,8 +108,9 @@ export class StatusPoller {
    *  the working-while-blocked suppression episode (herdr latches blocked after
    *  an answered dialog). Membership drives the `onWorkingBlocked` display flag:
    *  added (emit true) once per episode in `maybeClassify`'s suppression branch;
-   *  removed (emit false) on re-arm, on leaving herdr-blocked (`reconcileAgent`),
-   *  or on reap/prune. */
+   *  removed with an emit (false) on re-arm, on leaving herdr-blocked
+   *  (`reconcileAgent`), and on reap; dropped SILENTLY on prune (the session was
+   *  archived — no client cares about its flag anymore). */
   private workingWhileBlocked = new Set<string>();
 
   /** Timestamp of the last claude-liveness sweep (0 = never). */

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -104,6 +104,14 @@ export class StatusPoller {
   /** The resolved preview wiring (with real defaults filled in). */
   private readonly previewWiring: PreviewWiring;
 
+  /** Sessions herdr reports "blocked" whose TUI shows a live turn spinner —
+   *  the working-while-blocked suppression episode (herdr latches blocked after
+   *  an answered dialog). Membership drives the `onWorkingBlocked` display flag:
+   *  added (emit true) once per episode in `maybeClassify`'s suppression branch;
+   *  removed (emit false) on re-arm, on leaving herdr-blocked (`reconcileAgent`),
+   *  or on reap/prune. */
+  private workingWhileBlocked = new Set<string>();
+
   /** Timestamp of the last claude-liveness sweep (0 = never). */
   private lastLivenessSweepAt = 0;
   /** Last-swept per-session claude liveness; onChange fires on flips only. */
@@ -148,6 +156,13 @@ export class StatusPoller {
      * Resume when the claude process is actually gone (husk shell).
      */
     liveness?: Partial<LivenessWiring>,
+    /**
+     * Pushed when a session enters/leaves the working-while-blocked display state
+     * (herdr latched "blocked" but the TUI shows a live turn spinner). `true` fires
+     * once per suppression episode, `false` when the episode ends — same tick as
+     * (and before) any re-armed block emission.
+     */
+    private onWorkingBlocked: (id: string, working: boolean) => void = () => {},
   ) {
     // Merge supplied overrides with real defaults. When preview is omitted entirely
     // we create a no-op wiring so tick() never throws on undefined access.
@@ -244,6 +259,11 @@ export class StatusPoller {
     return Object.fromEntries(this.lastClaudeAlive);
   }
 
+  /** Sessions currently in the working-while-blocked display state, for client bootstrap. */
+  workingBlockedSnapshot(): Record<string, boolean> {
+    return Object.fromEntries([...this.workingWhileBlocked].map((id) => [id, true]));
+  }
+
   /**
    * The herdr agent is gone (claude exited / user ctrl-c'd the session).
    * Mirror reconcile()'s startup behavior, but live — otherwise the session
@@ -251,6 +271,7 @@ export class StatusPoller {
    * terminal (herdr replies agent_not_found in a tight reconnect loop).
    */
   private reapGone(s: Session): void {
+    if (this.workingWhileBlocked.delete(s.id)) this.onWorkingBlocked(s.id, false);
     this.clearBlock(s.id);
     if (s.status !== "done") {
       this.store.update(s.id, { status: "done", lastState: "done" });
@@ -277,6 +298,11 @@ export class StatusPoller {
       this.store.update(s.id, { readyToMerge: false });
       this.onReady(s.id, false);
     }
+    // Left herdr-blocked (running/idle/done alike) → the working-while-blocked
+    // display flag must drop in the SAME tick, not via the throttled probe paths.
+    if (status !== "blocked" && this.workingWhileBlocked.delete(s.id)) {
+      this.onWorkingBlocked(s.id, false);
+    }
     if (status === "blocked") this.maybeClassify(s.id, s.herdrAgentId);
     else if (status === "running") this.maybeProbe(s);
     else this.clearBlock(s.id);
@@ -297,6 +323,7 @@ export class StatusPoller {
       ...this.interimInFlight.keys(),
       ...this.lastTranscriptTs.keys(),
       ...this.previewStopState.keys(),
+      ...this.workingWhileBlocked,
     ]);
     for (const id of tracked) {
       if (!activeIds.has(id)) {
@@ -312,6 +339,8 @@ export class StatusPoller {
         this.interimInFlight.delete(id);
         this.lastTranscriptTs.delete(id);
         this.previewStopState.delete(id);
+        // archived/removed → no client cares anymore; drop without an emit
+        this.workingWhileBlocked.delete(id);
       }
     }
   }
@@ -598,7 +627,11 @@ export class StatusPoller {
    * Read + classify a blocked agent at most every `reclassifyMs`; emit only on change.
    * An `awaiting-input` fallback is suppressed (and any announced block cleared once)
    * while the TUI shows an active turn spinner — herdr can latch "blocked" after an
-   * answered dialog even though the agent resumed working.
+   * answered dialog even though the agent resumed working. The suppression episode
+   * is surfaced as the working-while-blocked display flag: `onWorkingBlocked(id, true)`
+   * once on entry; on re-arm (any block that will be emitted) `onWorkingBlocked(id,
+   * false)` fires first, then `onBlock`, in the same tick — clients see the flag drop
+   * and the block land together.
    */
   private maybeClassify(id: string, term: string): void {
     const t = this.now();
@@ -622,10 +655,17 @@ export class StatusPoller {
         this.lastSig.delete(id);
         this.onBlock(id, null);
       }
+      if (!this.workingWhileBlocked.has(id)) {
+        this.workingWhileBlocked.add(id);
+        this.onWorkingBlocked(id, true); // once per episode, not per cadence
+      }
       return;
     }
     const sig = JSON.stringify(reason);
     if (sig === this.lastSig.get(id)) return;
+    // Re-arm: a block is about to be emitted → end the suppression episode FIRST so
+    // the flag-off and the block reach clients in the same tick, in that order.
+    if (this.workingWhileBlocked.delete(id)) this.onWorkingBlocked(id, false);
     this.lastSig.set(id, sig);
     this.onBlock(id, reason);
   }

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -108,10 +108,26 @@ export class StatusPoller {
    *  the working-while-blocked suppression episode (herdr latches blocked after
    *  an answered dialog). Membership drives the `onWorkingBlocked` display flag:
    *  added (emit true) once per episode in `maybeClassify`'s suppression branch;
-   *  removed with an emit (false) on re-arm, on leaving herdr-blocked
-   *  (`reconcileAgent`), and on reap; dropped SILENTLY on prune (the session was
-   *  archived — no client cares about its flag anymore). */
+   *  removed with an emit (false) on re-arm — a spinner-free tail OR the
+   *  freshness gate tripping on a frozen buffer (see `lastSuppressVisible`) —
+   *  on leaving herdr-blocked (`reconcileAgent`), and on reap; dropped SILENTLY
+   *  on prune (the session was archived — no client cares about its flag
+   *  anymore). */
   private workingWhileBlocked = new Set<string>();
+  /** Per-session previous classify-read visible buffer while in a spinner-
+   *  suppression episode — the freshness gate. A spinner LINE match alone is
+   *  necessary but not sufficient to keep suppressing: a live spinner ticks its
+   *  elapsed/token counters, so the buffer always advances across the
+   *  reclassify cadence, while a wedged turn or a static buffer quoting a
+   *  spinner-like line (`* Done… (3s)` as a markdown bullet) stays frozen —
+   *  those must re-arm the block, not be suppressed forever. Deliberately
+   *  separate from `lastVisible` (evaluateStall's gate) and
+   *  `lastInterimVisible` (interim path) so the liveness diffs never trample
+   *  each other. Retained across a frozen re-arm (it IS the episode memory
+   *  that stops the same static buffer from re-earning first-sighting grace);
+   *  dropped when the suppression context ends (non-spinner classify, leaving
+   *  herdr-blocked, `clearBlock`, reap, prune). */
+  private lastSuppressVisible = new Map<string, string>();
 
   /** Timestamp of the last claude-liveness sweep (0 = never). */
   private lastLivenessSweepAt = 0;
@@ -301,8 +317,11 @@ export class StatusPoller {
     }
     // Left herdr-blocked (running/idle/done alike) → the working-while-blocked
     // display flag must drop in the SAME tick, not via the throttled probe paths.
-    if (status !== "blocked" && this.workingWhileBlocked.delete(s.id)) {
-      this.onWorkingBlocked(s.id, false);
+    // The suppression-episode baseline goes with it (flag or not — a frozen
+    // episode that already re-armed still holds one).
+    if (status !== "blocked") {
+      this.lastSuppressVisible.delete(s.id);
+      if (this.workingWhileBlocked.delete(s.id)) this.onWorkingBlocked(s.id, false);
     }
     if (status === "blocked") this.maybeClassify(s.id, s.herdrAgentId);
     else if (status === "running") this.maybeProbe(s);
@@ -325,6 +344,7 @@ export class StatusPoller {
       ...this.lastTranscriptTs.keys(),
       ...this.previewStopState.keys(),
       ...this.workingWhileBlocked,
+      ...this.lastSuppressVisible.keys(),
     ]);
     for (const id of tracked) {
       if (!activeIds.has(id)) {
@@ -342,6 +362,7 @@ export class StatusPoller {
         this.previewStopState.delete(id);
         // archived/removed → no client cares anymore; drop without an emit
         this.workingWhileBlocked.delete(id);
+        this.lastSuppressVisible.delete(id);
       }
     }
   }
@@ -628,7 +649,13 @@ export class StatusPoller {
    * Read + classify a blocked agent at most every `reclassifyMs`; emit only on change.
    * An `awaiting-input` fallback is suppressed (and any announced block cleared once)
    * while the TUI shows an active turn spinner — herdr can latch "blocked" after an
-   * answered dialog even though the agent resumed working. The suppression episode
+   * answered dialog even though the agent resumed working. Continued suppression
+   * additionally requires FRESHNESS: a live spinner ticks its elapsed/token counters,
+   * so the visible buffer advances between classify reads — an identical buffer means
+   * a wedged turn (or a static tail merely quoting a spinner-like line) and falls
+   * through to the normal emit, re-arming the block instead of suppressing forever.
+   * The first sighting of an episode gets a one-cadence grace (nothing to compare
+   * yet; the common case is a genuinely working spinner). The suppression episode
    * is surfaced as the working-while-blocked display flag: `onWorkingBlocked(id, true)`
    * once on entry; on re-arm (any block that will be emitted) `onWorkingBlocked(id,
    * false)` fires first, then `onBlock`, in the same tick — clients see the flag drop
@@ -652,15 +679,18 @@ export class StatusPoller {
       // agent resumed working — clear any announced block instead of emitting the
       // no-evidence fallback. (suppression scoped to awaiting-input only: a genuine
       // menu/y-n dialog must always surface, spinner or not)
-      if (this.lastSig.has(id)) {
-        this.lastSig.delete(id);
-        this.onBlock(id, null);
-      }
-      if (!this.workingWhileBlocked.has(id)) {
-        this.workingWhileBlocked.add(id);
-        this.onWorkingBlocked(id, true); // once per episode, not per cadence
-      }
-      return;
+      if (this.trySuppressSpinner(id, visible)) return;
+      // Freshness gate tripped: the buffer did NOT advance since the last classify
+      // read — a wedged turn or a static buffer quoting a spinner-like line, not a
+      // live spinner. Fall through to the normal emit so the block re-arms (flag-off
+      // before the block, below). `lastSuppressVisible` is deliberately KEPT: while
+      // the buffer stays frozen, every subsequent read lands here and dedupes on
+      // `lastSig` — deleting it would re-grant first-sighting grace each cadence
+      // (suppress/re-arm oscillation).
+    } else {
+      // Suppression context over (spinner gone, or a genuine menu/y-n dialog) →
+      // drop the episode memory so the next spinner sighting gets a fresh grace.
+      this.lastSuppressVisible.delete(id);
     }
     const sig = JSON.stringify(reason);
     if (sig === this.lastSig.get(id)) return;
@@ -669,6 +699,32 @@ export class StatusPoller {
     if (this.workingWhileBlocked.delete(id)) this.onWorkingBlocked(id, false);
     this.lastSig.set(id, sig);
     this.onBlock(id, reason);
+  }
+
+  /**
+   * Freshness-gated spinner suppression for `maybeClassify`. Records `visible`
+   * as the episode baseline and returns true when the buffer is FRESH — first
+   * sighting (one-cadence grace; nothing to compare yet) or advanced since the
+   * previous read (a live spinner ticking its counters) — having suppressed the
+   * fallback: any announced block is cleared once and the working-while-blocked
+   * flag turned on (a re-entry after a frozen re-arm lands here too). Returns
+   * false when the buffer is FROZEN (identical to the previous read — a wedged
+   * turn or a static tail quoting a spinner-like line): no suppression, the
+   * caller falls through to the normal emit and re-arms the block.
+   */
+  private trySuppressSpinner(id: string, visible: string): boolean {
+    const prev = this.lastSuppressVisible.get(id);
+    this.lastSuppressVisible.set(id, visible);
+    if (prev !== undefined && prev === visible) return false; // frozen → re-arm
+    if (this.lastSig.has(id)) {
+      this.lastSig.delete(id);
+      this.onBlock(id, null);
+    }
+    if (!this.workingWhileBlocked.has(id)) {
+      this.workingWhileBlocked.add(id);
+      this.onWorkingBlocked(id, true); // once per episode, not per cadence
+    }
+    return true;
   }
 
   /**
@@ -686,6 +742,7 @@ export class StatusPoller {
 
   private clearBlock(id: string): void {
     this.lastVisible.delete(id); // reset the stall liveness baseline regardless of block state
+    this.lastSuppressVisible.delete(id); // and the spinner-suppression episode baseline
     if (!this.lastSig.has(id)) return;
     this.lastSig.delete(id);
     this.lastReadAt.delete(id);

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1,7 +1,7 @@
 import type { SessionStore } from "./store";
 import type { Session } from "./types";
 import { mapState, matchAgents, type HerdrDriver, type HerdrAgent } from "./herdr";
-import { classifyBlocked, tailLines, type BlockReason } from "./blocked";
+import { classifyBlocked, hasActiveSpinner, tailLines, type BlockReason } from "./blocked";
 import { isStalled, DEFAULT_STALL, type ActivitySnapshot } from "./stall";
 import { jsonlPathFor } from "./usage";
 import { readTranscriptSignals, STRIP_WINDOW_MS, type SessionActivity } from "./activity-signal";
@@ -594,17 +594,35 @@ export class StatusPoller {
     this.onBlock(id, { shape: "stall", options: [], tail: tailLines(visible) });
   }
 
-  /** Read + classify a blocked agent at most every `reclassifyMs`; emit only on change. */
+  /**
+   * Read + classify a blocked agent at most every `reclassifyMs`; emit only on change.
+   * An `awaiting-input` fallback is suppressed (and any announced block cleared once)
+   * while the TUI shows an active turn spinner — herdr can latch "blocked" after an
+   * answered dialog even though the agent resumed working.
+   */
   private maybeClassify(id: string, term: string): void {
     const t = this.now();
     if (t - (this.lastReadAt.get(id) ?? 0) < this.reclassifyMs) return;
     this.lastReadAt.set(id, t);
+    let visible: string;
     let reason: BlockReason;
     try {
-      reason = this.classify(this.herdr.read(term, "visible"));
+      visible = this.herdr.read(term, "visible");
+      reason = this.classify(visible);
     } catch (err) {
       console.warn(`[poller] classify failed for ${id}:`, err);
       return; // best-effort; retry next cadence
+    }
+    if (reason.shape === "awaiting-input" && hasActiveSpinner(visible)) {
+      // herdr can latch "blocked" after an answered dialog; a live spinner means the
+      // agent resumed working — clear any announced block instead of emitting the
+      // no-evidence fallback. (suppression scoped to awaiting-input only: a genuine
+      // menu/y-n dialog must always surface, spinner or not)
+      if (this.lastSig.has(id)) {
+        this.lastSig.delete(id);
+        this.onBlock(id, null);
+      }
+      return;
     }
     const sig = JSON.stringify(reason);
     if (sig === this.lastSig.get(id)) return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -129,6 +129,10 @@ export interface AppDeps {
    *  live in the worktree?), for client bootstrap; updates flow via the
    *  `session:claude-alive` event. Absent in tests that skip it. */
   claudeAlive?: { snapshot(): Record<string, boolean> };
+  /** Sessions herdr reports blocked whose TUI shows a live turn spinner
+   *  (working-while-blocked display flag), for client bootstrap; updates flow via
+   *  the `session:working-blocked` event. Absent in tests that skip it. */
+  workingBlocked?: { snapshot(): Record<string, boolean> };
   /** Live preview port per session, for client bootstrap; absent until PreviewService is wired (Task 2+).
    *  `session:preview` events are emitted via PreviewService.onChange in index.ts. */
   preview?: {
@@ -242,6 +246,13 @@ function handleActivitySnapshot({ req, parts, deps }: Ctx): Response | null {
 function handleClaudeAliveSnapshot({ req, parts, deps }: Ctx): Response | null {
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "claude-alive" && !parts[2]) {
     return json(deps.claudeAlive?.snapshot() ?? {});
+  }
+  return null;
+}
+
+function handleWorkingBlockedSnapshot({ req, parts, deps }: Ctx): Response | null {
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "working-blocked" && !parts[2]) {
+    return json(deps.workingBlocked?.snapshot() ?? {});
   }
   return null;
 }
@@ -2327,6 +2338,7 @@ const ROUTE_HANDLERS = [
   handleGitSnapshot,
   handleActivitySnapshot,
   handleClaudeAliveSnapshot,
+  handleWorkingBlockedSnapshot,
   handlePreviewSnapshot,
   handleReviews,
   handlePlanGates,

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { classifyBlocked } from "../src/blocked";
+import { classifyBlocked, hasActiveSpinner } from "../src/blocked";
 
 test("classifies a numbered permission menu", () => {
   const tail = [
@@ -48,6 +48,39 @@ test("keeps only the last 15 non-empty lines in tail", () => {
   const r = classifyBlocked(tail);
   expect(r.tail.length).toBe(15);
   expect(r.tail[0]).toBe("line 15");
+});
+
+test("hasActiveSpinner detects real spinner variants", () => {
+  expect(hasActiveSpinner("✶ Bunning… (1m 13s · ↑ 1.3k tokens)")).toBe(true);
+  expect(
+    hasActiveSpinner("* Adding i18n + final review… (1h 29m 49s · ↓ 2.4k tokens · thinking)"),
+  ).toBe(true);
+  expect(hasActiveSpinner("⎿  Running… (4s)")).toBe(true);
+  expect(hasActiveSpinner("some output\nPress esc to interrupt\n❯")).toBe(true);
+});
+
+test("hasActiveSpinner detects a spinner with input-box/status lines after it", () => {
+  const tail = [
+    "· Churning… (2m 5s · ↓ 1.1k tokens · thought for 8s)",
+    "╭──────────────────────────────────╮",
+    "│ ❯                                │",
+    "╰──────────────────────────────────╯",
+    "⏵⏵ bypass permissions on (shift+tab to cycle)",
+  ].join("\n");
+  expect(hasActiveSpinner(tail)).toBe(true);
+});
+
+test("hasActiveSpinner rejects idle/blocked buffers", () => {
+  expect(hasActiveSpinner("… +5 lines (ctrl+o to expand)")).toBe(false);
+  expect(hasActiveSpinner("Opus 4.8 (1M context)")).toBe(false);
+  expect(hasActiveSpinner("❯ 1. Yes\n  2. No")).toBe(false);
+  expect(hasActiveSpinner("Enter to select · ↑/↓ to navigate · Esc to cancel")).toBe(false);
+  expect(hasActiveSpinner("❯\n⏵⏵ bypass permissions on (shift+tab to cycle)")).toBe(false);
+});
+
+test("hasActiveSpinner ignores a spinner outside the 15-line tail window", () => {
+  const filler = Array.from({ length: 16 }, (_, i) => `filler line ${i}`).join("\n");
+  expect(hasActiveSpinner(`✶ Bunning… (1m 13s · ↑ 1.3k tokens)\n${filler}`)).toBe(false);
 });
 
 test("strips ANSI escape codes before classifying a menu", () => {

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -88,6 +88,8 @@ test("hasActiveSpinner rejects spinner-shaped text on non-glyph-anchored lines",
   // the legacy hint outside a glyph-anchored spinner line no longer counts
   expect(hasActiveSpinner("press esc to interrupt")).toBe(false);
   expect(hasActiveSpinner("some output\nPress esc to interrupt\n❯")).toBe(false);
+  // `+` is a markdown/diff line leader, not a spinner frame (dropped from the glyph class)
+  expect(hasActiveSpinner("+ added a retry step… (2m 30s)")).toBe(false);
 });
 
 test("hasActiveSpinner ignores a spinner outside the 15-line tail window", () => {

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -55,8 +55,10 @@ test("hasActiveSpinner detects real spinner variants", () => {
   expect(
     hasActiveSpinner("* Adding i18n + final review… (1h 29m 49s · ↓ 2.4k tokens · thinking)"),
   ).toBe(true);
+  expect(hasActiveSpinner("· Churning… (2m 5s · ↓ 1.1k tokens · thought for 8s)")).toBe(true);
   expect(hasActiveSpinner("⎿  Running… (4s)")).toBe(true);
-  expect(hasActiveSpinner("some output\nPress esc to interrupt\n❯")).toBe(true);
+  // legacy hint still counts — but only on a glyph-anchored spinner line
+  expect(hasActiveSpinner("✻ Imagining… (esc to interrupt)")).toBe(true);
 });
 
 test("hasActiveSpinner detects a spinner with input-box/status lines after it", () => {
@@ -76,6 +78,16 @@ test("hasActiveSpinner rejects idle/blocked buffers", () => {
   expect(hasActiveSpinner("❯ 1. Yes\n  2. No")).toBe(false);
   expect(hasActiveSpinner("Enter to select · ↑/↓ to navigate · Esc to cancel")).toBe(false);
   expect(hasActiveSpinner("❯\n⏵⏵ bypass permissions on (shift+tab to cycle)")).toBe(false);
+});
+
+test("hasActiveSpinner rejects spinner-shaped text on non-glyph-anchored lines", () => {
+  // prose quoting an elapsed time mid-text — no glyph anchor
+  expect(hasActiveSpinner("the build finished… (3m 12s) faster than before")).toBe(false);
+  // queued-input/prompt line — starts with ❯, not a spinner/tool glyph
+  expect(hasActiveSpinner("❯ retry the failing test… (2m 30s)")).toBe(false);
+  // the legacy hint outside a glyph-anchored spinner line no longer counts
+  expect(hasActiveSpinner("press esc to interrupt")).toBe(false);
+  expect(hasActiveSpinner("some output\nPress esc to interrupt\n❯")).toBe(false);
 });
 
 test("hasActiveSpinner ignores a spinner outside the 15-line tail window", () => {

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -173,19 +173,23 @@ function spinnerHarness(initialText: string) {
   const events: string[] = [];
   let text = initialText;
   let agentStatus = "blocked";
+  let gone = false;
   const herdr = {
-    list: (): HerdrAgent[] => [
-      {
-        agent: "claude",
-        agentStatus,
-        cwd: "/wt",
-        paneId: "p",
-        tabId: "t",
-        name: "",
-        terminalId: "term_a",
-        workspaceId: "w",
-      } as HerdrAgent,
-    ],
+    list: (): HerdrAgent[] =>
+      gone
+        ? []
+        : [
+            {
+              agent: "claude",
+              agentStatus,
+              cwd: "/wt",
+              paneId: "p",
+              tabId: "t",
+              name: "",
+              terminalId: "term_a",
+              workspaceId: "w",
+            } as HerdrAgent,
+          ],
     read: () => text,
     readAsync: () => Promise.resolve(text),
   };
@@ -216,6 +220,7 @@ function spinnerHarness(initialText: string) {
   );
   return {
     poller,
+    store,
     blocks,
     working,
     statuses,
@@ -223,6 +228,7 @@ function spinnerHarness(initialText: string) {
     id: s.id,
     setText: (t: string) => (text = t),
     setStatus: (st: string) => (agentStatus = st),
+    setGone: () => (gone = true),
     advance: (ms: number) => (clock += ms),
   };
 }
@@ -324,6 +330,41 @@ test("suppress/re-arm cycle synthesizes no status transitions of its own", () =>
   h.advance(1000);
   h.poller.tick();
   expect(h.statuses).toEqual(["blocked", "running"]);
+});
+
+test("agent gone during suppression: reap emits exactly one working:false and marks done", () => {
+  const h = spinnerHarness(SPINNER_TAIL);
+  h.poller.tick(); // herdr blocked + spinner tail → suppression episode
+  expect(h.working).toEqual([{ id: h.id, working: true }]);
+
+  // claude exited / ctrl-c'd — herdr no longer lists the agent → reapGone
+  h.setGone();
+  h.advance(1000);
+  h.poller.tick();
+  expect(h.working).toEqual([
+    { id: h.id, working: true },
+    { id: h.id, working: false },
+  ]);
+  expect(h.store.get(h.id)?.status).toBe("done");
+  expect(h.poller.workingBlockedSnapshot()).toEqual({});
+
+  // further ticks emit nothing more
+  h.advance(1000);
+  h.poller.tick();
+  expect(h.working).toHaveLength(2);
+});
+
+test("archive during suppression: prune drops the flag silently (no working:false)", () => {
+  const h = spinnerHarness(SPINNER_TAIL);
+  h.poller.tick(); // enter the suppression episode
+  expect(h.working).toEqual([{ id: h.id, working: true }]);
+
+  // session archived → leaves the activeOnly list → pruneInactive clears tracking
+  h.store.update(h.id, { status: "archived" });
+  h.advance(1000);
+  h.poller.tick();
+  expect(h.working).toEqual([{ id: h.id, working: true }]); // NO additional emission
+  expect(h.poller.workingBlockedSnapshot()).toEqual({});
 });
 
 // route mirror of GET /api/claude-alive (see poller-liveness.test.ts)

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -158,7 +158,10 @@ test("re-emits onBlock when the blocked reason changes after the cadence", () =>
   expect((blocks[1]!.block as any).shape).toBe("yes-no");
 });
 
-const SPINNER_TAIL = "✶ Bunning… (1m 13s · ↑ 1.3k tokens)\n❯";
+/** A live spinner ticks its elapsed counter, so the buffer advances between
+ *  classify reads — parameterize the seconds to simulate that in tests. */
+const spinnerTail = (secs: number) => `✶ Bunning… (1m ${secs}s · ↑ 1.3k tokens)\n❯`;
+const SPINNER_TAIL = spinnerTail(13);
 
 /** Blocked-status herdr fake whose visible buffer (`setText`) and agent status
  *  (`setStatus`) are swappable. Captures block, working-blocked, and status
@@ -240,9 +243,11 @@ test("suppresses the awaiting-input fallback when the TUI shows a working spinne
   // exactly one working-blocked(true) for the episode …
   expect(h.working).toEqual([{ id: h.id, working: true }]);
 
-  // … and further cadences over the same buffer stay silent
+  // … and further cadences over an ADVANCING buffer (live spinner ticks) stay silent
+  h.setText(spinnerTail(18));
   h.advance(5000);
   h.poller.tick();
+  h.setText(spinnerTail(23));
   h.advance(5000);
   h.poller.tick();
   expect(h.blocks).toHaveLength(0);
@@ -265,9 +270,11 @@ test("clears an announced block exactly once when the buffer flips to a working 
   expect(h.blocks[1]!.block).toBeNull();
   expect(h.working).toEqual([{ id: h.id, working: true }]);
 
-  // further suppressed cycles emit nothing
+  // further suppressed cycles (spinner still ticking) emit nothing
+  h.setText(spinnerTail(18));
   h.advance(5000);
   h.poller.tick();
+  h.setText(spinnerTail(23));
   h.advance(5000);
   h.poller.tick();
   expect(h.blocks).toHaveLength(2);
@@ -319,6 +326,7 @@ test("herdr leaving blocked drops the working-blocked flag in the same tick", ()
 test("suppress/re-arm cycle synthesizes no status transitions of its own", () => {
   const h = spinnerHarness(SPINNER_TAIL);
   h.poller.tick(); // blocked + suppressed
+  h.setText(spinnerTail(18)); // spinner ticks → stays suppressed
   h.advance(5000);
   h.poller.tick(); // still suppressed
   h.setText("I need your input on the API design.\n❯");
@@ -364,6 +372,79 @@ test("archive during suppression: prune drops the flag silently (no working:fals
   h.advance(1000);
   h.poller.tick();
   expect(h.working).toEqual([{ id: h.id, working: true }]); // NO additional emission
+  expect(h.poller.workingBlockedSnapshot()).toEqual({});
+});
+
+test("frozen spinner re-arms: an identical buffer across cadences surfaces the block", () => {
+  const h = spinnerHarness(SPINNER_TAIL);
+  h.poller.tick(); // first sighting → one-cadence grace, suppressed
+  expect(h.blocks).toHaveLength(0);
+  expect(h.working).toEqual([{ id: h.id, working: true }]);
+
+  // buffer did NOT advance → wedged/static, not a live spinner → re-arm:
+  // exactly one working:false then one awaiting-input block, in that order
+  h.advance(3001);
+  h.poller.tick();
+  expect(h.events).toEqual(["working:true", "working:false", "block:awaiting-input"]);
+  expect(h.poller.workingBlockedSnapshot()).toEqual({});
+
+  // a further identical-buffer cadence: sig-dedupe → no new emissions
+  h.advance(3001);
+  h.poller.tick();
+  expect(h.events).toEqual(["working:true", "working:false", "block:awaiting-input"]);
+});
+
+test("advancing spinner stays suppressed across cadences", () => {
+  const h = spinnerHarness(spinnerTail(13));
+  h.poller.tick();
+  for (const secs of [14, 15, 16]) {
+    h.setText(spinnerTail(secs)); // elapsed counter ticks → buffer advances
+    h.advance(3001);
+    h.poller.tick();
+  }
+  expect(h.blocks).toHaveLength(0);
+  expect(h.working).toEqual([{ id: h.id, working: true }]); // only the initial flag-on
+  expect(h.poller.workingBlockedSnapshot()).toEqual({ [h.id]: true });
+});
+
+test("unwedged spinner re-enters suppression: flag back on, re-armed block cleared once", () => {
+  const h = spinnerHarness(SPINNER_TAIL);
+  h.poller.tick(); // grace
+  h.advance(3001);
+  h.poller.tick(); // frozen → re-arm
+  expect(h.events).toEqual(["working:true", "working:false", "block:awaiting-input"]);
+
+  // turn unwedges: the buffer advances again with a live spinner
+  h.setText(spinnerTail(14));
+  h.advance(3001);
+  h.poller.tick();
+  expect(h.events).toEqual([
+    "working:true",
+    "working:false",
+    "block:awaiting-input",
+    "block:null", // the re-armed block clears exactly once
+    "working:true", // flag back on for the fresh episode
+  ]);
+
+  // and the re-entered episode keeps suppressing while the spinner ticks
+  h.setText(spinnerTail(15));
+  h.advance(3001);
+  h.poller.tick();
+  expect(h.events).toHaveLength(5);
+  expect(h.poller.workingBlockedSnapshot()).toEqual({ [h.id]: true });
+});
+
+test("static buffer quoting a spinner-like markdown bullet ultimately surfaces the block", () => {
+  // genuine awaiting-input tail that merely CONTAINS a spinner-shaped bullet line
+  const h = spinnerHarness("Summary:\n* Done… (3s)\nWhich option do you prefer?\n❯");
+  h.poller.tick(); // first cadence: grace → may suppress
+  expect(h.blocks).toHaveLength(0);
+
+  // static across reads → second cadence re-arms with the block
+  h.advance(3001);
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(1);
+  expect((h.blocks[0]!.block as any).shape).toBe("awaiting-input");
   expect(h.poller.workingBlockedSnapshot()).toEqual({});
 });
 

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -157,6 +157,94 @@ test("re-emits onBlock when the blocked reason changes after the cadence", () =>
   expect((blocks[1]!.block as any).shape).toBe("yes-no");
 });
 
+const SPINNER_TAIL = "✶ Bunning… (1m 13s · ↑ 1.3k tokens)\n❯";
+
+/** Blocked-status herdr fake whose visible buffer is swappable via `setText`. */
+function spinnerHarness(initialText: string) {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const blocks: { id: string; block: unknown }[] = [];
+  let text = initialText;
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "blocked",
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => text,
+  };
+  let clock = 100_000;
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+  );
+  return {
+    poller,
+    blocks,
+    setText: (t: string) => (text = t),
+    advance: (ms: number) => (clock += ms),
+  };
+}
+
+test("suppresses the awaiting-input fallback when the TUI shows a working spinner", () => {
+  const h = spinnerHarness(SPINNER_TAIL);
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(0);
+});
+
+test("clears an announced block exactly once when the buffer flips to a working spinner", () => {
+  const h = spinnerHarness("❯ 1. Yes\n  2. No");
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(1);
+  expect((h.blocks[0]!.block as any).shape).toBe("menu");
+
+  // dialog answered, herdr latches blocked, TUI now shows a live turn spinner
+  h.setText(SPINNER_TAIL);
+  h.advance(5000);
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(2);
+  expect(h.blocks[1]!.block).toBeNull();
+
+  // further suppressed cycles emit nothing
+  h.advance(5000);
+  h.poller.tick();
+  h.advance(5000);
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(2);
+});
+
+test("re-arms after suppression: a later spinner-free awaiting-input tail emits a block", () => {
+  const h = spinnerHarness(SPINNER_TAIL);
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(0);
+
+  h.setText("I need your input on the API design.\n❯");
+  h.advance(5000);
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(1);
+  expect((h.blocks[0]!.block as any).shape).toBe("awaiting-input");
+});
+
+test("still emits a menu block when a spinner line is also visible", () => {
+  const h = spinnerHarness(`✶ Bunning… (1m 13s · ↑ 1.3k tokens)\n❯ 1. Yes\n  2. No`);
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(1);
+  expect((h.blocks[0]!.block as any).shape).toBe("menu");
+});
+
 test("marks a session done and emits once when its herdr agent is gone", () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
 import { SessionStore } from "../src/store";
 import { StatusPoller } from "../src/poller";
+import { makeApp } from "../src/server";
 import type { HerdrAgent } from "../src/herdr";
 import { classifyBlocked } from "../src/blocked";
 import { DEFAULT_STALL } from "../src/stall";
@@ -159,42 +160,69 @@ test("re-emits onBlock when the blocked reason changes after the cadence", () =>
 
 const SPINNER_TAIL = "✶ Bunning… (1m 13s · ↑ 1.3k tokens)\n❯";
 
-/** Blocked-status herdr fake whose visible buffer is swappable via `setText`. */
+/** Blocked-status herdr fake whose visible buffer (`setText`) and agent status
+ *  (`setStatus`) are swappable. Captures block, working-blocked, and status
+ *  emissions plus a combined `events` log for relative-order assertions. */
 function spinnerHarness(initialText: string) {
   const store = new SessionStore(":memory:");
-  store.create(baseSession);
+  const s = store.create(baseSession);
   const blocks: { id: string; block: unknown }[] = [];
+  const working: { id: string; working: boolean }[] = [];
+  const statuses: string[] = [];
+  /** Interleaved block + working-blocked emissions, most recent last. */
+  const events: string[] = [];
   let text = initialText;
+  let agentStatus = "blocked";
   const herdr = {
     list: (): HerdrAgent[] => [
       {
         agent: "claude",
-        agentStatus: "blocked",
+        agentStatus,
         cwd: "/wt",
         paneId: "p",
         tabId: "t",
         name: "",
         terminalId: "term_a",
         workspaceId: "w",
-      },
+      } as HerdrAgent,
     ],
     read: () => text,
+    readAsync: () => Promise.resolve(text),
   };
   let clock = 100_000;
   const poller = new StatusPoller(
     store,
     herdr as any,
-    () => {},
-    (id, block) => blocks.push({ id, block }),
+    (_id, status) => statuses.push(status),
+    (id, block) => {
+      blocks.push({ id, block });
+      events.push(`block:${block === null ? "null" : (block as any).shape}`);
+    },
     1000,
     3000,
     classifyBlocked,
     () => clock,
+    undefined, // probe
+    undefined, // stallCfg
+    undefined, // probeCheckMs
+    undefined, // onReady
+    undefined, // onActivity
+    undefined, // preview
+    undefined, // liveness
+    (id, w) => {
+      working.push({ id, working: w });
+      events.push(`working:${w}`);
+    },
   );
   return {
     poller,
     blocks,
+    working,
+    statuses,
+    events,
+    id: s.id,
     setText: (t: string) => (text = t),
+    setStatus: (st: string) => (agentStatus = st),
     advance: (ms: number) => (clock += ms),
   };
 }
@@ -203,6 +231,17 @@ test("suppresses the awaiting-input fallback when the TUI shows a working spinne
   const h = spinnerHarness(SPINNER_TAIL);
   h.poller.tick();
   expect(h.blocks).toHaveLength(0);
+  // exactly one working-blocked(true) for the episode …
+  expect(h.working).toEqual([{ id: h.id, working: true }]);
+
+  // … and further cadences over the same buffer stay silent
+  h.advance(5000);
+  h.poller.tick();
+  h.advance(5000);
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(0);
+  expect(h.working).toHaveLength(1);
+  expect(h.poller.workingBlockedSnapshot()).toEqual({ [h.id]: true });
 });
 
 test("clears an announced block exactly once when the buffer flips to a working spinner", () => {
@@ -210,6 +249,7 @@ test("clears an announced block exactly once when the buffer flips to a working 
   h.poller.tick();
   expect(h.blocks).toHaveLength(1);
   expect((h.blocks[0]!.block as any).shape).toBe("menu");
+  expect(h.working).toHaveLength(0);
 
   // dialog answered, herdr latches blocked, TUI now shows a live turn spinner
   h.setText(SPINNER_TAIL);
@@ -217,6 +257,7 @@ test("clears an announced block exactly once when the buffer flips to a working 
   h.poller.tick();
   expect(h.blocks).toHaveLength(2);
   expect(h.blocks[1]!.block).toBeNull();
+  expect(h.working).toEqual([{ id: h.id, working: true }]);
 
   // further suppressed cycles emit nothing
   h.advance(5000);
@@ -224,6 +265,7 @@ test("clears an announced block exactly once when the buffer flips to a working 
   h.advance(5000);
   h.poller.tick();
   expect(h.blocks).toHaveLength(2);
+  expect(h.working).toHaveLength(1);
 });
 
 test("re-arms after suppression: a later spinner-free awaiting-input tail emits a block", () => {
@@ -236,6 +278,9 @@ test("re-arms after suppression: a later spinner-free awaiting-input tail emits 
   h.poller.tick();
   expect(h.blocks).toHaveLength(1);
   expect((h.blocks[0]!.block as any).shape).toBe("awaiting-input");
+  // flag-off lands in the same tick, BEFORE the block (badge + red row together)
+  expect(h.events).toEqual(["working:true", "working:false", "block:awaiting-input"]);
+  expect(h.poller.workingBlockedSnapshot()).toEqual({});
 });
 
 test("still emits a menu block when a spinner line is also visible", () => {
@@ -243,6 +288,66 @@ test("still emits a menu block when a spinner line is also visible", () => {
   h.poller.tick();
   expect(h.blocks).toHaveLength(1);
   expect((h.blocks[0]!.block as any).shape).toBe("menu");
+  // a genuine dialog never enters the working-blocked display state
+  expect(h.working).toHaveLength(0);
+});
+
+test("herdr leaving blocked drops the working-blocked flag in the same tick", () => {
+  const h = spinnerHarness(SPINNER_TAIL);
+  h.poller.tick();
+  expect(h.working).toEqual([{ id: h.id, working: true }]);
+
+  // herdr flips to working → flag-off synchronously on that tick (no probe wait,
+  // no async flush — reconcileAgent clears it before any throttled path runs)
+  h.setStatus("working");
+  h.advance(1000);
+  h.poller.tick();
+  expect(h.working).toEqual([
+    { id: h.id, working: true },
+    { id: h.id, working: false },
+  ]);
+  expect(h.poller.workingBlockedSnapshot()).toEqual({});
+  expect(h.blocks).toHaveLength(0); // suppression never announced a block to clear
+});
+
+test("suppress/re-arm cycle synthesizes no status transitions of its own", () => {
+  const h = spinnerHarness(SPINNER_TAIL);
+  h.poller.tick(); // blocked + suppressed
+  h.advance(5000);
+  h.poller.tick(); // still suppressed
+  h.setText("I need your input on the API design.\n❯");
+  h.advance(5000);
+  h.poller.tick(); // re-arm → block emitted
+  expect(h.statuses).toEqual(["blocked"]); // only herdr's raw transition
+
+  h.setStatus("working");
+  h.advance(1000);
+  h.poller.tick();
+  expect(h.statuses).toEqual(["blocked", "running"]);
+});
+
+// route mirror of GET /api/claude-alive (see poller-liveness.test.ts)
+test("GET /api/working-blocked returns the snapshot; {} when unwired", async () => {
+  const baseDeps = {
+    store: new SessionStore(":memory:"),
+    service: {} as any,
+    events: { subscribe: () => () => {}, emit: () => {} } as any,
+    usageLimits: {
+      limits: () => ({ session5h: null, week: null, stale: true, calibratedAt: null }),
+    },
+  };
+  const wired = makeApp({
+    ...baseDeps,
+    workingBlocked: { snapshot: () => ({ "session-1": true }) },
+  } as any);
+  let res = await wired.fetch(new Request("http://localhost/api/working-blocked"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ "session-1": true });
+
+  const unwired = makeApp(baseDeps as any);
+  res = await unwired.fetch(new Request("http://localhost/api/working-blocked"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({});
 });
 
 test("marks a session done and emits once when its herdr agent is gone", () => {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -473,6 +473,16 @@ export async function claudeAliveStates(): Promise<Record<string, boolean>> {
   return r.json();
 }
 
+/** Snapshot of the working-while-blocked display flags, keyed by session id (for
+ *  client bootstrap; mirror of /api/claude-alive). `true` = herdr reports the
+ *  session "blocked" but the server saw it resume mid-turn (herdr's blocked
+ *  latch) — display-only, feeds `displayStatus` and nothing behavioral. */
+export async function workingBlockedStates(): Promise<Record<string, boolean>> {
+  const r = await fetch("/api/working-blocked");
+  if (!r.ok) throw await failed(r, "working-blocked states");
+  return r.json();
+}
+
 /** Snapshot of the bound preview-listener port per session, keyed by session id
  *  (for client bootstrap). `previewPort` is null when the server knows of no
  *  live dev-server listener. Empty object when nothing is bound. */

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -30,6 +30,7 @@
     filter = $bindable("all"),
     statusFilter = null,
     onstatusfilter = undefined,
+    workingBlocked = {},
   }: {
     sessions: Session[];
     selectedId: string | null;
@@ -74,6 +75,9 @@
     // the local all/ready filter (one filter at a time).
     statusFilter?: "running" | "idle" | "blocked" | null;
     onstatusfilter?: (status: "running" | "idle" | "blocked" | null) => void;
+    // working-while-blocked display flags (store map) — threaded into the rows'
+    // displayStatus and the "ready" filter so flagged sessions read as working
+    workingBlocked?: Record<string, boolean>;
   } = $props();
 
   // a critic post-PR review or a pre-execution plan-gate review currently in flight —
@@ -88,7 +92,7 @@
   // local all/ready filter ENTIRELY — a "ready" remnant would drop running sessions
   // and empty the list under statusFilter="running" (sessions already arrive filtered).
   const shown = $derived(
-    statusFilter != null ? sessions : shownSessions(sessions, filter, inReview),
+    statusFilter != null ? sessions : shownSessions(sessions, filter, inReview, workingBlocked),
   );
   // label for the status chip + filtered empty states (only read when set)
   const statusLabel = $derived(
@@ -202,6 +206,7 @@
           {ondecommission}
           {repoFilter}
           {onrepofilter}
+          {workingBlocked}
         />
       {/each}
       {#if partition.ciRunning.length > 0}
@@ -222,6 +227,7 @@
             {ondecommission}
             {repoFilter}
             {onrepofilter}
+            {workingBlocked}
           />
         {/each}
       {/if}
@@ -243,6 +249,7 @@
             {ondecommission}
             {repoFilter}
             {onrepofilter}
+            {workingBlocked}
           />
         {/each}
       {/if}
@@ -264,6 +271,7 @@
             {ondecommission}
             {repoFilter}
             {onrepofilter}
+            {workingBlocked}
           />
         {/each}
       {/if}
@@ -287,6 +295,7 @@
             {ondecommission}
             {repoFilter}
             {onrepofilter}
+            {workingBlocked}
           />
         {/each}
       {/if}
@@ -310,6 +319,7 @@
             {ondecommission}
             {repoFilter}
             {onrepofilter}
+            {workingBlocked}
           />
         {/each}
       {/if}
@@ -328,6 +338,7 @@
             {ondecommission}
             {repoFilter}
             {onrepofilter}
+            {workingBlocked}
           />
         {/each}
       {/if}
@@ -349,6 +360,7 @@
             {ondecommission}
             {repoFilter}
             {onrepofilter}
+            {workingBlocked}
           />
         {/each}
       {/if}
@@ -370,6 +382,7 @@
             {ondecommission}
             {repoFilter}
             {onrepofilter}
+            {workingBlocked}
           />
         {/each}
       {/if}
@@ -399,6 +412,7 @@
             {ondecommission}
             {repoFilter}
             {onrepofilter}
+            {workingBlocked}
           />
         {/each}
       {/if}
@@ -428,6 +442,7 @@
             {ondecommission}
             {repoFilter}
             {onrepofilter}
+            {workingBlocked}
           />
         {/each}
       {/if}

--- a/ui/src/lib/components/HerdGrid.svelte
+++ b/ui/src/lib/components/HerdGrid.svelte
@@ -15,6 +15,7 @@
     onsettings = undefined,
     filteredRepo = null,
     statusFilter = null,
+    workingBlocked = {},
   }: {
     sessions: Session[];
     selectedId: string | null;
@@ -29,6 +30,8 @@
     // page-level status filter (TopBar tallies); sessions arrive pre-filtered,
     // the prop only picks the right empty-state copy
     statusFilter?: "running" | "idle" | "blocked" | null;
+    // working-while-blocked display flags (store map) — threaded into the tiles' displayStatus
+    workingBlocked?: Record<string, boolean>;
   } = $props();
 
   const statusLabel = $derived(
@@ -63,6 +66,7 @@
         {nowMs}
         {onselect}
         git={git[session.id]}
+        {workingBlocked}
       />
     {/each}
   </div>

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -583,3 +583,37 @@ describe("TopBar — tallies toggle the status filter", () => {
     expect(onstatusfilter).toHaveBeenLastCalledWith(null);
   });
 });
+
+describe("TopBar — working-while-blocked counts in the working tally, not blocked", () => {
+  it("desktop: a flagged blocked session tallies as working; halt keeps the raw count", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const list = [
+      { id: "r1", status: "running" },
+      { id: "wb", status: "blocked" }, // herdr-latched, server flags it working
+      { id: "b1", status: "blocked" }, // genuinely blocked
+    ] as unknown as Session[];
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: list,
+      workingBlocked: { wb: true },
+    });
+    const working = page.getByTitle(
+      m.topbar_tally_filter_title({ status: m.topbar_working_label() }),
+    );
+    const blocked = page.getByTitle(
+      m.topbar_tally_filter_title({ status: m.topbar_blocked_label() }),
+    );
+    // display tallies: flagged session counts as working (2), not blocked (1)
+    await expect.element(working).toHaveTextContent("2");
+    await expect.element(blocked).toHaveTextContent("1");
+    // the e-stop stays RAW: only 1 raw-running agent is haltable, so the gear menu
+    // offers "Halt 1", not 2 (the server's haltAll can't reach the latched session)
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    await expect
+      .element(page.getByRole("menuitem", { name: m.halt_all_aria({ count: 1 }) }))
+      .toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Session, UsageLimits, UpdateStatus, HerdrUpdateStatus } from "$lib/types";
   import { formatReset } from "$lib/format";
+  import { displayStatus } from "$lib/display-status";
   import { gaugeList, hotterGauge, type GaugeKey } from "./usage-gauges";
   import { m } from "$lib/paraglide/messages";
   import { modeOf, topBarPlan, badgeCount } from "./top-bar-layout";
@@ -27,6 +28,7 @@
     onwhatsnew,
     statusFilter = null,
     onstatusfilter,
+    workingBlocked = {},
   }: {
     sessions: Session[];
     nowMs: number;
@@ -47,6 +49,9 @@
     // page-level session-status filter the tallies toggle; null = no filter
     statusFilter?: TallyStatus | null;
     onstatusfilter?: (status: TallyStatus | null) => void;
+    // working-while-blocked display flags (store map); tallies + gear pip read the
+    // DISPLAY status through it — the halt e-stop keeps the raw status (see below)
+    workingBlocked?: Record<string, boolean>;
   } = $props();
 
   // tally click: toggle — clicking the active status clears the filter
@@ -54,7 +59,14 @@
 
   const updateAvailable = $derived(!!update && update.behind > 0);
   const herdrUpdateAvailable = $derived(!!herdrUpdate && herdrUpdate.updateAvailable);
-  const working = $derived(sessions.filter((s) => s.status === "running").length);
+  // Tallies are DISPLAY: a working-while-blocked session counts as working, not
+  // blocked (displayStatus upgrades it). The halt e-stop instead reads the RAW
+  // status (`haltable` below): the server's haltAll only reaches agents herdr
+  // itself reports working, which the latched-"blocked" session is not.
+  const working = $derived(
+    sessions.filter((s) => displayStatus(s, workingBlocked) === "running").length,
+  );
+  const haltable = $derived(sessions.filter((s) => s.status === "running").length);
   // Responsive right-cluster decisions live in ./top-bar-layout (pure + unit-tested,
   // see top-bar-layout.test.ts). "touch-desktop" is the unfolded-foldable crunch
   // (~1000px) the #247/#322 overflow fixes targeted. The halt e-stop is NOT a bar
@@ -160,8 +172,10 @@
   const hideClockTime = $derived(plan.hideClockTime || (mode === "desktop" && desktopCompact));
   const compactBadges = $derived(plan.compactBadges || (mode === "desktop" && desktopCompact));
 
-  const idle = $derived(sessions.filter((s) => s.status === "idle").length);
-  const blocked = $derived(sessions.filter((s) => s.status === "blocked").length);
+  const idle = $derived(sessions.filter((s) => displayStatus(s, workingBlocked) === "idle").length);
+  const blocked = $derived(
+    sessions.filter((s) => displayStatus(s, workingBlocked) === "blocked").length,
+  );
   const clock = $derived(new Date(nowMs).toTimeString().slice(0, 8));
   const connText = $derived(
     connected ? m.topbar_clock_tip_connected() : m.topbar_clock_tip_disconnected(),
@@ -264,7 +278,7 @@
   // Drop the armed state if the herd goes quiet underneath it (agents finished), so a
   // later run doesn't surface a pre-armed row.
   $effect(() => {
-    if (working === 0) disarmHalt();
+    if (haltable === 0) disarmHalt();
   });
   // Destroy-only cleanup (no tracked reads → runs once): never leak the disarm timer.
   $effect(() => () => clearTimeout(armTimer));
@@ -557,14 +571,14 @@
         class="gear tip"
         type="button"
         onclick={toggleMenu}
-        data-tip={working > 0 ? m.topbar_menu_aria() : m.settings_title()}
+        data-tip={haltable > 0 ? m.topbar_menu_aria() : m.settings_title()}
         aria-haspopup="menu"
         aria-expanded={menuOpen}
-        aria-label={working > 0 ? m.topbar_menu_aria() : m.topbar_settings_aria()}
-        >⚙{#if working > 0}<span class="halt-pip" class:alert={blocked > 0} aria-hidden="true"
+        aria-label={haltable > 0 ? m.topbar_menu_aria() : m.topbar_settings_aria()}
+        >⚙{#if haltable > 0}<span class="halt-pip" class:alert={blocked > 0} aria-hidden="true"
           ></span>{/if}{#if herdrUpdateAvailable && mobile}<span
             class="gear-dot"
-            class:shift={working > 0}
+            class:shift={haltable > 0}
             aria-hidden="true"
           ></span>{/if}</button
       >
@@ -577,7 +591,7 @@
           bind:this={menuEl}
           onkeydown={onMenuKey}
         >
-          {#if working > 0}
+          {#if haltable > 0}
             <!-- e-stop row: first activation arms (red "Halt N?"), a second commits.
                  Full intent stays in the aria-label. -->
             <button
@@ -587,16 +601,16 @@
               role="menuitem"
               onclick={clickHalt}
               aria-label={armed
-                ? m.halt_arm_aria({ count: working })
-                : m.halt_all_aria({ count: working })}
+                ? m.halt_arm_aria({ count: haltable })
+                : m.halt_all_aria({ count: haltable })}
             >
               <svg class="menu-icon" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M8 2 H16 L22 8 V16 L16 22 H8 L2 16 V8 Z" fill="currentColor" />
               </svg>
               <span class="menu-label"
                 >{armed
-                  ? m.halt_arm({ count: working })
-                  : m.halt_menu_item({ count: working })}</span
+                  ? m.halt_arm({ count: haltable })
+                  : m.halt_menu_item({ count: haltable })}</span
               >
             </button>
             <div class="menu-sep" role="separator"></div>

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -5,6 +5,7 @@ import "../../app.css";
 import UnitRow from "./UnitRow.svelte";
 import { projectIcons } from "$lib/projectIcons.svelte";
 import type { Session } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
 
 function session(partial: Partial<Session> & { id: string }): Session {
   return {
@@ -163,5 +164,58 @@ describe("UnitRow inline repo emoji filter", () => {
     // the emoji still renders, but as plain decoration — no filter button
     await expect.element(page.getByText("🐑")).toBeInTheDocument();
     await expect.element(page.getByRole("button", { name: /repo/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("UnitRow working-while-blocked (full working treatment)", () => {
+  // What the FULL working treatment looks like on a row — asserted identically
+  // for a raw-running session and a blocked+flagged one, so the two renders
+  // can't drift apart: BUSY badge (not BLOCKED), the working pip (not the red
+  // "!" alarm badge), the typing caret, and the live activity line.
+  async function expectWorkingAffordances(root: HTMLElement) {
+    await expect.element(page.getByText(m.status_working())).toBeInTheDocument();
+    await expect.element(page.getByText(m.status_blocked())).not.toBeInTheDocument();
+    const pipLabel = m.statuspip_status_aria({ status: m.status_working() });
+    await expect.element(page.getByRole("img", { name: pipLabel })).toBeInTheDocument();
+    expect(root.querySelector(".pip.badge"), "no red ! alarm pip").toBeNull();
+    expect(root.querySelector(".car"), "typing caret present").not.toBeNull();
+    expect(
+      root.querySelector(".unit")?.classList.contains("has-activity"),
+      "live activity line",
+    ).toBe(true);
+  }
+
+  it("a blocked session flagged working renders identical to a raw-running one", async () => {
+    render(UnitRow, {
+      session: session({ id: "wb", status: "blocked" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      workingBlocked: { wb: true },
+    });
+    await expectWorkingAffordances(document.body);
+  });
+
+  it("baseline: a raw-running session shows the same affordances", async () => {
+    render(UnitRow, {
+      session: session({ id: "run", status: "running" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expectWorkingAffordances(document.body);
+  });
+
+  it("a blocked session WITHOUT the flag keeps the blocked treatment", async () => {
+    render(UnitRow, {
+      session: session({ id: "blk", status: "blocked" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      workingBlocked: {},
+    });
+    await expect.element(page.getByText(m.status_blocked())).toBeInTheDocument();
+    expect(document.body.querySelector(".pip.badge"), "red ! alarm pip").not.toBeNull();
+    expect(document.body.querySelector(".car"), "no typing caret").toBeNull();
   });
 });

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -7,6 +7,7 @@
 <script lang="ts">
   import type { Session, GitState, SessionActivity } from "$lib/types";
   import { elapsed, STATUS_COLOR, statusLabel, hideStatusBadge, canResume } from "$lib/format";
+  import { displayStatus } from "$lib/display-status";
   import { resumeSession } from "$lib/api";
   import CardMenu from "./CardMenu.svelte";
   import { longPress } from "./longpress";
@@ -45,6 +46,7 @@
     ondecommission,
     repoFilter = null,
     onrepofilter,
+    workingBlocked = {},
   }: {
     session: Session;
     selected: boolean;
@@ -66,7 +68,14 @@
     // when provided, clicking the inline repo emoji toggles the repo filter:
     // a path sets it, null clears (same contract as QueueStrip's band toggle)
     onrepofilter?: (repoPath: string | null) => void;
+    // working-while-blocked display flags (whole store map); feeds displayStatus only
+    workingBlocked?: Record<string, boolean>;
   } = $props();
+
+  // Every status-driven DISPLAY branch below reads this, not session.status: a
+  // working-while-blocked session gets the full working treatment. Behavioral
+  // reads (canResume) stay on the raw status.
+  const dStatus = $derived(displayStatus(session, workingBlocked));
 
   // repo the unit works in — the last path segment of its repoPath (e.g. "community-map")
   const repoName = $derived(session.repoPath.split("/").filter(Boolean).at(-1) ?? session.repoPath);
@@ -128,7 +137,7 @@
     if (openRow === close) openRow = null;
   });
 
-  const hideStatus = $derived(hideStatusBadge(session.status, reviews.isReviewing(session.id)));
+  const hideStatus = $derived(hideStatusBadge(dStatus, reviews.isReviewing(session.id)));
 
   // A status badge renders for merging / ready / a non-hidden status; only then
   // does #u-status-{id} exist. Build the overlay's aria-describedby so it omits
@@ -146,12 +155,12 @@
   );
 
   // live signals (heartbeat + current tool) only make sense while the agent works
-  const live = $derived(session.status === "running");
+  const live = $derived(dStatus === "running");
   // verbatim tool summary — NOT translated; shown as a quiet line when present
   const summary = $derived(activity?.summary?.trim() || null);
   // stepper conveys "how close to finishing" across the active lifecycle (not archived)
   const showStepper = $derived(
-    session.status === "running" || session.status === "blocked" || session.status === "done",
+    dStatus === "running" || dStatus === "blocked" || dStatus === "done",
   );
 
   // Decommission is deferred behind an undo window: while it's open, the row is
@@ -202,7 +211,7 @@
     class:has-activity={live}
     class:decommissioning
     data-unit-id={session.id}
-    style="--rule:{session.readyToMerge ? 'var(--color-green)' : STATUS_COLOR[session.status]}"
+    style="--rule:{session.readyToMerge ? 'var(--color-green)' : STATUS_COLOR[dStatus]}"
   >
     <button
       bind:this={hitEl}
@@ -217,7 +226,7 @@
     ></button>
     <div class="pip-col">
       <StatusPip
-        status={session.status}
+        status={dStatus}
         ready={session.readyToMerge}
         merging={isMerging(session, nowMs)}
       />
@@ -275,7 +284,7 @@
       {/if}
       <div class="u-sub" id="u-sub-{session.id}">
         {session.prompt}
-        {#if session.status === "running"}
+        {#if dStatus === "running"}
           <span class="car" aria-hidden="true">▏</span>
         {/if}
       </div>
@@ -318,7 +327,7 @@
       {:else if session.readyToMerge}
         <span class="badge" id="u-status-{session.id}">{m.status_ready_to_merge()}</span>
       {:else if !hideStatus}
-        <span class="badge" id="u-status-{session.id}">{statusLabel(session.status)}</span>
+        <span class="badge" id="u-status-{session.id}">{statusLabel(dStatus)}</span>
       {/if}
       <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
     </div>

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -4,6 +4,7 @@
   import { FitAddon } from "@xterm/addon-fit";
   import type { Session, GitState } from "$lib/types";
   import { STATUS_COLOR, statusLabel, elapsed, hideStatusBadge, canResume } from "$lib/format";
+  import { displayStatus } from "$lib/display-status";
   import { connectPty } from "$lib/pty";
   import { resumeSession } from "$lib/api";
   import { theme, xtermTheme } from "$lib/theme.svelte";
@@ -24,15 +25,22 @@
     nowMs = Date.now(),
     onselect,
     git,
+    workingBlocked = {},
   }: {
     session: Session;
     selected?: boolean;
     nowMs?: number;
     onselect: (id: string) => void;
     git?: GitState;
+    // working-while-blocked display flags (whole store map); feeds displayStatus only
+    workingBlocked?: Record<string, boolean>;
   } = $props();
 
-  const hideStatus = $derived(hideStatusBadge(session.status, reviews.isReviewing(session.id)));
+  // Display branches read this, not session.status: a working-while-blocked
+  // session gets the full working treatment. canResume stays on the raw status.
+  const dStatus = $derived(displayStatus(session, workingBlocked));
+
+  const hideStatus = $derived(hideStatusBadge(dStatus, reviews.isReviewing(session.id)));
 
   // A status badge renders for ready / a non-hidden status; only then does
   // #tile-status-{id} exist. Build the overlay's aria-describedby so it omits
@@ -171,7 +179,7 @@
 <div
   class="tile"
   class:sel={selected}
-  style="--rule:{session.readyToMerge ? 'var(--color-green)' : STATUS_COLOR[session.status]}"
+  style="--rule:{session.readyToMerge ? 'var(--color-green)' : STATUS_COLOR[dStatus]}"
 >
   <button
     bind:this={hitEl}
@@ -186,7 +194,7 @@
   <div class="t-head">
     <span class="name">{session.name}</span>
     <span class="spacer"></span>
-    {#if session.status === "running"}
+    {#if dStatus === "running"}
       <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
     {/if}
     <PrBadge {git} />
@@ -197,8 +205,8 @@
     {#if session.readyToMerge}
       <span class="badge" id="tile-status-{session.id}">{m.status_ready_to_merge()}</span>
     {:else if !hideStatus}
-      <span class="badge" class:alert={session.status === "blocked"} id="tile-status-{session.id}"
-        >{statusLabel(session.status)}</span
+      <span class="badge" class:alert={dStatus === "blocked"} id="tile-status-{session.id}"
+        >{statusLabel(dStatus)}</span
       >
     {/if}
     <span class="desig" id="tile-desig-{session.id}">{session.desig}</span>

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -12,6 +12,7 @@
     UsageLimits,
   } from "$lib/types";
   import { STATUS_COLOR, statusLabel, formatTokens, canResume } from "$lib/format";
+  import { displayStatus } from "$lib/display-status";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { hotterGauge } from "./usage-gauges";
   import { connectPty, type PtyConn } from "$lib/pty";
@@ -80,6 +81,7 @@
     buildQueue = null,
     onSeedBuildQueue,
     previewHost = null,
+    workingBlocked = {},
   }: {
     session: Session;
     onarchive?: (id: string, reap?: string[]) => void;
@@ -129,7 +131,14 @@
     /** The agent node's own tailnet host; preview URLs build from it when the HUD is
      *  fronted on a different host. Null → fall back to the operator's connection host. */
     previewHost?: string | null;
+    /** Working-while-blocked display flags (store map). Header status displays read
+     *  the derived `dStatus`; behavioral reads (resume self-heal, preview confirm
+     *  arm) stay on the raw `session.status`. */
+    workingBlocked?: Record<string, boolean>;
   } = $props();
+
+  // Display-side status for every header/status render below (see display-status.ts).
+  const dStatus = $derived(displayStatus(session, workingBlocked));
 
   let el: HTMLDivElement | undefined = $state();
   // root element + live signed offset (px) for the phone horizontal swipe gesture:
@@ -249,19 +258,17 @@
   // operator (blocked / done) so the tint stays a signal, not noise. The exact
   // status still reaches assistive tech via .vp-status-sr.
   const tintColor = $derived(
-    mobile && (session.status === "blocked" || session.status === "done")
-      ? STATUS_COLOR[session.status]
-      : null,
+    mobile && (dStatus === "blocked" || dStatus === "done") ? STATUS_COLOR[dStatus] : null,
   );
   // The header background uses a per-theme wash token (--wash-blocked / -done)
   // rather than mixing the status colour inline: a 24% red→head srgb blend that
   // reads as a deep alarm bezel on the dark ground muddies into a dusty pink in
   // light, so the light theme retunes the blocked wash in OKLCH (see app.css).
-  const tintWash = $derived(tintColor ? `var(--wash-${session.status})` : null);
+  const tintWash = $derived(tintColor ? `var(--wash-${dStatus})` : null);
   // Non-hue partner to the tint: a leading shape mark so blocked (!) vs done (✓)
   // never rests on colour alone (WCAG 1.4.1) — mirrors the StatusPip glyphs. Same
   // blocked/done-on-phone gate as the tint.
-  const statusGlyph = $derived(!tintColor ? null : session.status === "blocked" ? "!" : "✓");
+  const statusGlyph = $derived(!tintColor ? null : dStatus === "blocked" ? "!" : "✓");
   // Desktop counterpart (.status-mark): one glyph per status, shape-coded so no
   // state pair rests on hue alone — done (✓) and idle/archived (●) both resolve
   // to slate. Word stays in title/aria.
@@ -272,12 +279,12 @@
     idle: "●",
     archived: "●",
   };
-  const statusMark = $derived(STATUS_MARK[session.status]);
+  const statusMark = $derived(STATUS_MARK[dStatus]);
 
   // ...but a busy agent shouldn't read as idle either: running gets a faint,
   // gently-pulsing amber edge (CSS .working) — ambient enough to distinguish
   // "churning" from "idle" at a glance without competing with the alert states.
-  const working = $derived(mobile && session.status === "running");
+  const working = $derived(mobile && dStatus === "running");
 
   // phone: the usage gauge only mounts once the hotter window runs hot (≥70%),
   // i.e. exactly when the remaining token budget starts to matter mid-session
@@ -640,7 +647,8 @@
 
     // Two-step confirm when the agent is actively working: first click arms the
     // button into a confirm state; second click (within 3s) proceeds. Mirrors
-    // the decommission arm and GitRail merge arm patterns.
+    // the decommission arm and GitRail merge arm patterns. Raw status by design
+    // (gates an action, not a render) — see displayStatus for the display flag.
     if (session.status === "running") {
       if (!previewArmed) {
         previewArmed = true;
@@ -904,7 +912,8 @@
   // freezes at a stale "running", and acting on it would rebuild/reattach-loop every
   // fast-fail cycle and defeat the dedicated Reconnect overlay. Also gated on `ended`
   // so a normal idle→running turn never rebuilds a live terminal, and on `!resuming`
-  // so our own resume path doesn't double-bump the epoch.
+  // so our own resume path doesn't double-bump the epoch. Raw status by design:
+  // a working-while-blocked display upgrade must never trigger a terminal rebuild.
   $effect(() => {
     if (ended && endReason === "gone" && !resuming && session.status === "running") {
       ended = false;
@@ -1697,17 +1706,17 @@
       {/if}
       <!-- sighted users read status from the header tint + leading shape glyph;
            keep the word for assistive tech -->
-      <span class="vp-status-sr">{statusLabel(session.status)}</span>
+      <span class="vp-status-sr">{statusLabel(dStatus)}</span>
     {:else}
       <!-- desktop status: a single shape-coded glyph — done (✓) and idle/archived
            (●) share the slate hue, so shape carries the distinction; the status
            word lives in title + aria. -->
       <span
         class="status-mark"
-        style="color:{STATUS_COLOR[session.status]}"
+        style="color:{STATUS_COLOR[dStatus]}"
         role="img"
-        title={statusLabel(session.status)}
-        aria-label={statusLabel(session.status)}>{statusMark}</span
+        title={statusLabel(dStatus)}
+        aria-label={statusLabel(dStatus)}>{statusMark}</span
       >
     {/if}
     {#if !compact}
@@ -1836,7 +1845,7 @@
         name={session.name}
         prompt={session.prompt}
         ready={session.readyToMerge}
-        status={session.status}
+        status={dStatus}
         planPhase={session.planPhase}
         isolated={session.isolated}
         baseBranch={session.baseBranch}

--- a/ui/src/lib/components/herd-keynav.ts
+++ b/ui/src/lib/components/herd-keynav.ts
@@ -30,9 +30,10 @@ export function railOrder(
   isReviewing: (id: string) => boolean = () => false,
   now: number = Date.now(),
   filter: HerdFilter = "all",
+  workingBlocked: Record<string, boolean> = {},
 ): string[] {
   const partition = partitionSessions(
-    shownSessions(sessions, filter, isReviewing),
+    shownSessions(sessions, filter, isReviewing, workingBlocked),
     git,
     isReviewing,
     now,

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "vitest";
-import { partitionSessions } from "./herd-partition";
+import { partitionSessions, shownSessions } from "./herd-partition";
 import type { Session, GitState, SessionStatus } from "$lib/types";
 
 function session(id: string, readyToMerge = false, status: SessionStatus = "running"): Session {
@@ -313,4 +313,19 @@ test("draft + failed CI lands in ciFailed, not draftAwaitingSignoff", () => {
   });
   expect(ciFailed.map((s) => s.id)).toEqual(["d"]);
   expect(draftAwaitingSignoff).toHaveLength(0);
+});
+
+test('"ready" filter drops a working-while-blocked session like a running one', () => {
+  const list = [
+    session("run"), // running → dropped
+    session("wb", false, "blocked"), // blocked but flagged working → dropped
+    session("blk", false, "blocked"), // genuinely blocked → kept
+    session("idl", false, "idle"), // idle → kept
+  ];
+  const shown = shownSessions(list, "ready", () => false, { wb: true });
+  expect(shown.map((s) => s.id)).toEqual(["blk", "idl"]);
+  // without the flag map the blocked session stays listed
+  expect(shownSessions(list, "ready", () => false).map((s) => s.id)).toEqual(["wb", "blk", "idl"]);
+  // "all" ignores the flag entirely
+  expect(shownSessions(list, "all", () => false, { wb: true })).toHaveLength(4);
 });

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -1,4 +1,5 @@
 import type { Session, GitState } from "$lib/types";
+import { displayStatus } from "$lib/display-status";
 import { isMerging } from "./merge-train";
 
 /** Split sessions into stage groups, preserving input order within each:
@@ -56,14 +57,16 @@ export type HerdFilter = "all" | "ready";
 /** The sessions the rail actually lists under `filter` — "ready" keeps only sessions
  *  awaiting the operator (not running, not under review). Single source of truth shared
  *  by Herd.svelte's list and herd-keynav's rail order, so keyboard navigation can never
- *  land on a row the rail isn't showing. */
+ *  land on a row the rail isn't showing. Goes through `displayStatus` (a working-while-
+ *  blocked session is actually mid-turn, so it is NOT awaiting the operator). */
 export function shownSessions(
   sessions: Session[],
   filter: HerdFilter,
   inReview: (id: string) => boolean,
+  workingBlocked: Record<string, boolean> = {},
 ): Session[] {
   return filter === "ready"
-    ? sessions.filter((s) => s.status !== "running" && !inReview(s.id))
+    ? sessions.filter((s) => displayStatus(s, workingBlocked) !== "running" && !inReview(s.id))
     : sessions;
 }
 
@@ -105,6 +108,9 @@ function stageOf(
 ): Stage {
   const terminal = terminalStage(s, g, isReviewing, now);
   if (terminal) return terminal;
+  // Raw status by design: a working-while-blocked session (display "running") is raw
+  // "blocked" — both are excluded from greenIdle, so the display flag can't change
+  // the partition and doesn't need threading through here.
   const greenIdle =
     g?.state === "open" &&
     g.checks === "success" &&

--- a/ui/src/lib/display-status.test.ts
+++ b/ui/src/lib/display-status.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "vitest";
+import { displayStatus } from "./display-status";
+import type { SessionStatus } from "./types";
+
+const s = (id: string, status: SessionStatus) => ({ id, status });
+
+test("blocked + working-blocked flag upgrades to running (full working treatment)", () => {
+  expect(displayStatus(s("s1", "blocked"), { s1: true })).toBe("running");
+});
+
+test("blocked without a flag stays blocked", () => {
+  expect(displayStatus(s("s1", "blocked"), {})).toBe("blocked");
+  expect(displayStatus(s("s1", "blocked"), { other: true })).toBe("blocked");
+});
+
+test("a stale flag on a non-blocked session is inert", () => {
+  for (const status of ["running", "idle", "done", "archived"] as const) {
+    expect(displayStatus(s("s1", status), { s1: true })).toBe(status);
+  }
+});
+
+test("an explicit false flag reads the same as absent", () => {
+  expect(displayStatus(s("s1", "blocked"), { s1: false })).toBe("blocked");
+});

--- a/ui/src/lib/display-status.ts
+++ b/ui/src/lib/display-status.ts
@@ -1,0 +1,16 @@
+import type { Session, SessionStatus } from "./types";
+
+/** Display-side session status — the single source of truth for everything that
+ *  RENDERS a status. A session herdr reports "blocked" but the server flagged as
+ *  working-while-blocked (herdr's status latch after an answered dialog, surfaced
+ *  via `session:working-blocked` / GET /api/working-blocked) renders with the
+ *  FULL working treatment, so it upgrades blocked → running here. The flag only
+ *  ever upgrades blocked — a stale entry on a non-blocked session is inert.
+ *  Display-only: behavioral consumers (API actions, halt/resume gating, drain
+ *  banners, autopilot) must keep reading the raw `session.status`. */
+export function displayStatus(
+  s: Pick<Session, "id" | "status">,
+  workingBlocked: Record<string, boolean>,
+): SessionStatus {
+  return s.status === "blocked" && workingBlocked[s.id] ? "running" : s.status;
+}

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -432,6 +432,32 @@ test("session:archived drops the claude-alive entry for that session", () => {
   expect(s.claudeAlive["s1"]).toBeUndefined();
 });
 
+// ── session:working-blocked ────────────────────────────────────────────────
+
+test("setWorkingBlocked seeds the flag map for bootstrap", () => {
+  const s = new HerdStore();
+  s.setWorkingBlocked({ s1: true });
+  expect(s.workingBlocked["s1"]).toBe(true);
+  expect(s.workingBlocked["s2"]).toBeUndefined();
+});
+
+test("session:working-blocked sets the flag; working=false drops the key", () => {
+  const s = new HerdStore();
+  s.apply({ event: "session:working-blocked", data: { id: "s1", working: true } });
+  expect(s.workingBlocked["s1"]).toBe(true);
+  s.apply({ event: "session:working-blocked", data: { id: "s1", working: false } });
+  // false DROPS the entry (keeps the map small) — absent, not stored-false
+  expect("s1" in s.workingBlocked).toBe(false);
+});
+
+test("session:archived drops the working-blocked entry for that session", () => {
+  const s = new HerdStore();
+  s.setAll([session("s1")]);
+  s.apply({ event: "session:working-blocked", data: { id: "s1", working: true } });
+  s.apply({ event: "session:archived", data: { id: "s1" } });
+  expect(s.workingBlocked["s1"]).toBeUndefined();
+});
+
 // ── session:preview ────────────────────────────────────────────────────────
 
 test("setPreview seeds the preview map for bootstrap", () => {

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -46,6 +46,12 @@ export class HerdStore {
    *  husk shell → the Resume affordance applies; `true` = claude still runs.
    *  Absent = not swept yet (treated as unknown → Resume stays offered). */
   claudeAlive = $state<Record<string, boolean>>({});
+  /** Display-only flag (sessionId → true), pushed by the server's
+   *  `session:working-blocked` event: the server says this herdr-"blocked"
+   *  session is actually mid-turn (herdr latches "blocked" after an answered
+   *  dialog). Used ONLY to derive the display status (see display-status.ts) —
+   *  never behavioral. Entries drop on working=false and on archive. */
+  workingBlocked = $state<Record<string, boolean>>({});
   /** Live per-session preview-listener port (sessionId → port), pushed by the
    *  server's `session:preview` event. A present, non-null value is the single
    *  source of truth for "this agent has a live preview"; absent/null = none. */
@@ -90,6 +96,10 @@ export class HerdStore {
   /** Seed (or replace) the claude-liveness map after a bootstrap GET. */
   setClaudeAlive(map: Record<string, boolean>) {
     this.claudeAlive = map;
+  }
+  /** Seed (or replace) the working-while-blocked flag map after a bootstrap GET. */
+  setWorkingBlocked(map: Record<string, boolean>) {
+    this.workingBlocked = map;
   }
   /** Seed (or replace) the preview-port map after a bootstrap GET. */
   setPreview(map: Record<string, number | null>) {
@@ -166,6 +176,14 @@ export class HerdStore {
     else this.previewServe = { ...this.previewServe, [id]: serve };
   }
 
+  /** Set or clear a session's working-while-blocked display flag. false drops the
+   *  entry (keeps the map small — absent reads the same as false). Extracted from
+   *  apply() to keep that dispatch switch under the complexity gate. */
+  private setWorkingBlockedFlag(id: string, working: boolean) {
+    if (working) this.workingBlocked = { ...this.workingBlocked, [id]: true };
+    else this.workingBlocked = dropKey(this.workingBlocked, id);
+  }
+
   /** Patch a session's name + branch, then surface the rename (esp. the async
    *  namer's auto-rename, which lands while the agent is already working) so the
    *  row changing under the user is explained. Toasts only when the visible name
@@ -226,6 +244,7 @@ export class HerdStore {
         this.git = dropKey(this.git, ev.data.id);
         this.activity = dropKey(this.activity, ev.data.id);
         this.claudeAlive = dropKey(this.claudeAlive, ev.data.id);
+        this.workingBlocked = dropKey(this.workingBlocked, ev.data.id);
         this.preview = dropKey(this.preview, ev.data.id);
         this.previewServe = dropKey(this.previewServe, ev.data.id);
         reviews.drop(ev.data.id);
@@ -240,6 +259,9 @@ export class HerdStore {
         break;
       case "session:claude-alive":
         this.claudeAlive = { ...this.claudeAlive, [ev.data.id]: ev.data.claudeAlive };
+        break;
+      case "session:working-blocked":
+        this.setWorkingBlockedFlag(ev.data.id, ev.data.working);
         break;
       case "session:preview":
         this.setPreviewPort(ev.data.id, ev.data.previewPort);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -497,6 +497,7 @@ export type WsEvent =
   | { event: "session:git"; data: { id: string; git: GitState } }
   | { event: "session:activity"; data: { id: string; activity: SessionActivity } }
   | { event: "session:claude-alive"; data: { id: string; claudeAlive: boolean } }
+  | { event: "session:working-blocked"; data: { id: string; working: boolean } }
   | { event: "session:preview"; data: { id: string; previewPort: number | null } }
   | { event: "session:preview-serve"; data: { id: string; serve: "ok" | "failed" | null } }
   | { event: "update:status"; data: UpdateStatus }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -17,6 +17,7 @@
     gitStates,
     activityStates,
     claudeAliveStates,
+    workingBlockedStates,
     previewStates,
     getBacklog,
     getSettings,
@@ -41,6 +42,7 @@
     Settings as Settings_,
   } from "$lib/types";
   import { sortBlocked } from "$lib/triage";
+  import { displayStatus } from "$lib/display-status";
   import { steers } from "$lib/steers.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { reviews, planGates } from "$lib/reviews.svelte";
@@ -127,10 +129,15 @@
   // repoPath so the drawer scrolls to the matching section; null = opened globally.
   let learningsRepo = $state<string | null>(null);
   // Repos with at least one currently-running agent — the repo-status band lists only
-  // these (matches TopBar's "working" definition). Drives both the band rows and the
-  // filterable scope below.
+  // these (matches TopBar's "working" definition, so it shares the displayStatus
+  // routing: a working-while-blocked agent counts as running). Drives both the band
+  // rows and the filterable scope below.
   const runningRepoPaths = $derived(
-    new Set(store.sessions.filter((s) => s.status === "running").map((s) => s.repoPath)),
+    new Set(
+      store.sessions
+        .filter((s) => displayStatus(s, store.workingBlocked) === "running")
+        .map((s) => s.repoPath),
+    ),
   );
   // Herd repo filter (full repo path), toggled from the repo-status band or from a
   // card's inline repo emoji; null = all repos. Only narrows the herd list views —
@@ -169,7 +176,11 @@
     const byRepo = repoFilter
       ? store.sessions.filter((s) => s.repoPath === repoFilter)
       : store.sessions;
-    return statusFilter ? byRepo.filter((s) => s.status === statusFilter) : byRepo;
+    // displayStatus, not raw status: a working-while-blocked session belongs under
+    // the "running" filter (the tallies count it there), never under "blocked".
+    return statusFilter
+      ? byRepo.filter((s) => displayStatus(s, store.workingBlocked) === statusFilter)
+      : byRepo;
   });
   // basename of the active filter for the herd's empty-state copy; null when unfiltered
   const repoFilterName = $derived(repoFilter ? basename(repoFilter) : null);
@@ -249,6 +260,9 @@
       .catch(() => {});
     claudeAliveStates()
       .then((m) => store.setClaudeAlive(m))
+      .catch(() => {});
+    workingBlockedStates()
+      .then((m) => store.setWorkingBlocked(m))
       .catch(() => {});
     previewStates()
       .then((m) => {
@@ -461,6 +475,7 @@
       // Herd's shown set (one filter at a time) — mirror that here so keynav walks
       // exactly the visible rows, never a "ready" subset of the status-filtered list
       statusFilter != null ? "all" : herdFilter,
+      store.workingBlocked,
     );
   }
 
@@ -606,6 +621,9 @@
     claudeAliveStates()
       .then((m) => store.setClaudeAlive(m))
       .catch(() => {});
+    workingBlockedStates()
+      .then((m) => store.setWorkingBlocked(m))
+      .catch(() => {});
     previewStates()
       .then((m) => {
         store.setPreview(flattenPreview(m));
@@ -741,6 +759,9 @@
   // share the 'halt-done' key so each supersedes the last in place (interim →
   // Halted N on success, or interim → Retry on failure) rather than stacking.
   function haltHerd() {
+    // Raw status by design (NOT displayStatus): the server's haltAll only reaches
+    // agents herdr itself reports working — a working-while-blocked session is
+    // latched "blocked" there, so counting it would overstate the e-stop's reach.
     const count = store.sessions.filter((s) => s.status === "running").length;
     if (count === 0) return; // nothing to halt; the control is hidden in this state anyway
     toasts.info(m.halt_confirm({ count }), { key: "halt-done" });
@@ -888,6 +909,7 @@
         onwhatsnew={() => (showWhatsNew = true)}
         {statusFilter}
         onstatusfilter={(s) => (statusFilter = s)}
+        workingBlocked={store.workingBlocked}
       />
       <QueueStrip
         rows={bandRows}
@@ -929,6 +951,7 @@
             onsettings={() => (showSettings = true)}
             flow={true}
             bind:filter={herdFilter}
+            workingBlocked={store.workingBlocked}
           />
           {#if store.sessions.length === 0}
             <BacklogView
@@ -968,6 +991,7 @@
             switchOrder={store.sessions.map((s) => s.id)}
             onnavigate={(id) => selectUnit(id)}
             {onarchive}
+            workingBlocked={store.workingBlocked}
             onback={() => (mobileScreen = "list")}
             nextNeedsYou={otherNeedsYou.length}
             onnextneedsyou={jumpNextNeedsYou}
@@ -991,6 +1015,7 @@
           onnew={() => (showNew = true)}
           {standardCommandUnset}
           onsettings={() => (showSettings = true)}
+          workingBlocked={store.workingBlocked}
         />
       </div>
     {:else}
@@ -1016,6 +1041,7 @@
           {standardCommandUnset}
           onsettings={() => (showSettings = true)}
           bind:filter={herdFilter}
+          workingBlocked={store.workingBlocked}
         />
         {#if store.sessions.length === 0}
           <BacklogView
@@ -1044,6 +1070,7 @@
             switchOrder={store.sessions.map((s) => s.id)}
             onnavigate={(id) => selectUnit(id)}
             {onarchive}
+            workingBlocked={store.workingBlocked}
             onbroadcast={() => (showBroadcast = true)}
           />
         {:else}
@@ -1119,9 +1146,12 @@
 {/if}
 
 {#if showHerdrUpdate && store.herdrUpdate && (store.herdrUpdate.updateAvailable || herdrUpdating)}
+  <!-- displayStatus: the warning counts agents the herdr restart interrupts — a
+       working-while-blocked agent is genuinely mid-turn, so it counts as working -->
   <HerdrUpdateModal
     update={store.herdrUpdate}
-    sessions={store.sessions.filter((s) => s.status === "running").length}
+    sessions={store.sessions.filter((s) => displayStatus(s, store.workingBlocked) === "running")
+      .length}
     log={store.herdrUpdateLog}
     done={store.herdrUpdateDone}
     onconfirm={() => {


### PR DESCRIPTION
## Problem

The "needs you" badge (+ push notification + red blocked row/tally) fired for sessions whose agent was demonstrably mid-turn implementing. Empirical analysis of the live `signals` table (every block emission captures its fire-time terminal tail): **36% of all `awaiting-input` block emissions (104/288) showed an actively-working spinner at fire time** — e.g. `✶ Adding i18n + final review… (1h 29m 49s · ↑ 265.4k tokens)` — across 39 sessions in one month. 80 of the 104 directly followed `● User answered Claude's questions:`.

**Root cause (upstream, out of scope here): herdr latches `agent_status=blocked`** after a permission/elicitation dialog and does not return to `working` when the dialog is answered mid-turn. Shepherd re-read the buffer ~3s later, found the dialog gone, and classified the *working* TUI as the no-evidence `awaiting-input` fallback. The latch should eventually be fixed in herdr; this PR is shepherd's defense.

## Fix

**Server — suppression guard** (`src/blocked.ts`, `src/poller.ts`): when herdr says blocked but the visible tail shows a glyph-anchored active-turn spinner line (`^\s*[·✢✳✶✻✽*+⎿]` … `…(<elapsed>` or `esc to interrupt`), `maybeClassify` suppresses the `awaiting-input` fallback and clears any previously-announced block once per episode. Scoped strictly: **menu/y-n shapes always emit**, spinner or not. Reclassify cadence preserved (no extra reads).

**Server — display flag** (`session:working-blocked` event + `GET /api/working-blocked` bootstrap): `session.status` is **never synthesized** — drain, autopilot, automerge, draft-reconcile and the PR poller keep herdr's raw status (a synthesized blocked→running would disable drain's spawn-halt and could spuriously un-pause autopilot / reset its step budget). Suppression travels as a separate display-only flag.

**UI — full working treatment** (`displayStatus()` helper as single source of truth): every status-driven *display* read — UnitRow `live`/stepper/caret/badge, UnitTile, StatusPip callers, TopBar tallies + status filter, Viewport tint/glyph/pulse/SR text — routes through `displayStatus`, so a flagged session renders identically to a raw-running one (no half-state). Behavioral reads stay raw, each with a "raw by design" comment: `canResume` (`format.ts`), TopBar `haltable` + herd halt count, Viewport preview confirm-arm and resume self-heal.

## Operator-visible divergence (intentional)

A suppressed session shows **running** in tally/filter/row while drain's spawn-halt and the TopBar halt e-stop still treat it as **blocked** (raw status) — auto-spawns stay halted, and the halt-menu count can read lower than the working tally. A TopBar browser test pins exactly this split.

## Known accepted items

- **Autopilot in-flight `consider()` race** (a block-clear landing during a classify spawn isn't cancelled): pre-existing, unchanged — and false `awaiting-input` considers (LLM spawns against *working* agents, today's behavior) are eliminated by the guard.
- `*`/`+` in the anchor glyph set are also plausible markdown-bullet leaders; accepted because they are genuine spinner frames, suppression is scoped to the fallback shape + display-only flag, and the replay below shows zero such matches in practice.
- Spinner-format drift degrades silently back to *today's* behavior (never worse) and stays observable via the `signals` capture.

## Replay validation (hard merge gate — passed)

Re-run at merge time against the live DB (889 block signals): **103/297 `awaiting-input` tails suppressed** (covers 103 of the 104 known working-TUI false positives, ≥96%); 2 menu tails contain spinner-like text but are **shape-scoped → never suppressed**; the explicit matched-line listing contains **zero non-spinner lines**:

<details><summary>Every distinct matched line (normalized, 108 forms — all genuine spinner / tool-run lines)</summary>

```
⎿  Running… (Ns)
* Adding iNn + final review… (Nh Nm Ns · ↓ N.Nk tokens · thinking)
· Churning… (Nm Ns · ↓ N.Nk tokens · thought for Ns)
✻ Brewing… (Nm Ns · ↓ N.Nk tokens · thinking)
✽ Brewing… (Nm Ns · ↓ N.Nk tokens · thinking more)
· Beboppin'… (Nm Ns · ↓ N.Nk tokens · thinking)
· Cultivating… (Nm Ns · thinking some more)
✻ Nebulizing… (Nm Ns · ↓ N.Nk tokens · still thinking)
✢ Adding iNn + final review… (Nh Nm Ns · ↓ N.Nk tokens)
✶ Quantumizing… (Ns · ↑ N.Nk tokens)
✶ Bunning… (Nm Ns · ↑ N.Nk tokens)
… (+97 further forms of the same two shapes: `<glyph> <Verb>… (Nh Nm Ns · ↑/↓ N.Nk tokens · thinking…)`)
```
</details>

## Tests

Root 1757 pass (poller: suppression once-per-episode, same-tick re-arm ordering `working:false`→block, sync cleanup on herdr-flip/reap/prune, raw-only status transitions, menu+spinner still emits, `/api/working-blocked` route). UI 839 pass (displayStatus unit, store apply/bootstrap/archive, UnitRow flagged-blocked ≡ raw-running affordances, TopBar tally/halt split). `check:i18n` parity (no new strings). Rebased onto current main (#493/#497/#498 conflicts resolved; dStatus routing re-applied into the slimmed Viewport header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
