### PR TITLE
feat(epic): land epics in one piece — integration branch + done-on-merge gate (Stage A)

### DIFF
--- a/docs/superpowers/plans/2026-06-13-epic-integration-branch-stage-a.md
+++ b/docs/superpowers/plans/2026-06-13-epic-integration-branch-stage-a.md
@@ -1,0 +1,863 @@
+# Epic Integration Branches — Stage A (epic flows) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an epic *flow* — child PRs target a Shepherd-owned integration branch, get squash-merged into it on retire, and unblock their dependents — by gating on "child PR merged into the integration branch" instead of GitHub issue-closed.
+
+**Architecture:** A running epic owns a deterministic integration branch `epic/<parent#>-<slug>` cut off the latest default branch. Epic-child spawns base their worktree on that branch (not default); regular tasks are unchanged. The drain's retire path, for an epic child, squash-merges the child PR into the integration branch and records the child number in a persisted `epic_integrated` set. The epic gate (`epic-core.ts`) treats a child as done when it is in that set OR its issue is closed, so dependents unblock without GitHub auto-close. (Stage B — final `integration→default` PR, `landing` lifecycle, and UI — is a separate plan.)
+
+**Tech Stack:** TypeScript, Bun, `bun test` (root server tests in `./test`), SQLite (`bun:sqlite`), `gh` CLI forge layer.
+
+**Scope note:** This is Stage A of the approved spec `docs/superpowers/specs/2026-06-13-epic-integration-branch-design.md`. After Stage A the epic advances and accumulates children on the integration branch but does not yet land on default — that is Stage B.
+
+---
+
+## File Structure
+
+- `src/epic-branch.ts` *(new)* — pure helper: `epicIntegrationBranch(parentNumber, parentTitle) → "epic/<#>-<slug>"`. One responsibility: deterministic branch naming. No I/O.
+- `src/epic-core.ts` *(modify)* — `EpicChild.integrationMerged` field; `deriveChildState` + `selectEpicCandidates` gate on done-in-epic (`integrationMerged || issueClosed`).
+- `src/epic-model.ts` *(modify)* — thread `integrated: Set<number>` through `AssembleInput`; set `child.integrationMerged`.
+- `src/store.ts` *(modify)* — `epic_integrated` table + `recordEpicIntegrated` / `listEpicIntegrated`.
+- `src/forge/types.ts` *(modify)* — add optional `ensureBranch?(branch, fromRef)` to `GitForge`.
+- `src/forge/github.ts` *(modify)* — implement `ensureBranch` (`gh api` ref create, idempotent).
+- `src/drain.ts` *(modify)* — ensure integration branch on a running epic; thread integration branch + `integrated` set into `buildEpic`/spawn/retire; base epic-child spawns on the integration branch; squash-merge + record on epic-child retire.
+
+---
+
+## Task 1: Deterministic integration-branch name helper
+
+**Files:**
+- Create: `src/epic-branch.ts`
+- Test: `test/epic-branch.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/epic-branch.test.ts
+import { test, expect } from "bun:test";
+import { epicIntegrationBranch } from "../src/epic-branch";
+
+test("builds epic/<#>-<slug> from parent number + title", () => {
+  expect(epicIntegrationBranch(327, "EFI / Value-Map cluster — sequencing")).toBe(
+    "epic/327-efi-value-map-cluster-sequencing",
+  );
+});
+
+test("lowercases, collapses non-alnum to single dashes, trims edge dashes", () => {
+  expect(epicIntegrationBranch(5, "  Foo__Bar!! ")).toBe("epic/5-foo-bar");
+});
+
+test("bounds the slug length (<= 40 slug chars) and never trails a dash", () => {
+  const b = epicIntegrationBranch(9, "x".repeat(100));
+  expect(b.startsWith("epic/9-")).toBe(true);
+  expect(b.length).toBeLessThanOrEqual("epic/9-".length + 40);
+  expect(b.endsWith("-")).toBe(false);
+});
+
+test("empty/symbol-only title degrades to bare epic/<#>", () => {
+  expect(epicIntegrationBranch(12, "!!!")).toBe("epic/12");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/epic-branch.test.ts`
+Expected: FAIL — `Cannot find module '../src/epic-branch'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/epic-branch.ts
+
+/** Deterministic integration-branch name for an epic: `epic/<parent#>-<slug>`.
+ *  Pure — recomputed everywhere (spawn base, retire merge target, buildEpic) so
+ *  no per-epic branch name needs persisting. A title that slugs to empty degrades
+ *  to the bare `epic/<parent#>`. The slug is bounded so the ref stays a sane length. */
+export function epicIntegrationBranch(parentNumber: number, parentTitle: string): string {
+  const slug = parentTitle
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/g, "");
+  return slug ? `epic/${parentNumber}-${slug}` : `epic/${parentNumber}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/epic-branch.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/epic-branch.ts test/epic-branch.test.ts
+git commit -m "feat(epic): deterministic epic/<#>-<slug> integration branch name"
+```
+
+---
+
+## Task 2: `integrationMerged` field + done-in-epic gate in epic-core
+
+**Files:**
+- Modify: `src/epic-core.ts`
+- Test: `test/epic-core.test.ts` (add cases; create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/epic-core.test.ts`:
+
+```ts
+import { test, expect } from "bun:test";
+import { deriveChildState, selectEpicCandidates, type EpicChild } from "../src/epic-core";
+
+function child(p: Partial<EpicChild>): EpicChild {
+  return {
+    number: 0,
+    title: "",
+    url: "",
+    order: 0,
+    body: "",
+    blockedBy: [],
+    state: "blocked",
+    sessionId: null,
+    prNumber: null,
+    issueClosed: false,
+    integrationMerged: false,
+    claimed: false,
+    ...p,
+  };
+}
+
+test("integration-merged child reads 'merged' even with the issue still open", () => {
+  const c = child({ number: 320, issueClosed: false, integrationMerged: true });
+  expect(deriveChildState(c, new Set())).toBe("merged");
+});
+
+test("a dependent unblocks once its blocker is integration-merged (issue still open)", () => {
+  const blocker = child({ number: 320, integrationMerged: true });
+  const dep = child({ number: 322, blockedBy: [320] });
+  const cands = selectEpicCandidates([blocker, dep]);
+  expect(cands.map((c) => c.number)).toEqual([322]);
+});
+
+test("a dependent stays blocked while its blocker is neither integrated nor closed", () => {
+  const blocker = child({ number: 320 });
+  const dep = child({ number: 322, blockedBy: [320] });
+  expect(deriveChildState(dep, new Set())).toBe("blocked");
+  expect(selectEpicCandidates([blocker, dep]).map((c) => c.number)).toEqual([320]);
+});
+
+test("legacy issue-closed path still satisfies a dependency", () => {
+  const blocker = child({ number: 320, issueClosed: true });
+  const dep = child({ number: 322, blockedBy: [320] });
+  expect(selectEpicCandidates([blocker, dep]).map((c) => c.number)).toEqual([322]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/epic-core.test.ts`
+Expected: FAIL — `integrationMerged` missing on `EpicChild` type, and the done set ignores it.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/epic-core.ts`, add the field to `EpicChild` (after `issueClosed: boolean;`):
+
+```ts
+  issueClosed: boolean;
+  /** The child's PR was squash-merged into the epic integration branch (recorded
+   *  by the drain at merge time; the issue stays open until the final epic→default
+   *  PR lands). Satisfies dependencies the same as issueClosed. */
+  integrationMerged: boolean;
+  claimed: boolean;
+```
+
+Replace `deriveChildState` (rename `closed` → `done` to reflect the broadened set):
+
+```ts
+/** Child lifecycle state from its issue/session/PR facts. `done` = the set of member
+ *  #s that are done-in-epic (integration-merged OR issue-closed). A claimed, session-less,
+ *  open, not-yet-integrated child reads as in-review (spawned and retired/in-flight, PR
+ *  awaiting merge). Spawn-eligibility gating still lives in `selectEpicCandidates`. */
+export function deriveChildState(c: EpicChild, done: Set<number>): EpicChildState {
+  if (c.integrationMerged || c.issueClosed) return "merged";
+  if (c.sessionId && c.prNumber != null) return "in-review";
+  if (c.sessionId) return "running";
+  if (c.claimed) return "in-review";
+  return c.blockedBy.every((b) => done.has(b)) ? "ready" : "blocked";
+}
+```
+
+Replace `selectEpicCandidates` to build the done set from done-in-epic children:
+
+```ts
+/** Dependency-gated spawn candidates (open, unclaimed, unspawned, not-integrated, all
+ *  blockers done-in-epic), in epic order, shaped as drain's `Issue[]`. Pure: derives the
+ *  done set (integration-merged OR issue-closed) from `children`. */
+export function selectEpicCandidates(children: EpicChild[]): Issue[] {
+  const done = new Set(
+    children.filter((c) => c.integrationMerged || c.issueClosed).map((c) => c.number),
+  );
+  return children
+    .filter(
+      (c) =>
+        !c.integrationMerged &&
+        !c.issueClosed &&
+        !c.claimed &&
+        c.sessionId == null &&
+        c.blockedBy.every((b) => done.has(b)),
+    )
+    .sort((a, b) => a.order - b.order || a.number - b.number)
+    .map((c) => ({
+      number: c.number,
+      title: c.title,
+      body: c.body,
+      url: c.url,
+      labels: [],
+      createdAt: 0,
+    }));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/epic-core.test.ts`
+Expected: PASS. (If `test/epic-model.test.ts` exists it now fails to typecheck — fixed in Task 3.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/epic-core.ts test/epic-core.test.ts
+git commit -m "feat(epic): gate dependents on done-in-epic (integration-merged or closed)"
+```
+
+---
+
+## Task 3: Thread the `integrated` set through epic-model
+
+**Files:**
+- Modify: `src/epic-model.ts`
+- Test: `test/epic-model.test.ts` (add cases; create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/epic-model.test.ts`:
+
+```ts
+import { test, expect } from "bun:test";
+import { assembleEpic, type AssembleInput } from "../src/epic-model";
+
+function input(over: Partial<AssembleInput>): AssembleInput {
+  return {
+    repoPath: "/r",
+    run: { repoPath: "/r", parentIssueNumber: 327, mode: "auto", status: "running" },
+    parent: { number: 327, title: "Epic", body: "" },
+    subIssues: [
+      { number: 320, title: "root", url: "u320", body: "", closed: false, labels: [] },
+      { number: 322, title: "dep", url: "u322", body: "", closed: false, labels: [] },
+    ],
+    blockedBy: new Map([[322, [320]]]),
+    openIssues: [],
+    openIssuesTruncated: false,
+    sessions: [],
+    integrated: new Set<number>(),
+    ...over,
+  };
+}
+
+test("a child in the integrated set is integrationMerged and reads 'merged'", () => {
+  const epic = assembleEpic(input({ integrated: new Set([320]) }));
+  const c320 = epic.children.find((c) => c.number === 320)!;
+  expect(c320.integrationMerged).toBe(true);
+  expect(c320.state).toBe("merged");
+});
+
+test("integration-merging the blocker unblocks the dependent (issues still open)", () => {
+  const epic = assembleEpic(input({ integrated: new Set([320]) }));
+  expect(epic.children.find((c) => c.number === 322)!.state).toBe("ready");
+});
+
+test("empty integrated set leaves the dependent blocked", () => {
+  const epic = assembleEpic(input({ integrated: new Set() }));
+  expect(epic.children.find((c) => c.number === 322)!.state).toBe("blocked");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/epic-model.test.ts`
+Expected: FAIL — `integrated` not on `AssembleInput`; `child.integrationMerged` always false.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/epic-model.ts`, add to `AssembleInput` (after `sessions`):
+
+```ts
+  sessions: AssembleSession[];
+  /** Child #s whose PR was squash-merged into the epic integration branch (persisted
+   *  by the drain). Satisfies dependencies even though the issue is still open. */
+  integrated: Set<number>;
+```
+
+In `assembleEpic`, broaden the done set and pass it down. Replace:
+
+```ts
+  const closed = new Set(order.filter((n) => resolved.get(n)?.closed === true));
+```
+
+with:
+
+```ts
+  const done = new Set(
+    order.filter((n) => resolved.get(n)?.closed === true || input.integrated.has(n)),
+  );
+```
+
+In the `children` map, set the field on the built child and use `done`:
+
+```ts
+      issueClosed: r.closed,
+      integrationMerged: input.integrated.has(number),
+      claimed: r.claimed,
+    };
+    child.state = deriveChildState(child, done);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/epic-model.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/epic-model.ts test/epic-model.test.ts
+git commit -m "feat(epic): thread integration-merged child set into epic assembly"
+```
+
+---
+
+## Task 4: Persist the integration-merge record in the store
+
+**Files:**
+- Modify: `src/store.ts` (table in the constructor near `epic_run` ~line 259; methods near `getEpicRun` ~line 437)
+- Test: `test/store-epic-integrated.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/store-epic-integrated.test.ts
+import { test, expect } from "bun:test";
+import { Store } from "../src/store";
+
+test("records and lists integration-merged children per epic parent", () => {
+  const s = new Store(":memory:");
+  expect([...s.listEpicIntegrated("/r", 327)]).toEqual([]);
+  s.recordEpicIntegrated("/r", 327, 320);
+  s.recordEpicIntegrated("/r", 327, 320); // idempotent
+  s.recordEpicIntegrated("/r", 327, 322);
+  expect([...s.listEpicIntegrated("/r", 327)].sort((a, b) => a - b)).toEqual([320, 322]);
+  // scoped by repo + parent
+  expect([...s.listEpicIntegrated("/r", 999)]).toEqual([]);
+  expect([...s.listEpicIntegrated("/other", 327)]).toEqual([]);
+});
+```
+
+(Confirm the `Store` constructor accepts a path/`":memory:"` — match the pattern used by existing `test/store*.test.ts`; adjust the `new Store(...)` call to whatever those tests use if different.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/store-epic-integrated.test.ts`
+Expected: FAIL — `recordEpicIntegrated`/`listEpicIntegrated` are not functions.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In the `Store` constructor, after the `epic_run` table create (~line 261), add:
+
+```ts
+    this.db.run(`CREATE TABLE IF NOT EXISTS epic_integrated (
+      repoPath TEXT NOT NULL, parentIssueNumber INTEGER NOT NULL, childNumber INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL,
+      PRIMARY KEY (repoPath, parentIssueNumber, childNumber))`);
+```
+
+After `setEpicRun` (~line 451), add:
+
+```ts
+  /** Record that a child PR was squash-merged into the epic integration branch.
+   *  Idempotent (PK upsert) — the drain may re-observe a merge across pumps. */
+  recordEpicIntegrated(repoPath: string, parentIssueNumber: number, childNumber: number): void {
+    this.db.run(
+      `INSERT INTO epic_integrated (repoPath, parentIssueNumber, childNumber, createdAt)
+       VALUES (?,?,?,?) ON CONFLICT DO NOTHING`,
+      [repoPath, parentIssueNumber, childNumber, Date.now()],
+    );
+  }
+
+  /** Child #s squash-merged into the integration branch for one epic. */
+  listEpicIntegrated(repoPath: string, parentIssueNumber: number): Set<number> {
+    const rows = this.db
+      .query(
+        `SELECT childNumber FROM epic_integrated WHERE repoPath = ? AND parentIssueNumber = ?`,
+      )
+      .all(repoPath, parentIssueNumber) as { childNumber: number }[];
+    return new Set(rows.map((r) => r.childNumber));
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/store-epic-integrated.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store.ts test/store-epic-integrated.test.ts
+git commit -m "feat(epic): persist epic_integrated child-merge record"
+```
+
+---
+
+## Task 5: `ensureBranch` on the forge
+
+**Files:**
+- Modify: `src/forge/types.ts` (the `GitForge` interface)
+- Modify: `src/forge/github.ts` (implement near `defaultBranch` ~line 464)
+- Test: `test/github-ensure-branch.test.ts` (mock the `gh` runner the way existing github forge tests do — confirm the constructor/runner shape in `test/github*.test.ts` and match it)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/github-ensure-branch.test.ts
+import { test, expect } from "bun:test";
+import { GitHubForge } from "../src/forge/github";
+
+// Match the runner-injection pattern used by the other github forge tests.
+function forgeWith(calls: string[][], opts?: { existsRefs?: string[]; headSha?: string }) {
+  const run = async (args: string[]) => {
+    calls.push(args);
+    if (args.includes("rev-parse") || args.join(" ").includes("git/refs/heads/")) {
+      const wanted = args.find((a) => a.includes("heads/"));
+      const exists = (opts?.existsRefs ?? []).some((r) => wanted?.includes(r));
+      if (!exists) throw new Error("Not Found"); // ref absent
+      return JSON.stringify({ object: { sha: "base-sha" } });
+    }
+    return opts?.headSha ?? "base-sha";
+  };
+  // Construct GitHubForge with the injected runner — mirror the existing tests' helper.
+  return new GitHubForge({ slug: "o/r", mergeMethod: "squash", run } as any);
+}
+
+test("ensureBranch creates the ref off fromRef when absent (idempotent no-op when present)", async () => {
+  const calls: string[][] = [];
+  const f = forgeWith(calls, { existsRefs: [] });
+  await f.ensureBranch!("epic/327-x", "main");
+  expect(calls.some((c) => c.join(" ").includes("git/refs") && c.includes("POST"))).toBe(true);
+
+  const calls2: string[][] = [];
+  const f2 = forgeWith(calls2, { existsRefs: ["epic/327-x"] });
+  await f2.ensureBranch!("epic/327-x", "main");
+  expect(calls2.some((c) => c.includes("POST"))).toBe(false); // already exists → no create
+});
+```
+
+> NOTE: the exact `gh` invocation shape must match how `github.ts` already calls `this.run` (e.g. `["api", ...]` vs git). Before implementing, read `defaultBranch`/`openPr` in `src/forge/github.ts` and the github test helper, and mirror their argument convention. Adjust the assertions to the real call shape.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/github-ensure-branch.test.ts`
+Expected: FAIL — `ensureBranch` is undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/forge/types.ts`, add to `GitForge` (near `defaultBranch`):
+
+```ts
+  /** Ensure a branch exists on the host, creating it at `fromRef`'s tip when absent
+   *  (idempotent; a present branch is left untouched — its tip is NOT reset). Used to
+   *  cut an epic integration branch off the default branch. Optional: hosts without a
+   *  refs API omit it and the caller skips epic-branch orchestration. */
+  ensureBranch?(branch: string, fromRef: string): Promise<void>;
+```
+
+In `src/forge/github.ts`, implement using the same `this.run`/`gh api` convention as `defaultBranch`. Reference shape (adapt to the real runner):
+
+```ts
+  async ensureBranch(branch: string, fromRef: string): Promise<void> {
+    // already present? then leave it — never reset an in-flight integration branch.
+    try {
+      await this.run(["api", `repos/${this.slug}/git/ref/heads/${branch}`]);
+      return;
+    } catch {
+      // not found → fall through to create
+    }
+    const baseRef = await this.run(["api", `repos/${this.slug}/git/ref/heads/${fromRef}`]);
+    const sha = JSON.parse(baseRef).object.sha as string;
+    await this.run([
+      "api",
+      "--method",
+      "POST",
+      `repos/${this.slug}/git/refs`,
+      "-f",
+      `ref=refs/heads/${branch}`,
+      "-f",
+      `sha=${sha}`,
+    ]);
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/github-ensure-branch.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/forge/types.ts src/forge/github.ts test/github-ensure-branch.test.ts
+git commit -m "feat(forge): ensureBranch — create a branch off a ref idempotently"
+```
+
+---
+
+## Task 6: Drain — ensure the integration branch + thread it into spawn base
+
+**Files:**
+- Modify: `src/drain.ts` — `buildEpic` (pass `integrated` set), `buildState` (compute + carry the integration branch for the active epic), `doSpawn` (epic child → base on integration branch). Add an `integrationBranch?: string` to the spawn decision.
+- Modify: `src/drain-core.ts` — extend the `spawn` decision and `DrainRepoState` so the integration branch flows from state to `doSpawn`.
+- Test: `test/drain-epic-spawn-base.test.ts` (mirror the harness/mocks in existing `test/drain*.test.ts`).
+
+- [ ] **Step 1: Write the failing test**
+
+Mirror the existing drain test harness (mocked `forge`, `service`, `store`, `worktree`). The new assertions:
+
+```ts
+// test/drain-epic-spawn-base.test.ts — shape mirrors existing drain tests
+import { test, expect } from "bun:test";
+// import { makeDrainHarness } from "./helpers/drain-harness"; // use whatever existing tests use
+
+test("an epic-child spawn bases the worktree on the integration branch, not default", async () => {
+  // Arrange: a running epic (parent #327) with one ready child #320; forge.defaultBranch="main".
+  // forge.ensureBranch + service.create are spies.
+  const h = makeEpicDrainHarness({
+    parent: 327,
+    parentTitle: "EFI cluster",
+    children: [{ number: 320, blockedBy: [] }],
+  });
+  await h.drain.pump(h.repoPath);
+  // integration branch ensured off default
+  expect(h.forge.ensureBranch).toHaveBeenCalledWith("epic/327-efi-cluster", "main");
+  // child spawned with baseBranch = integration branch
+  const createArg = h.service.create.mock.calls[0][0];
+  expect(createArg.baseBranch).toBe("epic/327-efi-cluster");
+  expect(createArg.issueRef.number).toBe(320);
+});
+
+test("a regular (non-epic) spawn still bases on the default branch", async () => {
+  const h = makeLabelDrainHarness({ issues: [{ number: 7, labels: ["shepherd"] }] });
+  await h.drain.pump(h.repoPath);
+  expect(h.service.create.mock.calls[0][0].baseBranch).toBe("main");
+  expect(h.forge.ensureBranch).not.toHaveBeenCalled();
+});
+```
+
+> Build the harness from the existing drain test utilities — do not invent a new mock framework. If `makeEpicDrainHarness` doesn't exist, assemble the mocks inline the way the nearest existing epic drain test does.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/drain-epic-spawn-base.test.ts`
+Expected: FAIL — spawns still base on `defaultBranch`; `ensureBranch` never called.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/drain-core.ts`, extend the spawn decision and repo state so the integration branch reaches `doSpawn`:
+
+```ts
+export type DrainDecision =
+  | { kind: "spawn"; issue: Issue; integrationBranch?: string }
+  | { kind: "retire"; sessionId: string; prNumber: number }
+  | { kind: "hold"; reason: HoldReason };
+```
+
+Add to `DrainRepoState` (near `epicApprovedNext`):
+
+```ts
+  /** Epic mode: the active epic's integration branch — epic-child spawns base on it.
+   *  null/undefined for label-drain (spawns base on the default branch). */
+  epicIntegrationBranch?: string | null;
+```
+
+In `computeNext`, attach the branch to the spawn it returns:
+
+```ts
+  return { kind: "spawn", issue: next, integrationBranch: state.epicIntegrationBranch ?? undefined };
+```
+
+In `src/drain.ts`:
+
+1. `buildEpic` — load and pass the integrated set. After computing `sessions` and before `assembleEpic`, add:
+
+```ts
+    const integrated = this.deps.store.listEpicIntegrated(repoPath, run.parentIssueNumber);
+```
+
+and pass `integrated` in the `assembleEpic({ ... })` call.
+
+2. `buildState` — when the epic is active and built, compute and ensure the integration branch, and put it on the state. In the `if (builtEpic) { ... }` block (around line 252):
+
+```ts
+      if (builtEpic) {
+        epicParent = epicRun!.parentIssueNumber;
+        epicIntegrationBranch = epicIntegrationBranch ?? // computed below
+          epicBranchFor(builtEpic);
+        if (epicRun!.status === "running") {
+          await this.ensureEpicBranch(repoPath, epicIntegrationBranch);
+          candidates = selectEpicCandidates(builtEpic.children);
+        }
+        epicAttended = epicRun!.mode === "attended";
+      }
+```
+
+Declare `let epicIntegrationBranch: string | null = null;` alongside `epicParent`, add a private helper, and include `epicIntegrationBranch` in the returned `state`:
+
+```ts
+import { epicIntegrationBranch as epicBranchName } from "./epic-branch";
+
+// helper near buildEpic
+private epicBranchFor(epic: Epic): string {
+  return epicBranchName(epic.parentIssueNumber, epic.parentTitle);
+}
+
+/** Idempotently cut the integration branch off the latest default branch. Best-effort:
+ *  a failure warns and the spawn falls back to the default branch (Stage A still works
+ *  per-PR; the epic just doesn't accumulate on a branch this tick). */
+private async ensureEpicBranch(repoPath: string, branch: string): Promise<void> {
+  const forge = this.deps.resolveForge(repoPath);
+  if (!forge?.ensureBranch) return;
+  try {
+    await forge.ensureBranch(branch, await forge.defaultBranch());
+  } catch (err) {
+    console.warn(`[drain] ensureEpicBranch ${branch} failed for ${repoPath}:`, err);
+  }
+}
+```
+
+(Use `this.epicBranchFor(builtEpic)` directly rather than the placeholder `epicBranchFor`.)
+
+3. `doSpawn` — choose the base branch from the decision. Replace `const base = await forge.defaultBranch();` (line 528) with:
+
+```ts
+      // Epic children base on the epic integration branch so each builds on its
+      // predecessors' merged work; regular tasks base on the default branch.
+      const base = decision.integrationBranch ?? (await forge.defaultBranch());
+```
+
+(`doSpawn`'s `decision` is the `spawn` variant, which now carries `integrationBranch`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/drain-epic-spawn-base.test.ts`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Run the full drain suite to catch regressions**
+
+Run: `bun test ./test/drain-core.test.ts ./test/drain.test.ts` (and any other `drain*` tests).
+Expected: PASS — existing label-drain spawns unaffected (`integrationBranch` undefined → default branch).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/drain.ts src/drain-core.ts test/drain-epic-spawn-base.test.ts
+git commit -m "feat(epic): ensure integration branch + base epic-child spawns on it"
+```
+
+---
+
+## Task 7: Drain — squash-merge an epic child into the integration branch on retire + record it
+
+**Files:**
+- Modify: `src/drain.ts` — `doRetire` branches for epic children: squash-merge the child PR into the integration branch and record it, instead of leaving the PR open.
+- Test: `test/drain-epic-retire-merge.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/drain-epic-retire-merge.test.ts — shape mirrors existing drain retire tests
+import { test, expect } from "bun:test";
+
+test("retiring an epic child squash-merges its PR into the integration branch and records it", async () => {
+  // running epic #327; child #320 has a green/mergeable PR #330 (session is an epic auto child).
+  const h = makeEpicRetireHarness({ parent: 327, child: 320, pr: 330 });
+  await h.drain.pump(h.repoPath);
+  expect(h.forge.merge).toHaveBeenCalledWith(330, { method: "squash", deleteBranch: false });
+  expect(h.store.listEpicIntegrated(h.repoPath, 327).has(320)).toBe(true);
+  expect(h.service.archive).toHaveBeenCalledWith(h.sessionId);
+});
+
+test("a merge failure does not record integration nor abort the pump", async () => {
+  const h = makeEpicRetireHarness({ parent: 327, child: 320, pr: 330, mergeThrows: true });
+  await h.drain.pump(h.repoPath);
+  expect(h.store.listEpicIntegrated(h.repoPath, 327).has(320)).toBe(false);
+  // session stays live for a retry — not archived on merge failure
+  expect(h.service.archive).not.toHaveBeenCalled();
+});
+
+test("a non-epic retire still leaves the PR open (unchanged)", async () => {
+  const h = makeLabelRetireHarness({ pr: 42 });
+  await h.drain.pump(h.repoPath);
+  expect(h.forge.merge).not.toHaveBeenCalled();
+  expect(h.forge.ensureIssueLink).toHaveBeenCalled(); // legacy path intact
+  expect(h.service.archive).toHaveBeenCalled();
+});
+```
+
+> Reuse the existing retire-test harness. `makeEpicRetireHarness` should mark the session as an epic auto child (its `issueNumber` is an active epic's child) so `doRetire` takes the epic branch.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/drain-epic-retire-merge.test.ts`
+Expected: FAIL — `doRetire` never calls `forge.merge`; nothing is recorded.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/drain.ts` `doRetire`, before the existing `ensureIssueLink` block, detect an epic child of the active epic and, if so, merge + record + archive, then return. Add a small resolver and branch:
+
+```ts
+  private async doRetire(
+    repoPath: string,
+    decision: Extract<DrainDecision, { kind: "retire" }>,
+  ): Promise<void> {
+    const forge = this.deps.resolveForge(repoPath);
+    if (!forge) return;
+    const s = this.deps.store.get(decision.sessionId);
+
+    // Epic child: squash-merge the PR INTO the integration branch (not default) and record
+    // it, so dependents unblock without GitHub auto-close. The child issue stays open until
+    // the final epic→default PR lands (Stage B). Only when this session's issue is a child of
+    // the repo's active epic.
+    const epicRun = this.deps.store.getEpicRun(repoPath);
+    const epicActive =
+      !!epicRun && (epicRun.status === "running" || epicRun.status === "paused");
+    if (epicActive && s?.issueNumber != null) {
+      const epic = await this.buildEpic(repoPath, epicRun!);
+      const isChild = epic?.children.some((c) => c.number === s.issueNumber);
+      if (isChild) {
+        try {
+          await forge.merge(decision.prNumber, { method: "squash", deleteBranch: false });
+        } catch (err) {
+          console.warn(
+            `[drain] epic child merge pr#${decision.prNumber} (issue #${s.issueNumber}) into ${epicRun!.parentIssueNumber} integration failed:`,
+            err,
+          );
+          return; // leave the session live; next tick retries. Do NOT record or archive.
+        }
+        this.deps.store.recordEpicIntegrated(repoPath, epicRun!.parentIssueNumber, s.issueNumber);
+        try {
+          this.deps.service.archive(decision.sessionId);
+        } catch (err) {
+          console.warn(`[drain] archive (epic child) failed for ${decision.sessionId}:`, err);
+          return;
+        }
+        // Keep the claim: the issue stays open until the epic lands; releasing would let it
+        // re-spawn. Mirrors the legacy retire path.
+        this.retainClaimOnArchive.add(decision.sessionId);
+        this.deps.dropPrCache(decision.sessionId);
+        this.deps.emitArchived(decision.sessionId);
+        return;
+      }
+    }
+
+    // ── non-epic retire (unchanged) ──
+    // Best-effort issue link: a failure must NOT block teardown.
+    if (s?.issueNumber != null) {
+      try {
+        await forge.ensureIssueLink?.(decision.prNumber, s.issueNumber);
+      } catch (err) {
+        console.warn(
+          `[drain] ensureIssueLink pr#${decision.prNumber} issue#${s.issueNumber} failed for ${decision.sessionId}:`,
+          err,
+        );
+      }
+    }
+    try {
+      this.deps.service.archive(decision.sessionId);
+    } catch (err) {
+      console.warn(`[drain] archive failed for ${decision.sessionId}:`, err);
+      return;
+    }
+    this.retainClaimOnArchive.add(decision.sessionId);
+    this.deps.dropPrCache(decision.sessionId);
+    this.deps.emitArchived(decision.sessionId);
+  }
+```
+
+(Keep the existing trailing comment block's intent; this preserves the legacy path verbatim below the epic branch.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/drain-epic-retire-merge.test.ts`
+Expected: PASS (all three cases).
+
+- [ ] **Step 5: Run drain + epic suites for regressions**
+
+Run: `bun test ./test/drain.test.ts ./test/drain-core.test.ts ./test/epic-core.test.ts ./test/epic-model.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/drain.ts test/drain-epic-retire-merge.test.ts
+git commit -m "feat(epic): squash-merge epic child into integration branch on retire"
+```
+
+---
+
+## Task 8: Full verification + lint
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck the root package**
+
+Run: `bunx tsc --noEmit`
+Expected: no errors. (The new `integrationMerged` field is required on `EpicChild`; fix any other `EpicChild`/`AssembleInput` literal in the codebase — e.g. server epic routes or fixtures — that the compiler flags as missing it.)
+
+- [ ] **Step 2: Lint**
+
+Run: `bun run lint`
+Expected: clean (run with `--fix` semantics per the repo's lint script if it auto-fixes; otherwise resolve manually — never suppress).
+
+- [ ] **Step 3: Full server test suite**
+
+Run: `bun test ./test`
+Expected: PASS.
+
+- [ ] **Step 4: Fallow delta audit (the repo's pre-push complexity/dead-code gate)**
+
+Run: `bunx fallow audit --base origin/main --fail-on-issues`
+Expected: no new dead code; cognitive complexity within bounds. If `doRetire` trips the cognitive-complexity gate, extract the epic-child branch into a private `mergeEpicChild(repoPath, decision, s, epicRun)` helper and call it from `doRetire` (keeps behavior identical, lowers the function's complexity).
+
+- [ ] **Step 5: Commit any verification fixes**
+
+```bash
+git add -A
+git commit -m "chore(epic): typecheck/lint/fallow fixes for Stage A"
+```
+
+---
+
+## Out of scope (Stage B — separate plan)
+
+- The final aggregated `integration → default` PR (`Closes #<each child>` + parent) and the `landing` epic status / lifecycle.
+- Epic-panel UI surfacing (integration branch, merged-into-epic vs issue-closed, landing banner) + i18n + feature-catalog entry.
+- behindBase rebase-recovery of a sibling child PR before its merge (Stage A relies on the existing `mergeable === true` retire gate; a genuinely behind-but-mergeable PR merges fine via `gh pr merge`).
+- Integration-branch deletion/cleanup after landing.
+- Forge-query reconciliation of `integrationMerged` for a human-merged child PR.
+
+## Self-review notes
+
+- **Spec coverage:** done-signal (T2/T3), persisted record (T4), integration branch ensure (T5/T6), epic-child base branch (T6), child squash-merge into integration branch (T7) — all Stage A spec sections covered. Stage B sections explicitly deferred above.
+- **Type consistency:** `integrationMerged` added to `EpicChild` (T2) and set in `assembleEpic` (T3); `integrated: Set<number>` on `AssembleInput` (T3) and supplied by `buildEpic` (T6) and store `listEpicIntegrated` (T4); `integrationBranch?` on the `spawn` decision (T6) consumed in `doSpawn` (T6). `forge.merge(pr, { method, deleteBranch })` matches `MergeInput` in `forge/types.ts`.
+- **Harness caveat:** Tasks 5–7 must mirror the *existing* forge/drain test harnesses rather than the illustrative `makeXHarness` placeholders — the executing agent should read the nearest existing `test/github*.test.ts` / `test/drain*.test.ts` and match their mock-injection shape before writing the test body.

--- a/docs/superpowers/specs/2026-06-13-epic-integration-branch-design.md
+++ b/docs/superpowers/specs/2026-06-13-epic-integration-branch-design.md
@@ -98,6 +98,25 @@ the existing `worktree.behindBase` + AutoMergeService rebase-recovery handles
 rebasing it onto the integration branch before its own merge. No new rebase
 logic — point the existing logic at the integration branch for epic children.
 
+**Local-branch resolution (implementation reality).** `forge.ensureBranch`
+creates the integration branch on the **remote** (`gh api`), but `worktree.create`
+bases a worktree on a **local** ref. So `service.create` first calls
+`worktree.ensureBaseRef(repoPath, baseBranch)`: for the checked-out branch
+(normally the default — regular spawns) it no-ops; for any other base (the
+integration branch) it `git fetch origin <b>:<b>` to **create-or-fast-forward**
+the local branch to the latest remote tip. The FF-every-spawn is essential —
+the integration branch advances on the remote as siblings merge, and a later
+child must base on the *current* tip, not a stale local copy.
+
+**Child PR base (implementation reality).** The spawned agent opens its own PR
+with `gh pr create`, which defaults to the repo default branch. So Shepherd makes
+the child target the integration branch two ways: (1) `doSpawn` injects an
+`epicBaseDirective(branch)` into the epic-child spawn prompt instructing
+`gh pr create --base <branch>`; (2) `openPrSteer(draftMode, baseBranch)` emits the
+explicit `--base` as the autopilot open-PR fallback. (Advisory by design — there
+is no post-hoc enforcement that the opened PR's base equals the integration
+branch; a non-compliant agent could still target the default branch.)
+
 ## The done-signal change (the actual unblock)
 
 Stop gating on issue-closed; gate on **PR merged into the integration branch**.
@@ -130,10 +149,18 @@ When a child session is green + approved (existing critic / review / signoff
 gates — **unchanged**), the drain **retire path** for an epic child **squash-merges
 its PR into the integration branch** instead of leaving it open:
 
-- `drain.ts` `doRetire` branches: epic child of an active epic → merge into the
-  integration branch (reuse AutoMergeService merge mechanics: behindBase gate,
-  rebase recovery, squash) then archive. Non-epic retire is **unchanged** (PR
-  left open for a human; `ensureIssueLink` still applied).
+- `drain.ts` `doRetire` branches: epic child of an active epic → squash-merge
+  into the integration branch (`forge.merge(pr, {method:"squash"})`, which merges
+  a PR into its own base) then `recordEpicIntegrated` + archive. Non-epic retire
+  is **unchanged** (PR left open for a human; `ensureIssueLink` still applied).
+- **Merge-train exclusion (implementation reality).** The shared `isFullAuto`
+  signal gates BOTH the drain (leaves full-auto sessions for the train) and
+  AutoMergeService (only lands full-auto sessions). If an epic child were
+  full-auto, the train would merge it **without** `recordEpicIntegrated`,
+  stranding the epic gate. So `isFullAuto` returns false for any session whose
+  base is an epic integration branch (`isEpicIntegrationBranch(baseBranch)`) —
+  keeping epic children off the train and routing them through the drain's
+  squash-merge path above.
 - One PR per sub-issue (no batching). After merge → archive → the next pump sees
   `integrationMerged` and unblocks dependents.
 - Merge failure (conflict, not-green) must not abort the pump — warn and defer,

--- a/docs/superpowers/specs/2026-06-13-epic-integration-branch-design.md
+++ b/docs/superpowers/specs/2026-06-13-epic-integration-branch-design.md
@@ -1,0 +1,222 @@
+# Epic integration branches — land an epic in one piece on the default branch
+
+## Problem
+
+An epic is a tracking GitHub issue (e.g. #327) with native sub-issues (#320,
+#322, #323, #325…) wired by `blocked_by` edges. Shepherd's Epic Runner spawns a
+session per ready child, each opening its own PR. Today every spawn — epic child
+or regular task — bases its worktree on the **default branch** and its PR targets
+the **default branch** (`drain.ts` `doSpawn`: `const base = await forge.defaultBranch()`).
+
+The operator's intent for epics is different: an epic should **land in one piece
+on the default branch**, not trickle in as N granular PRs. When that intent was
+applied to the EFI epic, an agent improvised an integration branch
+`epic/efi-valuemap-327` and retargeted the child PRs at it. PR #330 then merged
+into that branch — and the epic **stalled**:
+
+- The child PR body said `Closes #320`. GitHub **only auto-closes a referenced
+  issue when the PR merges into the repository's default branch.** Merged into
+  `epic/efi-valuemap-327` (not default), GitHub left #320 **open**.
+- Shepherd's entire epic state machine gates on **issue-closed**:
+  - `epic-core.ts:48` — a child is `"merged"` **iff** `c.issueClosed`.
+  - `epic-core.ts:54,60,67` — a child is `"ready"` only when every `blockedBy`
+    number is in the `closed` set, and `closed` is built **solely** from
+    `issueClosed` children.
+  - `drain.ts:340` — the epic auto-completes only when every child reaches
+    `state === "merged"` (issue closed).
+- So #320 never counted as done → its dependents #322/#323/#325 stayed
+  `blocked` → the epic could neither advance nor complete.
+
+Two gaps to close:
+
+1. **The integration-branch model is unbuilt.** Shepherd has no epic-branch
+   awareness anywhere; the branch above was agent-improvised. To make
+   "land in one piece" the **default for epics**, Shepherd must own the
+   integration branch end-to-end.
+2. **The gate keys off the wrong signal.** Once children merge into an
+   integration branch they do not auto-close, so the dependency gate must key
+   off **child PR merged into the integration branch**, not issue-closed.
+
+This is the default for **epics only**. Regular (non-epic) tasks are unchanged:
+branch off default, one PR → default, `Closes #N` auto-closes on merge.
+
+## Why an integration branch is correct, not just cosmetic
+
+The children share code seams. Epic #327 seam #1: the population-σ helper is
+introduced by #320 (`src/lib/server/efi.ts`) and **reused** by #322 and #323.
+Basing each child worktree on the **integration branch's latest state** means
+#322 builds on #320's *merged* work instead of a stale default branch. The
+dependency DAG enforces order; the integration branch carries the accumulated
+result so downstream children compile against their blockers' code.
+
+## Design overview
+
+```
+epic run → running
+  └─ ensure integration branch  epic/<parent#>-<slug>  off latest default
+  └─ per ready child (DAG-gated):
+        spawn worktree based on integration branch
+        child PR targets integration branch
+        green + approved → SQUASH-merge child PR into integration branch
+        → child is "integration-merged" → dependents unblock
+  └─ all children integration-merged → status: landing
+        open ONE PR  integration → default  (Closes every child# + parent#)
+  └─ that PR merged (human / merge-train) → all issues close → status: idle (complete)
+```
+
+Statuses: `running → landing → idle`. The terminal `idle` is still driven by the
+genuine completion signal (all issues closed once the final PR lands).
+
+## Integration branch
+
+- **Name:** `epic/<parentNumber>-<slug>`, where `<slug>` is a sanitized,
+  length-bounded kebab of the parent issue title (e.g. `epic/327-efi-value-map-cluster`).
+  Deterministic so it is recomputable from the parent issue across restarts.
+- **Creation:** on epic run `→ running`, ensure the branch exists off the
+  **latest** default branch (fetch default, create + push if absent; reuse if
+  present — idempotent). Lives in a small helper alongside the worktree/forge
+  layer; the forge gains a "create branch from ref / branch exists" capability if
+  one isn't already available.
+- **Lifecycle:** persists for the epic's duration. Cleanup (deleting the merged
+  integration branch) is **out of scope** for this change — it is left after the
+  final PR lands, same as any merged feature branch.
+
+## Child spawns target the integration branch
+
+`drain.ts` `doSpawn` becomes epic-aware:
+
+- The spawn decision already flows from `buildState`, which knows `epicParent`
+  and the built epic. Thread the epic's integration branch into the spawn
+  decision so `doSpawn` can choose the base branch.
+- For an **epic child of an active epic**: `baseBranch = integrationBranch`
+  (fetched to latest first).
+- For everything else: `baseBranch = forge.defaultBranch()` — **unchanged**.
+
+Concurrent children that share a blocker branch off the same integration commit.
+When one merges first, a lagging sibling is **behind** the integration branch;
+the existing `worktree.behindBase` + AutoMergeService rebase-recovery handles
+rebasing it onto the integration branch before its own merge. No new rebase
+logic — point the existing logic at the integration branch for epic children.
+
+## The done-signal change (the actual unblock)
+
+Stop gating on issue-closed; gate on **PR merged into the integration branch**.
+
+- `EpicChild` gains `integrationMerged: boolean` — true when the child's PR is
+  `merged && baseRefName === <integrationBranch>`. Populated in `epic-model.ts`
+  from the child's PR state (the model already resolves each child's
+  `sessionId` / `prNumber`; extend it to read the PR's merged flag + base ref).
+- A child is **done-in-epic** ⇔ `integrationMerged || issueClosed`. The
+  `|| issueClosed` arm preserves the legacy/default path (and the post-landing
+  state, where issues finally close).
+- `epic-core.ts`:
+  - `deriveChildState`: return `"merged"` when `integrationMerged || issueClosed`
+    (rename the `closed` param to a `done` set to match).
+  - `selectEpicCandidates`: build the satisfied set from **done-in-epic**
+    children, not `issueClosed` only. **This unblocks #322/#323/#325 the moment
+    #320's PR squash-merges into the integration branch** — no GitHub auto-close
+    needed.
+
+## Child auto-merge into the integration branch
+
+When a child session is green + approved (existing critic / review / signoff
+gates — **unchanged**), the drain **retire path** for an epic child **squash-merges
+its PR into the integration branch** instead of leaving it open:
+
+- `drain.ts` `doRetire` branches: epic child of an active epic → merge into the
+  integration branch (reuse AutoMergeService merge mechanics: behindBase gate,
+  rebase recovery, squash) then archive. Non-epic retire is **unchanged** (PR
+  left open for a human; `ensureIssueLink` still applied).
+- One PR per sub-issue (no batching). After merge → archive → the next pump sees
+  `integrationMerged` and unblocks dependents.
+- Merge failure (conflict, not-green) must not abort the pump — warn and defer,
+  same isolation as the current retire path; the session stays live and the next
+  tick retries.
+
+This is the one place the "autopilot never merges" invariant is relaxed — and
+only for the **intra-epic** step into a **non-default** branch (not production).
+The final landing onto default stays gated (below).
+
+## Final epic → default PR + completion
+
+- When **every** child is `integrationMerged` (in dependency order; the DAG
+  guarantees the order children could even reach this state) but the issues are
+  still open, Shepherd opens **one** PR `integration → default`:
+  - Body aggregates `Closes #<child>` for **every** child **plus** `Closes
+    #<parent>`, so a single merge closes all child issues and the parent.
+  - Idempotent: if the epic PR already exists, do not open a second.
+  - Epic run enters new status **`landing`**.
+- Landing the final PR is **not** auto-merged — it follows the existing gate
+  (human click or merge-train), per the operator's choice. Merging it (squash,
+  repo default) closes all child issues + the parent.
+- Completion: once all issues are closed, the existing `handleEpicSideEffects`
+  check (`drain.ts`) transitions `landing → idle`. This stays the genuine
+  terminal state; it now fires only after the **final** PR lands, not after the
+  children integrate.
+
+## Staging — two PRs
+
+Coupled but separable; the reported stall is fixed by Stage A alone.
+
+**Stage A — epic flows (this fixes the bug):**
+- Integration branch ensure/create off default.
+- Epic-aware base branch in `doSpawn`.
+- `integrationMerged` signal in `epic-model.ts` + `epic-core.ts` done-set.
+- Child squash-merge into the integration branch in `doRetire`.
+- `epic_run` status: keep `running`; dependents unblock and children accumulate
+  on the integration branch.
+
+After Stage A the epic **advances and integrates** correctly, but does not yet
+land on default (children sit merged on the integration branch).
+
+**Stage B — epic lands + surfaces:**
+- `landing` status in the `epic_run` enum + store.
+- Final `integration → default` PR aggregation (all `Closes #N` + parent).
+- `running → landing → idle` lifecycle wiring; completion fires on issues-closed.
+- Epic panel UI: integration branch name, per-child "merged-into-epic" vs
+  "issue-closed" distinction, and a `landing` banner with the final PR link
+  (i18n EN+DE + one feature-catalog entry).
+
+## Touch list
+
+| Area | File | Change |
+| --- | --- | --- |
+| Done-signal | `src/epic-core.ts` | `deriveChildState` / `selectEpicCandidates` gate on done-in-epic (`integrationMerged \|\| issueClosed`); rename `closed`→`done` set |
+| Child PR facts | `src/epic-model.ts` | populate `EpicChild.integrationMerged` from PR `merged` + `baseRefName` |
+| Child type | `src/epic-core.ts` | `EpicChild.integrationMerged: boolean`; `EpicRunStatus` += `landing` (Stage B) |
+| Spawn base | `src/drain.ts` | epic child → base on integration branch; thread integration branch into the spawn decision |
+| Child merge | `src/drain.ts` | `doRetire` epic child → squash-merge into integration branch (reuse AutoMergeService mechanics) |
+| Final PR + lifecycle | `src/drain.ts` | open aggregated `integration→default` PR; `running→landing→idle` (Stage B) |
+| Branch ensure | small helper + `src/forge/*` | create/ensure `epic/<#>-<slug>` off default; read PR base+merged; create epic PR |
+| Store | `src/store.ts` / `epic_run` | persist `landing` status (Stage B) |
+| UI | `ui/src/lib/components/` epic panel | integration branch, merged-into-epic vs issue-closed, landing banner + final PR link; i18n EN+DE; feature-catalog entry (Stage B) |
+
+## Tests
+
+- **`epic-core` (unit):** with a child `integrationMerged` (issue still open), its
+  dependents become `ready` and it reads `"merged"`; legacy `issueClosed`-only
+  path still works; `selectEpicCandidates` excludes done-in-epic children and
+  yields the next blocked-now-unblocked child in DAG order.
+- **`epic-model` (unit):** `integrationMerged` true only when PR `merged` **and**
+  `baseRefName === integrationBranch`; false for a PR merged into default or
+  still open.
+- **`drain` (server):** epic child retire squash-merges into the integration
+  branch (mocked forge) then archives; non-epic retire leaves the PR open
+  (unchanged); merge failure defers without aborting the pump. Stage B: final PR
+  opened once all children integration-merged, body carries every `Closes #N` +
+  parent, idempotent (no second PR); `running→landing→idle` on issues-closed.
+- **UI (vitest, Stage B):** epic panel shows the integration branch, the
+  merged-into-epic vs issue-closed child distinction, and the landing banner +
+  final PR link.
+
+## Out of scope
+
+- Regular (non-epic) task flow — unchanged.
+- Auto-merging the final `integration → default` PR — stays human/merge-train
+  gated.
+- Integration branch deletion/cleanup after landing.
+- Markdown-epic (non-native) dependency richness — unchanged; the done-signal
+  applies to both sources, but no new parsing.
+- Reusing the merge-train (AutoMergeService) as the child-merge *driver* — we
+  reuse its *mechanics* (rebase/behindBase/squash) inside the epic child path,
+  not its queue.

--- a/docs/superpowers/specs/2026-06-13-epic-integration-branch-design.md
+++ b/docs/superpowers/specs/2026-06-13-epic-integration-branch-design.md
@@ -102,10 +102,17 @@ logic — point the existing logic at the integration branch for epic children.
 
 Stop gating on issue-closed; gate on **PR merged into the integration branch**.
 
-- `EpicChild` gains `integrationMerged: boolean` — true when the child's PR is
-  `merged && baseRefName === <integrationBranch>`. Populated in `epic-model.ts`
-  from the child's PR state (the model already resolves each child's
-  `sessionId` / `prNumber`; extend it to read the PR's merged flag + base ref).
+- `EpicChild` gains `integrationMerged: boolean`. **Source: a persisted set,
+  recorded at merge time** — not a per-child PR query. Rationale: once Shepherd
+  squash-merges a child PR into the integration branch, the child *issue stays
+  open* and the session is archived, so there is no live PR/issue state to read
+  the "done" fact back from. Shepherd owns the merge, so it records the child
+  number into a persisted `epic_integrated` set (`store.ts`) at the moment of
+  merge. `buildEpic` loads that set and passes it into `assembleEpic`, which sets
+  `child.integrationMerged = integrated.has(child.number)`. (A human manually
+  merging a child PR into the integration branch is out of the normal flow and
+  won't be recorded — acceptable for this change; a forge-query reconciliation is
+  a possible later refinement.)
 - A child is **done-in-epic** ⇔ `integrationMerged || issueClosed`. The
   `|| issueClosed` arm preserves the legacy/default path (and the post-landing
   state, where issues finally close).
@@ -182,7 +189,8 @@ land on default (children sit merged on the integration branch).
 | Area | File | Change |
 | --- | --- | --- |
 | Done-signal | `src/epic-core.ts` | `deriveChildState` / `selectEpicCandidates` gate on done-in-epic (`integrationMerged \|\| issueClosed`); rename `closed`→`done` set |
-| Child PR facts | `src/epic-model.ts` | populate `EpicChild.integrationMerged` from PR `merged` + `baseRefName` |
+| Child PR facts | `src/epic-model.ts` | populate `EpicChild.integrationMerged` from the persisted `integrated` set threaded through `AssembleInput` |
+| Merge record | `src/store.ts` | `epic_integrated` table: record/list child numbers squash-merged into the integration branch |
 | Child type | `src/epic-core.ts` | `EpicChild.integrationMerged: boolean`; `EpicRunStatus` += `landing` (Stage B) |
 | Spawn base | `src/drain.ts` | epic child → base on integration branch; thread integration branch into the spawn decision |
 | Child merge | `src/drain.ts` | `doRetire` epic child → squash-merge into integration branch (reuse AutoMergeService mechanics) |

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -17,15 +17,28 @@ export const PROCEED_STEER = [
   "requirements decision that only the user can make.",
 ].join("\n");
 
-export const OPEN_PR_STEER = [
-  "You're in autopilot and you've stopped, but there's no pull request yet. Commit your",
-  "work, push the branch, and open a PR (gh pr create). If something genuinely blocks that,",
-  "say specifically what you need.",
-].join("\n");
+/** Agent-facing directive injected into an epic child's spawn prompt: its PR must target the
+ *  epic integration branch, not the default branch. Shepherd owns this text (never i18n'd). */
+export function epicBaseDirective(baseBranch: string): string {
+  return [
+    `This task is part of an epic. When you open the pull request, it MUST target the epic`,
+    `integration branch \`${baseBranch}\` as its base — open it with`,
+    `\`gh pr create --base ${baseBranch} ...\`. Do NOT open it against the default branch.`,
+  ].join(" ");
+}
 
-/** Returns the open-PR steer, appending the draft-mode note when `draftMode` is true. */
-export function openPrSteer(draftMode: boolean): string {
-  return draftMode ? `${OPEN_PR_STEER} ${DRAFT_PR_NOTE}` : OPEN_PR_STEER;
+/** Returns the open-PR steer for a session whose PR base is `baseBranch`, appending the
+ *  draft-mode note when `draftMode` is true. The explicit `--base` keeps a session that opens
+ *  its PR from the steer (rather than proactively) targeting the right branch — load-bearing for
+ *  epic children whose base is the integration branch, harmless/correct for regular sessions
+ *  (base = default branch). */
+export function openPrSteer(draftMode: boolean, baseBranch: string): string {
+  const steer = [
+    "You're in autopilot and you've stopped, but there's no pull request yet. Commit your",
+    `work, push the branch, and open a PR (gh pr create --base ${baseBranch}). If something`,
+    "genuinely blocks that, say specifically what you need.",
+  ].join("\n");
+  return draftMode ? `${steer} ${DRAFT_PR_NOTE}` : steer;
 }
 
 export const CI_FIX_STEER = [
@@ -179,7 +192,10 @@ export class AutopilotService {
         return;
       case "finished":
         if (this.deps.hasPr(s.id)) return; // PR already open → nothing to do (full-auto rebase is steered by the merge train)
-        await this.driveSteer(s, openPrSteer(this.deps.store.getRepoConfig(s.repoPath).draftMode));
+        await this.driveSteer(
+          s,
+          openPrSteer(this.deps.store.getRepoConfig(s.repoPath).draftMode, s.baseBranch),
+        );
         return;
       case "complete":
         this.markComplete(s, v.summary || COMPLETE_MESSAGE);

--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -40,7 +40,7 @@ export interface HoldReason {
 }
 
 export type DrainDecision =
-  | { kind: "spawn"; issue: Issue }
+  | { kind: "spawn"; issue: Issue; integrationBranch?: string }
   | { kind: "retire"; sessionId: string; prNumber: number }
   | { kind: "hold"; reason: HoldReason };
 
@@ -92,6 +92,9 @@ export interface DrainRepoState {
   epicAttended: boolean;
   /** Epic mode: operator approved the next spawn (consumed on spawn). */
   epicApprovedNext: boolean;
+  /** Epic mode: the active epic's integration branch — epic-child spawns base on it.
+   *  null/undefined for label-drain (spawns base on the default branch). */
+  epicIntegrationBranch?: string | null;
 }
 
 /** True when this session's PR is ready to be retired / handed off for a human to merge.
@@ -218,7 +221,11 @@ export function computeNext(state: DrainRepoState): DrainDecision {
     return { kind: "hold", reason: { code: "awaiting_approval", detail: String(next.number) } };
   }
 
-  return { kind: "spawn", issue: next };
+  return {
+    kind: "spawn",
+    issue: next,
+    integrationBranch: state.epicIntegrationBranch ?? undefined,
+  };
 }
 
 /**

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -13,7 +13,7 @@ import {
   type DrainRepoState,
 } from "./drain-core";
 import { assembleEpic } from "./epic-model";
-import { epicIntegrationBranch as epicBranchName } from "./epic-branch";
+import { epicIntegrationBranch as epicBranchName, isEpicIntegrationBranch } from "./epic-branch";
 import { selectEpicCandidates, type Epic, type EpicRun } from "./epic-core";
 import { mapBounded } from "./map-bounded";
 import { config } from "./config";
@@ -72,6 +72,7 @@ export interface DrainDeps {
     | "getEpicRun"
     | "setEpicRun"
     | "listEpicIntegrated"
+    | "recordEpicIntegrated"
   >;
   service: { create(input: CreateSessionInput): Promise<Session>; archive(id: string): number };
   resolveForge: (repoPath: string) => GitForge | null;
@@ -451,6 +452,36 @@ export class DrainService {
     const forge = this.deps.resolveForge(repoPath);
     if (!forge) return;
     const s = this.deps.store.get(decision.sessionId);
+    // Epic child: squash-merge the PR INTO its integration branch (not the default branch) and
+    // record it so dependents unblock without a GitHub issue auto-close (the child issue stays
+    // open until the final epic→default PR lands). Detected by the integration-branch base +
+    // an active epic for the repo.
+    const epicRun = this.deps.store.getEpicRun(repoPath);
+    const epicActive = !!epicRun && (epicRun.status === "running" || epicRun.status === "paused");
+    if (epicActive && s?.issueNumber != null && isEpicIntegrationBranch(s.baseBranch)) {
+      try {
+        await forge.merge(decision.prNumber, { method: "squash", deleteBranch: false });
+      } catch (err) {
+        console.warn(
+          `[drain] epic child merge pr#${decision.prNumber} (issue #${s.issueNumber}) into ${s.baseBranch} failed:`,
+          err,
+        );
+        return; // leave the session live; next tick retries. Do NOT record or archive.
+      }
+      this.deps.store.recordEpicIntegrated(repoPath, epicRun!.parentIssueNumber, s.issueNumber);
+      try {
+        this.deps.service.archive(decision.sessionId);
+      } catch (err) {
+        console.warn(`[drain] archive (epic child) failed for ${decision.sessionId}:`, err);
+        return;
+      }
+      // Keep the claim: the child issue stays open until the epic lands; releasing would let it
+      // re-spawn. Mirrors the non-epic retire path below.
+      this.retainClaimOnArchive.add(decision.sessionId);
+      this.deps.dropPrCache(decision.sessionId);
+      this.deps.emitArchived(decision.sessionId);
+      return;
+    }
     // Best-effort issue link: a failure must NOT block teardown.
     if (s?.issueNumber != null) {
       try {

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -24,6 +24,7 @@ import { config } from "./config";
 const EPIC_BLOCKED_BY_CONCURRENCY = 8;
 import { drainSpawnModel } from "./default-model";
 import { resolveProfile, autoHoldReason, detectBackend } from "./sandbox";
+import { epicBaseDirective } from "./autopilot";
 
 /** Cached epic structure for one pump cycle. */
 interface EpicStructure {
@@ -557,13 +558,17 @@ export class DrainService {
       } else if (decision.integrationBranch) {
         console.warn(`[drain] forge lacks ensureBranch; basing epic child #${number} on ${def}`);
       }
+      // Epic child actually based on the integration branch → tell the agent to target it as
+      // the PR base (the agent opens its own PR and would otherwise default to the main branch).
+      const usingEpicBase = !!decision.integrationBranch && base === decision.integrationBranch;
+      const prompt = usingEpicBase ? `${title}\n\n${epicBaseDirective(base)}` : title;
       // Auto-spawns honor an explicit operator default-model; when unset ("auto")
       // they fall back to no --model flag (Claude's own default). The Fable promo
       // is a client-only UI concern and is NEVER applied to autonomous spawns.
       await this.deps.service.create({
         repoPath,
         baseBranch: base,
-        prompt: title,
+        prompt,
         model: drainSpawnModel(config.defaultModel),
         images: [],
         auto: true,

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -539,23 +539,23 @@ export class DrainService {
     this.approvedNext.delete(repoPath);
     try {
       // Epic children base on the epic integration branch so each builds on its
-      // predecessors' merged work; regular tasks base on the default branch. Ensure the
-      // branch exists (idempotent, off the latest default) before the worktree bases on it.
-      let base: string;
-      if (decision.integrationBranch) {
-        const def = await forge.defaultBranch();
+      // predecessors' merged work; regular tasks base on the default branch. Only use the
+      // integration branch when the forge can create it on the host (otherwise it would never
+      // exist for the worktree to fetch); fall back to the default branch otherwise.
+      const def = await forge.defaultBranch();
+      let base = def;
+      if (decision.integrationBranch && forge.ensureBranch) {
         try {
-          await forge.ensureBranch?.(decision.integrationBranch, def);
+          await forge.ensureBranch(decision.integrationBranch, def);
           base = decision.integrationBranch;
         } catch (err) {
           console.warn(
             `[drain] ensureBranch ${decision.integrationBranch} failed; basing on ${def}:`,
             err,
           );
-          base = def; // best-effort fallback: still spawn (per-PR) rather than stall the epic
         }
-      } else {
-        base = await forge.defaultBranch();
+      } else if (decision.integrationBranch) {
+        console.warn(`[drain] forge lacks ensureBranch; basing epic child #${number} on ${def}`);
       }
       // Auto-spawns honor an explicit operator default-model; when unset ("auto")
       // they fall back to no --model flag (Claude's own default). The Fable promo

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -13,6 +13,7 @@ import {
   type DrainRepoState,
 } from "./drain-core";
 import { assembleEpic } from "./epic-model";
+import { epicIntegrationBranch as epicBranchName } from "./epic-branch";
 import { selectEpicCandidates, type Epic, type EpicRun } from "./epic-core";
 import { mapBounded } from "./map-bounded";
 import { config } from "./config";
@@ -62,7 +63,14 @@ export interface QueuedItem {
 export interface DrainDeps {
   store: Pick<
     SessionStore,
-    "get" | "list" | "getRepoConfig" | "getReview" | "archive" | "getEpicRun" | "setEpicRun"
+    | "get"
+    | "list"
+    | "getRepoConfig"
+    | "getReview"
+    | "archive"
+    | "getEpicRun"
+    | "setEpicRun"
+    | "listEpicIntegrated"
   >;
   service: { create(input: CreateSessionInput): Promise<Session>; archive(id: string): number };
   resolveForge: (repoPath: string) => GitForge | null;
@@ -172,9 +180,11 @@ export class DrainService {
         issueNumber: x.issueNumber,
         prNumber: prSnap[x.id]?.number ?? null,
       }));
+    const integrated = this.deps.store.listEpicIntegrated(repoPath, run.parentIssueNumber);
     return assembleEpic({
       repoPath,
       run,
+      integrated,
       parent: {
         number: run.parentIssueNumber,
         title: struct.parent?.title ?? `#${run.parentIssueNumber}`,
@@ -244,6 +254,7 @@ export class DrainService {
     let candidates: Issue[] = [];
     let epicAttended = false;
     let epicParent: number | null = null;
+    let epicIntegrationBranch: string | null = null;
     let builtEpic: Epic | null = null;
     if (epicActive) {
       // Epic is running/paused: source candidates from its dependency-gated children
@@ -251,6 +262,7 @@ export class DrainService {
       builtEpic = await this.buildEpic(repoPath, epicRun!);
       if (builtEpic) {
         epicParent = epicRun!.parentIssueNumber;
+        epicIntegrationBranch = epicBranchName(builtEpic.parentIssueNumber, builtEpic.parentTitle);
         if (epicRun!.status === "running") candidates = selectEpicCandidates(builtEpic.children);
         epicAttended = epicRun!.mode === "attended";
       }
@@ -279,6 +291,7 @@ export class DrainService {
         epicAttended,
         epicApprovedNext: this.approvedNext.has(repoPath),
         epicParent,
+        epicIntegrationBranch,
       },
       epic: builtEpic,
     };
@@ -525,7 +538,25 @@ export class DrainService {
     // consume the attended-mode approval on attempt; a failed spawn requires re-approval (approval is not issue-bound)
     this.approvedNext.delete(repoPath);
     try {
-      const base = await forge.defaultBranch();
+      // Epic children base on the epic integration branch so each builds on its
+      // predecessors' merged work; regular tasks base on the default branch. Ensure the
+      // branch exists (idempotent, off the latest default) before the worktree bases on it.
+      let base: string;
+      if (decision.integrationBranch) {
+        const def = await forge.defaultBranch();
+        try {
+          await forge.ensureBranch?.(decision.integrationBranch, def);
+          base = decision.integrationBranch;
+        } catch (err) {
+          console.warn(
+            `[drain] ensureBranch ${decision.integrationBranch} failed; basing on ${def}:`,
+            err,
+          );
+          base = def; // best-effort fallback: still spawn (per-PR) rather than stall the epic
+        }
+      } else {
+        base = await forge.defaultBranch();
+      }
       // Auto-spawns honor an explicit operator default-model; when unset ("auto")
       // they fall back to no --model flag (Claude's own default). The Fable promo
       // is a client-only UI concern and is NEVER applied to autonomous spawns.

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -514,6 +514,39 @@ export class DrainService {
     this.deps.emitArchived(decision.sessionId);
   }
 
+  /**
+   * Resolve the base branch + agent prompt for a spawn. Epic children base on (and ensure on
+   * the host) the integration branch — so each builds on its predecessors' merged work — and
+   * get a directive to target it as their PR base; a forge that can't create the branch, or a
+   * non-epic spawn, falls back to the default branch with the bare task title.
+   */
+  private async resolveSpawnBase(
+    forge: GitForge,
+    decision: Extract<DrainDecision, { kind: "spawn" }>,
+  ): Promise<{ base: string; prompt: string }> {
+    const { number, title } = decision.issue;
+    const def = await forge.defaultBranch();
+    let base = def;
+    if (decision.integrationBranch && forge.ensureBranch) {
+      try {
+        await forge.ensureBranch(decision.integrationBranch, def);
+        base = decision.integrationBranch;
+      } catch (err) {
+        console.warn(
+          `[drain] ensureBranch ${decision.integrationBranch} failed; basing on ${def}:`,
+          err,
+        );
+      }
+    } else if (decision.integrationBranch) {
+      console.warn(`[drain] forge lacks ensureBranch; basing epic child #${number} on ${def}`);
+    }
+    // Epic child actually based on the integration branch → tell the agent to target it as the
+    // PR base (the agent opens its own PR and would otherwise default to the main branch).
+    const usingEpicBase = !!decision.integrationBranch && base === decision.integrationBranch;
+    const prompt = usingEpicBase ? `${title}\n\n${epicBaseDirective(base)}` : title;
+    return { base, prompt };
+  }
+
   private async doSpawn(
     repoPath: string,
     decision: Extract<DrainDecision, { kind: "spawn" }>,
@@ -570,29 +603,7 @@ export class DrainService {
     // consume the attended-mode approval on attempt; a failed spawn requires re-approval (approval is not issue-bound)
     this.approvedNext.delete(repoPath);
     try {
-      // Epic children base on the epic integration branch so each builds on its
-      // predecessors' merged work; regular tasks base on the default branch. Only use the
-      // integration branch when the forge can create it on the host (otherwise it would never
-      // exist for the worktree to fetch); fall back to the default branch otherwise.
-      const def = await forge.defaultBranch();
-      let base = def;
-      if (decision.integrationBranch && forge.ensureBranch) {
-        try {
-          await forge.ensureBranch(decision.integrationBranch, def);
-          base = decision.integrationBranch;
-        } catch (err) {
-          console.warn(
-            `[drain] ensureBranch ${decision.integrationBranch} failed; basing on ${def}:`,
-            err,
-          );
-        }
-      } else if (decision.integrationBranch) {
-        console.warn(`[drain] forge lacks ensureBranch; basing epic child #${number} on ${def}`);
-      }
-      // Epic child actually based on the integration branch → tell the agent to target it as
-      // the PR base (the agent opens its own PR and would otherwise default to the main branch).
-      const usingEpicBase = !!decision.integrationBranch && base === decision.integrationBranch;
-      const prompt = usingEpicBase ? `${title}\n\n${epicBaseDirective(base)}` : title;
+      const { base, prompt } = await this.resolveSpawnBase(forge, decision);
       // Auto-spawns honor an explicit operator default-model; when unset ("auto")
       // they fall back to no --model flag (Claude's own default). The Fable promo
       // is a client-only UI concern and is NEVER applied to autonomous spawns.

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -460,7 +460,10 @@ export class DrainService {
     const epicActive = !!epicRun && (epicRun.status === "running" || epicRun.status === "paused");
     if (epicActive && s?.issueNumber != null && isEpicIntegrationBranch(s.baseBranch)) {
       try {
-        await forge.merge(decision.prNumber, { method: "squash", deleteBranch: false });
+        // deleteBranch removes the child's MERGED head (task) branch on origin — standard
+        // post-merge hygiene. It is the PR's head, never the integration branch (the base),
+        // so the accumulating integration branch is untouched.
+        await forge.merge(decision.prNumber, { method: "squash", deleteBranch: true });
       } catch (err) {
         console.warn(
           `[drain] epic child merge pr#${decision.prNumber} (issue #${s.issueNumber}) into ${s.baseBranch} failed:`,
@@ -472,7 +475,19 @@ export class DrainService {
       try {
         this.deps.service.archive(decision.sessionId);
       } catch (err) {
-        console.warn(`[drain] archive (epic child) failed for ${decision.sessionId}:`, err);
+        // The squash-merge already landed (PR is now MERGED) but teardown didn't finish. This
+        // is recoverable, not a permanent strand: we deliberately do NOT dropPrCache/emit below,
+        // so the session stays live AND polled (pr-poller skips only archived rows). The poller
+        // re-observes the merged PR and settles it via reapMerged → settleMergedSession (archive
+        // + teardown) — the same path any out-of-band merge takes. That recovery closes the child
+        // issue instead of keeping it open, but the integration is already recorded above, so
+        // dependents unblock either way. The session can NOT be re-selected by the retire gate
+        // (readyToRetire requires state==="open"; the PR is merged), hence the poller is the
+        // recovery, not a retry of this path.
+        console.warn(
+          `[drain] archive (epic child) failed for ${decision.sessionId}; pr-poller will reap the merged PR:`,
+          err,
+        );
         return;
       }
       // Keep the claim: the child issue stays open until the epic lands; releasing would let it

--- a/src/epic-branch.ts
+++ b/src/epic-branch.ts
@@ -11,3 +11,11 @@ export function epicIntegrationBranch(parentNumber: number, parentTitle: string)
     .replace(/-+$/g, "");
   return slug ? `epic/${parentNumber}-${slug}` : `epic/${parentNumber}`;
 }
+
+/** True when `branch` is an epic integration branch (`epic/<#>` or `epic/<#>-<slug>`) as
+ *  produced by {@link epicIntegrationBranch}. The session-local marker that a drain auto
+ *  session is an epic child — used to keep it off the merge train and route its retire to a
+ *  squash-merge into the integration branch. */
+export function isEpicIntegrationBranch(branch: string): boolean {
+  return /^epic\/\d+(-[a-z0-9-]+)?$/.test(branch);
+}

--- a/src/epic-branch.ts
+++ b/src/epic-branch.ts
@@ -1,0 +1,13 @@
+/** Deterministic integration-branch name for an epic: `epic/<parent#>-<slug>`.
+ *  Pure — recomputed everywhere (spawn base, retire merge target, buildEpic) so
+ *  no per-epic branch name needs persisting. A title that slugs to empty degrades
+ *  to the bare `epic/<parent#>`. The slug is bounded so the ref stays a sane length. */
+export function epicIntegrationBranch(parentNumber: number, parentTitle: string): string {
+  const slug = parentTitle
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/g, "");
+  return slug ? `epic/${parentNumber}-${slug}` : `epic/${parentNumber}`;
+}

--- a/src/epic-core.ts
+++ b/src/epic-core.ts
@@ -21,6 +21,10 @@ export interface EpicChild {
   sessionId: string | null;
   prNumber: number | null;
   issueClosed: boolean;
+  /** The child's PR was squash-merged into the epic integration branch (recorded
+   *  by the drain at merge time; the issue stays open until the final epic→default
+   *  PR lands). Satisfies dependencies the same as issueClosed. */
+  integrationMerged: boolean;
   claimed: boolean;
 }
 /** Persisted `epic_run` store row (stands alone; repoPath/parentIssueNumber are intentionally self-contained, not a duplication bug). */
@@ -40,31 +44,35 @@ export interface Epic {
   run: EpicRun;
 }
 
-/** Child lifecycle state from its issue/session/PR facts. `closed` = closed member #s.
- *  Considers `claimed` for display: a claimed, session-less, open child reads as in-review
- *  (spawned and retired/in-flight, PR awaiting human merge). Spawn-eligibility gating still
- *  lives in `selectEpicCandidates` (which already excludes claimed). */
-export function deriveChildState(c: EpicChild, closed: Set<number>): EpicChildState {
-  if (c.issueClosed) return "merged";
+/** Child lifecycle state from its issue/session/PR facts. `done` = the set of member
+ *  #s that are done-in-epic (integration-merged OR issue-closed). A claimed, session-less,
+ *  open, not-yet-integrated child reads as in-review (spawned and retired/in-flight, PR
+ *  awaiting merge). Spawn-eligibility gating still lives in `selectEpicCandidates`. */
+export function deriveChildState(c: EpicChild, done: Set<number>): EpicChildState {
+  if (c.integrationMerged || c.issueClosed) return "merged";
   if (c.sessionId && c.prNumber != null) return "in-review";
   if (c.sessionId) return "running";
   // claimed but no live local session + issue still open = spawned & retired/in-flight
   // (PR awaiting human merge); session was archived after the retire path.
   if (c.claimed) return "in-review";
-  return c.blockedBy.every((b) => closed.has(b)) ? "ready" : "blocked";
+  return c.blockedBy.every((b) => done.has(b)) ? "ready" : "blocked";
 }
 
-/** Dependency-gated spawn candidates (open, unclaimed, unspawned, all blockers closed),
- *  in epic order, shaped as drain's `Issue[]`. Pure: derives the closed set from `children`. */
+/** Dependency-gated spawn candidates (open, unclaimed, unspawned, not-integrated, all
+ *  blockers done-in-epic), in epic order, shaped as drain's `Issue[]`. Pure: derives the
+ *  done set (integration-merged OR issue-closed) from `children`. */
 export function selectEpicCandidates(children: EpicChild[]): Issue[] {
-  const closed = new Set(children.filter((c) => c.issueClosed).map((c) => c.number));
+  const done = new Set(
+    children.filter((c) => c.integrationMerged || c.issueClosed).map((c) => c.number),
+  );
   return children
     .filter(
       (c) =>
+        !c.integrationMerged &&
         !c.issueClosed &&
         !c.claimed &&
         c.sessionId == null &&
-        c.blockedBy.every((b) => closed.has(b)),
+        c.blockedBy.every((b) => done.has(b)),
     )
     .sort((a, b) => a.order - b.order || a.number - b.number)
     .map((c) => ({

--- a/src/epic-model.ts
+++ b/src/epic-model.ts
@@ -26,6 +26,9 @@ export interface AssembleInput {
   openIssues: { number: number; body: string; labels: string[] }[]; // markdown fallback only (200-capped)
   openIssuesTruncated: boolean; // listIssues() hit the 200 cap
   sessions: AssembleSession[];
+  /** Child #s whose PR was squash-merged into the epic integration branch (persisted
+   *  by the drain). Satisfies dependencies even though the issue is still open. */
+  integrated: Set<number>;
 }
 
 interface ResolvedGraph {
@@ -84,7 +87,9 @@ export function assembleEpic(input: AssembleInput): Epic {
   const warnings = [...graph.warnings];
 
   const members = new Set(order);
-  const closed = new Set(order.filter((n) => resolved.get(n)?.closed === true));
+  const done = new Set(
+    order.filter((n) => resolved.get(n)?.closed === true || input.integrated.has(n)),
+  );
   const sessByIssue = new Map<number, AssembleSession>();
   for (const s of input.sessions) if (s.issueNumber != null) sessByIssue.set(s.issueNumber, s);
 
@@ -113,9 +118,10 @@ export function assembleEpic(input: AssembleInput): Epic {
       sessionId: sess?.id ?? null,
       prNumber: sess?.prNumber ?? null,
       issueClosed: r.closed,
+      integrationMerged: input.integrated.has(number),
       claimed: r.claimed,
     };
-    child.state = deriveChildState(child, closed);
+    child.state = deriveChildState(child, done);
     return child;
   });
 

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -483,6 +483,27 @@ export class GithubForge implements GitForge {
     return name;
   }
 
+  async ensureBranch(branch: string, fromRef: string): Promise<void> {
+    try {
+      await this.run(["api", `repos/${this.slug}/git/ref/heads/${branch}`]);
+      return; // exists → never reset its tip
+    } catch {
+      // not found → create below
+    }
+    const baseRef = await this.run(["api", `repos/${this.slug}/git/ref/heads/${fromRef}`]);
+    const sha = (JSON.parse(baseRef) as { object: { sha: string } }).object.sha;
+    await this.run([
+      "api",
+      "--method",
+      "POST",
+      `repos/${this.slug}/git/refs`,
+      "-f",
+      `ref=refs/heads/${branch}`,
+      "-f",
+      `sha=${sha}`,
+    ]);
+  }
+
   private cachedUser: string | null | undefined;
   /** The authenticated gh login (`gh api user`), cached for the forge's lifetime —
    *  it never changes mid-session, so one call serves every handoff computation. */

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -251,6 +251,11 @@ export interface GitForge {
   canPush?(): Promise<boolean>;
   /** The repo's default branch name (the promote PR's base). */
   defaultBranch(): Promise<string>;
+  /** Ensure a branch exists on the host, creating it at `fromRef`'s tip when absent
+   *  (idempotent; a present branch is left untouched — its tip is NOT reset). Used to
+   *  cut an epic integration branch off the default branch. Optional: hosts without a
+   *  refs API omit it and the caller skips epic-branch orchestration. */
+  ensureBranch?(branch: string, fromRef: string): Promise<void>;
   /** Rename a branch on the host, retargeting any open PR to the new name. Optional:
    *  hosts that can't do this safely (Gitea) omit it, and the caller falls back to a
    *  display-only rename so an open PR is never orphaned. */

--- a/src/full-auto.ts
+++ b/src/full-auto.ts
@@ -1,6 +1,7 @@
 import type { Session } from "./types";
 import type { RepoConfig } from "./store";
 import { effectiveAutopilot } from "./effective-autopilot";
+import { isEpicIntegrationBranch } from "./epic-branch";
 
 /**
  * A session is "full-auto" — the merge train carries its PR all the way to a merge — when
@@ -14,9 +15,12 @@ import { effectiveAutopilot } from "./effective-autopilot";
  * autoMergeEnabled override — draft PRs must go through sign-off before they can be landed.
  */
 export function isFullAuto(
-  s: Pick<Session, "autopilotEnabled" | "autoMergeEnabled">,
+  s: Pick<Session, "autopilotEnabled" | "autoMergeEnabled" | "baseBranch">,
   cfg: Pick<RepoConfig, "autopilotEnabled" | "autoMergeEnabled" | "draftMode">,
 ): boolean {
+  // Epic children are squash-merged into their integration branch by the drain's retire path,
+  // never carried by the merge train — exclude them regardless of repo auto-merge config.
+  if (isEpicIntegrationBranch(s.baseBranch)) return false;
   const autopilot = effectiveAutopilot(s, cfg.autopilotEnabled);
   const merge = cfg.draftMode ? false : (s.autoMergeEnabled ?? cfg.autoMergeEnabled);
   return autopilot && merge;

--- a/src/service.ts
+++ b/src/service.ts
@@ -54,6 +54,7 @@ export interface ServiceDeps {
   worktree: Pick<
     WorktreeMgr,
     | "create"
+    | "ensureBaseRef"
     | "remove"
     | "renameBranch"
     | "branchExists"
@@ -764,6 +765,11 @@ export class SessionService {
     const repoBasename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
     const herdSlug = repoBasename ? slugifyManual(repoBasename) : undefined;
     const name = this.uniqueName(await this.deps.namer(input.prompt), herdSlug);
+    // Resolve the base locally first: an epic integration branch exists only on origin, so
+    // worktree.create (which resolves baseBranch from LOCAL refs) would otherwise fail and
+    // silently drop the child into the non-isolated main checkout. The default-branch path
+    // already exists locally and early-returns, so regular spawns are unaffected.
+    await this.deps.worktree.ensureBaseRef(input.repoPath, input.baseBranch);
     const wt = this.deps.worktree.create(input.repoPath, input.baseBranch, name);
     // The worktree is created before the agent can start, so any failure past this
     // point (e.g. herdr `tab create` rejecting) would otherwise leave an orphan

--- a/src/store.ts
+++ b/src/store.ts
@@ -270,6 +270,10 @@ export class SessionStore implements CapStore {
     this.db.run(`CREATE TABLE IF NOT EXISTS epic_run (
       repoPath TEXT PRIMARY KEY, parentIssueNumber INTEGER NOT NULL,
       mode TEXT NOT NULL DEFAULT 'auto', status TEXT NOT NULL DEFAULT 'idle', updatedAt INTEGER NOT NULL)`);
+    this.db.run(`CREATE TABLE IF NOT EXISTS epic_integrated (
+      repoPath TEXT NOT NULL, parentIssueNumber INTEGER NOT NULL, childNumber INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL,
+      PRIMARY KEY (repoPath, parentIssueNumber, childNumber))`);
     this.db.run(`CREATE TABLE IF NOT EXISTS push_subscriptions (
       endpoint TEXT PRIMARY KEY, p256dh TEXT NOT NULL, auth TEXT NOT NULL,
       ua TEXT NOT NULL DEFAULT '', locale TEXT NOT NULL DEFAULT 'en',
@@ -482,6 +486,24 @@ export class SessionStore implements CapStore {
       ON CONFLICT(repoPath) DO UPDATE SET parentIssueNumber=excluded.parentIssueNumber, mode=excluded.mode, status=excluded.status, updatedAt=excluded.updatedAt`,
       [r.repoPath, r.parentIssueNumber, r.mode, r.status, Date.now()],
     );
+  }
+
+  /** Record that a child PR was squash-merged into the epic integration branch.
+   *  Idempotent (PK upsert) — the drain may re-observe a merge across pumps. */
+  recordEpicIntegrated(repoPath: string, parentIssueNumber: number, childNumber: number): void {
+    this.db.run(
+      `INSERT INTO epic_integrated (repoPath, parentIssueNumber, childNumber, createdAt)
+       VALUES (?,?,?,?) ON CONFLICT DO NOTHING`,
+      [repoPath, parentIssueNumber, childNumber, Date.now()],
+    );
+  }
+
+  /** Child #s squash-merged into the integration branch for one epic. */
+  listEpicIntegrated(repoPath: string, parentIssueNumber: number): Set<number> {
+    const rows = this.db
+      .query(`SELECT childNumber FROM epic_integrated WHERE repoPath = ? AND parentIssueNumber = ?`)
+      .all(repoPath, parentIssueNumber) as { childNumber: number }[];
+    return new Set(rows.map((r) => r.childNumber));
   }
 
   private nextDesignationSeq(): number {

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -113,6 +113,31 @@ export class WorktreeMgr {
     }
   }
 
+  /** Ensure `baseBranch` resolves LOCALLY before a worktree bases on it. The common case —
+   *  the default branch — already exists locally and returns immediately. An epic integration
+   *  branch exists only on origin, so fetch it into a local branch of the same name
+   *  (`git fetch origin <b>:<b>`, fast-forward). Best-effort + async (network — never sync on
+   *  the server loop): a failure leaves local state as-is and the subsequent worktree.create
+   *  surfaces a real error if the base is genuinely unresolvable. */
+  async ensureBaseRef(repoPath: string, baseBranch: string): Promise<void> {
+    if (!/^(?!-)[A-Za-z0-9._/-]{1,200}$/.test(baseBranch)) return;
+    try {
+      await execFileAsync("git", ["rev-parse", "--verify", "--quiet", `refs/heads/${baseBranch}`], {
+        cwd: repoPath,
+      });
+      return; // already a local branch (default branch path) — nothing to do
+    } catch {
+      // not a local branch — try to materialize it from origin below
+    }
+    try {
+      await execFileAsync("git", ["fetch", "origin", `${baseBranch}:${baseBranch}`], {
+        cwd: repoPath,
+      });
+    } catch (err) {
+      console.warn(`[worktree] ensureBaseRef fetch ${baseBranch} failed:`, err);
+    }
+  }
+
   /** Whether the branch checked out at `worktreePath` is BEHIND `baseBranch` — i.e.
    *  base has commits not yet in HEAD, so a strict merge train must rebase first.
    *  Best-effort fetches `origin/<base>` and prefers it; falls back to the local

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -113,21 +113,23 @@ export class WorktreeMgr {
     }
   }
 
-  /** Ensure `baseBranch` resolves LOCALLY before a worktree bases on it. The common case —
-   *  the default branch — already exists locally and returns immediately. An epic integration
-   *  branch exists only on origin, so fetch it into a local branch of the same name
-   *  (`git fetch origin <b>:<b>`, fast-forward). Best-effort + async (network — never sync on
-   *  the server loop): a failure leaves local state as-is and the subsequent worktree.create
-   *  surfaces a real error if the base is genuinely unresolvable. */
+  /** Ensure `baseBranch` resolves locally AND is current before a worktree bases on it.
+   *  Skips the fetch only for the main clone's checked-out branch (git refuses to fetch into
+   *  it; the default branch is normally HEAD, so regular spawns keep basing on the local tip
+   *  as before — no new network hit). For any other base (e.g. an epic integration branch that
+   *  advances on the remote as siblings merge), `git fetch origin <b>:<b>` creates-or-FFs the
+   *  local branch so the worktree bases on the latest tip. Best-effort + async (never sync on
+   *  the server loop): a failure warns and the subsequent worktree.create surfaces a real error
+   *  if the base is genuinely unresolvable. */
   async ensureBaseRef(repoPath: string, baseBranch: string): Promise<void> {
     if (!/^(?!-)[A-Za-z0-9._/-]{1,200}$/.test(baseBranch)) return;
     try {
-      await execFileAsync("git", ["rev-parse", "--verify", "--quiet", `refs/heads/${baseBranch}`], {
+      const { stdout } = await execFileAsync("git", ["symbolic-ref", "--short", "HEAD"], {
         cwd: repoPath,
       });
-      return; // already a local branch (default branch path) — nothing to do
+      if (stdout.trim() === baseBranch) return; // checked-out branch — can't/needn't fetch
     } catch {
-      // not a local branch — try to materialize it from origin below
+      // detached HEAD or error — fall through and attempt the fetch
     }
     try {
       await execFileAsync("git", ["fetch", "origin", `${baseBranch}:${baseBranch}`], {

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -2,12 +2,15 @@ import { test, expect, mock } from "bun:test";
 import {
   AutopilotService,
   PROCEED_STEER,
-  OPEN_PR_STEER,
   openPrSteer,
+  epicBaseDirective,
   CI_FIX_STEER,
   CI_CAP_MESSAGE,
 } from "../src/autopilot";
 import { DRAFT_PR_NOTE } from "../src/service";
+
+// The open-PR steer for sess()'s default base branch ("main"), no draft note.
+const OPEN_PR_STEER_MAIN = openPrSteer(false, "main");
 import type { AutopilotVerdict, Session } from "../src/types";
 import type { BlockReason } from "../src/blocked";
 import type { GitState } from "../src/forge/types";
@@ -161,19 +164,29 @@ test("gate verdict → proceed steer + step++", async () => {
 test("finished verdict → open-PR steer", async () => {
   const h = harness({ session: sess(), verdict: { kind: "finished", summary: "done, no PR" } });
   await h.svc.onBlock("s1", block(["I'm done."]));
-  expect(h.events).toContainEqual({ steer: OPEN_PR_STEER });
+  expect(h.events).toContainEqual({ steer: OPEN_PR_STEER_MAIN });
   expect(h.state().autopilotStepCount).toBe(1);
 });
 
-test("openPrSteer(false) equals OPEN_PR_STEER (no draft note)", () => {
-  expect(openPrSteer(false)).toBe(OPEN_PR_STEER);
-  expect(openPrSteer(false)).not.toContain(DRAFT_PR_NOTE);
+test("openPrSteer carries an explicit --base for the session's base branch", () => {
+  expect(openPrSteer(false, "epic/9-x")).toContain("gh pr create --base epic/9-x");
+  expect(openPrSteer(false, "main")).toContain("gh pr create --base main");
 });
 
-test("openPrSteer(true) appends the draft note", () => {
-  const steer = openPrSteer(true);
-  expect(steer).toContain(OPEN_PR_STEER);
+test("openPrSteer(false, ...) omits the draft note", () => {
+  expect(openPrSteer(false, "main")).not.toContain(DRAFT_PR_NOTE);
+});
+
+test("openPrSteer(true, ...) appends the draft note", () => {
+  const steer = openPrSteer(true, "main");
+  expect(steer).toContain("gh pr create --base main");
   expect(steer).toContain(DRAFT_PR_NOTE);
+});
+
+test("epicBaseDirective names the integration branch + --base", () => {
+  const d = epicBaseDirective("epic/9-x");
+  expect(d).toContain("gh pr create --base epic/9-x");
+  expect(d).toContain("epic/9-x");
 });
 
 test("finished verdict + draftMode=true → open-PR steer includes draft note", async () => {
@@ -188,14 +201,14 @@ test("finished verdict + draftMode=true → open-PR steer includes draft note", 
   expect(steerEv.steer).toContain(DRAFT_PR_NOTE);
 });
 
-test("finished verdict + draftMode=false → open-PR steer equals OPEN_PR_STEER", async () => {
+test("finished verdict + draftMode=false → open-PR steer equals OPEN_PR_STEER_MAIN", async () => {
   const h = harness({
     session: sess(),
     verdict: { kind: "finished", summary: "done" },
     repoDraftMode: false,
   });
   await h.svc.onBlock("s1", block(["I'm done."]));
-  expect(h.events).toContainEqual({ steer: OPEN_PR_STEER });
+  expect(h.events).toContainEqual({ steer: OPEN_PR_STEER_MAIN });
 });
 
 test("complete verdict → markComplete + onComplete, no steer, not paused", async () => {
@@ -351,7 +364,7 @@ test("finished + dead pane → resume then steer", async () => {
   });
   await h.svc.onDone("s1");
   expect(h.events).toContainEqual({ resume: true });
-  expect(h.events).toContainEqual({ steer: OPEN_PR_STEER });
+  expect(h.events).toContainEqual({ steer: OPEN_PR_STEER_MAIN });
 });
 
 test("onStatus running after pause clears pause + resets steps", async () => {

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -1,0 +1,266 @@
+import { test, expect, describe } from "bun:test";
+import { DrainService } from "../src/drain";
+import { SessionStore } from "../src/store";
+import type { GitForge, GitState, Issue, MergeMethod, PrStatus } from "../src/forge/types";
+import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
+import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
+
+const REPO = "/repo";
+const PARENT = 327;
+const CHILD = 320;
+const PR = 330;
+const EPIC_BRANCH = "epic/327-efi-cluster";
+
+const NO_USAGE: UsageLimitsType = { session5h: null, week: null, stale: false, calibratedAt: null };
+
+interface ForgeRec {
+  merges: { prNumber: number; method: MergeMethod; deleteBranch: boolean }[];
+  links: { prNumber: number; issueNumber: number }[];
+}
+
+function fakeForge(rec: ForgeRec, opts: { merge?: () => Promise<void> } = {}): GitForge {
+  return {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
+    openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
+    defaultBranch: async () => "main",
+    merge: async (prNumber, o) => {
+      rec.merges.push({ prNumber, method: o.method, deleteBranch: o.deleteBranch });
+      if (opts.merge) await opts.merge();
+    },
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    closeIssue: async () => {},
+    ensureIssueLink: async (prNumber: number, issueNumber: number) => {
+      rec.links.push({ prNumber, issueNumber });
+    },
+    addIssueLabel: async () => {},
+    removeIssueLabel: async () => {},
+    getIssue: async (n: number): Promise<Issue | null> =>
+      n === PARENT
+        ? {
+            number: PARENT,
+            title: "EFI cluster",
+            body: "epic body",
+            url: `https://x/${PARENT}`,
+            labels: [],
+            createdAt: 0,
+          }
+        : null,
+    // No sub-issues: the running epic spawns nothing new, leaving the drain free to retire the
+    // ready child session we seed below.
+    listSubIssues: async () => [],
+    listBlockedBy: async () => [],
+  };
+}
+
+interface Harness {
+  store: SessionStore;
+  drain: DrainService;
+  forgeRec: ForgeRec;
+  archived: string[];
+  prCache: Record<string, GitState>;
+}
+
+function makeHarness(
+  opts: {
+    mergeImpl?: () => Promise<void>;
+    epicStatus?: "running" | "paused" | "idle";
+    archiveImpl?: (id: string) => number;
+  } = {},
+): Harness {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: true,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: true,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 2,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+  });
+  if (opts.epicStatus) {
+    store.setEpicRun({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      mode: "auto",
+      status: opts.epicStatus,
+    });
+  }
+
+  const forgeRec: ForgeRec = { merges: [], links: [] };
+  const forge = fakeForge(forgeRec, { merge: opts.mergeImpl });
+
+  const prCache: Record<string, GitState> = {};
+  const reviews: Record<string, { decision: ReviewDecision; headSha: string }> = {};
+  const archived: string[] = [];
+
+  const service = {
+    create: async (input: CreateSessionInput): Promise<Session> => {
+      return store.create({
+        name: "auto",
+        prompt: input.prompt,
+        repoPath: input.repoPath,
+        baseBranch: input.baseBranch,
+        branch: `shepherd/auto-${input.issueRef?.number ?? "x"}`,
+        worktreePath: "/wt",
+        isolated: true,
+        herdrSession: "default",
+        herdrAgentId: "t",
+        auto: input.auto ?? false,
+        issueNumber: input.issueRef?.number ?? null,
+      });
+    },
+    archive: (id: string): number => {
+      if (opts.archiveImpl) return opts.archiveImpl(id);
+      store.archive(id);
+      return 1;
+    },
+  };
+
+  store.getReview = ((id: string) =>
+    reviews[id]
+      ? { decision: reviews[id].decision, headSha: reviews[id].headSha }
+      : null) as typeof store.getReview;
+
+  const harness: Harness = {
+    store,
+    drain: null as unknown as DrainService,
+    forgeRec,
+    archived,
+    prCache,
+  };
+  // expose a review setter via closure
+  (
+    harness as Harness & { setReview: (id: string, d: ReviewDecision, sha: string) => void }
+  ).setReview = (id, decision, headSha) => {
+    reviews[id] = { decision, headSha };
+  };
+
+  const drain = new DrainService({
+    store,
+    service,
+    resolveForge: () => forge,
+    prCache: { snapshot: () => prCache },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    emitStatus: () => {},
+    emitArchived: (id) => archived.push(id),
+    dropPrCache: () => {},
+    emitEpic: () => {},
+  });
+  harness.drain = drain;
+  return harness;
+}
+
+function openGreen(number: number, mergeable = true): GitState {
+  return {
+    kind: "github",
+    state: "open",
+    number,
+    checks: "success",
+    mergeable,
+    headSha: `sha-${number}`,
+    deployConfigured: false,
+  };
+}
+
+/** Seed a ready epic-child session: green+mergeable PR + clean critic verdict for its head. */
+function seedReadyChild(h: Harness, baseBranch: string): Session {
+  const s = h.store.create({
+    name: "auto",
+    prompt: "p",
+    repoPath: REPO,
+    baseBranch,
+    branch: `shepherd/auto-${CHILD}`,
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: true,
+    issueNumber: CHILD,
+  });
+  h.prCache[s.id] = openGreen(PR);
+  (h as Harness & { setReview: (id: string, d: ReviewDecision, sha: string) => void }).setReview(
+    s.id,
+    "commented",
+    `sha-${PR}`,
+  );
+  return s;
+}
+
+describe("epic child retire → squash-merge into integration branch", () => {
+  test("ready epic child: forge.merge(squash, no-delete) into integration branch, records integrated, archives", async () => {
+    const h = makeHarness({ epicStatus: "running" });
+    const s = seedReadyChild(h, EPIC_BRANCH);
+
+    await h.drain.pump(REPO);
+
+    expect(h.forgeRec.merges).toEqual([{ prNumber: PR, method: "squash", deleteBranch: false }]);
+    expect([...h.store.listEpicIntegrated(REPO, PARENT)]).toContain(CHILD);
+    expect(h.store.get(s.id)?.status).toBe("archived");
+    expect(h.archived).toEqual([s.id]);
+    // Epic child path does NOT auto-close-link the issue (no ensureIssueLink).
+    expect(h.forgeRec.links).toHaveLength(0);
+  });
+
+  test("merge throws: does NOT record integrated and does NOT archive (session left live)", async () => {
+    const h = makeHarness({
+      epicStatus: "running",
+      mergeImpl: async () => {
+        throw new Error("merge conflict");
+      },
+    });
+    const s = seedReadyChild(h, EPIC_BRANCH);
+
+    await h.drain.pump(REPO);
+
+    expect(h.forgeRec.merges).toHaveLength(1); // attempted
+    expect([...h.store.listEpicIntegrated(REPO, PARENT)]).not.toContain(CHILD);
+    expect(h.store.get(s.id)?.status).not.toBe("archived");
+    expect(h.archived).toHaveLength(0);
+  });
+
+  test("non-epic ready session (base main): legacy path — no merge, ensureIssueLink + archive", async () => {
+    // Epic active, but the session bases on main (not an integration branch) → legacy retire.
+    const h = makeHarness({ epicStatus: "running" });
+    const s = h.store.create({
+      name: "auto",
+      prompt: "p",
+      repoPath: REPO,
+      baseBranch: "main",
+      branch: "shepherd/auto-7",
+      worktreePath: "/wt",
+      isolated: true,
+      herdrSession: "default",
+      herdrAgentId: "t",
+      auto: true,
+      issueNumber: 7,
+    });
+    h.prCache[s.id] = openGreen(70);
+    (h as Harness & { setReview: (id: string, d: ReviewDecision, sha: string) => void }).setReview(
+      s.id,
+      "commented",
+      "sha-70",
+    );
+
+    await h.drain.pump(REPO);
+
+    expect(h.forgeRec.merges).toHaveLength(0); // drain never merges on the legacy path
+    expect(h.forgeRec.links).toEqual([{ prNumber: 70, issueNumber: 7 }]);
+    expect(h.store.get(s.id)?.status).toBe("archived");
+    expect([...h.store.listEpicIntegrated(REPO, PARENT)]).not.toContain(7);
+  });
+});

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -77,6 +77,7 @@ function makeHarness(
   const store = new SessionStore(":memory:");
   store.setRepoConfig(REPO, {
     criticEnabled: true,
+    criticAllPrs: false,
     autoAddressEnabled: false,
     learningsEnabled: true,
     autopilotEnabled: false,

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -209,7 +209,7 @@ describe("epic child retire → squash-merge into integration branch", () => {
 
     await h.drain.pump(REPO);
 
-    expect(h.forgeRec.merges).toEqual([{ prNumber: PR, method: "squash", deleteBranch: false }]);
+    expect(h.forgeRec.merges).toEqual([{ prNumber: PR, method: "squash", deleteBranch: true }]);
     expect([...h.store.listEpicIntegrated(REPO, PARENT)]).toContain(CHILD);
     expect(h.store.get(s.id)?.status).toBe("archived");
     expect(h.archived).toEqual([s.id]);

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -39,6 +39,8 @@ function fakeForge(
     listSubIssues?: (parentNumber: number) => Promise<SubIssueRef[]>;
     listBlockedBy?: (issueNumber: number) => Promise<number[]>;
     ensureBranch?: (branch: string, fromRef: string) => Promise<void>;
+    /** Omit the ensureBranch method entirely (e.g. a gitea forge that can't create refs). */
+    noEnsureBranch?: boolean;
   } = {},
 ): GitForge {
   return {
@@ -70,10 +72,12 @@ function fakeForge(
     },
     listSubIssues: opts.listSubIssues,
     listBlockedBy: opts.listBlockedBy,
-    ensureBranch: async (branch: string, fromRef: string) => {
-      rec.ensured.push({ branch, fromRef });
-      if (opts.ensureBranch) await opts.ensureBranch(branch, fromRef);
-    },
+    ensureBranch: opts.noEnsureBranch
+      ? undefined
+      : async (branch: string, fromRef: string) => {
+          rec.ensured.push({ branch, fromRef });
+          if (opts.ensureBranch) await opts.ensureBranch(branch, fromRef);
+        },
   };
 }
 
@@ -93,6 +97,7 @@ function makeHarness(
     getIssueImpl?: (n: number) => Promise<Issue | null>;
     listSubIssuesImpl?: (parentNumber: number) => Promise<SubIssueRef[]>;
     listBlockedByImpl?: (issueNumber: number) => Promise<number[]>;
+    noEnsureBranch?: boolean;
   } = {},
 ): Harness {
   const store = new SessionStore(":memory:");
@@ -119,6 +124,7 @@ function makeHarness(
     getIssue: opts.getIssueImpl,
     listSubIssues: opts.listSubIssuesImpl,
     listBlockedBy: opts.listBlockedByImpl,
+    noEnsureBranch: opts.noEnsureBranch,
   });
 
   const prCache: Record<string, GitState> = {};
@@ -210,6 +216,40 @@ describe("epic-child spawns base on the integration branch", () => {
     const created = h.creates[0]!;
     expect(created.baseBranch).toBe(EPIC_BRANCH);
     expect(created.issueRef?.number).toBe(CHILD);
+  });
+
+  test("running epic on a forge WITHOUT ensureBranch: falls back to main, never the epic branch", async () => {
+    const subIssues: SubIssueRef[] = [
+      { number: CHILD, title: "EFI", url: "u320", body: "spec 320", closed: false, labels: [] },
+    ];
+    const parentIssue: Issue = {
+      number: PARENT,
+      title: "EFI cluster",
+      body: "epic body",
+      url: `https://x/${PARENT}`,
+      labels: [],
+      createdAt: 0,
+    };
+    const h = makeHarness({
+      noEnsureBranch: true,
+      listIssuesImpl: async () => [],
+      getIssueImpl: async (n) => (n === PARENT ? parentIssue : null),
+      listSubIssuesImpl: async (n) => (n === PARENT ? subIssues : []),
+      listBlockedByImpl: async () => [],
+    });
+    h.store.setEpicRun({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      mode: "auto",
+      status: "running",
+    });
+
+    await h.drain.pump(REPO);
+
+    expect(h.creates).toHaveLength(1);
+    expect(h.creates[0]!.baseBranch).toBe("main"); // fallback, NOT the epic branch
+    expect(h.creates[0]!.issueRef?.number).toBe(CHILD);
+    expect(h.forgeRec.ensured).toHaveLength(0);
   });
 
   test("regular label-drain spawn: bases on main, never ensures a branch", async () => {

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -103,6 +103,7 @@ function makeHarness(
   const store = new SessionStore(":memory:");
   store.setRepoConfig(REPO, {
     criticEnabled: true,
+    criticAllPrs: false,
     autoAddressEnabled: false,
     learningsEnabled: true,
     autopilotEnabled: false,

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -216,6 +216,10 @@ describe("epic-child spawns base on the integration branch", () => {
     const created = h.creates[0]!;
     expect(created.baseBranch).toBe(EPIC_BRANCH);
     expect(created.issueRef?.number).toBe(CHILD);
+    // The spawn prompt carries the epic base directive so the agent opens its own PR
+    // against the integration branch, not the default branch.
+    expect(created.prompt).toContain(`--base ${EPIC_BRANCH}`);
+    expect(created.prompt).toContain(EPIC_BRANCH);
   });
 
   test("running epic on a forge WITHOUT ensureBranch: falls back to main, never the epic branch", async () => {
@@ -250,6 +254,9 @@ describe("epic-child spawns base on the integration branch", () => {
     expect(h.creates[0]!.baseBranch).toBe("main"); // fallback, NOT the epic branch
     expect(h.creates[0]!.issueRef?.number).toBe(CHILD);
     expect(h.forgeRec.ensured).toHaveLength(0);
+    // Fell back to main → did NOT use the integration branch, so no epic directive.
+    expect(h.creates[0]!.prompt).not.toContain("--base");
+    expect(h.creates[0]!.prompt).not.toContain("part of an epic");
   });
 
   test("regular label-drain spawn: bases on main, never ensures a branch", async () => {
@@ -259,5 +266,7 @@ describe("epic-child spawns base on the integration branch", () => {
     expect(h.creates[0]!.baseBranch).toBe("main");
     expect(h.forgeRec.ensured).toHaveLength(0);
     expect(h.forgeRec.added).toEqual([{ number: 1, label: ACTIVE_LABEL }]);
+    // Regular spawn → prompt is just the title, no --base directive.
+    expect(h.creates[0]!.prompt).not.toContain("--base");
   });
 });

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -1,0 +1,223 @@
+import { test, expect, describe } from "bun:test";
+import { DrainService, type DrainStatus } from "../src/drain";
+import { ACTIVE_LABEL } from "../src/drain-core";
+import { SessionStore } from "../src/store";
+import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
+import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
+import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
+import type { Epic } from "../src/epic-core";
+
+const REPO = "/repo";
+
+function issue(number: number, over: Partial<Issue> = {}): Issue {
+  return {
+    number,
+    title: `issue ${number}`,
+    body: `body ${number}`,
+    url: `https://x/${number}`,
+    labels: ["shepherd:auto"],
+    createdAt: number,
+    ...over,
+  };
+}
+
+const NO_USAGE: UsageLimitsType = { session5h: null, week: null, stale: false, calibratedAt: null };
+
+interface ForgeRec {
+  listIssuesCalls: number;
+  added: { number: number; label: string }[];
+  /** ensureBranch calls: [branch, fromRef]. */
+  ensured: { branch: string; fromRef: string }[];
+}
+
+function fakeForge(
+  issues: Issue[],
+  rec: ForgeRec,
+  opts: {
+    listIssues?: () => Promise<Issue[]>;
+    getIssue?: (n: number) => Promise<Issue | null>;
+    listSubIssues?: (parentNumber: number) => Promise<SubIssueRef[]>;
+    listBlockedBy?: (issueNumber: number) => Promise<number[]>;
+    ensureBranch?: (branch: string, fromRef: string) => Promise<void>;
+  } = {},
+): GitForge {
+  return {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => {
+      rec.listIssuesCalls++;
+      if (opts.listIssues) return opts.listIssues();
+      return issues;
+    },
+    listPullRequests: async () => [],
+    prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
+    openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
+    defaultBranch: async () => "main",
+    merge: async () => {},
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    closeIssue: async () => {},
+    ensureIssueLink: async () => {},
+    addIssueLabel: async (number: number, label: string) => {
+      rec.added.push({ number, label });
+    },
+    removeIssueLabel: async () => {},
+    getIssue: async (number: number) => {
+      if (opts.getIssue) return opts.getIssue(number);
+      return issues.find((i) => i.number === number) ?? null;
+    },
+    listSubIssues: opts.listSubIssues,
+    listBlockedBy: opts.listBlockedBy,
+    ensureBranch: async (branch: string, fromRef: string) => {
+      rec.ensured.push({ branch, fromRef });
+      if (opts.ensureBranch) await opts.ensureBranch(branch, fromRef);
+    },
+  };
+}
+
+interface Harness {
+  store: SessionStore;
+  drain: DrainService;
+  forgeRec: ForgeRec;
+  creates: CreateSessionInput[];
+  statuses: DrainStatus[];
+  epics: Epic[];
+}
+
+function makeHarness(
+  opts: {
+    issues?: Issue[];
+    listIssuesImpl?: () => Promise<Issue[]>;
+    getIssueImpl?: (n: number) => Promise<Issue | null>;
+    listSubIssuesImpl?: (parentNumber: number) => Promise<SubIssueRef[]>;
+    listBlockedByImpl?: (issueNumber: number) => Promise<number[]>;
+  } = {},
+): Harness {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: true,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: true,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 2,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+  });
+
+  const forgeRec: ForgeRec = { listIssuesCalls: 0, added: [], ensured: [] };
+  const forge = fakeForge(opts.issues ?? [], forgeRec, {
+    listIssues: opts.listIssuesImpl,
+    getIssue: opts.getIssueImpl,
+    listSubIssues: opts.listSubIssuesImpl,
+    listBlockedBy: opts.listBlockedByImpl,
+  });
+
+  const prCache: Record<string, GitState> = {};
+  const reviews: Record<string, { decision: ReviewDecision; headSha: string }> = {};
+  const creates: CreateSessionInput[] = [];
+  const statuses: DrainStatus[] = [];
+  const epics: Epic[] = [];
+
+  const service = {
+    create: async (input: CreateSessionInput): Promise<Session> => {
+      creates.push(input);
+      return store.create({
+        name: "auto",
+        prompt: input.prompt,
+        repoPath: input.repoPath,
+        baseBranch: input.baseBranch,
+        branch: `shepherd/auto-${input.issueRef?.number ?? "x"}`,
+        worktreePath: "/wt",
+        isolated: true,
+        herdrSession: "default",
+        herdrAgentId: "t",
+        auto: input.auto ?? false,
+        issueNumber: input.issueRef?.number ?? null,
+      });
+    },
+    archive: (id: string): number => {
+      store.archive(id);
+      return 1;
+    },
+  };
+
+  const usage = { limits: (): UsageLimitsType => NO_USAGE };
+
+  store.getReview = ((id: string) =>
+    reviews[id]
+      ? { decision: reviews[id].decision, headSha: reviews[id].headSha }
+      : null) as typeof store.getReview;
+
+  const drain = new DrainService({
+    store,
+    service,
+    resolveForge: () => forge,
+    prCache: { snapshot: () => prCache },
+    usage,
+    repos: () => [REPO],
+    emitStatus: (s) => statuses.push(s),
+    emitArchived: () => {},
+    dropPrCache: () => {},
+    emitEpic: (epic) => epics.push(epic),
+  });
+
+  return { store, drain, forgeRec, creates, statuses, epics };
+}
+
+describe("epic-child spawns base on the integration branch", () => {
+  const PARENT = 327;
+  const CHILD = 320;
+  const EPIC_BRANCH = "epic/327-efi-cluster";
+
+  test("running epic: ensureBranch(epic/327-efi-cluster, main) + spawn bases on it", async () => {
+    const subIssues: SubIssueRef[] = [
+      { number: CHILD, title: "EFI", url: "u320", body: "spec 320", closed: false, labels: [] },
+    ];
+    const parentIssue: Issue = {
+      number: PARENT,
+      title: "EFI cluster",
+      body: "epic body",
+      url: `https://x/${PARENT}`,
+      labels: [],
+      createdAt: 0,
+    };
+    const h = makeHarness({
+      listIssuesImpl: async () => [],
+      getIssueImpl: async (n) => (n === PARENT ? parentIssue : null),
+      listSubIssuesImpl: async (n) => (n === PARENT ? subIssues : []),
+      listBlockedByImpl: async () => [],
+    });
+    h.store.setEpicRun({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      mode: "auto",
+      status: "running",
+    });
+
+    await h.drain.pump(REPO);
+
+    expect(h.forgeRec.ensured).toEqual([{ branch: EPIC_BRANCH, fromRef: "main" }]);
+    expect(h.creates).toHaveLength(1);
+    const created = h.creates[0]!;
+    expect(created.baseBranch).toBe(EPIC_BRANCH);
+    expect(created.issueRef?.number).toBe(CHILD);
+  });
+
+  test("regular label-drain spawn: bases on main, never ensures a branch", async () => {
+    const h = makeHarness({ issues: [issue(1)] });
+    await h.drain.pump(REPO);
+    expect(h.creates).toHaveLength(1);
+    expect(h.creates[0]!.baseBranch).toBe("main");
+    expect(h.forgeRec.ensured).toHaveLength(0);
+    expect(h.forgeRec.added).toEqual([{ number: 1, label: ACTIVE_LABEL }]);
+  });
+});

--- a/test/epic-branch.test.ts
+++ b/test/epic-branch.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test";
+import { epicIntegrationBranch } from "../src/epic-branch";
+
+test("builds epic/<#>-<slug> from parent number + title", () => {
+  expect(epicIntegrationBranch(327, "EFI / Value-Map cluster — sequencing")).toBe(
+    "epic/327-efi-value-map-cluster-sequencing",
+  );
+});
+
+test("lowercases, collapses non-alnum to single dashes, trims edge dashes", () => {
+  expect(epicIntegrationBranch(5, "  Foo__Bar!! ")).toBe("epic/5-foo-bar");
+});
+
+test("bounds the slug length (<= 40 slug chars) and never trails a dash", () => {
+  const b = epicIntegrationBranch(9, "x".repeat(100));
+  expect(b.startsWith("epic/9-")).toBe(true);
+  expect(b.length).toBeLessThanOrEqual("epic/9-".length + 40);
+  expect(b.endsWith("-")).toBe(false);
+});
+
+test("empty/symbol-only title degrades to bare epic/<#>", () => {
+  expect(epicIntegrationBranch(12, "!!!")).toBe("epic/12");
+});

--- a/test/epic-core.test.ts
+++ b/test/epic-core.test.ts
@@ -13,6 +13,7 @@ function child(over: Partial<EpicChild> = {}): EpicChild {
     sessionId: null,
     prNumber: null,
     issueClosed: false,
+    integrationMerged: false,
     claimed: false,
     ...over,
   };
@@ -66,5 +67,31 @@ describe("selectEpicCandidates", () => {
       labels: [],
       createdAt: 0,
     });
+  });
+});
+
+describe("integrationMerged", () => {
+  test("integration-merged child reads 'merged' even with the issue still open", () => {
+    const c = child({ number: 320, issueClosed: false, integrationMerged: true });
+    expect(deriveChildState(c, new Set())).toBe("merged");
+  });
+
+  test("a dependent unblocks once its blocker is integration-merged (issue still open)", () => {
+    const blocker = child({ number: 320, integrationMerged: true });
+    const dep = child({ number: 322, blockedBy: [320] });
+    expect(selectEpicCandidates([blocker, dep]).map((c) => c.number)).toEqual([322]);
+  });
+
+  test("a dependent stays blocked while its blocker is neither integrated nor closed", () => {
+    const blocker = child({ number: 320 });
+    const dep = child({ number: 322, blockedBy: [320] });
+    expect(deriveChildState(dep, new Set())).toBe("blocked");
+    expect(selectEpicCandidates([blocker, dep]).map((c) => c.number)).toEqual([320]);
+  });
+
+  test("legacy issue-closed path still satisfies a dependency", () => {
+    const blocker = child({ number: 320, issueClosed: true });
+    const dep = child({ number: 322, blockedBy: [320] });
+    expect(selectEpicCandidates([blocker, dep]).map((c) => c.number)).toEqual([322]);
   });
 });

--- a/test/epic-model.test.ts
+++ b/test/epic-model.test.ts
@@ -22,6 +22,7 @@ const BASE: AssembleInput = {
   openIssues: [], // markdown-only input; ignored on the native path
   openIssuesTruncated: false,
   sessions: [],
+  integrated: new Set<number>(),
 };
 
 describe("assembleEpic", () => {
@@ -82,4 +83,39 @@ describe("assembleEpic", () => {
     expect(e.children.find((c) => c.number === 322)!.blockedBy).toEqual([]);
     expect(e.warnings.filter((w) => w.includes("blocked_by")).length).toBe(2);
   });
+});
+
+function input(over: Partial<AssembleInput>): AssembleInput {
+  return {
+    repoPath: "/r",
+    run: { repoPath: "/r", parentIssueNumber: 327, mode: "auto", status: "running" },
+    parent: { number: 327, title: "Epic", body: "" },
+    subIssues: [
+      { number: 320, title: "root", url: "u320", body: "", closed: false, labels: [] },
+      { number: 322, title: "dep", url: "u322", body: "", closed: false, labels: [] },
+    ],
+    blockedBy: new Map([[322, [320]]]),
+    openIssues: [],
+    openIssuesTruncated: false,
+    sessions: [],
+    integrated: new Set<number>(),
+    ...over,
+  };
+}
+
+test("a child in the integrated set is integrationMerged and reads 'merged'", () => {
+  const epic = assembleEpic(input({ integrated: new Set([320]) }));
+  const c320 = epic.children.find((c) => c.number === 320)!;
+  expect(c320.integrationMerged).toBe(true);
+  expect(c320.state).toBe("merged");
+});
+
+test("integration-merging the blocker unblocks the dependent (issues still open)", () => {
+  const epic = assembleEpic(input({ integrated: new Set([320]) }));
+  expect(epic.children.find((c) => c.number === 322)!.state).toBe("ready");
+});
+
+test("empty integrated set leaves the dependent blocked", () => {
+  const epic = assembleEpic(input({ integrated: new Set() }));
+  expect(epic.children.find((c) => c.number === 322)!.state).toBe("blocked");
 });

--- a/test/forge/github-ensure-branch.test.ts
+++ b/test/forge/github-ensure-branch.test.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "bun:test";
+import { GithubForge } from "../../src/forge/github";
+
+const SHA = "abc123def456";
+
+test("GithubForge.ensureBranch: absent ref → resolves fromRef sha + creates the branch", async () => {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<string> => {
+    calls.push(args);
+    // Probe for the target branch ref → not found (gh exits non-zero).
+    if (args.join(" ").includes("git/ref/heads/epic/327-x")) {
+      throw new Error("HTTP 404: Not Found");
+    }
+    // Resolve the base ref's sha.
+    if (args.join(" ").includes("git/ref/heads/main")) {
+      return JSON.stringify({ object: { sha: SHA } });
+    }
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+
+  await forge.ensureBranch!("epic/327-x", "main");
+
+  const create = calls.find((c) => c.includes("repos/o/r/git/refs"));
+  expect(create).toBeDefined();
+  expect(create).toEqual([
+    "api",
+    "--method",
+    "POST",
+    "repos/o/r/git/refs",
+    "-f",
+    "ref=refs/heads/epic/327-x",
+    "-f",
+    `sha=${SHA}`,
+  ]);
+});
+
+test("GithubForge.ensureBranch: present ref → no-op, never creates (tip not reset)", async () => {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<string> => {
+    calls.push(args);
+    // Probe for the target branch ref → found.
+    if (args.join(" ").includes("git/ref/heads/epic/327-x")) {
+      return JSON.stringify({ object: { sha: "existing-tip" } });
+    }
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+
+  await forge.ensureBranch!("epic/327-x", "main");
+
+  expect(calls.some((c) => c.includes("repos/o/r/git/refs"))).toBe(false);
+});

--- a/test/full-auto.test.ts
+++ b/test/full-auto.test.ts
@@ -5,6 +5,7 @@ import { isFullAuto } from "../src/full-auto";
 const fullAutoSession = {
   autopilotEnabled: true as boolean | null,
   autoMergeEnabled: true as boolean | null,
+  baseBranch: "main",
 };
 // cfg with both enabled and draftMode OFF (standard full-auto repo)
 const fullAutoCfg = { autopilotEnabled: true, autoMergeEnabled: true, draftMode: false };
@@ -22,6 +23,7 @@ test("isFullAuto: draftMode on → false even when repo autoMergeEnabled true an
   const sessionInherits = {
     autopilotEnabled: true as boolean | null,
     autoMergeEnabled: null as boolean | null,
+    baseBranch: "main",
   };
   const draftCfg = { autopilotEnabled: true, autoMergeEnabled: true, draftMode: true };
   expect(isFullAuto(sessionInherits, draftCfg)).toBe(false);
@@ -31,6 +33,7 @@ test("isFullAuto: draftMode off, session autoMerge null → inherits repo defaul
   const sessionInherits = {
     autopilotEnabled: true as boolean | null,
     autoMergeEnabled: null as boolean | null,
+    baseBranch: "main",
   };
   expect(isFullAuto(sessionInherits, fullAutoCfg)).toBe(true);
 });
@@ -39,6 +42,7 @@ test("isFullAuto: draftMode off, session autoMerge off → false (unchanged beha
   const session = {
     autopilotEnabled: true as boolean | null,
     autoMergeEnabled: false as boolean | null,
+    baseBranch: "main",
   };
   const cfg = { autopilotEnabled: true, autoMergeEnabled: false, draftMode: false };
   expect(isFullAuto(session, cfg)).toBe(false);
@@ -48,6 +52,27 @@ test("isFullAuto: draftMode off, autopilot off → false (unchanged behavior)", 
   const session = {
     autopilotEnabled: false as boolean | null,
     autoMergeEnabled: true as boolean | null,
+    baseBranch: "main",
   };
   expect(isFullAuto(session, fullAutoCfg)).toBe(false);
+});
+
+test("isFullAuto: epic-child base (epic/9-x) → false even when autopilot + auto-merge both on", () => {
+  const epicChild = {
+    autopilotEnabled: true as boolean | null,
+    autoMergeEnabled: true as boolean | null,
+    baseBranch: "epic/9-x",
+  };
+  // Epic children are squash-merged into their integration branch by the drain's retire
+  // path — never carried by the merge train, so isFullAuto must read false.
+  expect(isFullAuto(epicChild, fullAutoCfg)).toBe(false);
+});
+
+test("isFullAuto: bare epic base (epic/9) → false too", () => {
+  const epicChild = {
+    autopilotEnabled: true as boolean | null,
+    autoMergeEnabled: true as boolean | null,
+    baseBranch: "epic/9",
+  };
+  expect(isFullAuto(epicChild, fullAutoCfg)).toBe(false);
 });

--- a/test/sandbox-wiring.test.ts
+++ b/test/sandbox-wiring.test.ts
@@ -38,6 +38,7 @@ function worktreeStub() {
     }),
     remove: () => {},
     gitCommonDir: () => "/wt/s/.git",
+    ensureBaseRef: async () => {},
   } as any;
 }
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -32,6 +32,7 @@ function makeDeps(liveTerminals: string[] = []): AppDeps {
     namer: async () => "x",
     worktree: {
       create: () => ({ worktreePath: "/wt", branch: "shepherd/x", isolated: true }),
+      ensureBaseRef: async () => {},
       remove: () => {},
     } as any,
     herdr: {
@@ -181,6 +182,7 @@ function harnessWithReaper(reaper: { detect: any; reap: any; stopListenersOnPort
     namer: async () => "x",
     worktree: {
       create: () => ({ worktreePath: "/wt/x", branch: "shepherd/x", isolated: true }),
+      ensureBaseRef: async () => {},
       remove: () => {},
     } as any,
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {}, send: () => {} } as any,
@@ -1181,7 +1183,7 @@ function clearMergedHarness() {
   const service = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {}, send: () => {} } as any,
     reaper: {
       detect,
@@ -1774,6 +1776,7 @@ function harnessWithPreviewStop({
     namer: async () => "x",
     worktree: {
       create: () => ({ worktreePath: "/wt/x", branch: "shepherd/x", isolated: true }),
+      ensureBaseRef: async () => {},
       remove: () => {},
     } as any,
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {}, send: () => {} } as any,

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -34,6 +34,7 @@ test("createSession: names, makes worktree, starts herdr, persists", async () =>
     store,
     namer: async () => "repo-flatten",
     worktree: {
+      ensureBaseRef: async () => {},
       create: (repo: string, base: string, name: string) => {
         calls.wt = { repo, base, name };
         return {
@@ -105,7 +106,7 @@ test("setReadyToMerge persists the flag and emits session:ready", () => {
   const service = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: { start: () => ({}) as any, list: () => [] } as any,
     events: { emit: (event, data) => emitted.push({ event, data }) },
   });
@@ -299,6 +300,7 @@ test("createSession: uses herd-qualified name on collision with a different-repo
     // namer is deterministic, so a resubmitted prompt collides with a live agent's name
     namer: async () => "koennen-wir-schon",
     worktree: {
+      ensureBaseRef: async () => {},
       create: (_repo: string, _base: string, name: string) => {
         calls.wtName = name;
         return { worktreePath: `/wt/${name}`, branch: `shepherd/${name}`, isolated: true };
@@ -337,6 +339,7 @@ test("createSession: falls back to numeric suffix when base AND herd-qualified n
     store,
     namer: async () => "koennen-wir-schon",
     worktree: {
+      ensureBaseRef: async () => {},
       create: (_repo: string, _base: string, name: string) => {
         calls.wtName = name;
         return { worktreePath: `/wt/${name}`, branch: `shepherd/${name}`, isolated: true };
@@ -374,6 +377,7 @@ test("createSession: falls back to numeric-only suffix when repoPath has no usab
     store,
     namer: async () => "koennen-wir-schon",
     worktree: {
+      ensureBaseRef: async () => {},
       create: (_repo: string, _base: string, name: string) => {
         calls.wtName = name;
         return { worktreePath: `/wt/${name}`, branch: `shepherd/${name}`, isolated: true };
@@ -411,6 +415,7 @@ test("createSession: keeps the base name when no agent holds it", async () => {
     store,
     namer: async () => "fresh-name",
     worktree: {
+      ensureBaseRef: async () => {},
       create: (_r: string, _b: string, name: string) => ({
         worktreePath: `/wt/${name}`,
         branch: `shepherd/${name}`,
@@ -441,6 +446,7 @@ test("createSession: passes --model and persists it when a model is chosen", asy
     store,
     namer: async () => "repo-flatten",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({ worktreePath: "/wt/x", branch: "shepherd/x", isolated: true }),
       remove: () => {},
     } as any,
@@ -484,6 +490,7 @@ test("createSession: moves images into worktree and appends paths to the prompt"
     store,
     namer: async () => "repo-x",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({ worktreePath: "/wt/repo-x", branch: "shepherd/repo-x", isolated: true }),
       remove: () => {},
     } as any,
@@ -529,6 +536,7 @@ test("createSession: no images leaves the prompt argv unchanged", async () => {
     store,
     namer: async () => "repo-x",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({ worktreePath: "/wt/x", branch: "shepherd/x", isolated: true }),
       remove: () => {},
     } as any,
@@ -565,6 +573,7 @@ test("createSession: appends the issueRef body out-of-band, keeps the stored pro
     store,
     namer: async () => "repo-x",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({ worktreePath: "/wt/x", branch: "shepherd/x", isolated: true }),
       remove: () => {},
     } as any,
@@ -613,6 +622,7 @@ test("createSession: persists auto=true and issueNumber from issueRef.number", a
     store,
     namer: async () => "repo-x",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({ worktreePath: "/wt/x", branch: "shepherd/x", isolated: true }),
       remove: () => {},
     } as any,
@@ -646,6 +656,7 @@ test("createSession: defaults auto=false and issueNumber=null when not provided"
     store,
     namer: async () => "repo-x",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({ worktreePath: "/wt/x", branch: "shepherd/x", isolated: true }),
       remove: () => {},
     } as any,
@@ -676,6 +687,7 @@ test("createSession: rolls back the worktree when the agent fails to start", asy
     store,
     namer: async () => "boom",
     worktree: {
+      ensureBaseRef: async () => {},
       create: (_r: string, _b: string, name: string) => ({
         worktreePath: `/wt/${name}`,
         branch: `shepherd/${name}`,
@@ -714,6 +726,7 @@ test("createSession: skips worktree rollback when the cwd fallback isn't isolate
     store,
     namer: async () => "boom",
     worktree: {
+      ensureBaseRef: async () => {},
       // non-git repoPath → herdr runs in-place, no worktree to clean up
       create: () => ({ worktreePath: "/repo", branch: null, isolated: false }),
       remove: () => {
@@ -746,7 +759,11 @@ test("archive stops the herdr agent, removes the worktree, and archives the row"
   const service = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}), remove: (p: string) => calls.removed.push(p) } as any,
+    worktree: {
+      create: () => ({}),
+      ensureBaseRef: async () => {},
+      remove: (p: string) => calls.removed.push(p),
+    } as any,
     herdr: { start: () => ({}), list: () => [], stop: (t: string) => calls.stopped.push(t) } as any,
   });
   const s = store.create({
@@ -790,6 +807,7 @@ test("archive without a reaper just closes the session (no leftover handling)", 
     store,
     namer: async () => "x",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,
@@ -831,6 +849,7 @@ test("leftovers proxies to the reaper for the session; [] for unknown id", () =>
     store,
     namer: async () => "x",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,
@@ -874,6 +893,7 @@ test("archive reaps only the selected leftovers, re-detected (no trusting raw cl
     store,
     namer: async () => "x",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,
@@ -915,6 +935,7 @@ test("archive with no reap keys never calls the reaper", () => {
     store,
     namer: async () => "x",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,
@@ -957,7 +978,7 @@ test("resume respawns claude --resume in the worktree and re-points the agent", 
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: {
       start: (name: string, cwd: string, argv: string[]) => {
         calls.start = { name, cwd, argv };
@@ -992,7 +1013,7 @@ test("resume omits --model when the session had none", async () => {
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: {
       start: (_n: string, _c: string, argv: string[]) => {
         calls.argv = argv;
@@ -1021,7 +1042,7 @@ test("resume re-uses a still-live agent instead of spawning a duplicate", async 
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: {
       start: () => {
         started++;
@@ -1046,7 +1067,7 @@ test("resume force=true stops the live husk agent and respawns claude", async ()
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: {
       start: () => {
         started++;
@@ -1071,7 +1092,7 @@ test("resume returns null for unknown, archived, or pre-feature sessions", async
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {}, send: () => {} } as any,
   });
   expect(await svc.resume("ghost")).toBeNull(); // unknown id
@@ -1101,7 +1122,7 @@ test("reply delivers the text as a bracketed paste, then submits with a carriage
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: {
       start: () => ({}) as any,
       list: () => [{ terminalId: "term_z" }], // pane is live
@@ -1145,7 +1166,7 @@ test("reply returns false for a live-in-store session whose pane is dead (no thr
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: {
       start: () => ({}) as any,
       list: () => [{ terminalId: "term_other" }], // session's pane is NOT listed → dead
@@ -1179,7 +1200,7 @@ test("broadcast fans the text out to known sessions, skips unknown ids", () => {
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: {
       start: () => ({}) as any,
       list: () => [{ terminalId: "term_a" }, { terminalId: "term_b" }], // both panes live
@@ -1222,7 +1243,7 @@ test("haltAll sends a lone ESC only to working panes; idle/blocked/dead untouche
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     events: { emit: (e: string, d: unknown) => emitted.push({ e, d }) } as any,
     herdr: {
       start: () => ({}) as any,
@@ -1270,7 +1291,7 @@ test("haltAll keeps interrupting after one pane's send throws; counts only the l
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     events: { emit: (e: string, d: unknown) => emitted.push({ e, d }) } as any,
     herdr: {
       start: () => ({}) as any,
@@ -1310,7 +1331,7 @@ test("haltAll throws (no emit) when herdr can't be reached — never a silent no
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     events: { emit: (e: string, d: unknown) => emitted.push({ e, d }) } as any,
     herdr: {
       start: () => ({}) as any,
@@ -1345,6 +1366,7 @@ function svcDeps(over: any = {}) {
       branch: `shepherd/${name}`,
       isolated: true,
     }),
+    ensureBaseRef: async () => {},
     remove: () => {},
     renameBranch: (_r: string, _o: string, n: string) => renamedBranches.push(n),
     commitsAhead: () => 0,
@@ -1514,7 +1536,11 @@ test("archiveMany clears each session, reaping all its leftovers", () => {
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: (p: string) => calls.removed.push(p) } as any,
+    worktree: {
+      create: () => ({}) as any,
+      ensureBaseRef: async () => {},
+      remove: (p: string) => calls.removed.push(p),
+    } as any,
     herdr: {
       start: () => ({}) as any,
       list: () => [],
@@ -1556,6 +1582,7 @@ function injectDeps(store: SessionStore, captured: { argv?: string[] }, isolated
     store,
     namer: async () => "repo-task",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({
         worktreePath: "/wt/repo-task",
         branch: isolated ? "shepherd/repo-task" : null,
@@ -1803,7 +1830,7 @@ test("resume adopts a live agent found by cwd under a new terminalId — no dupl
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: {
       start: () => {
         startCalls++;
@@ -1839,6 +1866,7 @@ test("archiveMany isolates a failing session: others still clear, the failed id 
     store,
     namer: async () => "x",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({}) as any,
       // session b's worktree teardown blows up mid-loop
       remove: (p: string) => {
@@ -1880,6 +1908,7 @@ function mergeSvc() {
     store,
     namer: async () => "n",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({ worktreePath: "/wt", branch: "b", isolated: true }),
       remove: () => {},
     } as any,
@@ -2015,6 +2044,7 @@ test("isolated guard: a sole non-isolated merged member never emits", async () =
     store,
     namer: async () => "n",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({ worktreePath: "/wt", branch: null, isolated: false }),
       remove: () => {},
     } as any,
@@ -2259,6 +2289,7 @@ function buildQueueDeps(
     store,
     namer: async () => "repo-task",
     worktree: {
+      ensureBaseRef: async () => {},
       create: () => ({
         worktreePath: "/wt/repo-task",
         branch: "shepherd/repo-task",
@@ -2480,7 +2511,7 @@ function makePreviewSvc(opts: { terminalId: string; liveIds: string[] }) {
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: {
       start: () => ({}) as any,
       list: () => opts.liveIds.map((id) => ({ terminalId: id })),
@@ -2576,7 +2607,7 @@ function makeStopPreviewSvc(opts: {
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {}, send: () => {} } as any,
     reaper: reaper as any,
     preview: preview as any,
@@ -2661,7 +2692,7 @@ test("stopPreview: does NOT call any release method on the preview dep", () => {
   const svc = new SessionService({
     store,
     namer: async () => "x",
-    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    worktree: { create: () => ({}) as any, ensureBaseRef: async () => {}, remove: () => {} } as any,
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {}, send: () => {} } as any,
     reaper: {
       detect: () => [],
@@ -2854,7 +2885,11 @@ test("resume of an auto session re-applies the trim: flag + plugin-off overlay",
     const svc = new SessionService({
       store,
       namer: async () => "x",
-      worktree: { create: () => ({}) as any, remove: () => {} } as any,
+      worktree: {
+        create: () => ({}) as any,
+        ensureBaseRef: async () => {},
+        remove: () => {},
+      } as any,
       herdr: {
         start: (_n: string, _c: string, argv: string[]) => {
           calls.argv = argv;
@@ -2898,6 +2933,7 @@ function relaunchHarness(store: SessionStore) {
     store,
     namer: async () => "relaunched",
     worktree: {
+      ensureBaseRef: async () => {},
       create: (_repo: string, _base: string, name: string) => {
         const wp = `/wt/${name}-${++n}`;
         return { worktreePath: wp, branch: `shepherd/${name}`, isolated: true };
@@ -3207,7 +3243,11 @@ test("resume of a non-auto session stays untrimmed even with trim on", async () 
     const svc = new SessionService({
       store,
       namer: async () => "x",
-      worktree: { create: () => ({}) as any, remove: () => {} } as any,
+      worktree: {
+        create: () => ({}) as any,
+        ensureBaseRef: async () => {},
+        remove: () => {},
+      } as any,
       herdr: {
         start: (_n: string, _c: string, argv: string[]) => {
           calls.argv = argv;

--- a/test/store-epic-integrated.test.ts
+++ b/test/store-epic-integrated.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+
+test("records and lists integration-merged children per epic parent", () => {
+  const s = new SessionStore(":memory:");
+  expect([...s.listEpicIntegrated("/r", 327)]).toEqual([]);
+  s.recordEpicIntegrated("/r", 327, 320);
+  s.recordEpicIntegrated("/r", 327, 320); // idempotent
+  s.recordEpicIntegrated("/r", 327, 322);
+  expect([...s.listEpicIntegrated("/r", 327)].sort((a, b) => a - b)).toEqual([320, 322]);
+  expect([...s.listEpicIntegrated("/r", 999)]).toEqual([]); // scoped by parent
+  expect([...s.listEpicIntegrated("/other", 327)]).toEqual([]); // scoped by repo
+});

--- a/test/worktree-ensure-base-ref.test.ts
+++ b/test/worktree-ensure-base-ref.test.ts
@@ -27,6 +27,10 @@ function localBranches(dir: string): string[] {
     .filter(Boolean);
 }
 
+function revParse(dir: string, ref: string): string {
+  return execFileSync("git", ["rev-parse", ref], { cwd: dir, stdio: "pipe" }).toString().trim();
+}
+
 let origin: string;
 let repo: string;
 beforeEach(() => {
@@ -55,13 +59,23 @@ afterEach(() => {
   rmSync(repo, { recursive: true, force: true });
 });
 
-test("ensureBaseRef: local ref already exists (default branch) → no-op, no new branch", async () => {
+test("ensureBaseRef: checked-out (default) branch is NOT fetched → no-op, stays at local tip", async () => {
   const wt = new WorktreeMgr();
-  // main is the clone's local checkout branch — already resolves locally.
+  // main is the clone's local checkout branch — git refuses to fetch into it.
   expect(localBranches(repo)).toEqual(["main"]);
+  const before = revParse(repo, "main");
+
+  // Advance origin/main from a second clone so a fetch (if it wrongly happened) would move it.
+  const other = mkdtempSync(join(tmpdir(), "shepherd-other-"));
+  execFileSync("git", ["clone", "-q", "--branch", "main", origin, other], { stdio: "pipe" });
+  commit(other, "a.txt", "advanced", "advance main");
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: other, stdio: "pipe" });
+  rmSync(other, { recursive: true, force: true });
+
   await wt.ensureBaseRef(repo, "main");
-  // still just main — nothing fetched/created
+  // still just main, still at the original local tip — the checked-out branch is skipped.
   expect(localBranches(repo)).toEqual(["main"]);
+  expect(revParse(repo, "main")).toBe(before);
 });
 
 test("ensureBaseRef: origin-only branch is materialized into a local branch", async () => {
@@ -74,6 +88,28 @@ test("ensureBaseRef: origin-only branch is materialized into a local branch", as
   const r = wt.create(repo, "epic/9-x", "child");
   expect(r.isolated).toBe(true);
   wt.remove(r.worktreePath);
+});
+
+test("ensureBaseRef: existing local integration branch is fast-forwarded to origin tip", async () => {
+  const wt = new WorktreeMgr();
+  // C1: materialize local epic/9-x at origin's current tip.
+  await wt.ensureBaseRef(repo, "epic/9-x");
+  expect(localBranches(repo)).toContain("epic/9-x");
+  const c1 = revParse(repo, "epic/9-x");
+
+  // C2: a sibling advances origin/epic/9-x (simulates a sibling PR squash-merging into it).
+  const other = mkdtempSync(join(tmpdir(), "shepherd-sibling-"));
+  execFileSync("git", ["clone", "-q", "--branch", "epic/9-x", origin, other], { stdio: "pipe" });
+  commit(other, "c.txt", "sibling work", "sibling merge");
+  execFileSync("git", ["push", "-q", "origin", "epic/9-x"], { cwd: other, stdio: "pipe" });
+  const c2 = revParse(other, "epic/9-x");
+  rmSync(other, { recursive: true, force: true });
+  expect(c2).not.toBe(c1); // origin genuinely advanced
+
+  // Second spawn: local epic/9-x must fast-forward to C2, not stay stale at C1.
+  await wt.ensureBaseRef(repo, "epic/9-x");
+  expect(revParse(repo, "epic/9-x")).toBe(c2);
+  expect(revParse(repo, "epic/9-x")).not.toBe(c1);
 });
 
 test("ensureBaseRef: invalid base name is ignored (no throw, no branch)", async () => {

--- a/test/worktree-ensure-base-ref.test.ts
+++ b/test/worktree-ensure-base-ref.test.ts
@@ -1,0 +1,83 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { WorktreeMgr } from "../src/worktree";
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+
+function commit(dir: string, file: string, content: string, msg: string) {
+  writeFileSync(join(dir, file), content);
+  execFileSync("git", ["add", "-A"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["commit", "-qm", msg], { cwd: dir, stdio: "pipe", env: GIT_ENV });
+}
+
+function localBranches(dir: string): string[] {
+  return execFileSync("git", ["branch", "--format=%(refname:short)"], { cwd: dir, stdio: "pipe" })
+    .toString()
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+let origin: string;
+let repo: string;
+beforeEach(() => {
+  // A bare "origin" plus a clone, so a branch can live only on origin.
+  origin = mkdtempSync(join(tmpdir(), "shepherd-origin-"));
+  execFileSync("git", ["init", "-q", "--bare", "-b", "main", origin], { stdio: "pipe" });
+
+  const seed = mkdtempSync(join(tmpdir(), "shepherd-seed-"));
+  execFileSync("git", ["init", "-q", "-b", "main", seed], { stdio: "pipe" });
+  commit(seed, "a.txt", "1", "init");
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: seed, stdio: "pipe" });
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+  // an integration branch that exists ONLY on origin
+  execFileSync("git", ["checkout", "-q", "-b", "epic/9-x"], { cwd: seed, stdio: "pipe" });
+  commit(seed, "b.txt", "2", "epic work");
+  execFileSync("git", ["push", "-q", "origin", "epic/9-x"], { cwd: seed, stdio: "pipe" });
+  rmSync(seed, { recursive: true, force: true });
+
+  repo = mkdtempSync(join(tmpdir(), "shepherd-clone-"));
+  execFileSync("git", ["clone", "-q", "--single-branch", "--branch", "main", origin, repo], {
+    stdio: "pipe",
+  });
+});
+afterEach(() => {
+  rmSync(origin, { recursive: true, force: true });
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("ensureBaseRef: local ref already exists (default branch) → no-op, no new branch", async () => {
+  const wt = new WorktreeMgr();
+  // main is the clone's local checkout branch — already resolves locally.
+  expect(localBranches(repo)).toEqual(["main"]);
+  await wt.ensureBaseRef(repo, "main");
+  // still just main — nothing fetched/created
+  expect(localBranches(repo)).toEqual(["main"]);
+});
+
+test("ensureBaseRef: origin-only branch is materialized into a local branch", async () => {
+  const wt = new WorktreeMgr();
+  // epic/9-x exists on origin but NOT locally (single-branch clone of main)
+  expect(localBranches(repo)).not.toContain("epic/9-x");
+  await wt.ensureBaseRef(repo, "epic/9-x");
+  expect(localBranches(repo)).toContain("epic/9-x");
+  // and it now resolves locally so a worktree can base on it
+  const r = wt.create(repo, "epic/9-x", "child");
+  expect(r.isolated).toBe(true);
+  wt.remove(r.worktreePath);
+});
+
+test("ensureBaseRef: invalid base name is ignored (no throw, no branch)", async () => {
+  const wt = new WorktreeMgr();
+  await wt.ensureBaseRef(repo, "--evil");
+  expect(localBranches(repo)).toEqual(["main"]);
+});


### PR DESCRIPTION
## Why

Reported symptom: an epic stalled because merging a child PR (e.g. `ltdovr/flowagent#330`) did **not** close its issue (#320), so dependent tasks (#322/#323/#325) never unblocked.

**Root cause:** Shepherd's epic state machine gated entirely on GitHub **issue-closed** state (`epic-core.ts`, `drain.ts handleEpicSideEffects`). That only works when a child PR merges into the **default branch**, where `Closes #N` auto-closes the issue. The epic's children merged into an integration branch, where GitHub does **not** process `Closes #N` — so `issueClosed` stayed false and the gate never advanced. Additionally, the "epic integration branch" model wasn't actually implemented in Shepherd at all (`doSpawn` based every spawn on the default branch); the branch had been improvised by an agent.

## What (Stage A — make the epic *flow*)

Epics now land **in one piece** instead of trickling per-child PRs into the default branch. This is the default for epics; regular tasks are unchanged (branch off default, one PR → default).

- **Integration branch** `epic/<parent#>-<slug>` (`src/epic-branch.ts`), created off the latest default branch via the new `forge.ensureBranch` (idempotent `gh api` ref create).
- **Epic-child spawns base on it.** `drain.resolveSpawnBase` selects the integration branch (falling back to default if the forge can't create it, e.g. Gitea). `service.create → worktree.ensureBaseRef` fetches/**fast-forwards** the branch locally on every spawn, so each child builds on its predecessors' merged work — not a stale tip.
- **Done-on-merge gate (the actual fix).** A child is "done" when its PR is squash-merged into the integration branch **or** its issue is closed (`integrationMerged || issueClosed`), sourced from a persisted `epic_integrated` set recorded at merge time. Dependents unblock with no GitHub auto-close required (`src/epic-core.ts`, `src/epic-model.ts`, `src/store.ts`).
- **Child PRs target the integration branch.** The spawned agent opens its own PR, so Shepherd injects `gh pr create --base <branch>` into the epic-child spawn prompt (`epicBaseDirective`) and the open-PR steer (`openPrSteer`).
- **Child auto-merge into the integration branch.** On retire, `drain.doRetire` squash-merges the epic child's PR into the integration branch and records it (instead of leaving it open). Epic children are kept **off the merge train** (`isFullAuto` → false for an integration-branch base) so the train can't merge them without recording the integration.

## Scope / follow-up

This is **Stage A** of the approved design (`docs/superpowers/specs/2026-06-13-epic-integration-branch-design.md`). It makes the epic **flow** — dependents unblock, children accumulate on the integration branch — which fixes the reported stall.

**Stage B (separate PR)** adds the final `integration → default` PR (aggregating every `Closes #N` + the parent) and a `landing` lifecycle, plus epic-panel UI. Until Stage B, an epic's children sit merged on the integration branch with their issues open/claimed; the one-PR-to-default landing is opened manually. The epic auto-completes (→ idle) once all children are integration-merged — early relative to the not-yet-built final PR, but it leaves a sensible state (no re-spawn, no premature cleanup).

## Notes

- Server-only (no `ui/` changes) → no i18n / feature-catalog entry (Stage B owns the UI). The steer/directive strings are agent-facing PTY text, consistent with the existing non-i18n `OPEN_PR_STEER` convention.
- The PR-base mechanism is **advisory** (prompt + steer) by design — there is no post-hoc enforcement that the opened PR's base equals the integration branch.

## Tests / verification

- `bunx tsc --noEmit` ✅ · `bun run lint` ✅ · `bun test ./test` → **2315 pass, 0 fail** ✅ · `bunx fallow audit --base origin/main --fail-on-issues` ✅
- New suites: `epic-branch`, `epic-core`/`epic-model` done-on-merge cases, `store-epic-integrated`, `github-ensure-branch`, `worktree-ensure-base-ref` (real-git FF), `drain-epic-spawn-base`, `drain-epic-retire-merge`, `full-auto` epic exclusion.
- Built subagent-driven (fresh implementer + spec/quality review per task), rebased linear on latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)