### PR TITLE
fix(hud): tighten HUD against its own design system (3 critique fixes)

### DIFF
--- a/ui/src/lib/components/HeartbeatStrip.svelte
+++ b/ui/src/lib/components/HeartbeatStrip.svelte
@@ -30,10 +30,10 @@
 </span>
 
 <style>
-  /* 24 equal cells; intensity via opacity on currentColor, so it follows the
-     theme's running-status hue (--status-running, amber in Shepherd) — same
-     colour the StatusPip and the prior Heartbeat dot used. No motion — the
-     StatusPip already pulses (matches the prior Heartbeat.svelte decision). */
+  /* 24 equal cells; amber (--status-running) for live/recent signal (level ≥ 2
+     and .now); low-activity cells (level 0–1) render neutral faint ink so idle
+     strips read grey, not orange — amber is reserved for genuine "alive" signal.
+     No motion — StatusPip already pulses (matches prior Heartbeat.svelte decision). */
   .strip {
     display: inline-flex;
     align-items: stretch;
@@ -42,27 +42,35 @@
     max-width: 40vw;
     height: 12px;
     flex: none;
-    color: var(--status-running);
   }
   .cell {
     flex: 1 1 0;
     border-radius: 1px;
     background: currentColor;
+    /* faint neutral track by default; live cells (level ≥ 2 / now) re-set amber below */
+    color: var(--color-faint);
     opacity: 0.12; /* level 0 = faint empty track */
   }
   .cell[data-level="1"] {
+    color: var(--color-faint);
     opacity: 0.35;
   }
+  /* level ≥ 2 is genuine activity — restore amber over the faint base so the
+     live signal still glows while the empty track + trickle stay grey. */
   .cell[data-level="2"] {
+    color: var(--status-running);
     opacity: 0.6;
   }
   .cell[data-level="3"] {
+    color: var(--status-running);
     opacity: 0.82;
   }
   .cell[data-level="4"] {
+    color: var(--status-running);
     opacity: 1;
   }
   .cell.now {
+    color: var(--status-running);
     opacity: 1;
   }
   /* an errored slice (always level ≥ 1) renders red instead of amber. A

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -245,6 +245,12 @@
   .bc-label {
     margin-left: 6px;
   }
+  .chip-emoji {
+    /* operator-set emoji are useful identifiers but full-saturation colour leaks
+       outside the controlled palette on the always-present steer bar — desaturate
+       modestly so glyphs stay recognizable while the ground stays quiet (Quiet-Ground rule) */
+    filter: saturate(0.6);
+  }
   .chip-emoji + .chip-label {
     margin-left: 6px;
   }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -3623,18 +3623,22 @@
     border-color: var(--color-red);
     color: var(--color-red);
   }
-  /* Enter — the single affirmative "do it" key, the only filled accent in the
-     row so it reads as the primary action */
+  /* Enter — primary affirmative action. Amber outline-ghost (transparent fill,
+     amber border + text, inset amber glow) per the design-system primary recipe.
+     Four-Light Rule: green is reserved for READY agent state; primary buttons
+     are never solid-filled — always outline + inset glow. Mirrors EmptyHerd .spawn. */
   .ctrl-row .enter {
     font-family: var(--font-mono);
     font-size: var(--fs-xl);
-    color: var(--color-green);
-    border-color: color-mix(in srgb, var(--color-green) 60%, var(--color-line-bright));
-    background: color-mix(in srgb, var(--color-green) 18%, var(--color-inset));
+    color: var(--color-amber);
+    border-color: var(--color-amber);
+    background: transparent;
+    box-shadow: inset 0 0 18px -10px var(--color-amber);
   }
   .ctrl-row .enter:active {
-    background: color-mix(in srgb, var(--color-green) 34%, var(--color-inset));
-    border-color: var(--color-green);
+    background: var(--color-hover);
+    border-color: var(--color-amber);
+    box-shadow: inset 0 0 22px -10px var(--color-amber);
   }
   /* "add notes" affordance — only mounted while Claude's prompt offers it. Amber
      (the same attention hue as the running pip) plus a soft halo pulse so it's


### PR DESCRIPTION
## Why

`/impeccable critique HUD UI` (register: product) scored the HUD **33/40** and a clean deterministic scan (zero anti-patterns) — it is a disciplined terminal instrument, not AI slop. The actionable findings were all places where the HUD quietly **breaks Shepherd's own design system**. This PR fixes the three that hold up under verification.

## What changed

1. **Mobile Enter key → amber outline-ghost primary** (`Viewport.svelte`). `.ctrl-row .enter` was filled green — a double violation: green is reserved for the READY agent state (Four-Light Rule), and primary buttons are never solid-filled. Re-skinned to the canonical amber-outline + `inset 0 0 18px -10px` glow recipe (mirrors `EmptyHerd .spawn`). Stale "only filled accent" comment updated.
2. **Quiet the heartbeat "orange wall"** (`HeartbeatStrip.svelte`). Every cell was amber; stacked across 4+ busy agents the strips became the dominant chroma mass, straining the Quiet-Ground (≤10% chroma at rest) rule exactly when the operator needs a calm baseline for a new alarm to pop. Low cells (level 0-1) now render neutral faint ink; **amber is reserved for live cells** (level ≥ 2 + `now`); errored cells stay red. Removed the now-dead `.strip` color and fixed a stale "green" comment.
3. **Desaturate steer-chip emoji** (`SteerBar.svelte`). Operator-configured emoji punched full-spectrum colour on the always-present steer bar (a 🟢 sitting near the genuine READY green). `filter: saturate(0.6)` keeps glyphs recognizable while taming the chroma. Paint-only, no reflow, emoji already `aria-hidden`.

## Two critique findings deliberately NOT acted on (verified false/handled)

- **"Broadcast fires with no confirm" (was P2).** False positive. `BroadcastDialog.svelte` already implements a target-selection modal with a **two-step arm→confirm** ("mirrors the decommission/merge confirm so no fat-finger blasts the herd"), count-bearing confirm labels, re-arm on any change, and a reach toast. The critique traced the `onbroadcast` callback name but not its handler. Adding another confirm would be redundant dead code.
- **"Mobile header control density" (was P3).** Already extensively engineered: a `vp-fold` button collapses tabs + PR rail + build queue, REDRAW/decommission collapse to icon-only on compact, lifecycle controls move to a separate `vp-git-strip`, and decommission is arm-guarded (`✕` → `✕?`). The critique judged the unfolded state. A refactor here would be speculative regression risk on a deliberately-tuned component for an already-handled P3.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings.
- `SteerBar.browser.test.ts` + `Herd.browser.test.ts` → 20/20 pass.
- CSS cascade reviewed (esp. heartbeat: `.err` stays last so errored cells stay red; level 2/3/4/`now` re-set amber over the faint base).
- No new user-facing strings (no i18n keys); all `fix(...)` commits (feature-catalog gate not armed); linear branch off latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)