### PR TITLE
fix(merge-train): launch driver with autopilot off regardless of repo default

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -29,6 +29,7 @@ import {
 import type { Leftover, ProcessReaper } from "./process-reaper";
 import type { PreviewService } from "./preview";
 import { planHouseRulesInjection, renderHouseRulesBlock } from "./house-rules";
+import { effectiveAutopilot } from "./effective-autopilot";
 import { MAX_IMAGES } from "./validate";
 import {
   resolveProfile,
@@ -611,6 +612,24 @@ function pickOverride<T>(override: T | undefined, original: T): T {
   return override !== undefined ? override : original;
 }
 
+/**
+ * A freshly-created session is pre-approved into the build queue only when the repo runs the
+ * build queue AND the session is effectively on autopilot (so no human approval gate will ever
+ * come) AND it isn't a research task. Keyed on the session's EFFECTIVE autopilot (not the raw
+ * repo default), so an autopilot-off session — e.g. a merge-train driver — is never auto-approved.
+ */
+function shouldPreApproveBuildQueue(
+  repoConfig: RepoConfig,
+  session: Pick<Session, "autopilotEnabled">,
+  research?: boolean,
+): boolean {
+  return (
+    repoConfig.buildQueueEnabled &&
+    effectiveAutopilot(session, repoConfig.autopilotEnabled) &&
+    !research
+  );
+}
+
 /** Result of the shared spawn-wrap helper (prepareSpawn). `ok:false` carries the
  *  auto-gate hold reason; callers diverge on it (create throws, resume → null). */
 type SpawnSuccess = {
@@ -1078,13 +1097,14 @@ export class SessionService {
         auto: input.auto ?? false,
         issueNumber: input.issueRef?.number ?? null,
         planGateEnabled: input.planGateEnabled ?? null,
+        autopilotEnabled: input.autopilotEnabled ?? null,
         planPhase: planGateOn ? "planning" : null,
         research: input.research ?? false,
       });
       // Attended sessions stay unapproved until a human clicks Approve in the UI.
       // Autopilot sessions are pre-approved so the agent can begin executing immediately
       // after authoring the queue without waiting for a human gate that will never come.
-      if (repoConfig.buildQueueEnabled && repoConfig.autopilotEnabled && !input.research)
+      if (shouldPreApproveBuildQueue(repoConfig, session, input.research))
         this.deps.store.setBuildQueueApproved(sessionId, true);
       this.scheduleRefine(session, herdSlug);
       return session;
@@ -1193,6 +1213,11 @@ export class SessionService {
       prompt: overrides?.prompt ?? s.prompt,
       model: pickOverride(overrides?.model, s.model),
       planGateEnabled: pickOverride(overrides?.planGateEnabled, s.planGateEnabled),
+      // Carry autopilot at spawn time (NOT redundant with the setAutopilotState copy below):
+      // create()'s build-queue pre-approval reads the session's effective autopilot and is never
+      // re-evaluated after, so an autopilot-off original (e.g. a merge-train driver) must be off
+      // here too or a relaunch under an autopilot-on repo would wrongly auto-approve its queue.
+      autopilotEnabled: s.autopilotEnabled,
       research: pickOverride(overrides?.research, s.research),
       images,
       issueRef,

--- a/src/store.ts
+++ b/src/store.ts
@@ -145,6 +145,7 @@ type NewSession = Omit<
   auto?: boolean;
   issueNumber?: number | null;
   planGateEnabled?: boolean | null;
+  autopilotEnabled?: boolean | null;
   planPhase?: Session["planPhase"];
   sandboxApplied?: SandboxProfile | null;
   sandboxDegraded?: boolean;
@@ -889,7 +890,7 @@ export class SessionStore implements CapStore, CreditStore {
       id: input.id ?? randomUUID(),
       desig: `${DESIG_PREFIX}${String(seq).padStart(2, "0")}`,
       readyToMerge: false,
-      autopilotEnabled: null,
+      autopilotEnabled: input.autopilotEnabled ?? null,
       autopilotStepCount: 0,
       autopilotPaused: false,
       autopilotComplete: false,
@@ -940,7 +941,7 @@ export class SessionStore implements CapStore, CreditStore {
           s.readyToMerge ? 1 : 0,
           s.status,
           s.lastState,
-          null, // autopilotEnabled — inherit repo default
+          s.autopilotEnabled === null ? null : s.autopilotEnabled ? 1 : 0, // autopilotEnabled
           0, // autopilotStepCount
           0, // autopilotPaused
           0, // autopilotComplete

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,8 @@ export interface CreateSessionInput {
   auto?: boolean;
   /** Per-task plan-gate override; absent → inherit repo default. */
   planGateEnabled?: boolean | null;
+  /** Per-task autopilot override; absent/null → inherit repo default. */
+  autopilotEnabled?: boolean | null;
   /** Per-spawn sandbox profile override; absent → inherit repo default. */
   sandboxProfile?: SandboxProfile | null;
   /** Research task kind; absent → false. */

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -38,6 +38,7 @@ const ALLOWED_KEYS = new Set([
   "images",
   "issueRef",
   "planGateEnabled",
+  "autopilotEnabled",
   "sandboxProfile",
   "research",
 ]);
@@ -349,6 +350,9 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
   const planGateEnabled = validatePlanGateEnabled(obj.planGateEnabled);
   if (!planGateEnabled.ok) return planGateEnabled;
 
+  const autopilotEnabled = validateAutopilotEnabled(obj.autopilotEnabled);
+  if (!autopilotEnabled.ok) return autopilotEnabled;
+
   const sandboxProfile = validateSandboxProfile(obj.sandboxProfile);
   if (!sandboxProfile.ok) return sandboxProfile;
 
@@ -365,6 +369,7 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
       images: images.value,
       issueRef: issueRef.value,
       planGateEnabled: planGateEnabled.value,
+      autopilotEnabled: autopilotEnabled.value,
       sandboxProfile: sandboxProfile.value,
       research: research.value,
     },
@@ -376,6 +381,13 @@ function validatePlanGateEnabled(value: unknown): Field<boolean | null | undefin
   if (value === undefined) return field(undefined);
   if (value === null || typeof value === "boolean") return field(value);
   return err("planGateEnabled must be a boolean, null, or absent");
+}
+
+/** autopilotEnabled — optional per-task override; absent/null → inherit the repo default. */
+function validateAutopilotEnabled(value: unknown): Field<boolean | null | undefined> {
+  if (value === undefined) return field(undefined);
+  if (value === null || typeof value === "boolean") return field(value);
+  return err("autopilotEnabled must be a boolean, null, or absent");
 }
 
 /** research — optional plain boolean; absent/undefined → false; null or non-boolean rejected. */

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -311,6 +311,22 @@ test("session override off beats repo on", async () => {
   expect(h.events.length).toBe(0);
 });
 
+test("merge-train driver (override off, repo on) is never classified or steered", async () => {
+  // A merge-train driver is created with autopilotEnabled:false even though the repo
+  // default is on — neither a finished turn nor a steerable block may steer it elsewhere.
+  const h = harness({
+    session: sess({ autopilotEnabled: false }),
+    repoEnabled: true,
+    verdict: { kind: "gate", summary: "x" },
+  });
+  await h.svc.onDone("s1");
+  await h.svc.onBlock("s1", block(["I'm done."]));
+  // The disabled driver is never classified and never steered (onDone may emit a benign
+  // refreshPr kick, so assert on the classifier + steer rather than zero events).
+  expect(h.classifyCount()).toBe(0);
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+});
+
 test("any PR (open/merged/closed) → autopilot stands down", async () => {
   // hasPr is true for a PR in ANY state — open is the critic's territory, merged/closed mean
   // the pre-PR mission is over; autopilot must never steer such a session to open another PR.

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2586,6 +2586,25 @@ test("create with buildQueueEnabled=true + autopilot off: queue is NOT auto-appr
   expect(store.getBuildQueue(s.id).approved).toBe(false);
 });
 
+test("create with per-task autopilotEnabled=false: queue NOT pre-approved even when repo autopilot on", async () => {
+  // Merge-train driver path: repo default is autopilot-on, but the create input forces it off
+  // → the session's effective autopilot is off → build-queue pre-approval must be skipped.
+  const store = new SessionStore(":memory:");
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(
+    buildQueueDeps(store, captured, { buildQueueEnabled: true, autopilotEnabled: true }) as any,
+  );
+  const s = await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "do it",
+    model: null,
+    images: [],
+    autopilotEnabled: false,
+  });
+  expect(store.getBuildQueue(s.id).approved).toBe(false);
+});
+
 // ── draft mode ───────────────────────────────────────────────────────────────
 
 test("composeSystemPrompt includes <draft-mode> block when draftMode=true", () => {

--- a/test/store-autopilot.test.ts
+++ b/test/store-autopilot.test.ts
@@ -32,6 +32,25 @@ test("new sessions default autopilot off/zeroed/unpaused", () => {
   expect(s.autopilotQuestion).toBeNull();
 });
 
+test("create honors autopilotEnabled override (false round-trips, default → null)", () => {
+  const store = freshStore();
+  const off = store.create({
+    name: "t",
+    prompt: "p",
+    repoPath: "/repo",
+    baseBranch: "main",
+    branch: "shepherd/t-off",
+    worktreePath: "/wt-off",
+    isolated: true,
+    herdrSession: "h",
+    herdrAgentId: "term_1",
+    autopilotEnabled: false,
+  } as any);
+  expect(store.get(off.id)!.autopilotEnabled).toBe(false);
+  // default create (no override) inherits the repo default → null
+  expect(store.get(seed(store).id)!.autopilotEnabled).toBeNull();
+});
+
 test("setAutopilotState patches only the given fields", () => {
   const store = freshStore();
   const id = seed(store).id;

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -108,6 +108,48 @@ test("sandboxProfile: invalid value rejected", () => {
   if (!r.ok) expect(r.error).toMatch(/sandboxProfile/);
 });
 
+test("autopilotEnabled: false accepted + passed through", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", autopilotEnabled: false },
+    root,
+  );
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.autopilotEnabled).toBe(false);
+});
+
+test("autopilotEnabled: true accepted + passed through", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", autopilotEnabled: true },
+    root,
+  );
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.autopilotEnabled).toBe(true);
+});
+
+test("autopilotEnabled: null accepted (inherit repo default)", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", autopilotEnabled: null },
+    root,
+  );
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.autopilotEnabled).toBeNull();
+});
+
+test("autopilotEnabled: absent → undefined (inherit repo default)", () => {
+  const r = validateCreate({ repoPath: validRepo, baseBranch: "main", prompt: "go" }, root);
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.autopilotEnabled).toBeUndefined();
+});
+
+test("autopilotEnabled: non-boolean string rejected", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", autopilotEnabled: "yes" },
+    root,
+  );
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toMatch(/autopilotEnabled/);
+});
+
 test("research: true accepted + passed through", () => {
   const r = validateCreate(
     { repoPath: validRepo, baseBranch: "main", prompt: "go", research: true },

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -231,6 +231,10 @@ describe("mergeTrainCreateInput", () => {
     expect(mergeTrainCreateInput("/repo/a", "main", prs).planGateEnabled).toBe(false);
   });
 
+  it("always launches the driver with autopilot off (autopilotEnabled === false)", () => {
+    expect(mergeTrainCreateInput("/repo/a", "main", prs).autopilotEnabled).toBe(false);
+  });
+
   it("passes through repoPath/baseBranch with null model and a non-empty prompt", () => {
     const input = mergeTrainCreateInput("/repo/a", "main", prs);
     expect(input.repoPath).toBe("/repo/a");
@@ -358,6 +362,15 @@ describe("mergeTrainCreateInput with handpicked param", () => {
       false,
     );
     expect(mergeTrainCreateInput("/repo/a", "main", prsNoSession, true).planGateEnabled).toBe(
+      false,
+    );
+  });
+
+  it("always launches with autopilot off regardless of handpicked", () => {
+    expect(mergeTrainCreateInput("/repo/a", "main", prsNoSession, false).autopilotEnabled).toBe(
+      false,
+    );
+    expect(mergeTrainCreateInput("/repo/a", "main", prsNoSession, true).autopilotEnabled).toBe(
       false,
     );
   });

--- a/ui/src/lib/components/merge-train.ts
+++ b/ui/src/lib/components/merge-train.ts
@@ -117,6 +117,9 @@ export function mergeTrainCreateInput(
     // Merge train is a procedural land-the-queue task, never a feature plan —
     // always skip the plan gate regardless of the per-repo toggle.
     planGateEnabled: false,
+    // Merge train lands the queue procedurally — never let autopilot steer the
+    // driver into other work (overrides repo default).
+    autopilotEnabled: false,
   };
 }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -745,6 +745,7 @@ export interface CreateInput {
   images?: string[]; // absolute staging paths from /api/uploads
   issueRef?: IssueRef; // optional attached issue; body appended server-side
   planGateEnabled?: boolean | null; // per-task plan-gate override; absent → inherit repo default
+  autopilotEnabled?: boolean | null; // per-task autopilot override; absent/null → inherit repo default
   sandboxProfile?: SandboxProfile | null; // per-spawn sandbox override; absent → inherit repo default
   research?: boolean; // research task kind; absent → false
 }


### PR DESCRIPTION
## Problem

The merge-train **driver** session is created via `mergeTrainCreateInput`, which force-sets `planGateEnabled: false` but says nothing about autopilot. So the driver inherits the repo's `autopilotEnabled` default — and in an autopilot-on repo it gets classified/steered into unrelated tasks between/after PR landings (the observed "harassment").

A second, independent vector: build-queue pre-approval at session create keyed on the **repo** default (`repoConfig.autopilotEnabled`), not the session — so the driver could also be auto-approved into build-queue execution.

## Fix

- Add a per-task `autopilotEnabled?: boolean | null` create-input override, mirroring the existing `planGateEnabled` plumbing (validate → service → store). Reuses the existing `autopilotEnabled` column — **no new field, no migration, no schema change.**
- `mergeTrainCreateInput` now sets `autopilotEnabled: false`, so the driver launches autopilot-off regardless of the repo default. The existing `effectiveAutopilot()` gate (`s.autopilotEnabled ?? repoDefault`) then stands the driver down at every autopilot entry path (`eligible()`, `considerCi`, `reEngageCi`) — no `autopilot.ts` change needed.
- Build-queue pre-approval re-keyed onto the session's **effective** autopilot via a new `shouldPreApproveBuildQueue()` helper, excluding the driver (and any explicitly-autopilot-off session).
- Relaunch carries `autopilotEnabled` forward so a relaunched driver stays locked off (incl. its own build-queue check).

**Decision:** default-off at launch (not an un-toggleable hard-lock) — fully satisfies "launch without autopilot, no matter the repo settings"; an operator can still manually re-enable per session. The manual path was never the source of the harassment.

## Tests

- `merge-train.test.ts` — both kickoff framings assert `autopilotEnabled: false`.
- `autopilot.test.ts` — driver override-off under repo-default-on is never classified/steered.
- `store-autopilot.test.ts` — override round-trips (`false`→`false`, absent→`null` inherit).
- `validate.test.ts` — accepts `true`/`false`/`null`/absent, rejects non-boolean.
- `service.test.ts` — build-queue pre-approval excludes an autopilot-off session under a build-queue+autopilot repo (no regression to the normal autopilot case).

## Verification

Root `tsc` + lint + `bun test ./test` (3011 pass); UI `check` + `check:i18n` (parity) + tests (1293 pass); `fallow audit` clean. No new i18n keys, no UI changes (`[no-feature-entry]` not needed — `fix` commit, feature gate not armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)