### PR TITLE
fix(backlog): pin search fields flush so list doesn't bleed above them

### DIFF
--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -463,7 +463,7 @@
   .master-pane {
     border-right: 1px solid var(--color-line);
     overflow-y: auto;
-    padding: 6px 4px;
+    padding: 0 4px 6px;
   }
 
   .master-pane::-webkit-scrollbar {
@@ -513,7 +513,7 @@
   .mobile-master {
     flex: 1;
     overflow-y: auto;
-    padding: 6px 4px;
+    padding: 0 4px 6px;
     -webkit-overflow-scrolling: touch;
   }
 

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -282,6 +282,7 @@
 
   .issues-header {
     padding: 6px 12px;
+    margin-bottom: 8px; /* gap below the border to the flush sticky filter — margin (outside the border), not padding */
     font-size: var(--fs-micro);
     letter-spacing: 0.18em;
     text-transform: uppercase;
@@ -293,7 +294,7 @@
   .issues-list {
     flex: 1;
     overflow-y: auto;
-    padding: 10px 12px;
+    padding: 0 12px 10px;
     display: flex;
     flex-direction: column;
     gap: 6px;


### PR DESCRIPTION
## Problem

In the backlog, the **search issues** field (and the symmetric **repo-search** field) appeared to float over the list — scrolling rows bled through a band *above* the pinned field (an issue title visible above the "search issues…" box in the report screenshot).

## Root cause

Both fields use `position: sticky; top: 0`. A sticky element pins to its scroll container's **content-box** top — i.e. `padding-top` below the scrollport — so a non-zero `padding-top` on the container opens a band where scrolling content shows through above the field. The fields' backgrounds are opaque (`--color-inset`), so this top band was the only leak.

- `.issue-filter` inside `.issues-list` (`padding: 10px 12px`) → 10px bleed band (the reported one).
- `.filter-bar` inside `.master-pane` / `.mobile-master` (`padding: 6px 4px`) → 6px bleed band (symmetric case).

## Fix (CSS-only)

Drop the **top** padding of each scroll container so the field pins flush at the scrollport top (zero band); keep side + bottom padding. Restore the issues field's breathing room *outside* the scroll container via `.issues-header { margin-bottom: 8px }` — `margin` (not `padding`), because the header has a `border-bottom` and padding would sit inside it, leaving the field flush against the border line.

- `IssuesPanel.svelte`: `.issues-list` `10px 12px` → `0 12px 10px`; `.issues-header` + `margin-bottom: 8px`
- `BacklogView.svelte`: `.master-pane` and `.mobile-master` `6px 4px` → `0 4px 6px`

No markup/logic/i18n/feature-catalog changes. The sticky rules themselves are untouched. Bugfix (not a `feat`), so no feature-announcement entry.

## Verification

- `cd ui && bun run check` (0 errors), `bun run check:i18n` (parity), `bun run test` (1340 passing) — all green.
- In-browser (vite dev → live), **mobile + desktop**, measured via DOM rects after scrolling:
  - Issues field: bleed band above filter `10px → 0`; header→filter gap `8px` (the margin, clean, no bleed).
  - Repo filter-bar: bleed band above bar `6px → 0`.
  - Visual: rows now scroll cleanly *behind* the opaque field (body-preview shows below it, title covered) — nothing bleeds above.
  - Functional: typing filters rows (14 → 7 on "herdr"), clearing restores (→ 14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)