### PR TITLE
fix(autopilot): stand down CI-fix loop while a session is in a merge train

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -340,8 +340,14 @@ export class AutopilotService {
    *  unchanged red head — sustained idle re-engagement on that is owned by tick(). Synchronous (no
    *  classify needed: a red rollup is already an actionable verdict). The caller (onGit) has already
    *  checked existence / archive / enablement; here we gate on pause + per-head dedup and bound it
-   *  by the same step cap as the gate loop. */
+   *  by the same step cap as the gate loop.
+   *  Merge-train stand-down: while the session is merge-train-marked (`mergingSince !== null`) the
+   *  train owns it and is steering its own rebase — the CI-fix loop must not double-steer, so this
+   *  returns immediately. The gate/classify path stays alive (so a procedural prompt won't stall
+   *  the rebase); only this CI-fix entry point stands down. The mark is kept fresh by the 60s
+   *  sweepStaleMerging. */
   private considerCi(s: Session, git: GitState): void {
+    if (s.mergingSince !== null) return; // merge train owns this session; don't double-steer its rebase
     if (s.autopilotPaused) return; // already handed back; waits for operator
     if (this.pending.has(s.id)) return; // a classify (gate/done path) is mid-flight
     if (!git.headSha) return; // can't dedup a headless rollup → skip rather than spam
@@ -364,10 +370,20 @@ export class AutopilotService {
    *  so it works even when no `session:git` re-emits (unchanged red head). Returns true when it
    *  OWNED the session (re-engaged or paused), so onDone can short-circuit before classifying.
    *  Returns false for any ineligible session (no PR / green / pending / paused / complete /
-   *  autopilot-off / non-full-auto), leaving it untouched. */
+   *  autopilot-off / non-full-auto), leaving it untouched.
+   *  Merge-train stand-down: while the session is merge-train-marked (`mergingSince !== null`) the
+   *  train owns it and steers its own rebase. We CLAIM ownership (return true) so onDone
+   *  short-circuits BEFORE classify — but we do NOT steer/bump/pause. Returning true (not false) is
+   *  load-bearing: a false return would let the LLM classifier run on a marked, stuck-red full-auto
+   *  session and possibly mark it complete/paused, a terminal state that would SURVIVE the mark
+   *  clearing (reEngageCi/considerCi/eligible all reject complete/paused), wedging the CI-fix loop
+   *  shut. Claiming-but-not-acting leaves no state that outlives the mark, so the loop auto-resumes
+   *  once the train clears it. The guard sits before the step-cap branch (which calls pause()) so a
+   *  marked session is never paused either. The mark is kept fresh by the 60s sweepStaleMerging. */
   private reEngageCi(id: string): boolean {
     const s = this.deps.store.get(id);
     if (!s || s.status === "archived") return false;
+    if (s.mergingSince !== null) return true; // merge train owns this session: claim it so onDone short-circuits BEFORE classify, but don't steer/bump/pause — that state must not survive mark-clear
     if (!this.enabled(s)) return false;
     if (s.autopilotPaused) return false; // already handed back; waits for operator
     if (s.autopilotComplete) return false; // terminal

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -916,3 +916,68 @@ test("non-research + gate verdict → still gets PROCEED_STEER, not RESEARCH_PRO
   expect(steerEv.steer).toBe(PROCEED_STEER);
   expect(steerEv.steer).not.toBe(RESEARCH_PROCEED_STEER);
 });
+
+// ───────────── merge-train stand-down (don't double-steer the train's rebase) ─────────────
+// While a session is merge-train-marked (mergingSince !== null) the train owns it and steers its
+// own rebase. Autopilot's CI-fix loop (considerCi + reEngageCi) must stand down so two controllers
+// don't steer one agent at once. The gate/classify path stays alive (a procedural prompt must not
+// stall the rebase). The mark is the canonical "in a train" signal (pr-poller.ts:223), kept fresh
+// by the 60s sweepStaleMerging.
+
+test("merge-train: onGit/considerCi suppressed while marked (no CI steer, no bump)", async () => {
+  const h = harness({
+    session: sess({ status: "running", mergingSince: Date.now(), mergingTrainId: "train-1" }),
+    repoEnabled: true,
+  });
+  h.svc.onGit("s1", git()); // open + red
+  await Promise.resolve();
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  expect(h.state().autopilotStepCount).toBe(0);
+});
+
+test("merge-train: tick/reEngageCi suppressed while marked (no steer)", () => {
+  const h = stuckRed({ mergingSince: Date.now(), mergingTrainId: "train-1" });
+  h.svc.tick();
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  expect(h.state().autopilotStepCount).toBe(0);
+});
+
+test("merge-train: onDone short-circuits BEFORE classify (no steer, no terminal state)", async () => {
+  // The critical regression guard: a marked, idle, open+red FULL-AUTO session whose onDone fires
+  // must claim ownership (reEngageCi returns true) so onDone returns BEFORE consider()/classify().
+  // If reEngageCi returned false, the LLM classifier could mark this session complete/paused — a
+  // terminal state that would survive the mark clearing and wedge the CI-fix loop shut forever.
+  const h = stuckRed({ mergingSince: Date.now(), mergingTrainId: "train-1" });
+  await h.svc.onDone("s1");
+  expect(h.classifyCount()).toBe(0); // (c) classify never invoked → reEngageCi returned true
+  expect(h.events.some((e) => "steer" in e)).toBe(false); // (a) no CI-fix steer
+  expect(h.state().autopilotComplete).toBe(false); // (b) not wedged terminal
+  expect(h.state().autopilotPaused).toBe(false);
+  expect(h.state().autopilotStepCount).toBe(0); // no bump
+});
+
+test("merge-train: CI-fix resumes once the mark clears (guard is the only suppressor)", async () => {
+  // Same session as the suppressed case but with mergingSince null → the CI-fix steer fires again,
+  // proving the mark was the only thing holding the loop down and nothing wedged it terminal.
+  const h = harness({
+    session: sess({ status: "running", mergingSince: null }),
+    repoEnabled: true,
+  });
+  h.svc.onGit("s1", git());
+  await Promise.resolve();
+  expect(h.events).toContainEqual({ steer: CI_FIX_STEER });
+  expect(h.state().autopilotStepCount).toBe(1);
+});
+
+test("merge-train: gate/classify path is NOT suppressed by the mark (CI-fix-only scope)", async () => {
+  // A marked session that hits a procedural gate still gets its PROCEED_STEER — the stand-down is
+  // scoped to the CI-fix loop, not the gate-unblock path the train's rebase depends on.
+  const h = harness({
+    session: sess({ mergingSince: Date.now(), mergingTrainId: "train-1" }),
+    repoEnabled: true,
+    verdict: { kind: "gate", summary: "asking to start" },
+  });
+  await h.svc.onBlock("s1", block());
+  expect(h.events).toContainEqual({ steer: PROCEED_STEER });
+  expect(h.state().autopilotStepCount).toBe(1);
+});


### PR DESCRIPTION
## Problem

The merge train and autopilot could both steer the **same** agent session at once. When the merge train rebases a member PR it marks that PR's session (`mergingSince`/`mergingTrainId`) and steers a rebase into it. Independently, autopilot's red-CI recovery saw the open PR's failing CI and fired `CI_FIX_STEER` into the same session — two controllers driving one agent, each attempting to fix the same failing CI. This is the "train rebasing a PR while the open session got autopilot-triggered to fix the same CI failure" collision.

## Fix

While a session is merge-train-marked (`s.mergingSince !== null`), autopilot's **CI-fix loop stands down** — the train owns the session's path to merge. Two guards in `src/autopilot.ts`:

- **`considerCi`** (red-CI steer via `onGit`): early-returns when marked — no `CI_FIX_STEER`.
- **`reEngageCi`** (red-CI re-engage via `tick()`/`onDone`): returns **`true`** when marked, placed *before* the step-cap `pause()` branch. The `true` is load-bearing: `onDone` does `if (this.reEngageCi(id)) return;` *before* the LLM classifier, so claiming ownership prevents the classifier running on a marked stuck-red session and marking it `complete`/`paused` — a terminal state that (being rejected by `eligible`/`considerCi`/`reEngageCi`) would survive the mark clearing and permanently wedge the CI-fix loop shut.

Scope is **CI-fix-only**: the gate-unblock/classify path stays alive so a procedural prompt can't stall the train's rebase. No new config, DB column, dep, or freshness check — `mergingSince != null` is the canonical "in a train" signal (already used by `pr-poller`), kept fresh by the existing 60s `sweepStaleMerging`.

## Handoff back

A genuinely red marked PR is recovered by autopilot once the PR resolves or the mark goes stale — autopilot is suppressed for the session's whole merge-train membership, bounded by `MERGE_STALE_MS` (~30 min) / the train-session archive sweep. Accepted, simplest, fully reversible (clearing the mark resumes the loop).

## Tests (`test/autopilot.test.ts`)

- `onGit`/`considerCi` suppressed while marked (no steer, no step bump).
- `tick`/`reEngageCi` suppressed while marked.
- **`onDone` classify-short-circuit regression guard** — marked, idle, open+red, full-auto session: no `CI_FIX_STEER`, not `complete`/`paused`, and `classify` never invoked. Genuinely fails on a `false` return.
- Control: clearing the mark → CI-fix steer fires again.
- Negative: a marked session hitting a procedural gate still gets `PROCEED_STEER` (CI-fix-only scope).

Full root suite 2673 pass / 0 fail, `bun run lint` clean, `tsc --noEmit` exit 0.

Server-only autopilot change, no user-facing UI — no feature-catalog/i18n entry needed. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)