### PR TITLE
feat: integrated-epics band — finished epics stop vanishing

### DIFF
--- a/src/completed-epic.ts
+++ b/src/completed-epic.ts
@@ -1,0 +1,54 @@
+import type { EpicChild } from "./epic-core";
+
+export interface CompletedEpicChild {
+  number: number;
+  title: string;
+  url: string;
+  prNumber: number | null;
+  prUrl: string | null;
+  mergedAt: number | null;
+  integrated: boolean;
+}
+
+export interface CompletedEpic {
+  repoPath: string;
+  parentIssueNumber: number;
+  parentTitle: string;
+  completedAt: number;
+  children: CompletedEpicChild[];
+}
+
+export function buildRollup(
+  children: Pick<EpicChild, "number" | "title" | "url">[],
+  details: {
+    childNumber: number;
+    prNumber: number | null;
+    prUrl: string | null;
+    mergedAt: number;
+  }[],
+): CompletedEpicChild[] {
+  const detailMap = new Map(details.map((d) => [d.childNumber, d]));
+  return children.map((child) => {
+    const detail = detailMap.get(child.number);
+    if (detail) {
+      return {
+        number: child.number,
+        title: child.title,
+        url: child.url,
+        prNumber: detail.prNumber,
+        prUrl: detail.prUrl,
+        mergedAt: detail.mergedAt,
+        integrated: true,
+      };
+    }
+    return {
+      number: child.number,
+      title: child.title,
+      url: child.url,
+      prNumber: null,
+      prUrl: null,
+      mergedAt: null,
+      integrated: false,
+    };
+  });
+}

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -15,6 +15,7 @@ import {
 import { assembleEpic } from "./epic-model";
 import { epicIntegrationBranch as epicBranchName, isEpicIntegrationBranch } from "./epic-branch";
 import { selectEpicCandidates, type Epic, type EpicRun } from "./epic-core";
+import { buildRollup, type CompletedEpic } from "./completed-epic";
 import { mapBounded } from "./map-bounded";
 import { config } from "./config";
 
@@ -80,6 +81,8 @@ export interface DrainDeps {
     | "setEpicRun"
     | "listEpicIntegrated"
     | "recordEpicIntegrated"
+    | "listEpicIntegratedDetails"
+    | "recordEpicCompleted"
   >;
   service: { create(input: CreateSessionInput): Promise<Session>; archive(id: string): number };
   resolveForge: (repoPath: string) => GitForge | null;
@@ -95,6 +98,8 @@ export interface DrainDeps {
   dropPrCache: (id: string) => void;
   /** → events.emit("epic:update", epic). Optional — absent in tests that don't need it. */
   emitEpic?: (epic: Epic) => void;
+  /** → events.emit("epic:completed", e). Optional — absent in tests that don't need it. */
+  emitEpicCompleted?: (epic: CompletedEpic) => void;
   now?: () => number;
   /** Short cache for listIssues (default 10s). */
   issuesTtlMs?: number;
@@ -386,6 +391,38 @@ export class DrainService {
       epic.children.length > 0 &&
       epic.children.every((c) => c.state === "merged")
     ) {
+      // CONTRACT(#635): record before status flip — persist the durable completed-epic
+      // rollup (+ emit) BEFORE flipping to idle, and gate the flip on the record succeeding.
+      // A failed record leaves the epic running so the next pump re-observes all-merged and
+      // retries the idempotent upsert, rather than silently losing the rollup.
+      try {
+        const rollup = buildRollup(
+          epic.children,
+          this.deps.store.listEpicIntegratedDetails(repoPath, epicRun.parentIssueNumber),
+        );
+        const completed: CompletedEpic = {
+          repoPath,
+          parentIssueNumber: epicRun.parentIssueNumber,
+          parentTitle: epic.parentTitle,
+          completedAt: this.now(),
+          children: rollup,
+        };
+        this.deps.store.recordEpicCompleted({
+          repoPath: completed.repoPath,
+          parentIssueNumber: completed.parentIssueNumber,
+          parentTitle: completed.parentTitle,
+          completedAt: completed.completedAt,
+          childrenJson: JSON.stringify(rollup),
+        });
+        this.deps.emitEpicCompleted?.(completed);
+      } catch (err) {
+        console.warn(
+          `[drain] epic-completed record failed for ${repoPath}#${epicRun.parentIssueNumber}:`,
+          err,
+        );
+        this.emitEpicIfChanged(repoPath, epic);
+        return false; // CONTRACT(#635): stay running, retry next pump
+      }
       const completedRun = { ...epicRun, status: "idle" as const };
       this.deps.store.setEpicRun(completedRun);
       // Emit a final epic:update reflecting the completed/idle state before
@@ -503,7 +540,10 @@ export class DrainService {
         );
         return; // leave the session live; next tick retries. Do NOT record or archive.
       }
-      this.deps.store.recordEpicIntegrated(repoPath, epicRun!.parentIssueNumber, s.issueNumber);
+      this.deps.store.recordEpicIntegrated(repoPath, epicRun!.parentIssueNumber, s.issueNumber, {
+        number: decision.prNumber,
+        url: this.deps.prCache.snapshot()[decision.sessionId]?.url ?? "",
+      });
       try {
         this.deps.service.archive(decision.sessionId);
       } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -666,6 +666,7 @@ const drain = new DrainService({
   emitArchived: (id) => events.emit("session:archived", { id }),
   dropPrCache: (id) => prPoller.drop(id),
   emitEpic: (epic) => events.emit("epic:update", epic),
+  emitEpicCompleted: (e) => events.emit("epic:completed", e),
 });
 
 // Drive the drain off the poller events the rest of the system already emits.

--- a/src/server.ts
+++ b/src/server.ts
@@ -3100,6 +3100,99 @@ async function cachedListIssues(
   return issues;
 }
 
+// Auto-dismiss: a completed epic whose parent is confidently closed (absent from a complete
+// open set) gets cleared + emitted. openTruncated → can't be confident, so this is a no-op.
+function autoDismissClosed(
+  deps: AppDeps,
+  repo: string,
+  openNumbers: Set<number>,
+  openTruncated: boolean,
+): void {
+  if (openTruncated) return;
+  for (const row of deps.store.listEpicCompleted(repo)) {
+    if (!openNumbers.has(row.parentIssueNumber)) {
+      deps.store.dismissEpicCompleted(repo, row.parentIssueNumber);
+      deps.events?.emit("epic:completed-cleared", {
+        repoPath: repo,
+        parentIssueNumber: row.parentIssueNumber,
+      });
+    }
+  }
+}
+
+// Backfill: an idle run whose all-merged epic never got recorded (e.g. completion happened
+// across a restart). Needs buildEpic — no-op when drain is absent. Records the completed epic
+// when all children are merged; otherwise logs a visible skip (never silently dropped).
+async function backfillIdleEpic(
+  deps: AppDeps,
+  repo: string,
+  openNumbers: Set<number>,
+  openTruncated: boolean,
+): Promise<void> {
+  if (!deps.drain) return;
+  const run = deps.store.getEpicRun(repo);
+  if (run?.status !== "idle") return;
+  // hasEpicCompleted ignores dismissedAt, so a dismissed-but-idle run counts as recorded
+  // and never re-fires buildEpic (a forge round-trip) on every GET.
+  if (deps.store.hasEpicCompleted(repo, run.parentIssueNumber)) return;
+  // Parent confidently still open? If we have a complete open set and the parent is absent,
+  // it's about to be auto-dismissed anyway — skip the flash of recording it.
+  if (!openTruncated && !openNumbers.has(run.parentIssueNumber)) return;
+
+  const epic = await deps.drain.buildEpic(repo, run);
+  if (!epic || epic.children.length === 0) return;
+  if (epic.children.every((c) => c.state === "merged")) {
+    const rollup = buildRollup(
+      epic.children,
+      deps.store.listEpicIntegratedDetails(repo, run.parentIssueNumber),
+    );
+    // completedAt: latest non-null child mergedAt, else now (not in the sync pump → Date.now OK).
+    const mergedAts = rollup.map((c) => c.mergedAt).filter((m): m is number => m !== null);
+    const completedAt = mergedAts.length > 0 ? Math.max(...mergedAts) : Date.now();
+    const completed: CompletedEpic = {
+      repoPath: repo,
+      parentIssueNumber: run.parentIssueNumber,
+      parentTitle: epic.parentTitle,
+      completedAt,
+      children: rollup,
+    };
+    deps.store.recordEpicCompleted({
+      repoPath: completed.repoPath,
+      parentIssueNumber: completed.parentIssueNumber,
+      parentTitle: completed.parentTitle,
+      completedAt: completed.completedAt,
+      childrenJson: JSON.stringify(rollup),
+    });
+  } else {
+    // Visible skip — never silently drop a backfill candidate.
+    const pending = epic.children.filter((c) => c.state !== "merged").map((c) => c.number);
+    console.warn(
+      `[server] completed-epics backfill skipped for ${repo}#${run.parentIssueNumber}: ` +
+        `children not all merged (pending: ${pending.join(", ")})`,
+    );
+  }
+}
+
+// Bounded, best-effort, fail-safe per-repo reconcile: resolve the forge (skip if none), fetch
+// the open set (forge throw → skip this repo, route still serves DB rows), then auto-dismiss
+// confidently-closed parents + backfill an all-merged idle run that never got recorded.
+async function reconcileCompletedEpicsForRepo(deps: AppDeps, repo: string): Promise<void> {
+  const forge = deps.resolveForge?.(repo);
+  if (!forge) return; // no forge → skip reconcile for this repo (its DB rows are still served)
+
+  let open: Awaited<ReturnType<GitForge["listIssues"]>>;
+  try {
+    open = await cachedListIssues(repo, forge);
+  } catch {
+    return; // forge/network error → skip this repo's reconcile (fail-safe)
+  }
+  const openNumbers = new Set(open.map((i) => i.number));
+  const openTruncated = open.length >= 200;
+
+  autoDismissClosed(deps, repo, openNumbers, openTruncated);
+  await backfillIdleEpic(deps, repo, openNumbers, openTruncated);
+}
+
 // GET /api/epics/completed[?repo=] — durable completed-epics band. Primarily pure-DB; also
 // runs a bounded, best-effort, fail-safe reconcile (auto-dismiss confidently-closed parents +
 // backfill an all-merged idle run that never got recorded). Always serves DB rows; never 500s
@@ -3138,78 +3231,7 @@ async function handleEpicsCompletedList({ req, parts, url, deps }: Ctx): Promise
         ]),
       ];
 
-  for (const repo of scopeRepos) {
-    const forge = deps.resolveForge?.(repo);
-    if (!forge) continue; // no forge → skip reconcile for this repo (its DB rows are still served)
-
-    let open: Awaited<ReturnType<GitForge["listIssues"]>>;
-    try {
-      open = await cachedListIssues(repo, forge);
-    } catch {
-      continue; // forge/network error → skip this repo's reconcile (fail-safe)
-    }
-    const openNumbers = new Set(open.map((i) => i.number));
-    const openTruncated = open.length >= 200;
-
-    // Auto-dismiss: a completed epic whose parent is confidently closed (absent from a
-    // complete open set) gets cleared. openTruncated → can't be confident, so skip.
-    if (!openTruncated) {
-      for (const row of deps.store.listEpicCompleted(repo)) {
-        if (!openNumbers.has(row.parentIssueNumber)) {
-          deps.store.dismissEpicCompleted(repo, row.parentIssueNumber);
-          deps.events?.emit("epic:completed-cleared", {
-            repoPath: repo,
-            parentIssueNumber: row.parentIssueNumber,
-          });
-        }
-      }
-    }
-
-    // Backfill: an idle run whose all-merged epic never got recorded (e.g. completion happened
-    // across a restart). Needs buildEpic — skip when drain is absent.
-    if (!deps.drain) continue;
-    const run = deps.store.getEpicRun(repo);
-    if (run?.status !== "idle") continue;
-    // hasEpicCompleted ignores dismissedAt, so a dismissed-but-idle run counts as recorded
-    // and never re-fires buildEpic (a forge round-trip) on every GET.
-    if (deps.store.hasEpicCompleted(repo, run.parentIssueNumber)) continue;
-    // Parent confidently still open? If we have a complete open set and the parent is absent,
-    // it's about to be auto-dismissed anyway — skip the flash of recording it.
-    if (!openTruncated && !openNumbers.has(run.parentIssueNumber)) continue;
-
-    const epic = await deps.drain.buildEpic(repo, run);
-    if (!epic || epic.children.length === 0) continue;
-    if (epic.children.every((c) => c.state === "merged")) {
-      const rollup = buildRollup(
-        epic.children,
-        deps.store.listEpicIntegratedDetails(repo, run.parentIssueNumber),
-      );
-      // completedAt: latest non-null child mergedAt, else now (not in the sync pump → Date.now OK).
-      const mergedAts = rollup.map((c) => c.mergedAt).filter((m): m is number => m !== null);
-      const completedAt = mergedAts.length > 0 ? Math.max(...mergedAts) : Date.now();
-      const completed: CompletedEpic = {
-        repoPath: repo,
-        parentIssueNumber: run.parentIssueNumber,
-        parentTitle: epic.parentTitle,
-        completedAt,
-        children: rollup,
-      };
-      deps.store.recordEpicCompleted({
-        repoPath: completed.repoPath,
-        parentIssueNumber: completed.parentIssueNumber,
-        parentTitle: completed.parentTitle,
-        completedAt: completed.completedAt,
-        childrenJson: JSON.stringify(rollup),
-      });
-    } else {
-      // Visible skip — never silently drop a backfill candidate.
-      const pending = epic.children.filter((c) => c.state !== "merged").map((c) => c.number);
-      console.warn(
-        `[server] completed-epics backfill skipped for ${repo}#${run.parentIssueNumber}: ` +
-          `children not all merged (pending: ${pending.join(", ")})`,
-      );
-    }
-  }
+  for (const repo of scopeRepos) await reconcileCompletedEpicsForRepo(deps, repo);
 
   // Re-query post-reconcile so the response reflects dismiss + backfill.
   const rows = deps.store.listEpicCompleted(repoFilter).map((row) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -77,6 +77,7 @@ import type { DrainStatus, QueuedItem } from "./drain";
 import { ACTIVE_LABEL } from "./drain-core";
 import type { Epic, EpicRun, EpicSource } from "./epic-core";
 import { importEpicLinks, type ImportResult } from "./epic-import";
+import { buildRollup, type CompletedEpic } from "./completed-epic";
 import { parseEpicBody } from "./epic-parse";
 import { countDefinedWorkflows, type CountsService, type RepoCounts } from "./backlog";
 import { join, normalize } from "node:path";
@@ -3077,6 +3078,170 @@ async function handleEpicImport({ req, parts, url, deps }: Ctx): Promise<Respons
   return json(result);
 }
 
