### PR TITLE
fix(relaunch): show carried image in relaunch-elsewhere composer (no double, no loss)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import { detectForge } from "./forge";
 import { AccountUsageIndex } from "./usage";
 import { UsageLimitsService } from "./usage-limits";
 import { HerdrUsageProbe } from "./usage-probe";
-import { sweepStaging } from "./uploads";
+import { sweepStaging, STAGING_TTL_MS } from "./uploads";
 import { validateRoot } from "./dirs";
 import { UpdateService } from "./update";
 import { HerdrUpdateService } from "./herdr-update";
@@ -156,8 +156,8 @@ if (savedDm !== null) {
   }
 }
 
-// drop abandoned New-Task uploads (attached but never submitted) older than 24h
-sweepStaging(config.repoRoot, 24 * 60 * 60 * 1000, Date.now());
+// drop abandoned staged uploads (New-Task or relaunch carry, never submitted) past the TTL
+sweepStaging(config.repoRoot, STAGING_TTL_MS, Date.now());
 const herdr = new HerdrDriver();
 const worktree = new WorktreeMgr();
 const events = new EventHub();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1472,6 +1472,19 @@ async function handleSessionRelaunch({ req, parts, deps }: Ctx): Promise<Respons
   }
 }
 
+// POST /api/sessions/:id/relaunch-uploads — stage the original's uploaded images so a
+// relaunch composer can seed them as carried-over chips. Read-only on the session: it
+// copies (not moves) the originals into staging and returns { images: [{ path, name }] }.
+// Distinct from /relaunch (different parts[3]) — no spawn, no decommission.
+function handleRelaunchUploads({ req, parts, deps }: Ctx): Response | null {
+  if (!(req.method === "POST" && parts[2] && parts[3] === "relaunch-uploads")) return null;
+  const id = parts[2];
+  const original = deps.store.get(id);
+  if (!original) return json({ error: "not found" }, 404);
+  if (original.status === "archived") return json({ error: "already archived" }, 409);
+  return json({ images: deps.service.stageRelaunchImages(id) }, 200);
+}
+
 // Steer text sent to the agent when the operator approves the build queue.
 // Agent-facing — plain English, not user chrome, so no i18n.
 const APPROVE_STEER =
