### PR TITLE
feat(onboarding-harness): file a rolling GitHub issue on nightly regressions

### DIFF
--- a/ci/onboarding-harness/README.md
+++ b/ci/onboarding-harness/README.md
@@ -59,6 +59,16 @@ systemctl --user enable --now shepherd-onboarding.timer
 
 The timer fires nightly at 03:30 and writes the gap report to the working directory.
 
+## Accountability (GitHub issue)
+
+The `.service` sets `SHEPHERD_ONBOARDING_REPORT_ISSUE=1`, so the nightly **files its outcome to GitHub** as a single rolling issue (label `onboarding-regression`) whose lifecycle mirrors the regression:
+
+- **gap found, no open issue** → opens one (body = the gap report)
+- **gap persists** → refreshes the issue body to the latest report + adds a dated comment (an auditable timeline)
+- **run goes clean** → closes the issue ("regression resolved")
+
+So a finding can't rot in an overwritten file — it surfaces as an open, trackable issue until the harness is green again. Only **full** runs report (a single `--scenario` never opens/closes the issue, since it checks just one defect); the env-gate keeps manual/ad-hoc full runs side-effect-free. Requires `gh` authenticated on the host. Dedup relies on the daily cadence (GitHub's label list is eventually-consistent, so back-to-back runs within seconds could double-file — irrelevant 24h apart).
+
 ## Release gate
 
 Before tagging a release, run:

--- a/ci/onboarding-harness/incus.ts
+++ b/ci/onboarding-harness/incus.ts
@@ -1,41 +1,16 @@
-import { spawn } from "node:child_process";
+import { captureSpawn } from "./spawn";
 import type { IncusExec, IncusRunner } from "./types";
 
 /** Backstop kill timeout for any single `incus` call. The genuine hang fix is
- *  closing stdin (below); this cap only guards a process that wedges for some
- *  other reason. Generous on purpose — a cold image pull and an in-instance
- *  `bun install` legitimately take minutes. */
+ *  `captureSpawn` closing stdin (the incus Go client deadlocks on an open stdin
+ *  pipe for operation-streaming commands); this cap only guards a process that
+ *  wedges for some other reason. Generous on purpose — a cold image pull and an
+ *  in-instance `bun install` legitimately take minutes. */
 const RUNNER_TIMEOUT_MS = 20 * 60_000;
 
 /** Default runner: invokes the real `incus` binary, capturing output and never
- *  throwing on a non-zero exit (the caller inspects `code`).
- *
- *  stdin MUST be `"ignore"`, NOT an (execFile-style) pipe: the incus Go client
- *  DEADLOCKS forever on an open stdin pipe for its operation-streaming commands
- *  (`launch`, `exec`, `file push`) — every worker thread parks in `futex_wait`
- *  and the call never resolves. `execFile` forces a stdin pipe, which is why the
- *  harness hung on the very first launch. Closing stdin lets these commands
- *  return; the backstop timeout above is belt-and-suspenders only. */
-const defaultRunner: IncusRunner = (args) =>
-  new Promise((resolve) => {
-    const child = spawn("incus", args, { stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d));
-    child.stderr.on("data", (d) => (stderr += d));
-    const timer = setTimeout(() => {
-      stderr += `\nincus ${args[0] ?? ""} killed after ${RUNNER_TIMEOUT_MS}ms (timeout)`;
-      child.kill("SIGKILL");
-    }, RUNNER_TIMEOUT_MS);
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      resolve({ stdout, stderr: stderr + String(err), code: 1 });
-    });
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      resolve({ stdout, stderr, code: code ?? 1 });
-    });
-  });
+ *  throwing on a non-zero exit (the caller inspects `code`). */
+const defaultRunner: IncusRunner = (args) => captureSpawn("incus", args, RUNNER_TIMEOUT_MS);
 
 /** Thin, throw-away-instance lifecycle wrapper over the `incus` CLI. All managed
  *  instances carry `prefix` in their name so `sweep()` can reap leaks. */

