### PR TITLE
fix(tab-reaper): husk detection + worktree GC under herdr 0.7 pane-persistence (#721)

### DIFF
--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -29,6 +29,14 @@ export interface HerdrTab {
   workspaceId: string;
 }
 
+export interface HerdrPane {
+  paneId: string;
+  tabId: string;
+  label: string;
+  cwd: string;
+  agentStatus: HerdrState;
+}
+
 export type Runner = (args: string[]) => string;
 /** Async counterpart to `Runner` — spawns off Bun's single loop (no blocking). */
 export type AsyncRunner = (args: string[]) => Promise<string>;
@@ -206,6 +214,41 @@ export class HerdrDriver {
     }));
   }
 
+  /** Every pane across all tabs (`pane list`). Includes idle shell panes left behind by exited agents. */
+  panes(): HerdrPane[] {
+    const parsed = JSON.parse(this.runner(["pane", "list"]));
+    const panes = parsed?.result?.panes ?? [];
+    return panes.map((p: Record<string, string>) => ({
+      paneId: p.pane_id ?? "",
+      tabId: p.tab_id ?? "",
+      label: p.label ?? "",
+      cwd: p.cwd ?? "",
+      agentStatus: (p.agent_status ?? "unknown") as HerdrState,
+    }));
+  }
+
+  /**
+   * Async: returns the foreground process **names** in a pane (`pane process-info`).
+   * For a husk pane (idle shell) this is `["zsh"]`; for a live agent pane it includes
+   * `"claude"` and companion processes.
+   *
+   * A JSON parse failure (missing/malformed reply) returns `[]` — the caller can treat
+   * an unreadable pane as "no known foreground processes". A thrown CLI error (e.g.
+   * herdr lacks the subcommand) **propagates** — callers must distinguish "shell-only"
+   * (`["zsh"]`) from "subcommand unavailable" (throw).
+   */
+  async paneForegroundProcs(paneId: string): Promise<string[]> {
+    const out = await this.asyncRunner(["pane", "process-info", "--pane", paneId]);
+    try {
+      const parsed = JSON.parse(out);
+      const procs: Array<{ name: string }> =
+        parsed?.result?.process_info?.foreground_processes ?? [];
+      return procs.map((p) => p.name);
+    } catch {
+      return [];
+    }
+  }
+
   /**
    * herdr ≥0.6 refuses `tab create` with `workspace_not_found: no active workspace`
    * unless a workspace exists. A fresh daemon — or one restarted after an update —
@@ -348,8 +391,10 @@ export class HerdrDriver {
    * TAB, not just its pane: every agent gets its own dedicated tab, so closing only the
    * pane left an empty husk tab behind. Resolves `terminalId → current tabId` FRESH from
    * the live list — the live list is the source of truth; the agent may have ended or been
-   * relabeled, so a cached tabId may be stale. No-op if the agent has already left the
-   * list — the orphan sweep reaps that husk.
+   * relabeled, so a cached tabId may be stale. Under herdr 0.7 an exited agent persists as
+   * a husk that retains its terminalId, so stop() still finds and closes its tab. The no-op
+   * path fires only when the pane is truly gone from the list; the orphan sweep handles any
+   * residue in that case.
    */
   stop(terminalId: string): void {
     const agent = this.list().find((a) => a.terminalId === terminalId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,12 +283,14 @@ fireTmpSweep("boot");
 // shepherd restart cleared the in-memory review tracking. Run once on boot, then hourly.
 const sweepOrphanTabs = () => {
   if (maintenance.active) return;
-  try {
-    const closed = reapOrphanTabs(herdr);
-    if (closed.length) console.warn(`[tabs] reaped ${closed.length} orphan helper tab(s)`);
-  } catch (err) {
-    console.warn("[tabs] orphan sweep failed:", err);
-  }
+  // NOTE: reapOrphanTabs is now async + debounced (#721). This minimal call site keeps the
+  // boot/hourly sweep firing and preserves the prior logging intent; the full two-sweep
+  // debounce (threading `shellOnly` back in) + worktree wiring lands in the follow-up task.
+  void reapOrphanTabs(herdr)
+    .then((r) => {
+      if (r.closed.length) console.warn(`[tabs] reaped ${r.closed.length} orphan helper tab(s)`);
+    })
+    .catch((err) => console.warn("[tabs] orphan sweep failed:", err));
 };
 setTimeout(sweepOrphanTabs, 5_000);
 setInterval(sweepOrphanTabs, 60 * 60 * 1000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, existsSync } from "node:fs";
-import { dirname } from "node:path";
+import { mkdirSync, existsSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
 import {
   config,
   SESSION_RETENTION_MS,
@@ -25,7 +25,8 @@ import { StatusPoller } from "./poller";
 import { PrPoller } from "./pr-poller";
 import { BranchPruner } from "./branch-pruner";
 import { reconcile } from "./reconcile";
-import { reapOrphanTabs } from "./tab-reaper";
+import { reapOrphanTabs, reapStaleReviewWorktrees } from "./tab-reaper";
+import { scanClaudeAliveByWorktree } from "./process-reaper";
 import { serve, buildBacklogPayload } from "./server";
 import { detectForge } from "./forge";
 import { AccountUsageIndex } from "./usage";
@@ -281,18 +282,26 @@ fireTmpSweep("boot");
 // teardown paths close these at the source; this sweep is the safety net for husks
 // they miss — agents that crashed out of `agent list`, or anything left over after a
 // shepherd restart cleared the in-memory review tracking. Run once on boot, then hourly.
+// Debounce state for reapOrphanTabs' two-sweep husk confirmation (#721): the shell-only
+// tabIds seen last sweep, threaded back in as `prevShellOnly` so a husk is only reaped when
+// it read shell-only on two consecutive sweeps (avoids reaping an agent's pre-`exec` window).
+let shellOnlyTabs = new Set<string>();
 const sweepOrphanTabs = () => {
   if (maintenance.active) return;
-  // NOTE: reapOrphanTabs is now async + debounced (#721). This minimal call site keeps the
-  // boot/hourly sweep firing and preserves the prior logging intent; the full two-sweep
-  // debounce (threading `shellOnly` back in) + worktree wiring lands in the follow-up task.
-  void reapOrphanTabs(herdr)
+  void reapOrphanTabs(herdr, shellOnlyTabs)
     .then((r) => {
-      if (r.closed.length) console.warn(`[tabs] reaped ${r.closed.length} orphan helper tab(s)`);
+      shellOnlyTabs = r.shellOnly;
+      if (r.closed.length || r.sparedError)
+        console.warn(
+          `[tabs] reaped ${r.closed.length} husk tab(s); spared ${r.sparedLive} live, ${r.sparedError} undetermined`,
+        );
     })
     .catch((err) => console.warn("[tabs] orphan sweep failed:", err));
 };
+// Boot + a confirming pass @45s so pre-existing husks clear despite the two-sweep debounce,
+// then hourly.
 setTimeout(sweepOrphanTabs, 5_000);
+setTimeout(sweepOrphanTabs, 45_000);
 setInterval(sweepOrphanTabs, 60 * 60 * 1000);
 
 // Memoize forge resolution: detectForge shells out to a synchronous
@@ -551,16 +560,67 @@ const planGate = new PlanGateService({
   onReviewing: (id, reviewing) => events.emit("session:plangate-reviewing", { id, reviewing }),
   cap: () => config.planReviewCyclesCap,
 });
+// Grace window for a recent uncompleted reviewer_spawns row: covers the begin() spawn-window
+// before the owning service records the path in `inflight` (protectedPaths covers the rest).
+const REVIEW_WORKTREE_GRACE_MS = 15 * 60 * 1000;
+
+// Disk-driven stale reviewer-worktree sweep (#721): reaps `*-review-*` checkouts under each
+// `.shepherd-worktrees` dir whose teardown was missed (crash / restart / foreign-era basename).
+// COMPLEMENTS planGate.gcStaleReviewWorktrees (store-driven) — see tab-reaper.ts. Spares any
+// path a reviewer service currently holds (protectedPaths, the #631 guard — load-bearing that
+// adoptOrphans has repopulated `inflight` before the boot call), any live session path, any
+// recent uncompleted spawn, and any worktree hosting a live `claude`.
+const sweepStaleReviewWorktrees = () => {
+  if (maintenance.active) return; // a sync /proc+git sweep must not run mid-update
+  try {
+    const protectedPaths = new Set([
+      ...planGate.inflightWorktrees(),
+      ...reviewService.inflightWorktrees(),
+      ...standaloneCritic.inflightWorktrees(),
+    ]);
+    const sessionWorktreePaths = new Set(store.list().map((s) => s.worktreePath));
+    const parents = new Set<string>();
+    for (const s of store.list()) parents.add(join(dirname(s.repoPath), ".shepherd-worktrees"));
+    for (const row of store.listReviewerSpawns()) parents.add(dirname(row.worktreePath));
+    const r = reapStaleReviewWorktrees({
+      parents: [...parents],
+      listDir: (parent) => {
+        try {
+          return readdirSync(parent);
+        } catch {
+          return [];
+        }
+      },
+      protectedPaths,
+      sessionWorktreePaths,
+      scanAlive: scanClaudeAliveByWorktree,
+      listReviewerSpawns: () => store.listReviewerSpawns(),
+      now: Date.now,
+      graceMs: REVIEW_WORKTREE_GRACE_MS,
+      remove: (p) => worktree.remove(p),
+    });
+    if (r.reaped.length)
+      console.warn(
+        `[worktrees] reaped ${r.reaped.length} stale review worktree(s); spared ${r.sparedOwned} owned, ${r.sparedLive} live`,
+      );
+  } catch (err) {
+    console.warn("[worktrees] sweep failed:", err);
+  }
+};
+
 // Re-adopt plan reviews left in flight by the previous run (the `inflight` map is in-memory):
 // without this a restart mid-review orphans the reviewer forever — its verdict goes unread, the
 // gate never advances, and the planning agent sits idle awaiting a re-review that never comes.
 // The next tick() then finalizes each re-adopted run from the verdict it already wrote.
 // gcStaleReviewWorktrees runs AFTER adoptOrphans has repopulated `inflight` so it only reaps
-// truly ownerless review worktrees (e.g. the older of two #631 same-session orphans).
+// truly ownerless review worktrees (e.g. the older of two #631 same-session orphans); the
+// disk-sweep then runs after gc, with `inflight` populated so its protectedPaths spare holds.
 void planGate
   .adoptOrphans()
   .then(() => planGate.gcStaleReviewWorktrees())
+  .then(() => sweepStaleReviewWorktrees())
   .catch((err) => console.warn("[plan-gate] adoptOrphans:", err));
+setInterval(() => sweepStaleReviewWorktrees(), 60 * 60 * 1000);
 
 attachReviewPush(events, store, push);
 attachGitPush(events, store, push);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, existsSync, readdirSync } from "node:fs";
+import { mkdirSync, existsSync, readdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   config,
@@ -560,8 +560,11 @@ const planGate = new PlanGateService({
   onReviewing: (id, reviewing) => events.emit("session:plangate-reviewing", { id, reviewing }),
   cap: () => config.planReviewCyclesCap,
 });
-// Grace window for a recent uncompleted reviewer_spawns row: covers the begin() spawn-window
-// before the owning service records the path in `inflight` (protectedPaths covers the rest).
+// Grace window for a recent uncompleted reviewer_spawns row: spares a recently-spawned reviewer
+// whose path is not currently in `inflight` (e.g. a restart-orphan before re-adoption). It does
+// NOT cover the pre-`inflight` begin() window — recordReviewerSpawn runs AFTER inflight.set — so
+// that window is covered instead by the directory-age guard in reapStaleReviewWorktrees, which
+// reuses this same value as the dir-age threshold.
 const REVIEW_WORKTREE_GRACE_MS = 15 * 60 * 1000;
 
 // Disk-driven stale reviewer-worktree sweep (#721): reaps `*-review-*` checkouts under each
@@ -598,6 +601,13 @@ const sweepStaleReviewWorktrees = () => {
       listReviewerSpawns: () => store.listReviewerSpawns(),
       now: Date.now,
       graceMs: REVIEW_WORKTREE_GRACE_MS,
+      dirMtime: (p) => {
+        try {
+          return statSync(p).mtimeMs;
+        } catch {
+          return null;
+        }
+      },
       remove: (p) => worktree.remove(p),
     });
     if (r.reaped.length)

--- a/src/index.ts
+++ b/src/index.ts
@@ -578,9 +578,10 @@ const sweepStaleReviewWorktrees = () => {
       ...reviewService.inflightWorktrees(),
       ...standaloneCritic.inflightWorktrees(),
     ]);
-    const sessionWorktreePaths = new Set(store.list().map((s) => s.worktreePath));
+    const sessions = store.list();
+    const sessionWorktreePaths = new Set(sessions.map((s) => s.worktreePath));
     const parents = new Set<string>();
-    for (const s of store.list()) parents.add(join(dirname(s.repoPath), ".shepherd-worktrees"));
+    for (const s of sessions) parents.add(join(dirname(s.repoPath), ".shepherd-worktrees"));
     for (const row of store.listReviewerSpawns()) parents.add(dirname(row.worktreePath));
     const r = reapStaleReviewWorktrees({
       parents: [...parents],

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -628,6 +628,12 @@ export class PlanGateService {
     return [...this.inflight.keys()];
   }
 
+  /** Worktree paths of plan reviews currently owned in-memory — the GC sweep must spare
+   *  these (a re-adopted #631 orphan's tick() still needs its worktree). */
+  inflightWorktrees(): string[] {
+    return [...this.inflight.values()].map((f) => f.worktreePath);
+  }
+
   forget(sessionId: string): void {
     // Clear the `starting` tombstone so an archived session can't get a review after
     // forget(). begin() now awaits a best-effort network `getIssue` AFTER allocating its

--- a/src/review.ts
+++ b/src/review.ts
@@ -821,6 +821,12 @@ export class ReviewService {
     return [...this.inflight.keys()];
   }
 
+  /** Worktree paths of critic runs currently owned in-memory — the GC sweep must spare
+   *  these (a re-adopted #631 orphan's tick() still needs its worktree). */
+  inflightWorktrees(): string[] {
+    return [...this.inflight.values()].map((f) => f.worktreePath);
+  }
+
   forget(sessionId: string): void {
     // Clear any mid-spawn claim: a begin() suspended in either gh fetch (author-notes or
     // issue-body) checks this on resume and aborts, so an archived session can't get a critic

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -644,6 +644,12 @@ export class StandalonePrCriticService {
     return [...this.inFlight.keys()];
   }
 
+  /** Worktree paths of standalone critic runs currently owned in-memory — the GC sweep must spare
+   *  these (a re-adopted #631 orphan's tick() still needs its worktree). */
+  inflightWorktrees(): string[] {
+    return [...this.inFlight.values()].map((f) => f.worktreePath);
+  }
+
   /** Tear down every in-flight run (reap its terminal + worktree). For process shutdown. */
   stopAll(): void {
     for (const f of this.inFlight.values()) {

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import type { HerdrDriver } from "./herdr";
 import { PROBE_NAME } from "./usage-probe";
 import { DISTILL_LABEL } from "./distiller";
@@ -189,4 +190,133 @@ export function reapOrphanTabsLegacy(herdr: ReapableHerdr): string[] {
     .sort((a, b) => tabNumber(b.tabId) - tabNumber(a.tabId));
   for (const t of orphans) herdr.closeTab(t.tabId);
   return orphans.map((t) => t.tabId);
+}
+
+// ── Stranded review-worktree disk sweep (#721) ───────────────────────────────
+
+/**
+ * Reviewer/critic disposable checkouts (`{basename}-review-{tag}`, created by
+ * `worktree.ts:createDetached`) whose teardown was missed — a crash, a shepherd
+ * restart that cleared in-memory review tracking, or a foreign-era basename whose
+ * repo is no longer configured — accumulate as dead dirs under `.shepherd-worktrees`.
+ * This is a disk-driven sweep that reaps them; it COMPLEMENTS plan-gate's
+ * {@link gcStaleReviewWorktrees} (which is store-driven and only knows plan_gate
+ * spawns it still tracks) — it does not replace it. Runs SYNC (a boot + hourly
+ * maintenance pass, not on the typing hot path), consistent with that sibling.
+ *
+ * **Tag-shape match, basename-agnostic (guard d).** Selection keys off the reviewer
+ * TAG SHAPE — a name ending in `-review-(<8hex> | <uuid>-<8hex>)` — NOT the basename.
+ * This is deliberate: a worktree minted under a now-defunct basename (`tank-review-…`,
+ * `flowagent-review-…`, `pulse-review-…`) whose repo is no longer configured would be
+ * invisible to any basename- or repo-scoped filter, yet is exactly the kind of orphan
+ * that strands forever. Matching the tag suffix alone catches those. The flip side
+ * (guards below) is that a USER prompt slugging to `review-*` yields `{basename}-review-*`
+ * too — so a hex-shaped suffix could in principle alias real user work; (d)'s strict
+ * hex/uuid shape plus the session-path spare (e) keep that from being reaped.
+ *
+ * **Three spare reasons:**
+ *  - **owned in memory (`protectedPaths`)** — paths a reviewer service currently holds.
+ *    Spared REGARDLESS of age or `/proc` liveness. This is the #631 regression guard: a
+ *    re-adopted plan-gate orphan has a DEAD reviewer `claude` AND an OLD uncompleted
+ *    `reviewer_spawns` row, yet `tick()` still needs its worktree — age/proc heuristics
+ *    alone would wrongly reap it. The caller unions the three reviewer services'
+ *    `inflightWorktrees()` into this set.
+ *  - **live store session (`sessionWorktreePaths`, guard e)** — any path backing a live
+ *    user session is spared even if its name happens to match the tag shape.
+ *  - **recent uncompleted spawn** — a `reviewer_spawns` row with `completedAt == null`
+ *    whose `spawnedAt` is within `graceMs`: a spawn that may still be wiring up its
+ *    worktree before the owning service records it as inflight.
+ *
+ * Liveness for the remaining (non-owned) candidates comes from the injected
+ * {@link scanClaudeAliveByWorktree} — one cheap `/proc` pass; a candidate hosting a
+ * live `claude` is spared (`sparedLive`). Everything else is removed.
+ *
+ * Fully dependency-injected (no direct fs/proc/store calls) so it is unit-testable
+ * without a real filesystem, `/proc`, or store. The real wiring into `index.ts` is a
+ * separate task.
+ */
+export interface ReapWorktreesDeps {
+  /** Distinct `.shepherd-worktrees` dirs to sweep. */
+  parents: string[];
+  /** Entry NAMES under a parent (default in caller = readdirSync); `[]` if unreadable. */
+  listDir: (parent: string) => string[];
+  /** In-memory reviewer-owned paths — spare regardless of age/proc (#631 guard). */
+  protectedPaths: Set<string>;
+  /** Live store session worktreePaths — spare (user-work guard e). */
+  sessionWorktreePaths: Set<string>;
+  /** One-pass `/proc` liveness probe ({@link scanClaudeAliveByWorktree}). */
+  scanAlive: (paths: string[]) => Map<string, boolean>;
+  /** Append-only reviewer-spawn rows (subset of {@link ReviewerSpawnRow} fields). */
+  listReviewerSpawns: () => Array<{
+    worktreePath: string;
+    completedAt: number | null;
+    spawnedAt: number;
+  }>;
+  now: () => number;
+  /** Grace window for a recent uncompleted spawn (spare if `spawnedAt > now()-graceMs`). */
+  graceMs: number;
+  /** Worktree removal wrapper (`worktree.remove`). */
+  remove: (worktreePath: string) => void;
+}
+
+export interface ReapWorktreesResult {
+  /** Worktree paths actually removed this sweep. */
+  reaped: string[];
+  /** Spared because owned in memory / live session / recent uncompleted spawn. */
+  sparedOwned: number;
+  /** Spared because a live `claude` was running in them. */
+  sparedLive: number;
+}
+
+/** Reviewer disposable-worktree tag shape: `-review-` followed by an `sha8` or a
+ *  `randomUUID-sha8` (lowercase hex; `i` flag tolerates upper). Validated against every
+ *  on-disk `*-review-*` dir; matches the suffix produced by `worktree.ts:createDetached`. */
+const REVIEW_TAG_RE =
+  /-review-([0-9a-f]{8}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-[0-9a-f]{8})$/i;
+
+export function reapStaleReviewWorktrees(deps: ReapWorktreesDeps): ReapWorktreesResult {
+  // 1. Candidate paths: tag-shape matches under every parent, de-duped.
+  const candidates: string[] = [];
+  const seen = new Set<string>();
+  for (const parent of deps.parents) {
+    for (const name of deps.listDir(parent)) {
+      if (!REVIEW_TAG_RE.test(name)) continue;
+      const path = join(parent, name);
+      if (seen.has(path)) continue;
+      seen.add(path);
+      candidates.push(path);
+    }
+  }
+
+  // 2. owned(path): in-memory-owned, live session, or recent uncompleted spawn.
+  const recent = new Set<string>();
+  const cutoff = deps.now() - deps.graceMs;
+  for (const sp of deps.listReviewerSpawns()) {
+    if (sp.completedAt == null && sp.spawnedAt > cutoff) recent.add(sp.worktreePath);
+  }
+  const owned = (path: string): boolean =>
+    deps.protectedPaths.has(path) || deps.sessionWorktreePaths.has(path) || recent.has(path);
+
+  // 3. One /proc pass over the non-owned candidates only.
+  const nonOwned = candidates.filter((p) => !owned(p));
+  const aliveMap = deps.scanAlive(nonOwned);
+
+  // 4. Classify each candidate.
+  const reaped: string[] = [];
+  let sparedOwned = 0;
+  let sparedLive = 0;
+  for (const path of candidates) {
+    if (owned(path)) {
+      sparedOwned++;
+      continue;
+    }
+    if (aliveMap.get(path)) {
+      sparedLive++;
+      continue;
+    }
+    deps.remove(path);
+    reaped.push(path);
+  }
+
+  return { reaped, sparedOwned, sparedLive };
 }

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -274,12 +274,12 @@ export interface ReapWorktreesResult {
 const REVIEW_TAG_RE =
   /-review-([0-9a-f]{8}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-[0-9a-f]{8})$/i;
 
-export function reapStaleReviewWorktrees(deps: ReapWorktreesDeps): ReapWorktreesResult {
-  // 1. Candidate paths: tag-shape matches under every parent, de-duped.
+/** Collects de-duped tag-shape-matched worktree paths across all parent dirs. */
+function gatherReviewCandidates(parents: string[], listDir: (p: string) => string[]): string[] {
   const candidates: string[] = [];
   const seen = new Set<string>();
-  for (const parent of deps.parents) {
-    for (const name of deps.listDir(parent)) {
+  for (const parent of parents) {
+    for (const name of listDir(parent)) {
       if (!REVIEW_TAG_RE.test(name)) continue;
       const path = join(parent, name);
       if (seen.has(path)) continue;
@@ -287,19 +287,34 @@ export function reapStaleReviewWorktrees(deps: ReapWorktreesDeps): ReapWorktrees
       candidates.push(path);
     }
   }
+  return candidates;
+}
 
-  // 2. owned(path): in-memory-owned, live session, or recent uncompleted spawn.
+/** Builds the set of worktree paths for recent uncompleted spawns within `graceMs`. */
+function recentSpawnPaths(
+  rows: Array<{ worktreePath: string; completedAt: number | null; spawnedAt: number }>,
+  now: number,
+  graceMs: number,
+): Set<string> {
+  const cutoff = now - graceMs;
   const recent = new Set<string>();
-  const cutoff = deps.now() - deps.graceMs;
-  for (const sp of deps.listReviewerSpawns()) {
+  for (const sp of rows) {
     if (sp.completedAt == null && sp.spawnedAt > cutoff) recent.add(sp.worktreePath);
   }
+  return recent;
+}
+
+export function reapStaleReviewWorktrees(deps: ReapWorktreesDeps): ReapWorktreesResult {
+  // 1. Candidate paths: tag-shape matches under every parent, de-duped.
+  const candidates = gatherReviewCandidates(deps.parents, deps.listDir);
+
+  // 2. owned(path): in-memory-owned, live session, or recent uncompleted spawn.
+  const recent = recentSpawnPaths(deps.listReviewerSpawns(), deps.now(), deps.graceMs);
   const owned = (path: string): boolean =>
     deps.protectedPaths.has(path) || deps.sessionWorktreePaths.has(path) || recent.has(path);
 
   // 3. One /proc pass over the non-owned candidates only.
-  const nonOwned = candidates.filter((p) => !owned(p));
-  const aliveMap = deps.scanAlive(nonOwned);
+  const aliveMap = deps.scanAlive(candidates.filter((p) => !owned(p)));
 
   // 4. Classify each candidate.
   const reaped: string[] = [];

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -2,7 +2,10 @@ import type { HerdrDriver } from "./herdr";
 import { PROBE_NAME } from "./usage-probe";
 import { DISTILL_LABEL } from "./distiller";
 
-export type ReapableHerdr = Pick<HerdrDriver, "list" | "tabs" | "closeTab">;
+export type ReapableHerdr = Pick<
+  HerdrDriver,
+  "list" | "tabs" | "closeTab" | "panes" | "paneForegroundProcs"
+>;
 
 /** Labels shepherd authors for its short-lived helper agents. A tab with one of these
  *  labels but no live agent is an orphaned husk (the probe/critic ended without its tab
@@ -60,30 +63,120 @@ function tabNumber(tabId: string): number {
   return Number.isFinite(n) ? n : 0;
 }
 
+/** Foreground process names that mean "just an idle shell" (a husk PTY). A helper pane
+ *  whose foreground is *only* one of these has nothing running in it. */
+const SHELLS = new Set(["zsh", "bash", "sh", "fish", "dash"]);
+
+/** Breakdown of one reconciliation sweep. */
+export interface ReapResult {
+  /** Tab ids actually closed this sweep. */
+  closed: string[];
+  /** Helper panes spared because their foreground held a non-shell proc (claude/node/etc.). */
+  sparedLive: number;
+  /** Helper panes spared because process-info threw OR was empty/undeterminable (fail-closed). */
+  sparedError: number;
+  /** Tab ids that were shell-only THIS sweep — feed back as `prevShellOnly` next sweep to debounce. */
+  shellOnly: Set<string>;
+}
+
 /**
- * Reconciliation sweep: close any usage-probe / review / namer / distill helper tab that no
- * live agent backs. The teardown paths (herdr.stop / start rollback) stop most leaks at the source;
- * this is the durable safety net for husks they can't reach — agents that crashed out of
- * `agent list`, or anything orphaned across a shepherd restart (which clears in-memory
- * review tracking). Returns the ids it closed.
+ * Reconciliation sweep: close any usage-probe / review / namer / distill helper tab whose
+ * pane is a husk — an idle shell with no agent process running in it. The teardown paths
+ * (herdr.stop / start rollback) stop most leaks at the source; this is the durable safety
+ * net for husks they can't reach — agents that crashed, or anything orphaned across a
+ * shepherd restart (which clears in-memory review tracking). Returns a {@link ReapResult}.
  *
- * Safe against false positives: `herdr.start()` is synchronous and fully registers the
- * agent in `agent list` before yielding the event loop, so a labeled tab with no backing
- * agent is unambiguously dead — never a mid-start probe/review.
+ * **Husk signal = per-pane process liveness (ground truth), not list-absence.** Under
+ * herdr 0.7 an exited helper agent leaves its pane alive as an idle `zsh`, and that pane
+ * STILL appears in `agent list` (#721) — so the old "absent from `agent list` ⇒ orphan"
+ * signal never fires. Instead we ask herdr for each helper pane's foreground processes:
+ *
+ * - **non-shell proc present** (`claude` / `node` / `node-MainThread` / …) → live → spare
+ *   (`sparedLive`).
+ * - **process-info throws** (transient read failure / quirk) → spare (`sparedError`). A
+ *   per-pane throw is NOT a capability miss and does NOT trigger the legacy fallback.
+ * - **empty proc list** (undeterminable) → spare fail-closed (`sparedError`); we never
+ *   reap on no evidence.
+ * - **shell-only** (`procs.length > 0 && procs.every(SHELLS.has)`) → husk CANDIDATE this
+ *   sweep.
+ *
+ * **Two-sweep debounce.** herdr's own PTY is a `zsh` that runs the agent command, so a
+ * just-spawned agent is briefly shell-only during its pre-`exec` window. To avoid reaping
+ * that, a husk candidate is only closed when it was *also* shell-only on the previous sweep
+ * (its tabId was in `prevShellOnly`). A first-time shell-only sighting is recorded in the
+ * returned `shellOnly` set (caller threads it back in) but not closed.
+ *
+ * **Capability fallback for old herdr (0.6).** If `herdr.panes()` itself throws — the
+ * `pane`/`pane process-info` subcommands are absent — we fall back to
+ * {@link reapOrphanTabsLegacy}, the list-absence signal, which is *correct* on 0.6 because
+ * a finished helper there DOES drop out of `agent list`. Only a `panes()` throw triggers
+ * the fallback; a per-pane `paneForegroundProcs` throw is `sparedError` (see above).
  *
  * Closes in descending tab-number order. The behaviour under each herdr version:
  *
  * - **herdr ≤0.6** (positional ids, e.g. `workspace:N`): ids re-densify on close, so
  *   closing highest-number-first keeps each remaining snapshotted target id valid — only
- *   already-closed, higher-numbered tabs shift.
+ *   already-closed, higher-numbered tabs shift. (Relevant on the legacy fallback path.)
  * - **herdr 0.7** (#569, stable ids e.g. `w1:t1`): closed ids don't retarget, so close
  *   order is irrelevant. `tabNumber()` returns `0` for every 0.7 id, making the sort a
- *   harmless no-op (order-preserving on ties).
- *
- * Net: correct under both; the sort is load-bearing on 0.6.10 (still deployed) and
- * inert on 0.7.
+ *   harmless no-op (order-preserving on ties). Kept pending the id-cleanup issue #714.
  */
-export function reapOrphanTabs(herdr: ReapableHerdr): string[] {
+export async function reapOrphanTabs(
+  herdr: ReapableHerdr,
+  prevShellOnly: Set<string> = new Set(),
+): Promise<ReapResult> {
+  let panes: ReturnType<ReapableHerdr["panes"]>;
+  try {
+    panes = herdr.panes();
+  } catch {
+    // herdr 0.6: no `pane` subcommand. List-absence IS the correct husk signal there.
+    return {
+      closed: reapOrphanTabsLegacy(herdr),
+      sparedLive: 0,
+      sparedError: 0,
+      shellOnly: prevShellOnly,
+    };
+  }
+
+  let sparedLive = 0;
+  let sparedError = 0;
+  const shellOnly = new Set<string>();
+  const toReap = new Set<string>(); // tabIds, deduped (helper tab is single-pane, but be defensive)
+
+  for (const p of panes) {
+    if (!isShepherdHelperLabel(p.label)) continue;
+    let procs: string[];
+    try {
+      procs = await herdr.paneForegroundProcs(p.paneId);
+    } catch {
+      sparedError++; // transient process-info failure — spare, do not fall back
+      continue;
+    }
+    if (procs.length === 0) {
+      sparedError++; // undeterminable — fail closed, never reap on no evidence
+      continue;
+    }
+    if (!procs.every((n) => SHELLS.has(n))) {
+      sparedLive++; // a non-shell proc is running — live agent
+      continue;
+    }
+    // shell-only: husk candidate this sweep
+    shellOnly.add(p.tabId);
+    if (prevShellOnly.has(p.tabId)) toReap.add(p.tabId); // debounce: shell-only twice running
+  }
+
+  const orderedReap = [...toReap].sort((a, b) => tabNumber(b) - tabNumber(a));
+  for (const tabId of orderedReap) herdr.closeTab(tabId);
+  return { closed: orderedReap, sparedLive, sparedError, shellOnly };
+}
+
+/**
+ * Legacy (herdr ≤0.6) husk signal: a helper-labeled tab absent from `agent list` is an
+ * orphan. Correct only where a finished helper actually leaves `agent list` (pre-0.7);
+ * reached via the capability fallback in {@link reapOrphanTabs} when `panes()` is absent.
+ * Returns the ids it closed, in descending tab-number order (see {@link tabNumber}).
+ */
+export function reapOrphanTabsLegacy(herdr: ReapableHerdr): string[] {
   const liveTabIds = new Set(
     herdr
       .list()

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -214,7 +214,15 @@ export function reapOrphanTabsLegacy(herdr: ReapableHerdr): string[] {
  * too — so a hex-shaped suffix could in principle alias real user work; (d)'s strict
  * hex/uuid shape plus the session-path spare (e) keep that from being reaped.
  *
- * **Three spare reasons:**
+ * **Full spare/reap coverage matrix** (an unowned candidate is reaped only if it survives
+ * every spare below):
+ *  - **pre-`inflight` begin() window** — each reviewer service's `begin()` does
+ *    `createDetached` (mints the `-review-<tag>` dir on disk) and only LATER `inflight.set`
+ *    then `recordReviewerSpawn`. In that window the dir exists, matches the tag shape, is
+ *    NOT in `protectedPaths`, has NO `reviewer_spawns` row, and hosts no live `claude` yet —
+ *    a mid-begin checkout. Covered by the **directory-age guard**: a candidate whose dir is
+ *    younger than `graceMs` (or that can't be stat'd → fail-closed) is spared. Checked
+ *    BEFORE the `scanAlive` probe so a not-yet-running spawn is held by age alone.
  *  - **owned in memory (`protectedPaths`)** — paths a reviewer service currently holds.
  *    Spared REGARDLESS of age or `/proc` liveness. This is the #631 regression guard: a
  *    re-adopted plan-gate orphan has a DEAD reviewer `claude` AND an OLD uncompleted
@@ -223,13 +231,18 @@ export function reapOrphanTabsLegacy(herdr: ReapableHerdr): string[] {
  *    `inflightWorktrees()` into this set.
  *  - **live store session (`sessionWorktreePaths`, guard e)** — any path backing a live
  *    user session is spared even if its name happens to match the tag shape.
- *  - **recent uncompleted spawn** — a `reviewer_spawns` row with `completedAt == null`
- *    whose `spawnedAt` is within `graceMs`: a spawn that may still be wiring up its
- *    worktree before the owning service records it as inflight.
+ *  - **live `claude` under the dir (`scanAlive`)** — one cheap `/proc` pass; a candidate
+ *    hosting a live `claude` is spared (`sparedLive`).
+ *  - **recent uncompleted spawn (the `graceMs` grace)** — a `reviewer_spawns` row with
+ *    `completedAt == null` whose `spawnedAt` is within `graceMs`. INVARIANT:
+ *    `recordReviewerSpawn` runs AFTER `inflight.set`, so a row NEVER precedes in-memory
+ *    tracking — the grace therefore does NOT cover the pre-`inflight` window (the age guard
+ *    does). It spares a recently-spawned reviewer whose path is not (yet/any longer) in
+ *    `inflight`, e.g. across a restart before re-adoption, or a review/critic spawn that
+ *    isn't re-adopted.
+ *  - **old + ownerless** — survives every spare above → reaped.
  *
- * Liveness for the remaining (non-owned) candidates comes from the injected
- * {@link scanClaudeAliveByWorktree} — one cheap `/proc` pass; a candidate hosting a
- * live `claude` is spared (`sparedLive`). Everything else is removed.
+ * Too-young/unstattable and live-session spares are counted under `sparedOwned`.
  *
  * Fully dependency-injected (no direct fs/proc/store calls) so it is unit-testable
  * without a real filesystem, `/proc`, or store. The real wiring into `index.ts` is a
@@ -253,8 +266,12 @@ export interface ReapWorktreesDeps {
     spawnedAt: number;
   }>;
   now: () => number;
-  /** Grace window for a recent uncompleted spawn (spare if `spawnedAt > now()-graceMs`). */
+  /** Grace window for a recent uncompleted spawn (spare if `spawnedAt > now()-graceMs`).
+   *  Also the dir-age threshold: a candidate dir younger than `graceMs` is spared. */
   graceMs: number;
+  /** Dir mtime in epoch-ms, or `null` if it can't be stat'd (→ fail-closed spare). Injected
+   *  so the function stays I/O-free + unit-testable; the caller wraps `statSync(p).mtimeMs`. */
+  dirMtime: (path: string) => number | null;
   /** Worktree removal wrapper (`worktree.remove`). */
   remove: (worktreePath: string) => void;
 }
@@ -304,6 +321,13 @@ function recentSpawnPaths(
   return recent;
 }
 
+/** A candidate too young to reap (or unstattable): spares a mid-begin checkout in the
+ *  pre-`inflight` begin() window. Fail-closed — `null` mtime (can't stat) is spared. */
+function isTooYoung(path: string, deps: ReapWorktreesDeps): boolean {
+  const mtime = deps.dirMtime(path);
+  return mtime === null || deps.now() - mtime < deps.graceMs;
+}
+
 export function reapStaleReviewWorktrees(deps: ReapWorktreesDeps): ReapWorktreesResult {
   // 1. Candidate paths: tag-shape matches under every parent, de-duped.
   const candidates = gatherReviewCandidates(deps.parents, deps.listDir);
@@ -321,7 +345,8 @@ export function reapStaleReviewWorktrees(deps: ReapWorktreesDeps): ReapWorktrees
   let sparedOwned = 0;
   let sparedLive = 0;
   for (const path of candidates) {
-    if (owned(path)) {
+    // owned → too-young (spare a mid-begin dir before the alive check) → alive → else reap.
+    if (owned(path) || isTooYoung(path, deps)) {
       sparedOwned++;
       continue;
     }

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -8,17 +8,43 @@ export type ReapableHerdr = Pick<HerdrDriver, "list" | "tabs" | "closeTab">;
  *  labels but no live agent is an orphaned husk (the probe/critic ended without its tab
  *  being closed — e.g. a shepherd restart cleared the in-memory tracking).
  *
- *  All markers are collision-proof against user sessions, whose labels are prompt-derived
- *  `[a-z0-9-]` slugs: {@link PROBE_NAME} and {@link DISTILL_LABEL} contain underscores, and the
- *  "review " / "name " prefixes contain a space — none is producible by a slug. (Reaping by a
- *  bare slug like "usage-probe" or "distill" would be unsafe — a user prompt can slug to exactly
- *  that.) The "name " prefix is the background LLM namer's transient tab (`name TASK-NN`). */
-function isShepherdHelperLabel(label: string): boolean {
+ *  **Scope filter, not a safety gate.** This function is a first-pass scope filter; the
+ *  caller's process-liveness check (a live agent in `herdr list`) is the actual safety gate.
+ *  This matters for the one exact match with no space — `"rundown"` — which IS a producible
+ *  user slug. It is safe only because `reapOrphanTabs` never reaps a tab that has a live
+ *  backing agent; a running user "rundown" session is therefore never touched.
+ *
+ *  **Collision-proof markers** (space-prefix or underscore): {@link PROBE_NAME} and
+ *  {@link DISTILL_LABEL} contain underscores; every other helper uses a space-prefixed
+ *  label (`"review "`, `"name "`, `"plan-review "`, `"pr-critic "`, `"recap "`,
+ *  `"autopilot "`) or a multi-word exact phrase (`"verify api key"`). User sessions use
+ *  prompt-derived `[a-z0-9-]` slugs — no spaces, no underscores — so none of these labels
+ *  is reachable by a slug. Exception: `"rundown"` (exact, no space) relies on the
+ *  liveness gate instead.
+ *
+ *  Helpers covered:
+ *  - `__usage_probe__`   — usage probe (PROBE_NAME)
+ *  - `__distill__`       — distiller (DISTILL_LABEL)
+ *  - `review <desig>`    — critic / code-review spawns
+ *  - `name <desig>`      — background LLM namer
+ *  - `plan-review <desig>` — plan-gate reviewer (plan-gate.ts)
+ *  - `pr-critic <repo>#<n>` — standalone PR critic (standalone-critic.ts)
+ *  - `recap <desig>`     — recap generator (recap.ts)
+ *  - `rundown`           — herd-digest rundown (herd-digest.ts) — liveness-gated
+ *  - `autopilot <id>`    — autopilot LLM (autopilot-llm.ts)
+ *  - `verify api key`    — API-key verifier (verify-key.ts) */
+export function isShepherdHelperLabel(label: string): boolean {
   return (
     label === PROBE_NAME ||
     label === DISTILL_LABEL ||
+    label === "rundown" ||
+    label === "verify api key" ||
     label.startsWith("review ") ||
-    label.startsWith("name ")
+    label.startsWith("name ") ||
+    label.startsWith("plan-review ") ||
+    label.startsWith("pr-critic ") ||
+    label.startsWith("recap ") ||
+    label.startsWith("autopilot ")
   );
 }
 

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -444,3 +444,175 @@ test("start with empty env {}: wrapped is identical to no-env case", () => {
   const post = extractPost(calls);
   expect(post).toEqual(["env", "NODE_COMPILE_CACHE=/disk/ncc", "claude", "go"]);
 });
+
+// -- panes() tests --
+
+const PANE_LIST = JSON.stringify({
+  result: {
+    type: "pane_list",
+    panes: [
+      {
+        agent_status: "unknown",
+        cwd: "/home/patrick",
+        focused: false,
+        foreground_cwd: "/home/patrick",
+        label: "plan-review TASK-368",
+        pane_id: "w65:p2",
+        revision: 0,
+        tab_id: "w65:t2",
+        terminal_id: "term_abc",
+        workspace_id: "w65",
+      },
+      {
+        agent_status: "working",
+        cwd: "/wt/agent",
+        focused: true,
+        foreground_cwd: "/wt/agent",
+        label: "some-task",
+        pane_id: "w65:p3",
+        revision: 1,
+        tab_id: "w65:t3",
+        terminal_id: "term_xyz",
+        workspace_id: "w65",
+      },
+    ],
+  },
+});
+
+const PANE_LIST_MISSING_FIELDS = JSON.stringify({
+  result: {
+    type: "pane_list",
+    panes: [
+      {
+        pane_id: "w1:p1",
+        tab_id: "w1:t1",
+        // label, cwd, agent_status intentionally absent
+      },
+    ],
+  },
+});
+
+test("panes() parses multi-pane reply into HerdrPane[] with correct field mapping", () => {
+  const d = new HerdrDriver((args) =>
+    args[0] === "pane" && args[1] === "list" ? PANE_LIST : FIXTURE,
+  );
+  const p = d.panes();
+  expect(p.length).toBe(2);
+  expect(p[0]).toMatchObject({
+    paneId: "w65:p2",
+    tabId: "w65:t2",
+    label: "plan-review TASK-368",
+    cwd: "/home/patrick",
+    agentStatus: "unknown",
+  });
+  expect(p[1]).toMatchObject({
+    paneId: "w65:p3",
+    tabId: "w65:t3",
+    label: "some-task",
+    cwd: "/wt/agent",
+    agentStatus: "working",
+  });
+});
+
+test("panes() applies defensive defaults when optional fields are absent", () => {
+  const d = new HerdrDriver((args) =>
+    args[0] === "pane" && args[1] === "list" ? PANE_LIST_MISSING_FIELDS : FIXTURE,
+  );
+  const p = d.panes();
+  expect(p.length).toBe(1);
+  expect(p[0]).toMatchObject({
+    paneId: "w1:p1",
+    tabId: "w1:t1",
+    label: "",
+    cwd: "",
+    agentStatus: "unknown",
+  });
+});
+
+test("panes() returns [] when result.panes is absent", () => {
+  const d = new HerdrDriver((args) =>
+    args[0] === "pane" && args[1] === "list" ? JSON.stringify({ result: {} }) : FIXTURE,
+  );
+  expect(d.panes()).toEqual([]);
+});
+
+// -- paneForegroundProcs() tests --
+
+const HUSK_PROC_REPLY = JSON.stringify({
+  result: {
+    process_info: {
+      foreground_process_group_id: 4005163,
+      foreground_processes: [
+        {
+          argv: ["/usr/bin/zsh"],
+          cmdline: "/usr/bin/zsh",
+          cwd: "/home/patrick",
+          name: "zsh",
+          pid: 4005163,
+        },
+      ],
+      pane_id: "w65:p3",
+      shell_pid: 4005163,
+    },
+    type: "pane_process_info",
+  },
+});
+
+const LIVE_PROC_REPLY = JSON.stringify({
+  result: {
+    process_info: {
+      foreground_process_group_id: 5001000,
+      foreground_processes: [
+        { name: "claude", pid: 5001000 },
+        { name: "npm", pid: 5001001 },
+        { name: "node-MainThread", pid: 5001002 },
+      ],
+      pane_id: "w65:p4",
+      shell_pid: 5000900,
+    },
+    type: "pane_process_info",
+  },
+});
+
+test("paneForegroundProcs() returns ['zsh'] for a husk pane", async () => {
+  const d = new HerdrDriver(
+    () => FIXTURE,
+    async (args) => {
+      expect(args).toEqual(["pane", "process-info", "--pane", "w65:p3"]);
+      return HUSK_PROC_REPLY;
+    },
+  );
+  const procs = await d.paneForegroundProcs("w65:p3");
+  expect(procs).toEqual(["zsh"]);
+});
+
+test("paneForegroundProcs() returns multi-name list for a live pane", async () => {
+  const d = new HerdrDriver(
+    () => FIXTURE,
+    async () => LIVE_PROC_REPLY,
+  );
+  const procs = await d.paneForegroundProcs("w65:p4");
+  expect(procs).toEqual(["claude", "npm", "node-MainThread"]);
+});
+
+test("paneForegroundProcs() returns [] on unparseable reply (JSON parse failure)", async () => {
+  const d = new HerdrDriver(
+    () => FIXTURE,
+    async () => "not valid json at all",
+  );
+  const procs = await d.paneForegroundProcs("w65:p2");
+  expect(procs).toEqual([]);
+});
+
+test("paneForegroundProcs() propagates a thrown runner error (does not swallow)", async () => {
+  const cliErr = new Error("herdr: unknown subcommand pane process-info");
+  const d = new HerdrDriver(
+    () => FIXTURE,
+    async () => {
+      throw cliErr;
+    },
+  );
+  await expect(d.paneForegroundProcs("w65:p2")).rejects.toThrow(
+    "herdr: unknown subcommand pane process-info",
+  );
+});

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -745,3 +745,14 @@ test("adoptOrphans resolves the reviewer terminal by worktree cwd for reaping", 
   await h.svc.tick();
   expect(stopped).toContain("rev-term-9"); // reaped the resolved live reviewer terminal
 });
+
+test("inflightWorktrees: empty before any review starts", () => {
+  const h = harness();
+  expect(h.svc.inflightWorktrees()).toEqual([]);
+});
+
+test("inflightWorktrees: returns worktree path after consider() spawns a review", async () => {
+  const h = harness();
+  await h.svc.consider(planningSession() as any);
+  expect(h.svc.inflightWorktrees()).toEqual(["/wt-detached"]);
+});

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1899,3 +1899,16 @@ test("critic spawn degrades to unwrapped when backend is null", async () => {
   const argv = started[0]!.argv;
   expect(argv[0]).not.toBe("bwrap"); // passthrough — identical to pre-sandbox behavior
 });
+
+test("inflightWorktrees: empty before any review starts", () => {
+  const { deps: d } = makeDeps({});
+  const svc = new ReviewService(d as any);
+  expect(svc.inflightWorktrees()).toEqual([]);
+});
+
+test("inflightWorktrees: returns worktree path after consider() spawns a review", async () => {
+  const { deps: d } = makeDeps({});
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  expect(svc.inflightWorktrees()).toEqual(["/review-wt"]);
+});

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -704,3 +704,16 @@ test("bwrap backend present: critic spawn is wrapped + isolated, credential mask
     expect(spies.started[0]!.env).toBeUndefined();
   });
 });
+
+test("inflightWorktrees: empty before any sweep", () => {
+  const { deps } = makeDeps();
+  const svc = new StandalonePrCriticService(deps as any);
+  expect(svc.inflightWorktrees()).toEqual([]);
+});
+
+test("inflightWorktrees: returns worktree path after sweep() spawns a critic run", async () => {
+  const { deps } = makeDeps();
+  const svc = new StandalonePrCriticService(deps as any);
+  await svc.sweep();
+  expect(svc.inflightWorktrees()).toEqual(["/review-wt"]);
+});

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -3,7 +3,9 @@ import {
   reapOrphanTabs,
   reapOrphanTabsLegacy,
   isShepherdHelperLabel,
+  reapStaleReviewWorktrees,
   type ReapableHerdr,
+  type ReapWorktreesDeps,
 } from "../src/tab-reaper";
 import { PROBE_NAME } from "../src/usage-probe";
 import { DISTILL_LABEL } from "../src/distiller";
@@ -299,4 +301,164 @@ describe("isShepherdHelperLabel", () => {
       expect(isShepherdHelperLabel(label)).toBe(false);
     });
   }
+});
+
+// ── Stranded review-worktree disk sweep (#721) ────────────────────────────────
+
+const PARENT = "/home/x/.shepherd-worktrees";
+const HEX8 = "deadbeef";
+const UUID_TAG = "643cfec7-1234-5678-9abc-def012345678-deadbeef";
+
+/** Terse fake-deps builder. By default: one parent listing `names`, nothing owned,
+ *  no live session, scanAlive→all-false, no spawns, now=1_000_000, grace=60_000. */
+function mkDeps(overrides: Partial<ReapWorktreesDeps> & { names?: string[] } = {}): {
+  deps: ReapWorktreesDeps;
+  removed: string[];
+} {
+  const removed: string[] = [];
+  const names = overrides.names ?? [];
+  const deps: ReapWorktreesDeps = {
+    parents: overrides.parents ?? [PARENT],
+    listDir: overrides.listDir ?? (() => names),
+    protectedPaths: overrides.protectedPaths ?? new Set(),
+    sessionWorktreePaths: overrides.sessionWorktreePaths ?? new Set(),
+    scanAlive: overrides.scanAlive ?? ((paths) => new Map(paths.map((p) => [p, false]))),
+    listReviewerSpawns: overrides.listReviewerSpawns ?? (() => []),
+    now: overrides.now ?? (() => 1_000_000),
+    graceMs: overrides.graceMs ?? 60_000,
+    remove: overrides.remove ?? ((p) => void removed.push(p)),
+  };
+  return { deps, removed };
+}
+
+test("stranded reap: dead, unowned, no-spawn review husk is removed", () => {
+  const name = `shepherd-review-${HEX8}`;
+  const { deps, removed } = mkDeps({ names: [name] });
+  const r = reapStaleReviewWorktrees(deps);
+  expect(r.reaped).toEqual([`${PARENT}/${name}`]);
+  expect(removed).toEqual([`${PARENT}/${name}`]);
+  expect(r.sparedOwned).toBe(0);
+  expect(r.sparedLive).toBe(0);
+});
+
+test("foreign-basename reap: a defunct-repo basename is still selected (basename-agnostic)", () => {
+  const name = `flowagent-review-${HEX8}`;
+  const { deps, removed } = mkDeps({ names: [name] });
+  const r = reapStaleReviewWorktrees(deps);
+  expect(r.reaped).toEqual([`${PARENT}/${name}`]);
+  expect(removed).toEqual([`${PARENT}/${name}`]);
+});
+
+test("uuid-tag reap: a randomUUID-sha8 tag shape is matched and removed", () => {
+  const name = `shepherd-review-${UUID_TAG}`;
+  const { deps, removed } = mkDeps({ names: [name] });
+  const r = reapStaleReviewWorktrees(deps);
+  expect(r.reaped).toEqual([`${PARENT}/${name}`]);
+  expect(removed).toEqual([`${PARENT}/${name}`]);
+});
+
+test("live-claude spare: a candidate hosting a live claude is sparedLive, not removed", () => {
+  const name = `shepherd-review-${HEX8}`;
+  const path = `${PARENT}/${name}`;
+  const { deps, removed } = mkDeps({
+    names: [name],
+    scanAlive: () => new Map([[path, true]]),
+  });
+  const r = reapStaleReviewWorktrees(deps);
+  expect(r.reaped).toEqual([]);
+  expect(removed).toEqual([]);
+  expect(r.sparedLive).toBe(1);
+  expect(r.sparedOwned).toBe(0);
+});
+
+test("protectedPaths spare regardless of age/proc (#631 orphan regression guard)", () => {
+  // A re-adopted plan-gate orphan: DEAD reviewer (scanAlive→false) AND an OLD uncompleted
+  // reviewer_spawns row — but the service still holds it in memory. MUST be spared.
+  const name = `shepherd-review-${HEX8}`;
+  const path = `${PARENT}/${name}`;
+  const { deps, removed } = mkDeps({
+    names: [name],
+    protectedPaths: new Set([path]),
+    scanAlive: () => new Map([[path, false]]),
+    listReviewerSpawns: () => [
+      { worktreePath: path, completedAt: null, spawnedAt: 0 }, // ancient, uncompleted
+    ],
+  });
+  const r = reapStaleReviewWorktrees(deps);
+  expect(r.reaped).toEqual([]);
+  expect(removed).toEqual([]);
+  expect(r.sparedOwned).toBe(1);
+  expect(r.sparedLive).toBe(0);
+});
+
+test("recent-spawn grace: within-grace uncompleted spawn spared; older-than-grace reaped", () => {
+  const name = `shepherd-review-${HEX8}`;
+  const path = `${PARENT}/${name}`;
+  // now=1_000_000, grace=60_000 → cutoff=940_000.
+  const recent = mkDeps({
+    names: [name],
+    listReviewerSpawns: () => [
+      { worktreePath: path, completedAt: null, spawnedAt: 950_000 }, // within grace
+    ],
+  });
+  const r1 = reapStaleReviewWorktrees(recent.deps);
+  expect(r1.reaped).toEqual([]);
+  expect(recent.removed).toEqual([]);
+  expect(r1.sparedOwned).toBe(1);
+
+  const stale = mkDeps({
+    names: [name],
+    listReviewerSpawns: () => [
+      { worktreePath: path, completedAt: null, spawnedAt: 900_000 }, // older than grace
+    ],
+  });
+  const r2 = reapStaleReviewWorktrees(stale.deps);
+  expect(r2.reaped).toEqual([path]);
+  expect(stale.removed).toEqual([path]);
+  expect(r2.sparedOwned).toBe(0);
+});
+
+test("session spare (guard e): a hex-tag dir backing a live session is spared", () => {
+  const name = `shepherd-review-${HEX8}`; // would match the regex
+  const path = `${PARENT}/${name}`;
+  const { deps, removed } = mkDeps({
+    names: [name],
+    sessionWorktreePaths: new Set([path]),
+  });
+  const r = reapStaleReviewWorktrees(deps);
+  expect(r.reaped).toEqual([]);
+  expect(removed).toEqual([]);
+  expect(r.sparedOwned).toBe(1);
+});
+
+test("non-tag-shape user session ignored: non-hex suffix is not a candidate", () => {
+  const name = "shepherd-review-myfeature"; // user prompt slugging to review-myfeature
+  const { deps, removed } = mkDeps({ names: [name] });
+  const r = reapStaleReviewWorktrees(deps);
+  expect(r.reaped).toEqual([]);
+  expect(removed).toEqual([]);
+  expect(r.sparedOwned).toBe(0);
+  expect(r.sparedLive).toBe(0);
+});
+
+test("non-review dir ignored: a work-issue dir is not a candidate", () => {
+  const name = "shepherd-work-issue-721";
+  const { deps, removed } = mkDeps({ names: [name] });
+  const r = reapStaleReviewWorktrees(deps);
+  expect(r.reaped).toEqual([]);
+  expect(removed).toEqual([]);
+});
+
+test("multi-parent: candidates gathered across two parents", () => {
+  const p1 = "/a/.shepherd-worktrees";
+  const p2 = "/b/.shepherd-worktrees";
+  const n1 = `shepherd-review-${HEX8}`;
+  const n2 = `tank-review-cafebabe`;
+  const { deps, removed } = mkDeps({
+    parents: [p1, p2],
+    listDir: (parent) => (parent === p1 ? [n1] : [n2]),
+  });
+  const r = reapStaleReviewWorktrees(deps);
+  expect(new Set(r.reaped)).toEqual(new Set([`${p1}/${n1}`, `${p2}/${n2}`]));
+  expect(new Set(removed)).toEqual(new Set([`${p1}/${n1}`, `${p2}/${n2}`]));
 });

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -1,8 +1,13 @@
 import { test, expect, describe } from "bun:test";
-import { reapOrphanTabs, isShepherdHelperLabel, type ReapableHerdr } from "../src/tab-reaper";
+import {
+  reapOrphanTabs,
+  reapOrphanTabsLegacy,
+  isShepherdHelperLabel,
+  type ReapableHerdr,
+} from "../src/tab-reaper";
 import { PROBE_NAME } from "../src/usage-probe";
 import { DISTILL_LABEL } from "../src/distiller";
-import type { HerdrAgent } from "../src/herdr";
+import type { HerdrAgent, HerdrPane } from "../src/herdr";
 import type { HerdrTab } from "../src/herdr";
 
 function agent(terminalId: string, tabId: string): HerdrAgent {
@@ -20,8 +25,15 @@ function agent(terminalId: string, tabId: string): HerdrAgent {
 function tab(tabId: string, label: string): HerdrTab {
   return { tabId, label, agentStatus: "unknown", workspaceId: "w" };
 }
+function pane(paneId: string, tabId: string, label: string): HerdrPane {
+  return { paneId, tabId, label, cwd: "/wt", agentStatus: "unknown" };
+}
 
-function fake(agents: HerdrAgent[], tabs: HerdrTab[]): { h: ReapableHerdr; closed: string[] } {
+/** Drives the LEGACY (list-absence) path via `list`/`tabs`. */
+function legacyFake(
+  agents: HerdrAgent[],
+  tabs: HerdrTab[],
+): { h: ReapableHerdr; closed: string[] } {
   const closed: string[] = [];
   return {
     closed,
@@ -29,12 +41,47 @@ function fake(agents: HerdrAgent[], tabs: HerdrTab[]): { h: ReapableHerdr; close
       list: () => agents,
       tabs: () => tabs,
       closeTab: (id) => void closed.push(id),
+      panes: () => [],
+      paneForegroundProcs: async () => [],
     },
   };
 }
 
-test("reaps probe + review + namer + distill tabs that have no live agent", () => {
-  const { h, closed } = fake(
+/** Drives the process-info path: `panes()` returns the given panes, and
+ *  `paneForegroundProcs(paneId)` resolves from `procMap` (a thrown value re-throws). */
+function procFake(
+  panes: HerdrPane[],
+  procMap: Record<string, string[] | Error>,
+  opts: { panesThrows?: boolean } = {},
+): { h: ReapableHerdr; closed: string[] } {
+  const closed: string[] = [];
+  return {
+    closed,
+    h: {
+      list: () => {
+        throw new Error("list unused on process-info path");
+      },
+      tabs: () => {
+        throw new Error("tabs unused on process-info path");
+      },
+      closeTab: (id) => void closed.push(id),
+      panes: () => {
+        if (opts.panesThrows) throw new Error("pane list: unknown subcommand");
+        return panes;
+      },
+      paneForegroundProcs: async (paneId) => {
+        const v = procMap[paneId];
+        if (v instanceof Error) throw v;
+        return v ?? [];
+      },
+    },
+  };
+}
+
+// ── Legacy path (list-absence) — the herdr ≤0.6 fallback ──────────────────────
+
+test("legacy: reaps probe + review + namer + distill tabs that have no live agent", () => {
+  const { h, closed } = legacyFake(
     [agent("term_live", "w:5")], // the one live agent
     [
       tab("w:1", PROBE_NAME),
@@ -44,51 +91,51 @@ test("reaps probe + review + namer + distill tabs that have no live agent", () =
       tab("w:5", "addition-leaky"), // live session tab — backed by an agent
     ],
   );
-  const got = reapOrphanTabs(h);
+  const got = reapOrphanTabsLegacy(h);
   expect(new Set(got)).toEqual(new Set(["w:1", "w:2", "w:3", "w:4"]));
   expect(new Set(closed)).toEqual(new Set(["w:1", "w:2", "w:3", "w:4"]));
 });
 
-test("never reaps a labeled tab that still has a live agent (in-progress probe/review)", () => {
-  const { h, closed } = fake(
+test("legacy: never reaps a labeled tab that still has a live agent (in-progress probe/review)", () => {
+  const { h, closed } = legacyFake(
     [agent("term_probe", "w:1")], // probe currently running in w:1
     [tab("w:1", PROBE_NAME)],
   );
-  reapOrphanTabs(h);
+  reapOrphanTabsLegacy(h);
   expect(closed).toEqual([]);
 });
 
-test("never touches non-shepherd tabs — incl. user sessions slugged 'usage-probe' / 'distill'", () => {
+test("legacy: never touches non-shepherd tabs — incl. user sessions slugged 'usage-probe' / 'distill'", () => {
   // "usage-probe" and "distill" are producible prompt slugs (normalize("usage probe") ===
   // "usage-probe"; slugifyManual("distill") === "distill"); an agentless tab with such a bare
   // slug is a real user session, NOT a helper — must never be reaped. The helpers use the
   // collision-proof __usage_probe__ / __distill__ markers instead.
-  const { h, closed } = fake(
+  const { h, closed } = legacyFake(
     [],
     [tab("w:1", "my editor"), tab("w:2", "usage-probe"), tab("w:3", "distill")],
   );
-  reapOrphanTabs(h);
+  reapOrphanTabsLegacy(h);
   expect(closed).toEqual([]);
 });
 
-test("closes highest tab-number first so herdr's renumber-on-close can't drift targets", () => {
+test("legacy: closes highest tab-number first so herdr's renumber-on-close can't drift targets", () => {
   // Documents the herdr ≤0.6 drift-safety guarantee: positional ids (workspace:N)
   // re-densify on close, so closing highest-first keeps each remaining target id valid.
   // Under herdr 0.7 stable ids (w1:tN) tabNumber() returns 0 for all ids, so the
   // descending sort is a no-op — the asserted ordering only holds under ≤0.6.
-  const { h, closed } = fake(
+  const { h, closed } = legacyFake(
     [],
     [tab("w:2", PROBE_NAME), tab("w:10", PROBE_NAME), tab("w:5", "review TASK-1")],
   );
-  reapOrphanTabs(h);
+  reapOrphanTabsLegacy(h);
   expect(closed).toEqual(["w:10", "w:5", "w:2"]);
 });
 
-test("reaps 0.7 stable-id husks (w1:tN) and never touches a live tab", () => {
+test("legacy: reaps 0.7 stable-id husks (w1:tN) and never touches a live tab", () => {
   // herdr 0.7 (#569) introduced stable short handles (w1, w1:t1, w1:p1) that don't
   // renumber on close. Two helper husks with no backing agent must be reaped; the live
   // user tab backed by an agent must never be closed.
-  const { h, closed } = fake(
+  const { h, closed } = legacyFake(
     [agent("term_live", "w1:t3")],
     [
       tab("w1:t1", PROBE_NAME), // orphaned probe husk — no backing agent
@@ -96,10 +143,122 @@ test("reaps 0.7 stable-id husks (w1:tN) and never touches a live tab", () => {
       tab("w1:t3", "my-feature"), // live user tab — backed by an agent
     ],
   );
-  const got = reapOrphanTabs(h);
+  const got = reapOrphanTabsLegacy(h);
   expect(new Set(got)).toEqual(new Set(["w1:t1", "w1:t2"]));
   expect(new Set(closed)).toEqual(new Set(["w1:t1", "w1:t2"]));
   expect(closed).not.toContain("w1:t3");
+});
+
+// ── Process-info path (herdr 0.7 husk detection) ──────────────────────────────
+
+test("debounce: shell-only husk is NOT closed on first sweep, closed on second consecutive sweep", async () => {
+  const panes = [pane("w1:p1", "w1:t1", PROBE_NAME)];
+  const procMap: Record<string, string[]> = { "w1:p1": ["zsh"] };
+
+  // Sweep 1: shell-only sighting — recorded, NOT closed.
+  const f1 = procFake(panes, procMap);
+  const r1 = await reapOrphanTabs(f1.h);
+  expect(r1.closed).toEqual([]);
+  expect(f1.closed).toEqual([]);
+  expect(r1.shellOnly).toEqual(new Set(["w1:t1"]));
+
+  // Sweep 2: still shell-only AND seen last sweep → close.
+  const f2 = procFake(panes, procMap);
+  const r2 = await reapOrphanTabs(f2.h, r1.shellOnly);
+  expect(r2.closed).toEqual(["w1:t1"]);
+  expect(f2.closed).toEqual(["w1:t1"]);
+});
+
+test("live spare: a helper pane running claude is never closed, counts as sparedLive", async () => {
+  const panes = [pane("w1:p1", "w1:t1", "review TASK-09")];
+  const procMap: Record<string, string[]> = {
+    "w1:p1": ["claude", "npm exec something", "node-MainThread"],
+  };
+
+  const f1 = procFake(panes, procMap);
+  const r1 = await reapOrphanTabs(f1.h);
+  expect(r1.closed).toEqual([]);
+  expect(r1.sparedLive).toBe(1);
+  expect(r1.sparedError).toBe(0);
+  expect(r1.shellOnly.has("w1:t1")).toBe(false);
+
+  // Even feeding the (empty) set back, still spared.
+  const f2 = procFake(panes, procMap);
+  const r2 = await reapOrphanTabs(f2.h, r1.shellOnly);
+  expect(r2.closed).toEqual([]);
+  expect(f2.closed).toEqual([]);
+  expect(r2.sparedLive).toBe(1);
+});
+
+test("process-info error spare: paneForegroundProcs throwing spares the pane (sparedError)", async () => {
+  const panes = [pane("w1:p1", "w1:t1", PROBE_NAME)];
+  const procMap: Record<string, Error> = {
+    "w1:p1": new Error("transient process-info read failure"),
+  };
+
+  // Throwing on two consecutive sweeps never closes.
+  const f1 = procFake(panes, procMap);
+  const r1 = await reapOrphanTabs(f1.h);
+  expect(r1.closed).toEqual([]);
+  expect(r1.sparedError).toBe(1);
+  expect(r1.shellOnly.has("w1:t1")).toBe(false);
+
+  const f2 = procFake(panes, procMap);
+  const r2 = await reapOrphanTabs(f2.h, r1.shellOnly);
+  expect(r2.closed).toEqual([]);
+  expect(f2.closed).toEqual([]);
+  expect(r2.sparedError).toBe(1);
+});
+
+test("empty-procs spare: undeterminable pane (procs []) is spared fail-closed (sparedError)", async () => {
+  const panes = [pane("w1:p1", "w1:t1", PROBE_NAME)];
+  const procMap: Record<string, string[]> = { "w1:p1": [] };
+
+  const f1 = procFake(panes, procMap);
+  const r1 = await reapOrphanTabs(f1.h);
+  expect(r1.closed).toEqual([]);
+  expect(r1.sparedError).toBe(1);
+  expect(r1.shellOnly.has("w1:t1")).toBe(false);
+
+  const f2 = procFake(panes, procMap);
+  const r2 = await reapOrphanTabs(f2.h, r1.shellOnly);
+  expect(r2.closed).toEqual([]);
+  expect(f2.closed).toEqual([]);
+});
+
+test("non-helper untouched: a non-helper shell-only pane is ignored across two sweeps", async () => {
+  const panes = [pane("w1:p1", "w1:t1", "my-feature")];
+  const procMap: Record<string, string[]> = { "w1:p1": ["zsh"] };
+
+  const f1 = procFake(panes, procMap);
+  const r1 = await reapOrphanTabs(f1.h);
+  expect(r1.closed).toEqual([]);
+  expect(r1.sparedLive).toBe(0);
+  expect(r1.sparedError).toBe(0);
+  expect(r1.shellOnly.has("w1:t1")).toBe(false);
+
+  const f2 = procFake(panes, procMap);
+  const r2 = await reapOrphanTabs(f2.h, r1.shellOnly);
+  expect(r2.closed).toEqual([]);
+  expect(f2.closed).toEqual([]);
+});
+
+test("capability fallback: panes() throwing falls back to legacy list-absence reaping", async () => {
+  const closed: string[] = [];
+  const h: ReapableHerdr = {
+    list: () => [agent("term_live", "w:5")],
+    tabs: () => [tab("w:1", PROBE_NAME), tab("w:5", "addition-leaky")],
+    closeTab: (id) => void closed.push(id),
+    panes: () => {
+      throw new Error("pane list: unknown subcommand"); // herdr 0.6
+    },
+    paneForegroundProcs: async () => [],
+  };
+  const r = await reapOrphanTabs(h);
+  expect(r.closed).toEqual(["w:1"]); // husk absent from list
+  expect(closed).toEqual(["w:1"]);
+  expect(r.sparedLive).toBe(0);
+  expect(r.sparedError).toBe(0);
 });
 
 describe("isShepherdHelperLabel", () => {

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { reapOrphanTabs, type ReapableHerdr } from "../src/tab-reaper";
+import { test, expect, describe } from "bun:test";
+import { reapOrphanTabs, isShepherdHelperLabel, type ReapableHerdr } from "../src/tab-reaper";
 import { PROBE_NAME } from "../src/usage-probe";
 import { DISTILL_LABEL } from "../src/distiller";
 import type { HerdrAgent } from "../src/herdr";
@@ -100,4 +100,44 @@ test("reaps 0.7 stable-id husks (w1:tN) and never touches a live tab", () => {
   expect(new Set(got)).toEqual(new Set(["w1:t1", "w1:t2"]));
   expect(new Set(closed)).toEqual(new Set(["w1:t1", "w1:t2"]));
   expect(closed).not.toContain("w1:t3");
+});
+
+describe("isShepherdHelperLabel", () => {
+  const trueLabels: [string, string][] = [
+    // pre-existing helpers
+    [PROBE_NAME, "usage probe (underscore marker)"],
+    [DISTILL_LABEL, "distiller (underscore marker)"],
+    ["review TASK-09", "critic/code-review"],
+    ["name TASK-09", "background namer"],
+    // new helpers (#721)
+    ["plan-review TASK-09", "plan-gate reviewer"],
+    ["pr-critic /home/x/repo#42", "standalone PR critic"],
+    ["recap TASK-09", "recap generator"],
+    ["rundown", "herd-digest rundown (exact, liveness-gated)"],
+    ["autopilot 643cfec7-1234-5678-abcd-ef0123456789", "autopilot LLM"],
+    ["verify api key", "API-key verifier (multi-word exact)"],
+  ];
+
+  for (const [label, desc] of trueLabels) {
+    test(`true: ${desc} — ${JSON.stringify(label)}`, () => {
+      expect(isShepherdHelperLabel(label)).toBe(true);
+    });
+  }
+
+  const falseLabels: [string, string][] = [
+    // bare slugs that look similar but are producible user slugs
+    ["plan-review-thing", "hyphen, no space — not a plan-review helper"],
+    ["my-feature", "ordinary user session slug"],
+    ["usage-probe", "slug form of PROBE_NAME — must NOT be reaped"],
+    ["distill", "slug form of DISTILL_LABEL — must NOT be reaped"],
+    ["reviewing-pr", "starts with 'review' but no trailing space"],
+    ["autopilot-mode", "hyphen instead of space — not an autopilot helper"],
+    ["name-my-thing", "hyphen instead of space — not a namer helper"],
+  ];
+
+  for (const [label, desc] of falseLabels) {
+    test(`false: ${desc} — ${JSON.stringify(label)}`, () => {
+      expect(isShepherdHelperLabel(label)).toBe(false);
+    });
+  }
 });

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -326,6 +326,8 @@ function mkDeps(overrides: Partial<ReapWorktreesDeps> & { names?: string[] } = {
     listReviewerSpawns: overrides.listReviewerSpawns ?? (() => []),
     now: overrides.now ?? (() => 1_000_000),
     graceMs: overrides.graceMs ?? 60_000,
+    // Default to epoch (very old) so age guard never fires → existing reap-tests still reap.
+    dirMtime: overrides.dirMtime ?? (() => 0),
     remove: overrides.remove ?? ((p) => void removed.push(p)),
   };
   return { deps, removed };
@@ -429,6 +431,35 @@ test("session spare (guard e): a hex-tag dir backing a live session is spared", 
   expect(r.reaped).toEqual([]);
   expect(removed).toEqual([]);
   expect(r.sparedOwned).toBe(1);
+});
+
+test("dir-age guard: a too-young (mid-begin) candidate is spared, not reaped (TOCTOU)", () => {
+  // now=1_000_000, grace=60_000 → a dir mtime'd at now-grace/2 (970_000) is < graceMs old.
+  // It matches the tag regex, is not owned, not alive, has no recent spawn row (the
+  // pre-inflight begin() window), yet must be spared by the directory-age guard.
+  const name = `shepherd-review-${HEX8}`;
+  const { deps, removed } = mkDeps({
+    names: [name],
+    dirMtime: () => 1_000_000 - 60_000 / 2, // 970_000 — younger than graceMs
+  });
+  const r = reapStaleReviewWorktrees(deps);
+  expect(r.reaped).toEqual([]);
+  expect(removed).toEqual([]);
+  expect(r.sparedOwned).toBe(1);
+  expect(r.sparedLive).toBe(0);
+});
+
+test("dir-age guard: an unstattable candidate (dirMtime null) is spared fail-closed", () => {
+  const name = `shepherd-review-${HEX8}`;
+  const { deps, removed } = mkDeps({
+    names: [name],
+    dirMtime: () => null, // can't stat → fail closed, spare
+  });
+  const r = reapStaleReviewWorktrees(deps);
+  expect(r.reaped).toEqual([]);
+  expect(removed).toEqual([]);
+  expect(r.sparedOwned).toBe(1);
+  expect(r.sparedLive).toBe(0);
 });
 
 test("non-tag-shape user session ignored: non-hex suffix is not a candidate", () => {


### PR DESCRIPTION
Closes #721.

## Problem
Under herdr **0.7**, when a short-lived helper agent (reviewer/critic/namer/probe/…) exits, herdr keeps its pane alive as an idle `zsh` shell **and still lists it** in `agent list`. The reaper's signals — list-presence and `agent_status` — can no longer tell a husk from a live agent (`agent_status` is `unknown` for both live-idle agents *and* husks). Result: ~51 husk tabs + 57 stranded `*-review-*` worktrees accumulated on the live host.

## Fix
Switch the husk signal from list-absence to **ground-truth process liveness**, and add a disk-sweep for stranded reviewer worktrees.

1. **herdr driver** (`src/herdr.ts`): `panes()` (off `pane list`) + async `paneForegroundProcs()` (off `pane process-info`, returns the pane's foreground process names — `["zsh"]` for a husk, `["claude",…]` for a live agent). `stop()` doc corrected for 0.7.
2. **Helper-label scope** (`isShepherdHelperLabel`): exhaustive audit of all 11 `herdr.start` callsites added the 6 previously-unmatched helper labels — `plan-review `, `pr-critic `, `recap `, `rundown`, `autopilot `, `verify api key` (the user work-session spawn stays excluded).
3. **`reapOrphanTabs` rewrite**: async; husk ⇔ helper-labeled pane whose foreground is **shell-only**; **fail-closed** (non-shell / empty / error → spare + count); **two-sweep debounce** (threads a `shellOnly` set; a tab is reaped only when shell-only on two consecutive sweeps — spares an agent in its brief pre-`exec` `zsh` window); **capability fallback** to the legacy list-absence logic when `pane list` is absent (herdr 0.6).
4. **`reapStaleReviewWorktrees`** (disk-sweep): reaps `.shepherd-worktrees/*-review-(<8hex>|<uuid>-<8hex>)$` dirs (basename-agnostic, so foreign-era `tank-`/`flowagent-`/`pulse-` dirs are covered) that have no live `claude`, **sparing** anything a reviewer service currently owns in-memory (`protectedPaths` — the #631 re-adopted-orphan guard, regardless of age/proc), any live store-session worktree, and any recently-spawned reviewer. Complements (does not replace) `planGate.gcStaleReviewWorktrees()`.
5. **Wiring** (`src/index.ts`): tab sweep at `@5s` + `@45s` + hourly, threading the debounce set; worktree sweep sequenced **after** `adoptOrphans → gcStaleReviewWorktrees` (so `inflight` is repopulated → #631 spare holds) + hourly. Both sweeps log a `closed/sparedLive/sparedError` (and `reaped/sparedOwned`) breakdown so an incomplete auto-clean is observable.

## Success criteria (from the approved `.shepherd-plan.md`)
- 0.7: a two-sweep shell-only helper tab is reaped; a live (incl. just-started) one never is. ✅
- All six new helper labels covered; user-session slugs and the user work session never reaped. ✅
- Stranded `*-review-*` worktrees (incl. foreign-era) reaped; live/owned/recent/session ones spared. ✅
- 0.6 fallback to list-absence (no regression). ✅
- `herdr.stop()` still closes a helper tab under 0.7; doc accurate. ✅
- Deploy auto-cleans the live herd within ~45s via the boot sweep. ✅

## Testing
- `bunx tsc --noEmit` ✓ · `bun run lint` ✓ · `bun test ./test` → 3219 pass / 0 fail ✓ · `bunx fallow audit --base origin/main --fail-on-issues` → exit 0 (no new dead code/complexity) ✓ · pre-push gate ✓.
- New/updated unit tests cover: driver parsing; all helper labels + collision negatives; the debounce (one sweep no-reap, two consecutive reap); fail-closed live/error/empty spares; capability fallback; and the worktree sweep's stranded-reap, foreign-basename reap, #631 protected-spare, recent-grace, live-claude, and user-session spares.

Server-internal plumbing, no user-facing UX. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)