### PR TITLE
feat(ui): collapsible herd sidebar on touch-primary wide devices

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -223,6 +223,8 @@
   "herd_merge_train_action": "Merge-Train",
   "herd_merge_train_title": "Neue Session starten, die die merge-bereiten PRs abarbeitet und eine Merge-Reihenfolge vorschlägt",
   "herd_merge_train_prompt": "Führe einen Merge-Train für die Pull Requests aus, die ich als merge-bereit markiert habe. Prüfe jeden auf Korrektheit und Produkt-Fit, schlage eine sichere Merge-Reihenfolge vor und halte vor jedem Merge für meine Freigabe an — prüfe danach nach jedem Merge die Warteschlange erneut, denn main bewegt sich unter dir.\n\nMerge-bereite PRs:\n{prs}\n\nWenn dieses Repo einen /merge-train-Befehl oder -Skill bereitstellt, nutze ihn. Andernfalls arbeite den Train selbst ab:\n1. Erfasse für jeden PR den Status mit gh (CI-Rollup, Mergebarkeit/Konflikte, wie weit hinter main, und welche Dateien sich mit anderen PRs dieser Liste überschneiden).\n2. Verschiebe jeden PR, der CI-rot, konfliktbehaftet, gate-fehlerhaft oder nicht erwünscht ist, mit einer einzeiligen Begründung auf eine separate Halteliste — merge niemals an einem roten Gate vorbei.\n3. Ordne den Rest: am kleinsten und unabhängigsten zuerst; überschneiden sich zwei, sequenziere sie so, dass der riskantere auf den anderen rebased; release-please-PRs zuletzt.\n4. Präsentiere die nummerierte Merge-Reihenfolge plus die Halteliste und WARTE auf meine Freigabe.\n5. Nach Freigabe merge in Reihenfolge: erst auf das aktuelle main rebasen (niemals main in den Branch mergen), grüne Gates bestätigen, dann gh pr merge --squash --delete-branch, und vor dem nächsten die verbleibenden PRs erneut gegen main prüfen.",
+  "herd_collapse": "Seitenleiste einklappen",
+  "herd_expand": "Seitenleiste ausklappen",
   "issuespanel_title": "ISSUES",
   "issuespanel_title_with_slug": "ISSUES · {slug}",
   "issuespanel_no_host": "kein Git-Host für dieses Repo konfiguriert",
@@ -949,5 +951,7 @@
   "newproject_prd_seed": "Du startest ein brandneues Projekt. Bevor du Code schreibst, erstelle ein PRD (Product Requirements Document) unter `docs/PRD.md` in diesem Repository. Halte darin das Problem, die Ziele, die Zielgruppe, die wichtigsten User Stories, den Scope (In/Out) und die Erfolgskriterien fest. Halte es präzise und konkret. Die Idee dahinter:\n\n{idea}\n\nWenn das PRD geschrieben ist, committe es mit einem Conventional Commit (`docs: add initial PRD`) und pausiere zur Überprüfung, bevor du mit der Implementierung beginnst.",
   "newproject_prd_seed_noidea": "(keine Beschreibung angegeben — leite einen sinnvollen Ausgangspunkt ab und stelle klärende Fragen im PRD)",
   "feat_new_project_title": "Neues Projekt starten",
