### PR TITLE
feat(critic): bound per-streak review spawns + prove patch-id rebase-skip (#501)

### DIFF
--- a/src/review.ts
+++ b/src/review.ts
@@ -228,11 +228,24 @@ export class ReviewService {
     if (this.inflight.has(session.id) || this.starting.has(session.id)) return; // in flight / mid-spawn
     const prior = this.deps.store.getReview(session.id);
     if (prior?.headSha === git.headSha) return; // head already reviewed
-    // Hard per-streak spawn ceiling: review token spend is unbounded otherwise (consider()
-    // would spawn a critic on every new CI-green head forever). Cap finalized reviews per
+    // Per-streak spawn ceiling: review token spend is unbounded otherwise (consider() would
+    // spawn a critic on every new CI-green head forever). Cap *findings-bearing* reviews per
     // outstanding-findings streak at 2*cap (the live cap, derived inline — a persisted
     // spawnCap field would be dead weight nothing reads). Bail BEFORE allocating the probe
     // worktree so even that is saved.
+    //
+    // STRICT for findings reviews, APPROXIMATE for total spawns. streakReviews increments
+    // only on a findings verdict and an error/timeout verdict preserves it while carrying
+    // findings=[] (it earns no progress) — so an error verdict can never itself reach the
+    // ceiling (reaching it needs a findings verdict, which then blocks the next spawn), and
+    // it never trips this gate's findings>0 leg. Net: findings-bearing reviews are hard-capped
+    // at 2*cap, but a critic flapping on *timeouts* keeps re-spawning on each new head. That
+    // error churn is deliberately governed by the separate errorRound escalation in finalize()
+    // (a stall signal at the cap), NOT this ceiling: a transient timeout must neither be
+    // charged against the findings budget nor permanently halt review. So total critic spawns
+    // can exceed 2*cap while errors interleave — bounded by errorRound + the human it escalates
+    // to, not by this gate.
+    //
     // RE-ENGAGEMENT CLIFF: a PR paused one round short of clean stays paused. The only
     // resume paths are a clean verdict that lands while still under budget (won't happen
     // once paused — we don't re-spawn) or a human archiving the session (forget() →

--- a/src/review.ts
+++ b/src/review.ts
@@ -101,6 +101,27 @@ interface InFlight {
   finalizing?: boolean;
 }
 
+/** The prior verdict's streak-accountability state, carried into a fresh run's InFlight (no
+ *  prior → fresh defaults). Extracted from begin() so its per-field `??` defaults don't inflate
+ *  that method's branch count past the complexity budget. */
+type PriorStreakState = Pick<
+  InFlight,
+  | "priorRound"
+  | "priorErrorRound"
+  | "priorStreakReviews"
+  | "priorReviewedPatchIds"
+  | "priorSeenNoteIds"
+>;
+function priorStreakState(prior: ReviewVerdict | null): PriorStreakState {
+  return {
+    priorRound: prior?.addressRound ?? 0,
+    priorErrorRound: prior?.errorRound ?? 0,
+    priorStreakReviews: prior?.streakReviews ?? 0,
+    priorReviewedPatchIds: prior?.reviewedPatchIds ?? [],
+    priorSeenNoteIds: prior?.seenNoteIds ?? [],
+  };
+}
+
 export interface ReviewServiceDeps {
   store: Pick<
     SessionStore,
@@ -293,11 +314,7 @@ export class ReviewService {
       terminalId,
       criticSessionId,
       startedAt: this.now(),
-      priorRound: prior?.addressRound ?? 0,
-      priorErrorRound: prior?.errorRound ?? 0,
-      priorStreakReviews: prior?.streakReviews ?? 0,
-      priorReviewedPatchIds: prior?.reviewedPatchIds ?? [],
-      priorSeenNoteIds: prior?.seenNoteIds ?? [],
+      ...priorStreakState(prior),
       seenNoteIds,
     });
     // Persist the spawn row now (totals NULL until finalize) so review burn is attributable

--- a/src/review.ts
+++ b/src/review.ts
@@ -94,6 +94,8 @@ interface InFlight {
   startedAt: number;
   priorRound: number; // auto-address steers already spent on this findings streak
   priorErrorRound: number; // consecutive critic error/timeout verdicts before this run
+  priorStreakReviews: number; // critic reviews finalized on this streak before this run (bounds spawns at 2*cap)
+  priorReviewedPatchIds: string[]; // patch-ids reviewed on this streak before this run (churn/revert dedup set)
   priorSeenNoteIds: string[]; // seen-note set carried in (before this run's fetch)
   seenNoteIds: string[]; // priorSeen + notes fed to THIS run's critic; only "consumed" on a real verdict
   finalizing?: boolean;
@@ -203,7 +205,19 @@ export class ReviewService {
     if (!session.branch) return;
     if (!this.deps.store.getRepoConfig(session.repoPath).criticEnabled) return;
     if (this.inflight.has(session.id) || this.starting.has(session.id)) return; // in flight / mid-spawn
-    if (this.deps.store.getReview(session.id)?.headSha === git.headSha) return; // head already reviewed
+    const prior = this.deps.store.getReview(session.id);
+    if (prior?.headSha === git.headSha) return; // head already reviewed
+    // Hard per-streak spawn ceiling: review token spend is unbounded otherwise (consider()
+    // would spawn a critic on every new CI-green head forever). Cap finalized reviews per
+    // outstanding-findings streak at 2*cap (the live cap, derived inline — a persisted
+    // spawnCap field would be dead weight nothing reads). Bail BEFORE allocating the probe
+    // worktree so even that is saved.
+    // RE-ENGAGEMENT CLIFF: a PR paused one round short of clean stays paused. The only
+    // resume paths are a clean verdict that lands while still under budget (won't happen
+    // once paused — we don't re-spawn) or a human archiving the session (forget() →
+    // dropReview clears the row, resetting the streak). There is deliberately no in-PR
+    // "re-request review" action; crossing the ceiling means the critic gives up here.
+    if (prior && prior.findings.length > 0 && prior.streakReviews >= 2 * this.cap) return;
     // Claim the slot synchronously, BEFORE begin()'s await, so a concurrent consider bails.
     this.starting.add(session.id);
     try {
@@ -281,6 +295,8 @@ export class ReviewService {
       startedAt: this.now(),
       priorRound: prior?.addressRound ?? 0,
       priorErrorRound: prior?.errorRound ?? 0,
+      priorStreakReviews: prior?.streakReviews ?? 0,
+      priorReviewedPatchIds: prior?.reviewedPatchIds ?? [],
       priorSeenNoteIds: prior?.seenNoteIds ?? [],
       seenNoteIds,
     });
@@ -301,11 +317,20 @@ export class ReviewService {
    * Rebase-skip: dedup on WHAT the critic reviews (the branch diff `base...HEAD`), not on
    * the head SHA. A rebase/force-push moves the SHA but leaves the branch's own diff
    * identical, so its patch-id is stable (patch-id ignores line numbers — robust to the new
-   * base shifting hunks). Identical fingerprint → the prior verdict still holds: re-point it
-   * at the new head (so consider()'s SHA guard short-circuits next poll), reap the probe
+   * base shifting hunks). Skip when the incoming fingerprint is a member of the streak's
+   * reviewed-patch-id SET — the prior verdict's own patchId OR any earlier id in
+   * `reviewedPatchIds` (churn/revert: a diff bounced back to a state already reviewed this
+   * streak must not be re-reviewed). On a match the prior verdict still holds: re-point it at
+   * the new head (so consider()'s SHA guard short-circuits next poll), reap the probe
    * worktree, and skip the run — deliberately preserving findings/decision/rounds (those
    * still apply, and we must not double-post). Empty/failed fingerprint ('' or null) → never
    * skip; review. Returns the fingerprint (persisted on the verdict) + whether we skipped.
+   *
+   * Keep the `prior.patchId === patchId` OR-branch alongside set-membership: a clean verdict
+   * resets `reviewedPatchIds` to [] (but keeps its patchId), and every migrated DB row
+   * backfills the set to '[]' — set-membership alone would lose the rebase-skip for both on a
+   * same-diff force-push. The clean-reset also means a diff that was clean then reverted to an
+   * earlier buggy state IS reviewed again (its id is no longer in the now-empty set).
    *
    * Never skip past an `error` verdict: a timeout/unparseable run produced no real verdict,
    * so its decision is a transient failure to RETRY, not a result to preserve — inheriting it
@@ -320,7 +345,11 @@ export class ReviewService {
     worktreePath: string,
   ): Promise<{ patchId: string; skipped: boolean }> {
     const patchId = (await this.computePatchId(worktreePath, session.baseBranch)) ?? "";
-    if (patchId && prior?.patchId && prior.decision !== "error" && prior.patchId === patchId) {
+    if (
+      patchId &&
+      prior?.decision !== "error" &&
+      (prior?.patchId === patchId || (prior?.reviewedPatchIds ?? []).includes(patchId))
+    ) {
       this.deps.store.bumpReviewHead(session.id, git.headSha!, this.now());
       this.deps.worktree.remove(worktreePath);
       return { patchId, skipped: true };
@@ -438,6 +467,13 @@ export class ReviewService {
         // just un-reverified this push).
         verdict.errorRound = f.priorErrorRound + 1;
         verdict.addressRound = f.priorRound;
+        // Error verdicts deliberately do NOT increment streakReviews: error-spawn token cost
+        // is bounded by the separate errorRound counter + its own cap escalation, not by the
+        // spawn ceiling. Preserve the streak's review count + reviewed-patch-id set so the
+        // ceiling math and churn dedup stay correct across a transient failure (and the errored
+        // patch-id is NOT added — mirrors patchId:"" so the same diff re-reviews).
+        verdict.streakReviews = f.priorStreakReviews;
+        verdict.reviewedPatchIds = f.priorReviewedPatchIds;
         // The critic never produced a verdict, so it didn't actually consider this run's
         // freshly-fetched notes — roll the seen set back so they re-inject next round
         // instead of being silently swallowed by an error pass.
@@ -454,6 +490,31 @@ export class ReviewService {
           });
         }
       } else {
+        // Per-streak review accounting — independent of publish/steer outcome and of
+        // autoAddressEnabled (review token spend happens whether or not findings are steered).
+        // A clean verdict (findings:[]) resets the streak; any findings-bearing verdict
+        // increments it and appends this run's patch-id (deduped) to the churn-skip set.
+        if (verdict.findings.length === 0) {
+          verdict.streakReviews = 0;
+          verdict.reviewedPatchIds = [];
+        } else {
+          verdict.streakReviews = f.priorStreakReviews + 1;
+          verdict.reviewedPatchIds = [...new Set([...f.priorReviewedPatchIds, f.patchId])];
+          // Escalate once, when the streak first reaches the ceiling (2*cap). `>=` with a
+          // crossing guard (priorStreakReviews < ceiling) so a cap lowered between runs still
+          // fires rather than being stepped over, while reviews past the ceiling don't
+          // re-signal every tick (consider() bails before re-spawning anyway). Mirrors the
+          // errorRound crossing-guard pattern below in the error path.
+          const ceiling = 2 * this.cap;
+          if (verdict.streakReviews >= ceiling && f.priorStreakReviews < ceiling) {
+            this.deps.store.addSignal({
+              repoPath: f.repoPath,
+              sessionId: f.sessionId,
+              kind: "stall",
+              payload: `critic reviewed this PR ${verdict.streakReviews} times without reaching clean — auto-review paused; needs human attention`,
+            });
+          }
+        }
         await this.publishVerdict(f, verdict);
       }
       this.deps.store.putReview(verdict);
@@ -586,6 +647,13 @@ export class ReviewService {
       findings,
       addressRound: 0, // publishVerdict() overwrites with the streak round (finalize()'s error path holds priorRound)
       addressCap: this.cap, // surface the live cap so the UI badge need not mirror it
+      // streakReviews increments on ANY finalized verdict with findings (regardless of
+      // publish/steer outcome) and resets on clean — finalize() overwrites for findings/error;
+      // a clean (findings:[]) verdict keeps this 0 reset. reviewedPatchIds tracks the churn/
+      // revert dedup set: clean → [] (set above), findings → dedup append, error → preserve;
+      // finalize() overwrites for the non-clean branches.
+      streakReviews: 0,
+      reviewedPatchIds: [],
       errorRound: 0, // finalize() overwrites on an error verdict
       finalRoundPending: false, // finalize() sets this on a real verdict
       finalRoundTimeoutMs: DEFAULT_FINAL_ROUND_TIMEOUT_MS, // live escalation timeout

--- a/src/review.ts
+++ b/src/review.ts
@@ -690,7 +690,10 @@ export class ReviewService {
  *  no-op. patch-id ignores line numbers, so it stays stable when the rebased-onto base
  *  shifts hunks elsewhere; it changes only when the branch's own changed lines or their
  *  context change. Null on no diff or any git failure → caller never skips (reviews). */
-async function defaultComputePatchId(worktreePath: string, base: string): Promise<string | null> {
+export async function defaultComputePatchId(
+  worktreePath: string,
+  base: string,
+): Promise<string | null> {
   try {
     // Diff against the CURRENT base, not a possibly-stale local ref. createDetached fetches
     // only the head branch, so local `main` can lag behind origin; on a rebase onto newer

--- a/src/store.ts
+++ b/src/store.ts
@@ -179,6 +179,7 @@ export class SessionStore implements CapStore {
       summary TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '',
       findings TEXT NOT NULL DEFAULT '[]', addressRound INTEGER NOT NULL DEFAULT 0,
       addressCap INTEGER NOT NULL DEFAULT 3, errorRound INTEGER NOT NULL DEFAULT 0,
+      streakReviews INTEGER NOT NULL DEFAULT 0, reviewedPatchIds TEXT NOT NULL DEFAULT '[]',
       seenNoteIds TEXT NOT NULL DEFAULT '[]',
       finalRoundPending INTEGER NOT NULL DEFAULT 0,
       finalRoundTimeoutMs INTEGER NOT NULL DEFAULT 900000,
@@ -640,6 +641,8 @@ export class SessionStore implements CapStore {
       findings: parseFindings(r.findings),
       addressRound: r.addressRound ?? 0,
       addressCap: r.addressCap ?? 3,
+      streakReviews: r.streakReviews ?? 0,
+      reviewedPatchIds: parseFindings(r.reviewedPatchIds), // same string[] JSON shape as seenNoteIds
       errorRound: r.errorRound ?? 0,
       finalRoundPending: !!r.finalRoundPending,
       finalRoundTimeoutMs: r.finalRoundTimeoutMs ?? 900_000,
@@ -652,7 +655,7 @@ export class SessionStore implements CapStore {
     const r = this.db
       .query(
         `SELECT sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-                addressCap, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt
+                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt
               FROM reviews WHERE sessionId = ?`,
       )
       .get(sessionId) as any;
@@ -662,12 +665,13 @@ export class SessionStore implements CapStore {
   putReview(v: ReviewVerdict): void {
     this.db.run(
       `INSERT INTO reviews (sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-         addressCap, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET headSha=excluded.headSha, patchId=excluded.patchId,
          decision=excluded.decision,
          summary=excluded.summary, body=excluded.body, findings=excluded.findings,
          addressRound=excluded.addressRound, addressCap=excluded.addressCap,
+         streakReviews=excluded.streakReviews, reviewedPatchIds=excluded.reviewedPatchIds,
          errorRound=excluded.errorRound, finalRoundPending=excluded.finalRoundPending,
          finalRoundTimeoutMs=excluded.finalRoundTimeoutMs, seenNoteIds=excluded.seenNoteIds,
          url=excluded.url, updatedAt=excluded.updatedAt`,
@@ -681,6 +685,8 @@ export class SessionStore implements CapStore {
         JSON.stringify(v.findings ?? []),
         v.addressRound ?? 0,
         v.addressCap ?? 3,
+        v.streakReviews ?? 0,
+        JSON.stringify(v.reviewedPatchIds ?? []),
         v.errorRound ?? 0,
         v.finalRoundPending ? 1 : 0,
         v.finalRoundTimeoutMs ?? 900_000,
@@ -710,7 +716,7 @@ export class SessionStore implements CapStore {
     const rows = this.db
       .query(
         `SELECT sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-                addressCap, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt FROM reviews`,
+                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt FROM reviews`,
       )
       .all() as any[];
     const out: Record<string, ReviewVerdict> = {};
@@ -1015,6 +1021,11 @@ export class SessionStore implements CapStore {
     // an ongoing mirror. errorRound/seenNoteIds back the error-escalation + note dedup.
     add("addressCap", `addressCap INTEGER NOT NULL DEFAULT 3`);
     add("errorRound", `errorRound INTEGER NOT NULL DEFAULT 0`);
+    // Per-streak spawn ceiling + churn/revert dedup (#501). Old rows backfill to 0 / '[]':
+    // a row at rest hydrates to a fresh streak (next head reviews once and starts counting),
+    // and an empty reviewedPatchIds set keeps the patchId OR-branch as the lone rebase-skip.
+    add("streakReviews", `streakReviews INTEGER NOT NULL DEFAULT 0`);
+    add("reviewedPatchIds", `reviewedPatchIds TEXT NOT NULL DEFAULT '[]'`);
     add("seenNoteIds", `seenNoteIds TEXT NOT NULL DEFAULT '[]'`);
     // patchId backs rebase-skip: pre-existing rows backfill to '' (unknown), so the
     // next head change reviews once and records the fingerprint going forward.

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,6 +184,8 @@ export interface ReviewVerdict {
   findings: string[]; // discrete actionable items; [] = nothing to address (loop terminates)
   addressRound: number; // auto-address steers spent on the current findings streak (0 = clean/reset)
   addressCap: number; // the streak cap this run used — surfaced so the UI badge math need not mirror it
+  streakReviews: number; // critic reviews finalized during the current outstanding-findings streak (0 = clean/reset); bounds review spawns at 2*cap, independent of addressRound
+  reviewedPatchIds: string[]; // patch-ids reviewed during the current streak (cleared on a clean verdict, preserved across an error); a re-appeared id within the streak is skipped (churn/revert dedup)
   errorRound: number; // consecutive critic error/timeout verdicts (separate no-progress counter; 0 on any real verdict)
   finalRoundPending: boolean; // cap-th steer just delivered, no re-review yet → dimmed FINAL badge
   finalRoundTimeoutMs: number; // live abandonment timeout; surfaced so the UI never hardcodes it

--- a/test/review-patchid.test.ts
+++ b/test/review-patchid.test.ts
@@ -152,7 +152,10 @@ test("offline (no origin remote) still returns a valid id via the local base fal
 test("real origin: FETCH_HEAD path keeps the id stable when origin/main advances past the fork point (merge-train)", async () => {
   // Bare repo standing in for origin.
   const bare = mkTmp("shepherd-patchid-origin-");
-  git(["init", "-q", "--bare"], bare);
+  // `-b main` so the bare's HEAD tracks `main` regardless of the host's `init.defaultBranch`
+  // (CI defaults to `master`); otherwise the throwaway clone below checks out a nonexistent
+  // `master`, commits land there, and `push origin main` fails with "src refspec ... no match".
+  git(["init", "-q", "--bare", "-b", "main"], bare);
   git(["remote", "add", "origin", bare], repo);
   git(["push", "-q", "origin", "main"], repo);
 

--- a/test/review-patchid.test.ts
+++ b/test/review-patchid.test.ts
@@ -1,0 +1,204 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { defaultComputePatchId } from "../src/review";
+
+// `defaultComputePatchId` spawns git with INHERITED process.env and does NOT strip
+// GIT_DIR/GIT_WORK_TREE. The Shepherd suite can run under an ambient GIT_DIR (e.g.
+// inside a git hook), which would point the function-under-test at the WRONG repo.
+// Save + clear them so BOTH our own setup git AND the function operate on the temp repo;
+// restore afterward.
+let savedGitDir: string | undefined;
+let savedGitWorkTree: string | undefined;
+
+const GIT_ID_ENV = {
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+
+let repo: string;
+const tmpDirs: string[] = [];
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    env: { ...process.env, ...GIT_ID_ENV },
+    stdio: ["pipe", "pipe", "pipe"],
+  })
+    .toString()
+    .trim();
+}
+
+/** write a file then `git add` it (relative path under cwd). */
+function writeAdd(cwd: string, rel: string, contents: string): void {
+  writeFileSync(join(cwd, rel), contents);
+  git(["add", rel], cwd);
+}
+
+function commit(cwd: string, msg: string): void {
+  git(["commit", "-q", "-m", msg], cwd);
+}
+
+function mkTmp(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  tmpDirs.push(d);
+  return d;
+}
+
+/** Replicate the function's local-base path by hand: `git diff <base>...HEAD | git patch-id --stable`.
+ *  Used to prove the function does NOT fold the same diff as a stale-local-main diff. */
+function localPatchId(cwd: string, base: string): string | null {
+  const diff = execFileSync("git", ["diff", `${base}...HEAD`], {
+    cwd,
+    env: { ...process.env, ...GIT_ID_ENV },
+    maxBuffer: 64 * 1024 * 1024,
+    encoding: "utf8",
+  });
+  if (!diff.length) return null;
+  const out = execFileSync("git", ["patch-id", "--stable"], {
+    cwd,
+    input: diff,
+    stdio: ["pipe", "pipe", "ignore"],
+  })
+    .toString()
+    .trim();
+  return out.split(/\s+/)[0] || null;
+}
+
+beforeEach(() => {
+  savedGitDir = process.env.GIT_DIR;
+  savedGitWorkTree = process.env.GIT_WORK_TREE;
+  delete process.env.GIT_DIR;
+  delete process.env.GIT_WORK_TREE;
+
+  repo = mkTmp("shepherd-patchid-");
+  git(["init", "-q", "-b", "main"], repo);
+  writeAdd(repo, "base.txt", "baseline\n");
+  commit(repo, "init");
+});
+
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  if (savedGitDir !== undefined) process.env.GIT_DIR = savedGitDir;
+  if (savedGitWorkTree !== undefined) process.env.GIT_WORK_TREE = savedGitWorkTree;
+});
+
+test("patch-id is invariant across a clean rebase onto an advanced local base", async () => {
+  // No origin remote → the internal `git fetch origin` fails and the function falls back
+  // to diffing against the LOCAL base ref. (Exercises the offline fallback path.)
+  git(["checkout", "-q", "-b", "feature"], repo);
+  writeAdd(repo, "feat.txt", "alpha\nbeta\ngamma\n");
+  commit(repo, "feature change");
+
+  const id1 = await defaultComputePatchId(repo, "main");
+  expect(id1).toBeTruthy();
+  expect(typeof id1).toBe("string");
+
+  // advance main with an UNRELATED file, then rebase feature onto it
+  git(["checkout", "-q", "main"], repo);
+  writeAdd(repo, "unrelated.txt", "noise\n");
+  commit(repo, "advance main");
+  git(["checkout", "-q", "feature"], repo);
+  git(["rebase", "-q", "main"], repo);
+
+  const id2 = await defaultComputePatchId(repo, "main");
+  expect(id2).toBe(id1);
+});
+
+test("patch-id changes when the branch's own content changes", async () => {
+  git(["checkout", "-q", "-b", "feature"], repo);
+  writeAdd(repo, "feat.txt", "alpha\nbeta\ngamma\n");
+  commit(repo, "feature change");
+  const before = await defaultComputePatchId(repo, "main");
+  expect(before).toBeTruthy();
+
+  // change a tracked line on feature (new commit)
+  writeAdd(repo, "feat.txt", "alpha\nBETA-CHANGED\ngamma\n");
+  commit(repo, "edit feature");
+  const after = await defaultComputePatchId(repo, "main");
+  expect(after).toBeTruthy();
+  expect(after).not.toBe(before);
+});
+
+test("patch-id is null when the branch has no diff against base", async () => {
+  // a branch that sits exactly at main's tip → no diff → null
+  git(["checkout", "-q", "-b", "feature"], repo);
+  const id = await defaultComputePatchId(repo, "main");
+  expect(id).toBeNull();
+
+  // and main vs main is likewise empty
+  git(["checkout", "-q", "main"], repo);
+  expect(await defaultComputePatchId(repo, "main")).toBeNull();
+});
+
+test("offline (no origin remote) still returns a valid id via the local base fallback", async () => {
+  // Explicitly document the fallback: no `git remote` is configured at all, so the internal
+  // `git fetch origin -- main` errors and is swallowed; the function diffs the local base.
+  expect(git(["remote"], repo)).toBe("");
+  git(["checkout", "-q", "-b", "feature"], repo);
+  writeAdd(repo, "feat.txt", "alpha\n");
+  commit(repo, "feature change");
+
+  const id = await defaultComputePatchId(repo, "main");
+  expect(id).toBeTruthy();
+  expect(typeof id).toBe("string");
+  expect((id as string).length).toBeGreaterThan(0);
+});
+
+test("real origin: FETCH_HEAD path keeps the id stable when origin/main advances past the fork point (merge-train)", async () => {
+  // Bare repo standing in for origin.
+  const bare = mkTmp("shepherd-patchid-origin-");
+  git(["init", "-q", "--bare"], bare);
+  git(["remote", "add", "origin", bare], repo);
+  git(["push", "-q", "origin", "main"], repo);
+
+  // Branch feature off the current main and make its change; push it.
+  git(["checkout", "-q", "-b", "feature"], repo);
+  writeAdd(repo, "feat.txt", "alpha\nbeta\ngamma\n");
+  commit(repo, "feature change");
+  git(["push", "-q", "origin", "feature"], repo);
+
+  // BEFORE: fingerprint with feature sitting at its original fork point.
+  const before = await defaultComputePatchId(repo, "main");
+  expect(before).toBeTruthy();
+
+  // Advance origin/main with UNRELATED commits AFTER the branch point, WITHOUT moving the
+  // working repo's local `main` ref to match. We do this from a throwaway clone so the
+  // working repo's local `main` stays stale (simulating the merge-train: other PRs merged
+  // into origin/main while this branch was in flight).
+  // clone the bare origin into a fresh dir (git clone needs the target to not pre-exist;
+  // mkdtemp's dir would be non-empty-safe but git refuses, so make a unique subpath).
+  const pusherParent = mkTmp("shepherd-patchid-pusher-");
+  const pusher = join(pusherParent, "clone");
+  git(["clone", "-q", bare, pusher], pusherParent);
+  writeAdd(pusher, "other-pr.txt", "merged elsewhere\n");
+  commit(pusher, "unrelated PR merged to main");
+  writeAdd(pusher, "other-pr2.txt", "another merge\n");
+  commit(pusher, "second unrelated PR");
+  git(["push", "-q", "origin", "main"], pusher);
+
+  // The working repo's local `main` is now STALE (lags origin/main by 2 commits).
+  const localMain = git(["rev-parse", "main"], repo);
+  git(["fetch", "-q", "origin"], repo);
+  const originMain = git(["rev-parse", "origin/main"], repo);
+  expect(localMain).not.toBe(originMain); // confirm the stale-local-main setup
+
+  // Rebase feature onto the advanced origin/main (clean — feature's change is independent).
+  git(["rebase", "-q", "origin/main"], repo);
+
+  // AFTER: the function fetches origin/main fresh and diffs FETCH_HEAD...HEAD, so the
+  // merge-base is the TRUE current fork point → fingerprint stable across the clean rebase.
+  const after = await defaultComputePatchId(repo, "main");
+  expect(after).toBe(before);
+
+  // Contrast: a STALE-LOCAL-main diff (what the pre-fix code did) folds the two unrelated
+  // origin commits into the diff, so its patch-id DIFFERS from the function's fetched-base
+  // result — proving the function used the fresh base, not the lagging local ref.
+  const stale = localPatchId(repo, localMain);
+  expect(stale).toBeTruthy();
+  expect(stale).not.toBe(after);
+});

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1188,6 +1188,30 @@ test("under the ceiling still spawns normally", async () => {
   expect(started).toHaveLength(1); // budget remains → critic spawns
 });
 
+test("ceiling is strict for findings reviews but NOT total spawns: an error verdict (findings=[]) re-reviews", async () => {
+  // Documents the approximate-total bound (#501 critic note): the gate keys off
+  // findings.length > 0, so an error/timeout verdict (which preserves streakReviews but
+  // carries findings=[]) does NOT trip the ceiling — error churn is governed by errorRound,
+  // not this gate, so a flapping critic can re-spawn past 2*cap. (In the live loop an error
+  // verdict can't actually carry streakReviews >= ceiling, since reaching the ceiling needs a
+  // findings verdict that then blocks the next spawn; this fixture pins the gate's literal
+  // semantics so a refactor dropping the findings>0 leg fails here and forces a conscious call.)
+  const {
+    deps: d,
+    reviews,
+    started,
+  } = makeDeps({ computePatchId: async () => "pid-new" }, { autoAddressEnabled: true });
+  reviews["s1"] = priorReview({
+    decision: "error",
+    findings: [], // error verdicts carry no findings
+    streakReviews: 6, // at the default ceiling, yet not a findings streak
+    headSha: "old",
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(started).toHaveLength(1); // not blocked by the findings-review ceiling
+});
+
 test("clean verdict resets streakReviews and reviewedPatchIds (un-suppresses)", async () => {
   const { deps: d, reviews } = makeDeps(
     {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -412,6 +412,8 @@ test("forget reaps an in-flight critic and drops the stored review", async () =>
     findings: [],
     addressRound: 0,
     addressCap: 3,
+    streakReviews: 0,
+    reviewedPatchIds: [],
     errorRound: 0,
     finalRoundPending: false,
     finalRoundTimeoutMs: 15 * 60_000,
@@ -615,6 +617,8 @@ test("clean verdict (no findings) stops the loop and resets the round", async ()
     findings: ["was broken"],
     addressRound: 2,
     addressCap: 3,
+    streakReviews: 2,
+    reviewedPatchIds: [],
     errorRound: 0,
     finalRoundPending: false,
     finalRoundTimeoutMs: 15 * 60_000,
@@ -656,6 +660,8 @@ test("round cap reached: holds the round, posts the review + signal, does not st
     findings: ["still broken"],
     addressRound: 3, // == cap: the agent has had its 3 tries
     addressCap: 3,
+    streakReviews: 3,
+    reviewedPatchIds: [],
     errorRound: 0,
     finalRoundPending: false,
     finalRoundTimeoutMs: 15 * 60_000,
@@ -820,6 +826,8 @@ function priorReview(over: Partial<ReviewVerdict> = {}): ReviewVerdict {
     findings: ["fix the race in worker.ts"],
     addressRound: 1,
     addressCap: 3,
+    streakReviews: 1,
+    reviewedPatchIds: [],
     errorRound: 0,
     finalRoundPending: false,
     finalRoundTimeoutMs: 15 * 60_000,
@@ -1083,4 +1091,199 @@ test("an error verdict does not consume freshly-fetched author notes (re-inject 
   expect(reviews["s1"]?.decision).toBe("error");
   // the errored critic never produced a verdict on c9, so it must NOT be marked seen
   expect(reviews["s1"]?.seenNoteIds).toEqual([]);
+});
+
+// ── bound review spawns: per-streak spawn ceiling (#501) ─────────────────────────
+
+test("ceiling reached: does NOT spawn (no worktree allocated, no re-signal)", async () => {
+  const {
+    deps: d,
+    reviews,
+    started,
+    removed,
+    signals,
+  } = makeDeps({ computePatchId: async () => "pid-new" }, { autoAddressEnabled: true });
+  // cap default 3 → ceiling 6; a streak already AT the ceiling with outstanding findings.
+  reviews["s1"] = priorReview({ streakReviews: 6, headSha: "old" });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(started).toHaveLength(0); // critic not spawned
+  expect(removed).toEqual([]); // bailed BEFORE allocating the probe worktree
+  // the stall signal fired on crossing (in finalize), not here on the blocked tick
+  expect(signals.some((s) => s.kind === "stall")).toBe(false);
+});
+
+test("ceiling crossing emits exactly one stall signal", async () => {
+  const {
+    deps: d,
+    reviews,
+    signals,
+  } = makeDeps(
+    {
+      computePatchId: async () => "pid-cross",
+      readVerdict: () => ({
+        decision: "request-changes",
+        summary: "still broken",
+        body: "b",
+        findings: ["still broken"],
+      }),
+    },
+    { autoAddressEnabled: true },
+  );
+  // one review short of the ceiling (6); this run finalizes the 6th → crosses.
+  reviews["s1"] = priorReview({ streakReviews: 5, headSha: "old" });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.tick();
+  expect(reviews["s1"]?.streakReviews).toBe(6); // reached the ceiling
+  const paused = signals.filter(
+    (s) => s.kind === "stall" && s.payload.includes("auto-review paused"),
+  );
+  expect(paused).toHaveLength(1); // exactly one, on crossing
+  expect(paused[0]!.payload).toContain("6 times");
+});
+
+test("a higher live cap raises the ceiling: a streak at 6 still spawns + the signal tracks the cap", async () => {
+  // The ceiling is 2*cap, derived from the LIVE cap. With cap=4 the ceiling is 8, so a streak
+  // at 6 is under budget (would be at-ceiling under the default cap=3). Proves the gate +
+  // crossing guard both read the live cap, not a frozen number — and the crossing guard fires
+  // once exactly when the streak first reaches the live ceiling.
+  const {
+    deps: d,
+    reviews,
+    started,
+    signals,
+  } = makeDeps(
+    {
+      cap: 4, // ceiling = 8
+      computePatchId: async () => "pid-h",
+      readVerdict: () => ({
+        decision: "request-changes",
+        summary: "still broken",
+        body: "b",
+        findings: ["still broken"],
+      }),
+    },
+    { autoAddressEnabled: true },
+  );
+  reviews["s1"] = priorReview({ streakReviews: 7, headSha: "old" }); // one short of 8
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(started).toHaveLength(1); // under the raised ceiling → spawns
+  await svc.tick();
+  expect(reviews["s1"]?.streakReviews).toBe(8); // crosses the raised ceiling
+  const paused = signals.filter((s) => s.kind === "stall" && s.payload.includes("8 times"));
+  expect(paused).toHaveLength(1); // signal count tracks the live ceiling
+});
+
+test("under the ceiling still spawns normally", async () => {
+  const {
+    deps: d,
+    reviews,
+    started,
+  } = makeDeps({ computePatchId: async () => "pid-new" }, { autoAddressEnabled: true });
+  reviews["s1"] = priorReview({ streakReviews: 3, headSha: "old" }); // well under 6
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(started).toHaveLength(1); // budget remains → critic spawns
+});
+
+test("clean verdict resets streakReviews and reviewedPatchIds (un-suppresses)", async () => {
+  const { deps: d, reviews } = makeDeps(
+    {
+      computePatchId: async () => "pid-clean-run",
+      readVerdict: () => ({ decision: "comment", summary: "lgtm", body: "b", findings: [] }),
+    },
+    { autoAddressEnabled: true },
+  );
+  reviews["s1"] = priorReview({
+    streakReviews: 4,
+    reviewedPatchIds: ["pid-a", "pid-b"],
+    headSha: "old",
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.tick();
+  expect(reviews["s1"]?.streakReviews).toBe(0); // streak reset
+  expect(reviews["s1"]?.reviewedPatchIds).toEqual([]); // churn set cleared
+});
+
+// ── bound review spawns: per-streak patch-id dedup (#501) ────────────────────────
+
+test("revert to an earlier (not immediately-prior) reviewed patch-id skips", async () => {
+  const {
+    deps: d,
+    reviews,
+    started,
+    bumped,
+  } = makeDeps({
+    computePatchId: async () => "pid-a", // bounced back to a diff reviewed earlier this streak
+  });
+  // prior verdict's own patchId is pid-c, but pid-a was reviewed earlier in the streak.
+  reviews["s1"] = priorReview({
+    patchId: "pid-c",
+    headSha: "old",
+    reviewedPatchIds: ["pid-a", "pid-b", "pid-c"],
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(started).toHaveLength(0); // set-membership match → skipped
+  expect(bumped).toEqual([{ id: "s1", headSha: "newsha" }]); // head re-pointed, verdict preserved
+  expect(reviews["s1"]?.findings).toEqual(["fix the race in worker.ts"]); // outstanding findings held
+});
+
+test("after a clean verdict cleared the set, a pre-clean patch-id is reviewed again", async () => {
+  const { deps: d, reviews, started, bumped } = makeDeps({ computePatchId: async () => "pid-a" });
+  // a clean verdict reset the set to []; pid-a was reviewed pre-clean but is no longer tracked.
+  reviews["s1"] = priorReview({
+    decision: "commented",
+    findings: [],
+    patchId: "pid-clean",
+    reviewedPatchIds: [],
+    streakReviews: 0,
+    headSha: "old",
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(bumped).toHaveLength(0); // not skipped — the set was cleared
+  expect(started).toHaveLength(1); // reviewed again (a revert to a buggy earlier state)
+});
+
+test("error verdict does not poison the dedup set (same diff re-reviews)", async () => {
+  const { deps: d, reviews } = makeDeps({
+    computePatchId: async () => "pid-x",
+    // first run errors on pid-x; it must NOT be added to reviewedPatchIds.
+    readVerdict: () => ({ decision: "junk", summary: "boom", body: "" }),
+  });
+  reviews["s1"] = priorReview({ headSha: "old", reviewedPatchIds: [] });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  await svc.tick();
+  expect(reviews["s1"]?.decision).toBe("error");
+  // errored patch-id NOT added → a later head with the SAME diff re-reviews (rebaseSkip
+  // also independently refuses to skip past an error decision).
+  expect(reviews["s1"]?.reviewedPatchIds).toEqual([]);
+});
+
+test("clean prior verdict still rebase-skips on a same-patch-id force-push (OR-branch)", async () => {
+  const {
+    deps: d,
+    reviews,
+    started,
+    bumped,
+  } = makeDeps({ computePatchId: async () => "pid-clean" });
+  // a CLEAN verdict: reviewedPatchIds is [] but patchId is preserved. The OR-branch
+  // (prior.patchId === patchId) must still fire even with an empty set.
+  reviews["s1"] = priorReview({
+    decision: "commented",
+    findings: [],
+    patchId: "pid-clean",
+    reviewedPatchIds: [],
+    streakReviews: 0,
+    headSha: "old",
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(started).toHaveLength(0); // skipped via the patchId OR-branch
+  expect(bumped).toEqual([{ id: "s1", headSha: "newsha" }]); // head re-pointed
 });

--- a/test/server-reviews.test.ts
+++ b/test/server-reviews.test.ts
@@ -45,6 +45,8 @@ test("GET /api/reviews returns snapshot when reviewCache is present", async () =
     findings: [],
     addressRound: 0,
     addressCap: 3,
+    streakReviews: 0,
+    reviewedPatchIds: [],
     errorRound: 0,
     finalRoundPending: false,
     finalRoundTimeoutMs: 900_000,

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -195,6 +195,8 @@ test("reviews: upsert + read by session, snapshot all", () => {
     findings: ["fix the off-by-one", "handle the null case"],
     addressRound: 1,
     addressCap: 3,
+    streakReviews: 2,
+    reviewedPatchIds: ["pid-old", "pid-abc"],
     errorRound: 0,
     finalRoundPending: false,
     finalRoundTimeoutMs: 900_000,
@@ -231,6 +233,8 @@ test("reviews: findings/addressRound/addressCap/errorRound/seenNoteIds default w
   expect(r?.addressRound).toBe(0);
   expect(r?.addressCap).toBe(3); // backfilled to the migration default
   expect(r?.errorRound).toBe(0);
+  expect(r?.streakReviews).toBe(0); // backfilled to the migration default
+  expect(r?.reviewedPatchIds).toEqual([]); // backfilled to '[]'
   expect(r?.seenNoteIds).toEqual([]);
   expect(r?.patchId).toBe(""); // pre-rebase-skip rows backfill to '' (unknown → always reviews)
   expect(r?.finalRoundPending).toBe(false); // backfilled to the migration default
@@ -249,6 +253,8 @@ test("bumpReviewHead: re-points head + updatedAt, leaves the verdict otherwise i
     findings: ["fix the off-by-one"],
     addressRound: 2,
     addressCap: 3,
+    streakReviews: 2,
+    reviewedPatchIds: ["pid-1"],
     errorRound: 0,
     finalRoundPending: false,
     finalRoundTimeoutMs: 900_000,
@@ -274,6 +280,8 @@ test("putReview round-trips finalRoundPending + finalRoundTimeoutMs", () => {
     findings: ["x"],
     addressRound: 3,
     addressCap: 3,
+    streakReviews: 0,
+    reviewedPatchIds: [],
     errorRound: 0,
     finalRoundPending: true,
     finalRoundTimeoutMs: 900_000,


### PR DESCRIPTION
Closes #501.

## Why

Token-usage analysis (PR #496, `docs/token-usage-analysis.md`) found critic re-review is the clear second-order token cost — TASK-288 spawned **5 critic dirs**. Issue #501 asks to (1) confirm the patch-id rebase-skip actually suppresses redundant re-reviews, and (2) bound critic auto-address rounds with a clear stop signal so a churning PR can't spawn unbounded review passes.

## What

**1. Per-streak review-spawn ceiling + stop signal (ask #2).** The existing `DEFAULT_CAP` bounded only auto-address *steers*; `consider()` still spawned a critic on *every* new green head. This adds a per-streak `streakReviews` counter and gates `consider()` before worktree allocation once `streakReviews >= 2*cap` (default 6) with outstanding findings — emitting a one-shot `stall` escalation signal on crossing (crossing-guard, mirrors the existing `errorRound` pattern). Resets to 0 on a clean verdict; preserved (not incremented) across an `error` verdict (error spend is bounded by `errorRound`, not this ceiling). Applies independently of `autoAddressEnabled` (review token spend happens regardless of steering).

  **Bound is strict for findings-bearing reviews, approximate for total spawns.** `streakReviews` increments only on a findings verdict; an error/timeout verdict preserves it and carries `findings: []`, so it never trips the gate's `findings > 0` leg. Findings reviews are therefore hard-capped at `2*cap`, but a critic *flapping on timeouts* keeps re-spawning on each new head — that error churn is deliberately governed by `errorRound`'s escalation, not this ceiling (a transient timeout must neither be charged against the findings budget nor permanently halt review). Documented at the gate + pinned by a test. (Raised by the PR critic; see the author note.)

**2. Per-streak patch-id churn dedup (ask #2).** A new per-streak `reviewedPatchIds` set generalizes the single-prior rebase-skip: `rebaseSkip()` now skips when `prior.patchId === patchId || reviewedPatchIds.includes(patchId)`, so a reverted/oscillating diff (A→B→A) isn't re-reviewed. The `prior.patchId === patchId` OR-branch is retained so a clean verdict (set reset to `[]`) and migrated rows (backfilled `[]`) still rebase-skip. Fail-closed: skipping a re-appeared diff preserves outstanding findings; a clean-then-reverted-to-buggy diff is reviewed again.

**3. Prove the rebase-skip against real git (ask #1).** Every prior test *injected* `computePatchId`; the real `git fetch → diff FETCH_HEAD...HEAD → patch-id` pipeline had zero coverage. New `test/review-patchid.test.ts` exercises it against real temp repos — including a **mandatory bare-`origin`/`FETCH_HEAD` merge-train case**: it advances `origin/main` past the fork point while leaving local `main` stale, then asserts the patch-id is identical before/after a clean rebase, plus a contrast assertion proving the function used the *fetched* base, not the lagging local ref. (`GIT_DIR`/`GIT_WORK_TREE` are stripped from the env so the function-under-test can't be hijacked onto the wrong repo.)

New `ReviewVerdict` fields (`streakReviews`, `reviewedPatchIds`) are threaded through `types.ts` + `store.ts` with an additive, live-DB-safe migration.

## Honest scope of the bound

**The `2*cap` (=6) ceiling is a generous tail-guard; it does NOT reduce a TASK-288-class (≤6 dirs) spend.** 6 sits above the cited 5 dirs, and the dedup saves nothing if those 5 were *distinct iterative diffs* — the analysis records no per-dir patch-ids, so churn vs. honest iteration is unknowable. This follows the chosen "a genuinely new diff still reviews once" semantics: only the unbounded *tail* (>2×cap) is cut and escalated. Success here is the tail-bound + dedup behaving correctly, not shrinking the motivating incident.

**Re-engagement cliff:** past the ceiling, a PR paused one round short of clean stays paused until a clean verdict lands under budget or a human archives the session (`dropReview` resets the streak). No in-PR "re-request review" action — possible follow-up.

**Split out (follow-up):** the durable per-spawn attribution record (the analysis's "meta-lever" for exact `db`-tag token attribution) is intentionally **not** in this PR — it bounds no tokens and needs its own design. Will file a follow-up issue.

## Verification

- `bunx tsc --noEmit` clean; `bun run lint` clean
- `bun test ./test` — 1794 pass, 1 skip, 0 fail (incl. new ceiling/dedup/clean-reset/error-not-poisoned cases + 5 real-git patch-id cases)
- branch hygiene (linear off main) + `fallow audit` gates pass

[no-feature-entry] — server-internal change, no user-facing UI/i18n/feature-catalog surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

