### PR TITLE
feat(newtask): per-task Autopilot override in the New Task dialog

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -540,6 +540,8 @@
   "criticbadge_final_title": "Bearbeitet die letzte erlaubte Runde; danach folgt keine weitere.",
   "newtask_plan_gate_label": "Plan-Gate",
   "newtask_plan_gate_hint": "Plan vor dem Agentenlauf prüfen + kontradiktorisch hinterfragen",
+  "newtask_autopilot_label": "Autopilot bis zum PR",
+  "newtask_autopilot_hint": "Diese Aufgabe autonom bis zum PR durchziehen. Aus, um mitzudiskutieren, zu iterieren und jeden Schritt selbst freizugeben. Übernimmt standardmäßig die Autopilot-Einstellung des Repos.",
   "plangate_planning": "PLANUNG",
   "plangate_reviewing": "PRÜFUNG…",
   "plangate_changes": "REWORK · {round}/{cap}",
@@ -1327,5 +1329,7 @@
   "gloss_critic_def": "Shepherds isolierter, nur-lesender Review-Agent, der den Diff eines PRs prüft, sobald die CI grün ist, und ein Urteil abgibt.",
   "gloss_wikipedia_link": "Auf Wikipedia weiterlesen",
   "feat_glossary_title": "Glossar-Tooltips",
-  "feat_glossary_body": "Begriffe in What's-New und Coachmarks sind jetzt gestrichelt unterstrichen — fahre darüber oder tippe, um die Bedeutung zu sehen, mit Wikipedia-Link für Fachbegriffe."
+  "feat_glossary_body": "Begriffe in What's-New und Coachmarks sind jetzt gestrichelt unterstrichen — fahre darüber oder tippe, um die Bedeutung zu sehen, mit Wikipedia-Link für Fachbegriffe.",
+  "feat_task_autopilot_title": "Autopilot-Override pro Aufgabe",
+  "feat_task_autopilot_body": "Der Dialog „Neue Aufgabe“ hat jetzt eine Checkbox „Autopilot bis zum PR“. Sie startet mit der Autopilot-Einstellung des Repos, lässt sich aber für eine einzelne Aufgabe ausschalten, die du lieber Schritt für Schritt besprechen und freigeben möchtest — ohne den repoweiten Standard zu ändern."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -540,6 +540,8 @@
   "criticbadge_final_title": "Addressing the last allowed round; no more rounds after this.",
   "newtask_plan_gate_label": "Plan gate",
   "newtask_plan_gate_hint": "Grill + adversarial review before the agent runs",
+  "newtask_autopilot_label": "Autopilot to PR",
+  "newtask_autopilot_hint": "Drive this task autonomously through to a PR. Turn off to discuss, iterate and approve each step yourself. Defaults to this repo's Autopilot setting.",
   "plangate_planning": "PLANNING",
   "plangate_reviewing": "REVIEWING…",
   "plangate_changes": "REWORK · {round}/{cap}",
@@ -1327,5 +1329,7 @@
   "gloss_critic_def": "Shepherd's isolated, read-only review agent that inspects a PR's diff once CI is green and posts a verdict.",
   "gloss_wikipedia_link": "Read on Wikipedia",
   "feat_glossary_title": "Glossary tooltips",
-  "feat_glossary_body": "Terms in What's-New and coachmarks now have a dashed underline — hover or tap to see what they mean, with a Wikipedia link for industry-standard terms."
+  "feat_glossary_body": "Terms in What's-New and coachmarks now have a dashed underline — hover or tap to see what they mean, with a Wikipedia link for industry-standard terms.",
+  "feat_task_autopilot_title": "Per-task Autopilot override",
+  "feat_task_autopilot_body": "The New Task dialog now has an \"Autopilot to PR\" checkbox. It starts from the repo's Autopilot setting, but you can turn it off for a single task you'd rather discuss and approve step by step — without changing the repo-wide default."
 }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -261,9 +261,9 @@ describe("NewTask plan-gate inheritance", () => {
     mockGetRepoConfig.mockReturnValue(d.promise);
     render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: repoPath } });
 
-    // in flight: disabled + loading hint
+    // in flight: disabled + loading hint (both gate + autopilot show it, so match the first)
     await expect.poll(() => planGateBox().disabled).toBe(true);
-    await expect.element(page.getByText(m.common_loading())).toBeInTheDocument();
+    await expect.element(page.getByText(m.common_loading()).first()).toBeInTheDocument();
 
     d.resolve(repoConfig(true));
     await expect.poll(() => planGateBox().disabled).toBe(false);
