### PR TITLE
feat(ui): add version + README/docs link to the mobile gear menu

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1288,5 +1288,8 @@
   "feat_api_key_verify_title": "API-Schlüssel verifizieren",
   "feat_api_key_verify_body": "Prüfe, ob dein gespeicherter Anthropic-API-Schlüssel einen gestarteten Agenten tatsächlich authentifiziert — direkt in Einstellungen → Sitzung, bevor er beim ersten Einsatz versagt.",
   "feat_readiness_install_commands_title": "Kopierfertige Setup-Befehle in Readiness",
-  "feat_readiness_install_commands_body": "Die Readiness-Empfehlung listet jetzt die exakten Installationsbefehle für den Paketmanager deines Repos auf, sodass jede fehlende Schutzregel ohne Nachschlagen übernommen werden kann."
+  "feat_readiness_install_commands_body": "Die Readiness-Empfehlung listet jetzt die exakten Installationsbefehle für den Paketmanager deines Repos auf, sodass jede fehlende Schutzregel ohne Nachschlagen übernommen werden kann.",
+  "topbar_menu_docs": "README & Doku",
+  "feat_mobile_menu_docs_title": "Doku & Version im Mobil-Menü",
+  "feat_mobile_menu_docs_body": "Auf dem Handy verlinkt das Zahnrad-Menü jetzt direkt auf die Shepherd-Startseite — README und Doku — und zeigt die laufende Build-Version an."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1288,5 +1288,8 @@
   "feat_api_key_verify_title": "Verify your API key",
   "feat_api_key_verify_body": "Check that your saved Anthropic API key actually authenticates a spawned agent — right from Settings → Session, before it fails on first use.",
   "feat_readiness_install_commands_title": "Copy-paste setup commands in Readiness",
-  "feat_readiness_install_commands_body": "The Readiness prescription now lists the exact install commands for your repo's package manager, so each missing guardrail can be adopted without looking the steps up."
+  "feat_readiness_install_commands_body": "The Readiness prescription now lists the exact install commands for your repo's package manager, so each missing guardrail can be adopted without looking the steps up.",
+  "topbar_menu_docs": "README & docs",
+  "feat_mobile_menu_docs_title": "Docs & version in the mobile menu",
+  "feat_mobile_menu_docs_body": "On phones the gear menu now links straight to Shepherd's home — the README and docs — and shows the build version you're running."
 }

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -4,6 +4,7 @@ import { page } from "vitest/browser";
 import "../../app.css";
 import type { Session, UsageLimits, UpdateStatus, HerdrUpdateStatus } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
+import { REPO_URL, version } from "$lib/build-info";
 
 // Mock api so the manual /usage refresh path never fires a real network call —
 // individual tests stub refreshUsage's resolution/rejection per case.
@@ -729,6 +730,11 @@ describe("TopBar — idle gear opens Settings directly", () => {
     await expect
       .element(page.getByRole("menuitem", { name: m.settings_title() }))
       .toBeInTheDocument();
+    // mobile footer: a link to Shepherd's home (README + docs) and the build version
+    const docs = page.getByRole("menuitem", { name: m.topbar_menu_docs() });
+    await expect.element(docs).toBeInTheDocument();
+    await expect.element(docs).toHaveAttribute("href", REPO_URL);
+    await expect.element(page.getByText(`v${version}`)).toBeInTheDocument();
   });
 
   it("desktop: the gear menu omits the quick theme/contrast controls", async () => {
@@ -747,6 +753,10 @@ describe("TopBar — idle gear opens Settings directly", () => {
       .toBeInTheDocument();
     await expect
       .element(page.getByRole("button", { name: m.actionbar_contrast_toggle() }))
+      .not.toBeInTheDocument();
+    // the docs link + version footer are mobile-only too (desktop has the ActionBar footer)
+    await expect
+      .element(page.getByRole("menuitem", { name: m.topbar_menu_docs() }))
       .not.toBeInTheDocument();
   });
 });

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -923,7 +923,7 @@
               <span class="menu-glyph" aria-hidden="true">↗</span>
               <span class="menu-label">{m.topbar_menu_docs()}</span>
             </a>
