### PR TITLE
feat(newproject): pick the GitHub owner (personal or org) for a new repo

### DIFF
--- a/src/repos.ts
+++ b/src/repos.ts
@@ -198,6 +198,44 @@ const defaultGhRunner: GhRunner = async (args) => {
   ]);
 };
 
+/** Injectable gh runner that returns stdout — used to enumerate the GitHub
+ *  owners (the authenticated user + their orgs) the new-project dialog offers. */
+export type GhOutRunner = (args: string[]) => Promise<string>;
+
+const defaultGhOutRunner: GhOutRunner = async (args) => {
+  const { stdout } = await execFileAsync("gh", args, {
+    maxBuffer: 2 * 1024 * 1024,
+    timeout: 15_000,
+  });
+  return stdout.toString();
+};
+
+export type GithubOwners = { login: string; orgs: string[] };
+
+/**
+ * Enumerate the GitHub owners a new repo can be created under: the authenticated
+ * user's login plus every org they belong to (`/user/orgs` needs the `read:org`
+ * scope; if it's missing or the call fails we fall back to no orgs rather than
+ * erroring, so the dialog still offers the personal account).
+ * Throws only when the login itself can't be resolved (gh missing / not authed).
+ */
+export async function listGithubOwners(runner?: GhOutRunner): Promise<GithubOwners> {
+  const run = runner ?? defaultGhOutRunner;
+  const login = (await run(["api", "user", "--jq", ".login"])).trim();
+  let orgs: string[];
+  try {
+    const out = await run(["api", "user/orgs", "--jq", ".[].login"]);
+    orgs = out
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } catch {
+    // Missing read:org scope (or any org-list failure) → personal account only.
+    orgs = [];
+  }
+  return { login, orgs };
+}
+
 /** Check whether a commit identity is available — either via the GIT_AUTHOR_ /
  *  GIT_COMMITTER_ environment variables (which git honors over config, e.g. on
  *  CI runners without a global config) or via configured user.name/user.email. */
