### PR TITLE
feat(onboarding-harness): commit status + release gate (CI traceability)

### DIFF
--- a/.github/workflows/onboarding-release-gate.yml
+++ b/.github/workflows/onboarding-release-gate.yml
@@ -1,0 +1,40 @@
+name: Onboarding release gate
+
+# Block a release while the onboarding harness is red.
+#
+# The harness needs Incus (a self-hosted host), so it CANNOT run in CI — it runs
+# nightly on the Incus host and keeps one rolling `onboarding-regression` issue
+# open whenever a scenario regresses (closing it when green again). This gate
+# consults that issue when release-please's release PR is opened/updated, so a
+# release can't ship over a known onboarding regression. It only READS an issue —
+# no Incus, no host access — so it is safe and runs on a hosted runner (kept off
+# the CI_RUNNER toggle so it stays reliable when the self-hosted runner is down,
+# matching release-please.yml).
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  issues: read
+  contents: read
+
+jobs:
+  onboarding-release-gate:
+    # Only the release-please release PR is gated; every other PR is unaffected.
+    if: ${{ startsWith(github.head_ref, 'release-please--') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block the release if the onboarding harness is red
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          open=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --label onboarding-regression --state open --json url --jq 'length')
+          echo "open onboarding-regression issues: $open"
+          if [ "$open" -gt 0 ]; then
+            url=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+              --label onboarding-regression --state open --json url --jq '.[0].url')
+            echo "::error::Onboarding harness is RED — resolve the regression before releasing: $url"
+            exit 1
+          fi
+          echo "Onboarding harness is green (no open regression issue) — release may proceed."

--- a/ci/onboarding-harness/README.md
+++ b/ci/onboarding-harness/README.md
@@ -69,9 +69,17 @@ The `.service` sets `SHEPHERD_ONBOARDING_REPORT_ISSUE=1`, so the nightly **files
 
 So a finding can't rot in an overwritten file — it surfaces as an open, trackable issue until the harness is green again. Only **full** runs report (a single `--scenario` never opens/closes the issue, since it checks just one defect); the env-gate keeps manual/ad-hoc full runs side-effect-free. Requires `gh` authenticated on the host. Dedup relies on the daily cadence (GitHub's label list is eventually-consistent, so back-to-back runs within seconds could double-file — irrelevant 24h apart).
 
+The same full run also publishes a **commit status** (`onboarding-harness` context, success/failure) on the tested SHA, so every nightly leaves a visible green/red record on the commit — even a clean run that files no issue — linked to the regression issue when red.
+
 ## Release gate
 
