### PR TITLE
fix(plan-gate): unique per-run reviewer worktree path; GC stale review worktrees (#631)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -469,7 +469,12 @@ const planGate = new PlanGateService({
 // without this a restart mid-review orphans the reviewer forever — its verdict goes unread, the
 // gate never advances, and the planning agent sits idle awaiting a re-review that never comes.
 // The next tick() then finalizes each re-adopted run from the verdict it already wrote.
-void planGate.adoptOrphans().catch((err) => console.warn("[plan-gate] adoptOrphans:", err));
+// gcStaleReviewWorktrees runs AFTER adoptOrphans has repopulated `inflight` so it only reaps
+// truly ownerless review worktrees (e.g. the older of two #631 same-session orphans).
+void planGate
+  .adoptOrphans()
+  .then(() => planGate.gcStaleReviewWorktrees())
+  .catch((err) => console.warn("[plan-gate] adoptOrphans:", err));
 attachReviewPush(events, store, push);
 attachGitPush(events, store, push);
 attachMergePush(events, push);

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -279,39 +279,46 @@ export class PlanGateService {
     // default catches internally and falls back to the base ref / name, so this won't throw.
     const sha = this.baseSha(session.repoPath, session.baseBranch);
 
+    // Pre-inject the originating issue's body as UNTRUSTED reviewer context (the agent has no
+    // gh/network — the sandbox stays airtight). Best-effort: a missing issue / forge / getIssue
+    // must never block or throw the review, so any failure degrades to no issue context.
+    const issueBody = await this.fetchIssueBody(session);
+    const prompt = planReviewPrompt(session.prompt, plan, prior?.findings ?? [], issueBody);
+    // Mint the reviewer argv (and its pinned per-spawn --session-id) BEFORE createDetached so the
+    // reviewer session id can key the worktree path. It's a fresh randomUUID() per run.
+    const { argv, sessionId: reviewerSessionId } = reviewerArgv(this.deps.model ?? null, prompt);
+
     // Disposable detached worktree at the base: read-only codebase inspection that can't race
     // the live planning agent. The plan TEXT travels inline in the prompt, not via this tree.
-    // Key the path on session.id: every session detaches at the SAME base sha, so without this
-    // discriminator concurrent plan reviews would share one worktree path and read each other's
-    // verdict file (cross-session findings). See createDetached's `slug` doc.
+    // Key the path on the per-RUN reviewer session id (a fresh randomUUID per spawn): every
+    // session detaches at the SAME base sha, so even two reviews of the SAME session at that sha
+    // would otherwise share one worktree path and clobber each other's `.shepherd-plan-review.json`
+    // verdict (#631). The unique slug gives every run its own `…-review-<reviewerUuid>-<sha8>`
+    // path — no cross-run (nor cross-session) verdict clobber. See createDetached's `slug` doc.
     let wt;
     try {
       wt = await this.deps.worktree.createDetached(
         session.repoPath,
         session.baseBranch,
         sha,
-        session.id,
+        reviewerSessionId,
       );
     } catch (err) {
       console.warn(`[plan-gate] worktree failed for ${session.id}:`, err);
       return "error";
     }
 
-    // Pre-inject the originating issue's body as UNTRUSTED reviewer context (the agent has no
-    // gh/network — the sandbox stays airtight). Best-effort: a missing issue / forge / getIssue
-    // must never block or throw the review, so any failure degrades to no issue context.
-    const issueBody = await this.fetchIssueBody(session);
-    // forget() (session archived) may have fired during the getIssue await above; it clears our
-    // `starting` claim as a tombstone. Abort (reaping the worktree we allocated) before spawning
-    // so we don't run an orphaned reviewer for — and leak a worktree on — a gone session.
-    // Mirrors ReviewService.begin's post-fetch re-check.
+    // forget() (session archived) may have fired during either await above (getIssue OR the slow
+    // createDetached: git fetch + worktree add); it clears our `starting` claim as a tombstone.
+    // This SINGLE re-check covers BOTH awaits — it MUST stay AFTER createDetached so a forget()
+    // mid-fetch still aborts. Abort (reaping the worktree we allocated) before spawning so we don't
+    // run an orphaned reviewer for — and leak a worktree on — a gone session. Mirrors
+    // ReviewService.begin's post-fetch re-check.
     if (!this.starting.has(session.id)) {
       this.deps.worktree.remove(wt.worktreePath);
       return "skipped";
     }
 
-    const prompt = planReviewPrompt(session.prompt, plan, prior?.findings ?? [], issueBody);
-    const { argv, sessionId: reviewerSessionId } = reviewerArgv(this.deps.model ?? null, prompt);
     const backend = this.detectBackend();
     const env = this.membraneEnv();
     const membrane: MembraneInputs = {
@@ -372,7 +379,15 @@ export class PlanGateService {
    *  An orphan is a `plan_gate` spawn that never completed AND whose disposable worktree still
    *  exists — finalize() reaps that worktree, so a surviving one means finalize never ran. */
   async adoptOrphans(): Promise<void> {
-    for (const sp of this.deps.store.listReviewerSpawns()) {
+    // Iterate NEWEST-FIRST by sorting `spawnedAt` descending HERE (independent of the store
+    // query's ORDER BY). With per-run unique worktree paths (#631), two same-session orphans can
+    // coexist; the `inflight.has(id)` short-circuit adopts the FIRST eligible per session, so the
+    // newest-first sort makes that the NEWEST — whose verdict is the most recent. The older
+    // duplicate is left for gcStaleReviewWorktrees() to reap; adopting the older instead would
+    // strand the newer unread verdict (re-#631).
+    for (const sp of [...this.deps.store.listReviewerSpawns()].sort(
+      (a, b) => b.spawnedAt - a.spawnedAt,
+    )) {
       if (sp.kind !== "plan_gate" || sp.completedAt != null) continue;
       const id = sp.taskSessionId;
       if (this.inflight.has(id) || this.starting.has(id)) continue;
@@ -394,6 +409,31 @@ export class PlanGateService {
         startedAt: sp.spawnedAt, // keep the original start so a verdict-less orphan times out
       });
       this.deps.onReviewing?.(id, true);
+    }
+  }
+
+  /** Reap stale plan-review worktrees left on disk by a prior run — e.g. the older of two
+   *  same-session orphans that adoptOrphans() left behind when it adopted the newer (#631). A
+   *  persisted, not-yet-finalized `plan_gate` spawn whose disposable worktree still exists but is
+   *  NOT in the live inflight set has no owner: nothing will ever read its verdict or remove it.
+   *
+   *  Two safety conditions make this sound:
+   *   (a) it MUST run once at boot AFTER adoptOrphans() has repopulated `inflight`, so every
+   *       genuinely-live orphan is already adopted (its worktree is in the inflight set below) and
+   *       only the truly ownerless duplicates remain to reap;
+   *   (b) the load-bearing invariant that begin() calls recordReviewerSpawn AFTER inflight.set —
+   *       so any persisted not-yet-finalized plan_gate row implies its run is already in `inflight`
+   *       (or it finalized, and finalize already removed the worktree). A future reorder putting
+   *       recordReviewerSpawn BEFORE inflight.set would let this GC reap a live spawning run, so
+   *       that ordering must not be changed. */
+  gcStaleReviewWorktrees(): void {
+    const live = new Set([...this.inflight.values()].map((f) => f.worktreePath));
+    for (const sp of this.deps.store.listReviewerSpawns()) {
+      if (sp.kind !== "plan_gate" || sp.completedAt != null) continue; // finalize already reaped its worktree
+      if (live.has(sp.worktreePath)) continue;
+      if (!this.worktreeExists(sp.worktreePath)) continue;
+      this.deps.worktree.remove(sp.worktreePath);
+      console.warn(`[plan-gate] gc reaped stale review worktree ${sp.worktreePath}`);
     }
   }
 

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -297,12 +297,15 @@ export class WorktreeMgr {
    *
    *  `slug` disambiguates the worktree path when callers do NOT have a unique sha to key
    *  on. The PR critic detaches at the PR head sha (unique per PR), so it omits `slug` and
-   *  the path stays `…-review-<sha>` — reused-on-restart to reclaim an interrupted run. The
-   *  plan reviewer, however, detaches every session at the SAME base-branch sha, so without
-   *  a slug all concurrent plan reviews in a repo would collide on one path: a second begin()
-   *  would blow away the first's live worktree, and both inflight records would then read the
-   *  same `.shepherd-plan-review.json` — delivering one session's plan findings to another.
-   *  Passing the session id as `slug` gives each its own path.
+   *  the path stays `…-review-<sha>` — reused-on-restart to reclaim an interrupted run (the
+   *  `existsSync`-reclaim below is load-bearing for that slugless path). The plan reviewer,
+   *  however, detaches every session at the SAME base-branch sha, so without a slug all plan
+   *  reviews in a repo would collide on one path: a second begin() would blow away the first's
+   *  live worktree, and both inflight records would then read the same `.shepherd-plan-review.json`
+   *  — delivering one run's plan findings to another. It passes a per-RUN unique id (the reviewer's
+   *  pinned session id, a fresh randomUUID per spawn) as `slug`, so the path disambiguates across
+   *  RUNS — even two reviews of the SAME session at the SAME sha get distinct paths (#631), not
+   *  just two different sessions.
    *
    *  `pullRef` is the OPTIONAL fork escape hatch for the standalone PR critic. A fork PR's head
    *  sha is NOT on the base repo's `origin` (it lives on the contributor's fork), so the `branch`

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -550,6 +550,126 @@ test("adopted orphan with no verdict, past timeout → error gate + stall (fail-
   expect(h.removed).toContain("/wt-detached");
 });
 
+// ── #631: per-run unique worktree path + GC of stale review worktrees ──────────
+
+test("two reviews of the SAME session at the SAME sha get DISTINCT per-run slugs", async () => {
+  // Capture the slug (4th arg) createDetached receives across two begin() runs for one session
+  // at one base sha. They must differ AND each equal that run's reviewerSessionId — proving the
+  // path is keyed on the per-RUN reviewer id, not the (identical) session id.
+  const slugs: (string | undefined)[] = [];
+  let plan = "PLAN A";
+  const h = harness({
+    readPlan: () => plan,
+    worktree: {
+      createDetached: async (_r: string, _b: string, _s: string, slug?: string) => {
+        slugs.push(slug);
+        return { worktreePath: `/wt-${slug}`, branch: "main" };
+      },
+      remove: () => {},
+      gitCommonDir: () => "/fake-git-common",
+    },
+  });
+  const s1 = await h.svc.consider(planningSession() as any);
+  expect(s1).toBe("started");
+  // Free the first run's inflight slot, then change the plan text to defeat the unchanged-plan
+  // dedupe so the second consider() drives a fresh begin() (same session, same base sha).
+  h.svc.forget("s1");
+  plan = "PLAN B";
+  const s2 = await h.svc.consider(planningSession() as any);
+  expect(s2).toBe("started");
+
+  expect(slugs.length).toBe(2);
+  expect(slugs[0]).not.toBe(slugs[1]); // distinct per run
+  expect(slugs[0]).toBe(h.recordedSpawns[0].reviewerSessionId);
+  expect(slugs[1]).toBe(h.recordedSpawns[1].reviewerSessionId);
+});
+
+test("forget() during the createDetached await aborts the spawn and reaps the worktree", async () => {
+  // Park inside createDetached itself (the slow git fetch + worktree add window), fire forget()
+  // while suspended, then resolve. begin()'s post-createDetached re-check must abort: never spawn,
+  // and reap the worktree it allocated. Proves the createDetached window is covered by the re-check.
+  let release!: () => void;
+  const gate = new Promise<void>((r) => (release = r));
+  const reaped: string[] = [];
+  const h = harness({
+    worktree: {
+      createDetached: async (_r: string, _b: string, _s: string, slug?: string) => {
+        await gate;
+        return { worktreePath: `/wt-${slug}`, branch: "main" };
+      },
+      remove: (p: string) => reaped.push(p),
+      gitCommonDir: () => "/fake-git-common",
+    },
+  });
+  const considering = h.svc.consider(planningSession() as any);
+  await Promise.resolve(); // let begin() advance into the parked createDetached await
+  h.svc.forget("s1"); // archive mid-fetch → clears the `starting` tombstone
+  release();
+  await considering;
+  expect(h.started.length).toBe(0); // never spawned the reviewer
+  expect(reaped.length).toBe(1); // the detached worktree was reaped
+  expect(reaped[0]).toContain("/wt-"); // the per-run path
+  expect(h.svc.reviewingIds()).toEqual([]);
+});
+
+test("adoptOrphans adopts the NEWEST same-session orphan; GC reaps the older", async () => {
+  const older = orphanSpawn({
+    reviewerSessionId: "rev-old",
+    worktreePath: "/wt-old",
+    spawnedAt: 1000,
+  });
+  const newer = orphanSpawn({
+    reviewerSessionId: "rev-new",
+    worktreePath: "/wt-new",
+    spawnedAt: 2000,
+  });
+  const h = harness({
+    worktreeExists: () => true,
+    store: {
+      get: () => ({ id: "s1", repoPath: "/r", worktreePath: "/wt", planPhase: "planning" }),
+      listReviewerSpawns: () => [older, newer], // ASC by spawnedAt
+    },
+  });
+  await h.svc.adoptOrphans();
+  // The newer (more recent verdict) is the one adopted into inflight.
+  expect(h.svc.reviewingIds()).toEqual(["s1"]);
+  expect(h.recordedSpawns).toEqual([]); // adoption doesn't re-record
+
+  h.svc.gcStaleReviewWorktrees();
+  expect(h.removed).toEqual(["/wt-old"]); // older reaped
+  expect(h.removed).not.toContain("/wt-new"); // adopted (inflight) path preserved
+});
+
+test("gcStaleReviewWorktrees reaps only non-inflight plan_gate worktrees", async () => {
+  const stale = orphanSpawn({ worktreePath: "/wt-stale" }); // plan_gate, not inflight → REMOVE
+  const review = orphanSpawn({ kind: "review", worktreePath: "/wt-review" }); // NOT plan_gate → keep
+  const h = harness({
+    worktreeExists: () => true,
+    store: {
+      get: () => ({ id: "s1", repoPath: "/r", worktreePath: "/wt", planPhase: "planning" }),
+      listReviewerSpawns: () => [stale, review],
+    },
+  });
+  // No adoptOrphans() call → nothing inflight → the plan_gate orphan is ownerless.
+  h.svc.gcStaleReviewWorktrees();
+  expect(h.removed).toEqual(["/wt-stale"]);
+  expect(h.removed).not.toContain("/wt-review");
+});
+
+test("gcStaleReviewWorktrees leaves an inflight plan_gate worktree alone", async () => {
+  const adopted = orphanSpawn({ worktreePath: "/wt-detached" });
+  const h = harness({
+    worktreeExists: () => true,
+    store: {
+      get: () => ({ id: "s1", repoPath: "/r", worktreePath: "/wt", planPhase: "planning" }),
+      listReviewerSpawns: () => [adopted],
+    },
+  });
+  await h.svc.adoptOrphans(); // adopts it into inflight (path /wt-detached)
+  h.svc.gcStaleReviewWorktrees();
+  expect(h.removed).not.toContain("/wt-detached"); // inflight → preserved
+});
+
 test("adoptOrphans resolves the reviewer terminal by worktree cwd for reaping", async () => {
   const stopped: string[] = [];
   const h = harness({


### PR DESCRIPTION
## Problem

`WorktreeMgr.createDetached` keyed the plan-gate reviewer's disposable worktree on **`sessionId + baseSha`** only. Every plan review for a session detaches at the **same** base-branch SHA, so `session.id` was the only discriminator — identical across runs of the same session. Two plan reviews for the same session at the same base SHA therefore collided on one path, and `createDetached`'s reclaim step (`if (existsSync(worktreePath)) this.remove(worktreePath)`) deleted the older run's worktree — including its unread `.shepherd-plan-review.json` verdict — before it was read.

This bit us live (2026-06-13): a restart-orphaned plan review had a completed, unread verdict on disk; triggering a fresh "Review plan now" for the same session re-resolved to that exact path and the reclaim erased the verdict. Fixes #631.

## Fix

- **Per-run unique worktree path.** `begin()` now passes the reviewer's pinned `--session-id` (a per-spawn `randomUUID`, `reviewerSessionId`) as the worktree `slug`, so the path becomes `…-review-<reviewerUuid>-<sha8>` — unique per run, never re-resolving onto a prior run's path. `reviewerArgv` is reordered ahead of `createDetached` to make the id available; the **single abort re-check stays AFTER `createDetached`** so it still covers that slow await (a `forget()`/archive mid-fetch aborts and reaps the allocated worktree).
- **`adoptOrphans` adopts the newest same-session orphan.** Unique paths newly let two same-session orphans coexist; adoption now sorts `plan_gate` spawns newest-first (explicitly, independent of the store's `ORDER BY`) so the **older** duplicate is the one the GC reaps — never the newer run's more-recent unread verdict.
- **Explicit GC for stale review worktrees.** New `gcStaleReviewWorktrees()` runs once at boot (after `adoptOrphans` repopulates `inflight`) and reaps any `plan_gate` worktree that survives on disk but is not in the live inflight set, replacing the path-reuse `existsSync`-reclaim we no longer depend on. Its doc-comment pins both safety conditions, including the load-bearing `recordReviewerSpawn`-after-`inflight.set` ordering in `begin()`.

The slugless, sha-keyed `existsSync`-reclaim in `createDetached` is left **unchanged** — it remains load-bearing for the PR critic's reclaim-on-restart. Server-only plumbing, no user-facing UX (`[no-feature-entry]`).

## Tests

`test/plan-gate-service.test.ts` adds: per-run distinct slugs (each equal to its run's `reviewerSessionId`); an abort test parking inside the `createDetached` await; `adoptOrphans` newest-first + GC reaps the older same-session orphan; and selective GC (plan_gate non-inflight reaped, `review`-kind and inflight worktrees kept). The pre-existing getIssue-window abort test stays green unmodified. `test/worktree.test.ts` (critic reclaim path) stays green.

- `bun run lint` ✓ · `bunx tsc --noEmit` ✓ · `bun test ./test` → 2572 pass, 6 skip, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
