### PR TITLE
feat(settings): high-contrast toggle on mobile for sunlight readability

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1133,5 +1133,11 @@
   "session_sandbox_egress_degraded_title": "Autonome Dateisystem-Sandbox aktiv, aber das Netzwerk-Egress-Backend ist nicht verfügbar, daher ist ausgehender Verkehr uneingeschränkt — Tokens sind exfiltrierbar. Diese Sitzung nicht überschätzen.",
   "toast_egress_drop": "Egress zu {host} blockiert",
   "feat_egress_title": "Netzwerk-Egress-Allowlist",
-  "feat_egress_body": "Autonome Agenten sind jetzt auf eine Allowlist von Hosts beschränkt (Anthropic + den Forge-Host, plus operator-Extras); alle anderen ausgehenden Verbindungen werden blockiert. Blockierte Versuche erscheinen als Inline-Warnungen. Wenn das Backend nicht verfügbar ist, erscheint ein sichtbares Warn-Badge, damit klar ist, dass die Sitzung mit uneingeschränktem Netzwerk läuft."
+  "feat_egress_body": "Autonome Agenten sind jetzt auf eine Allowlist von Hosts beschränkt (Anthropic + den Forge-Host, plus operator-Extras); alle anderen ausgehenden Verbindungen werden blockiert. Blockierte Versuche erscheinen als Inline-Warnungen. Wenn das Backend nicht verfügbar ist, erscheint ein sichtbares Warn-Badge, damit klar ist, dass die Sitzung mit uneingeschränktem Netzwerk läuft.",
+  "settings_contrast_title": "Hoher Kontrast",
+  "settings_contrast_hint": "Hebt jedes Text- und Rahmenpaar auf WCAG AAA — für bessere Lesbarkeit bei Sonnenlicht und im Freien. Wirkt zusätzlich zum hellen oder dunklen Design oben.",
+  "settings_contrast_on": "Hoher Kontrast an",
+  "settings_contrast_off": "Hoher Kontrast aus",
+  "feat_mobile_contrast_title": "Hoher Kontrast auf dem Handy",
+  "feat_mobile_contrast_body": "Einstellungen → Gerät führt jetzt den Schalter für hohen Kontrast direkt neben dem Hell/Dunkel-Umschalter — so hebst du die Lesbarkeit auf dem Handy auf WCAG AAA. Gemacht fürs Steuern von Sessions draußen bei hellem Sonnenlicht."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1133,5 +1133,11 @@
   "session_sandbox_egress_degraded_title": "Autonomous filesystem sandbox active, but the network-egress backend is unavailable, so outbound is unrestricted — tokens are exfiltratable. Don't over-trust this run.",
   "toast_egress_drop": "Blocked egress to {host}",
   "feat_egress_title": "Network egress allowlist",
-  "feat_egress_body": "Autonomous agents are now confined to an allowlist of hosts (Anthropic + the forge, plus operator extras); all other outbound connections are blocked. Blocked attempts surface as inline alerts. When the backend is unavailable, a visible warning badge appears so you know the session is running with unrestricted network."
+  "feat_egress_body": "Autonomous agents are now confined to an allowlist of hosts (Anthropic + the forge, plus operator extras); all other outbound connections are blocked. Blocked attempts surface as inline alerts. When the backend is unavailable, a visible warning badge appears so you know the session is running with unrestricted network.",
+  "settings_contrast_title": "High contrast",
+  "settings_contrast_hint": "Boosts every text and border pair to WCAG AAA — for readability in bright sunlight and outdoors. Applies on top of the dark or light theme above.",
+  "settings_contrast_on": "High contrast on",
+  "settings_contrast_off": "High contrast off",
+  "feat_mobile_contrast_title": "High contrast on mobile",
+  "feat_mobile_contrast_body": "Settings → Device now carries the high-contrast toggle alongside the light/dark switch, so you can crank readability to WCAG AAA right on your phone — built for steering sessions outdoors in bright sunlight."
 }

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -629,6 +629,22 @@
           {/each}
         </div>
       </div>
