### PR TITLE
fix(repos): use Shepherd's own repo as fork placeholder example

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1299,7 +1299,7 @@
   "feat_newproject_owner_body": "Wenn du ein Projekt mit GitHub-Repository anlegst, kannst du jetzt wählen, ob es unter deinem persönlichen Konto oder einer deiner Organisationen landet — der Dialog listet jede Organisation auf, der du angehörst, statt immer dein Konto zu nehmen.",
   "forkrepo_title": "GitHub-Repo forken",
   "forkrepo_input_label": "Repository (owner/repo oder URL)",
-  "forkrepo_input_placeholder": "dannymcc/may",
+  "forkrepo_input_placeholder": "erwins-enkel/shepherd",
   "forkrepo_target_preview": "→ {root}/{name}",
   "forkrepo_hint": "Forkt das Repo unter deinem GitHub-Account und klont es. Pull Requests, die du daraus öffnest, zielen auf das Original (Upstream). Der Fork bleibt in deinem Account.",
   "forkrepo_submit": "Forken & starten",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1299,7 +1299,7 @@
   "feat_newproject_owner_body": "When you create a project with a GitHub repository, you can now pick whether it lands under your personal account or one of your organizations — the dialog lists every org you belong to instead of always defaulting to your account.",
   "forkrepo_title": "Fork a GitHub repo",
   "forkrepo_input_label": "Repository (owner/repo or URL)",
-  "forkrepo_input_placeholder": "dannymcc/may",
+  "forkrepo_input_placeholder": "erwins-enkel/shepherd",
   "forkrepo_target_preview": "→ {root}/{name}",
   "forkrepo_hint": "Forks the repo under your GitHub account and clones it. Pull requests you open from it target the original (upstream) repo. The fork stays in your account.",
   "forkrepo_submit": "Fork & start",


### PR DESCRIPTION
## Was

Im "GitHub-Repo forken"-Dialog war als Platzhalter ein **echtes fremdes Repo** hinterlegt (`dannymcc/may`). Als Beispiel ist das verwirrend — es zeigt auf jemandes tatsächliches Repository.

## Änderung

Platzhalter auf Shepherds eigenes Repo umgestellt: `erwins-enkel/shepherd`. Damit ist das Beispiel selbstreferenziell und zeigt nicht auf ein fremdes Repo.

- `ui/messages/en.json` + `ui/messages/de.json`: `forkrepo_input_placeholder`

Das Label (`Repository (owner/repo oder URL)`) liefert weiterhin die Erklärung des erwarteten Formats.

[no-feature-entry] — reiner Platzhalter-Text, kein neues Feature.