### PR TITLE
fix(ui): drop THE HERD label on mobile; move rundown next to settings cog

### DIFF
--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -777,6 +777,24 @@
   .panel.flow.bracket::after {
     display: none;
   }
+  /* On mobile (flow mode) the "THE HERD" title forces the filter row to wrap on
+     narrow phones; hide just the title span (the filter buttons are nested under
+     .right.filters, so the direct-child combinator leaves them untouched). The
+     herd_title key is still used on desktop (non-flow). */
+  .panel.flow .phead > .micro {
+    display: none;
+  }
+  /* Worst case (~320px wide phone with a status chip present = 6 buttons) still
+     overflows after hiding the title; tighten the filter buttons' tracking,
+     padding and inter-button gap just in flow mode so the row fits without
+     wrapping or horizontal overflow. */
+  .panel.flow .filters {
+    gap: 3px;
+  }
+  .panel.flow .filters .fbtn {
+    letter-spacing: 0.06em;
+    padding: 2px 4px;
+  }
 
   .phead {
     display: flex;

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -585,21 +585,6 @@
     </div>
   {/if}
   <div class="rightside">
-    <!-- ☰ RUNDOWN: opens the daily Herd Rundown digest lens. Compact (icon + label
-         dropped to a glyph) on phones and the touch-desktop badge crunch, mirroring
-         the NEEDS YOU badge's compact pattern. -->
-    <button
-      class="rundown-btn"
-      class:compact={mobile || compactBadges}
-      type="button"
-      onclick={() => onrundown?.()}
-      title={m.topbar_rundown()}
-      aria-label={m.topbar_rundown()}
-      use:coachTarget={"herd-rundown"}
-    >
-      <span class="rd-glyph" aria-hidden="true">☰</span>
-      {#if !(mobile || compactBadges)}<span class="rd-label">{m.topbar_rundown()}</span>{/if}
-    </button>
     {#if needsYou > 0}
       <button
         class="needsyou"
@@ -835,6 +820,21 @@
         <span class="health-dot" aria-hidden="true"></span>
       </button>
     {/if}
+    <!-- ☰ RUNDOWN: opens the daily Herd Rundown digest lens. Sits just left of the
+         settings cog. Compact (icon + label dropped to a glyph) on phones and the
+         touch-desktop badge crunch, mirroring the NEEDS YOU badge's compact pattern. -->
+    <button
+      class="rundown-btn"
+      class:compact={mobile || compactBadges}
+      type="button"
+      onclick={() => onrundown?.()}
+      title={m.topbar_rundown()}
+      aria-label={m.topbar_rundown()}
+      use:coachTarget={"herd-rundown"}
+    >
+      <span class="rd-glyph" aria-hidden="true">☰</span>
+      {#if !(mobile || compactBadges)}<span class="rd-label">{m.topbar_rundown()}</span>{/if}
+    </button>
     <!-- The gear adapts to state: idle herd → a click opens Settings directly;
          when something is haltable it becomes a menu button opening the e-stop above
          the Settings entry. A pip on the gear is the only at-rest cue that there's a


### PR DESCRIPTION
## What

Two small top-bar / herd-panel tweaks for the mobile layout:

1. **Drop the "THE HERD" panel-header label on mobile.** In `flow` (mobile-list) mode the title forced the All/Ready/Research/Done/Rundown filter row to wrap onto a second line. Hidden via `.panel.flow .phead > .micro { display:none }` — the direct-child `>` combinator targets only the title span; the filter buttons (nested under `.right.filters`) are untouched. The `herd_title` key stays — it's still shown on desktop.
2. **Move the Rundown (☰) button next to the settings cog.** Relocated the `.rundown-btn` block to sit immediately left of `.gear-wrap` in `.rightside`, on all viewports. Pure DOM reorder — styling and the `compact` icon-only logic are unchanged; the `herd-rundown` coachmark anchors by element ref so it still points correctly.

## Filter-row fit (measured at 320–360px)

Hiding the label alone fit every case **except** 320px with an active status chip, which still overflowed horizontally. Applied the minimal Tier-1 tightening — `.panel.flow` only, so desktop is untouched:

- `.panel.flow .filters { gap: 3px }`
- `.panel.flow .filters .fbtn { letter-spacing: 0.06em; padding: 2px 4px }`

After it, all four cases (320/360 × with/without chip) sit on one row with no wrap and no page overflow. No filter label text changed (no i18n churn).

## Scope / gates

- No new user-facing strings → no message-catalog or `feature-announcements.ts` change (layout/visibility tweak, `fix` not `feat`).
- `cd ui && bun run check` → 0 errors / 0 warnings; `bun run check:i18n` → locales in parity.

## Test plan

- [x] Desktop: "THE HERD" label still shows; Rundown ☰ + label sits just left of the gear.
- [x] Mobile/flow 320 & 360px (with and without status chip): label gone, filter row on one line, no wrap/overflow; Rundown glyph left of the gear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)