### PR TITLE
feat(gitrail): first-class manual plan-review trigger (#753)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1410,6 +1410,13 @@
   "gitrail_confirm_review": "bestätigen ✓",
   "gitrail_review_skipped": "Prüfung nicht gestartet – Bedingungen geändert oder läuft bereits.",
   "gitrail_review_failed": "Prüfung konnte nicht gestartet werden. Erneut versuchen.",
+  "gitrail_review_plan": "Plan prüfen",
+  "gitrail_rereview_plan": "Plan erneut prüfen",
+  "gitrail_reviewing_plan": "Prüfe Plan…",
+  "gitrail_review_plan_skipped": "Plan-Prüfung nicht gestartet – unverändert, bereits freigegeben oder läuft bereits.",
+  "gitrail_review_plan_failed": "Plan-Prüfung konnte nicht gestartet werden. Erneut versuchen.",
   "feat_manual_critic_review_title": "Kritiker-Review neu starten",
-  "feat_manual_critic_review_body": "Wenn der KI-Kritiker nie startete oder ohne Urteil hängen blieb, kannst du ihn über eine Schaltfläche in der PR-Leiste bei Bedarf neu starten – für offene PRs mit grünem CI."
+  "feat_manual_critic_review_body": "Wenn der KI-Kritiker nie startete oder ohne Urteil hängen blieb, kannst du ihn über eine Schaltfläche in der PR-Leiste bei Bedarf neu starten – für offene PRs mit grünem CI.",
+  "feat_manual_plan_review_title": "Plan-Review neu starten",
+  "feat_manual_plan_review_body": "Wenn das Plan-Gate ohne Urteil hängen bleibt (REVIEW ERR), kannst du die adversarische Plan-Prüfung über eine Schaltfläche in der Git-Leiste bei Bedarf neu starten – ohne das Plan-Panel zu öffnen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1410,6 +1410,13 @@
   "gitrail_confirm_review": "confirm ✓",
   "gitrail_review_skipped": "Review not started — conditions changed or one's already running.",
   "gitrail_review_failed": "Couldn't start the review. Try again.",
+  "gitrail_review_plan": "Review plan",
+  "gitrail_rereview_plan": "Re-review plan",
+  "gitrail_reviewing_plan": "Reviewing…",
+  "gitrail_review_plan_skipped": "Plan review not started — unchanged, already approved, or one's already running.",
+  "gitrail_review_plan_failed": "Couldn't start the plan review. Try again.",
   "feat_manual_critic_review_title": "Restart a critic review",
-  "feat_manual_critic_review_body": "When the AI critic never started or stalled without a verdict, a Review/Re-review button on the PR rail lets you start or restart it on demand — for open PRs with green CI."
+  "feat_manual_critic_review_body": "When the AI critic never started or stalled without a verdict, a Review/Re-review button on the PR rail lets you start or restart it on demand — for open PRs with green CI.",
+  "feat_manual_plan_review_title": "Restart a plan review",
+  "feat_manual_plan_review_body": "When the plan gate stalls without a verdict (REVIEW ERR), a Review-plan button on the git rail lets you re-kick the adversarial plan review on demand — no need to open the plan panel."
 }

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -32,6 +32,8 @@ const gitStateFn = vi.fn(async () => openPrState);
 // reviewPrFn drives the manual critic-trigger handler; per-test we resolve it to
 // "started"/"skipped"/"error" or reject it to exercise the fail-closed toast paths.
 const reviewPrFn = vi.fn(async () => "started" as "started" | "skipped" | "error");
+// reviewPlanFn drives the manual plan-review trigger handler; same resolution options.
+const reviewPlanFn = vi.fn(async () => "started" as "started" | "skipped" | "error");
 
 vi.mock("$lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("$lib/api")>();
@@ -43,6 +45,7 @@ vi.mock("$lib/api", async (importOriginal) => {
     redeploy: vi.fn(),
     replySession: vi.fn(),
     reviewPr: reviewPrFn,
+    reviewPlan: reviewPlanFn,
   };
 });
 
