### PR TITLE
chore(merge): union-merge feature-announcements + duplicate-id guard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,6 +26,16 @@
 ui/messages/*.json        merge=i18n-union
 extension/messages/*.json merge=i18n-union
 
+# Feature-announcement catalog: same append-to-tail churn as the message catalogs
+# (every feature PR appends one entry before the closing `];`), so concurrent
+# branches collide on the tail hunk on every rebase. It's a TS module, not JSON,
+# so the key-aware i18n-union driver can't parse it — instead use git's built-in
+# `union` driver, which keeps BOTH sides of a conflicting hunk. Append-only inserts
+# then auto-resolve. The one risk `union` introduces — two branches adding the SAME
+# entry, silently duplicated rather than conflicted — is caught loudly by the
+# duplicate-id guard in ui/src/lib/feature-gate.test.ts (CI verify + pre-push).
+ui/src/lib/feature-announcements.ts merge=union
+
 # Vendored, minified inlang/Paraglide plugins (copied verbatim into ui/ and
 # extension/). Not our source — mark generated + vendored so linguist and code
 # analysis skip them and diffs collapse. Hand-editing them would diverge from the

--- a/ui/src/lib/feature-gate.test.ts
+++ b/ui/src/lib/feature-gate.test.ts
@@ -111,6 +111,24 @@ describe("computeNewEntries", () => {
   });
 });
 
+describe("catalog has no duplicate ids — union-merge safeguard", () => {
+  // feature-announcements.ts uses git's built-in `union` merge driver (.gitattributes)
+  // to auto-resolve the append-to-tail conflicts every feature PR creates. The one
+  // failure mode `union` can't catch: two branches appending the SAME entry get both
+  // copies kept silently instead of conflicting. A duplicate `id` is the signature of
+  // that — fail loudly here so CI turns red instead of shipping a doubled What's-New
+  // entry. (Each entry carries its own titleKey/bodyKey, so a duplicated entry trips
+  // the id check; ids are the catalog's stable identity.)
+  it("every entry id is unique", () => {
+    const ids = featureAnnouncements.map((e) => e.id);
+    const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
+    expect(
+      dupes,
+      `duplicate feature-announcement id(s): ${[...new Set(dupes)].join(", ")}`,
+    ).toEqual([]);
+  });
+});
+
 describe("catalog key parity — all titleKey/bodyKey exist in en.json", () => {
   const enKeys = new Set(Object.keys(enMessages));
 


### PR DESCRIPTION
## Why

`ui/src/lib/feature-announcements.ts` has the **same append-to-tail churn** as the i18n message catalogs — every feature PR appends one entry before the closing `];`, so concurrent branches collide on the tail hunk on every rebase. The key-aware `i18n-union` driver can't help here: it's a TS module, not JSON, so `JSON.parse` fails and the driver bails to a manual merge.

## What

1. **`.gitattributes`** — bind `feature-announcements.ts` to git's **built-in `union` driver**. It keeps *both* sides of a conflicting hunk, so append-only inserts auto-resolve. No script/registration needed (unlike `i18n-union`).

2. **Duplicate-id guard** (`ui/src/lib/feature-gate.test.ts`) — `union`'s one blind spot is two branches appending the **same** entry: it silently keeps both copies instead of conflicting. A duplicate `id` is the signature of that, so a unique-id test makes it **fail loudly** (CI `verify` + pre-push) instead of shipping a doubled What's-New drawer entry.

## Trade-off

`union` is line-based and never emits conflict markers. It's the right fit *because* this file is effectively append-only; the dedup guard + `bun run check` (tsc) cover the failure modes it can't (silent duplicate, broken syntax). A genuine same-entry edit by two branches still surfaces — as a red test, not a merge conflict.

## Verification

- `cd ui && bun run test src/lib/feature-gate.test.ts` → 183 passed
- Proved the guard fails red on a synthetic duplicate (throwaway test)
- `bun run check` → 0 errors; prettier clean; pre-push (fallow/i18n/feature-catalog) green

[no-feature-entry] — dev-facing merge tooling, ships no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)