### PR TITLE
feat(epic): epic-branch guardrails + migration checkpoint — close out #645 learnings

### DIFF
--- a/src/completed-epic.ts
+++ b/src/completed-epic.ts
@@ -25,6 +25,12 @@ export interface CompletedEpic {
   landingPrNumber: number | null;
   landingPrUrl: string | null;
   landingState: EpicLandingState;
+  // Migration-awareness checkpoint (#645): migration file paths detected in the landing PR
+  // (empty when none / detection unavailable) + the epoch the operator acknowledged them (null
+  // until acknowledged). A non-empty `migrationPaths` with a null `migrationsAckedAt` gates the
+  // band row's clear behind an explicit acknowledgement — NEVER the autonomous completion flip.
+  migrationPaths: string[];
+  migrationsAckedAt: number | null;
 }
 
 export function buildRollup(

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -286,8 +286,11 @@ export class DrainService {
       persistedBranch,
     );
     // (Task 2) children parked at retire because their PR targets the wrong base.
-    const baseMismatches = this.deps.store.listEpicBaseMismatches(repoPath, run.parentIssueNumber);
-    return assembleEpic({
+    const recordedMismatches = this.deps.store.listEpicBaseMismatches(
+      repoPath,
+      run.parentIssueNumber,
+    );
+    const base = {
       repoPath,
       run,
       integrated,
@@ -304,8 +307,29 @@ export class DrainService {
       persistedBranch,
       integratedBases,
       divergentBranches,
-      baseMismatches,
+    };
+    // Self-heal orphaned base-mismatch markers (#645). The marker is only cleared inside the
+    // retire path (doRetire → epicChildBaseBlocked), which re-runs only while the child PR is
+    // still open. A blocked child resolved out-of-band (PR merged into default → issue closed)
+    // never re-enters retire, so its marker — and its actionable "epic blocked until fixed"
+    // warning — would persist forever. assembleEpic is PURE; the model decides done-in-epic as
+    // `integrationMerged || issueClosed`, so derive the same done-set from the assembled children
+    // (no forge call), clear markers for any now-done child, and surface only the still-blocked
+    // ones. Idempotent (runs every build) and fail-safe.
+    const probe = assembleEpic({ ...base, baseMismatches: recordedMismatches });
+    const doneInEpic = new Set(
+      probe.children.filter((c) => c.integrationMerged || c.issueClosed).map((c) => c.number),
+    );
+    const liveMismatches = recordedMismatches.filter((mm) => {
+      if (doneInEpic.has(mm.childNumber)) {
+        this.deps.store.clearEpicBaseMismatch(repoPath, run.parentIssueNumber, mm.childNumber);
+        return false;
+      }
+      return true;
     });
+    // No swept markers → the probe is already correct; reuse it rather than re-assembling.
+    if (liveMismatches.length === recordedMismatches.length) return probe;
+    return assembleEpic({ ...base, baseMismatches: liveMismatches });
   }
 
   /** #645 (c): list host `epic/*` branches that reference `parentNumber` as a digit-bounded

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -93,6 +93,7 @@ export interface DrainDeps {
     | "archive"
     | "getEpicRun"
     | "setEpicRun"
+    | "getOrInitEpicIntegrationBranch"
     | "listEpicIntegrated"
     | "recordEpicIntegrated"
     | "listEpicIntegratedDetails"
@@ -323,7 +324,13 @@ export class DrainService {
       builtEpic = await this.buildEpic(repoPath, epicRun!);
       if (builtEpic) {
         epicParent = epicRun!.parentIssueNumber;
-        epicIntegrationBranch = epicBranchName(builtEpic.parentIssueNumber, builtEpic.parentTitle);
+        // Pin the canonical name once (#645): re-deriving from the live title would re-point
+        // spawns + the landing base on a mid-run title edit, orphaning already-merged children.
+        epicIntegrationBranch = this.deps.store.getOrInitEpicIntegrationBranch(
+          repoPath,
+          builtEpic.parentIssueNumber,
+          epicBranchName(builtEpic.parentIssueNumber, builtEpic.parentTitle),
+        );
         if (epicRun!.status === "running") candidates = selectEpicCandidates(builtEpic.children);
         epicAttended = epicRun!.mode === "attended";
       }
@@ -588,7 +595,13 @@ export class DrainService {
         return;
       }
 
-      const integrationBranch = epicBranchName(parentIssueNumber, parentTitle);
+      // Read the pinned name (#645) so the landing PR bases on the SAME branch children
+      // merged into — even if the epic's title was edited after the branch was first pinned.
+      const integrationBranch = this.deps.store.getOrInitEpicIntegrationBranch(
+        repoPath,
+        parentIssueNumber,
+        epicBranchName(parentIssueNumber, parentTitle),
+      );
       const resolution = await this.classifyLanding(forge, row, integrationBranch);
       this.resolveLanding(repoPath, parentIssueNumber, resolution);
     } finally {

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -40,6 +40,11 @@ const EPIC_BLOCKED_BY_CONCURRENCY = 8;
  *  keeps `gh api matching-refs` off the per-pump hot path. */
 const EPIC_BRANCH_SCAN_TTL_MS = 5 * 60_000;
 
+/** #645 (Task 2): once a child's PR is found targeting the wrong base, don't re-pay the
+ *  `prReviewMeta` API call on every pump while the operator hasn't fixed it — recheck at most
+ *  this often per child. Bounds the cost to ≤1 call/child/~60s while a child stays blocked. */
+const EPIC_BASE_RECHECK_TTL_MS = 60_000;
+
 /** Cap on epic-landing-PR open attempts (#635, Stage B). A failed `openPr` flips the
  *  `epic_completed` row to `landingState:'error'` and increments `landingAttempts`; the
  *  autonomous tick retries until this many failures, then PARKS the row in `error` —
@@ -109,6 +114,10 @@ export interface DrainDeps {
     | "recordEpicCompleted"
     | "listEpicCompleted"
     | "setEpicLandingPr"
+    | "recordEpicBaseMismatch"
+    | "clearEpicBaseMismatch"
+    | "getEpicBaseMismatch"
+    | "listEpicBaseMismatches"
   >;
   service: {
     create(input: CreateSessionInput): Promise<Session>;
@@ -274,6 +283,8 @@ export class DrainService {
       run.parentIssueNumber,
       persistedBranch,
     );
+    // (Task 2) children parked at retire because their PR targets the wrong base.
+    const baseMismatches = this.deps.store.listEpicBaseMismatches(repoPath, run.parentIssueNumber);
     return assembleEpic({
       repoPath,
       run,
@@ -291,6 +302,7 @@ export class DrainService {
       persistedBranch,
       integratedBases,
       divergentBranches,
+      baseMismatches,
     });
   }
 
@@ -880,6 +892,121 @@ export class DrainService {
   }
 
   /**
+   * #645 (Task 2): verify an epic child's PR base before retire merges it into the integration
+   * branch. The child is only *told* (advisory prompt/steer) to open its PR with
+   * `--base <integration branch>`; nothing forces it. Returns `true` when retire must FAIL CLOSED
+   * (do not merge/record/archive/drop-claim) — either the PR targets the wrong base, the probe
+   * failed, or a fresh mismatch marker is throttling the recheck. `false` ⇒ base verified (or the
+   * forge can't tell — Gitea has no `prReviewMeta`, so behavior is unchanged). Side effects: parks
+   * / clears the `epic_base_mismatch` marker (the throttle anchor + assembleEpic warning source).
+   */
+  private async epicChildBaseBlocked(
+    forge: GitForge,
+    repoPath: string,
+    parent: number,
+    s: Session,
+    decision: Extract<DrainDecision, { kind: "retire" }>,
+  ): Promise<boolean> {
+    if (!forge.prReviewMeta) return false; // Gitea: can't tell — preserve today's behavior exactly.
+    const child = s.issueNumber!;
+    // Throttle: a fresh (<60s) marker means we already found the wrong base recently — stay blocked
+    // without re-paying the prReviewMeta call. Bounds it to ≤1 call/child/~60s while stuck.
+    const existing = this.deps.store.getEpicBaseMismatch(repoPath, parent, child);
+    if (existing && this.now() - existing.checkedAt < EPIC_BASE_RECHECK_TTL_MS) return true;
+    let actual: string | undefined;
+    try {
+      actual = (await forge.prReviewMeta(decision.prNumber))?.baseRefName;
+    } catch (err) {
+      // Probe failure is not a green light — stay blocked (do NOT merge into the wrong place on a
+      // transient API error). Refresh the marker so the throttle still applies.
+      console.warn(
+        `[drain] epic child base-check pr#${decision.prNumber} (issue #${child}) failed; staying blocked:`,
+        err,
+      );
+      this.deps.store.recordEpicBaseMismatch(repoPath, parent, child, {
+        actualBase: existing?.actualBase ?? "",
+        prNumber: decision.prNumber,
+        checkedAt: this.now(),
+      });
+      return true;
+    }
+    if (actual !== s.baseBranch) {
+      this.deps.store.recordEpicBaseMismatch(repoPath, parent, child, {
+        actualBase: actual ?? "",
+        prNumber: decision.prNumber,
+        checkedAt: this.now(),
+      });
+      console.warn(
+        `[drain] epic child pr#${decision.prNumber} (issue #${child}) targets \`${actual ?? "?"}\`, not the epic branch \`${s.baseBranch}\` — blocked until re-targeted`,
+      );
+      return true; // fail closed: child stays un-integrated; dependents stay blocked.
+    }
+    this.deps.store.clearEpicBaseMismatch(repoPath, parent, child); // matched — clear stale marker.
+    return false;
+  }
+
+  /**
+   * Epic-child retire (base already verified by {@link epicChildBaseBlocked}): squash-merge the PR
+   * INTO its integration branch, record it as integrated so dependents unblock (no GitHub issue
+   * auto-close — the child issue stays open until the epic→default PR lands), then archive. The
+   * claim is RETAINED (releasing would re-spawn the still-open issue). A merge throw leaves the
+   * session live for next-tick retry (no record/archive); an archive throw is recoverable — the
+   * integration is already recorded and the pr-poller reaps the merged PR.
+   */
+  private async retireEpicChild(
+    forge: GitForge,
+    repoPath: string,
+    parent: number,
+    s: Session,
+    decision: Extract<DrainDecision, { kind: "retire" }>,
+  ): Promise<void> {
+    try {
+      // deleteBranch removes the child's MERGED head (task) branch on origin — standard post-merge
+      // hygiene. It is the PR's head, never the integration branch (the base), so the accumulating
+      // integration branch is untouched.
+      await forge.merge(decision.prNumber, { method: "squash", deleteBranch: true });
+    } catch (err) {
+      console.warn(
+        `[drain] epic child merge pr#${decision.prNumber} (issue #${s.issueNumber}) into ${s.baseBranch} failed:`,
+        err,
+      );
+      return; // leave the session live; next tick retries. Do NOT record or archive.
+    }
+    this.deps.store.recordEpicIntegrated(
+      repoPath,
+      parent,
+      s.issueNumber!,
+      {
+        number: decision.prNumber,
+        url: this.deps.prCache.snapshot()[decision.sessionId]?.url ?? "",
+      },
+      s.baseBranch, // #645 (b): the branch this child actually squash-merged into
+    );
+    try {
+      await this.deps.service.archive(decision.sessionId);
+    } catch (err) {
+      // The squash-merge already landed (PR is now MERGED) but teardown didn't finish. This is
+      // recoverable, not a permanent strand: we deliberately do NOT dropPrCache/emit below, so the
+      // session stays live AND polled (pr-poller skips only archived rows). The poller re-observes
+      // the merged PR and settles it via reapMerged → settleMergedSession (archive + teardown) —
+      // the same path any out-of-band merge takes. That recovery closes the child issue instead of
+      // keeping it open, but the integration is already recorded above, so dependents unblock
+      // either way. The session can NOT be re-selected by the retire gate (readyToRetire requires
+      // state==="open"; the PR is merged), hence the poller is the recovery, not a retry.
+      console.warn(
+        `[drain] archive (epic child) failed for ${decision.sessionId}; pr-poller will reap the merged PR:`,
+        err,
+      );
+      return;
+    }
+    // Keep the claim: the child issue stays open until the epic lands; releasing would let it
+    // re-spawn. Mirrors the non-epic retire path.
+    this.retainClaimOnArchive.add(decision.sessionId);
+    this.deps.dropPrCache(decision.sessionId);
+    this.deps.emitArchived(decision.sessionId);
+  }
+
+  /**
    * Retire a ready session: ensure the PR links its issue (so the forge
    * auto-closes the issue when a human merges), then archive the session
    * (stops the pane, removes the worktree, marks the row archived). The open,
@@ -900,51 +1027,13 @@ export class DrainService {
     const epicRun = this.deps.store.getEpicRun(repoPath);
     const epicActive = !!epicRun && (epicRun.status === "running" || epicRun.status === "paused");
     if (epicActive && s?.issueNumber != null && isEpicIntegrationBranch(s.baseBranch)) {
-      try {
-        // deleteBranch removes the child's MERGED head (task) branch on origin — standard
-        // post-merge hygiene. It is the PR's head, never the integration branch (the base),
-        // so the accumulating integration branch is untouched.
-        await forge.merge(decision.prNumber, { method: "squash", deleteBranch: true });
-      } catch (err) {
-        console.warn(
-          `[drain] epic child merge pr#${decision.prNumber} (issue #${s.issueNumber}) into ${s.baseBranch} failed:`,
-          err,
-        );
-        return; // leave the session live; next tick retries. Do NOT record or archive.
-      }
-      this.deps.store.recordEpicIntegrated(
-        repoPath,
-        epicRun!.parentIssueNumber,
-        s.issueNumber,
-        {
-          number: decision.prNumber,
-          url: this.deps.prCache.snapshot()[decision.sessionId]?.url ?? "",
-        },
-        s.baseBranch, // #645 (b): the branch this child actually squash-merged into
-      );
-      try {
-        await this.deps.service.archive(decision.sessionId);
-      } catch (err) {
-        // The squash-merge already landed (PR is now MERGED) but teardown didn't finish. This
-        // is recoverable, not a permanent strand: we deliberately do NOT dropPrCache/emit below,
-        // so the session stays live AND polled (pr-poller skips only archived rows). The poller
-        // re-observes the merged PR and settles it via reapMerged → settleMergedSession (archive
-        // + teardown) — the same path any out-of-band merge takes. That recovery closes the child
-        // issue instead of keeping it open, but the integration is already recorded above, so
-        // dependents unblock either way. The session can NOT be re-selected by the retire gate
-        // (readyToRetire requires state==="open"; the PR is merged), hence the poller is the
-        // recovery, not a retry of this path.
-        console.warn(
-          `[drain] archive (epic child) failed for ${decision.sessionId}; pr-poller will reap the merged PR:`,
-          err,
-        );
+      // #645 (Task 2): enforce the child PR's actual base against the integration branch. On
+      // mismatch (or while throttled-blocked from a prior mismatch) this returns true → fail
+      // closed: skip merge/record/archive/claim-drop so the child stays un-integrated and the
+      // operator re-targets the PR (the remedy is surfaced via assembleEpic warnings).
+      if (await this.epicChildBaseBlocked(forge, repoPath, epicRun!.parentIssueNumber, s, decision))
         return;
-      }
-      // Keep the claim: the child issue stays open until the epic lands; releasing would let it
-      // re-spawn. Mirrors the non-epic retire path below.
-      this.retainClaimOnArchive.add(decision.sessionId);
-      this.deps.dropPrCache(decision.sessionId);
-      this.deps.emitArchived(decision.sessionId);
+      await this.retireEpicChild(forge, repoPath, epicRun!.parentIssueNumber, s, decision);
       return;
     }
     // Best-effort issue link: a failure must NOT block teardown.

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -19,6 +19,7 @@ import {
   branchReferencesEpic,
 } from "./epic-branch";
 import { selectEpicCandidates, type Epic, type EpicRun } from "./epic-core";
+import { detectMigrationPaths } from "./epic-migrations";
 import {
   buildRollup,
   type CompletedEpic,
@@ -114,6 +115,7 @@ export interface DrainDeps {
     | "recordEpicCompleted"
     | "listEpicCompleted"
     | "setEpicLandingPr"
+    | "setEpicMigrationPaths"
     | "recordEpicBaseMismatch"
     | "clearEpicBaseMismatch"
     | "getEpicBaseMismatch"
@@ -518,6 +520,9 @@ export class DrainService {
           landingPrNumber: null,
           landingPrUrl: null,
           landingState: "pending",
+          // Migration detection (#645) runs at landing-open, not completion — see ensureLandingPr.
+          migrationPaths: [],
+          migrationsAckedAt: null,
         };
         this.deps.store.recordEpicCompleted({
           repoPath: completed.repoPath,
@@ -580,6 +585,8 @@ export class DrainService {
       landingPrNumber: row.landingPrNumber,
       landingPrUrl: row.landingPrUrl,
       landingState: row.landingState,
+      migrationPaths: row.migrationPaths,
+      migrationsAckedAt: row.migrationsAckedAt,
     };
     this.deps.emitEpicCompleted?.(completed);
   }
@@ -599,6 +606,35 @@ export class DrainService {
   ): void {
     this.deps.store.setEpicLandingPr(repoPath, parentIssueNumber, fields);
     this.emitCompleted(repoPath, parentIssueNumber);
+  }
+
+  /**
+   * Migration-awareness checkpoint (#645): fetch the landing PR's changed paths, detect migration
+   * files, and persist them on the `epic_completed` row so the band can prompt the operator to
+   * acknowledge before clearing it. STRICTLY best-effort + fail-safe — the whole body is wrapped:
+   * a forge without `prChangedPaths`, a fetch failure, or any throw leaves no paths (hence no
+   * chip) and is swallowed. It NEVER affects the landing resolution and NEVER throws past the
+   * caller (which owns ensureLandingPr's never-throws contract). Re-emits so the chip appears live.
+   */
+  private async detectAndPersistMigrations(
+    forge: GitForge,
+    repoPath: string,
+    parentIssueNumber: number,
+    prNumber: number,
+  ): Promise<void> {
+    if (!forge.prChangedPaths) return; // host can't enumerate PR files → detection off
+    try {
+      const paths = await forge.prChangedPaths(prNumber);
+      const migrations = detectMigrationPaths(paths);
+      if (migrations.length === 0) return; // nothing to flag → leave the row untouched
+      this.deps.store.setEpicMigrationPaths(repoPath, parentIssueNumber, migrations);
+      this.emitCompleted(repoPath, parentIssueNumber);
+    } catch (err) {
+      console.warn(
+        `[drain] migration detection skipped for ${repoPath}#${parentIssueNumber} (PR #${prNumber}):`,
+        err,
+      );
+    }
   }
 
   /**
@@ -677,6 +713,18 @@ export class DrainService {
       );
       const resolution = await this.classifyLanding(forge, row, integrationBranch);
       this.resolveLanding(repoPath, parentIssueNumber, resolution);
+      // Migration-awareness checkpoint (#645): once the landing PR's number is known, detect any
+      // migration files it carries so the band can ask the operator to acknowledge them. Strictly
+      // best-effort — a detection failure (or a forge without prChangedPaths) leaves no paths,
+      // hence no chip, and NEVER affects the landing resolution above.
+      if (resolution.state === "open" && resolution.prNumber != null) {
+        await this.detectAndPersistMigrations(
+          forge,
+          repoPath,
+          parentIssueNumber,
+          resolution.prNumber,
+        );
+      }
     } finally {
       this.landingInFlight.delete(inFlightKey);
     }

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -13,7 +13,11 @@ import {
   type DrainRepoState,
 } from "./drain-core";
 import { assembleEpic } from "./epic-model";
-import { epicIntegrationBranch as epicBranchName, isEpicIntegrationBranch } from "./epic-branch";
+import {
+  epicIntegrationBranch as epicBranchName,
+  isEpicIntegrationBranch,
+  branchReferencesEpic,
+} from "./epic-branch";
 import { selectEpicCandidates, type Epic, type EpicRun } from "./epic-core";
 import {
   buildRollup,
@@ -30,6 +34,11 @@ import { config } from "./config";
  *  Bounds `gh api` subprocesses so a large (100+-child) epic can't exhaust FDs or
  *  trip GitHub secondary rate limits. */
 const EPIC_BLOCKED_BY_CONCURRENCY = 8;
+
+/** #645 (c): re-scan the host for stray `epic/*` branches at most this often per epic. The
+ *  scan is an advisory divergence warning, not gating — a 5-minute staleness is harmless and
+ *  keeps `gh api matching-refs` off the per-pump hot path. */
+const EPIC_BRANCH_SCAN_TTL_MS = 5 * 60_000;
 
 /** Cap on epic-landing-PR open attempts (#635, Stage B). A failed `openPr` flips the
  *  `epic_completed` row to `landingState:'error'` and increments `landingAttempts`; the
@@ -167,6 +176,10 @@ export class DrainService {
   private retainClaimOnArchive = new Set<string>();
   private issuesCache = new Map<string, { issues: Issue[]; ts: number }>();
   private epicStructureCache = new Map<string, { reads: EpicStructure; ts: number }>();
+  // #645 (c): throttle the host epic/* branch scan — keyed `${repoPath}#${parentIssueNumber}`,
+  // refreshed at most every EPIC_BRANCH_SCAN_TTL_MS. In-memory only (ephemeral advisory warning;
+  // recomputing on restart is fine — no persisted column).
+  private epicBranchScanCache = new Map<string, { at: number; divergent: string[] }>();
   private lastEpicSig = new Map<string, string>();
   private approvedNext = new Set<string>();
   private now: () => number;
@@ -243,13 +256,31 @@ export class DrainService {
         prNumber: prSnap[x.id]?.number ?? null,
       }));
     const integrated = this.deps.store.listEpicIntegrated(repoPath, run.parentIssueNumber);
+    const parentTitle = struct.parent?.title ?? `#${run.parentIssueNumber}`;
+    // The pinned canonical name (#645) — divergence is measured against THIS, not the live title.
+    const persistedBranch = this.deps.store.getOrInitEpicIntegrationBranch(
+      repoPath,
+      run.parentIssueNumber,
+      epicBranchName(run.parentIssueNumber, parentTitle),
+    );
+    // (b) recorded merge base per integrated child (null bases — legacy rows — are skipped).
+    const integratedBases = new Map<number, string>();
+    for (const d of this.deps.store.listEpicIntegratedDetails(repoPath, run.parentIssueNumber)) {
+      if (d.mergedBase) integratedBases.set(d.childNumber, d.mergedBase);
+    }
+    // (c) throttled host scan for stray epic/* refs that reference this epic.
+    const divergentBranches = await this.scanDivergentEpicBranches(
+      repoPath,
+      run.parentIssueNumber,
+      persistedBranch,
+    );
     return assembleEpic({
       repoPath,
       run,
       integrated,
       parent: {
         number: run.parentIssueNumber,
-        title: struct.parent?.title ?? `#${run.parentIssueNumber}`,
+        title: parentTitle,
         body: struct.parent?.body ?? "",
       },
       subIssues: struct.subIssues,
@@ -257,7 +288,37 @@ export class DrainService {
       openIssues,
       openIssuesTruncated,
       sessions,
+      persistedBranch,
+      integratedBases,
+      divergentBranches,
     });
+  }
+
+  /** #645 (c): list host `epic/*` branches that reference `parentNumber` as a digit-bounded
+   *  token but are NOT the pinned branch — i.e. divergent epic branches. Throttled per epic
+   *  (EPIC_BRANCH_SCAN_TTL_MS) and best-effort: a forge without `listBranches` or a scan
+   *  failure yields the cached or empty list and never breaks buildEpic. */
+  private async scanDivergentEpicBranches(
+    repoPath: string,
+    parentNumber: number,
+    persistedBranch: string,
+  ): Promise<string[]> {
+    const forge = this.deps.resolveForge(repoPath);
+    if (!forge?.listBranches) return [];
+    const key = `${repoPath}#${parentNumber}`;
+    const cached = this.epicBranchScanCache.get(key);
+    if (cached && this.now() - cached.at < EPIC_BRANCH_SCAN_TTL_MS) return cached.divergent;
+    try {
+      const branches = await forge.listBranches("epic/");
+      const divergent = branches.filter(
+        (b) => b !== persistedBranch && branchReferencesEpic(b, parentNumber),
+      );
+      this.epicBranchScanCache.set(key, { at: this.now(), divergent });
+      return divergent;
+    } catch (err) {
+      console.warn(`[drain] epic-branch scan for #${parentNumber} failed:`, err);
+      return cached?.divergent ?? [];
+    }
   }
 
   /** Emit the epic only when something meaningful changed (de-dup by signature). */
@@ -851,10 +912,16 @@ export class DrainService {
         );
         return; // leave the session live; next tick retries. Do NOT record or archive.
       }
-      this.deps.store.recordEpicIntegrated(repoPath, epicRun!.parentIssueNumber, s.issueNumber, {
-        number: decision.prNumber,
-        url: this.deps.prCache.snapshot()[decision.sessionId]?.url ?? "",
-      });
+      this.deps.store.recordEpicIntegrated(
+        repoPath,
+        epicRun!.parentIssueNumber,
+        s.issueNumber,
+        {
+          number: decision.prNumber,
+          url: this.deps.prCache.snapshot()[decision.sessionId]?.url ?? "",
+        },
+        s.baseBranch, // #645 (b): the branch this child actually squash-merged into
+      );
       try {
         await this.deps.service.archive(decision.sessionId);
       } catch (err) {

--- a/src/epic-branch.ts
+++ b/src/epic-branch.ts
@@ -19,3 +19,13 @@ export function epicIntegrationBranch(parentNumber: number, parentTitle: string)
 export function isEpicIntegrationBranch(branch: string): boolean {
   return /^epic\/\d+(-[a-z0-9-]+)?$/.test(branch);
 }
+
+/** True iff `branch` references `parentNumber` as a digit-bounded token — the number
+ *  appears with a non-digit (or string edge) on both sides. Used by divergence detection
+ *  (#645) to decide whether a stray `epic/*` branch belongs to this epic, catching BOTH
+ *  the canonical `epic/<#>-<slug>` and a hand-named `epic/<slug>-<#>` while rejecting
+ *  numeric superstrings (`1327`, `3270`). Out of scope: a rogue epic branch that doesn't
+ *  carry the parent number at all. */
+export function branchReferencesEpic(branch: string, parentNumber: number): boolean {
+  return new RegExp(`(?:^|[^0-9])${parentNumber}(?:[^0-9]|$)`).test(branch);
+}

--- a/src/epic-migrations.ts
+++ b/src/epic-migrations.ts
@@ -1,0 +1,74 @@
+/**
+ * Migration-awareness detection (#645 learning #5).
+ *
+ * Epic child PRs often add DB migrations, but the harness never runs them (the critic is
+ * read-only and has no DB). So a landed epic may carry unrun migrations with no signal. This
+ * module is the PURE detection half: given the changed paths of the landing PR, it returns the
+ * subset that look like migration files, so the band can ask the operator to acknowledge them
+ * before clearing the row. NO I/O — the forge supplies the paths.
+ *
+ * Conservative + repo-agnostic on purpose: a tight glob set avoids false positives (a stray
+ * "migrations" mention in a code path would be worse than a missed one — this is an advisory
+ * nudge, not a gate that blocks completion).
+ */
+
+/**
+ * Single source of truth for what counts as a migration path. Kept deliberately tight:
+ * directory-scoped (`**\/migrations/**`, `**\/drizzle/**`, `**\/neo4j/**`, `**\/alembic/**`)
+ * plus the Cypher file extension. Add a family here (and nowhere else) to widen detection.
+ */
+export const MIGRATION_GLOBS: readonly string[] = [
+  "**/migrations/**",
+  "**/drizzle/**",
+  "**/*.cypher",
+  "**/neo4j/**",
+  "**/alembic/**",
+];
+
+/** Compile one glob to an anchored RegExp. Supports the only two wildcards we use:
+ *  `**` (any chars incl. `/`) and `*` (any chars except `/`). Every other char is literal. */
+function globToRegExp(glob: string): RegExp {
+  let re = "";
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i]!;
+    if (c === "*") {
+      if (glob[i + 1] === "*") {
+        // `**/` → zero or more leading path segments (the trailing `/` is optional, so a
+        // root-level `drizzle/…` still matches `**/drizzle/**`); a bare `**` → any chars.
+        if (glob[i + 2] === "/") {
+          re += "(?:.*/)?";
+          i += 2;
+        } else {
+          re += ".*"; // `**` → any chars, including `/`
+          i++;
+        }
+      } else {
+        re += "[^/]*"; // `*` → any chars except `/`
+      }
+    } else if (".+?^${}()|[]\\".includes(c)) {
+      re += "\\" + c; // escape regex metachars
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+const MIGRATION_MATCHERS: readonly RegExp[] = MIGRATION_GLOBS.map(globToRegExp);
+
+/**
+ * Return the subset of `paths` that match any {@link MIGRATION_GLOBS} pattern — deduped and
+ * order-preserving (first occurrence wins). Pure; no I/O. Empty input → empty output.
+ */
+export function detectMigrationPaths(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const path of paths) {
+    if (seen.has(path)) continue;
+    if (MIGRATION_MATCHERS.some((re) => re.test(path))) {
+      seen.add(path);
+      out.push(path);
+    }
+  }
+  return out;
+}

--- a/src/epic-model.ts
+++ b/src/epic-model.ts
@@ -43,6 +43,10 @@ export interface AssembleInput {
   /** Stray `epic/*` host branches that reference the parent number but are NOT the pinned
    *  branch (computed + throttled in drain.buildEpic). Each surfaces a warning (c). */
   divergentBranches?: string[];
+  /** (Task 2) children parked at retire because their PR targets a base other than the pinned
+   *  epic branch (`epic_base_mismatch`, read in drain.buildEpic). Each surfaces an actionable,
+   *  remedy-naming warning — the epic is BLOCKED until the operator re-targets the PR. */
+  baseMismatches?: { childNumber: number; actualBase: string; prNumber: number | null }[];
 }
 
 interface ResolvedGraph {
@@ -139,30 +143,7 @@ export function assembleEpic(input: AssembleInput): Epic {
     return child;
   });
 
-  // ── #645 epic-branch divergence warnings ──────────────────────────────────
-  // (a) title drift: the live title now derives a different canonical name than the pinned one.
-  const canonical = epicIntegrationBranch(input.parent.number, input.parent.title);
-  if (canonical !== input.persistedBranch) {
-    warnings.push(
-      `epic branch pinned to \`${input.persistedBranch}\`; current title derives \`${canonical}\` (title edited — children stay on the pinned branch)`,
-    );
-  }
-  // (b) integrated-child drift: a child squash-merged into a branch other than the pinned one.
-  if (input.integratedBases) {
-    for (const [n, base] of input.integratedBases) {
-      if (base && base !== input.persistedBranch) {
-        warnings.push(
-          `child #${n} merged into \`${base}\`, not the pinned \`${input.persistedBranch}\``,
-        );
-      }
-    }
-  }
-  // (c) host-branch drift: a stray epic/* ref references this epic but isn't the pinned branch.
-  for (const b of input.divergentBranches ?? []) {
-    warnings.push(
-      `divergent epic branch \`${b}\` references epic #${input.parent.number} but is not the pinned \`${input.persistedBranch}\``,
-    );
-  }
+  warnings.push(...divergenceWarnings(input));
 
   return {
     repoPath: input.repoPath,
@@ -173,4 +154,49 @@ export function assembleEpic(input: AssembleInput): Epic {
     warnings,
     run: input.run,
   };
+}
+
+/** #645 epic-branch divergence warnings (pure — the drain reads forge/store and passes the inputs
+ *  in). (a) live title now derives a different canonical name than the pinned branch; (b) an
+ *  integrated child squash-merged into a non-pinned base; (c) a stray host `epic/*` ref references
+ *  this epic; (Task 2) a child parked at retire because its PR targets the wrong base — the warning
+ *  names the exact remedy (`gh pr edit … --base <pinned>`) and the epic is blocked until fixed. */
+function divergenceWarnings(input: AssembleInput): string[] {
+  const out: string[] = [];
+  const pinned = input.persistedBranch;
+  // (a) title drift
+  const canonical = epicIntegrationBranch(input.parent.number, input.parent.title);
+  if (canonical !== pinned) {
+    out.push(
+      `epic branch pinned to \`${pinned}\`; current title derives \`${canonical}\` (title edited — children stay on the pinned branch)`,
+    );
+  }
+  // (b) integrated-child drift
+  for (const [n, base] of input.integratedBases ?? []) {
+    if (base && base !== pinned) {
+      out.push(`child #${n} merged into \`${base}\`, not the pinned \`${pinned}\``);
+    }
+  }
+  // (c) host-branch drift
+  for (const b of input.divergentBranches ?? []) {
+    out.push(
+      `divergent epic branch \`${b}\` references epic #${input.parent.number} but is not the pinned \`${pinned}\``,
+    );
+  }
+  // (Task 2) base-mismatch
+  for (const mm of input.baseMismatches ?? []) out.push(baseMismatchWarning(mm, pinned));
+  return out;
+}
+
+/** (Task 2) One actionable base-mismatch warning: names the wrong base + the exact `gh pr edit`
+ *  remedy (omitted when the PR number is unknown) and that the epic is blocked until re-targeted. */
+function baseMismatchWarning(
+  mm: { childNumber: number; actualBase: string; prNumber: number | null },
+  pinned: string,
+): string {
+  const pr = mm.prNumber != null ? ` #${mm.prNumber}` : "";
+  const edit =
+    mm.prNumber != null ? ` — re-target it (gh pr edit ${mm.prNumber} --base ${pinned})` : "";
+  const target = mm.actualBase ? `targets \`${mm.actualBase}\`` : "targets an unknown base";
+  return `child #${mm.childNumber} PR${pr} ${target}, not the epic branch \`${pinned}\`${edit} — epic blocked until fixed`;
 }

--- a/src/epic-model.ts
+++ b/src/epic-model.ts
@@ -1,5 +1,6 @@
 import { parseEpicBody } from "./epic-parse";
 import { deriveChildState, type Epic, type EpicChild, type EpicRun } from "./epic-core";
+import { epicIntegrationBranch } from "./epic-branch";
 import type { SubIssueRef } from "./forge/types";
 
 const ACTIVE_LABEL = "shepherd:active"; // mirror src/drain-core.ts
@@ -29,6 +30,19 @@ export interface AssembleInput {
   /** Child #s whose PR was squash-merged into the epic integration branch (persisted
    *  by the drain). Satisfies dependencies even though the issue is still open. */
   integrated: Set<number>;
+  /** #645 divergence detection inputs (all pure — the drain reads forge/store and passes
+   *  them in; assembleEpic does NO I/O). */
+  /** The pinned canonical integration-branch name (`epic_run.integrationBranch`). Drives
+   *  signals (a)/(b)/(c): a freshly-derived name, a child's recorded merge base, or a stray
+   *  host branch is "divergent" iff it differs from this. */
+  persistedBranch: string;
+  /** Per integrated-child recorded merge base (`epic_integrated.mergedBase`). A child whose
+   *  base is non-null and `!== persistedBranch` merged into the WRONG epic branch → warn (b).
+   *  Null/absent entries (legacy rows) never fire. */
+  integratedBases?: Map<number, string>;
+  /** Stray `epic/*` host branches that reference the parent number but are NOT the pinned
+   *  branch (computed + throttled in drain.buildEpic). Each surfaces a warning (c). */
+  divergentBranches?: string[];
 }
 
 interface ResolvedGraph {
@@ -124,6 +138,31 @@ export function assembleEpic(input: AssembleInput): Epic {
     child.state = deriveChildState(child, done);
     return child;
   });
+
+  // ── #645 epic-branch divergence warnings ──────────────────────────────────
+  // (a) title drift: the live title now derives a different canonical name than the pinned one.
+  const canonical = epicIntegrationBranch(input.parent.number, input.parent.title);
+  if (canonical !== input.persistedBranch) {
+    warnings.push(
+      `epic branch pinned to \`${input.persistedBranch}\`; current title derives \`${canonical}\` (title edited — children stay on the pinned branch)`,
+    );
+  }
+  // (b) integrated-child drift: a child squash-merged into a branch other than the pinned one.
+  if (input.integratedBases) {
+    for (const [n, base] of input.integratedBases) {
+      if (base && base !== input.persistedBranch) {
+        warnings.push(
+          `child #${n} merged into \`${base}\`, not the pinned \`${input.persistedBranch}\``,
+        );
+      }
+    }
+  }
+  // (c) host-branch drift: a stray epic/* ref references this epic but isn't the pinned branch.
+  for (const b of input.divergentBranches ?? []) {
+    warnings.push(
+      `divergent epic branch \`${b}\` references epic #${input.parent.number} but is not the pinned \`${input.persistedBranch}\``,
+    );
+  }
 
   return {
     repoPath: input.repoPath,

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -514,6 +514,17 @@ export class GithubForge implements GitForge {
     ]);
   }
 
+  /** Short-names of all branches matching `prefix` via the matching-refs API. Strips the
+   *  leading `refs/heads/`. Returns [] when none match (the endpoint 200s with an empty list). */
+  async listBranches(prefix: string): Promise<string[]> {
+    const out = await this.run(["api", `repos/${this.slug}/git/matching-refs/heads/${prefix}`]);
+    const refs = JSON.parse(out || "[]") as { ref?: string }[];
+    return refs
+      .map((r) => r.ref ?? "")
+      .filter((r) => r.startsWith("refs/heads/"))
+      .map((r) => r.slice("refs/heads/".length));
+  }
+
   private cachedUser: string | null | undefined;
   /** The authenticated gh login (`gh api user`), cached for the forge's lifetime —
    *  it never changes mid-session, so one call serves every handoff computation. */

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -806,6 +806,24 @@ export class GithubForge implements GitForge {
     }));
   }
 
