### PR TITLE
fix(onboarding-harness): classify pre-detection throws as HARNESS ERROR, not detection gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ dist/
 # Agent-declared live-preview port hint (transient, never committed)
 .shepherd-preview
 
+# Onboarding-harness gap report — generated into cwd by ci/onboarding-harness/run.ts
+onboarding-gap-report.md
+
 # Self-hosted CI runner: never commit a filled-in env; keep the example tracked
 # (the global `.env.*` rule above would otherwise swallow .env.example).
 ci/self-hosted-runner/.env

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -1,12 +1,28 @@
 import type { ScenarioResult } from "./types";
 
+/** A scenario that THREW before its diagnostics could be evaluated — the
+ *  catch-block fallback sentinel (an error paired with no detection and no
+ *  recorded misses). This is an INFRASTRUCTURE failure (image-not-found, seed/boot
+ *  crash), NOT a product detection gap: the instance never booted far enough to
+ *  test Shepherd, so blaming detection would be a misclassification (and reads as a
+ *  Shepherd onboarding defect when it's really image rot). A throw AFTER detection
+ *  ran keeps its real detection result (non-empty misses or detected=true) and is
+ *  classified as a normal gap instead. */
+function isHarnessError(r: ScenarioResult): boolean {
+  return !!r.error && !r.detection.detected && r.detection.misses.length === 0;
+}
+
 /** Pure: render the per-scenario outcomes as a markdown gap report. Classifies
  *  each scenario as PASS, DETECTION GAP (defect missed/misclassified), ADVICE GAP
- *  (detected but coaching didn't reach green), or DETECTION-ONLY (detected with no
- *  apply attempted by design — e.g. claude-missing in Phase 1; NOT a gap). The
- *  green tally counts only apply-able scenarios so detection-only ones don't drag
- *  the denominator. */
-function classify(r: ScenarioResult): "PASS" | "DETECTION GAP" | "ADVICE GAP" | "DETECTION-ONLY" {
+ *  (detected but coaching didn't reach green), DETECTION-ONLY (detected with no
+ *  apply attempted by design — e.g. claude-missing in Phase 1; NOT a gap), or
+ *  HARNESS ERROR (threw before detection — infra/image-rot, not a product gap).
+ *  The green tally counts only apply-able scenarios so detection-only AND
+ *  harness-errored ones don't drag the denominator. */
+function classify(
+  r: ScenarioResult,
+): "PASS" | "DETECTION GAP" | "ADVICE GAP" | "DETECTION-ONLY" | "HARNESS ERROR" {
+  if (isHarnessError(r)) return "HARNESS ERROR";
   if (r.detectionOnly) return r.detection.detected ? "DETECTION-ONLY" : "DETECTION GAP";
   if (r.reachedGreen) return "PASS";
   return r.detection.detected ? "ADVICE GAP" : "DETECTION GAP";
@@ -40,29 +56,46 @@ function gapEntry(r: ScenarioResult, klass: "DETECTION GAP" | "ADVICE GAP"): str
   return `- **${r.scenarioId}** (${klass})${misses ? ` — ${misses}` : ""}${r.error ? ` — ${r.error}` : ""}`;
 }
 
+function harnessErrorEntry(r: ScenarioResult): string {
+  return `- **${r.scenarioId}** (HARNESS ERROR — infra, not a product gap)${r.error ? ` — ${r.error}` : ""}`;
+}
+
 export function buildGapReport(results: ScenarioResult[]): string {
-  const applicable = results.filter((r) => !r.detectionOnly);
+  // Both detection-only (by design) and harness-errored (never booted) scenarios
+  // are excluded from the green ratio — neither got a fair coaching attempt, so
+  // counting them as non-green would read as a product regression.
+  const harnessErrored = results.filter(isHarnessError);
+  const applicable = results.filter((r) => !r.detectionOnly && !isHarnessError(r));
   const green = applicable.filter((r) => r.reachedGreen).length;
-  const detectionOnly = results.length - applicable.length;
+  const detectionOnly = results.filter((r) => r.detectionOnly && !isHarnessError(r)).length;
   const lines: string[] = [
     "# Onboarding Gap Report",
     "",
     `**${green} / ${applicable.length} scenarios reached green.**` +
-      (detectionOnly ? ` (${detectionOnly} detection-only, by design — excluded.)` : ""),
+      (detectionOnly ? ` (${detectionOnly} detection-only, by design — excluded.)` : "") +
+      (harnessErrored.length
+        ? ` (${harnessErrored.length} harness error${harnessErrored.length > 1 ? "s" : ""} — infra, excluded.)`
+        : ""),
     "",
     "| Scenario | Image | Detected | Applied | Green | Classification |",
     "| --- | --- | --- | --- | --- | --- |",
   ];
   const gaps: string[] = [];
+  const errors: string[] = [];
   for (const r of results) {
     const klass = classify(r);
     lines.push(tableRow(r, klass));
     if (klass === "DETECTION GAP" || klass === "ADVICE GAP") {
       gaps.push(gapEntry(r, klass));
+    } else if (klass === "HARNESS ERROR") {
+      errors.push(harnessErrorEntry(r));
     }
   }
   if (gaps.length) {
     lines.push("", "## Gaps", "", ...gaps);
+  }
+  if (errors.length) {
+    lines.push("", "## Harness errors", "", ...errors);
   }
   return lines.join("\n") + "\n";
 }

--- a/test/onboarding-harness/report.test.ts
+++ b/test/onboarding-harness/report.test.ts
@@ -51,6 +51,61 @@ describe("buildGapReport", () => {
     expect(md).toContain("ADVICE GAP");
   });
 
+  it("classifies a pre-detection throw (image-not-found / boot crash) as HARNESS ERROR, not a detection gap, and excludes it from the denominator", () => {
+    const md = buildGapReport([
+      {
+        scenarioId: "git-missing",
+        image: "images:alpine/3.21",
+        // The catch-block sentinel: threw in seed/boot before detection ran, so
+        // detection never evaluated Shepherd (no misses recorded).
+        detection: { scenarioId: "git-missing", detected: false, misses: [] },
+        appliedVia: "skipped",
+        reachedGreen: false,
+        gateEligible: false,
+        error: "incus launch failed: image couldn't be found",
+      },
+      {
+        scenarioId: "gh-unauthed",
+        image: "i",
+        detection: { scenarioId: "gh-unauthed", detected: true, misses: [] },
+        appliedVia: "agent",
+        reachedGreen: true,
+        gateEligible: false,
+      },
+    ]);
+    expect(md).toContain("HARNESS ERROR");
+    expect(md).toContain("## Harness errors");
+    expect(md).toContain("incus launch failed: image couldn't be found");
+    // The instance never booted — it is NOT a product detection gap.
+    expect(md).not.toContain("DETECTION GAP");
+    expect(md).not.toContain("## Gaps");
+    // Excluded from the green ratio: a scenario that couldn't boot didn't get a
+    // fair attempt, so it must not drag the denominator (would read as a regression).
+    expect(md).toContain("1 / 1 scenarios reached green");
+    expect(md).toContain("1 harness error");
+  });
+
+  it("keeps a post-detection apply error (real detection miss recorded) as a DETECTION GAP, not a harness error", () => {
+    const md = buildGapReport([
+      {
+        scenarioId: "tailscale-missing",
+        image: "i",
+        detection: {
+          scenarioId: "tailscale-missing",
+          detected: false,
+          misses: [{ id: "tailscale", want: "error", got: "absent" }],
+        },
+        appliedVia: "agent",
+        reachedGreen: false,
+        gateEligible: false,
+        error: "agent gave up",
+      },
+    ]);
+    expect(md).toContain("DETECTION GAP");
+    expect(md).not.toContain("HARNESS ERROR");
+    expect(md).toContain("0 / 1 scenarios reached green"); // stays in the denominator
+  });
+
   it("classifies a by-design no-apply scenario as DETECTION-ONLY and excludes it from the denominator", () => {
     const md = buildGapReport([
       {


### PR DESCRIPTION
## Problem

The onboarding gap report misclassified **infrastructure failures as product detection gaps**. When a scenario throws during seed/boot — e.g. `incus launch images:alpine/3.20` fails with *"image couldn't be found"* — the catch block returns a result with `detected: false`, and `classify()` fell through to label it **`DETECTION GAP`**. That falsely implies Shepherd's diagnostics failed to detect the seeded defect, when in reality the instance never booted far enough to test anything.

This isn't hypothetical: `alpine/3.20` already aged out of the `images:` remote (fixed by bumping to `3.21` in #674), and a stale local report still showed `git-missing` as a `DETECTION GAP` for exactly this reason. Every future image rot would re-trigger the same false product-regression signal.

## Fix

Distinguish infra failures from genuine gaps by the **catch-block sentinel**: `error` set **AND** `detected === false` **AND** `misses` empty. That signature only occurs when the throw *preceded* `assertDetection` (which is pure and never throws) — i.e. seed/boot/launch never produced detection data.

- New `HARNESS ERROR` classification + a dedicated **`## Harness errors`** report section (separate from `## Gaps`).
- A throw that happens *after* detection (real `misses` recorded, e.g. an apply-path failure) keeps its detection result and stays a normal `DETECTION GAP`/`ADVICE GAP` — verified by test.
- Harness-errored scenarios are **excluded from the green ratio** (a scenario that couldn't boot got no fair coaching attempt; counting it non-green would itself read as a regression), mirroring how detection-only scenarios are excluded.
- **Gate verdict unchanged** — `gateGapScenarios`/`statusDescription` still key off `gateEligible && !reachedGreen`, so a gate-eligible scenario that can't boot still fails the gate (fail-closed: don't certify what couldn't be verified).
- Gitignore the generated `onboarding-gap-report.md` (written into cwd by `run.ts`; it was polluting `git status`).

## Tests

TDD: added a failing test reproducing the `git-missing` launch-error → `HARNESS ERROR` reclassification + denominator exclusion, plus a guard test that a post-detection apply error stays a `DETECTION GAP`. Full harness suite green (36/36); root `tsc` + `lint` clean.

[no-feature-entry] — CI/harness-internal reporting change, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)