@@ -1555,6 +1568,7 @@ async function handleSessions(ctx: Ctx): Promise<Response | null> {
     handleSessionAutopilot,
     handleSessionAutoMerge,
     handleSessionRelaunch,
+    handleRelaunchUploads,
   ]) {
     const res = await sub(ctx);
     if (res) return res;

--- a/src/service.ts
+++ b/src/service.ts
@@ -10,7 +10,14 @@ import type { HerdrDriver } from "./herdr";
 import { matchAgents } from "./herdr";
 import { config } from "./config";
 import type { CreateSessionInput, IssueRef, RelaunchOverrides, Session } from "./types";
-import { moveStagedIntoWorktree, stagingDir, uploadFilename, worktreeUploadsDir } from "./uploads";
+import {
+  moveStagedIntoWorktree,
+  stagingDir,
+  sweepStaging,
+  STAGING_TTL_MS,
+  uploadFilename,
+  worktreeUploadsDir,
+} from "./uploads";
 import { slugifyManual } from "./namer";
 import type { Leftover, ProcessReaper } from "./process-reaper";
 import type { PreviewService } from "./preview";
@@ -955,11 +962,16 @@ export class SessionService {
    * basename for each, capped at MAX_IMAGES so the UI never seeds more chips than a spawn
    * accepts. The copies are recoverable on disk; relaunch() then takes the (possibly
    * operator-edited) list back verbatim, so there is no server-side re-merge.
+   *
+   * Each open copies fresh into staging, so a cancelled open or a removed chip orphans
+   * its copies. Before staging, we reclaim staged uploads past the TTL (the same sweep the
+   * server runs at startup, over the shared staging dir) so repeated opens don't accumulate.
    */
   stageRelaunchImages(originalId: string): { path: string; name: string }[] {
     const s = this.deps.store.get(originalId);
     if (!s || s.status === "archived")
       throw new Error(`cannot stage relaunch images for ${originalId}: missing or archived`);
+    sweepStaging(config.repoRoot, STAGING_TTL_MS, Date.now());
     const paths = this.copyOriginalUploads(s.worktreePath).slice(0, MAX_IMAGES);
     return paths.map((p) => ({ path: p, name: basename(p) }));
   }

--- a/src/service.ts
+++ b/src/service.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { extname, join } from "node:path";
+import { basename, extname, join } from "node:path";
 import type { SessionStore } from "./store";
 import type { EventHub } from "./events";
 import type { WorktreeMgr } from "./worktree";
@@ -752,8 +752,8 @@ export class SessionService {
   }
 
   async create(input: CreateSessionInput): Promise<Session> {
-    const basename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
-    const herdSlug = basename ? slugifyManual(basename) : undefined;
+    const repoBasename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
+    const herdSlug = repoBasename ? slugifyManual(repoBasename) : undefined;
     const name = this.uniqueName(await this.deps.namer(input.prompt), herdSlug);
     const wt = this.deps.worktree.create(input.repoPath, input.baseBranch, name);
     // The worktree is created before the agent can start, so any failure past this
@@ -868,11 +868,17 @@ export class SessionService {
    * `overrides` is an optional bag applied over the original (absent field keeps the
    * original's value; a present one — incl. explicit `null` — replaces it), letting a
    * caller relaunch into a DIFFERENT repo while carrying prompt/model/base-branch
-   * forward. Supplied `images` are appended to the carried-over originals. Omitted →
-   * byte-for-byte the original quick-relaunch.
+   * forward. Image handling forks on whether overrides are present:
+   *   - quick relaunch (`overrides == null`) → the original's uploads are auto-carried
+   *     (copied into staging), byte-for-byte the original spawn.
+   *   - relaunch WITH overrides → `overrides.images` is used VERBATIM and the original's
+   *     uploads are NOT auto-carried. The composer is the single source of truth here: it
+   *     seeds the carried originals (via `stageRelaunchImages`) into the override list and
+   *     the operator edits that list, so re-merging server-side would double the images.
    *
-   * The original's uploaded images are COPIED (not moved) into staging and passed
-   * to `create`, which lands them in the new worktree — so a spawn failure here
+   * On the quick-relaunch branch, the original's uploaded images are COPIED (not
+   * moved) into staging and passed to `create`, which lands them in the new
+   * worktree — so a spawn failure here
    * leaves the original's images intact on disk (the originals are reclaimed only
    * when the original's worktree is torn down by the route, after a successful
    * spawn). On any error AFTER `create`, the just-created session is best-effort
@@ -887,21 +893,26 @@ export class SessionService {
     if (!s || s.status === "archived")
       throw new Error(`cannot relaunch ${originalId}: missing or archived`);
 
-    // Carry over the original's images: copied (not moved) into staging so create()
-    // can land them in the new worktree like New Task, and the originals stay
-    // recoverable on a spawn failure.
-    const copiedOriginalImages = this.copyOriginalUploads(s.worktreePath);
-
-    // Supplied images append to the carried-over originals. Each list is independently
-    // ≤ MAX_IMAGES (validated at the original's creation / on the override body), but the
-    // concatenation can exceed it — cap the merged list to the per-spawn limit, originals
-    // first, and log any drop rather than silently overflowing the spawn prompt.
-    const mergedImages = [...copiedOriginalImages, ...(overrides?.images ?? [])];
-    const images = mergedImages.slice(0, MAX_IMAGES);
-    if (mergedImages.length > images.length)
-      console.warn(
-        `[relaunch] ${originalId}: ${mergedImages.length} images exceed cap ${MAX_IMAGES}; dropped ${mergedImages.length - images.length}`,
-      );
+    // Image handling forks on whether overrides are present:
+    //   - quick relaunch (no overrides) → auto-carry the original's uploads, copied (not
+    //     moved) into staging so create() can land them in the new worktree like New Task,
+    //     with the originals staying recoverable on a spawn failure. Cap at MAX_IMAGES and
+    //     warn on drop rather than silently overflowing the spawn prompt.
+    //   - relaunch WITH overrides → use overrides.images VERBATIM and do NOT auto-carry.
+    //     The composer already seeded the carried originals into overrides.images (via
+    //     stageRelaunchImages) and the operator edited that list, so it is authoritative;
+    //     re-merging here would double the carried images.
+    let images: string[];
+    if (overrides == null) {
+      const copiedOriginalImages = this.copyOriginalUploads(s.worktreePath);
+      images = copiedOriginalImages.slice(0, MAX_IMAGES);
+      if (copiedOriginalImages.length > images.length)
+        console.warn(
+          `[relaunch] ${originalId}: ${copiedOriginalImages.length} images exceed cap ${MAX_IMAGES}; dropped ${copiedOriginalImages.length - images.length}`,
+        );
+    } else {
+      images = overrides.images ?? [];
+    }
 
     // Apply overrides over the original: an ABSENT field keeps the original's value;
     // a PRESENT one (including explicit `null` for model/planGateEnabled) replaces it.
@@ -935,6 +946,22 @@ export class SessionService {
 
     // Re-fetch AFTER the override writes so the returned session reflects them.
     return this.deps.store.get(newSession.id)!;
+  }
+
+  /**
+   * Stage an original session's uploaded images for a relaunch-WITH-overrides composer
+   * to seed. Copies (not moves) the original's worktree uploads into the repo staging dir
+   * — like the quick-relaunch branch and New Task — and returns the staged path plus its
+   * basename for each, capped at MAX_IMAGES so the UI never seeds more chips than a spawn
+   * accepts. The copies are recoverable on disk; relaunch() then takes the (possibly
+   * operator-edited) list back verbatim, so there is no server-side re-merge.
+   */
+  stageRelaunchImages(originalId: string): { path: string; name: string }[] {
+    const s = this.deps.store.get(originalId);
+    if (!s || s.status === "archived")
+      throw new Error(`cannot stage relaunch images for ${originalId}: missing or archived`);
+    const paths = this.copyOriginalUploads(s.worktreePath).slice(0, MAX_IMAGES);
+    return paths.map((p) => ({ path: p, name: basename(p) }));
   }
 
   /**

--- a/src/uploads.ts
+++ b/src/uploads.ts
@@ -13,6 +13,9 @@ import type { SessionStore } from "./store";
 
 export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 
+/** Age after which an abandoned staged upload (New Task or relaunch carry) is reclaimed. */
+export const STAGING_TTL_MS = 24 * 60 * 60 * 1000;
+
 const MIME_EXT: Record<string, string> = {
   "image/png": "png",
   "image/jpeg": "jpg",

--- a/test/server-relaunch.test.ts
+++ b/test/server-relaunch.test.ts
@@ -62,10 +62,12 @@ function harness(opts: {
   relaunchThrows?: Error;
   resolveForge?: AppDeps["resolveForge"];
   archiveCleared?: string[]; // ids archiveMany reports cleared (default: the requested id)
+  staged?: { path: string; name: string }[]; // what stageRelaunchImages returns
 }) {
   const emitted: Spy[] = [];
   const calls = {
     relaunch: [] as Array<{ id: string; issueRef: unknown; overrides: unknown }>,
+    stageRelaunchImages: [] as string[],
   };
   let retainClaimSeenArchived = false;
 
@@ -112,6 +114,10 @@ function harness(opts: {
       cleared: opts.archiveCleared ?? ids,
       leftovers: 0,
     }),
+    stageRelaunchImages: (id: string) => {
+      calls.stageRelaunchImages.push(id);
+      return opts.staged ?? [{ path: "/stage/carried.png", name: "carried.png" }];
+    },
   } as unknown as SessionService;
 
   const events = {
@@ -465,14 +471,45 @@ test("same-repo relaunch with { prompt, model, planGateEnabled, baseBranch } app
   expect(h.drainCalls).toEqual(["orig"]); // retainClaim called
 });
 
-test("images override is threaded through to service.relaunch (appended to originals)", async () => {
-  // The append-to-copied-originals merge lives in the service; at the route boundary we
-  // assert the supplied images ride through verbatim for the service to append.
+test("images override is threaded through to service.relaunch as the authoritative set", async () => {
+  // Image semantics live in the service (overrides → verbatim, no auto-carry); at the route
+  // boundary we assert the supplied images ride through unchanged as that authoritative set.
   const h = harness({ original: { issueNumber: null, repoPath: REPO } });
   const res = await h.app.fetch(relaunchReq("orig", { images: [STAGED_IMAGE] }));
   expect(res.status).toBe(201);
   // validateImages resolves each entry to its realpath; that resolved path rides through.
   expect(h.calls.relaunch[0]?.overrides).toMatchObject({ images: [STAGED_IMAGE] });
+});
+
+// ── POST /api/sessions/:id/relaunch-uploads — stage carried images for the composer ──────
+function relaunchUploadsReq(id = "orig"): Request {
+  return new Request(`http://localhost/api/sessions/${id}/relaunch-uploads`, { method: "POST" });
+}
+
+test("POST /api/sessions/:id/relaunch-uploads returns staged { images }", async () => {
+  const staged = [
+    { path: "/stage/a.png", name: "a.png" },
+    { path: "/stage/b.jpg", name: "b.jpg" },
+  ];
+  const h = harness({ original: { issueNumber: null, repoPath: REPO }, staged });
+  const res = await h.app.fetch(relaunchUploadsReq("orig"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ images: staged });
+  expect(h.calls.stageRelaunchImages).toEqual(["orig"]); // sourced from the service
+});
+
+test("POST /api/sessions/:id/relaunch-uploads → 404 for a missing original", async () => {
+  const h = harness({ original: null });
+  const res = await h.app.fetch(relaunchUploadsReq("ghost"));
+  expect(res.status).toBe(404);
+  expect(h.calls.stageRelaunchImages).toHaveLength(0); // never staged
+});
+
+test("POST /api/sessions/:id/relaunch-uploads → 409 for an archived original", async () => {
+  const h = harness({ original: { status: "archived", issueNumber: null, repoPath: REPO } });
+  const res = await h.app.fetch(relaunchUploadsReq("orig"));
+  expect(res.status).toBe(409);
+  expect(h.calls.stageRelaunchImages).toHaveLength(0);
 });
 
 // ── Override validation (closes the create/relaunch asymmetry — fail-closed) ──────────

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, readdirSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionStore } from "../src/store";
@@ -18,6 +18,7 @@ import {
 } from "../src/service";
 import { HOUSE_RULES_TAG } from "../src/house-rules";
 import { config, parseTrimAutoContext } from "../src/config";
+import { MAX_IMAGES } from "../src/validate";
 
 test("createSession: names, makes worktree, starts herdr, persists", async () => {
   const store = new SessionStore(":memory:");
@@ -3088,7 +3089,7 @@ test("relaunch overrides treat an absent field as keep-original (explicit null r
   expect(cleared.planGateEnabled).toBe(null);
 });
 
-test("relaunch images override appends to the carried-over originals", async () => {
+test("relaunch WITH overrides uses override images verbatim (no auto-carry)", async () => {
   const store = new SessionStore(":memory:");
   const root = mkdtempSync(join(tmpdir(), "relaunch-imgroot-"));
   const wt = mkdtempSync(join(tmpdir(), "relaunch-imgwt-"));
@@ -3104,44 +3105,49 @@ test("relaunch images override appends to the carried-over originals", async () 
 
     await service.relaunch(orig.id, undefined, { images: ["/stage/supplied.jpg"] });
 
-    // The new session's spawn argv carries BOTH the copied original and the supplied one.
+    // With overrides present, the composer is authoritative: copyOriginalUploads must NOT
+    // run, so the staging dir is absent or empty (no carried originals re-staged).
+    const stagingDir = join(root, ".shepherd-uploads-staging");
+    if (existsSync(stagingDir)) expect(readdirSync(stagingDir)).toHaveLength(0);
+
+    // Spawn argv carries ONLY the supplied override, never a copied original.
     const argv = calls.started[0]!.argv;
     const promptArg = argv[argv.length - 1]!;
     expect(promptArg).toContain("Attached images:");
-    // moveUploads mock maps each staged path to <wt>/.shepherd-uploads/<basename>
-    expect(promptArg).toMatch(/\.shepherd-uploads\/.+\.png/); // copied original
-    expect(promptArg).toContain("supplied.jpg"); // supplied override appended
+    expect(promptArg).toContain("supplied.jpg"); // the authoritative override list
+    expect(promptArg).not.toContain("orig"); // no auto-carried original
+    expect(promptArg).not.toMatch(/\.png/); // only the supplied .jpg made it
   } finally {
     config.repoRoot = prevRoot;
   }
 });
 
-test("relaunch caps the merged image list at MAX_IMAGES, carried-over originals first", async () => {
+test("stageRelaunchImages copies worktree uploads into staging, caps at MAX_IMAGES, returns path+name", () => {
   const store = new SessionStore(":memory:");
-  const root = mkdtempSync(join(tmpdir(), "relaunch-caproot-"));
-  const wt = mkdtempSync(join(tmpdir(), "relaunch-capwt-"));
+  const root = mkdtempSync(join(tmpdir(), "relaunch-stageroot-"));
+  const wt = mkdtempSync(join(tmpdir(), "relaunch-stagewt-"));
   const uploads = join(wt, ".shepherd-uploads");
   mkdirSync(uploads, { recursive: true });
-  // 8 carried-over originals + 5 supplied overrides = 13 → must cap to 10.
-  for (let i = 0; i < 8; i++) writeFileSync(join(uploads, `orig${i}.png`), "PNGDATA");
+  // More than MAX_IMAGES originals on disk → staging must cap at MAX_IMAGES.
+  for (let i = 0; i < 12; i++) writeFileSync(join(uploads, `orig${i}.png`), "PNGDATA");
 
   const prevRoot = config.repoRoot;
   config.repoRoot = root;
   try {
-    const { service, calls } = relaunchHarness(store);
+    const { service } = relaunchHarness(store);
     const orig = originalSession(store, { worktreePath: wt });
 
-    await service.relaunch(orig.id, undefined, {
-      images: ["/stage/a.jpg", "/stage/b.jpg", "/stage/c.jpg", "/stage/d.jpg", "/stage/e.jpg"],
-    });
+    const staged = service.stageRelaunchImages(orig.id);
 
-    const argv = calls.started[0]!.argv;
-    const promptArg = argv[argv.length - 1]!;
-    const moved = promptArg.split("Attached images:\n")[1]!.trim().split("\n");
-    expect(moved).toHaveLength(10); // capped from 13
-    // Originals come first and all 8 fit, so only 2 of the 5 supplied survive the cap.
-    const survivingSupplied = moved.filter((p) => /\/[a-e]\.jpg$/.test(p));
-    expect(survivingSupplied).toHaveLength(2);
+    expect(staged).toHaveLength(MAX_IMAGES);
+    const stagingDir = join(root, ".shepherd-uploads-staging");
+    for (const entry of staged) {
+      expect(entry.path.startsWith(stagingDir)).toBe(true);
+      expect(entry.name.length).toBeGreaterThan(0);
+      expect(entry.name).toBe(entry.path.split("/").pop()!);
+    }
+    // originals on disk untouched (all 12 still present)
+    expect(readdirSync(uploads)).toHaveLength(12);
   } finally {
     config.repoRoot = prevRoot;
   }

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1,5 +1,12 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readdirSync,
+  existsSync,
+  utimesSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionStore } from "../src/store";
@@ -3148,6 +3155,41 @@ test("stageRelaunchImages copies worktree uploads into staging, caps at MAX_IMAG
     }
     // originals on disk untouched (all 12 still present)
     expect(readdirSync(uploads)).toHaveLength(12);
+  } finally {
+    config.repoRoot = prevRoot;
+  }
+});
+
+test("stageRelaunchImages reclaims abandoned staged uploads past the TTL before copying", () => {
+  const store = new SessionStore(":memory:");
+  const root = mkdtempSync(join(tmpdir(), "relaunch-sweeproot-"));
+  const wt = mkdtempSync(join(tmpdir(), "relaunch-sweepwt-"));
+  const uploads = join(wt, ".shepherd-uploads");
+  mkdirSync(uploads, { recursive: true });
+  writeFileSync(join(uploads, "orig.png"), "PNGDATA");
+
+  const stagingDir = join(root, ".shepherd-uploads-staging");
+  mkdirSync(stagingDir, { recursive: true });
+  // An abandoned carry from a prior cancelled open, aged well past the 24h TTL.
+  const stale = join(stagingDir, "stale.png");
+  writeFileSync(stale, "OLD");
+  utimesSync(stale, 1000, 1000); // mtime ~1970 → past TTL
+  // A fresh, in-flight upload (recent mtime) that must survive the sweep.
+  const fresh = join(stagingDir, "fresh.png");
+  writeFileSync(fresh, "NEW");
+
+  const prevRoot = config.repoRoot;
+  config.repoRoot = root;
+  try {
+    const { service } = relaunchHarness(store);
+    const orig = originalSession(store, { worktreePath: wt });
+
+    const staged = service.stageRelaunchImages(orig.id);
+
+    expect(existsSync(stale)).toBe(false); // aged orphan reclaimed
+    expect(existsSync(fresh)).toBe(true); // recent upload untouched
+    expect(staged).toHaveLength(1); // the carried original still staged
+    expect(existsSync(staged[0]!.path)).toBe(true);
   } finally {
     config.repoRoot = prevRoot;
   }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -615,6 +615,7 @@
   "relaunch_in_progress": "Neustart läuft bereits",
   "relaunch_issue_unresolved": "Das verknüpfte Issue konnte nicht erneut aufgelöst werden – Original behalten, später erneut versuchen",
   "relaunch_failed": "Neustart fehlgeschlagen – das Original wurde behalten",
+  "relaunch_images_carry_failed": "Bilder des Originals konnten nicht geladen werden – bei Bedarf erneut anhängen.",
   "viewport_herdr_unreachable": "── herdr nicht erreichbar; Neuverbindung pausiert ──",
   "viewport_reconnect_title": "Neu verbinden",
   "viewport_reconnect_sub": "herdr ist offline. Tippen, sobald es zurück ist.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -615,6 +615,7 @@
   "relaunch_in_progress": "Relaunch already in progress",
   "relaunch_issue_unresolved": "Couldn't re-resolve the linked issue; original kept, retry later",
   "relaunch_failed": "Couldn't relaunch; the original was kept",
+  "relaunch_images_carry_failed": "Couldn't load the original's images — re-attach them if needed.",
   "viewport_herdr_unreachable": "── herdr unreachable; reconnect paused ──",
   "viewport_reconnect_title": "Reconnect",
   "viewport_reconnect_sub": "herdr is down. Tap once it's back.",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -371,6 +371,18 @@ export async function relaunchSession(
   throw new ApiError(r.status, base.message, body?.code);
 }
 
+/**
+ * Stage the original session's uploads for a relaunch-elsewhere so the composer
+ * can seed them as removable chips. Returns the carried images (server path +
+ * display name); throws a `failed` error on a non-2xx response.
+ */
+export async function stageRelaunchImages(id: string): Promise<{ path: string; name: string }[]> {
+  const r = await fetch(`/api/sessions/${id}/relaunch-uploads`, { method: "POST" });
+  if (!r.ok) throw await failed(r, "relaunch-uploads");
+  const body = (await r.json()) as { images?: { path: string; name: string }[] };
+  return body.images ?? [];
+}
+
 export async function dismissStall(id: string): Promise<void> {
   const r = await fetch(`/api/sessions/${id}/dismiss-stall`, { method: "POST" });
   if (!r.ok) throw await failed(r, "dismiss-stall");

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import NewTask from "./NewTask.svelte";
+import { m } from "$lib/paraglide/messages";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+const base = (extra: Record<string, unknown> = {}) => ({
+  onsubmit: vi.fn(),
+  ...extra,
+});
+
+describe("NewTask initialImages seed", () => {
+  it("renders a removable chip per seeded image", async () => {
+    render(NewTask, {
+      props: base({
+        initialImages: [
+          { path: "/srv/a.png", name: "a.png" },
+          { path: "/srv/b.png", name: "b.png" },
+        ],
+      }),
+    });
+
+    await expect.element(page.getByText("a.png")).toBeInTheDocument();
+    await expect.element(page.getByText("b.png")).toBeInTheDocument();
+    // Each seeded chip carries its own remove control.
+    const removers = page.getByRole("button", { name: m.newtask_remove_image_aria() }).all();
+    expect(removers.length).toBe(2);
+  });
+
+  it("renders no chips when initialImages is omitted", async () => {
+    render(NewTask, { props: base() });
+    expect(document.querySelector(".chip")).toBeNull();
+  });
+
+  it("removing a seeded chip drops it without mutating the others", async () => {
+    render(NewTask, {
+      props: base({
+        initialImages: [
+          { path: "/srv/a.png", name: "a.png" },
+          { path: "/srv/b.png", name: "b.png" },
+        ],
+      }),
+    });
+
+    await page.getByRole("button", { name: m.newtask_remove_image_aria() }).first().click();
+
+    expect(page.getByText("a.png").query()).toBeNull();
+    await expect.element(page.getByText("b.png")).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -33,6 +33,7 @@
     relaunch = false,
     initialBaseBranch,
     relaunchIssueNumber,
+    initialImages,
   }: {
     onsubmit: (input: {
       repoPath: string;
@@ -55,6 +56,7 @@
     relaunch?: boolean;
     initialBaseBranch?: string;
     relaunchIssueNumber?: number | null;
+    initialImages?: { path: string; name: string }[];
   } = $props();
 
   /** Short editable seed so the user only adds deltas; the body rides out-of-band. */
@@ -112,7 +114,9 @@
   // Echoed on the submit button so the destination repo is visible at commit time.
   const selectedRepoName = $derived(repos.find((r) => r.path === repoPath)?.name ?? "");
   let branches = $state<string[]>([]);
-  let images = $state<{ path: string; name: string }[]>([]);
+  // intentional one-time seed; NewTask remounts per open
+  // svelte-ignore state_referenced_locally
+  let images = $state<{ path: string; name: string }[]>(initialImages ? [...initialImages] : []);
   let dragging = $state(false);
   let uploading = $state(false);
   let fileInput = $state<HTMLInputElement>();

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -898,6 +898,22 @@
     // Guard a double-invoke while a slow upload-stage is in flight (don't double-seed).
     if (relaunchStaging) return;
     relaunchStaging = true;
+    // Stage the original's uploads FIRST and assign the relaunch/compose seed state only
+    // AFTER it resolves: a bare New-Task opener (onnew) can fire during this await, and if
+    // relaunchOriginalId were already set the composer would mount in a half-set relaunch
+    // state (and submit would wrongly archive the original). On failure, seed empty + warn
+    // so the operator knows to re-attach (never double-attach).
+    let staged: { path: string; name: string }[] = [];
+    try {
+      staged = await stageRelaunchImages(id);
+    } catch {
+      toasts.info(m.relaunch_images_carry_failed(), { alert: true });
+    } finally {
+      relaunchStaging = false;
+    }
+    // No await past this point: assign all seeds + open synchronously so nothing can
+    // interleave a half-set state. NewTask's one-time initialImages seed reads composeImages
+    // at mount, so it must be set before showNew flips true.
     composePrompt = s.prompt;
     composeRepoPath = s.repoPath;
     composeBaseBranch = s.baseBranch;
@@ -908,17 +924,7 @@
     composeIssue = null;
     relaunchIssueNumber = s.issueNumber;
     relaunchOriginalId = id;
-    // Stage the original's uploads so the composer seeds them as removable chips. On
-    // failure, seed empty + warn so the operator knows to re-attach (never double-attach).
-    try {
-      composeImages = await stageRelaunchImages(id);
-    } catch {
-      composeImages = [];
-      toasts.info(m.relaunch_images_carry_failed(), { alert: true });
-    } finally {
-      relaunchStaging = false;
-    }
-    // Open AFTER the seed resolves so NewTask's one-time initialImages seed picks it up at mount.
+    composeImages = staged;
     showNew = true;
   }
 

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -8,6 +8,7 @@
     startMergeTrain,
     archiveSession,
     relaunchSession,
+    stageRelaunchImages,
     ApiError,
     getUsageLimits,
     replySession,
@@ -218,6 +219,11 @@
   let composeBaseBranch = $state<string | null>(null);
   // Relaunch source issue number (null = none); drives the relaunch note's cross-repo issue-drop line.
   let relaunchIssueNumber = $state<number | null>(null);
+  // Carried images from the original session, staged on relaunch-elsewhere so the composer
+  // seeds them as removable chips (its image list is the single source of truth on submit).
+  let composeImages = $state<{ path: string; name: string }[]>([]);
+  // Re-entrancy guard so a double-invoke while staging is in flight doesn't double-seed.
+  let relaunchStaging = $state(false);
   let backlog = $state<BacklogPayload | null>(null);
   // loaded once on mount (previewHost etc.); re-read on settings close.
   let settings = $state<Settings_ | null>(null);
@@ -817,6 +823,7 @@
     composeBaseBranch = null;
     relaunchOriginalId = null;
     relaunchIssueNumber = null;
+    composeImages = [];
   }
 
   // Relaunch-elsewhere submit: route to relaunchSession(originalId, overrides) instead of
@@ -885,9 +892,12 @@
   // Relaunch elsewhere: open the New Task composer pre-filled from this session so the
   // operator can pick a different repo / base branch / prompt before submitting. The
   // submit routes through onsubmit's relaunch branch (relaunchOriginalId set).
-  function onrelaunchElsewhere(id: string) {
+  async function onrelaunchElsewhere(id: string) {
     const s = store.sessions.find((x) => x.id === id);
     if (!s) return;
+    // Guard a double-invoke while a slow upload-stage is in flight (don't double-seed).
+    if (relaunchStaging) return;
+    relaunchStaging = true;
     composePrompt = s.prompt;
     composeRepoPath = s.repoPath;
     composeBaseBranch = s.baseBranch;
@@ -898,6 +908,17 @@
     composeIssue = null;
     relaunchIssueNumber = s.issueNumber;
     relaunchOriginalId = id;
+    // Stage the original's uploads so the composer seeds them as removable chips. On
+    // failure, seed empty + warn so the operator knows to re-attach (never double-attach).
+    try {
+      composeImages = await stageRelaunchImages(id);
+    } catch {
+      composeImages = [];
+      toasts.info(m.relaunch_images_carry_failed(), { alert: true });
+    } finally {
+      relaunchStaging = false;
+    }
+    // Open AFTER the seed resolves so NewTask's one-time initialImages seed picks it up at mount.
     showNew = true;
   }
 
@@ -1459,6 +1480,7 @@
     initialBaseBranch={composeBaseBranch ?? undefined}
     initialIssue={composeIssue ?? undefined}
     {relaunchIssueNumber}
+    initialImages={composeImages}
     initialPrompt={composePrompt ?? undefined}
     initialModel={composeModel ?? undefined}
     defaultModel={settings?.defaultModel}


### PR DESCRIPTION
## Problem

"Relaunching a task in another repo loses the image attachment."

The image is **not** actually lost server-side — `service.relaunch()` already auto-carried the original's uploads *and merged* them with any override images. The real bug: the **relaunch-elsewhere composer never showed the carried image**, so the operator assumed it was dropped, re-attached it, and the server merge produced a **double**.

## Fix — make the composer the single source of truth

**Server**
- `service.relaunch()` now auto-carries the original's uploads **only on a bare quick-relaunch** (no overrides). When overrides are present it uses `overrides.images` **verbatim** — no merge, so no double.
- New `service.stageRelaunchImages(id)` copies the original's worktree uploads into staging (capped at `MAX_IMAGES`), returning `{ path, name }[]`.
- New route `POST /api/sessions/:id/relaunch-uploads` exposes it (404 missing / 409 archived / 200 `{ images }`).

**UI**
- `onrelaunchElsewhere` stages the carried images via that endpoint and **seeds the composer's image chips** before opening it — visible and removable. A `relaunchStaging` re-entrancy guard prevents double-invoke; a staging failure surfaces a **fail-closed toast** (operator told to re-attach) rather than a silent empty composer.
- `NewTask` gained an `initialImages` one-time seed prop; the existing chip render / remove / submit path is unchanged.
- One new i18n key (`relaunch_images_carry_failed`, EN + DE).

The composer's image list now flows straight through as `overrides.images` → validated against the staging dir → used verbatim → moved into the new worktree. Exactly one copy.

## Behavior

| Action | Result |
| --- | --- |
| Relaunch-elsewhere, don't touch images | Original's image shown as a chip → **exactly one** in the new session |
| Remove the chip, submit | New session has **no** image |
| Add a second image | New session has **two** |
| Bare quick-relaunch (no composer) | Auto-carry unchanged (regression-tested) |

## Tests
- `service.test.ts`: kept quick-relaunch carry test; replaced the old "appends/merges" test with a **verbatim / no-auto-carry** assertion; added a `stageRelaunchImages` cap + path/name + originals-untouched test.
- `server-relaunch.test.ts`: new `relaunch-uploads` route tests (200/404/409); de-staled the threaded-images test title/comment.
- `NewTask.browser.test.ts` (new): seeded chips render, per-chip removal, copy-not-mutate.

Root: `lint` ✓ · `tsc --noEmit` ✓ · `bun test ./test` ✓ (one pre-existing **environmental** failure, `installedPluginIds`, unrelated to this diff — passes in CI's clean container). UI: `check` ✓ · `check:i18n` ✓ · `test` ✓.

Classified `fix:` (no user-facing feature catalog entry required). No linked GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
