### PR TITLE
feat(model): per-repo default-model override

### DIFF
--- a/src/default-model.ts
+++ b/src/default-model.ts
@@ -17,6 +17,10 @@ import { MODELS } from "./types";
 
 const SETTING_VALUES = new Set<string>(["auto", "default", ...MODELS]);
 
+// The per-repo override space is the global space plus an "inherit" sentinel,
+// which means "no repo override — fall back to the global default setting".
+const REPO_SETTING_VALUES = new Set<string>(["inherit", ...SETTING_VALUES]);
+
 /**
  * Normalize an arbitrary value (env var, DB row, request body) to a valid
  * SETTING string, or null if the value is unrecognised / wrong type.
@@ -35,4 +39,34 @@ export function normalizeDefaultModelSetting(value: unknown): string | null {
 export function drainSpawnModel(setting: string): string | null {
   if (setting === "auto" || setting === "default") return null;
   return setting;
+}
+
+/**
+ * Normalize a per-repo default-model override to a valid REPO SETTING string,
+ * or null if unrecognised. Accepted: "inherit" plus everything the global
+ * setting accepts ("auto", "default", each MODELS alias). "inherit" (the
+ * default) means the repo defers to the global default.
+ */
+export function normalizeRepoDefaultModelSetting(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return REPO_SETTING_VALUES.has(value) ? value : null;
+}
+
+/**
+ * Resolve the effective default-model SETTING for a repo: the repo override
+ * unless it is "inherit" (or unset/invalid), in which case the global setting
+ * wins. The result is a global-space SETTING string ("auto" | "default" |
+ * <alias>) — pass it through drainSpawnModel to get a spawn flag.
+ */
+export function resolveDefaultModelSetting(
+  repoSetting: string | null | undefined,
+  globalSetting: string,
+): string {
+  if (
+    typeof repoSetting === "string" &&
+    repoSetting !== "inherit" &&
+    SETTING_VALUES.has(repoSetting)
+  )
+    return repoSetting;
+  return globalSetting;
 }

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -22,7 +22,7 @@ import { config } from "./config";
  *  Bounds `gh api` subprocesses so a large (100+-child) epic can't exhaust FDs or
  *  trip GitHub secondary rate limits. */
 const EPIC_BLOCKED_BY_CONCURRENCY = 8;
-import { drainSpawnModel } from "./default-model";
+import { drainSpawnModel, resolveDefaultModelSetting } from "./default-model";
 import { resolveProfile, autoHoldReason, detectBackend } from "./sandbox";
 import { epicBaseDirective } from "./autopilot";
 
