### PR TITLE
fix(steerbar): show ABC labels toggle only when a label is collapsed

### DIFF
--- a/ui/src/lib/components/SteerBar.browser.test.ts
+++ b/ui/src/lib/components/SteerBar.browser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
 import { tick } from "svelte";
 import "../../app.css";
 import type { Steer } from "$lib/types";
@@ -70,5 +71,68 @@ describe("SteerBar labels toggle", () => {
     const toggle = document.querySelector(".lbl-toggle") as HTMLElement;
     expect(toggle.getAttribute("aria-pressed")).toBe("true");
     expect(document.querySelector(".steer-bar")!.classList.contains("show-labels")).toBe(true);
+  });
+});
+
+// fitLabels measures via rAF + ResizeObserver; let layout settle before reading style.
+const frames = (n = 2) =>
+  new Promise<void>((r) => {
+    let i = 0;
+    const step = () => (++i >= n ? r() : requestAnimationFrame(step));
+    requestAnimationFrame(step);
+  });
+
+describe("ABC visibility gating", () => {
+  afterEach(async () => {
+    await page.viewport(1280, 900); // restore a sane width for other suites
+  });
+
+  it("desktop, not compact (everything fits) → ABC hidden", async () => {
+    await page.viewport(1000, 900);
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    await tick();
+    await frames();
+
+    const bar = document.querySelector(".steer-bar") as HTMLElement;
+    const toggle = document.querySelector(".lbl-toggle") as HTMLElement;
+    expect(bar.classList.contains("compact"), "bar not compact when one chip fits").toBe(false);
+    expect(getComputedStyle(toggle).display, "ABC hidden on wide non-compact bar").toBe("none");
+  });
+
+  it("compact via real overflow (>768px) → ABC revealed by compact alone", async () => {
+    await page.viewport(800, 900);
+    // Many emoji chips with long labels so full labels overflow ~800px and fitLabels
+    // sets AND keeps `compact` (real overflow is stable because fitLabels owns the class;
+    // a hand-added one would be stripped on the next ResizeObserver/MutationObserver
+    // decide() since the cached fullWidth wouldn't justify it).
+    steers.list = Array.from({ length: 24 }, (_, i) =>
+      steer({
+        id: String(i + 1),
+        label: `Long Steering Label Number ${i + 1}`,
+        emoji: "🚀",
+      }),
+    );
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    await tick();
+    await frames(4); // 24-chip layout takes longer to settle than the 2-frame default
+
+    const bar = document.querySelector(".steer-bar") as HTMLElement;
+    const toggle = document.querySelector(".lbl-toggle") as HTMLElement;
+    expect(bar.classList.contains("compact"), "bar compact on real overflow").toBe(true);
+    expect(getComputedStyle(toggle).display, "ABC revealed when compact").not.toBe("none");
+  });
+
+  it("mobile, not compact (≤768px) → ABC revealed, ⌁ label collapsed", async () => {
+    await page.viewport(400, 900);
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    await tick();
+    await frames();
+
+    const bar = document.querySelector(".steer-bar") as HTMLElement;
+    const toggle = document.querySelector(".lbl-toggle") as HTMLElement;
+    const bcLabel = document.querySelector(".chip.bc .bc-label") as HTMLElement;
+    expect(bar.classList.contains("compact"), "single chip fits → not compact").toBe(false);
+    expect(getComputedStyle(toggle).display, "ABC revealed by mobile rule").not.toBe("none");
+    expect(getComputedStyle(bcLabel).display, "⌁ label collapsed on mobile").toBe("none");
   });
 });

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -119,9 +119,11 @@
   </div>
 {/if}
 <!-- The ABC labels toggle lives OUTSIDE the scrolling/measured .steer-bar (as its
-     right-hand flex sibling) so it's always visible at the far right AND so its box
-     never enters fitLabels' scrollWidth measurement — an in-flow auto-margin would
-     make scrollWidth == clientWidth and poison the cached full-label width. -->
+     right-hand flex sibling) so its box never enters fitLabels' scrollWidth
+     measurement — an in-flow auto-margin would make scrollWidth == clientWidth and
+     poison the cached full-label width. It's shown only when there's actually a
+     collapsed label to reveal: when the bar collapses (`compact`) or on mobile
+     (≤768px); hidden on a desktop bar where everything fits. -->
 <div class="steer-row" data-swipe-ignore>
   <!-- fitLabels toggles `compact` when the full labels overflow: chips that carry an
        emoji collapse to emoji-only (label stays in title/aria); the rest keep their
@@ -162,9 +164,11 @@
     {/each}
   </div>
   <!-- Right-anchored labels toggle. Sits at the bar's far right as a flex sibling of
-       the scroll area (always visible, never scrolls under). The accessible name leads
-       with the visible "ABC" glyph so voice control can address it by what it reads
-       (WCAG 2.5.3 label-in-name); the title carries the plain description. -->
+       the scroll area (never scrolls under), shown only when a label is collapsed —
+       when the bar collapses (`compact`) or on mobile (≤768px); hidden on a desktop
+       bar where everything fits. The accessible name leads with the visible "ABC"
+       glyph so voice control can address it by what it reads (WCAG 2.5.3
+       label-in-name); the title carries the plain description. -->
   <button
     type="button"
     class="chip lbl-toggle"
