### PR TITLE
fix(tmp-sweep): reap stale fallow caches + prune orphaned worktree records

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ import { tailLines } from "./blocked";
 import { CountsService } from "./backlog";
 import { BacklogPoller } from "./backlog-poller";
 import { ProcessReaper } from "./process-reaper";
-import { sweepClaudeTmp, compileCacheDir } from "./tmp-sweep";
+import { sweepClaudeTmp, compileCacheDir, reapFallowCaches, pruneRepoWorktrees } from "./tmp-sweep";
 import { PreviewService } from "./preview";
 import { listRepos, listReposPathForReal } from "./repos";
 import { DistillerService, defaultScratch } from "./distiller";
@@ -274,9 +274,10 @@ try {
 }
 
 // Inode-guard sweep: drops the compile cache + stale scratch once /tmp inode pressure
-// crosses the threshold. Fire-and-forget — sweepClaudeTmp never rejects; runDailySweep is
-// synchronous, so the daily caller must not await it either.
-const fireTmpSweep = (phase: "boot" | "daily") =>
+// crosses the threshold. Also unconditionally reaps stale fallow caches and prunes
+// orphaned git worktree records. Fire-and-forget — none of these ever reject;
+// runDailySweep is synchronous, so the daily caller must not await them either.
+const fireTmpSweep = (phase: "boot" | "daily") => {
   void sweepClaudeTmp()
     .then((r) => {
       if (r.swept)
@@ -285,6 +286,19 @@ const fireTmpSweep = (phase: "boot" | "daily") =>
         );
     })
     .catch((err) => console.warn(`[tmp-sweep] ${phase} sweep failed:`, err));
+
+  void reapFallowCaches()
+    .then(({ removed }) =>
+      pruneRepoWorktrees(listRepos(config.repoRoot).map((r) => r.path)).then(
+        ({ pruned, failed }) => {
+          console.warn(
+            `[tmp-sweep] ${phase}: fallow reap removed ${removed}, worktree prune pruned ${pruned}${failed ? `, failed ${failed}` : ""}`,
+          );
+        },
+      ),
+    )
+    .catch((err) => console.warn(`[tmp-sweep] ${phase} fallow/prune failed:`, err));
+};
 
 fireTmpSweep("boot");
 

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -1,6 +1,10 @@
 import { promises as fsp, type Dirent } from "node:fs";
