### PR TITLE
fix(rundown): Herd-Rundown-Lens per ☰-Klick wieder schließbar

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -44,6 +44,7 @@
     needsYou = 0,
     ontriage,
     onrundown,
+    rundownActive = false,
     update = null,
     onupdate,
     herdrUpdate = null,
@@ -66,8 +67,10 @@
     onhalt?: () => void;
     needsYou?: number;
     ontriage?: () => void;
-    /** Called when the ☰ RUNDOWN control is clicked — selects the Rundown lens. */
+    /** Called when the ☰ RUNDOWN control is clicked — toggles the Rundown lens. */
     onrundown?: () => void;
+    /** true while the Rundown lens is the active herd view, so the ☰ button reads as on. */
+    rundownActive?: boolean;
     update?: UpdateStatus | null;
     onupdate?: () => void;
     herdrUpdate?: HerdrUpdateStatus | null;
@@ -826,10 +829,12 @@
     <button
       class="rundown-btn"
       class:compact={mobile || compactBadges}
+      class:active={rundownActive}
       type="button"
       onclick={() => onrundown?.()}
       title={m.topbar_rundown()}
       aria-label={m.topbar_rundown()}
+      aria-pressed={rundownActive}
       use:coachTarget={"herd-rundown"}
     >
       <span class="rd-glyph" aria-hidden="true">☰</span>
@@ -1079,6 +1084,13 @@
   .rundown-btn:hover {
     color: var(--color-amber);
     border-color: var(--color-amber);
+  }
+  /* Active: the Rundown lens is open. The ☰ button reads as on so re-clicking it to
+     toggle back is the obvious return path, mirroring the tally filters' active state. */
+  .rundown-btn.active {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
+    background: color-mix(in srgb, var(--color-amber) 14%, transparent);
   }
   .rundown-btn:focus-visible {
     outline: none;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -661,10 +661,16 @@
     if (mobile.current) mobileScreen = "detail";
   }
 
-  // ☰ RUNDOWN: switch the herd rail to the Rundown lens and ensure a digest is loaded
-  // (best-effort; live herd:digest pushes also keep it fresh). Clearing the status
-  // filter mirrors the lens tabs, which are mutually exclusive with it.
+  // ☰ RUNDOWN: toggle the herd rail's Rundown lens. Re-clicking while it's already
+  // open closes it back to the "all" list — the button is the only obvious return
+  // path, so it must be a toggle, not a one-way door. Opening ensures a digest is
+  // loaded (best-effort; live herd:digest pushes also keep it fresh) and clears the
+  // status filter, mirroring the lens tabs, which are mutually exclusive with it.
   function openRundown() {
+    if (herdFilter === "rundown") {
+      herdFilter = "all";
+      return;
+    }
     statusFilter = null;
     herdFilter = "rundown";
     void herdDigest.load();
@@ -1430,6 +1436,7 @@
         needsYou={blockedEntries.length}
         ontriage={() => (showTriage = true)}
         onrundown={openRundown}
+        rundownActive={herdFilter === "rundown"}
         update={store.update}
         onupdate={() => (showUpdate = true)}
         herdrUpdate={store.herdrUpdate}


### PR DESCRIPTION
## Problem

Beim Anklicken des **☰ RUNDOWN**-Icons öffnet sich die Herd-Rundown-Lens — aber ein erneuter Klick auf dasselbe Icon schließt sie **nicht** wieder. Man saß in der Rundown-Ansicht fest; das SHEPHERD-Logo ist (bewusst) kein Home-Button, also gab es keinen offensichtlichen Rückweg außer dem `ALLE`-Tab.

Ursache: Der `onrundown`-Handler setzte `herdFilter` bedingungslos auf `"rundown"` (Einbahnstraße), und der Button trug keinen Aktiv-Zustand — er las sich nie als „gerade an“.

## Fix

- **`openRundown()` ist jetzt ein Toggle:** Ist die Rundown-Lens bereits offen, schließt ein erneuter Klick sie zurück auf die `"all"`-Liste — analog zum bereits vorhandenen Toggle-Verhalten der Tally-Filter im TopBar.
- **Aktiv-Zustand am ☰-Button:** `class:active` + `aria-pressed` spiegeln `herdFilter === "rundown"`. Der Button zeigt im offenen Zustand einen Amber-Aktiv-Look (`color-mix`-Wash über `--color-amber`, gleiches Muster wie der `NEEDS YOU`-Button), damit der Rückklick als Rückweg erkennbar ist.

## Scope / Gates

- Reiner `fix`, keine neuen User-facing-Capabilities → kein Feature-Catalog-Eintrag nötig.
- Keine neuen i18n-Keys.
- `cd ui && bun run check` → 0 Errors.

Die Herd-Filter-Tabs (`ALLE … RUNDOWN`) bleiben bewusst eine Radio-Gruppe; `ALLE` ist weiterhin der Weg zurück über die Tab-Leiste.