### PR TITLE
fix(onboarding-harness): make the harness actually run end-to-end

### DIFF
--- a/ci/onboarding-harness/incus.ts
+++ b/ci/onboarding-harness/incus.ts
@@ -1,20 +1,41 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { spawn } from "node:child_process";
 import type { IncusExec, IncusRunner } from "./types";
 
-const execFileAsync = promisify(execFile);
+/** Backstop kill timeout for any single `incus` call. The genuine hang fix is
+ *  closing stdin (below); this cap only guards a process that wedges for some
+ *  other reason. Generous on purpose — a cold image pull and an in-instance
+ *  `bun install` legitimately take minutes. */
+const RUNNER_TIMEOUT_MS = 20 * 60_000;
 
 /** Default runner: invokes the real `incus` binary, capturing output and never
- *  throwing on a non-zero exit (the caller inspects `code`). */
-const defaultRunner: IncusRunner = async (args) => {
-  try {
-    const { stdout, stderr } = await execFileAsync("incus", args, { encoding: "utf8" });
-    return { stdout: stdout.toString(), stderr: stderr.toString(), code: 0 };
-  } catch (err) {
-    const e = err as { stdout?: string; stderr?: string; code?: number };
-    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", code: e.code ?? 1 };
-  }
-};
+ *  throwing on a non-zero exit (the caller inspects `code`).
+ *
+ *  stdin MUST be `"ignore"`, NOT an (execFile-style) pipe: the incus Go client
+ *  DEADLOCKS forever on an open stdin pipe for its operation-streaming commands
+ *  (`launch`, `exec`, `file push`) — every worker thread parks in `futex_wait`
+ *  and the call never resolves. `execFile` forces a stdin pipe, which is why the
+ *  harness hung on the very first launch. Closing stdin lets these commands
+ *  return; the backstop timeout above is belt-and-suspenders only. */
+const defaultRunner: IncusRunner = (args) =>
+  new Promise((resolve) => {
+    const child = spawn("incus", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    const timer = setTimeout(() => {
+      stderr += `\nincus ${args[0] ?? ""} killed after ${RUNNER_TIMEOUT_MS}ms (timeout)`;
+      child.kill("SIGKILL");
+    }, RUNNER_TIMEOUT_MS);
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr: stderr + String(err), code: 1 });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr, code: code ?? 1 });
+    });
+  });
 
 /** Thin, throw-away-instance lifecycle wrapper over the `incus` CLI. All managed
  *  instances carry `prefix` in their name so `sweep()` can reap leaks. */
