### PR TITLE
fix(tmp): bound /tmp tmpfs inode use from spawned agents (#560)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,21 @@ tailscale serve --bg 7330        # → https://<host>.<tailnet>.ts.net proxies t
 Add the public hostname to `SHEPHERD_ALLOWED_HOSTS` (the unit ships with the Tailscale name).
 Access control is **tailnet membership** — there is no app-level password.
 
+### Host tuning — tmpfs inodes
+
+Shepherd keeps spawned agents' Node compile cache **off** the `/tmp` tmpfs (it points
+`NODE_COMPILE_CACHE` at a disk dir) and runs an inode-guard sweep on **startup + daily** that
+drops the compile cache and stale per-session scratch once `/tmp` inode use crosses a threshold —
+so a long-lived host doesn't ENOSPC on inodes (with bytes to spare).
+
+The in-app guard bounds Shepherd's _own_ churn; as a host-level belt, raise `/tmp`'s `nr_inodes` in
+`/etc/fstab` on long-uptime hosts (e.g. `tmpfs /tmp tmpfs nr_inodes=4194304 0 0`) so a higher inode
+ceiling protects against any tmpfs consumer.
+
+Override env vars: `SHEPHERD_NODE_COMPILE_CACHE` (compile-cache dir), `SHEPHERD_TMP_INODE_PCT`
+(sweep threshold %, default `80`), `SHEPHERD_TMP_STALE_HOURS` (scratch staleness cutoff, default
+`24`), `SHEPHERD_TMP_SWEEP_DIR` (override the swept tmp root).
+
 ### Live preview
 
 When an agent's dev server is listening in its worktree, a **Preview** badge appears on its herd

--- a/README.md
+++ b/README.md
@@ -210,9 +210,10 @@ Access control is **tailnet membership** — there is no app-level password.
 ### Host tuning — tmpfs inodes
 
 Shepherd keeps spawned agents' Node compile cache **off** the `/tmp` tmpfs (it points
-`NODE_COMPILE_CACHE` at a disk dir) and runs an inode-guard sweep on **startup + daily** that
-drops the compile cache and stale per-session scratch once `/tmp` inode use crosses a threshold —
-so a long-lived host doesn't ENOSPC on inodes (with bytes to spare).
+`NODE_COMPILE_CACHE` at a disk dir) and runs an inode-guard sweep on **startup + daily** that, once
+`/tmp` inode use crosses a threshold, drops the compile cache and stale regenerable tool caches
+(bunx / fallow / agent-browser) — but never a live session's scratch, which is reclaimed on archival
+instead. So a long-lived host doesn't ENOSPC on inodes (with bytes to spare).
 
 The in-app guard bounds Shepherd's _own_ churn; as a host-level belt, raise `/tmp`'s `nr_inodes` in
 `/etc/fstab` on long-uptime hosts (e.g. `tmpfs /tmp tmpfs nr_inodes=4194304 0 0`) so a higher inode

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import { execFileSync } from "./instrument";
 import { config } from "./config";
 import { maintenance } from "./maintenance";
+import { compileCacheDir } from "./tmp-sweep";
 import type { HerdrState, SessionStatus } from "./types";
 
 const execFileAsync = promisify(execFile);
