### PR TITLE
fix(critic): bind herdr/worktree in reapRun so critic teardown can't crash

### DIFF
--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -497,13 +497,24 @@ export async function captureUsage(
 /** Terminal + disposable-worktree teardown for a finished critic run.
  *  Accepts the herdr and worktree OBJECTS and calls their methods so that
  *  `this` is preserved — passing bare unbound methods would lose `this` and
- *  crash inside HerdrDriver.stop / WorktreeMgr.remove. */
+ *  crash inside HerdrDriver.stop / WorktreeMgr.remove.
+ *
+ *  Teardown can't crash: callers invoke this from a `finally`, so it must
+ *  reap best-effort and never throw. `HerdrDriver.stop` can still throw (its
+ *  `this.list()` does `JSON.parse(runner(...))`, which fails if the herdr CLI
+ *  errors) — guard it so a herdr hiccup can't strand the worktree, and run
+ *  `worktree.remove` (itself internally guarded) unconditionally. */
 export function reapRun(
   herdr: { stop(terminalId: string): void },
   worktree: { remove(worktreePath: string): void },
   terminalId: string,
   worktreePath: string,
 ): void {
-  herdr.stop(terminalId);
-  worktree.remove(worktreePath);
+  try {
+    herdr.stop(terminalId);
+  } catch (err) {
+    console.warn(`[review] reap: herdr.stop failed for ${terminalId}:`, err);
+  } finally {
+    worktree.remove(worktreePath);
+  }
 }

--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -494,13 +494,16 @@ export async function captureUsage(
   }
 }
 
-/** Terminal + disposable-worktree teardown for a finished critic run. */
+/** Terminal + disposable-worktree teardown for a finished critic run.
+ *  Accepts the herdr and worktree OBJECTS and calls their methods so that
+ *  `this` is preserved — passing bare unbound methods would lose `this` and
+ *  crash inside HerdrDriver.stop / WorktreeMgr.remove. */
 export function reapRun(
-  stop: (terminalId: string) => void,
-  remove: (worktreePath: string) => void,
+  herdr: { stop(terminalId: string): void },
+  worktree: { remove(worktreePath: string): void },
   terminalId: string,
   worktreePath: string,
 ): void {
-  stop(terminalId);
-  remove(worktreePath);
+  herdr.stop(terminalId);
+  worktree.remove(worktreePath);
 }

--- a/src/review.ts
+++ b/src/review.ts
@@ -450,7 +450,7 @@ export class ReviewService {
     const f = this.inflight.get(session.id);
     if (f) {
       if (f.finalizing) return "skipped";
-      reapRun(this.deps.herdr.stop, this.deps.worktree.remove, f.terminalId, f.worktreePath);
+      reapRun(this.deps.herdr, this.deps.worktree, f.terminalId, f.worktreePath);
       this.deps.onReviewing?.(session.id, false);
       this.inflight.delete(session.id);
     }
@@ -725,7 +725,7 @@ export class ReviewService {
       );
     } finally {
       this.deps.onReviewing?.(f.sessionId, false);
-      reapRun(this.deps.herdr.stop, this.deps.worktree.remove, f.terminalId, f.worktreePath);
+      reapRun(this.deps.herdr, this.deps.worktree, f.terminalId, f.worktreePath);
     }
   }
 

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -635,7 +635,7 @@ export class StandalonePrCriticService {
         `pr:${f.repoPath}#${f.prNumber}`,
       );
     } finally {
-      reapRun(this.deps.herdr.stop, this.deps.worktree.remove, f.terminalId, f.worktreePath);
+      reapRun(this.deps.herdr, this.deps.worktree, f.terminalId, f.worktreePath);
     }
   }
 
