### PR TITLE
feat(backlog): type-to-filter search in the repo list filter bar

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -730,6 +730,8 @@
   "backlog_filter_has_issues": "Hat Issues",
   "backlog_filter_has_prs": "Hat PRs",
   "backlog_filter_none_match": "Keine Repos entsprechen dem Filter",
+  "backlog_filter_search_placeholder": "Repos filtern…",
+  "backlog_filter_search_clear": "Suche löschen",
   "a11y_skip_to_main": "Zum Hauptinhalt springen",
   "todopanel_add_aria": "Neuer To-do-Eintrag",
   "todopanel_item_aria": "Erledigt umschalten: {item}",
@@ -993,5 +995,7 @@
   "feat_repo_switcher_title": "Der Repo-Filter ist jetzt eine Chip-Reihe",
   "feat_repo_switcher_body": "Der Repo-Filter ist jetzt eine Chip-Reihe über der Herde. Klicke ein Repo an, um jede Ansicht darauf einzuschränken; klicke erneut, um wieder alle anzuzeigen. Ausstehende Learnings und Pausen eines Repos erscheinen an seinem Chip, die übrigen Drain-Details beim Filtern auf das Repo. Das Filtern funktioniert jetzt auch in der Rasteransicht.",
   "feat_redraw_menu_title": "Terminal-Neuzeichnen-Menü",
-  "feat_redraw_menu_body": "Terminal-Verlauf gestaucht, nachdem die Session auf einem schmaleren Gerät offen war? Der neue ↔ Neu-zeichnen-Button im Session-Header bietet vier Reparatur-Varianten zum Ausprobieren — vom sanften Resize-Impuls bis zum vollen claude --resume-Re-Render."
+  "feat_redraw_menu_body": "Terminal-Verlauf gestaucht, nachdem die Session auf einem schmaleren Gerät offen war? Der neue ↔ Neu-zeichnen-Button im Session-Header bietet vier Reparatur-Varianten zum Ausprobieren — vom sanften Resize-Impuls bis zum vollen claude --resume-Re-Render.",
+  "feat_backlog_repo_search_title": "Backlog-Repoliste durchsuchen",
+  "feat_backlog_repo_search_body": "Tippe in das neue Filtereingabefeld oben in der Backlog-Repoliste, um Repos nach Name einzuschränken — kombinierbar mit den Chips Hat Issues und Hat PRs."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -730,6 +730,8 @@
   "backlog_filter_has_issues": "Has issues",
   "backlog_filter_has_prs": "Has PRs",
   "backlog_filter_none_match": "No repos match the filter",
+  "backlog_filter_search_placeholder": "Filter repos…",
+  "backlog_filter_search_clear": "Clear search",
   "a11y_skip_to_main": "Skip to main content",
   "todopanel_add_aria": "New to-do item",
   "todopanel_item_aria": "Toggle done: {item}",
@@ -993,5 +995,7 @@
   "feat_repo_switcher_title": "The repo filter is now a chip rail",
   "feat_repo_switcher_body": "The repo filter is now a row of chips above the herd. Click a repo to scope every view to it; click it again to show all repos. A repo's pending learnings and pauses show on its chip, with the rest of its drain detail when you filter to it. Filtering now works in the grid view too.",
   "feat_redraw_menu_title": "Terminal redraw menu",
-  "feat_redraw_menu_body": "Terminal history squished after viewing a session from a narrower device? The new ↔ Redraw button in the session header offers four repair variants to try — from a gentle resize nudge to a full claude --resume re-render."
+  "feat_redraw_menu_body": "Terminal history squished after viewing a session from a narrower device? The new ↔ Redraw button in the session header offers four repair variants to try — from a gentle resize nudge to a full claude --resume re-render.",
+  "feat_backlog_repo_search_title": "Search the backlog repo list",
+  "feat_backlog_repo_search_body": "Type in the new filter input at the top of the backlog repo list to narrow repos by name — combines with the Has issues / Has PRs chips."
 }

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -44,12 +44,14 @@
   // Shared across tabs so switching Issues ↔ PRs keeps the chosen project.
   let selectedPath = $state<string | null>(null);
 
