### PR TITLE
fix(projects): stop new-project route test from creating real GitHub repos

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,7 @@ import {
 } from "./validate";
 import { slugifyManual } from "./namer";
 import { planHouseRulesInjection, prioritize } from "./house-rules";
-import { listRepos, readTodo, writeTodo, cloneRepo, createProject } from "./repos";
+import { listRepos, readTodo, writeTodo, cloneRepo, createProject, type GhRunner } from "./repos";
 import { resolveDefaultBranch, fastForwardDefaultBranch } from "./pull";
 import { analyzeReadiness } from "./readiness";
 import { listCommands } from "./commands";
@@ -184,6 +184,11 @@ export interface AppDeps {
   };
   /** Full-auto merge train snapshot; absent in tests that don't exercise it. */
   autoMerge?: { snapshot(): Promise<import("./automerge").AutoMergeStatus[]> };
+  /** Injectable `gh` CLI runner for the POST /api/projects remote step. Absent in
+   *  production (createProject falls back to the real `gh` runner); tests inject a
+   *  fake so the route's partial-success mapping can be exercised WITHOUT creating
+   *  real GitHub repos. */
+  newProjectGhRunner?: GhRunner;
 }
 
 const sessionUsage = (s: Session) =>
@@ -1590,13 +1595,13 @@ const PROJECT_ERROR_STATUS: Record<string, number> = {
   newproject_failed_generic: 422,
 };
 
-async function createProjectFromRequest(req: Request): Promise<Response> {
+async function createProjectFromRequest(req: Request, ghRunner?: GhRunner): Promise<Response> {
   const ctErr = requireJsonContentType(req);
   if (ctErr) return ctErr;
   const body = (await req.json().catch(() => null)) as unknown;
   const parsed = validateNewProject(body, config.repoRoot);
   if (!parsed.ok) return json({ error: parsed.error }, PROJECT_ERROR_STATUS[parsed.error] ?? 400);
-  const r = await createProject(parsed.value, config.repoRoot);
+  const r = await createProject(parsed.value, config.repoRoot, ghRunner);
   if (!r.ok) return json({ error: r.error }, PROJECT_ERROR_STATUS[r.error] ?? 422);
   return json(r.warning ? { ...r.entry, warning: r.warning } : r.entry, 201);
 }
@@ -1628,9 +1633,9 @@ async function handleRepos({ req, parts, deps }: Ctx): Promise<Response | null> 
 }
 
 // POST /api/projects — bootstrap a new git project (git init + optional GitHub remote).
