### PR TITLE
fix(backlog): pin icon replaces PINNED text pill so repo name fits

### DIFF
--- a/ui/src/lib/components/ProjectRow.svelte
+++ b/ui/src/lib/components/ProjectRow.svelte
@@ -31,7 +31,20 @@
   <div class="row-main">
     <span class="row-name">{displayName}</span>
     {#if pinned}
-      <span class="pinned-badge">{m.backlog_pinned_label()}</span>
+      <span class="pin-icon" role="img" aria-label={m.backlog_pinned_label()}>
+        <svg
+          viewBox="0 0 16 16"
+          width="1em"
+          height="1em"
+          fill="currentColor"
+          fill-rule="evenodd"
+          aria-hidden="true"
+        >
+          <path
+            d="M8 1.4a4.3 4.3 0 0 0-4.3 4.3c0 3.2 4.3 8.6 4.3 8.6s4.3-5.4 4.3-8.6A4.3 4.3 0 0 0 8 1.4Zm0 6a1.7 1.7 0 1 1 0-3.4 1.7 1.7 0 0 1 0 3.4Z"
+          />
+        </svg>
+      </span>
     {/if}
   </div>
   <div class="row-counts">
@@ -122,15 +135,16 @@
     text-overflow: ellipsis;
   }
 
-  .pinned-badge {
-    font-size: var(--fs-micro);
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
+  .pin-icon {
+    display: inline-flex;
+    align-items: center;
     color: var(--color-amber);
-    border: 1px solid var(--color-amber);
-    border-radius: 2px;
-    padding: 1px 5px;
+    font-size: var(--fs-base);
     flex-shrink: 0;
+  }
+
+  .pin-icon svg {
+    vertical-align: -0.125em;
   }
 
   .row-counts {

--- a/ui/src/lib/components/ProjectRow.svelte
+++ b/ui/src/lib/components/ProjectRow.svelte
@@ -32,16 +32,9 @@
     <span class="row-name">{displayName}</span>
     {#if pinned}
       <span class="pin-icon" role="img" aria-label={m.backlog_pinned_label()}>
-        <svg
-          viewBox="0 0 16 16"
-          width="1em"
-          height="1em"
-          fill="currentColor"
-          fill-rule="evenodd"
-          aria-hidden="true"
-        >
+        <svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor" aria-hidden="true">
           <path
-            d="M8 1.4a4.3 4.3 0 0 0-4.3 4.3c0 3.2 4.3 8.6 4.3 8.6s4.3-5.4 4.3-8.6A4.3 4.3 0 0 0 8 1.4Zm0 6a1.7 1.7 0 1 1 0-3.4 1.7 1.7 0 0 1 0 3.4Z"
+            d="M16 9V4h1c.55 0 1-.45 1-1s-.45-1-1-1H7c-.55 0-1 .45-1 1s.45 1 1 1h1v5c0 1.66-1.34 3-3 3v2h5.97v7l1 1 1-1v-7H19v-2c-1.66 0-3-1.34-3-3z"
           />
         </svg>
       </span>


### PR DESCRIPTION
## Problem

In the Backlog repo selector ("RECENTLY WORKED ON"), the amber **PINNED** text pill ate ~7ch + border/padding next to the repo name, forcing it to truncate — `shep…` instead of `shepherd`. The pill added little but cost a lot of name width.

## Change

Replace the text pill with a compact **filled amber pin glyph** trailing the name, in `ProjectRow.svelte` (only file touched):

- Inline filled SVG (`fill="currentColor"`, `viewBox 16`, `1em`) following the existing `ThemeIcon.svelte` idiom — solid amber weight, no faint hairline, no new inline-SVG style and no over-built shared primitive for a single glyph.
- `color: var(--color-amber)` — design-system tokens only, no raw hex/rgba/px.
- `role="img"` + `aria-label={m.backlog_pinned_label()}` keeps it announced as "Pinned" to assistive tech; **no** `title` on the span (the row `<button>` already carries `title={project.display}`, so a second tooltip would overlap on hover).
- Reuses the existing `backlog_pinned_label` message — **no new i18n key**, EN/DE parity untouched.

## Before / After

Before: `shep… [PINNED]  7 Issues · 4 PRs +1 rel`
After: `shepherd 📍  7 Issues · 5 PRs +1 rel` (name renders in full)

## Verification

- `cd ui && bun run check` — 0 errors / 0 warnings
- `cd ui && bun run check:i18n` — 2 locales in parity (1079 keys each; no delta)
- `cd ui && bun run test` — 1069 tests pass
- Visually confirmed against the live backend (vite dev proxy): pinned **shepherd** row now shows the amber pin and the full name, no `shep…` ellipsis.

`[no-feature-entry]` — visual refinement of an existing indicator, not a new user-facing capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)