### PR TITLE
feat(onboarding-harness): Incus-based onboarding challenge & regression framework

### DIFF
--- a/ci/onboarding-harness/README.md
+++ b/ci/onboarding-harness/README.md
@@ -1,0 +1,61 @@
+# Onboarding Challenge & Regression Harness
+
+Boots deliberately-messy Incus instances, runs Shepherd inside them in degraded mode, captures diagnostics, applies coaching via a Claude Code proxy-user agent, re-probes, and emits a gap report.
+
+## Prerequisites
+
+- Self-hosted Incus host with the `shep-onb` profile configured:
+  ```
+  incus profile create shep-onb
+  incus profile set shep-onb limits.cpu 2 limits.memory 2GiB
+  # For tailscale/systemd scenarios (nesting + TUN):
+  incus profile set shep-onb security.nesting true
+  incus profile device add shep-onb tun unix-char path=/dev/net/tun
+  ```
+- `bun` installed on the Incus host.
+- `~/.claude` credentials accessible on the host (mounted into instances for the agent apply path). The harness expects a valid Claude Code credential so the proxy-user agent can run `claude -p` inside each instance.
+
+## Usage
+
+```bash
+# Run all scenarios
+bun run onboarding:test
+
+# Run a single scenario
+bun run onboarding:test --scenario gh-unauthed
+
+# Reap leaked instances from a crashed run (manual recovery only)
+bun run onboarding:test --reap-orphans
+```
+
+The report lands at `onboarding-gap-report.md` in the working directory. Exit code is 0 if every apply-able scenario reached green; 1 if any failed; 2 if the named scenario was not found; 3 if another run holds the host lock.
+
+## Run isolation
+
+Each run acquires an exclusive host-wide lock at the **fixed absolute path** `~/.shepherd/onboarding-harness.lock` (NOT `$TMPDIR` — a systemd-user timer and an interactive run can see different `$TMPDIR` under PrivateTmp, so the lock must live under the stable `~/.shepherd` dir to actually serialize them). A second run while one is active exits with code 3.
+
+Each run also uses a unique per-run instance prefix (`shep-onb-<runId>-`) and sweeps only its own prefix on teardown, so two concurrent runs (if the lock were bypassed) could never destroy each other's instances.
+
+Crashed-run leftovers are cleared with `--reap-orphans`, which sweeps all `shep-onb-*` instances regardless of run prefix. This is the only command that touches other runs' instances — never invoked automatically.
+
+## Nightly timer (Incus host)
+
+Copy the systemd units and enable the timer:
+
+```bash
+cp ci/onboarding-harness/shepherd-onboarding.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now shepherd-onboarding.timer
+```
+
+The timer fires nightly at 03:30 and writes the gap report to the working directory.
+
+## Release gate
+
+Before tagging a release, run:
+
+```bash
+scripts/onboarding-gate.sh
+```
+
+This runs the deterministic (`structured`) scenario subset and exits non-zero on any red. It bypasses with exit 0 (loudly logged) when the Incus host is unavailable, so infra outages do not block unrelated releases. Add this check to the OSS-release checklist.

--- a/ci/onboarding-harness/README.md
+++ b/ci/onboarding-harness/README.md
@@ -1,6 +1,15 @@
 # Onboarding Challenge & Regression Harness
 
-Boots deliberately-messy Incus instances, runs Shepherd inside them in degraded mode, captures diagnostics, applies coaching via a Claude Code proxy-user agent, re-probes, and emits a gap report.
+Boots deliberately-messy Incus instances, runs Shepherd inside them in degraded mode, captures diagnostics, applies the coaching (a verbatim remediation where one exists, else a Claude Code proxy-user agent), re-probes, and emits a gap report.
+
+## Scenarios & success
+
+Success is scoped **per scenario**: a scenario passes when the checks it broke return to `ok` after the coaching is applied — NOT when the whole host is green. A throw-away instance never reaches all-7-green (no tailnet, no `gh` login), so a global finish line would be permanently red.
+
+Two scenario classes:
+
+- **Green-able** — the defect can be coached back to `ok` unattended. `coaching: "structured"` runs a verbatim `REMEDIATIONS` command (deterministic, LLM-free, **release-gate-eligible**); `coaching: "prose"` uses the agent (e.g. distro-specific git install). Today: `herdr-missing`, `claude-missing`, `node-too-old` (structured) and `git-missing` (prose).
+- **Detection-only** (`detectionOnly: true`) — the defect is detectable but its fix needs a human/secret a throw-away instance can't supply (`gh auth login`; a Tailscale tailnet login + `serve`). No apply is attempted; excluded from the green tally and the gate; reported as DETECTION-ONLY. Today: `gh-unauthed`, `gh-missing`, `tailscale-missing`.
 
 ## Prerequisites
 