-  "feat_new_project_body": "Lege ein frisches Git-Repository an — optional auch auf GitHub — und starte den ersten Agenten-Run, ohne Shepherd zu verlassen."
+  "feat_new_project_body": "Lege ein frisches Git-Repository an — optional auch auf GitHub — und starte den ersten Agenten-Run, ohne Shepherd zu verlassen.",
+  "feat_sidebar_collapse_title": "Einklappbare Seitenleiste",
+  "feat_sidebar_collapse_body": "Auf Touch-Tablets und aufgeklappten Foldables die Herd-Seitenleiste einklappen, um dem Terminal mehr Platz zu geben. Deine Auswahl wird gespeichert."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -223,6 +223,8 @@
   "herd_merge_train_action": "Merge train",
   "herd_merge_train_title": "Start a new session that works through the ready-to-merge PRs and suggests a merge order",
   "herd_merge_train_prompt": "Run a merge train for the pull requests I've flagged ready to merge. Review each for correctness and product-fit, propose a safe merge order, and stop for my approval before merging anything — then re-check the queue after every merge, because main moves under you.\n\nReady-to-merge PRs:\n{prs}\n\nIf this repo provides a /merge-train command or skill, use it. Otherwise work the train yourself:\n1. For each PR, gather status with gh (CI rollup, mergeability/conflicts, how far behind main, and which files overlap other PRs in this list).\n2. Move any PR that is CI-red, conflicting, gate-failing, or that we don't actually want into a separate hold list with a one-line reason — never merge past a red gate.\n3. Order the rest: smallest and most independent first; when two overlap, sequence them so the riskier one rebases onto the other; release-please PRs last.\n4. Present the numbered merge order plus the hold list and WAIT for my approval.\n5. On approval, merge in order: rebase onto latest main first (never merge main into the branch), confirm gates are green, then gh pr merge --squash --delete-branch, and re-check the remaining PRs against main before the next one.",
+  "herd_collapse": "Collapse sidebar",
+  "herd_expand": "Expand sidebar",
   "issuespanel_title": "ISSUES",
   "issuespanel_title_with_slug": "ISSUES · {slug}",
   "issuespanel_no_host": "no git host configured for this repo",
@@ -949,5 +951,7 @@
   "newproject_prd_seed": "You are starting a brand-new project. Before writing any code, create a PRD (Product Requirements Document) at `docs/PRD.md` in this repository. Capture the problem, goals, target users, core user stories, scope (in/out), and success criteria. Keep it concise and concrete. The idea to build from:\n\n{idea}\n\nWhen the PRD is written, commit it with a conventional commit (`docs: add initial PRD`) and stop for review before implementing.",
   "newproject_prd_seed_noidea": "(no description was provided — infer a reasonable starting scope and ask clarifying questions in the PRD)",
   "feat_new_project_title": "Start a new project",
-  "feat_new_project_body": "Create a fresh git repo — optionally on GitHub — and kick off the first agent run, all without leaving Shepherd."
+  "feat_new_project_body": "Create a fresh git repo — optionally on GitHub — and kick off the first agent run, all without leaving Shepherd.",
+  "feat_sidebar_collapse_title": "Collapsible sidebar",
+  "feat_sidebar_collapse_body": "On touch tablets and unfolded foldables, collapse the Herd sidebar to give the terminal more room. Your choice is remembered."
 }

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -181,6 +181,7 @@
     </div>
     {#if collapsible}
       <button
+        id="herd-collapse-btn"
         type="button"
         class="collapse-btn"
         title={m.herd_collapse()}
@@ -520,6 +521,8 @@
     padding: 9px 14px;
     border-bottom: 1px solid var(--color-line);
     color: var(--color-muted);
+    flex-wrap: wrap;
+    row-gap: 6px;
   }
   .phead .right {
     margin-left: auto;

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -31,6 +31,8 @@
     statusFilter = null,
     onstatusfilter = undefined,
     workingBlocked = {},
+    collapsible = false,
+    oncollapse = undefined,
   }: {
     sessions: Session[];
     selectedId: string | null;
@@ -78,6 +80,12 @@
     // working-while-blocked display flags (store map) — threaded into the rows'
     // displayStatus and the "ready" filter so flagged sessions read as working
     workingBlocked?: Record<string, boolean>;
+    // when true, renders a collapse chevron at the far-right of the header —
+    // only set on touch-primary wide devices where collapsing is meaningful
+    collapsible?: boolean;
+    // called when the collapse chevron is clicked; parent drives the actual
+    // collapse so the button is purely a signal
+    oncollapse?: () => void;
   } = $props();
 
   // a critic post-PR review or a pre-execution plan-gate review currently in flight —
@@ -171,6 +179,15 @@
         >
       {/if}
     </div>
