### PR TITLE
feat(ui): time-breakdown hover popover on session cards

### DIFF
--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -176,11 +176,13 @@ export class GiteaForge implements GitForge {
   private async toStatus(pr: GiteaPr): Promise<PrStatus> {
     const deployConfigured = Boolean(this.cfg.deployWorkflow);
     const state: PrStatus["state"] = pr.merged ? "merged" : pr.state === "open" ? "open" : "closed";
+    const createdAt = Date.parse(pr.created_at ?? "");
     return {
       state,
       number: pr.number,
       url: pr.html_url,
       title: pr.title ?? "",
+      createdAt: Number.isFinite(createdAt) ? createdAt : undefined,
       mergeable: pr.mergeable ?? null,
       // Gitea has no draft boolean; draft = the WIP-title-prefix convention (see WIP_PREFIX).
       isDraft: (pr.title ?? "").startsWith(GiteaForge.WIP_PREFIX),

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -69,6 +69,7 @@ interface GhPr {
   url: string;
   title: string;
   state: string; // OPEN | MERGED | CLOSED
+  createdAt?: string;
   mergeable?: string; // MERGEABLE | CONFLICTING | UNKNOWN
   isDraft?: boolean;
   statusCheckRollup?: RollupEntry[];
@@ -373,7 +374,7 @@ export class GithubForge implements GitForge {
       "--state",
       "all",
       "--json",
-      "number,url,title,state,mergeable,isDraft,statusCheckRollup,headRefOid,reviews",
+      "number,url,title,state,createdAt,mergeable,isDraft,statusCheckRollup,headRefOid,reviews",
       "--limit",
       "1",
     ]);
@@ -381,11 +382,13 @@ export class GithubForge implements GitForge {
     const pr = prs[0];
     if (!pr) return { state: "none", checks: "none", deployConfigured };
     const state = pr.state.toLowerCase() as PrStatus["state"];
+    const createdAt = Date.parse(pr.createdAt ?? "");
     return {
       state: state === "open" || state === "merged" || state === "closed" ? state : "none",
       number: pr.number,
       url: pr.url,
       title: pr.title,
+      createdAt: Number.isFinite(createdAt) ? createdAt : undefined,
       mergeable: mapMergeable(pr.mergeable),
       isDraft: pr.isDraft ?? false,
       checks: rollupChecks(pr.statusCheckRollup ?? []),

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -73,6 +73,9 @@ export interface PrStatus {
   number?: number;
   url?: string;
   title?: string;
+  /** ms epoch the PR was opened; undefined when there is no PR (or a cached
+   *  payload predates the field). Drives the UI's "PR open for X" wait line. */
+  createdAt?: number;
   /** null = host still computing mergeability. */
   mergeable?: boolean | null;
   checks: ChecksState;

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -902,5 +902,20 @@
   "feat_steer_labels_title": "Steer-Beschriftungen einblenden",
   "feat_steer_labels_body": "In der engen mobilen Steer-Leiste blendest du mit der rechts angedockten „ABC“-Taste die Textbeschriftung jedes Buttons ein statt nur das Emoji — so erkennst du die Steers wieder, wenn du nicht mehr weißt, was ein Symbol bedeutet. Nochmal tippen klappt zurück auf Symbole. Die Wahl wird pro Gerät gemerkt.",
   "feat_usage_gauge_detail_title": "Detaillierte Auslastungs-Anzeige am Desktop",
-  "feat_usage_gauge_detail_body": "Fahr in der oberen Leiste über die 5H-/WK-Balken — jetzt öffnet sich eine detaillierte Karte mit jedem Fenster, vollem Namen, breitem Balken, exaktem Prozentwert und Reset-Zeitpunkt, statt der bisherigen einzeiligen Tooltip-Zeile."
+  "feat_usage_gauge_detail_body": "Fahr in der oberen Leiste über die 5H-/WK-Balken — jetzt öffnet sich eine detaillierte Karte mit jedem Fenster, vollem Namen, breitem Balken, exaktem Prozentwert und Reset-Zeitpunkt, statt der bisherigen einzeiligen Tooltip-Zeile.",
+  "timetip_clock": "⏱ {elapsed} auf der Uhr — tickt seit {start}",
+  "timetip_last_activity": "Letztes Lebenszeichen vor {ago} 👀",
+  "timetip_pr_open_since": "PR #{number} schmort seit {ago} im Ofen 🍲",
+  "timetip_approved_ago": "Approved von {who} vor {ago} ✅",
+  "timetip_your_turn": "Du bist dran! 🫵",
+  "timetip_waiting_review_fresh": "{who} ist mit dem Review dran — seit {ago} ⏳",
+  "timetip_waiting_review_dozing": "Schläft {who}? Seit {ago} kein Review 😴",
+  "timetip_waiting_review_burning": "{who}! Dieses Review brennt an — {ago} 🔥",
+  "timetip_waiting_review_skeleton": "Warte immer noch auf {who}s Review… {ago} 💀",
+  "timetip_waiting_merge_fresh": "{who} muss nur noch mergen… {ago} ⏳",
+  "timetip_waiting_merge_dozing": "Der Merge-Knopf wartet auf {who} — {ago} 😴",
+  "timetip_waiting_merge_burning": "{who}! Der Merge-Knopf verstaubt! {ago} 🔥",
+  "timetip_waiting_merge_skeleton": "Warte seit {ago} auf {who}s Merge… 💀",
+  "feat_time_tooltip_title": "Kachel-Zeit, aufgeschlüsselt",
+  "feat_time_tooltip_body": "Fahre über eine Session-Karte und sieh, woraus ihre Uhr besteht — Laufzeit, letzte Aktivität und wie lange ein offener PR schon auf Review oder Merge wartet, mit eskalierenden Emojis, je länger es dauert 🔥."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -902,5 +902,20 @@
   "feat_steer_labels_title": "Reveal steer labels",
   "feat_steer_labels_body": "On the cramped mobile steer bar, tap the right-anchored “ABC” key to show every button's text label instead of just its emoji — so you can tell the steers apart when you forget what a glyph means. Tap again to collapse back to icons. The choice is remembered per device.",
   "feat_usage_gauge_detail_title": "Detailed usage gauges on desktop",
-  "feat_usage_gauge_detail_body": "Hover the 5H / WK usage bars in the top bar and a detailed card now opens — each window with its full name, a wide bar, the exact percentage and when it resets — instead of the old one-line tooltip."
+  "feat_usage_gauge_detail_body": "Hover the 5H / WK usage bars in the top bar and a detailed card now opens — each window with its full name, a wide bar, the exact percentage and when it resets — instead of the old one-line tooltip.",
+  "timetip_clock": "⏱ {elapsed} on the clock — ticking since {start}",
+  "timetip_last_activity": "Last sign of life {ago} ago 👀",
+  "timetip_pr_open_since": "PR #{number} has been simmering for {ago} 🍲",
+  "timetip_approved_ago": "Approved by {who} {ago} ago ✅",
+  "timetip_your_turn": "Your move! 🫵",
+  "timetip_waiting_review_fresh": "Review time, {who} — on it for {ago} ⏳",
+  "timetip_waiting_review_dozing": "Is {who} napping? {ago} without a review 😴",
+  "timetip_waiting_review_burning": "{who}! This review is on fire — {ago} 🔥",
+  "timetip_waiting_review_skeleton": "Still waiting for {who}'s review… {ago} 💀",
+  "timetip_waiting_merge_fresh": "{who} just needs to hit merge… {ago} ⏳",
+  "timetip_waiting_merge_dozing": "The merge button awaits {who} — {ago} 😴",
+  "timetip_waiting_merge_burning": "{who}! The merge button is gathering dust! {ago} 🔥",
+  "timetip_waiting_merge_skeleton": "Waiting {ago} for {who} to merge… 💀",
+  "feat_time_tooltip_title": "Tile time, explained",
+  "feat_time_tooltip_body": "Hover a session card to see what its clock is made of — runtime, last activity, and how long an open PR has been waiting on review or merge, with escalating emoji the longer it sits 🔥."
 }

--- a/ui/src/lib/components/HerdGrid.svelte
+++ b/ui/src/lib/components/HerdGrid.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Session, GitState } from "$lib/types";
+  import type { Session, GitState, SessionActivity } from "$lib/types";
   import UnitTile from "./UnitTile.svelte";
   import EmptyHerd from "./EmptyHerd.svelte";
   import { m } from "$lib/paraglide/messages";
@@ -11,6 +11,7 @@
     onselect,
     onnew,
     git,
+    activity = {},
     issueActionsUnset = false,
     onsettings = undefined,
     filteredRepo = null,
@@ -23,6 +24,8 @@
     onselect: (id: string) => void;
     onnew: () => void;
     git: Record<string, GitState>;
+    // per-session live activity (heartbeat) — threaded into the tiles' TimePopover
+    activity?: Record<string, SessionActivity>;
     issueActionsUnset?: boolean;
     onsettings?: () => void;
     // basename of an active repo filter; empty + filtered → neutral note, not EmptyHerd
@@ -66,6 +69,7 @@
         {nowMs}
         {onselect}
         git={git[session.id]}
+        activity={activity[session.id]}
         {workingBlocked}
       />
     {/each}

--- a/ui/src/lib/components/TimePopover.svelte
+++ b/ui/src/lib/components/TimePopover.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+  import type { Session, GitState, SessionActivity } from "$lib/types";
+  import { elapsed, formatAgo, waitTier } from "$lib/format";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    session,
+    git,
+    activity,
+    nowMs,
+    anchorRect,
+    onclose,
+  }: {
+    session: Session;
+    git?: GitState;
+    activity?: SessionActivity;
+    nowMs: number;
+    /** The card overlay's getBoundingClientRect() at show time — the popover is
+     *  position:fixed (the cards clip: .tile / .swipe-wrap are overflow:hidden). */
+    anchorRect: DOMRect;
+    onclose: () => void;
+  } = $props();
+
+  // Fixed positioning with a simple flip: below the anchor unless that would
+  // leave less room than above. Rather than measure the popover, compare the
+  // free space on each side — the content is a handful of one-liners, so the
+  // roomier side always fits it.
+  const placeAbove = $derived(
+    window.innerHeight - anchorRect.bottom < anchorRect.top &&
+      window.innerHeight - anchorRect.bottom < 220,
+  );
+  const left = $derived(Math.max(8, Math.min(anchorRect.left, window.innerWidth - 328)));
+
+  // The popover is hover-ephemeral; on any scroll/resize its fixed coordinates
+  // go stale, so close instead of repositioning. Capture-phase catches the
+  // rail's inner scroller, not just window scroll.
+  $effect(() => {
+    const close = () => onclose();
+    window.addEventListener("scroll", close, { capture: true, passive: true });
+    window.addEventListener("resize", close, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", close, { capture: true });
+      window.removeEventListener("resize", close);
+    };
+  });
+
+  const startLabel = $derived(
+    new Date(session.createdAt).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }),
+  );
+
+  const lastActivityTs = $derived(activity?.lastActivityTs || 0);
+
+  const prOpen = $derived(git?.state === "open" && git.number != null);
+
+  // "Waiting on {who}" — only when the server computed a handoff, which it does
+  // ONLY for an open PR with green CI (annotateHandoff, repo-roles.ts): with
+  // pending/failing checks nobody else is up yet, so the line is intentionally
+  // absent there (the "open for X" line still carries the total wait).
+  // The escalation clock measures what is actually being waited on:
+  //   reviewer → since the PR opened; merger → since the approval (an
+  //   un-approved latest review must not date the merge wait — merger handoffs
+  //   can exist without any approval), falling back to the PR open time.
+  const approvedReview = $derived(
+    git?.latestReview?.state === "approved" ? git.latestReview : undefined,
+  );
+  const waitSince = $derived(
+    git?.handoff === "merger" ? (approvedReview?.submittedAt ?? git.createdAt) : git?.createdAt,
+  );
+  const waiting = $derived(
+    git?.handoff && git.handoffWho && waitSince
+      ? {
+          role: git.handoff,
+          who: git.handoffWho,
+          tier: waitTier(nowMs - waitSince),
+          ago: formatAgo(nowMs - waitSince),
+        }
+      : null,
+  );
+  // No handoff on an open+green PR = the operator's own turn.
+  const yourTurn = $derived(
+    !git?.handoff && git?.state === "open" && git.checks === "success" && !git.isDraft,
+  );
+
+  const REVIEW_MSG = {
+    fresh: m.timetip_waiting_review_fresh,
+    dozing: m.timetip_waiting_review_dozing,
+    burning: m.timetip_waiting_review_burning,
+    skeleton: m.timetip_waiting_review_skeleton,
+  } as const;
+  const MERGE_MSG = {
+    fresh: m.timetip_waiting_merge_fresh,
+    dozing: m.timetip_waiting_merge_dozing,
+    burning: m.timetip_waiting_merge_burning,
+    skeleton: m.timetip_waiting_merge_skeleton,
+  } as const;
+</script>
+
+<div
+  class="time-pop"
+  role="tooltip"
+  style:left="{left}px"
+  style:top={placeAbove ? "auto" : `${anchorRect.bottom + 4}px`}
+  style:bottom={placeAbove ? `${window.innerHeight - anchorRect.top + 4}px` : "auto"}
+>
+  <div class="tp-repo">{session.repoPath}</div>
+  <div class="tp-line">
+    {m.timetip_clock({ elapsed: elapsed(session.createdAt, nowMs), start: startLabel })}
+  </div>
+  {#if lastActivityTs > 0}
+    <div class="tp-line">
+      {m.timetip_last_activity({ ago: formatAgo(nowMs - lastActivityTs) })}
+    </div>
+  {/if}
+  {#if prOpen}
+    {#if git?.createdAt}
+      <div class="tp-line">
+        {m.timetip_pr_open_since({ number: git.number!, ago: formatAgo(nowMs - git.createdAt) })}
+      </div>
+    {/if}
+    {#if approvedReview}
+      <div class="tp-line">
+        {m.timetip_approved_ago({
+          who: approvedReview.author,
+          ago: formatAgo(nowMs - approvedReview.submittedAt),
+        })}
+      </div>
+    {/if}
+    {#if waiting}
+      <div class="tp-line tp-wait tp-wait--{waiting.tier}">
+        {(waiting.role === "reviewer" ? REVIEW_MSG : MERGE_MSG)[waiting.tier]({
+          who: waiting.who,
+          ago: waiting.ago,
+        })}
+      </div>
+    {:else if yourTurn}
+      <div class="tp-line tp-wait">{m.timetip_your_turn()}</div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  /* Anchored, non-blocking hover popover (role=tooltip, no scrim — per the
+     design-system exemption for small anchored popovers, same family as
+     AutomationPanel's .auto-pop). pointer-events:none so it can never swallow
+     the click that selects the card underneath. */
+  .time-pop {
+    position: fixed;
+    z-index: 60;
+    width: max-content;
+    max-width: 320px;
+    pointer-events: none;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .tp-repo {
+    font-size: var(--fs-micro);
+    color: var(--color-faint);
+    letter-spacing: 0.06em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .tp-line {
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    font-variant-numeric: tabular-nums;
+  }
+  .tp-wait {
+    color: var(--color-ink-bright);
+  }
+  .tp-wait--burning,
+  .tp-wait--skeleton {
+    color: var(--color-amber);
+  }
+</style>

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -24,6 +24,7 @@
   import { isMerging } from "./merge-train";
   import StatusPip from "./StatusPip.svelte";
   import PrBadge from "./PrBadge.svelte";
+  import TimePopover from "./TimePopover.svelte";
   import CriticBadge from "./CriticBadge.svelte";
   import HeartbeatStrip from "./HeartbeatStrip.svelte";
   import Stepper from "./Stepper.svelte";
@@ -146,6 +147,7 @@
 
   onDestroy(() => {
     clearTimeout(armTimer);
+    clearTimeout(tipTimer);
     if (openRow === close) openRow = null;
   });
 
@@ -214,6 +216,21 @@
     menu = null;
     ondecommission?.(session.id);
   }
+
+  // Time-breakdown popover: the .unit-hit overlay is the row's only hover
+  // surface (it covers the elapsed span and PrBadge, so their own hovers can
+  // never fire) — trigger there, with hover-intent so sweeping the cursor
+  // across the list doesn't cascade popovers. Keyboard focus shows immediately.
+  let tipRect = $state<DOMRect | null>(null);
+  let tipTimer: ReturnType<typeof setTimeout> | undefined;
+  function tipShow(delay = 450) {
+    clearTimeout(tipTimer);
+    tipTimer = setTimeout(() => (tipRect = hitEl?.getBoundingClientRect() ?? null), delay);
+  }
+  function tipHide() {
+    clearTimeout(tipTimer);
+    tipRect = null;
+  }
 </script>
 
 {#snippet row()}
@@ -225,15 +242,31 @@
     data-unit-id={session.id}
     style="--rule:{session.readyToMerge ? 'var(--color-green)' : STATUS_COLOR[dStatus]}"
   >
+    <!-- no native title here (was repoPath): the TimePopover carries the repo
+         path as its first line, and a native tooltip would double up with it -->
     <button
       bind:this={hitEl}
       class="unit-hit"
       type="button"
       aria-label={m.unit_open_aria({ name: session.name })}
       aria-describedby={describedBy}
-      title={session.repoPath}
-      onclick={() => onselect(session.id)}
-      oncontextmenu={onContextMenu}
+      onclick={() => {
+        tipHide();
+        onselect(session.id);
+      }}
+      oncontextmenu={(e) => {
+        tipHide();
+        onContextMenu(e);
+      }}
+      onmouseenter={() => tipShow()}
+      onmouseleave={tipHide}
+      onfocus={() => {
+        if (hitEl?.matches(":focus-visible")) tipShow(0);
+      }}
+      onblur={tipHide}
+      onkeydown={(e) => {
+        if (e.key === "Escape" && tipRect) tipHide();
+      }}
       use:longPress={{ onTrigger: openMenuAt }}
     ></button>
     <div class="pip-col">
@@ -433,6 +466,10 @@
     ondecommission={ondecommission ? decommissionFromMenu : undefined}
     onclose={() => (menu = null)}
   />
+{/if}
+
+{#if tipRect && !menu}
+  <TimePopover {session} {git} {activity} {nowMs} anchorRect={tipRect} onclose={tipHide} />
 {/if}
 
 <style>

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -2,8 +2,9 @@
   import "@xterm/xterm/css/xterm.css";
   import { Terminal } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
-  import type { Session, GitState } from "$lib/types";
+  import type { Session, GitState, SessionActivity } from "$lib/types";
   import { STATUS_COLOR, statusLabel, elapsed, hideStatusBadge, canResume } from "$lib/format";
+  import { onDestroy } from "svelte";
   import { displayStatus } from "$lib/display-status";
   import { connectPty } from "$lib/pty";
   import { resumeSession } from "$lib/api";
@@ -11,6 +12,7 @@
   import CardMenu from "./CardMenu.svelte";
   import { longPress } from "./longpress";
   import PrBadge from "./PrBadge.svelte";
+  import TimePopover from "./TimePopover.svelte";
   import CriticBadge from "./CriticBadge.svelte";
   import { reviews } from "$lib/reviews.svelte";
   import { toasts } from "$lib/toasts.svelte";
@@ -25,6 +27,7 @@
     nowMs = Date.now(),
     onselect,
     git,
+    activity,
     workingBlocked = {},
   }: {
     session: Session;
@@ -32,6 +35,8 @@
     nowMs?: number;
     onselect: (id: string) => void;
     git?: GitState;
+    // live per-session signal (heartbeat ts); feeds the TimePopover's last-activity line
+    activity?: SessionActivity;
     // working-while-blocked display flags (whole store map); feeds displayStatus only
     workingBlocked?: Record<string, boolean>;
   } = $props();
@@ -174,6 +179,22 @@
       toasts.info(m.cardmenu_resume_failed({ name: session.name }));
     }
   }
+
+  // Time-breakdown popover: the .tile-hit overlay is the tile's only hover
+  // surface (it covers the elapsed span and PrBadge, so their own hovers can
+  // never fire) — trigger there, with hover-intent so sweeping the cursor
+  // across the grid doesn't cascade popovers. Keyboard focus shows immediately.
+  let tipRect = $state<DOMRect | null>(null);
+  let tipTimer: ReturnType<typeof setTimeout> | undefined;
+  function tipShow(delay = 450) {
+    clearTimeout(tipTimer);
+    tipTimer = setTimeout(() => (tipRect = hitEl?.getBoundingClientRect() ?? null), delay);
+  }
+  function tipHide() {
+    clearTimeout(tipTimer);
+    tipRect = null;
+  }
+  onDestroy(() => clearTimeout(tipTimer));
 </script>
 
 <div
@@ -187,8 +208,23 @@
     type="button"
     aria-label={m.unit_open_aria({ name: session.name })}
     aria-describedby={describedBy}
-    onclick={() => onselect(session.id)}
-    oncontextmenu={onContextMenu}
+    onclick={() => {
+      tipHide();
+      onselect(session.id);
+    }}
+    oncontextmenu={(e) => {
+      tipHide();
+      onContextMenu(e);
+    }}
+    onmouseenter={() => tipShow()}
+    onmouseleave={tipHide}
+    onfocus={() => {
+      if (hitEl?.matches(":focus-visible")) tipShow(0);
+    }}
+    onblur={tipHide}
+    onkeydown={(e) => {
+      if (e.key === "Escape" && tipRect) tipHide();
+    }}
     use:longPress={{ onTrigger: openMenuAt }}
   ></button>
   <div class="t-head">
@@ -225,6 +261,10 @@
     onresume={resumeFromMenu}
     onclose={() => (menu = null)}
   />
+{/if}
+
+{#if tipRect && !menu}
+  <TimePopover {session} {git} {activity} {nowMs} anchorRect={tipRect} onclose={tipHide} />
 {/if}
 
 <style>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -464,4 +464,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_usage_gauge_detail_title",
     bodyKey: "feat_usage_gauge_detail_body",
   },
+  {
+    // No targetId: the popover is hover-revealed (not persistently mounted), so a
+    // coachmark anchor would never exist — surface via the What's-New drawer only.
+    // v1.23.0 is already tagged, so this ships in the next release (1.24.0).
+    id: "tile-time-tooltip",
+    sinceVersion: "1.24.0",
+    titleKey: "feat_time_tooltip_title",
+    bodyKey: "feat_time_tooltip_body",
+  },
 ];

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { hideStatusBadge, relativeAge, formatAgo, heartbeatTone, canResume } from "./format";
+import {
+  hideStatusBadge,
+  relativeAge,
+  formatAgo,
+  heartbeatTone,
+  canResume,
+  waitTier,
+} from "./format";
 import type { Session, SessionStatus } from "./types";
 
 describe("canResume", () => {
@@ -79,6 +86,24 @@ describe("formatAgo", () => {
   ];
   for (const [ms, out] of cases) {
     it(`${ms}ms → ${out}`, () => expect(formatAgo(ms)).toBe(out));
+  }
+});
+
+describe("waitTier", () => {
+  const H = 3_600_000;
+  const D = 24 * H;
+  const cases: [number, ReturnType<typeof waitTier>][] = [
+    [0, "fresh"],
+    [4 * H - 1, "fresh"],
+    [4 * H, "dozing"],
+    [D - 1, "dozing"],
+    [D, "burning"],
+    [3 * D - 1, "burning"],
+    [3 * D, "skeleton"],
+    [14 * D, "skeleton"],
+  ];
+  for (const [ms, out] of cases) {
+    it(`${ms}ms → ${out}`, () => expect(waitTier(ms)).toBe(out));
   }
 });
 

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -116,6 +116,18 @@ export function statusLabel(s: SessionStatus): string {
   }
 }
 
+/**
+ * Escalation tier for the TimePopover's "waiting on {who}" line — purely
+ * cosmetic gamification, drives which playful message (and emoji) renders:
+ * `<4h` fresh ⏳, `<1d` dozing 😴, `<3d` burning 🔥, else skeleton 💀.
+ */
+export function waitTier(deltaMs: number): "fresh" | "dozing" | "burning" | "skeleton" {
+  if (deltaMs < 4 * 3_600_000) return "fresh";
+  if (deltaMs < 24 * 3_600_000) return "dozing";
+  if (deltaMs < 3 * 24 * 3_600_000) return "burning";
+  return "skeleton";
+}
+
 /** Compact age like "5m", "2h", "3d", or "now" under a minute. Units are
  *  abbreviations, intentionally untranslated — same precedent as `elapsed`.
  *  Shares the m/h/d tail with `formatAgo`; only the sub-minute label differs

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -116,6 +116,9 @@ export interface PrStatus {
   number?: number;
   url?: string;
   title?: string;
+  /** ms epoch the PR was opened; undefined when there is no PR (or a cached
+   *  payload predates the field). Drives the TimePopover's "open for X" line. */
+  createdAt?: number;
   mergeable?: boolean | null;
   checks: ChecksState;
   deployConfigured: boolean;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1089,6 +1089,7 @@
           {selectedId}
           {nowMs}
           git={store.git}
+          activity={store.activity}
           onselect={(id) => {
             selectedId = id;
             viewMode = "focus";


### PR DESCRIPTION
## What

The time shown on session cards (elapsed since session creation) now has a hover popover that explains what the clock is made of — and finally surfaces the missing number: **how long an open PR has been waiting on review or merge by someone else** (e.g. scoop), with playful escalating emoji. 😄

Hover any session row (rail) or tile (grid) for ~450 ms, or focus it with the keyboard:

- repo path (moved here from the row's old native `title` tooltip)
- ⏱ elapsed on the clock — ticking since {start}
- last sign of life {ago} (live activity heartbeat, when present)
- PR #{n} simmering for {ago} 🍲 (new `PrStatus.createdAt`, both forges)
- approved by {who} {ago} ago ✅ (only when the latest review **is** an approval)
- **waiting on {who}** with tier escalation ⏳ → 😴 → 🔥 → 💀 (4 h / 1 d / 3 d), or "Your move! 🫵" when it's the operator's turn

## Key decisions

- **Wait anchor per handoff role:** reviewer → since PR opened; merger → since the approval (`latestReview.submittedAt`), falling back to PR open when the latest review isn't an approval — merger handoffs can exist without one (`computeHandoff`).
- **The waiting line only renders for open + CI-green PRs** — intentional: `annotateHandoff` only computes a handoff then; with pending/failing CI nobody else is up yet. The "open for X" line still carries the total wait.
- **Trigger = the card hit overlay**, not per-element anchors: `.unit-hit`/`.tile-hit` swallow all pointer events, so the elapsed span / PrBadge could never hover. No raised anchors, no click-forwarding, zero click-to-select regression (popover is `pointer-events: none`).
- **`position: fixed`** with flip + close-on-scroll/resize/Esc — in-card absolute would clip (`.tile` and `.swipe-wrap` are `overflow: hidden`).
- Touch devices intentionally get no popover (tap = select, long-press = card menu).

## Server

`PrStatus.createdAt` (PR open timestamp, epoch ms) added and populated in both forges (GitHub: one more `--json` field; Gitea: parse `created_at`); flows through the existing `GitState` push. Cached payloads without the field simply omit the PR line until the next poll.

## Checks

- `ui`: `bun run check` ✓ (0 errors), `check:i18n` ✓ (EN/DE parity), `bun run test` ✓ (912 tests, incl. new `waitTier` tier-boundary tests), production build ✓
- root: `bun run lint` ✓, `bun test ./test` ✓ (1780 pass / 0 fail, verified in a clean /tmp worktree — the in-worktree pre-push run wedged on the known zombie-git hang, hence one `--no-verify` push after running all gates manually)
- gates: branch hygiene ✓, feature catalog ✓ (entry `tile-time-tooltip`, ships in 1.24.0)