### PR TITLE
fix(onboarding-harness): 4GiB profile cap clears claude-installer OOM; surface install RAM floor (#749)

### DIFF
--- a/ci/onboarding-harness/README.md
+++ b/ci/onboarding-harness/README.md
@@ -57,16 +57,11 @@ bun run onboarding:test --scenario install-e2e-service
 
 ## Prerequisites
 
-- Self-hosted Incus host with the `shep-onb` profile configured:
-  ```
-  incus profile create shep-onb
-  incus profile set shep-onb limits.cpu 2 limits.memory 2GiB
-  # For tailscale/systemd scenarios (nesting + TUN):
-  incus profile set shep-onb security.nesting true
-  incus profile device add shep-onb tun unix-char path=/dev/net/tun
-  ```
+- Self-hosted Incus host. No manual profile setup needed — the harness ensures the `shep-onb` profile automatically at run start (cpu 2, memory 4 GiB, nesting enabled, TUN device).
 - `bun` installed on the Incus host.
 - `~/.claude` credentials accessible on the host (mounted into instances for the agent apply path). The harness expects a valid Claude Code credential so the proxy-user agent can run `claude -p` inside each instance.
+
+**Install-time RAM floor:** Claude Code's native installer transiently peaks at ~2 GB RSS during `claude install`. The harness sizes instances at 4 GiB to provide headroom above the ~3 GB floor; hosts below that may OOM-kill the install.
 
 ## Usage
 

--- a/ci/onboarding-harness/incus.ts
+++ b/ci/onboarding-harness/incus.ts
@@ -106,10 +106,11 @@ export class IncusDriver {
     await this.run(["profile", "create", name]);
 
     // Step 2: set all config keys additively (must succeed — applies the memory cap).
-    const configArgs: string[] = [];
-    for (const [key, value] of Object.entries(HARNESS_PROFILE.config)) {
-      configArgs.push(key, value);
-    }
+    // Pass each as a single `key=value` token — the canonical, unambiguous form for
+    // setting multiple keys in one `incus profile set` call.
+    const configArgs = Object.entries(HARNESS_PROFILE.config).map(
+      ([key, value]) => `${key}=${value}`,
+    );
     const setResult = await this.run(["profile", "set", name, ...configArgs]);
     if (setResult.code !== 0) {
       throw new Error(

--- a/ci/onboarding-harness/incus.ts
+++ b/ci/onboarding-harness/incus.ts
@@ -1,6 +1,21 @@
 import { captureSpawn } from "./spawn";
 import type { IncusExec, IncusRunner } from "./types";
 
+/** The harness's `shep-onb` Incus profile, owned in-repo so a fresh/misconfigured host
+ *  self-heals. limits.memory headroom (4GiB) clears the ~2GB transient peak of claude's
+ *  native installer that OOM-killed the 2GiB profile (#749). */
+export const HARNESS_PROFILE = {
+  name: "shep-onb",
+  /** key/value pairs applied via `incus profile set` (additive — never clobbers extras). */
+  config: {
+    "limits.cpu": "2",
+    "limits.memory": "4GiB",
+    "security.nesting": "true",
+  },
+  /** `incus profile device add <name> tun unix-char path=/dev/net/tun`. */
+  device: { name: "tun", type: "unix-char", options: ["path=/dev/net/tun"] },
+} as const;
+
 /** Backstop kill timeout for any single `incus` call. The genuine hang fix is
  *  `captureSpawn` closing stdin (the incus Go client deadlocks on an open stdin
  *  pipe for operation-streaming commands); this cap only guards a process that
@@ -70,5 +85,40 @@ export class IncusDriver {
     for (const full of await this.listManaged()) {
       await this.run(["delete", full, "--force"]);
     }
+  }
+
+  /** Idempotently ensures the `shep-onb` Incus profile exists with the configured keys.
+   *
+   *  Uses additive `create`/`set`/`device add` (NOT declarative `profile edit`) so the
+   *  method enforces only the keys it owns and never strips operator-added config (e.g.
+   *  a credential disk). Profile names are global — NOT instance-prefixed — so we use
+   *  `HARNESS_PROFILE.name` raw, never `this.full()`.
+   *
+   *  Step 1: `profile create` — tolerated on non-zero (profile already exists is the
+   *    normal steady state on a pre-configured host).
+   *  Step 2: `profile set` with the full config key/value pairs — MUST succeed;
+   *    throws fail-closed on non-zero because a wrong memory cap defeats the fix for #749.
+   *  Step 3: `profile device add` — tolerated on non-zero (device already present). */
+  async ensureProfile(): Promise<void> {
+    const name = HARNESS_PROFILE.name;
+
+    // Step 1: create (tolerate non-zero — already-exists is the steady state).
+    await this.run(["profile", "create", name]);
+
+    // Step 2: set all config keys additively (must succeed — applies the memory cap).
+    const configArgs: string[] = [];
+    for (const [key, value] of Object.entries(HARNESS_PROFILE.config)) {
+      configArgs.push(key, value);
+    }
+    const setResult = await this.run(["profile", "set", name, ...configArgs]);
+    if (setResult.code !== 0) {
+      throw new Error(
+        `incus profile set failed for ${name}: ${setResult.stderr || setResult.stdout}`,
+      );
+    }
+
+    // Step 3: device add (tolerate non-zero — device already present is fine).
+    const { device } = HARNESS_PROFILE;
+    await this.run(["profile", "device", "add", name, device.name, device.type, ...device.options]);
   }
 }

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -325,6 +325,11 @@ async function main() {
   // touches our own, so overlapping runs can't destroy each other (point 5).
   const runId = `${Date.now().toString(36)}-${process.pid}`;
   const driver = new IncusDriver(undefined, `shep-onb-${runId}-`);
+  // Ensure the shared `shep-onb` profile exists with the in-repo spec before any
+  // instance is launched. Runs for both full and --scenario paths (only --reap-orphans
+  // returns early above, so this is never reached on that path). Fail-closed: a wrong
+  // or missing profile would silently OOM every instance, so we fix it up front.
+  await driver.ensureProfile();
   const results: ScenarioResult[] = [];
   try {
     const tarball = buildTarball();

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -325,13 +325,13 @@ async function main() {
   // touches our own, so overlapping runs can't destroy each other (point 5).
   const runId = `${Date.now().toString(36)}-${process.pid}`;
   const driver = new IncusDriver(undefined, `shep-onb-${runId}-`);
-  // Ensure the shared `shep-onb` profile exists with the in-repo spec before any
-  // instance is launched. Runs for both full and --scenario paths (only --reap-orphans
-  // returns early above, so this is never reached on that path). Fail-closed: a wrong
-  // or missing profile would silently OOM every instance, so we fix it up front.
-  await driver.ensureProfile();
   const results: ScenarioResult[] = [];
   try {
+    // Ensure the shared `shep-onb` profile exists with the in-repo spec before any
+    // instance is launched. Runs for both full and --scenario paths (only --reap-orphans
+    // returns early above, so this is never reached on that path). Fail-closed: a wrong
+    // or missing profile would silently OOM every instance, so we fix it up front.
+    await driver.ensureProfile();
     const tarball = buildTarball();
     for (const s of scenarios) {
       console.log(`\n=== ${s.id} (${s.image}) ===`);

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -26,6 +26,9 @@
 #   SHEPHERD_NO_SERVICE  Passed through to provision.ts: skip the systemd unit.
 #                        Set automatically on macOS (core-only mode).
 #
+# RAM floor: Claude Code's installer transiently needs ~2 GB RSS; hosts below ~3 GB
+#   total RAM may OOM-kill the install. Add RAM or swap if the install fails.
+#
 # Test seams (override OS detection; never set in real use):
 #   SHEPHERD_UNAME_S  Overrides `uname -s`.
 #   SHEPHERD_UNAME_M  Overrides `uname -m`.

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -16,7 +16,7 @@
  */
 import { execFileSync, spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, totalmem } from "node:os";
 import { join } from "node:path";
 import { BUN_MIN_VERSION, NODE_MIN_VERSION, HERDR_MIN_VERSION } from "../src/config";
 import { compareSemver } from "../src/herdr-update";
@@ -44,6 +44,24 @@ export const PREREQS: readonly Prereq[] = [
   // claude is presence-only (no version floor), like diagnostics.
   { bin: "claude", hintKey: "diagnostics_hint_claude_missing" },
 ];
+
+/** Install-time RAM floor. Claude Code's native installer transiently peaks at ~2 GB during
+ *  `claude install`; below this, the install can be OOM-killed on a small host (#749). Advisory
+ *  only — we warn, never abort (a swap-backed host may still succeed). */
+export const INSTALL_RAM_FLOOR_BYTES = 3 * 1024 * 1024 * 1024; // 3 GiB
+
+/** Pure: an advisory string when total RAM is under the floor, else null. */
+export function lowMemoryWarning(
+  totalBytes: number,
+  floorBytes = INSTALL_RAM_FLOOR_BYTES,
+): string | null {
+  if (totalBytes >= floorBytes) return null;
+  const gib = (n: number) => (n / 1024 / 1024 / 1024).toFixed(1);
+  return (
+    `low memory: ${gib(totalBytes)} GiB total RAM detected; Claude Code's installer needs ` +
+    `~2 GB free during setup, so the install may be OOM-killed. Add RAM or swap if it fails.`
+  );
+}
 
 /** The decision a host yields: whether to take the systemd-service path, and
  *  whether to print the macOS DEGRADED banner. */
@@ -184,6 +202,8 @@ interface ProvisionOpts {
   repo?: string;
   /** Injectable file IO (templated-unit read/write); real fs by default. */
   fileIO?: FileIO;
+  /** Injectable total-memory probe; defaults to os.totalmem. */
+  totalMem?: () => number;
 }
 
 /** Step 1 — table-driven prereq install loop (idempotent; skips adequate tools). */
@@ -275,6 +295,12 @@ export function provision(opts: ProvisionOpts = {}): void {
   const env = opts.env ?? process.env;
   const repo = opts.repo ?? process.cwd();
   const home = homedir();
+  const memFn = opts.totalMem ?? totalmem;
+
+  const memWarning = lowMemoryWarning(memFn());
+  if (memWarning !== null) {
+    process.stdout.write(`\x1b[33m${memWarning}\x1b[0m\n`);
+  }
 
   installPrereqs(probe, run, env);
   const buildEnv = ensureNodeGyp(run, env, home);

--- a/test/onboarding-harness/incus.test.ts
+++ b/test/onboarding-harness/incus.test.ts
@@ -1,12 +1,26 @@
 import { describe, expect, it } from "bun:test";
-import { IncusDriver } from "../../ci/onboarding-harness/incus";
+import { IncusDriver, HARNESS_PROFILE } from "../../ci/onboarding-harness/incus";
 import type { IncusExec } from "../../ci/onboarding-harness/types";
 
+/** Fixed-reply recorder: every call returns the same reply. Keeps existing tests working. */
 function recorder(reply: Partial<IncusExec> = {}) {
   const calls: string[][] = [];
   const run = async (args: string[]): Promise<IncusExec> => {
     calls.push(args);
     return { stdout: "", stderr: "", code: 0, ...reply };
+  };
+  return { calls, run };
+}
+
+/** Per-argv recorder: maps argv-prefix → reply; falls back to `{code:0}` for unmatched calls. */
+function argvRecorder(
+  replies: Array<{ match: (args: string[]) => boolean; reply: Partial<IncusExec> }>,
+) {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<IncusExec> => {
+    calls.push(args);
+    const found = replies.find((r) => r.match(args));
+    return { stdout: "", stderr: "", code: 0, ...(found?.reply ?? {}) };
   };
   return { calls, run };
 }
@@ -63,5 +77,82 @@ describe("IncusDriver", () => {
     await d.sweep();
     // listManaged (1) + one delete per managed instance (2)
     expect(calls.filter((c) => c[0] === "delete")).toHaveLength(2);
+  });
+});
+
+describe("ensureProfile", () => {
+  it("happy path: issues profile create, profile set with correct values, and device add in order", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await d.ensureProfile();
+
+    // Step 1: profile create
+    expect(calls[0]).toEqual(["profile", "create", "shep-onb"]);
+
+    // Step 2: profile set — must include limits.memory immediately followed by the
+    // constant's value (NOT a second literal), plus limits.cpu and security.nesting.
+    const setCall = calls[1];
+    expect(setCall[0]).toBe("profile");
+    expect(setCall[1]).toBe("set");
+    expect(setCall[2]).toBe("shep-onb");
+    const memIdx = setCall.indexOf("limits.memory");
+    expect(memIdx).toBeGreaterThan(-1);
+    expect(setCall[memIdx + 1]).toBe(HARNESS_PROFILE.config["limits.memory"]);
+    expect(setCall).toContain("limits.cpu");
+    const cpuIdx = setCall.indexOf("limits.cpu");
+    expect(setCall[cpuIdx + 1]).toBe(HARNESS_PROFILE.config["limits.cpu"]);
+    expect(setCall).toContain("security.nesting");
+    const nestIdx = setCall.indexOf("security.nesting");
+    expect(setCall[nestIdx + 1]).toBe(HARNESS_PROFILE.config["security.nesting"]);
+
+    // Step 3: device add
+    expect(calls[2]).toEqual([
+      "profile",
+      "device",
+      "add",
+      "shep-onb",
+      "tun",
+      "unix-char",
+      "path=/dev/net/tun",
+    ]);
+
+    // Exactly 3 calls total
+    expect(calls).toHaveLength(3);
+  });
+
+  it("tolerates existing profile: code:1 from profile create does not throw, still runs set + device add", async () => {
+    const { calls, run } = argvRecorder([
+      {
+        match: (args) => args[0] === "profile" && args[1] === "create",
+        reply: { code: 1, stderr: "Profile already exists" },
+      },
+    ]);
+    const d = new IncusDriver(run, "shep-onb-");
+    await expect(d.ensureProfile()).resolves.toBeUndefined();
+    expect(calls.some((c) => c[1] === "set")).toBe(true);
+    expect(calls.some((c) => c[1] === "device")).toBe(true);
+  });
+
+  it("tolerates existing device: code:1 from profile device add does not throw", async () => {
+    const { calls, run } = argvRecorder([
+      {
+        match: (args) => args[0] === "profile" && args[1] === "device",
+        reply: { code: 1, stderr: "Device already exists" },
+      },
+    ]);
+    const d = new IncusDriver(run, "shep-onb-");
+    await expect(d.ensureProfile()).resolves.toBeUndefined();
+    expect(calls.some((c) => c[1] === "device")).toBe(true);
+  });
+
+  it("fails closed on set: code:1 from profile set causes ensureProfile() to throw", async () => {
+    const { run } = argvRecorder([
+      {
+        match: (args) => args[0] === "profile" && args[1] === "set",
+        reply: { code: 1, stderr: "permission denied" },
+      },
+    ]);
+    const d = new IncusDriver(run, "shep-onb-");
+    await expect(d.ensureProfile()).rejects.toThrow();
   });
 });

--- a/test/onboarding-harness/incus.test.ts
+++ b/test/onboarding-harness/incus.test.ts
@@ -89,21 +89,16 @@ describe("ensureProfile", () => {
     // Step 1: profile create
     expect(calls[0]).toEqual(["profile", "create", "shep-onb"]);
 
-    // Step 2: profile set — must include limits.memory immediately followed by the
-    // constant's value (NOT a second literal), plus limits.cpu and security.nesting.
+    // Step 2: profile set — each config key passed as a single `key=value` token
+    // (the canonical form), with the memory value sourced from the constant (NOT a
+    // second literal), plus limits.cpu and security.nesting.
     const setCall = calls[1]!;
     expect(setCall[0]).toBe("profile");
     expect(setCall[1]).toBe("set");
     expect(setCall[2]).toBe("shep-onb");
-    const memIdx = setCall.indexOf("limits.memory");
-    expect(memIdx).toBeGreaterThan(-1);
-    expect(setCall[memIdx + 1]).toBe(HARNESS_PROFILE.config["limits.memory"]);
-    expect(setCall).toContain("limits.cpu");
-    const cpuIdx = setCall.indexOf("limits.cpu");
-    expect(setCall[cpuIdx + 1]).toBe(HARNESS_PROFILE.config["limits.cpu"]);
-    expect(setCall).toContain("security.nesting");
-    const nestIdx = setCall.indexOf("security.nesting");
-    expect(setCall[nestIdx + 1]).toBe(HARNESS_PROFILE.config["security.nesting"]);
+    expect(setCall).toContain(`limits.memory=${HARNESS_PROFILE.config["limits.memory"]}`);
+    expect(setCall).toContain(`limits.cpu=${HARNESS_PROFILE.config["limits.cpu"]}`);
+    expect(setCall).toContain(`security.nesting=${HARNESS_PROFILE.config["security.nesting"]}`);
 
     // Step 3: device add
     expect(calls[2]).toEqual([

--- a/test/onboarding-harness/incus.test.ts
+++ b/test/onboarding-harness/incus.test.ts
@@ -91,7 +91,7 @@ describe("ensureProfile", () => {
 
     // Step 2: profile set — must include limits.memory immediately followed by the
     // constant's value (NOT a second literal), plus limits.cpu and security.nesting.
-    const setCall = calls[1];
+    const setCall = calls[1]!;
     expect(setCall[0]).toBe("profile");
     expect(setCall[1]).toBe("set");
     expect(setCall[2]).toBe("shep-onb");

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn, beforeEach, afterEach } from "bun:test";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
@@ -14,6 +14,8 @@ import {
   ensureNodeGyp,
   installService,
   buildOnly,
+  lowMemoryWarning,
+  INSTALL_RAM_FLOOR_BYTES,
   type FileIO,
   type Runner,
 } from "../deploy/provision";
@@ -331,6 +333,73 @@ describe("extracted helpers (direct)", () => {
     expect(flat.some((c) => c.includes('cd "/repo" && bun install'))).toBe(true);
     expect(flat.some((c) => c.includes('cd "/repo/ui" && bun run build'))).toBe(true);
     expect(flat.some((c) => c.includes("systemctl"))).toBe(false);
+  });
+});
+
+describe("lowMemoryWarning (pure)", () => {
+  it("returns null at exactly the floor", () => {
+    expect(lowMemoryWarning(INSTALL_RAM_FLOOR_BYTES)).toBeNull();
+  });
+
+  it("returns null above the floor", () => {
+    expect(lowMemoryWarning(4 * 1024 ** 3)).toBeNull();
+  });
+
+  it("returns a non-null string below the floor that mentions the detected amount", () => {
+    const result = lowMemoryWarning(2 * 1024 ** 3);
+    expect(result).not.toBeNull();
+    expect(result).toContain("2.0 GiB");
+  });
+
+  it("custom floor: above custom floor → null", () => {
+    expect(lowMemoryWarning(2 * 1024 ** 3, 1 * 1024 ** 3)).toBeNull();
+  });
+});
+
+describe("provision — low-memory advisory wiring", () => {
+  let written: string[];
+  let restore: () => void;
+
+  beforeEach(() => {
+    written = [];
+    const spy = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      written.push(String(chunk));
+      return true;
+    });
+    restore = () => spy.mockRestore();
+  });
+
+  afterEach(() => restore());
+
+  it("emits the advisory when totalMem is below the floor", () => {
+    const { run, fileIO } = recorder();
+    provision({
+      run,
+      fileIO,
+      probe: adequateProbe,
+      platform: "linux",
+      env: { SHEPHERD_NO_SERVICE: "1" },
+      repo: "/repo",
+      totalMem: () => 2 * 1024 ** 3,
+    });
+    const all = written.join("");
+    expect(all).toContain("low memory");
+    expect(all).toContain("2.0 GiB");
+  });
+
+  it("does NOT emit the advisory when totalMem is above the floor", () => {
+    const { run, fileIO } = recorder();
+    provision({
+      run,
+      fileIO,
+      probe: adequateProbe,
+      platform: "linux",
+      env: { SHEPHERD_NO_SERVICE: "1" },
+      repo: "/repo",
+      totalMem: () => 8 * 1024 ** 3,
+    });
+    const all = written.join("");
+    expect(all).not.toContain("low memory");
   });
 });
 


### PR DESCRIPTION
Closes #749.

## Problem
The 2026-06-17 nightly reported `install-e2e` / `install-e2e-service` as INSTALL GAPs: the claude
native installer exited 137 (`Killed`) mid-`claude install`.

## Root cause (verified on the host)
Not an installer bug. The harness launches throwaway Incus instances under the `shep-onb` profile,
which capped **`limits.memory: 2GiB`** with no swap. `claude 2.1.179`'s `claude install` transiently
peaks at **~1.7–2.0 GB RSS** — right on the 2 GiB ceiling — so it flakily OOM-killed inside the
memcg. Kernel log from the run:

```
oom-kill:constraint=CONSTRAINT_MEMCG … task=claude-2.1.179- … anon-rss:2045988kB
```

Only `install-e2e` reddened because it runs the install fail-closed via `provision.ts`; the baseline
seed elsewhere uses `|| true` and swallowed the identical OOM (that's why `node-too-old` /
`claude-missing` "passed" — `claude-missing` was spared only by luck, staying under 2 GiB). 2 GiB was
an arbitrary throwaway size, not a documented host spec.

## Fix
1. **Codify the `shep-onb` profile in the repo** (`HARNESS_PROFILE` + `IncusDriver.ensureProfile()`,
   called once at run start) and **bump the cap 2GiB → 4GiB** for headroom over the ~2 GB peak.
   `ensureProfile()` is additive (`create`/`set`/`device add`, never declarative `profile edit`) so
   it enforces only the four keys it owns and never strips operator-added profile config; fail-closed
   only on the cap-applying `profile set`. A fresh/misconfigured host now self-heals — no manual setup.
2. **Surface Shepherd's real ~3 GB install-time RAM floor** rather than only hiding it behind a bigger
   CI box: a non-fatal `lowMemoryWarning()` advisory in `provision.ts` before prereq install, plus
   notes in the harness README and `install.sh` header.

## Verification
- `bun run lint` clean; `bun test ./test` = 3373 pass / 0 fail.
- **Live on the harness host** under the new 4 GiB profile: `install-e2e`, `install-e2e-service`, and
  `claude-missing` all reach **green**; `ensureProfile()` bumped the live profile 2GiB→4GiB at start.

## Notes
- `fix(...)` touching `ci/onboarding-harness/**`, `deploy/**`, `test/**`, harness README only — no UI,
  so no i18n / feature-catalog / glossary entries needed.
- Pre-existing & out of scope: `apply.ts:45` / harness-README reference a `~/.claude` mount "by run.ts"
  that isn't implemented, and the agent apply path is currently unreachable in the catalog — flagged
  for a separate follow-up, deliberately not expanded into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)