### PR TITLE
feat(installer): shepherd.run vanity install redirect via Vercel (Phase 1)

### DIFF
--- a/deploy/vanity/README.md
+++ b/deploy/vanity/README.md
@@ -1,0 +1,66 @@
+# `shepherd.run` vanity installer redirect (Vercel)
+
+This directory is **ops tooling**, not user-facing app UI — it is intentionally
+**not** internationalized and carries no feature-catalog entry.
+
+## Purpose
+
+Serve a short, memorable install command. `shepherd.run/install.sh` issues a
+**302 redirect** to the canonical raw-GitHub copy of `deploy/install.sh` on
+`main`:
+
+```
+shepherd.run/install.sh
+  → 302 →
+https://raw.githubusercontent.com/erwins-enkel/shepherd/main/deploy/install.sh
+```
+
+The **repo stays the single source of truth** — the redirect target is the same
+in-repo script the README already advertises. Nothing is built or copied; Vercel
+only re-points the request.
+
+`shepherd.run/` (the bare root) likewise 302-redirects to the GitHub repo.
+
+## Why a 302 (temporary), not 301/308
+
+The redirect is deliberately **temporary** so the destination can be re-pointed
+later (e.g. a CDN, or a pinned release tag instead of `main`) without fighting
+permanently-cached 301/308 redirects sitting in browsers and proxies. The
+destination currently tracks `main`.
+
+## Vercel setup (ordered)
+
+1. In Vercel, **create a new project** from this repository.
+2. Set **Root Directory = `deploy/vanity`** (this project is just the
+   `vercel.json` in this directory).
+3. **Framework Preset = "Other"**, with **no build command** and **no output
+   directory** — it is redirect-only, there is nothing to build.
+4. **Deploy.**
+5. Add the custom domain **`shepherd.run`** in
+   **Project → Settings → Domains**.
+6. At the domain registrar, set the **DNS records Vercel prescribes** for
+   `shepherd.run` (the apex/`A`/`CNAME` records shown in the Domains panel).
+
+## Verification
+
+Once DNS has propagated and the domain is attached:
+
+```bash
+curl -fsSL https://shepherd.run/install.sh | head
+```
+
+This should print the `deploy/install.sh` bash header
+(`#!/usr/bin/env bash` … "Shepherd cold-start bootstrap").
+
+**This curl check proves the command _works_, NOT that we own the domain.** A
+third party who registered a _misspelled-but-resolving_ lookalike domain could
+produce a working redirect and a false-green here. Ownership of `shepherd.run`
+rests on the operator's registrar fact (the registered-domain answer), not on
+this resolving.
+
+## Phase 2 gate (deferred — separate PR)
+
+The advertised install command in **`README.md`** and the header comment in
+**`deploy/install.sh`** currently point at the canonical raw-GitHub URL and
+**MUST NOT** be swapped to the `shepherd.run` URL until the verification above
+passes. That cutover is a **separate, deferred PR (Phase 2)**.

--- a/deploy/vanity/README.md
+++ b/deploy/vanity/README.md
@@ -58,6 +58,11 @@ produce a working redirect and a false-green here. Ownership of `shepherd.run`
 rests on the operator's registrar fact (the registered-domain answer), not on
 this resolving.
 
+> **Confirmed spelling: `shepherd.run`** (s-h-e-p-h-e-r-d, `.run` TLD). An earlier
+> reference to `shepard.run` was a typo; the registrant confirmed the registered,
+> paid-for domain is `shepherd.run`. Before cutover, re-check that the domain
+> attached in Vercel matches the registrar exactly — character for character.
+
 ## Phase 2 gate (deferred — separate PR)
 
 The advertised install command in **`README.md`** and the header comment in

--- a/deploy/vanity/vercel.json
+++ b/deploy/vanity/vercel.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "redirects": [
+    {
+      "source": "/install.sh",
+      "destination": "https://raw.githubusercontent.com/erwins-enkel/shepherd/main/deploy/install.sh",
+      "statusCode": 302
+    },
+    {
+      "source": "/",
+      "destination": "https://github.com/erwins-enkel/shepherd",
+      "statusCode": 302
+    }
+  ]
+}

