### PR TITLE
feat(hooks): measure Stop→herdr-done window (observe-only); drop SessionEnd consume (#713)

### DIFF
--- a/src/hooks-ingest.ts
+++ b/src/hooks-ingest.ts
@@ -9,8 +9,14 @@
 // activity signals; Notification(permission_prompt) feeds block detection.
 //
 // Phase 2 (#709): SessionStart is consumed to flip claude-liveness to true (fast-path
-// before the poller's liveness sweep). Stop / SessionEnd are recorded + logged only —
-// observe-only, no signal consumption this phase (deferred to #713).
+// before the poller's liveness sweep).
+//
+// Phase 2b (#713): Stop now feeds a turn-complete-window *measurement* — the poller pairs
+// it against herdr's `done` flip to record the offset between the two (flag-gated,
+// observe-only; NO status consumption — polling stays authoritative). SessionEnd remains
+// observe-only by gated decision: its `reason` proved uninformative in the spike (n=6, all
+// `other`), so consuming it would add nothing; the validator + HookEvent fields are retained
+// for ongoing observability so a future terminal reason can revive it.
 //
 // Phase 3 (#710): SubagentStart / SubagentStop maintain a per-session sub-agent roster
 // (agentId → entry; live until a matching Stop). The roster is its own state — gated only

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,9 +383,13 @@ if (config.hooksSignals && !config.hooksIngest) {
       poller.ingestNotification(id, ev.notificationType ?? "");
     } else if (ev.event === "SessionStart") {
       poller.ingestSessionStart(id);
+    } else if (ev.event === "Stop") {
+      poller.ingestStopMeasure(id, ev.receivedAt);
     }
-    // Stop + SessionEnd are observe-only this phase (deferred to #713):
-    // record() ring-buffers + logs them regardless of the sink, so they're measurable.
+    // Stop now feeds an observe-only window MEASUREMENT (no status mutation): the offset
+    // between the Stop hook and herdr's done flip (issue #713). SessionEnd stays observe-only
+    // (measured: reason always `other`, n=6, validator retained). record() ring-buffers +
+    // logs both regardless of the sink, so they remain measurable.
   });
 }
 // Phase-3 sub-agent fan-out push (issue #710): every roster mutation pushes the session's

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -28,6 +28,10 @@ const STALL_SIG = "stall"; // fixed signature → a stall fires once per episode
  */
 const BLOCK_NOTIFICATION_TYPES = new Set(["permission_prompt"]);
 
+/** Pairing horizon for the observe-only Stop↔herdr-done window (issue #713): a Stop and a
+ *  done-flip more than this apart are treated as unrelated turns and never paired. */
+const STOP_WINDOW_MAX_MS = 30_000;
+
 /** Both transcript-derived signals from a single read; the unified probe's result. */
 type TranscriptSignals = { snapshot: ActivitySnapshot | null; activity: SessionActivity | null };
 
