### PR TITLE
feat(steers): ABC toggle to reveal steer labels on the compact mobile bar

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -591,6 +591,8 @@
   "steerbar_send_failed": "Senden fehlgeschlagen",
   "steerbar_coach_hint": "Tippe einen Chip an, um den Agenten zu steuern. Broadcast sendet an mehrere zugleich.",
   "steerbar_coach_dismiss": "Verstanden",
+  "steerbar_labels_show": "Beschriftungen anzeigen",
+  "steerbar_labels_hide": "Nur Symbole anzeigen",
   "steerseditor_title": "Gespeicherte Steers",
   "steerseditor_label_placeholder": "Bezeichnung",
   "steerseditor_text_placeholder": "Prompt-Text",
@@ -895,5 +897,7 @@
   "steerseditor_scope_issues_title": "Als Schnellstart-Button auf Backlog-Issues anzeigen",
   "feat_issue_actions_title": "Issue-Aktionen & Steer-Emojis",
   "feat_issue_actions_body": "Definiere mehrere Prompts, die direkt auf einem Backlog-Issue starten — der bisherige Standard-Befehl wurde zur ersten Aktion. Steers und Issue-Aktionen teilen sich jetzt einen Editor in den Einstellungen, und jeder Eintrag kann ein Emoji tragen, damit Buttons bei wenig Platz unterscheidbar bleiben.",
-  "steerseditor_scope_none_error": "Jeder Eintrag muss irgendwo erscheinen — aktiviere in der markierten Zeile „Leiste“ und/oder „Issues“"
+  "steerseditor_scope_none_error": "Jeder Eintrag muss irgendwo erscheinen — aktiviere in der markierten Zeile „Leiste“ und/oder „Issues“",
+  "feat_steer_labels_title": "Steer-Beschriftungen einblenden",
+  "feat_steer_labels_body": "In der engen mobilen Steer-Leiste blendest du mit der rechts angedockten „ABC“-Taste die Textbeschriftung jedes Buttons ein statt nur das Emoji — so erkennst du die Steers wieder, wenn du nicht mehr weißt, was ein Symbol bedeutet. Nochmal tippen klappt zurück auf Symbole. Die Wahl wird pro Gerät gemerkt."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -593,6 +593,7 @@
   "steerbar_coach_dismiss": "Verstanden",
   "steerbar_labels_show": "Beschriftungen anzeigen",
   "steerbar_labels_hide": "Nur Symbole anzeigen",
+  "steerbar_labels_aria": "ABC: {action}",
   "steerseditor_title": "Gespeicherte Steers",
   "steerseditor_label_placeholder": "Bezeichnung",
   "steerseditor_text_placeholder": "Prompt-Text",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -591,6 +591,8 @@
   "steerbar_send_failed": "send failed",
   "steerbar_coach_hint": "Tap a chip to steer the agent. Broadcast sends to many at once.",
   "steerbar_coach_dismiss": "Got it",
+  "steerbar_labels_show": "Show button labels",
+  "steerbar_labels_hide": "Show icons only",
   "steerseditor_title": "Saved Steers",
   "steerseditor_label_placeholder": "label",
   "steerseditor_text_placeholder": "prompt text",
@@ -895,5 +897,7 @@
   "steerseditor_scope_issues_title": "Show as a quick-launch button on backlog issues",
   "feat_issue_actions_title": "Issue actions & steer emojis",
   "feat_issue_actions_body": "Define multiple prompts that launch straight on a backlog issue — the old single standard command became the first one. Steers and issue actions now share one editor in Settings, and each entry can carry an emoji so buttons stay recognizable when space runs out.",
-  "steerseditor_scope_none_error": "every entry must surface somewhere — enable “bar” and/or “issues” on the highlighted row"
+  "steerseditor_scope_none_error": "every entry must surface somewhere — enable “bar” and/or “issues” on the highlighted row",
+  "feat_steer_labels_title": "Reveal steer labels",
+  "feat_steer_labels_body": "On the cramped mobile steer bar, tap the right-anchored “ABC” key to show every button's text label instead of just its emoji — so you can tell the steers apart when you forget what a glyph means. Tap again to collapse back to icons. The choice is remembered per device."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -593,6 +593,7 @@
   "steerbar_coach_dismiss": "Got it",
   "steerbar_labels_show": "Show button labels",
   "steerbar_labels_hide": "Show icons only",
