### PR TITLE
feat(recap): session recap card — LLM merge-decision summary at the bottom of a finished task

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -537,8 +537,8 @@ setInterval(() => {
   void reviewService.tick();
   void planGate.tick();
   void standaloneCritic.tick();
-  void recapService.tick(); // finalize in-flight recaps (restart-safe)
-  void recapService.sweep(); // settled-idle auto-fire
+  void recapService.tick().catch((err) => console.warn("[recap] tick failed:", err)); // finalize in-flight recaps (restart-safe)
+  void recapService.sweep().catch((err) => console.warn("[recap] sweep failed:", err)); // settled-idle auto-fire
 }, 15_000);
 // The standalone critic's enumeration runs on its OWN 60s timer, separate from the 15s
 // finalize tick above: a sweep lists every open PR per repo (a forge round-trip), far

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ import { startLoopLagSampler, logRemainingOnLoopBlockers } from "./instrument";
 import { resolveNodeHost, TailscaleServeService } from "./tailscale";
 import { normalizeDefaultModelSetting } from "./default-model";
 import { EgressWatcher } from "./egress-watch";
+import { RecapService } from "./recap";
 
 const execFileAsync = promisify(execFile);
 
@@ -475,6 +476,15 @@ void planGate
   .adoptOrphans()
   .then(() => planGate.gcStaleReviewWorktrees())
   .catch((err) => console.warn("[plan-gate] adoptOrphans:", err));
+
+// Session recap (#XXX): generates a plain-language summary of each settled-idle session
+// so the operator can skim what happened without reading the transcript. Mirrors planGate's
+// deps/onChange wiring; model defaults to "sonnet" inside the service.
+const recapService = new RecapService({
+  store,
+  herdr,
+  onChange: (id, recap) => events.emit("session:recap", { id, recap }),
+});
 attachReviewPush(events, store, push);
 attachGitPush(events, store, push);
 attachMergePush(events, push);
@@ -527,6 +537,8 @@ setInterval(() => {
   void reviewService.tick();
   void planGate.tick();
   void standaloneCritic.tick();
+  void recapService.tick(); // finalize in-flight recaps (restart-safe)
+  void recapService.sweep(); // settled-idle auto-fire
 }, 15_000);
 // The standalone critic's enumeration runs on its OWN 60s timer, separate from the 15s
 // finalize tick above: a sweep lists every open PR per repo (a forge round-trip), far
@@ -543,6 +555,7 @@ events.subscribe((event, data) => {
     const id = (data as { id: string }).id;
     reviewService.forget(id);
     planGate.forget(id);
+    recapService.forget(id);
   }
 });
 
@@ -940,6 +953,8 @@ const server = serve(
       reviewing: () => planGate.reviewingIds(),
     },
     planGate: { consider: (s) => planGate.consider(s) },
+    recapCache: { snapshot: () => recapService.snapshot() },
+    recap: { regenerate: (s) => recapService.regenerate(s) },
     backlog,
     // After a backlog merge, force-refresh the repo's counts past the read-TTL and
     // re-broadcast the overview so the merged PR (and any auto-closed linked issue)

