### PR TITLE
feat(repos): add "Sync fork with upstream" action to fork repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,11 +273,18 @@ upstream** with its head on your fork (`<you>:<branch>`).
 Requires `gh auth login`. The fork is a real, persistent repo on your GitHub
 account — Shepherd does not remove it.
 
+**Keep the fork current:** fork rows in the repo picker carry a **⟲ Sync** button.
+It runs `gh repo sync` to fast-forward your fork's default branch from upstream and
+updates the local clone, so a fresh PR branch starts from current upstream rather
+than a stale base. If your fork's default branch has diverged (commits not on
+upstream), the sync is declined rather than discarding them — reconcile it on
+GitHub.
+
 v1 limitations on a fork (surfaced, not silent — they return GitHub's permission
 error if attempted): maintainer-side actions you don't have rights for —
 **merging** the upstream PR (the maintainer does that), re-running upstream CI,
 renaming upstream branches, requesting reviewers — and **epic / multi-branch**
-orchestration. Keeping the fork current with upstream (`gh repo sync`) is manual.
+orchestration.
 
 ### Submitting tasks from external agents
 

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -175,6 +175,11 @@ export class GithubForge implements GitForge {
     return `https://github.com/${this.slug}`;
   }
 
+  /** Fork mode = a fork slug was supplied (`slug` is the upstream it forked from). */
+  get isFork(): boolean {
+    return !!this.forkSlug;
+  }
+
   async listIssues(): Promise<Issue[]> {
     const out = await this.run([
       "issue",
@@ -592,6 +597,18 @@ export class GithubForge implements GitForge {
         // Absent/unknown permission is not a definitive deny — surface as a probe failure.
         throw new Error(`unexpected viewerPermission: ${viewerPermission ?? "(absent)"}`);
     }
+  }
+
+  /** Sync the fork's default branch from upstream on GitHub
+   *  (`gh repo sync <fork> --source <upstream>`). Idempotent — a fork already level
+   *  with upstream is a no-op. THROWS (with gh's stderr) when called on a non-fork,
+   *  on an auth failure, or when the fork's default branch has diverged from upstream
+   *  (gh refuses a non-fast-forward rather than discarding the fork's commits); the
+   *  caller classifies the stderr into a `syncfork_failed_*` code. */
+  async syncFork(): Promise<void> {
+    if (!this.forkSlug) throw new Error("syncFork called on a non-fork repo");
+    // `slug` is the upstream (source of truth); `forkSlug` is the fork (destination).
+    await this.run(["repo", "sync", this.forkSlug, "--source", this.slug]);
   }
 
   async listCollaborators(): Promise<{ logins: string[]; unavailable: boolean }> {

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -238,6 +238,10 @@ export interface GitForge {
   readonly deployWorkflow: string | null;
   /** Repo's web home page (e.g. https://github.com/owner/repo); null when unbuildable; absent → null. */
   readonly webUrl?: string | null;
+  /** True when this forge runs in fork mode — `origin` is a fork and `slug` is the
+   *  upstream it was forked from (the `gh repo fork --clone` topology). Drives the
+   *  repo picker's per-fork "Sync fork" affordance. Absent/false ⇒ not a fork. */
+  readonly isFork?: boolean;
   listIssues(): Promise<Issue[]>;
   /** Open PRs for the backlog PRs tab (newest first), capped server-side. */
   listPullRequests(): Promise<PullRequest[]>;
@@ -274,6 +278,14 @@ export interface GitForge {
    *  an info toast rather than an error). Optional: hosts without an access API omit
    *  it and the adopter treats absence as "no push access". */
   canPush?(): Promise<boolean>;
+  /** Sync the fork's default branch from the upstream on the host (`gh repo sync`),
+   *  keeping the fork current so fresh PR branches cut off it aren't already behind.
+   *  Only meaningful in fork mode ({@link isFork}); throws on a non-fork forge and
+   *  propagates the host error (auth / a diverged fork default) for the caller to
+   *  classify. The local clone is fast-forwarded separately by the caller. Optional:
+   *  only hosts with a fork-sync API (GitHub) implement it; others omit it and the
+   *  sync-fork endpoint 400s. */
+  syncFork?(): Promise<void>;
   /** The repo's default branch name (the promote PR's base). */
   defaultBranch(): Promise<string>;
   /** Short-names of all host branches under `prefix` (e.g. `"epic/"`), `refs/heads/`

--- a/src/server.ts
+++ b/src/server.ts
@@ -2125,6 +2125,10 @@ async function handleRepos({ req, parts, deps }: Ctx): Promise<Response | null> 
         ...r,
         lastUsedAt: lastUsed[r.path],
         recentAgentCount: recentCounts[r.path],
+        // Fork mode is derived from the (memoized) forge resolution, so the picker
+        // can offer "Sync fork" only on fork repos. resolveForge is cached per dir
+        // and shared with the backlog poller — no extra git shell on a warm cache.
+        isFork: deps.resolveForge?.(r.path)?.isFork ?? false,
       }));
       // Return the window alongside the repos so the picker labels the count with
       // the exact day count it was computed over — single source of truth.
@@ -2722,6 +2726,61 @@ async function handleRepoPull({ req, parts, deps }: Ctx): Promise<Response | nul
   const result = await fastForwardDefaultBranch(dir, branch);
   const status = result.ok ? 200 : result.reason === "error" ? 502 : 409;
   return json(result, status);
+}
+
+// Map a `gh repo sync` failure to a stable `syncfork_failed_*` code (mirrors the
+// fork-create classifier). Diverged = the fork's default branch carries commits
+// not on upstream, so gh refuses a non-fast-forward — client-correctable, hence 409.
+function classifySyncForkError(e: unknown): { code: string; status: number } {
+  const s = String(
+    (e as { stderr?: string; message?: string }).stderr ?? (e as Error).message ?? "",
+  ).toLowerCase();
+  if (s.includes("command not found") || (e as { code?: string }).code === "ENOENT")
+    return { code: "syncfork_failed_gh_missing", status: 502 };
+  if (
+    s.includes("not logged") ||
+    s.includes("gh auth login") ||
+    s.includes("authentication") ||
+    s.includes("403")
+  )
+    return { code: "syncfork_failed_auth", status: 502 };
+  if (s.includes("diverg") || s.includes("fast forward") || s.includes("fast-forward"))
+    return { code: "syncfork_failed_diverged", status: 409 };
+  return { code: "syncfork_failed_generic", status: 502 };
+}
+
+// POST /api/repos/sync-fork — bring a fork current with its upstream. Runs
+// `gh repo sync` on the host (updates the fork's default branch from upstream),
+// then fast-forwards the local default-branch checkout so the canonical clone
+// matches. Fork repos only: a non-fork forge (no `syncFork`) 400s and the UI never
+// offers the action. 200 on success; 4xx/502 with a `syncfork_failed_*` code on failure.
+async function handleSyncFork({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (
+    req.method !== "POST" ||
+    parts[0] !== "api" ||
+    parts[1] !== "repos" ||
+    parts[2] !== "sync-fork"
+  )
+    return null;
+  const body = (await req.json().catch(() => ({}))) as { repo?: string };
+  const dir = safeRepoDir(body.repo ?? "", config.repoRoot);
+  if (!dir) return json({ error: "invalid repo" }, 400);
+  const forge = deps.resolveForge?.(dir) ?? null;
+  if (!forge?.syncFork || !forge.isFork) return json({ error: "syncfork_failed_not_fork" }, 400);
+  try {
+    await forge.syncFork();
+  } catch (e) {
+    const { code, status } = classifySyncForkError(e);
+    return json({ error: code }, status);
+  }
+  // Best-effort: fast-forward the local default-branch checkout to the freshly
+  // synced fork tip. A fail-closed FF state (dirty/diverged local tree) is NOT a
+  // sync failure — the remote fork is already current — so we still report ok.
+  const branch = await resolveDefaultBranch(dir, {
+    forgeDefault: () => forge.defaultBranch().catch(() => null),
+  });
+  if (branch) await fastForwardDefaultBranch(dir, branch).catch(() => undefined);
+  return json({ ok: true, branch: branch ?? undefined });
 }
 
 // POST /api/prs/dependabot-rebase — post the opt-in "@dependabot rebase" command on
@@ -3610,6 +3669,7 @@ const ROUTE_HANDLERS = [
   handleActionsRunJobs,
   handlePrMerge,
   handleRepoPull,
+  handleSyncFork,
   handleDependabotRebase,
   handleReadiness,
   handleAdoptGitignore,

--- a/test/forge/github-fork.test.ts
+++ b/test/forge/github-fork.test.ts
@@ -123,3 +123,25 @@ test("non-fork canPush: probes the origin slug", async () => {
   const view = calls.find((c) => c[0] === "repo" && c[1] === "view")!;
   expect(view[2]).toBe("o/r");
 });
+
+// ── isFork + syncFork: keep the fork current with upstream ────────────────────────
+
+test("fork mode: isFork true; syncFork runs `gh repo sync <fork> --source <upstream>`", async () => {
+  const { run, calls } = fakeRunner({ "repo sync": "" });
+  const forge = new GithubForge(UPSTREAM, {}, run, FORK);
+  expect(forge.isFork).toBe(true);
+  await forge.syncFork();
+
+  const sync = calls.find((c) => c[0] === "repo" && c[1] === "sync")!;
+  expect(sync).toBeDefined();
+  expect(sync.slice(0, 3)).toEqual(["repo", "sync", FORK]); // destination = the fork
+  expect(sync[sync.indexOf("--source") + 1]).toBe(UPSTREAM); // source = upstream
+});
+
+test("non-fork: isFork false; syncFork throws and never shells out", async () => {
+  const { run, calls } = fakeRunner({});
+  const forge = new GithubForge("o/r", {}, run);
+  expect(forge.isFork).toBe(false);
+  await expect(forge.syncFork()).rejects.toThrow();
+  expect(calls.find((c) => c[0] === "repo" && c[1] === "sync")).toBeUndefined();
+});

--- a/test/server-sync-fork.test.ts
+++ b/test/server-sync-fork.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for POST /api/repos/sync-fork. The route resolves the repo's forge, rejects
+ * non-fork repos (400), runs `forge.syncFork()` and classifies its failures, then
+ * best-effort fast-forwards the local clone. The forge is injected via
+ * deps.resolveForge so no real `gh` runs; the fast-forward against the temp dir
+ * (not a git repo) fails silently — which is the point: the remote sync still
+ * reports ok.
+ *
+ * The temp repo dir lives INSIDE config.repoRoot so safeRepoDir accepts it.
+ */
+import { test, expect, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { SessionStore } from "../src/store";
+import { SessionService } from "../src/service";
+import { EventHub } from "../src/events";
+import { makeApp, type AppDeps } from "../src/server";
+import { config } from "../src/config";
+import type { GitForge } from "../src/forge/types";
+
+const repoDir = mkdtempSync(join(config.repoRoot, ".sync-fork-test-"));
+afterAll(() => rmSync(repoDir, { recursive: true, force: true }));
+
+function fakeForge(over: Partial<GitForge> = {}): GitForge {
+  return {
+    kind: "github",
+    slug: "dannymcc/may",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    isFork: true,
+    syncFork: async () => {},
+    defaultBranch: async () => "main",
+    ...over,
+  } as unknown as GitForge;
+}
+
+function makeDeps(resolveForge?: (dir: string) => GitForge | null): AppDeps {
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({ worktreePath: "/wt", branch: "shepherd/x", isolated: true }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => ({
+        terminalId: "term_x",
+        cwd: "/wt",
+        agent: "claude",
+        agentStatus: "working",
+        paneId: "p",
+        tabId: "t",
+        workspaceId: "w",
+      }),
+      list: () => [],
+      stop: () => {},
+      send: () => {},
+    } as any,
+    events,
+  });
+  const usageLimits = {
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
+  };
+  const distiller = { distillNow: () => {} };
+  return { store, service, events, usageLimits, distiller, resolveForge } as AppDeps;
+}
+
+function postSync(app: ReturnType<typeof makeApp>, body: unknown): Promise<Response> {
+  return app.fetch(
+    new Request("http://x/api/repos/sync-fork", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+test("POST /api/repos/sync-fork invalid repo → 400 invalid repo", async () => {
+  const app = makeApp(makeDeps(() => fakeForge()));
+  const res = await postSync(app, { repo: "/definitely/outside/the/root" });
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toBe("invalid repo");
+});
+
+test("POST /api/repos/sync-fork on a non-fork repo → 400 syncfork_failed_not_fork", async () => {
+  const app = makeApp(makeDeps(() => fakeForge({ isFork: false })));
+  const res = await postSync(app, { repo: repoDir });
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toBe("syncfork_failed_not_fork");
+});
+
+test("POST /api/repos/sync-fork happy path → 200 { ok:true }, syncFork invoked", async () => {
+  let synced = false;
+  const app = makeApp(makeDeps(() => fakeForge({ syncFork: async () => void (synced = true) })));
+  const res = await postSync(app, { repo: repoDir });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.ok).toBe(true);
+  expect(synced).toBe(true);
+});
+
+test("POST /api/repos/sync-fork diverged fork → 409 syncfork_failed_diverged", async () => {
+  const app = makeApp(
+    makeDeps(() =>
+      fakeForge({
+        syncFork: async () => {
+          throw new Error("can't sync because the branches have diverged");
+        },
+      }),
+    ),
+  );
+  const res = await postSync(app, { repo: repoDir });
+  expect(res.status).toBe(409);
+  expect((await res.json()).error).toBe("syncfork_failed_diverged");
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1380,5 +1380,13 @@
   "feat_herd_rundown_body": "Eine neue ☰-Rundown-Ansicht (und Schaltfläche in der Kopfzeile) zeigt einen täglichen Überblick über deinen Herd: was über Nacht eingespielt wurde, was eine Entscheidung braucht, welche Sitzungen CI-rot oder REWORK wurden, den Merge-Train-Status und worauf du dich als Nächstes konzentrieren solltest. Jeder Eintrag verlinkt direkt zu seiner Sitzung.",
   "feat_subagent_fanout_title": "Live-Sub-Agenten-Übersicht",
   "feat_subagent_fanout_body": "Der Aktivitäts-Tab zeigt jetzt live die von einer Sitzung gestarteten Sub-Agenten an — mit dem jeweiligen Typ und der Laufzeit.",
-  "rundown_all_quiet": "Alles ruhig — derzeit ist nichts zu tun."
+  "rundown_all_quiet": "Alles ruhig — derzeit ist nichts zu tun.",
+  "syncfork_action_title": "Fork mit Upstream synchronisieren",
+  "syncfork_toast_done": "{name} mit Upstream synchronisiert",
+  "syncfork_toast_diverged": "Der Standard-Branch deines Forks hat Commits, die nicht im Upstream sind — synchronisiere ihn manuell auf GitHub.",
+  "syncfork_toast_auth": "Nicht bei GitHub angemeldet. Führe gh auth login aus.",
+  "syncfork_toast_gh_missing": "GitHub CLI (gh) ist nicht installiert.",
+  "syncfork_toast_generic": "Fork konnte nicht synchronisiert werden, bitte erneut",
+  "feat_fork_sync_title": "Einen Fork mit einem Klick aktuell halten",
+  "feat_fork_sync_body": "Fork-Repos in der Auswahl zeigen jetzt einen ⟲ Sync-Button. Er führt gh repo sync aus, um den Standard-Branch deines Forks mit dem Upstream abzugleichen, und fast-forwardet den lokalen Klon — damit neue PR-Branches vom aktuellen Upstream statt von einer veralteten Basis ausgehen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1380,5 +1380,13 @@
   "feat_herd_rundown_body": "A new ☰ Rundown lens (and top-bar button) shows a daily digest of your herd: what landed overnight, what needs a decision, which sessions went CI-red or REWORK, the merge-train status, and what to focus on next. Each item deep-links to its session.",
   "feat_subagent_fanout_title": "Live sub-agent fan-out",
   "feat_subagent_fanout_body": "The Activity tab now shows the sub-agents a session has spawned, live, with each one's type and how long it ran.",
-  "rundown_all_quiet": "All quiet — nothing needs you right now."
+  "rundown_all_quiet": "All quiet — nothing needs you right now.",
+  "syncfork_action_title": "Sync fork with upstream",
+  "syncfork_toast_done": "Synced {name} with upstream",
+  "syncfork_toast_diverged": "Your fork's default branch has commits that aren't upstream — sync it manually on GitHub.",
+  "syncfork_toast_auth": "Not logged in to GitHub. Run gh auth login.",
+  "syncfork_toast_gh_missing": "GitHub CLI (gh) is not installed.",
+  "syncfork_toast_generic": "Couldn't sync the fork, please retry",
+  "feat_fork_sync_title": "Keep a fork current with one click",
+  "feat_fork_sync_body": "Fork repos in the picker now show a ⟲ Sync button. It runs gh repo sync to bring your fork's default branch up to date with upstream and fast-forwards the local clone — so new PR branches you cut start from current upstream instead of a stale base."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -207,6 +207,19 @@ export async function forkRepo(target: string): Promise<RepoEntry> {
   return postJson<RepoEntry>("/api/repos/fork", { target }, "fork");
 }
 
+/** Sync a fork's default branch with its upstream (`gh repo sync`) and fast-forward
+ *  the local clone. Fork repos only. Resolves to the synced default branch name on
+ *  success; on failure throws with `err.message` set to the server's `error` field
+ *  (a `syncfork_failed_*` code) so the caller can map it to a toast message. */
+export async function syncFork(repoPath: string): Promise<{ branch?: string }> {
+  const r = await fetch("/api/repos/sync-fork", JSON_POST({ repo: repoPath }));
+  if (!r.ok) {
+    const msg = await r.json().catch(() => ({ error: `${r.status}` }));
+    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
+  }
+  return (await r.json().catch(() => ({}))) as { branch?: string };
+}
+
 /** Create a new local git project (optionally with a GitHub remote).
  *  On success returns a `RepoEntry` plus an optional `warning` when the local repo
  *  was created but the GitHub step failed (partial success — the modal treats this as

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -7,7 +7,9 @@
     getEpics,
     uploadImage,
     isPreviewBlocked,
+    syncFork,
   } from "$lib/api";
+  import { toasts } from "$lib/toasts.svelte";
   import { handleImagePaste } from "$lib/clipboard";
   import {
     MODELS,
@@ -162,6 +164,32 @@
       }
     }
     return best?.path ?? list[0]?.path ?? "";
+  }
+
+  /** Map a `syncfork_failed_*` code to its toast message (default = generic). */
+  function syncForkMsg(code: string): string {
+    switch (code) {
+      case "syncfork_failed_diverged":
+        return m.syncfork_toast_diverged();
+      case "syncfork_failed_auth":
+        return m.syncfork_toast_auth();
+      case "syncfork_failed_gh_missing":
+        return m.syncfork_toast_gh_missing();
+      default:
+        return m.syncfork_toast_generic();
+    }
+  }
+
+  /** Sync a fork row with its upstream. Awaited by RepoSelect so the row shows a
+   *  busy state; result is surfaced as a toast. */
+  async function handleSync(repo: RepoEntry) {
+    try {
+      await syncFork(repo.path);
+      toasts.info(m.syncfork_toast_done({ name: repo.name }));
+    } catch (e) {
+      const code = e instanceof Error ? e.message : "syncfork_failed_generic";
+      toasts.info(syncForkMsg(code), { alert: true });
+    }
   }
 
   onMount(() => {
@@ -497,6 +525,7 @@
         {onclone}
         {onfork}
         {onnewproject}
+        onsync={handleSync}
       />
     </div>
 

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { tick } from "svelte";
+  import { SvelteSet } from "svelte/reactivity";
   import type { RepoEntry } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import EmojiPicker from "./EmojiPicker.svelte";
@@ -13,6 +14,7 @@
     onclone,
     onfork,
     onnewproject,
+    onsync,
     windowDays,
   }: {
     repos: RepoEntry[];
@@ -21,6 +23,9 @@
     onclone?: () => void;
     onfork?: () => void;
     onnewproject?: () => void;
+    /** Sync a fork repo with its upstream. Awaited so the row shows a busy state
+     *  while it runs; the parent owns the toast/refresh. Only fork rows expose it. */
+    onsync?: (repo: RepoEntry) => Promise<void> | void;
     /** Day count the server computed recentAgentCount over — named in the per-row label. */
     windowDays: number;
   } = $props();
@@ -41,6 +46,19 @@
   function setIcon(path: string, emoji: string | null) {
     projectIcons.set(path, emoji).catch(() => {});
     pickerFor = null;
+  }
+
+  // Paths with an in-flight fork sync — disables the row's sync button + shows a
+  // spinner glyph. SvelteSet is reactive, so direct add/delete re-render the row.
+  const syncing = new SvelteSet<string>();
+  async function doSync(r: RepoEntry) {
+    if (syncing.has(r.path)) return;
+    syncing.add(r.path);
+    try {
+      await onsync?.(r);
+    } finally {
+      syncing.delete(r.path);
+    }
   }
 
   // How many repos to pin in the "recently worked on" shortcut group at the top.
@@ -252,6 +270,21 @@
               <span class="rs-count" title={label} aria-label={label}>
                 {r.recentAgentCount}
               </span>
+            {/if}
+            {#if r.isFork && onsync}
+              <button
+                type="button"
+                class="rs-sync-btn"
+                title={m.syncfork_action_title()}
+                aria-label={m.syncfork_action_title()}
+                disabled={syncing.has(r.path)}
+                onclick={(e) => {
+                  e.stopPropagation();
+                  void doSync(r);
+                }}
+              >
+                {syncing.has(r.path) ? "…" : "⟲"}
+              </button>
             {/if}
           </li>
         {/each}
@@ -514,6 +547,29 @@
     color: var(--color-amber);
     background: color-mix(in srgb, var(--color-amber) 12%, transparent);
     border-radius: 999px;
+  }
+
+  /* Per-fork "sync with upstream" affordance. margin-left:auto right-aligns it on
+     rows without a count chip; on rows that have one, the chip claims the free space
+     and the button trails it. */
+  .rs-sync-btn {
+    flex-shrink: 0;
+    margin-left: auto;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    font-size: var(--fs-base);
+    line-height: 1;
+    padding: 1px 5px;
+    cursor: pointer;
+    color: var(--color-amber);
+  }
+  .rs-sync-btn:hover {
+    border-color: var(--color-line);
+  }
+  .rs-sync-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
   }
 
   .rs-empty {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -871,6 +871,16 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     targetId: "fork-row",
   },
   {
+    // No targetId: the ⟲ Sync button only renders on fork rows inside the repo
+    // picker (RepoSelect), which is closed by default — a coachmark anchor would
+    // usually be unmounted, so surface via the What's-New drawer only. 1.31.0 is the
+    // latest released tag (the fork-repo feature above), so this ships in 1.32.0.
+    id: "fork-sync",
+    sinceVersion: "1.32.0",
+    titleKey: "feat_fork_sync_title",
+    bodyKey: "feat_fork_sync_body",
+  },
+  {
     // No targetId: the link is inline in the panel header (only rendered when a repo is
     // selected in the Backlog view), so a coachmark anchor would usually be unmounted —
     // surface via the What's-New drawer only. 1.30.0 is the latest released tag, so this

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -24,6 +24,9 @@ export interface RepoEntry {
   lastUsedAt?: number;
   /** Count of sessions (agents) run on this repo within the recent window; undefined if none. */
   recentAgentCount?: number;
+  /** True when the repo is a fork (origin = fork, upstream = original) — the repo
+   *  picker shows a "Sync fork" action on these. Absent/false ⇒ not a fork. */
+  isFork?: boolean;
 }
 
 export interface Settings {


### PR DESCRIPTION
## What

Closes the last documented **v1 fork limitation** — keeping a fork current with upstream was manual (`gh repo sync`). This is a follow-up to the merged fork feature (#687).

Fork rows in the repo picker now carry a **⟲ Sync** button. It runs `gh repo sync <fork> --source <upstream>` to fast-forward the fork's default branch from upstream on the host, then fast-forwards the local clone — so a fresh PR branch starts from current upstream instead of a stale base.

A **diverged** fork default (commits not on upstream) is **declined (409)** rather than discarding them; the operator reconciles on GitHub.

## How

- **forge** (`src/forge/`): `GithubForge` gains `isFork` + `syncFork()` (added to the `GitForge` interface as optional; GitHub-only).
- **server** (`src/server.ts`): `/api/repos` entries now carry `isFork` (derived from the memoized forge resolution — no extra git shell on a warm cache); new `POST /api/repos/sync-fork` runs the remote sync then best-effort fast-forwards the local clone, with a `syncfork_failed_*` classifier (`auth` / `diverged`→409 / `gh_missing` / `generic`).
- **ui**: `RepoEntry.isFork`, `api.syncFork()`, a per-fork sync affordance in `RepoSelect` (busy state via `SvelteSet`); `NewTask` owns the handler + surfaces the result as a toast.
- **i18n** EN+DE, **feature-announcement** entry (`fork-sync`, 1.32.0), **README** caveat updated.

## Design notes

- A diverged fork default isn't auto-reset — we never discard the user's commits silently; gh's non-fast-forward refusal maps to a clear 409 + actionable toast.
- Local fast-forward is best-effort: a dirty/diverged **local** tree is not a sync failure (the remote fork is already current), so the route still reports `ok`.

## Tests / checks

- forge `isFork`/`syncFork` + sync-fork route (not-a-fork → 400, happy → 200, diverged → 409)
- Green locally: `tsc`, `eslint`, `svelte-check` (0 errors), `check:i18n` (parity), forge+route suite, UI node suite (1065), RepoSelect+NewTask browser specs (24)

[no-feature-entry] not used — catalog entry included.