### PR TITLE
feat(topbar): relative reset countdown on usage gauges

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -360,11 +360,12 @@
   "topbar_tally_status_aria": "{status} {count}; nur diese Sessions anzeigen",
   "topbar_gauge_period_5h": "5-Stunden",
   "topbar_gauge_period_weekly": "wöchentlich",
-  "topbar_gauge_title": "{period}-Limit · {pct}% genutzt · Reset {reset}",
+  "topbar_gauge_title": "{period}-Limit · {pct}% genutzt · Reset in {rel} ({abs})",
   "topbar_gauge_stale_suffix": " · veraltet",
   "topbar_gauge_popover_title": "Auslastung",
   "topbar_gauge_toggle_aria": "{period}-Limit bei {pct}%; für Details tippen",
   "topbar_gauge_reset": "Reset {reset}",
+  "topbar_gauge_reset_rel": "Reset in {rel} ({abs})",
   "topbar_theme_cycle": "Design: {label}; zum Wechseln tippen",
   "topbar_theme_cycle_aria": "Design: {label}",
   "topbar_settings_aria": "Einstellungen",
@@ -1388,5 +1389,7 @@
   "syncfork_toast_gh_missing": "GitHub CLI (gh) ist nicht installiert.",
   "syncfork_toast_generic": "Fork konnte nicht synchronisiert werden, bitte erneut",
   "feat_fork_sync_title": "Einen Fork mit einem Klick aktuell halten",
-  "feat_fork_sync_body": "Fork-Repos in der Auswahl zeigen jetzt einen ⟲ Sync-Button. Er führt gh repo sync aus, um den Standard-Branch deines Forks mit dem Upstream abzugleichen, und fast-forwardet den lokalen Klon — damit neue PR-Branches vom aktuellen Upstream statt von einer veralteten Basis ausgehen."
+  "feat_fork_sync_body": "Fork-Repos in der Auswahl zeigen jetzt einen ⟲ Sync-Button. Er führt gh repo sync aus, um den Standard-Branch deines Forks mit dem Upstream abzugleichen, und fast-forwardet den lokalen Klon — damit neue PR-Branches vom aktuellen Upstream statt von einer veralteten Basis ausgehen.",
+  "feat_usage_reset_countdown_title": "Auslastungslimits mit Countdown",
+  "feat_usage_reset_countdown_body": "Die 5-Stunden- und wöchentlichen Auslastungsanzeigen zeigen jetzt an, wie lange es noch bis zum Reset dauert — z. B. \"Reset in 2h (21:30)\" — damit du auf einen Blick siehst, ob bald wieder Kapazität verfügbar ist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -360,11 +360,12 @@
   "topbar_tally_status_aria": "{status} {count}; show only these sessions",
   "topbar_gauge_period_5h": "5-hour",
   "topbar_gauge_period_weekly": "weekly",
-  "topbar_gauge_title": "{period} limit · {pct}% used · resets {reset}",
+  "topbar_gauge_title": "{period} limit · {pct}% used · resets in {rel} ({abs})",
   "topbar_gauge_stale_suffix": " · stale",
   "topbar_gauge_popover_title": "Usage limits",
   "topbar_gauge_toggle_aria": "{period} limit at {pct}%; tap for details",
   "topbar_gauge_reset": "resets {reset}",
+  "topbar_gauge_reset_rel": "resets in {rel} ({abs})",
   "topbar_theme_cycle": "Theme: {label}; tap to cycle",
   "topbar_theme_cycle_aria": "Theme: {label}",
   "topbar_settings_aria": "settings",
@@ -1388,5 +1389,7 @@
   "syncfork_toast_gh_missing": "GitHub CLI (gh) is not installed.",
   "syncfork_toast_generic": "Couldn't sync the fork, please retry",
   "feat_fork_sync_title": "Keep a fork current with one click",
-  "feat_fork_sync_body": "Fork repos in the picker now show a ⟲ Sync button. It runs gh repo sync to bring your fork's default branch up to date with upstream and fast-forwards the local clone — so new PR branches you cut start from current upstream instead of a stale base."
+  "feat_fork_sync_body": "Fork repos in the picker now show a ⟲ Sync button. It runs gh repo sync to bring your fork's default branch up to date with upstream and fast-forwards the local clone — so new PR branches you cut start from current upstream instead of a stale base.",
+  "feat_usage_reset_countdown_title": "Usage limits show a countdown",
+  "feat_usage_reset_countdown_body": "The 5-hour and weekly usage gauges now show how long until the window resets — e.g. \"resets in 2h (21:30)\" — so you can see at a glance whether you'll have capacity soon."
 }

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -6,7 +6,7 @@
     HerdrUpdateStatus,
     DiagnosticState,
   } from "$lib/types";
-  import { formatReset, relativeAge } from "$lib/format";
+  import { formatReset, formatResetIn, relativeAge } from "$lib/format";
   import { displayStatus } from "$lib/display-status";
   import { gaugeList, hotterGauge, overspending, type GaugeKey } from "./usage-gauges";
   import { refreshUsage } from "$lib/api";
@@ -230,7 +230,8 @@
     return `${m.topbar_gauge_title({
       period: periodLabel(k),
       pct,
-      reset: formatReset(resetAt, nowMs),
+      rel: formatResetIn(resetAt, nowMs),
+      abs: formatReset(resetAt, nowMs),
     })}${limits?.stale ? m.topbar_gauge_stale_suffix() : ""}`;
   }
 
@@ -681,7 +682,10 @@
                   <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
                 </div>
                 <div class="gauge-pop-reset micro">
