### PR TITLE
feat(ui): opt-in colourblind status markers, hidden by default

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1225,5 +1225,11 @@
   "integrated_epics_collapse_aria": "Integriertes Epic #{number} einklappen",
   "integrated_epics_dismiss_failed": "Epic konnte nicht entfernt werden — bitte erneut versuchen",
   "feat_integrated_epics_title": "Abgeschlossene Epics bleiben sichtbar",
-  "feat_integrated_epics_body": "Wenn alle Sub-Issues eines Epics gelandet sind, verschwindet es nicht länger — ein neues Band 'Integrierte Epics' am unteren Rand der Herd behält es, samt PR jedes Kind-Issues und einem Ein-Klick-Verwerfen, sobald du nachgefasst hast."
+  "feat_integrated_epics_body": "Wenn alle Sub-Issues eines Epics gelandet sind, verschwindet es nicht länger — ein neues Band 'Integrierte Epics' am unteren Rand der Herd behält es, samt PR jedes Kind-Issues und einem Ein-Klick-Verwerfen, sobald du nachgefasst hast.",
+  "settings_colorblind_title": "Farbenblind-Status-Marker",
+  "settings_colorblind_hint": "Zeigt am Handy ein Symbol neben dem Session-Emoji (✓ wartet, ! blockiert), damit diese Zustände nicht allein an der grün/roten Header-Färbung hängen. Standardmäßig aus — einschalten, falls Grün und Rot schwer zu unterscheiden sind.",
+  "settings_colorblind_on": "Marker an",
+  "settings_colorblind_off": "Marker aus",
+  "feat_colorblind_markers_title": "Farbenblind-Status-Marker",
+  "feat_colorblind_markers_body": "Falls Grün und Rot schwer zu unterscheiden sind, aktiviere die Farbenblind-Status-Marker unter Einstellungen → Gerät. Dann steht am Handy ein ✓ (wartet) oder ! (blockiert) neben dem Session-Emoji, sodass diese Zustände nicht mehr allein an der Header-Färbung hängen. Standardmäßig aus."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1225,5 +1225,11 @@
   "integrated_epics_collapse_aria": "Collapse integrated epic #{number}",
   "integrated_epics_dismiss_failed": "Couldn't dismiss the epic — try again",
   "feat_integrated_epics_title": "Completed epics stay visible",
-  "feat_integrated_epics_body": "When an epic's sub-issues all land, it no longer vanishes — a new 'Integrated epics' band at the bottom of the Herd keeps it, with each child's PR and a one-click dismiss once you've followed up."
+  "feat_integrated_epics_body": "When an epic's sub-issues all land, it no longer vanishes — a new 'Integrated epics' band at the bottom of the Herd keeps it, with each child's PR and a one-click dismiss once you've followed up.",
+  "settings_colorblind_title": "Colourblind status markers",
+  "settings_colorblind_hint": "Shows a shape next to the session emoji on phones (✓ waiting, ! blocked) so those states don't rely on the green/red header tint alone. Off by default — turn it on if green and red are hard to tell apart.",
+  "settings_colorblind_on": "Markers on",
+  "settings_colorblind_off": "Markers off",
+  "feat_colorblind_markers_title": "Colourblind status markers",
+  "feat_colorblind_markers_body": "If green and red are hard to tell apart, switch on Colourblind status markers in Settings → Device. A ✓ (waiting) or ! (blocked) then sits next to the session emoji on phones, so those states no longer rely on the header tint alone. Off by default."
 }

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -686,6 +686,22 @@
           >
         </button>
       </div>
+      <div class="rc">
+        <span class="micro">{m.settings_colorblind_title()}</span>
+        <p class="hint">{m.settings_colorblind_hint()}</p>
+        <button
+          type="button"
+          class="toggle"
+          role="switch"
+          aria-checked={theme.colorblind}
+          onclick={() => theme.toggleColorblind()}
+        >
+          <span class="track" class:on={theme.colorblind}><span class="knob"></span></span>
+          <span class="state"
+            >{theme.colorblind ? m.settings_colorblind_on() : m.settings_colorblind_off()}</span
+          >
+        </button>
+      </div>
       <div class="push">
         <span class="micro">{m.settings_push_title()}</span>
         {#if !push.supported}

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -305,8 +305,12 @@
   const tintWash = $derived(tintColor ? `var(--wash-${dStatus})` : null);
   // Non-hue partner to the tint: a leading shape mark so blocked (!) vs done (✓)
   // never rests on colour alone (WCAG 1.4.1) — mirrors the StatusPip glyphs. Same
-  // blocked/done-on-phone gate as the tint.
-  const statusGlyph = $derived(!tintColor ? null : dStatus === "blocked" ? "!" : "✓");
+  // blocked/done-on-phone gate as the tint, but opt-in (theme.colorblind): for
+  // normal-sighted users the glyph just duplicates the tint and steals header
+  // width, so it's hidden unless the colourblind marker preference is on.
+  const statusGlyph = $derived(
+    !tintColor || !theme.colorblind ? null : dStatus === "blocked" ? "!" : "✓",
+  );
   // Desktop counterpart (.status-mark): one glyph per status, shape-coded so no
   // state pair rests on hue alone — done (✓) and idle/archived (●) both resolve
   // to slate. Word stays in title/aria.

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -747,4 +747,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_integrated_epics_title",
     bodyKey: "feat_integrated_epics_body",
   },