@@ -871,5 +874,317 @@ describe("GitRail — manual critic-review trigger", () => {
     // give any (incorrect) toast a tick to fire, then assert silence
     await new Promise((r) => setTimeout(r, 20));
     expect(toastsInfo, "no toast on started").not.toHaveBeenCalled();
+  });
+});
+
+describe("GitRail — manual plan-review trigger", () => {
+  beforeEach(() => {
+    reviewPlanFn.mockResolvedValue("started");
+    reviewPlanFn.mockClear();
+    toastsInfo.mockClear();
+  });
+  afterEach(() => {
+    planGates.drop(baseProps.sessionId);
+  });
+
+  // Find the plan-review button: a .gbtn whose text starts with "Review plan"
+  // (or "Re-review plan" / "Reviewing…" / "confirm ✓" once armed/reviewing).
+  function planReviewBtn(h: HTMLElement): HTMLButtonElement | null {
+    return (
+      [...h.querySelectorAll<HTMLButtonElement>("button.gbtn:not(.auto-pill)")].find((b) => {
+        const text = b.textContent?.trim() ?? "";
+        return (
+          text.startsWith("Review plan") ||
+          text.startsWith("Re-review plan") ||
+          text === m.gitrail_reviewing_plan() ||
+          text === m.gitrail_confirm_review()
+        );
+      }) ?? null
+    );
+  }
+
+  // arm and confirm the plan-review button (two clicks)
+  async function armAndConfirmPlan(h: HTMLElement) {
+    await vi.waitFor(() => expect(planReviewBtn(h)).not.toBeNull());
+    planReviewBtn(h)!.click();
+    await vi.waitFor(() =>
+      expect(planReviewBtn(h)!.textContent?.trim()).toBe(m.gitrail_confirm_review()),
+    );
+    planReviewBtn(h)!.click();
+  }
+
+  // 1. renders the Review-plan button when planPhase === "planning"
+  it("renders the Review-plan button when planPhase === 'planning'", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: "planning" },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await vi.waitFor(() => expect(planReviewBtn(h)).not.toBeNull());
+    expect(planReviewBtn(h)!.textContent?.trim()).toBe(m.gitrail_review_plan());
+  });
+
+  // 2. hides the button when planPhase is null or "executing"
+  it("hides the button when planPhase is null", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: null },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await vi.waitFor(() =>
+      expect(screen.getByRole("button", { name: /^Merge$/i }).element()).toBeTruthy(),
+    );
+    expect(planReviewBtn(h), "no plan-review button when planPhase null").toBeNull();
+  });
+
+  it("hides the button when planPhase is 'executing'", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: "executing" },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await vi.waitFor(() =>
+      expect(screen.getByRole("button", { name: /^Merge$/i }).element()).toBeTruthy(),
+    );
+    expect(planReviewBtn(h), "no plan-review button when planPhase executing").toBeNull();
+  });
+
+  // 3. shows Re-review plan when a prior verdict exists in planGates.map
+  it("shows Re-review plan label when a prior plan-gate verdict exists", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    // seed a prior plan gate verdict
+    planGates.apply(baseProps.sessionId, {
+      sessionId: baseProps.sessionId,
+      planHash: "abc123",
+      decision: "approved",
+      summary: "looks good",
+      body: "all good",
+      findings: [],
+      round: 0,
+      cap: 3,
+      approved: true,
+      plan: "do stuff",
+      updatedAt: Date.now(),
+    });
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: "planning" },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await vi.waitFor(() => expect(planReviewBtn(h)).not.toBeNull());
+    expect(planReviewBtn(h)!.textContent?.trim()).toBe(m.gitrail_rereview_plan());
+  });
+
+  // 4. first click arms (no call), second calls reviewPlan once
+  it("first click arms (no call); second click calls reviewPlan once with session id", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: "planning" },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await vi.waitFor(() => expect(planReviewBtn(h)).not.toBeNull());
+
+    const btn = planReviewBtn(h)!;
+    btn.click();
+    // armed → label becomes confirm, reviewPlan NOT yet called
+    await vi.waitFor(() =>
+      expect(planReviewBtn(h)!.textContent?.trim()).toBe(m.gitrail_confirm_review()),
+    );
+    expect(reviewPlanFn, "not called on first (arming) click").not.toHaveBeenCalled();
+
+    planReviewBtn(h)!.click();
+    await vi.waitFor(() => expect(reviewPlanFn).toHaveBeenCalledTimes(1));
+    expect(reviewPlanFn).toHaveBeenCalledWith(baseProps.sessionId);
+  });
+
+  // 5. "skipped" (NOT reviewing) → transient info toast
+  it("'skipped' (not reviewing) raises a transient info toast", async () => {
+    reviewPlanFn.mockResolvedValue("skipped");
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: "planning" },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await armAndConfirmPlan(h);
+    await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
+    expect(toastsInfo).toHaveBeenCalledWith(m.gitrail_review_plan_skipped());
+  });
+
+  // 6. "skipped" WHILE isReviewing is true → toasts.info NOT called.
+  // NOTE: Chromium disables click events on disabled buttons even via dispatchEvent,
+  // so we cannot reach doReviewPlan's planReviewing guard through the DOM. Instead,
+  // we verify the observable invariant: when planGates.isReviewing is true the button
+  // becomes disabled, preventing any interaction — which transitively means no toast
+  // can fire (the disabled state IS the guard at the DOM level). The in-handler
+  // `if (planReviewing) return` acts as belt-and-suspenders for programmatic callers.
+  it("'skipped' while planGates.isReviewing is true → button disabled → no interaction possible", async () => {
+    reviewPlanFn.mockResolvedValue("skipped");
+    gitStateFn.mockResolvedValue(openPrState);
+    planGates.applyReviewing(baseProps.sessionId, true);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: "planning" },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await vi.waitFor(() => expect(planReviewBtn(h)).not.toBeNull());
+    // button must be disabled → no clicks can reach the handler → no toast
+    expect(planReviewBtn(h)!.disabled, "button disabled while reviewing").toBe(true);
+    // try clicking — handler must not fire because button is disabled
+    planReviewBtn(h)!.click();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(
+      reviewPlanFn,
+      "reviewPlan not called on click of disabled button",
+    ).not.toHaveBeenCalled();
+    expect(toastsInfo, "no toast when button disabled").not.toHaveBeenCalled();
+  });
+
+  // 7. "error" status AND rejected → persistent keyed toast
+  it("'error' status raises the persistent, keyed failure toast", async () => {
+    reviewPlanFn.mockResolvedValue("error");
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: "planning" },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await armAndConfirmPlan(h);
+    await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
+    expect(toastsInfo).toHaveBeenCalledWith(
+      m.gitrail_review_plan_failed(),
+      expect.objectContaining({
+        duration: null,
+        alert: true,
+        key: `review-plan:${baseProps.sessionId}`,
+      }),
+    );
+  });
+
+  it("a rejected reviewPlan raises the persistent failure toast", async () => {
+    reviewPlanFn.mockRejectedValue(new Error("boom"));
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: "planning" },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await armAndConfirmPlan(h);
+    await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
+    expect(toastsInfo).toHaveBeenCalledWith(
+      m.gitrail_review_plan_failed(),
+      expect.objectContaining({ duration: null, alert: true }),
+    );
+  });
+
+  // 8. "started" → toasts.info NOT called
+  it("'started' status raises NO toast", async () => {
+    reviewPlanFn.mockResolvedValue("started");
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: "planning" },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await armAndConfirmPlan(h);
+    await vi.waitFor(() => expect(reviewPlanFn).toHaveBeenCalledTimes(1));
+    // give any (incorrect) toast a tick to fire, then assert silence
+    await new Promise((r) => setTimeout(r, 20));
+    expect(toastsInfo, "no toast on started").not.toHaveBeenCalled();
+  });
+
+  // 9. button is disabled while planGates.isReviewing is true
+  it("button is disabled while planGates.isReviewing is true", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    planGates.applyReviewing(baseProps.sessionId, true);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: "planning" },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+    await vi.waitFor(() => expect(planReviewBtn(h)).not.toBeNull());
+    expect(planReviewBtn(h)!.disabled, "button disabled while reviewing").toBe(true);
+  });
+
+  // 10. Co-render arm isolation: both buttons mounted, arm one, other stays unarmed.
+  // Captures stable DOM node references before any clicking to avoid re-querying
+  // ambiguously when both may show "confirm ✓" text.
+  it("arming plan-review button does not arm the critic button (arm isolation)", async () => {
+    // enable critic so both buttons render
+    repoConfig.enabled = { ...repoConfig.enabled, [baseProps.repoPath]: true };
+    gitStateFn.mockResolvedValue(openPrState); // open + checks:success + critic enabled
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: false, planPhase: "planning" },
+    });
+    await expect.element(screen.getByText(/PR #12345/)).toBeVisible();
+
+    // Capture stable DOM node references while both buttons show initial unarmed labels.
+    // The critic button starts as "Review" (no prior verdict); plan button as "Review plan".
+    let criticNode: HTMLButtonElement;
+    let planNode: HTMLButtonElement;
+    await vi.waitFor(() => {
+      const allBtns = [...h.querySelectorAll<HTMLButtonElement>("button.gbtn:not(.auto-pill)")];
+      const critic = allBtns.find((b) =>
+        /^(Review|Re-review|Restart)$/.test(b.textContent?.trim() ?? ""),
+      );
+      const plan = allBtns.find((b) => (b.textContent?.trim() ?? "").startsWith("Review plan"));
+      expect(critic, "critic button present").not.toBeNull();
+      expect(plan, "plan button present").not.toBeNull();
+      criticNode = critic!;
+      planNode = plan!;
+    });
+
+    // Click plan button once → plan button armed ("confirm ✓"), critic NOT armed
+    planNode!.click();
+    await vi.waitFor(() => expect(planNode!.textContent?.trim()).toBe(m.gitrail_confirm_review()));
+    expect(
+      criticNode!.textContent?.trim(),
+      "critic button NOT armed after plan button click",
+    ).not.toBe(m.gitrail_confirm_review());
+
+    // Click critic button once → critic button armed ("confirm ✓"), plan disarmed
+    criticNode!.click();
+    await vi.waitFor(() =>
+      expect(criticNode!.textContent?.trim()).toBe(m.gitrail_confirm_review()),
+    );
+    // plan button should show its unarmed "Review plan" label (NOT "confirm ✓")
+    expect(
+      planNode!.textContent?.trim(),
+      "plan button NOT armed after critic button click",
+    ).not.toBe(m.gitrail_confirm_review());
+
+    // cleanup
+    const next = { ...repoConfig.enabled };
+    delete next[baseProps.repoPath];
+    repoConfig.enabled = next;
   });
 });

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -1095,7 +1095,11 @@ describe("GitRail — manual plan-review trigger", () => {
     await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
     expect(toastsInfo).toHaveBeenCalledWith(
       m.gitrail_review_plan_failed(),
-      expect.objectContaining({ duration: null, alert: true }),
+      expect.objectContaining({
+        duration: null,
+        alert: true,
+        key: `review-plan:${baseProps.sessionId}`,
+      }),
     );
   });
 

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-  import { gitState, openPr, mergePr, redeploy, replySession, reviewPr } from "$lib/api";
+  import {
+    gitState,
+    openPr,
+    mergePr,
+    redeploy,
+    replySession,
+    reviewPr,
+    reviewPlan,
+  } from "$lib/api";
   import type { DrainStatus, GitState, Session, SessionStatus } from "$lib/types";
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
@@ -69,9 +77,9 @@
   let showAutomation = $state(false);
 
   // two-step confirm for destructive actions (mirrors decommission UX)