+  "steerbar_labels_aria": "ABC: {action}",
   "steerseditor_title": "Saved Steers",
   "steerseditor_label_placeholder": "label",
   "steerseditor_text_placeholder": "prompt text",

--- a/ui/src/lib/components/SteerBar.browser.test.ts
+++ b/ui/src/lib/components/SteerBar.browser.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { tick } from "svelte";
+import "../../app.css";
+import type { Steer } from "$lib/types";
+
+// Mock api so the steer-send path never fires a real network call.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return { ...actual, replySession: vi.fn(async () => undefined) };
+});
+
+const { default: SteerBar } = await import("./SteerBar.svelte");
+const { steers } = await import("$lib/steers.svelte");
+
+const LABELS_KEY = "shepherd:steer-labels";
+const COACH_KEY = "shepherd:steer-coach-seen";
+
+const steer = (p: Partial<Steer>): Steer => ({
+  id: "1",
+  label: "Ship",
+  text: "ship it",
+  emoji: "🚀",
+  inSteerBar: true,
+  onIssues: false,
+  ...p,
+});
+
+beforeEach(() => {
+  localStorage.setItem(COACH_KEY, "1"); // suppress the one-time coach hint
+  localStorage.removeItem(LABELS_KEY);
+  steers.list = [steer({ id: "1", label: "Ship", emoji: "🚀" })];
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  localStorage.clear();
+});
+
+describe("SteerBar labels toggle", () => {
+  it("renders a right-anchored ABC toggle, off by default", () => {
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    const toggle = document.querySelector(".lbl-toggle") as HTMLElement;
+    expect(toggle, "ABC toggle rendered").not.toBeNull();
+    expect(toggle.textContent?.trim()).toBe("ABC");
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+    expect(document.querySelector(".steer-bar")!.classList.contains("show-labels")).toBe(false);
+  });
+
+  it("clicking the toggle reveals labels, persists, and flips aria-pressed", async () => {
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    const toggle = document.querySelector(".lbl-toggle") as HTMLElement;
+
+    toggle.dispatchEvent(new PointerEvent("pointerdown", { pointerId: 1, bubbles: true }));
+    toggle.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1, bubbles: true }));
+    await tick();
+
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+    expect(document.querySelector(".steer-bar")!.classList.contains("show-labels")).toBe(true);
+    expect(localStorage.getItem(LABELS_KEY)).toBe("1");
+  });
+
+  it("starts in the labels-on state when persisted", () => {
+    localStorage.setItem(LABELS_KEY, "1");
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    const toggle = document.querySelector(".lbl-toggle") as HTMLElement;
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+    expect(document.querySelector(".steer-bar")!.classList.contains("show-labels")).toBe(true);
+  });
+});

--- a/ui/src/lib/components/SteerBar.browser.test.ts
+++ b/ui/src/lib/components/SteerBar.browser.test.ts
@@ -44,6 +44,10 @@ describe("SteerBar labels toggle", () => {
     expect(toggle, "ABC toggle rendered").not.toBeNull();
     expect(toggle.textContent?.trim()).toBe("ABC");
     expect(toggle.getAttribute("aria-pressed")).toBe("false");
+    // WCAG 2.5.3 label-in-name: the visible "ABC" glyph must be in the accessible name.
+    expect(toggle.getAttribute("aria-label")).toContain("ABC");
+    // Toggle lives OUTSIDE the measured/scrolling .steer-bar so it can't poison fitLabels.
+    expect(document.querySelector(".steer-bar")!.contains(toggle)).toBe(false);
     expect(document.querySelector(".steer-bar")!.classList.contains("show-labels")).toBe(false);
   });
 

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -118,53 +118,62 @@
     >
   </div>
 {/if}