-Before tagging a release, run:
+Because the harness needs Incus (a self-hosted host), it **cannot run in GitHub-hosted CI**, and exposing the host's Incus socket to the sandboxed self-hosted runners (which execute untrusted PR code) would defeat their isolation. So enforcement is split: the **host executes** the harness nightly and publishes the verdict to GitHub (the rolling issue + commit status above); **CI consults** it.
+
+`.github/workflows/onboarding-release-gate.yml` runs on release-please's release PR and **fails if an `onboarding-regression` issue is open** — i.e. it blocks shipping a release over a known-red onboarding harness. It only reads an issue (no Incus), runs on a hosted runner, and is robust to `main` moving (it consults the rolling issue, not a per-SHA status). To make it actually block the merge, add `onboarding-release-gate` to the branch's **required status checks** (a repo setting). It reflects the last nightly, so a host that's been down for days can leave the signal stale.
+
+### Manual subset gate
+
+Before tagging a release you can also run the deterministic subset directly:
 
 ```bash
 scripts/onboarding-gate.sh

--- a/ci/onboarding-harness/issue.ts
+++ b/ci/onboarding-harness/issue.ts
@@ -18,7 +18,7 @@ const TITLE = "Onboarding harness: nightly regression detected";
 // is eventually-consistent (a just-created issue isn't returned for a few seconds),
 // so back-to-back runs within that window could double-file. Runs 24h apart never
 // hit it — by the next night the issue is long-indexed.
-async function findOpenIssue(gh: GhRunner): Promise<number | null> {
+async function findOpenIssue(gh: GhRunner): Promise<{ number: number; url: string } | null> {
   const r = await gh([
     "issue",
     "list",
@@ -27,13 +27,13 @@ async function findOpenIssue(gh: GhRunner): Promise<number | null> {
     "--state",
     "open",
     "--json",
-    "number",
+    "number,url",
     "--limit",
     "1",
   ]);
   if (r.code !== 0) throw new Error(`gh issue list failed: ${r.stderr || r.stdout}`);
-  const rows = JSON.parse(r.stdout || "[]") as Array<{ number: number }>;
-  return rows[0]?.number ?? null;
+  const rows = JSON.parse(r.stdout || "[]") as Array<{ number: number; url: string }>;
+  return rows[0] ?? null;
 }
 
 /** Create the dedup label if absent (idempotent via --force). */
@@ -50,6 +50,13 @@ async function ensureLabel(gh: GhRunner): Promise<void> {
   ]);
 }
 
+export interface IssueOutcome {
+  /** Short description of the action taken, for the run log. */
+  summary: string;
+  /** URL of the open regression issue, if one is now open (for the status link). */
+  issueUrl: string | null;
+}
+
 /**
  * File the nightly outcome to GitHub for accountability, keeping ONE rolling
  * issue whose lifecycle mirrors the regression:
@@ -58,29 +65,30 @@ async function ensureLabel(gh: GhRunner): Promise<void> {
  *                           comment, so the issue is an auditable timeline
  *  - clean + open issue   → close it (the regression is resolved)
  *  - clean + no open issue → nothing
- * Returns a short description of the action taken (for the run log). `stamp` is
- * passed in so this module stays free of wall-clock for deterministic tests.
+ * `stamp` is passed in so this module stays free of wall-clock for deterministic
+ * tests.
  */
 export async function reportToGitHub(
   results: ScenarioResult[],
   reportMarkdown: string,
   stamp: string,
   gh: GhRunner = defaultGh,
-): Promise<string> {
+): Promise<IssueOutcome> {
   const gaps = gapScenarios(results);
   const existing = await findOpenIssue(gh);
 
   if (gaps.length === 0) {
-    if (existing == null) return "clean run, no open issue — nothing to do";
+    if (existing == null)
+      return { summary: "clean run, no open issue — nothing to do", issueUrl: null };
     const r = await gh([
       "issue",
       "close",
-      String(existing),
+      String(existing.number),
       "--comment",
       `All onboarding scenarios green as of ${stamp}. Closing.`,
     ]);
     if (r.code !== 0) throw new Error(`gh issue close failed: ${r.stderr || r.stdout}`);
-    return `closed #${existing} (regression resolved)`;
+    return { summary: `closed #${existing.number} (regression resolved)`, issueUrl: null };
   }
 
   const body = `${reportMarkdown}\n_Nightly run: ${stamp}_\n`;
@@ -88,20 +96,51 @@ export async function reportToGitHub(
     await ensureLabel(gh);
     const r = await gh(["issue", "create", "--title", TITLE, "--label", LABEL, "--body", body]);
     if (r.code !== 0) throw new Error(`gh issue create failed: ${r.stderr || r.stdout}`);
-    return `opened issue: ${r.stdout.trim()}`;
+    const url = r.stdout.trim();
+    return { summary: `opened issue: ${url}`, issueUrl: url };
   }
 
   const scenarios = gaps.map((g) => g.scenarioId).join(", ");
-  const edit = await gh(["issue", "edit", String(existing), "--body", body]);
+  const edit = await gh(["issue", "edit", String(existing.number), "--body", body]);
   if (edit.code !== 0) throw new Error(`gh issue edit failed: ${edit.stderr || edit.stdout}`);
   const comment = await gh([
     "issue",
     "comment",
-    String(existing),
+    String(existing.number),
     "--body",
     `Nightly run ${stamp}: ${gaps.length} gap(s) still present — ${scenarios}.`,
   ]);
   if (comment.code !== 0)
     throw new Error(`gh issue comment failed: ${comment.stderr || comment.stdout}`);
