### PR TITLE
fix(viewport): shrink compact strip decommission to icon-only ✕

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2095,7 +2095,7 @@
         <!-- earned prominence: once a PR exists the work is delivered, so the
              decommission nudge surfaces inline (green, arms red on click) — one
              obvious click+confirm away. Before that, desktop shows the quiet
-             icon-only ✕ below; compact keeps the labelled control in the git strip. -->
+             icon-only ✕ below; compact shows the same icon-only ✕ in the git strip. -->
         <button
           class="decom"
           class:armed
@@ -2116,7 +2116,7 @@
       {:else if !compact}
         <!-- no PR yet → desktop still keeps decommission one click away, but quiet:
              a faint icon-only ✕ (the green nudge is earned by delivering a PR).
-             Compact layouts keep the labelled control in the git strip instead.
+             Compact layouts show the same icon-only ✕ in the git strip instead.
              Same glyph rule as above: armed = red ✕?, never ✓. -->
         <button
           class="decom quiet"
@@ -2184,10 +2184,10 @@
             class:armed
             type="button"
             onclick={decommission}
-            title={m.viewport_decommission_title()}
-            aria-label={m.viewport_decommission_aria()}
+            title={armed ? m.viewport_confirm_decommission() : m.viewport_decommission_title()}
+            aria-label={armed ? m.viewport_confirm_decommission() : m.viewport_decommission_aria()}
           >
-            {armed ? m.viewport_confirm_decommission() : m.viewport_decommission()}
+            {armed ? "✕?" : "✕"}
           </button>
         {/if}
       </span>


### PR DESCRIPTION
## What

The compact (mobile) git-strip decommission button rendered the full `✕ DECOMMISSION` label, crowding the strip — visible alongside the already-truncating automation pill ("automat…").

This shrinks it to an icon-only `✕` (armed → red `✕?`), bringing it in line with the **two** sibling compact decommission controls in the same component that were already icon-only (the prReady inline button and the desktop `.decom.quiet` button). The strip button was the odd one out.

## Changes (`ui/src/lib/components/Viewport.svelte`, one file)

- Strip-decom button body: `✕ decommission` label → `{armed ? "✕?" : "✕"}` (same glyph rule as siblings — armed = red `✕?`, never `✓`, which means READY elsewhere in the HUD).
- `title`/`aria-label` now swap to `viewport_confirm_decommission()` when armed (else the rest labels), mirroring the `.decom.quiet` variant — the armed state is announced to screen readers.
- Updated two now-stale comments that claimed "compact keeps the labelled control in the git strip" — compact decommission is now icon-only at every render site.

## Out of scope / unchanged

- Decommission arm/confirm logic and `armed` state.
- Message catalogs — `viewport_decommission` / `viewport_confirm_decommission` stay in use by the desktop non-compact buttons, so no keys orphaned.
- CSS — bare `.decom` keeps its `letter-spacing` to match the prReady compact `✕` sibling (deliberate, for consistency).

No new user-facing capability → no feature-catalog entry (this is a `fix`).

## Verification

- `cd ui && bun run check` — 2122 files, 0 errors, 0 warnings (re-run after rebase onto latest main).
- `cd ui && bun run test` — 80 files / 1096 tests pass.
- Spec-compliance review: ✅. Code-quality review: ✅.

Before: `Open PR | ⚙ automat… | AP ON | ✕ DECOMMISSION`
After: `Open PR | ⚙ automation | AP ON | ✕`

🤖 Generated with [Claude Code](https://claude.com/claude-code)