+  async prChangedPaths(prNumber: number): Promise<string[]> {
+    const out = await this.run([
+      "pr",
+      "view",
+      String(prNumber),
+      "--repo",
+      this.slug,
+      "--json",
+      "files",
+      "--jq",
+      ".files[].path",
+    ]);
+    return out
+      .split("\n")
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+  }
+
   async prReviewMeta(prNumber: number): Promise<PrReviewMeta | null> {
     try {
       const out = await this.run([

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -308,6 +308,12 @@ export interface GitForge {
    *  responses to earlier review rounds. Optional: only hosts with a comments API
    *  implement it (GitHub); others omit it and no author notes are surfaced. */
   listPrComments?(prNumber: number): Promise<PrComment[]>;
+  /** The changed file paths of a PR (`gh pr view <n> --json files`). Used by the epic-landing
+   *  migration-awareness check (#645) to detect migration files carried by the landing PR.
+   *  Optional: only hosts with a PR-files API (GitHub) implement it; others omit it and the
+   *  migration check degrades to off (no chip). Best-effort; the caller wraps the call so a
+   *  failure never breaks the landing. */
+  prChangedPaths?(prNumber: number): Promise<string[]>;
   /** Number-keyed PR metadata for the standalone critic: body + base branch + fork flag +
    *  live state, via `gh pr view <number>`. Number-keyed so a recurring/fork head branch
    *  name can't resolve a different PR (unlike branch-keyed prStatus). Optional: only hosts

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -274,6 +274,11 @@ export interface GitForge {
   canPush?(): Promise<boolean>;
   /** The repo's default branch name (the promote PR's base). */
   defaultBranch(): Promise<string>;
+  /** Short-names of all host branches under `prefix` (e.g. `"epic/"`), `refs/heads/`
+   *  stripped. Used by epic-branch divergence detection (#645) to spot stray `epic/*`
+   *  branches that diverge from the pinned integration branch. Optional: only hosts with a
+   *  matching-refs API (GitHub) implement it; absent → divergence signal (c) degrades to off. */
+  listBranches?(prefix: string): Promise<string[]>;
   /** Ensure a branch exists on the host, creating it at `fromRef`'s tip when absent
    *  (idempotent; a present branch is left untouched — its tip is NOT reset). Used to
    *  cut an epic integration branch off the default branch. Optional: hosts without a

--- a/src/server.ts
+++ b/src/server.ts
@@ -3228,6 +3228,8 @@ async function backfillIdleEpic(
       landingPrNumber: null,
       landingPrUrl: null,
       landingState: "pending",
+      migrationPaths: [],
+      migrationsAckedAt: null,
     };
     deps.store.recordEpicCompleted({
       repoPath: completed.repoPath,
@@ -3339,6 +3341,35 @@ async function handleEpicsCompletedDismiss({ req, parts, deps }: Ctx): Promise<R
   return json({ ok: true });
 }
 
+// POST /api/epics/completed/ack-migrations — body { repo, parent }. Acknowledge the landing PR's
+// detected migrations (#645): stamps migrationsAckedAt + dismisses the row (one operator action,
+// clears the band). Mirrors the dismiss handler's validation + clear emit.
+async function handleEpicsCompletedAckMigrations({
+  req,
+  parts,
+  deps,
+}: Ctx): Promise<Response | null> {
+  if (
+    !(
+      req.method === "POST" &&
+      parts[0] === "api" &&
+      parts[1] === "epics" &&
+      parts[2] === "completed" &&
+      parts[3] === "ack-migrations"
+    )
+  )
+    return null;
+  const body = (await req.json().catch(() => null)) as { repo?: string; parent?: number } | null;
+  const dir = safeRepoDir(body?.repo ?? "", config.repoRoot);
+  if (!dir) return json({ error: "invalid repo" }, 400);
+  const parent = body?.parent;
+  if (typeof parent !== "number" || !Number.isInteger(parent) || parent <= 0)
+    return json({ error: "parent must be a positive integer" }, 400);
+  deps.store.ackEpicMigrations(dir, parent);
+  deps.events?.emit("epic:completed-cleared", { repoPath: dir, parentIssueNumber: parent });
+  return json({ ok: true });
+}
+
 // Ordered dispatch chain — preserves the original guard sequence verbatim.
 const ROUTE_HANDLERS = [
   handlePing,
@@ -3354,6 +3385,7 @@ const ROUTE_HANDLERS = [
   handleAutoMerge,
   handleEpicsList,
   handleEpicsCompletedDismiss,
+  handleEpicsCompletedAckMigrations,
   handleEpicsCompletedList,
   handleEpicApproveNext,
   handleEpicImport,

--- a/src/store.ts
+++ b/src/store.ts
@@ -407,6 +407,13 @@ export class SessionStore implements CapStore, CreditStore {
       landingAttempts INTEGER NOT NULL DEFAULT 0,
       PRIMARY KEY (repoPath, parentIssueNumber))`);
     this.migrateEpicCompletedColumns();
+    // #645: a child whose PR targets a base other than the pinned epic branch is parked here at
+    // retire (fail-closed: not merged, not integrated). Keyed per child; the row is the throttle
+    // anchor (bounds prReviewMeta to ≤1/child/~60s while stuck) and the assembleEpic warning source.
+    this.db.run(`CREATE TABLE IF NOT EXISTS epic_base_mismatch (
+      repoPath TEXT NOT NULL, parentIssueNumber INTEGER NOT NULL, childNumber INTEGER NOT NULL,
+      actualBase TEXT NOT NULL, prNumber INTEGER, checkedAt INTEGER NOT NULL,
+      PRIMARY KEY (repoPath, parentIssueNumber, childNumber))`);
     this.db.run(`CREATE TABLE IF NOT EXISTS push_subscriptions (
       endpoint TEXT PRIMARY KEY, p256dh TEXT NOT NULL, auth TEXT NOT NULL,
       ua TEXT NOT NULL DEFAULT '', locale TEXT NOT NULL DEFAULT 'en',
@@ -665,6 +672,69 @@ export class SessionStore implements CapStore, CreditStore {
       prUrl: string | null;
       mergedBase: string | null;
       mergedAt: number;
+    }[];
+  }
+
+  // ── epic base-mismatch markers (#645) ─────────────────────────────────────
+  /** Park a child whose PR targets the wrong base. Upsert — refreshes actualBase/prNumber/checkedAt
+   *  (checkedAt is the throttle anchor, so it must advance on every recheck). */
+  recordEpicBaseMismatch(
+    repoPath: string,
+    parentIssueNumber: number,
+    childNumber: number,
+    m: { actualBase: string; prNumber: number | null; checkedAt: number },
+  ): void {
+    this.db.run(
+      `INSERT INTO epic_base_mismatch (repoPath, parentIssueNumber, childNumber, actualBase, prNumber, checkedAt)
+       VALUES (?,?,?,?,?,?)
+       ON CONFLICT DO UPDATE SET
+         actualBase = excluded.actualBase,
+         prNumber = excluded.prNumber,
+         checkedAt = excluded.checkedAt`,
+      [repoPath, parentIssueNumber, childNumber, m.actualBase, m.prNumber, m.checkedAt],
+    );
+  }
+
+  /** Clear a child's base-mismatch marker (the PR was re-targeted / merged correctly). */
+  clearEpicBaseMismatch(repoPath: string, parentIssueNumber: number, childNumber: number): void {
+    this.db.run(
+      `DELETE FROM epic_base_mismatch WHERE repoPath = ? AND parentIssueNumber = ? AND childNumber = ?`,
+      [repoPath, parentIssueNumber, childNumber],
+    );
+  }
+
+  /** A single child's marker (or null) — drives the doRetire throttle read. */
+  getEpicBaseMismatch(
+    repoPath: string,
+    parentIssueNumber: number,
+    childNumber: number,
+  ): { actualBase: string; prNumber: number | null; checkedAt: number } | null {
+    return this.db
+      .query(
+        `SELECT actualBase, prNumber, checkedAt FROM epic_base_mismatch
+         WHERE repoPath = ? AND parentIssueNumber = ? AND childNumber = ?`,
+      )
+      .get(repoPath, parentIssueNumber, childNumber) as {
+      actualBase: string;
+      prNumber: number | null;
+      checkedAt: number;
+    } | null;
+  }
+
+  /** All parked children for one epic — fed into assembleEpic for the actionable warnings. */
+  listEpicBaseMismatches(
+    repoPath: string,
+    parentIssueNumber: number,
+  ): { childNumber: number; actualBase: string; prNumber: number | null }[] {
+    return this.db
+      .query(
+        `SELECT childNumber, actualBase, prNumber FROM epic_base_mismatch
+         WHERE repoPath = ? AND parentIssueNumber = ? ORDER BY childNumber`,
+      )
+      .all(repoPath, parentIssueNumber) as {
+      childNumber: number;
+      actualBase: string;
+      prNumber: number | null;
     }[];
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -390,6 +390,7 @@ export class SessionStore implements CapStore, CreditStore {
     this.db.run(`CREATE TABLE IF NOT EXISTS epic_run (
       repoPath TEXT PRIMARY KEY, parentIssueNumber INTEGER NOT NULL,
       mode TEXT NOT NULL DEFAULT 'auto', status TEXT NOT NULL DEFAULT 'idle', updatedAt INTEGER NOT NULL)`);
+    this.migrateEpicRunColumns();
     this.db.run(`CREATE TABLE IF NOT EXISTS epic_integrated (
       repoPath TEXT NOT NULL, parentIssueNumber INTEGER NOT NULL, childNumber INTEGER NOT NULL,
       createdAt INTEGER NOT NULL,
@@ -576,6 +577,31 @@ export class SessionStore implements CapStore, CreditStore {
       ON CONFLICT(repoPath) DO UPDATE SET parentIssueNumber=excluded.parentIssueNumber, mode=excluded.mode, status=excluded.status, updatedAt=excluded.updatedAt`,
       [r.repoPath, r.parentIssueNumber, r.mode, r.status, Date.now()],
     );
+  }
+
+  /** Single source of truth for an epic's pinned integration-branch name (#645).
+   *  The name is derived from the parent title, but the title can be edited mid-run —
+   *  re-deriving everywhere would re-point new spawns + the landing base, orphaning
+   *  children already merged on the old branch. So we pin it once and read it forever:
+   *   - row exists with a non-null `integrationBranch` → return the pinned value;
+   *   - row exists but unpinned → lazily pin `derived` and return it;
+   *   - no row exists → return `derived` WITHOUT persisting (best-effort; there is no
+   *     row to write into — the caller is deriving outside an active epic run). */
+  getOrInitEpicIntegrationBranch(
+    repoPath: string,
+    parentIssueNumber: number,
+    derived: string,
+  ): string {
+    const row = this.db
+      .query(`SELECT integrationBranch FROM epic_run WHERE repoPath = ?`)
+      .get(repoPath) as { integrationBranch: string | null } | null;
+    if (!row) return derived; // no epic_run row → nothing to pin into; best-effort derive
+    if (row.integrationBranch != null) return row.integrationBranch; // already pinned
+    this.db.run(`UPDATE epic_run SET integrationBranch = ? WHERE repoPath = ?`, [
+      derived,
+      repoPath,
+    ]);
+    return derived;
   }
 
   /** Record that a child PR was squash-merged into the epic integration branch.
@@ -1555,6 +1581,16 @@ export class SessionStore implements CapStore, CreditStore {
     add("defaultModel", `defaultModel TEXT NOT NULL DEFAULT 'inherit'`);
     // per-repo egress extra-hosts: JSON-encoded string array (nullable, default []).
     add("egressExtraHosts", `egressExtraHosts TEXT`);
+  }
+
+  // The pinned canonical integration-branch name (#645). Nullable: existing rows backfill
+  // to NULL and lazy-pin on first use; rows that predate the epic-runner had no name to pin.
+  private migrateEpicRunColumns(): void {
+    const cols = this.db.query(`PRAGMA table_info(epic_run)`).all() as { name: string }[];
+    const add = (name: string, ddl: string) => {
+      if (!cols.some((c) => c.name === name)) this.db.run(`ALTER TABLE epic_run ADD COLUMN ${ddl}`);
+    };
+    add("integrationBranch", `integrationBranch TEXT`);
   }
 
   private migrateEpicIntegratedColumns(): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -390,7 +390,14 @@ export class SessionStore implements CapStore, CreditStore {
     this.db.run(`CREATE TABLE IF NOT EXISTS epic_run (
       repoPath TEXT PRIMARY KEY, parentIssueNumber INTEGER NOT NULL,
       mode TEXT NOT NULL DEFAULT 'auto', status TEXT NOT NULL DEFAULT 'idle', updatedAt INTEGER NOT NULL)`);
-    this.migrateEpicRunColumns();
+    // #645: the pinned integration-branch name, keyed PER EPIC (repoPath, parentIssueNumber)
+    // — NOT on epic_run, which is one-row-per-repo and superseded when a new epic starts on that
+    // repo, so a pin stored there would be inherited by the next epic and would outlive its own
+    // epic's landing. A dedicated row per epic stays correct across supersession + into landing.
+    this.db.run(`CREATE TABLE IF NOT EXISTS epic_branch (
+      repoPath TEXT NOT NULL, parentIssueNumber INTEGER NOT NULL,
+      branch TEXT NOT NULL,
+      PRIMARY KEY (repoPath, parentIssueNumber))`);
     this.db.run(`CREATE TABLE IF NOT EXISTS epic_integrated (
       repoPath TEXT NOT NULL, parentIssueNumber INTEGER NOT NULL, childNumber INTEGER NOT NULL,
       createdAt INTEGER NOT NULL,
@@ -586,28 +593,29 @@ export class SessionStore implements CapStore, CreditStore {
     );
   }
 
-  /** Single source of truth for an epic's pinned integration-branch name (#645).
-   *  The name is derived from the parent title, but the title can be edited mid-run —
-   *  re-deriving everywhere would re-point new spawns + the landing base, orphaning
-   *  children already merged on the old branch. So we pin it once and read it forever:
-   *   - row exists with a non-null `integrationBranch` → return the pinned value;
-   *   - row exists but unpinned → lazily pin `derived` and return it;
-   *   - no row exists → return `derived` WITHOUT persisting (best-effort; there is no
-   *     row to write into — the caller is deriving outside an active epic run). */
+  /** Single source of truth for an epic's pinned integration-branch name (#645), keyed
+   *  PER EPIC `(repoPath, parentIssueNumber)`. The name derives from the parent title, but
+   *  the title can be edited mid-run — re-deriving everywhere would re-point new spawns +
+   *  the landing base and orphan children already merged on the old branch. So we pin it
+   *  once on first sight and read it forever: an existing pin is returned as-is; otherwise
+   *  `derived` is persisted for THIS epic and returned. Per-epic keying is load-bearing —
+   *  `epic_run` is one-row-per-repo and superseded when a new epic starts, so a repo-scoped
+   *  pin would be inherited by the next epic and would be wrong for a superseded epic's
+   *  still-pending landing PR. */
   getOrInitEpicIntegrationBranch(
     repoPath: string,
     parentIssueNumber: number,
     derived: string,
   ): string {
     const row = this.db
-      .query(`SELECT integrationBranch FROM epic_run WHERE repoPath = ?`)
-      .get(repoPath) as { integrationBranch: string | null } | null;
-    if (!row) return derived; // no epic_run row → nothing to pin into; best-effort derive
-    if (row.integrationBranch != null) return row.integrationBranch; // already pinned
-    this.db.run(`UPDATE epic_run SET integrationBranch = ? WHERE repoPath = ?`, [
-      derived,
-      repoPath,
-    ]);
+      .query(`SELECT branch FROM epic_branch WHERE repoPath = ? AND parentIssueNumber = ?`)
+      .get(repoPath, parentIssueNumber) as { branch: string } | null;
+    if (row) return row.branch; // already pinned for this epic
+    this.db.run(
+      `INSERT INTO epic_branch (repoPath, parentIssueNumber, branch) VALUES (?,?,?)
+       ON CONFLICT(repoPath, parentIssueNumber) DO NOTHING`,
+      [repoPath, parentIssueNumber, derived],
+    );
     return derived;
   }
 
@@ -1682,16 +1690,6 @@ export class SessionStore implements CapStore, CreditStore {
     add("defaultModel", `defaultModel TEXT NOT NULL DEFAULT 'inherit'`);
     // per-repo egress extra-hosts: JSON-encoded string array (nullable, default []).
     add("egressExtraHosts", `egressExtraHosts TEXT`);
-  }
-
-  // The pinned canonical integration-branch name (#645). Nullable: existing rows backfill
-  // to NULL and lazy-pin on first use; rows that predate the epic-runner had no name to pin.
-  private migrateEpicRunColumns(): void {
-    const cols = this.db.query(`PRAGMA table_info(epic_run)`).all() as { name: string }[];
-    const add = (name: string, ddl: string) => {
-      if (!cols.some((c) => c.name === name)) this.db.run(`ALTER TABLE epic_run ADD COLUMN ${ddl}`);
-    };
-    add("integrationBranch", `integrationBranch TEXT`);
   }
 
   private migrateEpicIntegratedColumns(): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -613,14 +613,24 @@ export class SessionStore implements CapStore, CreditStore {
     parentIssueNumber: number,
     childNumber: number,
     pr?: { number: number; url: string },
+    mergedBase?: string,
   ): void {
     this.db.run(
-      `INSERT INTO epic_integrated (repoPath, parentIssueNumber, childNumber, createdAt, prNumber, prUrl)
-       VALUES (?,?,?,?,?,?)
+      `INSERT INTO epic_integrated (repoPath, parentIssueNumber, childNumber, createdAt, prNumber, prUrl, mergedBase)
+       VALUES (?,?,?,?,?,?,?)
        ON CONFLICT DO UPDATE SET
          prNumber = COALESCE(excluded.prNumber, epic_integrated.prNumber),
-         prUrl = COALESCE(NULLIF(excluded.prUrl, ''), epic_integrated.prUrl)`,
-      [repoPath, parentIssueNumber, childNumber, Date.now(), pr?.number ?? null, pr?.url ?? null],
+         prUrl = COALESCE(NULLIF(excluded.prUrl, ''), epic_integrated.prUrl),
+         mergedBase = COALESCE(excluded.mergedBase, epic_integrated.mergedBase)`,
+      [
+        repoPath,
+        parentIssueNumber,
+        childNumber,
+        Date.now(),
+        pr?.number ?? null,
+        pr?.url ?? null,
+        mergedBase ?? null,
+      ],
     );
   }
 
@@ -636,10 +646,16 @@ export class SessionStore implements CapStore, CreditStore {
   listEpicIntegratedDetails(
     repoPath: string,
     parentIssueNumber: number,
-  ): { childNumber: number; prNumber: number | null; prUrl: string | null; mergedAt: number }[] {
+  ): {
+    childNumber: number;
+    prNumber: number | null;
+    prUrl: string | null;
+    mergedBase: string | null;
+    mergedAt: number;
+  }[] {
     return this.db
       .query(
-        `SELECT childNumber, prNumber, prUrl, createdAt AS mergedAt
+        `SELECT childNumber, prNumber, prUrl, mergedBase, createdAt AS mergedAt
          FROM epic_integrated WHERE repoPath = ? AND parentIssueNumber = ?
          ORDER BY childNumber`,
       )
@@ -647,6 +663,7 @@ export class SessionStore implements CapStore, CreditStore {
       childNumber: number;
       prNumber: number | null;
       prUrl: string | null;
+      mergedBase: string | null;
       mergedAt: number;
     }[];
   }
@@ -1601,6 +1618,9 @@ export class SessionStore implements CapStore, CreditStore {
     };
     add("prNumber", `prNumber INTEGER`);
     add("prUrl", `prUrl TEXT`);
+    // #645: the branch the child actually squash-merged into. Nullable — pre-existing rows
+    // backfill to NULL and never fire divergence warnings (forward-looking only; no backfill).
+    add("mergedBase", `mergedBase TEXT`);
   }
 
   private migrateEpicCompletedColumns(): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -842,8 +842,9 @@ export class SessionStore implements CapStore, CreditStore {
   }
 
   /** Acknowledge a completed epic's landing-PR migrations (#645): stamp `migrationsAckedAt` AND
-   *  dismiss the row — one operator action both records the acknowledgement durably (so it isn't
-   *  re-prompted on a re-record) and clears the band. */
+   *  dismiss the row in one operator action. `migrationsAckedAt` is the durable audit record of
+   *  WHEN the human acknowledged; the coupled `dismissedAt` is what actually clears the band and
+   *  prevents a re-prompt (listEpicCompleted filters `dismissedAt IS NULL`). */
   ackEpicMigrations(repoPath: string, parentIssueNumber: number): void {
     const now = Date.now();
     this.db.run(
@@ -1718,9 +1719,13 @@ export class SessionStore implements CapStore, CreditStore {
     add("landingPrUrl", `landingPrUrl TEXT`);
     add("landingState", `landingState TEXT NOT NULL DEFAULT 'pending'`);
     add("landingAttempts", `landingAttempts INTEGER NOT NULL DEFAULT 0`);
-    // Migration-awareness checkpoint (#645): paths of migration files detected in the landing
-    // PR (JSON array) + the epoch the operator acknowledged them. Both nullable: absence = no
-    // detection ran / nothing to acknowledge.
+    // Migration-awareness checkpoint (#645). migrationPathsJson: paths of migration files
+    // detected in the landing PR (JSON array). migrationsAckedAt: a durable audit timestamp
+    // recording WHEN a human acknowledged those migrations — written alongside dismissedAt by
+    // ackEpicMigrations. It is a record, NOT a gate: re-prompt suppression is the coupled
+    // dismissedAt (listEpicCompleted filters `dismissedAt IS NULL`), so an acked row is hidden
+    // by the dismiss, never by this column. Both nullable: absence = no detection ran / not
+    // yet acknowledged.
     add("migrationPathsJson", `migrationPathsJson TEXT`);
     add("migrationsAckedAt", `migrationsAckedAt INTEGER`);
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -780,35 +780,14 @@ export class SessionStore implements CapStore, CreditStore {
     landingPrUrl: string | null;
     landingState: EpicLandingState;
     landingAttempts: number;
+    migrationPaths: string[];
+    migrationsAckedAt: number | null;
   }[] {
-    if (repoPath !== undefined) {
-      return this.db
-        .query(
-          `SELECT repoPath, parentIssueNumber, parentTitle, completedAt, childrenJson,
-                  landingPrNumber, landingPrUrl, landingState, landingAttempts
-           FROM epic_completed WHERE dismissedAt IS NULL AND repoPath = ?
-           ORDER BY completedAt DESC`,
-        )
-        .all(repoPath) as {
-        repoPath: string;
-        parentIssueNumber: number;
-        parentTitle: string;
-        completedAt: number;
-        childrenJson: string;
-        landingPrNumber: number | null;
-        landingPrUrl: string | null;
-        landingState: EpicLandingState;
-        landingAttempts: number;
-      }[];
-    }
-    return this.db
-      .query(
-        `SELECT repoPath, parentIssueNumber, parentTitle, completedAt, childrenJson,
-                landingPrNumber, landingPrUrl, landingState, landingAttempts
-         FROM epic_completed WHERE dismissedAt IS NULL
-         ORDER BY completedAt DESC`,
-      )
-      .all() as {
+    const sql = `SELECT repoPath, parentIssueNumber, parentTitle, completedAt, childrenJson,
+                landingPrNumber, landingPrUrl, landingState, landingAttempts,
+                migrationPathsJson, migrationsAckedAt
+         FROM epic_completed WHERE dismissedAt IS NULL`;
+    type Raw = {
       repoPath: string;
       parentIssueNumber: number;
       parentTitle: string;
@@ -818,7 +797,19 @@ export class SessionStore implements CapStore, CreditStore {
       landingPrUrl: string | null;
       landingState: EpicLandingState;
       landingAttempts: number;
-    }[];
+      migrationPathsJson: string | null;
+      migrationsAckedAt: number | null;
+    };
+    const rows =
+      repoPath !== undefined
+        ? (this.db
+            .query(`${sql} AND repoPath = ? ORDER BY completedAt DESC`)
+            .all(repoPath) as Raw[])
+        : (this.db.query(`${sql} ORDER BY completedAt DESC`).all() as Raw[]);
+    return rows.map(({ migrationPathsJson, ...rest }) => ({
+      ...rest,
+      migrationPaths: parseFindings(migrationPathsJson),
+    }));
   }
 
   /** Write the Stage B (#635) landing-PR resolution onto a completed epic.
@@ -837,6 +828,28 @@ export class SessionStore implements CapStore, CreditStore {
       `UPDATE epic_completed SET landingState = ?, landingPrNumber = ?, landingPrUrl = ?, landingAttempts = ?
        WHERE repoPath = ? AND parentIssueNumber = ?`,
       [fields.state, fields.prNumber, fields.prUrl, fields.attempts, repoPath, parentIssueNumber],
+    );
+  }
+
+  /** Persist the migration paths detected in a completed epic's landing PR (#645). Stored as a
+   *  JSON array; an empty array clears any prior detection. Direct UPDATE, mirroring
+   *  {@link setEpicLandingPr}'s style. */
+  setEpicMigrationPaths(repoPath: string, parentIssueNumber: number, paths: string[]): void {
+    this.db.run(
+      `UPDATE epic_completed SET migrationPathsJson = ? WHERE repoPath = ? AND parentIssueNumber = ?`,
+      [JSON.stringify(paths), repoPath, parentIssueNumber],
+    );
+  }
+
+  /** Acknowledge a completed epic's landing-PR migrations (#645): stamp `migrationsAckedAt` AND
+   *  dismiss the row — one operator action both records the acknowledgement durably (so it isn't
+   *  re-prompted on a re-record) and clears the band. */
+  ackEpicMigrations(repoPath: string, parentIssueNumber: number): void {
+    const now = Date.now();
+    this.db.run(
+      `UPDATE epic_completed SET migrationsAckedAt = ?, dismissedAt = ?
+       WHERE repoPath = ? AND parentIssueNumber = ?`,
+      [now, now, repoPath, parentIssueNumber],
     );
   }
 
@@ -1705,6 +1718,11 @@ export class SessionStore implements CapStore, CreditStore {
     add("landingPrUrl", `landingPrUrl TEXT`);
     add("landingState", `landingState TEXT NOT NULL DEFAULT 'pending'`);
     add("landingAttempts", `landingAttempts INTEGER NOT NULL DEFAULT 0`);
+    // Migration-awareness checkpoint (#645): paths of migration files detected in the landing
+    // PR (JSON array) + the epoch the operator acknowledged them. Both nullable: absence = no
+    // detection ran / nothing to acknowledge.
+    add("migrationPathsJson", `migrationPathsJson TEXT`);
+    add("migrationsAckedAt", `migrationsAckedAt INTEGER`);
   }
 
   private migrateReviewColumns(): void {

--- a/test/drain-epic-divergence.test.ts
+++ b/test/drain-epic-divergence.test.ts
@@ -18,6 +18,7 @@ const NO_USAGE: UsageLimitsType = {
   credits: null,
   stale: false,
   calibratedAt: null,
+  subscriptionOnly: false,
 };
 
 type BranchesRef = { branches: string[]; calls: number; throws?: boolean };
@@ -104,7 +105,7 @@ function makeHarness(branchesRef: BranchesRef, clock: { t: number }) {
           auto: input.auto ?? false,
           issueNumber: input.issueRef?.number ?? null,
         }),
-      archive: (id: string): number => {
+      archive: async (id: string): Promise<number> => {
         store.archive(id);
         return 1;
       },

--- a/test/drain-epic-divergence.test.ts
+++ b/test/drain-epic-divergence.test.ts
@@ -1,0 +1,201 @@
+import { test, expect, describe } from "bun:test";
+import { DrainService } from "../src/drain";
+import { SessionStore } from "../src/store";
+import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
+import type { CreateSessionInput, Session } from "../src/types";
+import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
+
+// #645 (c): drain.buildEpic scans the host for stray epic/* branches, throttled per epic,
+// and surfaces each divergent branch (references the parent number, != pinned) as a warning.
+
+const REPO = "/repo";
+const PARENT = 327;
+const PINNED = "epic/327-efi-cluster";
+
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+};
+
+type BranchesRef = { branches: string[]; calls: number; throws?: boolean };
+
+function fakeForge(branchesRef: BranchesRef): GitForge {
+  return {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
+    openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
+    defaultBranch: async () => "main",
+    merge: async () => {},
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    getIssue: async (n: number): Promise<Issue | null> =>
+      n === PARENT
+        ? {
+            number: PARENT,
+            title: "EFI cluster",
+            body: "epic body",
+            url: `https://x/${PARENT}`,
+            labels: [],
+            createdAt: 0,
+          }
+        : null,
+    listSubIssues: async (n: number): Promise<SubIssueRef[]> =>
+      n === PARENT
+        ? [{ number: 320, title: "A", url: "u320", body: "", closed: false, labels: [] }]
+        : [],
+    listBlockedBy: async () => [],
+    ensureBranch: async () => {},
+    listBranches: async (prefix: string): Promise<string[]> => {
+      branchesRef.calls++;
+      if (branchesRef.throws) throw new Error("listBranches boom");
+      return prefix === "epic/" ? branchesRef.branches : [];
+    },
+  };
+}
+
+function makeHarness(branchesRef: BranchesRef, clock: { t: number }) {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: true,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 5,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+  });
+  store.setEpicRun({ repoPath: REPO, parentIssueNumber: PARENT, mode: "auto", status: "running" });
+  // Pin the canonical name up front so divergence is measured against PINNED.
+  store.getOrInitEpicIntegrationBranch(REPO, PARENT, PINNED);
+
+  const forge = fakeForge(branchesRef);
+  const drain = new DrainService({
+    store,
+    service: {
+      create: async (input: CreateSessionInput): Promise<Session> =>
+        store.create({
+          name: "auto",
+          prompt: input.prompt,
+          repoPath: input.repoPath,
+          baseBranch: input.baseBranch,
+          branch: `shepherd/auto-${input.issueRef?.number ?? "x"}`,
+          worktreePath: "/wt",
+          isolated: true,
+          herdrSession: "default",
+          herdrAgentId: "t",
+          auto: input.auto ?? false,
+          issueNumber: input.issueRef?.number ?? null,
+        }),
+      archive: (id: string): number => {
+        store.archive(id);
+        return 1;
+      },
+    },
+    resolveForge: () => forge,
+    prCache: { snapshot: () => ({}) as Record<string, GitState> },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    now: () => clock.t,
+    emitStatus: () => {},
+    emitArchived: () => {},
+    dropPrCache: () => {},
+  });
+  return { store, drain };
+}
+
+describe("epic-branch host divergence scan (#645 signal c)", () => {
+  test("surfaces a divergent host branch + throttles the scan across builds", async () => {
+    const branchesRef = {
+      branches: [PINNED, "epic/efi-valuemap-327", "epic/1327-x"],
+      calls: 0,
+    };
+    const clock = { t: 1_000 };
+    const { store, drain } = makeHarness(branchesRef, clock);
+    const run = store.getEpicRun(REPO)!;
+
+    const e1 = await drain.buildEpic(REPO, run);
+    expect(e1).not.toBeNull();
+    // efi-valuemap-327 references 327 and != pinned → warned; 1327 is a numeric superstring → not.
+    const divWarn = e1!.warnings.filter((w) => w.includes("divergent epic branch"));
+    expect(divWarn).toHaveLength(1);
+    expect(divWarn[0]).toContain("epic/efi-valuemap-327");
+    expect(divWarn[0]).not.toContain("1327");
+    expect(branchesRef.calls).toBe(1);
+
+    // Second build within the TTL reuses the cache — no extra forge call.
+    await drain.buildEpic(REPO, run);
+    expect(branchesRef.calls).toBe(1);
+
+    // Past the TTL → re-scans.
+    clock.t += 6 * 60_000;
+    await drain.buildEpic(REPO, run);
+    expect(branchesRef.calls).toBe(2);
+  });
+
+  test("aligned host (only the pinned branch) → no divergence warning", async () => {
+    const branchesRef = { branches: [PINNED], calls: 0 };
+    const { store, drain } = makeHarness(branchesRef, { t: 0 });
+    const run = store.getEpicRun(REPO)!;
+    const e = await drain.buildEpic(REPO, run);
+    expect(e!.warnings.some((w) => w.includes("divergent epic branch"))).toBe(false);
+  });
+
+  test("scan failure with no prior cache → empty list, buildEpic still succeeds", async () => {
+    // listBranches throws on the very first call → the (c) scan falls back to [],
+    // buildEpic does not throw, and no divergence warning is surfaced.
+    const branchesRef = { branches: [PINNED, "epic/efi-valuemap-327"], calls: 0, throws: true };
+    const { store, drain } = makeHarness(branchesRef, { t: 0 });
+    const run = store.getEpicRun(REPO)!;
+
+    const e = await drain.buildEpic(REPO, run);
+    expect(e).not.toBeNull();
+    expect(branchesRef.calls).toBe(1);
+    // No cache to fall back to → empty → no (c) warning, while the epic itself still builds.
+    expect(e!.warnings.some((w) => w.includes("divergent epic branch"))).toBe(false);
+    expect(e!.parentIssueNumber).toBe(PARENT);
+  });
+
+  test("scan failure past the TTL → reuses the stale cached divergent list", async () => {
+    // First a clean scan populates the cache with a divergent branch (warning present).
+    const branchesRef = {
+      branches: [PINNED, "epic/efi-valuemap-327"],
+      calls: 0,
+      throws: false,
+    };
+    const clock = { t: 1_000 };
+    const { store, drain } = makeHarness(branchesRef, clock);
+    const run = store.getEpicRun(REPO)!;
+
+    const e1 = await drain.buildEpic(REPO, run);
+    expect(e1!.warnings.filter((w) => w.includes("divergent epic branch"))).toHaveLength(1);
+    expect(branchesRef.calls).toBe(1);
+
+    // Past the TTL the scan re-fires, but now listBranches throws → the cached
+    // divergent list is reused, so the (c) warning persists rather than vanishing.
+    branchesRef.throws = true;
+    clock.t += 6 * 60_000;
+    const e2 = await drain.buildEpic(REPO, run);
+    expect(branchesRef.calls).toBe(2); // re-scan was attempted (past TTL)
+    const divWarn = e2!.warnings.filter((w) => w.includes("divergent epic branch"));
+    expect(divWarn).toHaveLength(1);
+    expect(divWarn[0]).toContain("epic/efi-valuemap-327");
+  });
+});

--- a/test/drain-epic-landing.test.ts
+++ b/test/drain-epic-landing.test.ts
@@ -43,6 +43,9 @@ function fakeForge(opts: {
   subIssues: SubIssueRef[];
   prStatus?: (head: string) => Promise<PrStatus>;
   openPr?: (o: OpenPrInput) => Promise<PrStatus>;
+  /** When provided, the forge exposes prChangedPaths (GitHub-like); omit to model a host
+   *  without it (Gitea) — detection then degrades to off. */
+  prChangedPaths?: (prNumber: number) => Promise<string[]>;
 }): ForgeSpy {
   const openPrCalls: OpenPrInput[] = [];
   const prStatusCalls: string[] = [];
@@ -88,6 +91,7 @@ function fakeForge(opts: {
         : null,
     listSubIssues: async () => opts.subIssues,
     listBlockedBy: async () => [],
+    ...(opts.prChangedPaths ? { prChangedPaths: opts.prChangedPaths } : {}),
   };
   return { forge, openPrCalls, prStatusCalls };
 }
@@ -103,6 +107,7 @@ function makeHarness(opts: {
   subIssues: SubIssueRef[];
   prStatus?: (head: string) => Promise<PrStatus>;
   openPr?: (o: OpenPrInput) => Promise<PrStatus>;
+  prChangedPaths?: (prNumber: number) => Promise<string[]>;
   /** Skip recording the running epic_run row (e.g. testing tick() in isolation). */
   noEpicRun?: boolean;
   autoDrainEnabled?: boolean;
@@ -529,5 +534,116 @@ describe("ensureLandingPr — open + track the epic→default landing PR (#635)"
     expect(row.landingState).toBe("open");
     expect(row.landingPrNumber).toBe(808);
     expect(h.spy.openPrCalls).toHaveLength(1); // still exactly one
+  });
+});
+
+describe("migration-awareness checkpoint at landing-open (#645)", () => {
+  const openWith = (number: number) => async () => ({
+    state: "open" as const,
+    number,
+    url: `https://github.com/o/r/pull/${number}`,
+    checks: "none" as const,
+    deployConfigured: false,
+  });
+
+  test("landing PR with migration files → paths persisted on the row + emitted", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      openPr: openWith(555),
+      prChangedPaths: async () => [
+        "src/foo.ts",
+        "server/migrations/001_init.sql",
+        "drizzle/0001.sql",
+        "README.md",
+      ],
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.migrationPaths).toEqual(["server/migrations/001_init.sql", "drizzle/0001.sql"]);
+    expect(row.migrationsAckedAt).toBe(null);
+    // the latest emit carries the detected paths so the chip appears live
+    expect(h.completedEmits.at(-1)!.migrationPaths).toEqual([
+      "server/migrations/001_init.sql",
+      "drizzle/0001.sql",
+    ]);
+  });
+
+  test("landing PR with NO migration files → no paths persisted", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      openPr: openWith(556),
+      prChangedPaths: async () => ["src/foo.ts", "ui/src/lib/api.ts", "README.md"],
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.migrationPaths).toEqual([]);
+  });
+
+  test("forge WITHOUT prChangedPaths (Gitea) → no paths, landing unaffected", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      openPr: openWith(557),
+      // no prChangedPaths → detection degrades to off
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.landingPrNumber).toBe(557);
+    expect(row.migrationPaths).toEqual([]);
+  });
+
+  test("prChangedPaths THROWS → landing still succeeds (fail-safe), no paths", async () => {
+    // console.warn "[drain] migration detection skipped…" is expected.
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      openPr: openWith(558),
+      prChangedPaths: async () => {
+        throw new Error("gh files down");
+      },
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open"); // landing unaffected by the detection failure
+    expect(row.landingPrNumber).toBe(558);
+    expect(row.migrationPaths).toEqual([]);
+  });
+
+  test("completion flip is INDEPENDENT of migrations: run goes idle even with migration files", async () => {
+    const h = makeHarness({
+      subIssues: [sub(320, false), sub(321, true)],
+      openPr: openWith(700),
+      prChangedPaths: async () => ["server/migrations/001.sql"],
+    });
+    h.store.recordEpicIntegrated(REPO, PARENT, 320, {
+      number: 9001,
+      url: "https://github.com/o/r/pull/9001",
+    });
+
+    await h.drain.pump(REPO);
+
+    // The autonomous running→idle flip happened regardless of the (unacknowledged) migrations.
+    expect(h.store.getEpicRun(REPO)?.status).toBe("idle");
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.migrationPaths).toEqual(["server/migrations/001.sql"]);
+    expect(row.migrationsAckedAt).toBe(null); // detected but NOT acknowledged — yet idle anyway
   });
 });

