### PR TITLE
fix(autopilot): re-engage idle full-auto sessions stuck on red CI

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -39,7 +39,10 @@ export const CI_FIX_STEER = [
 const STEERABLE_SHAPES = new Set(["awaiting-input", "yes-no"]);
 
 export interface AutopilotDeps {
-  store: Pick<SessionStore, "get" | "getRepoConfig" | "setAutopilotState" | "setAutoMergeState">;
+  store: Pick<
+    SessionStore,
+    "get" | "list" | "getRepoConfig" | "setAutopilotState" | "setAutoMergeState"
+  >;
   /** Classify why an agent stopped (src/autopilot-llm.classifyStop, pre-bound to herdr+model). */
   classify: (tail: string[], taskPrompt: string, label: string) => Promise<AutopilotVerdict>;
   /** Steer text into the session's live PTY (SessionService.reply). false = didn't land. */
@@ -54,6 +57,11 @@ export interface AutopilotDeps {
   /** Whether the session already has a PR in any state (open/merged/closed). True → autopilot
    *  stands down (open = critic territory; merged/closed = pre-PR mission over). */
   hasPr: (id: string) => boolean;
+  /** The cached PR snapshot for a session (the PR poller's last poll), or null when there is
+   *  none. The recurring tick reads this directly — NOT off a `session:git` emit — so it can
+   *  re-engage an idle agent stuck on an UNCHANGED open+red head, the case the event-driven
+   *  `onGit`/`considerCi` path structurally cannot reach (the poller only emits on a state change). */
+  prGit: (id: string) => GitState | null;
   /** Whether this session is in full-auto (autopilot ∧ auto-merge). When true, autopilot does
    *  NOT stand down at PR-open — it keeps unblocking procedural gates so a rebase can finish. */
   fullAuto: (id: string) => boolean;
@@ -71,8 +79,12 @@ export interface AutopilotDeps {
 }
 
 const DEFAULT_STEP_CAP = 10;
-/** Shown when the runaway guard trips rather than a classifier question. */
+/** Shown when the pre-PR runaway guard trips rather than a classifier question. */
 const CAP_MESSAGE = "Autopilot reached its step limit without opening a PR — over to you.";
+/** Hand-back when the post-PR CI-fix loop exhausts its step budget. Distinct from CAP_MESSAGE:
+ *  on the CI path a PR is already open, so "without opening a PR" would be wrong. */
+export const CI_CAP_MESSAGE =
+  "Autopilot couldn't get CI green after repeated attempts — over to you.";
 /** Generic hand-back text when a question/unknown verdict carries no summary of its own. */
 const SURFACE_MESSAGE = "Autopilot paused for your input.";
 /** Non-alarming hand-back text when a `complete` verdict carries no summary of its own. */
@@ -85,8 +97,10 @@ export class AutopilotService {
   // Post-PR CI-red recovery state (onGit). `openSeen` fires the critic handoff (pause-clear +
   // budget reset) exactly once per PR-open, so the 120s git poll doesn't keep zeroing the
   // step budget the CI-fix loop is spending. `ciNudged` maps a session to the head SHA we last
-  // steered for a red CI, so a still-failing head isn't re-nudged every poll — only a fresh
-  // push (new head) that still fails earns another steer.
+  // steered for a red CI: onGit/considerCi handles only red-CI STATE CHANGES (none→red, and a
+  // new-but-still-red head after a push), so a still-failing UNCHANGED head isn't re-nudged on
+  // every poll. Sustained idle re-engagement on that unchanged red head — which onGit cannot
+  // deliver (the poller emits no `session:git` without a state change) — is owned by tick().
   private openSeen = new Set<string>();
   private ciNudged = new Map<string, string>();
   private stepCap: number;
@@ -141,15 +155,21 @@ export class AutopilotService {
     this.deps.store.setAutopilotState(s.id, { stepCount: s.autopilotStepCount + 1 });
   }
 
-  /** Steer `text` into the session, resuming an exited pane first. Bumps the step on a
-   *  landed steer. Returns nothing — best-effort; a dead/unreachable pane just doesn't count. */
-  private async driveSteer(s: Session, text: string): Promise<void> {
+  /** Send `text` into the session, resuming an exited pane first. Returns whether the steer
+   *  landed; does NOT bump the step (the caller decides whether the attempt counts). */
+  private async sendSteer(s: Session, text: string): Promise<boolean> {
     if (!this.deps.paneAlive(s.id)) {
       // Exited pane: resume so there's something to steer. resume() resolves falsy when it
       // can't (archived / no pinned session id) — then there's nothing to do.
-      if (!(await this.deps.resume(s.id))) return;
+      if (!(await this.deps.resume(s.id))) return false;
     }
-    if (this.deps.steer(s.id, text)) this.bump(s);
+    return this.deps.steer(s.id, text);
+  }
+
+  /** Steer `text` into the session and bump the step on a landed steer. Best-effort —
+   *  a dead/unreachable pane just doesn't count. */
+  private async driveSteer(s: Session, text: string): Promise<void> {
+    if (await this.sendSteer(s, text)) this.bump(s);
   }
 
   private async dispatch(s: Session, v: AutopilotVerdict): Promise<void> {
@@ -205,6 +225,11 @@ export class AutopilotService {
     // (multi-second) classify spawn, so the post-classify eligible()/hasPr re-check in
     // consider() sees the fresh PR and stands down instead of redundantly steering "open a PR".
     this.deps.refreshPr?.(id);
+    // Stuck-red full-auto: re-engage the CI-fix loop and stand down BEFORE classifying. The LLM
+    // classifier could otherwise mark this idle red session complete/finished (silencing it AND
+    // making the tick skip it, since complete/paused sessions are ineligible). Lower latency than
+    // waiting for the next tick. reEngageCi returns true when it owned the session (steered/paused).
+    if (this.reEngageCi(id)) return;
     let tail: string[] = [];
     try {
       tail = this.deps.readTail(id);
@@ -279,17 +304,20 @@ export class AutopilotService {
     if (git.checks === "failure") this.considerCi(s, git);
   }
 
-  /** Open PR + red CI → steer the task agent to fix it. Synchronous (no classify needed: a red
-   *  rollup is already an actionable verdict). The caller (onGit) has already checked
-   *  existence / archive / enablement; here we gate on pause + per-head dedup and bound it by
-   *  the same step cap as the gate loop. */
+  /** Open PR + red CI → steer the task agent to fix it. The responsive FIRST-RESPONSE to a
+   *  red-CI STATE CHANGE only (none→red, or a new-but-still-red head after a push): it's reachable
+   *  solely via onGit, which the poller fires only on a state change, so it cannot re-fire on an
+   *  unchanged red head — sustained idle re-engagement on that is owned by tick(). Synchronous (no
+   *  classify needed: a red rollup is already an actionable verdict). The caller (onGit) has already
+   *  checked existence / archive / enablement; here we gate on pause + per-head dedup and bound it
+   *  by the same step cap as the gate loop. */
   private considerCi(s: Session, git: GitState): void {
     if (s.autopilotPaused) return; // already handed back; waits for operator
     if (this.pending.has(s.id)) return; // a classify (gate/done path) is mid-flight
     if (!git.headSha) return; // can't dedup a headless rollup → skip rather than spam
     if (this.ciNudged.get(s.id) === git.headSha) return; // already nudged this exact red head
     if (s.autopilotStepCount >= this.stepCap) {
-      this.pause(s, CAP_MESSAGE); // runaway guard — stop thrashing CI, surface to operator
+      this.pause(s, CI_CAP_MESSAGE); // runaway guard — stop thrashing CI, surface to operator
       return;
     }
     this.ciNudged.set(s.id, git.headSha);
@@ -299,5 +327,54 @@ export class AutopilotService {
     void this.driveSteer(s, CI_FIX_STEER).catch((err) =>
       console.warn("[autopilot] ci-fix steer:", err),
     );
+  }
+
+  /** Re-engage an idle full-auto session stuck on an open+red PR, or hand it back at the cap.
+   *  This is the event-INDEPENDENT recovery: it reads the cached PR snapshot directly (prGit),
+   *  so it works even when no `session:git` re-emits (unchanged red head). Returns true when it
+   *  OWNED the session (re-engaged or paused), so onDone can short-circuit before classifying.
+   *  Returns false for any ineligible session (no PR / green / pending / paused / complete /
+   *  autopilot-off / non-full-auto), leaving it untouched. */
+  private reEngageCi(id: string): boolean {
+    const s = this.deps.store.get(id);
+    if (!s || s.status === "archived") return false;
+    if (!this.enabled(s)) return false;
+    if (s.autopilotPaused) return false; // already handed back; waits for operator
+    if (s.autopilotComplete) return false; // terminal
+    if (!this.deps.fullAuto(id)) return false; // only full-auto owns the post-PR CI loop
+    const git = this.deps.prGit(id);
+    if (!git || git.state !== "open" || git.checks !== "failure") return false;
+    // Cap check BEFORE any bump/steer: at the budget, hand back instead of thrashing CI.
+    if (s.autopilotStepCount >= this.stepCap) {
+      this.pause(s, CI_CAP_MESSAGE);
+      return true;
+    }
+    // Count the attempt toward the cap regardless of whether the steer lands, so a
+    // dead/unresumable pane still marches to the cap → guaranteed clean hand-back.
+    // The only "agent is working" guard is the caller's status filter (tick's running/blocked
+    // skip). A steer takes a moment to flip the agent to "running", so a tick (or an onDone
+    // racing a just-fired considerCi steer) inside that gap can re-bump the same idle head: the
+    // step budget can burn slightly faster than one attempt per idle episode. That's harmless
+    // (the steer coalesces at the PTY) and bounded by the cap — it only ever hastens the clean
+    // hand-back, never a silent hang.
+    this.bump(s);
+    void this.sendSteer(s, CI_FIX_STEER).catch((err) =>
+      console.warn("[autopilot] ci re-engage steer:", err),
+    );
+    return true;
+  }
+
+  /** Recurring re-engagement sweep (driven by a ~30s setInterval in index.ts). Iterates all
+   *  sessions and re-engages the idle ones stuck on a red PR. A timer fires regardless of events,
+   *  so it is the one trigger that reliably re-fires while an agent idles on an UNCHANGED red head
+   *  — the case onGit/considerCi provably cannot reach. Only the idle filter lives here (status
+   *  done/idle, i.e. NOT running/blocked — mirrors the active grouping at poller.ts:314); all
+   *  eligibility/red/full-auto checks live inside reEngageCi. */
+  async tick(): Promise<void> {
+    for (const s of this.deps.store.list()) {
+      if (s.status === "archived") continue;
+      if (s.status === "running" || s.status === "blocked") continue; // working — don't interrupt
+      this.reEngageCi(s.id);
+    }
   }
 }

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -341,6 +341,7 @@ export class AutopilotService {
     if (!this.enabled(s)) return false;
     if (s.autopilotPaused) return false; // already handed back; waits for operator
     if (s.autopilotComplete) return false; // terminal
+    if (this.pending.has(id)) return false; // a classify (onDone/onBlock) is mid-flight — its dispatch will act; don't race it
     if (!this.deps.fullAuto(id)) return false; // only full-auto owns the post-PR CI loop
     const git = this.deps.prGit(id);
     if (!git || git.state !== "open" || git.checks !== "failure") return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -504,6 +504,7 @@ const autopilot = new AutopilotService({
     const st = prPoller.snapshot()[id]?.state;
     return st !== undefined && st !== "none";
   },
+  prGit: (id) => prPoller.snapshot()[id] ?? null,
   fullAuto: (id) => {
     const s = store.get(id);
     return !!s && isFullAuto(s, store.getRepoConfig(s.repoPath));
@@ -642,6 +643,13 @@ events.subscribe((event, data) => {
 setInterval(() => {
   if (maintenance.active) return;
   void autoMerge.tick().catch((err) => console.warn("[automerge] tick:", err));
+}, 30_000);
+// Re-engage idle full-auto sessions stuck on an open+red PR. A timer is the one trigger that
+// re-fires on an UNCHANGED red head (the PR poller emits no `session:git` without a state change),
+// so this owns the sustained re-engagement that onGit/considerCi structurally cannot deliver.
+setInterval(() => {
+  if (maintenance.active) return;
+  void autopilot.tick().catch((err) => console.warn("[autopilot] tick:", err));
 }, 30_000);
 
 const draftReconcile = new DraftReconcileService({

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -698,6 +698,26 @@ test("onDone guard: stuck-red full-auto re-engages and does NOT classify", async
   expect(h.state().autopilotStepCount).toBe(1);
 });
 
+test("pending guard: tick() does not re-engage while a classify is mid-flight", async () => {
+  // A `done`/idle session is exactly the status held while onDone→consider→classify() awaits the
+  // LLM. Without the `pending` guard a tick would steer CI_FIX_STEER + bump over that in-flight
+  // classify, racing its dispatch. The guard makes reEngageCi bail so the classify's own dispatch acts.
+  const h = stuckRed();
+  let release!: () => void;
+  const gate = new Promise<void>((r) => (release = r));
+  (h.svc as any).deps.classify = async (): Promise<AutopilotVerdict> => {
+    await gate;
+    return { kind: "complete", summary: "done" };
+  };
+  const inflight = h.svc.onBlock("s1", block()); // consider() adds `pending`, then awaits classify
+  await Promise.resolve(); // yield so onBlock reaches the classify await with `pending` set
+  h.svc.tick(); // `pending` set → reEngageCi bails → no CI steer, no bump
+  expect(h.events.some((e) => "steer" in e && e.steer === CI_FIX_STEER)).toBe(false);
+  expect(h.state().autopilotStepCount).toBe(0);
+  release();
+  await inflight; // let the gated classify settle so no promise dangles
+});
+
 test("guaranteed hand-back on a dead pane: failed resume still bumps toward the cap", async () => {
   const h = harness({
     session: sess({ status: "done" }),

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -1,8 +1,16 @@
 import { test, expect, mock } from "bun:test";
-import { AutopilotService, PROCEED_STEER, OPEN_PR_STEER, openPrSteer } from "../src/autopilot";
+import {
+  AutopilotService,
+  PROCEED_STEER,
+  OPEN_PR_STEER,
+  openPrSteer,
+  CI_FIX_STEER,
+  CI_CAP_MESSAGE,
+} from "../src/autopilot";
 import { DRAFT_PR_NOTE } from "../src/service";
 import type { AutopilotVerdict, Session } from "../src/types";
 import type { BlockReason } from "../src/blocked";
+import type { GitState } from "../src/forge/types";
 
 function sess(over: Partial<Session> = {}): Session {
   return {
@@ -59,13 +67,17 @@ function harness(opts: {
   resumeOk?: boolean;
   steerOk?: boolean;
   fullAuto?: boolean;
+  /** Cached PR snapshot returned by the prGit dep (the tick / reEngageCi source). */
+  prGit?: GitState | null;
 }) {
   let cur = opts.session;
   const events: any[] = [];
   const setAutoMergeStateCalls: any[] = [];
+  let classifyCalls = 0;
   const svc = new AutopilotService({
     store: {
       get: () => cur,
+      list: () => [cur],
       getRepoConfig: () =>
         ({
           criticEnabled: true,
@@ -106,7 +118,10 @@ function harness(opts: {
         };
       },
     } as any,
-    classify: async () => opts.verdict ?? { kind: "unknown", summary: "" },
+    classify: async () => {
+      classifyCalls++;
+      return opts.verdict ?? { kind: "unknown", summary: "" };
+    },
     steer: (_id, text) => {
       events.push({ steer: text });
       return opts.steerOk ?? true;
@@ -118,6 +133,7 @@ function harness(opts: {
     paneAlive: () => opts.paneAlive ?? true,
     readTail: () => ["finished, nothing else"],
     hasPr: () => opts.openPr ?? false,
+    prGit: () => opts.prGit ?? null,
     fullAuto: () => opts.fullAuto ?? false,
     refreshPr: (id) => events.push({ refreshPr: id }),
     onPause: (id, q) => events.push({ pause: id, q }),
@@ -125,7 +141,13 @@ function harness(opts: {
     onState: (id) => events.push({ state: id }),
     stepCap: 10,
   });
-  return { svc, events, state: () => cur, mergeStateCalls: setAutoMergeStateCalls };
+  return {
+    svc,
+    events,
+    state: () => cur,
+    mergeStateCalls: setAutoMergeStateCalls,
+    classifyCount: () => classifyCalls,
+  };
 }
 
 test("gate verdict → proceed steer + step++", async () => {
@@ -462,6 +484,7 @@ test("re-entrant onBlock during an in-flight classify spawns + steers only once"
     paneAlive: () => true,
     readTail: () => [],
     hasPr: () => false,
+    prGit: () => null,
     fullAuto: () => false,
     onPause: () => {},
     stepCap: 10,
@@ -479,9 +502,6 @@ test("re-entrant onBlock during an in-flight classify spawns + steers only once"
 // on green CI (review.ts) and pre-PR autopilot has stood down (hasPr). A PR sitting on
 // red CI is steered by nobody. onGit closes that gap: open + checks "failure" → drive
 // the task agent to fix the failing checks (dedup per head, step-capped).
-import { CI_FIX_STEER } from "../src/autopilot";
-import type { GitState } from "../src/forge/types";
-
 function git(over: Partial<GitState> = {}): GitState {
   return {
     kind: "github",
@@ -494,25 +514,30 @@ function git(over: Partial<GitState> = {}): GitState {
   };
 }
 
-test("open PR + failing CI → CI-fix steer + step++", () => {
+test("open PR + failing CI → CI-fix steer + step++", async () => {
   const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
   h.svc.onGit("s1", git());
+  await Promise.resolve(); // driveSteer bumps one microtask after the sync onGit returns
   expect(h.events).toContainEqual({ steer: CI_FIX_STEER });
   expect(h.state().autopilotStepCount).toBe(1);
 });
 
-test("same failing head is nudged only once", () => {
+test("same failing head is nudged only once", async () => {
   const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
   h.svc.onGit("s1", git({ headSha: "sha1" }));
+  await Promise.resolve();
   h.svc.onGit("s1", git({ headSha: "sha1" })); // next poll, same red head
+  await Promise.resolve();
   expect(h.events.filter((e) => "steer" in e).length).toBe(1);
   expect(h.state().autopilotStepCount).toBe(1);
 });
 
-test("a new failing head (agent pushed a fix that still fails) re-steers", () => {
+test("a new failing head (agent pushed a fix that still fails) re-steers", async () => {
   const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
   h.svc.onGit("s1", git({ headSha: "sha1" }));
+  await Promise.resolve();
   h.svc.onGit("s1", git({ headSha: "sha2" }));
+  await Promise.resolve();
   expect(h.events.filter((e) => "steer" in e).length).toBe(2);
   expect(h.state().autopilotStepCount).toBe(2);
 });
@@ -551,14 +576,19 @@ test("CI-fix recovery resumes a dead pane before steering", async () => {
   expect(h.events).toContainEqual({ steer: CI_FIX_STEER });
 });
 
-test("step cap stops CI-fix thrash and pauses to the operator", () => {
+test("step cap stops CI-fix thrash and pauses to the operator", async () => {
   const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
   // The session starts at step 0; each distinct red head burns one step (the red CI skips the
   // onPrOpen handoff, so there's no budget reset). With stepCap 10, the 11th distinct failing
-  // head surfaces (pauses) instead of steering.
-  for (let i = 0; i <= 10; i++) h.svc.onGit("s1", git({ headSha: "sha" + i }));
+  // head surfaces (pauses) instead of steering. Flush after each poll so the (async) bump from
+  // poll N is visible to the cap check at poll N+1 — the production polls are seconds apart.
+  for (let i = 0; i <= 10; i++) {
+    h.svc.onGit("s1", git({ headSha: "sha" + i }));
+    await Promise.resolve();
+  }
   expect(h.events.filter((e) => "steer" in e).length).toBe(10);
   expect(h.state().autopilotPaused).toBe(true);
+  expect(h.events).toContainEqual({ pause: "s1", q: CI_CAP_MESSAGE });
 });
 
 test("a green PR-open hands off to the critic (clears a stale pause + resets budget)", () => {
@@ -580,10 +610,11 @@ test("a deliberate pause survives a PR-open handoff (in-memory openSeen lost on 
   expect(h.state().autopilotStepCount).toBe(7);
 });
 
-test("handoff reset fires once per PR-open, not every poll (preserves CI-fix budget)", () => {
+test("handoff reset fires once per PR-open, not every poll (preserves CI-fix budget)", async () => {
   const h = harness({ session: sess({ status: "running" }), repoEnabled: true });
   h.svc.onGit("s1", git({ checks: "success", headSha: "sha1" })); // open transition → reset
   h.svc.onGit("s1", git({ checks: "failure", headSha: "sha1" })); // red → step 1
+  await Promise.resolve(); // let the (async) bump land before the next same-head poll
   h.svc.onGit("s1", git({ checks: "failure", headSha: "sha1" })); // same red head, no reset, no re-steer
   expect(h.state().autopilotStepCount).toBe(1);
 });
@@ -612,4 +643,160 @@ test("eligible() returns null while planPhase === 'planning' (autopilot suppress
   await h.svc.onDone("s1");
   expect(classified).toBe(false); // never classified
   expect(h.events.some((e) => "steer" in e)).toBe(false); // never steered
+});
+
+// ───────────────── tick() idle re-engagement (the silent-hang fix) ─────────────────
+// onGit/considerCi fires only on a red-CI STATE CHANGE; the PR poller emits no `session:git`
+// for an UNCHANGED red head, so an idle full-auto agent sitting on the same red PR is reached
+// by NOBODY there. The recurring tick() owns that case — it reads the cached PR (prGit) directly,
+// re-engages each idle poll, and ultimately caps + hands back.
+
+/** A stuck-red full-auto idle session: autopilot on, full-auto, cached open+red PR. */
+function stuckRed(over: Partial<Session> = {}) {
+  return harness({
+    session: sess({ status: "done", ...over }),
+    repoEnabled: true,
+    fullAuto: true,
+    prGit: git(), // open + failure
+  });
+}
+
+test("real-trigger regression: repeated tick() re-engages an idle red PR, then caps + notifies", () => {
+  const h = stuckRed();
+  // Each tick re-engages (step++ + CI-fix steer) — NO onGit needed (the gitStateChanged gate
+  // never re-emits for the unchanged red head). Drive ticks until the step budget (cap 10) trips.
+  for (let i = 0; i < 10; i++) h.svc.tick();
+  expect(h.events.filter((e) => "steer" in e && e.steer === CI_FIX_STEER).length).toBe(10);
+  expect(h.state().autopilotStepCount).toBe(10);
+  expect(h.state().autopilotPaused).toBe(false);
+  // The 11th tick is at the cap → pause + push (onPause), no further steer.
+  h.svc.tick();
+  expect(h.state().autopilotPaused).toBe(true);
+  expect(h.events).toContainEqual({ pause: "s1", q: CI_CAP_MESSAGE });
+  expect(h.events.filter((e) => "steer" in e).length).toBe(10); // no steer on the cap tick
+});
+
+test("idle gate: tick() does not steer a running session", () => {
+  const h = stuckRed({ status: "running" });
+  h.svc.tick();
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  expect(h.state().autopilotStepCount).toBe(0);
+});
+
+test("idle gate: tick() does not steer a blocked session", () => {
+  const h = stuckRed({ status: "blocked" });
+  h.svc.tick();
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  expect(h.state().autopilotStepCount).toBe(0);
+});
+
+test("onDone guard: stuck-red full-auto re-engages and does NOT classify", async () => {
+  const h = stuckRed();
+  await h.svc.onDone("s1");
+  expect(h.classifyCount()).toBe(0); // never reached the LLM classifier
+  expect(h.events).toContainEqual({ steer: CI_FIX_STEER });
+  expect(h.state().autopilotStepCount).toBe(1);
+});
+
+test("guaranteed hand-back on a dead pane: failed resume still bumps toward the cap", async () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    repoEnabled: true,
+    fullAuto: true,
+    prGit: git(),
+    paneAlive: false,
+    resumeOk: false, // resume fails → steer never lands
+  });
+  // The bump happens BEFORE the (failing) steer, so each tick counts toward the cap regardless.
+  for (let i = 0; i < 10; i++) h.svc.tick();
+  await Promise.resolve(); // flush the fire-and-forget sendSteer microtasks
+  expect(h.state().autopilotStepCount).toBe(10);
+  expect(h.events.some((e) => "steer" in e)).toBe(false); // resume failed → nothing steered
+  h.svc.tick(); // at cap → pause
+  expect(h.state().autopilotPaused).toBe(true);
+  expect(h.events).toContainEqual({ pause: "s1", q: CI_CAP_MESSAGE });
+});
+
+test("negative: tick() ignores a session with no PR (prGit null)", () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    repoEnabled: true,
+    fullAuto: true,
+    prGit: null,
+  });
+  h.svc.tick();
+  expect(h.events.length).toBe(0);
+});
+
+test("negative: tick() ignores a green PR", () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    repoEnabled: true,
+    fullAuto: true,
+    prGit: git({ checks: "success" }),
+  });
+  h.svc.tick();
+  expect(h.events.length).toBe(0);
+});
+
+test("negative: tick() ignores a pending PR", () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    repoEnabled: true,
+    fullAuto: true,
+    prGit: git({ checks: "pending" }),
+  });
+  h.svc.tick();
+  expect(h.events.length).toBe(0);
+});
+
+test("negative: tick() ignores a closed PR even when red", () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    repoEnabled: true,
+    fullAuto: true,
+    prGit: git({ state: "closed" }),
+  });
+  h.svc.tick();
+  expect(h.events.length).toBe(0);
+});
+
+test("negative: tick() ignores a paused session", () => {
+  const h = stuckRed({ autopilotPaused: true });
+  h.svc.tick();
+  expect(h.events.length).toBe(0);
+});
+
+test("negative: tick() ignores a complete session", () => {
+  const h = stuckRed({ autopilotComplete: true });
+  h.svc.tick();
+  expect(h.events.length).toBe(0);
+});
+
+test("negative: tick() ignores an autopilot-disabled session", () => {
+  const h = harness({
+    session: sess({ status: "done", autopilotEnabled: false }),
+    repoEnabled: true,
+    fullAuto: true,
+    prGit: git(),
+  });
+  h.svc.tick();
+  expect(h.events.length).toBe(0);
+});
+
+test("negative: tick() ignores a non-full-auto session (post-PR CI loop is full-auto only)", () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    repoEnabled: true,
+    fullAuto: false,
+    prGit: git(),
+  });
+  h.svc.tick();
+  expect(h.events.length).toBe(0);
+});
+
+test("negative: tick() ignores an archived session", () => {
+  const h = stuckRed({ status: "archived" });
+  h.svc.tick();
+  expect(h.events.length).toBe(0);
 });


### PR DESCRIPTION
## Problem

In full-auto mode (autopilot ∧ auto-merge), a session whose PR sat on **open + red CI** could silently hang: the agent went idle, CI stayed red, **nobody re-engaged it**, and no operator notification fired. The operator had to step in. (Confirmed symptom: agent idle, nothing moving.)

## Root cause

`AutopilotService.considerCi` is the only actor on a red PR — the critic skips red, and the merge train idle-holds on red. But `considerCi` is reachable only from `autopilot.onGit`, which fires on a `session:git` event, and the PR poller emits `session:git` **only when `gitStateChanged()` is true** (`src/pr-poller.ts:73-87`). An idle agent on an **unchanged** red head (same `headSha`, `checks` still `"failure"`) produces no state change → no event → `considerCi` never re-fires → no further steps burned → the step cap never trips → **no pause, no notification**. Silent hang.

`onDone` *does* fire each time the agent idles, but it ran the LLM classifier, whose `finished`/`complete`/`question` verdict is exactly what let the idle red PR fall silent (`complete` even marked it terminally "done" while CI was red).

## Fix

Two reliable, event-independent mechanisms (robust retry → guaranteed clean hand-back):

1. **Recurring `AutopilotService.tick()`** (a ~30s `setInterval` in `index.ts`, alongside the existing drain/auto-merge ticks). A timer fires regardless of poll emits, so it reliably re-fires while an agent idles on an unchanged red head. It re-engages **idle** full-auto sessions stuck on a cached open red PR (read directly via a new `prGit` dep, not an emit), **capped** so a stuck PR always reaches a clean operator pause + push notification.
2. **`onDone` guard:** stuck-red full-auto sessions re-engage immediately and return **before** classifying, so the classifier can't mis-mark them complete/finished (which would also make the tick skip them).

Shared helper `reEngageCi(id)` checks the cap **before** any bump/steer, then bumps the step *regardless of whether the steer lands* — so even a dead/unresumable pane marches to the cap rather than hanging. `considerCi`/`onGit` is kept as the responsive first-response to red-CI **state changes** (none→red, new-but-still-red head) with its per-head dedup intact; the two compose without double-firing (a steered agent is `running`, which the tick's idle gate skips).

Also adds a CI-specific `CI_CAP_MESSAGE` — the shared `CAP_MESSAGE` ("…without opening a PR") was wrong on the post-PR CI path.

## Scope

Server-only: `src/autopilot.ts`, `src/index.ts`, `test/autopilot.test.ts`. No UI, no new config knobs. `CI_CAP_MESSAGE` is server-side English passed verbatim as the `{question}` data param into the existing i18n shell (same pattern as `CAP_MESSAGE`) — no new catalog keys.

## Testing

New tests model the **real trigger** (repeated `tick()` against a static red `prGit` + idle status — not repeated `onGit`, which would bypass the `gitStateChanged` gate):
- Real-trigger regression: repeated ticks re-engage (step++) and reach a `CI_CAP_MESSAGE` pause + `onPause` notify.
- Idle gate: `running`/`blocked` sessions are not steered.
- `onDone` guard: classifier never invoked for a stuck-red full-auto session.
- Guaranteed hand-back on a dead pane: a failed `resume` still bumps to the cap.
- Negative cases: no-PR / green / pending / paused / complete / autopilot-off / non-full-auto / archived untouched.

- `bun test ./test/autopilot.test.ts` → 61 pass
- `bun test ./test` → 2219 pass / 1 skip
- `bun run lint` clean · `bunx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
