### PR TITLE
feat: in-app DIAGNOSE one-click Fix + keystone src/remediations.ts (#703)

### DIFF
--- a/ci/onboarding-harness/apply.ts
+++ b/ci/onboarding-harness/apply.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { IncusDriver } from "./incus";
-import { remediationsFor } from "./remediations";
+import { remediationsFor } from "../../src/remediations";
 import type { DiagnosticsSnapshot } from "../../src/types";
 
 export interface CoachingLine {

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -10,7 +10,7 @@ import { applyAgent, applyVerbatim } from "./apply";
 import { assertDetection } from "./assert";
 import { buildGapReport, statusDescription } from "./report";
 import { reportToGitHub, publishStatus } from "./issue";
-import { remediationsFor } from "./remediations";
+import { remediationsFor } from "../../src/remediations";
 import type { DetectionResult, Scenario, ScenarioResult } from "./types";
 
 /** `git archive` the current HEAD into a tarball the seed engine pushes. */

--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -10,7 +10,7 @@ import type { Scenario } from "./types";
  *  - **Green-able** — the seeded defect can be coached back to `ok` unattended.
  *    `coaching: "structured"` uses the deterministic verbatim-remediation path
  *    (LLM-free, release-gate-eligible) and MUST have a matching REMEDIATIONS entry
- *    in remediations.ts; `coaching: "prose"` uses the agent path (e.g. git, whose
+ *    in src/remediations.ts; `coaching: "prose"` uses the agent path (e.g. git, whose
  *    install is distro-specific with no single one-liner — the agent picks apt/
  *    apk/dnf). Success = the scenario's expected checks are `ok` after the apply.
  *  - **Detection-only** (`detectionOnly: true`) — the defect is detectable but its

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,11 @@ export const DIAGNOSTICS_TTL_MS = 60_000;
 // Per-probe exec timeout: a timed-out probe RESOLVES to its defined non-OK state
 // (never rejects the Promise.all), so one hung binary can't stall the batch.
 export const DIAGNOSTICS_PROBE_TIMEOUT_MS = 5_000;
+// Time budget for an in-app remediation command (POST /api/diagnostics/fix). Far
+// larger than a probe — these are real `curl | bash` installs. On timeout the whole
+// process GROUP is SIGKILLed (see diagnostics.ts runRemediation) so no reparented
+// grandchild survives to flip a later probe green behind a reported failure.
+export const REMEDIATION_TIMEOUT_MS = 120_000;
 // module-local seed defaults, used by the config seeds + boot-override fallbacks only.
 const PR_REVIEW_CYCLES_DEFAULT = 3;
 const PLAN_REVIEW_CYCLES_DEFAULT = 5;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import {
   BUN_MIN_VERSION,
@@ -6,10 +6,12 @@ import {
   DIAGNOSTICS_TTL_MS,
   HERDR_MIN_VERSION,
   NODE_MIN_VERSION,
+  REMEDIATION_TIMEOUT_MS,
   config,
   findServedPort,
 } from "./config";
 import { compareSemver } from "./herdr-update";
+import { autoFixCommandFor } from "./remediations";
 import { resolveNodeHost } from "./tailscale";
 import type { DiagnosticCheck, DiagnosticsSnapshot, DiagnosticState } from "./types";
 
@@ -39,6 +41,10 @@ export interface DiagnosticsDeps {
    *  `findServedPort`. Both a direct `tailscale serve` mapping and a Tailscale
    *  Service mapping are detected. Reject ⇒ treated as "not serving". */
   runServeStatus?: () => Promise<string>;
+  /** Run a verbatim remediation command (a shell pipeline like `curl … | bash`).
+   *  Resolves on exit 0; rejects on non-zero exit or timeout. Default spawns a
+   *  detached process group and SIGKILLs the whole group on timeout. Injected in tests. */
+  runRemediation?: (cmd: string) => Promise<void>;
 }
 
 /** A single probe: an async fn returning ONLY `{ id, state, hintKey }`. */
@@ -53,6 +59,50 @@ function worstOf(checks: DiagnosticCheck[]): DiagnosticState {
     if (STATE_RANK[c.state] > STATE_RANK[worst]) worst = c.state;
   }
   return worst;
+}
+
+/** Cap on drained child output: just enough to keep a noisy `curl | bash` install
+ *  from blocking on a full pipe, then dropped. NEVER surfaced to the client. */
+const REMEDIATION_DRAIN_CAP = 1 << 20; // 1 MiB
+
+/** Default `runRemediation`: spawn the verbatim command in its OWN process group
+ *  (`detached`), drain stdout/stderr into a bounded sink (so a noisy install can't
+ *  ENOBUFS or block on a full pipe), and SIGKILL the whole group on timeout. Resolves
+ *  on exit 0, rejects otherwise — the rejection message is generic (no captured
+ *  output / paths / identity ever reaches the caller). */
+function defaultRunRemediation(cmd: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn("sh", ["-c", cmd], { detached: true });
+    let drained = 0;
+    const drain = (chunk: Buffer) => {
+      if (drained < REMEDIATION_DRAIN_CAP) drained += chunk.length; // count then drop
+    };
+    child.stdout?.on("data", drain);
+    child.stderr?.on("data", drain);
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      try {
+        process.kill(-child.pid!, "SIGKILL"); // negative pid ⇒ kill the whole group
+      } catch {
+        /* group already gone */
+      }
+      reject(new Error("remediation timed out"));
+    }, REMEDIATION_TIMEOUT_MS);
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code === 0) resolve();
+      else reject(new Error(`remediation exited ${code}`));
+    });
+  });
 }
 
 /**
@@ -74,6 +124,7 @@ export class DiagnosticsService {
   private runGhAuth: () => Promise<void>;
   private resolveHost: () => Promise<string | null>;
   private runServeStatus: () => Promise<string>;
+  private runRemediation: (cmd: string) => Promise<void>;
   private last: DiagnosticsSnapshot | null = null;
   private lastAt = 0;
 
@@ -106,6 +157,7 @@ export class DiagnosticsService {
         });
         return stdout.toString();
       });
+    this.runRemediation = deps.runRemediation ?? defaultRunRemediation;
   }
 
   /** Parse a (major.minor.patch) out of arbitrary `--version` output; null if none. */