@@ -298,7 +336,13 @@ export function classifyProjectError(e: unknown): string {
  *   because Bun's process.env mutations don't propagate to child processes in the same way Node does.
  */
 export async function createProject(
-  input: { name: string; idea: string; createRemote: boolean; visibility: "private" | "public" },
+  input: {
+    name: string;
+    idea: string;
+    createRemote: boolean;
+    visibility: "private" | "public";
+    owner?: string;
+  },
   repoRoot: string,
   ghRunner?: GhRunner,
   _identityCheck?: () => boolean,
@@ -389,7 +433,7 @@ function writeBootstrapFiles(input: { name: string; idea: string }, target: stri
  */
 async function pushToGitHub(
   runner: GhRunner,
-  input: { name: string; visibility: "private" | "public" },
+  input: { name: string; visibility: "private" | "public"; owner?: string },
   target: string,
 ): Promise<string | undefined> {
   try {
@@ -401,11 +445,16 @@ async function pushToGitHub(
       : "newproject_failed_gh_auth";
   }
 
+  // An explicit owner (an org the user belongs to) is created as `<owner>/<name>`;
+  // an empty owner lets `gh` default to the authenticated user's personal account.
+  const owner = input.owner?.trim();
+  const repoArg = owner ? `${owner}/${input.name}` : input.name;
+
   try {
     await runner([
       "repo",
       "create",
-      input.name,
+      repoArg,
       "--source",
       target,
       input.visibility === "public" ? "--public" : "--private",

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,16 @@ import {
 } from "./validate";
 import { slugifyManual } from "./namer";
 import { planHouseRulesInjection, prioritize } from "./house-rules";
-import { listRepos, readTodo, writeTodo, cloneRepo, createProject, type GhRunner } from "./repos";
+import {
+  listRepos,
+  readTodo,
+  writeTodo,
+  cloneRepo,
+  createProject,
+  listGithubOwners,
+  type GhRunner,
+  type GhOutRunner,
+} from "./repos";
 import { resolveDefaultBranch, fastForwardDefaultBranch } from "./pull";
 import { analyzeReadiness } from "./readiness";
 import { listCommands } from "./commands";
@@ -238,6 +247,10 @@ export interface AppDeps {
    *  fake so the route's partial-success mapping can be exercised WITHOUT creating
    *  real GitHub repos. */
   newProjectGhRunner?: GhRunner;
+  /** Injectable stdout `gh` runner for GET /api/github/owners. Absent in production
+   *  (listGithubOwners falls back to the real `gh` runner); tests inject a fake so the
+   *  owner-enumeration route can be exercised without hitting GitHub. */
+  githubOwnersRunner?: GhOutRunner;
 }
 
 const sessionUsage = (s: Session) =>
@@ -1978,6 +1991,23 @@ async function handleProjects({ req, parts, deps }: Ctx): Promise<Response | nul
   return null;
 }
 
+// GET /api/github/owners — list the owners a new repo can be created under (the
+// authenticated user + their orgs). A gh failure (missing/not-authed) returns 200
+// with `{ login: null, orgs: [] }` so the new-project dialog degrades to a personal
+// repo without surfacing an error before the user has even opted into a remote.
+async function handleGithubOwners({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(parts[0] === "api" && parts[1] === "github" && parts[2] === "owners" && !parts[3])) {
+    return null;
+  }
+  if (req.method !== "GET") return null;
+  try {
+    const owners = await listGithubOwners(deps.githubOwnersRunner);
+    return json(owners);
+  } catch {
+    return json({ login: null, orgs: [] });
+  }
+}
+
 // ── settings: verify the configured api-key authenticates end-to-end ──
 // POST /api/settings/verify-key → spawns a transient verify agent (via deps.verifyKey)
 // and returns ONLY {ok,reason?,detail?} — never the key or its helper path, never logged.
@@ -3407,6 +3437,7 @@ const ROUTE_HANDLERS = [
   handleUploads,
   handleRepos,
   handleProjects,
+  handleGithubOwners,
   handleSettingsVerifyKey,
   handleSettings,
   handleSteers,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -177,9 +177,16 @@ export type NewProjectInput = {
   idea: string;
   createRemote: boolean;
   visibility: "private" | "public";
+  owner: string;
 };
 
-const NEW_PROJECT_ALLOWED_KEYS = new Set(["name", "idea", "createRemote", "visibility"]);
+const NEW_PROJECT_ALLOWED_KEYS = new Set(["name", "idea", "createRemote", "visibility", "owner"]);
+
+/**
+ * GitHub login/org slug: 1–39 chars, alphanumeric with single internal hyphens,
+ * no leading/trailing hyphen. Empty is allowed and means "personal account".
+ */
+const GH_OWNER_RE = /^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$/;
 
 /**
  * Validate and normalize a project name against slug rules.
@@ -223,6 +230,16 @@ function parseVisibilityField(value: unknown): Field<"private" | "public"> {
   return field(value);
 }
 
+/** owner — optional GitHub login/org slug, default "" (personal account). */
+function parseOwnerField(value: unknown): Field<string> {
+  if (value === undefined || value === "") return field("");
+  if (typeof value !== "string") return err("newproject_failed_generic");
+  const owner = value.trim();
+  if (owner === "") return field("");
+  if (owner.length > 39 || !GH_OWNER_RE.test(owner)) return err("newproject_failed_generic");
+  return field(owner);
+}
+
 /**
  * Validate a POST /api/projects request body.
  * Returns `{ ok: true; value: NewProjectInput }` on success or `{ ok: false; error: string }`
@@ -255,6 +272,9 @@ export function validateNewProject(
   const visibilityResult = parseVisibilityField(obj.visibility);
   if (!visibilityResult.ok) return visibilityResult;
 
+  const ownerResult = parseOwnerField(obj.owner);
+  if (!ownerResult.ok) return ownerResult;
+
   // Containment guard: target must resolve inside repoRoot.
   // The slug regex already blocks separators, but this is defense-in-depth (mirrors cloneRepo).
   const root = resolve(expandHome(repoRoot));
@@ -268,6 +288,7 @@ export function validateNewProject(
       idea: ideaResult.value,
       createRemote: createRemoteResult.value,
       visibility: visibilityResult.value,
+      owner: ownerResult.value,
     },
   };
 }

--- a/test/repos.test.ts
+++ b/test/repos.test.ts
@@ -20,7 +20,9 @@ import {
   classifyCloneError,
   createProject,
   classifyProjectError,
+  listGithubOwners,
   type GhRunner,
+  type GhOutRunner,
 } from "../src/repos";
 import { realpathSync } from "node:fs";
 
@@ -379,6 +381,73 @@ test("createProject: remote success with stub runner → ok:true, no warning", a
   } finally {
     cleanup();
   }
+});
+
+/** An explicit owner creates the repo as `<owner>/<name>`. */
+test("createProject: owner set → gh repo create uses 'owner/name'", async () => {
+  const { repoRoot, cleanup } = makeTempRoot();
+  try {
+    const calls: string[][] = [];
+    const stubRunner: GhRunner = async (args) => {
+      calls.push(args);
+    };
+
+    const result = await createProject(
+      { name: "team-app", idea: "", createRemote: true, visibility: "private", owner: "acme-corp" },
+      repoRoot,
+      stubRunner,
+    );
+    expect(result.ok).toBe(true);
+    // repo create is the second call; the positional repo arg is owner/name
+    expect(calls[1]![0]).toBe("repo");
+    expect(calls[1]![2]).toBe("acme-corp/team-app");
+  } finally {
+    cleanup();
+  }
+});
+
+/** An empty owner lets gh default to the personal account (bare name). */
+test("createProject: empty owner → gh repo create uses bare name", async () => {
+  const { repoRoot, cleanup } = makeTempRoot();
+  try {
+    const calls: string[][] = [];
+    const stubRunner: GhRunner = async (args) => {
+      calls.push(args);
+    };
+
+    const result = await createProject(
+      { name: "solo-app", idea: "", createRemote: true, visibility: "private", owner: "" },
+      repoRoot,
+      stubRunner,
+    );
+    expect(result.ok).toBe(true);
+    expect(calls[1]![2]).toBe("solo-app");
+  } finally {
+    cleanup();
+  }
+});
+
+/** listGithubOwners: login + orgs parsed from gh stdout. */
+test("listGithubOwners: returns login and orgs", async () => {
+  const runner: GhOutRunner = async (args) => {
+    if (args[1] === "user") return "octocat\n";
+    if (args[1] === "user/orgs") return "acme-corp\nwidgets-inc\n";
+    return "";
+  };
+  const owners = await listGithubOwners(runner);
+  expect(owners.login).toBe("octocat");
+  expect(owners.orgs).toEqual(["acme-corp", "widgets-inc"]);
+});
+
+/** listGithubOwners: an org-list failure degrades to login + no orgs. */
+test("listGithubOwners: org-list failure → login with empty orgs", async () => {
+  const runner: GhOutRunner = async (args) => {
+    if (args[1] === "user") return "octocat\n";
+    throw Object.assign(new Error("missing read:org scope"), { stderr: "HTTP 403" });
+  };
+  const owners = await listGithubOwners(runner);
+  expect(owners.login).toBe("octocat");
+  expect(owners.orgs).toEqual([]);
 });
 
 /** Stub rejects with "name already exists" → ok:true + warning:newproject_failed_gh_exists + dir kept. */

--- a/test/server-projects.test.ts
+++ b/test/server-projects.test.ts
@@ -313,3 +313,34 @@ test("POST /api/projects partial-success (gh missing) → 201 + warning", async 
     if (existsSync(targetDir)) rmSync(targetDir, { recursive: true, force: true });
   }
 });
+
+// ── GET /api/github/owners ────────────────────────────────────────────────────
+
+function getOwners(app: ReturnType<typeof makeApp>): Promise<Response> {
+  return app.fetch(new Request("http://x/api/github/owners", { method: "GET" }));
+}
+
+test("GET /api/github/owners → login + orgs from injected runner", async () => {
+  const runner = async (args: string[]) => {
+    if (args[1] === "user") return "octocat\n";
+    if (args[1] === "user/orgs") return "acme-corp\nwidgets-inc\n";
+    return "";
+  };
+  const app = makeApp({ ...makeDeps(), githubOwnersRunner: runner });
+  const res = await getOwners(app);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.login).toBe("octocat");
+  expect(body.orgs).toEqual(["acme-corp", "widgets-inc"]);
+});
+
+test("GET /api/github/owners gh failure → 200 with null login, empty orgs", async () => {
+  const runner = () =>
+    Promise.reject(Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" }));
+  const app = makeApp({ ...makeDeps(), githubOwnersRunner: runner });
+  const res = await getOwners(app);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.login).toBeNull();
+  expect(body.orgs).toEqual([]);
+});

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -770,6 +770,36 @@ test("validateNewProject: bad visibility → newproject_failed_generic", () => {
   if (!r.ok) expect(r.error).toBe("newproject_failed_generic");
 });
 
+test("validateNewProject: owner defaults to '' when absent", () => {
+  const r = validateNewProject({ name: "cool-proj" }, root);
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.owner).toBe("");
+});
+
+test("validateNewProject: valid org owner passes and is echoed", () => {
+  const r = validateNewProject({ name: "my-app", owner: "acme-corp" }, root);
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.owner).toBe("acme-corp");
+});
+
+test("validateNewProject: empty-string owner normalizes to '' (personal)", () => {
+  const r = validateNewProject({ name: "my-app", owner: "" }, root);
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.value.owner).toBe("");
+});
+
+test("validateNewProject: owner with illegal chars → newproject_failed_generic", () => {
+  const r = validateNewProject({ name: "my-app", owner: "bad/owner" }, root);
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toBe("newproject_failed_generic");
+});
+
+test("validateNewProject: owner too long → newproject_failed_generic", () => {
+  const r = validateNewProject({ name: "my-app", owner: "a".repeat(40) }, root);
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toBe("newproject_failed_generic");
+});
+
 test("validateNewProject: non-boolean createRemote → newproject_failed_generic", () => {
   const r = validateNewProject({ name: "my-app", createRemote: "yes" }, root);
   expect(r.ok).toBe(false);

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1005,6 +1005,8 @@
   "newproject_visibility_group": "Sichtbarkeit",
   "newproject_visibility_private": "Privat",
   "newproject_visibility_public": "Öffentlich",
+  "newproject_owner_label": "Besitzer",
+  "newproject_owner_personal": "{login} (persönliches Konto)",
   "newproject_kickoff_label": "Starten mit",
   "newproject_kickoff_prd": "PRD-Briefing (Standard)",
   "newproject_submit": "Projekt anlegen & starten",
@@ -1296,5 +1298,7 @@
   "integrated_epics_ack_migrations": "Migrationen bestätigen & schließen",
   "integrated_epics_ack_migrations_failed": "Migrationen konnten nicht bestätigt werden — erneut versuchen",
   "feat_epic_migrations_title": "Epic-Landungen melden nicht ausgeführte Migrationen",
-  "feat_epic_migrations_body": "Wenn der Landing-PR eines Epics Datenbankmigrationen hinzufügt, zeigt das Band 'Integrierte Epics' jetzt einen Warn-Chip mit der Dateianzahl — der Harness führt sie nie aus, prüfe sie also vor dem Merge. Vor dem Schließen der Zeile musst du die Migrationen bestätigen."
+  "feat_epic_migrations_body": "Wenn der Landing-PR eines Epics Datenbankmigrationen hinzufügt, zeigt das Band 'Integrierte Epics' jetzt einen Warn-Chip mit der Dateianzahl — der Harness führt sie nie aus, prüfe sie also vor dem Merge. Vor dem Schließen der Zeile musst du die Migrationen bestätigen.",
+  "feat_newproject_owner_title": "Besitzer für neues GitHub-Repo wählen",
+  "feat_newproject_owner_body": "Wenn du ein Projekt mit GitHub-Repository anlegst, kannst du jetzt wählen, ob es unter deinem persönlichen Konto oder einer deiner Organisationen landet — der Dialog listet jede Organisation auf, der du angehörst, statt immer dein Konto zu nehmen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1005,6 +1005,8 @@
   "newproject_visibility_group": "Visibility",
   "newproject_visibility_private": "Private",
   "newproject_visibility_public": "Public",
+  "newproject_owner_label": "Owner",
+  "newproject_owner_personal": "{login} (personal account)",
   "newproject_kickoff_label": "Kickoff with",
   "newproject_kickoff_prd": "PRD brief (default)",
   "newproject_submit": "Create project & start",
@@ -1296,5 +1298,7 @@
   "integrated_epics_ack_migrations": "Acknowledge migrations & dismiss",
   "integrated_epics_ack_migrations_failed": "Couldn't acknowledge the migrations — try again",
   "feat_epic_migrations_title": "Epic landings flag unrun migrations",
-  "feat_epic_migrations_body": "When an epic's landing PR adds database migrations, the Integrated-epics band now shows a warning chip with the file count — the harness never runs them, so verify them before merging. Clearing the row asks you to acknowledge the migrations first."
+  "feat_epic_migrations_body": "When an epic's landing PR adds database migrations, the Integrated-epics band now shows a warning chip with the file count — the harness never runs them, so verify them before merging. Clearing the row asks you to acknowledge the migrations first.",
+  "feat_newproject_owner_title": "Choose the owner for a new GitHub repo",
+  "feat_newproject_owner_body": "When you create a project with a GitHub repository, you can now pick whether it lands under your personal account or one of your organizations — the dialog lists every org you belong to instead of always defaulting to your account."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -208,8 +208,23 @@ export async function createProject(input: {
   idea: string;
   createRemote: boolean;
   visibility: "private" | "public";
+  owner?: string;
 }): Promise<RepoEntry & { warning?: string }> {
   return postJson<RepoEntry & { warning?: string }>("/api/projects", input, "newproject");
+}
+
+/** GitHub owners a new repo can be created under: the authenticated login plus the
+ *  user's orgs. `login` is null when gh is unavailable/unauthed — callers then offer
+ *  the personal account only (no owner picker). Never throws (degrades to no owners). */
+export async function getGithubOwners(): Promise<{ login: string | null; orgs: string[] }> {
+  try {
+    return await getJson<{ login: string | null; orgs: string[] }>(
+      "/api/github/owners",
+      "github_owners",
+    );
+  } catch {
+    return { login: null, orgs: [] };
+  }
 }
 
 export async function getSettings(): Promise<Settings> {

--- a/ui/src/lib/components/NewProject.svelte
+++ b/ui/src/lib/components/NewProject.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createProject, getCommands } from "$lib/api";
+  import { createProject, getCommands, getGithubOwners } from "$lib/api";
   import type { RepoEntry } from "$lib/types";
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
@@ -34,6 +34,13 @@
   let idea = $state("");
   let createRemote = $state(false);
   let visibility = $state<"private" | "public">("private");
+  // GitHub owner: "" → personal account, otherwise an org slug. Owners are fetched
+  // lazily the first time the GitHub box is checked; the picker only renders when the
+  // user belongs to at least one org (otherwise there's nothing to choose).
+  let owner = $state("");
+  let ownerLogin = $state<string | null>(null);
+  let ownerOrgs = $state<string[]>([]);
+  let ownersLoaded = $state(false);
   // String sentinel for the select bind — avoids Svelte 5 reference-equality bug with object values.
   // "__prd__" → { kind: "prd" }, any other value → { kind: "command", name: value }.
   let kickoffValue = $state<string>("__prd__");
@@ -54,6 +61,19 @@
   });
 
   const canSubmit = $derived(name.trim().length > 0 && !nameInvalid && !submitting);
+
+  // Lazily enumerate the GitHub owners the first time the box is checked. Set the
+  // guard before awaiting so a toggle storm can't fire overlapping requests, and so a
+  // failed fetch (gh missing/unauthed) doesn't retry — it just degrades to no picker.
+  $effect(() => {
+    if (createRemote && !ownersLoaded) {
+      ownersLoaded = true;
+      getGithubOwners().then(({ login, orgs }) => {
+        ownerLogin = login;
+        ownerOrgs = orgs;
+      });
+    }
+  });
 
   onMount(async () => {
     try {
@@ -113,6 +133,7 @@
         idea: trimmedIdea,
         createRemote,
         visibility,
+        owner: createRemote ? owner : "",
       });
       ondone(entry, resolveKickoff(), trimmedIdea);
     } catch (err) {
@@ -201,6 +222,16 @@
           <span class="micro">{m.newproject_visibility_public()}</span>
         </label>
       </div>
+
+      {#if ownerOrgs.length > 0}
+        <label class="micro" for="np-owner">{m.newproject_owner_label()}</label>
+        <select id="np-owner" bind:value={owner}>
+          <option value="">{m.newproject_owner_personal({ login: ownerLogin ?? "" })}</option>
+          {#each ownerOrgs as org (org)}
+            <option value={org}>{org}</option>
+          {/each}
+        </select>
+      {/if}
     {/if}
 
     <!-- Kickoff selection -->

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -850,4 +850,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_epic_migrations_title",
     bodyKey: "feat_epic_migrations_body",
   },
+  {
+    // No targetId: the owner picker only mounts inside the New-project dialog (closed by
+    // default) and only after the GitHub box is checked, so a coachmark anchor would
+    // rarely be present — surface via the What's-New drawer only. 1.30.0 is the latest
+    // released tag, so this ships in 1.31.0.
+    id: "newproject-github-owner",
+    sinceVersion: "1.31.0",
+    titleKey: "feat_newproject_owner_title",
+    bodyKey: "feat_newproject_owner_body",
+  },
 ];


### PR DESCRIPTION
## Problem

The new-project dialog never asked **which GitHub owner** a new repository should be created under — it always landed under the authenticated user's personal account. Users who belong to one or more organizations had no way to create the repo under an org from the UI.

(Reported via mobile screenshot: *"Es wird nicht nachgefragt, in welchem Bereich das Repo angelegt werden soll — bei mir unter meinem User oder unter einem Team, dem ich angehöre."*)

## Change

- **`GET /api/github/owners`** — enumerates the authenticated login plus the user's orgs (`gh api user` / `gh api user/orgs --jq '.[].login'`). A missing `read:org` scope or org-list failure degrades to the personal account only; a full gh failure returns `{ login: null, orgs: [] }` so the dialog silently keeps today's behaviour.
- **`POST /api/projects`** now accepts an optional `owner`. `pushToGitHub` creates the repo as `<owner>/<name>` when an owner is set, otherwise the bare name (gh defaults to the personal account). `owner` is format-validated as a GitHub login slug (≤39 chars, no separators) — passed to `gh` via `execFile` args, so no shell injection surface.
- **`NewProject.svelte`** lazily fetches the owners the first time the GitHub box is checked and renders an **Owner** picker only when the user actually belongs to at least one org. Default option is the personal account.

## UX

- Owner picker appears inside the existing GitHub block, below Private/Public, using the existing token-based `select` styling — no new design primitives.
- If gh is missing/unauthed or the user has no orgs, nothing changes visually (no picker), so the flow is unchanged for solo users.

## Tests

- `validate.test.ts`: owner default, valid org, empty→personal, illegal chars, too-long.
- `repos.test.ts`: `owner` → `gh repo create owner/name`; empty → bare name; `listGithubOwners` parsing + org-list-failure fallback.
- `server-projects.test.ts`: `GET /api/github/owners` success + gh-failure fallback.

i18n parity (EN+DE), feature-catalog entry (`newproject-github-owner`, 1.31.0), lint, `bun run check`, and the targeted root suites all pass. (Full UI suite shows pre-existing flaky timeouts in unrelated components — they pass in isolation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)