@@ -31,11 +52,14 @@ export class IncusDriver {
   async launch(
     image: string,
     name: string,
-    opts: { vm?: boolean; profile?: string } = {},
+    opts: { vm?: boolean; profiles?: string[] } = {},
   ): Promise<void> {
     const args = ["launch", image, this.full(name)];
     if (opts.vm) args.push("--vm");
-    if (opts.profile) args.push("--profile", opts.profile);
+    // Each `--profile` STACKS; the caller must include `default` explicitly, since
+    // passing only a custom profile REPLACES default and strips its root disk + NIC
+    // ("No root device could be found"). See seed.ts for the canonical list.
+    for (const p of opts.profiles ?? []) args.push("--profile", p);
     const r = await this.run(args);
     if (r.code !== 0) throw new Error(`incus launch failed: ${r.stderr || r.stdout}`);
   }

--- a/ci/onboarding-harness/probe.ts
+++ b/ci/onboarding-harness/probe.ts
@@ -15,10 +15,20 @@ const PORT = 7330; // config.port default
  *  correct option. (If a future scenario needs a token, the probe must add
  *  `-H "Authorization: Bearer $SHEPHERD_TOKEN"` instead.) */
 export async function bootShepherd(driver: IncusDriver, name: string): Promise<void> {
+  // - `bun src/index.ts`, NOT `bun run start`: the `start` package-script spawns a
+  //   nested BARE `bun`, which the non-login exec PATH can't resolve ("bun: not
+  //   found"). Running the entry file directly avoids the indirection.
+  // - `setsid`: a plain `nohup … &` child is reaped when the `incus exec` session
+  //   closes; setsid detaches it into its own session so the server outlives exec.
+  // - PATH adds ~/.local/bin + ~/.bun/bin so binaries a remediation installs there
+  //   (node symlink, claude, herdr) are visible to the running server's probes,
+  //   which resolve each tool via PATH on every `?refresh=1`.
   await driver.exec(name, [
     "sh",
     "-c",
-    `cd ${SHEPHERD_DIR} && env -u SHEPHERD_TOKEN nohup ~/.bun/bin/bun run start >/var/log/shepherd.log 2>&1 &`,
+    `cd ${SHEPHERD_DIR} && setsid env -u SHEPHERD_TOKEN ` +
+      `PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" ` +
+      `~/.bun/bin/bun src/index.ts >/var/log/shepherd.log 2>&1 </dev/null &`,
   ]);
   const poll = await driver.exec(name, [
     "sh",

--- a/ci/onboarding-harness/remediations.ts
+++ b/ci/onboarding-harness/remediations.ts
@@ -8,7 +8,17 @@ import type { DiagnosticsSnapshot } from "../../src/types";
  *  the agent path. Every `coaching: "structured"` scenario must have a matching
  *  entry here — otherwise it silently falls through to the LLM agent path,
  *  breaking the deterministic LLM-free gate guarantee. */
-const NODE_INSTALL = "curl -fsSL https://fnm.vercel.app/install | bash && fnm install --lts";
+// fnm installs node into its own versions dir (NOT on PATH) and exposes it only
+// via a shell `eval` an `incus exec sh -c` never runs — so a bare `fnm install`
+// leaves the running server still seeing the old node. Reference fnm by absolute
+// path and symlink the installed node into ~/.local/bin, which the booted server
+// has FIRST on PATH (see probe.ts), so the next probe resolves the new node.
+const NODE_INSTALL =
+  "curl -fsSL https://fnm.vercel.app/install | bash && " +
+  'FNM="$HOME/.local/share/fnm/fnm" && "$FNM" install --lts && ' +
+  'mkdir -p "$HOME/.local/bin" && ' +
+  'ln -sf "$("$FNM" exec --using=lts-latest node -e \'console.log(process.execPath)\')" ' +
+  '"$HOME/.local/bin/node"';
 const HERDR_INSTALL = "curl -fsSL https://herdr.dev/install.sh | bash";
 
 export const REMEDIATIONS: Record<string, string> = {

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -87,7 +87,11 @@ async function runScenario(
 const LOCK_PATH = join(homedir(), ".shepherd", "onboarding-harness.lock");
 
 /** Acquire a host-wide exclusive lock so concurrent runs never share the Incus
- *  host. `wx` fails if the lock already exists. Returns a release fn. */
+ *  host. `wx` fails if the lock already exists. Returns an idempotent release fn.
+ *  The release is ALSO wired to SIGINT/SIGTERM: Node skips `finally` on a
+ *  signal-kill, so without this a Ctrl-C'd or `systemctl stop`-ed run would leave
+ *  a stale lock that blocks every future run at exit 3. (A hard SIGKILL still
+ *  can't be caught — `--reap-orphans` clears such a leak.) */
 function acquireHostLock(): () => void {
   mkdirSync(dirname(LOCK_PATH), { recursive: true });
   let fd: number;
@@ -97,7 +101,10 @@ function acquireHostLock(): () => void {
     console.error(`another onboarding-harness run holds ${LOCK_PATH}; aborting`);
     process.exit(3);
   }
-  return () => {
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
     closeSync(fd);
     try {
       unlinkSync(LOCK_PATH);
@@ -105,12 +112,26 @@ function acquireHostLock(): () => void {
       /* already gone */
     }
   };
+  for (const sig of ["SIGINT", "SIGTERM"] as const) {
+    process.once(sig, () => {
+      release();
+      process.exit(130);
+    });
+  }
+  return release;
 }
 
 async function main() {
-  // Maintenance: reap ALL harness instances across runs (manual recovery only).
+  // Maintenance: reap ALL harness instances across runs AND clear a stale lock
+  // left by a hard-killed (SIGKILL) run (manual recovery only).
   if (process.argv.includes("--reap-orphans")) {
     await new IncusDriver(undefined, "shep-onb-").sweep();
+    try {
+      unlinkSync(LOCK_PATH);
+      console.log("cleared stale host lock");
+    } catch {
+      /* no lock held */
+    }
     console.log("reaped all shep-onb-* instances");
     return;
   }

--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -74,7 +74,7 @@ export const SCENARIOS: Scenario[] = [
     // dispatch reinstalls claude deterministically, so this IS green-able;
     // `agentIncompatible` is only the fallback if the verbatim fix were ever absent.
     id: "claude-missing",
-    image: "images:fedora/40",
+    image: "images:fedora/42",
     seed: ["rm -f /usr/local/bin/claude ~/.local/bin/claude"],
     expect: [{ id: "claude", state: "error" }],
     coaching: "structured",

--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -3,13 +3,53 @@ import type { Scenario } from "./types";
 
 const SHEPHERD_DIR = "/opt/shepherd";
 
+// `default` FIRST so the instance keeps its root disk + NIC, then `shep-onb`
+// layers the harness limits/nesting/tun on top. Passing only `shep-onb` would
+// replace default and leave the instance with no root device.
+const PROFILES = ["default", "shep-onb"];
+
+/** Cross-distro "ensure package `$1` is installed" one-liner (apt/apk/dnf/pacman). */
+function ensurePkg(pkg: string): string {
+  return (
+    `command -v ${pkg} >/dev/null 2>&1 || ` +
+    `(apt-get update && apt-get install -y ${pkg}) || apk add --no-cache ${pkg} || ` +
+    `dnf install -y ${pkg} || pacman -Sy --noconfirm ${pkg}`
+  );
+}
+
+/** Cross-distro C/C++ toolchain + python3. `node-pty` (Shepherd's PTY dep) ships
+ *  no prebuilt binary for every runtime, so `bun install` compiles it from source
+ *  via node-gyp; without a compiler the install fails and Shepherd never boots. */
+function ensureToolchain(): string {
+  return (
+    "command -v cc >/dev/null 2>&1 && command -v make >/dev/null 2>&1 || " +
+    "(apt-get update && apt-get install -y build-essential python3) || " +
+    "apk add --no-cache build-base python3 || " +
+    "dnf install -y gcc-c++ make python3 || " +
+    "pacman -Sy --noconfirm base-devel python3"
+  );
+}
+
 /** Commands that turn a fresh instance into a bootable-Shepherd baseline: bun
  *  runtime + the pushed working-tree build + deps + the claude CLI (agent path).
  *  Defects are layered AFTER this so degraded Shepherd can still boot. */
 function baselineCommands(): string[] {
   return [
-    "command -v curl >/dev/null 2>&1 || (apt-get update && apt-get install -y curl) || (apk add --no-cache curl) || (dnf install -y curl) || (pacman -Sy --noconfirm curl)",
+    ensurePkg("curl"),
+    // bun's installer hard-requires `unzip`; minimal images (debian/12) lack it,
+    // and without it the bun install silently no-ops and Shepherd never boots.
+    ensurePkg("unzip"),
+    ensureToolchain(),
     "curl -fsSL https://bun.sh/install | bash",
+    // node-gyp shells out to a BARE `bun` while building node-pty; the installer
+    // only adds bun to shell rc files (not the non-login exec PATH), so expose it
+    // on a system path or the native build fails with "bun: not found".
+    'ln -sf "$HOME/.bun/bin/bun" /usr/local/bin/bun',
+    // node-pty's install is `node scripts/prebuild.js || node-gyp rebuild`. When no
+    // prebuilt binary matches the instance (arch/fedora fall through to a rebuild),
+    // it needs `node-gyp` — which is only a node-pty *dev*dependency, so it isn't in
+    // node_modules/.bin. Install it globally + expose on PATH so the rebuild works.
+    '~/.bun/bin/bun add -g node-gyp && ln -sf "$HOME/.bun/bin/node-gyp" /usr/local/bin/node-gyp',
     `mkdir -p ${SHEPHERD_DIR} && tar -xf /root/shepherd.tar -C ${SHEPHERD_DIR}`,
     `cd ${SHEPHERD_DIR} && ~/.bun/bin/bun install`,
     // claude CLI for the agent apply path; harmless if a scenario removes it later.
@@ -26,18 +66,31 @@ export async function seedInstance(
 ): Promise<void> {
   await driver.launch(scenario.image, scenario.id, {
     vm: scenario.vm,
-    profile: "shep-onb",
+    profiles: PROFILES,
   });
-  // Wait for the instance's network/init to settle before exec.
+  // Wait for the instance's network to actually resolve DNS before the baseline
+  // hits the package mirrors. `/bin/sh` exists instantly, so the old test only
+  // proved the rootfs unpacked — on Arch, systemd-resolved comes up slower than
+  // on debian/fedora and `pacman -Sy` failed with "Could not resolve host". Poll
+  // a real resolution instead (skip on images without glibc `getent`, e.g. musl).
   await driver.exec(scenario.id, [
     "sh",
     "-c",
-    "for i in $(seq 1 30); do test -e /bin/sh && break; sleep 1; done",
+    "for i in $(seq 1 60); do command -v getent >/dev/null 2>&1 || break; " +
+      "getent hosts bun.sh >/dev/null 2>&1 && break; sleep 1; done",
   ]);
   await driver.push(scenario.id, tarballPath, "/root/shepherd.tar");
+  // Baseline steps are infrastructure: a failure here (e.g. bun didn't install)
+  // leaves a non-bootable instance, so surface it now instead of limping on to a
+  // misleading "Shepherd did not come up" 60s later.
   for (const cmd of baselineCommands()) {
-    await driver.exec(scenario.id, ["sh", "-c", cmd]);
+    const r = await driver.exec(scenario.id, ["sh", "-c", cmd]);
+    if (r.code !== 0) {
+      throw new Error(`baseline step failed (${scenario.id}): ${cmd}\n${r.stderr || r.stdout}`);
+    }
   }
+  // Scenario seed commands intentionally tolerate non-zero (e.g. removing a pkg
+  // that isn't present), so they are NOT checked.
   for (const cmd of scenario.seed) {
     await driver.exec(scenario.id, ["sh", "-c", cmd]);
   }

--- a/ci/onboarding-harness/shepherd-onboarding.service
+++ b/ci/onboarding-harness/shepherd-onboarding.service
@@ -6,3 +6,6 @@ After=network-online.target
 Type=oneshot
 WorkingDirectory=%h/Work/shepherd
 ExecStart=/usr/bin/env bun run onboarding:test
+# A oneshot start has no timeout by default — bound the whole nightly run so a
+# wedged scenario is killed instead of pinning the host lock indefinitely.
+TimeoutStartSec=2h

--- a/test/onboarding-harness/incus.test.ts
+++ b/test/onboarding-harness/incus.test.ts
@@ -12,14 +12,17 @@ function recorder(reply: Partial<IncusExec> = {}) {
 }
 
 describe("IncusDriver", () => {
-  it("launches a system container with the managed-name prefix and profile", async () => {
+  it("launches a system container with the managed-name prefix and STACKED profiles", async () => {
     const { calls, run } = recorder();
     const d = new IncusDriver(run, "shep-onb-");
-    await d.launch("images:ubuntu/24.04", "gh-unauthed", { profile: "shep-onb" });
+    await d.launch("images:ubuntu/24.04", "gh-unauthed", { profiles: ["default", "shep-onb"] });
+    // `default` MUST be stacked (not replaced) or the instance loses its root disk.
     expect(calls[0]).toEqual([
       "launch",
       "images:ubuntu/24.04",
       "shep-onb-gh-unauthed",
+      "--profile",
+      "default",
       "--profile",
       "shep-onb",
     ]);

--- a/test/onboarding-harness/probe.test.ts
+++ b/test/onboarding-harness/probe.test.ts
@@ -1,7 +1,24 @@
 import { describe, expect, it } from "bun:test";
 import { IncusDriver } from "../../ci/onboarding-harness/incus";
-import { probeDiagnostics } from "../../ci/onboarding-harness/probe";
+import { bootShepherd, probeDiagnostics } from "../../ci/onboarding-harness/probe";
 import type { IncusExec } from "../../ci/onboarding-harness/types";
+
+describe("bootShepherd", () => {
+  it("runs the entry file directly, detached, with installs visible on PATH", async () => {
+    const calls: string[][] = [];
+    const run = async (args: string[]): Promise<IncusExec> => {
+      calls.push(args);
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const d = new IncusDriver(run, "shep-onb-");
+    await bootShepherd(d, "node-too-old");
+    const boot = calls[0]!.join(" ");
+    expect(boot).toContain("src/index.ts"); // not the nested `bun run start` script
+    expect(boot).not.toContain("run start");
+    expect(boot).toContain("setsid"); // survives the exec session
+    expect(boot).toContain(".local/bin"); // remediation installs resolve on PATH
+  });
+});
 
 describe("probeDiagnostics", () => {
   it("curls the diagnostics endpoint inside the instance and parses the snapshot", async () => {

--- a/test/onboarding-harness/remediations.test.ts
+++ b/test/onboarding-harness/remediations.test.ts
@@ -7,6 +7,12 @@ describe("remediations catalog", () => {
     expect(REMEDIATIONS.diagnostics_hint_bun_missing).toContain("bun.sh/install");
   });
 
+  it("node remediation symlinks the new node onto the server's PATH (~/.local/bin), not just fnm's dir", () => {
+    // Regression: a bare `fnm install` leaves node off PATH, so the re-probe never
+    // sees it and the scenario can't reach green.
+    expect(REMEDIATIONS.diagnostics_hint_node_outdated).toContain(".local/bin/node");
+  });
+
   it("collects verbatim commands for non-ok checks that have one (skips prose-only and ok)", () => {
     const snap: DiagnosticsSnapshot = {
       checks: [

--- a/test/onboarding-harness/seed.test.ts
+++ b/test/onboarding-harness/seed.test.ts
@@ -28,6 +28,9 @@ describe("seedInstance", () => {
 
     expect(calls[0]![0]).toBe("launch");
     expect(calls[0]!).toContain("images:ubuntu/24.04");
+    // stacks default (root disk + NIC) under the shep-onb limits profile
+    expect(calls[0]!).toContain("default");
+    expect(calls[0]!).toContain("shep-onb");
 
     const flat = calls.map((c) => c.join(" "));
     // baseline installs bun before the scenario seed runs
@@ -35,6 +38,9 @@ describe("seedInstance", () => {
     const seedIdx = flat.findIndex((c) => c.includes("rm -rf ~/.config/gh"));
     expect(bunIdx).toBeGreaterThanOrEqual(0);
     expect(seedIdx).toBeGreaterThan(bunIdx);
+    // unzip (bun installer prereq) + a build toolchain (node-pty) are ensured
+    expect(flat.some((c) => c.includes("unzip"))).toBe(true);
+    expect(flat.some((c) => c.includes("build-essential"))).toBe(true);
   });
 
   it("pushes the Shepherd build tarball into the instance", async () => {


### PR DESCRIPTION
## Why

The onboarding harness from #644 had **never completed a single scenario**. Every test injects a fake Incus runner, so the real `launch → seed → boot → detect → apply → re-probe` path had never executed against a live host — the `shep-onb` profile didn't even exist on the dev host. Walking it through on a real Incus host surfaced a stack of blockers that each hung or failed the run. The promised nightly timer would have hung forever; the release gate would never have gone green.

This fixes the whole chain. The deterministic gate subset now reaches green on a live host:

```
herdr-missing | images:archlinux | Detected: yes | Applied: verbatim | Green: yes | PASS
claude-missing | images:fedora/42 | Detected: yes | Applied: verbatim | Green: yes | PASS
node-too-old  | images:debian/12 | Detected: yes | Applied: verbatim | Green: yes | PASS
```
`scripts/onboarding-gate.sh` → **3/3 green**.

## What was broken (each independently fatal)

**Driver (`incus.ts`)**
- `incus launch` **deadlocked forever** under `execFile`: the Go client parks every thread in `futex_wait` on an open stdin pipe for operation-streaming commands. Fixed by spawning with stdin `"ignore"` + a backstop kill timeout (there was none, so the hang was unbounded).
- `launch()` now **stacks** profiles — passing only `shep-onb` *replaced* `default` and stripped the root disk (`No root device could be found`).

**Baseline + boot (`seed.ts`, `probe.ts`)**
- Wait for **real DNS resolution**, not just `/bin/sh` (Arch's `pacman -Sy` raced systemd-resolved).
- Ensure `unzip` (bun-installer prereq), a **C toolchain** + **node-gyp** (node-pty compiles from source and its rebuild fallback needs node-gyp, which is only a devDependency), and expose `bun` on PATH for node-gyp.
- Boot `bun src/index.ts`, not `bun run start` (the package-script indirection lost `bun` from the non-login exec PATH); **`setsid`** so the server survives the exec session; add `~/.local/bin`/`~/.bun/bin` to the server PATH so remediated binaries are visible to its probes.
- Baseline failures now **fail loudly** instead of limping to a misleading "Shepherd did not come up".

**Remediations (`remediations.ts`)**
- The node fix **symlinks the new node onto the server's PATH**; a bare `fnm install` left it in fnm's dir, invisible to the running server, so the re-probe never saw it.

**Robustness (`run.ts`, `scenarios.ts`, service)**
- Release the host lock on **SIGINT/SIGTERM** (Node skips `finally` on signal-kill, leaking the lock and blocking all future runs at exit 3); `--reap-orphans` also clears a stale lock.
- Bump `claude-missing` `fedora/40 → fedora/42` (40 aged off the image remote).
- `shepherd-onboarding.service`: `TimeoutStartSec` so a wedged nightly run is killed instead of pinning the lock forever.

## Validation

Run live on a real Incus host (6.23): each gate scenario taken end-to-end to green; the full `onboarding-gate.sh` passes 3/3. Unit tests extended with regression guards (stacked profiles, boot invocation, node-on-PATH remediation). `tsc` + `lint` + harness tests green.

> Note: scenarios install tooling over the network (fnm/herdr/claude installers), so a transient download failure can flake a run (observed once on node-too-old, green on re-run). Inherent to a harness that exercises real installers; the gate is meant to be re-runnable.

[no-feature-entry] — CI tooling only, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)