-  // Repo-list filter (chips live in ProjectBacklogList, state owned here so the
-  // selection effects below can stay in sync with what the list actually shows).
+  // Repo-list filter (chips + search input live in ProjectBacklogList, state
+  // owned here so the selection effects below can stay in sync with what the
+  // list actually shows).
   let hasIssues = $state(false);
   let hasPRs = $state(false);
+  let query = $state("");
   let visibleProjects = $derived(
-    payload ? filterProjects(payload.projects, { hasIssues, hasPRs }) : [],
+    payload ? filterProjects(payload.projects, { hasIssues, hasPRs, query }) : [],
   );
 
   // Tab badges count the SELECTED repo's items — the same repo the detail pane
@@ -129,8 +131,10 @@
         {selectedPath}
         {hasIssues}
         {hasPRs}
+        {query}
         ontoggleissues={() => (hasIssues = !hasIssues)}
         ontoggleprs={() => (hasPRs = !hasPRs)}
+        onsearch={(q) => (query = q)}
         onselect={(p) => (selectedPath = p)}
       />
     </div>
@@ -232,8 +236,10 @@
           {selectedPath}
           {hasIssues}
           {hasPRs}
+          {query}
           ontoggleissues={() => (hasIssues = !hasIssues)}
           ontoggleprs={() => (hasPRs = !hasPRs)}
+          onsearch={(q) => (query = q)}
           onselect={(p) => (selectedPath = p)}
         />
       </div>

--- a/ui/src/lib/components/ProjectBacklogList.svelte
+++ b/ui/src/lib/components/ProjectBacklogList.svelte
@@ -10,8 +10,10 @@
     selectedPath,
     hasIssues,
     hasPRs,
+    query,
     ontoggleissues,
     ontoggleprs,
