### PR TITLE
fix(cards): make REVIEWING / NEEDS YOU / WAITING badges mutually exclusive

### DIFF
--- a/ui/src/lib/components/AutopilotBadge.svelte
+++ b/ui/src/lib/components/AutopilotBadge.svelte
@@ -5,6 +5,7 @@
   let { session }: { session: Session } = $props();
 </script>
 
+<!-- Keep in sync with autopilotBadgeShown() in $lib/format — both must list the same states or card status-badge suppression desyncs. -->
 {#if session.autopilotPaused}
   <span
     class="ap-paused"

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
@@ -6,6 +6,15 @@ import UnitRow from "./UnitRow.svelte";
 import { projectIcons } from "$lib/projectIcons.svelte";
 import type { Session } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
+import type { ReviewVerdict } from "$lib/types";
+
+// Mock api so the reviews store's load() never fires real network calls.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return { ...actual, getReviews: vi.fn(async () => ({})), getReviewingIds: vi.fn(async () => []) };
+});
+
+const { reviews } = await import("$lib/reviews.svelte");
 
 function session(partial: Partial<Session> & { id: string }): Session {
   return {
@@ -43,6 +52,25 @@ function session(partial: Partial<Session> & { id: string }): Session {
     ...partial,
   };
 }
+
+const baseVerdict: ReviewVerdict = {
+  sessionId: "s1",
+  headSha: "abc",
+  decision: "commented",
+  summary: "",
+  body: "## findings",
+  findings: [],
+  addressRound: 0,
+  addressCap: 5,
+  finalRoundPending: false,
+  finalRoundTimeoutMs: 900_000,
+  updatedAt: Date.now(),
+};
+
+beforeEach(() => {
+  reviews.reviewing = {};
+  reviews.map = {};
+});
 
 describe("UnitRow merging badge", () => {
   it("shows MERGING for a merging session, not READY", async () => {
@@ -258,5 +286,37 @@ describe("UnitRow fine-pointer decommission ✕", () => {
     expect(decommissioned).toBe("d1");
     // the ✕ sits above the row overlay as a sibling — the row select never fires
     expect(selects).toBe(0);
+  });
+});
+
+describe("UnitRow badge mutual-exclusion (reviewing vs autopilot/status)", () => {
+  it("reviewing + autopilotPaused: REVIEWING… shown, Needs you and WAITING hidden", async () => {
+    const s = session({ id: "mx1", status: "done", autopilotPaused: true });
+    reviews.reviewing = { mx1: true };
+    render(UnitRow, {
+      session: s,
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expect.element(page.getByText(m.criticbadge_reviewing())).toBeInTheDocument();
+    await expect
+      .element(page.getByText(m.session_autopilot_paused_label()))
+      .not.toBeInTheDocument();
+    await expect.element(page.getByText(m.status_done())).not.toBeInTheDocument();
+  });
+
+  it("verdict + autopilotPaused (not reviewing): Needs you and verdict shown, WAITING hidden", async () => {
+    const s = session({ id: "mx2", status: "done", autopilotPaused: true });
+    reviews.map = { mx2: { ...baseVerdict, sessionId: "mx2", decision: "commented" } };
+    render(UnitRow, {
+      session: s,
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expect.element(page.getByText(m.session_autopilot_paused_label())).toBeInTheDocument();
+    await expect.element(page.getByText(m.criticbadge_commented())).toBeInTheDocument();
+    await expect.element(page.getByText(m.status_done())).not.toBeInTheDocument();
   });
 });

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -16,7 +16,14 @@
 
 <script lang="ts">
   import type { Session, GitState, SessionActivity } from "$lib/types";
-  import { elapsed, STATUS_COLOR, statusLabel, hideStatusBadge, canResume } from "$lib/format";
+  import {
+    elapsed,
+    STATUS_COLOR,
+    statusLabel,
+    hideStatusBadge,
+    autopilotBadgeShown,
+    canResume,
+  } from "$lib/format";
   import { displayStatus } from "$lib/display-status";
   import { resumeSession } from "$lib/api";
   import CardMenu from "./CardMenu.svelte";
@@ -151,7 +158,9 @@
     if (openRow === close) openRow = null;
   });
 
-  const hideStatus = $derived(hideStatusBadge(dStatus, reviews.isReviewing(session.id)));
+  const reviewing = $derived(reviews.isReviewing(session.id));
+  const autopilotShown = $derived(autopilotBadgeShown(session));
+  const hideStatus = $derived(hideStatusBadge(dStatus, reviewing, autopilotShown));
 
   // A status badge renders for merging / ready / a non-hidden status; only then
   // does #u-status-{id} exist. Build the overlay's aria-describedby so it omits
@@ -388,7 +397,8 @@
       <PrBadge {git} />
       <CriticBadge sessionId={session.id} />
       <PlanGateBadge {session} />
-      <AutopilotBadge {session} />
+      <!-- REVIEWING (in-flight critic) outranks the autopilot badge -->
+      {#if !reviewing}<AutopilotBadge {session} />{/if}
       {#if isMerging(session, nowMs)}
         <span class="badge merging" id="u-status-{session.id}">{m.status_merging()}</span>
       {:else if session.readyToMerge}

--- a/ui/src/lib/components/UnitTile.browser.test.ts
+++ b/ui/src/lib/components/UnitTile.browser.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { Session } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+
+// Mock api so the reviews store's load() never fires real network calls.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return { ...actual, getReviews: vi.fn(async () => ({})), getReviewingIds: vi.fn(async () => []) };
+});
+
+const { default: UnitTile } = await import("./UnitTile.svelte");
+const { reviews } = await import("$lib/reviews.svelte");
+
+function session(partial: Partial<Session> & { id: string }): Session {
+  return {
+    desig: "TASK-01",
+    name: "task one",
+    prompt: "p",
+    repoPath: "/repo/a",
+    baseBranch: "main",
+    branch: "feat/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "h",
+    herdrAgentId: "ha",
+    claudeSessionId: "cs",
+    model: null,
+    status: "idle",
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: null,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    auto: false,
+    issueNumber: null,
+    lastState: "",
+    createdAt: 0,
+    updatedAt: 0,
+    archivedAt: null,
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  reviews.reviewing = {};
+  reviews.map = {};
+});
+
+describe("UnitTile badge mutual-exclusion (reviewing vs autopilot)", () => {
+  it("reviewing + autopilotPaused: REVIEWING… shown, Needs you hidden", async () => {
+    const s = session({ id: "tx1", status: "done", autopilotPaused: true });
+    reviews.reviewing = { tx1: true };
+    render(UnitTile, {
+      session: s,
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expect.element(page.getByText(m.criticbadge_reviewing())).toBeInTheDocument();
+    await expect
+      .element(page.getByText(m.session_autopilot_paused_label()))
+      .not.toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -3,7 +3,14 @@
   import { Terminal } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
   import type { Session, GitState, SessionActivity } from "$lib/types";
-  import { STATUS_COLOR, statusLabel, elapsed, hideStatusBadge, canResume } from "$lib/format";
+  import {
+    STATUS_COLOR,
+    statusLabel,
+    elapsed,
+    hideStatusBadge,
+    autopilotBadgeShown,
+    canResume,
+  } from "$lib/format";
   import { onDestroy } from "svelte";
   import { displayStatus } from "$lib/display-status";
   import { connectPty } from "$lib/pty";
@@ -45,7 +52,9 @@
   // session gets the full working treatment. canResume stays on the raw status.
   const dStatus = $derived(displayStatus(session, workingBlocked));
 
-  const hideStatus = $derived(hideStatusBadge(dStatus, reviews.isReviewing(session.id)));
+  const reviewing = $derived(reviews.isReviewing(session.id));
+  const autopilotShown = $derived(autopilotBadgeShown(session));
+  const hideStatus = $derived(hideStatusBadge(dStatus, reviewing, autopilotShown));
 
   // A status badge renders for ready / a non-hidden status; only then does
   // #tile-status-{id} exist. Build the overlay's aria-describedby so it omits
@@ -236,7 +245,8 @@
     <PrBadge {git} />
     <CriticBadge sessionId={session.id} />
     <PlanGateBadge {session} />
-    <AutopilotBadge {session} />
+    <!-- REVIEWING (in-flight critic) outranks the autopilot badge -->
+    {#if !reviewing}<AutopilotBadge {session} />{/if}
     <AutoPip {session} />
     {#if session.readyToMerge}
       <span class="badge" id="tile-status-{session.id}">{m.status_ready_to_merge()}</span>

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
@@ -18,7 +18,11 @@ vi.mock("$lib/api", async (importOriginal) => {
 
 // Component must be imported AFTER the mock is registered.
 const { default: Viewport } = await import("./Viewport.svelte");
+// Dynamic import AFTER the $lib/api mock: reviews.svelte imports $lib/api, so a static
+// (hoisted) import would pull the real module in before the mock registers and break it.
+const { reviews } = await import("$lib/reviews.svelte");
 import { toasts } from "$lib/toasts.svelte";
+import { m } from "$lib/paraglide/messages";
 import type { Session } from "$lib/types";
 
 function session(partial: Partial<Session> & { id: string }): Session {
@@ -260,5 +264,38 @@ describe("Viewport preview stop — per-session pending resolution", () => {
     ).toBe(false);
 
     infoSpy.mockRestore();
+  });
+});
+
+// In the Viewport header the autopilot badge (NEEDS YOU / DELIVERED) can co-exist on
+// screen with the GitRail's in-flight REVIEWING indicator. Precedence mirrors the cards:
+// REVIEWING wins, so the header badge is suppressed while a critic review is in flight.
+describe("Viewport autopilot badge vs in-flight review", () => {
+  beforeEach(() => {
+    reviews.reviewing = {};
+  });
+
+  // Target the badge by its role="img" + aria-label, NOT getByText: the keynav hint
+  // ("g needs you") substring-matches the label and would mask the real badge.
+  const badge = () =>
+    page.getByRole("img", { name: m.session_autopilot_paused_label(), exact: true });
+
+  it("shows NEEDS YOU when no review is in flight", async () => {
+    render(Viewport, {
+      session: session({ id: "vr-ctl", autopilotPaused: true }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+    await expect.element(badge()).toBeInTheDocument();
+  });
+
+  it("suppresses NEEDS YOU while a critic review is in flight (REVIEWING wins)", async () => {
+    reviews.setReviewing("vr-rev", true);
+    render(Viewport, {
+      session: session({ id: "vr-rev", autopilotPaused: true }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+    await expect.element(badge()).not.toBeInTheDocument();
   });
 });

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1848,7 +1848,10 @@
           title={m.session_autopilot_on_label()}>{m.viewport_autopilot_pip()}</span
         >
       {/if}
-      <AutopilotBadge {session} />
+      <!-- REVIEWING (in-flight critic, surfaced in the GitRail/auto-pill) outranks the
+           autopilot badge — mirror the cards' precedence so NEEDS YOU/DELIVERED never
+           co-renders with REVIEWING anywhere. -->
+      {#if !reviews.isReviewing(session.id)}<AutopilotBadge {session} />{/if}
     {/if}
     <!-- trailing controls: on compact/phone they group + wrap together as a
          right-aligned cluster so the close button never orphans to its own row -->

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   hideStatusBadge,
+  autopilotBadgeShown,
   relativeAge,
   formatAgo,
   heartbeatTone,
@@ -35,23 +36,43 @@ describe("canResume", () => {
 });
 
 describe("hideStatusBadge", () => {
-  const cases: [SessionStatus, boolean, boolean][] = [
-    // status, reviewing, hidden
-    ["done", true, true],
-    ["idle", true, true],
-    ["done", false, false],
-    ["idle", false, false],
-    ["running", true, false],
-    ["running", false, false],
-    ["blocked", true, false],
-    ["blocked", false, false],
-    ["archived", true, false],
+  const cases: [SessionStatus, boolean, boolean, boolean][] = [
+    // status, reviewing, autopilotShown, hidden
+    ["done", true, false, true],
+    ["idle", true, false, true],
+    ["done", false, false, false],
+    ["idle", false, false, false],
+    ["running", true, false, false],
+    ["running", false, false, false],
+    ["blocked", true, false, false],
+    ["blocked", false, false, false],
+    ["archived", true, false, false],
+    // autopilotShown cases
+    ["done", false, true, true],
+    ["idle", false, true, true],
+    ["running", false, true, false],
+    ["blocked", false, true, false],
+    ["done", true, true, true],
   ];
 
-  for (const [status, reviewing, hidden] of cases) {
-    it(`${status} + reviewing=${reviewing} → ${hidden ? "hidden" : "shown"}`, () =>
-      expect(hideStatusBadge(status, reviewing)).toBe(hidden));
+  for (const [status, reviewing, autopilotShown, hidden] of cases) {
+    it(`${status} + reviewing=${reviewing} + autopilotShown=${autopilotShown} → ${hidden ? "hidden" : "shown"}`, () =>
+      expect(hideStatusBadge(status, reviewing, autopilotShown)).toBe(hidden));
   }
+});
+
+describe("autopilotBadgeShown", () => {
+  const session = (over: Partial<Session>): Session =>
+    ({ autopilotPaused: false, autopilotComplete: false, ...over }) as Session;
+
+  it("returns true when autopilotPaused", () =>
+    expect(autopilotBadgeShown(session({ autopilotPaused: true }))).toBe(true));
+
+  it("returns true when autopilotComplete", () =>
+    expect(autopilotBadgeShown(session({ autopilotComplete: true }))).toBe(true));
+
+  it("returns false when neither paused nor complete", () =>
+    expect(autopilotBadgeShown(session({}))).toBe(false));
 });
 
 describe("relativeAge", () => {

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -93,12 +93,31 @@ export const STATUS_COLOR: Record<SessionStatus, string> = {
 };
 
 /**
- * While a review is in flight, the WAITING/IDLE status badge is redundant noise
- * next to REVIEWING… — both just say "nothing actionable yet". Hide it then.
+ * The WAITING/IDLE status badge is redundant noise when a review is in flight
+ * (REVIEWING… already says "nothing actionable yet") OR when the autopilot badge
+ * (NEEDS YOU / DELIVERED) is shown — both cases make it superfluous.
  * WORKING/BLOCKED stay visible: those are genuinely different signals.
  */
-export function hideStatusBadge(s: SessionStatus, reviewing: boolean): boolean {
-  return reviewing && (s === "done" || s === "idle");
+export function hideStatusBadge(
+  s: SessionStatus,
+  reviewing: boolean,
+  autopilotShown = false,
+): boolean {
+  return (reviewing || autopilotShown) && (s === "done" || s === "idle");
+}
+
+/**
+ * Whether the autopilot badge (NEEDS YOU / DELIVERED) is currently shown for a
+ * session. Mirrors the render condition in `AutopilotBadge.svelte`
+ * (`{#if session.autopilotPaused}{:else if session.autopilotComplete}`) — the
+ * single source card parents consume to suppress the redundant status badge.
+ *
+ * IMPORTANT: if a new autopilot state is added, it MUST be reflected in BOTH
+ * this helper AND `AutopilotBadge.svelte`'s render condition, or status-badge
+ * suppression silently desyncs.
+ */
+export function autopilotBadgeShown(s: Session): boolean {
+  return s.autopilotPaused || s.autopilotComplete;
 }
 
 export function statusLabel(s: SessionStatus): string {


### PR DESCRIPTION
## Problem

On herd session cards, contradictory right-column badges stacked:

1. `REVIEWING…` (in-flight critic) **and** `NEEDS YOU` (autopilot paused) showed together.
2. `WAITING` status **and** `NEEDS YOU` showed together.

## Fix

Single, consistent precedence: **`REVIEWING…` > `NEEDS YOU` / `DELIVERED` > `WAITING` / `IDLE`** (operator-confirmed direction — REVIEWING wins).

- While a critic review is **in flight**, the autopilot badge (`NEEDS YOU` *and* `DELIVERED`) is hidden via a parent-level `{#if !reviewing}` guard in the cards. `AutopilotBadge`'s API/behavior is **unchanged**, so the Viewport's badge is unaffected by construction.
- When the autopilot badge is shown (paused or complete), the redundant `WAITING`(done)/`IDLE` status badge is hidden — `hideStatusBadge` now also takes `autopilotShown`.
- The **durable** verdict chip (`REVIEWED` / `CHANGES`) still coexists with `NEEDS YOU` — only the transient `REVIEWING…` chip is governed by precedence.

Applied symmetrically to both card surfaces (`UnitRow`, `UnitTile`).

### Behavior (truth table)

| reviewing | autopilot | status | Result |
|---|---|---|---|
| true | paused | done | `REVIEWING…` only |
| false (verdict) | paused | done | `REVIEWED` + `NEEDS YOU` |
| false | none | done | `WAITING` (unchanged) |
| true | none | idle | `REVIEWING…` only (unchanged) |

### Single-source guard

`autopilotBadgeShown()` (new helper in `format.ts`) mirrors `AutopilotBadge.svelte`'s render condition; cross-reference comments on both sides flag that a future autopilot state must be added in both places or status suppression desyncs.

### Accessibility

Suppressing the status badge drops its text from the row's `aria-describedby`; the autopilot badge is a `role="img"` with its own `aria-label`, announced independently as the replacement. Mirrors the existing `reviewing` behavior (no new a11y pattern).

## Tests

- `format.test.ts`: extended `hideStatusBadge` cases + new `autopilotBadgeShown` describe.
- `UnitRow.browser.test.ts`: reviewing+paused → only REVIEWING…; verdict+paused → NEEDS YOU + verdict, no WAITING.
- `UnitTile.browser.test.ts` (new): second surface coverage.

## Verification

- `cd ui && bun run check` — 0 errors / 0 warnings
- `cd ui && bun run test` — 935 passed
- pre-push hygiene + fallow audit gate pass (no new dead code / complexity; duplication warn-only, pre-existing)

No new user-facing strings (i18n n/a); `fix:` so feature-catalog gate not armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)