### PR TITLE
fix(toasts): full-width bottom banner with draining undo fill on phones

### DIFF
--- a/ui/src/lib/components/Toasts.svelte
+++ b/ui/src/lib/components/Toasts.svelte
@@ -44,7 +44,9 @@
 {/if}
 
 <style>
-  /* Bottom-center stack, clear of the safe area and the touch control bar. */
+  /* Desktop: a bottom-center floating stack, clear of the safe area. On phones
+     it becomes a full-width banner flush to the bottom edge — see the mobile
+     block at the foot of this file. */
   .toasts {
     position: fixed;
     left: 50%;

--- a/ui/src/lib/components/Toasts.svelte
+++ b/ui/src/lib/components/Toasts.svelte
@@ -169,7 +169,12 @@
       border-left: 0;
       border-right: 0;
       border-bottom: 0;
-      padding: 10px 14px calc(10px + env(safe-area-inset-bottom));
+      padding: 10px 14px;
+    }
+    /* column-reverse puts the first DOM child at the bottom — only that banner
+       touches the screen edge, so only it reserves the home-bar safe area. */
+    .toast:first-child {
+      padding-bottom: calc(10px + env(safe-area-inset-bottom));
     }
     .msg {
       font-size: var(--fs-meta);

--- a/ui/src/lib/components/Toasts.svelte
+++ b/ui/src/lib/components/Toasts.svelte
@@ -20,7 +20,7 @@
         <span class="msg">{t.text}</span>
         {#if t.tone === "undo"}
           <button type="button" class="undo" onclick={() => toasts.cancel(t.id)}>
-            {t.undoLabel}
+            <span class="undo-label">{t.undoLabel}</span>
             <span class="bar" style="--ms:{t.durationMs}ms" aria-hidden="true"></span>
           </button>
         {:else}
@@ -98,8 +98,13 @@
   .undo:hover {
     background: var(--color-hover);
   }
+  .undo-label {
+    position: relative;
+    z-index: 1;
+  }
   /* Depleting underline counting down the commit window. transform-only (no
-     layout), and the app-wide reduced-motion guard zeroes it out. */
+     layout), and the app-wide reduced-motion guard zeroes it out. On phones it
+     grows into a full-height fill behind the label (see the mobile block). */
   .bar {
     position: absolute;
     left: 0;
@@ -109,6 +114,7 @@
     background: var(--color-amber);
     transform-origin: left;
     animation: toast-deplete var(--ms, 5000ms) linear forwards;
+    z-index: 0;
   }
   .x {
     margin-left: auto;
@@ -140,6 +146,39 @@
     }
     to {
       transform: scaleX(0);
+    }
+  }
+
+  /* On small phones the stack becomes a full-width banner flush to the bottom
+     edge, with a tighter type scale. The undo countdown grows from a hairline
+     underline into a translucent fill that drains across the whole button —
+     the receding amber wash reads the shrinking commit window at a glance. */
+  @media (max-width: 768px) {
+    .toasts {
+      left: 0;
+      right: 0;
+      bottom: 0;
+      transform: none;
+      gap: 0;
+      align-items: stretch;
+    }
+    .toast {
+      max-width: none;
+      width: 100%;
+      border-radius: 0;
+      border-left: 0;
+      border-right: 0;
+      border-bottom: 0;
+      padding: 10px 14px calc(10px + env(safe-area-inset-bottom));
+    }
+    .msg {
+      font-size: var(--fs-meta);
+    }
+    .bar {
+      top: 0;
+      bottom: auto;
+      height: 100%;
+      background: color-mix(in srgb, var(--color-amber) 22%, transparent);
     }
   }
 </style>


### PR DESCRIPTION
## Was

Auf kleinen Handy-Bildschirmen schwebte die Undo-Toast ("Session stillgelegt") mittig über dem Inhalt, mit kleiner Schrift, und der Countdown war nur eine 2 px dünne Unterstreichung unter dem RÜCKGÄNGIG-Button.

Dieser PR macht die Toast auf Phones (`max-width: 768px`) zu einem **vollbreiten Banner bündig am unteren Bildschirmrand** mit etwas kleinerer Schrift. Der Undo-Countdown wächst von der Haarlinie zu einer **durchscheinenden Füllung, die quer durch den ganzen Button abläuft** — die zurückweichende Amber-Fläche zeigt das schrumpfende Commit-Fenster auf einen Blick.

## Wie

- `Toasts.svelte`: Label in `.undo-label` (z-index 1) gekapselt, damit die Füllung (`.bar`, z-index 0) dahinter liegt.
- Mobile-Block (`@media (max-width: 768px)`): `.toasts` spannt voll, `bottom: 0`, `align-items: stretch`; `.toast` randlos & vollbreit mit Safe-Area-Padding; `.msg` auf `--fs-meta`; `.bar` wird `height: 100%` mit `color-mix(... var(--color-amber) 22%, transparent)`.
- Desktop bleibt unverändert (dünne Unterstreichung).
- Nur Design-Tokens, keine Literale. Keine neuen i18n-Keys (bestehender Text wiederverwendet).

[no-feature-entry] — responsive Verfeinerung einer bestehenden Toast, kein neues Feature.

Preview: `https://moes-tavern.long-tautara.ts.net:5174/`