-  let armed = $state<"merge" | "redeploy" | "review" | null>(null);
+  let armed = $state<"merge" | "redeploy" | "review" | "review-plan" | null>(null);
   let armTimer: ReturnType<typeof setTimeout> | undefined;
-  function arm(which: "merge" | "redeploy" | "review"): boolean {
+  function arm(which: "merge" | "redeploy" | "review" | "review-plan"): boolean {
     if (armed === which) {
       clearTimeout(armTimer);
       armed = null;
@@ -92,6 +100,21 @@
     }
   }
 
+  // Bridge the gap between the review-plan HTTP reply and the WS plangate-reviewing
+  // flag so the button's reviewing state doesn't blink back to idle. Held until the
+  // reviewing flag is observed, with a backstop timeout so a lost event can't wedge it.
+  let awaitingPlanReview = $state(false);
+  // A real WS reviewing run supersedes the bridge.
+  $effect(() => {
+    if (planGates.isReviewing(sessionId)) awaitingPlanReview = false;
+  });
+  // Backstop: never wedge the indicator if the reviewing event never arrives.
+  $effect(() => {
+    if (!awaitingPlanReview) return;
+    const t = setTimeout(() => (awaitingPlanReview = false), 4000);
+    return () => clearTimeout(t);
+  });
+
   $effect(() => {
     const id = sessionId;
     git = null;
@@ -101,6 +124,7 @@
     showPr = false;
     showReview = false;
     showAutomation = false;
+    awaitingPlanReview = false;
     load(id);
     // light poll only while a PR is open (CI/merge state can change);
     // hidden-tab ticks are skipped, with a refresh on tab return
@@ -313,6 +337,19 @@
           ? m.gitrail_rereview()
           : m.gitrail_review(),
   );
+  // Manual plan-review trigger: visible only while the plan gate is active
+  // (planPhase === "planning"), matching PlanPanel's canReviewNow.
+  const canReviewPlan = $derived(planPhase === "planning");
+  const planReviewing = $derived(planGates.isReviewing(sessionId) || awaitingPlanReview);
+  const planReviewLabel = $derived(
+    armed === "review-plan"
+      ? m.gitrail_confirm_review()
+      : planReviewing
+        ? m.gitrail_reviewing_plan()
+        : planGates.map[sessionId]
+          ? m.gitrail_rereview_plan()
+          : m.gitrail_review_plan(),
+  );
   // Render the (AI-authored) findings as markdown, sanitized before @html.
   // marked + DOMPurify are dynamically imported on first render so they stay off
   // the first-paint critical path; gated on showReview so the (browser-only)
@@ -394,6 +431,31 @@
         duration: null,
         alert: true,
         key: `review-pr:${sessionId}`,
+      });
+    }
+  }
+
+  async function doReviewPlan() {
+    if (!arm("review-plan")) return; // first click arms, second confirms
+    if (planReviewing) return; // already in flight — consider() would skip
+    try {
+      const status = await reviewPlan(sessionId);
+      // "started" → bridge to the WS reviewing flag (silent; the indicator is the feedback).
+      // "skipped" while NOT already reviewing → transient note. "error" → persistent toast.
+      if (status === "started") awaitingPlanReview = true;
+      else if (status === "skipped" && !planGates.isReviewing(sessionId))
+        toasts.info(m.gitrail_review_plan_skipped());
+      else if (status !== "skipped")
+        toasts.info(m.gitrail_review_plan_failed(), {
+          duration: null,
+          alert: true,
+          key: `review-plan:${sessionId}`,
+        });
+    } catch {
+      toasts.info(m.gitrail_review_plan_failed(), {
+        duration: null,
+        alert: true,
+        key: `review-plan:${sessionId}`,
       });
     }
   }
