### PR TITLE
fix(ui): epic header overflow on the unfolded-foldable sidebar

### DIFF
--- a/ui/src/lib/components/EpicBadge.svelte
+++ b/ui/src/lib/components/EpicBadge.svelte
@@ -63,6 +63,7 @@
   .epic-badge {
     display: inline-flex;
     flex-direction: column;
+    flex: none;
     gap: 2px;
     font: inherit;
     font-size: var(--fs-micro);

--- a/ui/src/lib/components/EpicGroupHeader.svelte
+++ b/ui/src/lib/components/EpicGroupHeader.svelte
@@ -100,6 +100,7 @@
     gap: 6px;
     flex: 1;
     min-width: 0;
+    overflow: hidden;
     border: 0;
     background: none;
     font: inherit;
@@ -129,7 +130,8 @@
   }
   /* repo basename — quiet identity marker ahead of the epic title */
   .repo {
-    flex: none;
+    flex: 0 1 auto;
+    min-width: 0;
     color: var(--color-muted);
     max-width: 16ch;
     overflow: hidden;
@@ -138,12 +140,15 @@
   }
 
   .title {
+    flex: 0 1 auto;
     min-width: 0;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
     color: var(--color-ink-bright);
   }
+  /* No overflow rule here — clipped by the parent .epic-toggle's overflow: hidden
+     at extreme widths. */
   .num {
     flex: none;
     color: var(--color-blue);

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -107,10 +107,10 @@
     // working-while-blocked display flags (store map) — threaded into the rows'
     // displayStatus and the "ready" filter so flagged sessions read as working
     workingBlocked?: Record<string, boolean>;
-    // when true, renders a collapse chevron at the far-right of the header —
+    // when true, renders a collapse arrow at the trailing end of the filters bar —
     // only set on touch-primary wide devices where collapsing is meaningful
     collapsible?: boolean;
-    // called when the collapse chevron is clicked; parent drives the actual
+    // called when the collapse arrow is clicked; parent drives the actual
     // collapse so the button is purely a signal
     oncollapse?: () => void;
   } = $props();
@@ -204,102 +204,134 @@
   const mergerWho = $derived(uniqueWho(partition.waitingOnMerger));
 </script>
 
