### PR TITLE
fix(ui): scope session-card time popover to the wall-clock hover

### DIFF
--- a/ui/src/lib/components/TimePopover.svelte
+++ b/ui/src/lib/components/TimePopover.svelte
@@ -15,7 +15,7 @@
     git?: GitState;
     activity?: SessionActivity;
     nowMs: number;
-    /** The card overlay's getBoundingClientRect() at show time — the popover is
+    /** The wall-clock element's getBoundingClientRect() at show time — the popover is
      *  position:fixed (the cards clip: .tile / .swipe-wrap are overflow:hidden). */
     anchorRect: DOMRect;
     onclose: () => void;

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -190,6 +190,7 @@
   // ever misreport a session as alive.
   const resumable = $derived(canResume(session));
   let hitEl = $state<HTMLButtonElement>();
+  let elapsedEl = $state<HTMLSpanElement>();
   let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
   // Returns whether a menu actually opened (so the long-press can decide whether to
   // swallow the trailing tap). No-ops when nothing to offer or one is already open.
@@ -217,19 +218,36 @@
     ondecommission?.(session.id);
   }
 
-  // Time-breakdown popover: the .unit-hit overlay is the row's only hover
-  // surface (it covers the elapsed span and PrBadge, so their own hovers can
-  // never fire) — trigger there, with hover-intent so sweeping the cursor
-  // across the list doesn't cascade popovers. Keyboard focus shows immediately.
+  // Time-breakdown popover: the .unit-hit overlay is the row's only click/
+  // keyboard surface, but its mouse trigger is bounds-gated to the wall-clock
+  // (.elapsed) — onHitMove latches when the cursor enters/leaves the clock's
+  // rect, arming the 450ms hover-intent once on enter (not on every move) so
+  // sweeping the cursor across the list doesn't cascade popovers. Keyboard focus
+  // on the card still reveals it immediately; the popover anchors to the clock.
   let tipRect = $state<DOMRect | null>(null);
   let tipTimer: ReturnType<typeof setTimeout> | undefined;
+  let overClock = false; // pointer currently within the wall-clock element's bounds
   function tipShow(delay = 450) {
     clearTimeout(tipTimer);
-    tipTimer = setTimeout(() => (tipRect = hitEl?.getBoundingClientRect() ?? null), delay);
+    tipTimer = setTimeout(() => (tipRect = elapsedEl?.getBoundingClientRect() ?? null), delay);
   }
   function tipHide() {
     clearTimeout(tipTimer);
     tipRect = null;
+    overClock = false;
+  }
+  function onHitMove(e: MouseEvent) {
+    const r = elapsedEl?.getBoundingClientRect();
+    const inside =
+      !!r &&
+      e.clientX >= r.left &&
+      e.clientX <= r.right &&
+      e.clientY >= r.top &&
+      e.clientY <= r.bottom;
+    if (inside === overClock) return;
+    overClock = inside;
+    if (inside) tipShow();
+    else tipHide();
   }
 </script>
 
@@ -258,7 +276,7 @@
         tipHide();
         onContextMenu(e);
       }}
