### PR TITLE
fix(diagnostics): accurate Tailscale check — detect Service-fronted HUD, fix copy

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -182,9 +182,12 @@ function servedPortInWebMap(webMap: Record<string, unknown>, localPort: number):
  * null without throwing.
  *
  * **Accepted trade-offs:**
- * - On a Tailscale too old to support `--json`, the runner yields nothing
- *   parseable, so a served HUD reads Warning. This is accepted — Shepherd
- *   already requires a Service-capable Tailscale version.
+ * - On a Tailscale too old to support `--json`, the `serve status --json` call
+ *   typically exits non-zero; that rejection surfaces via the probe's *error*
+ *   fallback (`diagnostics_hint_tailscale_missing`), not as a Warning. Only a
+ *   zero-exit-but-unparseable payload reaches this parser and returns null →
+ *   Warning. Either way a served HUD is mis-reported there — accepted, since
+ *   Shepherd already requires a Service-capable Tailscale version.
  * - Loopback coverage is `localhost` + `127.0.0.1` only; `[::1]` is
  *   intentionally not matched (Tailscale always emits one of the two above).
  * - A pending/unapproved Service still shows its mapping in the JSON and so

--- a/src/config.ts
+++ b/src/config.ts
@@ -111,6 +111,100 @@ function isProxyTarget(line: string, localPort: number): boolean {
   return m !== null && Number(m[1]) === localPort;
 }
 