+    onsearch,
     onselect,
   }: {
     /** Already filtered by the parent (BacklogView) via filterProjects — the
@@ -21,18 +23,50 @@
     selectedPath: string | null;
     hasIssues: boolean;
     hasPRs: boolean;
+    query: string;
     ontoggleissues: () => void;
     ontoggleprs: () => void;
+    onsearch: (q: string) => void;
     onselect: (path: string) => void;
   } = $props();
 
+  const searching = $derived(query.trim() !== "");
+
   // "Recently worked on" group at the top — same ranking criteria as the New
   // Task repo picker's pinned recents (see partitionRecents). Hoisted, not
-  // duplicated, so each repo keeps a single selectable row.
-  const grouped = $derived(partitionRecents(projects));
+  // duplicated, so each repo keeps a single selectable row. Suppressed while
+  // searching so the results read as a flat search list.
+  const grouped = $derived(partitionRecents(projects, searching));
 </script>
 
 <div class="filter-bar">
+  <div class="filter-search-wrap">
+    <input
+      class="filter-search"
+      type="text"
+      autocomplete="off"
+      spellcheck={false}
+      value={query}
+      placeholder={m.backlog_filter_search_placeholder()}
+      aria-label={m.backlog_filter_search_placeholder()}
+      oninput={(e) => onsearch(e.currentTarget.value)}
+      onkeydown={(e) => {
+        if (e.key === "Escape" && query !== "") {
+          e.stopPropagation();
+          e.preventDefault();
+          onsearch("");
+        }
+      }}
+    />
+    {#if searching}
+      <button
+        class="filter-search-clear"
+        type="button"
+        aria-label={m.backlog_filter_search_clear()}
+        onclick={() => onsearch("")}>×</button
+      >
+    {/if}
+  </div>
   <button
     class="filter-chip"
     class:active={hasIssues}
@@ -54,7 +88,7 @@
 </div>
 
 <!-- The parent only renders this list when there are forge repos, so an empty
-     `projects` here always means the active filter matched nothing. -->
+     `projects` here always means the active chips or search matched nothing. -->
 {#if projects.length === 0}
   <div class="filter-empty">
     <span class="filter-empty-label">{m.backlog_filter_none_match()}</span>
@@ -97,6 +131,58 @@
     margin-bottom: 2px;
     background: var(--color-inset);
     border-bottom: 1px solid var(--color-line);
+  }
+
+  .filter-search-wrap {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .filter-search {
+    width: 100%;
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.04em;
+    padding: 0 28px 0 10px;
+    min-height: 36px;
+    outline: none;
+    transition: border-color 0.12s;
+  }
+
+  .filter-search::placeholder {
+    color: var(--color-muted);
+  }
+
+  .filter-search:focus {
+    border-color: var(--color-line-bright);
+  }
+
+  .filter-search-clear {
+    position: absolute;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: transparent;
+    border: none;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    padding: 0 8px;
+    min-height: 36px;
+    cursor: pointer;
+    line-height: 1;
+    touch-action: manipulation;
+  }
+
+  .filter-search-clear:hover {
+    color: var(--color-ink);
   }
 
   .filter-chip {

--- a/ui/src/lib/components/backlog-view.test.ts
+++ b/ui/src/lib/components/backlog-view.test.ts
@@ -248,6 +248,75 @@ describe("filterProjects", () => {
   });
 });
 
+describe("filterProjects — query search", () => {
+  // Corpus: paths whose basenames and display paths vary for substring testing.
+  const alpha = { ...project("/repos/alpha", 2, 1), display: "/repos/alpha" };
+  const betaWidget = { ...project("/repos/beta-widget", 0, 3), display: "/work/beta-widget" };
+  const gamma = { ...project("/repos/gamma", 1, 0), display: "/repos/gamma" };
+  const projects = [alpha, betaWidget, gamma];
+
+  it("matches on the path basename (name)", () => {
+    expect(filterProjects(projects, { hasIssues: false, hasPRs: false, query: "alpha" })).toEqual([
+      alpha,
+    ]);
+  });
+
+  it("matches on the display path", () => {
+    // betaWidget has display "/work/beta-widget" — "work" only lives in display.
+    expect(filterProjects(projects, { hasIssues: false, hasPRs: false, query: "work" })).toEqual([
+      betaWidget,
+    ]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(filterProjects(projects, { hasIssues: false, hasPRs: false, query: "GAMMA" })).toEqual([
+      gamma,
+    ]);
+  });
+
+  it("blank query is identity (all projects pass)", () => {
+    expect(filterProjects(projects, { hasIssues: false, hasPRs: false, query: "" })).toEqual(
+      projects,
+    );
+  });
+
+  it("whitespace-only query is identity", () => {
+    expect(filterProjects(projects, { hasIssues: false, hasPRs: false, query: "   " })).toEqual(
+      projects,
+    );
+  });
+
+  it("undefined query is identity (existing call sites unaffected)", () => {
+    expect(filterProjects(projects, { hasIssues: false, hasPRs: false })).toEqual(projects);
+  });
+
+  it("AND-combines query with hasIssues", () => {
+    // alpha has issues (2>0) and matches "alpha"; betaWidget has no issues (0)
+    expect(filterProjects(projects, { hasIssues: true, hasPRs: false, query: "alpha" })).toEqual([
+      alpha,
+    ]);
+    // betaWidget matches "beta" but has 0 issues — excluded
+    expect(filterProjects(projects, { hasIssues: true, hasPRs: false, query: "beta" })).toEqual([]);
+  });
+
+  it("AND-combines query with hasPRs", () => {
+    // betaWidget has PRs (3>0) and matches "beta"
+    expect(filterProjects(projects, { hasIssues: false, hasPRs: true, query: "beta" })).toEqual([
+      betaWidget,
+    ]);
+    // gamma matches "gamma" but 0 PRs — excluded
+    expect(filterProjects(projects, { hasIssues: false, hasPRs: true, query: "gamma" })).toEqual(
+      [],
+    );
+  });
+
+  it("returns empty array when query matches nothing", () => {
+    expect(
+      filterProjects(projects, { hasIssues: false, hasPRs: false, query: "zzz-no-match" }),
+    ).toEqual([]);
+  });
+});
+
 describe("partitionRecents", () => {
   // Same ranking criteria as the New Task repo picker (RepoSelect): recent agent
   // count desc, then lastUsedAt desc, then name asc — capped at RECENT_LIMIT.
@@ -305,6 +374,23 @@ describe("partitionRecents", () => {
     expect(rest).toEqual([a, c]);
     const all = [...recents, ...rest].map((p) => p.path);
     expect(new Set(all).size).toBe(all.length);
+  });
+
+  it("searching=true returns empty recents and all projects flat in rest", () => {
+    const a = recentProject("/repos/a", 5);
+    const b = recentProject("/repos/b", 2);
+    const c = recentProject("/repos/c", null);
+    const { recents, rest } = partitionRecents([a, b, c], true);
+    expect(recents).toEqual([]);
+    expect(rest).toEqual([a, b, c]);
+  });
+
+  it("searching=false keeps existing hoist behaviour (default, backward-safe)", () => {
+    const a = recentProject("/repos/a", 5);
+    const b = recentProject("/repos/b", null);
+    const { recents, rest } = partitionRecents([a, b], false);
+    expect(recents).toEqual([a]);
+    expect(rest).toEqual([b]);
   });
 });
 

--- a/ui/src/lib/components/backlog-view.ts
+++ b/ui/src/lib/components/backlog-view.ts
@@ -108,17 +108,22 @@ function projectName(p: BacklogProject): string {
  * pinned rows below), this persistent list hoists the recents — `rest` keeps
  * the parent's order minus the hoisted entries, so no repo appears twice.
  *
- * Deliberate divergence from RepoSelect, which drops its recents group while
- * the user types: there the filter is a *search* for one specific repo, so the
- * shortcut only gets in the way. The backlog chips are persistent *scope*
- * filters (has issues / has PRs) — running on the already-filtered list keeps
- * the group useful while a scope is active, and never re-surfaces a repo the
- * active chips exclude (which would break the filter's promise).
+ * The scope chips (has issues / has PRs) keep the recents group alive while
+ * active — they narrow the universe but don't make the shortcut confusing.
+ * An active *search* (`searching = true`) suppresses the group entirely and
+ * returns a flat list, mirroring RepoSelect's behaviour: when the user is
+ * hunting for a specific repo by name the shortcut group only gets in the way.
  */
-export function partitionRecents(projects: readonly BacklogProject[]): {
+export function partitionRecents(
+  projects: readonly BacklogProject[],
+  searching = false,
+): {
   recents: BacklogProject[];
   rest: BacklogProject[];
 } {
+  if (searching) {
+    return { recents: [], rest: [...projects] };
+  }
   const recents = projects
     .filter((p) => (p.recentAgentCount ?? 0) > 0)
     .sort(
@@ -133,10 +138,13 @@ export function partitionRecents(projects: readonly BacklogProject[]): {
 }
 
 /**
- * Narrow the repo list by activity. Each active flag is a *required* predicate
- * (AND semantics): `hasIssues` keeps only repos with open issues, `hasPRs` only
- * repos with open PRs, and both together keep only their intersection. With
- * both off, every project passes (an identity filter).
+ * Narrow the repo list by activity and optional name search. Each active
+ * predicate is AND'd together:
+ * - `hasIssues` keeps only repos with open issues.
+ * - `hasPRs` keeps only repos with open PRs.
+ * - `query` (optional) keeps only repos whose name + display path contains the
+ *   query string (case-insensitive substring, same rule as RepoSelect). An
+ *   undefined or blank/whitespace-only query is the identity predicate.
  *
  * Counts fail closed: `?? 0` maps an unknown count (`null`, e.g. a non-github
  * forge or a not-yet-fetched repo) to 0, so only a count strictly `> 0`
@@ -144,9 +152,13 @@ export function partitionRecents(projects: readonly BacklogProject[]): {
  */
 export function filterProjects(
   projects: readonly BacklogProject[],
-  opts: { hasIssues: boolean; hasPRs: boolean },
+  opts: { hasIssues: boolean; hasPRs: boolean; query?: string },
 ): BacklogProject[] {
+  const q = opts.query?.trim().toLowerCase() ?? "";
   return projects.filter(
-    (p) => (!opts.hasIssues || (p.openIssues ?? 0) > 0) && (!opts.hasPRs || (p.openPRs ?? 0) > 0),
+    (p) =>
+      (!opts.hasIssues || (p.openIssues ?? 0) > 0) &&
+      (!opts.hasPRs || (p.openPRs ?? 0) > 0) &&
+      (q === "" || (projectName(p) + " " + p.display).toLowerCase().includes(q)),
   );
 }

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -542,4 +542,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_pr_kind_badges_title",
     bodyKey: "feat_pr_kind_badges_body",
   },
+  {
+    // No targetId: the backlog repo list only mounts on the Backlog view (not the
+    // default dashboard), so a coachmark anchor would usually be unmounted —
+    // surface via the What's-New drawer only.
+    id: "backlog-repo-search",
+    sinceVersion: "1.26.0",
+    titleKey: "feat_backlog_repo_search_title",
+    bodyKey: "feat_backlog_repo_search_body",
+  },
 ];


### PR DESCRIPTION
## What

Adds a **type-to-filter text search input** to the backlog repo-list filter bar. As you type, the backlog repo list narrows by name; the search combines (AND) with the existing **Has issues** / **Has PRs** chips.

Matching mirrors the New Task repo picker (`RepoSelect`): case-insensitive substring over the repo's **name + display path**.

## Why

"Add a repo type to filter bar" — the user clarified this means *typing* to filter by repo name (not a forge-kind/GitHub-vs-Gitea facet, which would duplicate the existing repo-filter chips). A scrollable backlog repo list with no search is slow to navigate once there are many repos.

## Behavior

- Search input sits first in the filter bar (`flex: 1`), chips to its right; sticky bar unchanged.
- A clear (×) button appears only when the query is non-empty; **Esc** clears a non-empty query (and is swallowed so it doesn't also close the mobile detail overlay) — an empty-query Esc propagates normally.
- While the search is non-empty, the **"recently worked on"** grouping is suppressed and the list goes flat (matching `RepoSelect`); an empty search restores the grouping.
- A selected repo that the search hides is auto-deselected via the existing `visibleProjects` clear effect (no new effect) — the detail pane never shows a hidden repo (fail-closed).
- No matches → existing `backlog_filter_none_match` empty state.
- Works in both desktop split and mobile master views.

## Implementation

- `backlog-view.ts`: `filterProjects` gains optional `query?: string` (blank/undefined = identity, so existing call sites are untouched); `partitionRecents` gains a `searching` flag that drops the recents hoist. Both pure + unit-tested (9 new tests).
- `ProjectBacklogList.svelte` / `BacklogView.svelte`: new `query`/`onsearch` prop pair threaded through the single filter path; design-system tokens only; 36px touch targets.
- i18n: `backlog_filter_search_placeholder`, `backlog_filter_search_clear` (+ feature-announcement keys) added to EN and DE.
- Feature discovery: `backlog-repo-search` catalog entry (`sinceVersion: 1.26.0`, drawer-only, no coachmark — the backlog list isn't the default view).

## Verification

- `cd ui && bun run test` — 1001 pass (incl. 9 new)
- `cd ui && bun run check` — 0 errors
- `cd ui && bun run check:i18n` — EN/DE parity (989 keys each)
- branch-hygiene + feature-catalog gates pass; pre-push green

🤖 Generated with [Claude Code](https://claude.com/claude-code)