### PR TITLE
feat(auth): verify-key step for api-key auth (#671)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ import { normalizeDefaultModelSetting } from "./default-model";
 import { normalizeAuthModeSetting } from "./auth-mode";
 import { EgressWatcher } from "./egress-watch";
 import { RecapService } from "./recap";
+import { verifyApiKey } from "./verify-key";
 
 const execFileAsync = promisify(execFile);
 
@@ -977,6 +978,7 @@ const server = serve(
     planGate: { consider: (s) => planGate.consider(s) },
     recapCache: { snapshot: () => recapService.snapshot() },
     recap: { regenerate: (s) => recapService.regenerate(s) },
+    verifyKey: () => verifyApiKey({ herdr }),
     backlog,
     // After a backlog merge, force-refresh the repo's counts past the read-TTL and
     // re-broadcast the overview so the merged PR (and any auto-closed linked issue)

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,7 @@ import type { UsageLimits, UsageLimitsService } from "./usage-limits";
 import type { UpdateService } from "./update";
 import type { HerdrUpdateService } from "./herdr-update";
 import type { DiagnosticsService } from "./diagnostics";
+import type { VerifyKeyResult } from "./verify-key";
 import type { StarPromptStatus } from "./star-prompt";
 import type {
   Session,
@@ -196,6 +197,9 @@ export interface AppDeps {
   recapCache?: { snapshot(): Record<string, import("./types").Recap> };
   /** Force-regenerate a session recap on demand (the /recap/regenerate route). */
   recap?: { regenerate(session: Session): Promise<"started" | "empty" | "error"> };
+  /** Verify the configured api-key authenticates end-to-end (the /settings/verify-key route);
+   *  absent in environments where it isn't wired. Returns only {ok,reason?,detail?} — no key/path. */
+  verifyKey?: () => Promise<VerifyKeyResult>;
   /** Backlog counts service; absent in tests that don't exercise it. */
   backlog?: Pick<CountsService, "counts">;
   /** Force-refresh one repo's backlog counts (bypassing the read-TTL) and push the
@@ -1974,6 +1978,25 @@ async function handleProjects({ req, parts, deps }: Ctx): Promise<Response | nul
   return null;
 }
 
+// ── settings: verify the configured api-key authenticates end-to-end ──
+// POST /api/settings/verify-key → spawns a transient verify agent (via deps.verifyKey)
+// and returns ONLY {ok,reason?,detail?} — never the key or its helper path, never logged.
+async function handleSettingsVerifyKey({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (
+    !(
+      parts[0] === "api" &&
+      parts[1] === "settings" &&
+      parts[2] === "verify-key" &&
+      !parts[3] &&
+      req.method === "POST"
+    )
+  )
+    return null;
+  if (!deps.verifyKey) return json({ error: "verify not available" }, 503);
+  const r = await deps.verifyKey();
+  return json({ ok: r.ok, reason: r.reason, detail: r.detail });
+}
+
 // ── settings: read/update the repo root (persisted, applied at runtime) ──
 async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (!(parts[0] === "api" && parts[1] === "settings" && !parts[2])) return null;
@@ -3352,6 +3375,7 @@ const ROUTE_HANDLERS = [
   handleUploads,
   handleRepos,
   handleProjects,
+  handleSettingsVerifyKey,
   handleSettings,
   handleSteers,
   handleProjectIcons,

--- a/src/verify-key.ts
+++ b/src/verify-key.ts
@@ -1,0 +1,216 @@
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import type { HerdrDriver } from "./herdr";
+import {
+  isApiKeyMode,
+  isApiKeyConfigured,
+  apiKeySettingsFragment,
+  apiKeyPassthroughEnv,
+} from "./spawn-auth";
+
+/**
+ * Token the verify agent must write to {@link VERIFY_FILE}. Distinctive + unlikely
+ * to appear in benign pane chatter — so its presence in the file is unambiguous proof
+ * the spawned `claude` completed a real authenticated turn end-to-end.
+ */
+export const SENTINEL = "SHEPHERD_KEY_OK_8F3A";
+
+/** The file the verify agent writes {@link SENTINEL} to, in its temp cwd. */
+export const VERIFY_FILE = ".shepherd-verify";
+
+/**
+ * Conservative, auth-SPECIFIC signatures that flag an authentication failure in the
+ * agent's pane text. Kept narrow so benign output (or a successful turn) never matches:
+ * each pattern names an unambiguous auth condition, not a generic error. Used to
+ * FAST-FAIL `verifyApiKey` the instant a 401/login error renders, instead of waiting
+ * out the full timeout.
+ */
+export const AUTH_ERROR_SIGNATURES: RegExp[] = [
+  /invalid x-api-key/i,
+  /authentication_error/i,
+  /(api error|status)[: ]+401/i,
+  /invalid api key/i,
+  /please run \/login/i,
+  /oauth token has expired/i,
+];
+
+/**
+ * First pane line matching any {@link AUTH_ERROR_SIGNATURES} signature, trimmed (for
+ * surfacing as `detail`); null when nothing matches. Line-scoped so the returned detail
+ * is a single readable line, not the whole buffer.
+ */
+export function matchAuthError(paneText: string): string | null {
+  for (const rawLine of paneText.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (AUTH_ERROR_SIGNATURES.some((re) => re.test(line))) return line;
+  }
+  return null;
+}
+
+export interface VerifyKeyDeps {
+  herdr: Pick<HerdrDriver, "start" | "stop" | "readAsync">;
+  makeTmpDir?: () => string;
+  readSentinel?: (cwd: string) => string | null;
+  cleanup?: (cwd: string) => void;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  timeoutMs?: number;
+  pollMs?: number;
+}
+
+export interface VerifyKeyResult {
+  ok: boolean;
+  reason?: string;
+  detail?: string;
+}
+
+/** Self-contained instructions for the verify agent. NOT UI chrome — never i18n'd. */
+export function verifyPrompt(): string {
+  return [
+    `Write EXACTLY the token \`${SENTINEL}\` (and nothing else — no quotes, no newline preamble)`,
+    `to the file \`${VERIFY_FILE}\` in the current directory, then stop.`,
+    "Do not read or modify any other file.",
+  ].join(" ");
+}
+
+const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function defaultMakeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "shepherd-verify-"));
+}
+function defaultReadSentinel(cwd: string): string | null {
+  const p = join(cwd, VERIFY_FILE);
+  if (!existsSync(p)) return null;
+  try {
+    return readFileSync(p, "utf8");
+  } catch {
+    return null; // partial write; try again next poll
+  }
+}
+function defaultCleanup(cwd: string): void {
+  try {
+    rmSync(cwd, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * The `claude` argv for the verify spawn — mirrors the namer (src/namer-llm.ts):
+ *  - `--disable-slash-commands`: drop the user's global hooks/skills so a SessionStart
+ *    preamble can't make the agent thrash under dontAsk. NOT `--bare` (refuses sub-OAuth);
+ *    in api-key mode the key arrives via `apiKeyHelper` in --settings + a credential-less
+ *    CLAUDE_CONFIG_DIR (see spawn-auth).
+ *  - Bare `Write` — NOT Write(<path>): path-scoped Write is silently denied under dontAsk,
+ *    which would block the sentinel write. The agent has no Bash/Edit/network.
+ *  - `--permission-mode dontAsk` LAST before the prompt: `--allowedTools` is variadic and
+ *    eats following tokens until the next flag, so a single-value flag must sit between the
+ *    allowlist and the trailing prompt. Don't reorder.
+ */
+function verifyArgv(): string[] {
+  return [
+    "claude",
+    "--session-id",
+    randomUUID(),
+    "--settings",
+    JSON.stringify({ disableAllHooks: true, ...apiKeySettingsFragment() }),
+    "--disable-slash-commands",
+    "--allowedTools",
+    "Write",
+    "--model",
+    "haiku",
+    "--permission-mode",
+    "dontAsk",
+    verifyPrompt(),
+  ];
+}
+
+/** Single readable line for `detail`: newlines collapsed, clipped to ~500 chars. */
+function clipDetail(line: string): string {
+  return line.replace(/\s+/g, " ").trim().slice(0, 500);
+}
+
+/**
+ * Verify the configured Anthropic API key actually authenticates, END-TO-END through
+ * the same api-key spawn wiring real agents use: a transient interactive `claude`
+ * (subscription-style OAuth spawn — NOT `claude -p`) with the key supplied via the
+ * `apiKeyHelper` + credential-less CLAUDE_CONFIG_DIR. Spawns haiku in a fresh temp dir
+ * with only Write, instructed to write {@link SENTINEL} to {@link VERIFY_FILE}; polls
+ * for that file, fast-fails on an auth error in the pane, then tears the agent + dir down.
+ *
+ * WHY the sentinel-file + pane-matcher discriminator: a `claude` spawned this way does
+ * NOT exit after its turn — on success it writes the file and goes idle; on a 401 it
+ * renders the error and ALSO stays idle. herdr exposes no liveness/exit field, so the
+ * ONLY way to tell the two apart is the sentinel file (good) vs an auth-error in the pane
+ * (bad). Hence {@link matchAuthError} is load-bearing, not a nicety.
+ *
+ * Fail-closed: never spawns unless api-key mode is selected AND a key is configured.
+ * Secret hygiene: this function never receives the raw key (only the helper PATH via
+ * config) and never logs pane text / detail verbatim — `detail` is clipped.
+ */
+export async function verifyApiKey(deps: VerifyKeyDeps): Promise<VerifyKeyResult> {
+  // Guards (fail-closed): do NOT spawn outside a configured api-key setup.
+  if (!isApiKeyMode()) return { ok: false, reason: "not-api-key-mode" };
+  if (!isApiKeyConfigured()) return { ok: false, reason: "not-configured" };
+
+  const {
+    makeTmpDir = defaultMakeTmpDir,
+    readSentinel = defaultReadSentinel,
+    cleanup = defaultCleanup,
+    now = Date.now,
+    sleep = realSleep,
+    timeoutMs = 60_000, // cold `claude` startup + a haiku turn needs headroom
+    pollMs = 750,
+  } = deps;
+
+  let cwd: string | null = null;
+  let terminalId: string | null = null;
+  try {
+    cwd = makeTmpDir();
+    try {
+      terminalId = deps.herdr.start(
+        "verify api key",
+        cwd,
+        verifyArgv(),
+        apiKeyPassthroughEnv(false),
+      ).terminalId;
+    } catch {
+      return { ok: false, reason: "spawn-failed" };
+    }
+
+    const start = now();
+    while (now() - start <= timeoutMs) {
+      // 1. Sentinel file = unambiguous success.
+      const raw = readSentinel(cwd);
+      if (raw !== null && raw.includes(SENTINEL)) return { ok: true };
+
+      // 2. Auth error in the pane = unambiguous failure — fast-fail before the deadline.
+      let pane = "";
+      try {
+        pane = await deps.herdr.readAsync(terminalId, "visible");
+      } catch {
+        pane = ""; // transient read failure → just keep polling
+      }
+      const authError = matchAuthError(pane);
+      if (authError) {
+        return { ok: false, reason: "not-authenticated", detail: clipDetail(authError) };
+      }
+
+      // 3. Neither yet — wait and re-probe.
+      await sleep(pollMs);
+    }
+    return { ok: false, reason: "timeout" };
+  } finally {
+    if (terminalId) {
+      try {
+        deps.herdr.stop(terminalId);
+      } catch {
+        /* best-effort */
+      }
+    }
+    if (cwd) cleanup(cwd);
+  }
+}

--- a/src/verify-key.ts
+++ b/src/verify-key.ts
@@ -68,7 +68,7 @@ export interface VerifyKeyResult {
 }
 
 /** Self-contained instructions for the verify agent. NOT UI chrome — never i18n'd. */
-export function verifyPrompt(): string {
+function verifyPrompt(): string {
   return [
     `Write EXACTLY the token \`${SENTINEL}\` (and nothing else — no quotes, no newline preamble)`,
     `to the file \`${VERIFY_FILE}\` in the current directory, then stop.`,

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -538,3 +538,57 @@ test("PUT anthropicApiKey with non-string/non-null value → 400", async () => {
     expect(res.status).toBe(400);
   }
 });
+
+// ── POST /api/settings/verify-key ──────────────────────────────────────────
+// Builds an app wiring a stubbed deps.verifyKey (or omitting it).
+function verifyHarness(verifyKey?: AppDeps["verifyKey"]): ReturnType<typeof makeApp> {
+  const deps: AppDeps = {
+    store: new SessionStore(":memory:"),
+    events: new EventHub(),
+    service: {} as any,
+    usageLimits: { limits: () => ({}) } as any,
+    verifyKey,
+  };
+  return makeApp(deps);
+}
+
+const postVerify = (app: ReturnType<typeof makeApp>) =>
+  app.fetch(new Request("http://x/api/settings/verify-key", { method: "POST" }));
+
+test("POST /api/settings/verify-key → 200 {ok:true} when the verify succeeds", async () => {
+  const app = verifyHarness(async () => ({ ok: true }));
+  const res = await postVerify(app);
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+});
+
+test("POST /api/settings/verify-key echoes reason+detail and leaks no key/path", async () => {
+  const app = verifyHarness(async () => ({
+    ok: false,
+    reason: "not-authenticated",
+    detail: "invalid x-api-key",
+  }));
+  const res = await postVerify(app);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.ok).toBe(false);
+  expect(body.reason).toBe("not-authenticated");
+  expect(body.detail).toBe("invalid x-api-key");
+  // Body must carry ONLY {ok,reason,detail} — never a key or its helper path.
+  const allowed = new Set(["ok", "reason", "detail"]);
+  expect(Object.keys(body).every((k) => allowed.has(k))).toBe(true);
+});
+
+test("POST /api/settings/verify-key → 503 when deps.verifyKey is absent", async () => {
+  const app = verifyHarness(undefined);
+  const res = await postVerify(app);
+  expect(res.status).toBe(503);
+});
+
+test("GET /api/settings is unaffected by the verify-key route", async () => {
+  config.repoRoot = tmp;
+  const app = verifyHarness(async () => ({ ok: true }));
+  const res = await app.fetch(new Request("http://x/api/settings"));
+  expect(res.status).toBe(200);
+  expect((await res.json()).repoRoot).toBe(tmp);
+});

--- a/test/verify-key.test.ts
+++ b/test/verify-key.test.ts
@@ -1,0 +1,249 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  verifyApiKey,
+  matchAuthError,
+  AUTH_ERROR_SIGNATURES,
+  SENTINEL,
+  VERIFY_FILE,
+  type VerifyKeyDeps,
+} from "../src/verify-key";
+import { config } from "../src/config";
+import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+
+beforeEach(() => {
+  __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
+});
+
+afterEach(() => {
+  __setApiKeyConfigDirProvisionForTest(null);
+});
+
+async function withAuth<T>(
+  mode: typeof config.authMode,
+  helper: string | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  config.authMode = mode;
+  config.authApiKeyHelperPath = helper;
+  try {
+    return await fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
+
+function makeDeps(over: Partial<VerifyKeyDeps> & { readAsync?: () => Promise<string> } = {}) {
+  const calls: any = { started: null, stopped: false, cleaned: false, reads: 0 };
+  const { readAsync: readAsyncOver, ...rest } = over;
+  const base: VerifyKeyDeps = {
+    herdr: {
+      start: (name: string, cwd: string, argv: string[], env?: Record<string, string>) => {
+        calls.started = { name, cwd, argv, env };
+        return { terminalId: "term_v", cwd } as any;
+      },
+      stop: () => {
+        calls.stopped = true;
+      },
+      readAsync: async () => {
+        calls.reads += 1;
+        return readAsyncOver ? await readAsyncOver() : "";
+      },
+    },
+    makeTmpDir: () => "/tmp/verify-xyz",
+    readSentinel: () => null,
+    cleanup: () => {
+      calls.cleaned = true;
+    },
+    now: () => 0,
+    sleep: async () => {},
+    timeoutMs: 30_000,
+    pollMs: 750,
+    ...rest,
+  };
+  return { deps: base, calls };
+}
+
+test("SENTINEL + VERIFY_FILE are the agreed constants", () => {
+  expect(SENTINEL).toBe("SHEPHERD_KEY_OK_8F3A");
+  expect(VERIFY_FILE).toBe(".shepherd-verify");
+});
+
+test("verifyApiKey: sentinel file present with token → ok", async () => {
+  const { deps, calls } = await withAuth("api-key", "/helper.sh", async () => {
+    const d = makeDeps({ readSentinel: () => `${SENTINEL}\n` });
+    const r = await verifyApiKey(d.deps);
+    expect(r).toEqual({ ok: true });
+    return d;
+  });
+  expect(calls.started).not.toBeNull();
+  expect(calls.stopped).toBe(true);
+  expect(calls.cleaned).toBe(true);
+  void deps;
+});
+
+test("verifyApiKey: file present but missing sentinel → keeps polling, then times out", async () => {
+  let t = 0;
+  const { deps: _d, calls } = await withAuth("api-key", "/helper.sh", async () => {
+    const d = makeDeps({
+      readSentinel: () => "some unrelated content",
+      now: () => (t += 6_000),
+      timeoutMs: 30_000,
+    });
+    const r = await verifyApiKey(d.deps);
+    expect(r).toEqual({ ok: false, reason: "timeout" });
+    return d;
+  });
+  expect(calls.stopped).toBe(true);
+  expect(calls.cleaned).toBe(true);
+  void _d;
+});
+
+test("verifyApiKey: auth-error pane text + no file → not-authenticated, FAST-fail before deadline", async () => {
+  let t = 0;
+  await withAuth("api-key", "/helper.sh", async () => {
+    const d = makeDeps({
+      readSentinel: () => null,
+      readAsync: async () => 'API Error: 401 {"error":{"type":"authentication_error"}}',
+      // clock advances 1s per call — far below the 30s deadline
+      now: () => (t += 1_000),
+      timeoutMs: 30_000,
+    });
+    const r = await verifyApiKey(d.deps);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("not-authenticated");
+    expect(r.detail).toContain("401");
+    // fast-fail: clock never reached the deadline
+    expect(t).toBeLessThan(30_000);
+  });
+});
+
+test("verifyApiKey: benign idle pane text + no file → timeout (no false-positive)", async () => {
+  let t = 0;
+  await withAuth("api-key", "/helper.sh", async () => {
+    const d = makeDeps({
+      readSentinel: () => null,
+      readAsync: async () => "Welcome to Claude Code. Writing file...\n> ",
+      now: () => (t += 6_000),
+      timeoutMs: 30_000,
+    });
+    const r = await verifyApiKey(d.deps);
+    expect(r).toEqual({ ok: false, reason: "timeout" });
+  });
+});
+
+test("verifyApiKey: spawn throws → spawn-failed, still cleans up", async () => {
+  await withAuth("api-key", "/helper.sh", async () => {
+    const calls: any = { cleaned: false };
+    const deps: VerifyKeyDeps = {
+      herdr: {
+        start: () => {
+          throw new Error("spawn failed");
+        },
+        stop: () => {},
+        readAsync: async () => "",
+      },
+      makeTmpDir: () => "/tmp/verify-xyz",
+      readSentinel: () => null,
+      cleanup: () => {
+        calls.cleaned = true;
+      },
+      now: () => 0,
+      sleep: async () => {},
+    };
+    const r = await verifyApiKey(deps);
+    expect(r).toEqual({ ok: false, reason: "spawn-failed" });
+    expect(calls.cleaned).toBe(true);
+  });
+});
+
+test("verifyApiKey: not api-key mode → not-api-key-mode, no spawn", async () => {
+  const { result, calls } = await withAuth("subscription", "/ignored.sh", async () => {
+    const d = makeDeps({ readSentinel: () => `${SENTINEL}` });
+    const r = await verifyApiKey(d.deps);
+    return { result: r, calls: d.calls };
+  });
+  expect(result).toEqual({ ok: false, reason: "not-api-key-mode" });
+  expect(calls.started).toBeNull();
+});
+
+test("verifyApiKey: api-key mode but no key → not-configured, no spawn", async () => {
+  const { result, calls } = await withAuth("api-key", null, async () => {
+    const d = makeDeps({ readSentinel: () => `${SENTINEL}` });
+    const r = await verifyApiKey(d.deps);
+    return { result: r, calls: d.calls };
+  });
+  expect(result).toEqual({ ok: false, reason: "not-configured" });
+  expect(calls.started).toBeNull();
+});
+
+test("verifyApiKey: argv carries sentinel prompt + apiKeyHelper; env carries CLAUDE_CONFIG_DIR", async () => {
+  const { calls } = await withAuth("api-key", "/helper.sh", async () => {
+    const d = makeDeps({ readSentinel: () => SENTINEL });
+    await verifyApiKey(d.deps);
+    return d;
+  });
+  const argv: string[] = calls.started.argv;
+  expect(argv[0]).toBe("claude");
+  expect(argv).toContain("--model");
+  expect(argv).toContain("haiku");
+  // prompt is the trailing arg, references the sentinel + verify file
+  const prompt = argv[argv.length - 1];
+  expect(prompt).toContain(SENTINEL);
+  expect(prompt).toContain(VERIFY_FILE);
+  // dontAsk sits LAST before the prompt (variadic --allowedTools guard)
+  const pm = argv.indexOf("--permission-mode");
+  expect(argv[pm + 1]).toBe("dontAsk");
+  expect(pm + 2).toBe(argv.length - 1);
+  // bare Write, not path-scoped
+  const at = argv.indexOf("--allowedTools");
+  expect(argv[at + 1]).toBe("Write");
+  // settings carry the apiKeyHelper
+  const settings = JSON.parse(argv[argv.indexOf("--settings") + 1]!);
+  expect(settings.disableAllHooks).toBe(true);
+  expect(settings.apiKeyHelper).toBe("/helper.sh");
+  // env points at the credential-less mirror
+  expect(calls.started.env).toBeDefined();
+  expect(Object.keys(calls.started.env)).toEqual(["CLAUDE_CONFIG_DIR"]);
+});
+
+test("matchAuthError: every signature matches a representative real error string", () => {
+  const samples = [
+    'API Error: 401 {"type":"error","error":{"type":"invalid_request_error","message":"invalid x-api-key"}}',
+    '{"error":{"type":"authentication_error","message":"unauthorized"}}',
+    "API Error: 401 Unauthorized",
+    "status: 401 forbidden",
+    "Error: Invalid API key provided",
+    "Please run /login to authenticate.",
+    "OAuth token has expired. Please re-authenticate.",
+  ];
+  for (const s of samples) {
+    expect(matchAuthError(s)).not.toBeNull();
+  }
+  // every signature is exercised by at least one sample
+  for (const re of AUTH_ERROR_SIGNATURES) {
+    expect(samples.some((s) => re.test(s))).toBe(true);
+  }
+});
+
+test("matchAuthError: benign / successful output does NOT match", () => {
+  const benign = [
+    "Welcome to Claude Code!",
+    "Writing SHEPHERD_KEY_OK_8F3A to .shepherd-verify",
+    "I have written the file and will now stop.",
+    "Reading task description... done. Status: 200 OK",
+    "> ",
+    "",
+  ];
+  for (const b of benign) {
+    expect(matchAuthError(b)).toBeNull();
+  }
+});
+
+test("matchAuthError: returns the trimmed matched line", () => {
+  const text = "line one\n   API Error: 401 Unauthorized   \nline three";
+  const m = matchAuthError(text);
+  expect(m).toBe("API Error: 401 Unauthorized");
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1277,5 +1277,14 @@
   "feat_api_key_auth_title": "API-Schlüssel-Authentifizierung",
   "feat_api_key_auth_body": "Aktiviere die Abrechnung gestarteter Agenten über einen Anthropic-API-Schlüssel (Commercial Terms) statt über dein Abonnement — Einstellungen → Sitzung.",
   "feat_tappable_slash_commands_title": "Antippbare Slash-Commands",
-  "feat_tappable_slash_commands_body": "Tippe einen von Claude im Terminal vorgeschlagenen Slash-Command an (z. B. /squad, /gsd-quick), um ihn in die Eingabe zu übernehmen — kein Abtippen auf dem Handy. Er wird eingefügt, nicht gesendet: du prüfst und drückst selbst Enter."
+  "feat_tappable_slash_commands_body": "Tippe einen von Claude im Terminal vorgeschlagenen Slash-Command an (z. B. /squad, /gsd-quick), um ihn in die Eingabe zu übernehmen — kein Abtippen auf dem Handy. Er wird eingefügt, nicht gesendet: du prüfst und drückst selbst Enter.",
+  "settings_auth_key_verify": "Prüfen",
+  "settings_auth_key_verifying": "Wird geprüft…",
+  "settings_auth_key_verify_ok": "Schlüssel verifiziert — authentifiziert",
+  "settings_auth_key_verify_failed": "Prüfung fehlgeschlagen:",
+  "settings_auth_key_verify_timeout": "Zeitüberschreitung beim Warten auf eine Antwort.",
+  "settings_auth_key_verify_not_authenticated": "Der Schlüssel hat sich nicht authentifiziert.",
+  "settings_auth_key_verify_error_generic": "Schlüssel konnte nicht geprüft werden.",
+  "feat_api_key_verify_title": "API-Schlüssel verifizieren",
+  "feat_api_key_verify_body": "Prüfe, ob dein gespeicherter Anthropic-API-Schlüssel einen gestarteten Agenten tatsächlich authentifiziert — direkt in Einstellungen → Sitzung, bevor er beim ersten Einsatz versagt."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1277,5 +1277,14 @@
   "feat_api_key_auth_title": "API-key auth mode",
   "feat_api_key_auth_body": "Opt into billing spawned agents against an Anthropic API key (Commercial Terms) instead of your subscription — Settings → Session.",
   "feat_tappable_slash_commands_title": "Tappable slash commands",
-  "feat_tappable_slash_commands_body": "Tap a slash command Claude suggests in the terminal (e.g. /squad, /gsd-quick) to drop it into the prompt — no retyping on mobile. It's inserted, not sent, so you review and press Enter yourself."
+  "feat_tappable_slash_commands_body": "Tap a slash command Claude suggests in the terminal (e.g. /squad, /gsd-quick) to drop it into the prompt — no retyping on mobile. It's inserted, not sent, so you review and press Enter yourself.",
+  "settings_auth_key_verify": "Verify",
+  "settings_auth_key_verifying": "Verifying…",
+  "settings_auth_key_verify_ok": "Key verified — authenticates",
+  "settings_auth_key_verify_failed": "Verification failed:",
+  "settings_auth_key_verify_timeout": "Timed out waiting for a response.",
+  "settings_auth_key_verify_not_authenticated": "The key did not authenticate.",
+  "settings_auth_key_verify_error_generic": "Could not verify the key.",
+  "feat_api_key_verify_title": "Verify your API key",
+  "feat_api_key_verify_body": "Check that your saved Anthropic API key actually authenticates a spawned agent — right from Settings → Session, before it fails on first use."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -272,6 +272,13 @@ export const putAuthMode = (mode: string): Promise<{ authMode: string; hasApiKey
 export const putAnthropicApiKey = (key: string | null): Promise<{ hasApiKey: boolean }> =>
   patchSettings({ anthropicApiKey: key });
 
+// Probe whether the stored API key actually authenticates a spawned agent. The server
+// runs a short, throwaway claude auth check and returns only the verdict — never the key.
+// `reason` codes a known failure (not-authenticated/timeout/not-configured/…); `detail`
+// (present on not-authenticated) is a verbatim claude auth-error string surfaced as data.
+export const verifyApiKey = (): Promise<{ ok: boolean; reason?: string; detail?: string }> =>
+  postJson("/api/settings/verify-key", {}, "verify-key");
+
 // Persist the account-wide extra-credit (paid overage) spend ceiling. Auto-drain/autopilot
 // pauses when measured spend strictly exceeds it; 0 = pause on any spend. The server
 // validates a non-negative number and returns the stored value.

--- a/ui/src/lib/api.verifyKey.test.ts
+++ b/ui/src/lib/api.verifyKey.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { verifyApiKey } from "./api";
+
+function mockFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn(
+    async () => new Response(JSON.stringify(body), { status }),
+  ) as unknown as typeof fetch;
+}
+
+describe("verifyApiKey", () => {
+  it("POSTs to /api/settings/verify-key with an empty body", async () => {
+    const calls: { url?: string; method?: string; body?: string }[] = [];
+    globalThis.fetch = vi.fn(async (url: unknown, init?: { method?: string; body?: string }) => {
+      calls.push({ url: String(url), method: init?.method, body: init?.body });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as unknown as typeof fetch;
+    await verifyApiKey();
+    expect(calls[0]!.url).toBe("/api/settings/verify-key");
+    expect(calls[0]!.method).toBe("POST");
+    expect(JSON.parse(calls[0]!.body!)).toEqual({});
+  });
+
+  it("returns {ok:true} on a passing verdict", async () => {
+    globalThis.fetch = mockFetch(200, { ok: true });
+    expect(await verifyApiKey()).toEqual({ ok: true });
+  });
+
+  it("returns the failure verdict verbatim (reason + detail)", async () => {
+    globalThis.fetch = mockFetch(200, {
+      ok: false,
+      reason: "not-authenticated",
+      detail: "invalid x-api-key",
+    });
+    expect(await verifyApiKey()).toEqual({
+      ok: false,
+      reason: "not-authenticated",
+      detail: "invalid x-api-key",
+    });
+  });
+
+  it("throws when the endpoint is unwired (503)", async () => {
+    globalThis.fetch = mockFetch(503, { error: "not wired" });
+    await expect(verifyApiKey()).rejects.toThrow();
+  });
+});

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { Settings as SettingsPayload } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+import { getSettings, verifyApiKey, putAnthropicApiKey } from "$lib/api";
+
+// Mock the API so Settings never hits the network. The settings GET is seeded to
+// land on api-key mode WITH a key configured, so the api-key block + Verify button
+// render; each test then drives verifyApiKey / putAnthropicApiKey.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    getSettings: vi.fn(),
+    listDirs: vi.fn(async () => ({ path: "/repo", display: "/repo", parent: null, entries: [] })),
+    getDiagnostics: vi.fn(async () => ({ checks: [] })),
+    verifyApiKey: vi.fn(),
+    putAnthropicApiKey: vi.fn(),
+    putAuthMode: vi.fn(async () => ({ authMode: "api-key", hasApiKey: true })),
+  };
+});
+
+// `onMount` awaits refreshPush() before loading settings; a throwing push probe
+// would abort the load and never render the api-key block. Stub it to a quiet,
+// unsupported, unsubscribed state.
+vi.mock("$lib/push", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/push")>();
+  return {
+    ...actual,
+    pushState: vi.fn(async () => ({
+      supported: false,
+      permission: "unsupported" as const,
+      subscribed: false,
+    })),
+    getPushCategories: vi.fn(async () => ({ agent: true, reviews: true, ci: true })),
+  };
+});
+
+const { default: Settings } = await import("./Settings.svelte");
+
+const mockGetSettings = vi.mocked(getSettings);
+const mockVerify = vi.mocked(verifyApiKey);
+const mockPutKey = vi.mocked(putAnthropicApiKey);
+
+function settings(over: Partial<SettingsPayload> = {}): SettingsPayload {
+  return {
+    repoRoot: "/repo",
+    repoRootDisplay: "/repo",
+    remoteControlAtStartup: false,
+    sessionHousekeepingEnabled: true,
+    defaultModel: "auto",
+    authMode: "api-key",
+    hasApiKey: true,
+    prReviewCyclesCap: 3,
+    prReviewCyclesMin: 1,
+    prReviewCyclesMax: 8,
+    planReviewCyclesCap: 5,
+    planReviewCyclesMin: 1,
+    planReviewCyclesMax: 12,
+    extraCreditsDrainCeiling: 0,
+    sessionRetentionDays: 30,
+    sessionRetentionKeep: 250,
+    previewHost: null,
+    ...over,
+  };
+}
+
+let fontStyle: HTMLStyleElement;
+beforeEach(() => {
+  fontStyle = document.createElement("style");
+  fontStyle.textContent = `:root {
+    --font-mono: ui-monospace, monospace;
+    --color-panel: #1a1a1a;
+    --color-line: #333;
+    --color-line-bright: #555;
+    --color-inset: #111;
+    --color-ink: #ccc;
+    --color-ink-bright: #fff;
+    --color-muted: #666;
+    --color-faint: #444;
+    --color-amber: #f5a623;
+    --color-green: #4caf50;
+    --color-red: #f44336;
+    --color-blue: #2196f3;
+    --color-scrim: rgba(0,0,0,0.6);
+    --fs-base: 13px;
+    --fs-meta: 12px;
+    --fs-micro: 10px;
+    --fs-lg: 15px;
+    --fs-xl: 18px;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  body { margin: 0; }`;
+  document.head.appendChild(fontStyle);
+  mockGetSettings.mockReset();
+  mockVerify.mockReset();
+  mockPutKey.mockReset();
+  // Default seed: api-key mode, key configured → Verify button renders.
+  mockGetSettings.mockResolvedValue(settings());
+});
+afterEach(() => {
+  fontStyle.remove();
+  document.body.innerHTML = "";
+});
+
+const noop = () => {};
+
+const verifyBtn = () => page.getByRole("button", { name: m.settings_auth_key_verify() });
+const saveBtn = () => page.getByRole("button", { name: m.settings_auth_key_save(), exact: true });
+const keyInput = () => page.getByRole("textbox", { name: m.settings_auth_key_label() });
+
+function mountSession() {
+  render(Settings, { initialTab: "session", onclose: noop, onsaved: noop });
+}
+
+describe("Settings api-key verify", () => {
+  it("verify → OK renders the verified line", async () => {
+    mockVerify.mockResolvedValue({ ok: true });
+    mountSession();
+
+    await expect.element(verifyBtn()).toBeInTheDocument();
+    await verifyBtn().click();
+
+    await expect.element(page.getByText(m.settings_auth_key_verify_ok())).toBeInTheDocument();
+  });
+
+  it("verify → failed surfaces the not-authenticated message AND the verbatim detail", async () => {
+    mockVerify.mockResolvedValue({
+      ok: false,
+      reason: "not-authenticated",
+      detail: "invalid x-api-key",
+    });
+    mountSession();
+
+    await expect.element(verifyBtn()).toBeInTheDocument();
+    await verifyBtn().click();
+
+    // The failed line prefixes the failure header, then the resolved not-authenticated
+    // message, then the verbatim server detail (surfaced as data, not translated).
+    await expect
+      .element(page.getByText(m.settings_auth_key_verify_not_authenticated(), { exact: false }))
+      .toBeInTheDocument();
+    await expect.element(page.getByText("invalid x-api-key", { exact: false })).toBeInTheDocument();
+    // Not the OK state.
+    await expect.element(page.getByText(m.settings_auth_key_verify_ok())).not.toBeInTheDocument();
+  });
+
+  it("verify throw → fail-closed (renders FAILED, never OK)", async () => {
+    mockVerify.mockRejectedValue(new Error("boom"));
+    mountSession();
+
+    await expect.element(verifyBtn()).toBeInTheDocument();
+    await verifyBtn().click();
+
+    // A thrown probe must read as a failure, not silently pass.
+    await expect
+      .element(page.getByText(m.settings_auth_key_verify_error_generic(), { exact: false }))
+      .toBeInTheDocument();
+    await expect.element(page.getByText(m.settings_auth_key_verify_ok())).not.toBeInTheDocument();
+  });
+
+  it("saving a key auto-verifies it (the key gap) and renders the verdict", async () => {
+    // Start with NO key so the Save flow is the thing under test.
+    mockGetSettings.mockResolvedValue(settings({ hasApiKey: false }));
+    mockPutKey.mockResolvedValue({ hasApiKey: true });
+    mockVerify.mockResolvedValue({ ok: true });
+    mountSession();
+
+    await expect.element(keyInput()).toBeInTheDocument();
+    await keyInput().fill("sk-ant-test");
+    await saveBtn().click();
+
+    // Auto-verify must have fired off the back of a successful save…
+    await vi.waitFor(() => expect(mockVerify).toHaveBeenCalled());
+    // …and its verdict renders inline.
+    await expect.element(page.getByText(m.settings_auth_key_verify_ok())).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -290,9 +290,11 @@
   async function saveApiKey() {
     if (authBusy || apiKeyInput.trim() === "") return;
     authBusy = true;
+    let saved = false;
     try {
       const r = await putAnthropicApiKey(apiKeyInput.trim());
       hasApiKey = r.hasApiKey;
+      saved = true;
       apiKeyInput = ""; // never retain the key in component state
     } catch {
       toasts.info(m.settings_auth_key_save_failed(), {
@@ -303,9 +305,11 @@
     } finally {
       authBusy = false;
     }
-    // After a successful save the key is configured — immediately probe whether it
-    // actually authenticates so a bad/expired key surfaces here, not on first spawn.
-    if (hasApiKey) await verifyKey();
+    // Only after a genuinely successful save — gate on the save outcome, not residual
+    // `hasApiKey` (a replacement-save that throws must NOT auto-verify the old key) —
+    // immediately probe whether it actually authenticates so a bad/expired key surfaces
+    // here, not on first spawn.
+    if (saved) await verifyKey();
   }
 
   // Probe the stored key against claude auth. Inline result only (no toast); guards

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -10,10 +10,12 @@
     putDefaultModel,
     putAuthMode,
     putAnthropicApiKey,
+    verifyApiKey,
     putExtraCreditsDrainCeiling,
     listDirs,
     getDiagnostics,
   } from "$lib/api";
+  import { verifyFailureMessage } from "$lib/verify-key";
   import {
     MODELS,
     PREMIUM_MODELS,
@@ -155,6 +157,9 @@
   let authBusy = $state(false);
   let hasApiKey = $state(false); // whether a key is configured (boolean only; key never sent)
   let apiKeyInput = $state(""); // write-only paste field; cleared after save, never prefilled
+  // Inline verify-key result (probes whether the stored key actually authenticates).
+  let verifyState = $state<"idle" | "verifying" | "ok" | "failed">("idle");
+  let verifyMsg = $state(""); // resolved, localized failure message (incl. any verbatim detail)
   let extraCreditsCeiling = $state(0); // account-wide extra-credit spend ceiling (0 = pause on any)
   let extraCreditsCeilingSaved = 0; // last server-confirmed value, for revert on failure
   let extraCreditsBusy = $state(false);
@@ -264,6 +269,11 @@
       authMode = r.authMode;
       authModeSaved = r.authMode;
       hasApiKey = r.hasApiKey;
+      // The verify result belongs only to api-key mode; drop it when leaving.
+      if (r.authMode !== "api-key") {
+        verifyState = "idle";
+        verifyMsg = "";
+      }
     } catch {
       // revert to the last server-confirmed value; surface the failure persistently.
       authMode = authModeSaved;
@@ -293,11 +303,40 @@
     } finally {
       authBusy = false;
     }
+    // After a successful save the key is configured — immediately probe whether it
+    // actually authenticates so a bad/expired key surfaces here, not on first spawn.
+    if (hasApiKey) await verifyKey();
+  }
+
+  // Probe the stored key against claude auth. Inline result only (no toast); guards
+  // against concurrent runs so a double-click can't race two checks.
+  async function verifyKey() {
+    if (verifyState === "verifying") return;
+    verifyState = "verifying";
+    verifyMsg = "";
+    try {
+      const r = await verifyApiKey();
+      if (r.ok) {
+        verifyState = "ok";
+      } else {
+        verifyState = "failed";
+        verifyMsg = verifyFailureMessage(r.reason, r.detail, {
+          notAuthenticated: m.settings_auth_key_verify_not_authenticated,
+          timeout: m.settings_auth_key_verify_timeout,
+          generic: m.settings_auth_key_verify_error_generic,
+        });
+      }
+    } catch {
+      verifyState = "failed";
+      verifyMsg = m.settings_auth_key_verify_error_generic();
+    }
   }
 
   async function clearApiKey() {
     if (authBusy) return;
     authBusy = true;
+    verifyState = "idle"; // a cleared key has no verdict
+    verifyMsg = "";
     try {
       const r = await putAnthropicApiKey(null);
       hasApiKey = r.hasApiKey;
@@ -711,9 +750,29 @@
           <div class="apikey">
             {#if hasApiKey}
               <p class="key-status">{m.settings_auth_key_saved()}</p>
-              <button type="button" class="gbtn" disabled={authBusy} onclick={clearApiKey}>
-                {m.settings_auth_key_clear()}
-              </button>
+              <div class="key-actions">
+                <button type="button" class="gbtn" disabled={authBusy} onclick={clearApiKey}>
+                  {m.settings_auth_key_clear()}
+                </button>
+                <button
+                  type="button"
+                  class="gbtn"
+                  disabled={authBusy || verifyState === "verifying"}
+                  onclick={verifyKey}
+                >
+                  {m.settings_auth_key_verify()}
+                </button>
+              </div>
+              {#if verifyState === "verifying"}
+                <p class="verify-line verify-busy">{m.settings_auth_key_verifying()}</p>
+              {:else if verifyState === "ok"}
+                <p class="verify-line verify-ok">{m.settings_auth_key_verify_ok()}</p>
+              {:else if verifyState === "failed"}
+                <p class="verify-line verify-failed">
+                  {m.settings_auth_key_verify_failed()}
+                  {verifyMsg}
+                </p>
+              {/if}
             {/if}
             <div class="key-entry">
               <input
@@ -1307,6 +1366,27 @@
     color: var(--color-muted);
     font-size: var(--fs-meta);
     margin: 0;
+  }
+  .key-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .verify-line {
+    font-size: var(--fs-meta);
+    margin: 0;
+    font-weight: 500;
+  }
+  .verify-busy {
+    color: var(--color-muted);
+    font-weight: 400;
+  }
+  .verify-ok {
+    color: var(--color-green);
+  }
+  .verify-failed {
+    color: var(--color-red);
   }
   .gbtn {
     background: transparent;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -813,4 +813,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_tappable_slash_commands_title",
     bodyKey: "feat_tappable_slash_commands_body",
   },
+  {
+    // No targetId: the Verify button only mounts in the Settings modal SESSION tab
+    // (closed by default) and only once an API key is configured, so a coachmark
+    // anchor would rarely be mounted — surface via the What's-New drawer only.
+    id: "api-key-verify",
+    sinceVersion: "1.30.0",
+    titleKey: "feat_api_key_verify_title",
+    bodyKey: "feat_api_key_verify_body",
+  },
 ];

--- a/ui/src/lib/verify-key.test.ts
+++ b/ui/src/lib/verify-key.test.ts
@@ -16,9 +16,9 @@ describe("verifyFailureMessage", () => {
   });
 
   it("appends the verbatim detail to not-authenticated when present", () => {
-    expect(verifyFailureMessage("not-authenticated", "invalid x-api-key", msgs)).toBe(
-      "The key did not authenticate.: invalid x-api-key",
-    );
+    const out = verifyFailureMessage("not-authenticated", "invalid x-api-key", msgs);
+    expect(out).toContain("The key did not authenticate.");
+    expect(out).toContain("invalid x-api-key");
   });
 
   it("maps timeout to its message", () => {

--- a/ui/src/lib/verify-key.test.ts
+++ b/ui/src/lib/verify-key.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { verifyFailureMessage, type VerifyMessages } from "./verify-key";
+
+// Stub resolvers so the mapping is testable without the Paraglide runtime.
+const msgs: VerifyMessages = {
+  notAuthenticated: () => "The key did not authenticate.",
+  timeout: () => "Timed out waiting for a response.",
+  generic: () => "Could not verify the key.",
+};
+
+describe("verifyFailureMessage", () => {
+  it("maps not-authenticated to its message", () => {
+    expect(verifyFailureMessage("not-authenticated", undefined, msgs)).toBe(
+      "The key did not authenticate.",
+    );
+  });
+
+  it("appends the verbatim detail to not-authenticated when present", () => {
+    expect(verifyFailureMessage("not-authenticated", "invalid x-api-key", msgs)).toBe(
+      "The key did not authenticate.: invalid x-api-key",
+    );
+  });
+
+  it("maps timeout to its message", () => {
+    expect(verifyFailureMessage("timeout", undefined, msgs)).toBe(
+      "Timed out waiting for a response.",
+    );
+  });
+
+  it("ignores detail on timeout (only not-authenticated carries it)", () => {
+    expect(verifyFailureMessage("timeout", "ignored", msgs)).toBe(
+      "Timed out waiting for a response.",
+    );
+  });
+
+  it("falls back to generic for unknown/other reasons", () => {
+    expect(verifyFailureMessage("spawn-failed", undefined, msgs)).toBe("Could not verify the key.");
+    expect(verifyFailureMessage("not-configured", undefined, msgs)).toBe(
+      "Could not verify the key.",
+    );
+  });
+
+  it("falls back to generic for an undefined reason", () => {
+    expect(verifyFailureMessage(undefined, undefined, msgs)).toBe("Could not verify the key.");
+  });
+});

--- a/ui/src/lib/verify-key.ts
+++ b/ui/src/lib/verify-key.ts
@@ -1,0 +1,29 @@
+// Pure mapping from a verify-key failure `reason` (+ optional `detail`) to a localized
+// message. Kept framework-free (the localized strings are injected) so it's unit-testable
+// without the Paraglide runtime — Settings.svelte passes its `m.*` resolvers.
+//
+// `detail` is server DATA (a verbatim claude auth-error string), surfaced as-is — NOT
+// translated — appended only to the not-authenticated case where it's present.
+
+export type VerifyMessages = {
+  notAuthenticated: () => string;
+  timeout: () => string;
+  generic: () => string;
+};
+
+export function verifyFailureMessage(
+  reason: string | undefined,
+  detail: string | undefined,
+  msgs: VerifyMessages,
+): string {
+  switch (reason) {
+    case "not-authenticated": {
+      const base = msgs.notAuthenticated();
+      return detail ? `${base}: ${detail}` : base;
+    }
+    case "timeout":
+      return msgs.timeout();
+    default:
+      return msgs.generic();
+  }
+}

--- a/ui/src/lib/verify-key.ts
+++ b/ui/src/lib/verify-key.ts
@@ -19,7 +19,7 @@ export function verifyFailureMessage(
   switch (reason) {
     case "not-authenticated": {
       const base = msgs.notAuthenticated();
-      return detail ? `${base}: ${detail}` : base;
+      return detail ? `${base} (${detail})` : base;
     }
     case "timeout":
       return msgs.timeout();


### PR DESCRIPTION
Closes #671. Follow-up to #660 / PR #664 (api-key auth mode, footing B).

## Problem
The Settings → Session key field saved an API key with **no validation** — a typo'd/revoked key saved fine (`hasApiKey: true`) and only surfaced later when an agent spawn failed to authenticate. Because api-key mode fails closed (no subscription fallback), a bad key silently paused all spawns.

## What this adds
A **verify-key** step that confirms the key actually authenticates, surfaced in Settings → Session as an explicit green pass / red fail.

- **Mechanism (single, proven):** a transient interactive `claude` (haiku) spawned through herdr — exactly the `src/namer-llm.ts` pattern — using the **same** api-key spawn wiring real spawns use: `apiKeySettingsFragment()` (the `apiKeyHelper` in `--settings`) + `apiKeyPassthroughEnv(false)` (credential-less `CLAUDE_CONFIG_DIR`). Validates the real end-to-end auth mechanism, not just the key string. **No `claude -p`, no `--bare`** (keeps the house-rule-compliant interactive substrate; no subscription login is ever presented).
- **Positive proof, fail-closed:** the agent writes a fixed sentinel file → `{ok:true}` only on a sentinel match. A clean-exit-without-sentinel is **not** treated as healthy.
- **Fast failure:** `claude` stays idle at the prompt on a 401 (herdr exposes no liveness field), so the poll loop reads the pane each tick and matches a conservative, unit-tested `AUTH_ERROR_SIGNATURES` set → fails in seconds, not at the 60s ceiling (which is only a backstop for a slow good cold start).
- **Triggers:** auto-verify right after a successful key Save, **plus** a manual "Verify" button to re-check an already-configured key.
- **Secret hygiene:** the raw key never leaves the server. The endpoint returns only `{ ok, reason?, detail? }`; `detail` is a clipped claude auth-error line (never the key), and nothing logs the key/pane verbatim.

## Layers
- `src/verify-key.ts` — `verifyApiKey()` + `matchAuthError`/`AUTH_ERROR_SIGNATURES`.
- `src/server.ts` + `src/index.ts` — `POST /api/settings/verify-key` (returns only `{ok,reason?,detail?}`), wired with the real herdr driver.
- `ui/src/lib/api.ts`, `ui/src/lib/components/Settings.svelte`, `ui/src/lib/verify-key.ts` — Verify button, auto-verify-on-save, inline pass/fail using semantic status tokens (no toast, no raw color literals); reason→message mapping; verdict reset on key clear / leaving api-key mode.
- i18n EN+DE (parity) + a `feature-announcements.ts` catalog entry (`api-key-verify`, `sinceVersion: 1.30.0`).

## Acceptance criteria
- [x] Operator verifies the configured key from Settings → Session and sees a clear pass/fail.
- [x] Verification uses the real `apiKeyHelper` + credential-less config-dir path (no subscription login).
- [x] Raw key never sent to the client or logged; response is only `{ ok, reason?, detail? }`.
- [x] Failure (bad key, timeout, spawn failure, or client throw) renders as an explicit red error state, never silent/healthy.
- [x] EN+DE strings; `check:i18n` green.

## Tests & gates
- `src/verify-key.ts`: 12 unit tests (sentinel→ok, no-sentinel keeps polling, auth-error fast-fail asserted via injected clock, benign→timeout, spawn-failed, both guards, argv/env assertions, matcher signature + false-positive guards).
- Server endpoint + UI: `POST` shape + key-leak guard; Settings component tests (verify→ok, →failed-with-detail, throw→fail-closed, **auto-verify-on-save**).
- Green: branch-hygiene, feature-catalog, root lint/tsc, `bun test ./test` (2933 pass), `ui` check + `check:i18n` (parity) + vitest (1261 pass), and the fallow delta gate.

Refs: #660, #647 (R1), PR #664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)