### PR TITLE
fix(topbar): idle gear opens settings directly instead of a one-item menu

### DIFF
--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -617,3 +617,49 @@ describe("TopBar — working-while-blocked counts in the working tally, not bloc
       .toBeInTheDocument();
   });
 });
+
+describe("TopBar — idle gear opens Settings directly", () => {
+  it("desktop: an idle herd's gear opens Settings without a menu", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const onsettings = vi.fn();
+    const list = [
+      { id: "b1", status: "blocked" },
+      { id: "d1", status: "done" },
+    ] as unknown as Session[];
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: list,
+      onsettings,
+    });
+    // idle → the gear's accessible name is the settings label, not the menu label
+    await page.getByRole("button", { name: m.topbar_settings_aria() }).click();
+    expect(onsettings).toHaveBeenCalledTimes(1);
+    // no menu opened: neither the dropdown Settings row nor any menuitem exists
+    await expect
+      .element(page.getByRole("menuitem", { name: m.settings_title() }))
+      .not.toBeInTheDocument();
+  });
+
+  it("desktop: a running herd's gear still opens the menu, only the row calls onsettings", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const onsettings = vi.fn();
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: sessions(1),
+      onsettings,
+    });
+    // running → gear is a menu button; clicking it opens the menu, not Settings
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    expect(onsettings).not.toHaveBeenCalled();
+    const settingsRow = page.getByRole("menuitem", { name: m.settings_title() });
+    await expect.element(settingsRow).toBeInTheDocument();
+    await settingsRow.click();
+    expect(onsettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -662,4 +662,30 @@ describe("TopBar — idle gear opens Settings directly", () => {
     await settingsRow.click();
     expect(onsettings).toHaveBeenCalledTimes(1);
   });
+
+  it("desktop: the open menu dismisses itself when the herd goes quiet underneath it", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const { rerender } = render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: sessions(1),
+    });
+    // running → open the menu
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    await expect
+      .element(page.getByRole("menuitem", { name: m.settings_title() }))
+      .toBeInTheDocument();
+    // agents finish → no haltable session left; the stale menu must close itself
+    await rerender({
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: sessions(0),
+    });
+    await expect
+      .element(page.getByRole("menuitem", { name: m.settings_title() }))
+      .not.toBeInTheDocument();
+  });
 });

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -283,10 +283,15 @@
       e.key === "ArrowDown" ? (here + 1) % items.length : (here - 1 + items.length) % items.length;
     items[next]?.focus();
   }
-  // Drop the armed state if the herd goes quiet underneath it (agents finished), so a
-  // later run doesn't surface a pre-armed row.
+  // If the herd goes quiet underneath the gear (agents finished), dismiss the menu and
+  // drop any armed state. Otherwise the e-stop row vanishes from the open menu, leaving a
+  // stale lone-Settings popup — and since an idle gear opens Settings directly, the next
+  // click would surface Settings without first dismissing it. When the menu wasn't open we
+  // still disarm, so a later run never surfaces a pre-armed row.
   $effect(() => {
-    if (haltable === 0) disarmHalt();
+    if (haltable !== 0) return;
+    if (menuOpen) closeMenu(true);
+    else disarmHalt();
   });
   // Destroy-only cleanup (no tracked reads → runs once): never leak the disarm timer.
   $effect(() => () => clearTimeout(armTimer));

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -211,10 +211,10 @@
     if (!touch || !hotter) popoverOpen = false;
   });
 
-  // The gear is a menu button: one click opens a small popup with the e-stop (when
-  // something is working) above a "Settings…" row. The menu always opens — when the
-  // herd is idle it just holds the lone Settings row — so the gear's behaviour stays
-  // predictable regardless of state.
+  // The gear adapts to herd state. When the herd is idle (haltable === 0) a click
+  // opens the Settings pane directly — matching the gear's "Settings" tooltip/aria.
+  // Only when something is haltable does it become a menu button: one click opens a
+  // small popup with the e-stop row above a "Settings…" row.
   let menuOpen = $state(false);
   let gearBtn = $state<HTMLButtonElement | null>(null);
   let gearWrap = $state<HTMLElement | null>(null);
