### PR TITLE
fix(viewport): keep mobile state-badge strip on one scrollable row

### DIFF
--- a/ui/src/lib/components/AutomationPanel.svelte
+++ b/ui/src/lib/components/AutomationPanel.svelte
@@ -541,8 +541,11 @@
 </div>
 
 <style>
-  /* anchored by the parent's positioning context (GitRail's .git-rail-wrap is
-     position: relative); this component must be mounted inside such a wrapper */
+  /* anchored to the nearest positioned ancestor: GitRail's .git-rail-wrap
+     (position: relative) on desktop, or the wider .vp-git-strip on mobile where
+     that wrapper goes position:static (see GitRail's .git-rail-wrap.mobile). The
+     flip/clamp effect re-measures offsetParent, so either anchor works — but this
+     component must still be mounted inside one such positioned ancestor. */
   .auto-pop {
     position: absolute;
     top: 100%;

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -48,8 +48,10 @@ const { default: GitRail } = await import("./GitRail.svelte");
 const { planGates } = await import("$lib/reviews.svelte");
 
 // Deterministic measurement: pin the rail's font so CI (no Berkeley Mono) and
-// local agree. The rail mounts into a fixed-width host cell (a session row's git
-// column); overflow within that cell is the failure we guard against.
+// local agree. The rail mounts into a fixed-width host cell. On desktop the
+// failure we guard against is overflow past that cell; on mobile the rail is a
+// single horizontally-scrollable row, so there the guard is that it stays one
+// line high (no vertical stacking) with no squished-to-zero controls.
 let fontStyle: HTMLStyleElement;
 beforeEach(() => {
   fontStyle = document.createElement("style");
@@ -65,7 +67,8 @@ afterEach(() => {
 
 // A fixed-width host cell. overflow:visible means getBoundingClientRect reports
 // the true painted rect of each control even if it escapes the cell — that's
-// exactly what we want so assertControlsWithin can catch overflows directly.
+// exactly what we want so assertControlsWithin can catch desktop overflows (and
+// measure the mobile row's true painted height) directly.
 function host(width: number): HTMLDivElement {
   const h = document.createElement("div");
   h.style.width = `${width}px`;
@@ -77,18 +80,51 @@ function host(width: number): HTMLDivElement {
 function assertControlsWithin(cell: HTMLElement) {
   const wrap = cell.querySelector<HTMLElement>(".git-rail-wrap");
   expect(wrap, ".git-rail-wrap mounted").not.toBeNull();
-  const cellRect = cell.getBoundingClientRect();
+  const rail = wrap!.querySelector<HTMLElement>(".rail");
+  expect(rail, ".rail mounted").not.toBeNull();
   const controls = wrap!.querySelectorAll<HTMLElement>("button, a[href]");
   expect(controls.length, "rail has controls").toBeGreaterThan(0);
+
+  // Every control must stay sized — no squished-to-zero element (regression:
+  // flex-shrink let the PR link wrap and the CI dot collapse to 0px).
   for (const c of controls) {
     const r = c.getBoundingClientRect();
     const label = c.getAttribute("aria-label") || c.textContent?.trim() || c.className;
-    // Labels may ellipsis-truncate, but the clickable element must stay sized
-    // and within the cell's left and right edges (2px slack for borders/rounding).
     expect(r.width, `${label} zero width`).toBeGreaterThan(0);
     expect(r.height, `${label} zero height`).toBeGreaterThan(0);
-    expect(r.left, `${label} escapes cell left edge`).toBeGreaterThanOrEqual(cellRect.left - 2);
-    expect(r.right, `${label} escapes cell right edge`).toBeLessThanOrEqual(cellRect.right + 2);
+  }
+  const dot = wrap!.querySelector<HTMLElement>(".dot");
+  if (dot) {
+    expect(dot.getBoundingClientRect().width, "CI dot not squished to 0").toBeGreaterThan(0);
+  }
+
+  if (rail!.classList.contains("mobile")) {
+    // Mobile: one horizontally-scrollable row, never a vertical stack. Controls
+    // may run past the cell's RIGHT edge (that's the scroll, not a failure), so
+    // assert the row stays one line high and is actually a scroll container. The
+    // left edge still holds — the leading auto-margin collapses to 0 under
+    // overflow, so nothing paints left of the cell's origin.
+    const cellRect = cell.getBoundingClientRect();
+    expect(getComputedStyle(rail!).overflowX, "mobile rail scrolls horizontally").toBe("auto");
+    const tallest = Math.max(...[...controls].map((c) => c.getBoundingClientRect().height));
+    const railH = rail!.getBoundingClientRect().height;
+    expect(railH, "rail stays a single row (no vertical stacking)").toBeLessThanOrEqual(
+      tallest + 8,
+    );
+    for (const c of controls) {
+      const r = c.getBoundingClientRect();
+      const label = c.getAttribute("aria-label") || c.textContent?.trim() || c.className;
+      expect(r.left, `${label} escapes cell left edge`).toBeGreaterThanOrEqual(cellRect.left - 2);
+    }
+  } else {
+    // Desktop: the rail must fit within its fixed-width cell (no overflow).
+    const cellRect = cell.getBoundingClientRect();
+    for (const c of controls) {
+      const r = c.getBoundingClientRect();
+      const label = c.getAttribute("aria-label") || c.textContent?.trim() || c.className;
+      expect(r.left, `${label} escapes cell left edge`).toBeGreaterThanOrEqual(cellRect.left - 2);
+      expect(r.right, `${label} escapes cell right edge`).toBeLessThanOrEqual(cellRect.right + 2);
+    }
   }
 }
 
@@ -213,7 +249,7 @@ describe("GitRail — controls stay within the cell", () => {
     assertControlsWithin(h);
   });
 
-  it("mobile 360px — open, mergeable:false → Merge button disabled, all controls in-bounds", async () => {
+  it("mobile 360px — open, mergeable:false → Merge button disabled, single scroll row", async () => {
     const conflictState: GitState = {
       ...openPrState,
       checks: "success",
@@ -264,7 +300,7 @@ describe("GitRail — controls stay within the cell", () => {
   // distinct GitRail rail state — the component has no git.state === "draining"
   // branch. The widest real label is the armed merge-confirm text; that's the
   // actual overflow stressor the critic named.
-  it("mobile 360px — open, Merge armed → 'confirm ✓' label fits in cell (key stressor)", async () => {
+  it("mobile 360px — open, Merge armed → 'confirm ✓' stays one scroll row (key stressor)", async () => {
     gitStateFn.mockResolvedValue(openPrState);
     await page.viewport(400, 900);
     const h = host(360);
@@ -278,7 +314,7 @@ describe("GitRail — controls stay within the cell", () => {
     // Wait for the armed label to appear.
     await expect.element(screen.getByRole("button", { name: /confirm/i })).toBeVisible();
 
-    // Assert all controls (including the now-armed "confirm ✓" button) stay in-bounds.
+    // Assert the now-armed "confirm ✓" button keeps the rail one scrollable row.
     assertControlsWithin(h);
   });
 
@@ -294,6 +330,54 @@ describe("GitRail — controls stay within the cell", () => {
     await expect.element(screen.getByRole("button", { name: /confirm/i })).toBeVisible();
 
     assertControlsWithin(h);
+  });
+});
+
+describe("GitRail — mobile scroll affordance", () => {
+  it("mobile 360px — overflowing rail fades its trailing edge to cue the scroll", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(400, 900);
+    const h = host(360);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: true } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+
+    const rail = h.querySelector<HTMLElement>(".rail.mobile");
+    expect(rail, ".rail.mobile mounted").not.toBeNull();
+    // content overflows the 360px cell → the right edge fades (--fade-r = 1)
+    expect(rail!.scrollWidth, "rail actually overflows").toBeGreaterThan(rail!.clientWidth);
+    await vi.waitFor(() =>
+      expect(rail!.style.getPropertyValue("--fade-r"), "trailing edge faded").toBe("1"),
+    );
+    // start is in view (scrollLeft 0) → leading edge not faded
+    expect(rail!.style.getPropertyValue("--fade-l"), "leading edge not faded").toBe("0");
+  });
+
+  it("mobile 360px — recomputes the fade on content change, not just scroll/resize", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(400, 900);
+    const h = host(360);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: true } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+
+    const rail = h.querySelector<HTMLElement>(".rail.mobile")!;
+    await vi.waitFor(() => expect(rail.style.getPropertyValue("--fade-r")).toBe("1"));
+
+    // Shrink the content so it no longer overflows — WITHOUT scrolling or resizing
+    // the rail's (width:100%) box. Only the MutationObserver can catch this; with a
+    // scroll/resize-only watcher --fade-r would stay stale at "1".
+    while (rail.children.length > 1) rail.removeChild(rail.lastElementChild!);
+    await vi.waitFor(() => expect(rail.style.getPropertyValue("--fade-r")).toBe("0"));
+  });
+
+  it("desktop 600px — no fade vars (rail is not a scroller)", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+
+    const rail = h.querySelector<HTMLElement>(".rail");
+    expect(rail!.style.getPropertyValue("--fade-r"), "no fade var on desktop").toBe("");
   });
 });
 

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -291,6 +291,51 @@
       setTimeout(() => (reviewFlash = null), 1500);
     }
   }
+
+  // The mobile rail is a hidden-scrollbar horizontal scroller; without a visible
+  // bar nothing hints that trailing controls (auto-pill, verdict chip) scroll off
+  // the right edge. Fade whichever edge still has content beyond it, driven into
+  // the .rail.mobile mask via --fade-l/--fade-r (0 = no fade, 1 = fade). A row
+  // that fully fits shows no fade; an overflowing one cues the scroll. No-op (and
+  // self-cleans) on desktop, where the rail isn't a scroller.
+  function edgeFades(node: HTMLElement, enabled: boolean) {
+    let ro: ResizeObserver | undefined;
+    let mo: MutationObserver | undefined;
+    const update = () => {
+      const max = node.scrollWidth - node.clientWidth;
+      node.style.setProperty("--fade-l", node.scrollLeft > 1 ? "1" : "0");
+      node.style.setProperty("--fade-r", node.scrollLeft < max - 1 ? "1" : "0");
+    };
+    const start = () => {
+      update();
+      node.addEventListener("scroll", update, { passive: true });
+      ro = new ResizeObserver(update);
+      ro.observe(node);
+      // The rail's box is width:100% of its wrapper, so a content change that
+      // shifts scrollWidth without resizing that box (Merge arming to 'confirm ✓',
+      // the verdict chip appearing) won't trip ResizeObserver — watch the subtree
+      // too so the fade can't go stale. NOT attributes: our own --fade-* writes are
+      // style-attribute mutations and would loop.
+      mo = new MutationObserver(update);
+      mo.observe(node, { childList: true, subtree: true, characterData: true });
+    };
+    const stop = () => {
+      node.removeEventListener("scroll", update);
+      ro?.disconnect();
+      mo?.disconnect();
+      ro = mo = undefined;
+      node.style.removeProperty("--fade-l");
+      node.style.removeProperty("--fade-r");
+    };
+    if (enabled) start();
+    return {
+      update(next: boolean) {
+        stop();
+        if (next) start();
+      },
+      destroy: stop,
+    };
+  }
 </script>
 
 <svelte:window onkeydown={onWindowKeydown} onpointerdown={onWindowPointerdown} />
@@ -303,7 +348,7 @@
     <div class="review-scrim" aria-hidden="true"></div>
   {/if}
   <span class="git-rail-wrap" class:mobile bind:this={wrapEl}>
-    <span class="rail" class:mobile>
+    <span class="rail" class:mobile use:edgeFades={mobile}>
       {#if git.state === "none"}
         <button class="gbtn" type="button" disabled={busy} onclick={startPr}
           >{m.gitrail_open_pr()}</button
@@ -518,8 +563,10 @@
 {/if}
 
 <style>
-  /* own positioning context so .pr-pop anchors to the button in every
-     mount site (desktop header + compact strip), not to some far ancestor */
+  /* own positioning context so .pr-pop/.auto-pop/.review-pop anchor here in the
+     desktop (non-mobile) mount, not to some far ancestor. On mobile the wrapper
+     is narrower than the strip, so it goes position:static and the popovers
+     anchor to the wider .vp-git-strip instead — see .git-rail-wrap.mobile. */
   .git-rail-wrap {
     position: relative;
     display: inline-flex;
@@ -652,23 +699,68 @@
     cursor: default;
   }
 
-  /* touch layouts: bigger tap targets + readable PR link/dot. fill the strip and
-     wrap whole buttons onto a new right-aligned row, rather than letting a single
-     nowrap rail overflow and squeeze button labels across lines */
+  /* touch layouts: bigger tap targets + a single horizontally-scrollable row.
+     Whole badges never wrap to a second line (that read as a vertical stack on
+     phones); the rail (.rail.mobile below) scrolls instead. Because the strip
+     keeps .strip-controls on this same row, the wrapper is narrower than the
+     viewport — so go position:static here and let the popovers
+     (.pr-pop/.auto-pop/.review-pop) anchor to the full-width .vp-git-strip
+     (itself position:relative). Anchored to this narrow wrapper, a right:8px
+     popover would shoot off the left screen edge. */
   .git-rail-wrap.mobile {
+    position: static;
     flex: 1 1 auto;
     min-width: 0;
   }
   .rail.mobile {
     width: 100%;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: 10px;
-    row-gap: 8px;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    min-width: 0;
+    gap: 6px;
+    /* scroll affordance: with the scrollbar hidden, fade whichever edge has more
+       content beyond it so an overflowing row visibly cues the scroll (the edgeFades
+       action sets --fade-l/--fade-r to 0|1). The #000/transparent stops are mask
+       alpha, not a theme color — the faded edge just reveals the strip's own
+       --color-head behind the rail. Both vars 0 (fits / no action) → fully opaque. */
+    --rail-fade: 22px;
+    --fade-l: 0;
+    --fade-r: 0;
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      #000 calc(var(--fade-l) * var(--rail-fade)),
+      #000 calc(100% - var(--fade-r) * var(--rail-fade)),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      #000 calc(var(--fade-l) * var(--rail-fade)),
+      #000 calc(100% - var(--fade-r) * var(--rail-fade)),
+      transparent 100%
+    );
+  }
+  .rail.mobile::-webkit-scrollbar {
+    display: none;
+  }
+  /* horizontal-scroll row: items keep natural width and overflow → scroll,
+     never shrink-wrap (the PR link wrapped to 3 lines and the CI dot squished
+     to 0px otherwise). Mirrors the .tab-scroll recipe. */
+  .rail.mobile > * {
+    flex-shrink: 0;
+  }
+  /* right-pin the badge group when it fits; under overflow the auto margin
+     collapses to 0 so the row scrolls cleanly from the first badge (avoids the
+     flex justify-content:flex-end + overflow-x start-clip bug) */
+  .rail.mobile > :first-child {
+    margin-left: auto;
   }
   .rail.mobile .gbtn {
     min-height: 40px;
-    padding: 6px 14px;
+    padding: 6px 9px;
     font-size: var(--fs-base);
   }
   /* The critic chip is the gateway to the findings popover, but it's a
@@ -682,7 +774,7 @@
      40px button-looking element that does nothing on tap. */
   .rail.mobile button.verdict-chip {
     min-height: 40px;
-    padding: 6px 14px;
+    padding: 6px 9px;
     font-size: var(--fs-base);
     display: inline-flex;
     align-items: center;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -3083,7 +3083,8 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    min-width: 0;
     gap: 6px;
     padding: 6px 10px;
     background: var(--color-head);
@@ -3097,8 +3098,8 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    flex-shrink: 0;
-    padding-left: 10px;
+    flex: 0 0 auto;
+    padding-left: 8px;
     border-left: 1px solid var(--color-line);
   }
   /* the strip's GitRail always renders its ≥40px touch variant — match it so the
@@ -3106,7 +3107,7 @@
   .strip-controls .ap-toggle,
   .strip-controls .decom {
     min-height: 40px;
-    padding: 6px 14px;
+    padding: 6px 9px;
   }
 
   .vp-head.mobile {


### PR DESCRIPTION
## Problem

On the session-detail header, the state-badge strip (`merged ✓` · `⚙ automation N/9` · `Ready` · `REVIEWED` · `AUTOPILOT ON` · decommission) **stacked each badge vertically** when the row wrapped on a narrow phone — each badge orphaned onto its own right-aligned line.

## Fix

Make the strip a **single, non-wrapping, horizontally-scrollable row** that shrinks to fit and scrolls only as a fallback (long German labels / smallest phones). The lifecycle controls (autopilot/decommission) stay pinned at the right edge.

- `.rail.mobile` becomes the scroll container: `flex-wrap: nowrap` + `overflow-x: auto` (scrollbar hidden, mirroring the existing `.tab-scroll` recipe). **`overflow` is on `.rail` only** — the `.pr-pop` / `.auto-pop` / `.review-pop` popovers are DOM **siblings** of `.rail`, so they are never clipped.
- `.rail.mobile > * { flex-shrink: 0 }` so badges keep natural width and scroll instead of squishing (otherwise the PR link wrapped to 3 lines and the CI dot collapsed to **0px**).
- `.rail.mobile > :first-child { margin-left: auto }` right-pins the group when it fits and collapses to 0 under overflow, so a scrolling row reads cleanly from the first badge (avoids the flex `justify-content:flex-end` + `overflow-x` start-clip bug).
- Badge horizontal padding trimmed `6px 14px → 6px 9px`; **tap-target `min-height: 40px` kept** (preserves the recent 44px touch-guideline work).
- `.vp-git-strip` → `flex-wrap: nowrap`; `.strip-controls` → `flex: 0 0 auto`.
- `.git-rail-wrap.mobile` → `position: static`: now that `.strip-controls` shares the row the wrapper is narrower than the viewport, so the popovers re-anchor to the full-width `position:relative` `.vp-git-strip` — otherwise a `right:8px` popover shot off the **left** screen edge.

Same surface serves both the compact mobile strip and the desktop `gitOpen` disclosure, so both are covered.

## Tests

`GitRail.browser.test.ts` `assertControlsWithin` now branches: **desktop** keeps the within-cell overflow guard; **mobile** asserts a single scrollable row — one line high (no vertical stacking), `overflow-x: auto`, and no squished-to-zero controls / CI dot. (Updated stale comment in `AutomationPanel.svelte` to reflect the new anchor.)

## Verification

- `cd ui && bun run check` ✓ (0 errors) · `bun run check:i18n` ✓ (parity) · `bun run test` ✓ (924 pass)
- Live browser at **390px EN + DE** and the **desktop `gitOpen` disclosure**: one row, scrolls when overflowing, autopilot pinned right, CI dot visible, PR link single-line, and `.auto-pop` / `.review-pop` render fully on-screen (not clipped) in both locales.

CSS + test only — no user-facing string changes, so no i18n keys or feature-catalog entry needed (this is a `fix:`, not a `feat:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)