### PR TITLE
chore(i18n): union merge driver to auto-resolve catalog conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,14 @@
 *.yaml  text diff
 *.sh    text eol=lf diff
 
+# Flat i18n message catalogs: every feature PR appends keys to the same files,
+# so concurrent branches collide on the tail hunk on every rebase. The custom
+# union driver merges by key — additive/one-sided changes auto-resolve, only a
+# real same-key clash conflicts. Defined in scripts/json-union-merge.mjs and
+# registered per-clone by scripts/register-merge-driver.mjs (husky `prepare`).
+ui/messages/*.json        merge=i18n-union
+extension/messages/*.json merge=i18n-union
+
 # Vendored, minified inlang/Paraglide plugins (copied verbatim into ui/ and
 # extension/). Not our source — mark generated + vendored so linguist and code
 # analysis skip them and diffs collapse. Hand-editing them would diverge from the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ Data passed through verbatim (tool-use summaries, PR titles, designations like `
 
 **Gate:** `cd ui && bun run check:i18n` enforces that all locale catalogs share an identical, non-empty key set (Paraglide silently falls back to EN for a missing key, so an incomplete `de.json` would otherwise ship looking fine). It runs in CI `verify` and the pre-push hook — a PR that adds an EN key without its DE counterpart fails. It does not detect hardcoded strings that skip the catalog entirely; that's on you and review.
 
+**Merge conflicts auto-resolve.** Because every PR appends keys to the same `ui/messages/*.json` + `extension/messages/*.json`, concurrent branches used to collide on the tail hunk on every rebase. A custom **union merge driver** (`scripts/json-union-merge.mjs`, bound in `.gitattributes`, registered per-clone by `scripts/register-merge-driver.mjs` from the root `prepare` script) now merges these catalogs **by key**: additive and one-sided edits resolve silently; only a genuine same-key-different-value clash falls through as a normal conflict. It activates on the next `bun install`; no action needed when rebasing. If you ever do see a catalog conflict, it's a real one — two branches gave the **same** key different values.
+
 ## Feature discovery (REQUIRED for user-facing features)
 
 New user-facing capabilities surface to users through the What's-New drawer + first-view coachmarks, both driven by the catalog `ui/src/lib/feature-announcements.ts`. **A `feat` that ships UX but skips the catalog rots it silently** — it builds, passes CI, and deploys while the discovery system stops reflecting reality. So every shipped user-facing feature adds **one** catalog entry **in the same PR as the feature**:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write .",
     "start": "bun run src/index.ts",
     "update": "bash deploy/update.sh",
-    "prepare": "husky"
+    "prepare": "husky && node scripts/register-merge-driver.mjs"
   },
   "lint-staged": {
     "*.{ts,js,json,css,html,md,svelte}": "prettier --write",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write .",
     "start": "bun run src/index.ts",
     "update": "bash deploy/update.sh",
-    "prepare": "husky && node scripts/register-merge-driver.mjs"
+    "prepare": "husky; node scripts/register-merge-driver.mjs"
   },
   "lint-staged": {
     "*.{ts,js,json,css,html,md,svelte}": "prettier --write",

--- a/scripts/json-union-merge.d.mts
+++ b/scripts/json-union-merge.d.mts
@@ -1,0 +1,17 @@
+// Types for the node-run merge driver (scripts/json-union-merge.mjs). The driver
+// stays plain .mjs so git can invoke it via node in any context; this declaration
+// only exists so the TypeScript test (test/json-union-merge.test.ts) can import it.
+
+export interface CatalogMergeResult {
+  /** Union of both sides, ours' key order preserved, theirs-only keys appended. */
+  merged: Record<string, string>;
+  /** Keys both sides changed differently (or one edited while the other deleted). */
+  conflicts: string[];
+}
+
+/** Three-way union of two flat string→string i18n catalogs. */
+export function mergeCatalogs(
+  base: Record<string, string>,
+  ours: Record<string, string>,
+  theirs: Record<string, string>,
+): CatalogMergeResult;

