### PR TITLE
feat(hooks): reach Shepherd from inside the autonomous egress netns (#711)

### DIFF
--- a/scripts/egress-runner.sh
+++ b/scripts/egress-runner.sh
@@ -113,8 +113,13 @@ for _ in $(seq 1 200); do
 done
 
 # ── (B) slirp4netns uplink, ALSO pdeathsig-bound (host-side leash) ────────────
+# Host-loopback IS permitted at the slirp level (we do NOT pass the slirp flag that
+# would block it) so the netns can reach the host's 127.0.0.1 control plane via the
+# slirp gateway 10.0.2.2.
+# The nft ruleset (policy drop + a single explicit allow for that IP:port) remains
+# the real gate — dropping the slirp-level block widens nothing on its own.
 setpriv --pdeathsig SIGKILL \
-  slirp4netns --configure --mtu=65520 --disable-host-loopback "$CHILD" tap0 &
+  slirp4netns --configure --mtu=65520 "$CHILD" tap0 &
 SLIRP=$!
 
 wait "$CHILD"   # agent runs; stdio = inherited PTY fds (never redirected)

--- a/src/egress.ts
+++ b/src/egress.ts
@@ -261,8 +261,7 @@ export function detectEgressHostLoopback(
   try {
     const out = versionOutput();
     const parsed = out ? parseSemverish(out) : null;
-    if (parsed)
-      result = semverGte(parsed, parseSemverish(SLIRP4NETNS_HOSTLOOPBACK_MIN) ?? [1, 0, 0]);
+    if (parsed) result = semverGte(parsed, SLIRP4NETNS_HOSTLOOPBACK_MIN);
   } catch {
     result = false; // best-effort — never throw
   }
@@ -313,8 +312,9 @@ const SLIRP_RESOLVER = "10.0.2.3";
 export const SLIRP_HOST_GATEWAY = "10.0.2.2";
 
 /** Minimum slirp4netns version whose host-loopback (10.0.2.2 → host 127.0.0.1) we rely on.
- *  A broadly-available modern floor; below it we fall back to polling (see detectEgressHostLoopback). */
-export const SLIRP4NETNS_HOSTLOOPBACK_MIN = "1.0.0";
+ *  Human-readable source-of-truth: "1.0.0" — a broadly-available modern floor; below it we fall back
+ *  to polling (see detectEgressHostLoopback). Module-private (only detectEgressHostLoopback uses it). */
+const SLIRP4NETNS_HOSTLOOPBACK_MIN: [number, number, number] = [1, 0, 0];
 
 /** dnsmasq min-cache-ttl in seconds: keeps resolved IPs pinned in the nft set longer. */
 const DEFAULT_MIN_CACHE_TTL = 600;

--- a/src/egress.ts
+++ b/src/egress.ts
@@ -23,6 +23,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { execFileSync } from "./instrument";
 import { resolveNodeBin } from "./node-bin";
 import {
   type BackendProbeDeps,
@@ -124,10 +125,19 @@ function buildProbeMembrane(probeDir: string, deps: EgressBackendProbeDeps): Mem
   };
 }
 
+/** Representative port for the self-test only — the probe verifies the host-gateway rule LOADS,
+ *  not that it routes anywhere. The real spawn passes the live ingress port. */
+const PROBE_GATEWAY_PORT = 7330;
+
 /** Write probe config files to tmpDir and return the inner bwrap argv. */
 function buildProbeInnerArgv(tmpDir: string, deps: EgressBackendProbeDeps): string[] {
   const writeFile = deps.writeFile ?? ((p: string, d: string) => writeFileSync(p, d, "utf8"));
-  const cfg = buildEgressConfig([...ANTHROPIC_EGRESS_HOSTS], { tmpDir });
+  // When host-loopback is available, load the SAME rule shape the real spawn uses, so the
+  // self-test actually nft-loads it; omit it otherwise (probe matches production omission).
+  const hostGateway = detectEgressHostLoopback()
+    ? { ip: SLIRP_HOST_GATEWAY, port: PROBE_GATEWAY_PORT }
+    : undefined;
+  const cfg = buildEgressConfig([...ANTHROPIC_EGRESS_HOSTS], { tmpDir, hostGateway });
   writeFile(join(tmpDir, "egress.nft"), cfg.nftRuleset);
   writeFile(join(tmpDir, "dnsmasq.argv"), cfg.dnsmasqArgv.join("\n"));
   writeFile(join(tmpDir, "resolv.conf"), cfg.resolvConf);
@@ -197,6 +207,70 @@ export function detectEgressBackend(deps: EgressBackendProbeDeps = {}): EgressBa
   }
 }
 
+// ── host-loopback capability probe ──────────────────────────────────────────────
+
+let _egressHostLoopbackCache: boolean | undefined;
+
+/** Clear the per-process host-loopback capability cache (tests). */
+export function resetEgressHostLoopbackCache(): void {
+  _egressHostLoopbackCache = undefined;
+}
+
+/** Parse the first X.Y.Z (or X.Y) triple from slirp4netns --version output. */
+function parseSemverish(out: string): [number, number, number] | null {
+  const m = out.match(/(\d+)\.(\d+)(?:\.(\d+))?/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3] ?? 0)];
+}
+
+/** Numeric major.minor.patch comparison: a >= b. */
+function semverGte(a: [number, number, number], b: [number, number, number]): boolean {
+  for (let i = 0; i < 3; i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av > bv) return true;
+    if (av < bv) return false;
+  }
+  return true;
+}
+
+/**
+ * Detect whether the host's slirp4netns is recent enough to route the host-loopback
+ * gateway (10.0.2.2 → host 127.0.0.1), gating agent→Shepherd reachability. Cached per
+ * process. Best-effort: NEVER throws — a capture failure or unparseable version is false.
+ *
+ * @param deps.versionOutput  Override for capturing `slirp4netns --version` stdout
+ *                            (default: execFileSync wrapper), trimmed or null on throw.
+ */
+export function detectEgressHostLoopback(
+  deps: { versionOutput?: () => string | null } = {},
+): boolean {
+  if (_egressHostLoopbackCache !== undefined) return _egressHostLoopbackCache;
+
+  const versionOutput =
+    deps.versionOutput ??
+    (() => {
+      try {
+        return execFileSync("slirp4netns", ["--version"], { encoding: "utf8" }).toString().trim();
+      } catch {
+        return null;
+      }
+    });
+
+  let result = false;
+  try {
+    const out = versionOutput();
+    const parsed = out ? parseSemverish(out) : null;
+    if (parsed)
+      result = semverGte(parsed, parseSemverish(SLIRP4NETNS_HOSTLOOPBACK_MIN) ?? [1, 0, 0]);
+  } catch {
+    result = false; // best-effort — never throw
+  }
+
+  _egressHostLoopbackCache = result;
+  return result;
+}
+
 // ── Anthropic base set ────────────────────────────────────────────────────────
 
 /**
@@ -233,6 +307,14 @@ const DEFAULT_NFT_SET = "inet#egress#allowed";
 
 /** slirp4netns built-in DNS forwarder — always reachable at this IP inside the netns. */
 const SLIRP_RESOLVER = "10.0.2.3";
+
+/** slirp4netns host-loopback gateway: inside the netns this IP routes to the host's 127.0.0.1
+ *  (reachable once `--disable-host-loopback` is dropped from the slirp invocation). */
+export const SLIRP_HOST_GATEWAY = "10.0.2.2";
+
+/** Minimum slirp4netns version whose host-loopback (10.0.2.2 → host 127.0.0.1) we rely on.
+ *  A broadly-available modern floor; below it we fall back to polling (see detectEgressHostLoopback). */
+export const SLIRP4NETNS_HOSTLOOPBACK_MIN = "1.0.0";
 
 /** dnsmasq min-cache-ttl in seconds: keeps resolved IPs pinned in the nft set longer. */
 const DEFAULT_MIN_CACHE_TTL = 600;
