### PR TITLE
feat(steerbar): Edit-steers pencil fills the slot when ABC is hidden

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -626,6 +626,7 @@
   "steerbar_labels_show": "Beschriftungen anzeigen",
   "steerbar_labels_hide": "Nur Symbole anzeigen",
   "steerbar_labels_aria": "ABC: {action}",
+  "steerbar_edit": "Steers bearbeiten",
   "steerseditor_title": "Gespeicherte Steers",
   "steerseditor_label_placeholder": "Bezeichnung",
   "steerseditor_text_placeholder": "Prompt-Text",
@@ -1016,5 +1017,7 @@
   "feat_redraw_menu_title": "Terminal-Neuzeichnen-Menü",
   "feat_redraw_menu_body": "Terminal-Verlauf gestaucht, nachdem die Session auf einem schmaleren Gerät offen war? Der neue ↔ Neu-zeichnen-Button im Session-Header bietet vier Reparatur-Varianten zum Ausprobieren, vom sanften Resize-Impuls bis zum vollen claude --resume-Re-Render.",
   "feat_backlog_repo_search_title": "Backlog-Repoliste durchsuchen",
-  "feat_backlog_repo_search_body": "Tippe in das neue Filtereingabefeld oben in der Backlog-Repoliste, um Repos nach Name einzuschränken; kombinierbar mit den Chips Hat Issues und Hat PRs."
+  "feat_backlog_repo_search_body": "Tippe in das neue Filtereingabefeld oben in der Backlog-Repoliste, um Repos nach Name einzuschränken; kombinierbar mit den Chips Hat Issues und Hat PRs.",
+  "feat_steerbar_edit_title": "Steers aus der Leiste bearbeiten",
+  "feat_steerbar_edit_body": "Wenn die Steer-Leiste nicht überfüllt ist, sitzt am rechten Rand eine Stift-Schaltfläche — tippe sie an, um direkt zum Steers-Editor zu springen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -626,6 +626,7 @@
   "steerbar_labels_show": "Show button labels",
   "steerbar_labels_hide": "Show icons only",
   "steerbar_labels_aria": "ABC: {action}",
+  "steerbar_edit": "Edit steers",
   "steerseditor_title": "Saved Steers",
   "steerseditor_label_placeholder": "label",
   "steerseditor_text_placeholder": "prompt text",
@@ -1016,5 +1017,7 @@
   "feat_redraw_menu_title": "Terminal redraw menu",
   "feat_redraw_menu_body": "Terminal history squished after viewing a session from a narrower device? The new ↔ Redraw button in the session header offers four repair variants to try, from a gentle resize nudge to a full claude --resume re-render.",
   "feat_backlog_repo_search_title": "Search the backlog repo list",
-  "feat_backlog_repo_search_body": "Type in the new filter input at the top of the backlog repo list to narrow repos by name; combines with the Has issues / Has PRs chips."
+  "feat_backlog_repo_search_body": "Type in the new filter input at the top of the backlog repo list to narrow repos by name; combines with the Has issues / Has PRs chips.",
+  "feat_steerbar_edit_title": "Edit steers from the bar",
+  "feat_steerbar_edit_body": "When the steer bar isn't crowded, a pencil button sits at its right edge — tap it to jump straight into the steers editor."
 }

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, untrack } from "svelte";
   import {
     getSettings,
     putSettings,
@@ -52,7 +52,6 @@
     { id: "device", label: m.settings_tab_device },
   ] as const;
   type TabId = (typeof TABS)[number]["id"];
-  let tab = $state<TabId>("workspace");
   let tabEls: HTMLButtonElement[] = [];
 
   function onTabKey(e: KeyboardEvent, i: number) {
@@ -75,6 +74,7 @@
     herdrUpdate = null,
     onherdrupdate,
     onwhatsnew,
+    initialTab = "workspace",
   }: {
     onclose?: () => void;
     onsaved?: (root: string) => void;
@@ -82,7 +82,19 @@
     herdrUpdate?: HerdrUpdateStatus | null;
     onherdrupdate?: () => void;
     onwhatsnew?: () => void;
+    initialTab?: TabId;
   } = $props();