--- a/scripts/json-union-merge.mjs
+++ b/scripts/json-union-merge.mjs
@@ -130,10 +130,10 @@ function main(argv) {
   const theirs = readJson(theirsPath);
 
   // If any side isn't parseable JSON, don't risk mangling the file: leave
-  // `ours` untouched and exit non-zero. Git then marks the path unmerged (with
-  // no conflict markers, since we wrote nothing), so a human resolves it by
-  // hand. This is NOT git's default text merge — that already ran and produced
-  // the unparseable input we're declining to touch.
+  // `ours` (%A) untouched and exit non-zero. A custom driver runs INSTEAD of
+  // git's built-in text merge, so %A is the verbatim `ours` blob, not a
+  // pre-merged result — exiting here just marks the path unmerged with no
+  // conflict markers, leaving it as `ours` for a human to resolve by hand.
   if (base === null || ours === null || theirs === null) {
     process.stderr.write(
       `i18n-union: ${label ?? oursPath} not parseable as JSON — leaving for manual merge\n`,

--- a/scripts/json-union-merge.mjs
+++ b/scripts/json-union-merge.mjs
@@ -27,6 +27,11 @@ import { fileURLToPath } from "node:url";
  *   edited while the other deleted) — these are left for manual resolution.
  */
 export function mergeCatalogs(base, ours, theirs) {
+  // Value comparisons below use `===`, which assumes the catalogs are flat
+  // string→string maps (the inlang message-format here). If the format ever
+  // gains nested plural/variant *objects*, `===` compares object identity, not
+  // content — two equal-but-distinct objects would look "changed" and a real
+  // edit could look unchanged. Switch to a deep compare before adopting nesting.
   const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
   const conflicts = [];
   // Start from ours so base keys ours kept + ours-added keys retain their order.
@@ -77,6 +82,15 @@ function serializeClean(merged) {
  * (build, check:i18n) until a human resolves it, never look like a clean pass.
  */
 function serializeConflicted(merged, conflicts, ours, theirs) {
+  const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+  // Render one side of a conflicting key. An edit/delete conflict means the key
+  // is absent on the deleting side — show that explicitly rather than emitting a
+  // literal `undefined` value, which would read as a real (and invalid) entry.
+  const side = (obj, k) =>
+    has(obj, k)
+      ? `  ${JSON.stringify(k)}: ${JSON.stringify(obj[k])}`
+      : `  (${JSON.stringify(k)} deleted)`;
+
   const conflictSet = new Set(conflicts);
   // Render every surviving key in order, plus the conflicting keys (which may
   // have been dropped from `merged`) so both sides' values stay visible.
@@ -87,9 +101,9 @@ function serializeConflicted(merged, conflicts, ours, theirs) {
     }
     return (
       "<<<<<<< ours\n" +
-      `  ${JSON.stringify(k)}: ${JSON.stringify(ours[k])}\n` +
+      `${side(ours, k)}\n` +
       "=======\n" +
-      `  ${JSON.stringify(k)}: ${JSON.stringify(theirs[k])}\n` +
+      `${side(theirs, k)}\n` +
       ">>>>>>> theirs"
     );
   });
@@ -115,8 +129,11 @@ function main(argv) {
   const ours = readJson(oursPath);
   const theirs = readJson(theirsPath);
 
-  // If any side isn't parseable JSON, fall back to git's default text conflict
-  // rather than risk mangling the file.
+  // If any side isn't parseable JSON, don't risk mangling the file: leave
+  // `ours` untouched and exit non-zero. Git then marks the path unmerged (with
+  // no conflict markers, since we wrote nothing), so a human resolves it by
+  // hand. This is NOT git's default text merge — that already ran and produced
+  // the unparseable input we're declining to touch.
   if (base === null || ours === null || theirs === null) {
     process.stderr.write(
       `i18n-union: ${label ?? oursPath} not parseable as JSON — leaving for manual merge\n`,

--- a/scripts/json-union-merge.mjs
+++ b/scripts/json-union-merge.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// Git merge driver for flat i18n message catalogs (ui/ + extension/ messages/*.json).
+//
+// Why this exists: every feature PR appends keys to the tail of the same
+// catalogs, so two concurrent branches collide on the identical hunk on every
+// rebase onto main — a constant, content-free merge conflict. These clashes are
+// almost always *additive* (branch A adds `foo`, branch B adds `bar`), which a
+// line-based merge can't reconcile but a key-aware one can. This driver unions
+// the keys: additive and one-sided edits auto-resolve, and only a genuine
+// same-key-different-value clash falls through as a real conflict.
+//
+// Registered as `merge.i18n-union.driver` (see scripts/register-merge-driver.mjs,
+// run from husky `prepare`) and bound to the catalogs in .gitattributes.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Three-way union of two flat string→string catalogs.
+ *
+ * @param {Record<string,unknown>} base   common ancestor (%O)
+ * @param {Record<string,unknown>} ours   current branch (%A)
+ * @param {Record<string,unknown>} theirs incoming branch (%B)
+ * @returns {{ merged: Record<string,unknown>, conflicts: string[] }}
+ *   `merged` preserves ours' key order, with theirs-only additions appended.
+ *   `conflicts` lists keys both sides changed to different values (or one side
+ *   edited while the other deleted) — these are left for manual resolution.
+ */
+export function mergeCatalogs(base, ours, theirs) {
+  const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+  const conflicts = [];
+  // Start from ours so base keys ours kept + ours-added keys retain their order.
+  const merged = { ...ours };
+
+  for (const k of Object.keys(theirs)) {
+    if (!has(ours, k)) {
+      if (!has(base, k)) {
+        merged[k] = theirs[k]; // theirs added a brand-new key
+      } else if (base[k] === theirs[k]) {
+        // ours deleted it, theirs left it untouched → stay deleted
+      } else {
+        conflicts.push(k); // ours deleted, theirs edited → genuine conflict
+      }
+      continue;
+    }
+    if (ours[k] === theirs[k]) continue; // identical on both sides
+    if (has(base, k) && base[k] === ours[k]) {
+      merged[k] = theirs[k]; // only theirs changed it
+    } else if (has(base, k) && base[k] === theirs[k]) {
+      // only ours changed it → keep ours (already in `merged`)
+    } else {
+      conflicts.push(k); // both sides changed it differently
+    }
+  }
+
+  // Keys theirs deleted: drop them when ours left them untouched, else conflict.
+  for (const k of Object.keys(base)) {
+    if (has(theirs, k) || !has(ours, k)) continue; // not deleted by theirs, or already gone from ours
+    if (ours[k] === base[k]) {
+      delete merged[k]; // theirs deleted, ours unchanged → honor the deletion
+    } else {
+      conflicts.push(k); // theirs deleted, ours edited → genuine conflict
+    }
+  }
+
+  return { merged, conflicts };
+}
+
+/** Serialize a clean (conflict-free) merge in the catalogs' canonical format. */
+function serializeClean(merged) {
+  return JSON.stringify(merged, null, 2) + "\n";
+}
+
+/**
+ * Serialize a conflicted merge with inline git markers for each conflicting key.
+ * The output is deliberately not valid JSON — it must fail loudly downstream
+ * (build, check:i18n) until a human resolves it, never look like a clean pass.
+ */
+function serializeConflicted(merged, conflicts, ours, theirs) {
+  const conflictSet = new Set(conflicts);
+  // Render every surviving key in order, plus the conflicting keys (which may
+  // have been dropped from `merged`) so both sides' values stay visible.
+  const order = [...new Set([...Object.keys(merged), ...conflicts])];
+  const parts = order.map((k) => {
+    if (!conflictSet.has(k)) {
+      return `  ${JSON.stringify(k)}: ${JSON.stringify(merged[k])}`;
+    }
+    return (
+      "<<<<<<< ours\n" +
+      `  ${JSON.stringify(k)}: ${JSON.stringify(ours[k])}\n` +
+      "=======\n" +
+      `  ${JSON.stringify(k)}: ${JSON.stringify(theirs[k])}\n` +
+      ">>>>>>> theirs"
+    );
+  });
+  return "{\n" + parts.join(",\n") + "\n}\n";
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * CLI entry: `json-union-merge.mjs <base> <ours> <theirs> [path]`.
+ * Git invokes it with %O %A %B %P; the merged result is written back to <ours>.
+ * Exit 0 = clean, exit 1 = unresolved conflicts remain.
+ */
+function main(argv) {
+  const [basePath, oursPath, theirsPath, label] = argv;
+  const base = readJson(basePath);
+  const ours = readJson(oursPath);
+  const theirs = readJson(theirsPath);
+
+  // If any side isn't parseable JSON, fall back to git's default text conflict
+  // rather than risk mangling the file.
+  if (base === null || ours === null || theirs === null) {
+    process.stderr.write(
+      `i18n-union: ${label ?? oursPath} not parseable as JSON — leaving for manual merge\n`,
+    );
+    return 1;
+  }
+
+  const { merged, conflicts } = mergeCatalogs(base, ours, theirs);
+  if (conflicts.length === 0) {
+    writeFileSync(oursPath, serializeClean(merged));
+    return 0;
+  }
+  writeFileSync(oursPath, serializeConflicted(merged, conflicts, ours, theirs));
+  process.stderr.write(
+    `i18n-union: ${label ?? oursPath} has ${conflicts.length} conflicting key(s): ${conflicts.join(", ")}\n`,
+  );
+  return 1;
+}
+
+const isMain = Boolean(process.argv[1]) && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/register-merge-driver.mjs
+++ b/scripts/register-merge-driver.mjs
@@ -11,14 +11,12 @@
 // See scripts/json-union-merge.mjs and .gitattributes.
 
 import { execFileSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
 
-const scriptDir = dirname(fileURLToPath(import.meta.url));
-const driver = join(scriptDir, "json-union-merge.mjs");
-
+// Git runs merge drivers from the worktree root, so a repo-relative path resolves
+// correctly in every worktree — and unlike an absolute path it doesn't go stale
+// when a worktree is relocated or pruned (Shepherd spins worktrees up and down).
 // %O = ancestor, %A = ours/output, %B = theirs, %P = pathname (for messages).
-const command = `node ${JSON.stringify(driver)} %O %A %B %P`;
+const command = "node scripts/json-union-merge.mjs %O %A %B %P";
 
 function gitConfig(key, value) {
   execFileSync("git", ["config", key, value], { stdio: "ignore" });

--- a/scripts/register-merge-driver.mjs
+++ b/scripts/register-merge-driver.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Register the i18n catalog union merge driver in this clone's git config.
+//
+// .gitattributes can *name* a merge driver (`merge=i18n-union`) but git refuses
+// to run one unless `merge.i18n-union.driver` is defined in config — and config
+// is not checked in. So every clone must self-register. This runs from the root
+// `prepare` script (husky), i.e. on every `bun install`, covering dev clones,
+// CI, and the merge-train server. Worktrees share the common config, so one
+// registration covers them all. It's idempotent.
+//
+// See scripts/json-union-merge.mjs and .gitattributes.
+
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const driver = join(scriptDir, "json-union-merge.mjs");
+
+// %O = ancestor, %A = ours/output, %B = theirs, %P = pathname (for messages).
+const command = `node ${JSON.stringify(driver)} %O %A %B %P`;
+
+function gitConfig(key, value) {
+  execFileSync("git", ["config", key, value], { stdio: "ignore" });
+}
+
+try {
+  gitConfig("merge.i18n-union.name", "union merge for flat i18n catalogs");
+  gitConfig("merge.i18n-union.driver", command);
+  process.stdout.write("✓ registered i18n-union merge driver\n");
+} catch (err) {
+  // Not fatal — a missing driver just means catalog conflicts resolve the old
+  // (manual) way. Don't break `bun install` outside a git checkout (e.g. tarball).
+  process.stderr.write(`i18n-union: could not register merge driver (${err?.message ?? err})\n`);
+}

--- a/test/json-union-merge.test.ts
+++ b/test/json-union-merge.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { mergeCatalogs } from "../scripts/json-union-merge.mjs";
+
+// The merge driver's whole reason to exist: two branches that each only *add*
+// keys to a flat i18n catalog must union cleanly with no conflict — that is the
+// ~99% case behind the constantly-reoccurring catalog conflicts.
+describe("mergeCatalogs — additive (the common case)", () => {
+  const base = { a: "1", b: "2" };
+
+  test("disjoint additions on both sides union with no conflict", () => {
+    const ours = { a: "1", b: "2", ours_key: "o" };
+    const theirs = { a: "1", b: "2", theirs_key: "t" };
+    const { merged, conflicts } = mergeCatalogs(base, ours, theirs);
+    expect(conflicts).toEqual([]);
+    expect(merged).toEqual({ a: "1", b: "2", ours_key: "o", theirs_key: "t" });
+  });
+
+  test("the same key added identically on both sides is not a conflict", () => {
+    const ours = { a: "1", b: "2", shared: "x" };
+    const theirs = { a: "1", b: "2", shared: "x" };
+    const { merged, conflicts } = mergeCatalogs(base, ours, theirs);
+    expect(conflicts).toEqual([]);
+    expect(merged).toEqual({ a: "1", b: "2", shared: "x" });
+  });
+
+  test("ours order is preserved and theirs-only keys are appended", () => {
+    const ours = { a: "1", b: "2", o: "o" };
+    const theirs = { a: "1", b: "2", t1: "t1", t2: "t2" };
+    const { merged } = mergeCatalogs(base, ours, theirs);
+    expect(Object.keys(merged)).toEqual(["a", "b", "o", "t1", "t2"]);
+  });
+});
+
+describe("mergeCatalogs — one-sided edits (auto-resolvable)", () => {
+  const base = { a: "1", b: "2" };
+
+  test("only theirs changed an existing key ⇒ take theirs", () => {
+    const ours = { a: "1", b: "2" };
+    const theirs = { a: "1", b: "CHANGED" };
+    const { merged, conflicts } = mergeCatalogs(base, ours, theirs);
+    expect(conflicts).toEqual([]);
+    expect(merged.b).toBe("CHANGED");
+  });
+
+  test("only ours changed an existing key ⇒ keep ours", () => {
+    const ours = { a: "1", b: "CHANGED" };
+    const theirs = { a: "1", b: "2" };
+    const { merged, conflicts } = mergeCatalogs(base, ours, theirs);
+    expect(conflicts).toEqual([]);
+    expect(merged.b).toBe("CHANGED");
+  });
+
+  test("theirs deleted a key ours left untouched ⇒ stays deleted, no resurrection", () => {
+    const ours = { a: "1", b: "2" };
+    const theirs = { a: "1" };
+    const { merged, conflicts } = mergeCatalogs(base, ours, theirs);
+    expect(conflicts).toEqual([]);
+    expect(merged).toEqual({ a: "1" });
+  });
+
+  test("ours deleted a key theirs left untouched ⇒ stays deleted", () => {
+    const ours = { a: "1" };
+    const theirs = { a: "1", b: "2" };
+    const { merged, conflicts } = mergeCatalogs(base, ours, theirs);
+    expect(conflicts).toEqual([]);
+    expect(merged).toEqual({ a: "1" });
+  });
+});
+
+describe("mergeCatalogs — genuine conflicts (must fail loud)", () => {
+  const base = { a: "1", b: "2" };
+
+  test("same existing key changed to different values on each side", () => {
+    const ours = { a: "1", b: "OURS" };
+    const theirs = { a: "1", b: "THEIRS" };
+    const { conflicts } = mergeCatalogs(base, ours, theirs);
+    expect(conflicts).toEqual(["b"]);
+  });
+
+  test("same new key added with different values on each side", () => {
+    const ours = { a: "1", b: "2", k: "OURS" };
+    const theirs = { a: "1", b: "2", k: "THEIRS" };
+    const { conflicts } = mergeCatalogs(base, ours, theirs);
+    expect(conflicts).toEqual(["k"]);
+  });
+
+  test("ours changed a key theirs deleted ⇒ conflict (don't silently drop the edit)", () => {
+    const ours = { a: "1", b: "OURS" };
+    const theirs = { a: "1" };
+    const { conflicts } = mergeCatalogs(base, ours, theirs);
+    expect(conflicts).toEqual(["b"]);
+  });
+
+  test("clean additions still merge alongside a conflicting key", () => {
+    const ours = { a: "1", b: "OURS", o: "o" };
+    const theirs = { a: "1", b: "THEIRS", t: "t" };
+    const { merged, conflicts } = mergeCatalogs(base, ours, theirs);
+    expect(conflicts).toEqual(["b"]);
+    // the additive keys are preserved even though `b` conflicts
+    expect(merged.o).toBe("o");
+    expect(merged.t).toBe("t");
+  });
+});


### PR DESCRIPTION
## Problem

Every feature PR appends keys to the tail of the same flat i18n catalogs (`ui/messages/{en,de}.json` + `extension/messages/{en,de}.json`). Two concurrent branches each turn the last key's `…"` into `…",` + a new line, so they collide on the **identical hunk** on every rebase onto main. Looking at recent history, nearly every PR touches these files → the collision rate is effectively 100% whenever agents run in parallel.

These aren't *semantic* conflicts — they're textual conflicts over **independent additions** (branch A adds `foo`, branch B adds `bar`). Git's line-based merge can't see that; a key-aware one can.

## Fix: a JSON union merge driver

A custom git merge driver scoped to the catalogs via `.gitattributes`. On rebase/merge it parses base/ours/theirs as JSON and unions by key:

- **Additive** (both sides add different keys) → auto-resolve
- **One-sided edit / deletion** → auto-resolve
- **Genuine same-key/different-value clash** → falls through as a real conflict with fail-loud inline markers (deliberately invalid JSON so `check:i18n`/build can't mistake it for a pass)

Runs during the exact pain point (local rebase-onto-main) and on the merge-train's local rebase. **No workflow change for agents.**

### Why this over alternatives
- *Split catalogs into namespaced files* — bigger refactor, and two features in the same area still collide.
- *Alphabetical key sort* — reduces but doesn't eliminate (adjacent keys still clash); reorders the whole file once.
- The merge driver kills the entire additive class outright.

## How it's wired
- `scripts/json-union-merge.mjs` — the driver (pure `mergeCatalogs()` + thin CLI). Node-run for universal availability, matching the existing `check-i18n.mjs` precedent.
- `.gitattributes` — binds `ui/messages/*.json` + `extension/messages/*.json` to `merge=i18n-union`.
- `scripts/register-merge-driver.mjs` — registers the driver in `.git/config` (drivers can't be checked in). Runs from the root `prepare` script, so it self-activates on the next `bun install` for dev clones, CI, and the merge-train server. Worktrees share the common config. Idempotent.
- `scripts/json-union-merge.d.mts` — types so the TS test can import the `.mjs`.

## Verification
- 11 unit tests covering additive / one-sided / deletion / genuine-conflict cases (`test/json-union-merge.test.ts`).
- End-to-end `git merge` in a throwaway repo: additive merge auto-unions in canonical format; same-key clash produces inline `<<<<<<<` markers and a real `CONFLICT`.
- `bun install` confirmed to auto-register the driver via `prepare`.
- prettier · eslint · `tsc --noEmit` · full root suite (1967 pass) green.

No user-facing UX → no feature-catalog entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)