### PR TITLE
refactor(ui): set automation pill apart + drop redundant autopilot ON pip

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -483,7 +483,6 @@
   "viewport_git_actions_state_clear": "bereit zum Mergen",
   "viewport_git_actions_title_state": "PR, Merge, Kritiker & Merge-Freigabe ({state})",
   "viewport_git_actions_aria_state": "PR- und Merge-Aktionen ein-/ausblenden ({state})",
-  "viewport_autopilot_pip": "AP",
   "viewport_fold_aria": "Kopfbereich einklappen: Tabs und PR-Aktionen ausblenden für mehr Terminal-Platz",
   "viewport_unfold_aria": "Kopfbereich ausklappen: Tabs und PR-Aktionen anzeigen",
   "diff_refresh": "Diff aktualisieren",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -483,7 +483,6 @@
   "viewport_git_actions_state_clear": "ready to merge",
   "viewport_git_actions_title_state": "PR, merge, critic & ready-to-merge actions ({state})",
   "viewport_git_actions_aria_state": "Toggle PR and merge actions ({state})",
-  "viewport_autopilot_pip": "AP",
   "viewport_fold_aria": "Collapse header: hide tabs and PR actions for more terminal space",
   "viewport_unfold_aria": "Expand header: show tabs and PR actions",
   "diff_refresh": "Refresh diff",

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -418,28 +418,6 @@
         <span class="merged">{m.gitrail_closed()}</span>
       {/if}
 
