### PR TITLE
feat(epic): land the epic via a final epic/#→default PR (#635)

### DIFF
--- a/src/completed-epic.ts
+++ b/src/completed-epic.ts
@@ -10,12 +10,20 @@ export interface CompletedEpicChild {
   integrated: boolean;
 }
 
+/** Landing-PR lifecycle state — pending=not yet resolved, open=PR opened/reused,
+ *  none=nothing to land / human-closed, error=last open attempt failed/retrying. */
+export type EpicLandingState = "pending" | "open" | "none" | "error";
+
 export interface CompletedEpic {
   repoPath: string;
   parentIssueNumber: number;
   parentTitle: string;
   completedAt: number;
   children: CompletedEpicChild[];
+  // Stage B (#635) landing-PR carried on the band; null/'pending' until the aggregate PR opens.
+  landingPrNumber: number | null;
+  landingPrUrl: string | null;
+  landingState: EpicLandingState;
 }
 
 export function buildRollup(

--- a/src/completed-epic.ts
+++ b/src/completed-epic.ts
@@ -11,8 +11,9 @@ export interface CompletedEpicChild {
 }
 
 /** Landing-PR lifecycle state — pending=not yet resolved, open=PR opened/reused,
+ *  merged=landing PR has merged (epic landed; band about to be dismissed on parent close),
  *  none=nothing to land / human-closed, error=last open attempt failed/retrying. */
-export type EpicLandingState = "pending" | "open" | "none" | "error";
+export type EpicLandingState = "pending" | "open" | "merged" | "none" | "error";
 
 export interface CompletedEpic {
   repoPath: string;

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -559,8 +559,13 @@ export class DrainService {
       if (!row) return; // nothing recorded (or already dismissed/landed)
 
       // Terminal / parked short-circuit — never re-touch the forge for a resolved or
-      // capped-out row. `open`/`none` are terminal; `error` at/over the cap is parked.
-      if (row.landingState === "open" || row.landingState === "none") return;
+      // capped-out row. `open`/`merged`/`none` are terminal; `error` at/over the cap is parked.
+      if (
+        row.landingState === "open" ||
+        row.landingState === "merged" ||
+        row.landingState === "none"
+      )
+        return;
       if (row.landingState === "error" && row.landingAttempts >= MAX_LANDING_ATTEMPTS) return;
 
       // Cheap pre-gate: a pure-legacy epic accumulated nothing on the integration branch,
@@ -590,9 +595,10 @@ export class DrainService {
 
   /**
    * Resolve what the landing PR's state should become by talking to the forge: reuse an
-   * existing open/merged PR, treat a human-closed PR as terminal `none`, open a new one, or
-   * classify the failure (EmptyDiffError → `none`; anything else → `error` + attempt++). Pure
-   * decision — the caller persists + emits. NEVER throws: every forge touch is wrapped here.
+   * existing open PR, record an already-merged one as `merged`, treat a human-closed one as
+   * terminal `none`, open a new one, or classify the failure (EmptyDiffError → `none`; anything
+   * else → `error` + attempt++). Pure decision — the caller persists + emits. NEVER throws:
+   * every forge touch is wrapped here.
    */
   private async classifyLanding(
     forge: GitForge,
@@ -615,10 +621,20 @@ export class DrainService {
       // Idempotency guard: prStatus reads `--state all`, so it sees any prior PR whose head
       // is the integration branch (which is only ever the landing PR's head).
       const existing = await forge.prStatus(integrationBranch);
-      if (existing.state === "open" || existing.state === "merged") {
+      if (existing.state === "open") {
         // Reuse — never open a second PR. Covers the open-succeeded/record-failed gap.
         return {
           state: "open",
+          prNumber: existing.number ?? null,
+          prUrl: existing.url ?? null,
+          attempts: landingAttempts,
+        };
+      }
+      if (existing.state === "merged") {
+        // Already merged (epic landed) — record as terminal `merged` so the band reads
+        // accurately post-merge rather than "awaiting merge" until the parent-close reconcile.
+        return {
+          state: "merged",
           prNumber: existing.number ?? null,
           prUrl: existing.url ?? null,
           attempts: landingAttempts,

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -15,7 +15,14 @@ import {
 import { assembleEpic } from "./epic-model";
 import { epicIntegrationBranch as epicBranchName, isEpicIntegrationBranch } from "./epic-branch";
 import { selectEpicCandidates, type Epic, type EpicRun } from "./epic-core";
-import { buildRollup, type CompletedEpic } from "./completed-epic";
+import {
+  buildRollup,
+  type CompletedEpic,
+  type CompletedEpicChild,
+  type EpicLandingState,
+} from "./completed-epic";
+import { buildLandingPrTitle, buildLandingPrBody } from "./epic-landing";
+import { EmptyDiffError } from "./forge/types";
 import { mapBounded } from "./map-bounded";
 import { config } from "./config";
 
@@ -23,6 +30,13 @@ import { config } from "./config";
  *  Bounds `gh api` subprocesses so a large (100+-child) epic can't exhaust FDs or
  *  trip GitHub secondary rate limits. */
 const EPIC_BLOCKED_BY_CONCURRENCY = 8;
+
+/** Cap on epic-landing-PR open attempts (#635, Stage B). A failed `openPr` flips the
+ *  `epic_completed` row to `landingState:'error'` and increments `landingAttempts`; the
+ *  autonomous tick retries until this many failures, then PARKS the row in `error` —
+ *  still surfaced on the band, but excluded from the retry set so it makes no further
+ *  forge calls. Bounds the cost of a permanently-broken landing (no perpetual retry). */
+const MAX_LANDING_ATTEMPTS = 5;
 import { drainSpawnModel, resolveDefaultModelSetting } from "./default-model";
 import {
   resolveProfile,
@@ -83,6 +97,8 @@ export interface DrainDeps {
     | "recordEpicIntegrated"
     | "listEpicIntegratedDetails"
     | "recordEpicCompleted"
+    | "listEpicCompleted"
+    | "setEpicLandingPr"
   >;
   service: { create(input: CreateSessionInput): Promise<Session>; archive(id: string): number };
   resolveForge: (repoPath: string) => GitForge | null;
@@ -130,6 +146,14 @@ export class DrainService {
   // repoPath lock held across the whole async pump — a concurrent pump for the
   // same repo bails immediately so we never double-spawn/double-retire.
   private pumping = new Set<string>();
+  // In-flight guard for ensureLandingPr, keyed `${repoPath}#${parentIssueNumber}`.
+  // ensureLandingPr is a read-modify-write across awaits and runs OUTSIDE the per-repo
+  // `pumping` lock (reachable from tick(), which has no re-entrancy guard, and from the
+  // pumpStep completion edge). Two overlapping resolutions for the same epic would
+  // otherwise both read prStatus=none → both openPr (two landing PRs) and both read the
+  // same landingAttempts → lose an increment. This set makes the second invocation a
+  // no-op; it'll be retried next tick anyway.
+  private landingInFlight = new Set<string>();
   // sessionIds whose claim label onArchived must NOT release. Populated in doRetire
   // (a ready PR stays open → keep the claim so no instance re-spawns it; the human
   // merge auto-closes the issue, retiring the claim) and in onGit ONLY for a merge
@@ -440,6 +464,229 @@ export class DrainService {
   }
 
   /**
+   * Re-read the resolved `epic_completed` row and emit it as a {@link CompletedEpic}
+   * so the integrated-epics band reflects the new landing state. Called by every
+   * resolve branch of {@link ensureLandingPr} after `setEpicLandingPr` writes, so the
+   * band sees the latest landing fields without duplicating the build. A
+   * vanished row (dismissed mid-flight) silently no-ops.
+   */
+  private emitCompleted(repoPath: string, parentIssueNumber: number): void {
+    const row = this.deps.store
+      .listEpicCompleted(repoPath)
+      .find((r) => r.parentIssueNumber === parentIssueNumber);
+    if (!row) return;
+    // Display-only emit; called from ensureLandingPr's catch path, so a malformed
+    // childrenJson must NOT throw past the handler (breaking its never-throws contract).
+    let children: CompletedEpicChild[];
+    try {
+      children = JSON.parse(row.childrenJson) as CompletedEpicChild[];
+    } catch (err) {
+      console.warn(
+        `[drain] emitCompleted skipped — bad childrenJson for ${repoPath}#${parentIssueNumber}:`,
+        err,
+      );
+      return;
+    }
+    const completed: CompletedEpic = {
+      repoPath,
+      parentIssueNumber,
+      parentTitle: row.parentTitle,
+      completedAt: row.completedAt,
+      children,
+      landingPrNumber: row.landingPrNumber,
+      landingPrUrl: row.landingPrUrl,
+      landingState: row.landingState,
+    };
+    this.deps.emitEpicCompleted?.(completed);
+  }
+
+  /** Write the resolved landing fields to the `epic_completed` row and re-emit the band's
+   *  CompletedEpic. The store-write + emit pair recurs in every resolve branch of
+   *  {@link ensureLandingPr}; collapsing it here removes copy-paste drift risk. */
+  private resolveLanding(
+    repoPath: string,
+    parentIssueNumber: number,
+    fields: {
+      state: EpicLandingState;
+      prNumber: number | null;
+      prUrl: string | null;
+      attempts: number;
+    },
+  ): void {
+    this.deps.store.setEpicLandingPr(repoPath, parentIssueNumber, fields);
+    this.emitCompleted(repoPath, parentIssueNumber);
+  }
+
+  /**
+   * Open (or reuse) the aggregate `epic/<#>-<slug> → <default>` landing PR for a completed
+   * epic and record its resolution on the `epic_completed` row — a single idempotent
+   * operation (#635, Stage B).
+   *
+   * DECOUPLED FROM THE IDLE FLIP (NEVER wedges the repo's drain): completion already
+   * recorded the row + flipped `running → idle` (see {@link handleEpicSideEffects}); a
+   * running epic suppresses the repo's label-mode drain, so we MUST NOT gate that flip on
+   * the landing PR — a single forge hiccup would otherwise freeze ALL autonomous drain for
+   * the repo. This runs separately and surfaces failure on the band (`landingState:'error'`),
+   * never by holding the run open. It MUST NEVER throw: every forge touch is wrapped and
+   * mapped to a terminal/retryable state.
+   *
+   * Idempotent: `prStatus(integrationBranch)` (the integration branch is only ever the
+   * landing PR's head, and prStatus reads `--state all`) reuses any prior PR (open/merged),
+   * treats a human-closed PR as terminal `none` (we don't re-open what an operator closed),
+   * and only opens when there is none. An `EmptyDiffError` (nothing to land) resolves `none`;
+   * any other failure resolves `error` and increments `landingAttempts` for capped retry.
+   */
+  private async ensureLandingPr(
+    repoPath: string,
+    parentIssueNumber: number,
+    parentTitle: string,
+  ): Promise<void> {
+    const forge = this.deps.resolveForge(repoPath);
+    if (!forge) return;
+
+    // Serialize per (repo, parent): bail if a resolution for this epic is already mid-flight.
+    // The body is a read-modify-write across awaits and runs outside the `pumping` lock, so an
+    // overlapping invocation (tick() ⟷ pumpStep edge) would otherwise double-open the PR and
+    // lose a landingAttempts increment. The second caller no-ops; the tick retries it anyway.
+    const inFlightKey = `${repoPath}#${parentIssueNumber}`;
+    if (this.landingInFlight.has(inFlightKey)) return;
+    this.landingInFlight.add(inFlightKey);
+    try {
+      const row = this.deps.store
+        .listEpicCompleted(repoPath)
+        .find((r) => r.parentIssueNumber === parentIssueNumber);
+      if (!row) return; // nothing recorded (or already dismissed/landed)
+
+      // Terminal / parked short-circuit — never re-touch the forge for a resolved or
+      // capped-out row. `open`/`none` are terminal; `error` at/over the cap is parked.
+      if (row.landingState === "open" || row.landingState === "none") return;
+      if (row.landingState === "error" && row.landingAttempts >= MAX_LANDING_ATTEMPTS) return;
+
+      // Cheap pre-gate: a pure-legacy epic accumulated nothing on the integration branch,
+      // so there is nothing to land. The authoritative empty-diff check is the openPr
+      // EmptyDiffError below; this just avoids a doomed openPr round-trip.
+      const integratedDetails = this.deps.store.listEpicIntegratedDetails(
+        repoPath,
+        parentIssueNumber,
+      );
+      if (integratedDetails.length === 0) {
+        this.resolveLanding(repoPath, parentIssueNumber, {
+          state: "none",
+          prNumber: null,
+          prUrl: null,
+          attempts: row.landingAttempts,
+        });
+        return;
+      }
+
+      const integrationBranch = epicBranchName(parentIssueNumber, parentTitle);
+      try {
+        // Idempotency guard: prStatus reads `--state all`, so it sees any prior PR whose head
+        // is the integration branch (which is only ever the landing PR's head).
+        const existing = await forge.prStatus(integrationBranch);
+        if (existing.state === "open" || existing.state === "merged") {
+          // Reuse — never open a second PR. Covers the open-succeeded/record-failed gap.
+          this.resolveLanding(repoPath, parentIssueNumber, {
+            state: "open",
+            prNumber: existing.number ?? null,
+            prUrl: existing.url ?? null,
+            attempts: row.landingAttempts,
+          });
+          return;
+        }
+        if (existing.state === "closed") {
+          // A human deliberately closed the landing PR (unmerged) — terminal, do NOT re-open it.
+          this.resolveLanding(repoPath, parentIssueNumber, {
+            state: "none",
+            prNumber: null,
+            prUrl: null,
+            attempts: row.landingAttempts,
+          });
+          return;
+        }
+        // existing.state === "none" → no PR yet, open one.
+        const defaultBranch = await forge.defaultBranch();
+        const children = JSON.parse(row.childrenJson) as CompletedEpicChild[];
+        const title = buildLandingPrTitle(parentIssueNumber, parentTitle);
+        const body = buildLandingPrBody({
+          parentNumber: parentIssueNumber,
+          parentTitle,
+          integrationBranch,
+          defaultBranch,
+          children,
+        });
+        const status = await forge.openPr({
+          head: integrationBranch,
+          base: defaultBranch,
+          title,
+          body,
+        });
+        this.resolveLanding(repoPath, parentIssueNumber, {
+          state: "open",
+          prNumber: status.number ?? null,
+          prUrl: status.url ?? null,
+          attempts: row.landingAttempts,
+        });
+      } catch (err) {
+        if (err instanceof EmptyDiffError) {
+          // No net diff vs default (already landed, or integrations that net to nothing) —
+          // terminal `none`, NOT an error. The length>0 pre-gate can't detect a zero net diff.
+          this.resolveLanding(repoPath, parentIssueNumber, {
+            state: "none",
+            prNumber: null,
+            prUrl: null,
+            attempts: row.landingAttempts,
+          });
+          return;
+        }
+        // Transient/unknown failure (network, no push access) → error + count it; retried by
+        // the autonomous tick until the cap, then parked. NEVER holds the run.
+        this.resolveLanding(repoPath, parentIssueNumber, {
+          state: "error",
+          prNumber: null,
+          prUrl: null,
+          attempts: row.landingAttempts + 1,
+        });
+        console.warn(
+          `[drain] ensureLandingPr openPr failed for ${repoPath}#${parentIssueNumber} (attempt ${row.landingAttempts + 1}/${MAX_LANDING_ATTEMPTS}):`,
+          err,
+        );
+      }
+    } finally {
+      this.landingInFlight.delete(inFlightKey);
+    }
+  }
+
+  /**
+   * DB-gated landing-PR retry for one repo, run UNGATED in {@link tick} (even for an idle
+   * epic in a repo with autoDrain off). It touches the forge ONLY when a completed epic
+   * still needs its landing PR resolved (`pending`, or `error` below the cap) — so steady
+   * state (all rows `open`/`none`/parked-`error`) is zero forge calls. This is the genuinely-
+   * autonomous home: it covers both an edge-time openPr failure and a completion recorded
+   * across a restart (no UI required).
+   */
+  private async ensureLandingPrsForRepo(repoPath: string): Promise<void> {
+    const pending = this.deps.store
+      .listEpicCompleted(repoPath)
+      .filter(
+        (r) =>
+          (r.landingState === "pending" || r.landingState === "error") &&
+          r.landingAttempts < MAX_LANDING_ATTEMPTS,
+      );
+    for (const r of pending) {
+      try {
+        await this.ensureLandingPr(repoPath, r.parentIssueNumber, r.parentTitle);
+      } catch (err) {
+        // ensureLandingPr already swallows; this is defense-in-depth.
+        console.warn(
+          `[drain] ensureLandingPr retry failed for ${repoPath}#${r.parentIssueNumber}:`,
+          err,
+        );
+      }
+    }
+  }
+
+  /**
    * Execute one step of the drain loop: build state, run epic side-effects,
    * compute the next decision, emit status, then apply the decision.
    * Returns false when the loop should break (hold or error), true to continue.
@@ -458,6 +705,20 @@ export class DrainService {
       if (epic && state.epicParent !== null) {
         const epicRun = this.deps.store.getEpicRun(repoPath);
         if (epicRun) epicAutoCompleted = this.handleEpicSideEffects(repoPath, epicRun, epic);
+      }
+      if (epicAutoCompleted && epic) {
+        // Best-effort landing PR on the completion edge. DECOUPLED from the (already-done)
+        // record+idle flip: ensureLandingPr resolves to a state and never throws, but the
+        // try/catch is defense-in-depth — a landing failure must NEVER hold the run open
+        // (that would freeze the whole repo's drain). The autonomous tick retries it.
+        try {
+          await this.ensureLandingPr(repoPath, epic.parentIssueNumber, epic.parentTitle);
+        } catch (err) {
+          console.warn(
+            `[drain] ensureLandingPr (completion edge) failed for ${repoPath}#${epic.parentIssueNumber}:`,
+            err,
+          );
+        }
       }
       decision = computeNext(state);
       // When the epic just auto-completed (running→idle), the state we built still
@@ -833,6 +1094,10 @@ export class DrainService {
   /** Periodic sweep (~30s): catches newly-labeled issues + resumed usage windows. */
   async tick(): Promise<void> {
     for (const repoPath of this.deps.repos()) {
+      // UNGATED landing-PR retry: runs for EVERY repo, BEFORE the pump gate, so a completed
+      // epic's PR is opened/retried even in a repo with autoDrain off and no running epic.
+      // DB-gated internally → zero forge calls in steady state.
+      await this.ensureLandingPrsForRepo(repoPath);
       const cfg = this.deps.store.getRepoConfig(repoPath);
       const er = this.deps.store.getEpicRun(repoPath);
       if (cfg.autoDrainEnabled || er?.status === "running") await this.pump(repoPath);

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -581,80 +581,89 @@ export class DrainService {
       }
 
       const integrationBranch = epicBranchName(parentIssueNumber, parentTitle);
-      try {
-        // Idempotency guard: prStatus reads `--state all`, so it sees any prior PR whose head
-        // is the integration branch (which is only ever the landing PR's head).
-        const existing = await forge.prStatus(integrationBranch);
-        if (existing.state === "open" || existing.state === "merged") {
-          // Reuse — never open a second PR. Covers the open-succeeded/record-failed gap.
-          this.resolveLanding(repoPath, parentIssueNumber, {
-            state: "open",
-            prNumber: existing.number ?? null,
-            prUrl: existing.url ?? null,
-            attempts: row.landingAttempts,
-          });
-          return;
-        }
-        if (existing.state === "closed") {
-          // A human deliberately closed the landing PR (unmerged) — terminal, do NOT re-open it.
-          this.resolveLanding(repoPath, parentIssueNumber, {
-            state: "none",
-            prNumber: null,
-            prUrl: null,
-            attempts: row.landingAttempts,
-          });
-          return;
-        }
-        // existing.state === "none" → no PR yet, open one.
-        const defaultBranch = await forge.defaultBranch();
-        const children = JSON.parse(row.childrenJson) as CompletedEpicChild[];
-        const title = buildLandingPrTitle(parentIssueNumber, parentTitle);
-        const body = buildLandingPrBody({
-          parentNumber: parentIssueNumber,
-          parentTitle,
-          integrationBranch,
-          defaultBranch,
-          children,
-        });
-        const status = await forge.openPr({
-          head: integrationBranch,
-          base: defaultBranch,
-          title,
-          body,
-        });
-        this.resolveLanding(repoPath, parentIssueNumber, {
-          state: "open",
-          prNumber: status.number ?? null,
-          prUrl: status.url ?? null,
-          attempts: row.landingAttempts,
-        });
-      } catch (err) {
-        if (err instanceof EmptyDiffError) {
-          // No net diff vs default (already landed, or integrations that net to nothing) —
-          // terminal `none`, NOT an error. The length>0 pre-gate can't detect a zero net diff.
-          this.resolveLanding(repoPath, parentIssueNumber, {
-            state: "none",
-            prNumber: null,
-            prUrl: null,
-            attempts: row.landingAttempts,
-          });
-          return;
-        }
-        // Transient/unknown failure (network, no push access) → error + count it; retried by
-        // the autonomous tick until the cap, then parked. NEVER holds the run.
-        this.resolveLanding(repoPath, parentIssueNumber, {
-          state: "error",
-          prNumber: null,
-          prUrl: null,
-          attempts: row.landingAttempts + 1,
-        });
-        console.warn(
-          `[drain] ensureLandingPr openPr failed for ${repoPath}#${parentIssueNumber} (attempt ${row.landingAttempts + 1}/${MAX_LANDING_ATTEMPTS}):`,
-          err,
-        );
-      }
+      const resolution = await this.classifyLanding(forge, row, integrationBranch);
+      this.resolveLanding(repoPath, parentIssueNumber, resolution);
     } finally {
       this.landingInFlight.delete(inFlightKey);
+    }
+  }
+
+  /**
+   * Resolve what the landing PR's state should become by talking to the forge: reuse an
+   * existing open/merged PR, treat a human-closed PR as terminal `none`, open a new one, or
+   * classify the failure (EmptyDiffError → `none`; anything else → `error` + attempt++). Pure
+   * decision — the caller persists + emits. NEVER throws: every forge touch is wrapped here.
+   */
+  private async classifyLanding(
+    forge: GitForge,
+    row: {
+      repoPath: string;
+      parentIssueNumber: number;
+      parentTitle: string;
+      childrenJson: string;
+      landingAttempts: number;
+    },
+    integrationBranch: string,
+  ): Promise<{
+    state: EpicLandingState;
+    prNumber: number | null;
+    prUrl: string | null;
+    attempts: number;
+  }> {
+    const { repoPath, parentIssueNumber, parentTitle, landingAttempts } = row;
+    try {
+      // Idempotency guard: prStatus reads `--state all`, so it sees any prior PR whose head
+      // is the integration branch (which is only ever the landing PR's head).
+      const existing = await forge.prStatus(integrationBranch);
+      if (existing.state === "open" || existing.state === "merged") {
+        // Reuse — never open a second PR. Covers the open-succeeded/record-failed gap.
+        return {
+          state: "open",
+          prNumber: existing.number ?? null,
+          prUrl: existing.url ?? null,
+          attempts: landingAttempts,
+        };
+      }
+      if (existing.state === "closed") {
+        // A human deliberately closed the landing PR (unmerged) — terminal, do NOT re-open it.
+        return { state: "none", prNumber: null, prUrl: null, attempts: landingAttempts };
+      }
+      // existing.state === "none" → no PR yet, open one.
+      const defaultBranch = await forge.defaultBranch();
+      const children = JSON.parse(row.childrenJson) as CompletedEpicChild[];
+      const title = buildLandingPrTitle(parentIssueNumber, parentTitle);
+      const body = buildLandingPrBody({
+        parentNumber: parentIssueNumber,
+        parentTitle,
+        integrationBranch,
+        defaultBranch,
+        children,
+      });
+      const status = await forge.openPr({
+        head: integrationBranch,
+        base: defaultBranch,
+        title,
+        body,
+      });
+      return {
+        state: "open",
+        prNumber: status.number ?? null,
+        prUrl: status.url ?? null,
+        attempts: landingAttempts,
+      };
+    } catch (err) {
+      if (err instanceof EmptyDiffError) {
+        // No net diff vs default (already landed, or integrations that net to nothing) —
+        // terminal `none`, NOT an error. The length>0 pre-gate can't detect a zero net diff.
+        return { state: "none", prNumber: null, prUrl: null, attempts: landingAttempts };
+      }
+      // Transient/unknown failure (network, no push access) → error + count it; retried by
+      // the autonomous tick until the cap, then parked. NEVER holds the run.
+      console.warn(
+        `[drain] ensureLandingPr openPr failed for ${repoPath}#${parentIssueNumber} (attempt ${landingAttempts + 1}/${MAX_LANDING_ATTEMPTS}):`,
+        err,
+      );
+      return { state: "error", prNumber: null, prUrl: null, attempts: landingAttempts + 1 };
     }
   }
 
@@ -707,20 +716,7 @@ export class DrainService {
         const epicRun = this.deps.store.getEpicRun(repoPath);
         if (epicRun) epicAutoCompleted = this.handleEpicSideEffects(repoPath, epicRun, epic);
       }
-      if (epicAutoCompleted && epic) {
-        // Best-effort landing PR on the completion edge. DECOUPLED from the (already-done)
-        // record+idle flip: ensureLandingPr resolves to a state and never throws, but the
-        // try/catch is defense-in-depth — a landing failure must NEVER hold the run open
-        // (that would freeze the whole repo's drain). The autonomous tick retries it.
-        try {
-          await this.ensureLandingPr(repoPath, epic.parentIssueNumber, epic.parentTitle);
-        } catch (err) {
-          console.warn(
-            `[drain] ensureLandingPr (completion edge) failed for ${repoPath}#${epic.parentIssueNumber}:`,
-            err,
-          );
-        }
-      }
+      if (epicAutoCompleted && epic) await this.openLandingPrOnComplete(repoPath, epic);
       decision = computeNext(state);
       // When the epic just auto-completed (running→idle), the state we built still
       // carries epicParent from the now-idle run. Emit a corrected status built from
@@ -750,6 +746,23 @@ export class DrainService {
       return true;
     }
     return false; // hold
+  }
+
+  /**
+   * Best-effort landing PR on the completion edge. DECOUPLED from the (already-done) record+idle
+   * flip: {@link ensureLandingPr} resolves to a state and never throws, but the try/catch is
+   * defense-in-depth — a landing failure must NEVER hold the run open (that would freeze the
+   * whole repo's drain). The autonomous tick retries it.
+   */
+  private async openLandingPrOnComplete(repoPath: string, epic: Epic): Promise<void> {
+    try {
+      await this.ensureLandingPr(repoPath, epic.parentIssueNumber, epic.parentTitle);
+    } catch (err) {
+      console.warn(
+        `[drain] ensureLandingPr (completion edge) failed for ${repoPath}#${epic.parentIssueNumber}:`,
+        err,
+      );
+    }
   }
 
   /** Drain `repoPath`: build state → computeNext → apply, until the core holds.

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -430,7 +430,8 @@ export class DrainService {
           parentTitle: epic.parentTitle,
           completedAt: this.now(),
           children: rollup,
-          // Stage B landing-PR fields wired by a later task; defaults until then.
+          // Recorded as pending — its final state here; ensureLandingPr (driven by the
+          // autonomous tick) opens the landing PR and transitions landingState/landingPrNumber.
           landingPrNumber: null,
           landingPrUrl: null,
           landingState: "pending",

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -406,6 +406,10 @@ export class DrainService {
           parentTitle: epic.parentTitle,
           completedAt: this.now(),
           children: rollup,
+          // Stage B landing-PR fields wired by a later task; defaults until then.
+          landingPrNumber: null,
+          landingPrUrl: null,
+          landingState: "pending",
         };
         this.deps.store.recordEpicCompleted({
           repoPath: completed.repoPath,

--- a/src/epic-landing.ts
+++ b/src/epic-landing.ts
@@ -1,0 +1,52 @@
+/** Pure title/body builders for the aggregate epic-landing PR (#635, Stage B).
+ *  When an epic completes, Shepherd opens ONE PR `epic/<#>-<slug> → <default>` whose
+ *  body is the status report and whose `Closes #…` lines close every child + the parent
+ *  on a single merge. This is a forge artifact authored by Shepherd, passed verbatim to
+ *  GitHub — like `epicBaseDirective` in src/autopilot.ts, Shepherd owns this text and it is
+ *  NEVER i18n'd. No forge calls, no store, no I/O — deterministic string building only. */
+import type { CompletedEpicChild } from "./completed-epic";
+
+/** `Land epic #<n>: <title>` — concise, stable PR title. */
+export function buildLandingPrTitle(parentNumber: number, parentTitle: string): string {
+  return `Land epic #${parentNumber}: ${parentTitle}`;
+}
+
+/** Sanitize a child title for a single Markdown table cell: escape pipes (a raw `|` would
+ *  add a spurious column and corrupt the row) and collapse any newlines to spaces (a row
+ *  must stay single-line). Minimal — only the two characters that break a table row. */
+function cellSafe(title: string): string {
+  return title.replace(/\r?\n/g, " ").replace(/\|/g, "\\|");
+}
+
+export function buildLandingPrBody(input: {
+  parentNumber: number;
+  parentTitle: string;
+  integrationBranch: string;
+  defaultBranch: string;
+  children: Pick<CompletedEpicChild, "number" | "title" | "prNumber" | "prUrl">[];
+}): string {
+  const { parentNumber, parentTitle, integrationBranch, defaultBranch, children } = input;
+
+  // Parent first, then one Closes line per child in array order — a single merge closes all.
+  const closes = [`Closes #${parentNumber}`, ...children.map((c) => `Closes #${c.number}`)].join(
+    "\n",
+  );
+
+  const rows = children
+    .map((c) => {
+      const pr = c.prNumber != null ? `#${c.prNumber}` : "—";
+      return `| #${c.number} | ${cellSafe(c.title)} | ${pr} |`;
+    })
+    .join("\n");
+
+  // N derives from the array — single source of truth, never a separate count.
+  // Header stays even with zero rows; `rows` is appended only when non-empty.
+  const tableHeader = `### Children (${children.length})\n\n| Issue | Title | PR |\n| ----- | ----- | -- |`;
+  const childrenSection = rows ? `${tableHeader}\n${rows}` : tableHeader;
+
+  return (
+    `Lands epic **#${parentNumber} — ${parentTitle}** from \`${integrationBranch}\` onto \`${defaultBranch}\`.\n\n` +
+    `${closes}\n\n` +
+    `${childrenSection}\n`
+  );
+}

--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -16,6 +16,7 @@ import type {
   WorkflowJob,
   WorkflowRun,
 } from "./types";
+import { EmptyDiffError } from "./types";
 
 interface GiteaPr {
   number: number;
@@ -43,6 +44,20 @@ const STATUS_FETCH_CONCURRENCY = 6;
 /** Cap on workflows surfaced in the Actions tab (one row per workflow, latest
  *  run). Mirrors github.ts's own MAX_WORKFLOWS — the two packages don't share it. */
 const MAX_WORKFLOWS = 10;
+
+/** Match (case-insensitively) Gitea's empty-diff signal on a failed pull creation. Best-effort:
+ *  with no live Gitea to verify against, we match a small set of documented no-changes wordings —
+ *  Gitea returns 422 "There are no changes between the head and the base" when head == base. An
+ *  unmatched signal falls through as the original error (the caller's attempt-cap bounds the miss).
+ *  Pass an already-lowercased string. */
+function isGiteaNoChanges(text: string): boolean {
+  return (
+    text.includes("no changes between the head and the base") ||
+    text.includes("there are no changes") ||
+    text.includes("no commits between") ||
+    text.includes("has no changes")
+  );
+}
 
 /** Gitea/Forgejo forge driven through the /api/v1 REST API (API-compatible). */
 export class GiteaForge implements GitForge {
@@ -334,12 +349,27 @@ export class GiteaForge implements GitForge {
 
   async openPr(o: OpenPrInput): Promise<PrStatus> {
     const title = o.draft ? GiteaForge.addWip(o.title) : o.title;
-    const pr = (await this.req("POST", `/api/v1/repos/${this.slug}/pulls`, {
-      head: o.head,
-      base: o.base,
-      title,
-      body: o.body,
-    })) as GiteaPr;
+    let pr: GiteaPr;
+    try {
+      pr = (await this.req("POST", `/api/v1/repos/${this.slug}/pulls`, {
+        head: o.head,
+        base: o.base,
+        title,
+        body: o.body,
+      })) as GiteaPr;
+    } catch (err) {
+      // req()'s error message embeds the Gitea response body + status. Classify the empty-diff
+      // signal so the epic-landing caller (#635) can resolve "nothing to land" rather than
+      // retrying forever. Best-effort: there is no live Gitea to verify against here, so we match
+      // a small set of documented no-changes wordings (Gitea returns 422 "There are no changes
+      // between the head and the base" when head == base). If the signal isn't matched, the
+      // original error propagates and the caller's attempt-cap bounds any miss — it never retries
+      // forever. We deliberately do NOT map all 409/errors here (e.g. a plain already-exists PR or
+      // an unrelated failure) so other openPr callers (gitignore-adopt, etc.) aren't mis-told.
+      const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+      if (isGiteaNoChanges(msg)) throw new EmptyDiffError(o.head, o.base, err);
+      throw err;
+    }
     return this.toStatus(pr);
   }
 

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -3,7 +3,7 @@ import { promisify } from "node:util";
 import { timedAsync } from "../instrument";
 import { jobsFromRollup, mapCheckState, rollupChecks } from "./checks";
 import { classifyPr } from "./pr-kind";
-import { CRITIC_REVIEW_MARKER } from "./types";
+import { CRITIC_REVIEW_MARKER, EmptyDiffError } from "./types";
 import type {
   ForgeConfig,
   GitForge,
@@ -27,6 +27,12 @@ import type {
 /** Cap on distinct workflows fetched per repo: each kept run costs one extra
  *  `gh run view` subprocess, so bound the fan-out. */
 const MAX_WORKFLOWS = 10;
+
+/** `gh pr create` on an empty diff prints "No commits between <base> and <head>" to stderr.
+ *  Match that case-insensitively to classify an openPr failure as an EmptyDiffError. */
+function isNoCommitsBetween(text: string): boolean {
+  return text.toLowerCase().includes("no commits between");
+}
 
 /** Cap on summary pages for listSubIssueSummaries: 2 pages × 100 issues = ~200 issues,
  *  mirroring the listIssues() 200-open-issue cap. */
@@ -582,7 +588,16 @@ export class GithubForge implements GitForge {
       o.body,
     ];
     if (o.draft) args.push("--draft");
-    await this.run(args);
+    try {
+      await this.run(args);
+    } catch (err) {
+      // An execFile rejection carries the subprocess stderr on err.stderr plus the message;
+      // read both defensively (err is unknown) and classify the empty-diff signal.
+      const stderr = (err as { stderr?: unknown }).stderr;
+      const text = `${typeof stderr === "string" ? stderr : ""} ${err instanceof Error ? err.message : String(err)}`;
+      if (isNoCommitsBetween(text)) throw new EmptyDiffError(o.head, o.base, err);
+      throw err;
+    }
     return this.prStatus(o.head);
   }
 

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -185,6 +185,21 @@ export interface OpenPrInput {
   draft?: boolean;
 }
 
+/** Thrown by a forge's openPr when the head branch has no net diff vs the base — there is
+ *  nothing to open a PR for (already landed, or commits that net to zero). Forge-agnostic so a
+ *  caller (epic landing, #635) can resolve "nothing to land" instead of retrying openPr forever. */
+export class EmptyDiffError extends Error {
+  constructor(
+    readonly head: string,
+    readonly base: string,
+    cause?: unknown,
+  ) {
+    super(`no commits between ${base} and ${head}`);
+    this.name = "EmptyDiffError";
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
 export interface MergeInput {
   method: MergeMethod;
   deleteBranch: boolean;

--- a/src/server.ts
+++ b/src/server.ts
@@ -3159,6 +3159,10 @@ async function backfillIdleEpic(
       parentTitle: epic.parentTitle,
       completedAt,
       children: rollup,
+      // Stage B landing-PR fields wired by a later task; defaults until then.
+      landingPrNumber: null,
+      landingPrUrl: null,
+      landingState: "pending",
     };
     deps.store.recordEpicCompleted({
       repoPath: completed.repoPath,
@@ -3238,8 +3242,10 @@ async function handleEpicsCompletedList({ req, parts, url, deps }: Ctx): Promise
   for (const repo of scopeRepos) await reconcileCompletedEpicsForRepo(deps, repo);
 
   // Re-query post-reconcile so the response reflects dismiss + backfill.
-  const rows = deps.store.listEpicCompleted(repoFilter).map((row) => {
-    const { childrenJson, ...rest } = row;
+  const rows = deps.store.listEpicCompleted(repoFilter).map((row): CompletedEpic => {
+    // landingAttempts is an internal retry counter, not part of the CompletedEpic response.
+    const { childrenJson, landingAttempts, ...rest } = row;
+    void landingAttempts;
     return { ...rest, children: JSON.parse(childrenJson) as CompletedEpic["children"] };
   });
   return json(rows);

--- a/src/server.ts
+++ b/src/server.ts
@@ -3159,7 +3159,8 @@ async function backfillIdleEpic(
       parentTitle: epic.parentTitle,
       completedAt,
       children: rollup,
-      // Stage B landing-PR fields wired by a later task; defaults until then.
+      // A backfilled completion (e.g. across a restart) is recorded as pending — its final
+      // state here; the autonomous drain tick (ensureLandingPrsForRepo) opens the landing PR.
       landingPrNumber: null,
       landingPrUrl: null,
       landingState: "pending",

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -24,6 +24,7 @@ import type { WorktreeMgr } from "./worktree";
 import type { GitForge, PrReviewMeta, PullRequest } from "./forge/types";
 import { CRITIC_REVIEW_MARKER } from "./forge/types";
 import { readonlyReviewerArgv } from "./reviewer-argv";
+import { isEpicIntegrationBranch } from "./epic-branch";
 import { readSessionUsage, type SessionUsage } from "./usage";
 import {
   prReviewPrompt,
@@ -68,6 +69,7 @@ export interface StandalonePrCriticDeps {
     | "bumpPrReviewHead"
     | "recordReviewerSpawn"
     | "completeReviewerSpawn"
+    | "listEpicCompleted"
   >;
   herdr: Pick<HerdrDriver, "start" | "stop">;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove">;
@@ -147,12 +149,28 @@ export class StandalonePrCriticService {
   }
 
   /**
-   * The 60s enumeration. For each `criticAllPrs` repo (round-robin), list its open PRs, filter to
-   * the session-less ones worth reviewing, and spawn a critic for as many as the global
-   * concurrency cap allows — deferring (and logging) the rest to the next sweep.
+   * The 60s enumeration. For each swept repo (round-robin), list its open PRs, filter to the
+   * session-less ones worth reviewing, and spawn a critic for as many as the global concurrency
+   * cap allows — deferring (and logging) the rest to the next sweep.
+   *
+   * The swept set is the UNION of (a) repos with `criticAllPrs` ON and (b) repos with a pending
+   * epic LANDING PR (Stage B, #635). An epic completion opens an aggregate PR off the epic
+   * integration branch; the operator wants the critic to review THAT PR even when the repo never
+   * opted into all-PR review — so (b) is added unconditionally. We must union at the SWEEP level,
+   * not just in eligible(): if no repo has criticAllPrs, an eligible()-only widening would never
+   * run because sweep() early-returns here before ever calling sweepRepo. eligible() then carves
+   * the (b)-only repos down to JUST the landing PR (head == the integration branch).
    */
   async sweep(): Promise<void> {
-    const enabled = this.deps.repos().filter((r) => this.deps.store.getRepoConfig(r).criticAllPrs);
+    const flagged = this.deps.repos().filter((r) => this.deps.store.getRepoConfig(r).criticAllPrs);
+    // A pending landing PR is a non-dismissed epic_completed row with landingPrNumber set
+    // (landingState === "open"); listEpicCompleted() already filters out dismissed rows. No-arg =
+    // every repo. The set is small (one row per in-flight epic) so scanning it each sweep is cheap.
+    const epicRepos = this.deps.store
+      .listEpicCompleted()
+      .filter((r) => r.landingPrNumber != null)
+      .map((r) => r.repoPath);
+    const enabled = [...new Set([...flagged, ...epicRepos])];
     if (enabled.length === 0) return;
     // Round-robin: rotate the start index each sweep so a repo that keeps saturating the cap can't
     // perpetually starve later repos. Advance regardless of how far we got this sweep.
@@ -187,7 +205,12 @@ export class StandalonePrCriticService {
     // critic at all: with it OFF, the standalone critic is the sole reviewer and must cover
     // session-managed PRs too (the coverage-hole the criticAllPrs flag closes).
     const managed = this.deps.managedBranches(repoPath);
-    const criticEnabled = this.deps.store.getRepoConfig(repoPath).criticEnabled;
+    const cfg = this.deps.store.getRepoConfig(repoPath);
+    const criticEnabled = cfg.criticEnabled;
+    // criticAllPrs threaded into eligible() (alongside criticEnabled) so it can tell the two ways a
+    // repo lands in the swept set apart: flag ON → review every eligible PR (old behavior); flag OFF
+    // → this repo is here ONLY for its epic landing PR, so eligible() restricts to that one PR.
+    const criticAllPrs = cfg.criticAllPrs;
 
     let prs: PullRequest[];
     try {
@@ -197,7 +220,9 @@ export class StandalonePrCriticService {
       return;
     }
 
-    const candidates = prs.filter((pr) => this.eligible(repoPath, pr, managed, criticEnabled));
+    const candidates = prs.filter((pr) =>
+      this.eligible(repoPath, pr, managed, criticEnabled, criticAllPrs),
+    );
     let deferred = 0;
     for (const pr of candidates) {
       if (!this.underCap()) {
@@ -222,6 +247,7 @@ export class StandalonePrCriticService {
     pr: PullRequest,
     managed: Set<string>,
     criticEnabled: boolean,
+    criticAllPrs: boolean,
   ): boolean {
     if (pr.isDraft) return false;
     // Best-effort TOCTOU gate: the rollup can change between enumeration and spawn, but a green
@@ -232,6 +258,11 @@ export class StandalonePrCriticService {
       this.log(`[pr-critic] ${repoPath}#${pr.number} missing headSha/headRefName — skipping`);
       return false;
     }
+    // Stage B (#635): a repo without criticAllPrs is swept ONLY because it has an epic landing PR.
+    // Review ONLY that PR (head == the epic integration branch) — a child PR's head is its own task
+    // branch (base=integration), so isEpicIntegrationBranch(head) is false and it stays excluded.
+    // With criticAllPrs ON this carve-out is inert (every regular PR is in scope as before).
+    if (!criticAllPrs && !isEpicIntegrationBranch(pr.headRefName)) return false;
     // The session critic already owns this branch — only defer to it when it's actually running
     // (criticEnabled). With the session critic off, we are the sole reviewer and must cover it.
     if (criticEnabled && managed.has(pr.headRefName)) return false;

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -163,12 +163,13 @@ export class StandalonePrCriticService {
    */
   async sweep(): Promise<void> {
     const flagged = this.deps.repos().filter((r) => this.deps.store.getRepoConfig(r).criticAllPrs);
-    // A pending landing PR is a non-dismissed epic_completed row with landingPrNumber set
-    // (landingState === "open"); listEpicCompleted() already filters out dismissed rows. No-arg =
-    // every repo. The set is small (one row per in-flight epic) so scanning it each sweep is cheap.
+    // A reviewable landing PR is a non-dismissed epic_completed row that is still open
+    // (landingState === "open") — a merged landing PR is no longer reviewable, so it drops out of
+    // the union. listEpicCompleted() already filters out dismissed rows. No-arg = every repo. The
+    // set is small (one row per in-flight epic) so scanning it each sweep is cheap.
     const epicRepos = this.deps.store
       .listEpicCompleted()
-      .filter((r) => r.landingPrNumber != null)
+      .filter((r) => r.landingState === "open")
       .map((r) => r.repoPath);
     const enabled = [...new Set([...flagged, ...epicRepos])];
     if (enabled.length === 0) return;

--- a/src/store.ts
+++ b/src/store.ts
@@ -21,6 +21,7 @@ import { dominantModel, type SessionUsage } from "./usage";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
 import { normalizeRepoDefaultModelSetting } from "./default-model";
 import type { EpicRun } from "./epic-core";
+import type { EpicLandingState } from "./completed-epic";
 
 /** Tolerantly parse the persisted findings JSON back to a string[] (never throws). */
 function parseFindings(raw: unknown): string[] {
@@ -393,7 +394,12 @@ export class SessionStore implements CapStore, CreditStore {
       parentTitle TEXT NOT NULL, completedAt INTEGER NOT NULL,
       dismissedAt INTEGER,
       childrenJson TEXT NOT NULL,
+      landingPrNumber INTEGER,
+      landingPrUrl TEXT,
+      landingState TEXT NOT NULL DEFAULT 'pending',
+      landingAttempts INTEGER NOT NULL DEFAULT 0,
       PRIMARY KEY (repoPath, parentIssueNumber))`);
+    this.migrateEpicCompletedColumns();
     this.db.run(`CREATE TABLE IF NOT EXISTS push_subscriptions (
       endpoint TEXT PRIMARY KEY, p256dh TEXT NOT NULL, auth TEXT NOT NULL,
       ua TEXT NOT NULL DEFAULT '', locale TEXT NOT NULL DEFAULT 'en',
@@ -651,11 +657,16 @@ export class SessionStore implements CapStore, CreditStore {
     parentTitle: string;
     completedAt: number;
     childrenJson: string;
+    landingPrNumber: number | null;
+    landingPrUrl: string | null;
+    landingState: EpicLandingState;
+    landingAttempts: number;
   }[] {
     if (repoPath !== undefined) {
       return this.db
         .query(
-          `SELECT repoPath, parentIssueNumber, parentTitle, completedAt, childrenJson
+          `SELECT repoPath, parentIssueNumber, parentTitle, completedAt, childrenJson,
+                  landingPrNumber, landingPrUrl, landingState, landingAttempts
            FROM epic_completed WHERE dismissedAt IS NULL AND repoPath = ?
            ORDER BY completedAt DESC`,
         )
@@ -665,11 +676,16 @@ export class SessionStore implements CapStore, CreditStore {
         parentTitle: string;
         completedAt: number;
         childrenJson: string;
+        landingPrNumber: number | null;
+        landingPrUrl: string | null;
+        landingState: EpicLandingState;
+        landingAttempts: number;
       }[];
     }
     return this.db
       .query(
-        `SELECT repoPath, parentIssueNumber, parentTitle, completedAt, childrenJson
+        `SELECT repoPath, parentIssueNumber, parentTitle, completedAt, childrenJson,
+                landingPrNumber, landingPrUrl, landingState, landingAttempts
          FROM epic_completed WHERE dismissedAt IS NULL
          ORDER BY completedAt DESC`,
       )
@@ -679,7 +695,30 @@ export class SessionStore implements CapStore, CreditStore {
       parentTitle: string;
       completedAt: number;
       childrenJson: string;
+      landingPrNumber: number | null;
+      landingPrUrl: string | null;
+      landingState: EpicLandingState;
+      landingAttempts: number;
     }[];
+  }
+
+  /** Write the Stage B (#635) landing-PR resolution onto a completed epic.
+   *  Direct UPDATE (not part of recordEpicCompleted's preserve-by-omission upsert). */
+  setEpicLandingPr(
+    repoPath: string,
+    parentIssueNumber: number,
+    fields: {
+      state: EpicLandingState;
+      prNumber: number | null;
+      prUrl: string | null;
+      attempts: number;
+    },
+  ): void {
+    this.db.run(
+      `UPDATE epic_completed SET landingState = ?, landingPrNumber = ?, landingPrUrl = ?, landingAttempts = ?
+       WHERE repoPath = ? AND parentIssueNumber = ?`,
+      [fields.state, fields.prNumber, fields.prUrl, fields.attempts, repoPath, parentIssueNumber],
+    );
   }
 
   /** Mark a completed epic as dismissed (hides it from listEpicCompleted).
@@ -1490,6 +1529,20 @@ export class SessionStore implements CapStore, CreditStore {
     };
     add("prNumber", `prNumber INTEGER`);
     add("prUrl", `prUrl TEXT`);
+  }
+
+  private migrateEpicCompletedColumns(): void {
+    const cols = this.db.query(`PRAGMA table_info(epic_completed)`).all() as { name: string }[];
+    const add = (name: string, ddl: string) => {
+      if (!cols.some((c) => c.name === name))
+        this.db.run(`ALTER TABLE epic_completed ADD COLUMN ${ddl}`);
+    };
+    // Stage B (#635) landing-PR lifecycle. NOT NULL columns carry constant defaults so the
+    // ALTER backfills existing rows to 'pending'/0.
+    add("landingPrNumber", `landingPrNumber INTEGER`);
+    add("landingPrUrl", `landingPrUrl TEXT`);
+    add("landingState", `landingState TEXT NOT NULL DEFAULT 'pending'`);
+    add("landingAttempts", `landingAttempts INTEGER NOT NULL DEFAULT 0`);
   }
 
   private migrateReviewColumns(): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -722,7 +722,10 @@ export class SessionStore implements CapStore, CreditStore {
   }
 
   /** Mark a completed epic as dismissed (hides it from listEpicCompleted).
-   *  TODO(#635): Stage B should call this at land-time when it closes the parent. */
+   *  At land-time there's no explicit dismiss call: the aggregate landing PR's
+   *  `Closes #<parent>` closes the parent on merge, and the autoDismissClosed
+   *  reconcile (src/server.ts) then dismisses the band once the parent is
+   *  confidently closed. */
   dismissEpicCompleted(repoPath: string, parentIssueNumber: number): void {
     this.db.run(
       `UPDATE epic_completed SET dismissedAt = ? WHERE repoPath = ? AND parentIssueNumber = ?`,

--- a/test/drain-epic-completed.test.ts
+++ b/test/drain-epic-completed.test.ts
@@ -153,11 +153,14 @@ describe("epic auto-complete → record before idle flip (#635)", () => {
     // Run flipped to idle.
     expect(h.store.getEpicRun(REPO)?.status).toBe("idle");
 
-    // Emitter fired with the same CompletedEpic.
-    expect(h.completedEmits).toHaveLength(1);
+    // Two emits: the completion record, then the Stage B (#635) landing-PR resolution. Both
+    // children are issue-closed (no epic_integrated rows) so the landing resolves to 'none'.
+    expect(h.completedEmits.length).toBeGreaterThanOrEqual(1);
     const emit = h.completedEmits[0]!;
     expect(emit.parentIssueNumber).toBe(PARENT);
     expect(emit.children.map((c) => c.number).sort()).toEqual([320, 321]);
+    // Last emit carries the resolved landing state (no integrated children → 'none').
+    expect(h.completedEmits.at(-1)!.landingState).toBe("none");
   });
 
   test("record failure keeps the epic RUNNING (no flip, no row) → retried next pump", async () => {

--- a/test/drain-epic-landing.test.ts
+++ b/test/drain-epic-landing.test.ts
@@ -1,0 +1,513 @@
+import { test, expect, describe } from "bun:test";
+import { DrainService } from "../src/drain";
+import { SessionStore } from "../src/store";
+import { EmptyDiffError } from "../src/forge/types";
+import type { GitForge, Issue, OpenPrInput, PrStatus, SubIssueRef } from "../src/forge/types";
+import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
+import type { CompletedEpic } from "../src/completed-epic";
+import { epicIntegrationBranch } from "../src/epic-branch";
+
+const REPO = "/repo";
+const PARENT = 327;
+const PARENT_TITLE = "EFI cluster";
+const INTEGRATION_BRANCH = epicIntegrationBranch(PARENT, PARENT_TITLE); // epic/327-efi-cluster
+
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+};
+
+function sub(number: number, closed: boolean): SubIssueRef {
+  return {
+    number,
+    title: `child ${number}`,
+    url: `https://x/${number}`,
+    body: "",
+    closed,
+    labels: [],
+  };
+}
+
+/** Records the forge calls a test cares about, with per-test overrides for prStatus/openPr. */
+interface ForgeSpy {
+  forge: GitForge;
+  openPrCalls: OpenPrInput[];
+  prStatusCalls: string[];
+}
+
+function fakeForge(opts: {
+  subIssues: SubIssueRef[];
+  prStatus?: (head: string) => Promise<PrStatus>;
+  openPr?: (o: OpenPrInput) => Promise<PrStatus>;
+}): ForgeSpy {
+  const openPrCalls: OpenPrInput[] = [];
+  const prStatusCalls: string[] = [];
+  const forge: GitForge = {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus: async (head: string) => {
+      prStatusCalls.push(head);
+      return (
+        (await opts.prStatus?.(head)) ??
+        ({ state: "none", checks: "none", deployConfigured: false } as PrStatus)
+      );
+    },
+    openPr: async (o: OpenPrInput) => {
+      openPrCalls.push(o);
+      return (
+        (await opts.openPr?.(o)) ??
+        ({ state: "open", checks: "none", deployConfigured: false } as PrStatus)
+      );
+    },
+    defaultBranch: async () => "main",
+    merge: async () => {},
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    closeIssue: async () => {},
+    ensureIssueLink: async () => {},
+    addIssueLabel: async () => {},
+    removeIssueLabel: async () => {},
+    getIssue: async (n: number): Promise<Issue | null> =>
+      n === PARENT
+        ? {
+            number: PARENT,
+            title: PARENT_TITLE,
+            body: "epic body",
+            url: `https://x/${PARENT}`,
+            labels: [],
+            createdAt: 0,
+          }
+        : null,
+    listSubIssues: async () => opts.subIssues,
+    listBlockedBy: async () => [],
+  };
+  return { forge, openPrCalls, prStatusCalls };
+}
+
+interface Harness {
+  store: SessionStore;
+  drain: DrainService;
+  completedEmits: CompletedEpic[];
+  spy: ForgeSpy;
+}
+
+function makeHarness(opts: {
+  subIssues: SubIssueRef[];
+  prStatus?: (head: string) => Promise<PrStatus>;
+  openPr?: (o: OpenPrInput) => Promise<PrStatus>;
+  /** Skip recording the running epic_run row (e.g. testing tick() in isolation). */
+  noEpicRun?: boolean;
+  autoDrainEnabled?: boolean;
+}): Harness {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: opts.autoDrainEnabled ?? true,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 2,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+  });
+  if (!opts.noEpicRun) {
+    store.setEpicRun({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      mode: "auto",
+      status: "running",
+    });
+  }
+
+  const spy = fakeForge(opts);
+  const completedEmits: CompletedEpic[] = [];
+
+  const service = {
+    create: async () => {
+      throw new Error("not used in these tests");
+    },
+    archive: () => 1,
+  };
+
+  const drain = new DrainService({
+    store,
+    service: service as never,
+    resolveForge: () => spy.forge,
+    prCache: { snapshot: () => ({}) },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    emitStatus: () => {},
+    emitArchived: () => {},
+    dropPrCache: () => {},
+    emitEpic: () => {},
+    emitEpicCompleted: (e) => completedEmits.push(e),
+  });
+
+  return { store, drain, completedEmits, spy };
+}
+
+/** Seed a recorded, integration-merged epic_completed row WITHOUT driving the completion
+ *  edge — for exercising ensureLandingPr directly via tick()/ensureLandingPrsForRepo. */
+function seedCompleted(h: Harness, children: number[] = [320]): void {
+  for (const c of children) {
+    h.store.recordEpicIntegrated(REPO, PARENT, c, {
+      number: 9000 + c,
+      url: `https://github.com/o/r/pull/${9000 + c}`,
+    });
+  }
+  const rollup = children.map((c) => ({
+    number: c,
+    title: `child ${c}`,
+    url: `https://x/${c}`,
+    prNumber: 9000 + c,
+    prUrl: `https://github.com/o/r/pull/${9000 + c}`,
+    mergedAt: 1,
+    integrated: true,
+  }));
+  h.store.recordEpicCompleted({
+    repoPath: REPO,
+    parentIssueNumber: PARENT,
+    parentTitle: PARENT_TITLE,
+    completedAt: 1,
+    childrenJson: JSON.stringify(rollup),
+  });
+}
+
+describe("ensureLandingPr — open + track the epic→default landing PR (#635)", () => {
+  test("opens once: pending row + prStatus none → openPr exactly once, row open with returned facts", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      openPr: async () => ({
+        state: "open",
+        number: 555,
+        url: "https://github.com/o/r/pull/555",
+        checks: "none",
+        deployConfigured: false,
+      }),
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.openPrCalls).toHaveLength(1);
+    expect(h.spy.openPrCalls[0]!.head).toBe(INTEGRATION_BRANCH);
+    expect(h.spy.openPrCalls[0]!.base).toBe("main");
+
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.landingPrNumber).toBe(555);
+    expect(row.landingPrUrl).toBe("https://github.com/o/r/pull/555");
+
+    const emit = h.completedEmits.at(-1)!;
+    expect(emit.landingState).toBe("open");
+    expect(emit.landingPrNumber).toBe(555);
+    expect(emit.landingPrUrl).toBe("https://github.com/o/r/pull/555");
+  });
+
+  test("idempotent reuse: prStatus open (#99) → openPr NOT called, row open #99", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      prStatus: async () => ({
+        state: "open",
+        number: 99,
+        url: "https://github.com/o/r/pull/99",
+        checks: "none",
+        deployConfigured: false,
+      }),
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.openPrCalls).toHaveLength(0);
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.landingPrNumber).toBe(99);
+  });
+
+  test("merged PR also reused (no second PR), row open", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      prStatus: async () => ({
+        state: "merged",
+        number: 77,
+        url: "https://github.com/o/r/pull/77",
+        checks: "none",
+        deployConfigured: false,
+      }),
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.openPrCalls).toHaveLength(0);
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.landingPrNumber).toBe(77);
+  });
+
+  test("closed PR not re-opened → row none", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      prStatus: async () => ({ state: "closed", checks: "none", deployConfigured: false }),
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.openPrCalls).toHaveLength(0);
+    expect(h.store.listEpicCompleted(REPO)[0]!.landingState).toBe("none");
+  });
+
+  test("no integrated children → row none, openPr NOT called", async () => {
+    const h = makeHarness({ subIssues: [], noEpicRun: true });
+    // record a completed row with NO epic_integrated rows
+    h.store.recordEpicCompleted({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      parentTitle: PARENT_TITLE,
+      completedAt: 1,
+      childrenJson: JSON.stringify([]),
+    });
+
+    await h.drain.tick();
+
+    expect(h.spy.openPrCalls).toHaveLength(0);
+    expect(h.spy.prStatusCalls).toHaveLength(0); // short-circuited before the forge
+    expect(h.store.listEpicCompleted(REPO)[0]!.landingState).toBe("none");
+  });
+
+  test("EmptyDiffError → row none, no error state", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      openPr: async () => {
+        throw new EmptyDiffError(INTEGRATION_BRANCH, "main");
+      },
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.openPrCalls).toHaveLength(1);
+    expect(h.store.listEpicCompleted(REPO)[0]!.landingState).toBe("none");
+  });
+
+  test("generic error → error + attempts++; retries to success; parks at the cap", async () => {
+    // console.warn "[drain] ensureLandingPr openPr failed…" is expected on each failure.
+    let calls = 0;
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      openPr: async () => {
+        calls++;
+        throw new Error("network");
+      },
+    });
+    seedCompleted(h);
+
+    // 1st failure → error, attempts 1
+    await h.drain.tick();
+    let row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("error");
+    expect(row.landingAttempts).toBe(1);
+    expect(calls).toBe(1);
+
+    // Make the next attempt succeed → open
+    h.spy.forge.openPr = async (o) => {
+      h.spy.openPrCalls.push(o);
+      return {
+        state: "open",
+        number: 600,
+        url: "u",
+        checks: "none",
+        deployConfigured: false,
+      } as PrStatus;
+    };
+    await h.drain.tick();
+    row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.landingPrNumber).toBe(600);
+  });
+
+  test("parks at MAX_LANDING_ATTEMPTS: no further forge call once capped", async () => {
+    // console.warn expected on each of the 5 failures.
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      openPr: async () => {
+        throw new Error("network");
+      },
+    });
+    seedCompleted(h);
+
+    // Drive 5 failing ticks → attempts climbs to 5, row parked.
+    for (let i = 0; i < 5; i++) await h.drain.tick();
+    let row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("error");
+    expect(row.landingAttempts).toBe(5);
+    const openCallsAtCap = h.spy.openPrCalls.length;
+    const prStatusAtCap = h.spy.prStatusCalls.length;
+    expect(openCallsAtCap).toBe(5);
+
+    // 6th tick: row is at the cap → retry set excludes it → ZERO new forge calls.
+    await h.drain.tick();
+    expect(h.spy.openPrCalls.length).toBe(openCallsAtCap);
+    expect(h.spy.prStatusCalls.length).toBe(prStatusAtCap);
+    row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingAttempts).toBe(5); // unchanged
+  });
+
+  test("terminal short-circuit: a row already open → no forge calls", async () => {
+    const h = makeHarness({ subIssues: [], noEpicRun: true });
+    seedCompleted(h);
+    h.store.setEpicLandingPr(REPO, PARENT, {
+      state: "open",
+      prNumber: 42,
+      prUrl: "u",
+      attempts: 0,
+    });
+
+    await h.drain.tick();
+
+    expect(h.spy.openPrCalls).toHaveLength(0);
+    expect(h.spy.prStatusCalls).toHaveLength(0);
+    expect(h.store.listEpicCompleted(REPO)[0]!.landingPrNumber).toBe(42);
+  });
+
+  test("completion not wedged: openPr throws at the edge → run still idle, row error", async () => {
+    // console.warn expected (landing failure). Drives the real completion edge via pump().
+    const h = makeHarness({
+      subIssues: [sub(320, false), sub(321, true)],
+      openPr: async () => {
+        throw new Error("network");
+      },
+    });
+    // 320 integration-merged (so listEpicIntegratedDetails is non-empty → openPr is attempted).
+    h.store.recordEpicIntegrated(REPO, PARENT, 320, {
+      number: 9001,
+      url: "https://github.com/o/r/pull/9001",
+    });
+
+    await h.drain.pump(REPO);
+
+    // The idle flip happened DESPITE the landing failure (decoupled — drain not frozen).
+    expect(h.store.getEpicRun(REPO)?.status).toBe("idle");
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("error");
+    expect(row.landingAttempts).toBe(1);
+    expect(h.spy.openPrCalls).toHaveLength(1);
+  });
+
+  test("completion edge opens the landing PR when openPr succeeds", async () => {
+    const h = makeHarness({
+      subIssues: [sub(320, false), sub(321, true)],
+      openPr: async () => ({
+        state: "open",
+        number: 700,
+        url: "https://github.com/o/r/pull/700",
+        checks: "none",
+        deployConfigured: false,
+      }),
+    });
+    h.store.recordEpicIntegrated(REPO, PARENT, 320, {
+      number: 9001,
+      url: "https://github.com/o/r/pull/9001",
+    });
+
+    await h.drain.pump(REPO);
+
+    expect(h.store.getEpicRun(REPO)?.status).toBe("idle");
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.landingPrNumber).toBe(700);
+    // openPr targeted the integration branch → default.
+    expect(h.spy.openPrCalls[0]!.head).toBe(INTEGRATION_BRANCH);
+    expect(h.spy.openPrCalls[0]!.base).toBe("main");
+    // Body closes the parent + the integrated child.
+    expect(h.spy.openPrCalls[0]!.body).toContain(`Closes #${PARENT}`);
+    expect(h.spy.openPrCalls[0]!.body).toContain("Closes #320");
+  });
+
+  test("prStatus itself throws → row error, attempts 1, openPr NOT called (throw caught, not escaped)", async () => {
+    // console.warn expected (landing failure).
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      prStatus: async () => {
+        throw new Error("forge down");
+      },
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.openPrCalls).toHaveLength(0); // never reached openPr — the throw was caught
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("error");
+    expect(row.landingAttempts).toBe(1);
+  });
+
+  test("in-flight guard: two concurrent ensureLandingPr → openPr called exactly once", async () => {
+    // A deferred we resolve manually to hold openPr open across both invocations.
+    let releaseOpenPr: (s: PrStatus) => void;
+    const openPrGate = new Promise<PrStatus>((resolve) => {
+      releaseOpenPr = resolve;
+    });
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      openPr: () => openPrGate, // blocks until released
+    });
+    seedCompleted(h);
+
+    // Invoke twice concurrently — the second must no-op (first is mid-flight).
+    const ensure = (
+      h.drain as unknown as {
+        ensureLandingPr: (r: string, p: number, t: string) => Promise<void>;
+      }
+    ).ensureLandingPr.bind(h.drain);
+    const first = ensure(REPO, PARENT, PARENT_TITLE);
+    const second = ensure(REPO, PARENT, PARENT_TITLE);
+    await second; // returns immediately (guard no-op) while first is still gated
+    // Let `first` advance through prStatus → defaultBranch up to the gated openPr.
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+
+    expect(h.spy.openPrCalls).toHaveLength(1); // exactly one openPr, no double-open
+    expect(h.spy.prStatusCalls).toHaveLength(1); // and no double prStatus
+
+    releaseOpenPr!({
+      state: "open",
+      number: 808,
+      url: "https://github.com/o/r/pull/808",
+      checks: "none",
+      deployConfigured: false,
+    });
+    await first;
+
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.landingPrNumber).toBe(808);
+    expect(h.spy.openPrCalls).toHaveLength(1); // still exactly one
+  });
+});

--- a/test/drain-epic-landing.test.ts
+++ b/test/drain-epic-landing.test.ts
@@ -243,7 +243,7 @@ describe("ensureLandingPr — open + track the epic→default landing PR (#635)"
     expect(row.landingPrNumber).toBe(99);
   });
 
-  test("merged PR also reused (no second PR), row open", async () => {
+  test("merged PR recorded as merged (no second PR), row merged", async () => {
     const h = makeHarness({
       subIssues: [],
       noEpicRun: true,
@@ -261,7 +261,7 @@ describe("ensureLandingPr — open + track the epic→default landing PR (#635)"
 
     expect(h.spy.openPrCalls).toHaveLength(0);
     const row = h.store.listEpicCompleted(REPO)[0]!;
-    expect(row.landingState).toBe("open");
+    expect(row.landingState).toBe("merged");
     expect(row.landingPrNumber).toBe(77);
   });
 
@@ -393,6 +393,25 @@ describe("ensureLandingPr — open + track the epic→default landing PR (#635)"
     expect(h.spy.openPrCalls).toHaveLength(0);
     expect(h.spy.prStatusCalls).toHaveLength(0);
     expect(h.store.listEpicCompleted(REPO)[0]!.landingPrNumber).toBe(42);
+  });
+
+  test("terminal short-circuit: a row already merged → no forge calls", async () => {
+    const h = makeHarness({ subIssues: [], noEpicRun: true });
+    seedCompleted(h);
+    h.store.setEpicLandingPr(REPO, PARENT, {
+      state: "merged",
+      prNumber: 77,
+      prUrl: "u",
+      attempts: 0,
+    });
+
+    await h.drain.tick();
+
+    expect(h.spy.openPrCalls).toHaveLength(0);
+    expect(h.spy.prStatusCalls).toHaveLength(0);
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("merged");
+    expect(row.landingPrNumber).toBe(77);
   });
 
   test("completion not wedged: openPr throws at the edge → run still idle, row error", async () => {

--- a/test/epic-landing.test.ts
+++ b/test/epic-landing.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { buildLandingPrBody, buildLandingPrTitle } from "../src/epic-landing";
+
+describe("buildLandingPrTitle", () => {
+  it("renders `Land epic #<n>: <title>`", () => {
+    expect(buildLandingPrTitle(327, "EFI value map")).toBe("Land epic #327: EFI value map");
+  });
+});
+
+describe("buildLandingPrBody", () => {
+  const base = {
+    parentNumber: 327,
+    parentTitle: "EFI value map",
+    integrationBranch: "epic/327-efi-value-map",
+    defaultBranch: "main",
+  };
+
+  it("closes the parent and every child, one line each", () => {
+    const children = [
+      { number: 401, title: "A", prNumber: 410, prUrl: null },
+      { number: 402, title: "B", prNumber: 420, prUrl: null },
+      { number: 403, title: "C", prNumber: null, prUrl: null },
+    ];
+    const body = buildLandingPrBody({ ...base, children });
+    expect(body).toContain("Closes #327");
+    for (const c of children) {
+      expect(body).toContain(`Closes #${c.number}`);
+    }
+    const closesLines = body.split("\n").filter((l) => /^Closes #\d+$/.test(l));
+    expect(closesLines.length).toBe(children.length + 1);
+  });
+
+  it("`### Children (N)` header N equals children.length", () => {
+    const children = [
+      { number: 1, title: "x", prNumber: 11, prUrl: null },
+      { number: 2, title: "y", prNumber: 12, prUrl: null },
+      { number: 3, title: "z", prNumber: 13, prUrl: null },
+    ];
+    const body = buildLandingPrBody({ ...base, children });
+    expect(body).toContain("### Children (3)");
+  });
+
+  it("renders #<prNumber> when present and — when null", () => {
+    const children = [
+      { number: 50, title: "has pr", prNumber: 330, prUrl: null },
+      { number: 51, title: "no pr", prNumber: null, prUrl: null },
+    ];
+    const body = buildLandingPrBody({ ...base, children });
+    const rows = body.split("\n").filter((l) => l.startsWith("| #"));
+    const withPr = rows.find((r) => r.includes("#50"))!;
+    const noPr = rows.find((r) => r.includes("#51"))!;
+    expect(withPr).toContain("#330");
+    expect(noPr).toContain("—");
+  });
+
+  it("escapes a pipe in a child title so the row stays 3 cells", () => {
+    const children = [{ number: 70, title: "a | b", prNumber: 700, prUrl: null }];
+    const body = buildLandingPrBody({ ...base, children });
+    const row = body.split("\n").find((l) => l.startsWith("| #70"))!;
+    // Escaped pipe present; no bare table-breaking pipe from the title.
+    expect(row).toContain("a \\| b");
+    // A `| a | b | c |` row has 4 unescaped delimiters → 5 split segments (empty, 3 cells,
+    // empty). The escaped `\|` from the title must NOT add a delimiter, so it stays 5.
+    const segments = row.split(/(?<!\\)\|/);
+    expect(segments.length).toBe(5);
+    const cells = segments.slice(1, -1).map((s) => s.trim());
+    expect(cells).toEqual(["#70", "a \\| b", "#700"]);
+  });
+
+  it("collapses newlines in a child title to keep the row single-line", () => {
+    const children = [{ number: 80, title: "line1\nline2", prNumber: 800, prUrl: null }];
+    const body = buildLandingPrBody({ ...base, children });
+    const row = body.split("\n").find((l) => l.startsWith("| #80"))!;
+    expect(row).toContain("line1 line2");
+  });
+
+  it("empty children: header shows (0), only the parent Closes line, table header but no rows", () => {
+    const body = buildLandingPrBody({ ...base, children: [] });
+    expect(body).toContain("### Children (0)");
+    const closesLines = body.split("\n").filter((l) => /^Closes #\d+$/.test(l));
+    expect(closesLines).toEqual(["Closes #327"]);
+    const rows = body.split("\n").filter((l) => l.startsWith("| #"));
+    expect(rows.length).toBe(0);
+    expect(body).toContain("| Issue | Title | PR |");
+  });
+});

--- a/test/epic-server.test.ts
+++ b/test/epic-server.test.ts
@@ -809,6 +809,48 @@ describe("GET /api/epics/completed", () => {
     ]);
   });
 
+  test("response carries landing-PR fields; landingAttempts excluded", async () => {
+    const { app, store } = completedHarness({ resolveForge: () => null });
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 42,
+      parentTitle: "Epic Done",
+      completedAt: 5000,
+      childrenJson: "[]",
+    });
+    store.setEpicLandingPr(repoDir, 42, {
+      state: "open",
+      prNumber: 42,
+      prUrl: "https://example/pr/42",
+      attempts: 0,
+    });
+    const res = await app.fetch(new Request(`http://x/api/epics/completed`));
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    const row = body[0];
+    expect(row.landingPrNumber).toBe(42);
+    expect(row.landingPrUrl).toBe("https://example/pr/42");
+    expect(row.landingState).toBe("open");
+    expect("landingAttempts" in row).toBe(false);
+  });
+
+  test("plain record → default landing fields (pending/null/null)", async () => {
+    const { app, store } = completedHarness({ resolveForge: () => null });
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 7,
+      parentTitle: "Fresh",
+      completedAt: 1,
+      childrenJson: "[]",
+    });
+    const res = await app.fetch(new Request(`http://x/api/epics/completed`));
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].landingState).toBe("pending");
+    expect(body[0].landingPrNumber).toBe(null);
+    expect(body[0].landingPrUrl).toBe(null);
+  });
+
   test("?repo= filters to one repo", async () => {
     const other = join(tmpRoot, "other");
     mkdirSync(other);
@@ -927,6 +969,9 @@ describe("GET /api/epics/completed", () => {
     expect(body[0].parentIssueNumber).toBe(88);
     expect(body[0].children).toHaveLength(2);
     expect(body[0].children.every((c: any) => c.integrated)).toBe(true);
+    // backfill seeds the retry-able pending state the drain tick will resolve
+    expect(body[0].landingState).toBe("pending");
+    expect(body[0].landingPrNumber).toBe(null);
     // persisted
     expect(store.listEpicCompleted(repoDir)).toHaveLength(1);
   });

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
 import { GiteaForge } from "../../src/forge/gitea";
+import { EmptyDiffError } from "../../src/forge/types";
 import type { ForgeConfig } from "../../src/forge/types";
 
 const CFG: ForgeConfig = {
@@ -366,6 +367,45 @@ test("GiteaForge.openPr: POSTs pull then returns status", async () => {
   expect(st.checks).toBe("pending");
   const post = calls.find((c) => c.method === "POST")!;
   expect(post.body).toEqual({ head: "feature", base: "main", title: "T", body: "B" });
+});
+
+test("GiteaForge.openPr: empty-diff response (422 no changes) → EmptyDiffError", async () => {
+  const { fn } = fakeFetch({
+    "POST /api/v1/repos/team/proj/pulls": {
+      status: 422,
+      // Gitea's wording when head == base (422 Unprocessable Entity).
+      json: { message: "There are no changes between the head and the base" },
+    },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  let caught: unknown;
+  try {
+    await forge.openPr({ head: "epic/327-foo", base: "main", title: "T", body: "B" });
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(EmptyDiffError);
+  expect((caught as EmptyDiffError).head).toBe("epic/327-foo");
+  expect((caught as EmptyDiffError).base).toBe("main");
+});
+
+test("GiteaForge.openPr: unrelated error (500) propagates unchanged (NOT EmptyDiffError)", async () => {
+  const { fn } = fakeFetch({
+    "POST /api/v1/repos/team/proj/pulls": {
+      status: 500,
+      json: { message: "internal server error" },
+    },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  let caught: unknown;
+  try {
+    await forge.openPr({ head: "feat", base: "main", title: "T", body: "B" });
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).not.toBeInstanceOf(EmptyDiffError);
+  expect(caught).toBeInstanceOf(Error);
+  expect((caught as Error).message).toContain("500");
 });
 
 test("GiteaForge.merge: POSTs merge with Do + delete_branch_after_merge", async () => {

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
 import { GithubForge } from "../../src/forge/github";
+import { EmptyDiffError } from "../../src/forge/types";
 
 // A recording fake `gh` runner. Returns canned stdout keyed by the subcommand.
 function fakeRunner(responses: Record<string, string>) {
@@ -953,6 +954,46 @@ test("GithubForge.openPr: draft:false (or omitted) does NOT pass --draft", async
   const createCall = calls.find((c) => c[0] === "pr" && c[1] === "create")!;
   expect(createCall).toBeDefined();
   expect(createCall).not.toContain("--draft");
+});
+
+test("GithubForge.openPr: empty diff (gh stderr 'No commits between') → EmptyDiffError", async () => {
+  const run = async (args: string[]): Promise<string> => {
+    if (args[0] === "pr" && args[1] === "create") {
+      // Mirror an execFile rejection: stderr carries gh's empty-diff message.
+      const err = new Error("Command failed: gh pr create") as Error & { stderr?: string };
+      err.stderr = "No commits between main and epic/327-foo\n";
+      throw err;
+    }
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+  let caught: unknown;
+  try {
+    await forge.openPr({ head: "epic/327-foo", base: "main", title: "T", body: "B" });
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(EmptyDiffError);
+  expect((caught as EmptyDiffError).head).toBe("epic/327-foo");
+  expect((caught as EmptyDiffError).base).toBe("main");
+});
+
+test("GithubForge.openPr: unrelated failure propagates unchanged (NOT EmptyDiffError)", async () => {
+  const boom = new Error("network unreachable") as Error & { stderr?: string };
+  boom.stderr = "network unreachable";
+  const run = async (args: string[]): Promise<string> => {
+    if (args[0] === "pr" && args[1] === "create") throw boom;
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+  let caught: unknown;
+  try {
+    await forge.openPr({ head: "feat", base: "main", title: "T", body: "B" });
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBe(boom);
+  expect(caught).not.toBeInstanceOf(EmptyDiffError);
 });
 
 test("GithubForge.markReady: invokes gh pr ready <n> --repo", async () => {

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -91,8 +91,13 @@ function makeDeps(
     priorReviews?: Record<string, PrReview>; // keyed `${repo}#${n}`
     concurrency?: number;
     // epic_completed rows surfaced by store.listEpicCompleted() (Stage B, #635). A row whose
-    // landingPrNumber is set unions its repo into the swept set even with criticAllPrs OFF.
-    epicCompleted?: { repoPath: string; landingPrNumber: number | null }[];
+    // landingState is "open" unions its repo into the swept set even with criticAllPrs OFF; a
+    // "merged" row is no longer reviewable and drops out.
+    epicCompleted?: {
+      repoPath: string;
+      landingPrNumber: number | null;
+      landingState?: string;
+    }[];
   } = {},
 ) {
   const spies: Spies = {
@@ -294,7 +299,7 @@ test("reviews the epic landing PR even with criticAllPrs OFF everywhere", async 
     {},
     {
       criticAllPrs: false,
-      epicCompleted: [{ repoPath: "/r", landingPrNumber: 42 }],
+      epicCompleted: [{ repoPath: "/r", landingPrNumber: 42, landingState: "open" }],
       forge: undefined,
     },
   );
@@ -315,7 +320,7 @@ test("with criticAllPrs OFF, a non-epic PR in the (epic-unioned) repo is NOT rev
     {},
     {
       criticAllPrs: false,
-      epicCompleted: [{ repoPath: "/r", landingPrNumber: 42 }],
+      epicCompleted: [{ repoPath: "/r", landingPrNumber: 42, landingState: "open" }],
       forge: undefined,
     },
   );
@@ -339,7 +344,8 @@ test("empty union (no criticAllPrs, no pending landing PR) → no forge call, no
     {},
     {
       criticAllPrs: false,
-      epicCompleted: [{ repoPath: "/r", landingPrNumber: null }], // no landing PR → not in union
+      // no open landing PR → not in union
+      epicCompleted: [{ repoPath: "/r", landingPrNumber: null, landingState: "none" }],
       forge: undefined,
     },
   );
@@ -357,12 +363,38 @@ test("empty union (no criticAllPrs, no pending landing PR) → no forge call, no
   expect(local.spies.started).toHaveLength(0);
 });
 
+test("a merged epic landing PR is NOT swept (no longer reviewable)", async () => {
+  // The landing PR has merged → landingState "merged"; even though landingPrNumber is still set,
+  // the union keys off "open" only, so the repo is no longer swept (no list, no spawn).
+  let listed = 0;
+  const local = makeDeps(
+    {},
+    {
+      criticAllPrs: false,
+      epicCompleted: [{ repoPath: "/r", landingPrNumber: 42, landingState: "merged" }],
+      forge: undefined,
+    },
+  );
+  local.deps.resolveForge = () => {
+    const f = makeForge(local.spies, { prs: [pr({ number: 42, headRefName: "epic/327-foo" })] });
+    f.listPullRequests = async () => {
+      listed++;
+      return [pr({ number: 42, headRefName: "epic/327-foo" })];
+    };
+    return f;
+  };
+  const svc = new StandalonePrCriticService(local.deps as any);
+  await svc.sweep();
+  expect(listed).toBe(0);
+  expect(local.spies.started).toHaveLength(0);
+});
+
 test("per-head dedup still holds for the epic landing PR across two sweeps", async () => {
   const local = makeDeps(
     {},
     {
       criticAllPrs: false,
-      epicCompleted: [{ repoPath: "/r", landingPrNumber: 42 }],
+      epicCompleted: [{ repoPath: "/r", landingPrNumber: 42, landingState: "open" }],
       forge: undefined,
     },
   );

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -90,6 +90,9 @@ function makeDeps(
     forge?: (r: string) => GitForge | null;
     priorReviews?: Record<string, PrReview>; // keyed `${repo}#${n}`
     concurrency?: number;
+    // epic_completed rows surfaced by store.listEpicCompleted() (Stage B, #635). A row whose
+    // landingPrNumber is set unions its repo into the swept set even with criticAllPrs OFF.
+    epicCompleted?: { repoPath: string; landingPrNumber: number | null }[];
   } = {},
 ) {
   const spies: Spies = {
@@ -129,6 +132,10 @@ function makeDeps(
       recordReviewerSpawn: (r: any) => spies.recordedSpawns.push(r),
       completeReviewerSpawn: (id: string, u: any, at: number) =>
         spies.completedSpawns.push({ id, u, at }),
+      // Minimal listEpicCompleted: returns the injected rows (filtered by repoPath when given),
+      // shaped just enough for sweep()'s landingPrNumber != null filter + repoPath map.
+      listEpicCompleted: (repoPath?: string) =>
+        (opts.epicCompleted ?? []).filter((r) => repoPath === undefined || r.repoPath === repoPath),
     },
     herdr: {
       start: (name: string, cwd: string, argv: string[]) => {
@@ -276,6 +283,96 @@ test("does nothing for a repo whose criticAllPrs is OFF", async () => {
   const svc = new StandalonePrCriticService(deps as any);
   await svc.sweep();
   expect(spies.started).toHaveLength(0);
+});
+
+// ── 2b. epic landing PR coverage (Stage B, #635) ─────────────────────────────
+
+test("reviews the epic landing PR even with criticAllPrs OFF everywhere", async () => {
+  // criticAllPrs off, but an epic_completed row with a landing PR number unions /r into the swept
+  // set. The open green regular PR's head is the epic integration branch → eligible.
+  const local = makeDeps(
+    {},
+    {
+      criticAllPrs: false,
+      epicCompleted: [{ repoPath: "/r", landingPrNumber: 42 }],
+      forge: undefined,
+    },
+  );
+  local.deps.resolveForge = () =>
+    makeForge(local.spies, {
+      prs: [pr({ number: 42, headRefName: "epic/327-foo" })],
+    });
+  const svc = new StandalonePrCriticService(local.deps as any);
+  await svc.sweep();
+  expect(local.spies.started).toHaveLength(1);
+  expect(local.spies.started[0]!.name).toBe("pr-critic /r#42");
+});
+
+test("with criticAllPrs OFF, a non-epic PR in the (epic-unioned) repo is NOT reviewed", async () => {
+  // /r is swept ONLY because of its landing PR; a normal green regular PR whose head is a plain
+  // task branch must stay excluded (eligible carves the OFF repo down to the integration branch).
+  const local = makeDeps(
+    {},
+    {
+      criticAllPrs: false,
+      epicCompleted: [{ repoPath: "/r", landingPrNumber: 42 }],
+      forge: undefined,
+    },
+  );
+  local.deps.resolveForge = () =>
+    makeForge(local.spies, {
+      prs: [
+        pr({ number: 42, headRefName: "epic/327-foo" }), // the landing PR — eligible
+        pr({ number: 8, headRefName: "feature/x" }), // a normal PR — excluded
+      ],
+    });
+  const svc = new StandalonePrCriticService(local.deps as any);
+  await svc.sweep();
+  expect(local.spies.started).toHaveLength(1);
+  expect(local.spies.started[0]!.name).toBe("pr-critic /r#42");
+});
+
+test("empty union (no criticAllPrs, no pending landing PR) → no forge call, no spawn", async () => {
+  // Neither flagged nor epic-unioned: sweep() must early-return before resolving/listing the forge.
+  let listed = 0;
+  const local = makeDeps(
+    {},
+    {
+      criticAllPrs: false,
+      epicCompleted: [{ repoPath: "/r", landingPrNumber: null }], // no landing PR → not in union
+      forge: undefined,
+    },
+  );
+  local.deps.resolveForge = () => {
+    const f = makeForge(local.spies, {});
+    f.listPullRequests = async () => {
+      listed++;
+      return [];
+    };
+    return f;
+  };
+  const svc = new StandalonePrCriticService(local.deps as any);
+  await svc.sweep();
+  expect(listed).toBe(0);
+  expect(local.spies.started).toHaveLength(0);
+});
+
+test("per-head dedup still holds for the epic landing PR across two sweeps", async () => {
+  const local = makeDeps(
+    {},
+    {
+      criticAllPrs: false,
+      epicCompleted: [{ repoPath: "/r", landingPrNumber: 42 }],
+      forge: undefined,
+    },
+  );
+  local.deps.resolveForge = () =>
+    makeForge(local.spies, { prs: [pr({ number: 42, headRefName: "epic/327-foo" })] });
+  const svc = new StandalonePrCriticService(local.deps as any);
+  await svc.sweep();
+  await svc.sweep(); // still in flight (no tick) → the in-flight guard blocks a re-spawn
+  expect(local.spies.started).toHaveLength(1);
+  expect(local.spies.created).toHaveLength(1);
 });
 
 // ── 3. in-flight exclusion across sweeps ─────────────────────────────────────

--- a/test/store-epic-completed.test.ts
+++ b/test/store-epic-completed.test.ts
@@ -151,6 +151,101 @@ test("dismissedAt IS NULL filter — dismissed epics never appear in list", () =
   expect(list[0]!.parentIssueNumber).toBe(2);
 });
 
+test("fresh recordEpicCompleted defaults landing columns (pending/null/null/0)", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.landingState).toBe("pending");
+  expect(row.landingPrNumber).toBe(null);
+  expect(row.landingPrUrl).toBe(null);
+  expect(row.landingAttempts).toBe(0);
+});
+
+test("setEpicLandingPr writes the landing resolution", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+
+  s.setEpicLandingPr("/r", 10, {
+    state: "open",
+    prNumber: 42,
+    prUrl: "http://x/42",
+    attempts: 0,
+  });
+
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.landingState).toBe("open");
+  expect(row.landingPrNumber).toBe(42);
+  expect(row.landingPrUrl).toBe("http://x/42");
+  expect(row.landingAttempts).toBe(0);
+});
+
+test("setEpicLandingPr persists a non-zero attempts counter", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+
+  s.setEpicLandingPr("/r", 10, {
+    state: "error",
+    prNumber: null,
+    prUrl: null,
+    attempts: 3,
+  });
+
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.landingState).toBe("error");
+  expect(row.landingAttempts).toBe(3);
+});
+
+test("re-recordEpicCompleted preserves landing resolution by omission", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "Old",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  s.setEpicLandingPr("/r", 10, {
+    state: "open",
+    prNumber: 42,
+    prUrl: "http://x/42",
+    attempts: 0,
+  });
+
+  // a later re-record refreshes title/children but must NOT reset the landing back to pending
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "New",
+    completedAt: 999,
+    childrenJson: "[1,2]",
+  });
+
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.parentTitle).toBe("New");
+  expect(row.childrenJson).toBe("[1,2]");
+  expect(row.landingState).toBe("open");
+  expect(row.landingPrNumber).toBe(42);
+});
+
 test("listEpicRuns returns all persisted epic_run rows", () => {
   const s = new SessionStore(":memory:");
   expect(s.listEpicRuns()).toEqual([]);

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1237,5 +1237,6 @@
   "integrated_epics_landing_pr": "Landing-PR #{number} — wartet auf Merge",
   "integrated_epics_landing_failed": "Landing-PR konnte nicht geöffnet werden — erneuter Versuch",
   "feat_epic_landing_pr_title": "Epics landen über einen finalen PR",
-  "feat_epic_landing_pr_body": "Wenn alle Kind-Issues eines Epics integriert sind, öffnet Shepherd einen finalen PR, der das gesamte Epic landet und das Eltern-Issue schließt — als Link im Band 'Integrierte Epics'."
+  "feat_epic_landing_pr_body": "Wenn alle Kind-Issues eines Epics integriert sind, öffnet Shepherd einen finalen PR, der das gesamte Epic landet und das Eltern-Issue schließt — als Link im Band 'Integrierte Epics'.",
+  "integrated_epics_landing_pr_merged": "Landing-PR #{number} — gemergt"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1233,5 +1233,9 @@
   "feat_colorblind_markers_body": "Falls Grün und Rot schwer zu unterscheiden sind, aktiviere die Farbenblind-Status-Marker unter Einstellungen → Gerät. Dann steht am Handy ein ✓ (wartet) oder ! (blockiert) neben dem Session-Emoji, sodass diese Zustände nicht mehr allein an der Header-Färbung hängen. Standardmäßig aus.",
   "timetip_ready_to_merge": "Grünes Licht — bereit zum Mergen 🟢",
   "feat_quick_theme_title": "Thema & Kontrast direkt im Menü",
-  "feat_quick_theme_body": "Am Handy öffnest du mit dem Zahnrad (oben rechts) das Menü und schaltest Dark-/Light-Thema sowie hohen Kontrast direkt dort um — kein Umweg mehr über Einstellungen → Gerät. Das Menü sitzt jetzt bündig am Rand und legt einen unscharfen Hintergrund darunter, damit es klar im Fokus steht."
+  "feat_quick_theme_body": "Am Handy öffnest du mit dem Zahnrad (oben rechts) das Menü und schaltest Dark-/Light-Thema sowie hohen Kontrast direkt dort um — kein Umweg mehr über Einstellungen → Gerät. Das Menü sitzt jetzt bündig am Rand und legt einen unscharfen Hintergrund darunter, damit es klar im Fokus steht.",
+  "integrated_epics_landing_pr": "Landing-PR #{number} — wartet auf Merge",
+  "integrated_epics_landing_failed": "Landing-PR konnte nicht geöffnet werden — erneuter Versuch",
+  "feat_epic_landing_pr_title": "Epics landen über einen finalen PR",
+  "feat_epic_landing_pr_body": "Wenn alle Kind-Issues eines Epics integriert sind, öffnet Shepherd einen finalen PR, der das gesamte Epic landet und das Eltern-Issue schließt — als Link im Band 'Integrierte Epics'."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1233,5 +1233,9 @@
   "feat_colorblind_markers_body": "If green and red are hard to tell apart, switch on Colourblind status markers in Settings → Device. A ✓ (waiting) or ! (blocked) then sits next to the session emoji on phones, so those states no longer rely on the header tint alone. Off by default.",
   "timetip_ready_to_merge": "Green light — ready to merge 🟢",
   "feat_quick_theme_title": "Quick theme & contrast in the menu",
-  "feat_quick_theme_body": "On phones, tap the gear (top-right) to switch dark/light theme and toggle high contrast right from the menu — no more digging into Settings → Device. The menu now sits flush to the edge with a blurred backdrop so it reads as the focus."
+  "feat_quick_theme_body": "On phones, tap the gear (top-right) to switch dark/light theme and toggle high contrast right from the menu — no more digging into Settings → Device. The menu now sits flush to the edge with a blurred backdrop so it reads as the focus.",
+  "integrated_epics_landing_pr": "Landing PR #{number} — awaiting merge",
+  "integrated_epics_landing_failed": "Couldn't open the landing PR — retrying",
+  "feat_epic_landing_pr_title": "Epics land via a final PR",
+  "feat_epic_landing_pr_body": "When an epic's children are all integrated, Shepherd opens a final PR that lands the whole epic and closes the parent issue — surfaced as a link in the Integrated-epics band."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1237,5 +1237,6 @@
   "integrated_epics_landing_pr": "Landing PR #{number} — awaiting merge",
   "integrated_epics_landing_failed": "Couldn't open the landing PR — retrying",
   "feat_epic_landing_pr_title": "Epics land via a final PR",
-  "feat_epic_landing_pr_body": "When an epic's children are all integrated, Shepherd opens a final PR that lands the whole epic and closes the parent issue — surfaced as a link in the Integrated-epics band."
+  "feat_epic_landing_pr_body": "When an epic's children are all integrated, Shepherd opens a final PR that lands the whole epic and closes the parent issue — surfaced as a link in the Integrated-epics band.",
+  "integrated_epics_landing_pr_merged": "Landing PR #{number} — merged"
 }

--- a/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
@@ -137,6 +137,66 @@ describe("IntegratedEpicRow", () => {
     expect(document.querySelector(".child .closed")).toBeNull();
   });
 
+  it("landingState 'open' with a PR number renders the Landing PR link to landingPrUrl", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "open",
+        landingPrNumber: 42,
+        landingPrUrl: "https://github.com/o/r/pull/42",
+      }),
+      ondismiss: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const link = await vi.waitFor(() => {
+      const a = [...document.querySelectorAll(".actions a")].find((el) =>
+        el.textContent?.includes("Landing PR #42"),
+      ) as HTMLAnchorElement | undefined;
+      if (!a) throw new Error("no landing pr link yet");
+      return a;
+    });
+    expect(link.getAttribute("href")).toBe("https://github.com/o/r/pull/42");
+    // not the fallback awaiting-landing copy
+    expect(document.querySelector(".actions")?.textContent).not.toContain("awaiting landing");
+  });
+
+  it("landingState 'error' renders the failure note and NO PR link", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "error",
+        landingPrNumber: null,
+        landingPrUrl: null,
+      }),
+      ondismiss: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const note = await vi.waitFor(() => {
+      const el = document.querySelector(".actions .landing-failed") as HTMLElement | null;
+      if (!el) throw new Error("no failure note yet");
+      return el;
+    });
+    expect(note.textContent).toContain("retrying");
+    // no link in the actions block — there's no PR yet
+    expect(document.querySelector(".actions a")).toBeNull();
+  });
+
+  it("landingState 'pending' falls back to the awaiting-landing copy", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], { landingState: "pending" }),
+      ondismiss: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const awaiting = await vi.waitFor(() => {
+      const el = document.querySelector(".actions .awaiting") as HTMLElement | null;
+      if (!el) throw new Error("no awaiting copy yet");
+      return el;
+    });
+    expect(awaiting.textContent).toContain("awaiting landing");
+    expect(document.querySelector(".actions .landing-failed")).toBeNull();
+  });
+
   it("clicking Dismiss calls ondismiss(repoPath, parentIssueNumber)", async () => {
     const ondismiss = vi.fn();
     render(IntegratedEpicRow, {

--- a/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
@@ -160,6 +160,31 @@ describe("IntegratedEpicRow", () => {
     expect(document.querySelector(".actions")?.textContent).not.toContain("awaiting landing");
   });
 
+  it("landingState 'merged' renders the merged Landing PR link, not the awaiting copy", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "merged",
+        landingPrNumber: 42,
+        landingPrUrl: "https://github.com/o/r/pull/42",
+      }),
+      ondismiss: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const link = await vi.waitFor(() => {
+      const a = [...document.querySelectorAll(".actions a")].find((el) =>
+        el.textContent?.includes("Landing PR #42"),
+      ) as HTMLAnchorElement | undefined;
+      if (!a) throw new Error("no landing pr link yet");
+      return a;
+    });
+    expect(link.getAttribute("href")).toBe("https://github.com/o/r/pull/42");
+    expect(link.textContent).toContain("merged");
+    // not the "awaiting merge" copy, not the awaiting-landing fallback
+    expect(document.querySelector(".actions")?.textContent).not.toContain("awaiting merge");
+    expect(document.querySelector(".actions")?.textContent).not.toContain("awaiting landing");
+  });
+
   it("landingState 'error' renders the failure note and NO PR link", async () => {
     render(IntegratedEpicRow, {
       epic: epic([child({ number: 1 })], {

--- a/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
@@ -23,6 +23,9 @@ const epic = (children: CompletedEpicChild[], p: Partial<CompletedEpic> = {}): C
   parentTitle: "Big epic",
   completedAt: Date.now() - 120_000,
   children,
+  landingPrNumber: null,
+  landingPrUrl: null,
+  landingState: "pending",
   ...p,
 });
 

--- a/ui/src/lib/components/IntegratedEpicRow.svelte
+++ b/ui/src/lib/components/IntegratedEpicRow.svelte
@@ -96,7 +96,20 @@
       >
         {m.integrated_epics_dismiss()}
       </button>
-      {#if parentUrl}
+      {#if epic.landingState === "open" && epic.landingPrNumber != null}
+        {#if epic.landingPrUrl}
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+          <a class="awaiting" href={epic.landingPrUrl} target="_blank" rel="noopener noreferrer"
+            >{m.integrated_epics_landing_pr({ number: epic.landingPrNumber })}</a
+          >
+        {:else}
+          <span class="awaiting"
+            >{m.integrated_epics_landing_pr({ number: epic.landingPrNumber })}</span
+          >
+        {/if}
+      {:else if epic.landingState === "error"}
+        <span class="landing-failed">{m.integrated_epics_landing_failed()}</span>
+      {:else if parentUrl}
         <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
         <a class="awaiting" href={parentUrl} target="_blank" rel="noopener noreferrer"
           >{m.integrated_epics_awaiting_landing({ number: epic.parentIssueNumber })}</a
@@ -244,6 +257,11 @@
   a.awaiting:hover {
     color: var(--color-muted);
     text-decoration: underline;
+  }
+  /* Quiet warning note — landing PR couldn't be opened (no link yet). */
+  .landing-failed {
+    color: var(--color-amber);
+    font-size: var(--fs-micro);
   }
 
   /* Canonical .gbtn recipe (scoped per-component; see /design-system). */

--- a/ui/src/lib/components/IntegratedEpicRow.svelte
+++ b/ui/src/lib/components/IntegratedEpicRow.svelte
@@ -107,6 +107,17 @@
             >{m.integrated_epics_landing_pr({ number: epic.landingPrNumber })}</span
           >
         {/if}
+      {:else if epic.landingState === "merged" && epic.landingPrNumber != null}
+        {#if epic.landingPrUrl}
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+          <a class="awaiting" href={epic.landingPrUrl} target="_blank" rel="noopener noreferrer"
+            >{m.integrated_epics_landing_pr_merged({ number: epic.landingPrNumber })}</a
+          >
+        {:else}
+          <span class="awaiting"
+            >{m.integrated_epics_landing_pr_merged({ number: epic.landingPrNumber })}</span
+          >
+        {/if}
       {:else if epic.landingState === "error"}
         <span class="landing-failed">{m.integrated_epics_landing_failed()}</span>
       {:else if parentUrl}

--- a/ui/src/lib/components/IntegratedEpicsBand.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicsBand.browser.test.ts
@@ -22,6 +22,9 @@ const epic = (n: number): CompletedEpic => ({
       integrated: true,
     },
   ],
+  landingPrNumber: null,
+  landingPrUrl: null,
+  landingState: "pending",
 });
 
 afterEach(() => {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -766,4 +766,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_quick_theme_title",
     bodyKey: "feat_quick_theme_body",
   },
+  {
+    // No targetId: the band only mounts when there are completed epics, and the
+    // landing-PR link only appears once the aggregate PR is open, so a coachmark
+    // anchor would usually be absent — surface via the What's-New drawer only.
+    // 1.29.0 is the latest released tag, so this ships in 1.30.0: computeNewEntries
+    // only surfaces entries with sinceVersion > lastSeen.
+    id: "epic-landing-pr",
+    sinceVersion: "1.30.0",
+    titleKey: "feat_epic_landing_pr_title",
+    bodyKey: "feat_epic_landing_pr_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -739,6 +739,9 @@ function completedEpic(repoPath: string, parentIssueNumber: number): CompletedEp
         integrated: true,
       },
     ],
+    landingPrNumber: null,
+    landingPrUrl: null,
+    landingState: "pending",
   };
 }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -385,6 +385,12 @@ export interface CompletedEpic {
   parentTitle: string;
   completedAt: number;
   children: CompletedEpicChild[];
+  // Stage B (#635) landing-PR carried on the band; null/'pending' until the aggregate PR opens.
+  landingPrNumber: number | null;
+  landingPrUrl: string | null;
+  // Landing-PR lifecycle state (mirrors server EpicLandingState): pending=not yet
+  // resolved, open=PR opened/reused, none=nothing to land, error=last attempt failed.
+  landingState: "pending" | "open" | "none" | "error";
 }
 
 /** One queued backlog issue behind DrainStatus.queued — a row in the queue popover.

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -389,8 +389,9 @@ export interface CompletedEpic {
   landingPrNumber: number | null;
   landingPrUrl: string | null;
   // Landing-PR lifecycle state (mirrors server EpicLandingState): pending=not yet
-  // resolved, open=PR opened/reused, none=nothing to land, error=last attempt failed.
-  landingState: "pending" | "open" | "none" | "error";
+  // resolved, open=PR opened/reused, merged=landing PR merged (epic landed), none=nothing
+  // to land, error=last attempt failed.
+  landingState: "pending" | "open" | "merged" | "none" | "error";
 }
 
 /** One queued backlog issue behind DrainStatus.queued — a row in the queue popover.


### PR DESCRIPTION
## Epic Stage B: land the epic via a final `epic/# → default` PR

Closes #635.

When an epic's last child squash-merges into its `epic/<#>-<slug>` integration branch, the drain records completion and flips the run `running → idle` — but until now there was **no final PR** and the **parent issue stayed open forever**. The epic integrated but never *landed*. This is the unbuilt "Stage B" from the Stage-A design.

### What this does

On epic completion, Shepherd opens **one** aggregate PR `epic/<#>-<slug> → <default>` whose body is the epic status report (every child + its PR + totals) and whose `Closes #<parent>` + `Closes #<child>` lines close the whole epic on a single merge. The critic reviews it; a human merges it; the band auto-clears.

- **Decoupled from the idle flip (never wedges the drain).** A running epic suppresses the repo's label-mode drain, so completion records + flips `running → idle` *unconditionally*; the landing PR is opened on a separate idempotent path. A forge failure surfaces as `landingState:'error'` on the band, never by holding the run open.
- **Idempotent, three guards.** A per-`repo#parent` in-flight `Set` serializes the read-modify-write; `prStatus(integrationBranch)` (`--state all`) reuses an existing open/merged PR (never a second) and treats a human-**closed** PR as terminal (won't re-open what the operator dismissed); terminal/parked rows short-circuit before touching the forge.
- **Two retry paths.** The autonomous `drain.tick()` (DB-gated — zero forge calls in steady state) covers headless + across-restart; the server reconcile carries the columns for the band. The drain is the **only** opener.
- **Lifecycle state** on the `epic_completed` row: `pending → open` (PR opened/reused) / `none` (nothing to land — empty diff via a typed cross-forge `EmptyDiffError`, no integrated children, or human-closed) / `error` (retried up to `MAX_LANDING_ATTEMPTS`, then parked, still shown on the band).
- **Critic on the aggregate.** `StandalonePrCriticService` now reviews the landing PR (head = epic integration branch) **even when `criticAllPrs` is off** — comment-only, gated on CI-green as usual.
- **UI band** shows a "Landing PR #N — awaiting merge" link / a retry-warning on `error` / the existing "awaiting landing" fallback, all i18n'd (EN+DE) with a feature-catalog entry.
- **Completion** closes the loop: the landing PR's `Closes #<parent>` closes the parent on merge → the existing `autoDismissClosed` reconcile clears the band.

### Resolved design questions (from the issue)

- **Merge train:** the landing PR is sessionless and `AutoMergeService` is session-based, so it can never auto-merge — it's a human click. (Invariant: autopilot never merges to default.)
- **Attended vs auto:** the PR is auto-*opened* in both modes (non-destructive); the *merge* stays human-gated.
- **What closes the parent:** `Closes #<parent>` in the body — no explicit close call.
- **PR body** is a Shepherd-authored forge artifact (like `epicBaseDirective`), intentionally **not** i18n'd.

### `#645` items addressed

This also satisfies two of the [#645](https://github.com/erwins-enkel/shepherd/issues/645) Epic-Runner learnings:
- **#645.3** (no sub-issue/checklist reconciliation on epic-branch merge): the landing PR is the reconciliation surface — one merge closes every child + the parent.
- **#645.8** (aggregate cross-ticket status onto the epic): the landing PR body is that aggregate (children + PRs + totals).

The remaining #645 items (topology-drift detection, base/stacked-PR enforcement, DB-migration/CI verification in worktrees) are out of scope — separate harness concerns.

### Intentional behavior worth flagging

When the landing resolves to `none` (empty diff / human-closed PR), the band shows the parent-issue link and the always-present **Dismiss** button, and clears on parent close — it does not auto-close the parent (Shepherd did its part and hands off). This is the one state that doesn't self-close; by design.

### Tests / gates

Root `typecheck` + `lint` + `bun test ./test` (2783 pass), UI `check` + `check:i18n` (EN/DE parity) + vitest (1215 pass), branch-hygiene + feature-catalog + fallow audit all green. New coverage: drain landing lifecycle (incl. completion-not-wedged, in-flight concurrency, park-at-cap), forge `EmptyDiffError`, pure body builders, critic union eligibility, server response shape, and the three UI band states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