-async function handleProjects({ req, parts }: Ctx): Promise<Response | null> {
+async function handleProjects({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (parts[0] === "api" && parts[1] === "projects" && !parts[2]) {
-    if (req.method === "POST") return createProjectFromRequest(req);
+    if (req.method === "POST") return createProjectFromRequest(req, deps.newProjectGhRunner);
   }
   return null;
 }

--- a/test/server-projects.test.ts
+++ b/test/server-projects.test.ts
@@ -262,23 +262,31 @@ test("POST /api/projects local-only happy path → 201 + RepoEntry shape", async
 //
 // The partial-success logic lives in createProject (repos.ts, Task 2).
 // Here we verify the route correctly maps { ok: true, entry, warning } → 201 + warning.
-// We do this by crafting a request where createRemote=true but gh is not installed
-// (ENOENT → newproject_failed_gh_missing). The local repo is kept, response is 201
-// with a warning. We clean up the created dir after.
+//
+// We inject a FAKE gh runner (deps.newProjectGhRunner) that throws ENOENT, simulating
+// gh-not-installed → newproject_failed_gh_missing. This is mandatory: without it the
+// route would invoke the REAL gh on a developer machine where gh is installed +
+// authenticated, creating an actual private `srv-proj-partial-*` repo on every test
+// run (the remote step is never cleaned up — only the local dir is). The local repo
+// is kept on the partial failure, the response is 201 with the warning, and we remove
+// the created dir afterwards.
 
 test("POST /api/projects partial-success (gh missing) → 201 + warning", async () => {
   const { config } = await import("../src/config");
   const name = "srv-proj-partial-" + Date.now();
   const targetDir = join(config.repoRoot, name);
+  // gh runner that fails as if gh were not installed — keeps the test fully offline.
+  const ghMissing = () =>
+    Promise.reject(Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" }));
   try {
-    const app = makeTestApp();
+    const app = makeApp({ ...makeDeps(), newProjectGhRunner: ghMissing });
     const res = await postProjects(app, {
       name,
       idea: "test partial success",
       createRemote: true,
       visibility: "private",
     });
-    // May 422 if identity not set — skip
+    // May 422 if git identity is not configured in the test env — skip gracefully.
     if (res.status === 422) {
       const body = await res.json();
       if (body.error === "newproject_failed_identity") {
@@ -286,23 +294,14 @@ test("POST /api/projects partial-success (gh missing) → 201 + warning", async 
         return;
       }
     }
-    // Either 201 (local created, gh step failed or succeeded) or 422 (gh pre-check failed locally)
-    // We can't guarantee gh is absent, so we accept 201 with or without warning,
-    // or 422/504 if gh is installed and we hit a real error.
-    // The key assertion: if 201 → body has name/path/display (RepoEntry shape).
-    if (res.status === 201) {
-      const body = await res.json();
-      expect(typeof body.name).toBe("string");
-      expect(typeof body.path).toBe("string");
-      expect(typeof body.display).toBe("string");
-      // warning is either undefined or a newproject_failed_* string
-      if (body.warning !== undefined) {
-        expect(typeof body.warning).toBe("string");
-        expect(body.warning).toMatch(/^newproject_failed_/);
-      }
-    }
-    // We at minimum need the response to be a valid JSON object
-    // (already parsed above if 201)
+    // The fake runner forces the gh-missing branch: local create succeeds, remote
+    // step fails → 201 + warning. Deterministic, no network, no real repo.
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.name).toBe(name);
+    expect(typeof body.path).toBe("string");
+    expect(typeof body.display).toBe("string");
+    expect(body.warning).toBe("newproject_failed_gh_missing");
   } finally {
     if (existsSync(targetDir)) rmSync(targetDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem

A user noticed a pile of private `srv-proj-partial-*` repos accumulating in their personal GitHub account — **11 leaked repos**, all created in a ~1h window during development of #527 (the "create new project" feature).

Root cause is in `test/server-projects.test.ts` — the *partial-success* route test:

```ts
test("POST /api/projects partial-success (gh missing) → 201 + warning", ...)
```

Its premise (per the comment) was that `gh` is **not installed**, so `gh repo create` fails with ENOENT and the route returns `201 + warning`. But the test never mocked `gh`; `makeTestApp()` wired the **real** runner. On any machine where `gh` is installed + authenticated (i.e. every dev machine), the route actually ran:

```
gh repo create srv-proj-partial-<timestamp> --private --push
```

…creating a real private repo. The `finally` block only `rmSync`'d the **local** dir — the remote was never deleted. So **every `bun test` run leaked one private repo**. The test was also toothless: it accepted `201` with-or-without warning, `422`, or `504`, asserting almost nothing.

## Fix

The deeper flaw: the `POST /api/projects` route hardcoded the real `gh` runner with **no injection seam**, so it could not be tested without hitting GitHub.

- Add an optional `newProjectGhRunner?: GhRunner` to `AppDeps` and thread it through `handleProjects → createProjectFromRequest → createProject` (production passes nothing → real runner, unchanged behavior). `createProject` already supported runner injection at its layer; this just extends the seam to the route.
- Rewrite the leaky test to inject a fake runner that throws `ENOENT`, exercising the gh-missing branch **offline** and asserting deterministically: `201` + `warning === "newproject_failed_gh_missing"`. No network, no real repo.

## Verification

- `bun test ./test/server-projects.test.ts ./test/repos.test.ts` → 51 pass
- `bunx tsc --noEmit` clean, `bun run lint` clean, pre-push gate passed
- Ran the test against my real `gh` (installed + authed): the `srv-proj-partial-*` count stayed at **11** — confirmed no new leak.

## Cleanup note

The 11 already-leaked repos are not touched by this change — they need manual deletion (`gh repo delete`). Flagging for the maintainer rather than deleting from a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)