### PR TITLE
fix(ci): pin fallow to 2.97.0 to stop template-complexity gate tripping on large UI files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,5 +106,11 @@ jobs:
       - name: Fallow audit (PR delta)
         # Only new findings introduced by the PR block — inherited issues don't.
         # Skip on direct pushes to main: there's no base branch to diff against.
+        # Version pinned (not @latest) so analyzer changes are adopted deliberately,
+        # not on a random CI run. 2.97.0 is the last release before the synthetic
+        # Svelte <template> complexity metric, whose unnamed entry breaks fallow's
+        # inherited-vs-introduced attribution on line shifts (#756). A future bump to
+        # 2.98+ must intentionally adopt a <template> config (thresholdOverrides /
+        # health.ignore). Keep this in sync with .husky/pre-push and CONTRIBUTING.md.
         if: github.event_name == 'pull_request'
-        run: bunx fallow audit --base origin/${{ github.base_ref }} --fail-on-issues
+        run: bunx fallow@2.97.0 audit --base origin/${{ github.base_ref }} --fail-on-issues

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -63,9 +63,11 @@ echo "→ extension build"
 
 # Delta audit vs the merge base — only new dead-code/complexity/dupes block.
 # Skipped when origin/main is unavailable (e.g. offline) so a push isn't wedged.
+# Version pinned (see .github/workflows/ci.yml): 2.97.0 is the last release before
+# the synthetic Svelte <template> complexity metric (#756); bump deliberately.
 if git rev-parse --verify --quiet origin/main >/dev/null; then
   echo "→ fallow audit (delta vs origin/main)"
-  bunx fallow audit --base origin/main --fail-on-issues
+  bunx fallow@2.97.0 audit --base origin/main --fail-on-issues
 else
   echo "→ fallow audit skipped (origin/main not available)"
 fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,12 +82,21 @@ The `pre-push` hook runs the **same checks as CI** so failures surface before a 
 8. `bun test ./test` (core tests)
 9. `cd ui && bun run test` (ui tests)
 10. `cd ui && bun run build` (ui build)
-11. `bunx fallow audit --base origin/main --fail-on-issues` (delta dead-code/complexity audit
-    vs `origin/main`)
+11. `bunx fallow@2.97.0 audit --base origin/main --fail-on-issues` (delta dead-code/complexity
+    audit vs `origin/main`; version pinned — see note below)
 
 > Lint and typecheck are separate gates: eslint catches lint rules, `tsc` catches
 > type errors. Bun runs `.ts` by stripping types, so it never type-checks — only
 > `tsc` does.
+
+> **fallow is pinned to `2.97.0`** (not `@latest`) so analyzer changes are adopted
+> deliberately, not on a random run. 2.97.0 is the last release before the synthetic
+> Svelte `<template>` complexity metric, whose unnamed entry breaks fallow's
+> inherited-vs-introduced attribution on line shifts and trips the gate on any PR
+> touching a large UI file ([#756](https://github.com/erwins-enkel/shepherd/issues/756)).
+> A future bump to 2.98+ must intentionally adopt a `<template>` config
+> (`health.thresholdOverrides` or `health.ignore`). Keep the version in sync with
+> `.github/workflows/ci.yml` and `.husky/pre-push`.
 
 Run any of these manually at any time:
 
@@ -100,7 +109,7 @@ cd ui && bun run check       # svelte-check (ui types)
 cd ui && bun run check:i18n  # locale-catalog parity (en ↔ de)
 cd ui && bun run test        # ui test suite (vitest)
 cd ui && bun run build       # ui production build
-bunx fallow audit --base origin/main --fail-on-issues   # delta dead-code/complexity audit
+bunx fallow@2.97.0 audit --base origin/main --fail-on-issues  # delta dead-code/complexity audit (version pinned)
 ```
 
 ## Tests


### PR DESCRIPTION
## Problem

`bunx fallow` was invoked **unpinned** in CI (`.github/workflows/ci.yml`), the pre-push hook (`.husky/pre-push`), and `CONTRIBUTING.md`, so it silently rolled to **2.98.0** — which added a synthetic Svelte `<template>` complexity metric. That entry is unnamed, so fallow's inherited-vs-introduced attribution breaks when a file's line numbers shift, and a big file's *pre-existing* template finding re-surfaces as `introduced: true`. Net effect: **any PR that merely touches a large UI file fails the fallow delta gate even when it doesn't worsen complexity at all** (first hit: #755).

On `main`, 2.98.0 reports 36 complexity findings — **35** are the synthetic `<template>` entry, only **1** is a real function.

## Fix

Pin the fallow CLI to **`2.97.0`** — the last release *before* template-complexity analysis — at all four reference sites:

- `.github/workflows/ci.yml`
- `.husky/pre-push`
- `CONTRIBUTING.md` (×2: the pre-push checklist + the manual-commands block)

Acceptance #1 ("CI fallow version is deterministic **OR** template-complexity gating intentionally configured") is satisfied by the deterministic pin; no `.fallowrc` change is needed. 2.97.0 is a documented, deliberate choice — a future bump to 2.98+ must intentionally adopt a `<template>` config (`health.thresholdOverrides` or `health.ignore`), noted at each site.

### Why 2.97.0 rather than 2.98.0 + a `.fallowrc` override

- 2.98.0 was published ~5h before this work; the only repo-relevant change is the buggy template metric itself, with no identified non-template fix to justify adopting it.
- The override path depends on `health.thresholdOverrides` + `functions: ["<template>"]` and a hand-maintained ceiling. Pinning to 2.97.0 needs **zero** config change and eliminates that schema/maintenance risk.
- Function-level complexity gating (`maxCognitive 15` / `maxCyclomatic 20`) is **unchanged** in 2.97.0; the only thing forgone is the synthetic template metric the project never curated (35/36 findings inherited on `main`).

## Verification

- `bunx fallow@2.97.0 health --complexity` → **0** `<template>` findings (only the inherited real function `todo.ts::cleanupTodo`, cog 19).
- `bunx fallow@2.97.0 audit --base origin/main --fail-on-issues` → **pass** on this branch.
- **Acceptance #2:** a throwaway no-op edit (a comment) to a large UI file (`Herd.svelte`) → audit still **passes** (exit 0, no `<template>` finding), then reverted.
- Full pre-push gate (lint, typecheck, ui/extension check, i18n parity, all tests, builds, fallow audit) green.

No product/UI source changes — config + docs only. No `feat` commit; no feature-catalog / i18n / glossary entries required.

### Follow-up (out of scope)
The issue's **option 3** — curating the synthetic template metric by splitting the large components (Viewport, Herd, TopBar, +page, GitRail, IssuesPanel, UnitRow) so it could become a real gate under a 2.98+ bump — is intentionally deferred. Not filed as a separate issue yet; can be on request.

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)