@@ -163,6 +167,16 @@ export class StatusPoller {
    *  herdr's latchy `blocked` status. */
   private hookAwaitingInput = new Set<string>();
 
+  /** Observe-only Stop↔herdr-done pairing markers (issue #713), flag-gated, NO behaviour
+   *  change. They measure the offset between a Claude Code `Stop` hook and herdr's `done`
+   *  flip per turn; polling stays authoritative. The two sides of the same pairing:
+   *  `pendingStopAt` holds a Stop seen before its done-flip (stop-wins side); `pendingDoneAt`
+   *  holds a done-flip seen before its Stop (herdr-wins side). Whichever arrives first parks
+   *  here; the other side pairs it (emitting the signed window) or it expires unpaired. Both
+   *  are reaped on gone/prune and inert when `config.hooksSignals` is off. */
+  private pendingStopAt = new Map<string, number>();
+  private pendingDoneAt = new Map<string, number>();
+
   /** Timestamp of the last claude-liveness sweep (0 = never). */
   private lastLivenessSweepAt = 0;
   /** Last-swept per-session claude liveness; onChange fires on flips only. */
@@ -221,6 +235,18 @@ export class StatusPoller {
      * ingest module isn't wired, e.g. in tests / flag off).
      */
     private pruneHooks?: (activeIds: Set<string>) => void,
+    /**
+     * Observe-only Stop↔herdr-done window emitter (issue #713), flag-gated. Called once per
+     * resolved pairing with the SIGNED offset between a `Stop` hook and herdr's `done` flip:
+     * `windowMs > 0` ⇒ Stop arrived first (stop-wins); `windowMs <= 0` ⇒ herdr flipped first
+     * (herdr-wins); `windowMs === null` ⇒ a done-flip never paired (no Stop within the
+     * horizon). Pure measurement — never mutates status/routing. Defaults to a single
+     * greppable `[hooks]` log line; tests inject a capturer.
+     */
+    private onStopWindow: (id: string, windowMs: number | null) => void = (id, windowMs) => {
+      const kind = windowMs === null ? "no-stop" : windowMs > 0 ? "stop-wins" : "herdr-wins";
+      console.log(`[hooks] stop-window session=${id} windowMs=${windowMs ?? "null"} case=${kind}`);
+    },
   ) {
     // Merge supplied overrides with real defaults. When preview is omitted entirely
     // we create a no-op wiring so tick() never throws on undefined access.
@@ -272,6 +298,9 @@ export class StatusPoller {
       else this.reconcileAgent(s, agent);
     }
     this.pruneInactive(activeIds);
+    // Observe-only Stop↔herdr-done window (issue #713): expire markers that never paired
+    // within the horizon (no-stop emit / silent stale-Stop drop). Gated; no behaviour change.
+    if (config.hooksSignals) this.expireStaleStopWindows();
     // preview sweep: throttled + re-entrancy guarded; fire-and-forget (never blocks tick)
     this.maybeRunPreviewSweep(sessions);
     // claude-liveness sweep: throttled; synchronous (one cheap /proc pass)
@@ -331,6 +360,10 @@ export class StatusPoller {
   private reapGone(s: Session): void {
     if (this.workingWhileBlocked.delete(s.id)) this.onWorkingBlocked(s.id, false);
     this.clearBlock(s.id);
+    // Observe-only Stop↔herdr-done markers (issue #713): the agent's gone — drop both
+    // without an emit (a reap is not a measurable done-flip pairing).
+    this.pendingStopAt.delete(s.id);
+    this.pendingDoneAt.delete(s.id);
     if (s.status !== "done") {
       this.store.update(s.id, { status: "done", lastState: "done" });
       this.onChange(s.id, "done");
@@ -350,6 +383,13 @@ export class StatusPoller {
       this.onChange(s.id, status); // nudge clients to re-attach the PTY to the fresh terminal
     }
     if (idChanged) s = { ...s, herdrAgentId: agent.terminalId };
+    // Observe-only Stop↔herdr-done measurement (issue #713): on the done-EDGE (status flips
+    // to done; `s.status` holds the PRIOR value) record/pair the window. Placed BEFORE the
+    // tryHookAwaitingBlock early-return below so a stale `hookAwaitingInput` short-circuit
+    // can never swallow the measurement. Pure measurement — does not alter status/routing.
+    if (config.hooksSignals && status === "done" && s.status !== "done") {
+      this.measureStopWindow(s.id, this.now());
+    }
     this.dropReadyToMergeIfActionable(s, status);
     // Left herdr-blocked (running/idle/done alike) → the working-while-blocked
     // display flag must drop in the SAME tick, not via the throttled probe paths.
@@ -431,6 +471,8 @@ export class StatusPoller {
       ...this.lastHookActivityAt.keys(),
       ...this.hookTicks.keys(),
       ...this.hookAwaitingInput,
+      ...this.pendingStopAt.keys(),
+      ...this.pendingDoneAt.keys(),
     ]);
     for (const id of tracked) {
       if (!activeIds.has(id)) {
@@ -453,6 +495,9 @@ export class StatusPoller {
         this.lastHookActivityAt.delete(id);
         this.hookTicks.delete(id);
         this.hookAwaitingInput.delete(id);
+        // Observe-only Stop↔herdr-done markers (issue #713)
+        this.pendingStopAt.delete(id);
+        this.pendingDoneAt.delete(id);
       }
     }
     // Phase-1 (issue #704): drop the HookIngest ring buffers for dead sessions too
@@ -542,6 +587,72 @@ export class StatusPoller {
     if (this.lastClaudeAlive.get(id) !== true) {
       this.lastClaudeAlive.set(id, true);
       this.livenessWiring.onChange(id, true);
+    }
+  }
+
+  /**
+   * Observe-only Stop measurement (issue #713), fed by HookIngest.onSignal for `Stop`
+   * events. Records the Stop's receive time as one half of the Stop↔herdr-done pairing.
+   * If a done-flip is already pending within the horizon, herdr won this turn's race —
+   * emit the (≤0) window immediately and clear the pending done. Otherwise park the Stop
+   * so the next done-flip in `measureStopWindow` can pair it (a stale prior pending stop
+   * is silently overwritten — Stop is a per-turn edge, only the latest matters).
+   *
+   * Pure measurement: never touches status, routing, or any block/activity state — polling
+   * stays authoritative. No-op when `config.hooksSignals` is off.
+   */
+  ingestStopMeasure(id: string, stopAt: number): void {
+    if (!config.hooksSignals) return;
+    const d = this.pendingDoneAt.get(id);
+    if (d !== undefined && stopAt - d <= STOP_WINDOW_MAX_MS) {
+      // herdr-wins: the done-flip preceded this Stop (window ≤ 0).
+      this.onStopWindow(id, d - stopAt);
+      this.pendingDoneAt.delete(id);
+    } else {
+      this.pendingStopAt.set(id, stopAt);
+    }
+  }
+
+  /**
+   * Observe-only done-edge half of the Stop↔herdr-done pairing (issue #713), called from
+   * `reconcileAgent` on a done-flip. If a Stop is already pending within the horizon, Stop
+   * won this turn's race — emit the (≥0) window and clear it. Otherwise park the done as
+   * pending so a later `ingestStopMeasure` can pair it; if a prior pending done is being
+   * superseded (it never paired) emit a `null` for it first, then record this one.
+   *
+   * Pure measurement: never touches status, onChange, or routing — emit + marker
+   * bookkeeping only.
+   */
+  private measureStopWindow(id: string, doneAt: number): void {
+    const st = this.pendingStopAt.get(id);
+    if (st !== undefined && doneAt - st <= STOP_WINDOW_MAX_MS) {
+      // stop-wins: the Stop preceded this done-flip (window ≥ 0).
+      this.onStopWindow(id, doneAt - st);
+      this.pendingStopAt.delete(id);
+    } else {
+      // No pairable Stop. A prior pending done is being superseded by this fresh one and
+      // never paired → emit null for it before overwriting.
+      if (this.pendingDoneAt.has(id)) this.onStopWindow(id, null);
+      this.pendingDoneAt.set(id, doneAt);
+    }
+  }
+
+  /**
+   * Per-tick expiry sweep for the observe-only Stop↔done markers (issue #713). A pending
+   * done that aged past the horizon never paired with a Stop → emit `null` (no-stop) and
+   * drop it. A pending Stop that aged out is dropped SILENTLY — a Stop with no done-flip is
+   * not a done-flip and emits nothing. Inert when `config.hooksSignals` is off (callers gate).
+   */
+  private expireStaleStopWindows(): void {
+    const now = this.now();
+    for (const [id, doneAt] of this.pendingDoneAt) {
+      if (now - doneAt > STOP_WINDOW_MAX_MS) {
+        this.onStopWindow(id, null);
+        this.pendingDoneAt.delete(id);
+      }
+    }
+    for (const [id, stopAt] of this.pendingStopAt) {
+      if (now - stopAt > STOP_WINDOW_MAX_MS) this.pendingStopAt.delete(id);
     }
   }
 

--- a/test/poller-stop-window.test.ts
+++ b/test/poller-stop-window.test.ts
@@ -1,0 +1,255 @@
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { StatusPoller } from "../src/poller";
+import type { HerdrAgent } from "../src/herdr";
+import { classifyBlocked } from "../src/blocked";
+import { config } from "../src/config";
+
+// Observe-only Stop↔herdr-done window measurement (issue #713). Polling stays authoritative;
+// these tests assert the SIGNED window emission + marker bookkeeping only, never any routing
+// change. `config.hooksSignals` gates the whole feature — save/restore it per-test so the
+// flag never leaks across the suite.
+
+const baseSession = {
+  name: "x",
+  prompt: "x",
+  repoPath: "/r",
+  baseBranch: "main",
+  branch: "shepherd/x",
+  worktreePath: "/wt",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "term_a",
+};
+
+/** A swappable-status herdr agent + an injected clock; captures every onStopWindow call and
+ *  the status onChange edges. The transcript probe returns null (interim path) so a done-flip
+ *  routes through `clearBlock`, never a stall. */
+function stopHarness() {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const windows: Array<{ id: string; windowMs: number | null }> = [];
+  const changes: Array<{ id: string; status: string }> = [];
+  let agentStatus = "working";
+  let clock = 1_700_000_000_000;
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      } as HerdrAgent,
+    ],
+    read: () => "",
+    readAsync: () => Promise.resolve(""),
+  };
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    (id, status) => changes.push({ id, status }),
+    () => {},
+    1000, // intervalMs
+    3000, // reclassifyMs
+    classifyBlocked,
+    () => clock, // now (controllable)
+    () => ({ snapshot: null, activity: null }), // probe
+    { stallMs: 1, pendingStallMs: 1 }, // stallCfg
+    7000, // probeCheckMs
+    () => {}, // onReady
+    () => {}, // onActivity
+    undefined, // preview
+    undefined, // liveness
+    () => {}, // onWorkingBlocked
+    () => {}, // pruneHooks
+    (id, windowMs) => windows.push({ id, windowMs }), // onStopWindow
+  );
+  return {
+    poller,
+    store,
+    windows,
+    changes,
+    id: s.id,
+    setStatus: (st: string) => (agentStatus = st),
+    setClock: (ms: number) => (clock = ms),
+    advance: (ms: number) => (clock += ms),
+    now: () => clock,
+  };
+}
+
+test("stop-window: inert when config.hooksSignals is off", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = false;
+  try {
+    const h = stopHarness();
+    h.poller.ingestStopMeasure(h.id, h.now());
+    h.setStatus("done");
+    h.poller.tick();
+    expect(h.windows).toHaveLength(0);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("stop-window: stop-wins emits a positive window on the done-flip", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = stopHarness();
+    const t1 = h.now();
+    h.poller.ingestStopMeasure(h.id, t1);
+    h.advance(2000); // t2 within window
+    const t2 = h.now();
+    h.setStatus("done");
+    h.poller.tick();
+    expect(h.windows).toEqual([{ id: h.id, windowMs: t2 - t1 }]);
+    expect(t2 - t1).toBeGreaterThan(0);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("stop-window: herdr-wins emits a negative window when Stop arrives after the done-flip", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = stopHarness();
+    const t1 = h.now();
+    h.setStatus("done"); // done flip, no pending stop → parks pendingDone, no emit yet
+    h.poller.tick();
+    expect(h.windows).toHaveLength(0);
+
+    h.advance(1500); // t2 within window
+    const t2 = h.now();
+    h.poller.ingestStopMeasure(h.id, t2);
+    expect(h.windows).toEqual([{ id: h.id, windowMs: t1 - t2 }]);
+    expect(t1 - t2).toBeLessThan(0);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("stop-window: no-stop null emitted on expiry when a done-flip never pairs", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = stopHarness();
+    h.setStatus("done"); // done flip, no stop → pendingDone parked
+    h.poller.tick();
+    expect(h.windows).toHaveLength(0);
+
+    h.advance(31_000); // past the 30s horizon
+    h.poller.tick(); // expiry sweep fires the null
+    expect(h.windows).toEqual([{ id: h.id, windowMs: null }]);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("stop-window: a stale Stop with no done-flip is dropped silently (no emit)", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = stopHarness();
+    h.poller.ingestStopMeasure(h.id, h.now());
+    // never flips to done; advance past the horizon and tick the expiry sweep
+    h.advance(31_000);
+    h.poller.tick();
+    expect(h.windows).toHaveLength(0); // a Stop with no done-flip is not a done-flip
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("stop-window: a superseded prior done emits null when overwritten by a fresh done", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = stopHarness();
+    h.setStatus("done"); // done flip #1 at t1 (no stop → pendingDone parked)
+    h.poller.tick();
+    expect(h.windows).toHaveLength(0);
+
+    // leave done so a later done flip is a fresh EDGE
+    h.advance(1000);
+    h.setStatus("working");
+    h.poller.tick();
+
+    // done flip #2 within the horizon, still no stop → supersedes the parked t1 done
+    h.advance(1000);
+    h.setStatus("done");
+    h.poller.tick();
+    expect(h.windows).toEqual([{ id: h.id, windowMs: null }]); // the superseded t1 done
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("stop-window: a Stop arriving past the horizon after a parked done parks instead of pairing", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = stopHarness();
+    // done flip parks pendingDoneAt at t1 (no stop yet); same-tick expiry can't clear it (age 0)
+    h.setStatus("done");
+    h.poller.tick();
+    expect(h.windows).toHaveLength(0);
+
+    // a Stop arrives MORE than the horizon later — but no tick ran, so the parked done survives.
+    // ingestStopMeasure's out-of-horizon branch must park the Stop, NOT pair it (no herdr-wins emit).
+    h.advance(31_000);
+    h.poller.ingestStopMeasure(h.id, h.now());
+    expect(h.windows).toHaveLength(0);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("stop-window: a stale hookAwaitingInput marker does not swallow the measurement", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = stopHarness();
+    // arm the awaiting-input marker (would short-circuit reconcileAgent at tryHookAwaitingBlock)
+    h.poller.ingestNotification(h.id, "permission_prompt");
+    const t1 = h.now();
+    h.poller.ingestStopMeasure(h.id, t1);
+
+    h.advance(2000);
+    const t2 = h.now();
+    h.setStatus("done");
+    h.poller.tick();
+    // the measurement still fires — emit is structurally before reconcileAgent's tryHookAwaitingBlock early-return
+    expect(h.windows).toEqual([{ id: h.id, windowMs: t2 - t1 }]);
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("stop-window: measurement is observe-only — status still flips and onChange fires once", () => {
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    const h = stopHarness();
+    h.poller.tick(); // prime: working → onChange(running)
+    const beforeDone = h.changes.length;
+
+    const t1 = h.now();
+    h.poller.ingestStopMeasure(h.id, t1);
+    h.advance(2000);
+    const t2 = h.now();
+    h.setStatus("done");
+    h.poller.tick();
+
+    expect(h.windows).toEqual([{ id: h.id, windowMs: t2 - t1 }]); // stop-wins
+    expect(h.store.get(h.id)?.status).toBe("done"); // routing untouched
+    const doneEdges = h.changes.slice(beforeDone).filter((c) => c.status === "done");
+    expect(doneEdges).toEqual([{ id: h.id, status: "done" }]); // exactly one done edge
+  } finally {
+    config.hooksSignals = orig;
+  }
+});


### PR DESCRIPTION
Refs #713 (does **not** close it — see "Issue tracking" below). Follow-up to #709/#710. Server-only, additive, flag-gated (`SHEPHERD_HOOKS_SIGNALS`), fail-open, **observe-only**.

## What this does
Lands the data the deferred Stop-consumption decision needs, and records the SessionEnd-drop decision. Two halves:

### Stop → measured, not consumed
The #709 plan deferred consuming `Stop` until its latency win over herdr's `done`-flip was **measured** ("wire only if the window is non-trivial"). The window is **not extractable from existing logs** (no timestamps, no status-change logging). So this PR adds **two-sided, observe-only** instrumentation that pairs each `Stop` hook with the herdr-`done` flip and emits a signed window per turn:

- `case=stop-wins` (`windowMs > 0`): Stop preceded herdr-`done` — the latency to harvest.
- `case=herdr-wins` (`windowMs <= 0`): herdr-`done` preceded Stop — argues *against* consumption.
- `case=no-stop` (`windowMs=null`): a `done` flip with no Stop within the 30s horizon — a real hook-coverage gap (e.g. autonomous/sandbox sessions).

Pairing is in-process (poller maps `pendingStopAt`/`pendingDoneAt`, `STOP_WINDOW_MAX_MS=30_000`, per-tick expiry sweep). The done-edge emit is placed **before** the `tryHookAwaitingBlock` early-return so a stale awaiting-input marker can't swallow it. **No status/`onChange`/routing change** — polling stays authoritative.

### SessionEnd → dropped (gated, not permanent)
Live prod data (n=6) shows `SessionEnd.reason` is **always `other`** — no `clear`/`logout`/`prompt_input_exit` ever. With only the catch-all reason observed there's no confirmed-terminal reason to gate teardown on (the exact spurious-flip risk #713 named), and `reapGone`/liveness-sweep already cover real exits within ~1 tick while recap debounces on settled-idle. So SessionEnd stays **observe-only**. The sample is small and a future terminal reason could appear, so the `SessionEnd` validator + `[hooks]` log fields are **retained** for ongoing observability — the drop is revivable.

## How to read the measurement (caveats — important)
- **`doneAt` is poll-quantized** (the poller *observes* herdr-`done` up to ~1 poll interval late; `stopAt` is instant). This biases `windowMs` upward, so positive magnitudes are an **upper bound**, and — more seriously — the **sign is unreliable within ±~one poll interval**: a true herdr-win with a sub-interval lead can be misclassified as a stop-win. Trust `stop-wins` vs `herdr-wins` only when `|windowMs|` comfortably exceeds the poll interval.
- **Subpopulation:** the window covers **herdr-`done`-ending turns only** — it excludes `idle`/`unknown`-ending turns (live snapshot `unknown ≫ done`) and `reapGone` process-exit turns. The future *consumption* would assert `done` on **every** `Stop`, so the measured subset may not represent the consumption population.

## Trade-off tension (stated plainly)
This is a real bet, not free. The quantization + subpopulation analysis above predicts the consumption gate **may well fail** (much of any apparent stop-win is poll-quantization, and the measured subset under-represents the consumption population). If it does, the in-process pairing scaffolding — chosen over a lighter offline-log-correlation alternative because it de-risks the follow-up consumption PR *if it passes* — is stranded (reverted or left dormant). We accept that risk for the de-risking upside; recording it here so the choice is auditable.

## Issue tracking
This PR ships **only the measurement + the SessionEnd-drop decision** — it does **not** consume Stop, so it **does not close #713**. #713 stays open as the single tracker for the remaining Stop turn-complete *consumption*, gated on the offline window summary. No duplicate follow-up issue is created. A summary comment on #713 records the SessionEnd decision + the consumption design to apply when the gate passes.

## Changes
- `src/poller.ts` — `STOP_WINDOW_MAX_MS`, `pendingStopAt`/`pendingDoneAt` maps, optional injected `onStopWindow` (default `[hooks] stop-window …` log), `ingestStopMeasure`, `measureStopWindow` (done-edge, pre-early-return), `expireStaleStopWindows` per-tick sweep, marker cleanup in `reapGone` + `pruneInactive`.
- `src/index.ts` — Stop sink branch → `ingestStopMeasure`; observe-only comment updated.
- `src/hooks-ingest.ts` — comment-only header refresh; `SessionEnd` validator + fields unchanged.
- `test/poller-stop-window.test.ts` — 9 tests (inert-when-off, stop-wins, herdr-wins, no-stop expiry null, stale-Stop silent drop, superseded-done null, out-of-horizon park, stale-awaiting-input non-swallow, observe-only routing intact).

## Verification
`bunx tsc --noEmit`, `bun run lint`, `bun test ./test` (3289 pass / 6 skip / 0 fail), branch-hygiene + fallow delta audit all green. Server-only, no `ui/src/**` → i18n + feature-catalog gates N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)