+    {#if collapsible}
+      <button
+        type="button"
+        class="collapse-btn"
+        title={m.herd_collapse()}
+        aria-label={m.herd_collapse()}
+        onclick={() => oncollapse?.()}>‹</button
+      >
+    {/if}
   </div>
   <div class="units" class:flow>
     {#if sessions.length === 0}
@@ -525,6 +542,28 @@
   }
   .fbtn.active {
     color: var(--color-amber);
+  }
+
+  /* collapse trigger — far-right of .phead, touch-comfortable target, visually
+     quiet chrome (no accent hue); mirrors .fbtn style but sized for touch */
+  .collapse-btn {
+    border: 0;
+    background: none;
+    font-family: inherit;
+    font-size: var(--fs-lg);
+    cursor: pointer;
+    padding: 4px 8px;
+    min-width: 32px;
+    min-height: 32px;
+    color: var(--color-faint);
+    transition: color 0.12s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 4px;
+  }
+  .collapse-btn:hover {
+    color: var(--color-ink);
   }
 
   .micro {

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -547,8 +547,9 @@
     color: var(--color-amber);
   }
 
-  /* collapse trigger — far-right of .phead, touch-comfortable target, visually
-     quiet chrome (no accent hue); mirrors .fbtn style but sized for touch */
+  /* collapse trigger — far-right of .phead, visually quiet chrome (no accent
+     hue); mirrors .fbtn style but sized to the ~44px touch guideline, matching
+     the reopen tab (both are activated on the same touch devices) */
   .collapse-btn {
     border: 0;
     background: none;
@@ -556,8 +557,8 @@
     font-size: var(--fs-lg);
     cursor: pointer;
     padding: 4px 8px;
-    min-width: 32px;
-    min-height: 32px;
+    min-width: 44px;
+    min-height: 44px;
     color: var(--color-faint);
     transition: color 0.12s ease;
     display: flex;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -483,4 +483,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_new_project_body",
     targetId: "newproject-row",
   },
+  {
+    // No targetId — the collapse chevron only mounts on unfolded-fold / touch-wide
+    // layouts, so a coachmark anchor would rarely exist — surface via the What's-New
+    // drawer only. v1.24.0 is already tagged, so this ships in the next release (1.25.0).
+    id: "sidebar-collapse",
+    sinceVersion: "1.25.0",
+    titleKey: "feat_sidebar_collapse_title",
+    bodyKey: "feat_sidebar_collapse_body",
+  },
 ];