+  {
+    // No targetId: the toggle lives in the Settings modal DEVICE tab (closed by
+    // default), so a coachmark anchor would rarely be mounted — surface via the
+    // What's-New drawer only. v1.28.0 is already released, so this ships in 1.29.0:
+    // computeNewEntries only surfaces entries with sinceVersion > lastSeen.
+    id: "colorblind-status-markers",
+    sinceVersion: "1.29.0",
+    titleKey: "feat_colorblind_markers_title",
+    bodyKey: "feat_colorblind_markers_body",
+  },
 ];

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -751,7 +751,7 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     // No targetId: the toggle lives in the Settings modal DEVICE tab (closed by
     // default), so a coachmark anchor would rarely be mounted — surface via the
     // What's-New drawer only. v1.28.0 is already released, so this ships in 1.29.0:
-    // computeNewEntries only surfaces entries with sinceVersion > lastSeen.
+    // computeNewEntries surfaces entries where lastSeen < sinceVersion <= current app version.
     id: "colorblind-status-markers",
     sinceVersion: "1.29.0",
     titleKey: "feat_colorblind_markers_title",

--- a/ui/src/lib/theme.svelte.ts
+++ b/ui/src/lib/theme.svelte.ts
@@ -9,6 +9,7 @@ export type Resolved = "dark" | "light";
 
 const STORAGE_KEY = "shepherd:theme";
 const CONTRAST_KEY = "shepherd:contrast";
+const COLORBLIND_KEY = "shepherd:colorblind";
 const DARK_QUERY = "(prefers-color-scheme: dark)";
 
 function readPref(): ThemePref {
@@ -30,6 +31,15 @@ function readContrast(): boolean {
   }
 }
 
+function readColorblind(): boolean {
+  try {
+    return localStorage.getItem(COLORBLIND_KEY) === "on";
+  } catch {
+    /* localStorage unavailable (SSR / privacy mode) */
+    return false;
+  }
+}
+
 function systemPrefersDark(): boolean {
   return typeof matchMedia !== "undefined" ? matchMedia(DARK_QUERY).matches : true;
 }
@@ -42,6 +52,12 @@ class ThemeController {
   // not a theme: it composes on top of whichever dark/light theme is resolved,
   // strengthening the low-contrast greys/hairlines via [data-contrast="high"].
   contrast = $state<boolean>(readContrast());
+
+  // Colourblind status markers: opt-in shape glyph (✓ done / ! blocked) that
+  // partners the saturated header tint on phone so the two states don't rest on
+  // hue alone (WCAG 1.4.1). Off by default — the redundant glyph is noise for
+  // normal-sighted users, but a rotgrün-confused operator can switch it on.
+  colorblind = $state<boolean>(readColorblind());
 
   resolved = $derived<Resolved>(
     this.pref === "system" ? (this.systemDark ? "dark" : "light") : this.pref,
@@ -76,6 +92,20 @@ class ThemeController {
 
   toggleContrast() {
     this.setContrast(!this.contrast);
+  }
+
+  /** Persist the colourblind status-marker preference (consumed in-component). */
+  setColorblind(on: boolean) {
+    this.colorblind = on;
+    try {
+      localStorage.setItem(COLORBLIND_KEY, on ? "on" : "off");
+    } catch {
+      /* ignore — preference just won't survive reload */
+    }
+  }
+
+  toggleColorblind() {
+    this.setColorblind(!this.colorblind);
   }
 
   #apply() {


### PR DESCRIPTION
## Was & warum

Im mobilen Viewport-Header stand vor dem Session-Emoji ein Form-Glyph (`✓` wartet / `!` blockiert) — ein Nicht-Farb-Partner zum gesättigten Header-Tint (grün=fertig, rot=blockiert), ursprünglich für **WCAG 1.4.1** (Rotgrün-Schwäche) eingeführt.

Für normalsichtige Nutzer **dupliziert** der Glyph aber nur den Farb-Tint und kostet im schmalen Handy-Header Platz. Diese Doppelung war fest verdrahtet.

## Änderung

Neuer **Opt-in-Toggle „Farbenblind-Status-Marker"** (Einstellungen → Gerät), **standardmäßig AUS**:

- AUS (Default): nur der farbige Header-Tint, kein Glyph — mehr Platz, keine Redundanz.
- AN: `✓`/`!` erscheint wieder neben dem Emoji.

Persistenz über `localStorage` (`shepherd:colorblind`), gespiegelt am bestehenden High-Contrast-Toggle-Muster in `theme.svelte.ts`.

**Bewusst nicht angefasst:** die Desktop-`status-mark` — die unterscheidet *gleichfarbige* Zustände (z. B. done `✓` vs. idle `●`, beide slate) und trägt damit echte Information, keine Redundanz.

> Hinweis zum Default: Out-of-the-box nutzt der mobile Status damit für blockiert/fertig allein die Farbe (grün/rot). Bewusste Produktentscheidung (Opt-in statt Opt-out) — ein farbenblinder Operator schaltet die Marker bei Bedarf in den Settings ein.

## Dateien

- `theme.svelte.ts` — `colorblind`-Preference + Setter (localStorage)
- `Viewport.svelte` — mobiler `statusGlyph` zusätzlich an `theme.colorblind` gegated
- `Settings.svelte` — Toggle im DEVICE-Tab
- `en.json`/`de.json` — Settings- + What's-New-Keys
- `feature-announcements.ts` — Katalog-Eintrag (`colorblind-status-markers`, 1.29.0)

## Checks

- `bun run check` (svelte-check) — 0 Fehler
- `bun run check:i18n` — Parität (1114 Keys)
- `bun run test` — 1135/1135 grün
- Pre-push-Gates (Hygiene, i18n, Feature-Catalog) — grün
