### PR TITLE
fix(ci-runner): self-heal watchdog restarts dead rootless-docker egress

### DIFF
--- a/ci/self-hosted-runner/runner-liveness.sh
+++ b/ci/self-hosted-runner/runner-liveness.sh
@@ -7,10 +7,11 @@
 # runner is silently down, PR jobs don't go red — they sit QUEUED/pending forever
 # (GitHub waits indefinitely for a matching runner). A pending-but-not-failed
 # check is invisible on the PR; nobody gets paged. This watchdog is what surfaces
-# that: it runs on a timer, fails visibly in the journal when the runner is gone,
-# and best-effort desktop-notifies the operator. The outage runbook (README) is
-# then: `gh variable delete CI_RUNNER` to instantly revert to hosted runners,
-# repair the runner, re-set the variable.
+# that: it runs on a timer, and on a confirmed outage it first tries to SELF-HEAL
+# (see REMEDIATE below), then — only if that is disabled or fails — fails visibly in
+# the journal and best-effort desktop-notifies the operator. The outage runbook
+# (README) is then: `gh variable delete CI_RUNNER` to instantly revert to hosted
+# runners, repair the runner, re-set the variable.
 #
 # It checks BOTH halves of "the runner is actually serving":
 #   (a) GitHub agrees at least one registered runner is `online`, AND
@@ -35,6 +36,33 @@ set -euo pipefail
 # the per-job restart gap (5s RestartSec + container spawn + token mint), short
 # enough to alert well within one 5-min timer tick.
 RECHECK_DELAY="${RECHECK_DELAY:-15}"
+
+# SELF-HEAL: on a CONFIRMED outage (still down after the debounce re-check), try to
+# automatically remediate before alerting. Set REMEDIATE=0 to restore the old
+# alert-only behaviour. WHY this exists: the dominant real-world outage on this host
+# is rootless docker's `slirp4netns` (the per-daemon userspace NAT uplink for all
+# containers) dying/zombieing — it silently kills ALL container egress while the
+# host itself stays online, so every ephemeral runner fails `configure` with EAGAIN
+# on api.github.com and crash-loops. Restarting the runner units does NOT fix it
+# (the fresh container hits the same dead slirp and re-loops); only restarting the
+# rootless docker daemon respawns a healthy slirp. This watchdog is the only thing
+# on a timer positioned to catch + auto-repair that. (2026-06-12 incident.)
+REMEDIATE="${REMEDIATE:-1}"
+
+# The ROOTLESS docker daemon the runner containers use (mirrors DOCKER_HOST from the
+# unit EnvironmentFile). The egress canary + the docker restart both target THIS
+# daemon, never the user's default/rootful docker.
+DOCKER_HOST="${DOCKER_HOST:-unix:///run/user/$(id -u)/docker.sock}"
+export DOCKER_HOST
+
+# Image for the egress canary. Defaults to the runner IMAGE (from the EnvironmentFile)
+# because it is GUARANTEED already present locally — the canary runs with --pull=never
+# so it never depends on the very egress it is testing.
+CANARY_IMAGE="${CANARY_IMAGE:-${IMAGE:-alpine}}"
+
+# How long (seconds) to wait for a healthy slirp4netns after restarting docker before
+# giving up and alerting. Restart + daemon init + slirp spawn is a few seconds.
+SLIRP_RECOVER_TIMEOUT="${SLIRP_RECOVER_TIMEOUT:-30}"
 
 # GH_REPO (owner/name) comes from the same EnvironmentFile the runner units load
 # (~/.config/shepherd-ci-runner/.env). gh resolves auth from the host login or the
@@ -89,6 +117,78 @@ probe() {
   return 0
 }
 
