### PR TITLE
fix(steers): keep delete button inline in saved-steers rows

### DIFF
--- a/ui/src/lib/components/SteersEditor.svelte
+++ b/ui/src/lib/components/SteersEditor.svelte
@@ -200,7 +200,6 @@
     display: flex;
     gap: 4px;
     align-items: center;
-    flex-wrap: wrap;
   }
   .grip {
     flex: 0 0 auto;


### PR DESCRIPTION
## Problem

In the Saved Steers editor (Settings → Saved Steers), the `✕` delete button at the end of each steer row wrapped onto its own line below the row, looking broken:

The row is a flex container with `flex-wrap: wrap`. It packs seven controls — grip, emoji, label input, text input, `BAR`, `ISSUES`, `✕` — into the Settings card, which is only `width: min(520px, 92vw)`. They don't fit, so the last item (`✕`) wraps alone.

## Fix

Remove `flex-wrap: wrap` from `.srow`. The fixed controls are `flex: 0 0 auto`; the two inputs have `min-width: 0` and `flex-shrink: 1`, so they absorb the squeeze and keep the whole row on one line at every width — no orphaned delete button, and no horizontal overflow (inputs just get a touch narrower).

One-line CSS change, no markup/logic/i18n change.

## Verification

- `cd ui && bun run check` — 0 errors, 0 warnings
- `cd ui && bun run check:i18n` — locales in parity (no strings touched)

`[no-feature-entry]` — bug fix, ships no new user-facing capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)