### PR TITLE
feat(herdr-update): link upstream release notes for multi-version jumps

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -20,6 +20,7 @@
   "herdrupdate_done_fail": "Update nicht abgeschlossen (weiterhin auf {current}). Prüfe das Log; du kannst es erneut versuchen.",
   "herdrupdate_later": "Später",
   "herdrupdate_log_label": "Update-Protokoll",
+  "herdrupdate_all_notes_link": "Alle Release-Notes ansehen",
   "common_needs_you": "BRAUCHT DICH · {count}",
   "common_no_open_issues": "keine offenen Issues",
   "main_no_unit_selected": "KEINE AUFGABE GEWÄHLT",
@@ -953,5 +954,7 @@
   "feat_new_project_title": "Neues Projekt starten",
   "feat_new_project_body": "Lege ein frisches Git-Repository an — optional auch auf GitHub — und starte den ersten Agenten-Run, ohne Shepherd zu verlassen.",
   "feat_sidebar_collapse_title": "Einklappbare Seitenleiste",
-  "feat_sidebar_collapse_body": "Auf Touch-Tablets und aufgeklappten Foldables die Herd-Seitenleiste einklappen, um dem Terminal mehr Platz zu geben. Deine Auswahl wird gespeichert."
+  "feat_sidebar_collapse_body": "Auf Touch-Tablets und aufgeklappten Foldables die Herd-Seitenleiste einklappen, um dem Terminal mehr Platz zu geben. Deine Auswahl wird gespeichert.",
+  "feat_herdr_release_notes_link_title": "herdr-Release-Notes (Upstream)",
+  "feat_herdr_release_notes_link_body": "Das herdr-Update-Panel verlinkt jetzt den vollständigen Upstream-Release-Verlauf auf GitHub — praktisch, wenn du mehrere Versionen überspringst und die Notizen aller Versionen sehen willst, nicht nur der neuesten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -20,6 +20,7 @@
   "herdrupdate_done_fail": "Update did not complete (still on {current}). Check the log; you can retry.",
   "herdrupdate_later": "Later",
   "herdrupdate_log_label": "Update log",
+  "herdrupdate_all_notes_link": "View all release notes",
   "common_needs_you": "NEEDS YOU · {count}",
   "common_no_open_issues": "no open issues",
   "main_no_unit_selected": "NO TASK SELECTED",
@@ -953,5 +954,7 @@
   "feat_new_project_title": "Start a new project",
   "feat_new_project_body": "Create a fresh git repo — optionally on GitHub — and kick off the first agent run, all without leaving Shepherd.",
   "feat_sidebar_collapse_title": "Collapsible sidebar",
-  "feat_sidebar_collapse_body": "On touch tablets and unfolded foldables, collapse the Herd sidebar to give the terminal more room. Your choice is remembered."
+  "feat_sidebar_collapse_body": "On touch tablets and unfolded foldables, collapse the Herd sidebar to give the terminal more room. Your choice is remembered.",
+  "feat_herdr_release_notes_link_title": "Upstream herdr release notes",
+  "feat_herdr_release_notes_link_body": "The herdr update panel now links to the full upstream release history on GitHub — handy when you're jumping across several versions and want every version's notes, not just the latest."
 }

--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -25,6 +25,12 @@
   let error = $state<string | null>(null);
   let logEl = $state<HTMLPreElement | null>(null);
 
+  // Upstream release history. herdr.dev/releases/ was stale (only 0.6.3) as of
+  // 2026-06-11 while upstream was 0.6.10, and itself links to this GitHub repo —
+  // same slug as latest.json's binary-download asset URLs. Revisit if
+  // herdr.dev/releases/ catches up or the repo moves.
+  const HERDR_RELEASES_URL = "https://github.com/ogulcancelik/herdr/releases";
+
   // Render the (GitHub release) notes as markdown, sanitized before @html.
   // marked + DOMPurify are dynamically imported on first render so they stay
   // off the critical path; the (browser-only) sanitizer never runs during SSR.
@@ -146,6 +152,10 @@
         <pre class="notes notes-raw">{update.notes}</pre>
       {/if}
     {/if}
+
+    <a class="all-notes" href={HERDR_RELEASES_URL} target="_blank" rel="noopener noreferrer"
+      >{m.herdrupdate_all_notes_link()} ↗</a
+    >
 
     <div class="instructions">{m.herdrupdate_instructions()}</div>
 
@@ -319,6 +329,16 @@
   .notes :global(a) {
     color: var(--color-blue);
     text-decoration: underline;
+  }
+  .all-notes {
+    align-self: flex-start;
+    color: var(--color-blue);
+    font-size: var(--fs-meta);
+    text-decoration: underline;
+    letter-spacing: 0.04em;
+  }
+  .all-notes:hover {
+    color: var(--color-amber);
   }
   .notes :global(code) {
     font-family: var(--font-mono);

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -492,4 +492,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_sidebar_collapse_title",
     bodyKey: "feat_sidebar_collapse_body",
   },
+  {
+    // No targetId: the herdr update modal is only mounted while open (and only when an
+    // update is available), so a coachmark anchor would rarely exist — surface via the
+    // What's-New drawer only. v1.24.0 is already tagged, so this ships in 1.25.0.
+    id: "herdr-release-notes-link",
+    sinceVersion: "1.25.0",
+    titleKey: "feat_herdr_release_notes_link_title",
+    bodyKey: "feat_herdr_release_notes_link_body",
+  },
 ];


### PR DESCRIPTION
## What

The herdr update modal renders only the **latest** version's release notes (the single top-level `notes` blob from `herdr.dev/latest.json`). When an operator is several versions behind (e.g. 0.6.5 → 0.6.10), the intermediate versions' notes are invisible.

This adds an always-visible **"View all release notes ↗"** link in the modal pointing at the full upstream release history.

## Link target

`https://github.com/ogulcancelik/herdr/releases` — chosen over herdr.dev's own `/releases/` page after verifying (2026-06-11):

- GitHub releases → HTTP 200, lists v0.6.7–v0.6.10 (the live multi-version range). ✓
- `herdr.dev/releases/` → HTTP 200 but **stale (only 0.6.3)**, and that page itself links out to the same GitHub repo.

The `ogulcancelik/herdr` slug is corroborated by `latest.json`'s binary-download asset URLs. The hardcoded URL carries a dated, conditional code comment so a future reader knows the choice was made because herdr.dev was stale, not as a permanent fact.

## Changes

- `HerdrUpdateModal.svelte` — `HERDR_RELEASES_URL` const + always-visible link (outside the `{#if update.notes}` conditional, opens in a new tab with `rel="noopener noreferrer"`); `.all-notes` style using only design tokens.
- `en.json` / `de.json` — `herdrupdate_all_notes_link` + feature-catalog `feat_herdr_release_notes_link_{title,body}` (EN+DE parity).
- `feature-announcements.ts` — one catalog entry (`sinceVersion: 1.25.0`).

## Verification

- `cd ui && bun run check` — pass (0 errors/warnings)
- `cd ui && bun run check:i18n` — pass (2 locales, parity)
- `cd ui && bun run test` — pass (951/951)
- pre-push gates (branch hygiene, feature catalog, fallow audit) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)