### PR TITLE
fix(review): center the verdict popover as a modal sheet on touch

### DIFF
--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import type { GitState } from "$lib/types";
+import type { GitState, ReviewVerdict } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 
 // GitRail loads PR state from $lib/api.gitState on mount; mock it to a populated
@@ -46,7 +46,7 @@ const { default: GitRail } = await import("./GitRail.svelte");
 // The plan-gate reviewing store drives the auto-pill pulse for plan reviews,
 // mirroring the critic (reviews) store. Imported from the same module the
 // component reads so toggling it reactively updates the rendered pill.
-const { planGates } = await import("$lib/reviews.svelte");
+const { planGates, reviews } = await import("$lib/reviews.svelte");
 
 // Deterministic measurement: pin the rail's font so CI (no Berkeley Mono) and
 // local agree. The rail mounts into a fixed-width host cell. On desktop the
@@ -539,5 +539,155 @@ describe("GitRail — plan review pulses the automation pill", () => {
       expect(pill!.classList.contains("reviewing"), "pulse cleared").toBe(false),
     );
     expect(pill!.getAttribute("aria-busy")).toBe("false");
+  });
+});
+
+describe("GitRail — review popover is a modal dialog with real focus semantics", () => {
+  // A changes_requested verdict whose body contains a markdown link, so the
+  // Tab-trap's DYNAMIC enumeration must include the rendered <a> (the body is
+  // sanitized markdown → it lands inside .rv-body as a real focusable link).
+  const verdict: ReviewVerdict = {
+    sessionId: baseProps.sessionId,
+    headSha: "deadbeef",
+    decision: "changes_requested",
+    summary: "Two issues to address before merge.",
+    body: "See [the failing case](https://example.com/issue) and fix the guard.",
+    findings: ["fix the guard"],
+    addressRound: 0,
+    addressCap: 2,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 900000,
+    updatedAt: Date.now(),
+  };
+
+  beforeEach(() => {
+    reviews.apply({ id: baseProps.sessionId, review: verdict });
+  });
+  afterEach(() => {
+    reviews.drop(baseProps.sessionId);
+  });
+
+  // Open the popover by clicking the REVIEWED/CHANGES verdict chip; returns the
+  // chip (opener), the dialog, and the host. Waits a microtask flush so the
+  // dynamically-imported marked+DOMPurify body render resolves before asserting.
+  async function openReview(h: HTMLElement) {
+    const chip = h.querySelector<HTMLButtonElement>("button.verdict-chip");
+    expect(chip, "verdict chip present").not.toBeNull();
+    chip!.click();
+    const dialog = await vi.waitFor(() => {
+      const d = h.querySelector<HTMLElement>(".review-pop");
+      expect(d, "review dialog opened").not.toBeNull();
+      return d!;
+    });
+    // give marked+DOMPurify (dynamic import in an $effect) a tick to render the body
+    await vi.waitFor(() => {
+      expect(dialog.querySelector(".rv-body a"), "body link rendered").not.toBeNull();
+    });
+    return { chip: chip!, dialog };
+  }
+
+  it("dialog has role=dialog AND aria-modal=true", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+
+    const { dialog } = await openReview(h);
+    expect(dialog.getAttribute("role")).toBe("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("moves focus into the dialog on open", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+
+    const { dialog } = await openReview(h);
+    await vi.waitFor(() => {
+      expect(dialog.contains(document.activeElement), "focus inside the dialog").toBe(true);
+    });
+  });
+
+  it("restores focus to the opener chip when closed via the ✕ button", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+
+    const { chip, dialog } = await openReview(h);
+    const closeBtn = dialog.querySelector<HTMLButtonElement>(
+      `button[aria-label="${m.common_close()}"]`,
+    );
+    expect(closeBtn, "close button present").not.toBeNull();
+    closeBtn!.click();
+    await vi.waitFor(() => {
+      expect(h.querySelector(".review-pop"), "dialog closed").toBeNull();
+      expect(document.activeElement, "focus restored to opener").toBe(chip);
+    });
+  });
+
+  it("restores focus to the opener chip when closed via Escape", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+
+    const { chip } = await openReview(h);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await vi.waitFor(() => {
+      expect(h.querySelector(".review-pop"), "dialog closed").toBeNull();
+      expect(document.activeElement, "focus restored to opener").toBe(chip);
+    });
+  });
+
+  it("Tab from the last focusable node wraps to the first (trap stays inside)", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+
+    const { dialog } = await openReview(h);
+    const focusables = dialog.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    expect(focusables.length, "more than one focusable").toBeGreaterThan(1);
+    // the rendered body link must be in the enumerated set
+    expect(
+      [...focusables].some((n) => n.matches(".rv-body a")),
+      "body link in trap set",
+    ).toBe(true);
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    last.focus();
+    dialog.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    expect(document.activeElement, "Tab wraps last → first").toBe(first);
+  });
+
+  it("Shift+Tab from the first focusable node wraps to the last", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+
+    const { dialog } = await openReview(h);
+    const focusables = dialog.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    first.focus();
+    dialog.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true }),
+    );
+    expect(document.activeElement, "Shift+Tab wraps first → last").toBe(last);
   });
 });

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -58,6 +58,12 @@
   // Critic-findings popover (read the full verdict body without leaving the app)
   let showReview = $state(false);
   let wrapEl = $state<HTMLElement | null>(null);
