### PR TITLE
feat(readiness): bun-aware Dependabot config + dependency-automation guardrail

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # Bun version updates across all three packages. Bun *security* updates are
+  # unsupported by Dependabot and are disabled at the repo level; daily keeps the
+  # version-update (= effective security-fix) latency to ~1 day.
+  - package-ecosystem: "bun"
+    directories:
+      - "/"
+      - "/ui"
+      - "/extension"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      development-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -25,6 +25,7 @@ export type GuardrailId =
   | "test_runner"
   | "dead_code_audit"
   | "ci"
+  | "dependency_automation"
   | "agent_instructions";
 
 export interface GuardrailCheck {
@@ -168,6 +169,24 @@ export const GUARDRAILS: GuardrailDef[] = [
       const wf = s.glob(".github/workflows", (n) => n.endsWith(".yml") || n.endsWith(".yaml"));
       if (wf.length) ev.push(`.github/workflows (${wf.length})`);
       if (s.has(".gitlab-ci.yml")) ev.push(".gitlab-ci.yml");
+      return ev;
+    },
+  },
+  {
+    id: "dependency_automation",
+    weight: 5,
+    detect: (s) => {
+      const ev: string[] = [];
+      if (s.has(".github/dependabot.yml") || s.has(".github/dependabot.yaml"))
+        ev.push("dependabot.yml");
+      if (
+        s.has("renovate.json") ||
+        s.has("renovate.json5") ||
+        s.has(".github/renovate.json") ||
+        s.has(".github/renovate.json5") ||
+        s.glob(".", (n) => n.startsWith(".renovaterc")).length
+      )
+        ev.push("renovate config");
       return ev;
     },
   },
