### PR TITLE
fix(whatsnew): newest release first + mobile layout rework

### DIFF
--- a/ui/src/lib/components/WhatsNew.svelte
+++ b/ui/src/lib/components/WhatsNew.svelte
@@ -29,7 +29,7 @@
   // Localized release date for an entry's `sinceVersion`, or "" if the version
   // isn't tagged yet (e.g. the in-development release) — then only the version
   // badge shows. Date is data formatted via Intl, so it needs no message key.
-  function entryDate(sinceVersion: string): string {
+  function releaseDate(sinceVersion: string): string {
     const iso = releaseDates[sinceVersion];
     if (!iso) return "";
     const d = new Date(`${iso}T00:00:00`);
@@ -40,6 +40,27 @@
       day: "numeric",
     }).format(d);
   }
+
+  // Entries arrive sorted newest release first (computeNewEntries); collapse
+  // consecutive same-version entries into one release group so version + date
+  // render once per release instead of repeating on every entry.
+  type ReleaseGroup = { version: string; date: string; entries: FeatureAnnouncement[] };
+  const groups = $derived.by(() => {
+    const out: ReleaseGroup[] = [];
+    for (const entry of entries) {
+      const last = out[out.length - 1];
+      if (last && last.version === entry.sinceVersion) {
+        last.entries.push(entry);
+      } else {
+        out.push({
+          version: entry.sinceVersion,
+          date: releaseDate(entry.sinceVersion),
+          entries: [entry],
+        });
+      }
+    }
+    return out;
+  });
 </script>
 
 <div
@@ -66,21 +87,26 @@
       <p class="empty">{m.whatsnew_empty()}</p>
     {:else}
       <ul class="list">
