### PR TITLE
fix(onboarding-harness): fresh-green, deterministic-scoped release gate

### DIFF
--- a/.github/workflows/onboarding-release-gate.yml
+++ b/.github/workflows/onboarding-release-gate.yml
@@ -24,17 +24,65 @@ jobs:
     if: ${{ startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Block the release if the onboarding harness is red
+      - name: Require the onboarding harness to be fresh-green
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # Max age of the latest nightly verdict before it's "stale" (nightly is
+          # daily, so this allows one missed run of slack).
+          MAX_AGE_SECONDS: "172800" # 48h
         run: |
-          open=$(gh issue list --repo "$GITHUB_REPOSITORY" \
-            --label onboarding-regression --state open --json url --jq 'length')
-          echo "open onboarding-regression issues: $open"
-          if [ "$open" -gt 0 ]; then
-            url=$(gh issue list --repo "$GITHUB_REPOSITORY" \
-              --label onboarding-regression --state open --json url --jq '.[0].url')
-            echo "::error::Onboarding harness is RED — resolve the regression before releasing: $url"
+          set -euo pipefail
+
+          # Two signals from the nightly host run cover two distinct failure modes;
+          # either one blocks the release (fail closed):
+          #
+          #   1. an open `onboarding-regression` issue  → an ACTIVE regression
+          #      (also catches a red run whose status-publish failed but whose
+          #       issue still opened).
+          #   2. the latest `onboarding-harness` commit status is not a FRESH
+          #      success → the harness isn't verified-green recently, e.g. the
+          #      Incus host has been DOWN (no run at all leaves no fresh status).
+          #
+          # The status is the load-bearing freshness/liveness signal; the issue is
+          # the human-facing active-regression signal.
+
+          # (1) Active regression?
+          if [ "$(gh issue list --repo "$REPO" --label onboarding-regression --state open --json url --jq 'length')" -gt 0 ]; then
+            url=$(gh issue list --repo "$REPO" --label onboarding-regression --state open --json url --jq '.[0].url')
+            echo "::error::Onboarding harness is RED (open regression issue) — resolve before releasing: $url"
             exit 1
           fi
-          echo "Onboarding harness is green (no open regression issue) — release may proceed."
+
+          # (2) Fresh green status? The nightly stamps an `onboarding-harness` status
+          # on the main SHA it tested; main moves on (this repo lands dozens of
+          # commits/day), so walk commits NEWEST-FIRST within a generous time window
+          # — `since` + `--paginate`, so a busy day can't truncate the search the way
+          # a fixed commit count would — and take the first status found. Then require
+          # success + age < MAX_AGE_SECONDS. Missing or stale ⇒ fail closed (we can't
+          # confirm a recent green run, e.g. the Incus host is down).
+          since=$(date -u -d '96 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          latest=""
+          for sha in $(gh api --paginate "repos/$REPO/commits?sha=main&since=$since&per_page=100" --jq '.[].sha'); do
+            latest=$(gh api "repos/$REPO/commits/$sha/statuses" \
+              --jq '[.[] | select(.context=="onboarding-harness")] | sort_by(.created_at) | last // empty')
+            [ -n "$latest" ] && break
+          done
+          if [ -z "$latest" ]; then
+            echo "::error::No onboarding-harness status on recent main commits — has the nightly run? Refusing to release unverified."
+            exit 1
+          fi
+
+          state=$(printf '%s' "$latest" | jq -r .state)
+          created=$(printf '%s' "$latest" | jq -r .created_at)
+          age=$(( $(date -u +%s) - $(date -u -d "$created" +%s) ))
+          echo "latest onboarding-harness status: $state at $created (age ${age}s)"
+          if [ "$state" != "success" ]; then
+            echo "::error::Latest onboarding-harness status is '$state' — the harness is not green."
+            exit 1
+          fi
+          if [ "$age" -gt "$MAX_AGE_SECONDS" ]; then
+            echo "::error::Latest onboarding-harness status is stale (> ${MAX_AGE_SECONDS}s) — the nightly may not be running. Refusing to release on a stale signal."
+            exit 1
+          fi
+          echo "Onboarding harness is fresh-green — release may proceed."

--- a/ci/onboarding-harness/README.md
+++ b/ci/onboarding-harness/README.md
@@ -71,11 +71,18 @@ So a finding can't rot in an overwritten file — it surfaces as an open, tracka
 
 The same full run also publishes a **commit status** (`onboarding-harness` context, success/failure) on the tested SHA, so every nightly leaves a visible green/red record on the commit — even a clean run that files no issue — linked to the regression issue when red.
 
+**Scope — the verdict (issue, status, exit code) is the deterministic GATE subset only** (`structured` AND not `detectionOnly` — the same scenarios `onboarding-gate.sh` runs). A prose/agent gap (e.g. `git-missing`, whose distro-specific fix runs through the LLM agent) or a detection-only scenario shows in the report but **never** opens the issue, flips the status to red, or fails the run — it can't auto-heal unattended, so it must not block releases. The full gap report still lists every scenario.
+
 ## Release gate
 
 Because the harness needs Incus (a self-hosted host), it **cannot run in GitHub-hosted CI**, and exposing the host's Incus socket to the sandboxed self-hosted runners (which execute untrusted PR code) would defeat their isolation. So enforcement is split: the **host executes** the harness nightly and publishes the verdict to GitHub (the rolling issue + commit status above); **CI consults** it.
 
-`.github/workflows/onboarding-release-gate.yml` runs on release-please's release PR and **fails if an `onboarding-regression` issue is open** — i.e. it blocks shipping a release over a known-red onboarding harness. It only reads an issue (no Incus), runs on a hosted runner, and is robust to `main` moving (it consults the rolling issue, not a per-SHA status). To make it actually block the merge, add `onboarding-release-gate` to the branch's **required status checks** (a repo setting). It reflects the last nightly, so a host that's been down for days can leave the signal stale.
+`.github/workflows/onboarding-release-gate.yml` runs on release-please's release PR and requires the harness to be **fresh-green** before a release can ship. Two checks, each blocking (fail closed), covering distinct failure modes:
+
+1. **No open `onboarding-regression` issue** — an open one means an _active regression_ (and catches a red run whose status-publish failed but whose issue still opened).
+2. **A fresh green `onboarding-harness` commit status** — the nightly stamps that status on the main SHA it tested; main moves on, so the gate walks recent commits to the latest such status and requires `success` **and** age < 48h. Missing or stale ⇒ blocked, so a **host that's been down for days can't slip a release through** on "no open issue alone" (the staleness hole). This is what makes the commit status load-bearing rather than decorative.
+
+It only reads issues/statuses (no Incus), runs on a hosted runner. To make it actually block the merge, add `onboarding-release-gate` to the branch's **required status checks** (a repo setting).
 
 ### Manual subset gate
 

--- a/ci/onboarding-harness/issue.ts
+++ b/ci/onboarding-harness/issue.ts
@@ -1,4 +1,4 @@
-import { gapScenarios } from "./report";
+import { gateGapScenarios } from "./report";
 import { captureSpawn, type Captured } from "./spawn";
 import type { ScenarioResult } from "./types";
 
@@ -74,7 +74,7 @@ export async function reportToGitHub(
   stamp: string,
   gh: GhRunner = defaultGh,
 ): Promise<IssueOutcome> {
-  const gaps = gapScenarios(results);
+  const gaps = gateGapScenarios(results);
   const existing = await findOpenIssue(gh);
 
   if (gaps.length === 0) {

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -12,24 +12,23 @@ function classify(r: ScenarioResult): "PASS" | "DETECTION GAP" | "ADVICE GAP" | 
   return r.detection.detected ? "ADVICE GAP" : "DETECTION GAP";
 }
 
-/** Scenarios that represent a real regression worth flagging — a missed/
- *  misclassified defect (DETECTION GAP) or coaching that didn't heal it (ADVICE
- *  GAP). PASS and by-design DETECTION-ONLY are NOT gaps. */
-export function gapScenarios(results: ScenarioResult[]): ScenarioResult[] {
-  return results.filter((r) => {
-    const k = classify(r);
-    return k === "DETECTION GAP" || k === "ADVICE GAP";
-  });
+/** Gate regressions: a gate-eligible (deterministic) scenario that didn't reach
+ *  green. These — and only these — drive the release verdict (status + issue).
+ *  Prose/agent + detection-only scenarios are reported but never gate. */
+export function gateGapScenarios(results: ScenarioResult[]): ScenarioResult[] {
+  return results.filter((r) => r.gateEligible && !r.reachedGreen);
 }
 
-/** One-line outcome for a commit-status description (≤140 chars on the wire). */
+/** One-line GATE outcome for a commit-status description (≤140 chars on the
+ *  wire) — scoped to the deterministic subset, so an informational prose/agent
+ *  gap (e.g. git-missing) doesn't flip the release verdict. */
 export function statusDescription(results: ScenarioResult[]): string {
-  const applicable = results.filter((r) => !r.detectionOnly);
-  const green = applicable.filter((r) => r.reachedGreen).length;
-  const gaps = gapScenarios(results);
+  const gate = results.filter((r) => r.gateEligible);
+  const green = gate.filter((r) => r.reachedGreen).length;
+  const gaps = gateGapScenarios(results);
   return gaps.length === 0
-    ? `${green}/${applicable.length} scenarios green`
-    : `${gaps.length} gap(s): ${gaps.map((g) => g.scenarioId).join(", ")}`;
+    ? `${green}/${gate.length} gate scenarios green`
+    : `${gaps.length} gate gap(s): ${gaps.map((g) => g.scenarioId).join(", ")}`;
 }
 
 function tableRow(r: ScenarioResult, klass: ReturnType<typeof classify>): string {

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -26,7 +26,13 @@ async function runScenario(
   scenario: Scenario,
   tarball: string,
 ): Promise<ScenarioResult> {
-  const base = { scenarioId: scenario.id, image: scenario.image };
+  const base = {
+    scenarioId: scenario.id,
+    image: scenario.image,
+    // Part of the deterministic release gate iff structured AND not detection-only
+    // (mirrors onboarding-gate.sh). Prose/agent + detection-only never gate.
+    gateEligible: scenario.coaching === "structured" && !scenario.detectionOnly,
+  };
   let detection: DetectionResult | undefined;
   try {
     await seedInstance(driver, scenario, tarball);
@@ -193,12 +199,12 @@ async function main() {
   writeFileSync(out, report);
   console.log(`\n${report}\nReport written to ${out}`);
 
-  // Non-zero exit if any APPLY-ABLE scenario failed to reach green (detection-only
-  // scenarios are excluded). Consumed by the Phase 2 gate.
-  const applicable = results.filter((r) => !r.detectionOnly);
-  const ok = applicable.every((r) => r.reachedGreen);
-  await maybeReportRun(results, report, only, ok);
-  process.exit(ok ? 0 : 1);
+  // Verdict = the deterministic GATE subset only (structured, non-detection-only —
+  // same as onboarding-gate.sh). A prose/agent gap (git-missing) or a detection-only
+  // scenario shows in the report but never fails the run or blocks a release.
+  const gateOk = results.filter((r) => r.gateEligible).every((r) => r.reachedGreen);
+  await maybeReportRun(results, report, only, gateOk);
+  process.exit(gateOk ? 0 : 1);
 }
 
 void main();

--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -82,7 +82,7 @@ export const SCENARIOS: Scenario[] = [
   },
   {
     id: "git-missing",
-    image: "images:alpine/3.20",
+    image: "images:alpine/3.21",
     seed: ["apk del git 2>/dev/null || true", "rm -f /usr/bin/git"],
     expect: [{ id: "git", state: "error" }],
     // prose: git install is distro-specific; no single verbatim one-liner covers

--- a/ci/onboarding-harness/types.ts
+++ b/ci/onboarding-harness/types.ts
@@ -54,6 +54,12 @@ export interface ScenarioResult {
   /** True when no apply was attempted BY DESIGN (e.g. claude-missing in Phase 1):
    *  the report classifies it DETECTION-ONLY, not an advice gap. */
   detectionOnly?: boolean;
+  /** Whether this scenario is part of the deterministic RELEASE GATE — i.e.
+   *  `coaching: "structured"` AND not `detectionOnly`, the same subset
+   *  `onboarding-gate.sh` runs. Only these drive the gate verdict (commit status +
+   *  rolling issue); prose/agent + detection-only scenarios stay in the report as
+   *  information and never block a release. */
+  gateEligible: boolean;
   error?: string;
 }
 

--- a/test/onboarding-harness/issue.test.ts
+++ b/test/onboarding-harness/issue.test.ts
@@ -10,13 +10,21 @@ function result(over: Partial<ScenarioResult>): ScenarioResult {
     detection: { scenarioId: "herdr-missing", detected: true, misses: [] },
     appliedVia: "verbatim",
     reachedGreen: true,
+    gateEligible: true, // structured, non-detection-only
     ...over,
   };
 }
 
-const GAP = result({ reachedGreen: false }); // detected but not green → ADVICE GAP
+const GAP = result({ reachedGreen: false }); // gate-eligible + not green → GATE GAP
 const PASS = result({ reachedGreen: true });
-const DETECTION_ONLY = result({ detectionOnly: true }); // by design — NOT a gap
+const DETECTION_ONLY = result({ detectionOnly: true, gateEligible: false }); // by design — NOT a gap
+// A prose/agent gap (e.g. git-missing): not green, but NOT gate-eligible → must not
+// open/keep an issue or fail the gate.
+const NON_GATE_GAP = result({
+  scenarioId: "git-missing",
+  reachedGreen: false,
+  gateEligible: false,
+});
 
 /** Fake `gh` that records argv and replies to `issue list` with `openIssue`. */
 function fakeGh(openIssue: { number: number; url: string } | null) {
@@ -71,6 +79,19 @@ describe("reportToGitHub", () => {
     const out = await reportToGitHub([PASS], "REPORT", "2026-06-15", gh);
     expect(calls.every((c) => !["create", "edit", "comment", "close"].includes(c[1]!))).toBe(true);
     expect(out.summary).toMatch(/nothing/i);
+  });
+
+  it("ignores a non-gate gap (git-missing) — it must not open an issue", async () => {
+    const { calls, gh } = fakeGh(null);
+    const out = await reportToGitHub([PASS, NON_GATE_GAP], "REPORT", "2026-06-15", gh);
+    expect(calls.some((c) => c[0] === "issue" && c[1] === "create")).toBe(false);
+    expect(out.summary).toMatch(/nothing/i);
+  });
+
+  it("closes the gate issue when only a non-gate gap remains (gate is green)", async () => {
+    const { calls, gh } = fakeGh({ number: 42, url: "https://github.com/x/y/issues/42" });
+    await reportToGitHub([PASS, NON_GATE_GAP], "REPORT", "2026-06-15", gh);
+    expect(calls.some((c) => c[0] === "issue" && c[1] === "close" && c[2] === "42")).toBe(true);
   });
 });
 

--- a/test/onboarding-harness/report.test.ts
+++ b/test/onboarding-harness/report.test.ts
@@ -9,6 +9,7 @@ const results: ScenarioResult[] = [
     detection: { scenarioId: "gh-unauthed", detected: true, misses: [] },
     appliedVia: "agent",
     reachedGreen: true,
+    gateEligible: false,
   },
   {
     scenarioId: "tailscale-missing",
@@ -20,6 +21,7 @@ const results: ScenarioResult[] = [
     },
     appliedVia: "agent",
     reachedGreen: false,
+    gateEligible: false,
     error: "agent gave up",
   },
 ];
@@ -43,6 +45,7 @@ describe("buildGapReport", () => {
         detection: { scenarioId: "x", detected: true, misses: [] },
         appliedVia: "agent",
         reachedGreen: false,
+        gateEligible: false,
       },
     ]);
     expect(md).toContain("ADVICE GAP");
@@ -52,11 +55,12 @@ describe("buildGapReport", () => {
     const md = buildGapReport([
       {
         scenarioId: "claude-missing",
-        image: "images:fedora/40",
+        image: "images:fedora/42",
         detection: { scenarioId: "claude-missing", detected: true, misses: [] },
         appliedVia: "skipped",
         reachedGreen: false,
         detectionOnly: true,
+        gateEligible: false,
       },
       {
         scenarioId: "gh-unauthed",
@@ -64,6 +68,7 @@ describe("buildGapReport", () => {
         detection: { scenarioId: "gh-unauthed", detected: true, misses: [] },
         appliedVia: "agent",
         reachedGreen: true,
+        gateEligible: false,
       },
     ]);
     expect(md).toContain("DETECTION-ONLY");


### PR DESCRIPTION
## Why

Hardens the release gate from #672 after an **end-to-end manual run** exposed two problems:
1. The commit status was **decorative** — nothing consumed it (the gate read only the issue).
2. A full run is **red because `git-missing` can't reach green** (its fix runs through the LLM agent), which would block *every* release on a non-deterministic scenario.

## What

**Status is now load-bearing (closes the staleness hole).** The gate requires a **fresh green** `onboarding-harness` status — `success` AND age < 48h, found by walking recent `main` commits in a time-bounded, paginated window (this repo lands ~80 commits/48h, so a fixed count would truncate) — *in addition to* no open regression issue. The two checks cover distinct failure modes: an open issue = active regression; a missing/stale status = no recent run (e.g. the Incus host is down). A host down for days can no longer slip a release through on "no open issue" alone.

**Verdict scoped to the deterministic subset.** The status, rolling issue, and exit code now reflect only **gate-eligible** scenarios (`structured` AND not `detectionOnly` — exactly what `onboarding-gate.sh` runs). A prose/agent gap (`git-missing`) or a detection-only scenario appears in the report but **never** flips the verdict or blocks a release — it can't auto-heal unattended, so it mustn't gate. New `ScenarioResult.gateEligible`; `gateGapScenarios` / `statusDescription` are gate-scoped; the full report still lists every scenario.

**Image bump.** `git-missing` `alpine/3.20 → 3.21` (3.20 aged off the `images:` remote, like `fedora/40` before it).

## Validation (end-to-end)

A real `bun run onboarding:test` from the deployed checkout was run against the live repo: it published an `onboarding-harness` commit status on `main` and opened a regression issue, both verified by read-back, then cleaned up — proving the `run.ts → publishStatus → gh` path. That run is what surfaced the `git-missing` stale-image + verdict-drag, motivating the scoping. New unit tests cover the scoping (a non-gate gap must not open an issue or fail the gate). `tsc` + `lint` + 34 harness tests + `fallow` green.

Follow-up to #663 / #670 / #672.

[no-feature-entry] — CI tooling, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)