-<!-- fitLabels toggles `compact` when the full labels overflow: chips that carry an
-     emoji collapse to emoji-only (label stays in title/aria); the rest keep their
-     label and the bar's horizontal scroll remains the final fallback. -->
-<div
-  class="steer-bar"
-  class:show-labels={showLabels}
-  role="toolbar"
-  aria-label={m.steerbar_toolbar_aria()}
-  data-swipe-ignore
-  use:fitLabels
->
-  <button
-    type="button"
-    class="chip bc"
-    onpointerdown={down}
-    onpointermove={move}
-    onpointercancel={cancel}
-    onpointerup={(e) => tap(e, onbroadcast)}
-    title={m.steerbar_broadcast_aria()}
-    aria-label={m.steerbar_broadcast_aria()}
-    >⌁<span class="bc-label">{m.steerbar_broadcast()}</span></button
+<!-- The ABC labels toggle lives OUTSIDE the scrolling/measured .steer-bar (as its
+     right-hand flex sibling) so it's always visible at the far right AND so its box
+     never enters fitLabels' scrollWidth measurement — an in-flow auto-margin would
+     make scrollWidth == clientWidth and poison the cached full-label width. -->
+<div class="steer-row" data-swipe-ignore>
+  <!-- fitLabels toggles `compact` when the full labels overflow: chips that carry an
+       emoji collapse to emoji-only (label stays in title/aria); the rest keep their
+       label and the bar's horizontal scroll remains the final fallback. -->
+  <div
+    class="steer-bar"
+    class:show-labels={showLabels}
+    role="toolbar"
+    aria-label={m.steerbar_toolbar_aria()}
+    use:fitLabels
   >
