### PR TITLE
fix(plan-gate): re-adopt in-flight plan reviews orphaned by a restart

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -465,6 +465,11 @@ const planGate = new PlanGateService({
   onReviewing: (id, reviewing) => events.emit("session:plangate-reviewing", { id, reviewing }),
   cap: () => config.planReviewCyclesCap,
 });
+// Re-adopt plan reviews left in flight by the previous run (the `inflight` map is in-memory):
+// without this a restart mid-review orphans the reviewer forever — its verdict goes unread, the
+// gate never advances, and the planning agent sits idle awaiting a re-review that never comes.
+// The next tick() then finalizes each re-adopted run from the verdict it already wrote.
+void planGate.adoptOrphans().catch((err) => console.warn("[plan-gate] adoptOrphans:", err));
 attachReviewPush(events, store, push);
 attachGitPush(events, store, push);
 attachMergePush(events, push);

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -110,8 +110,9 @@ export interface PlanGateServiceDeps {
     | "get"
     | "recordReviewerSpawn"
     | "completeReviewerSpawn"
+    | "listReviewerSpawns"
   >;
-  herdr: Pick<HerdrDriver, "start" | "stop">;
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list">;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "gitCommonDir">;
   /** Resolve the forge for a repo so begin() can fetch the originating issue's body as UNTRUSTED
    *  reviewer context. Optional + optional-chained: absence ⇒ no issue context (never blocks). */
@@ -134,6 +135,10 @@ export interface PlanGateServiceDeps {
   timeoutMs?: number; // give up waiting on the verdict file
   /** default: read `.shepherd-plan.md` from the live worktree. */
   readPlan?: (worktreePath: string) => string | null;
+  /** default: `existsSync` — whether a reviewer's disposable worktree is still on disk.
+   *  adoptOrphans() uses it to tell a true restart-orphan (worktree survives) from an
+   *  already-finalized review (finalize reaps the worktree). */
+  worktreeExists?: (worktreePath: string) => boolean;
   /** default: read PLAN_VERDICT_FILE from the reviewer's disposable worktree. */
   readVerdict?: (worktreePath: string) => RawPlanVerdict | null;
   /** default: `git rev-parse origin/<base>` (fallback `<base>`) in the repo. */
@@ -183,6 +188,7 @@ export class PlanGateService {
   }
   private readPlan: (worktreePath: string) => string | null;
   private readVerdict: (worktreePath: string) => RawPlanVerdict | null;
+  private worktreeExists: (worktreePath: string) => boolean;
   private baseSha: (repoPath: string, base: string) => string;
   private readUsage: (
     worktreePath: string,
@@ -224,6 +230,7 @@ export class PlanGateService {
     this.capFn = typeof cap === "function" ? cap : () => cap ?? DEFAULT_CAP;
     this.readPlan = deps.readPlan ?? defaultReadPlan;
     this.readVerdict = deps.readVerdict ?? defaultReadVerdict;
+    this.worktreeExists = deps.worktreeExists ?? existsSync;
     this.baseSha = deps.baseSha ?? defaultBaseSha;
     this.readUsage = deps.readUsage ?? readSessionUsage;
   }
@@ -353,6 +360,48 @@ export class PlanGateService {
     });
     this.deps.onReviewing?.(session.id, true);
     return "started";
+  }
+
+  /** Re-adopt plan reviews that were in flight when the server last stopped. The `inflight`
+   *  map is in-memory only, so a restart mid-review used to orphan the reviewer forever: its
+   *  verdict was never read, the gate never advanced, and the planning agent sat idle waiting
+   *  for a re-review that would never come. This rebuilds those entries from the persisted
+   *  `reviewer_spawns` rows so the normal `tick()` finalizes them — reading the verdict the
+   *  reviewer already wrote, or timing the run out. Call once at boot, before the tick loop.
+   *
+   *  An orphan is a `plan_gate` spawn that never completed AND whose disposable worktree still
+   *  exists — finalize() reaps that worktree, so a surviving one means finalize never ran. */
+  async adoptOrphans(): Promise<void> {
+    for (const sp of this.deps.store.listReviewerSpawns()) {
+      if (sp.kind !== "plan_gate" || sp.completedAt != null) continue;
+      const id = sp.taskSessionId;
+      if (this.inflight.has(id) || this.starting.has(id)) continue;
+      const s = this.deps.store.get(id);
+      if (!s || s.planPhase !== "planning") continue; // session gone or already past the gate
+      // Reaped worktree ⇒ the review finalized (finalize removes it); nothing to re-adopt.
+      if (!this.worktreeExists(sp.worktreePath)) continue;
+      const prior = this.deps.store.getPlanGate(id);
+      const plan = (this.readPlan(s.worktreePath) ?? "").trim();
+      this.inflight.set(id, {
+        sessionId: id,
+        repoPath: s.repoPath,
+        worktreePath: sp.worktreePath,
+        terminalId: this.resolveTerminal(sp.worktreePath),
+        reviewerSessionId: sp.reviewerSessionId,
+        planHash: await PlanGateService.hashPlan(plan),
+        plan,
+        priorRound: prior?.round ?? 0,
+        startedAt: sp.spawnedAt, // keep the original start so a verdict-less orphan times out
+      });
+      this.deps.onReviewing?.(id, true);
+    }
+  }
+
+  /** Best-effort: find the reviewer's live terminal id by its disposable-worktree cwd, so a
+   *  re-adopted orphan can still be reaped. "" when no live pane matches (reviewer already gone);
+   *  herdr.stop("") is a safe no-op. */
+  private resolveTerminal(worktreePath: string): string {
+    return this.deps.herdr.list().find((a) => a.cwd === worktreePath)?.terminalId ?? "";
   }
 
   /** Finalize any in-flight plan review whose verdict file is ready or that timed out. */

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -21,6 +21,7 @@ function harness(over: any = {}) {
     get: () => ({ id: "s1", auto: false }),
     recordReviewerSpawn: (r: any) => recordedSpawns.push(r),
     completeReviewerSpawn: (id: any, u: any, at: any) => completedSpawns.push({ id, u, at }),
+    listReviewerSpawns: () => [],
     ...(over.store ?? {}),
   };
   const deps: any = {
@@ -31,7 +32,9 @@ function harness(over: any = {}) {
         return { terminalId: "t1" };
       },
       stop() {},
+      list: () => [],
     },
+    worktreeExists: () => true,
     worktree: {
       createDetached: async () => ({ worktreePath: "/wt-detached", branch: "main" }),
       remove: (p: string) => removed.push(p),
@@ -452,4 +455,116 @@ test("plan-gate reviewer spawn degrades to unwrapped when backend is null", asyn
   await h.svc.consider(planningSession() as any);
   const argv = h.started[0]!.argv;
   expect(argv[0]).not.toBe("bwrap"); // passthrough — identical to pre-sandbox behavior
+});
+
+// ── adoptOrphans: recover plan reviews orphaned by a restart ──────────────────
+const orphanSpawn = (over: any = {}) => ({
+  reviewerSessionId: "rev-1",
+  taskSessionId: "s1",
+  kind: "plan_gate",
+  worktreePath: "/wt-detached",
+  model: null,
+  spawnedAt: 1000,
+  completedAt: null,
+  inputTokens: null,
+  outputTokens: null,
+  cacheReadTokens: null,
+  cacheWriteTokens: null,
+  totalTokens: null,
+  ...over,
+});
+
+test("adoptOrphans re-adopts an orphaned review; next tick finalizes it from the on-disk verdict", async () => {
+  const replied: string[] = [];
+  const h = harness({
+    now: () => 1000,
+    store: {
+      get: () => ({ id: "s1", repoPath: "/r", worktreePath: "/wt", planPhase: "planning" }),
+      getPlanGate: () => ({ round: 1, decision: "changes_requested" }),
+      listReviewerSpawns: () => [orphanSpawn()],
+    },
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "fix it",
+      body: "B",
+      findings: ["do A"],
+    }),
+    reply: (id: string) => {
+      replied.push(id);
+      return true;
+    },
+  });
+  await h.svc.adoptOrphans();
+  expect(h.svc.reviewingIds()).toEqual(["s1"]); // re-claimed into inflight
+  await h.svc.tick();
+  expect(h.store.gate.decision).toBe("changes_requested");
+  expect(h.store.gate.round).toBe(2); // priorRound (1) advanced once the steer landed
+  expect(replied).toEqual(["s1"]); // findings steered back to the planning agent
+  expect(h.removed).toContain("/wt-detached"); // reviewer worktree reaped
+});
+
+test("adoptOrphans skips a spawn whose worktree was already reaped (finalized)", async () => {
+  const h = harness({
+    worktreeExists: () => false,
+    store: {
+      get: () => ({ id: "s1", repoPath: "/r", worktreePath: "/wt", planPhase: "planning" }),
+      listReviewerSpawns: () => [orphanSpawn()],
+    },
+  });
+  await h.svc.adoptOrphans();
+  expect(h.svc.reviewingIds()).toEqual([]);
+});
+
+test("adoptOrphans ignores completed, non-plan_gate, and non-planning spawns", async () => {
+  const h = harness({
+    store: {
+      get: () => ({ id: "s1", repoPath: "/r", worktreePath: "/wt", planPhase: "executing" }),
+      listReviewerSpawns: () => [
+        orphanSpawn({ completedAt: 5 }),
+        orphanSpawn({ kind: "review" }),
+        orphanSpawn(), // planPhase is "executing" above → skipped
+      ],
+    },
+  });
+  await h.svc.adoptOrphans();
+  expect(h.svc.reviewingIds()).toEqual([]);
+});
+
+test("adopted orphan with no verdict, past timeout → error gate + stall (fail-closed)", async () => {
+  const signals: any[] = [];
+  let t = 1000;
+  const h = harness({
+    now: () => t,
+    readVerdict: () => null,
+    store: {
+      get: () => ({ id: "s1", repoPath: "/r", worktreePath: "/wt", planPhase: "planning" }),
+      listReviewerSpawns: () => [orphanSpawn()], // spawnedAt = 1000
+      addSignal: (s: any) => signals.push(s),
+    },
+  });
+  await h.svc.adoptOrphans();
+  t = 1000 + 11 * 60 * 1000; // exceed the 10m timeout measured from spawnedAt
+  await h.svc.tick();
+  expect(h.store.gate.decision).toBe("error");
+  expect(signals.some((s) => s.kind === "stall")).toBe(true);
+  expect(h.removed).toContain("/wt-detached");
+});
+
+test("adoptOrphans resolves the reviewer terminal by worktree cwd for reaping", async () => {
+  const stopped: string[] = [];
+  const h = harness({
+    store: {
+      get: () => ({ id: "s1", repoPath: "/r", worktreePath: "/wt", planPhase: "planning" }),
+      listReviewerSpawns: () => [orphanSpawn()],
+    },
+    herdr: {
+      start: () => ({ terminalId: "t1" }),
+      stop: (id: string) => stopped.push(id),
+      list: () => [{ cwd: "/wt-detached", terminalId: "rev-term-9" }],
+    },
+    readVerdict: () => ({ decision: "approve", summary: "ok", body: "B", findings: [] }),
+  });
+  await h.svc.adoptOrphans();
+  await h.svc.tick();
+  expect(stopped).toContain("rev-term-9"); // reaped the resolved live reviewer terminal
 });