@@ -562,6 +624,18 @@
           use:coachTarget={"manual-critic-review"}
         >
           {reviewLabel}
+        </button>
+      {/if}
+
+      {#if canReviewPlan}
+        <button
+          class="gbtn"
+          class:armed={armed === "review-plan"}
+          type="button"
+          disabled={planReviewing}
+          onclick={() => doReviewPlan()}
+        >
+          {planReviewLabel}
         </button>
       {/if}
 

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -52,7 +52,8 @@
   import ComposeBar from "$lib/components/ComposeBar.svelte";
   import GitRail from "$lib/components/GitRail.svelte";
   import AutopilotBadge from "$lib/components/AutopilotBadge.svelte";
-  import { reviews, repoConfig } from "$lib/reviews.svelte";
+  import PlanGateBadge from "$lib/components/PlanGateBadge.svelte";
+  import { reviews, planGates, repoConfig } from "$lib/reviews.svelte";
   import { toasts } from "$lib/toasts.svelte";
   import SteerBar from "$lib/components/SteerBar.svelte";
   import RedrawMenu from "$lib/components/RedrawMenu.svelte";
@@ -511,12 +512,24 @@
       git.checks === "success" &&
       git.latestReview?.state !== "changes_requested",
   );
+  const planGate = $derived(planGates.map[session.id]);
+  // The git strip holds the Review-plan action during planning; flag the collapsed
+  // desktop disclosure when the gate is in the stuck state the re-kick is FOR — a
+  // latched REVIEW ERR — so the operator is cued to expand it and reach the button.
+  // Scoped to "error" only: other planning states are surfaced by the PlanGateBadge
+  // in the header without lighting a "needs you" hue on every planning session.
+  // (During planning there is no PR, so prAttention/prClear are both false → no hue
+  // conflict with the merge-readiness vocabulary; once a PR opens, planPhase is
+  // "executing" so planAttention is false. The two are temporally disjoint.)
+  const planAttention = $derived(
+    session.planPhase === "planning" && planGate?.decision === "error",
+  );
   // Localized status word folded into the toggle's title/aria so the hue isn't the only
   // signal — color-only status fails colorblind users and screen readers.
   const gitToggleState = $derived(
     prClear
       ? m.viewport_git_actions_state_clear()
-      : prAttention
+      : prAttention || planAttention
         ? m.viewport_git_actions_state_attention()
         : "",
   );
