### PR TITLE
fix(merge-train): confirm before launching a merge train

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1182,7 +1182,7 @@
   "diagnostics_rerun_error": "Checks konnten nicht neu geprüft werden.",
   "diagnostics_load_error": "Checks konnten nicht geladen werden.",
   "mergetrain_confirm_title": "Merge-Train starten",
-  "mergetrain_confirm_desc_ready": "{count} bereite PRs in {repo} abarbeiten?",
+  "mergetrain_confirm_desc_ready": "{count} bereite PR(s) in {repo} abarbeiten?",
   "mergetrain_confirm_desc_picked": "{count} ausgewählte PRs in {repo} abarbeiten?",
   "mergetrain_confirm_action": "Merge-Train starten",
   "mergetrain_confirm_other_repos": "{count} bereite PR(s) in anderen Repos sind nicht enthalten."

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -666,7 +666,6 @@
   "toast_cleared_merged": "{count} gemergte Sessions aufgeräumt",
   "toast_clear_merged_failed": "Gemergte Sessions konnten nicht aufgeräumt werden",
   "toast_merge_train_no_prs": "Keine merge-bereiten PRs für einen Merge-Train vorhanden",
-  "toast_merge_train_other_repos": "{count} merge-bereite PRs in anderen Repos wurden ausgelassen; starte dort einen separaten Merge-Train",
   "toast_merge_train_failed": "Merge-Train konnte nicht gestartet werden",
   "toast_merge_train_mark_failed": "Merge-Train gestartet, aber das Markieren der PRs ist fehlgeschlagen.",
   "toast_merged": "{name} gemergt",
@@ -1181,5 +1180,10 @@
   "feat_diagnostics_body": "Shepherd prüft jetzt seine Voraussetzungen — herdr, Tailscale, git, gh, claude, bun und node — und warnt dich unter Einstellungen → Diagnose, wenn etwas fehlt oder besser konfiguriert werden könnte.",
   "diagnostics_hint_gh_missing": "GitHub CLI (gh) nicht im PATH gefunden — installiere es und führe anschließend gh auth login aus.",
   "diagnostics_rerun_error": "Checks konnten nicht neu geprüft werden.",
-  "diagnostics_load_error": "Checks konnten nicht geladen werden."
+  "diagnostics_load_error": "Checks konnten nicht geladen werden.",
+  "mergetrain_confirm_title": "Merge-Train starten",
+  "mergetrain_confirm_desc_ready": "{count} bereite PRs in {repo} abarbeiten?",
+  "mergetrain_confirm_desc_picked": "{count} ausgewählte PRs in {repo} abarbeiten?",
+  "mergetrain_confirm_action": "Merge-Train starten",
+  "mergetrain_confirm_other_repos": "{count} bereite PR(s) in anderen Repos sind nicht enthalten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -666,7 +666,6 @@
   "toast_cleared_merged": "Cleared {count} merged sessions",
   "toast_clear_merged_failed": "Couldn't clear merged sessions",
   "toast_merge_train_no_prs": "No ready-to-merge PRs to run a merge train on",
-  "toast_merge_train_other_repos": "{count} ready-to-merge PRs in other repos were left out; run a separate merge train there",
   "toast_merge_train_failed": "Couldn't start the merge train",
   "toast_merge_train_mark_failed": "Merge train started, but marking its PRs failed.",
   "toast_merged": "Merged {name}",
@@ -1181,5 +1180,10 @@
   "feat_diagnostics_body": "Shepherd now checks its prerequisites — herdr, tailscale, git, gh, claude, bun, and node — and warns you in Settings → Diagnostics when something's missing or could be configured better.",
   "diagnostics_hint_gh_missing": "GitHub CLI (gh) not found in PATH — install it, then run gh auth login.",
   "diagnostics_rerun_error": "Failed to re-run checks.",
-  "diagnostics_load_error": "Couldn't load checks."
+  "diagnostics_load_error": "Couldn't load checks.",
+  "mergetrain_confirm_title": "Start merge train",
+  "mergetrain_confirm_desc_ready": "Work through {count} ready PRs in {repo}?",
+  "mergetrain_confirm_desc_picked": "Work through {count} selected PRs in {repo}?",
+  "mergetrain_confirm_action": "Start merge train",
+  "mergetrain_confirm_other_repos": "{count} ready PR(s) in other repos are not included."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1182,7 +1182,7 @@
   "diagnostics_rerun_error": "Failed to re-run checks.",
   "diagnostics_load_error": "Couldn't load checks.",
   "mergetrain_confirm_title": "Start merge train",
-  "mergetrain_confirm_desc_ready": "Work through {count} ready PRs in {repo}?",
+  "mergetrain_confirm_desc_ready": "Work through {count} ready PR(s) in {repo}?",
   "mergetrain_confirm_desc_picked": "Work through {count} selected PRs in {repo}?",
   "mergetrain_confirm_action": "Start merge train",
   "mergetrain_confirm_other_repos": "{count} ready PR(s) in other repos are not included."

