### PR TITLE
fix(learnings): restore distiller — unique agent name, bounded concurrency, fail-closed health

### DIFF
--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -126,10 +126,12 @@ export class DistillerService {
   }
 
   private recordHealthFailure(repoPath: string, reason: string): void {
-    const wasOk = this.healthOk();
     this.healthFailures++;
     this.lastFailure = { reason, at: this.now(), repoPath };
-    if (wasOk && !this.healthOk()) this.deps.onChange();
+    // Emit on the ok→unhealthy transition AND on every further failure while unhealthy,
+    // so an already-open drawer keeps a fresh consecutiveFailures count instead of freezing
+    // at the threshold value. Below the threshold the banner is hidden, so no emit is needed.
+    if (!this.healthOk()) this.deps.onChange();
   }
 
   private recordHealthSuccess(): void {

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
+import { HerdrUnavailableError } from "./herdr";
 import type { Signal, SignalKind } from "./types";
 import {
   isApiKeyMode,
@@ -20,12 +21,16 @@ const PROPOSALS_FILE = ".shepherd-learnings.json";
 const NON_LEARNING_SIGNAL_KINDS: ReadonlySet<SignalKind> = new Set<SignalKind>(["egress_drop"]);
 
 /**
- * Reserved herdr label for the ephemeral distiller agent. The underscores are load-bearing:
- * prompt-derived session slugs are `[a-z0-9-]` only (see namer.ts), so no real session can
- * collide. The orphan-tab reaper keys off this exact label — a bare "distill" would NOT be
- * safe, since a user prompt slugs to exactly that and would get reaped (cf. {@link PROBE_NAME}).
+ * Prefix for ephemeral distiller agent names. Each run appends the first 8 chars of its
+ * session UUID so concurrent runs for different repos never collide on the same herdr name
+ * (`agent_name_taken`). The underscores are load-bearing: prompt-derived session slugs are
+ * `[a-z0-9-]` only (see namer.ts), so no real session can collide. The orphan-tab reaper
+ * matches tabs whose name starts with this prefix — a bare "distill" would NOT be safe, since
+ * a user prompt slugs to exactly that and would get reaped (cf. {@link PROBE_NAME}).
  */
 export const DISTILL_LABEL = "__distill__";
+
+const HEALTH_FAILURE_THRESHOLD = 3;
 
 interface RawRule {
   rule?: unknown;
@@ -70,6 +75,7 @@ export interface DistillerDeps {
   timeoutMs?: number;
   windowMs?: number; // how far back to read signals (default 60d)
   minSignals?: number; // threshold for consider() (default 5)
+  maxConcurrent?: number; // max simultaneous distill runs (default 3)
   writeSignals?: (
     dir: string,
     signals: Signal[],
@@ -81,20 +87,56 @@ export interface DistillerDeps {
 
 export class DistillerService {
   private inflight = new Map<string, InFlight>();
+  private queue: { repoPath: string; signals: Signal[] }[] = [];
+  private queued = new Set<string>();
+  private maxConcurrent: number;
   private now: () => number;
   private timeoutMs: number;
   private windowMs: number;
   private minSignals: number;
   private writeSignals: NonNullable<DistillerDeps["writeSignals"]>;
   private readProposals: (dir: string) => RawProposals | null;
+  private healthFailures = 0;
+  private lastFailure: { reason: string; at: number; repoPath: string } | null = null;
 
   constructor(private deps: DistillerDeps) {
     this.now = deps.now ?? Date.now;
     this.timeoutMs = deps.timeoutMs ?? 10 * 60 * 1000;
     this.windowMs = deps.windowMs ?? 60 * 24 * 60 * 60 * 1000;
     this.minSignals = deps.minSignals ?? 5;
+    this.maxConcurrent = deps.maxConcurrent ?? 3;
     this.writeSignals = deps.writeSignals ?? defaultWriteSignals;
     this.readProposals = deps.readProposals ?? defaultReadProposals;
+  }
+
+  health(): {
+    ok: boolean;
+    consecutiveFailures: number;
+    lastFailure: { reason: string; at: number; repoPath: string } | null;
+  } {
+    return {
+      ok: this.healthOk(),
+      consecutiveFailures: this.healthFailures,
+      lastFailure: this.lastFailure,
+    };
+  }
+
+  private healthOk(): boolean {
+    return this.healthFailures < HEALTH_FAILURE_THRESHOLD;
+  }
+
+  private recordHealthFailure(repoPath: string, reason: string): void {
+    const wasOk = this.healthOk();
+    this.healthFailures++;
+    this.lastFailure = { reason, at: this.now(), repoPath };
+    if (wasOk && !this.healthOk()) this.deps.onChange();
+  }
+
+  private recordHealthSuccess(): void {
+    const wasUnhealthy = !this.healthOk();
+    this.healthFailures = 0;
+    this.lastFailure = null;
+    if (wasUnhealthy) this.deps.onChange();
   }
 
   /** Recent learning signals for a repo — listSignals minus non-learning kinds
@@ -108,20 +150,29 @@ export class DistillerService {
 
   /** Start a distill run for `repoPath` if enough recent signals exist and none is in flight. */
   consider(repoPath: string): void {
-    if (this.inflight.has(repoPath)) return;
     if (!this.deps.store.getRepoConfig(repoPath).learningsEnabled) return;
     const signals = this.recentLearningSignals(repoPath);
     if (signals.length < this.minSignals) return;
-    this.begin(repoPath, signals);
+    this.enqueueOrBegin(repoPath, signals);
   }
 
   /** Force a distill run regardless of the signal threshold (manual trigger).
-   *  Still requires at least one signal — nothing to distill from otherwise. */
+   *  Still requires at least one signal — nothing to distill from otherwise.
+   *  Subject to the concurrency cap; excess calls are queued. */
   distillNow(repoPath: string): void {
-    if (this.inflight.has(repoPath)) return;
     const signals = this.recentLearningSignals(repoPath);
     if (signals.length === 0) return;
-    this.begin(repoPath, signals);
+    this.enqueueOrBegin(repoPath, signals);
+  }
+
+  private enqueueOrBegin(repoPath: string, signals: Signal[]): void {
+    if (this.inflight.has(repoPath) || this.queued.has(repoPath)) return;
+    if (this.inflight.size < this.maxConcurrent) {
+      this.begin(repoPath, signals);
+    } else {
+      this.queue.push({ repoPath, signals });
+      this.queued.add(repoPath);
+    }
   }
 
   private begin(repoPath: string, signals: Signal[]): void {
@@ -146,6 +197,7 @@ export class DistillerService {
     } catch (err) {
       console.warn(`[distill] write signals failed for ${repoPath}:`, err);
       this.deps.scratch.remove(dir);
+      this.recordHealthFailure(repoPath, "write");
       return;
     }
     // Read-only distiller — same hard-won spawn contract as the critic
@@ -154,10 +206,12 @@ export class DistillerService {
     // --allowedTools) so the trailing prompt isn't swallowed. Bare Write only.
     // Subscription OAuth (NOT --bare); in api-key auth mode the key arrives via
     // apiKeyHelper in --settings (folded in) + a credential-less CLAUDE_CONFIG_DIR.
+    const sessionId = randomUUID();
+    const agentName = DISTILL_LABEL + sessionId.slice(0, 8);
     const argv = [
       "claude",
       "--session-id",
-      randomUUID(),
+      sessionId,
       "--settings",
       // subscription → byte-identical `{"disableAllHooks":true}`; api-key folds in apiKeyHelper.
       JSON.stringify({ disableAllHooks: true, ...apiKeySettingsFragment() }),
@@ -174,13 +228,18 @@ export class DistillerService {
     let terminalId: string;
     try {
       terminalId = this.deps.herdr.start(
-        DISTILL_LABEL,
+        agentName,
         dir,
         argv,
         apiKeyPassthroughEnv(false),
       ).terminalId;
     } catch (err) {
-      console.warn(`[distill] spawn failed for ${repoPath}:`, err);
+      if (err instanceof HerdrUnavailableError) {
+        console.warn(`[distill] herdr unavailable for ${repoPath}:`, err);
+      } else {
+        console.warn(`[distill] spawn failed for ${repoPath}:`, err);
+        this.recordHealthFailure(repoPath, "spawn");
+      }
       this.deps.scratch.remove(dir);
       return;
     }
@@ -193,7 +252,7 @@ export class DistillerService {
     });
   }
 
-  /** Finalize any run whose proposals file is ready or that timed out. */
+  /** Finalize any run whose proposals file is ready or that timed out, then drain queue. */
   async tick(): Promise<void> {
     for (const f of [...this.inflight.values()]) {
       if (f.finalizing) continue;
@@ -204,6 +263,12 @@ export class DistillerService {
       this.finalize(f, raw);
       this.inflight.delete(f.repoPath);
     }
+    // Drain queue: each finalized run frees a slot
+    while (this.inflight.size < this.maxConcurrent && this.queue.length) {
+      const e = this.queue.shift()!;
+      this.queued.delete(e.repoPath);
+      this.begin(e.repoPath, e.signals);
+    }
   }
 
   private finalize(f: InFlight, raw: RawProposals | null): void {
@@ -211,6 +276,11 @@ export class DistillerService {
     const flagged = this.applyIneffective(f, raw);
     this.deps.herdr.stop(f.terminalId);
     this.deps.scratch.remove(f.dir);
+    if (raw !== null) {
+      this.recordHealthSuccess();
+    } else {
+      this.recordHealthFailure(f.repoPath, "timeout-no-output");
+    }
     if (added > 0 || flagged > 0) this.deps.onChange();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1035,6 +1035,7 @@ const gitignoreAdopter = new GitignoreAdopter({ worktree, resolveForge });
 // Daily: prune archived sessions, prune old signals, then consider a distill per repo
 // with enough recent signal.
 const runDailySweep = () => {
+  if (maintenance.active) return;
   if (config.sessionHousekeepingEnabled)
     store.pruneArchivedSessions({
       maxAgeMs: SESSION_RETENTION_MS,

--- a/src/server.ts
+++ b/src/server.ts
@@ -252,7 +252,14 @@ export interface AppDeps {
   /** Learning distiller — manual trigger for the proposal pass over a repo's transcripts.
    *  Optional so environments/tests that don't wire it still type-check; the route
    *  no-ops the trigger when absent. Wired to the real DistillerService in index.ts. */
-  distiller?: { distillNow: (repoPath: string) => void };
+  distiller?: {
+    distillNow: (repoPath: string) => void;
+    health?: () => {
+      ok: boolean;
+      consecutiveFailures: number;
+      lastFailure: { reason: string; at: number; repoPath: string } | null;
+    };
+  };
   /** Promote a curated rule into the repo's CLAUDE.md via an auto-opened PR. */
   promoter?: { promote: (id: string) => Promise<import("./promote").PromoteResult> };
   /** Open a PR adding Shepherd's managed `.shepherd-*` ignore block to a repo's `.gitignore`. */
@@ -877,6 +884,16 @@ function handleLearningsGet({ parts, url, deps }: Ctx): Response | null {
       };
     });
     return json(out);
+  }
+
+  // GET /api/learnings/health — distiller health (fail-safe: safe default when absent)
+  if (parts[2] === "health") {
+    const h = deps.distiller?.health?.() ?? {
+      ok: true,
+      consecutiveFailures: 0,
+      lastFailure: null,
+    };
+    return json(h);
   }
 
   // GET /api/learnings?repo=&status=

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -23,9 +23,14 @@ export type ReapableHerdr = Pick<HerdrDriver, "closeTab" | "panes" | "paneForegr
  *  is reachable by a slug. Exception: `"rundown"` (exact, no space) relies on the
  *  liveness gate instead.
  *
+ *  The distiller now spawns under a UNIQUE per-run name of the form
+ *  `__distill__<8hex>` (prefix `DISTILL_LABEL`), matched here by prefix. The prefix ends
+ *  in `__`, which `[a-z0-9-]` slugs can never produce, so the prefix match stays
+ *  collision-proof. The per-pane liveness check remains the actual safety gate.
+ *
  *  Helpers covered:
  *  - `__usage_probe__`   — usage probe (PROBE_NAME)
- *  - `__distill__`       — distiller (DISTILL_LABEL)
+ *  - `__distill__<hex>`  — distiller (DISTILL_LABEL prefix, unique per run)
  *  - `review <desig>`    — critic / code-review spawns
  *  - `name <desig>`      — background LLM namer
  *  - `plan-review <desig>` — plan-gate reviewer (plan-gate.ts)
@@ -37,7 +42,7 @@ export type ReapableHerdr = Pick<HerdrDriver, "closeTab" | "panes" | "paneForegr
 export function isShepherdHelperLabel(label: string): boolean {
   return (
     label === PROBE_NAME ||
-    label === DISTILL_LABEL ||
+    label.startsWith(DISTILL_LABEL) ||
     label === "rundown" ||
     label === "verify api key" ||
     label.startsWith("review ") ||

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -546,6 +546,43 @@ test("health — spawn failures accumulate; HerdrUnavailableError is NOT counted
   expect(d.health().lastFailure?.repoPath).toBe("/r3");
 });
 
+test("health — onChange fires on the unhealthy transition and on every further failure while unhealthy", () => {
+  const store = new SessionStore(":memory:");
+  for (let i = 0; i < 6; i++) seedSignals(store, `/r${i}`, 1);
+
+  let changes = 0;
+  const deps = {
+    store,
+    herdr: {
+      start: () => {
+        throw new Error("spawn failed");
+      },
+      stop: () => {},
+    } as any,
+    scratch: { create: () => ({ dir: "/s" }), remove: () => {} },
+    onChange: () => changes++,
+    now: () => 1000,
+    minSignals: 1,
+    writeSignals: () => {},
+    readProposals: () => null,
+  };
+  const d = new DistillerService(deps as any);
+
+  // Below threshold (banner hidden): no emit.
+  d.distillNow("/r0"); // 1 failure
+  d.distillNow("/r1"); // 2 failures
+  expect(changes).toBe(0);
+
+  d.distillNow("/r2"); // 3rd failure → ok→unhealthy transition
+  expect(changes).toBe(1);
+
+  // Already unhealthy: each further failure still emits so the count stays fresh.
+  d.distillNow("/r3"); // 4 failures
+  d.distillNow("/r4"); // 5 failures
+  expect(changes).toBe(3);
+  expect(d.health().consecutiveFailures).toBe(5);
+});
+
 test("health — timeout-no-output counts as failure; successful finalize resets health", async () => {
   const store = new SessionStore(":memory:");
   seedSignals(store, "/r", 1);

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -1,8 +1,9 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { DistillerService } from "../src/distiller";
+import { DistillerService, DISTILL_LABEL } from "../src/distiller";
 import { SessionStore } from "../src/store";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+import { HerdrUnavailableError } from "../src/herdr";
 
 beforeEach(() => {
   __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
@@ -390,4 +391,199 @@ test("dismissed rules are passed to the distiller so they aren't re-proposed", (
   const d = new DistillerService(deps as any);
   d.distillNow("/r");
   expect(captured).toContain("dismissed rule");
+});
+
+// ── New tests: unique agent name, concurrency cap, health ───────────────────
+
+function mkCollisionAwareDeps(
+  store: SessionStore,
+  proposals: any,
+  onChange = () => {},
+  maxConcurrent?: number,
+) {
+  const liveNames = new Set<string>();
+  const nameByTerminalId = new Map<string, string>();
+  let nextId = 0;
+  const started: { name: string; dir: string }[] = [];
+  return {
+    deps: {
+      store,
+      herdr: {
+        start: (name: string, cwd: string) => {
+          if (liveNames.has(name)) throw new Error(`agent_name_taken: ${name}`);
+          const terminalId = `dist${nextId++}`;
+          liveNames.add(name);
+          nameByTerminalId.set(terminalId, name);
+          started.push({ name, dir: cwd });
+          return { terminalId };
+        },
+        stop: (terminalId: string) => {
+          const n = nameByTerminalId.get(terminalId);
+          if (n) liveNames.delete(n);
+          nameByTerminalId.delete(terminalId);
+        },
+      } as any,
+      scratch: {
+        create: () => ({ dir: `/scratch/${nextId}` }),
+        remove: () => {},
+      },
+      onChange,
+      now: () => 1000,
+      minSignals: 3,
+      maxConcurrent,
+      writeSignals: () => {},
+      readProposals: () => proposals,
+    },
+    started,
+    liveNames,
+  };
+}
+
+test("collision regression: two repos considered together get distinct unique agent names", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r1", 3);
+  seedSignals(store, "/r2", 3);
+  const { deps, started } = mkCollisionAwareDeps(store, { rules: [], ineffective: [] });
+  const d = new DistillerService(deps as any);
+  // Both repos pass threshold — both should spawn without collision
+  d.consider("/r1");
+  d.consider("/r2");
+  expect(started.length).toBe(2);
+  // Names must be unique and share the DISTILL_LABEL prefix
+  const [n1, n2] = started.map((s) => s.name);
+  expect(n1).toMatch(new RegExp(`^${DISTILL_LABEL}`));
+  expect(n2).toMatch(new RegExp(`^${DISTILL_LABEL}`));
+  expect(n1).not.toBe(n2);
+});
+
+test("concurrency cap: at most maxConcurrent spawns live; queue drains via tick", async () => {
+  const store = new SessionStore(":memory:");
+  for (const r of ["/r1", "/r2", "/r3", "/r4"]) seedSignals(store, r, 3);
+  let tickRead = false;
+  const readProposals = () => (tickRead ? { rules: [], ineffective: [] } : null);
+  const { deps, started } = mkCollisionAwareDeps(store, null, () => {}, 2);
+  // override readProposals to be dynamic
+  (deps as any).readProposals = readProposals;
+  const d = new DistillerService(deps as any);
+
+  d.consider("/r1");
+  d.consider("/r2");
+  d.consider("/r3");
+  d.consider("/r4");
+
+  // Only 2 spawned (cap)
+  expect(started.length).toBe(2);
+
+  // Let the inflight runs finalize and drain queue
+  tickRead = true;
+  await d.tick(); // finalizes r1 + r2, drains r3 + r4
+  expect(started.length).toBe(4);
+});
+
+test("distillNow respects the cap: second call queued, drains on tick", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r1", 1);
+  seedSignals(store, "/r2", 1);
+  let tickRead = false;
+  const readProposals = () => (tickRead ? { rules: [], ineffective: [] } : null);
+  const { deps, started } = mkCollisionAwareDeps(store, null, () => {}, 1);
+  (deps as any).readProposals = readProposals;
+  const d = new DistillerService(deps as any);
+
+  d.distillNow("/r1");
+  d.distillNow("/r2");
+
+  expect(started.length).toBe(1); // only 1 inflight
+
+  tickRead = true;
+  await d.tick(); // finalizes r1, drains r2
+  expect(started.length).toBe(2);
+});
+
+test("health — spawn failures accumulate; HerdrUnavailableError is NOT counted", async () => {
+  const store = new SessionStore(":memory:");
+  for (let i = 0; i < 5; i++) seedSignals(store, `/r${i}`, 1);
+
+  let throwUnavailable = false;
+  let throwSpawn = false;
+  const deps = {
+    store,
+    herdr: {
+      start: () => {
+        if (throwUnavailable) throw new HerdrUnavailableError();
+        if (throwSpawn) throw new Error("spawn failed");
+        return { terminalId: "t1" };
+      },
+      stop: () => {},
+    } as any,
+    scratch: { create: () => ({ dir: "/s" }), remove: () => {} },
+    onChange: () => {},
+    now: () => 1000,
+    minSignals: 1,
+    writeSignals: () => {},
+    readProposals: () => null,
+  };
+  const d = new DistillerService(deps as any);
+
+  // HerdrUnavailableError does NOT affect health
+  throwUnavailable = true;
+  d.distillNow("/r0");
+  expect(d.health().ok).toBe(true);
+  expect(d.health().consecutiveFailures).toBe(0);
+
+  throwUnavailable = false;
+  throwSpawn = true;
+
+  // 3 spawn failures → threshold breached
+  d.distillNow("/r1");
+  expect(d.health().ok).toBe(true); // 1 failure
+  d.distillNow("/r2");
+  expect(d.health().ok).toBe(true); // 2 failures
+  d.distillNow("/r3");
+  expect(d.health().ok).toBe(false); // 3 failures → not ok
+  expect(d.health().consecutiveFailures).toBe(3);
+  expect(d.health().lastFailure?.reason).toBe("spawn");
+  expect(d.health().lastFailure?.repoPath).toBe("/r3");
+});
+
+test("health — timeout-no-output counts as failure; successful finalize resets health", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 1);
+  let t = 1000;
+  let readResult: any = null;
+  let stops = 0;
+  const deps = {
+    store,
+    herdr: {
+      start: () => ({ terminalId: "t1" }),
+      stop: () => stops++,
+    } as any,
+    scratch: { create: () => ({ dir: "/s" }), remove: () => {} },
+    onChange: () => {},
+    now: () => t,
+    minSignals: 1,
+    timeoutMs: 5_000,
+    writeSignals: () => {},
+    readProposals: () => readResult,
+  };
+  const d = new DistillerService(deps as any);
+
+  // 3 timeout failures to trip health
+  for (let i = 0; i < 3; i++) {
+    readResult = null;
+    d.distillNow("/r");
+    t += 6_000; // force timeout
+    await d.tick(); // timeout-no-output → failure
+  }
+  expect(d.health().ok).toBe(false);
+  expect(d.health().consecutiveFailures).toBe(3);
+
+  // Now a successful run resets health
+  t += 1;
+  readResult = { rules: [], ineffective: [] };
+  d.distillNow("/r");
+  await d.tick(); // proposals ready → success
+  expect(d.health().ok).toBe(true);
+  expect(d.health().consecutiveFailures).toBe(0);
+  expect(d.health().lastFailure).toBeNull();
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1232,6 +1232,32 @@ test("GET /api/learnings/injectable marks all rules uninjected when learnings di
   expect(off.rules[0].injected).toBe(false);
 });
 
+// ── /api/learnings/health ────────────────────────────────────────────────────
+
+test("GET /api/learnings/health returns distiller health when health() present", async () => {
+  const deps = makeDeps();
+  const unhealthy = {
+    ok: false,
+    consecutiveFailures: 3,
+    lastFailure: { reason: "spawn", at: 1, repoPath: "/r" },
+  };
+  deps.distiller = { distillNow: () => {}, health: () => unhealthy };
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://x/api/learnings/health"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual(unhealthy);
+});
+
+test("GET /api/learnings/health returns safe default when distiller lacks health()", async () => {
+  const deps = makeDeps(); // distiller = { distillNow: () => {} } — no health
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://x/api/learnings/health"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, consecutiveFailures: 0, lastFailure: null });
+});
+
 // ── clear-all-merged endpoint ────────────────────────────────────────────────
 // Build an app with a mutable stub prCache (the merged source of truth) + reaper.
 // Rows get random ids, so we create them first, then seed each session's PR state.

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -133,6 +133,43 @@ test("non-helper untouched: a non-helper shell-only pane is ignored across two s
   expect(f2.closed).toEqual([]);
 });
 
+test("distiller unique label: husk tab __distill__<8hex> is reaped after two shell-only sweeps", async () => {
+  const uniqueLabel = `${DISTILL_LABEL}a1b2c3d4`;
+  const panes = [pane("w1:p1", "w1:t1", uniqueLabel)];
+  const procMap: Record<string, string[]> = { "w1:p1": ["zsh"] };
+
+  // Sweep 1: shell-only sighting — recorded, NOT closed.
+  const f1 = procFake(panes, procMap);
+  const r1 = await reapOrphanTabs(f1.h);
+  expect(r1.closed).toEqual([]);
+  expect(f1.closed).toEqual([]);
+  expect(r1.shellOnly).toEqual(new Set(["w1:t1"]));
+
+  // Sweep 2: still shell-only AND seen last sweep → close.
+  const f2 = procFake(panes, procMap);
+  const r2 = await reapOrphanTabs(f2.h, r1.shellOnly);
+  expect(r2.closed).toEqual(["w1:t1"]);
+  expect(f2.closed).toEqual(["w1:t1"]);
+});
+
+test("distiller unique label: tab __distill__<8hex> with live agent is spared (liveness gate)", async () => {
+  const uniqueLabel = `${DISTILL_LABEL}a1b2c3d4`;
+  const panes = [pane("w1:p1", "w1:t1", uniqueLabel)];
+  const procMap: Record<string, string[]> = { "w1:p1": ["claude"] };
+
+  const f1 = procFake(panes, procMap);
+  const r1 = await reapOrphanTabs(f1.h);
+  expect(r1.closed).toEqual([]);
+  expect(r1.sparedLive).toBe(1);
+  expect(r1.shellOnly.has("w1:t1")).toBe(false);
+
+  const f2 = procFake(panes, procMap);
+  const r2 = await reapOrphanTabs(f2.h, r1.shellOnly);
+  expect(r2.closed).toEqual([]);
+  expect(f2.closed).toEqual([]);
+  expect(r2.sparedLive).toBe(1);
+});
+
 test("panes() throwing fails closed — reaps nothing, preserves debounce state", async () => {
   const { h, closed } = procFake([], {}, { panesThrows: true });
   const r = await reapOrphanTabs(h, new Set(["w1:t1"]));
@@ -147,7 +184,8 @@ describe("isShepherdHelperLabel", () => {
   const trueLabels: [string, string][] = [
     // pre-existing helpers
     [PROBE_NAME, "usage probe (underscore marker)"],
-    [DISTILL_LABEL, "distiller (underscore marker)"],
+    [DISTILL_LABEL, "distiller bare prefix (underscore marker)"],
+    [`${DISTILL_LABEL}a1b2c3d4`, "distiller unique label (prefix + 8hex suffix)"],
     ["review TASK-09", "critic/code-review"],
     ["name TASK-09", "background namer"],
     // new helpers (#721)
@@ -171,6 +209,7 @@ describe("isShepherdHelperLabel", () => {
     ["my-feature", "ordinary user session slug"],
     ["usage-probe", "slug form of PROBE_NAME — must NOT be reaped"],
     ["distill", "slug form of DISTILL_LABEL — must NOT be reaped"],
+    ["my-feature-branch", "ordinary user slug (no underscores)"],
     ["reviewing-pr", "starts with 'review' but no trailing space"],
     ["autopilot-mode", "hyphen instead of space — not an autopilot helper"],
     ["name-my-thing", "hyphen instead of space — not a namer helper"],

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -444,6 +444,8 @@
   "learnings_promote_started": "CLAUDE.md-PR für die Regel geöffnet",
   "learnings_promote_failed": "Regel konnte nicht übernommen werden; siehe Server-Log",
   "learnings_promoted_pr": "PR ansehen",
+  "learnings_distiller_stalled_title": "Learnings-Distiller blockiert",
+  "learnings_distiller_stalled_body": "Der Distiller hat seine letzten {count} Versuche nicht abgeschlossen – neue Learnings erscheinen erst, wenn er sich erholt.",
   "viewport_back_aria": "Zurück zum Herd",
   "viewport_back_button": "‹ Herd",
   "viewport_next_needs_you": "Wartet · {count}",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -444,6 +444,8 @@
   "learnings_promote_started": "Opened a CLAUDE.md PR for the rule",
   "learnings_promote_failed": "Could not promote the rule; see the server log",
   "learnings_promoted_pr": "View PR",
+  "learnings_distiller_stalled_title": "Learnings distiller stalled",
+  "learnings_distiller_stalled_body": "The distiller hasn't completed a run in its last {count} attempts — new learnings won't appear until it recovers.",
   "viewport_back_aria": "Back to herd",
   "viewport_back_button": "‹ Herd",
   "viewport_next_needs_you": "Needs you · {count}",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -48,6 +48,7 @@ import type {
   Recap,
   CompletedEpic,
   HerdDigest,
+  DistillerHealth,
 } from "./types";
 import { m } from "$lib/paraglide/messages";
 
@@ -1080,6 +1081,12 @@ export async function getPendingLearnings(): Promise<Learning[]> {
 export async function getInjectableLearnings(): Promise<RepoInjectable[]> {
   const r = await fetch("/api/learnings/injectable");
   if (!r.ok) throw await failed(r, "injectable learnings");
+  return r.json();
+}
+
+export async function getLearningsHealth(): Promise<DistillerHealth> {
+  const r = await fetch("/api/learnings/health");
+  if (!r.ok) throw await failed(r, "learnings health");
   return r.json();
 }
 

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -4,6 +4,7 @@
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
   import type { Learning, RepoInjectable, SignalKind } from "$lib/types";
+  import { learnings } from "$lib/learnings.svelte";
   import {
     basename,
     repoAnchorId,
@@ -136,6 +137,15 @@
     <span class="title">{m.learnings_title()}</span>
     <button class="close" onclick={() => onclose()} aria-label={m.learnings_close_aria()}>✕</button>
   </header>
+
+  {#if !learnings.health.ok}
+    <div class="health-warn" role="status">
+      <strong class="hw-title">{m.learnings_distiller_stalled_title()}</strong>
+      <span class="hw-body"
+        >{m.learnings_distiller_stalled_body({ count: learnings.health.consecutiveFailures })}</span
+      >
+    </div>
+  {/if}
 
   <section class="about">
     <button
@@ -346,6 +356,24 @@
     color: var(--color-muted);
     cursor: pointer;
     font-size: var(--fs-lg);
+  }
+  /* distiller-stalled persistent warning banner */
+  .health-warn {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 10px;
+    border: 1px solid var(--color-amber);
+    background: color-mix(in srgb, var(--color-amber) 12%, var(--color-head));
+    font-size: var(--fs-base);
+  }
+  .hw-title {
+    color: var(--color-amber);
+    font-weight: 600;
+  }
+  .hw-body {
+    color: var(--color-ink-bright);
+    line-height: 1.45;
   }
   /* "What is this?" explainer — collapsible, default open, state remembered. */
   .about {

--- a/ui/src/lib/learnings.svelte.ts
+++ b/ui/src/lib/learnings.svelte.ts
@@ -1,5 +1,5 @@
-import type { Learning, RepoInjectable } from "./types";
-import { getPendingLearnings, getInjectableLearnings } from "./api";
+import type { Learning, RepoInjectable, DistillerHealth } from "./types";
+import { getPendingLearnings, getInjectableLearnings, getLearningsHealth } from "./api";
 
 /** Client cache of PROPOSED learnings (across all repos) plus the per-repo
  *  INJECTABLE view (active/promoted rules + budget meter). Loaded once on app
@@ -8,6 +8,7 @@ import { getPendingLearnings, getInjectableLearnings } from "./api";
 class LearningsStore {
   items = $state<Learning[]>([]);
   injectable = $state<RepoInjectable[]>([]);
+  health = $state<DistillerHealth>({ ok: true, consecutiveFailures: 0, lastFailure: null });
 
   async load() {
     // Independent best-effort fetches: a failure in one must not blank the other.
@@ -19,6 +20,11 @@ class LearningsStore {
         }),
       getInjectableLearnings()
         .then((v) => (this.injectable = v))
+        .catch(() => {
+          /* best-effort */
+        }),
+      getLearningsHealth()
+        .then((v) => (this.health = v))
         .catch(() => {
           /* best-effort */
         }),

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -906,6 +906,12 @@ export interface RepoInjectable {
   rules: (Learning & { injected: boolean })[];
 }
 
+export interface DistillerHealth {
+  ok: boolean;
+  consecutiveFailures: number;
+  lastFailure: { reason: string; at: number; repoPath: string } | null;
+}
+
 // ── leftover subprocesses surfaced at session close ─────────────────────────
 export type LeftoverKind = "process" | "system";
 


### PR DESCRIPTION
## Why

New learnings stopped surfacing — even for repos with thousands of signals. Diagnosed as a **distillation outage**, not a capture problem: signals flow fine (`shepherd`: 2274 signals) and `learningsEnabled=1` everywhere, but the newest learning in the live DB was 2026-06-14.

**Root cause:** every distill run spawned its ephemeral analyst under one *shared* herdr agent name `__distill__`. The daily sweep calls `consider()` for every repo in a tight loop, and the per-repo `inflight` guard doesn't know the name is globally in use — so the 2nd-onward repo collided with `agent_name_taken`, and a stranded `__distill__` husk in the long-lived herdr server (which survives Shepherd restarts) blocked even the first. The spawn error was swallowed as a `console.warn`, so the flywheel died silently. Live `shepherd.log` held **2882** `agent_name_taken` errors (~400 recent `[distill] spawn failed`). Cross-repo because the name is global — matching "even repos I don't usually work in."

## What

- **Unique per-run agent name** (`__distill__<8hex>`; `DISTILL_LABEL` kept as the underscore-bounded, slug-collision-proof prefix) — eliminates the collision class. Reaper now prefix-matches it.
- **Bounded concurrency** — `maxConcurrent` (default 3) + a deduped queue drained by `tick()`; both `consider()` and the manual `distillNow()`/backlog-kick route through one shared slot/queue, so unique names don't turn a sweep into an N-wide burst.
- **Fail-closed health** — global, end-to-end (counts real spawn/write failures and finalize-timeout-with-no-output; excludes `HerdrUnavailableError` + the api-key-not-configured skip; resets on any completed run). `GET /api/learnings/health` + a persistent "distiller stalled" banner in the Learnings drawer (EN+DE), so a future silent outage is visible.
- **Maintenance guard** on `runDailySweep` so sweeps don't fire mid-herdr-update.

## Validation

- Root: `lint` ✓, `tsc --noEmit` ✓, `bun test ./test` 3374 pass / 0 fail.
- UI: `check` 0/0, `check:i18n` parity (1414 keys), `bun run test` 1380 pass.
- Hygiene: branch-hygiene ✓, feature-catalog ✓, glossary ✓, `fallow audit` → no issues in changed files.
- Built subagent-driven (4 tasks, per-task spec+quality reviews + an opus whole-branch review: *Ready to merge*).

The collision regression test bites: its herdr mock enforces name-uniqueness, so it's red against the old fixed name and green now.

## Follow-ups (not in this PR)

- Post-deploy: trigger `POST /api/learnings/distill?repo=…` for the high-signal repos to surface the waiting backlog, and confirm the first-in-sweep-order repo produces a fresh learning (rules out any residual cause).
- `usage-probe` (`__usage_probe__`) shares the same shared-exact-name husk-collision class (singleton, self-heals via the reaper) — same prefix treatment is a candidate cleanup.

`fix:` only — no feature-catalog entry (the banner is failure-surfacing diagnostics, not a promoted capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
