### PR TITLE
fix(herd): drop redundant repo-filter underline + keep filter alive at one repo

### DIFF
--- a/ui/src/lib/components/RepoSwitcher.svelte
+++ b/ui/src/lib/components/RepoSwitcher.svelte
@@ -23,8 +23,9 @@
   } = $props();
 
   // ── render branch selection ────────────────────────────────────────────────
-  const railVisible = $derived(chipRailVisible(chips));
-  // Lone-repo telemetry: one repo (nothing to filter) but it carries drain/learnings.
+  const railVisible = $derived(chipRailVisible(chips, repoFilter));
+  // Lone-repo telemetry: one repo with no active filter, carrying drain/learnings.
+  // (When that lone repo IS the active filter, the rail shows instead — see railVisible.)
   const loneChip = $derived(chips.length === 1 && chipHasTelemetry(chips[0]) ? chips[0] : null);
   // The active chip whose detail line shows below the rail — only when it has telemetry.
   const activeChip = $derived(

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -323,7 +323,6 @@
                the row's own select doesn't also fire. -->
           <span
             class="name-icon actionable"
-            class:filtered={repoFiltered}
             role="button"
             tabindex="0"
             title={repoName}
@@ -723,12 +722,6 @@
     outline: 1.5px solid var(--color-line-bright);
     outline-offset: 0;
   }
-  /* active filter: a quiet amber underline marks the icon as the engaged toggle
-     (matches the .fbtn active accent in the herd head) without adding a new hue */
-  .name-icon.actionable.filtered {
-    box-shadow: 0 1px 0 0 var(--color-amber);
-  }
-
   /* Visually hidden but available to screen readers (matches GitRail.svelte) */
   .sr-only {
     position: absolute;

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -354,19 +354,33 @@ describe("chipRailVisible", () => {
   }
 
   it("false for empty array", () => {
-    expect(chipRailVisible([])).toBe(false);
+    expect(chipRailVisible([], null)).toBe(false);
   });
 
   it("false for 1 chip", () => {
-    expect(chipRailVisible([chip("/repos/a")])).toBe(false);
+    expect(chipRailVisible([chip("/repos/a")], null)).toBe(false);
   });
 
   it("true for 2 chips", () => {
-    expect(chipRailVisible([chip("/repos/a"), chip("/repos/b")])).toBe(true);
+    expect(chipRailVisible([chip("/repos/a"), chip("/repos/b")], null)).toBe(true);
   });
 
   it("true for 3+ chips", () => {
-    expect(chipRailVisible([chip("/repos/a"), chip("/repos/b"), chip("/repos/c")])).toBe(true);
+    expect(chipRailVisible([chip("/repos/a"), chip("/repos/b"), chip("/repos/c")], null)).toBe(
+      true,
+    );
+  });
+
+  it("true for 1 chip when filter matches that chip (lone-repo filter stays visible)", () => {
+    expect(chipRailVisible([chip("/repos/a")], "/repos/a")).toBe(true);
+  });
+
+  it("false for 1 chip when filter is a different repo (filter on repo with no chip)", () => {
+    expect(chipRailVisible([chip("/repos/a")], "/repos/b")).toBe(false);
+  });
+
+  it("false for empty array with an active filter", () => {
+    expect(chipRailVisible([], "/repos/a")).toBe(false);
   });
 });
 
@@ -413,7 +427,15 @@ describe("shouldClearRepoFilter", () => {
     expect(shouldClearRepoFilter("/repos/x", [chip("/repos/a"), chip("/repos/b")])).toBe(true);
   });
 
-  it("TRUE when only 1 chip (rail hidden) even if it is that repo — the strand case", () => {
-    expect(shouldClearRepoFilter("/repos/a", [chip("/repos/a")])).toBe(true);
+  it("false when filtered repo is the lone live repo — keeps the filter while its session is alive", () => {
+    expect(shouldClearRepoFilter("/repos/a", [chip("/repos/a")])).toBe(false);
+  });
+
+  it("TRUE when filtered repo is absent from a 1-chip rail — its session is gone", () => {
+    expect(shouldClearRepoFilter("/repos/x", [chip("/repos/a")])).toBe(true);
+  });
+
+  it("TRUE when no chips remain (all sessions ended)", () => {
+    expect(shouldClearRepoFilter("/repos/a", [])).toBe(true);
   });
 });

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -81,9 +81,11 @@ export function repoChipRows(
     .sort((a, b) => a.repoPath.localeCompare(b.repoPath));
 }
 
