### PR TITLE
fix(ui): inherit repo plan-gate when composer box untouched

### DIFF
--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import type { Issue } from "$lib/types";
+import type { Issue, RepoConfig } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
-import { listIssues, getEpics, getTodo } from "$lib/api";
+import { listIssues, getEpics, getTodo, listBranches, getRepoConfig } from "$lib/api";
 
 // Mock the API so the issue picker renders deterministically with no network.
 vi.mock("$lib/api", async (importOriginal) => {
@@ -14,6 +14,8 @@ vi.mock("$lib/api", async (importOriginal) => {
     listIssues: vi.fn(),
     getEpics: vi.fn(),
     getTodo: vi.fn(),
+    listBranches: vi.fn(),
+    getRepoConfig: vi.fn(),
   };
 });
 
@@ -22,16 +24,44 @@ const { default: NewTask } = await import("./NewTask.svelte");
 const mockListIssues = vi.mocked(listIssues);
 const mockGetEpics = vi.mocked(getEpics);
 const mockGetTodo = vi.mocked(getTodo);
+const mockListBranches = vi.mocked(listBranches);
+const mockGetRepoConfig = vi.mocked(getRepoConfig);
+
+// A full RepoConfig with the plan gate flag overridable; the composer only reads
+// planGateEnabled but the store ingests the whole shape.
+function repoConfig(planGateEnabled: boolean): RepoConfig {
+  return {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    autoDrainEnabled: false,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    planGateEnabled,
+    draftMode: false,
+    signoffAuthority: "human",
+    sandboxProfile: "trusted",
+    maxAuto: 1,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+  };
+}
 
 beforeEach(() => {
   mockListIssues.mockReset();
   mockGetEpics.mockReset();
   mockGetTodo.mockReset();
+  mockListBranches.mockReset();
+  mockGetRepoConfig.mockReset();
   // Safe defaults so any test that mounts the picker (PromptSources) gets resolved
   // promises, never `undefined`; individual tests override as needed.
   mockGetTodo.mockResolvedValue({ exists: false, content: "" });
   mockListIssues.mockResolvedValue({ slug: null, issues: [] });
   mockGetEpics.mockResolvedValue([]);
+  mockListBranches.mockResolvedValue({ current: "main", branches: ["main"] });
+  mockGetRepoConfig.mockResolvedValue(repoConfig(false));
 });
 
 afterEach(() => {
@@ -152,5 +182,108 @@ describe("NewTask issue picker epic-parent rows", () => {
     expect((plainRow as HTMLButtonElement).disabled).toBe(false);
     plainRow.click();
     await expect.poll(() => promptField.value).toContain("#31");
+  });
+});
+
+describe("NewTask plan-gate inheritance", () => {
+  function deferred<T>() {
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  const planGateBox = () => document.querySelector<HTMLInputElement>(".plan-gate input")!;
+  const submitBtn = () => document.querySelector<HTMLButtonElement>("button.run")!;
+
+  async function fillAndSubmit() {
+    const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    promptField.value = "do the thing";
+    promptField.dispatchEvent(new Event("input", { bubbles: true }));
+    await expect.poll(() => submitBtn().disabled).toBe(false);
+    submitBtn().click();
+  }
+
+  it("submits planGateEnabled:null when the box is untouched on a gate-ON repo", async () => {
+    // unique repoPath per test: repoConfig store is a module singleton that caches by path
+    const repoPath = "/repo/gate-on-untouched";
+    mockGetRepoConfig.mockResolvedValue(repoConfig(true));
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    // box mirrors the gate-ON default once config settles
+    await expect.poll(() => planGateBox().checked).toBe(true);
+    await fillAndSubmit();
+
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({ planGateEnabled: null });
+  });
+
+  it("submits the explicit boolean once the user toggles the box", async () => {
+    // gate-OFF repo, user ticks it ON → explicit true
+    const repoPath = "/repo/toggle-on";
+    mockGetRepoConfig.mockResolvedValue(repoConfig(false));
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => planGateBox().disabled).toBe(false);
+    planGateBox().click(); // toggles + pins planGateTouched
+    expect(planGateBox().checked).toBe(true);
+    await fillAndSubmit();
+
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({ planGateEnabled: true });
+  });
+
+  it("submits explicit false when the user unticks a gate-ON repo", async () => {
+    const repoPath = "/repo/toggle-off";
+    mockGetRepoConfig.mockResolvedValue(repoConfig(true));
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => planGateBox().checked).toBe(true);
+    planGateBox().click(); // untick → explicit false
+    expect(planGateBox().checked).toBe(false);
+    await fillAndSubmit();
+
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({ planGateEnabled: false });
+  });
+
+  it("disables the box until config settles, then re-enables", async () => {
+    const repoPath = "/repo/settle-success";
+    const d = deferred<RepoConfig>();
+    mockGetRepoConfig.mockReturnValue(d.promise);
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: repoPath } });
+
+    // in flight: disabled + loading hint
+    await expect.poll(() => planGateBox().disabled).toBe(true);
+    await expect.element(page.getByText(m.common_loading())).toBeInTheDocument();
+
+    d.resolve(repoConfig(true));
+    await expect.poll(() => planGateBox().disabled).toBe(false);
+    expect(planGateBox().checked).toBe(true);
+  });
+
+  it("never wedges disabled when the config fetch fails", async () => {
+    const repoPath = "/repo/settle-failure";
+    const d = deferred<RepoConfig>();
+    mockGetRepoConfig.mockReturnValue(d.promise);
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => planGateBox().disabled).toBe(true);
+
+    d.reject(new Error("boom"));
+    // failure still settles → box re-enables (unchecked) and inherits via null
+    await expect.poll(() => planGateBox().disabled).toBe(false);
+    expect(planGateBox().checked).toBe(false);
+
+    await fillAndSubmit();
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({ planGateEnabled: null });
   });
 });

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -49,7 +49,7 @@
       model: string | null;
       images: string[];
       issueRef?: IssueRef;