-<div class="herd-root" class:collapsible>
-  <div class="panel bracket" class:flow>
-    <div class="phead">
-      <span class="micro">{m.herd_title()}</span>
-      <div class="right filters">
+<div class="panel bracket" class:flow>
+  <div class="phead">
+    <span class="micro">{m.herd_title()}</span>
+    <div class="right filters">
+      <button
+        type="button"
+        class="micro fbtn"
+        class:active={statusFilter == null && filter === "all"}
+        title={m.herd_all_title()}
+        aria-pressed={statusFilter == null && filter === "all"}
+        onclick={() => {
+          filter = "all";
+          onstatusfilter?.(null);
+        }}>{m.herd_all_hint()}</button
+      >
+      <button
+        type="button"
+        class="micro fbtn"
+        class:active={statusFilter == null && filter === "ready"}
+        title={m.herd_ready_title()}
+        aria-pressed={statusFilter == null && filter === "ready"}
+        onclick={() => {
+          filter = "ready";
+          onstatusfilter?.(null);
+        }}>{m.herd_ready_filter()}</button
+      >
+      {#if statusFilter != null}
+        <!-- aria-label carries status + clear action; the visible "✕" glyph would
+           otherwise be read aloud without conveying what the chip does -->
         <button
           type="button"
-          class="micro fbtn"
-          class:active={statusFilter == null && filter === "all"}
-          title={m.herd_all_title()}
-          aria-pressed={statusFilter == null && filter === "all"}
-          onclick={() => {
-            filter = "all";
-            onstatusfilter?.(null);
-          }}>{m.herd_all_hint()}</button
+          class="micro fbtn active statchip"
+          title={m.topbar_tally_clear_title()}
+          aria-label={m.herd_status_chip_aria({ status: statusLabel })}
+          aria-pressed="true"
+          onclick={() => onstatusfilter?.(null)}>{statusLabel} ✕</button
         >
+      {/if}
+      {#if collapsible}
         <button
+          id="herd-collapse-btn"
           type="button"
-          class="micro fbtn"
-          class:active={statusFilter == null && filter === "ready"}
-          title={m.herd_ready_title()}
-          aria-pressed={statusFilter == null && filter === "ready"}
-          onclick={() => {
-            filter = "ready";
-            onstatusfilter?.(null);
-          }}>{m.herd_ready_filter()}</button
+          class="fbtn collapse-inline"
+          title={m.herd_collapse()}
+          aria-label={m.herd_collapse()}
+          onclick={() => oncollapse?.()}>‹</button
         >
-        {#if statusFilter != null}
-          <!-- aria-label carries status + clear action; the visible "✕" glyph would
-             otherwise be read aloud without conveying what the chip does -->
-          <button
-            type="button"
-            class="micro fbtn active statchip"
-            title={m.topbar_tally_clear_title()}
-            aria-label={m.herd_status_chip_aria({ status: statusLabel })}
-            aria-pressed="true"
-            onclick={() => onstatusfilter?.(null)}>{statusLabel} ✕</button
-          >
-        {/if}
-      </div>
+      {/if}
     </div>
-    <div class="units" class:flow>
-      {#if sessions.length === 0}
-        <!-- the status filter empties the list at PAGE level (herdSessions), so an
-           empty status result lands HERE — it must outrank the repo note and the
-           first-run EmptyHerd nudge, and name the active status so vanished
-           done/parked sessions read as intentional -->
-        {#if statusFilter != null && filteredRepo}
-          <div class="empty micro static">
-            {m.herd_status_repo_filter_empty({ status: statusLabel, repo: filteredRepo })}
-          </div>
-        {:else if statusFilter != null}
-          <div class="empty micro static">
-            {m.herd_status_filter_empty({ status: statusLabel })}
-          </div>
-        {:else if filteredRepo}
-          <div class="empty micro static">{m.herd_repo_filter_empty({ repo: filteredRepo })}</div>
-        {:else}
-          <EmptyHerd {onnew} {issueActionsUnset} {onsettings} />
-        {/if}
-      {:else if shown.length === 0}
-        <div class="empty micro static">{m.herd_ready_empty()}</div>
+  </div>
+  <div class="units" class:flow>
+    {#if sessions.length === 0}
+      <!-- the status filter empties the list at PAGE level (herdSessions), so an
+         empty status result lands HERE — it must outrank the repo note and the
+         first-run EmptyHerd nudge, and name the active status so vanished
+         done/parked sessions read as intentional -->
+      {#if statusFilter != null && filteredRepo}
+        <div class="empty micro static">
+          {m.herd_status_repo_filter_empty({ status: statusLabel, repo: filteredRepo })}
+        </div>
+      {:else if statusFilter != null}
+        <div class="empty micro static">
+          {m.herd_status_filter_empty({ status: statusLabel })}
+        </div>
+      {:else if filteredRepo}
+        <div class="empty micro static">{m.herd_repo_filter_empty({ repo: filteredRepo })}</div>
       {:else}
-        {#each grouped.groups as g (g.key)}
-          <EpicGroupHeader
-            epic={g.epic}
-            collapsed={collapsedKeys.has(g.key)}
-            cues={cuesFor(g)}
-            ontoggle={() => oncollapsetoggle?.(g.key)}
-            {onepic}
-          />
-          {#if !collapsedKeys.has(g.key)}
-            <div class="epic-children">
-              {#each g.sessions as session (session.id)}
-                <UnitRow
-                  {session}
-                  selected={session.id === selectedId}
-                  {nowMs}
-                  {onselect}
-                  git={git[session.id]}
-                  activity={activity[session.id]}
-                  previewPort={preview[session.id] ?? null}
-                  previewServeFailed={previewServe[session.id] === "failed"}
-                  {onpreview}
-                  {ondecommission}
-                  {onrelaunch}
-                  {onrelaunchElsewhere}
-                  {repoFilter}
-                  {onrepofilter}
-                  {workingBlocked}
-                />
-              {/each}
-            </div>
-          {/if}
-        {/each}
-        {#each partition.active as session (session.id)}
+        <EmptyHerd {onnew} {issueActionsUnset} {onsettings} />
+      {/if}
+    {:else if shown.length === 0}
+      <div class="empty micro static">{m.herd_ready_empty()}</div>
+    {:else}
+      {#each grouped.groups as g (g.key)}
+        <EpicGroupHeader
+          epic={g.epic}
+          collapsed={collapsedKeys.has(g.key)}
+          cues={cuesFor(g)}
+          ontoggle={() => oncollapsetoggle?.(g.key)}
+          {onepic}
+        />
+        {#if !collapsedKeys.has(g.key)}
+          <div class="epic-children">
+            {#each g.sessions as session (session.id)}
+              <UnitRow
+                {session}
+                selected={session.id === selectedId}
+                {nowMs}
+                {onselect}
+                git={git[session.id]}
+                activity={activity[session.id]}
+                previewPort={preview[session.id] ?? null}
+                previewServeFailed={previewServe[session.id] === "failed"}
+                {onpreview}
+                {ondecommission}
+                {onrelaunch}
+                {onrelaunchElsewhere}
+                {repoFilter}
+                {onrepofilter}
+                {workingBlocked}
+              />
+            {/each}
+          </div>
+        {/if}
+      {/each}
+      {#each partition.active as session (session.id)}
+        <UnitRow
+          {session}
+          selected={session.id === selectedId}
+          {nowMs}
+          {onselect}
+          git={git[session.id]}
+          activity={activity[session.id]}
+          previewPort={preview[session.id] ?? null}
+          previewServeFailed={previewServe[session.id] === "failed"}
+          {onpreview}
+          {ondecommission}
+          {onrelaunch}
+          {onrelaunchElsewhere}
+          {repoFilter}
+          {onrepofilter}
+          {workingBlocked}
+        />
+      {/each}
+      {#if partition.ciRunning.length > 0}
+        <div class="ci-head micro">
+          {m.herd_ci_running_group({ count: partition.ciRunning.length })}
+        </div>
+        {#each partition.ciRunning as session (session.id)}
           <UnitRow
             {session}
             selected={session.id === selectedId}
@@ -318,306 +350,255 @@
             {workingBlocked}
           />
         {/each}
-        {#if partition.ciRunning.length > 0}
-          <div class="ci-head micro">
-            {m.herd_ci_running_group({ count: partition.ciRunning.length })}
-          </div>
-          {#each partition.ciRunning as session (session.id)}
-            <UnitRow
-              {session}
-              selected={session.id === selectedId}
-              {nowMs}
-              {onselect}
-              git={git[session.id]}
-              activity={activity[session.id]}
-              previewPort={preview[session.id] ?? null}
-              previewServeFailed={previewServe[session.id] === "failed"}
-              {onpreview}
-              {ondecommission}
-              {onrelaunch}
-              {onrelaunchElsewhere}
-              {repoFilter}
-              {onrepofilter}
-              {workingBlocked}
-            />
-          {/each}
-        {/if}
-        {#if partition.ciFailed.length > 0}
-          <div class="ci-failed-head micro">
-            {m.herd_ci_failed_group({ count: partition.ciFailed.length })}
-          </div>
-          {#each partition.ciFailed as session (session.id)}
-            <UnitRow
-              {session}
-              selected={session.id === selectedId}
-              {nowMs}
-              {onselect}
-              git={git[session.id]}
-              activity={activity[session.id]}
-              previewPort={preview[session.id] ?? null}
-              previewServeFailed={previewServe[session.id] === "failed"}
-              {onpreview}
-              {ondecommission}
-              {onrelaunch}
-              {onrelaunchElsewhere}
-              {repoFilter}
-              {onrepofilter}
-              {workingBlocked}
-            />
-          {/each}
-        {/if}
-        {#if partition.reviewerRunning.length > 0}
-          <div class="reviewing-head micro">
-            {m.herd_reviewer_running_group({ count: partition.reviewerRunning.length })}
-          </div>
-          {#each partition.reviewerRunning as session (session.id)}
-            <UnitRow
-              {session}
-              selected={session.id === selectedId}
-              {nowMs}
-              {onselect}
-              git={git[session.id]}
-              activity={activity[session.id]}
-              previewPort={preview[session.id] ?? null}
-              previewServeFailed={previewServe[session.id] === "failed"}
-              {onpreview}
-              {ondecommission}
-              {onrelaunch}
-              {onrelaunchElsewhere}
-              {repoFilter}
-              {onrepofilter}
-              {workingBlocked}
-            />
-          {/each}
-        {/if}
-        {#if partition.waitingOnReviewer.length > 0}
-          <div class="waiting-head micro">
-            {reviewerWho
-              ? m.herd_waiting_reviewer_group({
-                  who: reviewerWho,
-                  count: partition.waitingOnReviewer.length,
-                })
-              : m.herd_waiting_reviewer_group_multi({ count: partition.waitingOnReviewer.length })}
-          </div>
-          {#each partition.waitingOnReviewer as session (session.id)}
-            <UnitRow
-              {session}
-              selected={session.id === selectedId}
-              {nowMs}
-              {onselect}
-              git={git[session.id]}
-              activity={activity[session.id]}
-              {ondecommission}
-              {onrelaunch}
-              {onrelaunchElsewhere}
-              {repoFilter}
-              {onrepofilter}
-              {workingBlocked}
-            />
-          {/each}
-        {/if}
-        {#if partition.waitingOnMerger.length > 0}
-          <div class="waiting-head micro">
-            {mergerWho
-              ? m.herd_waiting_merger_group({
-                  who: mergerWho,
-                  count: partition.waitingOnMerger.length,
-                })
-              : m.herd_waiting_merger_group_multi({ count: partition.waitingOnMerger.length })}
-          </div>
-          {#each partition.waitingOnMerger as session (session.id)}
-            <UnitRow
-              {session}
-              selected={session.id === selectedId}
-              {nowMs}
-              {onselect}
-              git={git[session.id]}
-              activity={activity[session.id]}
-              {ondecommission}
-              {onrelaunch}
-              {onrelaunchElsewhere}
-              {repoFilter}
-              {onrepofilter}
-              {workingBlocked}
-            />
-          {/each}
-        {/if}
-        {#if partition.draftAwaitingSignoff.length > 0}
-          <div class="draft-head micro">
-            {m.herd_draft_awaiting_signoff_group({ count: partition.draftAwaitingSignoff.length })}
-          </div>
-          {#each partition.draftAwaitingSignoff as session (session.id)}
-            <UnitRow
-              {session}
-              selected={session.id === selectedId}
-              {nowMs}
-              {onselect}
-              git={git[session.id]}
-              activity={activity[session.id]}
-              {ondecommission}
-              {onrelaunch}
-              {onrelaunchElsewhere}
-              {repoFilter}
-              {onrepofilter}
-              {workingBlocked}
-            />
-          {/each}
-        {/if}
-        {#if partition.awaitingMerge.length > 0}
-          <div class="awaiting-head micro">
-            {m.herd_awaiting_merge_group({ count: partition.awaitingMerge.length })}
-          </div>
-          {#each partition.awaitingMerge as session (session.id)}
-            <UnitRow
-              {session}
-              selected={session.id === selectedId}
-              {nowMs}
-              {onselect}
-              git={git[session.id]}
-              activity={activity[session.id]}
-              previewPort={preview[session.id] ?? null}
-              previewServeFailed={previewServe[session.id] === "failed"}
-              {onpreview}
-              {ondecommission}
-              {onrelaunch}
-              {onrelaunchElsewhere}
-              {repoFilter}
-              {onrepofilter}
-              {workingBlocked}
-            />
-          {/each}
-        {/if}
-        {#if partition.ready.length + readyAbove > 0}
-          <div class="ready-head micro">
-            {#if partition.ready.length > 0}
-              {m.herd_ready_group({ count: partition.ready.length })}
-            {/if}
-            {#if readyAbove > 0}
-              <span class="above">{m.herd_in_epics_above({ count: readyAbove })}</span>
-            {/if}
-            {#if onmergetrain && readyPrCount > 0}
-              <button
-                type="button"
-                class="merge-train micro"
-                title={m.herd_merge_train_title()}
-                onclick={onmergetrain}>{m.herd_merge_train_action()}</button
-              >
-            {/if}
-          </div>
-          {#each partition.ready as session (session.id)}
-            <UnitRow
-              {session}
-              selected={session.id === selectedId}
-              {nowMs}
-              {onselect}
-              git={git[session.id]}
-              activity={activity[session.id]}
-              previewPort={preview[session.id] ?? null}
-              previewServeFailed={previewServe[session.id] === "failed"}
-              {onpreview}
-              {ondecommission}
-              {onrelaunch}
-              {onrelaunchElsewhere}
-              {repoFilter}
-              {onrepofilter}
-              {workingBlocked}
-            />
-          {/each}
-        {/if}
-        {#if partition.merging.length > 0}
-          <div class="merging-head micro">
-            {m.herd_merging_group({ count: partition.merging.length })}
-          </div>
-          {#each partition.merging as session (session.id)}
-            <UnitRow
-              {session}
-              selected={session.id === selectedId}
-              {nowMs}
-              {onselect}
-              git={git[session.id]}
-              activity={activity[session.id]}
-              previewPort={preview[session.id] ?? null}
-              previewServeFailed={previewServe[session.id] === "failed"}
-              {onpreview}
-              {ondecommission}
-              {onrelaunch}
-              {onrelaunchElsewhere}
-              {repoFilter}
-              {onrepofilter}
-              {workingBlocked}
-            />
-          {/each}
-        {/if}
-        {#if partition.merged.length + mergedAbove > 0}
-          <div class="merged-head micro">
-            {#if partition.merged.length > 0}
-              {m.herd_merged_group({ count: partition.merged.length })}
-            {/if}
-            {#if mergedAbove > 0}
-              <span class="above">{m.herd_in_epics_above({ count: mergedAbove })}</span>
-            {/if}
-            {#if onclearmerged && mergedCount > 0}
-              <button
-                type="button"
-                class="clear-merged micro"
-                title={m.herd_clear_merged_title()}
-                onclick={onclearmerged}>{m.herd_clear_merged_action()}</button
-              >
-            {/if}
-          </div>
-          {#each partition.merged as session (session.id)}
-            <UnitRow
-              {session}
-              selected={session.id === selectedId}
-              {nowMs}
-              {onselect}
-              git={git[session.id]}
-              activity={activity[session.id]}
-              previewPort={preview[session.id] ?? null}
-              previewServeFailed={previewServe[session.id] === "failed"}
-              {onpreview}
-              {ondecommission}
-              {onrelaunch}
-              {onrelaunchElsewhere}
-              {repoFilter}
-              {onrepofilter}
-              {workingBlocked}
-            />
-          {/each}
-        {/if}
       {/if}
-    </div>
+      {#if partition.ciFailed.length > 0}
+        <div class="ci-failed-head micro">
+          {m.herd_ci_failed_group({ count: partition.ciFailed.length })}
+        </div>
+        {#each partition.ciFailed as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            activity={activity[session.id]}
+            previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
+            {onpreview}
+            {ondecommission}
+            {onrelaunch}
+            {onrelaunchElsewhere}
+            {repoFilter}
+            {onrepofilter}
+            {workingBlocked}
+          />
+        {/each}
+      {/if}
+      {#if partition.reviewerRunning.length > 0}
+        <div class="reviewing-head micro">
+          {m.herd_reviewer_running_group({ count: partition.reviewerRunning.length })}
+        </div>
+        {#each partition.reviewerRunning as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            activity={activity[session.id]}
+            previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
+            {onpreview}
+            {ondecommission}
+            {onrelaunch}
+            {onrelaunchElsewhere}
+            {repoFilter}
+            {onrepofilter}
+            {workingBlocked}
+          />
+        {/each}
+      {/if}
+      {#if partition.waitingOnReviewer.length > 0}
+        <div class="waiting-head micro">
+          {reviewerWho
+            ? m.herd_waiting_reviewer_group({
+                who: reviewerWho,
+                count: partition.waitingOnReviewer.length,
+              })
+            : m.herd_waiting_reviewer_group_multi({ count: partition.waitingOnReviewer.length })}
+        </div>
+        {#each partition.waitingOnReviewer as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            activity={activity[session.id]}
+            {ondecommission}
+            {onrelaunch}
+            {onrelaunchElsewhere}
+            {repoFilter}
+            {onrepofilter}
+            {workingBlocked}
+          />
+        {/each}
+      {/if}
+      {#if partition.waitingOnMerger.length > 0}
+        <div class="waiting-head micro">
+          {mergerWho
+            ? m.herd_waiting_merger_group({
+                who: mergerWho,
+                count: partition.waitingOnMerger.length,
+              })
+            : m.herd_waiting_merger_group_multi({ count: partition.waitingOnMerger.length })}
+        </div>
+        {#each partition.waitingOnMerger as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            activity={activity[session.id]}
+            {ondecommission}
+            {onrelaunch}
+            {onrelaunchElsewhere}
+            {repoFilter}
+            {onrepofilter}
+            {workingBlocked}
+          />
+        {/each}
+      {/if}
+      {#if partition.draftAwaitingSignoff.length > 0}
+        <div class="draft-head micro">
+          {m.herd_draft_awaiting_signoff_group({ count: partition.draftAwaitingSignoff.length })}
+        </div>
+        {#each partition.draftAwaitingSignoff as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            activity={activity[session.id]}
+            {ondecommission}
+            {onrelaunch}
+            {onrelaunchElsewhere}
+            {repoFilter}
+            {onrepofilter}
+            {workingBlocked}
+          />
+        {/each}
+      {/if}
+      {#if partition.awaitingMerge.length > 0}
+        <div class="awaiting-head micro">
+          {m.herd_awaiting_merge_group({ count: partition.awaitingMerge.length })}
+        </div>
+        {#each partition.awaitingMerge as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            activity={activity[session.id]}
+            previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
+            {onpreview}
+            {ondecommission}
+            {onrelaunch}
+            {onrelaunchElsewhere}
+            {repoFilter}
+            {onrepofilter}
+            {workingBlocked}
+          />
+        {/each}
+      {/if}
+      {#if partition.ready.length + readyAbove > 0}
+        <div class="ready-head micro">
+          {#if partition.ready.length > 0}
+            {m.herd_ready_group({ count: partition.ready.length })}
+          {/if}
+          {#if readyAbove > 0}
+            <span class="above">{m.herd_in_epics_above({ count: readyAbove })}</span>
+          {/if}
+          {#if onmergetrain && readyPrCount > 0}
+            <button
+              type="button"
+              class="merge-train micro"
+              title={m.herd_merge_train_title()}
+              onclick={onmergetrain}>{m.herd_merge_train_action()}</button
+            >
+          {/if}
+        </div>
+        {#each partition.ready as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            activity={activity[session.id]}
+            previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
+            {onpreview}
+            {ondecommission}
+            {onrelaunch}
+            {onrelaunchElsewhere}
+            {repoFilter}
+            {onrepofilter}
+            {workingBlocked}
+          />
+        {/each}
+      {/if}
+      {#if partition.merging.length > 0}
+        <div class="merging-head micro">
+          {m.herd_merging_group({ count: partition.merging.length })}
+        </div>
+        {#each partition.merging as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            activity={activity[session.id]}
+            previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
+            {onpreview}
+            {ondecommission}
+            {onrelaunch}
+            {onrelaunchElsewhere}
+            {repoFilter}
+            {onrepofilter}
+            {workingBlocked}
+          />
+        {/each}
+      {/if}
+      {#if partition.merged.length + mergedAbove > 0}
+        <div class="merged-head micro">
+          {#if partition.merged.length > 0}
+            {m.herd_merged_group({ count: partition.merged.length })}
+          {/if}
+          {#if mergedAbove > 0}
+            <span class="above">{m.herd_in_epics_above({ count: mergedAbove })}</span>
+          {/if}
+          {#if onclearmerged && mergedCount > 0}
+            <button
+              type="button"
+              class="clear-merged micro"
+              title={m.herd_clear_merged_title()}
+              onclick={onclearmerged}>{m.herd_clear_merged_action()}</button
+            >
+          {/if}
+        </div>
+        {#each partition.merged as session (session.id)}
+          <UnitRow
+            {session}
+            selected={session.id === selectedId}
+            {nowMs}
+            {onselect}
+            git={git[session.id]}
+            activity={activity[session.id]}
+            previewPort={preview[session.id] ?? null}
+            previewServeFailed={previewServe[session.id] === "failed"}
+            {onpreview}
+            {ondecommission}
+            {onrelaunch}
+            {onrelaunchElsewhere}
+            {repoFilter}
+            {onrepofilter}
+            {workingBlocked}
+          />
+        {/each}
+      {/if}
+    {/if}
   </div>
-  {#if collapsible}
-    <button
-      id="herd-collapse-btn"
-      type="button"
-      class="collapse-edge"
-      title={m.herd_collapse()}
-      aria-label={m.herd_collapse()}
-      onclick={() => oncollapse?.()}>‹</button
-    >
-  {/if}
 </div>
 
 <style>
-  /* display: contents keeps the non-collapsible (desktop/mobile) layout
-     byte-for-byte identical — the .panel stays the laid-out grid/flow child.
-     Only when collapsible (touch && !mobile) does it become a flex row holding
-     the panel + the right-edge collapse tab. */
-  .herd-root {
-    display: contents;
-  }
-  .herd-root.collapsible {
-    display: flex;
-    min-width: 0;
-    min-height: 0;
-  }
-  .herd-root.collapsible > .panel {
-    flex: 1;
-    min-width: 0;
-  }
-
   .panel {
     position: relative;
     border: 1px solid var(--color-line);
@@ -625,6 +606,7 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
+    min-width: 0;
   }
 
   .bracket::before,
@@ -700,33 +682,12 @@
     box-shadow: inset 0 0 0 1px var(--color-amber);
   }
 
-  /* collapse trigger — a slim full-height tab on the panel's right edge, the
-     mirror image of the reopen tab (+page.svelte .reopen-tab); both are the same
-     44px width and appear on the same touch devices. Replaces the old in-header
-     chevron, which wrapped to its own row when the filter group's auto-margin
-     starved it of space. */
-  .collapse-edge {
-    flex: 0 0 44px;
-    box-sizing: border-box;
-    align-self: stretch;
-    background: var(--color-panel);
-    border: 1px solid var(--color-line);
-    border-left: 0;
-    color: var(--color-faint);
+  /* inline collapse trigger living in the filters group (touch wide devices). */
+  .collapse-inline {
+    flex: none;
+    margin-left: 4px;
     font-size: var(--fs-lg);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-    transition: color 0.12s ease;
-  }
-  .collapse-edge:hover {
-    color: var(--color-ink);
-  }
-  .collapse-edge:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 1px var(--color-amber);
+    line-height: 1;
   }
 
   .micro {


### PR DESCRIPTION
## Problem

On unfolded foldables (`(pointer: coarse)` + width > 768px) the left **THE HERD** sidebar is a narrow grid column (`minmax(244px, 288px)`) that *additionally* surrendered a fixed **44px** to a full-height right-edge collapse tab. The epic group header row (`chevron + repo-icon + repo + title + #num` + EPIC badge + cue chips) exceeded the remaining width and overflowed/overlapped — the reported "epic display broken on unfolded fold."

## Fix

Two coherent changes:

1. **Harden the epic header** so it degrades gracefully and can never overflow (`EpicGroupHeader.svelte`, `EpicBadge.svelte`):
   - `.epic-toggle` gets `overflow: hidden` (final clip boundary).
   - `.repo` becomes a real shrink sink (`flex: 0 1 auto; min-width: 0`) so it ellipsises under pressure; `.title` flex made explicit for consistency.
   - `.epic-badge` pinned `flex: none` — the `EPIC x/y` badge (and the already-`flex:none` cue chips) stay visible; the trailing `#num` is clipped only at the genuine extreme (self-documenting comment added).
2. **Relocate the collapse control** (`Herd.svelte`) — per design discussion, move the `‹` arrow off the wasteful 44px edge tab into the **trailing end of the filters bar** (`fbtn collapse-inline`), reclaiming the horizontal space. The `.herd-root` wrapper is removed (`.panel` becomes top-level) with the load-bearing `min-width: 0` re-added to `.panel`; dead `.collapse-edge`/`.herd-root` CSS + stale comments removed. The button keeps `id="herd-collapse-btn"` so `+page.svelte`'s focus-on-reopen contract is preserved. The collapsed `›` reopen tab is unchanged.

## Verification

- `bun run check` (0 errors) + `bun run test` (1165 passing) green after rebase onto latest main.
- **Visual check against live data** at an emulated touch/coarse-pointer 900×800 viewport with the real `flowagent` epic #327:
  - epic header fits the panel, no overflow/overlap; repo/title ellipsise; `#327` + `EPIC 4/6` badge fully visible;
  - `‹` appears inline at the trailing end of the filters row (not a 44px edge tab); collapse → slim `›` bar → restore all work;
  - non-touch desktop (1400×900): epic header normal, **no** inline `‹` arrow (renders only on touch-wide).

## Notes

- No new i18n strings (reuses `m.herd_collapse()`); no design-token literals introduced.
- `fix(...)` commits ship no new user-facing capability surface, so no feature-catalog entry (`[no-feature-entry]` not needed — the gate is armed only by `feat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)