+
+  // initialTab seeds the starting tab; the user then freely switches it, so we
+  // only ever read the prop once (untrack silences the initial-value warning).
+  let tab = $state<TabId>(untrack(() => initialTab));
+  let steersEl = $state<HTMLDivElement | null>(null);
+
+  onMount(() => {
+    if (initialTab === "session") {
+      requestAnimationFrame(() => steersEl?.scrollIntoView({ behavior: "auto", block: "start" }));
+    }
+  });
 
   // On a phone the HERDR badge folds into the gear; its update flow lands here.
   const herdrUpdateAvailable = $derived(!!herdrUpdate && herdrUpdate.updateAvailable);
@@ -542,7 +554,7 @@
           <p class="premium-warn">{m.settings_default_model_premium_warning()}</p>
         {/if}
       </div>
-      <SteersEditor />
+      <div bind:this={steersEl}><SteersEditor /></div>
     </div>
 
     <div

--- a/ui/src/lib/components/SteerBar.browser.test.ts
+++ b/ui/src/lib/components/SteerBar.browser.test.ts
@@ -136,3 +136,85 @@ describe("ABC visibility gating", () => {
     expect(getComputedStyle(bcLabel).display, "⌁ label collapsed on mobile").toBe("none");
   });
 });
+
+describe("SteerBar edit-steers button", () => {
+  afterEach(async () => {
+    await page.viewport(1280, 900); // restore a sane width for other suites
+  });
+
+  it("renders the pencil edit button, outside the measured bar, with an accessible name", async () => {
+    await page.viewport(1000, 900);
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    await tick();
+    await frames();
+
+    const editBtn = document.querySelector(".edit-steers") as HTMLElement;
+    expect(editBtn, "edit-steers button rendered").not.toBeNull();
+    expect(editBtn.textContent).toContain("✎");
+    expect(editBtn.getAttribute("title")?.trim()).toBeTruthy();
+    expect(editBtn.getAttribute("aria-label")?.trim()).toBeTruthy();
+    expect(editBtn.getAttribute("title")).toBe(editBtn.getAttribute("aria-label"));
+    // Lives OUTSIDE the measured/scrolling .steer-bar so it can't poison fitLabels.
+    expect(document.querySelector(".steer-bar")!.contains(editBtn)).toBe(false);
+  });
+
+  it("clicking it fires onedit", async () => {
+    await page.viewport(1000, 900);
+    const onedit = vi.fn();
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {}, onedit });
+    await tick();
+    await frames();
+
+    const editBtn = document.querySelector(".edit-steers") as HTMLElement;
+    editBtn.dispatchEvent(new PointerEvent("pointerdown", { pointerId: 1, bubbles: true }));
+    editBtn.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1, bubbles: true }));
+    await tick();
+
+    expect(onedit).toHaveBeenCalledOnce();
+  });
+
+  it("desktop fits → edit shown, ABC hidden", async () => {
+    await page.viewport(1000, 900);
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    await tick();
+    await frames();
+
+    const editBtn = document.querySelector(".edit-steers") as HTMLElement;
+    const abc = document.querySelector(".lbl-toggle") as HTMLElement;
+    expect(getComputedStyle(editBtn).display, "edit shown on wide non-compact bar").not.toBe(
+      "none",
+    );
+    expect(getComputedStyle(abc).display, "ABC hidden on wide non-compact bar").toBe("none");
+  });
+
+  it("compact overflow (>768px) → edit hidden, ABC shown", async () => {
+    await page.viewport(800, 900);
+    steers.list = Array.from({ length: 24 }, (_, i) =>
+      steer({
+        id: String(i + 1),
+        label: `Long Steering Label Number ${i + 1}`,
+        emoji: "🚀",
+      }),
+    );
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    await tick();
+    await frames(4); // 24-chip layout takes longer to settle than the 2-frame default
+
+    const editBtn = document.querySelector(".edit-steers") as HTMLElement;
+    const abc = document.querySelector(".lbl-toggle") as HTMLElement;
+    expect(getComputedStyle(editBtn).display, "edit hidden when compact").toBe("none");
+    expect(getComputedStyle(abc).display, "ABC revealed when compact").not.toBe("none");
+  });
+
+  it("mobile (≤768px) → edit hidden, ABC shown", async () => {
+    await page.viewport(400, 900);
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    await tick();
+    await frames();
+
+    const editBtn = document.querySelector(".edit-steers") as HTMLElement;
+    const abc = document.querySelector(".lbl-toggle") as HTMLElement;
+    expect(getComputedStyle(editBtn).display, "edit hidden on mobile").toBe("none");
+    expect(getComputedStyle(abc).display, "ABC revealed by mobile rule").not.toBe("none");
+  });
+});

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -209,9 +209,11 @@
 </div>
 
 <style>
