### PR TITLE
test(viewport): cover RedrawMenu; gate redraw toggle to the terminal tab

### DIFF
--- a/ui/src/lib/components/RedrawMenu.browser.test.ts
+++ b/ui/src/lib/components/RedrawMenu.browser.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import RedrawMenu from "./RedrawMenu.svelte";
+import { m } from "$lib/paraglide/messages";
+
+// A real, connected trigger button: the menu measures its rect for positioning
+// and restores focus to it on close.
+let anchor: HTMLButtonElement;
+beforeEach(() => {
+  anchor = document.createElement("button");
+  anchor.textContent = "anchor";
+  document.body.appendChild(anchor);
+});
+afterEach(() => {
+  anchor.remove();
+});
+
+function handlers() {
+  return {
+    onnudge: vi.fn(),
+    onreattach: vi.fn(),
+    onfullscreen: vi.fn(),
+    onresume: vi.fn(),
+    onclose: vi.fn(),
+  };
+}
+
+// document.activeElement, polled: the menu focuses its first item from the
+// measuring $effect, which lands a microtask after render returns.
+function activeText() {
+  return document.activeElement?.textContent ?? "";
+}
+
+describe("RedrawMenu", () => {
+  it("focuses the first item when live", async () => {
+    render(RedrawMenu, { props: { anchor, live: true, resuming: false, ...handlers() } });
+
+    await expect.poll(activeText).toContain(m.redrawmenu_nudge());
+  });
+
+  it("disables the connection-bound items when !live and focuses the first enabled one", async () => {
+    render(RedrawMenu, { props: { anchor, live: false, resuming: false, ...handlers() } });
+
+    await expect.element(page.getByRole("menuitem", { name: m.redrawmenu_nudge() })).toBeDisabled();
+    await expect
+      .element(page.getByRole("menuitem", { name: m.redrawmenu_fullscreen() }))
+      .toBeDisabled();
+    // first *focusable* item: nudge is disabled, so initial focus lands on re-attach
+    await expect.poll(activeText).toContain(m.redrawmenu_reattach());
+  });
+
+  it("disables force resume while a resume is in flight", async () => {
+    render(RedrawMenu, { props: { anchor, live: true, resuming: true, ...handlers() } });
+
+    await expect
+      .element(page.getByRole("menuitem", { name: m.redrawmenu_resume() }))
+      .toBeDisabled();
+  });
+
+  it("dismisses on Escape", async () => {
+    const h = handlers();
+    render(RedrawMenu, { props: { anchor, live: true, resuming: false, ...h } });
+    await expect.poll(activeText).toContain(m.redrawmenu_nudge());
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(h.onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses on outside pointerdown, but not on one inside the menu or on the anchor", async () => {
+    const h = handlers();
+    render(RedrawMenu, { props: { anchor, live: true, resuming: false, ...h } });
+    await expect.poll(activeText).toContain(m.redrawmenu_nudge());
+
+    // inside the menu → stays open
+    document.activeElement!.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    expect(h.onclose).not.toHaveBeenCalled();
+    // on the anchor → the trigger's own toggle handles it, not the menu
+    anchor.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    expect(h.onclose).not.toHaveBeenCalled();
+    // anywhere else → dismiss
+    document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    expect(h.onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses on scroll (the anchor moves out from under the popover)", async () => {
+    const h = handlers();
+    render(RedrawMenu, { props: { anchor, live: true, resuming: false, ...h } });
+    await expect.poll(activeText).toContain(m.redrawmenu_nudge());
+
+    window.dispatchEvent(new Event("scroll"));
+
+    expect(h.onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores focus to the trigger when the menu closes", async () => {
+    const screen = render(RedrawMenu, {
+      props: { anchor, live: true, resuming: false, ...handlers() },
+    });
+    await expect.poll(activeText).toContain(m.redrawmenu_nudge());
+
+    // closing unmounts the menu; the focused item vanishes (focus falls to
+    // <body>) and the teardown hands it back to the trigger
+    await screen.unmount();
+
+    await expect.poll(() => document.activeElement).toBe(anchor);
+  });
+});

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1923,31 +1923,36 @@
       {/if}
       <!-- squished-history repair variants under field test (see redrawNudge etc.
            above) — a quiet ↔ toggle opening an anchored popover with the four
-           candidates. The losing variants get removed after testing. -->
-      <button
-        class="vp-redraw"
-        bind:this={redrawBtnEl}
-        type="button"
-        aria-haspopup="menu"
-        aria-expanded={redrawOpen}
-        onclick={() => (redrawOpen = !redrawOpen)}
-        title={m.viewport_redraw_title()}
-        aria-label={m.viewport_redraw_title()}
-      >
-        <span aria-hidden="true">↔</span>
-        {#if !compact}<span>{m.viewport_redraw_btn()}</span>{/if}
-      </button>
-      {#if redrawOpen && redrawBtnEl}
-        <RedrawMenu
-          anchor={redrawBtnEl}
-          live={!ended && !parked}
-          {resuming}
-          onnudge={redrawNudge}
-          onreattach={redrawReattach}
-          onfullscreen={redrawFullscreen}
-          onresume={redrawResume}
-          onclose={() => (redrawOpen = false)}
-        />
+           candidates. The losing variants get removed after testing. Terminal-tab
+           only: every variant acts on the terminal, so the control can't issue a
+           silent nudge/fullscreen against a hidden mount from another tab (the
+           button unmounting also drops redrawBtnEl, which closes an open menu). -->
+      {#if tab === "term"}
+        <button
+          class="vp-redraw"
+          bind:this={redrawBtnEl}
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded={redrawOpen}
+          onclick={() => (redrawOpen = !redrawOpen)}
+          title={m.viewport_redraw_title()}
+          aria-label={m.viewport_redraw_title()}
+        >
+          <span aria-hidden="true">↔</span>
+          {#if !compact}<span>{m.viewport_redraw_btn()}</span>{/if}
+        </button>
+        {#if redrawOpen && redrawBtnEl}
+          <RedrawMenu
+            anchor={redrawBtnEl}
+            live={!ended && !parked}
+            {resuming}
+            onnudge={redrawNudge}
+            onreattach={redrawReattach}
+            onfullscreen={redrawFullscreen}
+            onresume={redrawResume}
+            onclose={() => (redrawOpen = false)}
+          />
+        {/if}
       {/if}
       {#if resumable}
         <!-- bring claude back when the session is parked (idle/done) — e.g. claude


### PR DESCRIPTION
Follow-up to #540 (merged while the critic's third round was being addressed — the head branch was deleted on merge, so this lands the remaining two fixes as a fresh branch off main).

## Critic findings addressed

**1. Verify `/tui fullscreen` actually executes via bracketed paste — verified, no code change.**
Empirically tested against the locally installed Claude Code (v2.1.173): spawned a real `claude` in a node-pty, sent the exact bytes `composeKeystrokes("/tui fullscreen")` produces (`ESC[200~/tui fullscreen ESC[201~ CR`), and observed `ESC[?1049h` — the alternate-screen switch — within seconds, with no model turn started. The paste is ingested into the input buffer and the CR submit parses the leading-slash line as a command, exactly like typed input.

**2. Dedicated RedrawMenu component test** (`RedrawMenu.browser.test.ts`, 7 cases):
- first-item focus when live; first *focusable* item focus (re-attach) when `!live` with nudge/fullscreen disabled
- force-resume disabled while a resume is in flight
- dismissal on Esc, outside pointerdown, and scroll — plus non-dismissal for pointerdowns inside the menu or on the anchor
- focus restoration to the trigger on close

**3. Redraw toggle gated to the terminal tab.**
Every variant acts on the terminal, so the ↔ control now only renders while the terminal tab is active — it can no longer issue a silent nudge/fullscreen against a hidden mount from the To-Do/Diff/Preview tabs. (The unmounting button also drops its bind ref, which closes an open menu.)

## Testing

- `cd ui && bun run check` — 0 errors / 0 warnings
- `cd ui && bun run test` — 70 files, 986 tests green (7 new)
- branch-hygiene + feature-catalog gates green (no `feat` commits in range)

Note: the stray `shepherd/terminal-lesbarkeit` branch (accidentally resurrected by a push that raced the #540 merge by a minute) has been deleted from the remote.