### PR TITLE
fix(prbadge): drop the unactionable "NO PR" pill

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -519,7 +519,6 @@
   "prbadge_open": "PR #{number}",
   "prbadge_merged": "✓ GEMERGT",
   "prbadge_closed": "GESCHLOSSEN",
-  "prbadge_none": "KEIN PR",
   "prbadge_review_approved": "Reviewer hat genehmigt",
   "prbadge_review_changes": "Reviewer fordert Änderungen",
   "prbadge_review_comment": "Reviewer hat kommentiert",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -519,7 +519,6 @@
   "prbadge_open": "PR #{number}",
   "prbadge_merged": "✓ MERGED",
   "prbadge_closed": "CLOSED",
-  "prbadge_none": "NO PR",
   "prbadge_review_approved": "Reviewer approved",
   "prbadge_review_changes": "Reviewer requested changes",
   "prbadge_review_comment": "Reviewer commented",

--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -59,7 +59,6 @@
   .pr-merged {
     color: var(--color-slate);
   }
-  .pr-none,
   .pr-closed {
     color: var(--color-faint);
   }

--- a/ui/src/lib/components/pr-badge.test.ts
+++ b/ui/src/lib/components/pr-badge.test.ts
@@ -10,8 +10,8 @@ describe("prBadgeLabel", () => {
   it("returns null for an absent entry (renders nothing)", () => {
     expect(prBadgeLabel(undefined)).toBeNull();
   });
-  it("labels state none as NO PR", () => {
-    expect(prBadgeLabel(git({ state: "none" }))).toBe("NO PR");
+  it("renders nothing (null) for state none", () => {
+    expect(prBadgeLabel(git({ state: "none" }))).toBeNull();
   });
   it("labels an open PR with its number", () => {
     expect(prBadgeLabel(git({ state: "open", number: 12 }))).toBe("PR #12");

--- a/ui/src/lib/components/pr-badge.ts
+++ b/ui/src/lib/components/pr-badge.ts
@@ -1,8 +1,9 @@
 import type { GitState } from "../types";
 import { m } from "$lib/paraglide/messages";
 
-/** Badge text for a session's PR state, or null when there is no entry to show.
- *  `none` is a real state ("NO PR"); only an absent entry renders nothing. */
+/** Badge text for a session's PR state, or null when there is nothing to show.
+ *  Both an absent entry and the `none` state render nothing; only open/merged/closed
+ *  produce a visible badge. */
 export function prBadgeLabel(git: GitState | undefined): string | null {
   if (!git) return null;
   switch (git.state) {
@@ -13,7 +14,7 @@ export function prBadgeLabel(git: GitState | undefined): string | null {
     case "closed":
       return m.prbadge_closed();
     default:
-      return m.prbadge_none();
+      return null;
   }
 }
 


### PR DESCRIPTION
## What

Stop rendering the **NO PR** pill on session cards when a session has no PR yet. `prBadgeLabel()` now returns `null` for the `none`/default git state, so `PrBadge`'s existing `{#if label}` guard renders nothing — exactly like every other state badge (CriticBadge, PlanGateBadge, AutopilotBadge) that shows nothing when it has nothing to say.

Open / merged / closed badges (`PR #N`, `✓ MERGED`, `CLOSED`) are unchanged — those carry real identifying/terminal info.

## Why

The pill isn't actionable. The **absence** of a PR badge already signals "no PR", and in list view the 5-segment Stepper's unfilled PR segment reinforces it. The "NO PR" pill was redundant noise.

## Trade-off (explicit)

The grid/tile view (`UnitTile`) has no Stepper, so removing the badge there collapses "no PR yet" and "git not loaded" into the same empty state. Accepted, user-chosen: neither is actionable, and the real signal is the presence of `PR #N`/`MERGED`/`CLOSED`.

## Changes

- `ui/src/lib/components/pr-badge.ts` — `default:` branch returns `null`; JSDoc updated.
- `ui/messages/{en,de}.json` — removed the now-dead `prbadge_none` key (parity preserved).
- `ui/src/lib/components/pr-badge.test.ts` — `none`-state test now asserts `null`.
- `ui/src/lib/components/PrBadge.svelte` — dropped the now-unreachable `.pr-none` CSS rule.

Not a `feat` (removes UX), so no feature-announcement entry.

## Verification

- `bun run check` → 0 errors, 0 warnings
- `bun run check:i18n` → 2 locales in parity (1078 keys each)
- `bun run test` → 1069 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)