### PR TITLE
feat(backlog): show PR target branch when it isn't the repo default

### DIFF
--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -28,6 +28,7 @@ interface GiteaPr {
   user?: { login?: string } | null;
   created_at?: string;
   head?: { ref?: string; sha: string };
+  base?: { ref?: string };
   labels?: Array<{ name?: string }>;
 }
 
@@ -179,10 +180,14 @@ export class GiteaForge implements GitForge {
 
   async listPullRequests(): Promise<PullRequest[]> {
     // See listIssues: 200 cap vs the unbounded PR count (open_pr_counter).
-    const prs = (await this.req(
-      "GET",
-      `/api/v1/repos/${this.slug}/pulls?state=open&limit=200`,
-    )) as GiteaPr[];
+    // Resolve the default branch concurrently — used to flag non-default-targeting
+    // (stacked/epic) PRs; a failure degrades to null (no chip), never rejects the list.
+    const [prs, def] = await Promise.all([
+      this.req("GET", `/api/v1/repos/${this.slug}/pulls?state=open&limit=200`) as Promise<
+        GiteaPr[]
+      >,
+      this.defaultBranch().catch(() => null),
+    ]);
     // Checks ride a per-PR commit-status call (same shape as prStatus); fan out
     // (bounded — see STATUS_FETCH_CONCURRENCY) so the list isn't serialized on a
     // chain of round-trips, nor bursts 50 requests at once. Gitea's list API
@@ -211,6 +216,7 @@ export class GiteaForge implements GitForge {
         mergeable: pr.mergeable ?? null,
         checks,
         jobs,
+        nonDefaultBase: def && pr.base?.ref && pr.base.ref !== def ? pr.base.ref : undefined,
       } satisfies PullRequest;
     });
   }
@@ -277,11 +283,18 @@ export class GiteaForge implements GitForge {
     return this.toStatus(pr);
   }
 
