### PR TITLE
refactor(tab-reaper): retire herdr-0.6 fallback + positional-id machinery (#714)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,11 +34,11 @@ export const PLAN_REVIEW_CYCLES_MAX = 12;
 // Single source of truth for the readiness-probe version floors (issue #623).
 // Floors are ADVISORY: a below-floor toolchain is a `warning`, never an `error`
 // — presence is the only hard gate. Seeded conservatively below the versions
-// installed today (node 24.x, bun 1.3.x, herdr 0.6.x) so a typical install isn't
+// installed today (node 24.x, bun 1.3.x, herdr 0.7.x) so a typical install isn't
 // warned on day one while a genuinely stale toolchain still flags.
 export const NODE_MIN_VERSION = "20.0.0";
 export const BUN_MIN_VERSION = "1.1.0";
-export const HERDR_MIN_VERSION = "0.6.0";
+export const HERDR_MIN_VERSION = "0.7.0";
 // TTL backing DiagnosticsService.current() — a request without ?refresh=1 reads
 // this cache. Matches the existing CountsService/backlog 60s TTL.
 export const DIAGNOSTICS_TTL_MS = 60_000;

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -3,10 +3,7 @@ import type { HerdrDriver } from "./herdr";
 import { PROBE_NAME } from "./usage-probe";
 import { DISTILL_LABEL } from "./distiller";
 
-export type ReapableHerdr = Pick<
-  HerdrDriver,
-  "list" | "tabs" | "closeTab" | "panes" | "paneForegroundProcs"
->;
+export type ReapableHerdr = Pick<HerdrDriver, "closeTab" | "panes" | "paneForegroundProcs">;
 
 /** Labels shepherd authors for its short-lived helper agents. A tab with one of these
  *  labels but no live agent is an orphaned husk (the probe/critic ended without its tab
@@ -52,18 +49,6 @@ export function isShepherdHelperLabel(label: string): boolean {
   );
 }
 
-/**
- * Parses the positional `workspace:N` index used by herdr **≤0.6**, where tab ids are
- * `"workspace:N"` with N a dense integer that re-numbers on close. Under herdr 0.7 stable
- * ids (e.g. `w1:t1`) the last `:`-segment is not numeric, so this returns `0` for every
- * tab — which is fine (see `reapOrphanTabs`). Retained until herdr 0.7 is the deployed
- * floor, at which point this helper and the `.sort()` in `reapOrphanTabs` can be removed.
- */
-function tabNumber(tabId: string): number {
-  const n = Number.parseInt(tabId.split(":").at(-1) ?? "", 10);
-  return Number.isFinite(n) ? n : 0;
-}
-
 /** Foreground process names that mean "just an idle shell" (a husk PTY). A helper pane
  *  whose foreground is *only* one of these has nothing running in it. */
 const SHELLS = new Set(["zsh", "bash", "sh", "fish", "dash"]);
@@ -94,8 +79,7 @@ export interface ReapResult {
  *
  * - **non-shell proc present** (`claude` / `node` / `node-MainThread` / …) → live → spare
  *   (`sparedLive`).
- * - **process-info throws** (transient read failure / quirk) → spare (`sparedError`). A
- *   per-pane throw is NOT a capability miss and does NOT trigger the legacy fallback.
+ * - **process-info throws** (transient read failure / quirk) → spare (`sparedError`).
  * - **empty proc list** (undeterminable) → spare fail-closed (`sparedError`); we never
  *   reap on no evidence.
  * - **shell-only** (`procs.length > 0 && procs.every(SHELLS.has)`) → husk CANDIDATE this
@@ -107,20 +91,13 @@ export interface ReapResult {
  * (its tabId was in `prevShellOnly`). A first-time shell-only sighting is recorded in the
  * returned `shellOnly` set (caller threads it back in) but not closed.
  *
- * **Capability fallback for old herdr (0.6).** If `herdr.panes()` itself throws — the
- * `pane`/`pane process-info` subcommands are absent — we fall back to
- * {@link reapOrphanTabsLegacy}, the list-absence signal, which is *correct* on 0.6 because
- * a finished helper there DOES drop out of `agent list`. Only a `panes()` throw triggers
- * the fallback; a per-pane `paneForegroundProcs` throw is `sparedError` (see above).
+ * **`panes()` throw is fail-closed.** If `herdr.panes()` itself throws it's a transient
+ * herdr read failure on a supported herdr — we reap nothing this sweep and preserve the
+ * debounce set (return `prevShellOnly` unchanged) so a candidate isn't lost mid-debounce.
+ * (A per-pane `paneForegroundProcs` throw is `sparedError`, see above.)
  *
- * Closes in descending tab-number order. The behaviour under each herdr version:
- *
- * - **herdr ≤0.6** (positional ids, e.g. `workspace:N`): ids re-densify on close, so
- *   closing highest-number-first keeps each remaining snapshotted target id valid — only
- *   already-closed, higher-numbered tabs shift. (Relevant on the legacy fallback path.)
- * - **herdr 0.7** (#569, stable ids e.g. `w1:t1`): closed ids don't retarget, so close
- *   order is irrelevant. `tabNumber()` returns `0` for every 0.7 id, making the sort a
- *   harmless no-op (order-preserving on ties). Kept pending the id-cleanup issue #714.
+ * Closed tabs are closed in arbitrary order — herdr 0.7 stable ids (#569, e.g. `w1:t1`)
+ * don't retarget on close, so close order is irrelevant.
  */
 export async function reapOrphanTabs(
   herdr: ReapableHerdr,
@@ -130,13 +107,9 @@ export async function reapOrphanTabs(
   try {
     panes = herdr.panes();
   } catch {
-    // herdr 0.6: no `pane` subcommand. List-absence IS the correct husk signal there.
-    return {
-      closed: reapOrphanTabsLegacy(herdr),
-      sparedLive: 0,
-      sparedError: 0,
-      shellOnly: prevShellOnly,
-    };
+    // Transient herdr read failure on a supported herdr — fail closed: reap nothing this
+    // sweep, preserve the debounce set.
+    return { closed: [], sparedLive: 0, sparedError: 0, shellOnly: prevShellOnly };
   }
 
   let sparedLive = 0;
@@ -166,30 +139,9 @@ export async function reapOrphanTabs(
     if (prevShellOnly.has(p.tabId)) toReap.add(p.tabId); // debounce: shell-only twice running
   }
 
-  const orderedReap = [...toReap].sort((a, b) => tabNumber(b) - tabNumber(a));
-  for (const tabId of orderedReap) herdr.closeTab(tabId);
-  return { closed: orderedReap, sparedLive, sparedError, shellOnly };
-}
-
-/**
- * Legacy (herdr ≤0.6) husk signal: a helper-labeled tab absent from `agent list` is an
- * orphan. Correct only where a finished helper actually leaves `agent list` (pre-0.7);
- * reached via the capability fallback in {@link reapOrphanTabs} when `panes()` is absent.
- * Returns the ids it closed, in descending tab-number order (see {@link tabNumber}).
- */
-export function reapOrphanTabsLegacy(herdr: ReapableHerdr): string[] {
-  const liveTabIds = new Set(
-    herdr
-      .list()
-      .map((a) => a.tabId)
-      .filter(Boolean),
-  );
-  const orphans = herdr
-    .tabs()
-    .filter((t) => isShepherdHelperLabel(t.label) && !liveTabIds.has(t.tabId))
-    .sort((a, b) => tabNumber(b.tabId) - tabNumber(a.tabId));
-  for (const t of orphans) herdr.closeTab(t.tabId);
-  return orphans.map((t) => t.tabId);
+  const closed = [...toReap];
+  for (const tabId of closed) herdr.closeTab(tabId);
+  return { closed, sparedLive, sparedError, shellOnly };
 }
 
 // ── Stranded review-worktree disk sweep (#721) ───────────────────────────────

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -21,7 +21,7 @@ function versionRunner(map: Record<string, string | Error>): DiagnosticsDeps["ru
 }
 
 const HEALTHY_VERSIONS: Record<string, string> = {
-  herdr: "herdr 0.6.10",
+  herdr: "herdr 0.7.0",
   bun: "1.3.10",
   node: "v24.14.1",
   git: "git version 2.45.0",
@@ -90,7 +90,7 @@ describe("DiagnosticsService probes", () => {
     [
       "herdr",
       "herdr",
-      "herdr 0.6.10",
+      "herdr 0.7.0",
       "herdr 0.5.0",
       "diagnostics_hint_herdr_ok",
       "diagnostics_hint_herdr_outdated",

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -1,7 +1,6 @@
 import { test, expect, describe } from "bun:test";
 import {
   reapOrphanTabs,
-  reapOrphanTabsLegacy,
   isShepherdHelperLabel,
   reapStaleReviewWorktrees,
   type ReapableHerdr,
@@ -9,44 +8,10 @@ import {
 } from "../src/tab-reaper";
 import { PROBE_NAME } from "../src/usage-probe";
 import { DISTILL_LABEL } from "../src/distiller";
-import type { HerdrAgent, HerdrPane } from "../src/herdr";
-import type { HerdrTab } from "../src/herdr";
+import type { HerdrPane } from "../src/herdr";
 
-function agent(terminalId: string, tabId: string): HerdrAgent {
-  return {
-    agent: "claude",
-    agentStatus: "working",
-    cwd: "/wt",
-    name: "x",
-    paneId: "p",
-    tabId,
-    terminalId,
-    workspaceId: "w",
-  };
-}
-function tab(tabId: string, label: string): HerdrTab {
-  return { tabId, label, agentStatus: "unknown", workspaceId: "w" };
-}
 function pane(paneId: string, tabId: string, label: string): HerdrPane {
   return { paneId, tabId, label, cwd: "/wt", agentStatus: "unknown" };
-}
-
-/** Drives the LEGACY (list-absence) path via `list`/`tabs`. */
-function legacyFake(
-  agents: HerdrAgent[],
-  tabs: HerdrTab[],
-): { h: ReapableHerdr; closed: string[] } {
-  const closed: string[] = [];
-  return {
-    closed,
-    h: {
-      list: () => agents,
-      tabs: () => tabs,
-      closeTab: (id) => void closed.push(id),
-      panes: () => [],
-      paneForegroundProcs: async () => [],
-    },
-  };
 }
 
 /** Drives the process-info path: `panes()` returns the given panes, and
@@ -60,12 +25,6 @@ function procFake(
   return {
     closed,
     h: {
-      list: () => {
-        throw new Error("list unused on process-info path");
-      },
-      tabs: () => {
-        throw new Error("tabs unused on process-info path");
-      },
       closeTab: (id) => void closed.push(id),
       panes: () => {
         if (opts.panesThrows) throw new Error("pane list: unknown subcommand");
@@ -79,77 +38,6 @@ function procFake(
     },
   };
 }
-
-// ── Legacy path (list-absence) — the herdr ≤0.6 fallback ──────────────────────
-
-test("legacy: reaps probe + review + namer + distill tabs that have no live agent", () => {
-  const { h, closed } = legacyFake(
-    [agent("term_live", "w:5")], // the one live agent
-    [
-      tab("w:1", PROBE_NAME),
-      tab("w:2", "review TASK-09"),
-      tab("w:3", "name TASK-09"), // orphaned background-namer tab
-      tab("w:4", DISTILL_LABEL), // orphaned distiller tab
-      tab("w:5", "addition-leaky"), // live session tab — backed by an agent
-    ],
-  );
-  const got = reapOrphanTabsLegacy(h);
-  expect(new Set(got)).toEqual(new Set(["w:1", "w:2", "w:3", "w:4"]));
-  expect(new Set(closed)).toEqual(new Set(["w:1", "w:2", "w:3", "w:4"]));
-});
-
-test("legacy: never reaps a labeled tab that still has a live agent (in-progress probe/review)", () => {
-  const { h, closed } = legacyFake(
-    [agent("term_probe", "w:1")], // probe currently running in w:1
-    [tab("w:1", PROBE_NAME)],
-  );
-  reapOrphanTabsLegacy(h);
-  expect(closed).toEqual([]);
-});
-
-test("legacy: never touches non-shepherd tabs — incl. user sessions slugged 'usage-probe' / 'distill'", () => {
-  // "usage-probe" and "distill" are producible prompt slugs (normalize("usage probe") ===
-  // "usage-probe"; slugifyManual("distill") === "distill"); an agentless tab with such a bare
-  // slug is a real user session, NOT a helper — must never be reaped. The helpers use the
-  // collision-proof __usage_probe__ / __distill__ markers instead.
-  const { h, closed } = legacyFake(
-    [],
-    [tab("w:1", "my editor"), tab("w:2", "usage-probe"), tab("w:3", "distill")],
-  );
-  reapOrphanTabsLegacy(h);
-  expect(closed).toEqual([]);
-});
-
-test("legacy: closes highest tab-number first so herdr's renumber-on-close can't drift targets", () => {
-  // Documents the herdr ≤0.6 drift-safety guarantee: positional ids (workspace:N)
-  // re-densify on close, so closing highest-first keeps each remaining target id valid.
-  // Under herdr 0.7 stable ids (w1:tN) tabNumber() returns 0 for all ids, so the
-  // descending sort is a no-op — the asserted ordering only holds under ≤0.6.
-  const { h, closed } = legacyFake(
-    [],
-    [tab("w:2", PROBE_NAME), tab("w:10", PROBE_NAME), tab("w:5", "review TASK-1")],
-  );
-  reapOrphanTabsLegacy(h);
-  expect(closed).toEqual(["w:10", "w:5", "w:2"]);
-});
-
-test("legacy: reaps 0.7 stable-id husks (w1:tN) and never touches a live tab", () => {
-  // herdr 0.7 (#569) introduced stable short handles (w1, w1:t1, w1:p1) that don't
-  // renumber on close. Two helper husks with no backing agent must be reaped; the live
-  // user tab backed by an agent must never be closed.
-  const { h, closed } = legacyFake(
-    [agent("term_live", "w1:t3")],
-    [
-      tab("w1:t1", PROBE_NAME), // orphaned probe husk — no backing agent
-      tab("w1:t2", "review TASK-1"), // orphaned review husk — no backing agent
-      tab("w1:t3", "my-feature"), // live user tab — backed by an agent
-    ],
-  );
-  const got = reapOrphanTabsLegacy(h);
-  expect(new Set(got)).toEqual(new Set(["w1:t1", "w1:t2"]));
-  expect(new Set(closed)).toEqual(new Set(["w1:t1", "w1:t2"]));
-  expect(closed).not.toContain("w1:t3");
-});
 
 // ── Process-info path (herdr 0.7 husk detection) ──────────────────────────────
 
@@ -245,22 +133,14 @@ test("non-helper untouched: a non-helper shell-only pane is ignored across two s
   expect(f2.closed).toEqual([]);
 });
 
-test("capability fallback: panes() throwing falls back to legacy list-absence reaping", async () => {
-  const closed: string[] = [];
-  const h: ReapableHerdr = {
-    list: () => [agent("term_live", "w:5")],
-    tabs: () => [tab("w:1", PROBE_NAME), tab("w:5", "addition-leaky")],
-    closeTab: (id) => void closed.push(id),
-    panes: () => {
-      throw new Error("pane list: unknown subcommand"); // herdr 0.6
-    },
-    paneForegroundProcs: async () => [],
-  };
-  const r = await reapOrphanTabs(h);
-  expect(r.closed).toEqual(["w:1"]); // husk absent from list
-  expect(closed).toEqual(["w:1"]);
+test("panes() throwing fails closed — reaps nothing, preserves debounce state", async () => {
+  const { h, closed } = procFake([], {}, { panesThrows: true });
+  const r = await reapOrphanTabs(h, new Set(["w1:t1"]));
+  expect(r.closed).toEqual([]);
+  expect(closed).toEqual([]);
   expect(r.sparedLive).toBe(0);
   expect(r.sparedError).toBe(0);
+  expect(r.shellOnly).toEqual(new Set(["w1:t1"])); // debounce state preserved
 });
 
 describe("isShepherdHelperLabel", () => {


### PR DESCRIPTION
Closes #714.

herdr **0.7** is now the deployed floor (stable, non-renumbering short ids `w1:t1`, #569), so the positional-id machinery in `src/tab-reaper.ts` is genuinely dead and the herdr-0.6 capability fallback can be retired.

## Context: this is post-#721
#714 was filed against the pre-#721 74-line `tab-reaper.ts`. #721 (#726) reworked husk detection to a process-info path (`panes()` + `paneForegroundProcs` + two-sweep debounce) and moved the old list-absence logic into `reapOrphanTabsLegacy()`, kept as a **live herdr-0.6 capability fallback** (reached when `panes()` throws). So `tabNumber()` had two consumers and wasn't simply deletable — retiring it required retiring 0.6 as a supported runtime. That full-retirement scope was reviewed and approved.

## Changes
- **`src/config.ts`** — `HERDR_MIN_VERSION` `0.6.0` → `0.7.0`; stale `herdr 0.6.x` comment → `0.7.x`.
  - Note: this floor isn't purely advisory — `deploy/provision.ts` uses it as the herdr install floor, so a below-floor (0.6.x) host now provisions an **auto-upgrade** to 0.7. Intended under full 0.6 retirement.
- **`src/tab-reaper.ts`** — delete `tabNumber()` and `reapOrphanTabsLegacy()`; the `panes()` `catch` now **fails closed** (reap nothing this sweep, preserve the debounce set) instead of invoking the legacy reaper; drop the descending `.sort()` (0.7 stable ids don't retarget on close → arbitrary close order is safe); doc block rewritten to drop all ≤0.6 / dual-model / descending-order wording; `ReapableHerdr` narrowed to `Pick<HerdrDriver, "closeTab" | "panes" | "paneForegroundProcs">` (`list`/`tabs` were only used by the deleted legacy path).
- **`test/tab-reaper.test.ts`** — remove the dead legacy helpers + the five `legacy:` tests; replace the capability-fallback test with a fail-closed test (`panes()` throws → reaps nothing, preserves debounce state, never calls `closeTab`). Slug-collision safety stays covered by the `isShepherdHelperLabel` block + the non-helper process-info test; 0.7 reaping by the debounce test.
- **`test/diagnostics.test.ts`** — bump the two healthy herdr fixtures `0.6.10` → `0.7.0` (the `0.5.0` below-floor fixture is unchanged).

## Verification
- `bun run lint` — pass
- `bunx tsc --noEmit` — pass
- `bun test ./test` — pass (3275 pass, 6 skip, 0 fail)

No user-facing surface (server-only internal plumbing) → no feature-catalog / i18n / glossary changes. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)