@@ -2145,6 +2158,10 @@
         aria-label={statusLabel(dStatus)}>{statusMark}</span
       >
     {/if}
+    <!-- plan-gate state in the focused view (PLANNING / REWORK / READY / REVIEW ERR);
+         self-hides outside the plan phase. Both layouts — the Review-plan trigger on
+         the git rail acts on this state. -->
+    <PlanGateBadge {session} />
     {#if !compact}
       <!-- desktop: the full git rail (PR / CI / merge / critic / ready / verdict)
            plus the autopilot toggle live one disclosure away — this toggle reveals
@@ -2154,7 +2171,7 @@
       <button
         class="git-toggle"
         class:open={gitOpen}
-        class:attention={prAttention}
+        class:attention={prAttention || planAttention}
         class:clear={prClear}
         type="button"
         aria-expanded={gitOpen}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -987,4 +987,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_manual_critic_review_body",
     targetId: "manual-critic-review",
   },
+  {
+    // No targetId: the only <Coachmark> host (GitRail) arms exclusively over
+    // PILL_FEATURE_IDS, and WhatsNew surfaces entries by text. An anchored coachmark
+    // would never fire (and the Review-plan button is anyway unmounted on desktop
+    // until the git disclosure expands, and only exists while planPhase==="planning").
+    // Discovery is via the What's-New drawer.
+    id: "manual-plan-review",
+    sinceVersion: "1.33.0",
+    titleKey: "feat_manual_plan_review_title",
+    bodyKey: "feat_manual_plan_review_body",
+  },
 ];


