### PR TITLE
fix(reposelect): open dropdown with cursor on the selected repo, not the pinned one

### DIFF
--- a/ui/src/lib/components/RepoSelect.browser.test.ts
+++ b/ui/src/lib/components/RepoSelect.browser.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import RepoSelect from "./RepoSelect.svelte";
+import { m } from "$lib/paraglide/messages";
+import type { RepoEntry } from "$lib/types";
+
+const noop = vi.fn();
+
+function makeRepos(): RepoEntry[] {
+  return [
+    // Two pinned repos (recentAgentCount > 0); they will occupy rows 0 and 1.
+    { name: "alpha", path: "/repos/alpha", display: "~/repos/alpha", recentAgentCount: 5 },
+    { name: "beta", path: "/repos/beta", display: "~/repos/beta", recentAgentCount: 3 },
+    // The selected repo has NO recentAgentCount — it is main-list-only, so it
+    // never appears in the pinned group. Rows 0+1 are alpha+beta; gamma is later.
+    { name: "gamma", path: "/repos/gamma", display: "~/repos/gamma" },
+  ];
+}
+
+describe("RepoSelect — keyboard cursor on open", () => {
+  it("puts the cursor on the selected repo, not on the first pinned row", async () => {
+    const repos = makeRepos();
+    // gamma is selected; it is NOT pinned, so row 0 = alpha (pinned).
+    render(RepoSelect, {
+      repos,
+      value: "/repos/gamma",
+      onchange: noop,
+      windowDays: 7,
+    });
+
+    // Open the dropdown.
+    await page.getByRole("button", { name: /gamma/ }).click();
+
+    // The row with aria-selected="true" is the keyboard cursor.
+    const selected = page.getByRole("option", { selected: true });
+    await expect.element(selected).toBeVisible();
+
+    // The cursor row must contain "gamma", not "alpha" (which is row 0 / pinned).
+    await expect.element(selected).toHaveTextContent("gamma");
+    // And confirm row 0 (alpha) is NOT the cursor.
+    const alphaRow = page.getByRole("option", { name: /alpha/ }).first();
+    await expect.element(alphaRow).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("resets the cursor to the first result when the user types in the filter", async () => {
+    const repos = makeRepos();
+    // Start with gamma selected (not row 0).
+    render(RepoSelect, {
+      repos,
+      value: "/repos/gamma",
+      onchange: noop,
+      windowDays: 7,
+    });
+
+    // Open the dropdown.
+    await page.getByRole("button", { name: /gamma/ }).click();
+
+    // Type "al" — only alpha matches; filter collapses the pinned group (filter
+    // not empty), so the shown list is just [alpha]. Row 0 should get the cursor.
+    const filterInput = page.getByPlaceholder(m.reposelect_filter_placeholder());
+    await filterInput.fill("al");
+
+    // The first (and only) option should now have aria-selected="true".
+    const firstOption = page.getByRole("option").first();
+    await expect.element(firstOption).toHaveAttribute("aria-selected", "true");
+    await expect.element(firstOption).toHaveTextContent("alpha");
+  });
+
+  it("falls back to the first row when value matches no repo in the list", async () => {
+    const repos = makeRepos();
+    // value points at a repo that isn't in `shown` at all → findIndex returns -1,
+    // so the `idx >= 0 ? idx : 0` fallback must park the cursor on row 0.
+    render(RepoSelect, {
+      repos,
+      value: "/repos/does-not-exist",
+      onchange: noop,
+      windowDays: 7,
+    });
+
+    // Nothing is selected, so the trigger shows the placeholder; open via it.
+    // (Accessible name also picks up the chevron glyph, hence the regex.)
+    await page.getByRole("button", { name: new RegExp(m.reposelect_placeholder()) }).click();
+
+    // Row 0 (alpha, the first pinned repo) must be the keyboard cursor.
+    const firstOption = page.getByRole("option").first();
+    await expect.element(firstOption).toHaveAttribute("aria-selected", "true");
+    await expect.element(firstOption).toHaveTextContent("alpha");
+  });
+});

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { tick } from "svelte";
   import type { RepoEntry } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import EmojiPicker from "./EmojiPicker.svelte";
@@ -81,10 +82,16 @@
     ...filtered.map((r) => ({ repo: r, pinned: false })),
   ]);
 