@@ -257,6 +309,14 @@ export class DiagnosticsService {
     const checks = await Promise.all(
       this.probes().map(({ run, onTimeout }) => run().catch(() => onTimeout)),
     );
+    // Annotate each non-ok, auto-fixable check with its verbatim Fix command. Only
+    // attach the key when a command exists (guidance-only / ok stay absent), so
+    // payload-purity expectations hold.
+    for (const c of checks) {
+      if (c.state === "ok") continue;
+      const cmd = autoFixCommandFor(c.hintKey);
+      if (cmd) c.remediation = cmd;
+    }
     const snapshot: DiagnosticsSnapshot = {
       checks,
       generatedAt: now,
@@ -273,5 +333,19 @@ export class DiagnosticsService {
       return Promise.resolve(this.last);
     }
     return this.check(now);
+  }
+
+  /** Run the verbatim remediation for `checkId`'s current hintKey, then force a fresh
+   *  probe and return the new snapshot. Throws if the check is unknown or has no
+   *  auto-fix command (guidance-only / prose-only). A failing command REJECTS
+   *  (fail-closed) — the caller maps that to an explicit failure, never a false pass. */
+  async fix(checkId: string, now: number): Promise<DiagnosticsSnapshot> {
+    const snapshot = await this.current(now);
+    const check = snapshot.checks.find((c) => c.id === checkId);
+    if (!check) throw new Error(`unknown check ${checkId}`);
+    const cmd = autoFixCommandFor(check.hintKey);
+    if (!cmd) throw new Error(`no remediation for ${checkId}`);
+    await this.runRemediation(cmd); // rejection propagates → fail closed
+    return this.check(now); // forced re-probe reflects the fix
   }
 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -69,8 +69,12 @@ const REMEDIATION_DRAIN_CAP = 1 << 20; // 1 MiB
  *  (`detached`), drain stdout/stderr into a bounded sink (so a noisy install can't
  *  ENOBUFS or block on a full pipe), and SIGKILL the whole group on timeout. Resolves
  *  on exit 0, rejects otherwise — the rejection message is generic (no captured
- *  output / paths / identity ever reaches the caller). */
-function defaultRunRemediation(cmd: string): Promise<void> {
+ *  output / paths / identity ever reaches the caller). `timeoutMs` is injectable so
+ *  tests can exercise the timeout/group-kill path without waiting the real budget. */
+export function defaultRunRemediation(
+  cmd: string,
+  timeoutMs: number = REMEDIATION_TIMEOUT_MS,
+): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const child = spawn("sh", ["-c", cmd], { detached: true });
     let drained = 0;
@@ -88,7 +92,7 @@ function defaultRunRemediation(cmd: string): Promise<void> {
         /* group already gone */
       }
       reject(new Error("remediation timed out"));
-    }, REMEDIATION_TIMEOUT_MS);
+    }, timeoutMs);
     child.on("error", (err) => {
       if (settled) return;
       settled = true;

--- a/src/remediations.ts
+++ b/src/remediations.ts
@@ -1,13 +1,12 @@
-import type { DiagnosticsSnapshot } from "../../src/types";
+import type { DiagnosticsSnapshot } from "./types";
 
 /** hintKey → verbatim shell remediation, keyed by the advice identifier Shepherd
- *  emits. Lives in the HARNESS (not the diagnostics payload) so the shipped
- *  DiagnosticCheck contract is unchanged. Only keys whose canonical fix is a
- *  single non-interactive command appear; prose-only coaching (interactive
- *  `gh auth login`, tailscale serve setup) is intentionally absent and stays on
- *  the agent path. Every `coaching: "structured"` scenario must have a matching
- *  entry here — otherwise it silently falls through to the LLM agent path,
- *  breaking the deterministic LLM-free gate guarantee. */
+ *  emits. Shipped product code so three consumers share one source of truth: the
+ *  onboarding harness, the in-app Fix endpoint, and a future cold-start installer.
+ *  The map is keyed by the shipped `hintKey` contract; only deterministically-
+ *  fixable deficiencies get entries. Interactive/secret fixes (`gh auth login`,
+ *  tailscale login/serve) are intentionally absent — they can't run unattended and
+ *  stay on the agent/coaching path. */
 // fnm installs node into its own versions dir (NOT on PATH) and exposes it only
 // via a shell `eval` an `incus exec sh -c` never runs — so a bare `fnm install`
 // leaves the running server still seeing the old node. Reference fnm by absolute
@@ -31,9 +30,27 @@ export const REMEDIATIONS: Record<string, string> = {
   diagnostics_hint_tailscale_missing: "curl -fsSL https://tailscale.com/install.sh | sh",
 };
 
+/** Hints that have a verbatim install command (valid for a future cold-start
+ *  installer) but where running that command never clears the diagnostics check —
+ *  so the in-app Fix surface must treat them as guidance-only, not auto-fix.
+ *
+ *  tailscale is the canonical case: installing the binary leaves `resolveNodeHost`
+ *  null until an interactive tailnet login, so the check stays non-ok. This is the
+ *  in-app analogue of the harness `detectionOnly` split in scenarios.ts. */
+export const GUIDANCE_ONLY: ReadonlySet<string> = new Set(["diagnostics_hint_tailscale_missing"]);
+
 /** Verbatim commands for every non-ok check whose emitted hintKey has a known fix. */
 export function remediationsFor(snapshot: DiagnosticsSnapshot): string[] {
   return snapshot.checks
     .filter((c) => c.state !== "ok" && REMEDIATIONS[c.hintKey])
     .map((c) => REMEDIATIONS[c.hintKey]!);
+}
+
+/** The auto-fix gate for product surfaces (in-app Fix endpoint): the command for a
+ *  hintKey iff one exists AND it actually clears the check when run unattended.
+ *  Guidance-only hints (see GUIDANCE_ONLY) return undefined even though they have a
+ *  REMEDIATIONS entry. `remediationsFor` stays raw/guidance-agnostic for the harness. */
+export function autoFixCommandFor(hintKey: string): string | undefined {
+  if (GUIDANCE_ONLY.has(hintKey)) return undefined;
+  return REMEDIATIONS[hintKey];
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -146,7 +146,7 @@ export interface AppDeps {
   /** herdr-version tracker + applier; absent in environments where it isn't wired. */
   herdrUpdates?: Pick<HerdrUpdateService, "current" | "apply">;
   /** environment-readiness diagnostics (issue #623); absent in tests that don't wire it. */
-  diagnostics?: Pick<DiagnosticsService, "current" | "check">;
+  diagnostics?: Pick<DiagnosticsService, "current" | "check" | "fix">;
   /** GitHub-star nudge: tracks first-use + the operator's choice, stars the repo
    *  via gh. Absent in tests that don't exercise it. */
   starPrompt?: {
@@ -1925,6 +1925,36 @@ async function handleDiagnostics({ req, parts, url, deps }: Ctx): Promise<Respon
   return json(snapshot);
 }
 
+/** POST /api/diagnostics/fix {checkId} → run the verbatim remediation for that
+ *  check server-side (operator's own user), re-probe, and return the fresh snapshot
+ *  (also pushed on `diagnostics:status` so every client + the TopBar pip refresh).
+ *  Fail-closed: an unknown / guidance-only check is 409; a failed/timed-out command
+ *  is 502 — never a 2xx. CSRF/token already enforced by the global request guards. */
+async function handleDiagnosticsFix({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(parts[0] === "api" && parts[1] === "diagnostics" && parts[2] === "fix" && !parts[3])) {
+    return null;
+  }
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+  if (!deps.diagnostics) return json({ error: "diagnostics unavailable" }, 503);
+  const body = (await req.json().catch(() => null)) as { checkId?: string } | null;
+  const checkId = body?.checkId;
+  if (!checkId) return json({ error: "missing checkId" }, 400);
+  let snapshot;
+  try {
+    snapshot = await deps.diagnostics.fix(checkId, Date.now());
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    // unknown check / guidance-only ⇒ not fixable (409); anything else is a failed
+    // or timed-out command (502). Never a 2xx on failure.
+    if (msg.startsWith("unknown check ") || msg.startsWith("no remediation for ")) {
+      return json({ error: msg }, 409);
+    }
+    return json({ error: "remediation failed" }, 502);
+  }
+  deps.events.emit("diagnostics:status", snapshot);
+  return json(snapshot);
+}
+
 /** GET → current "star us on GitHub?" nudge status (safe `{shouldPrompt:false}`
  *  default when the service isn't wired). POST {action} → dismiss / snooze / star. */
 function handleStarPrompt({ req, parts, deps }: Ctx): Response | Promise<Response> | null {
@@ -3505,6 +3535,7 @@ const ROUTE_HANDLERS = [
   handleUpdate,
   handleHerdrUpdate,
   handleDiagnostics,
+  handleDiagnosticsFix,
   handleStarPrompt,
   handleUploads,
   handleRepos,

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,6 +210,11 @@ export interface DiagnosticCheck {
   id: string;
   state: DiagnosticState;
   hintKey: string;
+  /** A non-secret public install command (e.g. "curl -fsSL https://bun.sh/install | bash")
+   *  the operator can one-click-run via POST /api/diagnostics/fix. Set ONLY on non-ok,
+   *  auto-fixable checks (autoFixCommandFor resolved) — never on `ok` checks and never on
+   *  guidance-only ones (tailscale). Still no stdout/tokens/paths/identity ever cross here. */
+  remediation?: string;
 }
 
 /** The full diagnostics payload returned by GET /api/diagnostics and pushed on

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { DiagnosticsService, type DiagnosticsDeps } from "../src/diagnostics";
+import {
+  DiagnosticsService,
+  defaultRunRemediation,
+  type DiagnosticsDeps,
+} from "../src/diagnostics";
 import { DIAGNOSTICS_TTL_MS } from "../src/config";
 import { REMEDIATIONS } from "../src/remediations";
 import type { DiagnosticCheck } from "../src/types";
@@ -463,5 +467,24 @@ describe("DiagnosticsService.fix", () => {
       },
     });
     await expect(svc.fix("bun", 0)).rejects.toThrow("remediation exited 1");
+  });
+});
+
+// The real spawn-based runner — the riskiest code (detached group, timeout SIGKILL,
+// double-settle guard). Exercised here against actual short-lived `sh` commands; the
+// timeout path uses an injected tiny budget so it doesn't wait the real 120s.
+describe("defaultRunRemediation (real spawn)", () => {
+  it("resolves when the command exits 0", async () => {
+    await expect(defaultRunRemediation("exit 0")).resolves.toBeUndefined();
+  });
+
+  it("rejects with the exit code on non-zero exit", async () => {
+    await expect(defaultRunRemediation("exit 3")).rejects.toThrow("remediation exited 3");
+  });
+
+  it("times out and group-kills a long-running command", async () => {
+    // `sleep 30` would outlive the test; the 50ms budget fires the timeout path,
+    // SIGKILLs the process group, and rejects — proving the budget is honored.
+    await expect(defaultRunRemediation("sleep 30", 50)).rejects.toThrow("remediation timed out");
   });
 });

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { DiagnosticsService, type DiagnosticsDeps } from "../src/diagnostics";
 import { DIAGNOSTICS_TTL_MS } from "../src/config";
+import { REMEDIATIONS } from "../src/remediations";
 import type { DiagnosticCheck } from "../src/types";
 
 // ── injected-runner helpers ────────────────────────────────────────────────────
@@ -47,10 +48,15 @@ function byId(checks: DiagnosticCheck[], id: string): DiagnosticCheck {
   return c;
 }
 
-// Probe-payload purity: a check carries EXACTLY id/state/hintKey, nothing else.
+// Probe-payload purity: a check carries id/state/hintKey + (optionally) the
+// non-secret `remediation` command — and NOTHING else (no stdout/tokens/paths).
 function assertPure(check: DiagnosticCheck) {
-  expect(Object.keys(check).sort()).toEqual(["hintKey", "id", "state"]);
+  const allowed = new Set(["hintKey", "id", "remediation", "state"]);
+  for (const k of Object.keys(check)) expect(allowed.has(k)).toBe(true);
+  expect(typeof check.id).toBe("string");
+  expect(typeof check.state).toBe("string");
   expect(typeof check.hintKey).toBe("string");
+  if ("remediation" in check) expect(typeof check.remediation).toBe("string");
 }
 
 describe("DiagnosticsService probes", () => {
@@ -368,5 +374,94 @@ describe("DiagnosticsService TTL caching", () => {
     await svc.check(1000);
     await svc.check(1000); // same `now`, still re-runs
     expect(calls).toBe(2);
+  });
+});
+
+describe("DiagnosticsService remediation annotation", () => {
+  it("check() sets remediation on a non-ok auto-fixable check, absent on ok checks", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runVersion: versionRunner({ ...HEALTHY_VERSIONS, bun: new Error("ENOENT") }),
+    });
+    const snap = await svc.check(0);
+    const bun = byId(snap.checks, "bun");
+    expect(bun.state).toBe("error");
+    expect(bun.remediation).toBe(REMEDIATIONS.diagnostics_hint_bun_missing!);
+    assertPure(bun);
+    // every ok check stays bare (no remediation key)
+    for (const c of snap.checks) {
+      if (c.state === "ok") expect("remediation" in c).toBe(false);
+    }
+  });
+
+  it("check() does NOT set remediation on guidance-only tailscale (even when error)", async () => {
+    const svc = new DiagnosticsService({ ...healthyDeps(), resolveHost: async () => null });
+    const c = byId((await svc.check(0)).checks, "tailscale");
+    expect(c.state).toBe("error");
+    expect(c.hintKey).toBe("diagnostics_hint_tailscale_missing");
+    expect("remediation" in c).toBe(false);
+    assertPure(c);
+  });
+});
+
+describe("DiagnosticsService.fix", () => {
+  it("happy path: runs the verbatim command, re-probes, returns the fresh snapshot", async () => {
+    let installed = false;
+    const calls: string[] = [];
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      // bun missing until the remediation "installs" it, then healthy.
+      runVersion: async (bin, args) => {
+        if (bin === "bun") {
+          if (!installed) throw new Error("ENOENT");
+          return "1.3.10";
+        }
+        return versionRunner({ ...HEALTHY_VERSIONS })!(bin, args);
+      },
+      runRemediation: async (cmd) => {
+        calls.push(cmd);
+        installed = true;
+      },
+    });
+    const snap = await svc.fix("bun", 0);
+    expect(calls).toEqual([REMEDIATIONS.diagnostics_hint_bun_missing!]);
+    const bun = byId(snap.checks, "bun");
+    expect(bun.state).toBe("ok");
+  });
+
+  it("throws for an unknown checkId (runner never called)", async () => {
+    let called = false;
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runRemediation: async () => {
+        called = true;
+      },
+    });
+    await expect(svc.fix("nope", 0)).rejects.toThrow("unknown check nope");
+    expect(called).toBe(false);
+  });
+
+  it("throws for a guidance-only check (tailscale) — runner not called", async () => {
+    let called = false;
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      resolveHost: async () => null, // tailscale → error, hintKey tailscale_missing
+      runRemediation: async () => {
+        called = true;
+      },
+    });
+    await expect(svc.fix("tailscale", 0)).rejects.toThrow("no remediation for tailscale");
+    expect(called).toBe(false);
+  });
+
+  it("propagates a runner rejection (fail-closed)", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runVersion: versionRunner({ ...HEALTHY_VERSIONS, bun: new Error("ENOENT") }),
+      runRemediation: async () => {
+        throw new Error("remediation exited 1");
+      },
+    });
+    await expect(svc.fix("bun", 0)).rejects.toThrow("remediation exited 1");
   });
 });

--- a/test/onboarding-harness/remediations.test.ts
+++ b/test/onboarding-harness/remediations.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { REMEDIATIONS, remediationsFor } from "../../ci/onboarding-harness/remediations";
+import {
+  autoFixCommandFor,
+  GUIDANCE_ONLY,
+  REMEDIATIONS,
+  remediationsFor,
+} from "../../src/remediations";
 import type { DiagnosticsSnapshot } from "../../src/types";
 
 describe("remediations catalog", () => {
@@ -24,5 +29,19 @@ describe("remediations catalog", () => {
       overall: "error",
     };
     expect(remediationsFor(snap)).toEqual([REMEDIATIONS["diagnostics_hint_bun_missing"]!]);
+  });
+
+  it("autoFixCommandFor returns the command for an auto-fixable hintKey", () => {
+    expect(autoFixCommandFor("diagnostics_hint_bun_missing")).toBe(
+      REMEDIATIONS.diagnostics_hint_bun_missing,
+    );
+  });
+
+  it("autoFixCommandFor gates guidance-only hints to undefined even when they have a REMEDIATIONS entry", () => {
+    // tailscale has a verbatim install command but it never clears the check
+    // (needs an interactive tailnet login), so it's guidance-only, not auto-fix.
+    expect(REMEDIATIONS.diagnostics_hint_tailscale_missing).toBeDefined();
+    expect(GUIDANCE_ONLY.has("diagnostics_hint_tailscale_missing")).toBe(true);
+    expect(autoFixCommandFor("diagnostics_hint_tailscale_missing")).toBeUndefined();
   });
 });

--- a/test/server-diagnostics-fix.test.ts
+++ b/test/server-diagnostics-fix.test.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "bun:test";
+import { makeApp, type AppDeps } from "../src/server";
+import type { SessionStore } from "../src/store";
+import type { SessionService } from "../src/service";
+import type { EventHub } from "../src/events";
+import type { DiagnosticsService } from "../src/diagnostics";
+import type { DiagnosticsSnapshot } from "../src/types";
+
+const SNAPSHOT: DiagnosticsSnapshot = {
+  checks: [{ id: "bun", state: "ok", hintKey: "diagnostics_hint_bun_ok" }],
+  generatedAt: 1,
+  overall: "ok",
+};
+
+// AppDeps with an injectable diagnostics.fix + an events spy.
+function deps(
+  fix: DiagnosticsService["fix"],
+  events: { emit: (e: string, p: unknown) => void } = { emit: () => {} },
+): AppDeps {
+  return {
+    store: {} as SessionStore,
+    service: {} as SessionService,
+    events: events as unknown as EventHub,
+    usageLimits: { limits: () => ({}) } as never,
+    diagnostics: {
+      current: async () => SNAPSHOT,
+      check: async () => SNAPSHOT,
+      fix,
+    } as Pick<DiagnosticsService, "current" | "check" | "fix">,
+  };
+}
+
+function postFix(body: unknown): Request {
+  return new Request("http://localhost/api/diagnostics/fix", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("POST /api/diagnostics/fix runs the fix, emits diagnostics:status, returns the snapshot", async () => {
+  let fixedId = "";
+  const emitted: Array<{ e: string; p: unknown }> = [];
+  const app = makeApp(
+    deps(
+      async (id) => {
+        fixedId = id;
+        return SNAPSHOT;
+      },
+      { emit: (e, p) => emitted.push({ e, p }) },
+    ),
+  );
+  const res = await app.fetch(postFix({ checkId: "bun" }));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual(SNAPSHOT);
+  expect(fixedId).toBe("bun");
+  expect(emitted).toEqual([{ e: "diagnostics:status", p: SNAPSHOT }]);
+});
+
+test("POST /api/diagnostics/fix → 400 on missing checkId", async () => {
+  const app = makeApp(deps(async () => SNAPSHOT));
+  const res = await app.fetch(postFix({}));
+  expect(res.status).toBe(400);
+});
+
+test("POST /api/diagnostics/fix → 409 for an unknown / guidance-only check", async () => {
+  const app = makeApp(
+    deps(async () => {
+      throw new Error("no remediation for tailscale");
+    }),
+  );
+  const res = await app.fetch(postFix({ checkId: "tailscale" }));
+  expect(res.status).toBe(409);
+});
+
+test("POST /api/diagnostics/fix → 502 (never 2xx) when the command fails", async () => {
+  let emitted = 0;
+  const app = makeApp(
+    deps(
+      async () => {
+        throw new Error("remediation exited 1");
+      },
+      { emit: () => emitted++ },
+    ),
+  );
+  const res = await app.fetch(postFix({ checkId: "bun" }));
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toBe("remediation failed");
+  expect(emitted).toBe(0); // no status push on failure
+});
+
+test("GET /api/diagnostics/fix → 405", async () => {
+  const app = makeApp(deps(async () => SNAPSHOT));
+  const res = await app.fetch(new Request("http://localhost/api/diagnostics/fix"));
+  expect(res.status).toBe(405);
+});
+
+test("POST /api/diagnostics/fix → 503 when diagnostics is unwired", async () => {
+  const base = deps(async () => SNAPSHOT);
+  delete (base as { diagnostics?: unknown }).diagnostics;
+  const app = makeApp(base);
+  const res = await app.fetch(postFix({ checkId: "bun" }));
+  expect(res.status).toBe(503);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1345,5 +1345,6 @@
   "diagnostics_fix_failed": "Beheben fehlgeschlagen — der Befehl wurde nicht abgeschlossen. Führe ihn manuell aus.",
   "diagnostics_fix_success": "Behoben — neu geprüft.",
   "feat_diagnose_fix_title": "Ein-Klick-Behebung in der Diagnose",
-  "feat_diagnose_fix_body": "Wenn Einstellungen → Diagnose eine fehlende Voraussetzung mit bekanntem Installationsbefehl meldet — bun, node, herdr oder claude — kannst du sie jetzt direkt beheben: Ein Beheben-Button führt den genauen Befehl (zur Bestätigung vorab angezeigt) auf dem Server aus und prüft erneut. Schritte mit Login, etwa gh und tailscale, verweisen weiterhin auf eine Anleitung."
+  "feat_diagnose_fix_body": "Wenn Einstellungen → Diagnose eine fehlende Voraussetzung mit bekanntem Installationsbefehl meldet — bun, node, herdr oder claude — kannst du sie jetzt direkt beheben: Ein Beheben-Button führt den genauen Befehl (zur Bestätigung vorab angezeigt) auf dem Server aus und prüft erneut. Schritte mit Login, etwa gh und tailscale, verweisen weiterhin auf eine Anleitung.",
+  "diagnostics_fix_unresolved": "Der Befehl wurde ausgeführt, aber der Check ist weiterhin nicht OK — möglicherweise ist ein manueller Schritt oder ein Neustart nötig."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1336,5 +1336,12 @@
   "feat_task_autopilot_title": "Autopilot-Override pro Aufgabe",
   "feat_task_autopilot_body": "Der Dialog „Neue Aufgabe“ hat jetzt eine Checkbox „Autopilot bis zum PR“. Sie startet mit der Autopilot-Einstellung des Repos, lässt sich aber für eine einzelne Aufgabe ausschalten, die du lieber Schritt für Schritt besprechen und freigeben möchtest — ohne den repoweiten Standard zu ändern.",
   "feat_newtask_infotips_title": "Aufgeräumtere Erklärungen der Aufgaben-Optionen",
-  "feat_newtask_infotips_body": "Plan-Gate, Autopilot bis zum PR und Recherche-Aufgabe haben jetzt je ein kleines „i“ — mit Maus drüberfahren (oder am Handy antippen), um zu lesen, was es tut, statt eines Absatzes, der den Dialog vollstopft. Bei Autopilot steht direkt daneben der Repo-Standard, damit klar ist, wie das Repo es normalerweise handhabt, bevor du es für eine einzelne Aufgabe änderst."
+  "feat_newtask_infotips_body": "Plan-Gate, Autopilot bis zum PR und Recherche-Aufgabe haben jetzt je ein kleines „i“ — mit Maus drüberfahren (oder am Handy antippen), um zu lesen, was es tut, statt eines Absatzes, der den Dialog vollstopft. Bei Autopilot steht direkt daneben der Repo-Standard, damit klar ist, wie das Repo es normalerweise handhabt, bevor du es für eine einzelne Aufgabe änderst.",
+  "diagnostics_fix": "Beheben",
+  "diagnostics_fix_confirm_title": "Diesen Befehl ausführen?",
+  "diagnostics_fix_confirm_body": "Shepherd führt diesen Befehl auf dem Server als dein Benutzer aus:",
+  "diagnostics_fix_confirm_run": "Ausführen",
+  "diagnostics_fix_running": "Wird ausgeführt…",
+  "diagnostics_fix_failed": "Beheben fehlgeschlagen — der Befehl wurde nicht abgeschlossen. Führe ihn manuell aus.",
+  "diagnostics_fix_success": "Behoben — neu geprüft."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1343,5 +1343,7 @@
   "diagnostics_fix_confirm_run": "Ausführen",
   "diagnostics_fix_running": "Wird ausgeführt…",
   "diagnostics_fix_failed": "Beheben fehlgeschlagen — der Befehl wurde nicht abgeschlossen. Führe ihn manuell aus.",
-  "diagnostics_fix_success": "Behoben — neu geprüft."
+  "diagnostics_fix_success": "Behoben — neu geprüft.",
+  "feat_diagnose_fix_title": "Ein-Klick-Behebung in der Diagnose",
+  "feat_diagnose_fix_body": "Wenn Einstellungen → Diagnose eine fehlende Voraussetzung mit bekanntem Installationsbefehl meldet — bun, node, herdr oder claude — kannst du sie jetzt direkt beheben: Ein Beheben-Button führt den genauen Befehl (zur Bestätigung vorab angezeigt) auf dem Server aus und prüft erneut. Schritte mit Login, etwa gh und tailscale, verweisen weiterhin auf eine Anleitung."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1343,5 +1343,7 @@
   "diagnostics_fix_confirm_run": "Run",
   "diagnostics_fix_running": "Running…",
   "diagnostics_fix_failed": "Fix failed — the command did not complete. Try running it manually.",
-  "diagnostics_fix_success": "Fixed — re-checked."
+  "diagnostics_fix_success": "Fixed — re-checked.",
+  "feat_diagnose_fix_title": "One-click Fix in Diagnostics",
+  "feat_diagnose_fix_body": "When Settings → Diagnostics flags a missing prerequisite with a known install command — bun, node, herdr, or claude — you can now fix it in place: a Fix button runs the exact command (shown first for your confirmation) on the server and re-checks. Steps that need a login, like gh and tailscale, still link out to guidance."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1336,5 +1336,12 @@
   "feat_task_autopilot_title": "Per-task Autopilot override",
   "feat_task_autopilot_body": "The New Task dialog now has an \"Autopilot to PR\" checkbox. It starts from the repo's Autopilot setting, but you can turn it off for a single task you'd rather discuss and approve step by step — without changing the repo-wide default.",
   "feat_newtask_infotips_title": "Tidier task-option explanations",
-  "feat_newtask_infotips_body": "Plan gate, Autopilot to PR, and Research task each got a small \"i\" — hover (or tap on mobile) to read what it does, instead of a paragraph crowding the dialog. Autopilot also shows the repo's standing default right beside it, so it's clear how the repo normally handles it before you change it for one task."
+  "feat_newtask_infotips_body": "Plan gate, Autopilot to PR, and Research task each got a small \"i\" — hover (or tap on mobile) to read what it does, instead of a paragraph crowding the dialog. Autopilot also shows the repo's standing default right beside it, so it's clear how the repo normally handles it before you change it for one task.",
+  "diagnostics_fix": "Fix",
+  "diagnostics_fix_confirm_title": "Run this command?",
+  "diagnostics_fix_confirm_body": "Shepherd will run this command on the server as your user:",
+  "diagnostics_fix_confirm_run": "Run",
+  "diagnostics_fix_running": "Running…",
+  "diagnostics_fix_failed": "Fix failed — the command did not complete. Try running it manually.",
+  "diagnostics_fix_success": "Fixed — re-checked."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1345,5 +1345,6 @@
   "diagnostics_fix_failed": "Fix failed — the command did not complete. Try running it manually.",
   "diagnostics_fix_success": "Fixed — re-checked.",
   "feat_diagnose_fix_title": "One-click Fix in Diagnostics",
-  "feat_diagnose_fix_body": "When Settings → Diagnostics flags a missing prerequisite with a known install command — bun, node, herdr, or claude — you can now fix it in place: a Fix button runs the exact command (shown first for your confirmation) on the server and re-checks. Steps that need a login, like gh and tailscale, still link out to guidance."
+  "feat_diagnose_fix_body": "When Settings → Diagnostics flags a missing prerequisite with a known install command — bun, node, herdr, or claude — you can now fix it in place: a Fix button runs the exact command (shown first for your confirmation) on the server and re-checks. Steps that need a login, like gh and tailscale, still link out to guidance.",
+  "diagnostics_fix_unresolved": "The command ran, but the check is still not OK — it may need a manual step or a restart."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -704,6 +704,19 @@ export async function getDiagnostics(refresh = false): Promise<DiagnosticsSnapsh
   return r.json();
 }
 
+/** Run the verbatim remediation for a diagnostics check, then return the re-probed
+ *  snapshot. Throws (via failed/apiError) on a non-2xx — the caller surfaces it as an
+ *  explicit failure, never a silent pass. */
+export async function fixDiagnostic(checkId: string): Promise<DiagnosticsSnapshot> {
+  const r = await fetch("/api/diagnostics/fix", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ checkId }),
+  });
+  if (!r.ok) throw await failed(r, "diagnostics fix");
+  return r.json();
+}
+
 /** Trigger `herdr update` (restarts herdr → ends live sessions → restarts shepherd). */
 export async function applyHerdrUpdate(): Promise<void> {
   const r = await fetch("/api/herdr-update", { method: "POST", headers: JSON_HEADERS });

--- a/ui/src/lib/components/DiagnoseRows.browser.test.ts
+++ b/ui/src/lib/components/DiagnoseRows.browser.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import DiagnoseRows from "./DiagnoseRows.svelte";
+import { m } from "$lib/paraglide/messages";
+import type { DiagnosticCheck } from "$lib/types";
+
+const check = (over: Partial<DiagnosticCheck> = {}): DiagnosticCheck => ({
+  id: "git",
+  state: "error",
+  hintKey: "diagnostics_hint_gh_missing",
+  ...over,
+});
+
+describe("DiagnoseRows fix button gating", () => {
+  it("shows Fix only on a non-ok check WITH remediation", async () => {
+    render(DiagnoseRows, {
+      props: {
+        onfix: vi.fn(),
+        checks: [
+          check({ id: "git", state: "error", remediation: "sudo apt-get install -y git" }),
+          // non-ok but guidance-only (no remediation) → no button
+          check({ id: "tailscale", state: "warning", remediation: undefined }),
+          // ok rows never get a button
+          check({ id: "bun", state: "ok", remediation: "ignored" }),
+        ],
+      },
+    });
+
+    const buttons = document.querySelectorAll<HTMLButtonElement>("button.fix");
+    expect(buttons.length).toBe(1);
+    expect(buttons[0].textContent?.trim()).toBe(m.diagnostics_fix());
+  });
+
+  it("renders NO Fix button when onfix is not provided", () => {
+    render(DiagnoseRows, {
+      props: {
+        checks: [check({ state: "error", remediation: "sudo apt-get install -y git" })],
+      },
+    });
+    expect(document.querySelector("button.fix")).toBeNull();
+  });
+
+  it("clicking Fix opens the confirm modal with the exact command", async () => {
+    render(DiagnoseRows, {
+      props: {
+        onfix: vi.fn(),
+        checks: [check({ state: "error", remediation: "sudo apt-get install -y git" })],
+      },
+    });
+
+    await page.getByRole("button", { name: m.diagnostics_fix() }).click();
+
+    const dlg = document.querySelector('[role="dialog"][aria-modal="true"]');
+    expect(dlg).not.toBeNull();
+    expect(dlg?.querySelector("code.cmd")?.textContent).toBe("sudo apt-get install -y git");
+  });
+
+  it("confirming Run calls onfix with the check id and shows busy", async () => {
+    // onfix never resolves → row stays busy so we can assert the busy label
+    let resolve!: () => void;
+    const onfix = vi.fn(() => new Promise<void>((r) => (resolve = r)));
+    render(DiagnoseRows, {
+      props: {
+        onfix,
+        checks: [check({ id: "git", state: "error", remediation: "sudo apt-get install -y git" })],
+      },
+    });
+
+    await page.getByRole("button", { name: m.diagnostics_fix() }).click();
+    await page.getByRole("button", { name: m.diagnostics_fix_confirm_run() }).click();
+
+    expect(onfix).toHaveBeenCalledTimes(1);
+    expect(onfix).toHaveBeenCalledWith("git");
+    // modal closed, row now busy
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    await expect
+      .element(page.getByRole("button", { name: m.diagnostics_fix_running() }))
+      .toBeInTheDocument();
+    resolve();
+  });
+
+  it("leaves busy state (and shows no success) when onfix rejects", async () => {
+    const onfix = vi.fn(() => Promise.reject(new Error("fix failed")));
+    render(DiagnoseRows, {
+      props: {
+        onfix,
+        checks: [check({ id: "git", state: "error", remediation: "sudo apt-get install -y git" })],
+      },
+    });
+
+    await page.getByRole("button", { name: m.diagnostics_fix() }).click();
+    await page.getByRole("button", { name: m.diagnostics_fix_confirm_run() }).click();
+
+    // settles back to the idle Fix label (not stuck on Running), no success state
+    await expect
+      .element(page.getByRole("button", { name: m.diagnostics_fix() }))
+      .toBeInTheDocument();
+  });
+
+  it("Esc cancels the confirm modal without calling onfix", async () => {
+    const onfix = vi.fn();
+    render(DiagnoseRows, {
+      props: {
+        onfix,
+        checks: [check({ state: "error", remediation: "sudo apt-get install -y git" })],
+      },
+    });
+
+    await page.getByRole("button", { name: m.diagnostics_fix() }).click();
+    const dlg = document.querySelector('[role="dialog"]');
+    expect(dlg).not.toBeNull();
+
+    dlg!.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await expect.element(page.getByRole("button", { name: m.diagnostics_fix() })).toBeVisible();
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(onfix).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/components/DiagnoseRows.svelte
+++ b/ui/src/lib/components/DiagnoseRows.svelte
@@ -1,12 +1,46 @@
 <script lang="ts">
   import type { DiagnosticCheck } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { dialog } from "$lib/a11yDialog";
+  import { SvelteSet } from "svelte/reactivity";
 
   let {
     checks,
     failed = false,
     onretry,
-  }: { checks: DiagnosticCheck[] | null; failed?: boolean; onretry?: () => void } = $props();
+    onfix,
+  }: {
+    checks: DiagnosticCheck[] | null;
+    failed?: boolean;
+    onretry?: () => void;
+    /** Parent-owned: run the check's remediation, update state, surface failure toast. */
+    onfix?: (checkId: string) => Promise<void>;
+  } = $props();
+
+  // The check whose Fix button was clicked → renders the confirm modal. null = closed.
+  let confirming = $state<DiagnosticCheck | null>(null);
+  // ids currently running a fix (button disabled + "Running…"); cleared on settle.
+  const busyIds = new SvelteSet<string>();
+
+  // A Fix button shows iff the check is non-ok AND the server attached a remediation
+  // command — guidance-only rows (tailscale) and ok rows carry none → no button.
+  function fixable(check: DiagnosticCheck): boolean {
+    return check.state !== "ok" && !!check.remediation;
+  }
+
+  async function runFix() {
+    const check = confirming;
+    if (!check) return;
+    confirming = null;
+    busyIds.add(check.id);
+    try {
+      await onfix?.(check.id);
+    } catch {
+      // Parent surfaces the failure toast; we only clear busy so the row is retryable.
+    } finally {
+      busyIds.delete(check.id);
+    }
+  }
 
   // Dynamic message key lookup — m is typed as specific functions; cast for dynamic access.
   const msg = m as unknown as Record<string, () => string>;
@@ -53,6 +87,18 @@
         {#if check.state !== "ok"}
           <p class="hint">{hint(check.hintKey)}</p>
         {/if}
+        {#if onfix && fixable(check)}
+          <div class="fix-wrap">
+            <button
+              type="button"
+              class="fix micro"
+              disabled={busyIds.has(check.id)}
+              onclick={() => (confirming = check)}
+            >
+              {busyIds.has(check.id) ? m.diagnostics_fix_running() : m.diagnostics_fix()}
+            </button>
+          </div>
+        {/if}
       </div>
     {/each}
     {#if allOk}
@@ -68,6 +114,40 @@
   </div>
 {:else}
   <div class="all-ok micro">{m.common_loading()}</div>
+{/if}
+
+{#if confirming}
+  {@const cmd = confirming.remediation}
+  <!-- Blocking confirm: scoped .overlay supplies position/scrim; the global .overlay
+       rule (app.css) layers the blur so the diagnose tab recedes behind it. -->
+  <div
+    class="overlay"
+    role="presentation"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) confirming = null;
+    }}
+  >
+    <div
+      class="card"
+      role="dialog"
+      aria-modal="true"
+      aria-label={m.diagnostics_fix_confirm_title()}
+      use:dialog={{ onclose: () => (confirming = null) }}
+    >
+      <span class="micro chead">{m.diagnostics_fix_confirm_title()}</span>
+      <p class="desc">{m.diagnostics_fix_confirm_body()}</p>
+      <!-- Verbatim command — data, not chrome → never translated. -->
+      <code class="cmd">{cmd}</code>
+      <div class="actions">
+        <button type="button" class="ghost micro" onclick={() => (confirming = null)}>
+          {m.common_cancel()}
+        </button>
+        <button type="button" class="run micro" onclick={runFix}>
+          {m.diagnostics_fix_confirm_run()}
+        </button>
+      </div>
+    </div>
+  </div>
 {/if}
 
 <style>
@@ -129,5 +209,103 @@
   .retry:hover {
     border-color: var(--color-amber);
     color: var(--color-amber);
+  }
+  .fix-wrap {
+    margin: 2px 0 0 22px;
+  }
+  .fix {
+    background: none;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 6px;
+    color: var(--color-muted);
+    font: inherit;
+    font-size: var(--fs-meta);
+    padding: 4px 10px;
+    cursor: pointer;
+  }
+  .fix:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .fix:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  /* Blocking confirm modal — scrim + (global) blur per the design rule. */
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--color-scrim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+  }
+  .card {
+    width: min(440px, 92vw);
+    border: 1px solid var(--color-line-bright);
+    background: var(--color-panel);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .chead {
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .desc {
+    margin: 0;
+    color: var(--color-ink);
+    font-size: var(--fs-base);
+    line-height: 1.4;
+  }
+  .cmd {
+    display: block;
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    border-radius: 2px;
+    padding: 8px 10px;
+    font-family: var(--font-mono, monospace);
+    font-size: var(--fs-meta);
+    color: var(--color-ink-bright);
+    overflow-x: auto;
+    white-space: pre;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 2px;
+  }
+  .ghost,
+  .run {
+    border: 1px solid var(--color-line-bright);
+    background: transparent;
+    color: var(--color-ink);
+    padding: 9px 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: var(--fs-meta);
+    cursor: pointer;
+  }
+  .run {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  @media (max-width: 768px) {
+    .overlay {
+      align-items: stretch;
+      justify-content: stretch;
+    }
+    .card {
+      width: 100%;
+      height: 100dvh;
+      border: 0;
+      overflow-y: auto;
+    }
   }
 </style>

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import type { Settings as SettingsPayload } from "$lib/types";
+import type { Settings as SettingsPayload, DiagnosticCheck } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
-import { getSettings, verifyApiKey, putAnthropicApiKey } from "$lib/api";
+import { getSettings, verifyApiKey, putAnthropicApiKey, fixDiagnostic } from "$lib/api";
+import { toasts } from "$lib/toasts.svelte";
 
 // Mock the API so Settings never hits the network. The settings GET is seeded to
 // land on api-key mode WITH a key configured, so the api-key block + Verify button
@@ -16,6 +17,7 @@ vi.mock("$lib/api", async (importOriginal) => {
     getSettings: vi.fn(),
     listDirs: vi.fn(async () => ({ path: "/repo", display: "/repo", parent: null, entries: [] })),
     getDiagnostics: vi.fn(async () => ({ checks: [] })),
+    fixDiagnostic: vi.fn(),
     verifyApiKey: vi.fn(),
     putAnthropicApiKey: vi.fn(),
     putAuthMode: vi.fn(async () => ({ authMode: "api-key", hasApiKey: true })),
@@ -43,6 +45,7 @@ const { default: Settings } = await import("./Settings.svelte");
 const mockGetSettings = vi.mocked(getSettings);
 const mockVerify = vi.mocked(verifyApiKey);
 const mockPutKey = vi.mocked(putAnthropicApiKey);
+const mockFix = vi.mocked(fixDiagnostic);
 
 function settings(over: Partial<SettingsPayload> = {}): SettingsPayload {
   return {
@@ -176,5 +179,75 @@ describe("Settings api-key verify", () => {
     await vi.waitFor(() => expect(mockVerify).toHaveBeenCalled());
     // …and its verdict renders inline.
     await expect.element(page.getByText(m.settings_auth_key_verify_ok())).toBeInTheDocument();
+  });
+});
+
+// Regression guard for the issue's "no false success" criterion (PR #703): the green
+// "Fixed" toast must only fire when the RE-PROBED snapshot shows the targeted check ok.
+// A command that exits 0 but leaves the check non-ok (e.g. installer succeeds but its
+// binary isn't on the server PATH) must surface the persistent "unresolved" toast, not
+// a fake success.
+describe("Settings diagnose one-click fix toast", () => {
+  const bunBroken = (): DiagnosticCheck => ({
+    id: "bun",
+    state: "error",
+    hintKey: "diagnostics_hint_bun_missing",
+    remediation: "curl -fsSL https://bun.sh/install | bash",
+  });
+
+  function mountDiagnose() {
+    render(Settings, {
+      initialTab: "diagnose",
+      initialDiagnostics: [bunBroken()],
+      onclose: noop,
+      onsaved: noop,
+    });
+  }
+
+  async function clickFixThenRun() {
+    await page.getByRole("button", { name: m.diagnostics_fix(), exact: true }).click();
+    await page.getByRole("button", { name: m.diagnostics_fix_confirm_run(), exact: true }).click();
+  }
+
+  beforeEach(() => {
+    mockFix.mockReset();
+    toasts.items = []; // singleton store — clear so each assertion sees only its own toast
+  });
+
+  it("shows the success toast when the re-probe clears the check", async () => {
+    mockFix.mockResolvedValue({
+      checks: [{ id: "bun", state: "ok", hintKey: "diagnostics_hint_bun_ok" }],
+      generatedAt: 1,
+      overall: "ok",
+    });
+    mountDiagnose();
+    await clickFixThenRun();
+
+    await vi.waitFor(() => expect(mockFix).toHaveBeenCalledWith("bun"));
+    await vi.waitFor(() =>
+      expect(toasts.items.some((t) => t.text === m.diagnostics_fix_success())).toBe(true),
+    );
+    expect(toasts.items.some((t) => t.text === m.diagnostics_fix_unresolved())).toBe(false);
+  });
+
+  it("shows the persistent unresolved toast (NOT success) when the check is still non-ok after exit 0", async () => {
+    // Command resolved (2xx), but the re-probe still reports bun as error.
+    mockFix.mockResolvedValue({
+      checks: [bunBroken()],
+      generatedAt: 1,
+      overall: "error",
+    });
+    mountDiagnose();
+    await clickFixThenRun();
+
+    await vi.waitFor(() => expect(mockFix).toHaveBeenCalledWith("bun"));
+    await vi.waitFor(() =>
+      expect(toasts.items.some((t) => t.text === m.diagnostics_fix_unresolved())).toBe(true),
+    );
+    // The critical assertion: no green "Fixed" toast on an unresolved check.
+    expect(toasts.items.some((t) => t.text === m.diagnostics_fix_success())).toBe(false);
+    // And the unresolved toast is persistent (no auto-dismiss) — durationMs unset.
+    const t = toasts.items.find((x) => x.text === m.diagnostics_fix_unresolved())!;
+    expect(t.durationMs).toBeUndefined();
   });
 });

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -14,6 +14,7 @@
     putExtraCreditsDrainCeiling,
     listDirs,
     getDiagnostics,
+    fixDiagnostic,
   } from "$lib/api";
   import { verifyFailureMessage } from "$lib/verify-key";
   import {
@@ -183,6 +184,24 @@
       diagError = m.diagnostics_rerun_error();
     } finally {
       diagBusy = false;
+    }
+  }
+
+  // One-click fix: run the check's remediation server-side, re-render from the
+  // re-probed snapshot. Fail closed — a non-2xx surfaces a persistent, deduped
+  // failure toast and rethrows so DiagnoseRows clears its busy state (no fake success).
+  async function fixCheck(checkId: string) {
+    try {
+      const snap = await fixDiagnostic(checkId);
+      diagChecks = snap.checks;
+      toasts.info(m.diagnostics_fix_success(), { duration: 3000 });
+    } catch {
+      toasts.info(m.diagnostics_fix_failed(), {
+        duration: null,
+        alert: true,
+        key: `diagnose-fix:${checkId}`,
+      });
+      throw new Error("fix failed");
     }
   }
 
@@ -957,7 +976,7 @@
         <span class="micro">{m.diagnostics_title()}</span>
         <p class="hint">{m.diagnostics_subtitle()}</p>
       </div>
-      <DiagnoseRows checks={diagChecks} />
+      <DiagnoseRows checks={diagChecks} onfix={fixCheck} />
       <!-- Client-only: install/standalone state can't come from /api/diagnostics, so this
            row renders independently of the server snapshot's load/fail/empty state. -->
       <PwaInstallRow />

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -188,13 +188,24 @@
   }
 
   // One-click fix: run the check's remediation server-side, re-render from the
-  // re-probed snapshot. Fail closed — a non-2xx surfaces a persistent, deduped
-  // failure toast and rethrows so DiagnoseRows clears its busy state (no fake success).
+  // re-probed snapshot. Fail closed on two levels: a non-2xx surfaces a persistent,
+  // deduped failure toast (and rethrows so DiagnoseRows clears busy); a 2xx whose
+  // re-probe shows the target check STILL not ok (the command exited 0 but didn't
+  // clear it) surfaces a persistent "unresolved" toast — never a green success.
   async function fixCheck(checkId: string) {
     try {
       const snap = await fixDiagnostic(checkId);
       diagChecks = snap.checks;
-      toasts.info(m.diagnostics_fix_success(), { duration: 3000 });
+      const cleared = snap.checks.find((c) => c.id === checkId)?.state === "ok";
+      if (cleared) {
+        toasts.info(m.diagnostics_fix_success(), { duration: 3000 });
+      } else {
+        toasts.info(m.diagnostics_fix_unresolved(), {
+          duration: null,
+          alert: true,
+          key: `diagnose-fix:${checkId}`,
+        });
+      }
     } catch {
       toasts.info(m.diagnostics_fix_failed(), {
         duration: null,

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -910,4 +910,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_newtask_infotips_body",
     targetId: "task-autopilot",
   },
+  {
+    // No targetId: the Fix button lives in the Settings → Diagnostics tab (modal closed
+    // by default), so a coachmark anchor would rarely be mounted — surface via the
+    // What's-New drawer only (same as the prior "diagnostics"/"pwa-install-diagnostic"
+    // entries). 1.31.0 is the latest released tag, so this ships in 1.32.0.
+    id: "diagnose-one-click-fix",
+    sinceVersion: "1.32.0",
+    titleKey: "feat_diagnose_fix_title",
+    bodyKey: "feat_diagnose_fix_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -660,6 +660,10 @@ export interface DiagnosticCheck {
   id: string;
   state: DiagnosticState;
   hintKey: string;
+  /** A non-secret public install command the operator can one-click-run via the Fix
+   *  button. Present only on non-ok, auto-fixable checks (server sets it; guidance-only
+   *  rows like tailscale and ok rows have none → no Fix button). */
+  remediation?: string;
 }
 export interface DiagnosticsSnapshot {
   checks: DiagnosticCheck[];


### PR DESCRIPTION
Implements **Phase 1 + Phase 2** of the first-run installer (#703): the keystone refactor and the in-app DIAGNOSE **Fix** surface. The cold-start `curl|bash` bootstrap (Surface A) and the Phase-4 harness e2e gate are deliberately deferred — tracked in **#706**.

Refs #703 (does **not** close it — Surface A / acceptance-criterion #3 ship in #706).

## What ships

### Phase 1 — keystone: one canonical remediation table
- Promotes `REMEDIATIONS` + `remediationsFor` out of the test harness into shipped **`src/remediations.ts`** (git-tracked rename, no behavior change). The harness now imports from `src/`.
- Adds the **guidance-only taxonomy** — `GUIDANCE_ONLY` + `autoFixCommandFor(hintKey)`. Membership in `REMEDIATIONS` is *not* the auto-fixable set: `tailscale_missing` has an install command (for the future cold-start installer) but the binary alone never clears the check (`resolveNodeHost` stays null until an interactive tailnet login), so it's gated out of in-app Fix — no false-failure button.

### Phase 2 — Surface B: in-app DIAGNOSE Fix
- **`POST /api/diagnostics/fix { checkId }`** — resolves the check's `hintKey` against the table, runs the **verbatim** command server-side (operator's user), forces a fresh probe, returns the snapshot, and emits `diagnostics:status` so every client + the TopBar pip refresh. Behind the existing `checkAuth`/`checkOrigin` (CSRF + token) guards.
  - **Single-loop safe:** spawns a **detached process group** (async, never sync), drains stdout/stderr into a bounded 1 MiB sink (no ENOBUFS on noisy installs), and **SIGKILLs the whole group on timeout** (`REMEDIATION_TIMEOUT_MS`) so no reparented grandchild survives to flip a later probe green behind a reported failure.
  - **Fail closed:** non-zero exit / timeout / unknown-or-guidance-only check → explicit non-2xx (502 / 409), never a masked success.
- **DiagnoseRows.svelte** — a **Fix** button on every non-ok auto-fixable row (symmetric across warning + error), behind a blurred-scrim confirm modal that shows the **exact command** before running. Guidance-only (tailscale) and prose-only (git/gh) rows keep their prose hint, no button.
- **Settings.svelte** — owns the flow: re-renders from the re-probed snapshot on success; on failure raises a **persistent, assertive, per-target-keyed** toast (`diagnose-fix:<id>`) — never a silent pass.
- Feature-catalog entry (`diagnose-one-click-fix`, `sinceVersion: 1.32.0`) + EN/DE message keys.

## Tests
- `test/remediations.test.ts` — table + `autoFixCommandFor` (tailscale → `undefined` despite being in `REMEDIATIONS`).
- `test/diagnostics.test.ts` — snapshot annotation (ok/guidance-only get no `remediation`); `fix()` happy path, unknown-check throw, guidance-only gate, runner-rejection (fail-closed).
- `test/server-diagnostics-fix.test.ts` — endpoint 200+emit / 400 / 409 / 502 / 405 / 503 + no-emit-on-failure.
- `DiagnoseRows.browser.test.ts` — button gating, confirm shows exact command, Run calls `onfix`, reject leaves no success, Esc cancels.

## Verification
- Root: `tsc --noEmit` clean, `lint` clean, `bun test ./test` → **3076 pass / 0 fail**.
- UI: `bun run check` → **0 errors**, `bun run test` → **1327 pass**, `check:i18n` parity.
- Pre-push gates (branch-hygiene, feature-catalog, glossary, fallow delta) all green. Rebased linear onto latest `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)