### PR TITLE
feat(usage): surface paid extra-credit overage (gauge, alert, drain guard, push)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -264,6 +264,13 @@ export const config = {
   // value applies to both the New Task picker and drain/autopilot auto-spawns. Env seeds
   // a fresh DB; absent/invalid → "auto".
   defaultModel: normalizeDefaultModelSetting(process.env.SHEPHERD_DEFAULT_MODEL) ?? "auto",
+  // Account-wide extra-credit (paid pay-as-you-go overage) spend ceiling, in account
+  // currency units. Auto-drain/autopilot pauses when measured spend strictly exceeds it.
+  // Persisted + UI-configurable; env seeds a fresh DB. Default 0 = pause on ANY spend.
+  extraCreditsDrainCeiling: Math.max(
+    0,
+    Number(process.env.SHEPHERD_EXTRA_CREDITS_DRAIN_CEILING ?? 0) || 0,
+  ),
   // Max consecutive auto-rebase attempts the merge train spends on a PR before pausing for the operator.
   autoMergeRebaseCap: Number(process.env.SHEPHERD_AUTOMERGE_REBASE_CAP ?? 5),
   // git host (forge) integration: per-host {type,baseUrl,token,deployWorkflow,mergeMethod}

--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -29,6 +29,7 @@ export interface HoldReason {
     | "disabled" // per-repo toggle off
     | "cap" // maxAuto auto-agents already running
     | "usage" // usage % at/over the repo's ceiling
+    | "credits" // extra-credit (paid overage) spend over the account ceiling
     | "blocked" // an auto-agent is blocked (trouble pause)
     | "changes_requested" // an auto-agent's critic is blocking (trouble pause)
     | "error" // an auto-agent's critic verdict is an error (don't advance on uncertainty)
@@ -82,6 +83,10 @@ export interface DrainRepoState {
   usageCeilingPct: number;
   /** The worse of the 5h / weekly usage windows, 0–100. */
   usagePct: number;
+  /** Paid extra-credit spend this monthly window (account-wide), 0 when none/stale/unknown. */
+  creditSpent: number;
+  /** Account-wide ceiling (account currency units); spend strictly above it pauses the drain. */
+  creditSpendCeiling: number;
   /** Non-archived auto sessions for this repo (sessions mid-merge carry git: null). */
   autoSessions: AutoSessionView[];
   /** Issue numbers already mapped to a non-archived session (auto OR manual). */
@@ -210,6 +215,11 @@ export function computeNext(state: DrainRepoState): DrainDecision {
   // 4. Usage ceiling.
   if (state.usagePct >= state.usageCeilingPct) {
     return { kind: "hold", reason: { code: "usage", detail: String(state.usagePct) } };
+  }
+
+  // Extra-credit cost guard: never keep spending real pay-as-you-go money unattended.
+  if (state.creditSpent > state.creditSpendCeiling) {
+    return { kind: "hold", reason: { code: "credits", detail: String(state.creditSpent) } };
   }
 
   // 5. Next un-mapped candidate.

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -287,6 +287,10 @@ export class DrainService {
         maxAuto: cfg.maxAuto,
         usageCeilingPct: cfg.usageCeilingPct,
         usagePct,
+        // Extra-credit cost guard: paid overage spent this window (0 when credits is
+        // null/stale/post-reset — fail-safe), against the account-wide live ceiling.
+        creditSpent: limits.credits && !limits.credits.stale ? limits.credits.spent : 0,
+        creditSpendCeiling: config.extraCreditsDrainCeiling,
         autoSessions,
         mappedIssueNumbers,
         candidates,
@@ -324,7 +328,8 @@ export class DrainService {
     const hold = decision.kind === "hold" ? decision.reason : null;
     // cap is conveyed by inFlight/max, empty is normal idle — neither pauses.
     const paused =
-      hold !== null && ["blocked", "changes_requested", "error", "usage"].includes(hold.code);
+      hold !== null &&
+      ["blocked", "changes_requested", "error", "usage", "credits"].includes(hold.code);
     const queued = state.candidates.filter((c) => !state.mappedIssueNumbers.has(c.number)).length;
     return {
       repoPath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import { reapOrphanTabs } from "./tab-reaper";
 import { serve, buildBacklogPayload } from "./server";
 import { detectForge } from "./forge";
 import { AccountUsageIndex } from "./usage";
-import { UsageLimitsService } from "./usage-limits";
+import { UsageLimitsService, calibrateDelay, type UsageLimits } from "./usage-limits";
 import { HerdrUsageProbe } from "./usage-probe";
 import { sweepStaging, STAGING_TTL_MS } from "./uploads";
 import { validateRoot } from "./dirs";
@@ -43,6 +43,7 @@ import {
   attachGitPush,
   attachMergePush,
   attachUsagePush,
+  attachCreditsPush,
 } from "./push";
 import { Presence } from "./presence";
 import { ReviewService } from "./review";
@@ -128,6 +129,14 @@ if (savedDm !== null) {
   if (v !== null) config.defaultModel = v;
 }
 
+// A UI-set extra-credit drain ceiling (persisted) overrides the env seed; a missing
+// or invalid row keeps the seeded default. Parsed to a non-negative number.
+const savedEcc = store.getSetting("extra_credits_drain_ceiling");
+if (savedEcc !== null) {
+  const n = Number(savedEcc);
+  if (Number.isFinite(n) && n >= 0) config.extraCreditsDrainCeiling = n;
+}
+
 // ── preview port range startup validation (hard-fail) ──────────────────────
 // Discover the public served port by parsing `tailscale serve status`; default
 // to 443 when tailscale is unavailable or the mapping isn't found. The parser
@@ -186,7 +195,7 @@ const service = new SessionService({
 });
 
 const accountIndex = new AccountUsageIndex();
-const usageLimits = new UsageLimitsService(accountIndex, store, new HerdrUsageProbe(herdr));
+const usageLimits = new UsageLimitsService(accountIndex, store, new HerdrUsageProbe(herdr), store);
 
 reconcile(store, herdr);
 
@@ -752,24 +761,44 @@ setInterval(runDailySweep, 24 * 60 * 60 * 1000);
 
 // recompute live limit % from local JSONL ~every 30s; push to clients
 attachUsagePush(events, store, push);
+attachCreditsPush(events, store, push);
 setInterval(async () => {
   await accountIndex.refresh(Date.now());
   events.emit("usage:limits", usageLimits.limits(Date.now()));
 }, 30_000);
 
-// calibrate the per-window caps daily (and once on startup) by scraping `/usage`
-const calibrate = async () => {
-  if (maintenance.active) return;
+// calibrate the per-window caps daily (and once on startup) by scraping `/usage`.
+// The `/usage` probe is a single ephemeral agent — a manual refresh and a scheduled
+// calibrate racing each other would double-spawn it and conflict, so guard with a flag.
+let calibrating = false;
+const calibrate = async (): Promise<UsageLimits> => {
+  if (maintenance.active || calibrating) return usageLimits.limits(Date.now());
   try {
+    calibrating = true;
     await accountIndex.refresh(Date.now());
     const ok = await usageLimits.calibrate(Date.now());
     if (ok) events.emit("usage:limits", usageLimits.limits(Date.now()));
   } catch (err) {
     console.warn("[usage] calibration failed:", err);
+  } finally {
+    calibrating = false;
   }
+  return usageLimits.limits(Date.now());
 };
 setTimeout(calibrate, 3_000);
-setInterval(calibrate, 24 * 60 * 60 * 1000);
+// self-rescheduling so the cadence escalates while the weekly window nears its cap (keeping
+// paid extra-credit spend fresh) and relaxes back to daily once it's clear of the cap.
+const scheduleCalibrate = () => {
+  setTimeout(
+    async () => {
+      await calibrate();
+      scheduleCalibrate();
+    },
+    calibrateDelay(usageLimits.limits(Date.now())),
+  );
+};
+scheduleCalibrate();
+const refreshUsage = () => calibrate();
 
 // watch origin/main for new commits and push the result to clients; the badge in
 // the UI keys off `behind > 0`, so it only appears when main has moved ahead.
@@ -848,6 +877,7 @@ const server = serve(
     service,
     events,
     usageLimits,
+    refreshUsage,
     updates,
     herdrUpdates,
     starPrompt,

--- a/src/push.ts
+++ b/src/push.ts
@@ -18,7 +18,8 @@ export interface PushPayload {
     | "autopilot"
     | "autopilot-done"
     | "merge_attention"
-    | "usage_limit";
+    | "usage_limit"
+    | "extra_credits";
   tag: string;
 }
 
@@ -36,6 +37,7 @@ const KIND_CATEGORY: Record<PushPayload["kind"], PushCategory> = {
   ci: "ci",
   merge_attention: "ci",
   usage_limit: "agent",
+  extra_credits: "agent",
 };
 
 /** A notification described by intent, not text — localized per device at send time. */
@@ -49,7 +51,8 @@ export interface NotifyInput {
     | "autopilot"
     | "autopilot-done"
     | "merge_attention"
-    | "usage_limit";
+    | "usage_limit"
+    | "extra_credits";
   sessionId: string;
   tag: string;
   name: string;
@@ -70,6 +73,12 @@ export interface NotifyInput {
   pct?: number;
   /** For kind "usage_limit": epoch ms when the window resets. */
   resetAt?: number;
+  /** For kind "extra_credits": paid extra-credit overage spent this window. */
+  creditSpent?: number;
+  /** For kind "extra_credits": the extra-credit cap for this window. */
+  creditCap?: number;
+  /** For kind "extra_credits": currency symbol/prefix for the amounts. */
+  currency?: string;
   /** Overrides the cooldown key (default `${kind}:${sessionId}`). */
   cooldownKey?: string;
 }
@@ -116,6 +125,8 @@ const NOTIFY_TEXT = {
     usageLimitTitle: (pct: number) => `5-hour limit at ${pct}%`,
     usageLimitBody: (time: string | null) =>
       time ? `Approaching the usage cap — resets at ${time}.` : "Approaching the usage cap.",
+    extraCreditsTitle: "Extra credits in use",
+    extraCreditsBody: (amount: string) => `Now spending paid extra usage — ${amount} this period.`,
   },
   de: {
     doneTitle: (name: string) => `${name} — wartet`,
@@ -147,6 +158,9 @@ const NOTIFY_TEXT = {
     usageLimitTitle: (pct: number) => `5-Stunden-Limit bei ${pct} %`,
     usageLimitBody: (time: string | null) =>
       time ? `Limit fast erreicht — Reset um ${time}.` : "Limit fast erreicht.",
+    extraCreditsTitle: "Zusatzguthaben aktiv",
+    extraCreditsBody: (amount: string) =>
+      `Kostenpflichtige Zusatznutzung läuft — ${amount} in diesem Zeitraum.`,
   },
 } as const;
 
@@ -185,6 +199,27 @@ export function blockSummary(reason: BlockReason, locale: string = "en"): string
   }
 }
 
+/** Autopilot body: the agent's summary when present, else the locale fallback line. */
+function autopilotBody(summary: string | undefined, fallback: string): string {
+  return summary && summary.trim() ? summary : fallback;
+}
+
+/** Merge-attention title/body: rebase-cap copy when capped, else the generic merge-error copy. */
+function mergeAttentionParts(t: NotifyText, input: NotifyInput): { title: string; body: string } {
+  const desig = input.desig ?? input.name;
+  if (input.mergeState === "rebase_cap") {
+    return { title: t.rebaseCapTitle, body: t.rebaseCapBody(desig) };
+  }
+  return { title: t.mergeErrorTitle, body: t.mergeErrorBody(desig) };
+}
+
+/** Extra-credits body: the spent/cap amount formatted with the optional currency prefix. */
+function extraCreditsBody(t: NotifyText, input: NotifyInput): string {
+  const cur = input.currency ?? "";
+  const amount = `${cur}${(input.creditSpent ?? 0).toFixed(2)} / ${cur}${(input.creditCap ?? 0).toFixed(2)}`;
+  return t.extraCreditsBody(amount);
+}
+
 /** Locale-formatted clock time of a window reset, or null without an anchor. */
 function resetTimeLabel(resetAt: number | undefined, locale: NotifyLocale): string | null {
   if (resetAt === undefined) return null;
@@ -219,27 +254,24 @@ export function buildPayload(input: NotifyInput, locale: string): PushPayload {
       return {
         ...base,
         title: t.autopilotTitle(input.name),
-        body: input.summary && input.summary.trim() ? input.summary : t.autopilotFallback,
+        body: autopilotBody(input.summary, t.autopilotFallback),
       };
     case "autopilot-done":
       return {
         ...base,
         title: t.autopilotDoneTitle(input.name),
-        body: input.summary && input.summary.trim() ? input.summary : t.autopilotDoneFallback,
+        body: autopilotBody(input.summary, t.autopilotDoneFallback),
       };
-    case "merge_attention": {
-      const desig = input.desig ?? input.name;
-      if (input.mergeState === "rebase_cap") {
-        return { ...base, title: t.rebaseCapTitle, body: t.rebaseCapBody(desig) };
-      }
-      return { ...base, title: t.mergeErrorTitle, body: t.mergeErrorBody(desig) };
-    }
+    case "merge_attention":
+      return { ...base, ...mergeAttentionParts(t, input) };
     case "usage_limit":
       return {
         ...base,
         title: t.usageLimitTitle(input.pct ?? 0),
         body: t.usageLimitBody(resetTimeLabel(input.resetAt, asLocale(locale))),
       };
+    case "extra_credits":
+      return { ...base, title: t.extraCreditsTitle, body: extraCreditsBody(t, input) };
     default:
       return {
         ...base,
@@ -474,6 +506,70 @@ export function attachUsagePush(
         if (sent) store.setSetting(USAGE_WARNED_KEY, String(session5h.resetAt));
       })
       .catch((err) => console.warn("[push] usage_limit notify failed:", err))
+      .finally(() => {
+        inFlight = false;
+      });
+  });
+}
+
+/** Setting key holding the year-month bucket of the credit window already warned about. */
+const CREDITS_WARNED_KEY = "usage_credits_warned";
+
+/** A snapshot of the paid extra-credit (pay-as-you-go overage) window, off usage:limits. */
+interface CreditWindowLike {
+  spent: number;
+  cap: number;
+  currency: string;
+  resetAt: number | null;
+  stale: boolean;
+}
+
+/** Year-month bucket ("YYYY-MM") identifying the credit window via its upcoming reset month. */
+function creditBucket(resetAt: number | null, now: number): string {
+  const d = new Date(resetAt ?? now);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/** Push once per monthly credit window the first time paid extra-credit spend exceeds 0. */
+export function attachCreditsPush(
+  events: EventHub,
+  store: SessionStore,
+  push: PushService,
+  now: () => number = () => Date.now(),
+): void {
+  // Same in-flight discipline as attachUsagePush: the warned bucket is read sync
+  // but persisted in notify's .then, so an emit landing mid-delivery would re-read
+  // the stale marker and could double-warn the same window. Skip while one pends.
+  let inFlight = false;
+  events.subscribe((event, data) => {
+    if (event !== "usage:limits") return;
+    const { credits } = data as { credits: CreditWindowLike | null };
+    // Gate on freshness (a stale snapshot is data the app disregards) and key off
+    // spent: pct rounds to 0 while real money is being spent.
+    if (!credits || credits.stale || credits.spent <= 0) return;
+    // One warning per monthly window, keyed by the bucket (stable per window,
+    // survives redeploys) — NOT the raw resetAt epoch, which could shift/mis-roll.
+    const bucket = creditBucket(credits.resetAt, now());
+    const warned = store.getSetting(CREDITS_WARNED_KEY);
+    if (inFlight || warned === bucket) return;
+    inFlight = true;
+    void push
+      .notify({
+        kind: "extra_credits",
+        sessionId: "",
+        tag: "usage-credits",
+        name: "credits",
+        creditSpent: credits.spent,
+        creditCap: credits.cap,
+        currency: credits.currency,
+        cooldownKey: "usage_limit:credits",
+      })
+      .then((sent) => {
+        // Only mark the window once a device heard it: a push suppressed while
+        // the app is active retries next tick and fires when the user steps away.
+        if (sent) store.setSetting(CREDITS_WARNED_KEY, bucket);
+      })
+      .catch((err) => console.warn("[push] extra_credits notify failed:", err))
       .finally(() => {
         inFlight = false;
       });

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,7 +43,7 @@ import { sessionTokens, jsonlPathFor } from "./usage";
 import { detectDevCommand } from "./preview";
 import { sessionActivity } from "./activity";
 import { handleUpload } from "./uploads";
-import type { UsageLimitsService } from "./usage-limits";
+import type { UsageLimits, UsageLimitsService } from "./usage-limits";
 import type { UpdateService } from "./update";
 import type { HerdrUpdateService } from "./herdr-update";
 import type { StarPromptStatus } from "./star-prompt";
@@ -118,6 +118,9 @@ export interface AppDeps {
   service: SessionService;
   events: EventHub;
   usageLimits: Pick<UsageLimitsService, "limits">;
+  /** Force a `/usage` re-scrape (calibration) and return fresh limits; absent in tests that
+   *  don't wire the live calibrator (the route then falls back to the current snapshot). */
+  refreshUsage?: () => Promise<UsageLimits>;
   /** Resolve the git forge for a repo dir; null when none is configured. */
   resolveForge?: (repoDir: string) => GitForge | null;
   /** Self-update tracker; absent in environments where it isn't wired. */
@@ -1684,7 +1687,18 @@ async function handleSessionGit(ctx: Ctx): Promise<Response | null> {
   }
 }
 
-function handleUsageLimits({ req, parts, deps }: Ctx): Response | null {
+async function handleUsageLimits({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (
+    req.method === "POST" &&
+    parts[0] === "api" &&
+    parts[1] === "usage" &&
+    parts[2] === "refresh"
+  ) {
+    const limits = deps.refreshUsage
+      ? await deps.refreshUsage()
+      : deps.usageLimits.limits(Date.now());
+    return json(limits);
+  }
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "usage" && parts[2] === "limits") {
     return json(deps.usageLimits.limits(Date.now()));
   }
@@ -1902,6 +1916,9 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       previewHost: config.previewHost,
       // raw configured default model; "auto" = unset/seed; client resolves promo itself.
       defaultModel: config.defaultModel,
+      // account-wide extra-credit (paid overage) spend ceiling; drain pauses above it.
+      // 0 = pause on ANY extra-credit spend.
+      extraCreditsDrainCeiling: config.extraCreditsDrainCeiling,
     });
   }
   if (req.method === "PUT") {
@@ -1926,6 +1943,7 @@ const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response]
   ["prReviewCyclesCap", putPrReviewCyclesCap],
   ["planReviewCyclesCap", putPlanReviewCyclesCap],
   ["defaultModel", putDefaultModel],
+  ["extraCreditsDrainCeiling", putExtraCreditsDrainCeiling],
 ];
 
 function putRemoteControl(value: unknown, deps: Ctx["deps"]): Response {
@@ -1978,6 +1996,18 @@ function putDefaultModel(value: unknown, deps: Ctx["deps"]): Response {
   config.defaultModel = v; // live: next drain spawn picks it up
   deps.store.setSetting("defaultModel", v); // persist across restarts
   return json({ defaultModel: config.defaultModel });
+}
+
+// Account-wide extra-credit (paid overage) spend ceiling. Requires a finite, non-negative
+// number; persisted as the canonical "extra_credits_drain_ceiling" setting key and applied
+// live so the next drain assembly reads it without a restart.
+function putExtraCreditsDrainCeiling(value: unknown, deps: Ctx["deps"]): Response {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return json({ error: "extraCreditsDrainCeiling must be a non-negative number" }, 400);
+  }
+  config.extraCreditsDrainCeiling = value; // live: next drain assembly reads it
+  deps.store.setSetting("extra_credits_drain_ceiling", String(value)); // persist across restarts
+  return json({ extraCreditsDrainCeiling: config.extraCreditsDrainCeiling });
 }
 
 function putRepoRoot(value: unknown, deps: Ctx["deps"]): Response {

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,7 +15,7 @@ import type {
   ReviewerSpawnRow,
   PrReview,
 } from "./types";
-import type { CapRow, CapStore, WindowKey } from "./usage-limits";
+import type { CapRow, CapStore, CreditSnapshot, CreditStore, WindowKey } from "./usage-limits";
 import { dominantModel, type SessionUsage } from "./usage";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
 import { normalizeRepoDefaultModelSetting } from "./default-model";
@@ -151,7 +151,7 @@ const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePat
   auto, issueNumber, sandboxApplied, sandboxDegraded,
   createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId`;
 
-export class SessionStore implements CapStore {
+export class SessionStore implements CapStore, CreditStore {
   private db: Database;
   constructor(path: string) {
     this.db = new Database(path);
@@ -179,6 +179,10 @@ export class SessionStore implements CapStore {
     this.db.run(`CREATE TABLE IF NOT EXISTS usage_caps (
       window TEXT PRIMARY KEY, cap REAL NOT NULL, resetAt INTEGER NOT NULL,
       pct INTEGER NOT NULL, scrapedAt INTEGER NOT NULL)`);
+    this.db.run(`CREATE TABLE IF NOT EXISTS usage_credit (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      spent REAL NOT NULL, cap REAL NOT NULL, currency TEXT NOT NULL,
+      pct INTEGER NOT NULL, resetAt INTEGER, scrapedAt INTEGER NOT NULL)`);
     // small key/value store for runtime-configurable settings (e.g. repoRoot)
     this.db.run(`CREATE TABLE IF NOT EXISTS settings (
       key TEXT PRIMARY KEY, value TEXT NOT NULL)`);
@@ -764,6 +768,25 @@ export class SessionStore implements CapStore {
        ON CONFLICT(window) DO UPDATE SET cap=excluded.cap, resetAt=excluded.resetAt,
          pct=excluded.pct, scrapedAt=excluded.scrapedAt`,
       [row.window as WindowKey, row.cap, row.resetAt, row.pct, row.scrapedAt],
+    );
+  }
+
+  getCreditSnapshot(): CreditSnapshot | null {
+    return (
+      (this.db
+        .query(
+          `SELECT spent, cap, currency, pct, resetAt, scrapedAt FROM usage_credit WHERE id = 1`,
+        )
+        .get() as CreditSnapshot | null) ?? null
+    );
+  }
+
+  putCreditSnapshot(row: CreditSnapshot): void {
+    this.db.run(
+      `INSERT INTO usage_credit (id, spent, cap, currency, pct, resetAt, scrapedAt) VALUES (1, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET spent=excluded.spent, cap=excluded.cap, currency=excluded.currency,
+         pct=excluded.pct, resetAt=excluded.resetAt, scrapedAt=excluded.scrapedAt`,
+      [row.spent, row.cap, row.currency, row.pct, row.resetAt, row.scrapedAt],
     );
   }
 

--- a/src/usage-limits.ts
+++ b/src/usage-limits.ts
@@ -10,14 +10,39 @@ const PERIOD_MS: Record<WindowKey, number> = {
 /** Below this scraped %, inverting to a cap is too noisy — keep the prior cap instead. */
 const MIN_CALIBRATION_PCT = 5;
 
+/** Weekly-window % at/above which we escalate /usage calibration cadence: close enough to the
+ *  subscription cap that paid extra-credit spend becomes plausible and a daily credit snapshot is
+ *  too stale to trust. */
+const CREDIT_WATCH_PCT = 90; // internal watermark for calibrateDelay; not part of the public API
+export const CREDIT_WATCH_INTERVAL_MS = 15 * 60 * 1000; // escalated cadence near the cap
+export const CALIBRATE_INTERVAL_MS = 24 * 60 * 60 * 1000; // normal daily cadence
+
+/** Delay until the next `/usage` calibration, given the latest live limits. Escalates to the
+ *  watch cadence while the weekly window is near its cap so credit spend stays fresh. */
+export function calibrateDelay(limits: UsageLimits): number {
+  return (limits.week?.pct ?? 0) >= CREDIT_WATCH_PCT
+    ? CREDIT_WATCH_INTERVAL_MS
+    : CALIBRATE_INTERVAL_MS;
+}
+
 export interface ScrapedWindow {
   pct: number;
+  resetAt: number | null;
+  resetLabel: string | null;
+}
+/** The "Usage credits" panel: paid pay-as-you-go overage spend against a monthly budget. */
+export interface ScrapedCredit {
+  pct: number;
+  spent: number;
+  cap: number;
+  currency: string;
   resetAt: number | null;
   resetLabel: string | null;
 }
 export interface ScrapedUsage {
   session5h: ScrapedWindow | null;
   week: ScrapedWindow | null;
+  credits: ScrapedCredit | null;
 }
 
 const MONTHS = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
@@ -54,6 +79,42 @@ export function parseResetLabel(label: string, now: number): number | null {
   return null;
 }
 
+/**
+ * Parse a credits-cycle reset label (month-name + day, e.g. "Jun1" / "Jun 1") to a ms epoch at
+ * local midnight. Unlike `parseResetLabel`, a date already past rolls forward ONE MONTH (the
+ * credits budget is monthly), not one year — carrying the year on a Dec→Jan wrap.
+ */
+export function parseMonthlyReset(label: string, now: number): number | null {
+  const m = label
+    .replace(/\s+/g, "")
+    .toLowerCase()
+    .match(/^([a-z]{3})(\d{1,2})$/);
+  if (!m) return null;
+  const mon = MONTHS.indexOf(m[1]!);
+  if (mon < 0) return null;
+  const day = +m[2]!;
+  const d = new Date(now);
+  // day-safe: pin to the 1st before setting the month so a short target month can't overflow
+  // (e.g. setting month while on day 31 spills "Feb 31" into March), then clamp the labeled day
+  // to the new month's length. Re-clamp on every step — the month length changes as we advance.
+  const clampDay = () => {
+    d.setDate(1);
+    const lastDay = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+    d.setDate(Math.min(day, lastDay));
+  };
+  d.setMonth(mon, 1);
+  clampDay();
+  d.setHours(0, 0, 0, 0);
+  // the credits cycle is monthly: a label naming a past month/day is the NEXT occurrence — step
+  // forward a month at a time (carrying the year on the Dec→Jan wrap) until it lands at/after now.
+  // (One step suffices for "this month, day already past"; the loop also handles Dec-scrape/Jan-reset.)
+  while (d.getTime() < now) {
+    d.setMonth(d.getMonth() + 1, 1);
+    clampDay();
+  }
+  return d.getTime();
+}
+
 // Built from char codes so the control bytes never appear literally in a regex literal.
 const ESC = String.fromCharCode(27);
 const BEL = String.fromCharCode(7);
@@ -83,6 +144,39 @@ function parseSegment(seg: string, now: number): ScrapedWindow | null {
   };
 }
 
+/**
+ * Read the "Usage credits" panel out of the already-ANSI-stripped, whitespace-collapsed capture.
+ * This is a STANDALONE scan — it must NOT route through the section anchor/`SECTION_TRAILER` loop,
+ * which lists `Usagecredits` as a trailer and would truncate this segment to empty. Collapsed shape:
+ *   Usagecredits▎0%used€0.29/€50.00spent·ResetsJun1(Europe/Berlin)
+ * The gauge pct rounds down (can read `0%used` while real money is spent), so `spent` is the truth
+ * signal and is parsed independently of pct.
+ */
+export function parseCredits(collapsed: string, now: number): ScrapedCredit | null {
+  const start = collapsed.search(/Usagecredits/i);
+  if (start < 0) return null;
+  let seg = collapsed.slice(start);
+  const end = seg.search(/Esctocancel/i);
+  if (end >= 0) seg = seg.slice(0, end);
+  // pct rounds down and can be absent; treat missing as 0 — spend below is the real signal
+  const pct = +(seg.match(/(\d+)%used/i)?.[1] ?? 0);
+  // symbol-only currency group: a `(\D*)([\d.]+)` form would wrongly grab the `%used` of `0%used€`.
+  // Amounts are assumed dot-decimal (as the Europe/Berlin TUI renders, e.g. `€0.29`); a comma render
+  // (`€0,29`) wouldn't match `[\d.]+` and would drop the whole credits section (returns null).
+  // `seg` is already whitespace-collapsed, so there is no inter-group whitespace to skip.
+  const spend = seg.match(/([^\d.\s/])([\d.]+)\/[^\d.\s/]?([\d.]+)spent/i);
+  if (!spend) return null;
+  const label = seg.match(/Resets(.*?)\(/i)?.[1] ?? null;
+  return {
+    pct,
+    spent: +spend[2]!,
+    cap: +spend[3]!,
+    currency: spend[1]!,
+    resetLabel: label,
+    resetAt: label ? parseMonthlyReset(label, now) : null,
+  };
+}
+
 /** Extract the two limit windows from a (possibly multi-frame, ANSI-laden) `/usage` capture. */
 export function parseUsageFrame(raw: string, now: number): ScrapedUsage {
   const noAnsi = raw.replace(ANSI_CSI, "").replace(ANSI_OSC, "");
@@ -91,7 +185,7 @@ export function parseUsageFrame(raw: string, now: number): ScrapedUsage {
   // so a window's pct/reset can only be read from its OWN section — a truncated redraw must
   // not let one window steal the next section's (or the next frame's) values.
   const anchors = [...c.matchAll(/Currentsession|Currentweek/gi)];
-  const best: ScrapedUsage = { session5h: null, week: null };
+  const best: ScrapedUsage = { session5h: null, week: null, credits: parseCredits(c, now) };
   for (let i = 0; i < anchors.length; i++) {
     let seg = c.slice(anchors[i]!.index, anchors[i + 1]?.index ?? c.length);
     const trailer = seg.search(SECTION_TRAILER);
@@ -118,16 +212,46 @@ export interface LimitWindow {
   pct: number;
   resetAt: number;
 }
+/** Live "Usage credits" window — a direct passthrough of the last scrape snapshot. */
+export interface CreditWindow {
+  pct: number;
+  spent: number;
+  cap: number;
+  currency: string;
+  resetAt: number | null;
+  scrapedAt: number;
+  stale: boolean; // derived from scrapedAt age (NOT the cap-based 2-week stale flag)
+}
 export interface UsageLimits {
   session5h: LimitWindow | null;
   week: LimitWindow | null;
+  credits: CreditWindow | null;
   stale: boolean;
   calibratedAt: number | null;
 }
 
+// Credits is scrape-fresh-only (no local signal to recompute from), so it goes stale fast —
+// 1h, unlike the 2-week cap stale that tolerates JSONL-recomputed windows drifting.
+const CREDIT_STALE_MS = 60 * 60 * 1000;
+
 export interface CapStore {
   getCaps(): CapRow[];
   putCap(row: CapRow): void;
+}
+
+/** Latest persisted "Usage credits" snapshot — a direct passthrough of the scrape, not back-calculated. */
+export interface CreditSnapshot {
+  spent: number;
+  cap: number;
+  currency: string;
+  pct: number;
+  resetAt: number | null; // monthly reset epoch (ms); null if the label was unparseable
+  scrapedAt: number;
+}
+
+export interface CreditStore {
+  getCreditSnapshot(): CreditSnapshot | null; // null when nothing persisted yet
+  putCreditSnapshot(row: CreditSnapshot): void; // single-row: upsert, latest wins
 }
 
 /** A source of raw `/usage` text. Returns null on failure (spawn/parse/timeout). */
@@ -153,6 +277,7 @@ export class UsageLimitsService {
     private index: AccountUsageIndex,
     private caps: CapStore,
     private probe: UsageProbe,
+    private creditStore: CreditStore,
   ) {}
 
   /** Scrape `/usage` and recalibrate the per-window caps from local JSONL. */
@@ -163,31 +288,63 @@ export class UsageLimitsService {
     const prior = new Map(this.caps.getCaps().map((r) => [r.window, r]));
     let any = false;
     for (const key of ["session5h", "week"] as WindowKey[]) {
-      const w = parsed[key];
-      if (!w) continue;
-      const period = PERIOD_MS[key];
-      const p = prior.get(key);
-      // unparseable reset label: a prior anchor rolled forward beats guessing now+period —
-      // a bogus anchor poisons both the calibration window and the displayed reset time
-      const resetAt = w.resetAt ?? (p ? rollForward(p.resetAt, period, now) : now + period);
-      const start = resetAt - period;
-      const units = this.index.windowSum(start, Math.min(resetAt, now));
-      if (w.pct >= MIN_CALIBRATION_PCT && units > 0) {
-        this.caps.putCap({
-          window: key,
-          cap: units / (w.pct / 100),
-          resetAt,
-          pct: w.pct,
-          scrapedAt: now,
-        });
-        any = true;
-      } else {
-        // too little signal to invert a cap — refresh the anchor on the prior cap if we have one
-        if (p) this.caps.putCap({ ...p, resetAt, pct: w.pct, scrapedAt: now });
-        any = any || !!p;
-      }
+      if (this.calibrateWindow(key, parsed[key], prior.get(key), now)) any = true;
     }
+    if (this.persistCredit(parsed, now)) any = true;
     return any;
+  }
+
+  /**
+   * Recalibrate one window's cap from its scraped pct against local JSONL. Returns true when it
+   * wrote a cap (or refreshed a prior anchor) — i.e. when the calibration produced something worth
+   * emitting. Absent window (`w` null) → no-op, returns false.
+   */
+  private calibrateWindow(
+    key: WindowKey,
+    w: ScrapedUsage[WindowKey],
+    p: CapRow | undefined,
+    now: number,
+  ): boolean {
+    if (!w) return false;
+    const period = PERIOD_MS[key];
+    // unparseable reset label: a prior anchor rolled forward beats guessing now+period —
+    // a bogus anchor poisons both the calibration window and the displayed reset time
+    const resetAt = w.resetAt ?? (p ? rollForward(p.resetAt, period, now) : now + period);
+    const start = resetAt - period;
+    const units = this.index.windowSum(start, Math.min(resetAt, now));
+    if (w.pct >= MIN_CALIBRATION_PCT && units > 0) {
+      this.caps.putCap({
+        window: key,
+        cap: units / (w.pct / 100),
+        resetAt,
+        pct: w.pct,
+        scrapedAt: now,
+      });
+      return true;
+    }
+    // too little signal to invert a cap — refresh the anchor on the prior cap if we have one
+    if (p) this.caps.putCap({ ...p, resetAt, pct: w.pct, scrapedAt: now });
+    return !!p;
+  }
+
+  /**
+   * Credits is a direct passthrough — persist the scrape verbatim whenever the panel rendered it.
+   * No MIN_CALIBRATION_PCT gate (that's a cap-inversion guard, irrelevant here). A missing section
+   * (extra usage disabled) leaves any prior snapshot untouched — never fabricate. Returns true when
+   * a snapshot was persisted (worth emitting usage:limits even if caps didn't move).
+   */
+  private persistCredit(parsed: ScrapedUsage, now: number): boolean {
+    if (!parsed.credits) return false;
+    const cr = parsed.credits;
+    this.creditStore.putCreditSnapshot({
+      spent: cr.spent,
+      cap: cr.cap,
+      currency: cr.currency,
+      pct: cr.pct,
+      resetAt: cr.resetAt,
+      scrapedAt: now,
+    });
+    return true;
   }
 
   /** Current live limits, recomputed from local JSONL against the calibrated caps. */
@@ -205,6 +362,23 @@ export class UsageLimitsService {
     const session5h = compute("session5h");
     const week = compute("week");
     const stale = calibratedAt === null || now - calibratedAt > 2 * PERIOD_MS.week;
-    return { session5h, week, stale, calibratedAt };
+    // Credits is a passthrough of the stored snapshot — not recomputed from JSONL.
+    const snap = this.creditStore.getCreditSnapshot();
+    let credits: CreditWindow | null = null;
+    // Post-reset guard: a snapshot whose monthly budget has already rolled over is meaningless
+    // until re-scraped — drop it (also stops the gauge showing a past reset date). An unparseable
+    // (null) resetAt can't be known to have rolled over, so it passes through.
+    if (snap && !(snap.resetAt != null && snap.resetAt <= now)) {
+      credits = {
+        pct: snap.pct,
+        spent: snap.spent,
+        cap: snap.cap,
+        currency: snap.currency,
+        resetAt: snap.resetAt,
+        scrapedAt: snap.scrapedAt,
+        stale: now - snap.scrapedAt > CREDIT_STALE_MS,
+      };
+    }
+    return { session5h, week, credits, stale, calibratedAt };
   }
 }

--- a/test/drain-core.test.ts
+++ b/test/drain-core.test.ts
@@ -45,6 +45,8 @@ function state(over: Partial<DrainRepoState> = {}): DrainRepoState {
     maxAuto: 2,
     usageCeilingPct: 80,
     usagePct: 0,
+    creditSpent: 0,
+    creditSpendCeiling: 0,
     autoSessions: [],
     mappedIssueNumbers: new Set<number>(),
     candidates: [],
@@ -91,6 +93,36 @@ describe("computeNext", () => {
   test("usage just under ceiling → spawn", () => {
     const d = computeNext(state({ usagePct: 79, usageCeilingPct: 80, candidates: [issue(2)] }));
     expect(d.kind).toBe("spawn");
+  });
+
+  test("extra-credit spend over ceiling → hold credits with spend detail", () => {
+    const d = computeNext(
+      state({ creditSpent: 0.29, creditSpendCeiling: 0, candidates: [issue(2)] }),
+    );
+    expect(d).toEqual({ kind: "hold", reason: { code: "credits", detail: "0.29" } });
+  });
+
+  test("extra-credit spend equal to ceiling → no credits hold (uses > not >=)", () => {
+    const d = computeNext(state({ creditSpent: 5, creditSpendCeiling: 5, candidates: [issue(2)] }));
+    expect(d.kind).toBe("spawn");
+  });
+
+  test("extra-credit spend 0 (stale/absent) → no credits hold", () => {
+    const d = computeNext(state({ creditSpent: 0, creditSpendCeiling: 0, candidates: [issue(2)] }));
+    expect(d.kind).toBe("spawn");
+  });
+
+  test("credits guard sits AFTER the usage gate (usage wins when both fire)", () => {
+    const d = computeNext(
+      state({
+        usagePct: 92,
+        usageCeilingPct: 80,
+        creditSpent: 1,
+        creditSpendCeiling: 0,
+        candidates: [issue(2)],
+      }),
+    );
+    expect(d).toEqual({ kind: "hold", reason: { code: "usage", detail: "92" } });
   });
 
   test("blocked auto session → hold blocked with desig", () => {

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -11,7 +11,13 @@ const CHILD = 320;
 const PR = 330;
 const EPIC_BRANCH = "epic/327-efi-cluster";
 
-const NO_USAGE: UsageLimitsType = { session5h: null, week: null, stale: false, calibratedAt: null };
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+};
 
 interface ForgeRec {
   merges: { prNumber: number; method: MergeMethod; deleteBranch: boolean }[];

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -21,7 +21,13 @@ function issue(number: number, over: Partial<Issue> = {}): Issue {
   };
 }
 
-const NO_USAGE: UsageLimitsType = { session5h: null, week: null, stale: false, calibratedAt: null };
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+};
 
 interface ForgeRec {
   listIssuesCalls: number;

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -28,7 +28,13 @@ function issue(number: number, over: Partial<Issue> = {}): Issue {
   };
 }
 
-const NO_USAGE: UsageLimitsType = { session5h: null, week: null, stale: false, calibratedAt: null };
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+};
 
 interface ForgeRec {
   merges: { prNumber: number; method: MergeMethod; deleteBranch: boolean }[];
@@ -131,6 +137,7 @@ function makeHarness(
     autoDrainEnabled?: boolean;
     usagePct?: number;
     usageCeilingPct?: number;
+    credits?: UsageLimitsType["credits"];
     mergeImpl?: () => Promise<void>;
     listIssuesImpl?: () => Promise<Issue[]>;
     archiveImpl?: (id: string) => number;
@@ -224,7 +231,9 @@ function makeHarness(
   const usage = {
     limits: (): UsageLimitsType => {
       const pct = opts.usagePct ?? 0;
-      return pct > 0 ? { ...NO_USAGE, session5h: { pct, resetAt: 0 } } : NO_USAGE;
+      const base = pct > 0 ? { ...NO_USAGE, session5h: { pct, resetAt: 0 } } : { ...NO_USAGE };
+      if (opts.credits !== undefined) base.credits = opts.credits;
+      return base;
     },
   };
 
@@ -549,6 +558,49 @@ test("usage ceiling hold → status paused (usage banner reachable)", async () =
   expect(last.reason).toBe("usage");
   expect(last.paused).toBe(true);
   expect(last.detail).toBe("92");
+});
+
+function creditWindow(over: Partial<NonNullable<UsageLimitsType["credits"]>> = {}) {
+  return {
+    pct: 50,
+    spent: 25,
+    cap: 50,
+    currency: "€",
+    resetAt: null,
+    scrapedAt: 0,
+    stale: false,
+    ...over,
+  };
+}
+
+// Fail-safe gate: a stale credits snapshot (>1h old, monthly budget not rolled over) is
+// non-null with a real `spent`, but the rest of the app deliberately disregards it
+// (overspending() = !!c && !c.stale && c.spent > 0). The drain must apply the same !stale
+// gate, else a stale `spent > ceiling` would freeze every repo on disregarded data.
+test("stale credits snapshot → NO credits hold (drain proceeds, stale data disregarded)", async () => {
+  const h = makeHarness({
+    maxAuto: 2,
+    issues: [issue(1)],
+    credits: creditWindow({ spent: 999, stale: true }), // far above default ceiling 0
+  });
+  await h.drain.pump(REPO);
+  const last = h.statuses.at(-1)!;
+  expect(last.reason).not.toBe("credits");
+  expect(h.creates).toHaveLength(1); // spawned: not frozen on stale spend
+});
+
+// Control: same overage, fresh snapshot → DOES hold. Proves the !stale gate is the difference.
+test("fresh credits snapshot over ceiling → credits hold (paused)", async () => {
+  const h = makeHarness({
+    maxAuto: 2,
+    issues: [issue(1)],
+    credits: creditWindow({ spent: 999, stale: false }),
+  });
+  await h.drain.pump(REPO);
+  const last = h.statuses.at(-1)!;
+  expect(last.reason).toBe("credits");
+  expect(last.paused).toBe(true);
+  expect(h.creates).toHaveLength(0);
 });
 
 test("merged → archive → advance chain: onGit(merged) closes issue, archives, drops, emits, and onArchived spawns #2", async () => {

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -8,6 +8,7 @@ import {
   attachGitPush,
   attachMergePush,
   attachUsagePush,
+  attachCreditsPush,
   blockSummary,
   buildPayload,
   USAGE_WARN_PCT,
@@ -650,6 +651,180 @@ test("attachUsagePush does not double-warn when an emit lands mid-delivery", asy
   release(true); // delivery completes, window marked
   await tick();
   events.emit("usage:limits", limitsEvent(87, 10_000)); // marked → still no second call
+  await tick();
+  expect(calls.length).toBe(1);
+});
+
+// Credits live on usage:limits alongside session5h/week; only `credits` matters here.
+const creditsEvent = (
+  c: {
+    spent: number;
+    cap: number;
+    currency?: string;
+    resetAt: number | null;
+    stale?: boolean;
+  } | null,
+) => ({
+  session5h: null,
+  week: null,
+  stale: false,
+  calibratedAt: 1,
+  credits:
+    c === null
+      ? null
+      : {
+          pct: 0,
+          spent: c.spent,
+          cap: c.cap,
+          currency: c.currency ?? "$",
+          resetAt: c.resetAt,
+          scrapedAt: 1,
+          stale: c.stale ?? false,
+        },
+});
+
+// Fixed epochs: July 2026 → bucket "2026-07"; August 2026 → "2026-08".
+const JULY = new Date(2026, 6, 1).getTime();
+const AUGUST = new Date(2026, 7, 1).getTime();
+
+test("attachCreditsPush fires once when credits are fresh and spend > 0", async () => {
+  const calls: any[] = [];
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => {
+    calls.push(p);
+    return true;
+  };
+  const events = new EventHub();
+  attachCreditsPush(events, store, push, () => JULY);
+
+  events.emit("usage:limits", creditsEvent({ spent: 0.29, cap: 50, currency: "$", resetAt: JULY }));
+  await tick();
+  expect(calls.length).toBe(1);
+  expect(calls[0]).toMatchObject({
+    kind: "extra_credits",
+    tag: "usage-credits",
+    creditSpent: 0.29,
+    creditCap: 50,
+    currency: "$",
+    cooldownKey: "usage_limit:credits",
+  });
+  expect(buildPayload(calls[0], "en").body).toContain("$0.29 / $50.00");
+});
+
+test("attachCreditsPush does not fire when the snapshot is stale", async () => {
+  const calls: any[] = [];
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => {
+    calls.push(p);
+    return true;
+  };
+  const events = new EventHub();
+  attachCreditsPush(events, store, push, () => JULY);
+  events.emit("usage:limits", creditsEvent({ spent: 5, cap: 50, resetAt: JULY, stale: true }));
+  await tick();
+  expect(calls.length).toBe(0);
+});
+
+test("attachCreditsPush does not fire when spend is 0", async () => {
+  const calls: any[] = [];
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => {
+    calls.push(p);
+    return true;
+  };
+  const events = new EventHub();
+  attachCreditsPush(events, store, push, () => JULY);
+  events.emit("usage:limits", creditsEvent({ spent: 0, cap: 50, resetAt: JULY }));
+  await tick();
+  expect(calls.length).toBe(0);
+});
+
+test("attachCreditsPush does not fire when credits is null", async () => {
+  const calls: any[] = [];
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => {
+    calls.push(p);
+    return true;
+  };
+  const events = new EventHub();
+  attachCreditsPush(events, store, push, () => JULY);
+  events.emit("usage:limits", creditsEvent(null));
+  await tick();
+  expect(calls.length).toBe(0);
+});
+
+test("attachCreditsPush dedups within a month bucket, re-fires on a new window", async () => {
+  const calls: any[] = [];
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => {
+    calls.push(p);
+    return true;
+  };
+  const events = new EventHub();
+  let nowT = JULY;
+  attachCreditsPush(events, store, push, () => nowT);
+
+  events.emit("usage:limits", creditsEvent({ spent: 1, cap: 50, resetAt: JULY }));
+  await tick();
+  events.emit("usage:limits", creditsEvent({ spent: 2, cap: 50, resetAt: JULY })); // same bucket → suppressed
+  await tick();
+  expect(calls.length).toBe(1);
+
+  // Window rolled over: resetAt now in August → new bucket → fires again
+  nowT = AUGUST;
+  events.emit("usage:limits", creditsEvent({ spent: 3, cap: 50, resetAt: AUGUST }));
+  await tick();
+  expect(calls.length).toBe(2);
+  expect(calls[1]).toMatchObject({ creditSpent: 3 });
+});
+
+test("attachCreditsPush marks only on delivery, retries while suppressed", async () => {
+  const calls: any[] = [];
+  let delivered = false;
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => {
+    calls.push(p);
+    return delivered;
+  };
+  const events = new EventHub();
+  attachCreditsPush(events, store, push, () => JULY);
+
+  events.emit("usage:limits", creditsEvent({ spent: 1, cap: 50, resetAt: JULY })); // suppressed
+  await tick();
+  events.emit("usage:limits", creditsEvent({ spent: 2, cap: 50, resetAt: JULY })); // retried
+  await tick();
+  expect(calls.length).toBe(2);
+  expect(store.getSetting("usage_credits_warned")).toBeNull();
+
+  delivered = true;
+  events.emit("usage:limits", creditsEvent({ spent: 3, cap: 50, resetAt: JULY })); // delivered → marked
+  await tick();
+  expect(store.getSetting("usage_credits_warned")).toBe("2026-07");
+  events.emit("usage:limits", creditsEvent({ spent: 4, cap: 50, resetAt: JULY })); // marked → no more
+  await tick();
+  expect(calls.length).toBe(3);
+});
+
+test("attachCreditsPush does not double-fire when an emit lands mid-delivery", async () => {
+  const calls: any[] = [];
+  let release!: (sent: boolean) => void;
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = (p: any) => {
+    calls.push(p);
+    return new Promise<boolean>((r) => {
+      release = r;
+    });
+  };
+  const events = new EventHub();
+  attachCreditsPush(events, store, push, () => JULY);
+
+  events.emit("usage:limits", creditsEvent({ spent: 1, cap: 50, resetAt: JULY })); // notify in flight
+  events.emit("usage:limits", creditsEvent({ spent: 2, cap: 50, resetAt: JULY })); // not marked yet → skip
+  expect(calls.length).toBe(1);
+
+  release(true);
+  await tick();
+  events.emit("usage:limits", creditsEvent({ spent: 3, cap: 50, resetAt: JULY })); // marked → no second
   await tick();
   expect(calls.length).toBe(1);
 });

--- a/test/sandbox-wiring.test.ts
+++ b/test/sandbox-wiring.test.ts
@@ -259,6 +259,7 @@ test("drain pre-check: standard profile holds → service.create NOT called", as
 const NO_USAGE: UsageLimits = {
   session5h: null,
   week: null,
+  credits: null,
   stale: false,
   calibratedAt: null,
 };

--- a/test/server-ping.test.ts
+++ b/test/server-ping.test.ts
@@ -20,7 +20,7 @@ function makeDeps(): AppDeps {
     events,
   });
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, stale: true, calibratedAt: null }),
+    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
   };
   return { store, service, events, usageLimits, distiller: { distillNow: () => {} } };
 }

--- a/test/server-projects.test.ts
+++ b/test/server-projects.test.ts
@@ -49,7 +49,7 @@ function makeDeps(): AppDeps {
     events,
   });
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, stale: true, calibratedAt: null }),
+    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
   };
   const distiller = { distillNow: () => {} };
   return { store, service, events, usageLimits, distiller };

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -15,6 +15,7 @@ let savedHk: boolean;
 let savedPrCap: number;
 let savedPlanCap: number;
 let savedDefaultModel: string;
+let savedExtraCredits: number;
 
 beforeEach(() => {
   // realpath so comparisons hold where tmpdir() is a symlink (macOS)
@@ -27,6 +28,7 @@ beforeEach(() => {
   savedPrCap = config.prReviewCyclesCap;
   savedPlanCap = config.planReviewCyclesCap;
   savedDefaultModel = config.defaultModel;
+  savedExtraCredits = config.extraCreditsDrainCeiling;
   // the ceiling is the immutable boundary; point it at our temp dir for the test so
   // dirs inside tmp validate and the dir browser is confined to tmp.
   config.rootCeiling = tmp;
@@ -40,6 +42,7 @@ afterEach(() => {
   config.prReviewCyclesCap = savedPrCap;
   config.planReviewCyclesCap = savedPlanCap;
   config.defaultModel = savedDefaultModel;
+  config.extraCreditsDrainCeiling = savedExtraCredits;
   rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -339,4 +342,50 @@ test("PUT /api/settings rejects a non-string defaultModel", async () => {
   const res = await put(app, { defaultModel: 42 });
   expect(res.status).toBe(400);
   expect(config.defaultModel).toBe("auto"); // unchanged on failure
+});
+
+test("GET /api/settings includes extraCreditsDrainCeiling", async () => {
+  config.extraCreditsDrainCeiling = 25;
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/settings"));
+  const body = await res.json();
+  expect(body.extraCreditsDrainCeiling).toBe(25);
+});
+
+test("PUT /api/settings sets extraCreditsDrainCeiling, persists, leaves repoRoot intact", async () => {
+  config.repoRoot = tmp;
+  config.extraCreditsDrainCeiling = 0;
+  const { app, store } = harness();
+  const res = await put(app, { extraCreditsDrainCeiling: 50 });
+  expect(res.status).toBe(200);
+  expect((await res.json()).extraCreditsDrainCeiling).toBe(50);
+  expect(config.extraCreditsDrainCeiling).toBe(50); // live
+  expect(store.getSetting("extra_credits_drain_ceiling")).toBe("50"); // persisted
+  expect(config.repoRoot).toBe(tmp); // patch must not touch the repo root
+  const got = await (await app.fetch(new Request("http://x/api/settings"))).json();
+  expect(got.extraCreditsDrainCeiling).toBe(50);
+});
+
+test("PUT /api/settings accepts a fractional extraCreditsDrainCeiling (currency amount)", async () => {
+  const { app, store } = harness();
+  const res = await put(app, { extraCreditsDrainCeiling: 0.5 });
+  expect(res.status).toBe(200);
+  expect((await res.json()).extraCreditsDrainCeiling).toBe(0.5);
+  expect(store.getSetting("extra_credits_drain_ceiling")).toBe("0.5");
+});
+
+test("PUT /api/settings rejects a negative extraCreditsDrainCeiling", async () => {
+  const { app } = harness();
+  config.extraCreditsDrainCeiling = 0;
+  const res = await put(app, { extraCreditsDrainCeiling: -5 });
+  expect(res.status).toBe(400);
+  expect(config.extraCreditsDrainCeiling).toBe(0); // unchanged on failure
+});
+
+test("PUT /api/settings rejects a non-number extraCreditsDrainCeiling", async () => {
+  const { app } = harness();
+  config.extraCreditsDrainCeiling = 0;
+  const res = await put(app, { extraCreditsDrainCeiling: "lots" });
+  expect(res.status).toBe(400);
+  expect(config.extraCreditsDrainCeiling).toBe(0); // unchanged on failure
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -52,7 +52,7 @@ function makeDeps(liveTerminals: string[] = []): AppDeps {
     events,
   });
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, stale: true, calibratedAt: null }),
+    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
   };
   const distiller = { distillNow: () => {} };
   return { store, service, events, usageLimits, distiller };
@@ -67,7 +67,55 @@ test("GET /api/usage/limits returns the limits snapshot", async () => {
   const res = await harness().fetch(new Request("http://x/api/usage/limits"));
   expect(res.status).toBe(200);
   const body = await res.json();
-  expect(body).toEqual({ session5h: null, week: null, stale: true, calibratedAt: null });
+  expect(body).toEqual({
+    session5h: null,
+    week: null,
+    credits: null,
+    stale: true,
+    calibratedAt: null,
+  });
+});
+
+test("POST /api/usage/refresh calls refreshUsage and returns its fresh limits", async () => {
+  const fresh = {
+    session5h: { pct: 80, resetAt: 123 },
+    week: { pct: 95, resetAt: 456 },
+    credits: {
+      pct: 12,
+      spent: 6,
+      cap: 50,
+      currency: "€",
+      resetAt: 789,
+      scrapedAt: 1,
+      stale: false,
+    },
+    stale: false,
+    calibratedAt: 1,
+  };
+  let called = 0;
+  const deps = makeDeps();
+  deps.refreshUsage = async () => {
+    called++;
+    return fresh as any;
+  };
+  const res = await makeApp(deps).fetch(
+    new Request("http://x/api/usage/refresh", { method: "POST" }),
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual(fresh);
+  expect(called).toBe(1);
+});
+
+test("POST /api/usage/refresh without refreshUsage falls back to current limits snapshot", async () => {
+  const res = await harness().fetch(new Request("http://x/api/usage/refresh", { method: "POST" }));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({
+    session5h: null,
+    week: null,
+    credits: null,
+    stale: true,
+    calibratedAt: null,
+  });
 });
 
 test("GET /api/sessions/:id/usage returns zeroed usage for a session w/o JSONL", async () => {
@@ -189,7 +237,7 @@ function harnessWithReaper(reaper: { detect: any; reap: any; stopListenersOnPort
     reaper: fullReaper,
   });
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, stale: true, calibratedAt: null }),
+    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
   };
   const app = makeApp({ store, service, events, usageLimits, distiller: { distillNow: () => {} } });
   return { app, store };
@@ -1204,7 +1252,7 @@ function clearMergedHarness() {
     },
   };
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, stale: true, calibratedAt: null }),
+    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
   };
   const app = makeApp({ store, service, events, usageLimits, prCache } as any);
   const mk = (name: string, state: string) => {
@@ -1813,7 +1861,7 @@ function harnessWithPreviewStop({
     preview: { devPortFor },
   });
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, stale: true, calibratedAt: null }),
+    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
   };
   const app = makeApp({ store, service, events, usageLimits, distiller: { distillNow: () => {} } });
   return { app, store };

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -915,3 +915,60 @@ test("pr_reviews: rows for different (repoPath, prNumber) are independent", () =
   expect(store.getPrReview("/repo/a", 1)?.headSha).toBe("sha-a");
   expect(store.getPrReview("/repo/b", 2)?.headSha).toBe("sha-b");
 });
+
+test("getCreditSnapshot returns null on a fresh store", () => {
+  const store = mk();
+  expect(store.getCreditSnapshot()).toBeNull();
+});
+
+test("putCreditSnapshot round-trips exact values", () => {
+  const store = mk();
+  const row = {
+    spent: 4.2,
+    cap: 25,
+    currency: "USD",
+    pct: 17,
+    resetAt: 1_700_000_000_000,
+    scrapedAt: 1_699_000_000_000,
+  };
+  store.putCreditSnapshot(row);
+  expect(store.getCreditSnapshot()).toEqual(row);
+});
+
+test("putCreditSnapshot overwrites latest (single row wins)", () => {
+  const store = mk();
+  store.putCreditSnapshot({
+    spent: 4.2,
+    cap: 25,
+    currency: "USD",
+    pct: 17,
+    resetAt: 1_700_000_000_000,
+    scrapedAt: 1_699_000_000_000,
+  });
+  const next = {
+    spent: 9.99,
+    cap: 50,
+    currency: "EUR",
+    pct: 20,
+    resetAt: 1_710_000_000_000,
+    scrapedAt: 1_709_000_000_000,
+  };
+  store.putCreditSnapshot(next);
+  expect(store.getCreditSnapshot()).toEqual(next);
+});
+
+test("putCreditSnapshot round-trips a null resetAt as null", () => {
+  const store = mk();
+  const row = {
+    spent: 1,
+    cap: 10,
+    currency: "USD",
+    pct: 10,
+    resetAt: null,
+    scrapedAt: 1_699_000_000_000,
+  };
+  store.putCreditSnapshot(row);
+  const got = store.getCreditSnapshot();
+  expect(got).toEqual(row);
+  expect(got!.resetAt).toBeNull();
+});

--- a/test/usage-limits.test.ts
+++ b/test/usage-limits.test.ts
@@ -4,9 +4,17 @@ import { join } from "node:path";
 import {
   parseUsageFrame,
   parseResetLabel,
+  parseMonthlyReset,
+  parseCredits,
+  calibrateDelay,
+  CREDIT_WATCH_INTERVAL_MS,
+  CALIBRATE_INTERVAL_MS,
+  type UsageLimits,
   UsageLimitsService,
   type CapRow,
   type CapStore,
+  type CreditSnapshot,
+  type CreditStore,
   type UsageProbe,
 } from "../src/usage-limits";
 import { AccountUsageIndex } from "../src/usage";
@@ -102,6 +110,101 @@ test("parseUsageFrame: model-scoped weekly gauges never override the account cap
   expect(parseUsageFrame(raw, NOW).week?.pct).toBe(40);
 });
 
+// ── usage credits (paid overage) ─────────────────────────────────────────────
+
+// Mid-June 2026, local time (month 0-indexed; June = 5). Jun1 is already past here.
+const JUN13 = new Date(2026, 5, 13, 12, 0, 0, 0).getTime();
+
+test("parseUsageFrame parses the credits panel from the captured fixture", () => {
+  const raw = readFileSync(join(import.meta.dir, "fixtures", "usage-frame.txt"), "utf8");
+  const p = parseUsageFrame(raw, NOW);
+  expect(p.credits).not.toBeNull();
+  expect(p.credits!.currency).toBe("€");
+  expect(p.credits!.spent).toBe(0.29);
+  expect(p.credits!.cap).toBe(50);
+  expect(p.credits!.pct).toBe(0);
+  expect(p.credits!.resetLabel).toBe("Jun1");
+});
+
+test("credits: pct rounds to 0 while spend is the real (non-zero) signal", () => {
+  const raw = readFileSync(join(import.meta.dir, "fixtures", "usage-frame.txt"), "utf8");
+  const c = parseUsageFrame(raw, NOW).credits!;
+  expect(c.pct).toBe(0);
+  expect(c.spent).toBeGreaterThan(0);
+});
+
+test("parseCredits captures $ and £ currency symbols exactly", () => {
+  const usd = parseCredits("Usagecredits12%used$3.50/$25.00spent·ResetsJul1(x)", NOW)!;
+  expect(usd.currency).toBe("$");
+  expect(usd.spent).toBe(3.5);
+  expect(usd.cap).toBe(25);
+  expect(usd.pct).toBe(12);
+  const gbp = parseCredits("Usagecredits0%used£0.99/£10.00spent·ResetsAug2(x)", NOW)!;
+  expect(gbp.currency).toBe("£");
+  expect(gbp.spent).toBe(0.99);
+  expect(gbp.cap).toBe(10);
+});
+
+test("parseCredits stops at the Esc-to-cancel chrome and ignores absent section", () => {
+  expect(parseCredits("Currentsession3%usedResets9:30pm(x)", NOW)).toBeNull();
+  expect(parseUsageFrame("Current session\n3% used\nResets 9:30pm (x)", NOW).credits).toBeNull();
+});
+
+test("parseMonthlyReset rolls a past day forward ONE MONTH, not one year", () => {
+  // Jun1 is past relative to mid-June → next month, same year (Jul 1), NOT Jun 2027
+  const jul1 = new Date(parseMonthlyReset("Jun1", JUN13)!);
+  expect(jul1.getFullYear()).toBe(2026);
+  expect(jul1.getMonth()).toBe(6); // July
+  expect(jul1.getDate()).toBe(1);
+  expect(jul1.getHours()).toBe(0); // midnight local
+});
+
+test("parseMonthlyReset keeps a future day this month", () => {
+  const jun20 = new Date(parseMonthlyReset("Jun20", JUN13)!);
+  expect(jun20.getFullYear()).toBe(2026);
+  expect(jun20.getMonth()).toBe(5); // June
+  expect(jun20.getDate()).toBe(20);
+});
+
+test("parseMonthlyReset carries the year on a Dec→Jan wrap", () => {
+  const dec15 = new Date(2026, 11, 15, 12, 0, 0, 0).getTime();
+  const jan1 = new Date(parseMonthlyReset("Jan1", dec15)!);
+  expect(jan1.getFullYear()).toBe(2027);
+  expect(jan1.getMonth()).toBe(0);
+  expect(jan1.getDate()).toBe(1);
+});
+
+test("parseMonthlyReset clamps a day-31 label to the next month's last day (no month skip)", () => {
+  // Jan31 near end of Jan 2027 (non-leap) → next occurrence is Feb 28, NOT a March spill-over.
+  const jan31 = new Date(2027, 0, 31, 23, 59, 0, 0).getTime();
+  const feb = new Date(parseMonthlyReset("Jan31", jan31)!);
+  expect(feb.getFullYear()).toBe(2027);
+  expect(feb.getMonth()).toBe(1); // February — not skipped to March
+  expect(feb.getDate()).toBe(28); // clamped to Feb's last day
+  expect(feb.getHours()).toBe(0);
+});
+
+test("parseMonthlyReset clamps a day-31 label to Feb 29 in a leap year", () => {
+  // 2028 is a leap year → Jan31 rolls to Feb 29.
+  const jan31 = new Date(2028, 0, 31, 23, 59, 0, 0).getTime();
+  const feb = new Date(parseMonthlyReset("Jan31", jan31)!);
+  expect(feb.getMonth()).toBe(1); // February
+  expect(feb.getDate()).toBe(29); // leap-year last day
+});
+
+test("parseMonthlyReset returns null for an unparseable label", () => {
+  expect(parseMonthlyReset("someday", NOW)).toBeNull();
+  expect(parseMonthlyReset("9:30pm", NOW)).toBeNull();
+});
+
+test("parseUsageFrame: adding credits parsing did not break the week anchor loop", () => {
+  // self-truncation regression: the fixture must still yield BOTH a week window AND credits
+  const raw = readFileSync(join(import.meta.dir, "fixtures", "usage-frame.txt"), "utf8");
+  const p = parseUsageFrame(raw, NOW);
+  expect(p.week).not.toBeNull();
+  expect(p.credits).not.toBeNull();
+});
+
 // ── calibration + live limits ───────────────────────────────────────────────
 
 class MemCaps implements CapStore {
@@ -111,6 +214,16 @@ class MemCaps implements CapStore {
   }
   putCap(row: CapRow): void {
     this.rows.set(row.window, row);
+  }
+}
+
+class MemCredits implements CreditStore {
+  snap: CreditSnapshot | null = null;
+  getCreditSnapshot(): CreditSnapshot | null {
+    return this.snap;
+  }
+  putCreditSnapshot(row: CreditSnapshot): void {
+    this.snap = row;
   }
 }
 
@@ -130,7 +243,7 @@ test("calibrate backs out cap = units / (pct/100)", async () => {
   const caps = new MemCaps();
   const raw =
     "Current session\n10% used\nResets 9:30pm (x)\nCurrent week\n20% used\nResets Jun 6 (x)";
-  const svc = new UsageLimitsService(fakeIndex(100), caps, new StubProbe(raw));
+  const svc = new UsageLimitsService(fakeIndex(100), caps, new StubProbe(raw), new MemCredits());
   expect(await svc.calibrate(NOW)).toBe(true);
   // session: 100 units at 10% → cap 1000 ; week: 100 at 20% → cap 500
   expect(caps.rows.get("session5h")!.cap).toBeCloseTo(1000, 5);
@@ -141,7 +254,7 @@ test("low-pct scrape keeps the prior cap (noise guard)", async () => {
   const caps = new MemCaps();
   caps.putCap({ window: "session5h", cap: 1000, resetAt: NOW + 1000, pct: 40, scrapedAt: NOW - 1 });
   const raw = "Current session\n2% used\nResets 9:30pm (x)";
-  const svc = new UsageLimitsService(fakeIndex(5), caps, new StubProbe(raw));
+  const svc = new UsageLimitsService(fakeIndex(5), caps, new StubProbe(raw), new MemCredits());
   await svc.calibrate(NOW);
   expect(caps.rows.get("session5h")!.cap).toBe(1000); // unchanged
 });
@@ -152,13 +265,18 @@ test("unparseable reset label keeps the prior anchor rolled forward, not now+per
   const priorReset = NOW - 1000; // just expired → rolls forward one period
   caps.putCap({ window: "week", cap: 500, resetAt: priorReset, pct: 20, scrapedAt: NOW - WEEK });
   const raw = "Current week (all models)\n30% used\nResets someday (x)";
-  const svc = new UsageLimitsService(fakeIndex(100), caps, new StubProbe(raw));
+  const svc = new UsageLimitsService(fakeIndex(100), caps, new StubProbe(raw), new MemCredits());
   await svc.calibrate(NOW);
   expect(caps.rows.get("week")!.resetAt).toBe(priorReset + WEEK);
 });
 
 test("calibrate returns false when the probe fails", async () => {
-  const svc = new UsageLimitsService(fakeIndex(100), new MemCaps(), new StubProbe(null));
+  const svc = new UsageLimitsService(
+    fakeIndex(100),
+    new MemCaps(),
+    new StubProbe(null),
+    new MemCredits(),
+  );
   expect(await svc.calibrate(NOW)).toBe(false);
 });
 
@@ -172,7 +290,7 @@ test("limits computes pct = units/cap and rolls the reset anchor forward", () =>
     pct: 25,
     scrapedAt: NOW,
   });
-  const svc = new UsageLimitsService(fakeIndex(50), caps, new StubProbe(null));
+  const svc = new UsageLimitsService(fakeIndex(50), caps, new StubProbe(null), new MemCredits());
   const l = svc.limits(NOW);
   expect(l.session5h!.pct).toBe(25); // 50/200
   expect(l.session5h!.resetAt).toBe(NOW - 2 * 3600_000 + 5 * 3600_000);
@@ -180,13 +298,151 @@ test("limits computes pct = units/cap and rolls the reset anchor forward", () =>
 });
 
 test("limits clamps to 100 and reports stale when never calibrated", () => {
-  const empty = new UsageLimitsService(fakeIndex(0), new MemCaps(), new StubProbe(null));
+  const empty = new UsageLimitsService(
+    fakeIndex(0),
+    new MemCaps(),
+    new StubProbe(null),
+    new MemCredits(),
+  );
   const l = empty.limits(NOW);
   expect(l.session5h).toBeNull();
   expect(l.stale).toBe(true);
 
   const caps = new MemCaps();
   caps.putCap({ window: "week", cap: 10, resetAt: NOW + 1000, pct: 99, scrapedAt: NOW });
-  const over = new UsageLimitsService(fakeIndex(999), caps, new StubProbe(null));
+  const over = new UsageLimitsService(fakeIndex(999), caps, new StubProbe(null), new MemCredits());
   expect(over.limits(NOW).week!.pct).toBe(100);
+});
+
+// ── credits: calibrate persist + live passthrough ────────────────────────────
+
+test("calibrate persists the parsed credit snapshot with scrapedAt === now", async () => {
+  const raw = readFileSync(join(import.meta.dir, "fixtures", "usage-frame.txt"), "utf8");
+  const credits = new MemCredits();
+  const svc = new UsageLimitsService(fakeIndex(100), new MemCaps(), new StubProbe(raw), credits);
+  expect(await svc.calibrate(NOW)).toBe(true);
+  const snap = credits.getCreditSnapshot()!;
+  expect(snap.spent).toBe(0.29);
+  expect(snap.cap).toBe(50);
+  expect(snap.currency).toBe("€");
+  expect(snap.pct).toBe(0);
+  expect(snap.resetAt).toBe(parseMonthlyReset("Jun1", NOW)); // direct passthrough of parsed reset
+  expect(snap.scrapedAt).toBe(NOW);
+});
+
+test("calibrate with no credits section leaves the prior snapshot untouched", async () => {
+  const credits = new MemCredits();
+  const prior: CreditSnapshot = {
+    spent: 1.5,
+    cap: 50,
+    currency: "$",
+    pct: 3,
+    resetAt: NOW + 1000,
+    scrapedAt: NOW - 1000,
+  };
+  credits.putCreditSnapshot({ ...prior });
+  // a capture with windows but no Usagecredits panel
+  const raw = "Current session\n10% used\nResets 9:30pm (x)";
+  const svc = new UsageLimitsService(fakeIndex(100), new MemCaps(), new StubProbe(raw), credits);
+  await svc.calibrate(NOW);
+  expect(credits.getCreditSnapshot()).toEqual(prior); // never fabricated/cleared
+});
+
+test("limits passes a fresh credit snapshot through (incl. pct 0 while spend > 0)", () => {
+  const credits = new MemCredits();
+  credits.putCreditSnapshot({
+    spent: 0.29,
+    cap: 50,
+    currency: "€",
+    pct: 0,
+    resetAt: NOW + 7 * 24 * 3600_000,
+    scrapedAt: NOW,
+  });
+  const svc = new UsageLimitsService(fakeIndex(0), new MemCaps(), new StubProbe(null), credits);
+  const c = svc.limits(NOW).credits!;
+  expect(c.stale).toBe(false);
+  expect(c.pct).toBe(0);
+  expect(c.spent).toBe(0.29);
+  expect(c.cap).toBe(50);
+  expect(c.currency).toBe("€");
+  expect(c.resetAt).toBe(NOW + 7 * 24 * 3600_000);
+  expect(c.scrapedAt).toBe(NOW);
+});
+
+test("limits marks a credit snapshot older than 1h as stale", () => {
+  const credits = new MemCredits();
+  credits.putCreditSnapshot({
+    spent: 5,
+    cap: 50,
+    currency: "€",
+    pct: 10,
+    resetAt: NOW + 1000,
+    scrapedAt: NOW - 2 * 3600_000,
+  });
+  const svc = new UsageLimitsService(fakeIndex(0), new MemCaps(), new StubProbe(null), credits);
+  expect(svc.limits(NOW).credits!.stale).toBe(true);
+});
+
+test("limits drops a credit snapshot whose monthly budget already reset", () => {
+  const credits = new MemCredits();
+  credits.putCreditSnapshot({
+    spent: 5,
+    cap: 50,
+    currency: "€",
+    pct: 10,
+    resetAt: NOW - 1, // already rolled over
+    scrapedAt: NOW,
+  });
+  const svc = new UsageLimitsService(fakeIndex(0), new MemCaps(), new StubProbe(null), credits);
+  expect(svc.limits(NOW).credits).toBeNull();
+});
+
+test("limits keeps a credit snapshot with an unparseable (null) resetAt", () => {
+  const credits = new MemCredits();
+  credits.putCreditSnapshot({
+    spent: 5,
+    cap: 50,
+    currency: "€",
+    pct: 10,
+    resetAt: null, // can't be known to have rolled over → not post-reset
+    scrapedAt: NOW,
+  });
+  const svc = new UsageLimitsService(fakeIndex(0), new MemCaps(), new StubProbe(null), credits);
+  const c = svc.limits(NOW).credits!;
+  expect(c).not.toBeNull();
+  expect(c.resetAt).toBeNull();
+});
+
+test("limits returns null credits when nothing has been persisted", () => {
+  const svc = new UsageLimitsService(
+    fakeIndex(0),
+    new MemCaps(),
+    new StubProbe(null),
+    new MemCredits(),
+  );
+  expect(svc.limits(NOW).credits).toBeNull();
+});
+
+const mkLimits = (weekPct: number | null): UsageLimits => ({
+  session5h: null,
+  week: weekPct === null ? null : { pct: weekPct, resetAt: NOW },
+  credits: null,
+  stale: false,
+  calibratedAt: NOW,
+});
+
+test("calibrateDelay: week pct above watch threshold escalates cadence", () => {
+  expect(calibrateDelay(mkLimits(95))).toBe(CREDIT_WATCH_INTERVAL_MS);
+});
+
+test("calibrateDelay: week pct exactly at threshold escalates (>= boundary)", () => {
+  expect(calibrateDelay(mkLimits(90))).toBe(CREDIT_WATCH_INTERVAL_MS);
+});
+
+test("calibrateDelay: week pct below threshold stays daily", () => {
+  expect(calibrateDelay(mkLimits(50))).toBe(CALIBRATE_INTERVAL_MS);
+});
+
+test("calibrateDelay: null week window stays daily", () => {
+  expect(calibrateDelay(mkLimits(null))).toBe(CALIBRATE_INTERVAL_MS);
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1115,5 +1115,18 @@
   "automation_default_model_inherit": "Erben (globaler Standard)",
   "automation_default_model_hint": "Überschreibt das globale Standardmodell (Einstellungen → Sitzung) für dieses Repository. Erben übernimmt die globale Einstellung; eine explizite Wahl wählt den Modell-Picker bei neuen Aufgaben vor und steuert autonome Drain-/Autopilot-Starts in diesem Repository.",
   "feat_repo_default_model_title": "Standardmodell pro Repository",
-  "feat_repo_default_model_body": "Lege im Automatisierungs-Panel eines Repositorys ein Standardmodell fest — es überschreibt den globalen Standard und wählt den Modell-Picker bei neuen Aufgaben vor. Auf Erben belassen, um weiter der globalen Einstellung zu folgen."
+  "feat_repo_default_model_body": "Lege im Automatisierungs-Panel eines Repositorys ein Standardmodell fest — es überschreibt den globalen Standard und wählt den Modell-Picker bei neuen Aufgaben vor. Auf Erben belassen, um weiter der globalen Einstellung zu folgen.",
+  "drain_paused_credits": "Pausiert: Zusatzguthaben wird verbraucht",
+  "topbar_credits_period": "Zusatzguthaben",
+  "topbar_credits_amount": "{spent} von {cap} verbraucht",
+  "topbar_credits_age": "abgerufen vor {age}",
+  "topbar_credits_stale": "Snapshot veraltet — für Live-Verbrauch aktualisieren",
+  "topbar_credits_alert_aria": "Zusatzguthaben in Nutzung: {amount}",
+  "topbar_credits_refresh": "Aktualisieren",
+  "settings_extra_credits_ceiling_title": "Ausgabenlimit für Zusatzguthaben",
+  "settings_extra_credits_ceiling_hint": "Pausiert autonomen Drain und Autopilot, sobald die gemessenen Pay-as-you-go-Ausgaben für Zusatzguthaben (echtes Geld über dein Abo hinaus) diesen Betrag in deiner Kontowährung übersteigen. 0 pausiert bei jeglichen Zusatzguthaben-Ausgaben.",
+  "settings_extra_credits_ceiling_label": "Pausieren, wenn Ausgaben übersteigen",
+  "settings_extra_credits_ceiling_save_failed": "Ausgabenlimit für Zusatzguthaben konnte nicht geändert werden. Erneut versuchen.",
+  "feat_extra_credits_title": "Anzeige für Zusatzguthaben",
+  "feat_extra_credits_body": "Wenn du kostenpflichtige nutzungsbasierte Abrechnung aktivierst, zeigt die obere Leiste jetzt eine CR-Anzeige mit dem verbrauchten Betrag gegen dein monatliches Limit — und hebt sie hervor, sobald echte Kosten anfallen. Öffne sie für Betrag, Reset und Snapshot-Alter, oder aktualisiere sie bei Bedarf."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1115,5 +1115,18 @@
   "automation_default_model_inherit": "Inherit (global default)",
   "automation_default_model_hint": "Overrides the global default model (Settings → Session) for this repo. Inherit defers to the global setting; an explicit choice preselects the New Task picker and drives autonomous drain/autopilot spawns in this repo.",
   "feat_repo_default_model_title": "Per-repo default model",
-  "feat_repo_default_model_body": "Set a default model per repository in its automation panel — it overrides the global default and preselects the New Task picker. Leave it on Inherit to keep following the global setting."
+  "feat_repo_default_model_body": "Set a default model per repository in its automation panel — it overrides the global default and preselects the New Task picker. Leave it on Inherit to keep following the global setting.",
+  "drain_paused_credits": "Paused: spending extra credits",
+  "topbar_credits_period": "Extra credits",
+  "topbar_credits_amount": "{spent} of {cap} spent",
+  "topbar_credits_age": "scraped {age} ago",
+  "topbar_credits_stale": "snapshot stale — refresh for live spend",
+  "topbar_credits_alert_aria": "Extra credits in use: {amount}",
+  "topbar_credits_refresh": "Refresh",
+  "settings_extra_credits_ceiling_title": "Extra-credit spend ceiling",
+  "settings_extra_credits_ceiling_hint": "Pauses autonomous drain and autopilot once measured pay-as-you-go extra-credit spend (real money beyond your subscription) exceeds this amount, in your account currency. 0 pauses on any extra-credit spend at all.",
+  "settings_extra_credits_ceiling_label": "Pause when spend exceeds",
+  "settings_extra_credits_ceiling_save_failed": "Couldn't change the extra-credit spend ceiling. Retry.",
+  "feat_extra_credits_title": "Extra-credit overage gauge",
+  "feat_extra_credits_body": "When you opt into paid pay-as-you-go usage, the top bar now shows a CR gauge with money spent against your monthly cap — and flags it the moment real spend starts. Open it to see the amount, reset, and snapshot age, or refresh on demand."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -260,6 +260,14 @@ export const putPlanReviewCyclesCap = (cap: number): Promise<{ planReviewCyclesC
 export const putDefaultModel = (model: string): Promise<{ defaultModel: string }> =>
   patchSettings<{ defaultModel: string }>({ defaultModel: model });
 
+// Persist the account-wide extra-credit (paid overage) spend ceiling. Auto-drain/autopilot
+// pauses when measured spend strictly exceeds it; 0 = pause on any spend. The server
+// validates a non-negative number and returns the stored value.
+export const putExtraCreditsDrainCeiling = (
+  ceiling: number,
+): Promise<{ extraCreditsDrainCeiling: number }> =>
+  patchSettings({ extraCreditsDrainCeiling: ceiling });
+
 export async function listDirs(path?: string): Promise<DirListing> {
   const q = path ? `?path=${encodeURIComponent(path)}` : "";
   const r = await fetch(`/api/fs/dirs${q}`);
@@ -311,6 +319,12 @@ export async function getDiff(id: string): Promise<DiffResult> {
 export async function getUsageLimits(): Promise<UsageLimits> {
   const r = await fetch("/api/usage/limits");
   if (!r.ok) throw await failed(r, "limits");
+  return r.json();
+}
+
+export async function refreshUsage(): Promise<UsageLimits> {
+  const r = await fetch("/api/usage/refresh", { method: "POST" });
+  if (!r.ok) throw await failed(r, "refresh");
   return r.json();
 }
 

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -8,6 +8,7 @@
     putPrReviewCyclesCap,
     putPlanReviewCyclesCap,
     putDefaultModel,
+    putExtraCreditsDrainCeiling,
     listDirs,
   } from "$lib/api";
   import { MODELS, PREMIUM_MODELS, type DirListing, type HerdrUpdateStatus } from "$lib/types";
@@ -134,6 +135,9 @@
   let defaultModelSaved = "auto"; // last server-confirmed value, for revert on failure
   let defaultModelBusy = $state(false);
   const isPremiumModel = $derived(PREMIUM_MODELS.includes(defaultModel));
+  let extraCreditsCeiling = $state(0); // account-wide extra-credit spend ceiling (0 = pause on any)
+  let extraCreditsCeilingSaved = 0; // last server-confirmed value, for revert on failure
+  let extraCreditsBusy = $state(false);
 
   async function savePrReviewCycles() {
     if (prRcyBusy) return;
@@ -209,6 +213,32 @@
       });
     } finally {
       defaultModelBusy = false;
+    }
+  }
+
+  async function saveExtraCreditsCeiling() {
+    if (extraCreditsBusy) return;
+    extraCreditsBusy = true;
+    // Clamp to a non-negative number client-side (the server validates too); an
+    // empty/NaN field falls back to 0 rather than posting garbage.
+    const n = Number(extraCreditsCeiling);
+    const clamped = Number.isFinite(n) && n >= 0 ? n : 0;
+    extraCreditsCeiling = clamped;
+    try {
+      const r = await putExtraCreditsDrainCeiling(clamped);
+      extraCreditsCeiling = r.extraCreditsDrainCeiling;
+      extraCreditsCeilingSaved = r.extraCreditsDrainCeiling;
+    } catch {
+      // revert to the last server-confirmed value; surface the failure as a persistent,
+      // deduped alert so the no-op never looks like a save.
+      extraCreditsCeiling = extraCreditsCeilingSaved;
+      toasts.info(m.settings_extra_credits_ceiling_save_failed(), {
+        key: "extra-credits-ceiling",
+        duration: null,
+        alert: true,
+      });
+    } finally {
+      extraCreditsBusy = false;
     }
   }
 
@@ -295,6 +325,8 @@
       planReviewCyclesSaved = s.planReviewCyclesCap;
       defaultModel = s.defaultModel;
       defaultModelSaved = s.defaultModel;
+      extraCreditsCeiling = s.extraCreditsDrainCeiling;
+      extraCreditsCeilingSaved = s.extraCreditsDrainCeiling;
       await browse(s.repoRoot);
     } catch {
       await browse();
@@ -553,6 +585,23 @@
         {#if isPremiumModel}
           <p class="premium-warn">{m.settings_default_model_premium_warning()}</p>
         {/if}
+      </div>
+      <div class="rc">
+        <span class="micro">{m.settings_extra_credits_ceiling_title()}</span>
+        <p class="hint">{m.settings_extra_credits_ceiling_hint()}</p>
+        <label class="cycles">
+          <span class="cycles-label">{m.settings_extra_credits_ceiling_label()}</span>
+          <input
+            class="num"
+            type="number"
+            min="0"
+            step="1"
+            disabled={extraCreditsBusy}
+            bind:value={extraCreditsCeiling}
+            aria-label={m.settings_extra_credits_ceiling_title()}
+            onchange={saveExtraCreditsCeiling}
+          />
+        </label>
       </div>
       <div bind:this={steersEl}><SteersEditor /></div>
     </div>

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1,11 +1,22 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
-import TopBar from "./TopBar.svelte";
-import TopBarLimitsHarness from "./TopBarLimitsHarness.svelte";
 import "../../app.css";
 import type { Session, UsageLimits, UpdateStatus, HerdrUpdateStatus } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
+
+// Mock api so the manual /usage refresh path never fires a real network call —
+// individual tests stub refreshUsage's resolution/rejection per case.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  // Default: resolve (success). The value is ignored by the component (the gauge
+  // self-updates via the ln WS frame); the fail-closed test overrides with a reject.
+  return { ...actual, refreshUsage: vi.fn(async () => undefined) };
+});
+
+const { default: TopBar } = await import("./TopBar.svelte");
+const { default: TopBarLimitsHarness } = await import("./TopBarLimitsHarness.svelte");
+const { refreshUsage } = await import("$lib/api");
 
 // Deterministic measurement: pin the bar's font so CI (no Berkeley Mono) and
 // local agree. Mounted into a full-width container; widths come from page.viewport.
@@ -63,6 +74,7 @@ const allBadges = {
 const fullLimits: UsageLimits = {
   session5h: { pct: 88, resetAt: 1_700_003_600_000 },
   week: { pct: 64, resetAt: 1_700_600_000_000 },
+  credits: null,
   stale: false,
   calibratedAt: 1_700_000_000_000,
 };
@@ -687,5 +699,169 @@ describe("TopBar — idle gear opens Settings directly", () => {
     await expect
       .element(page.getByRole("menuitem", { name: m.settings_title() }))
       .not.toBeInTheDocument();
+  });
+});
+
+describe("TopBar — CR extra-credit gauge", () => {
+  type Credit = NonNullable<UsageLimits["credits"]>;
+  function limitsWithCredit(credit: Partial<Credit>): UsageLimits {
+    return {
+      session5h: { pct: 88, resetAt: 1_700_003_600_000 },
+      week: { pct: 64, resetAt: 1_700_600_000_000 },
+      stale: false,
+      calibratedAt: 1_700_000_000_000,
+      credits: {
+        pct: 0,
+        spent: 0.29,
+        cap: 50,
+        currency: "€",
+        resetAt: 1_702_600_000_000,
+        scrapedAt: 1_700_000_000_000 - 5 * 60_000, // 5m before nowMs
+        stale: false,
+        ...credit,
+      },
+    };
+  }
+
+  async function renderDesktop(limits: UsageLimits | null) {
+    await page.viewport(1436, 900);
+    document.body.style.width = "1436px";
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      ...sessionsProp(0),
+      limits,
+    });
+    const hud = document.querySelector<HTMLElement>(".hud");
+    expect(hud, "TopBar .hud mounted").not.toBeNull();
+    return hud!;
+  }
+
+  it("renders the CR gauge on desktop when credits are present", async () => {
+    const hud = await renderDesktop(limitsWithCredit({}));
+    const cr = hud.querySelector<HTMLElement>(".credit-gauge");
+    expect(cr, "CR gauge present").not.toBeNull();
+    expect(cr!.textContent ?? "", "CR label + amount").toContain("CR");
+    expect(cr!.textContent ?? "", "amount text").toContain("€0.29");
+  });
+
+  it("does NOT render the CR gauge when credits is null", async () => {
+    const hud = await renderDesktop(fullLimits); // fullLimits.credits === null
+    expect(hud.querySelector(".credit-gauge"), "no CR gauge without credits").toBeNull();
+  });
+
+  it("does NOT render anything credit-related when limits is null", async () => {
+    const hud = await renderDesktop(null);
+    expect(hud.querySelector(".credit-gauge"), "no CR gauge without limits").toBeNull();
+  });
+
+  it("flags the alert state when spend > 0 on a fresh snapshot", async () => {
+    const hud = await renderDesktop(limitsWithCredit({ spent: 0.29, stale: false }));
+    const cr = hud.querySelector<HTMLElement>(".credit-gauge");
+    expect(cr!.classList.contains("alert"), "CR gauge alert when overspending").toBe(true);
+  });
+
+  it("does NOT flag alert when spend is zero", async () => {
+    const hud = await renderDesktop(limitsWithCredit({ spent: 0, stale: false }));
+    const cr = hud.querySelector<HTMLElement>(".credit-gauge");
+    expect(cr!.classList.contains("alert"), "no alert without spend").toBe(false);
+  });
+
+  it("renders muted/stale (no alert) on a stale snapshot even with spend", async () => {
+    const hud = await renderDesktop(limitsWithCredit({ spent: 5, stale: true }));
+    const cr = hud.querySelector<HTMLElement>(".credit-gauge");
+    expect(cr!.classList.contains("stale"), "CR gauge stale class").toBe(true);
+    expect(cr!.classList.contains("alert"), "stale never alerts").toBe(false);
+  });
+
+  it("shows the amount + age text in the hover detail popover", async () => {
+    const hud = await renderDesktop(limitsWithCredit({}));
+    const wrap = hud.querySelector<HTMLElement>(".gauges-wrap");
+    expect(wrap, "gauges-wrap present").not.toBeNull();
+    wrap!.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await nextFrame();
+    const detail = hud.querySelector<HTMLElement>(".credit-detail");
+    expect(detail, "credit detail rendered on hover").not.toBeNull();
+    const txt = detail!.textContent ?? "";
+    expect(txt, "amount line").toContain("€0.29");
+    // 2-decimal precision, aligned with the server push copy (src/push.ts extraCreditsBody)
+    expect(txt, "cap").toContain("€50.00");
+    expect(txt, "snapshot age (5m)").toContain(m.topbar_credits_age({ age: "5m" }));
+    // refresh control present
+    expect(detail!.querySelector(".credit-refresh"), "refresh button present").not.toBeNull();
+  });
+
+  it("shows the stale note in the popover for a stale snapshot", async () => {
+    const hud = await renderDesktop(limitsWithCredit({ stale: true }));
+    const wrap = hud.querySelector<HTMLElement>(".gauges-wrap");
+    wrap!.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await nextFrame();
+    const detail = hud.querySelector<HTMLElement>(".credit-detail");
+    expect(detail!.textContent ?? "", "stale note").toContain(m.topbar_credits_stale());
+  });
+
+  it("fail-closed: a rejected refresh surfaces the error state, not silent success", async () => {
+    // The house-rule fail-closed path: refreshUsage() rejects → the popover must show
+    // its visible error state (role=alert / .credit-error / retry message) so the user
+    // sees the refresh FAILED rather than it looking like a success.
+    vi.mocked(refreshUsage).mockRejectedValueOnce(new Error("network down"));
+    const hud = await renderDesktop(limitsWithCredit({}));
+    const wrap = hud.querySelector<HTMLElement>(".gauges-wrap");
+    wrap!.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await nextFrame();
+    const detail = hud.querySelector<HTMLElement>(".credit-detail");
+    expect(detail, "credit detail rendered on hover").not.toBeNull();
+    // No error before the refresh is attempted.
+    expect(detail!.querySelector(".credit-error"), "no error before refresh").toBeNull();
+
+    const refreshBtn = detail!.querySelector<HTMLButtonElement>(".credit-refresh");
+    expect(refreshBtn, "refresh button present").not.toBeNull();
+    refreshBtn!.click();
+
+    // The rejection sets refreshError → the error alert appears. Poll for the rAF/
+    // microtask settle so a genuinely-missing error state still fails the test.
+    await vi.waitFor(() => {
+      const err = hud.querySelector<HTMLElement>(".credit-error");
+      expect(err, "error state appears on rejected refresh").not.toBeNull();
+      expect(err!.getAttribute("role"), "error is an alert").toBe("alert");
+      expect(err!.textContent ?? "", "retry message").toContain(m.common_retry());
+    });
+    expect(vi.mocked(refreshUsage), "refresh was attempted").toHaveBeenCalledTimes(1);
+  });
+
+  it("touch: the collapsed credits-only button carries the alert class when overspending", async () => {
+    // On touch the gauges collapse to one button; with no usage windows but extra
+    // spend present it's the credits-only collapsed button, which must read as alert.
+    await page.viewport(1000, 900);
+    document.body.style.width = "1000px";
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS["touch-desktop"],
+      ...sessionsProp(0),
+      // credits-only: usage windows null so `hotter` is absent → credits-only branch.
+      limits: {
+        session5h: null,
+        week: null,
+        stale: false,
+        calibratedAt: 1_700_000_000_000,
+        credits: {
+          pct: 0,
+          spent: 0.29,
+          cap: 50,
+          currency: "€",
+          resetAt: 1_702_600_000_000,
+          scrapedAt: 1_700_000_000_000 - 5 * 60_000,
+          stale: false,
+        },
+      } as unknown as UsageLimits,
+    });
+    const hud = document.querySelector<HTMLElement>(".hud");
+    const btn = hud!.querySelector<HTMLButtonElement>(".gauge-btn");
+    expect(btn, "collapsed gauge button present").not.toBeNull();
+    expect(btn!.classList.contains("alert"), "collapsed button alerts when overspending").toBe(
+      true,
+    );
   });
 });

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import type { Session, UsageLimits, UpdateStatus, HerdrUpdateStatus } from "$lib/types";
-  import { formatReset } from "$lib/format";
+  import { formatReset, relativeAge } from "$lib/format";
   import { displayStatus } from "$lib/display-status";