-      planGateEnabled: boolean;
+      planGateEnabled: boolean | null;
       sandboxProfile?: SandboxProfile;
     }) => Promise<void> | void;
     onclose?: () => void;
@@ -198,6 +198,12 @@
     if (repoPath) repoConfig.ensure(repoPath);
   });
   const planGateDefault = $derived(repoPath ? repoConfig.isPlanGateEnabled(repoPath) : false);
+  // While the repo's config fetch is still in flight (and the user hasn't toggled),
+  // the checkbox would read "off" even for a gate-ON repo. Disable + hint until it
+  // settles; a failed fetch still settles, so the box never wedges disabled.
+  const planGateLoading = $derived(
+    !!repoPath && !planGateTouched && !repoConfig.isConfigSettled(repoPath),
+  );
   $effect(() => {
     // mirror the repo default until the user makes a manual choice
     if (!planGateTouched) planGate = planGateDefault;
@@ -383,7 +389,7 @@
               body: issueRef.body,
             }
           : undefined,
-        planGateEnabled: planGate,
+        planGateEnabled: planGateTouched ? planGate : null,
         sandboxProfile: sandboxProfile === "default" ? undefined : sandboxProfile,
       });
     } catch (err) {
@@ -570,10 +576,17 @@
          reads on one line; Model + Sandbox share a 50/50 row beneath. -->
     <div class="opts-row">
       <label class="plan-gate" use:coachTarget={"plan-gate"}>
-        <input type="checkbox" bind:checked={planGate} onchange={() => (planGateTouched = true)} />
+        <input
+          type="checkbox"
+          bind:checked={planGate}
+          onchange={() => (planGateTouched = true)}
+          disabled={planGateLoading}
+        />
         <span class="pg-text">
           <span class="pg-label">{m.newtask_plan_gate_label()}</span>
-          <span class="pg-hint">{m.newtask_plan_gate_hint()}</span>
+          <span class="pg-hint">
+            {planGateLoading ? m.common_loading() : m.newtask_plan_gate_hint()}
+          </span>
         </span>
       </label>
 
@@ -761,6 +774,10 @@
     margin-top: 2px;
     flex: 0 0 auto;
     accent-color: var(--color-amber);
+  }
+  .plan-gate:has(input:disabled) {
+    cursor: progress;
+    opacity: 0.6;
   }
   .pg-text {
     display: flex;

--- a/ui/src/lib/reviews.svelte.ts
+++ b/ui/src/lib/reviews.svelte.ts
@@ -168,6 +168,10 @@ class RepoConfigStore {
   maxAuto = $state<Record<string, number>>({}); // max concurrent auto sessions (default 1)
   autoLabel = $state<Record<string, string>>({}); // label used to pick drain issues (default "shepherd:auto")
   usageCeiling = $state<Record<string, number>>({}); // usage % ceiling before pausing drain (default 80)
+  // repoPaths whose ensure() fetch has resolved (success OR failure). Distinct from
+  // "has a value": a failed fetch leaves the per-field maps unset yet must count as
+  // settled so the UI stops showing a loading state and falls back to defaults.
+  settled = $state<Record<string, boolean>>({});
 
   /** Spread a fetched RepoConfig into every per-field $state map for `repoPath`. */
   private ingest(repoPath: string, c: RepoConfig) {
@@ -188,13 +192,34 @@ class RepoConfigStore {
     this.usageCeiling = { ...this.usageCeiling, [repoPath]: c.usageCeilingPct };
   }
 
+  /** Idempotently mark a repo's config as settled; no-op (no reactive write) if it
+   *  already is, so calling it from an effect can't self-trigger an update loop. */
+  private markSettled(repoPath: string) {
+    if (this.settled[repoPath]) return;
+    this.settled = { ...this.settled, [repoPath]: true };
+  }
+
   async ensure(repoPath: string) {
-    if (repoPath in this.enabled) return;
+    if (repoPath in this.enabled) {
+      this.markSettled(repoPath); // already-loaded ⇒ settled
+      return;
+    }
     try {
       this.ingest(repoPath, await getRepoConfig(repoPath));
     } catch {
       /* leave unset; UI shows defaults optimistically */
+    } finally {
+      // mark settled on every exit (success AND failure) so a failed fetch never
+      // wedges the UI in a loading state — it falls back to defaults instead.
+      this.markSettled(repoPath);
     }
+  }
+
+  /** Whether ensure() for this repo has resolved (success or failure). False until the
+   *  fetch lands; the new-task composer reads this to avoid showing the plan-gate box
+   *  as "off" while its repo default is still loading. */
+  isConfigSettled(repoPath: string): boolean {
+    return this.settled[repoPath] ?? false;
   }
 
   /** Optimistically apply a patch, then reconcile from the server (or revert on error). */

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -928,7 +928,7 @@
       prompt: string;
       model: string | null;
       images: string[];
-      planGateEnabled: boolean;
+      planGateEnabled: boolean | null;
     },
   ) {
     let result: { session: Session; archived: boolean };
@@ -968,7 +968,7 @@
     model: string | null;
     images: string[];
     issueRef?: IssueRef;
-    planGateEnabled: boolean;
+    planGateEnabled: boolean | null;
     sandboxProfile?: SandboxProfile;
   }) {
     // Relaunch-elsewhere path branches off to submitRelaunch; otherwise the New Task create.


### PR DESCRIPTION
## Why

TASK-402 ("never went to the reviewer") never entered the plan gate even though the repo has the gate **on**. Root cause: the new-task composer **silently submits `planGateEnabled: false`** when the async repo-config GET hasn't resolved yet (load race) or fails.

- The checkbox state `planGate` starts `false` and only syncs to the repo default *after* `repoConfig.ensure()`'s network GET lands; submit always sent the explicit boolean.
- The server supports inheritance (`input.planGateEnabled ?? repoConfig.planGateEnabled`) — but only when the UI sends `null`/absent. An explicit `false` short-circuits `??`, so the live repo default never applied and the session was created `planPhase: null` (ungated, no plan reviewer).
- Confirmed against the live DB: TASK-402's row is an **explicit** `planGateEnabled=0` (not NULL), and reproduced live (checkbox reads `false` on a gate-on repo while the config GET is blocked; `true` once it loads).

## Fix

- **Send `null` when untouched** — `NewTask.svelte` submit: `planGateEnabled: planGateTouched ? planGate : null`. The server then authoritatively inherits the live repo default; an explicit user toggle is still honored verbatim. Fail-safe and race-free (submission no longer depends on config-load timing).
- **Widen three intermediate UI signatures** to `boolean | null` (NewTask `onsubmit` prop, `+page.svelte` `onsubmit`, `+page.svelte` `submitRelaunch`) so `null` flows through; the API-boundary types (`CreateInput`, relaunch override) were already `boolean | null`.
- **Display consistency** — `RepoConfigStore` gains a `settled` map + `isConfigSettled()`; the plan-gate checkbox is disabled (with a `common_loading` hint) until the repo config settles, so it can't visibly read "off" on a gate-on repo while the submit inherits "on". A failed fetch settles too, so the box never wedges disabled (and still inherits via `null`).

## Scope notes

- No dedicated in-place "send to reviewer" trigger (operator-confirmed drop): the plan gate is a spawn-time directive — no code path moves an existing session *into* planning. The manual recourse for a slipped session is a **composer** relaunch with the checkbox untouched (override `null` → inherit); quick/one-click relaunch carries the prior explicit `false` forward and does **not** re-gate.
- TASK-402 itself is left untouched (operator decision) — it's a finished investigation with no plan file and no PR, so no reviewer can act on it. This PR fixes the cause so future tasks don't repeat it.
- `fix` (not `feat`) → no feature-catalog entry; no new i18n keys (reused `common_loading`).

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings (gates the type widening)
- `cd ui && bun run test` → 1138 passed (5 new `NewTask` tests: untouched→`null`, toggle→explicit bool both ways, disabled-until-settled, failed-fetch-never-wedges)
- `cd ui && bun run check:i18n` → 2 locales in parity
- Branch hygiene: linear off `origin/main`, no merge commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)