@@ -360,6 +379,7 @@ const TOOLING_LABEL: Record<GuardrailId, string> = {
   test_runner: "A test runner wired into the hook",
   agent_instructions: "A CLAUDE.md/AGENTS.md house-rules file",
   ci: "A CI workflow",
+  dependency_automation: "Dependency automation (Dependabot/Renovate)",
   lint_staged: "lint-staged on staged files",
   commit_lint: "Conventional-commit lint (commitlint)",
   dead_code_audit: "A dead-code/complexity audit (fallow/knip)",
@@ -378,6 +398,8 @@ const CHURN_PLAIN: Record<GuardrailId, string> = {
     "without tests in the hook, regressions reach you instead of failing the agent first.",
   agent_instructions: "without house rules, you re-explain the same posture in chat every task.",
   ci: "without CI, nothing independently re-checks what the agent self-reported.",
+  dependency_automation:
+    "without it dependency bumps pile up as manual busywork and stale-dep bugs reach you instead of an automated PR.",
   lint_staged:
     "without it the whole tree is re-checked or skipped; staged-only keeps the hook fast.",
   commit_lint: "without it you correct commit message format by hand.",

--- a/test/readiness.test.ts
+++ b/test/readiness.test.ts
@@ -101,6 +101,7 @@ test("a fully-equipped repo (Shepherd-shaped) scores 100 with all guardrails pre
   write(".husky/commit-msg", "commitlint");
   write(".fallowrc.jsonc", "{}");
   write(".github/workflows/ci.yml", "name: ci");
+  write(".github/dependabot.yml", "version: 2");
   write("CLAUDE.md", "# rules");
 
   const r = analyzeReadiness(dir);
@@ -123,6 +124,31 @@ test("detects individual guardrails from their markers", () => {
   expect(present("test_runner", r)).toBe(true); // real test script
   expect(present("linter", r)).toBe(false);
   expect(present("git_hooks", r)).toBe(false);
+});
+
+test("detects dependency automation from a Dependabot config", () => {
+  pkg({ name: "bot" });
+  write(".github/dependabot.yml", "version: 2");
+  const r = analyzeReadiness(dir);
+  expect(present("dependency_automation", r)).toBe(true);
+  const ev = r.checks.find((c) => c.id === "dependency_automation")?.evidence ?? [];
+  expect(ev).toContain("dependabot.yml");
+});
+
+test("detects dependency automation from a Renovate config", () => {
+  pkg({ name: "renovated" });
+  write("renovate.json", "{}");
+  const r = analyzeReadiness(dir);
+  expect(present("dependency_automation", r)).toBe(true);
+  const ev = r.checks.find((c) => c.id === "dependency_automation")?.evidence ?? [];
+  expect(ev).toContain("renovate config");
+});
+
+test("absent dependency automation is prescribed in the generated CLAUDE.md", () => {
+  pkg({ name: "no-bot" });
+  const r = analyzeReadiness(dir);
+  expect(present("dependency_automation", r)).toBe(false);
+  expect(r.claudeMd).toContain("Dependency automation");
 });
 
 test("the npm placeholder test script does not count as a test runner", () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1084,5 +1084,9 @@
   "feat_session_epic_badge_title": "Epics in deinen Sessions erkennen",
   "feat_session_epic_badge_body": "Eine Session, die an einem Tracking-Issue arbeitet, zeigt jetzt ein EPIC-Badge mit Live-Fortschritt der Unter-Issues — klick es an, um das Epic im Backlog zu öffnen.",
   "epic_badge_open_title": "Epic #{number}: {merged}/{total} Unteraufgaben erledigt — im Backlog öffnen",
-  "epic_badge_open_aria": "Epic #{number} im Backlog öffnen ({merged} von {total} Unteraufgaben erledigt)"
+  "epic_badge_open_aria": "Epic #{number} im Backlog öffnen ({merged} von {total} Unteraufgaben erledigt)",
+  "readiness_g_dependency_automation_title": "Abhängigkeits-Automatisierung (Dependabot/Renovate)",
+  "readiness_g_dependency_automation_removes": "Ohne sie häufen sich Abhängigkeits-Updates als manuelle Fleißarbeit an, statt als automatische PRs, die du nur noch prüfst und mergst.",
+  "feat_dependency_automation_title": "Reife-Analyse prüft Abhängigkeits-Automatisierung",
+  "feat_dependency_automation_body": "Der Backlog → Reife-Tab bewertet jetzt, ob ein Repo seine Abhängigkeiten mit Dependabot oder Renovate aktuell hält, und empfiehlt sie, wenn sie fehlt."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1084,5 +1084,9 @@
   "feat_session_epic_badge_title": "Spot epics in your sessions",
   "feat_session_epic_badge_body": "A session working a tracking issue now shows an EPIC badge with live sub-issue progress — click it to open that epic in the backlog.",
   "epic_badge_open_title": "Epic #{number}: {merged}/{total} sub-issues done — open in backlog",
-  "epic_badge_open_aria": "Open epic #{number} in the backlog ({merged} of {total} sub-issues done)"
+  "epic_badge_open_aria": "Open epic #{number} in the backlog ({merged} of {total} sub-issues done)",
+  "readiness_g_dependency_automation_title": "Dependency automation (Dependabot/Renovate)",
+  "readiness_g_dependency_automation_removes": "Without it, dependency bumps pile up as manual busywork instead of automated PRs you just review and merge.",
+  "feat_dependency_automation_title": "Readiness checks dependency automation",
+  "feat_dependency_automation_body": "The Backlog → Readiness tab now scores whether a repo keeps dependencies current with Dependabot or Renovate, and prescribes it when missing."
 }

--- a/ui/src/lib/components/ReadinessPanel.svelte
+++ b/ui/src/lib/components/ReadinessPanel.svelte
@@ -69,6 +69,8 @@
         return m.readiness_g_agent_instructions_title();
       case "ci":
         return m.readiness_g_ci_title();
+      case "dependency_automation":
+        return m.readiness_g_dependency_automation_title();
       case "lint_staged":
         return m.readiness_g_lint_staged_title();
       case "commit_lint":
@@ -96,6 +98,8 @@
         return m.readiness_g_agent_instructions_removes();
       case "ci":
         return m.readiness_g_ci_removes();
+      case "dependency_automation":
+        return m.readiness_g_dependency_automation_removes();
       case "lint_staged":
         return m.readiness_g_lint_staged_removes();
       case "commit_lint":

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -627,4 +627,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_session_epic_badge_title",
     bodyKey: "feat_session_epic_badge_body",
   },
+  {
+    // No targetId: the guardrail row only mounts on the Backlog Readiness tab once a
+    // project is selected, so a coachmark anchor would usually be unmounted — surface
+    // via the What's-New drawer only.
+    id: "readiness-dependency-automation",
+    sinceVersion: "1.28.0",
+    titleKey: "feat_dependency_automation_title",
+    bodyKey: "feat_dependency_automation_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -526,6 +526,7 @@ export type GuardrailId =
   | "test_runner"
   | "dead_code_audit"
   | "ci"
+  | "dependency_automation"
   | "agent_instructions";
 export interface GuardrailCheck {
   id: GuardrailId;


### PR DESCRIPTION
## Summary

Sets up Dependabot for Shepherd (was missing) and makes dependency automation part of the AI-readiness check.

- **`.github/dependabot.yml`** — native, **Bun-aware** version-update config:
  - `bun` ecosystem across all three packages (`/`, `/ui`, `/extension`) — the dedicated `bun` token correctly updates `bun.lock` (the default `npm` ecosystem does **not**, which is what broke #595).
  - **`daily`** cadence (see security note below); minor+patch bundled into `production-dependencies` / `development-dependencies` groups; **majors arrive as individual reviewable PRs**. No `group-by` (it fragments groups into one-PR-per-dependency and would *increase* volume).
  - `github-actions` ecosystem (weekly) to keep workflow action pins current.
  - `chore(deps)` / `chore(deps-dev)` / `chore(ci)` commit prefixes — conventional-commit-clean, never arms the `feat`-only feature-catalog gate.
- **`dependency_automation` readiness guardrail** (weight 5) — detects Dependabot **or** Renovate (tool-family, like `dead_code_audit`). Server (`src/readiness.ts`), UI mirror + Readiness panel, EN/DE catalogs, feature-announcement entry (`sinceVersion 1.28.0`), and tests.

## Fixes the #595 failure (npm-vs-bun lockfile desync)

[#595](https://github.com/erwins-enkel/shepherd/pull/595) was a Dependabot **security** update via the `npm_and_yarn` ecosystem that bumped `package.json` but left `bun.lock` untouched → CI's `bun install --frozen-lockfile` failed in 16s. **Dependabot does not support Bun _security_ updates** (only version updates), so that path will *always* desync `bun.lock`.

**Resolution:** disable Dependabot **security updates** at the repo level and rely on the `bun` **version-update** cycle (which keeps `bun.lock` in sync) plus Dependabot **alerts** (kept ON, notify-only).

### ⚠️ Security-fix latency trade-off (please ack)

Disabling security updates means CVE fixes are no longer instant dedicated PRs — they ride the version-update cycle. To keep that window small for a soon-to-be-public repo, the `bun` ecosystem runs **`daily`** (worst-case ~1 day from a fixed release to a PR, vs ~7 on weekly). **Dependabot alerts stay ON**, so an as-yet-unfixed CVE is still surfaced for manual action. Both intervals are one-line tunable.

## Scoring shift (intended, user-visible)

Adding a weight-5 guardrail enlarges the readiness denominator, so every scored repo lacking Dependabot/Renovate sees its displayed score drop slightly. This is deliberate — repos without dependency automation *should* read as less AI-ready.

## Operational steps (repo admin — done alongside this PR)

- [x] Disable Dependabot security updates: `gh api -X DELETE /repos/erwins-enkel/shepherd/automated-security-fixes` (alerts left ON)
- [x] Close the broken #595

## Test Plan

- [x] `bun run lint` / `bun run typecheck` / `bun test ./test` (2186 pass)
- [x] `cd ui && bun run check` + `bun run check:i18n` (EN↔DE parity)
- [x] branch-hygiene, feature-catalog, fallow delta audit (no issues)
- [ ] **Post-merge (hard gate):** Insights → Dependency graph → Dependabot shows no config-rejection error and lists the `bun` (×3 dirs) + `github-actions` jobs
- [ ] **First `bun` cycle:** PRs arrive bundled per-directory (not one-per-dependency) and touch `bun.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)