+  private cachedDefaultBranch?: string;
+  /** The repo's default branch (`GET /api/v1/repos/{slug}`), cached for the
+   *  forge's lifetime — it never changes mid-session, and listPullRequests polls
+   *  this. Cached ONLY on success: a transient failure rethrows so the next call
+   *  retries rather than sticking. Mirrors GithubForge.defaultBranch. */
   async defaultBranch(): Promise<string> {
+    if (this.cachedDefaultBranch !== undefined) return this.cachedDefaultBranch;
     const repo = (await this.req("GET", `/api/v1/repos/${this.slug}`)) as {
       default_branch?: string;
     };
     if (!repo.default_branch) throw new Error("could not resolve default branch");
+    this.cachedDefaultBranch = repo.default_branch;
     return repo.default_branch;
   }
 

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -232,18 +232,21 @@ export class GithubForge implements GitForge {
   }
 
   async listPullRequests(): Promise<PullRequest[]> {
-    const out = await this.run([
-      "pr",
-      "list",
-      "--repo",
-      this.slug,
-      "--state",
-      "open",
-      "--json",
-      "number,title,url,author,createdAt,isDraft,mergeable,statusCheckRollup,reviews,headRefName,labels",
-      // See listIssues: 200 cap vs unbounded PR count (pullRequests.totalCount).
-      "--limit",
-      "200",
+    const [out, def] = await Promise.all([
+      this.run([
+        "pr",
+        "list",
+        "--repo",
+        this.slug,
+        "--state",
+        "open",
+        "--json",
+        "number,title,url,author,createdAt,isDraft,mergeable,statusCheckRollup,reviews,headRefName,baseRefName,labels",
+        // See listIssues: 200 cap vs unbounded PR count (pullRequests.totalCount).
+        "--limit",
+        "200",
+      ]),
+      this.defaultBranch().catch(() => null),
     ]);
     const raw = JSON.parse(out || "[]") as Array<
       GhPr & {
@@ -251,6 +254,7 @@ export class GithubForge implements GitForge {
         createdAt?: string;
         isDraft?: boolean;
         headRefName?: string;
+        baseRefName?: string;
         labels?: Array<{ name?: string }>;
       }
     >;
@@ -270,15 +274,15 @@ export class GithubForge implements GitForge {
         checks: rollupChecks(p.statusCheckRollup ?? []),
         jobs: jobsFromRollup(p.statusCheckRollup ?? []),
         latestReview: latestHumanReview(p.reviews),
+        nonDefaultBase: def && p.baseRefName && p.baseRefName !== def ? p.baseRefName : undefined,
       };
     });
   }
 
   async listWorkflowRuns(): Promise<WorkflowRun[]> {
     // Resolve the default branch; CI health is read from its runs, not PR branches.
-    const repoOut = await this.run(["repo", "view", this.slug, "--json", "defaultBranchRef"]);
-    const branch = (JSON.parse(repoOut || "{}") as { defaultBranchRef?: { name?: string } })
-      .defaultBranchRef?.name;
+    // A lookup failure degrades to [] (fail-quiet, matching the other forge readers).
+    const branch = await this.defaultBranch().catch(() => null);
     if (!branch) return [];
 
     const listOut = await this.run([
@@ -461,11 +465,17 @@ export class GithubForge implements GitForge {
     };
   }
 
+  private cachedDefaultBranch?: string;
+  /** The repo's default branch (`gh repo view ... defaultBranchRef`), cached for
+   *  the forge's lifetime — it never changes mid-session. Cached ONLY on success:
+   *  a transient failure rethrows so the next call retries rather than sticking. */
   async defaultBranch(): Promise<string> {
+    if (this.cachedDefaultBranch !== undefined) return this.cachedDefaultBranch;
     const out = await this.run(["repo", "view", this.slug, "--json", "defaultBranchRef"]);
     const name = (JSON.parse(out || "{}") as { defaultBranchRef?: { name?: string } })
       .defaultBranchRef?.name;
     if (!name) throw new Error("could not resolve default branch");
+    this.cachedDefaultBranch = name;
     return name;
   }
 

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -95,6 +95,12 @@ export interface PullRequest {
   jobs: WorkflowJob[];
   /** Newest *human* review (critic-marked reviews excluded), or undefined. */
   latestReview?: PrReview;
+  /** The PR's base (target) branch, populated ONLY when it is NOT the repo's
+   *  default branch (e.g. an epic/stacked branch); `undefined` for the common
+   *  default-targeting PR. This is intentionally NOT the raw base ref — do not
+   *  rely on it to read a PR's actual target; it exists solely to surface
+   *  non-default (stacked) PRs in the backlog PRs tab. */
+  nonDefaultBase?: string;
 }
 
 export interface PrStatus {

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -57,6 +57,9 @@ test("GiteaForge.listPullRequests: maps open PRs and fans out per-PR checks", as
         ],
       },
     },
+    // defaultBranch() — needed so nonDefaultBase can be computed (and so this call
+    // is recorded by fakeFetch, see the count assertion below).
+    "GET /api/v1/repos/team/proj": { json: { default_branch: "main" } },
   });
   const forge = new GiteaForge("team/proj", CFG, fn);
   const prs = await forge.listPullRequests();
@@ -77,8 +80,41 @@ test("GiteaForge.listPullRequests: maps open PRs and fans out per-PR checks", as
       ],
     },
   ]);