-                  {m.topbar_gauge_reset({ reset: formatReset(g.w.resetAt, nowMs) })}
+                  {m.topbar_gauge_reset_rel({
+                    rel: formatResetIn(g.w.resetAt, nowMs),
+                    abs: formatReset(g.w.resetAt, nowMs),
+                  })}
                 </div>
               {/each}
               {@render creditDetail()}
@@ -731,7 +735,10 @@
                   ></span></span
                 >
                 <div class="gauge-pop-reset micro">
-                  {m.topbar_gauge_reset({ reset: formatReset(g.w.resetAt, nowMs) })}
+                  {m.topbar_gauge_reset_rel({
+                    rel: formatResetIn(g.w.resetAt, nowMs),
+                    abs: formatReset(g.w.resetAt, nowMs),
+                  })}
                 </div>
               </div>
             {/each}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -881,6 +881,16 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_fork_sync_body",
   },
   {
+    // No targetId: the countdown surfaces in the hover tooltip and hover/tap popovers
+    // of the TopBar usage gauges; there is no single persistent anchor element to
+    // point a coachmark at. Surface via the What's-New drawer only. 1.32.0 is the
+    // latest released tag, so this ships in 1.33.0.
+    id: "usage-reset-countdown",
+    sinceVersion: "1.33.0",
+    titleKey: "feat_usage_reset_countdown_title",
+    bodyKey: "feat_usage_reset_countdown_body",
+  },
+  {
     // No targetId: the link is inline in the panel header (only rendered when a repo is
     // selected in the Backlog view), so a coachmark anchor would usually be unmounted —
     // surface via the What's-New drawer only. 1.30.0 is the latest released tag, so this

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -4,6 +4,7 @@ import {
   autopilotBadgeShown,
   relativeAge,
   formatAgo,
+  formatResetIn,
   heartbeatTone,
   canResume,
   canRelaunch,
@@ -120,6 +121,21 @@ describe("relativeAge", () => {
     expect(relativeAge(now - 2 * 3_600_000, now)).toBe("2h");
     expect(relativeAge(now - 3 * 86_400_000, now)).toBe("3d");
     expect(relativeAge(now + 10_000, now)).toBe("now"); // future clamps to 0
+  });
+});
+
+describe("formatResetIn", () => {
+  const now = 1_000_000_000_000;
+  it("returns coarse floored unit for future reset times", () => {
+    expect(formatResetIn(now + 2 * 3_600_000, now)).toBe("2h");
+    expect(formatResetIn(now + 5 * 86_400_000, now)).toBe("5d");
+    expect(formatResetIn(now + 45 * 60_000, now)).toBe("45m");
+    expect(formatResetIn(now + 30_000, now)).toBe("30s");
+  });
+  it("clamps past/now resets to 0s", () => {
+    expect(formatResetIn(now, now)).toBe("0s");
+    expect(formatResetIn(now - 1000, now)).toBe("0s"); // stale: past reset
+    expect(formatResetIn(now - 3_600_000, now)).toBe("0s"); // far past
   });
 });
 

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -105,6 +105,17 @@ export function formatReset(ts: number, nowMs: number): string {
     : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
+/**
+ * Coarse relative countdown to a future reset timestamp, e.g. "2h", "5d".
+ * Delegates to `formatAgo(ts - nowMs)`, which floors each unit and clamps
+ * negative deltas to 0 — so a stale past-reset snapshot yields "0s" rather
+ * than throwing. Pairs with `formatReset` (absolute) for combined display:
+ * `resets in {formatResetIn(ts, nowMs)} ({formatReset(ts, nowMs)})`.
+ */
+export function formatResetIn(ts: number, nowMs: number): string {
+  return formatAgo(ts - nowMs);
+}
+
 export const STATUS_COLOR: Record<SessionStatus, string> = {
   running: "var(--status-running)",
   idle: "var(--status-idle)",


### PR DESCRIPTION
## What

The TopBar usage gauges (`5H` 5-hour session + `WK` weekly) now show a relative countdown alongside the absolute reset time:

- before: `resets 21:30`
- after: `resets in 2h (21:30)` · `resets in 5d (Jun 21)`

Relative + absolute together, single coarse floored unit (reuses the existing `formatAgo` magnitude — consistent with `relativeAge` for credits age). Applied across all three render sites: desktop hover tooltip/aria, desktop hover detail popover, and the touch tap-popover.

The **credits** (monthly) reset line is intentionally unchanged — stays absolute-only.

## How

- `formatResetIn(ts, nowMs)` added to `ui/src/lib/format.ts` — `formatAgo(ts - nowMs)`, which already floors and clamps negatives to `0s` (a stale past-reset snapshot degrades to `in 0s`, displayed inside the already-stale popover state — fail-closed, no false freshness).
- New i18n key `topbar_gauge_reset_rel` (`resets in {rel} ({abs})` / DE `Reset in {rel} ({abs})`); `topbar_gauge_title` updated to the same shape. EN+DE parity maintained; `topbar_gauge_reset` (credits) untouched.
- `TopBar.svelte`: import `formatResetIn`, update `gaugeTip()` + the two 5H/WK reset render sites.
- Feature-catalog entry `usage-reset-countdown` (sinceVersion `1.33.0`) + EN/DE announcement copy.

## Tests / gates

- `cd ui && bun run check` — 0 errors/0 warnings (incl. `check:i18n` parity, 1392 keys/locale).
- `cd ui && bun run test` — 1367 tests pass, incl. 7 new `formatResetIn` cases.
- pre-push green: branch hygiene · feature catalog · glossary · prettier · fallow delta (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)