### PR TITLE
fix(automation-panel): centered modal sheet + blurred scrim on touch

### DIFF
--- a/ui/src/lib/components/AutomationPanel.svelte
+++ b/ui/src/lib/components/AutomationPanel.svelte
@@ -149,6 +149,15 @@
     const el = popEl;
     if (!el) return;
     const clamp = () => {
+      // Touch layouts render the panel as a centered fixed modal sheet (see the
+      // pointer:coarse block in the stylesheet), where the anchor-relative height math
+      // below is meaningless and the inline max-height would override the CSS.
+      // Hand max-height back to the stylesheet and never flip on touch.
+      if (window.matchMedia("(pointer: coarse)").matches) {
+        el.style.maxHeight = "";
+        flipUp = false;
+        return;
+      }
       // Measure the anchor (the positioning wrapper), not the popover itself —
       // the popover's own rect moves when we flip it, the anchor's doesn't.
       const anchor = el.offsetParent;
@@ -671,6 +680,27 @@
     bottom: 100%;
     margin-top: 0;
     margin-bottom: 4px;
+  }
+  /* Touch layouts (phones + unfolded folds): the strip goes position:static, so
+     this absolute popover hangs below the 44px strip and — anchored right:8px and
+     narrower than the page — could be panned partly off-screen. Override into a
+     centered fixed modal sheet over the .auto-scrim backdrop (rendered by GitRail),
+     wider than the desktop popover and impossible to pan. Mirrors .review-pop.
+     The JS height-clamp bails on coarse pointers, leaving max-height to this rule. */
+  @media (pointer: coarse) {
+    .auto-pop {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      right: auto;
+      bottom: auto;
+      transform: translate(-50%, -50%);
+      margin: 0;
+      width: min(480px, 92vw);
+      max-width: none;
+      max-height: 85vh;
+      z-index: 51;
+    }
   }
   .auto-head {
     font-size: var(--fs-micro);

--- a/ui/src/lib/components/AutomationPanel.svelte
+++ b/ui/src/lib/components/AutomationPanel.svelte
@@ -195,6 +195,57 @@
     };
   });
 
