### PR TITLE
feat(ui): expand steer prompt field on focus + slash-command picker

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1108,5 +1108,7 @@
   "automation_allprs_detail": "Normalerweise prüft der Kritiker nur Pull Requests, die Shepherds eigene Agenten öffnen. Ist dies an, durchsucht der Kritiker stattdessen periodisch das gesamte Repo und prüft jeden offenen, CI-grünen Pull Request — auch solche von Menschen oder anderen Werkzeugen sowie Beiträge aus Forks. Jeder erhält denselben nur-lesenden Diff-Review, gepostet als Kommentar (nie eine blockierende Änderungsanforderung, damit Fremd-PRs nicht ausgebremst werden). Dies ist unabhängig vom Kritiker-Schalter pro Session und prüft mehr PRs, kostet also mehr Tokens. Jeder PR wird einmal pro gepushtem Head geprüft; ein reiner Rebase wird nicht erneut geprüft.",
   "feat_critic_all_prs_title": "Critic prüft jeden Pull Request",
   "feat_critic_all_prs_body": "Aktiviere „Alle PRs prüfen“ im Automatisierungs-Panel eines Repos, damit der Critic jeden CI-grünen Pull Request bewertet – nicht nur solche, die einer Shepherd-Sitzung zugeordnet sind. Pro Repo opt-in; beachte den höheren Token-Verbrauch bei vielen offenen PRs.",
-  "automation_sandbox_profile_summary": "Optionale Abschottung für Agenten."
+  "automation_sandbox_profile_summary": "Optionale Abschottung für Agenten.",
+  "feat_steers_prompt_editor_title": "Größerer Steer-Editor mit Slash-Befehlen",
+  "feat_steers_prompt_editor_body": "In den gespeicherten Steers vergrößert sich ein Prompt-Feld jetzt beim Reinklicken, sodass der ganze Text sichtbar ist, und mit „/“ erscheint dieselbe Slash-Befehl-Auswahl wie in den Feldern für Neue Aufgabe und Verfassen – Befehl per Pfeiltasten oder Tipp auswählen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1108,5 +1108,7 @@
   "automation_allprs_detail": "Normally the Critic only reviews pull requests opened by Shepherd's own agents. Turn this on and the Critic instead sweeps the whole repo on a timer, reviewing every open, CI-green pull request — including ones humans or other tools opened, and fork contributions. Each gets the same read-only diff review, posted as a comment (never a blocking change request, so it won't gate third-party PRs). This is independent of the per-session Critic switch and reviews more PRs, so it costs more tokens. Each PR is reviewed once per pushed head; a pure rebase isn't re-reviewed.",
   "feat_critic_all_prs_title": "Critic reviews every PR",
   "feat_critic_all_prs_body": "Enable \"Review all PRs\" in a repo's automation panel and the Critic will review every CI-green pull request — not just ones tied to a Shepherd session. Opt-in per repo; note the higher token cost for busy repos.",
-  "automation_sandbox_profile_summary": "Opt-in confinement for agents."
+  "automation_sandbox_profile_summary": "Opt-in confinement for agents.",
+  "feat_steers_prompt_editor_title": "Roomier steer editor with slash commands",
+  "feat_steers_prompt_editor_body": "In Saved Steers, clicking into a prompt field now expands it to show the whole text, and typing \"/\" offers the same slash-command picker as the New Task and compose fields — pick a command with the arrow keys or a tap."
 }

--- a/ui/src/lib/components/SteersEditor.svelte
+++ b/ui/src/lib/components/SteersEditor.svelte
@@ -5,7 +5,10 @@
   import type { DndEvent } from "svelte-dnd-action";
   import { steers } from "$lib/steers.svelte";
   import EmojiPicker from "$lib/components/EmojiPicker.svelte";
-  import type { Steer } from "$lib/types";
+  import SlashCommandMenu from "$lib/components/SlashCommandMenu.svelte";
+  import { getCommands } from "$lib/api";
+  import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
+  import type { Steer, SlashCommand } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
 
   const flipDurationMs = 150;
@@ -16,6 +19,20 @@
   let saved = $state(false);
   // steer id whose emoji picker is open; null = closed
   let pickerFor = $state<string | null>(null);
