### PR TITLE
feat(herd): full-bleed session list on mobile

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -82,6 +82,10 @@
   --mobile-actionbar-h: calc(
     var(--mobile-actionbar-hit) + var(--mobile-actionbar-pad) + 2 * var(--actionbar-border)
   );
+  /* Mobile shell's base edge padding — single source shared by .shell.mobile
+     (+page.svelte) and the full-bleed herd panel's negative margin
+     (Herd.svelte), so the two can't drift apart. */
+  --mobile-shell-pad: 10px;
 
   --status-running: var(--color-amber);
   /* done = WAITING (finished turn, parked for the operator's next steer). It is

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -128,7 +128,7 @@
   const mergerWho = $derived(uniqueWho(partition.waitingOnMerger));
 </script>
 
-<div class="panel bracket">
+<div class="panel bracket" class:flow>
   <div class="phead">
     <span class="micro">{m.herd_title()}</span>
     <div class="right filters">
@@ -466,6 +466,20 @@
     border-top: 0;
   }
 
+  /* flow mode (mobile list): full-bleed panel — the side borders + corner
+     brackets cost two vertical lines plus gutters on a narrow phone, so drop
+     them and stretch into the shell's 10px horizontal padding (margin matches
+     .shell.mobile in +page.svelte; with a larger safe-area inset the shell
+     keeps the remainder). Top/bottom hairlines stay as section rules. */
+  .panel.flow {
+    border-inline: 0;
+    margin-inline: -10px;
+  }
+  .panel.flow.bracket::before,
+  .panel.flow.bracket::after {
+    display: none;
+  }
+
   .phead {
     display: flex;
     align-items: center;
@@ -610,11 +624,14 @@
     container: herd / inline-size;
   }
 
-  /* flow mode: render at natural height for parent-page scrolling (mobile list) */
+  /* flow mode: render at natural height for parent-page scrolling (mobile list);
+     no horizontal gutter — the full-bleed panel has no side borders to clear,
+     and the rows' own padding keeps text off the screen edge */
   .units.flow {
     overflow: visible;
     flex: none;
     min-height: auto;
+    padding-inline: 0;
   }
 
   .empty {

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -468,12 +468,13 @@
 
   /* flow mode (mobile list): full-bleed panel — the side borders + corner
      brackets cost two vertical lines plus gutters on a narrow phone, so drop
-     them and stretch into the shell's 10px horizontal padding (margin matches
-     .shell.mobile in +page.svelte; with a larger safe-area inset the shell
-     keeps the remainder). Top/bottom hairlines stay as section rules. */
+     them and stretch into the shell's base edge padding (--mobile-shell-pad,
+     shared with .shell.mobile in +page.svelte; with a larger safe-area inset
+     the shell keeps the remainder). Top/bottom hairlines stay as section
+     rules. */
   .panel.flow {
     border-inline: 0;
-    margin-inline: -10px;
+    margin-inline: calc(-1 * var(--mobile-shell-pad));
   }
   .panel.flow.bracket::before,
   .panel.flow.bracket::after {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1330,8 +1330,10 @@
   }
 
   .shell.mobile {
-    padding: max(10px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right))
-      max(10px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
+    padding: max(var(--mobile-shell-pad), env(safe-area-inset-top))
+      max(var(--mobile-shell-pad), env(safe-area-inset-right))
+      max(var(--mobile-shell-pad), env(safe-area-inset-bottom))
+      max(var(--mobile-shell-pad), env(safe-area-inset-left));
     gap: 10px;
   }
 
@@ -1367,9 +1369,9 @@
     background: var(--color-bg);
     /* own the top safe-area inset (mirrors the ActionBar's padding-bottom): keeps
        the TopBar clear of the notch / Dynamic Island while the chrome is stuck at
-       top:0, with the opaque background filling the inset area. max(10px, …) keeps
-       the prior 10px breathing room on non-notched devices. */
-    padding-top: max(10px, env(safe-area-inset-top));
+       top:0, with the opaque background filling the inset area. max(…) keeps
+       the prior --mobile-shell-pad breathing room on non-notched devices. */
+    padding-top: max(var(--mobile-shell-pad), env(safe-area-inset-top));
   }
   .shell.mobile.list .main-region,
   .shell.mobile.list .col {


### PR DESCRIPTION
## Summary

On the mobile (PWA) list view, the session cards were wrapped in the panel's "hug" — 1px side borders + corner brackets, plus the shell's 10px and the list's 6px horizontal gutters. On a phone that costs ~21px of width per side that could be card text instead.

This makes the herd panel **full-bleed in flow mode** (the mobile list):

- drop the panel's inline borders and the corner brackets (`.panel.flow`)
- zero the `.units` inline padding
- stretch the panel into the shell's 10px horizontal padding via `margin-inline: -10px` (with a larger safe-area inset the shell keeps the remainder, so nothing slides under a notch in landscape)
- top/bottom hairlines stay as section rules; the desktop sidebar (`flow=false`) is untouched

### Before / after

Card text now starts ~14px from the screen edge instead of ~31px — roughly **34px more width** for titles and prompt excerpts.

`[no-feature-entry]` — pure layout/space optimization, no new user-facing capability to announce.

## Verification

- `cd ui && bun run check` — 0 errors, 0 warnings
- Playwright screenshot at iPhone viewport (390×844): cards span edge to edge, section rules run full width, no stray brackets