-  return `updated #${existing} (${gaps.length} gap(s))`;
+  return { summary: `updated #${existing.number} (${gaps.length} gap(s))`, issueUrl: existing.url };
+}
+
+/**
+ * Publish a GitHub commit status (`onboarding-harness` context) on the tested
+ * `sha`, so every nightly run leaves a visible, linkable green/red record on the
+ * commit — even a clean run that files no issue. `targetUrl` (the regression
+ * issue) is attached when present so the red check links straight to the gaps.
+ */
+export async function publishStatus(
+  sha: string,
+  ok: boolean,
+  description: string,
+  targetUrl: string | null,
+  gh: GhRunner = defaultGh,
+): Promise<void> {
+  const args = [
+    "api",
+    "--method",
+    "POST",
+    `repos/{owner}/{repo}/statuses/${sha}`,
+    "-f",
+    `state=${ok ? "success" : "failure"}`,
+    "-f",
+    "context=onboarding-harness",
+    "-f",
+    `description=${description.slice(0, 140)}`,
+  ];
+  if (targetUrl) args.push("-f", `target_url=${targetUrl}`);
+  const r = await gh(args);
+  if (r.code !== 0) throw new Error(`gh status publish failed: ${r.stderr || r.stdout}`);
 }

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -22,6 +22,16 @@ export function gapScenarios(results: ScenarioResult[]): ScenarioResult[] {
   });
 }
 
+/** One-line outcome for a commit-status description (≤140 chars on the wire). */
+export function statusDescription(results: ScenarioResult[]): string {
+  const applicable = results.filter((r) => !r.detectionOnly);
+  const green = applicable.filter((r) => r.reachedGreen).length;
+  const gaps = gapScenarios(results);
+  return gaps.length === 0
+    ? `${green}/${applicable.length} scenarios green`
+    : `${gaps.length} gap(s): ${gaps.map((g) => g.scenarioId).join(", ")}`;
+}
+
 function tableRow(r: ScenarioResult, klass: ReturnType<typeof classify>): string {
   return `| ${r.scenarioId} | ${r.image} | ${r.detection.detected ? "yes" : "no"} | ${r.appliedVia} | ${r.reachedGreen ? "yes" : "no"} | ${klass} |`;
 }

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -8,8 +8,8 @@ import { seedInstance } from "./seed";
 import { bootShepherd, probeDiagnostics } from "./probe";
 import { applyAgent, applyVerbatim } from "./apply";
 import { assertDetection } from "./assert";
-import { buildGapReport } from "./report";
-import { reportToGitHub } from "./issue";
+import { buildGapReport, statusDescription } from "./report";
+import { reportToGitHub, publishStatus } from "./issue";
 import { remediationsFor } from "./remediations";
 import type { DetectionResult, Scenario, ScenarioResult } from "./types";
 
@@ -122,6 +122,31 @@ function acquireHostLock(): () => void {
   return release;
 }
 
