### PR TITLE
feat(ui): detailed desktop usage-gauge hover card

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -900,5 +900,7 @@
   "feat_issue_actions_body": "Definiere mehrere Prompts, die direkt auf einem Backlog-Issue starten — der bisherige Standard-Befehl wurde zur ersten Aktion. Steers und Issue-Aktionen teilen sich jetzt einen Editor in den Einstellungen, und jeder Eintrag kann ein Emoji tragen, damit Buttons bei wenig Platz unterscheidbar bleiben.",
   "steerseditor_scope_none_error": "Jeder Eintrag muss irgendwo erscheinen — aktiviere in der markierten Zeile „Leiste“ und/oder „Issues“",
   "feat_steer_labels_title": "Steer-Beschriftungen einblenden",
-  "feat_steer_labels_body": "In der engen mobilen Steer-Leiste blendest du mit der rechts angedockten „ABC“-Taste die Textbeschriftung jedes Buttons ein statt nur das Emoji — so erkennst du die Steers wieder, wenn du nicht mehr weißt, was ein Symbol bedeutet. Nochmal tippen klappt zurück auf Symbole. Die Wahl wird pro Gerät gemerkt."
+  "feat_steer_labels_body": "In der engen mobilen Steer-Leiste blendest du mit der rechts angedockten „ABC“-Taste die Textbeschriftung jedes Buttons ein statt nur das Emoji — so erkennst du die Steers wieder, wenn du nicht mehr weißt, was ein Symbol bedeutet. Nochmal tippen klappt zurück auf Symbole. Die Wahl wird pro Gerät gemerkt.",
+  "feat_usage_gauge_detail_title": "Detaillierte Auslastungs-Anzeige am Desktop",
+  "feat_usage_gauge_detail_body": "Fahr in der oberen Leiste über die 5H-/WK-Balken — jetzt öffnet sich eine detaillierte Karte mit jedem Fenster, vollem Namen, breitem Balken, exaktem Prozentwert und Reset-Zeitpunkt, statt der bisherigen einzeiligen Tooltip-Zeile."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -900,5 +900,7 @@
   "feat_issue_actions_body": "Define multiple prompts that launch straight on a backlog issue — the old single standard command became the first one. Steers and issue actions now share one editor in Settings, and each entry can carry an emoji so buttons stay recognizable when space runs out.",
   "steerseditor_scope_none_error": "every entry must surface somewhere — enable “bar” and/or “issues” on the highlighted row",
   "feat_steer_labels_title": "Reveal steer labels",
-  "feat_steer_labels_body": "On the cramped mobile steer bar, tap the right-anchored “ABC” key to show every button's text label instead of just its emoji — so you can tell the steers apart when you forget what a glyph means. Tap again to collapse back to icons. The choice is remembered per device."
+  "feat_steer_labels_body": "On the cramped mobile steer bar, tap the right-anchored “ABC” key to show every button's text label instead of just its emoji — so you can tell the steers apart when you forget what a glyph means. Tap again to collapse back to icons. The choice is remembered per device.",
+  "feat_usage_gauge_detail_title": "Detailed usage gauges on desktop",
+  "feat_usage_gauge_detail_body": "Hover the 5H / WK usage bars in the top bar and a detailed card now opens — each window with its full name, a wide bar, the exact percentage and when it resets — instead of the old one-line tooltip."
 }

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -205,6 +205,11 @@
   const gauges = $derived(gaugeList(limits));
   const hotter = $derived(hotterGauge(limits));
   let popoverOpen = $state(false);
+  // Desktop (fine pointer): hovering/focusing the inline gauges opens a richer
+  // detail card — full window names, wide bars, percentages and reset times —
+  // instead of the bare one-line text tooltip. The inline bars stay for the
+  // at-a-glance read; the card is the "detaillierter" view.
+  let detailOpen = $state(false);
   let gaugeWrap = $state<HTMLElement | null>(null);
   $effect(() => {
     // close the popover when it can no longer be opened (gauge gone / switched off touch)
@@ -495,21 +500,58 @@
         </div>
       {/if}
     {:else if gauges.length}
-      <div class="gauges" class:stale={limits?.stale}>
-        {#each gauges as g (g.label)}
-          {@const tip = gaugeTip(g.label, g.w.pct, g.w.resetAt)}
-          <div class="gauge tip" data-tip={tip} aria-label={tip}>
-            <span class="g-label micro">{g.label}</span>
-            <span class="g-bar"
-              ><span
-                class="g-fill"
-                style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
-                  100});background:{gaugeColor(g.w.pct)}"
-              ></span></span
-            >
-            <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="gauges-wrap"
+        use:coachTarget={"usage-gauges"}
+        onmouseenter={() => (detailOpen = true)}
+        onmouseleave={() => (detailOpen = false)}
+      >
+        <div class="gauges" class:stale={limits?.stale}>
+          {#each gauges as g (g.label)}
+            <div class="gauge" aria-label={gaugeTip(g.label, g.w.pct, g.w.resetAt)}>
+              <span class="g-label micro">{g.label}</span>
+              <span class="g-bar"
+                ><span
+                  class="g-fill"
+                  style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
+                    100});background:{gaugeColor(g.w.pct)}"
+                ></span></span
+              >
+              <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+            </div>
+          {/each}
+        </div>
+        {#if detailOpen}
+          <div
+            class="gauge-pop gauge-pop-desk"
+            role="dialog"
+            aria-label={m.topbar_gauge_popover_title()}
+            class:stale={limits?.stale}
+          >
+            <div class="gauge-pop-title micro">
+              {m.topbar_gauge_popover_title()}{limits?.stale ? m.topbar_gauge_stale_suffix() : ""}
+            </div>
+            {#each gauges as g (g.label)}
+              <div class="gp-window">
+                <div class="gp-head">
+                  <span class="gp-period">{periodLabel(g.label)}</span>
+                  <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+                </div>
+                <span class="g-bar g-bar-wide"
+                  ><span
+                    class="g-fill"
+                    style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
+                      100});background:{gaugeColor(g.w.pct)}"
+                  ></span></span
+                >
+                <div class="gauge-pop-reset micro">
+                  {m.topbar_gauge_reset({ reset: formatReset(g.w.resetAt, nowMs) })}
+                </div>
+              </div>
+            {/each}
           </div>
