### PR TITLE
feat(viewport): rename session by double-tapping the header title

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -558,6 +558,7 @@
   "viewport_decommission": "✕ stilllegen",
   "viewport_decommission_aria": "Einheit stilllegen",
   "viewport_rename_aria": "Task umbenennen",
+  "viewport_title_enter_renames": "Enter zum Umbenennen",
   "viewport_rename_placeholder": "Neuer Name",
   "viewport_rename_failed": "Umbenennen fehlgeschlagen",
   "viewport_rename_name_taken": "Name bereits vergeben",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -826,6 +826,8 @@
   "feat_pr_kind_badges_body": "Die Backlog-Repo-Liste zeigt jetzt deine echte Anzahl an Code-PRs, mit eigenen Badges für Dependabot- und release-please-PRs, damit automatisierte PRs nicht wie offene Arbeit aussehen. Auch der PRs-Tab kennzeichnet jeden PR nach Art.",
   "feat_relaunch_title": "Aufgabe neu starten",
   "feat_relaunch_body": "Rechtsklick (oder langes Tippen) auf eine Karte und „Neu starten“ wählen, um eine frische Aufgabe mit demselben Prompt und den aktuellen Einstellungen zu starten – inklusive Modell, Repo, Basis-Branch und Plan-Gate – und das Original anschließend stillzulegen. Der Ersatz beginnt von vorn: Bei aktivem Plan-Gate plant er neu, und eine Aufgabe aus dem Drain wird zu einer betreuten Aufgabe, die auf deine Freigabe wartet.",
+  "feat_title_rename_title": "Doppeltipp auf den Titel zum Umbenennen",
+  "feat_title_rename_body": "Doppeltipp (oder Doppelklick) auf den Sessionnamen in der Kopfzeile öffnet das Umbenennen direkt an Ort und Stelle – kein Suchen mehr nach dem kleinen ✎-Knopf. Ein einfacher Tipp zeigt weiterhin Modellprofil und Token-Verbrauch.",
   "feat_readiness_title": "KI-Reife-Analyse",
   "feat_readiness_body": "Die Backlog-Seite hat einen neuen Reife-Tab: Er bewertet die Leitplanken eines Repos anhand von Shepherds dogfooded Baseline, empfiehlt das Tooling, das das meiste Hin und Her zwischen Mensch und KI beseitigt, und generiert eine maßgeschneiderte CLAUDE.md, die du direkt an eine Aufgabe senden kannst.",
   "automerge_state_merging": "Wird gemergt…",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -826,6 +826,8 @@
   "feat_pr_kind_badges_body": "The backlog repo list now shows your real code-PR count, with separate badges for Dependabot and release-please PRs so automated PRs don't look like pending work. The PRs tab tags each PR by kind too.",
   "feat_relaunch_title": "Relaunch a task",
   "feat_relaunch_body": "Right-click (or long-press) any card and choose Relaunch to spawn a fresh task with the same prompt and current settings (model, repo, base branch and plan-gate included) then decommission the original. The replacement starts fresh: with plan-gate on it re-plans, and a task that came from the drain becomes an attended task awaiting your Approve.",
+  "feat_title_rename_title": "Double-tap the title to rename",
+  "feat_title_rename_body": "Double-tap (or double-click) the session name in the header to rename it right there — no need to hunt for the little ✎ button. A single tap still shows the model profile and token usage.",
   "feat_readiness_title": "AI-readiness analyzer",
   "feat_readiness_body": "The Backlog page has a new Readiness tab: it scores a repo's guardrails against Shepherd's dogfooded baseline, prescribes the tooling that removes the most human↔AI back-and-forth, and generates a tailored CLAUDE.md you can send straight to a task.",
   "automerge_state_merging": "Merging…",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -558,6 +558,7 @@
   "viewport_decommission": "✕ decommission",
   "viewport_decommission_aria": "decommission unit",
   "viewport_rename_aria": "Rename task",
+  "viewport_title_enter_renames": "press Enter to rename",
   "viewport_rename_placeholder": "New name",
   "viewport_rename_failed": "Rename failed",
   "viewport_rename_name_taken": "Name already in use",

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -607,7 +607,7 @@
     }
   }
   function onTitleKey(e: KeyboardEvent) {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       void startRename();
     }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -591,10 +591,15 @@
   // Hand-rolled click timing instead of ondblclick so touch and mouse behave
   // identically (iOS Safari fires dblclick unreliably) — the first tap keeps
   // its existing job (meta popover via focus), the second one renames.