-        {#each entries as entry (entry.id)}
-          {@const date = entryDate(entry.sinceVersion)}
-          <li class="entry">
-            <div class="entry-meta">
-              <span class="entry-version">v{entry.sinceVersion}</span>
-              {#if date}
-                <span class="entry-date">{date}</span>
+        {#each groups as group (group.version)}
+          <li class="group">
+            <h3 class="ghead">
+              <span class="gversion">v{group.version}</span>
+              {#if group.date}
+                <span class="gdate">{group.date}</span>
               {/if}
-            </div>
-            <h3 class="entry-title">
-              {(m as unknown as Record<string, () => string>)[entry.titleKey]()}
             </h3>
-            <p class="entry-body">
-              {(m as unknown as Record<string, () => string>)[entry.bodyKey]()}
-            </p>
+            <ul class="entries">
+              {#each group.entries as entry (entry.id)}
+                <li class="entry">
+                  <h4 class="entry-title">
+                    {(m as unknown as Record<string, () => string>)[entry.titleKey]()}
+                  </h4>
+                  <p class="entry-body">
+                    {(m as unknown as Record<string, () => string>)[entry.bodyKey]()}
+                  </p>
+                </li>
+              {/each}
+            </ul>
           </li>
         {/each}
       </ul>
@@ -110,8 +136,10 @@
     display: flex;
     flex-direction: column;
     gap: 10px;
-    padding: 14px;
-    overflow-y: auto;
+    /* safe-area: keep header/footer clear of the Dynamic Island / home indicator */
+    padding: calc(14px + env(safe-area-inset-top)) 14px calc(14px + env(safe-area-inset-bottom));
+    /* the list is the single scroll container (header + footer stay pinned) */
+    overflow: hidden;
     z-index: 51;
   }
   .bar {
@@ -132,6 +160,9 @@
     color: var(--color-muted);
     cursor: pointer;
     font-size: var(--fs-lg);
+    /* ~44px touch target without shifting the visual layout */
+    padding: 14px;
+    margin: -14px;
   }
   .empty {
     color: var(--color-muted);
@@ -145,37 +176,62 @@
     padding: 0;
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 22px;
     flex: 1;
     overflow-y: auto;
   }
+  .group {
+    display: flex;
+    flex-direction: column;
+  }
+  /* Release rail: version + date once per release, sticky while its entries
+     scroll past so the operator always knows which release they're reading. */
+  .ghead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--color-panel);
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    margin: 0;
+    padding: 2px 0 6px;
+    border-bottom: 1px solid var(--color-line-bright);
+    font-size: var(--fs-meta);
+    font-weight: 500;
+    letter-spacing: 0.06em;
+  }
+  .gversion {
+    color: var(--color-amber);
+    font-variant-numeric: tabular-nums;
+  }
+  .gdate {
+    color: var(--color-muted);
+    font-weight: 400;
+  }
+  .entries {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
   .entry {
-    border: 1px solid var(--color-line);
-    padding: 12px 14px;
+    padding: 12px 0;
     display: flex;
     flex-direction: column;
     gap: 6px;
   }
-  .entry-meta {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: var(--fs-meta);
-    letter-spacing: 0.06em;
-  }
-  .entry-version {
-    color: var(--color-amber);
-    font-variant-numeric: tabular-nums;
-  }
-  .entry-date {
-    color: var(--color-muted);
+  .entry + .entry {
+    border-top: 1px solid var(--color-line);
   }
   .entry-title {
     margin: 0;
-    font-size: var(--fs-base);
+    font-size: var(--fs-lg);
     font-weight: 600;
     color: var(--color-ink-bright);
-    letter-spacing: 0.04em;
+    letter-spacing: 0.02em;
+    line-height: 1.3;
   }
   .entry-body {
     margin: 0;
@@ -204,5 +260,12 @@
   .dismiss:focus-visible {
     outline: 1px solid var(--color-amber);
     outline-offset: 2px;
+  }
+  /* phone steering is first-class: full-width, 44px primary action in thumb reach */
+  @media (pointer: coarse) {
+    .dismiss {
+      width: 100%;
+      min-height: 44px;
+    }
   }
 </style>

--- a/ui/src/lib/feature-gate.test.ts
+++ b/ui/src/lib/feature-gate.test.ts
@@ -81,6 +81,21 @@ describe("computeNewEntries", () => {
     expect(computeNewEntries("1.9.0", "1.10.0", [])).toEqual([]);
   });
 
+  it("orders results newest release first, catalog order within a release", () => {
+    const c: readonly FeatureAnnouncement[] = [
+      { id: "old", sinceVersion: "1.10.0", titleKey: "t", bodyKey: "b" },
+      { id: "mid-1", sinceVersion: "1.11.0", titleKey: "t", bodyKey: "b" },
+      { id: "new", sinceVersion: "1.12.0", titleKey: "t", bodyKey: "b" },
+      { id: "mid-2", sinceVersion: "1.11.0", titleKey: "t", bodyKey: "b" },
+    ];
+    expect(computeNewEntries("1.9.0", "1.12.0", c).map((e) => e.id)).toEqual([
+      "new",
+      "mid-1",
+      "mid-2",
+      "old",
+    ]);
+  });
+
   it("real catalog: upgrade from 1.9.0 → 1.10.0 shows the three 1.10.0 seed entries", () => {
     // sinceVersion "1.10.0" <= current "1.10.0" → included (upper-bound is inclusive);
     // later entries (e.g. the 1.15.0 halt-the-herd e-stop) are future-dated → excluded.

--- a/ui/src/lib/feature-gate.ts
+++ b/ui/src/lib/feature-gate.ts
@@ -25,7 +25,9 @@ function cmp(a: [number, number, number], b: [number, number, number]): -1 | 0 |
  * - lastSeenVersion === null (fresh install) → []  (caller seeds baseline)
  * - lastSeenVersion unparseable → []
  * - current <= lastSeen → []
- * - otherwise: entries where sinceVersion > lastSeen (unparseable sinceVersion excluded)
+ * - otherwise: entries where sinceVersion > lastSeen (unparseable sinceVersion excluded),
+ *   ordered newest release first (catalog order within a release) so the What's-New
+ *   drawer leads with the latest changes
  */
 export function computeNewEntries(
   lastSeenVersion: string | null,
@@ -42,9 +44,14 @@ export function computeNewEntries(
 
   if (cmp(current, lastSeen) <= 0) return [];
 
-  return catalog.filter((entry) => {
+  const fresh: { entry: FeatureAnnouncement; since: [number, number, number] }[] = [];
+  for (const entry of catalog) {
     const since = parse(entry.sinceVersion);
-    if (!since) return false;
-    return cmp(since, lastSeen) > 0 && cmp(since, current) <= 0;
-  });
+    if (!since) continue;
+    if (cmp(since, lastSeen) > 0 && cmp(since, current) <= 0) fresh.push({ entry, since });
+  }
+  // The catalog is append-only (oldest first); sort is stable, so entries of the
+  // same release keep their catalog order.
+  fresh.sort((a, b) => cmp(b.since, a.since));
+  return fresh.map((f) => f.entry);
 }


### PR DESCRIPTION
## Summary

Fixes the What's-New drawer sort order (user report: oldest release was on top on mobile) and reworks the drawer layout for small screens (iPhone 14, ~390px), based on a design-system audit.

### Sort order (data bug)
- `computeNewEntries` returned entries in catalog order; the catalog is append-only (oldest first), so the drawer led with the oldest release.
- Now sorted by `sinceVersion` descending (stable — entries within one release keep catalog order). Covered by a new unit test.

### Mobile layout (WhatsNew.svelte)
- **Release groups**: entries are grouped under one sticky release rail (amber version + localized date) instead of repeating the version/date meta line on every entry — follows the `LearningsDrawer` `.ghead` convention and keeps orientation while scrolling.
- **Flat list instead of boxes**: per-entry borders replaced by hairline separators (flat-panel doctrine), reclaiming ~30px of line width on a 390px viewport.
- **Type hierarchy**: 11px release rail (`--fs-meta`) / 16px entry title (`--fs-lg`, the modal section-head rung) / 13px body (`--fs-base`) — previously title and body were both 13px.
- **Mobile ergonomics**: safe-area insets (Dynamic Island / home indicator), ~44px touch targets for the close glyph and the dismiss action on coarse pointers, single scroll container with pinned header/footer.

All colors/sizes remain design-system tokens; no new i18n keys needed (version + date are data, not chrome).

## Verification
- `bun run check` — 0 errors, `bun run test` — 950/950 passed, `check:i18n` — parity ok
- Playwright screenshots at 390×844 (light + dark): newest release on top, sticky rail correct mid-scroll

No feature-catalog entry: `fix` commits, no new user-facing capability.