-  // list call + one commit-status call
-  expect(calls.length).toBe(2);
+  // list call + default-branch call + one commit-status call
+  expect(calls.length).toBe(3);
+});
+
+test("GiteaForge.listPullRequests: nonDefaultBase set only for non-default-targeting PRs", async () => {
+  const { fn } = fakeFetch({
+    "GET /api/v1/repos/team/proj/pulls?state=open&limit=200": {
+      json: [
+        {
+          number: 1,
+          title: "targets default",
+          state: "open",
+          mergeable: true,
+          html_url: "u1",
+          head: { ref: "f1", sha: "a" },
+          base: { ref: "main" },
+        },
+        {
+          number: 2,
+          title: "stacked on epic",
+          state: "open",
+          mergeable: true,
+          html_url: "u2",
+          head: { ref: "f2", sha: "b" },
+          base: { ref: "epic/foo" },
+        },
+      ],
+    },
+    "GET /api/v1/repos/team/proj/commits/a/status": { json: { state: "success" } },
+    "GET /api/v1/repos/team/proj/commits/b/status": { json: { state: "success" } },
+    "GET /api/v1/repos/team/proj": { json: { default_branch: "main" } },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const prs = await forge.listPullRequests();
+  expect(prs.map((p) => p.nonDefaultBase)).toEqual([undefined, "epic/foo"]);
 });
 
 test("GiteaForge.listPullRequests: classifies dependabot + release PRs by kind", async () => {

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -144,6 +144,53 @@ test("GithubForge.listPullRequests: classifies dependabot + release PRs by kind"
   expect(prs.map((p) => p.kind)).toEqual(["dependabot", "release", "regular"]);
 });
 
+test("GithubForge.listPullRequests: nonDefaultBase set only for non-default-targeting PRs", async () => {
+  const prsJson = JSON.stringify([
+    {
+      number: 1,
+      title: "feat: targets default",
+      url: "u1",
+      author: { login: "alice" },
+      createdAt: "2024-02-02T00:00:00Z",
+      baseRefName: "main",
+    },
+    {
+      number: 2,
+      title: "feat: stacked on epic",
+      url: "u2",
+      author: { login: "bob" },
+      createdAt: "2024-02-02T00:00:00Z",
+      baseRefName: "epic/foo",
+    },
+  ]);
+  const { run } = fakeRunner({
+    "pr list": prsJson,
+    "repo view": JSON.stringify({ defaultBranchRef: { name: "main" } }),
+  });
+  const forge = new GithubForge("o/r", {}, run);
+  const prs = await forge.listPullRequests();
+  expect(prs.map((p) => p.nonDefaultBase)).toEqual([undefined, "epic/foo"]);
+});
+
+test("GithubForge.listPullRequests: nonDefaultBase undefined when default branch is unresolvable", async () => {
+  // No "repo view" mock → defaultBranch() rejects → def === null → no chip even
+  // for a non-default-targeting PR (fail-quiet, never a bogus chip).
+  const prsJson = JSON.stringify([
+    {
+      number: 2,
+      title: "feat: stacked on epic",
+      url: "u2",
+      author: { login: "bob" },
+      createdAt: "2024-02-02T00:00:00Z",
+      baseRefName: "epic/foo",
+    },
+  ]);
+  const { run } = fakeRunner({ "pr list": prsJson, "repo view": "{}" });
+  const forge = new GithubForge("o/r", {}, run);
+  const prs = await forge.listPullRequests();
+  expect(prs[0]!.nonDefaultBase).toBeUndefined();
+});
+
 test("GithubForge.listPullRequests: empty output → []", async () => {
   const { run } = fakeRunner({ "pr list": "" });
   const forge = new GithubForge("o/r", {}, run);

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -733,6 +733,7 @@
   "prspanel_open_link": "PR öffnen",
   "prspanel_draft": "Entwurf",
   "prspanel_conflicts": "Konflikte",
+  "prspanel_targets": "Ziel-Branch {branch}",
   "prspanel_review_button": "+ Review",
   "prspanel_review_button_title": "Review-Aufgabe mit diesem PR vorbefüllt öffnen",
   "prspanel_merge_button": "Merge",
@@ -1088,5 +1089,7 @@
   "readiness_g_dependency_automation_title": "Abhängigkeits-Automatisierung (Dependabot/Renovate)",
   "readiness_g_dependency_automation_removes": "Ohne sie häufen sich Abhängigkeits-Updates als manuelle Fleißarbeit an, statt als automatische PRs, die du nur noch prüfst und mergst.",
   "feat_dependency_automation_title": "Reife-Analyse prüft Abhängigkeits-Automatisierung",
-  "feat_dependency_automation_body": "Der Backlog → Reife-Tab bewertet jetzt, ob ein Repo seine Abhängigkeiten mit Dependabot oder Renovate aktuell hält, und empfiehlt sie, wenn sie fehlt."
+  "feat_dependency_automation_body": "Der Backlog → Reife-Tab bewertet jetzt, ob ein Repo seine Abhängigkeiten mit Dependabot oder Renovate aktuell hält, und empfiehlt sie, wenn sie fehlt.",
+  "feat_pr_target_branch_title": "PR-Zeilen zeigen einen abweichenden Ziel-Branch",
+  "feat_pr_target_branch_body": "Im Backlog → PRs-Tab zeigt ein PR, der auf einen abweichenden (Epic-/gestapelten) Branch zielt, jetzt einen kleinen Chip mit seinem Ziel – so sehen gestapelte PRs nicht mehr identisch zu denen aus, die auf den Standard-Branch zielen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -733,6 +733,7 @@
   "prspanel_open_link": "open PR",
   "prspanel_draft": "Draft",
   "prspanel_conflicts": "conflicts",
+  "prspanel_targets": "Targets {branch}",
   "prspanel_review_button": "+ Review",
   "prspanel_review_button_title": "Open a review task seeded with this PR",
   "prspanel_merge_button": "Merge",
@@ -1088,5 +1089,7 @@
   "readiness_g_dependency_automation_title": "Dependency automation (Dependabot/Renovate)",
   "readiness_g_dependency_automation_removes": "Without it, dependency bumps pile up as manual busywork instead of automated PRs you just review and merge.",
   "feat_dependency_automation_title": "Readiness checks dependency automation",
-  "feat_dependency_automation_body": "The Backlog → Readiness tab now scores whether a repo keeps dependencies current with Dependabot or Renovate, and prescribes it when missing."
+  "feat_dependency_automation_body": "The Backlog → Readiness tab now scores whether a repo keeps dependencies current with Dependabot or Renovate, and prescribes it when missing.",
+  "feat_pr_target_branch_title": "PR rows show a non-default target branch",
+  "feat_pr_target_branch_body": "In the Backlog → PRs tab, a PR that targets a non-default (epic/stacked) branch now shows a small chip with its target, so stacked PRs no longer look identical to ones targeting the default branch."
 }

--- a/ui/src/lib/components/PrRow.browser.test.ts
+++ b/ui/src/lib/components/PrRow.browser.test.ts
@@ -49,3 +49,27 @@ describe("PrRow kind tag", () => {
     expect(document.body.querySelector(".kind-tag")).toBeNull();
   });
 });
+
+describe("PrRow target branch chip", () => {
+  it("renders the target-branch chip when nonDefaultBase is set", async () => {
+    render(PrRow, {
+      repoPath: "/repo/a",
+      pr: pr({ nonDefaultBase: "epic/foo" }),
+      onreview: () => {},
+      onmerged: () => {},
+    });
+    const chip = document.body.querySelector(".target-branch");
+    expect(chip).not.toBeNull();
+    expect(chip!.textContent).toContain("epic/foo");
+  });
+
+  it("renders no target-branch chip when nonDefaultBase is unset", () => {
+    render(PrRow, {
+      repoPath: "/repo/a",
+      pr: pr(),
+      onreview: () => {},
+      onmerged: () => {},
+    });
+    expect(document.body.querySelector(".target-branch")).toBeNull();
+  });
+});

--- a/ui/src/lib/components/PrRow.svelte
+++ b/ui/src/lib/components/PrRow.svelte
@@ -185,6 +185,15 @@
       {#if blocked}
         <span class="conflict">{m.prspanel_conflicts()}</span>
       {/if}
+      {#if pr.nonDefaultBase}
+        <span
+          class="target-branch"
+          title={m.prspanel_targets({ branch: pr.nonDefaultBase })}
+          aria-label={m.prspanel_targets({ branch: pr.nonDefaultBase })}
+        >
+          <span class="arrow" aria-hidden="true">→</span>{pr.nonDefaultBase}
+        </span>
+      {/if}
       {#if pr.author}<span class="author">@{pr.author}</span>{/if}
       {#if age}
         <span class="age-chip">{relativeAge(pr.createdAt, clock.current)}</span>
@@ -477,6 +486,26 @@
     letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--color-red);
+  }
+
+  /* Non-default target branch — a hairline neutral chip (mirrors .kind-tag),
+     shown ONLY when the PR targets something other than the repo default (a
+     stacked/epic branch). Neutral hue: never a status green/amber. A long
+     branch name truncates rather than stretching the row. */
+  .target-branch {
+    flex-shrink: 0;
+    max-width: 12em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--fs-micro);
+    padding: 1px 5px;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+  }
+  .target-branch .arrow {
+    margin-right: 2px;
   }
 
   .author {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -636,4 +636,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_dependency_automation_title",
     bodyKey: "feat_dependency_automation_body",
   },
+  {
+    // No targetId: the chip is per-row/dynamic (only on PRs targeting a non-default
+    // branch) — there's no single stable anchor for a coachmark. Surface via the
+    // What's-New drawer only.
+    id: "pr-target-branch",
+    sinceVersion: "1.28.0",
+    titleKey: "feat_pr_target_branch_title",
+    bodyKey: "feat_pr_target_branch_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -167,6 +167,12 @@ export interface PullRequest {
     author: string;
     submittedAt: number;
   };
+  /** The PR's base (target) branch, populated ONLY when it is NOT the repo's
+   *  default branch (e.g. an epic/stacked branch); `undefined` for the common
+   *  default-targeting PR. This is intentionally NOT the raw base ref — do not
+   *  rely on it to read a PR's actual target; it exists solely to surface
+   *  non-default (stacked) PRs in the backlog PRs tab. */
+  nonDefaultBase?: string;
 }
 
 /** Result of fast-forwarding a repo's local default-branch checkout after a merge


### PR DESCRIPTION
## Why

In the backlog → PRs pane, a PR targeting a **non-default** branch (an epic/stacked branch) looked identical to one targeting `main` — so a stacked PR (like the `#330` row in the reported screenshot, which targets an epic branch) gave no hint it doesn't merge into the default branch. This makes that case visible.

## What

PR rows now show a small `→ <branch>` chip **only when** the PR targets something other than the repo's default branch. Default-targeting PRs (the ~95% case) render nothing — no redundant `→ main`.

The "is it non-default?" decision lives **server-side** (single source of truth = the forge's own `defaultBranch()`), so the UI carries no magic `"main"`/`"master"` constant.

- **Model:** `PullRequest.nonDefaultBase?: string` (server `src/forge/types.ts` + client mirror), populated **only** for non-default targets, `undefined` otherwise (doc comment warns it is *not* the raw base ref).
- **GitHub forge:** fetch `baseRefName`, resolve the default branch concurrently (`Promise.all`, failure-guarded), set `nonDefaultBase` when it differs. `defaultBranch()` is now **memoized** (mirrors `cachedUser`) and reused by `listWorkflowRuns`, killing a duplicate `repo view` round-trip.
- **Gitea forge:** read `base.ref`, same non-default comparison.
- **UI:** hairline `.target-branch` chip in `PrRow.svelte`'s meta line — mirrors the `.kind-tag` recipe, tokens only, neutral hue (not status green/amber), truncates long refs; `title` + `aria-label` via the new `prspanel_targets` message.
- **Fail-quiet:** if the default branch can't be resolved, the chip is omitted (we can't assert "non-default" without a known default) — documented inline.

## i18n & discovery
- `prspanel_targets` added to EN + DE (parity gate passes).
- One feature-announcement entry (`pr-target-branch`, `sinceVersion 1.28.0`) for the What's-New drawer.

## Tests
- GitHub forge: non-default → set, default → `undefined`, and default-unresolvable → `undefined` (fail-quiet).
- Gitea forge: analogous non-default/default test; existing fan-out test updated for the added repo-info call.
- `PrRow.browser.test.ts`: chip present when set, absent when not.

All gates green: root `bun run lint` + `bun test ./test` (2208 pass); UI `bun run check`, `check:i18n` (locales in parity), `bun run test` (1100 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)