-  /* Row = scrolling chip bar (flex:1) + the ABC toggle at the right (shown only when a
-     label is collapsed / on mobile; display:none on a desktop bar where everything fits).
-     Background + top border live here so they span the full width including the toggle. */
+  /* Row = scrolling chip bar (flex:1) + a right-hand slot holding exactly one of two
+     complementary buttons: the ABC toggle (when a label is collapsed / on mobile) or the
+     Edit-steers pencil (on a desktop bar where everything fits). Both are sized identically
+     so the slot's width is constant whichever shows. Background + top border live here so
+     they span the full width including that slot. */
   .steer-row {
     display: flex;
     align-items: stretch;

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -5,7 +5,11 @@
   import { fitLabels } from "$lib/fit-labels";
   import { m } from "$lib/paraglide/messages";
 
-  let { focusedId, onbroadcast }: { focusedId: string; onbroadcast: () => void } = $props();
+  let {
+    focusedId,
+    onbroadcast,
+    onedit,
+  }: { focusedId: string; onbroadcast: () => void; onedit?: () => void } = $props();
 
   // Only steer-bar-scoped entries render here; issue-scoped ones live on backlog rows.
   const chips = $derived(steers.list.filter((s) => s.inSteerBar));
@@ -118,12 +122,15 @@
     >
   </div>
 {/if}
-<!-- The ABC labels toggle lives OUTSIDE the scrolling/measured .steer-bar (as its
-     right-hand flex sibling) so its box never enters fitLabels' scrollWidth
-     measurement — an in-flow auto-margin would make scrollWidth == clientWidth and
-     poison the cached full-label width. It's shown only when there's actually a
-     collapsed label to reveal: when the bar collapses (`compact`) or on mobile
-     (≤768px); hidden on a desktop bar where everything fits. -->
+<!-- The right-hand slot lives OUTSIDE the scrolling/measured .steer-bar (its flex
+     siblings) so neither button enters fitLabels' scrollWidth measurement — an
+     in-flow auto-margin would make scrollWidth == clientWidth and poison the cached
+     full-label width. The slot holds EITHER the ABC labels toggle (when a label is
+     collapsed: bar `compact` or mobile ≤768px) OR the Edit-steers pencil (desktop bar
+     where everything fits). They're complementary — exactly one shows, never both —
+     and dimensionally identical so the reserved slot width is constant on desktop
+     (swapping equal-width buttons never changes .steer-bar's clientWidth, so fitLabels
+     can't oscillate). -->
 <div class="steer-row" data-swipe-ignore>
   <!-- fitLabels toggles `compact` when the full labels overflow: chips that carry an
        emoji collapse to emoji-only (label stays in title/aria); the rest keep their
@@ -182,6 +189,22 @@
     onpointermove={move}
     onpointercancel={cancel}
     onpointerup={(e) => tap(e, toggleLabels)}>ABC</button
+  >
+  <!-- Edit-steers pencil: fills the same right slot when the ABC toggle is hidden
+       (desktop bar where everything fits). Pencil-only glyph; the title/aria-label
+       carry "Edit steers" (WCAG: a visible label would be a glyph, so the name lives
+       in the attributes). Follows .lbl-toggle in source so the `.steer-bar.compact ~`
+       general-sibling reveal/hide rules can reach it. Same tap-vs-drag wiring. -->
+  <button
+    type="button"
+    class="chip edit-steers"
+    title={m.steerbar_edit()}
+    aria-label={m.steerbar_edit()}
+    data-swipe-ignore
+    onpointerdown={down}
+    onpointermove={move}
+    onpointercancel={cancel}
+    onpointerup={(e) => tap(e, () => onedit?.())}>✎</button
   >
 </div>
 
@@ -291,6 +314,25 @@
   .steer-bar:global(.compact) ~ .lbl-toggle {
     display: inline-flex;
   }
+  /* Edit-steers: fills the right slot on a desktop bar where everything fits (the
+     ABC toggle's complement). Same box as .lbl-toggle so the reserved right slot is
+     the same width whichever button shows — fitLabels never sees the channel width
+     change, so no compaction oscillation. Pencil-only; the title/aria-label carry
+     "Edit steers". Hidden whenever ABC takes the slot: on overflow (.compact) and on
+     mobile (≤768px). */
+  .edit-steers {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-self: center;
+    margin: 6px 10px;
+    min-width: 44px;
+    padding: 0;
+    font-size: var(--fs-base);
+    color: var(--color-muted);
+  }
+  .steer-bar:global(.compact) ~ .edit-steers {
+    display: none;
+  }
   .lbl-toggle[aria-pressed="true"] {
     color: var(--color-ink-bright);
     border-color: var(--color-ink);
@@ -324,6 +366,9 @@
     }
     .lbl-toggle {
       display: inline-flex;
+    }
+    .edit-steers {
+      display: none;
     }
   }
   /* one-time steer hint: flat, square, hairline-bordered, muted ink — sits

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -67,6 +67,7 @@
     onnextneedsyou,
     nextNeedsYou = 0,
     onbroadcast,
+    onedit,
     mobile = false,
     touch = false,
     queue = [],
@@ -94,6 +95,7 @@
     /** How many *other* sessions are waiting on the operator; gates the button. */
     nextNeedsYou?: number;
     onbroadcast?: () => void;
+    onedit?: () => void;
     mobile?: boolean;
     touch?: boolean;
     // ordered ids of sessions currently waiting on the operator ("needs you"),
@@ -2269,7 +2271,11 @@
   </div>
 
   {#if tab === "term"}
-    <SteerBar focusedId={session.id} onbroadcast={() => onbroadcast?.()} />
+    <SteerBar
+      focusedId={session.id}
+      onbroadcast={() => onbroadcast?.()}
+      onedit={() => onedit?.()}
+    />
   {/if}
 
   <!-- control-key bar: any touch device (incl. unfolded foldables wider than the

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -571,4 +571,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_title_rename_title",
     bodyKey: "feat_title_rename_body",
   },
+  {
+    // No targetId: the pencil only mounts on the steer bar (focused-session view) and
+    // only when the bar isn't crowded — on mobile/overflow the ABC toggle takes the
+    // slot — so a coachmark anchor would often be absent. Surface via the What's-New
+    // drawer only. 1.26.0 is already released, so this ships in 1.27.0.
+    id: "steerbar-edit",
+    sinceVersion: "1.27.0",
+    titleKey: "feat_steerbar_edit_title",
+    bodyKey: "feat_steerbar_edit_body",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -130,6 +130,7 @@
   }
   let showNew = $state(false);
   let showSettings = $state(false);
+  let settingsTab = $state<"workspace" | "session" | "device">("workspace");
   let showClone = $state(false);
   let showNewProject = $state(false);
   let showBroadcast = $state(false);
@@ -1018,7 +1019,10 @@
         mobile={mobile.current}
         touch={touch.current}
         limits={store.usageLimits}
-        onsettings={() => (showSettings = true)}
+        onsettings={() => {
+          settingsTab = "workspace";
+          showSettings = true;
+        }}
         onhalt={haltHerd}
         needsYou={blockedEntries.length}
         ontriage={() => (showTriage = true)}
@@ -1070,7 +1074,10 @@
             {onclearmerged}
             {onmergetrain}
             {issueActionsUnset}
-            onsettings={() => (showSettings = true)}
+            onsettings={() => {
+              settingsTab = "workspace";
+              showSettings = true;
+            }}
             flow={true}
             bind:filter={herdFilter}
             workingBlocked={store.workingBlocked}
@@ -1119,6 +1126,10 @@
             nextNeedsYou={otherNeedsYou.length}
             onnextneedsyou={jumpNextNeedsYou}
             onbroadcast={() => (showBroadcast = true)}
+            onedit={() => {
+              settingsTab = "session";
+              showSettings = true;
+            }}
           />
         </div>
       {/if}
@@ -1139,7 +1150,10 @@
           }}
           onnew={() => (showNew = true)}
           {issueActionsUnset}
