### PR TITLE
fix(herd): pin card clock top-right + free the badge rail in the desktop sidebar

### DIFF
--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -1155,15 +1155,41 @@
       text-align: left;
       gap: 6px;
     }
-    /* The decommission ✕ is invisible-but-keyboard-focusable (opacity, not
-       display:none), so as the rail's first flex child it would indent the
-       horizontal strip. Lift it out of flow to the row's top-right corner (its
-       prior position when the rail was a right-hand column) so the strip starts
-       flush left; it stays in the tab order and reveals on hover/focus as before. */
+    /* Pin the elapsed clock to the card's top-right, aligned with the name row,
+       instead of letting it ride along in the own-row badge strip. pointer-events
+       is none (MANDATORY, not cosmetic): .elapsed paints above the .unit-hit
+       overlay (it's later in the DOM), so without this it would swallow row-select
+       clicks in the top-right corner and starve onHitMove's mousemove — breaking
+       the TimePopover hover trigger. none passes events through to the overlay
+       while getBoundingClientRect() still measures the clock for the bounds test
+       + popover anchor. */
+    :global(.units:not(.flow)) .elapsed {
+      position: absolute;
+      top: 11px;
+      right: 14px;
+      pointer-events: none;
+    }
+    /* Reserve room on the name row so a long name ellipsizes BEFORE the clock
+       rather than sliding under it (the clock still paints over the name —
+       pointer-events stops event capture, not painting). 62px ≈ widest elapsed()
+       "29d 23h" (~7 tabular chars) + the right offset. */
+    :global(.units:not(.flow)) .u-top {
+      padding-right: 62px;
+    }
+    /* The decommission ✕ is invisible-but-keyboard-focusable (opacity:0 +
+       pointer-events:none from the base .row-decom rule, NOT display:none) so it
+       stays in the tab order and reveals on hover/focus. Keep it absolute and out
+       of flow, parked just below the pinned clock in the right gutter (on the
+       prompt's first line) so it clears the clock and doesn't indent the badge
+       strip. top: 30px = the clock's top: 11px + ~one clock line-height, dropping
+       the ✕ just under the clock onto the prompt's first line. Unlike .u-top, .u-sub
+       (the prompt) reserves no right gutter, so a very long prompt's first line can
+       run under the ✕ — acceptable: the ✕ is hover-only, tiny, and sits over muted
+       secondary text, so it merely paints over (same as the clock-over-name case). */
     :global(.units:not(.flow)) .row-decom {
       position: absolute;
-      top: 8px;
-      right: 10px;
+      top: 30px;
+      right: 12px;
     }
   }
 </style>

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -1171,10 +1171,14 @@
     }
     /* Reserve room on the name row so a long name ellipsizes BEFORE the clock
        rather than sliding under it (the clock still paints over the name —
-       pointer-events stops event capture, not painting). 62px ≈ widest elapsed()
-       "29d 23h" (~7 tabular chars) + the right offset. */
+       pointer-events stops event capture, not painting). 72px clears realistic
+       elapsed() widths incl. the multi-day forms "29d 23h" / "100d 23h" (8
+       tabular chars) + the right offset. elapsed() has no day cap, so a
+       pathological 1000d+ run (9+ chars) would still overflow — accepted: such a
+       session is unreachable in practice and it degrades gracefully (the name
+       just paints under the clock, same tradeoff as everywhere else here). */
     :global(.units:not(.flow)) .u-top {
-      padding-right: 62px;
+      padding-right: 72px;
     }
     /* The decommission ✕ is invisible-but-keyboard-focusable (opacity:0 +
        pointer-events:none from the base .row-decom rule, NOT display:none) so it


### PR DESCRIPTION
## What

The desktop Herd sidebar cards (`UnitRow.svelte`) lost their layout in **#566** (`fix(herd): drop badge rail to its own row`). That PR moved the badge/status cluster to its own full-width row under the prompt — but swept the **elapsed clock** into that strip (so it trailed after the status badge instead of anchoring the card) and left the hover decommission ✕ sitting exactly where the clock now belongs.

Reported symptom: clock misplaced, badge strip sprawls/misaligns on desktop.

## Fix

CSS-only, scoped entirely to the existing `@container herd (max-width: 360px) { :global(.units:not(.flow)) … }` block (desktop sidebar only — mobile `.units.flow` list and the base layout untouched):

- **Pin the clock top-right** on the name line, with `pointer-events: none`. The latter is load-bearing, not cosmetic: an absolutely-positioned `.elapsed` paints above the `.unit-hit` overlay, so without it the clock would swallow row-select clicks and starve the geometric TimePopover hover trigger (`onHitMove`). `none` passes events through while `getBoundingClientRect()` still measures the clock for the bounds test + popover anchor.
- **Reserve room on the name row** (`.u-top { padding-right }`) so long names ellipsize before the clock instead of sliding under it.
- **Drop the hover ✕** just below the pinned clock (kept `position: absolute` / `opacity:0` so it stays keyboard-focusable — not `display:none`, not reordered into the strip where it would wrap).

Result:

```
🟠 [icon] session-name                16:56   ← clock pinned top-right, on the name line
Work on issue #327: tracking: EFI…            ← prompt
NO PR  PLANNING  BUSY                         ← badge strip, its own row, no clock
TASK-372 · opus            ▪▪▫▫               ← meta + stepper
```

Not a revert of #566 (that fixed real repo-name→ellipsis-stub crushing); this refines it.

## Verification

- `cd ui && bun run check` — svelte-check 0 errors / 0 warnings.
- `cd ui && bun run test` — vitest green; `UnitRow.browser.test.ts` still passes (CSS-only).
- Live-proxy dev server + browser, sidebar at ~358px (within the ≤360 query): clock pinned & aligned; badge strip clock-free & left-aligned; 75-char name ellipsizes clear of the clock; TimePopover opens on clock-hover and a corner click still selects the row (confirms `pointer-events:none` pass-through); hover ✕ reveals below the clock without overlapping clock/prompt/badges/stepper; near-empty badge row collapses with no stray band.

`fix`, no user-facing feature → no feature-catalog entry; no new i18n keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