@@ -287,6 +287,51 @@ describe("NewTask plan-gate inheritance", () => {
     await fillAndSubmit();
     await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
     expect(onsubmit.mock.calls[0]![0]).toMatchObject({ planGateEnabled: null });
+  });
+});
+
+describe("NewTask autopilot override", () => {
+  const autopilotBox = () =>
+    Array.from(document.querySelectorAll<HTMLInputElement>(".plan-gate input")).find((el) =>
+      el.closest("label")?.textContent?.includes(m.newtask_autopilot_label()),
+    )!;
+  const submitBtn = () => document.querySelector<HTMLButtonElement>("button.run")!;
+
+  async function fillAndSubmit() {
+    const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    promptField.value = "do the thing";
+    promptField.dispatchEvent(new Event("input", { bubbles: true }));
+    await expect.poll(() => submitBtn().disabled).toBe(false);
+    submitBtn().click();
+  }
+
+  it("submits autopilotEnabled:null when untouched (inherits the repo default)", async () => {
+    const repoPath = "/repo/ap-untouched";
+    mockGetRepoConfig.mockResolvedValue({ ...repoConfig(false), autopilotEnabled: true });
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    // box mirrors the autopilot-ON default once config settles
+    await expect.poll(() => autopilotBox().checked).toBe(true);
+    await fillAndSubmit();
+
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({ autopilotEnabled: null });
+  });
+
+  it("submits explicit false when the user unticks an autopilot-ON repo", async () => {
+    const repoPath = "/repo/ap-opt-out";
+    mockGetRepoConfig.mockResolvedValue({ ...repoConfig(false), autopilotEnabled: true });
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => autopilotBox().checked).toBe(true);
+    autopilotBox().click(); // untick → explicit opt-out for this task
+    expect(autopilotBox().checked).toBe(false);
+    await fillAndSubmit();
+
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({ autopilotEnabled: false });
   });
 });
 

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -333,6 +333,16 @@ describe("NewTask autopilot override", () => {
     await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
     expect(onsubmit.mock.calls[0]![0]).toMatchObject({ autopilotEnabled: false });
   });
+
+  it("hides the checkbox in relaunch mode (relaunch carries the original's value)", async () => {
+    const repoPath = "/repo/ap-relaunch";
+    mockGetRepoConfig.mockResolvedValue({ ...repoConfig(false), autopilotEnabled: true });
+    render(NewTask, { props: base({ relaunch: true, initialRepoPath: repoPath }) });
+
+    // plan-gate still renders in relaunch (it IS overridable); autopilot does not
+    await expect.poll(() => document.querySelector(".plan-gate")).toBeTruthy();
+    expect(autopilotBox()).toBeUndefined();
+  });
 });
 
 describe("NewTask research toggle", () => {

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -51,6 +51,7 @@
       images: string[];
       issueRef?: IssueRef;
       planGateEnabled: boolean | null;
+      autopilotEnabled: boolean | null;
       sandboxProfile?: SandboxProfile;
       research: boolean;
     }) => Promise<void> | void;
@@ -107,6 +108,12 @@
   // it. `planGateTouched` pins a manual choice so switching repos doesn't clobber it.
   let planGate = $state(false);
   let planGateTouched = $state(false);
+  // Autopilot override: defaults to the selected repo's stored flag until the user
+  // toggles it. `autopilotTouched` pins a manual choice so switching repos doesn't
+  // clobber it. Lets a single task opt out of "drive autonomously to a PR" — e.g. to
+  // discuss/iterate and approve each step yourself — without changing the repo default.
+  let autopilot = $state(false);
+  let autopilotTouched = $state(false);
   // Research task kind: web research → report PR or issue; mutually exclusive w/ plan-gate.
   let research = $state(false);
   // Per-spawn sandbox override; "default" → omit (inherit the repo's configured profile).
@@ -215,6 +222,15 @@
   $effect(() => {
     // mirror the repo default until the user makes a manual choice
     if (!planGateTouched) planGate = planGateDefault;
+  });
+
+  // Same seed-from-repo-default pattern for the autopilot override.
+  const autopilotDefault = $derived(repoPath ? repoConfig.isAutopilotEnabled(repoPath) : false);
+  const autopilotLoading = $derived(
+    !!repoPath && !autopilotTouched && !repoConfig.isConfigSettled(repoPath),
+  );
+  $effect(() => {
+    if (!autopilotTouched) autopilot = autopilotDefault;
   });
 
   // Effective default model = repo override (if not "inherit") → global default → promo.
@@ -409,6 +425,7 @@
             }
           : undefined,
         planGateEnabled: planGateTouched ? planGate : null,
+        autopilotEnabled: autopilotTouched ? autopilot : null,
         sandboxProfile: sandboxProfile === "default" ? undefined : sandboxProfile,
         research,
       });
@@ -614,6 +631,21 @@
           <span class="pg-label">{m.newtask_plan_gate_label()}</span>
           <span class="pg-hint">
             {planGateLoading ? m.common_loading() : m.newtask_plan_gate_hint()}
+          </span>
+        </span>
+      </label>
+
+      <label class="plan-gate" use:coachTarget={"task-autopilot"}>
+        <input
+          type="checkbox"
+          bind:checked={autopilot}
+          onchange={() => (autopilotTouched = true)}
+          disabled={autopilotLoading}
+        />
+        <span class="pg-text">
+          <span class="pg-label">{m.newtask_autopilot_label()}</span>
+          <span class="pg-hint">
+            {autopilotLoading ? m.common_loading() : m.newtask_autopilot_hint()}
           </span>
         </span>
       </label>

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -635,20 +635,26 @@
         </span>
       </label>
 