--- a/docs/research/shepherd-installer.md
+++ b/docs/research/shepherd-installer.md
@@ -250,8 +250,15 @@ raw GitHub URL on day one, no domain required:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erwins-enkel/shepherd/main/deploy/install.sh | bash
-# later, optionally, a vanity:  curl -fsSL https://shepherd.dev/install.sh | bash
+# later, optionally, a vanity (illustrative `shepherd.dev` superseded by the
+# now-registered `shepherd.run`):  curl -fsSL https://shepherd.run/install.sh | bash
 ```
+
+> **Update (hosting resolved):** the vanity domain is now **`shepherd.run`**
+> (registered), served via a **Vercel 302 redirect → the raw-GitHub
+> `deploy/install.sh` on `main`** (repo stays the single source of truth). See
+> `deploy/vanity/`. The advertised command above stays on the raw-GitHub URL
+> until DNS cutover is verified (a deferred phase).
 
 Piping through `| bash` adds three mechanics worth designing for explicitly:
 
@@ -368,8 +375,11 @@ inventing a parallel one.
 1. **Scope of v1** — ship only Surface B (in-app Fix, finishing setup for users who already cloned),
    or also Surface A (`curl|bash` cold-start) for the OSS launch? _(Recommend B first — small,
    reuses the on-screen surface; A next as the launch lever.)_
-2. **`install.sh` hosting** — committed in-repo and run via raw GitHub URL, or a vanity
-   `shepherd.dev/install.sh`? (The latter matches herdr/bun/claude but needs a domain.)
+2. **`install.sh` hosting** — _resolved._ Committed in-repo (single source of truth) and reachable
+   via the registered vanity **`shepherd.run`**, served by a **Vercel 302 redirect → the raw-GitHub
+   `deploy/install.sh` on `main`** (`deploy/vanity/`). The illustrative `shepherd.dev` above is
+   superseded by `shepherd.run`. Matches the herdr/bun/claude vanity pattern; the README/`install.sh`
+   command swaps to the vanity only after the redirect is verified (deferred).
 3. **OS scope of v1** (see §5) — Linux-only (the only fully-featured, harness-proven target), or
    also a labeled core-only macOS path? Recommendation in §5 is Linux-first + refuse/degrade
    elsewhere; this question is whether that's acceptable for launch.


### PR DESCRIPTION
## What

Phase 1 of wiring the registered vanity domain **`shepherd.run`** into the installer. Adds the Vercel redirect config + an operator runbook so `shepherd.run/install.sh` can 302-redirect to the canonical raw-GitHub `deploy/install.sh`. References **#725** item 3 ("Vanity install URL"). [no-feature-entry]

Infra only — **the advertised install command is intentionally unchanged** (still the raw GitHub URL). Swapping it to the vanity URL is a deferred Phase 2 PR, gated on the domain verifiably resolving (see runbook).

## Changes
- **`deploy/vanity/vercel.json`** (new) — redirect-only project (no build). `302`: `/install.sh` → `raw.githubusercontent.com/erwins-enkel/shepherd/main/deploy/install.sh`; `/` → the repo. Destination is byte-identical to `README.md:94`. Spelling-independent: the domain string is **not** in this file (set in the Vercel dashboard).
- **`deploy/vanity/README.md`** (new) — operator runbook: Vercel project (Root Directory `deploy/vanity`, framework "Other", no build), add custom domain `shepherd.run`, DNS records, `curl … | head` verification, and the explicit caveat that the curl check proves the command *works*, **not** that we *own* the domain (false-green risk for a lookalike domain).
- **`docs/research/shepherd-installer.md`** — records `shepherd.run` (Vercel 302→raw GitHub) as the resolved hosting decision; the old illustrative `shepherd.dev` is annotated as superseded.

## Why 302
Temporary (not 301/308) so the redirect target can be re-pointed later (CDN / pinned tag) without fighting permanently-cached redirects. Destination tracks `main`, keeping the repo the single source of truth.

## Operator action required for go-live
This PR does **not** make `shepherd.run/install.sh` live. Per the runbook, the operator must connect the Vercel project + DNS, then verify with `curl -fsSL https://shepherd.run/install.sh | head`. Only after that does Phase 2 (the advertised-command swap) ship.

## Out of scope / unaffected
- `README.md:94` / `deploy/install.sh:4` advertised command — unchanged (Phase 2).
- Onboarding `install-e2e` gate — uses a local `SHEPHERD_SRC` tarball, never the URL; unaffected.
- No `ui/**`, message catalogs, or feature-announcement catalog touched (no user-facing UX ships).

## Verification
- `vercel.json` valid JSON; `statusCode: 302` confirmed against current Vercel docs.
- Root `bun run lint` clean; branch-hygiene gate green (linear off `main`).
- Spec-compliance + code-quality review both passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)