@@ -653,7 +653,7 @@ export class StandalonePrCriticService {
   /** Tear down every in-flight run (reap its terminal + worktree). For process shutdown. */
   stopAll(): void {
     for (const f of this.inFlight.values()) {
-      reapRun(this.deps.herdr.stop, this.deps.worktree.remove, f.terminalId, f.worktreePath);
+      reapRun(this.deps.herdr, this.deps.worktree, f.terminalId, f.worktreePath);
     }
     this.inFlight.clear();
     this.starting.clear();

--- a/test/critic-core.test.ts
+++ b/test/critic-core.test.ts
@@ -8,6 +8,7 @@ import {
   buildVerdictCore,
   reviewPrompt,
   prReviewPrompt,
+  reapRun,
 } from "../src/critic-core";
 
 // ── prReviewPrompt (session-less) ───────────────────────────────────────────
@@ -230,4 +231,29 @@ test("buildVerdictCore: request-changes with no findings falls back to its summa
   );
   expect(core.decision).toBe("changes_requested");
   expect(core.findings).toEqual(["needs work"]);
+});
+
+// ── reapRun: teardown can't crash ───────────────────────────────────────────
+
+test("reapRun: a throwing herdr.stop still removes the worktree and does not escape", () => {
+  const removed: string[] = [];
+  const herdr = {
+    stop() {
+      throw new Error("herdr CLI failed (e.g. JSON.parse of a non-JSON list)");
+    },
+  };
+  const worktree = { remove: (p: string) => removed.push(p) };
+  // finally callers rely on this never throwing — a herdr hiccup must not strand the worktree.
+  expect(() => reapRun(herdr, worktree, "term-1", "/wt-1")).not.toThrow();
+  expect(removed).toEqual(["/wt-1"]);
+});
+
+test("reapRun: clean path reaps both terminal and worktree", () => {
+  const stopped: string[] = [];
+  const removed: string[] = [];
+  const herdr = { stop: (t: string) => stopped.push(t) };
+  const worktree = { remove: (p: string) => removed.push(p) };
+  reapRun(herdr, worktree, "term-2", "/wt-2");
+  expect(stopped).toEqual(["term-2"]);
+  expect(removed).toEqual(["/wt-2"]);
 });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -168,18 +168,24 @@ function makeDeps(
       completeReviewerSpawn: (id: string, u: any, at: number) =>
         completedSpawns.push({ id, u, at }),
     },
-    herdr: {
-      start: (name: string, cwd: string, argv: string[], env?: Record<string, string>) => {
+    herdr: new (class {
+      readonly recorded = stopped; // this-dependent: unbound call loses this.recorded
+      start(name: string, cwd: string, argv: string[], env?: Record<string, string>) {
         started.push({ name, cwd, argv, env });
         return { terminalId: "rt" } as any;
-      },
-      stop: (t: string) => stopped.push(t),
-    },
-    worktree: {
-      createDetached: async () => ({ worktreePath: "/review-wt", branch: null, isolated: true }),
-      remove: (p: string) => removed.push(p),
-      gitCommonDir: () => "/fake-git-common",
-    },
+      }
+      stop(t: string) {
+        this.recorded.push(t); // this.recorded → throws TypeError if called unbound
+      }
+    })(),
+    worktree: new (class {
+      readonly recorded = removed; // this-dependent: unbound call loses this.recorded
+      createDetached = async () => ({ worktreePath: "/review-wt", branch: null, isolated: true });
+      remove(p: string) {
+        this.recorded.push(p); // this.recorded → throws TypeError if called unbound
+      }
+      gitCommonDir = () => "/fake-git-common";
+    })(),
     // no bwrap on test hosts: degrade to passthrough so existing argv assertions hold
     detectBackend: () => null,
     resolveForge: () =>

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -169,15 +169,19 @@ function makeDeps(
       listEpicCompleted: (repoPath?: string) =>
         (opts.epicCompleted ?? []).filter((r) => repoPath === undefined || r.repoPath === repoPath),
     },