@@ -58,4 +67,4 @@ Before tagging a release, run:
 scripts/onboarding-gate.sh
 ```
 
-This runs the deterministic (`structured`) scenario subset and exits non-zero on any red. It bypasses with exit 0 (loudly logged) when the Incus host is unavailable, so infra outages do not block unrelated releases. Add this check to the OSS-release checklist.
+This runs the deterministic, green-able subset (`structured` AND not `detectionOnly`) and exits non-zero on any red. It bypasses with exit 0 (loudly logged) when the Incus host is unavailable, so infra outages do not block unrelated releases. Add this check to the OSS-release checklist.

--- a/ci/onboarding-harness/apply.ts
+++ b/ci/onboarding-harness/apply.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { IncusDriver } from "./incus";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+export interface CoachingLine {
+  id: string;
+  text: string;
+}
+
+/** Pure: resolve every non-ok check's hintKey to the user-visible EN string
+ *  (falling back to the raw key). This is exactly the coaching a new user reads. */
+export function resolveCoaching(
+  snapshot: DiagnosticsSnapshot,
+  messages: Record<string, string>,
+): CoachingLine[] {
+  return snapshot.checks
+    .filter((c) => c.state !== "ok")
+    .map((c) => ({ id: c.id, text: messages[c.hintKey] ?? c.hintKey }));
+}
+
+/** Pure: the proxy-user prompt — only what a real user sees, plus the goal. */
+export function buildAgentPrompt(lines: CoachingLine[]): string {
+  const coaching = lines.map((l) => `- (${l.id}) ${l.text}`).join("\n");
+  return [
+    "You are a new user setting up Shepherd on this machine.",
+    "Shepherd's onboarding screen shows these issues and advice:",
+    "",
+    coaching,
+    "",
+    "Follow this advice to get the machine to a healthy state. Use the shell.",
+    "Do not invent steps beyond what the advice implies. Stop when done.",
+  ].join("\n");
+}
+
+/** Load the EN catalog once (the user-visible coaching source of truth). */
+export function loadEnMessages(): Record<string, string> {
+  const p = join(import.meta.dir, "..", "..", "ui", "messages", "en.json");
+  return JSON.parse(readFileSync(p, "utf8")) as Record<string, string>;
+}
+
+/** Run the proxy-user agent inside the instance to act on the coaching. Returns
+ *  the agent's exit code (0 ⇒ it believes it finished). Auth is provided by a
+ *  ~/.claude credential mounted into the instance by run.ts. */
+export async function applyAgent(
+  driver: IncusDriver,
+  name: string,
+  snapshot: DiagnosticsSnapshot,
+): Promise<number> {
+  const lines = resolveCoaching(snapshot, loadEnMessages());
+  if (lines.length === 0) return 0;
+  const prompt = buildAgentPrompt(lines);
+  const r = await driver.exec(name, [
+    "sh",
+    "-c",
+    `claude -p ${shellQuote(prompt)} --permission-mode dontAsk --allowedTools Bash`,
+  ]);
+  return r.code;
+}
+
+/** Minimal single-quote shell escape for embedding the prompt safely. */
+export function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}

--- a/ci/onboarding-harness/apply.ts
+++ b/ci/onboarding-harness/apply.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { IncusDriver } from "./incus";
+import { remediationsFor } from "./remediations";
 import type { DiagnosticsSnapshot } from "../../src/types";
 
 export interface CoachingLine {
@@ -61,4 +62,18 @@ export async function applyAgent(
 /** Minimal single-quote shell escape for embedding the prompt safely. */
 export function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Run each harness-catalog remediation (keyed by Shepherd's emitted hintKeys)
+ *  verbatim inside the instance. Returns false if any command exits non-zero. */
+export async function applyVerbatim(
+  driver: IncusDriver,
+  name: string,
+  snapshot: DiagnosticsSnapshot,
+): Promise<boolean> {
+  for (const cmd of remediationsFor(snapshot)) {
+    const r = await driver.exec(name, ["sh", "-c", cmd]);
+    if (r.code !== 0) return false;
+  }
+  return true;
 }

--- a/ci/onboarding-harness/apply.ts
+++ b/ci/onboarding-harness/apply.ts
@@ -35,7 +35,7 @@ export function buildAgentPrompt(lines: CoachingLine[]): string {
 }
 
 /** Load the EN catalog once (the user-visible coaching source of truth). */
-export function loadEnMessages(): Record<string, string> {
+function loadEnMessages(): Record<string, string> {
   const p = join(import.meta.dir, "..", "..", "ui", "messages", "en.json");
   return JSON.parse(readFileSync(p, "utf8")) as Record<string, string>;
 }
@@ -60,7 +60,7 @@ export async function applyAgent(
 }
 
 /** Minimal single-quote shell escape for embedding the prompt safely. */
-export function shellQuote(s: string): string {
+function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 

--- a/ci/onboarding-harness/assert.ts
+++ b/ci/onboarding-harness/assert.ts
@@ -1,0 +1,18 @@
+import type { DiagnosticsSnapshot } from "../../src/types";
+import type { DetectionResult, ExpectedCheck } from "./types";
+
+/** Pure: does the captured snapshot flag every expected check at its expected
+ *  state? Any mismatch (wrong state, or check absent) is a detection gap. */
+export function assertDetection(
+  snapshot: DiagnosticsSnapshot,
+  scenarioId: string,
+  expected: ExpectedCheck[],
+): DetectionResult {
+  const byId = new Map(snapshot.checks.map((c) => [c.id, c.state]));
+  const misses: DetectionResult["misses"] = [];
+  for (const e of expected) {
+    const got = byId.get(e.id) ?? "absent";
+    if (got !== e.state) misses.push({ id: e.id, want: e.state, got });
+  }
+  return { scenarioId, detected: misses.length === 0, misses };
+}

--- a/ci/onboarding-harness/incus.ts
+++ b/ci/onboarding-harness/incus.ts
@@ -1,0 +1,75 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { IncusExec, IncusRunner } from "./types";
+
+const execFileAsync = promisify(execFile);
+
+/** Default runner: invokes the real `incus` binary, capturing output and never
+ *  throwing on a non-zero exit (the caller inspects `code`). */
+const defaultRunner: IncusRunner = async (args) => {
+  try {
+    const { stdout, stderr } = await execFileAsync("incus", args, { encoding: "utf8" });
+    return { stdout: stdout.toString(), stderr: stderr.toString(), code: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; code?: number };
+    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", code: e.code ?? 1 };
+  }
+};
+
+/** Thin, throw-away-instance lifecycle wrapper over the `incus` CLI. All managed
+ *  instances carry `prefix` in their name so `sweep()` can reap leaks. */
+export class IncusDriver {
+  constructor(
+    private run: IncusRunner = defaultRunner,
+    private prefix = "shep-onb-",
+  ) {}
+
+  private full(name: string): string {
+    return this.prefix + name;
+  }
+
+  async launch(
+    image: string,
+    name: string,
+    opts: { vm?: boolean; profile?: string } = {},
+  ): Promise<void> {
+    const args = ["launch", image, this.full(name)];
+    if (opts.vm) args.push("--vm");
+    if (opts.profile) args.push("--profile", opts.profile);
+    const r = await this.run(args);
+    if (r.code !== 0) throw new Error(`incus launch failed: ${r.stderr || r.stdout}`);
+  }
+
+  async exec(name: string, cmd: string[]): Promise<IncusExec> {
+    return this.run(["exec", this.full(name), "--", ...cmd]);
+  }
+
+  async push(name: string, localPath: string, remotePath: string): Promise<void> {
+    const r = await this.run(["file", "push", localPath, `${this.full(name)}${remotePath}`]);
+    if (r.code !== 0) throw new Error(`incus file push failed: ${r.stderr}`);
+  }
+
+  async pull(name: string, remotePath: string, localPath: string): Promise<void> {
+    const r = await this.run(["file", "pull", `${this.full(name)}${remotePath}`, localPath]);
+    if (r.code !== 0) throw new Error(`incus file pull failed: ${r.stderr}`);
+  }
+
+  async delete(name: string): Promise<void> {
+    await this.run(["delete", this.full(name), "--force"]);
+  }
+
+  /** Names of all instances carrying the managed prefix. */
+  async listManaged(): Promise<string[]> {
+    const r = await this.run(["list", "--format", "json"]);
+    if (r.code !== 0) return [];
+    const rows = JSON.parse(r.stdout) as Array<{ name: string }>;
+    return rows.map((x) => x.name).filter((n) => n.startsWith(this.prefix));
+  }
+
+  /** Force-delete every managed instance (orphan reaper, run at start + teardown). */
+  async sweep(): Promise<void> {
+    for (const full of await this.listManaged()) {
+      await this.run(["delete", full, "--force"]);
+    }
+  }
+}

--- a/ci/onboarding-harness/probe.ts
+++ b/ci/onboarding-harness/probe.ts
@@ -1,0 +1,45 @@
+import type { IncusDriver } from "./incus";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+const SHEPHERD_DIR = "/opt/shepherd";
+const PORT = 7330; // config.port default
+
+/** Start Shepherd detached inside the instance and poll until its HTTP API
+ *  answers (or time out). Degraded boots are expected — we only need the server
+ *  process up far enough to serve `/api/diagnostics`.
+ *
+ *  AUTH (point 7): `GET /api/diagnostics` passes through `checkAuth`, which only
+ *  authorizes when `config.token` (`SHEPHERD_TOKEN`) is null. We boot with the
+ *  var explicitly UNSET (`env -u SHEPHERD_TOKEN`) so the plain `curl` probe below
+ *  is authorized — the harness controls the env, so this is safe and the simplest
+ *  correct option. (If a future scenario needs a token, the probe must add
+ *  `-H "Authorization: Bearer $SHEPHERD_TOKEN"` instead.) */
+export async function bootShepherd(driver: IncusDriver, name: string): Promise<void> {
+  await driver.exec(name, [
+    "sh",
+    "-c",
+    `cd ${SHEPHERD_DIR} && env -u SHEPHERD_TOKEN nohup ~/.bun/bin/bun run start >/var/log/shepherd.log 2>&1 &`,
+  ]);
+  const poll = await driver.exec(name, [
+    "sh",
+    "-c",
+    `for i in $(seq 1 60); do curl -sf localhost:${PORT}/api/diagnostics >/dev/null 2>&1 && exit 0; sleep 1; done; exit 1`,
+  ]);
+  if (poll.code !== 0) throw new Error(`Shepherd did not come up in ${name}`);
+}
+
+/** Capture a fresh diagnostics snapshot from inside the instance. */
+export async function probeDiagnostics(
+  driver: IncusDriver,
+  name: string,
+): Promise<DiagnosticsSnapshot> {
+  const r = await driver.exec(name, [
+    "sh",
+    "-c",
+    `curl -s localhost:${PORT}/api/diagnostics?refresh=1`,
+  ]);
+  if (r.code !== 0 || !r.stdout.trim()) {
+    throw new Error(`diagnostics probe failed in ${name}: ${r.stderr || "empty"}`);
+  }
+  return JSON.parse(r.stdout) as DiagnosticsSnapshot;
+}

--- a/ci/onboarding-harness/remediations.ts
+++ b/ci/onboarding-harness/remediations.ts
@@ -1,0 +1,22 @@
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+/** hintKey → verbatim shell remediation, keyed by the advice identifier Shepherd
+ *  emits. Lives in the HARNESS (not the diagnostics payload) so the shipped
+ *  DiagnosticCheck contract is unchanged. Only keys whose canonical fix is a
+ *  single non-interactive command appear; prose-only coaching (interactive
+ *  `gh auth login`, tailscale serve setup) is intentionally absent and stays on
+ *  the agent path. */
+export const REMEDIATIONS: Record<string, string> = {
+  diagnostics_hint_bun_missing: "curl -fsSL https://bun.sh/install | bash",
+  diagnostics_hint_node_missing:
+    "curl -fsSL https://fnm.vercel.app/install | bash && fnm install --lts",
+  diagnostics_hint_herdr_missing: "curl -fsSL https://herdr.dev/install.sh | bash",
+  diagnostics_hint_claude_missing: "curl -fsSL https://claude.ai/install.sh | bash",
+};
+
+/** Verbatim commands for every non-ok check whose emitted hintKey has a known fix. */
+export function remediationsFor(snapshot: DiagnosticsSnapshot): string[] {
+  return snapshot.checks
+    .filter((c) => c.state !== "ok" && REMEDIATIONS[c.hintKey])
+    .map((c) => REMEDIATIONS[c.hintKey]!);
+}

--- a/ci/onboarding-harness/remediations.ts
+++ b/ci/onboarding-harness/remediations.ts
@@ -5,13 +5,20 @@ import type { DiagnosticsSnapshot } from "../../src/types";
  *  DiagnosticCheck contract is unchanged. Only keys whose canonical fix is a
  *  single non-interactive command appear; prose-only coaching (interactive
  *  `gh auth login`, tailscale serve setup) is intentionally absent and stays on
- *  the agent path. */
+ *  the agent path. Every `coaching: "structured"` scenario must have a matching
+ *  entry here — otherwise it silently falls through to the LLM agent path,
+ *  breaking the deterministic LLM-free gate guarantee. */
+const NODE_INSTALL = "curl -fsSL https://fnm.vercel.app/install | bash && fnm install --lts";
+const HERDR_INSTALL = "curl -fsSL https://herdr.dev/install.sh | bash";
+
 export const REMEDIATIONS: Record<string, string> = {
   diagnostics_hint_bun_missing: "curl -fsSL https://bun.sh/install | bash",
-  diagnostics_hint_node_missing:
-    "curl -fsSL https://fnm.vercel.app/install | bash && fnm install --lts",
-  diagnostics_hint_herdr_missing: "curl -fsSL https://herdr.dev/install.sh | bash",
+  diagnostics_hint_node_missing: NODE_INSTALL,
+  diagnostics_hint_node_outdated: NODE_INSTALL,
+  diagnostics_hint_herdr_missing: HERDR_INSTALL,
+  diagnostics_hint_herdr_outdated: HERDR_INSTALL,
   diagnostics_hint_claude_missing: "curl -fsSL https://claude.ai/install.sh | bash",
+  diagnostics_hint_tailscale_missing: "curl -fsSL https://tailscale.com/install.sh | sh",
 };
 
 /** Verbatim commands for every non-ok check whose emitted hintKey has a known fix. */

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -1,0 +1,48 @@
+import type { ScenarioResult } from "./types";
+
+/** Pure: render the per-scenario outcomes as a markdown gap report. Classifies
+ *  each scenario as PASS, DETECTION GAP (defect missed/misclassified), ADVICE GAP
+ *  (detected but coaching didn't reach green), or DETECTION-ONLY (detected with no
+ *  apply attempted by design — e.g. claude-missing in Phase 1; NOT a gap). The
+ *  green tally counts only apply-able scenarios so detection-only ones don't drag
+ *  the denominator. */
+function classify(r: ScenarioResult): "PASS" | "DETECTION GAP" | "ADVICE GAP" | "DETECTION-ONLY" {
+  if (r.detectionOnly) return r.detection.detected ? "DETECTION-ONLY" : "DETECTION GAP";
+  if (r.reachedGreen) return "PASS";
+  return r.detection.detected ? "ADVICE GAP" : "DETECTION GAP";
+}
+
+export function buildGapReport(results: ScenarioResult[]): string {
+  const applicable = results.filter((r) => !r.detectionOnly);
+  const green = applicable.filter((r) => r.reachedGreen).length;
+  const detectionOnly = results.length - applicable.length;
+  const lines: string[] = [
+    "# Onboarding Gap Report",
+    "",
+    `**${green} / ${applicable.length} scenarios reached green.**` +
+      (detectionOnly ? ` (${detectionOnly} detection-only, by design — excluded.)` : ""),
+    "",
+    "| Scenario | Image | Detected | Applied | Green | Classification |",
+    "| --- | --- | --- | --- | --- | --- |",
+  ];
+  const gaps: string[] = [];
+  for (const r of results) {
+    const klass = classify(r);
+    lines.push(
+      `| ${r.scenarioId} | ${r.image} | ${r.detection.detected ? "yes" : "no"} | ${r.appliedVia} | ${r.reachedGreen ? "yes" : "no"} | ${klass} |`,
+    );
+    // Only genuine gaps go in the gaps section; PASS and DETECTION-ONLY do not.
+    if (klass === "DETECTION GAP" || klass === "ADVICE GAP") {
+      const misses = r.detection.misses
+        .map((m) => `${m.id} want=${m.want} got=${m.got}`)
+        .join("; ");
+      gaps.push(
+        `- **${r.scenarioId}** (${klass})${misses ? ` — ${misses}` : ""}${r.error ? ` — ${r.error}` : ""}`,
+      );
+    }
+  }
+  if (gaps.length) {
+    lines.push("", "## Gaps", "", ...gaps);
+  }
+  return lines.join("\n") + "\n";
+}

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -12,6 +12,15 @@ function classify(r: ScenarioResult): "PASS" | "DETECTION GAP" | "ADVICE GAP" | 
   return r.detection.detected ? "ADVICE GAP" : "DETECTION GAP";
 }
 
+function tableRow(r: ScenarioResult, klass: ReturnType<typeof classify>): string {
+  return `| ${r.scenarioId} | ${r.image} | ${r.detection.detected ? "yes" : "no"} | ${r.appliedVia} | ${r.reachedGreen ? "yes" : "no"} | ${klass} |`;
+}
+
+function gapEntry(r: ScenarioResult, klass: "DETECTION GAP" | "ADVICE GAP"): string {
+  const misses = r.detection.misses.map((m) => `${m.id} want=${m.want} got=${m.got}`).join("; ");
+  return `- **${r.scenarioId}** (${klass})${misses ? ` — ${misses}` : ""}${r.error ? ` — ${r.error}` : ""}`;
+}
+
 export function buildGapReport(results: ScenarioResult[]): string {
   const applicable = results.filter((r) => !r.detectionOnly);
   const green = applicable.filter((r) => r.reachedGreen).length;
@@ -28,17 +37,9 @@ export function buildGapReport(results: ScenarioResult[]): string {
   const gaps: string[] = [];
   for (const r of results) {
     const klass = classify(r);
-    lines.push(
-      `| ${r.scenarioId} | ${r.image} | ${r.detection.detected ? "yes" : "no"} | ${r.appliedVia} | ${r.reachedGreen ? "yes" : "no"} | ${klass} |`,
-    );
-    // Only genuine gaps go in the gaps section; PASS and DETECTION-ONLY do not.
+    lines.push(tableRow(r, klass));
     if (klass === "DETECTION GAP" || klass === "ADVICE GAP") {
-      const misses = r.detection.misses
-        .map((m) => `${m.id} want=${m.want} got=${m.got}`)
-        .join("; ");
-      gaps.push(
-        `- **${r.scenarioId}** (${klass})${misses ? ` — ${misses}` : ""}${r.error ? ` — ${r.error}` : ""}`,
-      );
+      gaps.push(gapEntry(r, klass));
     }
   }
   if (gaps.length) {

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -36,11 +36,17 @@ async function runScenario(
     const verbatim = remediationsFor(before);
     let appliedVia: ScenarioResult["appliedVia"];
     let detectionOnly = false;
-    if (verbatim.length > 0) {
+    if (scenario.detectionOnly) {
+      // Defect detectable but unfixable unattended (needs human/secret) — verify
+      // detection only, never apply.
+      console.log(`[${scenario.id}] detection-only by design — no apply`);
+      appliedVia = "skipped";
+      detectionOnly = true;
+    } else if (verbatim.length > 0) {
       await applyVerbatim(driver, scenario.id, before);
       appliedVia = "verbatim";
     } else if (scenario.agentIncompatible) {
-      console.log(`[${scenario.id}] agent-incompatible — detection-only`);
+      console.log(`[${scenario.id}] agent-incompatible, no verbatim fix — detection-only`);
       appliedVia = "skipped";
       detectionOnly = true;
     } else {
@@ -48,11 +54,17 @@ async function runScenario(
       appliedVia = "agent";
     }
     const after = detectionOnly ? before : await probeDiagnostics(driver, scenario.id);
+    // Success is SCOPED to the checks this scenario broke: a throw-away instance
+    // never has a fully-healthy host (no tailnet, no gh login, etc.), so the global
+    // `overall` can't be "ok" — green means the seeded defect's checks recovered.
+    const expectedNowOk = scenario.expect.every(
+      (e) => after.checks.find((c) => c.id === e.id)?.state === "ok",
+    );
     return {
       ...base,
       detection,
       appliedVia,
-      reachedGreen: !detectionOnly && after.overall === "ok",
+      reachedGreen: !detectionOnly && expectedNowOk,
       detectionOnly: detectionOnly || undefined,
     };
   } catch (err) {

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -9,7 +9,7 @@ import { bootShepherd, probeDiagnostics } from "./probe";
 import { applyAgent } from "./apply";
 import { assertDetection } from "./assert";
 import { buildGapReport } from "./report";
-import type { Scenario, ScenarioResult } from "./types";
+import type { DetectionResult, Scenario, ScenarioResult } from "./types";
 
 /** `git archive` the current HEAD into a tarball the seed engine pushes. */
 function buildTarball(): string {
@@ -25,11 +25,12 @@ async function runScenario(
   tarball: string,
 ): Promise<ScenarioResult> {
   const base = { scenarioId: scenario.id, image: scenario.image };
+  let detection: DetectionResult | undefined;
   try {
     await seedInstance(driver, scenario, tarball);
     await bootShepherd(driver, scenario.id);
     const before = await probeDiagnostics(driver, scenario.id);
-    const detection = assertDetection(before, scenario.id, scenario.expect);
+    detection = assertDetection(before, scenario.id, scenario.expect);
 
     // Phase 1 has no verbatim path yet. A scenario that disabled the agent
     // (claude-missing — the agent IS claude in-instance) is detection-only and
@@ -54,7 +55,7 @@ async function runScenario(
   } catch (err) {
     return {
       ...base,
-      detection: { scenarioId: scenario.id, detected: false, misses: [] },
+      detection: detection ?? { scenarioId: scenario.id, detected: false, misses: [] },
       appliedVia: "skipped",
       reachedGreen: false,
       error: err instanceof Error ? err.message : String(err),
@@ -113,10 +114,9 @@ async function main() {
   // touches our own, so overlapping runs can't destroy each other (point 5).
   const runId = `${Date.now().toString(36)}-${process.pid}`;
   const driver = new IncusDriver(undefined, `shep-onb-${runId}-`);
-  const tarball = buildTarball();
-
   const results: ScenarioResult[] = [];
   try {
+    const tarball = buildTarball();
     for (const s of scenarios) {
       console.log(`\n=== ${s.id} (${s.image}) ===`);
       results.push(await runScenario(driver, s, tarball));

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -6,9 +6,10 @@ import { IncusDriver } from "./incus";
 import { SCENARIOS } from "./scenarios";
 import { seedInstance } from "./seed";
 import { bootShepherd, probeDiagnostics } from "./probe";
-import { applyAgent } from "./apply";
+import { applyAgent, applyVerbatim } from "./apply";
 import { assertDetection } from "./assert";
 import { buildGapReport } from "./report";
+import { remediationsFor } from "./remediations";
 import type { DetectionResult, Scenario, ScenarioResult } from "./types";
 
 /** `git archive` the current HEAD into a tarball the seed engine pushes. */
@@ -32,26 +33,28 @@ async function runScenario(
     const before = await probeDiagnostics(driver, scenario.id);
     detection = assertDetection(before, scenario.id, scenario.expect);
 
-    // Phase 1 has no verbatim path yet. A scenario that disabled the agent
-    // (claude-missing — the agent IS claude in-instance) is detection-only and
-    // is NOT counted as an advice gap. Everything else uses the agent proxy-user.
-    if (scenario.agentIncompatible) {
-      console.log(`[${scenario.id}] agent-incompatible — detection-only in Phase 1`);
-      return {
-        ...base,
-        detection,
-        appliedVia: "skipped",
-        reachedGreen: false,
-        detectionOnly: true,
-      };
+    const verbatim = remediationsFor(before);
+    let appliedVia: ScenarioResult["appliedVia"];
+    let detectionOnly = false;
+    if (verbatim.length > 0) {
+      await applyVerbatim(driver, scenario.id, before);
+      appliedVia = "verbatim";
+    } else if (scenario.agentIncompatible) {
+      console.log(`[${scenario.id}] agent-incompatible — detection-only`);
+      appliedVia = "skipped";
+      detectionOnly = true;
+    } else {
+      await applyAgent(driver, scenario.id, before);
+      appliedVia = "agent";
     }
-    if (scenario.coaching === "structured") {
-      console.log(`[${scenario.id}] structured coaching not yet available — using agent path`);
-    }
-    await applyAgent(driver, scenario.id, before);
-
-    const after = await probeDiagnostics(driver, scenario.id);
-    return { ...base, detection, appliedVia: "agent", reachedGreen: after.overall === "ok" };
+    const after = detectionOnly ? before : await probeDiagnostics(driver, scenario.id);
+    return {
+      ...base,
+      detection,
+      appliedVia,
+      reachedGreen: !detectionOnly && after.overall === "ok",
+      detectionOnly: detectionOnly || undefined,
+    };
   } catch (err) {
     return {
       ...base,

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -1,0 +1,140 @@
+import { execFileSync } from "node:child_process";
+import { closeSync, mkdirSync, mkdtempSync, openSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { IncusDriver } from "./incus";
+import { SCENARIOS } from "./scenarios";
+import { seedInstance } from "./seed";
+import { bootShepherd, probeDiagnostics } from "./probe";
+import { applyAgent } from "./apply";
+import { assertDetection } from "./assert";
+import { buildGapReport } from "./report";
+import type { Scenario, ScenarioResult } from "./types";
+
+/** `git archive` the current HEAD into a tarball the seed engine pushes. */
+function buildTarball(): string {
+  const dir = mkdtempSync(join(tmpdir(), "shep-onb-"));
+  const tar = join(dir, "shepherd.tar");
+  execFileSync("git", ["archive", "--format=tar", "-o", tar, "HEAD"]);
+  return tar;
+}
+
+async function runScenario(
+  driver: IncusDriver,
+  scenario: Scenario,
+  tarball: string,
+): Promise<ScenarioResult> {
+  const base = { scenarioId: scenario.id, image: scenario.image };
+  try {
+    await seedInstance(driver, scenario, tarball);
+    await bootShepherd(driver, scenario.id);
+    const before = await probeDiagnostics(driver, scenario.id);
+    const detection = assertDetection(before, scenario.id, scenario.expect);
+
+    // Phase 1 has no verbatim path yet. A scenario that disabled the agent
+    // (claude-missing — the agent IS claude in-instance) is detection-only and
+    // is NOT counted as an advice gap. Everything else uses the agent proxy-user.
+    if (scenario.agentIncompatible) {
+      console.log(`[${scenario.id}] agent-incompatible — detection-only in Phase 1`);
+      return {
+        ...base,
+        detection,
+        appliedVia: "skipped",
+        reachedGreen: false,
+        detectionOnly: true,
+      };
+    }
+    if (scenario.coaching === "structured") {
+      console.log(`[${scenario.id}] structured coaching not yet available — using agent path`);
+    }
+    await applyAgent(driver, scenario.id, before);
+
+    const after = await probeDiagnostics(driver, scenario.id);
+    return { ...base, detection, appliedVia: "agent", reachedGreen: after.overall === "ok" };
+  } catch (err) {
+    return {
+      ...base,
+      detection: { scenarioId: scenario.id, detected: false, misses: [] },
+      appliedVia: "skipped",
+      reachedGreen: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    await driver.delete(scenario.id);
+  }
+}
+
+// FIXED absolute path under the host-global Shepherd state dir (~/.shepherd) — NOT
+// $TMPDIR. A systemd-user timer service and an interactive shell can see different
+// $TMPDIR (PrivateTmp, per-session dirs), which would defeat the lock; $HOME is
+// stable and identical for both (same user), so the lock is genuinely host-wide.
+const LOCK_PATH = join(homedir(), ".shepherd", "onboarding-harness.lock");
+
+/** Acquire a host-wide exclusive lock so concurrent runs never share the Incus
+ *  host. `wx` fails if the lock already exists. Returns a release fn. */
+function acquireHostLock(): () => void {
+  mkdirSync(dirname(LOCK_PATH), { recursive: true });
+  let fd: number;
+  try {
+    fd = openSync(LOCK_PATH, "wx");
+  } catch {
+    console.error(`another onboarding-harness run holds ${LOCK_PATH}; aborting`);
+    process.exit(3);
+  }
+  return () => {
+    closeSync(fd);
+    try {
+      unlinkSync(LOCK_PATH);
+    } catch {
+      /* already gone */
+    }
+  };
+}
+
+async function main() {
+  // Maintenance: reap ALL harness instances across runs (manual recovery only).
+  if (process.argv.includes("--reap-orphans")) {
+    await new IncusDriver(undefined, "shep-onb-").sweep();
+    console.log("reaped all shep-onb-* instances");
+    return;
+  }
+
+  const only = process.argv.includes("--scenario")
+    ? process.argv[process.argv.indexOf("--scenario") + 1]
+    : null;
+  const scenarios = only ? SCENARIOS.filter((s) => s.id === only) : SCENARIOS;
+  if (scenarios.length === 0) {
+    console.error(`no scenario matched ${only}`);
+    process.exit(2);
+  }
+
+  const release = acquireHostLock();
+  // Per-run prefix isolates this run's instances; `sweep()` then only ever
+  // touches our own, so overlapping runs can't destroy each other (point 5).
+  const runId = `${Date.now().toString(36)}-${process.pid}`;
+  const driver = new IncusDriver(undefined, `shep-onb-${runId}-`);
+  const tarball = buildTarball();
+
+  const results: ScenarioResult[] = [];
+  try {
+    for (const s of scenarios) {
+      console.log(`\n=== ${s.id} (${s.image}) ===`);
+      results.push(await runScenario(driver, s, tarball));
+    }
+  } finally {
+    await driver.sweep(); // teardown — own-prefix instances only
+    release();
+  }
+
+  const report = buildGapReport(results);
+  const out = join(process.cwd(), "onboarding-gap-report.md");
+  writeFileSync(out, report);
+  console.log(`\n${report}\nReport written to ${out}`);
+
+  // Non-zero exit if any APPLY-ABLE scenario failed to reach green (detection-only
+  // scenarios are excluded). Consumed by the Phase 2 gate.
+  const applicable = results.filter((r) => !r.detectionOnly);
+  process.exit(applicable.every((r) => r.reachedGreen) ? 0 : 1);
+}
+
+void main();

--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -1,0 +1,89 @@
+import type { Scenario } from "./types";
+
+/**
+ * The Phase 1 messy-environment catalog. Every baseline is assumed bootable
+ * (the bun runtime is installed by the seed engine before these seeds run — see
+ * seed.ts); defects are layered on top so degraded Shepherd can still boot and
+ * self-diagnose. `coaching: "structured"` scenarios fall back to the agent path
+ * in Phase 1 (no diagnostics remediation field exists yet) and switch to the
+ * deterministic verbatim path in Phase 2.
+ */
+export const SCENARIOS: Scenario[] = [
+  {
+    id: "gh-unauthed",
+    image: "images:ubuntu/24.04",
+    seed: [
+      "type gh >/dev/null 2>&1 || (apt-get update && apt-get install -y gh)",
+      "rm -rf ~/.config/gh", // installed but never logged in
+    ],
+    expect: [{ id: "gh", state: "error" }],
+    coaching: "prose",
+  },
+  {
+    id: "gh-missing",
+    image: "images:debian/12",
+    seed: ["apt-get remove -y gh 2>/dev/null || true", "rm -f /usr/bin/gh /usr/local/bin/gh"],
+    expect: [{ id: "gh", state: "error" }],
+    coaching: "structured",
+  },
+  {
+    id: "tailscale-missing",
+    image: "images:ubuntu/24.04",
+    seed: ["rm -f /usr/bin/tailscale /usr/sbin/tailscaled /usr/local/bin/tailscale"],
+    expect: [{ id: "tailscale", state: "error" }],
+    coaching: "structured",
+  },
+  {
+    id: "tailscale-not-serving",
+    image: "images:ubuntu/24.04",
+    // tailscaled up + logged in but no `serve` mapping for the HUD port → warning.
+    // Uses a faked tailnet so no real login is required (see seed.ts notes).
+    seed: ["systemctl start tailscaled || true", "tailscale serve reset 2>/dev/null || true"],
+    expect: [{ id: "tailscale", state: "warning" }],
+    coaching: "prose",
+  },
+  {
+    id: "herdr-missing",
+    image: "images:archlinux",
+    seed: ["rm -f /usr/local/bin/herdr ~/.local/bin/herdr"],
+    expect: [{ id: "herdr", state: "error" }],
+    coaching: "structured",
+  },
+  {
+    // claudeProbe is PRESENCE-ONLY (a successful `claude --version` ⇒ ok; there is
+    // NO auth/login probe, so there is deliberately no "claude-unauthed" scenario —
+    // an unauthed-but-installed claude reports ok by design, which the gap report
+    // notes as a known non-detection, not a discovered gap). Removing claude also
+    // disables the agent apply path (the agent IS claude running in-instance), so
+    // this scenario is detection-only in Phase 1 and verbatim-reinstalled in Phase 2.
+    id: "claude-missing",
+    image: "images:fedora/40",
+    seed: ["rm -f /usr/local/bin/claude ~/.local/bin/claude"],
+    expect: [{ id: "claude", state: "error" }],
+    coaching: "structured",
+    agentIncompatible: true,
+  },
+  {
+    id: "git-missing",
+    image: "images:alpine/3.20",
+    seed: ["apk del git 2>/dev/null || true", "rm -f /usr/bin/git"],
+    expect: [{ id: "git", state: "error" }],
+    coaching: "structured",
+  },
+  {
+    id: "node-too-old",
+    image: "images:debian/12",
+    // Debian 12's archive node is well below NODE_MIN_VERSION → warning.
+    seed: ["apt-get update", "apt-get install -y nodejs"],
+    expect: [{ id: "node", state: "warning" }],
+    coaching: "structured",
+  },
+  {
+    id: "herdr-too-old",
+    image: "images:ubuntu/24.04",
+    // Seed engine installs a pinned old herdr build at this path (see seed.ts).
+    seed: ["echo 'placeholder: old herdr pinned by baseline' >/dev/null"],
+    expect: [{ id: "herdr", state: "warning" }],
+    coaching: "structured",
+  },
+];

--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -4,13 +4,31 @@ import type { Scenario } from "./types";
  * The messy-environment scenario catalog. Every baseline is assumed bootable
  * (the bun runtime is installed by the seed engine before these seeds run — see
  * seed.ts); defects are layered on top so degraded Shepherd can still boot and
- * self-diagnose. `coaching: "structured"` scenarios use the deterministic
- * verbatim-remediation path (LLM-free gate); every such scenario MUST have a
- * matching REMEDIATIONS entry in remediations.ts. `coaching: "prose"` scenarios
- * are agent-path only (e.g. distro-specific installs with no single one-liner).
+ * self-diagnose.
+ *
+ * Two classes of scenario:
+ *  - **Green-able** — the seeded defect can be coached back to `ok` unattended.
+ *    `coaching: "structured"` uses the deterministic verbatim-remediation path
+ *    (LLM-free, release-gate-eligible) and MUST have a matching REMEDIATIONS entry
+ *    in remediations.ts; `coaching: "prose"` uses the agent path (e.g. git, whose
+ *    install is distro-specific with no single one-liner — the agent picks apt/
+ *    apk/dnf). Success = the scenario's expected checks are `ok` after the apply.
+ *  - **Detection-only** (`detectionOnly: true`) — the defect is detectable but its
+ *    fix needs a human/secret that a throw-away instance cannot supply (`gh auth
+ *    login` device-flow; a Tailscale tailnet login + `serve` to reach `ok`). These
+ *    verify detection only: no apply, excluded from the green tally and the gate,
+ *    reported as DETECTION-ONLY. This is the honest "onboarding still needs the
+ *    user here" finding the gap report exists to surface.
+ *
+ * NOTE: scenarios that require provisioning the harness doesn't yet implement
+ * (a pinned outdated herdr build; a faked tailnet for the not-serving warning
+ * state) are intentionally OMITTED rather than shipped as permanent gaps — see
+ * the deferred follow-ups in docs/superpowers/specs/...-design.md.
  */
 export const SCENARIOS: Scenario[] = [
   {
+    // gh authentication is interactive (device-flow) — undetectable-to-green in a
+    // throw-away instance, so detection-only.
     id: "gh-unauthed",
     image: "images:ubuntu/24.04",
     seed: [
@@ -19,31 +37,27 @@ export const SCENARIOS: Scenario[] = [
     ],
     expect: [{ id: "gh", state: "error" }],
     coaching: "prose",
+    detectionOnly: true,
   },
   {
+    // gh install is distro-specific AND auth is interactive → detection-only.
     id: "gh-missing",
     image: "images:debian/12",
     seed: ["apt-get remove -y gh 2>/dev/null || true", "rm -f /usr/bin/gh /usr/local/bin/gh"],
     expect: [{ id: "gh", state: "error" }],
-    // prose: gh install is distro-specific; no single verbatim one-liner covers
-    // ubuntu/debian/alpine/arch/fedora → agent path only, not the deterministic gate.
     coaching: "prose",
+    detectionOnly: true,
   },
   {
+    // tailscale=ok requires a logged-in tailnet AND `serve` — neither is reachable
+    // unattended without a tailnet auth key, so detection-only (installing the
+    // binary alone never clears the check).
     id: "tailscale-missing",
     image: "images:ubuntu/24.04",
     seed: ["rm -f /usr/bin/tailscale /usr/sbin/tailscaled /usr/local/bin/tailscale"],
     expect: [{ id: "tailscale", state: "error" }],
-    coaching: "structured",
-  },
-  {
-    id: "tailscale-not-serving",
-    image: "images:ubuntu/24.04",
-    // tailscaled up + logged in but no `serve` mapping for the HUD port → warning.
-    // Uses a faked tailnet so no real login is required (see seed.ts notes).
-    seed: ["systemctl start tailscaled || true", "tailscale serve reset 2>/dev/null || true"],
-    expect: [{ id: "tailscale", state: "warning" }],
     coaching: "prose",
+    detectionOnly: true,
   },
   {
     id: "herdr-missing",
@@ -55,10 +69,10 @@ export const SCENARIOS: Scenario[] = [
   {
     // claudeProbe is PRESENCE-ONLY (a successful `claude --version` ⇒ ok; there is
     // NO auth/login probe, so there is deliberately no "claude-unauthed" scenario —
-    // an unauthed-but-installed claude reports ok by design, which the gap report
-    // notes as a known non-detection, not a discovered gap). Removing claude also
-    // disables the agent apply path (the agent IS claude running in-instance), so
-    // this scenario is detection-only in Phase 1 and verbatim-reinstalled in Phase 2.
+    // an unauthed-but-installed claude reports ok by design). Removing claude
+    // disables the agent path (the agent IS claude in-instance), but verbatim-first
+    // dispatch reinstalls claude deterministically, so this IS green-able;
+    // `agentIncompatible` is only the fallback if the verbatim fix were ever absent.
     id: "claude-missing",
     image: "images:fedora/40",
     seed: ["rm -f /usr/local/bin/claude ~/.local/bin/claude"],
@@ -72,7 +86,7 @@ export const SCENARIOS: Scenario[] = [
     seed: ["apk del git 2>/dev/null || true", "rm -f /usr/bin/git"],
     expect: [{ id: "git", state: "error" }],
     // prose: git install is distro-specific; no single verbatim one-liner covers
-    // ubuntu/debian/alpine/arch/fedora → agent path only, not the deterministic gate.
+    // ubuntu/debian/alpine/arch/fedora → agent path picks the right installer.
     coaching: "prose",
   },
   {
@@ -81,14 +95,6 @@ export const SCENARIOS: Scenario[] = [
     // Debian 12's archive node is well below NODE_MIN_VERSION → warning.
     seed: ["apt-get update", "apt-get install -y nodejs"],
     expect: [{ id: "node", state: "warning" }],
-    coaching: "structured",
-  },
-  {
-    id: "herdr-too-old",
-    image: "images:ubuntu/24.04",
-    // Seed engine installs a pinned old herdr build at this path (see seed.ts).
-    seed: ["echo 'placeholder: old herdr pinned by baseline' >/dev/null"],
-    expect: [{ id: "herdr", state: "warning" }],
     coaching: "structured",
   },
 ];

--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -1,12 +1,13 @@
 import type { Scenario } from "./types";
 
 /**
- * The Phase 1 messy-environment catalog. Every baseline is assumed bootable
+ * The messy-environment scenario catalog. Every baseline is assumed bootable
  * (the bun runtime is installed by the seed engine before these seeds run — see
  * seed.ts); defects are layered on top so degraded Shepherd can still boot and
- * self-diagnose. `coaching: "structured"` scenarios fall back to the agent path
- * in Phase 1 (no diagnostics remediation field exists yet) and switch to the
- * deterministic verbatim path in Phase 2.
+ * self-diagnose. `coaching: "structured"` scenarios use the deterministic
+ * verbatim-remediation path (LLM-free gate); every such scenario MUST have a
+ * matching REMEDIATIONS entry in remediations.ts. `coaching: "prose"` scenarios
+ * are agent-path only (e.g. distro-specific installs with no single one-liner).
  */
 export const SCENARIOS: Scenario[] = [
   {
@@ -24,7 +25,9 @@ export const SCENARIOS: Scenario[] = [
     image: "images:debian/12",
     seed: ["apt-get remove -y gh 2>/dev/null || true", "rm -f /usr/bin/gh /usr/local/bin/gh"],
     expect: [{ id: "gh", state: "error" }],
-    coaching: "structured",
+    // prose: gh install is distro-specific; no single verbatim one-liner covers
+    // ubuntu/debian/alpine/arch/fedora → agent path only, not the deterministic gate.
+    coaching: "prose",
   },
   {
     id: "tailscale-missing",
@@ -68,7 +71,9 @@ export const SCENARIOS: Scenario[] = [
     image: "images:alpine/3.20",
     seed: ["apk del git 2>/dev/null || true", "rm -f /usr/bin/git"],
     expect: [{ id: "git", state: "error" }],
-    coaching: "structured",
+    // prose: git install is distro-specific; no single verbatim one-liner covers
+    // ubuntu/debian/alpine/arch/fedora → agent path only, not the deterministic gate.
+    coaching: "prose",
   },
   {
     id: "node-too-old",

--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -1,0 +1,44 @@
+import type { IncusDriver } from "./incus";
+import type { Scenario } from "./types";
+
+const SHEPHERD_DIR = "/opt/shepherd";
+
+/** Commands that turn a fresh instance into a bootable-Shepherd baseline: bun
+ *  runtime + the pushed working-tree build + deps + the claude CLI (agent path).
+ *  Defects are layered AFTER this so degraded Shepherd can still boot. */
+function baselineCommands(): string[] {
+  return [
+    "command -v curl >/dev/null 2>&1 || (apt-get update && apt-get install -y curl) || (apk add --no-cache curl) || (dnf install -y curl) || (pacman -Sy --noconfirm curl)",
+    "curl -fsSL https://bun.sh/install | bash",
+    `mkdir -p ${SHEPHERD_DIR} && tar -xf /root/shepherd.tar -C ${SHEPHERD_DIR}`,
+    `cd ${SHEPHERD_DIR} && ~/.bun/bin/bun install`,
+    // claude CLI for the agent apply path; harmless if a scenario removes it later.
+    "curl -fsSL https://claude.ai/install.sh | bash || true",
+  ];
+}
+
+/** Launch a fresh instance for `scenario`, install the bootable baseline, push
+ *  the Shepherd build, then run the scenario's messy-state seed commands. */
+export async function seedInstance(
+  driver: IncusDriver,
+  scenario: Scenario,
+  tarballPath: string,
+): Promise<void> {
+  await driver.launch(scenario.image, scenario.id, {
+    vm: scenario.vm,
+    profile: "shep-onb",
+  });
+  // Wait for the instance's network/init to settle before exec.
+  await driver.exec(scenario.id, [
+    "sh",
+    "-c",
+    "for i in $(seq 1 30); do test -e /bin/sh && break; sleep 1; done",
+  ]);
+  await driver.push(scenario.id, tarballPath, "/root/shepherd.tar");
+  for (const cmd of baselineCommands()) {
+    await driver.exec(scenario.id, ["sh", "-c", cmd]);
+  }
+  for (const cmd of scenario.seed) {
+    await driver.exec(scenario.id, ["sh", "-c", cmd]);
+  }
+}

--- a/ci/onboarding-harness/shepherd-onboarding.service
+++ b/ci/onboarding-harness/shepherd-onboarding.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Shepherd onboarding regression harness (nightly)
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/Work/shepherd
+ExecStart=/usr/bin/env bun run onboarding:test

--- a/ci/onboarding-harness/shepherd-onboarding.timer
+++ b/ci/onboarding-harness/shepherd-onboarding.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Nightly Shepherd onboarding harness run
+
+[Timer]
+OnCalendar=*-*-* 03:30:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ci/onboarding-harness/types.ts
+++ b/ci/onboarding-harness/types.ts
@@ -12,11 +12,21 @@ export interface Scenario {
   seed: string[];
   /** Checks that MUST be flagged at the given state after seeding. */
   expect: ExpectedCheck[];
-  /** Which apply path to use. In Phase 1 "structured" falls back to the agent path. */
+  /** Which apply path to use when the scenario is green-able. "structured" ⇒ a
+   *  verbatim REMEDIATIONS command (LLM-free, gate-eligible); "prose" ⇒ the agent
+   *  interprets the coaching. Ignored when `detectionOnly` is set (no apply runs). */
   coaching: "structured" | "prose";
-  /** The agent apply path runs `claude` INSIDE the instance; a scenario that
-   *  removes claude (claude-missing) cannot use it. Such scenarios are
-   *  detection-only in Phase 1 and switch to the verbatim path in Phase 2. */
+  /** The defect is DETECTABLE but cannot be auto-remediated to green in a
+   *  throw-away instance because the fix needs a human/secret (e.g. `gh auth login`
+   *  device-flow, a Tailscale tailnet login + `serve`). Such scenarios verify
+   *  detection only — no apply is attempted, they are excluded from the green
+   *  tally and from the release gate, and the gap report classes them DETECTION-ONLY.
+   *  An honest "onboarding still needs the user here" finding, not a failure. */
+  detectionOnly?: boolean;
+  /** Safety net: the agent apply path runs `claude` INSIDE the instance, so a
+   *  scenario that removes claude can't use it. With verbatim-first dispatch this
+   *  rarely triggers (claude-missing has a verbatim reinstall), but a scenario with
+   *  no verbatim fix AND no claude falls back to detection-only rather than failing. */
   agentIncompatible?: boolean;
 }
 

--- a/ci/onboarding-harness/types.ts
+++ b/ci/onboarding-harness/types.ts
@@ -1,0 +1,61 @@
+import type { DiagnosticState, DiagnosticsSnapshot } from "../../src/types";
+
+/** A single deliberately-messy environment definition (pure data). */
+export interface Scenario {
+  /** Stable kebab id; also the Incus instance name suffix. */
+  id: string;
+  /** Incus image ref, e.g. "images:ubuntu/24.04" or "images:debian/12". */
+  image: string;
+  /** Provision as a full VM instead of a system container (kernel/arch fidelity). */
+  vm?: boolean;
+  /** Shell commands run in order (each via `sh -c`) to produce the messy state. */
+  seed: string[];
+  /** Checks that MUST be flagged at the given state after seeding. */
+  expect: ExpectedCheck[];
+  /** Which apply path to use. In Phase 1 "structured" falls back to the agent path. */
+  coaching: "structured" | "prose";
+  /** The agent apply path runs `claude` INSIDE the instance; a scenario that
+   *  removes claude (claude-missing) cannot use it. Such scenarios are
+   *  detection-only in Phase 1 and switch to the verbatim path in Phase 2. */
+  agentIncompatible?: boolean;
+}
+
+export interface ExpectedCheck {
+  id: string;
+  state: DiagnosticState;
+}
+
+/** Result of comparing a captured snapshot against a scenario's expectations. */
+export interface DetectionResult {
+  scenarioId: string;
+  /** True when every expected check matched its expected state. */
+  detected: boolean;
+  /** Expected checks whose actual state diverged (incl. absent from snapshot). */
+  misses: Array<{ id: string; want: DiagnosticState; got: DiagnosticState | "absent" }>;
+}
+
+/** Full per-scenario outcome the report is built from. */
+export interface ScenarioResult {
+  scenarioId: string;
+  image: string;
+  detection: DetectionResult;
+  appliedVia: "agent" | "verbatim" | "skipped";
+  reachedGreen: boolean;
+  /** True when no apply was attempted BY DESIGN (e.g. claude-missing in Phase 1):
+   *  the report classifies it DETECTION-ONLY, not an advice gap. */
+  detectionOnly?: boolean;
+  error?: string;
+}
+
+/** One `incus` CLI invocation result. */
+export interface IncusExec {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/** Injectable `incus` runner: receives argv (after the `incus` binary), resolves
+ *  with captured output. Tests inject a fake; production runs the real binary. */
+export type IncusRunner = (args: string[]) => Promise<IncusExec>;
+
+export type { DiagnosticsSnapshot };

--- a/ci/onboarding-harness/types.ts
+++ b/ci/onboarding-harness/types.ts
@@ -1,4 +1,4 @@
-import type { DiagnosticState, DiagnosticsSnapshot } from "../../src/types";
+import type { DiagnosticState } from "../../src/types";
 
 /** A single deliberately-messy environment definition (pure data). */
 export interface Scenario {
@@ -57,5 +57,3 @@ export interface IncusExec {
 /** Injectable `incus` runner: receives argv (after the `incus` binary), resolves
  *  with captured output. Tests inject a fake; production runs the real binary. */
 export type IncusRunner = (args: string[]) => Promise<IncusExec>;
-
-export type { DiagnosticsSnapshot };

--- a/docs/superpowers/plans/2026-06-13-onboarding-challenge-harness.md
+++ b/docs/superpowers/plans/2026-06-13-onboarding-challenge-harness.md
@@ -1,0 +1,1501 @@
+# Onboarding Challenge & Regression Harness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a throw-away-environment harness that boots deliberately-messy Incus instances, runs Shepherd inside them in degraded mode, captures its diagnostics, applies the coaching, re-probes, and emits a gap report — manually in Phase 1, then green-gating releases in Phase 2.
+
+**Architecture:** A standalone Bun/TS harness in `ci/onboarding-harness/`, separate from the shipped server. Six small units — an injectable `incus` CLI driver, a declarative scenario catalog, a seed engine, a diagnostics probe, an apply engine (agent path in P1, verbatim path added in P2), and a gap-report builder — wired by an orchestrator with guaranteed teardown. Phase 2 adds an additive structured-remediation field to `src/diagnostics.ts` and ops wiring (nightly + release gate).
+
+**Tech Stack:** Bun, TypeScript, `bun:test`, the `incus` CLI (system containers + VMs), Shepherd's existing `GET /api/diagnostics` HTTP API, the `claude` CLI (agent apply path).
+
+---
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `ci/onboarding-harness/types.ts` | Shared harness types (`Scenario`, `ExpectedCheck`, `DetectionResult`, `ScenarioResult`, `IncusExec`, `IncusRunner`). |
+| `ci/onboarding-harness/incus.ts` | `IncusDriver` — thin, injectable wrapper over the `incus` CLI (launch/exec/push/pull/delete/list/sweep). |
+| `ci/onboarding-harness/scenarios.ts` | `SCENARIOS` — the declarative messy-environment catalog (pure data). |
+| `ci/onboarding-harness/assert.ts` | `assertDetection` — pure: snapshot + expectations → `DetectionResult`. |
+| `ci/onboarding-harness/report.ts` | `buildGapReport` — pure: `ScenarioResult[]` → markdown. |
+| `ci/onboarding-harness/seed.ts` | `seedInstance` — launch, install bootable-Shepherd baseline, run scenario seed. |
+| `ci/onboarding-harness/probe.ts` | `bootShepherd` + `probeDiagnostics` — start Shepherd, poll `GET /api/diagnostics?refresh=1`. |
+| `ci/onboarding-harness/apply.ts` | `applyCoaching` — agent path (P1) and verbatim path (P2), dispatched by scenario `coaching`. |
+| `ci/onboarding-harness/run.ts` | Orchestrator + CLI entry; per-scenario seed→probe→assert→apply→re-probe with `finally` teardown + orphan sweep; writes the report. |
+| `scripts/onboarding-gate.sh` | Phase 2: runs the deterministic (verbatim) subset, exits non-zero on red — the release gate. |
+| `ci/onboarding-harness/shepherd-onboarding.{service,timer}` | Phase 2: systemd units for the nightly run on the Incus host. |
+| `src/diagnostics.ts` (modify) | Phase 2: additive `REMEDIATIONS` map + `remediation?` field decoration on non-ok checks. |
+| `src/types.ts` (modify) | Phase 2: add optional `remediation?: Remediation` to `DiagnosticCheck` + the `Remediation` type. |
+| `test/onboarding-harness/*.test.ts` | Unit tests for the pure/injectable units (driver argv, catalog validity, assert, report, resolution). |
+
+**Test strategy:** Logic with no real-Incus dependency (driver argv-building, catalog validity, `assertDetection`, `buildGapReport`, hintKey→text resolution, P2 remediation decoration) is unit-tested via `bun:test` with injected runners — mirroring `src/diagnostics.ts`'s injectable-deps pattern. The end-to-end seed→boot→apply→re-probe loop requires a real Incus host and is validated by a documented manual run (Task 9), not unit tests.
+
+---
+
+## Phase 1 — gap-report MVP (manual, no product change)
+
+### Task 1: Scaffolding, shared types, and tooling globs
+
+**Files:**
+- Create: `ci/onboarding-harness/types.ts`
+- Modify: `package.json` (lint glob)
+
+- [ ] **Step 1: Create the shared types**
+
+`ci/onboarding-harness/types.ts`:
+
+```ts
+import type { DiagnosticState, DiagnosticsSnapshot } from "../../src/types";
+
+/** A single deliberately-messy environment definition (pure data). */
+export interface Scenario {
+  /** Stable kebab id; also the Incus instance name suffix. */
+  id: string;
+  /** Incus image ref, e.g. "images:ubuntu/24.04" or "images:debian/12". */
+  image: string;
+  /** Provision as a full VM instead of a system container (kernel/arch fidelity). */
+  vm?: boolean;
+  /** Shell commands run in order (each via `sh -c`) to produce the messy state. */
+  seed: string[];
+  /** Checks that MUST be flagged at the given state after seeding. */
+  expect: ExpectedCheck[];
+  /** Which apply path to use. In Phase 1 "structured" falls back to the agent path. */
+  coaching: "structured" | "prose";
+}
+
+export interface ExpectedCheck {
+  id: string;
+  state: DiagnosticState;
+}
+
+/** Result of comparing a captured snapshot against a scenario's expectations. */
+export interface DetectionResult {
+  scenarioId: string;
+  /** True when every expected check matched its expected state. */
+  detected: boolean;
+  /** Expected checks whose actual state diverged (incl. absent from snapshot). */
+  misses: Array<{ id: string; want: DiagnosticState; got: DiagnosticState | "absent" }>;
+}
+
+/** Full per-scenario outcome the report is built from. */
+export interface ScenarioResult {
+  scenarioId: string;
+  image: string;
+  detection: DetectionResult;
+  appliedVia: "agent" | "verbatim" | "skipped";
+  reachedGreen: boolean;
+  error?: string;
+}
+
+/** One `incus` CLI invocation result. */
+export interface IncusExec {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/** Injectable `incus` runner: receives argv (after the `incus` binary), resolves
+ *  with captured output. Tests inject a fake; production runs the real binary. */
+export type IncusRunner = (args: string[]) => Promise<IncusExec>;
+
+export type { DiagnosticsSnapshot };
+```
+
+- [ ] **Step 2: Add the harness to the lint glob**
+
+In `package.json`, change the `lint` script to include the harness:
+
+```json
+"lint": "eslint --no-error-on-unmatched-pattern src test ui/src ci/onboarding-harness",
+```
+
+- [ ] **Step 3: Verify type-check + lint pass**
+
+Run: `bun install && bunx tsc --noEmit && bun run lint`
+Expected: PASS (no errors; the new file type-checks).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ci/onboarding-harness/types.ts package.json
+git commit -m "feat(onboarding-harness): shared types + lint glob"
+```
+
+---
+
+### Task 2: IncusDriver (injectable CLI wrapper)
+
+**Files:**
+- Create: `ci/onboarding-harness/incus.ts`
+- Test: `test/onboarding-harness/incus.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`test/onboarding-harness/incus.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { IncusDriver } from "../../ci/onboarding-harness/incus";
+import type { IncusExec } from "../../ci/onboarding-harness/types";
+
+function recorder(reply: Partial<IncusExec> = {}) {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<IncusExec> => {
+    calls.push(args);
+    return { stdout: "", stderr: "", code: 0, ...reply };
+  };
+  return { calls, run };
+}
+
+describe("IncusDriver", () => {
+  it("launches a system container with the managed-name prefix and profile", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await d.launch("images:ubuntu/24.04", "gh-unauthed", { profile: "shep-onb" });
+    expect(calls[0]).toEqual([
+      "launch", "images:ubuntu/24.04", "shep-onb-gh-unauthed", "--profile", "shep-onb",
+    ]);
+  });
+
+  it("adds --vm when the scenario requests a VM", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await d.launch("images:ubuntu/24.04", "kernel-x", { vm: true });
+    expect(calls[0]).toContain("--vm");
+  });
+
+  it("execs a command inside the instance via -- separator", async () => {
+    const { calls, run } = recorder({ stdout: "ok" });
+    const d = new IncusDriver(run, "shep-onb-");
+    const r = await d.exec("gh-unauthed", ["sh", "-c", "echo hi"]);
+    expect(calls[0]).toEqual(["exec", "shep-onb-gh-unauthed", "--", "sh", "-c", "echo hi"]);
+    expect(r.stdout).toBe("ok");
+  });
+
+  it("force-deletes an instance", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await d.delete("gh-unauthed");
+    expect(calls[0]).toEqual(["delete", "shep-onb-gh-unauthed", "--force"]);
+  });
+
+  it("lists only managed instances and sweeps them", async () => {
+    const { calls, run } = recorder({
+      stdout: JSON.stringify([{ name: "shep-onb-a" }, { name: "unrelated" }, { name: "shep-onb-b" }]),
+    });
+    const d = new IncusDriver(run, "shep-onb-");
+    expect(await d.listManaged()).toEqual(["shep-onb-a", "shep-onb-b"]);
+    await d.sweep();
+    // listManaged (1) + one delete per managed instance (2)
+    expect(calls.filter((c) => c[0] === "delete")).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/onboarding-harness/incus.test.ts`
+Expected: FAIL — `Cannot find module '../../ci/onboarding-harness/incus'`.
+
+- [ ] **Step 3: Write the implementation**
+
+`ci/onboarding-harness/incus.ts`:
+
+```ts
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { IncusExec, IncusRunner } from "./types";
+
+const execFileAsync = promisify(execFile);
+
+/** Default runner: invokes the real `incus` binary, capturing output and never
+ *  throwing on a non-zero exit (the caller inspects `code`). */
+const defaultRunner: IncusRunner = async (args) => {
+  try {
+    const { stdout, stderr } = await execFileAsync("incus", args, { encoding: "utf8" });
+    return { stdout: stdout.toString(), stderr: stderr.toString(), code: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; code?: number };
+    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", code: e.code ?? 1 };
+  }
+};
+
+/** Thin, throw-away-instance lifecycle wrapper over the `incus` CLI. All managed
+ *  instances carry `prefix` in their name so `sweep()` can reap leaks. */
+export class IncusDriver {
+  constructor(
+    private run: IncusRunner = defaultRunner,
+    private prefix = "shep-onb-",
+  ) {}
+
+  private full(name: string): string {
+    return this.prefix + name;
+  }
+
+  async launch(
+    image: string,
+    name: string,
+    opts: { vm?: boolean; profile?: string } = {},
+  ): Promise<void> {
+    const args = ["launch", image, this.full(name)];
+    if (opts.vm) args.push("--vm");
+    if (opts.profile) args.push("--profile", opts.profile);
+    const r = await this.run(args);
+    if (r.code !== 0) throw new Error(`incus launch failed: ${r.stderr || r.stdout}`);
+  }
+
+  async exec(name: string, cmd: string[]): Promise<IncusExec> {
+    return this.run(["exec", this.full(name), "--", ...cmd]);
+  }
+
+  async push(name: string, localPath: string, remotePath: string): Promise<void> {
+    const r = await this.run(["file", "push", localPath, `${this.full(name)}${remotePath}`]);
+    if (r.code !== 0) throw new Error(`incus file push failed: ${r.stderr}`);
+  }
+
+  async pull(name: string, remotePath: string, localPath: string): Promise<void> {
+    const r = await this.run(["file", "pull", `${this.full(name)}${remotePath}`, localPath]);
+    if (r.code !== 0) throw new Error(`incus file pull failed: ${r.stderr}`);
+  }
+
+  async delete(name: string): Promise<void> {
+    await this.run(["delete", this.full(name), "--force"]);
+  }
+
+  /** Names of all instances carrying the managed prefix. */
+  async listManaged(): Promise<string[]> {
+    const r = await this.run(["list", "--format", "json"]);
+    if (r.code !== 0) return [];
+    const rows = JSON.parse(r.stdout) as Array<{ name: string }>;
+    return rows.map((x) => x.name).filter((n) => n.startsWith(this.prefix));
+  }
+
+  /** Force-delete every managed instance (orphan reaper, run at start + teardown). */
+  async sweep(): Promise<void> {
+    for (const full of await this.listManaged()) {
+      await this.run(["delete", full, "--force"]);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/onboarding-harness/incus.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/onboarding-harness/incus.ts test/onboarding-harness/incus.test.ts
+git commit -m "feat(onboarding-harness): injectable Incus CLI driver"
+```
+
+---
+
+### Task 3: Scenario catalog + validity test
+
+**Files:**
+- Create: `ci/onboarding-harness/scenarios.ts`
+- Test: `test/onboarding-harness/scenarios.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`test/onboarding-harness/scenarios.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { SCENARIOS } from "../../ci/onboarding-harness/scenarios";
+
+const CHECK_IDS = new Set(["bun", "node", "claude", "gh", "git", "herdr", "tailscale"]);
+
+describe("scenario catalog", () => {
+  it("has unique kebab-case ids", () => {
+    const ids = SCENARIOS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+  });
+
+  it("only expects known check ids", () => {
+    for (const s of SCENARIOS) {
+      for (const e of s.expect) expect(CHECK_IDS.has(e.id)).toBe(true);
+    }
+  });
+
+  it("every scenario seeds at least one command and expects at least one flag", () => {
+    for (const s of SCENARIOS) {
+      expect(s.seed.length).toBeGreaterThan(0);
+      expect(s.expect.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("covers each non-bun check id at least once", () => {
+    const covered = new Set(SCENARIOS.flatMap((s) => s.expect.map((e) => e.id)));
+    for (const id of ["node", "claude", "gh", "git", "herdr", "tailscale"]) {
+      expect(covered.has(id)).toBe(true);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/onboarding-harness/scenarios.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the catalog**
+
+`ci/onboarding-harness/scenarios.ts`:
+
+```ts
+import type { Scenario } from "./types";
+
+/**
+ * The Phase 1 messy-environment catalog. Every baseline is assumed bootable
+ * (the bun runtime is installed by the seed engine before these seeds run — see
+ * seed.ts); defects are layered on top so degraded Shepherd can still boot and
+ * self-diagnose. `coaching: "structured"` scenarios fall back to the agent path
+ * in Phase 1 (no diagnostics remediation field exists yet) and switch to the
+ * deterministic verbatim path in Phase 2.
+ */
+export const SCENARIOS: Scenario[] = [
+  {
+    id: "gh-unauthed",
+    image: "images:ubuntu/24.04",
+    seed: [
+      "type gh >/dev/null 2>&1 || (apt-get update && apt-get install -y gh)",
+      "rm -rf ~/.config/gh", // installed but never logged in
+    ],
+    expect: [{ id: "gh", state: "error" }],
+    coaching: "prose",
+  },
+  {
+    id: "gh-missing",
+    image: "images:debian/12",
+    seed: ["apt-get remove -y gh 2>/dev/null || true", "rm -f /usr/bin/gh /usr/local/bin/gh"],
+    expect: [{ id: "gh", state: "error" }],
+    coaching: "structured",
+  },
+  {
+    id: "tailscale-missing",
+    image: "images:ubuntu/24.04",
+    seed: ["rm -f /usr/bin/tailscale /usr/sbin/tailscaled /usr/local/bin/tailscale"],
+    expect: [{ id: "tailscale", state: "error" }],
+    coaching: "structured",
+  },
+  {
+    id: "tailscale-not-serving",
+    image: "images:ubuntu/24.04",
+    // tailscaled up + logged in but no `serve` mapping for the HUD port → warning.
+    // Uses a faked tailnet so no real login is required (see seed.ts notes).
+    seed: ["systemctl start tailscaled || true", "tailscale serve reset 2>/dev/null || true"],
+    expect: [{ id: "tailscale", state: "warning" }],
+    coaching: "prose",
+  },
+  {
+    id: "herdr-missing",
+    image: "images:archlinux",
+    seed: ["rm -f /usr/local/bin/herdr ~/.local/bin/herdr"],
+    expect: [{ id: "herdr", state: "error" }],
+    coaching: "structured",
+  },
+  {
+    id: "claude-missing",
+    image: "images:fedora/40",
+    seed: ["rm -f /usr/local/bin/claude ~/.local/bin/claude"],
+    expect: [{ id: "claude", state: "error" }],
+    coaching: "structured",
+  },
+  {
+    id: "git-missing",
+    image: "images:alpine/3.20",
+    seed: ["apk del git 2>/dev/null || true", "rm -f /usr/bin/git"],
+    expect: [{ id: "git", state: "error" }],
+    coaching: "structured",
+  },
+  {
+    id: "node-too-old",
+    image: "images:debian/12",
+    // Debian 12's archive node is well below NODE_MIN_VERSION → warning.
+    seed: ["apt-get update", "apt-get install -y nodejs"],
+    expect: [{ id: "node", state: "warning" }],
+    coaching: "structured",
+  },
+  {
+    id: "herdr-too-old",
+    image: "images:ubuntu/24.04",
+    // Seed engine installs a pinned old herdr build at this path (see seed.ts).
+    seed: ["echo 'placeholder: old herdr pinned by baseline' >/dev/null"],
+    expect: [{ id: "herdr", state: "warning" }],
+    coaching: "structured",
+  },
+];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/onboarding-harness/scenarios.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/onboarding-harness/scenarios.ts test/onboarding-harness/scenarios.test.ts
+git commit -m "feat(onboarding-harness): messy-environment scenario catalog"
+```
+
+---
+
+### Task 4: Detection assertion (pure)
+
+**Files:**
+- Create: `ci/onboarding-harness/assert.ts`
+- Test: `test/onboarding-harness/assert.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`test/onboarding-harness/assert.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { assertDetection } from "../../ci/onboarding-harness/assert";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+function snap(checks: Array<[string, "ok" | "warning" | "error"]>): DiagnosticsSnapshot {
+  return {
+    checks: checks.map(([id, state]) => ({ id, state, hintKey: `k_${id}` })),
+    generatedAt: 1,
+    overall: checks.some(([, s]) => s === "error")
+      ? "error"
+      : checks.some(([, s]) => s === "warning")
+        ? "warning"
+        : "ok",
+  };
+}
+
+describe("assertDetection", () => {
+  it("detects when every expected check matches its state", () => {
+    const r = assertDetection(snap([["gh", "error"], ["git", "ok"]]), "s", [
+      { id: "gh", state: "error" },
+    ]);
+    expect(r.detected).toBe(true);
+    expect(r.misses).toEqual([]);
+  });
+
+  it("reports a state mismatch as a miss", () => {
+    const r = assertDetection(snap([["gh", "warning"]]), "s", [{ id: "gh", state: "error" }]);
+    expect(r.detected).toBe(false);
+    expect(r.misses).toEqual([{ id: "gh", want: "error", got: "warning" }]);
+  });
+
+  it("reports an absent expected check as a miss", () => {
+    const r = assertDetection(snap([["git", "ok"]]), "s", [{ id: "gh", state: "error" }]);
+    expect(r.misses).toEqual([{ id: "gh", want: "error", got: "absent" }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/onboarding-harness/assert.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+`ci/onboarding-harness/assert.ts`:
+
+```ts
+import type { DiagnosticsSnapshot } from "../../src/types";
+import type { DetectionResult, ExpectedCheck } from "./types";
+
+/** Pure: does the captured snapshot flag every expected check at its expected
+ *  state? Any mismatch (wrong state, or check absent) is a detection gap. */
+export function assertDetection(
+  snapshot: DiagnosticsSnapshot,
+  scenarioId: string,
+  expected: ExpectedCheck[],
+): DetectionResult {
+  const byId = new Map(snapshot.checks.map((c) => [c.id, c.state]));
+  const misses: DetectionResult["misses"] = [];
+  for (const e of expected) {
+    const got = byId.get(e.id) ?? "absent";
+    if (got !== e.state) misses.push({ id: e.id, want: e.state, got });
+  }
+  return { scenarioId, detected: misses.length === 0, misses };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/onboarding-harness/assert.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/onboarding-harness/assert.ts test/onboarding-harness/assert.test.ts
+git commit -m "feat(onboarding-harness): detection assertion"
+```
+
+---
+
+### Task 5: Gap-report builder (pure)
+
+**Files:**
+- Create: `ci/onboarding-harness/report.ts`
+- Test: `test/onboarding-harness/report.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`test/onboarding-harness/report.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { buildGapReport } from "../../ci/onboarding-harness/report";
+import type { ScenarioResult } from "../../ci/onboarding-harness/types";
+
+const results: ScenarioResult[] = [
+  {
+    scenarioId: "gh-unauthed",
+    image: "images:ubuntu/24.04",
+    detection: { scenarioId: "gh-unauthed", detected: true, misses: [] },
+    appliedVia: "agent",
+    reachedGreen: true,
+  },
+  {
+    scenarioId: "tailscale-missing",
+    image: "images:ubuntu/24.04",
+    detection: {
+      scenarioId: "tailscale-missing",
+      detected: false,
+      misses: [{ id: "tailscale", want: "error", got: "absent" }],
+    },
+    appliedVia: "agent",
+    reachedGreen: false,
+    error: "agent gave up",
+  },
+];
+
+describe("buildGapReport", () => {
+  it("summarizes pass/fail counts and lists gaps", () => {
+    const md = buildGapReport(results);
+    expect(md).toContain("# Onboarding Gap Report");
+    expect(md).toContain("1 / 2 scenarios reached green");
+    expect(md).toContain("gh-unauthed");
+    expect(md).toContain("tailscale-missing");
+    expect(md).toContain("tailscale want=error got=absent");
+    expect(md).toContain("agent gave up");
+  });
+
+  it("marks a detection-but-not-fixed scenario as an advice gap", () => {
+    const md = buildGapReport([
+      {
+        scenarioId: "x",
+        image: "i",
+        detection: { scenarioId: "x", detected: true, misses: [] },
+        appliedVia: "agent",
+        reachedGreen: false,
+      },
+    ]);
+    expect(md).toContain("ADVICE GAP");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/onboarding-harness/report.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+`ci/onboarding-harness/report.ts`:
+
+```ts
+import type { ScenarioResult } from "./types";
+
+/** Pure: render the per-scenario outcomes as a markdown gap report. Classifies
+ *  each scenario as PASS, DETECTION GAP (defect missed/misclassified), or
+ *  ADVICE GAP (detected but coaching didn't reach green). */
+export function buildGapReport(results: ScenarioResult[]): string {
+  const green = results.filter((r) => r.reachedGreen).length;
+  const lines: string[] = [
+    "# Onboarding Gap Report",
+    "",
+    `**${green} / ${results.length} scenarios reached green.**`,
+    "",
+    "| Scenario | Image | Detected | Applied | Green | Classification |",
+    "| --- | --- | --- | --- | --- | --- |",
+  ];
+  const gaps: string[] = [];
+  for (const r of results) {
+    const klass = r.reachedGreen
+      ? "PASS"
+      : !r.detection.detected
+        ? "DETECTION GAP"
+        : "ADVICE GAP";
+    lines.push(
+      `| ${r.scenarioId} | ${r.image} | ${r.detection.detected ? "yes" : "no"} | ${r.appliedVia} | ${r.reachedGreen ? "yes" : "no"} | ${klass} |`,
+    );
+    if (klass !== "PASS") {
+      const misses = r.detection.misses.map((m) => `${m.id} want=${m.want} got=${m.got}`).join("; ");
+      gaps.push(
+        `- **${r.scenarioId}** (${klass})${misses ? ` — ${misses}` : ""}${r.error ? ` — ${r.error}` : ""}`,
+      );
+    }
+  }
+  if (gaps.length) {
+    lines.push("", "## Gaps", "", ...gaps);
+  }
+  return lines.join("\n") + "\n";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/onboarding-harness/report.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/onboarding-harness/report.ts test/onboarding-harness/report.test.ts
+git commit -m "feat(onboarding-harness): gap-report builder"
+```
+
+---
+
+### Task 6: Seed engine
+
+**Files:**
+- Create: `ci/onboarding-harness/seed.ts`
+- Test: `test/onboarding-harness/seed.test.ts`
+
+The seed engine launches an instance, installs the **bootable-Shepherd baseline** (bun + the working-tree build + `bun install`, plus `claude` for the agent path), then runs the scenario's `seed`. The baseline install is what guarantees Shepherd can boot before defects are layered on. Unit-tested via the injected `IncusDriver` runner by asserting the command sequence.
+
+- [ ] **Step 1: Write the failing test**
+
+`test/onboarding-harness/seed.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { IncusDriver } from "../../ci/onboarding-harness/incus";
+import { seedInstance } from "../../ci/onboarding-harness/seed";
+import type { IncusExec } from "../../ci/onboarding-harness/types";
+
+function recorder() {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<IncusExec> => {
+    calls.push(args);
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  return { calls, run };
+}
+
+const scenario = {
+  id: "gh-unauthed",
+  image: "images:ubuntu/24.04",
+  seed: ["rm -rf ~/.config/gh"],
+  expect: [{ id: "gh", state: "error" as const }],
+  coaching: "prose" as const,
+};
+
+describe("seedInstance", () => {
+  it("launches, installs the bun baseline, then runs the scenario seed in order", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await seedInstance(d, scenario, "/tmp/shepherd.tar");
+
+    expect(calls[0][0]).toBe("launch");
+    expect(calls[0]).toContain("images:ubuntu/24.04");
+
+    const flat = calls.map((c) => c.join(" "));
+    // baseline installs bun before the scenario seed runs
+    const bunIdx = flat.findIndex((c) => c.includes("bun.sh/install"));
+    const seedIdx = flat.findIndex((c) => c.includes("rm -rf ~/.config/gh"));
+    expect(bunIdx).toBeGreaterThanOrEqual(0);
+    expect(seedIdx).toBeGreaterThan(bunIdx);
+  });
+
+  it("pushes the Shepherd build tarball into the instance", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await seedInstance(d, scenario, "/tmp/shepherd.tar");
+    const push = calls.find((c) => c[0] === "file" && c[1] === "push");
+    expect(push).toBeDefined();
+    expect(push!).toContain("/tmp/shepherd.tar");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/onboarding-harness/seed.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+`ci/onboarding-harness/seed.ts`:
+
+```ts
+import type { IncusDriver } from "./incus";
+import type { Scenario } from "./types";
+
+const SHEPHERD_DIR = "/opt/shepherd";
+
+/** Commands that turn a fresh instance into a bootable-Shepherd baseline: bun
+ *  runtime + the pushed working-tree build + deps + the claude CLI (agent path).
+ *  Defects are layered AFTER this so degraded Shepherd can still boot. */
+function baselineCommands(): string[] {
+  return [
+    "command -v curl >/dev/null 2>&1 || (apt-get update && apt-get install -y curl) || (apk add --no-cache curl) || (dnf install -y curl) || (pacman -Sy --noconfirm curl)",
+    "curl -fsSL https://bun.sh/install | bash",
+    `mkdir -p ${SHEPHERD_DIR} && tar -xf /root/shepherd.tar -C ${SHEPHERD_DIR}`,
+    `cd ${SHEPHERD_DIR} && ~/.bun/bin/bun install`,
+    // claude CLI for the agent apply path; harmless if a scenario removes it later.
+    "curl -fsSL https://claude.ai/install.sh | bash || true",
+  ];
+}
+
+/** Launch a fresh instance for `scenario`, install the bootable baseline, push
+ *  the Shepherd build, then run the scenario's messy-state seed commands. */
+export async function seedInstance(
+  driver: IncusDriver,
+  scenario: Scenario,
+  tarballPath: string,
+): Promise<void> {
+  await driver.launch(scenario.image, scenario.id, {
+    vm: scenario.vm,
+    profile: "shep-onb",
+  });
+  // Wait for the instance's network/init to settle before exec.
+  await driver.exec(scenario.id, ["sh", "-c", "for i in $(seq 1 30); do test -e /bin/sh && break; sleep 1; done"]);
+  await driver.push(scenario.id, tarballPath, "/root/shepherd.tar");
+  for (const cmd of baselineCommands()) {
+    await driver.exec(scenario.id, ["sh", "-c", cmd]);
+  }
+  for (const cmd of scenario.seed) {
+    await driver.exec(scenario.id, ["sh", "-c", cmd]);
+  }
+}
+```
+
+> **Note for the implementer:** `herdr-too-old` and `tailscale-not-serving` need real fixture state (a pinned old `herdr` binary; a faked tailnet so `resolveNodeHost` returns non-null without a real login). Add those as extra baseline branches keyed on `scenario.id` once the real-Incus run (Task 9) confirms the probe behavior; do not block Phase 1's other scenarios on them.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/onboarding-harness/seed.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/onboarding-harness/seed.ts test/onboarding-harness/seed.test.ts
+git commit -m "feat(onboarding-harness): seed engine (baseline + messy state)"
+```
+
+---
+
+### Task 7: Diagnostics probe (boot Shepherd + capture snapshot)
+
+**Files:**
+- Create: `ci/onboarding-harness/probe.ts`
+- Test: `test/onboarding-harness/probe.test.ts`
+
+`probeDiagnostics` runs `curl` **inside** the instance against Shepherd's loopback API and parses the JSON snapshot. `bootShepherd` starts the server detached and polls until the API answers. Both are exercised via the injected driver runner.
+
+- [ ] **Step 1: Write the failing test**
+
+`test/onboarding-harness/probe.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { IncusDriver } from "../../ci/onboarding-harness/incus";
+import { probeDiagnostics } from "../../ci/onboarding-harness/probe";
+import type { IncusExec } from "../../ci/onboarding-harness/types";
+
+describe("probeDiagnostics", () => {
+  it("curls the diagnostics endpoint inside the instance and parses the snapshot", async () => {
+    const snapshot = {
+      checks: [{ id: "gh", state: "error", hintKey: "diagnostics_hint_gh_not_authenticated" }],
+      generatedAt: 5,
+      overall: "error",
+    };
+    const calls: string[][] = [];
+    const run = async (args: string[]): Promise<IncusExec> => {
+      calls.push(args);
+      return { stdout: JSON.stringify(snapshot), stderr: "", code: 0 };
+    };
+    const d = new IncusDriver(run, "shep-onb-");
+    const snap = await probeDiagnostics(d, "gh-unauthed");
+    expect(snap.overall).toBe("error");
+    expect(snap.checks[0].id).toBe("gh");
+    // exec'd a curl against the loopback diagnostics endpoint with refresh
+    const cmd = calls[0].join(" ");
+    expect(cmd).toContain("curl");
+    expect(cmd).toContain("/api/diagnostics?refresh=1");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/onboarding-harness/probe.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+`ci/onboarding-harness/probe.ts`:
+
+```ts
+import type { IncusDriver } from "./incus";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+const SHEPHERD_DIR = "/opt/shepherd";
+const PORT = 7330; // config.port default
+
+/** Start Shepherd detached inside the instance and poll until its HTTP API
+ *  answers (or time out). Degraded boots are expected — we only need the server
+ *  process up far enough to serve `/api/diagnostics`. */
+export async function bootShepherd(driver: IncusDriver, name: string): Promise<void> {
+  await driver.exec(name, [
+    "sh",
+    "-c",
+    `cd ${SHEPHERD_DIR} && nohup ~/.bun/bin/bun run start >/var/log/shepherd.log 2>&1 &`,
+  ]);
+  const poll = await driver.exec(name, [
+    "sh",
+    "-c",
+    `for i in $(seq 1 60); do curl -sf localhost:${PORT}/api/diagnostics >/dev/null 2>&1 && exit 0; sleep 1; done; exit 1`,
+  ]);
+  if (poll.code !== 0) throw new Error(`Shepherd did not come up in ${name}`);
+}
+
+/** Capture a fresh diagnostics snapshot from inside the instance. */
+export async function probeDiagnostics(
+  driver: IncusDriver,
+  name: string,
+): Promise<DiagnosticsSnapshot> {
+  const r = await driver.exec(name, [
+    "sh",
+    "-c",
+    `curl -s localhost:${PORT}/api/diagnostics?refresh=1`,
+  ]);
+  if (r.code !== 0 || !r.stdout.trim()) {
+    throw new Error(`diagnostics probe failed in ${name}: ${r.stderr || "empty"}`);
+  }
+  return JSON.parse(r.stdout) as DiagnosticsSnapshot;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/onboarding-harness/probe.test.ts`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/onboarding-harness/probe.ts test/onboarding-harness/probe.test.ts
+git commit -m "feat(onboarding-harness): diagnostics probe + boot"
+```
+
+---
+
+### Task 8: Apply engine — agent path + hintKey resolution
+
+**Files:**
+- Create: `ci/onboarding-harness/apply.ts`
+- Test: `test/onboarding-harness/apply.test.ts`
+
+Phase 1 applies coaching via a **Claude Code agent** acting as a proxy-user. The agent receives the diagnostics snapshot plus the **resolved EN coaching text** for each non-ok check (what a real user sees), and is let loose to fix the env. `resolveCoaching` is a pure, unit-tested function reading `ui/messages/en.json`; the agent invocation's command construction is also asserted. `coaching: "structured"` falls back to the agent path in Phase 1 (logged), since no remediation field exists yet.
+
+- [ ] **Step 1: Write the failing test**
+
+`test/onboarding-harness/apply.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { resolveCoaching, buildAgentPrompt } from "../../ci/onboarding-harness/apply";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+const snap: DiagnosticsSnapshot = {
+  checks: [
+    { id: "gh", state: "error", hintKey: "diagnostics_hint_gh_not_authenticated" },
+    { id: "git", state: "ok", hintKey: "diagnostics_hint_git_ok" },
+  ],
+  generatedAt: 1,
+  overall: "error",
+};
+
+describe("resolveCoaching", () => {
+  it("resolves non-ok check hintKeys to their EN message text", () => {
+    const messages = { diagnostics_hint_gh_not_authenticated: "Run `gh auth login` to authenticate." };
+    const lines = resolveCoaching(snap, messages);
+    expect(lines).toEqual([{ id: "gh", text: "Run `gh auth login` to authenticate." }]);
+  });
+
+  it("skips ok checks and falls back to the raw key when a message is missing", () => {
+    const lines = resolveCoaching(snap, {});
+    expect(lines).toEqual([{ id: "gh", text: "diagnostics_hint_gh_not_authenticated" }]);
+  });
+});
+
+describe("buildAgentPrompt", () => {
+  it("includes the coaching text and a clear success instruction", () => {
+    const p = buildAgentPrompt([{ id: "gh", text: "Run gh auth login." }]);
+    expect(p).toContain("Run gh auth login.");
+    expect(p.toLowerCase()).toContain("healthy");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/onboarding-harness/apply.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+`ci/onboarding-harness/apply.ts`:
+
+```ts
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { IncusDriver } from "./incus";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+export interface CoachingLine {
+  id: string;
+  text: string;
+}
+
+/** Pure: resolve every non-ok check's hintKey to the user-visible EN string
+ *  (falling back to the raw key). This is exactly the coaching a new user reads. */
+export function resolveCoaching(
+  snapshot: DiagnosticsSnapshot,
+  messages: Record<string, string>,
+): CoachingLine[] {
+  return snapshot.checks
+    .filter((c) => c.state !== "ok")
+    .map((c) => ({ id: c.id, text: messages[c.hintKey] ?? c.hintKey }));
+}
+
+/** Pure: the proxy-user prompt — only what a real user sees, plus the goal. */
+export function buildAgentPrompt(lines: CoachingLine[]): string {
+  const coaching = lines.map((l) => `- (${l.id}) ${l.text}`).join("\n");
+  return [
+    "You are a new user setting up Shepherd on this machine.",
+    "Shepherd's onboarding screen shows these issues and advice:",
+    "",
+    coaching,
+    "",
+    "Follow this advice to get the machine to a healthy state. Use the shell.",
+    "Do not invent steps beyond what the advice implies. Stop when done.",
+  ].join("\n");
+}
+
+/** Load the EN catalog once (the user-visible coaching source of truth). */
+export function loadEnMessages(): Record<string, string> {
+  const p = join(import.meta.dir, "..", "..", "ui", "messages", "en.json");
+  return JSON.parse(readFileSync(p, "utf8")) as Record<string, string>;
+}
+
+/** Run the proxy-user agent inside the instance to act on the coaching. Returns
+ *  the agent's exit code (0 ⇒ it believes it finished). Auth is provided by a
+ *  ~/.claude credential mounted into the instance by run.ts. */
+export async function applyAgent(
+  driver: IncusDriver,
+  name: string,
+  snapshot: DiagnosticsSnapshot,
+): Promise<number> {
+  const lines = resolveCoaching(snapshot, loadEnMessages());
+  if (lines.length === 0) return 0;
+  const prompt = buildAgentPrompt(lines);
+  const r = await driver.exec(name, [
+    "sh",
+    "-c",
+    `claude -p ${shellQuote(prompt)} --permission-mode dontAsk --allowedTools Bash`,
+  ]);
+  return r.code;
+}
+
+/** Minimal single-quote shell escape for embedding the prompt safely. */
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test ./test/onboarding-harness/apply.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/onboarding-harness/apply.ts test/onboarding-harness/apply.test.ts
+git commit -m "feat(onboarding-harness): agent apply path + coaching resolution"
+```
+
+---
+
+### Task 9: Orchestrator + CLI + manual integration run
+
+**Files:**
+- Create: `ci/onboarding-harness/run.ts`
+- Create: `ci/onboarding-harness/README.md`
+- Modify: `package.json` (add `onboarding:test` script)
+
+- [ ] **Step 1: Write the orchestrator**
+
+`ci/onboarding-harness/run.ts`:
+
+```ts
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { IncusDriver } from "./incus";
+import { SCENARIOS } from "./scenarios";
+import { seedInstance } from "./seed";
+import { bootShepherd, probeDiagnostics } from "./probe";
+import { applyAgent } from "./apply";
+import { assertDetection } from "./assert";
+import { buildGapReport } from "./report";
+import type { Scenario, ScenarioResult } from "./types";
+
+/** `git archive` the current HEAD into a tarball the seed engine pushes. */
+function buildTarball(): string {
+  const dir = mkdtempSync(join(tmpdir(), "shep-onb-"));
+  const tar = join(dir, "shepherd.tar");
+  execFileSync("git", ["archive", "--format=tar", "-o", tar, "HEAD"]);
+  return tar;
+}
+
+async function runScenario(
+  driver: IncusDriver,
+  scenario: Scenario,
+  tarball: string,
+): Promise<ScenarioResult> {
+  const base = { scenarioId: scenario.id, image: scenario.image };
+  try {
+    await seedInstance(driver, scenario, tarball);
+    await bootShepherd(driver, scenario.id);
+    const before = await probeDiagnostics(driver, scenario.id);
+    const detection = assertDetection(before, scenario.id, scenario.expect);
+
+    // Phase 1: agent path for all scenarios (structured falls back, logged).
+    if (scenario.coaching === "structured") {
+      console.log(`[${scenario.id}] structured coaching not yet available — using agent path`);
+    }
+    await applyAgent(driver, scenario.id, before);
+
+    const after = await probeDiagnostics(driver, scenario.id);
+    return { ...base, detection, appliedVia: "agent", reachedGreen: after.overall === "ok" };
+  } catch (err) {
+    return {
+      ...base,
+      detection: { scenarioId: scenario.id, detected: false, misses: [] },
+      appliedVia: "skipped",
+      reachedGreen: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    await driver.delete(scenario.id);
+  }
+}
+
+async function main() {
+  const only = process.argv.includes("--scenario")
+    ? process.argv[process.argv.indexOf("--scenario") + 1]
+    : null;
+  const scenarios = only ? SCENARIOS.filter((s) => s.id === only) : SCENARIOS;
+  if (scenarios.length === 0) {
+    console.error(`no scenario matched ${only}`);
+    process.exit(2);
+  }
+
+  const driver = new IncusDriver();
+  await driver.sweep(); // reap any leaked instances from a prior crashed run
+  const tarball = buildTarball();
+
+  const results: ScenarioResult[] = [];
+  try {
+    for (const s of scenarios) {
+      console.log(`\n=== ${s.id} (${s.image}) ===`);
+      results.push(await runScenario(driver, s, tarball));
+    }
+  } finally {
+    await driver.sweep(); // belt-and-suspenders teardown
+  }
+
+  const report = buildGapReport(results);
+  const out = join(process.cwd(), "onboarding-gap-report.md");
+  writeFileSync(out, report);
+  console.log(`\n${report}\nReport written to ${out}`);
+
+  // Non-zero exit if any scenario failed to reach green (used by the P2 gate).
+  process.exit(results.every((r) => r.reachedGreen) ? 0 : 1);
+}
+
+void main();
+```
+
+- [ ] **Step 2: Add the npm script**
+
+In `package.json` `scripts`:
+
+```json
+"onboarding:test": "bun run ci/onboarding-harness/run.ts",
+```
+
+- [ ] **Step 3: Write the README (auth + prereqs + usage)**
+
+`ci/onboarding-harness/README.md` — document: requires the self-hosted Incus host; create the `shep-onb` Incus profile with resource caps + (for tailscale/systemd scenarios) `security.nesting=true` and a TUN device; mount `~/.claude` credentials for the agent path; run with `bun run onboarding:test [--scenario <id>]`; report lands at `onboarding-gap-report.md`; instances are name-prefixed `shep-onb-` and swept on start and teardown.
+
+- [ ] **Step 4: Verify type-check, lint, and the unit suite**
+
+Run: `bunx tsc --noEmit && bun run lint && bun test ./test/onboarding-harness`
+Expected: PASS (all harness unit tests green; no type/lint errors).
+
+- [ ] **Step 5: Manual integration run (on the Incus host)**
+
+Run: `bun run onboarding:test --scenario gh-unauthed`
+Expected: launches `shep-onb-gh-unauthed`, boots Shepherd, prints a snapshot with `gh: error`, runs the agent, re-probes, deletes the instance, writes `onboarding-gap-report.md`. Confirm `incus list` shows no leaked `shep-onb-*` instances afterward.
+Then iterate the `seed.ts` per-scenario fixtures (herdr-too-old, tailscale-not-serving) against real probe behavior until each scenario's detection matches `expect`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ci/onboarding-harness/run.ts ci/onboarding-harness/README.md package.json
+git commit -m "feat(onboarding-harness): orchestrator, CLI, and run docs"
+```
+
+---
+
+## Phase 2 — deterministic regression tier + ops wiring
+
+### Task 10: Structured remediation in diagnostics (additive product change)
+
+**Files:**
+- Modify: `src/types.ts` (add `Remediation` + `remediation?` on `DiagnosticCheck`)
+- Modify: `src/diagnostics.ts` (add `REMEDIATIONS` map + decorate non-ok checks)
+- Modify: `test/diagnostics.test.ts` (purity test allows the optional field; add a remediation test)
+
+> **i18n note:** `remediation.run` is a verbatim shell command (data, like a CLI invocation), not authored UI chrome — exempt from the message catalog, same class as PR titles / `TASK-07` designations. No new EN/DE keys.
+> **Feature-catalog note:** this is server-only plumbing surfacing no new UI — mark the commit/PR `[no-feature-entry]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/diagnostics.test.ts`:
+
+```ts
+it("attaches a structured remediation to a known non-ok check", async () => {
+  const svc = new DiagnosticsService({
+    runVersion: versionRunner({ ...HEALTHY_VERSIONS, bun: new Error("ENOENT") }),
+    runGhAuth: async () => {},
+    resolveHost: async () => "node.example.ts.net",
+    runServeStatus: async () =>
+      JSON.stringify({ Web: { "node.example.ts.net:443": { Handlers: { "/": { Proxy: "http://127.0.0.1:7330" } } } } }),
+  });
+  const snap = await svc.check(1000);
+  const bun = snap.checks.find((c) => c.id === "bun")!;
+  expect(bun.state).toBe("error");
+  expect(bun.remediation?.run).toContain("bun.sh/install");
+});
+
+it("does not attach a remediation to ok checks", async () => {
+  const svc = new DiagnosticsService(healthyDeps());
+  const snap = await svc.check(1000);
+  expect(snap.checks.every((c) => c.state !== "ok" || c.remediation === undefined)).toBe(true);
+});
+```
+
+Also update the payload-shape helper (around `test/diagnostics.test.ts:52`) to permit the optional key:
+
+```ts
+const keys = Object.keys(check).sort();
+expect(keys).toEqual(check.remediation ? ["hintKey", "id", "remediation", "state"] : ["hintKey", "id", "state"]);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/diagnostics.test.ts`
+Expected: FAIL — `remediation` is not a property of `DiagnosticCheck`.
+
+- [ ] **Step 3: Extend the types**
+
+In `src/types.ts`, add above `DiagnosticCheck`:
+
+```ts
+/** A runnable, verbatim remediation for a non-ok check — a single shell command
+ *  the onboarding harness (and a future one-click-fix UI) can execute as-is.
+ *  Verbatim data (a command), not authored UI text — exempt from i18n. */
+export interface Remediation {
+  run: string;
+}
+```
+
+And add the optional field to `DiagnosticCheck`:
+
+```ts
+export interface DiagnosticCheck {
+  id: string;
+  state: DiagnosticState;
+  hintKey: string;
+  /** Present only on non-ok checks that reduce to a single runnable command. */
+  remediation?: Remediation;
+}
+```
+
+- [ ] **Step 4: Add the remediation map + decoration in `src/diagnostics.ts`**
+
+Add the map near the top (after imports):
+
+```ts
+import type { DiagnosticCheck, DiagnosticsSnapshot, DiagnosticState, Remediation } from "./types";
+
+/** hintKey → verbatim shell remediation. Only keys that reduce cleanly to one
+ *  command appear here; prose-only coaching (e.g. interactive `gh auth login`,
+ *  tailscale serve setup) is intentionally absent and stays on the agent path. */
+const REMEDIATIONS: Record<string, Remediation> = {
+  diagnostics_hint_bun_missing: { run: "curl -fsSL https://bun.sh/install | bash" },
+  diagnostics_hint_node_missing: { run: "curl -fsSL https://fnm.vercel.app/install | bash && fnm install --lts" },
+  diagnostics_hint_herdr_missing: { run: "curl -fsSL https://herdr.dev/install.sh | bash" },
+  diagnostics_hint_claude_missing: { run: "curl -fsSL https://claude.ai/install.sh | bash" },
+};
+```
+
+> **Implementer:** confirm each install URL against the project's actual install docs before committing — use the exact command Shepherd's onboarding docs prescribe. Drop any key whose canonical fix is not a single non-interactive command.
+
+In the `check(now)` method, decorate the assembled checks before building the snapshot (find where `const snapshot: DiagnosticsSnapshot = {` is built, ~line 260, and map the checks first):
+
+```ts
+const decorated = checks.map((c): DiagnosticCheck => {
+  const r = c.state !== "ok" ? REMEDIATIONS[c.hintKey] : undefined;
+  return r ? { ...c, remediation: r } : c;
+});
+const snapshot: DiagnosticsSnapshot = {
+  checks: decorated,
+  generatedAt: now,
+  overall: worstOf(decorated),
+};
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test ./test/diagnostics.test.ts`
+Expected: PASS (existing tests + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types.ts src/diagnostics.ts test/diagnostics.test.ts
+git commit -m "feat(diagnostics): structured remediation for command-fixable checks [no-feature-entry]"
+```
+
+---
+
+### Task 11: Verbatim apply path
+
+**Files:**
+- Modify: `ci/onboarding-harness/apply.ts` (add `applyVerbatim`)
+- Modify: `ci/onboarding-harness/run.ts` (dispatch `structured` → verbatim)
+- Test: `test/onboarding-harness/apply.test.ts` (add verbatim cases)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/onboarding-harness/apply.test.ts`:
+
+```ts
+import { collectRemediations } from "../../ci/onboarding-harness/apply";
+
+describe("collectRemediations", () => {
+  it("returns the verbatim run command for each non-ok check that has one", () => {
+    const s = {
+      checks: [
+        { id: "bun", state: "error", hintKey: "k", remediation: { run: "curl x | bash" } },
+        { id: "gh", state: "error", hintKey: "k2" }, // prose-only, no remediation
+        { id: "git", state: "ok", hintKey: "k3", remediation: { run: "noop" } },
+      ],
+      generatedAt: 1,
+      overall: "error" as const,
+    };
+    expect(collectRemediations(s)).toEqual(["curl x | bash"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test ./test/onboarding-harness/apply.test.ts`
+Expected: FAIL — `collectRemediations` is not exported.
+
+- [ ] **Step 3: Implement `collectRemediations` + `applyVerbatim`**
+
+Append to `ci/onboarding-harness/apply.ts`:
+
+```ts
+/** Pure: the verbatim shell commands for every non-ok check that ships one. */
+export function collectRemediations(snapshot: DiagnosticsSnapshot): string[] {
+  return snapshot.checks
+    .filter((c) => c.state !== "ok" && c.remediation)
+    .map((c) => c.remediation!.run);
+}
+
+/** Run each structured remediation verbatim inside the instance. Returns false
+ *  if any command exits non-zero. */
+export async function applyVerbatim(
+  driver: IncusDriver,
+  name: string,
+  snapshot: DiagnosticsSnapshot,
+): Promise<boolean> {
+  for (const cmd of collectRemediations(snapshot)) {
+    const r = await driver.exec(name, ["sh", "-c", cmd]);
+    if (r.code !== 0) return false;
+  }
+  return true;
+}
+```
+
+- [ ] **Step 4: Dispatch in `run.ts`**
+
+In `runScenario`, replace the Phase-1 agent-only block with path dispatch:
+
+```ts
+let appliedVia: ScenarioResult["appliedVia"];
+if (scenario.coaching === "structured" && collectRemediations(before).length > 0) {
+  await applyVerbatim(driver, scenario.id, before);
+  appliedVia = "verbatim";
+} else {
+  await applyAgent(driver, scenario.id, before);
+  appliedVia = "agent";
+}
+const after = await probeDiagnostics(driver, scenario.id);
+return { ...base, detection, appliedVia, reachedGreen: after.overall === "ok" };
+```
+
+Update the imports in `run.ts` to include `applyVerbatim` and `collectRemediations`.
+
+- [ ] **Step 5: Run tests + type-check**
+
+Run: `bun test ./test/onboarding-harness && bunx tsc --noEmit && bun run lint`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ci/onboarding-harness/apply.ts ci/onboarding-harness/run.ts test/onboarding-harness/apply.test.ts
+git commit -m "feat(onboarding-harness): deterministic verbatim apply path"
+```
+
+---
+
+### Task 12: Release gate + nightly wiring (Incus host)
+
+**Files:**
+- Create: `scripts/onboarding-gate.sh`
+- Create: `ci/onboarding-harness/shepherd-onboarding.service`
+- Create: `ci/onboarding-harness/shepherd-onboarding.timer`
+- Modify: `ci/onboarding-harness/README.md` (install instructions for the units)
+
+The gate runs the **deterministic verbatim subset** (the `structured` scenarios) so the release check is reproducible and LLM-free; agent-path scenarios are reported by the nightly run but do not gate.
+
+- [ ] **Step 1: Write the gate script**
+
+`scripts/onboarding-gate.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Release gate: run the deterministic (structured) onboarding scenarios and fail
+# the release if any does not reach a healthy state. Requires the Incus host.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+STRUCTURED_IDS=$(bun -e '
+  import("./ci/onboarding-harness/scenarios.ts").then(({ SCENARIOS }) =>
+    console.log(SCENARIOS.filter((s) => s.coaching === "structured").map((s) => s.id).join(" ")));
+')
+
+fail=0
+for id in $STRUCTURED_IDS; do
+  echo "::onboarding-gate:: $id"
+  bun run onboarding:test --scenario "$id" || fail=1
+done
+exit "$fail"
+```
+
+Make it executable: `chmod +x scripts/onboarding-gate.sh`
+
+- [ ] **Step 2: Write the systemd units (nightly)**
+
+`ci/onboarding-harness/shepherd-onboarding.service`:
+
+```ini
+[Unit]
+Description=Shepherd onboarding regression harness (nightly)
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/Work/shepherd
+ExecStart=/usr/bin/env bun run onboarding:test
+```
+
+`ci/onboarding-harness/shepherd-onboarding.timer`:
+
+```ini
+[Unit]
+Description=Nightly Shepherd onboarding harness run
+
+[Timer]
+OnCalendar=*-*-* 03:30:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+- [ ] **Step 3: Document install + wire the pre-release gate**
+
+In `ci/onboarding-harness/README.md`, add: copy the units to `~/.config/systemd/user/`, `systemctl --user enable --now shepherd-onboarding.timer`; and add to the OSS-release checklist that `scripts/onboarding-gate.sh` must exit 0 before tagging. (No GitHub Actions wiring — this is self-hosted-Incus-only, never per-PR, per the design.)
+
+- [ ] **Step 4: Verify the gate script parses + selects scenarios**
+
+Run: `bash -n scripts/onboarding-gate.sh && bun -e 'import("./ci/onboarding-harness/scenarios.ts").then(({SCENARIOS})=>console.log(SCENARIOS.filter(s=>s.coaching==="structured").map(s=>s.id)))'`
+Expected: the script has no syntax errors; the command prints the list of structured scenario ids.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/onboarding-gate.sh ci/onboarding-harness/shepherd-onboarding.service ci/onboarding-harness/shepherd-onboarding.timer ci/onboarding-harness/README.md
+git commit -m "feat(onboarding-harness): release gate + nightly timer"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Incus driver (system containers + VM opt-in, snapshot/sweep) → Task 2. ✓
+- Scenario catalog (7 checks × states, distro spread) → Task 3. ✓
+- Seed engine (bootable baseline + messy seed) → Task 6. ✓
+- Probe via `GET /api/diagnostics?refresh=1` → Task 7. ✓
+- Detection assertion (gap source #1) → Task 4. ✓
+- Apply: agent path (P1) → Task 8; verbatim path (P2) → Task 11. ✓
+- Gap report → Task 5; wired in orchestrator → Task 9. ✓
+- Detect→apply→re-probe-green success signal → Task 9 `runScenario`. ✓
+- Structured remediation product change in `diagnostics.ts` → Task 10. ✓
+- Manual + nightly + pre-release gate on Incus host → Task 9 (manual) + Task 12 (nightly/gate). ✓
+- Guaranteed teardown + orphan sweep → Task 2 `sweep` + Task 9 `finally`. ✓
+- Bootstrap-paradox boundary (baseline always has bun; cold-bun-absent deferred) → encoded in Task 6 baseline + scenario catalog scope; cold-bun-absent NOT in Phase 1 catalog (matches spec). ✓
+
+**Placeholder scan:** No TBD/TODO left as work; two explicit *implementer-confirm* notes (per-scenario fixtures in Task 6; install-URL verification in Task 10) are deliberate real-world verifications, each with concrete instructions, not deferred design.
+
+**Type consistency:** `IncusRunner`/`IncusExec`, `Scenario`/`ExpectedCheck`, `DetectionResult`, `ScenarioResult` defined in Task 1 and used unchanged throughout. `assertDetection(snapshot, scenarioId, expected)` signature matches its call in Task 9. `applyAgent`/`applyVerbatim`/`collectRemediations`/`resolveCoaching`/`buildAgentPrompt` names consistent across Tasks 8/11. `Remediation.run` field consistent across Tasks 10/11.
+
+## Unresolved questions
+
+None — all scope/approach decisions resolved during brainstorming. Two real-world values to confirm during execution (not design gaps): exact install-command URLs for the `REMEDIATIONS` map (Task 10), and the per-scenario fixture setup for `herdr-too-old` / `tailscale-not-serving` (Task 6), both validated against real Incus behavior in Task 9.

--- a/docs/superpowers/plans/2026-06-13-onboarding-challenge-harness.md
+++ b/docs/superpowers/plans/2026-06-13-onboarding-challenge-harness.md
@@ -1110,9 +1110,9 @@ git commit -m "feat(onboarding-harness): agent apply path + coaching resolution"
 
 ```ts
 import { execFileSync } from "node:child_process";
-import { closeSync, mkdtempSync, openSync, unlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { closeSync, mkdirSync, mkdtempSync, openSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { IncusDriver } from "./incus";
 import { SCENARIOS } from "./scenarios";
 import { seedInstance } from "./seed";
@@ -1169,11 +1169,16 @@ async function runScenario(
   }
 }
 
-const LOCK_PATH = join(tmpdir(), "shep-onb.lock");
+// FIXED absolute path under the host-global Shepherd state dir (~/.shepherd) — NOT
+// $TMPDIR. A systemd-user timer service and an interactive shell can see different
+// $TMPDIR (PrivateTmp, per-session dirs), which would defeat the lock; $HOME is
+// stable and identical for both (same user), so the lock is genuinely host-wide.
+const LOCK_PATH = join(homedir(), ".shepherd", "onboarding-harness.lock");
 
 /** Acquire a host-wide exclusive lock so concurrent runs never share the Incus
  *  host. `wx` fails if the lock already exists. Returns a release fn. */
 function acquireHostLock(): () => void {
+  mkdirSync(dirname(LOCK_PATH), { recursive: true });
   let fd: number;
   try {
     fd = openSync(LOCK_PATH, "wx");
@@ -1250,7 +1255,7 @@ In `package.json` `scripts`:
 
 - [ ] **Step 3: Write the README (auth + prereqs + usage)**
 
-`ci/onboarding-harness/README.md` — document: requires the self-hosted Incus host; create the `shep-onb` Incus profile with resource caps + (for tailscale/systemd scenarios) `security.nesting=true` and a TUN device; mount `~/.claude` credentials for the agent path; run with `bun run onboarding:test [--scenario <id>]`; report lands at `onboarding-gap-report.md`. **Run isolation:** each run takes a host-wide lock (`$TMPDIR/shep-onb.lock`) and uses a per-run instance prefix `shep-onb-<runId>-`, swept (own-prefix only) on teardown — so a second run cannot launch while one holds the lock, and crashed-run leftovers are cleared with `bun run onboarding:test --reap-orphans` (the only command that touches other runs' instances).
+`ci/onboarding-harness/README.md` — document: requires the self-hosted Incus host; create the `shep-onb` Incus profile with resource caps + (for tailscale/systemd scenarios) `security.nesting=true` and a TUN device; mount `~/.claude` credentials for the agent path; run with `bun run onboarding:test [--scenario <id>]`; report lands at `onboarding-gap-report.md`. **Run isolation:** each run takes a host-wide lock at the fixed absolute path `~/.shepherd/onboarding-harness.lock` (NOT `$TMPDIR` — a systemd-user service and an interactive run can see different `$TMPDIR`, so the lock must live under the stable host-global `~/.shepherd` dir to actually serialize them) and uses a per-run instance prefix `shep-onb-<runId>-`, swept (own-prefix only) on teardown — so a second run cannot launch while one holds the lock, and crashed-run leftovers are cleared with `bun run onboarding:test --reap-orphans` (the only command that touches other runs' instances).
 
 - [ ] **Step 4: Verify type-check, lint, and the unit suite**
 
@@ -1594,6 +1599,10 @@ git commit -m "feat(onboarding-harness): release gate + nightly timer"
 - (5) Per-run prefix + host lock + own-prefix sweep + `--reap-orphans` → Tasks 2/9. ✓
 - (6) Release gate bypasses (exit 0, logged) when Incus host unavailable → Task 12. ✓
 - (7) Probe auth: baseline boots with `SHEPHERD_TOKEN` unset so plain `curl` passes `checkAuth` → Task 7. ✓
+
+**Plan-review points (round 2):**
+- (1, re-raised) The gate reviews a frozen *main* worktree (`ef27e9bf`, #637) lacking this feature branch's commits, and `.shepherd-plan.md` is `.gitignore`d (read live). Committing to the branch can't make `docs/` visible to the gate, so the full plan + spec are now embedded **inline** in `.shepherd-plan.md` (executable detail, not a pointer). The `docs/` copies remain committed on the branch for the eventual PR. ✓
+- (2) Host lock moved off `$TMPDIR` to the fixed absolute `~/.shepherd/onboarding-harness.lock` so a systemd-user timer and an interactive run (which can see different `$TMPDIR` under PrivateTmp) share one lock and truly serialize → Task 9 `acquireHostLock`. ✓
 
 **Placeholder scan:** No TBD/TODO left as work; two explicit *implementer-confirm* notes (per-scenario fixtures in Task 6; install-URL verification in Task 10) are deliberate real-world verifications, each with concrete instructions, not deferred design.
 

--- a/docs/superpowers/plans/2026-06-13-onboarding-challenge-harness.md
+++ b/docs/superpowers/plans/2026-06-13-onboarding-challenge-harness.md
@@ -4,7 +4,7 @@
 
 **Goal:** Build a throw-away-environment harness that boots deliberately-messy Incus instances, runs Shepherd inside them in degraded mode, captures its diagnostics, applies the coaching, re-probes, and emits a gap report — manually in Phase 1, then green-gating releases in Phase 2.
 
-**Architecture:** A standalone Bun/TS harness in `ci/onboarding-harness/`, separate from the shipped server. Six small units — an injectable `incus` CLI driver, a declarative scenario catalog, a seed engine, a diagnostics probe, an apply engine (agent path in P1, verbatim path added in P2), and a gap-report builder — wired by an orchestrator with guaranteed teardown. Phase 2 adds an additive structured-remediation field to `src/diagnostics.ts` and ops wiring (nightly + release gate).
+**Architecture:** A standalone Bun/TS harness in `ci/onboarding-harness/`, separate from the shipped server. Six small units — an injectable `incus` CLI driver, a declarative scenario catalog, a seed engine, a diagnostics probe, an apply engine (agent path in P1, verbatim path added in P2), and a gap-report builder — wired by an orchestrator with guaranteed teardown. Phase 2 adds a harness-side structured-remediation catalog (no `src/` change) and ops wiring (nightly + release gate).
 
 **Tech Stack:** Bun, TypeScript, `bun:test`, the `incus` CLI (system containers + VMs), Shepherd's existing `GET /api/diagnostics` HTTP API, the `claude` CLI (agent apply path).
 
@@ -23,11 +23,12 @@
 | `ci/onboarding-harness/probe.ts` | `bootShepherd` + `probeDiagnostics` — start Shepherd, poll `GET /api/diagnostics?refresh=1`. |
 | `ci/onboarding-harness/apply.ts` | `applyCoaching` — agent path (P1) and verbatim path (P2), dispatched by scenario `coaching`. |
 | `ci/onboarding-harness/run.ts` | Orchestrator + CLI entry; per-scenario seed→probe→assert→apply→re-probe with `finally` teardown + orphan sweep; writes the report. |
-| `scripts/onboarding-gate.sh` | Phase 2: runs the deterministic (verbatim) subset, exits non-zero on red — the release gate. |
+| `ci/onboarding-harness/remediations.ts` | Phase 2: **harness-side** `REMEDIATIONS` map (hintKey → verbatim shell command). Keeps fixes out of the shipped diagnostics payload. |
+| `scripts/onboarding-gate.sh` | Phase 2: runs the deterministic (verbatim) subset, exits non-zero on red, **bypasses (exit 0) when the Incus host is unavailable** — the release gate. |
 | `ci/onboarding-harness/shepherd-onboarding.{service,timer}` | Phase 2: systemd units for the nightly run on the Incus host. |
-| `src/diagnostics.ts` (modify) | Phase 2: additive `REMEDIATIONS` map + `remediation?` field decoration on non-ok checks. |
-| `src/types.ts` (modify) | Phase 2: add optional `remediation?: Remediation` to `DiagnosticCheck` + the `Remediation` type. |
-| `test/onboarding-harness/*.test.ts` | Unit tests for the pure/injectable units (driver argv, catalog validity, assert, report, resolution). |
+| `test/onboarding-harness/*.test.ts` | Unit tests for the pure/injectable units (driver argv, catalog validity, assert, report, resolution, remediation map). |
+
+**No `src/` product change.** Per plan review, structured remediations live **harness-side** (`remediations.ts`), not as a `remediation?` field on the shipped `DiagnosticCheck` payload — this preserves the exact-keys payload-purity contract (`test/diagnostics.test.ts:52`) and avoids a hidden, undiscoverable shipped field. A user-facing "click-to-fix" feature, if ever wanted, gets its own spec.
 
 **Test strategy:** Logic with no real-Incus dependency (driver argv-building, catalog validity, `assertDetection`, `buildGapReport`, hintKey→text resolution, P2 remediation decoration) is unit-tested via `bun:test` with injected runners — mirroring `src/diagnostics.ts`'s injectable-deps pattern. The end-to-end seed→boot→apply→re-probe loop requires a real Incus host and is validated by a documented manual run (Task 9), not unit tests.
 
@@ -62,6 +63,10 @@ export interface Scenario {
   expect: ExpectedCheck[];
   /** Which apply path to use. In Phase 1 "structured" falls back to the agent path. */
   coaching: "structured" | "prose";
+  /** The agent apply path runs `claude` INSIDE the instance; a scenario that
+   *  removes claude (claude-missing) cannot use it. Such scenarios are
+   *  detection-only in Phase 1 and switch to the verbatim path in Phase 2. */
+  agentIncompatible?: boolean;
 }
 
 export interface ExpectedCheck {
@@ -85,6 +90,9 @@ export interface ScenarioResult {
   detection: DetectionResult;
   appliedVia: "agent" | "verbatim" | "skipped";
   reachedGreen: boolean;
+  /** True when no apply was attempted BY DESIGN (e.g. claude-missing in Phase 1):
+   *  the report classifies it DETECTION-ONLY, not an advice gap. */
+  detectionOnly?: boolean;
   error?: string;
 }
 
@@ -129,6 +137,8 @@ git commit -m "feat(onboarding-harness): shared types + lint glob"
 **Files:**
 - Create: `ci/onboarding-harness/incus.ts`
 - Test: `test/onboarding-harness/incus.test.ts`
+
+> **Run isolation (point 5):** the driver's `prefix` is the **per-run** prefix the orchestrator passes (`shep-onb-<runId>-`, Task 9), NOT a shared constant. Because `sweep()` only force-deletes instances matching its own prefix, two overlapping runs can never destroy each other's live instances. The unit test below uses a fixed `shep-onb-` prefix only for assertion simplicity. A separate `--reap-orphans` maintenance flag (Task 9) is the only thing that touches other prefixes, and it is never invoked automatically.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -401,11 +411,18 @@ export const SCENARIOS: Scenario[] = [
     coaching: "structured",
   },
   {
+    // claudeProbe is PRESENCE-ONLY (a successful `claude --version` ⇒ ok; there is
+    // NO auth/login probe, so there is deliberately no "claude-unauthed" scenario —
+    // an unauthed-but-installed claude reports ok by design, which the gap report
+    // notes as a known non-detection, not a discovered gap). Removing claude also
+    // disables the agent apply path (the agent IS claude running in-instance), so
+    // this scenario is detection-only in Phase 1 and verbatim-reinstalled in Phase 2.
     id: "claude-missing",
     image: "images:fedora/40",
     seed: ["rm -f /usr/local/bin/claude ~/.local/bin/claude"],
     expect: [{ id: "claude", state: "error" }],
     coaching: "structured",
+    agentIncompatible: true,
   },
   {
     id: "git-missing",
@@ -600,6 +617,29 @@ describe("buildGapReport", () => {
     ]);
     expect(md).toContain("ADVICE GAP");
   });
+
+  it("classifies a by-design no-apply scenario as DETECTION-ONLY and excludes it from the denominator", () => {
+    const md = buildGapReport([
+      {
+        scenarioId: "claude-missing",
+        image: "images:fedora/40",
+        detection: { scenarioId: "claude-missing", detected: true, misses: [] },
+        appliedVia: "skipped",
+        reachedGreen: false,
+        detectionOnly: true,
+      },
+      {
+        scenarioId: "gh-unauthed",
+        image: "i",
+        detection: { scenarioId: "gh-unauthed", detected: true, misses: [] },
+        appliedVia: "agent",
+        reachedGreen: true,
+      },
+    ]);
+    expect(md).toContain("DETECTION-ONLY");
+    expect(md).toContain("1 / 1 scenarios reached green"); // claude-missing excluded
+    expect(md).not.toContain("## Gaps"); // DETECTION-ONLY is not a gap
+  });
 });
 ```
 
@@ -616,29 +656,38 @@ Expected: FAIL — module not found.
 import type { ScenarioResult } from "./types";
 
 /** Pure: render the per-scenario outcomes as a markdown gap report. Classifies
- *  each scenario as PASS, DETECTION GAP (defect missed/misclassified), or
- *  ADVICE GAP (detected but coaching didn't reach green). */
+ *  each scenario as PASS, DETECTION GAP (defect missed/misclassified), ADVICE GAP
+ *  (detected but coaching didn't reach green), or DETECTION-ONLY (detected with no
+ *  apply attempted by design — e.g. claude-missing in Phase 1; NOT a gap). The
+ *  green tally counts only apply-able scenarios so detection-only ones don't drag
+ *  the denominator. */
+function classify(r: ScenarioResult): "PASS" | "DETECTION GAP" | "ADVICE GAP" | "DETECTION-ONLY" {
+  if (r.detectionOnly) return r.detection.detected ? "DETECTION-ONLY" : "DETECTION GAP";
+  if (r.reachedGreen) return "PASS";
+  return r.detection.detected ? "ADVICE GAP" : "DETECTION GAP";
+}
+
 export function buildGapReport(results: ScenarioResult[]): string {
-  const green = results.filter((r) => r.reachedGreen).length;
+  const applicable = results.filter((r) => !r.detectionOnly);
+  const green = applicable.filter((r) => r.reachedGreen).length;
+  const detectionOnly = results.length - applicable.length;
   const lines: string[] = [
     "# Onboarding Gap Report",
     "",
-    `**${green} / ${results.length} scenarios reached green.**`,
+    `**${green} / ${applicable.length} scenarios reached green.**` +
+      (detectionOnly ? ` (${detectionOnly} detection-only, by design — excluded.)` : ""),
     "",
     "| Scenario | Image | Detected | Applied | Green | Classification |",
     "| --- | --- | --- | --- | --- | --- |",
   ];
   const gaps: string[] = [];
   for (const r of results) {
-    const klass = r.reachedGreen
-      ? "PASS"
-      : !r.detection.detected
-        ? "DETECTION GAP"
-        : "ADVICE GAP";
+    const klass = classify(r);
     lines.push(
       `| ${r.scenarioId} | ${r.image} | ${r.detection.detected ? "yes" : "no"} | ${r.appliedVia} | ${r.reachedGreen ? "yes" : "no"} | ${klass} |`,
     );
-    if (klass !== "PASS") {
+    // Only genuine gaps go in the gaps section; PASS and DETECTION-ONLY do not.
+    if (klass === "DETECTION GAP" || klass === "ADVICE GAP") {
       const misses = r.detection.misses.map((m) => `${m.id} want=${m.want} got=${m.got}`).join("; ");
       gaps.push(
         `- **${r.scenarioId}** (${klass})${misses ? ` — ${misses}` : ""}${r.error ? ` — ${r.error}` : ""}`,
@@ -857,12 +906,19 @@ const PORT = 7330; // config.port default
 
 /** Start Shepherd detached inside the instance and poll until its HTTP API
  *  answers (or time out). Degraded boots are expected — we only need the server
- *  process up far enough to serve `/api/diagnostics`. */
+ *  process up far enough to serve `/api/diagnostics`.
+ *
+ *  AUTH (point 7): `GET /api/diagnostics` passes through `checkAuth`, which only
+ *  authorizes when `config.token` (`SHEPHERD_TOKEN`) is null. We boot with the
+ *  var explicitly UNSET (`env -u SHEPHERD_TOKEN`) so the plain `curl` probe below
+ *  is authorized — the harness controls the env, so this is safe and the simplest
+ *  correct option. (If a future scenario needs a token, the probe must add
+ *  `-H "Authorization: Bearer $SHEPHERD_TOKEN"` instead.) */
 export async function bootShepherd(driver: IncusDriver, name: string): Promise<void> {
   await driver.exec(name, [
     "sh",
     "-c",
-    `cd ${SHEPHERD_DIR} && nohup ~/.bun/bin/bun run start >/var/log/shepherd.log 2>&1 &`,
+    `cd ${SHEPHERD_DIR} && env -u SHEPHERD_TOKEN nohup ~/.bun/bin/bun run start >/var/log/shepherd.log 2>&1 &`,
   ]);
   const poll = await driver.exec(name, [
     "sh",
@@ -1054,7 +1110,7 @@ git commit -m "feat(onboarding-harness): agent apply path + coaching resolution"
 
 ```ts
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { closeSync, mkdtempSync, openSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { IncusDriver } from "./incus";
@@ -1086,7 +1142,13 @@ async function runScenario(
     const before = await probeDiagnostics(driver, scenario.id);
     const detection = assertDetection(before, scenario.id, scenario.expect);
 
-    // Phase 1: agent path for all scenarios (structured falls back, logged).
+    // Phase 1 has no verbatim path yet. A scenario that disabled the agent
+    // (claude-missing — the agent IS claude in-instance) is detection-only and
+    // is NOT counted as an advice gap. Everything else uses the agent proxy-user.
+    if (scenario.agentIncompatible) {
+      console.log(`[${scenario.id}] agent-incompatible — detection-only in Phase 1`);
+      return { ...base, detection, appliedVia: "skipped", reachedGreen: false, detectionOnly: true };
+    }
     if (scenario.coaching === "structured") {
       console.log(`[${scenario.id}] structured coaching not yet available — using agent path`);
     }
@@ -1107,7 +1169,36 @@ async function runScenario(
   }
 }
 
+const LOCK_PATH = join(tmpdir(), "shep-onb.lock");
+
+/** Acquire a host-wide exclusive lock so concurrent runs never share the Incus
+ *  host. `wx` fails if the lock already exists. Returns a release fn. */
+function acquireHostLock(): () => void {
+  let fd: number;
+  try {
+    fd = openSync(LOCK_PATH, "wx");
+  } catch {
+    console.error(`another onboarding-harness run holds ${LOCK_PATH}; aborting`);
+    process.exit(3);
+  }
+  return () => {
+    closeSync(fd);
+    try {
+      unlinkSync(LOCK_PATH);
+    } catch {
+      /* already gone */
+    }
+  };
+}
+
 async function main() {
+  // Maintenance: reap ALL harness instances across runs (manual recovery only).
+  if (process.argv.includes("--reap-orphans")) {
+    await new IncusDriver(undefined, "shep-onb-").sweep();
+    console.log("reaped all shep-onb-* instances");
+    return;
+  }
+
   const only = process.argv.includes("--scenario")
     ? process.argv[process.argv.indexOf("--scenario") + 1]
     : null;
@@ -1117,8 +1208,11 @@ async function main() {
     process.exit(2);
   }
 
-  const driver = new IncusDriver();
-  await driver.sweep(); // reap any leaked instances from a prior crashed run
+  const release = acquireHostLock();
+  // Per-run prefix isolates this run's instances; `sweep()` then only ever
+  // touches our own, so overlapping runs can't destroy each other (point 5).
+  const runId = `${Date.now().toString(36)}-${process.pid}`;
+  const driver = new IncusDriver(undefined, `shep-onb-${runId}-`);
   const tarball = buildTarball();
 
   const results: ScenarioResult[] = [];
@@ -1128,7 +1222,8 @@ async function main() {
       results.push(await runScenario(driver, s, tarball));
     }
   } finally {
-    await driver.sweep(); // belt-and-suspenders teardown
+    await driver.sweep(); // teardown — own-prefix instances only
+    release();
   }
 
   const report = buildGapReport(results);
@@ -1136,8 +1231,10 @@ async function main() {
   writeFileSync(out, report);
   console.log(`\n${report}\nReport written to ${out}`);
 
-  // Non-zero exit if any scenario failed to reach green (used by the P2 gate).
-  process.exit(results.every((r) => r.reachedGreen) ? 0 : 1);
+  // Non-zero exit if any APPLY-ABLE scenario failed to reach green (detection-only
+  // scenarios are excluded). Consumed by the Phase 2 gate.
+  const applicable = results.filter((r) => !r.detectionOnly);
+  process.exit(applicable.every((r) => r.reachedGreen) ? 0 : 1);
 }
 
 void main();
@@ -1153,7 +1250,7 @@ In `package.json` `scripts`:
 
 - [ ] **Step 3: Write the README (auth + prereqs + usage)**
 
-`ci/onboarding-harness/README.md` — document: requires the self-hosted Incus host; create the `shep-onb` Incus profile with resource caps + (for tailscale/systemd scenarios) `security.nesting=true` and a TUN device; mount `~/.claude` credentials for the agent path; run with `bun run onboarding:test [--scenario <id>]`; report lands at `onboarding-gap-report.md`; instances are name-prefixed `shep-onb-` and swept on start and teardown.
+`ci/onboarding-harness/README.md` — document: requires the self-hosted Incus host; create the `shep-onb` Incus profile with resource caps + (for tailscale/systemd scenarios) `security.nesting=true` and a TUN device; mount `~/.claude` credentials for the agent path; run with `bun run onboarding:test [--scenario <id>]`; report lands at `onboarding-gap-report.md`. **Run isolation:** each run takes a host-wide lock (`$TMPDIR/shep-onb.lock`) and uses a per-run instance prefix `shep-onb-<runId>-`, swept (own-prefix only) on teardown — so a second run cannot launch while one holds the lock, and crashed-run leftovers are cleared with `bun run onboarding:test --reap-orphans` (the only command that touches other runs' instances).
 
 - [ ] **Step 4: Verify type-check, lint, and the unit suite**
 
@@ -1177,123 +1274,88 @@ git commit -m "feat(onboarding-harness): orchestrator, CLI, and run docs"
 
 ## Phase 2 — deterministic regression tier + ops wiring
 
-### Task 10: Structured remediation in diagnostics (additive product change)
+### Task 10: Harness-side remediation catalog (no `src/` change)
 
 **Files:**
-- Modify: `src/types.ts` (add `Remediation` + `remediation?` on `DiagnosticCheck`)
-- Modify: `src/diagnostics.ts` (add `REMEDIATIONS` map + decorate non-ok checks)
-- Modify: `test/diagnostics.test.ts` (purity test allows the optional field; add a remediation test)
+- Create: `ci/onboarding-harness/remediations.ts`
+- Test: `test/onboarding-harness/remediations.test.ts`
 
-> **i18n note:** `remediation.run` is a verbatim shell command (data, like a CLI invocation), not authored UI chrome — exempt from the message catalog, same class as PR titles / `TASK-07` designations. No new EN/DE keys.
-> **Feature-catalog note:** this is server-only plumbing surfacing no new UI — mark the commit/PR `[no-feature-entry]`.
+Per plan review (point 3), structured remediations live **in the harness**, keyed by the `hintKey` Shepherd emits — NOT as a field on the shipped `DiagnosticCheck` payload. This keeps the exact-keys payload-purity contract (`test/diagnostics.test.ts:52`) intact and avoids a hidden shipped field. `src/diagnostics.ts` and `src/types.ts` are **not touched**. The verbatim path therefore guards *detection + scenario-reachability deterministically*; advice-text correctness remains the agent path's job (Task 8).
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `test/diagnostics.test.ts`:
+`test/onboarding-harness/remediations.test.ts`:
 
 ```ts
-it("attaches a structured remediation to a known non-ok check", async () => {
-  const svc = new DiagnosticsService({
-    runVersion: versionRunner({ ...HEALTHY_VERSIONS, bun: new Error("ENOENT") }),
-    runGhAuth: async () => {},
-    resolveHost: async () => "node.example.ts.net",
-    runServeStatus: async () =>
-      JSON.stringify({ Web: { "node.example.ts.net:443": { Handlers: { "/": { Proxy: "http://127.0.0.1:7330" } } } } }),
+import { describe, expect, it } from "bun:test";
+import { REMEDIATIONS, remediationsFor } from "../../ci/onboarding-harness/remediations";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+describe("remediations catalog", () => {
+  it("maps known fixable hintKeys to a single shell command", () => {
+    expect(REMEDIATIONS.diagnostics_hint_bun_missing).toContain("bun.sh/install");
   });
-  const snap = await svc.check(1000);
-  const bun = snap.checks.find((c) => c.id === "bun")!;
-  expect(bun.state).toBe("error");
-  expect(bun.remediation?.run).toContain("bun.sh/install");
+
+  it("collects verbatim commands for non-ok checks that have one (skips prose-only and ok)", () => {
+    const snap: DiagnosticsSnapshot = {
+      checks: [
+        { id: "bun", state: "error", hintKey: "diagnostics_hint_bun_missing" },
+        { id: "gh", state: "error", hintKey: "diagnostics_hint_gh_not_authenticated" }, // prose-only → skipped
+        { id: "git", state: "ok", hintKey: "diagnostics_hint_git_ok" }, // ok → skipped
+      ],
+      generatedAt: 1,
+      overall: "error",
+    };
+    expect(remediationsFor(snap)).toEqual([REMEDIATIONS.diagnostics_hint_bun_missing]);
+  });
 });
-
-it("does not attach a remediation to ok checks", async () => {
-  const svc = new DiagnosticsService(healthyDeps());
-  const snap = await svc.check(1000);
-  expect(snap.checks.every((c) => c.state !== "ok" || c.remediation === undefined)).toBe(true);
-});
-```
-
-Also update the payload-shape helper (around `test/diagnostics.test.ts:52`) to permit the optional key:
-
-```ts
-const keys = Object.keys(check).sort();
-expect(keys).toEqual(check.remediation ? ["hintKey", "id", "remediation", "state"] : ["hintKey", "id", "state"]);
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `bun test ./test/diagnostics.test.ts`
-Expected: FAIL — `remediation` is not a property of `DiagnosticCheck`.
+Run: `bun test ./test/onboarding-harness/remediations.test.ts`
+Expected: FAIL — module not found.
 
-- [ ] **Step 3: Extend the types**
+- [ ] **Step 3: Write the catalog**
 
-In `src/types.ts`, add above `DiagnosticCheck`:
-
-```ts
-/** A runnable, verbatim remediation for a non-ok check — a single shell command
- *  the onboarding harness (and a future one-click-fix UI) can execute as-is.
- *  Verbatim data (a command), not authored UI text — exempt from i18n. */
-export interface Remediation {
-  run: string;
-}
-```
-
-And add the optional field to `DiagnosticCheck`:
+`ci/onboarding-harness/remediations.ts`:
 
 ```ts
-export interface DiagnosticCheck {
-  id: string;
-  state: DiagnosticState;
-  hintKey: string;
-  /** Present only on non-ok checks that reduce to a single runnable command. */
-  remediation?: Remediation;
-}
-```
+import type { DiagnosticsSnapshot } from "../../src/types";
 
-- [ ] **Step 4: Add the remediation map + decoration in `src/diagnostics.ts`**
-
-Add the map near the top (after imports):
-
-```ts
-import type { DiagnosticCheck, DiagnosticsSnapshot, DiagnosticState, Remediation } from "./types";
-
-/** hintKey → verbatim shell remediation. Only keys that reduce cleanly to one
- *  command appear here; prose-only coaching (e.g. interactive `gh auth login`,
- *  tailscale serve setup) is intentionally absent and stays on the agent path. */
-const REMEDIATIONS: Record<string, Remediation> = {
-  diagnostics_hint_bun_missing: { run: "curl -fsSL https://bun.sh/install | bash" },
-  diagnostics_hint_node_missing: { run: "curl -fsSL https://fnm.vercel.app/install | bash && fnm install --lts" },
-  diagnostics_hint_herdr_missing: { run: "curl -fsSL https://herdr.dev/install.sh | bash" },
-  diagnostics_hint_claude_missing: { run: "curl -fsSL https://claude.ai/install.sh | bash" },
+/** hintKey → verbatim shell remediation, keyed by the advice identifier Shepherd
+ *  emits. Lives in the HARNESS (not the diagnostics payload) so the shipped
+ *  DiagnosticCheck contract is unchanged. Only keys whose canonical fix is a
+ *  single non-interactive command appear; prose-only coaching (interactive
+ *  `gh auth login`, tailscale serve setup) is intentionally absent and stays on
+ *  the agent path. */
+export const REMEDIATIONS: Record<string, string> = {
+  diagnostics_hint_bun_missing: "curl -fsSL https://bun.sh/install | bash",
+  diagnostics_hint_node_missing: "curl -fsSL https://fnm.vercel.app/install | bash && fnm install --lts",
+  diagnostics_hint_herdr_missing: "curl -fsSL https://herdr.dev/install.sh | bash",
+  diagnostics_hint_claude_missing: "curl -fsSL https://claude.ai/install.sh | bash",
 };
+
+/** Verbatim commands for every non-ok check whose emitted hintKey has a known fix. */
+export function remediationsFor(snapshot: DiagnosticsSnapshot): string[] {
+  return snapshot.checks
+    .filter((c) => c.state !== "ok" && REMEDIATIONS[c.hintKey])
+    .map((c) => REMEDIATIONS[c.hintKey]!);
+}
 ```
 
 > **Implementer:** confirm each install URL against the project's actual install docs before committing — use the exact command Shepherd's onboarding docs prescribe. Drop any key whose canonical fix is not a single non-interactive command.
 
-In the `check(now)` method, decorate the assembled checks before building the snapshot (find where `const snapshot: DiagnosticsSnapshot = {` is built, ~line 260, and map the checks first):
+- [ ] **Step 4: Run test to verify it passes**
 
-```ts
-const decorated = checks.map((c): DiagnosticCheck => {
-  const r = c.state !== "ok" ? REMEDIATIONS[c.hintKey] : undefined;
-  return r ? { ...c, remediation: r } : c;
-});
-const snapshot: DiagnosticsSnapshot = {
-  checks: decorated,
-  generatedAt: now,
-  overall: worstOf(decorated),
-};
-```
+Run: `bun test ./test/onboarding-harness/remediations.test.ts`
+Expected: PASS (2 tests).
 
-- [ ] **Step 5: Run tests to verify they pass**
-
-Run: `bun test ./test/diagnostics.test.ts`
-Expected: PASS (existing tests + 2 new).
-
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add src/types.ts src/diagnostics.ts test/diagnostics.test.ts
-git commit -m "feat(diagnostics): structured remediation for command-fixable checks [no-feature-entry]"
+git add ci/onboarding-harness/remediations.ts test/onboarding-harness/remediations.test.ts
+git commit -m "feat(onboarding-harness): harness-side remediation catalog"
 ```
 
 ---
@@ -1301,29 +1363,34 @@ git commit -m "feat(diagnostics): structured remediation for command-fixable che
 ### Task 11: Verbatim apply path
 
 **Files:**
-- Modify: `ci/onboarding-harness/apply.ts` (add `applyVerbatim`)
-- Modify: `ci/onboarding-harness/run.ts` (dispatch `structured` → verbatim)
-- Test: `test/onboarding-harness/apply.test.ts` (add verbatim cases)
+- Modify: `ci/onboarding-harness/apply.ts` (add `applyVerbatim`, sourced from `remediations.ts`)
+- Modify: `ci/onboarding-harness/run.ts` (verbatim-first dispatch; replaces the Phase-1 block)
+- Test: `test/onboarding-harness/apply.test.ts` (add the verbatim case)
 
 - [ ] **Step 1: Write the failing test**
 
 Add to `test/onboarding-harness/apply.test.ts`:
 
 ```ts
-import { collectRemediations } from "../../ci/onboarding-harness/apply";
+import { applyVerbatim } from "../../ci/onboarding-harness/apply";
+import { IncusDriver } from "../../ci/onboarding-harness/incus";
 
-describe("collectRemediations", () => {
-  it("returns the verbatim run command for each non-ok check that has one", () => {
-    const s = {
-      checks: [
-        { id: "bun", state: "error", hintKey: "k", remediation: { run: "curl x | bash" } },
-        { id: "gh", state: "error", hintKey: "k2" }, // prose-only, no remediation
-        { id: "git", state: "ok", hintKey: "k3", remediation: { run: "noop" } },
-      ],
+describe("applyVerbatim", () => {
+  it("runs each harness-catalog remediation for non-ok checks inside the instance", async () => {
+    const calls: string[][] = [];
+    const run = async (args: string[]) => {
+      calls.push(args);
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const d = new IncusDriver(run, "shep-onb-");
+    const snap = {
+      checks: [{ id: "bun", state: "error" as const, hintKey: "diagnostics_hint_bun_missing" }],
       generatedAt: 1,
       overall: "error" as const,
     };
-    expect(collectRemediations(s)).toEqual(["curl x | bash"]);
+    const ok = await applyVerbatim(d, "bun-missing", snap);
+    expect(ok).toBe(true);
+    expect(calls[0].join(" ")).toContain("bun.sh/install");
   });
 });
 ```
@@ -1331,28 +1398,27 @@ describe("collectRemediations", () => {
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `bun test ./test/onboarding-harness/apply.test.ts`
-Expected: FAIL — `collectRemediations` is not exported.
+Expected: FAIL — `applyVerbatim` is not exported.
 
-- [ ] **Step 3: Implement `collectRemediations` + `applyVerbatim`**
+- [ ] **Step 3: Implement `applyVerbatim` (sourcing the harness catalog)**
+
+Add the import at the top of `ci/onboarding-harness/apply.ts`:
+
+```ts
+import { remediationsFor } from "./remediations";
+```
 
 Append to `ci/onboarding-harness/apply.ts`:
 
 ```ts
-/** Pure: the verbatim shell commands for every non-ok check that ships one. */
-export function collectRemediations(snapshot: DiagnosticsSnapshot): string[] {
-  return snapshot.checks
-    .filter((c) => c.state !== "ok" && c.remediation)
-    .map((c) => c.remediation!.run);
-}
-
-/** Run each structured remediation verbatim inside the instance. Returns false
- *  if any command exits non-zero. */
+/** Run each harness-catalog remediation (keyed by Shepherd's emitted hintKeys)
+ *  verbatim inside the instance. Returns false if any command exits non-zero. */
 export async function applyVerbatim(
   driver: IncusDriver,
   name: string,
   snapshot: DiagnosticsSnapshot,
 ): Promise<boolean> {
-  for (const cmd of collectRemediations(snapshot)) {
+  for (const cmd of remediationsFor(snapshot)) {
     const r = await driver.exec(name, ["sh", "-c", cmd]);
     if (r.code !== 0) return false;
   }
@@ -1360,24 +1426,41 @@ export async function applyVerbatim(
 }
 ```
 
-- [ ] **Step 4: Dispatch in `run.ts`**
+- [ ] **Step 4: Verbatim-first dispatch in `run.ts`**
 
-In `runScenario`, replace the Phase-1 agent-only block with path dispatch:
+Add the imports to `run.ts`:
 
 ```ts
+import { applyVerbatim } from "./apply";
+import { remediationsFor } from "./remediations";
+```
+
+In `runScenario`, **replace** the Phase-1 `agentIncompatible`/agent block (the one added in Task 9) with verbatim-first dispatch. Verbatim takes precedence, so `claude-missing` (which now has a catalog remediation) is reinstalled and reaches green instead of staying detection-only:
+
+```ts
+const verbatim = remediationsFor(before);
 let appliedVia: ScenarioResult["appliedVia"];
-if (scenario.coaching === "structured" && collectRemediations(before).length > 0) {
+let detectionOnly = false;
+if (verbatim.length > 0) {
   await applyVerbatim(driver, scenario.id, before);
   appliedVia = "verbatim";
+} else if (scenario.agentIncompatible) {
+  // No structured fix AND the agent can't run here (no claude) → detection-only.
+  appliedVia = "skipped";
+  detectionOnly = true;
 } else {
   await applyAgent(driver, scenario.id, before);
   appliedVia = "agent";
 }
-const after = await probeDiagnostics(driver, scenario.id);
-return { ...base, detection, appliedVia, reachedGreen: after.overall === "ok" };
+const after = detectionOnly ? before : await probeDiagnostics(driver, scenario.id);
+return {
+  ...base,
+  detection,
+  appliedVia,
+  reachedGreen: !detectionOnly && after.overall === "ok",
+  detectionOnly: detectionOnly || undefined,
+};
 ```
-
-Update the imports in `run.ts` to include `applyVerbatim` and `collectRemediations`.
 
 - [ ] **Step 5: Run tests + type-check**
 
@@ -1410,9 +1493,20 @@ The gate runs the **deterministic verbatim subset** (the `structured` scenarios)
 ```bash
 #!/usr/bin/env bash
 # Release gate: run the deterministic (structured) onboarding scenarios and fail
-# the release if any does not reach a healthy state. Requires the Incus host.
+# the release if any does not reach a healthy state.
+#
+# SAFE DEGRADE (point 6): this gate depends on a single self-hosted Incus host.
+# If that host is unavailable, we must NOT hard-block an otherwise-good release on
+# unrelated infra — we log a loud, explicit bypass and exit 0. A red SCENARIO
+# (Incus present, a scenario failed) still fails the gate; only an absent/broken
+# Incus host bypasses.
 set -euo pipefail
 cd "$(dirname "$0")/.."
+
+if ! command -v incus >/dev/null 2>&1 || ! incus list >/dev/null 2>&1; then
+  echo "::onboarding-gate:: BYPASSED — Incus host unavailable; not blocking the release on infra." >&2
+  exit 0
+fi
 
 STRUCTURED_IDS=$(bun -e '
   import("./ci/onboarding-harness/scenarios.ts").then(({ SCENARIOS }) =>
@@ -1485,16 +1579,25 @@ git commit -m "feat(onboarding-harness): release gate + nightly timer"
 - Probe via `GET /api/diagnostics?refresh=1` → Task 7. ✓
 - Detection assertion (gap source #1) → Task 4. ✓
 - Apply: agent path (P1) → Task 8; verbatim path (P2) → Task 11. ✓
-- Gap report → Task 5; wired in orchestrator → Task 9. ✓
+- Gap report (incl. DETECTION-ONLY class, green over applicable) → Task 5; wired in orchestrator → Task 9. ✓
 - Detect→apply→re-probe-green success signal → Task 9 `runScenario`. ✓
-- Structured remediation product change in `diagnostics.ts` → Task 10. ✓
+- Structured remediations **harness-side** (no `src/` change; payload-purity contract intact) → Task 10. ✓
 - Manual + nightly + pre-release gate on Incus host → Task 9 (manual) + Task 12 (nightly/gate). ✓
-- Guaranteed teardown + orphan sweep → Task 2 `sweep` + Task 9 `finally`. ✓
+- Guaranteed teardown + run isolation → Task 2 note + Task 9 host-lock + per-run prefix + `finally` sweep + `--reap-orphans`. ✓
 - Bootstrap-paradox boundary (baseline always has bun; cold-bun-absent deferred) → encoded in Task 6 baseline + scenario catalog scope; cold-bun-absent NOT in Phase 1 catalog (matches spec). ✓
+
+**Plan-review points (this revision):**
+- (1) Spec + detailed plan committed (`0589f426`, `04c21a98`) and tracked. ✓
+- (2) Brokenness scope = the 7 diagnostics checks for v1 — user-signed-off; other failure modes (corrupted/locked git, port-in-use, partial herdr, no network/DNS, full disk, broken worktrees, target-repo readiness) explicitly deferred. ✓
+- (3) Remediations harness-side, not a shipped `DiagnosticCheck` field → Task 10. ✓
+- (4) `claude` presence-only: no `claude-unauthed` scenario; `claude-missing` is detection-only in P1 (agent needs claude), verbatim-reinstalled in P2 → Tasks 3/5/9/11. ✓
+- (5) Per-run prefix + host lock + own-prefix sweep + `--reap-orphans` → Tasks 2/9. ✓
+- (6) Release gate bypasses (exit 0, logged) when Incus host unavailable → Task 12. ✓
+- (7) Probe auth: baseline boots with `SHEPHERD_TOKEN` unset so plain `curl` passes `checkAuth` → Task 7. ✓
 
 **Placeholder scan:** No TBD/TODO left as work; two explicit *implementer-confirm* notes (per-scenario fixtures in Task 6; install-URL verification in Task 10) are deliberate real-world verifications, each with concrete instructions, not deferred design.
 
-**Type consistency:** `IncusRunner`/`IncusExec`, `Scenario`/`ExpectedCheck`, `DetectionResult`, `ScenarioResult` defined in Task 1 and used unchanged throughout. `assertDetection(snapshot, scenarioId, expected)` signature matches its call in Task 9. `applyAgent`/`applyVerbatim`/`collectRemediations`/`resolveCoaching`/`buildAgentPrompt` names consistent across Tasks 8/11. `Remediation.run` field consistent across Tasks 10/11.
+**Type consistency:** `IncusRunner`/`IncusExec`, `Scenario`/`ExpectedCheck` (incl. `agentIncompatible?`), `DetectionResult`, `ScenarioResult` (incl. `detectionOnly?`) defined in Task 1 and used unchanged throughout. `assertDetection(snapshot, scenarioId, expected)` signature matches its call in Task 9. `applyAgent`/`applyVerbatim`/`resolveCoaching`/`buildAgentPrompt` (apply.ts) and `REMEDIATIONS`/`remediationsFor` (remediations.ts) names consistent across Tasks 8/10/11. No `src/` types touched.
 
 ## Unresolved questions
 

--- a/docs/superpowers/plans/2026-06-13-onboarding-challenge-harness.md
+++ b/docs/superpowers/plans/2026-06-13-onboarding-challenge-harness.md
@@ -8,6 +8,12 @@
 
 **Tech Stack:** Bun, TypeScript, `bun:test`, the `incus` CLI (system containers + VMs), Shepherd's existing `GET /api/diagnostics` HTTP API, the `claude` CLI (agent apply path).
 
+> **Post-implementation revisions (PR critic review).** The shipped code supersedes a few blocks below — where they differ, the code in `ci/onboarding-harness/` is authoritative:
+> 1. **Scoped success.** `reachedGreen` is evaluated over the scenario's **expected checks** (`scenario.expect.every(e => after.checks…state === "ok")`), not the global `after.overall === "ok"` shown in the Task 9 block — a throw-away instance can never reach all-7-green, so a global finish line would be permanently red.
+> 2. **Detection-only class.** Auth/serve defects whose fix needs a human/secret (`gh-unauthed`, `gh-missing`, `tailscale-missing`) carry `detectionOnly: true` (new `Scenario` field): no apply, excluded from the green tally and the release gate, reported DETECTION-ONLY.
+> 3. **Catalog trimmed.** `tailscale-not-serving` and `herdr-too-old` were **removed** (their fixtures — a faked tailnet, a pinned old herdr — aren't implemented; shipping them would be permanent detection gaps). They're deferred follow-ups.
+> 4. **Gate filter.** `scripts/onboarding-gate.sh` selects `coaching === "structured" && !detectionOnly` (green-able deterministic subset): `herdr-missing`, `claude-missing`, `node-too-old`.
+
 ---
 
 ## File structure

--- a/docs/superpowers/specs/2026-06-13-onboarding-challenge-harness-design.md
+++ b/docs/superpowers/specs/2026-06-13-onboarding-challenge-harness-design.md
@@ -1,0 +1,105 @@
+# Onboarding Challenge & Regression Harness — Design
+
+**Date:** 2026-06-13
+**Status:** Approved (brainstorm) — pending spec review
+**Topic:** A throw-away-environment harness that boots deliberately-messy machines, turns real Shepherd loose to self-diagnose & coach the local user to a healthy host, scores how well it copes, and locks that in as a regression guard for the OSS-launch onboarding experience.
+
+## Why
+
+Shepherd is heading for an open-source launch. A new user's first experience must not be merely documentation-bound — Shepherd should **intelligently coach** a messy machine to a working state. Today that coaching is `diagnostics.ts` (detect a host defect → surface a prose `hintKey`) and `readiness.ts` (static target-repo guardrail scoring). Neither is regression-tested against the divergent, broken environments real users actually have.
+
+This framework **discovers where onboarding fails today** (the primary deliverable) and then **locks in a regression guard** so coping with divergent setups does not silently regress.
+
+## Scope & decisions (locked during brainstorm)
+
+- **Deliverable:** discover onboarding gaps today **and** guard against regressions (not building a new coach — testing/hardening the existing one and reporting its gaps).
+- **Topology:** *in-VM degraded self-heal* — Shepherd runs **inside** the messy environment, boots in a degraded-but-running mode, self-diagnoses via its own checks, and coaches the local user.
+- **Isolation primitive:** **Incus** (already on the host). **System containers** are the default tier (real `systemd`, real `tailscaled`+TUN, full distro userland — unlike single-process Docker app containers); **Incus VMs** are reserved per-scenario for kernel/arch fidelity. One CLI/API for both; snapshots give instant throw-away reset.
+- **Success signal:** *detect → apply → re-probe green*. A scenario passes only if the environment actually reaches a healthy state after Shepherd's coaching is applied — proving advice is correct, not merely present.
+- **Apply mechanism:** **both** — run a **structured remediation verbatim** where the check provides one; fall back to an **agent interpreting prose coaching** otherwise.
+- **Finish line:** **host green** — Shepherd boots and all 7 diagnostic checks pass. Target-repo readiness coaching and "first agent launches" are explicitly **out of scope** (separate, already-shipped or future surfaces).
+- **Cadence/location:** **manual + nightly + pre-release gate**, on the self-hosted **Incus host**. **Never per-PR.**
+
+### The bootstrap-paradox boundary
+
+Shepherd is a Bun app: if `bun` is entirely absent it cannot boot to coach anyone. Therefore:
+
+- Every core scenario's **baseline image already has the bun runtime** (the one true prereq). Defects are layered **on top** of a bootable Shepherd: `gh` missing/unauthed, `tailscale` missing/not-serving, `herdr` missing, `claude` missing, `git` missing, and **too-old** `bun`/`node`/`herdr` (Shepherd boots and warns).
+- The **truly-cold "bun absent" cold-start** is the only path Shepherd-in-VM cannot self-heal. It is scoped to the **agent-bootstrap path** (a Claude Code agent following install docs stands Shepherd up) as a **Phase 2 stretch scenario class**, not the Phase 1 core matrix.
+
+## Detection signal (grounded)
+
+The harness reads `GET /api/diagnostics?refresh=1` (Shepherd's loopback HTTP API, already serving the HUD) inside each instance. The returned `DiagnosticsSnapshot` lists each check with its `id`, `state` (`ok`/`warning`/`error`), and `hintKey`. This is the structured detection signal asserted against each scenario's expectations.
+
+The 7 checks (from `src/diagnostics.ts`): `bun`, `node`, `claude`, `gh`, `git`, `herdr`, `tailscale` — each with missing / too-old / not-authenticated / not-serving / ok states.
+
+## Architecture
+
+Code lives in **`ci/onboarding-harness/`** (Bun + TS), a sibling of the existing `ci/self-hosted-runner/`. It is an ops/test harness, **not** part of the shipped server runtime. Six small, independently-testable units:
+
+1. **Incus driver** — thin wrapper over the `incus` CLI: `launch(image, profile)`, `exec`, `push`/`pull`, `snapshot`/`restore`, `delete`. Instances are ephemeral and deleted on teardown; resource caps applied via a dedicated Incus profile. System containers by default; a scenario opts into a VM with `type: "vm"`.
+2. **Scenario catalog** — declarative TS records. Each scenario: `id`; `image` (ubuntu/debian/alpine/arch/fedora); optional `vm: true`; `seed` (commands that diverge/break the env); `expect` (the checks that must flag and their expected `state`); and `coaching` kind (`structured` | `prose`) selecting the apply path.
+3. **Seed engine** — launches a fresh instance, installs the bootable-Shepherd baseline, then runs the scenario's `seed` steps to produce the messy state.
+4. **Probe + assert (detection)** — boots Shepherd in the instance, polls `GET /api/diagnostics?refresh=1`, and asserts the snapshot matches `expect`. This is the first source of gap findings (defect missed or mis-classified).
+5. **Apply engine** — two paths, chosen per scenario `coaching` kind:
+   - **Verbatim:** runs the check's **structured remediation** (Phase 2 `diagnostics.ts` field) exactly as emitted. Deterministic, LLM-free.
+   - **Agent:** spawns a fresh Claude Code agent given **only** what a real user sees (the diagnostics snapshot + prose coaching) and lets it drive the env to green — a proxy-user UX test. Non-deterministic; LLM cost.
+6. **Re-probe + report** — re-runs diagnostics; the scenario passes only when all checks are green. Emits a **markdown gap report**: per scenario — detected? advice present? advice actually fixed it? — plus an agent-transcript reference for prose cases.
+
+### Unit boundaries
+
+- The **Incus driver** knows nothing about scenarios or diagnostics — pure instance lifecycle over the `incus` CLI.
+- The **scenario catalog** is pure data; adding a scenario never touches engine code.
+- The **apply engine's** two paths share a `(snapshot, instance) → result` interface so the orchestrator treats them uniformly.
+- **Shepherd's job stays detect+advise**; the harness (not Shepherd) orchestrates the apply. The agent in the agent-path is a *harness* proxy-user, not a Shepherd-spawned agent.
+
+## Phasing
+
+### Phase 1 — gap-report MVP (the primary deliverable)
+Units 1–4 + 5(**agent path**) + 6, run **manually**. Tests *current* Shepherd with **no product change** (all coaching is prose today), and produces the "where onboarding fails today" report. Covers ≥1 scenario per relevant check×state plus distro spread.
+
+### Phase 2 — deterministic regression tier
+- Add a **structured-remediation field** to `src/diagnostics.ts` for checks that reduce to a single command (the only product-code change in this effort). The human prose hint stays; the structured field is additive.
+- Build the **verbatim apply path** against it → a fast, deterministic, LLM-free regression subset.
+- Wire **nightly** (existing scheduler) + **pre-release gate** (required-green before the OSS tag) on the Incus host.
+
+## Scenario matrix (backbone)
+
+Derived from the 7 checks × their states, across the distro spread. Representative (not exhaustive) Phase 1 set:
+
+| Scenario | Image | Seed (messy state) | Expect | Coaching path |
+| --- | --- | --- | --- | --- |
+| `gh-unauthed` | ubuntu | `gh` installed, not logged in | `gh: error/warning` (not-authenticated) | prose (agent) |
+| `gh-missing` | debian | `gh` absent | `gh: error` (missing) | structured (P2) / prose |
+| `tailscale-missing` | ubuntu | no tailscale | `tailscale: error` | structured (P2) / prose |
+| `tailscale-not-serving` | ubuntu (sys container, TUN) | tailscaled up, not serving | `tailscale: warning` | prose (agent) |
+| `herdr-missing` | arch | no herdr | `herdr: error` | structured (P2) / prose |
+| `claude-missing` | fedora | no claude CLI | `claude: error` | structured (P2) / prose |
+| `git-missing` | alpine | no git | `git: error` | structured (P2) / prose |
+| `bun-too-old` | ubuntu | bun < `BUN_MIN_VERSION` | `bun: warning` | structured (P2) / prose |
+| `node-too-old` | debian | node < `NODE_MIN_VERSION` | `node: warning` | structured (P2) / prose |
+| `herdr-too-old` | ubuntu | herdr < `HERDR_MIN_VERSION` | `herdr: warning` | structured (P2) / prose |
+| *(Phase 2 stretch)* `cold-bun-absent` | ubuntu (bare) | no bun at all | Shepherd can't boot | agent-bootstrap |
+
+Additional divergence axes to fold in opportunistically (confirmed in scope as future scenarios, not blocking Phase 1): corrupted/short `PATH`, root-vs-nonroot user, restricted-egress / proxied networks.
+
+## Risks & mitigations
+
+- **Incus-in-CI:** requires the self-hosted Incus host; not portable to GitHub cloud runners — acceptable, matches the manual/nightly/pre-release cadence.
+- **tailscaled in a system container:** needs TUN + `security.nesting`; the not-serving scenario may use a fake/loopback tailnet rather than a real login. Prototype this path **first** to de-risk.
+- **Agent-path flakiness/cost:** non-deterministic and token-spending; kept off the per-PR path. The release gate relies on the **deterministic verbatim subset**, with agent-path scenarios reported but not gating.
+- **claude OAuth in a throw-away instance:** the agent path needs auth — provisioned via a mounted credential/secret, never interactive login.
+- **Snapshot/teardown leaks:** every instance is created from a profile with caps and force-deleted in a `finally`; a sweep step reaps orphaned harness instances by name prefix at start.
+
+## Success criteria
+
+1. The harness provisions ≥1 scenario per relevant check×state from the catalog on Incus, boots degraded Shepherd, captures the diagnostics snapshot, applies coaching (verbatim or agent), re-probes, and emits a gap report — runnable via `bun run onboarding:test [--scenario <id>]`.
+2. Detection assertions correctly flag both matches and gaps (a deliberately-broken expectation fails the scenario).
+3. Phase 2 adds a deterministic verbatim subset that green-gates a release, wired to nightly + pre-release.
+4. All harness instances are torn down (no leaked Incus instances) after a full run, including on failure.
+
+## Out of scope
+
+- Building a new/LLM onboarding coach (we test and report on the existing detect+advise layer).
+- Target-repo readiness coaching (`readiness.ts`) and "first agent launches" finish lines.
+- Per-PR execution; macOS/Windows hosts; ARM via emulation.

--- a/docs/superpowers/specs/2026-06-13-onboarding-challenge-harness-design.md
+++ b/docs/superpowers/specs/2026-06-13-onboarding-challenge-harness-design.md
@@ -17,7 +17,7 @@ This framework **discovers where onboarding fails today** (the primary deliverab
 - **Isolation primitive:** **Incus** (already on the host). **System containers** are the default tier (real `systemd`, real `tailscaled`+TUN, full distro userland — unlike single-process Docker app containers); **Incus VMs** are reserved per-scenario for kernel/arch fidelity. One CLI/API for both; snapshots give instant throw-away reset.
 - **Success signal:** *detect → apply → re-probe green*. A scenario passes only if the environment actually reaches a healthy state after Shepherd's coaching is applied — proving advice is correct, not merely present.
 - **Apply mechanism:** **both** — run a **structured remediation verbatim** where the check provides one; fall back to an **agent interpreting prose coaching** otherwise.
-- **Finish line:** **host green** — Shepherd boots and all 7 diagnostic checks pass. Target-repo readiness coaching and "first agent launches" are explicitly **out of scope** (separate, already-shipped or future surfaces).
+- **Finish line:** **the seeded defect recovers.** Success is evaluated *per-scenario* — the checks a scenario broke return to `ok` after the coaching is applied — NOT global "all 7 green". A throw-away instance can never reach all-7-green (no tailnet login, no `gh` device-flow, no `tailscale serve`), so an all-`overall`-ok finish line would make every scenario permanently red. Checks whose fix needs a human/secret (`gh` auth, `tailscale` login+serve) are **detection-only**: detected and reported, but not expected to reach green, and excluded from the release gate. Target-repo readiness coaching and "first agent launches" remain **out of scope**.
 - **Cadence/location:** **manual + nightly + pre-release gate**, on the self-hosted **Incus host**. **Never per-PR.**
 
 ### The bootstrap-paradox boundary
@@ -44,7 +44,7 @@ Code lives in **`ci/onboarding-harness/`** (Bun + TS), a sibling of the existing
 5. **Apply engine** — two paths, chosen per scenario `coaching` kind:
    - **Verbatim:** runs the command from the **harness-side remediation catalog** (Phase 2 `ci/onboarding-harness/remediations.ts`, keyed by the `hintKey` Shepherd emits) exactly as written. Deterministic, LLM-free. No change to the shipped diagnostics payload (revised per plan review — keeps the `DiagnosticCheck` exact-keys purity contract intact).
    - **Agent:** spawns a fresh Claude Code agent given **only** what a real user sees (the diagnostics snapshot + prose coaching) and lets it drive the env to green — a proxy-user UX test. Non-deterministic; LLM cost.
-6. **Re-probe + report** — re-runs diagnostics; the scenario passes only when all checks are green. Emits a **markdown gap report**: per scenario — detected? advice present? advice actually fixed it? — plus an agent-transcript reference for prose cases.
+6. **Re-probe + report** — re-runs diagnostics; the scenario passes only when its **expected** checks are back to `ok` (scoped, not global `overall`). Detection-only scenarios skip apply and are excluded from the green tally. Emits a **markdown gap report**: per scenario — detected? advice present? advice actually fixed it? (PASS / DETECTION GAP / ADVICE GAP / DETECTION-ONLY) — plus an agent-transcript reference for prose cases.
 
 ### Unit boundaries
 
@@ -65,23 +65,21 @@ Units 1–4 + 5(**agent path**) + 6, run **manually**. Tests *current* Shepherd 
 
 ## Scenario matrix (backbone)
 
-Derived from the 7 checks × their states, across the distro spread. Representative (not exhaustive) Phase 1 set:
+Derived from the 7 checks × their states, across the distro spread. **As-built** Phase 1 catalog (`ci/onboarding-harness/scenarios.ts`):
 
-| Scenario | Image | Seed (messy state) | Expect | Coaching path |
+| Scenario | Image | Seed (messy state) | Expect | Class |
 | --- | --- | --- | --- | --- |
-| `gh-unauthed` | ubuntu | `gh` installed, not logged in | `gh: error/warning` (not-authenticated) | prose (agent) |
-| `gh-missing` | debian | `gh` absent | `gh: error` (missing) | structured (P2) / prose |
-| `tailscale-missing` | ubuntu | no tailscale | `tailscale: error` | structured (P2) / prose |
-| `tailscale-not-serving` | ubuntu (sys container, TUN) | tailscaled up, not serving | `tailscale: warning` | prose (agent) |
-| `herdr-missing` | arch | no herdr | `herdr: error` | structured (P2) / prose |
-| `claude-missing` | fedora | no claude CLI | `claude: error` | structured (P2) / prose |
-| `git-missing` | alpine | no git | `git: error` | structured (P2) / prose |
-| `bun-too-old` | ubuntu | bun < `BUN_MIN_VERSION` | `bun: warning` | structured (P2) / prose |
-| `node-too-old` | debian | node < `NODE_MIN_VERSION` | `node: warning` | structured (P2) / prose |
-| `herdr-too-old` | ubuntu | herdr < `HERDR_MIN_VERSION` | `herdr: warning` | structured (P2) / prose |
-| *(Phase 2 stretch)* `cold-bun-absent` | ubuntu (bare) | no bun at all | Shepherd can't boot | agent-bootstrap |
+| `gh-unauthed` | ubuntu | `gh` installed, not logged in | `gh: error` | detection-only (auth needs device-flow) |
+| `gh-missing` | debian | `gh` absent | `gh: error` | detection-only (distro install + auth) |
+| `tailscale-missing` | ubuntu | no tailscale | `tailscale: error` | detection-only (ok needs tailnet login + serve) |
+| `herdr-missing` | arch | no herdr | `herdr: error` | green-able · structured (verbatim) |
+| `claude-missing` | fedora | no claude CLI | `claude: error` | green-able · structured (verbatim reinstall) |
+| `git-missing` | alpine | no git | `git: error` | green-able · prose (agent picks installer) |
+| `node-too-old` | debian | node < `NODE_MIN_VERSION` | `node: warning` | green-able · structured (verbatim) |
 
-Additional divergence axes to fold in opportunistically (confirmed in scope as future scenarios, not blocking Phase 1): corrupted/short `PATH`, root-vs-nonroot user, restricted-egress / proxied networks.
+Only the green-able **structured** scenarios (`herdr-missing`, `claude-missing`, `node-too-old`) feed the deterministic release gate. `git-missing` is green-able via the agent path (nightly, not gated). The three detection-only rows are the honest "onboarding still needs the user" findings.
+
+**Deferred / omitted** (not shipped as permanent gaps — fixtures not yet implemented): `tailscale-not-serving` (needs a faked tailnet for the not-serving `warning` state), `herdr-too-old` (needs a pinned outdated herdr build), the `cold-bun-absent` Phase-2 agent-bootstrap stretch, and the further divergence axes (corrupted/short `PATH`, root-vs-nonroot, restricted-egress). These are follow-ups once the framework's first real-Incus run lands.
 
 ## Risks & mitigations
 

--- a/docs/superpowers/specs/2026-06-13-onboarding-challenge-harness-design.md
+++ b/docs/superpowers/specs/2026-06-13-onboarding-challenge-harness-design.md
@@ -42,7 +42,7 @@ Code lives in **`ci/onboarding-harness/`** (Bun + TS), a sibling of the existing
 3. **Seed engine** — launches a fresh instance, installs the bootable-Shepherd baseline, then runs the scenario's `seed` steps to produce the messy state.
 4. **Probe + assert (detection)** — boots Shepherd in the instance, polls `GET /api/diagnostics?refresh=1`, and asserts the snapshot matches `expect`. This is the first source of gap findings (defect missed or mis-classified).
 5. **Apply engine** — two paths, chosen per scenario `coaching` kind:
-   - **Verbatim:** runs the check's **structured remediation** (Phase 2 `diagnostics.ts` field) exactly as emitted. Deterministic, LLM-free.
+   - **Verbatim:** runs the command from the **harness-side remediation catalog** (Phase 2 `ci/onboarding-harness/remediations.ts`, keyed by the `hintKey` Shepherd emits) exactly as written. Deterministic, LLM-free. No change to the shipped diagnostics payload (revised per plan review — keeps the `DiagnosticCheck` exact-keys purity contract intact).
    - **Agent:** spawns a fresh Claude Code agent given **only** what a real user sees (the diagnostics snapshot + prose coaching) and lets it drive the env to green — a proxy-user UX test. Non-deterministic; LLM cost.
 6. **Re-probe + report** — re-runs diagnostics; the scenario passes only when all checks are green. Emits a **markdown gap report**: per scenario — detected? advice present? advice actually fixed it? — plus an agent-transcript reference for prose cases.
 
@@ -59,7 +59,7 @@ Code lives in **`ci/onboarding-harness/`** (Bun + TS), a sibling of the existing
 Units 1–4 + 5(**agent path**) + 6, run **manually**. Tests *current* Shepherd with **no product change** (all coaching is prose today), and produces the "where onboarding fails today" report. Covers ≥1 scenario per relevant check×state plus distro spread.
 
 ### Phase 2 — deterministic regression tier
-- Add a **structured-remediation field** to `src/diagnostics.ts` for checks that reduce to a single command (the only product-code change in this effort). The human prose hint stays; the structured field is additive.
+- Add a **harness-side remediation catalog** (`ci/onboarding-harness/remediations.ts`) mapping each command-fixable `hintKey` to a verbatim shell command. **No `src/` product change** (revised per plan review): the shipped `DiagnosticCheck` payload is untouched, so the exact-keys purity contract holds and there is no hidden, undiscoverable field. A user-facing "click-to-fix" feature, if ever wanted, is a separate spec.
 - Build the **verbatim apply path** against it → a fast, deterministic, LLM-free regression subset.
 - Wire **nightly** (existing scheduler) + **pre-release gate** (required-green before the OSS tag) on the Incus host.
 
@@ -100,6 +100,9 @@ Additional divergence axes to fold in opportunistically (confirmed in scope as f
 
 ## Out of scope
 
+**Brokenness scope (user-signed-off):** "various states of brokenness" is intentionally scoped to exactly what `diagnostics.ts` can detect today — the 7 checks × their states. The gap report is honestly bounded to detectable states; the harness is built so these can be added later as Shepherd's detection grows. Explicitly **deferred** (not v1):
+
+- Corrupted / locked git repos, port-already-in-use, partial/half-installed herdr state, no network / DNS failure, full disk, broken git worktrees.
 - Building a new/LLM onboarding coach (we test and report on the existing detect+advise layer).
 - Target-repo readiness coaching (`readiness.ts`) and "first agent launches" finish lines.
 - Per-PR execution; macOS/Windows hosts; ARM via emulation.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "bun test ./test",
-    "lint": "eslint --no-error-on-unmatched-pattern src test ui/src",
+    "lint": "eslint --no-error-on-unmatched-pattern src test ui/src ci/onboarding-harness",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "start": "bun run src/index.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write .",
     "start": "bun run src/index.ts",
     "update": "bash deploy/update.sh",
-    "prepare": "husky; node scripts/register-merge-driver.mjs"
+    "prepare": "husky; node scripts/register-merge-driver.mjs",
+    "onboarding:test": "bun run ci/onboarding-harness/run.ts"
   },
   "lint-staged": {
     "*.{ts,js,json,css,html,md,svelte}": "prettier --write",

--- a/scripts/onboarding-gate.sh
+++ b/scripts/onboarding-gate.sh
@@ -15,9 +15,16 @@ if ! command -v incus >/dev/null 2>&1 || ! incus list >/dev/null 2>&1; then
   exit 0
 fi
 
+# Gate runs only green-able deterministic scenarios: structured (verbatim, LLM-free)
+# AND not detection-only (detection-only defects need a human/secret to clear, so
+# they can never reach green and must not gate a release).
 STRUCTURED_IDS=$(bun -e '
   import("./ci/onboarding-harness/scenarios.ts").then(({ SCENARIOS }) =>
-    console.log(SCENARIOS.filter((s) => s.coaching === "structured").map((s) => s.id).join(" ")));
+    console.log(
+      SCENARIOS.filter((s) => s.coaching === "structured" && !s.detectionOnly)
+        .map((s) => s.id)
+        .join(" "),
+    ));
 ')
 
 fail=0

--- a/scripts/onboarding-gate.sh
+++ b/scripts/onboarding-gate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Release gate: run the deterministic (structured) onboarding scenarios and fail
+# the release if any does not reach a healthy state.
+#
+# SAFE DEGRADE (point 6): this gate depends on a single self-hosted Incus host.
+# If that host is unavailable, we must NOT hard-block an otherwise-good release on
+# unrelated infra — we log a loud, explicit bypass and exit 0. A red SCENARIO
+# (Incus present, a scenario failed) still fails the gate; only an absent/broken
+# Incus host bypasses.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if ! command -v incus >/dev/null 2>&1 || ! incus list >/dev/null 2>&1; then
+  echo "::onboarding-gate:: BYPASSED — Incus host unavailable; not blocking the release on infra." >&2
+  exit 0
+fi
+
+STRUCTURED_IDS=$(bun -e '
+  import("./ci/onboarding-harness/scenarios.ts").then(({ SCENARIOS }) =>
+    console.log(SCENARIOS.filter((s) => s.coaching === "structured").map((s) => s.id).join(" ")));
+')
+
+fail=0
+for id in $STRUCTURED_IDS; do
+  echo "::onboarding-gate:: $id"
+  bun run onboarding:test --scenario "$id" || fail=1
+done
+exit "$fail"

--- a/test/onboarding-harness/apply.test.ts
+++ b/test/onboarding-harness/apply.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { resolveCoaching, buildAgentPrompt } from "../../ci/onboarding-harness/apply";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+const snap: DiagnosticsSnapshot = {
+  checks: [
+    { id: "gh", state: "error", hintKey: "diagnostics_hint_gh_not_authenticated" },
+    { id: "git", state: "ok", hintKey: "diagnostics_hint_git_ok" },
+  ],
+  generatedAt: 1,
+  overall: "error",
+};
+
+describe("resolveCoaching", () => {
+  it("resolves non-ok check hintKeys to their EN message text", () => {
+    const messages = {
+      diagnostics_hint_gh_not_authenticated: "Run `gh auth login` to authenticate.",
+    };
+    const lines = resolveCoaching(snap, messages);
+    expect(lines).toEqual([{ id: "gh", text: "Run `gh auth login` to authenticate." }]);
+  });
+
+  it("skips ok checks and falls back to the raw key when a message is missing", () => {
+    const lines = resolveCoaching(snap, {});
+    expect(lines).toEqual([{ id: "gh", text: "diagnostics_hint_gh_not_authenticated" }]);
+  });
+});
+
+describe("buildAgentPrompt", () => {
+  it("includes the coaching text and a clear success instruction", () => {
+    const p = buildAgentPrompt([{ id: "gh", text: "Run gh auth login." }]);
+    expect(p).toContain("Run gh auth login.");
+    expect(p.toLowerCase()).toContain("healthy");
+  });
+});

--- a/test/onboarding-harness/apply.test.ts
+++ b/test/onboarding-harness/apply.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { resolveCoaching, buildAgentPrompt } from "../../ci/onboarding-harness/apply";
+import {
+  resolveCoaching,
+  buildAgentPrompt,
+  applyVerbatim,
+} from "../../ci/onboarding-harness/apply";
+import { IncusDriver } from "../../ci/onboarding-harness/incus";
 import type { DiagnosticsSnapshot } from "../../src/types";
 
 const snap: DiagnosticsSnapshot = {
@@ -31,5 +36,24 @@ describe("buildAgentPrompt", () => {
     const p = buildAgentPrompt([{ id: "gh", text: "Run gh auth login." }]);
     expect(p).toContain("Run gh auth login.");
     expect(p.toLowerCase()).toContain("healthy");
+  });
+});
+
+describe("applyVerbatim", () => {
+  it("runs each harness-catalog remediation for non-ok checks inside the instance", async () => {
+    const calls: string[][] = [];
+    const run = async (args: string[]) => {
+      calls.push(args);
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const d = new IncusDriver(run, "shep-onb-");
+    const snap = {
+      checks: [{ id: "bun", state: "error" as const, hintKey: "diagnostics_hint_bun_missing" }],
+      generatedAt: 1,
+      overall: "error" as const,
+    };
+    const ok = await applyVerbatim(d, "bun-missing", snap);
+    expect(ok).toBe(true);
+    expect(calls[0]!.join(" ")).toContain("bun.sh/install");
   });
 });

--- a/test/onboarding-harness/assert.test.ts
+++ b/test/onboarding-harness/assert.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { assertDetection } from "../../ci/onboarding-harness/assert";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+function snap(checks: Array<[string, "ok" | "warning" | "error"]>): DiagnosticsSnapshot {
+  return {
+    checks: checks.map(([id, state]) => ({ id, state, hintKey: `k_${id}` })),
+    generatedAt: 1,
+    overall: checks.some(([, s]) => s === "error")
+      ? "error"
+      : checks.some(([, s]) => s === "warning")
+        ? "warning"
+        : "ok",
+  };
+}
+
+describe("assertDetection", () => {
+  it("detects when every expected check matches its state", () => {
+    const r = assertDetection(
+      snap([
+        ["gh", "error"],
+        ["git", "ok"],
+      ]),
+      "s",
+      [{ id: "gh", state: "error" }],
+    );
+    expect(r.detected).toBe(true);
+    expect(r.misses).toEqual([]);
+  });
+
+  it("reports a state mismatch as a miss", () => {
+    const r = assertDetection(snap([["gh", "warning"]]), "s", [{ id: "gh", state: "error" }]);
+    expect(r.detected).toBe(false);
+    expect(r.misses).toEqual([{ id: "gh", want: "error", got: "warning" }]);
+  });
+
+  it("reports an absent expected check as a miss", () => {
+    const r = assertDetection(snap([["git", "ok"]]), "s", [{ id: "gh", state: "error" }]);
+    expect(r.misses).toEqual([{ id: "gh", want: "error", got: "absent" }]);
+  });
+});

--- a/test/onboarding-harness/incus.test.ts
+++ b/test/onboarding-harness/incus.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import { IncusDriver } from "../../ci/onboarding-harness/incus";
+import type { IncusExec } from "../../ci/onboarding-harness/types";
+
+function recorder(reply: Partial<IncusExec> = {}) {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<IncusExec> => {
+    calls.push(args);
+    return { stdout: "", stderr: "", code: 0, ...reply };
+  };
+  return { calls, run };
+}
+
+describe("IncusDriver", () => {
+  it("launches a system container with the managed-name prefix and profile", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await d.launch("images:ubuntu/24.04", "gh-unauthed", { profile: "shep-onb" });
+    expect(calls[0]).toEqual([
+      "launch",
+      "images:ubuntu/24.04",
+      "shep-onb-gh-unauthed",
+      "--profile",
+      "shep-onb",
+    ]);
+  });
+
+  it("adds --vm when the scenario requests a VM", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await d.launch("images:ubuntu/24.04", "kernel-x", { vm: true });
+    expect(calls[0]).toContain("--vm");
+  });
+
+  it("execs a command inside the instance via -- separator", async () => {
+    const { calls, run } = recorder({ stdout: "ok" });
+    const d = new IncusDriver(run, "shep-onb-");
+    const r = await d.exec("gh-unauthed", ["sh", "-c", "echo hi"]);
+    expect(calls[0]).toEqual(["exec", "shep-onb-gh-unauthed", "--", "sh", "-c", "echo hi"]);
+    expect(r.stdout).toBe("ok");
+  });
+
+  it("force-deletes an instance", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await d.delete("gh-unauthed");
+    expect(calls[0]).toEqual(["delete", "shep-onb-gh-unauthed", "--force"]);
+  });
+
+  it("lists only managed instances and sweeps them", async () => {
+    const { calls, run } = recorder({
+      stdout: JSON.stringify([
+        { name: "shep-onb-a" },
+        { name: "unrelated" },
+        { name: "shep-onb-b" },
+      ]),
+    });
+    const d = new IncusDriver(run, "shep-onb-");
+    expect(await d.listManaged()).toEqual(["shep-onb-a", "shep-onb-b"]);
+    await d.sweep();
+    // listManaged (1) + one delete per managed instance (2)
+    expect(calls.filter((c) => c[0] === "delete")).toHaveLength(2);
+  });
+});

--- a/test/onboarding-harness/probe.test.ts
+++ b/test/onboarding-harness/probe.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { IncusDriver } from "../../ci/onboarding-harness/incus";
+import { probeDiagnostics } from "../../ci/onboarding-harness/probe";
+import type { IncusExec } from "../../ci/onboarding-harness/types";
+
+describe("probeDiagnostics", () => {
+  it("curls the diagnostics endpoint inside the instance and parses the snapshot", async () => {
+    const snapshot = {
+      checks: [{ id: "gh", state: "error", hintKey: "diagnostics_hint_gh_not_authenticated" }],
+      generatedAt: 5,
+      overall: "error",
+    };
+    const calls: string[][] = [];
+    const run = async (args: string[]): Promise<IncusExec> => {
+      calls.push(args);
+      return { stdout: JSON.stringify(snapshot), stderr: "", code: 0 };
+    };
+    const d = new IncusDriver(run, "shep-onb-");
+    const snap = await probeDiagnostics(d, "gh-unauthed");
+    expect(snap.overall).toBe("error");
+    expect(snap.checks[0].id).toBe("gh");
+    // exec'd a curl against the loopback diagnostics endpoint with refresh
+    const cmd = calls[0].join(" ");
+    expect(cmd).toContain("curl");
+    expect(cmd).toContain("/api/diagnostics?refresh=1");
+  });
+});

--- a/test/onboarding-harness/probe.test.ts
+++ b/test/onboarding-harness/probe.test.ts
@@ -18,9 +18,9 @@ describe("probeDiagnostics", () => {
     const d = new IncusDriver(run, "shep-onb-");
     const snap = await probeDiagnostics(d, "gh-unauthed");
     expect(snap.overall).toBe("error");
-    expect(snap.checks[0].id).toBe("gh");
+    expect(snap.checks[0]!.id).toBe("gh");
     // exec'd a curl against the loopback diagnostics endpoint with refresh
-    const cmd = calls[0].join(" ");
+    const cmd = calls[0]!.join(" ");
     expect(cmd).toContain("curl");
     expect(cmd).toContain("/api/diagnostics?refresh=1");
   });

--- a/test/onboarding-harness/remediations.test.ts
+++ b/test/onboarding-harness/remediations.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { REMEDIATIONS, remediationsFor } from "../../ci/onboarding-harness/remediations";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+describe("remediations catalog", () => {
+  it("maps known fixable hintKeys to a single shell command", () => {
+    expect(REMEDIATIONS.diagnostics_hint_bun_missing).toContain("bun.sh/install");
+  });
+
+  it("collects verbatim commands for non-ok checks that have one (skips prose-only and ok)", () => {
+    const snap: DiagnosticsSnapshot = {
+      checks: [
+        { id: "bun", state: "error", hintKey: "diagnostics_hint_bun_missing" },
+        { id: "gh", state: "error", hintKey: "diagnostics_hint_gh_not_authenticated" }, // prose-only → skipped
+        { id: "git", state: "ok", hintKey: "diagnostics_hint_git_ok" }, // ok → skipped
+      ],
+      generatedAt: 1,
+      overall: "error",
+    };
+    expect(remediationsFor(snap)).toEqual([REMEDIATIONS.diagnostics_hint_bun_missing]);
+  });
+});

--- a/test/onboarding-harness/remediations.test.ts
+++ b/test/onboarding-harness/remediations.test.ts
@@ -17,6 +17,6 @@ describe("remediations catalog", () => {
       generatedAt: 1,
       overall: "error",
     };
-    expect(remediationsFor(snap)).toEqual([REMEDIATIONS.diagnostics_hint_bun_missing]);
+    expect(remediationsFor(snap)).toEqual([REMEDIATIONS["diagnostics_hint_bun_missing"]!]);
   });
 });

--- a/test/onboarding-harness/report.test.ts
+++ b/test/onboarding-harness/report.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { buildGapReport } from "../../ci/onboarding-harness/report";
+import type { ScenarioResult } from "../../ci/onboarding-harness/types";
+
+const results: ScenarioResult[] = [
+  {
+    scenarioId: "gh-unauthed",
+    image: "images:ubuntu/24.04",
+    detection: { scenarioId: "gh-unauthed", detected: true, misses: [] },
+    appliedVia: "agent",
+    reachedGreen: true,
+  },
+  {
+    scenarioId: "tailscale-missing",
+    image: "images:ubuntu/24.04",
+    detection: {
+      scenarioId: "tailscale-missing",
+      detected: false,
+      misses: [{ id: "tailscale", want: "error", got: "absent" }],
+    },
+    appliedVia: "agent",
+    reachedGreen: false,
+    error: "agent gave up",
+  },
+];
+
+describe("buildGapReport", () => {
+  it("summarizes pass/fail counts and lists gaps", () => {
+    const md = buildGapReport(results);
+    expect(md).toContain("# Onboarding Gap Report");
+    expect(md).toContain("1 / 2 scenarios reached green");
+    expect(md).toContain("gh-unauthed");
+    expect(md).toContain("tailscale-missing");
+    expect(md).toContain("tailscale want=error got=absent");
+    expect(md).toContain("agent gave up");
+  });
+
+  it("marks a detection-but-not-fixed scenario as an advice gap", () => {
+    const md = buildGapReport([
+      {
+        scenarioId: "x",
+        image: "i",
+        detection: { scenarioId: "x", detected: true, misses: [] },
+        appliedVia: "agent",
+        reachedGreen: false,
+      },
+    ]);
+    expect(md).toContain("ADVICE GAP");
+  });
+
+  it("classifies a by-design no-apply scenario as DETECTION-ONLY and excludes it from the denominator", () => {
+    const md = buildGapReport([
+      {
+        scenarioId: "claude-missing",
+        image: "images:fedora/40",
+        detection: { scenarioId: "claude-missing", detected: true, misses: [] },
+        appliedVia: "skipped",
+        reachedGreen: false,
+        detectionOnly: true,
+      },
+      {
+        scenarioId: "gh-unauthed",
+        image: "i",
+        detection: { scenarioId: "gh-unauthed", detected: true, misses: [] },
+        appliedVia: "agent",
+        reachedGreen: true,
+      },
+    ]);
+    expect(md).toContain("DETECTION-ONLY");
+    expect(md).toContain("1 / 1 scenarios reached green"); // claude-missing excluded
+    expect(md).not.toContain("## Gaps"); // DETECTION-ONLY is not a gap
+  });
+});

--- a/test/onboarding-harness/scenarios.test.ts
+++ b/test/onboarding-harness/scenarios.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { SCENARIOS } from "../../ci/onboarding-harness/scenarios";
+
+const CHECK_IDS = new Set(["bun", "node", "claude", "gh", "git", "herdr", "tailscale"]);
+
+describe("scenario catalog", () => {
+  it("has unique kebab-case ids", () => {
+    const ids = SCENARIOS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+  });
+
+  it("only expects known check ids", () => {
+    for (const s of SCENARIOS) {
+      for (const e of s.expect) expect(CHECK_IDS.has(e.id)).toBe(true);
+    }
+  });
+
+  it("every scenario seeds at least one command and expects at least one flag", () => {
+    for (const s of SCENARIOS) {
+      expect(s.seed.length).toBeGreaterThan(0);
+      expect(s.expect.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("covers each non-bun check id at least once", () => {
+    const covered = new Set(SCENARIOS.flatMap((s) => s.expect.map((e) => e.id)));
+    for (const id of ["node", "claude", "gh", "git", "herdr", "tailscale"]) {
+      expect(covered.has(id)).toBe(true);
+    }
+  });
+});

--- a/test/onboarding-harness/seed.test.ts
+++ b/test/onboarding-harness/seed.test.ts
@@ -26,8 +26,8 @@ describe("seedInstance", () => {
     const d = new IncusDriver(run, "shep-onb-");
     await seedInstance(d, scenario, "/tmp/shepherd.tar");
 
-    expect(calls[0][0]).toBe("launch");
-    expect(calls[0]).toContain("images:ubuntu/24.04");
+    expect(calls[0]![0]).toBe("launch");
+    expect(calls[0]!).toContain("images:ubuntu/24.04");
 
     const flat = calls.map((c) => c.join(" "));
     // baseline installs bun before the scenario seed runs

--- a/test/onboarding-harness/seed.test.ts
+++ b/test/onboarding-harness/seed.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { IncusDriver } from "../../ci/onboarding-harness/incus";
+import { seedInstance } from "../../ci/onboarding-harness/seed";
+import type { IncusExec } from "../../ci/onboarding-harness/types";
+
+function recorder() {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<IncusExec> => {
+    calls.push(args);
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  return { calls, run };
+}
+
+const scenario = {
+  id: "gh-unauthed",
+  image: "images:ubuntu/24.04",
+  seed: ["rm -rf ~/.config/gh"],
+  expect: [{ id: "gh", state: "error" as const }],
+  coaching: "prose" as const,
+};
+
+describe("seedInstance", () => {
+  it("launches, installs the bun baseline, then runs the scenario seed in order", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await seedInstance(d, scenario, "/tmp/shepherd.tar");
+
+    expect(calls[0][0]).toBe("launch");
+    expect(calls[0]).toContain("images:ubuntu/24.04");
+
+    const flat = calls.map((c) => c.join(" "));
+    // baseline installs bun before the scenario seed runs
+    const bunIdx = flat.findIndex((c) => c.includes("bun.sh/install"));
+    const seedIdx = flat.findIndex((c) => c.includes("rm -rf ~/.config/gh"));
+    expect(bunIdx).toBeGreaterThanOrEqual(0);
+    expect(seedIdx).toBeGreaterThan(bunIdx);
+  });
+
+  it("pushes the Shepherd build tarball into the instance", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await seedInstance(d, scenario, "/tmp/shepherd.tar");
+    const push = calls.find((c) => c[0] === "file" && c[1] === "push");
+    expect(push).toBeDefined();
+    expect(push!).toContain("/tmp/shepherd.tar");
+  });
+});


### PR DESCRIPTION
## What

Adds an **onboarding challenge & regression harness** — an OSS-launch prerequisite that boots deliberately-messy throw-away environments, runs Shepherd inside them in degraded mode, and verifies it detects + coaches a new user's host to a healthy state. Produces a **gap report** of where onboarding fails today, and a deterministic subset that can **green-gate releases**.

All new code lives under `ci/onboarding-harness/` + `test/onboarding-harness/` + `scripts/` — **no `src/` product change**.

## How it works

- **Incus** as the isolation primitive (system containers default, VM opt-in) — already on the host.
- Per scenario: seed a messy env → boot degraded Shepherd → read `GET /api/diagnostics?refresh=1` → assert detection → **apply the coaching** → re-probe → pass only at host-green.
- Two apply paths: **verbatim** (deterministic, from a harness-side remediation catalog keyed by Shepherd's emitted `hintKey`s) and **agent** (a Claude Code proxy-user given only what a real user sees, for prose coaching).
- Cadence: **manual + nightly (systemd timer) + pre-release gate**, on the self-hosted Incus host — never per-PR.

## Components (`ci/onboarding-harness/`)

`incus.ts` (injectable CLI driver) · `scenarios.ts` (catalog, 7 checks × states across 5 distros) · `seed.ts` · `probe.ts` · `apply.ts` (agent + verbatim) · `remediations.ts` · `assert.ts` · `report.ts` (PASS / DETECTION GAP / ADVICE GAP / DETECTION-ONLY) · `run.ts` (orchestrator + CLI). Run: `bun run onboarding:test [--scenario <id>]`.

## Notable design points

- **Bootstrap paradox:** baselines always carry the bun runtime (Shepherd must boot to coach); the cold "bun absent" case is a deferred Phase-2 stretch.
- **`claude` is presence-only** → no `claude-unauthed` scenario; `claude-missing` is detection-only when the agent path is unavailable, verbatim-reinstalled otherwise.
- **Run isolation:** host-wide lock at `~/.shepherd/onboarding-harness.lock` (stable across a systemd-user timer and interactive runs, unlike `$TMPDIR`) + per-run instance prefix; `--reap-orphans` for crash recovery.
- **Gate fails closed but degrades safely:** bypasses (logged, exit 0) only when the Incus host is absent; fails on a red scenario. Every `structured` (gate-run) scenario has a verbatim remediation, so the gate is genuinely LLM-free.
- **Probe auth:** baseline boots with `SHEPHERD_TOKEN` unset so the loopback `curl` probe passes `checkAuth`.

## Scope (v1, user-signed-off)

Scoped to the 7 diagnostics checks. Deferred: corrupted/locked git repos, port-in-use, partial herdr, no network/DNS, full disk, broken worktrees, target-repo readiness, macOS/Windows/ARM.

## Testing

- 24 harness unit tests (injectable runners — no real Incus needed); full root suite **2698 pass / 0 fail**; `tsc` clean; `lint` clean; `fallow` clean.
- The live Incus integration run is a documented manual step (`README.md`), not run in CI.

Spec: `docs/superpowers/specs/2026-06-13-onboarding-challenge-harness-design.md`
Plan: `docs/superpowers/plans/2026-06-13-onboarding-challenge-harness.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)