### PR TITLE
feat(repos): add "Fork a GitHub repo" with upstream-aware forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,27 @@ Notes:
   branch and requires `deployWorkflow` (the host's CI must support
   `workflow_dispatch`).
 
+### Forking a repo to contribute upstream
+
+To contribute to a GitHub project you don't have write access to, use **Fork a
+GitHub repo** in the repo picker (next to _Clone_). Paste `owner/repo` (or a URL);
+Shepherd runs `gh repo fork --clone`, which forks it under your account and sets
+up the standard topology: **`origin` = your fork**, **`upstream` = the original**.
+
+In this fork mode Shepherd is **upstream-aware**: issues, the PR list, checks, and
+the backlog all read from the **upstream** repo (the issues you'd work on, your
+upstream PRs), branches push to your **fork**, and a **PR you open targets the
+upstream** with its head on your fork (`<you>:<branch>`).
+
+Requires `gh auth login`. The fork is a real, persistent repo on your GitHub
+account — Shepherd does not remove it.
+
+v1 limitations on a fork (surfaced, not silent — they return GitHub's permission
+error if attempted): maintainer-side actions you don't have rights for —
+**merging** the upstream PR (the maintainer does that), re-running upstream CI,
+renaming upstream branches, requesting reviewers — and **epic / multi-branch**
+orchestration. Keeping the fork current with upstream (`gh repo sync`) is manual.
+
 ### Submitting tasks from external agents
 
 The HTTP API the UI uses is open to any client that can reach the core — no

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -123,6 +123,8 @@ interface GhPr {
   headRefOid?: string;
   reviews?: GhReview[];
   reviewRequests?: { login?: string }[];
+  isCrossRepository?: boolean;
+  headRepositoryOwner?: { login?: string };
 }
 
 function mapMergeable(v: string | undefined): boolean | null {
@@ -153,13 +155,21 @@ export class GithubForge implements GitForge {
   readonly kind = "github" as const;
   readonly mergeMethod: MergeMethod;
   readonly deployWorkflow: string | null;
+  /** In fork mode, the owner of the fork (origin) repo — the `<user>` half of
+   *  {@link forkSlug}. Used to qualify `pr create --head <forkOwner>:<branch>` and
+   *  to disambiguate `prStatus`'s cross-repo match. Undefined for non-fork repos. */
+  private readonly forkOwner?: string;
   constructor(
     readonly slug: string,
     private readonly cfg: ForgeConfig,
     private readonly run: GhRunner = defaultRunner,
+    /** Fork (origin) slug when the repo is a fork (`slug` = upstream). Drives the
+     *  fork-aware PR head qualifier and the `canPush` probe target. */
+    private readonly forkSlug?: string,
   ) {
     this.mergeMethod = cfg.mergeMethod ?? "squash";
     this.deployWorkflow = cfg.deployWorkflow ?? null;
+    this.forkOwner = forkSlug?.split("/")[0] || undefined;
   }
 
   async listIssues(): Promise<Issue[]> {
@@ -441,6 +451,12 @@ export class GithubForge implements GitForge {
 
   async prStatus(headBranch: string): Promise<PrStatus> {
     const deployConfigured = Boolean(this.cfg.deployWorkflow);
+    // `gh pr list --head` matches by bare branch ref name — it does NOT accept the
+    // `<owner>:<branch>` qualifier (verified, gh 2.83.2: it silently returns []).
+    // A bare `--head` DOES surface cross-repo (fork) PRs (verified against a real
+    // fork PR), so in fork mode we keep the bare head, widen the limit, and request
+    // `headRepositoryOwner`/`isCrossRepository` to pick the PR whose head lives on
+    // OUR fork — otherwise a same-named branch on another fork could match first.
     const out = await this.run([
       "pr",
       "list",
@@ -451,12 +467,14 @@ export class GithubForge implements GitForge {
       "--state",
       "all",
       "--json",
-      "number,url,title,state,createdAt,mergeable,mergeStateStatus,isDraft,statusCheckRollup,headRefOid,reviews,reviewRequests",
+      "number,url,title,state,createdAt,mergeable,mergeStateStatus,isDraft,statusCheckRollup,headRefOid,reviews,reviewRequests,isCrossRepository,headRepositoryOwner",
       "--limit",
-      "1",
+      this.forkOwner ? "30" : "1",
     ]);
     const prs = JSON.parse(out || "[]") as GhPr[];
-    const pr = prs[0];
+    const pr = this.forkOwner
+      ? prs.find((p) => p.headRepositoryOwner?.login === this.forkOwner)
+      : prs[0];
     if (!pr) return { state: "none", checks: "none", deployConfigured };
     const state = pr.state.toLowerCase() as PrStatus["state"];
     const createdAt = Date.parse(pr.createdAt ?? "");
@@ -542,9 +560,14 @@ export class GithubForge implements GitForge {
    *  THROWS on a probe failure (network/auth/unrecognised output) so the caller
    *  can treat that as retryable rather than silently as "no access". */
   async canPush(): Promise<boolean> {
+    // Fork mode: `this.slug` is the upstream (read-only to a contributor), but the
+    // user pushes branches and opens PRs from their fork — so probe the FORK
+    // (`forkSlug`). Probing upstream would report READf→false and silently disable
+    // the adopt-PR flow (gitignore-adopt.ts) on every fork (READ → false).
+    const probeSlug = this.forkSlug ?? this.slug;
     // `this.run` throwing (offline/unauth) and JSON.parse throwing (garbled)
     // both propagate as probe failures — intentionally not caught here.
-    const out = await this.run(["repo", "view", this.slug, "--json", "viewerPermission"]);
+    const out = await this.run(["repo", "view", probeSlug, "--json", "viewerPermission"]);
     const { viewerPermission } = JSON.parse(out || "{}") as { viewerPermission?: string };
     switch (viewerPermission) {
       case "ADMIN":
@@ -584,13 +607,18 @@ export class GithubForge implements GitForge {
   }
 
   async openPr(o: OpenPrInput): Promise<PrStatus> {
+    // Fork mode: the PR is created against the upstream (`this.slug`) but its head
+    // lives on the fork, so qualify it as `<forkOwner>:<branch>`. `gh pr create`
+    // supports this syntax (verified, gh 2.83.2); a bare branch would resolve the
+    // head against the upstream and fail.
+    const head = this.forkOwner ? `${this.forkOwner}:${o.head}` : o.head;
     const args = [
       "pr",
       "create",
       "--repo",
       this.slug,
       "--head",
-      o.head,
+      head,
       "--base",
       o.base,
       "--title",

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -123,7 +123,6 @@ interface GhPr {
   headRefOid?: string;
   reviews?: GhReview[];
   reviewRequests?: { login?: string }[];
-  isCrossRepository?: boolean;
   headRepositoryOwner?: { login?: string };
 }
 
@@ -455,8 +454,15 @@ export class GithubForge implements GitForge {
     // `<owner>:<branch>` qualifier (verified, gh 2.83.2: it silently returns []).
     // A bare `--head` DOES surface cross-repo (fork) PRs (verified against a real
     // fork PR), so in fork mode we keep the bare head, widen the limit, and request
-    // `headRepositoryOwner`/`isCrossRepository` to pick the PR whose head lives on
-    // OUR fork — otherwise a same-named branch on another fork could match first.
+    // `headRepositoryOwner` to pick the PR whose head lives on OUR fork — otherwise a
+    // same-named branch on another fork could match first.
+    //
+    // The 30 cap bounds the (cheap) poll while tolerating other forks opening a PR
+    // for the same branch ref. The only way to miss our PR is 30+ DISTINCT forks
+    // each opening an upstream PR from an identically-named branch; Shepherd branches
+    // are `shepherd/<session>`, so this is effectively impossible. If it ever bites,
+    // prStatus returns state:none and a duplicate PR could be opened — acceptable vs.
+    // unbounded paging on a hot path.
     const out = await this.run([
       "pr",
       "list",
@@ -467,7 +473,7 @@ export class GithubForge implements GitForge {
       "--state",
       "all",
       "--json",
-      "number,url,title,state,createdAt,mergeable,mergeStateStatus,isDraft,statusCheckRollup,headRefOid,reviews,reviewRequests,isCrossRepository,headRepositoryOwner",
+      "number,url,title,state,createdAt,mergeable,mergeStateStatus,isDraft,statusCheckRollup,headRefOid,reviews,reviewRequests,headRepositoryOwner",
       "--limit",
       this.forkOwner ? "30" : "1",
     ]);
@@ -562,8 +568,8 @@ export class GithubForge implements GitForge {
   async canPush(): Promise<boolean> {
     // Fork mode: `this.slug` is the upstream (read-only to a contributor), but the
     // user pushes branches and opens PRs from their fork — so probe the FORK
-    // (`forkSlug`). Probing upstream would report READf→false and silently disable
-    // the adopt-PR flow (gitignore-adopt.ts) on every fork (READ → false).
+    // (`forkSlug`). Probing upstream would report READ → false and silently disable
+    // the adopt-PR flow (gitignore-adopt.ts) on every fork.
     const probeSlug = this.forkSlug ?? this.slug;
     // `this.run` throwing (offline/unauth) and JSON.parse throwing (garbled)
     // both propagate as probe failures — intentionally not caught here.

--- a/src/forge/index.ts
+++ b/src/forge/index.ts
@@ -24,10 +24,10 @@ export function forgeFor(remoteUrl: string, map: ForgeMap): GitForge | null {
   return new GiteaForge(parsed.slug, cfg);
 }
 
-/** Read `origin` remote URL for a repo dir, or null. */
-function originUrl(repoDir: string): string | null {
+/** Read a named remote's URL for a repo dir, or null if the remote is absent. */
+function remoteUrl(repoDir: string, remote: string): string | null {
   try {
-    return execFileSync("git", ["-C", repoDir, "remote", "get-url", "origin"], {
+    return execFileSync("git", ["-C", repoDir, "remote", "get-url", remote], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
@@ -36,8 +36,37 @@ function originUrl(repoDir: string): string | null {
   }
 }
 
-/** Resolve the forge for a repo directory using its origin remote + config map. */
+/**
+ * Resolve the forge for a repo directory.
+ *
+ * Default: the forge targets the `origin` remote's slug.
+ *
+ * Fork mode: when an `upstream` remote exists whose slug differs from `origin`,
+ * and both resolve to GitHub, the forge targets the **upstream** slug (so issues,
+ * PRs, checks, backlog and the PR base all point at the original repo a
+ * contributor works against) while carrying the `origin` slug as `forkSlug` (the
+ * write target — pushes, the `pr create --head` qualifier, and the `canPush`
+ * probe). This is exactly the topology `gh repo fork --clone` produces.
+ */
 export function detectForge(repoDir: string, map: ForgeMap): GitForge | null {
-  const url = originUrl(repoDir);
-  return url ? forgeFor(url, map) : null;
+  const origin = remoteUrl(repoDir, "origin");
+  if (!origin) return null;
+
+  const upstream = remoteUrl(repoDir, "upstream");
+  if (upstream) {
+    const originParsed = parseRemote(origin);
+    const upstreamParsed = parseRemote(upstream);
+    if (
+      originParsed &&
+      upstreamParsed &&
+      upstreamParsed.slug !== originParsed.slug &&
+      kindFor(upstreamParsed.host, map) === "github" &&
+      kindFor(originParsed.host, map) === "github"
+    ) {
+      const cfg = map[upstreamParsed.host] ?? {};
+      return new GithubForge(upstreamParsed.slug, cfg, undefined, originParsed.slug);
+    }
+  }
+
+  return forgeFor(origin, map);
 }

--- a/src/forge/index.ts
+++ b/src/forge/index.ts
@@ -47,6 +47,14 @@ function remoteUrl(repoDir: string, remote: string): string | null {
  * contributor works against) while carrying the `origin` slug as `forkSlug` (the
  * write target — pushes, the `pr create --head` qualifier, and the `canPush`
  * probe). This is exactly the topology `gh repo fork --clone` produces.
+ *
+ * The trigger leans on the git convention that a remote literally named `upstream`
+ * is the repo `origin` was forked from — the dominant (and `gh`'s own) meaning. A
+ * repo that keeps a differing-slug `upstream` for some OTHER purpose while actually
+ * working within `origin` will read upstream's issues/PRs and target PRs there;
+ * that is intentional (we follow the convention rather than a network fork-check,
+ * which detectForge — sync and hot-path cached — must avoid). Rename the remote to
+ * opt out.
  */
 export function detectForge(repoDir: string, map: ForgeMap): GitForge | null {
   const origin = remoteUrl(repoDir, "origin");

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -470,3 +470,118 @@ async function pushToGitHub(
 
   return undefined;
 }
+
+// ── forkRepo ──────────────────────────────────────────────────────────────────
+
+/** Default gh runner for fork: promisified execFile wrapped in a 120s timeout
+ *  (forking + cloning can be slow — matches cloneRepo's 120s budget).
+ *  On timeout, rejects with an error whose `code` is `"_timeout"` so
+ *  classifyForkError maps it to `forkrepo_failed_timeout`. */
+const defaultForkRunner: GhRunner = async (args) => {
+  const TIMEOUT_MS = 120_000;
+  const timeoutErr = Object.assign(new Error("gh fork timed out"), { code: "_timeout" });
+  await Promise.race([
+    execFileAsync("gh", args, { maxBuffer: 4 * 1024 * 1024 }).then(() => undefined),
+    new Promise<never>((_, reject) => setTimeout(() => reject(timeoutErr), TIMEOUT_MS)),
+  ]);
+};
+
+type ForkErrorPredicate = (e: unknown, stderr: string) => boolean;
+const FORK_ERROR_TABLE: Array<[ForkErrorPredicate, string]> = [
+  // Explicit timeout code set by the default runner
+  [(e) => (e as any).code === "_timeout", "forkrepo_failed_timeout"],
+  // killed by SIGTERM (e.g. from an execFileSync timeout option)
+  [(e) => !!(e as any).killed && (e as any).signal === "SIGTERM", "forkrepo_failed_timeout"],
+  // gh not installed
+  [
+    (e, s) => (e as any).code === "ENOENT" || s.includes("command not found"),
+    "forkrepo_failed_gh_missing",
+  ],
+  // gh auth failures / insufficient permission to fork
+  [
+    (_, s) =>
+      s.includes("not logged") ||
+      s.includes("auth status") ||
+      s.includes("gh auth login") ||
+      s.includes("authentication") ||
+      s.includes("you are not logged") ||
+      s.includes("permission") ||
+      s.includes("403"),
+    "forkrepo_failed_auth",
+  ],
+  // repo not found / unreachable host / bad slug
+  [
+    (_, s) =>
+      s.includes("not found") ||
+      s.includes("could not resolve host") ||
+      s.includes("does not exist") ||
+      s.includes("no such") ||
+      s.includes("unable to access"),
+    "forkrepo_failed_url",
+  ],
+];
+
+/**
+ * Classify an error from forkRepo into a stable `forkrepo_failed_*` code.
+ * Mirrors classifyProjectError / classifyCloneError — lowercase stderr first.
+ */
+export function classifyForkError(e: unknown): string {
+  const stderr = String((e as any).stderr ?? (e as any).message ?? "").toLowerCase();
+  for (const [predicate, code] of FORK_ERROR_TABLE) {
+    if (predicate(e, stderr)) return code;
+  }
+  return "forkrepo_failed_generic";
+}
+
+/**
+ * Fork a GitHub repo under the authenticated user's account and clone it into
+ * `<repoRoot>/<input.name>`. Uses `gh repo fork <repo> --clone`, which sets
+ * `origin` = the fork and `upstream` = the original (default remote), so PRs from
+ * the worktrees target upstream automatically. Idempotent: an existing fork is
+ * synced and still cloned.
+ *
+ * Returns `{ ok: true, entry }` on success, or `{ ok: false, error }` with a
+ * `forkrepo_failed_*` code. Forking always requires `gh` auth, so a not-logged-in
+ * state is reported as `forkrepo_failed_auth` (not a generic failure).
+ *
+ * @param ghRunner - Injectable async runner for `gh` CLI calls (default: 120s timeout).
+ */
+export async function forkRepo(
+  input: { repo: string; name: string },
+  repoRoot: string,
+  ghRunner?: GhRunner,
+): Promise<{ ok: true; entry: RepoEntry } | { ok: false; error: string }> {
+  const runner = ghRunner ?? defaultForkRunner;
+
+  // Step 1: resolve paths + containment + existence checks (defense-in-depth)
+  const root = resolve(expandHome(repoRoot));
+  const target = join(root, input.name);
+  const inside = target === root || target.startsWith(root + sep);
+  if (!inside) return { ok: false, error: "forkrepo_failed_outside" };
+  if (existsSync(target)) return { ok: false, error: "forkrepo_failed_exists" };
+
+  // Step 2: auth pre-check (forking always requires a logged-in gh)
+  try {
+    await runner(["auth", "status"]);
+  } catch (e) {
+    const code = classifyForkError(e);
+    return {
+      ok: false,
+      error:
+        code === "forkrepo_failed_gh_missing"
+          ? "forkrepo_failed_gh_missing"
+          : "forkrepo_failed_auth",
+    };
+  }
+
+  // Step 3: fork + clone. Git-clone flags after `--` route the destination dir to
+  // `git clone <forkURL> <target>`, so it lands directly in repoRoot/<name>.
+  try {
+    await runner(["repo", "fork", input.repo, "--clone", "--", target]);
+  } catch (e) {
+    return { ok: false, error: classifyForkError(e) };
+  }
+
+  const entry: RepoEntry = { name: input.name, path: target, display: toDisplay(target) };
+  return { ok: true, entry };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import {
   validateCreate,
   validateRelaunchOverrides,
   validateCloneUrl,
+  validateForkTarget,
   validateNewProject,
   isAuthorized,
   originAllowed,
@@ -39,6 +40,7 @@ import {
   cloneRepo,
   createProject,
   listGithubOwners,
+  forkRepo,
   type GhRunner,
   type GhOutRunner,
 } from "./repos";
@@ -1931,6 +1933,25 @@ async function cloneRepoFromRequest(req: Request): Promise<Response> {
   return json(r.entry, 201);
 }
 
+// HTTP status per fork-failure code; anything unlisted falls back to 422.
+const FORK_ERROR_STATUS: Record<string, number> = {
+  forkrepo_failed_url: 400,
+  forkrepo_failed_outside: 400,
+  forkrepo_failed_exists: 409,
+  forkrepo_failed_timeout: 504,
+};
+
+async function forkRepoFromRequest(req: Request, ghRunner?: GhRunner): Promise<Response> {
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+  const body = (await req.json().catch(() => null)) as { target?: unknown } | null;
+  const parsed = validateForkTarget(body?.target);
+  if (!parsed.ok) return json({ error: parsed.error }, FORK_ERROR_STATUS[parsed.error] ?? 400);
+  const r = await forkRepo(parsed.value, config.repoRoot, ghRunner);
+  if (!r.ok) return json({ error: r.error }, FORK_ERROR_STATUS[r.error] ?? 422);
+  return json(r.entry, 201);
+}
+
 // HTTP status per new-project-failure code; anything unlisted falls back to 422.
 const PROJECT_ERROR_STATUS: Record<string, number> = {
   newproject_failed_slug: 400,
@@ -1979,6 +2000,10 @@ async function handleRepos({ req, parts, deps }: Ctx): Promise<Response | null> 
       return json({ repos, recentWindowDays: RECENT_WINDOW_DAYS });
     }
     if (req.method === "POST") return cloneRepoFromRequest(req);
+  }
+  // POST /api/repos/fork — fork a GitHub repo under the user's account + clone it.
+  if (parts[0] === "api" && parts[1] === "repos" && parts[2] === "fork" && !parts[3]) {
+    if (req.method === "POST") return forkRepoFromRequest(req, deps.newProjectGhRunner);
   }
   return null;
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -338,6 +338,58 @@ export function validateCloneUrl(value: unknown): Field<{ url: string; name: str
   return field({ url, name });
 }
 
+// Bare `owner/repo` shorthand for `gh repo fork` (exactly two safe segments).
+const OWNER_REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/**
+ * Resolve a fork input into the gh `repo` argument and its `owner/repo` slug, or
+ * null if the form is unrecognized. Accepts the same URL forms as
+ * {@link validateCloneUrl} (https://, http://, scp-style git@) plus the bare
+ * `owner/repo` shorthand that `gh repo fork` understands.
+ */
+function parseForkInput(input: string): { repo: string; slug: string } | null {
+  const isHttps = /^https?:\/\//i.test(input);
+  const isScp = /^[^@]+@[^:/]+:/.test(input) && !input.includes("://");
+  if (isHttps || isScp) {
+    const parsed = parseRemote(input);
+    return parsed ? { repo: input, slug: parsed.slug } : null; // full URL → gh
+  }
+  if (OWNER_REPO_RE.test(input)) {
+    const slug = input.replace(/\.git$/i, "");
+    return { repo: slug, slug }; // normalized owner/repo → gh
+  }
+  return null;
+}
+
+/**
+ * Validate a fork target submitted by the user. Derives the target folder name
+ * from the last slug segment. Returns `{ repo, name }` where `repo` is the
+ * argument passed to `gh repo fork` and `name` is the destination folder.
+ */
+export function validateForkTarget(value: unknown): Field<{ repo: string; name: string }> {
+  if (typeof value !== "string") return err("forkrepo_failed_url");
+  const input = value.trim();
+  if (input.length === 0 || input.length > CLONE_URL_MAX) return err("forkrepo_failed_url");
+
+  const parsed = parseForkInput(input);
+  if (!parsed) return err("forkrepo_failed_url");
+  const { repo, slug } = parsed;
+
+  // Reject slugs containing any traversal segment
+  if (slug.split("/").some((s) => s === "..")) return err("forkrepo_failed_outside");
+
+  // Derive folder name from the last slug segment (e.g. "owner/repo" → "repo")
+  const name = (slug.split("/").at(-1) ?? "").replace(/\.git$/i, "").trim();
+  if (name.length === 0) return err("forkrepo_failed_url");
+  if (name.includes("..") || name.includes("/") || name.includes("\\")) {
+    return err("forkrepo_failed_outside");
+  }
+  // Reject values that would be interpreted as a git/gh flag
+  if (name.startsWith("-") || repo.startsWith("-")) return err("forkrepo_failed_url");
+
+  return field({ repo, name });
+}
+
 /** Pure validator — no side-effects beyond fs.statSync for the repoPath check. */
 export function validateCreate(body: unknown, repoRoot: string): Result {
   if (body === null || typeof body !== "object" || Array.isArray(body)) {

--- a/test/forge-detect.test.ts
+++ b/test/forge-detect.test.ts
@@ -29,6 +29,24 @@ test("detectForge resolves a github.com origin to a github forge with the slug",
   expect(forge!.slug).toBe("acme/widget");
 });
 
+test("detectForge fork mode: origin=fork + upstream=original → forge targets the upstream slug", () => {
+  // The topology `gh repo fork --clone` produces: origin = the user's fork,
+  // upstream = the original. The forge must target upstream so issues/PRs/checks
+  // and the PR base all point at the repo the contributor works against.
+  git("remote", "add", "origin", "https://github.com/kai/widget.git");
+  git("remote", "add", "upstream", "https://github.com/acme/widget.git");
+  const forge = detectForge(dir, {});
+  expect(forge!.kind).toBe("github");
+  expect(forge!.slug).toBe("acme/widget"); // upstream, not the fork
+});
+
+test("detectForge: upstream remote with the SAME slug as origin → not fork mode (origin slug)", () => {
+  git("remote", "add", "origin", "https://github.com/acme/widget.git");
+  git("remote", "add", "upstream", "https://github.com/acme/widget.git");
+  const forge = detectForge(dir, {});
+  expect(forge!.slug).toBe("acme/widget");
+});
+
 test("detectForge returns null for a repo without an origin remote", () => {
   expect(detectForge(dir, {})).toBeNull();
 });

--- a/test/forge/github-fork.test.ts
+++ b/test/forge/github-fork.test.ts
@@ -33,7 +33,6 @@ function prEntry(owner: string, extra: Record<string, unknown> = {}) {
     headRefOid: "abc123",
     reviews: [],
     reviewRequests: [],
-    isCrossRepository: true,
     headRepositoryOwner: { login: owner },
     ...extra,
   };

--- a/test/forge/github-fork.test.ts
+++ b/test/forge/github-fork.test.ts
@@ -1,0 +1,126 @@
+import { test, expect } from "bun:test";
+import { GithubForge } from "../../src/forge/github";
+
+// A recording fake `gh` runner. Returns canned stdout keyed by the subcommand
+// (`<arg0> <arg1>`), and records every call for argument assertions.
+function fakeRunner(responses: Record<string, string>) {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<string> => {
+    calls.push(args);
+    const key = `${args[0]} ${args[1] ?? ""}`.trim();
+    return key in responses ? responses[key]! : "";
+  };
+  return { run, calls };
+}
+
+const UPSTREAM = "dannymcc/may";
+const FORK = "kai-osthoff/may";
+const FORK_OWNER = "kai-osthoff";
+const BRANCH = "shepherd/fix-thing";
+
+/** Build a single gh `pr list` JSON entry (shape captured from a real cross-repo PR). */
+function prEntry(owner: string, extra: Record<string, unknown> = {}) {
+  return {
+    number: 42,
+    url: `https://github.com/${UPSTREAM}/pull/42`,
+    title: "feat: thing",
+    state: "OPEN",
+    createdAt: "2026-01-01T00:00:00Z",
+    isDraft: false,
+    mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
+    statusCheckRollup: [],
+    headRefOid: "abc123",
+    reviews: [],
+    reviewRequests: [],
+    isCrossRepository: true,
+    headRepositoryOwner: { login: owner },
+    ...extra,
+  };
+}
+
+// ── openPr: PR targets upstream, head qualified with the fork owner ──────────────
+
+test("fork mode openPr: --repo upstream, --base, --head <forkOwner>:<branch>", async () => {
+  const { run, calls } = fakeRunner({ "pr list": JSON.stringify([prEntry(FORK_OWNER)]) });
+  const forge = new GithubForge(UPSTREAM, {}, run, FORK);
+  await forge.openPr({ head: BRANCH, base: "main", title: "t", body: "b" });
+
+  const create = calls.find((c) => c[0] === "pr" && c[1] === "create")!;
+  expect(create).toBeDefined();
+  const repoIdx = create.indexOf("--repo");
+  expect(create[repoIdx + 1]).toBe(UPSTREAM);
+  const headIdx = create.indexOf("--head");
+  expect(create[headIdx + 1]).toBe(`${FORK_OWNER}:${BRANCH}`);
+  const baseIdx = create.indexOf("--base");
+  expect(create[baseIdx + 1]).toBe("main");
+});
+
+test("non-fork openPr: bare --head, --repo origin", async () => {
+  const { run, calls } = fakeRunner({ "pr list": JSON.stringify([]) });
+  const forge = new GithubForge("o/r", {}, run);
+  await forge.openPr({ head: BRANCH, base: "main", title: "t", body: "b" });
+
+  const create = calls.find((c) => c[0] === "pr" && c[1] === "create")!;
+  expect(create[create.indexOf("--repo") + 1]).toBe("o/r");
+  expect(create[create.indexOf("--head") + 1]).toBe(BRANCH); // no owner: qualifier
+});
+
+// ── prStatus: bare --head (gh rejects owner:branch) + headRepositoryOwner filter ──
+
+test("fork mode prStatus: resolves the cross-repo PR (not state:none) via bare --head", async () => {
+  const { run, calls } = fakeRunner({ "pr list": JSON.stringify([prEntry(FORK_OWNER)]) });
+  const forge = new GithubForge(UPSTREAM, {}, run, FORK);
+  const status = await forge.prStatus(BRANCH);
+
+  expect(status.state).toBe("open");
+  expect(status.number).toBe(42);
+
+  const list = calls.find((c) => c[0] === "pr" && c[1] === "list")!;
+  // gh `pr list --head` does NOT accept `<owner>:<branch>` — must be the bare branch.
+  expect(list[list.indexOf("--head") + 1]).toBe(BRANCH);
+  expect(list[list.indexOf("--json") + 1]).toContain("headRepositoryOwner");
+});
+
+test("fork mode prStatus: picks OUR fork when a same-named branch exists on another fork", async () => {
+  const { run } = fakeRunner({
+    // Another fork's PR for the same branch name comes first; ours second.
+    "pr list": JSON.stringify([
+      prEntry("someone-else", { number: 99, url: "x" }),
+      prEntry(FORK_OWNER, { number: 42 }),
+    ]),
+  });
+  const forge = new GithubForge(UPSTREAM, {}, run, FORK);
+  const status = await forge.prStatus(BRANCH);
+  expect(status.number).toBe(42); // filtered by headRepositoryOwner.login === forkOwner
+});
+
+test("fork mode prStatus: no PR from our fork → state:none", async () => {
+  const { run } = fakeRunner({ "pr list": JSON.stringify([prEntry("someone-else")]) });
+  const forge = new GithubForge(UPSTREAM, {}, run, FORK);
+  const status = await forge.prStatus(BRANCH);
+  expect(status.state).toBe("none");
+});
+
+// ── canPush: probe the fork (write target), not the read-only upstream ───────────
+
+test("fork mode canPush: probes the FORK slug, returns true on WRITE", async () => {
+  const { run, calls } = fakeRunner({
+    "repo view": JSON.stringify({ viewerPermission: "WRITE" }),
+  });
+  const forge = new GithubForge(UPSTREAM, {}, run, FORK);
+  expect(await forge.canPush()).toBe(true);
+
+  const view = calls.find((c) => c[0] === "repo" && c[1] === "view")!;
+  expect(view[2]).toBe(FORK); // forkSlug, NOT the upstream slug
+});
+
+test("non-fork canPush: probes the origin slug", async () => {
+  const { run, calls } = fakeRunner({
+    "repo view": JSON.stringify({ viewerPermission: "READ" }),
+  });
+  const forge = new GithubForge("o/r", {}, run);
+  expect(await forge.canPush()).toBe(false);
+  const view = calls.find((c) => c[0] === "repo" && c[1] === "view")!;
+  expect(view[2]).toBe("o/r");
+});

--- a/test/repos.test.ts
+++ b/test/repos.test.ts
@@ -21,6 +21,8 @@ import {
   createProject,
   classifyProjectError,
   listGithubOwners,
+  forkRepo,
+  classifyForkError,
   type GhRunner,
   type GhOutRunner,
 } from "../src/repos";
@@ -620,4 +622,153 @@ test("createProject: runner _timeout on repo create → ok:true + warning timeou
   } finally {
     cleanup();
   }
+});
+
+// ── forkRepo ──────────────────────────────────────────────────────────────────
+
+/** Happy path: auth ok + fork ok → ok:true, entry, and the exact gh args. */
+test("forkRepo: happy path → ok:true, entry, runs auth then `repo fork --clone -- <target>`", async () => {
+  const { repoRoot, cleanup } = makeTempRoot();
+  try {
+    const calls: string[][] = [];
+    const stubRunner: GhRunner = async (args) => {
+      calls.push(args);
+      // resolve void — success for both auth status and repo fork
+    };
+    const result = await forkRepo({ repo: "dannymcc/may", name: "may" }, repoRoot, stubRunner);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.entry.name).toBe("may");
+    expect(result.entry.path).toBe(join(repoRoot, "may"));
+    expect(calls.length).toBe(2);
+    expect(calls[0]).toEqual(["auth", "status"]);
+    expect(calls[1]).toEqual([
+      "repo",
+      "fork",
+      "dannymcc/may",
+      "--clone",
+      "--",
+      join(repoRoot, "may"),
+    ]);
+  } finally {
+    cleanup();
+  }
+});
+
+/** Not logged in: auth status rejects → ok:false + forkrepo_failed_auth, no fork attempted. */
+test("forkRepo: gh not logged in → forkrepo_failed_auth", async () => {
+  const { repoRoot, cleanup } = makeTempRoot();
+  try {
+    const calls: string[][] = [];
+    const stubRunner: GhRunner = async (args) => {
+      calls.push(args);
+      const err = Object.assign(new Error("You are not logged into any GitHub hosts"), {
+        stderr: "You are not logged into any GitHub hosts. Run gh auth login",
+      });
+      throw err;
+    };
+    const result = await forkRepo({ repo: "dannymcc/may", name: "may" }, repoRoot, stubRunner);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("forkrepo_failed_auth");
+    expect(calls.length).toBe(1); // fork never attempted
+  } finally {
+    cleanup();
+  }
+});
+
+/** gh not installed: auth status rejects ENOENT → forkrepo_failed_gh_missing. */
+test("forkRepo: gh missing → forkrepo_failed_gh_missing", async () => {
+  const { repoRoot, cleanup } = makeTempRoot();
+  try {
+    const stubRunner: GhRunner = async () => {
+      throw Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" });
+    };
+    const result = await forkRepo({ repo: "dannymcc/may", name: "may" }, repoRoot, stubRunner);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("forkrepo_failed_gh_missing");
+  } finally {
+    cleanup();
+  }
+});
+
+/** Existence guard: target dir already exists → forkrepo_failed_exists (no gh call). */
+test("forkRepo: target dir exists → forkrepo_failed_exists", async () => {
+  const { repoRoot, cleanup } = makeTempRoot();
+  try {
+    mkdirSync(join(repoRoot, "may"));
+    let called = false;
+    const stubRunner: GhRunner = async () => {
+      called = true;
+    };
+    const result = await forkRepo({ repo: "dannymcc/may", name: "may" }, repoRoot, stubRunner);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("forkrepo_failed_exists");
+    expect(called).toBe(false);
+  } finally {
+    cleanup();
+  }
+});
+
+/** Containment guard: an escaping name → forkrepo_failed_outside (no gh call). */
+test("forkRepo: escaping name → forkrepo_failed_outside", async () => {
+  const { repoRoot, cleanup } = makeTempRoot();
+  try {
+    let called = false;
+    const stubRunner: GhRunner = async () => {
+      called = true;
+    };
+    const result = await forkRepo(
+      { repo: "dannymcc/may", name: "../escape" },
+      repoRoot,
+      stubRunner,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("forkrepo_failed_outside");
+    expect(called).toBe(false);
+  } finally {
+    cleanup();
+  }
+});
+
+/** Fork step fails with "repository not found" → forkrepo_failed_url (auth passed). */
+test("forkRepo: fork step 'repository not found' → forkrepo_failed_url", async () => {
+  const { repoRoot, cleanup } = makeTempRoot();
+  try {
+    let call = 0;
+    const stubRunner: GhRunner = async () => {
+      call++;
+      if (call === 1) return; // auth ok
+      throw Object.assign(new Error("not found"), {
+        stderr:
+          "GraphQL: Could not resolve to a Repository with the name 'dannymcc/nope'. (not found)",
+      });
+    };
+    const result = await forkRepo({ repo: "dannymcc/nope", name: "nope" }, repoRoot, stubRunner);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("forkrepo_failed_url");
+  } finally {
+    cleanup();
+  }
+});
+
+test("classifyForkError: timeout, gh-missing, auth, url, generic", () => {
+  expect(classifyForkError(Object.assign(new Error("t"), { code: "_timeout" }))).toBe(
+    "forkrepo_failed_timeout",
+  );
+  expect(classifyForkError(Object.assign(new Error("x"), { code: "ENOENT" }))).toBe(
+    "forkrepo_failed_gh_missing",
+  );
+  expect(classifyForkError({ stderr: "you are not logged in" })).toBe("forkrepo_failed_auth");
+  expect(classifyForkError({ stderr: "HTTP 403: forbidden (permission)" })).toBe(
+    "forkrepo_failed_auth",
+  );
+  expect(classifyForkError({ stderr: "could not resolve host github.com" })).toBe(
+    "forkrepo_failed_url",
+  );
+  expect(classifyForkError({ stderr: "something weird" })).toBe("forkrepo_failed_generic");
 });

--- a/test/server-fork.test.ts
+++ b/test/server-fork.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for POST /api/repos/fork route. Mirrors test/server-projects.test.ts.
+ * Route-level tests own the 415/400/201-shape contract; the deeper error mapping
+ * (auth/exists/url) is owned by forkRepo in test/repos.test.ts.
+ *
+ * A recording gh runner is injected via deps.newProjectGhRunner so no real `gh`
+ * fork is performed; the happy path resolves to a 201 without touching the network
+ * or the filesystem.
+ */
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { SessionService } from "../src/service";
+import { EventHub } from "../src/events";
+import { makeApp, type AppDeps } from "../src/server";
+import type { GhRunner } from "../src/repos";
+
+function makeDeps(ghRunner?: GhRunner): AppDeps {
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({ worktreePath: "/wt", branch: "shepherd/x", isolated: true }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => ({
+        terminalId: "term_x",
+        cwd: "/wt",
+        agent: "claude",
+        agentStatus: "working",
+        paneId: "p",
+        tabId: "t",
+        workspaceId: "w",
+      }),
+      list: () => [],
+      stop: () => {},
+      send: () => {},
+    } as any,
+    events,
+  });
+  const usageLimits = {
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
+  };
+  const distiller = { distillNow: () => {} };
+  return { store, service, events, usageLimits, distiller, newProjectGhRunner: ghRunner };
+}
+
+function postFork(
+  app: ReturnType<typeof makeApp>,
+  body: unknown,
+  headers?: HeadersInit,
+): Promise<Response> {
+  return app.fetch(
+    new Request("http://x/api/repos/fork", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+test("POST /api/repos/fork missing Content-Type → 415", async () => {
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(
+    new Request("http://x/api/repos/fork", {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+      body: JSON.stringify({ target: "dannymcc/may" }),
+    }),
+  );
+  expect(res.status).toBe(415);
+});
+
+test("POST /api/repos/fork invalid target → 400 forkrepo_failed_url", async () => {
+  const app = makeApp(makeDeps());
+  const res = await postFork(app, { target: "just-a-repo" });
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toBe("forkrepo_failed_url");
+});
+
+test("POST /api/repos/fork happy path → 201 + RepoEntry, runs gh fork", async () => {
+  const calls: string[][] = [];
+  const ghRunner: GhRunner = async (args) => {
+    calls.push(args);
+  };
+  const app = makeApp(makeDeps(ghRunner));
+  // Unique name so the existence guard never collides with a real repoRoot entry.
+  const name = `forktest-${process.pid}-${Date.now()}`;
+  const res = await postFork(app, { target: `dannymcc/${name}` });
+  expect(res.status).toBe(201);
+  const body = await res.json();
+  expect(body.name).toBe(name);
+  expect(typeof body.path).toBe("string");
+  // auth status + repo fork were invoked through the injected runner
+  expect(calls[0]).toEqual(["auth", "status"]);
+  expect(calls[1]?.slice(0, 4)).toEqual(["repo", "fork", `dannymcc/${name}`, "--clone"]);
+});

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   validateCreate,
   validateCloneUrl,
+  validateForkTarget,
   validateNewProject,
   isAuthorized,
   originAllowed,
@@ -527,6 +528,69 @@ test("validateCreate rejects an issueRef with a non-http url", () => {
 });
 
 import { validateSteers, validateBroadcast } from "../src/validate";
+
+// ── validateForkTarget ────────────────────────────────────────────────────────
+
+test("validateForkTarget: bare owner/repo shorthand → repo passed through, name from slug", () => {
+  const r = validateForkTarget("dannymcc/may");
+  expect(r.ok).toBe(true);
+  if (r.ok) {
+    expect(r.value.repo).toBe("dannymcc/may");
+    expect(r.value.name).toBe("may");
+  }
+});
+
+test("validateForkTarget: owner/repo.git shorthand strips .git for both repo and name", () => {
+  const r = validateForkTarget("dannymcc/may.git");
+  expect(r.ok).toBe(true);
+  if (r.ok) {
+    expect(r.value.repo).toBe("dannymcc/may");
+    expect(r.value.name).toBe("may");
+  }
+});
+
+test("validateForkTarget: https URL → full URL passed to gh, name from slug", () => {
+  const r = validateForkTarget("https://github.com/dannymcc/may");
+  expect(r.ok).toBe(true);
+  if (r.ok) {
+    expect(r.value.repo).toBe("https://github.com/dannymcc/may");
+    expect(r.value.name).toBe("may");
+  }
+});
+
+test("validateForkTarget: scp-style git@ URL accepted, name from slug", () => {
+  const r = validateForkTarget("git@github.com:dannymcc/may.git");
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.name).toBe("may");
+});
+
+test("validateForkTarget: empty / non-string → _url", () => {
+  expect(validateForkTarget("").ok).toBe(false);
+  expect(validateForkTarget("   ").ok).toBe(false);
+  expect(validateForkTarget(123).ok).toBe(false);
+  expect(validateForkTarget(null).ok).toBe(false);
+});
+
+test("validateForkTarget: bare single segment (no owner) rejected as _url", () => {
+  const r = validateForkTarget("just-a-repo");
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toBe("forkrepo_failed_url");
+});
+
+test("validateForkTarget: ftp:// and other schemes rejected as _url", () => {
+  expect(validateForkTarget("ftp://github.com/owner/repo").ok).toBe(false);
+  expect(validateForkTarget("file:///etc/passwd").ok).toBe(false);
+});
+
+test("validateForkTarget: traversal segment in a URL rejected as _outside", () => {
+  const r = validateForkTarget("https://github.com/owner/..");
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toBe("forkrepo_failed_outside");
+});
+
+test("validateForkTarget: leading-dash repo (would be a gh flag) rejected", () => {
+  expect(validateForkTarget("-flag/repo").ok).toBe(false);
+});
 
 // ── validateCloneUrl ──────────────────────────────────────────────────────────
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1300,5 +1300,22 @@
   "feat_epic_migrations_title": "Epic-Landungen melden nicht ausgeführte Migrationen",
   "feat_epic_migrations_body": "Wenn der Landing-PR eines Epics Datenbankmigrationen hinzufügt, zeigt das Band 'Integrierte Epics' jetzt einen Warn-Chip mit der Dateianzahl — der Harness führt sie nie aus, prüfe sie also vor dem Merge. Vor dem Schließen der Zeile musst du die Migrationen bestätigen.",
   "feat_newproject_owner_title": "Besitzer für neues GitHub-Repo wählen",
-  "feat_newproject_owner_body": "Wenn du ein Projekt mit GitHub-Repository anlegst, kannst du jetzt wählen, ob es unter deinem persönlichen Konto oder einer deiner Organisationen landet — der Dialog listet jede Organisation auf, der du angehörst, statt immer dein Konto zu nehmen."
+  "feat_newproject_owner_body": "Wenn du ein Projekt mit GitHub-Repository anlegst, kannst du jetzt wählen, ob es unter deinem persönlichen Konto oder einer deiner Organisationen landet — der Dialog listet jede Organisation auf, der du angehörst, statt immer dein Konto zu nehmen.",
+  "forkrepo_title": "GitHub-Repo forken",
+  "forkrepo_input_label": "Repository (owner/repo oder URL)",
+  "forkrepo_input_placeholder": "dannymcc/may",
+  "forkrepo_target_preview": "→ {root}/{name}",
+  "forkrepo_hint": "Forkt das Repo unter deinem GitHub-Account und klont es. Pull Requests, die du daraus öffnest, zielen auf das Original (Upstream). Der Fork bleibt in deinem Account.",
+  "forkrepo_submit": "Forken & starten",
+  "forkrepo_forking": "Forke…",
+  "forkrepo_trigger": "+ GitHub-Repo forken",
+  "forkrepo_failed_auth": "Nicht bei GitHub angemeldet (oder keine Berechtigung zum Forken). Führe gh auth login aus.",
+  "forkrepo_failed_exists": "Zielordner existiert bereits",
+  "forkrepo_failed_url": "Ungültiges Repository — nutze owner/repo oder eine GitHub-URL",
+  "forkrepo_failed_outside": "Ziel liegt außerhalb des Projektordners",
+  "forkrepo_failed_timeout": "Timeout, bitte erneut",
+  "forkrepo_failed_gh_missing": "GitHub CLI (gh) ist nicht installiert.",
+  "forkrepo_failed_generic": "Forken fehlgeschlagen",
+  "feat_fork_repo_title": "Repo forken, um zum Upstream beizutragen",
+  "feat_fork_repo_body": "Die Repo-Auswahl hat jetzt neben „Klonen“ die Option „GitHub-Repo forken“. Gib owner/repo (oder eine URL) ein, und Shepherd forkt es unter deinem Account, klont es und richtet die Remotes so ein, dass deine Pull Requests auf das Original (Upstream) zielen — der Weg, um zu einem Projekt beizutragen, für das du keine Schreibrechte hast."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1300,5 +1300,22 @@
   "feat_epic_migrations_title": "Epic landings flag unrun migrations",
   "feat_epic_migrations_body": "When an epic's landing PR adds database migrations, the Integrated-epics band now shows a warning chip with the file count — the harness never runs them, so verify them before merging. Clearing the row asks you to acknowledge the migrations first.",
   "feat_newproject_owner_title": "Choose the owner for a new GitHub repo",
-  "feat_newproject_owner_body": "When you create a project with a GitHub repository, you can now pick whether it lands under your personal account or one of your organizations — the dialog lists every org you belong to instead of always defaulting to your account."
+  "feat_newproject_owner_body": "When you create a project with a GitHub repository, you can now pick whether it lands under your personal account or one of your organizations — the dialog lists every org you belong to instead of always defaulting to your account.",
+  "forkrepo_title": "Fork a GitHub repo",
+  "forkrepo_input_label": "Repository (owner/repo or URL)",
+  "forkrepo_input_placeholder": "dannymcc/may",
+  "forkrepo_target_preview": "→ {root}/{name}",
+  "forkrepo_hint": "Forks the repo under your GitHub account and clones it. Pull requests you open from it target the original (upstream) repo. The fork stays in your account.",
+  "forkrepo_submit": "Fork & start",
+  "forkrepo_forking": "Forking…",
+  "forkrepo_trigger": "+ Fork a GitHub repo",
+  "forkrepo_failed_auth": "Not logged in to GitHub (or no permission to fork). Run gh auth login.",
+  "forkrepo_failed_exists": "Target folder already exists",
+  "forkrepo_failed_url": "Invalid repository — use owner/repo or a GitHub URL",
+  "forkrepo_failed_outside": "Target is outside the projects folder",
+  "forkrepo_failed_timeout": "Timed out, please retry",
+  "forkrepo_failed_gh_missing": "GitHub CLI (gh) is not installed.",
+  "forkrepo_failed_generic": "Fork failed",
+  "feat_fork_repo_title": "Fork a repo to contribute upstream",
+  "feat_fork_repo_body": "The repo picker now has a “Fork a GitHub repo” option next to Clone. Paste owner/repo (or a URL) and Shepherd forks it under your account, clones it, and wires the remotes so pull requests you open target the original (upstream) repo — the way to contribute to a project you don't have write access to."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -196,6 +196,15 @@ export async function cloneRepo(url: string): Promise<RepoEntry> {
   return postJson<RepoEntry>("/api/repos", { url }, "clone");
 }
 
+/** Fork a GitHub repo under the user's account and clone it locally.
+ *  `target` is `owner/repo` or a GitHub URL. On a hard failure throws with
+ *  `err.message` set to the server's `error` field (a `forkrepo_failed_*` code),
+ *  so the modal can strip the prefix and map to its `msg(code)` switch — same
+ *  contract as `cloneRepo`. */
+export async function forkRepo(target: string): Promise<RepoEntry> {
+  return postJson<RepoEntry>("/api/repos/fork", { target }, "fork");
+}
+
 /** Create a new local git project (optionally with a GitHub remote).
  *  On success returns a `RepoEntry` plus an optional `warning` when the local repo
  *  was created but the GitHub step failed (partial success — the modal treats this as

--- a/ui/src/lib/components/ForkRepo.svelte
+++ b/ui/src/lib/components/ForkRepo.svelte
@@ -1,0 +1,304 @@
+<script lang="ts">
+  import { forkRepo } from "$lib/api";
+  import type { RepoEntry } from "$lib/types";
+  import { dialog } from "$lib/a11yDialog";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    onclose,
+    ondone,
+    repoRootDisplay = "~/projects",
+  }: {
+    onclose?: () => void;
+    ondone: (entry: RepoEntry) => void;
+    repoRootDisplay?: string;
+  } = $props();
+
+  let target = $state("");
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+  let retry = $state<(() => void) | null>(null);
+
+  const targetName = $derived.by(() => {
+    const segment = target.split("/").filter(Boolean).at(-1) ?? "";
+    return segment.replace(/\.git$/i, "").trim();
+  });
+
+  function msg(code: string): string {
+    switch (code) {
+      case "auth":
+        return m.forkrepo_failed_auth();
+      case "exists":
+        return m.forkrepo_failed_exists();
+      case "url":
+        return m.forkrepo_failed_url();
+      case "outside":
+        return m.forkrepo_failed_outside();
+      case "timeout":
+        return m.forkrepo_failed_timeout();
+      case "gh_missing":
+        return m.forkrepo_failed_gh_missing();
+      default:
+        return m.forkrepo_failed_generic();
+    }
+  }
+
+  async function submit(e: Event) {
+    e.preventDefault();
+    if (!target.trim() || submitting) return;
+    submitting = true;
+    error = null;
+    retry = null;
+    try {
+      const entry = await forkRepo(target.trim());
+      ondone(entry);
+    } catch (err) {
+      const code = err instanceof Error ? err.message.replace(/^forkrepo_failed_/, "") : "";
+      error = msg(code);
+      retry = () => submit(e);
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div
+  class="overlay"
+  role="presentation"
+  onclick={(e) => {
+    if (e.target === e.currentTarget) onclose?.();
+  }}
+>
+  <!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
+  <form
+    class="card bracket"
+    role="dialog"
+    aria-modal="true"
+    aria-label={m.forkrepo_title()}
+    use:dialog={{ onclose: () => onclose?.() }}
+    onsubmit={submit}
+  >
+    <div class="chead">
+      <span class="micro">{m.forkrepo_title()}</span>
+      <button type="button" class="x" onclick={() => onclose?.()} aria-label={m.common_close()}
+        >✕</button
+      >
+    </div>
+
+    <label class="micro" for="fr-target">{m.forkrepo_input_label()}</label>
+    <input
+      id="fr-target"
+      type="text"
+      bind:value={target}
+      placeholder={m.forkrepo_input_placeholder()}
+      autocomplete="off"
+      autocorrect="off"
+      autocapitalize="off"
+      spellcheck={false}
+      required
+    />
+
+    {#if targetName}
+      <p class="preview">
+        {m.forkrepo_target_preview({ root: repoRootDisplay, name: targetName })}
+      </p>
+    {/if}
+
+    <p class="hint">{m.forkrepo_hint()}</p>
+
+    {#if error}
+      <div class="err" role="alert">
+        <span>{error}</span>
+        {#if retry}
+          <button type="button" class="retry" onclick={() => retry?.()}>{m.common_retry()}</button>
+        {/if}
+      </div>
+    {/if}
+
+    <button class="run" type="submit" disabled={submitting}>
+      {submitting ? m.forkrepo_forking() : m.forkrepo_submit()}
+    </button>
+  </form>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--color-scrim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+  }
+  .card {
+    position: relative;
+    width: min(520px, 92vw);
+    border: 1px solid var(--color-line-bright);
+    background: var(--color-panel);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .bracket::before,
+  .bracket::after {
+    content: "";
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    border: 1px solid var(--color-line-bright);
+  }
+  .bracket::before {
+    top: -1px;
+    left: -1px;
+    border-right: 0;
+    border-bottom: 0;
+  }
+  .bracket::after {
+    bottom: -1px;
+    right: -1px;
+    border-left: 0;
+    border-top: 0;
+  }
+  .chead {
+    display: flex;
+    align-items: center;
+    margin-bottom: 8px;
+  }
+  .x {
+    margin-left: auto;
+    background: transparent;
+    border: 0;
+    color: var(--color-muted);
+    cursor: pointer;
+    font: inherit;
+  }
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-top: 6px;
+  }
+  input {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    padding: 8px 10px;
+    border-radius: 2px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  input:focus {
+    outline: none;
+    border-color: var(--color-line-bright);
+  }
+  .preview {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    margin: 0;
+    padding: 2px 0;
+  }
+  .hint {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    margin: 4px 0 0;
+    line-height: 1.5;
+  }
+  .err {
+    color: var(--color-red);
+    font-size: var(--fs-meta);
+    margin-top: 6px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .retry {
+    flex-shrink: 0;
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    color: var(--color-amber);
+    font: inherit;
+    font-size: var(--fs-meta);
+    letter-spacing: 0.06em;
+    padding: 3px 8px;
+    cursor: pointer;
+  }
+  .retry:hover {
+    border-color: var(--color-amber);
+  }
+  .run {
+    margin-top: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    border: 1px solid var(--color-amber);
+    color: var(--color-amber);
+    background: transparent;
+    padding: 9px 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: var(--fs-meta);
+    cursor: pointer;
+    box-shadow: inset 0 0 18px -10px var(--color-amber);
+  }
+  .run:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  @media (max-width: 768px) {
+    .overlay {
+      align-items: stretch;
+      justify-content: stretch;
+    }
+    .card {
+      width: 100%;
+      max-width: none;
+      height: 100dvh;
+      border: 0;
+      overflow-y: auto;
+      animation: sheet-up 0.18s ease-out;
+    }
+    input {
+      /* 16px no-zoom font-size comes from the global iOS guard in app.css */
+      min-height: 44px;
+    }
+    .run {
+      min-height: 44px;
+    }
+    .chead {
+      margin-bottom: 6px;
+      min-height: 44px;
+    }
+    .chead .micro {
+      display: none;
+    }
+    .x {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 44px;
+      height: 44px;
+      margin-right: -10px;
+      font-size: var(--fs-lg);
+    }
+  }
+
+  @keyframes sheet-up {
+    from {
+      transform: translateY(12px);
+      opacity: 0.6;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+</style>

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -31,6 +31,7 @@
     onsubmit,
     onclose,
     onclone,
+    onfork,
     onnewproject,
     initialPrompt,
     initialRepoPath,
@@ -55,6 +56,7 @@
     }) => Promise<void> | void;
     onclose?: () => void;
     onclone?: () => void;
+    onfork?: () => void;
     onnewproject?: () => void;
     initialPrompt?: string;
     initialRepoPath?: string;
@@ -475,6 +477,7 @@
         value={repoPath}
         onchange={(p) => (repoPath = p)}
         {onclone}
+        {onfork}
         {onnewproject}
       />
     </div>

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -11,6 +11,7 @@
     value,
     onchange,
     onclone,
+    onfork,
     onnewproject,
     windowDays,
   }: {
@@ -18,6 +19,7 @@
     value: string;
     onchange: (path: string) => void;
     onclone?: () => void;
+    onfork?: () => void;
     onnewproject?: () => void;
     /** Day count the server computed recentAgentCount over — named in the per-row label. */
     windowDays: number;
@@ -273,6 +275,21 @@
           }}
         >
           {m.clonerepo_trigger()}
+        </button>
+      {/if}
+      {#if onfork}
+        <!-- coachTarget id "fork-row" must match FeatureAnnouncement.targetId in feature-announcements.ts -->
+        <button
+          type="button"
+          class="rs-clone-row"
+          use:coachTarget={"fork-row"}
+          onclick={() => {
+            open = false;
+            filter = "";
+            onfork?.();
+          }}
+        >
+          {m.forkrepo_trigger()}
         </button>
       {/if}
       {#if onnewproject}

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -86,6 +86,7 @@
     onclose,
     onsaved,
     onclone,
+    onfork,
     herdrUpdate = null,
     onherdrupdate,
     onwhatsnew,
@@ -95,6 +96,7 @@
     onclose?: () => void;
     onsaved?: (root: string) => void;
     onclone?: () => void;
+    onfork?: () => void;
     herdrUpdate?: HerdrUpdateStatus | null;
     onherdrupdate?: () => void;
     onwhatsnew?: () => void;
@@ -624,6 +626,11 @@
       {#if onclone}
         <button type="button" class="clone-trigger" onclick={() => onclone?.()}
           >{m.clonerepo_trigger()}</button
+        >
+      {/if}
+      {#if onfork}
+        <button type="button" class="clone-trigger" onclick={() => onfork?.()}
+          >{m.forkrepo_trigger()}</button
         >
       {/if}
     </div>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -860,4 +860,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_newproject_owner_title",
     bodyKey: "feat_newproject_owner_body",
   },
+  {
+    // targetId "fork-row" anchors the coachmark on the "Fork a GitHub repo" trigger
+    // in the repo picker (RepoSelect). 1.30.0 is the latest released tag, so this
+    // ships in 1.31.0.
+    id: "fork-repo",
+    sinceVersion: "1.31.0",
+    titleKey: "feat_fork_repo_title",
+    bodyKey: "feat_fork_repo_body",
+    targetId: "fork-row",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -85,6 +85,7 @@
   import NewTask from "$lib/components/NewTask.svelte";
   import Settings from "$lib/components/Settings.svelte";
   import CloneRepo from "$lib/components/CloneRepo.svelte";
+  import ForkRepo from "$lib/components/ForkRepo.svelte";
   import NewProject from "$lib/components/NewProject.svelte";
   import type { KickoffChoice } from "$lib/components/NewProject.svelte";
   import BroadcastDialog from "$lib/components/BroadcastDialog.svelte";
@@ -146,6 +147,7 @@
   let showSettings = $state(false);
   let settingsTab = $state<"workspace" | "session" | "device" | "diagnose">("workspace");
   let showClone = $state(false);
+  let showFork = $state(false);
   let showNewProject = $state(false);
   let showBroadcast = $state(false);
   // "clear all merged" confirm modal: the merged sessions to clear + their total
@@ -1826,6 +1828,12 @@
       showNew = false;
       showClone = true;
     }}
+    onfork={() => {
+      // Same handoff contract as onclone: ForkRepo.ondone reopens NewTask.
+      resetCompose();
+      showNew = false;
+      showFork = true;
+    }}
     onnewproject={() => {
       // Same as onclone: NewProject.ondone reopens NewTask, so drop any stale
       // relaunch/compose seed first to avoid an unintended relaunch.
@@ -1853,6 +1861,10 @@
       showSettings = false;
       showClone = true;
     }}
+    onfork={() => {
+      showSettings = false;
+      showFork = true;
+    }}
     onwhatsnew={() => {
       showSettings = false;
       showWhatsNew = true;
@@ -1867,6 +1879,19 @@
     onclose={() => (showClone = false)}
     ondone={(entry) => {
       showClone = false;
+      composeRepoPath = entry.path;
+      showNew = true;
+    }}
+    repoRootDisplay={settings?.repoRootDisplay}
+  />
+{/if}
+
+{#if showFork}
+  <!-- Same flow as CloneRepo: ondone reopens NewTask preselected on the forked repo. -->
+  <ForkRepo
+    onclose={() => (showFork = false)}
+    ondone={(entry) => {
+      showFork = false;
       composeRepoPath = entry.path;
       showNew = true;
     }}


### PR DESCRIPTION
## What

Adds a **Fork a GitHub repo** option to the repo picker (next to *Clone* / *New project*) so you can contribute to a GitHub project you don't have write access to — fork it under your account, clone it, and open PRs against the upstream.

Motivating use case: opening PRs against a repo like `dannymcc/may` where you're not (yet) a collaborator.

## How

**Fork + clone** via `gh repo fork --clone` → standard topology `origin = your fork`, `upstream = the original`:
- `validateForkTarget` accepts `owner/repo`, `https://…`, and scp-style `git@…` inputs
- `forkRepo` (async, injectable gh runner) with auth / containment / existence guards and a `forkrepo_failed_*` error taxonomy
- `POST /api/repos/fork` endpoint + `ForkRepo.svelte` modal, wired through `RepoSelect` (NewTask) and `Settings`
- i18n (EN+DE) + feature-catalog entry (`fork-repo`, since 1.31.0)

**Upstream-aware forge** — `detectForge` now reads the `upstream` remote and, in fork mode:
- targets the **upstream** slug, so issues / PR list / checks / backlog read from upstream (the issues you'd work on, your upstream PRs)
- `openPr` qualifies the head as `<forkOwner>:<branch>` (gh `pr create` supports this)
- `prStatus` keeps a **bare** `--head` (gh `pr list` rejects the `owner:branch` qualifier) and disambiguates the cross-repo PR via `headRepositoryOwner` — so a freshly-created fork PR resolves to `state:open`, not `none`
- `canPush` probes the **fork** (origin), keeping the adopt-PR flow enabled on forks (it would otherwise read upstream as READ → false and silently disable)

Pushes stay on `origin` = fork, so the existing push/worktree machinery is untouched.

## Cross-repo gh behavior — pinned empirically (gh 2.83.2)

Verified against a real fork PR (`cli/cli#13658`):
- `gh pr list --repo upstream --head <bare-branch> --state all` **returns** the cross-repo PR ✓
- the `<owner>:<branch>` qualifier returns `[]` on `pr list` (would break it) but **is** supported on `pr create`
- REST `repos/<upstream>/pulls?head=<owner>:<branch>` is a verified deterministic fallback

## Scope / limitations (documented in README)

Maintainer-side actions a contributor lacks rights for — merging the upstream PR, re-running upstream CI, renaming upstream branches, requesting reviewers — and epic/multi-branch orchestration are out of scope for v1; they surface GitHub's permission error rather than failing silently. Keeping the fork current (`gh repo sync`) is manual. The fork is a real, persistent repo on your account.

## Tests

- `validateForkTarget` (owner/repo, URL, scp; rejects traversal / leading-dash / non-string / unsupported schemes)
- `forkRepo` with injected gh runner (happy path + exact args, auth, gh-missing, exists, outside, not-found; `classifyForkError`)
- `forge-detect` fork mode (origin=fork + upstream → upstream slug; same-slug → non-fork)
- `github-fork` forge: `openPr` head qualifier, `prStatus` bare-head + owner-filter (incl. same-named branch on another fork, and our-fork-absent → none), `canPush` probe target, non-fork regressions
- `POST /api/repos/fork` route (415 / 400 / 201-shape)

All root + UI suites green; lint, svelte-check, `check:i18n`, branch-hygiene and feature-catalog gates pass.

[no-feature-entry] not used — catalog entry included.