### PR TITLE
fix(ui): drop side borders on mobile selected card and full-bleed the top bar

### DIFF
--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -693,6 +693,17 @@
     padding-inline: 0;
   }
 
+  /* flow mode: rows are full-bleed, so the selected card's side borders would
+     draw two vertical lines hugging the screen edges (the panel itself already
+     dropped its own for the same reason) — keep only the top/bottom hairlines,
+     and drop the corner bracket that hangs off the right border with them. */
+  .units.flow :global(.unit.sel) {
+    border-inline-color: transparent;
+  }
+  .units.flow :global(.unit.sel::after) {
+    display: none;
+  }
+
   .empty {
     width: 100%;
     padding: 24px 14px;

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -1180,6 +1180,17 @@
     gap: 7px;
     row-gap: 8px;
     padding: 10px 12px;
+    /* full-bleed like the herd panel in flow mode: drop the side borders +
+       brackets and stretch into the shell's base edge padding
+       (--mobile-shell-pad, shared with .shell.mobile in +page.svelte; with a
+       larger safe-area inset the shell keeps the remainder). Top/bottom
+       hairlines stay as section rules. */
+    border-inline: 0;
+    margin-inline: calc(-1 * var(--mobile-shell-pad));
+  }
+  .hud.mobile.bracket::before,
+  .hud.mobile.bracket::after {
+    display: none;
   }
   .hud.mobile .logo {
     font-size: var(--fs-base);


### PR DESCRIPTION
## Problem

In der mobilen Listenansicht (Flow-Modus):

1. **Markierte Karte**: Unmarkierte Karten laufen randlos bis an die Bildschirmkanten, die markierte Karte zeichnete aber ihre hellen Seitenborder als zwei vertikale Linien direkt an den Kanten — sie wirkte eingerückt.
2. **Menüleiste (TopBar)**: Saß noch mit Shell-Randabstand (`--mobile-shell-pad`) + eigenen Seitenbordern/Eck-Brackets eingerückt, während die Liste darunter randlos läuft.

## Fix

- `Herd.svelte`: Im Flow-Modus bekommt `.unit.sel` transparente Seitenborder (obere/untere Haarlinien markieren weiterhin die Auswahl) und das Eck-Bracket unten rechts entfällt — gleiches Muster wie beim Panel selbst (`.panel.flow`).
- `TopBar.svelte`: `.hud.mobile` streckt sich per negativer Margin in den Shell-Rand (Safe-Area-Rest bleibt bei der Shell, identisch zu `.panel.flow`), Seitenborder + Brackets entfallen, obere/untere Haarlinien bleiben als Sektionslinien.

## Verifikation

- `bun run check`: 0 Errors / 0 Warnings
- Playwright-Screenshot (390×844, Touch) gegen den Dev-Server mit echtem herdr-Backend: TopBar randlos, markierte Karte randlos mit nur Top/Bottom-Haarlinien, kein Eck-Bracket.

Kein neuer User-facing Feature-Umfang (reiner `fix`), keine neuen Strings.