-  import { gaugeList, hotterGauge, type GaugeKey } from "./usage-gauges";
+  import { gaugeList, hotterGauge, overspending, type GaugeKey } from "./usage-gauges";
+  import { refreshUsage } from "$lib/api";
   import { m } from "$lib/paraglide/messages";
   import { modeOf, topBarPlan, badgeCount } from "./top-bar-layout";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
@@ -204,6 +205,48 @@
   // breakdown — including reset times — through a tap popover instead.
   const gauges = $derived(gaugeList(limits));
   const hotter = $derived(hotterGauge(limits));
+
+  // Paid extra-credit overage. Rendered as a distinct CR element (NOT a gaugeList
+  // entry — its window shape carries no credit fields, and a 0%-pct credit gauge
+  // must never become the "hotter" collapsed gauge). Null → render nothing.
+  const credits = $derived(limits?.credits ?? null);
+  const overspend = $derived(overspending(limits));
+  // Bar fill is spent/cap (NOT pct — pct rounds to 0 while money is already spent).
+  const creditFill = $derived(
+    credits && credits.cap > 0 ? Math.min(Math.max(credits.spent / credits.cap, 0), 1) : 0,
+  );
+  // Currency + numbers are passthrough data, NOT translated. Amounts use 2 decimals to match the
+  // server push copy (src/push.ts extraCreditsBody) so the gauge and the notification read identically.
+  const creditAmount = $derived(
+    credits
+      ? `${credits.currency}${credits.spent.toFixed(2)} / ${credits.currency}${credits.cap.toFixed(2)}`
+      : "",
+  );
+  // Alert hue: amber is the design system's caution token (reused by the usage
+  // gauges' hot state + the update badge). pct is 0 here so gaugeColor(pct) can't
+  // drive it — overspend keys off real spend instead. Stale → muted; idle → neutral.
+  const creditColor = $derived(
+    credits?.stale ? "var(--color-muted)" : overspend ? "var(--color-amber)" : "var(--color-muted)",
+  );
+
+  // Refresh: POST /api/usage/refresh; the server's calibrate emit bridges back to the
+  // client `ln` WS frame, so the gauge self-updates — we ignore the returned value.
+  // Fail closed: a rejected refresh sets an error flag so it never looks like success.
+  let refreshing = $state(false);
+  let refreshError = $state(false);
+  async function doRefresh() {
+    if (refreshing) return;
+    refreshing = true;
+    refreshError = false;
+    try {
+      await refreshUsage();
+    } catch {
+      refreshError = true;
+    } finally {
+      refreshing = false;
+    }
+  }
+
   let popoverOpen = $state(false);
   // Desktop (fine pointer): hovering the inline gauges opens a richer detail
   // card — full window names, wide bars, percentages and reset times — in place
