### PR TITLE
test(egress): isolate real-slirp suite from the CI runner host (#591)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,18 +71,6 @@ jobs:
           (cd ui && bun run check:i18n)
           (cd extension && bun run check:i18n)
 
-      # TEMPORARY (issue #591 diagnostic — REMOVE before merge): confirm the runner
-      # image lacks the egress real-machinery tools, so egress-runner.test.ts's CAPABLE
-      # gate is already false in CI and the suite skips here regardless of the new CI gate.
-      - name: Egress tooling diagnostic (TEMP — remove)
-        run: |
-          echo "RUNNER_ENVIRONMENT=${RUNNER_ENVIRONMENT:-<unset>}"
-          echo "CI=${CI:-<unset>}"
-          echo "DOCKER_HOST=${DOCKER_HOST:-<unset>}"
-          for t in setpriv unshare slirp4netns nft dnsmasq; do
-            if command -v "$t" >/dev/null 2>&1; then echo "tool $t: PRESENT ($(command -v "$t"))"; else echo "tool $t: ABSENT"; fi
-          done
-
       - name: Test (root)
         # server.test.ts creates its temp repo inside repoRoot (default
         # $HOME/Work, absent on the runner). Point it at a writable temp dir.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,18 @@ jobs:
           (cd ui && bun run check:i18n)
           (cd extension && bun run check:i18n)
 
+      # TEMPORARY (issue #591 diagnostic — REMOVE before merge): confirm the runner
+      # image lacks the egress real-machinery tools, so egress-runner.test.ts's CAPABLE
+      # gate is already false in CI and the suite skips here regardless of the new CI gate.
+      - name: Egress tooling diagnostic (TEMP — remove)
+        run: |
+          echo "RUNNER_ENVIRONMENT=${RUNNER_ENVIRONMENT:-<unset>}"
+          echo "CI=${CI:-<unset>}"
+          echo "DOCKER_HOST=${DOCKER_HOST:-<unset>}"
+          for t in setpriv unshare slirp4netns nft dnsmasq; do
+            if command -v "$t" >/dev/null 2>&1; then echo "tool $t: PRESENT ($(command -v "$t"))"; else echo "tool $t: ABSENT"; fi
+          done
+
       - name: Test (root)
         # server.test.ts creates its temp repo inside repoRoot (default
         # $HOME/Work, absent on the runner). Point it at a writable temp dir.

--- a/ci/self-hosted-runner/README.md
+++ b/ci/self-hosted-runner/README.md
@@ -198,6 +198,21 @@ step's warning.
 > (reverting CI to GitHub-hosted runners) **before** the repo goes public, and tear the
 > runner down if it won't be re-privatized.
 
+## Egress real-machinery tests
+
+**`test/egress-runner.test.ts` exercises the REAL rootless-netns machinery** —
+`slirp4netns`/`nft`/`dnsmasq`/`unshare`/`setpriv` — and tears it down with SIGKILL.
+It must **NEVER** run on this host: the rootless docker daemon that serves the
+runner containers uses its **OWN shared `slirp4netns`**, and churning the real
+machinery here can take it out, knocking every runner offline (2026-06-12 incident;
+issue #591). The suite **self-skips** via `test/egress-runner-gate.ts`
+(`egressRunnerShouldSkip`, unit-tested in `test/egress-runner-gate.test.ts`), which
+skips when the host can't do rootless user+net namespaces, when running under `CI`,
+**or** when a rootless docker socket is present — so it runs only on a capable local
+host without rootless docker, never in any CI job. **Do NOT weaken that gate** (e.g.
+don't reintroduce a hosted/self-hosted-only condition): the fail-closed `CI` +
+rootless-socket checks are precisely what keep it off this box.
+
 ## Outage runbook
 
 **Symptom:** PR checks are stuck **pending** (queued, spinner, never go red). Because

--- a/test/egress-runner-gate.test.ts
+++ b/test/egress-runner-gate.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the egress real-machinery suite's skip gate
+ * (test/egress-runner-gate.ts). Pure helpers, no filesystem — `isSocket` is
+ * stubbed throughout.
+ */
+
+import { test, expect } from "bun:test";
+import {
+  egressRunnerShouldSkip,
+  rootlessDockerSocketPresent,
+  type GateProbes,
+} from "./egress-runner-gate";
+
+const never = (): boolean => false;
+const onlyRootlessSock = (p: string) => p === "/run/user/1000/docker.sock";
+
+const cases: { name: string; probes: GateProbes; expected: boolean }[] = [
+  {
+    name: "not capable ⇒ skip",
+    probes: { capable: false, env: {}, uid: 1000, isSocket: never },
+    expected: true,
+  },
+  {
+    name: "capable + CI:'true' (no socket) ⇒ skip",
+    probes: { capable: true, env: { CI: "true" }, uid: 1000, isSocket: never },
+    expected: true,
+  },
+  {
+    name: "capable + CI:'' (empty) + no socket ⇒ run",
+    probes: { capable: true, env: { CI: "" }, uid: 1000, isSocket: never },
+    expected: false,
+  },
+  {
+    name: "capable + no CI + no socket ⇒ run",
+    probes: { capable: true, env: {}, uid: 1000, isSocket: never },
+    expected: false,
+  },
+  {
+    name: "capable + no CI + rootless docker.sock present ⇒ skip",
+    probes: { capable: true, env: {}, uid: 1000, isSocket: onlyRootlessSock },
+    expected: true,
+  },
+  {
+    name: "capable + no CI + DOCKER_HOST unix socket present ⇒ skip",
+    probes: {
+      capable: true,
+      env: { DOCKER_HOST: "unix:///run/user/1000/docker.sock" },
+      uid: 1000,
+      isSocket: onlyRootlessSock,
+    },
+    expected: true,
+  },
+  {
+    name: "capable + no CI + DOCKER_HOST tcp (non-unix) + no unix socket ⇒ run",
+    probes: {
+      capable: true,
+      env: { DOCKER_HOST: "tcp://1.2.3.4:2375" },
+      uid: 1000,
+      isSocket: never,
+    },
+    expected: false,
+  },
+  {
+    name: "capable + no CI + path exists but not a socket ⇒ run",
+    probes: { capable: true, env: {}, uid: 1000, isSocket: never },
+    expected: false,
+  },
+  {
+    name: "capable + no CI + uid undefined + no DOCKER_HOST ⇒ run (no candidates)",
+    probes: { capable: true, env: {}, uid: undefined, isSocket: never },
+    expected: false,
+  },
+];
+
+for (const { name, probes, expected } of cases) {
+  test(`egressRunnerShouldSkip: ${name}`, () => {
+    expect(egressRunnerShouldSkip(probes)).toBe(expected);
+  });
+}
+
+test("rootlessDockerSocketPresent: uid undefined + no DOCKER_HOST ⇒ false", () => {
+  expect(rootlessDockerSocketPresent({}, undefined, () => true)).toBe(false);
+});

--- a/test/egress-runner-gate.test.ts
+++ b/test/egress-runner-gate.test.ts
@@ -61,8 +61,13 @@ const cases: { name: string; probes: GateProbes; expected: boolean }[] = [
     expected: false,
   },
   {
-    name: "capable + no CI + path exists but not a socket ⇒ run",
-    probes: { capable: true, env: {}, uid: 1000, isSocket: never },
+    name: "capable + no CI + DOCKER_HOST unix candidate probed but isSocket false ⇒ run",
+    probes: {
+      capable: true,
+      env: { DOCKER_HOST: "unix:///var/run/docker.sock" },
+      uid: 1000,
+      isSocket: never,
+    },
     expected: false,
   },
   {

--- a/test/egress-runner-gate.ts
+++ b/test/egress-runner-gate.ts
@@ -1,0 +1,55 @@
+/**
+ * Skip-gate for the egress real-machinery suite (test/egress-runner.test.ts).
+ * Pure + injectable so it can be unit-tested without touching the host (see
+ * test/egress-runner-gate.test.ts). The wiring in egress-runner.test.ts supplies
+ * the live probes.
+ */
+
+export interface GateProbes {
+  /** Result of the host-capability probe (tools present + rootless user+net ns works). */
+  capable: boolean;
+  /** Process env (injected for testability). */
+  env: Record<string, string | undefined>;
+  /** Current uid, or undefined when getuid is unavailable (e.g. Windows). */
+  uid: number | undefined;
+  /** Returns true iff `path` exists AND is a unix socket. */
+  isSocket: (path: string) => boolean;
+}
+
+/**
+ * True iff a rootless docker daemon's socket is present on this host — the
+ * co-tenant `slirp4netns` the egress real-machinery teardown can disrupt.
+ * Mirrors ci/self-hosted-runner/runner-liveness.sh's socket convention:
+ *   - honor $DOCKER_HOST when it is a unix:// path, plus
+ *   - /run/user/<uid>/docker.sock (the canonical rootless socket path).
+ */
+export function rootlessDockerSocketPresent(
+  env: Record<string, string | undefined>,
+  uid: number | undefined,
+  isSocket: (path: string) => boolean,
+): boolean {
+  const candidates: string[] = [];
+  const dockerHost = env.DOCKER_HOST;
+  if (dockerHost && dockerHost.startsWith("unix://")) {
+    candidates.push(dockerHost.slice("unix://".length));
+  }
+  if (uid !== undefined) {
+    candidates.push(`/run/user/${uid}/docker.sock`);
+  }
+  return candidates.some((p) => isSocket(p));
+}
+
+/**
+ * Decide whether to SKIP the egress real-machinery suite. Fail-closed: skip when
+ *   - the host can't run the machinery at all (`!capable`), OR
+ *   - we are under CI (`env.CI` truthy) — no real slirp teardown in ANY CI job,
+ *     independent of hosted/self-hosted, so there is no fail-open surface, OR
+ *   - a rootless docker daemon's socket is present (the host/dev-box trigger).
+ *
+ * `!!env.CI` treats any non-empty value as CI (standard convention; GitHub sets
+ * CI=true). An explicit `CI=false` string is non-empty and so also skips — the
+ * safe direction for this optional, gated coverage.
+ */
+export function egressRunnerShouldSkip(p: GateProbes): boolean {
+  return !p.capable || !!p.env.CI || rootlessDockerSocketPresent(p.env, p.uid, p.isSocket);
+}

--- a/test/egress-runner.test.ts
+++ b/test/egress-runner.test.ts
@@ -3,8 +3,16 @@
  * netns runner orchestrator (issue #551, Task 3).
  *
  * These exercise the REAL rootless-netns machinery (setpriv/unshare/slirp4netns/
- * nft/dnsmasq), so they are GATED: the suite skips cleanly on hosts that can't do
- * rootless user+net namespaces (most CI). When capable, it verifies:
+ * nft/dnsmasq) and tear it down with SIGKILL, so they are GATED. The suite SKIPS
+ * when (a) the host can't do rootless user+net namespaces / lacks the tools, (b)
+ * running under CI (no real slirp teardown in any CI job), or (c) a rootless
+ * docker daemon's socket is present — because on a host (e.g. `backontop`) whose
+ * rootless docker serves the CI runners, churning the real slirp machinery can
+ * take out that daemon's shared `slirp4netns` and knock all runners offline
+ * (2026-06-12 incident; issue #591). The skip decision lives in
+ * egress-runner-gate.ts and is unit-tested in egress-runner-gate.test.ts.
+ *
+ * When NOT skipped, it verifies:
  *   1. exit-code propagation (inner exits 42 ⇒ runner exits 42),
  *   2. clean-exit teardown (no slirp / netns-owner survive the inner exiting),
  *   3. SIGTERM teardown,
@@ -19,11 +27,12 @@
  */
 
 import { test, expect, afterEach } from "bun:test";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { buildEgressConfig } from "../src/egress";
+import { egressRunnerShouldSkip } from "./egress-runner-gate";
 
 const SCRIPT = join(import.meta.dir, "..", "scripts", "egress-runner.sh");
 
@@ -41,7 +50,18 @@ function hostCapable(): boolean {
   return probe.status === 0;
 }
 
-const CAPABLE = hostCapable();
+const SKIP = egressRunnerShouldSkip({
+  capable: hostCapable(),
+  env: process.env,
+  uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+  isSocket: (p) => {
+    try {
+      return statSync(p).isSocket();
+    } catch {
+      return false;
+    }
+  },
+});
 
 // ── helpers ─────────────────────────────────────────────────────────────────────
 
@@ -131,14 +151,14 @@ function spawnRunner(inner: string[]) {
 
 // ── tests (gated) ─────────────────────────────────────────────────────────────────
 
-test.skipIf(!CAPABLE)("propagates the inner exit code (42)", async () => {
+test.skipIf(SKIP)("propagates the inner exit code (42)", async () => {
   const proc = spawnRunner(["bash", "-c", "echo READY; exit 42"]);
   recorded.push(proc.pid);
   const code = await proc.exited;
   expect(code).toBe(42);
 });
 
-test.skipIf(!CAPABLE)("clean inner exit tears down slirp + netns owner", async () => {
+test.skipIf(SKIP)("clean inner exit tears down slirp + netns owner", async () => {
   const proc = spawnRunner(["bash", "-c", "echo READY; sleep 1"]);
   recorded.push(proc.pid);
   const { owner, slirp } = await captureChildren(proc.pid);
@@ -154,7 +174,7 @@ test.skipIf(!CAPABLE)("clean inner exit tears down slirp + netns owner", async (
   expect(alive(slirp!)).toBe(false);
 });
 
-test.skipIf(!CAPABLE)("SIGTERM on the runner tears down slirp + netns owner", async () => {
+test.skipIf(SKIP)("SIGTERM on the runner tears down slirp + netns owner", async () => {
   const proc = spawnRunner(["bash", "-c", "echo READY; sleep 30"]);
   recorded.push(proc.pid);
   const { owner, slirp } = await captureChildren(proc.pid);
@@ -171,7 +191,7 @@ test.skipIf(!CAPABLE)("SIGTERM on the runner tears down slirp + netns owner", as
   expect(alive(slirp!)).toBe(false);
 });
 
-test.skipIf(!CAPABLE)(
+test.skipIf(SKIP)(
   "SIGKILL on the runner STILL tears down slirp + netns owner (pdeathsig leash)",
   async () => {
     const proc = spawnRunner(["bash", "-c", "echo READY; sleep 30"]);
@@ -193,7 +213,7 @@ test.skipIf(!CAPABLE)(
   },
 );
 
-test.skipIf(!CAPABLE)(
+test.skipIf(SKIP)(
   "FAIL-CLOSED: malformed nft ruleset refuses to exec the agent (no firewall, no run)",
   async () => {
     // A fresh tmp dir with a DELIBERATELY malformed egress.nft. The runner's


### PR DESCRIPTION
Closes #591.

## Problem

`test/egress-runner.test.ts` exercises the **real** rootless-netns machinery (`setpriv`/`unshare`/`slirp4netns`/`nft`/`dnsmasq`) and tears it down with SIGKILL. On the CI host `backontop`, the self-hosted runner containers run on a **rootless docker** daemon that uses its **own** shared `slirp4netns` for all container egress. Churning the real machinery on that host can take out the daemon's slirp → every runner loses DNS+egress and crash-loops (incident 2026-06-12 ~22:07).

The egress *code* is clean (PID-scoped kills); the hazard is **co-tenancy**. This is the upstream fix; #589 (self-heal watchdog) is the downstream backstop.

## Diagnosis (empirically confirmed)

The runner image (`ci/self-hosted-runner/Dockerfile`) installs **none** of `slirp4netns`/`dnsmasq`/`nft`, so the suite's existing `hostCapable()` (`CAPABLE`) is already `false` inside every CI job — it has been skipping in CI all along. The real trigger is a **maintainer running `bun test` directly on the `backontop` host**, where the tools *and* rootless docker are both present.

A temporary CI diagnostic step (now removed) confirmed this on the actual self-hosted runner:

```
RUNNER_ENVIRONMENT=self-hosted
CI=true
DOCKER_HOST=<unset>
tool setpriv: PRESENT (/usr/bin/setpriv)
tool unshare: PRESENT (/usr/bin/unshare)
tool slirp4netns: ABSENT
tool nft: PRESENT (/usr/sbin/nft)
tool dnsmasq: ABSENT
```

`slirp4netns`/`dnsmasq` absent ⇒ `CAPABLE=false` in CI; `CI=true` ⇒ the new fail-closed gate fires anyway; `DOCKER_HOST` unset + no socket mounted ⇒ socket-detection alone can't catch the in-CI case, which is exactly why the `CI` branch (not a self-hosted marker) is the load-bearing in-CI signal.

## Fix — single fail-closed skip gate

Skip the suite when **any** of:

```
!CAPABLE                          # tools absent OR rootless user+net ns can't be created
|| !!process.env.CI               # fail closed in ALL CI — no hosted/self-hosted distinction, no fail-open surface
|| rootlessDockerSocketPresent()  # a rootless docker daemon's socket on THIS host (the real trigger)
```

- The decision is a **pure, injectable, unit-tested** helper — `test/egress-runner-gate.ts` (`egressRunnerShouldSkip`), with a 10-case table test in `test/egress-runner-gate.test.ts`. A future contributor re-widening the predicate breaks that test.
- `rootlessDockerSocketPresent` mirrors `ci/self-hosted-runner/runner-liveness.sh`'s socket convention: honors `$DOCKER_HOST` (unix path) + `/run/user/$(id -u)/docker.sock`, counting a path only if it exists **and is a socket**.

The suite now runs only on a capable local host without rootless docker.

## Acceptance criteria

- [x] Cannot run where a rootless docker daemon serves the runners — proven by the gate table test (`CI` set ⇒ skip; rootless socket present ⇒ skip).
- [x] CI on `runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}` does not exercise real slirp teardown against the host (`CI` set ⇒ skip; CI images are `!CAPABLE` anyway — confirmed above).
- [x] Constraint documented — test header **and** `ci/self-hosted-runner/README.md` (new "Egress real-machinery tests" section), **and** enforced mechanically by the gate unit test.

## Verification

- `bun test ./test/egress-runner-gate.test.ts` → 10 pass.
- `bun test ./test/egress-runner.test.ts` → 5 skip on a rootless-docker host (this gate firing).
- `bun run typecheck`, `bun run lint`, `bunx prettier --check .` → clean.
- `verify` CI run on the self-hosted runner → green (with the diagnostic; now removed).

The temporary diagnostic step has been **removed** (commit `1713bd00`); the merge diff is clean.

[no-feature-entry] — test + docs only; no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)