### PR DESCRIPTION
## Problem

Tasks parked in plan-gate **REWORK** that sit **idle forever** instead of reworking. Observed live on TASK-413/421/423/424: each planning agent had revised its plan and gone idle "for re-review," but the gate never advanced.

Root cause: `PlanGateService.inflight` (the map of in-progress plan reviews) is **in-memory only**. Shepherd redeploys on every merge, so a restart routinely lands mid-review. When it does:

- the spawned reviewer runs to completion and writes its verdict JSON, but
- the `inflight` entry that `tick()` reads to consume that verdict is gone, so
- the gate never advances, the reviewer worktree/terminal are never reaped, and
- the planning agent waits on a re-review that will never be finalized.

Unlike sessions and the tailscale-serve range, the plan gate had **no boot reconciliation**, so an orphaned review wedged the task permanently.

## Fix

`adoptOrphans()` — called once at boot before the tick loop — rebuilds `inflight` from the persisted `reviewer_spawns` rows. An orphan is a `plan_gate` spawn that **never completed** AND whose **disposable worktree still exists** (finalize reaps the worktree, so a survivor means finalize never ran). Each orphan is re-claimed into `inflight`, and the existing `tick()` then finalizes it through the normal path:

- verdict on disk → advance gate, steer findings back / release, reap worktree+terminal, record token totals;
- no verdict + past timeout → fail-closed `error` gate + stall signal (surfaces to a human rather than going silently idle).

The reviewer terminal is re-resolved best-effort by its worktree cwd for reaping. No schema change.

## Tests

5 new `adoptOrphans` cases (re-adopt+finalize from on-disk verdict, skip already-reaped, ignore completed/non-plan_gate/non-planning, fail-closed timeout, terminal resolution). Full root suite green (2551 pass), tsc + lint clean.

[no-feature-entry] — server-only restart-recovery; no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)