+/** Accountability + traceability: on a FULL run (never a single `--scenario`,
+ *  which checks one defect and must not open/close the rolling issue or stamp a
+ *  verdict), report the outcome to GitHub — a rolling regression issue AND a
+ *  commit status on the tested SHA, so every run leaves a visible green/red record
+ *  and even a clean run is observable. Opt-in via env so manual full runs stay
+ *  side-effect-free; the nightly service sets it. Best-effort: a gh failure is
+ *  logged loudly but never masks the run result. */
+async function maybeReportRun(
+  results: ScenarioResult[],
+  report: string,
+  only: string | null | undefined,
+  ok: boolean,
+): Promise<void> {
+  if (only || process.env.SHEPHERD_ONBOARDING_REPORT_ISSUE !== "1") return;
+  try {
+    const outcome = await reportToGitHub(results, report, new Date().toISOString());
+    console.log(`[github] issue: ${outcome.summary}`);
+    const sha = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    await publishStatus(sha, ok, statusDescription(results), outcome.issueUrl);
+    console.log(`[github] status: ${ok ? "success" : "failure"} on ${sha.slice(0, 7)}`);
+  } catch (err) {
+    console.error(`[github] reporting failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 async function main() {
   // Maintenance: reap ALL harness instances across runs AND clear a stale lock
   // left by a hard-killed (SIGKILL) run (manual recovery only).
@@ -168,25 +193,12 @@ async function main() {
   writeFileSync(out, report);
   console.log(`\n${report}\nReport written to ${out}`);
 
-  // Accountability: on a FULL run (never a single `--scenario`, which only checks
-  // one defect and must not open/close the rolling issue), file the outcome to
-  // GitHub. Opt-in via env so manual full runs stay side-effect-free; the nightly
-  // service sets it. A gh failure is logged loudly but never masks the run result.
-  if (!only && process.env.SHEPHERD_ONBOARDING_REPORT_ISSUE === "1") {
-    try {
-      const action = await reportToGitHub(results, report, new Date().toISOString());
-      console.log(`[github] ${action}`);
-    } catch (err) {
-      console.error(
-        `[github] failed to file accountability issue: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-  }
-
   // Non-zero exit if any APPLY-ABLE scenario failed to reach green (detection-only
   // scenarios are excluded). Consumed by the Phase 2 gate.
   const applicable = results.filter((r) => !r.detectionOnly);
-  process.exit(applicable.every((r) => r.reachedGreen) ? 0 : 1);
+  const ok = applicable.every((r) => r.reachedGreen);
+  await maybeReportRun(results, report, only, ok);
+  process.exit(ok ? 0 : 1);
 }
 
 void main();

--- a/test/onboarding-harness/issue.test.ts
+++ b/test/onboarding-harness/issue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { reportToGitHub } from "../../ci/onboarding-harness/issue";
+import { reportToGitHub, publishStatus } from "../../ci/onboarding-harness/issue";
 import type { GhRunner } from "../../ci/onboarding-harness/issue";
 import type { ScenarioResult } from "../../ci/onboarding-harness/types";
 
@@ -19,13 +19,12 @@ const PASS = result({ reachedGreen: true });
 const DETECTION_ONLY = result({ detectionOnly: true }); // by design — NOT a gap
 
 /** Fake `gh` that records argv and replies to `issue list` with `openIssue`. */
-function fakeGh(openIssue: number | null) {
+function fakeGh(openIssue: { number: number; url: string } | null) {
   const calls: string[][] = [];
   const gh: GhRunner = async (args) => {
     calls.push(args);
     if (args[0] === "issue" && args[1] === "list") {
-      const rows = openIssue == null ? [] : [{ number: openIssue }];
-      return { stdout: JSON.stringify(rows), stderr: "", code: 0 };
+      return { stdout: JSON.stringify(openIssue ? [openIssue] : []), stderr: "", code: 0 };
     }
     if (args[0] === "issue" && args[1] === "create") {
       return { stdout: "https://github.com/x/y/issues/99", stderr: "", code: 0 };
@@ -38,36 +37,76 @@ function fakeGh(openIssue: number | null) {
 describe("reportToGitHub", () => {
   it("opens a labelled issue when there are gaps and none is open", async () => {
     const { calls, gh } = fakeGh(null);
-    const action = await reportToGitHub([GAP, PASS, DETECTION_ONLY], "REPORT", "2026-06-15", gh);
+    const out = await reportToGitHub([GAP, PASS, DETECTION_ONLY], "REPORT", "2026-06-15", gh);
     const create = calls.find((c) => c[0] === "issue" && c[1] === "create");
     expect(create).toBeDefined();
     expect(create).toContain("--label");
     expect(create!.join(" ")).toContain("REPORT");
-    expect(calls.some((c) => c[0] === "label" && c[1] === "create")).toBe(true); // ensures label exists
-    expect(action).toContain("opened");
+    expect(calls.some((c) => c[0] === "label" && c[1] === "create")).toBe(true);
+    expect(out.summary).toContain("opened");
+    expect(out.issueUrl).toBe("https://github.com/x/y/issues/99");
   });
 
-  it("comments + refreshes the existing issue when gaps persist (no duplicate issue)", async () => {
-    const { calls, gh } = fakeGh(42);
-    const action = await reportToGitHub([GAP], "REPORT", "2026-06-15", gh);
+  it("comments + refreshes the existing issue when gaps persist (no duplicate)", async () => {
+    const { calls, gh } = fakeGh({ number: 42, url: "https://github.com/x/y/issues/42" });
+    const out = await reportToGitHub([GAP], "REPORT", "2026-06-15", gh);
     expect(calls.some((c) => c[0] === "issue" && c[1] === "create")).toBe(false);
     expect(calls.some((c) => c[0] === "issue" && c[1] === "edit" && c[2] === "42")).toBe(true);
     expect(calls.some((c) => c[0] === "issue" && c[1] === "comment" && c[2] === "42")).toBe(true);
-    expect(action).toContain("42");
+    expect(out.summary).toContain("42");
+    expect(out.issueUrl).toBe("https://github.com/x/y/issues/42");
   });
 
   it("closes the open issue when the run is clean (regression resolved)", async () => {
-    const { calls, gh } = fakeGh(42);
-    const action = await reportToGitHub([PASS, DETECTION_ONLY], "REPORT", "2026-06-15", gh);
+    const { calls, gh } = fakeGh({ number: 42, url: "https://github.com/x/y/issues/42" });
+    const out = await reportToGitHub([PASS, DETECTION_ONLY], "REPORT", "2026-06-15", gh);
     expect(calls.some((c) => c[0] === "issue" && c[1] === "close" && c[2] === "42")).toBe(true);
     expect(calls.some((c) => c[0] === "issue" && c[1] === "create")).toBe(false);
-    expect(action).toContain("closed");
+    expect(out.summary).toContain("closed");
+    expect(out.issueUrl).toBeNull();
   });
 
   it("does nothing when the run is clean and no issue is open", async () => {
     const { calls, gh } = fakeGh(null);
-    const action = await reportToGitHub([PASS], "REPORT", "2026-06-15", gh);
+    const out = await reportToGitHub([PASS], "REPORT", "2026-06-15", gh);
     expect(calls.every((c) => !["create", "edit", "comment", "close"].includes(c[1]!))).toBe(true);
-    expect(action).toMatch(/nothing/i);
+    expect(out.summary).toMatch(/nothing/i);
+  });
+});
+
+describe("publishStatus", () => {
+  function fakeGh() {
+    const calls: string[][] = [];
+    const gh: GhRunner = async (args) => {
+      calls.push(args);
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    return { calls, gh };
+  }
+
+  it("POSTs a success status with the onboarding-harness context on the SHA", async () => {
+    const { calls, gh } = fakeGh();
+    await publishStatus("abc123", true, "3/3 scenarios green", null, gh);
+    const c = calls[0]!;
+    expect(c).toEqual([
+      "api",
+      "--method",
+      "POST",
+      "repos/{owner}/{repo}/statuses/abc123",
+      "-f",
+      "state=success",
+      "-f",
+      "context=onboarding-harness",
+      "-f",
+      "description=3/3 scenarios green",
+    ]);
+  });
+
+  it("POSTs failure + a target_url linking the regression issue", async () => {
+    const { calls, gh } = fakeGh();
+    await publishStatus("def456", false, "1 gap(s): herdr-missing", "https://x/issues/7", gh);
+    const c = calls[0]!.join(" ");
+    expect(c).toContain("state=failure");
+    expect(c).toContain("target_url=https://x/issues/7");
   });
 });


### PR DESCRIPTION
## Why

Two gaps remained after the harness started running nightly (#663) and filing issues (#670):

1. **No traceability** — the nightly was a systemd timer invisible to GitHub; a clean run left no trace at all.
2. **The "release gate" was still a manual script** enforced by nothing.

The constraint: the harness needs Incus (a self-hosted host), so it **can't run in GitHub-hosted CI**, and mounting the host's Incus socket into the sandboxed self-hosted runners — which execute **untrusted PR code** — would hand that code host-root. So this **splits execution from enforcement**: the host executes nightly and *publishes* the verdict; CI *consults* it.

## What

**Commit status (traceability)** — a full run now also publishes an `onboarding-harness` commit status (success/failure) on the tested SHA. Every nightly leaves a visible green/red record on the commit — even a clean run that files no issue — linked to the regression issue when red. `reportToGitHub` surfaces the issue URL for the link; `maybeReportRun` extracted to keep `main` under the complexity gate.

**Release gate (enforcement)** — `.github/workflows/onboarding-release-gate.yml` runs on release-please's release PR and **fails if an `onboarding-regression` issue is open**, blocking a release that would ship over a known-red harness. It:
- reads an issue only — **no Incus, no host access** — so it's safe on a hosted runner;
- runs on `ubuntu-latest` (off the `CI_RUNNER` toggle) so it stays reliable when the self-hosted runner is down, matching `release-please.yml`;
- consults the **rolling issue**, not a per-SHA status, so it's robust to `main` moving between the nightly and the release.

## Enforcement note

The workflow makes the gate **visible and failing** on the release PR. To make it actually **block the merge**, add `onboarding-release-gate` to the branch's required status checks (a repo setting — same as any gate). It reflects the last nightly, so a host down for days can leave the signal stale.

## Validation

- Status publish **verified live** against the real `gh` (POST status + read-back of state/context/description/target_url).
- Issue paths + `publishStatus` argv unit-tested (32 harness tests).
- `tsc` + `lint` + `fallow` green. Workflow uses no `${{ }}` interpolation of untrusted input into shell (`head_ref` only in an `if:` expression).

Follow-up to #663 (harness runs e2e) and #670 (accountability issue).

[no-feature-entry] — CI tooling, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)