+
+  // ── inline slash-command autocomplete for each steer's prompt field ──
+  // Steers are global presets (not bound to a repo), so we load the user-scope
+  // command index: passing no repo to /api/commands yields the user/.claude
+  // commands + skills only, the layer common to every session.
+  let allCommands = $state<SlashCommand[]>([]);
+  // steer id whose slash menu is open; null = closed (only one field is focused
+  // at a time, so a single set of menu state covers the whole list).
+  let slashFor = $state<string | null>(null);
+  let slashQuery = $state("");
+  let slashIndex = $state(0);
+  // the textarea currently driving the menu, for caret reads + post-pick refocus
+  let activeTa: HTMLTextAreaElement | null = null;
+  const slashMatches = $derived(slashFor ? filterCommands(allCommands, slashQuery) : []);
 
   function reorder(e: CustomEvent<DndEvent<Steer>>) {
     draft = e.detail.items;
@@ -29,7 +46,88 @@
   onMount(async () => {
     if (!steers.loaded) await steers.load();
     syncFromStore();
+    getCommands("")
+      .then((r) => (allCommands = r.commands))
+      .catch(() => (allCommands = []));
   });
+
+  // Grow the focused prompt field to fit its content; at rest it collapses back to
+  // a single line so the row list stays compact. This is the "click-in → bigger"
+  // behaviour: a long steer prompt is fully visible and editable once focused.
+  function autogrow(ta: HTMLTextAreaElement) {
+    ta.style.height = "auto";
+    ta.style.height = `${ta.scrollHeight}px`;
+  }
+
+  function onTextFocus(e: FocusEvent) {
+    activeTa = e.currentTarget as HTMLTextAreaElement;
+    autogrow(activeTa);
+  }
+
+  function onTextInput(s: Steer, e: Event) {
+    saved = false;
+    const ta = e.currentTarget as HTMLTextAreaElement;
+    activeTa = ta;
+    autogrow(ta);
+    // open/refresh the menu from the caret, or close it once the text is no longer
+    // a leading `/token` (mirrors the ComposeBar / New Task picker).
+    const trigger = matchSlashTrigger(s.text, ta.selectionStart ?? s.text.length);
+    if (trigger) {
+      slashFor = s.id;
+      slashQuery = trigger.query;
+      slashIndex = 0;
+    } else if (slashFor === s.id) {
+      slashFor = null;
+    }
+  }
+
+  function onTextBlur(s: Steer, e: FocusEvent) {
+    (e.currentTarget as HTMLTextAreaElement).style.height = ""; // collapse to one line
+    if (slashFor === s.id) slashFor = null;
+  }
+
+  // Replace the typed `/query` with the chosen command, hoisting it to the front —
+  // Claude only runs a *leading* slash command, so any surrounding text becomes its
+  // argument. Caret lands past `/name ` so arguments can be typed straight away.
+  function pickCommand(s: Steer, cmd: SlashCommand) {
+    const ta = activeTa;
+    const caret = ta?.selectionStart ?? s.text.length;
+    const start = matchSlashTrigger(s.text, caret)?.start ?? 0;
+    const next = applyCommandPick(s.text, start, caret, cmd.name);
+    s.text = next.value;
+    slashFor = null;
+    saved = false;
+    queueMicrotask(() => {
+      if (!ta) return;
+      ta.focus();
+      autogrow(ta);
+      ta.setSelectionRange(next.caret, next.caret);
+    });
+  }
+
+  // While the menu is open, arrows/Enter/Tab/Escape drive the picker instead of the
+  // textarea (a tap on a row works regardless).
+  function onTextKeydown(s: Steer, e: KeyboardEvent) {
+    if (slashFor !== s.id) return;
+    if (slashMatches.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        slashIndex = (slashIndex + 1) % slashMatches.length;
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        slashIndex = (slashIndex - 1 + slashMatches.length) % slashMatches.length;
+      } else if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        pickCommand(s, slashMatches[slashIndex]!);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        slashFor = null;
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      slashFor = null;
+    }
+  }
 
   function add() {
     draft = [
@@ -110,13 +208,28 @@
           aria-label={m.steerseditor_label_aria()}
           oninput={() => (saved = false)}
         />
-        <input
-          class="text"
-          bind:value={s.text}
-          placeholder={m.steerseditor_text_placeholder()}
-          aria-label={m.steerseditor_text_aria()}
-          oninput={() => (saved = false)}
-        />
+        <div class="text-wrap">
+          <textarea
+            class="text"
+            rows="1"
+            bind:value={s.text}
+            placeholder={m.steerseditor_text_placeholder()}
+            aria-label={m.steerseditor_text_aria()}
+            onfocus={onTextFocus}
+            oninput={(e) => onTextInput(s, e)}
+            onblur={(e) => onTextBlur(s, e)}
+            onkeydown={(e) => onTextKeydown(s, e)}
+          ></textarea>
+          {#if slashFor === s.id}
+            <SlashCommandMenu
+              commands={slashMatches}
+              activeIndex={slashIndex}
+              placement="down"
+              onpick={(cmd) => pickCommand(s, cmd)}
+              onhover={(i) => (slashIndex = i)}
+            />
+          {/if}
+        </div>
         <div class="scopes" class:none={!s.inSteerBar && !s.onIssues}>
           <button
             type="button"
@@ -199,7 +312,9 @@
     position: relative;
     display: flex;
     gap: 4px;
-    align-items: center;
+    /* top-aligned so the controls stay level with the first line when the prompt
+       field grows to multiple lines on focus */
+    align-items: flex-start;
   }
   .grip {
     flex: 0 0 auto;
@@ -217,7 +332,8 @@
   .grip:active {
     cursor: grabbing;
   }
-  .srow input {
+  .srow input,
+  .srow textarea {
     background: var(--color-inset);
     border: 1px solid var(--color-line-bright);
     border-radius: 2px;
@@ -230,9 +346,21 @@
     flex: 1 1 26%;
     min-width: 0;
   }
-  .srow .text {
+  /* anchors the slash-command menu (absolutely positioned) to the prompt field */
+  .text-wrap {
+    position: relative;
     flex: 2 1 38%;
     min-width: 0;
+    display: flex;
+  }
+  /* one-line at rest (compact list), autogrows to its content while focused —
+     JS sets an inline height on focus/input and clears it on blur. */
+  .srow .text {
+    flex: 1 1 auto;
+    min-width: 0;
+    resize: none;
+    overflow: hidden;
+    line-height: 1.4;
   }
   .emoji-btn {
     flex: 0 0 auto;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -664,4 +664,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_critic_all_prs_title",
     bodyKey: "feat_critic_all_prs_body",
   },
+  {
+    // No targetId: the steers editor lives inside Settings (closed by default), so a
+    // coachmark anchor would rarely be mounted — surface via the What's-New drawer
+    // only. 1.27.0 is already released, so this ships in 1.28.0.
+    id: "steers-prompt-slash-commands",
+    sinceVersion: "1.28.0",
+    titleKey: "feat_steers_prompt_editor_title",
+    bodyKey: "feat_steers_prompt_editor_body",
+  },
 ];


### PR DESCRIPTION
## Was

Der Editor der gespeicherten Steers war zu klein: das Prompt-Feld war ein einzeiliges `<input>` — zu schmal, um einen langen Steer zu lesen oder zu bearbeiten, und ohne Slash-Command-Unterstützung.

Diese PR behebt beides (per Screenshot/Feedback gemeldet):

- **Reinklicken → größer.** Das Prompt-Feld ist jetzt eine `<textarea>`, die im Ruhezustand auf eine Zeile kollabiert (kompakte Liste) und beim Fokus auf ihre Inhaltshöhe wächst, sodass der ganze Steer-Text sichtbar und editierbar ist. Die Zeile richtet sich oben aus, damit die Bedienelemente bei mehrzeiligem Feld bündig bleiben.
- **Slash-Commands wie in den anderen Feldern.** Tippen von `/` öffnet denselben `SlashCommandMenu`-Picker wie *Neue Aufgabe* und die *Compose*-Leiste — gespeist aus dem `/api/commands`-Index. Da Steers globale Presets ohne Repo-Bindung sind, werden die User-Scope-Befehle geladen (kein Repo → User-`.claude`-Commands/Skills). Auswahl per Pfeiltasten/Enter/Tab oder Klick; Escape schließt das Menü.

Wiederverwendet die bestehende Slash-Infrastruktur (`$lib/slash`, `SlashCommandMenu.svelte`) statt etwas Neues zu bauen.

## Discovery

Feature-Catalog-Eintrag `steers-prompt-slash-commands` (v1.28.0) + EN/DE-Keys ergänzt.

## Checks

- `bun run check` ✅ (0 Fehler)
- `bun run check:i18n` ✅ (1110 Keys in Parität)
- `bun run test` ✅ (1135 Tests)
- Feature-Catalog-Gate ✅