### PR TITLE
fix(whatsnew): lock background scroll so the drawer doesn't scroll the page

### DIFF
--- a/ui/src/lib/components/WhatsNew.svelte
+++ b/ui/src/lib/components/WhatsNew.svelte
@@ -22,6 +22,25 @@
     window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
   const slide = { x: 440, duration: reduceMotion ? 0 : 220, opacity: 1 };
 
+  // Lock the background document scroll while the drawer is open. Without this a
+  // touch-drag near the right edge (or overscroll at the list's top/bottom)
+  // chains through to the page, so the operator scrolls the background instead of
+  // the drawer — the "two scrollbars" they see on mobile. Compensate the now-gone
+  // scrollbar with padding so desktop layout doesn't jump (mobile scrollbars are
+  // overlay/0-width, so no shift there).
+  $effect(() => {
+    const root = document.documentElement;
+    const sbw = window.innerWidth - root.clientWidth;
+    const prevOverflow = root.style.overflow;
+    const prevPadding = root.style.paddingRight;
+    root.style.overflow = "hidden";
+    if (sbw > 0) root.style.paddingRight = `${sbw}px`;
+    return () => {
+      root.style.overflow = prevOverflow;
+      root.style.paddingRight = prevPadding;
+    };
+  });
+
   function dismiss() {
     ondismiss();
     onclose();
@@ -182,6 +201,9 @@
     gap: 22px;
     flex: 1;
     overflow-y: auto;
+    /* keep the scroll inside the drawer — don't chain to the background page when
+       the list bottoms out (pairs with the document scroll-lock in the script) */
+    overscroll-behavior: contain;
   }
   .group {
     display: flex;


### PR DESCRIPTION
## Problem

Beim Scrollen im **WAS-IST-NEU**-Drawer (besonders am rechten Rand auf dem Handy) bewegte sich der **Hintergrund** statt des Drawer-Inhalts. Man sah zwei Scrollbalken nebeneinander: den großen der Seite und den kleineren des Drawers — und konnte versehentlich die Hintergrundseite verschieben.

## Ursache

Der Drawer ist ein `position: fixed` Overlay, sperrte aber nie das Scrollen des Hintergrund-Dokuments. Eine Touch-Geste am Rand (oder Overscroll am oberen/unteren Listenende) kettete an die Seite durch (scroll chaining) → der Hintergrund scrollte.

## Fix

- **Hintergrund-Scroll sperren**, solange der Drawer offen ist (`$effect` setzt `overflow: hidden` auf `<html>`, stellt beim Schließen den vorherigen Wert wieder her). Scrollbar-Breite wird per `padding-right` kompensiert, damit das Desktop-Layout nicht springt; auf Mobil (Overlay-Scrollbars, 0 px) entfällt das.
- **`overscroll-behavior: contain`** auf der Drawer-Liste, damit das Scrollen am Listenende nicht zur Seite durchkettet.

Auf dem Handy nutzt der Drawer durch `width: min(440px, 100vw)` bereits die volle Breite — der zweite (Hintergrund-)Scrollbalken verschwindet jetzt komplett.

## Test

- `bun run check` → 0 Fehler
- `bun run check:i18n` → Parität ok (keine neuen Strings)

Bugfix ohne neue User-facing-Capability → kein Feature-Catalog-Eintrag.
