### PR TITLE
fix(ui): clear read-only message when a mutation is blocked by preview origin

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -35,6 +35,7 @@
   "emptyherd_verb_ready_desc": "Sitzungen mit grünem PR sammeln sich in einer eigenen Gruppe und warten auf deinen Merge.",
   "emptyherd_nudge_action": "Lege eine Issue-Aktion an",
   "emptyherd_nudge_tail": "in den Einstellungen unter Gespeicherte Steers, um Aufgaben direkt aus dem Backlog zu starten.",
+  "error_preview_readonly": "Die Vorschau ist schreibgeschützt. Öffne Shepherd direkt (nicht über die Live-Vorschau), um Änderungen vorzunehmen.",
   "status_working": "AKTIV",
   "status_idle": "INAKTIV",
   "status_blocked": "BLOCKIERT",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -35,6 +35,7 @@
   "emptyherd_verb_ready_desc": "Sessions with a green PR park in their own group, waiting on your merge.",
   "emptyherd_nudge_action": "Add an issue action",
   "emptyherd_nudge_tail": "under Settings → Saved steers to quick-launch tasks straight from the backlog.",
+  "error_preview_readonly": "Preview is read-only. Open Shepherd directly (not through the live preview) to make changes.",
   "status_working": "BUSY",
   "status_idle": "IDLE",
   "status_blocked": "BLOCKED",

--- a/ui/src/lib/api.previewBlocked.test.ts
+++ b/ui/src/lib/api.previewBlocked.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { createSession, isPreviewBlocked } from "./api";
+import type { CreateInput } from "./types";
+
+function mockFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn(
+    async () => new Response(JSON.stringify(body), { status }),
+  ) as unknown as typeof fetch;
+}
+
+describe("preview-origin blocked detection", () => {
+  it("maps a 403 origin-block body to a PreviewBlockedError", async () => {
+    globalThis.fetch = mockFetch(403, { error: "forbidden: origin not allowed" });
+    const err = await createSession({ repo: "r", prompt: "p" } as unknown as CreateInput).then(
+      () => null,
+      (e) => e as Error,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(isPreviewBlocked(err)).toBe(true);
+    // Remapped to a (translated) sentence — not the raw server string.
+    expect(err!.message.length).toBeGreaterThan(0);
+    expect(err!.message).not.toBe("forbidden: origin not allowed");
+  });
+
+  it("leaves a non-origin 403 as a plain error", async () => {
+    globalThis.fetch = mockFetch(403, { error: "nope" });
+    const err = await createSession({ repo: "r", prompt: "p" } as unknown as CreateInput).then(
+      () => null,
+      (e) => e as Error,
+    );
+    expect(isPreviewBlocked(err)).toBe(false);
+    expect(err!.message).toBe("nope");
+  });
+});

--- a/ui/src/lib/api.previewBlocked.test.ts
+++ b/ui/src/lib/api.previewBlocked.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { createSession, isPreviewBlocked } from "./api";
 import type { CreateInput } from "./types";
 
@@ -9,6 +9,13 @@ function mockFetch(status: number, body: unknown): typeof fetch {
 }
 
 describe("preview-origin blocked detection", () => {
+  // Each test reassigns globalThis.fetch; restore the real one so the mock
+  // doesn't leak into other suites that share the global.
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
   it("maps a 403 origin-block body to a PreviewBlockedError", async () => {
     globalThis.fetch = mockFetch(403, { error: "forbidden: origin not allowed" });
     const err = await createSession({ repo: "r", prompt: "p" } as unknown as CreateInput).then(

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -40,18 +40,45 @@ import type {
   BuildStepStatus,
   PullResult,
 } from "./types";
+import { m } from "$lib/paraglide/messages";
 
 const JSON_HEADERS = { "content-type": "application/json" };
 
+/** Server's CSRF preview-origin rejection string. The HUD origin guard
+ *  (`src/validate.ts` `originAllowed` → `src/server.ts:214` `checkOrigin`) returns
+ *  `403 {error:"forbidden: origin not allowed"}` for any mutation from the live-preview
+ *  port range — kept in sync here so the matched string stays discoverable. */
+const ORIGIN_BLOCK = "forbidden: origin not allowed";
+
+/** Thrown when a mutation is rejected because it originated from the read-only live
+ *  preview (CSRF origin guard). Detect via `isPreviewBlocked`/`instanceof`. */
+class PreviewBlockedError extends Error {}
+
+/** True when `e` is a preview-origin rejection (see {@link PreviewBlockedError}). */
+export function isPreviewBlocked(e: unknown): boolean {
+  return e instanceof PreviewBlockedError;
+}
+
+/** Build an Error from a failed response body. A `403` carrying the server's
+ *  preview-origin rejection becomes a translated {@link PreviewBlockedError}; every
+ *  other failure becomes a plain Error preferring the server `{error}` over `fallback`. */
+function apiError(
+  status: number,
+  body: { error?: string } | null | undefined,
+  fallback: string,
+): Error {
+  if (status === 403 && body?.error === ORIGIN_BLOCK) {
+    return new PreviewBlockedError(m.error_preview_readonly());
+  }
+  return new Error(body?.error ?? fallback);
+}
+
 /** Build an Error from a failed response, preferring the server's `{error}` body
  *  (e.g. "no active workspace") over the bare status code so the UI shows the real
- *  cause. Falls back to "<label> failed: <status>" when the body carries no message. */
+ *  cause. Falls back to "<label> failed: <status>" when the body carries no message;
+ *  a preview-origin 403 is remapped to a {@link PreviewBlockedError} via `apiError`. */
 async function failed(r: Response, label: string): Promise<Error> {
-  const detail = await r
-    .json()
-    .then((b) => (b as { error?: string })?.error)
-    .catch(() => null);
-  return new Error(detail ?? `${label} failed: ${r.status}`);
+  return apiError(r.status, await r.json().catch(() => null), `${label} failed: ${r.status}`);
 }
 
 /** GET a JSON resource, throwing `<label> failed: <status>` on a non-2xx response. */
@@ -183,7 +210,7 @@ async function patchSettings<T>(patch: Record<string, unknown>): Promise<T> {
   });
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
   }
   return r.json();
 }
@@ -293,7 +320,7 @@ export async function resumeSession(id: string, force = false): Promise<Session>
   const r = await fetch(`/api/sessions/${id}/resume`, init);
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `resume failed: ${r.status}`);
+    throw apiError(r.status, msg as { error?: string }, `resume failed: ${r.status}`);
   }
   return r.json();
 }
