### PR TITLE
feat(installer): Surface A curl|bash bootstrap + Phase-4 e2e gate (#706)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,63 @@ Shepherd core  ──  Bun + TypeScript (src/)
 - **PTY bridge**: `node-pty` is broken under Bun, so the PTY attaches in a Node helper subprocess
   (`src/pty-attach.mjs`) — never import `node-pty` from Bun.
 
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erwins-enkel/shepherd/main/deploy/install.sh | bash
+```
+
+Provisions prerequisites, clones to `~/Work/shepherd`, builds the UI, and on Linux installs and
+enables the systemd user service. Idempotent — safe to re-run: it never clobbers an existing
+`~/.shepherd/` state dir and never force-resets a dirty checkout.
+
+### `curl|bash` trust note
+
+This is third-party `curl|bash`: the script runs unconfined as your user _before_ any sandbox
+exists. It also invokes upstream installers it does not control — specifically: [bun.sh](https://bun.sh/install),
+[fnm.vercel.app](https://fnm.vercel.app) (Node via fnm), [herdr.dev](https://herdr.dev) (herdr), and
+[claude.ai](https://claude.ai/install.sh) (the `claude` CLI), plus your distro's package manager
+(`apt` / `apk` / `dnf` / `pacman`) for `git`, `unzip`, and the C/C++ build toolchain + `python3`
+(needed for the node-pty native build).
+
+In keeping with Shepherd's radical-transparency posture the script echoes each third-party command
+before running it. Read the script first:
+[deploy/install.sh](https://github.com/erwins-enkel/shepherd/blob/main/deploy/install.sh)
+
+### OS matrix
+
+| OS                                        | Mode                 | Notes                                                                                                                                                                                                                                           |
+| ----------------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linux (systemd + unprivileged userns)** | Full                 | The only fully supported target. Includes the sandbox membrane, egress allowlist, auto-drain, tailscale-serve previews, and the systemd user unit. The automated install-proof gate (`install-e2e`) runs here.                                  |
+| **macOS**                                 | Core-only / degraded | Installs prereqs, clones, and builds the UI. Prints a loud degraded banner. **No** sandbox membrane, egress allowlist, auto-drain, or tailscale-serve previews. **No systemd unit** — run `bun run start` manually. No automated install proof. |
+| **Windows**                               | Not supported        | The installer refuses and routes you to **WSL2** (a Linux distro under Windows Subsystem for Linux).                                                                                                                                            |
+
+### Environment knobs
+
+| Variable              | Default           | Purpose                                                                                       |
+| --------------------- | ----------------- | --------------------------------------------------------------------------------------------- |
+| `SHEPHERD_DIR`        | `~/Work/shepherd` | Where the repo is cloned / found                                                              |
+| `SHEPHERD_REF`        | `main`            | Git ref to clone or check out                                                                 |
+| `SHEPHERD_SRC`        | _(none)_          | Install from a local tarball or directory instead of cloning (used by the onboarding harness) |
+| `SHEPHERD_NO_SERVICE` | _(none)_          | Skip the systemd unit step (set automatically on macOS)                                       |
+
+### Finish setup
+
+The installer never runs commands that need a human secret. After it completes, log in:
+
+```bash
+claude              # sign in with your Max/Pro subscription (or configure API-key auth in Settings → Session)
+gh auth login       # GitHub integration (PR list, merge, redeploy)
+
+# remote access via Tailscale
+tailscale serve --bg 7330
+# then add the tailnet hostname to SHEPHERD_ALLOWED_HOSTS (in ~/.shepherd/env or deploy/shepherd.service)
+```
+
+Settings → DIAGNOSE surfaces any remaining gaps with one-click fixes.
+
+For the from-clone / development path, see [Quick start](#quick-start) below.
+
 ## Requirements
 
 - [Bun](https://bun.sh) — backend runtime + package manager

--- a/ci/onboarding-harness/README.md
+++ b/ci/onboarding-harness/README.md
@@ -8,8 +8,32 @@ Success is scoped **per scenario**: a scenario passes when the checks it broke r
 
 Two scenario classes:
 
-- **Green-able** — the defect can be coached back to `ok` unattended. `coaching: "structured"` runs a verbatim `REMEDIATIONS` command (deterministic, LLM-free, **release-gate-eligible**); `coaching: "prose"` uses the agent (e.g. distro-specific git install). Today: `herdr-missing`, `claude-missing`, `node-too-old` (structured) and `git-missing` (prose).
+- **Green-able** — the defect can be coached back to `ok` unattended. `coaching: "structured"` runs a verbatim `REMEDIATIONS` command (deterministic, LLM-free, **release-gate-eligible**); `coaching: "prose"` uses the agent (e.g. distro-specific git install). Today: `herdr-missing`, `claude-missing`, `node-too-old` (structured) and `git-missing` (prose). `install-e2e` is also structured (see below).
 - **Detection-only** (`detectionOnly: true`) — the defect is detectable but its fix needs a human/secret a throw-away instance can't supply (`gh auth login`; a Tailscale tailnet login + `serve`). No apply is attempted; excluded from the green tally and the gate; reported as DETECTION-ONLY. Today: `gh-unauthed`, `gh-missing`, `tailscale-missing`.
+
+### install-e2e
+
+The inverse of the seed-a-defect scenarios. A **bare** Ubuntu instance — no Bun, no checkout, no
+baseline — where the harness runs the real `deploy/install.sh` (via `SHEPHERD_SRC` pointing at the
+git-archive tarball of the current HEAD, `SHEPHERD_NO_SERVICE=1`, `SHEPHERD_DIR=/opt/shepherd`) rather than
+seeding a specific defect. Once the installer exits, the harness boots Shepherd and asserts that
+the auto-fixable checks reach `ok`:
+
+```
+herdr  bun  node  git  claude
+```
+
+`gh` and `tailscale` stay non-ok on a throw-away host (no tailnet, no gh login) and are
+intentionally excluded from `expect` — success is scoped to the installer's auto-fixable set,
+same as every other scenario.
+
+`install-e2e` is `coaching: "structured"` and not `detectionOnly`, so it is **gate-eligible**:
+`onboarding-gate.sh` and the nightly verdict pick it up, and a failing installer blocks the
+release gate. Run it directly with:
+
+```bash
+bun run onboarding:test --scenario install-e2e
+```
 
 ## Prerequisites
 

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -12,17 +12,28 @@ function isHarnessError(r: ScenarioResult): boolean {
   return !!r.error && !r.detection.detected && r.detection.misses.length === 0;
 }
 
+type Classification =
+  | "PASS"
+  | "DETECTION GAP"
+  | "ADVICE GAP"
+  | "INSTALL GAP"
+  | "DETECTION-ONLY"
+  | "HARNESS ERROR";
+
 /** Pure: render the per-scenario outcomes as a markdown gap report. Classifies
  *  each scenario as PASS, DETECTION GAP (defect missed/misclassified), ADVICE GAP
- *  (detected but coaching didn't reach green), DETECTION-ONLY (detected with no
- *  apply attempted by design — e.g. claude-missing in Phase 1; NOT a gap), or
- *  HARNESS ERROR (threw before detection — infra/image-rot, not a product gap).
- *  The green tally counts only apply-able scenarios so detection-only AND
- *  harness-errored ones don't drag the denominator. */
-function classify(
-  r: ScenarioResult,
-): "PASS" | "DETECTION GAP" | "ADVICE GAP" | "DETECTION-ONLY" | "HARNESS ERROR" {
+ *  (detected but coaching didn't reach green), INSTALL GAP (the install-e2e scenario
+ *  didn't reach green — an installer regression, NOT a detection failure, since it
+ *  has no seeded defect), DETECTION-ONLY (detected with no apply attempted by
+ *  design — e.g. claude-missing in Phase 1; NOT a gap), or HARNESS ERROR (threw
+ *  before detection — infra/image-rot, not a product gap). The green tally counts
+ *  only apply-able scenarios so detection-only AND harness-errored ones don't drag
+ *  the denominator. */
+function classify(r: ScenarioResult): Classification {
   if (isHarnessError(r)) return "HARNESS ERROR";
+  // install-e2e has no seeded defect, so a miss is an installer regression — never
+  // label it a DETECTION GAP (which reads as "a defect was missed").
+  if (r.installE2E) return r.reachedGreen ? "PASS" : "INSTALL GAP";
   if (r.detectionOnly) return r.detection.detected ? "DETECTION-ONLY" : "DETECTION GAP";
   if (r.reachedGreen) return "PASS";
   return r.detection.detected ? "ADVICE GAP" : "DETECTION GAP";
@@ -47,11 +58,14 @@ export function statusDescription(results: ScenarioResult[]): string {
     : `${gaps.length} gate gap(s): ${gaps.map((g) => g.scenarioId).join(", ")}`;
 }
 
-function tableRow(r: ScenarioResult, klass: ReturnType<typeof classify>): string {
+function tableRow(r: ScenarioResult, klass: Classification): string {
   return `| ${r.scenarioId} | ${r.image} | ${r.detection.detected ? "yes" : "no"} | ${r.appliedVia} | ${r.reachedGreen ? "yes" : "no"} | ${klass} |`;
 }
 
-function gapEntry(r: ScenarioResult, klass: "DETECTION GAP" | "ADVICE GAP"): string {
+function gapEntry(
+  r: ScenarioResult,
+  klass: "DETECTION GAP" | "ADVICE GAP" | "INSTALL GAP",
+): string {
   const misses = r.detection.misses.map((m) => `${m.id} want=${m.want} got=${m.got}`).join("; ");
   return `- **${r.scenarioId}** (${klass})${misses ? ` — ${misses}` : ""}${r.error ? ` — ${r.error}` : ""}`;
 }
@@ -85,7 +99,7 @@ export function buildGapReport(results: ScenarioResult[]): string {
   for (const r of results) {
     const klass = classify(r);
     lines.push(tableRow(r, klass));
-    if (klass === "DETECTION GAP" || klass === "ADVICE GAP") {
+    if (klass === "DETECTION GAP" || klass === "ADVICE GAP" || klass === "INSTALL GAP") {
       gaps.push(gapEntry(r, klass));
     } else if (klass === "HARNESS ERROR") {
       errors.push(harnessErrorEntry(r));

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -9,6 +9,11 @@ import type { ScenarioResult } from "./types";
  *  ran keeps its real detection result (non-empty misses or detected=true) and is
  *  classified as a normal gap instead. */
 function isHarnessError(r: ScenarioResult): boolean {
+  // install-e2e is never infra: it EXISTS to test the installer end-to-end, so a throw
+  // (install.sh non-zero, boot/probe failure) is an INSTALL regression that must gate —
+  // fail closed, never excluded as infra. (A genuinely down Incus host is handled by
+  // onboarding-gate.sh's host-unavailable bypass, not by silently dropping this scenario.)
+  if (r.installE2E) return false;
   return !!r.error && !r.detection.detected && r.detection.misses.length === 0;
 }
 
@@ -30,10 +35,11 @@ type Classification =
  *  only apply-able scenarios so detection-only AND harness-errored ones don't drag
  *  the denominator. */
 function classify(r: ScenarioResult): Classification {
-  if (isHarnessError(r)) return "HARNESS ERROR";
-  // install-e2e has no seeded defect, so a miss is an installer regression — never
-  // label it a DETECTION GAP (which reads as "a defect was missed").
+  // install-e2e takes precedence over the infra check: it has no seeded defect, so a
+  // miss — including a thrown install.sh/boot/probe failure — is an installer regression
+  // (INSTALL GAP), never a HARNESS ERROR or a DETECTION GAP ("a defect was missed").
   if (r.installE2E) return r.reachedGreen ? "PASS" : "INSTALL GAP";
+  if (isHarnessError(r)) return "HARNESS ERROR";
   if (r.detectionOnly) return r.detection.detected ? "DETECTION-ONLY" : "DETECTION GAP";
   if (r.reachedGreen) return "PASS";
   return r.detection.detected ? "ADVICE GAP" : "DETECTION GAP";

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -12,6 +12,7 @@ import { buildGapReport, statusDescription } from "./report";
 import { reportToGitHub, publishStatus } from "./issue";
 import { remediationsFor } from "../../src/remediations";
 import type { DetectionResult, Scenario, ScenarioResult } from "./types";
+import type { DiagnosticsSnapshot } from "../../src/types";
 
 /** `git archive` the current HEAD into a tarball the seed engine pushes. */
 function buildTarball(): string {
@@ -24,12 +25,80 @@ function buildTarball(): string {
 /** Local repo path to the installer the install-e2e scenario stages + runs. */
 const INSTALL_SCRIPT = join(import.meta.dir, "..", "..", "deploy", "install.sh");
 
+/** Base fields every ScenarioResult carries, computed once per run. */
+type ScenarioBase = {
+  scenarioId: string;
+  image: string;
+  gateEligible: boolean;
+};
+
+/** Inverse flow: bare host → real deploy/install.sh → assert it reaches green.
+ *  No seeded defect, no baseline; `expect` is the target-ok set. The install is a
+ *  deterministic, LLM-free apply, so it reuses the "verbatim" appliedVia. Throws
+ *  fail-closed on a non-zero install. */
+async function runInstallE2E(
+  driver: IncusDriver,
+  scenario: Scenario,
+  base: ScenarioBase,
+  tarball: string,
+): Promise<ScenarioResult> {
+  await seedInstance(driver, scenario, tarball, INSTALL_SCRIPT);
+  const install = await driver.exec(scenario.id, [
+    "sh",
+    "-c",
+    // SHEPHERD_DIR=/opt/shepherd so probe.ts's hardcoded `cd /opt/shepherd`
+    // finds it; NO_SERVICE skips systemd (no PID 1 in a fresh exec session).
+    // install.sh is `#!/usr/bin/env bash` + `set -o pipefail`; run it with bash,
+    // not sh — on Ubuntu /bin/sh is dash, which aborts at `set -o pipefail`.
+    "SHEPHERD_SRC=/root/shepherd.tar SHEPHERD_NO_SERVICE=1 SHEPHERD_DIR=/opt/shepherd bash /root/install.sh",
+  ]);
+  if (install.code !== 0) {
+    throw new Error(`install.sh failed in ${scenario.id}:\n${install.stderr || install.stdout}`);
+  }
+  await bootShepherd(driver, scenario.id);
+  const after = await probeDiagnostics(driver, scenario.id);
+  const detection = assertDetection(after, scenario.id, scenario.expect);
+  return {
+    ...base,
+    detection,
+    appliedVia: "verbatim",
+    reachedGreen: detection.detected,
+    installE2E: true,
+  };
+}
+
+/** Pick + run the standard-path remediation: detection-only (by design or
+ *  agent-incompatible), verbatim, or agent. Returns the chosen `appliedVia` and
+ *  whether this was a detection-only (no-apply) run. */
+async function applyDispatch(
+  driver: IncusDriver,
+  scenario: Scenario,
+  before: DiagnosticsSnapshot,
+): Promise<{ appliedVia: ScenarioResult["appliedVia"]; detectionOnly: boolean }> {
+  if (scenario.detectionOnly) {
+    // Defect detectable but unfixable unattended (needs human/secret) — verify
+    // detection only, never apply.
+    console.log(`[${scenario.id}] detection-only by design — no apply`);
+    return { appliedVia: "skipped", detectionOnly: true };
+  }
+  if (remediationsFor(before).length > 0) {
+    await applyVerbatim(driver, scenario.id, before);
+    return { appliedVia: "verbatim", detectionOnly: false };
+  }
+  if (scenario.agentIncompatible) {
+    console.log(`[${scenario.id}] agent-incompatible, no verbatim fix — detection-only`);
+    return { appliedVia: "skipped", detectionOnly: true };
+  }
+  await applyAgent(driver, scenario.id, before);
+  return { appliedVia: "agent", detectionOnly: false };
+}
+
 export async function runScenario(
   driver: IncusDriver,
   scenario: Scenario,
   tarball: string,
 ): Promise<ScenarioResult> {
-  const base = {
+  const base: ScenarioBase = {
     scenarioId: scenario.id,
     image: scenario.image,
     // Part of the deterministic release gate iff structured AND not detection-only
@@ -38,62 +107,14 @@ export async function runScenario(
   };
   let detection: DetectionResult | undefined;
   try {
-    if (scenario.installE2E) {
-      // Inverse flow: bare host → real deploy/install.sh → assert it reaches green.
-      // No seeded defect, no baseline; `expect` is the target-ok set. The install
-      // is a deterministic, LLM-free apply, so it reuses the "verbatim" appliedVia.
-      await seedInstance(driver, scenario, tarball, INSTALL_SCRIPT);
-      const install = await driver.exec(scenario.id, [
-        "sh",
-        "-c",
-        // SHEPHERD_DIR=/opt/shepherd so probe.ts's hardcoded `cd /opt/shepherd`
-        // finds it; NO_SERVICE skips systemd (no PID 1 in a fresh exec session).
-        // install.sh is `#!/usr/bin/env bash` + `set -o pipefail`; run it with bash,
-        // not sh — on Ubuntu /bin/sh is dash, which aborts at `set -o pipefail`.
-        "SHEPHERD_SRC=/root/shepherd.tar SHEPHERD_NO_SERVICE=1 SHEPHERD_DIR=/opt/shepherd bash /root/install.sh",
-      ]);
-      if (install.code !== 0) {
-        throw new Error(
-          `install.sh failed in ${scenario.id}:\n${install.stderr || install.stdout}`,
-        );
-      }
-      await bootShepherd(driver, scenario.id);
-      const after = await probeDiagnostics(driver, scenario.id);
-      detection = assertDetection(after, scenario.id, scenario.expect);
-      return {
-        ...base,
-        detection,
-        appliedVia: "verbatim",
-        reachedGreen: detection.detected,
-        installE2E: true,
-      };
-    }
+    if (scenario.installE2E) return await runInstallE2E(driver, scenario, base, tarball);
 
     await seedInstance(driver, scenario, tarball);
     await bootShepherd(driver, scenario.id);
     const before = await probeDiagnostics(driver, scenario.id);
     detection = assertDetection(before, scenario.id, scenario.expect);
 
-    const verbatim = remediationsFor(before);
-    let appliedVia: ScenarioResult["appliedVia"];
-    let detectionOnly = false;
-    if (scenario.detectionOnly) {
-      // Defect detectable but unfixable unattended (needs human/secret) — verify
-      // detection only, never apply.
-      console.log(`[${scenario.id}] detection-only by design — no apply`);
-      appliedVia = "skipped";
-      detectionOnly = true;
-    } else if (verbatim.length > 0) {
-      await applyVerbatim(driver, scenario.id, before);
-      appliedVia = "verbatim";
-    } else if (scenario.agentIncompatible) {
-      console.log(`[${scenario.id}] agent-incompatible, no verbatim fix — detection-only`);
-      appliedVia = "skipped";
-      detectionOnly = true;
-    } else {
-      await applyAgent(driver, scenario.id, before);
-      appliedVia = "agent";
-    }
+    const { appliedVia, detectionOnly } = await applyDispatch(driver, scenario, before);
     const after = detectionOnly ? before : await probeDiagnostics(driver, scenario.id);
     // Success is SCOPED to the checks this scenario broke: a throw-away instance
     // never has a fully-healthy host (no tailnet, no gh login, etc.), so the global

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -21,7 +21,10 @@ function buildTarball(): string {
   return tar;
 }
 
-async function runScenario(
+/** Local repo path to the installer the install-e2e scenario stages + runs. */
+const INSTALL_SCRIPT = join(import.meta.dir, "..", "..", "deploy", "install.sh");
+
+export async function runScenario(
   driver: IncusDriver,
   scenario: Scenario,
   tarball: string,
@@ -35,6 +38,37 @@ async function runScenario(
   };
   let detection: DetectionResult | undefined;
   try {
+    if (scenario.installE2E) {
+      // Inverse flow: bare host → real deploy/install.sh → assert it reaches green.
+      // No seeded defect, no baseline; `expect` is the target-ok set. The install
+      // is a deterministic, LLM-free apply, so it reuses the "verbatim" appliedVia.
+      await seedInstance(driver, scenario, tarball, INSTALL_SCRIPT);
+      const install = await driver.exec(scenario.id, [
+        "sh",
+        "-c",
+        // SHEPHERD_DIR=/opt/shepherd so probe.ts's hardcoded `cd /opt/shepherd`
+        // finds it; NO_SERVICE skips systemd (no PID 1 in a fresh exec session).
+        // install.sh is `#!/usr/bin/env bash` + `set -o pipefail`; run it with bash,
+        // not sh — on Ubuntu /bin/sh is dash, which aborts at `set -o pipefail`.
+        "SHEPHERD_SRC=/root/shepherd.tar SHEPHERD_NO_SERVICE=1 SHEPHERD_DIR=/opt/shepherd bash /root/install.sh",
+      ]);
+      if (install.code !== 0) {
+        throw new Error(
+          `install.sh failed in ${scenario.id}:\n${install.stderr || install.stdout}`,
+        );
+      }
+      await bootShepherd(driver, scenario.id);
+      const after = await probeDiagnostics(driver, scenario.id);
+      detection = assertDetection(after, scenario.id, scenario.expect);
+      return {
+        ...base,
+        detection,
+        appliedVia: "verbatim",
+        reachedGreen: detection.detected,
+        installE2E: true,
+      };
+    }
+
     await seedInstance(driver, scenario, tarball);
     await bootShepherd(driver, scenario.id);
     const before = await probeDiagnostics(driver, scenario.id);
@@ -207,4 +241,6 @@ async function main() {
   process.exit(gateOk ? 0 : 1);
 }
 
-void main();
+// Only run when executed directly (`bun run …/run.ts`), not when a test imports
+// `runScenario` from this module — importing must not acquire the host lock + exit.
+if (import.meta.main) void main();

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -135,6 +135,10 @@ export async function runScenario(
       detection: detection ?? { scenarioId: scenario.id, detected: false, misses: [] },
       appliedVia: "skipped",
       reachedGreen: false,
+      // Carry the flag through the throw path: an install-e2e that fails (install.sh
+      // non-zero, boot/probe crash) is an INSTALL regression that MUST gate — without
+      // this it'd be mislabeled a HARNESS ERROR and silently dropped from the tally.
+      installE2E: scenario.installE2E,
       error: err instanceof Error ? err.message : String(err),
     };
   } finally {

--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -97,4 +97,24 @@ export const SCENARIOS: Scenario[] = [
     expect: [{ id: "node", state: "warning" }],
     coaching: "structured",
   },
+  {
+    // Installer end-to-end regression: a BARE instance (no Bun, no checkout, no
+    // baseline) where the real deploy/install.sh must bring the host to green.
+    // `expect` is the TARGET-ok set, not a seeded defect (seed is empty). gh +
+    // tailscale are intentionally out — a throw-away instance has no gh login /
+    // tailnet, so they stay non-ok; success is scoped to the auto-fixable set,
+    // same as every other scenario.
+    id: "install-e2e",
+    image: "images:ubuntu/24.04", // apt (covered by install.sh distro detection for git) + x86_64 node-pty prebuilt → no node-gyp rebuild
+    seed: [],
+    expect: [
+      { id: "herdr", state: "ok" },
+      { id: "bun", state: "ok" },
+      { id: "node", state: "ok" },
+      { id: "git", state: "ok" },
+      { id: "claude", state: "ok" },
+    ],
+    coaching: "structured",
+    installE2E: true,
+  },
 ];

--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -57,29 +57,49 @@ function baselineCommands(): string[] {
   ];
 }
 
-/** Launch a fresh instance for `scenario`, install the bootable baseline, push
- *  the Shepherd build, then run the scenario's messy-state seed commands. */
-export async function seedInstance(
-  driver: IncusDriver,
-  scenario: Scenario,
-  tarballPath: string,
-): Promise<void> {
-  await driver.launch(scenario.image, scenario.id, {
-    vm: scenario.vm,
-    profiles: PROFILES,
-  });
-  // Wait for the instance's network to actually resolve DNS before the baseline
-  // hits the package mirrors. `/bin/sh` exists instantly, so the old test only
-  // proved the rootfs unpacked — on Arch, systemd-resolved comes up slower than
-  // on debian/fedora and `pacman -Sy` failed with "Could not resolve host". Poll
-  // a real resolution instead (skip on images without glibc `getent`, e.g. musl).
-  await driver.exec(scenario.id, [
+/** Wait for the instance's network to actually resolve DNS before anything hits
+ *  the package mirrors. `/bin/sh` exists instantly, so a launch alone only proves
+ *  the rootfs unpacked — on Arch, systemd-resolved comes up slower than on debian/
+ *  fedora and `pacman -Sy` failed with "Could not resolve host". Poll a real
+ *  resolution instead (skip on images without glibc `getent`, e.g. musl). */
+async function waitForDns(driver: IncusDriver, name: string): Promise<void> {
+  await driver.exec(name, [
     "sh",
     "-c",
     "for i in $(seq 1 60); do command -v getent >/dev/null 2>&1 || break; " +
       "getent hosts bun.sh >/dev/null 2>&1 && break; sleep 1; done",
   ]);
+}
+
+/** Launch a fresh instance for `scenario`, install the bootable baseline, push
+ *  the Shepherd build, then run the scenario's messy-state seed commands.
+ *
+ *  installE2E scenarios are the inverse: a BARE instance with NO baseline + NO
+ *  defect seed. We launch, wait for DNS (the real install.sh needs network), and
+ *  push the tarball + install.sh; run.ts then runs the installer itself. */
+export async function seedInstance(
+  driver: IncusDriver,
+  scenario: Scenario,
+  tarballPath: string,
+  installScriptPath?: string,
+): Promise<void> {
+  await driver.launch(scenario.image, scenario.id, {
+    vm: scenario.vm,
+    profiles: PROFILES,
+  });
+  await waitForDns(driver, scenario.id);
   await driver.push(scenario.id, tarballPath, "/root/shepherd.tar");
+
+  if (scenario.installE2E) {
+    // Bare host: skip the baseline (bun/extract/install) AND the defect seed — the
+    // real deploy/install.sh does all provisioning. Just stage the installer.
+    if (!installScriptPath) {
+      throw new Error(`installE2E scenario ${scenario.id} requires installScriptPath`);
+    }
+    await driver.push(scenario.id, installScriptPath, "/root/install.sh");
+    return;
+  }
+
   // Baseline steps are infrastructure: a failure here (e.g. bun didn't install)
   // leaves a non-bootable instance, so surface it now instead of limping on to a
   // misleading "Shepherd did not come up" 60s later.

--- a/ci/onboarding-harness/types.ts
+++ b/ci/onboarding-harness/types.ts
@@ -28,6 +28,15 @@ export interface Scenario {
    *  rarely triggers (claude-missing has a verbatim reinstall), but a scenario with
    *  no verbatim fix AND no claude falls back to detection-only rather than failing. */
   agentIncompatible?: boolean;
+  /** Installer END-TO-END regression scenario (the inverse of every other entry).
+   *  Instead of seeding a defect onto a bootable baseline, this launches a BARE
+   *  instance (no Bun, no checkout, no baseline) and runs the REAL `deploy/install.sh`
+   *  against it, then asserts the host reaches green. So there is NO seeded defect:
+   *  `seed` is empty and `expect` lists the checks that must be `ok` AFTER the
+   *  install (the target state, not a seeded defect). seed.ts skips the baseline +
+   *  scenario.seed and only pushes the tarball + install.sh; run.ts runs the
+   *  installer, boots, probes, and compares the snapshot against `expect`. */
+  installE2E?: true;
 }
 
 export interface ExpectedCheck {
@@ -60,6 +69,11 @@ export interface ScenarioResult {
    *  rolling issue); prose/agent + detection-only scenarios stay in the report as
    *  information and never block a release. */
   gateEligible: boolean;
+  /** This is the installer END-TO-END scenario (inverse flow: bare host → real
+   *  install.sh → assert green). It has NO seeded defect, so a non-green outcome is
+   *  an INSTALL regression, not a detection failure — the report classifies it as an
+   *  INSTALL GAP instead of a DETECTION GAP to keep the nightly signal accurate. */
+  installE2E?: boolean;
   error?: string;
 }
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Shepherd cold-start bootstrap — the `curl|bash` entry point.
+#
+#   curl -fsSL https://raw.githubusercontent.com/erwins-enkel/shepherd/main/deploy/install.sh | bash
+#
+# THIN bootstrap: does only what must happen before Bun + a checkout exist — OS
+# detect, distro OS-prereqs, install Bun, land the repo — then hands off to
+# `deploy/provision.ts` (run FROM the checkout), which finishes provisioning from
+# the shared remediation table (src/remediations.ts).
+#
+# Operator-facing ops tooling like update.sh: plain English, NOT internationalized.
+#
+# Structure: the OS-decision + source-resolve logic live in small sourceable
+# functions so a test can exercise the pure decisions without running the install:
+#   SHEPHERD_INSTALL_LIB=1 source deploy/install.sh
+# defines the functions but does NOT execute main (see the lib-mode guard at EOF).
+#
+# Environment contract:
+#   SHEPHERD_SRC      Local source override: a tarball file (extracted into
+#                     $SHEPHERD_DIR) or a directory (copied into $SHEPHERD_DIR).
+#                     Used by the onboarding harness + local checkouts. When unset,
+#                     the repo is git-cloned/updated.
+#   SHEPHERD_REF      Git ref to clone/checkout (default: main).
+#   SHEPHERD_DIR      Install dir (default: ~/Work/shepherd — matches the systemd
+#                     unit's WorkingDirectory).
+#   SHEPHERD_NO_SERVICE  Passed through to provision.ts: skip the systemd unit.
+#                        Set automatically on macOS (core-only mode).
+#
+# Test seams (override OS detection; never set in real use):
+#   SHEPHERD_UNAME_S  Overrides `uname -s`.
+#   SHEPHERD_UNAME_M  Overrides `uname -m`.
+set -euo pipefail
+
+REPO_URL="https://github.com/erwins-enkel/shepherd.git"
+SHEPHERD_REF="${SHEPHERD_REF:-main}"
+SHEPHERD_DIR="${SHEPHERD_DIR:-$HOME/Work/shepherd}"
+
+# ── colored helpers (match update.sh) ─────────────────────────────────────────
+note() { printf '\033[36m▸ %s\033[0m\n' "$*"; }
+warn() { printf '\033[33m! %s\033[0m\n' "$*"; }
+die() {
+  printf '\033[31m✗ %s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+# ── OS detection ──────────────────────────────────────────────────────────────
+# Sets OS_KIND (from uname -s) and ARCH (from uname -m). Honors the
+# SHEPHERD_UNAME_S / SHEPHERD_UNAME_M test seams.
+detect_os() {
+  OS_KIND="${SHEPHERD_UNAME_S:-$(uname -s)}"
+  ARCH="${SHEPHERD_UNAME_M:-$(uname -m)}"
+}
+
+# ── mode decision ─────────────────────────────────────────────────────────────
+# Maps OS_KIND to MODE: linux → full; darwin → core-only (degraded, no systemd);
+# Windows-ish → refuse with a WSL2 message. Echoes "mode: <MODE>" so the chosen
+# mode is observable to a test.
+decide() {
+  case "$OS_KIND" in
+    Linux)
+      MODE="full"
+      ;;
+    Darwin)
+      MODE="core-only"
+      export SHEPHERD_NO_SERVICE=1
+      # The authoritative degraded-capability list lives in provision.ts
+      # (MACOS_DEGRADED_BANNER) — the layer that actually proceeds core-only and
+      # prints it. Keep this to a one-liner so the two don't drift.
+      warn "macOS detected → core-only / DEGRADED mode (no systemd unit); details below."
+      ;;
+    MINGW* | MSYS* | CYGWIN* | Windows*)
+      die "Native Windows is not supported. Install Shepherd inside WSL2 (a Linux distro under Windows Subsystem for Linux), then re-run this installer from the WSL2 shell."
+      ;;
+    *)
+      die "Unsupported OS '$OS_KIND'. Shepherd supports Linux (full) and macOS (core-only)."
+      ;;
+  esac
+  echo "mode: $MODE"
+}
+
+# ── privilege helper ──────────────────────────────────────────────────────────
+# Echoes the prefix needed to run a system package manager: empty when root,
+# "sudo" when sudo is available, else dies with a clear manual-install message.
+# $* = the packages we are about to install (named in the error).
+sudo_prefix() {
+  if [ "$(id -u)" = "0" ]; then
+    printf ''
+    return 0
+  fi
+  if command -v sudo >/dev/null 2>&1; then
+    printf 'sudo'
+    return 0
+  fi
+  die "Not running as root and 'sudo' is not available. Install these packages manually, then re-run: $*"
+}
+
+# ── OS prereqs ────────────────────────────────────────────────────────────────
+# Cross-distro install of the bootstrap prereqs. Mirrors ci/onboarding-harness/
+# seed.ts: curl, git, unzip (bun's installer hard-requires it) and a C/C++
+# toolchain + python3 (node-pty has no prebuilt for every runtime → bun install
+# compiles it via node-gyp). Each guarded with `command -v` so it's idempotent.
+install_os_prereqs() {
+  # bin → package name (cc/make share the toolchain installer below)
+  ensure_pkg curl curl
+  ensure_pkg git git
+  ensure_pkg unzip unzip
+  ensure_toolchain
+}
+
+# ensure_pkg <bin> <pkg>: install <pkg> via apt/apk/dnf/pacman if <bin> is absent.
+ensure_pkg() {
+  local bin="$1" pkg="$2" sp
+  command -v "$bin" >/dev/null 2>&1 && return 0
+  sp="$(sudo_prefix "$pkg")"
+  note "installing $pkg (provides '$bin')"
+  $sp sh -c "(apt-get update && apt-get install -y $pkg) || apk add --no-cache $pkg || dnf install -y $pkg || pacman -Sy --noconfirm $pkg" \
+    || die "failed to install '$pkg' with any supported package manager (apt/apk/dnf/pacman)"
+}
+
+# ensure_toolchain: a C/C++ compiler + make + python3 for node-gyp's node-pty build.
+ensure_toolchain() {
+  local sp
+  command -v cc >/dev/null 2>&1 && command -v make >/dev/null 2>&1 && return 0
+  sp="$(sudo_prefix "build-essential/base-devel + python3")"
+  note "installing C/C++ build toolchain + python3 (node-pty native build)"
+  $sp sh -c "(apt-get update && apt-get install -y build-essential python3) || apk add --no-cache build-base python3 || dnf install -y gcc-c++ make python3 || pacman -Sy --noconfirm base-devel python3" \
+    || die "failed to install a C/C++ toolchain + python3 with any supported package manager"
+}
+
+# ── Bun ───────────────────────────────────────────────────────────────────────
+# Install Bun (idempotent — its installer no-ops when current) and put ~/.bun/bin
+# on PATH for the rest of this script. Transparency: echo the third-party command
+# before running it.
+install_bun() {
+  if ! command -v bun >/dev/null 2>&1 && [ ! -x "$HOME/.bun/bin/bun" ]; then
+    note "installing Bun via: curl -fsSL https://bun.sh/install | bash"
+    curl -fsSL https://bun.sh/install | bash || die "Bun install failed"
+  else
+    note "Bun already present — skipping"
+  fi
+  export PATH="$HOME/.bun/bin:$PATH"
+  command -v bun >/dev/null 2>&1 || die "bun not on PATH after install (expected ~/.bun/bin/bun)"
+}
+
+# ── source resolve ────────────────────────────────────────────────────────────
+# Populate $SHEPHERD_DIR with the repo. Precedence:
+#   1. SHEPHERD_SRC set → tarball (extract) or directory (copy).
+#   2. $SHEPHERD_DIR is an existing Shepherd checkout → update NON-DESTRUCTIVELY
+#      (mirrors update.sh): a dirty tree is left untouched; a clean tree is
+#      fast-forwarded only — never reset/--hard, never discarding work.
+#   3. $SHEPHERD_DIR exists but is NOT a Shepherd checkout → abort (never clobber).
+#   4. else → git clone the repo at $SHEPHERD_REF.
+# Never touches an existing ~/.shepherd/ state dir.
+resolve_source() {
+  if [ -n "${SHEPHERD_SRC:-}" ]; then
+    resolve_from_src
+    return 0
+  fi
+
+  if [ -e "$SHEPHERD_DIR" ]; then
+    if is_shepherd_checkout "$SHEPHERD_DIR"; then
+      update_existing_checkout
+    else
+      die "$SHEPHERD_DIR exists but is not a Shepherd checkout — refusing to clobber it. Set SHEPHERD_DIR to an empty/new path, or remove it yourself."
+    fi
+    return 0
+  fi
+
+  note "cloning $REPO_URL (ref: $SHEPHERD_REF) into $SHEPHERD_DIR"
+  git clone --branch "$SHEPHERD_REF" "$REPO_URL" "$SHEPHERD_DIR" \
+    || die "git clone failed"
+}
+
+# resolve_from_src: handle a SHEPHERD_SRC tarball or directory.
+resolve_from_src() {
+  local src="$SHEPHERD_SRC"
+  if [ -f "$src" ]; then
+    note "extracting source tarball $src into $SHEPHERD_DIR"
+    mkdir -p "$SHEPHERD_DIR"
+    tar -xf "$src" -C "$SHEPHERD_DIR" || die "failed to extract $src"
+  elif [ -d "$src" ]; then
+    if [ "$(cd "$src" && pwd -P)" = "$(cd "$SHEPHERD_DIR" 2>/dev/null && pwd -P || echo)" ]; then
+      note "source dir is the install dir — using in place: $SHEPHERD_DIR"
+    else
+      note "copying source dir $src into $SHEPHERD_DIR"
+      mkdir -p "$SHEPHERD_DIR"
+      # copy contents (including dotfiles) without nesting under a subdir
+      cp -a "$src/." "$SHEPHERD_DIR/" || die "failed to copy $src"
+    fi
+  else
+    die "SHEPHERD_SRC='$src' is neither a file (tarball) nor a directory"
+  fi
+}
+
+# update_existing_checkout: safely refresh the existing $SHEPHERD_DIR checkout.
+# Non-destructive (mirrors update.sh's posture): a dirty tree is left exactly as
+# the developer left it; a clean tree is fast-forwarded only. Never reset/--hard,
+# so uncommitted changes and un-pushed commits are never discarded. Idempotent for
+# the common already-current clean case. Hand-off then proceeds with this tree.
+update_existing_checkout() {
+  if [ -n "$(git -C "$SHEPHERD_DIR" status --porcelain 2>/dev/null)" ]; then
+    warn "existing checkout in $SHEPHERD_DIR has uncommitted changes — leaving it as-is (not updating)"
+    return 0
+  fi
+  note "updating existing checkout in $SHEPHERD_DIR (ref: $SHEPHERD_REF)"
+  git -C "$SHEPHERD_DIR" fetch --tags origin "$SHEPHERD_REF" || die "git fetch failed in $SHEPHERD_DIR"
+  git -C "$SHEPHERD_DIR" checkout "$SHEPHERD_REF" || die "git checkout '$SHEPHERD_REF' failed"
+  # fast-forward only; if it can't (diverged / un-pushed commits), leave it be.
+  git -C "$SHEPHERD_DIR" merge --ff-only "origin/$SHEPHERD_REF" 2>/dev/null \
+    || warn "cannot fast-forward $SHEPHERD_REF (diverged or un-pushed commits) — leaving checkout as-is"
+}
+
+# is_shepherd_checkout <dir>: true iff <dir> is a git repo that looks like Shepherd
+# (has deploy/provision.ts — our hand-off target).
+is_shepherd_checkout() {
+  local dir="$1"
+  [ -d "$dir/.git" ] || git -C "$dir" rev-parse --git-dir >/dev/null 2>&1 || return 1
+  [ -f "$dir/deploy/provision.ts" ]
+}
+
+# ── orchestration ─────────────────────────────────────────────────────────────
+main() {
+  detect_os
+  note "Shepherd installer — OS: $OS_KIND ($ARCH)"
+  decide
+
+  # core-only (macOS) still needs prereqs + bun; only the systemd path is skipped
+  # (handled downstream by SHEPHERD_NO_SERVICE in provision.ts).
+  install_os_prereqs
+  install_bun
+  resolve_source
+
+  cd "$SHEPHERD_DIR" || die "cannot cd into $SHEPHERD_DIR"
+  note "handing off to deploy/provision.ts (from $SHEPHERD_DIR)"
+  exec bun run deploy/provision.ts
+}
+
+# ── lib-mode guard ────────────────────────────────────────────────────────────
+# When sourced with SHEPHERD_INSTALL_LIB set, define functions but DO NOT run.
+[ "${SHEPHERD_INSTALL_LIB:-}" ] || main "$@"

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -186,16 +186,12 @@ interface ProvisionOpts {
   fileIO?: FileIO;
 }
 
-export function provision(opts: ProvisionOpts = {}): void {
-  const run = opts.run ?? defaultRunner;
-  const probe = opts.probe ?? probeVersion;
-  const fileIO = opts.fileIO ?? defaultFileIO;
-  const platform = opts.platform ?? process.platform;
-  const env = opts.env ?? process.env;
-  const repo = opts.repo ?? process.cwd();
-  const home = homedir();
-
-  // ── 1. prereqs (table-driven, idempotent) ──────────────────────────────────
+/** Step 1 — table-driven prereq install loop (idempotent; skips adequate tools). */
+export function installPrereqs(
+  probe: (bin: string) => string | null,
+  run: Runner,
+  env: NodeJS.ProcessEnv,
+): void {
   log("checking prerequisites");
   for (const prereq of PREREQS) {
     const version = probe(prereq.bin);
@@ -207,55 +203,88 @@ export function provision(opts: ProvisionOpts = {}): void {
     log(`  ${prereq.bin}: installing`);
     run("bash", ["-c", cmd], { env });
   }
+}
 
-  // ── 2. node-gyp safety net (replicates ci/onboarding-harness/seed.ts) ────────
-  // node-pty's install rebuilds via node-gyp on prebuilt-less distros; ensure it's
-  // present and that ~/.bun/bin + ~/.local/bin are on the PATH the later bun install
-  // sees. User-writable locations only — NO /usr/local/bin / sudo.
+/** Step 2 — node-gyp safety net (replicates ci/onboarding-harness/seed.ts).
+ * node-pty's install rebuilds via node-gyp on prebuilt-less distros; ensure it's
+ * present and that ~/.bun/bin + ~/.local/bin are on the PATH the later bun install
+ * sees. User-writable locations only — NO /usr/local/bin / sudo. Returns the build
+ * env (env + augmented PATH) used by every later build step. */
+export function ensureNodeGyp(
+  run: Runner,
+  env: NodeJS.ProcessEnv,
+  home: string,
+): NodeJS.ProcessEnv {
   log("ensuring node-gyp (node-pty build dep)");
   const bunBin = join(home, ".bun", "bin");
   const localBin = join(home, ".local", "bin");
   run("bash", ["-c", "bun add -g node-gyp"], { env });
-  const buildEnv: NodeJS.ProcessEnv = {
-    ...env,
-    PATH: `${bunBin}:${localBin}:${env.PATH ?? ""}`,
-  };
+  return { ...env, PATH: `${bunBin}:${localBin}:${env.PATH ?? ""}` };
+}
 
-  // ── 3. service vs no-service ────────────────────────────────────────────────
+/** Linux service path: template+write the systemd user unit, daemon-reload,
+ * enable-linger, enable, then build+start via deploy/update.sh. Fail-closed: throws
+ * if $USER is unset (enable-linger needs it). */
+export function installService(
+  repo: string,
+  run: Runner,
+  fileIO: FileIO,
+  env: NodeJS.ProcessEnv,
+  home: string,
+  buildEnv: NodeJS.ProcessEnv,
+): void {
+  log("installing systemd user unit");
+  const unitDir = join(home, ".config", "systemd", "user");
+  run("mkdir", ["-p", unitDir]);
+  // Template (not a verbatim copy): point WorkingDirectory at the ACTUAL checkout
+  // so a custom SHEPHERD_DIR install runs against the right dir, not the unit's
+  // hardcoded %h/Work/shepherd. Default repo (~/Work/shepherd) ⇒ identical output.
+  const unitSrc = fileIO.read(join(repo, "deploy", "shepherd.service"));
+  fileIO.write(join(unitDir, "shepherd.service"), templateUnit(unitSrc, repo));
+  run("systemctl", ["--user", "daemon-reload"]);
+  const user = env.USER;
+  if (!user) throw new Error("cannot enable-linger: $USER is not set");
+  run("loginctl", ["enable-linger", user]);
+  run("systemctl", ["--user", "enable", "shepherd"]);
+  // update.sh does deps → UI build → restart (starts the now-enabled unit) → health.
+  log("building + starting via deploy/update.sh");
+  run("bash", [join(repo, "deploy", "update.sh")], { env: buildEnv });
+}
+
+/** No-service path (harness e2e + macOS): deps + UI install + UI build only.
+ * Do NOT touch systemd. (The harness boots Shepherd directly afterward.) */
+export function buildOnly(repo: string, run: Runner, buildEnv: NodeJS.ProcessEnv): void {
+  log("installing deps (root + ui)");
+  run("bash", ["-c", `cd "${repo}" && bun install`], { env: buildEnv });
+  run("bash", ["-c", `cd "${repo}/ui" && bun install`], { env: buildEnv });
+  log("building UI");
+  run("bash", ["-c", `cd "${repo}/ui" && bun run build`], { env: buildEnv });
+}
+
+export function provision(opts: ProvisionOpts = {}): void {
+  const run = opts.run ?? defaultRunner;
+  const probe = opts.probe ?? probeVersion;
+  const fileIO = opts.fileIO ?? defaultFileIO;
+  const platform = opts.platform ?? process.platform;
+  const env = opts.env ?? process.env;
+  const repo = opts.repo ?? process.cwd();
+  const home = homedir();
+
+  installPrereqs(probe, run, env);
+  const buildEnv = ensureNodeGyp(run, env, home);
+
   const decision = decideServicePath(platform, env.SHEPHERD_NO_SERVICE);
-
   if (decision.service) {
-    log("installing systemd user unit");
-    const unitDir = join(home, ".config", "systemd", "user");
-    run("mkdir", ["-p", unitDir]);
-    // Template (not a verbatim copy): point WorkingDirectory at the ACTUAL checkout
-    // so a custom SHEPHERD_DIR install runs against the right dir, not the unit's
-    // hardcoded %h/Work/shepherd. Default repo (~/Work/shepherd) ⇒ identical output.
-    const unitSrc = fileIO.read(join(repo, "deploy", "shepherd.service"));
-    fileIO.write(join(unitDir, "shepherd.service"), templateUnit(unitSrc, repo));
-    run("systemctl", ["--user", "daemon-reload"]);
-    const user = env.USER;
-    if (!user) throw new Error("cannot enable-linger: $USER is not set");
-    run("loginctl", ["enable-linger", user]);
-    run("systemctl", ["--user", "enable", "shepherd"]);
-    // update.sh does deps → UI build → restart (starts the now-enabled unit) → health.
-    log("building + starting via deploy/update.sh");
-    run("bash", [join(repo, "deploy", "update.sh")], { env: buildEnv });
+    installService(repo, run, fileIO, env, home, buildEnv);
   } else {
-    // No-service path (harness e2e + macOS): deps + UI build + node-gyp net only.
-    // Do NOT touch systemd. (The harness boots Shepherd directly afterward.)
-    log("installing deps (root + ui)");
-    run("bash", ["-c", `cd "${repo}" && bun install`], { env: buildEnv });
-    run("bash", ["-c", `cd "${repo}/ui" && bun install`], { env: buildEnv });
-    log("building UI");
-    run("bash", ["-c", `cd "${repo}/ui" && bun run build`], { env: buildEnv });
+    buildOnly(repo, run, buildEnv);
   }
 
   if (decision.degradedBanner) {
     for (const line of MACOS_DEGRADED_BANNER) process.stdout.write(`\x1b[33m${line}\x1b[0m\n`);
   }
 
-  // ── 4. final summary + guidance ─────────────────────────────────────────────
+  // final summary + guidance
   process.stdout.write("\n");
   for (const line of guidanceNextSteps()) process.stdout.write(`${line}\n`);
 }

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env bun
+/**
+ * Cold-start provisioner — the hand-off target for `deploy/install.sh`.
+ *
+ * install.sh installs OS prereqs + Bun, lands the repo in $SHEPHERD_DIR, then runs
+ * `bun run deploy/provision.ts` FROM that checkout (cwd = the checkout). This script
+ * finishes provisioning using the SHARED remediation table (src/remediations.ts —
+ * single source of truth), installs/enables the systemd user unit, and builds by
+ * reusing deploy/update.sh (no duplicated deps/build/health logic).
+ *
+ * Operator-facing ops tooling like update.sh: output is plain English, NOT i18n'd.
+ *
+ * Structure: PURE decision logic (selecting commands, branch decisions) is separated
+ * from side effects (an injected command runner) so it's unit-testable without
+ * running anything (see test/provision.test.ts).
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { BUN_MIN_VERSION, NODE_MIN_VERSION, HERDR_MIN_VERSION } from "../src/config";
+import { compareSemver } from "../src/herdr-update";
+import { autoFixCommandFor } from "../src/remediations";
+
+// ── pure types + data ─────────────────────────────────────────────────────────
+
+/** A table-driven prerequisite. `floor` undefined ⇒ presence-only (no version
+ *  gate), like claude. `hintKey` selects the verbatim install via autoFixCommandFor
+ *  — so tailscale (guidance-only) is intentionally NOT in this table and can never
+ *  be auto-installed. */
+export interface Prereq {
+  /** Binary probed with `command -v` / `<bin> --version`. */
+  bin: string;
+  /** hintKey into the shared remediation table. */
+  hintKey: string;
+  /** Advisory version floor; undefined ⇒ presence-only. */
+  floor?: string;
+}
+
+export const PREREQS: readonly Prereq[] = [
+  { bin: "bun", hintKey: "diagnostics_hint_bun_missing", floor: BUN_MIN_VERSION },
+  { bin: "node", hintKey: "diagnostics_hint_node_missing", floor: NODE_MIN_VERSION },
+  { bin: "herdr", hintKey: "diagnostics_hint_herdr_missing", floor: HERDR_MIN_VERSION },
+  // claude is presence-only (no version floor), like diagnostics.
+  { bin: "claude", hintKey: "diagnostics_hint_claude_missing" },
+];
+
+/** The decision a host yields: whether to take the systemd-service path, and
+ *  whether to print the macOS DEGRADED banner. */
+export interface ServiceDecision {
+  service: boolean;
+  degradedBanner: boolean;
+}
+
+// ── pure decision logic ───────────────────────────────────────────────────────
+
+/** Install predicate: missing (null version) ⇒ install; with a floor, below-floor
+ *  ⇒ install; presence-only (no floor) ⇒ install only when absent. Adequate ⇒ skip
+ *  (never re-download). */
+export function needsInstall(version: string | null, floor: string | undefined): boolean {
+  if (version === null) return true;
+  if (floor === undefined) return false; // presence-only & present
+  return compareSemver(version, floor) < 0;
+}
+
+/** The verbatim command to run for a prereq given its probed state, or undefined to
+ *  skip. Selects via autoFixCommandFor (NOT raw REMEDIATIONS) so guidance-only hints
+ *  are excluded. */
+export function selectPrereqCommand(
+  prereq: Prereq,
+  probed: { version: string | null },
+): string | undefined {
+  if (!needsInstall(probed.version, prereq.floor)) return undefined;
+  return autoFixCommandFor(prereq.hintKey);
+}
+
+/** Service path iff linux AND SHEPHERD_NO_SERVICE unset/empty. macOS always takes
+ *  the no-service path AND warrants the degraded banner. */
+export function decideServicePath(
+  platform: NodeJS.Platform | string,
+  noService: string | undefined,
+): ServiceDecision {
+  if (platform === "darwin") return { service: false, degradedBanner: true };
+  const service = platform === "linux" && !noService;
+  return { service, degradedBanner: false };
+}
+
+/** Final guidance follow-ups that need a human secret and are NEVER auto-run. */
+export function guidanceNextSteps(): string[] {
+  return [
+    "Shepherd will be available at http://localhost:7330",
+    "",
+    "A few steps need a human secret and were NOT run for you:",
+    "  • Log into Claude:   claude   (then sign in with your Max/Pro subscription)",
+    "  • GitHub auth:       gh auth login",
+    "  • Remote access:     tailscale serve --bg 7330",
+    "                       then add the tailnet hostname to SHEPHERD_ALLOWED_HOSTS",
+    "                       (in ~/.shepherd/env or deploy/shepherd.service)",
+  ];
+}
+
+const MACOS_DEGRADED_BANNER = [
+  "",
+  "════════════════════════════════════════════════════════════════════",
+  "  ⚠  macOS: running in DEGRADED mode",
+  "════════════════════════════════════════════════════════════════════",
+  "  The following Linux-only capabilities are UNAVAILABLE on macOS:",
+  "    • sandbox membrane (per-spawn credential isolation)",
+  "    • egress allowlist (autonomous netns firewall)",
+  "    • auto-drain",
+  "    • tailscale-serve previews",
+  "    • no automated install proof (the onboarding harness is Linux-only)",
+  "",
+  "  No launchd unit is installed. Start Shepherd manually with:",
+  "    bun run start",
+  "════════════════════════════════════════════════════════════════════",
+  "",
+];
+
+// ── side-effect seam ──────────────────────────────────────────────────────────
+
+/** Injectable command runner. Production runs the real binary; tests inject a
+ *  recorder. Returns nothing — provision is fail-fast (throws on a hard failure). */
+export type Runner = (cmd: string, args: string[], opts?: { env?: NodeJS.ProcessEnv }) => void;
+
+const defaultRunner: Runner = (cmd, args, opts) => {
+  const r = spawnSync(cmd, args, {
+    stdio: "inherit",
+    env: opts?.env ?? process.env,
+  });
+  if (r.status !== 0) {
+    throw new Error(`command failed (exit ${r.status ?? "signal"}): ${cmd} ${args.join(" ")}`);
+  }
+};
+
+/** Probe a binary's version via `<bin> --version`; null if absent or unparseable. */
+function probeVersion(bin: string): string | null {
+  try {
+    const out = execFileSync(bin, ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const m = /(\d+\.\d+\.\d+)/.exec(out);
+    return m ? m[1]! : null;
+  } catch {
+    return null;
+  }
+}
+
+function log(msg: string): void {
+  process.stdout.write(`\x1b[36m▸ ${msg}\x1b[0m\n`);
+}
+
+// ── orchestration ─────────────────────────────────────────────────────────────
+
+interface ProvisionOpts {
+  run?: Runner;
+  probe?: (bin: string) => string | null;
+  platform?: NodeJS.Platform | string;
+  env?: NodeJS.ProcessEnv;
+  /** Repo checkout root (cwd by default). */
+  repo?: string;
+}
+
+export function provision(opts: ProvisionOpts = {}): void {
+  const run = opts.run ?? defaultRunner;
+  const probe = opts.probe ?? probeVersion;
+  const platform = opts.platform ?? process.platform;
+  const env = opts.env ?? process.env;
+  const repo = opts.repo ?? process.cwd();
+  const home = homedir();
+
+  // ── 1. prereqs (table-driven, idempotent) ──────────────────────────────────
+  log("checking prerequisites");
+  for (const prereq of PREREQS) {
+    const version = probe(prereq.bin);
+    const cmd = selectPrereqCommand(prereq, { version });
+    if (!cmd) {
+      log(`  ${prereq.bin}: ok (${version ?? "present"})`);
+      continue;
+    }
+    log(`  ${prereq.bin}: installing`);
+    run("bash", ["-c", cmd], { env });
+  }
+
+  // ── 2. node-gyp safety net (replicates ci/onboarding-harness/seed.ts) ────────
+  // node-pty's install rebuilds via node-gyp on prebuilt-less distros; ensure it's
+  // present and that ~/.bun/bin + ~/.local/bin are on the PATH the later bun install
+  // sees. User-writable locations only — NO /usr/local/bin / sudo.
+  log("ensuring node-gyp (node-pty build dep)");
+  const bunBin = join(home, ".bun", "bin");
+  const localBin = join(home, ".local", "bin");
+  run("bash", ["-c", "bun add -g node-gyp"], { env });
+  const buildEnv: NodeJS.ProcessEnv = {
+    ...env,
+    PATH: `${bunBin}:${localBin}:${env.PATH ?? ""}`,
+  };
+
+  // ── 3. service vs no-service ────────────────────────────────────────────────
+  const decision = decideServicePath(platform, env.SHEPHERD_NO_SERVICE);
+
+  if (decision.service) {
+    log("installing systemd user unit");
+    const unitDir = join(home, ".config", "systemd", "user");
+    run("mkdir", ["-p", unitDir]);
+    run("cp", [join(repo, "deploy", "shepherd.service"), join(unitDir, "shepherd.service")]);
+    run("systemctl", ["--user", "daemon-reload"]);
+    const user = env.USER;
+    if (!user) throw new Error("cannot enable-linger: $USER is not set");
+    run("loginctl", ["enable-linger", user]);
+    run("systemctl", ["--user", "enable", "shepherd"]);
+    // update.sh does deps → UI build → restart (starts the now-enabled unit) → health.
+    log("building + starting via deploy/update.sh");
+    run("bash", [join(repo, "deploy", "update.sh")], { env: buildEnv });
+  } else {
+    // No-service path (harness e2e + macOS): deps + UI build + node-gyp net only.
+    // Do NOT touch systemd. (The harness boots Shepherd directly afterward.)
+    log("installing deps (root + ui)");
+    run("bash", ["-c", `cd "${repo}" && bun install`], { env: buildEnv });
+    run("bash", ["-c", `cd "${repo}/ui" && bun install`], { env: buildEnv });
+    log("building UI");
+    run("bash", ["-c", `cd "${repo}/ui" && bun run build`], { env: buildEnv });
+  }
+
+  if (decision.degradedBanner) {
+    for (const line of MACOS_DEGRADED_BANNER) process.stdout.write(`\x1b[33m${line}\x1b[0m\n`);
+  }
+
+  // ── 4. final summary + guidance ─────────────────────────────────────────────
+  process.stdout.write("\n");
+  for (const line of guidanceNextSteps()) process.stdout.write(`${line}\n`);
+}
+
+// Run when invoked directly (not when imported by tests).
+if (import.meta.main) {
+  try {
+    provision();
+  } catch (err) {
+    process.stderr.write(`\x1b[31m✗ provision failed: ${(err as Error).message}\x1b[0m\n`);
+    process.exit(1);
+  }
+}

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -15,6 +15,7 @@
  * running anything (see test/provision.test.ts).
  */
 import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { BUN_MIN_VERSION, NODE_MIN_VERSION, HERDR_MIN_VERSION } from "../src/config";
@@ -84,6 +85,16 @@ export function decideServicePath(
   return { service, degradedBanner: false };
 }
 
+/** Template the systemd unit so its WorkingDirectory points at the ACTUAL checkout
+ *  (`repo`) instead of the hardcoded `%h/Work/shepherd`. This makes the default
+ *  (`~/Work/shepherd`) install byte-identical to today while making a custom
+ *  SHEPHERD_DIR correct — ExecStart stays `bun run src/index.ts` (relative to
+ *  WorkingDirectory) and bun's path is independent of the checkout, so retargeting
+ *  WorkingDirectory alone suffices. Replaces the single `WorkingDirectory=` line. */
+export function templateUnit(unit: string, repo: string): string {
+  return unit.replace(/^WorkingDirectory=.*$/m, `WorkingDirectory=${repo}`);
+}
+
 /** Final guidance follow-ups that need a human secret and are NEVER auto-run. */
 export function guidanceNextSteps(): string[] {
   return [
@@ -132,6 +143,18 @@ const defaultRunner: Runner = (cmd, args, opts) => {
   }
 };
 
+/** Injectable file IO. Production reads/writes the real filesystem; tests inject a
+ *  recorder so the templated unit can be asserted without touching disk. */
+export interface FileIO {
+  read: (path: string) => string;
+  write: (path: string, content: string) => void;
+}
+
+const defaultFileIO: FileIO = {
+  read: (path) => readFileSync(path, "utf8"),
+  write: (path, content) => writeFileSync(path, content),
+};
+
 /** Probe a binary's version via `<bin> --version`; null if absent or unparseable. */
 function probeVersion(bin: string): string | null {
   try {
@@ -159,11 +182,14 @@ interface ProvisionOpts {
   env?: NodeJS.ProcessEnv;
   /** Repo checkout root (cwd by default). */
   repo?: string;
+  /** Injectable file IO (templated-unit read/write); real fs by default. */
+  fileIO?: FileIO;
 }
 
 export function provision(opts: ProvisionOpts = {}): void {
   const run = opts.run ?? defaultRunner;
   const probe = opts.probe ?? probeVersion;
+  const fileIO = opts.fileIO ?? defaultFileIO;
   const platform = opts.platform ?? process.platform;
   const env = opts.env ?? process.env;
   const repo = opts.repo ?? process.cwd();
@@ -202,7 +228,11 @@ export function provision(opts: ProvisionOpts = {}): void {
     log("installing systemd user unit");
     const unitDir = join(home, ".config", "systemd", "user");
     run("mkdir", ["-p", unitDir]);
-    run("cp", [join(repo, "deploy", "shepherd.service"), join(unitDir, "shepherd.service")]);
+    // Template (not a verbatim copy): point WorkingDirectory at the ACTUAL checkout
+    // so a custom SHEPHERD_DIR install runs against the right dir, not the unit's
+    // hardcoded %h/Work/shepherd. Default repo (~/Work/shepherd) ⇒ identical output.
+    const unitSrc = fileIO.read(join(repo, "deploy", "shepherd.service"));
+    fileIO.write(join(unitDir, "shepherd.service"), templateUnit(unitSrc, repo));
     run("systemctl", ["--user", "daemon-reload"]);
     const user = env.USER;
     if (!user) throw new Error("cannot enable-linger: $USER is not set");

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "bun test ./test",
-    "lint": "eslint --no-error-on-unmatched-pattern src test ui/src ci/onboarding-harness",
+    "lint": "eslint --no-error-on-unmatched-pattern src test ui/src ci/onboarding-harness deploy",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "start": "bun run src/index.ts",

--- a/test/install-sh.test.ts
+++ b/test/install-sh.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Executable coverage for deploy/install.sh beyond `bash -n`: source it in
+ * lib-mode (SHEPHERD_INSTALL_LIB=1) and exercise the PURE decisions — OS→mode
+ * mapping and source-resolve — with NO real installs, NO network, NO Incus.
+ *
+ * detect_os honors SHEPHERD_UNAME_S/_M seams; resolve_source is driven with a
+ * temp dir + a local tarball (never the real `git clone` path).
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const INSTALL_SH = resolve(import.meta.dir, "..", "deploy", "install.sh");
+
+/** Source install.sh in lib-mode then run `script` (bash), returning the result. */
+function runLib(
+  script: string,
+  env: Record<string, string> = {},
+): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync("bash", ["-c", `source "${INSTALL_SH}"\n${script}`], {
+    encoding: "utf8",
+    env: { ...process.env, SHEPHERD_INSTALL_LIB: "1", ...env },
+  });
+  return { status: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+const tmpDirs: string[] = [];
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), "install-sh-"));
+  tmpDirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    const d = tmpDirs.pop()!;
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("detect_os + decide (OS → mode)", () => {
+  it("Linux ⇒ mode full", () => {
+    const r = runLib("detect_os; decide", { SHEPHERD_UNAME_S: "Linux" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("mode: full");
+  });
+
+  it("Darwin ⇒ core-only + degraded notice + SHEPHERD_NO_SERVICE set", () => {
+    const r = runLib('detect_os; decide; echo "NO_SERVICE=${SHEPHERD_NO_SERVICE:-unset}"', {
+      SHEPHERD_UNAME_S: "Darwin",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("mode: core-only");
+    expect(r.stdout).toContain("NO_SERVICE=1");
+    // Concise degraded notice (printed via warn → stderr); the full capability
+    // list now lives in provision.ts (MACOS_DEGRADED_BANNER), not exercised here.
+    const all = r.stdout + r.stderr;
+    expect(all).toContain("DEGRADED");
+    expect(all).toContain("core-only");
+  });
+
+  it("MINGW64_NT ⇒ refuse with WSL2 message + non-zero exit", () => {
+    const r = runLib("detect_os; decide", { SHEPHERD_UNAME_S: "MINGW64_NT" });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("WSL2");
+  });
+
+  it("MSYS ⇒ refuse with WSL2 message + non-zero exit", () => {
+    const r = runLib("detect_os; decide", { SHEPHERD_UNAME_S: "MSYS_NT-10.0" });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("WSL2");
+  });
+});
+
+describe("resolve_source", () => {
+  it("SHEPHERD_SRC tarball extracts into $SHEPHERD_DIR", () => {
+    const work = tmp();
+    // build a tiny tree that looks like a Shepherd checkout, tar it
+    const srcRoot = join(work, "srcroot");
+    mkdirSync(join(srcRoot, "deploy"), { recursive: true });
+    writeFileSync(join(srcRoot, "deploy", "provision.ts"), 'console.log("x");\n');
+    const tarball = join(work, "src.tar");
+    const tarRes = spawnSync("tar", ["-cf", tarball, "-C", srcRoot, "."], { encoding: "utf8" });
+    expect(tarRes.status).toBe(0);
+
+    const dest = join(work, "dest");
+    const r = runLib("resolve_source", { SHEPHERD_SRC: tarball, SHEPHERD_DIR: dest });
+    expect(r.status).toBe(0);
+
+    // verify the extracted hand-off target landed in $SHEPHERD_DIR
+    const check = spawnSync("test", ["-f", join(dest, "deploy", "provision.ts")]);
+    expect(check.status).toBe(0);
+  });
+
+  it("existing non-checkout $SHEPHERD_DIR ⇒ non-zero exit, no clobber", () => {
+    const work = tmp();
+    const dest = join(work, "occupied");
+    mkdirSync(dest, { recursive: true });
+    const marker = join(dest, "random.txt");
+    writeFileSync(marker, "do not touch me\n");
+
+    const r = runLib("resolve_source", { SHEPHERD_DIR: dest });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr.toLowerCase()).toContain("not a shepherd checkout");
+
+    // the pre-existing file must still be intact (never clobbered)
+    const check = spawnSync("cat", [marker], { encoding: "utf8" });
+    expect(check.stdout).toBe("do not touch me\n");
+  });
+});

--- a/test/onboarding-harness/install-e2e.test.ts
+++ b/test/onboarding-harness/install-e2e.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test";
+import { IncusDriver } from "../../ci/onboarding-harness/incus";
+import { seedInstance } from "../../ci/onboarding-harness/seed";
+import { runScenario } from "../../ci/onboarding-harness/run";
+import { SCENARIOS } from "../../ci/onboarding-harness/scenarios";
+import type { IncusExec } from "../../ci/onboarding-harness/types";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+const installE2E = SCENARIOS.find((s) => s.id === "install-e2e")!;
+
+/** Snapshot the install-e2e flow probes after install: the auto-fixable set is ok;
+ *  gh/tailscale stay non-ok (no gh login / tailnet on a throw-away instance). */
+function greenSnapshot(): DiagnosticsSnapshot {
+  return {
+    checks: [
+      { id: "herdr", state: "ok", hintKey: "" },
+      { id: "bun", state: "ok", hintKey: "" },
+      { id: "node", state: "ok", hintKey: "" },
+      { id: "git", state: "ok", hintKey: "" },
+      { id: "claude", state: "ok", hintKey: "" },
+      { id: "gh", state: "error", hintKey: "diagnostics_hint_gh_not_authenticated" },
+      { id: "tailscale", state: "error", hintKey: "diagnostics_hint_tailscale_missing" },
+    ],
+    generatedAt: 1,
+    overall: "error",
+  };
+}
+
+/** Recorder runner: code 0 for everything, but serves a diagnostics snapshot for
+ *  the probe call (the `?refresh=1` curl). Boot's poll loop also returns code 0. */
+function recorder(snapshot: DiagnosticsSnapshot) {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<IncusExec> => {
+    calls.push(args);
+    const joined = args.join(" ");
+    if (joined.includes("/api/diagnostics?refresh=1")) {
+      return { stdout: JSON.stringify(snapshot), stderr: "", code: 0 };
+    }
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  return { calls, run };
+}
+
+describe("install-e2e seedInstance", () => {
+  it("launches, waits for DNS, pushes the tarball + install.sh, and SKIPS the baseline", async () => {
+    const { calls, run } = recorder(greenSnapshot());
+    const d = new IncusDriver(run, "shep-onb-");
+    await seedInstance(d, installE2E, "/tmp/shepherd.tar", "/repo/deploy/install.sh");
+
+    const flat = calls.map((c) => c.join(" "));
+    // launch first
+    expect(calls[0]![0]).toBe("launch");
+    expect(calls[0]!).toContain("images:ubuntu/24.04");
+    // DNS wait runs
+    expect(flat.some((c) => c.includes("getent hosts bun.sh"))).toBe(true);
+    // pushes BOTH the tarball and install.sh
+    const pushes = calls.filter((c) => c[0] === "file" && c[1] === "push");
+    expect(pushes.some((c) => c.includes("/tmp/shepherd.tar"))).toBe(true);
+    expect(pushes.some((c) => c.includes("/repo/deploy/install.sh"))).toBe(true);
+    expect(pushes.some((c) => c.some((a) => a.endsWith("/root/shepherd.tar")))).toBe(true);
+    expect(pushes.some((c) => c.some((a) => a.endsWith("/root/install.sh")))).toBe(true);
+    // NO baseline: no bun install, no tarball extract to /opt/shepherd, no `bun install`
+    expect(flat.some((c) => c.includes("bun.sh/install"))).toBe(false);
+    expect(flat.some((c) => c.includes("tar -xf /root/shepherd.tar -C /opt/shepherd"))).toBe(false);
+    expect(flat.some((c) => c.includes("bun install"))).toBe(false);
+  });
+
+  it("throws when the install script path is omitted", async () => {
+    const { run } = recorder(greenSnapshot());
+    const d = new IncusDriver(run, "shep-onb-");
+    await expect(seedInstance(d, installE2E, "/tmp/shepherd.tar")).rejects.toThrow(
+      /requires installScriptPath/,
+    );
+  });
+});
+
+describe("install-e2e runScenario", () => {
+  it("runs the real install.sh, boots, probes, reaches green, and tears down", async () => {
+    const { calls, run } = recorder(greenSnapshot());
+    const d = new IncusDriver(run, "shep-onb-");
+    const result = await runScenario(d, installE2E, "/tmp/shepherd.tar");
+
+    const flat = calls.map((c) => c.join(" "));
+    // install.sh invoked with the expected env contract (the exec, not the push)
+    const installCall = flat.find((c) => c.startsWith("exec") && c.includes("/root/install.sh"));
+    expect(installCall).toBeDefined();
+    expect(installCall!).toContain("SHEPHERD_SRC=/root/shepherd.tar");
+    expect(installCall!).toContain("SHEPHERD_NO_SERVICE=1");
+    expect(installCall!).toContain("SHEPHERD_DIR=/opt/shepherd");
+    // boot + probe happened
+    expect(flat.some((c) => c.includes("src/index.ts"))).toBe(true);
+    expect(flat.some((c) => c.includes("/api/diagnostics?refresh=1"))).toBe(true);
+    // outcome
+    expect(result.reachedGreen).toBe(true);
+    expect(result.gateEligible).toBe(true);
+    expect(result.appliedVia).toBe("verbatim");
+    expect(result.detection.detected).toBe(true);
+    // teardown ran (finally → delete)
+    expect(calls.some((c) => c[0] === "delete")).toBe(true);
+  });
+
+  it("reports red when an expected check stays non-ok after install", async () => {
+    const snap = greenSnapshot();
+    snap.checks.find((c) => c.id === "herdr")!.state = "error";
+    const { calls, run } = recorder(snap);
+    const d = new IncusDriver(run, "shep-onb-");
+    const result = await runScenario(d, installE2E, "/tmp/shepherd.tar");
+
+    expect(result.reachedGreen).toBe(false);
+    expect(result.detection.detected).toBe(false);
+    expect(result.detection.misses.some((m) => m.id === "herdr")).toBe(true);
+    // still torn down
+    expect(calls.some((c) => c[0] === "delete")).toBe(true);
+  });
+});
+
+// Sanity: the catalog entry has the contract run.ts/seed.ts branch on.
+describe("install-e2e catalog entry", () => {
+  it("is installE2E, structured (gate-eligible), with an empty seed", () => {
+    expect(installE2E.installE2E).toBe(true);
+    expect(installE2E.coaching).toBe("structured");
+    expect(installE2E.detectionOnly).toBeUndefined();
+    expect(installE2E.seed).toEqual([]);
+  });
+});

--- a/test/onboarding-harness/install-e2e.test.ts
+++ b/test/onboarding-harness/install-e2e.test.ts
@@ -99,6 +99,32 @@ describe("install-e2e runScenario", () => {
     expect(calls.some((c) => c[0] === "delete")).toBe(true);
   });
 
+  it("carries installE2E through the catch when install.sh exits non-zero (so it gates as INSTALL GAP, not infra)", async () => {
+    const calls: string[][] = [];
+    // install.sh exec fails; everything else (launch/push/dns) succeeds.
+    const run = async (args: string[]): Promise<IncusExec> => {
+      calls.push(args);
+      // Fail only the install.sh EXEC (not its file-push during seed).
+      if (args[0] === "exec" && args.join(" ").includes("bash /root/install.sh")) {
+        return { stdout: "", stderr: "fnm install --lts: network unreachable", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const d = new IncusDriver(run, "shep-onb-");
+    const result = await runScenario(d, installE2E, "/tmp/shepherd.tar");
+
+    // The throw path must keep the flag so report.ts classifies it INSTALL GAP, not
+    // HARNESS ERROR (which would silently drop it from the gate).
+    expect(result.installE2E).toBe(true);
+    expect(result.reachedGreen).toBe(false);
+    expect(result.gateEligible).toBe(true);
+    expect(result.error).toContain("install.sh failed");
+    // never reached boot/probe
+    expect(calls.some((c) => c.join(" ").includes("src/index.ts"))).toBe(false);
+    // still torn down
+    expect(calls.some((c) => c[0] === "delete")).toBe(true);
+  });
+
   it("reports red when an expected check stays non-ok after install", async () => {
     const snap = greenSnapshot();
     snap.checks.find((c) => c.id === "herdr")!.state = "error";

--- a/test/onboarding-harness/report.test.ts
+++ b/test/onboarding-harness/report.test.ts
@@ -106,6 +106,49 @@ describe("buildGapReport", () => {
     expect(md).toContain("0 / 1 scenarios reached green"); // stays in the denominator
   });
 
+  it("classifies a red install-e2e result as an INSTALL GAP, not a DETECTION GAP", () => {
+    const md = buildGapReport([
+      {
+        scenarioId: "install-e2e",
+        image: "images:ubuntu/24.04",
+        // install-e2e has no seeded defect — `detected:false` here means the host
+        // didn't reach green after install.sh, i.e. an installer regression.
+        detection: {
+          scenarioId: "install-e2e",
+          detected: false,
+          misses: [{ id: "bun", want: "ok", got: "absent" }],
+        },
+        appliedVia: "verbatim",
+        reachedGreen: false,
+        gateEligible: true,
+        installE2E: true,
+      },
+    ]);
+    expect(md).toContain("INSTALL GAP");
+    expect(md).not.toContain("DETECTION GAP");
+    expect(md).toContain("## Gaps");
+    expect(md).toContain("bun want=ok got=absent");
+    expect(md).toContain("0 / 1 scenarios reached green");
+  });
+
+  it("classifies a green install-e2e result as PASS like the others", () => {
+    const md = buildGapReport([
+      {
+        scenarioId: "install-e2e",
+        image: "images:ubuntu/24.04",
+        detection: { scenarioId: "install-e2e", detected: true, misses: [] },
+        appliedVia: "verbatim",
+        reachedGreen: true,
+        gateEligible: true,
+        installE2E: true,
+      },
+    ]);
+    expect(md).toContain("PASS");
+    expect(md).not.toContain("INSTALL GAP");
+    expect(md).not.toContain("## Gaps");
+    expect(md).toContain("1 / 1 scenarios reached green");
+  });
+
   it("classifies a by-design no-apply scenario as DETECTION-ONLY and excludes it from the denominator", () => {
     const md = buildGapReport([
       {

--- a/test/onboarding-harness/report.test.ts
+++ b/test/onboarding-harness/report.test.ts
@@ -131,6 +131,33 @@ describe("buildGapReport", () => {
     expect(md).toContain("0 / 1 scenarios reached green");
   });
 
+  it("classifies a THROWN install-e2e (install.sh non-zero / boot crash) as an INSTALL GAP that gates, not a HARNESS ERROR", () => {
+    // This is the runScenario catch-block sentinel for install-e2e: error set,
+    // detection never ran (detected:false, no misses) — identical in shape to a
+    // pre-detection infra throw. Because it carries installE2E, it must be an
+    // INSTALL GAP (gates, stays in the denominator), NOT excluded as infra.
+    const md = buildGapReport([
+      {
+        scenarioId: "install-e2e",
+        image: "images:ubuntu/24.04",
+        detection: { scenarioId: "install-e2e", detected: false, misses: [] },
+        appliedVia: "skipped",
+        reachedGreen: false,
+        gateEligible: true,
+        installE2E: true,
+        error: "install.sh failed in install-e2e:\nfnm install --lts: network unreachable",
+      },
+    ]);
+    expect(md).toContain("INSTALL GAP");
+    expect(md).not.toContain("HARNESS ERROR");
+    expect(md).not.toContain("## Harness errors");
+    expect(md).toContain("## Gaps");
+    expect(md).toContain("install.sh failed in install-e2e");
+    // Stays in the denominator and is NOT green → a real installer regression gates.
+    expect(md).toContain("0 / 1 scenarios reached green");
+    expect(md).not.toContain("harness error");
+  });
+
   it("classifies a green install-e2e result as PASS like the others", () => {
     const md = buildGapReport([
       {

--- a/test/onboarding-harness/scenarios.test.ts
+++ b/test/onboarding-harness/scenarios.test.ts
@@ -18,7 +18,8 @@ describe("scenario catalog", () => {
 
   it("every scenario seeds at least one command and expects at least one flag", () => {
     for (const s of SCENARIOS) {
-      expect(s.seed.length).toBeGreaterThan(0);
+      // installE2E scenarios intentionally seed NO defect (bare host → install.sh).
+      if (!s.installE2E) expect(s.seed.length).toBeGreaterThan(0);
       expect(s.expect.length).toBeGreaterThan(0);
     }
   });

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { readFileSync } from "node:fs";
 import {
   PREREQS,
   provision,
@@ -8,6 +9,8 @@ import {
   needsInstall,
   decideServicePath,
   guidanceNextSteps,
+  templateUnit,
+  type FileIO,
   type Runner,
 } from "../deploy/provision";
 import { BUN_MIN_VERSION, NODE_MIN_VERSION, HERDR_MIN_VERSION } from "../src/config";
@@ -95,6 +98,36 @@ describe("decideServicePath", () => {
   });
 });
 
+describe("templateUnit", () => {
+  const unit = readFileSync("deploy/shepherd.service", "utf8");
+
+  it("default repo (~/Work/shepherd) keeps output identical to the source unit", () => {
+    // The shipped unit hardcodes %h/Work/shepherd; templating the literal value back
+    // in is a no-op — proving the default install is byte-identical to today.
+    const home = homedir();
+    const defaultRepo = join(home, "Work", "shepherd");
+    const templated = templateUnit(unit, defaultRepo);
+    expect(templated).toContain(`WorkingDirectory=${defaultRepo}`);
+    // only the WorkingDirectory line changed (from %h-form to absolute)
+    expect(
+      templated.replace(`WorkingDirectory=${defaultRepo}`, "WorkingDirectory=%h/Work/shepherd"),
+    ).toBe(unit);
+  });
+
+  it("custom repo retargets WorkingDirectory and leaves ExecStart/Environment alone", () => {
+    const templated = templateUnit(unit, "/srv/shepherd-prod");
+    expect(templated).toContain("WorkingDirectory=/srv/shepherd-prod");
+    expect(templated).not.toContain("WorkingDirectory=%h/Work/shepherd");
+    expect(templated).toContain("ExecStart=%h/.bun/bin/bun run src/index.ts");
+    expect(templated).toContain("EnvironmentFile=-%h/.shepherd/env");
+  });
+
+  it("replaces exactly one WorkingDirectory line", () => {
+    const templated = templateUnit(unit, "/x");
+    expect(templated.match(/^WorkingDirectory=/gm)?.length).toBe(1);
+  });
+});
+
 function recorder() {
   const calls: string[][] = [];
   const opts: ({ env?: NodeJS.ProcessEnv } | undefined)[] = [];
@@ -102,7 +135,16 @@ function recorder() {
     calls.push([cmd, ...args]);
     opts.push(o);
   };
-  return { calls, opts, run };
+  // Fake fileIO: reads serve the real unit template from the repo (so templating is
+  // exercised against the true file), writes are recorded in-memory.
+  const writes = new Map<string, string>();
+  const fileIO: FileIO = {
+    read: (path) => readFileSync(path.replace(/^.*\/deploy\//, "deploy/"), "utf8"),
+    write: (path, content) => {
+      writes.set(path, content);
+    },
+  };
+  return { calls, opts, run, writes, fileIO };
 }
 
 // All prereqs adequate → no prereq install runs; only node-gyp + the branch work.
@@ -147,16 +189,44 @@ describe("provision orchestration (injected runner, no real installs)", () => {
   });
 
   it("service path installs+enables the unit and delegates build to update.sh", () => {
-    const { calls, run } = recorder();
-    provision({ run, probe: adequateProbe, platform: "linux", env: { USER: "me" }, repo: "/repo" });
+    const { calls, run, writes, fileIO } = recorder();
+    provision({
+      run,
+      fileIO,
+      probe: adequateProbe,
+      platform: "linux",
+      env: { USER: "me" },
+      repo: "/repo",
+    });
     const flat = calls.map((c) => c.join(" "));
-    expect(flat.some((c) => c.includes("systemd/user/shepherd.service"))).toBe(true);
+    // The unit is now templated+written via fileIO (not a runner `cp`).
+    const unitTargets = [...writes.keys()].filter((p) =>
+      p.endsWith("systemd/user/shepherd.service"),
+    );
+    expect(unitTargets.length).toBe(1);
     expect(flat.some((c) => c.includes("daemon-reload"))).toBe(true);
     expect(flat.some((c) => c.includes("enable-linger"))).toBe(true);
     expect(flat.some((c) => c === "systemctl --user enable shepherd")).toBe(true);
     expect(flat.some((c) => c.includes("deploy/update.sh"))).toBe(true);
     // service path must NOT duplicate update.sh's deps/build
     expect(flat.some((c) => c.includes("ui && bun run build"))).toBe(false);
+    // no verbatim `cp` of the unit anymore
+    expect(flat.some((c) => c.startsWith("cp ") && c.includes("shepherd.service"))).toBe(false);
+  });
+
+  it("templates the installed unit's WorkingDirectory to the repo path (not a copy)", () => {
+    const { writes, run, fileIO } = recorder();
+    const repo = "/home/op/custom-shepherd-dir";
+    provision({ run, fileIO, probe: adequateProbe, platform: "linux", env: { USER: "me" }, repo });
+    const [target, content] = [...writes.entries()].find(([p]) =>
+      p.endsWith("systemd/user/shepherd.service"),
+    )!;
+    expect(target).toContain("systemd/user/shepherd.service");
+    // WorkingDirectory points at the custom checkout — proves templating, not passthrough
+    expect(content).toContain(`WorkingDirectory=${repo}`);
+    expect(content).not.toContain("WorkingDirectory=%h/Work/shepherd");
+    // everything else is untouched (ExecStart still relative + %h-based)
+    expect(content).toContain("ExecStart=%h/.bun/bin/bun run src/index.ts");
   });
 
   it("no-service path builds directly and never touches systemd", () => {

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -10,6 +10,10 @@ import {
   decideServicePath,
   guidanceNextSteps,
   templateUnit,
+  installPrereqs,
+  ensureNodeGyp,
+  installService,
+  buildOnly,
   type FileIO,
   type Runner,
 } from "../deploy/provision";
@@ -274,6 +278,51 @@ describe("provision orchestration (injected runner, no real installs)", () => {
     const flat = calls.map((c) => c.join(" "));
     expect(flat.some((c) => c.includes("systemctl"))).toBe(false);
     expect(flat.some((c) => c.includes("/ui") && c.includes("bun run build"))).toBe(true);
+  });
+});
+
+describe("extracted helpers (direct)", () => {
+  it("installPrereqs skips adequate tools and installs inadequate ones", () => {
+    const { calls, run } = recorder();
+    const probe = (bin: string) => (bin === "herdr" ? "0.1.0" : "999.0.0");
+    installPrereqs(probe, run, { FOO: "bar" });
+    const flat = calls.map((c) => c.join(" "));
+    expect(flat.some((c) => c.includes("herdr.dev/install"))).toBe(true);
+    expect(flat.some((c) => c.includes("bun.sh/install"))).toBe(false);
+  });
+
+  it("ensureNodeGyp installs node-gyp and returns build env with ~/.bun/bin on PATH", () => {
+    const { calls, run } = recorder();
+    const buildEnv = ensureNodeGyp(run, { PATH: "/usr/bin" }, "/home/op");
+    const flat = calls.map((c) => c.join(" "));
+    expect(flat.some((c) => c.includes("bun add -g node-gyp"))).toBe(true);
+    expect(buildEnv.PATH).toContain("/home/op/.bun/bin");
+    expect(buildEnv.PATH).toContain("/home/op/.local/bin");
+    expect(buildEnv.PATH).toContain("/usr/bin");
+  });
+
+  it("installService templates+writes the unit, enables, delegates build, throws without $USER", () => {
+    const { calls, writes, run, fileIO } = recorder();
+    installService("/repo", run, fileIO, { USER: "me" }, "/home/op", { PATH: "/x" });
+    const flat = calls.map((c) => c.join(" "));
+    expect([...writes.keys()].some((p) => p.endsWith("systemd/user/shepherd.service"))).toBe(true);
+    expect(flat.some((c) => c.includes("daemon-reload"))).toBe(true);
+    expect(flat.some((c) => c.includes("enable-linger"))).toBe(true);
+    expect(flat.some((c) => c.includes("deploy/update.sh"))).toBe(true);
+
+    const fresh = recorder();
+    expect(() =>
+      installService("/repo", fresh.run, fresh.fileIO, {}, "/home/op", { PATH: "/x" }),
+    ).toThrow(/\$USER/);
+  });
+
+  it("buildOnly installs deps + builds UI with the build env, no systemd", () => {
+    const { calls, run } = recorder();
+    buildOnly("/repo", run, { PATH: "/x" });
+    const flat = calls.map((c) => c.join(" "));
+    expect(flat.some((c) => c.includes('cd "/repo" && bun install'))).toBe(true);
+    expect(flat.some((c) => c.includes('cd "/repo/ui" && bun run build'))).toBe(true);
+    expect(flat.some((c) => c.includes("systemctl"))).toBe(false);
   });
 });
 

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  PREREQS,
+  provision,
+  selectPrereqCommand,
+  needsInstall,
+  decideServicePath,
+  guidanceNextSteps,
+  type Runner,
+} from "../deploy/provision";
+import { BUN_MIN_VERSION, NODE_MIN_VERSION, HERDR_MIN_VERSION } from "../src/config";
+
+describe("needsInstall (version-guard predicate)", () => {
+  it("flags a missing tool (null version) for install", () => {
+    expect(needsInstall(null, BUN_MIN_VERSION)).toBe(true);
+  });
+
+  it("flags a below-floor tool for install", () => {
+    expect(needsInstall("0.5.0", HERDR_MIN_VERSION)).toBe(true);
+    expect(needsInstall("19.9.0", NODE_MIN_VERSION)).toBe(true);
+  });
+
+  it("skips a tool at the floor", () => {
+    expect(needsInstall(NODE_MIN_VERSION, NODE_MIN_VERSION)).toBe(false);
+  });
+
+  it("skips a tool above the floor", () => {
+    expect(needsInstall("24.0.0", NODE_MIN_VERSION)).toBe(false);
+    expect(needsInstall("1.3.0", BUN_MIN_VERSION)).toBe(false);
+  });
+
+  it("presence-only (no floor) installs only when absent", () => {
+    expect(needsInstall(null, undefined)).toBe(true);
+    expect(needsInstall("anything", undefined)).toBe(false);
+  });
+});
+
+describe("selectPrereqCommand", () => {
+  it("returns the autoFix command for an inadequate (missing) tool", () => {
+    const bun = PREREQS.find((p) => p.bin === "bun")!;
+    const cmd = selectPrereqCommand(bun, { version: null });
+    expect(cmd).toContain("bun.sh/install");
+  });
+
+  it("returns nothing for an adequate tool (above floor)", () => {
+    const bun = PREREQS.find((p) => p.bin === "bun")!;
+    expect(selectPrereqCommand(bun, { version: "1.3.0" })).toBeUndefined();
+  });
+
+  it("returns nothing for an adequate presence-only tool (claude present)", () => {
+    const claude = PREREQS.find((p) => p.bin === "claude")!;
+    expect(selectPrereqCommand(claude, { version: "1.0.0" })).toBeUndefined();
+  });
+
+  it("selects an install for a below-floor herdr", () => {
+    const herdr = PREREQS.find((p) => p.bin === "herdr")!;
+    const cmd = selectPrereqCommand(herdr, { version: "0.1.0" });
+    expect(cmd).toContain("herdr.dev/install.sh");
+  });
+
+  it("never selects tailscale (guidance-only) — it is not a prereq", () => {
+    expect(PREREQS.some((p) => p.bin === "tailscale")).toBe(false);
+  });
+});
+
+describe("decideServicePath", () => {
+  it("linux + SHEPHERD_NO_SERVICE unset ⇒ service path", () => {
+    const d = decideServicePath("linux", undefined);
+    expect(d.service).toBe(true);
+    expect(d.degradedBanner).toBe(false);
+  });
+
+  it("linux + SHEPHERD_NO_SERVICE='' ⇒ service path", () => {
+    expect(decideServicePath("linux", "").service).toBe(true);
+  });
+
+  it("linux + SHEPHERD_NO_SERVICE set ⇒ no-service path", () => {
+    const d = decideServicePath("linux", "1");
+    expect(d.service).toBe(false);
+    expect(d.degradedBanner).toBe(false);
+  });
+
+  it("darwin ⇒ no-service path + degraded banner", () => {
+    const d = decideServicePath("darwin", undefined);
+    expect(d.service).toBe(false);
+    expect(d.degradedBanner).toBe(true);
+  });
+
+  it("darwin ignores SHEPHERD_NO_SERVICE (still no-service + banner)", () => {
+    const d = decideServicePath("darwin", "1");
+    expect(d.service).toBe(false);
+    expect(d.degradedBanner).toBe(true);
+  });
+});
+
+function recorder() {
+  const calls: string[][] = [];
+  const opts: ({ env?: NodeJS.ProcessEnv } | undefined)[] = [];
+  const run: Runner = (cmd, args, o) => {
+    calls.push([cmd, ...args]);
+    opts.push(o);
+  };
+  return { calls, opts, run };
+}
+
+// All prereqs adequate → no prereq install runs; only node-gyp + the branch work.
+const adequateProbe = () => "999.0.0";
+
+describe("provision orchestration (injected runner, no real installs)", () => {
+  it("skips adequate prereqs and never installs tailscale", () => {
+    const { calls, run } = recorder();
+    provision({
+      run,
+      probe: adequateProbe,
+      platform: "linux",
+      env: { SHEPHERD_NO_SERVICE: "1" },
+      repo: "/repo",
+    });
+    const flat = calls.map((c) => c.join(" "));
+    expect(flat.some((c) => c.includes("bun.sh/install"))).toBe(false);
+    expect(flat.some((c) => c.includes("herdr.dev/install"))).toBe(false);
+    expect(flat.some((c) => c.includes("tailscale.com/install"))).toBe(false);
+  });
+
+  it("installs a missing/below-floor prereq via its verbatim command", () => {
+    const { calls, run } = recorder();
+    // herdr below floor, rest adequate
+    const probe = (bin: string) => (bin === "herdr" ? "0.1.0" : "999.0.0");
+    provision({ run, probe, platform: "linux", env: { SHEPHERD_NO_SERVICE: "1" }, repo: "/repo" });
+    const flat = calls.map((c) => c.join(" "));
+    expect(flat.some((c) => c.includes("herdr.dev/install"))).toBe(true);
+  });
+
+  it("always lays the node-gyp safety net", () => {
+    const { calls, run } = recorder();
+    provision({
+      run,
+      probe: adequateProbe,
+      platform: "linux",
+      env: { SHEPHERD_NO_SERVICE: "1" },
+      repo: "/repo",
+    });
+    const flat = calls.map((c) => c.join(" "));
+    expect(flat.some((c) => c.includes("bun add -g node-gyp"))).toBe(true);
+  });
+
+  it("service path installs+enables the unit and delegates build to update.sh", () => {
+    const { calls, run } = recorder();
+    provision({ run, probe: adequateProbe, platform: "linux", env: { USER: "me" }, repo: "/repo" });
+    const flat = calls.map((c) => c.join(" "));
+    expect(flat.some((c) => c.includes("systemd/user/shepherd.service"))).toBe(true);
+    expect(flat.some((c) => c.includes("daemon-reload"))).toBe(true);
+    expect(flat.some((c) => c.includes("enable-linger"))).toBe(true);
+    expect(flat.some((c) => c === "systemctl --user enable shepherd")).toBe(true);
+    expect(flat.some((c) => c.includes("deploy/update.sh"))).toBe(true);
+    // service path must NOT duplicate update.sh's deps/build
+    expect(flat.some((c) => c.includes("ui && bun run build"))).toBe(false);
+  });
+
+  it("no-service path builds directly and never touches systemd", () => {
+    const { calls, run } = recorder();
+    provision({
+      run,
+      probe: adequateProbe,
+      platform: "linux",
+      env: { SHEPHERD_NO_SERVICE: "1" },
+      repo: "/repo",
+    });
+    const flat = calls.map((c) => c.join(" "));
+    expect(flat.some((c) => c.includes("systemctl"))).toBe(false);
+    expect(flat.some((c) => c.includes("update.sh"))).toBe(false);
+    expect(flat.some((c) => c.includes("/ui") && c.includes("bun run build"))).toBe(true);
+    // honors the injected repo root (not process cwd)
+    expect(flat.some((c) => c.includes('cd "/repo" && bun install'))).toBe(true);
+    expect(flat.some((c) => c.includes('cd "/repo/ui" && bun run build'))).toBe(true);
+  });
+
+  it("runs the build steps with ~/.bun/bin on PATH (node-gyp/node-pty rebuild)", () => {
+    const { calls, opts, run } = recorder();
+    provision({
+      run,
+      probe: adequateProbe,
+      platform: "linux",
+      env: { SHEPHERD_NO_SERVICE: "1", PATH: "/usr/bin" },
+      repo: "/repo",
+    });
+    // find the bun install / build steps and assert their env PATH carries .bun/bin
+    const buildIdxs = calls
+      .map((c, i) => ({ c: c.join(" "), i }))
+      .filter(({ c }) => c.includes("bun install") || c.includes("bun run build"))
+      .map(({ i }) => i);
+    expect(buildIdxs.length).toBeGreaterThan(0);
+    for (const i of buildIdxs) {
+      const path = opts[i]?.env?.PATH ?? "";
+      expect(path).toContain(`${join(homedir(), ".bun", "bin")}`);
+    }
+  });
+
+  it("darwin takes no-service path (no systemd)", () => {
+    const { calls, run } = recorder();
+    provision({ run, probe: adequateProbe, platform: "darwin", env: {}, repo: "/repo" });
+    const flat = calls.map((c) => c.join(" "));
+    expect(flat.some((c) => c.includes("systemctl"))).toBe(false);
+    expect(flat.some((c) => c.includes("/ui") && c.includes("bun run build"))).toBe(true);
+  });
+});
+
+describe("guidanceNextSteps", () => {
+  it("includes the local URL and the human-secret follow-ups", () => {
+    const steps = guidanceNextSteps().join("\n");
+    expect(steps).toContain("http://localhost:7330");
+    expect(steps.toLowerCase()).toContain("claude");
+    expect(steps).toContain("gh auth login");
+    expect(steps).toContain("tailscale serve");
+    expect(steps).toContain("SHEPHERD_ALLOWED_HOSTS");
+  });
+});


### PR DESCRIPTION
Closes #706 (Surface A + Phase-4 e2e gate). Follow-up to #703/#707, which shipped the keystone `src/remediations.ts` + the in-app DIAGNOSE **Fix** button (Surface B).

## What this ships

### Surface A — cold-start `curl | bash` installer
```bash
curl -fsSL https://raw.githubusercontent.com/erwins-enkel/shepherd/main/deploy/install.sh | bash
```
Thin-bootstrap-then-hand-off (research §6), so the canonical command table stays in one place:

- **`deploy/install.sh`** — runs before Bun exists: OS-detect (Linux full / **macOS core-only + loud degraded banner** / Windows→WSL2 refuse), install OS prereqs cross-distro (sudo when non-root), install Bun, resolve the repo into `$SHEPHERD_DIR`, then `exec bun run deploy/provision.ts`. Sourceable funcs + lib-mode guard for testing. Env knobs: `SHEPHERD_SRC` / `SHEPHERD_REF` / `SHEPHERD_DIR` / `SHEPHERD_NO_SERVICE`. Idempotent; never clobbers `~/.shepherd/` or a dirty checkout (no `git reset --hard`).
- **`deploy/provision.ts`** — finishes provisioning from the **shared** `src/remediations.ts` table (`autoFixCommandFor`, version-guarded by `src/config.ts` floors — guidance-only tailscale is correctly skipped); node-gyp net; on Linux installs the systemd user unit (templating `WorkingDirectory` to the actual install dir) + `enable-linger` + `enable` and reuses `deploy/update.sh`; macOS/no-service path = deps + UI build only; prints guidance-only next steps (claude / gh / tailscale login — never auto-run).

### Phase 4 — release-gate the installer
- New **`install-e2e`** onboarding-harness scenario: a bare Ubuntu instance → real `install.sh` (via `SHEPHERD_SRC` git-archive tarball, `SHEPHERD_NO_SERVICE`, `SHEPHERD_DIR=/opt/shepherd`) → boot → probe → assert the auto-fixable checks (herdr/bun/node/git/claude) reach `ok`. Gate-eligible (`structured`), so `scripts/onboarding-gate.sh` + the nightly verdict pick it up automatically. A miss reports as **INSTALL GAP** (not a misleading DETECTION GAP).

### OS matrix (decided in the issue)
| OS | Result |
| --- | --- |
| Linux (systemd + userns) | Full install — the only harness-proven target |
| macOS | Core-only, degraded banner, no systemd (manual `bun run start`) |
| Windows | Refused → routed to WSL2 |

## Out of scope (stays guidance-only)
Interactive/secret fixes never auto-run: `claude` subscription login, `gh auth login`, `tailscale` login + serve.

## Tests / gates
- New: `test/provision.test.ts`, `test/install-sh.test.ts` (bash sourced in lib-mode), `test/onboarding-harness/install-e2e.test.ts`, report/scenarios test updates.
- `bun run lint` (now covers `deploy/`), `bun run typecheck`, `bun test ./test` (3218 pass / 0 fail), `bash -n deploy/install.sh`, and `fallow audit` all green.
- No `ui/` or message-catalog changes → i18n + feature-catalog gates correctly dormant (server/ops-only). [no-feature-entry]

## Deferred (tracked in #725)
Optional DIAGNOSE doc-links (gh-auth, tailscale), full systemd user-unit **lifecycle** e2e, and vanity `shepherd.dev/install.sh` hosting — see #725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