-            <div class="menu-foot micro">v{version}</div>
+            <div class="menu-foot micro" role="none">v{version}</div>
           {/if}
         </div>
       {/if}

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -15,6 +15,7 @@
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import { theme, type ThemePref } from "$lib/theme.svelte";
   import ThemeIcon from "$lib/components/ThemeIcon.svelte";
+  import { REPO_URL, version } from "$lib/build-info";
 
   type TallyStatus = "running" | "idle" | "blocked";
 
@@ -906,6 +907,24 @@
             <span class="menu-glyph" aria-hidden="true">⚙</span>
             <span class="menu-label">{m.settings_title()}</span>
           </button>
+          {#if mobile}
+            <!-- Mobile footer: a jump to Shepherd's home (the repo's README + docs) and the
+                 running build version. Desktop surfaces these in the ActionBar footer +
+                 Settings → About instead, so they're folded into the gear menu only here. -->
+            <div class="menu-sep" role="separator"></div>
+            <a
+              class="menu-item"
+              href={REPO_URL}
+              target="_blank"
+              rel="external noreferrer noopener"
+              role="menuitem"
+              onclick={() => closeMenu()}
+            >
+              <span class="menu-glyph" aria-hidden="true">↗</span>
+              <span class="menu-label">{m.topbar_menu_docs()}</span>
+            </a>
+            <div class="menu-foot micro">v{version}</div>
+          {/if}
         </div>
       {/if}
     </div>
@@ -1192,6 +1211,13 @@
     height: 1px;
     margin: 3px 2px;
     background: var(--color-line);
+  }
+  /* Build-version footer under the mobile menu's docs link — a quiet, non-interactive
+     line, so it stays understated next to the tappable rows above it. */
+  .menu-foot {
+    padding: 6px 12px 2px;
+    color: var(--color-faint);
+    font-variant-numeric: tabular-nums;
   }
   /* Pip on the gear: the only at-rest cue that there's a herd to halt. Amber while
      agents merely work; red (.alert) only when something is blocked, so red stays

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -832,4 +832,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_readiness_install_commands_title",
     bodyKey: "feat_readiness_install_commands_body",
   },
+  {
+    // No targetId: the link lives inside the gear menu (closed by default) and is
+    // mobile-only, so a desktop coachmark anchor would mislead — surface via the
+    // What's-New drawer only. 1.30.0 is the latest released tag, so this ships in 1.31.0.
+    id: "mobile-menu-docs-version",
+    sinceVersion: "1.31.0",
+    titleKey: "feat_mobile_menu_docs_title",
+    bodyKey: "feat_mobile_menu_docs_body",
+  },
 ];


### PR DESCRIPTION
## Was

Im **mobilen Zahnrad-Menü** (TopBar) gibt es jetzt einen Footer mit:

- **Link zur Shepherd-Startseite** — öffnet das Repo (README + Dokumentation) in einem neuen Tab.
- **Build-Version** — die laufende `v{version}`, die der Build trägt.

Beides ist **mobile-only**: Auf dem Desktop liegen diese Infos bereits im ActionBar-Footer und unter Settings → About, daher wird der Footer dort nicht doppelt gezeigt.

## Warum

Auf dem Handy waren Version und ein Einstieg in die Doku bisher nur tief in Settings → Device versteckt. Das Zahnrad-Menü ist auf Mobile der natürliche Ort dafür.

## Details

- `TopBar.svelte`: Footer (Docs-Link als `role="menuitem"` für die Tastatur-Navigation, schließt das Menü beim Klick; Versionszeile via `.menu-foot`, dezent/`--color-faint`). Nutzt `REPO_URL` + `version` aus `build-info.ts`.
- i18n: neuer Key `topbar_menu_docs` (EN/DE).
- Feature-Katalog: Eintrag `mobile-menu-docs-version` (1.31.0) + `feat_mobile_menu_docs_*` Keys.
- Tests: mobile Menü-Test um Docs-Link + Version erweitert; Desktop-Test verifiziert die Abwesenheit.

## Checks

- `bun run check` ✓ (0 errors)
- `bun run check:i18n` ✓ (Parität, 1242 Keys)
- `bun run test -- TopBar` ✓ (39 passed)