-  {#each chips as s (s.id)}
     <button
       type="button"
-      class="chip"
-      class:has-emoji={!!s.emoji}
-      title={s.text}
-      aria-label={m.steerbar_send_aria({ label: s.label })}
+      class="chip bc"
       onpointerdown={down}
       onpointermove={move}
       onpointercancel={cancel}
-      onpointerup={(e) => tap(e, () => send(s.text))}
-      >{#if s.emoji}<span class="chip-emoji" aria-hidden="true">{s.emoji}</span>{/if}<span
-        class="chip-label">{s.label}</span
-      ></button
+      onpointerup={(e) => tap(e, onbroadcast)}
+      title={m.steerbar_broadcast_aria()}
+      aria-label={m.steerbar_broadcast_aria()}
+      >⌁<span class="bc-label">{m.steerbar_broadcast()}</span></button
     >
-  {/each}
-  <!-- Right-anchored labels toggle: stays pinned to the bar's right edge (sticky)
-       so it's reachable even when the chips scroll. Toggles every chip between
-       icon-only and icon+label. -->
+    {#each chips as s (s.id)}
+      <button
+        type="button"
+        class="chip"
+        class:has-emoji={!!s.emoji}
+        title={s.text}
+        aria-label={m.steerbar_send_aria({ label: s.label })}
+        onpointerdown={down}
+        onpointermove={move}
+        onpointercancel={cancel}
+        onpointerup={(e) => tap(e, () => send(s.text))}
+        >{#if s.emoji}<span class="chip-emoji" aria-hidden="true">{s.emoji}</span>{/if}<span
+          class="chip-label">{s.label}</span
+        ></button
+      >
+    {/each}
+  </div>
+  <!-- Right-anchored labels toggle. Sits at the bar's far right as a flex sibling of
+       the scroll area (always visible, never scrolls under). The accessible name leads
+       with the visible "ABC" glyph so voice control can address it by what it reads
+       (WCAG 2.5.3 label-in-name); the title carries the plain description. -->
   <button
     type="button"
     class="chip lbl-toggle"
     aria-pressed={showLabels}
     title={showLabels ? m.steerbar_labels_hide() : m.steerbar_labels_show()}
-    aria-label={showLabels ? m.steerbar_labels_hide() : m.steerbar_labels_show()}
+    aria-label={m.steerbar_labels_aria({
+      action: showLabels ? m.steerbar_labels_hide() : m.steerbar_labels_show(),
+    })}
+    data-swipe-ignore
     onpointerdown={down}
     onpointermove={move}
     onpointercancel={cancel}
@@ -173,12 +182,20 @@
 </div>
 
 <style>
+  /* Row = scrolling chip bar (flex:1) + the always-visible ABC toggle at the right.
+     Background + top border live here so they span the full width including the toggle. */
+  .steer-row {
+    display: flex;
+    align-items: stretch;
+    min-width: 0;
+    background: var(--color-head);
+    border-top: 1px solid var(--color-line);
+  }
   .steer-bar {
+    flex: 1 1 auto;
     display: flex;
     gap: 4px;
     padding: 6px 10px;
-    background: var(--color-head);
-    border-top: 1px solid var(--color-line);
     overflow-x: auto;
     white-space: nowrap;
     min-width: 0;
@@ -235,20 +252,18 @@
     min-width: 44px;
     padding: 0;
   }
-  /* Labels toggle: a flat "ABC" key pinned to the bar's right edge. It rides along
-     while the chips scroll (sticky) and snaps to the far right when they don't fill
-     the row (margin-left:auto). Reuses the .chip box; the left shadow masks chips
-     sliding beneath the opaque key. */
+  /* Labels toggle: a flat "ABC" key at the row's far right, outside the scroll area
+     (its own flex column), so it's always visible and never distorts the chip bar's
+     measured width. Margins mirror the bar's padding so it lines up vertically. */
   .lbl-toggle {
-    position: sticky;
-    right: 0;
-    margin-left: auto;
+    flex: 0 0 auto;
+    align-self: center;
+    margin: 6px 10px;
     min-width: 44px;
     padding: 0;
     font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     color: var(--color-muted);
-    box-shadow: -10px 0 8px -4px var(--color-head);
   }
   .lbl-toggle[aria-pressed="true"] {
     color: var(--color-ink-bright);

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -32,6 +32,29 @@
     }
   }
 
+  // Labels toggle: in the cramped mobile bar the emoji chips collapse to icon-only
+  // (fitLabels' `compact`), and it's easy to forget what each glyph does. The
+  // right-anchored "ABC" key forces every chip's text label back on (overriding
+  // compaction) so the operator can read the bar, then collapse it again. Persisted
+  // per-device so the choice survives reloads. SSR-safe: stays off until mount.
+  const LABELS_KEY = "shepherd:steer-labels";
+  let showLabels = $state(false);
+  $effect(() => {
+    try {
+      if (localStorage.getItem(LABELS_KEY) === "1") showLabels = true;
+    } catch {
+      // private mode / blocked storage: default to icon-only
+    }
+  });
+  function toggleLabels() {
+    showLabels = !showLabels;
+    try {
+      localStorage.setItem(LABELS_KEY, showLabels ? "1" : "0");
+    } catch {
+      // ignore: best-effort persistence
+    }
+  }
+
   // Tap-vs-drag: the bar scrolls horizontally (overflow-x), so a finger that
   // lands on a chip and drags to scroll must NOT fire it. Arm on pointerdown,
   // disarm once the pointer moves past a small slop (it's a scroll) or when the
@@ -100,6 +123,7 @@
      label and the bar's horizontal scroll remains the final fallback. -->
 <div
   class="steer-bar"
+  class:show-labels={showLabels}
   role="toolbar"
   aria-label={m.steerbar_toolbar_aria()}
   data-swipe-ignore
@@ -132,6 +156,20 @@
       ></button
     >
   {/each}
+  <!-- Right-anchored labels toggle: stays pinned to the bar's right edge (sticky)
+       so it's reachable even when the chips scroll. Toggles every chip between
+       icon-only and icon+label. -->
+  <button
+    type="button"
+    class="chip lbl-toggle"
+    aria-pressed={showLabels}
+    title={showLabels ? m.steerbar_labels_hide() : m.steerbar_labels_show()}
+    aria-label={showLabels ? m.steerbar_labels_hide() : m.steerbar_labels_show()}
+    onpointerdown={down}
+    onpointermove={move}
+    onpointercancel={cancel}
+    onpointerup={(e) => tap(e, toggleLabels)}>ABC</button
+  >
 </div>
 
 <style>
@@ -186,15 +224,36 @@
   }
   /* compact (set by fitLabels on overflow): emoji-carrying chips shed their label —
      the emoji is the identifier; label-only chips are untouched. The broadcast chip
-     joins in, matching its existing mobile collapse. */
-  .steer-bar:global(.compact) .chip.has-emoji .chip-label,
-  .steer-bar:global(.compact) .bc-label {
+     joins in, matching its existing mobile collapse. The `:not(.show-labels)` guard
+     lets the ABC toggle force every label back on regardless of available width. */
+  .steer-bar:global(.compact):not(.show-labels) .chip.has-emoji .chip-label,
+  .steer-bar:global(.compact):not(.show-labels) .bc-label {
     display: none;
   }
-  .steer-bar:global(.compact) .chip.has-emoji,
-  .steer-bar:global(.compact) .chip.bc {
+  .steer-bar:global(.compact):not(.show-labels) .chip.has-emoji,
+  .steer-bar:global(.compact):not(.show-labels) .chip.bc {
     min-width: 44px;
     padding: 0;
+  }
+  /* Labels toggle: a flat "ABC" key pinned to the bar's right edge. It rides along
+     while the chips scroll (sticky) and snaps to the far right when they don't fill
+     the row (margin-left:auto). Reuses the .chip box; the left shadow masks chips
+     sliding beneath the opaque key. */
+  .lbl-toggle {
+    position: sticky;
+    right: 0;
+    margin-left: auto;
+    min-width: 44px;
+    padding: 0;
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    color: var(--color-muted);
+    box-shadow: -10px 0 8px -4px var(--color-head);
+  }
+  .lbl-toggle[aria-pressed="true"] {
+    color: var(--color-ink-bright);
+    border-color: var(--color-ink);
+    background: var(--color-hover);
   }
   /* on mobile the broadcast chip collapses to just its ⌁ icon to reclaim
      space; matches the ControlBar Esc key's box model (min-width 44px, no
@@ -208,13 +267,13 @@
      equal the Esc→Tab channel (3px Esc-well + 6px ctrl-row gap + 3px Tab-well =
      12px). The flex `gap` already gives 4px, so add the remaining 8px here. */
   @media (max-width: 768px) {
-    .chip.bc {
+    .steer-bar:not(.show-labels) .chip.bc {
       min-width: 44px;
       padding: 0;
       margin-left: 3px;
       margin-right: 8px;
     }
-    .bc-label {
+    .steer-bar:not(.show-labels) .bc-label {
       display: none;
     }
   }

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -439,4 +439,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_issue_actions_title",
     bodyKey: "feat_issue_actions_body",
   },
+  {
+    // No targetId: the toggle only mounts on the steer bar of a focused/selected
+    // session, and there can be several steer bars in the DOM at once, so a single
+    // coachmark anchor would be wrong — surface via the What's-New drawer only.
+    // v1.23.0 is already tagged, so this ships in the next release (1.24.0):
+    // computeNewEntries only surfaces entries with sinceVersion > lastSeen.
+    id: "steer-labels-toggle",
+    sinceVersion: "1.24.0",
+    titleKey: "feat_steer_labels_title",
+    bodyKey: "feat_steer_labels_body",
+  },
 ];


### PR DESCRIPTION
## What

Adds a right-anchored **\`ABC\`** toggle to the session steer bar. On the cramped mobile layout the emoji chips collapse to icon-only, and it's easy to forget what each glyph does. Tapping the toggle forces every chip's **text label** back on (overriding compaction); tapping again collapses to icons. The choice is remembered per device (localStorage).

Requested in voice: *"ganz rechts ein Icon, das rechts orientiert ist, ABC als Symbol hat … wenn man das drückt, werden die Texte statt der Symbole angezeigt … eine Hilfe, um in der extrem kompakten mobilen Ansicht den Überblick zu behalten."*

## How

- New `.lbl-toggle` button, `position: sticky; right: 0` so it stays pinned to the bar's right edge even while the chips scroll, and `margin-left: auto` so it snaps to the far right when they don't fill the row.
- Compaction CSS (and the mobile broadcast-chip collapse) is gated behind `:not(.show-labels)`, so forcing labels on wins regardless of available width — the bar simply scrolls horizontally to read them.
- Reuses the existing tap-vs-drag pointer handling, so the toggle doesn't blur the terminal / dismiss the mobile soft keyboard.
- On-token throughout (`--color-*`, `--fs-meta`); no literals.

## i18n / discovery

- `steerbar_labels_show` / `steerbar_labels_hide` added to EN + DE (`check:i18n` green).
- Feature-catalog entry `steer-labels-toggle` (ships in **1.24.0**) + `feat_steer_labels_*` keys.

## Tests

- New `SteerBar.browser.test.ts`: default-off, toggle-on reveals labels + persists + flips `aria-pressed`, and starts-on when persisted. All green.
- `bun run check`, `check:i18n`, and pre-push (branch-hygiene + feature-catalog) pass.