-    herdr: {
-      start: (name: string, cwd: string, argv: string[], env?: Record<string, string>) => {
+    herdr: new (class {
+      readonly recorded = spies.stopped; // this-dependent: unbound call loses this.recorded
+      start(name: string, cwd: string, argv: string[], env?: Record<string, string>) {
         spies.started.push({ name, cwd, argv, env });
         return { terminalId: "rt" } as any;
-      },
-      stop: (t: string) => spies.stopped.push(t),
-    },
-    worktree: {
-      createDetached: async (
+      }
+      stop(t: string) {
+        this.recorded.push(t); // this.recorded → throws TypeError if called unbound
+      }
+    })(),
+    worktree: new (class {
+      readonly recorded = spies.removed; // this-dependent: unbound call loses this.recorded
+      createDetached = async (
         _repo: string,
         branch: string,
         sha: string,
@@ -186,10 +190,12 @@ function makeDeps(
       ) => {
         spies.created.push({ branch, sha, slug, pullRef });
         return { worktreePath: "/review-wt", branch: null, isolated: true };
-      },
-      remove: (p: string) => spies.removed.push(p),
-      gitCommonDir: () => "/fake-git-common",
-    },
+      };
+      remove(p: string) {
+        this.recorded.push(p); // this.recorded → throws TypeError if called unbound
+      }
+      gitCommonDir = () => "/fake-git-common";
+    })(),
     resolveForge: opts.forge ?? (() => makeForge(spies)),
     repos: () => opts.repos ?? ["/r"],
     managedBranches: opts.managed ?? (() => new Set<string>()),
@@ -716,4 +722,17 @@ test("inflightWorktrees: returns worktree path after sweep() spawns a critic run
   const svc = new StandalonePrCriticService(deps as any);
   await svc.sweep();
   expect(svc.inflightWorktrees()).toEqual(["/review-wt"]);
+});
+
+// ── regression: reapRun unbound-this (stop/remove must not throw) ────────────
+
+test("stopAll: reaps in-flight run without throwing (regression: unbound this)", async () => {
+  const { deps, spies } = makeDeps();
+  const svc = new StandalonePrCriticService(deps as any);
+  await svc.sweep();
+  expect(svc.inflightWorktrees()).toEqual(["/review-wt"]);
+  expect(() => svc.stopAll()).not.toThrow();
+  expect(spies.stopped).toEqual(["rt"]);
+  expect(spies.removed).toEqual(["/review-wt"]);
+  expect(svc.inflightWorktrees()).toEqual([]);
 });


### PR DESCRIPTION
## What

The critic-review teardown helper `reapRun` (`src/critic-core.ts`) was called at **four** sites with the **bare, unbound** methods `this.deps.herdr.stop` / `this.deps.worktree.remove`. Invoked unbound inside `reapRun`, `this` is `undefined`, so `HerdrDriver.stop`'s `this.list()` throws `TypeError: undefined is not an object` — crashing critic teardown.

`reapRun` now takes the `herdr`/`worktree` **objects** and calls their methods (method invocation rebinds `this`). All four call sites pass the objects:

- `src/review.ts` — `ReviewService.forceReview` (operator **manual** re-review abort) and `finalize`
- `src/standalone-critic.ts` — `StandalonePrCriticService.finalize` and `stopAll`

The param types (`{ stop(...): void }` / `{ remove(...): void }`) **reject a bare method at compile time**, so a future 5th site that reverts to passing `this.deps.herdr.stop` fails `tsc` instead of crashing at runtime.

## Why (root cause, verified against live logs)

Recurring in `~/.shepherd/shepherd.log` on `flowagent` sessions (e.g. TASK-505):

```
TypeError: undefined is not an object (evaluating 'this.list')
    at stop      (src/herdr.ts)
    at reapRun   (src/critic-core.ts)
    at finalize  (src/review.ts) / forceReview / standalone-critic
```

The verdict still posted (teardown runs after publish), but `stop()` threw **before** `reapRun` reached `remove()`, so the reviewer **terminal/tab was never closed** (husk panes → `agent_name_taken` blocking new review spawns) and the **worktree was never removed** (the stranded `*-review-*` worktrees + `tmp-sweep` prune failures). The operator's manual `forceReview` re-review propagated the throw outright — the "now specifically on TASK-505" symptom.

The bug is **repo-agnostic** (shared singleton deps, unconditional teardown); it just surfaced loudest on 3rd-party repos because the standalone every-PR critic runs only there and sweeps continuously. Introduced by #719 (which extracted `reapRun`); #745 copied the broken pattern into `forceReview`.

## Why existing tests missed it

The `herdr`/`worktree` test doubles were object literals whose `stop`/`remove` were `this`-independent (`stop: (t) => stopped.push(t)`), so unbound calls worked fine. They're now `this`-dependent class instances that throw exactly like production — reproducing RED across **forceReview, finalize (both services), and stopAll**, then GREEN after the fix.

## Verification

- `bun test ./test`: 3361 pass / 8 skip / 0 fail (RED→GREEN confirmed: 52 tests fail against pre-fix code with the unbound-`this` TypeError on all four paths)
- `bunx tsc --noEmit`: clean (also proves the new types reject bare methods)
- `bun run lint`: clean

Server-only; no user-facing UX → no i18n / feature-catalog / glossary entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)