### PR TITLE
fix(epic): guard all manual-spawn paths against epic-parent issues

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -241,7 +241,7 @@
   "issuespanel_no_host": "kein Git-Host für dieses Repo konfiguriert",
   "issuespanel_open_on_github": "auf GitHub öffnen",
   "issuespanel_task_button": "Aufgabe",
-  "issuespanel_task_button_epic_disabled": "Epics werden über „Start\" gestartet — öffne das Epic, statt eine Aufgabe.",
+  "issuespanel_task_button_epic_disabled": "Epics werden über „Start“ gestartet — öffne das Epic, statt eine Aufgabe.",
   "issuespanel_active_label_title": "Von einem aktiven Shepherd-Agenten beansprucht; an diesem Issue wird bereits gearbeitet",
   "issuespanel_filter_placeholder": "Issues durchsuchen…",
   "issuespanel_no_match": "keine Issues passen zur Suche",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -241,6 +241,7 @@
   "issuespanel_no_host": "kein Git-Host für dieses Repo konfiguriert",
   "issuespanel_open_on_github": "auf GitHub öffnen",
   "issuespanel_task_button": "Aufgabe",
+  "issuespanel_task_button_epic_disabled": "Epics werden über „Start\" gestartet — öffne das Epic, statt eine Aufgabe.",
   "issuespanel_active_label_title": "Von einem aktiven Shepherd-Agenten beansprucht; an diesem Issue wird bereits gearbeitet",
   "issuespanel_filter_placeholder": "Issues durchsuchen…",
   "issuespanel_no_match": "keine Issues passen zur Suche",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -278,6 +278,8 @@
   "promptsources_more_labels": "+{count}",
   "promptsources_no_commands": "keine installierten Befehle",
   "promptsources_commands_filter": "Befehle filtern…",
+  "promptsources_epic_tag": "EPIC",
+  "promptsources_epic_hint": "Über „Start“ starten, nicht als Aufgabe.",
   "slash_menu_label": "Slash-Befehle",
   "slash_menu_empty": "keine passenden Befehle",
   "reposelect_placeholder": "Repo auswählen…",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -241,6 +241,7 @@
   "issuespanel_no_host": "no git host configured for this repo",
   "issuespanel_open_on_github": "open on GitHub",
   "issuespanel_task_button": "Task",
+  "issuespanel_task_button_epic_disabled": "Epics launch via Start — open the epic, not a task.",
   "issuespanel_active_label_title": "Claimed by an active Shepherd agent; this issue is already being worked on",
   "issuespanel_filter_placeholder": "search issues…",
   "issuespanel_no_match": "no issues match the search",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -278,6 +278,8 @@
   "promptsources_more_labels": "+{count}",
   "promptsources_no_commands": "no installed commands",
   "promptsources_commands_filter": "filter commands…",