+const LOOPBACK_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1):(\d+)/;
+
+/** Plain (non-array) object guard — arrays are typeof "object" but malformed here. */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+/** Public port from a "host:PORT" web-map key; 443 when absent/non-numeric. */
+function publicPortFromKey(key: string): number {
+  const i = key.lastIndexOf(":");
+  if (i === -1) return 443;
+  const p = Number(key.slice(i + 1));
+  return Number.isFinite(p) ? p : 443;
+}
+
+/** Candidate web maps: top-level Web + each Services[svc].Web (arrays rejected, fail-closed). */
+function collectWebMaps(root: Record<string, unknown>): Array<Record<string, unknown>> {
+  const webMaps: Array<Record<string, unknown>> = [];
+  if (isPlainObject(root["Web"])) webMaps.push(root["Web"]);
+  const services = root["Services"];
+  if (isPlainObject(services)) {
+    for (const svc of Object.values(services)) {
+      if (isPlainObject(svc) && isPlainObject(svc["Web"])) {
+        webMaps.push(svc["Web"]);
+      }
+    }
+  }
+  return webMaps;
+}
+
+/** True when a handler's Proxy targets loopback:localPort. */
+function handlerTargetsPort(handler: unknown, localPort: number): boolean {
+  if (!isPlainObject(handler)) return false;
+  const proxy = handler["Proxy"];
+  if (typeof proxy !== "string") return false;
+  const m = LOOPBACK_RE.exec(proxy);
+  return m !== null && Number(m[1]) === localPort;
+}
+
+/** Public port if any handler in this web map targets localPort, else null. */
+function servedPortInWebMap(webMap: Record<string, unknown>, localPort: number): number | null {
+  for (const [key, entry] of Object.entries(webMap)) {
+    if (!isPlainObject(entry)) continue;
+    const handlers = entry["Handlers"];
+    if (!isPlainObject(handlers)) continue;
+    for (const handler of Object.values(handlers)) {
+      if (handlerTargetsPort(handler, localPort)) return publicPortFromKey(key);
+    }
+  }
+  return null;
+}
+
+/**
+ * JSON-based parser for `tailscale serve status --json` output. Given the raw
+ * JSON string and the HUD's local listen port, returns the public-facing HTTPS
+ * port that Tailscale fronts that local port on, or null when no match is found.
+ *
+ * Detection covers two serve topologies:
+ * - **Direct serve**: a mapping in the top-level `Web` object.
+ * - **Tailscale Service**: a mapping nested under `Services[svc].Web`.
+ *
+ * For each web-map entry whose key is `"host:PORT"`, every handler whose
+ * `.Proxy` URL targets a loopback address (`localhost` OR `127.0.0.1`) on
+ * `localPort` is considered a match; the public port is the integer after the
+ * LAST `:` in the entry's key (defaulting to 443 when no explicit port is
+ * present). First match wins.
+ *
+ * Parsing is fully defensive — any malformed, empty, or non-JSON input returns
+ * null without throwing.
+ *
+ * **Accepted trade-offs:**
+ * - On a Tailscale too old to support `--json`, the runner yields nothing
+ *   parseable, so a served HUD reads Warning. This is accepted — Shepherd
+ *   already requires a Service-capable Tailscale version.
+ * - Loopback coverage is `localhost` + `127.0.0.1` only; `[::1]` is
+ *   intentionally not matched (Tailscale always emits one of the two above).
+ * - A pending/unapproved Service still shows its mapping in the JSON and so
+ *   reads OK. The check is advisory, not a hard gate.
+ */
+export function findServedPort(serveStatusJson: string, localPort: number): number | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serveStatusJson);
+  } catch {
+    return null;
+  }
+  if (!isPlainObject(parsed)) return null;
+  for (const webMap of collectWebMaps(parsed)) {
+    const served = servedPortInWebMap(webMap, localPort);
+    if (served !== null) return served;
+  }
+  return null;
+}
+
 export interface PreviewPortRangeParams {
   previewPortBase: number;
   previewPortCount: number;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -184,7 +184,7 @@ export class DiagnosticsService {
   /** tailscale: missing binary / not-logged-in (resolveNodeHost null) ⇒ error;
    *  logged-in but not serving the HUD's local port (parseServedPort finds no
    *  mapping for config.port) ⇒ warning (advisory — Shepherd runs fine without
-   *  serve, it only gates the preview/remote nicety); both serving ⇒ ok. Never
+   *  serve, it only gates the remote-access nicety); both serving ⇒ ok. Never
    *  forwards raw status output. */
   private tailscaleProbe = async (): Promise<DiagnosticCheck> => {
     const host = await this.resolveHost();

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -7,7 +7,7 @@ import {
   HERDR_MIN_VERSION,
   NODE_MIN_VERSION,
   config,
-  parseServedPort,
+  findServedPort,
 } from "./config";
 import { compareSemver } from "./herdr-update";
 import { resolveNodeHost } from "./tailscale";
@@ -35,8 +35,9 @@ export interface DiagnosticsDeps {
   /** This node's tailnet hostname, or null when tailscale is absent / not logged
    *  in. Defaults to the shared `resolveNodeHost`. */
   resolveHost?: () => Promise<string | null>;
-  /** Raw `tailscale serve status` text, parsed into a served-port via the pure
-   *  `parseServedPort`. Reject ⇒ treated as "not serving". */
+  /** Raw `tailscale serve status --json` output, parsed into a served-port via
+   *  `findServedPort`. Both a direct `tailscale serve` mapping and a Tailscale
+   *  Service mapping are detected. Reject ⇒ treated as "not serving". */
   runServeStatus?: () => Promise<string>;
 }
 
@@ -99,7 +100,7 @@ export class DiagnosticsService {
     this.runServeStatus =
       deps.runServeStatus ??
       (async () => {
-        const { stdout } = await execFileAsync("tailscale", ["serve", "status"], {
+        const { stdout } = await execFileAsync("tailscale", ["serve", "status", "--json"], {
           encoding: "utf8",
           timeout: DIAGNOSTICS_PROBE_TIMEOUT_MS,
         });
@@ -182,10 +183,11 @@ export class DiagnosticsService {
   };
 
   /** tailscale: missing binary / not-logged-in (resolveNodeHost null) ⇒ error;
-   *  logged-in but not serving the HUD's local port (parseServedPort finds no
-   *  mapping for config.port) ⇒ warning (advisory — Shepherd runs fine without
-   *  serve, it only gates the remote-access nicety); both serving ⇒ ok. Never
-   *  forwards raw status output. */
+   *  logged-in but not serving the HUD's local port (findServedPort finds no
+   *  mapping for config.port in `tailscale serve status --json`) ⇒ warning
+   *  (advisory — Shepherd runs fine without serve, it only gates the
+   *  remote-access nicety); serving via direct serve OR a Tailscale Service ⇒
+   *  ok. Never forwards raw status output. */
   private tailscaleProbe = async (): Promise<DiagnosticCheck> => {
     const host = await this.resolveHost();
     if (!host) {
@@ -196,7 +198,7 @@ export class DiagnosticsService {
       };
     }
     const status = await this.runServeStatus();
-    const served = parseServedPort(status, config.port);
+    const served = findServedPort(status, config.port);
     if (served === null) {
       return {
         id: "tailscale",

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -29,9 +29,15 @@ function healthyDeps(): DiagnosticsDeps {
     runVersion: versionRunner({ ...HEALTHY_VERSIONS }),
     runGhAuth: async () => {},
     resolveHost: async () => "node.example.ts.net",
-    // served-status text that maps config.port (default 7330) → a public port.
+    // served-status JSON (tailscale serve status --json) that maps config.port (default 7330) → port 443.
     runServeStatus: async () =>
-      "https://node.example.ts.net (tailnet only)\n|-- / proxy http://127.0.0.1:7330\n",
+      JSON.stringify({
+        Web: {
+          "node.example.ts.net:443": {
+            Handlers: { "/": { Proxy: "http://127.0.0.1:7330" } },
+          },
+        },
+      }),
   };
 }
 
@@ -215,7 +221,15 @@ describe("DiagnosticsService probes", () => {
   it("tailscale: warning when logged in but not serving the port", async () => {
     const svc = new DiagnosticsService({
       ...healthyDeps(),
-      runServeStatus: async () => "https://node.example.ts.net (tailnet only)\n",
+      // Valid JSON but no Proxy entry targeting port 7330
+      runServeStatus: async () =>
+        JSON.stringify({
+          Web: {
+            "node.example.ts.net:5191": {
+              Handlers: { "/": { Proxy: "http://127.0.0.1:5190" } },
+            },
+          },
+        }),
     });
     const c = byId((await svc.check(0)).checks, "tailscale");
     expect(c.state).toBe("warning");
@@ -225,10 +239,40 @@ describe("DiagnosticsService probes", () => {
     const secret = "SECRET-SERVE-LINE-127.0.0.1";
     const svc = new DiagnosticsService({
       ...healthyDeps(),
-      runServeStatus: async () => `${secret}\n`,
+      // Embed the secret inside a JSON value (a Proxy URL path) to verify it never leaks out
+      runServeStatus: async () =>
+        JSON.stringify({
+          Web: {
+            "node.example.ts.net:5191": {
+              Handlers: { "/": { Proxy: `http://127.0.0.1:5190/${secret}` } },
+            },
+          },
+        }),
     });
     const c = byId((await svc.check(0)).checks, "tailscale");
     expect(JSON.stringify(c)).not.toContain("SECRET-SERVE-LINE");
+    assertPure(c);
+  });
+  it("tailscale: ok when HUD is fronted by a Tailscale Service (Services → svc:shepherd → localhost:7330)", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runServeStatus: async () =>
+        JSON.stringify({
+          Services: {
+            "svc:shepherd": {
+              TCP: { "443": { HTTPS: true } },
+              Web: {
+                "shepherd.chicken-beardie.ts.net:443": {
+                  Handlers: { "/": { Proxy: "http://localhost:7330" } },
+                },
+              },
+            },
+          },
+        }),
+    });
+    const c = byId((await svc.check(0)).checks, "tailscale");
+    expect(c.state).toBe("ok");
+    expect(c.hintKey).toBe("diagnostics_hint_tailscale_ok");
     assertPure(c);
   });
 });

--- a/test/preview-config.test.ts
+++ b/test/preview-config.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { parseServedPort, validatePreviewPortRange } from "../src/config";
+import { test, describe, expect } from "bun:test";
+import { parseServedPort, findServedPort, validatePreviewPortRange } from "../src/config";
 import { originAllowed } from "../src/validate";
 
 // ── parseServedPort ───────────────────────────────────────────────────────────
@@ -64,6 +64,108 @@ https://myhost.ts.net:7777 (tailnet only)
 |-- / proxy 127.0.0.1:5555
 `;
   expect(parseServedPort(text, 5555)).toBe(7777);
+});
+
+// ── findServedPort ────────────────────────────────────────────────────────────
+
+// Full captured shape from tailscale serve status --json (1.96.4)
+const SERVE_STATUS_JSON_FULL = JSON.stringify({
+  TCP: { "5191": { HTTPS: true } },
+  Web: {
+    "backontop.chicken-beardie.ts.net:5191": {
+      Handlers: { "/": { Proxy: "http://127.0.0.1:5190" } },
+    },
+  },
+  Services: {
+    "svc:shepherd": {
+      TCP: { "443": { HTTPS: true } },
+      Web: {
+        "shepherd.chicken-beardie.ts.net:443": {
+          Handlers: { "/": { Proxy: "http://localhost:7330" } },
+        },
+      },
+    },
+  },
+});
+
+describe("findServedPort", () => {
+  test("Service-fronted HUD (Services svc:shepherd → localhost:7330) returns 443", () => {
+    expect(findServedPort(SERVE_STATUS_JSON_FULL, 7330)).toBe(443);
+  });
+
+  test("direct-serve mapping (top-level Web :5191 → 127.0.0.1:5190) returns 5191", () => {
+    expect(findServedPort(SERVE_STATUS_JSON_FULL, 5190)).toBe(5191);
+  });
+
+  test("negative: web map present but no Proxy targeting the given localPort returns null", () => {
+    expect(findServedPort(SERVE_STATUS_JSON_FULL, 9999)).toBeNull();
+  });
+
+  test("negative: malformed JSON returns null", () => {
+    expect(findServedPort("not json", 7330)).toBeNull();
+  });
+
+  test("negative: empty string returns null", () => {
+    expect(findServedPort("", 7330)).toBeNull();
+  });
+
+  test("negative: empty object JSON returns null", () => {
+    expect(findServedPort("{}", 7330)).toBeNull();
+  });
+
+  test("key without explicit :PORT defaults public port to 443", () => {
+    const json = JSON.stringify({
+      Web: {
+        "shepherd.example.ts.net": {
+          Handlers: { "/": { Proxy: "http://127.0.0.1:7330" } },
+        },
+      },
+    });
+    expect(findServedPort(json, 7330)).toBe(443);
+  });
+
+  test("negative: array-valued top-level Web does not produce a false match", () => {
+    // Arrays satisfy typeof === "object"; must be rejected so a malformed payload
+    // doesn't masquerade as "served" (fail-closed contract).
+    expect(
+      findServedPort(
+        JSON.stringify({ Web: [{ Handlers: { "/": { Proxy: "http://127.0.0.1:7330" } } }] }),
+        7330,
+      ),
+    ).toBeNull();
+  });
+
+  test("negative: array-valued Services does not produce a false match", () => {
+    expect(
+      findServedPort(
+        JSON.stringify({
+          Services: [
+            { Web: { "host:443": { Handlers: { "/": { Proxy: "http://127.0.0.1:7330" } } } } },
+          ],
+        }),
+        7330,
+      ),
+    ).toBeNull();
+  });
+
+  test("multiple services: returns first match", () => {
+    const json = JSON.stringify({
+      Services: {
+        "svc:a": {
+          Web: {
+            "a.ts.net:8000": { Handlers: { "/": { Proxy: "http://localhost:3000" } } },
+          },
+        },
+        "svc:b": {
+          Web: {
+            "b.ts.net:9000": { Handlers: { "/": { Proxy: "http://localhost:4000" } } },
+          },
+        },
+      },
+    });
+    expect(findServedPort(json, 3000)).toBe(8000);
+    expect(findServedPort(json, 4000)).toBe(9000);
+  });
 });
 
 // ── validatePreviewPortRange ──────────────────────────────────────────────────

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1150,7 +1150,7 @@
   "diagnostics_hint_herdr_outdated": "Deine herdr-Version liegt unter dem unterstützten Minimum — aktualisiere herdr.",
   "diagnostics_hint_herdr_missing": "herdr-Binary nicht im PATH gefunden — installiere es, um Agent-Sessions zu starten.",
   "diagnostics_hint_tailscale_ok": "Tailscale ist verbunden.",
-  "diagnostics_hint_tailscale_not_serving": "Tailscale läuft, aber serve ist für den Vorschau-Port nicht eingerichtet — für Remote-Zugriff empfiehlt sich die Konfiguration.",
+  "diagnostics_hint_tailscale_not_serving": "Tailscale läuft, stellt Shepherd aber nicht bereit — richte tailscale serve oder einen Tailscale-Service für den Remote-Zugriff ein.",
   "diagnostics_hint_tailscale_missing": "Tailscale nicht installiert oder nicht angemeldet — installiere es und führe tailscale up aus.",
   "diagnostics_hint_git_ok": "git ist verfügbar.",
   "diagnostics_hint_git_missing": "git nicht im PATH gefunden — installiere es, bevor du Aufgaben startest.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1150,7 +1150,7 @@
   "diagnostics_hint_herdr_outdated": "Your herdr version is below the supported floor — update herdr.",
   "diagnostics_hint_herdr_missing": "herdr binary not found in PATH — install it to run agent sessions.",
   "diagnostics_hint_tailscale_ok": "Tailscale is connected.",
-  "diagnostics_hint_tailscale_not_serving": "Tailscale is running but serve isn't configured for the preview port — consider setting it up for remote access.",
+  "diagnostics_hint_tailscale_not_serving": "Tailscale is running but isn't fronting Shepherd — set up tailscale serve or a Tailscale Service for remote access.",
   "diagnostics_hint_tailscale_missing": "Tailscale not installed or not logged in — install it and run tailscale up.",
   "diagnostics_hint_git_ok": "git is available.",
   "diagnostics_hint_git_missing": "git not found in PATH — install it before running tasks.",


### PR DESCRIPTION
## Why

The Settings → Diagnostics **Tailscale** check was inaccurate in two ways (see screenshot in the originating report):

1. **Wrong copy.** The warning said serve "isn't configured for the **preview port**" — but the probe actually checks whether Tailscale fronts the **HUD's own port** (`config.port`), i.e. remote access to Shepherd, nothing to do with previews (which use a separate dynamic per-slot serve range).
2. **Missed Tailscale Services.** The probe parsed the **text** `tailscale serve status`, which in current Tailscale (verified on 1.96.4) **omits Services entirely**. A HUD fronted by a Tailscale Service (`svc:shepherd → localhost:7330`) was invisible to it, so the check showed a standing **Warning** that also degraded the overall health indicator — a false alarm for a perfectly valid setup.

## What

- **Copy (EN + DE):** `diagnostics_hint_tailscale_not_serving` reworded to describe HUD remote access via `tailscale serve` **or** a Tailscale Service; dropped "preview port". Probe doc comments updated to match.
- **Detection:** the diagnostics probe now reads `tailscale serve status --json` and uses a new pure parser `findServedPort` that detects the HUD port fronted by **either** a direct `serve` mapping (top-level `Web`) **or** a Tailscale Service (`Services[svc].Web`), accepting both `localhost` and `127.0.0.1` loopback targets. Served ⇒ OK; genuinely unserved/local-only HUD still ⇒ Warning (confirmed desired behaviour).

### Scope / decisions
- `src/index.ts` and the existing text `parseServedPort` are **intentionally untouched** — index.ts already defaults `servedPort` to 443 on a miss (correct for a 443 Service), and keeping it off `--json` avoids pulling JSON parsing into the `validatePreviewPortRange` hard-fail **startup** path. So `parseServedPort` stays live (no dead code).
- Parser is **fail-closed**: malformed/empty/non-object JSON, or array-valued `Web`/`Services` (malformed), return `null` ⇒ Warning, never a false OK. Never throws.
- On a Tailscale too old to support `serve status --json`, a served HUD reads Warning (accepted — Shepherd already requires Service-capable Tailscale; documented in the parser doc comment).

## Tests
- `findServedPort` unit tests (Service-fronted `localhost:7330` → 443, direct-serve `127.0.0.1` → public port, negatives, malformed/empty/`{}`, array-rejection, no-port-key default, multi-service).
- `diagnostics.test.ts` serve-status fixtures migrated text → captured `--json` shapes, plus a new Service-fronted → OK case.
- Green: root `bun run lint` + `bun test ./test` (2568 pass), `cd ui && bun run check` + `check:i18n` (locale parity), `fallow` delta audit (0 findings).

`[no-feature-entry]` — bugfix to already-shipped Diagnostics (#626), ships no new user-facing capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
