### PR TITLE
fix(ci): correct release-please CI framing; skip verify/hygiene on its PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ concurrency:
 jobs:
   verify:
     name: verify
+    # Skip release-please's own bot PRs: opened by github-actions[bot], they're
+    # parked behind GitHub's "Approve and run" gate and never auto-run, so they'd
+    # just accrue as awaiting-approval noise. release-please uses GITHUB_TOKEN by
+    # design (see release-please.yml) precisely so release PRs don't need CI.
+    # head_ref is empty on push-to-main, so this stays true there.
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     # Runner toggle for the closed-source phase: set the repo variable CI_RUNNER to
     # 'self-hosted' to run on the local self-hosted runner (saves included minutes).
     # Unset/empty falls back to ubuntu-latest. MUST be deleted before the repo goes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,12 @@ concurrency:
 jobs:
   verify:
     name: verify
-    # Skip release-please's own bot PRs: opened by github-actions[bot], they're
-    # parked behind GitHub's "Approve and run" gate and never auto-run, so they'd
-    # just accrue as awaiting-approval noise. release-please uses GITHUB_TOKEN by
-    # design (see release-please.yml) precisely so release PRs don't need CI.
-    # head_ref is empty on push-to-main, so this stays true there.
+    # Don't run the full suite on release-please's generated PR: it only bumps the
+    # version + CHANGELOG, so verify is wasted minutes. That PR DOES trigger this
+    # workflow (event=pull_request, actor=github-actions[bot]) — see release-please.yml.
+    # head_ref is empty on push-to-main, so main still runs. NB: this only skips the
+    # JOB once the run starts; GitHub's separate "awaiting approval" gate on bot PRs
+    # is a repo Actions setting, not something a workflow file can control.
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     # Runner toggle for the closed-source phase: set the repo variable CI_RUNNER to
     # 'self-hosted' to run on the local self-hosted runner (saves included minutes).

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   branch-hygiene:
     name: branch hygiene
+    # Skip release-please's own bot PRs: opened by github-actions[bot], they sit
+    # behind GitHub's "Approve and run" gate and never run, so they'd only accrue
+    # as awaiting-approval noise. Branch hygiene is moot on a generated release PR.
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     # Runner toggle for the closed-source phase: set the repo variable CI_RUNNER to
     # 'self-hosted' to run on the local self-hosted runner (saves included minutes).
     # Unset/empty falls back to ubuntu-latest. MUST be deleted before the repo goes

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -12,9 +12,9 @@ jobs:
     name: branch hygiene
     # Branch-hygiene is moot on release-please's generated PR — it's a clean,
     # auto-maintained branch off main — and that PR DOES trigger this workflow
-    # (see release-please.yml), so guard the job off for it. head_ref is empty on
-    # push, so non-release PRs are unaffected. This does NOT touch GitHub's separate
-    # bot-PR "awaiting approval" gate, which is a repo Actions setting.
+    # (see release-please.yml), so guard the job off for it. Non-release PRs run
+    # as normal: their head_ref doesn't start with `release-please--`. This does
+    # NOT touch GitHub's separate bot-PR "awaiting approval" gate (a repo setting).
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     # Runner toggle for the closed-source phase: set the repo variable CI_RUNNER to
     # 'self-hosted' to run on the local self-hosted runner (saves included minutes).

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -10,9 +10,11 @@ on:
 jobs:
   branch-hygiene:
     name: branch hygiene
-    # Skip release-please's own bot PRs: opened by github-actions[bot], they sit
-    # behind GitHub's "Approve and run" gate and never run, so they'd only accrue
-    # as awaiting-approval noise. Branch hygiene is moot on a generated release PR.
+    # Branch-hygiene is moot on release-please's generated PR — it's a clean,
+    # auto-maintained branch off main — and that PR DOES trigger this workflow
+    # (see release-please.yml), so guard the job off for it. head_ref is empty on
+    # push, so non-release PRs are unaffected. This does NOT touch GitHub's separate
+    # bot-PR "awaiting approval" gate, which is a repo Actions setting.
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     # Runner toggle for the closed-source phase: set the repo variable CI_RUNNER to
     # 'self-hosted' to run on the local self-hosted runner (saves included minutes).

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,9 +23,16 @@ jobs:
     steps:
       # Maintains a release PR that accrues a CHANGELOG from conventional
       # commits; merging it tags the version and cuts a GitHub release.
-      # Uses the default GITHUB_TOKEN — note that release PRs it opens will
-      # not trigger the `verify` CI workflow. Swap in a PAT via
-      # `token: ${{ secrets.RELEASE_PLEASE_TOKEN }}` if you need CI on them.
+      # Uses the default GITHUB_TOKEN. The release PR it opens DOES trigger the
+      # CI + PR-hygiene workflows (observed: event=pull_request, actor=
+      # github-actions[bot]); both short-circuit on `release-please--*` head
+      # branches via their job `if:` guards, so verify/hygiene don't burn minutes
+      # on a generated release PR. Separately, GitHub may park those bot-authored
+      # runs behind the repo's "require approval for workflows" Actions setting
+      # ("awaiting maintainer approval") — that gate is a repo/org setting, not
+      # controllable here. Swap in a PAT via `token: secrets.RELEASE_PLEASE_TOKEN`
+      # (a maintainer's token isn't approval-gated) if you want those runs to
+      # execute without manual approval.
       - uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json


### PR DESCRIPTION
## What

Release-please's generated PR (`chore(main): release …`, authored by `github-actions[bot]`) **does** trigger the `CI` and `PR hygiene` workflows — verified from run data (`event=pull_request`, `actor=github-actions[bot]`, on the `release-please--…` branch; some runs executed, some parked behind the approval gate). Running full `verify` + branch-hygiene on a version-bump/CHANGELOG PR is wasted work, so guard both jobs off for release branches.

## Changes

- **`ci.yml` / `pr-hygiene.yml`:** add `if: ${{ !startsWith(github.head_ref, 'release-please--') }}` to the `verify` / `branch-hygiene` jobs. `head_ref` is empty on `push`-to-main and on normal feature PRs it's their own branch, so only release-please's PR is skipped. (`on.pull_request` can only filter by *base* branch — always `main` here — so a job-level guard is the standard way to skip by head branch.)
- **`release-please.yml`:** correct the stale comment that claimed its PR "will not trigger the `verify` CI workflow" — run data shows it does. Documents the real options for the separate "awaiting maintainer approval" gate.

## On the original "awaiting maintainer approval" symptom

That gate is enforced by GitHub at the **workflow-run level before any job runs**, driven by the repo's Actions approval policy for bot/contributor PRs — it is **not** controllable from a workflow file, and this PR does not claim to remove it. It's fixed by loosening that repo/org setting, or by switching release-please to a maintainer PAT (`RELEASE_PLEASE_TOKEN`) whose PRs aren't approval-gated. See the author note for the full reconciliation of the critic's points.

## Verification

- All three workflow YAMLs parse (`yaml.safe_load`).
- `github.head_ref` is used only inside `if:` expressions (never a shell `run:`), so no injection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)