### PR TITLE
feat(usage): persist per-reviewer-spawn records for exact token attribution (#518)

### DIFF
--- a/scripts/usage-report.ts
+++ b/scripts/usage-report.ts
@@ -27,7 +27,7 @@ import { config } from "../src/config";
 
 // ── DB shape ────────────────────────────────────────────────────────────────
 
-interface SessionRow {
+export interface SessionRow {
   id: string;
   desig: string;
   name: string;
@@ -44,13 +44,18 @@ interface SessionRow {
   status: string | null;
 }
 
-interface ReviewRow {
+export interface ReviewRow {
   sessionId: string;
   headSha: string | null;
 }
 
-interface PlanGateRow {
+export interface PlanGateRow {
   sessionId: string;
+}
+
+export interface ReviewSpawnRow {
+  sessionId: string;
+  reviewerSessionId: string;
 }
 
 // ── CLI ───────────────────────────────────────────────────────────────────--
@@ -207,7 +212,7 @@ async function inWorktreeAncillary(
 
 // ── satellite (critic + plan-review) attribution ───────────────────────────---
 
-type LinkTag = "db" | "content" | "sha-confirmed";
+type LinkTag = "spawn" | "db" | "content" | "sha-confirmed";
 
 interface SatelliteDir {
   /** dashified project dir name under ~/.claude/projects */
@@ -218,6 +223,8 @@ interface SatelliteDir {
   embeddedSessionId: string | null;
   sha8: string;
   mtime: number;
+  /** `.jsonl` basenames in the dir (the reviewer session ids) */
+  jsonlIds: string[];
 }
 
 const REVIEW_MARK = "-review-";
@@ -236,9 +243,13 @@ function enumerateReviewDirs(): SatelliteDir[] {
   for (const dir of names) {
     const path = join(base, dir);
     let mtime: number;
+    let jsonlIds: string[];
     try {
       if (!statSync(path).isDirectory()) continue;
       mtime = newestJsonlMtime(path);
+      jsonlIds = readdirSync(path)
+        .filter((f) => f.endsWith(".jsonl"))
+        .map((f) => f.slice(0, -".jsonl".length));
     } catch {
       continue;
     }
@@ -251,6 +262,7 @@ function enumerateReviewDirs(): SatelliteDir[] {
       embeddedSessionId: uuidMatch ? uuidMatch[0] : null,
       sha8: shaMatch ? shaMatch[1]! : "",
       mtime,
+      jsonlIds,
     });
   }
   return out;
@@ -343,10 +355,11 @@ interface SatelliteResult {
  * The critic re-runs per reviewed head, so a task owns MULTIPLE critic dirs — all summed.
  * Residual: any review dir matching no task whose mtime lands in a task's [createdAt, end].
  */
-async function attributeSatellites(
+export async function attributeSatellites(
   sessions: ResolvedSession[],
   reviews: ReviewRow[],
   planGates: PlanGateRow[],
+  spawns: ReviewSpawnRow[],
 ): Promise<SatelliteResult> {
   const bySession = new Map<string, SatelliteTranscript[]>();
   const add = (sid: string, sat: SatelliteTranscript) => {
@@ -358,6 +371,20 @@ async function attributeSatellites(
   const dirs = enumerateReviewDirs();
   const consumed = new Set<string>(); // dir names already linked
   const byId = new Map(sessions.map((s) => [s.row.id, s]));
+
+  // 0. exact link: a stored per-spawn record names the reviewer's session id, which is the
+  //    dir's transcript .jsonl basename — authoritative, survives session archival.
+  const spawnByReviewer = new Map(
+    spawns.filter((s) => byId.has(s.sessionId)).map((s) => [s.reviewerSessionId, s]),
+  );
+  for (const d of dirs) {
+    if (consumed.has(d.dir)) continue;
+    const hit = d.jsonlIds.map((id) => spawnByReviewer.get(id)).find(Boolean);
+    if (!hit) continue;
+    const tc = await costReviewDir(d.path);
+    add(hit.sessionId, { dir: d.dir, tag: "spawn", ...tc });
+    consumed.add(d.dir);
+  }
 
   // 1. DB-first: a reviews/plan_gates row makes that session's matching dirs authoritative.
   //    (headSha is persisted on reviews; we match a review dir whose sha8 prefixes it.)
@@ -467,7 +494,7 @@ function shaBelongsToRepo(
 
 // ── session resolution ──────────────────────────────────────────────────────
 
-interface ResolvedSession {
+export interface ResolvedSession {
   row: SessionRow;
   authoring: TranscriptCost;
   ancillary: AncillaryTranscript[];
@@ -749,7 +776,7 @@ function renderPlainTable(rows: string[][]): string {
 const LEGEND = [
   "Legend:",
   "  Anc(p/r/u)  in-worktree ancillary transcripts: probe / resumed / unknown",
-  "  Sat tags    satellite linkage: db (DB row authoritative) / content (prompt+base or embedded UUID match) / sha-confirmed (sha8 found in repo)",
+  "  Sat tags    satellite linkage: spawn (exact per-spawn record) / db (DB row authoritative) / content (prompt+base or embedded UUID match) / sha-confirmed (sha8 found in repo)",
   "  ReviewMult  satellite cost-units ÷ authoring cost-units",
   "  *cost       RELATIVE per-Mtok cost-proxy (src/pricing.ts weightedUnits) — NOT dollars; only ratios are meaningful.",
   "  Out of scope: account-wide periodic distiller (/tmp/shepherd-distill-*) is not per-task and is never attributed here.",
@@ -790,9 +817,10 @@ async function buildGroup(
   rows: SessionRow[],
   reviews: ReviewRow[],
   planGates: PlanGateRow[],
+  spawns: ReviewSpawnRow[],
 ): Promise<{ reportRows: ReportRow[]; residual: SatelliteResult["residual"] }> {
   const resolved = await Promise.all(rows.map(resolveSession));
-  const sat = await attributeSatellites(resolved, reviews, planGates);
+  const sat = await attributeSatellites(resolved, reviews, planGates, spawns);
   const reportRows = resolved.map((s) => buildRow(s, sat.bySession.get(s.row.id) ?? []));
   return { reportRows, residual: sat.residual };
 }
@@ -803,6 +831,9 @@ async function main(): Promise<void> {
 
   const reviews = db.query<ReviewRow, []>("SELECT sessionId, headSha FROM reviews").all();
   const planGates = db.query<PlanGateRow, []>("SELECT sessionId FROM plan_gates").all();
+  const spawns = db
+    .query<ReviewSpawnRow, []>("SELECT sessionId, reviewerSessionId FROM review_spawns")
+    .all();
 
   let primary: SessionRow[];
   let title: string;
@@ -817,12 +848,12 @@ async function main(): Promise<void> {
     title = `Default sample (${DEFAULT_SAMPLE.join(", ")})`;
   }
 
-  const { reportRows, residual } = await buildGroup(primary, reviews, planGates);
+  const { reportRows, residual } = await buildGroup(primary, reviews, planGates, spawns);
   const out: string[] = [render(title, reportRows, residual, args.md)];
 
   if (args.includeExcluded) {
     const excluded = fetchExcluded(db, args.recent ?? 5);
-    const eg = await buildGroup(excluded, reviews, planGates);
+    const eg = await buildGroup(excluded, reviews, planGates, spawns);
     out.push("");
     out.push(
       render("Appendix: excluded operational archetypes", eg.reportRows, eg.residual, args.md),

--- a/src/index.ts
+++ b/src/index.ts
@@ -656,6 +656,7 @@ const runDailySweep = () => {
       keepNewest: SESSION_RETENTION_KEEP,
     });
   store.pruneSignals(Date.now() - 60 * 24 * 60 * 60 * 1000);
+  store.pruneReviewSpawns(Date.now() - 60 * 24 * 60 * 60 * 1000);
   for (const repo of listRepos(config.repoRoot)) distiller.consider(repo.path);
 };
 setTimeout(runDailySweep, 10_000); // once shortly after boot

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -53,12 +53,6 @@ export function planReviewPrompt(task: string, plan: string, priorFindings: stri
   return lines.join("\n");
 }
 
-/** The read-only plan reviewer's argv — the PR critic's exact hardening, shared via one builder
- *  (the plan text is UNTRUSTED, so it gets the same injection-contained sandbox). */
-export function reviewerArgv(model: string | null, prompt: string): string[] {
-  return readonlyReviewerArgv(model, prompt).argv;
-}
-
 // How long an in-flight plan review may run before tick() (Task 6) gives up on the verdict.
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_CAP = 5;
@@ -82,6 +76,7 @@ export interface PlanGateServiceDeps {
     | "getRepoConfig"
     | "addSignal"
     | "get"
+    | "recordReviewSpawn"
   >;
   herdr: Pick<HerdrDriver, "start" | "stop">;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove">;
@@ -214,7 +209,10 @@ export class PlanGateService {
     }
 
     const prompt = planReviewPrompt(session.prompt, plan, prior?.findings ?? []);
-    const argv = reviewerArgv(this.deps.model ?? null, prompt);
+    const { argv, sessionId: reviewerSessionId } = readonlyReviewerArgv(
+      this.deps.model ?? null,
+      prompt,
+    );
     let terminalId: string;
     try {
       terminalId = this.deps.herdr.start(
@@ -226,6 +224,17 @@ export class PlanGateService {
       console.warn(`[plan-gate] spawn failed for ${session.id}:`, err);
       this.deps.worktree.remove(wt.worktreePath);
       return "error";
+    }
+    // fail-open: the reviewer terminal is already running; a record failure must not
+    // skip inflight.set below (that would orphan the terminal — untracked, never reaped).
+    try {
+      this.deps.store.recordReviewSpawn({
+        sessionId: session.id,
+        reviewerSessionId,
+        startedAt: this.now(),
+      });
+    } catch (err) {
+      console.warn(`[plan-gate] spawn-record failed for ${session.id}:`, err);
     }
     this.inflight.set(session.id, {
       sessionId: session.id,

--- a/src/review.ts
+++ b/src/review.ts
@@ -109,6 +109,7 @@ export interface ReviewServiceDeps {
     | "dropReview"
     | "snapshotReviews"
     | "addSignal"
+    | "recordReviewSpawn"
   >;
   herdr: Pick<HerdrDriver, "start" | "stop">;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove">;
@@ -257,6 +258,17 @@ export class ReviewService {
       console.warn(`[review] spawn failed for ${session.id}:`, err);
       this.deps.worktree.remove(wt.worktreePath);
       return;
+    }
+    // fail-open: the critic terminal is already running; a record failure must not
+    // skip inflight.set below (that would orphan the terminal — untracked, never reaped).
+    try {
+      this.deps.store.recordReviewSpawn({
+        sessionId: session.id,
+        reviewerSessionId: criticSessionId,
+        startedAt: this.now(),
+      });
+    } catch (err) {
+      console.warn(`[review] spawn-record failed for ${session.id}:`, err);
     }
     this.inflight.set(session.id, {
       sessionId: session.id,

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,6 +4,7 @@ import type {
   Session,
   ReviewVerdict,
   PlanGate,
+  ReviewSpawn,
   Signal,
   SignalKind,
   Learning,
@@ -188,6 +189,16 @@ export class SessionStore implements CapStore {
       findings TEXT NOT NULL DEFAULT '[]', round INTEGER NOT NULL DEFAULT 0,
       cap INTEGER NOT NULL DEFAULT 3, approved INTEGER NOT NULL DEFAULT 0,
       plan TEXT NOT NULL DEFAULT '', updatedAt INTEGER NOT NULL)`);
+    // Append-only per-reviewer-spawn attribution log. DELIBERATELY NOT part of the
+    // pruneArchivedSessions cascade — it must survive session archival so usage
+    // reporting can link a reviewer transcript dir to its task after the fact.
+    // Pruned only by time via pruneReviewSpawns (see runDailySweep).
+    this.db.run(`CREATE TABLE IF NOT EXISTS review_spawns (
+      id TEXT PRIMARY KEY,
+      sessionId TEXT NOT NULL,
+      reviewerSessionId TEXT NOT NULL,
+      startedAt INTEGER NOT NULL)`);
+    this.db.run(`CREATE INDEX IF NOT EXISTS review_spawns_started ON review_spawns (startedAt)`);
     this.db.run(`CREATE TABLE IF NOT EXISTS signals (
       id TEXT PRIMARY KEY, repoPath TEXT NOT NULL, sessionId TEXT,
       kind TEXT NOT NULL, payload TEXT NOT NULL, ts INTEGER NOT NULL)`);
@@ -670,6 +681,18 @@ export class SessionStore implements CapStore {
     this.db.run(`DELETE FROM reviews WHERE sessionId = ?`, [sessionId]);
   }
 
+  // ── reviewer-spawn attribution log ──────────────────────────────────────────
+  recordReviewSpawn(s: ReviewSpawn): void {
+    this.db.run(
+      `INSERT INTO review_spawns (id, sessionId, reviewerSessionId, startedAt) VALUES (?,?,?,?)`,
+      [randomUUID(), s.sessionId, s.reviewerSessionId, s.startedAt],
+    );
+  }
+
+  pruneReviewSpawns(beforeTs: number): void {
+    this.db.run(`DELETE FROM review_spawns WHERE startedAt < ?`, [beforeTs]);
+  }
+
   /** Re-point an existing verdict at a new head without re-reviewing. Used when a head
    *  change (rebase/force-push) leaves the reviewed diff content-identical (same patchId):
    *  the prior decision/findings/rounds still apply, so only headSha + updatedAt move. */
@@ -840,6 +863,8 @@ export class SessionStore implements CapStore {
       if (n === 0) return 0;
       // reviews first (keyed by sessionId) so the cascade can't orphan; the sessions
       // subquery still resolves the same set afterward (deleting reviews doesn't touch it).
+      // NOTE: review_spawns is intentionally NOT deleted here — it is cascade-exempt /
+      // append-only audit; pruned independently by time via pruneReviewSpawns.
       this.db.run(
         `DELETE FROM reviews WHERE sessionId IN (SELECT id FROM sessions WHERE ${victims})`,
         params,

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,6 +192,13 @@ export interface ReviewVerdict {
   updatedAt: number;
 }
 
+// ── per-reviewer-spawn attribution log ──────────────────────────────────────
+export interface ReviewSpawn {
+  sessionId: string; // parent task session (the link target)
+  reviewerSessionId: string; // spawned reviewer's claude --session-id (== transcript .jsonl basename)
+  startedAt: number; // spawn time (epoch ms); consumed by pruneReviewSpawns
+}
+
 // ── autopilot mode ──────────────────────────────────────────────────────────
 export type AutopilotKind = "gate" | "question" | "finished" | "complete" | "unknown";
 

--- a/test/plan-gate-prompt.test.ts
+++ b/test/plan-gate-prompt.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { planReviewPrompt, reviewerArgv, PLAN_VERDICT_FILE } from "../src/plan-gate";
+import { planReviewPrompt, PLAN_VERDICT_FILE } from "../src/plan-gate";
+import { readonlyReviewerArgv } from "../src/reviewer-argv";
 
 test("prompt embeds task + plan + prior findings + verdict file + read-only", () => {
   const p = planReviewPrompt("do X", "PLAN TEXT", ["earlier nit"]);
@@ -13,8 +14,8 @@ test("prompt without prior findings omits the re-review block", () => {
   const p = planReviewPrompt("do X", "PLAN TEXT");
   expect(p).not.toContain("RE-REVIEW");
 });
-test("reviewerArgv mirrors critic hardening: dontAsk last, no --bare, disableAllHooks, slash disabled", () => {
-  const a = reviewerArgv(null, "PROMPT");
+test("readonlyReviewerArgv mirrors critic hardening: dontAsk last, no --bare, disableAllHooks, slash disabled", () => {
+  const a = readonlyReviewerArgv(null, "PROMPT").argv;
   expect(a).not.toContain("--bare");
   expect(a).toContain("--disable-slash-commands");
   expect(a.join(" ")).toContain('{"disableAllHooks":true}');
@@ -28,8 +29,8 @@ test("reviewerArgv mirrors critic hardening: dontAsk last, no --bare, disableAll
   expect(a).toContain("--safe-mode");
   expect(a.indexOf("--safe-mode")).toBeLessThan(a.indexOf("--allowedTools"));
 });
-test("reviewerArgv inserts --model when given", () => {
-  const a = reviewerArgv("opus", "PROMPT");
+test("readonlyReviewerArgv inserts --model when given", () => {
+  const a = readonlyReviewerArgv("opus", "PROMPT").argv;
   const mi = a.indexOf("--model");
   expect(mi).toBeGreaterThan(-1);
   expect(a[mi + 1]).toBe("opus");

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -4,6 +4,7 @@ import { PlanGateService } from "../src/plan-gate";
 function harness(over: any = {}) {
   const started: any[] = [];
   const removed: string[] = [];
+  const spawnRecords: any[] = [];
   const overWithoutStore = { ...over };
   delete overWithoutStore.store;
   const store = {
@@ -17,6 +18,9 @@ function harness(over: any = {}) {
     addSignal() {},
     setPlanPhase() {},
     get: () => ({ id: "s1", auto: false }),
+    recordReviewSpawn(r: any) {
+      spawnRecords.push(r);
+    },
     ...(over.store ?? {}),
   };
   const deps: any = {
@@ -45,7 +49,7 @@ function harness(over: any = {}) {
     // deps-level spread doesn't re-overwrite it with the un-merged per-test partial.
     ...overWithoutStore,
   };
-  return { deps, started, removed, store, svc: new PlanGateService(deps) };
+  return { deps, started, removed, store, spawnRecords, svc: new PlanGateService(deps) };
 }
 
 const planningSession = () => ({
@@ -65,6 +69,19 @@ test("consider spawns reviewer when a plan exists and is unreviewed", async () =
   expect(h.started.length).toBe(1);
   expect(h.started[0].argv[h.started[0].argv.length - 1]).toContain("PLAN TEXT");
   expect(h.svc.reviewingIds()).toEqual(["s1"]);
+});
+test("recordReviewSpawn called once with matching sessionId and reviewerSessionId", async () => {
+  const h = harness();
+  await h.svc.consider(planningSession() as any);
+  expect(h.spawnRecords.length).toBe(1);
+  const rec = h.spawnRecords[0];
+  expect(rec.sessionId).toBe("s1");
+  // reviewerSessionId must match the --session-id embedded in the argv passed to herdr.start
+  const argv: string[] = h.started[0].argv;
+  const sidIdx = argv.indexOf("--session-id");
+  expect(sidIdx).toBeGreaterThan(-1);
+  expect(rec.reviewerSessionId).toBe(argv[sidIdx + 1]);
+  expect(rec.startedAt).toBe(1000); // matches the fake now()
 });
 test("consider no-ops when plan missing/empty", async () => {
   const h = harness({ readPlan: () => null });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -98,6 +98,7 @@ function makeDeps(
   const steers: { id: string; text: string }[] = [];
   const signals: { kind: string; payload: string }[] = [];
   const commentCalls: number[] = []; // prNumbers passed to listPrComments
+  const spawnRecords: { sessionId: string; reviewerSessionId: string; startedAt: number }[] = [];
   const rec: { event?: string; body?: string } = {};
   const base = {
     store: {
@@ -119,6 +120,13 @@ function makeDeps(
       },
       snapshotReviews: () => reviews,
       addSignal: (s: { kind: string; payload: string }) => signals.push(s),
+      recordReviewSpawn: (s: {
+        sessionId: string;
+        reviewerSessionId: string;
+        startedAt: number;
+      }) => {
+        spawnRecords.push(s);
+      },
     },
     herdr: {
       start: (name: string, cwd: string, argv: string[]) => {
@@ -151,6 +159,7 @@ function makeDeps(
     steers,
     signals,
     commentCalls,
+    spawnRecords,
     rec,
   };
 }
@@ -1039,4 +1048,49 @@ test("an error verdict does not consume freshly-fetched author notes (re-inject 
   expect(reviews["s1"]?.decision).toBe("error");
   // the errored critic never produced a verdict on c9, so it must NOT be marked seen
   expect(reviews["s1"]?.seenNoteIds).toEqual([]);
+});
+
+// ── recordReviewSpawn (token attribution) ────────────────────────────────────
+
+test("recordReviewSpawn called once with correct sessionId and reviewerSessionId", async () => {
+  const { deps: d, started, spawnRecords } = makeDeps({});
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  // critic was spawned
+  expect(started).toHaveLength(1);
+  expect(spawnRecords).toHaveLength(1);
+  // sessionId must match the task session
+  expect(spawnRecords[0]!.sessionId).toBe("s1");
+  // reviewerSessionId must match the --session-id flag in the critic argv
+  const argv = started[0]!.argv;
+  const criticSessionId = argv[argv.indexOf("--session-id") + 1]!;
+  expect(spawnRecords[0]!.reviewerSessionId).toBe(criticSessionId);
+  // startedAt must be the injected now() value
+  expect(spawnRecords[0]!.startedAt).toBe(1000);
+});
+
+test("recordReviewSpawn throwing does not abort begin(): inflight set, onReviewing fires", async () => {
+  const events: { id: string; reviewing: boolean }[] = [];
+  const { deps: d, started } = makeDeps({
+    onReviewing: (id: string, reviewing: boolean) => events.push({ id, reviewing }),
+  });
+  // override store.recordReviewSpawn to throw
+  d.store.recordReviewSpawn = () => {
+    throw new Error("db write failed");
+  };
+  const svc = new ReviewService(d as any);
+  // must not throw
+  await svc.consider(session(), OPEN_GREEN);
+  // critic was still spawned
+  expect(started).toHaveLength(1);
+  // onReviewing(true) still fired → session is tracked in inflight
+  expect(events).toEqual([{ id: "s1", reviewing: true }]);
+  // finalize completes normally
+  await svc.tick();
+  expect(events).toEqual([
+    { id: "s1", reviewing: true },
+    { id: "s1", reviewing: false },
+  ]);
+  // nothing left in-flight
+  expect(svc.reviewingIds()).toEqual([]);
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -512,3 +512,66 @@ test("desig: seed from pre-existing DB high-water mark", () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// ── review_spawns ────────────────────────────────────────────────────────────
+
+test("review_spawns: recordReviewSpawn persists a row readable via raw DB", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-spawn-persist-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    const store = new SessionStore(dbPath);
+    store.recordReviewSpawn({
+      sessionId: "sess-1",
+      reviewerSessionId: "rev-abc",
+      startedAt: 1_000_000,
+    });
+    const raw = new Database(dbPath);
+    const row = raw
+      .query(`SELECT sessionId, reviewerSessionId, startedAt FROM review_spawns`)
+      .get() as { sessionId: string; reviewerSessionId: string; startedAt: number } | null;
+    raw.close();
+    expect(row).not.toBeNull();
+    expect(row!.sessionId).toBe("sess-1");
+    expect(row!.reviewerSessionId).toBe("rev-abc");
+    expect(row!.startedAt).toBe(1_000_000);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("review_spawns: cascade-exempt — pruneArchivedSessions removes session but keeps spawn", async () => {
+  const s = mk();
+  const session = s.create(base);
+  s.archive(session.id);
+  await sleep(5);
+  s.recordReviewSpawn({
+    sessionId: session.id,
+    reviewerSessionId: "rev-xyz",
+    startedAt: Date.now(),
+  });
+  // aggressive prune: evict all archived sessions
+  const removed = s.pruneArchivedSessions({ maxAgeMs: 1, keepNewest: 0 });
+  expect(removed).toBeGreaterThanOrEqual(1);
+  expect(s.get(session.id)).toBeNull(); // session gone
+  // spawn row must survive (raw query — no store reader method)
+  const raw = (s as any).db as import("bun:sqlite").Database;
+  const row = raw
+    .query(`SELECT reviewerSessionId FROM review_spawns WHERE sessionId = ?`)
+    .get(session.id) as { reviewerSessionId: string } | null;
+  expect(row).not.toBeNull();
+  expect(row!.reviewerSessionId).toBe("rev-xyz");
+});
+
+test("review_spawns: pruneReviewSpawns deletes old rows, keeps recent", () => {
+  const s = mk();
+  const cutoff = 5_000;
+  s.recordReviewSpawn({ sessionId: "s1", reviewerSessionId: "rev-old", startedAt: 1_000 });
+  s.recordReviewSpawn({ sessionId: "s2", reviewerSessionId: "rev-new", startedAt: 9_000 });
+  s.pruneReviewSpawns(cutoff);
+  const raw = (s as any).db as import("bun:sqlite").Database;
+  const rows = raw
+    .query(`SELECT reviewerSessionId FROM review_spawns ORDER BY startedAt`)
+    .all() as { reviewerSessionId: string }[];
+  expect(rows.length).toBe(1);
+  expect(rows[0]!.reviewerSessionId).toBe("rev-new");
+});

--- a/test/usage-report.test.ts
+++ b/test/usage-report.test.ts
@@ -1,0 +1,129 @@
+import { test, expect, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { config } from "../src/config";
+import {
+  attributeSatellites,
+  type ResolvedSession,
+  type ReviewRow,
+  type PlanGateRow,
+  type ReviewSpawnRow,
+  type SessionRow,
+} from "../scripts/usage-report";
+
+/** One assistant usage line so cost-units are non-zero for the review dir. */
+function usageLine(): string {
+  return JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-06-10T09:00:00.000Z",
+    requestId: "req-1",
+    message: {
+      model: "claude-opus-4-8",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 10,
+        cache_creation: { ephemeral_5m_input_tokens: 5, ephemeral_1h_input_tokens: 0 },
+      },
+    },
+  });
+}
+
+function makeSession(id: string): ResolvedSession {
+  const row: SessionRow = {
+    id,
+    desig: "TASK-001",
+    name: "test",
+    prompt: "do the thing",
+    baseBranch: "main",
+    branch: null,
+    worktreePath: "/tmp/wt",
+    repoPath: "/tmp/repo",
+    model: null,
+    claudeSessionId: null,
+    createdAt: 1_000,
+    updatedAt: 2_000,
+    archivedAt: null,
+    status: null,
+  };
+  return {
+    row,
+    authoring: { usage: { ...emptyUsage() }, costUnits: 0 },
+    ancillary: [],
+    end: 2_000,
+    durationMs: 1_000,
+  };
+}
+
+function emptyUsage() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+    messageCount: 0,
+    byModel: {},
+    lastActivity: null as number | null,
+  };
+}
+
+let prevProjectsDir: string;
+let tempBase: string | null = null;
+
+afterEach(() => {
+  config.claudeProjectsDir = prevProjectsDir;
+  if (tempBase) rmSync(tempBase, { recursive: true, force: true });
+  tempBase = null;
+});
+
+test("attributeSatellites links a reviewer dir to its task by the stored spawn record (tag: spawn)", async () => {
+  prevProjectsDir = config.claudeProjectsDir;
+  tempBase = mkdtempSync(join(tmpdir(), "usage-report-spawn-"));
+  config.claudeProjectsDir = tempBase;
+
+  const reviewerSessionId = "11111111-2222-3333-4444-555555555555";
+  const sessionId = "task-session-abc";
+
+  // A `*-review-*` project dir whose transcript .jsonl basename is the reviewerSessionId.
+  const dirName = "-tmp-repo-review-deadbeef";
+  const dirPath = join(tempBase, dirName);
+  mkdirSync(dirPath, { recursive: true });
+  writeFileSync(join(dirPath, `${reviewerSessionId}.jsonl`), usageLine() + "\n");
+
+  const sessions = [makeSession(sessionId)];
+  const reviews: ReviewRow[] = [];
+  const planGates: PlanGateRow[] = [];
+  const spawns: ReviewSpawnRow[] = [{ sessionId, reviewerSessionId }];
+
+  const result = await attributeSatellites(sessions, reviews, planGates, spawns);
+
+  const sats = result.bySession.get(sessionId);
+  expect(sats).toBeDefined();
+  expect(sats!.length).toBe(1);
+  expect(sats![0]!.tag).toBe("spawn");
+  expect(sats![0]!.dir).toBe(dirName);
+  expect(sats![0]!.costUnits).toBeGreaterThan(0);
+  // exact-link consumed the dir — no residual leakage.
+  expect(result.residual.length).toBe(0);
+});
+
+test("attributeSatellites ignores a spawn record whose task is out of scope", async () => {
+  prevProjectsDir = config.claudeProjectsDir;
+  tempBase = mkdtempSync(join(tmpdir(), "usage-report-spawn-"));
+  config.claudeProjectsDir = tempBase;
+
+  const reviewerSessionId = "99999999-8888-7777-6666-555555555555";
+  const dirName = "-tmp-repo-review-cafef00d";
+  const dirPath = join(tempBase, dirName);
+  mkdirSync(dirPath, { recursive: true });
+  writeFileSync(join(dirPath, `${reviewerSessionId}.jsonl`), usageLine() + "\n");
+
+  // session in scope is "in-scope"; the spawn references a different (out-of-scope) session.
+  const sessions = [makeSession("in-scope")];
+  const spawns: ReviewSpawnRow[] = [{ sessionId: "other-session", reviewerSessionId }];
+
+  const result = await attributeSatellites(sessions, [], [], spawns);
+  expect(result.bySession.get("in-scope")).toBeUndefined();
+});


### PR DESCRIPTION
Closes #518.

## What
Persist an **append-only, cascade-exempt** per-reviewer-spawn record so `scripts/usage-report.ts` links every reviewer transcript dir to its parent task by a **stored fact** (`spawn` tag, exact) instead of reconstructing via content-match. Covers **both** PR-critic and plan-gate (plan-review) spawns.

Root cause it fixes: `reviews`/`plan_gates` rows are keyed by `sessionId` (overwritten each finalize) and cascade-deleted on archival — so a finished session leaves nothing to link its critic dirs by. The new table survives archival, keyed per spawn.

## How
- **`review_spawns` table** (`src/store.ts`) — minimal, link-only: `(id UUID PK, sessionId, reviewerSessionId, startedAt)`. `reviewerSessionId` is the reviewer's forced `--session-id`, which **is** the transcript `.jsonl` basename the report matches on. Deliberately **not** part of the `pruneArchivedSessions` cascade (comment at both the DDL and the cascade site guard against a future regression). `recordReviewSpawn` + `pruneReviewSpawns`.
- **Spawn sites** (`src/review.ts`, `src/plan-gate.ts`) — a **fail-open** `recordReviewSpawn` call sits strictly between `herdr.start` (terminal already running) and `inflight.set`, so a DB error can never orphan a running reviewer terminal. Plan-gate now captures the reviewer session id via `readonlyReviewerArgv` directly; the orphaned `reviewerArgv` wrapper is deleted (tests repointed).
- **Prune** (`src/index.ts`) — `pruneReviewSpawns` in the daily sweep, 60-day window mirroring `pruneSignals`.
- **Report** (`scripts/usage-report.ts`) — a new most-authoritative pass (runs first) links a dir by its `.jsonl` basename against a stored spawn row, tagged `"spawn"` (distinct from the legacy `db`/`content`/`sha-confirmed` provenance). Existing passes + residual remain as historical fallbacks.

## Scope decisions (from plan + adversarial review)
- **Minimal schema**: `headSha`/`patchId`/`kind` from the issue's suggested tuple were dropped — at report time the dir must exist to compute its cost, and while it exists `kind` (embedded UUID) and head `sha8` are already dir-derivable; `patchId` had no consumer. The load-bearing stored fact is `(sessionId, reviewerSessionId)`. No-dead-data clean.
- Only makes **future** attribution exact; historical dirs still use content-match.

## Tests
Store (persist / cascade-exempt / prune), review begin (records once + fail-open), plan-gate begin (recorded id == argv `--session-id`), usage-report (dir linked with `tag: "spawn"`; out-of-scope ignored). Full suite: 1789 pass / 0 fail; tsc, lint, fallow all clean.

Note: the two near-identical fail-open blocks in `review.ts`/`plan-gate.ts` show as a fallow duplication *warning* (parallel spawn sites, intentional) — warn-only, not gated.

`[no-feature-entry]` — server-only plumbing + a dev CLI; no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
