### PR TITLE
fix(ui): one pulse for in-progress + cohesive amber streak badge

### DIFF
--- a/ui/src/lib/components/CriticBadge.svelte
+++ b/ui/src/lib/components/CriticBadge.svelte
@@ -94,14 +94,16 @@
       opacity: 1;
     }
   }
-  /* auto-address streak label that takes over the whole pill. Compound selectors
-     (.critic-badge.streak-*, specificity 0,2,0) so the status colour beats the reviewing
-     amber (.critic-reviewing, 0,1,0) by specificity rather than source order — robust
-     against stylesheet reordering; the amber border + rev-dot still signal running. */
+  /* auto-address streak label that takes over the whole pill. streak-round now matches the
+     reviewing amber (cohesive amber pill, like the plain REVIEWING badge); the amber border +
+     rev-dot still signal running. Compound selectors (.critic-badge.streak-*, specificity 0,2,0)
+     so the recessive states (streak-final faint) still beat the reviewing amber
+     (.critic-reviewing, 0,1,0) by specificity rather than source order — robust against
+     stylesheet reordering. */
   .critic-badge.streak-round {
-    color: var(--color-blue);
+    color: var(--color-amber);
   }
-  /* final allowed round in flight: recessive vs. the blue in-progress and orange stalled */
+  /* final allowed round in flight: recessive (faint) vs. the amber in-progress/stalled streak states */
   .critic-badge.streak-final {
     color: var(--color-faint);
   }

--- a/ui/src/lib/components/Stepper.svelte
+++ b/ui/src/lib/components/Stepper.svelte
@@ -209,17 +209,6 @@
   .seg.rv-reviewing {
     background: var(--status-running);
   }
-  @media (prefers-reduced-motion: no-preference) {
-    .seg.ci-pending,
-    .seg.rv-reviewing {
-      animation: seg-pulse 1.8s ease-in-out infinite;
-    }
-  }
-  @keyframes seg-pulse {
-    50% {
-      opacity: 0.45;
-    }
-  }
   /* Failure/changes also carry a non-color cue (a ring + extra height) so red
      differs from green by shape/weight, not hue alone (WCAG 1.4.1). No animation. */
   .seg.ci-failure,
@@ -266,7 +255,7 @@
   .lg-state {
     flex: none;
   }
-  /* legend swatch reuses .seg state classes; pulse animation inherited. */
+  /* legend swatch reuses .seg state classes (tint + done/active/pending); only its width differs. */
   .seg.sw {
     width: 12px;
   }


### PR DESCRIPTION
## Problem

On a session card row the "in-progress" state animated **twice at once**, and the auto-address streak badge clashed on color (user-circled both in the report):

- **Redundant pulse** — the badge's amber dot pulsed **and** the progress-bar's last segment pulsed for the same state. This was symmetric across both in-progress segments (`.seg.ci-pending` ⟷ PrBadge dot, `.seg.rv-reviewing` ⟷ CriticBadge dot). Too much motion.
- **Color clash** — the `REVIEW 2/5` streak label rendered in **blue** inside its **amber** border + amber pulsing dot.

## Fix (two focused commits)

1. **`fix(stepper)`** — drop the `seg-pulse` animation (and its orphaned keyframe) from *both* in-progress segments. Segments stay solid amber (`--status-running`) to mark the stage; the badge dot is now the **sole** pulse. Stale legend-swatch comment corrected.
2. **`fix(criticbadge)`** — `streak-round` text goes blue → **amber**, cohesive with its amber border + dot (matching the plain `REVIEWING` badge). Two falsified comments updated; the `streak-*` specificity rationale that keeps `streak-final` recessive is preserved.

## Co-presence (no state loses its only motion)

- `rv-reviewing`: stepper segment and CriticBadge dot are both driven by the same `reviews.isReviewing(id)`; CriticBadge is always in `UnitRow` markup → structurally co-present.
- `ci-pending`: `info.ci = git.checks` is realistically `pending` only on an **open** PR (merged/closed → terminal chip, no segments), where `PrBadge.showCi` → `.dot-pending` pulses. The only exception (malformed `checks=pending` with `state≠open`) renders no PrBadge anyway; solid-amber-no-motion is acceptable and not produced in practice.

## Scope

CSS-only, two components. No markup/logic/token/i18n changes; no new user-facing capability (motion/color refinement) → no feature-catalog entry. Existing `CriticBadge`/`Stepper` tests assert classes + text, not colors, and stay green.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings (2087 files)
- `cd ui && bun run test` → 1069 passed (78 files)
- Rebased onto latest `main`; branch linear, pre-push hygiene + i18n + feature-catalog gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
