### PR TITLE
refactor(automation): move lengthy sandbox explanation behind a tap-to-open ⓘ

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1107,5 +1107,6 @@
   "automation_allprs_desc": "Kritiker prüft jeden offenen CI-grünen PR, nicht nur die der Agenten",
   "automation_allprs_detail": "Normalerweise prüft der Kritiker nur Pull Requests, die Shepherds eigene Agenten öffnen. Ist dies an, durchsucht der Kritiker stattdessen periodisch das gesamte Repo und prüft jeden offenen, CI-grünen Pull Request — auch solche von Menschen oder anderen Werkzeugen sowie Beiträge aus Forks. Jeder erhält denselben nur-lesenden Diff-Review, gepostet als Kommentar (nie eine blockierende Änderungsanforderung, damit Fremd-PRs nicht ausgebremst werden). Dies ist unabhängig vom Kritiker-Schalter pro Session und prüft mehr PRs, kostet also mehr Tokens. Jeder PR wird einmal pro gepushtem Head geprüft; ein reiner Rebase wird nicht erneut geprüft.",
   "feat_critic_all_prs_title": "Critic prüft jeden Pull Request",
-  "feat_critic_all_prs_body": "Aktiviere „Alle PRs prüfen“ im Automatisierungs-Panel eines Repos, damit der Critic jeden CI-grünen Pull Request bewertet – nicht nur solche, die einer Shepherd-Sitzung zugeordnet sind. Pro Repo opt-in; beachte den höheren Token-Verbrauch bei vielen offenen PRs."
+  "feat_critic_all_prs_body": "Aktiviere „Alle PRs prüfen“ im Automatisierungs-Panel eines Repos, damit der Critic jeden CI-grünen Pull Request bewertet – nicht nur solche, die einer Shepherd-Sitzung zugeordnet sind. Pro Repo opt-in; beachte den höheren Token-Verbrauch bei vielen offenen PRs.",
+  "automation_sandbox_profile_summary": "Optionale Abschottung für Agenten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1107,5 +1107,6 @@
   "automation_allprs_desc": "Critic reviews every open CI-green PR, not just agent ones",
   "automation_allprs_detail": "Normally the Critic only reviews pull requests opened by Shepherd's own agents. Turn this on and the Critic instead sweeps the whole repo on a timer, reviewing every open, CI-green pull request — including ones humans or other tools opened, and fork contributions. Each gets the same read-only diff review, posted as a comment (never a blocking change request, so it won't gate third-party PRs). This is independent of the per-session Critic switch and reviews more PRs, so it costs more tokens. Each PR is reviewed once per pushed head; a pure rebase isn't re-reviewed.",
   "feat_critic_all_prs_title": "Critic reviews every PR",
-  "feat_critic_all_prs_body": "Enable \"Review all PRs\" in a repo's automation panel and the Critic will review every CI-green pull request — not just ones tied to a Shepherd session. Opt-in per repo; note the higher token cost for busy repos."
+  "feat_critic_all_prs_body": "Enable \"Review all PRs\" in a repo's automation panel and the Critic will review every CI-green pull request — not just ones tied to a Shepherd session. Opt-in per repo; note the higher token cost for busy repos.",
+  "automation_sandbox_profile_summary": "Opt-in confinement for agents."
 }

--- a/ui/src/lib/components/AutomationPanel.svelte
+++ b/ui/src/lib/components/AutomationPanel.svelte
@@ -514,8 +514,19 @@
         <option value="autonomous">{m.sandbox_profile_autonomous()}</option>
       </select>
     </label>
-    <div class="signoff-note">{m.automation_sandbox_profile_hint()}</div>
-    <div class="signoff-note">{m.automation_sandbox_profile_caveats()}</div>
+    <div class="signoff-note sandbox-summary">
+      {m.automation_sandbox_profile_summary()}
+      {@render info("sandbox", m.automation_sandbox_profile_label())}
+    </div>
+    <div
+      id="auto-detail-sandbox"
+      class="auto-detail sandbox-detail"
+      role="note"
+      hidden={openDetail !== "sandbox"}
+    >
+      <p>{m.automation_sandbox_profile_hint()}</p>
+      <p>{m.automation_sandbox_profile_caveats()}</p>
+    </div>
   </div>
   {#if flags.autoDrain}
     <div class="drain-fields">
@@ -866,6 +877,27 @@
     text-align: left;
     cursor: pointer;
     appearance: auto;
+  }
+  /* Sandbox summary line: flex so the circular ⓘ vertically centers against the
+     text (mirrors .auto-name), instead of sitting baseline-misaligned. */
+  .sandbox-summary {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  /* Sandbox ⓘ detail: recess to --color-inset so it steps against the
+     --color-panel .drain-fields ground (panel-over-panel would show no fill
+     step — only the border). margin-top:0 cancels the .auto-detail 6px that
+     would otherwise stack on .drain-fields' 6px gap. */
+  .sandbox-detail {
+    margin-top: 0;
+    background: var(--color-inset);
+  }
+  .sandbox-detail p {
+    margin: 0;
+  }
+  .sandbox-detail p + p {
+    margin-top: 6px;
   }
   /* Epic-mode precedence banner: unmistakable amber notice inside the Work queue
      section that label-drain is suspended while an epic runs. Sits above the


### PR DESCRIPTION
## What

The Sandbox profile section in the Automation panel rendered two long always-visible notes (the confinement hint + the HTTPS-remote/MCP caveats). This collapses that lengthy text behind the same tap-to-open **ⓘ** disclosure the switch rows already use (Critic, Build queue, …), leaving a short summary line visible by default.

| Before | After |
| --- | --- |
| Sandbox label + dropdown, then two long gray paragraphs always shown | Sandbox label + dropdown + short summary + ⓘ; long hint+caveats hidden until tapped |

## How

- `ui/src/lib/components/AutomationPanel.svelte`: replaced the two `.signoff-note` paragraphs with a short `.sandbox-summary` line carrying `{@render info("sandbox", …)}` (ⓘ outside the `<label>` so it can't forward to the `<select>`), plus a hidden `#auto-detail-sandbox` block holding the two existing long strings. Reuses the shared `info`/`openDetail`/`toggleDetail` machinery — one detail open at a time, `aria-expanded`/`aria-controls` wired, detail kept in the DOM via `hidden`.
- New i18n key `automation_sandbox_profile_summary` (EN + DE). The existing `automation_sandbox_profile_hint` / `_caveats` keys are reused verbatim inside the detail.
- CSS: `.sandbox-summary` flex-centers the ⓘ against the text; `.sandbox-detail` recesses to `--color-inset` for a real tonal step over the `--color-panel` ground and normalizes top spacing.

Presentation-only refactor — no new capability, so no feature-catalog entry. `[no-feature-entry]`

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- `cd ui && bun run check:i18n` → 2 locales in parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)