### PR DESCRIPTION
Closes #753.

Adds a first-class manual plan-review trigger mirroring the critic-review button (#745), so an operator can re-kick a plan review — including a latched `REVIEW ERR` — in one click from the main session surface, without drilling into the `PlanPanel` modal.

## What changed

- **GitRail trigger button** (`GitRail.svelte`) — a `Review plan` / `Re-review plan` button gated on `planPhase === "planning"` (matches `PlanPanel`'s `canReviewNow`). Arm-then-confirm, reusing the existing `.gbtn`/`.armed` recipe. Calls the existing `reviewPlan()` → `POST /api/sessions/:id/review-plan` route (no server work — `consider()` already re-kicks a latched `REVIEW ERR` even on an unchanged plan).
- **Fail-closed toasts** — `started` → silent (a WS-bridged reviewing indicator is the feedback); `skipped` (and not already reviewing) → transient note; `error`/throw → **persistent** toast with the namespaced dedupe key `review-plan:<id>`. A deduped `skipped` *during* a live run is silent (mirrors `PlanPanel`).
- **WS bridge** — `awaitingPlanReview` bridges the HTTP reply → `plangate-reviewing` WS flag so the button's reviewing state doesn't blink, with a backstop timeout (cleaned up) and a session-switch reset.
- **Viewport state-surfacing** (`Viewport.svelte`) — the focused view previously showed *no* plan-gate state. Now mounts `<PlanGateBadge>` (both layouts) so `PLANNING/REWORK/READY/REVIEW ERR` is visible, and lights the desktop git-actions disclosure's attention cue on a latched `REVIEW ERR` so the collapsed rail cues expansion (button discoverability on desktop).
- **Feature discovery + i18n** — one `feature-announcements.ts` entry (no `targetId` — the only Coachmark host arms exclusively over `PILL_FEATURE_IDS`, so an anchor would be dead code; discovery is via the What's-New drawer), and 7 EN+DE message keys with parity.

The deliberate difference from the critic button: plan `consider()` has no abort path (returns `skipped` while in flight), so the button is **disabled** while reviewing rather than offering a no-op "Restart". The existing `PlanPanel` "Review now" stays — both call the same `reviewPlan()` route (no divergent path).

## Acceptance criteria

- [x] One-click plan-review from the main surface (not only the modal) whenever the gate is active, incl. `REVIEW ERR`
- [x] `started`/`skipped`/`error` surfaced distinctly; skipped/error never read as success (fail-closed)
- [x] `PlanPanel` "Review now" stays; no duplicate divergent trigger paths
- [x] One feature-announcements entry; EN+DE keys with parity (`check:i18n` green)
- [x] Lint/check/tests green (1394/1394 UI tests, incl. 11 new GitRail cases + co-render arm-isolation; `svelte-check` 0 errors)

Out of scope (per issue): hardening the plan-gate reviewer against the orphaned-reviewer/name-squat class fixed for the critic in #751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)