### PR TITLE
feat(issue-log): post waiting/merged workflow comments on the backlog issue

### DIFF
--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -363,6 +363,10 @@ export class GiteaForge implements GitForge {
     });
   }
 
+  async commentIssue(issueNumber: number, body: string): Promise<void> {
+    await this.req("POST", `/api/v1/repos/${this.slug}/issues/${issueNumber}/comments`, { body });
+  }
+
   async ensureIssueLink(prNumber: number, issueNumber: number): Promise<void> {
     const pr = (await this.req("GET", `/api/v1/repos/${this.slug}/pulls/${prNumber}`)) as {
       body?: string | null;

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -504,6 +504,10 @@ export class GithubForge implements GitForge {
     await this.run(["issue", "close", String(issueNumber), "--repo", this.slug]);
   }
 
+  async commentIssue(issueNumber: number, body: string): Promise<void> {
+    await this.run(["issue", "comment", String(issueNumber), "--repo", this.slug, "--body", body]);
+  }
+
   async comment(prNumber: number, body: string): Promise<void> {
     await this.run(["pr", "comment", String(prNumber), "--repo", this.slug, "--body", body]);
   }

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -221,6 +221,11 @@ export interface GitForge {
   /** Close an issue by number (best-effort; used by the drain to retire a backlog
    *  issue once its auto PR merges). Optional: hosts without an issues-close API omit it. */
   closeIssue?(issueNumber: number): Promise<void>;
+  /** Post a plain comment on an issue (the issue-log's workflow protocol: one note
+   *  when the session's PR enters the waiting-on-handoff state, one when it merges).
+   *  Best-effort; optional (hosts without an issue-comment API omit it and the
+   *  issue-log stays silent). */
+  commentIssue?(issueNumber: number, body: string): Promise<void>;
   /** Ensure the PR body links the issue so the forge auto-closes it on merge.
    *  Idempotent: appends a `Closes #<issueNumber>` line only when no closing
    *  keyword for that issue is already present. Best-effort; optional (hosts

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import {
 } from "./push";
 import { Presence } from "./presence";
 import { ReviewService } from "./review";
+import { createIssueLogger } from "./issue-log";
 import { PlanGateService } from "./plan-gate";
 import { AutopilotService } from "./autopilot";
 import { DrainService } from "./drain";
@@ -420,6 +421,21 @@ events.subscribe((event, data) => {
   // work and log spam on every subsequent poll tick (mirrors how session:archived
   // gates forget() on the id being present before calling it).
   if (advanced) planGate.forget(id);
+});
+
+// Workflow protocol on the session's backlog issue: one comment when the PR enters
+// the waiting-on-handoff state (open + green + foreign reviewer/merger), one when it
+// merges. Stamped per PR in issue_log so each fires once, across restarts and CI
+// flaps; best-effort — a failed comment is retried on the next git event.
+const logIssueWorkflow = createIssueLogger({ resolveForge, store });
+events.subscribe((event, data) => {
+  if (event !== "session:git") return;
+  const { id, git } = data as { id: string; git: import("./forge/types").GitState };
+  const s = store.get(id);
+  if (!s || s.issueNumber == null) return;
+  void logIssueWorkflow(s, git).catch((err) =>
+    console.warn(`[issue-log] comment on #${s.issueNumber} failed:`, err),
+  );
 });
 setInterval(() => {
   if (maintenance.active) return;

--- a/src/issue-log.ts
+++ b/src/issue-log.ts
@@ -1,0 +1,89 @@
+import type { GitForge, GitState } from "./forge/types";
+import type { Session } from "./types";
+
+/**
+ * Issue-log: the workflow protocol on a session's backlog issue. For a session
+ * spawned from an issue, post one comment when its PR enters the waiting-on-handoff
+ * state (open + green CI + a foreign reviewer/merger from `.shepherd/roles.json`)
+ * and one when the PR merges — so the issue's timeline records who the work was
+ * parked on and when it landed.
+ *
+ * Deliberately STATELESS over the current GitState (no prev-state comparison):
+ * dedup lives in the persisted `issue_log` stamps, so each transition comments
+ * exactly once per PR across restarts, CI flaps, and the one-time backfill burst
+ * when roles are first configured (the operator chose to backfill already-waiting
+ * PRs). A reviewer→merger handoff flip after approval does NOT re-comment — one
+ * "waiting" note per PR, keyed `waiting:<pr>` / `merged:<pr>`; a NEW PR (new
+ * number) logs again. Best-effort like closeIssue: a failed comment is not
+ * stamped, so the next session:git event retries it.
+ */
+export interface IssueLogEntry {
+  key: string;
+  body: string;
+}
+
+/** The comments `git`'s current state still owes the issue — pure, testable core.
+ *  Wording is forge content (English, like PR bodies); the merged note is phrased
+ *  to stay valid whether the issue is open (manual session) or being closed by
+ *  merge-teardown at the same moment (auto session). */
+export function issueLogEntries(
+  git: GitState,
+  alreadyLogged: (key: string) => boolean,
+): IssueLogEntry[] {
+  if (git.number == null) return [];
+  const out: IssueLogEntry[] = [];
+  // handoff is only annotated on an open+green PR (annotateHandoff), but re-check
+  // the full condition so a stale/hand-rolled GitState can't comment early.
+  if (git.state === "open" && git.checks === "success" && git.handoff) {
+    const key = `waiting:${git.number}`;
+    if (!alreadyLogged(key)) out.push({ key, body: waitingBody(git, git.number) });
+  }
+  if (git.state === "merged") {
+    const key = `merged:${git.number}`;
+    if (!alreadyLogged(key)) out.push({ key, body: `✅ PR #${git.number} merged.` });
+  }
+  return out;
+}
+
+function waitingBody(git: GitState, prNumber: number): string {
+  if (git.handoff === "reviewer" && git.handoffWho)
+    return `⏸️ Waiting on review of PR #${prNumber} by @${git.handoffWho}.`;
+  if (git.handoff === "merger" && git.handoffWho)
+    return `⏸️ Waiting on @${git.handoffWho} to merge PR #${prNumber}.`;
+  return `⏸️ Waiting on PR #${prNumber} to merge.`;
+}
+
+export interface IssueLogDeps {
+  resolveForge: (repoPath: string) => Pick<GitForge, "commentIssue"> | null;
+  store: {
+    hasIssueLog(sessionId: string, key: string): boolean;
+    markIssueLog(sessionId: string, key: string): void;
+  };
+}
+
+type IssueLogSession = Pick<Session, "id" | "repoPath" | "issueNumber">;
+
+/** Build the session:git handler: post any owed comments, stamping each only after
+ *  its comment succeeded. The in-flight guard closes the check-then-comment race
+ *  when two git events for one session land back-to-back (poller + repushHandoff). */
+export function createIssueLogger(deps: IssueLogDeps) {
+  const inFlight = new Set<string>();
+  return async (s: IssueLogSession, git: GitState): Promise<void> => {
+    if (s.issueNumber == null) return;
+    const entries = issueLogEntries(git, (key) => deps.store.hasIssueLog(s.id, key));
+    if (entries.length === 0) return;
+    const forge = deps.resolveForge(s.repoPath);
+    if (!forge?.commentIssue) return; // host can't comment → stay silent, don't stamp
+    for (const e of entries) {
+      const flightKey = `${s.id}:${e.key}`;
+      if (inFlight.has(flightKey)) continue;
+      inFlight.add(flightKey);
+      try {
+        await forge.commentIssue(s.issueNumber, e.body);
+        deps.store.markIssueLog(s.id, e.key);
+      } finally {
+        inFlight.delete(flightKey);
+      }
+    }
+  };
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -237,6 +237,12 @@ export class SessionStore implements CapStore {
     );
     this.db.run(`CREATE TABLE IF NOT EXISTS build_queue_state (
       sessionId TEXT PRIMARY KEY, approved INTEGER NOT NULL DEFAULT 0, updatedAt INTEGER NOT NULL)`);
+    // One stamp per workflow-protocol comment posted on a session's backlog issue
+    // (issue-log: `waiting:<pr>` / `merged:<pr>`), so each transition comments exactly
+    // once per PR across restarts and CI flaps.
+    this.db.run(`CREATE TABLE IF NOT EXISTS issue_log (
+      sessionId TEXT NOT NULL, key TEXT NOT NULL, createdAt INTEGER NOT NULL,
+      PRIMARY KEY (sessionId, key))`);
     this.db.run(`CREATE TABLE IF NOT EXISTS push_subscriptions (
       endpoint TEXT PRIMARY KEY, p256dh TEXT NOT NULL, auth TEXT NOT NULL,
       ua TEXT NOT NULL DEFAULT '', locale TEXT NOT NULL DEFAULT 'en',
@@ -701,6 +707,23 @@ export class SessionStore implements CapStore {
     this.db.run(`DELETE FROM reviews WHERE sessionId = ?`, [sessionId]);
   }
 
+  // ── issue workflow log (one stamp per posted issue comment) ───────────────
+  hasIssueLog(sessionId: string, key: string): boolean {
+    return (
+      this.db
+        .query(`SELECT 1 FROM issue_log WHERE sessionId = ? AND key = ?`)
+        .get(sessionId, key) != null
+    );
+  }
+
+  markIssueLog(sessionId: string, key: string): void {
+    this.db.run(`INSERT OR IGNORE INTO issue_log (sessionId, key, createdAt) VALUES (?, ?, ?)`, [
+      sessionId,
+      key,
+      Date.now(),
+    ]);
+  }
+
   /** Re-point an existing verdict at a new head without re-reviewing. Used when a head
    *  change (rebase/force-push) leaves the reviewed diff content-identical (same patchId):
    *  the prior decision/findings/rounds still apply, so only headSha + updatedAt move. */
@@ -952,6 +975,10 @@ export class SessionStore implements CapStore {
       );
       this.db.run(
         `DELETE FROM plan_gates WHERE sessionId IN (SELECT id FROM sessions WHERE ${victims})`,
+        params,
+      );
+      this.db.run(
+        `DELETE FROM issue_log WHERE sessionId IN (SELECT id FROM sessions WHERE ${victims})`,
         params,
       );
       this.db.run(`DELETE FROM sessions WHERE ${victims}`, params);

--- a/test/issue-log.test.ts
+++ b/test/issue-log.test.ts
@@ -1,0 +1,135 @@
+import { test, expect, mock } from "bun:test";
+import { issueLogEntries, createIssueLogger } from "../src/issue-log";
+import { SessionStore } from "../src/store";
+import type { GitState } from "../src/forge/types";
+
+const never = () => false;
+
+function open(over: Partial<GitState> = {}): GitState {
+  return {
+    kind: "github",
+    state: "open",
+    checks: "success",
+    number: 7,
+    deployConfigured: false,
+    ...over,
+  };
+}
+
+// ── issueLogEntries (pure decision) ──────────────────────────────────────────
+
+test("open+green+reviewer handoff → one waiting entry naming the reviewer", () => {
+  const e = issueLogEntries(open({ handoff: "reviewer", handoffWho: "scoop" }), never);
+  expect(e).toEqual([{ key: "waiting:7", body: "⏸️ Waiting on review of PR #7 by @scoop." }]);
+});
+
+test("open+green+merger handoff → one waiting entry naming the merger", () => {
+  const e = issueLogEntries(open({ handoff: "merger", handoffWho: "scoop" }), never);
+  expect(e).toEqual([{ key: "waiting:7", body: "⏸️ Waiting on @scoop to merge PR #7." }]);
+});
+
+test("handoff without a login → generic waiting wording", () => {
+  const e = issueLogEntries(open({ handoff: "merger" }), never);
+  expect(e).toEqual([{ key: "waiting:7", body: "⏸️ Waiting on PR #7 to merge." }]);
+});
+
+test("merged → one merged entry, phrased issue-state-agnostic", () => {
+  const e = issueLogEntries(open({ state: "merged" }), never);
+  expect(e).toEqual([{ key: "merged:7", body: "✅ PR #7 merged." }]);
+});
+
+test("no handoff / pending checks / no PR number → nothing owed", () => {
+  expect(issueLogEntries(open(), never)).toEqual([]); // green but self-turn
+  expect(issueLogEntries(open({ handoff: "merger", checks: "pending" }), never)).toEqual([]);
+  expect(issueLogEntries(open({ handoff: "merger", number: undefined }), never)).toEqual([]);
+});
+
+test("already-logged keys are owed nothing (flap/restart dedup)", () => {
+  const logged = new Set(["waiting:7"]);
+  const e = issueLogEntries(open({ handoff: "merger", handoffWho: "scoop" }), (k) => logged.has(k));
+  expect(e).toEqual([]);
+  // a NEW PR number logs again
+  const e2 = issueLogEntries(open({ handoff: "merger", handoffWho: "scoop", number: 9 }), (k) =>
+    logged.has(k),
+  );
+  expect(e2.map((x) => x.key)).toEqual(["waiting:9"]);
+});
+
+// ── createIssueLogger (wiring: comment → stamp, best-effort) ─────────────────
+
+const session = { id: "s1", repoPath: "/r", issueNumber: 42 };
+
+function logger(over: { comment?: () => Promise<void>; forge?: null } = {}) {
+  const store = new SessionStore(":memory:");
+  const comment = mock<(issueNumber: number, body: string) => Promise<void>>(
+    over.comment ?? (async () => {}),
+  );
+  const log = createIssueLogger({
+    resolveForge: () => (over.forge === null ? null : { commentIssue: comment }),
+    store,
+  });
+  return { store, comment, log };
+}
+
+test("posts the owed comment once, stamps it, and never re-posts", async () => {
+  const { store, comment, log } = logger();
+  const git = open({ handoff: "merger", handoffWho: "scoop" });
+  await log(session, git);
+  await log(session, git); // flap / restart replay
+  expect(comment.mock.calls).toEqual([[42, "⏸️ Waiting on @scoop to merge PR #7."]]);
+  expect(store.hasIssueLog("s1", "waiting:7")).toBe(true);
+});
+
+test("waiting then merged: two comments, two stamps", async () => {
+  const { store, comment, log } = logger();
+  await log(session, open({ handoff: "reviewer", handoffWho: "scoop" }));
+  await log(session, open({ state: "merged" }));
+  expect(comment.mock.calls.length).toBe(2);
+  expect(store.hasIssueLog("s1", "merged:7")).toBe(true);
+});
+
+test("failed comment is NOT stamped → retried on the next event", async () => {
+  let calls = 0;
+  const { store, comment, log } = logger({
+    comment: async () => {
+      if (++calls === 1) throw new Error("gh down");
+    },
+  });
+  const git = open({ handoff: "merger", handoffWho: "scoop" });
+  await expect(log(session, git)).rejects.toThrow("gh down");
+  expect(store.hasIssueLog("s1", "waiting:7")).toBe(false);
+  await log(session, git); // next session:git event retries
+  expect(comment.mock.calls.length).toBe(2);
+  expect(store.hasIssueLog("s1", "waiting:7")).toBe(true);
+});
+
+test("no issueNumber / no forge / forge without commentIssue → silent, no stamp", async () => {
+  const { comment, log } = logger();
+  await log({ ...session, issueNumber: null }, open({ handoff: "merger" }));
+  expect(comment.mock.calls.length).toBe(0);
+
+  const noForge = logger({ forge: null });
+  await noForge.log(session, open({ handoff: "merger" }));
+  expect(noForge.store.hasIssueLog("s1", "waiting:7")).toBe(false);
+
+  const bare = new SessionStore(":memory:");
+  const noComment = createIssueLogger({ resolveForge: () => ({}), store: bare });
+  await noComment(session, open({ handoff: "merger" }));
+  expect(bare.hasIssueLog("s1", "waiting:7")).toBe(false);
+});
+
+test("concurrent events for the same owed comment post it once (in-flight guard)", async () => {
+  let resolveComment: () => void = () => {};
+  const { comment, log } = logger({
+    comment: () =>
+      new Promise<void>((res) => {
+        resolveComment = res;
+      }),
+  });
+  const git = open({ handoff: "merger", handoffWho: "scoop" });
+  const first = log(session, git); // hangs in commentIssue
+  const second = log(session, git); // same key in flight → skipped
+  resolveComment();
+  await Promise.all([first, second]);
+  expect(comment.mock.calls.length).toBe(1);
+});


### PR DESCRIPTION
## What

For a session spawned from a GitHub issue, Shepherd now writes a small workflow protocol onto that issue:

- **⏸️ Waiting** — one comment when the session's PR enters the waiting-on-handoff state (open + green CI + a foreign reviewer/merger from `.shepherd/roles.json`), naming who the work is parked on (e.g. *"Waiting on @scoop to merge PR #531."*).
- **✅ Merged** — one comment when the PR lands. Phrased issue-state-agnostic, since merge-teardown may be closing the issue at the same moment (auto sessions).

Each transition comments **exactly once per PR**, across restarts, CI flaps, and a reviewer→merger handoff flip: stamps live in the new `issue_log` table and are written only after the comment succeeded (a transient `gh` failure retries on the next `session:git` event). Sessions without an issue stay silent. New optional `Forge.commentIssue` (GitHub: `gh issue comment`; Gitea: comments API); hosts without it stay silent and unstamped.

## Context (approved plan)

This is Teil B of the approved `.shepherd-plan.md`. Teil A — fixing the misleading "Du bist dran" for PRs that actually wait on Patrick — needed **no code**: the repo roles are now configured (`reviewer: scoop, merger: scoop`, commit `1e6eb95` on `main` via the Automations-panel endpoint), so open+green PR sessions sort into "Warten auf scoop" instead of "Your turn".

Per the user's explicit choice, already-waiting PRs get a **one-time backfill** comment when this lands (stateless trigger by design); the stamps cap that at one comment per issue. Empirics for the roles value, re-run at execution time: PRs #529–#533 were all merged by `scoop`, and the operator confirmed scoop merges every PR in this repo.

`[no-feature-entry]` — server-only: no in-app UX surface; the protocol lands on the forge.

## Verification

- Root suite in a fresh `/tmp` worktree at this HEAD: **1879 pass, 1 skip (pre-existing), 0 fail** (session-worktree runs are hang-prone, hence `/tmp`).
- `tsc --noEmit`, `eslint`, `prettier --check`, branch-hygiene + feature-catalog gates: green locally.
- New `test/issue-log.test.ts`: wording per handoff role, dedupe (flap/restart/new-PR), stamp-after-success retry, silent paths (no issue / no forge / no `commentIssue`), in-flight race guard.
- UI/extension untouched; their CI gates cover the no-op.