### PR TITLE
feat(newtask): info tooltips for run options + visible repo autopilot default

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -542,6 +542,9 @@
   "newtask_plan_gate_hint": "Plan vor dem Agentenlauf prüfen + kontradiktorisch hinterfragen",
   "newtask_autopilot_label": "Autopilot bis zum PR",
   "newtask_autopilot_hint": "Diese Aufgabe autonom bis zum PR durchziehen. Aus, um mitzudiskutieren, zu iterieren und jeden Schritt selbst freizugeben. Übernimmt standardmäßig die Autopilot-Einstellung des Repos.",
+  "newtask_autopilot_repo_default_on": "Repo-Standard: an",
+  "newtask_autopilot_repo_default_off": "Repo-Standard: aus",
+  "newtask_info_aria": "Erklärung: {topic}",
   "plangate_planning": "PLANUNG",
   "plangate_reviewing": "PRÜFUNG…",
   "plangate_changes": "REWORK · {round}/{cap}",
@@ -1331,5 +1334,7 @@
   "feat_glossary_title": "Glossar-Tooltips",
   "feat_glossary_body": "Begriffe in What's-New und Coachmarks sind jetzt gestrichelt unterstrichen — fahre darüber oder tippe, um die Bedeutung zu sehen, mit Wikipedia-Link für Fachbegriffe.",
   "feat_task_autopilot_title": "Autopilot-Override pro Aufgabe",
-  "feat_task_autopilot_body": "Der Dialog „Neue Aufgabe“ hat jetzt eine Checkbox „Autopilot bis zum PR“. Sie startet mit der Autopilot-Einstellung des Repos, lässt sich aber für eine einzelne Aufgabe ausschalten, die du lieber Schritt für Schritt besprechen und freigeben möchtest — ohne den repoweiten Standard zu ändern."
+  "feat_task_autopilot_body": "Der Dialog „Neue Aufgabe“ hat jetzt eine Checkbox „Autopilot bis zum PR“. Sie startet mit der Autopilot-Einstellung des Repos, lässt sich aber für eine einzelne Aufgabe ausschalten, die du lieber Schritt für Schritt besprechen und freigeben möchtest — ohne den repoweiten Standard zu ändern.",
+  "feat_newtask_infotips_title": "Aufgeräumtere Erklärungen der Aufgaben-Optionen",
+  "feat_newtask_infotips_body": "Plan-Gate, Autopilot bis zum PR und Recherche-Aufgabe haben jetzt je ein kleines „i“ — mit Maus drüberfahren (oder am Handy antippen), um zu lesen, was es tut, statt eines Absatzes, der den Dialog vollstopft. Bei Autopilot steht direkt daneben der Repo-Standard, damit klar ist, wie das Repo es normalerweise handhabt, bevor du es für eine einzelne Aufgabe änderst."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -542,6 +542,9 @@
   "newtask_plan_gate_hint": "Grill + adversarial review before the agent runs",
   "newtask_autopilot_label": "Autopilot to PR",
   "newtask_autopilot_hint": "Drive this task autonomously through to a PR. Turn off to discuss, iterate and approve each step yourself. Defaults to this repo's Autopilot setting.",
+  "newtask_autopilot_repo_default_on": "Repo default: on",
+  "newtask_autopilot_repo_default_off": "Repo default: off",
+  "newtask_info_aria": "Explain: {topic}",
   "plangate_planning": "PLANNING",
   "plangate_reviewing": "REVIEWING…",
   "plangate_changes": "REWORK · {round}/{cap}",
@@ -1331,5 +1334,7 @@
   "feat_glossary_title": "Glossary tooltips",
   "feat_glossary_body": "Terms in What's-New and coachmarks now have a dashed underline — hover or tap to see what they mean, with a Wikipedia link for industry-standard terms.",
   "feat_task_autopilot_title": "Per-task Autopilot override",
-  "feat_task_autopilot_body": "The New Task dialog now has an \"Autopilot to PR\" checkbox. It starts from the repo's Autopilot setting, but you can turn it off for a single task you'd rather discuss and approve step by step — without changing the repo-wide default."
+  "feat_task_autopilot_body": "The New Task dialog now has an \"Autopilot to PR\" checkbox. It starts from the repo's Autopilot setting, but you can turn it off for a single task you'd rather discuss and approve step by step — without changing the repo-wide default.",
+  "feat_newtask_infotips_title": "Tidier task-option explanations",
+  "feat_newtask_infotips_body": "Plan gate, Autopilot to PR, and Research task each got a small \"i\" — hover (or tap on mobile) to read what it does, instead of a paragraph crowding the dialog. Autopilot also shows the repo's standing default right beside it, so it's clear how the repo normally handles it before you change it for one task."
 }

