### PR TITLE
fix(herd): show the session's model on cards instead of the herdr session name

### DIFF
--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -378,7 +378,8 @@
 
     <span class="meta">
       <span class="meta-text"
-        ><span class="desig">{session.desig}</span> · {session.herdrSession || "—"}</span
+        ><span class="desig">{session.desig}</span> · {session.model ??
+          m.newtask_model_default()}</span
       >
       {#if showStepper && !session.readyToMerge}
         <span class="meta-stepper">
@@ -925,7 +926,7 @@
     align-items: center;
   }
   /* the task designation is metadata, not the human marker — demoted to the
-     quietest spot, the bottom-right meta line, next to the herdr session */
+     quietest spot, the bottom-right meta line, next to the session's model */
   .meta .desig {
     color: var(--color-faint);
     letter-spacing: 0.1em;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -348,7 +348,7 @@
   }
 
   // null model = claude's own default (shepherd passed no --model flag)
-  const modelLabel = $derived(session.model ?? "default");
+  const modelLabel = $derived(session.model ?? m.newtask_model_default());
 
   // The `session` prop is re-resolved from the store whenever the sessions
   // state changes, so its reference can churn while the id stays put. Derive


### PR DESCRIPTION
## Problem

Selecting an explicit model (e.g. **Opus**) in New Task looked ignored: the herd card still read `TASK-159 · default`.

The "default" in that slot was never the model — it's `session.herdrSession`, the herdr session group name (`HERDR_SESSION` env), which is the literal string `"default"` in virtually every setup. The selected model **was** applied all along (`src/service.ts` passes `--model opus` to claude); it just wasn't displayed anywhere on the card, while a meaningless "default" sat exactly where an operator expects the model.

## Fix

- The card meta slot now shows the session's **model** (`TASK-159 · opus`), falling back to the localized "default" label (`newtask_model_default`, existing key) when no explicit model was chosen — matching what the slot was already assumed to mean.
- The herdr session name is dropped from the card; this was its only display site and it carries no information in single-herdr setups.
- The Viewport profile popover's hardcoded `"default"` now routes through the same i18n key ("Standard" in DE).

## Verification

- `bun run check` — 0 errors / 0 warnings
- `bun run test` — 64 files, 902 tests passed
- No new i18n keys (reused `newtask_model_default`), so `check:i18n` parity unaffected.