@@ -182,7 +186,8 @@
 </div>
 
 <style>
-  /* Row = scrolling chip bar (flex:1) + the always-visible ABC toggle at the right.
+  /* Row = scrolling chip bar (flex:1) + the ABC toggle at the right (shown only when a
+     label is collapsed / on mobile; display:none on a desktop bar where everything fits).
      Background + top border live here so they span the full width including the toggle. */
   .steer-row {
     display: flex;
@@ -253,9 +258,13 @@
     padding: 0;
   }
   /* Labels toggle: a flat "ABC" key at the row's far right, outside the scroll area
-     (its own flex column), so it's always visible and never distorts the chip bar's
-     measured width. Margins mirror the bar's padding so it lines up vertically. */
+     (its own flex column), so it never distorts the chip bar's measured width. Hidden
+     by default and revealed only when a label is actually collapsed — when the bar
+     collapses (`compact`, rule below) or on mobile (≤768px, media block below); on a
+     desktop bar where everything fits it has nothing to reveal, so it stays hidden.
+     Margins mirror the bar's padding so it lines up vertically. */
   .lbl-toggle {
+    display: none;
     flex: 0 0 auto;
     align-self: center;
     margin: 6px 10px;
@@ -264,6 +273,13 @@
     font-size: var(--fs-meta);
     letter-spacing: 0.08em;
     color: var(--color-muted);
+  }
+  /* Overflow reveal: fitLabels adds `.compact` to .steer-bar when full labels
+     overflow. 3 classes (.steer-bar+.compact+.lbl-toggle) outrank the base rule's 1,
+     so this wins whenever compact regardless of source order. Independent of
+     .show-labels so the toggle stays visible to collapse back once ABC is pressed. */
+  .steer-bar:global(.compact) ~ .lbl-toggle {
+    display: inline-flex;
   }
   .lbl-toggle[aria-pressed="true"] {
     color: var(--color-ink-bright);
@@ -280,7 +296,12 @@
      (own box, frozen left) and the steer chips play the Tab/nav groups. To line
      the first steer chip up under the Tab key, the ⌁→first-chip channel must
      equal the Esc→Tab channel (3px Esc-well + 6px ctrl-row gap + 3px Tab-well =
-     12px). The flex `gap` already gives 4px, so add the remaining 8px here. */
+     12px). The flex `gap` already gives 4px, so add the remaining 8px here.
+     This block ALSO surfaces the ABC toggle: on mobile the ⌁ label collapses
+     regardless of `compact`, so there's always a label to reveal — the `.lbl-toggle`
+     reveal below is viewport-only (1 class, so it ties the base `display: none` and
+     wins by coming later in source order), independent of `.show-labels` so the
+     toggle stays visible to collapse back once ABC is pressed. */
   @media (max-width: 768px) {
     .steer-bar:not(.show-labels) .chip.bc {
       min-width: 44px;
@@ -290,6 +311,9 @@
     }
     .steer-bar:not(.show-labels) .bc-label {
       display: none;
+    }
+    .lbl-toggle {
+      display: inline-flex;
     }
   }
   /* one-time steer hint: flat, square, hairline-bordered, muted ink — sits


### PR DESCRIPTION
## What

The steer bar's right-anchored **ABC** labels toggle rendered **always** — even on a wide desktop bar where every chip label is already showing, where the toggle does nothing (see the reported screenshot). This gates its visibility so it appears only when there's actually a collapsed label to reveal.

## Behavior

ABC is now visible **iff** the bar is `compact` (full labels overflowed → emoji chips went icon-only, any viewport) **or** the viewport is ≤768px (where the ⌁ broadcast label collapses independently of `compact`). It's hidden **iff** the bar is not compact **and** >768px — i.e. a desktop bar where everything fits.

- **Mobile (≤768px): unchanged** — ABC stays visible (the ⌁ label always collapses there when labels are off, so the toggle still has a job).
- **Desktop, everything fits: ABC now hidden** — the fix.
- Once tapped (`showLabels` on), ABC stays visible to collapse back (reveal rules are independent of `show-labels`).

## How

Pure CSS, no new component state, no change to `fit-labels.ts`:
- `.lbl-toggle` defaults to `display: none`.
- `.steer-bar.compact ~ .lbl-toggle` reveals it on overflow (3-class selector, outranks the base).
- A `.lbl-toggle` rule inside the existing `@media (max-width: 768px)` block reveals it on mobile (ties the base on specificity; authored after it so it wins on source order).

The toggle stays a sibling **outside** `.steer-bar`, so it never enters `fitLabels`' `scrollWidth` measurement. Stale "always visible" comments updated to match.

## Tests

Adds a `describe("ABC visibility gating")` block to the existing `vitest-browser-svelte` suite with three `page.viewport`-driven cases:
- desktop not-compact (1000×900) → ABC hidden;
- compact via **real overflow** (800×900, 24 long-label chips) → ABC visible;
- mobile not-compact (400×900) → ABC visible **and** ⌁ `.bc-label` collapsed.

6/6 tests pass; `cd ui && bun run check` clean (svelte-check + i18n parity). No new user-facing strings → no i18n keys / feature-catalog entry (behavior refinement, `fix:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)