--- a/test/drain-epic-pin-branch.test.ts
+++ b/test/drain-epic-pin-branch.test.ts
@@ -19,6 +19,7 @@ const NO_USAGE: UsageLimitsType = {
   credits: null,
   stale: false,
   calibratedAt: null,
+  subscriptionOnly: false,
 };
 
 interface ForgeRec {
@@ -123,7 +124,7 @@ function makeHarness(parentTitleRef: { title: string }, subIssues: SubIssueRef[]
         issueNumber: input.issueRef?.number ?? null,
       });
     },
-    archive: (id: string): number => {
+    archive: async (id: string): Promise<number> => {
       store.archive(id);
       return 1;
     },

--- a/test/drain-epic-pin-branch.test.ts
+++ b/test/drain-epic-pin-branch.test.ts
@@ -1,0 +1,182 @@
+import { test, expect, describe } from "bun:test";
+import { DrainService, type DrainStatus } from "../src/drain";
+import { SessionStore } from "../src/store";
+import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
+import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
+import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
+import type { Epic } from "../src/epic-core";
+
+// #645 regression: the integration-branch name is pinned on first use and read everywhere,
+// so editing the epic's parent title mid-run must NOT re-point new child spawns (or, by the
+// same token, the landing base). Without the pin, both follow the live title's fresh slug,
+// orphaning children already merged on the original branch.
+
+const REPO = "/repo";
+
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+};
+
+interface ForgeRec {
+  ensured: { branch: string; fromRef: string }[];
+}
+
+function fakeForge(
+  rec: ForgeRec,
+  opts: {
+    getIssue: (n: number) => Promise<Issue | null>;
+    listSubIssues: (parentNumber: number) => Promise<SubIssueRef[]>;
+    listBlockedBy: (issueNumber: number) => Promise<number[]>;
+  },
+): GitForge {
+  return {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
+    openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
+    defaultBranch: async () => "main",
+    merge: async () => {},
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    closeIssue: async () => {},
+    ensureIssueLink: async () => {},
+    addIssueLabel: async () => {},
+    removeIssueLabel: async () => {},
+    getIssue: opts.getIssue,
+    listSubIssues: opts.listSubIssues,
+    listBlockedBy: opts.listBlockedBy,
+    ensureBranch: async (branch: string, fromRef: string) => {
+      rec.ensured.push({ branch, fromRef });
+    },
+  };
+}
+
+function makeHarness(parentTitleRef: { title: string }, subIssues: SubIssueRef[]) {
+  const PARENT = 327;
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: true,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 5,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+  });
+  store.setEpicRun({ repoPath: REPO, parentIssueNumber: PARENT, mode: "auto", status: "running" });
+
+  const rec: ForgeRec = { ensured: [] };
+  const forge = fakeForge(rec, {
+    getIssue: async (n) =>
+      n === PARENT
+        ? {
+            number: PARENT,
+            title: parentTitleRef.title,
+            body: "epic body",
+            url: `https://x/${PARENT}`,
+            labels: [],
+            createdAt: 0,
+          }
+        : null,
+    listSubIssues: async (n) => (n === PARENT ? subIssues : []),
+    listBlockedBy: async () => [],
+  });
+
+  const prCache: Record<string, GitState> = {};
+  const reviews: Record<string, { decision: ReviewDecision; headSha: string }> = {};
+  const creates: CreateSessionInput[] = [];
+  const statuses: DrainStatus[] = [];
+  const epics: Epic[] = [];
+
+  const service = {
+    create: async (input: CreateSessionInput): Promise<Session> => {
+      creates.push(input);
+      return store.create({
+        name: "auto",
+        prompt: input.prompt,
+        repoPath: input.repoPath,
+        baseBranch: input.baseBranch,
+        branch: `shepherd/auto-${input.issueRef?.number ?? "x"}`,
+        worktreePath: "/wt",
+        isolated: true,
+        herdrSession: "default",
+        herdrAgentId: "t",
+        auto: input.auto ?? false,
+        issueNumber: input.issueRef?.number ?? null,
+      });
+    },
+    archive: (id: string): number => {
+      store.archive(id);
+      return 1;
+    },
+  };
+
+  store.getReview = ((id: string) =>
+    reviews[id]
+      ? { decision: reviews[id].decision, headSha: reviews[id].headSha }
+      : null) as typeof store.getReview;
+
+  const drain = new DrainService({
+    store,
+    service,
+    resolveForge: () => forge,
+    prCache: { snapshot: () => prCache },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    emitStatus: (s) => statuses.push(s),
+    emitArchived: () => {},
+    dropPrCache: () => {},
+    emitEpic: (epic) => epics.push(epic),
+  });
+
+  return { store, drain, rec, creates };
+}
+
+describe("epic integration branch is pinned across a title edit (#645)", () => {
+  test("renaming the parent title mid-run does NOT re-point the spawn base", async () => {
+    const titleRef = { title: "EFI cluster" };
+    const subIssues: SubIssueRef[] = [
+      { number: 320, title: "child A", url: "u320", body: "spec", closed: false, labels: [] },
+      { number: 321, title: "child B", url: "u321", body: "spec", closed: false, labels: [] },
+    ];
+    const h = makeHarness(titleRef, subIssues);
+
+    // First pump pins the branch from the original title + spawns the first child on it.
+    await h.drain.pump(REPO);
+    const PINNED = "epic/327-efi-cluster";
+    expect(h.store.getEpicRun(REPO)).not.toBeNull();
+    expect(h.creates.map((c) => c.baseBranch)).toContain(PINNED);
+    const ensuredBranches = new Set(h.rec.ensured.map((e) => e.branch));
+    expect(ensuredBranches).toEqual(new Set([PINNED]));
+
+    // Operator renames the epic — the live title now slugs differently.
+    titleRef.title = "Completely renamed thing";
+
+    // Subsequent pump must still base every spawn on the originally-pinned branch.
+    await h.drain.pump(REPO);
+    for (const c of h.creates) expect(c.baseBranch).toBe(PINNED);
+    // ensureBranch was never asked for the post-rename slug.
+    expect(h.rec.ensured.map((e) => e.branch)).not.toContain("epic/327-completely-renamed-thing");
+
+    // And the store still holds the original pinned name.
+    expect(h.store.getOrInitEpicIntegrationBranch(REPO, 327, "epic/327-whatever-now")).toBe(PINNED);
+  });
+});