+      <div class="contrast-row">
+        <span class="micro">{m.settings_contrast_title()}</span>
+        <p class="hint">{m.settings_contrast_hint()}</p>
+        <button
+          type="button"
+          class="toggle"
+          role="switch"
+          aria-checked={theme.contrast}
+          onclick={() => theme.toggleContrast()}
+        >
+          <span class="track" class:on={theme.contrast}><span class="knob"></span></span>
+          <span class="state"
+            >{theme.contrast ? m.settings_contrast_on() : m.settings_contrast_off()}</span
+          >
+        </button>
+      </div>
       <div class="push">
         <span class="micro">{m.settings_push_title()}</span>
         {#if !push.supported}
@@ -1129,9 +1145,17 @@
     color: var(--color-ink-bright);
   }
   /* Desktop hosts the theme switcher in the ActionBar; only surface it here on
-     mobile, where the ActionBar hides it and the top bar no longer carries it. */
-  .theme-row {
+     mobile, where the ActionBar hides it and the top bar no longer carries it.
+     The high-contrast toggle (also ActionBar-only on desktop) rides along — it's
+     the readability lift for using the app outdoors / in bright sunlight. */
+  .theme-row,
+  .contrast-row {
     display: none;
+  }
+  .contrast-row .hint {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    margin: 0;
   }
   .theme-seg {
     display: flex;
@@ -1203,7 +1227,8 @@
       align-items: stretch;
       justify-content: stretch;
     }
-    .theme-row {
+    .theme-row,
+    .contrast-row {
       display: flex;
       flex-direction: column;
       gap: 6px;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -701,4 +701,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_egress_title",
     bodyKey: "feat_egress_body",
   },
+  {
+    // No targetId: the toggle lives on the Settings → Device tab (modal closed by
+    // default), so a coachmark anchor would rarely be mounted — surface via the
+    // What's-New drawer only. 1.27.0 is the latest released tag, so this ships in 1.28.0.
+    id: "mobile-high-contrast",
+    sinceVersion: "1.28.0",
+    titleKey: "feat_mobile_contrast_title",
+    bodyKey: "feat_mobile_contrast_body",
+  },
 ];


### PR DESCRIPTION
## Was

In der mobilen Version fehlte die Möglichkeit, **Hohen Kontrast** umzustellen. Light/Dark/System gab es bereits auf dem Settings-Tab **Gerät** (`.theme-row`), aber der High-Contrast-Layer war nur über die Desktop-ActionBar erreichbar.

Dieser PR holt den High-Contrast-Schalter aufs Handy — direkt unter den Theme-Umschalter im Einstellungsmenü (Zahnrad oben rechts → Gerät). Begründung des Users: die Oberfläche wird draußen bei Sonneneinstrahlung genutzt, wo hoher Kontrast nötig ist.

## Wie

- **`Settings.svelte`**: neuer mobile-only `.contrast-row`-Block auf dem Gerät-Tab — Titel, Hinweis (Sonnenlicht-Framing) und der etablierte `.toggle`/`role="switch"`-Schalter, gebunden an `theme.contrast` / `theme.toggleContrast()`.
- Kein neues Theme erfunden: der vorhandene **WCAG-AAA** High-Contrast-Layer (`[data-contrast="high"]`) ist genau das, was bei Sonnenlicht gebraucht wird. Persistenz läuft schon über `theme.svelte.ts` (`shepherd:contrast`).
- **i18n**: `settings_contrast_*` in EN + DE (`check:i18n` grün, 1135 Keys in Parität).
- **Feature-Katalog**: Eintrag `mobile-high-contrast` (sinceVersion `1.28.0`) + `feat_mobile_contrast_*`.

## Verifiziert

Dev-Preview bei 390×844 (Handy-Viewport): Gerät-Tab zeigt den HIGH-CONTRAST-Schalter; Umschalten setzt `data-theme`-unabhängig `data-contrast="high"` auf `<html>`, `aria-checked` wechselt, und der Text wird sichtbar kontraststärker. `bun run check` (0 Fehler) und `bun run check:i18n` grün; pre-push (branch-hygiene, feature-catalog, fallow) grün.