### PR TITLE
fix(backlog): two-row repo filter bar so "Filter repos…" stops truncating

### DIFF
--- a/ui/src/lib/components/ProjectBacklogList.svelte
+++ b/ui/src/lib/components/ProjectBacklogList.svelte
@@ -41,6 +41,7 @@
 
 <div class="filter-bar">
   <div class="filter-search-wrap">
+    <span class="filter-search-icon" aria-hidden="true">⌕</span>
     <input
       class="filter-search"
       type="text"
@@ -67,24 +68,26 @@
       >
     {/if}
   </div>
-  <button
-    class="filter-chip"
-    class:active={hasIssues}
-    type="button"
-    aria-pressed={hasIssues}
-    onclick={ontoggleissues}
-  >
-    {m.backlog_filter_has_issues()}
-  </button>
-  <button
-    class="filter-chip"
-    class:active={hasPRs}
-    type="button"
-    aria-pressed={hasPRs}
-    onclick={ontoggleprs}
-  >
-    {m.backlog_filter_has_prs()}
-  </button>
+  <div class="filter-chips">
+    <button
+      class="filter-chip"
+      class:active={hasIssues}
+      type="button"
+      aria-pressed={hasIssues}
+      onclick={ontoggleissues}
+    >
+      {m.backlog_filter_has_issues()}
+    </button>
+    <button
+      class="filter-chip"
+      class:active={hasPRs}
+      type="button"
+      aria-pressed={hasPRs}
+      onclick={ontoggleprs}
+    >
+      {m.backlog_filter_has_prs()}
+    </button>
+  </div>
 </div>
 
 <!-- The parent only renders this list when there are forge repos, so an empty
@@ -126,7 +129,8 @@
     top: 0;
     z-index: 1;
     display: flex;
-    gap: 2px;
+    flex-direction: column;
+    gap: 4px;
     padding: 4px 4px 6px;
     margin-bottom: 2px;
     background: var(--color-inset);
@@ -150,10 +154,21 @@
     font-family: var(--font-mono);
     font-size: var(--fs-meta);
     letter-spacing: 0.04em;
-    padding: 0 28px 0 10px;
+    padding: 0 28px 0 26px;
     min-height: 36px;
     outline: none;
     transition: border-color 0.12s;
+  }
+
+  .filter-search-icon {
+    position: absolute;
+    left: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    pointer-events: none;
   }
 
   .filter-search::placeholder {
@@ -183,6 +198,11 @@
 
   .filter-search-clear:hover {
     color: var(--color-ink);
+  }
+
+  .filter-chips {
+    display: flex;
+    gap: 2px;
   }
 
   .filter-chip {

--- a/ui/src/lib/components/ProjectBacklogList.svelte
+++ b/ui/src/lib/components/ProjectBacklogList.svelte
@@ -139,8 +139,6 @@
 
   .filter-search-wrap {
     position: relative;
-    flex: 1;
-    min-width: 0;
     display: flex;
     align-items: center;
   }


### PR DESCRIPTION
## Problem

The Backlog repo filter rendered its placeholder **"Filter repos…" clipped to "Filter re"** — even on desktop. Root cause: `.filter-bar` was a single flex **row** holding the `flex:1` search input plus both filter chips ("Has issues" / "Has PRs"). In the narrow Backlog sidebar the input only got the leftover width, so the placeholder truncated. Nothing signalled it was a typeahead either.

## Change

Split `.filter-bar` into **two rows** (entirely within `ProjectBacklogList.svelte`):

- **Row 1** — full-width search input with a leading **`⌕`** glyph (the codebase's existing search glyph — see `src/lib/activity.ts`, `AutomationPanel.svelte`). Placeholder can no longer be clipped at any panel width; the magnifier makes its purpose obvious.
- **Row 2** — the unchanged "Has issues" / "Has PRs" chips, left-aligned.

Before → after:

| | |
|---|---|
| `Filter re   Has issues  Has PRs` (one cramped row) | `⌕ Filter repos…` / `Has issues  Has PRs` (two rows) |

## Notes

- Tokens-only (`--color-muted`, `--fs-meta`, `--font-mono`); reuses the existing `.filter-search` / `.filter-chip` recipes — no new component, no off-token literals.
- No i18n changes — reuses existing keys; glyph is `aria-hidden` + `pointer-events: none`.
- Preserves all behavior: clear `×` while searching, `Escape`-clears, `oninput`/`aria-label`, chip `aria-pressed`/active states.
- UX polish to the already-shipped type-to-filter feature → `fix(...)`, no feature-announcement entry (`[no-feature-entry]` not needed; the `fix:` subject keeps the catalog gate disarmed).

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- `cd ui && bun run test` → 1027 passed
- `cd ui && bun run check:i18n` → 2 locales in parity
- Verified live in the browser: placeholder renders in full with the `⌕` glyph; typing filters the list and the clear `×` coexists with the glyph; chips toggle on row 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