-/** The chip rail renders only when ≥2 repos have a live session (real filtering need). */
-export function chipRailVisible(chips: RepoChip[]): boolean {
-  return chips.length >= 2;
+/** The chip rail renders when ≥2 repos have a live session (real filtering need), OR when
+ *  an active filter's repo still has a live chip — so a lone-repo filter stays visible
+ *  and can be toggled off, even after all other repos leave the herd. */
+export function chipRailVisible(chips: RepoChip[], repoFilter: string | null): boolean {
+  return chips.length >= 2 || (repoFilter !== null && chips.some((c) => c.repoPath === repoFilter));
 }
 
 /** Whether a chip carries any drain/learnings telemetry worth showing on its own. */
@@ -91,13 +93,10 @@ export function chipHasTelemetry(chip: RepoChip): boolean {
   return chip.drain !== null || chip.insights > 0 || chip.curate > 0;
 }
 
-/** Whether an active repo filter should be cleared because the repo no longer has a
- *  rail chip to un-toggle it — the only repo-filter control the grid view has, and
- *  one that disappears under the <2-repo rail gate. Prevents an un-clearable strand. */
+/** Whether an active repo filter should be cleared because its repo no longer has any live
+ *  session (no chip) — a filter on a vanished repo would strand an empty view. */
 export function shouldClearRepoFilter(repoFilter: string | null, chips: RepoChip[]): boolean {
-  return (
-    repoFilter !== null && !(chipRailVisible(chips) && chips.some((c) => c.repoPath === repoFilter))
-  );
+  return repoFilter !== null && !chips.some((c) => c.repoPath === repoFilter);
 }
 
 /** Whether the `queued` indicator is an interactive trigger (opens the queue

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -150,8 +150,8 @@
   const repoChips = $derived(
     repoChipRows(store.sessions, store.drain, learnings.items, learnings.injectable),
   );
-  // Clear a stranded filter the moment its repo loses its rail chip (the only un-toggle
-  // control the grid view has, gone under the <2-repo gate).
+  // Clear the filter only when its repo has no live session left (no chip) —
+  // a filter on a vanished repo would strand an empty view.
   $effect(() => {
     if (shouldClearRepoFilter(repoFilter, repoChips)) repoFilter = null;
   });


### PR DESCRIPTION
## Why

Two user-reported papercuts in the herd repo-filter chip rail (shipped in #538):

1. **Redundant underline.** Each task-card repo icon got an amber "active filter" underline whenever its repo was the active filter. But a filtered herd shows *only* that repo's cards, so every visible icon carried the identical underline — it distinguished nothing.
2. **Disappearing filter.** The rail only rendered at ≥2 live repos, and the active filter auto-cleared the moment its repo became the lone live repo. So a filter set while a second repo had a working agent vanished — rail and filter both — when that agent's work stopped and the repo left the herd, leaving no control to reset it.

## ⚠️ Behavior change for reviewers (beyond the cosmetic underline removal)

This PR is **not just** the underline removal — commit 2 changes the rail-visibility and filter auto-clear **semantics**:

- **Before:** the chip rail rendered only when ≥2 repos had a live session, and an active filter auto-cleared the instant its repo became the lone live repo.
- **After:** the rail (with its active pill) stays visible whenever a filter is active and its repo still has ≥1 live session — *even if it's the only live repo*. The filter now auto-clears **only** when its repo has no live session left at all (no chip).

Net: a lone filtered repo no longer drops the rail/filter; it stays controllable. The "show the rail at ≥2 repos" rule is unchanged for the no-filter case.

## What

- **`fix(herd): drop redundant repo-filter underline on task-card icons`** — removes the `.name-icon.actionable.filtered` box-shadow and the `class:filtered` binding in `UnitRow.svelte`. The icon stays a clickable filter toggle; `aria-pressed`/`aria-label` retained for screen readers. The rail's active pill is the filter indicator.
- **`fix(herd): keep repo filter + rail alive while its repo has a live session`** — `chipRailVisible(chips, repoFilter)` now also returns true when an active filter's repo still has a chip, and `shouldClearRepoFilter` clears only when the filtered repo has no chip at all (decoupled from the rail gate). So the rail + active pill stay visible and the filter persists whenever its repo has ≥1 live session; the filter auto-clears only when that repo has no session left.

## Behavior after (concrete cases)

- Filtered, ≥2 live repos: rail visible, active pill underlined; card icons show no underline; clicking a card icon still clears.
- Filtered, second repo's sessions leave → only the filtered repo remains live: **rail stays visible with the active pill** (filter persists); user un-toggles from the pill.
- Filtered repo's own sessions all leave (no chip): filter auto-clears, all repos shown.
- Unfiltered single live repo: unchanged (rail hidden; lone telemetry line if any).

## Notes

- No new user-facing strings, no new colors — a refinement of #538, not a new feature, so no feature-catalog entry (two `fix(herd)` commits, gate disarmed). `check:i18n` parity unchanged (985 keys).

## Test plan

- `cd ui && bun run check` — 0 errors / 0 warnings
- `cd ui && bun run test` — 993 passing (incl. updated + new `chipRailVisible` / `shouldClearRepoFilter` cases)
- `cd ui && bun run check:i18n` — parity OK
- branch-hygiene gate: linear off `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
