### PR TITLE
fix(ui): close review/plan popover trapped in swipe row on touch devices

### DIFF
--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import "../../app.css";
+import PlanPanel from "./PlanPanel.svelte";
+import type { Session } from "$lib/types";
+
+// Mock api so the panel's release/review calls never hit the network, keeping the
+// rest of the module intact (the reviews store imports other api exports).
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    releasePlanGate: vi.fn(async () => {}),
+    reviewPlan: vi.fn(async () => "skipped"),
+  };
+});
+
+function session(partial: Partial<Session> & { id: string }): Session {
+  return {
+    desig: "TASK-01",
+    name: "task one",
+    prompt: "p",
+    repoPath: "/repo/a",
+    baseBranch: "main",
+    branch: "feat/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "h",
+    herdrAgentId: "ha",
+    claudeSessionId: "cs",
+    model: null,
+    status: "idle",
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: "planning",
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    auto: false,
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    issueNumber: null,
+    lastState: "",
+    createdAt: 0,
+    updatedAt: 0,
+    archivedAt: null,
+    ...partial,
+  };
+}
+
+afterEach(() => {
+  // The overlay is portaled to <body>, outside the test container, so clean it up.
+  document.querySelectorAll(".overlay").forEach((el) => el.remove());
+});
+
+describe("PlanPanel portal", () => {
+  // Regression guard: PlanPanel's fixed overlay must escape its mount subtree so
+  // position:fixed resolves against the viewport, not UnitRow's transformed
+  // `.slider`. The portal action re-parents it to <body>.
+  it("portals the overlay to document.body, out of its own subtree", () => {
+    render(PlanPanel, { props: { session: session({ id: "s1" }), onclose: vi.fn() } });
+
+    const overlay = document.querySelector<HTMLElement>(".overlay");
+    expect(overlay).not.toBeNull();
+    expect(overlay!.parentElement).toBe(document.body);
+  });
+});

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -4,6 +4,7 @@
   import { releasePlanGate, reviewPlan } from "$lib/api";
   import { canRelease } from "./plan-gate-badge";
   import { dialog } from "$lib/a11yDialog";
+  import { portal } from "$lib/portal";
   import { m } from "$lib/paraglide/messages";
 
   let { session, onclose }: { session: Session; onclose: () => void } = $props();
@@ -118,6 +119,7 @@
 <div
   class="overlay"
   role="presentation"
+  use:portal
   onclick={(e) => {
     if (e.target === e.currentTarget) onclose();
   }}

--- a/ui/src/lib/portal.test.ts
+++ b/ui/src/lib/portal.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { portal } from "./portal";
+
+// The node project has no DOM, so stub the slice of the Element API the action
+// touches: appendChild (records the new parent), parentNode (set by appendChild),
+// and removeChild (clears it). Mirrors the stub-everything style of clipboard.test.ts.
+function stubNode(): HTMLElement {
+  const node = {
+    parentNode: null as unknown as ParentNode | null,
+    appendChild(child: { parentNode: ParentNode | null }) {
+      child.parentNode = node as unknown as ParentNode;
+      return child;
+    },
+    removeChild(child: { parentNode: ParentNode | null }) {
+      child.parentNode = null;
+      return child;
+    },
+  };
+  return node as unknown as HTMLElement;
+}
+
+describe("portal action", () => {
+  it("appends the node to a provided target on apply", () => {
+    const target = stubNode();
+    const node = stubNode();
+    const append = vi.spyOn(target, "appendChild");
+
+    portal(node, target);
+
+    expect(append).toHaveBeenCalledWith(node);
+    expect(node.parentNode).toBe(target);
+  });
+
+  it("removes the node from its parent on destroy", () => {
+    const target = stubNode();
+    const node = stubNode();
+
+    const { destroy } = portal(node, target);
+    expect(node.parentNode).toBe(target);
+
+    destroy();
+    expect(node.parentNode).toBeNull();
+  });
+
+  it("destroy is a harmless no-op when the node was already detached", () => {
+    const target = stubNode();
+    const node = stubNode();
+
+    const { destroy } = portal(node, target);
+    // simulate Svelte already detaching it during teardown (parentNode is read-only)
+    (node as { parentNode: ParentNode | null }).parentNode = null;
+
+    expect(() => destroy()).not.toThrow();
+  });
+});