--- a/ui/src/lib/sidebar-collapse.svelte.test.ts
+++ b/ui/src/lib/sidebar-collapse.svelte.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Stub localStorage before importing the module so the singleton's read() call
+// at init doesn't touch a real or missing localStorage.
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => {
+    store[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete store[key];
+  },
+  clear: () => {
+    for (const k of Object.keys(store)) delete store[k];
+  },
+};
+// @ts-expect-error stubbing global
+globalThis.localStorage = localStorageMock;
+
+import { sidebarCollapse, sidebarShouldCollapse } from "./sidebar-collapse.svelte";
+
+const KEY = "shepherd:sidebar-collapsed";
+
+beforeEach(() => {
+  localStorageMock.clear();
+  // Reset the store state to false (mirrors a fresh/unset localStorage)
+  sidebarCollapse.set(false);
+  localStorageMock.clear(); // clear side-effect write from the reset above
+});
+
+// ---------------------------------------------------------------------------
+// Predicate truth table
+// ---------------------------------------------------------------------------
+
+describe("sidebarShouldCollapse", () => {
+  it("returns true only for touch=true, mobile=false, collapsed=true", () => {
+    expect(sidebarShouldCollapse(true, false, true)).toBe(true);
+  });
+
+  it("returns false for mouse-primary desktop (touch=false)", () => {
+    expect(sidebarShouldCollapse(false, false, true)).toBe(false);
+    expect(sidebarShouldCollapse(false, true, true)).toBe(false);
+    expect(sidebarShouldCollapse(false, false, false)).toBe(false);
+    expect(sidebarShouldCollapse(false, true, false)).toBe(false);
+  });
+
+  it("returns false for phone (touch=true, mobile=true)", () => {
+    expect(sidebarShouldCollapse(true, true, true)).toBe(false);
+    expect(sidebarShouldCollapse(true, true, false)).toBe(false);
+  });
+
+  it("returns false when not opted in (collapsed=false)", () => {
+    expect(sidebarShouldCollapse(true, false, false)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store: toggle / set / localStorage
+// ---------------------------------------------------------------------------
+
+describe("sidebarCollapse store", () => {
+  it("toggle flips collapsed from false to true", () => {
+    expect(sidebarCollapse.collapsed).toBe(false);
+    sidebarCollapse.toggle();
+    expect(sidebarCollapse.collapsed).toBe(true);
+  });
+
+  it("toggle flips collapsed from true to false", () => {
+    sidebarCollapse.set(true);
+    sidebarCollapse.toggle();
+    expect(sidebarCollapse.collapsed).toBe(false);
+  });
+
+  it("set(true) writes '1' to localStorage under the correct key", () => {
+    sidebarCollapse.set(true);
+    expect(store[KEY]).toBe("1");
+  });
+
+  it("set(false) removes the key from localStorage", () => {
+    store[KEY] = "1"; // seed it
+    sidebarCollapse.set(false);
+    expect(store[KEY]).toBeUndefined();
+  });
+
+  it("set(true) sets collapsed to true", () => {
+    sidebarCollapse.set(true);
+    expect(sidebarCollapse.collapsed).toBe(true);
+  });
+
+  it("set(false) sets collapsed to false", () => {
+    sidebarCollapse.set(true);
+    sidebarCollapse.set(false);
+    expect(sidebarCollapse.collapsed).toBe(false);
+  });
+});

--- a/ui/src/lib/sidebar-collapse.svelte.ts
+++ b/ui/src/lib/sidebar-collapse.svelte.ts
@@ -1,0 +1,38 @@
+const KEY = "shepherd:sidebar-collapsed";
+
+function read(): boolean {
+  try {
+    return localStorage.getItem(KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Pure gate: collapse the sidebar only on touch-primary wide devices that have
+ *  opted in. No runes / no DOM — directly unit-testable. `touch` = coarse pointer,
+ *  `mobile` = ≤768px breakpoint, `collapsed` = the persisted user choice. */
+export function sidebarShouldCollapse(
+  touch: boolean,
+  mobile: boolean,
+  collapsed: boolean,
+): boolean {
+  return touch && !mobile && collapsed;
+}
+
+class SidebarCollapse {
+  collapsed = $state(read());
+  toggle() {
+    this.set(!this.collapsed);
+  }
+  set(v: boolean) {
+    this.collapsed = v;
+    try {
+      if (v) localStorage.setItem(KEY, "1");
+      else localStorage.removeItem(KEY);
+    } catch {
+      /* private mode / SSR — preference just won't survive reload */
+    }
+  }
+}
+
+export const sidebarCollapse = new SidebarCollapse();

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -95,6 +95,7 @@
   import { version } from "$lib/build-info";
   import WhatsNew from "$lib/components/WhatsNew.svelte";
   import FableArrival from "$lib/components/FableArrival.svelte";
+  import { sidebarCollapse, sidebarShouldCollapse } from "$lib/sidebar-collapse.svelte";
 
   const store = new HerdStore();
   let selectedId = $state<string | null>(null);
@@ -458,6 +459,13 @@
   // touch-primary device (e.g. unfolded foldable wider than the mobile breakpoint):
   // gets the control-key bar even in desktop layout, since there's no hardware keyboard
   const touch = new MediaQuery("(pointer: coarse)");
+  // Collapse the herd sidebar only on touch-primary wide devices (e.g. unfolded
+  // foldable) that opted in — gives the terminal full width. Mouse desktops and
+  // phones (handled by the mobile branch) never collapse.
+  const canCollapse = $derived(touch.current && !mobile.current);
+  const sidebarCollapsed = $derived(
+    sidebarShouldCollapse(touch.current, mobile.current, sidebarCollapse.collapsed),
+  );
   let mobileScreen = $state<"list" | "detail">("list");
   let showBacklog = $state(false);
 
@@ -1114,31 +1122,43 @@
         />
       </div>
     {:else}
-      <div class="grid" class:compact={touch.current}>
-        <Herd
-          sessions={herdSessions}
-          filteredRepo={repoFilterName}
-          {repoFilter}
-          onrepofilter={(repoPath) => (repoFilter = repoPath)}
-          {statusFilter}
-          onstatusfilter={(s) => (statusFilter = s)}
-          {selectedId}
-          {nowMs}
-          onselect={(id) => selectUnit(id)}
-          onnew={() => (showNew = true)}
-          git={store.git}
-          activity={store.activity}
-          preview={store.preview}
-          previewServe={store.previewServe}
-          onpreview={openPreview}
-          ondecommission={onarchive}
-          {onclearmerged}
-          {onmergetrain}
-          {issueActionsUnset}
-          onsettings={() => (showSettings = true)}
-          bind:filter={herdFilter}
-          workingBlocked={store.workingBlocked}
-        />
+      <div class="grid" class:compact={touch.current} class:collapsed={sidebarCollapsed}>
+        {#if sidebarCollapsed}
+          <button
+            type="button"
+            class="reopen-tab"
+            title={m.herd_expand()}
+            aria-label={m.herd_expand()}
+            onclick={() => sidebarCollapse.toggle()}>›</button
+          >
+        {:else}
+          <Herd
+            sessions={herdSessions}
+            filteredRepo={repoFilterName}
+            {repoFilter}
+            onrepofilter={(repoPath) => (repoFilter = repoPath)}
+            {statusFilter}
+            onstatusfilter={(s) => (statusFilter = s)}
+            {selectedId}
+            {nowMs}
+            onselect={(id) => selectUnit(id)}
+            onnew={() => (showNew = true)}
+            git={store.git}
+            activity={store.activity}
+            preview={store.preview}
+            previewServe={store.previewServe}
+            onpreview={openPreview}
+            ondecommission={onarchive}
+            {onclearmerged}
+            {onmergetrain}
+            {issueActionsUnset}
+            onsettings={() => (showSettings = true)}
+            bind:filter={herdFilter}
+            workingBlocked={store.workingBlocked}
+            collapsible={canCollapse}
+            oncollapse={() => sidebarCollapse.toggle()}
+          />
+        {/if}
         {#if store.sessions.length === 0}
           <BacklogView
             payload={backlog}
@@ -1451,6 +1471,33 @@
   .grid.compact {
     grid-template-columns: minmax(244px, 288px) 1fr;
     gap: 10px;
+  }
+  /* Collapsed herd on touch-primary wide devices: the sidebar is replaced by a
+     slim reopen tab and the terminal reclaims the width. Authored at
+     .grid.compact.collapsed specificity (0,3,0) so it outranks .grid.compact by
+     specificity, not source order — collapse on a touch device sets both classes. */
+  .grid.compact.collapsed {
+    grid-template-columns: 30px 1fr;
+    gap: 0;
+  }
+  .reopen-tab {
+    height: 100%;
+    width: 100%;
+    align-self: stretch;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line);
+    color: var(--color-faint);
+    font-size: var(--fs-lg);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    box-sizing: border-box;
+    transition: color 0.12s ease;
+  }
+  .reopen-tab:hover {
+    color: var(--color-ink);
   }
   .grid-all {
     flex: 1;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, tick } from "svelte";
   import { MediaQuery } from "svelte/reactivity";
   import { HerdStore } from "$lib/store.svelte";
   import {
@@ -466,6 +466,17 @@
   const sidebarCollapsed = $derived(
     sidebarShouldCollapse(touch.current, mobile.current, sidebarCollapse.collapsed),
   );
+
+  // Toggling unmounts whichever control was clicked (Herd's chevron on collapse,
+  // the reopen tab on expand), which would drop focus to <body>. After the DOM
+  // settles, move focus to the counterpart control so keyboard/SR users keep place.
+  async function toggleSidebar() {
+    const wasCollapsed = sidebarCollapsed;
+    sidebarCollapse.toggle();
+    await tick();
+    document.getElementById(wasCollapsed ? "herd-collapse-btn" : "herd-reopen-tab")?.focus();
+  }
+
   let mobileScreen = $state<"list" | "detail">("list");
   let showBacklog = $state(false);
 
@@ -1125,11 +1136,12 @@
       <div class="grid" class:compact={touch.current} class:collapsed={sidebarCollapsed}>
         {#if sidebarCollapsed}
           <button
+            id="herd-reopen-tab"
             type="button"
             class="reopen-tab"
             title={m.herd_expand()}
             aria-label={m.herd_expand()}
-            onclick={() => sidebarCollapse.toggle()}>›</button
+            onclick={toggleSidebar}>›</button
           >
         {:else}
           <Herd
@@ -1156,7 +1168,7 @@
             bind:filter={herdFilter}
             workingBlocked={store.workingBlocked}
             collapsible={canCollapse}
-            oncollapse={() => sidebarCollapse.toggle()}
+            oncollapse={toggleSidebar}
           />
         {/if}
         {#if store.sessions.length === 0}
@@ -1477,7 +1489,7 @@
      .grid.compact.collapsed specificity (0,3,0) so it outranks .grid.compact by
      specificity, not source order — collapse on a touch device sets both classes. */
   .grid.compact.collapsed {
-    grid-template-columns: 30px 1fr;
+    grid-template-columns: 44px 1fr;
     gap: 0;
   }
   .reopen-tab {


### PR DESCRIPTION
## What

On **touch-primary wide devices** (`pointer: coarse` + wider than the 768px mobile breakpoint — the unfolded fold is the motivating case, also tablets/touchscreen desktops), adds a control to **collapse the "THE HERD" sidebar** so the terminal/Viewport reclaims the width down to a slim edge tab. Mirrors the room the mobile full-screen terminal gives you, but as an explicit, persisted toggle.

- **Collapse:** a quiet chevron (`‹`) at the far-right of the Herd header.
- **Reopen:** a slim full-height edge tab (`›`, ~30px) replaces the sidebar when collapsed.
- **Persisted:** `localStorage["shepherd:sidebar-collapsed"]`, following the `theme.svelte.ts` store pattern.
- **Scoped:** only the focus split view on touch-primary wide devices. Mouse-primary desktops keep the always-on sidebar; phones (≤768px) already full-screen the terminal — both untouched.
- **Keyboard nav stays live** while collapsed (page-level `railIds()`/`railOrder`, list-independent) — intentional, so collapsing reclaims space without disabling keyboard switching.

## How

- `ui/src/lib/sidebar-collapse.svelte.ts` (new): persisted `$state` store + pure, unit-tested `sidebarShouldCollapse(touch, mobile, collapsed)` predicate (`touch && !mobile && collapsed`).
- `Herd.svelte`: optional `collapsible` / `oncollapse` props + far-right header chevron (last child of `.phead`, distinct from the all/ready filter chips).
- `+page.svelte`: derives `canCollapse`/`sidebarCollapsed`, swaps the Herd cell for the reopen tab in the focus split branch. Collapsed columns authored at `.grid.compact.collapsed` specificity (outranks `.grid.compact` by specificity, not source order) with `gap: 0` so no compact gutter is reserved.
- i18n: `herd_collapse` / `herd_expand` / `feat_sidebar_collapse_title` / `feat_sidebar_collapse_body` in EN + DE (parity gate green).
- Feature catalog: one entry (`sidebar-collapse`, `sinceVersion: 1.25.0`).
- Tokens only — no raw hex / ad-hoc px font-size; quiet chrome (no accent hue).

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- `bun run check:i18n` → 2 locales in parity (954 keys)
- `bun run test` → 936 passing (incl. new store + predicate truth-table tests)
- Pre-push gates green: branch hygiene (linear off main), feature catalog, fallow delta audit (dead code 0 · complexity 0)

## Notes / follow-up

Verified via builds, type-check, and unit tests. Browser verification on a live emulated unfolded-fold viewport (>768px + coarse pointer) — confirming the collapse/reopen visuals, persistence across reload, and that mouse-desktop/phone are unchanged — is recommended as a manual smoke check before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)