@@ -238,6 +238,14 @@
   function toggleMenu() {
     if (menuOpen) closeMenu();
     else menuOpen = true;
+  }
+  // Gear click: idle herd → open Settings directly; something haltable → open the menu.
+  function clickGear() {
+    if (haltable === 0) {
+      onsettings?.();
+      return;
+    }
+    toggleMenu();
   }
   function clickHalt() {
     if (!armed) {
@@ -559,21 +567,22 @@
         >
       {/if}
     {/if}
-    <!-- The gear is now a menu button: it opens the e-stop (when something is
-         working) plus the Settings entry. A pip on the gear is the only at-rest
-         cue that there's a herd to halt: amber while agents simply work (matches the
-         working colour), escalating to red only when something is blocked — so red
-         keeps meaning "needs you", consistent with the rest of the bar. The blue
-         herdr-update dot (mobile) shifts to the opposite corner when both want the gear. -->
+    <!-- The gear adapts to state: idle herd → a click opens Settings directly;
+         when something is haltable it becomes a menu button opening the e-stop above
+         the Settings entry. A pip on the gear is the only at-rest cue that there's a
+         herd to halt: amber while agents simply work (matches the working colour),
+         escalating to red only when something is blocked — so red keeps meaning
+         "needs you", consistent with the rest of the bar. The blue herdr-update dot
+         (mobile) shifts to the opposite corner when both want the gear. -->
     <div class="gear-wrap" bind:this={gearWrap}>
       <button
         bind:this={gearBtn}
         class="gear tip"
         type="button"
-        onclick={toggleMenu}
+        onclick={clickGear}
         data-tip={haltable > 0 ? m.topbar_menu_aria() : m.settings_title()}
-        aria-haspopup="menu"
-        aria-expanded={menuOpen}
+        aria-haspopup={haltable > 0 ? "menu" : undefined}
+        aria-expanded={haltable > 0 ? menuOpen : undefined}
         aria-label={haltable > 0 ? m.topbar_menu_aria() : m.topbar_settings_aria()}
         >⚙{#if haltable > 0}<span class="halt-pip" class:alert={blocked > 0} aria-hidden="true"
           ></span>{/if}{#if herdrUpdateAvailable && mobile}<span


### PR DESCRIPTION
## What

When the herd is **idle** (nothing running to halt), clicking the settings gear now opens the Settings pane **directly** instead of popping a dropdown whose only entry is "Settings". When agents are running, the gear keeps its existing menu-button behavior (e-stop arm→confirm row above Settings).

## Why

The gear already *labeled itself* as a Settings button when idle — its tooltip (`data-tip`), screen-reader name (`aria-label`), all branch on `haltable === 0` and say "Settings". Only the click handler never matched: it always opened a one-item menu. This aligns the behavior to the labels the UI already advertises.

`haltable` (count of sessions with `status === "running"`) is the existing single source of truth for "is there a herd to stop" — already gating the e-stop row, the halt pip, and the gear's idle labels. No new condition introduced.

## Changes

- New `clickGear()` handler: `haltable === 0` → `onsettings?.()` directly; else existing `toggleMenu()`. The e-stop / in-menu Settings paths are untouched.
- `aria-haspopup` / `aria-expanded` made conditional — the idle gear is a plain action button and no longer advertises a popup it doesn't have.
- Rewrote two now-stale comments that claimed "the menu always opens".
- Added two `TopBar.browser.test.ts` tests: idle gear opens Settings directly with **no** menu; running gear still opens the menu and only fires `onsettings` from the in-menu Settings row.

## Not a feature

Behavior is being aligned to labels that already promise it — no new user-facing capability, so labeled `fix` and no `feature-announcements.ts` entry. No i18n keys added (reuses existing `settings_title` / `topbar_settings_aria` / `topbar_menu_aria`).

## Verification

- `cd ui && bun run check` — 0 errors, 0 warnings
- `cd ui && bun run test` — full vitest suite green (904 tests); TopBar suite 26/26
- `cd ui && bun run check:i18n` — locales in parity, no key changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)