### PR TITLE
fix(recap): explain why a finished session has no recap

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1250,6 +1250,7 @@
   "integrated_epics_landing_pr_merged": "Landing-PR #{number} — gemergt",
   "recap_changed_files": "Geänderte Dateien",
   "recap_unavailable": "Für diese Sitzung ist keine Zusammenfassung verfügbar.",
+  "recap_predates_feature": "Diese Sitzung wurde abgeschlossen, bevor Sitzungs-Zusammenfassungen verfügbar waren – daher wurde keine erstellt.",
   "recap_issue": "Issue #{n}",
   "herd_done_filter": "✓ Fertig",
   "herd_done_title": "Abgeschlossene (archivierte) Sitzungen und ihre Zusammenfassungen anzeigen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1250,6 +1250,7 @@
   "integrated_epics_landing_pr_merged": "Landing PR #{number} — merged",
   "recap_changed_files": "Changed files",
   "recap_unavailable": "No recap available for this session.",
+  "recap_predates_feature": "This session finished before session recaps were available, so none was recorded.",
   "recap_issue": "Issue #{n}",
   "herd_done_filter": "✓ Done",
   "herd_done_title": "Show finished (archived) sessions and their recaps",

--- a/ui/src/lib/components/DoneRecapPanel.browser.test.ts
+++ b/ui/src/lib/components/DoneRecapPanel.browser.test.ts
@@ -127,20 +127,30 @@ describe("DoneRecapPanel generating state", () => {
 });
 
 describe("DoneRecapPanel fail-closed", () => {
-  it("failed recap → recap unavailable (never a blank success card)", async () => {
+  it("failed recap → names the failure (never a blank success card)", async () => {
     recaps.map = { f1: recap({ sessionId: "f1", state: "failed" }) };
     render(DoneRecapPanel, { session: session({ id: "f1" }) });
-    await expect
-      .element(page.getByText("No recap available for this session."))
-      .toBeInTheDocument();
+    await expect.element(page.getByText("Recap generation failed.")).toBeInTheDocument();
     expect(page.getByText("Shipped the feature").elements().length, "no headline").toBe(0);
   });
 
-  it("missing recap row → recap unavailable", async () => {
-    // no entry in recaps.map for this id
+  it("missing recap row on a recent session → generic unavailable", async () => {
+    // no entry in recaps.map; finished after recaps shipped → generic message
     render(DoneRecapPanel, { session: session({ id: "missing" }) });
     await expect
       .element(page.getByText("No recap available for this session."))
+      .toBeInTheDocument();
+  });
+
+  it("missing recap row on a pre-feature session → explains it predates recaps", async () => {
+    // finished before durable recaps shipped (epoch 1781423073000) → reason-named message
+    render(DoneRecapPanel, { session: session({ id: "old", archivedAt: 1_700_000_000_000 }) });
+    await expect
+      .element(
+        page.getByText(
+          "This session finished before session recaps were available, so none was recorded.",
+        ),
+      )
       .toBeInTheDocument();
   });
 });

--- a/ui/src/lib/components/DoneRecapPanel.svelte
+++ b/ui/src/lib/components/DoneRecapPanel.svelte
@@ -12,9 +12,16 @@
   // relative "finished X ago" from archivedAt; falls back to updatedAt when an
   // archived session somehow has no archivedAt stamp. Driven by the shared 30s
   // `clock` (matching the Herd row's nowMs) so the stamp ticks while the panel stays open.
-  const finishedAgo = $derived(
-    formatAgo(clock.current - (session.archivedAt ?? session.updatedAt)),
-  );
+  const finishedAt = $derived(session.archivedAt ?? session.updatedAt);
+  const finishedAgo = $derived(formatAgo(clock.current - finishedAt));
+
+  // Durable recaps + this Done lens shipped with #665 (2026-06-14 09:44 +02:00).
+  // A session that finished before then never got the chance to record a recap
+  // row, so the empty state explains *why* rather than reading like a failure.
+  // (epoch ms of the shipping commit; sessions carry no herdr-version stamp to
+  // compare against, so the finish time is the signal.)
+  const RECAP_FEATURE_EPOCH_MS = 1781423073000;
+  const predatesRecapFeature = $derived(recap === undefined && finishedAt < RECAP_FEATURE_EPOCH_MS);
 
   // Render the (LLM-authored) body as sanitized markdown. Dynamically imported so
   // marked/DOMPurify stay off the first-paint critical path; gated on a ready recap
@@ -100,9 +107,14 @@
       {/if}
     {:else if recap?.state === "generating"}
       <p class="dr-muted">{m.recap_generating()}</p>
+    {:else if recap?.state === "failed"}
+      <!-- generation ran but couldn't produce a recap — say so, don't imply it was never tried. -->
+      <p class="dr-muted">{m.recap_failed()}</p>
+    {:else if predatesRecapFeature}
+      <!-- finished before durable recaps existed: name the reason instead of a bare "unavailable". -->
+      <p class="dr-muted">{m.recap_predates_feature()}</p>
     {:else}
-      <!-- failed, empty, or no recap row: fail-closed — never a blank card that reads
-           as a success. -->
+      <!-- empty diff or no recap row: fail-closed — never a blank card that reads as a success. -->
       <p class="dr-muted">{m.recap_unavailable()}</p>
     {/if}
   </div>


### PR DESCRIPTION
## Was

Im **Done-Lens** stand bei jeder abgeschlossenen Sitzung ohne Recap nur flach „Für diese Sitzung ist keine Zusammenfassung verfügbar." — das liest sich wie ein Fehler, obwohl die Sitzung oft schlicht **vor** der Recap-Funktion abgeschlossen wurde. Jetzt nennt die Leerzustand-Meldung den **Grund**.

## Empty-State nach Grund aufgeteilt (`DoneRecapPanel.svelte`)

| Situation | Meldung |
|---|---|
| `state === "failed"` | „Zusammenfassung konnte nicht erstellt werden." (`recap_failed`, bestand bereits) |
| kein Recap + Sitzung abgeschlossen **vor** dem durable-Recap-Release (#665, 2026-06-14 09:44 +02:00) | **neu** `recap_predates_feature`: „Diese Sitzung wurde abgeschlossen, bevor Sitzungs-Zusammenfassungen verfügbar waren – daher wurde keine erstellt." |
| sonst (z. B. keine Änderungen) | bestehende generische Meldung |

Sitzungen tragen keinen herdr-Versionsstempel, daher ist der Abschlusszeitpunkt vs. Feature-Release-Epoch (`1781423073000`) das Signal für den predates-Fall.

## i18n
- `recap_predates_feature` in `en.json` + `de.json` (Parität geprüft, 1275 Keys).

## Tests
- `DoneRecapPanel.browser.test.ts`: failed-Fall erwartet jetzt die Fehlermeldung; neuer Test für den predates-feature-Fall. 1246/1246 grün.

[no-feature-entry] — kein neues nutzersichtbares Feature, nur präzisere Empty-State-Copy einer bestehenden Funktion.