### PR TITLE
fix(ui): full-bleed terminal view on phones, drop side borders

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1660,6 +1660,7 @@
 <div
   class="viewport"
   class:swiping
+  class:phone={mobile}
   bind:this={viewportEl}
   style:transform={swipeX ? `translateX(${swipeX}px)` : undefined}
 >
@@ -2528,6 +2529,18 @@
 
   .viewport.swiping {
     transition: none;
+  }
+
+  /* phone session view: full-bleed terminal — the side borders + rounded corners
+     cost two vertical lines plus gutters on a narrow phone, so drop them and
+     stretch into the shell's base edge padding (--mobile-shell-pad, shared with
+     .shell.mobile in +page.svelte; a larger safe-area inset keeps the remainder).
+     The top/bottom borders stay as horizontal section rules. Mirrors Herd's
+     .panel.flow full-bleed treatment for the mobile list. */
+  .viewport.phone {
+    border-inline: 0;
+    border-radius: 0;
+    margin-inline: calc(-1 * var(--mobile-shell-pad));
   }
 
   .vp-head {


### PR DESCRIPTION
## Was

Auf kleinen Bildschirmen behielt die Terminal-/Session-Ansicht (Viewport) ihre **linken und rechten Panel-Rahmen** plus die Shell-Randabstände — zwei vertikale Trennlinien plus Gutter, die auf schmalen Phones unnötig Platz fressen (siehe Screenshot 1).

Das Herd-/Auswahlmenü (Screenshot 2) wurde bereits randlos gemacht; diese PR zieht die Terminal-Ansicht nach.

## Änderung

Neue, rein additive Klasse `.viewport.phone` (greift nur im Phone-Layout, `mobile={true}`):

- `border-inline: 0` — vertikale Trennlinien links/rechts entfernt
- `border-radius: 0` — randlos, keine abgerundeten Ecken mehr
- `margin-inline: calc(-1 * var(--mobile-shell-pad))` — bleedet in den Shell-Randabstand

Die **horizontalen** Rahmen oben/unten bleiben als Sektions-Trennlinien erhalten — genau wie gewünscht (horizontale Linien okay, vertikale weg).

Spiegelt 1:1 das bestehende, bereits reviewte `.panel.flow`-Muster von `Herd.svelte`. Desktop ist nicht betroffen (neue Klasse existierte vorher nicht).

## Verifikation

- `cd ui && bun run check` → 0 errors

[no-feature-entry] — reine UI-Politur (Platzgewinn) einer bestehenden Ansicht, kein neues user-facing Feature.