### PR TITLE
feat(auth): ship API-key auth mode (footing B) as a first-class opt-in (#660)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -28,6 +28,11 @@ path on a sub. Shepherd's interactive-session substrate aims to be the **intende
 execution path** (per the position above, pending R1's resolution) for the whole ecosystem, not
 just a dashboard.
 
+**For operators who cannot accept the R1 ambiguity**, an API-key footing (B) is available as a
+shipped opt-in (v1.29.0, Settings → Session): still genuinely interactive, auth via Commercial
+Terms API key — the clearly-compliant, no-train-by-default path. See the
+[auth-path evaluation](docs/research/tos-position-and-auth-paths.md).
+
 ## 2. Goals / Non-goals
 
 **Goals**
@@ -47,8 +52,12 @@ just a dashboard.
 
 - No multi-user / team farming (ToS). Single operator, bring-your-own-Claude (sub).
 - No Agent SDK, no `claude -p` on a sub **by default** — but see the
-  [auth-path evaluation](docs/research/tos-position-and-auth-paths.md) (audit R1): a sanctioned
-  API-key / metered footing is offered as an opt-in for operators who need a clearly-compliant path.
+  [auth-path evaluation](docs/research/tos-position-and-auth-paths.md) (audit R1): **API-key auth
+  (footing B) is shipped as of v1.29.0** (Settings → Session → Auth Mode) as an opt-in for
+  operators who need a clearly-compliant path. Sessions remain genuinely interactive even in api-key
+  mode; only the auth channel changes (subscription OAuth → Commercial Terms API key, no-train-by-default,
+  R1 ambiguity resolved). Footing (C) — Agent SDK credit — remains out of scope; it reopens the
+  interactive-substrate thesis.
 - No cloud orchestration.
 
 ## 3. ToS compliance model (hard constraint)
@@ -59,12 +68,12 @@ just a dashboard.
 > and the [auth-path evaluation](docs/research/tos-position-and-auth-paths.md)). The table states
 > _how_ Shepherd operates; it does not assert the model is adjudicated-compliant.
 
-| Requirement                            | Mechanism                                                                         |
-| -------------------------------------- | --------------------------------------------------------------------------------- |
-| Sessions must be genuinely interactive | Real PTY via **herdr**, not `claude -p`                                           |
-| We observe, we don't impersonate       | Read terminal via `herdr agent read`; state via herdr agent-status + Claude hooks |
-| We steer by typing, like a human       | `herdr agent send` injects prompt text into the live pane                         |
-| Auth = the operator's own login        | `claude` uses operator's Max/Pro session; no token relay                          |
+| Requirement                            | Mechanism                                                                                                                         |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Sessions must be genuinely interactive | Real PTY via **herdr**, not `claude -p`                                                                                           |
+| We observe, we don't impersonate       | Read terminal via `herdr agent read`; state via herdr agent-status + Claude hooks                                                 |
+| We steer by typing, like a human       | `herdr agent send` injects prompt text into the live pane                                                                         |
+| Auth = the operator's own login        | Default: `claude` uses operator's Max/Pro subscription (OAuth); opt-in: API-key mode uses operator's Commercial Terms key instead |
 
 As a design default under this position, if a feature can't be done by _typing into a real
 terminal_, it doesn't ship — but this is Shepherd's posture, not adjudicated compliance (R1 open;

--- a/PRD.md
+++ b/PRD.md
@@ -29,7 +29,7 @@ execution path** (per the position above, pending R1's resolution) for the whole
 just a dashboard.
 
 **For operators who cannot accept the R1 ambiguity**, an API-key footing (B) is available as a
-shipped opt-in (v1.29.0, Settings → Session): still genuinely interactive, auth via Commercial
+shipped opt-in (v1.30.0, Settings → Session): still genuinely interactive, auth via Commercial
 Terms API key — the clearly-compliant, no-train-by-default path. See the
 [auth-path evaluation](docs/research/tos-position-and-auth-paths.md).
 
@@ -53,7 +53,7 @@ Terms API key — the clearly-compliant, no-train-by-default path. See the
 - No multi-user / team farming (ToS). Single operator, bring-your-own-Claude (sub).
 - No Agent SDK, no `claude -p` on a sub **by default** — but see the
   [auth-path evaluation](docs/research/tos-position-and-auth-paths.md) (audit R1): **API-key auth
-  (footing B) is shipped as of v1.29.0** (Settings → Session → Auth Mode) as an opt-in for
+  (footing B) is shipped as of v1.30.0** (Settings → Session → Auth Mode) as an opt-in for
   operators who need a clearly-compliant path. Sessions remain genuinely interactive even in api-key
   mode; only the auth channel changes (subscription OAuth → Commercial Terms API key, no-train-by-default,
   R1 ambiguity resolved). Footing (C) — Agent SDK credit — remains out of scope; it reopens the

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ live pane). Auth is the operator's own login; no token relay, no impersonation, 
 If a feature can't be done by typing into a real terminal, it doesn't ship. See `PRD.md` for the
 full rationale.
 
+Operators who need a clearly-compliant path — or who cannot accept the R1 ambiguity around
+keystroke-puppeting of interactive sessions — can opt into **API-key auth (footing B)** in Settings
+→ Session. In this mode Shepherd still drives genuine interactive `claude` sessions (NOT `claude -p`
+/ Agent SDK); only the auth changes from subscription OAuth to a metered Anthropic API key under the
+Commercial Terms, which explicitly exempts automated use from the §3 bot/script prohibition and is
+no-train-by-default. This closes both the R1 ambiguity and the R5 training-exposure. See
+[`docs/research/tos-position-and-auth-paths.md`](docs/research/tos-position-and-auth-paths.md) for
+the full evaluation.
+
 ## Your `/commands` come with you
 
 Because Shepherd attaches to a **genuine interactive `claude` session** running against your own
@@ -145,7 +154,7 @@ Shepherd can wrap each spawned `claude` process in an OS-level filesystem/proces
 
 - SSH-remote repos cannot `git push` from inside the membrane (the `~/.ssh` key dir is excluded). Use an HTTPS remote with the `gh` token instead.
 - MCP servers whose dependencies live outside the bound `$HOME` paths (e.g. a server installed in an arbitrary prefix) may fail to load inside the membrane.
-- The membrane relies on **OAuth/subscription auth** (`~/.claude/.credentials.json`, which it binds). `--clearenv` deliberately strips `ANTHROPIC_API_KEY` (and all other env), so a `claude` install that authenticates via that env var rather than OAuth will fail to authenticate inside `standard`/`autonomous` — and the node/git backend self-test won't catch it. This matches Shepherd's subscription-only ToS model; use OAuth login.
+- The membrane relies on **OAuth/subscription auth** (`~/.claude/.credentials.json`, which it binds) in the default **subscription mode**. `--clearenv` deliberately strips `ANTHROPIC_API_KEY` (and all other env), so a `claude` install that authenticates purely via that env var rather than OAuth will fail to authenticate inside `standard`/`autonomous`. In **api-key mode** (Settings → Session) this is reversed: the membrane instead masks the subscription credential with an empty overlay and injects the key via an `apiKeyHelper` script bound into the sandbox — the key is never passed as a raw env var.
 
 The membrane bind set is **host-derived** — Shepherd probes the node/claude install locations and `gh`/gitconfig paths at startup and uses `--bind-try` for optional paths, so no hardcoded path list needs maintenance.
 

--- a/docs/research/tos-position-and-auth-paths.md
+++ b/docs/research/tos-position-and-auth-paths.md
@@ -55,35 +55,44 @@ An operator can stand on any of three auth footings. None is pre-dismissed; each
 Recommend, do **not** mandate — the operator chooses their footing:
 
 - **Keep (A) as the default**, now wearing the honest, softened framing (R1 is Shepherd's _position_, not settled compliance — the PRD/PRODUCT softening lands this).
-- **Offer (B) as a first-class, clearly-compliant opt-in** for risk-averse operators who cannot accept R1's ambiguity. The Commercial/API path sidesteps the automation clause entirely and closes the training-by-default exposure; its cost is metered API rates and the architectural change in §4.
+- **Offer (B) as a first-class, clearly-compliant opt-in** for risk-averse operators who cannot accept R1's ambiguity. The Commercial/API path sidesteps the automation clause entirely and closes the training-by-default exposure; its cost is metered API rates and the architectural change now shipped in §4. **(B) is available as of v1.29.0 — Settings → Session → Auth Mode.)**
 - **Record (C) as the lowest-legal-risk, explicitly-permitted automation channel**, whose adoption is a deliberate **product decision** because it reopens the interactive-substrate thesis (§2(C)). Not recommended as default, but honestly the strongest R1 footing.
 
 **Internal-consistency flag.** Surfacing (B)/(C) revisits **PRD §2's non-goal**, whose original wording was the absolute _"No Agent SDK, no `claude -p`. Ever, on a sub."_ This work has softened that line from the absolute non-goal to a _by-default_ position that cross-refs this doc, so the two stay consistent; this doc names the tension plainly so neither ships a contradictory stance. If (C) is ever adopted, the §2 non-goal must be rewritten further, not silently left standing.
 
 ---
 
-## 4. Design sketch for (B) — API-key mode
+## 4. As-built: (B) API-key mode — shipped v1.29.0 (issue #660, closing R1 Action 3)
 
-> **NOT IMPLEMENTED — sketch for a future issue.** ADR-style outline only. No code in this PR.
+> **SHIPPED in v1.29.0 (issue #660, closing R1 Action 3 and also R5).** The sketch below has been superseded by the as-built notes. What follows is the accurate description of what shipped.
 
-**Shape.** An `authMode` setting: `subscription` (default, footing A) | `api-key` (footing B).
+**Shape.** A global operator setting `authMode`: `subscription` (default, footing A) | `api-key` (footing B). Env seed: `SHEPHERD_AUTH_MODE`. Configured in Settings → Session.
 
-- Under `api-key`, spawns pass `ANTHROPIC_API_KEY` (and may then use `--bare`) instead of relying on subscription OAuth.
-- The deliberate `NOT --bare` choices become **mode-conditional** at every spawn chokepoint:
-  - `src/reviewer-argv.ts` — the critic/plan-gate reviewer argv (currently refuses `--bare` by design).
-  - `src/namer-llm.ts` — the auto-namer spawn.
-  - `src/autopilot-llm.ts` — the autopilot stop-classifier spawn.
-- The autonomous **egress allowlist** (`src/egress.ts`, PR #601) is **unaffected** — `api.anthropic.com` is already on the allowlist regardless of auth mode.
-- The `/usage` probe (`src/usage-probe.ts`) is **subscription-only** (it parses subscription session JSONL / usage limits); under `api-key` it would **no-op** (or surface API-console billing instead — open question).
+**How key delivery works — NOT `--bare`.** All existing spawn flags are kept intact. The API key is not passed as a raw environment variable. Instead Shepherd writes a `0600` `apiKeyHelper` shell script and names it in the spawn's `--settings` JSON. Claude Code's `apiKeyHelper` mechanism invokes the script to retrieve the key at spawn time — so the key never appears in `ps` output, process environment, host logs, or the database (only the script path is stored).
 
-**Touch-points:** `authMode` setting + persistence; the three spawn builders above (mode-conditional `--bare` / env injection); `src/usage-probe.ts` no-op guard; settings UI surface; docs.
+**Credential masking — two paths by spawn type:**
 
-**Open design questions:**
+- **bwrap-membrane spawns** (`standard`/`autonomous` profile): the subscription credential (`~/.claude/.credentials.json`) is masked in-place via a last-wins `--overlay-tmp-upper` binding that presents an empty file; the `apiKeyHelper` is bound into the membrane. The spawned `claude` has no subscription credential to pick up and uses the key exclusively.
+- **Non-membraned spawns** (main interactive session, `trusted` profile): Shepherd provisions a credential-less `CLAUDE_CONFIG_DIR` — a symlink mirror of `~/.claude` with the credential file omitted — and sets that dir in the spawn. No subscription login is presented, so Claude's "Use custom API key" approval prompt cannot hang an unattended spawn.
 
-1. Per-operator global `authMode`, or per-repo / per-spawn-kind (e.g. cheap namer on sub, critic on API key)?
-2. Cost surfacing under `api-key` — where does spend show when `/usage` no-ops? API-console only, or a Shepherd-side meter?
-3. Key storage / scoping — env-only, or a settings-stored secret? Egress/secrets-handling review needed.
-4. Does footing (C) warrant a third `authMode` value (`agent-sdk-credit`), or is it out of scope for this sketch (it reopens the thesis — §2(C))?
+**Secondary spawns** (critic, plan-gate reviewer, namer, classifier, recap, distiller) all route through the same `apiKeyHelper` mechanism. None use `--bare`; hooks, skills, MCP, and `CLAUDE.md` are preserved exactly as in subscription mode.
+
+**Egress:** unaffected — `api.anthropic.com` was already on the autonomous-profile egress allowlist (PR #601) regardless of auth mode.
+
+**`/usage` under api-key:** the `/usage` probe is subscription-only (parses subscription session JSONL/limits). Under `api-key` it no-ops to an explicit "subscription-only" state — it does **not** show a fake zero meter. The UI surfaces a clear "subscription-only feature" message pointing the operator to the Anthropic Console for spend tracking.
+
+**Fail-closed:** `api-key` mode with no key configured refuses the main-session spawn outright and degrades secondary spawns to an error state. It **never** silently falls back to subscription billing.
+
+**Key custody:** operator pastes the key in Settings → Session; Shepherd writes the `0600` `apiKeyHelper` script and stores only its path. The raw key is never written to the DB, process env, or host logs.
+
+**Honest residual:** the `apiKeyHelper` script is readable (`cat`-able) by a hijacked in-sandbox agent — host `ps`/log hygiene only, not in-membrane secrecy. This is the same class as audit R3/R4 (in-membrane token readability, documented in commit ce6a4501 and [`docs/sandbox-security.md`](../sandbox-security.md)).
+
+**Resolved design questions (were open in the original sketch):**
+
+1. **Scope:** global `authMode` only (per-repo / per-spawn-kind granularity is a future extension, not shipped).
+2. **Cost surfacing:** minimal — `/usage` no-ops with a Console pointer; no Shepherd-side spend meter.
+3. **Key storage:** `apiKeyHelper` script path only; raw key never persisted in DB or env.
+4. **Footing (C):** excluded from scope — it reopens the interactive-substrate thesis (§2(C)) and remains a deliberate non-goal by default.
 
 ---
 

--- a/docs/research/tos-position-and-auth-paths.md
+++ b/docs/research/tos-position-and-auth-paths.md
@@ -55,16 +55,16 @@ An operator can stand on any of three auth footings. None is pre-dismissed; each
 Recommend, do **not** mandate — the operator chooses their footing:
 
 - **Keep (A) as the default**, now wearing the honest, softened framing (R1 is Shepherd's _position_, not settled compliance — the PRD/PRODUCT softening lands this).
-- **Offer (B) as a first-class, clearly-compliant opt-in** for risk-averse operators who cannot accept R1's ambiguity. The Commercial/API path sidesteps the automation clause entirely and closes the training-by-default exposure; its cost is metered API rates and the architectural change now shipped in §4. **(B) is available as of v1.29.0 — Settings → Session → Auth Mode.)**
+- **Offer (B) as a first-class, clearly-compliant opt-in** for risk-averse operators who cannot accept R1's ambiguity. The Commercial/API path sidesteps the automation clause entirely and closes the training-by-default exposure; its cost is metered API rates and the architectural change now shipped in §4. **(B) is available as of v1.30.0 — Settings → Session → Auth Mode.)**
 - **Record (C) as the lowest-legal-risk, explicitly-permitted automation channel**, whose adoption is a deliberate **product decision** because it reopens the interactive-substrate thesis (§2(C)). Not recommended as default, but honestly the strongest R1 footing.
 
 **Internal-consistency flag.** Surfacing (B)/(C) revisits **PRD §2's non-goal**, whose original wording was the absolute _"No Agent SDK, no `claude -p`. Ever, on a sub."_ This work has softened that line from the absolute non-goal to a _by-default_ position that cross-refs this doc, so the two stay consistent; this doc names the tension plainly so neither ships a contradictory stance. If (C) is ever adopted, the §2 non-goal must be rewritten further, not silently left standing.
 
 ---
 
-## 4. As-built: (B) API-key mode — shipped v1.29.0 (issue #660, closing R1 Action 3)
+## 4. As-built: (B) API-key mode — shipped v1.30.0 (issue #660, closing R1 Action 3)
 
-> **SHIPPED in v1.29.0 (issue #660, closing R1 Action 3 and also R5).** The sketch below has been superseded by the as-built notes. What follows is the accurate description of what shipped.
+> **SHIPPED in v1.30.0 (issue #660, closing R1 Action 3 and also R5).** The sketch below has been superseded by the as-built notes. What follows is the accurate description of what shipped.
 
 **Shape.** A global operator setting `authMode`: `subscription` (default, footing A) | `api-key` (footing B). Env seed: `SHEPHERD_AUTH_MODE`. Configured in Settings → Session.
 

--- a/src/auth-config-dir.ts
+++ b/src/auth-config-dir.ts
@@ -10,33 +10,50 @@
  * its config dir (skills, commands, CLAUDE.md, plugins, settings.json,
  * onboarding/theme state, statsig/, projects/, todos/, shell-snapshots/).
  *
- * Mechanism: build a mirror dir that symlinks every entry from the operator's
- * real `~/.claude` EXCEPT `.credentials.json`. Callers set `CLAUDE_CONFIG_DIR`
- * to this mirror for every api-key spawn. Symlinks keep the mirror "live" and
- * cheap — no file copying, changes in the source propagate instantly.
+ * Mechanism: build a mirror dir that (a) symlinks every entry from the operator's
+ * real `~/.claude` EXCEPT `.credentials.json`, and (b) COPIES in `$HOME/.claude.json`
+ * (see {@link CONFIG_FILE}). Callers set `CLAUDE_CONFIG_DIR` to this mirror for every
+ * api-key spawn. The symlinks keep skills/commands/CLAUDE.md/plugins/settings live and
+ * cheap; the credential file is absent so the spawn is "not logged in" and authenticates
+ * via `--settings apiKeyHelper` instead — with no "Use custom API key?" prompt.
  *
- * Residual / open question: `~/.claude.json` (at HOME, outside CLAUDE_CONFIG_DIR)
- * may carry an `oauthAccount` display field. The actual auth TOKEN lives only in
- * `.credentials.json`; omitting that file is the documented mechanism for
- * "no login." Whether `oauthAccount` metadata alone causes Claude Code to show a
- * login-related prompt in practice has not been verified with a live api-key spawn
- * — if prompted, callers should also override HOME or create a HOME shim that
- * omits `~/.claude.json`. That is NOT handled here.
+ * Why `.claude.json` is copied, not symlinked: Claude Code writes to it (onboarding/
+ * project state), and symlinking would mutate — and race the live shepherd on — the
+ * operator's real config. A snapshot copy is isolated and refreshed each provision.
+ *
+ * Verified with a live api-key spawn: a config dir holding a copied `.claude.json`
+ * (with its `oauthAccount` field) but NO `.credentials.json` reports "Not logged in",
+ * and an `apiKeyHelper` then authenticates with no approval prompt — so `oauthAccount`
+ * metadata is not itself a login and no HOME shim is needed.
  */
 
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
+  copyFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
   readdirSync,
   readlinkSync,
+  renameSync,
   rmSync,
   symlinkSync,
 } from "node:fs";
 
 /** The OAuth token file — its absence is what makes a config dir "not logged in." */
 export const CREDENTIAL_FILE = ".credentials.json";
+
+/**
+ * Claude Code's config/state file. It lives at `$HOME/.claude.json` — a SIBLING of
+ * `~/.claude`, NOT a child — so the symlink mirror never picks it up. But when
+ * `CLAUDE_CONFIG_DIR` is set, Claude Code reads `.claude.json` from THAT dir (not
+ * `$HOME`), so the mirror must provide one or the spawn fails to start ("configuration
+ * file not found"). We copy it in (see below). Safe: the OAuth token is in
+ * `.credentials.json` (excluded) — `.claude.json` only carries config + onboarding/trust
+ * state + an `oauthAccount` DISPLAY field, which is NOT a login (a config dir with
+ * `.claude.json` but no `.credentials.json` reports "Not logged in").
+ */
+export const CONFIG_FILE = ".claude.json";
 
 /**
  * Canonical location for the credential-less mirror, nested under Shepherd's
@@ -94,6 +111,10 @@ export function provisionApiKeyConfigDir(opts: {
   // ── 3. Guarantee no credential file in dest ───────────────────────────────
   _removeCredentialIfPresent(destDir);
 
+  // ── 4. Provide .claude.json (a HOME sibling, never mirrored above) ─────────
+  // Claude reads it from CLAUDE_CONFIG_DIR, so the spawn can't start without it.
+  _copyConfigFile(sourceClaudeDir, destDir);
+
   return destDir;
 }
 
@@ -123,6 +144,9 @@ function _pruneStaleDestEntry(
     _tryRemove(destEntryPath);
     return;
   }
+  // .claude.json is a copied HOME sibling (step 4), not a mirrored source child —
+  // it would otherwise look "stale" (absent from sourceEntries) and be pruned. Keep it.
+  if (entry === CONFIG_FILE) return;
   const isStale = !ctx.sourceEntries.has(entry);
   if (isStale || !_isSymlinkTo(destEntryPath, join(ctx.sourceClaudeDir, entry))) {
     _tryRemove(destEntryPath);
@@ -168,6 +192,26 @@ export function ensureApiKeyConfigDir(home: string, sourceClaudeDir: string): st
 
 function _removeCredentialIfPresent(dir: string): void {
   rmSync(join(dir, CREDENTIAL_FILE), { force: true });
+}
+
+/**
+ * Copy `$HOME/.claude.json` (sibling of `sourceClaudeDir`) into `destDir`.
+ * Written via a per-process temp file + atomic rename so a concurrent spawn
+ * reading the shared mirror never sees a torn/partial config. Best-effort: if the
+ * source is absent or the copy fails, leave any existing copy and let Claude Code
+ * recreate/onboard. Never throws.
+ */
+function _copyConfigFile(sourceClaudeDir: string, destDir: string): void {
+  const src = join(dirname(sourceClaudeDir), CONFIG_FILE);
+  if (!existsSync(src)) return;
+  const dest = join(destDir, CONFIG_FILE);
+  const tmp = `${dest}.tmp.${process.pid}`;
+  try {
+    copyFileSync(src, tmp);
+    renameSync(tmp, dest);
+  } catch {
+    _tryRemove(tmp); // clean a half-written temp; keep any prior good copy
+  }
 }
 
 function _tryRemove(p: string): void {

--- a/src/auth-config-dir.ts
+++ b/src/auth-config-dir.ts
@@ -1,0 +1,173 @@
+/**
+ * Credential-less CLAUDE_CONFIG_DIR provisioning for api-key spawns.
+ *
+ * Invariant: a spawn in "api-key" auth mode must NOT see the operator's
+ * OAuth token (`.credentials.json`) — if it does, Claude Code presents an
+ * interactive "Use custom API key?" approval prompt that hangs an unattended
+ * process. The API key itself arrives separately via `--settings apiKeyHelper`
+ * (see auth-mode.ts). This module's sole job is to remove the credential
+ * surface while preserving everything else that Claude Code expects to find in
+ * its config dir (skills, commands, CLAUDE.md, plugins, settings.json,
+ * onboarding/theme state, statsig/, projects/, todos/, shell-snapshots/).
+ *
+ * Mechanism: build a mirror dir that symlinks every entry from the operator's
+ * real `~/.claude` EXCEPT `.credentials.json`. Callers set `CLAUDE_CONFIG_DIR`
+ * to this mirror for every api-key spawn. Symlinks keep the mirror "live" and
+ * cheap — no file copying, changes in the source propagate instantly.
+ *
+ * Residual / open question: `~/.claude.json` (at HOME, outside CLAUDE_CONFIG_DIR)
+ * may carry an `oauthAccount` display field. The actual auth TOKEN lives only in
+ * `.credentials.json`; omitting that file is the documented mechanism for
+ * "no login." Whether `oauthAccount` metadata alone causes Claude Code to show a
+ * login-related prompt in practice has not been verified with a live api-key spawn
+ * — if prompted, callers should also override HOME or create a HOME shim that
+ * omits `~/.claude.json`. That is NOT handled here.
+ */
+
+import { join } from "node:path";
+import { existsSync, lstatSync, mkdirSync, readdirSync, rmSync, symlinkSync } from "node:fs";
+
+/** The OAuth token file — its absence is what makes a config dir "not logged in." */
+export const CREDENTIAL_FILE = ".credentials.json";
+
+/**
+ * Canonical location for the credential-less mirror, nested under Shepherd's
+ * existing state dir convention (`~/.shepherd/…`).
+ */
+export function apiKeyConfigDir(home: string): string {
+  return join(home, ".shepherd", "claude-apikey-config");
+}
+
+/**
+ * (Re)build `destDir` as a symlink-mirror of `sourceClaudeDir` that omits
+ * `CREDENTIAL_FILE`. Idempotent and self-healing:
+ *
+ *  - Stale entries in `destDir` (no longer present in `sourceClaudeDir`, or
+ *    previously-present real files/dirs left by bad prior state) are removed.
+ *  - For each entry in `sourceClaudeDir` except `CREDENTIAL_FILE`, a symlink
+ *    pointing at the absolute source path is created (or left if already correct).
+ *  - `destDir/.credentials.json` is explicitly removed even if somehow present.
+ *  - If `sourceClaudeDir` does not exist, an empty `destDir` is created and
+ *    returned (graceful degrade — a fresh, login-less config dir).
+ *
+ * Never copies file contents. Returns `destDir`.
+ */
+export function provisionApiKeyConfigDir(opts: {
+  sourceClaudeDir: string;
+  destDir: string;
+}): string {
+  const { sourceClaudeDir, destDir } = opts;
+
+  mkdirSync(destDir, { recursive: true });
+
+  if (!existsSync(sourceClaudeDir)) {
+    // Degrade: source missing → just guarantee an empty credential-less dir.
+    _removeCredentialIfPresent(destDir);
+    return destDir;
+  }
+
+  const sourceEntries = new Set(readdirSync(sourceClaudeDir));
+
+  // ── 1. Clean up destDir ───────────────────────────────────────────────────
+  // Remove entries that are either stale (no longer in source) or were left as
+  // real files/dirs by a previous bad provisioning run. Always skip
+  // CREDENTIAL_FILE — we'll enforce its absence separately.
+  let destEntries: string[];
+  try {
+    destEntries = readdirSync(destDir);
+  } catch {
+    destEntries = [];
+  }
+
+  for (const entry of destEntries) {
+    if (entry === CREDENTIAL_FILE) {
+      // Handled explicitly below — remove unconditionally.
+      _tryRemove(join(destDir, entry));
+      continue;
+    }
+
+    const destEntryPath = join(destDir, entry);
+    const sourcePath = join(sourceClaudeDir, entry);
+
+    const isStale = !sourceEntries.has(entry);
+    let isCorrectSymlink = false;
+
+    if (!isStale) {
+      try {
+        const stat = lstatSync(destEntryPath);
+        if (stat.isSymbolicLink()) {
+          // We'll re-create below if needed; for now just check if it points right.
+          isCorrectSymlink = true;
+        }
+      } catch {
+        // lstat failed — treat as not a correct symlink; fall through to remove.
+      }
+    }
+
+    if (isStale || !isCorrectSymlink) {
+      _tryRemove(destEntryPath);
+    }
+    void sourcePath; // suppress unused warning
+  }
+
+  // ── 2. Create symlinks for all source entries except CREDENTIAL_FILE ──────
+  for (const entry of sourceEntries) {
+    if (entry === CREDENTIAL_FILE) continue;
+
+    const sourcePath = join(sourceClaudeDir, entry);
+    const destEntryPath = join(destDir, entry);
+
+    // If a correct symlink already exists, skip it.
+    try {
+      const stat = lstatSync(destEntryPath);
+      if (stat.isSymbolicLink()) {
+        continue; // already linked — leave it
+      }
+      // It's a real file/dir (shouldn't happen after step 1, but be defensive).
+      _tryRemove(destEntryPath);
+    } catch {
+      // Entry doesn't exist — fall through to create.
+    }
+
+    try {
+      symlinkSync(sourcePath, destEntryPath);
+    } catch {
+      // Best-effort per entry; don't abort the whole provisioning loop.
+    }
+  }
+
+  // ── 3. Guarantee no credential file in dest ───────────────────────────────
+  _removeCredentialIfPresent(destDir);
+
+  return destDir;
+}
+
+/**
+ * Convenience wrapper: provisions the canonical api-key config dir for `home`
+ * mirroring `sourceClaudeDir`. Returns the destDir path.
+ */
+export function ensureApiKeyConfigDir(home: string, sourceClaudeDir: string): string {
+  return provisionApiKeyConfigDir({
+    sourceClaudeDir,
+    destDir: apiKeyConfigDir(home),
+  });
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function _removeCredentialIfPresent(dir: string): void {
+  const credPath = join(dir, CREDENTIAL_FILE);
+  try {
+    rmSync(credPath, { force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+function _tryRemove(p: string): void {
+  try {
+    rmSync(p, { recursive: true, force: true });
+  } catch {
+    // best-effort; a single entry failure must not abort the loop
+  }
+}

--- a/src/auth-config-dir.ts
+++ b/src/auth-config-dir.ts
@@ -25,7 +25,15 @@
  */
 
 import { join } from "node:path";
-import { existsSync, lstatSync, mkdirSync, readdirSync, rmSync, symlinkSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
 
 /** The OAuth token file — its absence is what makes a config dir "not logged in." */
 export const CREDENTIAL_FILE = ".credentials.json";
@@ -69,15 +77,11 @@ export function provisionApiKeyConfigDir(opts: {
   const sourceEntries = new Set(readdirSync(sourceClaudeDir));
 
   // ── 1. Clean up destDir ───────────────────────────────────────────────────
-  // Remove entries that are either stale (no longer in source) or were left as
-  // real files/dirs by a previous bad provisioning run. Always skip
-  // CREDENTIAL_FILE — we'll enforce its absence separately.
-  let destEntries: string[];
-  try {
-    destEntries = readdirSync(destDir);
-  } catch {
-    destEntries = [];
-  }
+  // Remove entries that are either stale (no longer in source), were left as
+  // real files/dirs by a previous bad provisioning run, or are symlinks
+  // pointing at the wrong absolute path. Always skip CREDENTIAL_FILE — we'll
+  // enforce its absence separately.
+  const destEntries = readdirSync(destDir);
 
   for (const entry of destEntries) {
     if (entry === CREDENTIAL_FILE) {
@@ -96,18 +100,17 @@ export function provisionApiKeyConfigDir(opts: {
       try {
         const stat = lstatSync(destEntryPath);
         if (stat.isSymbolicLink()) {
-          // We'll re-create below if needed; for now just check if it points right.
-          isCorrectSymlink = true;
+          // Correct only if the symlink target matches the intended source path.
+          isCorrectSymlink = readlinkSync(destEntryPath) === sourcePath;
         }
       } catch {
-        // lstat failed — treat as not a correct symlink; fall through to remove.
+        // lstat/readlink failed — treat as not a correct symlink; fall through to remove.
       }
     }
 
     if (isStale || !isCorrectSymlink) {
       _tryRemove(destEntryPath);
     }
-    void sourcePath; // suppress unused warning
   }
 
   // ── 2. Create symlinks for all source entries except CREDENTIAL_FILE ──────
@@ -120,10 +123,10 @@ export function provisionApiKeyConfigDir(opts: {
     // If a correct symlink already exists, skip it.
     try {
       const stat = lstatSync(destEntryPath);
-      if (stat.isSymbolicLink()) {
-        continue; // already linked — leave it
+      if (stat.isSymbolicLink() && readlinkSync(destEntryPath) === sourcePath) {
+        continue; // already linked to the right target — leave it
       }
-      // It's a real file/dir (shouldn't happen after step 1, but be defensive).
+      // Wrong target or a real file/dir (shouldn't happen after step 1, but be defensive).
       _tryRemove(destEntryPath);
     } catch {
       // Entry doesn't exist — fall through to create.
@@ -156,12 +159,7 @@ export function ensureApiKeyConfigDir(home: string, sourceClaudeDir: string): st
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 function _removeCredentialIfPresent(dir: string): void {
-  const credPath = join(dir, CREDENTIAL_FILE);
-  try {
-    rmSync(credPath, { force: true });
-  } catch {
-    // best-effort
-  }
+  rmSync(join(dir, CREDENTIAL_FILE), { force: true });
 }
 
 function _tryRemove(p: string): void {

--- a/src/auth-config-dir.ts
+++ b/src/auth-config-dir.ts
@@ -81,68 +81,76 @@ export function provisionApiKeyConfigDir(opts: {
   // real files/dirs by a previous bad provisioning run, or are symlinks
   // pointing at the wrong absolute path. Always skip CREDENTIAL_FILE — we'll
   // enforce its absence separately.
-  const destEntries = readdirSync(destDir);
-
-  for (const entry of destEntries) {
-    if (entry === CREDENTIAL_FILE) {
-      // Handled explicitly below — remove unconditionally.
-      _tryRemove(join(destDir, entry));
-      continue;
-    }
-
-    const destEntryPath = join(destDir, entry);
-    const sourcePath = join(sourceClaudeDir, entry);
-
-    const isStale = !sourceEntries.has(entry);
-    let isCorrectSymlink = false;
-
-    if (!isStale) {
-      try {
-        const stat = lstatSync(destEntryPath);
-        if (stat.isSymbolicLink()) {
-          // Correct only if the symlink target matches the intended source path.
-          isCorrectSymlink = readlinkSync(destEntryPath) === sourcePath;
-        }
-      } catch {
-        // lstat/readlink failed — treat as not a correct symlink; fall through to remove.
-      }
-    }
-
-    if (isStale || !isCorrectSymlink) {
-      _tryRemove(destEntryPath);
-    }
+  for (const entry of readdirSync(destDir)) {
+    _pruneStaleDestEntry(entry, { sourceClaudeDir, destDir, sourceEntries });
   }
 
   // ── 2. Create symlinks for all source entries except CREDENTIAL_FILE ──────
   for (const entry of sourceEntries) {
     if (entry === CREDENTIAL_FILE) continue;
-
-    const sourcePath = join(sourceClaudeDir, entry);
-    const destEntryPath = join(destDir, entry);
-
-    // If a correct symlink already exists, skip it.
-    try {
-      const stat = lstatSync(destEntryPath);
-      if (stat.isSymbolicLink() && readlinkSync(destEntryPath) === sourcePath) {
-        continue; // already linked to the right target — leave it
-      }
-      // Wrong target or a real file/dir (shouldn't happen after step 1, but be defensive).
-      _tryRemove(destEntryPath);
-    } catch {
-      // Entry doesn't exist — fall through to create.
-    }
-
-    try {
-      symlinkSync(sourcePath, destEntryPath);
-    } catch {
-      // Best-effort per entry; don't abort the whole provisioning loop.
-    }
+    _ensureSourceSymlink(entry, { sourceClaudeDir, destDir });
   }
 
   // ── 3. Guarantee no credential file in dest ───────────────────────────────
   _removeCredentialIfPresent(destDir);
 
   return destDir;
+}
+
+/**
+ * Whether `path` is a symlink whose target is exactly `expectedTarget`.
+ * Swallows lstat/readlink failures (missing entry, perms) → `false`.
+ */
+function _isSymlinkTo(path: string, expectedTarget: string): boolean {
+  try {
+    return lstatSync(path).isSymbolicLink() && readlinkSync(path) === expectedTarget;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Step-1 per-entry cleanup: remove a dest entry that is stale (gone from
+ * source), a leftover real file/dir, or a symlink to the wrong target.
+ * CREDENTIAL_FILE is always removed (enforced absent in step 3).
+ */
+function _pruneStaleDestEntry(
+  entry: string,
+  ctx: { sourceClaudeDir: string; destDir: string; sourceEntries: Set<string> },
+): void {
+  const destEntryPath = join(ctx.destDir, entry);
+  if (entry === CREDENTIAL_FILE) {
+    _tryRemove(destEntryPath);
+    return;
+  }
+  const isStale = !ctx.sourceEntries.has(entry);
+  if (isStale || !_isSymlinkTo(destEntryPath, join(ctx.sourceClaudeDir, entry))) {
+    _tryRemove(destEntryPath);
+  }
+}
+
+/**
+ * Step-2 per-entry linking: ensure `destDir/entry` is a symlink to the source
+ * entry. Leaves an already-correct symlink untouched; otherwise removes any
+ * leftover and (re)creates the link best-effort (a single failure never aborts
+ * the loop).
+ */
+function _ensureSourceSymlink(
+  entry: string,
+  ctx: { sourceClaudeDir: string; destDir: string },
+): void {
+  const sourcePath = join(ctx.sourceClaudeDir, entry);
+  const destEntryPath = join(ctx.destDir, entry);
+
+  if (_isSymlinkTo(destEntryPath, sourcePath)) return; // already correct — leave it
+
+  // Wrong target or a real file/dir (shouldn't happen after step 1, but be defensive).
+  _tryRemove(destEntryPath);
+  try {
+    symlinkSync(sourcePath, destEntryPath);
+  } catch {
+    // Best-effort per entry; don't abort the whole provisioning loop.
+  }
 }
 
 /**

--- a/src/auth-mode.ts
+++ b/src/auth-mode.ts
@@ -1,0 +1,134 @@
+/**
+ * Server-side source of truth for the persisted auth-mode SETTING value space
+ * and its mapping to spawn settings.
+ *
+ * The SETTING space is: "subscription" | "api-key".
+ *   - "subscription" (default) — spawned claude authenticates via the operator's
+ *     OAuth subscription (Claude.ai Pro / Max). No extra spawn settings needed.
+ *   - "api-key" — spawned claude authenticates against an Anthropic API key
+ *     (Commercial Terms, footing B). The key is supplied via an apiKeyHelper
+ *     executable that prints it to stdout; Shepherd writes that helper and
+ *     stores ONLY its path, never the raw key.
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ── value space ───────────────────────────────────────────────────────────────
+
+export type AuthMode = "subscription" | "api-key";
+
+export const AUTH_MODES: readonly AuthMode[] = ["subscription", "api-key"] as const;
+
+export function isAuthMode(v: unknown): v is AuthMode {
+  return typeof v === "string" && (AUTH_MODES as readonly string[]).includes(v);
+}
+
+/**
+ * Normalize an arbitrary value (env var, DB row, request body) to a valid
+ * AuthMode, or null if the value is unrecognised / wrong type.
+ * Accepted: "subscription", "api-key". Everything else → null.
+ */
+export function normalizeAuthModeSetting(value: unknown): AuthMode | null {
+  if (typeof value !== "string") return null;
+  return isAuthMode(value) ? value : null;
+}
+
+// ── apiKeyHelper filesystem lifecycle ─────────────────────────────────────────
+
+/** Well-known filename for the helper script written into the config dir. */
+export const API_KEY_HELPER_FILE = "anthropic-api-key-helper.sh";
+
+/**
+ * Escape a string for safe embedding inside POSIX single-quotes.
+ * Single quotes cannot appear inside a single-quoted string; the idiom to
+ * include one is: end the single-quoted string, emit a \'-escaped quote,
+ * then restart the single-quoted string.  e.g. "a'b" → 'a'\''b'
+ */
+function singleQuoteShell(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+/**
+ * Write an executable helper script into `dir` (created if missing) that
+ * prints EXACTLY `key` to stdout when executed. The key is embedded safely
+ * via POSIX single-quote escaping so shell metacharacters cannot escape.
+ * Returns the absolute path of the written script.
+ *
+ * Throws if `key` is empty or whitespace-only.
+ */
+export function writeApiKeyHelper(key: string, dir: string): string {
+  if (!key || !key.trim()) throw new Error("API key must be a non-empty, non-whitespace string");
+
+  mkdirSync(dir, { recursive: true });
+
+  const scriptPath = join(dir, API_KEY_HELPER_FILE);
+  const script = `#!/bin/sh\nprintf '%s' ${singleQuoteShell(key)}\n`;
+  writeFileSync(scriptPath, script, { mode: 0o700 });
+
+  return scriptPath;
+}
+
+/**
+ * Return the helper path if the script exists in `dir`, otherwise null.
+ * Safe to call when `dir` does not exist (returns null).
+ */
+export function readApiKeyHelperPath(dir: string): string | null {
+  const scriptPath = join(dir, API_KEY_HELPER_FILE);
+  try {
+    return existsSync(scriptPath) ? scriptPath : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort remove the helper script from `dir`. Never throws.
+ */
+export function clearApiKeyHelper(dir: string): void {
+  const scriptPath = join(dir, API_KEY_HELPER_FILE);
+  try {
+    rmSync(scriptPath, { force: true });
+  } catch {
+    // best-effort; ignore missing file or dir
+  }
+}
+
+// ── spawn settings ────────────────────────────────────────────────────────────
+
+/**
+ * Return the fragment of a claude --settings JSON that wires up apiKeyHelper
+ * authentication. Callers spread this into their settings object.
+ *
+ * Returns `{ apiKeyHelper: helperPath }` ONLY when mode is "api-key" AND
+ * `helperPath` is a non-empty string; otherwise returns `{}`.
+ *
+ * The empty-object-on-subscription contract is LOAD-BEARING: it guarantees
+ * the subscription default produces byte-for-byte-identical --settings (no
+ * extra keys) when callers spread the result.
+ */
+export function spawnAuthSettings(
+  authMode: AuthMode,
+  helperPath: string | null,
+): { apiKeyHelper?: string } {
+  if (authMode === "api-key" && helperPath && helperPath.length > 0) {
+    return { apiKeyHelper: helperPath };
+  }
+  return {};
+}
+
+// ── log scrubbing ─────────────────────────────────────────────────────────────
+
+/**
+ * Conservative regex matching Anthropic API key patterns (`sk-ant-` followed
+ * by key-ish characters). Used to scrub keys from log strings.
+ */
+const API_KEY_RE = /sk-ant-[A-Za-z0-9_-]+/g;
+
+/**
+ * Replace any `sk-ant-…`-style Anthropic key occurrences in `s` with a
+ * redaction marker. Leaves all other text intact.
+ */
+export function redactKey(s: string): string {
+  return s.replace(API_KEY_RE, "sk-ant-***");
+}

--- a/src/auth-mode.ts
+++ b/src/auth-mode.ts
@@ -116,19 +116,3 @@ export function spawnAuthSettings(
   }
   return {};
 }
-
-// ── log scrubbing ─────────────────────────────────────────────────────────────
-
-/**
- * Conservative regex matching Anthropic API key patterns (`sk-ant-` followed
- * by key-ish characters). Used to scrub keys from log strings.
- */
-const API_KEY_RE = /sk-ant-[A-Za-z0-9_-]+/g;
-
-/**
- * Replace any `sk-ant-…`-style Anthropic key occurrences in `s` with a
- * redaction marker. Leaves all other text intact.
- */
-export function redactKey(s: string): string {
-  return s.replace(API_KEY_RE, "sk-ant-***");
-}

--- a/src/autopilot-llm.ts
+++ b/src/autopilot-llm.ts
@@ -4,6 +4,12 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { HerdrDriver } from "./herdr";
 import type { AutopilotVerdict, AutopilotKind } from "./types";
+import {
+  isApiKeyMode,
+  isApiKeyConfigured,
+  apiKeySettingsFragment,
+  apiKeyPassthroughEnv,
+} from "./spawn-auth";
 
 /** The file the classifier agent writes its verdict JSON to, in its temp cwd. */
 export const VERDICT_FILE = ".shepherd-autopilot.json";
@@ -88,7 +94,8 @@ function defaultCleanup(cwd: string): void {
  * (src/namer-llm.ts) and critic: clean context (disableAllHooks + disable-slash-commands),
  * subscription OAuth (NOT --bare), bare `Write` (scoped Write denied under dontAsk),
  * and --permission-mode dontAsk LAST (after the variadic --allowedTools, before the
- * trailing prompt). Don't reorder.
+ * trailing prompt). Don't reorder. In api-key auth mode the key arrives via apiKeyHelper
+ * in --settings (folded in) + a credential-less CLAUDE_CONFIG_DIR — still NOT --bare.
  */
 function classifierArgv(model: string | null, prompt: string): string[] {
   const argv = [
@@ -96,7 +103,8 @@ function classifierArgv(model: string | null, prompt: string): string[] {
     "--session-id",
     randomUUID(),
     "--settings",
-    '{"disableAllHooks":true}',
+    // subscription → byte-identical `{"disableAllHooks":true}`; api-key folds in apiKeyHelper.
+    JSON.stringify({ disableAllHooks: true, ...apiKeySettingsFragment() }),
     "--disable-slash-commands",
     "--allowedTools",
     "Write",
@@ -163,13 +171,22 @@ export async function classifyStop(
     pollMs = 1_000,
   } = deps;
 
+  // Fail closed: api-key mode without a configured key must NOT bill the subscription —
+  // surface to the operator rather than auto-classifying on the wrong footing.
+  if (isApiKeyMode() && !isApiKeyConfigured()) return SURFACE;
+
   let cwd: string | null = null;
   let terminalId: string | null = null;
   try {
     cwd = makeTmpDir();
     const prompt = classifierPrompt(tail, taskPrompt);
     try {
-      terminalId = deps.herdr.start(label, cwd, classifierArgv(model, prompt)).terminalId;
+      terminalId = deps.herdr.start(
+        label,
+        cwd,
+        classifierArgv(model, prompt),
+        apiKeyPassthroughEnv(false),
+      ).terminalId;
     } catch {
       return SURFACE; // herdr/claude unavailable → surface (don't auto-proceed blind)
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "node:path";
 import { resolveNodeBin } from "./node-bin";
 import { loadForgeMap } from "./forge/load-config";
 import { normalizeDefaultModelSetting } from "./default-model";
+import { normalizeAuthModeSetting } from "./auth-mode";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
 
 const dbPath = process.env.SHEPHERD_DB ?? `${process.env.HOME}/.shepherd/shepherd.db`;
@@ -383,6 +384,12 @@ export const config = {
   // value applies to both the New Task picker and drain/autopilot auto-spawns. Env seeds
   // a fresh DB; absent/invalid → "auto".
   defaultModel: normalizeDefaultModelSetting(process.env.SHEPHERD_DEFAULT_MODEL) ?? "auto",
+  // Operator auth footing for spawned agents. 'subscription' (default) = subscription OAuth;
+  // 'api-key' = bill against an Anthropic API key. Persisted + UI-configurable; env seeds a fresh DB.
+  authMode: normalizeAuthModeSetting(process.env.SHEPHERD_AUTH_MODE) ?? "subscription",
+  // Path to the apiKeyHelper script (written by Shepherd when the operator supplies a key).
+  // null = no key configured. The raw key is NEVER stored — only this script path.
+  authApiKeyHelperPath: (process.env.SHEPHERD_API_KEY_HELPER_PATH ?? null) as string | null,
   // Account-wide extra-credit (paid pay-as-you-go overage) spend ceiling, in account
   // currency units. Auto-drain/autopilot pauses when measured spend strictly exceeds it.
   // Persisted + UI-configurable; env seeds a fresh DB. Default 0 = pause on ANY spend.

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -5,6 +5,12 @@ import { tmpdir } from "node:os";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import type { Signal, SignalKind } from "./types";
+import {
+  isApiKeyMode,
+  isApiKeyConfigured,
+  apiKeySettingsFragment,
+  apiKeyPassthroughEnv,
+} from "./spawn-auth";
 
 const PROPOSALS_FILE = ".shepherd-learnings.json";
 
@@ -120,6 +126,14 @@ export class DistillerService {
 
   private begin(repoPath: string, signals: Signal[]): void {
     const { dir } = this.deps.scratch.create();
+    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
+    if (isApiKeyMode() && !isApiKeyConfigured()) {
+      console.warn(
+        "[distill] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
+      );
+      this.deps.scratch.remove(dir);
+      return;
+    }
     // Include dismissed rules in the "do NOT repeat" list: finalize() drops any
     // re-proposal of a known rule anyway, so omitting dismissed ones just wastes
     // a proposal slot + tokens re-suggesting something the operator already rejected.
@@ -138,12 +152,15 @@ export class DistillerService {
     // (src/review.ts:begin). NOT --dangerously-skip-permissions: it reads
     // untrusted agent/repo text. dontAsk MUST be last (after the variadic
     // --allowedTools) so the trailing prompt isn't swallowed. Bare Write only.
+    // Subscription OAuth (NOT --bare); in api-key auth mode the key arrives via
+    // apiKeyHelper in --settings (folded in) + a credential-less CLAUDE_CONFIG_DIR.
     const argv = [
       "claude",
       "--session-id",
       randomUUID(),
       "--settings",
-      '{"disableAllHooks":true}',
+      // subscription → byte-identical `{"disableAllHooks":true}`; api-key folds in apiKeyHelper.
+      JSON.stringify({ disableAllHooks: true, ...apiKeySettingsFragment() }),
       "--disable-slash-commands",
       "--allowedTools",
       "Read",
@@ -156,7 +173,12 @@ export class DistillerService {
     argv.push(distillPrompt());
     let terminalId: string;
     try {
-      terminalId = this.deps.herdr.start(DISTILL_LABEL, dir, argv).terminalId;
+      terminalId = this.deps.herdr.start(
+        DISTILL_LABEL,
+        dir,
+        argv,
+        apiKeyPassthroughEnv(false),
+      ).terminalId;
     } catch (err) {
       console.warn(`[distill] spawn failed for ${repoPath}:`, err);
       this.deps.scratch.remove(dir);

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -224,7 +224,7 @@ export class HerdrDriver {
     }
   }
 
-  start(name: string, cwd: string, argv: string[]): HerdrAgent {
+  start(name: string, cwd: string, argv: string[], env?: Record<string, string>): HerdrAgent {
     // herdr needs an active workspace before any tab can be created — guarantee one.
     this.ensureWorkspace(cwd);
     // Give each agent its OWN tab so its pane spans the full herdr window width.
@@ -250,8 +250,15 @@ export class HerdrDriver {
       // compile cache to a disk-backed dir. `env` execvp's straight into claude (no extra
       // process layer), so herdr's PTY/agent detection is unaffected — but NODE_COMPILE_CACHE
       // now lands on disk instead of `$TMPDIR/node-compile-cache` on the tmpfs, where it
-      // accreted unbounded and exhausted inodes (#560).
-      const wrapped = ["env", `NODE_COMPILE_CACHE=${compileCacheDir()}`, ...argv];
+      // accreted unbounded and exhausted inodes (#560). Caller-supplied `env` vars (e.g.
+      // CLAUDE_CONFIG_DIR for api-key auth mode) are injected as additional KEY=VALUE tokens
+      // after NODE_COMPILE_CACHE, in sorted-key order for stability.
+      const envTokens = env
+        ? Object.entries(env)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([k, v]) => `${k}=${v}`)
+        : [];
+      const wrapped = ["env", `NODE_COMPILE_CACHE=${compileCacheDir()}`, ...envTokens, ...argv];
       this.runner([
         "agent",
         "start",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { mkdirSync, existsSync } from "node:fs";
 import { dirname } from "node:path";
 import {
   config,
@@ -74,6 +74,7 @@ import { promisify } from "node:util";
 import { startLoopLagSampler, logRemainingOnLoopBlockers } from "./instrument";
 import { resolveNodeHost, TailscaleServeService } from "./tailscale";
 import { normalizeDefaultModelSetting } from "./default-model";
+import { normalizeAuthModeSetting } from "./auth-mode";
 import { EgressWatcher } from "./egress-watch";
 import { RecapService } from "./recap";
 
@@ -130,6 +131,20 @@ const savedDm = store.getSetting("defaultModel");
 if (savedDm !== null) {
   const v = normalizeDefaultModelSetting(savedDm);
   if (v !== null) config.defaultModel = v;
+}
+// a UI-chosen auth mode (persisted) overrides the env seed; absent or unrecognised → keep default.
+const savedAm = store.getSetting("authMode");
+if (savedAm !== null) {
+  const v = normalizeAuthModeSetting(savedAm);
+  if (v !== null) config.authMode = v;
+}
+// restore the apiKeyHelper path if the file still exists on disk; self-heal if it was deleted.
+const savedHelperPath = store.getSetting("authApiKeyHelperPath");
+if (savedHelperPath !== null && savedHelperPath !== "") {
+  if (existsSync(savedHelperPath)) {
+    config.authApiKeyHelperPath = savedHelperPath;
+  }
+  // if the file is gone, leave config null — dangling path self-heals silently
 }
 
 // A UI-set extra-credit drain ceiling (persisted) overrides the env seed; a missing

--- a/src/namer-llm.ts
+++ b/src/namer-llm.ts
@@ -4,6 +4,12 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { HerdrDriver } from "./herdr";
 import { slugifyManual } from "./namer";
+import {
+  isApiKeyMode,
+  isApiKeyConfigured,
+  apiKeySettingsFragment,
+  apiKeyPassthroughEnv,
+} from "./spawn-auth";
 
 /** The file the namer agent writes its slug to, in its temp cwd. */
 export const NAME_FILE = ".shepherd-name";
@@ -62,7 +68,9 @@ function defaultCleanup(cwd: string): void {
  *  - CLEAN context: user's global hooks (e.g. the SessionStart superpowers preamble)
  *    would inject a "you MUST invoke a skill" message that dontAsk can't satisfy,
  *    making the agent thrash. `--disable-slash-commands` removes skills entirely.
- *    NOT `--bare`: it refuses subscription OAuth (demands ANTHROPIC_API_KEY).
+ *    NOT `--bare`: it refuses subscription OAuth (demands ANTHROPIC_API_KEY). In
+ *    api-key auth mode the key arrives via `apiKeyHelper` in --settings (folded in
+ *    below) and the spawn points at a credential-less CLAUDE_CONFIG_DIR — still NOT --bare.
  *  - Bare `Write` — NOT Write(<path>): path-scoped Write rules are silently denied
  *    under `dontAsk`, which would block the slug write. Bare Write is not cwd-scoped,
  *    so an absolute-path write is technically permitted — an accepted trade-off (same
@@ -79,7 +87,8 @@ function namerArgv(model: string | null, taskText: string): string[] {
     "--session-id",
     randomUUID(),
     "--settings",
-    '{"disableAllHooks":true}',
+    // subscription → byte-identical `{"disableAllHooks":true}`; api-key folds in apiKeyHelper.
+    JSON.stringify({ disableAllHooks: true, ...apiKeySettingsFragment() }),
     "--disable-slash-commands",
     "--allowedTools",
     "Write",
@@ -150,12 +159,21 @@ export async function llmName(
     pollMs = 1_000,
   } = deps;
 
+  // Fail closed: api-key mode without a configured key must NOT bill the subscription —
+  // skip the LLM namer and keep the heuristic name.
+  if (isApiKeyMode() && !isApiKeyConfigured()) return null;
+
   let cwd: string | null = null;
   let terminalId: string | null = null;
   try {
     cwd = makeTmpDir();
     try {
-      terminalId = deps.herdr.start(label, cwd, namerArgv(model, taskText)).terminalId;
+      terminalId = deps.herdr.start(
+        label,
+        cwd,
+        namerArgv(model, taskText),
+        apiKeyPassthroughEnv(false),
+      ).terminalId;
     } catch {
       return null; // herdr/claude unavailable → fall back to heuristic
     }

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -325,6 +325,16 @@ export class PlanGateService {
       return "skipped";
     }
 
+    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
+    // Checked AFTER the worktree allocation + the post-await re-check so the worktree cleanup
+    // here has wt.worktreePath — but BEFORE membrane/backend construction so we skip that work.
+    if (isApiKeyMode() && !isApiKeyConfigured()) {
+      console.warn(
+        "[plan-gate] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
+      );
+      this.deps.worktree.remove(wt.worktreePath);
+      return "error";
+    }
     const backend = this.detectBackend();
     const env = this.membraneEnv();
     const membrane: MembraneInputs = {
@@ -339,14 +349,6 @@ export class PlanGateService {
       // api-key mode: a bwrap-wrapped reviewer masks the OAuth credential + binds the helper.
       ...apiKeyMembraneFields(),
     };
-    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
-    if (isApiKeyMode() && !isApiKeyConfigured()) {
-      console.warn(
-        "[plan-gate] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
-      );
-      this.deps.worktree.remove(wt.worktreePath);
-      return "error";
-    }
     const wrapped = wrapArgv(argv, { profile: "standard", backend, membrane });
     let terminalId: string;
     try {

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -9,6 +9,12 @@ import type { WorktreeMgr } from "./worktree";
 import type { Session, PlanGate, PlanDecision } from "./types";
 import type { GitForge } from "./forge/types";
 import { readonlyReviewerArgv } from "./reviewer-argv";
+import {
+  isApiKeyMode,
+  isApiKeyConfigured,
+  apiKeyMembraneFields,
+  apiKeyPassthroughEnv,
+} from "./spawn-auth";
 import { readSessionUsage, type SessionUsage } from "./usage";
 import { effectiveAutopilot } from "./effective-autopilot";
 import {
@@ -330,7 +336,17 @@ export class PlanGateService {
       home: env.home,
       nodeBinReal: env.nodeBinReal,
       extraEnv: env.extraEnv,
+      // api-key mode: a bwrap-wrapped reviewer masks the OAuth credential + binds the helper.
+      ...apiKeyMembraneFields(),
     };
+    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
+    if (isApiKeyMode() && !isApiKeyConfigured()) {
+      console.warn(
+        "[plan-gate] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
+      );
+      this.deps.worktree.remove(wt.worktreePath);
+      return "error";
+    }
     const wrapped = wrapArgv(argv, { profile: "standard", backend, membrane });
     let terminalId: string;
     try {
@@ -338,6 +354,9 @@ export class PlanGateService {
         `plan-review ${session.desig}`,
         wt.worktreePath,
         wrapped,
+        // No backend → passthrough (no membrane) → set CLAUDE_CONFIG_DIR to a
+        // credential-less mirror; with a backend the membrane masks creds in place.
+        apiKeyPassthroughEnv(backend !== null),
       ).terminalId;
     } catch (err) {
       console.warn(`[plan-gate] spawn failed for ${session.id}:`, err);

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -27,6 +27,12 @@ import { computeDiff } from "./diff";
 import { parseActivity, readTranscriptTail } from "./activity";
 import { jsonlPathFor } from "./usage";
 import {
+  isApiKeyMode,
+  isApiKeyConfigured,
+  apiKeySettingsFragment,
+  apiKeyPassthroughEnv,
+} from "./spawn-auth";
+import {
   parseRecapVerdict,
   buildTranscriptDigest,
   buildRecapPrompt,
@@ -106,6 +112,8 @@ function defaultCleanup(cwd: string): void {
  *   --permission-mode dontAsk <prompt>
  * NOTE: --allowedTools is variadic and eats tokens until the next flag, so
  * --permission-mode must follow it and the prompt must be last. Don't reorder.
+ * Subscription OAuth (NOT --bare); in api-key auth mode the key arrives via
+ * apiKeyHelper in --settings (folded in) + a credential-less CLAUDE_CONFIG_DIR.
  */
 function recapArgv(model: string | null, prompt: string): { argv: string[]; sessionId: string } {
   const sessionId = randomUUID();
@@ -114,7 +122,8 @@ function recapArgv(model: string | null, prompt: string): { argv: string[]; sess
     "--session-id",
     sessionId,
     "--settings",
-    '{"disableAllHooks":true}',
+    // subscription → byte-identical `{"disableAllHooks":true}`; api-key folds in apiKeyHelper.
+    JSON.stringify({ disableAllHooks: true, ...apiKeySettingsFragment() }),
     "--disable-slash-commands",
     "--allowedTools",
     "Write",
@@ -350,6 +359,13 @@ export class RecapService {
    * A synchronous in-flight guard prevents double-spawn if regenerate races sweep.
    */
   async generate(session: Session, knownHead?: string): Promise<"started" | "empty" | "error"> {
+    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
+    if (isApiKeyMode() && !isApiKeyConfigured()) {
+      console.warn(
+        "[recap] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
+      );
+      return "error";
+    }
     const { id, worktreePath, baseBranch, branch, claudeSessionId } = session;
 
     // Synchronous guard: if already mid-flight for this session, bail immediately.
@@ -418,7 +434,7 @@ export class RecapService {
       // Spawn.
       const cwd = this._makeTmpDir();
       try {
-        this.deps.herdr.start(`recap ${session.desig}`, cwd, argv);
+        this.deps.herdr.start(`recap ${session.desig}`, cwd, argv, apiKeyPassthroughEnv(false));
       } catch {
         this._cleanup(cwd);
         return "error"; // spawn failed; no row left so next settle can retry

--- a/src/review.ts
+++ b/src/review.ts
@@ -6,6 +6,12 @@ import type { GitForge, GitState, PrStatus } from "./forge/types";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "./forge/types";
 import type { ReviewVerdict, Session } from "./types";
 import { readonlyReviewerArgv } from "./reviewer-argv";
+import {
+  isApiKeyMode,
+  isApiKeyConfigured,
+  apiKeyMembraneFields,
+  apiKeyPassthroughEnv,
+} from "./spawn-auth";
 import { jsonlPathFor, readSessionUsage, type SessionUsage } from "./usage";
 import { readActivitySignal } from "./activity-signal";
 import {
@@ -354,7 +360,17 @@ export class ReviewService {
       home: env.home,
       nodeBinReal: env.nodeBinReal,
       extraEnv: env.extraEnv,
+      // api-key mode: a bwrap-wrapped reviewer masks the OAuth credential + binds the helper.
+      ...apiKeyMembraneFields(),
     };
+    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
+    if (isApiKeyMode() && !isApiKeyConfigured()) {
+      console.warn(
+        "[review] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
+      );
+      this.deps.worktree.remove(wt.worktreePath);
+      return;
+    }
     const wrapped = wrapArgv(argv, { profile: "standard", backend, membrane });
     let terminalId: string;
     try {
@@ -362,6 +378,9 @@ export class ReviewService {
         `review ${session.desig}`,
         wt.worktreePath,
         wrapped,
+        // No backend → passthrough (no membrane) → set CLAUDE_CONFIG_DIR to a
+        // credential-less mirror; with a backend the membrane masks creds in place.
+        apiKeyPassthroughEnv(backend !== null),
       ).terminalId;
     } catch (err) {
       console.warn(`[review] spawn failed for ${session.id}:`, err);

--- a/src/review.ts
+++ b/src/review.ts
@@ -342,6 +342,16 @@ export class ReviewService {
       return;
     }
 
+    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
+    // Checked AFTER the worktree allocation + the post-await re-check so the worktree cleanup
+    // here has wt.worktreePath — but BEFORE membrane/backend construction so we skip that work.
+    if (isApiKeyMode() && !isApiKeyConfigured()) {
+      console.warn(
+        "[review] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
+      );
+      this.deps.worktree.remove(wt.worktreePath);
+      return;
+    }
     const { argv, sessionId: criticSessionId } = this.criticArgv(
       session,
       diffBase,
@@ -363,14 +373,6 @@ export class ReviewService {
       // api-key mode: a bwrap-wrapped reviewer masks the OAuth credential + binds the helper.
       ...apiKeyMembraneFields(),
     };
-    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
-    if (isApiKeyMode() && !isApiKeyConfigured()) {
-      console.warn(
-        "[review] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
-      );
-      this.deps.worktree.remove(wt.worktreePath);
-      return;
-    }
     const wrapped = wrapArgv(argv, { profile: "standard", backend, membrane });
     let terminalId: string;
     try {

--- a/src/reviewer-argv.ts
+++ b/src/reviewer-argv.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { apiKeySettingsFragment } from "./spawn-auth";
 
 /** Build the argv for a read-only adversarial reviewer agent (PR critic + plan reviewer share it).
  *  Deliberately NOT --dangerously-skip-permissions: the agent inspects UNTRUSTED input (a PR diff
@@ -31,6 +32,10 @@ export function readonlyReviewerArgv(
     enableAllProjectMcpServers: true,
   };
   if (thinkingTokens) settings.env = { MAX_THINKING_TOKENS: String(thinkingTokens) };
+  // api-key mode folds in `apiKeyHelper` AFTER the existing keys (stable key order;
+  // subscription spreads {} → byte-identical JSON). The membrane masks the OAuth
+  // credential in place for the wrapped reviewer; see spawn-auth + review.ts/plan-gate.ts.
+  Object.assign(settings, apiKeySettingsFragment());
   const argv = [
     "claude",
     "--session-id",
@@ -43,8 +48,11 @@ export function readonlyReviewerArgv(
     // inherited hook (also gsd/herdr/ensure-deps — none of which the reviewer
     // needs); --disable-slash-commands removes skills entirely.
     // NOT --bare: it refuses OAuth/keychain auth (strictly ANTHROPIC_API_KEY),
-    // and shepherd runs on subscription OAuth with no API key — --bare would
+    // and shepherd defaults to subscription OAuth with no API key — --bare would
     // break the reviewer's auth. --settings keeps OAuth while disabling hooks.
+    // In api-key auth mode the key is supplied via `apiKeyHelper` in --settings
+    // (folded in above) and the membrane masks the operator's OAuth credential —
+    // still NOT --bare (the helper path is honored without it).
     // enableAllProjectMcpServers pre-approves the repo's project .mcp.json so the
     // interactive "new MCP servers found" gate never renders (see the MCP block
     // below for why it's necessary AND why it is COUPLED to --safe-mode).

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -15,7 +15,7 @@
  * `*-bind-try` for every host-variable path so an absent source is skipped
  * rather than hard-failing the spawn.
  */
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { dirname } from "node:path";
 import { execFileSync } from "./instrument";
 import { resolveNodeBin } from "./node-bin";
@@ -67,6 +67,17 @@ export interface PathProbeDeps {
   run?: (cmd: string, args: string[]) => { status: number };
   /** Existence probe; default fs.existsSync. */
   exists?: (p: string) => boolean;
+  /** Directory listing; default a safe readdirSync wrapper returning [] on error. */
+  readdir?: (p: string) => string[];
+}
+
+/** readdirSync that returns [] on any error (missing dir, perms). */
+function safeReaddir(p: string): string[] {
+  try {
+    return readdirSync(p);
+  } catch {
+    return [];
+  }
 }
 
 /** detectBackend additionally needs a probe environment to build a self-test membrane. */
@@ -161,9 +172,11 @@ export interface MembraneInputs {
    *  cat-able by an in-sandbox agent (host hygiene only, same class as audit R3/R4)
    *  — NOT in-membrane secrecy. */
   apiKeyHelperPath?: string | null;
-  /** api-key mode: overlay <claudeDir>/.credentials.json with /dev/null AFTER the
-   *  whole-dir RO bind so no subscription login is presented; skip the rw
-   *  credentials bind. */
+  /** api-key mode: present <claudeDir>/.credentials.json as GENUINELY ABSENT
+   *  inside the sandbox (not an empty /dev/null overlay) by binding every child
+   *  of claudeDir individually EXCEPT the credential file — matching the
+   *  credential-less CLAUDE_CONFIG_DIR mirror (auth-config-dir.ts). Also skips
+   *  the rw credentials bind. So no "Use custom API key?"/re-auth prompt fires. */
   maskCredentials?: boolean;
 }
 
@@ -234,6 +247,28 @@ function nodeToolchainFlags(inputs: MembraneInputs, exists: (p: string) => boole
 }
 
 /**
+ * api-key mode base binds for the claude config dir, presenting
+ * `.credentials.json` as GENUINELY ABSENT (not an empty /dev/null overlay).
+ *
+ * bwrap cannot hide a single child of a whole-dir bind, so instead of binding
+ * `claudeDir` wholesale we `--dir` the mount point (so it exists even when the
+ * dir is empty) then bind every child RO individually EXCEPT the credential
+ * file. The OAuth token simply does not exist inside the sandbox — exactly the
+ * shape of the credential-less CLAUDE_CONFIG_DIR mirror (auth-config-dir.ts),
+ * so no "Use custom API key?"/re-auth prompt can fire on empty/invalid creds.
+ * Entries are sorted for deterministic, testable output.
+ */
+function maskedClaudeDirBinds(claudeDir: string, readdir: (p: string) => string[]): string[] {
+  const flags = ["--dir", claudeDir];
+  for (const entry of readdir(claudeDir)
+    .filter((e) => e !== ".credentials.json")
+    .sort()) {
+    flags.push("--ro-bind-try", `${claudeDir}/${entry}`, `${claudeDir}/${entry}`);
+  }
+  return flags;
+}
+
+/**
  * The frozen, host-derived membrane flag list (validated against real claude
  * 2.1.173 on the reference host). Returns the bwrap argv PREFIX flags only —
  * `wrapArgv` appends `-- <innerArgv>`.
@@ -244,19 +279,27 @@ function nodeToolchainFlags(inputs: MembraneInputs, exists: (p: string) => boole
  */
 export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps = {}): string[] {
   const exists = deps.exists ?? existsSync;
+  const readdir = deps.readdir ?? safeReaddir;
   const home = inputs.home;
   const claudeDir = inputs.claudeDir;
   const term = inputs.term ?? "xterm-256color";
 
-  // Credential handling sits right after the whole-dir RO bind so a /dev/null
-  // overlay (api-key mode) is last-wins. Subscription/default: the original rw
-  // `--bind-try` (OAuth token refresh writes back) — byte-for-byte unchanged.
+  // Claude config dir base bind(s). Two shapes:
+  //  - subscription/default: the whole dir RO in one bind — byte-for-byte unchanged.
+  //  - api-key (maskCredentials): per-child RO binds EXCEPT `.credentials.json`, so
+  //    the OAuth token is GENUINELY ABSENT inside the sandbox (matching the
+  //    credential-less CLAUDE_CONFIG_DIR mirror in auth-config-dir.ts) rather than
+  //    an empty overlay — an empty/invalid creds file could trip a re-auth prompt.
+  const claudeDirBaseBinds: string[] = inputs.maskCredentials
+    ? maskedClaudeDirBinds(claudeDir, readdir)
+    : ["--ro-bind", claudeDir, claudeDir];
+
+  // Subscription/default: rw `--bind-try` so OAuth token refresh writes back.
+  // api-key (maskCredentials): EMPTY — the credential is absent (see above), there
+  // is no `.credentials.json` bind of any kind.
   const credentialFlags: string[] = inputs.maskCredentials
-    ? // api-key mode: overlay the OAuth token with /dev/null so no subscription
-      // login is presented; the whole-dir RO bind above already exposes the rest.
-      ["--ro-bind", "/dev/null", `${claudeDir}/.credentials.json`]
-    : // RW: OAuth token refresh writes back.
-      ["--bind-try", `${claudeDir}/.credentials.json`, `${claudeDir}/.credentials.json`];
+    ? []
+    : ["--bind-try", `${claudeDir}/.credentials.json`, `${claudeDir}/.credentials.json`];
 
   const f: string[] = [
     // ── base read-only root ──────────────────────────────────────────────
@@ -295,9 +338,8 @@ export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps =
     "/run/systemd/resolve",
     "/run/systemd/resolve",
     // ── claude config: base RO (auth + commands + skills) ────────────────
-    "--ro-bind",
-    claudeDir,
-    claudeDir,
+    // Subscription: whole-dir RO. api-key: per-child RO minus `.credentials.json`.
+    ...claudeDirBaseBinds,
     // RW: agent writes transcript; host reads it after.
     "--bind",
     `${claudeDir}/projects`,
@@ -311,7 +353,7 @@ export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps =
     "--bind-try",
     `${claudeDir}/shell-snapshots`,
     `${claudeDir}/shell-snapshots`,
-    // OAuth credential: rw bind (subscription) or /dev/null overlay (api-key mask).
+    // OAuth credential: rw bind (subscription) or nothing (api-key mask: absent).
     ...credentialFlags,
     // RW persisted: trust/onboarding state (else non-interactive auto hangs on onboarding).
     "--bind-try",

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -157,6 +157,14 @@ export interface MembraneInputs {
    *  caller builds this via `collectPassthroughEnv`. HOME/PATH/TERM are always set
    *  separately and must NOT be included here. */
   extraEnv?: Record<string, string>;
+  /** api-key mode: bind this helper script RO so claude can exec it. RESIDUAL:
+   *  cat-able by an in-sandbox agent (host hygiene only, same class as audit R3/R4)
+   *  — NOT in-membrane secrecy. */
+  apiKeyHelperPath?: string | null;
+  /** api-key mode: overlay <claudeDir>/.credentials.json with /dev/null AFTER the
+   *  whole-dir RO bind so no subscription login is presented; skip the rw
+   *  credentials bind. */
+  maskCredentials?: boolean;
 }
 
 /**
@@ -240,6 +248,16 @@ export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps =
   const claudeDir = inputs.claudeDir;
   const term = inputs.term ?? "xterm-256color";
 
+  // Credential handling sits right after the whole-dir RO bind so a /dev/null
+  // overlay (api-key mode) is last-wins. Subscription/default: the original rw
+  // `--bind-try` (OAuth token refresh writes back) — byte-for-byte unchanged.
+  const credentialFlags: string[] = inputs.maskCredentials
+    ? // api-key mode: overlay the OAuth token with /dev/null so no subscription
+      // login is presented; the whole-dir RO bind above already exposes the rest.
+      ["--ro-bind", "/dev/null", `${claudeDir}/.credentials.json`]
+    : // RW: OAuth token refresh writes back.
+      ["--bind-try", `${claudeDir}/.credentials.json`, `${claudeDir}/.credentials.json`];
+
   const f: string[] = [
     // ── base read-only root ──────────────────────────────────────────────
     "--ro-bind",
@@ -293,10 +311,8 @@ export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps =
     "--bind-try",
     `${claudeDir}/shell-snapshots`,
     `${claudeDir}/shell-snapshots`,
-    // RW: OAuth token refresh writes back.
-    "--bind-try",
-    `${claudeDir}/.credentials.json`,
-    `${claudeDir}/.credentials.json`,
+    // OAuth credential: rw bind (subscription) or /dev/null overlay (api-key mask).
+    ...credentialFlags,
     // RW persisted: trust/onboarding state (else non-interactive auto hangs on onboarding).
     "--bind-try",
     `${home}/.claude.json`,
@@ -316,6 +332,14 @@ export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps =
   // ── commit identity + gh token ───────────────────────────────────────────
   f.push("--ro-bind-try", `${home}/.gitconfig`, `${home}/.gitconfig`);
   f.push("--ro-bind-try", `${home}/.config/gh`, `${home}/.config/gh`);
+
+  // ── api-key helper (api-key mode only) ────────────────────────────────────
+  // Bind the apiKeyHelper script RO at the SAME path so the `apiKeyHelper` entry
+  // in --settings resolves inside the sandbox. Omitted (guarded) in subscription
+  // mode so flags stay byte-identical.
+  if (typeof inputs.apiKeyHelperPath === "string" && inputs.apiKeyHelperPath.length > 0) {
+    f.push("--ro-bind-try", inputs.apiKeyHelperPath, inputs.apiKeyHelperPath);
+  }
 
   // ── worktree / git store ─────────────────────────────────────────────────
   if (inputs.isolated) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -86,6 +86,7 @@ import { homedir } from "node:os";
 import type { ServerWebSocket } from "bun";
 import { markPtyEvent } from "./instrument";
 import { normalizeDefaultModelSetting, normalizeRepoDefaultModelSetting } from "./default-model";
+import { normalizeAuthModeSetting, writeApiKeyHelper, clearApiKeyHelper } from "./auth-mode";
 import {
   type SandboxProfile,
   SANDBOX_PROFILES,
@@ -2003,6 +2004,10 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       // account-wide extra-credit (paid overage) spend ceiling; drain pauses above it.
       // 0 = pause on ANY extra-credit spend.
       extraCreditsDrainCeiling: config.extraCreditsDrainCeiling,
+      // auth footing for spawned agents; "subscription" (default) or "api-key".
+      authMode: config.authMode,
+      // whether an apiKeyHelper script is configured; NEVER expose the key or path.
+      hasApiKey: config.authApiKeyHelperPath !== null,
     });
   }
   if (req.method === "PUT") {
@@ -2028,6 +2033,8 @@ const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response]
   ["planReviewCyclesCap", putPlanReviewCyclesCap],
   ["defaultModel", putDefaultModel],
   ["extraCreditsDrainCeiling", putExtraCreditsDrainCeiling],
+  ["authMode", putAuthMode],
+  ["anthropicApiKey", putAnthropicApiKey],
 ];
 
 function putRemoteControl(value: unknown, deps: Ctx["deps"]): Response {
@@ -2092,6 +2099,35 @@ function putExtraCreditsDrainCeiling(value: unknown, deps: Ctx["deps"]): Respons
   config.extraCreditsDrainCeiling = value; // live: next drain assembly reads it
   deps.store.setSetting("extra_credits_drain_ceiling", String(value)); // persist across restarts
   return json({ extraCreditsDrainCeiling: config.extraCreditsDrainCeiling });
+}
+
+// Switching to api-key without a key configured is allowed; spawns fail closed until a key is supplied.
+function putAuthMode(value: unknown, deps: Ctx["deps"]): Response {
+  const v = normalizeAuthModeSetting(value);
+  if (v === null) return json({ error: "authMode must be 'subscription' or 'api-key'" }, 400);
+  config.authMode = v; // live: next spawn picks it up
+  deps.store.setSetting("authMode", v); // persist across restarts
+  return json({ authMode: config.authMode, hasApiKey: config.authApiKeyHelperPath !== null });
+}
+
+function putAnthropicApiKey(value: unknown, deps: Ctx["deps"]): Response {
+  if (value !== null && typeof value !== "string") {
+    return json({ error: "anthropicApiKey must be a string or null" }, 400);
+  }
+  const dir = join(homedir(), ".shepherd");
+  if (typeof value === "string" && value.trim().length > 0) {
+    // SET — write helper, store path; NEVER echo key or path
+    const path = writeApiKeyHelper(value.trim(), dir);
+    config.authApiKeyHelperPath = path;
+    deps.store.setSetting("authApiKeyHelperPath", path);
+    return json({ hasApiKey: true });
+  } else {
+    // CLEAR (null or empty string)
+    clearApiKeyHelper(dir);
+    config.authApiKeyHelperPath = null;
+    deps.store.setSetting("authApiKeyHelperPath", ""); // mark cleared
+    return json({ hasApiKey: false });
+  }
 }
 
 function putRepoRoot(value: unknown, deps: Ctx["deps"]): Response {

--- a/src/service.ts
+++ b/src/service.ts
@@ -19,8 +19,13 @@ import {
   worktreeUploadsDir,
 } from "./uploads";
 import { slugifyManual } from "./namer";
-import { spawnAuthSettings } from "./auth-mode";
-import { ensureApiKeyConfigDir } from "./auth-config-dir";
+import {
+  isApiKeyMode,
+  isApiKeyConfigured,
+  apiKeySettingsFragment,
+  apiKeyMembraneFields,
+  apiKeyPassthroughEnv,
+} from "./spawn-auth";
 import type { Leftover, ProcessReaper } from "./process-reaper";
 import type { PreviewService } from "./preview";
 import { planHouseRulesInjection, renderHouseRulesBlock } from "./house-rules";
@@ -194,8 +199,8 @@ export function spawnSettingsOverlay(opts: { disablePlugins?: string[] } = {}): 
     settings.enabledPlugins = Object.fromEntries(opts.disablePlugins.map((id) => [id, false]));
   }
   // api-key mode folds in `apiKeyHelper` LAST so key order is stable; subscription
-  // returns {} so the JSON is byte-for-byte identical to before (see spawnAuthSettings).
-  Object.assign(settings, spawnAuthSettings(config.authMode, config.authApiKeyHelperPath));
+  // returns {} so the JSON is byte-for-byte identical to before (see spawn-auth).
+  Object.assign(settings, apiKeySettingsFragment());
   return JSON.stringify(settings);
 }
 
@@ -752,12 +757,11 @@ export class SessionService {
     },
   ): SpawnOutcome {
     const repoConfig = this.deps.store.getRepoConfig(ctx.repoPath);
-    const apiKeyMode = config.authMode === "api-key";
     // Fail closed: api-key mode with no helper path configured must NOT silently
     // fall back to subscription (OAuth) billing. Refuse before the auto-gate so it
     // applies to BOTH interactive create (prepareSpawnOrThrow → throws) and
     // resume/drain (returns ok:false → null/caught).
-    if (apiKeyMode && !config.authApiKeyHelperPath) {
+    if (isApiKeyMode() && !isApiKeyConfigured()) {
       return {
         ok: false,
         holdReason:
@@ -808,8 +812,7 @@ export class SessionService {
           extraEnv: collectPassthroughEnv(),
           // api-key mode: bind the helper RO + mask the OAuth credential in place
           // (the operator's ~/.claude customizations stay bound). Subscription: null/false.
-          apiKeyHelperPath: apiKeyMode ? config.authApiKeyHelperPath : null,
-          maskCredentials: apiKeyMode,
+          ...apiKeyMembraneFields(),
         }
       : ({} as MembraneInputs);
 
@@ -849,10 +852,7 @@ export class SessionService {
     // credential-less mirror dir. The membrane case masks creds in place (keeping
     // the operator's real ~/.claude customizations), so it needs no env override.
     // The egress branch is always willWrap, so this is undefined there.
-    const spawnEnv =
-      apiKeyMode && !willWrap
-        ? { CLAUDE_CONFIG_DIR: ensureApiKeyConfigDir(homedir(), config.claudeDir) }
-        : undefined;
+    const spawnEnv = apiKeyPassthroughEnv(willWrap);
     const agent = this.deps.herdr.start(ctx.name, ctx.worktreePath, wrapped, spawnEnv);
     // Start the egress drop-watcher AFTER herdr.start (the agent is now running).
     if (egressOn && egressAllowlist && egressDnsLog) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -744,6 +744,32 @@ export class SessionService {
    * `applied` = the resolved profile (what was requested), `degraded` = a sandboxed
    * profile was requested but no backend was present, so it ran unconfined.
    */
+  /**
+   * Resolve this spawn's api-key auth wiring in one place (the addition this
+   * feature layered onto prepareSpawn):
+   *   - `hold`: fail-closed reason string when api-key mode is on but no key is
+   *     configured (else null) — caller refuses before the auto-gate;
+   *   - `membraneFields`: helper-bind + credential-mask flags for the membrane;
+   *   - `passthroughEnv(willWrap)`: CLAUDE_CONFIG_DIR override for the non-wrapped
+   *     (passthrough) case, undefined otherwise.
+   * Subscription mode: hold null, fields null/false, env undefined.
+   */
+  private resolveApiKeyAuth(): {
+    hold: string | null;
+    membraneFields: { apiKeyHelperPath: string | null; maskCredentials: boolean };
+    passthroughEnv: (willWrap: boolean) => Record<string, string> | undefined;
+  } {
+    const hold =
+      isApiKeyMode() && !isApiKeyConfigured()
+        ? "API-key auth mode is enabled but no Anthropic API key is configured (Settings → Session)."
+        : null;
+    return {
+      hold,
+      membraneFields: apiKeyMembraneFields(),
+      passthroughEnv: apiKeyPassthroughEnv,
+    };
+  }
+
   private prepareSpawn(
     innerArgv: string[],
     ctx: {
@@ -757,17 +783,14 @@ export class SessionService {
     },
   ): SpawnOutcome {
     const repoConfig = this.deps.store.getRepoConfig(ctx.repoPath);
+    // Resolve api-key auth wiring once: fail-closed hold reason (null when OK),
+    // the membrane mask/helper fields, and the passthrough config-dir env.
+    const apiKeyAuth = this.resolveApiKeyAuth();
     // Fail closed: api-key mode with no helper path configured must NOT silently
     // fall back to subscription (OAuth) billing. Refuse before the auto-gate so it
     // applies to BOTH interactive create (prepareSpawnOrThrow → throws) and
     // resume/drain (returns ok:false → null/caught).
-    if (isApiKeyMode() && !isApiKeyConfigured()) {
-      return {
-        ok: false,
-        holdReason:
-          "API-key auth mode is enabled but no Anthropic API key is configured (Settings → Session).",
-      };
-    }
+    if (apiKeyAuth.hold) return { ok: false, holdReason: apiKeyAuth.hold };
     const profile = resolveProfile(
       ctx.profileOverride,
       repoConfig.sandboxProfile,
@@ -812,7 +835,7 @@ export class SessionService {
           extraEnv: collectPassthroughEnv(),
           // api-key mode: bind the helper RO + mask the OAuth credential in place
           // (the operator's ~/.claude customizations stay bound). Subscription: null/false.
-          ...apiKeyMembraneFields(),
+          ...apiKeyAuth.membraneFields,
         }
       : ({} as MembraneInputs);
 
@@ -852,7 +875,7 @@ export class SessionService {
     // credential-less mirror dir. The membrane case masks creds in place (keeping
     // the operator's real ~/.claude customizations), so it needs no env override.
     // The egress branch is always willWrap, so this is undefined there.
-    const spawnEnv = apiKeyPassthroughEnv(willWrap);
+    const spawnEnv = apiKeyAuth.passthroughEnv(willWrap);
     const agent = this.deps.herdr.start(ctx.name, ctx.worktreePath, wrapped, spawnEnv);
     // Start the egress drop-watcher AFTER herdr.start (the agent is now running).
     if (egressOn && egressAllowlist && egressDnsLog) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -19,6 +19,8 @@ import {
   worktreeUploadsDir,
 } from "./uploads";
 import { slugifyManual } from "./namer";
+import { spawnAuthSettings } from "./auth-mode";
+import { ensureApiKeyConfigDir } from "./auth-config-dir";
 import type { Leftover, ProcessReaper } from "./process-reaper";
 import type { PreviewService } from "./preview";
 import { planHouseRulesInjection, renderHouseRulesBlock } from "./house-rules";
@@ -191,6 +193,9 @@ export function spawnSettingsOverlay(opts: { disablePlugins?: string[] } = {}): 
   if (opts.disablePlugins && opts.disablePlugins.length > 0) {
     settings.enabledPlugins = Object.fromEntries(opts.disablePlugins.map((id) => [id, false]));
   }
+  // api-key mode folds in `apiKeyHelper` LAST so key order is stable; subscription
+  // returns {} so the JSON is byte-for-byte identical to before (see spawnAuthSettings).
+  Object.assign(settings, spawnAuthSettings(config.authMode, config.authApiKeyHelperPath));
   return JSON.stringify(settings);
 }
 
@@ -747,6 +752,18 @@ export class SessionService {
     },
   ): SpawnOutcome {
     const repoConfig = this.deps.store.getRepoConfig(ctx.repoPath);
+    const apiKeyMode = config.authMode === "api-key";
+    // Fail closed: api-key mode with no helper path configured must NOT silently
+    // fall back to subscription (OAuth) billing. Refuse before the auto-gate so it
+    // applies to BOTH interactive create (prepareSpawnOrThrow → throws) and
+    // resume/drain (returns ok:false → null/caught).
+    if (apiKeyMode && !config.authApiKeyHelperPath) {
+      return {
+        ok: false,
+        holdReason:
+          "API-key auth mode is enabled but no Anthropic API key is configured (Settings → Session).",
+      };
+    }
     const profile = resolveProfile(
       ctx.profileOverride,
       repoConfig.sandboxProfile,
@@ -789,6 +806,10 @@ export class SessionService {
           nodeBinReal,
           term: process.env.TERM,
           extraEnv: collectPassthroughEnv(),
+          // api-key mode: bind the helper RO + mask the OAuth credential in place
+          // (the operator's ~/.claude customizations stay bound). Subscription: null/false.
+          apiKeyHelperPath: apiKeyMode ? config.authApiKeyHelperPath : null,
+          maskCredentials: apiKeyMode,
         }
       : ({} as MembraneInputs);
 
@@ -823,7 +844,16 @@ export class SessionService {
     } else {
       wrapped = wrapArgv(innerArgv, { profile, backend, membrane });
     }
-    const agent = this.deps.herdr.start(ctx.name, ctx.worktreePath, wrapped);
+    // api-key passthrough (trusted, or a sandboxed profile degraded to no-backend):
+    // no membrane to mask the credential in place, so point the spawn at the
+    // credential-less mirror dir. The membrane case masks creds in place (keeping
+    // the operator's real ~/.claude customizations), so it needs no env override.
+    // The egress branch is always willWrap, so this is undefined there.
+    const spawnEnv =
+      apiKeyMode && !willWrap
+        ? { CLAUDE_CONFIG_DIR: ensureApiKeyConfigDir(homedir(), config.claudeDir) }
+        : undefined;
+    const agent = this.deps.herdr.start(ctx.name, ctx.worktreePath, wrapped, spawnEnv);
     // Start the egress drop-watcher AFTER herdr.start (the agent is now running).
     if (egressOn && egressAllowlist && egressDnsLog) {
       this.deps.egressWatcher?.start(ctx.sessionId, {

--- a/src/spawn-auth.ts
+++ b/src/spawn-auth.ts
@@ -29,6 +29,14 @@ import { config } from "./config";
 import { spawnAuthSettings } from "./auth-mode";
 import { ensureApiKeyConfigDir } from "./auth-config-dir";
 
+// Test seam: lets tests stub the (real-fs) config-dir provisioning so the suite never
+// scribbles the developer's real ~/.shepherd. Production never sets this. Mirrors the
+// resetBackendCache test seam in sandbox.ts.
+let _provisionForTest: (() => string) | null = null;
+export function __setApiKeyConfigDirProvisionForTest(fn: (() => string) | null): void {
+  _provisionForTest = fn;
+}
+
 /** True when the operator selected api-key auth mode (regardless of whether a key is configured). */
 export function isApiKeyMode(): boolean {
   return config.authMode === "api-key";
@@ -68,5 +76,8 @@ export function apiKeyMembraneFields(): {
  */
 export function apiKeyPassthroughEnv(wrapped: boolean): Record<string, string> | undefined {
   if (config.authMode !== "api-key" || wrapped) return undefined;
-  return { CLAUDE_CONFIG_DIR: ensureApiKeyConfigDir(homedir(), config.claudeDir) };
+  const dir = _provisionForTest
+    ? _provisionForTest()
+    : ensureApiKeyConfigDir(homedir(), config.claudeDir);
+  return { CLAUDE_CONFIG_DIR: dir };
 }

--- a/src/spawn-auth.ts
+++ b/src/spawn-auth.ts
@@ -1,0 +1,72 @@
+/**
+ * Single source of truth for api-key auth-mode SPAWN WIRING.
+ *
+ * Every transient/spawned `claude` Shepherd launches must, in `api-key` mode,
+ * (1) obtain the key via an `apiKeyHelper` in its `--settings`, and (2) see NO
+ * subscription login (`<claudeDir>/.credentials.json`) — else Claude's
+ * interactive "Use custom API key?" prompt hangs the unattended pane.
+ *
+ * The credential is suppressed by ONE of two mechanisms depending on whether
+ * the spawn is bwrap-wrapped (a membrane):
+ *   - Membrane-wrapped: mask the credential file in place + RO-bind the helper,
+ *     via the MembraneInputs fields {@link apiKeyMembraneFields} returns.
+ *   - Never-membraned (plain herdr.start): point the spawn at a credential-less
+ *     mirror config dir via the CLAUDE_CONFIG_DIR env {@link apiKeyPassthroughEnv}
+ *     returns.
+ *
+ * The settings fragment {@link apiKeySettingsFragment} carries the helper in
+ * BOTH cases. In subscription mode every helper here returns the empty/undefined
+ * shape so callers spread/pass it for BYTE-FOR-BYTE-identical behavior.
+ *
+ * This module is the only place that reads `config.authMode` /
+ * `config.authApiKeyHelperPath` for spawning — service.ts, review.ts,
+ * plan-gate.ts, and the four never-membraned spawns (namer, classifier, recap,
+ * distiller) all route through it so the wiring can't drift.
+ */
+
+import { homedir } from "node:os";
+import { config } from "./config";
+import { spawnAuthSettings } from "./auth-mode";
+import { ensureApiKeyConfigDir } from "./auth-config-dir";
+
+/** True when the operator selected api-key auth mode (regardless of whether a key is configured). */
+export function isApiKeyMode(): boolean {
+  return config.authMode === "api-key";
+}
+
+/** True when api-key mode is selected AND a helper path is configured (ready to bill an API key). */
+export function isApiKeyConfigured(): boolean {
+  return config.authMode === "api-key" && config.authApiKeyHelperPath !== null;
+}
+
+/**
+ * Fragment merged into a spawn's --settings JSON: `{apiKeyHelper}` in api-key
+ * mode (configured), else `{}` (byte-for-byte identical for subscription).
+ */
+export function apiKeySettingsFragment(): { apiKeyHelper?: string } {
+  return spawnAuthSettings(config.authMode, config.authApiKeyHelperPath);
+}
+
+/**
+ * Membrane (bwrap) fields for a wrapped spawn: bind the helper RO + mask the
+ * OAuth credential in place. Subscription → `{apiKeyHelperPath:null, maskCredentials:false}`.
+ */
+export function apiKeyMembraneFields(): {
+  apiKeyHelperPath: string | null;
+  maskCredentials: boolean;
+} {
+  const apiKey = config.authMode === "api-key";
+  return { apiKeyHelperPath: apiKey ? config.authApiKeyHelperPath : null, maskCredentials: apiKey };
+}
+
+/**
+ * CLAUDE_CONFIG_DIR env for a spawn that is NOT bwrap-wrapped (passthrough).
+ * `wrapped` = is the spawn bwrap-wrapped (membrane masks the credential in place,
+ * so no env override is needed there). Returns `undefined` in subscription mode
+ * or when wrapped; in api-key passthrough mode it provisions + returns the
+ * credential-less mirror config dir.
+ */
+export function apiKeyPassthroughEnv(wrapped: boolean): Record<string, string> | undefined {
+  if (config.authMode !== "api-key" || wrapped) return undefined;
+  return { CLAUDE_CONFIG_DIR: ensureApiKeyConfigDir(homedir(), config.claudeDir) };
+}

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -18,6 +18,7 @@
  * patch-id churn/revert set mirrors ReviewService's clean-resets-[] / findings-appends logic so an
  * identical-diff rebase is skipped and a revert-to-an-earlier-buggy-diff is re-reviewed.
  */
+import { homedir } from "node:os";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
@@ -25,6 +26,12 @@ import type { GitForge, PrReviewMeta, PullRequest } from "./forge/types";
 import { CRITIC_REVIEW_MARKER } from "./forge/types";
 import { readonlyReviewerArgv } from "./reviewer-argv";
 import { isEpicIntegrationBranch } from "./epic-branch";
+import {
+  isApiKeyMode,
+  isApiKeyConfigured,
+  apiKeyMembraneFields,
+  apiKeyPassthroughEnv,
+} from "./spawn-auth";
 import { readSessionUsage, type SessionUsage } from "./usage";
 import {
   prReviewPrompt,
@@ -37,6 +44,15 @@ import {
   CRITIC_THINKING_TOKENS,
   type RawVerdict,
 } from "./critic-core";
+import {
+  detectBackend as realDetectBackend,
+  wrapArgv,
+  safeRealpath,
+  collectPassthroughEnv,
+  type SandboxBackend,
+  type MembraneInputs,
+} from "./sandbox";
+import { config } from "./config";
 
 /** One PR critic run between its spawn (begin) and its verdict (finalize). Carries everything
  *  finalize needs without re-querying — mirrors ReviewService's InFlight, minus the streak/note
@@ -72,7 +88,7 @@ export interface StandalonePrCriticDeps {
     | "listEpicCompleted"
   >;
   herdr: Pick<HerdrDriver, "start" | "stop">;
-  worktree: Pick<WorktreeMgr, "createDetached" | "remove">;
+  worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "gitCommonDir">;
   resolveForge: (repoPath: string) => GitForge | null;
   /** Candidate repos to consider each sweep. The sweep itself filters to those with
    *  `criticAllPrs` ON (read live, so a toggle takes effect on the next sweep). */
@@ -102,6 +118,16 @@ export interface StandalonePrCriticDeps {
   ) => Promise<{ patchId: string | null; baseSha: string | null; files: string[] }>;
   /** Injectable reader of a finished reviewer's token totals (default: readSessionUsage). */
   readUsage?: (worktreePath: string, criticSessionId: string) => Promise<SessionUsage | null>;
+  /** Injectable sandbox backend probe seam (tests inject `() => null` so no real bwrap is
+   *  spawned). Presence-checked (not `??`) because the seam legitimately returns null. */
+  detectBackend?: () => SandboxBackend;
+  /** Injectable membrane env seam (tests inject a stub so no host paths are touched). */
+  membraneEnv?: () => {
+    claudeDir: string;
+    home: string;
+    nodeBinReal: string;
+    extraEnv?: Record<string, string>;
+  };
 }
 
 export class StandalonePrCriticService {
@@ -125,6 +151,33 @@ export class StandalonePrCriticService {
     worktreePath: string,
     criticSessionId: string,
   ) => Promise<SessionUsage | null>;
+
+  /** Sandbox backend probe: injected seam (tests) or the real cached self-test. Presence-
+   *  checked (not `??`) because the seam legitimately returns null (no backend). */
+  private detectBackend(): SandboxBackend {
+    if (this.deps.detectBackend) return this.deps.detectBackend();
+    return realDetectBackend({
+      home: homedir(),
+      claudeDir: config.claudeDir,
+      nodeBinReal: safeRealpath(config.nodeBin),
+    });
+  }
+
+  /** Membrane env: injected seam (tests) or real host values. */
+  private membraneEnv(): {
+    claudeDir: string;
+    home: string;
+    nodeBinReal: string;
+    extraEnv?: Record<string, string>;
+  } {
+    if (this.deps.membraneEnv) return this.deps.membraneEnv();
+    return {
+      claudeDir: config.claudeDir,
+      home: homedir(),
+      nodeBinReal: safeRealpath(config.nodeBin),
+      extraEnv: collectPassthroughEnv(),
+    };
+  }
 
   constructor(private deps: StandalonePrCriticDeps) {
     this.now = deps.now ?? Date.now;
@@ -356,56 +409,116 @@ export class StandalonePrCriticService {
       // Resolve the base for the prompt: the concrete fingerprinted SHA when we have it (so the
       // review diffs the identical base the skip decision used), else the base branch name.
       const diffBase = baseSha ?? meta.baseRefName;
-      const { argv, sessionId: criticSessionId } = readonlyReviewerArgv(
-        this.deps.model ?? null,
-        prReviewPrompt(diffBase, pr.title, meta.body),
-        // Same extended thinking budget as the session critic (#604): the standalone PR critic
-        // runs the identical #597 VERIFY prompt and needs the same cross-file reasoning headroom.
-        CRITIC_THINKING_TOKENS,
-      );
-
-      let terminalId: string;
-      try {
-        terminalId = this.deps.herdr.start(
-          `pr-critic ${repoPath}#${pr.number}`,
-          wt.worktreePath,
-          argv,
-        ).terminalId;
-      } catch (err) {
-        this.log(`[pr-critic] spawn failed for ${repoPath}#${pr.number}: ${String(err)}`);
-        this.deps.worktree.remove(wt.worktreePath);
-        return;
-      }
-
-      this.inFlight.set(key, {
-        repoPath,
-        prNumber: pr.number,
-        branch: pr.headRefName!,
-        headSha: pr.headSha!,
+      // Fail-closed guard + membrane-wrapped spawn + spawn-row record live in spawnAndRecord (keeps
+      // begin under the cognitive budget). Returns false when nothing spawned (fail-closed / spawn
+      // error) — the worktree is reaped inside, so begin just bails.
+      await this.spawnAndRecord(repoPath, pr, wt.worktreePath, diffBase, meta.body, key, {
         patchId,
         baseSha,
         files,
-        worktreePath: wt.worktreePath,
-        terminalId,
-        criticSessionId,
-        startedAt: this.now(),
         priorReviewedPatchIds: prior?.reviewedPatchIds ?? [],
-      });
-      // Persist the spawn row now (totals NULL until finalize) so review burn is attributable even
-      // if the run crashes/times out before a verdict (issue #502). The taskSessionId column is
-      // opaque TEXT with no FK to `sessions`, so a synthetic `pr:<repo>#<n>` is safe — it just
-      // labels the cost as belonging to this PR, not a managed session.
-      this.deps.store.recordReviewerSpawn({
-        reviewerSessionId: criticSessionId,
-        taskSessionId: `pr:${repoPath}#${pr.number}`,
-        kind: "review",
-        worktreePath: wt.worktreePath,
-        model: this.deps.model ?? null,
-        spawnedAt: this.now(),
       });
     } finally {
       this.starting.delete(key);
     }
+  }
+
+  /**
+   * Build the membrane-wrapped critic argv and spawn it, recording the in-flight run + spawn row on
+   * success. Extracted from begin() so begin stays under the complexity budget. Fail-closed: in
+   * api-key mode with no configured key it logs, reaps the worktree, and returns without spawning
+   * (never bills the subscription) — mirrors ReviewService.begin. On a spawn error it likewise reaps
+   * and returns. The FS membrane matches ReviewService (#601): an isolated worktree gets per-task
+   * binds (worktree + git common dir), not the whole repo; wrapArgv degrades to passthrough when no
+   * bwrap backend (no behavior change on backend-less hosts), and api-key mode masks the OAuth
+   * credential + binds the helper (passthrough carries a credential-less CLAUDE_CONFIG_DIR instead).
+   */
+  private async spawnAndRecord(
+    repoPath: string,
+    pr: PullRequest,
+    worktreePath: string,
+    diffBase: string,
+    prBody: string,
+    key: string,
+    fp: {
+      patchId: string;
+      baseSha: string | null;
+      files: string[];
+      priorReviewedPatchIds: string[];
+    },
+  ): Promise<void> {
+    if (isApiKeyMode() && !isApiKeyConfigured()) {
+      this.log(
+        `[pr-critic] ${repoPath}#${pr.number} api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)`,
+      );
+      this.deps.worktree.remove(worktreePath);
+      return;
+    }
+    const { argv, sessionId: criticSessionId } = readonlyReviewerArgv(
+      this.deps.model ?? null,
+      prReviewPrompt(diffBase, pr.title, prBody),
+      // Same extended thinking budget as the session critic (#604): the standalone PR critic runs
+      // the identical #597 VERIFY prompt and needs the same cross-file reasoning headroom.
+      CRITIC_THINKING_TOKENS,
+    );
+    const backend = this.detectBackend();
+    const env = this.membraneEnv();
+    const membrane: MembraneInputs = {
+      worktreePath,
+      gitCommonDir: this.deps.worktree.gitCommonDir(worktreePath),
+      isolated: true,
+      repoPath,
+      claudeDir: env.claudeDir,
+      home: env.home,
+      nodeBinReal: env.nodeBinReal,
+      extraEnv: env.extraEnv,
+      // api-key mode: a bwrap-wrapped reviewer masks the OAuth credential + binds the helper.
+      ...apiKeyMembraneFields(),
+    };
+    const wrapped = wrapArgv(argv, { profile: "standard", backend, membrane });
+
+    let terminalId: string;
+    try {
+      terminalId = this.deps.herdr.start(
+        `pr-critic ${repoPath}#${pr.number}`,
+        worktreePath,
+        wrapped,
+        // No backend → passthrough (no membrane) → set CLAUDE_CONFIG_DIR to a credential-less
+        // mirror; with a backend the membrane masks creds in place.
+        apiKeyPassthroughEnv(backend !== null),
+      ).terminalId;
+    } catch (err) {
+      this.log(`[pr-critic] spawn failed for ${repoPath}#${pr.number}: ${String(err)}`);
+      this.deps.worktree.remove(worktreePath);
+      return;
+    }
+
+    this.inFlight.set(key, {
+      repoPath,
+      prNumber: pr.number,
+      branch: pr.headRefName!,
+      headSha: pr.headSha!,
+      patchId: fp.patchId,
+      baseSha: fp.baseSha,
+      files: fp.files,
+      worktreePath,
+      terminalId,
+      criticSessionId,
+      startedAt: this.now(),
+      priorReviewedPatchIds: fp.priorReviewedPatchIds,
+    });
+    // Persist the spawn row now (totals NULL until finalize) so review burn is attributable even if
+    // the run crashes/times out before a verdict (issue #502). The taskSessionId column is opaque
+    // TEXT with no FK to `sessions`, so a synthetic `pr:<repo>#<n>` is safe — it just labels the cost
+    // as belonging to this PR, not a managed session.
+    this.deps.store.recordReviewerSpawn({
+      reviewerSessionId: criticSessionId,
+      taskSessionId: `pr:${repoPath}#${pr.number}`,
+      kind: "review",
+      worktreePath,
+      model: this.deps.model ?? null,
+      spawnedAt: this.now(),
+    });
   }
 
   /** The 15s finalize poll. Mirror ReviewService.tick: for each in-flight run not already

--- a/src/usage-limits.ts
+++ b/src/usage-limits.ts
@@ -1,4 +1,5 @@
 import type { AccountUsageIndex } from "./usage";
+import { isApiKeyMode } from "./spawn-auth";
 
 export type WindowKey = "session5h" | "week";
 
@@ -228,6 +229,9 @@ export interface UsageLimits {
   credits: CreditWindow | null;
   stale: boolean;
   calibratedAt: number | null;
+  /** true in api-key auth mode: usage tracking is subscription-only, so the meters carry no
+   *  data and the UI shows an explicit subscription-only state (not a fake zero meter). */
+  subscriptionOnly: boolean;
 }
 
 // Credits is scrape-fresh-only (no local signal to recompute from), so it goes stale fast —
@@ -282,6 +286,9 @@ export class UsageLimitsService {
 
   /** Scrape `/usage` and recalibrate the per-window caps from local JSONL. */
   async calibrate(now: number): Promise<boolean> {
+    // Subscription-only: never spawn the probe under api-key auth — the /usage panel doesn't
+    // exist for API-key accounts and spawning a bare claude risks a hang on the auth prompt.
+    if (isApiKeyMode()) return false;
     const raw = await this.probe.scrape();
     if (!raw) return false;
     const parsed = parseUsageFrame(raw, now);
@@ -379,6 +386,6 @@ export class UsageLimitsService {
         stale: now - snap.scrapedAt > CREDIT_STALE_MS,
       };
     }
-    return { session5h, week, credits, stale, calibratedAt };
+    return { session5h, week, credits, stale, calibratedAt, subscriptionOnly: isApiKeyMode() };
   }
 }

--- a/src/usage-probe.ts
+++ b/src/usage-probe.ts
@@ -2,6 +2,7 @@ import type { HerdrDriver } from "./herdr";
 import { parseUsageFrame, type UsageProbe } from "./usage-limits";
 import { config } from "./config";
 import { compileCacheDir } from "./tmp-sweep";
+import { isApiKeyMode } from "./spawn-auth";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const decoder = new TextDecoder();
@@ -51,6 +52,8 @@ export class HerdrUsageProbe implements UsageProbe {
   }
 
   async scrape(): Promise<string | null> {
+    // subscription-only; never spawn under api-key auth — see usage-limits calibrate short-circuit
+    if (isApiKeyMode()) return null;
     // Reap leftovers from any prior run that didn't clean up after itself, so probe tabs can't
     // accumulate in herdr over time.
     this.sweep();

--- a/test/auth-config-dir.test.ts
+++ b/test/auth-config-dir.test.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   rmSync,
   writeFileSync,
+  readFileSync,
   lstatSync,
   realpathSync,
   existsSync,
@@ -13,6 +14,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   CREDENTIAL_FILE,
+  CONFIG_FILE,
   apiKeyConfigDir,
   provisionApiKeyConfigDir,
   ensureApiKeyConfigDir,
@@ -60,6 +62,77 @@ function buildFakeSource(root: string): string {
 describe("CREDENTIAL_FILE", () => {
   test("is .credentials.json", () => {
     expect(CREDENTIAL_FILE).toBe(".credentials.json");
+  });
+});
+
+// ── CONFIG_FILE (.claude.json copy) ─────────────────────────────────────────────
+
+describe("CONFIG_FILE", () => {
+  test("is .claude.json", () => {
+    expect(CONFIG_FILE).toBe(".claude.json");
+  });
+});
+
+describe("provisionApiKeyConfigDir .claude.json handling", () => {
+  // .claude.json lives at $HOME/.claude.json — a SIBLING of ~/.claude, so it's never
+  // a child the symlink mirror would pick up. Claude reads it from CLAUDE_CONFIG_DIR,
+  // so the mirror must COPY it in or the spawn fails to start. These cover that copy.
+  test("copies the HOME-sibling .claude.json into dest as a real file (not a symlink)", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root); // ${root}/fake-claude
+    writeFileSync(join(root, ".claude.json"), '{"hasCompletedOnboarding":true}');
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    const destConfig = join(dest, ".claude.json");
+    expect(existsSync(destConfig)).toBe(true);
+    expect(lstatSync(destConfig).isSymbolicLink()).toBe(false); // a copy, not a symlink
+    expect(readFileSync(destConfig, "utf8")).toBe('{"hasCompletedOnboarding":true}');
+    // credential still absent; no stray temp file left behind
+    expect(existsSync(join(dest, CREDENTIAL_FILE))).toBe(false);
+    expect(existsSync(`${destConfig}.tmp.${process.pid}`)).toBe(false);
+  });
+
+  test("does not prune .claude.json on re-provision (idempotent) and refreshes it", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const homeConfig = join(root, ".claude.json");
+    writeFileSync(homeConfig, '{"v":1}');
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+    expect(readFileSync(join(dest, ".claude.json"), "utf8")).toBe('{"v":1}');
+
+    // source changes → re-provision picks it up, and the prune step must NOT delete it
+    writeFileSync(homeConfig, '{"v":2}');
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+    expect(existsSync(join(dest, ".claude.json"))).toBe(true);
+    expect(readFileSync(join(dest, ".claude.json"), "utf8")).toBe('{"v":2}');
+  });
+
+  test("is a snapshot copy — mutating dest does not touch the source", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const homeConfig = join(root, ".claude.json");
+    writeFileSync(homeConfig, '{"v":1}');
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+    writeFileSync(join(dest, ".claude.json"), '{"v":"mutated-by-spawn"}');
+    expect(readFileSync(homeConfig, "utf8")).toBe('{"v":1}'); // source untouched
+  });
+
+  test("missing HOME-sibling .claude.json → no dest copy, no throw, credential still absent", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root); // no ${root}/.claude.json written
+    const dest = join(root, "dest");
+
+    expect(() => provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest })).not.toThrow();
+    expect(existsSync(join(dest, ".claude.json"))).toBe(false);
+    expect(existsSync(join(dest, CREDENTIAL_FILE))).toBe(false);
+    // mirror still built
+    expect(existsSync(join(dest, "settings.json"))).toBe(true);
   });
 });
 

--- a/test/auth-config-dir.test.ts
+++ b/test/auth-config-dir.test.ts
@@ -1,0 +1,321 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  lstatSync,
+  realpathSync,
+  existsSync,
+  symlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  CREDENTIAL_FILE,
+  apiKeyConfigDir,
+  provisionApiKeyConfigDir,
+  ensureApiKeyConfigDir,
+} from "../src/auth-config-dir";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+let tmpRoot: string | null = null;
+
+function makeTmp(): string {
+  tmpRoot = mkdtempSync(join(tmpdir(), "auth-config-dir-test-"));
+  return tmpRoot;
+}
+
+afterEach(() => {
+  if (tmpRoot) {
+    try {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+    tmpRoot = null;
+  }
+});
+
+/** Build a fake source claude dir with representative contents. */
+function buildFakeSource(root: string): string {
+  const src = join(root, "fake-claude");
+  mkdirSync(src, { recursive: true });
+
+  // Credential file — must NOT appear in dest.
+  writeFileSync(join(src, ".credentials.json"), '{"token":"super-secret"}');
+  // Representative files that MUST appear in dest.
+  writeFileSync(join(src, "settings.json"), '{"theme":"dark"}');
+  writeFileSync(join(src, "CLAUDE.md"), "# Instructions");
+  // Subdir with a file.
+  mkdirSync(join(src, "skills"), { recursive: true });
+  writeFileSync(join(src, "skills", "my-skill.md"), "skill content");
+
+  return src;
+}
+
+// ── CREDENTIAL_FILE ───────────────────────────────────────────────────────────
+
+describe("CREDENTIAL_FILE", () => {
+  test("is .credentials.json", () => {
+    expect(CREDENTIAL_FILE).toBe(".credentials.json");
+  });
+});
+
+// ── apiKeyConfigDir ───────────────────────────────────────────────────────────
+
+describe("apiKeyConfigDir", () => {
+  test("is nested under .shepherd/", () => {
+    const dir = apiKeyConfigDir("/home/user");
+    expect(dir).toContain(".shepherd");
+    expect(dir.startsWith("/home/user")).toBe(true);
+  });
+
+  test("is deterministic for same home", () => {
+    expect(apiKeyConfigDir("/home/user")).toBe(apiKeyConfigDir("/home/user"));
+  });
+});
+
+// ── provisionApiKeyConfigDir — basic provisioning ─────────────────────────────
+
+describe("provisionApiKeyConfigDir — basic provisioning", () => {
+  test("destDir is created and exists", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    expect(existsSync(dest)).toBe(true);
+  });
+
+  test("settings.json appears as a symlink in dest", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    const stat = lstatSync(join(dest, "settings.json"));
+    expect(stat.isSymbolicLink()).toBe(true);
+  });
+
+  test("CLAUDE.md appears as a symlink in dest", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    const stat = lstatSync(join(dest, "CLAUDE.md"));
+    expect(stat.isSymbolicLink()).toBe(true);
+  });
+
+  test("skills/ subdir appears as a symlink in dest", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    const stat = lstatSync(join(dest, "skills"));
+    expect(stat.isSymbolicLink()).toBe(true);
+  });
+
+  test(".credentials.json does NOT appear in dest", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    expect(existsSync(join(dest, CREDENTIAL_FILE))).toBe(false);
+  });
+});
+
+// ── symlinks resolve to correct absolute source paths ─────────────────────────
+
+describe("provisionApiKeyConfigDir — symlink targets", () => {
+  test("settings.json symlink resolves to the source file", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    const resolved = realpathSync(join(dest, "settings.json"));
+    expect(resolved).toBe(realpathSync(join(src, "settings.json")));
+  });
+
+  test("skills/ symlink resolves to source skills/ dir", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    const resolved = realpathSync(join(dest, "skills"));
+    expect(resolved).toBe(realpathSync(join(src, "skills")));
+  });
+});
+
+// ── idempotency ───────────────────────────────────────────────────────────────
+
+describe("provisionApiKeyConfigDir — idempotent", () => {
+  test("calling twice does not throw", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+
+    expect(() => {
+      provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+      provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+    }).not.toThrow();
+  });
+
+  test("calling twice yields the same symlinks", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    const resolved = realpathSync(join(dest, "settings.json"));
+    expect(resolved).toBe(realpathSync(join(src, "settings.json")));
+    expect(existsSync(join(dest, CREDENTIAL_FILE))).toBe(false);
+  });
+});
+
+// ── self-healing ──────────────────────────────────────────────────────────────
+
+describe("provisionApiKeyConfigDir — self-healing", () => {
+  test("stale symlink in dest is removed on re-provision", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+    mkdirSync(dest, { recursive: true });
+
+    // Add a stale symlink pointing to a non-existent source entry.
+    const stale = join(src, "old-entry.txt");
+    symlinkSync(stale, join(dest, "old-entry.txt"));
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    expect(existsSync(join(dest, "old-entry.txt"))).toBe(false);
+  });
+
+  test("stale real file in dest is removed on re-provision", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+    mkdirSync(dest, { recursive: true });
+
+    // Write a real file for an entry that no longer exists in source.
+    writeFileSync(join(dest, "orphan.txt"), "stale data");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    expect(existsSync(join(dest, "orphan.txt"))).toBe(false);
+  });
+
+  test("removed source entry causes dest symlink to disappear on re-provision", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+    expect(lstatSync(join(dest, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+
+    // Remove source entry.
+    rmSync(join(src, "CLAUDE.md"));
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    expect(existsSync(join(dest, "CLAUDE.md"))).toBe(false);
+  });
+
+  test("pre-existing real .credentials.json in dest is removed", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+    mkdirSync(dest, { recursive: true });
+
+    // Manually place a real credential file in dest (bad prior state).
+    writeFileSync(join(dest, CREDENTIAL_FILE), '{"token":"leaked"}');
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    expect(existsSync(join(dest, CREDENTIAL_FILE))).toBe(false);
+  });
+});
+
+// ── missing source dir ────────────────────────────────────────────────────────
+
+describe("provisionApiKeyConfigDir — missing source dir", () => {
+  test("does not throw when sourceClaudeDir does not exist", () => {
+    const root = makeTmp();
+    const dest = join(root, "dest");
+
+    expect(() =>
+      provisionApiKeyConfigDir({
+        sourceClaudeDir: join(root, "nonexistent"),
+        destDir: dest,
+      }),
+    ).not.toThrow();
+  });
+
+  test("creates destDir when source is missing", () => {
+    const root = makeTmp();
+    const dest = join(root, "dest");
+
+    provisionApiKeyConfigDir({
+      sourceClaudeDir: join(root, "nonexistent"),
+      destDir: dest,
+    });
+
+    expect(existsSync(dest)).toBe(true);
+  });
+
+  test("returns destDir when source is missing", () => {
+    const root = makeTmp();
+    const dest = join(root, "dest");
+
+    const result = provisionApiKeyConfigDir({
+      sourceClaudeDir: join(root, "nonexistent"),
+      destDir: dest,
+    });
+
+    expect(result).toBe(dest);
+  });
+});
+
+// ── ensureApiKeyConfigDir ─────────────────────────────────────────────────────
+
+describe("ensureApiKeyConfigDir", () => {
+  test("returns the canonical apiKeyConfigDir path", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const home = join(root, "home");
+    mkdirSync(home, { recursive: true });
+
+    const result = ensureApiKeyConfigDir(home, src);
+
+    expect(result).toBe(apiKeyConfigDir(home));
+  });
+
+  test("provisions symlinks correctly via the convenience wrapper", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const home = join(root, "home");
+    mkdirSync(home, { recursive: true });
+
+    ensureApiKeyConfigDir(home, src);
+
+    const dest = apiKeyConfigDir(home);
+    expect(existsSync(join(dest, "settings.json"))).toBe(true);
+    expect(lstatSync(join(dest, "settings.json")).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(dest, CREDENTIAL_FILE))).toBe(false);
+  });
+});

--- a/test/auth-config-dir.test.ts
+++ b/test/auth-config-dir.test.ts
@@ -236,6 +236,25 @@ describe("provisionApiKeyConfigDir — self-healing", () => {
     expect(existsSync(join(dest, "CLAUDE.md"))).toBe(false);
   });
 
+  test("wrong-target symlink in dest is replaced with correct target on re-provision", () => {
+    const root = makeTmp();
+    const src = buildFakeSource(root);
+    const dest = join(root, "dest");
+    mkdirSync(dest, { recursive: true });
+
+    // Pre-create a symlink for settings.json pointing at a WRONG absolute path.
+    const wrongTarget = join(root, "wrong", "settings.json");
+    symlinkSync(wrongTarget, join(dest, "settings.json"));
+
+    provisionApiKeyConfigDir({ sourceClaudeDir: src, destDir: dest });
+
+    // The symlink must now resolve to the correct source file.
+    const stat = lstatSync(join(dest, "settings.json"));
+    expect(stat.isSymbolicLink()).toBe(true);
+    const resolved = realpathSync(join(dest, "settings.json"));
+    expect(resolved).toBe(realpathSync(join(src, "settings.json")));
+  });
+
   test("pre-existing real .credentials.json in dest is removed", () => {
     const root = makeTmp();
     const src = buildFakeSource(root);

--- a/test/auth-mode.test.ts
+++ b/test/auth-mode.test.ts
@@ -10,7 +10,6 @@ import {
   readApiKeyHelperPath,
   clearApiKeyHelper,
   spawnAuthSettings,
-  redactKey,
   API_KEY_HELPER_FILE,
 } from "../src/auth-mode";
 
@@ -214,30 +213,5 @@ describe("spawnAuthSettings", () => {
   test("spread into an object is safe and produces no extra keys in subscription mode", () => {
     const settings = { model: "sonnet", ...spawnAuthSettings("subscription", null) };
     expect(Object.keys(settings)).toEqual(["model"]);
-  });
-});
-
-// ── redactKey ─────────────────────────────────────────────────────────────────
-
-describe("redactKey", () => {
-  test("redacts a sample Anthropic API key", () => {
-    const s = "using key sk-ant-api03-abc123XYZ in request";
-    const out = redactKey(s);
-    expect(out).not.toContain("abc123XYZ");
-    expect(out).toContain("sk-ant-***");
-    expect(out).toContain("in request");
-  });
-
-  test("leaves non-key text intact", () => {
-    const s = "no secrets here";
-    expect(redactKey(s)).toBe(s);
-  });
-
-  test("redacts multiple occurrences", () => {
-    const s = "key1=sk-ant-api03-AAA key2=sk-ant-api03-BBB";
-    const out = redactKey(s);
-    expect(out).not.toContain("AAA");
-    expect(out).not.toContain("BBB");
-    expect((out.match(/sk-ant-\*\*\*/g) ?? []).length).toBe(2);
   });
 });

--- a/test/auth-mode.test.ts
+++ b/test/auth-mode.test.ts
@@ -1,0 +1,243 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, statSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  normalizeAuthModeSetting,
+  isAuthMode,
+  AUTH_MODES,
+  writeApiKeyHelper,
+  readApiKeyHelperPath,
+  clearApiKeyHelper,
+  spawnAuthSettings,
+  redactKey,
+  API_KEY_HELPER_FILE,
+} from "../src/auth-mode";
+
+// ── normalizeAuthModeSetting ──────────────────────────────────────────────────
+
+describe("normalizeAuthModeSetting", () => {
+  test("accepts 'subscription'", () => {
+    expect(normalizeAuthModeSetting("subscription")).toBe("subscription");
+  });
+
+  test("accepts 'api-key'", () => {
+    expect(normalizeAuthModeSetting("api-key")).toBe("api-key");
+  });
+
+  test("returns null for unknown string", () => {
+    expect(normalizeAuthModeSetting("oauth")).toBeNull();
+    expect(normalizeAuthModeSetting("")).toBeNull();
+    expect(normalizeAuthModeSetting("API-KEY")).toBeNull();
+  });
+
+  test("returns null for null", () => {
+    expect(normalizeAuthModeSetting(null)).toBeNull();
+  });
+
+  test("returns null for undefined", () => {
+    expect(normalizeAuthModeSetting(undefined)).toBeNull();
+  });
+
+  test("returns null for number", () => {
+    expect(normalizeAuthModeSetting(42)).toBeNull();
+  });
+
+  test("returns null for object", () => {
+    expect(normalizeAuthModeSetting({})).toBeNull();
+  });
+});
+
+// ── isAuthMode ────────────────────────────────────────────────────────────────
+
+describe("isAuthMode", () => {
+  test("returns true for each AUTH_MODES entry", () => {
+    for (const mode of AUTH_MODES) {
+      expect(isAuthMode(mode)).toBe(true);
+    }
+  });
+
+  test("returns false for unknown string", () => {
+    expect(isAuthMode("oauth")).toBe(false);
+    expect(isAuthMode("")).toBe(false);
+  });
+
+  test("returns false for non-string", () => {
+    expect(isAuthMode(null)).toBe(false);
+    expect(isAuthMode(undefined)).toBe(false);
+    expect(isAuthMode(42)).toBe(false);
+    expect(isAuthMode({})).toBe(false);
+  });
+});
+
+// ── apiKeyHelper filesystem lifecycle ─────────────────────────────────────────
+
+let tmpDir: string | null = null;
+
+function makeTmp(): string {
+  tmpDir = mkdtempSync(join(tmpdir(), "auth-mode-test-"));
+  return tmpDir;
+}
+
+afterEach(() => {
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+    tmpDir = null;
+  }
+});
+
+describe("writeApiKeyHelper", () => {
+  test("returns an absolute path ending in the known filename", () => {
+    const dir = makeTmp();
+    const path = writeApiKeyHelper("sk-ant-test123", dir);
+    expect(path).toMatch(new RegExp(`${API_KEY_HELPER_FILE}$`));
+    expect(path.startsWith("/")).toBe(true);
+  });
+
+  test("file has mode 0o700 set", () => {
+    const dir = makeTmp();
+    const path = writeApiKeyHelper("sk-ant-test123", dir);
+    const s = statSync(path);
+    expect(s.mode & 0o700).toBe(0o700);
+  });
+
+  test("executing the script prints exactly the key", () => {
+    const dir = makeTmp();
+    const key = "sk-ant-api03-hello";
+    const path = writeApiKeyHelper(key, dir);
+    const result = Bun.spawnSync([path]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toBe(key);
+  });
+
+  test("handles key with shell metacharacters safely", () => {
+    const dir = makeTmp();
+    // Key containing single quote, dollar sign, double quote, semicolon, space
+    const key = "a'b$c\"d ;e";
+    const path = writeApiKeyHelper(key, dir);
+    const result = Bun.spawnSync([path]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toBe(key);
+  });
+
+  test("handles key with multiple single quotes", () => {
+    const dir = makeTmp();
+    const key = "sk-ant-it's'tricky";
+    const path = writeApiKeyHelper(key, dir);
+    const result = Bun.spawnSync([path]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toBe(key);
+  });
+
+  test("creates dir if it does not exist", () => {
+    const dir = makeTmp();
+    const nested = join(dir, "subdir", "deeper");
+    const path = writeApiKeyHelper("sk-ant-x", nested);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test("throws on empty key", () => {
+    const dir = makeTmp();
+    expect(() => writeApiKeyHelper("", dir)).toThrow();
+  });
+
+  test("throws on whitespace-only key", () => {
+    const dir = makeTmp();
+    expect(() => writeApiKeyHelper("   ", dir)).toThrow();
+  });
+});
+
+describe("readApiKeyHelperPath", () => {
+  test("returns path when helper exists", () => {
+    const dir = makeTmp();
+    writeApiKeyHelper("sk-ant-exists", dir);
+    const result = readApiKeyHelperPath(dir);
+    expect(result).not.toBeNull();
+    expect(result).toMatch(new RegExp(`${API_KEY_HELPER_FILE}$`));
+  });
+
+  test("returns null when helper does not exist", () => {
+    const dir = makeTmp();
+    expect(readApiKeyHelperPath(dir)).toBeNull();
+  });
+
+  test("returns null when dir does not exist", () => {
+    expect(readApiKeyHelperPath("/nonexistent/path/that/does/not/exist")).toBeNull();
+  });
+});
+
+describe("clearApiKeyHelper", () => {
+  test("removes the helper script", () => {
+    const dir = makeTmp();
+    writeApiKeyHelper("sk-ant-remove-me", dir);
+    expect(readApiKeyHelperPath(dir)).not.toBeNull();
+    clearApiKeyHelper(dir);
+    expect(readApiKeyHelperPath(dir)).toBeNull();
+  });
+
+  test("is idempotent — no throw when already gone", () => {
+    const dir = makeTmp();
+    expect(() => clearApiKeyHelper(dir)).not.toThrow();
+    expect(() => clearApiKeyHelper(dir)).not.toThrow();
+  });
+
+  test("is idempotent — no throw when dir does not exist", () => {
+    expect(() => clearApiKeyHelper("/nonexistent/path")).not.toThrow();
+  });
+});
+
+// ── spawnAuthSettings ─────────────────────────────────────────────────────────
+
+describe("spawnAuthSettings", () => {
+  test("api-key mode with a path returns { apiKeyHelper: path }", () => {
+    const result = spawnAuthSettings("api-key", "/some/path/helper.sh");
+    expect(result).toEqual({ apiKeyHelper: "/some/path/helper.sh" });
+  });
+
+  test("subscription mode returns empty object regardless of path", () => {
+    expect(spawnAuthSettings("subscription", "/some/path/helper.sh")).toEqual({});
+    expect(spawnAuthSettings("subscription", null)).toEqual({});
+  });
+
+  test("api-key mode with null path returns empty object", () => {
+    expect(spawnAuthSettings("api-key", null)).toEqual({});
+  });
+
+  test("api-key mode with empty string path returns empty object", () => {
+    expect(spawnAuthSettings("api-key", "")).toEqual({});
+  });
+
+  test("spread into an object is safe and produces no extra keys in subscription mode", () => {
+    const settings = { model: "sonnet", ...spawnAuthSettings("subscription", null) };
+    expect(Object.keys(settings)).toEqual(["model"]);
+  });
+});
+
+// ── redactKey ─────────────────────────────────────────────────────────────────
+
+describe("redactKey", () => {
+  test("redacts a sample Anthropic API key", () => {
+    const s = "using key sk-ant-api03-abc123XYZ in request";
+    const out = redactKey(s);
+    expect(out).not.toContain("abc123XYZ");
+    expect(out).toContain("sk-ant-***");
+    expect(out).toContain("in request");
+  });
+
+  test("leaves non-key text intact", () => {
+    const s = "no secrets here";
+    expect(redactKey(s)).toBe(s);
+  });
+
+  test("redacts multiple occurrences", () => {
+    const s = "key1=sk-ant-api03-AAA key2=sk-ant-api03-BBB";
+    const out = redactKey(s);
+    expect(out).not.toContain("AAA");
+    expect(out).not.toContain("BBB");
+    expect((out.match(/sk-ant-\*\*\*/g) ?? []).length).toBe(2);
+  });
+});

--- a/test/autopilot-llm.test.ts
+++ b/test/autopilot-llm.test.ts
@@ -1,6 +1,15 @@
-import { test, expect } from "bun:test";
+import { test, expect, beforeEach, afterEach } from "bun:test";
 import { classifyStop, classifierPrompt, VERDICT_FILE } from "../src/autopilot-llm";
 import { config } from "../src/config";
+import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+
+beforeEach(() => {
+  __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
+});
+
+afterEach(() => {
+  __setApiKeyConfigDirProvisionForTest(null);
+});
 
 async function withAuth<T>(
   mode: typeof config.authMode,

--- a/test/autopilot-llm.test.ts
+++ b/test/autopilot-llm.test.ts
@@ -1,12 +1,30 @@
 import { test, expect } from "bun:test";
 import { classifyStop, classifierPrompt, VERDICT_FILE } from "../src/autopilot-llm";
+import { config } from "../src/config";
+
+async function withAuth<T>(
+  mode: typeof config.authMode,
+  helper: string | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  config.authMode = mode;
+  config.authApiKeyHelperPath = helper;
+  try {
+    return await fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
 
 function makeDeps(over: Partial<import("../src/autopilot-llm").ClassifierDeps> = {}) {
   const calls: any = { started: null, stopped: false, cleaned: false };
   const base = {
     herdr: {
-      start: (name: string, cwd: string, argv: string[]) => {
-        calls.started = { name, cwd, argv };
+      start: (name: string, cwd: string, argv: string[], env?: Record<string, string>) => {
+        calls.started = { name, cwd, argv, env };
         return { terminalId: "term_c", cwd } as any;
       },
       stop: () => {
@@ -63,6 +81,41 @@ test("classifyStop: parses a gate verdict; spawns haiku, dontAsk, Write-only", a
   expect(calls.started.argv[calls.started.argv.length - 1]).toContain("task");
   expect(calls.stopped).toBe(true);
   expect(calls.cleaned).toBe(true);
+});
+
+test("classifyStop: subscription mode — --settings unchanged + no env 4th arg", async () => {
+  const { calls } = await withAuth("subscription", "/ignored.sh", async () => {
+    const d = makeDeps({ readVerdict: () => ({ kind: "gate", summary: "x" }) });
+    await classifyStop(["…"], "task", d.deps, "l");
+    return d;
+  });
+  const argv = calls.started.argv;
+  const settings = JSON.parse(argv[argv.indexOf("--settings") + 1]);
+  expect(settings).toEqual({ disableAllHooks: true });
+  expect(calls.started.env).toBeUndefined();
+});
+
+test("classifyStop: api-key mode — apiKeyHelper in --settings + CLAUDE_CONFIG_DIR env", async () => {
+  const { calls } = await withAuth("api-key", "/helper.sh", async () => {
+    const d = makeDeps({ readVerdict: () => ({ kind: "gate", summary: "x" }) });
+    await classifyStop(["…"], "task", d.deps, "l");
+    return d;
+  });
+  const argv = calls.started.argv;
+  const settings = JSON.parse(argv[argv.indexOf("--settings") + 1]);
+  expect(settings.disableAllHooks).toBe(true);
+  expect(settings.apiKeyHelper).toBe("/helper.sh");
+  expect(Object.keys(calls.started.env)).toEqual(["CLAUDE_CONFIG_DIR"]);
+});
+
+test("classifyStop: api-key without configured key fails closed → SURFACE, no spawn", async () => {
+  const { result, calls } = await withAuth("api-key", null, async () => {
+    const d = makeDeps({ readVerdict: () => ({ kind: "gate", summary: "x" }) });
+    const r = await classifyStop(["…"], "task", d.deps, "l");
+    return { result: r, calls: d.calls };
+  });
+  expect(result).toEqual({ kind: "unknown", summary: "" });
+  expect(calls.started).toBeNull();
 });
 
 test("classifyStop: unknown/surface on timeout (null verdict)", async () => {

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -1,7 +1,16 @@
-import { test, expect } from "bun:test";
+import { test, expect, beforeEach, afterEach } from "bun:test";
 import { DistillerService } from "../src/distiller";
 import { SessionStore } from "../src/store";
 import { config } from "../src/config";
+import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+
+beforeEach(() => {
+  __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
+});
+
+afterEach(() => {
+  __setApiKeyConfigDirProvisionForTest(null);
+});
 
 function withAuth(mode: typeof config.authMode, helper: string | null, fn: () => void): void {
   const prevMode = config.authMode;

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -1,6 +1,20 @@
 import { test, expect } from "bun:test";
 import { DistillerService } from "../src/distiller";
 import { SessionStore } from "../src/store";
+import { config } from "../src/config";
+
+function withAuth(mode: typeof config.authMode, helper: string | null, fn: () => void): void {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  config.authMode = mode;
+  config.authApiKeyHelperPath = helper;
+  try {
+    fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
 
 function seedSignals(store: SessionStore, repo: string, n: number) {
   for (let i = 0; i < n; i++) {
@@ -147,6 +161,69 @@ test("spawn argv follows the safe critic contract (dontAsk after allowlist, bare
   expect(argv).toContain('{"disableAllHooks":true}');
   // the prompt is the trailing positional (last arg), after --permission-mode dontAsk
   expect(argv.length).toBeGreaterThan(mode + 2);
+});
+
+function spawnCapture(store: SessionStore) {
+  const cap: { argv: string[]; env?: Record<string, string>; starts: number; removed: number } = {
+    argv: [],
+    env: undefined,
+    starts: 0,
+    removed: 0,
+  };
+  const deps = {
+    store,
+    herdr: {
+      start: (_n: string, _c: string, a: string[], env?: Record<string, string>) => {
+        cap.argv = a;
+        cap.env = env;
+        cap.starts++;
+        return { terminalId: "d1" };
+      },
+      stop: () => {},
+    } as any,
+    scratch: { create: () => ({ dir: "/scratch" }), remove: () => cap.removed++ },
+    onChange: () => {},
+    now: () => 1000,
+    minSignals: 3,
+    writeSignals: () => {},
+    readProposals: () => null,
+  };
+  return { deps, cap };
+}
+
+test("distill spawn: subscription mode — --settings unchanged + no env 4th arg", () => {
+  withAuth("subscription", "/ignored.sh", () => {
+    const store = new SessionStore(":memory:");
+    seedSignals(store, "/r", 3);
+    const { deps, cap } = spawnCapture(store);
+    new DistillerService(deps as any).distillNow("/r");
+    expect(cap.argv).toContain('{"disableAllHooks":true}');
+    expect(cap.env).toBeUndefined();
+  });
+});
+
+test("distill spawn: api-key mode — apiKeyHelper in --settings + CLAUDE_CONFIG_DIR env", () => {
+  withAuth("api-key", "/helper.sh", () => {
+    const store = new SessionStore(":memory:");
+    seedSignals(store, "/r", 3);
+    const { deps, cap } = spawnCapture(store);
+    new DistillerService(deps as any).distillNow("/r");
+    const settings = JSON.parse(cap.argv[cap.argv.indexOf("--settings") + 1]!);
+    expect(settings.disableAllHooks).toBe(true);
+    expect(settings.apiKeyHelper).toBe("/helper.sh");
+    expect(Object.keys(cap.env!)).toEqual(["CLAUDE_CONFIG_DIR"]);
+  });
+});
+
+test("distill spawn: api-key without a configured key fails closed (no spawn, scratch cleaned)", () => {
+  withAuth("api-key", null, () => {
+    const store = new SessionStore(":memory:");
+    seedSignals(store, "/r", 3);
+    const { deps, cap } = spawnCapture(store);
+    new DistillerService(deps as any).distillNow("/r");
+    expect(cap.starts).toBe(0);
+    expect(cap.removed).toBe(1); // allocated scratch dir cleaned up
+  });
 });
 
 test("tick finalizes and reaps a run that times out without proposals", async () => {

--- a/test/drain-epic-completed.test.ts
+++ b/test/drain-epic-completed.test.ts
@@ -14,6 +14,7 @@ const NO_USAGE: UsageLimitsType = {
   credits: null,
   stale: false,
   calibratedAt: null,
+  subscriptionOnly: false,
 };
 
 /** A forge whose epic has the given native sub-issues (closed flag drives "merged"). */

--- a/test/drain-epic-landing.test.ts
+++ b/test/drain-epic-landing.test.ts
@@ -18,6 +18,7 @@ const NO_USAGE: UsageLimitsType = {
   credits: null,
   stale: false,
   calibratedAt: null,
+  subscriptionOnly: false,
 };
 
 function sub(number: number, closed: boolean): SubIssueRef {

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -17,6 +17,7 @@ const NO_USAGE: UsageLimitsType = {
   credits: null,
   stale: false,
   calibratedAt: null,
+  subscriptionOnly: false,
 };
 
 interface ForgeRec {

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -27,6 +27,7 @@ const NO_USAGE: UsageLimitsType = {
   credits: null,
   stale: false,
   calibratedAt: null,
+  subscriptionOnly: false,
 };
 
 interface ForgeRec {

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -34,6 +34,7 @@ const NO_USAGE: UsageLimitsType = {
   credits: null,
   stale: false,
   calibratedAt: null,
+  subscriptionOnly: false,
 };
 
 interface ForgeRec {

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -396,3 +396,51 @@ test("async runner throws fast (no spawn) while maintenance is active", async ()
     maintenance.end();
   }
 });
+
+// -- env param tests --
+
+function extractPost(calls: string[][]): string[] {
+  const startCall = calls.find((c) => c[0] === "agent" && c[1] === "start")!;
+  return startCall.slice(startCall.indexOf("--") + 1);
+}
+
+test("start with no env arg: wrapped portion is exactly [env, NODE_COMPILE_CACHE=…, claude, …]", () => {
+  const calls: string[][] = [];
+  const d = new HerdrDriver((args) => {
+    calls.push(args);
+    return reply(args, WORKSPACE_LIST);
+  });
+  d.start("flatten", "/wt/a", ["claude", "go"]);
+  const post = extractPost(calls);
+  expect(post).toEqual(["env", "NODE_COMPILE_CACHE=/disk/ncc", "claude", "go"]);
+});
+
+test("start with env arg: extra vars appear after NODE_COMPILE_CACHE, sorted by key, before argv", () => {
+  const calls: string[][] = [];
+  const d = new HerdrDriver((args) => {
+    calls.push(args);
+    return reply(args, WORKSPACE_LIST);
+  });
+  d.start("flatten", "/wt/a", ["claude", "go"], { CLAUDE_CONFIG_DIR: "/x", FOO: "bar" });
+  const post = extractPost(calls);
+  // Keys sorted: CLAUDE_CONFIG_DIR < FOO
+  expect(post).toEqual([
+    "env",
+    "NODE_COMPILE_CACHE=/disk/ncc",
+    "CLAUDE_CONFIG_DIR=/x",
+    "FOO=bar",
+    "claude",
+    "go",
+  ]);
+});
+
+test("start with empty env {}: wrapped is identical to no-env case", () => {
+  const calls: string[][] = [];
+  const d = new HerdrDriver((args) => {
+    calls.push(args);
+    return reply(args, WORKSPACE_LIST);
+  });
+  d.start("flatten", "/wt/a", ["claude", "go"], {});
+  const post = extractPost(calls);
+  expect(post).toEqual(["env", "NODE_COMPILE_CACHE=/disk/ncc", "claude", "go"]);
+});

--- a/test/namer-llm.test.ts
+++ b/test/namer-llm.test.ts
@@ -1,12 +1,30 @@
 import { test, expect } from "bun:test";
 import { llmName, namingPrompt, NAME_FILE } from "../src/namer-llm";
+import { config } from "../src/config";
+
+async function withAuth<T>(
+  mode: typeof config.authMode,
+  helper: string | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  config.authMode = mode;
+  config.authApiKeyHelperPath = helper;
+  try {
+    return await fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
 
 function makeDeps(over: Partial<import("../src/namer-llm").LlmNamerDeps> = {}) {
   const calls: any = { started: null, stopped: false, cleaned: false };
   const base = {
     herdr: {
-      start: (name: string, cwd: string, argv: string[]) => {
-        calls.started = { name, cwd, argv };
+      start: (name: string, cwd: string, argv: string[], env?: Record<string, string>) => {
+        calls.started = { name, cwd, argv, env };
         return { terminalId: "term_n", cwd } as any;
       },
       stop: () => {
@@ -49,6 +67,42 @@ test("llmName: returns sanitized slug, spawns haiku, stops + cleans up", async (
   );
   expect(calls.stopped).toBe(true);
   expect(calls.cleaned).toBe(true);
+});
+
+test("llmName: subscription mode — --settings unchanged + no env 4th arg", async () => {
+  const { calls } = await withAuth("subscription", "/ignored.sh", async () => {
+    const d = makeDeps({ readName: () => "ok-slug" });
+    await llmName("x", d.deps, "l");
+    return d;
+  });
+  const argv = calls.started.argv;
+  const settings = JSON.parse(argv[argv.indexOf("--settings") + 1]);
+  expect(settings).toEqual({ disableAllHooks: true });
+  expect(calls.started.env).toBeUndefined();
+});
+
+test("llmName: api-key mode — --settings gains apiKeyHelper + CLAUDE_CONFIG_DIR env", async () => {
+  const { calls } = await withAuth("api-key", "/helper.sh", async () => {
+    const d = makeDeps({ readName: () => "ok-slug" });
+    await llmName("x", d.deps, "l");
+    return d;
+  });
+  const argv = calls.started.argv;
+  const settings = JSON.parse(argv[argv.indexOf("--settings") + 1]);
+  expect(settings.disableAllHooks).toBe(true);
+  expect(settings.apiKeyHelper).toBe("/helper.sh");
+  expect(calls.started.env).toBeDefined();
+  expect(Object.keys(calls.started.env)).toEqual(["CLAUDE_CONFIG_DIR"]);
+});
+
+test("llmName: api-key mode without a configured key fails closed (returns null, no spawn)", async () => {
+  const { result, calls } = await withAuth("api-key", null, async () => {
+    const d = makeDeps({ readName: () => "ok-slug" });
+    const r = await llmName("x", d.deps, "l");
+    return { result: r, calls: d.calls };
+  });
+  expect(result).toBeNull();
+  expect(calls.started).toBeNull();
 });
 
 test("llmName: takes only the first non-empty line", async () => {

--- a/test/namer-llm.test.ts
+++ b/test/namer-llm.test.ts
@@ -1,6 +1,15 @@
-import { test, expect } from "bun:test";
+import { test, expect, beforeEach, afterEach } from "bun:test";
 import { llmName, namingPrompt, NAME_FILE } from "../src/namer-llm";
 import { config } from "../src/config";
+import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+
+beforeEach(() => {
+  __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
+});
+
+afterEach(() => {
+  __setApiKeyConfigDirProvisionForTest(null);
+});
 
 async function withAuth<T>(
   mode: typeof config.authMode,

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -1,5 +1,23 @@
 import { expect, test } from "bun:test";
 import { PlanGateService } from "../src/plan-gate";
+import { config } from "../src/config";
+
+async function withAuth<T>(
+  mode: typeof config.authMode,
+  helper: string | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  config.authMode = mode;
+  config.authApiKeyHelperPath = helper;
+  try {
+    return await fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
 
 function harness(over: any = {}) {
   const started: any[] = [];
@@ -27,8 +45,8 @@ function harness(over: any = {}) {
   const deps: any = {
     store,
     herdr: {
-      start: (l: string, cwd: string, argv: string[]) => {
-        started.push({ l, cwd, argv });
+      start: (l: string, cwd: string, argv: string[], env?: Record<string, string>) => {
+        started.push({ l, cwd, argv, env });
         return { terminalId: "t1" };
       },
       stop() {},
@@ -84,6 +102,36 @@ test("consider spawns reviewer when a plan exists and is unreviewed", async () =
   expect(h.started[0].argv[h.started[0].argv.length - 1]).toContain("PLAN TEXT");
   expect(h.svc.reviewingIds()).toEqual(["s1"]);
 });
+test("plan-gate: subscription mode — no apiKeyHelper, no env 4th arg", async () => {
+  await withAuth("subscription", "/ignored.sh", async () => {
+    const h = harness();
+    await h.svc.consider(planningSession() as any);
+    const argv = h.started[0].argv;
+    expect(JSON.parse(argv[argv.indexOf("--settings") + 1]).apiKeyHelper).toBeUndefined();
+    expect(h.started[0].env).toBeUndefined();
+  });
+});
+
+test("plan-gate: api-key mode (passthrough host) — apiKeyHelper + CLAUDE_CONFIG_DIR env", async () => {
+  await withAuth("api-key", "/helper.sh", async () => {
+    const h = harness();
+    await h.svc.consider(planningSession() as any);
+    const argv = h.started[0].argv;
+    expect(JSON.parse(argv[argv.indexOf("--settings") + 1]).apiKeyHelper).toBe("/helper.sh");
+    expect(Object.keys(h.started[0].env)).toEqual(["CLAUDE_CONFIG_DIR"]);
+  });
+});
+
+test("plan-gate: api-key without a configured key fails closed → 'error', no spawn, reaped", async () => {
+  await withAuth("api-key", null, async () => {
+    const h = harness();
+    const status = await h.svc.consider(planningSession() as any);
+    expect(status).toBe("error");
+    expect(h.started.length).toBe(0);
+    expect(h.removed).toEqual(["/wt-detached"]);
+  });
+});
+
 test("consider no-ops when plan missing/empty", async () => {
   const h = harness({ readPlan: () => null });
   const status = await h.svc.consider(planningSession() as any);

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -1,6 +1,15 @@
-import { expect, test } from "bun:test";
+import { expect, test, beforeEach, afterEach } from "bun:test";
 import { PlanGateService } from "../src/plan-gate";
 import { config } from "../src/config";
+import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+
+beforeEach(() => {
+  __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
+});
+
+afterEach(() => {
+  __setApiKeyConfigDirProvisionForTest(null);
+});
 
 async function withAuth<T>(
   mode: typeof config.authMode,

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -1,8 +1,17 @@
-import { expect, test } from "bun:test";
+import { expect, test, beforeEach, afterEach } from "bun:test";
 import { RecapService } from "../src/recap";
 import type { Recap, Session } from "../src/types";
 import type { ActivityEntry } from "../src/activity";
 import { config } from "../src/config";
+import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+
+beforeEach(() => {
+  __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
+});
+
+afterEach(() => {
+  __setApiKeyConfigDirProvisionForTest(null);
+});
 
 async function withAuth<T>(
   mode: typeof config.authMode,

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -2,6 +2,24 @@ import { expect, test } from "bun:test";
 import { RecapService } from "../src/recap";
 import type { Recap, Session } from "../src/types";
 import type { ActivityEntry } from "../src/activity";
+import { config } from "../src/config";
+
+async function withAuth<T>(
+  mode: typeof config.authMode,
+  helper: string | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  config.authMode = mode;
+  config.authApiKeyHelperPath = helper;
+  try {
+    return await fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -126,10 +144,15 @@ function makeStore(sessions: Session[] = [], recaps: Recap[] = []): FakeStore {
 type FakePaneEntry = { cwd: string; terminalId: string };
 
 type FakeHerdr = {
-  started: { label: string; cwd: string; argv: string[] }[];
+  started: { label: string; cwd: string; argv: string[]; env?: Record<string, string> }[];
   stopped: string[];
   livePanes: FakePaneEntry[];
-  start: (label: string, cwd: string, argv: string[]) => { terminalId: string };
+  start: (
+    label: string,
+    cwd: string,
+    argv: string[],
+    env?: Record<string, string>,
+  ) => { terminalId: string };
   stop: (id: string) => void;
   list: () => FakePaneEntry[];
 };
@@ -139,9 +162,9 @@ function makeHerdr(livePanes: FakePaneEntry[] = []): FakeHerdr {
     started: [],
     stopped: [],
     livePanes,
-    start: (label, cwd, argv) => {
+    start: (label, cwd, argv, env) => {
       const tid = `tid-${h.started.length + 1}`;
-      h.started.push({ label, cwd, argv });
+      h.started.push({ label, cwd, argv, env });
       h.livePanes.push({ cwd, terminalId: tid });
       return { terminalId: tid };
     },
@@ -516,6 +539,59 @@ test("regenerate: forces spawn even for auto:true (drain)", async () => {
   expect(result).toBe("started");
   expect(herdr.started.length).toBe(1);
   expect(store.getRecap("s1")?.state).toBe("generating");
+});
+
+// ── api-key auth-mode wiring ────────────────────────────────────────────────
+
+test("generate: subscription mode — --settings unchanged + no env 4th arg", async () => {
+  await withAuth("subscription", "/ignored.sh", async () => {
+    const s = makeSession({ status: "idle" });
+    const herdr = makeHerdr();
+    const svc = buildSvc({
+      store: makeStore([s]),
+      herdr,
+      nowFn: () => 1,
+      makeTmpDir: () => "/tmp/r",
+    });
+    await svc.regenerate(s);
+    const argv = herdr.started[0]!.argv;
+    expect(JSON.parse(argv[argv.indexOf("--settings") + 1]!)).toEqual({ disableAllHooks: true });
+    expect(herdr.started[0]!.env).toBeUndefined();
+  });
+});
+
+test("generate: api-key mode — apiKeyHelper in --settings + CLAUDE_CONFIG_DIR env", async () => {
+  await withAuth("api-key", "/helper.sh", async () => {
+    const s = makeSession({ status: "idle" });
+    const herdr = makeHerdr();
+    const svc = buildSvc({
+      store: makeStore([s]),
+      herdr,
+      nowFn: () => 1,
+      makeTmpDir: () => "/tmp/r",
+    });
+    await svc.regenerate(s);
+    const argv = herdr.started[0]!.argv;
+    const settings = JSON.parse(argv[argv.indexOf("--settings") + 1]!);
+    expect(settings.disableAllHooks).toBe(true);
+    expect(settings.apiKeyHelper).toBe("/helper.sh");
+    expect(Object.keys(herdr.started[0]!.env!)).toEqual(["CLAUDE_CONFIG_DIR"]);
+  });
+});
+
+test("generate: api-key without a configured key fails closed → 'error', no spawn", async () => {
+  await withAuth("api-key", null, async () => {
+    const s = makeSession({ status: "idle" });
+    const herdr = makeHerdr();
+    const svc = buildSvc({
+      store: makeStore([s]),
+      herdr,
+      nowFn: () => 1,
+      makeTmpDir: () => "/tmp/r",
+    });
+    expect(await svc.regenerate(s)).toBe("error");
+    expect(herdr.started.length).toBe(0);
+  });
 });
 
 test("regenerate: replaces an existing ready row", async () => {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1,7 +1,16 @@
-import { test, expect } from "bun:test";
+import { test, expect, beforeEach, afterEach } from "bun:test";
 import { ReviewService, reviewPrompt, scopeFindings, CRITIC_THINKING_TOKENS } from "../src/review";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "../src/forge/types";
 import { config } from "../src/config";
+import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+
+beforeEach(() => {
+  __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
+});
+
+afterEach(() => {
+  __setApiKeyConfigDirProvisionForTest(null);
+});
 
 async function withAuth<T>(
   mode: typeof config.authMode,

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1,6 +1,24 @@
 import { test, expect } from "bun:test";
 import { ReviewService, reviewPrompt, scopeFindings, CRITIC_THINKING_TOKENS } from "../src/review";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "../src/forge/types";
+import { config } from "../src/config";
+
+async function withAuth<T>(
+  mode: typeof config.authMode,
+  helper: string | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  config.authMode = mode;
+  config.authApiKeyHelperPath = helper;
+  try {
+    return await fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
 import type { GitForge, GitState, PrComment, PrStatus } from "../src/forge/types";
 import type { Session, ReviewVerdict } from "../src/types";
 
@@ -104,7 +122,7 @@ function makeDeps(
   } = {},
 ) {
   const reviews: Record<string, ReviewVerdict> = {};
-  const started: { name: string; cwd: string; argv: string[] }[] = [];
+  const started: { name: string; cwd: string; argv: string[]; env?: Record<string, string> }[] = [];
   const stopped: string[] = [];
   const removed: string[] = [];
   const bumped: { id: string; headSha: string }[] = []; // bumpReviewHead calls (rebase-skip)
@@ -140,8 +158,8 @@ function makeDeps(
         completedSpawns.push({ id, u, at }),
     },
     herdr: {
-      start: (name: string, cwd: string, argv: string[]) => {
-        started.push({ name, cwd, argv });
+      start: (name: string, cwd: string, argv: string[], env?: Record<string, string>) => {
+        started.push({ name, cwd, argv, env });
         return { terminalId: "rt" } as any;
       },
       stop: (t: string) => stopped.push(t),
@@ -347,6 +365,36 @@ test("critic spawns read-only: no skip-permissions, dontAsk + scoped allowlist",
     env: { MAX_THINKING_TOKENS: String(CRITIC_THINKING_TOKENS) },
   });
   expect(argv).toContain("--safe-mode");
+});
+
+test("critic: subscription mode — no apiKeyHelper, no env 4th arg", async () => {
+  await withAuth("subscription", "/ignored.sh", async () => {
+    const { deps: d, started } = makeDeps({});
+    await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+    const argv = started[0]!.argv;
+    expect(JSON.parse(argv[argv.indexOf("--settings") + 1]!).apiKeyHelper).toBeUndefined();
+    expect(started[0]!.env).toBeUndefined();
+  });
+});
+
+test("critic: api-key mode (passthrough host) — apiKeyHelper + CLAUDE_CONFIG_DIR env", async () => {
+  // detectBackend()→null on the test host → no membrane → passthrough env carries the mirror dir.
+  await withAuth("api-key", "/helper.sh", async () => {
+    const { deps: d, started } = makeDeps({});
+    await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+    const argv = started[0]!.argv;
+    expect(JSON.parse(argv[argv.indexOf("--settings") + 1]!).apiKeyHelper).toBe("/helper.sh");
+    expect(Object.keys(started[0]!.env!)).toEqual(["CLAUDE_CONFIG_DIR"]);
+  });
+});
+
+test("critic: api-key without a configured key fails closed (no spawn, worktree reaped)", async () => {
+  await withAuth("api-key", null, async () => {
+    const { deps: d, started, removed } = makeDeps({});
+    await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+    expect(started).toHaveLength(0);
+    expect(removed).toEqual(["/review-wt"]);
+  });
 });
 
 test("task prompt survives the variadic allowlist (not swallowed → no task → timeout)", async () => {

--- a/test/reviewer-argv.test.ts
+++ b/test/reviewer-argv.test.ts
@@ -1,5 +1,24 @@
 import { expect, test } from "bun:test";
 import { readonlyReviewerArgv } from "../src/reviewer-argv";
+import { config } from "../src/config";
+
+// Temporarily set config auth fields, always restoring them.
+function withAuth(mode: typeof config.authMode, helper: string | null, fn: () => void): void {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  try {
+    config.authMode = mode;
+    config.authApiKeyHelperPath = helper;
+    fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
+
+function settingsOf(argv: string[]): Record<string, unknown> {
+  return JSON.parse(argv[argv.indexOf("--settings") + 1]!);
+}
 
 test("--settings includes enableAllProjectMcpServers and disableAllHooks", () => {
   const { argv: a } = readonlyReviewerArgv(null, "some prompt");
@@ -94,6 +113,36 @@ test("reviewer never bypasses permissions and pins dontAsk", () => {
     expect(permIdx).toBeGreaterThan(-1);
     expect(argv[permIdx + 1]).toBe("dontAsk");
   }
+});
+
+// ── api-key auth-mode wiring ────────────────────────────────────────────────
+
+test("subscription mode: --settings carries NO apiKeyHelper (byte-for-byte)", () => {
+  withAuth("subscription", "/should/be/ignored.sh", () => {
+    const { argv } = readonlyReviewerArgv(null, "p");
+    const s = settingsOf(argv);
+    expect(s.apiKeyHelper).toBeUndefined();
+    // unchanged from the pre-api-key shape
+    expect(s).toEqual({ disableAllHooks: true, enableAllProjectMcpServers: true });
+  });
+});
+
+test("api-key mode (configured): --settings folds in apiKeyHelper after existing keys", () => {
+  withAuth("api-key", "/helper.sh", () => {
+    const { argv } = readonlyReviewerArgv(null, "p");
+    const s = settingsOf(argv);
+    expect(s.apiKeyHelper).toBe("/helper.sh");
+    // existing reviewer invariants untouched
+    expect(s.disableAllHooks).toBe(true);
+    expect(s.enableAllProjectMcpServers).toBe(true);
+  });
+});
+
+test("api-key mode (unconfigured): no apiKeyHelper key emitted", () => {
+  withAuth("api-key", null, () => {
+    const s = settingsOf(readonlyReviewerArgv(null, "p").argv);
+    expect(s.apiKeyHelper).toBeUndefined();
+  });
 });
 
 test("reviewer allowlist excludes write/exec/outbound tools", () => {

--- a/test/sandbox-wiring.test.ts
+++ b/test/sandbox-wiring.test.ts
@@ -561,6 +561,7 @@ const NO_USAGE: UsageLimits = {
   credits: null,
   stale: false,
   calibratedAt: null,
+  subscriptionOnly: false,
 };
 
 function defaultRepoConfig() {

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -256,6 +256,14 @@ function hasTriple(flags: string[], flag: string, a: string, b: string): boolean
   return false;
 }
 
+/** Index of the `flag a b` triple's first token, or -1. */
+function findTripleIndex(flags: string[], flag: string, a: string, b: string): number {
+  for (let i = 0; i + 2 < flags.length; i++) {
+    if (flags[i] === flag && flags[i + 1] === a && flags[i + 2] === b) return i;
+  }
+  return -1;
+}
+
 describe("buildMembraneFlags", () => {
   test("has hardened process isolation flags", () => {
     const f = buildMembraneFlags(fakeMembrane(), detDeps);
@@ -442,6 +450,68 @@ describe("buildMembraneFlags", () => {
   test(".claude.json persisted RW bind via *-bind-try", () => {
     const f = buildMembraneFlags(fakeMembrane(), detDeps);
     expect(hasTriple(f, "--bind-try", "/home/me/.claude.json", "/home/me/.claude.json")).toBe(true);
+  });
+
+  test("subscription (no api-key fields): rw .credentials.json bind, no helper, no /dev/null overlay", () => {
+    const f = buildMembraneFlags(fakeMembrane(), detDeps);
+    // rw credential bind present (today's behavior)
+    expect(
+      hasTriple(
+        f,
+        "--bind-try",
+        "/home/me/.claude/.credentials.json",
+        "/home/me/.claude/.credentials.json",
+      ),
+    ).toBe(true);
+    // no /dev/null overlay of the credential
+    expect(hasTriple(f, "--ro-bind", "/dev/null", "/home/me/.claude/.credentials.json")).toBe(
+      false,
+    );
+  });
+
+  test("no api-key fields => BYTE-IDENTICAL to a bare fakeMembrane (deep equal)", () => {
+    // Explicit nulls/false must produce the exact same flags as omitting them.
+    const bare = buildMembraneFlags(fakeMembrane(), detDeps);
+    const explicit = buildMembraneFlags(
+      fakeMembrane({ apiKeyHelperPath: null, maskCredentials: false }),
+      detDeps,
+    );
+    expect(explicit).toEqual(bare);
+  });
+
+  test("maskCredentials + apiKeyHelperPath: /dev/null overlay AFTER whole-dir bind, helper RO, no rw credential bind", () => {
+    const f = buildMembraneFlags(
+      fakeMembrane({ maskCredentials: true, apiKeyHelperPath: "/h/x.sh" }),
+      detDeps,
+    );
+    // /dev/null overlay of the credential present
+    expect(hasTriple(f, "--ro-bind", "/dev/null", "/home/me/.claude/.credentials.json")).toBe(true);
+    // the rw bind of the credential is GONE
+    expect(
+      hasTriple(
+        f,
+        "--bind-try",
+        "/home/me/.claude/.credentials.json",
+        "/home/me/.claude/.credentials.json",
+      ),
+    ).toBe(false);
+    // overlay must come AFTER the whole-dir RO bind so it wins (last-wins).
+    const wholeDir = findTripleIndex(f, "--ro-bind", "/home/me/.claude", "/home/me/.claude");
+    const overlay = findTripleIndex(
+      f,
+      "--ro-bind",
+      "/dev/null",
+      "/home/me/.claude/.credentials.json",
+    );
+    expect(wholeDir).toBeGreaterThanOrEqual(0);
+    expect(overlay).toBeGreaterThan(wholeDir);
+    // helper bound RO at the same path inside the sandbox
+    expect(hasTriple(f, "--ro-bind-try", "/h/x.sh", "/h/x.sh")).toBe(true);
+  });
+
+  test("apiKeyHelperPath empty/whitespace-guard: empty string => no helper bind", () => {
+    const f = buildMembraneFlags(fakeMembrane({ apiKeyHelperPath: "" }), detDeps);
+    expect(f.some((x) => x === "")).toBe(false);
   });
 
   test("membrane guard: key invariants hold and no --network flags present (no egress plumbing in membrane)", () => {

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -256,14 +256,6 @@ function hasTriple(flags: string[], flag: string, a: string, b: string): boolean
   return false;
 }
 
-/** Index of the `flag a b` triple's first token, or -1. */
-function findTripleIndex(flags: string[], flag: string, a: string, b: string): number {
-  for (let i = 0; i + 2 < flags.length; i++) {
-    if (flags[i] === flag && flags[i + 1] === a && flags[i + 2] === b) return i;
-  }
-  return -1;
-}
-
 describe("buildMembraneFlags", () => {
   test("has hardened process isolation flags", () => {
     const f = buildMembraneFlags(fakeMembrane(), detDeps);
@@ -479,14 +471,31 @@ describe("buildMembraneFlags", () => {
     expect(explicit).toEqual(bare);
   });
 
-  test("maskCredentials + apiKeyHelperPath: /dev/null overlay AFTER whole-dir bind, helper RO, no rw credential bind", () => {
+  test("maskCredentials: .credentials.json ABSENT (per-child binds, no whole-dir bind, no overlay), helper RO", () => {
     const f = buildMembraneFlags(
       fakeMembrane({ maskCredentials: true, apiKeyHelperPath: "/h/x.sh" }),
-      detDeps,
+      {
+        ...detDeps,
+        readdir: () => [
+          ".credentials.json",
+          "skills",
+          "settings.json",
+          "projects",
+          "statsig",
+          "CLAUDE.md",
+        ],
+      },
     );
-    // /dev/null overlay of the credential present
-    expect(hasTriple(f, "--ro-bind", "/dev/null", "/home/me/.claude/.credentials.json")).toBe(true);
-    // the rw bind of the credential is GONE
+    // NO whole-dir RO bind of claudeDir (replaced by per-child binds).
+    expect(hasTriple(f, "--ro-bind", "/home/me/.claude", "/home/me/.claude")).toBe(false);
+    // The mount point still exists via --dir.
+    const di = f.indexOf("--dir");
+    expect(di).toBeGreaterThanOrEqual(0);
+    expect(f[di + 1]).toBe("/home/me/.claude");
+    // NO bind of .credentials.json of ANY kind — the file is absent.
+    expect(hasTriple(f, "--ro-bind", "/dev/null", "/home/me/.claude/.credentials.json")).toBe(
+      false,
+    );
     expect(
       hasTriple(
         f,
@@ -495,16 +504,29 @@ describe("buildMembraneFlags", () => {
         "/home/me/.claude/.credentials.json",
       ),
     ).toBe(false);
-    // overlay must come AFTER the whole-dir RO bind so it wins (last-wins).
-    const wholeDir = findTripleIndex(f, "--ro-bind", "/home/me/.claude", "/home/me/.claude");
-    const overlay = findTripleIndex(
-      f,
-      "--ro-bind",
-      "/dev/null",
-      "/home/me/.claude/.credentials.json",
-    );
-    expect(wholeDir).toBeGreaterThanOrEqual(0);
-    expect(overlay).toBeGreaterThan(wholeDir);
+    expect(
+      hasTriple(
+        f,
+        "--ro-bind-try",
+        "/home/me/.claude/.credentials.json",
+        "/home/me/.claude/.credentials.json",
+      ),
+    ).toBe(false);
+    // Per-child RO binds present for the non-credential entries.
+    expect(
+      hasTriple(f, "--ro-bind-try", "/home/me/.claude/skills", "/home/me/.claude/skills"),
+    ).toBe(true);
+    expect(
+      hasTriple(
+        f,
+        "--ro-bind-try",
+        "/home/me/.claude/settings.json",
+        "/home/me/.claude/settings.json",
+      ),
+    ).toBe(true);
+    expect(
+      hasTriple(f, "--ro-bind-try", "/home/me/.claude/CLAUDE.md", "/home/me/.claude/CLAUDE.md"),
+    ).toBe(true);
     // helper bound RO at the same path inside the sandbox
     expect(hasTriple(f, "--ro-bind-try", "/h/x.sh", "/h/x.sh")).toBe(true);
   });

--- a/test/server-ping.test.ts
+++ b/test/server-ping.test.ts
@@ -20,7 +20,14 @@ function makeDeps(): AppDeps {
     events,
   });
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
   };
   return { store, service, events, usageLimits, distiller: { distillNow: () => {} } };
 }

--- a/test/server-projects.test.ts
+++ b/test/server-projects.test.ts
@@ -49,7 +49,14 @@ function makeDeps(): AppDeps {
     events,
   });
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
   };
   const distiller = { distillNow: () => {} };
   return { store, service, events, usageLimits, distiller };

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -1,11 +1,12 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, realpathSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
 import { makeApp, type AppDeps } from "../src/server";
 import { config, clampCap, PR_REVIEW_CYCLES_MIN, PR_REVIEW_CYCLES_MAX } from "../src/config";
+import type { AuthMode } from "../src/auth-mode";
 
 let tmp: string;
 let savedRoot: string;
@@ -16,6 +17,9 @@ let savedPrCap: number;
 let savedPlanCap: number;
 let savedDefaultModel: string;
 let savedExtraCredits: number;
+let savedAuthMode: AuthMode;
+let savedAuthApiKeyHelperPath: string | null;
+let savedHome: string | undefined;
 
 beforeEach(() => {
   // realpath so comparisons hold where tmpdir() is a symlink (macOS)
@@ -29,9 +33,14 @@ beforeEach(() => {
   savedPlanCap = config.planReviewCyclesCap;
   savedDefaultModel = config.defaultModel;
   savedExtraCredits = config.extraCreditsDrainCeiling;
+  savedAuthMode = config.authMode;
+  savedAuthApiKeyHelperPath = config.authApiKeyHelperPath;
+  savedHome = process.env.HOME;
   // the ceiling is the immutable boundary; point it at our temp dir for the test so
   // dirs inside tmp validate and the dir browser is confined to tmp.
   config.rootCeiling = tmp;
+  // redirect HOME so putAnthropicApiKey writes into our temp dir, not ~/.shepherd
+  process.env.HOME = tmp;
 });
 
 afterEach(() => {
@@ -43,6 +52,10 @@ afterEach(() => {
   config.planReviewCyclesCap = savedPlanCap;
   config.defaultModel = savedDefaultModel;
   config.extraCreditsDrainCeiling = savedExtraCredits;
+  config.authMode = savedAuthMode;
+  config.authApiKeyHelperPath = savedAuthApiKeyHelperPath;
+  if (savedHome !== undefined) process.env.HOME = savedHome;
+  else delete process.env.HOME;
   rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -388,4 +401,140 @@ test("PUT /api/settings rejects a non-number extraCreditsDrainCeiling", async ()
   const res = await put(app, { extraCreditsDrainCeiling: "lots" });
   expect(res.status).toBe(400);
   expect(config.extraCreditsDrainCeiling).toBe(0); // unchanged on failure
+});
+
+// ── authMode ──────────────────────────────────────────────────────────────────
+
+test("GET /api/settings includes authMode and hasApiKey, never key/path", async () => {
+  config.authMode = "subscription";
+  config.authApiKeyHelperPath = null;
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/settings"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.authMode).toBe("subscription");
+  expect(body.hasApiKey).toBe(false);
+  // must NOT expose the raw key or helper path
+  expect("authApiKeyHelperPath" in body).toBe(false);
+  expect("anthropicApiKey" in body).toBe(false);
+});
+
+test("GET /api/settings hasApiKey is true when helper path is set", async () => {
+  config.authMode = "api-key";
+  config.authApiKeyHelperPath = "/some/path/helper.sh";
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/settings"));
+  const body = await res.json();
+  expect(body.authMode).toBe("api-key");
+  expect(body.hasApiKey).toBe(true);
+  expect("authApiKeyHelperPath" in body).toBe(false);
+});
+
+test("PUT /api/settings sets authMode to 'api-key', persists, returns shape", async () => {
+  config.authMode = "subscription";
+  config.authApiKeyHelperPath = null;
+  const { app, store } = harness();
+  const res = await put(app, { authMode: "api-key" });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.authMode).toBe("api-key");
+  expect(typeof body.hasApiKey).toBe("boolean");
+  expect(config.authMode as string).toBe("api-key"); // live
+  expect(store.getSetting("authMode")).toBe("api-key"); // persisted
+});
+
+test("PUT /api/settings sets authMode to 'subscription', persists", async () => {
+  config.authMode = "api-key";
+  const { app, store } = harness();
+  const res = await put(app, { authMode: "subscription" });
+  expect(res.status).toBe(200);
+  expect((await res.json()).authMode).toBe("subscription");
+  expect(config.authMode as string).toBe("subscription");
+  expect(store.getSetting("authMode")).toBe("subscription");
+});
+
+test("PUT /api/settings allows switching to api-key with no key configured", async () => {
+  config.authMode = "subscription";
+  config.authApiKeyHelperPath = null;
+  const { app } = harness();
+  const res = await put(app, { authMode: "api-key" });
+  expect(res.status).toBe(200);
+  // hasApiKey reflects no key is set yet
+  expect((await res.json()).hasApiKey).toBe(false);
+});
+
+test("PUT /api/settings rejects an unknown authMode value → 400", async () => {
+  config.authMode = "subscription";
+  const { app } = harness();
+  for (const bad of ["oauth", "api_key", "", 42, null, true]) {
+    const res = await put(app, { authMode: bad });
+    expect(res.status).toBe(400);
+  }
+  expect(config.authMode).toBe("subscription"); // unchanged on failure
+});
+
+// ── anthropicApiKey ───────────────────────────────────────────────────────────
+
+test("PUT anthropicApiKey writes helper, sets config path, returns {hasApiKey:true} — no key/path in response", async () => {
+  config.authApiKeyHelperPath = null;
+  const { app, store } = harness();
+  const res = await put(app, { anthropicApiKey: "sk-ant-api03-testkey" });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.hasApiKey).toBe(true);
+  // NEVER expose raw key or path
+  expect("authApiKeyHelperPath" in body).toBe(false);
+  expect("anthropicApiKey" in body).toBe(false);
+  // config updated
+  expect(config.authApiKeyHelperPath).not.toBeNull();
+  // persisted (we store the path; path must NOT contain the key text)
+  const persisted = store.getSetting("authApiKeyHelperPath");
+  expect(persisted).not.toBeNull();
+  expect(persisted).not.toContain("sk-ant-api03-testkey");
+  // helper file must exist
+  expect(existsSync(config.authApiKeyHelperPath!)).toBe(true);
+});
+
+test("PUT anthropicApiKey trims whitespace from the key", async () => {
+  config.authApiKeyHelperPath = null;
+  const { app } = harness();
+  const res = await put(app, { anthropicApiKey: "  sk-ant-api03-trimmed  " });
+  expect(res.status).toBe(200);
+  expect(config.authApiKeyHelperPath).not.toBeNull();
+});
+
+test("PUT anthropicApiKey with null clears helper, returns {hasApiKey:false}", async () => {
+  // first set a key
+  config.authApiKeyHelperPath = null;
+  const { app, store } = harness();
+  await put(app, { anthropicApiKey: "sk-ant-api03-somekey" });
+  const pathAfterSet = config.authApiKeyHelperPath;
+  expect(pathAfterSet).not.toBeNull();
+
+  // now clear it
+  const res = await put(app, { anthropicApiKey: null });
+  expect(res.status).toBe(200);
+  expect((await res.json()).hasApiKey).toBe(false);
+  expect(config.authApiKeyHelperPath).toBeNull();
+  expect(store.getSetting("authApiKeyHelperPath")).toBe(""); // marked cleared
+  // file should be gone
+  expect(existsSync(pathAfterSet!)).toBe(false);
+});
+
+test("PUT anthropicApiKey with empty string clears helper", async () => {
+  config.authApiKeyHelperPath = null;
+  const { app } = harness();
+  await put(app, { anthropicApiKey: "sk-ant-api03-somekey" });
+  const res = await put(app, { anthropicApiKey: "" });
+  expect(res.status).toBe(200);
+  expect((await res.json()).hasApiKey).toBe(false);
+  expect(config.authApiKeyHelperPath).toBeNull();
+});
+
+test("PUT anthropicApiKey with non-string/non-null value → 400", async () => {
+  const { app } = harness();
+  for (const bad of [42, true, {}, []]) {
+    const res = await put(app, { anthropicApiKey: bad });
+    expect(res.status).toBe(400);
+  }
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -52,7 +52,14 @@ function makeDeps(liveTerminals: string[] = []): AppDeps {
     events,
   });
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
   };
   const distiller = { distillNow: () => {} };
   return { store, service, events, usageLimits, distiller };
@@ -73,6 +80,7 @@ test("GET /api/usage/limits returns the limits snapshot", async () => {
     credits: null,
     stale: true,
     calibratedAt: null,
+    subscriptionOnly: false,
   });
 });
 
@@ -115,6 +123,7 @@ test("POST /api/usage/refresh without refreshUsage falls back to current limits 
     credits: null,
     stale: true,
     calibratedAt: null,
+    subscriptionOnly: false,
   });
 });
 
@@ -237,7 +246,14 @@ function harnessWithReaper(reaper: { detect: any; reap: any; stopListenersOnPort
     reaper: fullReaper,
   });
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
   };
   const app = makeApp({ store, service, events, usageLimits, distiller: { distillNow: () => {} } });
   return { app, store };
@@ -1253,7 +1269,14 @@ function clearMergedHarness() {
     },
   };
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
   };
   const app = makeApp({ store, service, events, usageLimits, prCache } as any);
   const mk = (name: string, state: string) => {
@@ -1862,7 +1885,14 @@ function harnessWithPreviewStop({
     preview: { devPortFor },
   });
   const usageLimits = {
-    limits: () => ({ session5h: null, week: null, credits: null, stale: true, calibratedAt: null }),
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
   };
   const app = makeApp({ store, service, events, usageLimits, distiller: { distillNow: () => {} } });
   return { app, store };

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -89,6 +89,47 @@ test("createSession: names, makes worktree, starts herdr, persists", async () =>
   expect(store.get(s.id)?.claudeSessionId).toBe(s.claudeSessionId);
 });
 
+test("prepareSpawn fail-closed: api-key mode with no helper path refuses create() (never silent subscription fallback)", async () => {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  const store = new SessionStore(":memory:");
+  let started = false;
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      ensureBaseRef: async () => {},
+      create: () => ({ worktreePath: "/wt/x", branch: "shepherd/x", isolated: true }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => {
+        started = true;
+        return { terminalId: "term_z" } as any;
+      },
+      list: () => [],
+    } as any,
+  });
+  try {
+    config.authMode = "api-key";
+    config.authApiKeyHelperPath = null;
+    await expect(
+      service.create({
+        repoPath: "/repo",
+        baseBranch: "main",
+        prompt: "go",
+        model: null,
+        images: [],
+      }),
+    ).rejects.toThrow(/API-key auth mode is enabled but no Anthropic API key is configured/);
+    // fail-closed: the spawn never started, so it can't have run on subscription billing.
+    expect(started).toBe(false);
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+});
+
 test("setReadyToMerge persists the flag and emits session:ready", () => {
   const store = new SessionStore(":memory:");
   const s = store.create({
@@ -289,6 +330,36 @@ test("spawnSettingsOverlay pins remoteControlAtStartup + disables claude.ai conn
     });
   } finally {
     config.remoteControlAtStartup = prev;
+  }
+});
+
+test("spawnSettingsOverlay: subscription => byte-identical (no apiKeyHelper); api-key + helper path => adds apiKeyHelper last", () => {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  try {
+    // subscription (default) — identical to today's overlay, no apiKeyHelper key.
+    config.authMode = "subscription";
+    config.authApiKeyHelperPath = null;
+    const subJson = spawnSettingsOverlay();
+    expect(JSON.parse(subJson)).not.toHaveProperty("apiKeyHelper");
+    // a stray helper path in subscription mode must still be ignored (byte-identical).
+    config.authApiKeyHelperPath = "/h/x.sh";
+    expect(spawnSettingsOverlay()).toBe(subJson);
+
+    // api-key + non-empty helper path — overlay gains apiKeyHelper.
+    config.authMode = "api-key";
+    config.authApiKeyHelperPath = "/h/x.sh";
+    const parsed = JSON.parse(spawnSettingsOverlay());
+    expect(parsed.apiKeyHelper).toBe("/h/x.sh");
+    // everything else is unchanged from subscription.
+    expect(parsed.remoteControlAtStartup).toBe(config.remoteControlAtStartup);
+    expect(parsed.env).toEqual({ ENABLE_CLAUDEAI_MCP_SERVERS: "false" });
+    // apiKeyHelper trails (stable key order — folded in last).
+    const keys = Object.keys(parsed);
+    expect(keys[keys.length - 1]).toBe("apiKeyHelper");
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
   }
 });
 

--- a/test/spawn-auth.test.ts
+++ b/test/spawn-auth.test.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "bun:test";
-import { join } from "node:path";
+import { expect, test, beforeEach, afterEach } from "bun:test";
 import { config } from "../src/config";
 import {
   isApiKeyMode,
@@ -7,7 +6,18 @@ import {
   apiKeySettingsFragment,
   apiKeyMembraneFields,
   apiKeyPassthroughEnv,
+  __setApiKeyConfigDirProvisionForTest,
 } from "../src/spawn-auth";
+
+const FAKE_CONFIG_DIR = "/tmp/shepherd-test-apikey-config";
+
+beforeEach(() => {
+  __setApiKeyConfigDirProvisionForTest(() => FAKE_CONFIG_DIR);
+});
+
+afterEach(() => {
+  __setApiKeyConfigDirProvisionForTest(null);
+});
 
 // Helper: run `fn` with config auth fields temporarily set, always restoring them.
 function withAuth(mode: typeof config.authMode, helper: string | null, fn: () => void): void {
@@ -93,14 +103,11 @@ test("apiKeyPassthroughEnv is undefined when wrapped (membrane masks in place)",
 });
 
 test("apiKeyPassthroughEnv returns a single CLAUDE_CONFIG_DIR key for api-key + not wrapped", () => {
-  // Shape-only assertion (homedir() is OS-derived, not $HOME-overridable here): the
-  // canonical mirror lives at <home>/.shepherd/claude-apikey-config — assert that
-  // suffix rather than scribbling the real ~/.shepherd via an env override.
+  // The test seam stubs provisioning so no real ~/.shepherd is written.
   withAuth("api-key", "/h.sh", () => {
     const env = apiKeyPassthroughEnv(false);
     expect(env).toBeDefined();
     expect(Object.keys(env!)).toEqual(["CLAUDE_CONFIG_DIR"]);
-    const dir = env!.CLAUDE_CONFIG_DIR ?? "";
-    expect(dir.endsWith(join(".shepherd", "claude-apikey-config"))).toBe(true);
+    expect(env!.CLAUDE_CONFIG_DIR).toBe(FAKE_CONFIG_DIR);
   });
 });

--- a/test/spawn-auth.test.ts
+++ b/test/spawn-auth.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+import { config } from "../src/config";
+import {
+  isApiKeyMode,
+  isApiKeyConfigured,
+  apiKeySettingsFragment,
+  apiKeyMembraneFields,
+  apiKeyPassthroughEnv,
+} from "../src/spawn-auth";
+
+// Helper: run `fn` with config auth fields temporarily set, always restoring them.
+function withAuth(mode: typeof config.authMode, helper: string | null, fn: () => void): void {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  try {
+    config.authMode = mode;
+    config.authApiKeyHelperPath = helper;
+    fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
+
+// ── isApiKeyMode / isApiKeyConfigured ───────────────────────────────────────
+
+test("isApiKeyMode reflects config.authMode only", () => {
+  withAuth("subscription", null, () => expect(isApiKeyMode()).toBe(false));
+  withAuth("subscription", "/h.sh", () => expect(isApiKeyMode()).toBe(false));
+  withAuth("api-key", null, () => expect(isApiKeyMode()).toBe(true));
+  withAuth("api-key", "/h.sh", () => expect(isApiKeyMode()).toBe(true));
+});
+
+test("isApiKeyConfigured requires api-key mode AND a helper path", () => {
+  withAuth("subscription", null, () => expect(isApiKeyConfigured()).toBe(false));
+  withAuth("subscription", "/h.sh", () => expect(isApiKeyConfigured()).toBe(false));
+  withAuth("api-key", null, () => expect(isApiKeyConfigured()).toBe(false));
+  withAuth("api-key", "/h.sh", () => expect(isApiKeyConfigured()).toBe(true));
+});
+
+// ── apiKeySettingsFragment ──────────────────────────────────────────────────
+
+test("apiKeySettingsFragment is {} for subscription (byte-for-byte)", () => {
+  withAuth("subscription", "/h.sh", () => expect(apiKeySettingsFragment()).toEqual({}));
+});
+
+test("apiKeySettingsFragment is {} for api-key-unconfigured (no helper)", () => {
+  withAuth("api-key", null, () => expect(apiKeySettingsFragment()).toEqual({}));
+});
+
+test("apiKeySettingsFragment carries apiKeyHelper for api-key-configured", () => {
+  withAuth("api-key", "/path/helper.sh", () =>
+    expect(apiKeySettingsFragment()).toEqual({ apiKeyHelper: "/path/helper.sh" }),
+  );
+});
+
+// ── apiKeyMembraneFields ────────────────────────────────────────────────────
+
+test("apiKeyMembraneFields: subscription → no helper, no mask", () => {
+  withAuth("subscription", "/h.sh", () =>
+    expect(apiKeyMembraneFields()).toEqual({ apiKeyHelperPath: null, maskCredentials: false }),
+  );
+});
+
+test("apiKeyMembraneFields: api-key-unconfigured → mask on, null helper", () => {
+  // Mask is keyed off mode, NOT configuration — a credential must never leak in api-key mode.
+  withAuth("api-key", null, () =>
+    expect(apiKeyMembraneFields()).toEqual({ apiKeyHelperPath: null, maskCredentials: true }),
+  );
+});
+
+test("apiKeyMembraneFields: api-key-configured → helper path + mask on", () => {
+  withAuth("api-key", "/path/helper.sh", () =>
+    expect(apiKeyMembraneFields()).toEqual({
+      apiKeyHelperPath: "/path/helper.sh",
+      maskCredentials: true,
+    }),
+  );
+});
+
+// ── apiKeyPassthroughEnv ────────────────────────────────────────────────────
+
+test("apiKeyPassthroughEnv is undefined for subscription (wrapped or not)", () => {
+  withAuth("subscription", "/h.sh", () => {
+    expect(apiKeyPassthroughEnv(false)).toBeUndefined();
+    expect(apiKeyPassthroughEnv(true)).toBeUndefined();
+  });
+});
+
+test("apiKeyPassthroughEnv is undefined when wrapped (membrane masks in place)", () => {
+  withAuth("api-key", "/h.sh", () => expect(apiKeyPassthroughEnv(true)).toBeUndefined());
+});
+
+test("apiKeyPassthroughEnv returns a single CLAUDE_CONFIG_DIR key for api-key + not wrapped", () => {
+  // Shape-only assertion (homedir() is OS-derived, not $HOME-overridable here): the
+  // canonical mirror lives at <home>/.shepherd/claude-apikey-config — assert that
+  // suffix rather than scribbling the real ~/.shepherd via an env override.
+  withAuth("api-key", "/h.sh", () => {
+    const env = apiKeyPassthroughEnv(false);
+    expect(env).toBeDefined();
+    expect(Object.keys(env!)).toEqual(["CLAUDE_CONFIG_DIR"]);
+    const dir = env!.CLAUDE_CONFIG_DIR ?? "";
+    expect(dir.endsWith(join(".shepherd", "claude-apikey-config"))).toBe(true);
+  });
+});

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -1,9 +1,36 @@
-import { test, expect } from "bun:test";
+import { test, expect, beforeEach, afterEach } from "bun:test";
 import { StandalonePrCriticService } from "../src/standalone-critic";
 import { CRITIC_THINKING_TOKENS } from "../src/critic-core";
 import { CRITIC_REVIEW_MARKER } from "../src/forge/types";
+import { config } from "../src/config";
+import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 import type { GitForge, PrReviewMeta, PullRequest } from "../src/forge/types";
 import type { PrReview } from "../src/types";
+
+beforeEach(() => {
+  __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
+});
+
+afterEach(() => {
+  __setApiKeyConfigDirProvisionForTest(null);
+});
+
+async function withAuth<T>(
+  mode: typeof config.authMode,
+  helper: string | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  config.authMode = mode;
+  config.authApiKeyHelperPath = helper;
+  try {
+    return await fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
 
 // ── fixtures ────────────────────────────────────────────────────────────────
 
@@ -35,7 +62,7 @@ const OPEN_META: PrReviewMeta = {
 interface Spies {
   posted: { n: number; event: string; body: string }[];
   comments: { n: number; body: string }[];
-  started: { name: string; cwd: string; argv: string[] }[];
+  started: { name: string; cwd: string; argv: string[]; env?: Record<string, string> }[];
   stopped: string[];
   removed: string[];
   created: { branch: string; sha: string; slug?: string; pullRef?: string }[];
@@ -143,8 +170,8 @@ function makeDeps(
         (opts.epicCompleted ?? []).filter((r) => repoPath === undefined || r.repoPath === repoPath),
     },
     herdr: {
-      start: (name: string, cwd: string, argv: string[]) => {
-        spies.started.push({ name, cwd, argv });
+      start: (name: string, cwd: string, argv: string[], env?: Record<string, string>) => {
+        spies.started.push({ name, cwd, argv, env });
         return { terminalId: "rt" } as any;
       },
       stop: (t: string) => spies.stopped.push(t),
@@ -161,6 +188,7 @@ function makeDeps(
         return { worktreePath: "/review-wt", branch: null, isolated: true };
       },
       remove: (p: string) => spies.removed.push(p),
+      gitCommonDir: () => "/fake-git-common",
     },
     resolveForge: opts.forge ?? (() => makeForge(spies)),
     repos: () => opts.repos ?? ["/r"],
@@ -178,6 +206,14 @@ function makeDeps(
     // no real git: keep base unknown so the scope backstop is skipped (findings pass through)
     computePatchId: async () => ({ patchId: "p1", baseSha: null, files: [] }),
     readUsage: async () => null,
+    // default: backend null → wrapArgv passthrough = current (pre-sandbox) behavior, so existing
+    // tests stay green without spawning the real bwrap probe. membraneEnv stub keeps host paths out.
+    detectBackend: () => null,
+    membraneEnv: () => ({
+      claudeDir: "/fake/.claude",
+      home: "/fake/home",
+      nodeBinReal: "/fake/bin/node",
+    }),
     ...over,
   };
   return { deps, spies, reviews };
@@ -612,4 +648,59 @@ test("two enabled repos: the round-robin offset rotates which repo is considered
   await svc.sweep(); // offset 1 → /b, /a
   await svc.sweep(); // offset 0 → /a, /b
   expect(considered).toEqual(["/a", "/b", "/b", "/a", "/a", "/b"]);
+});
+
+// ── 10. api-key auth membrane (7th spawn path, mirrors review.test) ───────────
+
+test("api-key mode (passthrough host): apiKeyHelper in argv + CLAUDE_CONFIG_DIR env", async () => {
+  // detectBackend()→null on the test host → no membrane → passthrough env carries the mirror dir.
+  await withAuth("api-key", "/helper.sh", async () => {
+    const { deps, spies } = makeDeps({ detectBackend: () => null });
+    const svc = new StandalonePrCriticService(deps as any);
+    await svc.sweep();
+    expect(spies.started).toHaveLength(1);
+    const argv = spies.started[0]!.argv;
+    expect(JSON.parse(argv[argv.indexOf("--settings") + 1]!).apiKeyHelper).toBe("/helper.sh");
+    expect(Object.keys(spies.started[0]!.env!)).toEqual(["CLAUDE_CONFIG_DIR"]);
+  });
+});
+
+test("api-key without a configured key fails closed (no spawn, worktree reaped)", async () => {
+  await withAuth("api-key", null, async () => {
+    const { deps, spies } = makeDeps();
+    const svc = new StandalonePrCriticService(deps as any);
+    await svc.sweep();
+    expect(spies.started).toHaveLength(0);
+    expect(spies.removed).toEqual(["/review-wt"]);
+  });
+});
+
+test("bwrap backend present: critic spawn is wrapped + isolated, credential masked", async () => {
+  await withAuth("api-key", "/helper.sh", async () => {
+    const { deps, spies } = makeDeps({
+      detectBackend: () => "bwrap",
+      membraneEnv: () => ({
+        claudeDir: "/fake/.claude",
+        home: "/fake/home",
+        nodeBinReal: "/fake/bin/node",
+      }),
+    });
+    const svc = new StandalonePrCriticService(deps as any);
+    await svc.sweep();
+    expect(spies.started).toHaveLength(1);
+    const argv = spies.started[0]!.argv;
+    expect(argv[0]).toBe("bwrap");
+    // membrane uses isolated:true → worktree + gitCommonDir binds, not the whole repo.
+    expect(argv).toContain("/review-wt");
+    expect(argv).toContain("/fake-git-common");
+    expect(argv).not.toContain("/r"); // not the whole-repo bind
+    // api-key maskCredentials: NO `.credentials.json` rw bind anywhere — the credential is masked.
+    expect(argv.some((a) => a.includes(".credentials.json"))).toBe(false);
+    // inner reviewer argv follows the "--" separator (not another bwrap).
+    const sep = argv.indexOf("--");
+    expect(sep).toBeGreaterThan(0);
+    expect(argv[sep + 1]).not.toBe("bwrap");
+    // membrane masks creds in place → no passthrough CLAUDE_CONFIG_DIR env.
+    expect(spies.started[0]!.env).toBeUndefined();
+  });
 });

--- a/test/usage-limits.test.ts
+++ b/test/usage-limits.test.ts
@@ -18,6 +18,7 @@ import {
   type UsageProbe,
 } from "../src/usage-limits";
 import { AccountUsageIndex } from "../src/usage";
+import { config } from "../src/config";
 
 const NOW = Date.parse("2026-05-30T18:00:00.000Z");
 
@@ -429,6 +430,7 @@ const mkLimits = (weekPct: number | null): UsageLimits => ({
   credits: null,
   stale: false,
   calibratedAt: NOW,
+  subscriptionOnly: false,
 });
 
 test("calibrateDelay: week pct above watch threshold escalates cadence", () => {
@@ -445,4 +447,49 @@ test("calibrateDelay: week pct below threshold stays daily", () => {
 
 test("calibrateDelay: null week window stays daily", () => {
   expect(calibrateDelay(mkLimits(null))).toBe(CALIBRATE_INTERVAL_MS);
+});
+
+// ── api-key mode: subscription-only flag + probe never spawned ───────────────
+
+/** Probe whose scrape() throws (or increments a call counter) to catch stray spawns. */
+class ThrowingProbe implements UsageProbe {
+  calls = 0;
+  async scrape(): Promise<string | null> {
+    this.calls++;
+    throw new Error("probe must not be called in api-key mode");
+  }
+}
+
+test("calibrate short-circuits in api-key mode without calling the probe", async () => {
+  const prior = config.authMode;
+  try {
+    config.authMode = "api-key";
+    const probe = new ThrowingProbe();
+    const svc = new UsageLimitsService(fakeIndex(100), new MemCaps(), probe, new MemCredits());
+    const result = await svc.calibrate(NOW);
+    expect(result).toBe(false);
+    expect(probe.calls).toBe(0);
+  } finally {
+    config.authMode = prior;
+  }
+});
+
+test("limits() subscriptionOnly is true in api-key mode, false in subscription mode", () => {
+  const prior = config.authMode;
+  try {
+    const svc = new UsageLimitsService(
+      fakeIndex(0),
+      new MemCaps(),
+      new StubProbe(null),
+      new MemCredits(),
+    );
+
+    config.authMode = "api-key";
+    expect(svc.limits(NOW).subscriptionOnly).toBe(true);
+
+    config.authMode = "subscription";
+    expect(svc.limits(NOW).subscriptionOnly).toBe(false);
+  } finally {
+    config.authMode = prior;
+  }
 });

--- a/test/usage-probe.test.ts
+++ b/test/usage-probe.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
 import { HerdrUsageProbe, PROBE_NAME } from "../src/usage-probe";
 import type { HerdrAgent } from "../src/herdr";
+import { config } from "../src/config";
 
 function agent(over: Partial<HerdrAgent>): HerdrAgent {
   return {
@@ -22,6 +23,27 @@ function agent(over: Partial<HerdrAgent>): HerdrAgent {
 // PROBE_NAME) up front (and on every exit), self-healing past leaks regardless of how the prior
 // run died — while leaving every real session strictly alone, INCLUDING one a user happened to
 // name "usage-probe" (a producible prompt slug that the old bare-string match would have killed).
+test("scrape returns null without calling herdr.start in api-key mode", async () => {
+  const prior = config.authMode;
+  try {
+    config.authMode = "api-key";
+    let startCalled = false;
+    const herdr = {
+      list: () => [] as HerdrAgent[],
+      start: () => {
+        startCalled = true;
+        throw new Error("herdr.start must not be called in api-key mode");
+      },
+      stop: () => {},
+    };
+    const result = await new HerdrUsageProbe(herdr, "/repo").scrape();
+    expect(result).toBeNull();
+    expect(startCalled).toBe(false);
+  } finally {
+    config.authMode = prior;
+  }
+});
+
 test("scrape reaps leftover probe tabs and never touches real sessions", async () => {
   const stopped: string[] = [];
   const agents = [

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1258,5 +1258,20 @@
   "done_recap_panel_aria": "Zusammenfassung für {desig}",
   "done_back_to_list": "‹ Zurück zu Fertig",
   "feat_done_lens_title": "Fertig-Ansicht",
-  "feat_done_lens_body": "Filtere die Herde auf deine abgeschlossenen und gemergten Sitzungen und öffne eine davon, um die schreibgeschützte Zusammenfassung des Verlaufs anzusehen."
+  "feat_done_lens_body": "Filtere die Herde auf deine abgeschlossenen und gemergten Sitzungen und öffne eine davon, um die schreibgeschützte Zusammenfassung des Verlaufs anzusehen.",
+  "settings_auth_mode_title": "Authentifizierung",
+  "settings_auth_mode_hint": "Wie gestartete Agenten sich authentifizieren. Der API-Schlüssel-Modus rechnet API-Nutzung zu Verbrauchspreisen unter den Commercial Terms ab statt über dein Abonnement.",
+  "settings_auth_mode_subscription": "Abonnement (OAuth)",
+  "settings_auth_mode_apikey": "Anthropic-API-Schlüssel",
+  "settings_auth_mode_save_failed": "Authentifizierungsmodus konnte nicht geändert werden",
+  "settings_auth_key_label": "Anthropic-API-Schlüssel",
+  "settings_auth_key_placeholder": "sk-ant-…",
+  "settings_auth_key_save": "Speichern",
+  "settings_auth_key_saved": "API-Schlüssel konfiguriert",
+  "settings_auth_key_clear": "Schlüssel entfernen",
+  "settings_auth_key_missing_warning": "Der API-Schlüssel-Modus ist gewählt, aber kein Schlüssel hinterlegt — Agenten-Starts pausieren, bis du einen hinzufügst.",
+  "settings_auth_key_save_failed": "API-Schlüssel konnte nicht gespeichert werden",
+  "usage_subscription_only": "Nutzungserfassung nur im Abonnement — siehe die Anthropic-Konsole.",
+  "feat_api_key_auth_title": "API-Schlüssel-Authentifizierung",
+  "feat_api_key_auth_body": "Aktiviere die Abrechnung gestarteter Agenten über einen Anthropic-API-Schlüssel (Commercial Terms) statt über dein Abonnement — Einstellungen → Sitzung."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1258,5 +1258,20 @@
   "done_recap_panel_aria": "Recap for {desig}",
   "done_back_to_list": "‹ Back to done",
   "feat_done_lens_title": "Done lens",
-  "feat_done_lens_body": "Filter the Herd to your finished and merged sessions, then open any one to review its read-only recap of what happened."
+  "feat_done_lens_body": "Filter the Herd to your finished and merged sessions, then open any one to review its read-only recap of what happened.",
+  "settings_auth_mode_title": "Authentication",
+  "settings_auth_mode_hint": "How spawned agents authenticate. API-key mode bills metered API rates under the Commercial Terms instead of your subscription.",
+  "settings_auth_mode_subscription": "Subscription (OAuth)",
+  "settings_auth_mode_apikey": "Anthropic API key",
+  "settings_auth_mode_save_failed": "Couldn't update authentication mode",
+  "settings_auth_key_label": "Anthropic API key",
+  "settings_auth_key_placeholder": "sk-ant-…",
+  "settings_auth_key_save": "Save",
+  "settings_auth_key_saved": "API key configured",
+  "settings_auth_key_clear": "Clear key",
+  "settings_auth_key_missing_warning": "API-key mode is selected but no key is set — agent spawns are paused until you add one.",
+  "settings_auth_key_save_failed": "Couldn't save the API key",
+  "usage_subscription_only": "Usage tracking is subscription-only — see the Anthropic Console.",
+  "feat_api_key_auth_title": "API-key auth mode",
+  "feat_api_key_auth_body": "Opt into billing spawned agents against an Anthropic API key (Commercial Terms) instead of your subscription — Settings → Session."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -263,6 +263,15 @@ export const putPlanReviewCyclesCap = (cap: number): Promise<{ planReviewCyclesC
 export const putDefaultModel = (model: string): Promise<{ defaultModel: string }> =>
   patchSettings<{ defaultModel: string }>({ defaultModel: model });
 
+// Switch how spawned agents authenticate (subscription OAuth vs. metered API key).
+export const putAuthMode = (mode: string): Promise<{ authMode: string; hasApiKey: boolean }> =>
+  patchSettings({ authMode: mode });
+
+// Set (or clear, with null) the Anthropic API key. The server stores only the path
+// to a helper it writes; the raw key never round-trips back to the client.
+export const putAnthropicApiKey = (key: string | null): Promise<{ hasApiKey: boolean }> =>
+  patchSettings({ anthropicApiKey: key });
+
 // Persist the account-wide extra-credit (paid overage) spend ceiling. Auto-drain/autopilot
 // pauses when measured spend strictly exceeds it; 0 = pause on any spend. The server
 // validates a non-negative number and returns the stored value.

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -1316,7 +1316,7 @@
     font-family: var(--font-mono);
     font-size: var(--fs-meta);
     letter-spacing: 0.08em;
-    padding: 8px 12px;
+    padding: 2px 8px;
     cursor: pointer;
   }
   .gbtn:hover:not(:disabled) {

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -8,6 +8,8 @@
     putPrReviewCyclesCap,
     putPlanReviewCyclesCap,
     putDefaultModel,
+    putAuthMode,
+    putAnthropicApiKey,
     putExtraCreditsDrainCeiling,
     listDirs,
     getDiagnostics,
@@ -148,6 +150,11 @@
   let defaultModelSaved = "auto"; // last server-confirmed value, for revert on failure
   let defaultModelBusy = $state(false);
   const isPremiumModel = $derived(PREMIUM_MODELS.includes(defaultModel));
+  let authMode = $state("subscription"); // how spawned agents authenticate
+  let authModeSaved = "subscription"; // last server-confirmed value, for revert on failure
+  let authBusy = $state(false);
+  let hasApiKey = $state(false); // whether a key is configured (boolean only; key never sent)
+  let apiKeyInput = $state(""); // write-only paste field; cleared after save, never prefilled
   let extraCreditsCeiling = $state(0); // account-wide extra-credit spend ceiling (0 = pause on any)
   let extraCreditsCeilingSaved = 0; // last server-confirmed value, for revert on failure
   let extraCreditsBusy = $state(false);
@@ -246,6 +253,62 @@
       });
     } finally {
       defaultModelBusy = false;
+    }
+  }
+
+  async function saveAuthMode() {
+    if (authBusy) return;
+    authBusy = true;
+    try {
+      const r = await putAuthMode(authMode);
+      authMode = r.authMode;
+      authModeSaved = r.authMode;
+      hasApiKey = r.hasApiKey;
+    } catch {
+      // revert to the last server-confirmed value; surface the failure persistently.
+      authMode = authModeSaved;
+      toasts.info(m.settings_auth_mode_save_failed(), {
+        key: "auth-mode",
+        duration: null,
+        alert: true,
+      });
+    } finally {
+      authBusy = false;
+    }
+  }
+
+  async function saveApiKey() {
+    if (authBusy || apiKeyInput.trim() === "") return;
+    authBusy = true;
+    try {
+      const r = await putAnthropicApiKey(apiKeyInput.trim());
+      hasApiKey = r.hasApiKey;
+      apiKeyInput = ""; // never retain the key in component state
+    } catch {
+      toasts.info(m.settings_auth_key_save_failed(), {
+        key: "auth-key",
+        duration: null,
+        alert: true,
+      });
+    } finally {
+      authBusy = false;
+    }
+  }
+
+  async function clearApiKey() {
+    if (authBusy) return;
+    authBusy = true;
+    try {
+      const r = await putAnthropicApiKey(null);
+      hasApiKey = r.hasApiKey;
+    } catch {
+      toasts.info(m.settings_auth_key_save_failed(), {
+        key: "auth-key",
+        duration: null,
+        alert: true,
+      });
+    } finally {
+      authBusy = false;
     }
   }
 
@@ -358,6 +421,9 @@
       planReviewCyclesSaved = s.planReviewCyclesCap;
       defaultModel = s.defaultModel;
       defaultModelSaved = s.defaultModel;
+      authMode = s.authMode;
+      authModeSaved = s.authMode;
+      hasApiKey = s.hasApiKey;
       extraCreditsCeiling = s.extraCreditsDrainCeiling;
       extraCreditsCeilingSaved = s.extraCreditsDrainCeiling;
       await browse(s.repoRoot);
@@ -626,6 +692,52 @@
         </select>
         {#if isPremiumModel}
           <p class="premium-warn">{m.settings_default_model_premium_warning()}</p>
+        {/if}
+      </div>
+      <div class="rc">
+        <span class="micro">{m.settings_auth_mode_title()}</span>
+        <p class="hint">{m.settings_auth_mode_hint()}</p>
+        <select
+          class="model-select"
+          bind:value={authMode}
+          disabled={authBusy}
+          aria-label={m.settings_auth_mode_title()}
+          onchange={saveAuthMode}
+        >
+          <option value="subscription">{m.settings_auth_mode_subscription()}</option>
+          <option value="api-key">{m.settings_auth_mode_apikey()}</option>
+        </select>
+        {#if authMode === "api-key"}
+          <div class="apikey">
+            {#if hasApiKey}
+              <p class="key-status">{m.settings_auth_key_saved()}</p>
+              <button type="button" class="gbtn" disabled={authBusy} onclick={clearApiKey}>
+                {m.settings_auth_key_clear()}
+              </button>
+            {/if}
+            <div class="key-entry">
+              <input
+                type="password"
+                class="model-select key-input"
+                bind:value={apiKeyInput}
+                disabled={authBusy}
+                placeholder={m.settings_auth_key_placeholder()}
+                aria-label={m.settings_auth_key_label()}
+                autocomplete="off"
+              />
+              <button
+                type="button"
+                class="gbtn"
+                disabled={authBusy || apiKeyInput.trim() === ""}
+                onclick={saveApiKey}
+              >
+                {m.settings_auth_key_save()}
+              </button>
+            </div>
+            {#if !hasApiKey}
+              <p class="premium-warn">{m.settings_auth_key_missing_warning()}</p>
+            {/if}
+          </div>
         {/if}
       </div>
       <div class="rc">
@@ -1174,6 +1286,50 @@
     font-size: var(--fs-meta);
     margin: 0;
     font-weight: 500;
+  }
+  .apikey {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-self: stretch;
+  }
+  .key-entry {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .key-input {
+    flex: 1 1 16rem;
+    align-self: auto;
+  }
+  .key-status {
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    margin: 0;
+  }
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 8px 12px;
+    cursor: pointer;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
   .toggle {
     display: flex;

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -77,6 +77,7 @@ const fullLimits: UsageLimits = {
   credits: null,
   stale: false,
   calibratedAt: 1_700_000_000_000,
+  subscriptionOnly: false,
 };
 
 const SCENARIOS: Scenario[] = [
@@ -758,6 +759,7 @@ describe("TopBar — CR extra-credit gauge", () => {
       week: { pct: 64, resetAt: 1_700_600_000_000 },
       stale: false,
       calibratedAt: 1_700_000_000_000,
+      subscriptionOnly: false,
       credits: {
         pct: 0,
         spent: 0.29,

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -232,6 +232,9 @@
   // breakdown — including reset times — through a tap popover instead.
   const gauges = $derived(gaugeList(limits));
   const hotter = $derived(hotterGauge(limits));
+  // api-key auth mode: subscription usage windows carry no data. Fail closed —
+  // render an explicit note instead of empty/zero meters.
+  const subscriptionOnly = $derived(limits?.subscriptionOnly === true);
 
   // Paid extra-credit overage. Rendered as a distinct CR element (NOT a gaugeList
   // entry — its window shape carries no credit fields, and a 0%-pct credit gauge
@@ -592,7 +595,9 @@
         {/if}
       </button>
     {/if}
-    {#if touch}
+    {#if subscriptionOnly}
+      <span class="usage-sub-only micro">{m.usage_subscription_only()}</span>
+    {:else if touch}
       {#if hotter || credits}
         <!-- touch: collapse to the hotter window (or the CR gauge when credits are the
              only signal); tap for the full breakdown. The collapsed button carries an
@@ -1324,6 +1329,11 @@
   }
   .gauges-wrap {
     position: relative;
+  }
+  /* api-key mode: explicit fail-closed note in place of the usage meters. */
+  .usage-sub-only {
+    color: var(--color-muted);
+    max-width: 22rem;
   }
   .gauges {
     display: flex;

--- a/ui/src/lib/components/usage-gauges.test.ts
+++ b/ui/src/lib/components/usage-gauges.test.ts
@@ -6,7 +6,15 @@ function w(pct: number, resetAt = 0): LimitWindow {
   return { pct, resetAt };
 }
 function limits(over: Partial<UsageLimits>): UsageLimits {
-  return { session5h: null, week: null, credits: null, stale: false, calibratedAt: null, ...over };
+  return {
+    session5h: null,
+    week: null,
+    credits: null,
+    stale: false,
+    calibratedAt: null,
+    subscriptionOnly: false,
+    ...over,
+  };
 }
 function credit(over: Partial<CreditWindow>): CreditWindow {
   return {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -795,4 +795,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_done_lens_body",
     targetId: "done-lens",
   },
+  {
+    // No targetId: the toggle lives in the Settings modal SESSION tab (closed by default),
+    // so a coachmark anchor would rarely be mounted — surface via the What's-New drawer only.
+    // 1.29.0 is the latest released tag, so this ships in 1.30.0.
+    id: "api-key-auth",
+    sinceVersion: "1.30.0",
+    titleKey: "feat_api_key_auth_title",
+    bodyKey: "feat_api_key_auth_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -535,6 +535,8 @@ export interface UsageLimits {
   credits: CreditWindow | null;
   stale: boolean;
   calibratedAt: number | null;
+  /** true in api-key auth mode: usage tracking is subscription-only, meters carry no data. */
+  subscriptionOnly: boolean;
 }
 
 export interface UpdateCommit {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -35,6 +35,10 @@ export interface Settings {
   /** Raw configured default-model setting (auto|default|<alias>); the New Task
    *  picker resolves `auto` via the client promo. */
   defaultModel: string;
+  /** How spawned agents authenticate: "subscription" (OAuth) | "api-key". */
+  authMode: string;
+  /** Whether an Anthropic API key is configured. The key itself is NEVER sent. */
+  hasApiKey: boolean;
   /** Max PR-critic auto-address rounds before escalating to a human (global). */
   prReviewCyclesCap: number;
   /** Display-only: lower bound for prReviewCyclesCap (drives the stepper's min). */

--- a/ui/test/store.test.ts
+++ b/ui/test/store.test.ts
@@ -65,6 +65,7 @@ test("applies usage:limits", () => {
       credits: null,
       stale: false,
       calibratedAt: 5,
+      subscriptionOnly: false,
     },
   });
   expect(store.usageLimits?.session5h?.pct).toBe(12);


### PR DESCRIPTION
Closes #660 — the last open prong of audit **R1** (#647 Action 3), and also closes **R5** (the Commercial/API path is no-train-by-default).

## What this ships

A global operator setting **`authMode: "subscription" (default) | "api-key"`**. In `api-key` mode every spawned `claude` — the main interactive session **and** the critic, plan-gate, namer, classifier, recap, and distiller — bills against an Anthropic **API key** under the Commercial Terms instead of the operator's subscription OAuth. It stays genuinely interactive (this is footing **B**, *not* footing C / `claude -p` / Agent SDK).

Modeled on `default-model.ts`: a normalized setting (`src/auth-mode.ts`), env seed `SHEPHERD_AUTH_MODE`, store persistence, live PUT routes, and a Settings → Session UI control.

## How it works (corrects the §4 sketch)

- **NOT `--bare`.** All existing spawn flags are kept. The key is delivered via an **`apiKeyHelper`** script named in the spawn's `--settings` — never as a raw env var or argv.
- **No subscription login is ever presented** (so Claude's "Use custom API key" approval prompt can't hang an unattended spawn). Two mechanisms, always paired with the key:
  - **Membrane-wrapped spawns** (main session under `standard`/`autonomous`; critic; plan-gate) mask `~/.claude/.credentials.json` in place with a last-wins `--ro-bind /dev/null` overlay placed *after* the whole-dir bind, and bind the helper RO.
  - **Never-membraned spawns** (namer, classifier, recap, distiller; trusted main session) use a Shepherd-provisioned **credential-less `CLAUDE_CONFIG_DIR`** — a symlink-mirror of `~/.claude` minus the credential (customizations + onboarding state preserved).
- **Key custody:** operator pastes the key in Settings; Shepherd writes a `0600` `apiKeyHelper` script and stores **only its path** — the raw key never lands in the DB, the process env, host `ps`/logs, or any HTTP response (the client only ever sees a `hasApiKey` boolean).
- **Fail closed everywhere:** api-key mode with no key configured refuses the main-session spawn and degrades the secondary spawns — it never silently falls back to subscription billing.
- **`/usage`** is subscription-only, so under api-key it short-circuits (probe never spawned) to an **explicit `subscriptionOnly` state** (no fake zero meter), with a Console pointer in the UI.
- `src/spawn-auth.ts` is the single source of truth threading all of the above; `prepareSpawn` was refactored to use it.

## Acceptance criteria

- [x] `authMode` persists; default `subscription` reproduces today's spawn argv **byte-for-byte** (empty `apiKeyHelper` fragment + `undefined` env — asserted across all spawn builders).
- [x] Sandbox membrane injects the key and presents no subscription login in api-key mode; still strips all other secrets.
- [x] `/usage` shows an explicit subscription-only state under api-key (fails closed, no fake meter).
- [x] Settings → Session toggle + key field, fully i18n'd (EN+DE, `check:i18n` green) + a `feature-announcements.ts` entry (`sinceVersion 1.30.0`).
- [x] Docs: auth-paths §4 flipped "NOT IMPLEMENTED" → "As-built, shipped v1.30.0"; README + PRD describe both footings; the stale README membrane note de-staled.
- [ ] **All six spawn paths bill against the key on a real interactive spawn, with no approval-prompt hang** — ⚠️ **needs a live run with a throwaway `ANTHROPIC_API_KEY`** (see below). Everything is wired + unit-tested; the one thing automated tests can't prove is Claude Code's live prompt/billing behavior.

## ⚠️ Remaining manual verification (needs an operator API key)

The "no approval-prompt hang + actual API billing" check (issue Step 0 spike + the six-spawn acceptance) requires a real `claude` spawn with a disposable key — it can't be unit-tested. Checklist for the operator (or I can run it if handed a throwaway key):
1. Settings → Session → API key, paste a throwaway key, toggle to **API key**.
2. Start a task (default `trusted` profile) → confirm it runs with **no "Use custom API key" prompt** and the spawn bills the key (Anthropic Console), not the subscription.
3. Repeat under a `standard`/`autonomous` profile (membrane path) and trigger a critic + plan-gate review.
4. Confirm `/usage` shows the subscription-only note.
5. Empirically confirm whether `~/.claude.json` `oauthAccount` (HOME-keyed) affects "logged-in" detection (documented open residual in `src/auth-config-dir.ts`); masking `.credentials.json` is expected to suffice.

## Known residual (documented, for the secrets review)

The RO-bound `apiKeyHelper` is `cat`-able by a hijacked / prompt-injected in-sandbox agent — it buys **host** `ps`/log hygiene only, **not** in-membrane secrecy (same class as audit R3/R4, commit `ce6a4501`). Stated in `src/sandbox.ts` + the auth-paths doc, not implied away.

## Verification (this branch, rebased on latest main)

root: `tsc` clean · `lint` clean · `bun test` 2885 pass / 0 fail
ui: `check` 0 errors · `check:i18n` parity (1254 keys) · vitest 1222 pass
gates: branch-hygiene ✓ · feature-catalog ✓ · fallow audit exit 0 (no new dead code / complexity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)