-  function toggle() {
+  async function toggle() {
     open = !open;
     if (open) {
       filter = "";
+      // Point the keyboard cursor at the currently-selected repo (its first
+      // occurrence — the pinned one if it's a recent), not row 0.
+      const idx = shown.findIndex((row) => row.repo.path === value);
+      activeIdx = idx >= 0 ? idx : 0;
+      await tick();
+      scrollActiveIntoView();
     }
   }
 
@@ -97,14 +104,16 @@
 
   $effect(() => {
     if (open && filterInput) {
-      filterInput.focus();
+      filterInput.focus({ preventScroll: true });
     }
   });
 
-  // Reset the cursor to the top whenever the filtered list changes (open/typing).
+  // Keep the keyboard cursor in range if an async update (server/WS poll) shrinks
+  // `shown` while the panel is open — otherwise activeIdx could point past the end
+  // (stale aria-activedescendant, vanished cursor). Typing resets to top via the
+  // filter input's oninput; opening points at the selected repo via toggle().
   $effect(() => {
-    void shown;
-    activeIdx = 0;
+    if (activeIdx > shown.length - 1) activeIdx = Math.max(0, shown.length - 1);
   });
 
   // Keyboard-driven row navigation from the focused filter input.
@@ -196,6 +205,7 @@
         aria-controls="rs-listbox"
         aria-autocomplete="list"
         aria-activedescendant={shown.length ? `rs-opt-${activeIdx}` : undefined}
+        oninput={() => (activeIdx = 0)}
         onkeydown={onFilterKey}
       />
       <ul class="rs-list" id="rs-listbox" role="listbox" bind:this={listEl}>


### PR DESCRIPTION
## Problem

Opening the repo drop-down in the new-task pane put the orange-bordered keyboard cursor on the first **pinned** "recently worked on" repo, never on the **currently selected** repo. The "orange border" is the `.rs-row.kbd-active` amber outline driven by `activeIdx`, which a `$effect` reset to `0` (= the first pinned row) on every open — so the highlight always landed on the pinned repo regardless of what was selected.

## Fix

`ui/src/lib/components/RepoSelect.svelte`:

- **Init the cursor on open.** `toggle()` is now async; on open it sets `activeIdx` to the selected repo's position via `shown.findIndex(row => row.repo.path === value)` (fallback `0` when nothing matches), then `await tick()` + `scrollActiveIntoView()` so a selection low in the list is brought into view. When the selected repo is also pinned, its top (pinned) occurrence is highlighted — visible without scrolling.
- **Decouple reset-to-top from open.** The old "reset on every `shown` change" `$effect` is replaced with a bounds **clamp** (`if (activeIdx > shown.length - 1) activeIdx = Math.max(0, shown.length - 1)`) so an async poll shrinking the list can't strand the cursor past the end. Typing-reset moves to an explicit `oninput={() => (activeIdx = 0)}` on the filter input.
- **Belt-and-suspenders:** focus the filter input with `{ preventScroll: true }` so it can't fight the row scroll-into-view.

Moving the cursor (rather than just hiding the outline) also fixes Enter-after-open, which now picks the *selected* repo instead of the first pinned one, and keeps `aria-activedescendant` correct.

## Tests

New `ui/src/lib/components/RepoSelect.browser.test.ts` (vitest-browser-svelte), asserting on `aria-selected="true"` (the cursor) — not the `.active` tint, which keys on `r.path === value` independently and would prove nothing:

- Open puts the cursor on the selected (non-pinned) repo, not the first pinned row.
- Typing a filter resets the cursor to the first result.
- Unknown `value` falls back to row 0.

`cd ui && bun run check` clean; full UI suite green (990+ tests). UI-only `fix:` — no new i18n keys, no feature-catalog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)