### PR TITLE
feat(recap): durable session recap + in-app Done lens

### DIFF
--- a/src/automerge.ts
+++ b/src/automerge.ts
@@ -46,7 +46,7 @@ export interface AutoMergeDeps {
     "get" | "list" | "getRepoConfig" | "getReview" | "setAutoMergeState" | "setAutopilotState"
   >;
   service: {
-    archive(id: string): number;
+    archive(id: string): Promise<number>;
     reply(id: string, text: string): boolean;
     /** SessionService.resume (async — the awaited result decides; truthy = resumed). */
     resume(id: string): unknown;

--- a/src/config.ts
+++ b/src/config.ts
@@ -434,6 +434,10 @@ export const SESSION_RETENTION_DAYS = 30;
 export const SESSION_RETENTION_MS = SESSION_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 export const SESSION_RETENTION_KEEP = 250;
 
+// "Done" lens window: sessions archived within this window are surfaced in the
+// in-app Done lens (read-only recap review). Independent of SESSION_RETENTION_*.
+export const DONE_LENS_WINDOW_MS = 48 * 60 * 60 * 1000; // 48h
+
 // reviewer_spawns rows (critic/plan-gate cost-attribution records, issue #502) are
 // deliberately decoupled from session lifecycle so they outlive archive/prune — but they
 // still need a ceiling. 90 days > SESSION_RETENTION_DAYS so a cost report can still attribute

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -100,7 +100,10 @@ export interface DrainDeps {
     | "listEpicCompleted"
     | "setEpicLandingPr"
   >;
-  service: { create(input: CreateSessionInput): Promise<Session>; archive(id: string): number };
+  service: {
+    create(input: CreateSessionInput): Promise<Session>;
+    archive(id: string): Promise<number>;
+  };
   resolveForge: (repoPath: string) => GitForge | null;
   prCache: { snapshot(): Record<string, GitState> };
   usage: { limits(now: number): UsageLimits };
@@ -840,7 +843,7 @@ export class DrainService {
         url: this.deps.prCache.snapshot()[decision.sessionId]?.url ?? "",
       });
       try {
-        this.deps.service.archive(decision.sessionId);
+        await this.deps.service.archive(decision.sessionId);
       } catch (err) {
         // The squash-merge already landed (PR is now MERGED) but teardown didn't finish. This
         // is recoverable, not a permanent strand: we deliberately do NOT dropPrCache/emit below,
@@ -881,7 +884,7 @@ export class DrainService {
     // next tick retries; we must NOT drop the pr-cache or emit "archived" for a
     // session that didn't actually archive.
     try {
-      this.deps.service.archive(decision.sessionId);
+      await this.deps.service.archive(decision.sessionId);
     } catch (err) {
       console.warn(`[drain] archive failed for ${decision.sessionId}:`, err);
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,6 +185,16 @@ const egressWatcher = new EgressWatcher({
   emit: (event, data) => events.emit(event, data),
 });
 
+// Session recap (#XXX): generates a plain-language summary of each settled-idle session
+// so the operator can skim what happened without reading the transcript. Mirrors planGate's
+// deps/onChange wiring; model defaults to "sonnet" inside the service. Constructed BEFORE
+// SessionService so its pre-teardown hook (beforeArchive) can be wired into the service.
+const recapService = new RecapService({
+  store,
+  herdr,
+  onChange: (id, recap) => events.emit("session:recap", { id, recap }),
+});
+
 const service = new SessionService({
   store,
   worktree,
@@ -201,6 +211,10 @@ const service = new SessionService({
   // prPoller is defined below; this closure is only invoked at runtime, after init.
   refreshPr: (id) => prPoller.pollSession(id),
   egressWatcher,
+  // Best-effort pre-teardown recap: generate a durable recap while the worktree still
+  // exists (the generator reads it to build its prompt). Bounded + swallowed inside
+  // archive() so it can never block teardown / the merge train.
+  beforeArchive: (s) => recapService.considerForArchive(s).then(() => {}),
 });
 
 const accountIndex = new AccountUsageIndex();
@@ -477,14 +491,6 @@ void planGate
   .then(() => planGate.gcStaleReviewWorktrees())
   .catch((err) => console.warn("[plan-gate] adoptOrphans:", err));
 
-// Session recap (#XXX): generates a plain-language summary of each settled-idle session
-// so the operator can skim what happened without reading the transcript. Mirrors planGate's
-// deps/onChange wiring; model defaults to "sonnet" inside the service.
-const recapService = new RecapService({
-  store,
-  herdr,
-  onChange: (id, recap) => events.emit("session:recap", { id, recap }),
-});
 attachReviewPush(events, store, push);
 attachGitPush(events, store, push);
 attachMergePush(events, push);
@@ -555,7 +561,7 @@ events.subscribe((event, data) => {
     const id = (data as { id: string }).id;
     reviewService.forget(id);
     planGate.forget(id);
-    recapService.forget(id);
+    recapService.onArchived(id);
   }
 });
 

--- a/src/merge-teardown.ts
+++ b/src/merge-teardown.ts
@@ -4,7 +4,7 @@ import type { Session } from "./types";
 export interface MergeTeardownDeps {
   resolveForge: (repoPath: string) => GitForge | null;
   /** service.archive */
-  archive: (id: string) => number;
+  archive: (id: string) => Promise<number>;
   /** prPoller.drop */
   dropPrCache: (id: string) => void;
   /** events.emit("session:archived", {id}) */
@@ -40,7 +40,7 @@ export async function settleMergedSession(s: Session, deps: MergeTeardownDeps): 
     // any instance re-spawning already-merged work.
     if (!closed) deps.retainClaim(s.id);
   }
-  deps.archive(s.id);
+  await deps.archive(s.id);
   deps.dropPrCache(s.id);
   deps.emitArchived(s.id);
 }

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -292,6 +292,49 @@ export class RecapService {
     }
   }
 
+  // ── considerForArchive ─────────────────────────────────────────────────────────
+
+  /**
+   * Archive-hook entry point. Unlike sweep()/considerSession, this fires for EVERY
+   * finishing session — including `auto`/drain — with NO debounce and NO auto-skip,
+   * so every session gets a durable recap row for the Done lens (the live-sweep's
+   * skip of `auto` sessions would otherwise starve drained sessions of a recap).
+   *
+   * Head-keyed dedup: if a recap already exists for the current HEAD we return "skip"
+   * (the common case — the live sweep usually already generated one), so we never
+   * double-spawn. Otherwise we generate synchronously.
+   *
+   * Does NOT throw: a git/worktree-unavailable rev-parse failure self-heals to "error"
+   * rather than throwing out of the archive hook.
+   */
+  async considerForArchive(session: Session): Promise<"started" | "empty" | "error" | "skip"> {
+    let head: string;
+    try {
+      head = await this._headSha(session.worktreePath);
+    } catch {
+      return "error"; // git/worktree unavailable — don't throw out of the hook
+    }
+
+    if (!needsRecap(this.deps.store.getRecap(session.id), head)) return "skip";
+
+    return await this.generate(session, head);
+  }
+
+  // ── onArchived ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Slim archive cleanup: frees ONLY the per-session debounce entry. Without this the
+   * `debounce` Map would leak entries for archived sessions (they never re-enter the
+   * sweep's active-session list to be cleared).
+   *
+   * Deliberately does NOT reapGenerating — an in-flight spawn must be allowed to finish
+   * (it's worktree-independent once launched, and tick() finalizes it post-archive) —
+   * and does NOT dropRecap — the row must persist for the Done lens.
+   */
+  onArchived(sessionId: string): void {
+    this.debounce.delete(sessionId);
+  }
+
   // ── generate ─────────────────────────────────────────────────────────────────
 
   /**
@@ -339,6 +382,7 @@ export class RecapService {
           headline: "",
           body: "",
           openItems: [],
+          changedFiles: [],
           spawnSessionId: "",
           cwd: "",
           model: this.model,
@@ -400,6 +444,7 @@ export class RecapService {
         headline: "",
         body: "",
         openItems: [],
+        changedFiles,
         spawnSessionId,
         cwd,
         model: this.model,

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -6,7 +6,6 @@
  *   generate()   — shared spawn path (auto + on-demand)
  *   regenerate() — on-demand force (bypasses scope/debounce/dedupe)
  *   snapshot()   — snapshot for client bootstrap
- *   forget()     — reap + drop on archive
  *
  * Spawn pattern mirrors src/namer-llm.ts: tmpdir cwd, Write-only, dontAsk,
  * disableAllHooks, disable-slash-commands. No worktree, no membrane.
@@ -541,14 +540,5 @@ export class RecapService {
 
   snapshot(): Record<string, Recap> {
     return this.deps.store.snapshotRecaps();
-  }
-
-  // ── forget ───────────────────────────────────────────────────────────────────
-
-  /** On session archive: reap any in-flight generating row, then drop the recap row. */
-  forget(sessionId: string): void {
-    this.reapGenerating(sessionId);
-    this.debounce.delete(sessionId);
-    this.deps.store.dropRecap(sessionId);
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1076,7 +1076,7 @@ async function handleSessionsClearMerged({ req, parts, deps }: Ctx): Promise<Res
     ? (body!.ids as unknown[]).filter((x): x is string => typeof x === "string")
     : [...merged];
   const target = requested.filter((id) => merged.has(id)); // merged-only, no matter what was sent
-  const { cleared, leftovers } = deps.service.archiveMany(target);
+  const { cleared, leftovers } = await deps.service.archiveMany(target);
   for (const id of cleared) {
     deps.prCache?.drop(id);
     deps.events.emit("session:archived", { id });
@@ -1092,7 +1092,7 @@ async function handleSessionDelete({ req, parts, deps }: Ctx): Promise<Response 
   const reap = Array.isArray(body?.reap)
     ? (body!.reap as unknown[]).filter((x): x is string => typeof x === "string")
     : undefined;
-  deps.service.archive(parts[2], reap);
+  await deps.service.archive(parts[2], reap);
   deps.prCache?.drop(parts[2]);
   deps.events.emit("session:archived", { id: parts[2] });
   return json({ ok: true });
@@ -1444,12 +1444,12 @@ async function resolveRelaunchIssueRef(
 // After a successful spawn: emit session:new (service.relaunch/create do not), re-stamp the
 // new session's drain claim exactly like handleSessionCreate, then tear down the original.
 // Returns whether the original was actually archived (teardown can fail, leaving it active).
-function finalizeRelaunch(
+async function finalizeRelaunch(
   original: Session,
   fresh: Session,
   issueRef: IssueRef | undefined,
   deps: Ctx["deps"],
-): { archived: boolean } {
+): Promise<{ archived: boolean }> {
   const id = original.id;
   deps.events.emit("session:new", fresh);
   if (issueRef) {
@@ -1460,7 +1460,7 @@ function finalizeRelaunch(
 
   // Tear down the original — archiveMany auto-detects + reaps leftover subprocesses and
   // isolates teardown failures (unlike a bare archive(id)).
-  const { cleared } = deps.service.archiveMany([id]);
+  const { cleared } = await deps.service.archiveMany([id]);
   const archived = cleared.includes(id);
   if (archived) {
     // Retain the original's claim ONLY when the replacement actually carries the issue
@@ -1520,7 +1520,7 @@ async function handleSessionRelaunch({ req, parts, deps }: Ctx): Promise<Respons
       return json({ error: msg }, 502);
     }
 
-    const { archived } = finalizeRelaunch(original, fresh, issueRef, deps);
+    const { archived } = await finalizeRelaunch(original, fresh, issueRef, deps);
     return json({ session: fresh, archived }, 201);
   } finally {
     inFlightRelaunch.delete(id);

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import type { EventHub } from "./events";
 import { PtyBridge } from "./pty-bridge";
 import {
   config,
+  DONE_LENS_WINDOW_MS,
   SESSION_RETENTION_DAYS,
   SESSION_RETENTION_KEEP,
   clampCap,
@@ -1032,6 +1033,10 @@ function sessionRead(id: string, deps: AppDeps): Response {
 async function handleSessionReads({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (req.method !== "GET") return null;
   if (!parts[2]) return json(deps.store.list({ activeOnly: true }));
+  // "Done" lens: sessions archived within the last DONE_LENS_WINDOW_MS, newest-first.
+  // Must precede the bare sessionRead fall-through so "done" isn't read as a session id.
+  if (parts[2] === "done" && !parts[3])
+    return json(deps.store.listRecentlyArchived(Date.now() - DONE_LENS_WINDOW_MS));
   if (parts[3] === "usage") return sessionUsageRead(parts[2], deps);
   if (parts[3] === "activity") return sessionActivityRead(parts[2], deps);
   if (parts[3] === "diff") return sessionDiffRead(parts[2], deps);

--- a/src/service.ts
+++ b/src/service.ts
@@ -106,6 +106,12 @@ export interface ServiceDeps {
   detectEgressBackend?: () => EgressBackend;
   /** Per-session DNS-drop watcher; absent in tests that don't care → no-op. */
   egressWatcher?: Pick<EgressWatcher, "start" | "stop">;
+  /** Best-effort pre-teardown hook (recap generation) — runs while the worktree still
+   *  exists; bounded + swallowed so it can never block teardown. Absent → no hook. */
+  beforeArchive?: (s: Session) => Promise<void>;
+  /** Hard cap on the beforeArchive hook (ms) so a stuck git can never permanently stall
+   *  teardown / the merge train. Defaults to 15_000; tests inject a tiny value. */
+  beforeArchiveTimeoutMs?: number;
 }
 
 /**
@@ -1149,7 +1155,7 @@ export class SessionService {
     } catch (e) {
       // best-effort teardown so no orphaned new session leaks alongside the intact original
       try {
-        this.archive(newSession.id);
+        await this.archive(newSession.id);
       } catch {
         /* ignore cleanup error; surface the original failure */
       }
@@ -1787,7 +1793,7 @@ export class SessionService {
    * leftovers actually reaped (the intersection), so bulk callers can report a count
    * that reflects what was killed rather than what was requested.
    */
-  archive(id: string, reapKeys?: string[]): number {
+  async archive(id: string, reapKeys?: string[]): Promise<number> {
     const s = this.deps.store.get(id);
     if (!s) return 0;
     let reaped = 0;
@@ -1798,6 +1804,21 @@ export class SessionService {
       reaped = hit.length;
     }
     this.deps.herdr.stop(s.herdrAgentId); // stop the live claude agent so it doesn't leak
+    // Best-effort pre-teardown hook (recap generation): the recap generator reads the
+    // worktree to build its prompt, so it MUST run while the worktree still exists.
+    // Race a 15s timeout so a stuck git can never permanently stall teardown / the merge
+    // train, and swallow any rejection — recap must never block teardown.
+    if (this.deps.beforeArchive) {
+      const timeoutMs = this.deps.beforeArchiveTimeoutMs ?? 15_000;
+      try {
+        await Promise.race([
+          this.deps.beforeArchive(s),
+          new Promise<void>((r) => setTimeout(r, timeoutMs)),
+        ]);
+      } catch {
+        /* best-effort: recap must never block teardown */
+      }
+    }
     if (s.isolated)
       this.deps.worktree.remove(s.worktreePath, { branch: s.branch, baseBranch: s.baseBranch });
     // Stop the drop-watcher before removing the temp dir so it can't read a torn-down path.
@@ -1833,7 +1854,7 @@ export class SessionService {
    * the rest, so each is isolated: a failed id is skipped and left out of `cleared`,
    * so the caller emits archived events for exactly the rows that really went away.
    */
-  archiveMany(ids: string[]): { cleared: string[]; leftovers: number } {
+  async archiveMany(ids: string[]): Promise<{ cleared: string[]; leftovers: number }> {
     const cleared: string[] = [];
     let leftovers = 0;
     for (const id of ids) {
@@ -1841,7 +1862,7 @@ export class SessionService {
       if (!s) continue;
       const keys = this.deps.reaper?.detect(s).map((l) => l.key) ?? [];
       try {
-        leftovers += this.archive(id, keys); // count what was reaped, not what was detected
+        leftovers += await this.archive(id, keys); // count what was reaped, not what was detected
         cleared.push(id);
       } catch {
         // skip this one; its row stays active and gets no archived event

--- a/src/store.ts
+++ b/src/store.ts
@@ -323,12 +323,18 @@ export class SessionStore implements CapStore, CreditStore {
       headline TEXT NOT NULL DEFAULT '',
       body TEXT NOT NULL DEFAULT '',
       openItems TEXT NOT NULL DEFAULT '[]',
+      changedFiles TEXT NOT NULL DEFAULT '[]',
       spawnSessionId TEXT NOT NULL DEFAULT '',
       cwd TEXT NOT NULL DEFAULT '',
       model TEXT,
       spawnedAt INTEGER NOT NULL,
       generatedAt INTEGER,
       updatedAt INTEGER NOT NULL)`);
+    // migrate recaps that predate the changedFiles column (existing rows default to none)
+    const recapCols = this.db.query(`PRAGMA table_info(recaps)`).all() as { name: string }[];
+    if (!recapCols.some((c) => c.name === "changedFiles")) {
+      this.db.run(`ALTER TABLE recaps ADD COLUMN changedFiles TEXT NOT NULL DEFAULT '[]'`);
+    }
     // Exact reviewer-cost attribution. Keyed by the *reviewer's* forced --session-id (which
     // locates its transcript), NOT the task — and deliberately carries NO foreign key to
     // `sessions`. `reviews`/`plan_gates` are keyed by the task sessionId and get deleted on
@@ -839,6 +845,18 @@ export class SessionStore implements CapStore, CreditStore {
     ).map((r) => this.hydrate(r));
   }
 
+  /** Archived sessions retired since `sinceMs`, newest-first — drives the read-only
+   *  "recently done" surface (recaps survive worktree teardown). */
+  listRecentlyArchived(sinceMs: number): Session[] {
+    return (
+      this.db
+        .query(
+          `SELECT ${COLS} FROM sessions WHERE status = 'archived' AND archivedAt >= ? ORDER BY archivedAt DESC`,
+        )
+        .all(sinceMs) as any[]
+    ).map((r) => this.hydrate(r));
+  }
+
   update(
     id: string,
     patch: Partial<
@@ -1202,6 +1220,14 @@ export class SessionStore implements CapStore, CreditStore {
     } catch {
       openItems = [];
     }
+    let changedFiles: string[] = [];
+    try {
+      const parsed = JSON.parse(r.changedFiles);
+      if (Array.isArray(parsed))
+        changedFiles = parsed.filter((x): x is string => typeof x === "string");
+    } catch {
+      changedFiles = [];
+    }
     return {
       sessionId: r.sessionId,
       state: r.state,
@@ -1210,6 +1236,7 @@ export class SessionStore implements CapStore, CreditStore {
       headline: r.headline ?? "",
       body: r.body ?? "",
       openItems,
+      changedFiles,
       spawnSessionId: r.spawnSessionId ?? "",
       cwd: r.cwd ?? "",
       model: r.model ?? null,
@@ -1222,7 +1249,7 @@ export class SessionStore implements CapStore, CreditStore {
   getRecap(sessionId: string): Recap | null {
     const r = this.db
       .query(
-        `SELECT sessionId, state, headSha, verdict, headline, body, openItems,
+        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles,
                 spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
               FROM recaps WHERE sessionId = ?`,
       )
@@ -1232,12 +1259,13 @@ export class SessionStore implements CapStore, CreditStore {
 
   putRecap(recap: Recap): void {
     this.db.run(
-      `INSERT INTO recaps (sessionId, state, headSha, verdict, headline, body, openItems,
+      `INSERT INTO recaps (sessionId, state, headSha, verdict, headline, body, openItems, changedFiles,
          spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET state=excluded.state, headSha=excluded.headSha,
          verdict=excluded.verdict, headline=excluded.headline, body=excluded.body,
-         openItems=excluded.openItems, spawnSessionId=excluded.spawnSessionId,
+         openItems=excluded.openItems, changedFiles=excluded.changedFiles,
+         spawnSessionId=excluded.spawnSessionId,
          cwd=excluded.cwd, model=excluded.model, spawnedAt=excluded.spawnedAt,
          generatedAt=excluded.generatedAt, updatedAt=excluded.updatedAt`,
       [
@@ -1248,6 +1276,7 @@ export class SessionStore implements CapStore, CreditStore {
         recap.headline ?? "",
         recap.body ?? "",
         JSON.stringify(recap.openItems ?? []),
+        JSON.stringify(recap.changedFiles ?? []),
         recap.spawnSessionId ?? "",
         recap.cwd ?? "",
         recap.model ?? null,
@@ -1262,7 +1291,7 @@ export class SessionStore implements CapStore, CreditStore {
   snapshotRecaps(): Record<string, Recap> {
     const rows = this.db
       .query(
-        `SELECT sessionId, state, headSha, verdict, headline, body, openItems,
+        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles,
                 spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
               FROM recaps WHERE state != 'empty'`,
       )
@@ -1276,7 +1305,7 @@ export class SessionStore implements CapStore, CreditStore {
   generatingRecaps(): Recap[] {
     const rows = this.db
       .query(
-        `SELECT sessionId, state, headSha, verdict, headline, body, openItems,
+        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles,
                 spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
               FROM recaps WHERE state = 'generating'`,
       )
@@ -1454,6 +1483,10 @@ export class SessionStore implements CapStore, CreditStore {
       );
       this.db.run(
         `DELETE FROM issue_log WHERE sessionId IN (SELECT id FROM sessions WHERE ${victims})`,
+        params,
+      );
+      this.db.run(
+        `DELETE FROM recaps WHERE sessionId IN (SELECT id FROM sessions WHERE ${victims})`,
         params,
       );
       this.db.run(`DELETE FROM sessions WHERE ${victims}`, params);

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,6 +283,7 @@ export interface Recap {
   headline: string; // <=100 chars; "" until ready
   body: string; // markdown; "" until ready
   openItems: string[]; // [] until ready
+  changedFiles: string[]; // files changed in the session (captured at gen time; survives worktree teardown)
   spawnSessionId: string; // claude --session-id of the recap spawn (usage + pane resolve)
   cwd: string; // tmpdir cwd of the spawn (verdict file read + pane reap)
   model: string | null;

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -77,7 +77,7 @@ function makeHarness(
   opts: {
     mergeImpl?: () => Promise<void>;
     epicStatus?: "running" | "paused" | "idle";
-    archiveImpl?: (id: string) => number;
+    archiveImpl?: (id: string) => number | Promise<number>;
   } = {},
 ): Harness {
   const store = new SessionStore(":memory:");
@@ -132,7 +132,7 @@ function makeHarness(
         issueNumber: input.issueRef?.number ?? null,
       });
     },
-    archive: (id: string): number => {
+    archive: async (id: string): Promise<number> => {
       if (opts.archiveImpl) return opts.archiveImpl(id);
       store.archive(id);
       return 1;

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -159,7 +159,7 @@ function makeHarness(
         issueNumber: input.issueRef?.number ?? null,
       });
     },
-    archive: (id: string): number => {
+    archive: async (id: string): Promise<number> => {
       store.archive(id);
       return 1;
     },

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -140,7 +140,7 @@ function makeHarness(
     credits?: UsageLimitsType["credits"];
     mergeImpl?: () => Promise<void>;
     listIssuesImpl?: () => Promise<Issue[]>;
-    archiveImpl?: (id: string) => number;
+    archiveImpl?: (id: string) => number | Promise<number>;
     onArchived?: (h: Harness, id: string) => void;
     addIssueLabelImpl?: (n: number, label: string) => Promise<void>;
     closeIssueImpl?: (n: number) => Promise<void>;
@@ -222,7 +222,7 @@ function makeHarness(
         issueNumber: input.issueRef?.number ?? null,
       });
     },
-    archive: (id: string): number => {
+    archive: async (id: string): Promise<number> => {
       if (opts.archiveImpl) return opts.archiveImpl(id);
       store.archive(id);
       return 1;
@@ -691,7 +691,7 @@ test("ensureIssueLink failure is best-effort: retire still archives and emits ev
       create: async () => {
         throw new Error("should not spawn");
       },
-      archive: (id: string): number => {
+      archive: async (id: string): Promise<number> => {
         store.archive(id);
         return 1;
       },
@@ -785,7 +785,7 @@ test("tick + snapshot over repos: only drain-enabled repo is acted on and report
           issueNumber: input.issueRef?.number ?? null,
         });
       },
-      archive: (id: string): number => {
+      archive: async (id: string): Promise<number> => {
         store.archive(id);
         return 1;
       },

--- a/test/merge-teardown.test.ts
+++ b/test/merge-teardown.test.ts
@@ -4,7 +4,7 @@ import { settleMergedSession, type MergeTeardownDeps } from "../src/merge-teardo
 function deps(over: Partial<MergeTeardownDeps> = {}): MergeTeardownDeps {
   return {
     resolveForge: () => ({ closeIssue: mock(async () => {}) }) as any,
-    archive: mock(() => 1),
+    archive: mock(async () => 1),
     dropPrCache: mock(() => {}),
     emitArchived: mock(() => {}),
     retainClaim: mock(() => {}),

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -117,6 +117,7 @@ const baseRecap = (over: Partial<Recap> = {}): Recap => ({
   headline: "done",
   body: "",
   openItems: [],
+  changedFiles: [],
   spawnSessionId: "spawn-1",
   cwd: "/tmp/x",
   model: null,

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -58,6 +58,7 @@ function makeRecap(over: Partial<Recap> = {}): Recap {
     headline: "",
     body: "",
     openItems: [],
+    changedFiles: [],
     spawnSessionId: "spawn-1",
     cwd: "/tmp/recap-s1",
     model: "sonnet",
@@ -648,6 +649,184 @@ test("in-flight guard: second generate call for same session mid-await does not 
   expect(r1).toBe("started");
   expect(r2).toBe("started"); // guard returns "started" immediately
   expect(herdr.started.length).toBe(1); // only ONE spawn happened
+});
+
+// ── changedFiles capture ────────────────────────────────────────────────────────
+
+test("generate: non-empty diff → generating row captures changedFiles", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    makeTmpDir: () => "/tmp/recap-changed",
+  });
+
+  const result = await svc.generate(s);
+  expect(result).toBe("started");
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("generating");
+  expect(r?.changedFiles).toEqual(["src/foo.ts"]); // from NON_EMPTY_DIFF
+});
+
+test("generate: empty diff → empty row has changedFiles = []", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: EMPTY_DIFF,
+    makeTmpDir: () => "/tmp/recap-changed-empty",
+  });
+
+  const result = await svc.generate(s);
+  expect(result).toBe("empty");
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("empty");
+  expect(r?.changedFiles).toEqual([]);
+});
+
+// ── considerForArchive tests ──────────────────────────────────────────────────────
+
+test("considerForArchive: existing recap at current head → 'skip', no spawn", async () => {
+  const s = makeSession({ status: "done" });
+  const existingRecap = makeRecap({ state: "ready", headSha: "sha-head", verdict: "ready" });
+  const store = makeStore([s], [existingRecap]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    headSha: "sha-head",
+  });
+
+  const result = await svc.considerForArchive(s);
+  expect(result).toBe("skip");
+  expect(herdr.started.length).toBe(0);
+});
+
+test("considerForArchive: no existing recap → generates", async () => {
+  const s = makeSession({ status: "done" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    headSha: "sha-head",
+    makeTmpDir: () => "/tmp/recap-archive-gen",
+  });
+
+  const result = await svc.considerForArchive(s);
+  expect(result).toBe("started");
+  expect(herdr.started.length).toBe(1);
+  expect(store.getRecap("s1")?.state).toBe("generating");
+});
+
+test("considerForArchive: auto:true (drain) with no recap → generates (NOT skipped)", async () => {
+  const s = makeSession({ status: "done", auto: true });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    headSha: "sha-head",
+    makeTmpDir: () => "/tmp/recap-archive-auto",
+  });
+
+  const result = await svc.considerForArchive(s);
+  expect(result).toBe("started"); // key difference from considerSession: auto is NOT skipped
+  expect(herdr.started.length).toBe(1);
+  expect(store.getRecap("s1")?.state).toBe("generating");
+});
+
+test("considerForArchive: headSha throws → 'error', no throw, no spawn", async () => {
+  const s = makeSession({ status: "done" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = new RecapService({
+    store: store as any,
+    herdr: herdr as any,
+    onChange: () => {},
+    model: "sonnet",
+    now: () => 200_000,
+    timeoutMs: 300_000,
+    headSha: async () => {
+      throw new Error("worktree gone");
+    },
+    computeDiff: async () => NON_EMPTY_DIFF as any,
+    readTranscript: (): ActivityEntry[] => [],
+    readPlan: () => "",
+    readVerdict: () => null,
+    readUsage: async () => null,
+    makeTmpDir: () => "/tmp/recap-archive-err",
+    cleanup: () => {},
+  });
+
+  const result = await svc.considerForArchive(s);
+  expect(result).toBe("error");
+  expect(herdr.started.length).toBe(0);
+  expect(store.getRecap("s1")).toBeNull();
+});
+
+// ── onArchived tests ──────────────────────────────────────────────────────────────
+
+test("onArchived: keeps in-flight generating row (no reap, no drop)", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-onarchived",
+    spawnSessionId: "sp-oa",
+  });
+  const store = makeStore([], [rec]);
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-onarchived", terminalId: "t-oa" }]);
+  const cleaned: string[] = [];
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  svc.onArchived("s1");
+
+  // Row persists for the Done lens; spawn allowed to finish (no stop, no cleanup, no drop).
+  expect(store.getRecap("s1")).not.toBeNull();
+  expect(store.getRecap("s1")?.state).toBe("generating");
+  expect(herdr.stopped).not.toContain("t-oa");
+  expect(cleaned).not.toContain("/tmp/recap-onarchived");
+});
+
+test("onArchived: clears debounce so a later re-stamp is clean", async () => {
+  const s = makeSession({ status: "idle", auto: false });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  let t = 100_000;
+  const svc = buildSvc({ store, herdr, nowFn: () => t, idleThresholdMs: 120_000 });
+
+  await svc.sweep(); // stamp set at 100_000
+  svc.onArchived("s1"); // clears the debounce entry
+
+  // Re-stamp: a single settled sweep right after the clear should NOT fire (needs a
+  // fresh debounce window), proving the entry was cleared (no stale stamp survived).
+  t = 110_000;
+  await svc.sweep(); // re-stamp at 110_000, idleMs=0 → no spawn
+  expect(herdr.started.length).toBe(0);
+
+  t = 240_000; // idleMs from 110_000 = 130_000 >= threshold → now fires
+  await svc.sweep();
+  expect(herdr.started.length).toBe(1);
 });
 
 // ── forget tests ──────────────────────────────────────────────────────────────

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -829,39 +829,6 @@ test("onArchived: clears debounce so a later re-stamp is clean", async () => {
   expect(herdr.started.length).toBe(1);
 });
 
-// ── forget tests ──────────────────────────────────────────────────────────────
-
-test("forget: reaps generating row + drops recap from store", async () => {
-  const rec = makeRecap({
-    state: "generating",
-    cwd: "/tmp/recap-forget",
-    spawnSessionId: "sp3",
-  });
-  const store = makeStore([], [rec]);
-  const herdr = makeHerdr([{ cwd: "/tmp/recap-forget", terminalId: "t-forget" }]);
-  const cleaned: string[] = [];
-
-  const svc = buildSvc({
-    store,
-    herdr,
-    nowFn: () => 200_000,
-    cleanup: (d) => cleaned.push(d),
-  });
-
-  svc.forget("s1");
-  expect(store.getRecap("s1")).toBeNull();
-  expect(herdr.stopped).toContain("t-forget");
-  expect(cleaned).toContain("/tmp/recap-forget");
-});
-
-test("forget: no existing recap → no crash", async () => {
-  const store = makeStore([]);
-  const herdr = makeHerdr();
-  const svc = buildSvc({ store, herdr, nowFn: () => 200_000 });
-  svc.forget("s1"); // should not throw
-  expect(store.getRecap("s1")).toBeNull();
-});
-
 // ── git/diff failure self-heals to "error" (must NOT throw out of bare-void sweep) ──
 
 test("generate: computeDiff rejection → 'error', no throw, no row", async () => {

--- a/test/sandbox-wiring.test.ts
+++ b/test/sandbox-wiring.test.ts
@@ -337,7 +337,7 @@ test("drain pre-check: standard profile holds → service.create NOT called", as
         issueNumber: input.issueRef?.number ?? null,
       });
     },
-    archive: () => 1,
+    archive: async () => 1,
   };
   const forge = makeForge([issue(1)]);
   const drain = new DrainService({
@@ -440,7 +440,7 @@ test("drain + autonomous repo + egress NULL → held, service.create NOT called"
         issueNumber: input.issueRef?.number ?? null,
       });
     },
-    archive: () => 1,
+    archive: async () => 1,
   };
   const forge = makeForge([issue(1)]);
   const drain = new DrainService({
@@ -523,7 +523,7 @@ test("egressWatcher.stop called on archive (before removeEgressTmp)", async () =
 
   const s = await service.create(baseInput({ auto: true }));
   try {
-    service.archive(s.id);
+    await service.archive(s.id);
     expect(watcher.stops).toContain(s.id);
   } finally {
     // egressTmpDir already removed by archive; ignore if already gone.

--- a/test/server-recap.test.ts
+++ b/test/server-recap.test.ts
@@ -65,6 +65,41 @@ test("GET /api/recaps returns {} when recapCache is absent", async () => {
   expect(await res.json()).toEqual({});
 });
 
+// ── GET /api/sessions/done ─────────────────────────────────────────────────────
+
+test("GET /api/sessions/done returns recently-archived sessions, excludes live ones", async () => {
+  const { app, store } = harness();
+  const mk = (agent: string) =>
+    store.create({
+      name: agent,
+      prompt: "go",
+      repoPath: repoDir,
+      baseBranch: "main",
+      branch: `shepherd/${agent}`,
+      worktreePath: join(repoDir, agent),
+      isolated: true,
+      herdrSession: `sess-${agent}`,
+      herdrAgentId: `term_${agent}`,
+      claudeSessionId: `claude-${agent}`,
+      model: null,
+    });
+  const live = mk("live");
+  const doneA = mk("done-a");
+  store.archive(doneA.id);
+  await Bun.sleep(2); // distinct archivedAt so newest-first ordering is deterministic
+  const doneB = mk("done-b");
+  store.archive(doneB.id);
+
+  const res = await app.fetch(new Request("http://x/api/sessions/done"));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Session[];
+  const ids = body.map((s) => s.id);
+  // both freshly-archived sessions are within the 48h window, newest-first
+  expect(ids).toEqual([doneB.id, doneA.id]);
+  // the never-archived (live) session is excluded
+  expect(ids).not.toContain(live.id);
+});
+
 // ── POST /api/sessions/:id/recap/regenerate ───────────────────────────────────
 
 test("POST /api/sessions/:id/recap/regenerate → 202, calls regenerate, relays status:started", async () => {

--- a/test/server-recap.test.ts
+++ b/test/server-recap.test.ts
@@ -43,6 +43,7 @@ test("GET /api/recaps returns snapshot when recapCache is present", async () => 
     headline: "Did the thing",
     body: "",
     openItems: [],
+    changedFiles: [],
     spawnSessionId: "spawn-abc",
     cwd: "/tmp/recap-test",
     model: null,

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -753,7 +753,7 @@ test("createSession: skips worktree rollback when the cwd fallback isn't isolate
   expect(removeCalls).toBe(0);
 });
 
-test("archive stops the herdr agent, removes the worktree, and archives the row", () => {
+test("archive stops the herdr agent, removes the worktree, and archives the row", async () => {
   const store = new SessionStore(":memory:");
   const calls: any = { stopped: [], removed: [] };
   const service = new SessionService({
@@ -777,9 +777,90 @@ test("archive stops the herdr agent, removes the worktree, and archives the row"
     herdrSession: "default",
     herdrAgentId: "term_z",
   });
-  service.archive(s.id);
+  await service.archive(s.id);
   expect(calls.stopped).toEqual(["term_z"]); // agent stopped (no leak)
   expect(calls.removed).toEqual(["/wt"]); // worktree removed
+  expect(store.get(s.id)?.status).toBe("archived");
+});
+
+function archivableSession(store: SessionStore) {
+  return store.create({
+    name: "x",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_z",
+  });
+}
+
+test("archive awaits beforeArchive BEFORE removing the worktree (recap reads it first)", async () => {
+  const store = new SessionStore(":memory:");
+  const order: string[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({}),
+      ensureBaseRef: async () => {},
+      remove: () => order.push("remove"),
+    } as any,
+    herdr: { start: () => ({}), list: () => [], stop: () => {} } as any,
+    // resolves only after a tick — if archive didn't await it, remove would race ahead.
+    beforeArchive: async () => {
+      await new Promise<void>((r) => setTimeout(r, 5));
+      order.push("hook");
+    },
+  });
+  const s = archivableSession(store);
+  await service.archive(s.id);
+  expect(order).toEqual(["hook", "remove"]); // hook ran AND completed before worktree teardown
+  expect(store.get(s.id)?.status).toBe("archived");
+});
+
+test("archive: a rejecting beforeArchive never blocks teardown (worktree still removed)", async () => {
+  const store = new SessionStore(":memory:");
+  const removed: string[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({}),
+      ensureBaseRef: async () => {},
+      remove: (p: string) => removed.push(p),
+    } as any,
+    herdr: { start: () => ({}), list: () => [], stop: () => {} } as any,
+    beforeArchive: async () => {
+      throw new Error("recap spawn failed");
+    },
+  });
+  const s = archivableSession(store);
+  await service.archive(s.id); // must resolve, not reject
+  expect(removed).toEqual(["/wt"]);
+  expect(store.get(s.id)?.status).toBe("archived");
+});
+
+test("archive: a HANGING beforeArchive is bounded by the timeout (teardown proceeds)", async () => {
+  const store = new SessionStore(":memory:");
+  const removed: string[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({}),
+      ensureBaseRef: async () => {},
+      remove: (p: string) => removed.push(p),
+    } as any,
+    herdr: { start: () => ({}), list: () => [], stop: () => {} } as any,
+    beforeArchive: () => new Promise<void>(() => {}), // never resolves
+    beforeArchiveTimeoutMs: 5, // tiny backstop so the test doesn't sleep 15s
+  });
+  const s = archivableSession(store);
+  await service.archive(s.id); // resolves once the timeout wins the race
+  expect(removed).toEqual(["/wt"]);
   expect(store.get(s.id)?.status).toBe("archived");
 });
 
@@ -801,7 +882,7 @@ function resumable(store: SessionStore, over: Partial<Parameters<SessionStore["c
   return s;
 }
 
-test("archive without a reaper just closes the session (no leftover handling)", () => {
+test("archive without a reaper just closes the session (no leftover handling)", async () => {
   const store = new SessionStore(":memory:");
   const svc = new SessionService({
     store,
@@ -829,7 +910,7 @@ test("archive without a reaper just closes the session (no leftover handling)", 
     herdrSession: "default",
     herdrAgentId: "term_z",
   });
-  svc.archive(s.id, ["process:1"]); // keys ignored without a reaper
+  await svc.archive(s.id, ["process:1"]); // keys ignored without a reaper
   expect(store.get(s.id)?.status).toBe("archived");
 });
 
@@ -876,7 +957,7 @@ test("leftovers proxies to the reaper for the session; [] for unknown id", () =>
   expect(svc.leftovers("ghost")).toEqual([]);
 });
 
-test("archive reaps only the selected leftovers, re-detected (no trusting raw client keys)", () => {
+test("archive reaps only the selected leftovers, re-detected (no trusting raw client keys)", async () => {
   const store = new SessionStore(":memory:");
   const reaped: string[][] = [];
   const detected = [
@@ -921,13 +1002,13 @@ test("archive reaps only the selected leftovers, re-detected (no trusting raw cl
     herdrAgentId: "term_z",
   });
   // ask to reap the tailscale proxy + a forged key that isn't in the detected set
-  svc.archive(s.id, ["system:tailscale serve:5174", "process:99999"]);
+  await svc.archive(s.id, ["system:tailscale serve:5174", "process:99999"]);
   // only the genuinely-detected, selected leftover is reaped — the forged key is dropped
   expect(reaped).toEqual([["system:tailscale serve:5174"]]);
   expect(store.get(s.id)?.status).toBe("archived");
 });
 
-test("archive with no reap keys never calls the reaper", () => {
+test("archive with no reap keys never calls the reaper", async () => {
   const store = new SessionStore(":memory:");
   let reapCalls = 0;
   let detectCalls = 0;
@@ -967,7 +1048,7 @@ test("archive with no reap keys never calls the reaper", () => {
     herdrSession: "default",
     herdrAgentId: "term_z",
   });
-  svc.archive(s.id);
+  await svc.archive(s.id);
   expect(detectCalls).toBe(0);
   expect(reapCalls).toBe(0);
 });
@@ -1527,7 +1608,7 @@ test("refine skipped entirely when refineName dep is absent", async () => {
   expect(events.emitted.some((x: any) => x.e === "session:renamed")).toBe(false);
 });
 
-test("archiveMany clears each session, reaping all its leftovers", () => {
+test("archiveMany clears each session, reaping all its leftovers", async () => {
   const store = new SessionStore(":memory:");
   const calls: any = { stopped: [], removed: [], reaped: [] };
   const detect = (sess: any): any[] => [
@@ -1567,7 +1648,7 @@ test("archiveMany clears each session, reaping all its leftovers", () => {
   const a = mk("a", "term_a");
   const b = mk("b", "term_b");
 
-  const res = svc.archiveMany([a.id, b.id, "missing-id"]);
+  const res = await svc.archiveMany([a.id, b.id, "missing-id"]);
 
   expect(res.cleared).toEqual([a.id, b.id]); // missing id skipped
   expect(res.leftovers).toBe(2); // one leftover each, both counted
@@ -1863,7 +1944,7 @@ test("resume adopts a live agent found by cwd under a new terminalId — no dupl
   expect(out?.herdrAgentId).toBe("term_fresh"); // adopted the new id
 });
 
-test("archiveMany isolates a failing session: others still clear, the failed id is excluded", () => {
+test("archiveMany isolates a failing session: others still clear, the failed id is excluded", async () => {
   const store = new SessionStore(":memory:");
   const detect = (): any[] => [];
   const svc = new SessionService({
@@ -1896,7 +1977,7 @@ test("archiveMany isolates a failing session: others still clear, the failed id 
   const b = mk("b");
   const c = mk("c");
 
-  const res = svc.archiveMany([a.id, b.id, c.id]);
+  const res = await svc.archiveMany([a.id, b.id, c.id]);
 
   expect(res.cleared).toEqual([a.id, c.id]); // b's failure didn't abort the loop, and b is excluded
   expect(store.get(a.id)?.status).toBe("archived");

--- a/test/store-recaps.test.ts
+++ b/test/store-recaps.test.ts
@@ -10,6 +10,7 @@ const r = (over: Partial<Recap> = {}): Recap => ({
   headline: "",
   body: "",
   openItems: [],
+  changedFiles: [],
   spawnSessionId: "spawn-1",
   cwd: "/tmp/recap-1",
   model: "claude-sonnet-4-5",
@@ -108,6 +109,31 @@ test("recaps: openItems with bad JSON in DB defaults to []", () => {
   );
   const got = s.getRecap("s-bad");
   expect(got?.openItems).toEqual([]);
+});
+
+test("recaps: changedFiles round-trips through put→get / snapshot / generating", () => {
+  const s = new SessionStore(":memory:");
+  const files = ["src/store.ts", "src/types.ts", "test/store-recaps.test.ts"];
+  // generating row carries changedFiles — guards the finalize() {...r} spread that
+  // sources from generatingRecaps(); a dropped column there silently loses them.
+  s.putRecap(r({ sessionId: "s1", state: "generating", changedFiles: files }));
+  expect(s.getRecap("s1")?.changedFiles).toEqual(files);
+  expect(s.generatingRecaps()[0]?.changedFiles).toEqual(files);
+
+  s.putRecap(
+    r({ sessionId: "s2", state: "ready", verdict: "ready", headline: "done", changedFiles: files }),
+  );
+  expect(s.snapshotRecaps()["s2"]?.changedFiles).toEqual(files);
+});
+
+test("recaps: changedFiles with bad JSON in DB defaults to []", () => {
+  const s = new SessionStore(":memory:");
+  s["db"].run(
+    `INSERT INTO recaps (sessionId, state, headSha, verdict, headline, body, openItems, changedFiles,
+       spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt)
+     VALUES ('s-bad', 'ready', 'sha', 'ready', 'h', 'b', '[]', 'NOT_JSON', '', '/tmp', null, 1, null, 1)`,
+  );
+  expect(s.getRecap("s-bad")?.changedFiles).toEqual([]);
 });
 
 test("recaps: model field stores null correctly", () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { SessionStore } from "../src/store";
-import type { PrReview, ReviewVerdict } from "../src/types";
+import type { PrReview, Recap, ReviewVerdict } from "../src/types";
 import type { SessionUsage } from "../src/usage";
 
 function mk() {
@@ -442,6 +442,59 @@ test("pruneArchivedSessions: legacy archived row with null archivedAt expires vi
   const removed = s.pruneArchivedSessions({ maxAgeMs: 1, keepNewest: 250 });
   expect(removed).toBe(1);
   expect(s.get(a.id)).toBeNull();
+});
+
+const recap = (sessionId: string, over: Partial<Recap> = {}): Recap => ({
+  sessionId,
+  state: "ready",
+  headSha: "sha",
+  verdict: "ready",
+  headline: "done",
+  body: "",
+  openItems: [],
+  changedFiles: [],
+  spawnSessionId: "spawn",
+  cwd: "/tmp",
+  model: null,
+  spawnedAt: 1,
+  generatedAt: 2,
+  updatedAt: 2,
+  ...over,
+});
+
+test("listRecentlyArchived: only archived sessions with archivedAt >= cutoff, newest-first", async () => {
+  const s = mk();
+  // a running (never-archived) session must be excluded regardless of cutoff
+  s.create({ ...base, herdrAgentId: "live" });
+  const old = s.create({ ...base, herdrAgentId: "old" });
+  s.archive(old.id);
+  await sleep(5);
+  const cutoff = Date.now();
+  await sleep(2);
+  const mid = s.create({ ...base, herdrAgentId: "mid" });
+  s.archive(mid.id);
+  await sleep(2);
+  const recent = s.create({ ...base, herdrAgentId: "recent" });
+  s.archive(recent.id);
+
+  const got = s.listRecentlyArchived(cutoff);
+  // old archived (before cutoff) and the live row are both excluded; newest-first ordering
+  expect(got.map((x) => x.id)).toEqual([recent.id, mid.id]);
+});
+
+test("pruneArchivedSessions: cascades the victim's recap, keeps survivor's", async () => {
+  const s = mk();
+  const victim = s.create({ ...base, herdrAgentId: "tv" });
+  s.archive(victim.id);
+  await sleep(2);
+  const keep = s.create({ ...base, herdrAgentId: "tk" });
+  s.archive(keep.id);
+  s.putRecap(recap(victim.id, { changedFiles: ["a.ts"] }));
+  s.putRecap(recap(keep.id, { changedFiles: ["b.ts"] }));
+  const removed = s.pruneArchivedSessions({ maxAgeMs: YEAR_MS, keepNewest: 1 });
+  expect(removed).toBe(1);
+  expect(s.getRecap(victim.id)).toBeNull(); // recap pruned with the session
+  expect(s.getRecap(keep.id)).not.toBeNull(); // survivor's recap intact
 });
 
 function newMergeInput() {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1254,7 +1254,6 @@
   "herd_done_filter": "✓ Fertig",
   "herd_done_title": "Abgeschlossene (archivierte) Sitzungen und ihre Zusammenfassungen anzeigen",
   "herd_done_empty": "Noch keine abgeschlossenen Sitzungen.",
-  "done_lens_title": "Fertig",
   "done_recap_finished": "Vor {ago} abgeschlossen",
   "done_recap_panel_aria": "Zusammenfassung für {desig}",
   "done_back_to_list": "‹ Zurück zu Fertig",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1257,5 +1257,7 @@
   "done_lens_title": "Fertig",
   "done_recap_finished": "Vor {ago} abgeschlossen",
   "done_recap_panel_aria": "Zusammenfassung für {desig}",
-  "done_back_to_list": "‹ Zurück zu Fertig"
+  "done_back_to_list": "‹ Zurück zu Fertig",
+  "feat_done_lens_title": "Fertig-Ansicht",
+  "feat_done_lens_body": "Filtere die Herde auf deine abgeschlossenen und gemergten Sitzungen und öffne eine davon, um die schreibgeschützte Zusammenfassung des Verlaufs anzusehen."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1247,5 +1247,15 @@
   "integrated_epics_landing_failed": "Landing-PR konnte nicht geöffnet werden — erneuter Versuch",
   "feat_epic_landing_pr_title": "Epics landen über einen finalen PR",
   "feat_epic_landing_pr_body": "Wenn alle Kind-Issues eines Epics integriert sind, öffnet Shepherd einen finalen PR, der das gesamte Epic landet und das Eltern-Issue schließt — als Link im Band 'Integrierte Epics'.",
-  "integrated_epics_landing_pr_merged": "Landing-PR #{number} — gemergt"
+  "integrated_epics_landing_pr_merged": "Landing-PR #{number} — gemergt",
+  "recap_changed_files": "Geänderte Dateien",
+  "recap_unavailable": "Für diese Sitzung ist keine Zusammenfassung verfügbar.",
+  "recap_issue": "Issue #{n}",
+  "herd_done_filter": "✓ Fertig",
+  "herd_done_title": "Abgeschlossene (archivierte) Sitzungen und ihre Zusammenfassungen anzeigen",
+  "herd_done_empty": "Noch keine abgeschlossenen Sitzungen.",
+  "done_lens_title": "Fertig",
+  "done_recap_finished": "Vor {ago} abgeschlossen",
+  "done_recap_panel_aria": "Zusammenfassung für {desig}",
+  "done_back_to_list": "‹ Zurück zu Fertig"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1247,5 +1247,15 @@
   "integrated_epics_landing_failed": "Couldn't open the landing PR — retrying",
   "feat_epic_landing_pr_title": "Epics land via a final PR",
   "feat_epic_landing_pr_body": "When an epic's children are all integrated, Shepherd opens a final PR that lands the whole epic and closes the parent issue — surfaced as a link in the Integrated-epics band.",
-  "integrated_epics_landing_pr_merged": "Landing PR #{number} — merged"
+  "integrated_epics_landing_pr_merged": "Landing PR #{number} — merged",
+  "recap_changed_files": "Changed files",
+  "recap_unavailable": "No recap available for this session.",
+  "recap_issue": "Issue #{n}",
+  "herd_done_filter": "✓ Done",
+  "herd_done_title": "Show finished (archived) sessions and their recaps",
+  "herd_done_empty": "No finished sessions yet.",
+  "done_lens_title": "Done",
+  "done_recap_finished": "Finished {ago} ago",
+  "done_recap_panel_aria": "Recap for {desig}",
+  "done_back_to_list": "‹ Back to done"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1254,7 +1254,6 @@
   "herd_done_filter": "✓ Done",
   "herd_done_title": "Show finished (archived) sessions and their recaps",
   "herd_done_empty": "No finished sessions yet.",
-  "done_lens_title": "Done",
   "done_recap_finished": "Finished {ago} ago",
   "done_recap_panel_aria": "Recap for {desig}",
   "done_back_to_list": "‹ Back to done",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1257,5 +1257,7 @@
   "done_lens_title": "Done",
   "done_recap_finished": "Finished {ago} ago",
   "done_recap_panel_aria": "Recap for {desig}",
-  "done_back_to_list": "‹ Back to done"
+  "done_back_to_list": "‹ Back to done",
+  "feat_done_lens_title": "Done lens",
+  "feat_done_lens_body": "Filter the Herd to your finished and merged sessions, then open any one to review its read-only recap of what happened."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -784,6 +784,11 @@ export async function getRecaps(): Promise<Record<string, Recap>> {
   return getJson("/api/recaps", "recaps");
 }
 
+/** Sessions archived within the Done-lens window (last 48h), newest-first. */
+export async function getDoneSessions(): Promise<Session[]> {
+  return getJson("/api/sessions/done", "done sessions");
+}
+
 /** Trigger a recap regeneration for a session. Returns `{status}` from the server. */
 export async function regenerateRecap(id: string): Promise<{ status: string }> {
   const r = await fetch(`/api/sessions/${encodeURIComponent(id)}/recap/regenerate`, {

--- a/ui/src/lib/components/DoneRecapPanel.browser.test.ts
+++ b/ui/src/lib/components/DoneRecapPanel.browser.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import DoneRecapPanel from "./DoneRecapPanel.svelte";
+import { recaps } from "$lib/recaps.svelte";
+import type { Session, Recap } from "$lib/types";
+
+function session(partial: Partial<Session> & { id: string }): Session {
+  return {
+    desig: "TASK-09",
+    name: "finished task",
+    prompt: "do the thing",
+    repoPath: "/repo/shepherd",
+    baseBranch: "main",
+    branch: "feat/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "h",
+    herdrAgentId: "ha",
+    claudeSessionId: "cs",
+    model: null,
+    status: "idle",
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: null,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    auto: false,
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    research: false,
+    issueNumber: null,
+    lastState: "",
+    createdAt: 0,
+    updatedAt: 1000,
+    archivedAt: Date.now() - 60_000,
+    ...partial,
+  };
+}
+
+function recap(partial: Partial<Recap> & { sessionId: string }): Recap {
+  return {
+    state: "ready",
+    headSha: "abc",
+    verdict: "ready",
+    headline: "Shipped the feature",
+    body: "Did **all** the work.",
+    openItems: [],
+    changedFiles: [],
+    spawnSessionId: partial.sessionId,
+    cwd: "/repo",
+    model: null,
+    spawnedAt: 0,
+    generatedAt: 1000,
+    updatedAt: 1000,
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  recaps.map = {};
+});
+
+afterEach(() => {
+  recaps.map = {};
+  document.body.innerHTML = "";
+});
+
+describe("DoneRecapPanel ready state", () => {
+  it("renders verdict chip + headline + changed files + issue text", async () => {
+    recaps.map = {
+      s1: recap({
+        sessionId: "s1",
+        verdict: "ready",
+        headline: "Shipped the feature",
+        changedFiles: ["src/a.ts", "src/b.ts"],
+        openItems: ["follow up on X"],
+      }),
+    };
+    render(DoneRecapPanel, { session: session({ id: "s1", issueNumber: 123 }) });
+
+    await expect.element(page.getByText("Shipped the feature")).toBeInTheDocument();
+    // verdict chip (Ready)
+    await expect.element(page.getByText("Ready")).toBeInTheDocument();
+    // changed files section + entries
+    await expect.element(page.getByText("Changed files")).toBeInTheDocument();
+    await expect.element(page.getByText("src/a.ts")).toBeInTheDocument();
+    await expect.element(page.getByText("src/b.ts")).toBeInTheDocument();
+    // open items
+    await expect.element(page.getByText("follow up on X")).toBeInTheDocument();
+    // issue rendered as text (no fabricated PR URL/link)
+    await expect.element(page.getByText("Issue #123")).toBeInTheDocument();
+    expect(document.querySelector("a"), "no fabricated PR link in header").toBeNull();
+  });
+
+  it("omits the changed-files section when the list is empty", async () => {
+    recaps.map = { s2: recap({ sessionId: "s2", changedFiles: [] }) };
+    render(DoneRecapPanel, { session: session({ id: "s2" }) });
+    await expect.element(page.getByText("Shipped the feature")).toBeInTheDocument();
+    expect(page.getByText("Changed files").elements().length, "no changed-files heading").toBe(0);
+  });
+
+  it("has no regenerate/retry button (worktree is gone)", async () => {
+    recaps.map = { s3: recap({ sessionId: "s3" }) };
+    render(DoneRecapPanel, { session: session({ id: "s3" }) });
+    await expect.element(page.getByText("Shipped the feature")).toBeInTheDocument();
+    expect(document.querySelectorAll("button").length, "panel renders no buttons").toBe(0);
+  });
+});
+
+describe("DoneRecapPanel generating state", () => {
+  it("shows the generating line", async () => {
+    recaps.map = { g1: recap({ sessionId: "g1", state: "generating" }) };
+    render(DoneRecapPanel, { session: session({ id: "g1" }) });
+    await expect.element(page.getByText("Generating recap…")).toBeInTheDocument();
+  });
+});
+
+describe("DoneRecapPanel fail-closed", () => {
+  it("failed recap → recap unavailable (never a blank success card)", async () => {
+    recaps.map = { f1: recap({ sessionId: "f1", state: "failed" }) };
+    render(DoneRecapPanel, { session: session({ id: "f1" }) });
+    await expect
+      .element(page.getByText("No recap available for this session."))
+      .toBeInTheDocument();
+    expect(page.getByText("Shipped the feature").elements().length, "no headline").toBe(0);
+  });
+
+  it("missing recap row → recap unavailable", async () => {
+    // no entry in recaps.map for this id
+    render(DoneRecapPanel, { session: session({ id: "missing" }) });
+    await expect
+      .element(page.getByText("No recap available for this session."))
+      .toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/DoneRecapPanel.svelte
+++ b/ui/src/lib/components/DoneRecapPanel.svelte
@@ -2,6 +2,7 @@
   import type { Session, RecapVerdict } from "$lib/types";
   import { recaps } from "$lib/recaps.svelte";
   import { formatAgo } from "$lib/format";
+  import { clock } from "$lib/now.svelte";
   import { m } from "$lib/paraglide/messages";
 
   let { session }: { session: Session } = $props();
@@ -9,8 +10,11 @@
   const recap = $derived(recaps.map[session.id]);
 
   // relative "finished X ago" from archivedAt; falls back to updatedAt when an
-  // archived session somehow has no archivedAt stamp.
-  const finishedAgo = $derived(formatAgo(Date.now() - (session.archivedAt ?? session.updatedAt)));
+  // archived session somehow has no archivedAt stamp. Driven by the shared 30s
+  // `clock` (matching the Herd row's nowMs) so the stamp ticks while the panel stays open.
+  const finishedAgo = $derived(
+    formatAgo(clock.current - (session.archivedAt ?? session.updatedAt)),
+  );
 
   // Render the (LLM-authored) body as sanitized markdown. Dynamically imported so
   // marked/DOMPurify stay off the first-paint critical path; gated on a ready recap

--- a/ui/src/lib/components/DoneRecapPanel.svelte
+++ b/ui/src/lib/components/DoneRecapPanel.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+  import type { Session, RecapVerdict } from "$lib/types";
+  import { recaps } from "$lib/recaps.svelte";
+  import { formatAgo } from "$lib/format";
+  import { m } from "$lib/paraglide/messages";
+
+  let { session }: { session: Session } = $props();
+
+  const recap = $derived(recaps.map[session.id]);
+
+  // relative "finished X ago" from archivedAt; falls back to updatedAt when an
+  // archived session somehow has no archivedAt stamp.
+  const finishedAgo = $derived(formatAgo(Date.now() - (session.archivedAt ?? session.updatedAt)));
+
+  // Render the (LLM-authored) body as sanitized markdown. Dynamically imported so
+  // marked/DOMPurify stay off the first-paint critical path; gated on a ready recap
+  // body so the browser-only sanitizer never runs during SSR or for an empty body.
+  let renderedBody = $state("");
+  $effect(() => {
+    const body = recap?.state === "ready" ? recap.body : undefined;
+    if (!body) {
+      renderedBody = "";
+      return;
+    }
+    let alive = true;
+    Promise.all([import("marked"), import("dompurify")])
+      .then(([{ marked }, { default: DOMPurify }]) => {
+        if (alive)
+          renderedBody = DOMPurify.sanitize(marked.parse(body, { async: false }) as string);
+      })
+      .catch((err) => {
+        console.warn("Recap body markdown render failed", err);
+      });
+    return () => {
+      alive = false;
+    };
+  });
+
+  // Mirrors SessionRecap's verdict mapping (semantic, not decorative): green only for a
+  // genuinely-ready verdict; a parked/done session reads slate; needs-attention amber.
+  const VERDICT_COLOR: Record<RecapVerdict, string> = {
+    ready: "var(--color-green)",
+    parked: "var(--status-done)",
+    needs_attention: "var(--color-amber)",
+  };
+
+  function verdictLabel(v: RecapVerdict): string {
+    if (v === "ready") return m.recap_verdict_ready();
+    if (v === "parked") return m.recap_verdict_parked();
+    return m.recap_verdict_needs_attention();
+  }
+</script>
+
+<section class="done-recap" aria-label={m.done_recap_panel_aria({ desig: session.desig })}>
+  <header class="dr-head">
+    <span class="dr-desig">{session.desig}</span>
+    <span class="dr-finished">{m.done_recap_finished({ ago: finishedAgo })}</span>
+    {#if session.issueNumber != null}
+      <span class="dr-issue">{m.recap_issue({ n: session.issueNumber })}</span>
+    {/if}
+  </header>
+
+  <div class="dr-body">
+    {#if recap?.state === "ready"}
+      {#if recap.verdict}
+        <span class="dr-verdict" style:color={VERDICT_COLOR[recap.verdict]}
+          >{verdictLabel(recap.verdict)}</span
+        >
+      {/if}
+      {#if recap.headline}
+        <p class="dr-headline">{recap.headline}</p>
+      {/if}
+      {#if renderedBody}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized via DOMPurify above -->
+        <div class="dr-md">{@html renderedBody}</div>
+      {/if}
+      {#if recap.openItems.length > 0}
+        <div class="dr-section">
+          <p class="dr-section-head">{m.recap_open_items()}</p>
+          <ul class="dr-list">
+            {#each recap.openItems as item (item)}
+              <li>{item}</li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+      {#if recap.changedFiles.length > 0}
+        <div class="dr-section">
+          <p class="dr-section-head">{m.recap_changed_files()}</p>
+          <ul class="dr-list dr-files">
+            {#each recap.changedFiles as file (file)}
+              <li>{file}</li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+    {:else if recap?.state === "generating"}
+      <p class="dr-muted">{m.recap_generating()}</p>
+    {:else}
+      <!-- failed, empty, or no recap row: fail-closed — never a blank card that reads
+           as a success. -->
+      <p class="dr-muted">{m.recap_unavailable()}</p>
+    {/if}
+  </div>
+</section>
+
+<style>
+  .done-recap {
+    position: relative;
+    border: 1px solid var(--color-line);
+    background: var(--color-panel);
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+    min-height: 0;
+    flex: 1;
+  }
+
+  .dr-head {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 10px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--color-line);
+  }
+
+  .dr-desig {
+    font-size: var(--fs-base);
+    color: var(--color-ink-bright);
+    font-weight: 600;
+  }
+
+  .dr-finished {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+
+  .dr-issue {
+    margin-left: auto;
+    font-size: var(--fs-meta);
+    color: var(--color-faint);
+  }
+
+  .dr-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 14px 16px;
+  }
+
+  .dr-verdict {
+    align-self: flex-start;
+    font-size: var(--fs-micro);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .dr-headline {
+    margin: 0;
+    font-size: var(--fs-base);
+    color: var(--color-ink-bright);
+  }
+
+  .dr-md {
+    font-size: var(--fs-base);
+    color: var(--color-ink);
+    line-height: 1.5;
+  }
+
+  .dr-md :global(p) {
+    margin: 0 0 8px 0;
+  }
+
+  .dr-md :global(ul),
+  .dr-md :global(ol) {
+    margin: 0 0 8px 0;
+    padding-left: 18px;
+  }
+
+  .dr-md :global(a) {
+    color: var(--color-amber);
+  }
+
+  .dr-section-head {
+    margin: 0 0 4px 0;
+    font-size: var(--fs-micro);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-muted);
+  }
+
+  .dr-list {
+    margin: 0;
+    padding-left: 16px;
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+  }
+
+  .dr-list li {
+    margin-bottom: 2px;
+  }
+
+  .dr-files {
+    font-variant-numeric: tabular-nums;
+    word-break: break-all;
+  }
+
+  .dr-muted {
+    margin: 0;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+</style>

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -325,6 +325,53 @@ describe("Herd status filter (TopBar tallies)", () => {
   });
 });
 
+describe("Herd Done filter", () => {
+  it("clicking DONE clears any status filter (one filter at a time)", async () => {
+    const onstatusfilter = vi.fn();
+    render(Herd, {
+      ...base,
+      sessions: [session({ id: "live", name: "live one" })],
+      git: {},
+      onstatusfilter,
+    });
+    await page.getByRole("button", { name: "✓ Done" }).click();
+    expect(onstatusfilter).toHaveBeenCalledWith(null);
+  });
+
+  it("done mode lists the doneList rows (not the live sessions) and fires ondoneselect", async () => {
+    const ondoneselect = vi.fn();
+    render(Herd, {
+      ...base,
+      // live session must NOT appear under the done lens
+      sessions: [session({ id: "live", name: "live one" })],
+      git: {},
+      filter: "done" as const,
+      doneList: [
+        session({ id: "d1", desig: "TASK-77", name: "archived one", repoPath: "/repo/shepherd" }),
+      ],
+      ondoneselect,
+    });
+    await expect.element(page.getByText("TASK-77")).toBeInTheDocument();
+    // repo basename rendered
+    await expect.element(page.getByText("shepherd")).toBeInTheDocument();
+    // live session hidden in done mode
+    expect(page.getByText("live one").elements().length, "live row hidden under done").toBe(0);
+    await page.getByText("TASK-77").click();
+    expect(ondoneselect).toHaveBeenCalledWith("d1");
+  });
+
+  it("empty done list shows the done empty-state note", async () => {
+    render(Herd, {
+      ...base,
+      sessions: [],
+      git: {},
+      filter: "done" as const,
+      doneList: [],
+    });
+    await expect.element(page.getByText("No finished sessions yet.")).toBeInTheDocument();
+  });
+});
+
 describe("Herd epic grouping", () => {
   const epicChild = (number: number): EpicChild => ({
     number,

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -9,6 +9,9 @@
   import { collectReadyPrs } from "./merge-train";
   import { displayStatus } from "$lib/display-status";
   import { reviews, planGates } from "$lib/reviews.svelte";
+  import { recaps } from "$lib/recaps.svelte";
+  import { formatAgo } from "$lib/format";
+  import type { RecapVerdict } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
 
   let {
@@ -46,6 +49,9 @@
     oncollapse = undefined,
     completedEpics = [],
     ondismissepic = undefined,
+    doneList = [],
+    doneSelectedId = null,
+    ondoneselect = undefined,
   }: {
     sessions: Session[];
     selectedId: string | null;
@@ -121,6 +127,14 @@
     completedEpics?: CompletedEpic[];
     // dismiss a completed epic from the band; page owns the optimistic remove + reconcile
     ondismissepic?: (repoPath: string, parent: number) => void;
+    // Done lens: the archived ("done") sessions to list when filter === "done" (newest
+    // first; the endpoint already orders them). These are NOT live sessions — they live in
+    // the page's lazy doneSessions store, distinct from `sessions`.
+    doneList?: Session[];
+    // the picked done row (resolved against doneList, not the live `sessions`/selectedId)
+    doneSelectedId?: string | null;
+    // a done row was picked → page selects it + shows its DoneRecapPanel in the main area
+    ondoneselect?: (id: string) => void;
   } = $props();
 
   // a critic post-PR review or a pre-execution plan-gate review currently in flight —
@@ -210,6 +224,24 @@
   }
   const reviewerWho = $derived(uniqueWho(partition.waitingOnReviewer));
   const mergerWho = $derived(uniqueWho(partition.waitingOnMerger));
+
+  // Done lens row chrome: a finished session's recap verdict drives a small chip. Semantic
+  // colors mirror SessionRecap/DoneRecapPanel (green = genuinely READY only; parked = slate;
+  // needs-attention = amber).
+  const VERDICT_COLOR: Record<RecapVerdict, string> = {
+    ready: "var(--color-green)",
+    parked: "var(--status-done)",
+    needs_attention: "var(--color-amber)",
+  };
+  function verdictLabel(v: RecapVerdict): string {
+    if (v === "ready") return m.recap_verdict_ready();
+    if (v === "parked") return m.recap_verdict_parked();
+    return m.recap_verdict_needs_attention();
+  }
+  // last path segment of a repoPath, for the done row's repo label
+  function repoBasename(p: string): string {
+    return p.split("/").filter(Boolean).at(-1) ?? p;
+  }
 </script>
 
 <div class="panel bracket" class:flow>
@@ -249,6 +281,17 @@
           onstatusfilter?.(null);
         }}>{m.herd_research_filter()}</button
       >
+      <button
+        type="button"
+        class="micro fbtn"
+        class:active={statusFilter == null && filter === "done"}
+        title={m.herd_done_title()}
+        aria-pressed={statusFilter == null && filter === "done"}
+        onclick={() => {
+          filter = "done";
+          onstatusfilter?.(null);
+        }}>{m.herd_done_filter()}</button
+      >
       {#if statusFilter != null}
         <!-- aria-label carries status + clear action; the visible "✕" glyph would
            otherwise be read aloud without conveying what the chip does -->
@@ -274,7 +317,42 @@
     </div>
   </div>
   <div class="units" class:flow>
-    {#if sessions.length === 0}
+    {#if filter === "done"}
+      <!-- Done lens: archived sessions from the page's lazy doneSessions store (NOT the
+         live `sessions` list). Read-only rows; clicking opens the DoneRecapPanel. -->
+      {#if doneList.length === 0}
+        <div class="empty micro static">{m.herd_done_empty()}</div>
+      {:else}
+        {#each doneList as ds (ds.id)}
+          {@const r = recaps.map[ds.id]}
+          <button
+            type="button"
+            class="done-row"
+            class:sel={ds.id === doneSelectedId}
+            data-unit-id={ds.id}
+            onclick={() => ondoneselect?.(ds.id)}
+          >
+            <div class="done-row-top">
+              <span class="done-desig">{ds.desig}</span>
+              <span class="done-repo" title={ds.repoPath}>{repoBasename(ds.repoPath)}</span>
+              {#if r?.state === "ready" && r.verdict}
+                <span class="done-verdict" style:color={VERDICT_COLOR[r.verdict]}
+                  >{verdictLabel(r.verdict)}</span
+                >
+              {/if}
+              <span class="done-ago"
+                >{m.done_recap_finished({
+                  ago: formatAgo(nowMs - (ds.archivedAt ?? ds.updatedAt)),
+                })}</span
+              >
+            </div>
+            <span class="done-snippet"
+              >{r?.state === "ready" ? r.headline : ds.name || ds.prompt}</span
+            >
+          </button>
+        {/each}
+      {/if}
+    {:else if sessions.length === 0}
       <!-- the status filter empties the list at PAGE level (herdSessions), so an
          empty status result lands HERE — it must outrank the repo note and the
          first-run EmptyHerd nudge, and name the active status so vanished
@@ -618,7 +696,9 @@
         {/each}
       {/if}
     {/if}
-    <IntegratedEpicsBand epics={completedEpics} ondismiss={ondismissepic ?? (() => {})} {nowMs} />
+    {#if filter !== "done"}
+      <IntegratedEpicsBand epics={completedEpics} ondismiss={ondismissepic ?? (() => {})} {nowMs} />
+    {/if}
   </div>
 </div>
 
@@ -890,5 +970,72 @@
   }
   .empty.static:hover {
     color: var(--color-faint);
+  }
+
+  /* Done-lens row: a finished session, picked to show its recap in the main panel.
+     Borrows the rail's row rhythm/tokens; selection mirrors UnitRow's .sel cue. */
+  .done-row {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    width: 100%;
+    text-align: left;
+    border: 1px solid transparent;
+    background: none;
+    font-family: inherit;
+    cursor: pointer;
+    padding: 8px 10px;
+    transition:
+      border-color 0.12s ease,
+      background 0.12s ease;
+  }
+  .done-row:hover {
+    border-color: var(--color-line);
+    background: var(--color-hover);
+  }
+  .done-row:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .done-row.sel {
+    border-color: var(--color-line-bright);
+    background: var(--color-sel);
+  }
+  .done-row-top {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .done-desig {
+    font-size: var(--fs-meta);
+    color: var(--color-ink-bright);
+    font-weight: 600;
+  }
+  .done-repo {
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .done-verdict {
+    font-size: var(--fs-micro);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    flex-shrink: 0;
+  }
+  .done-ago {
+    margin-left: auto;
+    flex-shrink: 0;
+    font-size: var(--fs-micro);
+    color: var(--color-faint);
+  }
+  .done-snippet {
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 </style>

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -13,6 +13,7 @@
   import { formatAgo } from "$lib/format";
   import type { RecapVerdict } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
 
   let {
     sessions,
@@ -287,6 +288,7 @@
         class:active={statusFilter == null && filter === "done"}
         title={m.herd_done_title()}
         aria-pressed={statusFilter == null && filter === "done"}
+        use:coachTarget={"done-lens"}
         onclick={() => {
           filter = "done";
           onstatusfilter?.(null);

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -51,8 +51,12 @@ type Stage =
   | "awaitingMerge"
   | "active";
 
-/** The herd rail's list filter: everything, only sessions awaiting the operator, or only research tasks. */
-export type HerdFilter = "all" | "ready" | "research";
+/** The herd rail's list filter: everything, only sessions awaiting the operator, only
+ *  research tasks, or the Done lens (archived/finished sessions). "done" is NOT a live-list
+ *  filter — the page renders the separate `doneSessions` list for it; here it falls through
+ *  to the live filtering's default (returns the live set untouched, so no crash if it ever
+ *  reaches shownSessions). */
+export type HerdFilter = "all" | "ready" | "research" | "done";
 
 /** The sessions the rail actually lists under `filter` — "ready" keeps only sessions
  *  awaiting the operator (not running, not under review); "research" keeps only sessions

--- a/ui/src/lib/done.svelte.test.ts
+++ b/ui/src/lib/done.svelte.test.ts
@@ -12,21 +12,19 @@ const session = (id: string): Session => ({ id }) as Session;
 
 beforeEach(() => {
   doneSessions.sessions = [];
-  doneSessions.loaded = false;
   vi.clearAllMocks();
 });
 
-test("load() populates sessions from api and sets loaded", async () => {
+test("load() populates sessions from api", async () => {
   const list = [session("s1"), session("s2")];
   vi.mocked(getDoneSessions).mockResolvedValue(list);
   await doneSessions.load();
   expect(doneSessions.sessions).toEqual(list);
-  expect(doneSessions.loaded).toBe(true);
 });
 
-test("load() swallows api errors (best-effort)", async () => {
+test("load() swallows api errors and leaves the list untouched (best-effort)", async () => {
+  doneSessions.sessions = [session("prev")];
   vi.mocked(getDoneSessions).mockRejectedValue(new Error("network error"));
   await expect(doneSessions.load()).resolves.toBeUndefined();
-  expect(doneSessions.sessions).toEqual([]);
-  expect(doneSessions.loaded).toBe(false);
+  expect(doneSessions.sessions).toEqual([session("prev")]);
 });

--- a/ui/src/lib/done.svelte.test.ts
+++ b/ui/src/lib/done.svelte.test.ts
@@ -1,0 +1,32 @@
+import { test, expect, vi, beforeEach } from "vitest";
+import type { Session } from "./types";
+
+vi.mock("./api", () => ({
+  getDoneSessions: vi.fn(),
+}));
+
+import { doneSessions } from "./done.svelte";
+import { getDoneSessions } from "./api";
+
+const session = (id: string): Session => ({ id }) as Session;
+
+beforeEach(() => {
+  doneSessions.sessions = [];
+  doneSessions.loaded = false;
+  vi.clearAllMocks();
+});
+
+test("load() populates sessions from api and sets loaded", async () => {
+  const list = [session("s1"), session("s2")];
+  vi.mocked(getDoneSessions).mockResolvedValue(list);
+  await doneSessions.load();
+  expect(doneSessions.sessions).toEqual(list);
+  expect(doneSessions.loaded).toBe(true);
+});
+
+test("load() swallows api errors (best-effort)", async () => {
+  vi.mocked(getDoneSessions).mockRejectedValue(new Error("network error"));
+  await expect(doneSessions.load()).resolves.toBeUndefined();
+  expect(doneSessions.sessions).toEqual([]);
+  expect(doneSessions.loaded).toBe(false);
+});

--- a/ui/src/lib/done.svelte.ts
+++ b/ui/src/lib/done.svelte.ts
@@ -7,14 +7,15 @@ import { getDoneSessions } from "./api";
  *  this store deliberately subscribes to no WS events. */
 class DoneSessionsStore {
   sessions = $state<Session[]>([]);
-  loaded = $state(false);
 
+  /** Re-fetches every call; the Done lens reloads on each open (see +page.svelte) so the
+   *  list reflects sessions that finished since last time. On failure it leaves the
+   *  existing list untouched and swallows the error — the next open retries. */
   async load() {
     try {
       this.sessions = await getDoneSessions();
-      this.loaded = true;
     } catch {
-      /* best-effort; leaves the list empty + loaded=false so a retry is possible */
+      /* best-effort; the next lens open retries */
     }
   }
 }

--- a/ui/src/lib/done.svelte.ts
+++ b/ui/src/lib/done.svelte.ts
@@ -1,0 +1,21 @@
+import type { Session } from "./types";
+import { getDoneSessions } from "./api";
+
+/** Lazy client store of recently-archived ("done") sessions, populated on demand
+ *  when the Done lens opens. It holds only the session list — recap content lives in
+ *  the shared `recaps` store and updates via the `session:recap` WS event there, so
+ *  this store deliberately subscribes to no WS events. */
+class DoneSessionsStore {
+  sessions = $state<Session[]>([]);
+  loaded = $state(false);
+
+  async load() {
+    try {
+      this.sessions = await getDoneSessions();
+      this.loaded = true;
+    } catch {
+      /* best-effort; leaves the list empty + loaded=false so a retry is possible */
+    }
+  }
+}
+export const doneSessions = new DoneSessionsStore();

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -786,4 +786,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_pwa_install_title",
     bodyKey: "feat_pwa_install_body",
   },
+  {
+    // The DONE filter button lives in the always-visible Herd header, so a coachmark
+    // anchor is reliably mounted — point at it via targetId + use:coachTarget.
+    id: "done-lens",
+    sinceVersion: "1.30.0",
+    titleKey: "feat_done_lens_title",
+    bodyKey: "feat_done_lens_body",
+    targetId: "done-lens",
+  },
 ];

--- a/ui/src/lib/recaps.svelte.test.ts
+++ b/ui/src/lib/recaps.svelte.test.ts
@@ -16,6 +16,7 @@ const recap = (id: string): Recap => ({
   headline: "All done",
   body: "Everything went smoothly.",
   openItems: [],
+  changedFiles: [],
   spawnSessionId: id,
   cwd: "/repo",
   model: null,

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -273,6 +273,12 @@ export class HerdStore {
         this.previewServe = dropKey(this.previewServe, ev.data.id);
         reviews.drop(ev.data.id);
         planGates.drop(ev.data.id);
+        // Drop the recap from the live cache on archive. DELIBERATELY re-populated later:
+        // the post-archive `session:recap` finalize event re-adds this id (and the Done
+        // lens calls recaps.load() to repopulate archived recaps from /api/recaps). This is
+        // SAFE because the live Herd renders from the `sessions` array (which dropped the
+        // session above), so a lingering recap entry can't resurrect a live row — and the
+        // Done lens WANTS the recap. Do NOT "fix" the re-add, or the Done lens goes blank.
         recaps.drop(ev.data.id);
         this.clearDraftReconcileToast(ev.data.id);
         break;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -236,6 +236,7 @@ export interface Recap {
   headline: string;
   body: string;
   openItems: string[];
+  changedFiles: string[];
   spawnSessionId: string;
   cwd: string;
   model: string | null;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -57,6 +57,7 @@
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { reviews, planGates } from "$lib/reviews.svelte";
   import { recaps } from "$lib/recaps.svelte";
+  import { doneSessions } from "$lib/done.svelte";
   import { learnings } from "$lib/learnings.svelte";
   import TopBar from "$lib/components/TopBar.svelte";
   import TriageDrawer from "$lib/components/TriageDrawer.svelte";
@@ -79,6 +80,7 @@
     sessionsForPrNumbers,
   } from "$lib/components/merge-train";
   import Viewport from "$lib/components/Viewport.svelte";
+  import DoneRecapPanel from "$lib/components/DoneRecapPanel.svelte";
   import NewTask from "$lib/components/NewTask.svelte";
   import Settings from "$lib/components/Settings.svelte";
   import CloneRepo from "$lib/components/CloneRepo.svelte";
@@ -667,11 +669,40 @@
   // what the rail shows — with "ready" active, j/k/1-9 only walk visible rows.
   let herdFilter = $state<HerdFilter>("all");
 
+  // Done lens: separate selection state. selectedId resolves against store.sessions
+  // (the live list), which has EVICTED archived sessions — so reusing it for a done
+  // (archived) id would break. doneSelectedId tracks the picked done row instead.
+  let doneSelectedId = $state<string | null>(null);
+  // The currently-selected done session (resolved against the lazy doneSessions list).
+  const doneSelected = $derived(doneSessions.sessions.find((s) => s.id === doneSelectedId) ?? null);
+  // Entering the Done lens lazy-loads the archived session list + repopulates the
+  // shared recaps store (archived recaps persist server-side; live events dropped the
+  // session's recap, /api/recaps returns it). Both are best-effort / self-handling.
+  // Re-selects the first done row whenever the current pick isn't in the (re)loaded list.
+  $effect(() => {
+    if (herdFilter !== "done") return;
+    void doneSessions.load();
+    void recaps.load();
+  });
+  $effect(() => {
+    if (herdFilter !== "done") return;
+    const list = doneSessions.sessions;
+    if (list.length === 0) {
+      doneSelectedId = null;
+    } else if (!list.some((s) => s.id === doneSelectedId)) {
+      doneSelectedId = list[0].id;
+    }
+  });
+
   // The herd rail's visible session order (same shown set + partition + group
   // order Herd.svelte renders) — the j/k/1-9 navigation space. Computed on demand
   // at keypress time, not $derived: re-partitioning on every nowMs tick would be
   // wasted work for a value only keystrokes read.
   function railIds(): string[] {
+    // The Done lens is its own navigation space (archived rows, not live `sessions`),
+    // so j/k/1-9 walk the done list and select via doneSelectedId — never the hidden
+    // live partition.
+    if (herdFilter === "done") return doneSessions.sessions.map((s) => s.id);
     return railOrder(
       herdSessions,
       store.git,
@@ -693,7 +724,13 @@
   // focusTerm = whether the remounted terminal should grab the keyboard.
   function keyNavSelect(id: string | null, focusTerm = true) {
     if (!id) return;
-    selectUnit(id, focusTerm);
+    // Done lens: pick the archived row (its own selection state, no terminal to focus).
+    if (herdFilter === "done") {
+      doneSelectedId = id;
+      if (mobile.current) mobileScreen = "detail";
+    } else {
+      selectUnit(id, focusTerm);
+    }
     document
       .querySelector(`[data-unit-id="${CSS.escape(id)}"]`)
       ?.scrollIntoView({ block: "nearest" });
@@ -708,17 +745,23 @@
   // focusTerm follows the keystroke's origin: plain keys pass false so focus
   // stays out of the terminal and the next plain key still chains; Alt combos
   // pass true only when fired from inside the terminal (focus follows origin).
+  // The keynav cursor: the Done lens cycles from doneSelectedId, every other mode from
+  // the live selectedId (the two selection spaces never mix).
+  function navCursor(): string | null {
+    return herdFilter === "done" ? doneSelectedId : selectedId;
+  }
+
   function handleHerdKeyNav(key: string, e: KeyboardEvent, focusTerm: boolean): boolean {
     switch (key) {
       case "j":
       case "arrowdown":
         e.preventDefault();
-        keyNavSelect(cycleId(railIds(), selectedId, 1), focusTerm);
+        keyNavSelect(cycleId(railIds(), navCursor(), 1), focusTerm);
         return true;
       case "k":
       case "arrowup":
         e.preventDefault();
-        keyNavSelect(cycleId(railIds(), selectedId, -1), focusTerm);
+        keyNavSelect(cycleId(railIds(), navCursor(), -1), focusTerm);
         return true;
       case "g": {
         e.preventDefault();
@@ -1406,8 +1449,14 @@
             workingBlocked={store.workingBlocked}
             completedEpics={completedEpicsShown}
             ondismissepic={onDismissEpic}
+            doneList={doneSessions.sessions}
+            {doneSelectedId}
+            ondoneselect={(id) => {
+              doneSelectedId = id;
+              mobileScreen = "detail";
+            }}
           />
-          {#if store.sessions.length === 0}
+          {#if store.sessions.length === 0 && herdFilter !== "done"}
             <BacklogView
               payload={backlog}
               mobile={true}
@@ -1426,6 +1475,18 @@
           onbacklog={store.sessions.length > 0 ? () => (showBacklog = true) : undefined}
           mobile={mobile.current}
         />
+      {:else if herdFilter === "done"}
+        <!-- Done lens detail (mobile): read-only recap; back returns to the done list -->
+        <div class="col">
+          <button type="button" class="done-back" onclick={() => (mobileScreen = "list")}
+            >{m.done_back_to_list()}</button
+          >
+          {#if doneSelected}
+            <DoneRecapPanel session={doneSelected} />
+          {:else}
+            <div class="empty">{m.herd_done_empty()}</div>
+          {/if}
+        </div>
       {:else if selected}
         <div class="col">
           <Viewport
@@ -1534,9 +1595,19 @@
             oncollapse={toggleSidebar}
             completedEpics={completedEpicsShown}
             ondismissepic={onDismissEpic}
+            doneList={doneSessions.sessions}
+            {doneSelectedId}
+            ondoneselect={(id) => (doneSelectedId = id)}
           />
         {/if}
-        {#if store.sessions.length === 0}
+        {#if herdFilter === "done"}
+          <!-- Done lens: read-only recap for the picked archived session -->
+          {#if doneSelected}
+            <DoneRecapPanel session={doneSelected} />
+          {:else}
+            <div class="empty">{m.herd_done_empty()}</div>
+          {/if}
+        {:else if store.sessions.length === 0}
           <BacklogView
             payload={backlog}
             mobile={false}
@@ -1960,6 +2031,21 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
+  }
+  /* Done-lens mobile back affordance: a quiet text trigger above the recap panel. */
+  .done-back {
+    align-self: flex-start;
+    border: 0;
+    background: none;
+    font-family: inherit;
+    cursor: pointer;
+    padding: 4px 2px;
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    transition: color 0.12s ease;
+  }
+  .done-back:hover {
+    color: var(--color-ink);
   }
   /* Primary landmark wrapping the herd/viewport content. Transparent to the
      flex layout: it fills the shell column and lets its own child (.col /

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -904,6 +904,7 @@
     projectIcons.load();
     reviews.load();
     planGates.load();
+    recaps.load();
     learnings.load();
     loadSettings();
     // Feature-discovery gate — synchronous, independent of loadSettings().


### PR DESCRIPTION
## Why

The session recap (PR #640) was **never actually seen**. Two root causes, both confirmed against the live DB (0 of 250 archived sessions retained a recap):

1. **Surfacing bug** — `recaps.load()` ran only in `resync()` (tab refocus), never in `onMount`, so a fresh page load left the recaps store empty until a blur+refocus. (Found by a live render check before building.)
2. **Durability** — the recap was dropped on archive (`forget()` + client `recaps.drop`), and finished sessions are evicted from the app entirely, so a merged session's recap was destroyed exactly when you'd review it.

## What

- **Surfacing fix:** load recaps on initial mount.
- **Durable generation:** `SessionService.archive()` is now `async`; a best-effort, timeout-bounded `beforeArchive` hook generates the recap **before** `worktree.remove` (the spawn is worktree-independent once launched — transcript lives in `~/.claude`). Fires for **all** finishing sessions incl. fast auto-merges and drain (`considerForArchive` is head-keyed, no `auto`-skip). In-flight recaps are no longer reaped on archive; `tick()` finalizes them post-archive.
- **Persistence:** recap rows survive archive (`onArchived` frees only the debounce entry); `changedFiles` captured at gen time (the worktree's gone afterward); `pruneArchivedSessions` reclaims recap rows so nothing leaks.
- **In-app Done lens:** a `DONE` filter in the Herd lists sessions archived in the last 48h (`GET /api/sessions/done`); selecting one opens a read-only `DoneRecapPanel` (verdict, headline, markdown body, open items, changed-files list, issue ref) — no live terminal, no regenerate, fail-closed states.
- Feature-catalog entry `done-lens` + EN/DE i18n.

## Async ripple

`archive()`/`archiveMany()` → `Promise<number>`; awaited at every call site (drain epic-child/retire try-catch, merge-teardown before `emitArchived`, server clear-merged/close/relaunch, internal relaunch cleanup) with the `=> Promise<number>` type changes in the merge-teardown/drain/automerge deps.

## Notes / scope

- Archived sessions carry no stored PR URL (it lived in the dropped git cache), so the panel shows the **issue number as text** and relies on the recap body for any PR link — no fabricated URLs.
- Done lens is bounded by existing retention (newest-250 / 30d); on a >250/48h burst it shows the most recent finished work.

## Verification

Root: `lint` + `tsc --noEmit` clean, `bun test ./test` → 2793 pass. UI: `check` 0 errors, `check:i18n` parity (1250 keys), `bun run test` → 1233 pass. Fallow: dead-code 0, complexity 0. Branch hygiene linear. Final adversarial integration review: no blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)