+  "promptsources_epic_tag": "EPIC",
+  "promptsources_epic_hint": "Run via Start, not as a task.",
   "slash_menu_label": "slash commands",
   "slash_menu_empty": "no matching commands",
   "reposelect_placeholder": "select a repo…",

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import type { Issue, EpicSummary, Epic } from "$lib/types";
+import type { Issue, EpicSummary, Epic, Steer } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import { listIssues, getEpics, getEpic } from "$lib/api";
+import { steers } from "$lib/steers.svelte";
 
 // Mock the API so no network calls fire; each test seeds the results.
 vi.mock("$lib/api", async (importOriginal) => {
@@ -116,6 +117,45 @@ describe("IssuesPanel epic badge", () => {
 
     expect(plainTask.disabled).toBe(false);
     expect(plainTask.getAttribute("aria-label")).toBe(m.issuespanel_task_button());
+  });
+
+  it("disables quick-launch steers on an epic-parent row, enables them on a normal one", async () => {
+    const steer: Steer = {
+      id: "qa",
+      label: "QA",
+      text: "Run QA on this issue",
+      inSteerBar: false,
+      onIssues: true,
+    };
+    const prev = steers.list;
+    steers.list = [steer];
+    try {
+      seed([issue(40, "Epic parent"), issue(41, "Plain issue")], [epic(40, 1, 2, "markdown")]);
+      // onquick must be set for .quick-btn to render at all.
+      render(IssuesPanel, { repoPath: "/repo", onnewtask: noop, onquick: noop });
+
+      // One quick-btn per onIssues steer per row → 2 rows × 1 steer = 2 buttons.
+      await expect.poll(() => document.querySelectorAll(".quick-btn").length).toBe(2);
+
+      const rows = document.querySelectorAll(".issue-row");
+      const quickBtn = (row: Element) => row.querySelector(".quick-btn") as HTMLButtonElement;
+
+      // Row order mirrors the seeded issue order: 40 (epic parent) then 41 (plain).
+      const epicQuick = quickBtn(rows[0]);
+      const plainQuick = quickBtn(rows[1]);
+
+      expect(epicQuick.disabled).toBe(true);
+      expect(epicQuick.getAttribute("aria-label")).toBe(m.issuespanel_task_button_epic_disabled());
+      expect(epicQuick.getAttribute("title")).toBe(m.issuespanel_task_button_epic_disabled());
+
+      expect(plainQuick.disabled).toBe(false);
+      expect(plainQuick.getAttribute("aria-label")).toBe(
+        m.issuespanel_action_aria({ label: steer.label }),
+      );
+      expect(plainQuick.getAttribute("title")).toBe(steer.text);
+    } finally {
+      steers.list = prev;
+    }
   });
 });
 

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -95,6 +95,28 @@ describe("IssuesPanel epic badge", () => {
     expect(badge).not.toBeNull();
     expect(badge!.textContent?.trim()).toBe(expectedText);
   });
