### PR TITLE
fix(newtask): two-row run-settings layout so plan-gate explainer reads on one line

### DIFF
--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -537,7 +537,7 @@
   "criticbadge_final": "FINAL REVIEW",
   "criticbadge_final_title": "Addressing the last allowed round; no more rounds after this.",
   "newtask_plan_gate_label": "Plan gate",
-  "newtask_plan_gate_hint": "Grill + adversarial plan review before the agent runs",
+  "newtask_plan_gate_hint": "Grill + adversarial review before the agent runs",
   "plangate_planning": "PLANNING",
   "plangate_reviewing": "REVIEWING…",
   "plangate_changes": "REWORK · {round}/{cap}",

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -537,10 +537,10 @@
       <input id="nt-base" bind:value={baseBranch} placeholder={m.newtask_branch_placeholder()} />
     {/if}
 
-    <!-- Both are per-task run settings: plan-gate takes the primary slot,
-         the model select sits compact beside it on desktop (stacked on phones). -->
+    <!-- Per-task run settings. Plan gate gets its own full-width row so its explainer
+         reads on one line; Model + Sandbox share a 50/50 row beneath. -->
     <div class="opts-row">
-      <label class="plan-gate" use:coachTarget={"plan-gate"} title={m.newtask_plan_gate_hint()}>
+      <label class="plan-gate" use:coachTarget={"plan-gate"}>
         <input type="checkbox" bind:checked={planGate} onchange={() => (planGateTouched = true)} />
         <span class="pg-text">
           <span class="pg-label">{m.newtask_plan_gate_label()}</span>
@@ -548,24 +548,26 @@
         </span>
       </label>
 
-      <div class="model-field">
-        <label class="micro" for="nt-model">{m.newtask_model_label()}</label>
-        <select id="nt-model" bind:value={model}>
-          <option value="default">{m.newtask_model_default()}</option>
-          {#each MODELS as mdl (mdl)}
-            <option value={mdl}>{mdl}</option>
-          {/each}
-        </select>
-      </div>
+      <div class="run-config">
+        <div class="model-field">
+          <label class="micro" for="nt-model">{m.newtask_model_label()}</label>
+          <select id="nt-model" bind:value={model}>
+            <option value="default">{m.newtask_model_default()}</option>
+            {#each MODELS as mdl (mdl)}
+              <option value={mdl}>{mdl}</option>
+            {/each}
+          </select>
+        </div>
 
-      <div class="model-field">
-        <label class="micro" for="nt-sandbox">{m.newtask_sandbox_label()}</label>
-        <select id="nt-sandbox" bind:value={sandboxProfile} title={m.newtask_sandbox_hint()}>
-          <option value="default">{m.newtask_sandbox_default()}</option>
-          <option value="trusted">{m.sandbox_profile_trusted()}</option>
-          <option value="standard">{m.sandbox_profile_standard()}</option>
-          <option value="autonomous">{m.sandbox_profile_autonomous()}</option>
-        </select>
+        <div class="model-field">
+          <label class="micro" for="nt-sandbox">{m.newtask_sandbox_label()}</label>
+          <select id="nt-sandbox" bind:value={sandboxProfile} title={m.newtask_sandbox_hint()}>
+            <option value="default">{m.newtask_sandbox_default()}</option>
+            <option value="trusted">{m.sandbox_profile_trusted()}</option>
+            <option value="standard">{m.sandbox_profile_standard()}</option>
+            <option value="autonomous">{m.sandbox_profile_autonomous()}</option>
+          </select>
+        </div>
       </div>
     </div>
 
@@ -698,22 +700,26 @@
     border-color: var(--color-line-bright);
   }
   .opts-row {
-    /* flex-start: plan-gate label and MODEL caption share a top edge */
     display: flex;
-    align-items: flex-start;
-    gap: 14px;
+    flex-direction: column;
+    gap: 12px;
     margin-top: 10px;
   }
   .plan-gate {
-    flex: 1;
     min-width: 0;
     display: flex;
     align-items: flex-start;
     gap: 8px;
     cursor: pointer;
   }
+  .run-config {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+  }
   .model-field {
-    flex: 0 0 180px;
+    flex: 1 1 0;
+    min-width: 120px;
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -861,16 +867,6 @@
       max-height: 40dvh;
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
-    }
-    /* Stack the run settings again on phones — the sheet is too narrow for
-       the side-by-side row. */
-    .opts-row {
-      flex-direction: column;
-      align-items: stretch;
-      gap: 10px;
-    }
-    .model-field {
-      flex: none;
     }
   }
 


### PR DESCRIPTION
## What

The New Task composer's per-task run-settings row crammed three controls onto one ~488px line — the **Plan gate** checkbox + explainer and the **Model** + **Sandbox** selects. With the Sandbox select added (#554), the plan-gate column got squeezed to ~100px and its explainer wrapped to ~5 lines (tall, cramped).

This splits the row into **two rows**:
- **Plan gate** on its own full-width row → the explainer now reads on **one line**.
- **Model** + **Sandbox** share a 50/50 row beneath — the same stacking pattern the `<768px` breakpoint already used.

Also:
- Shortened the explainer copy: *"adversarial **plan** review"* → *"adversarial review"* (the label already says **Plan gate** — "plan" was redundant).
- Dropped the now-redundant native `title` tooltip on the plan-gate label (the hint is permanently visible inline).

## Why this approach

Considered (and rejected) demoting the explainer behind a hover tooltip / info-icon disclosure — but the equivalent control in `AutomationPanel` keeps this same short sentence **always visible** (the ⓘ there reveals a *different*, longer paragraph), so hiding it would be *less* consistent, not more. Two rows keeps the explainer visible, removes the wrap, and is intrinsically responsive (`flex-wrap` handles narrow phones) with no fragile per-column width tuning.

## Scope

- `ui/src/lib/components/NewTask.svelte` — template restructure (wrap the two selects in `.run-config`) + CSS (`.opts-row` → column, new `.run-config`, `.model-field` → 50/50, removed now-redundant 768px overrides).
- `ui/messages/en.json` — one-word copy edit to `newtask_plan_gate_hint` (existing key; `de.json` unchanged, parity intact).

No behavior change to `planGate` / `model` / `sandboxProfile`; no new component, state, or aria wiring.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- `cd ui && bun run check:i18n` → 2 locales in parity
- prettier clean
- Layout/responsive + a11y reviewed (explainer stays visible; selects wrap gracefully from 488px desktop down to ~290px phone).

`[no-feature-entry]` — layout/copy refinement of an existing shipped feature, no new user-facing capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)