--- a/ui/src/lib/portal.ts
+++ b/ui/src/lib/portal.ts
@@ -1,0 +1,22 @@
+// Teleport an element to a target (default <body>) for the lifetime of the action.
+//
+// A `position: fixed` overlay normally resolves against the viewport — UNLESS an
+// ancestor establishes a containing block (a `transform`, `will-change`, or
+// `filter`), in which case `fixed` is trapped to that ancestor's box instead.
+// UnitRow's swipe slider (`.slider`, `will-change: transform` + inline
+// `transform: translateX(0)`) does exactly this on coarse-pointer devices, so a
+// modal rendered inside a row (PlanPanel via PlanGateBadge) was sized to the row
+// rather than the screen — inline, undimmed, and un-closable.
+//
+// `use:portal` moves the node out to <body> on mount (no transformed ancestor
+// there), restoring honest viewport-relative `fixed`, and removes it on destroy.
+export function portal(node: HTMLElement, target: HTMLElement = document.body) {
+  target.appendChild(node);
+  return {
+    destroy() {
+      // Optional-chain the removal so a double-teardown (Svelte may already have
+      // detached the node) is a harmless no-op rather than a throw.
+      node.parentNode?.removeChild(node);
+    },
+  };
+}


### PR DESCRIPTION
## Problem

The plan-gate **review popover** (`PlanPanel`, opened from a session row's REWORK/READY badge) could not be closed on touch devices — it rendered *inline inside the card*, undimmed, with no working backdrop or close affordance (see report screenshot).

## Root cause

`PlanPanel` is a `position: fixed; inset: 0` modal rendered (via `PlanGateBadge`) inside `UnitRow`'s `row()` snippet. On coarse-pointer (touch) devices the row is wrapped in the swipe-to-decommission `<div class="slider">`, which carries `will-change: transform` (`UnitRow.svelte:694`) plus an always-present inline `transform: translateX(0px)`. Either property makes `.slider` the **containing block for `position: fixed` descendants**, so the overlay was sized/positioned to the one-row box instead of the viewport — the scrim never covered the app and the backdrop/✕/Esc targets were unreachable.

This is why `CardMenu`/`TimePopover` work but the plan popover didn't: those are rendered as siblings *outside* `.slider`; only `PlanGateBadge`→`PlanPanel` lives inside it.

(`container-type: inline-size` on the herd container was ruled out empirically — it does **not** trap fixed elements.)

## Fix

A tiny reusable `portal` Svelte action (`ui/src/lib/portal.ts`) that teleports the overlay to `document.body` for its lifetime, so `position: fixed` resolves against the viewport again. Self-contained in `PlanPanel` and the canonical fix for "fixed modal under a transformed ancestor". Side benefit: the modal now correctly dims + blurs the app behind it (design-system compliance).

## Changes

- `ui/src/lib/portal.ts` (new) — `portal` action (append on mount, optional-chained removeChild on destroy).
- `ui/src/lib/components/PlanPanel.svelte` — import + `use:portal` on the `.overlay` div (2 lines; no behavioral change).
- `ui/src/lib/portal.test.ts` (new) — unit tests for the action.
- `ui/src/lib/components/PlanPanel.browser.test.ts` (new) — regression guard: asserts the overlay is parented to `document.body`.

## Verification

- `cd ui && bun run check` — 0 errors / 0 warnings.
- `cd ui && bun run test` — 83 files, 1169 tests pass.

Bug fix only (no user-facing strings, no feature-catalog entry needed). `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)