### PR TITLE
fix(ui): right-align the redraw menu under its trigger

### DIFF
--- a/ui/src/lib/components/RedrawMenu.svelte
+++ b/ui/src/lib/components/RedrawMenu.svelte
@@ -36,14 +36,14 @@
   // clamp approach as CardMenu); measured by the effect below once mounted.
   let pos = $state<{ left: number; top: number } | null>(null);
   // Until the measuring effect runs, fall back to a concrete estimate from the
-  // anchor rect (230 = the menu's CSS min-width) so the menu is visible — and
+  // anchor rect (320 = the menu's CSS width) so the menu is visible — and
   // focusable — from its very first paint. Never visibility:hidden: a hidden
   // element refuses focus, which would break the first-item-focused contract.
   const shown = $derived(
     pos ??
       (() => {
         const a = anchor.getBoundingClientRect();
-        return { left: Math.max(8, a.right - 230), top: a.bottom + 4 };
+        return { left: Math.max(8, a.right - 320), top: a.bottom + 4 };
       })(),
   );
   $effect(() => {
@@ -157,8 +157,12 @@
   .redraw-menu {
     position: fixed;
     z-index: 60;
-    min-width: 230px;
-    max-width: min(320px, calc(100vw - 16px));
+    /* A FIXED width (not max-width + shrink-to-fit): a position:fixed element with
+       width:auto sizes against the space from `left` to the viewport's right edge,
+       so its wrapping width would depend on `left` — and the measuring effect would
+       right-align against a stale width, leaving the menu off the anchor / spilling
+       past the edge. A concrete width decouples geometry from position. */
+    width: min(320px, calc(100vw - 16px));
     padding: 4px;
     background: var(--color-panel);
     border: 1px solid var(--color-line-bright);


### PR DESCRIPTION
## Was

Das **↔ NEU ZEICHNEN**-Popover (RedrawMenu) saß nicht unter seinem Button: auf breiten Fenstern weit links daneben, auf schmalen an der Viewport-Kante klebend mit abgeschnittenem Hint-Text.

## Ursache

Das Menü nutzte `max-width` + `width:auto` (Shrink-to-fit). Bei `position: fixed` ist die verfügbare Breite eines Auto-Width-Elements `innerWidth − left`, und die langen Hint-Zeilen brechen je nach Platz unterschiedlich um — **die Breite hing also von `left` ab**:

1. Erster Paint an der Fallback-Position → Menü ~250px breit.
2. `$effect` misst diese 250px und berechnet `left = anchorRight − 250`.
3. Menü springt nach links, hat nun mehr Platz → Text bricht neu um → Breite wächst → rechte Kante schießt über den 8px-Rand hinaus.

Einmal gegen eine veraltete, schmalere Breite positioniert.

## Fix

Dem Menü eine **feste Breite** `width: min(320px, calc(100vw - 16px))` geben statt `max-width` + Auto-Breite. Damit ist die Geometrie positionsunabhängig: die Messung stimmt mit der finalen Breite überein, das Menü sitzt rechtsbündig unter dem Button und bleibt innerhalb des Viewport-Rands. Fallback-Schätzwert entsprechend auf 320 angepasst.

## Verifikation

Browser-Mess-Test (vor/nach):

```
vorher:  anchorRight=394  menu left=144 right=414 width=270   ← rechte Kante am Viewport-Rand, off-anchor
nachher: anchorRight=394  menu left=74  right=394 width=320   ← rechtsbündig unter dem Button
```

- `RedrawMenu.browser` Tests: 7 passed
- `bun run check`: 0 errors

CSS-only Verhaltenskorrektur — keine i18n-/Feature-Catalog-Änderung. [no-feature-entry]