@@ -394,7 +421,7 @@ export async function mergeBacklogPr(
   const r = await fetch("/api/prs/merge", JSON_POST({ repo: repoPath, number, ...body }));
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
   }
 }
 
@@ -416,7 +443,7 @@ export async function requestDependabotRebase(repoPath: string, number: number):
   const r = await fetch("/api/prs/dependabot-rebase", JSON_POST({ repo: repoPath, number }));
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
   }
 }
 
@@ -430,7 +457,7 @@ export async function rerunWorkflowRun(
   const r = await fetch("/api/actions/rerun", JSON_POST({ repo: repoPath, runId, failedOnly }));
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
   }
 }
 
@@ -439,7 +466,7 @@ export async function cancelWorkflowRun(repoPath: string, runId: number): Promis
   const r = await fetch("/api/actions/cancel", JSON_POST({ repo: repoPath, runId }));
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
   }
 }
 
@@ -514,7 +541,7 @@ export async function previewStates(): Promise<
 async function gitJson<T = PrStatus>(res: Response): Promise<T> {
   if (!res.ok) {
     const msg = await res.json().catch(() => ({ error: `${res.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `error ${res.status}`);
+    throw apiError(res.status, msg as { error?: string }, `error ${res.status}`);
   }
   return res.json();
 }
@@ -571,7 +598,7 @@ export async function applyHerdrUpdate(): Promise<void> {
   const r = await fetch("/api/herdr-update", { method: "POST", headers: JSON_HEADERS });
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
   }
 }
 
@@ -580,7 +607,7 @@ export async function applyUpdate(): Promise<void> {
   const r = await fetch("/api/update", { method: "POST", headers: JSON_HEADERS });
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
   }
 }
 
@@ -588,7 +615,7 @@ export async function redeploy(id: string): Promise<void> {
   const r = await fetch(`/api/sessions/${id}/git/redeploy`, JSON_POST());
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
   }
 }
 
@@ -606,7 +633,7 @@ export async function putSteers(steers: Steer[]): Promise<Steer[]> {
   });
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
   }
   return r.json();
 }
@@ -646,7 +673,7 @@ export async function putProjectIcon(path: string, emoji: string): Promise<Proje
   });
   if (!r.ok) {
     const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw new Error((msg as { error?: string }).error ?? `error ${r.status}`);
+    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
   }
   return r.json();
 }
@@ -911,7 +938,7 @@ export async function startPreview(
   if (r.ok) return { ok: true, command: body.command ?? "" };
   if (r.status === 409 && body.error === "command_unknown") return { needCommand: true };
   if (r.status === 409 && body.error === "already_bound") return { alreadyBound: true };
-  throw new Error(body.error ?? `startPreview failed: ${r.status}`);
+  throw apiError(r.status, body, `startPreview failed: ${r.status}`);
 }
 
 /** Force-stop the previewed dev server (SIGKILL on the server side).
@@ -924,5 +951,5 @@ export async function stopPreview(id: string): Promise<{ killed: number } | { no
   const body = (await r.json().catch(() => ({}))) as { killed?: number; error?: string };
   if (r.ok) return { killed: body.killed ?? 0 };
   if (r.status === 409 && body.error === "not_bound") return { notBound: true };
-  throw new Error(body.error ?? `stopPreview failed: ${r.status}`);
+  throw apiError(r.status, body, `stopPreview failed: ${r.status}`);
 }

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { listRepos, listBranches, getCommands, uploadImage } from "$lib/api";
+  import { listRepos, listBranches, getCommands, uploadImage, isPreviewBlocked } from "$lib/api";
   import { handleImagePaste } from "$lib/clipboard";
   import { MODELS, type Issue, type IssueRef, type RepoEntry, type SlashCommand } from "$lib/types";
   import { promoDefaultModel } from "$lib/fable-promo";
@@ -192,8 +192,12 @@
         images.push({ path, name: f.name });
       }
     } catch (err) {
-      error = m.newtask_upload_failed({ reason: reason(err, m.newtask_attach_image()) });
-      retry = () => addFiles(imgs);
+      if (isPreviewBlocked(err)) {
+        error = (err as Error).message;
+      } else {
+        error = m.newtask_upload_failed({ reason: reason(err, m.newtask_attach_image()) });
+        retry = () => addFiles(imgs);
+      }
     } finally {
       uploading = false;
     }
@@ -321,8 +325,12 @@
         planGateEnabled: planGate,
       });
     } catch (err) {
-      error = m.newtask_create_failed({ reason: reason(err, m.newtask_submit()) });
-      retry = () => submit(e);
+      if (isPreviewBlocked(err)) {
+        error = (err as Error).message;
+      } else {
+        error = m.newtask_create_failed({ reason: reason(err, m.newtask_submit()) });
+        retry = () => submit(e);
+      }
       submitting = false;
     }
   }


### PR DESCRIPTION
## Problem

Posting something back to Shepherd from inside the **live preview** fails with a misleading toast:

> Create failed: forbidden: origin not allowed. Check repo and base branch, then retry.

…plus a futile **Retry**. This isn't a repo/branch problem and retrying can't help.

## Root cause (working as designed)

Every state-changing request (`POST`/`PUT`/`DELETE`) runs the CSRF origin guard (`checkOrigin` → `originAllowed`), which **rejects any `Origin` whose port is in the preview range** `[8001, 8017)` — even when the hostname is allow-listed — so a previewed app can't forge `/api` mutations against the HUD. The server returns `403 {error:"forbidden: origin not allowed"}`. Reads (`GET`) are exempt, which is why *viewing* in preview works but *posting back* doesn't.

The guard is correct security and is **left untouched**. This PR only fixes the UX so the message is accurate.

## Change

- **`api.ts`**: new internal `apiError(status, body, fallback)` maps the preview-origin `403` to a typed `PreviewBlockedError` carrying a translated read-only message; everything else stays a plain `Error` (behavior-equivalent for non-origin failures). Routed **every body-reading thrower** through it — `failed()`, `gitJson()`, the ~11 inline throwers, and the `startPreview`/`stopPreview` fallthroughs — so steers, merge, preview start/stop, etc. all report the clear text instead of the raw string. Exported `isPreviewBlocked()` for callers to branch on. (Bare-status throwers that never read the body are intentionally out of scope.)
- **NewTask** (the reported surface): on a preview block, shows the standalone read-only message with **no** "check repo and base branch" wrapper and **no** Retry, in both the create and image-upload paths. `submitting` still resets on both branches.
- **i18n**: adds `error_preview_readonly` to EN + DE (parity gate passes).
- **Test**: `api.previewBlocked.test.ts` exercises the real `apiError` path — positive (`isPreviewBlocked` true, message remapped) and negative (non-origin `403` passes through) cases.

## Scope notes

- Secondary surfaces get the clearer **message text only**; their own display chrome (wrapper/Retry) is unchanged — a deliberately separate, larger change.
- `fix(ui)`, not a feat — no feature-catalog entry needed.

## Verification

- `cd ui && bun run check` → 0 errors
- `cd ui && bun run check:i18n` → 2 locales in parity
- `cd ui && bun run test` → 951 passed
- Branch rebased on latest `main`; fallow pre-push gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)