@@ -213,8 +256,8 @@
   let detailOpen = $state(false);
   let gaugeWrap = $state<HTMLElement | null>(null);
   $effect(() => {
-    // close the popover when it can no longer be opened (gauge gone / switched off touch)
-    if (!touch || !hotter) popoverOpen = false;
+    // close the popover when it can no longer be opened (no gauge AND no credit, or off touch)
+    if (!touch || (!hotter && !credits)) popoverOpen = false;
   });
 
   // The gear adapts to herd state. When the herd is idle (haltable === 0) a click
@@ -314,6 +357,74 @@
 </script>
 
 <svelte:window onkeydown={dismissOnEscape} onclick={dismissOnOutside} />
+
+<!-- CR credit gauge: the compact inline bar (label + bar + amount), reused across the
+     desktop .gauges row and the desktop hover popover. Mirrors the .gauge recipe. -->
+{#snippet creditGauge()}
+  {#if credits}
+    <div
+      class="gauge credit-gauge"
+      class:stale={credits.stale}
+      class:alert={overspend}
+      aria-label={overspend
+        ? m.topbar_credits_alert_aria({ amount: creditAmount })
+        : `${m.topbar_credits_period()} · ${creditAmount}`}
+    >
+      <span class="g-label micro">CR</span>
+      <span class="g-bar"
+        ><span class="g-fill" style="transform:scaleX({creditFill});background:{creditColor}"
+        ></span></span
+      >
+      <span class="g-pct credit-amount" style="color:{creditColor}">{creditAmount}</span>
+    </div>
+  {/if}
+{/snippet}
+
+<!-- CR credit detail block for the popovers: full name, wide bar + amount, reset,
+     snapshot age, stale note, and an on-demand refresh button. -->
+{#snippet creditDetail()}
+  {#if credits}
+    <div class="credit-detail" class:stale={credits.stale}>
+      <div class="gp-head">
+        <span class="gp-period">{m.topbar_credits_period()}</span>
+        <span class="g-pct credit-amount" style="color:{creditColor}">{creditAmount}</span>
+      </div>
+      <span class="g-bar g-bar-wide"
+        ><span class="g-fill" style="transform:scaleX({creditFill});background:{creditColor}"
+        ></span></span
+      >
+      <div class="credit-sub micro">
+        {m.topbar_credits_amount({
+          spent: `${credits.currency}${credits.spent.toFixed(2)}`,
+          cap: `${credits.currency}${credits.cap.toFixed(2)}`,
+        })}
+      </div>
+      {#if credits.resetAt !== null}
+        <div class="gauge-pop-reset micro">
+          {m.topbar_gauge_reset({ reset: formatReset(credits.resetAt, nowMs) })}
+        </div>
+      {/if}
+      <div class="gauge-pop-reset micro">
+        {m.topbar_credits_age({ age: relativeAge(credits.scrapedAt, nowMs) })}
+      </div>
+      {#if credits.stale}
+        <div class="credit-stale micro">{m.topbar_credits_stale()}</div>
+      {/if}
+      <button
+        type="button"
+        class="credit-refresh micro"
+        disabled={refreshing}
+        aria-busy={refreshing}
+        onclick={doRefresh}
+      >
+        {refreshing ? m.common_loading() : m.topbar_credits_refresh()}
+      </button>
+      {#if refreshError}
+        <div class="credit-error micro" role="alert">{m.common_retry()}</div>
+      {/if}
+    </div>
+  {/if}
+{/snippet}
 
 <div class="hud bracket" class:mobile bind:this={hudEl}>
   <div class="logo">SHEP<b>HERD</b></div>
@@ -445,31 +556,59 @@
       </button>
     {/if}
     {#if touch}
-      {#if hotter}
-        <!-- touch: collapse to the hotter window; tap for the full breakdown -->
+      {#if hotter || credits}
+        <!-- touch: collapse to the hotter window (or the CR gauge when credits are the
+             only signal); tap for the full breakdown. The collapsed button carries an
+             alert state while extra credits are being spent. -->
         <div class="gauge-wrap" bind:this={gaugeWrap}>
-          <button
-            class="gauge gauge-btn"
-            class:stale={limits?.stale}
-            type="button"
-            aria-haspopup="dialog"
-            aria-expanded={popoverOpen}
-            aria-label={m.topbar_gauge_toggle_aria({
-              period: periodLabel(hotter.label),
-              pct: hotter.w.pct,
-            })}
-            onclick={() => (popoverOpen = !popoverOpen)}
-          >
-            <span class="g-label micro">{hotter.label}</span>
-            <span class="g-bar"
-              ><span
-                class="g-fill"
-                style="transform:scaleX({Math.min(Math.max(hotter.w.pct, 0), 100) /
-                  100});background:{gaugeColor(hotter.w.pct)}"
-              ></span></span
+          {#if hotter}
+            <button
+              class="gauge gauge-btn"
+              class:stale={limits?.stale}
+              class:alert={overspend}
+              type="button"
+              aria-haspopup="dialog"
+              aria-expanded={popoverOpen}
+              aria-label={m.topbar_gauge_toggle_aria({
+                period: periodLabel(hotter.label),
+                pct: hotter.w.pct,
+              })}
+              onclick={() => (popoverOpen = !popoverOpen)}
             >
-            <span class="g-pct" style="color:{gaugeColor(hotter.w.pct)}">{hotter.w.pct}%</span>
-          </button>
+              <span class="g-label micro">{hotter.label}</span>
+              <span class="g-bar"
+                ><span
+                  class="g-fill"
+                  style="transform:scaleX({Math.min(Math.max(hotter.w.pct, 0), 100) /
+                    100});background:{gaugeColor(hotter.w.pct)}"
+                ></span></span
+              >
+              <span class="g-pct" style="color:{gaugeColor(hotter.w.pct)}">{hotter.w.pct}%</span>
+            </button>
+          {:else}
+            <!-- credits-only: no usage windows scraped, but extra spend exists -->
+            <button
+              class="gauge gauge-btn"
+              class:stale={credits?.stale}
+              class:alert={overspend}
+              type="button"
+              aria-haspopup="dialog"
+              aria-expanded={popoverOpen}
+              aria-label={overspend
+                ? m.topbar_credits_alert_aria({ amount: creditAmount })
+                : `${m.topbar_credits_period()} · ${creditAmount}`}
+              onclick={() => (popoverOpen = !popoverOpen)}
+            >
+              <span class="g-label micro">CR</span>
+              <span class="g-bar"
+                ><span
+                  class="g-fill"
+                  style="transform:scaleX({creditFill});background:{creditColor}"
+                ></span></span
+              >
+              <span class="g-pct credit-amount" style="color:{creditColor}">{creditAmount}</span>
+            </button>
+          {/if}
           {#if popoverOpen}
             <div
               class="gauge-pop"
@@ -496,11 +635,12 @@
                   {m.topbar_gauge_reset({ reset: formatReset(g.w.resetAt, nowMs) })}
                 </div>
               {/each}
+              {@render creditDetail()}
             </div>
           {/if}
         </div>
       {/if}
-    {:else if gauges.length}
+    {:else if gauges.length || credits}
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="gauges-wrap"
@@ -521,6 +661,7 @@
               <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
             </div>
           {/each}
+          {@render creditGauge()}
         </div>
         {#if detailOpen}
           <div class="gauge-pop gauge-pop-desk" role="tooltip" class:stale={limits?.stale}>
@@ -545,6 +686,11 @@
                 </div>
               </div>
             {/each}
+            {#if credits}
+              <div class="gp-window">
+                {@render creditDetail()}
+              </div>
+            {/if}
           </div>
         {/if}
       </div>
@@ -1000,6 +1146,66 @@
     font-size: var(--fs-meta);
     min-width: 30px;
     text-align: right;
+  }
+  /* CR credit gauge: reuses the .gauge recipe. The amount text is wider than a
+     percentage, so it gets a larger min-width and rides on the same tabular nums. */
+  .credit-gauge.alert .g-label {
+    color: var(--color-amber);
+  }
+  .credit-gauge.stale {
+    opacity: 0.5;
+  }
+  .credit-amount {
+    min-width: max-content;
+    white-space: nowrap;
+  }
+  /* CR collapsed touch button + popover detail when extra credits are being spent. */
+  .gauge-btn.alert {
+    border-color: var(--color-amber);
+  }
+  .credit-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .credit-detail.stale {
+    opacity: 0.5;
+  }
+  .credit-sub {
+    text-transform: none;
+    letter-spacing: 0.04em;
+    color: var(--color-ink);
+  }
+  .credit-stale {
+    text-transform: none;
+    letter-spacing: 0.04em;
+    color: var(--color-amber);
+  }
+  .credit-error {
+    text-transform: none;
+    letter-spacing: 0.04em;
+    color: var(--color-red);
+  }
+  .credit-refresh {
+    align-self: flex-start;
+    margin-top: 2px;
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font: inherit;
+    font-size: var(--fs-meta);
+    text-transform: none;
+    letter-spacing: 0.04em;
+    padding: 4px 9px;
+    cursor: pointer;
+  }
+  .credit-refresh:hover:not(:disabled) {
+    background: var(--color-inset);
+  }
+  .credit-refresh:disabled {
+    cursor: default;
+    opacity: 0.5;
   }
   /* Touch: a single collapsed gauge rendered as a tappable button. */
   .gauge-wrap {

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -111,6 +111,12 @@ describe("pausedText", () => {
     expect(text.length).toBeGreaterThan(0);
     expect(text).not.toBe(pausedText(drain({ paused: true, reason: null })));
   });
+  it("maps credits to drain_paused_credits", () => {
+    const text = pausedText(drain({ paused: true, reason: "credits", detail: "0.29" }));
+    expect(text.length).toBeGreaterThan(0);
+    // must differ from the generic fallback so it's actually the correct branch
+    expect(text).not.toBe(pausedText(drain({ paused: true, reason: null })));
+  });
   it("does not throw when detail is null", () => {
     expect(() =>
       pausedText(drain({ paused: true, reason: "blocked", detail: null })),

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -148,6 +148,8 @@ export function pausedText(d: DrainStatus): string {
       return m.drain_paused_error({ desig });
     case "usage":
       return m.drain_paused_usage({ pct: desig });
+    case "credits":
+      return m.drain_paused_credits();
     default:
       return m.drain_paused_generic();
   }

--- a/ui/src/lib/components/usage-gauges.test.ts
+++ b/ui/src/lib/components/usage-gauges.test.ts
@@ -1,12 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { gaugeList, hotterGauge } from "./usage-gauges";
-import type { UsageLimits, LimitWindow } from "../types";
+import { gaugeList, hotterGauge, overspending } from "./usage-gauges";
+import type { UsageLimits, LimitWindow, CreditWindow } from "../types";
 
 function w(pct: number, resetAt = 0): LimitWindow {
   return { pct, resetAt };
 }
 function limits(over: Partial<UsageLimits>): UsageLimits {
-  return { session5h: null, week: null, stale: false, calibratedAt: null, ...over };
+  return { session5h: null, week: null, credits: null, stale: false, calibratedAt: null, ...over };
+}
+function credit(over: Partial<CreditWindow>): CreditWindow {
+  return {
+    pct: 0,
+    spent: 0,
+    cap: 50,
+    currency: "€",
+    resetAt: null,
+    scrapedAt: 0,
+    stale: false,
+    ...over,
+  };
 }
 
 describe("gaugeList", () => {
@@ -44,5 +56,23 @@ describe("hotterGauge", () => {
   it("returns the only present window", () => {
     expect(hotterGauge(limits({ session5h: w(40) }))?.label).toBe("5H");
     expect(hotterGauge(limits({ week: w(40) }))?.label).toBe("WK");
+  });
+});
+
+describe("overspending", () => {
+  it("is true on a fresh snapshot with real spend (pct may still round to 0)", () => {
+    expect(overspending(limits({ credits: credit({ spent: 0.29, pct: 0, stale: false }) }))).toBe(
+      true,
+    );
+  });
+  it("is false when the snapshot is stale, even with spend", () => {
+    expect(overspending(limits({ credits: credit({ spent: 5, stale: true }) }))).toBe(false);
+  });
+  it("is false when nothing has been spent", () => {
+    expect(overspending(limits({ credits: credit({ spent: 0, stale: false }) }))).toBe(false);
+  });
+  it("is false when credits is null or limits is null", () => {
+    expect(overspending(limits({ credits: null }))).toBe(false);
+    expect(overspending(null)).toBe(false);
   });
 });

--- a/ui/src/lib/components/usage-gauges.ts
+++ b/ui/src/lib/components/usage-gauges.ts
@@ -25,3 +25,11 @@ export function hotterGauge(limits: UsageLimits | null): Gauge | null {
   if (!gauges.length) return null;
   return gauges.reduce((hot, g) => (g.w.pct >= hot.w.pct ? g : hot));
 }
+
+/** True when paid extra-credit spend is actually happening on a fresh snapshot — the signal that
+ *  drives the elevated alert. Keyed off `spent` (pct rounds to 0 while money is already spent) and
+ *  gated on freshness so a stale snapshot never raises a false alarm. */
+export function overspending(limits: UsageLimits | null): boolean {
+  const c = limits?.credits;
+  return !!c && !c.stale && c.spent > 0;
+}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -682,4 +682,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_repo_default_model_title",
     bodyKey: "feat_repo_default_model_body",
   },
+  {
+    // No targetId: the CR credit gauge only mounts when paid extra usage is enabled
+    // (limits.credits present), so a coachmark anchor would usually be absent —
+    // surface via the What's-New drawer only. 1.27.0 is the latest released tag, so
+    // this ships in 1.28.0: computeNewEntries only surfaces sinceVersion > lastSeen.
+    id: "extra-credits-gauge",
+    sinceVersion: "1.28.0",
+    titleKey: "feat_extra_credits_title",
+    bodyKey: "feat_extra_credits_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -47,6 +47,9 @@ export interface Settings {
   planReviewCyclesMin: number;
   /** Display-only: upper bound for planReviewCyclesCap (drives the stepper's max). */
   planReviewCyclesMax: number;
+  /** Account-wide extra-credit (paid overage) spend ceiling; drain pauses above it.
+   *  0 = pause on ANY extra-credit spend. */
+  extraCreditsDrainCeiling: number;
   /** Display-only: archived sessions older than this many days are pruned. */
   sessionRetentionDays: number;
   /** Display-only: newest archived sessions kept regardless of age. */
@@ -447,9 +450,32 @@ export interface LimitWindow {
   pct: number;
   resetAt: number;
 }
+/**
+ * Paid pay-as-you-go extra-credit overage (mirrors the server's CreditWindow).
+ * The truth signal for "running into extra credits" is `spent > 0` on a FRESH
+ * snapshot (`!stale`), NOT `pct` — pct rounds to 0 while money is already spent.
+ */
+export interface CreditWindow {
+  /** Panel's rounded % — can be 0 while real money is spent; do NOT rely on it for "is spending". */
+  pct: number;
+  /** Money spent this monthly window (e.g. 0.29). */
+  spent: number;
+  /** Monthly extra-usage budget (e.g. 50). */
+  cap: number;
+  /** Currency symbol, e.g. "€" — passed through verbatim, NOT translated. */
+  currency: string;
+  /** Monthly reset epoch ms, or null. */
+  resetAt: number | null;
+  /** When this snapshot was scraped. */
+  scrapedAt: number;
+  /** True when the snapshot is older than 1h (credits is scrape-fresh-only). */
+  stale: boolean;
+}
 export interface UsageLimits {
   session5h: LimitWindow | null;
   week: LimitWindow | null;
+  /** Paid extra-credit overage; null when extra usage is off or post-reset. */
+  credits: CreditWindow | null;
   stale: boolean;
   calibratedAt: number | null;
 }

--- a/ui/test/store.test.ts
+++ b/ui/test/store.test.ts
@@ -59,6 +59,7 @@ test("applies usage:limits", () => {
     data: {
       session5h: { pct: 12, resetAt: 1000 },
       week: { pct: 40, resetAt: 2000 },
+      credits: null,
       stale: false,
       calibratedAt: 5,
     },


### PR DESCRIPTION
## What & why

Answers "can we tell from our usage parsing if the subscription is running into extra credits, and surface it?" — **yes**. The `/usage` panel Shepherd already scrapes contains a **Usage credits** section (`€spent / €cap`) = paid pay-as-you-go overage beyond the subscription. We were capturing it but discarding it. This branch parses it and surfaces it end-to-end.

## What it does

- **Parse** the `Usage credits` section (`parseCredits` + monthly-aware `parseMonthlyReset`) — standalone scan so it isn't truncated by the section-trailer loop. Symbol-only currency match (the `0%used€` trap), spend parsed independently of the rounded pct.
- **Persist** the latest snapshot (`usage_credit` table) and expose it on `UsageLimits.credits` as a direct passthrough (no back-calc — there's no local-JSONL signal for dollars).
- **TopBar CR gauge** (always-visible when extra usage is enabled) showing `€spent / €cap`, reset, and snapshot age, with an **elevated alert** the moment any credit is spent, plus a **manual refresh** button.
- **Drain cost-guard**: auto-drain / autopilot **pauses** (`credits` hold reason) when spend exceeds a configurable, account-wide ceiling (Settings → SESSION; default 0 = pause on any spend).
- **Push notification** the first time spend crosses 0 in a monthly window (deduped per `YYYY-MM`).

## Freshness (the crux)

Credit spend is **scrape-fresh-only** (the 30s tick recomputes 5h/week from JSONL but cannot know dollars). So:
- Calibration **escalates** from daily → every 15 min once the weekly window is ≥ 90% (near the cap, where overage becomes plausible), plus the manual refresh as an escape hatch.
- The credit window carries its **own 1h staleness** (not the 2-week cap flag), and a **post-reset** snapshot is treated as `null`.
- The alert, drain guard, and notification **all gate on `!stale && spent > 0`** — never the rounded pct, never stale/post-reset data (consistent across UI `overspending()`, the drain assembly, and `attachCreditsPush`).

## Notes for the reviewer

- Billing semantics (paid overage, not granted credits) were **confirmed by the operator** before wiring the autopilot-pause + push.
- Outside the near-cap window the credit data goes stale ~1h after the daily scrape, so the guard/alert/push are dormant until the next scrape — by design; the manual refresh covers "is it happening right now?".
- i18n: 14 new EN/DE keys (parity-gated); push copy lives in the server-side `NOTIFY_TEXT` (en+de), the sanctioned exception. Feature-catalog entry `extra-credits-gauge` @ `1.28.0`.

## Verification

Root: lint ✓, `tsc --noEmit` ✓, 2252 tests ✓, fallow audit ✓, branch hygiene ✓, feature catalog ✓.
UI: `check` 0 errors ✓, `check:i18n` parity ✓, 1113 tests ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)