--- a/ui/src/lib/components/MergeTrainConfirmDialog.svelte
+++ b/ui/src/lib/components/MergeTrainConfirmDialog.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+  import { dialog } from "$lib/a11yDialog";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    repoLabel,
+    items,
+    handpicked,
+    otherRepoCount,
+    onclose,
+    onconfirm,
+  }: {
+    /** Short repo name (basename) for the desc line. */
+    repoLabel: string;
+    /** PRs the train will work through — `#<number> <title>` per row. */
+    items: { number: number; title: string }[];
+    /** false = ready-group path (genuinely flagged ready); true = backlog hand-pick. */
+    handpicked: boolean;
+    /** Ready PRs in OTHER repos excluded from this train (>0 only on the ready path). */
+    otherRepoCount: number;
+    onclose: () => void;
+    /** Launch the merge train. */
+    onconfirm: () => void;
+  } = $props();
+</script>
+
+<div
+  class="overlay"
+  role="presentation"
+  onclick={(e) => {
+    if (e.target === e.currentTarget) onclose();
+  }}
+>
+  <div
+    class="card"
+    role="dialog"
+    aria-modal="true"
+    aria-label={m.mergetrain_confirm_title()}
+    use:dialog={{ onclose }}
+  >
+    <div class="chead">
+      <span class="micro">{m.mergetrain_confirm_title()}</span>
+      <button type="button" class="x" onclick={onclose} aria-label={m.common_close()}>✕</button>
+    </div>
+
+    <p class="desc">
+      {#if handpicked}
+        {m.mergetrain_confirm_desc_picked({ count: items.length, repo: repoLabel })}
+      {:else}
+        {m.mergetrain_confirm_desc_ready({ count: items.length, repo: repoLabel })}
+      {/if}
+    </p>
+
+    <div class="rows">
+      {#each items as it (it.number)}
+        <div class="row">
+          <span class="num">#{it.number}</span>
+          <span class="nm">{it.title}</span>
+        </div>
+      {/each}
+    </div>
+
+    {#if otherRepoCount > 0}
+      <p class="warn">{m.mergetrain_confirm_other_repos({ count: otherRepoCount })}</p>
+    {/if}
+
+    <div class="actions">
+      <button type="button" class="ghost" onclick={onclose}>{m.common_cancel()}</button>
+      <button type="button" class="run" onclick={onconfirm}>
+        {m.mergetrain_confirm_action()}
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--color-scrim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+  }
+  .card {
+    width: min(440px, 92vw);
+    border: 1px solid var(--color-line-bright);
+    background: var(--color-panel);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .chead {
+    display: flex;
+    align-items: center;
+  }
+  .x {
+    margin-left: auto;
+    background: transparent;
+    border: 0;
+    color: var(--color-muted);
+    cursor: pointer;
+    font: inherit;
+  }
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .desc {
+    margin: 0;
+    color: var(--color-ink);
+    font-size: var(--fs-base);
+    line-height: 1.4;
+  }
+  .rows {
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    border-radius: 2px;
+    display: flex;
+    flex-direction: column;
+    max-height: 200px;
+    overflow-y: auto;
+  }
+  .row {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font-size: var(--fs-base);
+  }
+  .row:last-child {
+    border-bottom: 0;
+  }
+  .num {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    color: var(--color-blue);
+  }
+  .nm {
+    font-family: var(--font-mono, monospace);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .warn {
+    margin: 0;
+    color: var(--color-amber);
+    font-size: var(--fs-meta);
+    line-height: 1.4;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 2px;
+  }
+  .ghost,
+  .run {
+    border: 1px solid var(--color-line-bright);
+    background: transparent;
+    color: var(--color-ink);
+    padding: 9px 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: var(--fs-meta);
+    cursor: pointer;
+  }
+  .run {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  @media (max-width: 768px) {
+    .overlay {
+      align-items: stretch;
+      justify-content: stretch;
+    }
+    .card {
+      width: 100%;
+      height: 100dvh;
+      border: 0;
+      overflow-y: auto;
+    }
+  }
+</style>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -82,6 +82,7 @@
   import type { KickoffChoice } from "$lib/components/NewProject.svelte";
   import BroadcastDialog from "$lib/components/BroadcastDialog.svelte";
   import ClearMergedDialog from "$lib/components/ClearMergedDialog.svelte";
+  import MergeTrainConfirmDialog from "$lib/components/MergeTrainConfirmDialog.svelte";
   import ActionBar from "$lib/components/ActionBar.svelte";
   import HerdGrid from "$lib/components/HerdGrid.svelte";
   import QueueStrip from "$lib/components/QueueStrip.svelte";
@@ -144,6 +145,17 @@
   // leftover subprocess count (both fetched server-side when the modal opens).
   let clearMergedSessions = $state<Session[] | null>(null);
   let clearMergedLeftovers = $state(0);
+  // Pending merge-train awaiting operator confirmation. Setting it opens the
+  // confirm modal; confirming runs `run` (the original launch); closing discards
+  // with zero side effects. `run` carries the full launch closure for whichever
+  // trigger armed it, so the modal stays uniform across both paths.
+  let pendingTrain = $state<{
+    repoLabel: string;
+    items: { number: number; title: string }[];
+    handpicked: boolean;
+    otherRepoCount: number;
+    run: () => Promise<void>;
+  } | null>(null);
   let showTriage = $state(false);
   let showLearnings = $state(false);
   // When the learnings drawer is opened from a repo's chip (its ✦ in the RepoSwitcher
@@ -477,7 +489,7 @@
   // order. A merge train is per-repo, so when ready PRs span repos we scope to
   // the repo with the most and surface a fail-loud notice for the rest rather
   // than silently folding them in. Mirrors onquickissue for branch + create.
-  async function onmergetrain() {
+  function onmergetrain() {
     const ready = collectReadyPrs(
       store.sessions,
       store.git,
@@ -488,27 +500,35 @@
       toasts.info(m.toast_merge_train_no_prs());
       return;
     }
-    const br = await listBranches(repoPath).catch(() => null);
-    const baseBranch = br?.current ?? br?.branches[0] ?? "main";
-    try {
-      const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs));
-      selectedId = s.id;
-      // Mark this repo's ready PR-sessions as "merging" so the list shows them
-      // in-flight. Derived from the same scoped `prs` array the train works
-      // through — single source of truth, no separate filter needed.
-      // Fire-and-forget + fail-soft: a marking error must not abort the launch —
-      // the train (session s) is already running.
-      startMergeTrain(
-        prs.map((p) => p.sessionId),
-        s.id,
-      ).catch(() => toasts.info(m.toast_merge_train_mark_failed()));
-      showBacklog = false;
-      if (mobile.current) mobileScreen = "detail";
-      if (otherRepoCount > 0)
-        toasts.info(m.toast_merge_train_other_repos({ count: otherRepoCount }));
-    } catch {
-      toasts.info(m.toast_merge_train_failed());
-    }
+    // Don't launch yet — open the confirm modal. The excluded-repo count is
+    // surfaced as the modal's warn line, NOT a post-launch toast (no double-surfacing).
+    pendingTrain = {
+      repoLabel: basename(repoPath),
+      items: prs.map((p) => ({ number: p.number, title: p.title })),
+      handpicked: false,
+      otherRepoCount,
+      run: async () => {
+        const br = await listBranches(repoPath).catch(() => null);
+        const baseBranch = br?.current ?? br?.branches[0] ?? "main";
+        try {
+          const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs));
+          selectedId = s.id;
+          // Mark this repo's ready PR-sessions as "merging" so the list shows them
+          // in-flight. Derived from the same scoped `prs` array the train works
+          // through — single source of truth, no separate filter needed.
+          // Fire-and-forget + fail-soft: a marking error must not abort the launch —
+          // the train (session s) is already running.
+          startMergeTrain(
+            prs.map((p) => p.sessionId),
+            s.id,
+          ).catch(() => toasts.info(m.toast_merge_train_mark_failed()));
+          showBacklog = false;
+          if (mobile.current) mobileScreen = "detail";
+        } catch {
+          toasts.info(m.toast_merge_train_failed());
+        }
+      },
+    };
   }
 
   /** Launch a merge train scoped to a hand-picked set of PRs from the backlog
@@ -516,30 +536,40 @@
    *  operator chose these PRs directly, so the kickoff prompt uses the
    *  hand-picked framing. Matching ready-to-merge sessions are marked "merging";
    *  backlog-only PRs (no session) still ride along in the prompt. */
-  async function onlaunchtrain(repoPath: string, prs: PullRequest[]) {
+  function onlaunchtrain(repoPath: string, prs: PullRequest[]) {
     if (prs.length < 2) return; // UI gates at >=2; defensive guard
-    const br = await listBranches(repoPath).catch(() => null);
-    const baseBranch = br?.current ?? br?.branches[0] ?? "main";
-    try {
-      const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs, true));
-      selectedId = s.id;
-      // Mark any ready-to-merge sessions whose open PR is in this selection as
-      // "merging" (same coupling as onmergetrain). Composed review predicate
-      // matches onmergetrain. Fire-and-forget + fail-soft; skip when none match.
-      const ids = sessionsForPrNumbers(
-        repoPath,
-        prs.map((p) => p.number),
-        store.sessions,
-        store.git,
-        (id) => reviews.isReviewing(id) || planGates.isReviewing(id),
-      );
-      if (ids.length > 0)
-        startMergeTrain(ids, s.id).catch(() => toasts.info(m.toast_merge_train_mark_failed()));
-      showBacklog = false;
-      if (mobile.current) mobileScreen = "detail";
-    } catch {
-      toasts.info(m.toast_merge_train_failed());
-    }
+    // Don't launch yet — open the confirm modal (renders above the still-mounted
+    // backlog overlay). The launch body runs on confirm; backlog stays open until then.
+    pendingTrain = {
+      repoLabel: basename(repoPath),
+      items: prs.map((p) => ({ number: p.number, title: p.title })),
+      handpicked: true,
+      otherRepoCount: 0,
+      run: async () => {
+        const br = await listBranches(repoPath).catch(() => null);
+        const baseBranch = br?.current ?? br?.branches[0] ?? "main";
+        try {
+          const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs, true));
+          selectedId = s.id;
+          // Mark any ready-to-merge sessions whose open PR is in this selection as
+          // "merging" (same coupling as onmergetrain). Composed review predicate
+          // matches onmergetrain. Fire-and-forget + fail-soft; skip when none match.
+          const ids = sessionsForPrNumbers(
+            repoPath,
+            prs.map((p) => p.number),
+            store.sessions,
+            store.git,
+            (id) => reviews.isReviewing(id) || planGates.isReviewing(id),
+          );
+          if (ids.length > 0)
+            startMergeTrain(ids, s.id).catch(() => toasts.info(m.toast_merge_train_mark_failed()));
+          showBacklog = false;
+          if (mobile.current) mobileScreen = "detail";
+        } catch {
+          toasts.info(m.toast_merge_train_failed());
+        }
+      },
+    };
   }
 
   const mobile = new MediaQuery("max-width: 768px");