--- a/test/drain-epic-retire-base.test.ts
+++ b/test/drain-epic-retire-base.test.ts
@@ -1,0 +1,298 @@
+import { test, expect, describe } from "bun:test";
+import { DrainService } from "../src/drain";
+import { SessionStore } from "../src/store";
+import type {
+  GitForge,
+  GitState,
+  Issue,
+  MergeMethod,
+  PrReviewMeta,
+  PrStatus,
+} from "../src/forge/types";
+import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
+import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
+
+// #645 Task 2: retire enforces the child PR's base against the pinned epic integration branch.
+// On mismatch it FAILS CLOSED — no merge, no integration, claim retained, marker parked, dependents
+// stay blocked. Throttled via the marker. Gitea (no prReviewMeta) preserves today's behavior.
+
+const REPO = "/repo";
+const PARENT = 327;
+const CHILD = 320;
+const PR = 330;
+const EPIC_BRANCH = "epic/327-efi-cluster";
+
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+};
+
+interface ForgeRec {
+  merges: { prNumber: number; method: MergeMethod; deleteBranch: boolean }[];
+  reviewMetaCalls: number;
+}
+
+function fakeForge(
+  rec: ForgeRec,
+  opts: { baseRefName?: string; withReviewMeta?: boolean } = {},
+): GitForge {
+  const withReviewMeta = opts.withReviewMeta ?? true;
+  const f: GitForge = {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
+    openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
+    defaultBranch: async () => "main",
+    merge: async (prNumber, o) => {
+      rec.merges.push({ prNumber, method: o.method, deleteBranch: o.deleteBranch });
+    },
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    closeIssue: async () => {},
+    ensureIssueLink: async () => {},
+    addIssueLabel: async () => {},
+    removeIssueLabel: async () => {},
+    getIssue: async (n: number): Promise<Issue | null> =>
+      n === PARENT
+        ? {
+            number: PARENT,
+            title: "EFI cluster",
+            body: "epic body",
+            url: `https://x/${PARENT}`,
+            labels: [],
+            createdAt: 0,
+          }
+        : null,
+    listSubIssues: async () => [],
+    listBlockedBy: async () => [],
+  };
+  if (withReviewMeta) {
+    f.prReviewMeta = async (): Promise<PrReviewMeta> => {
+      rec.reviewMetaCalls++;
+      return {
+        body: "",
+        baseRefName: opts.baseRefName ?? EPIC_BRANCH,
+        isCrossRepository: false,
+        state: "open",
+      };
+    };
+  }
+  return f;
+}
+
+interface Harness {
+  store: SessionStore;
+  drain: DrainService;
+  forgeRec: ForgeRec;
+  archived: string[];
+  prCache: Record<string, GitState>;
+  setReview: (id: string, d: ReviewDecision, sha: string) => void;
+}
+
+function makeHarness(
+  opts: { baseRefName?: string; withReviewMeta?: boolean; now?: () => number } = {},
+): Harness {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: true,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 2,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+  });
+  store.setEpicRun({
+    repoPath: REPO,
+    parentIssueNumber: PARENT,
+    mode: "auto",
+    status: "running",
+  });
+
+  const forgeRec: ForgeRec = { merges: [], reviewMetaCalls: 0 };
+  const forge = fakeForge(forgeRec, {
+    baseRefName: opts.baseRefName,
+    withReviewMeta: opts.withReviewMeta,
+  });
+
+  const prCache: Record<string, GitState> = {};
+  const reviews: Record<string, { decision: ReviewDecision; headSha: string }> = {};
+  const archived: string[] = [];
+
+  const service = {
+    create: async (input: CreateSessionInput): Promise<Session> =>
+      store.create({
+        name: "auto",
+        prompt: input.prompt,
+        repoPath: input.repoPath,
+        baseBranch: input.baseBranch,
+        branch: `shepherd/auto-${input.issueRef?.number ?? "x"}`,
+        worktreePath: "/wt",
+        isolated: true,
+        herdrSession: "default",
+        herdrAgentId: "t",
+        auto: input.auto ?? false,
+        issueNumber: input.issueRef?.number ?? null,
+      }),
+    archive: (id: string): number => {
+      store.archive(id);
+      return 1;
+    },
+  };
+
+  store.getReview = ((id: string) =>
+    reviews[id]
+      ? { decision: reviews[id].decision, headSha: reviews[id].headSha }
+      : null) as typeof store.getReview;
+
+  const drain = new DrainService({
+    store,
+    service,
+    resolveForge: () => forge,
+    prCache: { snapshot: () => prCache },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    emitStatus: () => {},
+    emitArchived: (id) => archived.push(id),
+    dropPrCache: () => {},
+    emitEpic: () => {},
+    now: opts.now,
+  });
+
+  return {
+    store,
+    drain,
+    forgeRec,
+    archived,
+    prCache,
+    setReview: (id, decision, headSha) => {
+      reviews[id] = { decision, headSha };
+    },
+  };
+}
+
+function openGreen(number: number): GitState {
+  return {
+    kind: "github",
+    state: "open",
+    number,
+    checks: "success",
+    mergeable: true,
+    headSha: `sha-${number}`,
+    deployConfigured: false,
+  };
+}
+
+function seedReadyChild(h: Harness, baseBranch: string): Session {
+  const s = h.store.create({
+    name: "auto",
+    prompt: "p",
+    repoPath: REPO,
+    baseBranch,
+    branch: `shepherd/auto-${CHILD}`,
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: true,
+    issueNumber: CHILD,
+  });
+  h.prCache[s.id] = openGreen(PR);
+  h.setReview(s.id, "commented", `sha-${PR}`);
+  return s;
+}
+
+describe("epic child retire → PR base enforcement (#645 Task 2)", () => {
+  test("matching base: merges as before, records integrated, clears any stale marker", async () => {
+    const h = makeHarness({ baseRefName: EPIC_BRANCH });
+    // pre-seed a stale marker to prove it is cleared on a successful (matching) retire
+    h.store.recordEpicBaseMismatch(REPO, PARENT, CHILD, {
+      actualBase: "main",
+      prNumber: PR,
+      checkedAt: 0,
+    });
+    const s = seedReadyChild(h, EPIC_BRANCH);
+
+    await h.drain.pump(REPO);
+
+    expect(h.forgeRec.reviewMetaCalls).toBe(1);
+    expect(h.forgeRec.merges).toEqual([{ prNumber: PR, method: "squash", deleteBranch: true }]);
+    expect([...h.store.listEpicIntegrated(REPO, PARENT)]).toContain(CHILD);
+    expect(h.store.get(s.id)?.status).toBe("archived");
+    expect(h.archived).toEqual([s.id]);
+    expect(h.store.getEpicBaseMismatch(REPO, PARENT, CHILD)).toBeNull();
+  });
+
+  test("mismatched base: NOT merged, marker recorded, claim retained, dependents stay blocked", async () => {
+    const h = makeHarness({ baseRefName: "main" }); // PR opened against default branch
+    const s = seedReadyChild(h, EPIC_BRANCH);
+
+    await h.drain.pump(REPO);
+
+    expect(h.forgeRec.reviewMetaCalls).toBe(1);
+    expect(h.forgeRec.merges).toHaveLength(0); // fail closed
+    expect([...h.store.listEpicIntegrated(REPO, PARENT)]).not.toContain(CHILD);
+    expect(h.store.get(s.id)?.status).not.toBe("archived");
+    expect(h.archived).toHaveLength(0);
+    const mm = h.store.getEpicBaseMismatch(REPO, PARENT, CHILD);
+    expect(mm?.actualBase).toBe("main");
+    expect(mm?.prNumber).toBe(PR);
+    // surfaced through assembleEpic for the operator
+    const epic = await h.drain.buildEpic(REPO, h.store.getEpicRun(REPO)!);
+    expect(
+      epic!.warnings.some(
+        (w) => w.includes(`child #${CHILD}`) && w.includes("epic blocked until fixed"),
+      ),
+    ).toBe(true);
+  });
+
+  test("throttle: a fresh (<60s) marker skips the prReviewMeta call and stays blocked", async () => {
+    let t = 1_000_000;
+    const h = makeHarness({ baseRefName: "main", now: () => t });
+    const s = seedReadyChild(h, EPIC_BRANCH);
+
+    await h.drain.pump(REPO); // first pump: probes, records marker, blocks
+    expect(h.forgeRec.reviewMetaCalls).toBe(1);
+    expect(h.forgeRec.merges).toHaveLength(0);
+
+    t += 30_000; // <60s later
+    await h.drain.pump(REPO); // throttled: no new probe, still blocked
+    expect(h.forgeRec.reviewMetaCalls).toBe(1);
+    expect(h.forgeRec.merges).toHaveLength(0);
+    expect(h.store.get(s.id)?.status).not.toBe("archived");
+
+    t += 31_000; // now >60s since the marker → rechecks
+    await h.drain.pump(REPO);
+    expect(h.forgeRec.reviewMetaCalls).toBe(2);
+  });
+
+  test("Gitea (no prReviewMeta): merges as today, no base check, no marker", async () => {
+    const h = makeHarness({ withReviewMeta: false });
+    const s = seedReadyChild(h, EPIC_BRANCH);
+
+    await h.drain.pump(REPO);
+
+    expect(h.forgeRec.reviewMetaCalls).toBe(0);
+    expect(h.forgeRec.merges).toEqual([{ prNumber: PR, method: "squash", deleteBranch: true }]);
+    expect([...h.store.listEpicIntegrated(REPO, PARENT)]).toContain(CHILD);
+    expect(h.store.get(s.id)?.status).toBe("archived");
+    expect(h.store.getEpicBaseMismatch(REPO, PARENT, CHILD)).toBeNull();
+  });
+});