--- a/src/recap-core.ts
+++ b/src/recap-core.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure helpers for the Session Recap feature — no I/O, no DB, no spawn.
+ * Mirrors the structure of critic-core.ts (parse/validate/clamp + prompt building).
+ */
+import type { ActivityEntry } from "./activity";
+import type { Recap, RecapVerdict } from "./types";
+
+export const RECAP_VERDICTS: readonly RecapVerdict[] = ["ready", "parked", "needs_attention"];
+export const RECAP_HEADLINE_MAX = 100;
+export const RECAP_DIGEST_MAX_CHARS = 4000;
+
+/** Parse + validate the raw .shepherd-recap.json the spawn wrote. Returns null when the
+ *  shape is invalid (caller fails closed). Clamps headline to RECAP_HEADLINE_MAX, coerces
+ *  openItems to a string[] (drops non-strings), requires verdict ∈ RECAP_VERDICTS. */
+export function parseRecapVerdict(
+  raw: unknown,
+): { verdict: RecapVerdict; headline: string; body: string; openItems: string[] } | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const r = raw as Record<string, unknown>;
+
+  const verdict = r.verdict;
+  if (!RECAP_VERDICTS.includes(verdict as RecapVerdict)) return null;
+
+  const headline = typeof r.headline === "string" ? r.headline.slice(0, RECAP_HEADLINE_MAX) : "";
+  const body = typeof r.body === "string" ? r.body : "";
+  const rawItems = r.openItems;
+  const openItems = Array.isArray(rawItems)
+    ? rawItems.filter((x): x is string => typeof x === "string")
+    : [];
+
+  return { verdict: verdict as RecapVerdict, headline, body, openItems };
+}
+
+/** Build a bounded digest of what the agent did from parsed transcript entries
+ *  (tool-use summaries, oldest→newest), capped to ~maxChars (default RECAP_DIGEST_MAX_CHARS).
+ *  If the very first entry exceeds the cap, a truncated version of it is included so a single
+ *  large entry always contributes something rather than returning "". */
+export function buildTranscriptDigest(
+  entries: ActivityEntry[],
+  maxChars = RECAP_DIGEST_MAX_CHARS,
+): string {
+  if (entries.length === 0) return "";
+  const lines: string[] = [];
+  let total = 0;
+  for (const e of entries) {
+    const line = `[${e.tool}] ${e.summary}`;
+    if (total + line.length + 1 > maxChars) {
+      if (lines.length === 0) lines.push(line.slice(0, maxChars));
+      break;
+    }
+    lines.push(line);
+    total += line.length + 1;
+  }
+  return lines.join("\n");
+}
+
+/** The instruction prompt for the recap spawn. Tells the agent to summarize a COMPLETED
+ *  coding session for an operator deciding whether to merge, and to Write a
+ *  `.shepherd-recap.json` file with {verdict, headline, body, openItems}. */
+export function buildRecapPrompt(input: {
+  taskPrompt: string;
+  plan: string; // "" when no .shepherd-plan.md
+  changedFiles: string[];
+  digest: string;
+  context: string; // pre-rendered critic verdict / CI / readyToMerge lines (may be "")
+}): string {
+  const lines = [
+    "You are summarizing a COMPLETED coding session for an operator who will decide whether to merge the work.",
+    "Do NOT modify, build, commit, or run anything — read-only inspection only.",
+    "",
+    "The task that was worked on:",
+    input.taskPrompt,
+    "",
+  ];
+
+  if (input.plan.trim()) {
+    lines.push("Plan that was executed:", input.plan, "");
+  }
+
+  if (input.changedFiles.length > 0) {
+    lines.push("Files changed in this session:", ...input.changedFiles.map((f) => `  ${f}`), "");
+  }
+
+  if (input.digest.trim()) {
+    lines.push("What the agent did (tool-use digest, oldest→newest):", input.digest, "");
+  }
+
+  if (input.context.trim()) {
+    lines.push("Additional context (CI / critic verdict / merge readiness):", input.context, "");
+  }
+
+  lines.push(
+    "Based on the above, write a concise recap for the operator:",
+    '- verdict: one of "ready" | "parked" | "needs_attention"',
+    '  - "ready": the session looks complete, merged-able, no blocking issues',
+    '  - "parked": work done but not yet complete (e.g. mid-task, awaiting feedback)',
+    '  - "needs_attention": blocking issues, failing tests, or something the operator must act on',
+    `- headline: ≤${RECAP_HEADLINE_MAX} chars — one-line summary of what was accomplished`,
+    "- body: concise markdown covering what changed, key decisions made, and merge-readiness",
+    "- openItems: string[] of anything left to do or worth noting for the next session ([] if none)",
+    "",
+    `Write the result as JSON to the file \`.shepherd-recap.json\` in your CWD with EXACTLY this shape:`,
+    `{"verdict": "ready" | "parked" | "needs_attention", "headline": "<string>", "body": "<markdown>", "openItems": ["<string>", ...]}`,
+    "Write the file as your final action, then stop.",
+  );
+
+  return lines.join("\n");
+}
+
+/** Settled-idle test: agent status is finished AND has been idle long enough. */
+export function isSettledIdle(status: string, idleMs: number, thresholdMs: number): boolean {
+  return (status === "idle" || status === "done") && idleMs >= thresholdMs;
+}
+
+/** Head-keyed dedupe: regenerate only when there's no recap yet, or the existing recap
+ *  summarized a different HEAD. Any existing row at the same head — generating/ready/failed/
+ *  empty — means do NOT auto-fire; fail-closed: no auto-retry of a failed recap. */
+export function needsRecap(existing: Recap | null, currentHeadSha: string): boolean {
+  return !existing || existing.headSha !== currentHeadSha;
+}

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -1,0 +1,489 @@
+/**
+ * RecapService — auto-generates a one-time, head-keyed session recap via a transient
+ * Sonnet spawn. Mirrors ReviewService/PlanGateService structure:
+ *   sweep()      — periodic auto-fire (settled-idle debounce, head-keyed dedupe)
+ *   tick()       — finalize in-flight recaps (restart-safe, reads from DB)
+ *   generate()   — shared spawn path (auto + on-demand)
+ *   regenerate() — on-demand force (bypasses scope/debounce/dedupe)
+ *   snapshot()   — snapshot for client bootstrap
+ *   forget()     — reap + drop on archive
+ *
+ * Spawn pattern mirrors src/namer-llm.ts: tmpdir cwd, Write-only, dontAsk,
+ * disableAllHooks, disable-slash-commands. No worktree, no membrane.
+ */
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { SessionStore } from "./store";
+import type { HerdrDriver } from "./herdr";
+import type { Session, Recap } from "./types";
+import type { DiffResult } from "./types";
+import type { ActivityEntry } from "./activity";
+import type { SessionUsage } from "./usage";
+import { readSessionUsage } from "./usage";
+import { computeDiff } from "./diff";
+import { parseActivity, readTranscriptTail } from "./activity";
+import { jsonlPathFor } from "./usage";
+import {
+  parseRecapVerdict,
+  buildTranscriptDigest,
+  buildRecapPrompt,
+  isSettledIdle,
+  needsRecap,
+} from "./recap-core";
+
+const execFileAsync = promisify(execFile);
+
+/** The file the recap agent writes its JSON verdict to, in its temp cwd. */
+export const RECAP_VERDICT_FILE = ".shepherd-recap.json";
+
+/** Plan file the agent writes in its LIVE session worktree. */
+const PLAN_FILE = ".shepherd-plan.md";
+
+const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+const DEFAULT_IDLE_THRESHOLD_MS = 120_000;
+
+// ── defaults ──────────────────────────────────────────────────────────────────
+
+async function defaultHeadSha(worktreePath: string): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+    cwd: worktreePath,
+    encoding: "utf8",
+  });
+  return stdout.trim();
+}
+
+function defaultReadTranscript(worktreePath: string, claudeSessionId: string): ActivityEntry[] {
+  const path = jsonlPathFor(worktreePath, claudeSessionId);
+  try {
+    const text = readTranscriptTail(path);
+    return parseActivity(text, -1); // -1 = all entries
+  } catch {
+    return [];
+  }
+}
+
+function defaultReadPlan(worktreePath: string): string {
+  const p = join(worktreePath, PLAN_FILE);
+  if (!existsSync(p)) return "";
+  try {
+    return readFileSync(p, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function defaultReadVerdict(cwd: string): unknown | null {
+  const p = join(cwd, RECAP_VERDICT_FILE);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, "utf8")) as unknown;
+  } catch {
+    return null; // partial write; retry next tick
+  }
+}
+
+function defaultMakeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "shepherd-recap-"));
+}
+
+function defaultCleanup(cwd: string): void {
+  try {
+    rmSync(cwd, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * The `claude` argv for the recap spawn — mirrors namerArgv exactly, with model
+ * defaulting to "sonnet" instead of "haiku".
+ *
+ * Layout: --session-id uuid --settings '{"disableAllHooks":true}'
+ *   --disable-slash-commands --allowedTools Write [--model <m>]
+ *   --permission-mode dontAsk <prompt>
+ * NOTE: --allowedTools is variadic and eats tokens until the next flag, so
+ * --permission-mode must follow it and the prompt must be last. Don't reorder.
+ */
+function recapArgv(model: string | null, prompt: string): { argv: string[]; sessionId: string } {
+  const sessionId = randomUUID();
+  const argv = [
+    "claude",
+    "--session-id",
+    sessionId,
+    "--settings",
+    '{"disableAllHooks":true}',
+    "--disable-slash-commands",
+    "--allowedTools",
+    "Write",
+  ];
+  if (model) argv.push("--model", model);
+  argv.push("--permission-mode", "dontAsk");
+  argv.push(prompt);
+  return { argv, sessionId };
+}
+
+// ── deps interface ────────────────────────────────────────────────────────────
+
+export interface RecapServiceDeps {
+  store: Pick<
+    SessionStore,
+    | "getRecap"
+    | "putRecap"
+    | "snapshotRecaps"
+    | "generatingRecaps"
+    | "dropRecap"
+    | "getReview"
+    | "recordReviewerSpawn"
+    | "completeReviewerSpawn"
+    | "list"
+  >;
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list">;
+  onChange: (id: string, recap: Recap | null) => void;
+  model?: string | null;
+  now?: () => number;
+  timeoutMs?: number;
+  idleThresholdMs?: number;
+  // injectables:
+  computeDiff?: (worktreePath: string, base: string, branch: string | null) => Promise<DiffResult>;
+  headSha?: (worktreePath: string) => Promise<string>;
+  readTranscript?: (worktreePath: string, claudeSessionId: string) => ActivityEntry[];
+  readPlan?: (worktreePath: string) => string;
+  readVerdict?: (cwd: string) => unknown | null;
+  readUsage?: (cwd: string, spawnSessionId: string) => Promise<SessionUsage | null>;
+  makeTmpDir?: () => string;
+  cleanup?: (cwd: string) => void;
+}
+
+// ── per-session debounce state ────────────────────────────────────────────────
+
+interface DebounceEntry {
+  stamp: number; // epoch ms when we first saw the session idle/done
+  fired: boolean; // true = recap already triggered this idle episode
+}
+
+// ── service ───────────────────────────────────────────────────────────────────
+
+export class RecapService {
+  private now: () => number;
+  private timeoutMs: number;
+  private idleThresholdMs: number;
+  private model: string | null;
+
+  private _computeDiff: (
+    worktreePath: string,
+    base: string,
+    branch: string | null,
+  ) => Promise<DiffResult>;
+  private _headSha: (worktreePath: string) => Promise<string>;
+  private _readTranscript: (worktreePath: string, claudeSessionId: string) => ActivityEntry[];
+  private _readPlan: (worktreePath: string) => string;
+  private _readVerdict: (cwd: string) => unknown | null;
+  private _readUsage: (cwd: string, spawnSessionId: string) => Promise<SessionUsage | null>;
+  private _makeTmpDir: () => string;
+  private _cleanup: (cwd: string) => void;
+
+  /** Per-session settled-idle debounce: stamp + fired-this-episode flag. */
+  private debounce = new Map<string, DebounceEntry>();
+
+  /** Guards against a session being finalized twice across overlapping ticks. */
+  private finalizing = new Set<string>();
+
+  /** Guards against double-spawn when regenerate races a mid-flight sweep. */
+  private inFlight = new Set<string>();
+
+  constructor(private deps: RecapServiceDeps) {
+    this.now = deps.now ?? Date.now;
+    this.timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.idleThresholdMs = deps.idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
+    this.model = deps.model ?? "sonnet";
+    this._computeDiff = deps.computeDiff ?? computeDiff;
+    this._headSha = deps.headSha ?? defaultHeadSha;
+    this._readTranscript = deps.readTranscript ?? defaultReadTranscript;
+    this._readPlan = deps.readPlan ?? defaultReadPlan;
+    this._readVerdict = deps.readVerdict ?? defaultReadVerdict;
+    this._readUsage = deps.readUsage ?? readSessionUsage;
+    this._makeTmpDir = deps.makeTmpDir ?? defaultMakeTmpDir;
+    this._cleanup = deps.cleanup ?? defaultCleanup;
+  }
+
+  // ── resolveTerminal ──────────────────────────────────────────────────────────
+
+  /** Find a recap spawn's live terminal by its tmpdir cwd. "" when gone; herdr.stop("") is a no-op. */
+  private resolveTerminal(cwd: string): string {
+    return this.deps.herdr.list().find((a) => a.cwd === cwd)?.terminalId ?? "";
+  }
+
+  // ── reapGenerating ───────────────────────────────────────────────────────────
+
+  /** Reap any existing generating row for this session (stop pane + cleanup dir + drop row). */
+  private reapGenerating(sessionId: string): void {
+    const existing = this.deps.store.getRecap(sessionId);
+    if (!existing || existing.state !== "generating") return;
+    try {
+      this.deps.herdr.stop(this.resolveTerminal(existing.cwd));
+    } catch {
+      /* best-effort */
+    }
+    this._cleanup(existing.cwd);
+    this.deps.store.dropRecap(sessionId);
+  }
+
+  // ── sweep ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Periodic auto-fire. For each active session, debounce the settled-idle window
+   * then generate a recap once per idle episode (head-keyed).
+   */
+  async sweep(): Promise<void> {
+    const sessions = this.deps.store.list({ activeOnly: true });
+    const t = this.now();
+
+    for (const s of sessions) {
+      const settled = s.status === "idle" || s.status === "done";
+
+      if (!settled) {
+        // Re-activating: clear debounce so a later settle re-evaluates cleanly.
+        this.debounce.delete(s.id);
+        continue;
+      }
+
+      // Settled:
+      const entry = this.debounce.get(s.id);
+      if (!entry) {
+        this.debounce.set(s.id, { stamp: t, fired: false });
+        continue;
+      }
+
+      if (entry.fired) continue; // already triggered this episode
+
+      const idleMs = t - entry.stamp;
+      if (!isSettledIdle(s.status, idleMs, this.idleThresholdMs)) continue;
+
+      // Eligibility: mark fired NOW (prevents repeated rev-parse until re-activity).
+      entry.fired = true;
+
+      // Skip drain sessions and sessions without a branch.
+      if (s.auto || !s.branch) continue;
+
+      let head: string;
+      try {
+        head = await this._headSha(s.worktreePath);
+      } catch {
+        continue; // git unavailable; retry next sweep
+      }
+
+      if (!needsRecap(this.deps.store.getRecap(s.id), head)) continue;
+
+      await this.generate(s, head);
+    }
+  }
+
+  // ── generate ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Spawn a recap agent for `session`. Shared by sweep (auto) and regenerate (on-demand).
+   *
+   * Returns:
+   *   "empty"   — diff had no files; an empty row is written and onChange is fired.
+   *   "started" — spawn launched; a generating row is written.
+   *   "error"   — herdr.start failed; tmpdir is cleaned, no row is left so a later
+   *               auto-settle can retry. Does NOT throw.
+   *
+   * A synchronous in-flight guard prevents double-spawn if regenerate races sweep.
+   */
+  async generate(session: Session, knownHead?: string): Promise<"started" | "empty" | "error"> {
+    const { id, worktreePath, baseBranch, branch, claudeSessionId } = session;
+
+    // Synchronous guard: if already mid-flight for this session, bail immediately.
+    if (this.inFlight.has(id)) return "started";
+    this.inFlight.add(id);
+
+    try {
+      // Reap any in-flight row for this session first (prevents stale generating rows).
+      this.reapGenerating(id);
+
+      const head = knownHead ?? (await this._headSha(worktreePath));
+
+      const diff = await this._computeDiff(worktreePath, baseBranch, branch);
+      if (diff.files.length === 0) {
+        const t = this.now();
+        this.deps.store.putRecap({
+          sessionId: id,
+          state: "empty",
+          headSha: head,
+          verdict: null,
+          headline: "",
+          body: "",
+          openItems: [],
+          spawnSessionId: "",
+          cwd: "",
+          model: this.model,
+          spawnedAt: t,
+          generatedAt: t,
+          updatedAt: t,
+        });
+        this.deps.onChange(id, null);
+        return "empty";
+      }
+
+      // Build prompt inputs.
+      const transcript = this._readTranscript(worktreePath, claudeSessionId);
+      const digest = buildTranscriptDigest(transcript);
+      const plan = this._readPlan(worktreePath);
+      const changedFiles = diff.files.map((f) => f.path);
+
+      const contextParts: string[] = [];
+      const review = this.deps.store.getReview(id);
+      if (review?.summary) contextParts.push(`Critic verdict: ${review.summary}`);
+      if (session.readyToMerge) contextParts.push("Operator marked ready to merge.");
+      if (session.planPhase) contextParts.push(`Plan phase: ${session.planPhase}`);
+      const context = contextParts.join("\n");
+
+      const prompt = buildRecapPrompt({
+        taskPrompt: session.prompt,
+        plan,
+        changedFiles,
+        digest,
+        context,
+      });
+      const { argv, sessionId: spawnSessionId } = recapArgv(this.model, prompt);
+
+      // Spawn.
+      const cwd = this._makeTmpDir();
+      try {
+        this.deps.herdr.start(`recap ${session.desig}`, cwd, argv);
+      } catch {
+        this._cleanup(cwd);
+        return "error"; // spawn failed; no row left so next settle can retry
+      }
+
+      const spawnedAt = this.now();
+
+      this.deps.store.recordReviewerSpawn({
+        reviewerSessionId: spawnSessionId,
+        taskSessionId: id,
+        kind: "recap",
+        worktreePath: cwd,
+        model: this.model,
+        spawnedAt,
+      });
+
+      const row: Recap = {
+        sessionId: id,
+        state: "generating",
+        headSha: head,
+        verdict: null,
+        headline: "",
+        body: "",
+        openItems: [],
+        spawnSessionId,
+        cwd,
+        model: this.model,
+        spawnedAt,
+        generatedAt: null,
+        updatedAt: spawnedAt,
+      };
+      this.deps.store.putRecap(row);
+      this.deps.onChange(id, row);
+
+      return "started";
+    } finally {
+      this.inFlight.delete(id);
+    }
+  }
+
+  // ── tick ─────────────────────────────────────────────────────────────────────
+
+  /**
+   * Finalize any generating recap whose verdict file is ready or that has timed out.
+   * Restart-safe: reads from the DB, not memory.
+   */
+  async tick(): Promise<void> {
+    for (const r of this.deps.store.generatingRecaps()) {
+      if (this.finalizing.has(r.sessionId)) continue;
+
+      const raw = this._readVerdict(r.cwd);
+      const timedOut = this.now() - r.spawnedAt > this.timeoutMs;
+      if (!raw && !timedOut) continue;
+
+      this.finalizing.add(r.sessionId);
+      try {
+        await this.finalize(r, raw);
+      } finally {
+        this.finalizing.delete(r.sessionId);
+      }
+    }
+  }
+
+  private async finalize(r: Recap, raw: unknown | null): Promise<void> {
+    const t = this.now();
+    let newRow: Recap;
+    try {
+      const parsed = raw ? parseRecapVerdict(raw) : null;
+      if (parsed) {
+        newRow = {
+          ...r,
+          state: "ready",
+          verdict: parsed.verdict,
+          headline: parsed.headline,
+          body: parsed.body,
+          openItems: parsed.openItems,
+          generatedAt: t,
+          updatedAt: t,
+        };
+      } else {
+        // timeout or unparseable — fail closed, never fake a ready
+        newRow = { ...r, state: "failed", generatedAt: t, updatedAt: t };
+      }
+      this.deps.store.putRecap(newRow);
+      this.deps.onChange(r.sessionId, newRow);
+
+      // Best-effort usage capture.
+      try {
+        const u = await this._readUsage(r.cwd, r.spawnSessionId);
+        if (u) this.deps.store.completeReviewerSpawn(r.spawnSessionId, u, t);
+      } catch (err) {
+        console.warn(`[recap] usage capture failed for ${r.sessionId}:`, err);
+      }
+    } finally {
+      // Always reap pane + tmpdir.
+      try {
+        this.deps.herdr.stop(this.resolveTerminal(r.cwd));
+      } catch {
+        /* best-effort */
+      }
+      this._cleanup(r.cwd);
+    }
+  }
+
+  // ── regenerate ───────────────────────────────────────────────────────────────
+
+  /**
+   * Force a fresh recap for ANY session, regardless of existing row / debounce / drain.
+   * Returns "empty" | "started" | "error".
+   */
+  async regenerate(session: Session): Promise<"started" | "empty" | "error"> {
+    // Clear debounce so next sweep re-evaluates cleanly.
+    this.debounce.delete(session.id);
+    return this.generate(session);
+  }
+
+  // ── snapshot ─────────────────────────────────────────────────────────────────
+
+  snapshot(): Record<string, Recap> {
+    return this.deps.store.snapshotRecaps();
+  }
+
+  // ── forget ───────────────────────────────────────────────────────────────────
+
+  /** On session archive: reap any in-flight generating row, then drop the recap row. */
+  forget(sessionId: string): void {
+    this.reapGenerating(sessionId);
+    this.debounce.delete(sessionId);
+    this.deps.store.dropRecap(sessionId);
+  }
+}

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -249,18 +249,22 @@ export class RecapService {
     const idleMs = now - entry.stamp;
     if (!isSettledIdle(s.status, idleMs, this.idleThresholdMs)) return;
 
-    // Eligibility: mark fired NOW (prevents repeated rev-parse until re-activity).
-    entry.fired = true;
-
-    // Skip drain sessions and sessions without a branch.
-    if (s.auto || !s.branch) return;
+    // Skip drain sessions and sessions without a branch — stable for the episode, so
+    // burn the marker (no point re-checking until the session re-activates).
+    if (s.auto || !s.branch) {
+      entry.fired = true;
+      return;
+    }
 
     let head: string;
     try {
       head = await this._headSha(s.worktreePath);
     } catch {
-      return; // git unavailable; retry next sweep
+      return; // git unavailable; leave fired=false so the next sweep retries
     }
+
+    // rev-parse succeeded → mark fired so we don't re-rev-parse until re-activity.
+    entry.fired = true;
 
     if (!needsRecap(this.deps.store.getRecap(s.id), head)) return;
 
@@ -296,9 +300,11 @@ export class RecapService {
    * Returns:
    *   "empty"   — diff had no files; an empty row is written and onChange is fired.
    *   "started" — spawn launched; a generating row is written.
-   *   "error"   — herdr.start failed; tmpdir is cleaned, no row is left so a later
-   *               auto-settle can retry. Does NOT throw.
+   *   "error"   — git (rev-parse/diff) failed, or herdr.start failed; any tmpdir is
+   *               cleaned and no row is left so a later auto-settle can retry.
    *
+   * Does NOT throw — git/diff rejections are caught and surface as "error" — so callers
+   * (incl. the bare-`void` sweep loop) need not guard it.
    * A synchronous in-flight guard prevents double-spawn if regenerate races sweep.
    */
   async generate(session: Session, knownHead?: string): Promise<"started" | "empty" | "error"> {
@@ -312,9 +318,17 @@ export class RecapService {
       // Reap any in-flight row for this session first (prevents stale generating rows).
       this.reapGenerating(id);
 
-      const head = knownHead ?? (await this._headSha(worktreePath));
+      // Resolve HEAD + diff up front; a git/diff rejection self-heals to "error"
+      // (no row left) rather than throwing out of this bare-`void`-called method.
+      let head: string;
+      let diff: DiffResult;
+      try {
+        head = knownHead ?? (await this._headSha(worktreePath));
+        diff = await this._computeDiff(worktreePath, baseBranch, branch);
+      } catch {
+        return "error";
+      }
 
-      const diff = await this._computeDiff(worktreePath, baseBranch, branch);
       if (diff.files.length === 0) {
         const t = this.now();
         this.deps.store.putRecap({

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -38,7 +38,7 @@ import {
 const execFileAsync = promisify(execFile);
 
 /** The file the recap agent writes its JSON verdict to, in its temp cwd. */
-export const RECAP_VERDICT_FILE = ".shepherd-recap.json";
+const RECAP_VERDICT_FILE = ".shepherd-recap.json";
 
 /** Plan file the agent writes in its LIVE session worktree. */
 const PLAN_FILE = ".shepherd-plan.md";
@@ -235,6 +235,39 @@ export class RecapService {
   // ── sweep ────────────────────────────────────────────────────────────────────
 
   /**
+   * Per-session debounce + eligibility decision. Called by sweep() for each settled session.
+   */
+  private async considerSession(s: Session, now: number): Promise<void> {
+    const entry = this.debounce.get(s.id);
+    if (!entry) {
+      this.debounce.set(s.id, { stamp: now, fired: false });
+      return;
+    }
+
+    if (entry.fired) return; // already triggered this episode
+
+    const idleMs = now - entry.stamp;
+    if (!isSettledIdle(s.status, idleMs, this.idleThresholdMs)) return;
+
+    // Eligibility: mark fired NOW (prevents repeated rev-parse until re-activity).
+    entry.fired = true;
+
+    // Skip drain sessions and sessions without a branch.
+    if (s.auto || !s.branch) return;
+
+    let head: string;
+    try {
+      head = await this._headSha(s.worktreePath);
+    } catch {
+      return; // git unavailable; retry next sweep
+    }
+
+    if (!needsRecap(this.deps.store.getRecap(s.id), head)) return;
+
+    await this.generate(s, head);
+  }
+
+  /**
    * Periodic auto-fire. For each active session, debounce the settled-idle window
    * then generate a recap once per idle episode (head-keyed).
    */
@@ -251,34 +284,7 @@ export class RecapService {
         continue;
       }
 
-      // Settled:
-      const entry = this.debounce.get(s.id);
-      if (!entry) {
-        this.debounce.set(s.id, { stamp: t, fired: false });
-        continue;
-      }
-
-      if (entry.fired) continue; // already triggered this episode
-
-      const idleMs = t - entry.stamp;
-      if (!isSettledIdle(s.status, idleMs, this.idleThresholdMs)) continue;
-
-      // Eligibility: mark fired NOW (prevents repeated rev-parse until re-activity).
-      entry.fired = true;
-
-      // Skip drain sessions and sessions without a branch.
-      if (s.auto || !s.branch) continue;
-
-      let head: string;
-      try {
-        head = await this._headSha(s.worktreePath);
-      } catch {
-        continue; // git unavailable; retry next sweep
-      }
-
-      if (!needsRecap(this.deps.store.getRecap(s.id), head)) continue;
-
-      await this.generate(s, head);
+      await this.considerSession(s, t);
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1184,6 +1184,8 @@ async function handleSessionReviewPlan({ req, parts, deps }: Ctx): Promise<Respo
 
 // POST /api/sessions/:id/recap/regenerate — force-regenerate the session recap on demand.
 // 404 unknown id; 202 with {status} = "started" | "empty" | "error" so the UI can explain the outcome.
+// NOTE: unlike the auto-fire sweep (which skips drain sessions), on-demand regenerate is
+// intentionally allowed for ANY session — an operator may want a summary of a drain run.
 async function handleSessionRecapRegenerate({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "POST" && parts[2] && parts[3] === "recap" && parts[4] === "regenerate"))
     return null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -189,6 +189,10 @@ export interface AppDeps {
   planGate?: {
     consider(session: Session): Promise<import("./plan-gate").PlanReviewTrigger>;
   };
+  /** Snapshot of session recaps keyed by session id; absent in tests that skip it. */
+  recapCache?: { snapshot(): Record<string, import("./types").Recap> };
+  /** Force-regenerate a session recap on demand (the /recap/regenerate route). */
+  recap?: { regenerate(session: Session): Promise<"started" | "empty" | "error"> };
   /** Backlog counts service; absent in tests that don't exercise it. */
   backlog?: Pick<CountsService, "counts">;
   /** Force-refresh one repo's backlog counts (bypassing the read-TTL) and push the
@@ -330,6 +334,15 @@ function handlePlanGates({ req, parts, deps }: Ctx): Response | null {
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "plan-gates") {
     if (!parts[2]) return json(deps.planGateCache?.snapshot() ?? {});
     if (parts[2] === "inflight") return json(deps.planGateCache?.reviewing?.() ?? []);
+  }
+  return null;
+}
+
+// GET /api/recaps — bootstrap snapshot of session recaps keyed by session id.
+// Mirrors handleReviews / handlePlanGates; absent dep returns {}.
+function handleRecaps({ req, parts, deps }: Ctx): Response | null {
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "recaps") {
+    if (!parts[2]) return json(deps.recapCache?.snapshot() ?? {});
   }
   return null;
 }
@@ -1169,6 +1182,17 @@ async function handleSessionReviewPlan({ req, parts, deps }: Ctx): Promise<Respo
   return json({ ok: true, status }, 202);
 }
 
+// POST /api/sessions/:id/recap/regenerate — force-regenerate the session recap on demand.
+// 404 unknown id; 202 with {status} = "started" | "empty" | "error" so the UI can explain the outcome.
+async function handleSessionRecapRegenerate({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(req.method === "POST" && parts[2] && parts[3] === "recap" && parts[4] === "regenerate"))
+    return null;
+  const s = deps.store.get(parts[2]);
+  if (!s) return json({ error: "not found" }, 404);
+  const status = (await deps.recap?.regenerate(s)) ?? "error";
+  return json({ ok: true, status }, 202);
+}
+
 // Validate the rename body, returning the typed name or the error Response to send.
 async function parseRenameName(req: Request): Promise<string | Response> {
   const ctErr = requireJsonContentType(req);
@@ -1583,6 +1607,7 @@ async function handleSessions(ctx: Ctx): Promise<Response | null> {
     handleSessionReply,
     handleSessionGo,
     handleSessionReviewPlan,
+    handleSessionRecapRegenerate,
     handlePreviewStart,
     handlePreviewStop,
     handleSessionRename,
@@ -3060,6 +3085,7 @@ const ROUTE_HANDLERS = [
   handlePreviewSnapshot,
   handleReviews,
   handlePlanGates,
+  handleRecaps,
   handleDrain,
   handleAutoMerge,
   handleEpicsList,

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,6 +4,7 @@ import type {
   Session,
   ReviewVerdict,
   PlanGate,
+  Recap,
   Signal,
   SignalKind,
   Learning,
@@ -310,6 +311,20 @@ export class SessionStore implements CapStore, CreditStore {
       findings TEXT NOT NULL DEFAULT '[]', round INTEGER NOT NULL DEFAULT 0,
       cap INTEGER NOT NULL DEFAULT 3, approved INTEGER NOT NULL DEFAULT 0,
       plan TEXT NOT NULL DEFAULT '', updatedAt INTEGER NOT NULL)`);
+    this.db.run(`CREATE TABLE IF NOT EXISTS recaps (
+      sessionId TEXT PRIMARY KEY,
+      state TEXT NOT NULL,
+      headSha TEXT NOT NULL DEFAULT '',
+      verdict TEXT,
+      headline TEXT NOT NULL DEFAULT '',
+      body TEXT NOT NULL DEFAULT '',
+      openItems TEXT NOT NULL DEFAULT '[]',
+      spawnSessionId TEXT NOT NULL DEFAULT '',
+      cwd TEXT NOT NULL DEFAULT '',
+      model TEXT,
+      spawnedAt INTEGER NOT NULL,
+      generatedAt INTEGER,
+      updatedAt INTEGER NOT NULL)`);
     // Exact reviewer-cost attribution. Keyed by the *reviewer's* forced --session-id (which
     // locates its transcript), NOT the task — and deliberately carries NO foreign key to
     // `sessions`. `reviews`/`plan_gates` are keyed by the task sessionId and get deleted on
@@ -1009,6 +1024,102 @@ export class SessionStore implements CapStore, CreditStore {
     return out;
   }
 
+  // ── session recaps ────────────────────────────────────────────────────────────
+  private hydrateRecap(r: any): Recap {
+    let openItems: string[] = [];
+    try {
+      const parsed = JSON.parse(r.openItems);
+      if (Array.isArray(parsed))
+        openItems = parsed.filter((x): x is string => typeof x === "string");
+    } catch {
+      openItems = [];
+    }
+    return {
+      sessionId: r.sessionId,
+      state: r.state,
+      headSha: r.headSha ?? "",
+      verdict: r.verdict ?? null,
+      headline: r.headline ?? "",
+      body: r.body ?? "",
+      openItems,
+      spawnSessionId: r.spawnSessionId ?? "",
+      cwd: r.cwd ?? "",
+      model: r.model ?? null,
+      spawnedAt: r.spawnedAt,
+      generatedAt: r.generatedAt ?? null,
+      updatedAt: r.updatedAt,
+    } as Recap;
+  }
+
+  getRecap(sessionId: string): Recap | null {
+    const r = this.db
+      .query(
+        `SELECT sessionId, state, headSha, verdict, headline, body, openItems,
+                spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
+              FROM recaps WHERE sessionId = ?`,
+      )
+      .get(sessionId) as any;
+    return r ? this.hydrateRecap(r) : null;
+  }
+
+  putRecap(recap: Recap): void {
+    this.db.run(
+      `INSERT INTO recaps (sessionId, state, headSha, verdict, headline, body, openItems,
+         spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+       ON CONFLICT(sessionId) DO UPDATE SET state=excluded.state, headSha=excluded.headSha,
+         verdict=excluded.verdict, headline=excluded.headline, body=excluded.body,
+         openItems=excluded.openItems, spawnSessionId=excluded.spawnSessionId,
+         cwd=excluded.cwd, model=excluded.model, spawnedAt=excluded.spawnedAt,
+         generatedAt=excluded.generatedAt, updatedAt=excluded.updatedAt`,
+      [
+        recap.sessionId,
+        recap.state,
+        recap.headSha ?? "",
+        recap.verdict ?? null,
+        recap.headline ?? "",
+        recap.body ?? "",
+        JSON.stringify(recap.openItems ?? []),
+        recap.spawnSessionId ?? "",
+        recap.cwd ?? "",
+        recap.model ?? null,
+        recap.spawnedAt,
+        recap.generatedAt ?? null,
+        recap.updatedAt,
+      ],
+    );
+  }
+
+  /** All recaps except `empty` ones — the UI never shows an empty recap. */
+  snapshotRecaps(): Record<string, Recap> {
+    const rows = this.db
+      .query(
+        `SELECT sessionId, state, headSha, verdict, headline, body, openItems,
+                spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
+              FROM recaps WHERE state != 'empty'`,
+      )
+      .all() as any[];
+    const out: Record<string, Recap> = {};
+    for (const r of rows) out[r.sessionId] = this.hydrateRecap(r);
+    return out;
+  }
+
+  /** Rows currently in-flight — used by the service's finalize loop (restart-safe). */
+  generatingRecaps(): Recap[] {
+    const rows = this.db
+      .query(
+        `SELECT sessionId, state, headSha, verdict, headline, body, openItems,
+                spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
+              FROM recaps WHERE state = 'generating'`,
+      )
+      .all() as any[];
+    return rows.map((r) => this.hydrateRecap(r));
+  }
+
+  dropRecap(sessionId: string): void {
+    this.db.run(`DELETE FROM recaps WHERE sessionId = ?`, [sessionId]);
+  }
+
   setPlanPhase(id: string, phase: Session["planPhase"]): void {
     this.db.run(`UPDATE sessions SET planPhase = ?, updatedAt = ? WHERE id = ?`, [
       phase,
@@ -1024,7 +1135,7 @@ export class SessionStore implements CapStore, CreditStore {
   recordReviewerSpawn(r: {
     reviewerSessionId: string;
     taskSessionId: string;
-    kind: "review" | "plan_gate";
+    kind: "review" | "plan_gate" | "recap";
     worktreePath: string;
     model: string | null;
     spawnedAt: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -262,6 +262,29 @@ export interface PrReview {
 }
 
 // ── reviewer spawn cost-attribution record ──────────────────────────────────
+// ── session recap ────────────────────────────────────────────────────────────
+export type RecapState = "generating" | "ready" | "failed" | "empty";
+export type RecapVerdict = "ready" | "parked" | "needs_attention";
+
+/** A per-session LLM recap. One row per session, keyed by the HEAD it summarizes
+ *  (head-keyed dedupe: a new head re-generates). `state` distinguishes in-flight /
+ *  done / failed / no-changes. verdict/headline/body/openItems are empty until ready. */
+export interface Recap {
+  sessionId: string;
+  state: RecapState;
+  headSha: string; // the git HEAD this recap summarizes; "" for empty/in-flight w/o head
+  verdict: RecapVerdict | null;
+  headline: string; // <=100 chars; "" until ready
+  body: string; // markdown; "" until ready
+  openItems: string[]; // [] until ready
+  spawnSessionId: string; // claude --session-id of the recap spawn (usage + pane resolve)
+  cwd: string; // tmpdir cwd of the spawn (verdict file read + pane reap)
+  model: string | null;
+  spawnedAt: number;
+  generatedAt: number | null; // set when finalized (ready/failed/empty)
+  updatedAt: number;
+}
+
 /** Append-only, archive-decoupled record of one spawned critic/plan-gate reviewer
  *  session and its token total. Keyed by the *reviewer* session id (NOT the task) and
  *  deliberately carries no FK to `sessions`, so it outlives task archive + prune —
@@ -269,7 +292,7 @@ export interface PrReview {
 export interface ReviewerSpawnRow {
   reviewerSessionId: string;
   taskSessionId: string;
-  kind: "review" | "plan_gate";
+  kind: "review" | "plan_gate" | "recap";
   worktreePath: string;
   model: string | null;
   spawnedAt: number;

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -1,0 +1,281 @@
+import { test, expect } from "bun:test";
+import {
+  parseRecapVerdict,
+  buildTranscriptDigest,
+  buildRecapPrompt,
+  isSettledIdle,
+  needsRecap,
+  RECAP_VERDICTS,
+  RECAP_HEADLINE_MAX,
+  RECAP_DIGEST_MAX_CHARS,
+} from "../src/recap-core";
+import type { Recap } from "../src/types";
+
+// ── parseRecapVerdict ────────────────────────────────────────────────────────
+
+test("parseRecapVerdict: valid object returns normalized shape", () => {
+  const result = parseRecapVerdict({
+    verdict: "ready",
+    headline: "All done",
+    body: "## Summary\nEverything looks good.",
+    openItems: ["Deploy to staging"],
+  });
+  expect(result).not.toBeNull();
+  expect(result?.verdict).toBe("ready");
+  expect(result?.headline).toBe("All done");
+  expect(result?.body).toBe("## Summary\nEverything looks good.");
+  expect(result?.openItems).toEqual(["Deploy to staging"]);
+});
+
+test("parseRecapVerdict: parked and needs_attention verdicts accepted", () => {
+  expect(
+    parseRecapVerdict({ verdict: "parked", headline: "x", body: "", openItems: [] })?.verdict,
+  ).toBe("parked");
+  expect(
+    parseRecapVerdict({ verdict: "needs_attention", headline: "x", body: "", openItems: [] })
+      ?.verdict,
+  ).toBe("needs_attention");
+});
+
+test("parseRecapVerdict: invalid verdict returns null", () => {
+  expect(
+    parseRecapVerdict({ verdict: "approve", headline: "x", body: "", openItems: [] }),
+  ).toBeNull();
+  expect(parseRecapVerdict({ verdict: null, headline: "x", body: "", openItems: [] })).toBeNull();
+  expect(parseRecapVerdict({ verdict: 42, headline: "x", body: "", openItems: [] })).toBeNull();
+});
+
+test("parseRecapVerdict: headline > RECAP_HEADLINE_MAX is clamped", () => {
+  const long = "a".repeat(RECAP_HEADLINE_MAX + 20);
+  const result = parseRecapVerdict({ verdict: "ready", headline: long, body: "", openItems: [] });
+  expect(result?.headline.length).toBe(RECAP_HEADLINE_MAX);
+});
+
+test("parseRecapVerdict: openItems filters out non-strings", () => {
+  const result = parseRecapVerdict({
+    verdict: "ready",
+    headline: "x",
+    body: "",
+    openItems: ["valid", 42, null, "also valid", true],
+  });
+  expect(result?.openItems).toEqual(["valid", "also valid"]);
+});
+
+test("parseRecapVerdict: non-object/garbage returns null", () => {
+  expect(parseRecapVerdict(null)).toBeNull();
+  expect(parseRecapVerdict(undefined)).toBeNull();
+  expect(parseRecapVerdict("string")).toBeNull();
+  expect(parseRecapVerdict(42)).toBeNull();
+  expect(parseRecapVerdict([])).toBeNull();
+});
+
+test("parseRecapVerdict: missing headline/body/openItems defaults gracefully", () => {
+  const result = parseRecapVerdict({ verdict: "ready" });
+  expect(result).not.toBeNull();
+  expect(result?.headline).toBe("");
+  expect(result?.body).toBe("");
+  expect(result?.openItems).toEqual([]);
+});
+
+// ── isSettledIdle ────────────────────────────────────────────────────────────
+
+test("isSettledIdle: idle status + over threshold → true", () => {
+  expect(isSettledIdle("idle", 5000, 3000)).toBe(true);
+});
+
+test("isSettledIdle: done status + over threshold → true", () => {
+  expect(isSettledIdle("done", 5000, 3000)).toBe(true);
+});
+
+test("isSettledIdle: idle status + exactly at threshold → true", () => {
+  expect(isSettledIdle("idle", 3000, 3000)).toBe(true);
+});
+
+test("isSettledIdle: idle status + under threshold → false", () => {
+  expect(isSettledIdle("idle", 2999, 3000)).toBe(false);
+});
+
+test("isSettledIdle: running status → false", () => {
+  expect(isSettledIdle("running", 9999, 3000)).toBe(false);
+});
+
+test("isSettledIdle: blocked status → false", () => {
+  expect(isSettledIdle("blocked", 9999, 3000)).toBe(false);
+});
+
+test("isSettledIdle: empty string status → false", () => {
+  expect(isSettledIdle("", 9999, 3000)).toBe(false);
+});
+
+// ── needsRecap ───────────────────────────────────────────────────────────────
+
+const baseRecap = (over: Partial<Recap> = {}): Recap => ({
+  sessionId: "s1",
+  state: "ready",
+  headSha: "sha-abc",
+  verdict: "ready",
+  headline: "done",
+  body: "",
+  openItems: [],
+  spawnSessionId: "spawn-1",
+  cwd: "/tmp/x",
+  model: null,
+  spawnedAt: 1000,
+  generatedAt: 2000,
+  updatedAt: 2000,
+  ...over,
+});
+
+test("needsRecap: null existing → true (no recap yet)", () => {
+  expect(needsRecap(null, "sha-abc")).toBe(true);
+});
+
+test("needsRecap: same head (state=ready) → false", () => {
+  expect(needsRecap(baseRecap({ state: "ready", headSha: "sha-abc" }), "sha-abc")).toBe(false);
+});
+
+test("needsRecap: same head (state=generating) → false", () => {
+  expect(needsRecap(baseRecap({ state: "generating", headSha: "sha-abc" }), "sha-abc")).toBe(false);
+});
+
+test("needsRecap: same head (state=failed) → false (no auto-retry)", () => {
+  expect(needsRecap(baseRecap({ state: "failed", headSha: "sha-abc" }), "sha-abc")).toBe(false);
+});
+
+test("needsRecap: same head (state=empty) → false", () => {
+  expect(needsRecap(baseRecap({ state: "empty", headSha: "sha-abc" }), "sha-abc")).toBe(false);
+});
+
+test("needsRecap: different head → true", () => {
+  expect(needsRecap(baseRecap({ headSha: "sha-old" }), "sha-new")).toBe(true);
+});
+
+// ── buildTranscriptDigest ─────────────────────────────────────────────────────
+
+test("buildTranscriptDigest: empty entries → empty string", () => {
+  expect(buildTranscriptDigest([])).toBe("");
+});
+
+test("buildTranscriptDigest: includes tool+summary per entry", () => {
+  const entries = [
+    { ts: 1, tool: "Edit", summary: "edited server.ts", status: "ok" as const },
+    { ts: 2, tool: "Bash", summary: "$ bun test", status: "ok" as const },
+  ];
+  const digest = buildTranscriptDigest(entries);
+  expect(digest).toContain("[Edit] edited server.ts");
+  expect(digest).toContain("[Bash] $ bun test");
+});
+
+test("buildTranscriptDigest: respects maxChars cap", () => {
+  const entries = Array.from({ length: 100 }, (_, i) => ({
+    ts: i,
+    tool: "Edit",
+    summary: `edited file-${i}.ts`,
+    status: "ok" as const,
+  }));
+  const maxChars = 200;
+  const digest = buildTranscriptDigest(entries, maxChars);
+  expect(digest.length).toBeLessThanOrEqual(maxChars);
+});
+
+test("buildTranscriptDigest: single entry within cap is fully included", () => {
+  const entries = [{ ts: 1, tool: "Write", summary: "wrote store.ts", status: "ok" as const }];
+  const digest = buildTranscriptDigest(entries, 4000);
+  expect(digest).toBe("[Write] wrote store.ts");
+});
+
+test("buildTranscriptDigest: oversized single entry is truncated to maxChars, not empty", () => {
+  const maxChars = 20;
+  const longSummary = "x".repeat(100);
+  const entries = [{ ts: 1, tool: "Edit", summary: longSummary, status: "ok" as const }];
+  const digest = buildTranscriptDigest(entries, maxChars);
+  expect(digest.length).toBe(maxChars);
+  expect(digest).toBe(`[Edit] ${longSummary}`.slice(0, maxChars));
+});
+
+test("RECAP_DIGEST_MAX_CHARS is exported and equals the default cap", () => {
+  expect(typeof RECAP_DIGEST_MAX_CHARS).toBe("number");
+  expect(RECAP_DIGEST_MAX_CHARS).toBe(4000);
+});
+
+// ── buildRecapPrompt ──────────────────────────────────────────────────────────
+
+test("buildRecapPrompt: includes .shepherd-recap.json filename", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "Implement recap",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  expect(p).toContain(".shepherd-recap.json");
+});
+
+test("buildRecapPrompt: includes all three verdict enum values", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  for (const v of RECAP_VERDICTS) {
+    expect(p).toContain(v);
+  }
+});
+
+test("buildRecapPrompt: injects task prompt", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "Refactor the drain module",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  expect(p).toContain("Refactor the drain module");
+});
+
+test("buildRecapPrompt: injects plan when non-empty", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "Step 1: do x",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  expect(p).toContain("Step 1: do x");
+});
+
+test("buildRecapPrompt: injects changedFiles", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: ["src/store.ts", "src/types.ts"],
+    digest: "",
+    context: "",
+  });
+  expect(p).toContain("src/store.ts");
+  expect(p).toContain("src/types.ts");
+});
+
+test("buildRecapPrompt: injects digest when non-empty", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "[Edit] edited server.ts",
+    context: "",
+  });
+  expect(p).toContain("[Edit] edited server.ts");
+});
+
+test("buildRecapPrompt: skips plan section when plan is empty", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  expect(p).not.toContain("Plan that was executed");
+});

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -681,3 +681,105 @@ test("forget: no existing recap → no crash", async () => {
   svc.forget("s1"); // should not throw
   expect(store.getRecap("s1")).toBeNull();
 });
+
+// ── git/diff failure self-heals to "error" (must NOT throw out of bare-void sweep) ──
+
+test("generate: computeDiff rejection → 'error', no throw, no row", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  const cleaned: string[] = [];
+
+  const svc = new RecapService({
+    store: store as any,
+    herdr: herdr as any,
+    onChange: () => {},
+    model: "sonnet",
+    now: () => 200_000,
+    timeoutMs: 300_000,
+    headSha: async () => "sha-head",
+    computeDiff: async () => {
+      throw new Error("git diff exceeded maxBuffer");
+    },
+    readTranscript: (): ActivityEntry[] => [],
+    readPlan: () => "",
+    readVerdict: () => null,
+    readUsage: async () => null,
+    makeTmpDir: () => "/tmp/recap-diff-fail",
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  const result = await svc.generate(s); // must resolve, not reject
+  expect(result).toBe("error");
+  expect(herdr.started.length).toBe(0);
+  expect(store.getRecap("s1")).toBeNull(); // no row left → a later settle can retry
+});
+
+test("regenerate: headSha rejection → 'error', no throw", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = new RecapService({
+    store: store as any,
+    herdr: herdr as any,
+    onChange: () => {},
+    model: "sonnet",
+    now: () => 200_000,
+    timeoutMs: 300_000,
+    headSha: async () => {
+      throw new Error("rev-parse failed");
+    },
+    computeDiff: async () => NON_EMPTY_DIFF as any,
+    readTranscript: (): ActivityEntry[] => [],
+    readPlan: () => "",
+    readVerdict: () => null,
+    readUsage: async () => null,
+    makeTmpDir: () => "/tmp/recap-head-fail",
+    cleanup: () => {},
+  });
+
+  const result = await svc.regenerate(s);
+  expect(result).toBe("error");
+  expect(herdr.started.length).toBe(0);
+});
+
+test("considerSession: headSha failure leaves fired=false so next sweep retries", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  let t = 0;
+  let failHead = true;
+
+  const svc = new RecapService({
+    store: store as any,
+    herdr: herdr as any,
+    onChange: () => {},
+    model: "sonnet",
+    now: () => t,
+    idleThresholdMs: 120_000,
+    timeoutMs: 300_000,
+    headSha: async () => {
+      if (failHead) throw new Error("transient git failure");
+      return "sha-head";
+    },
+    computeDiff: async () => NON_EMPTY_DIFF as any,
+    readTranscript: (): ActivityEntry[] => [],
+    readPlan: () => "",
+    readVerdict: () => null,
+    readUsage: async () => null,
+    makeTmpDir: () => "/tmp/recap-retry",
+    cleanup: () => {},
+  });
+
+  t = 0;
+  await svc.sweep(); // stamp set
+  t = 200_000;
+  await svc.sweep(); // settled → headSha throws → no spawn, fired stays false
+  expect(herdr.started.length).toBe(0);
+
+  failHead = false;
+  t = 400_000;
+  await svc.sweep(); // retries headSha (fired was not burned) → spawns
+  expect(herdr.started.length).toBe(1);
+});

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -1,0 +1,683 @@
+import { expect, test } from "bun:test";
+import { RecapService } from "../src/recap";
+import type { Recap, Session } from "../src/types";
+import type { ActivityEntry } from "../src/activity";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeSession(over: Partial<Session> = {}): Session {
+  return {
+    id: "s1",
+    desig: "TASK-01",
+    name: "x",
+    prompt: "do the thing",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    claudeSessionId: "c1",
+    model: null,
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: null,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    autoMergeRebaseHead: null,
+    auto: false,
+    issueNumber: null,
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    status: "idle",
+    lastState: "idle",
+    createdAt: 0,
+    updatedAt: 0,
+    archivedAt: null,
+    ...over,
+  };
+}
+
+function makeRecap(over: Partial<Recap> = {}): Recap {
+  return {
+    sessionId: "s1",
+    state: "generating",
+    headSha: "sha-a",
+    verdict: null,
+    headline: "",
+    body: "",
+    openItems: [],
+    spawnSessionId: "spawn-1",
+    cwd: "/tmp/recap-s1",
+    model: "sonnet",
+    spawnedAt: 1000,
+    generatedAt: null,
+    updatedAt: 1000,
+    ...over,
+  };
+}
+
+const VALID_VERDICT_JSON = {
+  verdict: "ready",
+  headline: "All done",
+  body: "## Summary\nFixed the bug.",
+  openItems: ["Write more tests"],
+};
+
+type FakeStore = {
+  recaps: Record<string, Recap>;
+  generatingRows: Recap[];
+  reviewerSpawns: any[];
+  completedSpawns: any[];
+  sessions: Session[];
+  getRecap: (id: string) => Recap | null;
+  putRecap: (r: Recap) => void;
+  snapshotRecaps: () => Record<string, Recap>;
+  generatingRecaps: () => Recap[];
+  dropRecap: (id: string) => void;
+  getReview: (id: string) => null;
+  recordReviewerSpawn: (r: any) => void;
+  completeReviewerSpawn: (id: string, u: any, at: number) => void;
+  list: (opts?: { activeOnly?: boolean }) => Session[];
+};
+
+function makeStore(sessions: Session[] = [], recaps: Recap[] = []): FakeStore {
+  const recapMap: Record<string, Recap> = {};
+  for (const r of recaps) recapMap[r.sessionId] = r;
+
+  const store: FakeStore = {
+    recaps: recapMap,
+    generatingRows: recaps.filter((r) => r.state === "generating"),
+    reviewerSpawns: [] as any[],
+    completedSpawns: [] as any[],
+    sessions,
+    getRecap: (id) => store.recaps[id] ?? null,
+    putRecap: (r) => {
+      store.recaps[r.sessionId] = r;
+      store.generatingRows = Object.values(store.recaps).filter((x) => x.state === "generating");
+    },
+    snapshotRecaps: () => ({ ...store.recaps }),
+    generatingRecaps: () => store.generatingRows,
+    dropRecap: (id) => {
+      delete store.recaps[id];
+      store.generatingRows = store.generatingRows.filter((r) => r.sessionId !== id);
+    },
+    getReview: () => null,
+    recordReviewerSpawn: (r: any) => store.reviewerSpawns.push(r),
+    completeReviewerSpawn: (id: string, u: any, at: number) =>
+      store.completedSpawns.push({ id, u, at }),
+    list: () => store.sessions,
+  };
+  return store;
+}
+
+type FakePaneEntry = { cwd: string; terminalId: string };
+
+type FakeHerdr = {
+  started: { label: string; cwd: string; argv: string[] }[];
+  stopped: string[];
+  livePanes: FakePaneEntry[];
+  start: (label: string, cwd: string, argv: string[]) => { terminalId: string };
+  stop: (id: string) => void;
+  list: () => FakePaneEntry[];
+};
+
+function makeHerdr(livePanes: FakePaneEntry[] = []): FakeHerdr {
+  const h: FakeHerdr = {
+    started: [],
+    stopped: [],
+    livePanes,
+    start: (label, cwd, argv) => {
+      const tid = `tid-${h.started.length + 1}`;
+      h.started.push({ label, cwd, argv });
+      h.livePanes.push({ cwd, terminalId: tid });
+      return { terminalId: tid };
+    },
+    stop: (id) => h.stopped.push(id),
+    list: () => h.livePanes,
+  };
+  return h;
+}
+
+const NON_EMPTY_DIFF = {
+  base: "main",
+  baseRef: "origin/main",
+  head: "shepherd/x",
+  fetchFailed: false as const,
+  truncated: false as const,
+  files: [
+    {
+      path: "src/foo.ts",
+      status: "modified" as const,
+      additions: 5,
+      deletions: 2,
+      binary: false as const,
+      hunks: [],
+    },
+  ],
+};
+
+const EMPTY_DIFF = {
+  base: "main",
+  baseRef: "origin/main",
+  head: "shepherd/x",
+  fetchFailed: false as const,
+  truncated: false as const,
+  files: [],
+};
+
+function buildSvc(opts: {
+  store: FakeStore;
+  herdr: FakeHerdr;
+  onChange?: (id: string, recap: Recap | null) => void;
+  nowFn: () => number;
+  headSha?: string;
+  diff?: typeof NON_EMPTY_DIFF | typeof EMPTY_DIFF;
+  verdictJson?: unknown | null;
+  idleThresholdMs?: number;
+  timeoutMs?: number;
+  cleanup?: (d: string) => void;
+  makeTmpDir?: () => string;
+  readUsage?: () => Promise<any>;
+}): RecapService {
+  let tmpIdx = 0;
+  return new RecapService({
+    store: opts.store as any,
+    herdr: opts.herdr as any,
+    onChange: opts.onChange ?? (() => {}),
+    model: "sonnet",
+    now: opts.nowFn,
+    idleThresholdMs: opts.idleThresholdMs ?? 120_000,
+    timeoutMs: opts.timeoutMs ?? 300_000,
+    headSha: async () => opts.headSha ?? "sha-head",
+    computeDiff: async () => (opts.diff ?? NON_EMPTY_DIFF) as any,
+    readTranscript: (): ActivityEntry[] => [],
+    readPlan: () => "",
+    readVerdict: () => (opts.verdictJson !== undefined ? opts.verdictJson : null),
+    readUsage: opts.readUsage ?? (async () => null),
+    makeTmpDir: opts.makeTmpDir ?? (() => `/tmp/recap-test-${++tmpIdx}`),
+    cleanup: opts.cleanup ?? (() => {}),
+  });
+}
+
+// ── sweep tests ───────────────────────────────────────────────────────────────
+
+test("sweep: under threshold → no spawn", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  let t = 50_000;
+  const svc = buildSvc({ store, herdr, nowFn: () => t, idleThresholdMs: 120_000 });
+
+  // First sweep: stamp set at 50_000; idleMs=0 → not settled
+  await svc.sweep();
+  expect(herdr.started.length).toBe(0);
+
+  // Second sweep at 100_000: idleMs=50_000 < 120_000 → still not settled
+  t = 100_000;
+  await svc.sweep();
+  expect(herdr.started.length).toBe(0);
+});
+
+test("sweep: status running → no spawn, clears debounce", async () => {
+  const s = makeSession({ status: "running" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  const svc = buildSvc({ store, herdr, nowFn: () => 300_000 });
+  await svc.sweep();
+  expect(herdr.started.length).toBe(0);
+});
+
+test("sweep: auto:true (drain) settled → no spawn", async () => {
+  const s = makeSession({ status: "idle", auto: true });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  let t = 100_000;
+  const svc = buildSvc({ store, herdr, nowFn: () => t, idleThresholdMs: 120_000 });
+
+  await svc.sweep(); // stamp set
+  t = 300_000; // idleMs = 200_000 >= 120_000, but auto=true → skip
+  await svc.sweep();
+  expect(herdr.started.length).toBe(0);
+});
+
+test("sweep: attended settled + non-empty diff + no existing recap → spawns once", async () => {
+  const s = makeSession({ status: "idle", auto: false });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  let t = 100_000;
+  const svc = buildSvc({ store, herdr, nowFn: () => t, idleThresholdMs: 120_000 });
+
+  await svc.sweep(); // stamp set at 100_000
+  expect(herdr.started.length).toBe(0);
+
+  t = 230_000; // idleMs=130_000 >= 120_000 → generate
+  await svc.sweep();
+  expect(herdr.started.length).toBe(1);
+  expect(herdr.started[0]!.label).toBe("recap TASK-01");
+  expect(store.getRecap("s1")?.state).toBe("generating");
+  expect(store.reviewerSpawns.length).toBe(1);
+  expect(store.reviewerSpawns[0]!.kind).toBe("recap");
+  expect(store.reviewerSpawns[0]!.taskSessionId).toBe("s1");
+});
+
+test("sweep idempotency: second sweep in same idle episode → no second spawn", async () => {
+  const s = makeSession({ status: "idle", auto: false });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  let t = 100_000;
+  const svc = buildSvc({ store, herdr, nowFn: () => t, idleThresholdMs: 120_000 });
+
+  await svc.sweep(); // stamp
+  t = 230_000;
+  await svc.sweep(); // fires
+  expect(herdr.started.length).toBe(1);
+
+  await svc.sweep(); // should NOT fire again
+  expect(herdr.started.length).toBe(1);
+});
+
+test("sweep: empty diff → state 'empty', no spawn, onChange(id, null)", async () => {
+  const s = makeSession({ status: "idle", auto: false });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  const changes: Array<[string, Recap | null]> = [];
+  let t = 100_000;
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    onChange: (id, recap) => changes.push([id, recap]),
+    nowFn: () => t,
+    idleThresholdMs: 120_000,
+    diff: EMPTY_DIFF,
+  });
+
+  await svc.sweep(); // stamp
+  t = 230_000;
+  await svc.sweep(); // fire → empty diff
+
+  expect(herdr.started.length).toBe(0);
+  expect(store.getRecap("s1")?.state).toBe("empty");
+  const lastChange = changes[changes.length - 1];
+  expect(lastChange).toBeDefined();
+  expect(lastChange![0]).toBe("s1");
+  expect(lastChange![1]).toBeNull();
+});
+
+test("sweep: existing READY recap at headA; session re-activates then re-settles at headB → new spawn", async () => {
+  const s = makeSession({ status: "idle", auto: false });
+  const existingRecap = makeRecap({
+    state: "ready",
+    headSha: "sha-a",
+    verdict: "ready",
+    headline: "done",
+    generatedAt: 500,
+  });
+  const store = makeStore([s], [existingRecap]);
+  const herdr = makeHerdr();
+  let t = 100_000;
+  let currentHead = "sha-a";
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => t,
+    idleThresholdMs: 120_000,
+    headSha: undefined, // override via workaround
+  });
+  // Build with injectable headSha
+  const svc2 = new RecapService({
+    store: store as any,
+    herdr: herdr as any,
+    onChange: () => {},
+    model: "sonnet",
+    now: () => t,
+    idleThresholdMs: 120_000,
+    timeoutMs: 300_000,
+    headSha: async () => currentHead,
+    computeDiff: async () => NON_EMPTY_DIFF as any,
+    readTranscript: (): ActivityEntry[] => [],
+    readPlan: () => "",
+    readVerdict: () => null,
+    readUsage: async () => null,
+    makeTmpDir: () => "/tmp/recap-headb",
+    cleanup: () => {},
+  });
+
+  // First episode: settle at sha-a → existing recap matches, needsRecap = false
+  await svc2.sweep(); // stamp
+  t = 230_000;
+  await svc2.sweep(); // fire → skip (headSha same as existing)
+  expect(herdr.started.length).toBe(0);
+
+  // Re-activate → clears debounce
+  store.sessions[0] = makeSession({ status: "running" });
+  await svc2.sweep();
+
+  // New commit + re-settle
+  currentHead = "sha-b";
+  store.sessions[0] = makeSession({ status: "idle" });
+  t = 300_000;
+  await svc2.sweep(); // stamp
+  t = 430_000;
+  await svc2.sweep(); // fire → needsRecap(existingRecap, "sha-b") = true
+  expect(herdr.started.length).toBe(1);
+  void svc; // suppress unused var
+});
+
+// ── tick tests ────────────────────────────────────────────────────────────────
+
+test("tick: generating row + valid verdict → state 'ready' + usage + stop + cleanup", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-s1",
+    spawnSessionId: "sp1",
+    spawnedAt: 100_000,
+  });
+  const store = makeStore([], [rec]);
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-s1", terminalId: "t99" }]);
+  const cleaned: string[] = [];
+  const fakeUsage = {
+    input: 1,
+    output: 2,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 3,
+    messageCount: 1,
+    lastActivity: null,
+    byModel: {},
+    fullRecaches: 0,
+    sidechainCount: 0,
+  };
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    timeoutMs: 300_000,
+    verdictJson: VALID_VERDICT_JSON,
+    readUsage: async () => fakeUsage,
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  await svc.tick();
+
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("ready");
+  expect(r?.verdict).toBe("ready");
+  expect(r?.headline).toBe("All done");
+  expect(r?.body).toContain("Fixed the bug");
+  expect(r?.openItems).toEqual(["Write more tests"]);
+  expect(store.completedSpawns.length).toBe(1);
+  expect(store.completedSpawns[0]!.id).toBe("sp1");
+  expect(herdr.stopped).toContain("t99");
+  expect(cleaned).toContain("/tmp/recap-s1");
+});
+
+test("tick timeout: generating row, no verdict, past timeout → state 'failed', reaped", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-timeout",
+    spawnSessionId: "sp2",
+    spawnedAt: 1_000,
+  });
+  const store = makeStore([], [rec]);
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-timeout", terminalId: "t-timeout" }]);
+  const cleaned: string[] = [];
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 400_000, // spawnedAt=1_000, timeout=300_000 → timedOut
+    timeoutMs: 300_000,
+    verdictJson: null,
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  await svc.tick();
+  expect(store.getRecap("s1")?.state).toBe("failed");
+  expect(herdr.stopped).toContain("t-timeout");
+  expect(cleaned).toContain("/tmp/recap-timeout");
+});
+
+test("tick unparseable: garbage verdict → state 'failed'", async () => {
+  const rec = makeRecap({ state: "generating", cwd: "/tmp/recap-garbage", spawnedAt: 100_000 });
+  const store = makeStore([], [rec]);
+  const herdr = makeHerdr();
+  const cleaned: string[] = [];
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    timeoutMs: 300_000,
+    verdictJson: { verdict: "not-a-valid-verdict", headline: 42 }, // invalid
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  await svc.tick();
+  expect(store.getRecap("s1")?.state).toBe("failed");
+  expect(cleaned).toContain("/tmp/recap-garbage");
+});
+
+test("tick restart-safety: generating row in DB, no in-memory state → finalizes", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-restart",
+    spawnedAt: 100_000,
+  });
+  const store = makeStore([], [rec]);
+  const herdr = makeHerdr();
+  const cleaned: string[] = [];
+
+  // Fresh service — no prior state
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    timeoutMs: 300_000,
+    verdictJson: VALID_VERDICT_JSON,
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  await svc.tick();
+  expect(store.getRecap("s1")?.state).toBe("ready");
+  expect(cleaned).toContain("/tmp/recap-restart");
+});
+
+// ── regenerate tests ──────────────────────────────────────────────────────────
+
+test("regenerate: forces spawn even for auto:true (drain)", async () => {
+  const s = makeSession({ auto: true, status: "done" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    makeTmpDir: () => "/tmp/recap-auto",
+  });
+
+  const result = await svc.regenerate(s);
+  expect(result).toBe("started");
+  expect(herdr.started.length).toBe(1);
+  expect(store.getRecap("s1")?.state).toBe("generating");
+});
+
+test("regenerate: replaces an existing ready row", async () => {
+  const s = makeSession({ status: "idle" });
+  const existingRecap = makeRecap({
+    state: "ready",
+    headSha: "sha-old",
+    verdict: "ready",
+    headline: "old",
+    generatedAt: 500,
+  });
+  const store = makeStore([s], [existingRecap]);
+  const herdr = makeHerdr();
+  const cleaned: string[] = [];
+
+  const svc = new RecapService({
+    store: store as any,
+    herdr: herdr as any,
+    onChange: () => {},
+    model: "sonnet",
+    now: () => 200_000,
+    timeoutMs: 300_000,
+    headSha: async () => "sha-new",
+    computeDiff: async () => NON_EMPTY_DIFF as any,
+    readTranscript: (): ActivityEntry[] => [],
+    readPlan: () => "",
+    readVerdict: () => null,
+    readUsage: async () => null,
+    makeTmpDir: () => "/tmp/recap-regen",
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  const result = await svc.regenerate(s);
+  expect(result).toBe("started");
+  expect(herdr.started.length).toBe(1);
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("generating");
+  expect(r?.headSha).toBe("sha-new");
+});
+
+test("regenerate: empty diff returns 'empty'", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: EMPTY_DIFF,
+    makeTmpDir: () => "/tmp/recap-empty2",
+  });
+
+  const result = await svc.regenerate(s);
+  expect(result).toBe("empty");
+  expect(herdr.started.length).toBe(0);
+  expect(store.getRecap("s1")?.state).toBe("empty");
+});
+
+test("generate/regenerate: herdr.start throws → returns 'error', no row, tmpdir cleaned", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const cleaned: string[] = [];
+
+  // herdr that throws on start
+  const herdr: FakeHerdr = {
+    started: [],
+    stopped: [],
+    livePanes: [],
+    start: () => {
+      throw new Error("herdr start failed");
+    },
+    stop: (id) => herdr.stopped.push(id),
+    list: () => herdr.livePanes,
+  };
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    cleanup: (d) => cleaned.push(d),
+    makeTmpDir: () => "/tmp/recap-error-test",
+  });
+
+  const result = await svc.regenerate(s);
+  expect(result).toBe("error");
+  expect(store.getRecap("s1")).toBeNull();
+  expect(cleaned).toContain("/tmp/recap-error-test");
+});
+
+test("in-flight guard: second generate call for same session mid-await does not double-spawn", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  // Use a promise to stall computeDiff so we can fire the second generate while first is awaiting
+  let resolveDiff!: (v: typeof NON_EMPTY_DIFF) => void;
+  const diffPromise = new Promise<typeof NON_EMPTY_DIFF>((res) => {
+    resolveDiff = res;
+  });
+
+  const svc = new RecapService({
+    store: store as any,
+    herdr: herdr as any,
+    onChange: () => {},
+    model: "sonnet",
+    now: () => 200_000,
+    timeoutMs: 300_000,
+    headSha: async () => "sha-head",
+    computeDiff: async () => diffPromise as any,
+    readTranscript: (): ActivityEntry[] => [],
+    readPlan: () => "",
+    readVerdict: () => null,
+    readUsage: async () => null,
+    makeTmpDir: () => "/tmp/recap-inflight",
+    cleanup: () => {},
+  });
+
+  // Start first generate — will stall at computeDiff
+  const p1 = svc.generate(s);
+
+  // Immediately fire second generate for same session — should return "started" without spawning
+  const p2 = svc.generate(s);
+
+  // Now resolve the diff so the first call can complete
+  resolveDiff(NON_EMPTY_DIFF);
+
+  const [r1, r2] = await Promise.all([p1, p2]);
+
+  // First call should have spawned, second should have been blocked by the guard
+  expect(r1).toBe("started");
+  expect(r2).toBe("started"); // guard returns "started" immediately
+  expect(herdr.started.length).toBe(1); // only ONE spawn happened
+});
+
+// ── forget tests ──────────────────────────────────────────────────────────────
+
+test("forget: reaps generating row + drops recap from store", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-forget",
+    spawnSessionId: "sp3",
+  });
+  const store = makeStore([], [rec]);
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-forget", terminalId: "t-forget" }]);
+  const cleaned: string[] = [];
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  svc.forget("s1");
+  expect(store.getRecap("s1")).toBeNull();
+  expect(herdr.stopped).toContain("t-forget");
+  expect(cleaned).toContain("/tmp/recap-forget");
+});
+
+test("forget: no existing recap → no crash", async () => {
+  const store = makeStore([]);
+  const herdr = makeHerdr();
+  const svc = buildSvc({ store, herdr, nowFn: () => 200_000 });
+  svc.forget("s1"); // should not throw
+  expect(store.getRecap("s1")).toBeNull();
+});

--- a/test/server-recap.test.ts
+++ b/test/server-recap.test.ts
@@ -1,0 +1,139 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { config } from "../src/config";
+import type { Session, Recap } from "../src/types";
+
+let tmpRoot: string;
+let repoDir: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(config.repoRoot, "shepherd-recap-test-"));
+  repoDir = join(tmpRoot, "repo");
+  mkdirSync(repoDir);
+});
+afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+function harness(over: Partial<AppDeps> = {}): {
+  app: ReturnType<typeof makeApp>;
+  store: SessionStore;
+} {
+  const store = new SessionStore(":memory:");
+  const deps: AppDeps = {
+    store,
+    service: {} as any,
+    events: new EventHub(),
+    usageLimits: { limits: () => ({}) } as any,
+    ...over,
+  };
+  return { app: makeApp(deps), store };
+}
+
+// ── GET /api/recaps ───────────────────────────────────────────────────────────
+
+test("GET /api/recaps returns snapshot when recapCache is present", async () => {
+  const recap: Recap = {
+    sessionId: "sess-1",
+    state: "ready",
+    headSha: "abc123",
+    verdict: "ready",
+    headline: "Did the thing",
+    body: "",
+    openItems: [],
+    spawnSessionId: "spawn-abc",
+    cwd: "/tmp/recap-test",
+    model: null,
+    spawnedAt: 900,
+    generatedAt: 1000,
+    updatedAt: 1000,
+  };
+  const { app } = harness({ recapCache: { snapshot: () => ({ "sess-1": recap }) } });
+  const res = await app.fetch(new Request("http://x/api/recaps"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ "sess-1": recap });
+});
+
+test("GET /api/recaps returns {} when recapCache is absent", async () => {
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/recaps"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({});
+});
+
+// ── POST /api/sessions/:id/recap/regenerate ───────────────────────────────────
+
+test("POST /api/sessions/:id/recap/regenerate → 202, calls regenerate, relays status:started", async () => {
+  const regenerated: Session[] = [];
+  const { app, store } = harness({
+    recap: {
+      regenerate: async (s: Session) => {
+        regenerated.push(s);
+        return "started" as const;
+      },
+    },
+  });
+  const seeded = store.create({
+    name: "x",
+    prompt: "go",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: join(repoDir, "wt"),
+    isolated: true,
+    herdrSession: "sess-x",
+    herdrAgentId: "term_x",
+    claudeSessionId: "claude-x",
+    model: null,
+  });
+  const id = seeded.id;
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${id}/recap/regenerate`, { method: "POST" }),
+  );
+  expect(res.status).toBe(202);
+  expect(await res.json()).toEqual({ ok: true, status: "started" });
+  expect(regenerated.length).toBe(1);
+  expect(regenerated[0]!.id).toBe(id);
+});
+
+test("POST /api/sessions/:id/recap/regenerate → 404 for unknown id", async () => {
+  let called = false;
+  const { app } = harness({
+    recap: {
+      regenerate: async () => {
+        called = true;
+        return "started" as const;
+      },
+    },
+  });
+  const res = await app.fetch(
+    new Request("http://x/api/sessions/nope/recap/regenerate", { method: "POST" }),
+  );
+  expect(res.status).toBe(404);
+  expect(called).toBe(false);
+});
+
+test("POST /api/sessions/:id/recap/regenerate → status:error when recap dep is absent", async () => {
+  const { app, store } = harness(); // no recap dep
+  const seeded = store.create({
+    name: "z",
+    prompt: "go",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/z",
+    worktreePath: join(repoDir, "wt3"),
+    isolated: true,
+    herdrSession: "sess-z",
+    herdrAgentId: "term_z",
+    claudeSessionId: "claude-z",
+    model: null,
+  });
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${seeded.id}/recap/regenerate`, { method: "POST" }),
+  );
+  expect(res.status).toBe(202);
+  expect(await res.json()).toEqual({ ok: true, status: "error" });
+});

--- a/test/store-recaps.test.ts
+++ b/test/store-recaps.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "bun:test";
+import { SessionStore } from "../src/store";
+import type { Recap } from "../src/types";
+
+const r = (over: Partial<Recap> = {}): Recap => ({
+  sessionId: "s1",
+  state: "generating",
+  headSha: "sha-abc",
+  verdict: null,
+  headline: "",
+  body: "",
+  openItems: [],
+  spawnSessionId: "spawn-1",
+  cwd: "/tmp/recap-1",
+  model: "claude-sonnet-4-5",
+  spawnedAt: 1000,
+  generatedAt: null,
+  updatedAt: 1000,
+  ...over,
+});
+
+test("recaps: put→get round-trip (incl. openItems JSON)", () => {
+  const s = new SessionStore(":memory:");
+  expect(s.getRecap("s1")).toBeNull();
+  s.putRecap(r({ openItems: ["fix tests", "update docs"] }));
+  const got = s.getRecap("s1");
+  expect(got).not.toBeNull();
+  expect(got?.sessionId).toBe("s1");
+  expect(got?.state).toBe("generating");
+  expect(got?.headSha).toBe("sha-abc");
+  expect(got?.openItems).toEqual(["fix tests", "update docs"]);
+  expect(got?.verdict).toBeNull();
+  expect(got?.model).toBe("claude-sonnet-4-5");
+  expect(got?.generatedAt).toBeNull();
+});
+
+test("recaps: upsert overwrites existing row", () => {
+  const s = new SessionStore(":memory:");
+  s.putRecap(r());
+  s.putRecap(
+    r({
+      state: "ready",
+      verdict: "ready",
+      headline: "all done",
+      body: "## Summary",
+      openItems: ["cleanup"],
+      generatedAt: 2000,
+      updatedAt: 2000,
+    }),
+  );
+  const got = s.getRecap("s1");
+  expect(got?.state).toBe("ready");
+  expect(got?.verdict).toBe("ready");
+  expect(got?.headline).toBe("all done");
+  expect(got?.openItems).toEqual(["cleanup"]);
+  expect(got?.generatedAt).toBe(2000);
+});
+
+test("recaps: snapshotRecaps excludes empty-state rows", () => {
+  const s = new SessionStore(":memory:");
+  s.putRecap(r({ sessionId: "s1", state: "ready", verdict: "ready", headline: "done" }));
+  s.putRecap(r({ sessionId: "s2", state: "empty", generatedAt: 1000 }));
+  s.putRecap(r({ sessionId: "s3", state: "generating" }));
+  s.putRecap(r({ sessionId: "s4", state: "failed", generatedAt: 1000 }));
+  const snap = s.snapshotRecaps();
+  expect(Object.keys(snap).sort()).toEqual(["s1", "s3", "s4"]);
+  expect(snap["s2"]).toBeUndefined();
+});
+
+test("recaps: getRecap returns an empty-state row (excluded only from snapshot)", () => {
+  const s = new SessionStore(":memory:");
+  s.putRecap(r({ state: "empty", generatedAt: 1000 }));
+  const got = s.getRecap("s1");
+  expect(got?.state).toBe("empty");
+});
+
+test("recaps: generatingRecaps returns only generating rows", () => {
+  const s = new SessionStore(":memory:");
+  s.putRecap(r({ sessionId: "s1", state: "generating" }));
+  s.putRecap(r({ sessionId: "s2", state: "ready", verdict: "ready" }));
+  s.putRecap(r({ sessionId: "s3", state: "generating" }));
+  const rows = s.generatingRecaps();
+  const ids = rows.map((x) => x.sessionId).sort();
+  expect(ids).toEqual(["s1", "s3"]);
+  expect(rows.every((x) => x.state === "generating")).toBe(true);
+});
+
+test("recaps: dropRecap deletes the row", () => {
+  const s = new SessionStore(":memory:");
+  s.putRecap(r());
+  expect(s.getRecap("s1")).not.toBeNull();
+  s.dropRecap("s1");
+  expect(s.getRecap("s1")).toBeNull();
+});
+
+test("recaps: dropRecap is a no-op for unknown sessionId", () => {
+  const s = new SessionStore(":memory:");
+  expect(() => s.dropRecap("nonexistent")).not.toThrow();
+});
+
+test("recaps: openItems with bad JSON in DB defaults to []", () => {
+  const s = new SessionStore(":memory:");
+  // Insert directly with bad JSON to simulate corruption
+  s["db"].run(
+    `INSERT INTO recaps (sessionId, state, headSha, verdict, headline, body, openItems,
+       spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt)
+     VALUES ('s-bad', 'ready', 'sha', 'ready', 'h', 'b', 'NOT_JSON', '', '/tmp', null, 1, null, 1)`,
+  );
+  const got = s.getRecap("s-bad");
+  expect(got?.openItems).toEqual([]);
+});
+
+test("recaps: model field stores null correctly", () => {
+  const s = new SessionStore(":memory:");
+  s.putRecap(r({ model: null }));
+  expect(s.getRecap("s1")?.model).toBeNull();
+});
+
+test("recaps: snapshotRecaps returns hydrated Recap objects", () => {
+  const s = new SessionStore(":memory:");
+  s.putRecap(
+    r({
+      sessionId: "s1",
+      state: "ready",
+      verdict: "needs_attention",
+      headline: "has issues",
+      openItems: ["fix CI"],
+    }),
+  );
+  const snap = s.snapshotRecaps();
+  expect(snap["s1"]?.openItems).toEqual(["fix CI"]);
+  expect(snap["s1"]?.verdict).toBe("needs_attention");
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1187,5 +1187,18 @@
   "mergetrain_confirm_desc_ready": "{count} bereite PR(s) in {repo} abarbeiten?",
   "mergetrain_confirm_desc_picked": "{count} ausgewählte PRs in {repo} abarbeiten?",
   "mergetrain_confirm_action": "Merge-Train starten",
-  "mergetrain_confirm_other_repos": "{count} bereite PR(s) in anderen Repos sind nicht enthalten."
+  "mergetrain_confirm_other_repos": "{count} bereite PR(s) in anderen Repos sind nicht enthalten.",
+  "recap_generating": "Zusammenfassung wird erstellt…",
+  "recap_failed": "Zusammenfassung konnte nicht erstellt werden.",
+  "recap_retry": "Erneut versuchen",
+  "recap_regenerate": "Neu erstellen",
+  "recap_verdict_ready": "Bereit",
+  "recap_verdict_parked": "Zurückgestellt",
+  "recap_verdict_needs_attention": "Handlungsbedarf",
+  "recap_open_items": "Offene Punkte",
+  "recap_expand": "▸",
+  "recap_collapse": "▾",
+  "recap_regenerate_failed": "Neu erstellen fehlgeschlagen. Bitte erneut versuchen.",
+  "feat_session_recap_title": "Sitzungszusammenfassung",
+  "feat_session_recap_body": "Shepherd erstellt nach jeder Sitzung eine kompakte Zusammenfassung — mit Ergebnis, Überschrift und offenen Punkten — damit du auf einen Blick siehst, was passiert ist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1187,5 +1187,18 @@
   "mergetrain_confirm_desc_ready": "Work through {count} ready PR(s) in {repo}?",
   "mergetrain_confirm_desc_picked": "Work through {count} selected PRs in {repo}?",
   "mergetrain_confirm_action": "Start merge train",
-  "mergetrain_confirm_other_repos": "{count} ready PR(s) in other repos are not included."
+  "mergetrain_confirm_other_repos": "{count} ready PR(s) in other repos are not included.",
+  "recap_generating": "Generating recap…",
+  "recap_failed": "Recap generation failed.",
+  "recap_retry": "Retry",
+  "recap_regenerate": "Regenerate",
+  "recap_verdict_ready": "Ready",
+  "recap_verdict_parked": "Parked",
+  "recap_verdict_needs_attention": "Needs attention",
+  "recap_open_items": "Open items",
+  "recap_expand": "▸",
+  "recap_collapse": "▾",
+  "recap_regenerate_failed": "Regenerate failed. Please try again.",
+  "feat_session_recap_title": "Session recap",
+  "feat_session_recap_body": "Shepherd now generates a concise recap after each session — verdict, headline, and open items — so you can see what happened at a glance."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -44,6 +44,7 @@ import type {
   Epic,
   EpicRun,
   EpicSummary,
+  Recap,
 } from "./types";
 import { m } from "$lib/paraglide/messages";
 
@@ -775,6 +776,21 @@ export async function getPlanGates(): Promise<Record<string, PlanGate>> {
 /** Session ids with a plan review currently in flight (bootstrap for the reviewing indicator). */
 export async function getPlanGatesInflight(): Promise<string[]> {
   return getJson("/api/plan-gates/inflight", "plan-gates inflight");
+}
+
+/** Snapshot of every session's recap, keyed by session id (bootstrap; excludes empty rows). */
+export async function getRecaps(): Promise<Record<string, Recap>> {
+  return getJson("/api/recaps", "recaps");
+}
+
+/** Trigger a recap regeneration for a session. Returns `{status}` from the server. */
+export async function regenerateRecap(id: string): Promise<{ status: string }> {
+  const r = await fetch(`/api/sessions/${encodeURIComponent(id)}/recap/regenerate`, {
+    method: "POST",
+    headers: JSON_HEADERS,
+  });
+  if (!r.ok) throw await failed(r, "regenerate recap");
+  return r.json();
 }
 
 /** Release an approved plan gate so the agent executes. Returns false on 409 (not approved). */

--- a/ui/src/lib/components/SessionRecap.svelte
+++ b/ui/src/lib/components/SessionRecap.svelte
@@ -1,0 +1,249 @@
+<script lang="ts">
+  import type { Session } from "$lib/types";
+  import type { RecapVerdict } from "$lib/types";
+  import { recaps } from "$lib/recaps.svelte";
+  import { regenerateRecap } from "$lib/api";
+  import { m } from "$lib/paraglide/messages";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
+
+  let { session }: { session: Session } = $props();
+
+  const recap = $derived(recaps.map[session.id]);
+
+  let expanded = $state(false);
+  let regenerating = $state(false);
+  let regenFailed = $state(false);
+
+  // Render the (LLM-authored) body as sanitized markdown.
+  // Dynamically imported so marked/DOMPurify stay off the first-paint critical path;
+  // gated on expanded so the browser-only sanitizer never runs during SSR.
+  let renderedBody = $state("");
+  $effect(() => {
+    const body = expanded ? recap?.body : undefined;
+    if (!body) {
+      renderedBody = "";
+      return;
+    }
+    let alive = true;
+    Promise.all([import("marked"), import("dompurify")])
+      .then(([{ marked }, { default: DOMPurify }]) => {
+        if (alive)
+          renderedBody = DOMPurify.sanitize(marked.parse(body, { async: false }) as string);
+      })
+      .catch((err) => {
+        console.warn("Recap body markdown render failed", err);
+      });
+    return () => {
+      alive = false;
+    };
+  });
+
+  const VERDICT_COLOR: Record<RecapVerdict, string> = {
+    ready: "var(--color-green)",
+    parked: "var(--status-done)",
+    needs_attention: "var(--color-amber)",
+  };
+
+  function verdictLabel(v: RecapVerdict): string {
+    if (v === "ready") return m.recap_verdict_ready();
+    if (v === "parked") return m.recap_verdict_parked();
+    return m.recap_verdict_needs_attention();
+  }
+
+  async function handleRegenerate() {
+    regenFailed = false;
+    regenerating = true;
+    try {
+      const result = await regenerateRecap(session.id);
+      if (result && result.status === "error") regenFailed = true;
+    } catch {
+      regenFailed = true;
+    } finally {
+      regenerating = false;
+    }
+  }
+</script>
+
+{#if recap && recap.state !== "empty"}
+  <!-- coachTarget id "session-recap" matches FeatureAnnouncement.targetId -->
+  <div class="recap-card panel" use:coachTarget={"session-recap"}>
+    {#if recap.state === "generating"}
+      <p class="recap-generating">{m.recap_generating()}</p>
+    {:else if recap.state === "failed"}
+      <div class="recap-failed-row">
+        <span class="recap-label">{m.recap_failed()}</span>
+        <button class="gbtn" onclick={handleRegenerate} disabled={regenerating}
+          >{m.recap_retry()}</button
+        >
+      </div>
+      {#if regenFailed}
+        <p class="recap-regen-error">{m.recap_regenerate_failed()}</p>
+      {/if}
+    {:else if recap.state === "ready"}
+      <button class="recap-header" onclick={() => (expanded = !expanded)} aria-expanded={expanded}>
+        {#if recap.verdict}
+          <span class="recap-verdict-chip" style:color={VERDICT_COLOR[recap.verdict]}
+            >{verdictLabel(recap.verdict)}</span
+          >
+        {/if}
+        <span class="recap-headline">{recap.headline}</span>
+        <span class="recap-expand-icon" aria-hidden="true"
+          >{expanded ? m.recap_collapse() : m.recap_expand()}</span
+        >
+      </button>
+      {#if expanded}
+        <div class="recap-body">
+          {#if renderedBody}
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized via DOMPurify above -->
+            <div class="recap-md">{@html renderedBody}</div>
+          {/if}
+          {#if recap.openItems.length > 0}
+            <div class="recap-open-items">
+              <p class="recap-open-items-heading">{m.recap_open_items()}</p>
+              <ul>
+                {#each recap.openItems as item (item)}
+                  <li>{item}</li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+          <div class="recap-actions">
+            <button class="gbtn" onclick={handleRegenerate} disabled={regenerating}
+              >{m.recap_regenerate()}</button
+            >
+            {#if regenFailed}
+              <p class="recap-regen-error">{m.recap_regenerate_failed()}</p>
+            {/if}
+          </div>
+        </div>
+      {/if}
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .recap-card {
+    margin: 0;
+    padding: 6px 10px;
+    font-size: var(--fs-sm);
+    border-top: none;
+    border-left: none;
+    border-right: none;
+    border-radius: 0;
+    border-bottom: 1px solid var(--color-line);
+  }
+
+  .recap-generating {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: var(--fs-sm);
+  }
+
+  .recap-failed-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .recap-label {
+    color: var(--color-text-muted);
+    font-size: var(--fs-sm);
+    flex: 1;
+  }
+
+  .recap-header {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-align: left;
+    color: var(--color-text);
+    font-size: var(--fs-sm);
+    width: 100%;
+  }
+
+  .recap-header:hover .recap-headline {
+    text-decoration: underline;
+  }
+
+  .recap-verdict-chip {
+    font-size: var(--fs-micro);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    flex-shrink: 0;
+  }
+
+  .recap-headline {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--color-text);
+  }
+
+  .recap-expand-icon {
+    font-size: var(--fs-micro);
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+  }
+
+  .recap-body {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .recap-md {
+    font-size: var(--fs-sm);
+    color: var(--color-text);
+    line-height: 1.5;
+  }
+
+  .recap-md :global(p) {
+    margin: 0 0 6px 0;
+  }
+
+  .recap-md :global(ul),
+  .recap-md :global(ol) {
+    margin: 0 0 6px 0;
+    padding-left: 18px;
+  }
+
+  .recap-open-items-heading {
+    margin: 0 0 4px 0;
+    font-size: var(--fs-micro);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+
+  .recap-open-items ul {
+    margin: 0;
+    padding-left: 16px;
+    font-size: var(--fs-sm);
+    color: var(--color-text);
+  }
+
+  .recap-open-items li {
+    margin-bottom: 2px;
+  }
+
+  .recap-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .recap-regen-error {
+    margin: 0;
+    font-size: var(--fs-sm);
+    color: var(--color-red, var(--color-amber));
+  }
+</style>

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -54,6 +54,7 @@
   import RedrawMenu from "$lib/components/RedrawMenu.svelte";
   import LeftoverDialog from "$lib/components/LeftoverDialog.svelte";
   import BuildQueuePanel from "$lib/components/BuildQueuePanel.svelte";
+  import SessionRecap from "$lib/components/SessionRecap.svelte";
   import type { BuildQueue } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { buildPreviewUrl } from "$lib/previewUrl";
@@ -2464,6 +2465,8 @@
       }}
     />
   {/if}
+
+  <SessionRecap {session} />
 
   <!-- footer: keyboard-affordance hints — true desktop only (mouse + hardware
        keyboard). Any coarse-pointer device (phone OR unfolded foldable) has no

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -720,4 +720,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_diagnostics_body",
     targetId: "diagnostics",
   },
+  {
+    // targetId "session-recap" matches use:coachTarget on the recap card root in
+    // SessionRecap.svelte, so the coachmark can point at it.
+    id: "session-recap",
+    sinceVersion: "1.29.0",
+    titleKey: "feat_session_recap_title",
+    bodyKey: "feat_session_recap_body",
+    targetId: "session-recap",
+  },
 ];

--- a/ui/src/lib/recaps.svelte.test.ts
+++ b/ui/src/lib/recaps.svelte.test.ts
@@ -1,0 +1,77 @@
+import { test, expect, vi, beforeEach } from "vitest";
+import type { Recap } from "./types";
+
+vi.mock("./api", () => ({
+  getRecaps: vi.fn(),
+}));
+
+import { recaps } from "./recaps.svelte";
+import { getRecaps } from "./api";
+
+const recap = (id: string): Recap => ({
+  sessionId: id,
+  state: "ready",
+  headSha: "abc123",
+  verdict: "ready",
+  headline: "All done",
+  body: "Everything went smoothly.",
+  openItems: [],
+  spawnSessionId: id,
+  cwd: "/repo",
+  model: null,
+  spawnedAt: 0,
+  generatedAt: 1000,
+  updatedAt: 1000,
+});
+
+beforeEach(() => {
+  recaps.map = {};
+  vi.clearAllMocks();
+});
+
+test("load() populates map from api", async () => {
+  const r = recap("s1");
+  vi.mocked(getRecaps).mockResolvedValue({ s1: r });
+  await recaps.load();
+  expect(recaps.map["s1"]).toEqual(r);
+});
+
+test("load() swallows api errors (best-effort)", async () => {
+  vi.mocked(getRecaps).mockRejectedValue(new Error("network error"));
+  await expect(recaps.load()).resolves.toBeUndefined();
+  expect(recaps.map).toEqual({});
+});
+
+test("apply({id, recap}) adds the recap", () => {
+  const r = recap("s1");
+  recaps.apply({ id: "s1", recap: r });
+  expect(recaps.map["s1"]).toBe(r);
+});
+
+test("apply({id, recap: null}) removes an existing entry", () => {
+  recaps.map = { s1: recap("s1") };
+  recaps.apply({ id: "s1", recap: null });
+  expect(recaps.map["s1"]).toBeUndefined();
+});
+
+test("apply({id, recap: null}) is a no-op for unknown id", () => {
+  recaps.apply({ id: "nope", recap: null });
+  expect(recaps.map["nope"]).toBeUndefined();
+  expect(Object.keys(recaps.map)).toHaveLength(0);
+});
+
+test("drop() removes an existing entry", () => {
+  recaps.map = { s1: recap("s1") };
+  recaps.drop("s1");
+  expect(recaps.map["s1"]).toBeUndefined();
+});
+
+test("drop() is a no-op for unknown id", () => {
+  recaps.map = { s1: recap("s1") };
+  const before = recaps.map;
+  recaps.drop("s2");
+  // s1 must still be present
+  expect(recaps.map["s1"]).toBeDefined();
+  // map object is the same reference (no copy was made)
+  expect(recaps.map).toBe(before);
+});

--- a/ui/src/lib/recaps.svelte.ts
+++ b/ui/src/lib/recaps.svelte.ts
@@ -1,0 +1,33 @@
+import type { Recap } from "./types";
+import { getRecaps } from "./api";
+
+/** Client cache of session recaps keyed by session id. Loaded once on app start;
+ *  live updates arrive via the `session:recap` WS event (see store.svelte.ts). */
+class RecapsStore {
+  map = $state<Record<string, Recap>>({});
+
+  async load() {
+    try {
+      this.map = await getRecaps();
+    } catch {
+      /* best-effort; live events still populate */
+    }
+  }
+
+  apply(d: { id: string; recap: Recap | null }) {
+    if (d.recap) this.map = { ...this.map, [d.id]: d.recap };
+    else {
+      const copy = { ...this.map };
+      delete copy[d.id];
+      this.map = copy;
+    }
+  }
+
+  drop(id: string) {
+    if (!(id in this.map)) return;
+    const copy = { ...this.map };
+    delete copy[id];
+    this.map = copy;
+  }
+}
+export const recaps = new RecapsStore();

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -20,6 +20,7 @@ import type {
 import type { BlockState } from "./triage";
 import { projectIcons } from "./projectIcons.svelte";
 import { reviews, planGates } from "./reviews.svelte";
+import { recaps } from "./recaps.svelte";
 import { learnings } from "./learnings.svelte";
 import { toasts } from "./toasts.svelte";
 import { m } from "$lib/paraglide/messages";
@@ -306,6 +307,9 @@ export class HerdStore {
    *  switch stays under the complexity gate. Returns true if `ev` was handled. */
   private applyReviewEvent(ev: WsEvent): boolean {
     switch (ev.event) {
+      case "session:recap":
+        recaps.apply(ev.data);
+        return true;
       case "session:review":
         reviews.apply(ev.data);
         return true;

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -265,6 +265,7 @@ export class HerdStore {
         this.previewServe = dropKey(this.previewServe, ev.data.id);
         reviews.drop(ev.data.id);
         planGates.drop(ev.data.id);
+        recaps.drop(ev.data.id);
         this.clearDraftReconcileToast(ev.data.id);
         break;
       case "session:git":
@@ -297,15 +298,15 @@ export class HerdStore {
       default:
         // Review/plan-gate and app-global (non-per-session-row) events are handled
         // out of line to keep this dispatch switch under the complexity gate.
-        if (!this.applyReviewEvent(ev)) this.applyGlobalEvent(ev);
+        if (!this.applySessionCardEvent(ev)) this.applyGlobalEvent(ev);
         break;
     }
   }
 
-  /** Handle the review + plan-gate WS events, all of which delegate to the
-   *  `reviews`/`planGates` sub-stores. Split out of apply() so its dispatch
+  /** Handle the review + plan-gate + recap WS events, all of which delegate to the
+   *  `reviews`/`planGates`/`recaps` sub-stores. Split out of apply() so its dispatch
    *  switch stays under the complexity gate. Returns true if `ev` was handled. */
-  private applyReviewEvent(ev: WsEvent): boolean {
+  private applySessionCardEvent(ev: WsEvent): boolean {
     switch (ev.event) {
       case "session:recap":
         recaps.apply(ev.data);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -224,6 +224,26 @@ export interface PlanGate {
   updatedAt: number;
 }
 
+// ── session recap ────────────────────────────────────────────────────────────
+// mirrors server Recap / RecapState / RecapVerdict
+export type RecapState = "generating" | "ready" | "failed" | "empty";
+export type RecapVerdict = "ready" | "parked" | "needs_attention";
+export interface Recap {
+  sessionId: string;
+  state: RecapState;
+  headSha: string;
+  verdict: RecapVerdict | null;
+  headline: string;
+  body: string;
+  openItems: string[];
+  spawnSessionId: string;
+  cwd: string;
+  model: string | null;
+  spawnedAt: number;
+  generatedAt: number | null;
+  updatedAt: number;
+}
+
 export type ReviewDecision = "changes_requested" | "commented" | "error";
 export interface ReviewVerdict {
   sessionId: string;
@@ -639,6 +659,7 @@ export type WsEvent =
       data: { ok: boolean; from: string | null; to: string | null; error?: string };
     }
   | { event: "project-icons:update"; data: ProjectIcons }
+  | { event: "session:recap"; data: { id: string; recap: Recap | null } }
   | { event: "session:review"; data: { id: string; review: ReviewVerdict | null } }
   | { event: "session:reviewing"; data: { id: string; reviewing: boolean } }
   | { event: "session:critic-activity"; data: { id: string; summary: string } }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -53,6 +53,7 @@
   import { steers } from "$lib/steers.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { reviews, planGates } from "$lib/reviews.svelte";
+  import { recaps } from "$lib/recaps.svelte";
   import { learnings } from "$lib/learnings.svelte";
   import TopBar from "$lib/components/TopBar.svelte";
   import TriageDrawer from "$lib/components/TriageDrawer.svelte";
@@ -389,6 +390,7 @@
     // ids, so a `reviewing=false` missed across a disconnect/restart is corrected.
     reviews.load();
     planGates.load();
+    recaps.load();
   }
 
   // Fetch backlog when the overview is empty, or when the operator opens the


### PR DESCRIPTION
## Why

When a task is done and there's nothing more to do, you scroll up the transcript to decide *"merge now, or is there more for me to do?"*. This adds a one-time LLM **recap** at the bottom of the task window so that decision doesn't require re-reading the whole session.

Plan + adversarial review history: `.shepherd-plan.md` (two review rounds resolved before execution).

## What

An inline, collapsible **Session Recap card** at the bottom of `Viewport.svelte` (non-blocking — not a modal). A transient read-only **Sonnet** spawn summarizes the session into a verdict + headline + body + open-items; the card shows the headline collapsed and the full markdown when expanded.

- **Trigger:** auto, on **settled idle** (`status ∈ {idle,done}` held ≥ ~2 min — *not* the first mid-work idle), for **attended** sessions only (`!auto`; drain is skipped as a cost guard). **Head-keyed**: regenerates when new commits land and the session re-settles, so it's never stale at the merge decision. A **Regenerate** button covers on-demand refresh and works for any session (incl. drain).
- **Generator:** namer-style tmpdir spawn — **no worktree / git / membrane**, `Write`-only, `dontAsk`. The server computes the diff off-loop (`computeDiff`) and injects a bounded transcript digest + plan + changed files + critic/CI context into the prompt. (In-app LLM = subscription spawn, per house rule.)
- **Restart-safe:** all in-flight state lives on the `recaps` row; `tick()` finalizes from the DB and reaps the herdr pane by `cwd` — no leaked process, no `adoptOrphans` needed.
- **Fail closed:** spawn error / 5-min timeout / unparseable verdict → explicit **failed** state with Retry, never a blank or fake "ready". Empty-diff finished session → `empty` sentinel (no card, no per-tick recompute).
- Delivered like reviews/plan-gates: `recaps` table → `snapshot()` → `GET /api/recaps` + `session:recap` WS event → client `recaps` store → card. Semantic verdict colors (green=ready / slate=parked / amber=needs-attention), full EN+DE i18n, one feature-catalog entry (`sinceVersion 1.29.0`).

## Architecture

`RecapService` (`src/recap.ts`), a sibling of `ReviewService`/`PlanGateService`, with pure logic in `src/recap-core.ts`. Driven from the shared 15s interval (`tick()` finalize + `sweep()` auto-fire).

## Testing

- New: `recap-core` (pure), `recap` service (18 tests, injected deps — settled-idle debounce, head-key regen, empty/failed/timeout, restart-safe finalize, pane reap, regenerate, archive cascade), store CRUD, server routes, UI `recaps` store.
- Full sweep green: root lint + tsc + `bun test ./test` (2639), `cd ui` check + check:i18n (parity) + vitest (1178), branch-hygiene, feature-catalog, `fallow audit` (exit 0).

Executed subagent-driven (fresh implementer + spec-compliance + code-quality review per task, plus a final integration review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)