### PR TITLE
fix(herd): order ready-to-merge before merging in the rail

### DIFF
--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -86,6 +86,37 @@ describe("Herd merging group", () => {
     });
     await expect.element(page.getByText(/Merging \(1\)/i)).toBeInTheDocument();
   });
+
+  it("orders the section heads ready → merging → merged top→bottom", async () => {
+    render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "rdy", readyToMerge: true }),
+        session({
+          id: "mrg",
+          readyToMerge: true,
+          mergingSince: Date.now(),
+          mergingTrainId: "t",
+        }),
+        session({ id: "mgd" }),
+      ],
+      git: {
+        rdy: openPr,
+        mrg: { kind: "github", state: "open", checks: "success", deployConfigured: false },
+        mgd: { kind: "github", state: "merged", checks: "success", deployConfigured: false },
+      },
+    });
+    // all three heads present
+    await expect.element(page.getByText(/Ready to merge \(1\)/i)).toBeInTheDocument();
+    await expect.element(page.getByText(/Merging \(1\)/i)).toBeInTheDocument();
+    await expect.element(page.getByText(/Merged \(1\)/i)).toBeInTheDocument();
+    // compare document positions: ready before merging before merged
+    const ready = document.querySelector(".ready-head")!;
+    const merging = document.querySelector(".merging-head")!;
+    const merged = document.querySelector(".merged-head")!;
+    expect(ready.compareDocumentPosition(merging) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(merging.compareDocumentPosition(merged) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
 });
 
 describe("Herd merge-train link", () => {

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -420,11 +420,19 @@
             />
           {/each}
         {/if}
-        {#if partition.merging.length > 0}
-          <div class="merging-head micro">
-            {m.herd_merging_group({ count: partition.merging.length })}
+        {#if partition.ready.length > 0}
+          <div class="ready-head micro">
+            {m.herd_ready_group({ count: partition.ready.length })}
+            {#if onmergetrain && readyPrCount > 0}
+              <button
+                type="button"
+                class="merge-train micro"
+                title={m.herd_merge_train_title()}
+                onclick={onmergetrain}>{m.herd_merge_train_action()}</button
+              >
+            {/if}
           </div>
-          {#each partition.merging as session (session.id)}
+          {#each partition.ready as session (session.id)}
             <UnitRow
               {session}
               selected={session.id === selectedId}
@@ -446,19 +454,11 @@
             />
           {/each}
         {/if}
-        {#if partition.ready.length > 0}
-          <div class="ready-head micro">
-            {m.herd_ready_group({ count: partition.ready.length })}
-            {#if onmergetrain && readyPrCount > 0}
-              <button
-                type="button"
-                class="merge-train micro"
-                title={m.herd_merge_train_title()}
-                onclick={onmergetrain}>{m.herd_merge_train_action()}</button
-              >
-            {/if}
+        {#if partition.merging.length > 0}
+          <div class="merging-head micro">
+            {m.herd_merging_group({ count: partition.merging.length })}
           </div>
-          {#each partition.ready as session (session.id)}
+          {#each partition.merging as session (session.id)}
             <UnitRow
               {session}
               selected={session.id === selectedId}

--- a/ui/src/lib/components/herd-keynav.test.ts
+++ b/ui/src/lib/components/herd-keynav.test.ts
@@ -47,16 +47,19 @@ function git(state: GitState["state"], checks: GitState["checks"] = "none"): Git
 
 test("railOrder flattens the partition in the rail's render order", () => {
   // input order interleaves stages; the rail renders active → ciRunning →
-  // ready → merged (among others), preserving input order within each group
+  // ready → merging → merged (among others), preserving input order within each
+  // group — ready precedes merging precedes merged in the flattened output.
+  const merging1 = { ...session("merging1"), mergingSince: Date.now(), mergingTrainId: "t" };
   const list = [
     session("merged1"),
     session("ready1", true),
     session("a"),
+    merging1,
     session("ci1"),
     session("b"),
   ];
   const order = railOrder(list, { merged1: git("merged"), ci1: git("open", "pending") });
-  expect(order).toEqual(["a", "b", "ci1", "ready1", "merged1"]);
+  expect(order).toEqual(["a", "b", "ci1", "ready1", "merging1", "merged1"]);
 });
 
 test("railOrder under the ready filter only walks rows the rail shows", () => {

--- a/ui/src/lib/components/herd-keynav.ts
+++ b/ui/src/lib/components/herd-keynav.ts
@@ -16,8 +16,8 @@ const RAIL_GROUP_ORDER = [
   "waitingOnMerger",
   "draftAwaitingSignoff",
   "awaitingMerge",
-  "merging",
   "ready",
+  "merging",
   "merged",
 ] as const;
 

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -35,7 +35,7 @@ import { isMerging } from "./merge-train";
  *  yet) stays in `active` to avoid flicker into the "Your turn" group before CI registers
  *  as pending. The groups render top→bottom as active → ciRunning → ciFailed →
  *  reviewerRunning → waitingOnReviewer → waitingOnMerger → draftAwaitingSignoff →
- *  awaitingMerge → merging → ready → merged (Herd.svelte's template order, mirrored
+ *  awaitingMerge → ready → merging → merged (Herd.svelte's template order, mirrored
  *  by herd-keynav's RAIL_GROUP_ORDER), tracking the session lifecycle. `isReviewing`
  *  is injected so this stays a pure function (the caller wires it to the reviews store). */
 type Stage =


### PR DESCRIPTION
## What

Reorders the herd rail's lifecycle status groups so **READY TO MERGE** renders before **MERGING**, with **MERGED** still last:

`… → awaitingMerge → ready → merging → merged`

(was `… → awaitingMerge → merging → ready → merged`)

This matches the real lifecycle — operator parks a session as ready, the merge train then picks it up, then it lands — and the requested top→bottom visual order.

## Scope

**Display-order only.** The partition *precedence* in `terminalStage` (`merged > merging > ready > …`) is untouched: a session actively in a merge train still buckets under MERGING even when its `readyToMerge` flag is set. Only the render order of the `merging` and `ready` groups swaps.

## Changes

- `herd-keynav.ts` — swap `merging`/`ready` in `RAIL_GROUP_ORDER` (keynav source of truth).
- `Herd.svelte` — move the merging template block after the ready block.
- `herd-partition.ts` — update only the render-order doc sentence; precedence line byte-for-byte unchanged.
- `herd-keynav.test.ts` — extend the `railOrder` test with a merging session, asserting `ready → merging → merged` (guards array/template drift the old test couldn't catch).
- `Herd.browser.test.ts` — new DOM-order assertion: `.ready-head` before `.merging-head` before `.merged-head`.

No new i18n strings (the three group keys already exist EN+DE); no feature-catalog entry (fix, not feat).

## Verification

- `cd ui && bun run check` — 0 errors, 0 warnings.
- `cd ui && bun run test` — 78 files, 1076 tests passing.
- `cd ui && bun run check:i18n` — locales in parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)