@@ -245,6 +246,12 @@ export class HerdrDriver {
     // finds nothing). The tab already exists, so on ANY failure we must close it —
     // otherwise it lingers forever as an empty husk with no claude in it.
     try {
+      // Wrap argv (always `["claude", …]`) in a coreutils `env` shim that pins the V8
+      // compile cache to a disk-backed dir. `env` execvp's straight into claude (no extra
+      // process layer), so herdr's PTY/agent detection is unaffected — but NODE_COMPILE_CACHE
+      // now lands on disk instead of `$TMPDIR/node-compile-cache` on the tmpfs, where it
+      // accreted unbounded and exhausted inodes (#560).
+      const wrapped = ["env", `NODE_COMPILE_CACHE=${compileCacheDir()}`, ...argv];
       this.runner([
         "agent",
         "start",
@@ -255,7 +262,7 @@ export class HerdrDriver {
         cwd,
         "--no-focus",
         "--",
-        ...argv,
+        ...wrapped,
       ]);
 
       if (rootPaneId) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ import { tailLines } from "./blocked";
 import { CountsService } from "./backlog";
 import { BacklogPoller } from "./backlog-poller";
 import { ProcessReaper } from "./process-reaper";
+import { sweepClaudeTmp, compileCacheDir } from "./tmp-sweep";
 import { PreviewService } from "./preview";
 import { listRepos, listReposPathForReal } from "./repos";
 import { DistillerService, defaultScratch } from "./distiller";
@@ -187,6 +188,29 @@ const accountIndex = new AccountUsageIndex();
 const usageLimits = new UsageLimitsService(accountIndex, store, new HerdrUsageProbe(herdr));
 
 reconcile(store, herdr);
+
+// Ensure the disk-backed compile-cache dir exists so spawns can point NODE_COMPILE_CACHE
+// at it (keeps the V8 compile cache off the /tmp tmpfs).
+try {
+  mkdirSync(compileCacheDir(), { recursive: true });
+} catch (err) {
+  console.warn("[tmp-sweep] could not create compile-cache dir:", err);
+}
+
+// Inode-guard sweep: drops the compile cache + stale scratch once /tmp inode pressure
+// crosses the threshold. Fire-and-forget — sweepClaudeTmp never rejects; runDailySweep is
+// synchronous, so the daily caller must not await it either.
+const fireTmpSweep = (phase: "boot" | "daily") =>
+  void sweepClaudeTmp()
+    .then((r) => {
+      if (r.swept)
+        console.warn(
+          `[tmp-sweep] ${phase}: ${r.reason}, removed ${r.removed} entr${r.removed === 1 ? "y" : "ies"}`,
+        );
+    })
+    .catch((err) => console.warn(`[tmp-sweep] ${phase} sweep failed:`, err));
+
+fireTmpSweep("boot");
 
 // Reap orphaned helper tabs (usage-probe / review husks no live agent backs). The
 // teardown paths close these at the source; this sweep is the safety net for husks
@@ -679,6 +703,7 @@ const runDailySweep = () => {
   // session housekeeping, so they survive an archived task's removal for later usage reports.
   store.pruneReviewerSpawns(Date.now() - REVIEWER_SPAWN_RETENTION_MS);
   for (const repo of listRepos(config.repoRoot)) distiller.consider(repo.path);
+  fireTmpSweep("daily");
 };
 setTimeout(runDailySweep, 10_000); // once shortly after boot
 setInterval(runDailySweep, 24 * 60 * 60 * 1000);

--- a/src/pty-bridge.ts
+++ b/src/pty-bridge.ts
@@ -1,6 +1,7 @@
 import { config } from "./config";
 import { isValidTerminalId } from "./validate";
 import { markPtyEvent } from "./instrument";
+import { compileCacheDir } from "./tmp-sweep";
 
 export interface PtySocket {
   send(data: string | Uint8Array): void;
@@ -27,7 +28,8 @@ export class PtyBridge {
         stdin: "pipe" as const,
         stdout: "pipe" as const,
         stderr: "inherit" as const,
-        env: { ...process.env, HERDR_BIN: config.herdrBin },
+        // Pin the V8 compile cache off the tmpfs (see usage-probe for the shared rationale).
+        env: { ...process.env, HERDR_BIN: config.herdrBin, NODE_COMPILE_CACHE: compileCacheDir() },
         onExit: () => this.ws.close(),
       },
     ) as NodeProc;

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -26,7 +26,7 @@ const dashify = (p: string): string => p.replace(/[/.]/g, "-");
  * The claude tmp root for this user. Read from env at call time so tests and operators
  * can redirect it; falls back to the conventional `<tmpdir>/claude-$uid`.
  */
-export function claudeTmpRoot(): string {
+function claudeTmpRoot(): string {
   return (
     process.env.SHEPHERD_TMP_SWEEP_DIR ??
     process.env.CLAUDE_CODE_TMPDIR ??
@@ -76,6 +76,97 @@ interface SweepOpts {
   log?: (msg: string) => void;
 }
 
+/** Resolved options for one sweep run, threaded through the internal helpers. */
+interface SweepCtx {
+  ops: FsOps;
+  now: number;
+  staleMs: number;
+  nestedName: string;
+  log: (msg: string) => void;
+}
+
+/**
+ * Resolves the fail-open inode gate. Returns the numeric inode use% when readable, or a
+ * string skip-reason when the guard cannot read inode pressure:
+ *  - `"statfs-unavailable"` — `statfs` is not a function, or reports non-finite `files`/`ffree`
+ *    or `files <= 0` (an unusable count).
+ *  - `"root-missing"` — `statfs(root)` throws (root absent / unstatfs-able).
+ */
+async function inodeUsePct(
+  root: string,
+  statfs: FsOps["statfs"],
+  log: (msg: string) => void,
+): Promise<number | string> {
+  // Fail-open: without a usable statfs we cannot read inode pressure, so do nothing.
+  if (typeof statfs !== "function") {
+    log("[tmp-sweep] statfs unavailable — skipping inode guard");
+    return "statfs-unavailable";
+  }
+
+  let stats: Awaited<ReturnType<typeof fsp.statfs>>;
+  try {
+    stats = await statfs(root);
+  } catch {
+    // Root absent / unstatfs-able — nothing to guard.
+    return "root-missing";
+  }
+
+  const files = Number((stats as { files?: unknown }).files);
+  const ffree = Number((stats as { ffree?: unknown }).ffree);
+  if (!Number.isFinite(files) || !Number.isFinite(ffree) || files <= 0) {
+    return "statfs-unavailable";
+  }
+  return (1 - ffree / files) * 100;
+}
+
+/**
+ * Handles ONE directory entry, returning the count removed (0 or 1). Fail-closed per-entry:
+ * its own try/catch surfaces a removal failure in the log and continues, so a bad entry NEVER
+ * aborts the sweep and is never miscounted as success. The three cases:
+ *  - `node-compile-cache` — pure V8 compile cache, dropped wholesale regardless of age.
+ *  - the nested `claude-$uid` root — never wholesale-removed (its children are age-gated when
+ *    it is itself the sweep root); skipped here.
+ *  - anything else — age-gated by the entry's own top-level mtime.
+ */
+async function sweepEntry(dir: string, ent: Dirent, ctx: SweepCtx): Promise<number> {
+  const p = join(dir, ent.name);
+  try {
+    if (ent.name === "node-compile-cache") {
+      await ctx.ops.rm(p, { recursive: true, force: true });
+      return 1;
+    }
+    if (ent.name === ctx.nestedName) return 0;
+
+    const st = await ctx.ops.stat(p);
+    // Deliberately the top-level entry's own mtime, not a recursive
+    // newest-descendant walk — don't "fix" this into a sync/expensive tree traversal.
+    if (ctx.now - st.mtimeMs > ctx.staleMs) {
+      await ctx.ops.rm(p, { recursive: true, force: true });
+      return 1;
+    }
+    return 0;
+  } catch (err) {
+    // Fail-closed per-entry: a removal that fails is surfaced in the log and
+    // skipped — it NEVER aborts the sweep and is never miscounted as success.
+    ctx.log(`[tmp-sweep] failed to remove ${p}: ${String(err)}`);
+    return 0;
+  }
+}
+
+/** Sweep one directory: readdir (skip a missing/unreadable dir) then sum sweepEntry over it. */
+async function sweepDir(dir: string, ctx: SweepCtx): Promise<number> {
+  let entries: Dirent[];
+  try {
+    entries = (await ctx.ops.readdir(dir, { withFileTypes: true })) as Dirent[];
+  } catch {
+    // Missing/unreadable dir (e.g. no nested claude root yet) — skip it.
+    return 0;
+  }
+  let removed = 0;
+  for (const ent of entries) removed += await sweepEntry(dir, ent, ctx);
+  return removed;
+}
+
 /**
  * Threshold-gated inode guard. TOTAL by contract: it NEVER throws or rejects — any
  * unexpected error resolves to `{ swept:false, reason:"error", removed:0 }` after logging,
@@ -104,27 +195,11 @@ export async function sweepClaudeTmp(opts?: SweepOpts): Promise<SweepResult> {
       rm: fsp.rm,
     };
 
-    // Fail-open: without a usable statfs we cannot read inode pressure, so do nothing.
-    if (typeof ops.statfs !== "function") {
-      log("[tmp-sweep] statfs unavailable — skipping inode guard");
-      return { swept: false, reason: "statfs-unavailable", removed: 0 };
+    const usePct = await inodeUsePct(root, ops.statfs, log);
+    if (typeof usePct === "string") {
+      return { swept: false, reason: usePct, removed: 0 };
     }
 
-    let stats: Awaited<ReturnType<typeof fsp.statfs>>;
-    try {
-      stats = await ops.statfs(root);
-    } catch {
-      // Root absent / unstatfs-able — nothing to guard.
-      return { swept: false, reason: "root-missing", removed: 0 };
-    }
-
-    const files = Number((stats as { files?: unknown }).files);
-    const ffree = Number((stats as { ffree?: unknown }).ffree);
-    if (!Number.isFinite(files) || !Number.isFinite(ffree) || files <= 0) {
-      return { swept: false, reason: "statfs-unavailable", removed: 0 };
-    }
-
-    const usePct = (1 - ffree / files) * 100;
     if (usePct < thresholdPct) {
       return {
         swept: false,
@@ -134,44 +209,11 @@ export async function sweepClaudeTmp(opts?: SweepOpts): Promise<SweepResult> {
     }
 
     const nestedName = `claude-${uid()}`;
-    let removed = 0;
+    const ctx: SweepCtx = { ops, now, staleMs, nestedName, log };
     const sweepRoots = [root, join(root, nestedName)];
 
-    for (const dir of sweepRoots) {
-      let entries: Dirent[];
-      try {
-        entries = (await ops.readdir(dir, { withFileTypes: true })) as Dirent[];
-      } catch {
-        // Missing/unreadable dir (e.g. no nested claude root yet) — skip it.
-        continue;
-      }
-      for (const ent of entries) {
-        const p = join(dir, ent.name);
-        try {
-          if (ent.name === "node-compile-cache") {
-            // Pure V8 compile cache — safe to drop wholesale regardless of age.
-            await ops.rm(p, { recursive: true, force: true });
-            removed++;
-          } else if (ent.name === nestedName) {
-            // The nested scratch root: never wholesale-removed; its children are
-            // age-gated when it is itself swept (as the second sweep root).
-            continue;
-          } else {
-            const st = await ops.stat(p);
-            // Deliberately the top-level entry's own mtime, not a recursive
-            // newest-descendant walk — don't "fix" this into a sync/expensive tree traversal.
-            if (now - st.mtimeMs > staleMs) {
-              await ops.rm(p, { recursive: true, force: true });
-              removed++;
-            }
-          }
-        } catch (err) {
-          // Fail-closed per-entry: a removal that fails is surfaced in the log and
-          // skipped — it NEVER aborts the sweep and is never miscounted as success.
-          log(`[tmp-sweep] failed to remove ${p}: ${String(err)}`);
-        }
-      }
-    }
+    let removed = 0;
+    for (const dir of sweepRoots) removed += await sweepDir(dir, ctx);
 
     return {
       swept: true,

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -1,0 +1,202 @@
+import { promises as fsp, type Dirent } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Centralizes the "claude tmp directory" geometry and a threshold-gated inode-guard
+ * sweep. Claude Code points spawned agents at `TMPDIR=/tmp/claude-$uid`; Node's V8
+ * compile cache (`$TMPDIR/node-compile-cache`) and per-session scratch accumulate
+ * unbounded there and exhaust the tmpfs *inodes* (ENOSPC with bytes to spare).
+ *
+ * The proven operator fix is `rm -rf /tmp/claude-$uid/node-compile-cache` (inode use
+ * ~88%→16%); this module automates that plus age-gated scratch cleanup, but only once
+ * inode use crosses a threshold — so a healthy tmpfs is never disturbed.
+ *
+ * The server runs on a single Bun event loop, so EVERYTHING here is async `fs/promises`:
+ * a sync stat/rm on the loop freezes the live web terminal.
+ */
+
+/** Process uid, derived at call time (1000 fallback when getuid is absent, e.g. Windows). */
+const uid = (): number => process.getuid?.() ?? 1000;
+
+/** A worktree cwd → the dash-encoded directory name a nested claude derives for it. */
+const dashify = (p: string): string => p.replace(/[/.]/g, "-");
+
+/**
+ * The claude tmp root for this user. Read from env at call time so tests and operators
+ * can redirect it; falls back to the conventional `<tmpdir>/claude-$uid`.
+ */
+export function claudeTmpRoot(): string {
+  return (
+    process.env.SHEPHERD_TMP_SWEEP_DIR ??
+    process.env.CLAUDE_CODE_TMPDIR ??
+    join(tmpdir(), `claude-${uid()}`)
+  );
+}
+
+/**
+ * Disk-backed compile-cache dir (deliberately OFF tmpfs). Other code sets
+ * `NODE_COMPILE_CACHE` to this on spawns so the cache stops eating tmpfs inodes.
+ */
+export function compileCacheDir(): string {
+  return (
+    process.env.SHEPHERD_NODE_COMPILE_CACHE ??
+    join(homedir(), ".cache", "shepherd", "node-compile-cache")
+  );
+}
+
+/**
+ * The per-session scratch dir a NESTED claude derives for a given worktree cwd:
+ * `<claudeTmpRoot>/claude-$uid/<dashified-worktree-path>`. The doubled `claude-$uid`
+ * is real — our spawned agents inherit TMPDIR and re-derive their own claude root under it.
+ */
+export function worktreeScratchDir(worktreePath: string): string {
+  return join(claudeTmpRoot(), `claude-${uid()}`, dashify(worktreePath));
+}
+
+export interface SweepResult {
+  swept: boolean;
+  reason: string;
+  removed: number;
+}
+
+interface FsOps {
+  statfs: typeof fsp.statfs;
+  readdir: typeof fsp.readdir;
+  stat: typeof fsp.stat;
+  rm: typeof fsp.rm;
+}
+
+interface SweepOpts {
+  root?: string;
+  thresholdPct?: number;
+  staleMs?: number;
+  now?: number;
+  fsOps?: FsOps;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Threshold-gated inode guard. TOTAL by contract: it NEVER throws or rejects — any
+ * unexpected error resolves to `{ swept:false, reason:"error", removed:0 }` after logging,
+ * so a caller can fire-and-forget it on a timer without a guard.
+ *
+ * Only sweeps once inode use ≥ `thresholdPct`; below that it removes NOTHING. When it does
+ * sweep, it walks `root` and the nested `root/claude-$uid`, removing `node-compile-cache`
+ * wholesale (pure cache) and age-gating everything else, but never the nested scratch dir
+ * itself (its children are age-gated when it is the sweep root) and never a root dir itself.
+ * Age-gating is evaluated at stat time: an entry that looks fresh by mtime is kept. This is a
+ * best-effort age check, not a TOCTOU-atomic guarantee — a writer touching an entry between
+ * our stat and rm is not fenced out.
+ */
+export async function sweepClaudeTmp(opts?: SweepOpts): Promise<SweepResult> {
+  const log = opts?.log ?? console.warn;
+  try {
+    const root = opts?.root ?? claudeTmpRoot();
+    const thresholdPct = opts?.thresholdPct ?? (Number(process.env.SHEPHERD_TMP_INODE_PCT) || 80);
+    const staleMs =
+      opts?.staleMs ?? (Number(process.env.SHEPHERD_TMP_STALE_HOURS) || 24) * 3600_000;
+    const now = opts?.now ?? Date.now();
+    const ops: FsOps = opts?.fsOps ?? {
+      statfs: fsp.statfs,
+      readdir: fsp.readdir,
+      stat: fsp.stat,
+      rm: fsp.rm,
+    };
+
+    // Fail-open: without a usable statfs we cannot read inode pressure, so do nothing.
+    if (typeof ops.statfs !== "function") {
+      log("[tmp-sweep] statfs unavailable — skipping inode guard");
+      return { swept: false, reason: "statfs-unavailable", removed: 0 };
+    }
+
+    let stats: Awaited<ReturnType<typeof fsp.statfs>>;
+    try {
+      stats = await ops.statfs(root);
+    } catch {
+      // Root absent / unstatfs-able — nothing to guard.
+      return { swept: false, reason: "root-missing", removed: 0 };
+    }
+
+    const files = Number((stats as { files?: unknown }).files);
+    const ffree = Number((stats as { ffree?: unknown }).ffree);
+    if (!Number.isFinite(files) || !Number.isFinite(ffree) || files <= 0) {
+      return { swept: false, reason: "statfs-unavailable", removed: 0 };
+    }
+
+    const usePct = (1 - ffree / files) * 100;
+    if (usePct < thresholdPct) {
+      return {
+        swept: false,
+        reason: `below-threshold ${usePct.toFixed(1)}%`,
+        removed: 0,
+      };
+    }
+
+    const nestedName = `claude-${uid()}`;
+    let removed = 0;
+    const sweepRoots = [root, join(root, nestedName)];
+
+    for (const dir of sweepRoots) {
+      let entries: Dirent[];
+      try {
+        entries = (await ops.readdir(dir, { withFileTypes: true })) as Dirent[];
+      } catch {
+        // Missing/unreadable dir (e.g. no nested claude root yet) — skip it.
+        continue;
+      }
+      for (const ent of entries) {
+        const p = join(dir, ent.name);
+        try {
+          if (ent.name === "node-compile-cache") {
+            // Pure V8 compile cache — safe to drop wholesale regardless of age.
+            await ops.rm(p, { recursive: true, force: true });
+            removed++;
+          } else if (ent.name === nestedName) {
+            // The nested scratch root: never wholesale-removed; its children are
+            // age-gated when it is itself swept (as the second sweep root).
+            continue;
+          } else {
+            const st = await ops.stat(p);
+            // Deliberately the top-level entry's own mtime, not a recursive
+            // newest-descendant walk — don't "fix" this into a sync/expensive tree traversal.
+            if (now - st.mtimeMs > staleMs) {
+              await ops.rm(p, { recursive: true, force: true });
+              removed++;
+            }
+          }
+        } catch (err) {
+          // Fail-closed per-entry: a removal that fails is surfaced in the log and
+          // skipped — it NEVER aborts the sweep and is never miscounted as success.
+          log(`[tmp-sweep] failed to remove ${p}: ${String(err)}`);
+        }
+      }
+    }
+
+    return {
+      swept: true,
+      reason: `swept ${usePct.toFixed(1)}% inode use`,
+      removed,
+    };
+  } catch (err) {
+    log(`[tmp-sweep] unexpected error: ${String(err)}`);
+    return { swept: false, reason: "error", removed: 0 };
+  }
+}
+
+/**
+ * Best-effort targeted teardown of one worktree's scratch dir (e.g. on session retire).
+ * No-op when absent (`force:true`), swallows every error — never throws.
+ */
+export async function removeWorktreeScratch(
+  worktreePath: string,
+  opts?: { dir?: string; rm?: typeof fsp.rm },
+): Promise<void> {
+  const dir = opts?.dir ?? worktreeScratchDir(worktreePath);
+  const rm = opts?.rm ?? fsp.rm;
+  try {
+    await rm(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -9,8 +9,9 @@ import { join } from "node:path";
  * unbounded there and exhaust the tmpfs *inodes* (ENOSPC with bytes to spare).
  *
  * The proven operator fix is `rm -rf /tmp/claude-$uid/node-compile-cache` (inode use
- * ~88%→16%); this module automates that plus age-gated scratch cleanup, but only once
- * inode use crosses a threshold — so a healthy tmpfs is never disturbed.
+ * ~88%→16%); this module automates that plus age-gated removal of known regenerable tool
+ * caches, but only once inode use crosses a threshold — so a healthy tmpfs is never
+ * disturbed, and a live session's per-session scratch is never wholesale-removed.
  *
  * The server runs on a single Bun event loop, so EVERYTHING here is async `fs/promises`:
  * a sync stat/rm on the loop freezes the live web terminal.
@@ -130,13 +131,26 @@ async function inodeUsePct(
 }
 
 /**
+ * Entry names this sweep is willing to age-gate-remove: regenerable tool caches that hold NO
+ * live session working state (Bun's bunx cache, fallow's audit base cache, agent-browser's
+ * Chrome profiles). Per-session scratch — the dashified `-home-…` worktree dirs and their
+ * session-id subdirs — is deliberately EXCLUDED: a still-running session leaves a stale
+ * TOP-LEVEL mtime because it only writes into subdirs, so a coarse mtime check would let this
+ * best-effort sweep `rm -rf` a live agent's scratch out from under it. Those dirs are reclaimed
+ * precisely by `removeWorktreeScratch` on archival, when the session is known to be finished.
+ */
+const REGENERABLE_CACHE = /^(bunx-|fallow-|agent-browser-)/;
+
+/**
  * Handles ONE directory entry, returning the count removed (0 or 1). Fail-closed per-entry:
  * its own try/catch surfaces a removal failure in the log and continues, so a bad entry NEVER
- * aborts the sweep and is never miscounted as success. The three cases:
+ * aborts the sweep and is never miscounted as success. The cases:
  *  - `node-compile-cache` — pure V8 compile cache, dropped wholesale regardless of age.
- *  - the nested `claude-$uid` root — never wholesale-removed (its children are age-gated when
- *    it is itself the sweep root); skipped here.
- *  - anything else — age-gated by the entry's own top-level mtime.
+ *  - the nested `claude-$uid` root — never wholesale-removed (its children are swept when it is
+ *    itself the sweep root); skipped here.
+ *  - a known regenerable cache (see `REGENERABLE_CACHE`) — age-gated by its top-level mtime.
+ *  - anything else (per-session/unknown scratch) — LEFT in place; never wholesale-removed by
+ *    this sweep (reclaimed via `removeWorktreeScratch` on archival instead).
  */
 async function sweepEntry(dir: string, ent: Dirent, ctx: SweepCtx): Promise<number> {
   const p = join(dir, ent.name);
@@ -146,6 +160,9 @@ async function sweepEntry(dir: string, ent: Dirent, ctx: SweepCtx): Promise<numb
       return 1;
     }
     if (ent.name === ctx.nestedName) return 0;
+    // Only known regenerable caches are eligible for age-gated removal; everything else
+    // (live/orphaned session scratch, unrecognized dirs) is left untouched by the sweep.
+    if (!REGENERABLE_CACHE.test(ent.name)) return 0;
 
     const st = await ctx.ops.stat(p);
     // Deliberately the top-level entry's own mtime, not a recursive
@@ -184,11 +201,12 @@ async function sweepDir(dir: string, ctx: SweepCtx): Promise<number> {
  *
  * Only sweeps once inode use ≥ `thresholdPct`; below that it removes NOTHING. When it does
  * sweep, it walks `root` and the nested `root/claude-$uid`, removing `node-compile-cache`
- * wholesale (pure cache) and age-gating everything else, but never the nested scratch dir
- * itself (its children are age-gated when it is the sweep root) and never a root dir itself.
- * Age-gating is evaluated at stat time: an entry that looks fresh by mtime is kept. This is a
- * best-effort age check, not a TOCTOU-atomic guarantee — a writer touching an entry between
- * our stat and rm is not fenced out.
+ * wholesale (pure cache) and age-gating known regenerable tool caches (see `REGENERABLE_CACHE`),
+ * while LEAVING per-session/unknown scratch in place, the nested scratch dir itself (its
+ * children are swept when it is the sweep root), and every root dir itself. Age-gating is
+ * evaluated at stat time: an entry that looks fresh by mtime is kept. This is a best-effort age
+ * check, not a TOCTOU-atomic guarantee — a writer touching an entry between our stat and rm is
+ * not fenced out.
  */
 export async function sweepClaudeTmp(opts?: SweepOpts): Promise<SweepResult> {
   const log = opts?.log ?? console.warn;

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -23,6 +23,16 @@ const uid = (): number => process.getuid?.() ?? 1000;
 const dashify = (p: string): string => p.replace(/[/.]/g, "-");
 
 /**
+ * Parse a numeric env override, honoring a legitimate `0` (unlike `Number(x) || d`, which
+ * coerces a configured `0` back to the default). Empty/whitespace/non-finite → the fallback.
+ */
+const envNum = (value: string | undefined, fallback: number): number => {
+  if (value === undefined || value.trim() === "") return fallback;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+/**
  * The claude tmp root for this user. Read from env at call time so tests and operators
  * can redirect it; falls back to the conventional `<tmpdir>/claude-$uid`.
  */
@@ -184,9 +194,8 @@ export async function sweepClaudeTmp(opts?: SweepOpts): Promise<SweepResult> {
   const log = opts?.log ?? console.warn;
   try {
     const root = opts?.root ?? claudeTmpRoot();
-    const thresholdPct = opts?.thresholdPct ?? (Number(process.env.SHEPHERD_TMP_INODE_PCT) || 80);
-    const staleMs =
-      opts?.staleMs ?? (Number(process.env.SHEPHERD_TMP_STALE_HOURS) || 24) * 3600_000;
+    const thresholdPct = opts?.thresholdPct ?? envNum(process.env.SHEPHERD_TMP_INODE_PCT, 80);
+    const staleMs = opts?.staleMs ?? envNum(process.env.SHEPHERD_TMP_STALE_HOURS, 24) * 3600_000;
     const now = opts?.now ?? Date.now();
     const ops: FsOps = opts?.fsOps ?? {
       statfs: fsp.statfs,

--- a/src/usage-probe.ts
+++ b/src/usage-probe.ts
@@ -1,6 +1,7 @@
 import type { HerdrDriver } from "./herdr";
 import { parseUsageFrame, type UsageProbe } from "./usage-limits";
 import { config } from "./config";
+import { compileCacheDir } from "./tmp-sweep";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const decoder = new TextDecoder();
@@ -77,7 +78,10 @@ export class HerdrUsageProbe implements UsageProbe {
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe", // must be piped + drained; "ignore" can stall the helper's stdout under Bun
-      env: { ...process.env, HERDR_BIN: config.herdrBin },
+      // Pin the V8 compile cache to disk, off the tmpfs — same rationale as the herdr spawn
+      // shim: these direct `node` helpers otherwise write `node-compile-cache` into TMPDIR and
+      // accrete inodes there until the tmpfs runs dry (#560).
+      env: { ...process.env, HERDR_BIN: config.herdrBin, NODE_COMPILE_CACHE: compileCacheDir() },
     });
 
     let buf = "";

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -5,6 +5,7 @@ import { dirname, join, basename, resolve } from "node:path";
 import { promisify } from "node:util";
 import { timedAsync } from "./instrument";
 import { ensureShepherdExclude } from "./shepherd-exclude";
+import { removeWorktreeScratch } from "./tmp-sweep";
 
 const execFileAsync = promisify(execFile);
 
@@ -240,6 +241,9 @@ export class WorktreeMgr {
         this.pruneMergedBranch(mainRepo, opts.branch, opts.baseBranch);
       }
     }
+    // best-effort reclamation of the nested claude scratch dir for this worktree;
+    // never blocks or fails archival (fire-and-forget, removeWorktreeScratch never throws).
+    void removeWorktreeScratch(worktreePath).catch(() => {});
   }
 
   /** Detached worktree at a specific commit, fetching it from origin first so a

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -1,5 +1,18 @@
-import { test, expect } from "bun:test";
+import { test, expect, beforeEach, afterEach } from "bun:test";
 import { HerdrDriver, mapState, matchAgent, matchAgents, type HerdrAgent } from "../src/herdr";
+
+// Pin compileCacheDir() to a deterministic sentinel so the `env NODE_COMPILE_CACHE=…`
+// shim that start() prepends to every agent argv is assertable.
+const NCC_SENTINEL = "/disk/ncc";
+let prevNcc: string | undefined;
+beforeEach(() => {
+  prevNcc = process.env.SHEPHERD_NODE_COMPILE_CACHE;
+  process.env.SHEPHERD_NODE_COMPILE_CACHE = NCC_SENTINEL;
+});
+afterEach(() => {
+  if (prevNcc === undefined) delete process.env.SHEPHERD_NODE_COMPILE_CACHE;
+  else process.env.SHEPHERD_NODE_COMPILE_CACHE = prevNcc;
+});
 
 const FIXTURE = JSON.stringify({
   result: {
@@ -90,6 +103,8 @@ test("start gives each agent its own full-width tab, not a shared split pane", (
     "/wt/a",
     "--no-focus",
     "--",
+    "env",
+    "NODE_COMPILE_CACHE=/disk/ncc",
     "claude",
     "--dangerously-skip-permissions",
     "go",
@@ -97,6 +112,19 @@ test("start gives each agent its own full-width tab, not a shared split pane", (
   // 3) the leftover shell root pane is closed so the agent is the tab's sole,
   //    full-width pane — a split pane would only get ~window/N width (the bug)
   expect(calls[3]).toEqual(["pane", "close", "p_root"]);
+});
+
+test("start wraps the agent argv in an `env NODE_COMPILE_CACHE=…` shim (off tmpfs, #560)", () => {
+  const calls: string[][] = [];
+  const d = new HerdrDriver((args) => {
+    calls.push(args);
+    return reply(args, WORKSPACE_LIST);
+  });
+  d.start("flatten", "/wt/a", ["claude", "--dangerously-skip-permissions", "go"]);
+  const startCall = calls.find((c) => c[0] === "agent" && c[1] === "start")!;
+  const post = startCall.slice(startCall.indexOf("--") + 1);
+  // env shim is the first three post-`--` tokens, and claude is still argv[0] after it
+  expect(post.slice(0, 3)).toEqual(["env", "NODE_COMPILE_CACHE=/disk/ncc", "claude"]);
 });
 
 test("start bootstraps a 'shepherd' workspace when herdr has none (fresh/restarted daemon)", () => {

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -1,0 +1,300 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { worktreeScratchDir, sweepClaudeTmp, removeWorktreeScratch } from "../src/tmp-sweep";
+
+const uid = (): number => process.getuid?.() ?? 1000;
+const nested = `claude-${uid()}`;
+
+// Track temp dirs + env mutations so each test self-cleans (no cross-test bleed).
+const dirs: string[] = [];
+const savedEnv: Record<string, string | undefined> = {};
+
+function mkTmp(): string {
+  const d = mkdtempSync(join(tmpdir(), "tmp-sweep-test-"));
+  dirs.push(d);
+  return d;
+}
+function setEnv(key: string, val: string | undefined) {
+  if (!(key in savedEnv)) savedEnv[key] = process.env[key];
+  if (val === undefined) delete process.env[key];
+  else process.env[key] = val;
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  for (const k of Object.keys(savedEnv)) delete savedEnv[k];
+});
+
+// Fake statfs reporting a given inode use ratio. files=total inodes, ffree=free.
+function fakeStatfs(files: number, ffree: number) {
+  return async () =>
+    ({ files, ffree }) as unknown as ReturnType<
+      typeof import("node:fs/promises").statfs
+    > extends Promise<infer R>
+      ? R
+      : never;
+}
+
+describe("worktreeScratchDir", () => {
+  test("produces the exact dashified path under the doubled claude root", () => {
+    const root = "/tmp/claude-1000-fake-root";
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", root);
+    const wt = "/home/patrick/Work/.shepherd-worktrees/x-review-0a928a8b";
+    expect(worktreeScratchDir(wt)).toBe(
+      join(root, nested, "-home-patrick-Work--shepherd-worktrees-x-review-0a928a8b"),
+    );
+  });
+});
+
+describe("sweepClaudeTmp", () => {
+  test("below threshold: sweeps nothing, leaves node-compile-cache intact", async () => {
+    const root = mkTmp();
+    const ncc = join(root, "node-compile-cache");
+    mkdirSync(ncc);
+    writeFileSync(join(ncc, "blob.bin"), "x");
+
+    const res = await sweepClaudeTmp({
+      root,
+      fsOps: {
+        statfs: fakeStatfs(1000, 900), // 10% used
+        readdir: () => {
+          throw new Error("readdir should not be called below threshold");
+        },
+        stat: (() => {
+          throw new Error("stat should not be called");
+        }) as never,
+        rm: (() => {
+          throw new Error("rm should not be called");
+        }) as never,
+      } as never,
+      log: () => {},
+    });
+
+    expect(res.swept).toBe(false);
+    expect(res.reason).toContain("below-threshold");
+    expect(res.removed).toBe(0);
+    expect(existsSync(ncc)).toBe(true);
+  });
+
+  test("over threshold: removes node-compile-cache wholesale + stale entries, keeps fresh", async () => {
+    const root = mkTmp();
+    const ncc = join(root, "node-compile-cache");
+    mkdirSync(ncc); // freshly created (recent mtime) yet must still be removed wholesale
+    writeFileSync(join(ncc, "blob.bin"), "x");
+
+    const stale = join(root, "stale-scratch");
+    mkdirSync(stale);
+    const fresh = join(root, "fresh-scratch");
+    mkdirSync(fresh);
+
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000); // 48h ago
+    utimesSync(stale, old, old);
+
+    // Fake statfs forces over-threshold deterministically (real tmpfs use varies).
+    const fsp = await import("node:fs/promises");
+    const res = await sweepClaudeTmp({
+      root,
+      now,
+      fsOps: {
+        statfs: fakeStatfs(1000, 100), // 90% used
+        readdir: fsp.readdir,
+        stat: fsp.stat,
+        rm: fsp.rm,
+      } as never,
+      log: () => {},
+    });
+
+    expect(res.swept).toBe(true);
+    expect(res.reason).toContain("inode use");
+    expect(existsSync(ncc)).toBe(false);
+    expect(existsSync(stale)).toBe(false);
+    expect(existsSync(fresh)).toBe(true);
+    expect(existsSync(root)).toBe(true); // root itself never removed
+    expect(res.removed).toBe(2);
+  });
+
+  test("over threshold via fake statfs removes only stale, keeps fresh", async () => {
+    const root = mkTmp();
+    const ncc = join(root, "node-compile-cache");
+    mkdirSync(ncc);
+    const stale = join(root, "stale");
+    mkdirSync(stale);
+    const fresh = join(root, "fresh");
+    mkdirSync(fresh);
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+    utimesSync(stale, old, old);
+
+    const fsp = await import("node:fs/promises");
+    const res = await sweepClaudeTmp({
+      root,
+      now,
+      fsOps: {
+        statfs: fakeStatfs(1000, 100), // 90% used
+        readdir: fsp.readdir,
+        stat: fsp.stat,
+        rm: fsp.rm,
+      } as never,
+      log: () => {},
+    });
+
+    expect(res.swept).toBe(true);
+    expect(existsSync(ncc)).toBe(false);
+    expect(existsSync(stale)).toBe(false);
+    expect(existsSync(fresh)).toBe(true);
+    expect(existsSync(root)).toBe(true);
+  });
+
+  test("nested claude-$uid dir is not wholesale-removed; its stale child is swept", async () => {
+    const root = mkTmp();
+    const nestedDir = join(root, nested);
+    mkdirSync(nestedDir);
+    // Make the nested dir itself old to prove it is NOT age-gated as a root entry.
+    const now = Date.now();
+    const old = new Date(now - 72 * 3600_000);
+
+    const staleChild = join(nestedDir, "old-session");
+    mkdirSync(staleChild);
+    const freshChild = join(nestedDir, "live-session");
+    mkdirSync(freshChild);
+    utimesSync(staleChild, old, old);
+    utimesSync(nestedDir, old, old);
+
+    const fsp = await import("node:fs/promises");
+    const res = await sweepClaudeTmp({
+      root,
+      now,
+      fsOps: {
+        statfs: fakeStatfs(1000, 50), // 95% used
+        readdir: fsp.readdir,
+        stat: fsp.stat,
+        rm: fsp.rm,
+      } as never,
+      log: () => {},
+    });
+
+    expect(res.swept).toBe(true);
+    expect(existsSync(nestedDir)).toBe(true); // never wholesale-removed
+    expect(existsSync(staleChild)).toBe(false); // swept as the second root
+    expect(existsSync(freshChild)).toBe(true);
+  });
+
+  test("fail-open: statfs not a function → statfs-unavailable, nothing removed", async () => {
+    const root = mkTmp();
+    const ncc = join(root, "node-compile-cache");
+    mkdirSync(ncc);
+    const res = await sweepClaudeTmp({
+      root,
+      fsOps: {
+        statfs: undefined,
+        readdir: (() => {
+          throw new Error("nope");
+        }) as never,
+        stat: (() => {
+          throw new Error("nope");
+        }) as never,
+        rm: (() => {
+          throw new Error("nope");
+        }) as never,
+      } as never,
+      log: () => {},
+    });
+    expect(res).toEqual({
+      swept: false,
+      reason: "statfs-unavailable",
+      removed: 0,
+    });
+    expect(existsSync(ncc)).toBe(true);
+  });
+
+  test("statfs that throws → root-missing", async () => {
+    const root = mkTmp();
+    const res = await sweepClaudeTmp({
+      root,
+      fsOps: {
+        statfs: async () => {
+          throw new Error("ENOENT");
+        },
+        readdir: (() => {}) as never,
+        stat: (() => {}) as never,
+        rm: (() => {}) as never,
+      } as never,
+      log: () => {},
+    });
+    expect(res).toEqual({ swept: false, reason: "root-missing", removed: 0 });
+  });
+
+  test("never rejects: rm always throwing still resolves with swept:true", async () => {
+    const root = mkTmp();
+    mkdirSync(join(root, "node-compile-cache"));
+    mkdirSync(join(root, "old"));
+    const old = new Date(Date.now() - 48 * 3600_000);
+    utimesSync(join(root, "old"), old, old);
+
+    const fsp = await import("node:fs/promises");
+    const res = await sweepClaudeTmp({
+      root,
+      fsOps: {
+        statfs: fakeStatfs(1000, 50),
+        readdir: fsp.readdir,
+        stat: fsp.stat,
+        rm: async () => {
+          throw new Error("EACCES");
+        },
+      } as never,
+      log: () => {},
+    });
+    expect(res.swept).toBe(true); // resolved, not rejected
+  });
+
+  test("statfs reporting non-finite files → statfs-unavailable", async () => {
+    const root = mkTmp();
+    const res = await sweepClaudeTmp({
+      root,
+      fsOps: {
+        statfs: async () => ({ files: NaN, ffree: 10 }) as never,
+        readdir: (() => {}) as never,
+        stat: (() => {}) as never,
+        rm: (() => {}) as never,
+      } as never,
+      log: () => {},
+    });
+    expect(res).toEqual({
+      swept: false,
+      reason: "statfs-unavailable",
+      removed: 0,
+    });
+  });
+});
+
+describe("removeWorktreeScratch", () => {
+  test("removes an existing target dir", async () => {
+    const dir = mkTmp();
+    expect(existsSync(dir)).toBe(true);
+    await removeWorktreeScratch("/whatever", { dir });
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  test("no-op (no throw) when the dir is absent", async () => {
+    const dir = join(tmpdir(), "tmp-sweep-absent-" + Math.random());
+    await expect(removeWorktreeScratch("/whatever", { dir })).resolves.toBeUndefined();
+  });
+
+  test("swallows a throwing rm (resolves)", async () => {
+    await expect(
+      removeWorktreeScratch("/whatever", {
+        dir: "/x",
+        rm: async () => {
+          throw new Error("EACCES");
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -16,10 +16,9 @@ function mkTmp(): string {
   dirs.push(d);
   return d;
 }
-function setEnv(key: string, val: string | undefined) {
+function setEnv(key: string, val: string) {
   if (!(key in savedEnv)) savedEnv[key] = process.env[key];
-  if (val === undefined) delete process.env[key];
-  else process.env[key] = val;
+  process.env[key] = val;
 }
 
 afterEach(() => {

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -82,6 +82,31 @@ describe("sweepClaudeTmp", () => {
     expect(existsSync(ncc)).toBe(true);
   });
 
+  test("honors a configured 0 threshold (not coerced to the default 80)", async () => {
+    // SHEPHERD_TMP_INODE_PCT=0 means "always sweep". With the old `Number(x)||80`
+    // parse this 0 was silently coerced back to 80, so a 10%-used fs would NOT sweep.
+    setEnv("SHEPHERD_TMP_INODE_PCT", "0");
+    const root = mkTmp();
+    const ncc = join(root, "node-compile-cache");
+    mkdirSync(ncc);
+    writeFileSync(join(ncc, "blob.bin"), "x");
+
+    const fsp = await import("node:fs/promises");
+    const res = await sweepClaudeTmp({
+      root,
+      fsOps: {
+        statfs: fakeStatfs(1000, 900), // 10% used — below the default 80, at/over 0
+        readdir: fsp.readdir,
+        stat: fsp.stat,
+        rm: fsp.rm,
+      } as never,
+      log: () => {},
+    });
+
+    expect(res.swept).toBe(true);
+    expect(existsSync(ncc)).toBe(false); // dropped because threshold 0 was honored
+  });
+
   test("over threshold: removes node-compile-cache wholesale + stale entries, keeps fresh", async () => {
     const root = mkTmp();
     const ncc = join(root, "node-compile-cache");

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -106,20 +106,25 @@ describe("sweepClaudeTmp", () => {
     expect(existsSync(ncc)).toBe(false); // dropped because threshold 0 was honored
   });
 
-  test("over threshold: removes node-compile-cache wholesale + stale entries, keeps fresh", async () => {
+  test("over threshold: node-compile-cache wholesale + stale caches removed, fresh caches + session scratch kept", async () => {
     const root = mkTmp();
     const ncc = join(root, "node-compile-cache");
     mkdirSync(ncc); // freshly created (recent mtime) yet must still be removed wholesale
     writeFileSync(join(ncc, "blob.bin"), "x");
 
-    const stale = join(root, "stale-scratch");
-    mkdirSync(stale);
-    const fresh = join(root, "fresh-scratch");
-    mkdirSync(fresh);
+    const staleCache = join(root, "bunx-1000-typescript"); // known regenerable cache, stale → removed
+    mkdirSync(staleCache);
+    const freshCache = join(root, "fallow-audit-base-cache-abc"); // known cache, fresh → kept
+    mkdirSync(freshCache);
+    // A still-active session's scratch: NOT a cache name, stale top-level mtime → must be KEPT
+    // (only `removeWorktreeScratch` on archival may reclaim it, never this sweep).
+    const sessionScratch = join(root, "-home-patrick-Work--shepherd-worktrees-x-review-0a928a8b");
+    mkdirSync(sessionScratch);
 
     const now = Date.now();
     const old = new Date(now - 48 * 3600_000); // 48h ago
-    utimesSync(stale, old, old);
+    utimesSync(staleCache, old, old);
+    utimesSync(sessionScratch, old, old);
 
     // Fake statfs forces over-threshold deterministically (real tmpfs use varies).
     const fsp = await import("node:fs/promises");
@@ -137,31 +142,30 @@ describe("sweepClaudeTmp", () => {
 
     expect(res.swept).toBe(true);
     expect(res.reason).toContain("inode use");
-    expect(existsSync(ncc)).toBe(false);
-    expect(existsSync(stale)).toBe(false);
-    expect(existsSync(fresh)).toBe(true);
+    expect(existsSync(ncc)).toBe(false); // wholesale
+    expect(existsSync(staleCache)).toBe(false); // known cache, stale → removed
+    expect(existsSync(freshCache)).toBe(true); // known cache, fresh → kept
+    expect(existsSync(sessionScratch)).toBe(true); // non-cache scratch → kept despite being stale
     expect(existsSync(root)).toBe(true); // root itself never removed
-    expect(res.removed).toBe(2);
+    expect(res.removed).toBe(2); // ncc + staleCache only
   });
 
-  test("over threshold via fake statfs removes only stale, keeps fresh", async () => {
+  test("over threshold: a stale NON-cache (session) scratch dir is left in place", async () => {
     const root = mkTmp();
-    const ncc = join(root, "node-compile-cache");
-    mkdirSync(ncc);
-    const stale = join(root, "stale");
-    mkdirSync(stale);
-    const fresh = join(root, "fresh");
-    mkdirSync(fresh);
+    // Mimics a live long-running session whose top-level mtime is stale (writes go to subdirs).
+    const sessionScratch = join(root, "-home-fake-session");
+    mkdirSync(sessionScratch);
+    mkdirSync(join(sessionScratch, "1778cf88-session-id")); // in-use subdir
     const now = Date.now();
-    const old = new Date(now - 48 * 3600_000);
-    utimesSync(stale, old, old);
+    const old = new Date(now - 72 * 3600_000);
+    utimesSync(sessionScratch, old, old);
 
     const fsp = await import("node:fs/promises");
     const res = await sweepClaudeTmp({
       root,
       now,
       fsOps: {
-        statfs: fakeStatfs(1000, 100), // 90% used
+        statfs: fakeStatfs(1000, 50), // 95% used
         readdir: fsp.readdir,
         stat: fsp.stat,
         rm: fsp.rm,
@@ -170,10 +174,8 @@ describe("sweepClaudeTmp", () => {
     });
 
     expect(res.swept).toBe(true);
-    expect(existsSync(ncc)).toBe(false);
-    expect(existsSync(stale)).toBe(false);
-    expect(existsSync(fresh)).toBe(true);
-    expect(existsSync(root)).toBe(true);
+    expect(res.removed).toBe(0); // nothing eligible — session scratch is not a known cache
+    expect(existsSync(sessionScratch)).toBe(true);
   });
 
   test("nested claude-$uid dir is not wholesale-removed; its stale child is swept", async () => {
@@ -184,11 +186,14 @@ describe("sweepClaudeTmp", () => {
     const now = Date.now();
     const old = new Date(now - 72 * 3600_000);
 
-    const staleChild = join(nestedDir, "old-session");
-    mkdirSync(staleChild);
-    const freshChild = join(nestedDir, "live-session");
+    const staleCacheChild = join(nestedDir, "bunx-1000-old"); // known cache, stale → swept
+    mkdirSync(staleCacheChild);
+    const freshChild = join(nestedDir, "bunx-1000-live"); // known cache, fresh → kept
     mkdirSync(freshChild);
-    utimesSync(staleChild, old, old);
+    const staleSessionChild = join(nestedDir, "-home-old-worktree"); // session scratch, stale → kept
+    mkdirSync(staleSessionChild);
+    utimesSync(staleCacheChild, old, old);
+    utimesSync(staleSessionChild, old, old);
     utimesSync(nestedDir, old, old);
 
     const fsp = await import("node:fs/promises");
@@ -206,8 +211,9 @@ describe("sweepClaudeTmp", () => {
 
     expect(res.swept).toBe(true);
     expect(existsSync(nestedDir)).toBe(true); // never wholesale-removed
-    expect(existsSync(staleChild)).toBe(false); // swept as the second root
+    expect(existsSync(staleCacheChild)).toBe(false); // known cache swept as the second root
     expect(existsSync(freshChild)).toBe(true);
+    expect(existsSync(staleSessionChild)).toBe(true); // session scratch preserved even when stale
   });
 
   test("fail-open: statfs not a function → statfs-unavailable, nothing removed", async () => {


### PR DESCRIPTION
Closes #560.

## Problem

Long-uptime hosts hit intermittent `ENOSPC: no space left on device` in spawned-agent tool calls **with free bytes** — the `/tmp` tmpfs ran out of **inodes** (observed 88%, 915k/1.05M). Root: Claude Code pins `TMPDIR=/tmp/claude-$uid`, so Node's V8 compile cache (`$TMPDIR/node-compile-cache`, ~74% of inodes) and per-session scratch accumulate unbounded across Shepherd's high spawn volume, cleared only on reboot.

> **Root-cause correction:** the issue attributed `TMPDIR`/`CLAUDE_CODE_TMPDIR` to Shepherd. It's actually set by **Claude Code itself** — Shepherd's code and systemd unit set no `TMPDIR`. Spawned agents inherit the **herdr daemon's** env (Shepherd doesn't launch it, and `herdr agent start` has no `--env` flag), which shaped the fix below.

## Fix

**Prevention (primary) — pin the compile cache off tmpfs.** Every spawn sets `NODE_COMPILE_CACHE` to a disk-backed dir (`~/.cache/shepherd/node-compile-cache`):
- All claude agents funnel through `HerdrDriver.start()` → prepend a coreutils `env NODE_COMPILE_CACHE=… ` exec shim (`env` execvp's into `claude`, so argv[0] stays `claude` and herdr PTY/agent detection is unaffected). `src/herdr.ts`
- The two direct-`node` `Bun.spawn` helpers (usage-probe, pty-bridge) inject the same key into their env map. `src/usage-probe.ts`, `src/pty-bridge.ts`

**Backstop — inode-guard sweep.** `src/tmp-sweep.ts`: a TOTAL (never-rejects), fully-async (`fs/promises`, single-loop-safe) sweep that, once `/tmp` inode use ≥ threshold (default 80%), drops `node-compile-cache` wholesale and age-stale (>24h) scratch — automating the proven operator workaround. Fail-open if `statfs` is unavailable. Wired fire-and-forget into boot + the daily-sweep timer (`src/index.ts`).

**Targeted — per-session cleanup.** `WorktreeMgr.remove()` fire-and-forgets `removeWorktreeScratch()` to reclaim a worktree's nested claude scratch on archive (stays sync `: void`). `src/worktree.ts`

**Host belt (doc).** `README.md`: raise `/tmp` `nr_inodes` in fstab + override env vars (`SHEPHERD_NODE_COMPILE_CACHE`, `SHEPHERD_TMP_INODE_PCT`, `SHEPHERD_TMP_STALE_HOURS`, `SHEPHERD_TMP_SWEEP_DIR`).

## Testing

- `bun run lint` ✅ · `bunx tsc --noEmit` ✅ · `bun test ./test` ✅ 1969 pass / 1 skip / 0 fail · `bunx fallow audit --base origin/main --fail-on-issues` ✅
- New `test/tmp-sweep.test.ts` (12 tests): threshold gate, wholesale cache drop, age-gating, nested-dir protection, both fail-open paths, never-rejects. Updated `test/herdr.test.ts` asserts the wrapped argv keeps `claude` as argv[0].
- `NODE_COMPILE_CACHE` redirect mechanism verified against live Node; spawn-path coverage traced (all herdr spawns + both direct-node helpers).

> **Recommended pre-merge smoke** (needs the live herdr/claude, not runnable in CI): after `bun run update`, spawn one agent and confirm `herdr agent list` shows non-`unknown` status + it accepts input (no detection regression from the `env` shim), and that `~/.cache/shepherd/node-compile-cache` populates while `/tmp/claude-$uid/node-compile-cache` stops growing.

Server-only, no user-facing UI → no i18n / feature-catalog entry (`[no-feature-entry]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)