### PR TITLE
fix(review): reap orphaned reviewers across restart to stop recurring REVIEW ERR

### DIFF
--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -181,6 +181,27 @@ export function matchAgents(
   return out;
 }
 
+/**
+ * Returns true when the error thrown by `runner` signals that a same-named agent is
+ * already registered in herdr. The CLI emits `agent_name_taken` as a JSON code on
+ * stderr/stdout, which execFileSync surfaces on the thrown error's `.stderr`/`.stdout`/
+ * `.message`. Defensive: coerces unknown fields to string safely; non-Error throws return
+ * false.
+ */
+export function isNameTakenError(err: unknown): boolean {
+  if (err == null) return false;
+  const marker = "agent_name_taken";
+  if (typeof err === "string") return err.includes(marker);
+  if (typeof err === "object") {
+    const e = err as Record<string, unknown>;
+    for (const field of ["stderr", "stdout", "message"]) {
+      const v = e[field];
+      if (v != null && String(v).includes(marker)) return true;
+    }
+  }
+  return false;
+}
+
 export class HerdrDriver {
   constructor(
     private runner: Runner = defaultRunner,
@@ -302,7 +323,14 @@ export class HerdrDriver {
             .map(([k, v]) => `${k}=${v}`)
         : [];
       const wrapped = ["env", `NODE_COMPILE_CACHE=${compileCacheDir()}`, ...envTokens, ...argv];
-      this.runner([
+      // Collision-breaker: if herdr rejects with `agent_name_taken` (a stale same-named
+      // agent is still registered — e.g. shepherd restarted while an interactive `claude`
+      // was running), resolve the squatter(s) by name from `list()`, close their tabs
+      // (which both kills the orphan via --die-with-parent and synchronously releases the
+      // name), then retry. Bounded at 3 total attempts — no sleep: the sync herdr
+      // round-trips (list + tab close) provide the real-world spacing; a blocking sleep
+      // would freeze Bun's single event loop and stall the live web terminal.
+      const agentStartArgs = [
         "agent",
         "start",
         name,
@@ -313,7 +341,22 @@ export class HerdrDriver {
         "--no-focus",
         "--",
         ...wrapped,
-      ]);
+      ];
+      const MAX_ATTEMPTS = 3;
+      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        try {
+          this.runner(agentStartArgs);
+          break;
+        } catch (err) {
+          if (!isNameTakenError(err) || attempt === MAX_ATTEMPTS - 1) {
+            // Non-name-taken error → propagate immediately; or attempts exhausted → propagate
+            throw err;
+          }
+          // Evict squatter(s) by name — never by regex-parsing the error string
+          const squatters = this.list().filter((a) => a.name === name);
+          for (const sq of squatters) this.closeTab(sq.tabId);
+        }
+      }
 
       if (rootPaneId) {
         try {

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -288,6 +288,44 @@ export class HerdrDriver {
     }
   }
 
+  /** Bounded-retry wrapper around `agent start` that evicts same-named squatter agents
+   *  when herdr rejects with `agent_name_taken`. Up to 3 attempts; no sleep between them
+   *  (the sync herdr round-trips provide real-world spacing). */
+  private startAgentWithCollisionRetry(
+    name: string,
+    tabId: string,
+    cwd: string,
+    wrapped: string[],
+  ): void {
+    const agentStartArgs = [
+      "agent",
+      "start",
+      name,
+      "--tab",
+      tabId,
+      "--cwd",
+      cwd,
+      "--no-focus",
+      "--",
+      ...wrapped,
+    ];
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      try {
+        this.runner(agentStartArgs);
+        return;
+      } catch (err) {
+        if (!isNameTakenError(err) || attempt === MAX_ATTEMPTS - 1) {
+          // Non-name-taken error → propagate immediately; or attempts exhausted → propagate
+          throw err;
+        }
+        // Evict squatter(s) by name — never by regex-parsing the error string
+        const squatters = this.list().filter((a) => a.name === name);
+        for (const sq of squatters) this.closeTab(sq.tabId);
+      }
+    }
+  }
+
   start(name: string, cwd: string, argv: string[], env?: Record<string, string>): HerdrAgent {
     // herdr needs an active workspace before any tab can be created — guarantee one.
     this.ensureWorkspace(cwd);
@@ -330,33 +368,7 @@ export class HerdrDriver {
       // name), then retry. Bounded at 3 total attempts — no sleep: the sync herdr
       // round-trips (list + tab close) provide the real-world spacing; a blocking sleep
       // would freeze Bun's single event loop and stall the live web terminal.
-      const agentStartArgs = [
-        "agent",
-        "start",
-        name,
-        "--tab",
-        tabId,
-        "--cwd",
-        cwd,
-        "--no-focus",
-        "--",
-        ...wrapped,
-      ];
-      const MAX_ATTEMPTS = 3;
-      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-        try {
-          this.runner(agentStartArgs);
-          break;
-        } catch (err) {
-          if (!isNameTakenError(err) || attempt === MAX_ATTEMPTS - 1) {
-            // Non-name-taken error → propagate immediately; or attempts exhausted → propagate
-            throw err;
-          }
-          // Evict squatter(s) by name — never by regex-parsing the error string
-          const squatters = this.list().filter((a) => a.name === name);
-          for (const sq of squatters) this.closeTab(sq.tabId);
-        }
-      }
+      this.startAgentWithCollisionRetry(name, tabId, cwd, wrapped);
 
       if (rootPaneId) {
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -692,7 +692,7 @@ void planGate
     for (const id of ids) reKickReapedReview(id);
   })
   .then(() => sweepStaleReviewWorktrees())
-  .catch((err) => console.warn("[plan-gate] adoptOrphans:", err));
+  .catch((err) => console.warn("[boot] review/plan-gate orphan reconcile:", err));
 setInterval(() => sweepStaleReviewWorktrees(), 60 * 60 * 1000);
 
 attachReviewPush(events, store, push);

--- a/src/index.ts
+++ b/src/index.ts
@@ -672,14 +672,20 @@ const reKickReapedReview = (id: string) => {
   if (!s) return;
   const git = prPoller.get(id);
   if (git) {
-    // Warm cache: force-consider bypasses head-dedup and spawn-ceiling so it doesn't depend on
-    // gitStateChanged; consider itself no-ops if the PR isn't open+green, so a stale kick is safe.
+    // Have a fresh cached GitState → re-review directly. NOT forced, and that is deliberate:
+    // for an error orphan reapOrphans already dropped the verdict, so a plain consider() re-reviews
+    // (no head-dedup); for a non-error orphan, normal rules re-review on a moved head and correctly
+    // skip a redundant same-head re-review, keeping the spawn-ceiling cost guard intact. This also
+    // matches the cold-cache branch below, which can only run a non-force consider via the
+    // subscription — so both paths have identical semantics (consider itself no-ops if the PR
+    // isn't open+green, so a stale kick is safe).
     void reviewService
-      .consider(s, git, { force: true })
+      .consider(s, git)
       .catch((err) => console.warn("[review] reap re-kick consider failed:", err));
   } else {
-    // Cold cache (3s warm tick hasn't run yet): drop+pollSession so the next refresh() emits
-    // session:git with no prior `prev`, guaranteeing consider() fires via the subscription below.
+    // No cached GitState yet (the 3s boot warm-tick hasn't run): drop+pollSession so the next
+    // refresh() emits session:git with no prior `prev`, firing the same non-force consider() via
+    // the subscription below.
     prPoller.drop(id);
     prPoller.pollSession(id);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -661,11 +661,36 @@ const sweepStaleReviewWorktrees = () => {
 // gate never advances, and the planning agent sits idle awaiting a re-review that never comes.
 // The next tick() then finalizes each re-adopted run from the verdict it already wrote.
 // gcStaleReviewWorktrees runs AFTER adoptOrphans has repopulated `inflight` so it only reaps
-// truly ownerless review worktrees (e.g. the older of two #631 same-session orphans); the
-// disk-sweep then runs after gc, with `inflight` populated so its protectedPaths spare holds.
+// truly ownerless review worktrees (e.g. the older of two #631 same-session orphans).
+// reapOrphans() runs BEFORE sweepStaleReviewWorktrees: for a dead-process orphan whose claude
+// already exited but finalize never ran the worktree survives — the disk sweep would delete it
+// first, erasing the orphan signal before reapOrphans can see it. Running reap first drops the
+// sticky error verdict and returns the task session ids to re-kick with a force-consider so the
+// critic re-runs; the disk-sweep then runs last, with `inflight` populated so protectedPaths hold.
+const reKickReapedReview = (id: string) => {
+  const s = store.get(id);
+  if (!s) return;
+  const git = prPoller.get(id);
+  if (git) {
+    // Warm cache: force-consider bypasses head-dedup and spawn-ceiling so it doesn't depend on
+    // gitStateChanged; consider itself no-ops if the PR isn't open+green, so a stale kick is safe.
+    void reviewService
+      .consider(s, git, { force: true })
+      .catch((err) => console.warn("[review] reap re-kick consider failed:", err));
+  } else {
+    // Cold cache (3s warm tick hasn't run yet): drop+pollSession so the next refresh() emits
+    // session:git with no prior `prev`, guaranteeing consider() fires via the subscription below.
+    prPoller.drop(id);
+    prPoller.pollSession(id);
+  }
+};
 void planGate
   .adoptOrphans()
   .then(() => planGate.gcStaleReviewWorktrees())
+  .then(() => reviewService.reapOrphans())
+  .then((ids) => {
+    for (const id of ids) reKickReapedReview(id);
+  })
   .then(() => sweepStaleReviewWorktrees())
   .catch((err) => console.warn("[plan-gate] adoptOrphans:", err));
 setInterval(() => sweepStaleReviewWorktrees(), 60 * 60 * 1000);

--- a/src/review.ts
+++ b/src/review.ts
@@ -882,10 +882,13 @@ export class ReviewService {
 
   /** Find a live herdr agent that was spawned for a review run, resolved by NAME first
    *  ("review TASK-<n>"), falling back to the worktree cwd. ONE `list()` call per
-   *  invocation. Returns undefined when no live agent matches — the reviewer is already gone. */
+   *  invocation. An empty/falsy `label` (session gone) skips the name match entirely —
+   *  an unnamed agent (name="") would otherwise match every gone-session lookup and
+   *  close an unrelated agent. Returns undefined when no live agent matches. */
   private findSquatter(label: string, cwd: string): HerdrAgent | undefined {
     const agents = this.deps.herdr.list();
-    return agents.find((a) => a.name === label) ?? agents.find((a) => a.cwd === cwd);
+    const byName = label ? agents.find((a) => a.name === label) : undefined;
+    return byName ?? agents.find((a) => a.cwd === cwd);
   }
 
   /** Boot reconcile: close dangling `reviewer_spawns` rows from the last run and kill

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
+import { existsSync } from "node:fs";
 import type { SessionStore } from "./store";
-import type { HerdrDriver } from "./herdr";
+import type { HerdrDriver, HerdrAgent } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
 import type { GitForge, GitState, PrStatus } from "./forge/types";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "./forge/types";
@@ -124,8 +125,10 @@ export interface ReviewServiceDeps {
     | "addSignal"
     | "recordReviewerSpawn"
     | "completeReviewerSpawn"
+    | "listReviewerSpawns"
+    | "get"
   >;
-  herdr: Pick<HerdrDriver, "start" | "stop">;
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab">;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "gitCommonDir">;
   resolveForge: (repoPath: string) => GitForge | null;
   onChange: (id: string, verdict: ReviewVerdict) => void;
@@ -155,6 +158,10 @@ export interface ReviewServiceDeps {
   model?: string | null; // optional --model for the critic
   now?: () => number;
   timeoutMs?: number; // give up waiting on the verdict file
+  /** default: `existsSync` — whether a reviewer's disposable worktree is still on disk.
+   *  reapOrphans() uses it to tell a true restart-orphan (worktree survives) from an
+   *  already-finalized review (finalize reaps the worktree). */
+  worktreeExists?: (p: string) => boolean;
   /** Injectable verdict reader (default: read VERDICT_FILE from the worktree). */
   readVerdict?: (worktreePath: string) => RawVerdict | null;
   /** Injectable content fingerprint of `git diff base...HEAD` in the worktree (default:
@@ -209,6 +216,7 @@ export class ReviewService {
     worktreePath: string,
     criticSessionId: string,
   ) => Promise<SessionUsage | null>;
+  private worktreeExists: (p: string) => boolean;
 
   /** Sandbox backend probe: injected seam (tests) or the real cached self-test. Presence-
    *  checked (not `??`) because the seam legitimately returns null (no backend). */
@@ -247,6 +255,7 @@ export class ReviewService {
     this.computePatchId = deps.computePatchId ?? defaultComputePatchId;
     this.readActivity = deps.readActivity ?? defaultReadActivity;
     this.readUsage = deps.readUsage ?? readSessionUsage;
+    this.worktreeExists = deps.worktreeExists ?? existsSync;
   }
 
   /** Decide whether `git` warrants a fresh critic run for `session`, and start one. With
@@ -869,6 +878,108 @@ export class ReviewService {
       seenNoteIds: f.seenNoteIds, // carry the per-round note dedup set forward
       updatedAt: this.now(),
     };
+  }
+
+  /** Find a live herdr agent that was spawned for a review run, resolved by NAME first
+   *  ("review TASK-<n>"), falling back to the worktree cwd. ONE `list()` call per
+   *  invocation. Returns undefined when no live agent matches — the reviewer is already gone. */
+  private findSquatter(label: string, cwd: string): HerdrAgent | undefined {
+    const agents = this.deps.herdr.list();
+    return agents.find((a) => a.name === label) ?? agents.find((a) => a.cwd === cwd);
+  }
+
+  /** Boot reconcile: close dangling `reviewer_spawns` rows from the last run and kill
+   *  any still-alive orphaned critic processes.
+   *
+   *  An "orphan" is a review that was in flight when the server last restarted. Because
+   *  `inflight` is in-memory only, tick() never finalizes it; the still-alive `claude`
+   *  holds the stable herdr name "review TASK-<n>", and the next consider() for that
+   *  session collides with `agent_name_taken`. This sweep detects and reaps them.
+   *
+   *  The orphan SIGNAL is the surviving disposable worktree — finalize() always removes
+   *  it, so a present worktree means finalize() NEVER ran (i.e., a true restart-orphan).
+   *  A row whose worktree is already gone (finalize ran but captureUsage's `if (usage)`
+   *  guard left the row uncompleted) is NOT an orphan: it's a completed-but-unclosed row.
+   *  We close those too (step a), but we do NOT reap/drop/re-kick them — preserving any
+   *  genuine-timeout `error` verdict's errorRound/streak escalation accounting.
+   *
+   *  Returns the taskSessionIds that should be re-kicked by the caller (index.ts wiring
+   *  in a separate task). Logs a one-line summary of what was reaped. */
+  async reapOrphans(): Promise<string[]> {
+    const reKick: string[] = [];
+    let danglingClosed = 0;
+    let orphansReaped = 0;
+
+    for (const row of this.deps.store.listReviewerSpawns()) {
+      // Only handle uncompleted review rows; plan_gate/recap/rundown are handled elsewhere.
+      if (row.kind !== "review" || row.completedAt != null) continue;
+      // Defensive: if already tracked in-memory (shouldn't be at boot, but guard anyway).
+      if (this.inflight.has(row.taskSessionId) || this.starting.has(row.taskSessionId)) continue;
+
+      // Wrap the entire row body so one bad row cannot abort the sweep.
+      try {
+        // a. Always close the dangling row first — read real usage when available, else
+        //    zero (so the row is never re-listed every boot). This is ONE unconditional
+        //    completion, avoiding captureUsage's `if (usage)` double-complete trap.
+        const usage = await this.readUsage(row.worktreePath, row.reviewerSessionId).catch(
+          () => null,
+        );
+        const zeroedUsage: SessionUsage = {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+          messageCount: 0,
+          lastActivity: null,
+          byModel: {},
+          fullRecaches: 0,
+          sidechainCount: 0,
+        };
+        this.deps.store.completeReviewerSpawn(
+          row.reviewerSessionId,
+          usage ?? zeroedUsage,
+          this.now(),
+        );
+
+        // b. Worktree gone → finalize already ran; just a dangling completion row.
+        //    Do NOT reap/drop/re-kick — preserves genuine-timeout error verdict accounting.
+        if (!this.worktreeExists(row.worktreePath)) {
+          danglingClosed++;
+          continue;
+        }
+
+        // c. True orphan: the disposable worktree still exists → finalize never ran.
+        orphansReaped++;
+        const s = this.deps.store.get(row.taskSessionId);
+        // Free the name AND kill the still-alive claude process by closing its herdr tab.
+        // Resolve by NAME first ("review TASK-<n>"), fall back to cwd only as a safety net
+        // (avoids a second list() call for the name-absent case when the session is gone).
+        const squatter = this.findSquatter(s ? `review ${s.desig}` : "", row.worktreePath);
+        if (squatter) this.deps.herdr.closeTab(squatter.tabId);
+        // Remove the worktree AFTER freeing the name so the herdr slot is open before
+        // the worktree is gone (mirrors plan-gate's ordering invariant).
+        this.deps.worktree.remove(row.worktreePath);
+
+        // Re-engage only when the session is still present — a gone session needs no kick.
+        if (s) {
+          reKick.push(row.taskSessionId);
+          // An error verdict carries no findings — drop it so the next run starts fresh
+          // without a sticky REVIEW ERR badge. Non-error verdicts are left intact so the
+          // force-consider path in the later wiring task can preserve their streak accounting.
+          if (this.deps.store.getReview(row.taskSessionId)?.decision === "error") {
+            this.deps.store.dropReview(row.taskSessionId);
+          }
+        }
+      } catch (err) {
+        console.warn(`[review] reapOrphans: error processing row ${row.reviewerSessionId}:`, err);
+      }
+    }
+
+    console.warn(
+      `[review] reapOrphans: ${orphansReaped} orphan(s) reaped, ${danglingClosed} dangling row(s) closed`,
+    );
+    return reKick;
   }
 
   snapshot(): Record<string, ReviewVerdict> {

--- a/src/review.ts
+++ b/src/review.ts
@@ -5,7 +5,7 @@ import type { HerdrDriver, HerdrAgent } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
 import type { GitForge, GitState, PrStatus } from "./forge/types";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "./forge/types";
-import type { ReviewVerdict, Session } from "./types";
+import type { ReviewVerdict, Session, ReviewerSpawnRow } from "./types";
 import { readonlyReviewerArgv } from "./reviewer-argv";
 import {
   isApiKeyMode,
@@ -921,58 +921,12 @@ export class ReviewService {
 
       // Wrap the entire row body so one bad row cannot abort the sweep.
       try {
-        // a. Always close the dangling row first — read real usage when available, else
-        //    zero (so the row is never re-listed every boot). This is ONE unconditional
-        //    completion, avoiding captureUsage's `if (usage)` double-complete trap.
-        const usage = await this.readUsage(row.worktreePath, row.reviewerSessionId).catch(
-          () => null,
-        );
-        const zeroedUsage: SessionUsage = {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          total: 0,
-          messageCount: 0,
-          lastActivity: null,
-          byModel: {},
-          fullRecaches: 0,
-          sidechainCount: 0,
-        };
-        this.deps.store.completeReviewerSpawn(
-          row.reviewerSessionId,
-          usage ?? zeroedUsage,
-          this.now(),
-        );
-
-        // b. Worktree gone → finalize already ran; just a dangling completion row.
-        //    Do NOT reap/drop/re-kick — preserves genuine-timeout error verdict accounting.
-        if (!this.worktreeExists(row.worktreePath)) {
+        const result = await this.reapOneOrphanRow(row);
+        if (result.kind === "dangling") {
           danglingClosed++;
-          continue;
-        }
-
-        // c. True orphan: the disposable worktree still exists → finalize never ran.
-        orphansReaped++;
-        const s = this.deps.store.get(row.taskSessionId);
-        // Free the name AND kill the still-alive claude process by closing its herdr tab.
-        // Resolve by NAME first ("review TASK-<n>"), fall back to cwd only as a safety net
-        // (avoids a second list() call for the name-absent case when the session is gone).
-        const squatter = this.findSquatter(s ? `review ${s.desig}` : "", row.worktreePath);
-        if (squatter) this.deps.herdr.closeTab(squatter.tabId);
-        // Remove the worktree AFTER freeing the name so the herdr slot is open before
-        // the worktree is gone (mirrors plan-gate's ordering invariant).
-        this.deps.worktree.remove(row.worktreePath);
-
-        // Re-engage only when the session is still present — a gone session needs no kick.
-        if (s) {
-          reKick.push(row.taskSessionId);
-          // An error verdict carries no findings — drop it so the next run starts fresh
-          // without a sticky REVIEW ERR badge. Non-error verdicts are left intact so the
-          // force-consider path in the later wiring task can preserve their streak accounting.
-          if (this.deps.store.getReview(row.taskSessionId)?.decision === "error") {
-            this.deps.store.dropReview(row.taskSessionId);
-          }
+        } else if (result.kind === "orphan") {
+          orphansReaped++;
+          if (result.reKickId) reKick.push(result.reKickId);
         }
       } catch (err) {
         console.warn(`[review] reapOrphans: error processing row ${row.reviewerSessionId}:`, err);
@@ -983,6 +937,60 @@ export class ReviewService {
       `[review] reapOrphans: ${orphansReaped} orphan(s) reaped, ${danglingClosed} dangling row(s) closed`,
     );
     return reKick;
+  }
+
+  /** Process a single uncompleted reviewer_spawns row during the boot orphan sweep.
+   *  Returns `{ kind: "dangling" }` for rows whose worktree is already gone (finalize ran),
+   *  or `{ kind: "orphan", reKickId }` for true restart-orphans (worktree still present).
+   *  Always closes the DB row first. Never throws — caller's try/catch scopes the error. */
+  private async reapOneOrphanRow(
+    row: ReviewerSpawnRow,
+  ): Promise<{ kind: "dangling" } | { kind: "orphan"; reKickId: string | null }> {
+    // a. Always close the dangling row first — read real usage when available, else
+    //    zero (so the row is never re-listed every boot). This is ONE unconditional
+    //    completion, avoiding captureUsage's `if (usage)` double-complete trap.
+    const usage = await this.readUsage(row.worktreePath, row.reviewerSessionId).catch(() => null);
+    const zeroedUsage: SessionUsage = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+      messageCount: 0,
+      lastActivity: null,
+      byModel: {},
+      fullRecaches: 0,
+      sidechainCount: 0,
+    };
+    this.deps.store.completeReviewerSpawn(row.reviewerSessionId, usage ?? zeroedUsage, this.now());
+
+    // b. Worktree gone → finalize already ran; just a dangling completion row.
+    //    Do NOT reap/drop/re-kick — preserves genuine-timeout error verdict accounting.
+    if (!this.worktreeExists(row.worktreePath)) {
+      return { kind: "dangling" };
+    }
+
+    // c. True orphan: the disposable worktree still exists → finalize never ran.
+    const s = this.deps.store.get(row.taskSessionId);
+    // Free the name AND kill the still-alive claude process by closing its herdr tab.
+    // Resolve by NAME first ("review TASK-<n>"), fall back to cwd only as a safety net
+    // (avoids a second list() call for the name-absent case when the session is gone).
+    const squatter = this.findSquatter(s ? `review ${s.desig}` : "", row.worktreePath);
+    if (squatter) this.deps.herdr.closeTab(squatter.tabId);
+    // Remove the worktree AFTER freeing the name so the herdr slot is open before
+    // the worktree is gone (mirrors plan-gate's ordering invariant).
+    this.deps.worktree.remove(row.worktreePath);
+
+    // Re-engage only when the session is still present — a gone session needs no kick.
+    if (!s) return { kind: "orphan", reKickId: null };
+
+    // An error verdict carries no findings — drop it so the next run starts fresh
+    // without a sticky REVIEW ERR badge. Non-error verdicts are left intact so the
+    // force-consider path in the later wiring task can preserve their streak accounting.
+    if (this.deps.store.getReview(row.taskSessionId)?.decision === "error") {
+      this.deps.store.dropReview(row.taskSessionId);
+    }
+    return { kind: "orphan", reKickId: row.taskSessionId };
   }
 
   snapshot(): Record<string, ReviewVerdict> {

--- a/src/review.ts
+++ b/src/review.ts
@@ -985,8 +985,9 @@ export class ReviewService {
     if (!s) return { kind: "orphan", reKickId: null };
 
     // An error verdict carries no findings — drop it so the next run starts fresh
-    // without a sticky REVIEW ERR badge. Non-error verdicts are left intact so the
-    // force-consider path in the later wiring task can preserve their streak accounting.
+    // without a sticky REVIEW ERR badge (and so the re-kick's plain consider() isn't head-deduped).
+    // Non-error verdicts are left intact: the re-kick re-reviews them under normal rules (on a moved
+    // head, within the spawn ceiling), which preserves their streak accounting — no dropReview reset.
     if (this.deps.store.getReview(row.taskSessionId)?.decision === "error") {
       this.deps.store.dropReview(row.taskSessionId);
     }

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -324,7 +324,7 @@ test("matchAgents: a sole session at its cwd re-pairs even when its name drifted
 });
 
 import { maintenance } from "../src/maintenance";
-import { HerdrUnavailableError, makeHerdrRunner } from "../src/herdr";
+import { HerdrUnavailableError, makeHerdrRunner, isNameTakenError } from "../src/herdr";
 
 test("runner throws fast (no spawn) while maintenance is active", () => {
   let spawned = 0;
@@ -615,4 +615,208 @@ test("paneForegroundProcs() propagates a thrown runner error (does not swallow)"
   await expect(d.paneForegroundProcs("w65:p2")).rejects.toThrow(
     "herdr: unknown subcommand pane process-info",
   );
+});
+
+// -- isNameTakenError unit tests --
+
+const NAME_TAKEN_JSON =
+  '{"error":{"code":"agent_name_taken","message":"agent name review TASK-504 is already used; candidates: terminal_id=t1 tab_id=tab_9 status=Unknown"},"id":"cli:agent:start"}';
+
+test("isNameTakenError: true when agent_name_taken appears on .stderr", () => {
+  const err = Object.assign(new Error("herdr CLI error"), { stderr: NAME_TAKEN_JSON });
+  expect(isNameTakenError(err)).toBe(true);
+});
+
+test("isNameTakenError: true when agent_name_taken appears on .message", () => {
+  const err = new Error(NAME_TAKEN_JSON);
+  expect(isNameTakenError(err)).toBe(true);
+});
+
+test("isNameTakenError: true when agent_name_taken appears on .stdout", () => {
+  const err = Object.assign(new Error("herdr CLI error"), { stdout: NAME_TAKEN_JSON });
+  expect(isNameTakenError(err)).toBe(true);
+});
+
+test("isNameTakenError: false for an unrelated error", () => {
+  const err = new Error("herdr: some other failure");
+  expect(isNameTakenError(err)).toBe(false);
+});
+
+test("isNameTakenError: false for undefined", () => {
+  expect(isNameTakenError(undefined)).toBe(false);
+});
+
+test("isNameTakenError: false for null", () => {
+  expect(isNameTakenError(null)).toBe(false);
+});
+
+test("isNameTakenError: false for plain string without marker", () => {
+  expect(isNameTakenError("something went wrong")).toBe(false);
+});
+
+// -- start() collision-breaker tests --
+
+// Fixture: the squatter agent that holds the name before the retry succeeds
+const SQUATTER_LIST = JSON.stringify({
+  result: {
+    type: "agent_list",
+    agents: [
+      {
+        agent: "claude",
+        agent_status: "done",
+        cwd: "/wt/a",
+        name: "review TASK-504",
+        pane_id: "p_sq",
+        tab_id: "tab_squatter",
+        terminal_id: "term_squatter",
+        workspace_id: "w1",
+      },
+    ],
+  },
+});
+
+// Agent list after the squatter is evicted: the freshly started agent appears at /wt/a
+const POST_EVICT_LIST = JSON.stringify({
+  result: {
+    type: "agent_list",
+    agents: [
+      {
+        agent: "claude",
+        agent_status: "working",
+        cwd: "/wt/a",
+        name: "review TASK-504",
+        pane_id: "p_new",
+        tab_id: "tab_started",
+        terminal_id: "term_started",
+        workspace_id: "w1",
+      },
+    ],
+  },
+});
+
+function makeNameTakenError(): Error {
+  return Object.assign(new Error("herdr CLI error"), { stderr: NAME_TAKEN_JSON });
+}
+
+test("start: single collision then success — squatter tab closed, agent returned", () => {
+  const calls: string[][] = [];
+  let agentStartAttempts = 0;
+  // list() returns squatter on first call (during eviction), then the fresh agent
+  let listCallCount = 0;
+
+  const runner = (args: string[]) => {
+    calls.push(args);
+    if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
+    if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
+    if (args[0] === "agent" && args[1] === "start") {
+      agentStartAttempts++;
+      if (agentStartAttempts === 1) throw makeNameTakenError();
+      return "{}";
+    }
+    if (args[0] === "agent" && args[1] === "list") {
+      listCallCount++;
+      // first list() call is during eviction (resolves squatter), second is the final resolve
+      return listCallCount === 1 ? SQUATTER_LIST : POST_EVICT_LIST;
+    }
+    if (args[0] === "tab" && args[1] === "close") return "{}";
+    if (args[0] === "pane" && args[1] === "close") return "{}";
+    return "{}";
+  };
+
+  const d = new HerdrDriver(runner);
+  const agent = d.start("review TASK-504", "/wt/a", ["claude", "go"]);
+
+  // squatter's tab was closed
+  expect(calls).toContainEqual(["tab", "close", "tab_squatter"]);
+  // exactly 2 agent start attempts
+  expect(agentStartAttempts).toBe(2);
+  // returned the newly started agent
+  expect(agent.terminalId).toBe("term_started");
+});
+
+test("start: two collisions then success — bounded retry recovers, squatter evicted each time", () => {
+  const calls: string[][] = [];
+  let agentStartAttempts = 0;
+  let listCallCount = 0;
+
+  const runner = (args: string[]) => {
+    calls.push(args);
+    if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
+    if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
+    if (args[0] === "agent" && args[1] === "start") {
+      agentStartAttempts++;
+      if (agentStartAttempts < 3) throw makeNameTakenError();
+      return "{}";
+    }
+    if (args[0] === "agent" && args[1] === "list") {
+      listCallCount++;
+      // first two list() calls are squatter evictions; third is final resolve
+      return listCallCount < 3 ? SQUATTER_LIST : POST_EVICT_LIST;
+    }
+    if (args[0] === "tab" && args[1] === "close") return "{}";
+    if (args[0] === "pane" && args[1] === "close") return "{}";
+    return "{}";
+  };
+
+  const d = new HerdrDriver(runner);
+  const agent = d.start("review TASK-504", "/wt/a", ["claude", "go"]);
+
+  expect(agentStartAttempts).toBe(3);
+  expect(agent.terminalId).toBe("term_started");
+  // squatter tab closed at least once (may be twice if it re-appears)
+  const closeCalls = calls.filter((c) => c[0] === "tab" && c[1] === "close");
+  // the squatter close happened (tab_squatter), created tab NOT closed (no rollback)
+  expect(closeCalls.some((c) => c[2] === "tab_squatter")).toBe(true);
+  expect(closeCalls.every((c) => c[2] !== "t_new")).toBe(true);
+});
+
+test("start: persistent collision exhausts 3 attempts — created tab rolled back, throws", () => {
+  const calls: string[][] = [];
+  let agentStartAttempts = 0;
+
+  const runner = (args: string[]) => {
+    calls.push(args);
+    if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
+    if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
+    if (args[0] === "agent" && args[1] === "start") {
+      agentStartAttempts++;
+      throw makeNameTakenError();
+    }
+    if (args[0] === "agent" && args[1] === "list") return SQUATTER_LIST;
+    if (args[0] === "tab" && args[1] === "close") return "{}";
+    return "{}";
+  };
+
+  const d = new HerdrDriver(runner);
+  expect(() => d.start("review TASK-504", "/wt/a", ["claude", "go"])).toThrow();
+
+  // 3 total attempts exhausted
+  expect(agentStartAttempts).toBe(3);
+  // our freshly created tab (t_new) was rolled back
+  expect(calls).toContainEqual(["tab", "close", "t_new"]);
+});
+
+test("start: non-name-taken error — no retry, immediate rollback", () => {
+  const calls: string[][] = [];
+  let agentStartAttempts = 0;
+
+  const runner = (args: string[]) => {
+    calls.push(args);
+    if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
+    if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
+    if (args[0] === "agent" && args[1] === "start") {
+      agentStartAttempts++;
+      throw new Error("herdr: disk full");
+    }
+    if (args[0] === "tab" && args[1] === "close") return "{}";
+    return "{}";
+  };
+
+  const d = new HerdrDriver(runner);
+  expect(() => d.start("review TASK-504", "/wt/a", ["claude", "go"])).toThrow("herdr: disk full");
+
+  // only one attempt — no retry for non-name-taken errors
+  expect(agentStartAttempts).toBe(1);
+  // created tab rolled back
+  expect(calls).toContainEqual(["tab", "close", "t_new"]);
 });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -2076,7 +2076,6 @@ function makeOrphanDeps(
       dropReview: (id: string) => droppedReviews.push(id),
       // other store methods not needed for reapOrphans
       getRepoConfig: () => ({ criticEnabled: false, autoAddressEnabled: false }),
-      getReview_unused: () => null,
       putReview: () => {},
       bumpReviewHead: () => {},
       snapshotReviews: () => ({}),
@@ -2157,7 +2156,7 @@ test("reapOrphans: true orphan (worktree present), error verdict — reaps, drop
   expect(result).toContain("s1");
 });
 
-test("reapOrphans: readUsage returns null → zeroed usage used", async () => {
+test("reapOrphans: readUsage returns null → zeroed usage used, full reap for error-verdict orphan", async () => {
   const row = {
     reviewerSessionId: "rev-null",
     taskSessionId: "s1",
@@ -2167,15 +2166,15 @@ test("reapOrphans: readUsage returns null → zeroed usage used", async () => {
     spawnedAt: 0,
   };
   const s = session({ id: "s1", desig: "TASK-01" });
-  const { deps, completedSpawns } = makeOrphanDeps([row], {
+  const { deps, completedSpawns, droppedReviews } = makeOrphanDeps([row], {
     sessions: { s1: s },
     reviews: { s1: priorReview({ decision: "error" }) },
     agents: [],
-    worktreeExists: () => true,
+    worktreeExists: () => true, // true orphan: worktree present, finalize never ran
     readUsage: async () => null,
   });
   const svc = new ReviewService(deps as any);
-  await svc.reapOrphans();
+  const result = await svc.reapOrphans();
 
   expect(completedSpawns).toHaveLength(1);
   const u = completedSpawns[0]!.u;
@@ -2188,6 +2187,9 @@ test("reapOrphans: readUsage returns null → zeroed usage used", async () => {
   expect(u.messageCount).toBe(0);
   expect(u.fullRecaches).toBe(0);
   expect(u.sidechainCount).toBe(0);
+  // worktree-present error orphan: dropReview called and taskSessionId in re-kick set
+  expect(droppedReviews).toContain("s1");
+  expect(result).toContain("s1");
 });
 
 test("reapOrphans: non-error prior verdict — NOT dropped, BUT taskId IS returned and proc/worktree reaped", async () => {
@@ -2357,4 +2359,36 @@ test("reapOrphans: session gone (store.get → undefined) — reaps proc/worktre
   // NOT dropped, NOT returned
   expect(droppedReviews).toEqual([]);
   expect(result).not.toContain("s-gone");
+});
+
+test("findSquatter: empty label does NOT match an unnamed agent whose cwd differs (no wrong-agent kill)", async () => {
+  // Regression guard for the empty-label correctness edge: when the session is gone the caller
+  // passes label="" — a naive `a.name === label` would match any unnamed agent (name="") regardless
+  // of cwd, potentially closing an unrelated agent. The fix skips the name match when label is falsy.
+  const row = {
+    reviewerSessionId: "rev-unrelated",
+    taskSessionId: "s-unrelated",
+    kind: "review",
+    worktreePath: "/orphan-wt",
+    completedAt: null,
+    spawnedAt: 0,
+  };
+  const { deps, closedTabs } = makeOrphanDeps([row], {
+    sessions: {}, // session gone → label will be ""
+    agents: [
+      // unnamed agent whose cwd does NOT match the orphan's worktree — must NOT be closed
+      {
+        name: "",
+        tabId: "tab-unrelated",
+        terminalId: "rt-unrelated",
+        cwd: "/completely-different-wt",
+      } as any,
+    ],
+    worktreeExists: () => true,
+  });
+  const svc = new ReviewService(deps as any);
+  await svc.reapOrphans();
+
+  // The unrelated unnamed agent must not have been killed
+  expect(closedTabs).toEqual([]);
 });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -2046,3 +2046,315 @@ test("forceReview HYGIENE: resets errorRound/streak/reviewedPatchIds on the prio
   expect(reviews["s1"]?.findings).toEqual(["still outstanding"]);
   expect(reviews["s1"]?.addressRound).toBe(1);
 });
+
+// ── reapOrphans (boot reconcile) ────────────────────────────────────────────────
+
+/** Build fake deps for reapOrphans tests — minimal, narrowly focused on reapOrphans. */
+function makeOrphanDeps(
+  rows: any[],
+  opts: {
+    sessions?: Record<string, any>;
+    reviews?: Record<string, any>;
+    agents?: any[];
+    worktreeExists?: (p: string) => boolean;
+    readUsage?: (wt: string, id: string) => Promise<any>;
+  } = {},
+) {
+  const completedSpawns: { id: string; u: any; at: number }[] = [];
+  const droppedReviews: string[] = [];
+  const closedTabs: string[] = [];
+  const removedWorktrees: string[] = [];
+  const agents = opts.agents ?? [];
+
+  const deps = {
+    store: {
+      listReviewerSpawns: () => rows,
+      get: (id: string) => opts.sessions?.[id] ?? null,
+      getReview: (id: string) => opts.reviews?.[id] ?? null,
+      completeReviewerSpawn: (id: string, u: any, at: number) =>
+        completedSpawns.push({ id, u, at }),
+      dropReview: (id: string) => droppedReviews.push(id),
+      // other store methods not needed for reapOrphans
+      getRepoConfig: () => ({ criticEnabled: false, autoAddressEnabled: false }),
+      getReview_unused: () => null,
+      putReview: () => {},
+      bumpReviewHead: () => {},
+      snapshotReviews: () => ({}),
+      addSignal: () => {},
+      recordReviewerSpawn: () => {},
+    },
+    herdr: {
+      start: () => ({ terminalId: "rt" }) as any,
+      stop: () => {},
+      list: () => agents,
+      closeTab: (tabId: string) => closedTabs.push(tabId),
+    },
+    worktree: {
+      createDetached: async () => ({ worktreePath: "/wt", branch: null, isolated: true }),
+      remove: (p: string) => removedWorktrees.push(p),
+      gitCommonDir: () => "/fake-git",
+    },
+    resolveForge: () => null,
+    onChange: () => {},
+    detectBackend: () => null,
+    worktreeExists: opts.worktreeExists ?? (() => false),
+    readUsage: opts.readUsage ?? (async () => null),
+    now: () => 9999,
+  };
+
+  return { deps, completedSpawns, droppedReviews, closedTabs, removedWorktrees };
+}
+
+test("reapOrphans: true orphan (worktree present), error verdict — reaps, drops, returns taskId", async () => {
+  const row = {
+    reviewerSessionId: "rev-1",
+    taskSessionId: "s1",
+    kind: "review",
+    worktreePath: "/orphan-wt",
+    completedAt: null,
+    spawnedAt: 0,
+  };
+  const s = session({ id: "s1", desig: "TASK-01" });
+  const fakeUsage = {
+    input: 10,
+    output: 5,
+    cacheRead: 20,
+    cacheWrite: 1,
+    total: 36,
+    messageCount: 2,
+    lastActivity: 0,
+    byModel: {},
+    fullRecaches: 0,
+    sidechainCount: 0,
+  };
+  const { deps, completedSpawns, droppedReviews, closedTabs, removedWorktrees } = makeOrphanDeps(
+    [row],
+    {
+      sessions: { s1: s },
+      reviews: { s1: priorReview({ decision: "error" }) },
+      agents: [
+        { name: "review TASK-01", tabId: "tab-99", terminalId: "rt-99", cwd: "/other-wt" } as any,
+      ],
+      worktreeExists: (p) => p === "/orphan-wt",
+      readUsage: async () => fakeUsage,
+    },
+  );
+  const svc = new ReviewService(deps as any);
+  const result = await svc.reapOrphans();
+
+  // store.get was called with the taskSessionId
+  // squatter found by name "review TASK-01" → closeTab called
+  expect(closedTabs).toEqual(["tab-99"]);
+  // worktree removed
+  expect(removedWorktrees).toEqual(["/orphan-wt"]);
+  // spawn row completed with real usage
+  expect(completedSpawns).toHaveLength(1);
+  expect(completedSpawns[0]!.id).toBe("rev-1");
+  expect(completedSpawns[0]!.u.total).toBe(36);
+  // error verdict → dropReview called
+  expect(droppedReviews).toEqual(["s1"]);
+  // taskId in re-kick set
+  expect(result).toContain("s1");
+});
+
+test("reapOrphans: readUsage returns null → zeroed usage used", async () => {
+  const row = {
+    reviewerSessionId: "rev-null",
+    taskSessionId: "s1",
+    kind: "review",
+    worktreePath: "/orphan-wt",
+    completedAt: null,
+    spawnedAt: 0,
+  };
+  const s = session({ id: "s1", desig: "TASK-01" });
+  const { deps, completedSpawns } = makeOrphanDeps([row], {
+    sessions: { s1: s },
+    reviews: { s1: priorReview({ decision: "error" }) },
+    agents: [],
+    worktreeExists: () => true,
+    readUsage: async () => null,
+  });
+  const svc = new ReviewService(deps as any);
+  await svc.reapOrphans();
+
+  expect(completedSpawns).toHaveLength(1);
+  const u = completedSpawns[0]!.u;
+  // all numeric fields zeroed
+  expect(u.input).toBe(0);
+  expect(u.output).toBe(0);
+  expect(u.cacheRead).toBe(0);
+  expect(u.cacheWrite).toBe(0);
+  expect(u.total).toBe(0);
+  expect(u.messageCount).toBe(0);
+  expect(u.fullRecaches).toBe(0);
+  expect(u.sidechainCount).toBe(0);
+});
+
+test("reapOrphans: non-error prior verdict — NOT dropped, BUT taskId IS returned and proc/worktree reaped", async () => {
+  const row = {
+    reviewerSessionId: "rev-2",
+    taskSessionId: "s1",
+    kind: "review",
+    worktreePath: "/orphan-wt",
+    completedAt: null,
+    spawnedAt: 0,
+  };
+  const s = session({ id: "s1", desig: "TASK-01" });
+  const { deps, completedSpawns, droppedReviews, closedTabs, removedWorktrees } = makeOrphanDeps(
+    [row],
+    {
+      sessions: { s1: s },
+      reviews: { s1: priorReview({ decision: "changes_requested" }) },
+      agents: [
+        { name: "review TASK-01", tabId: "tab-55", terminalId: "rt-55", cwd: "/orphan-wt" } as any,
+      ],
+      worktreeExists: () => true,
+    },
+  );
+  const svc = new ReviewService(deps as any);
+  const result = await svc.reapOrphans();
+
+  // proc and worktree reaped
+  expect(closedTabs).toEqual(["tab-55"]);
+  expect(removedWorktrees).toEqual(["/orphan-wt"]);
+  // spawn row completed
+  expect(completedSpawns).toHaveLength(1);
+  // NOT dropped (non-error verdict)
+  expect(droppedReviews).toEqual([]);
+  // but taskId IS in the re-kick set
+  expect(result).toContain("s1");
+});
+
+test("reapOrphans: worktree absent (cleanly finalized, transcript miss) — completes row, no reap/drop/re-kick", async () => {
+  const row = {
+    reviewerSessionId: "rev-3",
+    taskSessionId: "s1",
+    kind: "review",
+    worktreePath: "/gone-wt",
+    completedAt: null,
+    spawnedAt: 0,
+  };
+  const { deps, completedSpawns, droppedReviews, closedTabs, removedWorktrees } = makeOrphanDeps(
+    [row],
+    {
+      sessions: { s1: session({ id: "s1", desig: "TASK-01" }) },
+      reviews: {},
+      agents: [],
+      worktreeExists: () => false, // worktree gone → cleanly finalized
+    },
+  );
+  const svc = new ReviewService(deps as any);
+  const result = await svc.reapOrphans();
+
+  // row completed (zeroed usage)
+  expect(completedSpawns).toHaveLength(1);
+  expect(completedSpawns[0]!.u.total).toBe(0);
+  // no reap, no drop, no re-kick
+  expect(closedTabs).toEqual([]);
+  expect(removedWorktrees).toEqual([]);
+  expect(droppedReviews).toEqual([]);
+  expect(result).not.toContain("s1");
+});
+
+test("reapOrphans: kind=plan_gate and completedAt!=null rows are ignored entirely", async () => {
+  const rows = [
+    {
+      reviewerSessionId: "rev-pg",
+      taskSessionId: "pg1",
+      kind: "plan_gate",
+      worktreePath: "/pg-wt",
+      completedAt: null,
+      spawnedAt: 0,
+    },
+    {
+      reviewerSessionId: "rev-done",
+      taskSessionId: "s2",
+      kind: "review",
+      worktreePath: "/done-wt",
+      completedAt: 12345, // already completed
+      spawnedAt: 0,
+    },
+  ];
+  const { deps, completedSpawns, closedTabs, removedWorktrees } = makeOrphanDeps(rows, {
+    sessions: { pg1: session({ id: "pg1" }), s2: session({ id: "s2" }) },
+    worktreeExists: () => true,
+  });
+  const svc = new ReviewService(deps as any);
+  const result = await svc.reapOrphans();
+
+  // neither row processed (no completions, no reaps, empty re-kick set)
+  expect(completedSpawns).toHaveLength(0);
+  expect(closedTabs).toHaveLength(0);
+  expect(removedWorktrees).toHaveLength(0);
+  expect(result).toEqual([]);
+});
+
+test("reapOrphans: row body throws → sweep continues to process next row", async () => {
+  const throwingRow = {
+    reviewerSessionId: "rev-bad",
+    taskSessionId: "s-bad",
+    kind: "review",
+    worktreePath: "/bad-wt",
+    completedAt: null,
+    spawnedAt: 0,
+  };
+  const goodRow = {
+    reviewerSessionId: "rev-good",
+    taskSessionId: "s-good",
+    kind: "review",
+    worktreePath: "/good-wt",
+    completedAt: null,
+    spawnedAt: 0,
+  };
+  const { deps, completedSpawns } = makeOrphanDeps([throwingRow, goodRow], {
+    sessions: { "s-good": session({ id: "s-good", desig: "TASK-02" }) },
+    worktreeExists: (p) => p === "/good-wt",
+    // readUsage throws for the bad row, returns null for the good one
+    readUsage: async (_wt, id) => {
+      if (id === "rev-bad") throw new Error("transcript gone");
+      return null;
+    },
+  });
+  const svc = new ReviewService(deps as any);
+  // must not reject
+  const result = await svc.reapOrphans();
+
+  // good row was still processed
+  expect(completedSpawns.some((c) => c.id === "rev-good")).toBe(true);
+  // good row re-kick (session exists + worktree present)
+  expect(result).toContain("s-good");
+});
+
+test("reapOrphans: session gone (store.get → undefined) — reaps proc/worktree (cwd fallback), no drop, not returned", async () => {
+  const row = {
+    reviewerSessionId: "rev-gone",
+    taskSessionId: "s-gone",
+    kind: "review",
+    worktreePath: "/orphan-wt",
+    completedAt: null,
+    spawnedAt: 0,
+  };
+  const { deps, completedSpawns, droppedReviews, closedTabs, removedWorktrees } = makeOrphanDeps(
+    [row],
+    {
+      sessions: {}, // session gone
+      agents: [
+        // no name match (session gone, label empty), but cwd matches
+        { name: "", tabId: "tab-cwd", terminalId: "rt-cwd", cwd: "/orphan-wt" } as any,
+      ],
+      worktreeExists: () => true,
+    },
+  );
+  const svc = new ReviewService(deps as any);
+  const result = await svc.reapOrphans();
+
+  // spawn row completed
+  expect(completedSpawns).toHaveLength(1);
+  // squatter found by cwd fallback → closeTab called
+  expect(closedTabs).toEqual(["tab-cwd"]);
+  // worktree removed
+  expect(removedWorktrees).toEqual(["/orphan-wt"]);
+  // NOT dropped, NOT returned
+  expect(droppedReviews).toEqual([]);
+  expect(result).not.toContain("s-gone");
+});


### PR DESCRIPTION
## Problem (task #508 — recurring "REVIEW ERR")

The session critic reviewer is an **interactive** `claude` (it must bill the subscription, not `claude -p`). On "stop" it goes **idle — it never exits**. The only thing that finalizes/kills a reviewer is `ReviewService.tick()`, which iterates the **in-memory `inflight` map only**. So on every shepherd restart (deploys, systemd), each in-flight reviewer becomes an **untracked orphan**: a still-alive `claude` holding the **stable** herdr name `review TASK-<n>`, with a surviving disposable worktree and an uncompleted `reviewer_spawns` row.

Nothing finalizes it (not in `inflight` → never times out) and nothing kills it (`reapOrphanTabs` and `reapStaleReviewWorktrees` both spare live procs). The next review for that task hits `herdr agent start review TASK-<n>` → **`agent_name_taken`** → spawn fails → the PR latches a self-perpetuating `decision:"error"` ("REVIEW ERR") verdict, permanently, per task.

Live evidence at investigation time: 75 leaked `claude` + 40 `bwrap` (oldest ~40 days), 20 uncompleted `kind="review"` spawn rows, 2882 `agent_name_taken` failures across 60+ task designations. PR #748 hardened reviewer *teardown crashing* — orthogonal to a name collision from a live orphan, so the bug persisted. `PlanGateService` already solved this exact class (#630, `adoptOrphans`); `ReviewService` never got the equivalent.

## Fix (three parts)

1. **`HerdrDriver.start()` self-heals `agent_name_taken`** — resolves the same-named squatter via `list()`, `closeTab`s it (verified: releases the name **and** kills the proc, synchronously), and retries the `agent start` (bounded, up to 3 attempts; no event-loop-blocking sleep). Generic — protects every stable-named helper. Non-name-taken errors rethrow immediately; the freshly-created tab is rolled back exactly once on terminal failure.
2. **`ReviewService.reapOrphans()` boot reconcile** — for each uncompleted `kind="review"` spawn row it always closes the dangling row once (`completeReviewerSpawn`, real-or-zeroed usage). The orphan signal is the **surviving disposable worktree** (the precise "finalize never ran" signal — not `completedAt==null`, since `captureUsage` completes only `if (usage)`); only then does it reap (findSquatter by name→cwd → `closeTab`; `worktree.remove`), drop a sticky `error` verdict (error-only, to preserve a genuine-timeout's escalation accounting), and return the present-session task ids to re-kick.
3. **`index.ts` boot chain** — `adoptOrphans → gc → reapOrphans → re-kick → sweepStaleReviewWorktrees`, ordered so the disk sweep can't erase reapOrphans's worktree signal first. Re-kick is a deterministic force-`consider` on the cached `GitState` (head-dedup at a settled head would otherwise swallow it), with a `drop`+`pollSession` cold-cache fallback.

Reap-fresh (not adopt) is deliberate: `InFlight` carries headSha/baseSha/patchId/files/streak that the spawn row doesn't persist, and the re-bill is bounded to live open+green sessions.

## Testing

- New unit tests: `test/herdr.test.ts` (collision-breaker: single/double/exhausted/non-name-taken + `isNameTakenError` units) and `test/review.test.ts` (`reapOrphans`: worktree-present error/non-error orphans, worktree-absent dangling row, plan_gate/completed ignored, throwing-row continues, session-gone cwd-fallback).
- Root `bunx tsc --noEmit` clean, `bun run lint` clean, `bun test ./test` → **3382 pass / 0 fail / 8 skip**. Fallow complexity/dead-code gate clean.

Server-only / internal plumbing — no user-facing UX, so `[no-feature-entry]` (the feature-catalog gate doesn't fire; no i18n strings added).

## Follow-up (operational, not in this diff)

After this lands + deploys, a one-time cleanup of the already-leaked host orphans (processes/husk tabs/stale worktrees) — the new boot reconcile handles `kind="review"` orphans automatically on restart; residual non-review leaks (recap, etc.) swept manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)