--- a/ci/onboarding-harness/issue.ts
+++ b/ci/onboarding-harness/issue.ts
@@ -1,0 +1,107 @@
+import { gapScenarios } from "./report";
+import { captureSpawn, type Captured } from "./spawn";
+import type { ScenarioResult } from "./types";
+
+/** Injectable `gh` runner: receives argv (after the `gh` binary), resolves with
+ *  captured output and never throws (the caller inspects `code`). Tests inject a
+ *  fake; production spawns the real CLI. */
+export type GhRunner = (args: string[]) => Promise<Captured>;
+
+const defaultGh: GhRunner = (args) => captureSpawn("gh", args);
+
+// A single rolling accountability issue, found by this label so a persisting gap
+// never spawns a duplicate night after night.
+const LABEL = "onboarding-regression";
+const TITLE = "Onboarding harness: nightly regression detected";
+
+// Dedup relies on the nightly's daily cadence: GitHub's label-filtered issue list
+// is eventually-consistent (a just-created issue isn't returned for a few seconds),
+// so back-to-back runs within that window could double-file. Runs 24h apart never
+// hit it — by the next night the issue is long-indexed.
+async function findOpenIssue(gh: GhRunner): Promise<number | null> {
+  const r = await gh([
+    "issue",
+    "list",
+    "--label",
+    LABEL,
+    "--state",
+    "open",
+    "--json",
+    "number",
+    "--limit",
+    "1",
+  ]);
+  if (r.code !== 0) throw new Error(`gh issue list failed: ${r.stderr || r.stdout}`);
+  const rows = JSON.parse(r.stdout || "[]") as Array<{ number: number }>;
+  return rows[0]?.number ?? null;
+}
+
+/** Create the dedup label if absent (idempotent via --force). */
+async function ensureLabel(gh: GhRunner): Promise<void> {
+  await gh([
+    "label",
+    "create",
+    LABEL,
+    "--color",
+    "B60205",
+    "--description",
+    "Onboarding harness nightly regression",
+    "--force",
+  ]);
+}
+
+/**
+ * File the nightly outcome to GitHub for accountability, keeping ONE rolling
+ * issue whose lifecycle mirrors the regression:
+ *  - gaps + no open issue → open a labelled issue (body = the report)
+ *  - gaps + open issue    → refresh the body to the latest report + add a dated
+ *                           comment, so the issue is an auditable timeline
+ *  - clean + open issue   → close it (the regression is resolved)
+ *  - clean + no open issue → nothing
+ * Returns a short description of the action taken (for the run log). `stamp` is
+ * passed in so this module stays free of wall-clock for deterministic tests.
+ */
+export async function reportToGitHub(
+  results: ScenarioResult[],
+  reportMarkdown: string,
+  stamp: string,
+  gh: GhRunner = defaultGh,
+): Promise<string> {
+  const gaps = gapScenarios(results);
+  const existing = await findOpenIssue(gh);
+
+  if (gaps.length === 0) {
+    if (existing == null) return "clean run, no open issue — nothing to do";
+    const r = await gh([
+      "issue",
+      "close",
+      String(existing),
+      "--comment",
+      `All onboarding scenarios green as of ${stamp}. Closing.`,
+    ]);
+    if (r.code !== 0) throw new Error(`gh issue close failed: ${r.stderr || r.stdout}`);
+    return `closed #${existing} (regression resolved)`;
+  }
+
+  const body = `${reportMarkdown}\n_Nightly run: ${stamp}_\n`;
+  if (existing == null) {
+    await ensureLabel(gh);
+    const r = await gh(["issue", "create", "--title", TITLE, "--label", LABEL, "--body", body]);
+    if (r.code !== 0) throw new Error(`gh issue create failed: ${r.stderr || r.stdout}`);
+    return `opened issue: ${r.stdout.trim()}`;
+  }
+
+  const scenarios = gaps.map((g) => g.scenarioId).join(", ");
+  const edit = await gh(["issue", "edit", String(existing), "--body", body]);
+  if (edit.code !== 0) throw new Error(`gh issue edit failed: ${edit.stderr || edit.stdout}`);
+  const comment = await gh([
+    "issue",
+    "comment",
+    String(existing),
+    "--body",
+    `Nightly run ${stamp}: ${gaps.length} gap(s) still present — ${scenarios}.`,
+  ]);
+  if (comment.code !== 0)
+    throw new Error(`gh issue comment failed: ${comment.stderr || comment.stdout}`);
+  return `updated #${existing} (${gaps.length} gap(s))`;
+}

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -12,6 +12,16 @@ function classify(r: ScenarioResult): "PASS" | "DETECTION GAP" | "ADVICE GAP" | 
   return r.detection.detected ? "ADVICE GAP" : "DETECTION GAP";
 }
 
+/** Scenarios that represent a real regression worth flagging — a missed/
+ *  misclassified defect (DETECTION GAP) or coaching that didn't heal it (ADVICE
+ *  GAP). PASS and by-design DETECTION-ONLY are NOT gaps. */
+export function gapScenarios(results: ScenarioResult[]): ScenarioResult[] {
+  return results.filter((r) => {
+    const k = classify(r);
+    return k === "DETECTION GAP" || k === "ADVICE GAP";
+  });
+}
+
 function tableRow(r: ScenarioResult, klass: ReturnType<typeof classify>): string {
   return `| ${r.scenarioId} | ${r.image} | ${r.detection.detected ? "yes" : "no"} | ${r.appliedVia} | ${r.reachedGreen ? "yes" : "no"} | ${klass} |`;
 }

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -9,6 +9,7 @@ import { bootShepherd, probeDiagnostics } from "./probe";
 import { applyAgent, applyVerbatim } from "./apply";
 import { assertDetection } from "./assert";
 import { buildGapReport } from "./report";
