### PR TITLE
feat(critic): extended thinking budget for the PR critics (#604)

### DIFF
--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -15,6 +15,16 @@ import type { SessionUsage } from "./usage";
 
 const execFileAsync = promisify(execFile);
 
+/** Extended thinking budget (MAX_THINKING_TOKENS) handed to BOTH PR critic spawns — the session
+ *  critic (`review.ts`) and the standalone PR critic (`standalone-critic.ts`). They share the
+ *  #597 VERIFY prompt (grep/resolve every identifier, confirm locale parity, check callers), which
+ *  needs reasoning headroom to do cross-file checking instead of one-pass pattern-matching. 8000 is
+ *  the "think harder" tier. The plan reviewer (`plan-gate.ts`) deliberately stays unbudgeted.
+ *  A one-line tunable: worst-case ~6 critic spawns/PR (DEFAULT_CAP), so ~8–48k thinking tokens/PR.
+ *  Only takes effect on a thinking-capable resolved model (no-op otherwise — gate verified before
+ *  ship: see issue #604). */
+export const CRITIC_THINKING_TOKENS = 8000;
+
 /** Self-contained instructions for the critic agent. NOT UI chrome — never i18n'd.
  *  `diffBase` is the RESOLVED base commit (a SHA captured by computePatchId from the same fresh
  *  fetch it fingerprints), NOT a branch name — so the review diffs the identical base the

--- a/src/review.ts
+++ b/src/review.ts
@@ -16,12 +16,13 @@ import {
   shouldSkipForPatchId,
   captureUsage,
   reapRun,
+  CRITIC_THINKING_TOKENS,
   type RawVerdict,
 } from "./critic-core";
 
 // Session-agnostic critic helpers now live in ./critic-core (a forthcoming standalone-PR-critic
 // service reuses them). Re-exported here so existing importers (and tests) keep their paths.
-export { reviewPrompt, defaultComputePatchId, scopeFindings };
+export { reviewPrompt, defaultComputePatchId, scopeFindings, CRITIC_THINKING_TOKENS };
 
 /** Agent-facing steer that carries critic findings into the task PTY. NOT i18n'd. */
 function steerText(findings: string[], prNumber: number): string {
@@ -422,6 +423,8 @@ export class ReviewService {
     return readonlyReviewerArgv(
       this.deps.model ?? null,
       reviewPrompt(diffBase, session.prompt, priorFindings, authorNotes, issueBody),
+      // Extended thinking budget (#604) — reasoning headroom for the #597 cross-file VERIFY pass.
+      CRITIC_THINKING_TOKENS,
     );
   }
 

--- a/src/reviewer-argv.ts
+++ b/src/reviewer-argv.ts
@@ -13,11 +13,24 @@ import { randomUUID } from "node:crypto";
 export function readonlyReviewerArgv(
   model: string | null,
   prompt: string,
+  // Optional extended thinking budget. When set, emitted as env.MAX_THINKING_TOKENS in the
+  // --settings JSON — the ONLY knob that grants a spawned session's initial positional prompt a
+  // thinking budget (the think/ultrathink magic words do NOT fire from it), and a no-op on a
+  // non-thinking model. The PR critics pass CRITIC_THINKING_TOKENS; the plan reviewer omits it.
+  thinkingTokens?: number,
 ): { argv: string[]; sessionId: string } {
   // The reviewer's claude session id, forced so the transcript lands at a path we can
   // predict (jsonlPathFor(worktree, sessionId)) — that's how the critic's live tool-use
   // gets surfaced in the UI badge tooltip. Returned to the caller alongside the argv.
   const sessionId = randomUUID();
+  // --settings JSON, assembled as an object so the optional thinking budget folds in cleanly.
+  // disableAllHooks + enableAllProjectMcpServers are load-bearing (see the flag rationale below);
+  // env.MAX_THINKING_TOKENS is added ONLY when a budget is requested (string — env values are).
+  const settings: Record<string, unknown> = {
+    disableAllHooks: true,
+    enableAllProjectMcpServers: true,
+  };
+  if (thinkingTokens) settings.env = { MAX_THINKING_TOKENS: String(thinkingTokens) };
   const argv = [
     "claude",
     "--session-id",
@@ -36,7 +49,7 @@ export function readonlyReviewerArgv(
     // interactive "new MCP servers found" gate never renders (see the MCP block
     // below for why it's necessary AND why it is COUPLED to --safe-mode).
     "--settings",
-    '{"disableAllHooks":true,"enableAllProjectMcpServers":true}',
+    JSON.stringify(settings),
     "--disable-slash-commands",
     // MCP isolation — TWO distinct gates, handled separately.
     // (1) LOADING: a fresh `claude` startup loads MCP servers from three sources —

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -33,6 +33,7 @@ import {
   shouldSkipForPatchId,
   captureUsage,
   reapRun,
+  CRITIC_THINKING_TOKENS,
   type RawVerdict,
 } from "./critic-core";
 
@@ -326,6 +327,9 @@ export class StandalonePrCriticService {
       const { argv, sessionId: criticSessionId } = readonlyReviewerArgv(
         this.deps.model ?? null,
         prReviewPrompt(diffBase, pr.title, meta.body),
+        // Same extended thinking budget as the session critic (#604): the standalone PR critic
+        // runs the identical #597 VERIFY prompt and needs the same cross-file reasoning headroom.
+        CRITIC_THINKING_TOKENS,
       );
 
       let terminalId: string;

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { ReviewService, reviewPrompt, scopeFindings } from "../src/review";
+import { ReviewService, reviewPrompt, scopeFindings, CRITIC_THINKING_TOKENS } from "../src/review";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "../src/forge/types";
 import type { GitForge, GitState, PrComment, PrStatus } from "../src/forge/types";
 import type { Session, ReviewVerdict } from "../src/types";
@@ -333,9 +333,12 @@ test("critic spawns read-only: no skip-permissions, dontAsk + scoped allowlist",
   expect(argv).toContain("--disable-slash-commands");
   const settingsRaw = argv[argv.indexOf("--settings") + 1];
   expect(settingsRaw).toBeDefined();
+  // The session critic carries an extended thinking budget (issue #604) so it has the
+  // reasoning headroom for the #597 cross-file verification its prompt now demands.
   expect(JSON.parse(settingsRaw!)).toEqual({
     disableAllHooks: true,
     enableAllProjectMcpServers: true,
+    env: { MAX_THINKING_TOKENS: String(CRITIC_THINKING_TOKENS) },
   });
   expect(argv).toContain("--safe-mode");
 });

--- a/test/reviewer-argv.test.ts
+++ b/test/reviewer-argv.test.ts
@@ -12,6 +12,27 @@ test("--settings includes enableAllProjectMcpServers and disableAllHooks", () =>
   expect(parsed.disableAllHooks).toBe(true);
 });
 
+test("no thinkingTokens → --settings carries no env / MAX_THINKING_TOKENS", () => {
+  // The plan reviewer (and any caller that omits the budget) must NOT get a thinking
+  // budget: MAX_THINKING_TOKENS would otherwise leak into every reviewer spawn.
+  const { argv: a } = readonlyReviewerArgv(null, "some prompt");
+  const parsed = JSON.parse(a[a.indexOf("--settings") + 1]!);
+  expect(parsed.env).toBeUndefined();
+});
+
+test("thinkingTokens → --settings env.MAX_THINKING_TOKENS as a string", () => {
+  // MAX_THINKING_TOKENS is the only knob that actually grants thinking budget to a
+  // spawned session's initial positional prompt (the think/ultrathink magic words do
+  // not fire there). Env values are strings.
+  const { argv: a } = readonlyReviewerArgv(null, "some prompt", 8000);
+  const parsed = JSON.parse(a[a.indexOf("--settings") + 1]!);
+  expect(parsed.env).toEqual({ MAX_THINKING_TOKENS: "8000" });
+  // budget must not disturb the existing reviewer invariants
+  expect(parsed.disableAllHooks).toBe(true);
+  expect(parsed.enableAllProjectMcpServers).toBe(true);
+  expect(a).toContain("--safe-mode");
+});
+
 test("coupling invariant: enableAllProjectMcpServers implies --safe-mode", () => {
   const { argv: a } = readonlyReviewerArgv(null, "some prompt");
   const settingsIdx = a.indexOf("--settings");

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
 import { StandalonePrCriticService } from "../src/standalone-critic";
+import { CRITIC_THINKING_TOKENS } from "../src/critic-core";
 import { CRITIC_REVIEW_MARKER } from "../src/forge/types";
 import type { GitForge, PrReviewMeta, PullRequest } from "../src/forge/types";
 import type { PrReview } from "../src/types";
@@ -180,6 +181,11 @@ test("reviews a fresh open green regular session-less PR", async () => {
   expect(spies.started[0]!.name).toBe("pr-critic /r#7");
   expect(spies.recordedSpawns).toHaveLength(1);
   expect(spies.recordedSpawns[0]!.taskSessionId).toBe("pr:/r#7");
+  // The standalone PR critic shares the session critic's VERIFY prompt (#597), so it gets
+  // the same extended thinking budget (#604): MAX_THINKING_TOKENS in its --settings.
+  const argv = spies.started[0]!.argv;
+  const settings = JSON.parse(argv[argv.indexOf("--settings") + 1]!);
+  expect(settings.env).toEqual({ MAX_THINKING_TOKENS: String(CRITIC_THINKING_TOKENS) });
 });
 
 test("skips draft / non-green / bot PRs", async () => {


### PR DESCRIPTION
Closes #604. The separable second half of the #597 grounding fix (PR #603 shipped **prompt-only**): give the critic spawn an extended thinking budget so it has reasoning headroom to actually perform the cross-file verification the #597 prompt now demands.

## Change

- `readonlyReviewerArgv` (`src/reviewer-argv.ts`) gains an optional `thinkingTokens?` arg. The `--settings` JSON is now assembled as an object and `JSON.stringify`d; `env.MAX_THINKING_TOKENS` (string) is emitted **only when set**.
- `CRITIC_THINKING_TOKENS = 8000` (the "think harder" tier) lives in `critic-core.ts` and is passed by **both** PR critics — the session critic (`review.ts`) and the standalone repo PR critic (`standalone-critic.ts`), since both run the identical #597 `scopeAndOutputTail` VERIFY prompt.
- The **plan reviewer** (`plan-gate.ts`) stays unchanged — it omits the arg, so its `--settings` carries no `env`.

## Why `MAX_THINKING_TOKENS` (not magic words)

The `think`/`ultrathink` magic words do **not** fire from a spawned session's initial positional prompt — only `MAX_THINKING_TOKENS` does, and it no-ops on a non-thinking model.

## Gate — PASSED ✅

Built the **exact** critic argv via the real `readonlyReviewerArgv(null, prompt, 8000)` (model `null` = production path → host `claude` default; `--safe-mode`; env block) and ran it to completion in a temp repo.

- **Tested/resolved model: `claude-opus-4-8`** (the host's `claude` default when `deps.model` is null, `review.ts`) — thinking-capable.
- Transcript carried **2 genuine `"type":"thinking"` blocks** with valid cryptographic signatures (Claude Code persists thinking as type+signature, plaintext stripped; the decoded signature embeds `claude-opus-4-8`).

So the budget produces real thinking on the model the critic actually deploys.

## Cost

`DEFAULT_CAP = 3` (`review.ts`) → worst-case ~6 critic spawns/PR; at 8000 that is ~8–48k thinking tokens/PR. The budget is a one-line tunable constant (`CRITIC_THINKING_TOKENS`).

## Tests

- `reviewer-argv.test.ts`: omitted budget → no `env`/`MAX_THINKING_TOKENS`; set → `env.MAX_THINKING_TOKENS` as a string; invariants preserved.
- `review.test.ts`: session critic `--settings` carries `MAX_THINKING_TOKENS`.
- `standalone-critic.test.ts`: standalone PR critic `--settings` carries it too.

Full root suite green (2374 pass), lint clean, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)