-      {#if repoPath}
-        <button
-          class={["gbtn", "auto-pill", { reviewing: pillReviewing, armed: showAutomation }]}
-          type="button"
-          aria-haspopup="dialog"
-          aria-expanded={showAutomation}
-          aria-busy={pillReviewing}
-          aria-label={pillReviewing
-            ? m.automation_pill_reviewing_aria()
-            : m.automation_pill_aria({ count: autoCount, total: AUTOMATION_TOTAL })}
-          use:coachTarget={"critic"}
-          use:coachTarget={"auto-address"}
-          use:coachTarget={"learnings"}
-          onclick={toggleAutomation}
-        >
-          ⚙ {m.automation_pill_label()}
-          <span class="auto-count" class:on={autoCount > 0}>{autoCount}/{AUTOMATION_TOTAL}</span>
-          {#if automationHasUnseen}<span class="new-dot" aria-hidden="true"></span><span
-              class="sr-only">{m.newdot_aria()}</span
-            >{/if}
-        </button>
-      {/if}
       {#if showReady && (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
         <ReadyToggle {sessionId} {ready} {mobile} />
       {/if}
@@ -472,6 +450,30 @@
           onclick={toggleReview}
         >
           {chip.label}
+        </button>
+      {/if}
+
+      {#if repoPath}
+        <span class="rail-sep" aria-hidden="true"></span>
+        <button
+          class={["gbtn", "auto-pill", { reviewing: pillReviewing, armed: showAutomation }]}
+          type="button"
+          aria-haspopup="dialog"
+          aria-expanded={showAutomation}
+          aria-busy={pillReviewing}
+          aria-label={pillReviewing
+            ? m.automation_pill_reviewing_aria()
+            : m.automation_pill_aria({ count: autoCount, total: AUTOMATION_TOTAL })}
+          use:coachTarget={"critic"}
+          use:coachTarget={"auto-address"}
+          use:coachTarget={"learnings"}
+          onclick={toggleAutomation}
+        >
+          ⚙ {m.automation_pill_label()}
+          <span class="auto-count" class:on={autoCount > 0}>{autoCount}/{AUTOMATION_TOTAL}</span>
+          {#if automationHasUnseen}<span class="new-dot" aria-hidden="true"></span><span
+              class="sr-only">{m.newdot_aria()}</span
+            >{/if}
         </button>
       {/if}
 
@@ -604,6 +606,13 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
+  }
+
+  .rail-sep {
+    width: 1px;
+    background: var(--color-line);
+    flex-shrink: 0;
+    align-self: stretch;
   }
 
   .gbtn {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1915,25 +1915,16 @@
         <span class="gt-label">{m.viewport_git_actions()}</span>
         <span class="gt-caret" aria-hidden="true">{gitOpen ? "▴" : "▾"}</span>
       </button>
-      <!-- passive at-rest pips: the READY / AUTOPILOT *controls* moved into the
-           git strip (one disclosure away), but their ON state must stay readable
-           at a glance — a quiet pill each, only when on, never interactive. The
-           autopilot pip yields to AutopilotBadge when paused/complete (those
-           states already imply autopilot, so two amber pills would be noise). -->
+      <!-- passive at-rest pip: the READY control lives in the git strip; its ON
+           state stays glance-able here. Autopilot's ON state is surfaced solely
+           by the Automation pill in GitRail; paused/complete states still appear
+           via AutopilotBadge below. -->
       {#if session.readyToMerge}
         <span
           class="state-pip ready"
           role="img"
           aria-label={m.gitrail_ready_on_title()}
           title={m.gitrail_ready_on_title()}>✓</span
-        >
-      {/if}
-      {#if autopilotEffective && !session.autopilotPaused && !session.autopilotComplete}
-        <span
-          class="state-pip auto"
-          role="img"
-          aria-label={m.session_autopilot_on_label()}
-          title={m.session_autopilot_on_label()}>{m.viewport_autopilot_pip()}</span
         >
       {/if}
       <!-- REVIEWING (in-flight critic, surfaced in the GitRail/auto-pill) outranks the
@@ -2653,10 +2644,6 @@
   .state-pip.ready {
     color: var(--color-green);
     border-color: color-mix(in srgb, var(--color-green) 55%, transparent);
-  }
-  .state-pip.auto {
-    color: var(--color-amber);
-    border-color: color-mix(in srgb, var(--color-amber) 55%, transparent);
   }
 
   /* per-session autopilot toggle (git strip): matches .git-toggle sizing */


### PR DESCRIPTION
## Why

Two small, related top-bar chrome cleanups around automation/autopilot.

**1. Automation pill sat among per-PR controls.** In `GitRail`, the repo-wide ⚙ Automation pill rendered *between* Merge and Ready/Reviewed — a different class of control (repo config) wedged into the per-PR action flow.

**2. Autopilot's ON state was shown twice.** The session header carried a passive "AUTOPILOT" on-pip duplicating what the Automation pill already reports.

## What

- **GitRail:** moved the Automation pill to the end of the rail, behind a thin vertical divider (`.rail-sep`, `var(--color-line)`, `align-self: stretch`). All per-PR controls (PR · CI · Merge · Ready · Verdict) now group together, then `│`, then the pill. Placed after the verdict chip and before the transient err/retry so the grouping holds in every state.
- **Viewport header:** removed the redundant passive AUTOPILOT on-pip (+ its `.state-pip.auto` CSS and the orphaned `viewport_autopilot_pip` i18n key, dropped from both EN and DE). Autopilot's ON state now lives solely in the Automation pill.

### Deliberately kept (not redundant)
- **NEEDS YOU / DELIVERED** `AutopilotBadge` (header + cards) — the attention/outcome signal the pill does not surface.
- The per-**session** git-strip autopilot toggle (`.ap-toggle`) and the panel's repo-**default** toggle — distinct-scope controls.
- The READY pip.

## Notes
- Layout/redundancy cleanup, not a new feature → `refactor(ui)`, no `feature-announcements.ts` entry.
- The desktop bounds test (`GitRail.browser.test.ts`) was pre-verified empirically: tightest cell has ~205px of slack vs the divider's ~7px footprint.

## Verification
- `cd ui && bun run check` — 0 errors / 0 warnings
- `cd ui && bun run check:i18n` — locales in parity (1006 keys each)
- `cd ui && bun run test` — 1027 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)