### PR TITLE
feat(gitrail): manual critic-review trigger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1204,6 +1204,7 @@ const appDeps: AppDeps = {
     reviewing: () => planGate.reviewingIds(),
   },
   planGate: { consider: (s) => planGate.consider(s) },
+  reviewTrigger: { force: (s, g) => reviewService.forceReview(s, g) },
   recapCache: { snapshot: () => recapService.snapshot() },
   recap: { regenerate: (s) => recapService.regenerate(s) },
   herdDigest: {

--- a/src/review.ts
+++ b/src/review.ts
@@ -40,6 +40,10 @@ import { config } from "./config";
 // service reuses them). Re-exported here so existing importers (and tests) keep their paths.
 export { reviewPrompt, defaultComputePatchId, scopeFindings, CRITIC_THINKING_TOKENS };
 
+/** Outcome of a consider()/forceReview() call: a critic was spawned, the run was declined
+ *  (preconditions unmet / dedup / ceiling / race guard), or begin() bailed before spawning. */
+export type ReviewOutcome = "started" | "skipped" | "error";
+
 /** Agent-facing steer that carries critic findings into the task PTY. NOT i18n'd. */
 function steerText(findings: string[], prNumber: number): string {
   return [
@@ -245,14 +249,23 @@ export class ReviewService {
     this.readUsage = deps.readUsage ?? readSessionUsage;
   }
 
-  /** Decide whether `git` warrants a fresh critic run for `session`, and start one. */
-  async consider(session: Session, git: GitState): Promise<void> {
-    if (git.state !== "open" || git.checks !== "success" || !git.headSha || !git.number) return;
-    if (!session.branch) return;
-    if (!this.deps.store.getRepoConfig(session.repoPath).criticEnabled) return;
-    if (this.inflight.has(session.id) || this.starting.has(session.id)) return; // in flight / mid-spawn
+  /** Decide whether `git` warrants a fresh critic run for `session`, and start one. With
+   *  `opts.force` (the operator's manual re-review via forceReview) the same-head dedup,
+   *  the spawn ceiling, and the patch-id churn-skip are bypassed — but the hard preconditions
+   *  (PR open + CI green + critic enabled + not already running) still gate. */
+  async consider(
+    session: Session,
+    git: GitState,
+    opts?: { force?: boolean },
+  ): Promise<ReviewOutcome> {
+    const force = opts?.force === true;
+    if (git.state !== "open" || git.checks !== "success" || !git.headSha || !git.number)
+      return "skipped";
+    if (!session.branch) return "skipped";
+    if (!this.deps.store.getRepoConfig(session.repoPath).criticEnabled) return "skipped";
+    if (this.inflight.has(session.id) || this.starting.has(session.id)) return "skipped"; // in flight / mid-spawn
     const prior = this.deps.store.getReview(session.id);
-    if (prior?.headSha === git.headSha) return; // head already reviewed
+    if (!force && prior?.headSha === git.headSha) return "skipped"; // head already reviewed
     // Per-streak spawn ceiling: review token spend is unbounded otherwise (consider() would
     // spawn a critic on every new CI-green head forever). Cap *findings-bearing* reviews per
     // outstanding-findings streak at 2*cap (the live cap, derived inline — a persisted
@@ -271,22 +284,31 @@ export class ReviewService {
     // can exceed 2*cap while errors interleave — bounded by errorRound + the human it escalates
     // to, not by this gate.
     //
-    // RE-ENGAGEMENT CLIFF: a PR paused one round short of clean stays paused. The only
-    // resume paths are a clean verdict that lands while still under budget (won't happen
-    // once paused — we don't re-spawn) or a human archiving the session (forget() →
-    // dropReview clears the row, resetting the streak). There is deliberately no in-PR
-    // "re-request review" action; crossing the ceiling means the critic gives up here.
-    if (prior && prior.findings.length > 0 && prior.streakReviews >= 2 * this.cap) return;
+    // RE-ENGAGEMENT CLIFF: a PR paused one round short of clean stays paused on the AUTO path.
+    // Crossing the ceiling halts only auto re-spawns here — the resume paths are a clean verdict
+    // that lands while still under budget (won't happen once paused — we don't auto re-spawn), a
+    // human archiving the session (forget() → dropReview clears the row, resetting the streak),
+    // or an operator manually re-engaging via forceReview (which resets the streak as hygiene so
+    // the next auto consider() re-engages too). `force` here is that manual path bypassing the
+    // ceiling for one run.
+    if (!force && prior && prior.findings.length > 0 && prior.streakReviews >= 2 * this.cap)
+      return "skipped";
     // Claim the slot synchronously, BEFORE begin()'s await, so a concurrent consider bails.
     this.starting.add(session.id);
     try {
-      await this.begin(session, git);
+      await this.begin(session, git, force);
     } finally {
       this.starting.delete(session.id);
     }
+    // begin() populates `inflight` only when it actually spawned a critic; its silent early
+    // returns (worktree/spawn fail, api-key-mode-without-key, post-await `starting` tombstone,
+    // or a non-force rebaseSkip churn-skip) leave it unset → "error". The auto caller ignores
+    // this return, so the non-force churn-skip "error" is irrelevant there; it's authoritative
+    // only for the manual/force path.
+    return this.inflight.has(session.id) ? "started" : "error";
   }
 
-  private async begin(session: Session, git: GitState): Promise<void> {
+  private async begin(session: Session, git: GitState, force: boolean): Promise<void> {
     // The prior verdict (an earlier head — consider() never re-reviews the same head)
     // carries this streak's accountability state: its findings get fed to the critic
     // to verify they were addressed, and its addressRound bounds the auto-address loop.
@@ -308,6 +330,7 @@ export class ReviewService {
       git,
       prior,
       wt.worktreePath,
+      force,
     );
     if (skipped) return;
     // The base the critic diffs against == the base the fingerprint (and file set) used —
@@ -418,6 +441,37 @@ export class ReviewService {
     this.deps.onReviewing?.(session.id, true);
   }
 
+  /** Operator-initiated (re)start of a critic review for `session`, bypassing the auto path's
+   *  same-head dedup, spawn ceiling, and patch-id churn-skip. Aborts a hung in-flight run first. */
+  async forceReview(session: Session, git: GitState): Promise<ReviewOutcome> {
+    // 1. mid-spawn window: can't safely abort begin()'s async fetch; operator retries.
+    if (this.starting.has(session.id)) return "skipped";
+    // 2. in-flight: abort it, but NOT if tick()'s finalize() already owns the teardown+verdict.
+    const f = this.inflight.get(session.id);
+    if (f) {
+      if (f.finalizing) return "skipped";
+      reapRun(this.deps.herdr.stop, this.deps.worktree.remove, f.terminalId, f.worktreePath);
+      this.deps.onReviewing?.(session.id, false);
+      this.inflight.delete(session.id);
+    }
+    // 3. escalation/streak HYGIENE on the prior verdict (NOT the re-trigger lever — rebaseSkip's
+    //    force bypass is): reset errorRound so finalize() doesn't immediately re-fire the
+    //    consecutive-error stall signal, and reset the streak so the next AUTO consider()
+    //    re-engages instead of re-hitting the ceiling. Preserve outstanding-work state the critic
+    //    must re-verify.
+    const prior = this.deps.store.getReview(session.id);
+    if (prior) {
+      this.deps.store.putReview({
+        ...prior,
+        errorRound: 0,
+        streakReviews: 0,
+        reviewedPatchIds: [],
+      });
+    }
+    // 4. one code path:
+    return this.consider(session, git, { force: true });
+  }
+
   /**
    * Rebase-skip: dedup on WHAT the critic reviews (the branch diff `base...HEAD`), not on
    * the head SHA. A rebase/force-push moves the SHA but leaves the branch's own diff
@@ -448,14 +502,19 @@ export class ReviewService {
     git: GitState,
     prior: ReviewVerdict | null,
     worktreePath: string,
+    force: boolean,
   ): Promise<{ patchId: string; baseSha: string | null; files: string[]; skipped: boolean }> {
     // Threads the fresh base SHA + changed-file set through alongside the fingerprint (all from
     // ONE computePatchId resolution) so the critic prompt and the buildVerdict backstop key off
-    // the same base the skip decision did. Skip logic itself is unchanged — keyed on patchId only.
+    // the same base the skip decision did. The fingerprint is always computed; only the skip
+    // short-circuit is suppressed under `force` — this is the lever that makes an operator's
+    // manual re-review of an unchanged head actually RUN. `shouldSkipForPatchId` matches via its
+    // `prior.patchId === patchId` OR-branch for any non-error prior, so clearing reviewedPatchIds
+    // alone would not prevent the skip; bypassing the decision under force is what works.
     const res = await this.computePatchId(worktreePath, session.baseBranch);
     const { baseSha, files } = res;
     const patchId = res.patchId ?? "";
-    if (shouldSkipForPatchId(prior, patchId)) {
+    if (!force && shouldSkipForPatchId(prior, patchId)) {
       this.deps.store.bumpReviewHead(session.id, git.headSha!, this.now());
       this.deps.worktree.remove(worktreePath);
       return { patchId, baseSha, files, skipped: true };

--- a/src/server.ts
+++ b/src/server.ts
@@ -220,6 +220,11 @@ export interface AppDeps {
   planGate?: {
     consider(session: Session): Promise<import("./plan-gate").PlanReviewTrigger>;
   };
+  /** Operator-initiated critic review (the POST /review-pr route). Wired to
+   *  ReviewService.forceReview in index.ts; absent in tests that don't exercise it. */
+  reviewTrigger?: {
+    force(session: Session, git: GitState): Promise<import("./review").ReviewOutcome>;
+  };
   /** Snapshot of session recaps keyed by session id; absent in tests that skip it. */
   recapCache?: { snapshot(): Record<string, import("./types").Recap> };
   /** Force-regenerate a session recap on demand (the /recap/regenerate route). */
@@ -1274,6 +1279,26 @@ async function handleSessionReviewPlan({ req, parts, deps }: Ctx): Promise<Respo
   return json({ ok: true, status }, 202);
 }
 
+// POST /api/sessions/:id/review-pr — operator-initiated (re)start of the critic review.
+// 404 unknown id; 404 when the repo has no forge; 502 on a forge error; 202 with
+// {status} = "started" | "skipped" | "error" so the UI can explain the outcome (fail-closed:
+// "skipped"/"error" must never read as success). forceReview itself enforces the CI-green /
+// open / critic-enabled / not-already-running preconditions and returns "skipped" when unmet.
+async function handleSessionReviewPr({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(req.method === "POST" && parts[2] && parts[3] === "review-pr")) return null;
+  const s = deps.store.get(parts[2]);
+  if (!s) return json({ error: "not found" }, 404);
+  const forge = deps.resolveForge?.(s.repoPath) ?? null;
+  if (!forge) return json({ error: "no forge for this repo" }, 404);
+  try {
+    const git = await resolveGitState(forge, s, deps);
+    const status = (await deps.reviewTrigger?.force(s, git)) ?? "skipped";
+    return json({ ok: true, status }, 202);
+  } catch (e) {
+    return json({ error: e instanceof Error ? e.message : "forge error" }, 502);
+  }
+}
+
 // POST /api/sessions/:id/recap/regenerate — force-regenerate the session recap on demand.
 // 404 unknown id; 202 with {status} = "started" | "empty" | "error" so the UI can explain the outcome.
 // NOTE: unlike the auto-fire sweep (which skips drain sessions), on-demand regenerate is
@@ -1734,6 +1759,7 @@ async function handleSessions(ctx: Ctx): Promise<Response | null> {
     handleSessionReply,
     handleSessionGo,
     handleSessionReviewPlan,
+    handleSessionReviewPr,
     handleSessionRecapRegenerate,
     handlePreviewStart,
     handlePreviewStop,
@@ -1829,17 +1855,16 @@ async function dispatchForgeAction(
   return null;
 }
 
-/**
- * GET /api/sessions/:id/git — the session's current PR status, with the same trust
- * logic as the background poller (trustsTerminal): keep a genuinely-merged/closed PR
- * when the session is merge-train-flagged or the cache already owned this PR, else
- * drop a reused-branch-name collision to "none" so GitRail and the list overview agree.
- */
-async function forgeGitStateResponse(
+// Compute the session's live, trust-guarded PR GitState — the same trust logic the
+// background poller uses (trustsTerminal): keep a genuinely-merged/closed PR when the
+// session is merge-train-flagged or the cache already owned this PR, else drop a
+// reused-branch-name collision to "none". Shared by the GET /git route and the
+// POST /review-pr route so both observe the identical value.
+async function resolveGitState(
   forge: GitForge,
   session: Session,
   deps: AppDeps,
-): Promise<Response> {
+): Promise<GitState> {
   const me = (await forge.currentUser?.()) ?? null;
   const git: GitState = annotateHandoff(
     { kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) },
@@ -1853,9 +1878,23 @@ async function forgeGitStateResponse(
     session.mergingSince != null,
     session.mergingPrNumber ?? null,
   );
-  return json(
-    trusted ? git : guardStaleTerminal(git, (headSha) => deps.ownsPr?.(session, headSha) ?? null),
-  );
+  return trusted
+    ? git
+    : guardStaleTerminal(git, (headSha) => deps.ownsPr?.(session, headSha) ?? null);
+}
+
+/**
+ * GET /api/sessions/:id/git — the session's current PR status, with the same trust
+ * logic as the background poller (trustsTerminal): keep a genuinely-merged/closed PR
+ * when the session is merge-train-flagged or the cache already owned this PR, else
+ * drop a reused-branch-name collision to "none" so GitRail and the list overview agree.
+ */
+async function forgeGitStateResponse(
+  forge: GitForge,
+  session: Session,
+  deps: AppDeps,
+): Promise<Response> {
+  return json(await resolveGitState(forge, session, deps));
 }
 
 async function handleSessionGit(ctx: Ctx): Promise<Response | null> {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1912,3 +1912,131 @@ test("inflightWorktrees: returns worktree path after consider() spawns a review"
   await svc.consider(session(), OPEN_GREEN);
   expect(svc.inflightWorktrees()).toEqual(["/review-wt"]);
 });
+
+// ── forceReview (operator-initiated manual re-review) ───────────────────────────
+
+test("forceReview LEVER: re-reviews an unchanged head (same patch-id) that consider() skips", async () => {
+  // The regression guard for the actual re-trigger lever (§4): a non-error prior verdict whose
+  // patchId equals the current head's computed patch-id. force must SPAWN — proving rebaseSkip
+  // did NOT skip because force bypassed shouldSkipForPatchId. NOT reliant on streak/error resets.
+  const mk = () =>
+    makeDeps({ computePatchId: async () => ({ patchId: "pid-same", baseSha: "b", files: ["f"] }) });
+
+  // control: same head + matching patch-id via the AUTO path → skipped, no spawn.
+  const ctl = mk();
+  ctl.reviews["s1"] = priorReview({ patchId: "pid-same", headSha: "abc" }); // OPEN_GREEN.headSha
+  const ctlSvc = new ReviewService(ctl.deps as any);
+  const ctlOutcome = await ctlSvc.consider(session(), OPEN_GREEN);
+  expect(ctlOutcome).toBe("skipped");
+  expect(ctl.started).toHaveLength(0);
+
+  // forceReview: same setup → bypasses the patch-id skip → spawns.
+  const f = mk();
+  f.reviews["s1"] = priorReview({ patchId: "pid-same", headSha: "abc" });
+  const svc = new ReviewService(f.deps as any);
+  const outcome = await svc.forceReview(session(), OPEN_GREEN);
+  expect(outcome).toBe("started");
+  expect(f.started).toHaveLength(1);
+  expect(svc.reviewingIds()).toEqual(["s1"]);
+});
+
+test("forceReview: aborts an in-flight run (finalizing=false), reaps it, then respawns", async () => {
+  const events: { id: string; reviewing: boolean }[] = [];
+  const {
+    deps: d,
+    started,
+    stopped,
+    removed,
+  } = makeDeps({
+    onReviewing: (id: string, reviewing: boolean) => events.push({ id, reviewing }),
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN); // now in-flight (terminal "rt", worktree /review-wt)
+  expect(svc.reviewingIds()).toEqual(["s1"]);
+  const outcome = await svc.forceReview(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(outcome).toBe("started");
+  // old run reaped: its terminal stopped + worktree removed; onReviewing(false) emitted
+  expect(stopped).toContain("rt");
+  expect(removed).toContain("/review-wt");
+  expect(events).toContainEqual({ id: "s1", reviewing: false });
+  // fresh run spawned (a second herdr.start) and is in-flight again
+  expect(started).toHaveLength(2);
+  expect(svc.reviewingIds()).toEqual(["s1"]);
+});
+
+test("forceReview: finalizing in-flight run → skipped, does NOT reap (tick owns teardown)", async () => {
+  const { deps: d, started, stopped, removed } = makeDeps({});
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  // tick()'s finalize already owns this run's teardown + verdict.
+  (svc as any).inflight.get("s1").finalizing = true;
+  const outcome = await svc.forceReview(session(), { ...OPEN_GREEN, headSha: "newsha" });
+  expect(outcome).toBe("skipped");
+  expect(stopped).toEqual([]); // not reaped — finalize() owns it
+  expect(removed).toEqual([]);
+  expect(started).toHaveLength(1); // no respawn
+});
+
+test("forceReview: mid-spawn (starting) → skipped", async () => {
+  const { deps: d, started } = makeDeps({});
+  const svc = new ReviewService(d as any);
+  (svc as any).starting.add("s1");
+  const outcome = await svc.forceReview(session(), OPEN_GREEN);
+  expect(outcome).toBe("skipped");
+  expect(started).toHaveLength(0);
+});
+
+test("forceReview: preconditions still gate → skipped (CI not green)", async () => {
+  const { deps: d, started } = makeDeps({});
+  const svc = new ReviewService(d as any);
+  expect(await svc.forceReview(session(), { ...OPEN_GREEN, checks: "pending" })).toBe("skipped");
+  expect(started).toHaveLength(0);
+});
+
+test("forceReview: preconditions still gate → skipped (PR not open)", async () => {
+  const { deps: d, started } = makeDeps({});
+  const svc = new ReviewService(d as any);
+  expect(await svc.forceReview(session(), { ...OPEN_GREEN, state: "merged" })).toBe("skipped");
+  expect(started).toHaveLength(0);
+});
+
+test("forceReview: preconditions still gate → skipped (critic disabled)", async () => {
+  const { deps: d, started } = makeDeps({});
+  d.store.getRepoConfig = () => ({ criticEnabled: false, autoAddressEnabled: false });
+  const svc = new ReviewService(d as any);
+  expect(await svc.forceReview(session(), OPEN_GREEN)).toBe("skipped");
+  expect(started).toHaveLength(0);
+});
+
+test("forceReview: begin() bails (spawn throws) → error, worktree cleaned up", async () => {
+  const { deps: d, removed } = makeDeps({});
+  d.herdr.start = () => {
+    throw new Error("spawn failed");
+  };
+  const svc = new ReviewService(d as any);
+  const outcome = await svc.forceReview(session(), OPEN_GREEN);
+  expect(outcome).toBe("error");
+  expect(removed).toEqual(["/review-wt"]); // probe worktree reaped on the bail
+  expect(svc.reviewingIds()).toEqual([]); // nothing left in-flight
+});
+
+test("forceReview HYGIENE: resets errorRound/streak/reviewedPatchIds on the prior verdict", async () => {
+  const { deps: d, reviews } = makeDeps({});
+  const svc = new ReviewService(d as any);
+  reviews["s1"] = priorReview({
+    headSha: "abc",
+    errorRound: 2,
+    streakReviews: 5,
+    reviewedPatchIds: ["pid-x", "pid-y"],
+    findings: ["still outstanding"],
+    addressRound: 1,
+  });
+  await svc.forceReview(session(), OPEN_GREEN);
+  // hygiene resets persisted via putReview, applied before the force re-review runs
+  expect(reviews["s1"]?.errorRound).toBe(0);
+  expect(reviews["s1"]?.streakReviews).toBe(0);
+  expect(reviews["s1"]?.reviewedPatchIds).toEqual([]);
+  // outstanding-work state the critic must re-verify is preserved
+  expect(reviews["s1"]?.findings).toEqual(["still outstanding"]);
+  expect(reviews["s1"]?.addressRound).toBe(1);
+});

--- a/test/server-review-pr.test.ts
+++ b/test/server-review-pr.test.ts
@@ -1,0 +1,202 @@
+import { test, expect } from "bun:test";
+import { makeApp, type AppDeps } from "../src/server";
+import type { SessionStore } from "../src/store";
+import type { SessionService } from "../src/service";
+import type { EventHub } from "../src/events";
+import type { Session } from "../src/types";
+import type { GitForge, GitState, PrStatus } from "../src/forge/types";
+import type { PrCache } from "../src/pr-poller";
+import type { ReviewOutcome } from "../src/review";
+
+const ORIGIN = "http://localhost";
+
+const SESSION: Session = {
+  id: "s1",
+  desig: "TASK-01",
+  name: "Add feature",
+  prompt: "Add the feature",
+  repoPath: "/repo",
+  baseBranch: "main",
+  branch: "shepherd/add-feature",
+  worktreePath: "/wt",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "a1",
+  claudeSessionId: "c1",
+  model: null,
+  readyToMerge: false,
+  mergingSince: null,
+  mergingTrainId: null,
+  mergeTrainPrs: null,
+  mergingPrNumber: null,
+  autopilotEnabled: null,
+  autopilotStepCount: 0,
+  autopilotPaused: false,
+  autopilotComplete: false,
+  autopilotQuestion: null,
+  planGateEnabled: null,
+  planPhase: null,
+  autoMergeEnabled: null,
+  autoMergeRebaseCount: 0,
+  autoMergeRebaseHead: null,
+  auto: false,
+  issueNumber: null,
+  sandboxApplied: null,
+  sandboxDegraded: false,
+  egressApplied: false,
+  egressDegraded: false,
+  research: false,
+  status: "running",
+  lastState: "working",
+  createdAt: 0,
+  updatedAt: 0,
+  archivedAt: null,
+};
+
+function fakeForge(over: Partial<GitForge> = {}): GitForge & { log: string[] } {
+  const log: string[] = [];
+  const base: GitForge = {
+    kind: "gitea",
+    slug: "team/proj",
+    mergeMethod: "squash",
+    deployWorkflow: "deploy.yaml",
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus: async (head) => {
+      log.push(`status:${head}`);
+      return { state: "open", number: 5, checks: "success", deployConfigured: true } as PrStatus;
+    },
+    openPr: async () => ({ state: "open", number: 5, checks: "pending", deployConfigured: true }),
+    merge: async () => {},
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    defaultBranch: async () => "main",
+  };
+  return Object.assign(base, over, { log });
+}
+
+function makeDeps(
+  forge: GitForge | null,
+  session: Session | null = SESSION,
+  reviewTrigger?: AppDeps["reviewTrigger"],
+): AppDeps {
+  const store: Partial<SessionStore> = {
+    get: (id) => (session && id === session.id ? session : null),
+    getRepoConfig: () => ({}) as any,
+  };
+  const snap: Record<string, GitState> = {};
+  const prCache: PrCache = {
+    snapshot: () => snap,
+    get: (id: string) => snap[id],
+    set: () => {},
+    drop: () => {},
+  };
+  return {
+    store: store as SessionStore,
+    service: {} as SessionService,
+    events: { emit: () => {} } as unknown as EventHub,
+    usageLimits: { limits: () => ({}) } as never,
+    resolveForge: () => forge,
+    prCache,
+    reviewTrigger,
+  };
+}
+
+function post(path: string): Request {
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", Origin: ORIGIN },
+  });
+}
+
+test("POST review-pr → 404 for unknown id (force not called)", async () => {
+  let called = false;
+  const app = makeApp(
+    makeDeps(fakeForge(), SESSION, {
+      force: async () => {
+        called = true;
+        return "started";
+      },
+    }),
+  );
+  const res = await app.fetch(post("/api/sessions/nope/review-pr"));
+  expect(res.status).toBe(404);
+  expect(called).toBe(false);
+});
+
+test("POST review-pr → 404 when no forge for repo", async () => {
+  const app = makeApp(makeDeps(null));
+  const res = await app.fetch(post("/api/sessions/s1/review-pr"));
+  expect(res.status).toBe(404);
+});
+
+test("POST review-pr → 202 relays status:started, calls force once with session + resolved GitState", async () => {
+  const calls: { session: Session; git: GitState }[] = [];
+  const app = makeApp(
+    makeDeps(fakeForge(), SESSION, {
+      force: async (session, git) => {
+        calls.push({ session, git });
+        return "started";
+      },
+    }),
+  );
+  const res = await app.fetch(post("/api/sessions/s1/review-pr"));
+  expect(res.status).toBe(202);
+  expect(await res.json()).toEqual({ ok: true, status: "started" });
+  expect(calls.length).toBe(1);
+  expect(calls[0]!.session.id).toBe("s1");
+  // resolved GitState carries the live forge prStatus + kind
+  expect(calls[0]!.git.kind).toBe("gitea");
+  expect(calls[0]!.git.state).toBe("open");
+  expect(calls[0]!.git.number).toBe(5);
+});
+
+test("POST review-pr → 202 relays status:skipped", async () => {
+  const app = makeApp(
+    makeDeps(fakeForge(), SESSION, {
+      force: async () => "skipped" as ReviewOutcome,
+    }),
+  );
+  const res = await app.fetch(post("/api/sessions/s1/review-pr"));
+  expect(res.status).toBe(202);
+  expect(await res.json()).toEqual({ ok: true, status: "skipped" });
+});
+
+test("POST review-pr → 202 status:skipped when reviewTrigger absent", async () => {
+  const app = makeApp(makeDeps(fakeForge()));
+  const res = await app.fetch(post("/api/sessions/s1/review-pr"));
+  expect(res.status).toBe(202);
+  expect(await res.json()).toEqual({ ok: true, status: "skipped" });
+});
+
+test("POST review-pr → 502 when forge prStatus throws", async () => {
+  const f = fakeForge({
+    prStatus: async () => {
+      throw new Error("forge boom");
+    },
+  });
+  const app = makeApp(
+    makeDeps(f, SESSION, {
+      force: async () => "started",
+    }),
+  );
+  const res = await app.fetch(post("/api/sessions/s1/review-pr"));
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toContain("forge boom");
+});
+
+test("GET /api/sessions/:id/review-pr falls through (handler claims POST only)", async () => {
+  let called = false;
+  const app = makeApp(
+    makeDeps(fakeForge(), SESSION, {
+      force: async () => {
+        called = true;
+        return "started";
+      },
+    }),
+  );
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/review-pr"));
+  // not a registered GET route → 404 (handler returned null, no other claims it)
+  expect(res.status).toBe(404);
+  expect(called).toBe(false);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1403,5 +1403,13 @@
   "clonerepo_repos_unavailable": "Deine GitHub-Repositories konnten nicht geladen werden. Klone unten per URL.",
   "clonerepo_url_toggle": "Stattdessen per URL klonen",
   "feat_clone_repo_picker_title": "Repo zum Klonen auswählen",
-  "feat_clone_repo_picker_body": "Der Klon-Dialog listet jetzt alle GitHub-Repos auf, auf die du Zugriff hast — deinen eigenen Account sowie die Orgs und Teams, denen du angehörst — und klont das ausgewählte direkt. Bereits geklonte Repos werden ausgeblendet, und das Klonen per URL bleibt als Rückfalloption erhalten."
+  "feat_clone_repo_picker_body": "Der Klon-Dialog listet jetzt alle GitHub-Repos auf, auf die du Zugriff hast — deinen eigenen Account sowie die Orgs und Teams, denen du angehörst — und klont das ausgewählte direkt. Bereits geklonte Repos werden ausgeblendet, und das Klonen per URL bleibt als Rückfalloption erhalten.",
+  "gitrail_review": "Prüfen",
+  "gitrail_rereview": "Erneut prüfen",
+  "gitrail_restart_review": "Neu starten",
+  "gitrail_confirm_review": "bestätigen ✓",
+  "gitrail_review_skipped": "Prüfung nicht gestartet – Bedingungen geändert oder läuft bereits.",
+  "gitrail_review_failed": "Prüfung konnte nicht gestartet werden. Erneut versuchen.",
+  "feat_manual_critic_review_title": "Kritiker-Review neu starten",
+  "feat_manual_critic_review_body": "Wenn der KI-Kritiker nie startete oder ohne Urteil hängen blieb, kannst du ihn über eine Schaltfläche in der PR-Leiste bei Bedarf neu starten – für offene PRs mit grünem CI."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1403,5 +1403,13 @@
   "clonerepo_repos_unavailable": "Couldn't list your GitHub repositories. Clone by URL below.",
   "clonerepo_url_toggle": "Clone by URL instead",
   "feat_clone_repo_picker_title": "Pick a repo to clone",
-  "feat_clone_repo_picker_body": "The clone dialog now lists every GitHub repo you can reach — your own account plus the orgs and teams you belong to — and clones the one you pick directly. Already-cloned repos are hidden, and clone-by-URL is still there as a fallback."
+  "feat_clone_repo_picker_body": "The clone dialog now lists every GitHub repo you can reach — your own account plus the orgs and teams you belong to — and clones the one you pick directly. Already-cloned repos are hidden, and clone-by-URL is still there as a fallback.",
+  "gitrail_review": "Review",
+  "gitrail_rereview": "Re-review",
+  "gitrail_restart_review": "Restart",
+  "gitrail_confirm_review": "confirm ✓",
+  "gitrail_review_skipped": "Review not started — conditions changed or one's already running.",
+  "gitrail_review_failed": "Couldn't start the review. Try again.",
+  "feat_manual_critic_review_title": "Restart a critic review",
+  "feat_manual_critic_review_body": "When the AI critic never started or stalled without a verdict, a Review/Re-review button on the PR rail lets you start or restart it on demand — for open PRs with green CI."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -928,6 +928,18 @@ export async function reviewPlan(id: string): Promise<PlanReviewTrigger> {
   return body.status ?? "skipped";
 }
 
+export type PrReviewTrigger = "started" | "skipped" | "error";
+
+/** Trigger an on-demand critic PR review (202). Fire-and-forget; the REVIEWING state and
+ *  verdict return via WS. Returns the trigger outcome so the caller can tell a real start
+ *  ("started") from a server decline ("skipped") and a spawn failure ("error"). */
+export async function reviewPr(id: string): Promise<PrReviewTrigger> {
+  const r = await fetch(`/api/sessions/${id}/review-pr`, JSON_POST());
+  if (!r.ok) throw await failed(r, "review-pr");
+  const body = (await r.json().catch(() => ({}))) as { status?: PrReviewTrigger };
+  return body.status ?? "skipped";
+}
+
 export async function getBacklog(): Promise<BacklogPayload> {
   const r = await fetch("/api/backlog");
   if (!r.ok) throw await failed(r, "backlog");

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -29,6 +29,10 @@ const gitStateFn = vi.fn(async () => openPrState);
 // pulls other named exports like getRepoConfig/getReviews) and override only the
 // PR-state fetch GitRail makes on mount. The real network calls never fire under
 // test: gitState is stubbed, and no other call path is exercised.
+// reviewPrFn drives the manual critic-trigger handler; per-test we resolve it to
+// "started"/"skipped"/"error" or reject it to exercise the fail-closed toast paths.
+const reviewPrFn = vi.fn(async () => "started" as "started" | "skipped" | "error");
+
 vi.mock("$lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("$lib/api")>();
   return {
@@ -38,15 +42,24 @@ vi.mock("$lib/api", async (importOriginal) => {
     mergePr: vi.fn(),
     redeploy: vi.fn(),
     replySession: vi.fn(),
+    reviewPr: reviewPrFn,
   };
 });
+
+// Mock the shared toast store so the manual-review handler's fail-closed/skipped
+// toasts can be asserted without rendering the real toast UI.
+const toastsInfo = vi.fn();
+vi.mock("$lib/toasts.svelte", () => ({
+  toasts: { info: toastsInfo },
+}));
 
 // Import the component AFTER the mock is registered.
 const { default: GitRail } = await import("./GitRail.svelte");
 // The plan-gate reviewing store drives the auto-pill pulse for plan reviews,
 // mirroring the critic (reviews) store. Imported from the same module the
 // component reads so toggling it reactively updates the rendered pill.
-const { planGates, reviews } = await import("$lib/reviews.svelte");
+// repoConfig drives the critic-enabled flag the manual-review button gates on.
+const { planGates, reviews, repoConfig } = await import("$lib/reviews.svelte");
 
 // Deterministic measurement: pin the rail's font so CI (no Berkeley Mono) and
 // local agree. The rail mounts into a fixed-width host cell. On desktop the
@@ -689,5 +702,174 @@ describe("GitRail — review popover is a modal dialog with real focus semantics
       new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true }),
     );
     expect(document.activeElement, "Shift+Tab wraps first → last").toBe(last);
+  });
+});
+
+describe("GitRail — manual critic-review trigger", () => {
+  // The button gates on git open + checks success + repo critic enabled. critic
+  // defaults to enabled (repoConfig.isEnabled → true when unknown); we set it
+  // explicitly so the gate is deterministic and the disabled-critic case is real.
+  beforeEach(() => {
+    reviewPrFn.mockResolvedValue("started");
+    toastsInfo.mockClear();
+    reviewPrFn.mockClear();
+    repoConfig.enabled = { ...repoConfig.enabled, [baseProps.repoPath]: true };
+  });
+  afterEach(() => {
+    reviews.drop(baseProps.sessionId);
+    // reset critic flag so it can't leak across suites
+    const next = { ...repoConfig.enabled };
+    delete next[baseProps.repoPath];
+    repoConfig.enabled = next;
+  });
+
+  // The manual-review button is a .gbtn with one of the Review/Re-review/Restart
+  // labels; the Merge button is also a .gbtn, so select by accessible name.
+  function reviewBtn(h: HTMLElement): HTMLButtonElement | null {
+    return (
+      [...h.querySelectorAll<HTMLButtonElement>("button.gbtn:not(.auto-pill)")].find((b) =>
+        /^(Review|Re-review|Restart|confirm)/.test(b.textContent?.trim() ?? ""),
+      ) ?? null
+    );
+  }
+
+  // ── visibility ─────────────────────────────────────────────────────────────
+  it("renders the Review button when open + checks success + critic enabled", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    // start state: no verdict, not reviewing → "Review" label (the new no-verdict path)
+    await vi.waitFor(() => expect(reviewBtn(h), "review button present").not.toBeNull());
+    expect(reviewBtn(h)!.textContent?.trim()).toBe(m.gitrail_review());
+  });
+
+  it("hides the Review button when CI is not success", async () => {
+    gitStateFn.mockResolvedValue({ ...openPrState, checks: "pending" });
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    expect(reviewBtn(h), "no review button without green CI").toBeNull();
+  });
+
+  it("hides the Review button when the PR is not open", async () => {
+    gitStateFn.mockResolvedValue({
+      kind: "github",
+      state: "merged",
+      checks: "success",
+      deployConfigured: false,
+    });
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/merged/i)).toBeVisible();
+    expect(reviewBtn(h), "no review button when not open").toBeNull();
+  });
+
+  it("hides the Review button when the repo critic is disabled", async () => {
+    repoConfig.enabled = { ...repoConfig.enabled, [baseProps.repoPath]: false };
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await vi.waitFor(() =>
+      expect(screen.getByRole("button", { name: /^Merge$/i }).element()).toBeTruthy(),
+    );
+    expect(reviewBtn(h), "no review button when critic disabled").toBeNull();
+  });
+
+  // ── arm → confirm → call ─────────────────────────────────────────────────────
+  it("first click arms (no call), second click calls reviewPr once", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await vi.waitFor(() => expect(reviewBtn(h)).not.toBeNull());
+
+    const btn = reviewBtn(h)!;
+    btn.click();
+    // armed → label becomes confirm, reviewPr NOT yet called
+    await vi.waitFor(() =>
+      expect(reviewBtn(h)!.textContent?.trim()).toBe(m.gitrail_confirm_review()),
+    );
+    expect(reviewPrFn, "not called on first (arming) click").not.toHaveBeenCalled();
+
+    reviewBtn(h)!.click();
+    await vi.waitFor(() => expect(reviewPrFn).toHaveBeenCalledTimes(1));
+    expect(reviewPrFn).toHaveBeenCalledWith(baseProps.sessionId);
+  });
+
+  // ── fail-closed + skipped + started toasts ───────────────────────────────────
+  async function armAndConfirm(h: HTMLElement) {
+    await vi.waitFor(() => expect(reviewBtn(h)).not.toBeNull());
+    reviewBtn(h)!.click();
+    await vi.waitFor(() =>
+      expect(reviewBtn(h)!.textContent?.trim()).toBe(m.gitrail_confirm_review()),
+    );
+    reviewBtn(h)!.click();
+  }
+
+  it("'error' status raises the persistent, keyed failure toast", async () => {
+    reviewPrFn.mockResolvedValue("error");
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await armAndConfirm(h);
+    await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
+    expect(toastsInfo).toHaveBeenCalledWith(
+      m.gitrail_review_failed(),
+      expect.objectContaining({
+        duration: null,
+        alert: true,
+        key: `review-pr:${baseProps.sessionId}`,
+      }),
+    );
+  });
+
+  it("a rejected reviewPr raises the persistent failure toast", async () => {
+    reviewPrFn.mockRejectedValue(new Error("boom"));
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await armAndConfirm(h);
+    await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
+    expect(toastsInfo).toHaveBeenCalledWith(
+      m.gitrail_review_failed(),
+      expect.objectContaining({ duration: null, alert: true }),
+    );
+  });
+
+  it("'skipped' status raises a transient info toast", async () => {
+    reviewPrFn.mockResolvedValue("skipped");
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await armAndConfirm(h);
+    await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
+    expect(toastsInfo).toHaveBeenCalledWith(m.gitrail_review_skipped());
+  });
+
+  it("'started' status raises NO toast (the REVIEWING badge is the feedback)", async () => {
+    reviewPrFn.mockResolvedValue("started");
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await armAndConfirm(h);
+    await vi.waitFor(() => expect(reviewPrFn).toHaveBeenCalledTimes(1));
+    // give any (incorrect) toast a tick to fire, then assert silence
+    await new Promise((r) => setTimeout(r, 20));
+    expect(toastsInfo, "no toast on started").not.toHaveBeenCalled();
   });
 });

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { gitState, openPr, mergePr, redeploy, replySession } from "$lib/api";
+  import { gitState, openPr, mergePr, redeploy, replySession, reviewPr } from "$lib/api";
   import type { DrainStatus, GitState, Session, SessionStatus } from "$lib/types";
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
@@ -69,9 +69,9 @@
   let showAutomation = $state(false);
 
   // two-step confirm for destructive actions (mirrors decommission UX)
-  let armed = $state<"merge" | "redeploy" | null>(null);
+  let armed = $state<"merge" | "redeploy" | "review" | null>(null);
   let armTimer: ReturnType<typeof setTimeout> | undefined;
-  function arm(which: "merge" | "redeploy"): boolean {
+  function arm(which: "merge" | "redeploy" | "review"): boolean {
     if (armed === which) {
       clearTimeout(armTimer);
       armed = null;
@@ -298,6 +298,21 @@
   const reviewing = $derived(reviews.isReviewing(sessionId));
   const pillReviewing = $derived(reviewing || planGates.isReviewing(sessionId));
   const chip = $derived(criticChip(verdict, reviewing));
+  // Manual critic trigger: only when the auto path's own precondition holds (open PR, green
+  // CI) AND the repo has the critic enabled. Mirrors the server's forceReview guard so a
+  // shown button is never server-rejected. Reviewing is allowed (label becomes "Restart").
+  const canReview = $derived(
+    git?.state === "open" && git?.checks === "success" && repoConfig.flags(repoPath).critic,
+  );
+  const reviewLabel = $derived(
+    armed === "review"
+      ? m.gitrail_confirm_review()
+      : reviewing
+        ? m.gitrail_restart_review()
+        : verdict
+          ? m.gitrail_rereview()
+          : m.gitrail_review(),
+  );
   // Render the (AI-authored) findings as markdown, sanitized before @html.
   // marked + DOMPurify are dynamically imported on first render so they stay off
   // the first-paint critical path; gated on showReview so the (browser-only)
@@ -360,6 +375,28 @@
   $effect(() => {
     if (repoPath) repoConfig.ensure(repoPath);
   });
+
+  async function doReview() {
+    if (!arm("review")) return; // first click arms, second confirms
+    try {
+      const status = await reviewPr(sessionId);
+      // "started" → the REVIEWING badge (via WS) is the feedback; nothing to show. Fail-closed:
+      // a decline or error must never read as success.
+      if (status === "skipped") toasts.info(m.gitrail_review_skipped());
+      else if (status !== "started")
+        toasts.info(m.gitrail_review_failed(), {
+          duration: null,
+          alert: true,
+          key: `review-pr:${sessionId}`,
+        });
+    } catch {
+      toasts.info(m.gitrail_review_failed(), {
+        duration: null,
+        alert: true,
+        key: `review-pr:${sessionId}`,
+      });
+    }
+  }
 
   async function sendReviewToAgent() {
     if (!verdict?.body) return;
@@ -513,6 +550,18 @@
           onclick={(e) => toggleReview(e)}
         >
           {chip.label}
+        </button>
+      {/if}
+
+      {#if canReview}
+        <button
+          class="gbtn"
+          class:armed={armed === "review"}
+          type="button"
+          onclick={() => doReview()}
+          use:coachTarget={"manual-critic-review"}
+        >
+          {reviewLabel}
         </button>
       {/if}
 

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -977,4 +977,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_clone_repo_picker_title",
     bodyKey: "feat_clone_repo_picker_body",
   },
+  {
+    // targetId "manual-critic-review" anchors the coachmark on the Review/Re-review
+    // button on the PR rail (GitRail), shown for open PRs with green CI + critic on.
+    // 1.32.0 is the latest released tag, so this ships in 1.33.0.
+    id: "manual-critic-review",
+    sinceVersion: "1.33.0",
+    titleKey: "feat_manual_critic_review_title",
+    bodyKey: "feat_manual_critic_review_body",
+    targetId: "manual-critic-review",
+  },
 ];


### PR DESCRIPTION
## Why

The event-driven critic sometimes silently fails to start or to produce a verdict for a PR — it never fires, stalls on consecutive `errorRound` timeouts, hits the per-streak spawn ceiling, or hangs in-flight. Until now there was **no way to recover**: `review.ts` deliberately had "no in-PR re-request-review action". This adds an operator-driven start/restart button on the GitRail.

## What

A **Review / Re-review / Restart** button on the PR rail that starts (or restarts) the critic on demand.

- **Visible only when** the PR is open, CI is green, and the repo has the critic enabled — mirroring the auto path's own precondition so a shown button isn't server-rejected.
- **Two-step arm** (reuses the existing Merge/Redeploy arm pattern): first click arms, second confirms.
- **Abort + restart**: if a run is hung in-flight, it's reaped (terminal + worktree) and a fresh one spawns immediately — no waiting for the 10-min timeout. Guarded against a concurrent `finalize()` (bails to `skipped` while finalizing).

## How

**One code path, not a parallel implementation.** A `force` flag is threaded through `consider()` → `begin()` → `rebaseSkip()`:

- `force` bypasses the same-head dedup and the spawn ceiling in `consider()`.
- Critically, `force` suppresses **only the skip decision** in `rebaseSkip()` (while still computing `patchId`/`baseSha`/`files`). This is the real lever: `shouldSkipForPatchId`'s `prior.patchId === patchId` branch matches an unchanged head for any non-error verdict, so a re-review would otherwise silently no-op.
- `forceReview()` is a thin wrapper: abort an in-flight run (finalizing-guarded), apply streak/`errorRound` **hygiene** (so `finalize()` doesn't immediately re-stall and the next *auto* run re-engages), then delegate to `consider(force)`.

**Route:** `POST /api/sessions/:id/review-pr` mirrors `/review-plan`; resolves a **live** forge `GitState` (new `resolveGitState` helper, not the ≤120s `prCache`) and returns `{ status: "started" | "skipped" | "error" }`.

**Fail-closed end to end:** `begin()`'s silent early-returns leave the run un-spawned → `consider` returns `"error"` → route relays it → UI shows a persistent, keyed failure toast. A non-spawn can never read as success (the REVIEWING badge only appears on a genuine `"started"`, via the existing WS event).

## Known limitation

Gating on green CI means a PR whose critic never fired **because CI never went green** is out of reach of this button — a deliberate consequence of the chosen "require CI green" semantics. A force-past-CI mode is a possible later follow-up.

## Tests

- Server (`bun test ./test`, 3355 pass): the lever test (re-review of an already-reviewed head spawns), in-flight abort+respawn, the finalizing-race guard, mid-spawn/precondition `skipped`, `begin`-bails `error`, `errorRound` hygiene; route 404/404/202/502.
- UI (`bun run test`, 1374 pass): button visibility across all gates, the no-verdict start-state branch, arm→confirm calls `reviewPr` once, fail-closed toast shapes.
- Lint, root `tsc`, `svelte-check`, `check:i18n` (EN+DE parity), branch-hygiene, feature-catalog, glossary, and fallow delta audit all clean. One feature-announcement entry (`manual-critic-review`, since 1.33.0) + EN/DE keys ship in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)