--- a/ui/src/lib/components/InfoTip.svelte
+++ b/ui/src/lib/components/InfoTip.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+  import { anchorPopover } from "$lib/floating-anchor";
+
+  // A small circular "i" affordance that reveals an explanation in a floating
+  // tooltip — opens above the icon on hover/focus (fine pointer) and tap-toggles
+  // on touch (coarse pointer). Reuses the native-popover + Floating UI pattern
+  // from GlossaryTerm so the explanation escapes overflow-clipped containers and
+  // never reserves vertical space inline (the point: keep dense forms compact,
+  // especially on phones). Text-only content — no interactive children — so it is
+  // a non-blocking role="tooltip" and warrants no scrim (exempt per CLAUDE.md).
+  let { text, label }: { text: string; label: string } = $props();
+
+  // SSR-stable, per-instance id for the aria-describedby wiring.
+  const tooltipId = $props.id();
+
+  let open = $state(false);
+  let btnEl = $state<HTMLButtonElement | null>(null);
+  let popEl = $state<HTMLElement | null>(null);
+
+  function isCoarse(): boolean {
+    return typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches;
+  }
+
+  // Position the popover above the button whenever open + both elements exist.
+  $effect(() => {
+    if (!open || !btnEl || !popEl) return;
+    try {
+      popEl.showPopover();
+    } catch {
+      return; // not connected this tick — effect re-runs once popEl mounts
+    }
+    return anchorPopover(btnEl, popEl, 6, "top");
+  });
+
+  // Dismiss on Esc, outside pointerdown, and scroll/resize. Listener attach is
+  // deferred one tick so the opening tap doesn't immediately close it.
+  $effect(() => {
+    if (!open) return;
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") open = false;
+    }
+    function onPointerdown(e: PointerEvent) {
+      if (
+        popEl &&
+        !popEl.contains(e.target as Node) &&
+        btnEl &&
+        !btnEl.contains(e.target as Node)
+      ) {
+        open = false;
+      }
+    }
+    function onScrollOrResize() {
+      open = false;
+    }
+    const tid = setTimeout(() => {
+      window.addEventListener("keydown", onKeydown);
+      window.addEventListener("pointerdown", onPointerdown);
+      window.addEventListener("scroll", onScrollOrResize, { capture: true, passive: true });
+      window.addEventListener("resize", onScrollOrResize, { passive: true });
+    }, 0);
+    return () => {
+      clearTimeout(tid);
+      window.removeEventListener("keydown", onKeydown);
+      window.removeEventListener("pointerdown", onPointerdown);
+      window.removeEventListener("scroll", onScrollOrResize, { capture: true });
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  });
+
+  // Desktop (fine pointer): hover/focus open, immediate close on leave/blur — the
+  // tooltip carries no interactive children, so no hover-bridge grace is needed.
+  function onPointerenter(e: PointerEvent) {
+    if (e.pointerType === "touch") return;
+    open = true;
+  }
+  function onPointerleave(e: PointerEvent) {
+    if (e.pointerType === "touch") return;
+    open = false;
+  }
+  function onFocus() {
+    if (isCoarse()) return;
+    open = true;
+  }
+  function onBlur() {
+    if (isCoarse()) return;
+    open = false;
+  }
+
+  // Touch (coarse pointer): tap-toggle. Stop propagation so a tap on the icon
+  // inside a <label> doesn't also toggle the checkbox the label wraps.
+  function onClick(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!isCoarse()) return;
+    open = !open;
+  }
+</script>
+
+<button
+  bind:this={btnEl}
+  class={["info", { open }]}
+  type="button"
+  aria-label={label}
+  aria-describedby={tooltipId}
+  onpointerenter={onPointerenter}
+  onpointerleave={onPointerleave}
+  onfocus={onFocus}
+  onblur={onBlur}
+  onclick={onClick}
+>
+  <span aria-hidden="true">i</span>
+</button>
+
+<!-- popover="manual": native top-layer, escapes overflow:hidden containers.
+     position:fixed + inset:auto + margin:0 so Floating UI's left/top drive placement. -->
+<div id={tooltipId} bind:this={popEl} class="info-tooltip" role="tooltip" popover="manual">
+  {text}
+</div>
+
+<style>
+  /* Clickable "ⓘ" — matches the AutomationPanel `.info` affordance. */
+  .info {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 15px;
+    height: 15px;
+    padding: 0;
+    border: 1px solid var(--color-line);
+    border-radius: 50%;
+    background: transparent;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    font-style: italic;
+    line-height: 1;
+    cursor: help;
+    touch-action: manipulation;
+    transition:
+      color 0.12s,
+      border-color 0.12s;
+  }
+  .info:hover,
+  .info.open {
+    color: var(--color-ink-bright);
+    border-color: var(--color-faint);
+  }
+  .info:focus-visible {
+    outline: 2px solid var(--color-line-bright);
+    outline-offset: 2px;
+  }
+
+  /* Top-layer popover positioning: fixed + inset:auto + margin:0 lets Floating UI
+     drive left/top without fighting browser default centering. */
+  [popover].info-tooltip {
+    position: fixed;
+    inset: auto;
+    margin: 0;
+    width: min(260px, 90vw);
+    padding: 8px 10px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    color: var(--color-ink);
+    font: inherit;
+    font-size: var(--fs-meta);
+    line-height: 1.5;
+  }
+
+  /* Entrance animation. The global blanket in app.css suppresses this under
+     prefers-reduced-motion via animation:none !important — no extra rule needed. */
+  @keyframes info-in {
+    from {
+      opacity: 0;
+      transform: translateY(3px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  [popover].info-tooltip:popover-open {
+    animation: info-in 120ms ease-out;
+  }
+</style>

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -22,6 +22,7 @@
   import RepoSelect from "./RepoSelect.svelte";
   import PromptSources from "./PromptSources.svelte";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
+  import InfoTip from "./InfoTip.svelte";
   import { dialog } from "$lib/a11yDialog";
   import { repoConfig } from "$lib/reviews.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
@@ -617,66 +618,90 @@
     <!-- Per-task run settings. Plan gate gets its own full-width row so its explainer
          reads on one line; Model + Sandbox share a 50/50 row beneath. -->
     <div class="opts-row">
-      <label class="plan-gate" use:coachTarget={"plan-gate"}>
-        <input
-          type="checkbox"
-          bind:checked={planGate}
-          onchange={() => {
-            planGateTouched = true;
-            if (planGate) research = false;
-          }}
-          disabled={planGateLoading}
-        />
-        <span class="pg-text">
+      <!-- Each toggle's long explainer now lives behind an InfoTip "i" rather than a
+           wrapped hint paragraph — keeps this stack of options compact, which matters
+           most on the phone sheet. The InfoTip is a sibling of the <label> (not nested
+           inside it) so a tap on the "i" never toggles the checkbox. -->
+      <div class="pg-row">
+        <label class="plan-gate" use:coachTarget={"plan-gate"}>
+          <input
+            type="checkbox"
+            bind:checked={planGate}
+            onchange={() => {
+              planGateTouched = true;
+              if (planGate) research = false;
+            }}
+            disabled={planGateLoading}
+          />
           <span class="pg-label">{m.newtask_plan_gate_label()}</span>
-          <span class="pg-hint">
-            {planGateLoading ? m.common_loading() : m.newtask_plan_gate_hint()}
-          </span>
-        </span>
-      </label>
+        </label>
+        {#if planGateLoading}
+          <span class="pg-loading">{m.common_loading()}</span>
+        {/if}
+        <InfoTip
+          text={m.newtask_plan_gate_hint()}
+          label={m.newtask_info_aria({ topic: m.newtask_plan_gate_label() })}
+        />
+      </div>
 
       <!-- Relaunch intentionally CARRIES the original session's autopilot value
            (server-side, src/service.ts relaunch()), so RelaunchOverrides has no
            autopilotEnabled field and the override wouldn't take effect here.
            Hide the control in relaunch so it never implies an override it can't honor. -->
       {#if !relaunch}
-        <label class="plan-gate" use:coachTarget={"task-autopilot"}>
-          <input
-            type="checkbox"
-            bind:checked={autopilot}
-            onchange={() => (autopilotTouched = true)}
-            disabled={autopilotLoading}
-          />
-          <span class="pg-text">
+        <div class="pg-row">
+          <label class="plan-gate" use:coachTarget={"task-autopilot"}>
+            <input
+              type="checkbox"
+              bind:checked={autopilot}
+              onchange={() => (autopilotTouched = true)}
+              disabled={autopilotLoading}
+            />
             <span class="pg-label">{m.newtask_autopilot_label()}</span>
-            <span class="pg-hint">
-              {autopilotLoading ? m.common_loading() : m.newtask_autopilot_hint()}
+          </label>
+          <!-- The repo's standing default, shown alongside so it's clear how this repo
+               normally handles it — the checkbox is seeded from it on open, so unchecking
+               here is a visible, deliberate opt-out for this one task. -->
+          {#if autopilotLoading}
+            <span class="pg-loading">{m.common_loading()}</span>
+          {:else if repoPath}
+            <span class="repo-default" class:on={autopilotDefault}>
+              {autopilotDefault
+                ? m.newtask_autopilot_repo_default_on()
+                : m.newtask_autopilot_repo_default_off()}
             </span>
-          </span>
-        </label>
+          {/if}
+          <InfoTip
+            text={m.newtask_autopilot_hint()}
+            label={m.newtask_info_aria({ topic: m.newtask_autopilot_label() })}
+          />
+        </div>
       {/if}
 
-      <label class="plan-gate">
-        <input
-          type="checkbox"
-          bind:checked={research}
-          onchange={() => {
-            if (research) {
-              planGate = false;
-              // pin touched so a later repo switch doesn't re-seed/re-enable plan-gate while research is active
-              planGateTouched = true;
-              autopilot = false;
-              // pin touched so a later repo switch doesn't re-seed/re-enable autopilot while research is active
-              autopilotTouched = true;
-              if (sandboxProfile === "autonomous") sandboxProfile = "default";
-            }
-          }}
-        />
-        <span class="pg-text">
+      <div class="pg-row">
+        <label class="plan-gate">
+          <input
+            type="checkbox"
+            bind:checked={research}
+            onchange={() => {
+              if (research) {
+                planGate = false;
+                // pin touched so a later repo switch doesn't re-seed/re-enable plan-gate while research is active
+                planGateTouched = true;
+                autopilot = false;
+                // pin touched so a later repo switch doesn't re-seed/re-enable autopilot while research is active
+                autopilotTouched = true;
+                if (sandboxProfile === "autonomous") sandboxProfile = "default";
+              }
+            }}
+          />
           <span class="pg-label">{m.newtask_research_label()}</span>
-          <span class="pg-hint">{m.newtask_research_hint()}</span>
-        </span>
-      </label>
+        </label>
+        <InfoTip
+          text={m.newtask_research_hint()}
+          label={m.newtask_info_aria({ topic: m.newtask_research_label() })}
+        />
+      </div>
 
       <div class="run-config">
         <div class="model-field">
@@ -842,12 +867,41 @@
     gap: 12px;
     margin-top: 10px;
   }
+  /* One toggle: the label (checkbox + name) plus its trailing InfoTip / repo-default
+     badge, laid out on a single baseline-centered line. */
+  .pg-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
   .plan-gate {
     min-width: 0;
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 8px;
     cursor: pointer;
+  }
+  .pg-loading {
+    flex: 0 0 auto;
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+  }
+  /* Standing repo default for autopilot — a quiet pill; amber when "on" to echo the
+     checkbox accent (green is reserved for actionable-complete per the design system). */
+  .repo-default {
+    flex: 0 0 auto;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.04em;
+    color: var(--color-muted);
+    border: 1px solid var(--color-line);
+    border-radius: 999px;
+    padding: 1px 8px;
+    white-space: nowrap;
+  }
+  .repo-default.on {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
   }
   .run-config {
     display: flex;
@@ -866,19 +920,12 @@
   }
   .plan-gate input {
     width: auto;
-    margin-top: 2px;
     flex: 0 0 auto;
     accent-color: var(--color-amber);
   }
   .plan-gate:has(input:disabled) {
     cursor: progress;
     opacity: 0.6;
-  }
-  .pg-text {
-    display: flex;
-    flex-direction: column;
-    gap: 1px;
-    min-width: 0;
   }
   .pg-label {
     color: var(--color-ink-bright);

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -900,4 +900,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_task_autopilot_body",
     targetId: "task-autopilot",
   },
+  {
+    // targetId "task-autopilot" anchors the coachmark on the Autopilot row in the New
+    // Task dialog, where the new "i" tooltips and the repo-default badge live. 1.31.0
+    // is the latest released tag, so this ships in 1.32.0.
+    id: "newtask-option-infotips",
+    sinceVersion: "1.32.0",
+    titleKey: "feat_newtask_infotips_title",
+    bodyKey: "feat_newtask_infotips_body",
+    targetId: "task-autopilot",
+  },
 ];

--- a/ui/src/lib/floating-anchor.ts
+++ b/ui/src/lib/floating-anchor.ts
@@ -1,14 +1,21 @@
-import { autoUpdate, computePosition, flip, offset, shift } from "@floating-ui/dom";
+import { autoUpdate, computePosition, flip, offset, type Placement, shift } from "@floating-ui/dom";
 
-// Anchor a native `popover` floating element under a reference element, keeping it
-// positioned on scroll / resize / movement via Floating UI autoUpdate. Returns a
+// Anchor a native `popover` floating element relative to a reference element, keeping
+// it positioned on scroll / resize / movement via Floating UI autoUpdate. Returns a
 // cleanup that stops autoUpdate and hides the popover — call it from an $effect
-// teardown. Shared by Coachmark and GlossaryTerm so the position loop + teardown
-// live in one place rather than being duplicated per popover component.
-export function anchorPopover(reference: HTMLElement, floating: HTMLElement, gap = 8): () => void {
+// teardown. Shared by Coachmark, GlossaryTerm, and InfoTip so the position loop +
+// teardown live in one place rather than being duplicated per popover component.
+// `placement` defaults to "bottom"; `flip()` still re-homes it to the opposite side
+// when the preferred side lacks room.
+export function anchorPopover(
+  reference: HTMLElement,
+  floating: HTMLElement,
+  gap = 8,
+  placement: Placement = "bottom",
+): () => void {
   const stop = autoUpdate(reference, floating, () => {
     computePosition(reference, floating, {
-      placement: "bottom",
+      placement,
       middleware: [offset(gap), flip(), shift({ padding: 8 })],
     }).then(({ x, y }) => {
       floating.style.left = x + "px";


### PR DESCRIPTION
## Was & warum

Im **Neue-Aufgabe**-Dialog nahmen die Erklärungsabsätze unter jeder Option (Plan-Gate, Autopilot bis zum PR, Recherche-Aufgabe) viel Platz weg — besonders auf dem Handy-Sheet. Außerdem war nicht sichtbar, wie das Repo den Autopilot standardmäßig handhabt.

## Änderungen

- **Erklärungen hinter ein „i“ verschoben.** Neue, wiederverwendbare `InfoTip.svelte`: kleines kreisförmiges „i“ neben jedem Options-Label. Tooltip öffnet **über** dem Icon — Hover/Fokus am Desktop, Tap-Toggle auf Touch (Esc / Außenklick / Scroll schließen). Der Options-Stack bleibt dadurch kompakt. Reuse des bewährten Native-Popover-+-Floating-UI-Musters von `GlossaryTerm`.
- **Repo-Standard sichtbar.** Neben „Autopilot bis zum PR“ steht jetzt ein leiser Pill „Repo-Standard: an/aus“ (bernsteinfarben bei „an“), damit klar ist, wie das Repo es normalerweise handhabt, bevor man es für eine einzelne Aufgabe abwählt.
- Die Checkbox wird (wie bisher) aus dem Repo-Standard geseedet — neu ist nur, dass dieser Seed jetzt sichtbar ist. Ist der Repo-Standard „an“, ist die Checkbox beim Öffnen angehakt.
- `anchorPopover()` um ein optionales `placement` erweitert (Default unverändert `"bottom"`), damit der Tip oberhalb seines Triggers sitzen kann.
- EN+DE Message-Keys ergänzt; Feature-Announcement-Eintrag (`newtask-option-infotips`, 1.32.0) hinzugefügt.

## Verifiziert

Lokal per Playwright gegen den laufenden Dev-Server geprüft:
- Desktop-Hover → Tooltip öffnet über dem „i“.
- Mobile-Tap → Tooltip toggelt, ohne die Checkbox umzuschalten.
- „Autopilot bis zum PR“ zeigt „Repo-Standard: an“ und ist beim Öffnen angehakt (Repo `shepherd` hat Autopilot standardmäßig an).

`bun run check` (0 Fehler), `check:i18n` (Parität), Glossar-Gate und Pre-Push-Hygiene grün.