+import { execFile } from "node:child_process";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Centralizes the "claude tmp directory" geometry and a threshold-gated inode-guard
@@ -142,13 +146,45 @@ async function inodeUsePct(
 const REGENERABLE_CACHE = /^(bunx-|fallow-|agent-browser-)/;
 
 /**
+ * Name prefix for fallow's audit-base worktree caches: `fallow-audit-base-cache-<srcHash>-<shaHash>`.
+ * Each `git worktree prune` pre-push creates one; they accumulate until reaped.
+ */
+export const FALLOW_CACHE_PREFIX = "fallow-audit-base-cache-";
+
+/**
+ * Shared helper: age-gate a single known-regenerable-cache dir by its own top-level mtime and
+ * `rm -rf` it if stale. Returns 1 if removed, 0 if kept. Fail-closed: a stat or rm failure is
+ * logged and counted as 0 (never miscounted as success). Does NOT remove sidecar files — callers
+ * that need sidecar cleanup (e.g. `reapFallowCaches`) must do so themselves.
+ */
+async function removeIfStale(
+  p: string,
+  st: { mtimeMs: number | bigint },
+  ctx: Pick<SweepCtx, "now" | "staleMs" | "log"> & { ops: Pick<FsOps, "rm"> },
+): Promise<number> {
+  // Deliberately the top-level entry's own mtime, not a recursive
+  // newest-descendant walk — don't "fix" this into a sync/expensive tree traversal.
+  if (ctx.now - Number(st.mtimeMs) > ctx.staleMs) {
+    try {
+      await ctx.ops.rm(p, { recursive: true, force: true });
+      return 1;
+    } catch (err) {
+      ctx.log(`[tmp-sweep] failed to remove ${p}: ${String(err)}`);
+      return 0;
+    }
+  }
+  return 0;
+}
+
+/**
  * Handles ONE directory entry, returning the count removed (0 or 1). Fail-closed per-entry:
  * its own try/catch surfaces a removal failure in the log and continues, so a bad entry NEVER
  * aborts the sweep and is never miscounted as success. The cases:
  *  - `node-compile-cache` — pure V8 compile cache, dropped wholesale regardless of age.
  *  - the nested `claude-$uid` root — never wholesale-removed (its children are swept when it is
  *    itself the sweep root); skipped here.
- *  - a known regenerable cache (see `REGENERABLE_CACHE`) — age-gated by its top-level mtime.
+ *  - a known regenerable cache (see `REGENERABLE_CACHE`) — age-gated by its top-level mtime via
+ *    `removeIfStale`.
  *  - anything else (per-session/unknown scratch) — LEFT in place; never wholesale-removed by
  *    this sweep (reclaimed via `removeWorktreeScratch` on archival instead).
  */
@@ -165,15 +201,9 @@ async function sweepEntry(dir: string, ent: Dirent, ctx: SweepCtx): Promise<numb
     if (!REGENERABLE_CACHE.test(ent.name)) return 0;
 
     const st = await ctx.ops.stat(p);
-    // Deliberately the top-level entry's own mtime, not a recursive
-    // newest-descendant walk — don't "fix" this into a sync/expensive tree traversal.
-    if (ctx.now - st.mtimeMs > ctx.staleMs) {
-      await ctx.ops.rm(p, { recursive: true, force: true });
-      return 1;
-    }
-    return 0;
+    return removeIfStale(p, st, ctx);
   } catch (err) {
-    // Fail-closed per-entry: a removal that fails is surfaced in the log and
+    // Fail-closed per-entry: a stat or wholesale-rm failure is surfaced in the log and
     // skipped — it NEVER aborts the sweep and is never miscounted as success.
     ctx.log(`[tmp-sweep] failed to remove ${p}: ${String(err)}`);
     return 0;
@@ -268,4 +298,143 @@ export async function removeWorktreeScratch(
   } catch {
     /* best-effort */
   }
+}
+
+interface ReapFallowOpts {
+  staleMs?: number;
+  now?: number;
+  fsOps?: Pick<FsOps, "readdir" | "stat" | "rm">;
+  log?: (msg: string) => void;
+}
+
+export interface ReapFallowResult {
+  removed: number;
+}
+
+/** Shared context threaded through the fallow reaper helpers. */
+interface ReapFallowCtx {
+  ops: Pick<FsOps, "readdir" | "stat" | "rm">;
+  now: number;
+  staleMs: number;
+  log: (msg: string) => void;
+}
+
+/**
+ * Handles ONE fallow-cache directory entry. Skips sidecar files (`.lock`/`.last-used` —
+ * cleaned up alongside their parent) and any name not starting with `FALLOW_CACHE_PREFIX`.
+ * For eligible entries: stats the path, age-gates via `removeIfStale`, and on removal
+ * best-effort removes `${p}.lock` and `${p}.last-used`. Per-entry try/catch — never
+ * aborts the pass, never rejects. Returns 1 if the dir was removed, 0 otherwise.
+ */
+async function reapFallowEntry(root: string, ent: Dirent, ctx: ReapFallowCtx): Promise<number> {
+  // Skip sidecar files (.lock / .last-used) — cleaned up with their parent dir.
+  if (!ent.name.startsWith(FALLOW_CACHE_PREFIX)) return 0;
+  if (ent.name.endsWith(".lock") || ent.name.endsWith(".last-used")) return 0;
+
+  const p = join(root, ent.name);
+  try {
+    const st = await ctx.ops.stat(p);
+    const wasRemoved = await removeIfStale(p, st, ctx);
+    if (wasRemoved) {
+      // Best-effort removal of sidecars; ignore individual failures.
+      await ctx.ops.rm(`${p}.lock`, { recursive: false, force: true }).catch(() => {});
+      await ctx.ops.rm(`${p}.last-used`, { recursive: false, force: true }).catch(() => {});
+      return 1;
+    }
+    return 0;
+  } catch (err) {
+    ctx.log(`[tmp-sweep] fallow reap failed for ${p}: ${String(err)}`);
+    return 0;
+  }
+}
+
+/**
+ * Reaps one root directory: readdirs it (skipping missing/unreadable roots silently) then
+ * sums `reapFallowEntry` over every entry. Returns the count of dirs removed.
+ */
+async function reapFallowRoot(root: string, ctx: ReapFallowCtx): Promise<number> {
+  let entries: Dirent[];
+  try {
+    entries = (await ctx.ops.readdir(root, { withFileTypes: true })) as Dirent[];
+  } catch {
+    // Missing/unreadable root — skip it silently.
+    return 0;
+  }
+  let removed = 0;
+  for (const ent of entries) removed += await reapFallowEntry(root, ent, ctx);
+  return removed;
+}
+
+/**
+ * Ungated reaper for stale `fallow-audit-base-cache-*` worktree cache dirs. Runs regardless of
+ * inode pressure — decoupled from the `sweepClaudeTmp` threshold gate.
+ *
+ * Scans the deduped set of roots `[claudeTmpRoot(), join(claudeTmpRoot(), "claude-"+uid()),
+ * tmpdir()]` (the third catches caches whose `TMPDIR` was the bare system `/tmp`). Only considers
+ * entries whose name starts with `FALLOW_CACHE_PREFIX`; ignores `.lock`/`.last-used` sidecar
+ * files (they are cleaned up alongside their parent dir). For each stale cache dir it removes the
+ * dir AND `${dir}.lock` AND `${dir}.last-used`. Per-entry try/catch — never aborts the pass,
+ * never rejects. Returns `{ removed }`.
+ */
+export async function reapFallowCaches(opts?: ReapFallowOpts): Promise<ReapFallowResult> {
+  const log = opts?.log ?? console.warn;
+  const staleMs = opts?.staleMs ?? envNum(process.env.SHEPHERD_TMP_STALE_HOURS, 24) * 3600_000;
+  const now = opts?.now ?? Date.now();
+  const ops: Pick<FsOps, "readdir" | "stat" | "rm"> = opts?.fsOps ?? {
+    readdir: fsp.readdir,
+    stat: fsp.stat,
+    rm: fsp.rm,
+  };
+
+  // Dedupe roots: claudeTmpRoot(), claude-$uid subdir, and bare tmpdir() for caches whose
+  // TMPDIR was the system default. Using a Set so a reconfigured env can't double-scan.
+  const claudeRoot = claudeTmpRoot();
+  const nestedRoot = join(claudeRoot, `claude-${uid()}`);
+  const systemTmp = tmpdir();
+  const roots = [...new Set([claudeRoot, nestedRoot, systemTmp])];
+
+  const ctx: ReapFallowCtx = { ops, now, staleMs, log };
+  let removed = 0;
+  for (const root of roots) removed += await reapFallowRoot(root, ctx);
+
+  return { removed };
+}
+
+interface PruneOpts {
+  /** Injectable git-exec hook for tests. Receives the same args as `git -C <repo> worktree prune`. */
+  execGit?: (repo: string, args: string[]) => Promise<void>;
+  log?: (msg: string) => void;
+}
+
+export interface PruneResult {
+  pruned: number;
+  failed: number;
+}
+
+/**
+ * Runs `git worktree prune` for each supplied repo path. Unconditional — prunes every
+ * orphaned record (missing working dir) regardless of how the dir vanished (reboot,
+ * tmpfiles, manual rm). Per-repo try/catch: a failing repo is logged and skipped; the
+ * rest still run. Never rejects. Returns `{ pruned, failed }`.
+ */
+export async function pruneRepoWorktrees(
+  repoPaths: string[],
+  opts?: PruneOpts,
+): Promise<PruneResult> {
+  const log = opts?.log ?? console.warn;
+  const execGit =
+    opts?.execGit ?? ((repo: string, args: string[]) => execFileAsync("git", args).then(() => {}));
+
+  let pruned = 0;
+  let failed = 0;
+  for (const repo of repoPaths) {
+    try {
+      await execGit(repo, ["-C", repo, "worktree", "prune"]);
+      pruned += 1;
+    } catch (err) {
+      log(`[tmp-sweep] git worktree prune failed for ${repo}: ${String(err)}`);
+      failed += 1;
+    }
+  }
+  return { pruned, failed };
 }

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -429,7 +429,12 @@ export async function pruneRepoWorktrees(
   let failed = 0;
   for (const repo of repoPaths) {
     try {
-      await execGit(repo, ["-C", repo, "worktree", "prune"]);
+      // `--expire=now` makes the immediate-prune intent explicit. A bare `git worktree prune`
+      // already defaults to `--expire=TIME_MAX` (prune every orphaned record regardless of age),
+      // but `gc.worktreePruneExpire` (default 3.months.ago) governs the prune that automatic
+      // `git gc` runs — so being explicit here keeps reaped records (deleted at ~24h) from being
+      // misread as subject to that 3-month window.
+      await execGit(repo, ["-C", repo, "worktree", "prune", "--expire=now"]);
       pruned += 1;
     } catch (err) {
       log(`[tmp-sweep] git worktree prune failed for ${repo}: ${String(err)}`);

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -520,8 +520,8 @@ describe("pruneRepoWorktrees", () => {
     expect(res.pruned).toBe(2);
     expect(res.failed).toBe(0);
     expect(calls).toHaveLength(2);
-    expect(calls.at(0)?.args).toEqual(["-C", "/repo/a", "worktree", "prune"]);
-    expect(calls.at(1)?.args).toEqual(["-C", "/repo/b", "worktree", "prune"]);
+    expect(calls.at(0)?.args).toEqual(["-C", "/repo/a", "worktree", "prune", "--expire=now"]);
+    expect(calls.at(1)?.args).toEqual(["-C", "/repo/b", "worktree", "prune", "--expire=now"]);
   });
 
   test("a failing repo does not abort the others", async () => {

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -1,8 +1,16 @@
 import { test, expect, describe, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync, existsSync } from "node:fs";
+import * as fsp from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { worktreeScratchDir, sweepClaudeTmp, removeWorktreeScratch } from "../src/tmp-sweep";
+import {
+  worktreeScratchDir,
+  sweepClaudeTmp,
+  removeWorktreeScratch,
+  reapFallowCaches,
+  pruneRepoWorktrees,
+  FALLOW_CACHE_PREFIX,
+} from "../src/tmp-sweep";
 
 const uid = (): number => process.getuid?.() ?? 1000;
 const nested = `claude-${uid()}`;
@@ -326,5 +334,215 @@ describe("removeWorktreeScratch", () => {
         },
       }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("reapFallowCaches", () => {
+  test("removes a stale fallow dir and its .lock / .last-used sidecars", async () => {
+    const root = mkTmp();
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", root);
+
+    const name = `${FALLOW_CACHE_PREFIX}abc123`;
+    const dir = join(root, name);
+    mkdirSync(dir);
+    writeFileSync(`${dir}.lock`, "");
+    writeFileSync(`${dir}.last-used`, "");
+
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+    utimesSync(dir, old, old);
+
+    const res = await reapFallowCaches({ now, staleMs: 24 * 3600_000, fsOps: fsp, log: () => {} });
+
+    expect(res.removed).toBe(1);
+    expect(existsSync(dir)).toBe(false);
+    expect(existsSync(`${dir}.lock`)).toBe(false);
+    expect(existsSync(`${dir}.last-used`)).toBe(false);
+  });
+
+  test("keeps a fresh fallow dir", async () => {
+    const root = mkTmp();
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", root);
+
+    const name = `${FALLOW_CACHE_PREFIX}fresh`;
+    const dir = join(root, name);
+    mkdirSync(dir);
+
+    const res = await reapFallowCaches({
+      now: Date.now(),
+      staleMs: 24 * 3600_000,
+      fsOps: fsp,
+      log: () => {},
+    });
+
+    expect(res.removed).toBe(0);
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  test("ignores non-fallow dirs", async () => {
+    const root = mkTmp();
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", root);
+
+    const otherDir = join(root, "bunx-1000-something");
+    mkdirSync(otherDir);
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+    utimesSync(otherDir, old, old);
+
+    const res = await reapFallowCaches({
+      now,
+      staleMs: 24 * 3600_000,
+      fsOps: fsp,
+      log: () => {},
+    });
+
+    expect(res.removed).toBe(0);
+    expect(existsSync(otherDir)).toBe(true);
+  });
+
+  test("ignores .lock and .last-used sidecar entries in the scan", async () => {
+    // Even if a .lock / .last-used entry matches the prefix after stripping, they must not
+    // be treated as primary cache dirs — the reaper skips them; they're removed alongside
+    // their parent, not independently.
+    const root = mkTmp();
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", root);
+
+    // Create only sidecars, no parent dir (orphaned sidecars).
+    writeFileSync(join(root, `${FALLOW_CACHE_PREFIX}orphan.lock`), "");
+    writeFileSync(join(root, `${FALLOW_CACHE_PREFIX}orphan.last-used`), "");
+
+    const res = await reapFallowCaches({
+      now: Date.now(),
+      staleMs: 24 * 3600_000,
+      fsOps: fsp,
+      log: () => {},
+    });
+
+    // sidecars are skipped, so removed count stays 0; the sidecar files themselves stay
+    expect(res.removed).toBe(0);
+  });
+
+  test("scans the bare tmpdir() root", async () => {
+    // Simulate a stale fallow cache landing in the system tmpdir (TMPDIR was system default
+    // during the push). We create it under a test-controlled root set as SHEPHERD_TMP_SWEEP_DIR
+    // but also verify tmpdir() is in the scan roots by using the real tmpdir.
+    const sysTmp = tmpdir();
+    const name = `${FALLOW_CACHE_PREFIX}systmp-test-${Math.random().toString(36).slice(2)}`;
+    const dir = join(sysTmp, name);
+    mkdirSync(dir);
+    dirs.push(dir); // cleaned up in afterEach
+
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+    utimesSync(dir, old, old);
+
+    // Point SHEPHERD_TMP_SWEEP_DIR to a fresh temp dir that has NO fallow caches,
+    // so only the systmp root can supply the removed count.
+    const cleanRoot = mkTmp();
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", cleanRoot);
+
+    const res = await reapFallowCaches({
+      now,
+      staleMs: 24 * 3600_000,
+      fsOps: fsp,
+      log: () => {},
+    });
+
+    expect(res.removed).toBeGreaterThanOrEqual(1);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  test("runs without a statfs/inode gate", async () => {
+    // reapFallowCaches must work even when statfs would be unavailable (no fsOps.statfs).
+    const root = mkTmp();
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", root);
+
+    const name = `${FALLOW_CACHE_PREFIX}ungated`;
+    const dir = join(root, name);
+    mkdirSync(dir);
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+    utimesSync(dir, old, old);
+
+    // Only provide readdir/stat/rm — no statfs property at all.
+    const res = await reapFallowCaches({
+      now,
+      staleMs: 24 * 3600_000,
+      fsOps: { readdir: fsp.readdir, stat: fsp.stat, rm: fsp.rm },
+      log: () => {},
+    });
+
+    expect(res.removed).toBe(1);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  test("never rejects; per-entry errors are swallowed", async () => {
+    const root = mkTmp();
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", root);
+
+    const name = `${FALLOW_CACHE_PREFIX}bad`;
+    const dir = join(root, name);
+    mkdirSync(dir);
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+    utimesSync(dir, old, old);
+
+    const res = await reapFallowCaches({
+      now,
+      staleMs: 24 * 3600_000,
+      fsOps: {
+        readdir: fsp.readdir,
+        stat: fsp.stat,
+        rm: async () => {
+          throw new Error("EACCES");
+        },
+      },
+      log: () => {},
+    });
+
+    // rm threw, so nothing removed — but we did not reject
+    expect(res.removed).toBe(0);
+  });
+});
+
+describe("pruneRepoWorktrees", () => {
+  test("invokes git -C <repo> worktree prune once per repo", async () => {
+    const calls: Array<{ repo: string; args: string[] }> = [];
+    const fakeExecGit = async (repo: string, args: string[]) => {
+      calls.push({ repo, args });
+    };
+
+    const res = await pruneRepoWorktrees(["/repo/a", "/repo/b"], {
+      execGit: fakeExecGit,
+      log: () => {},
+    });
+
+    expect(res.pruned).toBe(2);
+    expect(res.failed).toBe(0);
+    expect(calls).toHaveLength(2);
+    expect(calls.at(0)?.args).toEqual(["-C", "/repo/a", "worktree", "prune"]);
+    expect(calls.at(1)?.args).toEqual(["-C", "/repo/b", "worktree", "prune"]);
+  });
+
+  test("a failing repo does not abort the others", async () => {
+    const calls: string[] = [];
+    const fakeExecGit = async (repo: string) => {
+      if (repo === "/repo/bad") throw new Error("not a git repo");
+      calls.push(repo);
+    };
+
+    const res = await pruneRepoWorktrees(["/repo/bad", "/repo/good"], {
+      execGit: fakeExecGit,
+      log: () => {},
+    });
+
+    expect(res.pruned).toBe(1);
+    expect(res.failed).toBe(1);
+    expect(calls).toEqual(["/repo/good"]);
+  });
+
+  test("never rejects; empty list returns zeroes", async () => {
+    const res = await pruneRepoWorktrees([], { execGit: async () => {}, log: () => {} });
+    expect(res).toEqual({ pruned: 0, failed: 0 });
   });
 });


### PR DESCRIPTION
## Problem

`bunx fallow audit` (run in `.husky/pre-push`) creates throwaway base-snapshot git worktrees named `fallow-audit-base-cache-*` under `$TMPDIR`, each registered against the repo's gitdir. They accumulate without bound: **207 worktrees / ~2.2 GB** observed locally, **185 of them orphaned `.git/worktrees/<name>` records** whose cache dir was already gone.

### Would they get cleaned up eventually? Only partially, and slowly.
- The `/tmp` **dirs** largely self-clear — `/tmp` is tmpfs (empties on reboot) and `systemd-tmpfiles` clears entries idle >10d.
- The git **admin records** are the real slow leak: git only auto-prunes a missing-dir record during an automatic `git gc`, after `gc.worktreePruneExpire` (**default 3 months**). An *explicit* `git worktree prune` clears them immediately — but nothing was running one.

So `git worktree list` stayed polluted for up to ~3 months while disk churned through a ~10-day window of multi-GB caches.

## Fix

A boot + daily sweep in `src/tmp-sweep.ts`, wired into the existing `fireTmpSweep`, **decoupled from the inode gate** (which only fires ≥80% `/tmp` inode use — currently ~41%, so it never ran):

- **`reapFallowCaches`** — ungated; removes `fallow-audit-base-cache-*` dirs (+ their `.lock`/`.last-used` sidecars) idle >24h (`SHEPHERD_TMP_STALE_HOURS`), scanning all three `$TMPDIR` families. Narrow prefix match; per-entry fail-closed; never rejects.
- **`pruneRepoWorktrees`** — unconditionally runs `git -C <repo> worktree prune` for every repo from `listRepos(config.repoRoot)`. This is the core fix: it clears records orphaned by reboot/tmpfiles/manual rm that a dir-present-only reaper can't see. `git worktree prune` only ever drops records whose worktree dir is genuinely missing, so it cannot disturb a live worktree.

The existing `sweepEntry` age-gate/rm logic was factored into a shared `removeIfStale` helper (no behavior change to the inode-gated path).

### Empirically verified (fallow 2.96.0)
- A base cache is created only when the base-snapshot attribution pass runs (a real diff vs base) — not on every audit.
- Sidecars are `.lock` / `.last-used`; `.last-used` is **not** refreshed on a cache hit, so age-gating uses the dir's own mtime.

## Testing
- `test/tmp-sweep.test.ts`: +10 tests (stale removed + sidecars, fresh kept, non-fallow untouched, sidecar entries skipped, bare-`tmpdir()` scanned, ungated, never-rejects; prune arg correctness, failing-repo isolation, empty list). Existing `sweepClaudeTmp` tests stay green as a regression guard for the extraction.
- Full root suite: **3339 pass / 0 fail**. `lint`, `tsc --noEmit`, and `fallow audit` clean.

Server-only plumbing — no UI/i18n/feature-catalog impact (`[no-feature-entry]`).

> Note: the local pileup was already cleaned up out-of-band (207 → 22 worktrees, ~2.2 GB reclaimed); this PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