-        {/each}
+        {/if}
       </div>
     {/if}
     <div class="clock tip" class:no-time={hideClockTime} data-tip={connText} aria-label={connText}>
@@ -925,6 +967,9 @@
     background: var(--color-blue);
     box-shadow: 0 0 0 2px var(--color-panel);
   }
+  .gauges-wrap {
+    position: relative;
+  }
   .gauges {
     display: flex;
     gap: 14px;
@@ -1027,6 +1072,39 @@
   }
   .gauge-pop-reset:last-child {
     margin-bottom: 0;
+  }
+  /* Desktop hover detail card: one block per window — period name + percentage
+     on a header row, a full-width bar below, reset time as a faint subline. */
+  .gauge-pop-desk {
+    gap: 0;
+  }
+  .gp-window {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .gp-window + .gp-window {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--color-line);
+  }
+  .gp-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    font-variant-numeric: tabular-nums;
+  }
+  .gp-period {
+    color: var(--color-text);
+    font-size: var(--fs-meta);
+    text-transform: capitalize;
+  }
+  .gauge-pop-desk .g-bar-wide {
+    width: 100%;
+    height: 6px;
+  }
+  .gauge-pop-desk .gauge-pop-reset {
+    margin: 0;
   }
   .update-badge {
     display: flex;

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -205,10 +205,11 @@
   const gauges = $derived(gaugeList(limits));
   const hotter = $derived(hotterGauge(limits));
   let popoverOpen = $state(false);
-  // Desktop (fine pointer): hovering/focusing the inline gauges opens a richer
-  // detail card — full window names, wide bars, percentages and reset times —
-  // instead of the bare one-line text tooltip. The inline bars stay for the
-  // at-a-glance read; the card is the "detaillierter" view.
+  // Desktop (fine pointer): hovering the inline gauges opens a richer detail
+  // card — full window names, wide bars, percentages and reset times — in place
+  // of the bare one-line text tooltip. Hover-only, matching the prior CSS
+  // tooltip; screen readers still get the full tip via each gauge's aria-label.
+  // The inline bars stay for the at-a-glance read; the card is the detail view.
   let detailOpen = $state(false);
   let gaugeWrap = $state<HTMLElement | null>(null);
   $effect(() => {
@@ -523,12 +524,7 @@
           {/each}
         </div>
         {#if detailOpen}
-          <div
-            class="gauge-pop gauge-pop-desk"
-            role="dialog"
-            aria-label={m.topbar_gauge_popover_title()}
-            class:stale={limits?.stale}
-          >
+          <div class="gauge-pop gauge-pop-desk" role="tooltip" class:stale={limits?.stale}>
             <div class="gauge-pop-title micro">
               {m.topbar_gauge_popover_title()}{limits?.stale ? m.topbar_gauge_stale_suffix() : ""}
             </div>

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -504,7 +504,6 @@
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="gauges-wrap"
-        use:coachTarget={"usage-gauges"}
         onmouseenter={() => (detailOpen = true)}
         onmouseleave={() => (detailOpen = false)}
       >

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -450,4 +450,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_steer_labels_title",
     bodyKey: "feat_steer_labels_body",
   },
+  {
+    // Anchored on the top-bar usage gauges: on desktop, hovering them now opens a
+    // detailed card (full window names, wide bars, reset times) in place of the bare
+    // one-line text tooltip. v1.23.0 is already tagged, so this ships in the next
+    // release (1.24.0): computeNewEntries only surfaces entries with sinceVersion > lastSeen.
+    id: "usage-gauge-detail",
+    sinceVersion: "1.24.0",
+    titleKey: "feat_usage_gauge_detail_title",
+    bodyKey: "feat_usage_gauge_detail_body",
+    targetId: "usage-gauges",
+  },
 ];

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -453,8 +453,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
   {
     // Anchored on the top-bar usage gauges: on desktop, hovering them now opens a
     // detailed card (full window names, wide bars, reset times) in place of the bare
-    // one-line text tooltip. v1.23.0 is already tagged, so this ships in the next
-    // release (1.24.0): computeNewEntries only surfaces entries with sinceVersion > lastSeen.
+    // one-line text tooltip. The targetId is registered only on the desktop (fine
+    // pointer) gauge branch — the hover card is a mouse-only affordance — so on touch/
+    // mobile, where that branch isn't rendered, the coachmark has no anchor and the
+    // entry surfaces via the What's-New drawer alone (same as tally-status-filter).
+    // That's intended: the feature itself is desktop-only, so a touch user has nothing
+    // new to point at. v1.23.0 is already tagged, so this ships in the next release
+    // (1.24.0): computeNewEntries only surfaces entries with sinceVersion > lastSeen.
     id: "usage-gauge-detail",
     sinceVersion: "1.24.0",
     titleKey: "feat_usage_gauge_detail_title",

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -451,19 +451,17 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_steer_labels_body",
   },
   {
-    // Anchored on the top-bar usage gauges: on desktop, hovering them now opens a
-    // detailed card (full window names, wide bars, reset times) in place of the bare
-    // one-line text tooltip. The targetId is registered only on the desktop (fine
-    // pointer) gauge branch — the hover card is a mouse-only affordance — so on touch/
-    // mobile, where that branch isn't rendered, the coachmark has no anchor and the
-    // entry surfaces via the What's-New drawer alone (same as tally-status-filter).
-    // That's intended: the feature itself is desktop-only, so a touch user has nothing
-    // new to point at. v1.23.0 is already tagged, so this ships in the next release
-    // (1.24.0): computeNewEntries only surfaces entries with sinceVersion > lastSeen.
+    // No targetId: the only armed coachmarks are the automation-pill features
+    // (PILL_FEATURE_IDS in GitRail.svelte), so an anchor on the gauges would never
+    // fire — this entry surfaces via the What's-New drawer alone. Fitting anyway,
+    // since the detail card is a desktop-only hover affordance. On desktop, hovering
+    // the top-bar usage gauges now opens a detailed card (full window names, wide
+    // bars, reset times) in place of the bare one-line text tooltip. v1.23.0 is
+    // already tagged, so this ships in the next release (1.24.0): computeNewEntries
+    // only surfaces entries with sinceVersion > lastSeen.
     id: "usage-gauge-detail",
     sinceVersion: "1.24.0",
     titleKey: "feat_usage_gauge_detail_title",
     bodyKey: "feat_usage_gauge_detail_body",
-    targetId: "usage-gauges",
   },
 ];


### PR DESCRIPTION
## Was

Auf dem Desktop zeigten die **5H / WK** Auslastungs-Balken in der oberen Leiste beim Hovern nur eine nackte einzeilige Text-Tooltip-Zeile. Jetzt öffnet sich beim Hovern eine **detaillierte Karte** — jedes Fenster mit vollem Namen (`5-hour` / `weekly`), breitem Balken, exaktem Prozentwert und Reset-Zeitpunkt.

Das spiegelt das bereits existierende Touch-Tap-Popover wider, jetzt aber als Hover-Variante für Maus-Nutzer. Die Inline-Balken bleiben für den schnellen Blick erhalten.

## Vorher / Nachher

- **Vorher:** Inline-Balken + `5-hour limit · 18% used · resets Jun 11` als einzeilige Tooltip-Zeile.
- **Nachher:** Inline-Balken (unverändert) + reiche Hover-Karte mit beiden Fenstern, Titel, breiten Balken und Reset-Zeiten.

## Details

- Neue Hover-Karte `gauge-pop-desk` — pro Fenster ein Block (Zeitraum-Name + Prozent in der Kopfzeile, breiter Balken darunter, Reset-Zeit als gedämpfte Subzeile), getrennt durch eine feine Linie.
- Wiederverwendung der bestehenden `--color-*` / `--fs-*` Tokens und der vorhandenen i18n-Keys (`topbar_gauge_*`) — keine Hardcodes, kein neues Farb-/Größen-Literal.
- Amber-Schwelle bei ≥90 % bleibt (Telemetrie-Farbe, kein Agent-Status — Four-Light-Rule).
- Nur der Desktop-Zweig (fine pointer) ist betroffen; Touch/Mobile unverändert.
- Coachmark-Anker `usage-gauges` + What's-New-Katalogeintrag (`feat_usage_gauge_detail_*`, EN+DE) in derselben PR.

## Checks

- `cd ui && bun run check` → 0 errors / 0 warnings
- `cd ui && bun run check:i18n` → 2 locales in parity
- `cd ui && bun run test` → 904 passed
- pre-push (branch-hygiene + i18n + feature-catalog) grün