-          onsettings={() => (showSettings = true)}
+          onsettings={() => {
+            settingsTab = "workspace";
+            showSettings = true;
+          }}
           workingBlocked={store.workingBlocked}
         />
       </div>
@@ -1176,7 +1190,10 @@
             {onclearmerged}
             {onmergetrain}
             {issueActionsUnset}
-            onsettings={() => (showSettings = true)}
+            onsettings={() => {
+              settingsTab = "workspace";
+              showSettings = true;
+            }}
             bind:filter={herdFilter}
             workingBlocked={store.workingBlocked}
             collapsible={canCollapse}
@@ -1214,6 +1231,10 @@
             {onarchive}
             workingBlocked={store.workingBlocked}
             onbroadcast={() => (showBroadcast = true)}
+            onedit={() => {
+              settingsTab = "session";
+              showSettings = true;
+            }}
           />
         {:else}
           <div class="empty">{m.main_no_unit_selected()}</div>
@@ -1365,6 +1386,7 @@
 
 {#if showSettings}
   <Settings
+    initialTab={settingsTab}
     onclose={() => {
       showSettings = false;
       loadSettings();


### PR DESCRIPTION
## What

When the steer bar's right-hand **"ABC"** labels-toggle is *not* shown — i.e. on a **desktop bar that fits** (ABC only appears on overflow or mobile ≤768px) — that same right-hand slot now holds an **"Edit Steers"** pencil button (`✎`, tooltip only). Clicking it opens the Settings modal pre-selected to the **Session** tab and scrolls the steers editor (the last of six sections) into view, dropping the operator straight into editing their steers.

On mobile / when the bar overflows, the ABC toggle keeps the slot and the pencil is absent — the two are mutually exclusive. The editor stays reachable via the gear → Session everywhere else.

## How

- **`SteerBar.svelte`** — new optional `onedit` prop + `.edit-steers` button as a flex sibling of the scrolling bar (same tap-vs-drag wiring as the chips/ABC). CSS sizes it **identically** to `.lbl-toggle` (same `min-width`/`padding`/`margin`) with **inverse visibility**: shown by default, hidden on `.compact` overflow and on mobile. Equal box widths keep the reserved right slot a constant footprint on desktop, so `fitLabels` (which measures the bar) never oscillates.
- **`Viewport.svelte`** — forwards `onedit` to `SteerBar`, mirroring `onbroadcast`.
- **`+page.svelte`** — new `settingsTab` state set at every Settings open site (gear → `workspace`, pencil → `session`); passed as `initialTab` to `<Settings>`. Set-at-open (not reset-on-close) so no close path can leak a stale tab.
- **`Settings.svelte`** — new `initialTab` prop seeds the active tab; when it's `session`, the SteersEditor is scrolled into view on mount (one rAF deferral).
- **i18n** — `steerbar_edit` + the What's-New `feat_steerbar_edit_title`/`body` keys added to EN + DE.
- **Feature catalog** — `steerbar-edit` entry (`sinceVersion 1.27.0`), drawer-only (the pencil is often unmounted on mobile/overflow, so no coachmark anchor).

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings; `bun run test` → 1034 passing (incl. 5 new SteerBar tests covering render/a11y, click-fires-`onedit`, and inverse visibility across desktop-fits / compact-overflow / mobile).
- `check:i18n` (locale parity), `check-feature-catalog.sh`, `check-branch-hygiene.sh`, and `fallow audit` (dead code 0, complexity 0) all green.
- **Live UI** (vite proxy → running server): on a wide bar the pencil shows (ABC hidden, both 44px); clicking it opens Settings on the Session tab with the editor scrolled into view and the backdrop dimmed. Narrowing to overflow swaps the pencil out for ABC (`compact`, scroll fallback intact, no clipping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)