### PR TITLE
fix(viewport): shorten mobile autopilot pill to AP ON

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -772,6 +772,8 @@
   "session_autopilot_toggle_aria": "Autopilot für diese Session umschalten",
   "session_autopilot_on_label": "Autopilot an",
   "session_autopilot_off_label": "Autopilot aus",
+  "session_autopilot_on_short": "AP an",
+  "session_autopilot_off_short": "AP aus",
   "session_autopilot_paused_label": "Braucht dich",
   "session_autopilot_paused_title": "Autopilot hat dies für eine Entscheidung zurückgegeben: {question}",
   "session_autopilot_complete_label": "Fertig",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -772,6 +772,8 @@
   "session_autopilot_toggle_aria": "Toggle autopilot for this session",
   "session_autopilot_on_label": "Autopilot on",
   "session_autopilot_off_label": "Autopilot off",
+  "session_autopilot_on_short": "AP on",
+  "session_autopilot_off_short": "AP off",
   "session_autopilot_paused_label": "Needs you",
   "session_autopilot_paused_title": "Autopilot handed this back for a decision: {question}",
   "session_autopilot_complete_label": "Complete",

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2118,7 +2118,11 @@
             : m.session_autopilot_off_label()}
           onclick={toggleSessionAutopilot}
         >
-          {autopilotEffective ? m.session_autopilot_on_label() : m.session_autopilot_off_label()}
+          {#if compact}
+            {autopilotEffective ? m.session_autopilot_on_short() : m.session_autopilot_off_short()}
+          {:else}
+            {autopilotEffective ? m.session_autopilot_on_label() : m.session_autopilot_off_label()}
+          {/if}
         </button>
         {#if compact && !prReady}
           <!-- compact only: the rare destructive action, parked at the strip's far


### PR DESCRIPTION
## What

On mobile/compact layouts the per-session autopilot toggle pill rendered the full **AUTOPILOT ON / OFF** label, which overflowed the narrow git strip (see issue screenshot). It now shows a short **AP ON / AP OFF** on compact layouts; desktop (PR rail open) keeps the full **AUTOPILOT ON / OFF**.

## How

- Added short i18n keys `session_autopilot_on_short` / `session_autopilot_off_short` to both `en.json` (`AP on` / `AP off`) and `de.json` (`AP an` / `AP aus`).
- `Viewport.svelte` `.ap-toggle` visible text now branches on the existing `compact` (`mobile || touch`) derived state — short label on compact, full label otherwise. Uppercasing stays via the existing CSS `text-transform`.
- `title` and `aria-label` keep the full "Autopilot on/off" wording, so the tooltip and accessible name are unchanged — only the visible glyph shrinks. No CSS change (the pill auto-shrinks to the shorter content).

## Notes

- Label-sizing polish, not a new capability → no feature-catalog entry (`[no-feature-entry]`).
- `cd ui && bun run check` (0 errors) and `bun run check:i18n` (1029 keys, both locales in parity) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)