### PR TITLE
fix(ui): drop redundant PR merged/closed badge when Stepper shows terminal chip

### DIFF
--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -194,6 +194,12 @@
   const showStepper = $derived(
     dStatus === "running" || dStatus === "blocked" || dStatus === "done",
   );
+  // PrBadge's merged/closed state duplicates the Stepper's terminal chip; when
+  // that chip renders (same git.state), drop PrBadge so the terminal state shows
+  // once (the semantic green/faint chip). Open/draft PRs keep PrBadge as normal.
+  const stepperTerminal = $derived(
+    showStepper && !session.readyToMerge && (git?.state === "merged" || git?.state === "closed"),
+  );
 
   // Decommission is deferred behind an undo window: while it's open, the row is
   // doomed-but-still-present. Dim it so the operator sees it's on its way out.
@@ -445,7 +451,7 @@
           }}>{m.unitrow_preview_badge()}</span
         >
       {/if}
-      <PrBadge {git} />
+      {#if !stepperTerminal}<PrBadge {git} />{/if}
       <CriticBadge sessionId={session.id} />
       <PlanGateBadge {session} />
       <!-- REVIEWING (in-flight critic) outranks the autopilot badge -->


### PR DESCRIPTION
## Problem

On a row card (`UnitRow`) whose PR has **merged** (or closed), the terminal state rendered **twice within the same card**:

- dim slate **`✓ MERGED`** / **`CLOSED`** — `PrBadge` (top-right corner)
- green **`MERGED`** / faint **`CLOSED`** — the `Stepper`'s terminal chip (bottom, in the meta row)

Both read the *identical* fact, `git.state` (the Stepper via `deriveStage()` → `info.terminal`, `stage.ts`). `PrBadge` and `Stepper` were built independently and neither suppressed the other, so at the two terminal git states they converged on the same word. (The `MERGED (n)` group header is the column grouping — correct, untouched.)

## Fix

Suppress `PrBadge` in **`UnitRow` only** when the `Stepper`'s terminal chip is actually rendering, so the terminal state shows **once** — the semantic green/faint chip. A new `$derived` mirrors the chip's exact render gate:

```ts
const stepperTerminal = $derived(
  showStepper && !session.readyToMerge && (git?.state === "merged" || git?.state === "closed"),
);
```

…and the badge is wrapped `{#if !stepperTerminal}<PrBadge {git} />{/if}`.

### Scope / why it's conditional

- `PrBadge` is shared by `PrRow`, `UnitTile`, `Viewport` — none render a `Stepper`, so `PrBadge.svelte` is left untouched; only the `UnitRow` instance is gated. They keep their merged/closed badge.
- The gate ANDs `showStepper && !session.readyToMerge` so a merged session that *isn't* showing the chip (archived/idle, or `readyToMerge`) still keeps `PrBadge` as its sole merged indicator — no signal silently disappears.
- Handles **both** `merged` and `closed` (symmetric).
- Open/draft PRs are unaffected — there `PrBadge` (`PR #…` / `DRAFT`, with CI/review dots) and the `Stepper` segments are complementary, not duplicative.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings (2226 files)
- `cd ui && bun run test` → 1169 passed
- Two-stage subagent review (spec compliance + code quality) — both passed.

No new strings (i18n N/A), no feature-catalog entry (a `fix` removing a redundant element, no new UX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
