### PR TITLE
fix(viewport): clarify keynav legend needs Alt from terminal

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -564,7 +564,7 @@
   "viewport_type_steer_hint": "⌁ tippen zum Steuern",
   "viewport_detach_hint": "⇥ trennen",
   "viewport_select_hint": "{key} Ziehen zum Kopieren",
-  "viewport_keynav_hint": "j/k/1–9 Session wechseln ({key} aus dem Terminal)",
+  "viewport_keynav_hint": "j/k/1–9 Session wechseln: {key} im Terminal halten",
   "viewport_keynav_needsyou_hint": "g braucht dich",
   "viewport_keynav_enter_hint": "↵ zurück zum Terminal",
   "viewport_parked_title": "Auf anderem Gerät aktiv",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -564,7 +564,7 @@
   "viewport_type_steer_hint": "⌁ tippen zum Steuern",
   "viewport_detach_hint": "⇥ trennen",
   "viewport_select_hint": "{key} Ziehen zum Kopieren",
-  "viewport_keynav_hint": "j/k/1–9 Session wechseln: {key} im Terminal halten",
+  "viewport_keynav_hint": "j/k/1–9 Session wechseln: {key} aus dem Terminal halten",
   "viewport_keynav_needsyou_hint": "g braucht dich",
   "viewport_keynav_enter_hint": "↵ zurück zum Terminal",
   "viewport_parked_title": "Auf anderem Gerät aktiv",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -564,7 +564,7 @@
   "viewport_type_steer_hint": "⌁ type to steer",
   "viewport_detach_hint": "⇥ detach",
   "viewport_select_hint": "{key} drag to copy",
-  "viewport_keynav_hint": "j/k/1–9 switch session ({key} from terminal)",
+  "viewport_keynav_hint": "j/k/1–9 switch session: hold {key} from terminal",
   "viewport_keynav_needsyou_hint": "g needs you",
   "viewport_keynav_enter_hint": "↵ back to terminal",
   "viewport_parked_title": "Active on another device",


### PR DESCRIPTION
## What

The hotkey legend below the terminal advertised `j/k/1–9 switch session (Alt from terminal)`. The bare `j/k/1–9` keys only fire when focus is **out** of the terminal (the `isTyping` guard in `onShortcut`); with the terminal focused they're swallowed by the PTY and only `Alt`/`⌥ + j/k/1–9` work. The old `(Alt from terminal)` parenthetical read as an optional aside, so operators tried bare keys in the terminal and saw nothing happen.

## Change

Reword the `viewport_keynav_hint` message (string-only — no handler or markup change; the two-tier behavior is already correct) into an explicit imperative:

- EN: `j/k/1–9 switch session: hold {key} from terminal`
- DE: `j/k/1–9 Session wechseln: {key} im Terminal halten`

`{key}` still resolves to `⌥` (Mac) / `Alt` (other) at the existing call site (`Viewport.svelte:2219`).

Colon split chosen over an em-dash (avoids collision with the `1–9` en-dash) and over a `·` (the footer already uses `·` between separate hints).

## Why both tiers, bare-first

Decided with the user up front: keep advertising the bare-key chaining affordance, but make the Alt-from-terminal requirement unmissable via phrasing rather than reordering.

## Scope notes

- Copy-only fix → ships as `fix`, not `feat`; no `feature-announcements.ts` entry needed.
- i18n parity preserved (`check:i18n`: 950 keys each).

## Verification

- `cd ui && bun run check:i18n` ✓ (2 locales in parity)
- `cd ui && bun run check` ✓ (0 errors, 0 warnings)
- pre-push (fallow delta audit + branch hygiene) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)