+# runner_instances: space-separated list of the ENABLED shepherd-ci-runner@N.service
+# instances, read from the user manager's enable symlinks so it tracks however many
+# replicas are deployed (no hard-coded 1..4).
+runner_instances() {
+  local f
+  for f in "${HOME}/.config/systemd/user/default.target.wants/"shepherd-ci-runner@*.service; do
+    [ -e "${f}" ] || continue
+    basename "${f}"
+  done | tr '\n' ' '
+}
+
+# egress_ok: returns 0 iff a throwaway container on the ROOTLESS docker daemon can
+# open a TCP/443 connection to api.github.com. This is the TRUE root-cause probe for
+# the slirp4netns failure mode: a dead slirp takes out container DNS + egress while
+# the host stays online, so a host-side check (curl from this script) misses it
+# entirely — only a container-side probe sees it. Uses bash /dev/tcp (DNS + connect,
+# both of which traverse slirp) rather than curl/wget so it needs no in-image tooling,
+# and --pull=never so it never depends on the very egress it is testing.
+egress_ok() {
+  command -v docker >/dev/null 2>&1 || return 1
+  timeout 25 docker run --rm --pull=never --network bridge "${CANARY_IMAGE}" \
+    bash -c 'exec 3<>/dev/tcp/api.github.com/443' >/dev/null 2>&1
+}
+
+# remediate: best-effort self-heal of a confirmed outage. Returns 0 if it ran its
+# repair, 1 if it could not. ORDER + blast-radius are deliberate:
+#   1. Only restart the docker daemon when the egress canary PROVES slirp is dead —
+#      that restart ABORTS any in-progress job container, so we must not do it for a
+#      transient GitHub-0-online registration gap (where the canary still PASSES).
+#   2. Restarting the runner units alone never fixes dead egress (proven 2026-06-12),
+#      so it is the SECOND lever — applied after egress is confirmed healthy.
+remediate() {
+  if ! egress_ok; then
+    echo "runner-liveness: REMEDIATE — rootless docker egress is DOWN (slirp4netns dead); restarting docker.service" >&2
+    if ! systemctl --user restart docker.service; then
+      echo "runner-liveness: REMEDIATE — docker.service restart failed" >&2
+      return 1
+    fi
+    # Wait for a healthy slirp before touching the runners — a fresh runner that
+    # races the daemon's startup would just re-fail.
+    local waited=0
+    until egress_ok; do
+      if [ "${waited}" -ge "${SLIRP_RECOVER_TIMEOUT}" ]; then
+        echo "runner-liveness: REMEDIATE — egress still down ${SLIRP_RECOVER_TIMEOUT}s after docker restart" >&2
+        return 1
+      fi
+      sleep 2
+      waited=$((waited + 2))
+    done
+    echo "runner-liveness: REMEDIATE — docker egress restored after ${waited}s" >&2
+  fi
+
+  # Egress is healthy (either it always was — a pure runner-unit fault — or we just
+  # fixed it). Clear any failed/crash-loop state and bring the ephemeral instances
+  # back up fresh.
+  local instances
+  instances="$(runner_instances)"
+  if [ -z "${instances}" ]; then
+    echo "runner-liveness: REMEDIATE — no enabled runner instances found to restart" >&2
+    return 1
+  fi
+  echo "runner-liveness: REMEDIATE — restarting runner instances: ${instances}" >&2
+  # shellcheck disable=SC2086  # intentional word-splitting of the instance list
+  systemctl --user reset-failed ${instances} 2>/dev/null || true
+  # shellcheck disable=SC2086
+  if ! systemctl --user restart ${instances}; then
+    echo "runner-liveness: REMEDIATE — runner unit restart failed" >&2
+    return 1
+  fi
+  return 0
+}
+
 # Debounce: a single down-read may just be the normal per-job restart window
 # (ephemeral runner deregistered + unit restarting). Don't alert on it — sleep
 # and re-check. Alert only if STILL down on the second read.
@@ -105,5 +205,26 @@ if status="$(probe)"; then
   exit 0
 fi
 
