### PR TITLE
feat(hooks): push-based agent-info ingestion via Claude Code hooks — Phase 0 + 1 (#704)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -329,6 +329,16 @@ export const config = {
   // (and its notification noise) for agent sessions; `/remote-control` (`/rc`) still
   // works in the terminal to turn it on per-session. UI-configurable + persisted.
   remoteControlAtStartup: process.env.SHEPHERD_REMOTE_CONTROL_AT_STARTUP === "1",
+  // Push-based agent-info ingestion via Claude Code hooks (issue #704), additive on top
+  // of polling, staged behind two default-off flags so each phase is independently reversible.
+  // Phase 0: inject PostToolUse/PostToolUseFailure/Notification HTTP hooks into spawned
+  // agents + ingest + observe (no signal wiring) — to verify reachability, latency, and
+  // session correlation (incl. under the sandboxed/egress profile) before trusting the path.
+  hooksIngest: process.env.SHEPHERD_HOOKS_INGEST === "1",
+  // Phase 1: feed received hook events into the poller (the single owner of signal state).
+  // Meaningful only when `hooksIngest` is also on — with ingest off no events arrive to feed.
+  // Staged after Phase 0 has confirmed the live payload shape (see issue #704).
+  hooksSignals: process.env.SHEPHERD_HOOKS_SIGNALS === "1",
   // Context trim for auto-spawned (drain) agents (issue #499): spawn them with
   // `--disable-slash-commands` (drops the skill catalog) plus a per-spawn settings
   // overlay disabling every operator-enabled plugin (drops plugin hook injections,

--- a/src/hooks-ingest.ts
+++ b/src/hooks-ingest.ts
@@ -1,0 +1,148 @@
+// Phase 0 ingest path for Claude Code push hooks (issue #704).
+//
+// Observe-only: the spawned agent's PostToolUse / PostToolUseFailure / Notification
+// hooks POST here; we validate the untrusted body, normalize it, drop it into a
+// bounded per-session ring buffer, and log a structured line. NOTHING here feeds the
+// signal pipeline yet — `onSignal` is wired by Task 3 (Phase 1) when `hooksSignals`
+// is on. The whole point of the spike is to MEASURE (latency, correlation, the exact
+// upstream strings) before trusting the channel, so anything unrecognized is recorded
+// and flagged loudly rather than silently dropped.
+
+/** A normalized hook event after validation — the spike's observable unit. */
+export type HookEvent = {
+  /** Recognized lifecycle event; an unrecognized `hook_event_name` is still kept,
+   *  passed through verbatim, and flagged via `unknown`. */
+  event: "PostToolUse" | "PostToolUseFailure" | "Notification" | string;
+  /** The hook payload's `session_id` (== `claude --session-id` == `claudeSessionId`). */
+  sessionId: string;
+  /** PostToolUse(/Failure): the tool that ran. */
+  toolName?: string;
+  /** PostToolUse(/Failure): derived from exit_code / the *Failure event. */
+  status?: "ok" | "error";
+  /** PostToolUse(/Failure): tool exit code when present (logging aid). */
+  exitCode?: number;
+  /** Notification: the `notification_type` string (e.g. permission_prompt / idle_prompt). */
+  notificationType?: string;
+  /** Notification: the human-readable message string. */
+  message?: string;
+  /** True when `hook_event_name` or `notification_type` was unrecognized — recorded,
+   *  flagged, and `console.warn`-ed so a wrong upstream string surfaces in the spike. */
+  unknown?: boolean;
+  /** Server receive time (ms). CC's payload carries no reliable client timestamp, so
+   *  end-to-end latency is measured externally; this anchors per-event ordering + logs. */
+  receivedAt: number;
+  /** Route-decided cross-check of the body's `session_id` against the resolved
+   *  session's `claudeSessionId`. `false` ⇒ observe-only (never forwarded to signals). */
+  match?: boolean;
+};
+
+/** Validated-but-not-yet-normalized event — the shape `validateHookEvent` returns. It
+ *  carries everything the route needs; the route stamps `match` + `receivedAt`. */
+export type RawHookEvent = Omit<HookEvent, "receivedAt" | "match">;
+
+/** Max events retained per session before the oldest is evicted. */
+const RING_CAP = 50;
+
+// Defensive readers — the body is untrusted JSON; never assume a shape.
+const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+const num = (v: unknown): number | undefined => (typeof v === "number" ? v : undefined);
+const obj = (v: unknown): Record<string, unknown> | null =>
+  typeof v === "object" && v !== null ? (v as Record<string, unknown>) : null;
+
+/**
+ * Pure, total validator over an untrusted hook body. Returns null for non-objects or a
+ * missing/non-string `session_id` (the only hard requirement). Reads `hook_event_name`
+ * and derives a normalized event. UNKNOWN event/notification types are NOT dropped —
+ * they're accepted and flagged `unknown: true` so the spike surfaces a wrong upstream
+ * string instead of silently disabling a signal.
+ */
+export function validateHookEvent(body: unknown): RawHookEvent | null {
+  const b = obj(body);
+  if (!b) return null;
+  const sessionId = str(b.session_id);
+  if (!sessionId) return null;
+
+  const eventName = str(b.hook_event_name) ?? "";
+
+  if (eventName === "PostToolUse" || eventName === "PostToolUseFailure") {
+    const toolName = str(b.tool_name);
+    // Doc-corrected: the field is `tool_output`; defensively fall back to `tool_response`.
+    const output = obj(b.tool_output) ?? obj(b.tool_response);
+    const exitCode = num(output?.exit_code);
+    // exit_code !== 0 ⇒ error; the *Failure event is itself an error regardless of code.
+    const status: "ok" | "error" =
+      eventName === "PostToolUseFailure" || (exitCode !== undefined && exitCode !== 0)
+        ? "error"
+        : "ok";
+    return { event: eventName, sessionId, toolName, status, exitCode };
+  }
+
+  if (eventName === "Notification") {
+    const notificationType = str(b.notification_type);
+    const message = str(b.message);
+    // The `notification_type` strings are spike-validated, not assumed: flag an
+    // absent/unknown type so it's logged + recorded but never silently disables a signal.
+    return { event: eventName, sessionId, notificationType, message, unknown: !notificationType };
+  }
+
+  // Unrecognized hook_event_name — keep it, pass it through verbatim, flag it.
+  return { event: eventName || "unknown", sessionId, unknown: true };
+}
+
+/**
+ * Bounded in-memory ring buffer + structured logging for ingested hook events. The
+ * single owner of the Phase-0 observable surface. `record` never throws — a malformed
+ * forward must never crash the request loop.
+ */
+export class HookIngest {
+  // sessionId → ring buffer (oldest-first; capped at RING_CAP).
+  #buffers = new Map<string, HookEvent[]>();
+  // Set only by Task 3 (Phase 1) when `hooksSignals` is on; forwards matched events
+  // to the poller. Left undefined here ⇒ observe-only.
+  #onSignal?: (sessionId: string, ev: HookEvent) => void;
+
+  constructor(onSignal?: (sessionId: string, ev: HookEvent) => void) {
+    this.#onSignal = onSignal;
+  }
+
+  /** Push an event, log it, and (only on a matched session) forward to signals. */
+  record(sessionId: string, ev: HookEvent): void {
+    try {
+      const buf = this.#buffers.get(sessionId) ?? [];
+      buf.push(ev);
+      if (buf.length > RING_CAP) buf.splice(0, buf.length - RING_CAP);
+      this.#buffers.set(sessionId, buf);
+
+      const latencyMs = Date.now() - ev.receivedAt;
+      console.log(
+        `[hooks] ${ev.event} session=${sessionId} match=${ev.match === false ? "mismatch" : "ok"} ` +
+          `latencyMs=${latencyMs} tool=${ev.toolName ?? "-"} status=${ev.status ?? "-"} ` +
+          `ntype=${ev.notificationType ?? "-"} exit=${ev.exitCode ?? "-"}`,
+      );
+      if (ev.unknown) {
+        console.warn(
+          `[hooks] unknown event/notification type — event=${ev.event} ntype=${ev.notificationType ?? "-"} session=${sessionId}`,
+        );
+      }
+
+      // Fail-closed on the untrusted session_id: a mismatch is observe-only.
+      if (ev.match !== false) this.#onSignal?.(sessionId, ev);
+    } catch (err) {
+      // Never let a logging/forward fault escape into the request loop.
+      console.warn(`[hooks] record failed for session=${sessionId}: ${String(err)}`);
+    }
+  }
+
+  /** A copy of the session's ring buffer (or `[]`), safe to hand to a JSON response. */
+  snapshot(sessionId: string): HookEvent[] {
+    const buf = this.#buffers.get(sessionId);
+    return buf ? [...buf] : [];
+  }
+
+  /** Drop ring-buffer entries for sessions no longer active (called from the poller's prune). */
+  prune(activeIds: Set<string>): void {
+    for (const id of this.#buffers.keys()) {
+      if (!activeIds.has(id)) this.#buffers.delete(id);
+    }
+  }
+}

--- a/src/hooks-ingest.ts
+++ b/src/hooks-ingest.ts
@@ -105,6 +105,17 @@ export class HookIngest {
     this.#onSignal = onSignal;
   }
 
+  /**
+   * Set (or clear) the Phase-1 signal sink AFTER construction. index.ts constructs the
+   * HookIngest before the poller (the poller's prune callback needs it), then wires the
+   * sink once the poller exists — resolving the circular construction order without a
+   * forward-declared `let`. The ctor `onSignal` arg still works (Task 2 tests use it);
+   * this just lets the wiring happen post-construction when `config.hooksSignals` is on.
+   */
+  setSink(onSignal: (sessionId: string, ev: HookEvent) => void): void {
+    this.#onSignal = onSignal;
+  }
+
   /** Push an event, log it, and (only on a matched session) forward to signals. */
   record(sessionId: string, ev: HookEvent): void {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ import { DistillerService, defaultScratch } from "./distiller";
 import { Promoter } from "./promote";
 import { GitignoreAdopter } from "./gitignore-adopt";
 import { attachSignalCapture } from "./signals";
+import { HookIngest } from "./hooks-ingest";
 import { maintenance } from "./maintenance";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -961,6 +962,10 @@ const backlogPoller = new BacklogPoller(
 setTimeout(() => void backlogPoller.tick(), 3_000);
 backlogPoller.start();
 
+// Phase-0 push-hook ingest (issue #704), observe-only: no `onSignal` yet — Task 3 wires
+// the poller-forwarding closure when `config.hooksSignals` is on.
+const hookIngest = new HookIngest();
+
 const server = serve(
   {
     store,
@@ -984,6 +989,7 @@ const server = serve(
     push,
     presence,
     poller,
+    hooks: hookIngest,
     reviewCache: {
       snapshot: () => reviewService.snapshot(),
       reviewing: () => reviewService.reviewingIds(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -313,6 +313,11 @@ const tailscaleServe = new TailscaleServeService({
     events.emit("session:preview-serve", { id, serve } satisfies SessionPreviewServeEvent),
 });
 
+// Phase-0 push-hook ingest (issue #704), constructed BEFORE the poller so the poller's
+// `pruneHooks` callback can drop dead sessions' ring buffers. Observe-only until the
+// Phase-1 sink is wired below (only when `config.hooksSignals` is on).
+const hookIngest = new HookIngest();
+
 const poller = new StatusPoller(
   store,
   herdr,
@@ -341,7 +346,30 @@ const poller = new StatusPoller(
   // working-while-blocked display flag: herdr latched "blocked" but the TUI shows a
   // live turn spinner — the UI keeps working chrome instead of a false "needs you".
   (id, working) => events.emit("session:working-blocked", { id, working }),
+  // Phase-1 (issue #704): prune dead sessions' hook ring buffers from the poller's
+  // pruneInactive (so they don't grow unbounded by session count).
+  (ids) => hookIngest.prune(ids),
 );
+
+// Phase-1 push-hook signal wiring (issue #704): feed received hook events into the
+// poller (the single owner of per-session signal dedup + state). Only when
+// `config.hooksSignals` is on AND ingest is too — with ingest off no events ever
+// arrive, so signals-without-ingest is meaningless (warn once, behave as off). When
+// off, the sink stays unset → pure observe-only (Phase-0 behaviour), poller untouched.
+if (config.hooksSignals && !config.hooksIngest) {
+  console.warn(
+    "[hooks] SHEPHERD_HOOKS_SIGNALS is set but SHEPHERD_HOOKS_INGEST is off — no events " +
+      "will arrive to feed the poller; treating signals as off. Enable ingest first.",
+  );
+} else if (config.hooksSignals) {
+  hookIngest.setSink((id, ev) => {
+    if (ev.event === "PostToolUse" || ev.event === "PostToolUseFailure") {
+      poller.ingestActivity(id, { toolName: ev.toolName, status: ev.status, ts: ev.receivedAt });
+    } else if (ev.event === "Notification") {
+      poller.ingestNotification(id, ev.notificationType ?? "");
+    }
+  });
+}
 // Clear stale mappings left by a crashed prior run. Fire void, NOT await: the service's
 // single FIFO queue already guarantees this op completes before any register/unregister
 // enqueued after poller.start(), so awaiting only risks stalling boot up to count×5s
@@ -961,10 +989,6 @@ const backlogPoller = new BacklogPoller(
 );
 setTimeout(() => void backlogPoller.tick(), 3_000);
 backlogPoller.start();
-
-// Phase-0 push-hook ingest (issue #704), observe-only: no `onSignal` yet — Task 3 wires
-// the poller-forwarding closure when `config.hooksSignals` is on.
-const hookIngest = new HookIngest();
 
 const server = serve(
   {

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -17,13 +17,13 @@ const STALL_SIG = "stall"; // fixed signature → a stall fires once per episode
  * issue #704). Deliberately a small, named constant because under
  * `--dangerously-skip-permissions` (how Shepherd spawns every agent) tool-permission
  * prompts are suppressed, so it was unclear whether the real pausing cases emit a
- * usable edge. CONFIRMED by the Phase-0 live spike (2026-06-15): an `AskUserQuestion`
- * pause fires `Notification(permission_prompt)` even under skip-permissions — so this
- * set matches that (the common interactive-pause) case. `ExitPlanMode`/plan-approval
- * is not yet confirmed; ADD its type here once a spike observes it. If a pausing case
- * emits no matching type, the block trigger simply stays dormant for it and detection
- * cleanly degrades to the existing `herdr-blocked → classifyBlocked` fallback — the
- * intended no-regression path. `idle_prompt` is deliberately NOT here (idle is handled
+ * usable edge. CONFIRMED by the Phase-0 live spike (2026-06-15): BOTH interactive-pause
+ * cases — an `AskUserQuestion` pause AND an `ExitPlanMode`/plan-approval prompt — fire
+ * `Notification(permission_prompt)` even under skip-permissions, so this single type
+ * covers them. If some future pausing case emitted a different type, the block trigger
+ * would simply stay dormant for it and detection would cleanly degrade to the
+ * existing `herdr-blocked → classifyBlocked` fallback — the intended no-regression
+ * path. `idle_prompt` is deliberately NOT here (idle is handled
  * by herdr mapping).
  */
 const BLOCK_NOTIFICATION_TYPES = new Set(["permission_prompt"]);

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -12,6 +12,20 @@ import { config } from "./config";
 
 const STALL_SIG = "stall"; // fixed signature → a stall fires once per episode
 
+/**
+ * Notification `notification_type`s that assert an awaiting-input edge (Phase 1,
+ * issue #704). Deliberately a small, named constant: under
+ * `--dangerously-skip-permissions` (how Shepherd spawns every agent)
+ * `Notification(permission_prompt)` may NEVER fire, and the real pausing cases
+ * (`AskUserQuestion`, `ExitPlanMode`) emit an UNVERIFIED notification_type. The
+ * Phase-0 spike must confirm which type(s) those actually emit and ADD them here;
+ * until then this set may simply never match in practice, in which case the block
+ * trigger stays dormant and detection cleanly degrades to the existing
+ * `herdr-blocked → classifyBlocked` fallback — the intended no-regression path.
+ * `idle_prompt` is deliberately NOT here (idle is handled by herdr mapping).
+ */
+const BLOCK_NOTIFICATION_TYPES = new Set(["permission_prompt"]);
+
 /** Both transcript-derived signals from a single read; the unified probe's result. */
 type TranscriptSignals = { snapshot: ActivitySnapshot | null; activity: SessionActivity | null };
 
@@ -129,6 +143,24 @@ export class StatusPoller {
    *  herdr-blocked, `clearBlock`, reap, prune). */
   private lastSuppressVisible = new Map<string, string>();
 
+  /** Phase-1 push-hook state (issue #704), all gated by `config.hooksSignals`.
+   *  Fed via HookIngest.onSignal → ingestActivity / ingestNotification; the poller
+   *  stays the single owner of per-session signal dedup + the working-while-blocked
+   *  state machine, so push events funnel through `emitActivity`/`maybeClassify`
+   *  rather than emitting directly (which would bypass dedup + oscillate with poll).
+   *  Every map is pruned in `pruneInactive` and inert when the flag is off. */
+  /** Per-session ms of the last PostToolUse(/Failure) push activity — the freshness
+   *  baseline that lets `maybeProbe` suppress its now-redundant transcript activity
+   *  emit while the (fresher, real-summary) push path is carrying the session. */
+  private lastHookActivityAt = new Map<string, number>();
+  /** Per-session windowed heat-strip ticks accrued from push activity (mirrors
+   *  `interimTicks`, windowed to STRIP_WINDOW_MS). */
+  private hookTicks = new Map<string, number[]>();
+  /** Sessions for which a Notification reported an awaiting-input edge; consumed by
+   *  `reconcileAgent` to trigger a classify THIS tick (≤ ~1 tick), independent of
+   *  herdr's latchy `blocked` status. */
+  private hookAwaitingInput = new Set<string>();
+
   /** Timestamp of the last claude-liveness sweep (0 = never). */
   private lastLivenessSweepAt = 0;
   /** Last-swept per-session claude liveness; onChange fires on flips only. */
@@ -180,6 +212,13 @@ export class StatusPoller {
      * (and before) any re-armed block emission.
      */
     private onWorkingBlocked: (id: string, working: boolean) => void = () => {},
+    /**
+     * Phase-1 (issue #704): prune the HookIngest ring buffers for sessions no longer
+     * active, called from `pruneInactive` so dead sessions' buffers don't grow
+     * unbounded by session count (Task-2 reviewer flag). Undefined ⇒ no-op (the
+     * ingest module isn't wired, e.g. in tests / flag off).
+     */
+    private pruneHooks?: (activeIds: Set<string>) => void,
   ) {
     // Merge supplied overrides with real defaults. When preview is omitted entirely
     // we create a no-op wiring so tick() never throws on undefined access.
@@ -309,12 +348,7 @@ export class StatusPoller {
       this.onChange(s.id, status); // nudge clients to re-attach the PTY to the fresh terminal
     }
     if (idChanged) s = { ...s, herdrAgentId: agent.terminalId };
-    // There's a next action again → drop the manual "ready to merge" parking so
-    // the row rejoins the active group. Sticky otherwise (idle/done keep it).
-    if ((status === "running" || status === "blocked") && s.readyToMerge) {
-      this.store.update(s.id, { readyToMerge: false });
-      this.onReady(s.id, false);
-    }
+    this.dropReadyToMergeIfActionable(s, status);
     // Left herdr-blocked (running/idle/done alike) → the working-while-blocked
     // display flag must drop in the SAME tick, not via the throttled probe paths.
     // The suppression-episode baseline goes with it (flag or not — a frozen
@@ -323,9 +357,56 @@ export class StatusPoller {
       this.lastSuppressVisible.delete(s.id);
       if (this.workingWhileBlocked.delete(s.id)) this.onWorkingBlocked(s.id, false);
     }
+    // Phase-1 push block-trigger (issue #704): a Notification awaiting-input edge
+    // can classify THIS tick even before herdr latches "blocked". When it handles the
+    // session (announced a block), short-circuit so the normal routing below doesn't
+    // immediately wipe the just-emitted block. See tryHookAwaitingBlock.
+    if (status !== "blocked" && this.tryHookAwaitingBlock(s)) return;
+
     if (status === "blocked") this.maybeClassify(s.id, s.herdrAgentId);
     else if (status === "running") this.maybeProbe(s);
     else this.clearBlock(s.id);
+  }
+
+  /**
+   * There's a next action again → drop the manual "ready to merge" parking so the row
+   * rejoins the active group. Sticky otherwise (idle/done keep it).
+   */
+  private dropReadyToMergeIfActionable(s: Session, status: Session["status"]): void {
+    if ((status === "running" || status === "blocked") && s.readyToMerge) {
+      this.store.update(s.id, { readyToMerge: false });
+      this.onReady(s.id, false);
+    }
+  }
+
+  /**
+   * Phase-1 push block-trigger (issue #704): a Notification reported an awaiting-input
+   * edge. Classify THIS tick even if herdr hasn't latched "blocked" yet, so the block
+   * surfaces ≤ ~1 tick after the agent asks — independent of herdr's latchy status +
+   * the PTY-regex *detection* heuristics. classifyBlocked still supplies the menu/yes-no
+   * options + tail (the Notification payload has none). The PTY read stays on the TICK
+   * (maybeClassify), never in the route (single-loop-no-sync-exec). Callers skip this
+   * when status==="blocked" already (the normal branch classifies), to avoid a double
+   * read. The marker is consumed only once a classify ACTUALLY runs (maybeClassify
+   * returns true): if its reclassifyMs throttle skips this tick, we KEEP the marker and
+   * retry next tick — still faster/more reliable than waiting on herdr's latchy
+   * "blocked" fallback. When the type never arrives (the common skip-permissions case),
+   * this is dormant and detection stays on the herdr-blocked fallback — no regression.
+   *
+   * Returns true when it announced an awaiting-input/menu/yes-no block (lastSig set to a
+   * non-stall reason) → the caller must short-circuit: running the normal running/idle
+   * routing this tick (`maybeProbe`→`evaluateStall`→`clearBlock`, or the idle-branch
+   * `clearBlock`) would immediately wipe the just-emitted block. The next tick (no
+   * marker) routes normally, so a resolved prompt clears via the usual path. A non-block
+   * classify (e.g. a working spinner suppressed it) returns false → normal routing runs.
+   */
+  private tryHookAwaitingBlock(s: Session): boolean {
+    if (!config.hooksSignals || !this.hookAwaitingInput.has(s.id)) return false;
+    // Consume the marker only when the classify actually ran (throttle didn't skip);
+    // a throttled tick keeps the marker so the next tick retries the surface.
+    if (this.maybeClassify(s.id, s.herdrAgentId)) this.hookAwaitingInput.delete(s.id);
+    const sig = this.lastSig.get(s.id);
+    return sig !== undefined && sig !== STALL_SIG;
   }
 
   /** Prune tracking state for sessions no longer active (archived/removed). */
@@ -345,6 +426,9 @@ export class StatusPoller {
       ...this.previewStopState.keys(),
       ...this.workingWhileBlocked,
       ...this.lastSuppressVisible.keys(),
+      ...this.lastHookActivityAt.keys(),
+      ...this.hookTicks.keys(),
+      ...this.hookAwaitingInput,
     ]);
     for (const id of tracked) {
       if (!activeIds.has(id)) {
@@ -363,13 +447,83 @@ export class StatusPoller {
         // archived/removed → no client cares anymore; drop without an emit
         this.workingWhileBlocked.delete(id);
         this.lastSuppressVisible.delete(id);
+        // Phase-1 push-hook tracking (issue #704)
+        this.lastHookActivityAt.delete(id);
+        this.hookTicks.delete(id);
+        this.hookAwaitingInput.delete(id);
       }
     }
+    // Phase-1 (issue #704): drop the HookIngest ring buffers for dead sessions too
+    // (so they don't grow unbounded by session count). No-op when unwired.
+    this.pruneHooks?.(activeIds);
   }
 
   /** Last-emitted activity signal per running session, for client bootstrap. */
   activitySnapshot(): Record<string, SessionActivity> {
     return Object.fromEntries(this.lastActivity);
+  }
+
+  /**
+   * Phase-1 push activity (issue #704), fed by HookIngest.onSignal for both
+   * `PostToolUse` (`status:"ok"`) and `PostToolUseFailure` (`status:"error"`). Builds
+   * a `SessionActivity` from the tool name + a windowed heat-strip tick and routes it
+   * through the existing dedup `emitActivity` — the SAME sink the poll path uses, so
+   * push + poll never bypass the dedup or oscillate. A `PostToolUse` push carries a
+   * REAL tool summary (vs. the interim heartbeat's `summary:null`), so it beats the
+   * interim emit on the freshness guard below.
+   *
+   * No-op when `config.hooksSignals` is off (the sink is never wired in that case, so
+   * this is belt-and-suspenders for direct callers/tests). Records `lastHookActivityAt`
+   * so `maybeProbe` knows the push path is fresh.
+   */
+  ingestActivity(
+    id: string,
+    ev: { toolName?: string; status?: "ok" | "error"; ts?: number },
+  ): void {
+    if (!config.hooksSignals) return;
+    const t = ev.ts ?? this.now();
+    // heat-strip: append this tick, window to STRIP_WINDOW_MS (mirror probeTerminalInterim).
+    // Skip a duplicate same-ms tick so two events stamped identically dedupe through
+    // `emitActivity` (the strip would otherwise differ → spurious re-emit).
+    const ticks = this.hookTicks.get(id) ?? [];
+    if (ticks[ticks.length - 1] !== t) ticks.push(t);
+    const cutoff = t - STRIP_WINDOW_MS;
+    const windowed = ticks.filter((ts) => ts >= cutoff);
+    this.hookTicks.set(id, windowed);
+    // recentErrTs: only the error ticks within the window (a failure feeds error heat
+    // via the push path so the freshness guard below can safely suppress the probe's
+    // redundant emit without dropping error signal — Finding 3). We don't retain a
+    // separate error-tick list across calls (the strip is coarse + windowed), so a
+    // single push contributes its own `t` to recentErrTs when it's an error.
+    const recentErrTs = ev.status === "error" ? [t] : [];
+    this.emitActivity(id, {
+      lastActivityTs: t,
+      // A real tool name — non-null so it beats the interim `summary:null` heartbeat.
+      // We don't have rich tool_input here; the bare tool name is the available summary.
+      summary: ev.toolName ?? null,
+      recentTs: windowed,
+      recentErrTs,
+    });
+    this.lastHookActivityAt.set(id, t);
+  }
+
+  /**
+   * Phase-1 push notification (issue #704), fed by HookIngest.onSignal for
+   * `Notification` events. An awaiting-input type (see BLOCK_NOTIFICATION_TYPES) sets a
+   * marker consumed by `reconcileAgent` to classify THIS tick — surfacing the block
+   * ≤ ~1 tick after the agent asks, independent of herdr's latchy `blocked` status.
+   * `idle_prompt` clears the marker (idle is handled by herdr mapping; never force a
+   * block). Any other type is a no-op here — unknown types are already logged upstream,
+   * and an awaiting-input edge we haven't confirmed simply stays on the existing
+   * `herdr-blocked → classifyBlocked` fallback (no regression).
+   *
+   * No-op when `config.hooksSignals` is off.
+   */
+  ingestNotification(id: string, type: string): void {
+    if (!config.hooksSignals) return;
+    if (BLOCK_NOTIFICATION_TYPES.has(type)) this.hookAwaitingInput.add(id);
+    else if (type === "idle_prompt") this.hookAwaitingInput.delete(id);
+    // else: unknown/other type → no-op (dormant; fallback detection unchanged).
   }
 
   /**
@@ -465,8 +619,20 @@ export class StatusPoller {
     this.resetInterim(s.id);
 
     // ── activity emit (deduped by signal content) ──
+    // Phase-1 freshness guard (issue #704, Finding 3): when push activity is fresh, the
+    // push path already carries this session with a REAL tool summary (vs. the
+    // transcript probe's), so skip the probe's redundant *non-error* activity emit.
+    // Stall evaluation below still runs UNCHANGED — hooks only tighten the active path;
+    // the pure-generation stall cross-check is untouched. Error heat is NEVER dropped:
+    // `PostToolUseFailure` feeds `recentErrTs` via the push path, so suppression is
+    // safe — and as a belt-and-suspenders guard, if the probe carries error heat the
+    // push hasn't emitted, we still emit it.
     if (signals.activity) {
-      this.emitActivity(s.id, signals.activity);
+      if (this.hookActivityFresh(s.id, t) && signals.activity.recentErrTs.length === 0) {
+        // fresh push + no probe-side error heat → push path owns the activity emit
+      } else {
+        this.emitActivity(s.id, signals.activity);
+      }
     }
 
     // ── stall decision: transcript candidate + live-terminal liveness gate ──
@@ -539,7 +705,13 @@ export class StatusPoller {
       const changed = prev !== undefined && visible !== prev;
 
       // 1. heartbeat: a changed buffer is one live "tick"; window the list.
-      if (changed) {
+      // Phase-1 freshness guard (issue #704, Finding 3): when push activity is fresh,
+      // the push path carries this session with a REAL tool summary, so skip the
+      // interim's redundant `summary:null` heartbeat emit. The interim heartbeat
+      // carries no error heat (recentErrTs is always empty here), so suppression can
+      // never drop error signal. The stall logic below STILL runs — the interim
+      // terminal-freeze stall cross-check is untouched.
+      if (changed && !this.hookActivityFresh(id, t)) {
         const ticks = this.interimTicks.get(id) ?? [];
         ticks.push(t);
         const cutoff = t - STRIP_WINDOW_MS;
@@ -571,6 +743,20 @@ export class StatusPoller {
     } finally {
       this.interimInFlight.delete(id);
     }
+  }
+
+  /**
+   * Phase-1 (issue #704): is the push (PostToolUse) activity for this session fresh
+   * enough that the transcript/interim probe should defer its redundant activity emit?
+   * Fresh = a push landed within `2 × probeCheckMs` (two probe cadences — long enough
+   * to bridge the gap between two pushes, short enough that a gone-quiet push hands the
+   * active path back to the probe). Always false when `hooksSignals` is off (the map
+   * stays empty), so the probe emits exactly as today — the fallback.
+   */
+  private hookActivityFresh(id: string, now: number): boolean {
+    if (!config.hooksSignals) return false;
+    const at = this.lastHookActivityAt.get(id);
+    return at !== undefined && now - at < 2 * this.probeCheckMs;
   }
 
   /** Emit an activity signal, deduped by content so clients see only real changes. */
@@ -661,9 +847,10 @@ export class StatusPoller {
    * false)` fires first, then `onBlock`, in the same tick — clients see the flag drop
    * and the block land together.
    */
-  private maybeClassify(id: string, term: string): void {
+  private maybeClassify(id: string, term: string): boolean {
     const t = this.now();
-    if (t - (this.lastReadAt.get(id) ?? 0) < this.reclassifyMs) return;
+    // Throttled this tick → did NOT look (caller may keep an awaiting marker to retry).
+    if (t - (this.lastReadAt.get(id) ?? 0) < this.reclassifyMs) return false;
     this.lastReadAt.set(id, t);
     let visible: string;
     let reason: BlockReason;
@@ -672,14 +859,14 @@ export class StatusPoller {
       reason = this.classify(visible);
     } catch (err) {
       console.warn(`[poller] classify failed for ${id}:`, err);
-      return; // best-effort; retry next cadence
+      return false; // best-effort; retry next cadence (didn't classify → didn't look)
     }
     if (reason.shape === "awaiting-input" && hasActiveSpinner(visible)) {
       // herdr can latch "blocked" after an answered dialog; a live spinner means the
       // agent resumed working — clear any announced block instead of emitting the
       // no-evidence fallback. (suppression scoped to awaiting-input only: a genuine
       // menu/y-n dialog must always surface, spinner or not)
-      if (this.trySuppressSpinner(id, visible)) return;
+      if (this.trySuppressSpinner(id, visible)) return true; // looked this tick (suppressed emit)
       // Freshness gate tripped: the buffer did NOT advance since the last classify
       // read — a wedged turn or a static buffer quoting a spinner-like line, not a
       // live spinner. Fall through to the normal emit so the block re-arms (flag-off
@@ -693,12 +880,13 @@ export class StatusPoller {
       this.lastSuppressVisible.delete(id);
     }
     const sig = JSON.stringify(reason);
-    if (sig === this.lastSig.get(id)) return;
+    if (sig === this.lastSig.get(id)) return true; // looked this tick (dedup short-circuit)
     // Re-arm: a block is about to be emitted → end the suppression episode FIRST so
     // the flag-off and the block reach clients in the same tick, in that order.
     if (this.workingWhileBlocked.delete(id)) this.onWorkingBlocked(id, false);
     this.lastSig.set(id, sig);
     this.onBlock(id, reason);
+    return true; // looked + classified this tick
   }
 
   /**

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -14,15 +14,17 @@ const STALL_SIG = "stall"; // fixed signature → a stall fires once per episode
 
 /**
  * Notification `notification_type`s that assert an awaiting-input edge (Phase 1,
- * issue #704). Deliberately a small, named constant: under
- * `--dangerously-skip-permissions` (how Shepherd spawns every agent)
- * `Notification(permission_prompt)` may NEVER fire, and the real pausing cases
- * (`AskUserQuestion`, `ExitPlanMode`) emit an UNVERIFIED notification_type. The
- * Phase-0 spike must confirm which type(s) those actually emit and ADD them here;
- * until then this set may simply never match in practice, in which case the block
- * trigger stays dormant and detection cleanly degrades to the existing
- * `herdr-blocked → classifyBlocked` fallback — the intended no-regression path.
- * `idle_prompt` is deliberately NOT here (idle is handled by herdr mapping).
+ * issue #704). Deliberately a small, named constant because under
+ * `--dangerously-skip-permissions` (how Shepherd spawns every agent) tool-permission
+ * prompts are suppressed, so it was unclear whether the real pausing cases emit a
+ * usable edge. CONFIRMED by the Phase-0 live spike (2026-06-15): an `AskUserQuestion`
+ * pause fires `Notification(permission_prompt)` even under skip-permissions — so this
+ * set matches that (the common interactive-pause) case. `ExitPlanMode`/plan-approval
+ * is not yet confirmed; ADD its type here once a spike observes it. If a pausing case
+ * emits no matching type, the block trigger simply stays dormant for it and detection
+ * cleanly degrades to the existing `herdr-blocked → classifyBlocked` fallback — the
+ * intended no-regression path. `idle_prompt` is deliberately NOT here (idle is handled
+ * by herdr mapping).
  */
 const BLOCK_NOTIFICATION_TYPES = new Set(["permission_prompt"]);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -187,8 +187,11 @@ export interface AppDeps {
   push?: Pick<PushService, "publicKey" | "subscribe" | "unsubscribe">;
   /** Active-window tracker fed by /events presence frames; gates push suppression. */
   presence?: Pick<Presence, "set" | "drop">;
-  /** Status poller; used to manually dismiss a stall flag. Absent in tests. */
-  poller?: Pick<StatusPoller, "acknowledgeStall">;
+  /** Status poller; used to manually dismiss a stall flag (`acknowledgeStall`) and, when
+   *  `hooksSignals` is on, as the Phase-1 signal sink the index.ts onSignal closure feeds
+   *  push events to (`ingestActivity` / `ingestNotification` — issue #704). The route
+   *  itself never calls the ingest methods; the onSignal closure in index.ts does. */
+  poller?: Pick<StatusPoller, "acknowledgeStall" | "ingestActivity" | "ingestNotification">;
   /** Phase-0 hook ingest ring buffer (issue #704); absent in tests/envs that skip it.
    *  `record` is observe-only here — it forwards to signals only when Task 3 wires
    *  `onSignal` (the `hooksSignals` flag). */

--- a/src/server.ts
+++ b/src/server.ts
@@ -105,6 +105,7 @@ import {
   isSandboxProfile,
   SandboxAutoRefused,
 } from "./sandbox";
+import { validateHookEvent, type HookEvent } from "./hooks-ingest";
 
 const UI_DIR = join(import.meta.dir, "..", "ui", "build");
 
@@ -188,6 +189,10 @@ export interface AppDeps {
   presence?: Pick<Presence, "set" | "drop">;
   /** Status poller; used to manually dismiss a stall flag. Absent in tests. */
   poller?: Pick<StatusPoller, "acknowledgeStall">;
+  /** Phase-0 hook ingest ring buffer (issue #704); absent in tests/envs that skip it.
+   *  `record` is observe-only here — it forwards to signals only when Task 3 wires
+   *  `onSignal` (the `hooksSignals` flag). */
+  hooks?: { record(id: string, ev: HookEvent): void; snapshot(id: string): HookEvent[] };
   /** Snapshot of critic verdicts keyed by session id (+ in-flight run ids); absent in tests that skip it. */
   reviewCache?: {
     snapshot(): Record<string, import("./types").ReviewVerdict>;
@@ -1607,6 +1612,39 @@ function approveBuildQueue(deps: AppDeps, id: string): Response {
   deps.events?.emit("queue:update", q);
   deps.service.reply(id, APPROVE_STEER); // best-effort; ignore boolean return
   return json(q);
+}
+
+// /api/sessions/:id/hooks — Phase-0 push-hook ingest (issue #704).
+// Returns null for any path it doesn't own so other session sub-routes fall through
+// (registered before handleSessions, mirroring handleBuildQueue's ordering rationale).
+//
+// Deliberately NO requireJsonContentType gate (Finding 1): the POST body is authored by
+// Claude Code's own http-hook client, not a Shepherd curl with an explicit
+// `Content-Type: application/json`, so its Content-Type is unverified — a hard 415 could
+// silently record ZERO events for the whole spike. Parse defensively instead. The handler
+// does validate + record only — no file parse, no synchronous PTY/herdr read on the Bun
+// loop (memory: single-loop-no-sync-exec).
+async function handleSessionHooks({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(parts[0] === "api" && parts[1] === "sessions" && parts[3] === "hooks")) return null;
+  const id = parts[2];
+  if (!id || parts[4]) return null;
+
+  if (req.method === "GET") return json(deps.hooks?.snapshot(id) ?? []);
+  if (req.method !== "POST") return null;
+
+  const session = deps.store.get(id);
+  if (!session) return json({ error: "session not found" }, 404);
+
+  const body = await req.json().catch(() => null);
+  const raw = validateHookEvent(body);
+  if (!raw) return json({ error: "invalid hook event" }, 400);
+
+  // Cross-check the untrusted body's session_id against the resolved session's
+  // claudeSessionId. On mismatch we still record (for the spike's visibility) but flag
+  // `match: false` so HookIngest treats it as observe-only and never forwards to signals.
+  const match = raw.sessionId === session.claudeSessionId;
+  deps.hooks?.record(id, { ...raw, receivedAt: Date.now(), match });
+  return json({ ok: true }, 202);
 }
 
 // /api/sessions/:id/queue[/steps/:stepId | /approve]
@@ -3456,6 +3494,7 @@ const ROUTE_HANDLERS = [
   handleRepoCollaborators,
   handleLearnings,
   handlePush,
+  handleSessionHooks,
   handleBuildQueue,
   handleSessions,
   handleSessionGit,

--- a/src/service.ts
+++ b/src/service.ts
@@ -199,8 +199,17 @@ export function resetPluginIdsCacheForTests(): void {
  * which overrides the global `true` per-spawn and kills plugin SessionStart hooks, plugin
  * skills, and plugin MCP for this process only. Absent/empty → key omitted entirely, so
  * untrimmed spawns keep today's exact overlay.
+ *
+ * `hooks` (issue #704, only when `config.hooksIngest`) adds PostToolUse/PostToolUseFailure/
+ * Notification HTTP hooks pointing at this session's ingest route (see buildHooksFragment).
+ * Flag off → key omitted entirely, so the overlay JSON stays byte-for-byte identical to today.
  */
-export function spawnSettingsOverlay(opts: { disablePlugins?: string[] } = {}): string {
+export function spawnSettingsOverlay(
+  opts: {
+    disablePlugins?: string[];
+    hooks?: { sessionId: string; baseUrl: string; token: string | null };
+  } = {},
+): string {
   const settings: Record<string, unknown> = {
     remoteControlAtStartup: config.remoteControlAtStartup,
     env: { ENABLE_CLAUDEAI_MCP_SERVERS: "false" },
@@ -208,10 +217,50 @@ export function spawnSettingsOverlay(opts: { disablePlugins?: string[] } = {}): 
   if (opts.disablePlugins && opts.disablePlugins.length > 0) {
     settings.enabledPlugins = Object.fromEntries(opts.disablePlugins.map((id) => [id, false]));
   }
+  if (config.hooksIngest && opts.hooks) {
+    settings.hooks = buildHooksFragment(opts.hooks);
+  }
   // api-key mode folds in `apiKeyHelper` LAST so key order is stable; subscription
   // returns {} so the JSON is byte-for-byte identical to before (see spawn-auth).
   Object.assign(settings, apiKeySettingsFragment());
   return JSON.stringify(settings);
+}
+
+/**
+ * Build the `hooks` overlay fragment (issue #704): one synchronous `http` hook per event
+ * (PostToolUse, PostToolUseFailure, Notification), matcher `"*"`, short fail-open timeout,
+ * pointed at `POST <baseUrl>/api/sessions/<sessionId>/hooks`.
+ *
+ * Auth (Finding 2): the `--settings` JSON rides the spawn process argv (ps-visible), NOT the
+ * transcript — so we NEVER bake the literal token. When a token is configured we emit a
+ * `$SHEPHERD_TOKEN` placeholder + `allowedEnvVars`; Claude Code resolves it from the hook
+ * process env (only listed vars are interpolated). With no token (open loopback) we omit the
+ * `headers` + `allowedEnvVars` keys entirely, matching the queue route's no-auth path.
+ */
+export function buildHooksFragment(input: {
+  sessionId: string;
+  baseUrl: string;
+  token: string | null;
+}): Record<string, unknown> {
+  const authFields: Record<string, unknown> =
+    input.token !== null
+      ? {
+          headers: { Authorization: "Bearer $SHEPHERD_TOKEN" },
+          allowedEnvVars: ["SHEPHERD_TOKEN"],
+        }
+      : {};
+  const httpHook = {
+    type: "http",
+    url: `${input.baseUrl}/api/sessions/${input.sessionId}/hooks`,
+    timeout: 5,
+    ...authFields,
+  };
+  const eventEntry = [{ matcher: "*", hooks: [httpHook] }];
+  return {
+    PostToolUse: eventEntry,
+    PostToolUseFailure: eventEntry,
+    Notification: eventEntry,
+  };
 }
 
 /**
@@ -995,7 +1044,13 @@ export class SessionService {
       claudeSessionId,
       ...trim.extraFlags,
     ];
-    argv.push("--settings", spawnSettingsOverlay(trim.overlayOpts));
+    argv.push(
+      "--settings",
+      spawnSettingsOverlay({
+        ...trim.overlayOpts,
+        hooks: { sessionId, baseUrl: agentBaseUrl(), token: config.token },
+      }),
+    );
     argv.push(
       "--append-system-prompt",
       composeSystemPrompt(houseRules, autopilotActive, {
@@ -1455,7 +1510,13 @@ export class SessionService {
       s.claudeSessionId,
       ...trim.extraFlags,
     ];
-    innerArgv.push("--settings", spawnSettingsOverlay(trim.overlayOpts));
+    innerArgv.push(
+      "--settings",
+      spawnSettingsOverlay({
+        ...trim.overlayOpts,
+        hooks: { sessionId: s.id, baseUrl: agentBaseUrl(), token: config.token },
+      }),
+    );
     if (s.model) innerArgv.push("--model", s.model);
     const outcome = this.prepareSpawn(innerArgv, {
       sessionId: s.id,

--- a/test/hooks-ingest.test.ts
+++ b/test/hooks-ingest.test.ts
@@ -1,0 +1,155 @@
+import { test, expect } from "bun:test";
+import { validateHookEvent, HookIngest, type HookEvent } from "../src/hooks-ingest";
+
+// ── validateHookEvent (pure, untrusted body) ──────────────────────────────────
+
+test("validateHookEvent: PostToolUse with exit 0 → status ok", () => {
+  const ev = validateHookEvent({
+    session_id: "s1",
+    hook_event_name: "PostToolUse",
+    tool_name: "Bash",
+    tool_output: { stdout: "hi", stderr: "", exit_code: 0 },
+  });
+  expect(ev).toEqual({
+    event: "PostToolUse",
+    sessionId: "s1",
+    toolName: "Bash",
+    status: "ok",
+    exitCode: 0,
+  });
+});
+
+test("validateHookEvent: exit_code !== 0 → status error", () => {
+  const ev = validateHookEvent({
+    session_id: "s1",
+    hook_event_name: "PostToolUse",
+    tool_name: "Bash",
+    tool_output: { exit_code: 2 },
+  });
+  expect(ev?.status).toBe("error");
+  expect(ev?.exitCode).toBe(2);
+});
+
+test("validateHookEvent: PostToolUseFailure → status error regardless of code", () => {
+  const ev = validateHookEvent({
+    session_id: "s1",
+    hook_event_name: "PostToolUseFailure",
+    tool_name: "Edit",
+  });
+  expect(ev).toEqual({
+    event: "PostToolUseFailure",
+    sessionId: "s1",
+    toolName: "Edit",
+    status: "error",
+    exitCode: undefined,
+  });
+});
+
+test("validateHookEvent: reads tool_response as a defensive fallback for tool_output", () => {
+  const ev = validateHookEvent({
+    session_id: "s1",
+    hook_event_name: "PostToolUse",
+    tool_response: { exit_code: 1 },
+  });
+  expect(ev?.status).toBe("error");
+});
+
+test("validateHookEvent: Notification with type", () => {
+  const ev = validateHookEvent({
+    session_id: "s1",
+    hook_event_name: "Notification",
+    notification_type: "idle_prompt",
+    message: "waiting",
+  });
+  expect(ev).toEqual({
+    event: "Notification",
+    sessionId: "s1",
+    notificationType: "idle_prompt",
+    message: "waiting",
+    unknown: false,
+  });
+});
+
+test("validateHookEvent: missing session_id → null", () => {
+  expect(validateHookEvent({ hook_event_name: "PostToolUse" })).toBeNull();
+  expect(validateHookEvent({ session_id: 42, hook_event_name: "PostToolUse" })).toBeNull();
+});
+
+test("validateHookEvent: non-object → null", () => {
+  expect(validateHookEvent(null)).toBeNull();
+  expect(validateHookEvent("nope")).toBeNull();
+  expect(validateHookEvent(123)).toBeNull();
+});
+
+test("validateHookEvent: unknown hook_event_name → accepted with unknown:true (not dropped)", () => {
+  const ev = validateHookEvent({ session_id: "s1", hook_event_name: "SubagentStart" });
+  expect(ev).toEqual({ event: "SubagentStart", sessionId: "s1", unknown: true });
+});
+
+test("validateHookEvent: Notification with unknown/absent type → flagged unknown, not dropped", () => {
+  const ev = validateHookEvent({ session_id: "s1", hook_event_name: "Notification" });
+  expect(ev?.event).toBe("Notification");
+  expect(ev?.unknown).toBe(true);
+});
+
+// ── HookIngest ring buffer ─────────────────────────────────────────────────────
+
+function ev(over: Partial<HookEvent> = {}): HookEvent {
+  return { event: "PostToolUse", sessionId: "s1", receivedAt: Date.now(), ...over };
+}
+
+test("HookIngest: record + snapshot round-trips", () => {
+  const h = new HookIngest();
+  h.record("s1", ev({ toolName: "Bash" }));
+  const snap = h.snapshot("s1");
+  expect(snap).toHaveLength(1);
+  expect(snap[0]?.toolName).toBe("Bash");
+});
+
+test("HookIngest: snapshot returns a copy (mutation does not leak back)", () => {
+  const h = new HookIngest();
+  h.record("s1", ev());
+  const snap = h.snapshot("s1");
+  snap.push(ev());
+  expect(h.snapshot("s1")).toHaveLength(1);
+});
+
+test("HookIngest: snapshot of unknown session → []", () => {
+  expect(new HookIngest().snapshot("nope")).toEqual([]);
+});
+
+test("HookIngest: ring buffer caps at 50, evicting oldest", () => {
+  const h = new HookIngest();
+  for (let i = 0; i < 60; i++) h.record("s1", ev({ exitCode: i }));
+  const snap = h.snapshot("s1");
+  expect(snap).toHaveLength(50);
+  expect(snap[0]?.exitCode).toBe(10); // first 10 evicted
+  expect(snap[49]?.exitCode).toBe(59);
+});
+
+test("HookIngest: prune drops inactive sessions", () => {
+  const h = new HookIngest();
+  h.record("s1", ev());
+  h.record("s2", ev({ sessionId: "s2" }));
+  h.prune(new Set(["s1"]));
+  expect(h.snapshot("s1")).toHaveLength(1);
+  expect(h.snapshot("s2")).toEqual([]);
+});
+
+test("HookIngest: onSignal called on matched event, skipped on mismatch", () => {
+  const seen: string[] = [];
+  const h = new HookIngest((id) => seen.push(id));
+  h.record("s1", ev({ match: true }));
+  h.record("s1", ev({ match: false }));
+  h.record("s1", ev()); // match undefined ⇒ treated as ok
+  expect(seen).toEqual(["s1", "s1"]);
+});
+
+test("HookIngest: record never throws even if onSignal does", () => {
+  const h = new HookIngest(() => {
+    throw new Error("boom");
+  });
+  expect(() => h.record("s1", ev({ match: true }))).not.toThrow();
+  // The event is still buffered despite the forward fault.
+  expect(h.snapshot("s1")).toHaveLength(1);
+});

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -6,6 +6,7 @@ import type { HerdrAgent } from "../src/herdr";
 import { classifyBlocked } from "../src/blocked";
 import { DEFAULT_STALL } from "../src/stall";
 import { maintenance } from "../src/maintenance";
+import { config } from "../src/config";
 
 const baseSession = {
   name: "x",
@@ -2161,4 +2162,335 @@ test("tick() swallows a herdr.list() throw (no crash, no reap)", () => {
   // must NOT throw (an unhandled throw on the 1s interval would crash shepherd)
   expect(() => poller.tick()).not.toThrow();
   expect(reaped).toBe(false); // tick bailed before touching the store
+});
+
+// ── Phase-1 push-hook ingestion (issue #704) ──────────────────────────────────
+//
+// `config.hooksSignals` gates the whole feature; save/restore it per-test so the
+// flag never leaks across the suite (default off ⇒ ingest* are inert).
+
+/** A running-agent harness for the push-hook tests: a `working` herdr agent whose
+ *  status + visible buffer are swappable, capturing block + activity emissions. The
+ *  transcript probe returns null by default (interim path) so the freshness guard's
+ *  interaction with the interim heartbeat is exercisable. */
+function hookHarness(opts?: {
+  visible?: () => string;
+  probe?: () => { snapshot: any; activity: any };
+  stallCfg?: { stallMs: number; pendingStallMs: number };
+}) {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const activities: { id: string; activity: any }[] = [];
+  const blocks: { id: string; block: any }[] = [];
+  let agentStatus = "working";
+  let clock = 1_700_000_000_000;
+  const visible = opts?.visible ?? (() => "Computing… (1s)");
+  const pruned: Array<Set<string>> = [];
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      } as HerdrAgent,
+    ],
+    read: () => visible(),
+    readAsync: () => Promise.resolve(visible()),
+  };
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    opts?.probe ?? (() => ({ snapshot: null, activity: null })),
+    opts?.stallCfg ?? { stallMs: 1, pendingStallMs: 1 },
+    7000, // probeCheckMs
+    () => {},
+    (id, activity) => activities.push({ id, activity }),
+    undefined, // preview
+    undefined, // liveness
+    () => {}, // onWorkingBlocked
+    (ids) => pruned.push(new Set(ids)), // pruneHooks
+  );
+  return {
+    poller,
+    store,
+    activities,
+    blocks,
+    pruned,
+    id: s.id,
+    setStatus: (st: string) => (agentStatus = st),
+    advance: (ms: number) => (clock += ms),
+    now: () => clock,
+  };
+}
+
+test("hooks: ingestActivity emits a deduped session:activity with a non-null summary + tick", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = hookHarness();
+    h.poller.ingestActivity(h.id, { toolName: "Edit", status: "ok", ts: h.now() });
+    expect(h.activities).toHaveLength(1);
+    const a = h.activities[0]!.activity;
+    expect(a.summary).toBe("Edit");
+    expect(a.recentTs).toEqual([h.now()]);
+    expect(a.lastActivityTs).toBe(h.now());
+    expect(a.recentErrTs).toEqual([]);
+
+    // identical call → dedup (no re-emit)
+    h.poller.ingestActivity(h.id, { toolName: "Edit", status: "ok", ts: h.now() });
+    expect(h.activities).toHaveLength(1);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: PostToolUseFailure (status:error) populates recentErrTs", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = hookHarness();
+    h.poller.ingestActivity(h.id, { toolName: "Bash", status: "error", ts: h.now() });
+    expect(h.activities).toHaveLength(1);
+    const a = h.activities[0]!.activity;
+    expect(a.summary).toBe("Bash");
+    expect(a.recentErrTs).toEqual([h.now()]);
+    expect(a.recentTs).toEqual([h.now()]);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: a permission_prompt notification triggers maybeClassify on the next (non-blocked) tick, consumed once", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    // agent stays herdr-"working" (not blocked) yet the TUI shows a menu → the push
+    // notification, not herdr's latch, surfaces the block.
+    const h = hookHarness({ visible: () => "❯ 1. Yes\n  2. No" });
+    h.poller.ingestNotification(h.id, "permission_prompt");
+
+    h.poller.tick();
+    expect(h.blocks).toHaveLength(1);
+    expect((h.blocks[0]!.block as any).shape).toBe("menu");
+
+    // marker consumed → a later tick does NOT re-classify/re-fire (sig-deduped anyway,
+    // but the marker is gone so the awaiting branch never even runs again)
+    h.advance(5000);
+    h.poller.tick();
+    expect(h.blocks).toHaveLength(1);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: a throttled awaiting tick KEEPS the marker and retries once the cadence passes", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    // status stays herdr-"working" so only the push marker (never herdr's latch / the
+    // maybeProbe path) can surface the block. The buffer is swappable so a later
+    // classify yields a fresh sig (proves the retried classify actually re-emitted vs.
+    // dedup short-circuited).
+    let buf = "❯ 1. Yes\n  2. No";
+    const h = hookHarness({ visible: () => buf });
+
+    // Prime `lastReadAt` fresh: a blocked tick runs maybeClassify (records the read
+    // time + emits the first menu block), then drop back to working.
+    h.setStatus("blocked");
+    h.poller.tick();
+    expect(h.blocks).toHaveLength(1);
+    h.setStatus("working");
+
+    // Marker arrives but a classify just ran (<reclassifyMs ago) → this tick is
+    // throttled. maybeClassify returns false, so the marker is NOT consumed and no
+    // new block fires.
+    h.poller.ingestNotification(h.id, "permission_prompt");
+    h.advance(1000); // < reclassifyMs (3000)
+    h.poller.tick();
+    expect(h.blocks).toHaveLength(1); // still throttled, nothing new
+
+    // Cadence passes → the RETAINED marker drives a real classify this tick. Vary the
+    // buffer so the sig differs from the primed menu and the emit isn't dedup-skipped.
+    buf = "❯ 1. Approve\n  2. Deny\n  3. Cancel";
+    h.advance(3000); // now > reclassifyMs since the priming read
+    h.poller.tick();
+    expect(h.blocks).toHaveLength(2); // classify ran → block re-emitted
+    expect((h.blocks[1]!.block as any).shape).toBe("menu");
+
+    // Marker now consumed: a further (post-cadence) tick does not re-fire.
+    h.advance(3000);
+    h.poller.tick();
+    expect(h.blocks).toHaveLength(2);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: idle_prompt does NOT trigger a block", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = hookHarness({ visible: () => "❯ 1. Yes\n  2. No" });
+    h.poller.ingestNotification(h.id, "idle_prompt");
+    h.poller.tick();
+    expect(h.blocks).toHaveLength(0);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: freshness guard suppresses the interim activity emit while push is fresh", async () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    // interim path (probe null); terminal changes each cadence → normally a heartbeat
+    // tick emits. A fresh push must suppress that redundant null-summary emit.
+    let frame = 0;
+    const h = hookHarness({ visible: () => `Computing… (${frame}s)` });
+
+    // prime the interim baseline
+    h.poller.tick();
+    await flush();
+    expect(h.activities).toHaveLength(0);
+
+    // a fresh push lands (carries the real summary)
+    h.poller.ingestActivity(h.id, { toolName: "Read", status: "ok", ts: h.now() });
+    expect(h.activities).toHaveLength(1); // the push emit
+    expect(h.activities[0]!.activity.summary).toBe("Read");
+
+    // next probe: terminal changed (would emit a null-summary heartbeat) but push is
+    // fresh → suppressed. The only activity remains the push emit.
+    frame += 7;
+    h.advance(7000);
+    h.poller.tick();
+    await flush();
+    const interimEmits = h.activities.filter((a) => a.activity.summary === null);
+    expect(interimEmits).toHaveLength(0);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: freshness guard keeps the transcript stall firing for a frozen pure-generation turn", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    // live-writing transcript that's a 10m-old silence candidate (frozen terminal) →
+    // stall must still fire even while a push keeps the activity path fresh.
+    const visible = "still chewing on it";
+    const h = hookHarness({
+      visible: () => visible,
+      probe: () => ({ snapshot: { lastTs: h.now() - 600_000, pending: false }, activity: null }),
+      stallCfg: { stallMs: 1, pendingStallMs: 1 },
+    });
+
+    // keep the push fresh throughout
+    const refresh = () =>
+      h.poller.ingestActivity(h.id, { toolName: "Edit", status: "ok", ts: h.now() });
+
+    refresh();
+    h.poller.tick(); // priming: first sighting → interim, records transcript baseline
+    h.advance(7000);
+    refresh();
+    h.poller.tick(); // transcript path → terminal baseline, no stall yet
+    expect(h.blocks).toHaveLength(0);
+    h.advance(7000);
+    refresh();
+    h.poller.tick(); // frozen terminal + silent transcript → stall STILL fires
+    expect(h.blocks).toHaveLength(1);
+    expect((h.blocks[0]!.block as any).shape).toBe("stall");
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: freshness guard still emits the probe's activity when it carries error heat the push didn't", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    // transcript probe carries a recentErrTs while a non-error push is fresh — the
+    // belt-and-suspenders guard must still emit it (never drop error heat, Finding 3).
+    const h = hookHarness({
+      probe: () => ({
+        snapshot: null,
+        activity: {
+          lastActivityTs: h.now(),
+          summary: "$ bun test",
+          recentTs: [h.now()],
+          recentErrTs: [h.now()],
+        },
+      }),
+    });
+
+    // fresh non-error push
+    h.poller.ingestActivity(h.id, { toolName: "Read", status: "ok", ts: h.now() });
+    const pushEmits = h.activities.length;
+
+    // prime then advance so the transcript path engages (newest record advances)
+    h.poller.tick();
+    h.advance(8000);
+    h.poller.ingestActivity(h.id, { toolName: "Read", status: "ok", ts: h.now() }); // keep fresh
+    h.poller.tick();
+
+    // the probe's error-bearing signal was emitted despite the fresh push
+    const errEmits = h.activities.filter((a) => a.activity.recentErrTs.length > 0);
+    expect(errEmits.length).toBeGreaterThan(0);
+    expect(h.activities.length).toBeGreaterThan(pushEmits);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: pruneInactive clears the new maps and calls pruneHooks", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = hookHarness();
+    h.poller.ingestActivity(h.id, { toolName: "Edit", status: "ok", ts: h.now() });
+    h.poller.ingestNotification(h.id, "permission_prompt");
+
+    // archive the session → it leaves the activeOnly list → pruneInactive
+    h.store.update(h.id, { status: "archived" });
+    h.advance(1000);
+    h.poller.tick();
+
+    // pruneHooks called with the (now empty) active set
+    expect(h.pruned.length).toBeGreaterThan(0);
+    expect(h.pruned[h.pruned.length - 1]!.has(h.id)).toBe(false);
+
+    // re-ingesting after prune starts a fresh strip (no stale ticks): a single tick
+    config.hooksSignals = true;
+    h.poller.ingestActivity(h.id, { toolName: "Edit", status: "ok", ts: h.now() });
+    const a = h.activities[h.activities.length - 1]!.activity;
+    expect(a.recentTs).toEqual([h.now()]); // exactly one tick → strip was pruned
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: ingest* are inert when config.hooksSignals is off", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = false;
+  try {
+    const h = hookHarness({ visible: () => "❯ 1. Yes\n  2. No" });
+    h.poller.ingestActivity(h.id, { toolName: "Edit", status: "ok", ts: h.now() });
+    expect(h.activities).toHaveLength(0); // no emit
+
+    h.poller.ingestNotification(h.id, "permission_prompt");
+    h.poller.tick();
+    expect(h.blocks).toHaveLength(0); // no block trigger
+  } finally {
+    config.hooksSignals = orig;
+  }
 });

--- a/test/server-hooks.test.ts
+++ b/test/server-hooks.test.ts
@@ -1,0 +1,144 @@
+import { test, expect, afterEach } from "bun:test";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { HookIngest } from "../src/hooks-ingest";
+import { config } from "../src/config";
+
+const origToken = config.token;
+afterEach(() => {
+  config.token = origToken;
+});
+
+// The route resolves the session by `s.id` (path) and cross-checks the body's
+// `session_id` against the session's `claudeSessionId` (two distinct UUIDs).
+const CLAUDE_SID = "claude-sid-xyz";
+
+function harness(onSignal?: (id: string) => void) {
+  const store = new SessionStore(":memory:");
+  const hooks = new HookIngest(onSignal ? (id) => onSignal(id) : undefined);
+  const deps: AppDeps = {
+    store,
+    service: {} as any,
+    events: new EventHub(),
+    usageLimits: { limits: () => ({}) } as any,
+    hooks,
+  };
+  const session = store.create({
+    name: "t",
+    prompt: "p",
+    repoPath: "/wt",
+    baseBranch: "main",
+    branch: "shepherd/t",
+    worktreePath: "/wt",
+    isolated: false,
+    herdrSession: "sess-x",
+    herdrAgentId: "agent-x",
+    claudeSessionId: CLAUDE_SID,
+    model: null,
+  });
+  return { app: makeApp(deps), store, hooks, session };
+}
+
+function post(app: ReturnType<typeof makeApp>, id: string, body: unknown, opts: RequestInit = {}) {
+  return app.fetch(
+    new Request(`http://x/api/sessions/${id}/hooks`, {
+      method: "POST",
+      body: typeof body === "string" ? body : JSON.stringify(body),
+      ...opts,
+    }),
+  );
+}
+
+const validEvent = {
+  session_id: CLAUDE_SID,
+  hook_event_name: "PostToolUse",
+  tool_name: "Bash",
+  tool_output: { exit_code: 0 },
+};
+
+test("POST valid event → 202, recorded, and GET snapshot returns it", async () => {
+  const { app, session } = harness();
+  const res = await post(app, session.id, validEvent, {
+    headers: { "content-type": "application/json" },
+  });
+  expect(res.status).toBe(202);
+  expect(await res.json()).toEqual({ ok: true });
+
+  const snap = await app.fetch(new Request(`http://x/api/sessions/${session.id}/hooks`));
+  expect(snap.status).toBe(200);
+  const events = await snap.json();
+  expect(events).toHaveLength(1);
+  expect(events[0].toolName).toBe("Bash");
+  expect(events[0].match).toBe(true);
+});
+
+test("POST without application/json content-type still parses → 202 (no 415)", async () => {
+  const { app, session } = harness();
+  // No content-type header at all — mirrors CC's http-hook client (Finding 1).
+  const res = await post(app, session.id, validEvent);
+  expect(res.status).toBe(202);
+});
+
+test("POST unknown session id → 404", async () => {
+  const { app } = harness();
+  const res = await post(app, "no-such-id", validEvent, {
+    headers: { "content-type": "application/json" },
+  });
+  expect(res.status).toBe(404);
+  expect(await res.json()).toEqual({ error: "session not found" });
+});
+
+test("POST unparseable body → 400", async () => {
+  const { app, session } = harness();
+  const res = await post(app, session.id, "{not json", {
+    headers: { "content-type": "application/json" },
+  });
+  expect(res.status).toBe(400);
+  expect(await res.json()).toEqual({ error: "invalid hook event" });
+});
+
+test("POST invalid event (missing session_id) → 400", async () => {
+  const { app, session } = harness();
+  const res = await post(app, session.id, { hook_event_name: "PostToolUse" });
+  expect(res.status).toBe(400);
+});
+
+test("POST mismatched session_id → 202 but observe-only (not forwarded to signals)", async () => {
+  const seen: string[] = [];
+  const { app, session } = harness((id) => seen.push(id));
+  const res = await post(app, session.id, { ...validEvent, session_id: "WRONG-SID" });
+  expect(res.status).toBe(202);
+
+  // Recorded (visible to the spike) but flagged mismatch + never forwarded.
+  const snap = await (
+    await app.fetch(new Request(`http://x/api/sessions/${session.id}/hooks`))
+  ).json();
+  expect(snap).toHaveLength(1);
+  expect(snap[0].match).toBe(false);
+  expect(seen).toEqual([]);
+});
+
+test("POST matched session_id forwards to signals", async () => {
+  const seen: string[] = [];
+  const { app, session } = harness((id) => seen.push(id));
+  await post(app, session.id, validEvent);
+  expect(seen).toEqual([session.id]);
+});
+
+test("auth: 401 when token set and Authorization missing/wrong", async () => {
+  config.token = "secret-token";
+  const { app, session } = harness();
+  const missing = await post(app, session.id, validEvent);
+  expect(missing.status).toBe(401);
+
+  const wrong = await post(app, session.id, validEvent, {
+    headers: { Authorization: "Bearer nope" },
+  });
+  expect(wrong.status).toBe(401);
+
+  const ok = await post(app, session.id, validEvent, {
+    headers: { Authorization: "Bearer secret-token" },
+  });
+  expect(ok.status).toBe(202);
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -13,6 +13,7 @@ import { SessionStore } from "../src/store";
 import {
   SessionService,
   spawnSettingsOverlay,
+  buildHooksFragment,
   composeSystemPrompt,
   readInstalledPluginIds,
   installedPluginIds,
@@ -360,6 +361,86 @@ test("spawnSettingsOverlay: subscription => byte-identical (no apiKeyHelper); ap
   } finally {
     config.authMode = prevMode;
     config.authApiKeyHelperPath = prevPath;
+  }
+});
+
+test("spawnSettingsOverlay: hooksIngest off (default) => no hooks key, byte-identical to today", () => {
+  const prev = config.hooksIngest;
+  try {
+    config.hooksIngest = false;
+    const hookOpts = { sessionId: "sess-1", baseUrl: "http://127.0.0.1:7330", token: "tok" };
+    // even with opts.hooks supplied, the flag-off output is unchanged from no-opts.
+    const withHooks = spawnSettingsOverlay({ hooks: hookOpts });
+    expect(JSON.parse(withHooks)).not.toHaveProperty("hooks");
+    expect(withHooks).toBe(spawnSettingsOverlay());
+  } finally {
+    config.hooksIngest = prev;
+  }
+});
+
+test("spawnSettingsOverlay: hooksIngest on + token => three http hooks with $SHEPHERD_TOKEN auth", () => {
+  const prevFlag = config.hooksIngest;
+  const prevToken = config.token;
+  try {
+    config.hooksIngest = true;
+    config.token = "secret";
+    const parsed = JSON.parse(
+      spawnSettingsOverlay({
+        hooks: { sessionId: "sess-42", baseUrl: "http://127.0.0.1:7330", token: config.token },
+      }),
+    );
+    expect(Object.keys(parsed.hooks).sort()).toEqual([
+      "Notification",
+      "PostToolUse",
+      "PostToolUseFailure",
+    ]);
+    for (const event of ["PostToolUse", "PostToolUseFailure", "Notification"]) {
+      const httpHook = parsed.hooks[event][0].hooks[0];
+      expect(parsed.hooks[event][0].matcher).toBe("*");
+      expect(httpHook.type).toBe("http");
+      expect(httpHook.url).toBe("http://127.0.0.1:7330/api/sessions/sess-42/hooks");
+      expect(httpHook.timeout).toBe(5);
+      expect(httpHook.headers.Authorization).toBe("Bearer $SHEPHERD_TOKEN");
+      expect(httpHook.allowedEnvVars).toEqual(["SHEPHERD_TOKEN"]);
+    }
+  } finally {
+    config.hooksIngest = prevFlag;
+    config.token = prevToken;
+  }
+});
+
+test("spawnSettingsOverlay: hooksIngest on + null token => hooks present but no auth fields", () => {
+  const prevFlag = config.hooksIngest;
+  const prevToken = config.token;
+  try {
+    config.hooksIngest = true;
+    config.token = null;
+    const parsed = JSON.parse(
+      spawnSettingsOverlay({
+        hooks: { sessionId: "sess-7", baseUrl: "http://127.0.0.1:7330", token: config.token },
+      }),
+    );
+    const httpHook = parsed.hooks.PostToolUse[0].hooks[0];
+    expect(httpHook.url).toBe("http://127.0.0.1:7330/api/sessions/sess-7/hooks");
+    expect(httpHook.timeout).toBe(5);
+    expect(httpHook).not.toHaveProperty("headers");
+    expect(httpHook).not.toHaveProperty("allowedEnvVars");
+  } finally {
+    config.hooksIngest = prevFlag;
+    config.token = prevToken;
+  }
+});
+
+test("buildHooksFragment: null token omits headers/allowedEnvVars on every event", () => {
+  const frag = buildHooksFragment({
+    sessionId: "s",
+    baseUrl: "http://127.0.0.1:7330",
+    token: null,
+  }) as Record<string, Array<{ hooks: Array<Record<string, unknown>> }>>;
+  for (const event of ["PostToolUse", "PostToolUseFailure", "Notification"]) {
+    const httpHook = frag[event]?.[0]?.hooks[0];
+    expect(httpHook).not.toHaveProperty("headers");
+    expect(httpHook).not.toHaveProperty("allowedEnvVars");
   }
 });
 


### PR DESCRIPTION
Implements push-based agent-info ingestion via Claude Code hooks (#704), **additive on top of the poll-based pipeline**. Per the research doc (`docs/research/claude-code-hooks-ingestion.md`, #701). Scope: **Phase 0 + Phase 1**, both **default-OFF**, **observe-first**, **fail-open** — with both flags off the system is byte-for-byte today's behaviour.

## What ships

**Phase 0 — ingest spike** (`SHEPHERD_HOOKS_INGEST=1`)
- `spawnSettingsOverlay` injects `PostToolUse` / `PostToolUseFailure` / `Notification` HTTP hooks into every Shepherd-spawned agent's `--settings`, baking the per-session URL `…/api/sessions/<s.id>/hooks`.
- New `POST/GET /api/sessions/:id/hooks` route (sibling of the build-queue route) + `src/hooks-ingest.ts`: validates the untrusted body, records into a bounded in-memory ring buffer, logs each event. **Observe-only** — no signal-pipeline wiring at this stage.

**Phase 1 — retire fragile heuristics** (`SHEPHERD_HOOKS_SIGNALS=1`, requires ingest)
- Received events feed the **poller** (the single owner of per-session signal dedup + state), never emitting events directly:
  - `PostToolUse`/`PostToolUseFailure` → sub-second structured **activity** via the existing `emitActivity` dedup (real tool summary vs. the interim `summary:null` heartbeat; `PostToolUseFailure` carries error heat).
  - `Notification(awaiting-input type)` → authoritative **awaiting-input edge** that triggers a PTY classify on the next tick (independent of herdr's latchy `blocked` status). `classifyBlocked` still supplies menu options (the Notification payload has none).
- A **freshness guard** suppresses the redundant probe activity emit when a hook is fresh, but **never** the stall evaluation or error heat — polling stays the fallback.

## Design / correctness notes
- **Two distinct UUIDs:** the URL/route key on Shepherd's `s.id`; the body's `session_id` (= `claudeSessionId`) is validated as an untrusted cross-check; mismatches are recorded observe-only, never forwarded.
- **Single Bun loop respected:** the route only validates + records (no file/PTY I/O); the awaiting-edge classify runs on the poll tick where classify already runs.
- **Auth (Finding 2):** token rides via `allowedEnvVars:["SHEPHERD_TOKEN"]` + `$SHEPHERD_TOKEN` (kept out of ps-visible argv), bearer enforced by the global auth gate.
- **Finding 1 (honest, not assumed):** under `--dangerously-skip-permissions`, `Notification(permission_prompt)` may never fire; `AskUserQuestion`/`ExitPlanMode` emit an unverified type. The awaiting-input type set is deliberately narrow (`permission_prompt`) with a comment that **Phase 0 must confirm live which type(s) those cases emit**; until then the block-trigger is dormant and detection degrades to the existing `herdr-blocked → classifyBlocked` fallback — **no regression**.
- `stall.ts` untouched.

## Phase-0 runtime verification still owed (the spike's purpose)
These are observe-only outcomes to capture before enabling `hooksSignals` in earnest — fail-open means a negative result regresses nothing:
- Reachability + latency end-to-end, **incl. under a sandboxed/egress profile** (PR #601). Note: `src/sandbox.ts` strips `SHEPHERD_TOKEN`, so `$SHEPHERD_TOKEN` may interpolate empty under that profile → the documented fallback is the literal-in-argv form.
- Whether/which `notification_type` fires for `AskUserQuestion` + `ExitPlanMode` (Finding 1).
- Added per-tool agent-blocking overhead from matcher `"*"` (informs whether Phase 1 narrows the matcher).

## Known follow-up (non-blocking)
If herdr latches `status="blocked"` before a Notification's marker is consumed, the marker can linger one extra tick before self-consuming (bounded, fail-open, pruned on archive). Could be tightened later by consuming it in the blocked branch too.

## Verification
`bun run lint` clean · `bunx tsc --noEmit` clean · `bun test ./test` → 3100 pass / 6 skip / 0 fail · `bunx fallow audit --base origin/main --fail-on-issues` → exit 0 (no issues in changed files).

Server-only, no user-facing UI → i18n / feature-catalog N/A. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
