### PR TITLE
feat(ui): make Claude's suggested slash commands tappable in the terminal

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1273,5 +1273,7 @@
   "settings_auth_key_save_failed": "API-Schlüssel konnte nicht gespeichert werden",
   "usage_subscription_only": "Nutzungserfassung nur im Abonnement — siehe die Anthropic-Konsole.",
   "feat_api_key_auth_title": "API-Schlüssel-Authentifizierung",
-  "feat_api_key_auth_body": "Aktiviere die Abrechnung gestarteter Agenten über einen Anthropic-API-Schlüssel (Commercial Terms) statt über dein Abonnement — Einstellungen → Sitzung."
+  "feat_api_key_auth_body": "Aktiviere die Abrechnung gestarteter Agenten über einen Anthropic-API-Schlüssel (Commercial Terms) statt über dein Abonnement — Einstellungen → Sitzung.",
+  "feat_tappable_slash_commands_title": "Antippbare Slash-Commands",
+  "feat_tappable_slash_commands_body": "Tippe einen von Claude im Terminal vorgeschlagenen Slash-Command an (z. B. /squad, /gsd-quick), um ihn in die Eingabe zu übernehmen — kein Abtippen auf dem Handy. Er wird eingefügt, nicht gesendet: du prüfst und drückst selbst Enter."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1273,5 +1273,7 @@
   "settings_auth_key_save_failed": "Couldn't save the API key",
   "usage_subscription_only": "Usage tracking is subscription-only — see the Anthropic Console.",
   "feat_api_key_auth_title": "API-key auth mode",
-  "feat_api_key_auth_body": "Opt into billing spawned agents against an Anthropic API key (Commercial Terms) instead of your subscription — Settings → Session."
+  "feat_api_key_auth_body": "Opt into billing spawned agents against an Anthropic API key (Commercial Terms) instead of your subscription — Settings → Session.",
+  "feat_tappable_slash_commands_title": "Tappable slash commands",
+  "feat_tappable_slash_commands_body": "Tap a slash command Claude suggests in the terminal (e.g. /squad, /gsd-quick) to drop it into the prompt — no retyping on mobile. It's inserted, not sent, so you review and press Enter yourself."
 }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -31,9 +31,11 @@
     setSessionAutopilot,
     startPreview as apiStartPreview,
     stopPreview as apiStopPreview,
+    getCommands,
   } from "$lib/api";
   import { imageFilesFromItems } from "$lib/clipboard";
   import { composeKeystrokes } from "$lib/compose";
+  import { findCommandLinks } from "$lib/slashLinks";
   import { shouldForwardEscape } from "$lib/terminalEscape";
   import { altComboKey } from "./herd-keynav";
   import { detectNotesKey } from "$lib/notesAffordance";
@@ -204,6 +206,27 @@
   // mirror the live terminal so the theme effect can repaint it without
   // recreating it (recreating would tear down the PTY socket)
   let termRef = $state<Terminal | undefined>();