+  // The findings popover is modal (a scrim makes it modal on every size), so it
+  // needs real focus semantics: focus moves in on open, restores to the opener on
+  // close, and Tab is trapped inside. reviewPopEl is the dialog container;
+  // reviewOpener is the chip that opened it (so focus can return there).
+  let reviewPopEl = $state<HTMLElement | null>(null);
+  let reviewOpener: HTMLElement | null = null;
 
   // Repo-automation panel (pill-anchored popover; replaces the icon-toggle horde)
   let showAutomation = $state(false);
@@ -113,9 +119,13 @@
     retry = null;
   }
 
-  function toggleReview() {
+  function toggleReview(e?: Event) {
     showReview = !showReview;
     if (showReview) {
+      // remember which chip opened the dialog so focus can be restored on close;
+      // fall back to the active element (e.g. keyboard activation without currentTarget)
+      reviewOpener =
+        (e?.currentTarget as HTMLElement | null) ?? (document.activeElement as HTMLElement | null);
       showPr = false; // one popover at a time
       showAutomation = false;
     }
@@ -143,6 +153,48 @@
     if (wrapEl && !wrapEl.contains(e.target as Node)) {
       if (showReview) showReview = false;
       if (showAutomation) showAutomation = false;
+    }
+  }
+
+  // Modal focus management for the findings dialog, scoped strictly to showReview
+  // (the PR popover + AutomationPanel are unaffected). On open: move focus into the
+  // dialog. On close: restore focus to the opener — guarded so a now-detached opener
+  // (e.g. a session switch reset showReview while the dialog was open) is a no-op.
+  $effect(() => {
+    if (showReview && reviewPopEl) {
+      reviewPopEl.focus();
+    } else if (!showReview) {
+      const opener = reviewOpener;
+      reviewOpener = null;
+      if (opener?.isConnected) opener.focus();
+    }
+  });
+
+  // Minimal Tab focus-trap. Focusable nodes are enumerated DYNAMICALLY at trap time
+  // so links inside the rendered (sanitized markdown) body are included; the dialog
+  // container itself (tabindex="-1") is excluded by the selector.
+  function onReviewKeydown(e: KeyboardEvent) {
+    if (e.key !== "Tab" || !reviewPopEl) return;
+    const nodes = reviewPopEl.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    if (nodes.length === 0) {
+      e.preventDefault();
+      return;
+    }
+    const first = nodes[0];
+    const last = nodes[nodes.length - 1];
+    const active = document.activeElement;
+    if (e.shiftKey) {
+      if (active === first || active === reviewPopEl) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (active === last || active === reviewPopEl) {
+        e.preventDefault();
+        first.focus();
+      }
     }
   }
 
@@ -434,7 +486,7 @@
             aria-haspopup="dialog"
             aria-expanded={showReview}
             title={m.criticbadge_reviewing_title()}
-            onclick={toggleReview}
+            onclick={(e) => toggleReview(e)}
           >
             <span class="rev-dot" aria-hidden="true"></span>{m.criticbadge_reviewing()}
           </button>
@@ -450,7 +502,7 @@
           aria-haspopup="dialog"
           aria-expanded={showReview}
           title={m.gitrail_review_title()}
-          onclick={toggleReview}
+          onclick={(e) => toggleReview(e)}
         >
           {chip.label}
         </button>
@@ -542,7 +594,15 @@
     {/if}
 
     {#if showReview && verdict}
-      <div class="review-pop" role="dialog" aria-label={m.gitrail_review_title()}>
+      <div
+        class="review-pop"
+        role="dialog"
+        aria-modal="true"
+        aria-label={m.gitrail_review_title()}
+        tabindex="-1"
+        bind:this={reviewPopEl}
+        onkeydown={onReviewKeydown}
+      >
         <div class="review-head">
           {#if chip.kind === "reviewing"}
             <span class="rv-label critic-reviewing" title={m.criticbadge_reviewing_title()}>
@@ -925,7 +985,10 @@
   }
 
   /* findings popover: same anchoring as .pr-pop, wider + scrollable body.
-     Rides above .review-scrim (z-index 50) so it stays lit while the page dims. */
+     Rides above .review-scrim (z-index 50) so it stays lit while the page dims.
+     On touch (@media pointer: coarse, below) this absolute anchor is overridden
+     into a centered fixed modal sheet — anchored to the 44px strip it would hang
+     below and clip the body + action footer out of reach. */
   .review-pop {
     position: absolute;
     top: 100%;
@@ -1129,5 +1192,30 @@
     border-top: 1px solid var(--color-line);
     /* pinned footer: never compressed away by a tall body */
     flex-shrink: 0;
+  }
+
+  /* Touch layouts (phones + unfolded folds — the repo's canonical coarse-pointer
+     gate). The strip is position:static here, so the absolute .review-pop hangs
+     below the 44px strip and clips. Override it into a centered fixed modal sheet
+     over the existing .review-scrim. z-index:51 already sits above the scrim's 50;
+     the existing overflow:hidden + .rv-body scroller + pinned head/footer keep the
+     action footer reachable. */
+  @media (pointer: coarse) {
+    .review-pop {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      right: auto;
+      transform: translate(-50%, -50%);
+      margin-top: 0;
+      width: min(480px, 92vw);
+      max-height: 85vh;
+    }
+    /* the rail's 40px tap-target rule is scoped to .rail.mobile, not this popover —
+       give the dialog's own controls a ≥40px touch target too */
+    .review-head .gbtn,
+    .review-actions .gbtn {
+      min-height: 40px;
+    }
   }
 </style>


### PR DESCRIPTION
## Problem

On touch layouts (phone + unfolded fold), the code-review verdict popover (`GitRail.svelte`'s `.review-pop`, opened by the **REVIEWED** chip in the viewport git strip) is clipped: `.git-rail-wrap.mobile` goes `position:static`, so the popover anchors `position:absolute; top:100%` to the 44px-tall `.vp-git-strip` and hangs below it, cut off. Neither the full verdict body nor the **send-to-agent** action footer is reachable — there's no way to read the review or act on it from a phone.

## Fix

Two small, related changes in `GitRail.svelte`:

1. **Geometry (CSS, gated on `@media (pointer: coarse)`).** Promote `.review-pop` to a centered `position:fixed` modal sheet (`top/left:50%; translate(-50%,-50%); width:min(480px,92vw); max-height:85vh`) over the **already-existing** `.review-scrim` (dim+blur — design-system rule #5 compliant). Escapes the strip/overflow clip entirely; the existing internal `.rv-body` scroller + pinned head/footer keep the full body readable and the action button reachable. The popover's own controls get a ≥40px touch target. `(pointer: coarse)` is the repo's canonical touch gate, so this catches phones **and** unfolded folds while leaving **desktop fine-pointer geometry untouched**.

2. **Modal focus semantics (JS, all sizes).** The dialog already rendered a full-page scrim but lacked modal a11y. Added `aria-modal="true"`, focus-move-into-dialog on open, focus-restore-to-opener on close (safe no-op when the opener detaches on a session switch), and a minimal Tab focus-trap. The trap **enumerates focusables dynamically each keydown** (so sanitized markdown body links inside `.rv-body` are included and the `tabindex="-1"` container is excluded). Escape + click-outside-scrim dismissal preserved; logic scoped strictly to `showReview`, so `.pr-pop` / AutomationPanel are unaffected.

### Why `position:fixed` is safe under `.viewport`'s swipe transform
`.viewport` gets a `translateX` transform while `swipeX !== 0`, which would re-anchor `fixed` descendants. Verified benign: the swipe handler only runs in narrow `mobile` mode (folds never transform); swipes only arm from inside `.vp-body`, and while the popover is open the full-page scrim covers `.vp-body` and dismisses on touch — so open ⇄ swipe are mutually exclusive. Even in the sub-200ms snap-back race, re-anchoring is to the **full-screen** `.viewport`, not the 44px strip, so the strip-clip cannot recur.

## Scope notes
- Desktop fine-pointer keeps its anchored dropdown geometry (only the focus semantics are added). Known-unsolved residual: desktop `gitOpen` on a very short window can still clip the anchored dropdown's footer — out of scope per the reported touch bug.
- `.pr-pop` / AutomationPanel popovers share the anchored pattern but are non-modal (no scrim); converting them would be a separate design change. Not touched.
- `fix`, no new user-facing strings → no i18n keys and no feature-catalog entry required.

## Testing
- `cd ui && bun run check` → 0 errors. `cd ui && bun run test` → 77 files / 1072 tests pass.
- New deterministic, pointer-independent tests in `GitRail.browser.test.ts` (real-browser vitest): open the popover via the REVIEWED chip and assert `role="dialog"` + `aria-modal="true"`, focus-in on open, focus-restore on ✕ and Escape, and Tab/Shift+Tab **wrap** within the dialog — with a verdict body containing a markdown link, proving the trap's dynamic enumeration includes the rendered body link.
- The `(pointer: coarse)` fixed-sheet geometry itself isn't machine-assertable (the harness can't emulate a coarse pointer); verified manually in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)