### PR TITLE
fix(viewport): scope mobile page-swipe to the terminal body so the top action bar is reachable

### DIFF
--- a/ui/src/lib/components/DiffFileBlock.svelte
+++ b/ui/src/lib/components/DiffFileBlock.svelte
@@ -92,7 +92,9 @@
     {:else if flatLines.length === 0}
       <p class="note">no textual changes</p>
     {:else}
-      <div class="hunks">
+      <!-- long diff lines scroll horizontally (overflow-x); opt out of the mobile
+           page-swipe so a sideways drag scrolls the code instead of paging agents -->
+      <div class="hunks" data-swipe-ignore>
         {#each hunksView as hunk (hunk.header)}
           <div class="hunk-head">{hunk.header}</div>
           {#each hunk.lines as item (item.line.kind + (item.line.oldNo ?? "") + (item.line.newNo ?? "") + item.line.content)}

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -399,4 +399,24 @@ describe("Viewport mobile page-swipe scoping", () => {
       ).toBeNull();
     }
   });
+
+  it("does NOT page when a drag starts on a [data-swipe-ignore] surface inside the body", async () => {
+    const onnavigate = vi.fn();
+    const { container } = renderMobile(onnavigate);
+
+    const body = container.querySelector(".vp-body");
+    expect(body, ".vp-body should render").not.toBeNull();
+    // stand in for DiffFileBlock's horizontally-scrollable `.hunks`: an in-body
+    // surface that opts out so a sideways drag scrolls it instead of paging agents
+    const optOut = document.createElement("div");
+    optOut.setAttribute("data-swipe-ignore", "");
+    body!.appendChild(optOut);
+    // it IS inside the allow-list, so only the within-body deny check can suppress
+    // paging — this isolates that branch (distinct from the out-of-body chrome case)
+    expect(optOut.closest("[data-swipe-page]")).toBe(body);
+
+    leftwardDrag(optOut);
+
+    expect(onnavigate).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -23,7 +23,7 @@ const { default: Viewport } = await import("./Viewport.svelte");
 const { reviews } = await import("$lib/reviews.svelte");
 import { toasts } from "$lib/toasts.svelte";
 import { m } from "$lib/paraglide/messages";
-import type { Session } from "$lib/types";
+import type { Session, BuildQueue } from "$lib/types";
 
 function session(partial: Partial<Session> & { id: string }): Session {
   return {
@@ -300,5 +300,103 @@ describe("Viewport autopilot badge vs in-flight review", () => {
       openPreviewTick: 0,
     });
     await expect.element(badge()).not.toBeInTheDocument();
+  });
+});
+
+// ── Mobile page-swipe is scoped to the terminal/panel body (allow-list) ───────
+// Regression: the horizontal "switch task side-by-side" swipe used to arm for ANY
+// touch outside a small deny-set, so a drag starting on the top chrome (header/tabs,
+// the PR/automations/autopilot git strip, the build-queue panel) hijacked the
+// gesture and the buttons there were unreachable. The fix arms the swipe ONLY when
+// the touch starts inside `.vp-body` (tagged data-swipe-page); all chrome is excluded
+// by omission. The handler reads e.touches[0].clientX/clientY on start/move and
+// nothing off touchend, so we dispatch bubbling Events with a `touches` shim.
+describe("Viewport mobile page-swipe scoping", () => {
+  // The structural-invariant test below assumes the header is expanded so
+  // `.vp-git-strip` / `.bqp` render; clear the persisted collapse flag so a prior
+  // test can't leave it set ("1").
+  beforeEach(() => localStorage.removeItem("shepherd-vp-header-collapsed"));
+
+  // The swipe listeners live on the `.viewport` root and read e.target via closest();
+  // a bubbling Event carries our chosen target up to that root listener.
+  function fakeTouch(type: string, x: number, y: number): Event {
+    const e = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(e, "touches", {
+      value: type === "touchend" ? [] : [{ clientX: x, clientY: y }],
+      configurable: true,
+    });
+    return e;
+  }
+
+  // A leftward drag with a large dx clears the axis slop and the commit threshold
+  // (Math.min(120, width*0.33)), committing to "next" → onnavigate(switchOrder[1]).
+  function leftwardDrag(el: Element) {
+    el.dispatchEvent(fakeTouch("touchstart", 300, 100));
+    el.dispatchEvent(fakeTouch("touchmove", 0, 100));
+    el.dispatchEvent(fakeTouch("touchend", 0, 100));
+  }
+
+  const oneStepQueue = (sessionId: string): BuildQueue => ({
+    sessionId,
+    approved: false,
+    steps: [{ id: "s1", title: "step one", status: "pending", position: 0 }],
+  });
+
+  function renderMobile(onnavigate: (id: string) => void) {
+    return render(Viewport, {
+      session: session({ id: "v1" }),
+      mobile: true,
+      switchOrder: ["v1", "v2"],
+      onnavigate,
+      buildQueue: oneStepQueue("v1"),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+  }
+
+  it("pages to the next agent on a leftward drag inside the terminal body", async () => {
+    const onnavigate = vi.fn();
+    const { container } = renderMobile(onnavigate);
+
+    const body = container.querySelector(".vp-body");
+    expect(body, ".vp-body should render").not.toBeNull();
+    // drag on the terminal mount (a child of .vp-body), as a real touch would land
+    const mount = body!.querySelector(".term-mount") ?? body!;
+    leftwardDrag(mount);
+
+    expect(onnavigate).toHaveBeenCalledTimes(1);
+    expect(onnavigate).toHaveBeenCalledWith("v2");
+  });
+
+  it("does NOT page when the same drag starts on the header chrome (.vp-head)", async () => {
+    const onnavigate = vi.fn();
+    const { container } = renderMobile(onnavigate);
+
+    const head = container.querySelector(".vp-head");
+    expect(head, ".vp-head should render").not.toBeNull();
+    leftwardDrag(head!);
+
+    expect(onnavigate).not.toHaveBeenCalled();
+  });
+
+  it("tags only .vp-body with data-swipe-page; all top chrome is outside the allow-list", async () => {
+    const onnavigate = vi.fn();
+    const { container } = renderMobile(onnavigate);
+
+    const body = container.querySelector(".vp-body");
+    expect(body, ".vp-body should render").not.toBeNull();
+    // .vp-body itself carries the allow-list marker, and its terminal mount resolves to it
+    expect(body!.matches("[data-swipe-page]")).toBe(true);
+    expect(body!.querySelector(".term-mount")?.closest("[data-swipe-page]")).toBe(body);
+
+    // each chrome container renders and is OUTSIDE the page-swipe allow-list
+    for (const sel of [".vp-head", ".vp-git-strip", ".bqp"]) {
+      const el = container.querySelector(sel);
+      expect(el, `${sel} should render`).not.toBeNull();
+      expect(
+        el!.closest("[data-swipe-page]"),
+        `${sel} must not be inside data-swipe-page`,
+      ).toBeNull();
+    }
   });
 });

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1491,16 +1491,19 @@
     let locked = false; // recognised as an actionable horizontal swipe
     const onStart = (e: TouchEvent) => {
       if (e.touches.length !== 1) return;
-      // don't hijack text selection / cursor placement in editable fields, nor the
-      // horizontally-scrollable bottom bars (steer chips, control keys, compose) —
-      // those overflow off-screen on a phone and the operator scrolls them sideways
-      // to reach a hidden button; only the terminal pane itself pages between agents.
-      if (
-        (e.target as Element | null)?.closest(
-          "input, textarea, [contenteditable], [data-swipe-ignore]",
-        )
-      )
-        return;
+      const t = e.target as Element | null;
+      // Allow-list: page only from the terminal/panel body (`.vp-body`, tagged
+      // data-swipe-page). The surrounding chrome — header + tabs, the
+      // PR/automations strip, the build-queue panel, the steer + control bars, and
+      // any popover anchored to them — sits outside `.vp-body`, so it's excluded by
+      // omission (no per-container tagging, and new chrome is excluded automatically).
+      if (!t?.closest("[data-swipe-page]")) return;
+      // Within-body refinement: don't hijack text selection / cursor placement in
+      // editable fields that can appear inside a panel. [data-swipe-ignore] is a
+      // forward-compat opt-out for any FUTURE surface placed inside the body (e.g. a
+      // horizontally-scrollable panel) — today's markers (steer/control bars) live
+      // outside `.vp-body` and are already excluded by the allow-gate above.
+      if (t.closest("input, textarea, [contenteditable], [data-swipe-ignore]")) return;
       startX = e.touches[0].clientX;
       startY = e.touches[0].clientY;
       armed = true;
@@ -2079,7 +2082,7 @@
   {/if}
 
   <!-- scan overlay + terminal (terminal stays mounted across tab switches) -->
-  <div class="vp-body">
+  <div class="vp-body" data-swipe-page>
     <div class="scan" aria-hidden="true"></div>
     <div
       class="term-mount"


### PR DESCRIPTION
## Problem

On mobile, the page-switch swipe gesture ("switch task side-by-side") was bound to the entire `.viewport` and armed for any touch except a small deny-set. So a horizontal swipe starting anywhere on the **top action bar** — the header/tabs row (`.vp-head`), the PR/automations/autopilot git strip (`.vp-git-strip`), or the build-queue panel (`.bqp`) — got hijacked into a page switch. The controls there (Merge, automations, AUTOPILOT/ready, tabs, …) were unreachable by touch.

## Fix

Flip the gesture eligibility from a **deny-list to an allow-list**: the page-swipe now arms **only when the touch starts inside the terminal/panel body** (`.vp-body`, marked `data-swipe-page`). Everything outside it — all top chrome, the steer bar, the control row, and any popover anchored to chrome — is excluded by omission, so no per-container tagging to forget now or in future. This also matches the handler's long-standing intent comment ("only the terminal pane itself pages between agents").

The existing `input/textarea/contenteditable/[data-swipe-ignore]` deny check is retained as a **within-body refinement** (protect text selection in panel fields; `data-swipe-ignore` stays as a forward opt-out for any future surface placed *inside* the body).

### Why allow-list over deny-list
- Self-maintaining: new chrome is excluded automatically; the deny-list had to chase every new bar (which is how the bug appeared).
- Robust to floating chrome: header popovers (`.desig-pop`, preview-cmd pop, rename note, `RedrawMenu`) render outside `.vp-body` and are excluded structurally — even if one were ever portaled to `document.body`.

## Scope
- No changes to gesture thresholds, axis-lock logic, `paneSwipeAction`, or `onback`/`canSwitch` arming.
- `.vp-head` / `.vp-git-strip` / `BuildQueuePanel` markup untouched; existing `data-swipe-ignore` markers left in place.
- Desktop is unaffected (handler is mobile-gated).

## Tests
New regression coverage in `Viewport.browser.test.ts` (none existed before):
- a leftward drag inside `.vp-body` pages to the next agent (`onnavigate("v2")`);
- the same drag on `.vp-head` does **not** page;
- structural invariant: `.vp-body` carries `data-swipe-page`, and `.vp-head` / `.vp-git-strip` / `.bqp` each resolve `closest("[data-swipe-page]")` to `null`.

Falsifiability confirmed: removing the attribute or the gate makes the tests fail. `cd ui && bun run check` (0/0) and `bun run test` (991 passing) are green.

Touch-interaction bugfix (not a `feat`) — no i18n keys, design-system tokens, or feature-catalog entry required. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)