+  // The timestamp is deliberately shared across the title elements (desig +
+  // vp-name co-render on compact desktops): both carry the same session
+  // identity side by side, so a double-tap straddling them still reads as
+  // "double-tap the title" and should rename.
   let lastTitleTap = 0;
   function onTitleTap() {
     const now = Date.now();
-    if (now - lastTitleTap < 400) {
+    // 500ms matches the common OS double-click default (400 dropped slow double-clicks)
+    if (now - lastTitleTap < 500) {
       lastTitleTap = 0;
       void startRename();
     } else {
@@ -1727,7 +1732,7 @@
           class="ctx-trigger"
           role="button"
           tabindex="0"
-          aria-label={m.topbar_detail_context_aria({ repo: repoName, name: session.name })}
+          aria-label={`${m.topbar_detail_context_aria({ repo: repoName, name: session.name })} — ${m.viewport_title_enter_renames()}`}
           onclick={onTitleTap}
           onkeydown={onTitleKey}
         >
@@ -1750,7 +1755,7 @@
           class="desig"
           role="button"
           tabindex="0"
-          aria-label={m.viewport_meta_aria()}
+          aria-label={`${m.viewport_meta_aria()} — ${m.viewport_title_enter_renames()}`}
           onclick={onTitleTap}
           onkeydown={onTitleKey}>{session.desig}</span
         >
@@ -1758,16 +1763,11 @@
       </span>
       {#if compact}
         <!-- foldable/touch desktop only: surfaces the full name the desig can't carry.
-             tabindex -1: double-tap target only — the adjacent desig already carries
-             the keyboard path, a second tab stop on the same identity would be noise -->
-        <span
-          class="vp-name"
-          title={session.name}
-          role="button"
-          tabindex="-1"
-          onclick={onTitleTap}
-          onkeydown={onTitleKey}>{session.name}</span
-        >
+             Pointer-only rename target — the adjacent desig owns the keyboard/AT path
+             (a button role here would announce a second, redundant control for the
+             same identity), so no role/tabindex/keydown by design. -->
+        <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+        <span class="vp-name" title={session.name} onclick={onTitleTap}>{session.name}</span>
       {/if}
     {/if}
     {#if !compact}

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -533,7 +533,7 @@
     leftovers = found;
   }
 
-  // ── rename: one click opens an inline editor; Enter/blur commits, Esc cancels ──
+  // ── rename: ✎ click or title double-tap opens an inline editor; Enter/blur commits, Esc cancels ──
   let renaming = $state(false);
   let renameDraft = $state("");
   let renameError = $state<string | null>(null);
@@ -585,6 +585,26 @@
     } else if (e.key === "Escape") {
       e.preventDefault();
       cancelRename();
+    }
+  }
+  // Double-tap / double-click on the session title also opens the editor.
+  // Hand-rolled click timing instead of ondblclick so touch and mouse behave
+  // identically (iOS Safari fires dblclick unreliably) — the first tap keeps
+  // its existing job (meta popover via focus), the second one renames.
+  let lastTitleTap = 0;
+  function onTitleTap() {
+    const now = Date.now();
+    if (now - lastTitleTap < 400) {
+      lastTitleTap = 0;
+      void startRename();
+    } else {
+      lastTitleTap = now;
+    }
+  }
+  function onTitleKey(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      void startRename();
     }
   }
 
@@ -1708,6 +1728,8 @@
           role="button"
           tabindex="0"
           aria-label={m.topbar_detail_context_aria({ repo: repoName, name: session.name })}
+          onclick={onTitleTap}
+          onkeydown={onTitleKey}
         >
           {#if !repoIcon}
             <span class="ctx-glyph" aria-hidden="true">▣</span>
@@ -1724,14 +1746,28 @@
       <!-- TASK-XX: hover/focus reveals the secondary meta (profile + token usage)
            that used to sit inline in the header, reclaiming horizontal space -->
       <span class="desig-wrap">
-        <span class="desig" role="button" tabindex="0" aria-label={m.viewport_meta_aria()}
-          >{session.desig}</span
+        <span
+          class="desig"
+          role="button"
+          tabindex="0"
+          aria-label={m.viewport_meta_aria()}
+          onclick={onTitleTap}
+          onkeydown={onTitleKey}>{session.desig}</span
         >
         {@render metaPop()}
       </span>
       {#if compact}
-        <!-- foldable/touch desktop only: surfaces the full name the desig can't carry -->
-        <span class="vp-name" title={session.name}>{session.name}</span>
+        <!-- foldable/touch desktop only: surfaces the full name the desig can't carry.
+             tabindex -1: double-tap target only — the adjacent desig already carries
+             the keyboard path, a second tab stop on the same identity would be noise -->
+        <span
+          class="vp-name"
+          title={session.name}
+          role="button"
+          tabindex="-1"
+          onclick={onTitleTap}
+          onkeydown={onTitleKey}>{session.name}</span
+        >
       {/if}
     {/if}
     {#if !compact}
@@ -2441,6 +2477,10 @@
     flex-shrink: 0;
     cursor: default;
     border-bottom: 1px dotted var(--color-line);
+    /* double-tap renames: no double-tap zoom, no text-selection flash on dblclick */
+    touch-action: manipulation;
+    -webkit-user-select: none;
+    user-select: none;
   }
   .desig-wrap:hover .desig {
     color: var(--color-ink);
@@ -2493,6 +2533,10 @@
   .vp-name {
     color: var(--color-ink);
     font-size: var(--fs-base);
+    /* double-tap renames: no double-tap zoom, no text-selection flash on dblclick */
+    touch-action: manipulation;
+    -webkit-user-select: none;
+    user-select: none;
     /* flex-basis 0 (not auto) so the name's content width doesn't drive the
        wrap calc on mobile — otherwise a long name reserves the whole row and
        pushes the decommission button onto the next line. It absorbs the slack
@@ -2686,6 +2730,10 @@
     gap: 6px;
     min-width: 0;
     cursor: default;
+    /* double-tap renames: no double-tap zoom, no text-selection flash on dblclick */
+    touch-action: manipulation;
+    -webkit-user-select: none;
+    user-select: none;
   }
   .ctx-glyph {
     color: var(--color-amber);

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -560,4 +560,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_relaunch_title",
     bodyKey: "feat_relaunch_body",
   },
+  {
+    // No targetId: only the automation-pill coachmarks are armed (PILL_FEATURE_IDS
+    // in GitRail.svelte), so an anchor on the header title would never fire —
+    // surface via the What's-New drawer only. v1.26.0 is already released, so this
+    // ships in the next release (1.27.0): computeNewEntries only surfaces entries
+    // with sinceVersion > lastSeen.
+    id: "title-rename-shortcut",
+    sinceVersion: "1.27.0",
+    titleKey: "feat_title_rename_title",
+    bodyKey: "feat_title_rename_body",
+  },
 ];


### PR DESCRIPTION
## Was

Die Session lässt sich jetzt per **Doppeltipp / Doppelklick direkt auf den Titel** in der Kopfzeile umbenennen — statt nur über den kleinen, unscheinbaren ✎-Button.

- **Phone:** Doppeltipp auf den Sessionnamen (`.ctx-trigger`) öffnet den Inline-Editor. Ein einfacher Tipp zeigt weiterhin das Profil/Token-Popover (deshalb Doppeltipp, nicht Einfachtipp).
- **Desktop:** Doppelklick auf den TASK-XX-Chip (`.desig`); auf compact/touch-Desktops auch auf den vollen Namen (`.vp-name`).
- **Tastatur:** Enter auf dem fokussierten Titel öffnet den Editor ebenfalls.
- Der ✎-Button bleibt als sichtbare, beschriftete Affordance erhalten (Discoverability + Screenreader).

## Wie

- Handgerollte Click-Timing-Erkennung (400 ms) statt `ondblclick`, damit Touch und Maus identisch funktionieren (iOS Safari feuert `dblclick` unzuverlässig).
- `touch-action: manipulation` + `user-select: none` auf den Titel-Elementen — kein Doppeltipp-Zoom, kein Text-Selektions-Flackern beim Doppelklick.
- Feature-Katalog-Eintrag `title-rename-shortcut` (1.27.0, drawer-only) + EN/DE-Keys.

## Verifiziert

- `bun run check` — 0 Fehler / 0 Warnungen
- `bun run check:i18n` — 2 Locales in Parität (1009 Keys)
- `bun run test` — 1029 Tests, alle grün