+
+  it("disables the +Task button on an epic-parent row, enables it on a normal one", async () => {
+    seed([issue(30, "Epic parent"), issue(31, "Plain issue")], [epic(30, 1, 2, "markdown")]);
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    // Wait until both rows have rendered their +Task buttons.
+    await expect.poll(() => document.querySelectorAll(".task-btn").length).toBe(2);
+
+    const rows = document.querySelectorAll(".issue-row");
+    const taskBtn = (row: Element) => row.querySelector(".task-btn") as HTMLButtonElement;
+
+    // Row order mirrors the seeded issue order: 30 (epic parent) then 31 (plain).
+    const epicTask = taskBtn(rows[0]);
+    const plainTask = taskBtn(rows[1]);
+
+    expect(epicTask.disabled).toBe(true);
+    expect(epicTask.getAttribute("aria-label")).toBe(m.issuespanel_task_button_epic_disabled());
+    expect(epicTask.getAttribute("title")).toBe(m.issuespanel_task_button_epic_disabled());
+
+    expect(plainTask.disabled).toBe(false);
+    expect(plainTask.getAttribute("aria-label")).toBe(m.issuespanel_task_button());
+  });
 });
 
 describe("IssuesPanel expandEpic", () => {

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -229,9 +229,12 @@
                 <button
                   class="quick-btn"
                   class:has-emoji={!!a.emoji}
+                  disabled={isEpicParent}
                   onclick={() => onquick(issue, a)}
-                  aria-label={m.issuespanel_action_aria({ label: a.label })}
-                  title={a.text}
+                  aria-label={isEpicParent
+                    ? m.issuespanel_task_button_epic_disabled()
+                    : m.issuespanel_action_aria({ label: a.label })}
+                  title={isEpicParent ? m.issuespanel_task_button_epic_disabled() : a.text}
                   >{#if a.emoji}<span class="act-emoji" aria-hidden="true">{a.emoji}</span
                     >{/if}<span class="act-label">{a.label}</span></button
                 >
@@ -458,8 +461,16 @@
       color 0.12s;
   }
 
-  .quick-btn:hover {
+  .quick-btn:hover:not(:disabled) {
     background: color-mix(in srgb, var(--color-amber) 14%, transparent);
+  }
+
+  /* Epic-parent rows disable quick-launch steers for the same reason +Task is
+     disabled: an epic is launched via the epic panel's Start, not by spawning a
+     manual session linked to the parent tracking issue (footgun). */
+  .quick-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
   }
 
   .task-btn {

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -162,6 +162,7 @@
       {/if}
       {#each visibleIssues as issue (issue.number)}
         {@const epicSummary = epicByNumber.get(issue.number)}
+        {@const isEpicParent = !!epicSummary}
         {@const isExpanded = expanded.has(issue.number)}
         <div class="issue-row" id={`epic-issue-row-${issue.number}`}>
           <div class="issue-top">
@@ -238,8 +239,12 @@
             {/if}
             <button
               class="task-btn has-emoji"
+              disabled={isEpicParent}
               onclick={() => onnewtask(issue)}
-              aria-label={m.issuespanel_task_button()}
+              title={isEpicParent ? m.issuespanel_task_button_epic_disabled() : undefined}
+              aria-label={isEpicParent
+                ? m.issuespanel_task_button_epic_disabled()
+                : m.issuespanel_task_button()}
               ><span class="act-emoji" aria-hidden="true">+</span><span class="act-label"
                 >{m.issuespanel_task_button()}</span
               ></button
@@ -472,9 +477,16 @@
       color 0.12s;
   }
 
-  .task-btn:hover {
+  .task-btn:hover:not(:disabled) {
     border-color: var(--color-amber);
     color: var(--color-amber);
+  }
+
+  /* Epic-parent rows disable +Task: an epic is launched via the epic panel's Start,
+     not by spawning a manual task against the parent tracking issue (footgun). */
+  .task-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
   }
 
   .muted {

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1,9 +1,38 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import NewTask from "./NewTask.svelte";
+import type { Issue } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
+import { listIssues, getEpics, getTodo } from "$lib/api";
+
+// Mock the API so the issue picker renders deterministically with no network.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    listIssues: vi.fn(),
+    getEpics: vi.fn(),
+    getTodo: vi.fn(),
+  };
+});
+
+const { default: NewTask } = await import("./NewTask.svelte");
+
+const mockListIssues = vi.mocked(listIssues);
+const mockGetEpics = vi.mocked(getEpics);
+const mockGetTodo = vi.mocked(getTodo);
+
+beforeEach(() => {
+  mockListIssues.mockReset();
+  mockGetEpics.mockReset();
+  mockGetTodo.mockReset();
+  // Safe defaults so any test that mounts the picker (PromptSources) gets resolved
+  // promises, never `undefined`; individual tests override as needed.
+  mockGetTodo.mockResolvedValue({ exists: false, content: "" });
+  mockListIssues.mockResolvedValue({ slug: null, issues: [] });
+  mockGetEpics.mockResolvedValue([]);
+});
 
 afterEach(() => {
   document.body.innerHTML = "";
@@ -51,5 +80,68 @@ describe("NewTask initialImages seed", () => {
 
     expect(page.getByText("a.png").query()).toBeNull();
     await expect.element(page.getByText("b.png")).toBeInTheDocument();
+  });
+});
+
+describe("NewTask issue picker epic-parent rows", () => {
+  function issue(number: number, title: string): Issue {
+    return {
+      number,
+      title,
+      body: "",
+      url: `https://example.com/i/${number}`,
+      labels: [],
+      createdAt: 0,
+    };
+  }
+
+  it("renders the epic-parent row non-selectable and the normal row selectable", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      issues: [issue(30, "Epic parent"), issue(31, "Plain issue")],
+    });
+    mockGetEpics.mockResolvedValue([
+      {
+        parentIssueNumber: 30,
+        parentTitle: "Epic parent",
+        total: 2,
+        merged: 1,
+        status: "idle",
+        source: "markdown",
+      },
+    ]);
+
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: "/repo" } });
+
+    // Open the Issues tab in the picker, then wait for the rows to render.
+    await page.getByRole("button", { name: m.promptsources_issues_tab() }).click();
+    await expect.poll(() => document.querySelectorAll(".ps-body .row").length).toBe(2);
+
+    // The EPIC tag chip renders (exact match: "Epic parent" also contains "Epic").
+    await expect
+      .element(page.getByText(m.promptsources_epic_tag(), { exact: true }))
+      .toBeInTheDocument();
+    expect(document.querySelector(".chip-epic")?.textContent).toBe(m.promptsources_epic_tag());
+
+    const rows = Array.from(document.querySelectorAll<HTMLElement>(".ps-body .row"));
+    const epicRow = rows.find((r) => r.textContent?.includes("Epic parent"))!;
+    const plainRow = rows.find((r) => r.textContent?.includes("Plain issue"))!;
+
+    // Epic-parent row is a non-interactive element marked aria-disabled, not a button.
+    expect(epicRow.tagName).not.toBe("BUTTON");
+    expect(epicRow.getAttribute("aria-disabled")).toBe("true");
+    expect(epicRow.textContent).toContain(m.promptsources_epic_tag());
+
+    // Clicking it does NOT seed the prompt (no pick handler fires).
+    const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    epicRow.click();
+    expect(promptField.value).toBe("");
+
+    // The normal row is a clickable button; picking it seeds the prompt template.
+    expect(plainRow.tagName).toBe("BUTTON");
+    expect((plainRow as HTMLButtonElement).disabled).toBe(false);
+    plainRow.click();
+    await expect.poll(() => promptField.value).toContain("#31");
   });
 });

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -84,13 +84,13 @@ describe("NewTask initialImages seed", () => {
 });
 
 describe("NewTask issue picker epic-parent rows", () => {
-  function issue(number: number, title: string): Issue {
+  function issue(number: number, title: string, labels: string[] = []): Issue {
     return {
       number,
       title,
       body: "",
       url: `https://example.com/i/${number}`,
-      labels: [],
+      labels,
       createdAt: 0,
     };
   }
@@ -98,7 +98,7 @@ describe("NewTask issue picker epic-parent rows", () => {
   it("renders the epic-parent row non-selectable and the normal row selectable", async () => {
     mockListIssues.mockResolvedValue({
       slug: "owner/repo",
-      issues: [issue(30, "Epic parent"), issue(31, "Plain issue")],
+      issues: [issue(30, "Epic parent", ["shepherd:active"]), issue(31, "Plain issue")],
     });
     mockGetEpics.mockResolvedValue([
       {
@@ -132,6 +132,15 @@ describe("NewTask issue picker epic-parent rows", () => {
     expect(epicRow.tagName).not.toBe("BUTTON");
     expect(epicRow.getAttribute("aria-disabled")).toBe("true");
     expect(epicRow.textContent).toContain(m.promptsources_epic_tag());
+
+    // The epic row keeps the issue's normal label chips ALONGSIDE the EPIC tag:
+    // the EPIC chip and the "shepherd:active" highlight chip both render.
+    expect(epicRow.querySelector(".chip-epic")?.textContent).toBe(m.promptsources_epic_tag());
+    const epicLabelChips = Array.from(
+      epicRow.querySelectorAll<HTMLElement>(".chip:not(.chip-epic)"),
+    );
+    expect(epicLabelChips.map((c) => c.textContent?.trim())).toContain("shepherd:active");
+    expect(epicLabelChips.some((c) => c.classList.contains("active"))).toBe(true);
 
     // Clicking it does NOT seed the prompt (no pick handler fires).
     const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { listRepos, listBranches, getCommands, uploadImage, isPreviewBlocked } from "$lib/api";
+  import {
+    listRepos,
+    listBranches,
+    getCommands,
+    getEpics,
+    uploadImage,
+    isPreviewBlocked,
+  } from "$lib/api";
   import { handleImagePaste } from "$lib/clipboard";
   import {
     MODELS,
@@ -210,6 +217,27 @@
       })
       .catch(() => {
         if (rp === repoPath) allCommands = [];
+      });
+  });
+
+  // Epic-parent tracking issues for the selected repo. The issue picker shows them
+  // disabled (picking one as a manual task collides with the Epic Runner — epics
+  // launch via the epic panel's Start control instead).
+  let epicParents = $state<Set<number>>(new Set());
+  $effect(() => {
+    const rp = repoPath;
+    if (!rp) {
+      epicParents = new Set();
+      return;
+    }
+    getEpics(rp)
+      .then((summaries) => {
+        if (rp !== repoPath) return;
+        epicParents = new Set(summaries.map((s) => s.parentIssueNumber));
+      })
+      .catch(() => {
+        if (rp !== repoPath) return;
+        epicParents = new Set();
       });
   });
 
@@ -511,6 +539,7 @@
     {#if repoPath}
       <PromptSources
         {repoPath}
+        {epicParents}
         allowIssues={!relaunch}
         onpick={(p) => {
           prompt = p;

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -9,11 +9,13 @@
     onpick,
     onpickissue,
     allowIssues = true,
+    epicParents = new Set(),
   }: {
     repoPath: string;
     onpick: (prompt: string) => void;
     onpickissue: (issue: Issue) => void;
     allowIssues?: boolean;
+    epicParents?: Set<number>;
   } = $props();
 
   let tab = $state<"todo" | "issues" | "commands">("todo");
@@ -202,27 +204,40 @@
       {:else}
         {#each issues as i (i.number)}
           {@const ordered = orderedLabels(i.labels)}
-          <button class="row" type="button" onclick={() => onpickissue(i)}>
-            <span class="issue-num">#{i.number}</span>
-            <span class="row-text">{i.title}</span>
-            {#if ordered.length > 0}
+          {#if epicParents.has(i.number)}
+            <!-- Epic-parent tracking issue: not pickable as a manual task (it would
+                 collide with the Epic Runner). Shown disabled with an EPIC tag + hint;
+                 epics launch via the epic panel's Start control. -->
+            <div class="row row-epic" aria-disabled="true" title={m.promptsources_epic_hint()}>
+              <span class="issue-num">#{i.number}</span>
+              <span class="row-text">{i.title}</span>
               <span class="chips">
-                {#each ordered.slice(0, 3) as lbl (lbl)}
-                  <span
-                    class="chip"
-                    class:active={lbl === ACTIVE_LABEL}
-                    title={lbl === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}
-                    >{lbl}</span
-                  >
-                {/each}
-                {#if ordered.length > 3}
-                  <span class="chip chip-more" title={ordered.slice(3).join(", ")}>
-                    {m.promptsources_more_labels({ count: ordered.length - 3 })}
-                  </span>
-                {/if}
+                <span class="chip chip-epic">{m.promptsources_epic_tag()}</span>
               </span>
-            {/if}
-          </button>
+            </div>
+          {:else}
+            <button class="row" type="button" onclick={() => onpickissue(i)}>
+              <span class="issue-num">#{i.number}</span>
+              <span class="row-text">{i.title}</span>
+              {#if ordered.length > 0}
+                <span class="chips">
+                  {#each ordered.slice(0, 3) as lbl (lbl)}
+                    <span
+                      class="chip"
+                      class:active={lbl === ACTIVE_LABEL}
+                      title={lbl === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}
+                      >{lbl}</span
+                    >
+                  {/each}
+                  {#if ordered.length > 3}
+                    <span class="chip chip-more" title={ordered.slice(3).join(", ")}>
+                      {m.promptsources_more_labels({ count: ordered.length - 3 })}
+                    </span>
+                  {/if}
+                </span>
+              {/if}
+            </button>
+          {/if}
         {/each}
       {/if}
     {/if}
@@ -338,6 +353,12 @@
     color: var(--color-ink-bright);
   }
 
+  /* Epic-parent rows are listed but not selectable — muted, no hover affordance. */
+  .row-epic {
+    color: var(--color-faint);
+    cursor: default;
+  }
+
   .row-marker {
     color: var(--color-faint);
     flex-shrink: 0;
@@ -403,8 +424,10 @@
   }
 
   /* shepherd:active — claimed work. Same semantic running/in-progress token as
-     IssuesPanel so a taken issue stands out with the running-session hue. */
-  .chip.active {
+     IssuesPanel so a taken issue stands out with the running-session hue.
+     The EPIC tag (.chip-epic) shares this hue, matching the backlog epic badge. */
+  .chip.active,
+  .chip-epic {
     color: var(--status-running);
     border-color: var(--status-running);
     background: color-mix(in srgb, var(--status-running) 14%, transparent);

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -213,6 +213,7 @@
               <span class="row-text">{i.title}</span>
               <span class="chips">
                 <span class="chip chip-epic">{m.promptsources_epic_tag()}</span>
+                {@render labelChips(ordered)}
               </span>
             </div>
           {:else}
@@ -220,21 +221,7 @@
               <span class="issue-num">#{i.number}</span>
               <span class="row-text">{i.title}</span>
               {#if ordered.length > 0}
-                <span class="chips">
-                  {#each ordered.slice(0, 3) as lbl (lbl)}
-                    <span
-                      class="chip"
-                      class:active={lbl === ACTIVE_LABEL}
-                      title={lbl === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}
-                      >{lbl}</span
-                    >
-                  {/each}
-                  {#if ordered.length > 3}
-                    <span class="chip chip-more" title={ordered.slice(3).join(", ")}>
-                      {m.promptsources_more_labels({ count: ordered.length - 3 })}
-                    </span>
-                  {/if}
-                </span>
+                <span class="chips">{@render labelChips(ordered)}</span>
               {/if}
             </button>
           {/if}
@@ -243,6 +230,21 @@
     {/if}
   </div>
 </div>
+
+{#snippet labelChips(ordered: string[])}
+  {#each ordered.slice(0, 3) as lbl (lbl)}
+    <span
+      class="chip"
+      class:active={lbl === ACTIVE_LABEL}
+      title={lbl === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}>{lbl}</span
+    >
+  {/each}
+  {#if ordered.length > 3}
+    <span class="chip chip-more" title={ordered.slice(3).join(", ")}>
+      {m.promptsources_more_labels({ count: ordered.length - 3 })}
+    </span>
+  {/if}
+{/snippet}
 
 <style>
   .ps-wrap {


### PR DESCRIPTION
## Why

Spawning a **manual session linked to an epic _parent_ tracking issue** conflicts with the Epic Runner: the runner is designed to spawn one child session per dependency-ready sub-issue (each with its own PR + critic review), but a parent-linked manual session instead hand-rolls stacked PRs, can't be reflected by the per-child progress chips, and leaves the epic at `0/total`. This was the root cause surfaced while analysing a real epic that "wasn't progressing" — the operator had hit a per-issue **+ Task** action on the epic parent instead of the epic panel's **Start** control.

The UI offered **three** ways to make that mistake; this PR closes all three symmetrically.

## What changed

| Path | Before | After |
|---|---|---|
| **+ Task** button on a backlog row (`IssuesPanel.svelte`) | enabled on every row, incl. epic parents | **disabled on epic parents** with an explanatory `title`/`aria-label` ("Epics launch via Start…") |
| New-task **issue picker** (`NewTask.svelte` + `PromptSources.svelte`) | epic parents pickable | epic parents shown **non-selectable** with an "EPIC" tag + hint (still listed, not hidden); `NewTask` fetches `getEpics(repo)` into a `Set` and threads it down |
| **Quick-launch** steer buttons (`.quick-btn`, `IssuesPanel.svelte`) | route straight to `createSession({issueRef:{number…}})`, bypassing both guards above | **disabled on epic parents**, symmetric with the + Task guard (caught by final review — the third, non-obvious path) |

"Epic parent" is a single source of truth across all three: `getEpics(repo)` → `parentIssueNumber`. Sub-issues remain normally spawnable.

## Deliberately out of scope

- **List-badge source label** (`/api/epics` reports `markdown` while the assembled epic is `native` for a checklist-bodied native epic). This is **documented intentional behaviour** — `resolveEpicSummary` is markdown-first *by design* (cap-safe + free; the authoritative native source is shown in the expanded per-epic view). It is **not a defect**; changing it would reverse that trade and needs a product decision. Left untouched.

## Notes

- **i18n:** 3 new keys, added to both `en.json` + `de.json` (`check:i18n` parity green).
- **Design system:** tokens only — disabled states use `opacity`; the EPIC tag reuses the `.chip`/`--status-running` recipe. No raw hex/rgba/px.
- **`fix(...)` not `feat(...)`:** this is guard/hardening, not a new user-facing capability, so the feature-catalog gate is intentionally not armed (no announcement entry).
- **Tests:** browser tests assert real DOM `disabled` state on all three paths (epic-parent disabled, normal enabled) and that the picker's epic rows don't fire a pick.

## Verification

`cd ui && bun run check` (0 errors/0 warnings), `bun run check:i18n` (2 locales in parity), `bun run test` (1099 passing). Pre-push fallow gate: no issues in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)