-# Still down after the debounce delay — this is a real outage.
+# Still down after the debounce delay — this is a real outage. Try to self-heal
+# (restart dead rootless-docker egress and/or the runner units) BEFORE alerting; a
+# successful repair turns a page-the-operator outage into a logged, auto-recovered
+# blip. Only if remediation is disabled or fails do we fall through to the alert.
+if [ "${REMEDIATE}" = "1" ]; then
+  echo "runner-liveness: confirmed DOWN (${status}) — attempting self-heal" >&2
+  if remediate; then
+    # Give the freshly-restarted ephemeral runners a moment to register, then verify.
+    sleep "${RECHECK_DELAY}"
+    if status="$(probe)"; then
+      echo "runner-liveness: SELF-HEALED — ${status}"
+      notify-send -u normal "Shepherd CI runner self-healed" \
+        "Auto-recovered after an outage; see journal for details." 2>/dev/null || true
+      exit 0
+    fi
+    echo "runner-liveness: remediation ran but runner still down on re-check" >&2
+  else
+    echo "runner-liveness: remediation could not complete" >&2
+  fi
+fi
+
+# Self-heal disabled, impossible, or unsuccessful — surface the outage.
 fail "${status}"


### PR DESCRIPTION
## Why

The CI-runner liveness watchdog only **alerted** on an outage. But the dominant real-world failure mode can't be fixed by restarting the runner units:

**Rootless docker's `slirp4netns`** (the per-daemon userspace NAT uplink for *all* containers) dies/zombies → every container loses DNS + egress while the **host stays online** → each ephemeral runner fails `configure` with `EAGAIN` on `api.github.com` and crash-loops (RestartSec=5s, 200+ restarts). GitHub shows 0 runners online; PR jobs queue pending, never red. Restarting the runner units does **not** help (the fresh container hits the same dead slirp); only restarting the rootless docker daemon respawns a healthy slirp.

This happened 2026-06-12 (~22:07) — all 4 shepherd runners down ~10 min until manual `systemctl --user restart docker.service`.

## What

On a **confirmed** outage (still down after the existing debounce re-check), `runner-liveness.sh` now self-heals before alerting:

1. **Probe true egress** — a `--pull=never` container on the rootless daemon opens TCP/443 to `api.github.com` via bash `/dev/tcp` (DNS + connect both traverse slirp; needs no in-image tooling). This is the root-cause signal a host-side check can't see.
2. **If egress is dead** → `systemctl --user restart docker.service`, wait for a healthy slirp (≤30s), then restart the runner instances.
3. **If egress is fine** but runners are down → just restart the instances (pure unit fault).
4. **Alert only** if `REMEDIATE=0` or remediation fails (unchanged `fail()` path).

### Safety / blast radius
- The docker restart **aborts in-progress job containers**, so it's gated strictly on the egress canary proving slirp is dead — never fires during normal ephemeral churn (where the canary still passes).
- **Zero overhead on the healthy path**: the canary only runs after a debounced down-read; healthy ticks exit 0 exactly as before.
- Runner instances are enumerated from the enable symlinks (no hard-coded `1..4`).
- `REMEDIATE=0` restores the old alert-only behaviour.

## Validation
- `bash -n` clean; happy-path run on the live (healthy) host → `OK`, exit 0, no remediation.
- Isolated fn tests: `runner_instances` → all 4; canary → `shepherd-ci-runner:local`, egress HEALTHY via `/dev/tcp`.
- Full pre-push gate (lint · typecheck · tests · builds · fallow) passed.

## Related
Trigger of the 2026-06-12 incident appears to be #551 (`network-egress-allowlist`): its integration tests exercise the **real** `setpriv/unshare/slirp4netns/nft/dnsmasq` machinery (and SIGKILL it), which can take out the rootless-docker daemon's slirp on the same host. Flagged separately on that PR — this watchdog is the blast-radius backstop; isolating those tests is the upstream fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)