+
+  // Installed slash-command names (lowercased) for the terminal link provider, which
+  // linkifies command tokens Claude suggests in its output so a tap pastes them into
+  // the prompt. Same authoritative source ComposeBar uses; lowercased so branch (A)
+  // membership is case-insensitive. Stale-guarded against repoPath changing in flight.
+  let knownCommands = $state<Set<string>>(new Set());
+  $effect(() => {
+    const rp = session.repoPath;
+    if (!rp) {
+      knownCommands = new Set();
+      return;
+    }
+    getCommands(rp)
+      .then((r) => {
+        if (rp === session.repoPath)
+          knownCommands = new Set(r.commands.map((c) => c.name.toLowerCase()));
+      })
+      .catch(() => {
+        if (rp === session.repoPath) knownCommands = new Set();
+      });
+  });
 
   /** Hand the keyboard to the live terminal — the page's Enter shortcut calls this
    *  so plain-key navigation (which deliberately keeps focus *out* of the PTY, see
@@ -1180,6 +1203,44 @@
     );
     conn = c;
     term.onData((d) => c.send(d));
+
+    // Linkify slash-command tokens Claude suggests in its output (e.g. "/squad",
+    // "/gsd-quick") so a tap pastes the command into the prompt — on a phone the
+    // command text is otherwise un-actionable inside xterm's canvas. Same link layer
+    // as the URL WebLinksAddon above; recognizer is in slashLinks.ts. The paste omits
+    // a trailing CR (composeKeystrokes would submit) so the user reviews and presses
+    // Enter themselves. No preventDefault/focus here: the el click→onTap→term.focus()
+    // listener below already focuses the terminal on the same tap. Disposed implicitly
+    // by term.dispose() in teardown, like the WebLinksAddon.
+    term.registerLinkProvider({
+      provideLinks(bufferLineNumber, callback) {
+        const text = term.buffer.active.getLine(bufferLineNumber - 1)?.translateToString(true);
+        if (!text) {
+          callback(undefined);
+          return;
+        }
+        const found = findCommandLinks(text, knownCommands);
+        if (found.length === 0) {
+          callback(undefined);
+          return;
+        }
+        callback(
+          found.map((f) => ({
+            text: `/${f.name}`,
+            // xterm columns are 1-based and the range end is inclusive of the last
+            // cell; f.start/f.end are 0-based with end exclusive → +1 / as-is. ASCII
+            // tokens map 1:1 char-index ↔ column.
+            range: {
+              start: { x: f.start + 1, y: bufferLineNumber },
+              end: { x: f.end, y: bufferLineNumber },
+            },
+            activate: () => {
+              c.send(`\x1b[200~/${f.name}\x1b[201~`);
+            },
+          })),
+        );
+      },
+    });
 
     // Fit + push the size to the PTY — but only while the mount is actually
     // visible. A hidden (To-Do tab → display:none) or mid-layout mount

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import "@xterm/xterm/css/xterm.css";
-  import { Terminal } from "@xterm/xterm";
+  import { Terminal, type IBufferLine, type IBufferCell } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
   import { WebLinksAddon } from "@xterm/addon-web-links";
   import type {
@@ -227,6 +227,29 @@
         if (rp === session.repoPath) knownCommands = new Set();
       });
   });
+
+  // Build a terminal line's visible text together with a string-index → 0-based column
+  // map by walking cells, so a wide char (emoji/CJK: 2 columns but 1+ string chars)
+  // before a token doesn't desync the link's tap region from the glyph. Mirrors xterm's
+  // own translateToString (empty cell → " ", advance by the cell's width). `cell` is a
+  // reusable scratch cell to avoid per-cell allocation.
+  function lineTextWithColumns(
+    line: IBufferLine,
+    cell: IBufferCell,
+  ): { text: string; colAt: number[] } {
+    let text = "";
+    const colAt: number[] = [];
+    let col = 0;
+    while (col < line.length) {
+      const c = line.getCell(col, cell);
+      const width = c?.getWidth() ?? 1;
+      const chars = c?.getChars() || " ";
+      for (let i = 0; i < chars.length; i++) colAt.push(col);
+      text += chars;
+      col += width || 1;
+    }
+    return { text, colAt };
+  }
 
   /** Hand the keyboard to the live terminal — the page's Enter shortcut calls this
    *  so plain-key navigation (which deliberately keeps focus *out* of the PTY, see
@@ -1212,13 +1235,15 @@
     // Enter themselves. No preventDefault/focus here: the el click→onTap→term.focus()
     // listener below already focuses the terminal on the same tap. Disposed implicitly
     // by term.dispose() in teardown, like the WebLinksAddon.
+    const linkCell = term.buffer.active.getNullCell();
     term.registerLinkProvider({
       provideLinks(bufferLineNumber, callback) {
-        const text = term.buffer.active.getLine(bufferLineNumber - 1)?.translateToString(true);
-        if (!text) {
+        const line = term.buffer.active.getLine(bufferLineNumber - 1);
+        if (!line) {
           callback(undefined);
           return;
         }
+        const { text, colAt } = lineTextWithColumns(line, linkCell);
         const found = findCommandLinks(text, knownCommands);
         if (found.length === 0) {
           callback(undefined);
@@ -1227,12 +1252,12 @@
         callback(
           found.map((f) => ({
             text: `/${f.name}`,
-            // xterm columns are 1-based and the range end is inclusive of the last
-            // cell; f.start/f.end are 0-based with end exclusive → +1 / as-is. ASCII
-            // tokens map 1:1 char-index ↔ column.
+            // Map string indices → 1-based terminal columns via colAt so a wide char
+            // before the token doesn't shift the tap region; range end is the inclusive
+            // last cell of the token.
             range: {
-              start: { x: f.start + 1, y: bufferLineNumber },
-              end: { x: f.end, y: bufferLineNumber },
+              start: { x: colAt[f.start]! + 1, y: bufferLineNumber },
+              end: { x: colAt[f.end - 1]! + 1, y: bufferLineNumber },
             },
             activate: () => {
               c.send(`\x1b[200~/${f.name}\x1b[201~`);

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -804,4 +804,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_api_key_auth_title",
     bodyKey: "feat_api_key_auth_body",
   },
+  {
+    // No targetId: command links appear inline in the terminal output, which has no
+    // stable mountable anchor — surface via the What's-New drawer only.
+    // 1.29.0 is the latest released tag, so this ships in 1.30.0.
+    id: "tappable-slash-commands",
+    sinceVersion: "1.30.0",
+    titleKey: "feat_tappable_slash_commands_title",
+    bodyKey: "feat_tappable_slash_commands_body",
+  },
 ];

--- a/ui/src/lib/slashLinks.test.ts
+++ b/ui/src/lib/slashLinks.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { findCommandLinks } from "./slashLinks";
+
+const names = (line: string, known: Set<string> = new Set()) =>
+  findCommandLinks(line, known).map((l) => l.name);
+
+describe("findCommandLinks", () => {
+  describe("hits — boundary chars", () => {
+    it("at line start", () => {
+      expect(findCommandLinks("/squad", new Set())).toEqual([{ start: 0, end: 6, name: "squad" }]);
+    });
+    it("after whitespace", () => {
+      expect(findCommandLinks("via /squad", new Set())).toEqual([
+        { start: 4, end: 10, name: "squad" },
+      ]);
+    });
+    it("inline-code (backticks), parens, quotes, brackets", () => {
+      expect(names("`/squad`")).toEqual(["squad"]);
+      expect(names("(/squad)")).toEqual(["squad"]);
+      expect(names('"/squad"')).toEqual(["squad"]);
+      expect(names("[/squad]")).toEqual(["squad"]);
+    });
+  });
+
+  describe("hits — trailing punctuation (not part of the token)", () => {
+    it("sentence-final period", () => {
+      expect(findCommandLinks("run /squad.", new Set())).toEqual([
+        { start: 4, end: 10, name: "squad" },
+      ]);
+    });
+    it("closing paren / backtick / comma", () => {
+      expect(names("/gsd-quick)")).toEqual(["gsd-quick"]);
+      expect(names("/squad`")).toEqual(["squad"]);
+      expect(names("/squad,")).toEqual(["squad"]);
+    });
+  });
+
+  describe("hits — namespaced + two on one line", () => {
+    it("colon namespace via (B)", () => {
+      expect(names("/gsd:quick")).toEqual(["gsd:quick"]);
+    });
+    it("two suggested commands", () => {
+      expect(names("either /squad or /gsd-quick")).toEqual(["squad", "gsd-quick"]);
+    });
+  });
+
+  describe("hits — branch (A) case-insensitive incl. _ / mixed case", () => {
+    const known = new Set(["my_skill", "reviewpr"]);
+    it("uppercase/underscore name matches a known command", () => {
+      expect(names("/My_Skill", known)).toEqual(["My_Skill"]);
+      expect(names("/ReviewPR", known)).toEqual(["ReviewPR"]);
+    });
+    it("same name without a known entry does NOT match (not canonical for B)", () => {
+      expect(names("/My_Skill")).toEqual([]);
+    });
+  });
+
+  describe("no match — paths", () => {
+    it("multi-segment path (followed by /)", () => {
+      expect(names("/home/moe/projects")).toEqual([]);
+      expect(names("/usr/bin")).toEqual([]);
+    });
+    it("enumerated single-segment path prefixes", () => {
+      expect(names("/tmp")).toEqual([]);
+      expect(names("/etc")).toEqual([]);
+      expect(names("/usr")).toEqual([]);
+    });
+    it("file with extension", () => {
+      expect(names("/foo.txt")).toEqual([]);
+      expect(names("/a.md")).toEqual([]);
+    });
+  });
+
+  describe("no match — URLs and mid-word slashes", () => {
+    it("URL", () => {
+      expect(names("see http://example.com/squad")).toEqual([]);
+    });
+    it("mid-word slash", () => {
+      expect(names("a/foo")).toEqual([]);
+      expect(names("and/or")).toEqual([]);
+    });
+    it("fraction-like 24/7 (digit after slash)", () => {
+      expect(names("24/7")).toEqual([]);
+    });
+  });
+
+  describe("graceful degradation — empty known set", () => {
+    it("canonical command still matches via (B); path prefix does not", () => {
+      expect(names("/squad", new Set())).toEqual(["squad"]);
+      expect(names("/tmp", new Set())).toEqual([]);
+    });
+  });
+
+  describe("known command overrides path-prefix denylist", () => {
+    it('"/dev" linkifies when it is an installed command', () => {
+      expect(names("/dev", new Set(["dev"]))).toEqual(["dev"]);
+    });
+  });
+});

--- a/ui/src/lib/slashLinks.ts
+++ b/ui/src/lib/slashLinks.ts
@@ -1,0 +1,92 @@
+// Recognize Claude slash-command tokens (/squad, /gsd-quick) inside a rendered
+// terminal line so Viewport can linkify them — a tap pastes the command into Claude's
+// live prompt. Pure + co-located tests so the recognizer is render-agnostic and
+// reusable: the xterm link provider drives it today, and a DOM-chip fallback would
+// reuse it unchanged if canvas link activation ever proves unworkable.
+
+// Absolute-path first segments that read command-shaped but are filesystem paths in
+// prose. Excluded from the speculative branch (B) so "/tmp", "/etc", "/usr" stay
+// non-tappable. A name that IS an installed command still wins via branch (A).
+const PATH_PREFIXES = new Set([
+  "home",
+  "root",
+  "tmp",
+  "etc",
+  "var",
+  "opt",
+  "dev",
+  "bin",
+  "sbin",
+  "usr",
+  "lib",
+  "lib64",
+  "proc",
+  "sys",
+  "mnt",
+  "media",
+  "run",
+  "boot",
+  "srv",
+]);
+
+export interface CommandLink {
+  /** Char index of the leading "/" in the line. */
+  start: number;
+  /** Char index one past the last char of the name (exclusive). */
+  end: number;
+  /** Command name without the leading slash, verbatim from the line. */
+  name: string;
+}
+
+// Token = "/" + name. Captured broadly (incl. "_" and uppercase) because installed
+// command names are built verbatim from skill/command dir names (server commands.ts)
+// and can carry those — branch (A) membership must be able to see them. The name ends
+// at the first char outside this class (whitespace, backtick, ")", "]", '"', ".", "/").
+const TOKEN = /\/([A-Za-z][A-Za-z0-9:_-]*)/g;
+
+// The canonical lowercase command shape eligible for speculative (B) linkifying.
+const CANONICAL = /^[a-z][a-z0-9:-]*$/;
+
+// Left boundary: char before "/" is line-start OR not alnum/":"/"."/"/". Excludes
+// URLs ("http://" → "/" preceded by ":") and mid-word slashes ("a/foo").
+function leftBoundaryOk(line: string, slash: number): boolean {
+  const prev = slash > 0 ? line[slash - 1]! : "";
+  return prev === "" || !/[A-Za-z0-9:./]/.test(prev);
+}
+
+// Right disambiguation on the FOLLOWING char (already outside the token): a "/" means
+// a multi-segment path ("/home/moe"); a "." before an alnum means a file extension
+// ("/foo.txt"). A trailing "." at a sentence end ("/squad.") is fine.
+function rightBoundaryOk(line: string, end: number): boolean {
+  const next = line[end] ?? "";
+  if (next === "/") return false;
+  if (next === "." && /[A-Za-z0-9]/.test(line[end + 1] ?? "")) return false;
+  return true;
+}
+
+// Union: (A) a known installed command (case-insensitive — covers mixed-case/underscore
+// names) OR (B) a canonical lowercase shape that is not an absolute-path prefix.
+function nameOk(name: string, known: Set<string>): boolean {
+  if (known.has(name.toLowerCase())) return true;
+  return CANONICAL.test(name) && !PATH_PREFIXES.has(name);
+}
+
+/**
+ * Find linkifiable slash-command tokens in a single rendered terminal line.
+ *
+ *   findCommandLinks("via /squad", new Set())      → [{ start: 4, end: 10, name: "squad" }]
+ *   findCommandLinks("/home/moe/x", new Set())     → []   (followed by "/": path)
+ *   findCommandLinks("/My_Skill", set(["my_skill"]))→ [{ ... name: "My_Skill" }] (A)
+ */
+export function findCommandLinks(line: string, known: Set<string>): CommandLink[] {
+  const out: CommandLink[] = [];
+  for (const m of line.matchAll(TOKEN)) {
+    const slash = m.index;
+    const name = m[1]!;
+    const end = slash + 1 + name.length;
+    if (leftBoundaryOk(line, slash) && rightBoundaryOk(line, end) && nameOk(name, known)) {
+      out.push({ start: slash, end, name });
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Problem

Claude often suggests slash commands in its output (e.g. *„… via `/squad` oder `/gsd-quick`"*). In the terminal those are plain xterm-canvas text — on mobile there is **no selection affordance**, so the only way to act on one was to retype it by hand. Reported from the iPhone view: tapping a suggested command did nothing but focus the input.

## What this does

Registers an xterm **link provider** (the same link layer as the existing URL `WebLinksAddon`) that linkifies slash-command tokens in the terminal output. A **tap pastes the command into Claude's prompt** via bracketed paste **without** a trailing CR — so it is *inserted, not submitted*. The user reviews/edits and presses Enter themselves (safe against fat-finger taps that would otherwise fire e.g. a whole `/squad` team).

## Recognition (`ui/src/lib/slashLinks.ts`, pure + tested)

A token `/name` is linkified via a **union** so the reported scenario can't slip through a false-negative:

- **(A)** its name is an **installed command** (`getCommands`, the same authoritative source ComposeBar/NewTask use) — matched **case-insensitively** so mixed-case/underscore dir-names still resolve; **or**
- **(B)** it is a **canonical lowercase command shape** that is not an absolute-path prefix.

Excluded: URLs (`http://…`), multi-segment paths (`/home/moe/…`), single-segment path prefixes (`/tmp`, `/etc`, `/usr`), file extensions (`/foo.txt`), and mid-word slashes (`a/foo`). Inline-code/bracketed forms (`` `/squad` ``, `(/squad)`) and sentence-final punctuation (`/squad.`) are handled.

## Notes / scope

- No `preventDefault`/explicit focus in `activate()`: the existing `el` click→`term.focus()` listener already focuses the terminal on the same tap.
- The recognizer is render-agnostic and fully unit-tested, so it is reusable if a DOM-chip surface is ever preferred.
- Feature-discovery catalog entry + EN/DE messages added (`tappable-slash-commands`, ships in 1.30.0).
- Pre-push `fallow` flags a pre-existing UnitTile↔Viewport clone (shared xterm/connectPty boilerplate) as an inherited warning — not introduced here.

## Manual verification (human-in-the-loop)

xterm link activation under Claude Code's always-on mouse-tracking is already proven by the shipped URL `WebLinksAddon` (same pipeline). Please confirm on a **real iPhone** that a suggested command (a) activates on touch and (b) pastes without auto-submitting and without perturbing the TUI (no stray mouse-report) — that device tap is the one check I can't run autonomously.

## Tests

- `slashLinks.test.ts` — 17 cases (hits incl. boundary/punctuation/namespacing/case-insensitive (A); rejects paths/URLs/extensions; graceful degradation on empty command set).
- Full UI suite green (1264 passed); `check`, `check:i18n` green.