@@ -368,6 +450,8 @@ export interface EgressConfig {
  * @param opts.resolver      Upstream DNS resolver IP (default "10.0.2.3" = slirp4netns's built-in).
  * @param opts.minCacheTtl   dnsmasq min-cache-ttl seconds (default 600).
  * @param opts.nftSet        nft set identifier (default "inet#egress#allowed").
+ * @param opts.hostGateway   When set, opens exactly that host IP+port outbound (least-privilege
+ *                           agent→Shepherd reachability via the slirp host-loopback gateway).
  */
 export function buildEgressConfig(
   allowlist: string[],
@@ -376,16 +460,27 @@ export function buildEgressConfig(
     resolver?: string;
     minCacheTtl?: number;
     nftSet?: string;
+    hostGateway?: { ip: string; port: number };
   },
 ): EgressConfig {
   const resolver = opts.resolver ?? SLIRP_RESOLVER;
   const minCacheTtl = opts.minCacheTtl ?? DEFAULT_MIN_CACHE_TTL;
   const nftSet = opts.nftSet ?? DEFAULT_NFT_SET;
-  const { tmpDir } = opts;
+  const { tmpDir, hostGateway } = opts;
 
   // Guard: nftSet is interpolated directly into dnsmasq and nft config — must be safe.
   if (!/^[a-z0-9#_]+$/i.test(nftSet)) {
     throw new Error(`buildEgressConfig: invalid nftSet "${nftSet}" — must match /^[a-z0-9#_]+$/i`);
+  }
+
+  // Guard: hostGateway.port is interpolated directly into the nft ruleset — must be a port.
+  if (
+    hostGateway &&
+    !(Number.isInteger(hostGateway.port) && hostGateway.port >= 1 && hostGateway.port <= 65535)
+  ) {
+    throw new Error(
+      `buildEgressConfig: invalid hostGateway.port "${hostGateway.port}" — must be an integer 1..65535`,
+    );
   }
 
   // ── dnsmasq argv ────────────────────────────────────────────────────────────
@@ -425,6 +520,11 @@ export function buildEgressConfig(
 
   // ── nft ruleset ─────────────────────────────────────────────────────────────
   // family inet, table egress, default-drop with explicit REJECT for fast-fail.
+  // When hostGateway is set, ONE least-privilege allow for the host IP+port goes
+  // right after the @allowed accept (return traffic is covered by ct established).
+  const hostGatewayRule = hostGateway
+    ? `\n    ip daddr ${hostGateway.ip} tcp dport ${hostGateway.port} accept`
+    : "";
   const nftRuleset = `table inet egress {
   set allowed {
     type ipv4_addr
@@ -436,7 +536,7 @@ export function buildEgressConfig(
     ct state established,related accept
     ip daddr ${resolver} udp dport 53 accept
     ip daddr ${resolver} tcp dport 53 accept
-    ip daddr @allowed accept
+    ip daddr @allowed accept${hostGatewayRule}
     meta nfproto ipv6 reject
     meta l4proto tcp reject with tcp reset
     reject

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import { BranchPruner } from "./branch-pruner";
 import { reconcile } from "./reconcile";
 import { reapOrphanTabs, reapStaleReviewWorktrees } from "./tab-reaper";
 import { scanClaudeAliveByWorktree } from "./process-reaper";
-import { serve, buildBacklogPayload } from "./server";
+import { serve, serveAgentIngress, buildBacklogPayload, type AppDeps } from "./server";
 import { detectForge } from "./forge";
 import { AccountUsageIndex } from "./usage";
 import { UsageLimitsService, calibrateDelay, type UsageLimits } from "./usage-limits";
@@ -78,6 +78,7 @@ import { resolveNodeHost, TailscaleServeService } from "./tailscale";
 import { normalizeDefaultModelSetting } from "./default-model";
 import { normalizeAuthModeSetting } from "./auth-mode";
 import { EgressWatcher } from "./egress-watch";
+import { detectEgressHostLoopback } from "./egress";
 import { RecapService } from "./recap";
 import { HerdDigestService } from "./herd-digest";
 import { readSnapshot, isStalled, DEFAULT_STALL } from "./stall";
@@ -216,10 +217,19 @@ const recapService = new RecapService({
   onChange: (id, recap) => events.emit("session:recap", { id, recap }),
 });
 
+// Lazy holder for the restricted agent-ingress listener's ephemeral port. The listener is started
+// AFTER SessionService is constructed (it needs the same AppDeps), so the port is unknown here;
+// spawns only happen after startup completes, so the accessor returns the real port by the time
+// resolveSpawnBaseUrl/prepareSpawn read it. A holder object (mutated, not reassigned) avoids the
+// forward-reference `let`.
+const agentIngressState: { port: number | undefined } = { port: undefined };
+
 const service = new SessionService({
   store,
   worktree,
   herdr,
+  agentIngressPort: () => agentIngressState.port,
+  detectEgressHostLoopback,
   namer: generateName,
   refineName: config.llmNaming
     ? ({ taskText, label }) => llmName(taskText, { herdr, model: config.namerModel }, label)
@@ -1148,82 +1158,88 @@ const backlogPoller = new BacklogPoller(
 setTimeout(() => void backlogPoller.tick(), 3_000);
 backlogPoller.start();
 
-const server = serve(
-  {
-    store,
-    service,
-    events,
-    usageLimits,
-    refreshUsage,
-    updates,
-    herdrUpdates,
-    diagnostics,
-    starPrompt,
-    herdr,
-    resolveForge,
-    prCache: prPoller,
-    ownsPr,
-    activity: { snapshot: () => poller.activitySnapshot() },
-    claudeAlive: { snapshot: () => poller.claudeAliveSnapshot() },
-    workingBlocked: { snapshot: () => poller.workingBlockedSnapshot() },
-    preview: { snapshot: () => previewService.snapshot() },
-    previewServe: { snapshot: () => tailscaleServe.snapshot() },
-    push,
-    presence,
-    poller,
-    hooks: hookIngest,
-    reviewCache: {
-      snapshot: () => reviewService.snapshot(),
-      reviewing: () => reviewService.reviewingIds(),
-    },
-    planGateCache: {
-      snapshot: () => planGate.snapshot(),
-      reviewing: () => planGate.reviewingIds(),
-    },
-    planGate: { consider: (s) => planGate.consider(s) },
-    recapCache: { snapshot: () => recapService.snapshot() },
-    recap: { regenerate: (s) => recapService.regenerate(s) },
-    herdDigest: {
-      snapshot: () => herdDigestService.snapshot(),
-      currentFingerprint: () => herdDigestService.currentAttentionFingerprint(),
-      regenerate: () => herdDigestService.regenerate(),
-    },
-    verifyKey: () => verifyApiKey({ herdr }),
-    backlog,
-    // After a backlog merge, force-refresh the repo's counts past the read-TTL and
-    // re-broadcast the overview so the merged PR (and any auto-closed linked issue)
-    // leaves the counters + headline at once, not on the next ~45s warm tick.
-    //
-    // `dir` is safeRepoDir's realpath-resolved form, but the warmer +
-    // buildBacklogPayload key the counts cache by listRepos' raw join(repoRoot,
-    // name) path. Under a symlinked repoRoot/repo those diverge, so refreshing by
-    // `dir` would write a phantom key and the broadcast would re-read stale counts.
-    // Match the repo back to its listRepos entry by realpath and refresh that exact
-    // key (falling back to `dir` for a repo not under the enumerated root).
-    //
-    // Opportunistic: CountsService.load single-flights, so this refresh can
-    // piggyback on an in-flight pre-merge warm fetch and broadcast slightly stale
-    // counts; the next warm tick reconciles. Acceptable for a freshness nudge.
-    refreshBacklog: async (dir) => {
-      await backlog.refresh(listReposPathForReal(dir, config.repoRoot));
-      await broadcastBacklog();
-    },
-    distiller,
-    promoter,
-    gitignoreAdopter,
-    drain: {
-      snapshot: () => drain.snapshot(),
-      queue: (repoPath) => drain.queue(repoPath),
-      retainClaim: (id) => drain.retainClaim(id),
-      buildEpic: (repoPath, run) => drain.buildEpic(repoPath, run),
-      approveEpicNext: (repoPath) => drain.approveEpicNext(repoPath),
-      tick: () => drain.tick(),
-    },
-    autoMerge: { snapshot: () => autoMerge.snapshot() },
+const appDeps: AppDeps = {
+  store,
+  service,
+  events,
+  usageLimits,
+  refreshUsage,
+  updates,
+  herdrUpdates,
+  diagnostics,
+  starPrompt,
+  herdr,
+  resolveForge,
+  prCache: prPoller,
+  ownsPr,
+  activity: { snapshot: () => poller.activitySnapshot() },
+  claudeAlive: { snapshot: () => poller.claudeAliveSnapshot() },
+  workingBlocked: { snapshot: () => poller.workingBlockedSnapshot() },
+  preview: { snapshot: () => previewService.snapshot() },
+  previewServe: { snapshot: () => tailscaleServe.snapshot() },
+  push,
+  presence,
+  poller,
+  hooks: hookIngest,
+  reviewCache: {
+    snapshot: () => reviewService.snapshot(),
+    reviewing: () => reviewService.reviewingIds(),
   },
-  config.port,
-);
+  planGateCache: {
+    snapshot: () => planGate.snapshot(),
+    reviewing: () => planGate.reviewingIds(),
+  },
+  planGate: { consider: (s) => planGate.consider(s) },
+  recapCache: { snapshot: () => recapService.snapshot() },
+  recap: { regenerate: (s) => recapService.regenerate(s) },
+  herdDigest: {
+    snapshot: () => herdDigestService.snapshot(),
+    currentFingerprint: () => herdDigestService.currentAttentionFingerprint(),
+    regenerate: () => herdDigestService.regenerate(),
+  },
+  verifyKey: () => verifyApiKey({ herdr }),
+  backlog,
+  // After a backlog merge, force-refresh the repo's counts past the read-TTL and
+  // re-broadcast the overview so the merged PR (and any auto-closed linked issue)
+  // leaves the counters + headline at once, not on the next ~45s warm tick.
+  //
+  // `dir` is safeRepoDir's realpath-resolved form, but the warmer +
+  // buildBacklogPayload key the counts cache by listRepos' raw join(repoRoot,
+  // name) path. Under a symlinked repoRoot/repo those diverge, so refreshing by
+  // `dir` would write a phantom key and the broadcast would re-read stale counts.
+  // Match the repo back to its listRepos entry by realpath and refresh that exact
+  // key (falling back to `dir` for a repo not under the enumerated root).
+  //
+  // Opportunistic: CountsService.load single-flights, so this refresh can
+  // piggyback on an in-flight pre-merge warm fetch and broadcast slightly stale
+  // counts; the next warm tick reconciles. Acceptable for a freshness nudge.
+  refreshBacklog: async (dir) => {
+    await backlog.refresh(listReposPathForReal(dir, config.repoRoot));
+    await broadcastBacklog();
+  },
+  distiller,
+  promoter,
+  gitignoreAdopter,
+  drain: {
+    snapshot: () => drain.snapshot(),
+    queue: (repoPath) => drain.queue(repoPath),
+    retainClaim: (id) => drain.retainClaim(id),
+    buildEpic: (repoPath, run) => drain.buildEpic(repoPath, run),
+    approveEpicNext: (repoPath) => drain.approveEpicNext(repoPath),
+    tick: () => drain.tick(),
+  },
+  autoMerge: { snapshot: () => autoMerge.snapshot() },
+};
+const server = serve(appDeps, config.port);
 console.log(`shepherd core on http://localhost:${server.port}`);
+
+// Restricted agent-ingress listener: the autonomous netns's ONLY reachable control-plane surface.
+// Bound to loopback on an ephemeral port; slirp maps the netns's 10.0.2.2 → host 127.0.0.1. Started
+// with the SAME AppDeps as the main listener so delegated routes hit the real handlers (auth + origin
+// preserved). The lazy `agentIngressPort` accessor wired into SessionService reads `.port` below.
+const agentIngress = serveAgentIngress(appDeps);
+agentIngressState.port = agentIngress.port;
+console.log(`shepherd agent-ingress on http://127.0.0.1:${agentIngress.port}`);
 
 // Best-effort teardown of preview listeners and tailscale mappings on process exit / SIGTERM.
 process.on("exit", () => {

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -516,3 +516,18 @@ export function isEgressDegraded(
 export function egressApplies(profile: SandboxProfile): boolean {
   return profile === "autonomous";
 }
+
+/**
+ * Whether this spawn will actually run egress-confined: an autonomous profile
+ * (egressApplies) WITH both the FS sandbox backend AND the egress backend present.
+ * The single source of truth for "egress wraps this spawn" — shared by prepareSpawn
+ * (the wrap decision) and the agent base-URL decision (which control-plane address to
+ * bake) so the two can never drift.
+ */
+export function willEgressConfine(
+  profile: SandboxProfile,
+  backend: SandboxBackend,
+  egressBackend: EgressBackend,
+): boolean {
+  return egressApplies(profile) && backend !== null && egressBackend != null;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3659,6 +3659,48 @@ export function makeApp(deps: AppDeps) {
   };
 }
 
+/** Method+path allowlist for the restricted agent-ingress listener: EXACTLY the agent→server
+ *  control-plane routes the spawn directives instruct the agent to call. `parts` is
+ *  url.pathname.split("/").filter(Boolean), e.g. ["api","sessions","<id>","hooks"]. The session id
+ *  segment is an unguessable per-session UUID the agent only knows for its own session, so it is the
+ *  de-facto per-session capability; the listener exposes no enumeration route. NOTE: /queue/approve
+ *  is deliberately EXCLUDED — it is the human/autopilot gate, not an agent action. */
+export function isAgentIngressRoute(method: string, parts: string[]): boolean {
+  if (!(parts[0] === "api" && parts[1] === "sessions" && parts[2])) return false;
+  // POST /api/sessions/<id>/hooks
+  if (method === "POST" && parts[3] === "hooks" && !parts[4]) return true;
+  // PUT /api/sessions/<id>/queue
+  if (method === "PUT" && parts[3] === "queue" && !parts[4]) return true;
+  // POST /api/sessions/<id>/queue/steps/<stepId>
+  if (method === "POST" && parts[3] === "queue" && parts[4] === "steps" && parts[5] && !parts[6]) {
+    return true;
+  }
+  return false;
+}
+
+/** Restricted ingress app: 404 unless the request is an allowlisted agent→server route; otherwise
+ *  DELEGATE to the full app (so checkAuth + checkOrigin + the real handlers all still apply). This is
+ *  the autonomous netns's ONLY reachable control-plane surface (see isAgentIngressRoute). */
+export function makeAgentIngressApp(deps: AppDeps) {
+  const app = makeApp(deps);
+  return {
+    async fetch(req: Request): Promise<Response> {
+      const url = new URL(req.url);
+      const parts = url.pathname.split("/").filter(Boolean);
+      if (!isAgentIngressRoute(req.method, parts)) return json({ error: "not found" }, 404);
+      return app.fetch(req); // MUST delegate — preserves checkAuth (token) + checkOrigin (CSRF) + handlers
+    },
+  };
+}
+
+/** Start the agent-ingress listener bound to LOOPBACK ONLY (never config.host, which may be 0.0.0.0)
+ *  on an ephemeral port. slirp maps the netns's 10.0.2.2 to the host's 127.0.0.1, so loopback is the
+ *  correct + safest bind. Returns the Bun server (read `.port`). */
+export function serveAgentIngress(deps: AppDeps, port = 0) {
+  const app = makeAgentIngressApp(deps);
+  return Bun.serve({ port, hostname: "127.0.0.1", fetch: (req) => app.fetch(req) });
+}
+
 type WsData =
   | { kind: "events" }
   | { kind: "pty"; id: string; terminalId: string; cols: number; rows: number; bridge?: PtyBridge };

--- a/src/service.ts
+++ b/src/service.ts
@@ -248,6 +248,19 @@ export function spawnSettingsOverlay(
  * `$SHEPHERD_TOKEN` placeholder + `allowedEnvVars`; Claude Code resolves it from the hook
  * process env (only listed vars are interpolated). With no token (open loopback) we omit the
  * `headers` + `allowedEnvVars` keys entirely, matching the queue route's no-auth path.
+ *
+ * Token + `autonomous` (issue #711, DELIBERATE): under the autonomous membrane `--clearenv`
+ * strips `SHEPHERD_TOKEN`, so `$SHEPHERD_TOKEN` interpolates empty → the ingress listener 401s
+ * → hooks fail-open to polling (today's behaviour). We keep the placeholder rather than baking
+ * the literal token here ON PURPOSE: the hook header rides the ps-visible argv and is readable
+ * from the autonomous agent's own `/proc/self/cmdline`, so baking it would hand a hijacked agent
+ * the control-plane token — defeating the containment the autonomous profile exists to provide.
+ * This is asymmetric with the build-queue curl (buildQueueDirective), which DOES carry the literal
+ * token over the same ingress transport: that exposure is pre-existing, opt-in (only when
+ * `buildQueueEnabled`), and already documented as accepted there. Token-LESS deployments (the
+ * default) are unaffected and reach hooks under autonomous normally. To make token + autonomous
+ * hooks reach, re-inject the token into the sandbox env or accept the literal-in-argv exposure —
+ * intentionally NOT done here.
  */
 export function buildHooksFragment(input: {
   sessionId: string;

--- a/src/service.ts
+++ b/src/service.ts
@@ -38,6 +38,7 @@ import {
   isDegraded,
   isEgressDegraded,
   egressApplies,
+  willEgressConfine,
   wrapArgv,
   buildMembraneFlags,
   safeRealpath,
@@ -49,6 +50,8 @@ import {
 } from "./sandbox";
 import {
   detectEgressBackend as detectRealEgressBackend,
+  detectEgressHostLoopback as detectRealEgressHostLoopback,
+  SLIRP_HOST_GATEWAY,
   egressMembraneOverrideFlags,
   buildEgressAllowlist,
   buildEgressConfig,
@@ -121,6 +124,13 @@ export interface ServiceDeps {
    *  so no real netns/dnsmasq stack is spawned); defaults to the cached real self-test in
    *  egress.ts. Probed only for an autonomous spawn that already has an FS backend. */
   detectEgressBackend?: () => EgressBackend;
+  /** Restricted agent-ingress listener port accessor (lazy: the listener starts after this
+   *  service is constructed; see src/index.ts). Returns undefined when not wired (tests) or not
+   *  yet started; resolveSpawnBaseUrl/prepareSpawn fall back to the loopback main port then. */
+  agentIngressPort?: () => number | undefined;
+  /** slirp host-loopback capability probe seam (tests inject `() => true` / `() => false`); defaults
+   *  to the cached real version probe in egress.ts. Gates reaching Shepherd via 10.0.2.2. */
+  detectEgressHostLoopback?: () => boolean;
   /** Per-session DNS-drop watcher; absent in tests that don't care → no-op. */
   egressWatcher?: Pick<EgressWatcher, "start" | "stop">;
   /** Best-effort pre-teardown hook (recap generation) — runs while the worktree still
@@ -671,6 +681,14 @@ function agentBaseUrl(): string {
 }
 
 /**
+ * Base URL an egress-confined autonomous agent uses to reach Shepherd via the slirp host gateway
+ * (10.0.2.2 → host 127.0.0.1), targeting the RESTRICTED agent-ingress listener, not the main port.
+ */
+function agentEgressBaseUrl(ingressPort: number): string {
+  return `http://${SLIRP_HOST_GATEWAY}:${ingressPort}`;
+}
+
+/**
  * Pick an override value over an original: an `undefined` override inherits the original;
  * any present value (including explicit `null`) replaces it. Mirrors the relaunch override
  * semantics where absent means "keep the original" and present means "use this".
@@ -808,6 +826,44 @@ export class SessionService {
     });
   }
 
+  /** slirp host-loopback capability probe: injected seam (tests) or the real cached version
+   *  probe. Mirrors detectEgressBackend's PRESENCE check (the seam legitimately returns false). */
+  private detectHostLoopback(): boolean {
+    return this.deps.detectEgressHostLoopback
+      ? this.deps.detectEgressHostLoopback()
+      : detectRealEgressHostLoopback();
+  }
+
+  /**
+   * Which control-plane base URL to bake into a spawn's hooks + build-queue calls. Egress-confined
+   * autonomous spawns (willEgressConfine) on a host-loopback-capable slirp, with a known ingress
+   * port, reach the restricted ingress listener via 10.0.2.2; everything else uses the loopback
+   * main port. Shares the SAME predicate + host-loopback probe + ingress-port accessor that
+   * prepareSpawn uses, so the baked URL and the actual wrap/hostGateway decision cannot diverge.
+   */
+  private resolveSpawnBaseUrl(
+    profileOverride: string | null | undefined,
+    repoPath: string,
+  ): string {
+    const profile = resolveProfile(
+      profileOverride,
+      this.deps.store.getRepoConfig(repoPath).sandboxProfile,
+      config.sandboxDefaultProfile,
+    );
+    if (!egressApplies(profile)) return agentBaseUrl(); // no backend probe for trusted/standard
+    const backend = this.detectBackend();
+    const egressBackend = backend !== null ? this.detectEgressBackend() : null;
+    const ingressPort = this.deps.agentIngressPort?.();
+    if (
+      ingressPort != null &&
+      willEgressConfine(profile, backend, egressBackend) &&
+      this.detectHostLoopback()
+    ) {
+      return agentEgressBaseUrl(ingressPort);
+    }
+    return agentBaseUrl();
+  }
+
   /**
    * Auto-gate hold reason for resuming an auto session, or null when allowed. Prefers the
    * profile the session was SPAWNED with (`s.sandboxApplied`) so a per-spawn override is
@@ -911,8 +967,8 @@ export class SessionService {
     const hold = autoHoldReason(profile, backend, egressBackend);
     if (ctx.auto && hold) return { ok: false, holdReason: hold };
     const degraded = isDegraded(profile, backend);
-    // egress WILL wrap iff autonomous + FS backend + egress backend all present.
-    const egressOn = egressApplies(profile) && backend !== null && egressBackend != null;
+    // egress WILL wrap iff autonomous + FS backend + egress backend all present (shared predicate).
+    const egressOn = willEgressConfine(profile, backend, egressBackend ?? null);
     // An interactive autonomous session with the FS membrane but no egress backend ran
     // FS-only (network open) — warrants the egress-degraded banner.
     const egressDegraded = isEgressDegraded(profile, backend, egressBackend ?? null);
@@ -955,7 +1011,15 @@ export class SessionService {
           ...this.deps.store.getRepoConfig(ctx.repoPath).egressExtraHosts,
         ],
       });
-      const cfg = buildEgressConfig(allowlist, { tmpDir: tmp });
+      // Open exactly the restricted agent-ingress listener (host 127.0.0.1:<ingressPort> via the
+      // slirp gateway 10.0.2.2) — and ONLY when the slirp is host-loopback-capable AND a port is
+      // known. SAME gate as resolveSpawnBaseUrl, so the baked URL and this nft rule never diverge.
+      const ingressPort = this.deps.agentIngressPort?.();
+      const hostGateway =
+        this.detectHostLoopback() && ingressPort != null
+          ? { ip: SLIRP_HOST_GATEWAY, port: ingressPort }
+          : undefined;
+      const cfg = buildEgressConfig(allowlist, { tmpDir: tmp, hostGateway });
       writeEgressConfigFiles(tmp, cfg);
       const bwrapArgv = [
         "bwrap",
@@ -1033,6 +1097,7 @@ export class SessionService {
     planGateOn: boolean | undefined,
     isolated: boolean,
     trim: Awaited<ReturnType<typeof trimDecision>>,
+    baseUrl: string,
   ): string[] {
     const repoConfig = this.deps.store.getRepoConfig(input.repoPath);
     const houseRules = this.houseRules(input.repoPath);
@@ -1041,7 +1106,7 @@ export class SessionService {
     const buildQueue = repoConfig.buildQueueEnabled
       ? buildQueueDirective({
           sessionId,
-          baseUrl: agentBaseUrl(),
+          baseUrl,
           token: config.token,
           autopilot: autopilotActive,
         })
@@ -1057,7 +1122,7 @@ export class SessionService {
       "--settings",
       spawnSettingsOverlay({
         ...trim.overlayOpts,
-        hooks: { sessionId, baseUrl: agentBaseUrl(), token: config.token },
+        hooks: { sessionId, baseUrl, token: config.token },
       }),
     );
     argv.push(
@@ -1142,6 +1207,12 @@ export class SessionService {
       // plan. See resolvePlanGateOn for the override + research semantics.
       const planGateOn = this.resolvePlanGateOn(input, repoConfig);
       const trim = await this.trimFor(input.auto);
+      // Research needs OPEN web egress; a research session resolving to autonomous is
+      // downgraded to standard for this spawn (see researchSafeProfileOverride). Resolved BEFORE
+      // buildSpawnArgv so resolveSpawnBaseUrl bakes the URL matching the SAME profile prepareSpawn
+      // will wrap with — buildSpawnArgv doesn't use the override otherwise, so reordering is safe.
+      const profileOverride = this.researchSafeProfileOverride(input, repoConfig, sessionId);
+      const baseUrl = this.resolveSpawnBaseUrl(profileOverride, input.repoPath);
       const argv = this.buildSpawnArgv(
         input,
         claudeSessionId,
@@ -1150,10 +1221,8 @@ export class SessionService {
         planGateOn,
         wt.isolated,
         trim,
+        baseUrl,
       );
-      // Research needs OPEN web egress; a research session resolving to autonomous is
-      // downgraded to standard for this spawn (see researchSafeProfileOverride).
-      const profileOverride = this.researchSafeProfileOverride(input, repoConfig, sessionId);
       // Auto-refuse surfaces as a throw so the create() caller (route 4xx / drain catch) sees it.
       const outcome = this.prepareSpawnOrThrow(argv, {
         sessionId,
@@ -1512,6 +1581,10 @@ export class SessionService {
     // Forced respawn over a live agent: close the stale husk tab first so it doesn't
     // leak alongside the fresh one. (No-op when the agent is already gone.)
     if (agent) this.deps.herdr.stop(agent.terminalId);
+    // Bake the URL matching the SAME profile prepareSpawn resumes with (s.sandboxApplied), so an
+    // egress-confined resume reaches Shepherd via the restricted ingress listener, not the netns
+    // loopback. Uses the identical predicate/probe/port as prepareSpawn below → can't diverge.
+    const baseUrl = this.resolveSpawnBaseUrl(s.sandboxApplied ?? undefined, s.repoPath);
     const innerArgv = [
       "claude",
       "--dangerously-skip-permissions",
@@ -1523,7 +1596,7 @@ export class SessionService {
       "--settings",
       spawnSettingsOverlay({
         ...trim.overlayOpts,
-        hooks: { sessionId: s.id, baseUrl: agentBaseUrl(), token: config.token },
+        hooks: { sessionId: s.id, baseUrl, token: config.token },
       }),
     );
     if (s.model) innerArgv.push("--model", s.model);

--- a/src/service.ts
+++ b/src/service.ts
@@ -1009,42 +1009,16 @@ export class SessionService {
         }
       : ({} as MembraneInputs);
 
-    let wrapped: string[];
-    let egressAllowlist: string[] | undefined;
-    let egressDnsLog: string | undefined;
-    if (egressOn) {
-      // Egress path: write the per-session config artefacts, build the bwrap argv WITH the
-      // egress override binds (between the membrane flags and `--`), then wrap that in the
-      // egress-runner (netns + nft + dnsmasq). wrapArgv can't inject the override flags, so
-      // this case bypasses it.
-      const tmp = egressTmpDir(ctx.sessionId);
-      const allowlist = buildEgressAllowlist({
-        forges: config.forges,
-        extraHosts: [
-          ...config.sandboxEgressExtraHosts,
-          ...this.deps.store.getRepoConfig(ctx.repoPath).egressExtraHosts,
-        ],
-      });
-      // Open exactly the restricted agent-ingress listener (host 127.0.0.1:<ingressPort> via the
-      // slirp gateway 10.0.2.2) — and ONLY when the slirp is host-loopback-capable AND a port is
-      // known. SAME gate as resolveSpawnBaseUrl, so the baked URL and this nft rule never diverge.
-      const hostGateway =
-        this.egressHostGateway(profile, backend, egressBackend ?? null) ?? undefined;
-      const cfg = buildEgressConfig(allowlist, { tmpDir: tmp, hostGateway });
-      writeEgressConfigFiles(tmp, cfg);
-      const bwrapArgv = [
-        "bwrap",
-        ...buildMembraneFlags(membrane),
-        ...egressMembraneOverrideFlags(tmp),
-        "--",
-        ...innerArgv,
-      ];
-      wrapped = wrapEgress(bwrapArgv, tmp);
-      egressAllowlist = allowlist;
-      egressDnsLog = join(tmp, "dns.log");
-    } else {
-      wrapped = wrapArgv(innerArgv, { profile, backend, membrane });
-    }
+    const { wrapped, egressAllowlist, egressDnsLog } = this.wrapSpawnArgv({
+      innerArgv,
+      profile,
+      backend,
+      egressBackend,
+      membrane,
+      egressOn,
+      sessionId: ctx.sessionId,
+      repoPath: ctx.repoPath,
+    });
     // api-key passthrough (trusted, or a sandboxed profile degraded to no-backend):
     // no membrane to mask the credential in place, so point the spawn at the
     // credential-less mirror dir. The membrane case masks creds in place (keeping
@@ -1067,6 +1041,56 @@ export class SessionService {
       degraded,
       egressApplied: egressOn,
       egressDegraded,
+    };
+  }
+
+  /** Build the final spawn argv for an egress-confined run (writes the per-session egress config +
+   *  wraps the membrane bwrap argv in the egress-runner) or the plain membrane wrap otherwise.
+   *  Returns the wrapped argv plus the drop-watcher inputs (allowlist + dns log path) when egress wrapped. */
+  private wrapSpawnArgv(args: {
+    innerArgv: string[];
+    profile: SandboxProfile;
+    backend: SandboxBackend;
+    egressBackend: EgressBackend | undefined;
+    membrane: MembraneInputs;
+    egressOn: boolean;
+    sessionId: string;
+    repoPath: string;
+  }): { wrapped: string[]; egressAllowlist?: string[]; egressDnsLog?: string } {
+    const { innerArgv, profile, backend, egressBackend, membrane, egressOn } = args;
+    if (!egressOn) {
+      return { wrapped: wrapArgv(innerArgv, { profile, backend, membrane }) };
+    }
+    // Egress path: write the per-session config artefacts, build the bwrap argv WITH the
+    // egress override binds (between the membrane flags and `--`), then wrap that in the
+    // egress-runner (netns + nft + dnsmasq). wrapArgv can't inject the override flags, so
+    // this case bypasses it.
+    const tmp = egressTmpDir(args.sessionId);
+    const allowlist = buildEgressAllowlist({
+      forges: config.forges,
+      extraHosts: [
+        ...config.sandboxEgressExtraHosts,
+        ...this.deps.store.getRepoConfig(args.repoPath).egressExtraHosts,
+      ],
+    });
+    // Open exactly the restricted agent-ingress listener (host 127.0.0.1:<ingressPort> via the
+    // slirp gateway 10.0.2.2) — and ONLY when the slirp is host-loopback-capable AND a port is
+    // known. SAME gate as resolveSpawnBaseUrl, so the baked URL and this nft rule never diverge.
+    const hostGateway =
+      this.egressHostGateway(profile, backend, egressBackend ?? null) ?? undefined;
+    const cfg = buildEgressConfig(allowlist, { tmpDir: tmp, hostGateway });
+    writeEgressConfigFiles(tmp, cfg);
+    const bwrapArgv = [
+      "bwrap",
+      ...buildMembraneFlags(membrane),
+      ...egressMembraneOverrideFlags(tmp),
+      "--",
+      ...innerArgv,
+    ];
+    return {
+      wrapped: wrapEgress(bwrapArgv, tmp),
+      egressAllowlist: allowlist,
+      egressDnsLog: join(tmp, "dns.log"),
     };
   }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -834,6 +834,27 @@ export class SessionService {
       : detectRealEgressHostLoopback();
   }
 
+  /** The host-gateway {ip,port} to bake into an egress-confined autonomous spawn's control-plane
+   *  reachability (base URL + the nft allow rule), or null when this spawn must use the loopback
+   *  main port instead. SINGLE source for both the baked base URL (resolveSpawnBaseUrl) and the nft
+   *  host-gateway rule (prepareSpawn), so the two can never drift. Requires: an egress-confined
+   *  autonomous spawn (willEgressConfine) on a host-loopback-capable slirp, with a known ingress port. */
+  private egressHostGateway(
+    profile: SandboxProfile,
+    backend: SandboxBackend,
+    egressBackend: EgressBackend,
+  ): { ip: string; port: number } | null {
+    const ingressPort = this.deps.agentIngressPort?.();
+    if (
+      ingressPort != null &&
+      willEgressConfine(profile, backend, egressBackend) &&
+      this.detectHostLoopback()
+    ) {
+      return { ip: SLIRP_HOST_GATEWAY, port: ingressPort };
+    }
+    return null;
+  }
+
   /**
    * Which control-plane base URL to bake into a spawn's hooks + build-queue calls. Egress-confined
    * autonomous spawns (willEgressConfine) on a host-loopback-capable slirp, with a known ingress
@@ -853,15 +874,8 @@ export class SessionService {
     if (!egressApplies(profile)) return agentBaseUrl(); // no backend probe for trusted/standard
     const backend = this.detectBackend();
     const egressBackend = backend !== null ? this.detectEgressBackend() : null;
-    const ingressPort = this.deps.agentIngressPort?.();
-    if (
-      ingressPort != null &&
-      willEgressConfine(profile, backend, egressBackend) &&
-      this.detectHostLoopback()
-    ) {
-      return agentEgressBaseUrl(ingressPort);
-    }
-    return agentBaseUrl();
+    const gw = this.egressHostGateway(profile, backend, egressBackend);
+    return gw ? agentEgressBaseUrl(gw.port) : agentBaseUrl();
   }
 
   /**
@@ -1014,11 +1028,8 @@ export class SessionService {
       // Open exactly the restricted agent-ingress listener (host 127.0.0.1:<ingressPort> via the
       // slirp gateway 10.0.2.2) — and ONLY when the slirp is host-loopback-capable AND a port is
       // known. SAME gate as resolveSpawnBaseUrl, so the baked URL and this nft rule never diverge.
-      const ingressPort = this.deps.agentIngressPort?.();
       const hostGateway =
-        this.detectHostLoopback() && ingressPort != null
-          ? { ip: SLIRP_HOST_GATEWAY, port: ingressPort }
-          : undefined;
+        this.egressHostGateway(profile, backend, egressBackend ?? null) ?? undefined;
       const cfg = buildEgressConfig(allowlist, { tmpDir: tmp, hostGateway });
       writeEgressConfigFiles(tmp, cfg);
       const bwrapArgv = [

--- a/test/agent-ingress.test.ts
+++ b/test/agent-ingress.test.ts
@@ -3,6 +3,7 @@ import { SessionStore } from "../src/store";
 import { SessionService } from "../src/service";
 import { EventHub } from "../src/events";
 import { isAgentIngressRoute, makeAgentIngressApp, type AppDeps } from "../src/server";
+import { config } from "../src/config";
 
 // A representative per-session UUID — the de-facto capability segment the agent only knows
 // for its own session.
@@ -156,4 +157,45 @@ test("makeAgentIngressApp: an ALLOWED route DELEGATES to the full app (reaches t
   const q = await ok.json();
   expect(q.steps.length).toBe(1);
   expect(q.steps[0].title).toBe("do a thing");
+});
+
+test("makeAgentIngressApp: delegation does NOT bypass checkAuth (token is enforced)", async () => {
+  const deps = makeDeps();
+  const s = await deps.service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "go",
+    model: null,
+    images: [],
+  });
+  const app = makeAgentIngressApp(deps);
+  const prev = config.token;
+  config.token = "secret-token";
+  try {
+    // ALLOWED route, but WITHOUT a valid Authorization header → checkAuth 401s through the gate.
+    const unauthed = await app.fetch(
+      new Request(`http://x/api/sessions/${s.id}/queue`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ steps: [{ title: "do a thing" }] }),
+      }),
+    );
+    expect(unauthed.status).toBe(401);
+    expect(await unauthed.json()).toEqual({ error: "unauthorized" });
+
+    // SAME allowed route WITH the correct bearer token → past checkAuth, reaches the handler.
+    const authed = await app.fetch(
+      new Request(`http://x/api/sessions/${s.id}/queue`, {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          Authorization: "Bearer secret-token",
+        },
+        body: JSON.stringify({ steps: [{ title: "do a thing" }] }),
+      }),
+    );
+    expect(authed.status).not.toBe(401);
+  } finally {
+    config.token = prev;
+  }
 });

--- a/test/agent-ingress.test.ts
+++ b/test/agent-ingress.test.ts
@@ -1,0 +1,159 @@
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { SessionService } from "../src/service";
+import { EventHub } from "../src/events";
+import { isAgentIngressRoute, makeAgentIngressApp, type AppDeps } from "../src/server";
+
+// A representative per-session UUID — the de-facto capability segment the agent only knows
+// for its own session.
+const ID = "11111111-2222-3333-4444-555555555555";
+const SID = "step_abc";
+
+// Helper: split a path the way makeApp/makeAgentIngressApp do.
+const parts = (p: string) => p.split("/").filter(Boolean);
+
+// ── isAgentIngressRoute: exhaustive allow/deny table ────────────────────────────
+test("isAgentIngressRoute: ALLOWS exactly the three agent→server routes", () => {
+  expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/hooks`))).toBe(true);
+  expect(isAgentIngressRoute("PUT", parts(`/api/sessions/${ID}/queue`))).toBe(true);
+  expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/queue/steps/${SID}`))).toBe(true);
+});
+
+test("isAgentIngressRoute: DENIES everything else (containment property)", () => {
+  // The human/autopilot approve gate — NOT an agent action.
+  expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/queue/approve`))).toBe(false);
+  // Spawn a new session = full firewall escape; must never be reachable.
+  expect(isAgentIngressRoute("POST", parts(`/api/sessions`))).toBe(false);
+  // Read/delete a session.
+  expect(isAgentIngressRoute("GET", parts(`/api/sessions/${ID}`))).toBe(false);
+  expect(isAgentIngressRoute("DELETE", parts(`/api/sessions/${ID}`))).toBe(false);
+  // Wrong methods on the allowed paths.
+  expect(isAgentIngressRoute("GET", parts(`/api/sessions/${ID}/hooks`))).toBe(false);
+  expect(isAgentIngressRoute("PUT", parts(`/api/sessions/${ID}/hooks`))).toBe(false);
+  expect(isAgentIngressRoute("GET", parts(`/api/sessions/${ID}/queue`))).toBe(false);
+  expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/queue`))).toBe(false);
+  expect(isAgentIngressRoute("PUT", parts(`/api/sessions/${ID}/queue/steps/${SID}`))).toBe(false);
+  // queue/steps without a step id, or with a trailing extra segment.
+  expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/queue/steps`))).toBe(false);
+  expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/queue/steps/${SID}/x`))).toBe(
+    false,
+  );
+  // hooks with a trailing extra segment.
+  expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/hooks/x`))).toBe(false);
+  // Missing session id.
+  expect(isAgentIngressRoute("POST", parts(`/api/sessions`))).toBe(false);
+  expect(isAgentIngressRoute("PUT", parts(`/api/sessions//queue`))).toBe(false);
+  // Roots + non-/api/sessions paths.
+  expect(isAgentIngressRoute("GET", parts(`/`))).toBe(false);
+  expect(isAgentIngressRoute("GET", parts(`/api/sessions`))).toBe(false);
+  expect(isAgentIngressRoute("GET", parts(`/api/backlog`))).toBe(false);
+  expect(isAgentIngressRoute("POST", parts(`/healthz`))).toBe(false);
+});
+
+// ── makeAgentIngressApp: 404-at-gate vs delegate-to-real-app ────────────────────
+function makeDeps(): AppDeps {
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({ worktreePath: "/wt", branch: "shepherd/x", isolated: true }),
+      ensureBaseRef: async () => {},
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => ({ terminalId: "term_x" }),
+      list: () => [],
+      stop: () => {},
+      send: () => {},
+    } as any,
+    events,
+  });
+  const usageLimits = {
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
+  };
+  return { store, service, events, usageLimits, distiller: { distillNow: () => {} } };
+}
+
+test("makeAgentIngressApp: a DENIED route 404s AT THE GATE (never reaches a handler)", async () => {
+  const deps = makeDeps();
+  // Spawn a session so the route would otherwise be live — proving the 404 is the gate, not a
+  // missing session.
+  const s = await deps.service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "go",
+    model: null,
+    images: [],
+  });
+  const app = makeAgentIngressApp(deps);
+
+  // POST /api/sessions/:id/queue/approve is a real, working route on the full app — but the gate
+  // must 404 it (it's the human gate). Assert containment: the build queue is NOT approved after.
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/queue/approve`, { method: "POST" }),
+  );
+  expect(res.status).toBe(404);
+  expect(await res.json()).toEqual({ error: "not found" });
+  // The handler never ran → not approved.
+  expect(deps.store.getBuildQueue(s.id).approved).toBe(false);
+});
+
+test("makeAgentIngressApp: POST /api/sessions (spawn) is 404'd at the gate (no firewall escape)", async () => {
+  const deps = makeDeps();
+  const app = makeAgentIngressApp(deps);
+  const res = await app.fetch(
+    new Request("http://x/api/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repoPath: "/repo", baseBranch: "main", prompt: "p" }),
+    }),
+  );
+  expect(res.status).toBe(404);
+  expect(await res.json()).toEqual({ error: "not found" });
+});
+
+test("makeAgentIngressApp: an ALLOWED route DELEGATES to the full app (reaches the real handler)", async () => {
+  const deps = makeDeps();
+  const s = await deps.service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "go",
+    model: null,
+    images: [],
+  });
+  const app = makeAgentIngressApp(deps);
+
+  // PUT /api/sessions/:id/queue with an INVALID body reaches putBuildQueue, which validates and
+  // returns 400 "invalid build steps" — a NON-404 sentinel proving delegation past the gate.
+  const bad = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/queue`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ not: "steps" }),
+    }),
+  );
+  expect(bad.status).toBe(400);
+  expect(await bad.json()).toEqual({ error: "invalid build steps" });
+
+  // PUT with a VALID body reaches the handler and mutates the queue (200) — full delegation.
+  const ok = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/queue`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ steps: [{ title: "do a thing" }] }),
+    }),
+  );
+  expect(ok.status).toBe(200);
+  const q = await ok.json();
+  expect(q.steps.length).toBe(1);
+  expect(q.steps[0].title).toBe("do a thing");
+});

--- a/test/egress-runner.test.ts
+++ b/test/egress-runner.test.ts
@@ -27,11 +27,11 @@
  */
 
 import { test, expect, afterEach } from "bun:test";
-import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
-import { buildEgressConfig } from "../src/egress";
+import { buildEgressConfig, SLIRP_HOST_GATEWAY } from "../src/egress";
 import { egressRunnerShouldSkip } from "./egress-runner-gate";
 
 const SCRIPT = join(import.meta.dir, "..", "scripts", "egress-runner.sh");
@@ -69,6 +69,21 @@ const SKIP = egressRunnerShouldSkip({
 function makeTmp(): string {
   const dir = mkdtempSync(join(tmpdir(), "egress-runner-"));
   const cfg = buildEgressConfig(["api.anthropic.com"], { tmpDir: dir });
+  writeFileSync(join(dir, "egress.nft"), cfg.nftRuleset);
+  writeFileSync(join(dir, "dnsmasq.argv"), cfg.dnsmasqArgv.join("\n"));
+  return dir;
+}
+
+/**
+ * Like makeTmp, but the egress.nft INCLUDES the host-gateway allow rule
+ * (10.0.2.2:port), so a curl from inside the netns to that host port is permitted.
+ */
+function makeTmpWithGateway(port: number): string {
+  const dir = mkdtempSync(join(tmpdir(), "egress-runner-gw-"));
+  const cfg = buildEgressConfig(["api.anthropic.com"], {
+    tmpDir: dir,
+    hostGateway: { ip: SLIRP_HOST_GATEWAY, port },
+  });
   writeFileSync(join(dir, "egress.nft"), cfg.nftRuleset);
   writeFileSync(join(dir, "dnsmasq.argv"), cfg.dnsmasqArgv.join("\n"));
   return dir;
@@ -149,7 +164,85 @@ function spawnRunner(inner: string[]) {
   });
 }
 
+/** Spawn the runner against a SPECIFIC tmp dir (already tracked for teardown). */
+function spawnRunnerInDir(dir: string, inner: string[]) {
+  return Bun.spawn([SCRIPT, "--tmp", dir, "--", ...inner], {
+    stdout: "ignore",
+    stderr: "ignore",
+    stdin: "ignore",
+  });
+}
+
+/** True iff `curl` resolves on the host PATH (the gated reachability tests need it). */
+function hostHasCurl(): boolean {
+  return spawnSync("command", ["-v", "curl"], { shell: true }).status === 0;
+}
+
+// ── always-run: the script no longer disables host-loopback ──────────────────────
+
+test("egress-runner.sh permits host-loopback at the slirp level (no --disable-host-loopback)", () => {
+  const src = readFileSync(SCRIPT, "utf8");
+  expect(src).toContain("slirp4netns");
+  expect(src).not.toContain("--disable-host-loopback");
+});
+
 // ── tests (gated) ─────────────────────────────────────────────────────────────────
+
+const SKIP_LIVE_GW = SKIP || !hostHasCurl();
+
+test.skipIf(SKIP_LIVE_GW)(
+  "host-loopback reachability: netns reaches host 127.0.0.1 via 10.0.2.2 when nft allows it",
+  async () => {
+    const server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("ok") });
+    const port = server.port as number;
+    try {
+      // (a) ALLOWED: the gateway rule opens exactly this port → curl succeeds.
+      const dir = makeTmpWithGateway(port);
+      tmpDirs.push(dir);
+      const proc = spawnRunnerInDir(dir, [
+        "bash",
+        "-c",
+        `curl -fsS --max-time 5 -o /dev/null http://${SLIRP_HOST_GATEWAY}:${port}/ ; exit $?`,
+      ]);
+      recorded.push(proc.pid);
+      const { owner, slirp } = await captureChildren(proc.pid);
+      if (owner) recorded.push(owner);
+      if (slirp) recorded.push(slirp);
+      const code = await proc.exited;
+      expect(code).toBe(0);
+    } finally {
+      server.stop(true);
+    }
+  },
+);
+
+test.skipIf(SKIP_LIVE_GW)(
+  "least-privilege: a host port with NO nft rule + NO listener is unreachable from the netns",
+  async () => {
+    // Listener bound to `port`; nft rule opens ONLY `port`. We curl `port + 1`,
+    // which has no listener AND no nft allow → policy-drop rejects it, runner nonzero.
+    const server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("ok") });
+    const port = server.port as number;
+    const blockedPort = port + 1;
+    try {
+      const dir = makeTmpWithGateway(port);
+      tmpDirs.push(dir);
+      const proc = spawnRunnerInDir(dir, [
+        "bash",
+        "-c",
+        `curl -fsS --max-time 5 -o /dev/null http://${SLIRP_HOST_GATEWAY}:${blockedPort}/ ; exit $?`,
+      ]);
+      recorded.push(proc.pid);
+      const { owner, slirp } = await captureChildren(proc.pid);
+      if (owner) recorded.push(owner);
+      if (slirp) recorded.push(slirp);
+      const code = await proc.exited;
+      expect(code).not.toBe(0);
+    } finally {
+      server.stop(true);
+    }
+  },
+);
 
 test.skipIf(SKIP)("propagates the inner exit code (42)", async () => {
   const proc = spawnRunner(["bash", "-c", "echo READY; exit 42"]);

--- a/test/egress.test.ts
+++ b/test/egress.test.ts
@@ -8,6 +8,9 @@ import {
   egressMembraneOverrideFlags,
   detectEgressBackend,
   resetEgressBackendCache,
+  detectEgressHostLoopback,
+  resetEgressHostLoopbackCache,
+  SLIRP_HOST_GATEWAY,
   egressRunnerPath,
   egressTmpDir,
   writeEgressConfigFiles,
@@ -416,6 +419,103 @@ describe("buildEgressConfig", () => {
   test("invalid nftSet throws a clear error", () => {
     expect(() => config({ nftSet: "../../evil; rm -rf /" })).toThrow(/invalid nftSet/);
     expect(() => config({ nftSet: "" })).toThrow(/invalid nftSet/);
+  });
+
+  test("hostGateway: emits one allow rule after @allowed accept, before ipv6 reject", () => {
+    const { nftRuleset } = config({ hostGateway: { ip: SLIRP_HOST_GATEWAY, port: 7330 } });
+    expect(nftRuleset).toContain("ip daddr 10.0.2.2 tcp dport 7330 accept");
+    const idxRule = nftRuleset.indexOf("ip daddr 10.0.2.2 tcp dport 7330 accept");
+    const idxAllowed = nftRuleset.indexOf("ip daddr @allowed accept");
+    const idxIpv6 = nftRuleset.indexOf("meta nfproto ipv6 reject");
+    expect(idxAllowed).toBeGreaterThan(-1);
+    expect(idxRule).toBeGreaterThan(idxAllowed);
+    expect(idxRule).toBeLessThan(idxIpv6);
+  });
+
+  test("hostGateway absent: ruleset has no host gateway and is byte-identical to no-hostGateway", () => {
+    const withGw = config({ hostGateway: { ip: SLIRP_HOST_GATEWAY, port: 7330 } });
+    const without = config();
+    expect(without.nftRuleset).not.toContain("10.0.2.2");
+    // Default config (no hostGateway) must be unchanged vs. an explicitly-omitted one.
+    expect(config({}).nftRuleset).toBe(without.nftRuleset);
+    expect(withGw.nftRuleset).not.toBe(without.nftRuleset);
+  });
+
+  test("hostGateway: invalid port throws a clear error", () => {
+    for (const port of [0, -1, 70000, 1.5]) {
+      expect(() => config({ hostGateway: { ip: SLIRP_HOST_GATEWAY, port } })).toThrow(
+        /invalid hostGateway\.port/,
+      );
+    }
+  });
+});
+
+// ── detectEgressHostLoopback ─────────────────────────────────────────────────
+
+describe("detectEgressHostLoopback", () => {
+  beforeEach(() => {
+    resetEgressHostLoopbackCache();
+  });
+
+  test("true for 'slirp4netns version 1.3.3'", () => {
+    expect(detectEgressHostLoopback({ versionOutput: () => "slirp4netns version 1.3.3" })).toBe(
+      true,
+    );
+  });
+
+  test("true for exactly the floor '1.0.0'", () => {
+    expect(detectEgressHostLoopback({ versionOutput: () => "1.0.0" })).toBe(true);
+  });
+
+  test("false for below-floor 'slirp4netns version 0.4.7'", () => {
+    expect(detectEgressHostLoopback({ versionOutput: () => "slirp4netns version 0.4.7" })).toBe(
+      false,
+    );
+  });
+
+  test("numeric (not string) comparison: '1.10.0' >= '1.0.0' => true", () => {
+    expect(detectEgressHostLoopback({ versionOutput: () => "1.10.0" })).toBe(true);
+  });
+
+  test("false for null capture", () => {
+    expect(detectEgressHostLoopback({ versionOutput: () => null })).toBe(false);
+  });
+
+  test("false for unparseable garbage", () => {
+    expect(detectEgressHostLoopback({ versionOutput: () => "no version here" })).toBe(false);
+  });
+
+  test("never throws even when versionOutput throws", () => {
+    expect(() =>
+      detectEgressHostLoopback({
+        versionOutput: () => {
+          throw new Error("spawn ENOENT");
+        },
+      }),
+    ).not.toThrow();
+    resetEgressHostLoopbackCache();
+    expect(
+      detectEgressHostLoopback({
+        versionOutput: () => {
+          throw new Error("spawn ENOENT");
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("caches result: second call ignores new deps", () => {
+    let calls = 0;
+    expect(
+      detectEgressHostLoopback({
+        versionOutput: () => {
+          calls++;
+          return "1.3.3";
+        },
+      }),
+    ).toBe(true);
+    // Second call with a would-be-false dep still returns the cached true and does not re-probe.
+    expect(detectEgressHostLoopback({ versionOutput: () => "0.4.7" })).toBe(true);
+    expect(calls).toBe(1);
   });
 });
 

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -7,6 +7,7 @@ import {
   isDegraded,
   isEgressDegraded,
   egressApplies,
+  willEgressConfine,
   EGRESS_UNAVAILABLE_REASON,
   buildMembraneFlags,
   wrapArgv,
@@ -16,6 +17,7 @@ import {
   type MembraneInputs,
 } from "../src/sandbox";
 import { resolveNodeBin } from "../src/node-bin";
+import type { EgressBackend } from "../src/egress";
 
 // A deterministic MembraneInputs for flag-construction tests. exists is
 // injected so the host never influences the output.
@@ -193,6 +195,34 @@ describe("egressApplies", () => {
   test("false for trusted and standard", () => {
     expect(egressApplies("trusted")).toBe(false);
     expect(egressApplies("standard")).toBe(false);
+  });
+});
+
+describe("willEgressConfine", () => {
+  test("autonomous + bwrap + slirp4netns => true (fully confined)", () => {
+    expect(willEgressConfine("autonomous", "bwrap", "slirp4netns")).toBe(true);
+  });
+
+  test("autonomous + bwrap + null egressBackend => false (no egress backend)", () => {
+    expect(willEgressConfine("autonomous", "bwrap", null)).toBe(false);
+  });
+
+  test("autonomous + null backend + slirp4netns => false (no FS backend)", () => {
+    expect(willEgressConfine("autonomous", null, "slirp4netns")).toBe(false);
+  });
+
+  test("autonomous + bwrap + undefined egressBackend => false (loose-null check treats undefined as null)", () => {
+    expect(willEgressConfine("autonomous", "bwrap", undefined as unknown as EgressBackend)).toBe(
+      false,
+    );
+  });
+
+  test("standard + both backends present => false (egressApplies is false for standard)", () => {
+    expect(willEgressConfine("standard", "bwrap", "slirp4netns")).toBe(false);
+  });
+
+  test("trusted + both backends present => false (egressApplies is false for trusted)", () => {
+    expect(willEgressConfine("trusted", "bwrap", "slirp4netns")).toBe(false);
   });
 });
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -6,6 +6,7 @@ import {
   readdirSync,
   existsSync,
   utimesSync,
+  rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -3884,4 +3885,145 @@ test("relaunch keeps research:true; explicit override flips it to false", async 
 
   const flipped = await service.relaunch(orig.id, undefined, { research: false });
   expect(flipped.research).toBe(false);
+});
+
+// ── agent base-URL selection (issue #711 Task 4) ────────────────────────────────
+// The URL baked into a spawn's hooks (and build-queue) calls: an egress-confined autonomous
+// spawn on a host-loopback-capable slirp with a known ingress port reaches Shepherd via the
+// restricted ingress listener at 10.0.2.2:<ingressPort>; everything else uses the loopback main
+// port. config.hooksIngest must be ON for the overlay to emit the hooks URL.
+function baseUrlService(opts: {
+  store: SessionStore;
+  record: { argv?: string[] };
+  detectBackend?: () => "bwrap" | null;
+  detectEgressBackend?: () => "slirp4netns" | null;
+  detectEgressHostLoopback?: () => boolean;
+  agentIngressPort?: () => number | undefined;
+}) {
+  return new SessionService({
+    store: opts.store,
+    namer: async () => "s",
+    worktree: {
+      create: () => ({ worktreePath: "/wt/s", branch: "shepherd/s", isolated: true }),
+      remove: () => {},
+      gitCommonDir: () => "/wt/s/.git",
+      ensureBaseRef: async () => {},
+    } as any,
+    herdr: {
+      start: (_name: string, cwd: string, argv: string[]) => {
+        opts.record.argv = argv;
+        return { terminalId: "term_x", cwd } as any;
+      },
+      list: () => [],
+      stop: () => {},
+      send: () => {},
+    } as any,
+    detectBackend: opts.detectBackend,
+    detectEgressBackend: opts.detectEgressBackend,
+    detectEgressHostLoopback: opts.detectEgressHostLoopback,
+    agentIngressPort: opts.agentIngressPort,
+  });
+}
+
+// Pull the hooks endpoint URL baked into the `--settings` JSON of a captured spawn argv.
+function hooksUrlFrom(argv: string[] | undefined): string {
+  const i = argv?.indexOf("--settings") ?? -1;
+  if (i < 0) throw new Error("no --settings in argv");
+  const settings = JSON.parse(argv![i + 1] ?? "{}") as any;
+  return settings.hooks.PostToolUse[0].hooks[0].url;
+}
+
+test("baseUrl: egress-confined autonomous on host-loopback slirp → hooks via 10.0.2.2:<ingressPort>", async () => {
+  const prev = config.hooksIngest;
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig("/repo", { ...store.getRepoConfig("/repo"), sandboxProfile: "autonomous" });
+  const record: { argv?: string[] } = {};
+  const service = baseUrlService({
+    store,
+    record,
+    detectBackend: () => "bwrap",
+    detectEgressBackend: () => "slirp4netns",
+    detectEgressHostLoopback: () => true,
+    agentIngressPort: () => 7331,
+  });
+  try {
+    config.hooksIngest = true;
+    const s = await service.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "go",
+      model: null,
+      images: [],
+    });
+    expect(hooksUrlFrom(record.argv)).toBe(`http://10.0.2.2:7331/api/sessions/${s.id}/hooks`);
+  } finally {
+    config.hooksIngest = prev;
+    rmSync(join(tmpdir(), "shepherd-egress"), { recursive: true, force: true });
+  }
+});
+
+test("baseUrl: autonomous but slirp NOT host-loopback-capable → falls back to loopback main port", async () => {
+  const prev = config.hooksIngest;
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig("/repo", { ...store.getRepoConfig("/repo"), sandboxProfile: "autonomous" });
+  const record: { argv?: string[] } = {};
+  const service = baseUrlService({
+    store,
+    record,
+    detectBackend: () => "bwrap",
+    detectEgressBackend: () => "slirp4netns",
+    detectEgressHostLoopback: () => false,
+    agentIngressPort: () => 7331,
+  });
+  try {
+    config.hooksIngest = true;
+    const s = await service.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "go",
+      model: null,
+      images: [],
+    });
+    expect(hooksUrlFrom(record.argv)).toBe(
+      `http://127.0.0.1:${config.port}/api/sessions/${s.id}/hooks`,
+    );
+  } finally {
+    config.hooksIngest = prev;
+    rmSync(join(tmpdir(), "shepherd-egress"), { recursive: true, force: true });
+  }
+});
+
+test("baseUrl: trusted (default) → loopback main port, no backend probe required", async () => {
+  const prev = config.hooksIngest;
+  const store = new SessionStore(":memory:");
+  const record: { argv?: string[] } = {};
+  let probed = false;
+  const service = baseUrlService({
+    store,
+    record,
+    // If resolveSpawnBaseUrl probed the backend for a trusted spawn this would flip — it must not.
+    detectBackend: () => {
+      probed = true;
+      return "bwrap";
+    },
+    detectEgressHostLoopback: () => true,
+    agentIngressPort: () => 7331,
+  });
+  try {
+    config.hooksIngest = true;
+    const s = await service.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "go",
+      model: null,
+      images: [],
+    });
+    expect(hooksUrlFrom(record.argv)).toBe(
+      `http://127.0.0.1:${config.port}/api/sessions/${s.id}/hooks`,
+    );
+    // resolveSpawnBaseUrl returned early for the trusted profile (no backend probe).
+    expect(probed).toBe(false);
+  } finally {
+    config.hooksIngest = prev;
+  }
 });


### PR DESCRIPTION
Closes #711.

## Problem
Under the `autonomous` sandbox profile the agent runs in a slirp4netns network namespace, where `127.0.0.1` is the *namespace* loopback — not the host's. So the injected push hooks (#704/#708) and the build-queue curl, both baked with `http://127.0.0.1:<port>`, can't reach Shepherd there and silently fall back to polling — exactly where (unattended drain) push signals help most.

## Fix (least-privilege, fail-open, no exfil widening)
The agent→Shepherd control-plane channel is made reachable from inside the autonomous netns via the slirp host gateway `10.0.2.2` (→ host `127.0.0.1`). Covers **both** hooks and the build-queue curl (one `agentBaseUrl` source).

1. **Reachability.** `scripts/egress-runner.sh` drops `--disable-host-loopback` so the netns can route to host loopback at `10.0.2.2`; `buildEgressConfig` emits exactly one nft allow rule `ip daddr 10.0.2.2 tcp dport <ingress-port> accept`. Everything else stays `policy drop`.
2. **Containment — the crux.** `isAuthorized` returns `true` when no token is set (the default), and slirp NATs the netns→`10.0.2.2` connection to host `127.0.0.1` (indistinguishable from a real loopback client). Allowlisting the **main** port would hand a contained agent the entire control plane (`POST /api/sessions` → spawn a `trusted` host-net session = full firewall escape). Instead the netns reaches a **separate, route-restricted ingress listener** (`serveAgentIngress`, bound to `127.0.0.1` only) that serves **only** `POST .../hooks`, `PUT .../queue`, `POST .../queue/steps/:id` (404s everything else, incl. `POST /api/sessions` and `/queue/approve`) and **delegates** allowed routes through the full app so `checkAuth` + `checkOrigin` still apply. The per-session UUID in each path is the de-facto per-session capability (the agent only knows its own; no enumeration route). The main control-plane port is never in the nft allowlist — a hijacked autonomous agent cannot spawn/halt/merge.
3. **No-drift invariant.** The baked base URL and the nft host-gateway rule derive from one source (`egressHostGateway` over the shared `willEgressConfine` predicate + cached `detectEgressHostLoopback` + the `agentIngressPort` accessor), so they cannot diverge.
4. **Fail-open + loud.** Too-old slirp4netns (`detectEgressHostLoopback` version probe < 1.0.0) → fall back to the loopback URL (polling), never a refusal; an interactive autonomous spawn without an egress backend still degrades (banner), only auto spawns refuse (unchanged). The self-test probe loads the host-gateway rule shape so a rule-load failure is caught at detection, not as a late spawn abort.
5. **Token handling.** `buildHooksFragment` is unchanged: token-less deployments (the default) work fully; deployments **with** a token keep the `$SHEPHERD_TOKEN` placeholder, which the membrane's `--clearenv` strips → 401 → fail-open to polling under autonomous. No literal token is baked into argv (preserves containment for token deployments).

## Verification
- New tests: nft rule presence/ordering + byte-identity when absent; slirp version-probe matrix; `willEgressConfine` truth table; `isAgentIngressRoute` exhaustive allow/deny (incl. `POST /api/sessions` + `/queue/approve` 404 at the gate, with no side effect); ingress delegation preserves `checkAuth` (401 without token); base-URL selection (`10.0.2.2:<ingress>` confined vs `127.0.0.1:<main>` otherwise); gated real-machinery test for `10.0.2.2` reachability + least-privilege blocked-port control.
- The host-loopback transport was manually verified end-to-end on the dev host (slirp4netns 1.3.3): a host listener on `127.0.0.1` is reachable through `10.0.2.2` when the nft rule opens that port (curl exit 0), and an un-ruled port is policy-dropped (curl exit 7).
- Gates: root `bun test` (0 fail), `tsc --noEmit`, `bun run lint`, and `fallow audit --base origin/main --fail-on-issues` all green.

Server-only transport plumbing — no user-facing UX. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)