--- a/test/drain-epic-retire-base.test.ts
+++ b/test/drain-epic-retire-base.test.ts
@@ -296,3 +296,115 @@ describe("epic child retire → PR base enforcement (#645 Task 2)", () => {
     expect(h.store.getEpicBaseMismatch(REPO, PARENT, CHILD)).toBeNull();
   });
 });
+
+// Self-heal (#645 final review): a base-mismatch marker for a child resolved out-of-band — its PR
+// merged into the default branch (issue closed) OR shepherd-integrated — never re-enters doRetire,
+// so buildEpic must clear the now-orphaned marker (and drop its "epic blocked until fixed" warning).
+// A still-open, not-done child's marker MUST persist.
+describe("epic base-mismatch marker self-heal on buildEpic (#645)", () => {
+  // Native epic so we control each child's closed-state + the integrated set directly. Children:
+  // OPEN (blocked), ICLOSED (issue closed out-of-band), IINTEG (shepherd-integrated).
+  const OPEN = 401;
+  const ICLOSED = 402;
+  const IINTEG = 403;
+
+  function makeNativeHarness(): { store: SessionStore; drain: DrainService } {
+    const store = new SessionStore(":memory:");
+    store.setEpicRun({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      mode: "auto",
+      status: "running",
+    });
+    const sub = (number: number, closed: boolean) => ({
+      number,
+      title: `#${number}`,
+      url: `https://x/${number}`,
+      body: "",
+      closed,
+      labels: [] as string[],
+    });
+    const forge: GitForge = {
+      ...fakeForge({ merges: [], reviewMetaCalls: 0 }),
+      getIssue: async (n: number): Promise<Issue | null> =>
+        n === PARENT
+          ? {
+              number: PARENT,
+              title: "EFI cluster",
+              body: "",
+              url: `https://x/${PARENT}`,
+              labels: [],
+              createdAt: 0,
+            }
+          : null,
+      listSubIssues: async () => [sub(OPEN, false), sub(ICLOSED, true), sub(IINTEG, false)],
+      listBlockedBy: async () => [],
+    };
+    const service = {
+      create: async (): Promise<Session> => {
+        throw new Error("unused");
+      },
+      archive: (): number => 1,
+    };
+    const drain = new DrainService({
+      store,
+      service,
+      resolveForge: () => forge,
+      prCache: { snapshot: () => ({}) },
+      usage: { limits: (): UsageLimitsType => NO_USAGE },
+      repos: () => [REPO],
+      emitStatus: () => {},
+      emitArchived: () => {},
+      dropPrCache: () => {},
+      emitEpic: () => {},
+    });
+    return { store, drain };
+  }
+
+  test("clears markers for issue-closed AND integration-merged children; keeps the open one", async () => {
+    const { store, drain } = makeNativeHarness();
+    // IINTEG is shepherd-integrated; mark a base-mismatch on all three.
+    store.recordEpicIntegrated(REPO, PARENT, IINTEG, { number: 510, url: "" }, EPIC_BRANCH);
+    for (const c of [OPEN, ICLOSED, IINTEG]) {
+      store.recordEpicBaseMismatch(REPO, PARENT, c, {
+        actualBase: "main",
+        prNumber: c + 100,
+        checkedAt: 0,
+      });
+    }
+
+    const epic = await drain.buildEpic(REPO, store.getEpicRun(REPO)!);
+
+    // done-in-epic markers swept; open marker persists
+    expect(store.getEpicBaseMismatch(REPO, PARENT, ICLOSED)).toBeNull();
+    expect(store.getEpicBaseMismatch(REPO, PARENT, IINTEG)).toBeNull();
+    expect(store.getEpicBaseMismatch(REPO, PARENT, OPEN)).not.toBeNull();
+
+    // and the warnings reflect the sweep: only the open child is still "blocked until fixed"
+    const blocked = (n: number) =>
+      epic!.warnings.some(
+        (w) => w.includes(`child #${n}`) && w.includes("epic blocked until fixed"),
+      );
+    expect(blocked(OPEN)).toBe(true);
+    expect(blocked(ICLOSED)).toBe(false);
+    expect(blocked(IINTEG)).toBe(false);
+  });
+
+  test("a marker for a still-open, not-done child persists across buildEpic", async () => {
+    const { store, drain } = makeNativeHarness();
+    store.recordEpicBaseMismatch(REPO, PARENT, OPEN, {
+      actualBase: "main",
+      prNumber: 501,
+      checkedAt: 0,
+    });
+
+    const epic = await drain.buildEpic(REPO, store.getEpicRun(REPO)!);
+
+    expect(store.getEpicBaseMismatch(REPO, PARENT, OPEN)?.actualBase).toBe("main");
+    expect(
+      epic!.warnings.some(
+        (w) => w.includes(`child #${OPEN}`) && w.includes("epic blocked until fixed"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/test/drain-epic-retire-base.test.ts
+++ b/test/drain-epic-retire-base.test.ts
@@ -28,6 +28,7 @@ const NO_USAGE: UsageLimitsType = {
   credits: null,
   stale: false,
   calibratedAt: null,
+  subscriptionOnly: false,
 };
 
 interface ForgeRec {
@@ -151,7 +152,7 @@ function makeHarness(
         auto: input.auto ?? false,
         issueNumber: input.issueRef?.number ?? null,
       }),
-    archive: (id: string): number => {
+    archive: async (id: string): Promise<number> => {
       store.archive(id);
       return 1;
     },
@@ -344,7 +345,7 @@ describe("epic base-mismatch marker self-heal on buildEpic (#645)", () => {
       create: async (): Promise<Session> => {
         throw new Error("unused");
       },
-      archive: (): number => 1,
+      archive: async (): Promise<number> => 1,
     };
     const drain = new DrainService({
       store,

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -220,6 +220,11 @@ describe("epic child retire → squash-merge into integration branch", () => {
 
     expect(h.forgeRec.merges).toEqual([{ prNumber: PR, method: "squash", deleteBranch: true }]);
     expect([...h.store.listEpicIntegrated(REPO, PARENT)]).toContain(CHILD);
+    // #645 (b): the branch the child squash-merged into is recorded for divergence detection.
+    expect(
+      h.store.listEpicIntegratedDetails(REPO, PARENT).find((d) => d.childNumber === CHILD)
+        ?.mergedBase,
+    ).toBe(EPIC_BRANCH);
     expect(h.store.get(s.id)?.status).toBe("archived");
     expect(h.archived).toEqual([s.id]);
     // Epic child path does NOT auto-close-link the issue (no ensureIssueLink).

--- a/test/epic-branch.test.ts
+++ b/test/epic-branch.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { epicIntegrationBranch } from "../src/epic-branch";
+import { epicIntegrationBranch, branchReferencesEpic } from "../src/epic-branch";
 
 test("builds epic/<#>-<slug> from parent number + title", () => {
   expect(epicIntegrationBranch(327, "EFI / Value-Map cluster — sequencing")).toBe(
@@ -20,4 +20,25 @@ test("bounds the slug length (<= 40 slug chars) and never trails a dash", () => 
 
 test("empty/symbol-only title degrades to bare epic/<#>", () => {
   expect(epicIntegrationBranch(12, "!!!")).toBe("epic/12");
+});
+
+test("branchReferencesEpic: matches canonical suffix form epic/<#>-<slug>", () => {
+  expect(branchReferencesEpic("epic/327-foo", 327)).toBe(true);
+});
+
+test("branchReferencesEpic: matches number-in-middle / number-as-suffix forms", () => {
+  expect(branchReferencesEpic("epic/efi-valuemap-327", 327)).toBe(true);
+  expect(branchReferencesEpic("epic/327", 327)).toBe(true);
+});
+
+test("branchReferencesEpic: rejects numeric superstrings (prefix + suffix digits)", () => {
+  expect(branchReferencesEpic("epic/1327-x", 327)).toBe(false);
+  expect(branchReferencesEpic("epic/3270", 327)).toBe(false);
+  expect(branchReferencesEpic("epic/13270-x", 327)).toBe(false);
+});
+
+test("branchReferencesEpic: bounded both sides — exact token amid non-digits", () => {
+  expect(branchReferencesEpic("epic/a327b", 327)).toBe(true); // letters bound it
+  expect(branchReferencesEpic("327", 327)).toBe(true); // whole string
+  expect(branchReferencesEpic("epic/0327", 327)).toBe(false); // leading digit
 });

--- a/test/epic-migrations.test.ts
+++ b/test/epic-migrations.test.ts
@@ -1,0 +1,70 @@
+import { test, expect, describe } from "bun:test";
+import { detectMigrationPaths, MIGRATION_GLOBS } from "../src/epic-migrations";
+
+describe("detectMigrationPaths — pure migration-path detection (#645)", () => {
+  test("empty input → empty output", () => {
+    expect(detectMigrationPaths([])).toEqual([]);
+  });
+
+  test("matches each glob family", () => {
+    expect(detectMigrationPaths(["server/migrations/001_init.sql"])).toEqual([
+      "server/migrations/001_init.sql",
+    ]);
+    expect(detectMigrationPaths(["drizzle/0000_snapshot.sql"])).toEqual([
+      "drizzle/0000_snapshot.sql",
+    ]);
+    expect(detectMigrationPaths(["db/schema/init.cypher"])).toEqual(["db/schema/init.cypher"]);
+    expect(detectMigrationPaths(["infra/neo4j/seed.cql"])).toEqual(["infra/neo4j/seed.cql"]);
+    expect(detectMigrationPaths(["backend/alembic/versions/abc.py"])).toEqual([
+      "backend/alembic/versions/abc.py",
+    ]);
+  });
+
+  test("matches a migrations dir at the repo root (no leading segment)", () => {
+    expect(detectMigrationPaths(["migrations/001.sql"])).toEqual(["migrations/001.sql"]);
+  });
+
+  test("rejects non-migration paths", () => {
+    expect(
+      detectMigrationPaths([
+        "src/foo.ts",
+        "README.md",
+        "ui/src/lib/api.ts",
+        "package.json",
+        "docs/migration-guide.md", // a doc *about* migrations is NOT a migration file
+        "src/migrate.ts", // a code file named migrate is not under a migrations dir
+      ]),
+    ).toEqual([]);
+  });
+
+  test("filters a mixed list to only the migration paths, preserving order", () => {
+    expect(
+      detectMigrationPaths([
+        "src/foo.ts",
+        "drizzle/0001.sql",
+        "README.md",
+        "server/migrations/002.sql",
+        "src/bar.ts",
+      ]),
+    ).toEqual(["drizzle/0001.sql", "server/migrations/002.sql"]);
+  });
+
+  test("dedupes repeated paths, first occurrence wins (order-preserving)", () => {
+    expect(
+      detectMigrationPaths([
+        "drizzle/a.sql",
+        "migrations/b.sql",
+        "drizzle/a.sql",
+        "migrations/b.sql",
+      ]),
+    ).toEqual(["drizzle/a.sql", "migrations/b.sql"]);
+  });
+
+  test("MIGRATION_GLOBS is the single source of truth (non-empty, includes the core families)", () => {
+    expect(MIGRATION_GLOBS).toContain("**/migrations/**");
+    expect(MIGRATION_GLOBS).toContain("**/drizzle/**");
+    expect(MIGRATION_GLOBS).toContain("**/*.cypher");
+    expect(MIGRATION_GLOBS).toContain("**/neo4j/**");
+    expect(MIGRATION_GLOBS).toContain("**/alembic/**");
+  });
+});

--- a/test/epic-model.test.ts
+++ b/test/epic-model.test.ts
@@ -182,4 +182,45 @@ describe("epic-branch divergence warnings (#645)", () => {
     const e = assembleEpic(input({ divergentBranches: [] }));
     expect(e.warnings.some((w) => w.includes("divergent epic branch"))).toBe(false);
   });
+
+  // (Task 2) PR base-mismatch — actionable remedy
+  test("base-mismatch → warning naming gh pr edit … --base <pinned> and 'epic blocked'", () => {
+    const e = assembleEpic(
+      input({ baseMismatches: [{ childNumber: 320, actualBase: "main", prNumber: 42 }] }),
+    );
+    const w = e.warnings.find((x) => x.includes("child #320"));
+    expect(w).toBeDefined();
+    expect(w).toContain("targets `main`");
+    expect(w).toContain("epic/327-epic"); // the pinned branch
+    expect(w).toContain("gh pr edit 42 --base epic/327-epic");
+    expect(w).toContain("epic blocked until fixed");
+  });
+  test("base-mismatch with null prNumber → warning omits the gh-edit hint but still blocks", () => {
+    const e = assembleEpic(
+      input({ baseMismatches: [{ childNumber: 320, actualBase: "main", prNumber: null }] }),
+    );
+    const w = e.warnings.find((x) => x.includes("child #320"))!;
+    expect(w).toContain("epic blocked until fixed");
+    expect(w).not.toContain("gh pr edit");
+    // no double-space and no dangling "PR " followed by another space when prNumber is null
+    expect(w).not.toMatch(/PR\s\s/);
+    expect(w).toContain("child #320 PR targets");
+    expect(w).not.toContain("  ");
+  });
+  test("base-mismatch with empty actualBase → 'unknown base' phrasing, no empty backticks", () => {
+    const e = assembleEpic(
+      input({ baseMismatches: [{ childNumber: 320, actualBase: "", prNumber: 42 }] }),
+    );
+    const w = e.warnings.find((x) => x.includes("child #320"))!;
+    expect(w).toContain("targets an unknown base");
+    expect(w).not.toContain("``"); // no empty backtick pair
+    expect(w).toContain("gh pr edit 42 --base epic/327-epic"); // remedy retained
+    expect(w).toContain("epic blocked until fixed");
+  });
+  test("no base-mismatch entries → NO base-mismatch warning", () => {
+    const e1 = assembleEpic(input({ baseMismatches: [] }));
+    const e2 = assembleEpic(input({})); // undefined
+    expect(e1.warnings.some((w) => w.includes("epic blocked until fixed"))).toBe(false);
+    expect(e2.warnings.some((w) => w.includes("epic blocked until fixed"))).toBe(false);
+  });
 });

--- a/test/epic-model.test.ts
+++ b/test/epic-model.test.ts
@@ -23,6 +23,7 @@ const BASE: AssembleInput = {
   openIssuesTruncated: false,
   sessions: [],
   integrated: new Set<number>(),
+  persistedBranch: "epic/327-efi-cluster", // matches derive(327,"EFI cluster") → no (a) warning
 };
 
 describe("assembleEpic", () => {
@@ -68,6 +69,7 @@ describe("assembleEpic", () => {
       subIssues: [],
       blockedBy: new Map(),
       parent: { number: 1, title: "p", body: "```epic-dag\n#2\n#3 <- #2\n```" },
+      persistedBranch: "epic/1-p", // matches derive(1,"p") → isolate the truncation warning
       openIssues: [
         { number: 2, body: "", labels: [] },
         { number: 3, body: "", labels: [] },
@@ -99,6 +101,7 @@ function input(over: Partial<AssembleInput>): AssembleInput {
     openIssuesTruncated: false,
     sessions: [],
     integrated: new Set<number>(),
+    persistedBranch: "epic/327-epic", // matches derive(327,"Epic") → no (a) warning
     ...over,
   };
 }
@@ -118,4 +121,65 @@ test("integration-merging the blocker unblocks the dependent (issues still open)
 test("empty integrated set leaves the dependent blocked", () => {
   const epic = assembleEpic(input({ integrated: new Set() }));
   expect(epic.children.find((c) => c.number === 322)!.state).toBe("blocked");
+});
+
+// ── #645 divergence warnings ──────────────────────────────────────────────
+describe("epic-branch divergence warnings (#645)", () => {
+  // (a) title drift
+  test("(a) pinned branch ≠ freshly-derived canonical → title-drift warning", () => {
+    const e = assembleEpic(
+      input({ parent: { number: 327, title: "Renamed thing", body: "" } }),
+      // persistedBranch stays epic/327-epic from input(); live title now derives differently
+    );
+    expect(
+      e.warnings.some(
+        (w) =>
+          w.includes("epic/327-epic") &&
+          w.includes("epic/327-renamed-thing") &&
+          w.includes("title edited"),
+      ),
+    ).toBe(true);
+  });
+  test("(a) aligned pinned/derived name → NO title-drift warning", () => {
+    const e = assembleEpic(input({})); // title "Epic" derives epic/327-epic = pinned
+    expect(e.warnings.some((w) => w.includes("title edited"))).toBe(false);
+  });
+
+  // (b) integrated-child drift
+  test("(b) child merged into a non-pinned base → drift warning", () => {
+    const e = assembleEpic(input({ integratedBases: new Map([[320, "epic/efi-valuemap-327"]]) }));
+    expect(
+      e.warnings.some(
+        (w) =>
+          w.includes("child #320") &&
+          w.includes("epic/efi-valuemap-327") &&
+          w.includes("epic/327-epic"),
+      ),
+    ).toBe(true);
+  });
+  test("(b) child merged into the pinned base → NO warning", () => {
+    const e = assembleEpic(input({ integratedBases: new Map([[320, "epic/327-epic"]]) }));
+    expect(e.warnings.some((w) => w.includes("child #320"))).toBe(false);
+  });
+  test("(b) null mergedBase (legacy row) → NO warning", () => {
+    // a Map without the entry, or absent map entirely
+    const e1 = assembleEpic(input({ integratedBases: new Map() }));
+    const e2 = assembleEpic(input({})); // integratedBases undefined
+    expect(e1.warnings.some((w) => w.includes("child #"))).toBe(false);
+    expect(e2.warnings.some((w) => w.includes("child #"))).toBe(false);
+  });
+
+  // (c) host-branch drift
+  test("(c) divergent host branch → drift warning per branch", () => {
+    const e = assembleEpic(input({ divergentBranches: ["epic/efi-valuemap-327", "epic/327-old"] }));
+    const c = e.warnings.filter((w) => w.includes("divergent epic branch"));
+    expect(c).toHaveLength(2);
+    expect(c.some((w) => w.includes("epic/efi-valuemap-327") && w.includes("epic #327"))).toBe(
+      true,
+    );
+  });
+  test("(c) no divergent branches → NO warning", () => {
+    const e = assembleEpic(input({ divergentBranches: [] }));
+    expect(e.warnings.some((w) => w.includes("divergent epic branch"))).toBe(false);
+  });
 });

--- a/test/epic-server.test.ts
+++ b/test/epic-server.test.ts
@@ -1266,3 +1266,65 @@ describe("POST /api/epic/import", () => {
     expect(body.error).toMatch(/native epic links/i);
   });
 });
+
+// ── POST /api/epics/completed/ack-migrations (#645) ───────────────────────────
+
+describe("POST /api/epics/completed/ack-migrations", () => {
+  function seedRow(store: SessionStore, parent: number) {
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: parent,
+      parentTitle: "E",
+      completedAt: 1,
+      childrenJson: "[]",
+    });
+    store.setEpicMigrationPaths(repoDir, parent, ["server/migrations/001.sql"]);
+  }
+
+  test("acknowledges migrations: dismisses the row, clears band, emits cleared", async () => {
+    const { app, store, cleared } = completedHarness({ resolveForge: () => null });
+    seedRow(store, 327);
+    expect(store.listEpicCompleted(repoDir)).toHaveLength(1);
+
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed/ack-migrations`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 327 }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    // acknowledging dismisses → row cleared from the band + cleared event emitted
+    expect(store.listEpicCompleted(repoDir)).toHaveLength(0);
+    expect(cleared).toEqual([{ repoPath: repoDir, parentIssueNumber: 327 }]);
+    const get = await app.fetch(
+      new Request(`http://x/api/epics/completed?repo=${encRepo(repoDir)}`),
+    );
+    expect(await get.json()).toEqual([]);
+  });
+
+  test("invalid repo → 400", async () => {
+    const { app } = completedHarness();
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed/ack-migrations`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: "/nope/not/here", parent: 327 }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("non-positive parent → 400", async () => {
+    const { app } = completedHarness();
+    const res = await app.fetch(
+      new Request(`http://x/api/epics/completed/ack-migrations`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 0 }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/test/epic-store.test.ts
+++ b/test/epic-store.test.ts
@@ -24,9 +24,8 @@ describe("epic_run", () => {
 });
 
 describe("getOrInitEpicIntegrationBranch (pin-and-record)", () => {
-  test("first call on an existing row lazily pins + returns the derived name", () => {
+  test("first call pins + returns the derived name", () => {
     const s = new SessionStore(":memory:");
-    s.setEpicRun({ repoPath: "/repo", parentIssueNumber: 327, mode: "auto", status: "running" });
     expect(s.getOrInitEpicIntegrationBranch("/repo", 327, "epic/327-efi-cluster")).toBe(
       "epic/327-efi-cluster",
     );
@@ -34,7 +33,6 @@ describe("getOrInitEpicIntegrationBranch (pin-and-record)", () => {
 
   test("second call returns the PINNED value even when given a different derived (title-edit regression)", () => {
     const s = new SessionStore(":memory:");
-    s.setEpicRun({ repoPath: "/repo", parentIssueNumber: 327, mode: "auto", status: "running" });
     // first use pins "epic/327-efi-cluster"
     s.getOrInitEpicIntegrationBranch("/repo", 327, "epic/327-efi-cluster");
     // operator renames the epic mid-run → derived now slugs differently, but the pinned
@@ -44,21 +42,38 @@ describe("getOrInitEpicIntegrationBranch (pin-and-record)", () => {
     );
   });
 
-  test("no epic_run row: returns derived without persisting (best-effort)", () => {
+  test("the pin is independent of epic_run lifecycle (persists with no epic_run row)", () => {
     const s = new SessionStore(":memory:");
+    // No setEpicRun — the pin lives in its own per-epic table, so it persists regardless.
     expect(s.getOrInitEpicIntegrationBranch("/repo", 999, "epic/999-x")).toBe("epic/999-x");
-    // nothing was written — still no row
-    expect(s.getEpicRun("/repo")).toBeNull();
+    expect(s.getEpicRun("/repo")).toBeNull(); // pinning did not fabricate an epic_run row
+    // and a later derive (e.g. at landing, after a title edit) still returns the pinned name
+    expect(s.getOrInitEpicIntegrationBranch("/repo", 999, "epic/999-renamed")).toBe("epic/999-x");
   });
 
-  test("pin is scoped per-repo and survives setEpicRun status churn", () => {
+  test("pin survives setEpicRun status churn (not stored on epic_run)", () => {
     const s = new SessionStore(":memory:");
     s.setEpicRun({ repoPath: "/repo", parentIssueNumber: 327, mode: "auto", status: "running" });
     s.getOrInitEpicIntegrationBranch("/repo", 327, "epic/327-efi-cluster");
-    // a status change re-upserts the row but must NOT clear the pinned branch
+    // a status change re-upserts the epic_run row but must NOT affect the pinned branch
     s.setEpicRun({ repoPath: "/repo", parentIssueNumber: 327, mode: "auto", status: "paused" });
     expect(s.getOrInitEpicIntegrationBranch("/repo", 327, "epic/327-anything-else")).toBe(
       "epic/327-efi-cluster",
+    );
+  });
+
+  test("a second epic superseding the same repo gets its OWN pin (no inheritance); the first epic's pin survives for its landing", () => {
+    const s = new SessionStore(":memory:");
+    // Epic A runs on /repo and pins its branch.
+    s.setEpicRun({ repoPath: "/repo", parentIssueNumber: 327, mode: "auto", status: "running" });
+    expect(s.getOrInitEpicIntegrationBranch("/repo", 327, "epic/327-alpha")).toBe("epic/327-alpha");
+    // Epic B supersedes the repo's single epic_run row (server replaces parentIssueNumber).
+    s.setEpicRun({ repoPath: "/repo", parentIssueNumber: 400, mode: "auto", status: "running" });
+    // B must NOT inherit A's pin — it pins its own branch...
+    expect(s.getOrInitEpicIntegrationBranch("/repo", 400, "epic/400-beta")).toBe("epic/400-beta");
+    // ...and A's pin is still retrievable (e.g. for A's still-pending landing PR).
+    expect(s.getOrInitEpicIntegrationBranch("/repo", 327, "epic/327-whatever-now")).toBe(
+      "epic/327-alpha",
     );
   });
 });

--- a/test/epic-store.test.ts
+++ b/test/epic-store.test.ts
@@ -22,3 +22,43 @@ describe("epic_run", () => {
     expect(s.getEpicRun("/repo")!.parentIssueNumber).toBe(400);
   });
 });
+
+describe("getOrInitEpicIntegrationBranch (pin-and-record)", () => {
+  test("first call on an existing row lazily pins + returns the derived name", () => {
+    const s = new SessionStore(":memory:");
+    s.setEpicRun({ repoPath: "/repo", parentIssueNumber: 327, mode: "auto", status: "running" });
+    expect(s.getOrInitEpicIntegrationBranch("/repo", 327, "epic/327-efi-cluster")).toBe(
+      "epic/327-efi-cluster",
+    );
+  });
+
+  test("second call returns the PINNED value even when given a different derived (title-edit regression)", () => {
+    const s = new SessionStore(":memory:");
+    s.setEpicRun({ repoPath: "/repo", parentIssueNumber: 327, mode: "auto", status: "running" });
+    // first use pins "epic/327-efi-cluster"
+    s.getOrInitEpicIntegrationBranch("/repo", 327, "epic/327-efi-cluster");
+    // operator renames the epic mid-run → derived now slugs differently, but the pinned
+    // name must stick so already-merged children + the landing base stay consistent.
+    expect(s.getOrInitEpicIntegrationBranch("/repo", 327, "epic/327-renamed-thing")).toBe(
+      "epic/327-efi-cluster",
+    );
+  });
+
+  test("no epic_run row: returns derived without persisting (best-effort)", () => {
+    const s = new SessionStore(":memory:");
+    expect(s.getOrInitEpicIntegrationBranch("/repo", 999, "epic/999-x")).toBe("epic/999-x");
+    // nothing was written — still no row
+    expect(s.getEpicRun("/repo")).toBeNull();
+  });
+
+  test("pin is scoped per-repo and survives setEpicRun status churn", () => {
+    const s = new SessionStore(":memory:");
+    s.setEpicRun({ repoPath: "/repo", parentIssueNumber: 327, mode: "auto", status: "running" });
+    s.getOrInitEpicIntegrationBranch("/repo", 327, "epic/327-efi-cluster");
+    // a status change re-upserts the row but must NOT clear the pinned branch
+    s.setEpicRun({ repoPath: "/repo", parentIssueNumber: 327, mode: "auto", status: "paused" });
+    expect(s.getOrInitEpicIntegrationBranch("/repo", 327, "epic/327-anything-else")).toBe(
+      "epic/327-efi-cluster",
+    );
+  });
+});

--- a/test/forge/github-ensure-branch.test.ts
+++ b/test/forge/github-ensure-branch.test.ts
@@ -35,6 +35,31 @@ test("GithubForge.ensureBranch: absent ref → resolves fromRef sha + creates th
   ]);
 });
 
+test("GithubForge.listBranches: returns matching short-names, strips refs/heads/ (#645)", async () => {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<string> => {
+    calls.push(args);
+    if (args.join(" ").includes("git/matching-refs/heads/epic/")) {
+      return JSON.stringify([
+        { ref: "refs/heads/epic/327-foo" },
+        { ref: "refs/heads/epic/efi-valuemap-327" },
+        { ref: "refs/tags/v1" }, // non-head ref ignored
+      ]);
+    }
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+
+  const branches = await forge.listBranches!("epic/");
+  expect(branches).toEqual(["epic/327-foo", "epic/efi-valuemap-327"]);
+  expect(calls.some((c) => c.includes("repos/o/r/git/matching-refs/heads/epic/"))).toBe(true);
+});
+
+test("GithubForge.listBranches: empty list → []", async () => {
+  const forge = new GithubForge("o/r", {}, async () => "[]");
+  expect(await forge.listBranches!("epic/")).toEqual([]);
+});
+
 test("GithubForge.ensureBranch: present ref → no-op, never creates (tip not reset)", async () => {
   const calls: string[][] = [];
   const run = async (args: string[]): Promise<string> => {

--- a/test/store-epic-completed.test.ts
+++ b/test/store-epic-completed.test.ts
@@ -246,6 +246,140 @@ test("re-recordEpicCompleted preserves landing resolution by omission", () => {
   expect(row.landingPrNumber).toBe(42);
 });
 
+test("fresh recordEpicCompleted defaults migration columns (empty paths, null ackedAt)", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.migrationPaths).toEqual([]);
+  expect(row.migrationsAckedAt).toBe(null);
+});
+
+test("setEpicMigrationPaths round-trips a detected-paths array", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  s.setEpicMigrationPaths("/r", 10, ["drizzle/0001.sql", "server/migrations/002.sql"]);
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.migrationPaths).toEqual(["drizzle/0001.sql", "server/migrations/002.sql"]);
+  expect(row.migrationsAckedAt).toBe(null); // detection alone doesn't acknowledge
+});
+
+test("re-recordEpicCompleted preserves migration columns by omission", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "Old",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  s.setEpicMigrationPaths("/r", 10, ["drizzle/0001.sql", "server/migrations/002.sql"]);
+
+  // detection populated the paths, ack is still pending
+  const detected = s.listEpicCompleted()[0]!;
+  expect(detected.migrationPaths).toEqual(["drizzle/0001.sql", "server/migrations/002.sql"]);
+  expect(detected.migrationsAckedAt).toBe(null);
+
+  // a later re-record refreshes title/children but must NOT wipe the migration columns
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "New",
+    completedAt: 999,
+    childrenJson: "[1,2]",
+  });
+
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.parentTitle).toBe("New");
+  expect(row.childrenJson).toBe("[1,2]");
+  // preserved by omission — the upsert touches neither migration column
+  expect(row.migrationPaths).toEqual(["drizzle/0001.sql", "server/migrations/002.sql"]);
+  expect(row.migrationsAckedAt).toBe(null);
+});
+
+test("re-recordEpicCompleted preserves a prior migrationsAckedAt by omission", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "Old",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  s.setEpicMigrationPaths("/r", 10, ["migrations/001.sql"]);
+  s.ackEpicMigrations("/r", 10); // stamps migrationsAckedAt AND dismisses
+
+  // helper to read the (now-dismissed, hidden) row straight from the DB
+  const readRow = () =>
+    (
+      s as unknown as {
+        db: { query: (q: string) => { get: (...a: unknown[]) => unknown } };
+      }
+    ).db
+      .query(
+        `SELECT migrationPathsJson, migrationsAckedAt FROM epic_completed WHERE repoPath = ? AND parentIssueNumber = ?`,
+      )
+      .get("/r", 10) as { migrationPathsJson: string | null; migrationsAckedAt: number | null };
+
+  const acked = readRow();
+  expect(acked.migrationsAckedAt).not.toBe(null);
+
+  // re-record must not resurrect (stays dismissed) and must not wipe the ack timestamp/paths
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "New",
+    completedAt: 999,
+    childrenJson: "[1,2]",
+  });
+  expect(s.listEpicCompleted()).toHaveLength(0); // still dismissed, not resurrected
+
+  const after = readRow();
+  expect(after.migrationsAckedAt).toBe(acked.migrationsAckedAt); // ack survives the upsert
+  expect(after.migrationPathsJson).toBe(JSON.stringify(["migrations/001.sql"]));
+});
+
+test("ackEpicMigrations stamps migrationsAckedAt AND clears the row from the list", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  s.setEpicMigrationPaths("/r", 10, ["migrations/001.sql"]);
+  expect(s.listEpicCompleted()).toHaveLength(1);
+
+  const before = Date.now();
+  s.ackEpicMigrations("/r", 10);
+  // acknowledging dismisses → gone from the (dismissedAt IS NULL) list
+  expect(s.listEpicCompleted()).toHaveLength(0);
+
+  // the ack timestamp is durably recorded even though the row is hidden
+  const acked = (
+    s as unknown as {
+      db: { query: (q: string) => { get: (...a: unknown[]) => unknown } };
+    }
+  ).db
+    .query(
+      `SELECT migrationsAckedAt FROM epic_completed WHERE repoPath = ? AND parentIssueNumber = ?`,
+    )
+    .get("/r", 10) as { migrationsAckedAt: number };
+  expect(acked.migrationsAckedAt).toBeGreaterThanOrEqual(before);
+});
+
 test("listEpicRuns returns all persisted epic_run rows", () => {
   const s = new SessionStore(":memory:");
   expect(s.listEpicRuns()).toEqual([]);

--- a/test/store-epic-integrated.test.ts
+++ b/test/store-epic-integrated.test.ts
@@ -64,6 +64,22 @@ test("first observation stamps createdAt; later conflicting insert preserves it"
   expect(after.prUrl).toBe("https://github.com/r/pull/99");
 });
 
+test("recordEpicIntegrated persists mergedBase; listEpicIntegratedDetails returns it (#645)", () => {
+  const s = new SessionStore(":memory:");
+  // null when omitted (legacy / no base recorded)
+  s.recordEpicIntegrated("/r", 327, 320);
+  expect(s.listEpicIntegratedDetails("/r", 327)[0]!.mergedBase).toBeNull();
+  // recorded when passed
+  s.recordEpicIntegrated("/r", 327, 322, { number: 7, url: "u7" }, "epic/327-foo");
+  const d = s.listEpicIntegratedDetails("/r", 327).find((x) => x.childNumber === 322)!;
+  expect(d.mergedBase).toBe("epic/327-foo");
+  // re-observe without a base must NOT clobber a previously-recorded one (COALESCE)
+  s.recordEpicIntegrated("/r", 327, 322, { number: 7, url: "u7" });
+  expect(
+    s.listEpicIntegratedDetails("/r", 327).find((x) => x.childNumber === 322)!.mergedBase,
+  ).toBe("epic/327-foo");
+});
+
 test("3-arg recordEpicIntegrated + listEpicIntegrated Set behavior unchanged", () => {
   const s = new SessionStore(":memory:");
   s.recordEpicIntegrated("/r", 200, 11);

--- a/test/store-epic-integrated.test.ts
+++ b/test/store-epic-integrated.test.ts
@@ -92,3 +92,41 @@ test("3-arg recordEpicIntegrated + listEpicIntegrated Set behavior unchanged", (
   expect(details[0]!.prNumber).toBeNull();
   expect(details[0]!.prUrl).toBeNull();
 });
+
+test("epic base-mismatch markers: record/get/list/clear round-trip (#645)", () => {
+  const s = new SessionStore(":memory:");
+  // absent → null / empty
+  expect(s.getEpicBaseMismatch("/r", 327, 320)).toBeNull();
+  expect(s.listEpicBaseMismatches("/r", 327)).toEqual([]);
+
+  s.recordEpicBaseMismatch("/r", 327, 320, { actualBase: "main", prNumber: 42, checkedAt: 1000 });
+  const got = s.getEpicBaseMismatch("/r", 327, 320);
+  expect(got).toEqual({ actualBase: "main", prNumber: 42, checkedAt: 1000 });
+
+  // upsert refreshes actualBase/prNumber/checkedAt (checkedAt is the throttle anchor)
+  s.recordEpicBaseMismatch("/r", 327, 320, { actualBase: "dev", prNumber: 42, checkedAt: 2000 });
+  expect(s.getEpicBaseMismatch("/r", 327, 320)).toEqual({
+    actualBase: "dev",
+    prNumber: 42,
+    checkedAt: 2000,
+  });
+
+  // null prNumber is allowed
+  s.recordEpicBaseMismatch("/r", 327, 321, { actualBase: "main", prNumber: null, checkedAt: 3000 });
+  const list = s.listEpicBaseMismatches("/r", 327);
+  expect(list).toEqual([
+    { childNumber: 320, actualBase: "dev", prNumber: 42 },
+    { childNumber: 321, actualBase: "main", prNumber: null },
+  ]);
+
+  // scoped by repo + parent
+  expect(s.listEpicBaseMismatches("/other", 327)).toEqual([]);
+  expect(s.listEpicBaseMismatches("/r", 999)).toEqual([]);
+
+  // clear removes only the one child
+  s.clearEpicBaseMismatch("/r", 327, 320);
+  expect(s.getEpicBaseMismatch("/r", 327, 320)).toBeNull();
+  expect(s.listEpicBaseMismatches("/r", 327)).toEqual([
+    { childNumber: 321, actualBase: "main", prNumber: null },
+  ]);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1291,5 +1291,10 @@
   "feat_readiness_install_commands_body": "Die Readiness-Empfehlung listet jetzt die exakten Installationsbefehle für den Paketmanager deines Repos auf, sodass jede fehlende Schutzregel ohne Nachschlagen übernommen werden kann.",
   "topbar_menu_docs": "README & Doku",
   "feat_mobile_menu_docs_title": "Doku & Version im Mobil-Menü",
-  "feat_mobile_menu_docs_body": "Auf dem Handy verlinkt das Zahnrad-Menü jetzt direkt auf die Shepherd-Startseite — README und Doku — und zeigt die laufende Build-Version an."
+  "feat_mobile_menu_docs_body": "Auf dem Handy verlinkt das Zahnrad-Menü jetzt direkt auf die Shepherd-Startseite — README und Doku — und zeigt die laufende Build-Version an.",
+  "epic_migrations_pending": "{count} Migrationsdatei(en) — vor dem Merge prüfen (nicht im Harness ausgeführt)",
+  "integrated_epics_ack_migrations": "Migrationen bestätigen & schließen",
+  "integrated_epics_ack_migrations_failed": "Migrationen konnten nicht bestätigt werden — erneut versuchen",
+  "feat_epic_migrations_title": "Epic-Landungen melden nicht ausgeführte Migrationen",
+  "feat_epic_migrations_body": "Wenn der Landing-PR eines Epics Datenbankmigrationen hinzufügt, zeigt das Band 'Integrierte Epics' jetzt einen Warn-Chip mit der Dateianzahl — der Harness führt sie nie aus, prüfe sie also vor dem Merge. Vor dem Schließen der Zeile musst du die Migrationen bestätigen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1291,5 +1291,10 @@
   "feat_readiness_install_commands_body": "The Readiness prescription now lists the exact install commands for your repo's package manager, so each missing guardrail can be adopted without looking the steps up.",
   "topbar_menu_docs": "README & docs",
   "feat_mobile_menu_docs_title": "Docs & version in the mobile menu",
-  "feat_mobile_menu_docs_body": "On phones the gear menu now links straight to Shepherd's home — the README and docs — and shows the build version you're running."
+  "feat_mobile_menu_docs_body": "On phones the gear menu now links straight to Shepherd's home — the README and docs — and shows the build version you're running.",
+  "epic_migrations_pending": "{count} migration file(s) — verify before merge (not run in-harness)",
+  "integrated_epics_ack_migrations": "Acknowledge migrations & dismiss",
+  "integrated_epics_ack_migrations_failed": "Couldn't acknowledge the migrations — try again",
+  "feat_epic_migrations_title": "Epic landings flag unrun migrations",
+  "feat_epic_migrations_body": "When an epic's landing PR adds database migrations, the Integrated-epics band now shows a warning chip with the file count — the harness never runs them, so verify them before merging. Clearing the row asks you to acknowledge the migrations first."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1163,3 +1163,16 @@ export async function dismissCompletedEpic(
     "dismiss completed epic",
   );
 }
+
+/** Acknowledge the migrations detected in a completed epic's landing PR (#645). Like dismiss,
+ *  this clears the band row — one operator action both records the acknowledgement and dismisses. */
+export async function ackEpicMigrations(
+  repoPath: string,
+  parent: number,
+): Promise<{ ok: boolean }> {
+  return postJson(
+    "/api/epics/completed/ack-migrations",
+    { repo: repoPath, parent },
+    "acknowledge epic migrations",
+  );
+}

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -53,6 +53,7 @@
     doneList = [],
     doneSelectedId = null,
     ondoneselect = undefined,
+    onackmigrationsepic = undefined,
   }: {
     sessions: Session[];
     selectedId: string | null;
@@ -136,6 +137,8 @@
     doneSelectedId?: string | null;
     // a done row was picked → page selects it + shows its DoneRecapPanel in the main area
     ondoneselect?: (id: string) => void;
+    // acknowledge a completed epic's landing-PR migrations (#645); also clears the row
+    onackmigrationsepic?: (repoPath: string, parent: number) => void;
   } = $props();
 
   // a critic post-PR review or a pre-execution plan-gate review currently in flight —
@@ -699,7 +702,12 @@
       {/if}
     {/if}
     {#if filter !== "done"}
-      <IntegratedEpicsBand epics={completedEpics} ondismiss={ondismissepic ?? (() => {})} {nowMs} />
+      <IntegratedEpicsBand
+        epics={completedEpics}
+        ondismiss={ondismissepic ?? (() => {})}
+        onackmigrations={onackmigrationsepic ?? (() => {})}
+        {nowMs}
+      />
     {/if}
   </div>
 </div>

--- a/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
@@ -26,6 +26,8 @@ const epic = (children: CompletedEpicChild[], p: Partial<CompletedEpic> = {}): C
   landingPrNumber: null,
   landingPrUrl: null,
   landingState: "pending",
+  migrationPaths: [],
+  migrationsAckedAt: null,
   ...p,
 });
 
@@ -38,6 +40,7 @@ describe("IntegratedEpicRow", () => {
     render(IntegratedEpicRow, {
       epic: epic([child({ number: 1 }), child({ number: 2 })]),
       ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
     });
     await expect.element(page.getByText("INTEGRATED 2/2")).toBeInTheDocument();
     const chip = document.querySelector(".chip") as HTMLElement;
@@ -63,6 +66,7 @@ describe("IntegratedEpicRow", () => {
         }),
       ]),
       ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
     });
     // mixed epic: merged counts only integrated children, total counts all → 1/2 (not 2/2)
     await expect.element(page.getByText("INTEGRATED 1/2")).toBeInTheDocument();
@@ -95,6 +99,7 @@ describe("IntegratedEpicRow", () => {
         }),
       ]),
       ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -121,6 +126,7 @@ describe("IntegratedEpicRow", () => {
         }),
       ]),
       ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -145,6 +151,7 @@ describe("IntegratedEpicRow", () => {
         landingPrUrl: "https://github.com/o/r/pull/42",
       }),
       ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -168,6 +175,7 @@ describe("IntegratedEpicRow", () => {
         landingPrUrl: "https://github.com/o/r/pull/42",
       }),
       ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -193,6 +201,7 @@ describe("IntegratedEpicRow", () => {
         landingPrUrl: null,
       }),
       ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -210,6 +219,7 @@ describe("IntegratedEpicRow", () => {
     render(IntegratedEpicRow, {
       epic: epic([child({ number: 1 })], { landingState: "pending" }),
       ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -227,6 +237,7 @@ describe("IntegratedEpicRow", () => {
     render(IntegratedEpicRow, {
       epic: epic([child({ number: 1 })], { repoPath: "/x/y/zrepo", parentIssueNumber: 42 }),
       ondismiss,
+      onackmigrations: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
     const btn = await vi.waitFor(() => {
@@ -237,5 +248,89 @@ describe("IntegratedEpicRow", () => {
     btn.click();
     expect(ondismiss).toHaveBeenCalledTimes(1);
     expect(ondismiss).toHaveBeenCalledWith("/x/y/zrepo", 42);
+  });
+
+  // ── Migration-awareness checkpoint (#645) ──────────────────────────────────
+
+  it("pending ack: shows the warning chip (count from array) + ack button, hides plain Dismiss", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        migrationPaths: ["server/migrations/001.sql", "drizzle/0002.sql"],
+        migrationsAckedAt: null,
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const chip = await vi.waitFor(() => {
+      const el = document.querySelector(".actions .chip-migrations") as HTMLElement | null;
+      if (!el) throw new Error("no migration chip yet");
+      return el;
+    });
+    // count derives from migrationPaths.length (2), not a hardcoded number
+    expect(chip.textContent).toContain("2 migration");
+    // amber warning tone (NOT green)
+    expect(getComputedStyle(chip).color).not.toBe("");
+
+    // the ack action replaces the plain Dismiss button
+    const actionText = document.querySelector(".actions")?.textContent ?? "";
+    expect(actionText).toContain("Acknowledge migrations");
+    expect(actionText).not.toContain("Dismiss");
+  });
+
+  it("acknowledged migrations: behaves as normal (plain Dismiss, no chip)", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        migrationPaths: ["server/migrations/001.sql"],
+        migrationsAckedAt: Date.now(),
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+    await vi.waitFor(() => {
+      if (!document.querySelector(".actions .gbtn")) throw new Error("no actions yet");
+    });
+    expect(document.querySelector(".actions .chip-migrations")).toBeNull();
+    expect(document.querySelector(".actions")?.textContent).toContain("Dismiss");
+    expect(document.querySelector(".actions")?.textContent).not.toContain("Acknowledge migrations");
+  });
+
+  it("no migrations: behaves as normal (plain Dismiss, no chip)", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], { migrationPaths: [], migrationsAckedAt: null }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+    await vi.waitFor(() => {
+      if (!document.querySelector(".actions .gbtn")) throw new Error("no actions yet");
+    });
+    expect(document.querySelector(".actions .chip-migrations")).toBeNull();
+    expect(document.querySelector(".actions")?.textContent).toContain("Dismiss");
+  });
+
+  it("clicking the ack button calls onackmigrations(repoPath, parentIssueNumber)", async () => {
+    const onackmigrations = vi.fn();
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        repoPath: "/x/y/zrepo",
+        parentIssueNumber: 42,
+        migrationPaths: ["migrations/001.sql"],
+        migrationsAckedAt: null,
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations,
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+    const btn = await vi.waitFor(() => {
+      const b = document.querySelector(".actions .gbtn") as HTMLButtonElement | null;
+      if (!b) throw new Error("no ack button yet");
+      return b;
+    });
+    btn.click();
+    expect(onackmigrations).toHaveBeenCalledTimes(1);
+    expect(onackmigrations).toHaveBeenCalledWith("/x/y/zrepo", 42);
   });
 });

--- a/ui/src/lib/components/IntegratedEpicRow.svelte
+++ b/ui/src/lib/components/IntegratedEpicRow.svelte
@@ -20,6 +20,9 @@
   // Migration-awareness checkpoint (#645): the landing PR carries unacknowledged migration
   // files. The harness never runs them (read-only critic, no DB), so the operator must verify +
   // acknowledge before clearing the row. Count derives from the array — no hardcoded number.
+  // Note: acknowledging dismisses the row server-side (ackEpicMigrations sets dismissedAt, which
+  // listEpicCompleted filters out), so a displayed row always has migrationsAckedAt == null; the
+  // == null guard is belt-and-suspenders, not the gate. The real gate is the row being shown.
   const migrationCount = $derived(epic.migrationPaths.length);
   const pendingAck = $derived(migrationCount > 0 && epic.migrationsAckedAt == null);
 

--- a/ui/src/lib/components/IntegratedEpicRow.svelte
+++ b/ui/src/lib/components/IntegratedEpicRow.svelte
@@ -6,14 +6,22 @@
   let {
     epic,
     ondismiss,
+    onackmigrations,
     nowMs = Date.now(),
   }: {
     epic: CompletedEpic;
     ondismiss: (repoPath: string, parent: number) => void;
+    onackmigrations: (repoPath: string, parent: number) => void;
     nowMs?: number;
   } = $props();
 
   let open = $state(false);
+
+  // Migration-awareness checkpoint (#645): the landing PR carries unacknowledged migration
+  // files. The harness never runs them (read-only critic, no DB), so the operator must verify +
+  // acknowledge before clearing the row. Count derives from the array — no hardcoded number.
+  const migrationCount = $derived(epic.migrationPaths.length);
+  const pendingAck = $derived(migrationCount > 0 && epic.migrationsAckedAt == null);
 
   // repo basename — last path segment (e.g. "community-map")
   const repoName = $derived(epic.repoPath.split("/").filter(Boolean).at(-1) ?? epic.repoPath);
@@ -88,14 +96,28 @@
     </ul>
 
     <div class="actions">
-      <button
-        class="gbtn"
-        type="button"
-        title={m.integrated_epics_dismiss()}
-        onclick={() => ondismiss(epic.repoPath, epic.parentIssueNumber)}
-      >
-        {m.integrated_epics_dismiss()}
-      </button>
+      {#if pendingAck}
+        <span class="chip-migrations" title={m.epic_migrations_pending({ count: migrationCount })}>
+          {m.epic_migrations_pending({ count: migrationCount })}
+        </span>
+        <button
+          class="gbtn"
+          type="button"
+          title={m.integrated_epics_ack_migrations()}
+          onclick={() => onackmigrations(epic.repoPath, epic.parentIssueNumber)}
+        >
+          {m.integrated_epics_ack_migrations()}
+        </button>
+      {:else}
+        <button
+          class="gbtn"
+          type="button"
+          title={m.integrated_epics_dismiss()}
+          onclick={() => ondismiss(epic.repoPath, epic.parentIssueNumber)}
+        >
+          {m.integrated_epics_dismiss()}
+        </button>
+      {/if}
       {#if epic.landingState === "open" && epic.landingPrNumber != null}
         {#if epic.landingPrUrl}
           <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
@@ -273,6 +295,19 @@
   .landing-failed {
     color: var(--color-amber);
     font-size: var(--fs-micro);
+  }
+
+  /* Warning-tone chip — unrun migrations need operator verification before clearing the row.
+     Amber = caution (NOT success-green); mirrors the .badge recipe with the warning hue. */
+  .chip-migrations {
+    flex: none;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    padding: 1px 6px;
+    border: 1px solid var(--color-amber);
+    border-radius: 2px;
+    color: var(--color-amber);
+    background: color-mix(in oklab, var(--color-amber) 12%, transparent);
   }
 
   /* Canonical .gbtn recipe (scoped per-component; see /design-system). */

--- a/ui/src/lib/components/IntegratedEpicsBand.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicsBand.browser.test.ts
@@ -25,6 +25,8 @@ const epic = (n: number): CompletedEpic => ({
   landingPrNumber: null,
   landingPrUrl: null,
   landingState: "pending",
+  migrationPaths: [],
+  migrationsAckedAt: null,
 });
 
 afterEach(() => {
@@ -33,13 +35,17 @@ afterEach(() => {
 
 describe("IntegratedEpicsBand", () => {
   it("renders nothing when epics is empty", async () => {
-    render(IntegratedEpicsBand, { epics: [], ondismiss: vi.fn() });
+    render(IntegratedEpicsBand, { epics: [], ondismiss: vi.fn(), onackmigrations: vi.fn() });
     expect(document.querySelector(".band")).toBeNull();
     expect(document.querySelector(".band-head")).toBeNull();
   });
 
   it("header shows the count and expanding reveals one row per epic", async () => {
-    render(IntegratedEpicsBand, { epics: [epic(1), epic(2)], ondismiss: vi.fn() });
+    render(IntegratedEpicsBand, {
+      epics: [epic(1), epic(2)],
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+    });
     await expect.element(page.getByText("Integrated epics (2)")).toBeInTheDocument();
     // collapsed by default → no rows
     expect(document.querySelectorAll(".rows .row").length).toBe(0);

--- a/ui/src/lib/components/IntegratedEpicsBand.svelte
+++ b/ui/src/lib/components/IntegratedEpicsBand.svelte
@@ -6,10 +6,12 @@
   let {
     epics,
     ondismiss,
+    onackmigrations,
     nowMs = Date.now(),
   }: {
     epics: CompletedEpic[];
     ondismiss: (repoPath: string, parent: number) => void;
+    onackmigrations: (repoPath: string, parent: number) => void;
     nowMs?: number;
   } = $props();
 
@@ -34,7 +36,7 @@
     {#if !collapsed}
       <div class="rows">
         {#each epics as epic (`${epic.repoPath}#${epic.parentIssueNumber}`)}
-          <IntegratedEpicRow {epic} {ondismiss} {nowMs} />
+          <IntegratedEpicRow {epic} {ondismiss} {onackmigrations} {nowMs} />
         {/each}
       </div>
     {/if}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -841,4 +841,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_mobile_menu_docs_title",
     bodyKey: "feat_mobile_menu_docs_body",
   },
+  {
+    // No targetId: the migration chip only appears on a completed-epic row whose landing PR
+    // carries migration files, so a coachmark anchor would usually be absent — surface via the
+    // What's-New drawer only. 1.29.0 is the latest released tag, so this ships in 1.30.0.
+    id: "epic-migration-checkpoint",
+    sinceVersion: "1.30.0",
+    titleKey: "feat_epic_migrations_title",
+    bodyKey: "feat_epic_migrations_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -742,6 +742,8 @@ function completedEpic(repoPath: string, parentIssueNumber: number): CompletedEp
     landingPrNumber: null,
     landingPrUrl: null,
     landingState: "pending",
+    migrationPaths: [],
+    migrationsAckedAt: null,
   };
 }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -397,6 +397,12 @@ export interface CompletedEpic {
   // resolved, open=PR opened/reused, merged=landing PR merged (epic landed), none=nothing
   // to land, error=last attempt failed.
   landingState: "pending" | "open" | "merged" | "none" | "error";
+  // Migration-awareness checkpoint (#645): migration file paths detected in the landing PR
+  // (empty when none / detection unavailable) + the epoch the operator acknowledged them (null
+  // until acknowledged). A non-empty migrationPaths with a null migrationsAckedAt makes the row
+  // ask for acknowledgement before it can be cleared — never gates the completion flip.
+  migrationPaths: string[];
+  migrationsAckedAt: number | null;
 }
 
 /** One queued backlog issue behind DrainStatus.queued — a row in the queue popover.

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -35,6 +35,7 @@
     getAutoMerge,
     getCompletedEpics,
     dismissCompletedEpic,
+    ackEpicMigrations,
     getEpic,
     getDiagnostics,
     halt as apiHalt,
@@ -1281,6 +1282,26 @@
     }
   }
 
+  // Acknowledge a completed epic's landing-PR migrations (#645). Like onDismissEpic, the server
+  // ack also dismisses the row, so optimistically remove it; on failure, restore + toast.
+  async function onAckEpicMigrations(repoPath: string, parent: number) {
+    const match = (e: CompletedEpic) => e.repoPath === repoPath && e.parentIssueNumber === parent;
+    const removed = store.completedEpics.find(match);
+    store.completedEpics = store.completedEpics.filter((e) => !match(e)); // optimistic
+    try {
+      await ackEpicMigrations(repoPath, parent);
+    } catch {
+      if (removed && !store.completedEpics.some(match)) {
+        store.completedEpics = [removed, ...store.completedEpics];
+      }
+      toasts.info(m.integrated_epics_ack_migrations_failed(), {
+        alert: true,
+        duration: null,
+        key: `epic-ack-migrations-fail:${repoPath}#${parent}`,
+      });
+    }
+  }
+
   // Confirmed: clear the dialog state (before the await, so it can't double-submit),
   // then run the bulk archive.
   function confirmClearMerged() {
@@ -1455,6 +1476,7 @@
               doneSelectedId = id;
               mobileScreen = "detail";
             }}
+            onackmigrationsepic={onAckEpicMigrations}
           />
           {#if store.sessions.length === 0 && herdFilter !== "done"}
             <BacklogView
@@ -1598,6 +1620,7 @@
             doneList={doneSessions.sessions}
             {doneSelectedId}
             ondoneselect={(id) => (doneSelectedId = id)}
+            onackmigrationsepic={onAckEpicMigrations}
           />
         {/if}
         {#if herdFilter === "done"}


### PR DESCRIPTION
## Why

Closes the remaining actionable learnings from **#645** ("Epic Runner: learnings from first epic"), now that **both halves** of the Epic Runner have landed — Stage A (#618: integration branch + done-on-merge gate) and Stage B (#661: final `epic/# → default` landing PR). Of the 8 learnings, #3/#4/#8 were already delivered by those, #6/#7 turned out to be already-covered by the harness, and this PR ships the rest: the two epic-handler guardrails (#1, #2) and a migration-awareness checkpoint (#5). See the reconciliation table on #645 for the full per-learning disposition.

## What

**1. Pin & record the canonical epic branch (#645.1)** — `epic_run.integrationBranch` now **persists** the integration-branch name (`getOrInitEpicIntegrationBranch`); the spawn base **and the landing-PR base** read the pinned name instead of re-deriving it from the title each time. This fixes a latent bug: editing an epic's title mid-run used to re-point new spawns + the landing PR to `epic/<#>-<new-slug>`, orphaning children already merged on the old slug and landing a branch missing them.

**2. Detect epic-branch divergence (#645.1)** — three signals surfaced as `Epic.warnings`: (a) title drift (pinned ≠ title-derived), (b) a child's recorded merged-base ≠ pinned, (c) a host `epic/*` ref that references the parent number but isn't the pinned branch (throttled `forge.listBranches` scan, digit-bounded match so `epic/efi-valuemap-327` is caught). Forward-looking only — historical orphans aren't retroactively detected (documented).

**3. Enforce child PR base at retire — fail closed (#645.2)** — before squash-merging an epic child, retire now reads the PR's actual `baseRefName` (`forge.prReviewMeta`). On mismatch it **does not merge / record / drop the claim** — it parks a throttled marker and surfaces an **actionable** warning naming the remedy (`gh pr edit <pr> --base <pinned>`). Stale markers self-heal once the child is done-in-epic. (Auto-retarget was deliberately **not** built — operator chose warn+block.) Gitea (no `prReviewMeta`) keeps current behavior.

**4. Migration-awareness acknowledgement checkpoint (#645.5)** — when an epic's landing PR is opened, Shepherd detects DB-migration files in its diff (`detectMigrationPaths` + `forge.prChangedPaths`) and the landing band shows a **warning chip** ("N migration file(s) — verify before merge, not run in-harness"); the row requires an explicit **"Acknowledge migrations & dismiss"** before it clears. The gate is **band-level only** — it never blocks the autonomous `running → idle` completion flip (Stage B decoupled that to avoid wedging the drain). Detection is fail-safe (a probe failure just omits the chip). **Not** built: in-harness migration *execution* / ephemeral DB (conflicts with the read-only critic) — an accepted limitation noted on #645.

## Scope / non-goals

- `#645.3/#4/#8` shipped earlier (#661 / Stage A); `#645.6` (CI-green) is covered by real `forge.prStatus().checks`; `#645.7` (stale validation worktree) was already solved (reviewer checks out the exact PR-head SHA, #631/#638). No code here for those — see the #645 table.
- New forge methods (`listBranches`, `prChangedPaths`) are GitHub-only; Gitea degrades gracefully (no scan, no chip), consistent with the existing `prReviewMeta`/`ensureBranch` GitHub-lean.
- `assembleEpic` stays pure — all forge/store reads happen in `drain.buildEpic` and are passed in.

## Tests / gates

- Root: `bunx tsc --noEmit` ✅ · `bun run lint` ✅ · `bun test ./test` → **2835 pass, 0 fail** ✅
- UI: `bun run check` (0 errors) ✅ · `bun run check:i18n` (EN/DE parity, 1244 keys) ✅ · `bun run test` → **1226 pass** ✅
- `bunx fallow audit --base origin/main --fail-on-issues` ✅ · branch-hygiene ✅ · feature-catalog ✅
- New coverage: `epic-migrations` (glob matcher), `branchReferencesEpic` bounded-token edges, `assembleEpic` divergence + base-mismatch warnings, `recordEpicIntegrated` merged-base, base-enforcement fail-closed + throttle + marker self-heal, migration detect/persist + ack + completion-flip independence, the new server endpoint, and the UI band states.
- Built subagent-driven (fresh implementer + spec & quality review per task, holistic final review), rebased linear on latest `main` (includes #661).

Feature catalog: one entry `epic-migration-checkpoint` (sinceVersion 1.30.0). i18n: keys added to EN+DE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