@@ -1174,6 +1204,14 @@
     void runClearMerged(targets.map((s) => s.id));
   }
 
+  // Confirmed: capture the launch closure, clear the dialog state BEFORE awaiting
+  // (so it can't double-fire), then run the original launch.
+  function confirmTrain() {
+    const run = pendingTrain?.run;
+    pendingTrain = null;
+    if (run) void run();
+  }
+
   // The deploy runs detached: it builds, restarts the server, and only then —
   // after the new process answers a health check — writes its success marker.
   // So a readable `done` GUARANTEES the new build is already live. We poll the
@@ -1752,6 +1790,17 @@
     onclose={() => (showBacklog = false)}
     epics={store.epics}
     target={epicTarget}
+  />
+{/if}
+
+{#if pendingTrain}
+  <MergeTrainConfirmDialog
+    repoLabel={pendingTrain.repoLabel}
+    items={pendingTrain.items}
+    handpicked={pendingTrain.handpicked}
+    otherRepoCount={pendingTrain.otherRepoCount}
+    onclose={() => (pendingTrain = null)}
+    onconfirm={confirmTrain}
   />
 {/if}
 


### PR DESCRIPTION
## Why

The merge train launches **immediately on click** from two places, and has been triggered **accidentally twice**. This adds a confirmation modal that previews what the train will do before anything happens.

## What

A single reusable confirm modal (`MergeTrainConfirmDialog.svelte`) now gates **both** merge-train triggers:

- **Ready-to-merge group header button** (`onmergetrain`)
- **Backlog "Launch Train" button** (`onlaunchtrain`)

Each handler is split into *prepare* (opens the modal — no side effects beyond the existing guards) and *run* (the original launch, fires only on **Confirm**). Nothing is created — no `createSession`, no `startMergeTrain` — until the operator confirms. Cancel / Esc / outside-click dismiss with zero side effects.

The modal lists each PR it will work through (`#<number> <title>`), names the repo, and is **readiness-aware**: the hand-picked path says "selected PRs" (never falsely claims "ready"), preserving the codebase's deliberate ready-vs-selected distinction. For a ready set spanning repos, the excluded-repo count now surfaces **in the modal** (pre-launch) instead of a post-launch toast.

## Implementation notes

- Mirrors the existing `ClearMergedDialog` / `confirmClearMerged` pattern (scrim `.overlay` + `.card` + `use:dialog` focus-trap/Esc/restore, inherits the canonical backdrop blur; tokens only).
- New dialog block placed **after** `BacklogOverlay` so it stacks above the still-mounted backlog on the hand-picked path (same `z-index`, later-in-DOM wins).
- 5 new i18n keys × EN/DE (parity gate green). Removed the now-dead `toast_merge_train_other_repos` key.
- No server changes; no prop-chain/signature changes. Labeled `fix:` (accidental-trigger safeguard, not a new headline feature) → no feature-catalog entry.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- `bun run check:i18n` → EN/DE parity (1186 keys)
- `bun run test` → all UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)