### PR TITLE
fix(merge-train): server-derived participant marking that doesn't lose the status marker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -432,12 +432,13 @@ events.subscribe((event, data) => {
   service.clearMergingForTrain((data as { id: string }).id);
 });
 
-// Backstop sweep: drop marks older than the TTL so a stuck/rejected PR can't
-// stay "Merging" forever when neither of the above fires. Expected dwell: a PR
-// the train holds back (never merged, train not yet archived) keeps the amber
-// MERGING badge until the operator archives the train session, else up to
-// MERGE_STALE_MS (~30 min). There is no per-PR "rejected" signal — an accepted
-// cosmetic trade-off, fine while held-back PRs are rare; revisit if they aren't.
+// Backstop sweep: release a mark once its train is no longer live and reclaim
+// stale tracker entries. A PR the train holds back (never merged, train not yet
+// archived) keeps the amber MERGING badge for the LIFE of the train session — it
+// clears when the operator archives the train (clearMergingForTrain), or, for a
+// train that died without ever emitting session:archived, at the
+// TRAIN_TRACKER_MAX_MS liveness ceiling. There is no per-PR "rejected" signal —
+// an accepted cosmetic trade-off, fine while held-back PRs are rare.
 setInterval(() => service.sweepStaleMerging(), 60_000);
 
 // Hourly: delete local shepherd/* branches whose PR has merged. The merge train

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,6 +226,9 @@ const service = new SessionService({
   // archives before the 120s PR sweep credits it (the merge-train completion race).
   // prPoller is defined below; this closure is only invoked at runtime, after init.
   refreshPr: (id) => prPoller.pollSession(id),
+  // Live PR snapshot for server-derived merge-train participant marking; lazy (prPoller
+  // defined below). reconcileTrainMarks reads this to mark sessions whose PR is open.
+  prSnapshot: (): Record<string, import("./forge/types").GitState> => prPoller.snapshot(),
   egressWatcher,
   // Best-effort pre-teardown recap: generate a durable recap while the worktree still
   // exists (the generator reads it to build its prompt). Bounded + swallowed inside
@@ -405,7 +408,20 @@ events.subscribe((event, data) => {
   const { id, git } = data as { id: string; git: import("./forge/types").GitState };
   if (git.state === "merged" || git.state === "closed")
     service.resolveMerging(id, git.state === "merged");
+  // A participant's PR may flip to "open" only after the train launched (cold poller
+  // cache at create time). Re-reconcile all live trains on every git change so it gets
+  // marked. Cheap no-op when no train is live (#liveTrains empty).
+  service.reconcileTrainMarks();
 });
+
+// Startup rebuild: repopulate #liveTrains from persisted train sessions so their marks
+// survive a restart. Must run BEFORE the first sweepStaleMerging (below) — an empty
+// #liveTrains would otherwise sweep all persisted marks. Safe with a cold snapshot:
+// registerTrain just seeds the map; reconcile re-marks as the poller warms up.
+for (const s of store.list({ activeOnly: true })) {
+  if (s.mergeTrainPrs && s.mergeTrainPrs.length > 0)
+    service.registerTrain(s.id, s.repoPath, s.mergeTrainPrs);
+}
 
 // The train session itself was archived → clear any of its PRs still marked
 // (e.g. ones it held back / rejected and never merged). Keyed on archive (a

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -48,12 +48,12 @@ export function guardStaleTerminal(
  *  Returns false immediately for any non-terminal `raw` — `guardStaleTerminal` is a no-op off-terminal
  *  anyway, and this prevents a malformed `{state:"none"}` from ever being trusted.
  *  True (for a terminal `raw`) when either:
- *   - `marked`  — the session is currently merge-train-flagged (mergingSince set): a marked session
- *                 always had an open PR, so its terminal result is the train landing it (this holds
- *                 even when the PR was never cached open — the cold-cache case). NOTE this trusts ANY
- *                 terminal result while marked, relying on the invariant that `setMerging` only flags
- *                 `readyToMerge` sessions whose own PR is genuinely open (see `collectReadyPrs`); were
- *                 that invariant to break, a name-collision terminal hit could be trusted here; or
+ *   - `marked && markedNumber === raw.number` — the session is merge-train-flagged AND its recorded
+ *                 observed PR number matches the terminal result: server-side reconcile only sets
+ *                 `mergingSince` when it observed the PR as `state:"open"` with that number, so this
+ *                 still holds for the cold-cache rebase/force-push case (same PR number, head moved).
+ *                 A different-number terminal (reused branch name) falls through to the prev-cache check
+ *                 rather than being blanket-trusted; or
  *   - `prev` already cached THIS PR (same number, non-"none" state) — a PR we already owned.
  *  When this returns false, `raw` may be a reused-branch-name collision and must run through
  *  `guardStaleTerminal`. */
@@ -61,9 +61,10 @@ export function trustsTerminal(
   prev: GitState | undefined,
   raw: GitState,
   marked: boolean,
+  markedNumber: number | null,
 ): boolean {
   if (raw.state !== "merged" && raw.state !== "closed") return false; // guardStaleTerminal is a no-op off-terminal anyway
-  if (marked) return true;
+  if (marked && markedNumber != null && raw.number === markedNumber) return true;
   return !!prev && prev.number != null && prev.number === raw.number && prev.state !== "none";
 }
 
@@ -221,8 +222,9 @@ export class PrPoller implements PrCache {
     const me = (await forge.currentUser?.()) ?? null;
     const prev = this.cache.get(s.id);
     const marked = s.mergingSince != null;
+    const markedNumber = s.mergingPrNumber ?? null;
     const guard = (raw: GitState): GitState =>
-      trustsTerminal(prev, raw, marked) ? raw : this.rejectStaleTerminal(s, raw);
+      trustsTerminal(prev, raw, marked, markedNumber) ? raw : this.rejectStaleTerminal(s, raw);
     let git: GitState;
     try {
       git = guard({ kind: forge.kind, ...(await forge.prStatus(s.branch)) });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1735,7 +1735,12 @@ async function dispatchForgeAction(
       // owned this PR, else drop a reused-branch-name collision to "none" so GitRail and
       // the list overview agree.
       const prev = deps.prCache?.get(session.id);
-      const trusted = trustsTerminal(prev, git, session.mergingSince != null);
+      const trusted = trustsTerminal(
+        prev,
+        git,
+        session.mergingSince != null,
+        session.mergingPrNumber ?? null,
+      );
       return json(
         trusted
           ? git

--- a/src/server.ts
+++ b/src/server.ts
@@ -1723,30 +1723,7 @@ async function dispatchForgeAction(
 ): Promise<Response | null> {
   const { req, parts, deps } = ctx;
   if (req.method === "GET") {
-    if (!parts[4]) {
-      const me = (await forge.currentUser?.()) ?? null;
-      const git: GitState = annotateHandoff(
-        { kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) },
-        session.repoPath,
-        me,
-      );
-      // Same trust logic as the background poller (trustsTerminal): keep a genuinely-
-      // merged/closed PR when the session is merge-train-flagged or the cache already
-      // owned this PR, else drop a reused-branch-name collision to "none" so GitRail and
-      // the list overview agree.
-      const prev = deps.prCache?.get(session.id);
-      const trusted = trustsTerminal(
-        prev,
-        git,
-        session.mergingSince != null,
-        session.mergingPrNumber ?? null,
-      );
-      return json(
-        trusted
-          ? git
-          : guardStaleTerminal(git, (headSha) => deps.ownsPr?.(session, headSha) ?? null),
-      );
-    }
+    if (!parts[4]) return await forgeGitStateResponse(forge, session, deps);
     return null;
   }
   if (req.method === "POST") {
@@ -1755,6 +1732,35 @@ async function dispatchForgeAction(
     if (parts[4] === "redeploy") return forgeRedeploy(forge, session);
   }
   return null;
+}
+
+/**
+ * GET /api/sessions/:id/git — the session's current PR status, with the same trust
+ * logic as the background poller (trustsTerminal): keep a genuinely-merged/closed PR
+ * when the session is merge-train-flagged or the cache already owned this PR, else
+ * drop a reused-branch-name collision to "none" so GitRail and the list overview agree.
+ */
+async function forgeGitStateResponse(
+  forge: GitForge,
+  session: Session,
+  deps: AppDeps,
+): Promise<Response> {
+  const me = (await forge.currentUser?.()) ?? null;
+  const git: GitState = annotateHandoff(
+    { kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) },
+    session.repoPath,
+    me,
+  );
+  const prev = deps.prCache?.get(session.id);
+  const trusted = trustsTerminal(
+    prev,
+    git,
+    session.mergingSince != null,
+    session.mergingPrNumber ?? null,
+  );
+  return json(
+    trusted ? git : guardStaleTerminal(git, (headSha) => deps.ownsPr?.(session, headSha) ?? null),
+  );
 }
 
 async function handleSessionGit(ctx: Ctx): Promise<Response | null> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2268,28 +2268,6 @@ async function handleBroadcast({ req, parts, deps }: Ctx): Promise<Response | nu
   return null;
 }
 
-// POST /api/merge-train/start — mark a launched train's ready PRs as "merging".
-// The train itself runs client-side as an agent session; this only flags the
-// scoped PR-sessions so the list shows them in-flight. Body: {ids, trainId}.
-async function handleMergeTrain({ req, parts, deps }: Ctx): Promise<Response | null> {
-  if (!(parts[0] === "api" && parts[1] === "merge-train" && parts[2] === "start" && !parts[3]))
-    return null;
-  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
-  const ctErr = requireJsonContentType(req);
-  if (ctErr) return ctErr;
-  const body = (await req.json().catch(() => null)) as { ids?: unknown; trainId?: unknown } | null;
-  if (
-    !body ||
-    !Array.isArray(body.ids) ||
-    !body.ids.every((x) => typeof x === "string") ||
-    typeof body.trainId !== "string"
-  ) {
-    return json({ error: "body must be {ids: string[], trainId: string}" }, 400);
-  }
-  deps.service.setMerging(body.ids as string[], body.trainId);
-  return json({ ok: true });
-}
-
 // ── halt the herd: interrupt every live working agent at once ──
 function handleHalt({ req, parts, deps }: Ctx): Response | null {
   if (parts[0] !== "api" || parts[1] !== "halt" || parts[2]) return null;
@@ -3484,7 +3462,6 @@ const ROUTE_HANDLERS = [
   handleSteers,
   handleProjectIcons,
   handleBroadcast,
-  handleMergeTrain,
   handleHalt,
   handleFsDirs,
   handleBranches,

--- a/src/service.ts
+++ b/src/service.ts
@@ -1131,11 +1131,7 @@ export class SessionService {
       if (shouldPreApproveBuildQueue(repoConfig, session, input.research))
         this.deps.store.setBuildQueueApproved(sessionId, true);
       this.scheduleRefine(session, herdSlug);
-      // Launch-time merge-train trigger: register the train so its scoped PRs are tracked
-      // in #liveTrains and any already-open participant session is marked immediately
-      // (reconcileTrainMarks runs inside registerTrain). Empty/absent → no train.
-      if (input.mergeTrainPrs && input.mergeTrainPrs.length > 0)
-        this.registerTrain(session.id, session.repoPath, input.mergeTrainPrs);
+      this.#maybeRegisterTrain(session, input);
       return session;
     } catch (e) {
       // best-effort rollback; surface the original failure, not any cleanup error
@@ -1764,6 +1760,17 @@ export class SessionService {
    * selected open PR is marked on launch; the rest are marked as their PRs open
    * (via subsequent `reconcileTrainMarks` driven by `session:git`). `now` injectable.
    */
+  /**
+   * Launch-time merge-train trigger: when `create` spawned a train session (a
+   * non-empty `mergeTrainPrs`), register the train so its scoped PRs are tracked in
+   * `#liveTrains` and any already-open participant session is marked immediately
+   * (reconcileTrainMarks runs inside registerTrain). Empty/absent → no train.
+   */
+  #maybeRegisterTrain(session: Session, input: CreateSessionInput): void {
+    if (input.mergeTrainPrs && input.mergeTrainPrs.length > 0)
+      this.registerTrain(session.id, session.repoPath, input.mergeTrainPrs);
+  }
+
   registerTrain(
     trainId: string,
     repoPath: string,
@@ -1788,26 +1795,43 @@ export class SessionService {
    * one (a PR that opens later is picked up the next time this runs). `now` injectable.
    */
   reconcileTrainMarks(trainId?: string, now: number = Date.now()): void {
-    const targets =
-      trainId !== undefined
-        ? this.#liveTrains.has(trainId)
-          ? [trainId]
-          : []
-        : [...this.#liveTrains.keys()];
+    const targets = this.#resolveReconcileTargets(trainId);
     if (targets.length === 0) return;
     const snap = this.deps.prSnapshot?.() ?? {};
     for (const tid of targets) {
       const train = this.#liveTrains.get(tid)!;
       for (const s of this.deps.store.list({ activeOnly: true })) {
-        if (s.id === tid) continue; // never mark the train itself
-        if (s.repoPath !== train.repoPath) continue;
-        if (s.mergingSince !== null) continue; // already marked
-        const g = snap[s.id];
-        if (g?.state === "open" && g.number != null && train.prNumbers.has(g.number)) {
-          this.markTrainMember(tid, s.id, g.number, now);
-        }
+        const prNumber = this.#matchedOpenPrNumber(s, tid, train, snap);
+        if (prNumber !== null) this.markTrainMember(tid, s.id, prNumber, now);
       }
     }
+  }
+
+  /** The live trains a reconcile targets: the one `trainId` (if live), or all live. */
+  #resolveReconcileTargets(trainId?: string): string[] {
+    if (trainId === undefined) return [...this.#liveTrains.keys()];
+    return this.#liveTrains.has(trainId) ? [trainId] : [];
+  }
+
+  /**
+   * The open PR number that makes `session` a fresh member of `train`, or null when
+   * it doesn't qualify: it IS the train, is a different repo, is already marked, or
+   * its live PR isn't OPEN / not in the train's scoped queue.
+   */
+  #matchedOpenPrNumber(
+    session: Session,
+    trainId: string,
+    train: { repoPath: string; prNumbers: Set<number> },
+    snap: Record<string, GitState>,
+  ): number | null {
+    if (session.id === trainId) return null; // never mark the train itself
+    if (session.repoPath !== train.repoPath) return null;
+    if (session.mergingSince !== null) return null; // already marked
+    const g = snap[session.id];
+    if (g?.state === "open" && g.number != null && train.prNumbers.has(g.number)) {
+      return g.number;
+    }
+    return null;
   }
 
   /**
@@ -1946,7 +1970,20 @@ export class SessionService {
    * `now` injectable for tests.
    */
   sweepStaleMerging(now: number = Date.now()): void {
-    // A. Deregister crashed/gone trains (release them before clearing member marks).
+    // Three ordered phases — A feeds B and C, so the A→B→C ordering MUST be preserved.
+    this.#deregisterInactiveTrains(now);
+    this.#releaseNonLiveMarks();
+    this.#reclaimStaleTrainOffers(now);
+  }
+
+  /**
+   * Phase A: Deregister crashed/gone trains (release them before clearing member
+   * marks). A train whose session is missing or archived, or whose last activity
+   * (`max(registeredAt, updatedAt)`) is past TRAIN_TRACKER_MAX_MS, is dropped from
+   * `#liveTrains`. Last-activity-keyed so a slow-but-alive train (still touching its
+   * row) is never ceiled mid-run. `now` injectable.
+   */
+  #deregisterInactiveTrains(now: number): void {
     for (const [trainId, lt] of this.#liveTrains) {
       const ts = this.deps.store.get(trainId);
       if (!ts || ts.archivedAt != null) {
@@ -1956,15 +1993,33 @@ export class SessionService {
       const lastActive = Math.max(lt.registeredAt, ts.updatedAt);
       if (now - lastActive > TRAIN_TRACKER_MAX_MS) this.#liveTrains.delete(trainId);
     }
-    // B. Clear a member mark exactly when its train is no longer live.
+  }
+
+  /**
+   * Phase B: Clear a member mark exactly when its train is no longer live — released
+   * cleanly (via clearMergingForTrain) or via phase A's deregistration in the same
+   * sweep. No standalone age TTL.
+   */
+  #releaseNonLiveMarks(): void {
     for (const s of this.deps.store.list({ activeOnly: true })) {
       if (s.mergingSince === null) continue;
       if (s.mergingTrainId === null || !this.#liveTrains.has(s.mergingTrainId)) {
         this.clearMerging(s.id);
       }
     }
-    // C. Reclaim tracker entries directly (NOT via activeOnly, which excludes archived
-    // trains).
+  }
+
+  /**
+   * Phase C: Reclaim `#trainOffers` entries directly (NOT via activeOnly, which
+   * excludes archived trains), both no-emit (fail-safe no-offer):
+   *  - AWAITING (archived, awaiting a late credit): once the post-archive window
+   *    (MERGE_STALE_MS, #426) lapses — preserved exactly.
+   *  - LIVE-CRASH ORPHAN (awaitingSince null, train no longer live): A having just
+   *    dropped a crashed train, its still-live entry is reclaimed here. The
+   *    awaitingSince-null gate keeps a cleanly-archived entry on the AWAITING path.
+   * `now` injectable.
+   */
+  #reclaimStaleTrainOffers(now: number): void {
     for (const [trainId, entry] of this.#trainOffers) {
       const awaitingStale =
         entry.awaitingSince !== null && now - entry.awaitingSince > MERGE_STALE_MS;

--- a/src/service.ts
+++ b/src/service.ts
@@ -62,9 +62,12 @@ import {
 import type { EgressWatcher } from "./egress-watch";
 import type { GitState } from "./forge/types";
 
-/** A merge-train mark older than this is treated as stale and swept, so a
- *  rejected/held-back PR (never merged, train never archived) can't stay
- *  "Merging" forever. Mirrored in ui/src/lib/components/merge-train.ts. */
+/** Post-archive late-credit await window: after a merge-train session archives,
+ *  its completion-tracker entry waits this long for a poller-gated late merge to
+ *  credit it before the sweep reclaims it (no-credit); also bounds the same await
+ *  started in clearMergingForTrain. NOTE: per-session marks are NOT aged out by
+ *  this — they persist for the life of the train (see sweepStaleMerging, which
+ *  releases a mark only when its train leaves #liveTrains). */
 export const MERGE_STALE_MS = 30 * 60_000;
 
 /** Absolute backstop for a STILL-RUNNING merge-train completion-tracker entry: a

--- a/src/service.ts
+++ b/src/service.ts
@@ -60,6 +60,7 @@ import {
   type EgressBackend,
 } from "./egress";
 import type { EgressWatcher } from "./egress-watch";
+import type { GitState } from "./forge/types";
 
 /** A merge-train mark older than this is treated as stale and swept, so a
  *  rejected/held-back PR (never merged, train never archived) can't stay
@@ -102,6 +103,11 @@ export interface ServiceDeps {
    *  when a merge train archives before the 120s sweep surfaces its members' merges.
    *  Fire-and-forget, debounced, no-ops on archived sessions. Absent → no nudge. */
   refreshPr?: (id: string) => void;
+  /** Live PR-state map keyed by session id (= prPoller.snapshot), the source the
+   *  merge-train reconcile reads to derive which active sessions hold a selected,
+   *  still-open PR. Absent → reconcile sees an empty snapshot (marks nothing). Wired
+   *  from the poller in src/index.ts. */
+  prSnapshot?: () => Record<string, GitState>;
   /** Plugin ids to disable on trimmed auto spawns; defaults to the memoized read of
    *  ~/.claude/settings.json `enabledPlugins` (installedPluginIds). Inject point for tests. */
   pluginIds?: () => Promise<string[]>;
@@ -665,18 +671,32 @@ export class SessionService {
       repoPath: string;
       merged: boolean;
       archived: boolean;
-      // null while the train is still running — a LIVE entry is never swept on the
-      // normal path (however long the run / a slow first CI takes), only cleaned when
-      // the train archives; the sole exception is the TRAIN_TRACKER_MAX_MS absolute
-      // backstop below, for a train that died without a session:archived. Set to
-      // archive time when the train archives awaiting a late credit; the sweep then
-      // reclaims it once that post-archive window lapses.
+      // null while the train is still running — a LIVE entry is reclaimed only once
+      // the train leaves #liveTrains (phase A of sweepStaleMerging deregisters a train
+      // whose session is archived/missing or inactive past TRAIN_TRACKER_MAX_MS,
+      // measured by max(registeredAt, trainSession.updatedAt); phase C then reclaims
+      // the offer via liveCrashOrphan). Set to archive time when the train archives
+      // awaiting a late credit; the sweep reclaims it once that post-archive window
+      // lapses.
       awaitingSince: number | null;
-      launchedAt: number; // for the dead-train absolute backstop only
       members: Set<string>;
     }
   >();
   #memberToTrain = new Map<string, string>();
+
+  /**
+   * Live merge-trains, the SINGLE source of truth for "is this train running". A
+   * train is live iff it has an entry here. Registered when the train session
+   * launches (`registerTrain`), removed when it archives (`clearMergingForTrain`)
+   * or when the sweep deregisters a crashed/gone one. Keyed by train session id;
+   * `prNumbers` is the scoped queue (the PRs the train will land), `repoPath`
+   * scopes which active sessions a reconcile may mark, `registeredAt` feeds the
+   * crash backstop's last-activity ceiling.
+   */
+  #liveTrains = new Map<
+    string,
+    { repoPath: string; prNumbers: Set<number>; registeredAt: number }
+  >();
 
   /**
    * Build the human-turn prompt: the user's text plus any attached images and the
@@ -1728,45 +1748,108 @@ export class SessionService {
   }
 
   /**
-   * Mark each session as part of a launched merge train (the client passes the
-   * scoped ready-PR ids). Stamps `mergingSince`/`mergingTrainId`, persists, and
-   * pushes `session:merging` (carrying `trainId` so the live patch matches a
-   * refetch — the field is server state mirrored on the client). Unknown ids are
-   * skipped (best-effort: the set is cosmetic, never load-bearing).
+   * Register a launched merge train as LIVE (the train session owns it). `repoPath`
+   * scopes which active sessions a reconcile may mark; `prNumbers` is the scoped
+   * queue (the PR numbers the train will land). A train is "running" iff it has a
+   * `#liveTrains` entry. Immediately reconciles, so any session already holding a
+   * selected open PR is marked on launch; the rest are marked as their PRs open
+   * (via subsequent `reconcileTrainMarks` driven by `session:git`). `now` injectable.
    */
-  setMerging(ids: string[], trainId: string): void {
-    const since = Date.now();
-    const members = new Set<string>();
-    let repoPath: string | null = null;
-    for (const id of ids) {
-      const s = this.deps.store.get(id);
-      if (!s) continue;
-      this.deps.store.update(id, { mergingSince: since, mergingTrainId: trainId });
-      this.deps.events?.emit("session:merging", { id, since, trainId });
-      // Register the resolvable member for the completion tracker. repoPath is read
-      // off the FIRST resolvable member (never a skipped id) — the train is per-repo.
-      members.add(id);
-      this.#memberToTrain.set(id, trainId);
-      if (repoPath === null) repoPath = s.repoPath;
+  registerTrain(
+    trainId: string,
+    repoPath: string,
+    prNumbers: number[],
+    now: number = Date.now(),
+  ): void {
+    this.#liveTrains.set(trainId, {
+      repoPath,
+      prNumbers: new Set(prNumbers),
+      registeredAt: now,
+    });
+    this.reconcileTrainMarks(trainId, now);
+  }
+
+  /**
+   * Server-derived participant marking: for each live train (the one `trainId`, or
+   * all when omitted), mark every ACTIVE same-repo session whose live PR is OPEN and
+   * whose number is in the train's scoped queue. Reads the live PR snapshot via
+   * `deps.prSnapshot` (empty when unwired). The train session itself is never marked,
+   * and an already-marked session is left alone (idempotent — `markTrainMember`
+   * re-guards). Drives both the launch-time reconcile and the per-`session:git`
+   * one (a PR that opens later is picked up the next time this runs). `now` injectable.
+   */
+  reconcileTrainMarks(trainId?: string, now: number = Date.now()): void {
+    const targets =
+      trainId !== undefined
+        ? this.#liveTrains.has(trainId)
+          ? [trainId]
+          : []
+        : [...this.#liveTrains.keys()];
+    if (targets.length === 0) return;
+    const snap = this.deps.prSnapshot?.() ?? {};
+    for (const tid of targets) {
+      const train = this.#liveTrains.get(tid)!;
+      for (const s of this.deps.store.list({ activeOnly: true })) {
+        if (s.id === tid) continue; // never mark the train itself
+        if (s.repoPath !== train.repoPath) continue;
+        if (s.mergingSince !== null) continue; // already marked
+        const g = snap[s.id];
+        if (g?.state === "open" && g.number != null && train.prNumbers.has(g.number)) {
+          this.markTrainMember(tid, s.id, g.number, now);
+        }
+      }
     }
-    // No resolvable member → create no entry (so repoPath is never read off a skip).
-    if (repoPath !== null) {
-      this.#trainOffers.set(trainId, {
-        repoPath,
+  }
+
+  /**
+   * Stamp one session as a member of a live train and register it with the
+   * completion tracker. Idempotent and guarded: a no-op when the session IS the
+   * train, when the train is no longer live (a `session:git` after archive must not
+   * resurrect a member), when the session is unknown, or when already marked. The
+   * tracker entry is lazily created on the FIRST marked member, so a train whose PRs
+   * never open creates no entry. `now` injectable.
+   */
+  markTrainMember(
+    trainId: string,
+    sessionId: string,
+    prNumber: number,
+    now: number = Date.now(),
+  ): void {
+    if (sessionId === trainId) return;
+    const live = this.#liveTrains.get(trainId);
+    if (!live) return; // train not live → no resurrection
+    const s = this.deps.store.get(sessionId);
+    if (!s || s.mergingSince !== null) return; // unknown or already marked
+    this.deps.store.update(sessionId, {
+      mergingSince: now,
+      mergingTrainId: trainId,
+      mergingPrNumber: prNumber,
+    });
+    this.deps.events?.emit("session:merging", { id: sessionId, since: now, trainId });
+    this.#memberToTrain.set(sessionId, trainId);
+    let entry = this.#trainOffers.get(trainId);
+    if (!entry) {
+      entry = {
+        repoPath: live.repoPath,
         merged: false,
         archived: false,
         awaitingSince: null,
-        launchedAt: since,
-        members,
-      });
+        members: new Set<string>(),
+      };
+      this.#trainOffers.set(trainId, entry);
     }
+    entry.members.add(sessionId);
   }
 
   /** Clear one session's merge-train mark. No-op (no event) when not marked. */
   clearMerging(id: string): void {
     const s = this.deps.store.get(id);
     if (!s || s.mergingSince === null) return;
-    this.deps.store.update(id, { mergingSince: null, mergingTrainId: null });
+    this.deps.store.update(id, {
+      mergingSince: null,
+      mergingTrainId: null,
+      mergingPrNumber: null,
+    });
     this.deps.events?.emit("session:merging", { id, since: null, trainId: null });
   }
 
@@ -1809,6 +1892,10 @@ export class SessionService {
    * reclaimed mid-flight; only the post-archive wait is bounded). `now` injectable.
    */
   clearMergingForTrain(trainId: string, now: number = Date.now()): void {
+    // Drop the live-train entry FIRST (unconditionally, even with no #trainOffers
+    // entry) — the train has stopped running, so a later `session:git` reconcile
+    // must not re-mark a member against it.
+    this.#liveTrains.delete(trainId);
     for (const s of this.deps.store.list({ activeOnly: true })) {
       if (s.mergingTrainId === trainId) this.clearMerging(s.id);
     }
@@ -1831,25 +1918,49 @@ export class SessionService {
     this.#trainOffers.delete(trainId);
   }
 
-  /** Backstop: clear marks older than MERGE_STALE_MS. `now` injectable for tests. */
+  /**
+   * Liveness-based reclaim: marks live with their train, never on a flat age. Runs
+   * three ordered phases each call (order matters — A feeds B and C):
+   *  A. Deregister crashed/gone live trains. A train whose session is missing or
+   *     archived, or whose last activity (`max(registeredAt, updatedAt)`) is past
+   *     TRAIN_TRACKER_MAX_MS, is dropped from `#liveTrains`. Last-activity-keyed so a
+   *     slow-but-alive train (still touching its row) is never ceiled mid-run.
+   *  B. Clear member marks whose train is no longer live — a mark is released exactly
+   *     when its train stops running (cleanly via clearMergingForTrain, or via A's
+   *     deregistration here in the same sweep). No standalone age TTL.
+   *  C. Reclaim `#trainOffers` entries, both no-emit (fail-safe no-offer):
+   *     - AWAITING (archived, awaiting a late credit): once the post-archive window
+   *       (MERGE_STALE_MS, #426) lapses — preserved exactly.
+   *     - LIVE-CRASH ORPHAN (awaitingSince null, train no longer live): A having just
+   *       dropped a crashed train, its still-live entry is reclaimed here. The
+   *       awaitingSince-null gate keeps a cleanly-archived entry on the AWAITING path.
+   * `now` injectable for tests.
+   */
   sweepStaleMerging(now: number = Date.now()): void {
+    // A. Deregister crashed/gone trains (release them before clearing member marks).
+    for (const [trainId, lt] of this.#liveTrains) {
+      const ts = this.deps.store.get(trainId);
+      if (!ts || ts.archivedAt != null) {
+        this.#liveTrains.delete(trainId);
+        continue;
+      }
+      const lastActive = Math.max(lt.registeredAt, ts.updatedAt);
+      if (now - lastActive > TRAIN_TRACKER_MAX_MS) this.#liveTrains.delete(trainId);
+    }
+    // B. Clear a member mark exactly when its train is no longer live.
     for (const s of this.deps.store.list({ activeOnly: true })) {
-      if (s.mergingSince !== null && now - s.mergingSince > MERGE_STALE_MS) {
+      if (s.mergingSince === null) continue;
+      if (s.mergingTrainId === null || !this.#liveTrains.has(s.mergingTrainId)) {
         this.clearMerging(s.id);
       }
     }
-    // Reclaim tracker entries directly (NOT via activeOnly, which excludes archived
-    // trains). Two cases, both no-emit (fail-safe no-offer):
-    //  - AWAITING (archived, awaiting a late credit): once the post-archive window lapses.
-    //  - LIVE (awaitingSince null): NEVER on a normal run, however long it takes — only
-    //    the TRAIN_TRACKER_MAX_MS absolute backstop, which bounds an entry orphaned by a
-    //    train that died without a session:archived. Real runs finish far inside it.
+    // C. Reclaim tracker entries directly (NOT via activeOnly, which excludes archived
+    // trains).
     for (const [trainId, entry] of this.#trainOffers) {
       const awaitingStale =
         entry.awaitingSince !== null && now - entry.awaitingSince > MERGE_STALE_MS;
-      const deadTrainOrphan =
-        entry.awaitingSince === null && now - entry.launchedAt > TRAIN_TRACKER_MAX_MS;
-      if (awaitingStale || deadTrainOrphan) {
+      const liveCrashOrphan = entry.awaitingSince === null && !this.#liveTrains.has(trainId);
+      if (awaitingStale || liveCrashOrphan) {
         for (const id of entry.members) this.#memberToTrain.delete(id);
         this.#trainOffers.delete(trainId);
       }

--- a/src/service.ts
+++ b/src/service.ts
@@ -1120,6 +1120,7 @@ export class SessionService {
         autopilotEnabled: input.autopilotEnabled ?? null,
         planPhase: planGateOn ? "planning" : null,
         research: input.research ?? false,
+        mergeTrainPrs: input.mergeTrainPrs,
       });
       // Attended sessions stay unapproved until a human clicks Approve in the UI.
       // Autopilot sessions are pre-approved so the agent can begin executing immediately
@@ -1127,6 +1128,11 @@ export class SessionService {
       if (shouldPreApproveBuildQueue(repoConfig, session, input.research))
         this.deps.store.setBuildQueueApproved(sessionId, true);
       this.scheduleRefine(session, herdSlug);
+      // Launch-time merge-train trigger: register the train so its scoped PRs are tracked
+      // in #liveTrains and any already-open participant session is marked immediately
+      // (reconcileTrainMarks runs inside registerTrain). Empty/absent → no train.
+      if (input.mergeTrainPrs && input.mergeTrainPrs.length > 0)
+        this.registerTrain(session.id, session.repoPath, input.mergeTrainPrs);
       return session;
     } catch (e) {
       // best-effort rollback; surface the original failure, not any cleanup error

--- a/src/store.ts
+++ b/src/store.ts
@@ -121,6 +121,8 @@ type NewSession = Omit<
   | "readyToMerge"
   | "mergingSince"
   | "mergingTrainId"
+  | "mergeTrainPrs"
+  | "mergingPrNumber"
   | "autopilotEnabled"
   | "autopilotStepCount"
   | "autopilotPaused"
@@ -152,6 +154,7 @@ type NewSession = Omit<
   egressApplied?: boolean;
   egressDegraded?: boolean;
   research?: boolean;
+  mergeTrainPrs?: number[];
 };
 
 const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePath,
@@ -161,7 +164,7 @@ const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePat
   autoMergeEnabled, autoMergeRebaseCount, autoMergeRebaseHead,
   auto, issueNumber, sandboxApplied, sandboxDegraded, egressApplied, egressDegraded,
   research,
-  createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId`;
+  createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId, mergeTrainPrs, mergingPrNumber`;
 
 // ── repo_config row type + helpers ────────────────────────────────────────────
 
@@ -184,6 +187,19 @@ type RepoCfgRow = {
   defaultModel: string;
   egressExtraHosts: string | null;
 };
+
+/** Tolerantly parse the persisted mergeTrainPrs JSON back to number[] | null (never throws). */
+function parseMergeTrainPrsJson(raw: string | null | undefined): number[] | null {
+  if (raw === null || raw === undefined) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    if (parsed.some((el) => typeof el !== "number")) return null;
+    return parsed as number[];
+  } catch {
+    return null;
+  }
+}
 
 /** Tolerantly parse the persisted egressExtraHosts JSON back to string[] (never throws). */
 function parseEgressExtraHostsJson(raw: string | null | undefined): string[] {
@@ -914,6 +930,8 @@ export class SessionStore implements CapStore, CreditStore {
       archivedAt: null,
       mergingSince: null,
       mergingTrainId: null,
+      mergeTrainPrs: input.mergeTrainPrs ?? null,
+      mergingPrNumber: null,
     };
   }
 
@@ -923,7 +941,7 @@ export class SessionStore implements CapStore, CreditStore {
       const seq = this.nextDesignationSeq();
       const s = this.buildSessionRow(input, seq, now);
       this.db.run(
-        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
           s.id,
           s.desig,
@@ -963,6 +981,8 @@ export class SessionStore implements CapStore, CreditStore {
           s.archivedAt,
           s.mergingSince,
           s.mergingTrainId,
+          s.mergeTrainPrs !== null ? JSON.stringify(s.mergeTrainPrs) : null,
+          null, // mergingPrNumber — always null at create
         ],
       );
       return s;
@@ -1006,6 +1026,7 @@ export class SessionStore implements CapStore, CreditStore {
         | "readyToMerge"
         | "mergingSince"
         | "mergingTrainId"
+        | "mergingPrNumber"
       >
     >,
   ) {
@@ -1013,7 +1034,7 @@ export class SessionStore implements CapStore, CreditStore {
     if (!cur) return;
     const next = { ...cur, ...patch, updatedAt: Date.now() };
     this.db.run(
-      `UPDATE sessions SET name=?, status=?, lastState=?, branch=?, herdrAgentId=?, readyToMerge=?, mergingSince=?, mergingTrainId=?, updatedAt=? WHERE id=?`,
+      `UPDATE sessions SET name=?, status=?, lastState=?, branch=?, herdrAgentId=?, readyToMerge=?, mergingSince=?, mergingTrainId=?, mergingPrNumber=?, updatedAt=? WHERE id=?`,
       [
         next.name,
         next.status,
@@ -1023,6 +1044,7 @@ export class SessionStore implements CapStore, CreditStore {
         next.readyToMerge ? 1 : 0,
         next.mergingSince,
         next.mergingTrainId,
+        next.mergingPrNumber,
         next.updatedAt,
         id,
       ],
@@ -1664,6 +1686,8 @@ export class SessionStore implements CapStore, CreditStore {
     add("mergingTrainId", `mergingTrainId TEXT`);
     // research task kind: default 0 (false) for pre-existing rows.
     add("research", `research INTEGER NOT NULL DEFAULT 0`);
+    add("mergeTrainPrs", `mergeTrainPrs TEXT`);
+    add("mergingPrNumber", `mergingPrNumber INTEGER`);
   }
 
   // migrate repo_config that predates these opt-in columns. auto-address defaults
@@ -2095,6 +2119,8 @@ export class SessionStore implements CapStore, CreditStore {
       research: !!r.research,
       mergingSince: r.mergingSince ?? null,
       mergingTrainId: r.mergingTrainId ?? null,
+      mergeTrainPrs: parseMergeTrainPrsJson(r.mergeTrainPrs),
+      mergingPrNumber: r.mergingPrNumber ?? null,
     } as Session;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,10 @@ export interface Session {
   /** Id of the merge-train session that owns this mark (clears the whole set when
    *  that session is archived). Null when not merging. */
   mergingTrainId: string | null;
+  /** PR numbers selected by the merge train for this TRAIN session; null on non-train sessions. */
+  mergeTrainPrs: number[] | null;
+  /** The open-PR number observed when a PARTICIPANT session is marked "merging"; null otherwise. */
+  mergingPrNumber: number | null;
   /** Autopilot opt-in: true/false override, or null to inherit the repo default. */
   autopilotEnabled: boolean | null;
   /** Count of auto-steers autopilot has spent on this session (runaway guard; reset on PR-open / operator reply). */
@@ -102,6 +106,8 @@ export interface CreateSessionInput {
   sandboxProfile?: SandboxProfile | null;
   /** Research task kind; absent → false. */
   research?: boolean;
+  /** PR numbers selected for this TRAIN session; absent → null. */
+  mergeTrainPrs?: number[];
 }
 
 /**

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -41,6 +41,7 @@ const ALLOWED_KEYS = new Set([
   "autopilotEnabled",
   "sandboxProfile",
   "research",
+  "mergeTrainPrs",
 ]);
 
 /** Max staged images per spawn. Bounds the attach list (and the relaunch merge of
@@ -432,6 +433,9 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
   const research = validateResearch(obj.research);
   if (!research.ok) return research;
 
+  const mergeTrainPrs = validateMergeTrainPrs(obj.mergeTrainPrs);
+  if (!mergeTrainPrs.ok) return mergeTrainPrs;
+
   return {
     ok: true,
     value: {
@@ -445,6 +449,7 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
       autopilotEnabled: autopilotEnabled.value,
       sandboxProfile: sandboxProfile.value,
       research: research.value,
+      ...(mergeTrainPrs.value !== undefined ? { mergeTrainPrs: mergeTrainPrs.value } : {}),
     },
   };
 }
@@ -468,6 +473,18 @@ function validateResearch(value: unknown): Field<boolean> {
   if (value === undefined) return field(false);
   if (typeof value === "boolean") return field(value);
   return err("research must be a boolean or absent");
+}
+
+/** mergeTrainPrs — optional array of positive integers; absent → undefined (store defaults null). */
+function validateMergeTrainPrs(value: unknown): Field<number[] | undefined> {
+  if (value === undefined) return field(undefined);
+  if (!Array.isArray(value)) return err("mergeTrainPrs must be an array of integers");
+  for (let i = 0; i < value.length; i++) {
+    const n = value[i];
+    if (typeof n !== "number" || !Number.isInteger(n) || n <= 0)
+      return err(`mergeTrainPrs[${i}] must be an integer`);
+  }
+  return field(value as number[]);
 }
 
 type RelaunchResult = { ok: true; value: RelaunchOverrides } | { ok: false; error: string };

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -449,7 +449,9 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
       autopilotEnabled: autopilotEnabled.value,
       sandboxProfile: sandboxProfile.value,
       research: research.value,
-      ...(mergeTrainPrs.value !== undefined ? { mergeTrainPrs: mergeTrainPrs.value } : {}),
+      // value is number[] | undefined; consumers read it via truthiness / `?? null`,
+      // so an explicit undefined is equivalent to omitting the key.
+      mergeTrainPrs: mergeTrainPrs.value,
     },
   };
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -421,6 +421,35 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
   const issueRef = validateIssueRef(obj.issueRef);
   if (!issueRef.ok) return issueRef;
 
+  const options = validateOptions(obj);
+  if (!options.ok) return options;
+
+  return {
+    ok: true,
+    value: {
+      repoPath: repoPath.value,
+      baseBranch: baseBranch.value,
+      prompt: prompt.value,
+      model: model.value,
+      images: images.value,
+      issueRef: issueRef.value,
+      // mergeTrainPrs is number[] | undefined; consumers read it via truthiness /
+      // `?? null`, so an explicit undefined is equivalent to omitting the key.
+      ...options.value,
+    },
+  };
+}
+
+/** Optional create-time overrides, bundled so validateCreate stays flat (below the
+ *  complexity gate). Validator order is preserved, so first-error precedence is
+ *  identical to inlining these. */
+function validateOptions(obj: Record<string, unknown>): Field<{
+  planGateEnabled: boolean | null | undefined;
+  autopilotEnabled: boolean | null | undefined;
+  sandboxProfile: SandboxProfile | null | undefined;
+  research: boolean;
+  mergeTrainPrs: number[] | undefined;
+}> {
   const planGateEnabled = validatePlanGateEnabled(obj.planGateEnabled);
   if (!planGateEnabled.ok) return planGateEnabled;
 
@@ -436,24 +465,13 @@ export function validateCreate(body: unknown, repoRoot: string): Result {
   const mergeTrainPrs = validateMergeTrainPrs(obj.mergeTrainPrs);
   if (!mergeTrainPrs.ok) return mergeTrainPrs;
 
-  return {
-    ok: true,
-    value: {
-      repoPath: repoPath.value,
-      baseBranch: baseBranch.value,
-      prompt: prompt.value,
-      model: model.value,
-      images: images.value,
-      issueRef: issueRef.value,
-      planGateEnabled: planGateEnabled.value,
-      autopilotEnabled: autopilotEnabled.value,
-      sandboxProfile: sandboxProfile.value,
-      research: research.value,
-      // value is number[] | undefined; consumers read it via truthiness / `?? null`,
-      // so an explicit undefined is equivalent to omitting the key.
-      mergeTrainPrs: mergeTrainPrs.value,
-    },
-  };
+  return field({
+    planGateEnabled: planGateEnabled.value,
+    autopilotEnabled: autopilotEnabled.value,
+    sandboxProfile: sandboxProfile.value,
+    research: research.value,
+    mergeTrainPrs: mergeTrainPrs.value,
+  });
 }
 
 /** planGateEnabled — optional per-task override; absent/null → inherit the repo default. */

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -34,6 +34,8 @@ function sess(over: Partial<Session> = {}): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
+    mergingPrNumber: null,
     autopilotEnabled: true,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -667,14 +667,37 @@ test("prunes cache entries for sessions no longer active", async () => {
 
 // ── trustsTerminal unit tests ─────────────────────────────────────────────────
 
-test("trustsTerminal: signal (a) cold cache + marked → true", () => {
+test("trustsTerminal: signal (a) cold cache + marked + same number → true", () => {
   expect(
     trustsTerminal(
       undefined,
-      { kind: "github", state: "merged", number: 5, checks: "none", deployConfigured: false },
+      { kind: "github", state: "merged", number: 42, checks: "none", deployConfigured: false },
       true,
+      42,
     ),
   ).toBe(true);
+});
+
+test("trustsTerminal: marked + different-number terminal → false (falls to prev-cache path)", () => {
+  expect(
+    trustsTerminal(
+      undefined,
+      { kind: "github", state: "merged", number: 99, checks: "success", deployConfigured: false },
+      true,
+      42,
+    ),
+  ).toBe(false);
+});
+
+test("trustsTerminal: marked + markedNumber null + terminal, no prev → false", () => {
+  expect(
+    trustsTerminal(
+      undefined,
+      { kind: "github", state: "merged", number: 7, checks: "success", deployConfigured: false },
+      true,
+      null,
+    ),
+  ).toBe(false);
 });
 
 test("trustsTerminal: marked but state none → false (terminal-state gate)", () => {
@@ -684,7 +707,7 @@ test("trustsTerminal: marked but state none → false (terminal-state gate)", ()
     checks: "none" as const,
     deployConfigured: false,
   };
-  expect(trustsTerminal(undefined, noneState, true)).toBe(false);
+  expect(trustsTerminal(undefined, noneState, true, 42)).toBe(false);
 });
 
 test("trustsTerminal: marked but state open (non-terminal) → false (terminal-state gate)", () => {
@@ -693,6 +716,7 @@ test("trustsTerminal: marked but state open (non-terminal) → false (terminal-s
       undefined,
       { kind: "github", state: "open", number: 7, checks: "pending", deployConfigured: false },
       true,
+      7,
     ),
   ).toBe(false);
 });
@@ -703,6 +727,7 @@ test("trustsTerminal: signal (b) prev open #7, raw merged #7, unmarked → true"
       { kind: "github", state: "open", number: 7, checks: "pending", deployConfigured: false },
       { kind: "github", state: "merged", number: 7, checks: "success", deployConfigured: false },
       false,
+      null,
     ),
   ).toBe(true);
 });
@@ -713,6 +738,7 @@ test("trustsTerminal: no prev, raw merged #7, unmarked → false", () => {
       undefined,
       { kind: "github", state: "merged", number: 7, checks: "success", deployConfigured: false },
       false,
+      null,
     ),
   ).toBe(false);
 });
@@ -723,6 +749,7 @@ test("trustsTerminal: prev none, raw merged #7, unmarked → false", () => {
       { kind: "github", state: "none", checks: "none", deployConfigured: false },
       { kind: "github", state: "merged", number: 7, checks: "success", deployConfigured: false },
       false,
+      null,
     ),
   ).toBe(false);
 });
@@ -733,6 +760,7 @@ test("trustsTerminal: prev open #7, raw merged #8 (mismatched number), unmarked 
       { kind: "github", state: "open", number: 7, checks: "pending", deployConfigured: false },
       { kind: "github", state: "merged", number: 8, checks: "success", deployConfigured: false },
       false,
+      null,
     ),
   ).toBe(false);
 });
@@ -775,11 +803,11 @@ test("refresh signal (b): prior-owned PR transitions to merged, bypasses guard w
   expect(poller.snapshot()[s.id]?.state).toBe("merged");
 });
 
-test("refresh signal (a): cold cache + marked, ownsPr=false → merged passes through", async () => {
+test("refresh signal (a): cold cache + marked + markedNumber matches, ownsPr=false → merged passes through", async () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);
-  // Mark the session as merge-train-flagged BEFORE any poll
-  store.update(s.id, { mergingSince: Date.now(), mergingTrainId: "t" });
+  // Mark the session as merge-train-flagged with the observed PR number BEFORE any poll
+  store.update(s.id, { mergingSince: Date.now(), mergingTrainId: "t", mergingPrNumber: 344 });
   const emitted: { state: string; number?: number }[] = [];
   const poller = new PrPoller(
     store,

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -50,6 +50,8 @@ function makeSession(over: Partial<Session> = {}): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
+    mergingPrNumber: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -49,6 +49,8 @@ function session(over: Partial<Session> = {}): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
+    mergingPrNumber: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/test/server-diff.test.ts
+++ b/test/server-diff.test.ts
@@ -22,6 +22,8 @@ const SESSION: Session = {
   readyToMerge: false,
   mergingSince: null,
   mergingTrainId: null,
+  mergeTrainPrs: null,
+  mergingPrNumber: null,
   autopilotEnabled: null,
   autopilotStepCount: 0,
   autopilotPaused: false,

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -26,6 +26,8 @@ const SESSION: Session = {
   readyToMerge: false,
   mergingSince: null,
   mergingTrainId: null,
+  mergeTrainPrs: null,
+  mergingPrNumber: null,
   autopilotEnabled: null,
   autopilotStepCount: 0,
   autopilotPaused: false,

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -296,7 +296,12 @@ test("GET git trusts a merged PR when session is merge-train-flagged, cold cache
       deployConfigured: true,
     }),
   });
-  const mergeTrainSession = { ...SESSION, mergingSince: Date.now(), mergingTrainId: "t" };
+  const mergeTrainSession = {
+    ...SESSION,
+    mergingSince: Date.now(),
+    mergingTrainId: "t",
+    mergingPrNumber: 344,
+  };
   const deps = Object.assign(makeDeps(f, mergeTrainSession), { ownsPr: () => false });
   const app = makeApp(deps);
   const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1444,46 +1444,6 @@ test("POST /api/repos with foreign Origin → 403", async () => {
   expect(res.status).toBe(403);
 });
 
-// ── POST /api/merge-train/start ───────────────────────────────────────────────
-
-test("POST /api/merge-train/start marks sessions as merging", async () => {
-  const deps = makeDeps();
-  const app = makeApp(deps);
-  const s = deps.store.create({
-    name: "x",
-    prompt: "go",
-    repoPath: "/r",
-    baseBranch: "main",
-    branch: "shepherd/x",
-    worktreePath: "/wt/x",
-    isolated: true,
-    herdrSession: "default",
-    herdrAgentId: "term_z",
-  });
-  const res = await app.fetch(
-    new Request("http://x/api/merge-train/start", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ ids: [s.id], trainId: "train-7" }),
-    }),
-  );
-  expect(res.status).toBe(200);
-  expect(await res.json()).toEqual({ ok: true });
-  expect(deps.store.get(s.id)!.mergingTrainId).toBe("train-7");
-});
-
-test("POST /api/merge-train/start with invalid body → 400", async () => {
-  const app = harness();
-  const res = await app.fetch(
-    new Request("http://x/api/merge-train/start", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ ids: "nope" }),
-    }),
-  );
-  expect(res.status).toBe(400);
-});
-
 // ── autoMergeEnabled repo-config + per-session override ─────────────────────
 
 function putRepoConfig(app: ReturnType<typeof makeApp>, repo: string, body: unknown) {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2142,6 +2142,30 @@ test("registerTrain marks every selected-PR session observed open (incl. readyTo
   ev.forEach((e) => expect(e.data.trainId).toBe(train.id));
 });
 
+test("create() with mergeTrainPrs registers the train and marks an already-open participant", async () => {
+  const { store, service, openPr } = mergeSvc();
+  // A pre-existing ready participant whose PR #51 is already open in the snapshot.
+  const a = await mkSession(service);
+  openPr(a.id, 51);
+  // Launch the train session selecting PR #51 → create() must registerTrain, which
+  // reconciles and marks `a` immediately.
+  const train = await service.create({
+    repoPath: "/r",
+    baseBranch: "main",
+    prompt: "train",
+    model: null,
+    images: [],
+    mergeTrainPrs: [51],
+  });
+  expect(store.get(a.id)!.mergingSince).not.toBeNull();
+  expect(store.get(a.id)!.mergingTrainId).toBe(train.id);
+  expect(store.get(a.id)!.mergingPrNumber).toBe(51);
+  // the train session itself is never marked
+  expect(store.get(train.id)!.mergingSince).toBeNull();
+  // the train's selected PRs are persisted on its row
+  expect(store.get(train.id)!.mergeTrainPrs).toEqual([51]);
+});
+
 test("a participant already merged at launch (never open) is never marked", async () => {
   const { store, service, mergedPr } = mergeSvc();
   const train = await mkSession(service);

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2056,16 +2056,36 @@ test("archiveMany isolates a failing session: others still clear, the failed id 
   expect(store.get(b.id)?.status).not.toBe("archived"); // b stays active (teardown threw)
 });
 
-function mergeSvc() {
+function mergeSvc(opts: { isolated?: boolean } = {}) {
   const store = new SessionStore(":memory:");
   const emitted: { event: string; data: any }[] = [];
   const refreshed: string[] = [];
+  // Controllable live PR-state map keyed by session id; tests mutate it to simulate
+  // a session's PR opening / merging, then re-run reconcile. `openPr(id, number)`
+  // and `mergedPr(id, number)` are tiny helpers over it.
+  const snap: Record<string, any> = {};
+  const openPr = (id: string, number: number) =>
+    (snap[id] = {
+      kind: "github",
+      state: "open",
+      number,
+      checks: "success",
+      deployConfigured: false,
+    });
+  const mergedPr = (id: string, number: number) =>
+    (snap[id] = {
+      kind: "github",
+      state: "merged",
+      number,
+      checks: "success",
+      deployConfigured: false,
+    });
   const service = new SessionService({
     store,
     namer: async () => "n",
     worktree: {
       ensureBaseRef: async () => {},
-      create: () => ({ worktreePath: "/wt", branch: "b", isolated: true }),
+      create: () => ({ worktreePath: "/wt", branch: "b", isolated: opts.isolated ?? true }),
       remove: () => {},
     } as any,
     herdr: {
@@ -2083,8 +2103,9 @@ function mergeSvc() {
     } as any,
     events: { emit: (event: string, data: unknown) => emitted.push({ event, data }) } as any,
     refreshPr: (id: string) => refreshed.push(id),
+    prSnapshot: () => snap,
   });
-  return { store, service, emitted, refreshed };
+  return { store, service, emitted, refreshed, snap, openPr, mergedPr };
 }
 
 async function mkSession(service: SessionService) {
@@ -2097,51 +2118,92 @@ async function mkSession(service: SessionService) {
   });
 }
 
-test("setMerging stamps each id and emits session:merging; skips unknown ids", async () => {
-  const { store, service, emitted } = mergeSvc();
+test("registerTrain marks every selected-PR session observed open (incl. readyToMerge=false); emits session:merging", async () => {
+  const { store, service, emitted, openPr } = mergeSvc();
+  const train = await mkSession(service);
   const a = await mkSession(service);
-  service.setMerging([a.id, "ghost"], "train-9");
+  const b = await mkSession(service);
+  // a + b both hold OPEN selected PRs; b's PR is NOT ready-to-merge — must STILL mark
+  // (readyToMerge no longer gates marking — marking is purely state:"open").
+  openPr(a.id, 11);
+  openPr(b.id, 12);
+  expect(store.get(b.id)!.readyToMerge).toBe(false);
+  service.registerTrain(train.id, "/r", [11, 12]);
   expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
-  expect(store.get(a.id)!.mergingTrainId).toBe("train-9");
+  expect(store.get(a.id)!.mergingTrainId).toBe(train.id);
+  expect(store.get(a.id)!.mergingPrNumber).toBe(11);
+  expect(store.get(b.id)!.mergingSince).toBeGreaterThan(0);
+  expect(store.get(b.id)!.mergingPrNumber).toBe(12);
+  // the train session itself is never marked
+  expect(store.get(train.id)!.mergingSince).toBeNull();
   const ev = emitted.filter((e) => e.event === "session:merging");
-  expect(ev).toHaveLength(1);
-  expect(ev[0]!.data).toMatchObject({ id: a.id, trainId: "train-9" });
-  expect(typeof ev[0]!.data.since).toBe("number");
+  expect(ev).toHaveLength(2);
+  expect(ev.map((e) => e.data.id).sort()).toEqual([a.id, b.id].sort());
+  ev.forEach((e) => expect(e.data.trainId).toBe(train.id));
 });
 
-test("clearMerging nulls the fields and emits since:null; no-op when not merging", async () => {
-  const { store, service, emitted } = mergeSvc();
+test("a participant already merged at launch (never open) is never marked", async () => {
+  const { store, service, mergedPr } = mergeSvc();
+  const train = await mkSession(service);
+  const a = await mkSession(service);
+  mergedPr(a.id, 21); // terminal in the snapshot — never observed open
+  service.registerTrain(train.id, "/r", [21]);
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+});
+
+test("a PR not yet open at launch is marked once a later reconcile observes it open", async () => {
+  const { store, service, openPr } = mergeSvc();
+  const train = await mkSession(service);
+  const a = await mkSession(service);
+  // No open PR at launch → not marked.
+  service.registerTrain(train.id, "/r", [31]);
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+  // Its PR opens; a later reconcile (the `session:git` path) marks it.
+  openPr(a.id, 31);
+  service.reconcileTrainMarks(train.id);
+  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
+  expect(store.get(a.id)!.mergingPrNumber).toBe(31);
+});
+
+test("launchedAt = first-observed-open: PRs never open → no tracker entry, archive is a no-op", async () => {
+  const { service, emitted } = mergeSvc();
+  const train = await mkSession(service);
+  await mkSession(service); // a participant, but its PR never opens in the snapshot
+  service.registerTrain(train.id, "/r", [41]); // nothing open → no member, no entry
+  // No #trainOffers entry was created → a later archive has nothing to finalize.
+  expect(() => service.clearMergingForTrain(train.id)).not.toThrow();
+  expect(landed(emitted)).toHaveLength(0);
+});
+
+test("clearMerging nulls all three fields and emits since:null; no-op when not merging", async () => {
+  const { store, service, emitted, openPr } = mergeSvc();
+  const train = await mkSession(service);
   const a = await mkSession(service);
   service.clearMerging(a.id);
   expect(emitted.filter((e) => e.event === "session:merging")).toHaveLength(0);
-  service.setMerging([a.id], "t1");
+  openPr(a.id, 51);
+  service.registerTrain(train.id, "/r", [51]);
   service.clearMerging(a.id);
   expect(store.get(a.id)!.mergingSince).toBeNull();
   expect(store.get(a.id)!.mergingTrainId).toBeNull();
+  expect(store.get(a.id)!.mergingPrNumber).toBeNull();
   const last = emitted.filter((e) => e.event === "session:merging").at(-1)!;
   expect(last.data).toEqual({ id: a.id, since: null, trainId: null });
 });
 
 test("clearMergingForTrain clears every member of one train, leaves others", async () => {
-  const { store, service } = mergeSvc();
+  const { store, service, openPr } = mergeSvc();
+  const tA = await mkSession(service);
+  const tB = await mkSession(service);
   const a = await mkSession(service);
   const b = await mkSession(service);
-  service.setMerging([a.id], "train-A");
-  service.setMerging([b.id], "train-B");
-  service.clearMergingForTrain("train-A");
+  openPr(a.id, 61);
+  openPr(b.id, 62);
+  service.registerTrain(tA.id, "/r", [61]);
+  service.registerTrain(tB.id, "/r", [62]);
+  service.clearMergingForTrain(tA.id);
   expect(store.get(a.id)!.mergingSince).toBeNull();
   expect(store.get(b.id)!.mergingSince).toBeGreaterThan(0);
-});
-
-test("sweepStaleMerging clears marks older than the TTL, keeps fresh ones", async () => {
-  const { store, service } = mergeSvc();
-  const a = await mkSession(service);
-  service.setMerging([a.id], "t");
-  const now = Date.now();
-  service.sweepStaleMerging(now);
-  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
-  service.sweepStaleMerging(now + MERGE_STALE_MS + 1);
-  expect(store.get(a.id)!.mergingSince).toBeNull();
 });
 
 // ── mergetrain:landed completion tracker ──────────────────────────────────────
@@ -2151,26 +2213,31 @@ function landed(emitted: { event: string; data: any }[]) {
 }
 
 test("merge-before-archive: member merges, then train archives → one mergetrain:landed", async () => {
-  const { service, emitted } = mergeSvc();
+  const { service, emitted, openPr } = mergeSvc();
+  const train = await mkSession(service);
   const a = await mkSession(service); // repoPath "/r", isolated
-  service.setMerging([a.id], "train-X");
+  openPr(a.id, 71);
+  service.registerTrain(train.id, "/r", [71]);
   service.resolveMerging(a.id, true); // credited, but no emit yet (train still live)
   expect(landed(emitted)).toHaveLength(0);
-  service.clearMergingForTrain("train-X");
+  service.clearMergingForTrain(train.id);
   const ev = landed(emitted);
   expect(ev).toHaveLength(1);
   expect(ev[0]!.data).toEqual({ repoPath: "/r" });
   // idempotence: a second archive call is a no-op (entry already finalized)
-  service.clearMergingForTrain("train-X");
+  service.clearMergingForTrain(train.id);
   expect(landed(emitted)).toHaveLength(1);
 });
 
 test("archive-before-merge (the race): archive defers + nudges, late merge fires once", async () => {
-  const { service, emitted, refreshed } = mergeSvc();
+  const { service, emitted, refreshed, openPr } = mergeSvc();
+  const train = await mkSession(service);
   const a = await mkSession(service);
   const b = await mkSession(service);
-  service.setMerging([a.id, b.id], "train-R");
-  service.clearMergingForTrain("train-R"); // archives first, merged still false
+  openPr(a.id, 81);
+  openPr(b.id, 82);
+  service.registerTrain(train.id, "/r", [81, 82]);
+  service.clearMergingForTrain(train.id); // archives first, merged still false
   expect(landed(emitted)).toHaveLength(0); // deferred — no emit yet
   expect(refreshed.sort()).toEqual([a.id, b.id].sort()); // nudged each live member
   service.resolveMerging(a.id, true); // late credit → fires
@@ -2182,142 +2249,174 @@ test("archive-before-merge (the race): archive defers + nudges, late merge fires
   expect(landed(emitted)).toHaveLength(1);
 });
 
-test("nothing merged: all resolve false, archive, TTL sweep → never emits", async () => {
-  const { service, emitted } = mergeSvc();
+test("post-archive late credit survives: PR merges after a clean archive, fires once, reclaimed only after the await window", async () => {
+  const { service, emitted, openPr } = mergeSvc();
+  const train = await mkSession(service);
   const a = await mkSession(service);
-  service.setMerging([a.id], "train-N");
-  service.resolveMerging(a.id, false);
-  service.clearMergingForTrain("train-N");
+  openPr(a.id, 91);
+  const t0 = Date.now();
+  service.registerTrain(train.id, "/r", [91], t0);
+  service.clearMergingForTrain(train.id, t0); // clean archive (out of #liveTrains), awaiting late credit
   expect(landed(emitted)).toHaveLength(0);
-  service.sweepStaleMerging(Date.now() + MERGE_STALE_MS + 1);
+  // The member's PR merges AFTER archive → late credit fires exactly once.
+  service.resolveMerging(a.id, true);
+  expect(landed(emitted)).toHaveLength(1);
+  // The awaiting entry is reclaimed only after the post-archive window lapses.
+  // A re-resolve before reclaim would not re-fire (entry finalized), and a sweep
+  // inside the window leaves no new emit; advancing past it reclaims silently.
+  service.sweepStaleMerging(t0 + MERGE_STALE_MS + 1);
+  expect(landed(emitted)).toHaveLength(1);
+});
+
+test("nothing merged: all resolve false, archive, sweep → never emits", async () => {
+  const { service, emitted, openPr } = mergeSvc();
+  const train = await mkSession(service);
+  const a = await mkSession(service);
+  openPr(a.id, 101);
+  const t0 = Date.now();
+  service.registerTrain(train.id, "/r", [101], t0);
+  service.resolveMerging(a.id, false);
+  service.clearMergingForTrain(train.id, t0);
+  expect(landed(emitted)).toHaveLength(0);
+  service.sweepStaleMerging(t0 + MERGE_STALE_MS + 1);
   expect(landed(emitted)).toHaveLength(0);
 });
 
-test("isolated guard: a sole non-isolated merged member never emits", async () => {
-  const store = new SessionStore(":memory:");
-  const emitted: { event: string; data: any }[] = [];
-  const service = new SessionService({
-    store,
-    namer: async () => "n",
-    worktree: {
-      ensureBaseRef: async () => {},
-      create: () => ({ worktreePath: "/wt", branch: null, isolated: false }),
-      remove: () => {},
-    } as any,
-    herdr: {
-      start: () => ({
-        terminalId: "t",
-        cwd: "/",
-        agent: "claude",
-        agentStatus: "idle",
-        paneId: "p",
-        tabId: "x",
-        workspaceId: "w",
-      }),
-      list: () => [],
-      stop: () => {},
-    } as any,
-    events: { emit: (event: string, data: unknown) => emitted.push({ event, data }) } as any,
-  });
+test("isolated guard: a member is tracked even when non-isolated, but never credits a landing", async () => {
+  const { store, service, emitted, openPr } = mergeSvc({ isolated: false });
+  const train = await mkSession(service);
   const a = await mkSession(service); // non-isolated (worktree mock)
   expect(store.get(a.id)!.isolated).toBe(false);
-  service.setMerging([a.id], "train-NI");
-  service.resolveMerging(a.id, true); // not credited (non-isolated)
+  openPr(a.id, 111);
+  service.registerTrain(train.id, "/r", [111]);
+  // The non-isolated session IS marked and tracked as a member …
+  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
+  service.resolveMerging(a.id, true); // … but its merge does not credit (non-isolated)
   expect(landed(emitted)).toHaveLength(0);
-  service.clearMergingForTrain("train-NI"); // archive with merged still false
+  service.clearMergingForTrain(train.id); // archive with merged still false → no emit
   expect(landed(emitted)).toHaveLength(0);
 });
 
 test("pre-archive credit alone does not emit (fires on completion, not first merge)", async () => {
-  const { service, emitted } = mergeSvc();
+  const { service, emitted, openPr } = mergeSvc();
+  const train = await mkSession(service);
   const a = await mkSession(service);
-  service.setMerging([a.id], "train-P");
+  openPr(a.id, 121);
+  service.registerTrain(train.id, "/r", [121]);
   service.resolveMerging(a.id, true);
   expect(landed(emitted)).toHaveLength(0); // train still live
 });
 
-test("sweep eviction: stale awaiting entry evicted with no emit; fresh entry untouched", async () => {
-  const { service, emitted } = mergeSvc();
+test("sweep eviction: stale awaiting entry evicted with no emit; fresh live entry untouched", async () => {
+  const { service, emitted, openPr } = mergeSvc();
+  const tS = await mkSession(service);
   const a = await mkSession(service);
-  service.setMerging([a.id], "train-S");
-  service.clearMergingForTrain("train-S"); // archived, merged false → awaiting
-  // evict by age; verify no emit and that the memberToTrain row is cleared
-  service.sweepStaleMerging(Date.now() + MERGE_STALE_MS + 1);
+  openPr(a.id, 131);
+  const t0 = Date.now();
+  service.registerTrain(tS.id, "/r", [131], t0);
+  service.clearMergingForTrain(tS.id, t0); // archived, merged false → awaiting
+  // evict by the post-archive window; verify no emit and the memberToTrain row is cleared
+  service.sweepStaleMerging(t0 + MERGE_STALE_MS + 1);
   expect(landed(emitted)).toHaveLength(0);
   // a later credit can no longer fire (entry + memberToTrain row gone)
   service.resolveMerging(a.id, true);
   expect(landed(emitted)).toHaveLength(0);
 
-  // a LIVE (un-archived) entry is never swept — even by a sweep far past launch+TTL
+  // a LIVE (still-registered) entry whose train session is alive is never swept —
+  // even by a sweep far past launch (its updatedAt is recent / registeredAt fresh).
+  const tF = await mkSession(service);
   const b = await mkSession(service);
-  service.setMerging([b.id], "train-F");
-  service.sweepStaleMerging(Date.now() + 10 * MERGE_STALE_MS); // live → not evicted
-  service.clearMergingForTrain("train-F"); // would only fire if entry survived
-  // merged false so still no emit, but entry must still exist (not evicted):
+  openPr(b.id, 132);
+  const t1 = Date.now();
+  service.registerTrain(tF.id, "/r", [132], t1);
+  service.sweepStaleMerging(t1 + 10 * MERGE_STALE_MS); // live + alive → not evicted
+  service.clearMergingForTrain(tF.id); // would only fire if entry survived
   service.resolveMerging(b.id, true);
   expect(landed(emitted)).toHaveLength(1);
 });
 
-test("slow/long run: a still-running train is never swept, however long it takes (no activity, no archive)", async () => {
-  const { service, emitted } = mergeSvc();
+test("live train at 25h with a still-active train session keeps its members' marks (no age expiry)", async () => {
+  const { store, service, openPr } = mergeSvc();
+  const train = await mkSession(service);
   const a = await mkSession(service);
-  service.setMerging([a.id], "train-Slow"); // live; first PR's CI is slow — no member has resolved yet
-  const t0 = Date.now();
-  // The critic's case: no member activity and no archive for well past MERGE_STALE_MS.
-  // A live entry must NOT be reclaimed (a launch-/activity-keyed TTL would drop it here).
-  service.sweepStaleMerging(t0 + 5 * MERGE_STALE_MS);
-  // The first PR finally lands, then the train archives → entry intact, fires once.
-  service.resolveMerging(a.id, true);
-  service.clearMergingForTrain("train-Slow", t0 + 5 * MERGE_STALE_MS + 1);
-  expect(landed(emitted)).toHaveLength(1);
+  openPr(a.id, 141);
+  // registeredAt set near `now` (a recent activity) so the last-activity ceiling
+  // never trips even at 25h — the train is slow but ALIVE.
+  const now = Date.now() + TRAIN_TRACKER_MAX_MS + 60 * 60_000; // 25h out
+  service.registerTrain(train.id, "/r", [141], now - 1000);
+  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
+  service.sweepStaleMerging(now); // alive (recent registeredAt) → kept
+  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
+  // An archive clears the member's mark immediately (no waiting on any age window).
+  service.clearMergingForTrain(train.id, now);
+  expect(store.get(a.id)!.mergingSince).toBeNull();
 });
 
-test("repeat archive is idempotent: doesn't restart the await window or re-nudge members", async () => {
-  const { service, emitted, refreshed } = mergeSvc();
+test("crash without archive: a train session that never archives is deregistered past the backstop and its members' marks cleared", async () => {
+  const { store, service, emitted, openPr } = mergeSvc();
+  const train = await mkSession(service); // train session's updatedAt is frozen at ~now (real clock)
   const a = await mkSession(service);
-  service.setMerging([a.id], "train-Re");
-  const t0 = Date.now();
-  service.clearMergingForTrain("train-Re", t0); // archived, awaiting (merged false) → window starts at t0
-  // A second session:archived for the same train must be ignored — it must NOT
-  // restart the await window or fire refreshPr again.
-  service.clearMergingForTrain("train-Re", t0 + MERGE_STALE_MS / 2);
-  expect(refreshed).toEqual([a.id]); // nudged exactly once across both calls
-  // Window stays anchored at t0, so a sweep at t0+TTL+1 evicts (it would NOT have if reset).
-  service.sweepStaleMerging(t0 + MERGE_STALE_MS + 1);
-  service.resolveMerging(a.id, true); // entry gone → no late credit
-  expect(landed(emitted)).toHaveLength(0);
-});
-
-test("dead-train backstop: a live entry orphaned past TRAIN_TRACKER_MAX_MS is reclaimed (no emit)", async () => {
-  const { service, emitted } = mergeSvc();
-  const a = await mkSession(service);
-  // `base` is captured BEFORE setMerging, so launchedAt >= base; the ±1min margins
-  // dwarf any sub-ms drift, keeping the boundary checks non-flaky.
+  openPr(a.id, 151);
   const base = Date.now();
-  service.setMerging([a.id], "train-Dead"); // launchedAt ≈ base; train session then dies w/o session:archived
-  // Below the backstop while live → NOT reclaimed.
+  service.registerTrain(train.id, "/r", [151], base); // train then dies w/o session:archived
+  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
+  // Below the backstop (and train row still present/active) → NOT reclaimed.
   service.sweepStaleMerging(base + TRAIN_TRACKER_MAX_MS - 60_000);
-  // Past the backstop → reclaimed with no emit (no session:archived ever arrived).
+  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
+  // Past the backstop with frozen last-activity → train deregistered AND the member's
+  // persisted mark is cleared in the SAME sweep (A deregisters, B releases the mark).
   service.sweepStaleMerging(base + TRAIN_TRACKER_MAX_MS + 60_000);
-  // Entry gone: a later merge + archive can no longer fire an offer.
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+  expect(store.get(a.id)!.mergingTrainId).toBeNull();
+  // Entry reclaimed (no emit): a later merge + archive can no longer fire an offer.
   service.resolveMerging(a.id, true);
-  service.clearMergingForTrain("train-Dead", base + TRAIN_TRACKER_MAX_MS + 120_000);
+  service.clearMergingForTrain(train.id, base + TRAIN_TRACKER_MAX_MS + 120_000);
   expect(landed(emitted)).toHaveLength(0);
 });
 
-test("setMerging with all-unknown ids creates no entry; later archive is a no-op", async () => {
+test("crash via archived/missing train row: deregistered immediately, members released", async () => {
+  const { store, service, openPr } = mergeSvc();
+  const train = await mkSession(service);
+  const a = await mkSession(service);
+  openPr(a.id, 161);
+  service.registerTrain(train.id, "/r", [161]);
+  expect(store.get(a.id)!.mergingSince).toBeGreaterThan(0);
+  // The train row gets archived out-of-band without clearMergingForTrain ever running
+  // (a crash where the archive hook didn't fire). The sweep's phase A catches it.
+  store.archive(train.id);
+  service.sweepStaleMerging();
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+});
+
+test("post-archive markTrainMember/reconcile do NOT re-add a member or re-mark", async () => {
+  const { store, service, openPr } = mergeSvc();
+  const train = await mkSession(service);
+  const a = await mkSession(service);
+  openPr(a.id, 171);
+  service.registerTrain(train.id, "/r", [171]);
+  service.clearMergingForTrain(train.id); // train removed from #liveTrains, mark cleared
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+  // A late `session:git` reconcile or a direct markTrainMember must NOT resurrect it.
+  service.reconcileTrainMarks(train.id);
+  service.markTrainMember(train.id, a.id, 171);
+  expect(store.get(a.id)!.mergingSince).toBeNull();
+});
+
+test("registerTrain with no participant PRs open creates no entry; later archive is a no-op", async () => {
   const { service, emitted } = mergeSvc();
-  service.setMerging(["ghost"], "train-G"); // no resolvable member
-  expect(() => service.clearMergingForTrain("train-G")).not.toThrow();
+  const train = await mkSession(service);
+  service.registerTrain(train.id, "/r", [181]); // nothing open in the snapshot → no member
+  expect(() => service.clearMergingForTrain(train.id)).not.toThrow();
   expect(landed(emitted)).toHaveLength(0);
 });
 
 test("untracked passthrough: resolveMerging/clearMergingForTrain on unknown ids no-op, still clear marks", async () => {
-  const { store, service, emitted } = mergeSvc();
+  const { store, service, emitted, openPr } = mergeSvc();
+  const train = await mkSession(service);
   const a = await mkSession(service);
-  // resolveMerging on a session never registered with a train: clears mark, no emit
-  service.setMerging([a.id], "train-U");
-  // simulate an untracked member by resolving a truly unknown id
+  openPr(a.id, 191);
+  service.registerTrain(train.id, "/r", [191]);
+  // resolveMerging on a truly unknown id: no throw, no emit
   expect(() => service.resolveMerging("nobody", true)).not.toThrow();
   expect(() => service.clearMergingForTrain("no-such-train")).not.toThrow();
   expect(landed(emitted)).toHaveLength(0);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1168,3 +1168,46 @@ test("putCreditSnapshot round-trips a null resetAt as null", () => {
   expect(got).toEqual(row);
   expect(got!.resetAt).toBeNull();
 });
+
+test("mergeTrainPrs: absent → null, array round-trips, empty array round-trips", () => {
+  const store = new SessionStore(":memory:");
+  // absent → null
+  const plain = store.create(base);
+  expect(plain.mergeTrainPrs).toBeNull();
+
+  // array round-trips
+  const withPrs = store.create({ ...base, herdrAgentId: "t2", mergeTrainPrs: [1, 2, 3] });
+  expect(store.get(withPrs.id)!.mergeTrainPrs).toEqual([1, 2, 3]);
+
+  // empty array round-trips as [] (not null)
+  const empty = store.create({ ...base, herdrAgentId: "t3", mergeTrainPrs: [] });
+  expect(store.get(empty.id)!.mergeTrainPrs).toEqual([]);
+});
+
+test("mergingPrNumber: defaults null, set via update, clears back to null", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(base);
+  expect(s.mergingPrNumber).toBeNull();
+
+  store.update(s.id, { mergingPrNumber: 42 });
+  expect(store.get(s.id)!.mergingPrNumber).toBe(42);
+
+  store.update(s.id, { mergingPrNumber: null });
+  expect(store.get(s.id)!.mergingPrNumber).toBeNull();
+});
+
+test("parseMergeTrainPrsJson: non-number elements treated as corrupt → null", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-store-mtp-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    const store = new SessionStore(dbPath);
+    const s = store.create({ ...base, herdrAgentId: "mtp1" });
+    // inject a corrupt value: JSON array of strings, not numbers
+    const raw = new Database(dbPath);
+    raw.run(`UPDATE sessions SET mergeTrainPrs = '["a"]' WHERE id = ?`, [s.id]);
+    raw.close();
+    expect(new SessionStore(dbPath).get(s.id)!.mergeTrainPrs).toBeNull();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -1012,3 +1012,32 @@ test("validateRelaunchOverrides: absent research is not written onto output", ()
   expect(r.ok).toBe(true);
   if (r.ok) expect("research" in r.value).toBe(false);
 });
+
+// ── validateCreate: mergeTrainPrs ────────────────────────────────────────────
+
+test("mergeTrainPrs: [0] rejected (not positive)", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", mergeTrainPrs: [0] },
+    root,
+  );
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toMatch(/mergeTrainPrs/);
+});
+
+test("mergeTrainPrs: [-1] rejected (not positive)", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", mergeTrainPrs: [-1] },
+    root,
+  );
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toMatch(/mergeTrainPrs/);
+});
+
+test("mergeTrainPrs: [1, 2, 3] accepted", () => {
+  const r = validateCreate(
+    { repoPath: validRepo, baseBranch: "main", prompt: "go", mergeTrainPrs: [1, 2, 3] },
+    root,
+  );
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.mergeTrainPrs).toEqual([1, 2, 3]);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1315,5 +1315,6 @@
   "feat_fork_repo_title": "Repo forken, um zum Upstream beizutragen",
   "feat_fork_repo_body": "Die Repo-Auswahl hat jetzt neben „Klonen“ die Option „GitHub-Repo forken“. Gib owner/repo (oder eine URL) ein, und Shepherd forkt es unter deinem Account, klont es und richtet die Remotes so ein, dass deine Pull Requests auf das Original (Upstream) zielen — der Weg, um zu einem Projekt beizutragen, für das du keine Schreibrechte hast.",
   "feat_backlog_repo_link_title": "Repo-Name verlinkt auf die Forge",
-  "feat_backlog_repo_link_body": "Der Repository-Name in den Kopfzeilen der Backlog-Bereiche Issues, PRs und Actions verlinkt jetzt direkt auf das Repo in seiner Forge."
+  "feat_backlog_repo_link_body": "Der Repository-Name in den Kopfzeilen der Backlog-Bereiche Issues, PRs und Actions verlinkt jetzt direkt auf das Repo in seiner Forge.",
+  "prrow_in_train_title": "Ein Merge-Train landet diesen PR"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -669,7 +669,6 @@
   "toast_clear_merged_failed": "Gemergte Sessions konnten nicht aufgeräumt werden",
   "toast_merge_train_no_prs": "Keine merge-bereiten PRs für einen Merge-Train vorhanden",
   "toast_merge_train_failed": "Merge-Train konnte nicht gestartet werden",
-  "toast_merge_train_mark_failed": "Merge-Train gestartet, aber das Markieren der PRs ist fehlgeschlagen.",
   "toast_merged": "{name} gemergt",
   "toast_update_main_offer": "PR gemergt. Deinen lokalen Standard-Branch aktualisieren?",
   "toast_update_main_action": "Aktualisieren",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1315,5 +1315,6 @@
   "feat_fork_repo_title": "Fork a repo to contribute upstream",
   "feat_fork_repo_body": "The repo picker now has a “Fork a GitHub repo” option next to Clone. Paste owner/repo (or a URL) and Shepherd forks it under your account, clones it, and wires the remotes so pull requests you open target the original (upstream) repo — the way to contribute to a project you don't have write access to.",
   "feat_backlog_repo_link_title": "Repo name links to its forge",
-  "feat_backlog_repo_link_body": "The repository name in the backlog Issues, PRs, and Actions headers now links straight to the repo on its forge."
+  "feat_backlog_repo_link_body": "The repository name in the backlog Issues, PRs, and Actions headers now links straight to the repo on its forge.",
+  "prrow_in_train_title": "a merge train is landing this PR"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -669,7 +669,6 @@
   "toast_clear_merged_failed": "Couldn't clear merged sessions",
   "toast_merge_train_no_prs": "No ready-to-merge PRs to run a merge train on",
   "toast_merge_train_failed": "Couldn't start the merge train",
-  "toast_merge_train_mark_failed": "Merge train started, but marking its PRs failed.",
   "toast_merged": "Merged {name}",
   "toast_update_main_offer": "PR merged. Update your local default branch?",
   "toast_update_main_action": "Update",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -456,18 +456,6 @@ export async function setReadyToMerge(id: string, ready: boolean): Promise<void>
   if (!r.ok) throw await failed(r, "ready");
 }
 
-/** Flag a launched merge train's scoped ready PRs as "merging". Fire-and-forget
- *  shape like setReadyToMerge — live state returns via the session:merging WS
- *  event; marking is cosmetic, so a failure must not abort the train launch. */
-export async function startMergeTrain(ids: string[], trainId: string): Promise<void> {
-  const r = await fetch("/api/merge-train/start", {
-    method: "POST",
-    headers: JSON_HEADERS,
-    body: JSON.stringify({ ids, trainId }),
-  });
-  if (!r.ok) throw await failed(r, "merge-train");
-}
-
 export async function listIssues(
   repoPath: string,
 ): Promise<{ slug: string | null; webUrl: string | null; issues: Issue[] }> {

--- a/ui/src/lib/components/BacklogOverlay.svelte
+++ b/ui/src/lib/components/BacklogOverlay.svelte
@@ -14,6 +14,7 @@
     onlaunchtrain,
     onclose,
     epics = undefined,
+    inTrainPrs = new Set(),
     target = null,
   }: {
     payload: BacklogPayload | null;
@@ -26,6 +27,9 @@
     onclose: () => void;
     /** Live epic record from the store, threaded to BacklogView → IssuesPanel. */
     epics?: Record<string, Epic>;
+    /** PR identity keys (`${repoPath}#${number}`) owned by a running merge train,
+     *  threaded to BacklogView → PrsPanel → PrRow for the in-train badge + merge lock. */
+    inTrainPrs?: Set<string>;
     /** EPIC-badge target (repo + issue), forwarded to BacklogView to drive
      *  selection + epic expansion. */
     target?: { repoPath: string; issueNumber: number } | null;
@@ -62,6 +66,7 @@
         {onadopt}
         {onlaunchtrain}
         {epics}
+        {inTrainPrs}
         {target}
       />
     </div>

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -19,6 +19,7 @@
     onlaunchtrain,
     flow = false,
     epics = undefined,
+    inTrainPrs = new Set(),
     target = null,
   }: {
     payload: BacklogPayload | null;
@@ -38,6 +39,9 @@
     flow?: boolean;
     /** Live epic record from the store, threaded down to IssuesPanel. */
     epics?: Record<string, Epic>;
+    /** PR identity keys (`${repoPath}#${number}`) owned by a running merge train,
+     *  forwarded to PrsPanel → PrRow for the in-train badge + merge lock. */
+    inTrainPrs?: Set<string>;
     /** When set (EPIC badge click), select that repo, switch to the Issues tab,
      *  and expand+scroll the epic's row. Applied once per distinct value. */
     target?: { repoPath: string; issueNumber: number } | null;
@@ -241,6 +245,7 @@
               repoPath={selectedPath}
               onreview={(pr) => onpr(selectedPath!, pr)}
               {onlaunchtrain}
+              {inTrainPrs}
               age
             />
           {:else if activeTab === "actions"}
@@ -338,6 +343,7 @@
                 repoPath={selectedPath}
                 onreview={(pr) => onpr(selectedPath!, pr)}
                 {onlaunchtrain}
+                {inTrainPrs}
                 age
               />
             {:else if activeTab === "actions"}

--- a/ui/src/lib/components/DoneRecapPanel.browser.test.ts
+++ b/ui/src/lib/components/DoneRecapPanel.browser.test.ts
@@ -24,6 +24,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -24,6 +24,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -33,6 +33,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/PrRow.svelte
+++ b/ui/src/lib/components/PrRow.svelte
@@ -17,6 +17,7 @@
     selectable = false,
     selected = false,
     ontoggle,
+    inTrain = false,
   }: {
     repoPath: string;
     pr: PullRequest;
@@ -28,13 +29,16 @@
     selectable?: boolean;
     selected?: boolean;
     ontoggle?: () => void;
+    /** This PR is owned by a running merge train — show the MERGING badge and
+     *  lock the manual merge button so the train (not the operator) lands it. */
+    inTrain?: boolean;
   } = $props();
 
   // Merge is outward-facing and hard to reverse, so it arms on first click and
   // fires on the second. The armed state self-disarms after a few seconds so a
   // stray click never leaves a hot button waiting.
   let armed = $state(false);
-  let merging = $state(false);
+  let mergeBusy = $state(false);
   let failed = $state(false);
   // Stuck Dependabot PRs get a one-click "@dependabot rebase" opt-in. `requested`
   // is sticky for the row's lifetime so Dependabot is never asked twice.
@@ -88,7 +92,7 @@
   });
 
   async function onmerge() {
-    if (merging || blocked) return;
+    if (mergeBusy || blocked) return;
     failed = false;
     rebaseFailed = false; // a fresh merge attempt clears any stale rebase-error text
     if (!armed) {
@@ -97,14 +101,14 @@
       return;
     }
     disarm();
-    merging = true;
+    mergeBusy = true;
     try {
       await mergeBacklogPr(repoPath, pr.number);
       onmerged(pr.number);
       offerUpdateMain(repoPath);
     } catch {
       failed = true;
-      merging = false;
+      mergeBusy = false;
     }
   }
 
@@ -159,6 +163,9 @@
     </div>
 
     <div class="pr-meta">
+      {#if inTrain}
+        <span class="badge merging" title={m.prrow_in_train_title()}>{m.status_merging()}</span>
+      {/if}
       {#if pr.checks !== "none"}
         {#if hasJobs}
           <button
@@ -261,11 +268,15 @@
         <button
           class="merge-btn"
           class:armed
-          disabled={merging || blocked}
+          disabled={mergeBusy || blocked || inTrain}
           onclick={onmerge}
-          title={blocked ? m.prspanel_merge_blocked_title() : undefined}
+          title={inTrain
+            ? m.prrow_in_train_title()
+            : blocked
+              ? m.prspanel_merge_blocked_title()
+              : undefined}
         >
-          {merging
+          {mergeBusy
             ? m.prspanel_merging()
             : armed
               ? m.prspanel_merge_confirm()
@@ -486,6 +497,22 @@
     letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--color-red);
+  }
+
+  /* In-train badge — mirrors the session-list MERGING badge (UnitRow): the one
+     colored, moving status badge, amber + pulse, marking the running merge train
+     that owns this PR. Surfaces the same state the session row already shows. */
+  .badge {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .badge.merging {
+    color: var(--color-amber);
+    animation: merge-pulse 1.5s ease-in-out infinite;
   }
 
   /* Non-default target branch — a hairline neutral chip (mirrors .kind-tag),

--- a/ui/src/lib/components/PrsPanel.browser.test.ts
+++ b/ui/src/lib/components/PrsPanel.browser.test.ts
@@ -190,6 +190,28 @@ describe("PrsPanel launch-train toolbar", () => {
     await expect.element(launchBtn()).toBeDisabled();
   });
 
+  it("shows the in-train badge and disables merge only for PRs in the train set", async () => {
+    seed([pr(1), pr(2)]);
+    render(PrsPanel, {
+      repoPath: "/repo",
+      onreview: noop,
+      onlaunchtrain: noop,
+      // PR 1 is owned by a running train; PR 2 is not.
+      inTrainPrs: new Set(["/repo#1"]),
+    });
+    await expect.element(checkbox(1)).toBeInTheDocument();
+
+    // PR 1: in-train badge present, merge button locked.
+    await expect.element(page.getByText(m.status_merging())).toBeInTheDocument();
+    const mergeBtns = page.getByRole("button", { name: m.prspanel_merge_button(), exact: true });
+    await expect.element(mergeBtns.nth(0)).toBeDisabled();
+
+    // PR 2: not in the set → no badge of its own, merge button enabled.
+    await expect.element(mergeBtns.nth(1)).toBeEnabled();
+    // exactly one in-train badge (only PR 1)
+    expect(page.getByText(m.status_merging()).elements()).toHaveLength(1);
+  });
+
   it("calls onlaunchtrain with the selected PRs in display order", async () => {
     seed([pr(1, "first"), pr(2, "second"), pr(3, "third")]);
     const onlaunchtrain = vi.fn();

--- a/ui/src/lib/components/PrsPanel.svelte
+++ b/ui/src/lib/components/PrsPanel.svelte
@@ -11,6 +11,7 @@
     repoPath,
     onreview,
     onlaunchtrain,
+    inTrainPrs = new Set(),
     age = false,
   }: {
     repoPath: string;
@@ -19,6 +20,9 @@
     /** Launch a merge train from the multi-selected PRs (in display order).
      *  Optional so existing consumers keep compiling until Task 3 wires it. */
     onlaunchtrain?: (repoPath: string, prs: PullRequest[]) => void;
+    /** PR identity keys (`${repoPath}#${number}`) owned by a running merge train;
+     *  a matching row shows the in-train badge and locks its manual merge button. */
+    inTrainPrs?: Set<string>;
     age?: boolean;
   } = $props();
 
@@ -119,6 +123,7 @@
           {age}
           {onreview}
           {onmerged}
+          inTrain={inTrainPrs.has(`${repoPath}#${pr.number}`)}
           selectable
           selected={selected.has(pr.number)}
           ontoggle={() => toggle(pr.number)}

--- a/ui/src/lib/components/ResearchBadge.browser.test.ts
+++ b/ui/src/lib/components/ResearchBadge.browser.test.ts
@@ -24,6 +24,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -34,6 +34,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/UnitTile.browser.test.ts
+++ b/ui/src/lib/components/UnitTile.browser.test.ts
@@ -32,6 +32,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -43,6 +43,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/epic-grouping.test.ts
+++ b/ui/src/lib/components/epic-grouping.test.ts
@@ -27,6 +27,7 @@ function session(
     readyToMerge,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/herd-keynav.test.ts
+++ b/ui/src/lib/components/herd-keynav.test.ts
@@ -34,6 +34,7 @@ function session(
     readyToMerge,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -21,6 +21,7 @@ function session(id: string, readyToMerge = false, status: SessionStatus = "runn
     readyToMerge,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -28,6 +28,7 @@ function session(partial: Partial<Session> & { id: string }): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -5,8 +5,7 @@ import {
   mergeTrainCreateInput,
   pickTrainRepo,
   isMerging,
-  sessionsForPrNumbers,
-  MERGE_STALE_MS,
+  MERGE_MARK_BACKSTOP_MS,
 } from "./merge-train";
 import type { Session, GitState } from "$lib/types";
 
@@ -244,9 +243,17 @@ describe("mergeTrainCreateInput", () => {
     expect(typeof input.prompt).toBe("string");
     expect(input.prompt.length).toBeGreaterThan(0);
   });
+
+  it("includes mergeTrainPrs as the PR numbers (default call)", () => {
+    expect(mergeTrainCreateInput("/repo/a", "main", prs).mergeTrainPrs).toEqual([11, 22]);
+  });
+
+  it("includes mergeTrainPrs as the PR numbers (handpicked call)", () => {
+    expect(mergeTrainCreateInput("/repo/a", "main", prs, true).mergeTrainPrs).toEqual([11, 22]);
+  });
 });
 
-test("isMerging: true when marked and within TTL, false when null or stale", () => {
+test("isMerging: marked + within backstop true; null/aged-past-backstop false; 30-min cliff gone", () => {
   const now = 1_000_000_000;
   const make = (mergingSince: number | null) => ({
     ...session({ id: "m" }),
@@ -255,76 +262,10 @@ test("isMerging: true when marked and within TTL, false when null or stale", () 
   });
   expect(isMerging(make(null), now)).toBe(false);
   expect(isMerging(make(now - 1000), now)).toBe(true);
-  expect(isMerging(make(now - MERGE_STALE_MS - 1), now)).toBe(false);
-});
-
-describe("sessionsForPrNumbers", () => {
-  const repoA = "/repo/a";
-  const repoB = "/repo/b";
-
-  it("returns session ids for ready PRs matching repo and numbers", () => {
-    const sessions = [
-      session({ id: "a", readyToMerge: true, repoPath: repoA }),
-      session({ id: "b", readyToMerge: true, repoPath: repoA }),
-    ];
-    const git: Record<string, GitState> = {
-      a: openPr(11, "feat: a", "https://h/pull/11"),
-      b: openPr(22, "feat: b", "https://h/pull/22"),
-    };
-    expect(sessionsForPrNumbers(repoA, [11, 22], sessions, git)).toEqual(["a", "b"]);
-  });
-
-  it("excludes sessions from a different repo", () => {
-    const sessions = [
-      session({ id: "a", readyToMerge: true, repoPath: repoA }),
-      session({ id: "b", readyToMerge: true, repoPath: repoB }),
-    ];
-    const git: Record<string, GitState> = {
-      a: openPr(11, "feat: a", "https://h/pull/11"),
-      b: openPr(22, "feat: b", "https://h/pull/22"),
-    };
-    expect(sessionsForPrNumbers(repoA, [11, 22], sessions, git)).toEqual(["a"]);
-  });
-
-  it("excludes sessions not readyToMerge", () => {
-    const sessions = [
-      session({ id: "a", readyToMerge: true, repoPath: repoA }),
-      session({ id: "b", readyToMerge: false, repoPath: repoA }),
-    ];
-    const git: Record<string, GitState> = {
-      a: openPr(11, "feat: a", "https://h/pull/11"),
-      b: openPr(22, "feat: b", "https://h/pull/22"),
-    };
-    expect(sessionsForPrNumbers(repoA, [11, 22], sessions, git)).toEqual(["a"]);
-  });
-
-  it("excludes sessions where isReviewing returns true", () => {
-    const sessions = [
-      session({ id: "a", readyToMerge: true, repoPath: repoA }),
-      session({ id: "b", readyToMerge: true, repoPath: repoA }),
-    ];
-    const git: Record<string, GitState> = {
-      a: openPr(11, "feat: a", "https://h/pull/11"),
-      b: openPr(22, "feat: b", "https://h/pull/22"),
-    };
-    expect(sessionsForPrNumbers(repoA, [11, 22], sessions, git, (id) => id === "a")).toEqual(["b"]);
-  });
-
-  it("returns empty array when no numbers match", () => {
-    const sessions = [session({ id: "a", readyToMerge: true, repoPath: repoA })];
-    const git: Record<string, GitState> = {
-      a: openPr(11, "feat: a", "https://h/pull/11"),
-    };
-    expect(sessionsForPrNumbers(repoA, [99, 100], sessions, git)).toEqual([]);
-  });
-
-  it("returns empty array for an empty numbers list", () => {
-    const sessions = [session({ id: "a", readyToMerge: true, repoPath: repoA })];
-    const git: Record<string, GitState> = {
-      a: openPr(11, "feat: a", "https://h/pull/11"),
-    };
-    expect(sessionsForPrNumbers(repoA, [], sessions, git)).toEqual([]);
-  });
+  // 31 min old is now still merging — proves the old 30-min cliff is gone.
+  expect(isMerging(make(now - 31 * 60_000), now)).toBe(true);
+  // Past the 24h safety backstop → no longer merging.
+  expect(isMerging(make(now - MERGE_MARK_BACKSTOP_MS - 1), now)).toBe(false);
 });
 
 describe("mergeTrainCreateInput with handpicked param", () => {

--- a/ui/src/lib/components/merge-train.ts
+++ b/ui/src/lib/components/merge-train.ts
@@ -1,15 +1,17 @@
 import { m } from "$lib/paraglide/messages";
 import type { Session, GitState, CreateInput } from "$lib/types";
 
-/** Merge-train marks older than this read as stale (the row falls back to its
- *  prior state) so a stuck PR never sticks visually even if the server's TTL
- *  sweep is briefly behind. Mirrors MERGE_STALE_MS in src/service.ts. */
-export const MERGE_STALE_MS = 30 * 60_000;
+/** Safety backstop, NOT the authoritative TTL. The server keeps a merge mark for
+ *  the life of the train and clears it authoritatively on merge/close/archive, so
+ *  the client no longer expires marks on a short clock. This generous cap mirrors
+ *  TRAIN_TRACKER_MAX_MS in src/service.ts and exists only so a wedged mark can't
+ *  stick forever if a clear event is missed. */
+export const MERGE_MARK_BACKSTOP_MS = 24 * 60 * 60_000;
 
-/** True when a session is in a currently-running merge train: marked and the
- *  mark is still within the TTL. `now` injectable for tests. */
+/** True when a session is in a currently-running merge train: marked and the mark
+ *  is still within the safety backstop. `now` injectable for tests. */
 export function isMerging(s: Session, now: number = Date.now()): boolean {
-  return s.mergingSince !== null && now - s.mergingSince < MERGE_STALE_MS;
+  return s.mergingSince !== null && now - s.mergingSince < MERGE_MARK_BACKSTOP_MS;
 }
 
 /** A ready-to-merge session's open PR, the unit a merge train works through. */
@@ -114,6 +116,9 @@ export function mergeTrainCreateInput(
       ? m.prspanel_merge_train_prompt({ prs: formatted })
       : m.herd_merge_train_prompt({ prs: formatted }),
     model: null,
+    // Selected PR numbers — the server marks these participants as "merging" on
+    // create and clears them authoritatively on merge/close/archive.
+    mergeTrainPrs: prs.map((p) => p.number),
     // Merge train is a procedural land-the-queue task, never a feature plan —
     // always skip the plan gate regardless of the per-repo toggle.
     planGateEnabled: false,
@@ -121,22 +126,4 @@ export function mergeTrainCreateInput(
     // driver into other work (overrides repo default).
     autopilotEnabled: false,
   };
-}
-
-/** Return the `sessionId`s of ready-to-merge sessions whose open PR number is
- *  in `numbers` AND whose `repoPath` matches.
- *
- *  Selects **only `readyToMerge`** sessions (mirroring `onmergetrain`), so an
- *  in-progress session's PR not appearing here is deliberate, not a bug. */
-export function sessionsForPrNumbers(
-  repoPath: string,
-  numbers: number[],
-  sessions: Session[],
-  git: Record<string, GitState>,
-  isReviewing: (id: string) => boolean = () => false,
-): string[] {
-  const numberSet = new Set(numbers);
-  return collectReadyPrs(sessions, git, isReviewing)
-    .filter((p) => p.repoPath === repoPath && numberSet.has(p.number))
-    .map((p) => p.sessionId);
 }

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -219,6 +219,7 @@ function session(over: Partial<Session>): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -42,6 +42,7 @@ function session(id: string): Session {
     readyToMerge: false,
     mergingSince: null,
     mergingTrainId: null,
+    mergeTrainPrs: null,
     autopilotEnabled: null,
     autopilotStepCount: 0,
     autopilotPaused: false,

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -750,6 +750,7 @@ export interface CreateInput {
   autopilotEnabled?: boolean | null; // per-task autopilot override; absent/null → inherit repo default
   sandboxProfile?: SandboxProfile | null; // per-spawn sandbox override; absent → inherit repo default
   research?: boolean; // research task kind; absent → false
+  mergeTrainPrs?: number[]; // merge-train participant PR numbers; server marks them "merging" on create
 }
 
 /** Selectable claude model aliases; null = claude's own default. */

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -462,6 +462,8 @@ export interface Session {
   mergingSince: number | null;
   /** Id of the owning merge-train session; null when not merging. */
   mergingTrainId: string | null;
+  /** PR numbers selected by the merge train for this TRAIN session; null on non-train sessions. */
+  mergeTrainPrs: number[] | null;
   autopilotEnabled: boolean | null;
   autopilotStepCount: number;
   autopilotPaused: boolean;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -75,6 +75,7 @@
   import type { HerdFilter } from "$lib/components/herd-partition";
   import {
     collectReadyPrs,
+    isMerging,
     mergeTrainCreateInput,
     pickTrainRepo,
   } from "$lib/components/merge-train";
@@ -114,6 +115,26 @@
   import { sidebarCollapse, sidebarShouldCollapse } from "$lib/sidebar-collapse.svelte";
 
   const store = new HerdStore();
+  // PR identity keys (`${repoPath}#${number}`) currently owned by a running merge
+  // train — a session that's flagged merging and has an open PR number. Threaded
+  // down to the backlog PRs panel so each in-train row shows a badge + its manual
+  // merge button is disabled (the train owns the merge).
+  // NB: isMerging is called WITHOUT nowMs on purpose. Marks appear/disappear on
+  // `session:merging` store events (not the clock), so this re-derives only when
+  // the store changes — passing nowMs would rebuild the Set every 1s tick and
+  // re-render every backlog PR row for a 24h-backstop boundary that never bites
+  // in practice (cf. the partition's same nowMs-avoidance choice).
+  const inTrainPrs = $derived(
+    new Set(
+      store.sessions
+        .filter((s) => isMerging(s))
+        .map((s) => {
+          const n = store.git[s.id]?.number;
+          return n != null ? `${s.repoPath}#${n}` : null;
+        })
+        .filter((k): k is string => k !== null),
+    ),
+  );
   let selectedId = $state<string | null>(null);
   // Monotonic tick bumped when a row's Preview badge is clicked; passed to the
   // Viewport so it switches to its Preview tab. A counter (not a boolean) so a
@@ -1468,6 +1489,7 @@
               {onlaunchtrain}
               flow={true}
               epics={store.epics}
+              {inTrainPrs}
             />
           {/if}
         </div>
@@ -1619,6 +1641,7 @@
             {onadopt}
             {onlaunchtrain}
             epics={store.epics}
+            {inTrainPrs}
           />
         {:else if selected}
           <Viewport
@@ -1931,6 +1954,7 @@
     {onlaunchtrain}
     onclose={() => (showBacklog = false)}
     epics={store.epics}
+    {inTrainPrs}
     target={epicTarget}
   />
 {/if}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -5,7 +5,6 @@
   import {
     listSessions,
     createSession,
-    startMergeTrain,
     archiveSession,
     relaunchSession,
     stageRelaunchImages,
@@ -78,7 +77,6 @@
     collectReadyPrs,
     mergeTrainCreateInput,
     pickTrainRepo,
-    sessionsForPrNumbers,
   } from "$lib/components/merge-train";
   import Viewport from "$lib/components/Viewport.svelte";
   import DoneRecapPanel from "$lib/components/DoneRecapPanel.svelte";
@@ -529,15 +527,6 @@
         try {
           const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs));
           selectedId = s.id;
-          // Mark this repo's ready PR-sessions as "merging" so the list shows them
-          // in-flight. Derived from the same scoped `prs` array the train works
-          // through — single source of truth, no separate filter needed.
-          // Fire-and-forget + fail-soft: a marking error must not abort the launch —
-          // the train (session s) is already running.
-          startMergeTrain(
-            prs.map((p) => p.sessionId),
-            s.id,
-          ).catch(() => toasts.info(m.toast_merge_train_mark_failed()));
           showBacklog = false;
           if (mobile.current) mobileScreen = "detail";
         } catch {
@@ -550,8 +539,8 @@
   /** Launch a merge train scoped to a hand-picked set of PRs from the backlog
    *  PRs panel. Unlike onmergetrain (which auto-collects ready sessions), the
    *  operator chose these PRs directly, so the kickoff prompt uses the
-   *  hand-picked framing. Matching ready-to-merge sessions are marked "merging";
-   *  backlog-only PRs (no session) still ride along in the prompt. */
+   *  hand-picked framing. The server marks participant PRs "merging" from the
+   *  passed mergeTrainPrs; backlog-only PRs still ride along in the prompt. */
   function onlaunchtrain(repoPath: string, prs: PullRequest[]) {
     if (prs.length < 2) return; // UI gates at >=2; defensive guard
     // Don't launch yet — open the confirm modal (renders above the still-mounted
@@ -567,18 +556,6 @@
         try {
           const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs, true));
           selectedId = s.id;
-          // Mark any ready-to-merge sessions whose open PR is in this selection as
-          // "merging" (same coupling as onmergetrain). Composed review predicate
-          // matches onmergetrain. Fire-and-forget + fail-soft; skip when none match.
-          const ids = sessionsForPrNumbers(
-            repoPath,
-            prs.map((p) => p.number),
-            store.sessions,
-            store.git,
-            (id) => reviews.isReviewing(id) || planGates.isReviewing(id),
-          );
-          if (ids.length > 0)
-            startMergeTrain(ids, s.id).catch(() => toasts.info(m.toast_merge_train_mark_failed()));
           showBacklog = false;
           if (mobile.current) mobileScreen = "detail";
         } catch {

--- a/ui/test/store.test.ts
+++ b/ui/test/store.test.ts
@@ -20,6 +20,7 @@ const s = (id: string, status: any = "running"): Session => ({
   readyToMerge: false,
   mergingSince: null,
   mergingTrainId: null,
+  mergeTrainPrs: null,
   autopilotEnabled: null,
   autopilotStepCount: 0,
   autopilotPaused: false,


### PR DESCRIPTION
## Problem

Sessions that are participants in a running merge train were **not reliably showing the "merging" status marker** — in the session-list grouping *and* the backlog. Confirmed live: a real hand-picked train (TASK-456) was actively landing its PRs while all three of its participant sessions (incl. PR #677) had `mergingSince = null` and were never marked.

**Root cause:** marking was client-initiated, re-derived from a fragile `readyToMerge ∩ client-git-cache` set, fire-and-forget (a failed POST was a toast only), and expired by a flat **30-min** TTL. Participants silently dropped out whenever a hand-picked PR's session wasn't `readyToMerge`, the client git cache lacked the open-PR number at confirm time, the POST failed, or the train ran past 30 min. The backlog PRs panel had no merge-train marker at all.

## Fix — server-derived, life-of-train marking

1. **Server derives the marks** from the train session's own selected PR set (new `Session.mergeTrainPrs`). `SessionService` maps those numbers → participant sessions via the `PrPoller` snapshot and marks **every one observed `state:"open"`, regardless of `readyToMerge`**. Reconciled on train-session create, on every `session:git` (catches PRs that open after launch — the cold-cache miss), on startup rebuild, and a 60s sweep.
2. **Life-of-train durability:** marks persist until the PR merges/closes or the train session leaves `#liveTrains` (clean archive, or a crashed train past an activity-based `TRAIN_TRACKER_MAX_MS` ceiling) — no flat 30-min cliff. The post-archive late-credit window (`mergetrain:landed`, #426) is preserved exactly.
3. **Reused-branch safety over the longer window:** new `Session.mergingPrNumber` records the marked PR number; the poller's `trustsTerminal` trusts a terminal result for a marked session only when the number matches.
4. **Retired the fragile path:** removed `setMerging`, `POST /api/merge-train/start`, client `startMergeTrain`, and `sessionsForPrNumbers`.
5. **Client:** `mergeTrainCreateInput` now passes `mergeTrainPrs`; the client `isMerging` backstop is raised to 24h (mirrors the server, which is now authoritative); **backlog PR rows show an in-train badge and disable the manual merge button** (a train owns the merge).

## Verification

- Root: `tsc --noEmit` ✓ · `bun test ./test` ✓ (3014, 0 fail) · `bun run lint` ✓ · `fallow audit --base origin/main --fail-on-issues` ✓
- UI: `bun run check` ✓ (0 errors) · `bun run test` ✓ (1288) · `check:i18n` ✓ (parity)
- New unit tests cover: non-`readyToMerge` participant marked; already-merged-at-launch never marked; late-open marked on reconcile; never-open → no tracker entry; non-isolated member never credits; no resurrection after archive; post-archive late credit fires exactly once; live train at 25h keeps marks; crash-without-archive deregisters at the ceiling and clears persisted marks; poller number-keyed trust (same/different/null number); backlog badge + disabled merge.

Migrations are additive (`mergeTrainPrs TEXT`, `mergingPrNumber INTEGER`, NULL defaults) and restart-safe (startup rebuild repopulates `#liveTrains` before the first sweep).

[no-feature-entry] — this hardens an existing feature's status marker (incl. a small backlog badge); not a headline new capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)