+import { reportToGitHub } from "./issue";
 import { remediationsFor } from "./remediations";
 import type { DetectionResult, Scenario, ScenarioResult } from "./types";
 
@@ -166,6 +167,21 @@ async function main() {
   const out = join(process.cwd(), "onboarding-gap-report.md");
   writeFileSync(out, report);
   console.log(`\n${report}\nReport written to ${out}`);
+
+  // Accountability: on a FULL run (never a single `--scenario`, which only checks
+  // one defect and must not open/close the rolling issue), file the outcome to
+  // GitHub. Opt-in via env so manual full runs stay side-effect-free; the nightly
+  // service sets it. A gh failure is logged loudly but never masks the run result.
+  if (!only && process.env.SHEPHERD_ONBOARDING_REPORT_ISSUE === "1") {
+    try {
+      const action = await reportToGitHub(results, report, new Date().toISOString());
+      console.log(`[github] ${action}`);
+    } catch (err) {
+      console.error(
+        `[github] failed to file accountability issue: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
 
   // Non-zero exit if any APPLY-ABLE scenario failed to reach green (detection-only
   // scenarios are excluded). Consumed by the Phase 2 gate.

--- a/ci/onboarding-harness/shepherd-onboarding.service
+++ b/ci/onboarding-harness/shepherd-onboarding.service
@@ -6,6 +6,9 @@ After=network-online.target
 Type=oneshot
 WorkingDirectory=%h/Work/shepherd
 ExecStart=/usr/bin/env bun run onboarding:test
+# File the outcome to GitHub as a rolling accountability issue (opt-in, so only
+# the nightly does it — manual full runs stay side-effect-free).
+Environment=SHEPHERD_ONBOARDING_REPORT_ISSUE=1
 # A oneshot start has no timeout by default — bound the whole nightly run so a
 # wedged scenario is killed instead of pinning the host lock indefinitely.
 TimeoutStartSec=2h

--- a/ci/onboarding-harness/spawn.ts
+++ b/ci/onboarding-harness/spawn.ts
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+
+export interface Captured {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/** Spawn `bin args`, capture stdout/stderr, and resolve (never throw) so the
+ *  caller inspects `code`. stdin is `"ignore"`, NOT a pipe: the incus Go client
+ *  DEADLOCKS forever on an open stdin pipe for operation-streaming commands
+ *  (`launch`/`exec`/`file push`) — closing it lets them return. `timeoutMs`, when
+ *  given, SIGKILLs a wedged process as a backstop. Shared by the incus + gh
+ *  runners. */
+export function captureSpawn(bin: string, args: string[], timeoutMs?: number): Promise<Captured> {
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    const timer = timeoutMs
+      ? setTimeout(() => {
+          stderr += `\n${bin} ${args[0] ?? ""} killed after ${timeoutMs}ms (timeout)`;
+          child.kill("SIGKILL");
+        }, timeoutMs)
+      : null;
+    child.on("error", (err) => {
+      if (timer) clearTimeout(timer);
+      resolve({ stdout, stderr: stderr + String(err), code: 1 });
+    });
+    child.on("close", (code) => {
+      if (timer) clearTimeout(timer);
+      resolve({ stdout, stderr, code: code ?? 1 });
+    });
+  });
+}

--- a/test/onboarding-harness/issue.test.ts
+++ b/test/onboarding-harness/issue.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { reportToGitHub } from "../../ci/onboarding-harness/issue";
+import type { GhRunner } from "../../ci/onboarding-harness/issue";
+import type { ScenarioResult } from "../../ci/onboarding-harness/types";
+
+function result(over: Partial<ScenarioResult>): ScenarioResult {
+  return {
+    scenarioId: "herdr-missing",
+    image: "images:archlinux",
+    detection: { scenarioId: "herdr-missing", detected: true, misses: [] },
+    appliedVia: "verbatim",
+    reachedGreen: true,
+    ...over,
+  };
+}
+
+const GAP = result({ reachedGreen: false }); // detected but not green → ADVICE GAP
+const PASS = result({ reachedGreen: true });
+const DETECTION_ONLY = result({ detectionOnly: true }); // by design — NOT a gap
+
+/** Fake `gh` that records argv and replies to `issue list` with `openIssue`. */
+function fakeGh(openIssue: number | null) {
+  const calls: string[][] = [];
+  const gh: GhRunner = async (args) => {
+    calls.push(args);
+    if (args[0] === "issue" && args[1] === "list") {
+      const rows = openIssue == null ? [] : [{ number: openIssue }];
+      return { stdout: JSON.stringify(rows), stderr: "", code: 0 };
+    }
+    if (args[0] === "issue" && args[1] === "create") {
+      return { stdout: "https://github.com/x/y/issues/99", stderr: "", code: 0 };
+    }
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  return { calls, gh };
+}
+
+describe("reportToGitHub", () => {
+  it("opens a labelled issue when there are gaps and none is open", async () => {
+    const { calls, gh } = fakeGh(null);
+    const action = await reportToGitHub([GAP, PASS, DETECTION_ONLY], "REPORT", "2026-06-15", gh);
+    const create = calls.find((c) => c[0] === "issue" && c[1] === "create");
+    expect(create).toBeDefined();
+    expect(create).toContain("--label");
+    expect(create!.join(" ")).toContain("REPORT");
+    expect(calls.some((c) => c[0] === "label" && c[1] === "create")).toBe(true); // ensures label exists
+    expect(action).toContain("opened");
+  });
+
+  it("comments + refreshes the existing issue when gaps persist (no duplicate issue)", async () => {
+    const { calls, gh } = fakeGh(42);
+    const action = await reportToGitHub([GAP], "REPORT", "2026-06-15", gh);
+    expect(calls.some((c) => c[0] === "issue" && c[1] === "create")).toBe(false);
+    expect(calls.some((c) => c[0] === "issue" && c[1] === "edit" && c[2] === "42")).toBe(true);
+    expect(calls.some((c) => c[0] === "issue" && c[1] === "comment" && c[2] === "42")).toBe(true);
+    expect(action).toContain("42");
+  });
+
+  it("closes the open issue when the run is clean (regression resolved)", async () => {
+    const { calls, gh } = fakeGh(42);
+    const action = await reportToGitHub([PASS, DETECTION_ONLY], "REPORT", "2026-06-15", gh);
+    expect(calls.some((c) => c[0] === "issue" && c[1] === "close" && c[2] === "42")).toBe(true);
+    expect(calls.some((c) => c[0] === "issue" && c[1] === "create")).toBe(false);
+    expect(action).toContain("closed");
+  });
+
+  it("does nothing when the run is clean and no issue is open", async () => {
+    const { calls, gh } = fakeGh(null);
+    const action = await reportToGitHub([PASS], "REPORT", "2026-06-15", gh);
+    expect(calls.every((c) => !["create", "edit", "comment", "close"].includes(c[1]!))).toBe(true);
+    expect(action).toMatch(/nothing/i);
+  });
+});


### PR DESCRIPTION
## Why

The nightly harness wrote its gap report to `onboarding-gap-report.md` and **overwrote it every run** — a finding had no accountability path; it sat in a file nobody read until it vanished the next night. This closes that loop: a regression now surfaces as a tracked GitHub issue until the harness is green again.

## What

On a **full** nightly run, the harness files its outcome to GitHub as **one rolling issue** (label `onboarding-regression`) whose lifecycle mirrors the regression:

| State | Action |
|---|---|
| gap found, no open issue | **open** one (body = the gap report) |
| gap persists | **refresh** the body to the latest report + add a **dated comment** (auditable timeline) |
| run goes clean | **close** it ("regression resolved") |

So a gap can't rot in an overwritten file — it's an open, assignable issue that auto-updates nightly and auto-closes when fixed.

## Design

- New `ci/onboarding-harness/issue.ts` with an injectable `GhRunner` (mirrors the existing `IncusRunner` pattern), so the four-branch logic is unit-testable with a fake `gh`.
- Wired into `run.ts` **only on full runs** — a single `--scenario` checks one defect and must never open/close the rolling issue. Opt-in via `SHEPHERD_ONBOARDING_REPORT_ISSUE=1` (set in the nightly `.service`) so manual/ad-hoc full runs stay side-effect-free.
- A `gh` failure is **logged loudly** but never masks the harness's own exit code.
- Extracted the shared spawn-and-capture helper (`spawn.ts`) so the incus + gh runners don't duplicate it.
- Dedup relies on the daily cadence: GitHub's label-filtered issue list is eventually-consistent (a just-created issue isn't returned for a few seconds), which is irrelevant for runs 24h apart.

## Validation

- 4 new unit tests covering all branches (create / update+comment / close / no-op).
- **Validated live end-to-end** against the real `gh` on the host: created an issue on a synthetic gap, confirmed a second gap run **updates** (not duplicates) + comments, then **closes** on a clean run with both comments present — test issues deleted afterward.
- `tsc` + `lint` + harness tests (30) green; `fallow audit` clean.

Follow-up to #663 (which made the harness actually run end-to-end). Requires `gh` authenticated on the Incus host.

[no-feature-entry] — CI tooling, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)