### PR TITLE
feat(spawn): disable claude.ai connector MCP servers in agent spawns

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -92,11 +92,21 @@ export function installedPluginIds(read?: (path: string) => Promise<string>): Pr
 }
 
 /**
- * Per-spawn `--settings` overlay merged on top of the user's settings files.
- * Pins `remoteControlAtStartup` so a global opt-in in ~/.claude/settings.json
- * doesn't auto-start Claude Code's Remote Control for every Shepherd session
- * (default false suppresses the notification noise); `/remote-control` in the
- * terminal still toggles it per-session.
+ * Per-spawn `--settings` overlay merged on top of the user's settings files. Applied to every
+ * Shepherd task spawn — both `create` (`buildSpawnArgv`) and `resume`.
+ *
+ * Pins `remoteControlAtStartup` so a global opt-in in ~/.claude/settings.json doesn't auto-start
+ * Claude Code's Remote Control for every Shepherd session (default false suppresses the
+ * notification noise); `/remote-control` in the terminal still toggles it per-session.
+ *
+ * Pins `env.ENABLE_CLAUDEAI_MCP_SERVERS = "false"` to disable the claude.ai account-connector MCP
+ * servers (Gmail / Google Calendar / Google Drive / Notion / Microsoft 365) for every spawned
+ * coding agent (issue #509). Least-privilege hygiene, NOT a token win — the #499 spike measured
+ * the saving at only −132 tok/turn (connectors load as deferred, name-only tools) — but an
+ * autonomous coding agent has no business reaching the operator's personal Gmail/Notion.
+ * Unconditional and not opt-out'able by design; the overlay `env` merges key-by-key over the
+ * user's settings so the rest of their env is untouched. (Reviewer/critic/plan-gate spawns don't
+ * use this overlay — they run `--safe-mode`, which already disables ALL MCP.)
  *
  * `disablePlugins` (trimmed auto spawns only) adds `enabledPlugins: {<id>: false, ...}`,
  * which overrides the global `true` per-spawn and kills plugin SessionStart hooks, plugin
@@ -106,6 +116,7 @@ export function installedPluginIds(read?: (path: string) => Promise<string>): Pr
 export function spawnSettingsOverlay(opts: { disablePlugins?: string[] } = {}): string {
   const settings: Record<string, unknown> = {
     remoteControlAtStartup: config.remoteControlAtStartup,
+    env: { ENABLE_CLAUDEAI_MCP_SERVERS: "false" },
   };
   if (opts.disablePlugins && opts.disablePlugins.length > 0) {
     settings.enabledPlugins = Object.fromEntries(opts.disablePlugins.map((id) => [id, false]));

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -260,13 +260,20 @@ test("syncWorktreeBranch returns null on a detached HEAD (currentBranch null)", 
   expect(store.get(s.id)?.branch).toBe("shepherd/x");
 });
 
-test("spawnSettingsOverlay pins remoteControlAtStartup from config (default off)", () => {
+test("spawnSettingsOverlay pins remoteControlAtStartup + disables claude.ai connector MCP", () => {
   const prev = config.remoteControlAtStartup;
+  const connectorEnv = { ENABLE_CLAUDEAI_MCP_SERVERS: "false" };
   try {
     config.remoteControlAtStartup = false;
-    expect(JSON.parse(spawnSettingsOverlay())).toEqual({ remoteControlAtStartup: false });
+    expect(JSON.parse(spawnSettingsOverlay())).toEqual({
+      remoteControlAtStartup: false,
+      env: connectorEnv,
+    });
     config.remoteControlAtStartup = true;
-    expect(JSON.parse(spawnSettingsOverlay())).toEqual({ remoteControlAtStartup: true });
+    expect(JSON.parse(spawnSettingsOverlay())).toEqual({
+      remoteControlAtStartup: true,
+      env: connectorEnv,
+    });
   } finally {
     config.remoteControlAtStartup = prev;
   }


### PR DESCRIPTION
Closes #509.

## What

Adds one field — `env: { ENABLE_CLAUDEAI_MCP_SERVERS: "false" }` — to the shared `spawnSettingsOverlay()` so the claude.ai **account-connector MCP servers** (Gmail / Google Calendar / Google Drive / Notion / Microsoft 365) no longer load into Shepherd-spawned coding agents.

## Why

Least-privilege **hygiene**, not tokens. The #499 Phase-0 spike confirmed the mechanism works but measured the token saving at only **−132 tok/turn** (connectors load as *deferred*, name-only tools — full schemas never enter the prefix), below the trim PR's ≥1.5K gate, so it was split out into #509. The reason to ship is least-privilege: an autonomous coding agent has no business reaching the operator's personal Gmail/Notion.

## Scope decisions (with operator)

- **All task spawns**, not just auto/drain — the least-privilege argument applies equally to manual interactive coding sessions, and the unconditional form is strictly simpler (one field, no gating). `spawnSettingsOverlay()` is the single overlay used by both `create` (`buildSpawnArgv`) and `resume`, so one edit covers every task spawn.
- **No opt-out.** Hard-wired off; the overlay `env` merges key-by-key over the user's settings so the rest of their env is untouched.
- Reviewer / critic / plan-gate spawns are unaffected — they run `--safe-mode`, which already disables ALL MCP.

Composes cleanly with the trim path (#499/#510) that landed on main mid-development: orthogonal fields of the same settings object (`env` vs `enabledPlugins`).

## Tests

- Updated `spawnSettingsOverlay` shape test to assert the connector `env` is present alongside `remoteControlAtStartup`.
- Root `bun run lint`, `bunx tsc --noEmit`, and `bun test ./test` (1780 pass) all green.

Server-only plumbing, no user-facing UI surface — no `feature-announcements.ts` entry or i18n keys needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)