-      onmouseenter={() => tipShow()}
+      onmousemove={onHitMove}
       onmouseleave={tipHide}
       onfocus={() => {
         if (hitEl?.matches(":focus-visible")) tipShow(0);
@@ -396,7 +414,7 @@
       {:else if !hideStatus}
         <span class="badge" id="u-status-{session.id}">{statusLabel(dStatus)}</span>
       {/if}
-      <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
+      <span class="elapsed" bind:this={elapsedEl}>{elapsed(session.createdAt, nowMs)}</span>
     </div>
 
     {#if live}

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -224,9 +224,14 @@
   // rect, arming the 450ms hover-intent once on enter (not on every move) so
   // sweeping the cursor across the list doesn't cascade popovers. Keyboard focus
   // on the card still reveals it immediately; the popover anchors to the clock.
+  // The clock rect is measured once on card-enter and cached so the per-move
+  // bounds test never reads layout; bounded staleness is fine (the clock barely
+  // shifts during a hover, the popover anchors off a fresh read in tipShow, and
+  // it closes on scroll/resize).
   let tipRect = $state<DOMRect | null>(null);
   let tipTimer: ReturnType<typeof setTimeout> | undefined;
-  let overClock = false; // pointer currently within the wall-clock element's bounds
+  let overClock = false; // pointer currently within the cached clock bounds
+  let clockRect: DOMRect | null = null; // wall-clock bounds, cached on card-enter
   function tipShow(delay = 450) {
     clearTimeout(tipTimer);
     tipTimer = setTimeout(() => (tipRect = elapsedEl?.getBoundingClientRect() ?? null), delay);
@@ -236,8 +241,11 @@
     tipRect = null;
     overClock = false;
   }
+  function onHitEnter() {
+    clockRect = elapsedEl?.getBoundingClientRect() ?? null;
+  }
   function onHitMove(e: MouseEvent) {
-    const r = elapsedEl?.getBoundingClientRect();
+    const r = clockRect;
     const inside =
       !!r &&
       e.clientX >= r.left &&
@@ -276,6 +284,7 @@
         tipHide();
         onContextMenu(e);
       }}
+      onmouseenter={onHitEnter}
       onmousemove={onHitMove}
       onmouseleave={tipHide}
       onfocus={() => {

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -187,9 +187,14 @@
   // rect, arming the 450ms hover-intent once on enter (not on every move) so
   // sweeping the cursor across the grid doesn't cascade popovers. Keyboard focus
   // on the card still reveals it immediately; the popover anchors to the clock.
+  // The clock rect is measured once on card-enter and cached so the per-move
+  // bounds test never reads layout; bounded staleness is fine (the clock barely
+  // shifts during a hover, the popover anchors off a fresh read in tipShow, and
+  // it closes on scroll/resize).
   let tipRect = $state<DOMRect | null>(null);
   let tipTimer: ReturnType<typeof setTimeout> | undefined;
-  let overClock = false; // pointer currently within the wall-clock element's bounds
+  let overClock = false; // pointer currently within the cached clock bounds
+  let clockRect: DOMRect | null = null; // wall-clock bounds, cached on card-enter
   function tipShow(delay = 450) {
     clearTimeout(tipTimer);
     tipTimer = setTimeout(() => (tipRect = elapsedEl?.getBoundingClientRect() ?? null), delay);
@@ -199,8 +204,11 @@
     tipRect = null;
     overClock = false;
   }
+  function onHitEnter() {
+    clockRect = elapsedEl?.getBoundingClientRect() ?? null;
+  }
   function onHitMove(e: MouseEvent) {
-    const r = elapsedEl?.getBoundingClientRect();
+    const r = clockRect;
     const inside =
       !!r &&
       e.clientX >= r.left &&
@@ -234,6 +242,7 @@
       tipHide();
       onContextMenu(e);
     }}
+    onmouseenter={onHitEnter}
     onmousemove={onHitMove}
     onmouseleave={tipHide}
     onfocus={() => {

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -159,6 +159,7 @@
   // ever misreport a session as alive.
   const resumable = $derived(canResume(session));
   let hitEl = $state<HTMLButtonElement>();
+  let elapsedEl = $state<HTMLSpanElement>();
   let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
   function openMenuAt(x: number, y: number): boolean {
     if (menu || !resumable) return false;
@@ -180,19 +181,36 @@
     }
   }
 
-  // Time-breakdown popover: the .tile-hit overlay is the tile's only hover
-  // surface (it covers the elapsed span and PrBadge, so their own hovers can
-  // never fire) — trigger there, with hover-intent so sweeping the cursor
-  // across the grid doesn't cascade popovers. Keyboard focus shows immediately.
+  // Time-breakdown popover: the .tile-hit overlay is the tile's only click/
+  // keyboard surface, but its mouse trigger is bounds-gated to the wall-clock
+  // (.elapsed) — onHitMove latches when the cursor enters/leaves the clock's
+  // rect, arming the 450ms hover-intent once on enter (not on every move) so
+  // sweeping the cursor across the grid doesn't cascade popovers. Keyboard focus
+  // on the card still reveals it immediately; the popover anchors to the clock.
   let tipRect = $state<DOMRect | null>(null);
   let tipTimer: ReturnType<typeof setTimeout> | undefined;
+  let overClock = false; // pointer currently within the wall-clock element's bounds
   function tipShow(delay = 450) {
     clearTimeout(tipTimer);
-    tipTimer = setTimeout(() => (tipRect = hitEl?.getBoundingClientRect() ?? null), delay);
+    tipTimer = setTimeout(() => (tipRect = elapsedEl?.getBoundingClientRect() ?? null), delay);
   }
   function tipHide() {
     clearTimeout(tipTimer);
     tipRect = null;
+    overClock = false;
+  }
+  function onHitMove(e: MouseEvent) {
+    const r = elapsedEl?.getBoundingClientRect();
+    const inside =
+      !!r &&
+      e.clientX >= r.left &&
+      e.clientX <= r.right &&
+      e.clientY >= r.top &&
+      e.clientY <= r.bottom;
+    if (inside === overClock) return;
+    overClock = inside;
+    if (inside) tipShow();
+    else tipHide();
   }
   onDestroy(() => clearTimeout(tipTimer));
 </script>
@@ -216,7 +234,7 @@
       tipHide();
       onContextMenu(e);
     }}
-    onmouseenter={() => tipShow()}
+    onmousemove={onHitMove}
     onmouseleave={tipHide}
     onfocus={() => {
       if (hitEl?.matches(":focus-visible")) tipShow(0);
@@ -231,7 +249,7 @@
     <span class="name">{session.name}</span>
     <span class="spacer"></span>
     {#if dStatus === "running"}
-      <span class="elapsed">{elapsed(session.createdAt, nowMs)}</span>
+      <span class="elapsed" bind:this={elapsedEl}>{elapsed(session.createdAt, nowMs)}</span>
     {/if}
     <PrBadge {git} />
     <CriticBadge sessionId={session.id} />


### PR DESCRIPTION
## What

The session-card time-breakdown popover (PR #525) opened on hover **anywhere** on the card. Narrow the **mouse** trigger so it fires only while the pointer is over the wall-clock time (`<span class="elapsed">`).

## How

- Keep the full-card overlay (`.tile-hit` / `.unit-hit`) as the single click/keyboard target — no new interactive element, no pointer-events/CSS changes.
- Bounds-test the clock element inside the overlay's `mousemove` with an `overClock` edge-latch: the 450 ms hover-intent timer arms **once** on enter and clears once on leave (not restarted per move), so sweeping the cursor across the herd still doesn't cascade popovers.
- Anchor the popover to the **clock** rect (`elapsedEl.getBoundingClientRect()`) instead of the whole-card rect — `TimePopover` positioning is unchanged, just handed a smaller anchor.
- Applied **symmetrically** to both `UnitTile.svelte` (grid) and `UnitRow.svelte` (list); `TimePopover.svelte` gets a doc-only JSDoc fix for `anchorRect`.

## Behavior

- **Keyboard focus** on the card still reveals the popover (a keyboard user can't hover a sub-element) — `onfocus`/`onblur`/Escape unchanged.
- **Click-to-select** is untouched everywhere, including on the clock.
- **Accepted tradeoff:** in the grid, the clock only renders while a session is `running`, so idle/done **grid** tiles no longer show the popover (list view always renders the clock, so it keeps it in every state). This was reviewed and accepted in planning.

## Testing

- `cd ui && bun run check` — clean (0 errors, 0 warnings).
- Two-stage review (spec compliance + code quality) passed; latch transitions traced for stuck-shown/stuck-hidden — none found.

No new user-facing feature (refinement of existing hover) → no feature-catalog entry; no new strings → no i18n changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)