-      <label class="plan-gate" use:coachTarget={"task-autopilot"}>
-        <input
-          type="checkbox"
-          bind:checked={autopilot}
-          onchange={() => (autopilotTouched = true)}
-          disabled={autopilotLoading}
-        />
-        <span class="pg-text">
-          <span class="pg-label">{m.newtask_autopilot_label()}</span>
-          <span class="pg-hint">
-            {autopilotLoading ? m.common_loading() : m.newtask_autopilot_hint()}
+      <!-- Relaunch intentionally CARRIES the original session's autopilot value
+           (server-side, src/service.ts relaunch()), so RelaunchOverrides has no
+           autopilotEnabled field and the override wouldn't take effect here.
+           Hide the control in relaunch so it never implies an override it can't honor. -->
+      {#if !relaunch}
+        <label class="plan-gate" use:coachTarget={"task-autopilot"}>
+          <input
+            type="checkbox"
+            bind:checked={autopilot}
+            onchange={() => (autopilotTouched = true)}
+            disabled={autopilotLoading}
+          />
+          <span class="pg-text">
+            <span class="pg-label">{m.newtask_autopilot_label()}</span>
+            <span class="pg-hint">
+              {autopilotLoading ? m.common_loading() : m.newtask_autopilot_hint()}
+            </span>
           </span>
-        </span>
-      </label>
+        </label>
+      {/if}
 
       <label class="plan-gate">
         <input

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -890,4 +890,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_glossary_title",
     bodyKey: "feat_glossary_body",
   },
+  {
+    // targetId "task-autopilot" anchors the coachmark on the per-task Autopilot
+    // checkbox in the New Task dialog. 1.31.0 is the latest released tag, so this
+    // ships in 1.32.0.
+    id: "task-autopilot-override",
+    sinceVersion: "1.32.0",
+    titleKey: "feat_task_autopilot_title",
+    bodyKey: "feat_task_autopilot_body",
+    targetId: "task-autopilot",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1087,6 +1087,7 @@
     images: string[];
     issueRef?: IssueRef;
     planGateEnabled: boolean | null;
+    autopilotEnabled: boolean | null;
     sandboxProfile?: SandboxProfile;
     research: boolean;
   }) {


### PR DESCRIPTION
## Was & Warum

Die repo-weite **Autopilot**-Einstellung (Aufgabe autonom bis zum PR durchziehen) gilt für alle Aufgaben eines Repos. Manchmal will man aber eine *einzelne* Aufgabe lieber gemeinsam besprechen, iterieren und selbst freigeben — ohne den repo-weiten Standard umzuschalten.

Dieser PR ergänzt im **Neue-Aufgabe-Dialog** eine Checkbox **„Autopilot bis zum PR"** neben Plan-Gate und Recherche. Sie ist mit der Autopilot-Einstellung des gewählten Repos vorbelegt und lässt sich pro Aufgabe überschreiben:

- **Repo hat Autopilot AN** → Box ist angehakt; abhaken ⇒ diese eine Aufgabe stoppt für deine Freigabe (genau der gewünschte Fall).
- **Repo hat Autopilot AUS** → Box leer; anhaken ⇒ diese eine Aufgabe zieht autonom bis zum PR durch.

## Umsetzung

Server, Validierung, Service und `effectiveAutopilot` akzeptierten den Tri-State `CreateInput.autopilotEnabled` (`null` = Repo-Default erben) **bereits vollständig** — die per-Session-Override-Maschinerie existiert schon. Dieser PR verdrahtet nur das UI-Control + die Payload und spiegelt dabei 1:1 das bestehende Plan-Gate-Muster (Seed vom Repo-Default, `touched` pinnt eine manuelle Wahl):

- `NewTask.svelte`: Checkbox + `autopilot`/`autopilotTouched`-State, `autopilotDefault`/`autopilotLoading` derived, Payload `autopilotEnabled: autopilotTouched ? autopilot : null`.
- `+page.svelte`: `autopilotEnabled` im `onsubmit`-Typ (fließt via `createSession` durch `CreateInput`).
- EN/DE-Messages, Feature-Catalog-Eintrag (`1.32.0`, Coachmark-Target `task-autopilot`).
- Tests: erbt-(null) und expliziter-Opt-out-(false)-Fall.

## Verifikation

- `cd ui && bun run check` (svelte-check 0 Fehler) · `check:i18n` (Parität) · `check-glossary` · `check-feature-catalog` — grün
- UI-Tests: **1318 passed** (inkl. 2 neue) · Extension: 81 · Root: 3063/0 fail
- Branch linear off main

[no-feature-entry]-Opt-out wird **nicht** genutzt — Catalog-Eintrag liegt bei.