@@ -619,14 +619,15 @@ export class DrainService {
     this.approvedNext.delete(repoPath);
     try {
       const { base, prompt } = await this.resolveSpawnBase(forge, decision);
-      // Auto-spawns honor an explicit operator default-model; when unset ("auto")
-      // they fall back to no --model flag (Claude's own default). The Fable promo
-      // is a client-only UI concern and is NEVER applied to autonomous spawns.
+      // Auto-spawns honor an explicit operator default-model — the repo override
+      // wins over the global default; when both are unset ("inherit"/"auto") they
+      // fall back to no --model flag (Claude's own default). The Fable promo is a
+      // client-only UI concern and is NEVER applied to autonomous spawns.
       await this.deps.service.create({
         repoPath,
         baseBranch: base,
         prompt,
-        model: drainSpawnModel(config.defaultModel),
+        model: drainSpawnModel(resolveDefaultModelSetting(rc.defaultModel, config.defaultModel)),
         images: [],
         auto: true,
         issueRef: { number, url, title, body },

--- a/src/server.ts
+++ b/src/server.ts
@@ -81,7 +81,7 @@ import { join, normalize } from "node:path";
 import { homedir } from "node:os";
 import type { ServerWebSocket } from "bun";
 import { markPtyEvent } from "./instrument";
-import { normalizeDefaultModelSetting } from "./default-model";
+import { normalizeDefaultModelSetting, normalizeRepoDefaultModelSetting } from "./default-model";
 import {
   type SandboxProfile,
   SANDBOX_PROFILES,
@@ -389,6 +389,14 @@ function parseSandboxProfile(v: unknown): SandboxProfile | { error: string } {
   return v;
 }
 
+// defaultModel: a per-repo override SETTING ("inherit" | "auto" | "default" | <model alias>)
+function parseRepoDefaultModel(v: unknown): string | { error: string } {
+  const r = normalizeRepoDefaultModelSetting(v);
+  if (r === null)
+    return { error: "defaultModel must be one of: inherit, auto, default, or a model alias" };
+  return r;
+}
+
 // the optional boolean fields of a repo-config patch body
 const REPO_CFG_BOOL_FIELDS = [
   "criticEnabled",
@@ -416,6 +424,7 @@ type RepoCfgBody = {
   draftMode?: unknown;
   signoffAuthority?: unknown;
   sandboxProfile?: unknown;
+  defaultModel?: unknown;
   maxAuto?: unknown;
   autoLabel?: unknown;
   usageCeilingPct?: unknown;
@@ -429,50 +438,38 @@ function hasBadBoolField(body: RepoCfgBody): boolean {
   });
 }
 
-// Validate a repo-config PUT body → a partial patch, or the 400 Response to send.
-// All fields optional but each present one must pass its type check; at least one present.
+type RepoCfgScalars = {
+  maxAuto?: number;
+  autoLabel?: string;
+  usageCeilingPct?: number;
+  signoffAuthority?: "human" | "critic" | "either";
+  sandboxProfile?: SandboxProfile;
+  defaultModel?: string;
+};
+
+// Each non-boolean field paired with its validator. A validator returns the
+// validated value, or a { error } object that becomes a 400 Response.
+const REPO_CFG_SCALAR_PARSERS: readonly [keyof RepoCfgScalars, (v: unknown) => unknown][] = [
+  ["maxAuto", parseMaxAuto],
+  ["autoLabel", parseAutoLabel],
+  ["usageCeilingPct", parseUsageCeiling],
+  ["signoffAuthority", parseSignoffAuthority],
+  ["sandboxProfile", parseSandboxProfile],
+  ["defaultModel", parseRepoDefaultModel],
+];
+
 /** Validate the non-boolean (scalar/enum) repo-config fields, or the 400 Response to
- *  send. Pulled out of parseRepoConfigPatch so each adds no branch to that function. */
-function parseRepoCfgScalars(body: RepoCfgBody):
-  | {
-      maxAuto?: number;
-      autoLabel?: string;
-      usageCeilingPct?: number;
-      signoffAuthority?: "human" | "critic" | "either";
-      sandboxProfile?: SandboxProfile;
-    }
-  | Response {
-  let maxAuto: number | undefined;
-  if (body.maxAuto !== undefined) {
-    const r = parseMaxAuto(body.maxAuto);
-    if (typeof r !== "number") return json(r, 400);
-    maxAuto = r;
+ *  send. Each present field must pass its validator; absent fields are skipped. */
+function parseRepoCfgScalars(body: RepoCfgBody): RepoCfgScalars | Response {
+  const out: Record<string, unknown> = {};
+  for (const [field, parse] of REPO_CFG_SCALAR_PARSERS) {
+    const raw = body[field];
+    if (raw === undefined) continue;
+    const r = parse(raw);
+    if (r !== null && typeof r === "object" && "error" in r) return json(r, 400);
+    out[field] = r;
   }
-  let autoLabel: string | undefined;
-  if (body.autoLabel !== undefined) {
-    const r = parseAutoLabel(body.autoLabel);
-    if (typeof r !== "string") return json(r, 400);
-    autoLabel = r;
-  }
-  let usageCeilingPct: number | undefined;
-  if (body.usageCeilingPct !== undefined) {
-    const r = parseUsageCeiling(body.usageCeilingPct);
-    if (typeof r !== "number") return json(r, 400);
-    usageCeilingPct = r;
-  }
-  let signoffAuthority: "human" | "critic" | "either" | undefined;
-  if (body.signoffAuthority !== undefined) {
-    const r = parseSignoffAuthority(body.signoffAuthority);
-    if (typeof r !== "string") return json(r, 400);
-    signoffAuthority = r;
-  }
-  let sandboxProfile: SandboxProfile | undefined;
-  if (body.sandboxProfile !== undefined) {
-    const r = parseSandboxProfile(body.sandboxProfile);
-    if (typeof r !== "string") return json(r, 400);
-    sandboxProfile = r;
-  }
-  return { maxAuto, autoLabel, usageCeilingPct, signoffAuthority, sandboxProfile };
+  return out as RepoCfgScalars;
 }
 
 async function parseRepoConfigPatch(req: Request): Promise<
@@ -489,6 +486,7 @@ async function parseRepoConfigPatch(req: Request): Promise<
       draftMode?: boolean;
       signoffAuthority?: "human" | "critic" | "either";
       sandboxProfile?: SandboxProfile;
+      defaultModel?: string;
       maxAuto?: number;
       autoLabel?: string;
       usageCeilingPct?: number;
@@ -507,14 +505,16 @@ async function parseRepoConfigPatch(req: Request): Promise<
   }
   const scalars = parseRepoCfgScalars(body);
   if (scalars instanceof Response) return scalars;
-  const { maxAuto, autoLabel, usageCeilingPct, signoffAuthority, sandboxProfile } = scalars;
+  const { maxAuto, autoLabel, usageCeilingPct, signoffAuthority, sandboxProfile, defaultModel } =
+    scalars;
   const present =
     REPO_CFG_BOOL_FIELDS.some((k) => body[k] !== undefined) ||
     maxAuto !== undefined ||
     autoLabel !== undefined ||
     usageCeilingPct !== undefined ||
     signoffAuthority !== undefined ||
-    sandboxProfile !== undefined;
+    sandboxProfile !== undefined ||
+    defaultModel !== undefined;
   if (!present) {
     return json(
       {
@@ -537,34 +537,26 @@ async function parseRepoConfigPatch(req: Request): Promise<
     draftMode: body.draftMode as boolean | undefined,
     signoffAuthority,
     sandboxProfile,
+    defaultModel,
     maxAuto,
     autoLabel,
     usageCeilingPct,
   };
 }
 
-/** Merge a validated patch onto the current repo config, returning the new full config. */
+/** Merge a validated patch onto the current repo config, returning the new full config.
+ *  Patch fields are only ever undefined (absent) or a valid value, so every defined
+ *  field overrides and absent fields keep the current value. */
 function mergeRepoConfig(
   cur: RepoConfig,
   patch: Exclude<Awaited<ReturnType<typeof parseRepoConfigPatch>>, Response>,
 ): RepoConfig {
-  return {
-    criticEnabled: patch.criticEnabled ?? cur.criticEnabled,
-    criticAllPrs: patch.criticAllPrs ?? cur.criticAllPrs,
-    autoAddressEnabled: patch.autoAddressEnabled ?? cur.autoAddressEnabled,
-    learningsEnabled: patch.learningsEnabled ?? cur.learningsEnabled,
-    autopilotEnabled: patch.autopilotEnabled ?? cur.autopilotEnabled,
-    planGateEnabled: patch.planGateEnabled ?? cur.planGateEnabled,
-    autoDrainEnabled: patch.autoDrainEnabled ?? cur.autoDrainEnabled,
-    autoMergeEnabled: patch.autoMergeEnabled ?? cur.autoMergeEnabled,
-    buildQueueEnabled: patch.buildQueueEnabled ?? cur.buildQueueEnabled,
-    draftMode: patch.draftMode ?? cur.draftMode,
-    signoffAuthority: patch.signoffAuthority ?? cur.signoffAuthority,
-    maxAuto: patch.maxAuto ?? cur.maxAuto,
-    autoLabel: patch.autoLabel ?? cur.autoLabel,
-    usageCeilingPct: patch.usageCeilingPct ?? cur.usageCeilingPct,
-    sandboxProfile: patch.sandboxProfile ?? cur.sandboxProfile,
-  };
+  const out: RepoConfig = { ...cur };
+  const writable = out as unknown as Record<string, unknown>;
+  for (const [k, v] of Object.entries(patch)) {
+    if (v !== undefined) writable[k] = v;
+  }
+  return out;
 }
 
 async function handleRepoConfig({ req, parts, url, deps }: Ctx): Promise<Response | null> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -519,7 +519,7 @@ async function parseRepoConfigPatch(req: Request): Promise<
     return json(
       {
         error:
-          "body must set at least one of: criticEnabled, autoAddressEnabled, learningsEnabled, autopilotEnabled, autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, signoffAuthority, sandboxProfile, maxAuto, autoLabel, usageCeilingPct",
+          "body must set at least one of: criticEnabled, autoAddressEnabled, learningsEnabled, autopilotEnabled, autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, signoffAuthority, sandboxProfile, defaultModel, maxAuto, autoLabel, usageCeilingPct",
       },
       400,
     );

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,6 +18,7 @@ import type {
 import type { CapRow, CapStore, WindowKey } from "./usage-limits";
 import { dominantModel, type SessionUsage } from "./usage";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
+import { normalizeRepoDefaultModelSetting } from "./default-model";
 import type { EpicRun } from "./epic-core";
 
 /** Tolerantly parse the persisted findings JSON back to a string[] (never throws). */
@@ -76,6 +77,8 @@ export interface RepoConfig {
   usageCeilingPct: number;
   /** OS-level sandbox membrane for spawned task agents (default "trusted" = unconfined). */
   sandboxProfile: SandboxProfile;
+  /** Per-repo default-model override; "inherit" (default) defers to the global default setting. */
+  defaultModel: string;
 }
 
 export interface PushSubInput {
@@ -318,7 +321,7 @@ export class SessionStore implements CapStore {
       .query(
         `SELECT criticEnabled, criticAllPrs, autoAddressEnabled, learningsEnabled, autopilotEnabled, planGateEnabled,
                 autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, signoffAuthority,
-                maxAuto, autoLabel, usageCeilingPct, sandboxProfile
+                maxAuto, autoLabel, usageCeilingPct, sandboxProfile, defaultModel
          FROM repo_config WHERE repoPath = ?`,
       )
       .get(repoPath) as {
@@ -337,6 +340,7 @@ export class SessionStore implements CapStore {
       autoLabel: string;
       usageCeilingPct: number;
       sandboxProfile: string;
+      defaultModel: string;
     } | null;
     // absent → critic on, learnings on, auto-address off (the spendier loop is explicit opt-in)
     // drain fields default OFF / cap-1 / default-label / ceiling-80
@@ -357,6 +361,7 @@ export class SessionStore implements CapStore {
         autoLabel: "shepherd:auto",
         usageCeilingPct: 80,
         sandboxProfile: "trusted",
+        defaultModel: "inherit",
       };
     }
     return {
@@ -375,6 +380,7 @@ export class SessionStore implements CapStore {
       autoLabel: r.autoLabel,
       usageCeilingPct: r.usageCeilingPct,
       sandboxProfile: isSandboxProfile(r.sandboxProfile) ? r.sandboxProfile : "trusted",
+      defaultModel: normalizeRepoDefaultModelSetting(r.defaultModel) ?? "inherit",
     };
   }
 
@@ -383,8 +389,8 @@ export class SessionStore implements CapStore {
       `INSERT INTO repo_config
          (repoPath, criticEnabled, criticAllPrs, autoAddressEnabled, learningsEnabled, autopilotEnabled, planGateEnabled,
           autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, signoffAuthority,
-          maxAuto, autoLabel, usageCeilingPct, sandboxProfile, updatedAt)
-         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+          maxAuto, autoLabel, usageCeilingPct, sandboxProfile, defaultModel, updatedAt)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(repoPath) DO UPDATE SET criticEnabled = excluded.criticEnabled,
          criticAllPrs = excluded.criticAllPrs,
          autoAddressEnabled = excluded.autoAddressEnabled,
@@ -400,6 +406,7 @@ export class SessionStore implements CapStore {
          autoLabel = excluded.autoLabel,
          usageCeilingPct = excluded.usageCeilingPct,
          sandboxProfile = excluded.sandboxProfile,
+         defaultModel = excluded.defaultModel,
          updatedAt = excluded.updatedAt`,
       [
         repoPath,
@@ -418,6 +425,7 @@ export class SessionStore implements CapStore {
         cfg.autoLabel,
         cfg.usageCeilingPct,
         cfg.sandboxProfile,
+        cfg.defaultModel,
         Date.now(),
       ],
     );
@@ -1159,6 +1167,7 @@ export class SessionStore implements CapStore {
     add("draftMode", `draftMode INTEGER NOT NULL DEFAULT 0`);
     add("signoffAuthority", `signoffAuthority TEXT NOT NULL DEFAULT 'human'`);
     add("sandboxProfile", `sandboxProfile TEXT NOT NULL DEFAULT 'trusted'`);
+    add("defaultModel", `defaultModel TEXT NOT NULL DEFAULT 'inherit'`);
   }
 
   private migrateReviewColumns(): void {

--- a/test/default-model.test.ts
+++ b/test/default-model.test.ts
@@ -1,5 +1,10 @@
 import { test, expect, describe } from "bun:test";
-import { normalizeDefaultModelSetting, drainSpawnModel } from "../src/default-model";
+import {
+  normalizeDefaultModelSetting,
+  normalizeRepoDefaultModelSetting,
+  resolveDefaultModelSetting,
+  drainSpawnModel,
+} from "../src/default-model";
 import { MODELS } from "../src/types";
 
 describe("normalizeDefaultModelSetting", () => {
@@ -65,5 +70,49 @@ describe("drainSpawnModel", () => {
 
   test("'haiku' → 'haiku'", () => {
     expect(drainSpawnModel("haiku")).toBe("haiku");
+  });
+});
+
+describe("normalizeRepoDefaultModelSetting", () => {
+  test("accepts 'inherit'", () => {
+    expect(normalizeRepoDefaultModelSetting("inherit")).toBe("inherit");
+  });
+
+  test("accepts everything the global setting accepts", () => {
+    for (const v of ["auto", "default", ...MODELS]) {
+      expect(normalizeRepoDefaultModelSetting(v)).toBe(v);
+    }
+  });
+
+  test("returns null for unknown / wrong type", () => {
+    expect(normalizeRepoDefaultModelSetting("gpt4")).toBeNull();
+    expect(normalizeRepoDefaultModelSetting("")).toBeNull();
+    expect(normalizeRepoDefaultModelSetting(null)).toBeNull();
+    expect(normalizeRepoDefaultModelSetting(123)).toBeNull();
+  });
+});
+
+describe("resolveDefaultModelSetting", () => {
+  test("'inherit' defers to the global setting", () => {
+    expect(resolveDefaultModelSetting("inherit", "opus")).toBe("opus");
+    expect(resolveDefaultModelSetting("inherit", "auto")).toBe("auto");
+  });
+
+  test("unset / invalid repo override defers to the global setting", () => {
+    expect(resolveDefaultModelSetting(null, "sonnet")).toBe("sonnet");
+    expect(resolveDefaultModelSetting(undefined, "sonnet")).toBe("sonnet");
+    expect(resolveDefaultModelSetting("gpt4", "sonnet")).toBe("sonnet");
+  });
+
+  test("an explicit repo override wins over the global setting", () => {
+    expect(resolveDefaultModelSetting("haiku", "opus")).toBe("haiku");
+    expect(resolveDefaultModelSetting("default", "opus")).toBe("default");
+    expect(resolveDefaultModelSetting("auto", "opus")).toBe("auto");
+  });
+
+  test("composed with drainSpawnModel: repo override drives the spawn flag", () => {
+    expect(drainSpawnModel(resolveDefaultModelSetting("haiku", "auto"))).toBe("haiku");
+    expect(drainSpawnModel(resolveDefaultModelSetting("inherit", "opus"))).toBe("opus");
+    expect(drainSpawnModel(resolveDefaultModelSetting("inherit", "auto"))).toBeNull();
   });
 });

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -196,6 +196,7 @@ test("consider does nothing when learnings disabled for the repo", () => {
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   const { deps, started } = mkDeps(store, { rules: [] });
   const d = new DistillerService(deps as any);
@@ -230,6 +231,7 @@ test("distiller increments ineffective for cited active rule ids with validated 
         autoLabel: "shepherd:auto",
         usageCeilingPct: 80,
         sandboxProfile: "trusted",
+        defaultModel: "inherit",
       }),
       incrementLearningIneffective: (id: string, signals: string[]) => {
         bumped.push({ id, signals });

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -91,6 +91,7 @@ function makeHarness(
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   if (opts.epicStatus) {
     store.setEpicRun({

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -117,6 +117,7 @@ function makeHarness(
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
 
   const forgeRec: ForgeRec = { listIssuesCalls: 0, added: [], ensured: [] };

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -163,6 +163,7 @@ function makeHarness(
     autoLabel: "shepherd:auto",
     usageCeilingPct: opts.usageCeilingPct ?? 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
 
   const forgeRec: ForgeRec = {
@@ -676,6 +677,7 @@ test("tick + snapshot over repos: only drain-enabled repo is acted on and report
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   store.setRepoConfig(REPO2, {
     criticEnabled: true,
@@ -693,6 +695,7 @@ test("tick + snapshot over repos: only drain-enabled repo is acted on and report
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
 
   const forgeRec: ForgeRec = {

--- a/test/sandbox-wiring.test.ts
+++ b/test/sandbox-wiring.test.ts
@@ -280,6 +280,7 @@ function defaultRepoConfig() {
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted" as const,
+    defaultModel: "inherit",
   };
 }
 

--- a/test/server-reviews.test.ts
+++ b/test/server-reviews.test.ts
@@ -105,6 +105,7 @@ test("GET /api/repo-config defaults to critic on + auto-address off", async () =
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
 });
 
@@ -152,6 +153,7 @@ test("PUT /api/repo-config sets criticEnabled=false, GET reflects it", async () 
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
 
   const get = await app.fetch(new Request(url));
@@ -172,6 +174,7 @@ test("PUT /api/repo-config sets criticEnabled=false, GET reflects it", async () 
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
 });
 
@@ -202,6 +205,7 @@ test("PUT /api/repo-config toggles autoAddressEnabled independently of criticEna
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
 });
 
@@ -232,6 +236,7 @@ test("PUT /api/repo-config sets learningsEnabled independently of criticEnabled"
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
 });
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1153,6 +1153,7 @@ test("GET /api/learnings/injectable marks all rules uninjected when learnings di
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
 
   const res = await app.fetch(new Request("http://x/api/learnings/injectable"));
@@ -1628,6 +1629,34 @@ test("PUT /api/repo-config omitting sandboxProfile preserves existing value", as
   // PUT without sandboxProfile — should preserve autonomous
   await putRepoConfig(app, validRepo, { criticEnabled: true });
   expect(deps.store.getRepoConfig(validRepo).sandboxProfile).toBe("autonomous");
+});
+
+// ── defaultModel repo-config override ──────────────────────────────────────────
+
+test("PUT /api/repo-config accepts defaultModel override → 200 and GET reflects it", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  expect(deps.store.getRepoConfig(validRepo).defaultModel).toBe("inherit");
+  const res = await putRepoConfig(app, validRepo, { defaultModel: "opus" });
+  expect(res.status).toBe(200);
+  expect(deps.store.getRepoConfig(validRepo).defaultModel).toBe("opus");
+});
+
+test("PUT /api/repo-config rejects unknown defaultModel → 400 with error message", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const res = await putRepoConfig(app, validRepo, { defaultModel: "gpt4" });
+  expect(res.status).toBe(400);
+  const body = await res.json();
+  expect(body.error).toContain("defaultModel");
+});
+
+test("PUT /api/repo-config omitting defaultModel preserves existing override", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  await putRepoConfig(app, validRepo, { defaultModel: "haiku" });
+  await putRepoConfig(app, validRepo, { criticEnabled: true });
+  expect(deps.store.getRepoConfig(validRepo).defaultModel).toBe("haiku");
 });
 
 test("PUT /api/sessions/:id/automerge sets the override", async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1678,6 +1678,7 @@ test("create omits house rules when learnings disabled for the repo", async () =
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   const captured: { argv?: string[] } = {};
   const svc = new SessionService(injectDeps(store, captured) as any);
@@ -1719,6 +1720,7 @@ test("create seeds the autopilot directive when the repo has autopilot on", asyn
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   const captured: { argv?: string[] } = {};
   const svc = new SessionService(injectDeps(store, captured) as any);
@@ -2282,6 +2284,7 @@ function buildQueueDeps(
       autoLabel: "shepherd:auto",
       usageCeilingPct: 80,
       sandboxProfile: "trusted",
+      defaultModel: "inherit",
       ...repoConfig,
     });
   }

--- a/test/store-autopilot.test.ts
+++ b/test/store-autopilot.test.ts
@@ -88,6 +88,7 @@ test("repo config autopilotEnabled defaults off and round-trips", () => {
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   expect(store.getRepoConfig("/repo").autopilotEnabled).toBe(true);
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -74,6 +74,7 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   store.setRepoConfig("/repo/a", {
     criticEnabled: false,
@@ -91,6 +92,7 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   expect(store.getRepoConfig("/repo/a")).toEqual({
     criticEnabled: false,
@@ -108,6 +110,7 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   store.setRepoConfig("/repo/a", {
     criticEnabled: true,
@@ -125,6 +128,7 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   expect(store.getRepoConfig("/repo/a")).toEqual({
     criticEnabled: true,
@@ -142,6 +146,7 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
 });
 
@@ -153,6 +158,7 @@ test("repo_config: drain fields default off/cap-1/default-label/ceiling-80, pers
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   store.setRepoConfig("/repo/d", {
     criticEnabled: true,
@@ -170,6 +176,7 @@ test("repo_config: drain fields default off/cap-1/default-label/ceiling-80, pers
     autoLabel: "auto-go",
     usageCeilingPct: 65,
     sandboxProfile: "trusted",
+    defaultModel: "inherit",
   });
   expect(store.getRepoConfig("/repo/d")).toMatchObject({
     autoDrainEnabled: true,
@@ -177,6 +184,17 @@ test("repo_config: drain fields default off/cap-1/default-label/ceiling-80, pers
     autoLabel: "auto-go",
     usageCeilingPct: 65,
   });
+});
+
+test("repo_config: defaultModel defaults to 'inherit', persists an explicit override round-trip", () => {
+  const store = new SessionStore(":memory:");
+  expect(store.getRepoConfig("/repo/m").defaultModel).toBe("inherit");
+  const cfg = store.getRepoConfig("/repo/m");
+  store.setRepoConfig("/repo/m", { ...cfg, defaultModel: "opus" });
+  expect(store.getRepoConfig("/repo/m").defaultModel).toBe("opus");
+  // an unrecognised stored value normalises back to "inherit" on read
+  store.setRepoConfig("/repo/m", { ...cfg, defaultModel: "bogus" });
+  expect(store.getRepoConfig("/repo/m").defaultModel).toBe("inherit");
 });
 
 test("create: auto + issueNumber default false/null, persist when set, survive hydrate", () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1110,5 +1110,10 @@
   "feat_critic_all_prs_body": "Aktiviere „Alle PRs prüfen“ im Automatisierungs-Panel eines Repos, damit der Critic jeden CI-grünen Pull Request bewertet – nicht nur solche, die einer Shepherd-Sitzung zugeordnet sind. Pro Repo opt-in; beachte den höheren Token-Verbrauch bei vielen offenen PRs.",
   "automation_sandbox_profile_summary": "Optionale Abschottung für Agenten.",
   "feat_steers_prompt_editor_title": "Größerer Steer-Editor mit Slash-Befehlen",
-  "feat_steers_prompt_editor_body": "In den gespeicherten Steers vergrößert sich ein Prompt-Feld jetzt beim Reinklicken, sodass der ganze Text sichtbar ist, und mit „/“ erscheint dieselbe Slash-Befehl-Auswahl wie in den Feldern für Neue Aufgabe und Verfassen – Befehl per Pfeiltasten oder Tipp auswählen."
+  "feat_steers_prompt_editor_body": "In den gespeicherten Steers vergrößert sich ein Prompt-Feld jetzt beim Reinklicken, sodass der ganze Text sichtbar ist, und mit „/“ erscheint dieselbe Slash-Befehl-Auswahl wie in den Feldern für Neue Aufgabe und Verfassen – Befehl per Pfeiltasten oder Tipp auswählen.",
+  "automation_default_model_label": "Standardmodell",
+  "automation_default_model_inherit": "Erben (globaler Standard)",
+  "automation_default_model_hint": "Überschreibt das globale Standardmodell (Einstellungen → Sitzung) für dieses Repository. Erben übernimmt die globale Einstellung; eine explizite Wahl wählt den Modell-Picker bei neuen Aufgaben vor und steuert autonome Drain-/Autopilot-Starts in diesem Repository.",
+  "feat_repo_default_model_title": "Standardmodell pro Repository",
+  "feat_repo_default_model_body": "Lege im Automatisierungs-Panel eines Repositorys ein Standardmodell fest — es überschreibt den globalen Standard und wählt den Modell-Picker bei neuen Aufgaben vor. Auf Erben belassen, um weiter der globalen Einstellung zu folgen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1110,5 +1110,10 @@
   "feat_critic_all_prs_body": "Enable \"Review all PRs\" in a repo's automation panel and the Critic will review every CI-green pull request — not just ones tied to a Shepherd session. Opt-in per repo; note the higher token cost for busy repos.",
   "automation_sandbox_profile_summary": "Opt-in confinement for agents.",
   "feat_steers_prompt_editor_title": "Roomier steer editor with slash commands",
-  "feat_steers_prompt_editor_body": "In Saved Steers, clicking into a prompt field now expands it to show the whole text, and typing \"/\" offers the same slash-command picker as the New Task and compose fields — pick a command with the arrow keys or a tap."
+  "feat_steers_prompt_editor_body": "In Saved Steers, clicking into a prompt field now expands it to show the whole text, and typing \"/\" offers the same slash-command picker as the New Task and compose fields — pick a command with the arrow keys or a tap.",
+  "automation_default_model_label": "Default model",
+  "automation_default_model_inherit": "Inherit (global default)",
+  "automation_default_model_hint": "Overrides the global default model (Settings → Session) for this repo. Inherit defers to the global setting; an explicit choice preselects the New Task picker and drives autonomous drain/autopilot spawns in this repo.",
+  "feat_repo_default_model_title": "Per-repo default model",
+  "feat_repo_default_model_body": "Set a default model per repository in its automation panel — it overrides the global default and preselects the New Task picker. Leave it on Inherit to keep following the global setting."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -826,6 +826,7 @@ export async function putRepoConfig(
       | "planGateEnabled"
       | "signoffAuthority"
       | "sandboxProfile"
+      | "defaultModel"
       | "maxAuto"
       | "autoLabel"
       | "usageCeilingPct"

--- a/ui/src/lib/components/AutomationPanel.svelte
+++ b/ui/src/lib/components/AutomationPanel.svelte
@@ -5,6 +5,7 @@
   import { clampCap, clampCeiling, sanitizeLabel } from "./git-rail-drain";
   import { getRepoRoles, getRepoCollaborators, putRepoRoles } from "$lib/api";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import { MODELS } from "$lib/types";
   import type { Session, RepoRoles, SandboxProfile, DrainStatus } from "$lib/types";
 
   let {
@@ -527,6 +528,30 @@
       <p>{m.automation_sandbox_profile_hint()}</p>
       <p>{m.automation_sandbox_profile_caveats()}</p>
     </div>
+  </div>
+
+  <!-- Default model: a repo-wide override of the global default (Settings → Session).
+       "Inherit" defers to the global setting; an explicit choice wins for both the
+       New-Task picker preselect and autonomous drain/autopilot spawns in this repo. -->
+  <div class="drain-fields">
+    <label class="drain-field">
+      <span class="drain-label">{m.automation_default_model_label()}</span>
+      <select
+        class="num model-select"
+        aria-label={m.automation_default_model_label()}
+        value={repoConfig.defaultModelFor(repoPath)}
+        onchange={(e) =>
+          repoConfig.setDefaultModel(repoPath, (e.currentTarget as HTMLSelectElement).value)}
+      >
+        <option value="inherit">{m.automation_default_model_inherit()}</option>
+        <option value="auto">{m.settings_default_model_auto()}</option>
+        <option value="default">{m.newtask_model_default()}</option>
+        {#each MODELS as mdl (mdl)}
+          <option value={mdl}>{mdl}</option>
+        {/each}
+      </select>
+    </label>
+    <div class="signoff-note">{m.automation_default_model_hint()}</div>
   </div>
   {#if flags.autoDrain}
     <div class="drain-fields">

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -46,6 +46,7 @@ function repoConfig(planGateEnabled: boolean): RepoConfig {
     maxAuto: 1,
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
+    defaultModel: "inherit",
   };
 }
 

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -87,14 +87,17 @@
   // svelte-ignore state_referenced_locally
   let seededBase = $state(initialBaseBranch != null);
   // Picker preselect precedence: explicit initialModel (e.g. the "Try Fable" CTA) wins;
-  // else the operator's configured default if it's an explicit model; else the fresh
-  // client promo (configured "auto", or settings not yet loaded). Resolved at mount,
-  // and NewTask remounts per open, so the promo cutoff is honored fresh each open.
+  // else the selected repo's default-model override; else the operator's global default
+  // if it's an explicit model; else the fresh client promo (configured "auto", or
+  // settings not yet loaded). NewTask remounts per open, so the promo cutoff is honored
+  // fresh each open. `modelTouched` pins a manual pick so switching repos / a late repo
+  // config load doesn't clobber it.
   function preselectModel(configured: string | undefined): string {
     return configured && configured !== "auto" ? configured : promoDefaultModel();
   }
   // svelte-ignore state_referenced_locally
   let model = $state(initialModel ?? preselectModel(defaultModel));
+  let modelTouched = $state(false);
   // Relaunch reuses this composer with a distinct title + note set.
   const heading = $derived(relaunch ? m.newtask_relaunch_title() : m.newtask_title());
   // Plan gate: defaults to the selected repo's stored flag until the user toggles
@@ -207,6 +210,17 @@
   $effect(() => {
     // mirror the repo default until the user makes a manual choice
     if (!planGateTouched) planGate = planGateDefault;
+  });
+
+  // Effective default model = repo override (if not "inherit") → global default → promo.
+  // Re-seeds the picker when the repo config loads / the repo changes, unless an explicit
+  // initialModel (CTA) pinned it or the user already picked a model by hand.
+  const repoModelOverride = $derived(repoPath ? repoConfig.defaultModelFor(repoPath) : "inherit");
+  const effectiveModelSetting = $derived(
+    repoModelOverride !== "inherit" ? repoModelOverride : (defaultModel ?? "auto"),
+  );
+  $effect(() => {
+    if (initialModel == null && !modelTouched) model = preselectModel(effectiveModelSetting);
   });
 
   // (re)load the slash-command list when the target repo changes — a repo's own
@@ -593,7 +607,7 @@
       <div class="run-config">
         <div class="model-field">
           <label class="micro" for="nt-model">{m.newtask_model_label()}</label>
-          <select id="nt-model" bind:value={model}>
+          <select id="nt-model" bind:value={model} onchange={() => (modelTouched = true)}>
             <option value="default">{m.newtask_model_default()}</option>
             {#each MODELS as mdl (mdl)}
               <option value={mdl}>{mdl}</option>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -673,4 +673,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_steers_prompt_editor_title",
     bodyKey: "feat_steers_prompt_editor_body",
   },
+  {
+    // No targetId: the picker lives inside the AutomationPanel popover (closed by
+    // default), so a coachmark anchor would rarely be mounted — surface via the
+    // What's-New drawer only. 1.27.0 is already released, so this ships in 1.28.0.
+    id: "repo-default-model",
+    sinceVersion: "1.28.0",
+    titleKey: "feat_repo_default_model_title",
+    bodyKey: "feat_repo_default_model_body",
+  },
 ];

--- a/ui/src/lib/reviews.svelte.test.ts
+++ b/ui/src/lib/reviews.svelte.test.ts
@@ -25,6 +25,7 @@ const rc = (overrides: Partial<RepoConfig> = {}): RepoConfig => ({
   draftMode: false,
   signoffAuthority: "human",
   sandboxProfile: "trusted",
+  defaultModel: "inherit",
   maxAuto: 1,
   autoLabel: "shepherd:auto",
   usageCeilingPct: 80,

--- a/ui/src/lib/reviews.svelte.ts
+++ b/ui/src/lib/reviews.svelte.ts
@@ -165,6 +165,7 @@ class RepoConfigStore {
   draftMode = $state<Record<string, boolean>>({}); // open PRs as drafts (default off; mutually exclusive with autoMerge)
   signoffAuthority = $state<Record<string, "human" | "critic" | "either">>({}); // who may promote draft PRs (default "human")
   sandboxProfile = $state<Record<string, SandboxProfile>>({}); // per-repo sandbox confinement (default "trusted")
+  defaultModel = $state<Record<string, string>>({}); // per-repo default-model override (default "inherit")
   maxAuto = $state<Record<string, number>>({}); // max concurrent auto sessions (default 1)
   autoLabel = $state<Record<string, string>>({}); // label used to pick drain issues (default "shepherd:auto")
   usageCeiling = $state<Record<string, number>>({}); // usage % ceiling before pausing drain (default 80)
@@ -187,6 +188,7 @@ class RepoConfigStore {
     this.draftMode = { ...this.draftMode, [repoPath]: c.draftMode };
     this.signoffAuthority = { ...this.signoffAuthority, [repoPath]: c.signoffAuthority };
     this.sandboxProfile = { ...this.sandboxProfile, [repoPath]: c.sandboxProfile };
+    this.defaultModel = { ...this.defaultModel, [repoPath]: c.defaultModel };
     this.maxAuto = { ...this.maxAuto, [repoPath]: c.maxAuto };
     this.autoLabel = { ...this.autoLabel, [repoPath]: c.autoLabel };
     this.usageCeiling = { ...this.usageCeiling, [repoPath]: c.usageCeilingPct };
@@ -240,6 +242,7 @@ class RepoConfigStore {
         | "draftMode"
         | "signoffAuthority"
         | "sandboxProfile"
+        | "defaultModel"
         | "maxAuto"
         | "autoLabel"
         | "usageCeilingPct"
@@ -358,6 +361,14 @@ class RepoConfigStore {
     });
   }
 
+  async setDefaultModel(repoPath: string, value: string) {
+    const prev = this.defaultModel[repoPath];
+    this.defaultModel = { ...this.defaultModel, [repoPath]: value }; // optimistic
+    await this.apply(repoPath, { defaultModel: value }, () => {
+      this.defaultModel = { ...this.defaultModel, [repoPath]: prev };
+    });
+  }
+
   async toggleBuildQueue(repoPath: string) {
     const prev = this.buildQueue[repoPath];
     const next = !this.isBuildQueueEnabled(repoPath);
@@ -446,6 +457,11 @@ class RepoConfigStore {
 
   sandboxProfileFor(repoPath: string): SandboxProfile {
     return this.sandboxProfile[repoPath] ?? "trusted";
+  }
+
+  /** The repo's default-model override SETTING ("inherit" | "auto" | "default" | <model>). */
+  defaultModelFor(repoPath: string): string {
+    return this.defaultModel[repoPath] ?? "inherit";
   }
 
   /** All automation on/off flags for a repo, in one read — shared by the pill's

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -259,6 +259,8 @@ export interface RepoConfig {
   signoffAuthority: "human" | "critic" | "either";
   /** Per-repo sandbox confinement profile (default "trusted" = no sandbox). */
   sandboxProfile: SandboxProfile;
+  /** Per-repo default-model override; "inherit" (default) defers to the global default. */
+  defaultModel: string;
   maxAuto: number;
   autoLabel: string;
   usageCeilingPct: number;


### PR DESCRIPTION
## Was & Warum

Das **globale** Standardmodell (Einstellungen → Sitzung) bestimmt das Modell für neue Aufgaben und autonome Drain-/Autopilot-Starts — ließ sich aber **nicht pro Repository überschreiben**. Genau diese Lücke war im New-Task-Dialog spürbar: der `Standard`-Eintrag im Modell-Picker war nicht pro Repo steuerbar.

Dieser PR ergänzt einen **Per-Repo-Override** im Automatisierungs-Panel des Repos — gespiegelt am bestehenden Sandbox-Profil-Muster.

## Auflösungsreihenfolge

`Repo-Override → globaler Standard → Promo / Claudes Default`

- `RepoConfig.defaultModel`: `"inherit"` (Default) | `"auto"` | `"default"` | `<modell>`. `inherit` übernimmt die globale Einstellung.
- `resolveDefaultModelSetting(repoOverride, globalSetting)` faltet den Override über den globalen Default.
- **Autonome Starts** (Drain/Autopilot): Auflösung beim Spawn in `drain.ts`.
- **Interaktiv** (New-Task-Picker): Vorauswahl aus dem effektiven Default; eine manuelle Auswahl pinnt sich (`modelTouched`) und überschreibt nicht beim Repo-Wechsel.

## Änderungen

- **Server:** `default-model.ts` (Normalisierung + Resolver), `store.ts` (Spalte + Migration `defaultModel TEXT DEFAULT 'inherit'`), `server.ts` (Validierung + Merge), `drain.ts` (Spawn-Auflösung).
- **UI:** Picker im `AutomationPanel`, effektive Vorauswahl in `NewTask`, Store-Verdrahtung in `reviews.svelte.ts`, Typen + API.
- **i18n:** EN + DE Keys. **Feature-Katalog:** ein Eintrag (`repo-default-model`).
- **Tests:** Unit (Resolver/Normalisierung), Store-Round-Trip, API-Patch (200/400/Erhalt). Bestehende Repo-Config-Fixtures um `defaultModel` ergänzt.

Nebenbei: `mergeRepoConfig` und `parseRepoCfgScalars` tabellen-/schleifengetrieben refaktoriert (entfernt Wiederholung, hält den Komplexitäts-Gate grün).

## Hinweis

Die **globale** Einstellung existiert bereits (Einstellungen → Sitzung) und bleibt unverändert — dieser PR liefert nur den fehlenden Per-Repo-Override.