+  // On touch the panel becomes a centered fixed modal sheet over a dimming scrim
+  // (see the pointer:coarse block in the stylesheet). Give it the same dialog
+  // semantics as the sibling findings sheet (.review-pop) so keyboard/AT users get
+  // parity: aria-modal, initial focus, a Tab focus-trap, and focus restoration.
+  // On desktop it stays a non-modal anchored popover (no scrim), so none apply.
+  let touch = $state(false);
+  $effect(() => {
+    const mq = window.matchMedia("(pointer: coarse)");
+    touch = mq.matches;
+    const onChange = () => (touch = mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  });
+
+  // Move focus into the sheet on open and restore it to the opener (the pill) when
+  // the panel unmounts — touch only; on desktop the popover is non-modal.
+  $effect(() => {
+    if (!touch || !popEl) return;
+    const opener = document.activeElement as HTMLElement | null;
+    popEl.focus();
+    return () => {
+      if (opener?.isConnected) opener.focus();
+    };
+  });
+
+  // Minimal Tab focus-trap, mirroring GitRail's .review-pop trap. Focusables are
+  // enumerated at trap time so dynamically-rendered rows are included; the panel
+  // container itself (tabindex="-1") is excluded by the selector.
+  function trapTab(e: KeyboardEvent) {
+    if (!touch || e.key !== "Tab" || !popEl) return;
+    const nodes = popEl.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    if (nodes.length === 0) {
+      e.preventDefault();
+      return;
+    }
+    const first = nodes[0];
+    const last = nodes[nodes.length - 1];
+    const active = document.activeElement;
+    if (e.shiftKey) {
+      if (active === first || active === popEl) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else if (active === last || active === popEl) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
   async function setRole(role: "reviewer" | "merger", value: string | null) {
     const prev = roles;
     roles = { ...roles, [role]: value }; // optimistic
@@ -218,8 +269,11 @@
 <div
   class={["auto-pop", { "flip-up": flipUp }]}
   role="dialog"
+  aria-modal={touch ? "true" : undefined}
   aria-label={m.automation_panel_title()}
+  tabindex="-1"
   bind:this={popEl}
+  onkeydown={trapTab}
 >
   <div class="auto-head">{m.automation_panel_title()}</div>
   <div class="auto-sub">{m.automation_panel_subtitle()}</div>

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -428,6 +428,14 @@
   {#if showReview && verdict}
     <div class="review-scrim" aria-hidden="true"></div>
   {/if}
+  <!-- touch-only dim+blur behind the automation sheet. Like .review-scrim it sits
+       OUTSIDE wrapEl so a backdrop tap trips the existing click-outside dismiss.
+       Desktop keeps the lightweight anchored popover (non-modal, no scrim); only the
+       coarse-pointer layout — where the panel becomes a centered fixed sheet — shows
+       it (CSS-gated). Reuses the canonical .scrim primitive. Purely visual → aria-hidden. -->
+  {#if showAutomation}
+    <div class="auto-scrim scrim" aria-hidden="true"></div>
+  {/if}
   <span class="git-rail-wrap" class:mobile bind:this={wrapEl}>
     <span class="rail" class:mobile use:edgeFades={mobile}>
       {#if git.state === "none"}
@@ -982,6 +990,21 @@
     background: var(--color-scrim);
     -webkit-backdrop-filter: blur(3px);
     backdrop-filter: blur(3px);
+  }
+
+  /* backdrop behind the automation sheet — only on touch, where the panel becomes a
+     centered fixed sheet (see AutomationPanel's pointer:coarse block). The canonical
+     .scrim class supplies fixed/inset/dim/blur (and the reduced-transparency drop);
+     this rule only contributes the z-index and the coarse-pointer gate. Desktop keeps
+     the anchored non-modal popover, so it stays display:none there. */
+  .auto-scrim {
+    display: none;
+    z-index: 50;
+  }
+  @media (pointer: coarse) {
+    .auto-scrim {
+      display: block;
+    }
   }
 
   /* findings popover: same anchoring as .pr-pop, wider + scrollable body.


### PR DESCRIPTION
## Was & warum

Auf dem iPhone ließ sich das **Automatisierungs-Menü** (das Popover hinter der „Automatisierung x/10"-Pille) horizontal hin- und herschieben und hatte keinen abgedunkelten Hintergrund.

Ursache: das Popover war absolut mit `right: 8px` und einer festen Breite (320px, schmaler als der Viewport) an der `position:static`-Mobile-Strip verankert — es hing also unter der Strip und konnte teilweise aus dem Bild geschoben werden.

## Lösung

Auf `@media (pointer: coarse)` (Phones + aufgeklappte Folds) wird das Panel jetzt zu einem **mittig zentrierten, fixierten Sheet** (`width: min(480px, 92vw)`):

- **Nicht mehr schiebbar** — fixed + zentriert statt rechts-verankert.
- **Etwas breiter** als das Desktop-Popover (bis 480px / 92vw).
- **Blur-Backdrop** über die kanonische `.scrim`-Primitive (Dim + Blur, respektiert `prefers-reduced-transparency`) — genau wie beim Findings-Popover (`.review-pop`).
- Backdrop-Tap schließt das Menü (nutzt die bestehende Click-Outside-Dismiss-Logik, da der Scrim außerhalb `wrapEl` sitzt).

Der JS-Höhen-Clamp setzt auf Touch aus, damit seine Inline-`max-height` nicht gegen die CSS-Regel kämpft.

**Desktop bleibt unverändert** — das leichtgewichtige, verankerte, nicht-modale Popover.

Spiegelt 1:1 das etablierte `.review-pop`-Touch-Muster aus derselben Komponente.

## Checks
- `bun run check` ✅
- `bun run test` ✅ (1314 passed)

Keine neuen i18n-/Glossar-Keys; reiner Layout-Fix (`fix`, kein `feat` → kein Feature-Katalog-Eintrag nötig).