### PR TITLE
feat(research): attended research task kind (web research → report PR or issue) (#297, F9)

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -17,6 +17,15 @@ export const PROCEED_STEER = [
   "requirements decision that only the user can make.",
 ].join("\n");
 
+/** Proceed steer for a RESEARCH session in autopilot — like PROCEED_STEER but with NO
+ *  pull-request framing; research delivers a report PR or a GitHub issue, never a code PR. */
+export const RESEARCH_PROCEED_STEER = [
+  "You're in autopilot on a research task. Don't stop to ask whether to proceed —",
+  "make a reasonable decision yourself and keep going. Finish by delivering your research",
+  "report PR or a GitHub issue. Only stop to ask if you hit a genuine product or",
+  "requirements decision that only the user can make.",
+].join("\n");
+
 /** Agent-facing directive injected into an epic child's spawn prompt: its PR must target the
  *  epic integration branch, not the default branch. Shepherd owns this text (never i18n'd). */
 export function epicBaseDirective(baseBranch: string): string {
@@ -188,10 +197,15 @@ export class AutopilotService {
   private async dispatch(s: Session, v: AutopilotVerdict): Promise<void> {
     switch (v.kind) {
       case "gate":
-        await this.driveSteer(s, PROCEED_STEER);
+        await this.driveSteer(s, s.research ? RESEARCH_PROCEED_STEER : PROCEED_STEER);
         return;
       case "finished":
         if (this.deps.hasPr(s.id)) return; // PR already open → nothing to do (full-auto rebase is steered by the merge train)
+        if (s.research) {
+          // Research sessions never open a code PR — mark complete instead of steering open-a-PR.
+          this.markComplete(s, v.summary || COMPLETE_MESSAGE);
+          return;
+        }
         await this.driveSteer(
           s,
           openPrSteer(this.deps.store.getRepoConfig(s.repoPath).draftMode, s.baseBranch),

--- a/src/service.ts
+++ b/src/service.ts
@@ -330,6 +330,27 @@ const AUTOPILOT_DIRECTIVE =
   "you hit a genuine product or requirements decision that only a human can make.";
 
 /**
+ * Injected as the highest-priority directive for an attended RESEARCH task (`research: true`).
+ * A research session does open-ended web research with sub-agents and delivers a report-only PR
+ * OR a GitHub issue — never code. It SUPPRESSES the plan-gate, autopilot, and build-queue
+ * directives (see composeSystemPrompt), since none of those fit a research deliverable. Not
+ * user-facing chrome (an instruction to the agent), so no i18n — same precedent as
+ * AUTOPILOT_DIRECTIVE and the other spawn-constant directives.
+ */
+const RESEARCH_DIRECTIVE =
+  "You are running as an attended RESEARCH task — open-ended web research with sub-agents, NOT " +
+  "writing product code.\n" +
+  "- Use web search / fetch and dispatch sub-agents to investigate thoroughly, then synthesize " +
+  "the findings yourself.\n" +
+  "- Deliver exactly ONE of: (a) a markdown report written to `docs/research/<slug>.md` and " +
+  "opened as a report-only PR — that report file is the ENTIRE diff, no code changes; or (b) a " +
+  "GitHub issue capturing the findings and recommendation. Choose (a) for reference material, " +
+  "(b) for actionable follow-up work.\n" +
+  "- Do NOT open a code pull request and do NOT modify product code. Once your deliverable " +
+  "(report PR or issue) is up, you are done.\n" +
+  "- You are attended: ask the user on a genuine product/requirements decision; otherwise keep going.";
+
+/**
  * Build the build-queue directive injected at spawn when the repo has `buildQueueEnabled`.
  *
  * The build queue is a per-session, ordered, self-revising plan: the agent authors it via a
@@ -496,7 +517,10 @@ export function planGoSteer(draftMode: boolean): string {
  * is set: the plan gate and autopilot are mutually exclusive. During the planning phase the matching
  * plan-gate directive (interactive/auto) is appended INSTEAD of the autopilot directive, even when
  * `autopilotActive` is true — planning must suppress autopilot so the agent stops to plan/grill
- * rather than driving straight to a PR. `opts.buildQueue`, when set, appends the build-queue
+ * rather than driving straight to a PR. `opts.research`, when set, takes precedence over BOTH and
+ * appends the research directive INSTEAD — and it also suppresses the build-queue block (a research
+ * session authors no queue), so research suppresses plan-gate, autopilot, AND build-queue.
+ * `opts.buildQueue`, when set (and not research), appends the build-queue
  * directive — orthogonal to the plan-gate/autopilot choice, so it always rides. `opts.previewHint`,
  * when true, appends the preview-hint notice AFTER the build-queue block (or after the
  * plan-gate/autopilot block when no build-queue is present) — isolated-only, orthogonal to all
@@ -509,6 +533,7 @@ export function composeSystemPrompt(
   houseRules: string | null,
   autopilotActive = false,
   opts: {
+    research?: boolean;
     planGate?: "interactive" | "auto";
     buildQueue?: string | null;
     previewHint?: boolean;
@@ -522,15 +547,21 @@ export function composeSystemPrompt(
   const blocks = houseRules
     ? [posture, research, houseRules, branchNotice]
     : [posture, research, branchNotice];
-  if (opts.planGate) {
+  // Research is the highest-priority directive: it replaces BOTH the plan-gate and the autopilot
+  // directive (none of those fit a report-PR/issue deliverable).
+  if (opts.research) {
+    blocks.push(`<research-directive>\n${RESEARCH_DIRECTIVE}\n</research-directive>`);
+  } else if (opts.planGate) {
     const variant =
       opts.planGate === "auto" ? PLAN_GATE_DIRECTIVE_AUTO : PLAN_GATE_DIRECTIVE_INTERACTIVE;
     blocks.push(`<plan-gate-directive>\n${variant}\n</plan-gate-directive>`);
   } else if (autopilotActive) {
     blocks.push(`<autopilot-directive>\n${AUTOPILOT_DIRECTIVE}\n</autopilot-directive>`);
   }
-  // Build queue rides independently of the plan-gate/autopilot directive (orthogonal repo config).
-  if (opts.buildQueue != null) blocks.push(`<build-queue>\n${opts.buildQueue}\n</build-queue>`);
+  // Build queue rides independently of the plan-gate/autopilot directive (orthogonal repo config),
+  // but a research session authors no queue — suppress it there too.
+  if (!opts.research && opts.buildQueue != null)
+    blocks.push(`<build-queue>\n${opts.buildQueue}\n</build-queue>`);
   // Preview hint rides last — isolated sessions only. Non-isolated sessions share the main repo dir
   // and have no dedicated worktree, so the hint would be misleading there.
   if (opts.previewHint) {
@@ -858,6 +889,7 @@ export class SessionService {
     argv.push(
       "--append-system-prompt",
       composeSystemPrompt(houseRules, autopilotActive, {
+        research: input.research,
         planGate,
         buildQueue,
         previewHint: isolated,
@@ -894,7 +926,11 @@ export class SessionService {
       // Plan gate (#348): when on, spawn into a PLANNING phase with a grill directive that
       // suppresses autopilot — interactive grills a present human, auto (drain) just writes the
       // plan. Session-level override wins over the repo default.
-      const planGateOn = input.planGateEnabled ?? repoConfig.planGateEnabled;
+      // A research task never enters the plan gate — its deliverable is a report PR / issue, not a
+      // planned-then-implemented code change — so force it off (also yields planPhase: null).
+      const planGateOn = input.research
+        ? false
+        : (input.planGateEnabled ?? repoConfig.planGateEnabled);
       const trim = await this.trimFor(input.auto);
       const argv = this.buildSpawnArgv(
         input,
@@ -905,6 +941,23 @@ export class SessionService {
         wt.isolated,
         trim,
       );
+      // Research needs OPEN web egress (web search / fetch + sub-agents); the autonomous profile's
+      // egress firewall would block it. So when a research session would otherwise resolve to the
+      // autonomous profile, downgrade it to standard for this spawn. Mirror prepareSpawn's own
+      // resolveProfile(override, repoConfig.sandboxProfile, config.sandboxDefaultProfile) to compute
+      // the effective profile, using input.sandboxProfile as the override.
+      const effectiveProfile = resolveProfile(
+        input.sandboxProfile,
+        repoConfig.sandboxProfile,
+        config.sandboxDefaultProfile,
+      );
+      const researchDowngrade = !!input.research && effectiveProfile === "autonomous";
+      if (researchDowngrade) {
+        console.warn(
+          `[sandbox] research ${sessionId}: downgrading autonomous → standard ` +
+            `(research needs open web egress; the autonomous egress firewall would block web search)`,
+        );
+      }
       // Auto-refuse surfaces as a throw so the create() caller (route 4xx / drain catch) sees it.
       const outcome = this.prepareSpawnOrThrow(argv, {
         sessionId,
@@ -913,7 +966,7 @@ export class SessionService {
         repoPath: input.repoPath,
         isolated: wt.isolated,
         auto: input.auto,
-        profileOverride: input.sandboxProfile,
+        profileOverride: researchDowngrade ? "standard" : input.sandboxProfile,
       });
       const session = this.deps.store.create({
         id: sessionId,
@@ -936,11 +989,12 @@ export class SessionService {
         issueNumber: input.issueRef?.number ?? null,
         planGateEnabled: input.planGateEnabled ?? null,
         planPhase: planGateOn ? "planning" : null,
+        research: input.research ?? false,
       });
       // Attended sessions stay unapproved until a human clicks Approve in the UI.
       // Autopilot sessions are pre-approved so the agent can begin executing immediately
       // after authoring the queue without waiting for a human gate that will never come.
-      if (repoConfig.buildQueueEnabled && repoConfig.autopilotEnabled)
+      if (repoConfig.buildQueueEnabled && repoConfig.autopilotEnabled && !input.research)
         this.deps.store.setBuildQueueApproved(sessionId, true);
       this.scheduleRefine(session, herdSlug);
       return session;
@@ -1050,6 +1104,7 @@ export class SessionService {
       model: overrides?.model !== undefined ? overrides.model : s.model,
       planGateEnabled:
         overrides?.planGateEnabled !== undefined ? overrides.planGateEnabled : s.planGateEnabled,
+      research: overrides?.research !== undefined ? overrides.research : s.research,
       images,
       issueRef,
       auto: false,

--- a/src/service.ts
+++ b/src/service.ts
@@ -3,7 +3,7 @@ import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from "node
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, extname, join } from "node:path";
-import type { SessionStore } from "./store";
+import type { RepoConfig, SessionStore } from "./store";
 import type { EventHub } from "./events";
 import type { WorktreeMgr } from "./worktree";
 import type { HerdrDriver } from "./herdr";
@@ -586,6 +586,15 @@ function agentBaseUrl(): string {
   return `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${config.port}`;
 }
 
+/**
+ * Pick an override value over an original: an `undefined` override inherits the original;
+ * any present value (including explicit `null`) replaces it. Mirrors the relaunch override
+ * semantics where absent means "keep the original" and present means "use this".
+ */
+function pickOverride<T>(override: T | undefined, original: T): T {
+  return override !== undefined ? override : original;
+}
+
 /** Result of the shared spawn-wrap helper (prepareSpawn). `ok:false` carries the
  *  auto-gate hold reason; callers diverge on it (create throws, resume → null). */
 type SpawnSuccess = {
@@ -902,6 +911,46 @@ export class SessionService {
     return argv;
   }
 
+  /**
+   * Resolve the per-spawn sandbox profile override for a create(), accounting for the
+   * research downgrade: research needs OPEN web egress (web search / fetch + sub-agents),
+   * which the autonomous profile's egress firewall would block. So when a research session
+   * would otherwise resolve to the autonomous profile, downgrade it to standard for this
+   * spawn (warning once). Otherwise the override is `input.sandboxProfile` unchanged.
+   * Mirrors prepareSpawn's own resolveProfile(override, repoConfig.sandboxProfile,
+   * config.sandboxDefaultProfile), using input.sandboxProfile as the override.
+   */
+  private researchSafeProfileOverride(
+    input: CreateSessionInput,
+    repoConfig: RepoConfig,
+    sessionId: string,
+  ): string | null | undefined {
+    const effectiveProfile = resolveProfile(
+      input.sandboxProfile,
+      repoConfig.sandboxProfile,
+      config.sandboxDefaultProfile,
+    );
+    if (input.research && effectiveProfile === "autonomous") {
+      console.warn(
+        `[sandbox] research ${sessionId}: downgrading autonomous → standard ` +
+          `(research needs open web egress; the autonomous egress firewall would block web search)`,
+      );
+      return "standard";
+    }
+    return input.sandboxProfile;
+  }
+
+  /**
+   * Resolve whether a create() spawns into the plan gate (#348): a session-level override
+   * wins over the repo default. A research task never enters the plan gate — its deliverable
+   * is a report PR / issue, not a planned-then-implemented code change — so force it off
+   * (which also yields planPhase: null).
+   */
+  private resolvePlanGateOn(input: CreateSessionInput, repoConfig: RepoConfig): boolean {
+    if (input.research) return false;
+    return input.planGateEnabled ?? repoConfig.planGateEnabled;
+  }
+
   async create(input: CreateSessionInput): Promise<Session> {
     const repoBasename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
     const herdSlug = repoBasename ? slugifyManual(repoBasename) : undefined;
@@ -925,12 +974,8 @@ export class SessionService {
       const repoConfig = this.deps.store.getRepoConfig(input.repoPath);
       // Plan gate (#348): when on, spawn into a PLANNING phase with a grill directive that
       // suppresses autopilot — interactive grills a present human, auto (drain) just writes the
-      // plan. Session-level override wins over the repo default.
-      // A research task never enters the plan gate — its deliverable is a report PR / issue, not a
-      // planned-then-implemented code change — so force it off (also yields planPhase: null).
-      const planGateOn = input.research
-        ? false
-        : (input.planGateEnabled ?? repoConfig.planGateEnabled);
+      // plan. See resolvePlanGateOn for the override + research semantics.
+      const planGateOn = this.resolvePlanGateOn(input, repoConfig);
       const trim = await this.trimFor(input.auto);
       const argv = this.buildSpawnArgv(
         input,
@@ -941,23 +986,9 @@ export class SessionService {
         wt.isolated,
         trim,
       );
-      // Research needs OPEN web egress (web search / fetch + sub-agents); the autonomous profile's
-      // egress firewall would block it. So when a research session would otherwise resolve to the
-      // autonomous profile, downgrade it to standard for this spawn. Mirror prepareSpawn's own
-      // resolveProfile(override, repoConfig.sandboxProfile, config.sandboxDefaultProfile) to compute
-      // the effective profile, using input.sandboxProfile as the override.
-      const effectiveProfile = resolveProfile(
-        input.sandboxProfile,
-        repoConfig.sandboxProfile,
-        config.sandboxDefaultProfile,
-      );
-      const researchDowngrade = !!input.research && effectiveProfile === "autonomous";
-      if (researchDowngrade) {
-        console.warn(
-          `[sandbox] research ${sessionId}: downgrading autonomous → standard ` +
-            `(research needs open web egress; the autonomous egress firewall would block web search)`,
-        );
-      }
+      // Research needs OPEN web egress; a research session resolving to autonomous is
+      // downgraded to standard for this spawn (see researchSafeProfileOverride).
+      const profileOverride = this.researchSafeProfileOverride(input, repoConfig, sessionId);
       // Auto-refuse surfaces as a throw so the create() caller (route 4xx / drain catch) sees it.
       const outcome = this.prepareSpawnOrThrow(argv, {
         sessionId,
@@ -966,7 +997,7 @@ export class SessionService {
         repoPath: input.repoPath,
         isolated: wt.isolated,
         auto: input.auto,
-        profileOverride: researchDowngrade ? "standard" : input.sandboxProfile,
+        profileOverride,
       });
       const session = this.deps.store.create({
         id: sessionId,
@@ -1101,10 +1132,9 @@ export class SessionService {
       repoPath: overrides?.repoPath ?? s.repoPath,
       baseBranch: overrides?.baseBranch ?? s.baseBranch,
       prompt: overrides?.prompt ?? s.prompt,
-      model: overrides?.model !== undefined ? overrides.model : s.model,
-      planGateEnabled:
-        overrides?.planGateEnabled !== undefined ? overrides.planGateEnabled : s.planGateEnabled,
-      research: overrides?.research !== undefined ? overrides.research : s.research,
+      model: pickOverride(overrides?.model, s.model),
+      planGateEnabled: pickOverride(overrides?.planGateEnabled, s.planGateEnabled),
+      research: pickOverride(overrides?.research, s.research),
       images,
       issueRef,
       auto: false,

--- a/src/store.ts
+++ b/src/store.ts
@@ -136,6 +136,7 @@ type NewSession = Omit<
   | "sandboxDegraded"
   | "egressApplied"
   | "egressDegraded"
+  | "research"
 > & {
   id?: string;
   model?: string | null;
@@ -148,6 +149,7 @@ type NewSession = Omit<
   sandboxDegraded?: boolean;
   egressApplied?: boolean;
   egressDegraded?: boolean;
+  research?: boolean;
 };
 
 const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePath,
@@ -156,6 +158,7 @@ const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePat
   planGateEnabled, planPhase,
   autoMergeEnabled, autoMergeRebaseCount, autoMergeRebaseHead,
   auto, issueNumber, sandboxApplied, sandboxDegraded, egressApplied, egressDegraded,
+  research,
   createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId`;
 
 // ── repo_config row type + helpers ────────────────────────────────────────────
@@ -598,6 +601,7 @@ export class SessionStore implements CapStore, CreditStore {
       sandboxDegraded: input.sandboxDegraded ?? false,
       egressApplied: input.egressApplied ?? false,
       egressDegraded: input.egressDegraded ?? false,
+      research: input.research ?? false,
       status: "running",
       lastState: "idle",
       createdAt: now,
@@ -614,7 +618,7 @@ export class SessionStore implements CapStore, CreditStore {
       const seq = this.nextDesignationSeq();
       const s = this.buildSessionRow(input, seq, now);
       this.db.run(
-        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
           s.id,
           s.desig,
@@ -648,6 +652,7 @@ export class SessionStore implements CapStore, CreditStore {
           s.sandboxDegraded ? 1 : 0,
           s.egressApplied ? 1 : 0,
           s.egressDegraded ? 1 : 0,
+          s.research ? 1 : 0,
           s.createdAt,
           s.updatedAt,
           s.archivedAt,
@@ -1325,6 +1330,8 @@ export class SessionStore implements CapStore, CreditStore {
     add("egressDegraded", `egressDegraded INTEGER NOT NULL DEFAULT 0`);
     add("mergingSince", `mergingSince INTEGER`);
     add("mergingTrainId", `mergingTrainId TEXT`);
+    // research task kind: default 0 (false) for pre-existing rows.
+    add("research", `research INTEGER NOT NULL DEFAULT 0`);
   }
 
   // migrate repo_config that predates these opt-in columns. auto-address defaults
@@ -1717,6 +1724,7 @@ export class SessionStore implements CapStore, CreditStore {
       sandboxDegraded: !!r.sandboxDegraded,
       egressApplied: !!r.egressApplied,
       egressDegraded: !!r.egressDegraded,
+      research: !!r.research,
       mergingSince: r.mergingSince ?? null,
       mergingTrainId: r.mergingTrainId ?? null,
     } as Session;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,8 @@ export interface Session {
   planGateEnabled: boolean | null;
   /** Plan-gate phase: "planning" (grill+review) → "executing" (gate passed); null = gate off. */
   planPhase: "planning" | "executing" | null;
+  /** True for a research-kind task: web research → report PR or GitHub issue; never code-PR-steered. */
+  research: boolean;
   /** Full-auto merge opt-in: true/false override, or null to inherit the repo default. */
   autoMergeEnabled: boolean | null;
   /** Consecutive auto-rebase attempts the merge train has spent on this session
@@ -96,6 +98,8 @@ export interface CreateSessionInput {
   planGateEnabled?: boolean | null;
   /** Per-spawn sandbox profile override; absent → inherit repo default. */
   sandboxProfile?: SandboxProfile | null;
+  /** Research task kind; absent → false. */
+  research?: boolean;
 }
 
 /**
@@ -113,6 +117,8 @@ export interface RelaunchOverrides {
   model?: string | null;
   planGateEnabled?: boolean | null;
   images?: string[];
+  /** Research task kind override; absent → keep original. */
+  research?: boolean;
 }
 
 /** Selectable claude model aliases; absent/"default" means no --model flag.

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -39,6 +39,7 @@ const ALLOWED_KEYS = new Set([
   "issueRef",
   "planGateEnabled",
   "sandboxProfile",
+  "research",
 ]);
 
 /** Max staged images per spawn. Bounds the attach list (and the relaunch merge of
@@ -351,6 +352,9 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
   const sandboxProfile = validateSandboxProfile(obj.sandboxProfile);
   if (!sandboxProfile.ok) return sandboxProfile;
 
+  const research = validateResearch(obj.research);
+  if (!research.ok) return research;
+
   return {
     ok: true,
     value: {
@@ -362,6 +366,7 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
       issueRef: issueRef.value,
       planGateEnabled: planGateEnabled.value,
       sandboxProfile: sandboxProfile.value,
+      research: research.value,
     },
   };
 }
@@ -371,6 +376,13 @@ function validatePlanGateEnabled(value: unknown): Field<boolean | null | undefin
   if (value === undefined) return field(undefined);
   if (value === null || typeof value === "boolean") return field(value);
   return err("planGateEnabled must be a boolean, null, or absent");
+}
+
+/** research — optional plain boolean; absent/undefined → false; null or non-boolean rejected. */
+function validateResearch(value: unknown): Field<boolean> {
+  if (value === undefined) return field(false);
+  if (typeof value === "boolean") return field(value);
+  return err("research must be a boolean or absent");
 }
 
 type RelaunchResult = { ok: true; value: RelaunchOverrides } | { ok: false; error: string };

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -393,6 +393,7 @@ const RELAUNCH_ALLOWED_KEYS = new Set([
   "prompt",
   "model",
   "planGateEnabled",
+  "research",
   "images",
 ]);
 
@@ -427,6 +428,7 @@ export function validateRelaunchOverrides(body: unknown, repoRoot: string): Rela
     { key: "baseBranch", apply: () => validateBaseBranch(obj.baseBranch) },
     { key: "model", apply: () => validateModel(obj.model) },
     { key: "planGateEnabled", apply: () => validatePlanGateEnabled(obj.planGateEnabled) },
+    { key: "research", apply: () => validateResearch(obj.research) },
     { key: "repoPath", apply: () => validateRepoPath(obj.repoPath, root) },
     { key: "images", apply: () => validateImages(obj.images, root) },
   ];

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -49,6 +49,7 @@ function sess(over: Partial<Session> = {}): Session {
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     status: "blocked",
     lastState: "blocked",
     createdAt: 0,

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -2,6 +2,7 @@ import { test, expect, mock } from "bun:test";
 import {
   AutopilotService,
   PROCEED_STEER,
+  RESEARCH_PROCEED_STEER,
   openPrSteer,
   epicBaseDirective,
   CI_FIX_STEER,
@@ -835,4 +836,83 @@ test("negative: tick() ignores an archived session", () => {
   const h = stuckRed({ status: "archived" });
   h.svc.tick();
   expect(h.events.length).toBe(0);
+});
+
+// ───────────────────────── research guard ─────────────────────────
+// A research session (research: true) in an autopilot-enabled repo is reached by dispatch()
+// via the normal onBlock/onDone paths. The guard bars both PR-language steer paths while
+// leaving the complete path and non-research behavior untouched.
+
+test("research + finished verdict (no PR) → markComplete, no open-PR steer", async () => {
+  const h = harness({
+    session: sess({ research: true, status: "done" }),
+    verdict: { kind: "finished", summary: "Research done." },
+  });
+  await h.svc.onDone("s1");
+  // No steer event at all — not even a non-PR steer
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  // markComplete fired
+  expect(h.events).toContainEqual({ complete: "s1", summary: "Research done." });
+  expect(h.state().autopilotComplete).toBe(true);
+  expect(h.state().autopilotPaused).toBe(false);
+});
+
+test("research + gate verdict → RESEARCH_PROCEED_STEER sent, not PROCEED_STEER", async () => {
+  const h = harness({
+    session: sess({ research: true }),
+    verdict: { kind: "gate", summary: "asking to proceed" },
+  });
+  await h.svc.onBlock("s1", block());
+  const steerEv = h.events.find((e) => "steer" in e);
+  expect(steerEv).toBeDefined();
+  expect(steerEv.steer).toBe(RESEARCH_PROCEED_STEER);
+  expect(steerEv.steer).not.toContain("pull request");
+  expect(steerEv.steer).not.toBe(PROCEED_STEER);
+  expect(h.state().autopilotStepCount).toBe(1);
+});
+
+test("research + complete verdict → markComplete (clean-done preserved)", async () => {
+  const h = harness({
+    session: sess({ research: true, status: "done" }),
+    verdict: { kind: "complete", summary: "Research report filed." },
+  });
+  await h.svc.onDone("s1");
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  expect(h.events).toContainEqual({ complete: "s1", summary: "Research report filed." });
+  expect(h.state().autopilotComplete).toBe(true);
+});
+
+test("research + finished + PR already open → early-return (no steer, no markComplete)", async () => {
+  const h = harness({
+    session: sess({ research: true, status: "done" }),
+    verdict: { kind: "finished", summary: "done" },
+    openPr: true,
+  });
+  await h.svc.onDone("s1");
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  expect(h.events.some((e) => "complete" in e)).toBe(false);
+  expect(h.state().autopilotComplete).toBe(false);
+});
+
+// Negative controls: guard must not bleed into normal sessions
+test("non-research + finished verdict → still gets open-PR steer", async () => {
+  const h = harness({
+    session: sess({ research: false }),
+    verdict: { kind: "finished", summary: "done" },
+  });
+  await h.svc.onBlock("s1", block(["I'm done."]));
+  expect(h.events).toContainEqual({ steer: OPEN_PR_STEER_MAIN });
+  expect(h.events.some((e) => "complete" in e)).toBe(false);
+});
+
+test("non-research + gate verdict → still gets PROCEED_STEER, not RESEARCH_PROCEED_STEER", async () => {
+  const h = harness({
+    session: sess({ research: false }),
+    verdict: { kind: "gate", summary: "asking to proceed" },
+  });
+  await h.svc.onBlock("s1", block());
+  const steerEv = h.events.find((e) => "steer" in e);
+  expect(steerEv).toBeDefined();
+  expect(steerEv.steer).toBe(PROCEED_STEER);
+  expect(steerEv.steer).not.toBe(RESEARCH_PROCEED_STEER);
 });

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -30,6 +30,7 @@ function makeSession(over: Partial<Session> = {}): Session {
     autopilotQuestion: null,
     planGateEnabled: null,
     planPhase: null,
+    research: false,
     autoMergeEnabled: null,
     autoMergeRebaseCount: 0,
     autoMergeRebaseHead: null,

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -38,6 +38,7 @@ function session(over: Partial<Session> = {}): Session {
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     status: "running",
     lastState: "idle",
     createdAt: 0,

--- a/test/server-diff.test.ts
+++ b/test/server-diff.test.ts
@@ -38,6 +38,7 @@ const SESSION: Session = {
   sandboxDegraded: false,
   egressApplied: false,
   egressDegraded: false,
+  research: false,
   status: "running",
   lastState: "working",
   createdAt: 0,

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -42,6 +42,7 @@ const SESSION: Session = {
   sandboxDegraded: false,
   egressApplied: false,
   egressDegraded: false,
+  research: false,
   status: "running",
   lastState: "working",
   createdAt: 0,

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -3279,3 +3279,211 @@ test("resume of a non-auto session stays untrimmed even with trim on", async () 
     config.trimAutoContext = prev;
   }
 });
+
+// ── research task kind ─────────────────────────────────────────────────────────
+
+test("composeSystemPrompt: research is the highest-priority directive (suppresses plan-gate, autopilot, build-queue)", () => {
+  const sp = composeSystemPrompt(null, true, {
+    research: true,
+    planGate: "interactive",
+    buildQueue: "QUEUE",
+  });
+  expect(sp).toContain("<research-directive>");
+  expect(sp).not.toContain("<autopilot-directive>");
+  expect(sp).not.toContain("<plan-gate-directive>");
+  expect(sp).not.toContain("<build-queue>");
+});
+
+test("composeSystemPrompt: a non-research call with the same opts still carries plan-gate + build-queue", () => {
+  const sp = composeSystemPrompt(null, true, {
+    research: false,
+    planGate: "interactive",
+    buildQueue: "QUEUE",
+  });
+  expect(sp).not.toContain("<research-directive>");
+  expect(sp).toContain("<plan-gate-directive>");
+  expect(sp).toContain("<build-queue>");
+});
+
+test("create research: plan gate forced off even when repo planGateEnabled is true", async () => {
+  const store = new SessionStore(":memory:");
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(buildQueueDeps(store, captured, { planGateEnabled: true }) as any);
+  const s = await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "research it",
+    model: null,
+    images: [],
+    research: true,
+  });
+  expect(s.planPhase).toBeNull();
+  const sp = sysPrompt(captured.argv!);
+  expect(sp).not.toContain("<plan-gate-directive>");
+  expect(sp).toContain("<research-directive>");
+  expect(s.research).toBe(true);
+});
+
+test("create research: persists research flag; non-research stays false", async () => {
+  const store = new SessionStore(":memory:");
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(injectDeps(store, captured) as any);
+  const r = await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "x",
+    model: null,
+    images: [],
+    research: true,
+  });
+  expect(store.get(r.id)?.research).toBe(true);
+  const n = await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "y",
+    model: null,
+    images: [],
+  });
+  expect(store.get(n.id)?.research).toBe(false);
+});
+
+test("create research: build queue NOT pre-approved even with buildQueueEnabled + autopilot on", async () => {
+  const store = new SessionStore(":memory:");
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(
+    buildQueueDeps(store, captured, { buildQueueEnabled: true, autopilotEnabled: true }) as any,
+  );
+  const s = await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "research it",
+    model: null,
+    images: [],
+    research: true,
+  });
+  expect(store.getBuildQueue(s.id).approved).toBe(false);
+});
+
+test("create non-research: build queue IS pre-approved with buildQueueEnabled + autopilot on", async () => {
+  const store = new SessionStore(":memory:");
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(
+    buildQueueDeps(store, captured, { buildQueueEnabled: true, autopilotEnabled: true }) as any,
+  );
+  const s = await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "do it",
+    model: null,
+    images: [],
+  });
+  expect(store.getBuildQueue(s.id).approved).toBe(true);
+});
+
+/** A service whose worktree/herdr stubs satisfy the sandbox path (gitCommonDir present),
+ *  with injectable backend probes so an autonomous profile resolves deterministically. */
+function sandboxResearchDeps(store: SessionStore, captured: { argv?: string[] }) {
+  return {
+    store,
+    namer: async () => "s",
+    worktree: {
+      ensureBaseRef: async () => {},
+      create: () => ({ worktreePath: "/wt/s", branch: "shepherd/s", isolated: true }),
+      remove: () => {},
+      gitCommonDir: () => "/wt/s/.git",
+    } as any,
+    herdr: {
+      start: (_n: string, _c: string, argv: string[]) => {
+        captured.argv = argv;
+        return { terminalId: "t1" };
+      },
+      list: () => [],
+    } as any,
+    detectBackend: () => "bwrap" as const,
+    detectEgressBackend: () => "slirp4netns" as const,
+  };
+}
+
+test("create research under autonomous: downgrades to standard (sandboxApplied=standard)", async () => {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig("/repo", {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: false,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: false,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 1,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "autonomous",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+  });
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(sandboxResearchDeps(store, captured) as any);
+  const s = await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "research it",
+    model: null,
+    images: [],
+    research: true,
+  });
+  expect(s.sandboxApplied).toBe("standard");
+  expect(store.get(s.id)?.sandboxApplied).toBe("standard");
+  // standard wraps in bwrap, NOT the egress-runner
+  expect(captured.argv?.[0]).toBe("bwrap");
+  expect(captured.argv?.[1]).not.toBe("--tmp");
+});
+
+test("create NON-research under autonomous: stays autonomous (no downgrade)", async () => {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig("/repo", {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: false,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: false,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 1,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "autonomous",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+  });
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(sandboxResearchDeps(store, captured) as any);
+  const s = await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "do it",
+    model: null,
+    images: [],
+  });
+  expect(s.sandboxApplied).toBe("autonomous");
+});
+
+test("relaunch keeps research:true; explicit override flips it to false", async () => {
+  const store = new SessionStore(":memory:");
+  const { service } = relaunchHarness(store);
+  const orig = originalSession(store, { research: true });
+  expect(orig.research).toBe(true);
+
+  const fresh = await service.relaunch(orig.id);
+  expect(fresh.research).toBe(true);
+
+  const flipped = await service.relaunch(orig.id, undefined, { research: false });
+  expect(flipped.research).toBe(false);
+});

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -669,6 +669,50 @@ test("repo_config: invalid JSON in egressExtraHosts column → []", () => {
   }
 });
 
+test("session: research defaults false, round-trips via create + get", () => {
+  const s = mk();
+  // absent → false
+  const a = s.create(base);
+  expect(a.research).toBe(false);
+  expect(s.get(a.id)?.research).toBe(false);
+  // explicitly true → true
+  const b = s.create({ ...base, herdrAgentId: "t2", research: true });
+  expect(b.research).toBe(true);
+  expect(s.get(b.id)?.research).toBe(true);
+  // explicitly false → false
+  const c = s.create({ ...base, herdrAgentId: "t3", research: false });
+  expect(c.research).toBe(false);
+  expect(s.get(c.id)?.research).toBe(false);
+});
+
+test("session: research migration — pre-existing row without column reads as false", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-store-research-legacy-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    // Seed a DB without the research column, simulating a pre-feature DB.
+    const raw = new Database(dbPath);
+    raw.run(`CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, desig TEXT NOT NULL, name TEXT NOT NULL, prompt TEXT NOT NULL,
+      repoPath TEXT NOT NULL, baseBranch TEXT NOT NULL, branch TEXT,
+      worktreePath TEXT NOT NULL, isolated INTEGER NOT NULL,
+      herdrSession TEXT NOT NULL, herdrAgentId TEXT NOT NULL,
+      claudeSessionId TEXT NOT NULL DEFAULT '',
+      model TEXT, status TEXT NOT NULL, lastState TEXT NOT NULL,
+      auto INTEGER NOT NULL DEFAULT 0, issueNumber INTEGER,
+      createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL, archivedAt INTEGER)`);
+    raw.run(
+      `INSERT INTO sessions (id, desig, name, prompt, repoPath, baseBranch, worktreePath, isolated, herdrSession, herdrAgentId, status, lastState, createdAt, updatedAt)
+       VALUES ('leg1', 'TASK-01', 'n', 'p', '/r', 'main', '/wt', 1, 'h', 't', 'running', 'idle', 1, 1)`,
+    );
+    raw.close();
+    const store = new SessionStore(dbPath);
+    const s = store.get("leg1")!;
+    expect(s.research).toBe(false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("session: autoMergeEnabled override + rebase count round-trip", () => {
   const store = new SessionStore(":memory:");
   const s = store.create(base);

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -12,6 +12,7 @@ import {
   expandHome,
   parseTermDims,
   validateEgressExtraHosts,
+  validateRelaunchOverrides,
 } from "../src/validate";
 import { stagingDir } from "../src/uploads";
 
@@ -848,4 +849,30 @@ test("egressExtraHosts: aligned with allowlist normalizer — rejects what egres
   for (const bad of ["foo..com", "-foo.com", "foo-.com", ".foo.com", "foo.com."]) {
     expect(validateEgressExtraHosts([bad]).ok).toBe(false);
   }
+});
+
+// ── validateRelaunchOverrides: research field ─────────────────────────────────
+
+test("validateRelaunchOverrides: research:true is accepted and forwarded", () => {
+  const r = validateRelaunchOverrides({ research: true }, homedir());
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.research).toBe(true);
+});
+
+test("validateRelaunchOverrides: research:false is accepted and forwarded", () => {
+  const r = validateRelaunchOverrides({ research: false }, homedir());
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.research).toBe(false);
+});
+
+test("validateRelaunchOverrides: non-boolean research is rejected", () => {
+  const r = validateRelaunchOverrides({ research: "yes" }, homedir());
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toMatch(/research/);
+});
+
+test("validateRelaunchOverrides: absent research is not written onto output", () => {
+  const r = validateRelaunchOverrides({}, homedir());
+  expect(r.ok).toBe(true);
+  if (r.ok) expect("research" in r.value).toBe(false);
 });

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -107,6 +107,57 @@ test("sandboxProfile: invalid value rejected", () => {
   if (!r.ok) expect(r.error).toMatch(/sandboxProfile/);
 });
 
+test("research: true accepted + passed through", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", research: true },
+    root,
+  );
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.research).toBe(true);
+});
+
+test("research: false accepted + passed through", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", research: false },
+    root,
+  );
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.research).toBe(false);
+});
+
+test("research: absent → false", () => {
+  const r = validateCreate({ repoPath: validRepo, baseBranch: "main", prompt: "go" }, root);
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.research).toBe(false);
+});
+
+test("research: non-boolean string rejected", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", research: "yes" },
+    root,
+  );
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toMatch(/research/);
+});
+
+test("research: numeric 1 rejected", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", research: 1 },
+    root,
+  );
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toMatch(/research/);
+});
+
+test("research: null rejected", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", research: null },
+    root,
+  );
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toMatch(/research/);
+});
+
 test("unknown key is rejected", () => {
   const r = validateCreate(
     { repoPath: validRepo, baseBranch: "main", prompt: "go", evil: "x" },

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1207,5 +1207,7 @@
   "research_badge_label": "Recherche",
   "research_badge_title": "Rechercheaufgabe: Web-Recherche mit Sub-Agenten → ein Bericht-PR oder ein GitHub-Issue",
   "feat_research_title": "Rechercheaufgaben",
-  "feat_research_body": "Starte eine Rechercheaufgabe über Neue Aufgabe: Ein betreuter Agent führt Web-Recherche mit Sub-Agenten durch und liefert einen Bericht-PR oder öffnet ein GitHub-Issue. Rechercheaufgaben öffnen niemals einen Code-PR."
+  "feat_research_body": "Starte eine Rechercheaufgabe im Dialog „Neue Aufgabe“: Ein betreuter Agent führt Web-Recherche mit Sub-Agenten durch und liefert einen Bericht-PR oder öffnet ein GitHub-Issue. Rechercheaufgaben öffnen niemals einen Code-PR.",
+  "herd_research_filter": "⬡ Recherche",
+  "herd_research_title": "Nur Rechercheaufgaben anzeigen"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1209,5 +1209,6 @@
   "feat_research_title": "Rechercheaufgaben",
   "feat_research_body": "Starte eine Rechercheaufgabe im Dialog „Neue Aufgabe“: Ein betreuter Agent führt Web-Recherche mit Sub-Agenten durch und liefert einen Bericht-PR oder öffnet ein GitHub-Issue. Rechercheaufgaben öffnen niemals einen Code-PR.",
   "herd_research_filter": "⬡ Recherche",
-  "herd_research_title": "Nur Rechercheaufgaben anzeigen"
+  "herd_research_title": "Nur Rechercheaufgaben anzeigen",
+  "herd_research_empty": "Keine Rechercheaufgaben."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1200,5 +1200,8 @@
   "recap_collapse": "▾",
   "recap_regenerate_failed": "Neu erstellen fehlgeschlagen. Bitte erneut versuchen.",
   "feat_session_recap_title": "Sitzungszusammenfassung",
-  "feat_session_recap_body": "Shepherd erstellt nach jeder Sitzung eine kompakte Zusammenfassung — mit Ergebnis, Überschrift und offenen Punkten — damit du auf einen Blick siehst, was passiert ist."
+  "feat_session_recap_body": "Shepherd erstellt nach jeder Sitzung eine kompakte Zusammenfassung — mit Ergebnis, Überschrift und offenen Punkten — damit du auf einen Blick siehst, was passiert ist.",
+  "newtask_research_label": "Recherche-Aufgabe",
+  "newtask_research_hint": "Webrecherche mit Unter-Agenten → ein Bericht-PR oder ein GitHub-Issue. Keine Code-Änderungen.",
+  "newtask_research_sandbox_note": "Recherche-Aufgaben können das autonome Profil nicht verwenden — Websuche benötigt offenen Netzwerkzugang."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1203,5 +1203,9 @@
   "feat_session_recap_body": "Shepherd erstellt nach jeder Sitzung eine kompakte Zusammenfassung — mit Ergebnis, Überschrift und offenen Punkten — damit du auf einen Blick siehst, was passiert ist.",
   "newtask_research_label": "Recherche-Aufgabe",
   "newtask_research_hint": "Webrecherche mit Unter-Agenten → ein Bericht-PR oder ein GitHub-Issue. Keine Code-Änderungen.",
-  "newtask_research_sandbox_note": "Recherche-Aufgaben können das autonome Profil nicht verwenden — Websuche benötigt offenen Netzwerkzugang."
+  "newtask_research_sandbox_note": "Recherche-Aufgaben können das autonome Profil nicht verwenden — Websuche benötigt offenen Netzwerkzugang.",
+  "research_badge_label": "Recherche",
+  "research_badge_title": "Rechercheaufgabe: Web-Recherche mit Sub-Agenten → ein Bericht-PR oder ein GitHub-Issue",
+  "feat_research_title": "Rechercheaufgaben",
+  "feat_research_body": "Starte eine Rechercheaufgabe über Neue Aufgabe: Ein betreuter Agent führt Web-Recherche mit Sub-Agenten durch und liefert einen Bericht-PR oder öffnet ein GitHub-Issue. Rechercheaufgaben öffnen niemals einen Code-PR."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1207,5 +1207,7 @@
   "research_badge_label": "Research",
   "research_badge_title": "Research task: web research with sub-agents → a report PR or a GitHub issue",
   "feat_research_title": "Research tasks",
-  "feat_research_body": "Start a Research task from New Task: an attended agent does web research with sub-agents and delivers a report PR or opens a GitHub issue. Research never opens a code PR."
+  "feat_research_body": "Start a Research task from New Task: an attended agent does web research with sub-agents and delivers a report PR or opens a GitHub issue. Research never opens a code PR.",
+  "herd_research_filter": "⬡ Research",
+  "herd_research_title": "Show only research tasks"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1200,5 +1200,8 @@
   "recap_collapse": "▾",
   "recap_regenerate_failed": "Regenerate failed. Please try again.",
   "feat_session_recap_title": "Session recap",
-  "feat_session_recap_body": "Shepherd now generates a concise recap after each session — verdict, headline, and open items — so you can see what happened at a glance."
+  "feat_session_recap_body": "Shepherd now generates a concise recap after each session — verdict, headline, and open items — so you can see what happened at a glance.",
+  "newtask_research_label": "Research task",
+  "newtask_research_hint": "Web research with sub-agents → a report PR or a GitHub issue. No code changes.",
+  "newtask_research_sandbox_note": "Research can't use the autonomous profile — web search needs open network access."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1209,5 +1209,6 @@
   "feat_research_title": "Research tasks",
   "feat_research_body": "Start a Research task from New Task: an attended agent does web research with sub-agents and delivers a report PR or opens a GitHub issue. Research never opens a code PR.",
   "herd_research_filter": "⬡ Research",
-  "herd_research_title": "Show only research tasks"
+  "herd_research_title": "Show only research tasks",
+  "herd_research_empty": "No research tasks."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1203,5 +1203,9 @@
   "feat_session_recap_body": "Shepherd now generates a concise recap after each session — verdict, headline, and open items — so you can see what happened at a glance.",
   "newtask_research_label": "Research task",
   "newtask_research_hint": "Web research with sub-agents → a report PR or a GitHub issue. No code changes.",
-  "newtask_research_sandbox_note": "Research can't use the autonomous profile — web search needs open network access."
+  "newtask_research_sandbox_note": "Research can't use the autonomous profile — web search needs open network access.",
+  "research_badge_label": "Research",
+  "research_badge_title": "Research task: web research with sub-agents → a report PR or a GitHub issue",
+  "feat_research_title": "Research tasks",
+  "feat_research_body": "Start a Research task from New Task: an attended agent does web research with sub-agents and delivers a report PR or opens a GitHub issue. Research never opens a code PR."
 }

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -242,6 +242,25 @@ describe("Herd Ready filter", () => {
   });
 });
 
+describe("Herd Research filter", () => {
+  it("clicking Research chip shows only research sessions and hides non-research ones", async () => {
+    render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "rs", name: "research one", research: true }),
+        session({ id: "nr", name: "plain one", research: false }),
+      ],
+      git: {},
+    });
+    // both visible under All (default)
+    await expect.element(page.getByText("research one")).toBeInTheDocument();
+    await expect.element(page.getByText("plain one")).toBeInTheDocument();
+    await page.getByRole("button", { name: "⬡ Research" }).click();
+    await expect.element(page.getByText("research one")).toBeInTheDocument();
+    await expect.element(page.getByText("plain one")).not.toBeInTheDocument();
+  });
+});
+
 describe("Herd status filter (TopBar tallies)", () => {
   it("short-circuits the local Ready filter: running sessions stay visible", async () => {
     // statusFilter=running + local filter flipped to Ready would yield an empty

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -38,6 +38,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     issueNumber: null,
     lastState: "",
     createdAt: 0,

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -230,6 +230,17 @@
           onstatusfilter?.(null);
         }}>{m.herd_ready_filter()}</button
       >
+      <button
+        type="button"
+        class="micro fbtn"
+        class:active={statusFilter == null && filter === "research"}
+        title={m.herd_research_title()}
+        aria-pressed={statusFilter == null && filter === "research"}
+        onclick={() => {
+          filter = "research";
+          onstatusfilter?.(null);
+        }}>{m.herd_research_filter()}</button
+      >
       {#if statusFilter != null}
         <!-- aria-label carries status + clear action; the visible "✕" glyph would
            otherwise be read aloud without conveying what the chip does -->

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -285,7 +285,11 @@
         <EmptyHerd {onnew} {issueActionsUnset} {onsettings} />
       {/if}
     {:else if shown.length === 0}
-      <div class="empty micro static">{m.herd_ready_empty()}</div>
+      {#if filter === "research"}
+        <div class="empty micro static">{m.herd_research_empty()}</div>
+      {:else}
+        <div class="empty micro static">{m.herd_ready_empty()}</div>
+      {/if}
     {:else}
       {#each grouped.groups as g (g.key)}
         <EpicGroupHeader

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -370,16 +370,10 @@ describe("NewTask research toggle", () => {
   });
 
   it("submits research:true when Research is checked", async () => {
-    render(NewTask, { props: base({ initialRepoPath: "/repo/research-submit" }) });
-    await expect.poll(() => researchBox()).toBeTruthy();
-
-    researchBox().click();
-    expect(researchBox().checked).toBe(true);
-
-    // re-render with a capturable onsubmit
-    document.body.innerHTML = "";
     const captured = vi.fn();
-    render(NewTask, { props: { onsubmit: captured, initialRepoPath: "/repo/research-submit2" } });
+    render(NewTask, {
+      props: base({ onsubmit: captured, initialRepoPath: "/repo/research-submit" }),
+    });
     await expect.poll(() => researchBox()).toBeTruthy();
 
     researchBox().click();

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -288,3 +288,115 @@ describe("NewTask plan-gate inheritance", () => {
     expect(onsubmit.mock.calls[0]![0]).toMatchObject({ planGateEnabled: null });
   });
 });
+
+describe("NewTask research toggle", () => {
+  const researchBox = () =>
+    Array.from(document.querySelectorAll<HTMLInputElement>(".plan-gate input")).find((el) =>
+      el.closest("label")?.textContent?.includes(m.newtask_research_label()),
+    )!;
+  const planGateBox = () =>
+    Array.from(document.querySelectorAll<HTMLInputElement>(".plan-gate input")).find((el) =>
+      el.closest("label")?.textContent?.includes(m.newtask_plan_gate_label()),
+    )!;
+  const autonomousOption = () =>
+    document.querySelector<HTMLOptionElement>('#nt-sandbox option[value="autonomous"]')!;
+  const sandboxSelect = () => document.querySelector<HTMLSelectElement>("#nt-sandbox")!;
+  const submitBtn = () => document.querySelector<HTMLButtonElement>("button.run")!;
+
+  async function fillAndSubmit() {
+    const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    promptField.value = "do the thing";
+    promptField.dispatchEvent(new Event("input", { bubbles: true }));
+    await expect.poll(() => submitBtn().disabled).toBe(false);
+    submitBtn().click();
+  }
+
+  it("renders the Research checkbox", async () => {
+    render(NewTask, { props: base() });
+    await expect.poll(() => researchBox()).toBeTruthy();
+    expect(researchBox().checked).toBe(false);
+  });
+
+  it("toggling Research on unchecks plan-gate", async () => {
+    const repoPath = "/repo/research-clears-plangate";
+    mockGetRepoConfig.mockResolvedValue(repoConfig(true));
+    render(NewTask, { props: base({ initialRepoPath: repoPath }) });
+
+    // wait for plan-gate to reflect repo default
+    await expect.poll(() => planGateBox().checked).toBe(true);
+
+    researchBox().click();
+    await expect.poll(() => researchBox().checked).toBe(true);
+    await expect.poll(() => planGateBox().checked).toBe(false);
+  });
+
+  it("toggling plan-gate on unchecks Research", async () => {
+    render(NewTask, { props: base() });
+    await expect.poll(() => researchBox()).toBeTruthy();
+
+    // tick Research on first
+    researchBox().click();
+    await expect.poll(() => researchBox().checked).toBe(true);
+
+    // then tick plan-gate → Research should clear
+    planGateBox().click();
+    await expect.poll(() => planGateBox().checked).toBe(true);
+    await expect.poll(() => researchBox().checked).toBe(false);
+  });
+
+  it("disables the autonomous sandbox option when Research is on", async () => {
+    render(NewTask, { props: base() });
+    await expect.poll(() => researchBox()).toBeTruthy();
+
+    expect(autonomousOption().disabled).toBe(false);
+    researchBox().click();
+    await expect.poll(() => researchBox().checked).toBe(true);
+    await expect.poll(() => autonomousOption().disabled).toBe(true);
+  });
+
+  it("resets autonomous sandbox to default when Research is toggled on", async () => {
+    render(NewTask, { props: base() });
+    await expect.poll(() => sandboxSelect()).toBeTruthy();
+
+    // pick autonomous first
+    sandboxSelect().value = "autonomous";
+    sandboxSelect().dispatchEvent(new Event("change", { bubbles: true }));
+    await expect.poll(() => sandboxSelect().value).toBe("autonomous");
+
+    // toggle research on → sandbox should reset
+    researchBox().click();
+    await expect.poll(() => researchBox().checked).toBe(true);
+    await expect.poll(() => sandboxSelect().value).toBe("default");
+  });
+
+  it("submits research:true when Research is checked", async () => {
+    render(NewTask, { props: base({ initialRepoPath: "/repo/research-submit" }) });
+    await expect.poll(() => researchBox()).toBeTruthy();
+
+    researchBox().click();
+    expect(researchBox().checked).toBe(true);
+
+    // re-render with a capturable onsubmit
+    document.body.innerHTML = "";
+    const captured = vi.fn();
+    render(NewTask, { props: { onsubmit: captured, initialRepoPath: "/repo/research-submit2" } });
+    await expect.poll(() => researchBox()).toBeTruthy();
+
+    researchBox().click();
+    await fillAndSubmit();
+
+    await expect.poll(() => captured.mock.calls.length).toBe(1);
+    expect(captured.mock.calls[0]![0]).toMatchObject({ research: true });
+  });
+
+  it("submits research:false by default", async () => {
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: "/repo/research-default" } });
+    await expect.poll(() => submitBtn()).toBeTruthy();
+
+    await fillAndSubmit();
+
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({ research: false });
+  });
+});

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -51,6 +51,7 @@
       issueRef?: IssueRef;
       planGateEnabled: boolean | null;
       sandboxProfile?: SandboxProfile;
+      research: boolean;
     }) => Promise<void> | void;
     onclose?: () => void;
     onclone?: () => void;
@@ -104,6 +105,8 @@
   // it. `planGateTouched` pins a manual choice so switching repos doesn't clobber it.
   let planGate = $state(false);
   let planGateTouched = $state(false);
+  // Research task kind: web research → report PR or issue; mutually exclusive w/ plan-gate.
+  let research = $state(false);
   // Per-spawn sandbox override; "default" → omit (inherit the repo's configured profile).
   let sandboxProfile = $state<"default" | SandboxProfile>("default");
   let submitting = $state(false);
@@ -405,6 +408,7 @@
           : undefined,
         planGateEnabled: planGateTouched ? planGate : null,
         sandboxProfile: sandboxProfile === "default" ? undefined : sandboxProfile,
+        research,
       });
     } catch (err) {
       if (isPreviewBlocked(err)) {
@@ -593,7 +597,10 @@
         <input
           type="checkbox"
           bind:checked={planGate}
-          onchange={() => (planGateTouched = true)}
+          onchange={() => {
+            planGateTouched = true;
+            if (planGate) research = false;
+          }}
           disabled={planGateLoading}
         />
         <span class="pg-text">
@@ -601,6 +608,24 @@
           <span class="pg-hint">
             {planGateLoading ? m.common_loading() : m.newtask_plan_gate_hint()}
           </span>
+        </span>
+      </label>
+
+      <label class="plan-gate">
+        <input
+          type="checkbox"
+          bind:checked={research}
+          onchange={() => {
+            if (research) {
+              planGate = false;
+              planGateTouched = true;
+              if (sandboxProfile === "autonomous") sandboxProfile = "default";
+            }
+          }}
+        />
+        <span class="pg-text">
+          <span class="pg-label">{m.newtask_research_label()}</span>
+          <span class="pg-hint">{m.newtask_research_hint()}</span>
         </span>
       </label>
 
@@ -621,8 +646,11 @@
             <option value="default">{m.newtask_sandbox_default()}</option>
             <option value="trusted">{m.sandbox_profile_trusted()}</option>
             <option value="standard">{m.sandbox_profile_standard()}</option>
-            <option value="autonomous">{m.sandbox_profile_autonomous()}</option>
+            <option value="autonomous" disabled={research}>{m.sandbox_profile_autonomous()}</option>
           </select>
+          {#if research}
+            <span class="pg-hint">{m.newtask_research_sandbox_note()}</span>
+          {/if}
         </div>
       </div>
     </div>

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -618,6 +618,7 @@
           onchange={() => {
             if (research) {
               planGate = false;
+              // pin touched so a later repo switch doesn't re-seed/re-enable plan-gate while research is active
               planGateTouched = true;
               if (sandboxProfile === "autonomous") sandboxProfile = "default";
             }

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -47,6 +47,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     issueNumber: null,
     lastState: "",
     createdAt: 0,

--- a/ui/src/lib/components/ResearchBadge.browser.test.ts
+++ b/ui/src/lib/components/ResearchBadge.browser.test.ts
@@ -57,7 +57,7 @@ describe("ResearchBadge", () => {
     render(ResearchBadge, { session: session({ id: "r1", research: true }) });
     const badge = document.querySelector(".research-badge");
     expect(badge, "research-badge rendered").not.toBeNull();
-    await expect.element(page.getByText(/Recherche|Research/i)).toBeInTheDocument();
+    await expect.element(page.getByText(/Research/i)).toBeInTheDocument();
   });
 
   it("renders nothing when session.research is false", async () => {

--- a/ui/src/lib/components/ResearchBadge.browser.test.ts
+++ b/ui/src/lib/components/ResearchBadge.browser.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { Session } from "$lib/types";
+
+const { default: ResearchBadge } = await import("./ResearchBadge.svelte");
+
+function session(partial: Partial<Session> & { id: string }): Session {
+  return {
+    desig: "TASK-01",
+    name: "task one",
+    prompt: "p",
+    repoPath: "/repo/a",
+    baseBranch: "main",
+    branch: "feat/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "h",
+    herdrAgentId: "ha",
+    claudeSessionId: "cs",
+    model: null,
+    status: "idle",
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: null,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    auto: false,
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    research: false,
+    issueNumber: null,
+    lastState: "",
+    createdAt: 0,
+    updatedAt: 0,
+    archivedAt: null,
+    ...partial,
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("ResearchBadge", () => {
+  it("renders the badge with label text when session.research is true", async () => {
+    render(ResearchBadge, { session: session({ id: "r1", research: true }) });
+    const badge = document.querySelector(".research-badge");
+    expect(badge, "research-badge rendered").not.toBeNull();
+    await expect.element(page.getByText(/Recherche|Research/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing when session.research is false", async () => {
+    render(ResearchBadge, { session: session({ id: "r2", research: false }) });
+    const badge = document.querySelector(".research-badge");
+    expect(badge, "no research-badge when research is false").toBeNull();
+  });
+});

--- a/ui/src/lib/components/ResearchBadge.svelte
+++ b/ui/src/lib/components/ResearchBadge.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import type { Session } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  let { session }: { session: Session } = $props();
+</script>
+
+{#if session.research}
+  <span
+    class="research-badge"
+    role="img"
+    aria-label={m.research_badge_label()}
+    title={m.research_badge_title()}
+  >
+    {m.research_badge_label()}
+  </span>
+{/if}
+
+<style>
+  /* Quiet informational kind-marker — slate mirrors the confined-sandbox badge
+     color so both read as the same "noted info" tier, never green (reserved for READY). */
+  .research-badge {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 1px 6px;
+    border: 1px solid var(--color-slate);
+    border-radius: 2px;
+    color: var(--color-slate);
+    white-space: nowrap;
+    font-weight: 600;
+  }
+</style>

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -48,6 +48,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     issueNumber: null,
     lastState: "",
     createdAt: 0,

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -42,6 +42,7 @@
   import { m } from "$lib/paraglide/messages";
   import AutopilotBadge from "./AutopilotBadge.svelte";
   import PlanGateBadge from "./PlanGateBadge.svelte";
+  import ResearchBadge from "./ResearchBadge.svelte";
   import { onDestroy } from "svelte";
   import {
     REVEAL_PX,
@@ -451,6 +452,7 @@
           }}>{m.unitrow_preview_badge()}</span
         >
       {/if}
+      <ResearchBadge {session} />
       {#if !stepperTerminal}<PrBadge {git} />{/if}
       <CriticBadge sessionId={session.id} />
       <PlanGateBadge {session} />

--- a/ui/src/lib/components/UnitTile.browser.test.ts
+++ b/ui/src/lib/components/UnitTile.browser.test.ts
@@ -46,6 +46,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     issueNumber: null,
     lastState: "",
     createdAt: 0,

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -27,6 +27,7 @@
   import { m } from "$lib/paraglide/messages";
   import AutopilotBadge from "./AutopilotBadge.svelte";
   import PlanGateBadge from "./PlanGateBadge.svelte";
+  import ResearchBadge from "./ResearchBadge.svelte";
   import AutoPip from "./AutoPip.svelte";
 
   let {
@@ -292,6 +293,7 @@
     {#if dStatus === "running"}
       <span class="elapsed" bind:this={elapsedEl}>{elapsed(session.createdAt, nowMs)}</span>
     {/if}
+    <ResearchBadge {session} />
     <PrBadge {git} />
     <CriticBadge sessionId={session.id} />
     <PlanGateBadge {session} />

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -57,6 +57,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     issueNumber: null,
     lastState: "",
     createdAt: 0,

--- a/ui/src/lib/components/epic-grouping.test.ts
+++ b/ui/src/lib/components/epic-grouping.test.ts
@@ -41,6 +41,7 @@ function session(
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     issueNumber,
     lastState: "working",
     createdAt: 0,

--- a/ui/src/lib/components/herd-keynav.test.ts
+++ b/ui/src/lib/components/herd-keynav.test.ts
@@ -48,6 +48,7 @@ function session(
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     issueNumber,
     lastState: "working",
     createdAt: 0,

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -35,6 +35,7 @@ function session(id: string, readyToMerge = false, status: SessionStatus = "runn
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     issueNumber: null,
     lastState: "working",
     createdAt: 0,

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -320,6 +320,34 @@ test("draft + failed CI lands in ciFailed, not draftAwaitingSignoff", () => {
   expect(draftAwaitingSignoff).toHaveLength(0);
 });
 
+test('"research" filter returns only sessions with research === true', () => {
+  const r1 = { ...session("r1"), research: true };
+  const r2 = { ...session("r2"), research: true };
+  const n1 = session("n1"); // research: false by default
+  const shown = shownSessions([r1, n1, r2], "research", () => false);
+  expect(shown.map((s) => s.id)).toEqual(["r1", "r2"]);
+});
+
+test('"research" filter excludes all sessions when none are research', () => {
+  const shown = shownSessions([session("a"), session("b")], "research", () => false);
+  expect(shown).toHaveLength(0);
+});
+
+test('"all" filter is unaffected by research flag (regression)', () => {
+  const r1 = { ...session("r1"), research: true };
+  const n1 = session("n1");
+  const shown = shownSessions([r1, n1], "all", () => false);
+  expect(shown).toHaveLength(2);
+});
+
+test('"ready" filter is unaffected by research flag (regression)', () => {
+  const r1 = { ...session("r1", false, "idle"), research: true };
+  const n1 = { ...session("n1", false, "idle"), research: false };
+  const running = session("run"); // running → dropped by ready
+  const shown = shownSessions([r1, n1, running], "ready", () => false);
+  expect(shown.map((s) => s.id)).toEqual(["r1", "n1"]);
+});
+
 test('"ready" filter drops a working-while-blocked session like a running one', () => {
   const list = [
     session("run"), // running → dropped

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -55,10 +55,11 @@ type Stage =
 export type HerdFilter = "all" | "ready" | "research";
 
 /** The sessions the rail actually lists under `filter` — "ready" keeps only sessions
- *  awaiting the operator (not running, not under review). Single source of truth shared
- *  by Herd.svelte's list and herd-keynav's rail order, so keyboard navigation can never
- *  land on a row the rail isn't showing. Goes through `displayStatus` (a working-while-
- *  blocked session is actually mid-turn, so it is NOT awaiting the operator). */
+ *  awaiting the operator (not running, not under review); "research" keeps only sessions
+ *  with `s.research` set. Single source of truth shared by Herd.svelte's list and
+ *  herd-keynav's rail order, so keyboard navigation can never land on a row the rail
+ *  isn't showing. Goes through `displayStatus` (a working-while-blocked session is
+ *  actually mid-turn, so it is NOT awaiting the operator). */
 export function shownSessions(
   sessions: Session[],
   filter: HerdFilter,

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -51,8 +51,8 @@ type Stage =
   | "awaitingMerge"
   | "active";
 
-/** The herd rail's list filter: everything, or only sessions awaiting the operator. */
-export type HerdFilter = "all" | "ready";
+/** The herd rail's list filter: everything, only sessions awaiting the operator, or only research tasks. */
+export type HerdFilter = "all" | "ready" | "research";
 
 /** The sessions the rail actually lists under `filter` — "ready" keeps only sessions
  *  awaiting the operator (not running, not under review). Single source of truth shared
@@ -65,9 +65,12 @@ export function shownSessions(
   inReview: (id: string) => boolean,
   workingBlocked: Record<string, boolean> = {},
 ): Session[] {
-  return filter === "ready"
-    ? sessions.filter((s) => displayStatus(s, workingBlocked) !== "running" && !inReview(s.id))
-    : sessions;
+  if (filter === "ready")
+    return sessions.filter(
+      (s) => displayStatus(s, workingBlocked) !== "running" && !inReview(s.id),
+    );
+  if (filter === "research") return sessions.filter((s) => s.research);
+  return sessions;
 }
 
 /** Terminal / in-flight stages that win before the green-idle handoff decision, or null

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -42,6 +42,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     issueNumber: null,
     lastState: "",
     createdAt: 0,

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -233,6 +233,7 @@ function session(over: Partial<Session>): Session {
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     issueNumber: null,
     lastState: "",
     createdAt: 0,

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -729,4 +729,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_session_recap_body",
     targetId: "session-recap",
   },
+  {
+    // No targetId: the research toggle lives on the New Task sheet (a modal closed by
+    // default), so a coachmark anchor would rarely be mounted — surface via What's-New only.
+    // 1.28.0 is the latest released tag, so this ships in 1.29.0.
+    id: "research-task",
+    sinceVersion: "1.29.0",
+    titleKey: "feat_research_title",
+    bodyKey: "feat_research_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -55,6 +55,7 @@ function session(id: string): Session {
     sandboxDegraded: false,
     egressApplied: false,
     egressDegraded: false,
+    research: false,
     issueNumber: null,
     lastState: "working",
     createdAt: 0,

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -441,6 +441,8 @@ export interface Session {
   sandboxApplied: SandboxProfile | null;
   /** True when the requested sandbox couldn't be applied — the agent ran unconfined. */
   sandboxDegraded: boolean;
+  /** Research task kind: web research → report PR or issue; never code-PR-steered. */
+  research: boolean;
   /** True when the network-egress allowlist was applied (autonomous sessions only). */
   egressApplied: boolean;
   /** True when the egress backend was unavailable — outbound is unrestricted despite autonomous profile. */
@@ -700,6 +702,7 @@ export interface CreateInput {
   issueRef?: IssueRef; // optional attached issue; body appended server-side
   planGateEnabled?: boolean | null; // per-task plan-gate override; absent → inherit repo default
   sandboxProfile?: SandboxProfile | null; // per-spawn sandbox override; absent → inherit repo default
+  research?: boolean; // research task kind; absent → false
 }
 
 /** Selectable claude model aliases; null = claude's own default. */

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1031,6 +1031,7 @@
     issueRef?: IssueRef;
     planGateEnabled: boolean | null;
     sandboxProfile?: SandboxProfile;
+    research: boolean;
   }) {
     // Relaunch-elsewhere path branches off to submitRelaunch; otherwise the New Task create.
     if (relaunchOriginalId !== null) return submitRelaunch(relaunchOriginalId, input);

--- a/ui/test/store.test.ts
+++ b/ui/test/store.test.ts
@@ -34,6 +34,7 @@ const s = (id: string, status: any = "running"): Session => ({
   sandboxDegraded: false,
   egressApplied: false,
   egressDegraded: false,
+  research: false,
   issueNumber: null,
   lastState: "working",
   createdAt: 0,


### PR DESCRIPTION
Closes #297 (PRD **F9** — "Research chat with sub-agents + saved history").

## What & why
Adds a **Research task kind**: an *attended* interactive session that does web research with sub-agents and delivers **either** a report-only PR (`docs/research/<slug>.md`) **or** a GitHub issue — the agent's call. No new chat UI, no new LLM mechanism, no new persistence store — it reuses the existing spawn/Herd/steer/persistence stack, mirroring the plan-gate pattern end-to-end.

### Key product decisions (vigilance on current direction)
- **searxng dropped.** It lived only in `PRD.md` + one stale spec and was *never wired into code*; a self-hosted searxng dependency also conflicts with the egress-allowlist firewall (#601). Search uses Claude's **native WebSearch/WebFetch**, already available to task agents.
- **Option 2 (task kind), not a standalone chat surface.** A markdown chat client would re-create Anthropic's consumer chat product on a subscription — stepping outside the "every use = a real, observable, interactive session" posture that is the product's ToS-clean defense. A research *task* stays inside it and adds zero new LLM mechanism.
- **Attended-only, never drained.** Verified against `origin/main:src/egress.ts`: the egress firewall is autonomous-profile-only with an Anthropic+GitHub-only allowlist, so an autonomous research agent's web search would be silently `nft reject`-ed. Research therefore runs attended and is **downgraded off the autonomous profile** (see below).

## What's in it
**Server**
- `research: boolean` plumbed through `validate` (create + relaunch paths), the `Session` type, and `store` (additive 0/1 column, default-false migration for legacy rows).
- `RESEARCH_DIRECTIVE` injected via `composeSystemPrompt` as the **highest-priority** block — suppresses plan-gate, autopilot, **and** build-queue. `create()` forces plan-gate off, skips build-queue pre-approval, and persists the flag; relaunch preserves it.
- **Autonomous→standard downgrade:** `create()` pre-resolves the effective profile and passes `profileOverride: "standard"` (keeps the FS membrane, opens network), so `sandboxApplied` records `standard` and `resume()` reuses it; logged via `[sandbox]`.
- **Autopilot guard (load-bearing):** autopilot acts on any `autopilotEnabled` repo regardless of the drain flag, so an attended research session *would* be PR-steered. `dispatch()` now bars **both** PR-language paths for research — `finished`→`markComplete` (not `openPrSteer`) and `gate`→`RESEARCH_PROCEED_STEER` (not `PROCEED_STEER`) — while keeping research eligible for the non-PR `complete` verdict so it reads as cleanly done.

**UI**
- **Research toggle** on New Task (mutually exclusive with plan-gate; suppresses the autonomous sandbox option).
- **ResearchBadge** (quiet slate `--color-slate`, never green) on both card layouts.
- **Research lens** as a third Herd filter chip (`▦ All / ▤ Ready / ⬡ Research`) with a filter-aware empty state.
- Feature-catalog entry (`sinceVersion: 1.29.0`), full EN/DE i18n.

## Acceptance criteria — all met
1. Start Research from New Task → appears in Herd with badge → filterable via the Research lens. ✓
2. Spawn prompt has `<research-directive>` and none of plan-gate/autopilot/build-queue; web search + sub-agents work (attended, network-open). ✓
3. Completes via report-only PR **or** GitHub issue; reaches `autopilotComplete` even in an autopilot repo; never code-PR-steered via `finished` **or** `gate`. ✓
4. Never runs autonomous — downgraded to `standard` (persisted, logged) + UI-suppressed. ✓
5. `research` round-trips validate→store→reload **and** across relaunch. ✓

## Deliberate / known-minor behaviors (so the critic needn't re-flag)
- **Relaunch composer shows the research box unchecked**, but behavior is correct **and safe**: the relaunch path intentionally does *not* forward the (unseeded) checkbox; the server's `pickOverride` preserves the original `research`. Forwarding an unseeded box would *turn a research relaunch into a non-research task* — a real bug — so this is the right call. Mirrors the existing plan-gate relaunch-seed gap.
- **`validateResearch` rejects `null`** (vs `planGateEnabled` accepting it): `research` is a plain boolean with no repo-default, so `null` is meaningless; relaunch uses presence-gating, not `null`.
- **Plan-gate stays off after a research check/uncheck cycle** (documented inline): the research toggle pins `planGateTouched`; mutual exclusivity still holds.

## Tests & gates
New + existing tests green across server (`bun test ./test`, 2583 pass) and UI (`cd ui && bun run test`, 1185 pass): validate/store round-trip + migration, service directive-suppression + downgrade-persist + relaunch, autopilot `finished`/`gate`/`complete` guards (with non-research negative controls), and the UI toggle/badge/filter/empty-state. Root `tsc` + `lint`, UI `check` + `check:i18n` (parity), fallow audit (complexity gate cleared by extracting helpers), branch-hygiene, and feature-catalog all pass.

Built subagent-driven: a fresh implementer per task with two-stage (spec + quality) review between each, plus a final whole-branch review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)