### PR TITLE
docs(tab-reaper): correct positional-id comments for herdr 0.7 stable ids + 0.7-id reap test

### DIFF
--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -346,9 +346,10 @@ export class HerdrDriver {
   /**
    * Best-effort teardown of the agent backing a terminal id. Closes the agent's whole
    * TAB, not just its pane: every agent gets its own dedicated tab, so closing only the
-   * pane left an empty husk tab behind. Resolves the tab id FRESH from the live list
-   * (herdr tab ids are positional and renumber on close, so a stored id would drift).
-   * No-op if the agent has already left the list — the orphan sweep reaps that husk.
+   * pane left an empty husk tab behind. Resolves `terminalId → current tabId` FRESH from
+   * the live list — the live list is the source of truth; the agent may have ended or been
+   * relabeled, so a cached tabId may be stale. No-op if the agent has already left the
+   * list — the orphan sweep reaps that husk.
    */
   stop(terminalId: string): void {
     const agent = this.list().find((a) => a.terminalId === terminalId);
@@ -359,8 +360,9 @@ export class HerdrDriver {
   /**
    * Rename a live agent and its dedicated tab so a background re-name (the LLM namer)
    * is reflected in the herdr UI, not just shepherd's DB. Resolves the agent (and its
-   * tabId) FRESH from the live list by terminal id. Best-effort: a dead/already-renamed
-   * agent must never crash the caller, so every step is guarded.
+   * tabId) FRESH from the live list by terminal id — the live list is the source of truth;
+   * a cached tabId may be stale. Best-effort: a dead/already-renamed agent must never
+   * crash the caller, so every step is guarded.
    */
   relabel(terminalId: string, newName: string): void {
     let agent;

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -22,7 +22,13 @@ function isShepherdHelperLabel(label: string): boolean {
   );
 }
 
-/** herdr tab ids are "workspace:N" with N a positional index. */
+/**
+ * Parses the positional `workspace:N` index used by herdr **≤0.6**, where tab ids are
+ * `"workspace:N"` with N a dense integer that re-numbers on close. Under herdr 0.7 stable
+ * ids (e.g. `w1:t1`) the last `:`-segment is not numeric, so this returns `0` for every
+ * tab — which is fine (see `reapOrphanTabs`). Retained until herdr 0.7 is the deployed
+ * floor, at which point this helper and the `.sort()` in `reapOrphanTabs` can be removed.
+ */
 function tabNumber(tabId: string): number {
   const n = Number.parseInt(tabId.split(":").at(-1) ?? "", 10);
   return Number.isFinite(n) ? n : 0;
@@ -39,9 +45,17 @@ function tabNumber(tabId: string): number {
  * agent in `agent list` before yielding the event loop, so a labeled tab with no backing
  * agent is unambiguously dead — never a mid-start probe/review.
  *
- * Closes highest tab-number first: herdr re-densifies tab numbers when a tab closes, so
- * descending order guarantees each remaining target id stays valid (only already-closed,
- * higher-numbered tabs shift).
+ * Closes in descending tab-number order. The behaviour under each herdr version:
+ *
+ * - **herdr ≤0.6** (positional ids, e.g. `workspace:N`): ids re-densify on close, so
+ *   closing highest-number-first keeps each remaining snapshotted target id valid — only
+ *   already-closed, higher-numbered tabs shift.
+ * - **herdr 0.7** (#569, stable ids e.g. `w1:t1`): closed ids don't retarget, so close
+ *   order is irrelevant. `tabNumber()` returns `0` for every 0.7 id, making the sort a
+ *   harmless no-op (order-preserving on ties).
+ *
+ * Net: correct under both; the sort is load-bearing on 0.6.10 (still deployed) and
+ * inert on 0.7.
  */
 export function reapOrphanTabs(herdr: ReapableHerdr): string[] {
   const liveTabIds = new Set(

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -72,12 +72,32 @@ test("never touches non-shepherd tabs — incl. user sessions slugged 'usage-pro
 });
 
 test("closes highest tab-number first so herdr's renumber-on-close can't drift targets", () => {
-  // herdr tab_ids are positional (workspace:N) and re-densify when a tab closes;
-  // closing the highest number first means each close only shifts already-closed tabs.
+  // Documents the herdr ≤0.6 drift-safety guarantee: positional ids (workspace:N)
+  // re-densify on close, so closing highest-first keeps each remaining target id valid.
+  // Under herdr 0.7 stable ids (w1:tN) tabNumber() returns 0 for all ids, so the
+  // descending sort is a no-op — the asserted ordering only holds under ≤0.6.
   const { h, closed } = fake(
     [],
     [tab("w:2", PROBE_NAME), tab("w:10", PROBE_NAME), tab("w:5", "review TASK-1")],
   );
   reapOrphanTabs(h);
   expect(closed).toEqual(["w:10", "w:5", "w:2"]);
+});
+
+test("reaps 0.7 stable-id husks (w1:tN) and never touches a live tab", () => {
+  // herdr 0.7 (#569) introduced stable short handles (w1, w1:t1, w1:p1) that don't
+  // renumber on close. Two helper husks with no backing agent must be reaped; the live
+  // user tab backed by an agent must never be closed.
+  const { h, closed } = fake(
+    [agent("term_live", "w1:t3")],
+    [
+      tab("w1:t1", PROBE_NAME), // orphaned probe husk — no backing agent
+      tab("w1:t2", "review TASK-1"), // orphaned review husk — no backing agent
+      tab("w1:t3", "my-feature"), // live user tab — backed by an agent
+    ],
+  );
+  const got = reapOrphanTabs(h);
+  expect(new Set(got)).toEqual(new Set(["w1:t1", "w1:t2"]));
+  expect(new Set(closed)).toEqual(new Set(["w1:t1", "w1:t2"]));
+  expect(closed).not.toContain("w1:t3");
 });


### PR DESCRIPTION
Closes #712.

## What
herdr **0.7.0** (#569) makes tab/pane ids **stable short handles** (`w1`, `w1:t1`, `w1:p1`) that no longer renumber on close. Our `src/tab-reaper.ts` (and parallel comments in `src/herdr.ts`) documented only the pre-0.7 *positional `workspace:N` / re-densifies-on-close* model — **false under 0.7**.

This makes the code **honest and verified-correct under both id models**, with **no behavior change**:

- **`src/tab-reaper.ts`** — rewrote the `tabNumber()` and `reapOrphanTabs()` doc comments to cover both models. `tabNumber()` + the descending `.sort()` are **kept** (see below).
- **`src/herdr.ts`** — `stop()` / `relabel()` no longer claim "positional / renumber on close"; the fresh-resolve is restated with its model-independent reason (the live list is the source of truth; a cached `tabId` may be stale).
- **`test/tab-reaper.test.ts`** — refreshed the "highest-first" test's comment (assertion unchanged; it documents ≤0.6 drift-safety); **added** a 0.7 stable-id test (`w1:tN` husks + a live `w1:t3` tab) asserting husks are reaped and the live tab is never closed — the actual subject of #569, previously untested.

## Why keep `tabNumber()` + `.sort()` (not delete, per the issue's sketch)
While herdr **0.6.10 is still deployed**, they are **load-bearing, not dead**: positional ids re-densify on close, and the descending sort guarantees a snapshotted target id can't drift onto a live user tab mid-sweep. Deleting them now would either (a) be unsafe on 0.6.10, or (b) require rewriting the boot+hourly tab-*closing* sweep — which a plan review showed introduces a no-progress regression (best-effort `closeTab` + re-scan loop can spin on one stuck husk). Under 0.7 the sort is a harmless no-op (every id parses to `0`).

The clean deletion is deferred to **#714**, gated on herdr 0.7 being the deployed floor.

## Scope notes
- Server-internal docs + test only — no user-facing UX, so no feature-catalog / i18n / glossary entry. Not a `feat`.
- `HERDR_MIN_VERSION` left at `0.6.0` so both versions clear the gate during the upgrade transition.
- The live herdr 0.7.0 upgrade (proto 14, via `herdr update --handoff`) is a separate coordinated/drained operational step, not part of this PR.

## Test
- `bun test ./test` — 3164 pass, 0 fail (incl. the 5 `tab-reaper.test.ts` tests).
- `bun run lint`, `bunx tsc --noEmit` — clean.
- `fallow audit` (pre-push) — no issues in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)