+// Short-TTL per-repo cache around forge.listIssues(), shared by the completed-epics
+// band reconcile. Coalesces the concurrent band fetches a UI poll can fan out into one
+// forge round-trip per repo. The /api/epics route still calls listIssues() uncached, so
+// this is the same network cost — just deduplicated within the TTL window.
+const COMPLETED_EPICS_LIST_TTL_MS = 10_000;
+const completedEpicsIssueCache = new Map<
+  string,
+  { issues: Awaited<ReturnType<GitForge["listIssues"]>>; ts: number }
+>();
+
+async function cachedListIssues(
+  repo: string,
+  forge: GitForge,
+): Promise<Awaited<ReturnType<GitForge["listIssues"]>>> {
+  const hit = completedEpicsIssueCache.get(repo);
+  const now = Date.now();
+  if (hit && now - hit.ts < COMPLETED_EPICS_LIST_TTL_MS) return hit.issues;
+  const issues = await forge.listIssues();
+  completedEpicsIssueCache.set(repo, { issues, ts: now });
+  return issues;
+}
+
+// GET /api/epics/completed[?repo=] — durable completed-epics band. Primarily pure-DB; also
+// runs a bounded, best-effort, fail-safe reconcile (auto-dismiss confidently-closed parents +
+// backfill an all-merged idle run that never got recorded). Always serves DB rows; never 500s
+// on forge/network failure and never 503s just because drain is absent.
+async function handleEpicsCompletedList({ req, parts, url, deps }: Ctx): Promise<Response | null> {
+  if (
+    !(
+      req.method === "GET" &&
+      parts[0] === "api" &&
+      parts[1] === "epics" &&
+      parts[2] === "completed" &&
+      !parts[3]
+    )
+  )
+    return null;
+
+  const repoParam = url.searchParams.get("repo");
+  let repoFilter: string | undefined;
+  if (repoParam !== null) {
+    const dir = safeRepoDir(repoParam, config.repoRoot);
+    if (!dir) return json({ error: "invalid repo" }, 400);
+    repoFilter = dir;
+  }
+
+  // scopeRepos: ?repo → just that repo; else the union of repos with a DB completed-epic row
+  // and repos with an idle epic_run (the backfill source). One entry per repo — bounded.
+  const scopeRepos: string[] = repoFilter
+    ? [repoFilter]
+    : [
+        ...new Set([
+          ...deps.store.listEpicCompleted().map((r) => r.repoPath),
+          ...deps.store
+            .listEpicRuns()
+            .filter((r) => r.status === "idle")
+            .map((r) => r.repoPath),
+        ]),
+      ];
+
+  for (const repo of scopeRepos) {
+    const forge = deps.resolveForge?.(repo);
+    if (!forge) continue; // no forge → skip reconcile for this repo (its DB rows are still served)
+
+    let open: Awaited<ReturnType<GitForge["listIssues"]>>;
+    try {
+      open = await cachedListIssues(repo, forge);
+    } catch {
+      continue; // forge/network error → skip this repo's reconcile (fail-safe)
+    }
+    const openNumbers = new Set(open.map((i) => i.number));
+    const openTruncated = open.length >= 200;
+
+    // Auto-dismiss: a completed epic whose parent is confidently closed (absent from a
+    // complete open set) gets cleared. openTruncated → can't be confident, so skip.
+    if (!openTruncated) {
+      for (const row of deps.store.listEpicCompleted(repo)) {
+        if (!openNumbers.has(row.parentIssueNumber)) {
+          deps.store.dismissEpicCompleted(repo, row.parentIssueNumber);
+          deps.events?.emit("epic:completed-cleared", {
+            repoPath: repo,
+            parentIssueNumber: row.parentIssueNumber,
+          });
+        }
+      }
+    }
+
+    // Backfill: an idle run whose all-merged epic never got recorded (e.g. completion happened
+    // across a restart). Needs buildEpic — skip when drain is absent.
+    if (!deps.drain) continue;
+    const run = deps.store.getEpicRun(repo);
+    if (run?.status !== "idle") continue;
+    // hasEpicCompleted ignores dismissedAt, so a dismissed-but-idle run counts as recorded
+    // and never re-fires buildEpic (a forge round-trip) on every GET.
+    if (deps.store.hasEpicCompleted(repo, run.parentIssueNumber)) continue;
+    // Parent confidently still open? If we have a complete open set and the parent is absent,
+    // it's about to be auto-dismissed anyway — skip the flash of recording it.
+    if (!openTruncated && !openNumbers.has(run.parentIssueNumber)) continue;
+
+    const epic = await deps.drain.buildEpic(repo, run);
+    if (!epic || epic.children.length === 0) continue;
+    if (epic.children.every((c) => c.state === "merged")) {
+      const rollup = buildRollup(
+        epic.children,
+        deps.store.listEpicIntegratedDetails(repo, run.parentIssueNumber),
+      );
+      // completedAt: latest non-null child mergedAt, else now (not in the sync pump → Date.now OK).
+      const mergedAts = rollup.map((c) => c.mergedAt).filter((m): m is number => m !== null);
+      const completedAt = mergedAts.length > 0 ? Math.max(...mergedAts) : Date.now();
+      const completed: CompletedEpic = {
+        repoPath: repo,
+        parentIssueNumber: run.parentIssueNumber,
+        parentTitle: epic.parentTitle,
+        completedAt,
+        children: rollup,
+      };
+      deps.store.recordEpicCompleted({
+        repoPath: completed.repoPath,
+        parentIssueNumber: completed.parentIssueNumber,
+        parentTitle: completed.parentTitle,
+        completedAt: completed.completedAt,
+        childrenJson: JSON.stringify(rollup),
+      });
+    } else {
+      // Visible skip — never silently drop a backfill candidate.
+      const pending = epic.children.filter((c) => c.state !== "merged").map((c) => c.number);
+      console.warn(
+        `[server] completed-epics backfill skipped for ${repo}#${run.parentIssueNumber}: ` +
+          `children not all merged (pending: ${pending.join(", ")})`,
+      );
+    }
+  }
+
+  // Re-query post-reconcile so the response reflects dismiss + backfill.
+  const rows = deps.store.listEpicCompleted(repoFilter).map((row) => {
+    const { childrenJson, ...rest } = row;
+    return { ...rest, children: JSON.parse(childrenJson) as CompletedEpic["children"] };
+  });
+  return json(rows);
+}
+
+// POST /api/epics/completed/dismiss — body { repo, parent }. Dismiss one completed epic + emit.
+async function handleEpicsCompletedDismiss({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (
+    !(
+      req.method === "POST" &&
+      parts[0] === "api" &&
+      parts[1] === "epics" &&
+      parts[2] === "completed" &&
+      parts[3] === "dismiss"
+    )
+  )
+    return null;
+  const body = (await req.json().catch(() => null)) as { repo?: string; parent?: number } | null;
+  const dir = safeRepoDir(body?.repo ?? "", config.repoRoot);
+  if (!dir) return json({ error: "invalid repo" }, 400);
+  const parent = body?.parent;
+  if (typeof parent !== "number" || !Number.isInteger(parent) || parent <= 0)
+    return json({ error: "parent must be a positive integer" }, 400);
+  deps.store.dismissEpicCompleted(dir, parent);
+  deps.events?.emit("epic:completed-cleared", { repoPath: dir, parentIssueNumber: parent });
+  return json({ ok: true });
+}
+
 // Ordered dispatch chain — preserves the original guard sequence verbatim.
 const ROUTE_HANDLERS = [
   handlePing,
@@ -3091,6 +3256,8 @@ const ROUTE_HANDLERS = [
   handleDrain,
   handleAutoMerge,
   handleEpicsList,
+  handleEpicsCompletedDismiss,
+  handleEpicsCompletedList,
   handleEpicApproveNext,
   handleEpicImport,
   handleEpicGet,

--- a/src/store.ts
+++ b/src/store.ts
@@ -551,6 +551,13 @@ export class SessionStore implements CapStore, CreditStore {
     );
   }
 
+  /** All persisted epic_run rows (one per repo). Mirrors getEpicRun's row shape. */
+  listEpicRuns(): EpicRun[] {
+    return this.db
+      .query(`SELECT repoPath, parentIssueNumber, mode, status FROM epic_run`)
+      .all() as EpicRun[];
+  }
+
   setEpicRun(r: EpicRun): void {
     this.db.run(
       `INSERT INTO epic_run (repoPath, parentIssueNumber, mode, status, updatedAt) VALUES (?,?,?,?,?)
@@ -624,6 +631,16 @@ export class SessionStore implements CapStore, CreditStore {
          completedAt = excluded.completedAt,
          childrenJson = excluded.childrenJson`,
       [row.repoPath, row.parentIssueNumber, row.parentTitle, row.completedAt, row.childrenJson],
+    );
+  }
+
+  /** True if an epic_completed row exists for this key, regardless of dismissedAt.
+   *  Used by the backfill pre-check so a dismissed-but-idle run isn't re-backfilled. */
+  hasEpicCompleted(repoPath: string, parentIssueNumber: number): boolean {
+    return (
+      this.db
+        .query(`SELECT 1 FROM epic_completed WHERE repoPath = ? AND parentIssueNumber = ? LIMIT 1`)
+        .get(repoPath, parentIssueNumber) !== null
     );
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -387,6 +387,13 @@ export class SessionStore implements CapStore, CreditStore {
       repoPath TEXT NOT NULL, parentIssueNumber INTEGER NOT NULL, childNumber INTEGER NOT NULL,
       createdAt INTEGER NOT NULL,
       PRIMARY KEY (repoPath, parentIssueNumber, childNumber))`);
+    this.migrateEpicIntegratedColumns();
+    this.db.run(`CREATE TABLE IF NOT EXISTS epic_completed (
+      repoPath TEXT NOT NULL, parentIssueNumber INTEGER NOT NULL,
+      parentTitle TEXT NOT NULL, completedAt INTEGER NOT NULL,
+      dismissedAt INTEGER,
+      childrenJson TEXT NOT NULL,
+      PRIMARY KEY (repoPath, parentIssueNumber))`);
     this.db.run(`CREATE TABLE IF NOT EXISTS push_subscriptions (
       endpoint TEXT PRIMARY KEY, p256dh TEXT NOT NULL, auth TEXT NOT NULL,
       ua TEXT NOT NULL DEFAULT '', locale TEXT NOT NULL DEFAULT 'en',
@@ -553,12 +560,22 @@ export class SessionStore implements CapStore, CreditStore {
   }
 
   /** Record that a child PR was squash-merged into the epic integration branch.
-   *  Idempotent (PK upsert) — the drain may re-observe a merge across pumps. */
-  recordEpicIntegrated(repoPath: string, parentIssueNumber: number, childNumber: number): void {
+   *  Idempotent (PK upsert) — the drain may re-observe a merge across pumps.
+   *  On conflict, updates only PR columns (guarded by COALESCE so a null re-observe
+   *  cannot clobber previously-recorded good values). createdAt is never overwritten. */
+  recordEpicIntegrated(
+    repoPath: string,
+    parentIssueNumber: number,
+    childNumber: number,
+    pr?: { number: number; url: string },
+  ): void {
     this.db.run(
-      `INSERT INTO epic_integrated (repoPath, parentIssueNumber, childNumber, createdAt)
-       VALUES (?,?,?,?) ON CONFLICT DO NOTHING`,
-      [repoPath, parentIssueNumber, childNumber, Date.now()],
+      `INSERT INTO epic_integrated (repoPath, parentIssueNumber, childNumber, createdAt, prNumber, prUrl)
+       VALUES (?,?,?,?,?,?)
+       ON CONFLICT DO UPDATE SET
+         prNumber = COALESCE(excluded.prNumber, epic_integrated.prNumber),
+         prUrl = COALESCE(NULLIF(excluded.prUrl, ''), epic_integrated.prUrl)`,
+      [repoPath, parentIssueNumber, childNumber, Date.now(), pr?.number ?? null, pr?.url ?? null],
     );
   }
 
@@ -568,6 +585,93 @@ export class SessionStore implements CapStore, CreditStore {
       .query(`SELECT childNumber FROM epic_integrated WHERE repoPath = ? AND parentIssueNumber = ?`)
       .all(repoPath, parentIssueNumber) as { childNumber: number }[];
     return new Set(rows.map((r) => r.childNumber));
+  }
+
+  /** All integrated child rows for one epic, with PR details and mergedAt timestamp. */
+  listEpicIntegratedDetails(
+    repoPath: string,
+    parentIssueNumber: number,
+  ): { childNumber: number; prNumber: number | null; prUrl: string | null; mergedAt: number }[] {
+    return this.db
+      .query(
+        `SELECT childNumber, prNumber, prUrl, createdAt AS mergedAt
+         FROM epic_integrated WHERE repoPath = ? AND parentIssueNumber = ?
+         ORDER BY childNumber`,
+      )
+      .all(repoPath, parentIssueNumber) as {
+      childNumber: number;
+      prNumber: number | null;
+      prUrl: string | null;
+      mergedAt: number;
+    }[];
+  }
+
+  /** Record a completed epic (all children done-in-epic). Idempotent upsert.
+   *  On conflict, refreshes parentTitle/completedAt/childrenJson but leaves dismissedAt untouched
+   *  so a previously dismissed epic never resurrects. */
+  recordEpicCompleted(row: {
+    repoPath: string;
+    parentIssueNumber: number;
+    parentTitle: string;
+    completedAt: number;
+    childrenJson: string;
+  }): void {
+    this.db.run(
+      `INSERT INTO epic_completed (repoPath, parentIssueNumber, parentTitle, completedAt, childrenJson)
+       VALUES (?,?,?,?,?)
+       ON CONFLICT DO UPDATE SET
+         parentTitle = excluded.parentTitle,
+         completedAt = excluded.completedAt,
+         childrenJson = excluded.childrenJson`,
+      [row.repoPath, row.parentIssueNumber, row.parentTitle, row.completedAt, row.childrenJson],
+    );
+  }
+
+  /** All non-dismissed completed epics, optionally filtered by repoPath, newest-completed first. */
+  listEpicCompleted(repoPath?: string): {
+    repoPath: string;
+    parentIssueNumber: number;
+    parentTitle: string;
+    completedAt: number;
+    childrenJson: string;
+  }[] {
+    if (repoPath !== undefined) {
+      return this.db
+        .query(
+          `SELECT repoPath, parentIssueNumber, parentTitle, completedAt, childrenJson
+           FROM epic_completed WHERE dismissedAt IS NULL AND repoPath = ?
+           ORDER BY completedAt DESC`,
+        )
+        .all(repoPath) as {
+        repoPath: string;
+        parentIssueNumber: number;
+        parentTitle: string;
+        completedAt: number;
+        childrenJson: string;
+      }[];
+    }
+    return this.db
+      .query(
+        `SELECT repoPath, parentIssueNumber, parentTitle, completedAt, childrenJson
+         FROM epic_completed WHERE dismissedAt IS NULL
+         ORDER BY completedAt DESC`,
+      )
+      .all() as {
+      repoPath: string;
+      parentIssueNumber: number;
+      parentTitle: string;
+      completedAt: number;
+      childrenJson: string;
+    }[];
+  }
+
+  /** Mark a completed epic as dismissed (hides it from listEpicCompleted).
+   *  TODO(#635): Stage B should call this at land-time when it closes the parent. */
+  dismissEpicCompleted(repoPath: string, parentIssueNumber: number): void {
+    this.db.run(
+      `UPDATE epic_completed SET dismissedAt = ? WHERE repoPath = ? AND parentIssueNumber = ?`,
+      [Date.now(), repoPath, parentIssueNumber],
+    );
   }
 
   private nextDesignationSeq(): number {
@@ -1359,6 +1463,16 @@ export class SessionStore implements CapStore, CreditStore {
     add("defaultModel", `defaultModel TEXT NOT NULL DEFAULT 'inherit'`);
     // per-repo egress extra-hosts: JSON-encoded string array (nullable, default []).
     add("egressExtraHosts", `egressExtraHosts TEXT`);
+  }
+
+  private migrateEpicIntegratedColumns(): void {
+    const cols = this.db.query(`PRAGMA table_info(epic_integrated)`).all() as { name: string }[];
+    const add = (name: string, ddl: string) => {
+      if (!cols.some((c) => c.name === name))
+        this.db.run(`ALTER TABLE epic_integrated ADD COLUMN ${ddl}`);
+    };
+    add("prNumber", `prNumber INTEGER`);
+    add("prUrl", `prUrl TEXT`);
   }
 
   private migrateReviewColumns(): void {

--- a/test/completed-epic.test.ts
+++ b/test/completed-epic.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test";
+import { buildRollup } from "../src/completed-epic";
+
+describe("buildRollup", () => {
+  it("child WITH detail row → integrated true, PR facts from row", () => {
+    const children = [{ number: 1, title: "Fix auth", url: "https://gh/issues/1" }];
+    const details = [{ childNumber: 1, prNumber: 42, prUrl: "https://gh/pull/42", mergedAt: 1000 }];
+    const result = buildRollup(children, details);
+    expect(result).toEqual([
+      {
+        number: 1,
+        title: "Fix auth",
+        url: "https://gh/issues/1",
+        prNumber: 42,
+        prUrl: "https://gh/pull/42",
+        mergedAt: 1000,
+        integrated: true,
+      },
+    ]);
+  });
+
+  it("child WITHOUT detail row → integrated false, PR/mergedAt null, number/title/url present", () => {
+    const children = [{ number: 5, title: "Closed out-of-band", url: "https://gh/issues/5" }];
+    const result = buildRollup(children, []);
+    expect(result).toEqual([
+      {
+        number: 5,
+        title: "Closed out-of-band",
+        url: "https://gh/issues/5",
+        prNumber: null,
+        prUrl: null,
+        mergedAt: null,
+        integrated: false,
+      },
+    ]);
+  });
+
+  it("mixed epic (#327 shape): 6 children, 3 with detail rows, 3 without", () => {
+    const children = [
+      { number: 320, title: "Task A", url: "https://gh/issues/320" },
+      { number: 321, title: "Task B", url: "https://gh/issues/321" },
+      { number: 322, title: "Task C", url: "https://gh/issues/322" },
+      { number: 323, title: "Task D", url: "https://gh/issues/323" },
+      { number: 324, title: "Task E", url: "https://gh/issues/324" },
+      { number: 325, title: "Task F", url: "https://gh/issues/325" },
+    ];
+    const details = [
+      { childNumber: 322, prNumber: 101, prUrl: "https://gh/pull/101", mergedAt: 2000 },
+      { childNumber: 323, prNumber: 102, prUrl: "https://gh/pull/102", mergedAt: 2001 },
+      { childNumber: 325, prNumber: 103, prUrl: "https://gh/pull/103", mergedAt: 2002 },
+    ];
+    const result = buildRollup(children, details);
+
+    const integrated = result.filter((c) => c.integrated);
+    const notIntegrated = result.filter((c) => !c.integrated);
+
+    expect(integrated).toHaveLength(3);
+    expect(notIntegrated).toHaveLength(3);
+
+    expect(integrated.map((c) => c.number)).toEqual([322, 323, 325]);
+    expect(integrated.map((c) => c.prNumber)).toEqual([101, 102, 103]);
+    expect(integrated.map((c) => c.prUrl)).toEqual([
+      "https://gh/pull/101",
+      "https://gh/pull/102",
+      "https://gh/pull/103",
+    ]);
+    expect(integrated.map((c) => c.mergedAt)).toEqual([2000, 2001, 2002]);
+
+    expect(notIntegrated.map((c) => c.number)).toEqual([320, 321, 324]);
+    expect(notIntegrated.every((c) => c.prNumber === null)).toBe(true);
+    expect(notIntegrated.every((c) => c.prUrl === null)).toBe(true);
+    expect(notIntegrated.every((c) => c.mergedAt === null)).toBe(true);
+
+    // output order matches input order
+    expect(result.map((c) => c.number)).toEqual([320, 321, 322, 323, 324, 325]);
+  });
+
+  it("detail row with null prNumber/prUrl (legacy row) → integrated true, mergedAt present", () => {
+    const children = [{ number: 10, title: "Legacy task", url: "https://gh/issues/10" }];
+    const details = [{ childNumber: 10, prNumber: null, prUrl: null, mergedAt: 5000 }];
+    const result = buildRollup(children, details);
+    expect(result).toEqual([
+      {
+        number: 10,
+        title: "Legacy task",
+        url: "https://gh/issues/10",
+        prNumber: null,
+        prUrl: null,
+        mergedAt: 5000,
+        integrated: true,
+      },
+    ]);
+  });
+
+  it("order preservation: output order matches input child order regardless of detail order", () => {
+    const children = [
+      { number: 3, title: "C", url: "u3" },
+      { number: 1, title: "A", url: "u1" },
+      { number: 2, title: "B", url: "u2" },
+    ];
+    const details = [
+      { childNumber: 1, prNumber: 10, prUrl: "p1", mergedAt: 100 },
+      { childNumber: 3, prNumber: 30, prUrl: "p3", mergedAt: 300 },
+    ];
+    const result = buildRollup(children, details);
+    expect(result.map((c) => c.number)).toEqual([3, 1, 2]);
+    expect(result.at(0)?.integrated).toBe(true);
+    expect(result.at(1)?.integrated).toBe(true);
+    expect(result.at(2)?.integrated).toBe(false);
+  });
+});

--- a/test/drain-epic-completed.test.ts
+++ b/test/drain-epic-completed.test.ts
@@ -1,0 +1,224 @@
+import { test, expect, describe } from "bun:test";
+import { DrainService } from "../src/drain";
+import { SessionStore } from "../src/store";
+import type { GitForge, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
+import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
+import type { CompletedEpic, CompletedEpicChild } from "../src/completed-epic";
+
+const REPO = "/repo";
+const PARENT = 327;
+
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+};
+
+/** A forge whose epic has the given native sub-issues (closed flag drives "merged"). */
+function fakeForge(
+  subIssues: SubIssueRef[],
+  listBlockedByImpl?: (n: number) => Promise<number[]>,
+): GitForge {
+  return {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
+    openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
+    defaultBranch: async () => "main",
+    merge: async () => {},
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    closeIssue: async () => {},
+    ensureIssueLink: async () => {},
+    addIssueLabel: async () => {},
+    removeIssueLabel: async () => {},
+    getIssue: async (n: number): Promise<Issue | null> =>
+      n === PARENT
+        ? {
+            number: PARENT,
+            title: "EFI cluster",
+            body: "epic body",
+            url: `https://x/${PARENT}`,
+            labels: [],
+            createdAt: 0,
+          }
+        : null,
+    listSubIssues: async () => subIssues,
+    listBlockedBy: listBlockedByImpl ?? (async () => []),
+  };
+}
+
+function sub(number: number, closed: boolean): SubIssueRef {
+  return {
+    number,
+    title: `child ${number}`,
+    url: `https://x/${number}`,
+    body: "",
+    closed,
+    labels: [],
+  };
+}
+
+interface HarnessOpts {
+  subIssues: SubIssueRef[];
+  /** Override recordEpicCompleted on the store (e.g. to throw). */
+  recordImpl?: () => void;
+  /** Override listBlockedBy on the forge (defaults to always returning []). */
+  listBlockedByImpl?: (n: number) => Promise<number[]>;
+}
+
+interface Harness {
+  store: SessionStore;
+  drain: DrainService;
+  completedEmits: CompletedEpic[];
+}
+
+function makeHarness(opts: HarnessOpts): Harness {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: true,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 2,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+  });
+  store.setEpicRun({
+    repoPath: REPO,
+    parentIssueNumber: PARENT,
+    mode: "auto",
+    status: "running",
+  });
+
+  if (opts.recordImpl) {
+    store.recordEpicCompleted = opts.recordImpl as typeof store.recordEpicCompleted;
+  }
+
+  const forge = fakeForge(opts.subIssues, opts.listBlockedByImpl);
+  const completedEmits: CompletedEpic[] = [];
+
+  const service = {
+    create: async () => {
+      throw new Error("not used in these tests");
+    },
+    archive: () => 1,
+  };
+
+  const drain = new DrainService({
+    store,
+    service: service as never,
+    resolveForge: () => forge,
+    prCache: { snapshot: () => ({}) },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    emitStatus: () => {},
+    emitArchived: () => {},
+    dropPrCache: () => {},
+    emitEpic: () => {},
+    emitEpicCompleted: (e) => completedEmits.push(e),
+  });
+
+  return { store, drain, completedEmits };
+}
+
+describe("epic auto-complete → record before idle flip (#635)", () => {
+  test("all children merged: records epic_completed + emits BEFORE flipping run to idle", async () => {
+    const h = makeHarness({ subIssues: [sub(320, true), sub(321, true)] });
+
+    await h.drain.pump(REPO);
+
+    const rows = h.store.listEpicCompleted(REPO);
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.parentIssueNumber).toBe(PARENT);
+    expect(row.parentTitle).toBe("EFI cluster");
+
+    // Run flipped to idle.
+    expect(h.store.getEpicRun(REPO)?.status).toBe("idle");
+
+    // Emitter fired with the same CompletedEpic.
+    expect(h.completedEmits).toHaveLength(1);
+    const emit = h.completedEmits[0]!;
+    expect(emit.parentIssueNumber).toBe(PARENT);
+    expect(emit.children.map((c) => c.number).sort()).toEqual([320, 321]);
+  });
+
+  test("record failure keeps the epic RUNNING (no flip, no row) → retried next pump", async () => {
+    // console.warn "[drain] epic-completed record failed…" is expected here
+    const h = makeHarness({
+      subIssues: [sub(320, true), sub(321, true)],
+      recordImpl: () => {
+        throw new Error("disk full");
+      },
+    });
+
+    await h.drain.pump(REPO);
+
+    expect(h.store.getEpicRun(REPO)?.status).toBe("running"); // NOT idle
+    expect(h.store.listEpicCompleted(REPO)).toHaveLength(0);
+    expect(h.completedEmits).toHaveLength(0);
+  });
+
+  test("not all merged: no record, run stays running", async () => {
+    // #322 is an open in-epic dep, making #321 blocked (not spawnable) so no service.create noise.
+    const h = makeHarness({
+      subIssues: [sub(320, true), sub(321, false), sub(322, false)],
+      // 321→322 and 322→321 form a circular dep; assembleEpic accepts it (no cycle check),
+      // both derive as blocked, so neither is spawnable and service.create is never called.
+      listBlockedByImpl: async (n: number) => (n === 321 ? [322] : n === 322 ? [321] : []),
+    });
+
+    await h.drain.pump(REPO);
+
+    expect(h.store.listEpicCompleted(REPO)).toHaveLength(0);
+    expect(h.store.getEpicRun(REPO)?.status).toBe("running");
+    expect(h.completedEmits).toHaveLength(0);
+  });
+
+  test("mixed: integrated child carries PR facts, issue-closed child has integrated:false/null PR", async () => {
+    // 320 integration-merged with PR facts; 321 issue-closed (no detail row). Both → state merged.
+    const h = makeHarness({ subIssues: [sub(320, false), sub(321, true)] });
+    h.store.recordEpicIntegrated(REPO, PARENT, 320, {
+      number: 9001,
+      url: "https://github.com/o/r/pull/9001",
+    });
+
+    await h.drain.pump(REPO);
+
+    const rows = h.store.listEpicCompleted(REPO);
+    expect(rows).toHaveLength(1);
+    const children = JSON.parse(rows[0]!.childrenJson) as CompletedEpicChild[];
+    const byNum = new Map(children.map((c) => [c.number, c]));
+
+    const integrated = byNum.get(320)!;
+    expect(integrated.integrated).toBe(true);
+    expect(integrated.prNumber).toBe(9001);
+    expect(integrated.prUrl).toBe("https://github.com/o/r/pull/9001");
+    expect(integrated.mergedAt).toBeGreaterThan(0);
+
+    const closed = byNum.get(321)!;
+    expect(closed.integrated).toBe(false);
+    expect(closed.prNumber).toBeNull();
+    expect(closed.prUrl).toBeNull();
+    expect(closed.mergedAt).toBeNull();
+
+    expect(h.store.getEpicRun(REPO)?.status).toBe("idle");
+  });
+});

--- a/test/epic-server.test.ts
+++ b/test/epic-server.test.ts
@@ -6,7 +6,7 @@ import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
 import { config } from "../src/config";
 import { validateEpicRunPatch } from "../src/validate";
-import type { Epic, EpicRun } from "../src/epic-core";
+import type { Epic, EpicChild, EpicRun } from "../src/epic-core";
 
 // ── validateEpicRunPatch unit tests ──────────────────────────────────────────
 
@@ -706,6 +706,409 @@ describe("GET /api/epics", () => {
     const epicB = body.find((e) => e.parentIssueNumber === 11);
     expect(epicA?.status).toBe("running");
     expect(epicB?.status).toBe("idle");
+  });
+});
+
+// ── completed-epics band (GET /api/epics/completed + dismiss) ─────────────────
+
+function mergedChild(number: number): EpicChild {
+  return {
+    number,
+    title: `Child #${number}`,
+    url: `https://x/issues/${number}`,
+    order: number,
+    body: "",
+    blockedBy: [],
+    state: "merged",
+    sessionId: null,
+    prNumber: null,
+    issueClosed: true,
+    integrationMerged: true,
+    claimed: true,
+  };
+}
+
+// Harness that also captures epic:completed-cleared events (the default harness only
+// captures epic:update).
+function completedHarness(opts?: {
+  drainOverrides?: Partial<NonNullable<AppDeps["drain"]>>;
+  drain?: AppDeps["drain"] | null;
+  resolveForge?: AppDeps["resolveForge"];
+}): {
+  app: ReturnType<typeof makeApp>;
+  store: SessionStore;
+  cleared: { repoPath: string; parentIssueNumber: number }[];
+} {
+  const store = new SessionStore(":memory:");
+  const cleared: { repoPath: string; parentIssueNumber: number }[] = [];
+  const events = new EventHub();
+  events.subscribe((event, data) => {
+    if (event === "epic:completed-cleared")
+      cleared.push(data as { repoPath: string; parentIssueNumber: number });
+  });
+
+  const defaultDrain: NonNullable<AppDeps["drain"]> = {
+    snapshot: async () => [],
+    queue: async () => [],
+    retainClaim: () => {},
+    buildEpic: async (repoPath, run) => makeEpic(repoPath, run.parentIssueNumber, run),
+    approveEpicNext: () => {},
+    tick: async () => {},
+  };
+  const drain =
+    opts?.drain === null ? undefined : { ...defaultDrain, ...(opts?.drainOverrides ?? {}) };
+
+  const deps: AppDeps = {
+    store,
+    service: {} as AppDeps["service"],
+    events,
+    usageLimits: { limits: () => ({}) } as any,
+    drain,
+    resolveForge: opts?.resolveForge,
+  };
+  return { app: makeApp(deps), store, cleared };
+}
+
+describe("GET /api/epics/completed", () => {
+  test("returns persisted completed epics with parsed children", async () => {
+    const { app, store } = completedHarness({ resolveForge: () => null });
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 42,
+      parentTitle: "Epic Done",
+      completedAt: 5000,
+      childrenJson: JSON.stringify([
+        {
+          number: 1,
+          title: "C1",
+          url: "u1",
+          prNumber: 9,
+          prUrl: "pu9",
+          mergedAt: 4000,
+          integrated: true,
+        },
+      ]),
+    });
+    const res = await app.fetch(new Request(`http://x/api/epics/completed`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].parentIssueNumber).toBe(42);
+    expect(body[0].parentTitle).toBe("Epic Done");
+    expect(body[0].childrenJson).toBeUndefined();
+    expect(body[0].children).toEqual([
+      {
+        number: 1,
+        title: "C1",
+        url: "u1",
+        prNumber: 9,
+        prUrl: "pu9",
+        mergedAt: 4000,
+        integrated: true,
+      },
+    ]);
+  });
+
+  test("?repo= filters to one repo", async () => {
+    const other = join(tmpRoot, "other");
+    mkdirSync(other);
+    const { app, store } = completedHarness({ resolveForge: () => null });
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 1,
+      parentTitle: "A",
+      completedAt: 1,
+      childrenJson: "[]",
+    });
+    store.recordEpicCompleted({
+      repoPath: other,
+      parentIssueNumber: 2,
+      parentTitle: "B",
+      completedAt: 2,
+      childrenJson: "[]",
+    });
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed?repo=${encRepo(repoDir)}`),
+    );
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].parentIssueNumber).toBe(1);
+  });
+
+  test("invalid ?repo= → 400", async () => {
+    const { app } = completedHarness();
+    const res = await app.fetch(new Request(`http://x/api/epics/completed?repo=/nope/not/here`));
+    expect(res.status).toBe(400);
+  });
+
+  test("auto-dismiss: confidently-closed parent cleared + event; still-open retained", async () => {
+    const { app, store, cleared } = completedHarness({
+      // open set = [7] (the retained one); #5 is absent → confidently closed
+      resolveForge: () =>
+        ({
+          listIssues: async () => [
+            { number: 7, title: "Open epic", body: "", url: "", labels: [], createdAt: 0 },
+          ],
+        }) as any,
+    });
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 5,
+      parentTitle: "Closed",
+      completedAt: 1,
+      childrenJson: "[]",
+    });
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 7,
+      parentTitle: "Still open",
+      completedAt: 2,
+      childrenJson: "[]",
+    });
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed?repo=${encRepo(repoDir)}`),
+    );
+    const body = await res.json();
+    expect(body.map((e: any) => e.parentIssueNumber)).toEqual([7]);
+    expect(cleared).toEqual([{ repoPath: repoDir, parentIssueNumber: 5 }]);
+  });
+
+  test("auto-dismiss: skipped when open list is truncated (>=200)", async () => {
+    const openIssues = Array.from({ length: 200 }, (_, i) => ({
+      number: i + 1000,
+      title: `I${i}`,
+      body: "",
+      url: "",
+      labels: [],
+      createdAt: 0,
+    }));
+    const { app, store, cleared } = completedHarness({
+      resolveForge: () => ({ listIssues: async () => openIssues }) as any,
+    });
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 5,
+      parentTitle: "Maybe closed",
+      completedAt: 1,
+      childrenJson: "[]",
+    });
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed?repo=${encRepo(repoDir)}`),
+    );
+    const body = await res.json();
+    // not confidently closed → retained, no clear event
+    expect(body.map((e: any) => e.parentIssueNumber)).toEqual([5]);
+    expect(cleared).toEqual([]);
+  });
+
+  test("backfill: idle all-merged epic with no record → recorded + returned", async () => {
+    const { app, store } = completedHarness({
+      resolveForge: () =>
+        ({
+          listIssues: async () => [
+            { number: 88, title: "Epic", body: "", url: "", labels: [], createdAt: 0 },
+          ],
+        }) as any,
+      drainOverrides: {
+        buildEpic: async (repoPath, run) => ({
+          ...makeEpic(repoPath, run.parentIssueNumber, run),
+          children: [mergedChild(1), mergedChild(2)],
+        }),
+      },
+    });
+    store.setEpicRun({ repoPath: repoDir, parentIssueNumber: 88, mode: "auto", status: "idle" });
+    store.recordEpicIntegrated(repoDir, 88, 1, { number: 11, url: "pr11" });
+    store.recordEpicIntegrated(repoDir, 88, 2, { number: 22, url: "pr22" });
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed?repo=${encRepo(repoDir)}`),
+    );
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].parentIssueNumber).toBe(88);
+    expect(body[0].children).toHaveLength(2);
+    expect(body[0].children.every((c: any) => c.integrated)).toBe(true);
+    // persisted
+    expect(store.listEpicCompleted(repoDir)).toHaveLength(1);
+  });
+
+  test("backfill: NOT-all-merged epic → no record created (skip logged)", async () => {
+    const { app, store } = completedHarness({
+      resolveForge: () =>
+        ({
+          listIssues: async () => [
+            { number: 88, title: "Epic", body: "", url: "", labels: [], createdAt: 0 },
+          ],
+        }) as any,
+      drainOverrides: {
+        buildEpic: async (repoPath, run) => ({
+          ...makeEpic(repoPath, run.parentIssueNumber, run),
+          children: [
+            mergedChild(1),
+            { ...mergedChild(2), state: "in-review", integrationMerged: false },
+          ],
+        }),
+      },
+    });
+    store.setEpicRun({ repoPath: repoDir, parentIssueNumber: 88, mode: "auto", status: "idle" });
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed?repo=${encRepo(repoDir)}`),
+    );
+    const body = await res.json();
+    expect(body).toEqual([]);
+    expect(store.listEpicCompleted(repoDir)).toHaveLength(0);
+  });
+
+  test("backfill: dismissed idle run is NOT re-backfilled (buildEpic not re-called)", async () => {
+    let buildEpicCalls = 0;
+    const { app, store } = completedHarness({
+      // open set includes the parent → not auto-dismissed by the open-set sweep; the dismissed
+      // row must be honored by the hasEpicCompleted pre-check, not by absence from the open set.
+      resolveForge: () =>
+        ({
+          listIssues: async () => [
+            { number: 88, title: "Epic", body: "", url: "", labels: [], createdAt: 0 },
+          ],
+        }) as any,
+      drainOverrides: {
+        buildEpic: async (repoPath, run) => {
+          buildEpicCalls++;
+          return {
+            ...makeEpic(repoPath, run.parentIssueNumber, run),
+            children: [mergedChild(1), mergedChild(2)],
+          };
+        },
+      },
+    });
+    // Record + dismiss the completed epic, leaving an idle run for the same parent.
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 88,
+      parentTitle: "Epic",
+      completedAt: 1,
+      childrenJson: "[]",
+    });
+    store.dismissEpicCompleted(repoDir, 88);
+    store.setEpicRun({ repoPath: repoDir, parentIssueNumber: 88, mode: "auto", status: "idle" });
+
+    const res1 = await app.fetch(
+      new Request(`http://x/api/epics/completed?repo=${encRepo(repoDir)}`),
+    );
+    expect(res1.status).toBe(200);
+    expect(await res1.json()).toEqual([]); // dismissed → stays absent from response
+    const res2 = await app.fetch(
+      new Request(`http://x/api/epics/completed?repo=${encRepo(repoDir)}`),
+    );
+    expect(await res2.json()).toEqual([]);
+    // hasEpicCompleted (dismissedAt-agnostic) short-circuits the backfill → buildEpic never fires.
+    expect(buildEpicCalls).toBe(0);
+  });
+
+  test("forge throw during reconcile → still 200 with DB rows (fail-safe)", async () => {
+    const { app, store } = completedHarness({
+      resolveForge: () =>
+        ({
+          listIssues: async () => {
+            throw new Error("boom");
+          },
+        }) as any,
+    });
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 5,
+      parentTitle: "Persisted",
+      completedAt: 1,
+      childrenJson: "[]",
+    });
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed?repo=${encRepo(repoDir)}`),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].parentIssueNumber).toBe(5);
+  });
+
+  test("no drain → still serves DB rows + auto-dismiss (backfill skipped)", async () => {
+    const { app, store } = completedHarness({
+      drain: null,
+      resolveForge: () => ({ listIssues: async () => [] }) as any,
+    });
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 5,
+      parentTitle: "Closed",
+      completedAt: 1,
+      childrenJson: "[]",
+    });
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed?repo=${encRepo(repoDir)}`),
+    );
+    expect(res.status).toBe(200);
+    // open set empty → #5 confidently closed → auto-dismissed even without drain
+    expect(await res.json()).toEqual([]);
+  });
+});
+
+describe("POST /api/epics/completed/dismiss", () => {
+  test("dismiss hides row from subsequent GET + emits event", async () => {
+    const { app, store, cleared } = completedHarness({ resolveForge: () => null });
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 5,
+      parentTitle: "X",
+      completedAt: 1,
+      childrenJson: "[]",
+    });
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed/dismiss`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 5 }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(cleared).toEqual([{ repoPath: repoDir, parentIssueNumber: 5 }]);
+    const get = await app.fetch(
+      new Request(`http://x/api/epics/completed?repo=${encRepo(repoDir)}`),
+    );
+    expect(await get.json()).toEqual([]);
+  });
+
+  test("invalid repo → 400", async () => {
+    const { app } = completedHarness();
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed/dismiss`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: "/nope/not/here", parent: 5 }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("invalid parent → 400", async () => {
+    const { app } = completedHarness();
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed/dismiss`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: -1 }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("missing body (no repo) → 400", async () => {
+    const { app } = completedHarness();
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed/dismiss`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ parent: 5 }),
+      }),
+    );
+    expect(res.status).toBe(400);
   });
 });
 

--- a/test/store-epic-completed.test.ts
+++ b/test/store-epic-completed.test.ts
@@ -150,3 +150,15 @@ test("dismissedAt IS NULL filter — dismissed epics never appear in list", () =
   expect(list).toHaveLength(1);
   expect(list[0]!.parentIssueNumber).toBe(2);
 });
+
+test("listEpicRuns returns all persisted epic_run rows", () => {
+  const s = new SessionStore(":memory:");
+  expect(s.listEpicRuns()).toEqual([]);
+  s.setEpicRun({ repoPath: "/a", parentIssueNumber: 1, mode: "auto", status: "idle" });
+  s.setEpicRun({ repoPath: "/b", parentIssueNumber: 2, mode: "attended", status: "running" });
+  const runs = s.listEpicRuns().sort((x, y) => x.repoPath.localeCompare(y.repoPath));
+  expect(runs).toEqual([
+    { repoPath: "/a", parentIssueNumber: 1, mode: "auto", status: "idle" },
+    { repoPath: "/b", parentIssueNumber: 2, mode: "attended", status: "running" },
+  ]);
+});

--- a/test/store-epic-completed.test.ts
+++ b/test/store-epic-completed.test.ts
@@ -1,0 +1,152 @@
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+
+test("recordEpicCompleted + listEpicCompleted basic round-trip", () => {
+  const s = new SessionStore(":memory:");
+  expect(s.listEpicCompleted()).toEqual([]);
+
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "Epic Alpha",
+    completedAt: 1000,
+    childrenJson: "[]",
+  });
+
+  const list = s.listEpicCompleted();
+  expect(list).toHaveLength(1);
+  expect(list[0]!.repoPath).toBe("/r");
+  expect(list[0]!.parentIssueNumber).toBe(10);
+  expect(list[0]!.parentTitle).toBe("Epic Alpha");
+  expect(list[0]!.completedAt).toBe(1000);
+  expect(list[0]!.childrenJson).toBe("[]");
+});
+
+test("listEpicCompleted filters by repoPath", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/a",
+    parentIssueNumber: 1,
+    parentTitle: "A",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  s.recordEpicCompleted({
+    repoPath: "/b",
+    parentIssueNumber: 2,
+    parentTitle: "B",
+    completedAt: 2,
+    childrenJson: "[]",
+  });
+
+  expect(s.listEpicCompleted("/a")).toHaveLength(1);
+  expect(s.listEpicCompleted("/a")[0]!.repoPath).toBe("/a");
+  expect(s.listEpicCompleted("/b")).toHaveLength(1);
+  expect(s.listEpicCompleted()).toHaveLength(2);
+});
+
+test("listEpicCompleted orders by completedAt DESC", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 1,
+    parentTitle: "Old",
+    completedAt: 100,
+    childrenJson: "[]",
+  });
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 2,
+    parentTitle: "New",
+    completedAt: 200,
+    childrenJson: "[]",
+  });
+
+  const list = s.listEpicCompleted("/r");
+  expect(list[0]!.completedAt).toBe(200);
+  expect(list[1]!.completedAt).toBe(100);
+});
+
+test("dismissEpicCompleted removes it from listEpicCompleted", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  expect(s.listEpicCompleted()).toHaveLength(1);
+
+  s.dismissEpicCompleted("/r", 10);
+  expect(s.listEpicCompleted()).toHaveLength(0);
+});
+
+test("re-recordEpicCompleted after dismiss does NOT resurrect (stays dismissed)", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  s.dismissEpicCompleted("/r", 10);
+  expect(s.listEpicCompleted()).toHaveLength(0);
+
+  // re-record should not resurrect
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E updated",
+    completedAt: 999,
+    childrenJson: "[1]",
+  });
+  expect(s.listEpicCompleted()).toHaveLength(0);
+});
+
+test("recordEpicCompleted upsert refreshes parentTitle/completedAt/childrenJson", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "Old",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "New",
+    completedAt: 999,
+    childrenJson: "[1,2]",
+  });
+
+  const list = s.listEpicCompleted();
+  expect(list[0]!.parentTitle).toBe("New");
+  expect(list[0]!.completedAt).toBe(999);
+  expect(list[0]!.childrenJson).toBe("[1,2]");
+});
+
+test("dismissedAt IS NULL filter — dismissed epics never appear in list", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 1,
+    parentTitle: "A",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 2,
+    parentTitle: "B",
+    completedAt: 2,
+    childrenJson: "[]",
+  });
+  s.dismissEpicCompleted("/r", 1);
+
+  const list = s.listEpicCompleted("/r");
+  expect(list).toHaveLength(1);
+  expect(list[0]!.parentIssueNumber).toBe(2);
+});

--- a/test/store-epic-integrated.test.ts
+++ b/test/store-epic-integrated.test.ts
@@ -11,3 +11,68 @@ test("records and lists integration-merged children per epic parent", () => {
   expect([...s.listEpicIntegrated("/r", 999)]).toEqual([]); // scoped by parent
   expect([...s.listEpicIntegrated("/other", 327)]).toEqual([]); // scoped by repo
 });
+
+test("recordEpicIntegrated persists prNumber/prUrl; listEpicIntegratedDetails returns them", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicIntegrated("/r", 100, 10, { number: 42, url: "https://github.com/r/pull/42" });
+  const details = s.listEpicIntegratedDetails("/r", 100);
+  expect(details).toHaveLength(1);
+  expect(details[0]!.childNumber).toBe(10);
+  expect(details[0]!.prNumber).toBe(42);
+  expect(details[0]!.prUrl).toBe("https://github.com/r/pull/42");
+  expect(typeof details[0]!.mergedAt).toBe("number");
+});
+
+test("re-observe with no pr does not clobber previously-recorded prNumber/prUrl", () => {
+  const s = new SessionStore(":memory:");
+  const before = Date.now();
+  s.recordEpicIntegrated("/r", 100, 10, { number: 42, url: "https://github.com/r/pull/42" });
+  const firstDetails = s.listEpicIntegratedDetails("/r", 100);
+  const firstMergedAt = firstDetails[0]!.mergedAt;
+  expect(firstMergedAt).toBeGreaterThanOrEqual(before);
+
+  // re-observe without PR — should not clobber
+  s.recordEpicIntegrated("/r", 100, 10);
+  const details = s.listEpicIntegratedDetails("/r", 100);
+  expect(details[0]!.prNumber).toBe(42);
+  expect(details[0]!.prUrl).toBe("https://github.com/r/pull/42");
+  // createdAt/mergedAt must be preserved (first observation wins)
+  expect(details[0]!.mergedAt).toBe(firstMergedAt);
+});
+
+test("re-observe with empty url does not clobber previously-recorded prUrl", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicIntegrated("/r", 100, 10, { number: 42, url: "https://github.com/r/pull/42" });
+  // re-observe with a pr carrying empty url
+  s.recordEpicIntegrated("/r", 100, 10, { number: 42, url: "" });
+  const details = s.listEpicIntegratedDetails("/r", 100);
+  expect(details[0]!.prUrl).toBe("https://github.com/r/pull/42");
+});
+
+test("first observation stamps createdAt; later conflicting insert preserves it", () => {
+  const s = new SessionStore(":memory:");
+  const t0 = Date.now();
+  s.recordEpicIntegrated("/r", 100, 10);
+  const first = s.listEpicIntegratedDetails("/r", 100)[0]!;
+  expect(first.mergedAt).toBeGreaterThanOrEqual(t0);
+  // wait a tick then re-record — createdAt must not change, but PR columns must fill in
+  s.recordEpicIntegrated("/r", 100, 10, { number: 99, url: "https://github.com/r/pull/99" });
+  const after = s.listEpicIntegratedDetails("/r", 100)[0]!;
+  expect(after.mergedAt).toBe(first.mergedAt);
+  // COALESCE null→value: the second call must have filled in prNumber + prUrl
+  expect(after.prNumber).toBe(99);
+  expect(after.prUrl).toBe("https://github.com/r/pull/99");
+});
+
+test("3-arg recordEpicIntegrated + listEpicIntegrated Set behavior unchanged", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicIntegrated("/r", 200, 11);
+  s.recordEpicIntegrated("/r", 200, 12);
+  s.recordEpicIntegrated("/r", 200, 11); // idempotent
+  const set = s.listEpicIntegrated("/r", 200);
+  expect(set instanceof Set).toBe(true);
+  expect([...set].sort((a, b) => a - b)).toEqual([11, 12]);
+  const details = s.listEpicIntegratedDetails("/r", 200);
+  expect(details[0]!.prNumber).toBeNull();
+  expect(details[0]!.prUrl).toBeNull();
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1210,5 +1210,6 @@
   "feat_research_body": "Starte eine Rechercheaufgabe im Dialog „Neue Aufgabe“: Ein betreuter Agent führt Web-Recherche mit Sub-Agenten durch und liefert einen Bericht-PR oder öffnet ein GitHub-Issue. Rechercheaufgaben öffnen niemals einen Code-PR.",
   "herd_research_filter": "⬡ Recherche",
   "herd_research_title": "Nur Rechercheaufgaben anzeigen",
-  "herd_research_empty": "Keine Rechercheaufgaben."
+  "herd_research_empty": "Keine Rechercheaufgaben.",
+  "completed_epic_toast": "Epic #{number} abgeschlossen — {count} Teil-Issues gelandet"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1211,5 +1211,16 @@
   "herd_research_filter": "⬡ Recherche",
   "herd_research_title": "Nur Rechercheaufgaben anzeigen",
   "herd_research_empty": "Keine Rechercheaufgaben.",
-  "completed_epic_toast": "Epic #{number} abgeschlossen — {count} Teil-Issues gelandet"
+  "completed_epic_toast": "Epic #{number} abgeschlossen — {count} Teil-Issues gelandet",
+  "integrated_epics_band_title": "Integrierte Epics ({count})",
+  "integrated_epics_chip": "INTEGRIERT {merged}/{total}",
+  "integrated_epics_finished_ago": "vor {ago} abgeschlossen",
+  "integrated_epics_pr_ref": "PR #{number}",
+  "integrated_epics_pr_ref_nonum": "PR",
+  "integrated_epics_child_merged_ago": "vor {ago} gemergt",
+  "integrated_epics_child_closed": "geschlossen",
+  "integrated_epics_dismiss": "Verwerfen",
+  "integrated_epics_awaiting_landing": "Eltern-#{number} noch offen · wartet auf Landung",
+  "integrated_epics_expand_aria": "Integriertes Epic #{number} ausklappen",
+  "integrated_epics_collapse_aria": "Integriertes Epic #{number} einklappen"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1222,5 +1222,8 @@
   "integrated_epics_dismiss": "Verwerfen",
   "integrated_epics_awaiting_landing": "Eltern-#{number} noch offen · wartet auf Landung",
   "integrated_epics_expand_aria": "Integriertes Epic #{number} ausklappen",
-  "integrated_epics_collapse_aria": "Integriertes Epic #{number} einklappen"
+  "integrated_epics_collapse_aria": "Integriertes Epic #{number} einklappen",
+  "integrated_epics_dismiss_failed": "Epic konnte nicht entfernt werden — bitte erneut versuchen",
+  "feat_integrated_epics_title": "Abgeschlossene Epics bleiben sichtbar",
+  "feat_integrated_epics_body": "Wenn alle Sub-Issues eines Epics gelandet sind, verschwindet es nicht länger — ein neues Band 'Integrierte Epics' am unteren Rand der Herd behält es, samt PR jedes Kind-Issues und einem Ein-Klick-Verwerfen, sobald du nachgefasst hast."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1211,5 +1211,16 @@
   "herd_research_filter": "⬡ Research",
   "herd_research_title": "Show only research tasks",
   "herd_research_empty": "No research tasks.",
-  "completed_epic_toast": "Epic #{number} complete — {count} sub-issues landed"
+  "completed_epic_toast": "Epic #{number} complete — {count} sub-issues landed",
+  "integrated_epics_band_title": "Integrated epics ({count})",
+  "integrated_epics_chip": "INTEGRATED {merged}/{total}",
+  "integrated_epics_finished_ago": "finished {ago} ago",
+  "integrated_epics_pr_ref": "PR #{number}",
+  "integrated_epics_pr_ref_nonum": "PR",
+  "integrated_epics_child_merged_ago": "merged {ago} ago",
+  "integrated_epics_child_closed": "closed",
+  "integrated_epics_dismiss": "Dismiss",
+  "integrated_epics_awaiting_landing": "parent #{number} still open · awaiting landing",
+  "integrated_epics_expand_aria": "Expand integrated epic #{number}",
+  "integrated_epics_collapse_aria": "Collapse integrated epic #{number}"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1222,5 +1222,8 @@
   "integrated_epics_dismiss": "Dismiss",
   "integrated_epics_awaiting_landing": "parent #{number} still open · awaiting landing",
   "integrated_epics_expand_aria": "Expand integrated epic #{number}",
-  "integrated_epics_collapse_aria": "Collapse integrated epic #{number}"
+  "integrated_epics_collapse_aria": "Collapse integrated epic #{number}",
+  "integrated_epics_dismiss_failed": "Couldn't dismiss the epic — try again",
+  "feat_integrated_epics_title": "Completed epics stay visible",
+  "feat_integrated_epics_body": "When an epic's sub-issues all land, it no longer vanishes — a new 'Integrated epics' band at the bottom of the Herd keeps it, with each child's PR and a one-click dismiss once you've followed up."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1210,5 +1210,6 @@
   "feat_research_body": "Start a Research task from New Task: an attended agent does web research with sub-agents and delivers a report PR or opens a GitHub issue. Research never opens a code PR.",
   "herd_research_filter": "⬡ Research",
   "herd_research_title": "Show only research tasks",
-  "herd_research_empty": "No research tasks."
+  "herd_research_empty": "No research tasks.",
+  "completed_epic_toast": "Epic #{number} complete — {count} sub-issues landed"
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -45,6 +45,7 @@ import type {
   EpicRun,
   EpicSummary,
   Recap,
+  CompletedEpic,
 } from "./types";
 import { m } from "$lib/paraglide/messages";
 
@@ -1122,4 +1123,22 @@ export async function importEpic(
   });
   if (!r.ok) throw await failed(r, "import epic");
   return r.json();
+}
+
+export async function getCompletedEpics(repoPath?: string): Promise<CompletedEpic[]> {
+  return getJson(
+    `/api/epics/completed${repoPath ? `?repo=${encodeURIComponent(repoPath)}` : ""}`,
+    "get completed epics",
+  );
+}
+
+export async function dismissCompletedEpic(
+  repoPath: string,
+  parent: number,
+): Promise<{ ok: boolean }> {
+  return postJson(
+    "/api/epics/completed/dismiss",
+    { repo: repoPath, parent },
+    "dismiss completed epic",
+  );
 }

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import type { Session, GitState, SessionActivity, Epic } from "$lib/types";
+  import type { Session, GitState, SessionActivity, Epic, CompletedEpic } from "$lib/types";
   import UnitRow from "./UnitRow.svelte";
   import EmptyHerd from "./EmptyHerd.svelte";
   import EpicGroupHeader from "./EpicGroupHeader.svelte";
+  import IntegratedEpicsBand from "./IntegratedEpicsBand.svelte";
   import { partitionSessions, shownSessions, type HerdFilter } from "./herd-partition";
   import { groupSessionsByEpic } from "./epic-grouping";
   import { collectReadyPrs } from "./merge-train";
@@ -43,6 +44,8 @@
     workingBlocked = {},
     collapsible = false,
     oncollapse = undefined,
+    completedEpics = [],
+    ondismissepic = undefined,
   }: {
     sessions: Session[];
     selectedId: string | null;
@@ -113,6 +116,11 @@
     // called when the collapse arrow is clicked; parent drives the actual
     // collapse so the button is purely a signal
     oncollapse?: () => void;
+    // fully-integrated epics for this repo scope — rendered as the bottom
+    // "integrated epics" band (self-hides when empty)
+    completedEpics?: CompletedEpic[];
+    // dismiss a completed epic from the band; page owns the optimistic remove + reconcile
+    ondismissepic?: (repoPath: string, parent: number) => void;
   } = $props();
 
   // a critic post-PR review or a pre-execution plan-gate review currently in flight —
@@ -610,6 +618,7 @@
         {/each}
       {/if}
     {/if}
+    <IntegratedEpicsBand epics={completedEpics} ondismiss={ondismissepic ?? (() => {})} {nowMs} />
   </div>
 </div>
 

--- a/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { CompletedEpic, CompletedEpicChild } from "$lib/types";
+
+const { default: IntegratedEpicRow } = await import("./IntegratedEpicRow.svelte");
+
+const child = (p: Partial<CompletedEpicChild> = {}): CompletedEpicChild => ({
+  number: 11,
+  title: "child task",
+  url: "https://github.com/o/r/issues/11",
+  prNumber: 101,
+  prUrl: "https://github.com/o/r/pull/101",
+  mergedAt: Date.now() - 60_000,
+  integrated: true,
+  ...p,
+});
+
+const epic = (children: CompletedEpicChild[], p: Partial<CompletedEpic> = {}): CompletedEpic => ({
+  repoPath: "/home/me/work/myrepo",
+  parentIssueNumber: 327,
+  parentTitle: "Big epic",
+  completedAt: Date.now() - 120_000,
+  children,
+  ...p,
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("IntegratedEpicRow", () => {
+  it("collapsed shows the slate INTEGRATED n/n chip", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 }), child({ number: 2 })]),
+      ondismiss: vi.fn(),
+    });
+    await expect.element(page.getByText("INTEGRATED 2/2")).toBeInTheDocument();
+    const chip = document.querySelector(".chip") as HTMLElement;
+    expect(chip.classList.contains("chip-done")).toBe(true);
+  });
+
+  it("expanding a mixed epic shows a PR link for integrated + issue link & closed marker for out-of-band", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([
+        child({
+          number: 1,
+          prNumber: 501,
+          prUrl: "https://github.com/o/r/pull/501",
+          integrated: true,
+        }),
+        child({
+          number: 2,
+          prNumber: null,
+          prUrl: null,
+          mergedAt: null,
+          integrated: false,
+          url: "https://github.com/o/r/issues/2",
+        }),
+      ]),
+      ondismiss: vi.fn(),
+    });
+    // mixed epic: merged counts only integrated children, total counts all → 1/2 (not 2/2)
+    await expect.element(page.getByText("INTEGRATED 1/2")).toBeInTheDocument();
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const prLink = await vi.waitFor(() => {
+      const a = [...document.querySelectorAll("a.ref")].find((el) =>
+        el.textContent?.includes("PR #501"),
+      ) as HTMLAnchorElement | undefined;
+      if (!a) throw new Error("no pr link yet");
+      return a;
+    });
+    expect(prLink.getAttribute("href")).toBe("https://github.com/o/r/pull/501");
+
+    const issueLink = [...document.querySelectorAll("a.ref")].find(
+      (el) => el.textContent?.trim() === "#2",
+    ) as HTMLAnchorElement;
+    expect(issueLink.getAttribute("href")).toBe("https://github.com/o/r/issues/2");
+    await expect.element(page.getByText("closed")).toBeInTheDocument();
+  });
+
+  it("integrated child with prUrl but null prNumber shows a number-less PR label (not the issue number)", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([
+        child({
+          number: 77,
+          prNumber: null,
+          prUrl: "https://github.com/o/r/pull/abc",
+          integrated: true,
+        }),
+      ]),
+      ondismiss: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const prLink = await vi.waitFor(() => {
+      const a = document.querySelector("a.ref") as HTMLAnchorElement | null;
+      if (!a) throw new Error("no pr link yet");
+      return a;
+    });
+    expect(prLink.getAttribute("href")).toBe("https://github.com/o/r/pull/abc");
+    expect(prLink.textContent?.trim()).toBe("PR");
+    // must NOT mislabel with the issue number
+    expect(prLink.textContent).not.toContain("77");
+  });
+
+  it("clicking Dismiss calls ondismiss(repoPath, parentIssueNumber)", async () => {
+    const ondismiss = vi.fn();
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], { repoPath: "/x/y/zrepo", parentIssueNumber: 42 }),
+      ondismiss,
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+    const btn = await vi.waitFor(() => {
+      const b = document.querySelector(".actions .gbtn") as HTMLButtonElement | null;
+      if (!b) throw new Error("no dismiss yet");
+      return b;
+    });
+    btn.click();
+    expect(ondismiss).toHaveBeenCalledTimes(1);
+    expect(ondismiss).toHaveBeenCalledWith("/x/y/zrepo", 42);
+  });
+});

--- a/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
@@ -106,6 +106,34 @@ describe("IntegratedEpicRow", () => {
     expect(prLink.textContent).not.toContain("77");
   });
 
+  it("integrated child with empty prUrl renders the PR ref as text + merged-ago, no closed marker", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([
+        child({
+          number: 33,
+          prNumber: 808,
+          prUrl: "", // persisted empty when prCache lacked the URL at merge time
+          mergedAt: Date.now() - 90_000,
+          integrated: true,
+        }),
+      ]),
+      ondismiss: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    // PR ref renders as text (no link) — still labelled "PR #808"
+    const ref = await vi.waitFor(() => {
+      const el = document.querySelector(".child .ref") as HTMLElement | null;
+      if (!el) throw new Error("no ref yet");
+      return el;
+    });
+    expect(ref.tagName).toBe("SPAN"); // text, not <a>
+    expect(ref.textContent).toContain("PR #808");
+    // shows the merged-ago line and NOT the closed marker
+    expect(document.querySelector(".child .child-ago")).not.toBeNull();
+    expect(document.querySelector(".child .closed")).toBeNull();
+  });
+
   it("clicking Dismiss calls ondismiss(repoPath, parentIssueNumber)", async () => {
     const ondismiss = vi.fn();
     render(IntegratedEpicRow, {

--- a/ui/src/lib/components/IntegratedEpicRow.svelte
+++ b/ui/src/lib/components/IntegratedEpicRow.svelte
@@ -56,13 +56,21 @@
     <ul class="children">
       {#each epic.children as c (c.number)}
         <li class="child">
-          {#if c.integrated && c.prUrl}
-            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
-            <a class="ref" href={c.prUrl} target="_blank" rel="noopener noreferrer"
-              >{c.prNumber != null
-                ? m.integrated_epics_pr_ref({ number: c.prNumber })
-                : m.integrated_epics_pr_ref_nonum()}</a
-            >
+          {#if c.integrated}
+            {#if c.prUrl}
+              <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+              <a class="ref" href={c.prUrl} target="_blank" rel="noopener noreferrer"
+                >{c.prNumber != null
+                  ? m.integrated_epics_pr_ref({ number: c.prNumber })
+                  : m.integrated_epics_pr_ref_nonum()}</a
+              >
+            {:else if c.prNumber != null}
+              <!-- integrated but the PR url was empty at merge time → ref as plain text -->
+              <span class="ref">{m.integrated_epics_pr_ref({ number: c.prNumber })}</span>
+            {:else}
+              <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+              <a class="ref" href={c.url} target="_blank" rel="noopener noreferrer">#{c.number}</a>
+            {/if}
             <span class="title">{c.title}</span>
             <span class="child-ago"
               >{m.integrated_epics_child_merged_ago({

--- a/ui/src/lib/components/IntegratedEpicRow.svelte
+++ b/ui/src/lib/components/IntegratedEpicRow.svelte
@@ -1,0 +1,268 @@
+<script lang="ts">
+  import type { CompletedEpic } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { formatAgo } from "$lib/format";
+
+  let {
+    epic,
+    ondismiss,
+    nowMs = Date.now(),
+  }: {
+    epic: CompletedEpic;
+    ondismiss: (repoPath: string, parent: number) => void;
+    nowMs?: number;
+  } = $props();
+
+  let open = $state(false);
+
+  // repo basename — last path segment (e.g. "community-map")
+  const repoName = $derived(epic.repoPath.split("/").filter(Boolean).at(-1) ?? epic.repoPath);
+
+  // merged = count of shepherd-integrated children; total = all done children
+  const total = $derived(epic.children.length);
+  const merged = $derived(epic.children.filter((c) => c.integrated).length);
+
+  // Parent issue URL derived from any child's issue URL: children are all issues in
+  // the same repo (".../issues/<n>"), so swapping the trailing /<n> for the parent
+  // number targets the parent issue. Null when no child carries a url → plain text.
+  const parentUrl = $derived.by(() => {
+    const ref = epic.children.find((c) => c.url)?.url;
+    if (!ref) return null;
+    return ref.replace(/\/\d+(?=\/?$)/, `/${epic.parentIssueNumber}`);
+  });
+</script>
+
+<div class="row" role="region" aria-label={epic.parentTitle}>
+  <button
+    type="button"
+    class="row-head"
+    aria-expanded={open}
+    aria-label={open
+      ? m.integrated_epics_collapse_aria({ number: epic.parentIssueNumber })
+      : m.integrated_epics_expand_aria({ number: epic.parentIssueNumber })}
+    onclick={() => (open = !open)}
+  >
+    <span class="chev" class:collapsed={!open} aria-hidden="true">▾</span>
+    <span class="repo" title={repoName}>{repoName}</span>
+    <span class="title">{epic.parentTitle}</span>
+    <span class="num">#{epic.parentIssueNumber}</span>
+    <span class="chip chip-done">{m.integrated_epics_chip({ merged, total })}</span>
+    <span class="ago"
+      >{m.integrated_epics_finished_ago({ ago: formatAgo(nowMs - epic.completedAt) })}</span
+    >
+  </button>
+
+  {#if open}
+    <ul class="children">
+      {#each epic.children as c (c.number)}
+        <li class="child">
+          {#if c.integrated && c.prUrl}
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+            <a class="ref" href={c.prUrl} target="_blank" rel="noopener noreferrer"
+              >{c.prNumber != null
+                ? m.integrated_epics_pr_ref({ number: c.prNumber })
+                : m.integrated_epics_pr_ref_nonum()}</a
+            >
+            <span class="title">{c.title}</span>
+            <span class="child-ago"
+              >{m.integrated_epics_child_merged_ago({
+                ago: formatAgo(nowMs - (c.mergedAt ?? epic.completedAt)),
+              })}</span
+            >
+          {:else}
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+            <a class="ref" href={c.url} target="_blank" rel="noopener noreferrer">#{c.number}</a>
+            <span class="title">{c.title}</span>
+            <span class="closed">{m.integrated_epics_child_closed()}</span>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+
+    <div class="actions">
+      <button
+        class="gbtn"
+        type="button"
+        title={m.integrated_epics_dismiss()}
+        onclick={() => ondismiss(epic.repoPath, epic.parentIssueNumber)}
+      >
+        {m.integrated_epics_dismiss()}
+      </button>
+      {#if parentUrl}
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+        <a class="awaiting" href={parentUrl} target="_blank" rel="noopener noreferrer"
+          >{m.integrated_epics_awaiting_landing({ number: epic.parentIssueNumber })}</a
+        >
+      {:else}
+        <span class="awaiting"
+          >{m.integrated_epics_awaiting_landing({ number: epic.parentIssueNumber })}</span
+        >
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+  }
+
+  /* Collapsed header — quiet/slate, matching the done-state recipe. */
+  .row-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    border: 0;
+    background: none;
+    font: inherit;
+    color: var(--status-done);
+    text-align: left;
+    cursor: pointer;
+    padding: 4px 8px;
+  }
+  .row-head:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+
+  .chev {
+    flex: none;
+    transition: transform 0.12s ease;
+  }
+  .chev.collapsed {
+    transform: rotate(-90deg);
+  }
+
+  .repo {
+    flex: 0 1 auto;
+    min-width: 0;
+    color: var(--color-muted);
+    max-width: 16ch;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .title {
+    flex: 1;
+    min-width: 0;
+    color: var(--color-ink);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .num {
+    flex: none;
+    color: var(--color-muted);
+  }
+
+  .ago {
+    flex: none;
+    color: var(--color-faint);
+    font-size: var(--fs-micro);
+  }
+
+  /* Slate "done" chip — NEVER green; mirrors EpicPanel's .chip-done recipe. */
+  .chip {
+    flex: none;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 1px 5px;
+    border-radius: 2px;
+    white-space: nowrap;
+  }
+  .chip-done {
+    color: var(--status-done);
+    background: color-mix(in oklab, var(--status-done) 12%, transparent);
+  }
+
+  /* Expanded rollup. */
+  .children {
+    margin: 0;
+    padding: 0 8px;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .child {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+  .ref {
+    flex: none;
+    color: var(--color-muted);
+    font-size: var(--fs-micro);
+    text-decoration: none;
+  }
+  .ref:hover {
+    color: var(--color-ink-bright);
+    text-decoration: underline;
+  }
+  .child-ago {
+    flex: none;
+    color: var(--color-faint);
+    font-size: var(--fs-micro);
+  }
+  .closed {
+    flex: none;
+    color: var(--color-faint);
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding: 2px 8px 6px;
+  }
+  /* Quiet/muted "parent still open" note. */
+  .awaiting {
+    color: var(--color-faint);
+    font-size: var(--fs-micro);
+    text-decoration: none;
+  }
+  a.awaiting:hover {
+    color: var(--color-muted);
+    text-decoration: underline;
+  }
+
+  /* Canonical .gbtn recipe (scoped per-component; see /design-system). */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+</style>

--- a/ui/src/lib/components/IntegratedEpicsBand.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicsBand.browser.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { CompletedEpic } from "$lib/types";
+
+const { default: IntegratedEpicsBand } = await import("./IntegratedEpicsBand.svelte");
+
+const epic = (n: number): CompletedEpic => ({
+  repoPath: `/home/me/work/repo${n}`,
+  parentIssueNumber: 300 + n,
+  parentTitle: `Epic ${n}`,
+  completedAt: Date.now() - 60_000,
+  children: [
+    {
+      number: n * 10,
+      title: "c",
+      url: `https://github.com/o/r/issues/${n * 10}`,
+      prNumber: n * 100,
+      prUrl: `https://github.com/o/r/pull/${n * 100}`,
+      mergedAt: Date.now() - 30_000,
+      integrated: true,
+    },
+  ],
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("IntegratedEpicsBand", () => {
+  it("renders nothing when epics is empty", async () => {
+    render(IntegratedEpicsBand, { epics: [], ondismiss: vi.fn() });
+    expect(document.querySelector(".band")).toBeNull();
+    expect(document.querySelector(".band-head")).toBeNull();
+  });
+
+  it("header shows the count and expanding reveals one row per epic", async () => {
+    render(IntegratedEpicsBand, { epics: [epic(1), epic(2)], ondismiss: vi.fn() });
+    await expect.element(page.getByText("Integrated epics (2)")).toBeInTheDocument();
+    // collapsed by default → no rows
+    expect(document.querySelectorAll(".rows .row").length).toBe(0);
+    (document.querySelector(".band-head") as HTMLButtonElement).click();
+    const rows = await vi.waitFor(() => {
+      const r = document.querySelectorAll(".rows .row");
+      if (r.length !== 2) throw new Error("rows not yet rendered");
+      return r;
+    });
+    expect(rows.length).toBe(2);
+  });
+});

--- a/ui/src/lib/components/IntegratedEpicsBand.svelte
+++ b/ui/src/lib/components/IntegratedEpicsBand.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import type { CompletedEpic } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import IntegratedEpicRow from "./IntegratedEpicRow.svelte";
+
+  let {
+    epics,
+    ondismiss,
+    nowMs = Date.now(),
+  }: {
+    epics: CompletedEpic[];
+    ondismiss: (repoPath: string, parent: number) => void;
+    nowMs?: number;
+  } = $props();
+
+  let collapsed = $state(true);
+
+  const count = $derived(epics.length);
+</script>
+
+{#if epics.length > 0}
+  <section class="band" aria-label={m.integrated_epics_band_title({ count })}>
+    <button
+      type="button"
+      class="band-head"
+      aria-label={m.integrated_epics_band_title({ count })}
+      aria-expanded={!collapsed}
+      onclick={() => (collapsed = !collapsed)}
+    >
+      <span class="chev" class:collapsed aria-hidden="true">▾</span>
+      <span class="label">{m.integrated_epics_band_title({ count })}</span>
+    </button>
+
+    {#if !collapsed}
+      <div class="rows">
+        {#each epics as epic (`${epic.repoPath}#${epic.parentIssueNumber}`)}
+          <IntegratedEpicRow {epic} {ondismiss} {nowMs} />
+        {/each}
+      </div>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  .band {
+    display: flex;
+    flex-direction: column;
+    background: var(--color-panel);
+  }
+
+  /* Slate/quiet section header with a top rule — the done-state look (NOT green). */
+  .band-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 10px 8px 6px;
+    margin-top: 6px;
+    border: 0;
+    border-top: 1px solid color-mix(in srgb, var(--status-done) 30%, var(--color-line));
+    background: none;
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--status-done);
+    text-align: left;
+    cursor: pointer;
+  }
+  .band-head:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+
+  .chev {
+    flex: none;
+    transition: transform 0.12s ease;
+  }
+  .chev.collapsed {
+    transform: rotate(-90deg);
+  }
+
+  .label {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .rows {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-bottom: 4px;
+  }
+</style>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -738,4 +738,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_research_title",
     bodyKey: "feat_research_body",
   },
+  {
+    // No targetId: the band only mounts when there are completed epics, so a
+    // coachmark anchor would usually be absent — surface via the What's-New drawer
+    // only. 1.28.0 is the latest released tag, so this ships in 1.29.0.
+    id: "integrated-epics-band",
+    sinceVersion: "1.29.0",
+    titleKey: "feat_integrated_epics_title",
+    bodyKey: "feat_integrated_epics_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -8,6 +8,7 @@ import type {
   AutoMergeStatus,
   BacklogPayload,
   BuildQueue,
+  CompletedEpic,
   DrainStatus,
   GitState,
   Session,
@@ -717,4 +718,71 @@ test("draftreconcile:status null with no prior error toast is a no-op", () => {
     data: { repoPath: "/r", sessionId: "dr-noop-1", state: null, detail: null },
   });
   expect(toasts.items.filter((x) => x.key?.startsWith("draft-reconcile:"))).toHaveLength(0);
+});
+
+// ── completed epics ───────────────────────────────────────────────────────────
+
+function completedEpic(repoPath: string, parentIssueNumber: number): CompletedEpic {
+  return {
+    repoPath,
+    parentIssueNumber,
+    parentTitle: `Epic #${parentIssueNumber}`,
+    completedAt: Date.now(),
+    children: [
+      {
+        number: 1,
+        title: "sub-issue",
+        url: "https://github.com/x/y/issues/1",
+        prNumber: 2,
+        prUrl: "https://github.com/x/y/pull/2",
+        mergedAt: Date.now(),
+        integrated: true,
+      },
+    ],
+  };
+}
+
+test("epic:completed adds to completedEpics and enqueues a toast", () => {
+  toasts.items = [];
+  const s = new HerdStore();
+  const epic = completedEpic("/r", 42);
+  s.apply({ event: "epic:completed", data: epic });
+  expect(s.completedEpics).toHaveLength(1);
+  expect(s.completedEpics[0].parentIssueNumber).toBe(42);
+  expect(toasts.items.some((t) => t.key === "epic-complete:/r#42")).toBe(true);
+});
+
+test("epic:completed with same key replaces (no duplicates)", () => {
+  const s = new HerdStore();
+  const v1 = completedEpic("/r", 42);
+  const v2 = { ...completedEpic("/r", 42), parentTitle: "Updated title" };
+  s.apply({ event: "epic:completed", data: v1 });
+  s.apply({ event: "epic:completed", data: v2 });
+  expect(s.completedEpics).toHaveLength(1);
+  expect(s.completedEpics[0].parentTitle).toBe("Updated title");
+});
+
+test("epic:completed for different repos/parents appends", () => {
+  const s = new HerdStore();
+  s.apply({ event: "epic:completed", data: completedEpic("/r", 42) });
+  s.apply({ event: "epic:completed", data: completedEpic("/r", 99) });
+  expect(s.completedEpics).toHaveLength(2);
+});
+
+test("epic:completed-cleared removes matching entry and leaves others", () => {
+  const s = new HerdStore();
+  s.apply({ event: "epic:completed", data: completedEpic("/r", 42) });
+  s.apply({ event: "epic:completed", data: completedEpic("/r", 99) });
+  s.apply({ event: "epic:completed-cleared", data: { repoPath: "/r", parentIssueNumber: 42 } });
+  expect(s.completedEpics).toHaveLength(1);
+  expect(s.completedEpics[0].parentIssueNumber).toBe(99);
+});
+
+test("seedCompletedEpics replaces the array", () => {
+  const s = new HerdStore();
+  s.apply({ event: "epic:completed", data: completedEpic("/r", 1) });
+  const fresh = [completedEpic("/r", 7), completedEpic("/r", 8)];
+  s.seedCompletedEpics(fresh);
+  expect(s.completedEpics).toHaveLength(2);
+  expect(s.completedEpics[0].parentIssueNumber).toBe(7);
 });

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -16,6 +16,7 @@ import type {
   AutoMergeStatus,
   BuildQueue,
   Epic,
+  CompletedEpic,
 } from "./types";
 import type { BlockState } from "./triage";
 import { projectIcons } from "./projectIcons.svelte";
@@ -89,6 +90,9 @@ export class HerdStore {
   /** Live epic state keyed by `${repoPath}#${parentIssueNumber}`;
    *  updated in real-time by the `epic:update` WS event. */
   epics = $state<Record<string, Epic>>({});
+  /** Completed-epic records (newest first); bootstrapped via GET /api/epics/completed,
+   *  kept live by the `epic:completed` / `epic:completed-cleared` WS events. */
+  completedEpics = $state<CompletedEpic[]>([]);
   /** true once the user has confirmed an update; cleared by the reload it triggers */
   updating = $state(false);
   /** SHA we booted on; a different `current` after an update means a fresh build is live */
@@ -134,6 +138,10 @@ export class HerdStore {
   /** Upsert an epic — called after GET/PUT /api/epic or on `epic:update` WS push. */
   setEpic(e: Epic) {
     this.epics = { ...this.epics, [`${e.repoPath}#${e.parentIssueNumber}`]: e };
+  }
+  /** Seed (or replace) the completed-epics list after a bootstrap GET. */
+  seedCompletedEpics(list: CompletedEpic[]): void {
+    this.completedEpics = list;
   }
   setUsageLimits(l: UsageLimits) {
     this.usageLimits = l;
@@ -384,6 +392,27 @@ export class HerdStore {
         break;
       case "epic:update":
         this.setEpic(ev.data);
+        break;
+      case "epic:completed": {
+        const key = `${ev.data.repoPath}#${ev.data.parentIssueNumber}`;
+        const filtered = this.completedEpics.filter(
+          (e) => `${e.repoPath}#${e.parentIssueNumber}` !== key,
+        );
+        this.completedEpics = [ev.data, ...filtered];
+        toasts.info(
+          m.completed_epic_toast({
+            number: ev.data.parentIssueNumber,
+            count: ev.data.children.length,
+          }),
+          { key: `epic-complete:${ev.data.repoPath}#${ev.data.parentIssueNumber}` },
+        );
+        break;
+      }
+      case "epic:completed-cleared":
+        this.completedEpics = this.completedEpics.filter(
+          (e) =>
+            e.repoPath !== ev.data.repoPath || e.parentIssueNumber !== ev.data.parentIssueNumber,
+        );
         break;
       case "halt:done":
         // Fleet-wide stop landed: confirm the reach to EVERY connected operator (the

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -365,6 +365,28 @@ export interface EpicSummary {
   source: EpicSource;
 }
 
+/** One child issue in a completed epic record.
+ *  Carried inside CompletedEpic; mirrors the server-side CompletedEpicChild shape. */
+export interface CompletedEpicChild {
+  number: number;
+  title: string;
+  url: string;
+  prNumber: number | null;
+  prUrl: string | null;
+  mergedAt: number | null;
+  integrated: boolean;
+}
+
+/** A durable record of a fully-integrated epic; surfaced in the completed-epics band.
+ *  GET /api/epics/completed payload item; pushed live via the `epic:completed` WS event. */
+export interface CompletedEpic {
+  repoPath: string;
+  parentIssueNumber: number;
+  parentTitle: string;
+  completedAt: number;
+  children: CompletedEpicChild[];
+}
+
 /** One queued backlog issue behind DrainStatus.queued — a row in the queue popover.
  *  GET /api/drain/queue?repo= payload (in drain order). */
 export interface QueuedItem {
@@ -681,6 +703,8 @@ export type WsEvent =
   | { event: "mergetrain:landed"; data: { repoPath: string } }
   | { event: "draftreconcile:status"; data: DraftReconcileStatus }
   | { event: "epic:update"; data: Epic }
+  | { event: "epic:completed"; data: CompletedEpic }
+  | { event: "epic:completed-cleared"; data: { repoPath: string; parentIssueNumber: number } }
   | { event: "session:egress-drop"; data: { id: string; host: string } };
 
 /** Optional override bag for relaunch; absent fields inherit the original session. */

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -33,6 +33,8 @@
     clearMerged,
     getDrain,
     getAutoMerge,
+    getCompletedEpics,
+    dismissCompletedEpic,
     getEpic,
     getDiagnostics,
     halt as apiHalt,
@@ -195,6 +197,12 @@
   });
   // basename of the active filter for the herd's empty-state copy; null when unfiltered
   const repoFilterName = $derived(repoFilter ? basename(repoFilter) : null);
+  // completed epics scoped to the active repo filter (mirrors herdSessions' repo scope)
+  const completedEpicsShown = $derived(
+    repoFilter
+      ? store.completedEpics.filter((e) => e.repoPath === repoFilter)
+      : store.completedEpics,
+  );
 
   // ── Epic grouping (page-owned, shared by the Herd render AND the keynav rail) ──
   // The live ACTIVE epics: one per repo whose drain carries an `epicParent`. Keyed
@@ -888,6 +896,9 @@
     getAutoMerge()
       .then((l) => store.setAutoMerge(l))
       .catch(() => {});
+    getCompletedEpics()
+      .then((l) => store.seedCompletedEpics(l))
+      .catch(() => {});
     steers.load();
     projectIcons.load();
     reviews.load();
@@ -1199,6 +1210,27 @@
     }
   }
 
+  // Dismiss a completed epic from the integrated-epics band. Optimistic remove, then
+  // reconcile by restoring the prior list (fail-closed) on API error. A successful
+  // dismiss also fires an `epic:completed-cleared` WS event that removes it again —
+  // idempotent, harmless.
+  async function onDismissEpic(repoPath: string, parent: number) {
+    const prev = store.completedEpics;
+    store.completedEpics = prev.filter(
+      (e) => !(e.repoPath === repoPath && e.parentIssueNumber === parent),
+    );
+    try {
+      await dismissCompletedEpic(repoPath, parent);
+    } catch {
+      store.completedEpics = prev; // reconcile
+      toasts.info(m.integrated_epics_dismiss_failed(), {
+        alert: true,
+        duration: null,
+        key: `epic-dismiss-fail:${repoPath}#${parent}`,
+      });
+    }
+  }
+
   // Confirmed: clear the dialog state (before the await, so it can't double-submit),
   // then run the bulk archive.
   function confirmClearMerged() {
@@ -1365,6 +1397,8 @@
             flow={true}
             bind:filter={herdFilter}
             workingBlocked={store.workingBlocked}
+            completedEpics={completedEpicsShown}
+            ondismissepic={onDismissEpic}
           />
           {#if store.sessions.length === 0}
             <BacklogView
@@ -1491,6 +1525,8 @@
             workingBlocked={store.workingBlocked}
             collapsible={canCollapse}
             oncollapse={toggleSidebar}
+            completedEpics={completedEpicsShown}
+            ondismissepic={onDismissEpic}
           />
         {/if}
         {#if store.sessions.length === 0}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -40,6 +40,7 @@
     halt as apiHalt,
   } from "$lib/api";
   import type {
+    CompletedEpic,
     DeployState,
     BacklogPayload,
     Issue,
@@ -1211,18 +1212,23 @@
   }
 
   // Dismiss a completed epic from the integrated-epics band. Optimistic remove, then
-  // reconcile by restoring the prior list (fail-closed) on API error. A successful
-  // dismiss also fires an `epic:completed-cleared` WS event that removes it again —
+  // reconcile against the CURRENT state on API error — re-insert only the removed
+  // entry if it isn't already present, never clobber the whole array. Restoring a
+  // captured snapshot wholesale would drop a completed epic that arrived via an
+  // `epic:completed` WS event during the in-flight request. A successful dismiss
+  // also fires an `epic:completed-cleared` WS event that removes it again —
   // idempotent, harmless.
   async function onDismissEpic(repoPath: string, parent: number) {
-    const prev = store.completedEpics;
-    store.completedEpics = prev.filter(
-      (e) => !(e.repoPath === repoPath && e.parentIssueNumber === parent),
-    );
+    const match = (e: CompletedEpic) => e.repoPath === repoPath && e.parentIssueNumber === parent;
+    const removed = store.completedEpics.find(match);
+    store.completedEpics = store.completedEpics.filter((e) => !match(e)); // optimistic
     try {
       await dismissCompletedEpic(repoPath, parent);
     } catch {
-      store.completedEpics = prev; // reconcile
+      if (removed && !store.completedEpics.some(match)) {
+        // reconcile vs CURRENT state — don't clobber WS arrivals
+        store.completedEpics = [removed, ...store.completedEpics];
+      }
       toasts.info(m.integrated_epics_dismiss_failed(), {
         alert: true,
         duration: null,


### PR DESCRIPTION
## Why

When an epic's children all land, the epic **vanishes**: the drain flips `epic_run` `running→idle`, the Herd group dissolves (groups key off live sessions, which archive on merge), the banner clears. The parent issue lingers open in the backlog as a plain `8/8` badge with no PR rollup. There was no completion signal and no way to follow up — the exact gap that prompted *"give me a status report on the merged sub-issues for Epic #327."*

## What this ships (direction A+B)

A durable, collapsible **"Integrated epics" band** pinned to the bottom of the Herd:

- **Persistence** — a new `epic_completed` table (per-epic, survives the single-row `epic_run` overwrite) + enriched `epic_integrated` rows (PR number/url captured at the squash-merge hook in `doRetire`, `createdAt` = merged-at). The rollup is a forge-free snapshot, so the band renders fast and offline-safe.
- **Recorded before the idle flip** — `handleEpicSideEffects` records the completed-epic snapshot + emits `epic:completed` **before** `setEpicRun(idle)`, gated on the record succeeding (a failure stays `running` and retries next pump). Trigger keys on `children.every(c => c.state === "merged")` (done-in-epic), decoupled from the run-state edge so it survives #635's planned changes.
- **The band** — collapsed section, hidden when empty, one row per finished epic; expand for the per-child rollup (`#issue · title · PR link (or issue link) · merged-at`). Handles **mixed epics** (some children integration-merged, some closed out-of-band) honestly via a per-child `integrated` flag. Slate `--status-done` chip (never green); EN+DE i18n; feature-catalog entry.
- **Lifecycle** — a completion toast (stable per-epic key) on the live edge; explicit **Dismiss** (optimistic + fail-closed reconcile); **auto-dismiss** when the parent issue closes (bounded, TTL-cached, fail-safe route reconcile); and a **backfill** that recovers the surviving idle `epic_run` (so Epic #327 surfaces on first load).

## Not in scope → follow-up #635

Direction **C (Stage B)** — the final `epic/#→default` PR that *lands* the epic and closes the parent — is **not** built here and is filed as **#635**. The band's copy reads *integrated / awaiting landing* precisely because, in the Stage-A world, the integration branch is unlanded and the parent stays open. #635 will call `dismissEpicCompleted` at land-time (documented contract; `TODO(#635)` at the store method).

## The #327 report (delivered independently)

Verified live: Epic #327 is a mixed epic — #320/#326/#321 landed early to `dev`/legacy and closed; #322→PR #333, #325→PR #334, #323→PR #335 integration-merged into `epic/327-…` (still open, unlanded). The read-only recipe in `.shepherd-plan.md` answers the literal ask regardless of this feature; the backfill recovers it into the band.

## Note for a separate cleanup

While wiring the Dismiss button I found `.gbtn` is **not** a global class — each consumer (PrsPanel/GitRail/Onboarding) defines it scoped, and `EpicPanel.svelte`'s "global recipe" comment is wrong (its buttons share the same latent unstyled gap). This PR defines `.gbtn` locally in the new component (matching the real pattern); fixing EpicPanel's stale comment/gap is left out of scope.

## Verification

All gates green: root `lint` + `tsc --noEmit` + `bun test ./test` (2592 pass); UI `check` + `check:i18n` (EN/DE parity) + `test` (1182 pass); branch-hygiene + feature-catalog; `fallow audit --fail-on-issues` (exit 0). New tests cover the store (no-clobber/no-resurrect/createdAt-preservation), `buildRollup` (mixed-epic), the drain record-before-flip + retry, the routes (auto-dismiss/backfill/dismiss/fail-safe), the store WS handlers, and the components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)