### PR TITLE
feat(hooks): lifecycle-edge ingestion — SessionStart consumed; Stop/SessionEnd observe-only (Phase 2, #709)

### DIFF
--- a/src/hooks-ingest.ts
+++ b/src/hooks-ingest.ts
@@ -1,18 +1,31 @@
-// Phase 0 ingest path for Claude Code push hooks (issue #704).
+// Hook ingest path for Claude Code push hooks (issues #704 / #709).
 //
-// Observe-only: the spawned agent's PostToolUse / PostToolUseFailure / Notification
-// hooks POST here; we validate the untrusted body, normalize it, drop it into a
-// bounded per-session ring buffer, and log a structured line. NOTHING here feeds the
-// signal pipeline yet — `onSignal` is wired by Task 3 (Phase 1) when `hooksSignals`
-// is on. The whole point of the spike is to MEASURE (latency, correlation, the exact
-// upstream strings) before trusting the channel, so anything unrecognized is recorded
-// and flagged loudly rather than silently dropped.
+// The spawned agent's PostToolUse / PostToolUseFailure / Notification / SessionStart /
+// Stop / SessionEnd hooks POST here; we validate the untrusted body, normalize it, drop
+// it into a bounded per-session ring buffer, and log a structured line.
+//
+// Phase 1 (#704): when `hooksSignals` is on, matched events are forwarded to the poller
+// signal pipeline via `onSignal` (wired post-construction by setSink). PostToolUse feeds
+// activity signals; Notification(permission_prompt) feeds block detection.
+//
+// Phase 2 (#709): SessionStart is consumed to flip claude-liveness to true (fast-path
+// before the poller's liveness sweep). Stop / SessionEnd are recorded + logged only —
+// observe-only, no signal consumption this phase (deferred to #713).
+//
+// Anything unrecognized is recorded and flagged loudly rather than silently dropped.
 
 /** A normalized hook event after validation — the spike's observable unit. */
 export type HookEvent = {
   /** Recognized lifecycle event; an unrecognized `hook_event_name` is still kept,
    *  passed through verbatim, and flagged via `unknown`. */
-  event: "PostToolUse" | "PostToolUseFailure" | "Notification" | string;
+  event:
+    | "PostToolUse"
+    | "PostToolUseFailure"
+    | "Notification"
+    | "SessionStart"
+    | "Stop"
+    | "SessionEnd"
+    | string;
   /** The hook payload's `session_id` (== `claude --session-id` == `claudeSessionId`). */
   sessionId: string;
   /** PostToolUse(/Failure): the tool that ran. */
@@ -25,6 +38,12 @@ export type HookEvent = {
   notificationType?: string;
   /** Notification: the human-readable message string. */
   message?: string;
+  /** SessionStart: the `source` (startup/resume/clear/compact). */
+  source?: string;
+  /** Stop: the `stop_hook_active` boolean (whether a Stop hook is already active). */
+  stopHookActive?: boolean;
+  /** SessionEnd: the termination `reason` (clear/logout/prompt_input_exit/other). */
+  reason?: string;
   /** True when `hook_event_name` or `notification_type` was unrecognized — recorded,
    *  flagged, and `console.warn`-ed so a wrong upstream string surfaces in the spike. */
   unknown?: boolean;
@@ -46,6 +65,7 @@ const RING_CAP = 50;
 // Defensive readers — the body is untrusted JSON; never assume a shape.
 const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
 const num = (v: unknown): number | undefined => (typeof v === "number" ? v : undefined);
+const bool = (v: unknown): boolean | undefined => (typeof v === "boolean" ? v : undefined);
 const obj = (v: unknown): Record<string, unknown> | null =>
   typeof v === "object" && v !== null ? (v as Record<string, unknown>) : null;
 
@@ -83,6 +103,18 @@ export function validateHookEvent(body: unknown): RawHookEvent | null {
     // The `notification_type` strings are spike-validated, not assumed: flag an
     // absent/unknown type so it's logged + recorded but never silently disables a signal.
     return { event: eventName, sessionId, notificationType, message, unknown: !notificationType };
+  }
+
+  if (eventName === "SessionStart") {
+    return { event: eventName, sessionId, source: str(b.source) };
+  }
+
+  if (eventName === "Stop") {
+    return { event: eventName, sessionId, stopHookActive: bool(b.stop_hook_active) };
+  }
+
+  if (eventName === "SessionEnd") {
+    return { event: eventName, sessionId, reason: str(b.reason) };
   }
 
   // Unrecognized hook_event_name — keep it, pass it through verbatim, flag it.
@@ -128,7 +160,8 @@ export class HookIngest {
       console.log(
         `[hooks] ${ev.event} session=${sessionId} match=${ev.match === false ? "mismatch" : "ok"} ` +
           `latencyMs=${latencyMs} tool=${ev.toolName ?? "-"} status=${ev.status ?? "-"} ` +
-          `ntype=${ev.notificationType ?? "-"} exit=${ev.exitCode ?? "-"}`,
+          `ntype=${ev.notificationType ?? "-"} exit=${ev.exitCode ?? "-"}` +
+          ` src=${ev.source ?? "-"} reason=${ev.reason ?? "-"} stopActive=${ev.stopHookActive ?? "-"}`,
       );
       if (ev.unknown) {
         console.warn(

--- a/src/index.ts
+++ b/src/index.ts
@@ -367,7 +367,11 @@ if (config.hooksSignals && !config.hooksIngest) {
       poller.ingestActivity(id, { toolName: ev.toolName, status: ev.status, ts: ev.receivedAt });
     } else if (ev.event === "Notification") {
       poller.ingestNotification(id, ev.notificationType ?? "");
+    } else if (ev.event === "SessionStart") {
+      poller.ingestSessionStart(id);
     }
+    // Stop + SessionEnd are observe-only this phase (deferred to #713):
+    // record() ring-buffers + logs them regardless of the sink, so they're measurable.
   });
 }
 // Clear stale mappings left by a crashed prior run. Fire void, NOT await: the service's

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -145,9 +145,9 @@ export class StatusPoller {
    *  herdr-blocked, `clearBlock`, reap, prune). */
   private lastSuppressVisible = new Map<string, string>();
 
-  /** Phase-1 push-hook state (issue #704), all gated by `config.hooksSignals`.
-   *  Fed via HookIngest.onSignal → ingestActivity / ingestNotification; the poller
-   *  stays the single owner of per-session signal dedup + the working-while-blocked
+  /** Phase-1/2 push-hook state (issue #704), all gated by `config.hooksSignals`.
+   *  Fed via HookIngest.onSignal → ingestActivity / ingestNotification / ingestSessionStart;
+   *  the poller stays the single owner of per-session signal dedup + the working-while-blocked
    *  state machine, so push events funnel through `emitActivity`/`maybeClassify`
    *  rather than emitting directly (which would bypass dedup + oscillate with poll).
    *  Every map is pruned in `pruneInactive` and inert when the flag is off. */
@@ -526,6 +526,23 @@ export class StatusPoller {
     if (BLOCK_NOTIFICATION_TYPES.has(type)) this.hookAwaitingInput.add(id);
     else if (type === "idle_prompt") this.hookAwaitingInput.delete(id);
     // else: unknown/other type → no-op (dormant; fallback detection unchanged).
+  }
+
+  /**
+   * Phase-2 push lifecycle (issue #709): a SessionStart hook confirms the agent booted.
+   * Flips claude-liveness → true immediately (ahead of the throttled liveness sweep),
+   * reusing the sweep's own map + flip-dedup so push + poll never double-emit. Boot
+   * liveness is monotonic (true until exit), so this cannot oscillate with the sweep,
+   * which will agree (the process is alive — the hook fired from inside it). No-op when
+   * `config.hooksSignals` is off.
+   * (Stop/SessionEnd consumption is deferred to #713 — observe-only this phase.)
+   */
+  ingestSessionStart(id: string): void {
+    if (!config.hooksSignals) return;
+    if (this.lastClaudeAlive.get(id) !== true) {
+      this.lastClaudeAlive.set(id, true);
+      this.livenessWiring.onChange(id, true);
+    }
   }
 
   /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -201,8 +201,9 @@ export function resetPluginIdsCacheForTests(): void {
  * untrimmed spawns keep today's exact overlay.
  *
  * `hooks` (issue #704, only when `config.hooksIngest`) adds PostToolUse/PostToolUseFailure/
- * Notification HTTP hooks pointing at this session's ingest route (see buildHooksFragment).
- * Flag off → key omitted entirely, so the overlay JSON stays byte-for-byte identical to today.
+ * Notification/SessionStart/Stop/SessionEnd HTTP hooks pointing at this session's ingest route
+ * (see buildHooksFragment). Flag off → key omitted entirely, so the overlay JSON stays
+ * byte-for-byte identical to today.
  */
 export function spawnSettingsOverlay(
   opts: {
@@ -228,8 +229,8 @@ export function spawnSettingsOverlay(
 
 /**
  * Build the `hooks` overlay fragment (issue #704): one synchronous `http` hook per event
- * (PostToolUse, PostToolUseFailure, Notification), matcher `"*"`, short fail-open timeout,
- * pointed at `POST <baseUrl>/api/sessions/<sessionId>/hooks`.
+ * (PostToolUse, PostToolUseFailure, Notification, SessionStart, Stop, SessionEnd), matcher
+ * `"*"`, short fail-open timeout, pointed at `POST <baseUrl>/api/sessions/<sessionId>/hooks`.
  *
  * Auth (Finding 2): the `--settings` JSON rides the spawn process argv (ps-visible), NOT the
  * transcript — so we NEVER bake the literal token. When a token is configured we emit a
@@ -260,6 +261,9 @@ export function buildHooksFragment(input: {
     PostToolUse: eventEntry,
     PostToolUseFailure: eventEntry,
     Notification: eventEntry,
+    SessionStart: eventEntry,
+    Stop: eventEntry,
+    SessionEnd: eventEntry,
   };
 }
 

--- a/test/hooks-ingest.test.ts
+++ b/test/hooks-ingest.test.ts
@@ -92,6 +92,42 @@ test("validateHookEvent: Notification with unknown/absent type → flagged unkno
   expect(ev?.unknown).toBe(true);
 });
 
+test("validateHookEvent: SessionStart with source → recognized, not unknown", () => {
+  const ev = validateHookEvent({
+    session_id: "s1",
+    hook_event_name: "SessionStart",
+    source: "startup",
+  });
+  expect(ev).toEqual({ event: "SessionStart", sessionId: "s1", source: "startup" });
+  expect(ev?.unknown).toBeUndefined();
+});
+
+test("validateHookEvent: SessionStart without source → source undefined, not unknown", () => {
+  const ev = validateHookEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+  expect(ev).toEqual({ event: "SessionStart", sessionId: "s1", source: undefined });
+  expect(ev?.unknown).toBeUndefined();
+});
+
+test("validateHookEvent: Stop with stop_hook_active:false → recognized, stopHookActive false", () => {
+  const ev = validateHookEvent({
+    session_id: "s1",
+    hook_event_name: "Stop",
+    stop_hook_active: false,
+  });
+  expect(ev).toEqual({ event: "Stop", sessionId: "s1", stopHookActive: false });
+  expect(ev?.unknown).toBeUndefined();
+});
+
+test("validateHookEvent: SessionEnd with reason → recognized, not unknown", () => {
+  const ev = validateHookEvent({
+    session_id: "s1",
+    hook_event_name: "SessionEnd",
+    reason: "logout",
+  });
+  expect(ev).toEqual({ event: "SessionEnd", sessionId: "s1", reason: "logout" });
+  expect(ev?.unknown).toBeUndefined();
+});
+
 // ── HookIngest ring buffer ─────────────────────────────────────────────────────
 
 function ev(over: Partial<HookEvent> = {}): HookEvent {

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -2177,6 +2177,7 @@ function hookHarness(opts?: {
   visible?: () => string;
   probe?: () => { snapshot: any; activity: any };
   stallCfg?: { stallMs: number; pendingStallMs: number };
+  onLivenessChange?: (id: string, alive: boolean) => void;
 }) {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);
@@ -2202,6 +2203,7 @@ function hookHarness(opts?: {
     read: () => visible(),
     readAsync: () => Promise.resolve(visible()),
   };
+  const livenessWiring = opts?.onLivenessChange ? { onChange: opts.onLivenessChange } : undefined;
   const poller = new StatusPoller(
     store,
     herdr as any,
@@ -2217,7 +2219,7 @@ function hookHarness(opts?: {
     () => {},
     (id, activity) => activities.push({ id, activity }),
     undefined, // preview
-    undefined, // liveness
+    livenessWiring, // liveness
     () => {}, // onWorkingBlocked
     (ids) => pruned.push(new Set(ids)), // pruneHooks
   );
@@ -2490,6 +2492,54 @@ test("hooks: ingest* are inert when config.hooksSignals is off", () => {
     h.poller.ingestNotification(h.id, "permission_prompt");
     h.poller.tick();
     expect(h.blocks).toHaveLength(0); // no block trigger
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+// ── Phase-2 push lifecycle: ingestSessionStart (issue #709) ──────────────────
+
+test("hooks: ingestSessionStart flips claude-liveness to true on first call", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const livenessChanges: Array<{ id: string; alive: boolean }> = [];
+    const h = hookHarness({
+      onLivenessChange: (id, alive) => livenessChanges.push({ id, alive }),
+    });
+    h.poller.ingestSessionStart(h.id);
+    expect(livenessChanges).toEqual([{ id: h.id, alive: true }]);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: ingestSessionStart is a no-op on repeated calls (flip-dedup)", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const livenessChanges: Array<{ id: string; alive: boolean }> = [];
+    const h = hookHarness({
+      onLivenessChange: (id, alive) => livenessChanges.push({ id, alive }),
+    });
+    h.poller.ingestSessionStart(h.id);
+    h.poller.ingestSessionStart(h.id); // second call → already true, no re-emit
+    expect(livenessChanges).toHaveLength(1); // only one flip
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("hooks: ingestSessionStart is inert when config.hooksSignals is off", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = false;
+  try {
+    const livenessChanges: Array<{ id: string; alive: boolean }> = [];
+    const h = hookHarness({
+      onLivenessChange: (id, alive) => livenessChanges.push({ id, alive }),
+    });
+    h.poller.ingestSessionStart(h.id);
+    expect(livenessChanges).toHaveLength(0); // flag off → no emit
   } finally {
     config.hooksSignals = orig;
   }

--- a/test/server-hooks.test.ts
+++ b/test/server-hooks.test.ts
@@ -126,6 +126,42 @@ test("POST matched session_id forwards to signals", async () => {
   expect(seen).toEqual([session.id]);
 });
 
+test("POST SessionEnd (observe-only) → 202 and snapshot records reason field", async () => {
+  const { app, session } = harness();
+  const res = await post(app, session.id, {
+    session_id: CLAUDE_SID,
+    hook_event_name: "SessionEnd",
+    reason: "logout",
+  });
+  expect(res.status).toBe(202);
+
+  const snap = await (
+    await app.fetch(new Request(`http://x/api/sessions/${session.id}/hooks`))
+  ).json();
+  expect(snap).toHaveLength(1);
+  expect(snap[0].event).toBe("SessionEnd");
+  expect(snap[0].reason).toBe("logout");
+  expect(snap[0].match).toBe(true);
+});
+
+test("POST Stop (observe-only) → 202 and snapshot records stopHookActive field", async () => {
+  const { app, session } = harness();
+  const res = await post(app, session.id, {
+    session_id: CLAUDE_SID,
+    hook_event_name: "Stop",
+    stop_hook_active: false,
+  });
+  expect(res.status).toBe(202);
+
+  const snap = await (
+    await app.fetch(new Request(`http://x/api/sessions/${session.id}/hooks`))
+  ).json();
+  expect(snap).toHaveLength(1);
+  expect(snap[0].event).toBe("Stop");
+  expect(snap[0].stopHookActive).toBe(false);
+  expect(snap[0].match).toBe(true);
+});
+
 test("auth: 401 when token set and Authorization missing/wrong", async () => {
   config.token = "secret-token";
   const { app, session } = harness();

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -378,7 +378,7 @@ test("spawnSettingsOverlay: hooksIngest off (default) => no hooks key, byte-iden
   }
 });
 
-test("spawnSettingsOverlay: hooksIngest on + token => three http hooks with $SHEPHERD_TOKEN auth", () => {
+test("spawnSettingsOverlay: hooksIngest on + token => six http hooks with $SHEPHERD_TOKEN auth", () => {
   const prevFlag = config.hooksIngest;
   const prevToken = config.token;
   try {
@@ -393,8 +393,18 @@ test("spawnSettingsOverlay: hooksIngest on + token => three http hooks with $SHE
       "Notification",
       "PostToolUse",
       "PostToolUseFailure",
+      "SessionEnd",
+      "SessionStart",
+      "Stop",
     ]);
-    for (const event of ["PostToolUse", "PostToolUseFailure", "Notification"]) {
+    for (const event of [
+      "PostToolUse",
+      "PostToolUseFailure",
+      "Notification",
+      "SessionStart",
+      "Stop",
+      "SessionEnd",
+    ]) {
       const httpHook = parsed.hooks[event][0].hooks[0];
       expect(parsed.hooks[event][0].matcher).toBe("*");
       expect(httpHook.type).toBe("http");
@@ -437,7 +447,14 @@ test("buildHooksFragment: null token omits headers/allowedEnvVars on every event
     baseUrl: "http://127.0.0.1:7330",
     token: null,
   }) as Record<string, Array<{ hooks: Array<Record<string, unknown>> }>>;
-  for (const event of ["PostToolUse", "PostToolUseFailure", "Notification"]) {
+  for (const event of [
+    "PostToolUse",
+    "PostToolUseFailure",
+    "Notification",
+    "SessionStart",
+    "Stop",
+    "SessionEnd",
+  ]) {
     const httpHook = frag[event]?.[0]?.hooks[0];
     expect(httpHook).not.toHaveProperty("headers");
     expect(httpHook).not.toHaveProperty("allowedEnvVars");


### PR DESCRIPTION
Closes #709. Phase 2 of the hook-based agent-info ingestion effort (umbrella #704; builds on the Phase 0+1 channel in `fdf62ad`). Server-only, additive, flag-gated, fail-open.

## What this does
Adds three Claude Code lifecycle hooks to the existing per-session push-hook channel (`buildHooksFragment` → `--settings` overlay → `POST /api/sessions/:id/hooks` → `validateHookEvent` → `HookIngest`):

| Event | This phase | Why |
| --- | --- | --- |
| `SessionStart` | **Actively consumed** → flips claude-liveness → true on a real flip, ahead of the throttled liveness sweep | Distinct, non-oscillating "agent up" signal |
| `Stop` | **Observe-only** (injected + validated `stop_hook_active` + logged) | herdr already emits the turn-complete `"done"` edge via `mapState`; Stop adds no edge consumers see unless it provably precedes herdr's flip — unmeasured |
| `SessionEnd` | **Observe-only** (injected + validated `reason` + logged) | Ambiguous reasons (`clear` is non-terminal) + `reapGone`/liveness-sweep already cover real exits; recap sweep debounces on settled-idle |

Gated by the existing `SHEPHERD_HOOKS_SIGNALS` (consumption) / `SHEPHERD_HOOKS_INGEST` (injection) flags — no new env knob. Polling remains the authoritative fallback (and the only path for autonomous/drain sessions, which the egress sandbox blocks hooks from reaching).

## Why Stop/SessionEnd are observe-only (scope discipline)
The plan review established that a Stop-asserted `"done"` would either duplicate herdr's own `mapState("done")` edge or oscillate against the per-tick herdr-derived status rewrite — and the five `done` consumers want "turn complete," which herdr `"done"` already is. The only possible win is latency over herdr's detection lag, which is **unmeasured**. So this phase lands the inject/validate/**log** seam (the `[hooks]` log line now emits `source`/`reason`/`stopActive`) to *measure* those edges live, and defers their consumption — with an oscillation-proof design specified — to **#713**.

## Changes
- `src/service.ts` — `buildHooksFragment` emits 6 events (added SessionStart/Stop/SessionEnd, same per-session URL+auth); doc comments updated.
- `src/hooks-ingest.ts` — `validateHookEvent` recognizes the 3 new events (`source`/`stopHookActive`/`reason`, not flagged `unknown`); `HookEvent` widened; `record` log line extended; module header refreshed (was stale since Phase 1).
- `src/index.ts` — one new sink branch: `SessionStart → poller.ingestSessionStart(id)`. No branch for Stop/SessionEnd (observe-only; recorded pre-sink).
- `src/poller.ts` — one new method `ingestSessionStart`, reusing the liveness sweep's `lastClaudeAlive` flip-dedup (no new map, no `pruneInactive`/`reconcileAgent` change).
- Tests: validator cases for all 3 events; observe-only route pass-through for Stop+SessionEnd; `ingestSessionStart` emit-once / no-op-when-alive / inert-when-flag-off.

## Follow-up
**#713** — consume Stop (turn-complete edge) + SessionEnd (terminal-reason teardown), gated on this phase's live measurement.

## Verification
`bunx tsc --noEmit`, `bun run lint`, and `bun test ./test` all green (3109 pass / 0 fail). No UI touched → feature-catalog/i18n gates N/A. Live-verification steps (additive-merge safety incl. the operator global SessionStart hook; Stop-vs-herdr timing; SessionEnd reason strings) are documented in the plan for the deferred follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)