### PR TITLE
feat(ui): declutter mobile PWA header (#720)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1441,5 +1441,12 @@
   "quota_resume_failed": "Fortsetzen fehlgeschlagen — öffne die Sitzung zum Übernehmen.",
   "quota_resume_cleared": "Bereits erledigt.",
   "feat_quota_needs_you_title": "Hängende Sessions melden sich jetzt",
-  "feat_quota_needs_you_body": "Wenn eine Session ihr Überarbeitungs- oder Review-Limit erreicht, wird sie nicht mehr still inaktiv — sie zeigt ein „braucht dich\"-Badge und eine Benachrichtigung, und im Triage kannst du sie fortsetzen, übernehmen oder verwerfen."
+  "feat_quota_needs_you_body": "Wenn eine Session ihr Überarbeitungs- oder Review-Limit erreicht, wird sie nicht mehr still inaktiv — sie zeigt ein „braucht dich\"-Badge und eine Benachrichtigung, und im Triage kannst du sie fortsetzen, übernehmen oder verwerfen.",
+  "herd_seg_all": "Alle",
+  "herd_seg_ready": "Bereit",
+  "herd_seg_research": "Recherche",
+  "herd_seg_done": "Fertig",
+  "herd_seg_rundown": "Rundown",
+  "feat_mobile_header_title": "Aufgeräumterer mobiler Kopf",
+  "feat_mobile_header_body": "Der Statusfilter in der Herd-Kopfzeile ist auf dem Handy jetzt ein kompaktes Segmented-Control — ein Tippen wechselt die Ansicht, Symbole entfallen, und die Leiste bleibt einzeilig auf jeder Handybreite."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1448,5 +1448,7 @@
   "herd_seg_done": "Fertig",
   "herd_seg_rundown": "Rundown",
   "feat_mobile_header_title": "Aufgeräumterer mobiler Kopf",
-  "feat_mobile_header_body": "Der Statusfilter in der Herd-Kopfzeile ist auf dem Handy jetzt ein kompaktes Segmented-Control — ein Tippen wechselt die Ansicht, Symbole entfallen, und die Leiste bleibt einzeilig auf jeder Handybreite."
+  "feat_mobile_header_body": "Der Statusfilter in der Herd-Kopfzeile ist auf dem Handy jetzt ein kompaktes Segmented-Control — ein Tippen wechselt die Ansicht, Symbole entfallen, und die Leiste bleibt einzeilig auf jeder Handybreite.",
+  "topbar_sheet_title": "Steuerung",
+  "topbar_sheet_usage": "Auslastung"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1441,5 +1441,12 @@
   "quota_resume_failed": "Couldn't resume — open the session to take over.",
   "quota_resume_cleared": "Already cleared.",
   "feat_quota_needs_you_title": "Stalled sessions now ask for you",
-  "feat_quota_needs_you_body": "When a session hits its rework or review limit it no longer goes quietly idle — it raises a 'needs you' badge and a notification, and Triage lets you resume it, take over, or abandon."
+  "feat_quota_needs_you_body": "When a session hits its rework or review limit it no longer goes quietly idle — it raises a 'needs you' badge and a notification, and Triage lets you resume it, take over, or abandon.",
+  "herd_seg_all": "All",
+  "herd_seg_ready": "Ready",
+  "herd_seg_research": "Research",
+  "herd_seg_done": "Done",
+  "herd_seg_rundown": "Rundown",
+  "feat_mobile_header_title": "Tidier mobile header",
+  "feat_mobile_header_body": "The status filter in the Herd header is now a compact segmented control on mobile — one tap switches lens, glyphs are gone, and the bar stays single-line at any phone width."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1448,5 +1448,7 @@
   "herd_seg_done": "Done",
   "herd_seg_rundown": "Rundown",
   "feat_mobile_header_title": "Tidier mobile header",
-  "feat_mobile_header_body": "The status filter in the Herd header is now a compact segmented control on mobile — one tap switches lens, glyphs are gone, and the bar stays single-line at any phone width."
+  "feat_mobile_header_body": "The status filter in the Herd header is now a compact segmented control on mobile — one tap switches lens, glyphs are gone, and the bar stays single-line at any phone width.",
+  "topbar_sheet_title": "Controls",
+  "topbar_sheet_usage": "Usage"
 }

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -351,7 +351,13 @@
     <!-- Mobile-only segmented control: replaces the .fbtn filter row in flow
          mode. A direct child of the already-full-bleed .panel.flow, so it spans
          the full phone width without its own negative margin. Equal-width segments,
-         44px touch targets, --fs-base labels without leading glyphs. -->
+         44px touch targets, no leading glyphs. Labels are --fs-base (13px), a
+         DELIBERATE exception to the ≥16px label floor (NOT an oversight): five
+         equal segments on a 390px phone leave ~77px each, but the longest label
+         ("Recherche", DE) needs ~93px at 16px — so ≥16px would truncate it, which
+         breaks the "keep full text labels" criterion. 13px is the largest size
+         that fits the full word; contrast is held high to compensate (active
+         --color-amber 8.49:1, inactive --color-muted 5.27:1). -->
     <div class="seg-row" use:coachTarget={"mobile-seg-ctrl"}>
       <button
         type="button"
@@ -916,7 +922,12 @@
   /* Mobile-only segmented control: replaces the .fbtn filter row in flow mode.
      A direct child of the already-full-bleed .panel.flow, so it spans the full
      phone width without its own negative margin. Equal-width segments, 44px touch
-     targets, --fs-base labels. */
+     targets. Labels are --fs-base (13px) — a DELIBERATE sub-16px exception, not an
+     oversight: at the 390px reference five equal segments give ~77px each and the
+     longest label "Recherche" (DE) measures 93px at 16px (it would truncate),
+     vs 77px at 13px (fits). The ≥16px floor is waived for this one control to keep
+     full text labels; high contrast (amber active / muted inactive) compensates.
+     A text-overflow:ellipsis below handles even-narrower fold-cover widths. */
   .seg-row {
     display: none;
   }

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -937,6 +937,9 @@
     padding: 0 2px;
     color: var(--color-faint);
     text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     transition:
       color 0.12s ease,
       background 0.12s ease;

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -347,6 +347,69 @@
       {/if}
     </div>
   </div>
+  {#if flow}
+    <!-- Mobile-only segmented control: replaces the .fbtn filter row in flow
+         mode. A direct child of the already-full-bleed .panel.flow, so it spans
+         the full phone width without its own negative margin. Equal-width segments,
+         44px touch targets, --fs-base labels without leading glyphs. -->
+    <div class="seg-row" use:coachTarget={"mobile-seg-ctrl"}>
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={statusFilter == null && filter === "all"}
+        title={m.herd_all_title()}
+        aria-pressed={statusFilter == null && filter === "all"}
+        onclick={() => {
+          filter = "all";
+          onstatusfilter?.(null);
+        }}>{m.herd_seg_all()}</button
+      >
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={statusFilter == null && filter === "ready"}
+        title={m.herd_ready_title()}
+        aria-pressed={statusFilter == null && filter === "ready"}
+        onclick={() => {
+          filter = "ready";
+          onstatusfilter?.(null);
+        }}>{m.herd_seg_ready()}</button
+      >
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={statusFilter == null && filter === "research"}
+        title={m.herd_research_title()}
+        aria-pressed={statusFilter == null && filter === "research"}
+        onclick={() => {
+          filter = "research";
+          onstatusfilter?.(null);
+        }}>{m.herd_seg_research()}</button
+      >
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={statusFilter == null && filter === "done"}
+        title={m.herd_done_title()}
+        aria-pressed={statusFilter == null && filter === "done"}
+        onclick={() => {
+          filter = "done";
+          onstatusfilter?.(null);
+        }}>{m.herd_seg_done()}</button
+      >
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={statusFilter == null && filter === "rundown"}
+        title={m.herd_rundown_title()}
+        aria-pressed={statusFilter == null && filter === "rundown"}
+        onclick={() => {
+          filter = "rundown";
+          onstatusfilter?.(null);
+        }}>{m.herd_seg_rundown()}</button
+      >
+    </div>
+  {/if}
   <div class="units" class:flow>
     {#if filter === "rundown"}
       <!-- Rundown lens: the daily Herd Rundown digest panel, no session list. -->
@@ -806,16 +869,11 @@
   .panel.flow .phead > .micro {
     display: none;
   }
-  /* Worst case (~320px wide phone with a status chip present = 6 buttons) still
-     overflows after hiding the title; tighten the filter buttons' tracking,
-     padding and inter-button gap just in flow mode so the row fits without
-     wrapping or horizontal overflow. */
+  /* In flow mode the desktop .fbtn row is replaced by the segmented control row
+     below; hide the entire filters bar (and the statchip within it) on mobile.
+     Desktop keeps .phead + .filters exactly as-is. */
   .panel.flow .filters {
-    gap: 3px;
-  }
-  .panel.flow .filters .fbtn {
-    letter-spacing: 0.06em;
-    padding: 2px 4px;
+    display: none;
   }
 
   .phead {
@@ -851,6 +909,50 @@
     color: var(--color-amber);
   }
   .fbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+
+  /* Mobile-only segmented control: replaces the .fbtn filter row in flow mode.
+     A direct child of the already-full-bleed .panel.flow, so it spans the full
+     phone width without its own negative margin. Equal-width segments, 44px touch
+     targets, --fs-base labels. */
+  .seg-row {
+    display: none;
+  }
+  .panel.flow .seg-row {
+    display: flex;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .seg-btn {
+    flex: 1;
+    min-width: 0;
+    min-height: 44px;
+    border: 0;
+    border-right: 1px solid var(--color-line);
+    background: none;
+    font-family: inherit;
+    font-size: var(--fs-base);
+    cursor: pointer;
+    padding: 0 2px;
+    color: var(--color-faint);
+    text-align: center;
+    transition:
+      color 0.12s ease,
+      background 0.12s ease;
+  }
+  .seg-btn:last-child {
+    border-right: 0;
+  }
+  .seg-btn:hover {
+    color: var(--color-ink);
+  }
+  .seg-btn.seg-active {
+    color: var(--color-amber);
+    background: var(--color-inset);
+    box-shadow: inset 0 -2px 0 var(--color-amber);
+  }
+  .seg-btn:focus-visible {
     outline: none;
     box-shadow: inset 0 0 0 1px var(--color-amber);
   }

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -935,7 +935,7 @@
     font-size: var(--fs-base);
     cursor: pointer;
     padding: 0 2px;
-    color: var(--color-faint);
+    color: var(--color-muted);
     text-align: center;
     white-space: nowrap;
     overflow: hidden;

--- a/ui/src/lib/components/RepoSwitcher.svelte
+++ b/ui/src/lib/components/RepoSwitcher.svelte
@@ -313,10 +313,10 @@
     /* a fixed single-line height so the rail never wraps */
     padding: 2px 0;
     scrollbar-width: none;
-    /* peek cue: reserve enough room on the right so the next chip's leading edge
-       is always partially visible (straddles the clip boundary at rest). Combined
-       with the narrow right-fade below, this guarantees a real visible peek on
-       coarse-pointer / touch devices without a trackpad affordance. */
+    /* peek cue: the visible at-rest peek comes from the .rs-track's trailing
+       padding-right plus the narrow right-edge fade, which together guarantee the
+       next chip's leading edge protrudes into view. scroll-padding-right keeps
+       keyboard-focus scrollIntoView clear of the faded edge. */
     scroll-padding-right: 20px;
   }
   .rs-scroller::-webkit-scrollbar {

--- a/ui/src/lib/components/RepoSwitcher.svelte
+++ b/ui/src/lib/components/RepoSwitcher.svelte
@@ -12,6 +12,7 @@
     repoFilter,
     onrepofilter,
     onlearnings,
+    mobile = false,
   }: {
     chips: RepoChip[];
     // active repo full path, or null when showing every repo
@@ -20,6 +21,9 @@
     onrepofilter: (repoPath: string | null) => void;
     // open the learnings drawer for a repo
     onlearnings?: (repoPath: string) => void;
+    // true when rendered on a phone-sized viewport — suppresses the lone-repo
+    // telemetry band (collapses into the selected-state subline instead)
+    mobile?: boolean;
   } = $props();
 
   // ── render branch selection ────────────────────────────────────────────────
@@ -279,7 +283,7 @@
       {@render telemetry(activeChip)}
     {/if}
   </div>
-{:else if loneChip}
+{:else if loneChip && !mobile}
   <div class="rs">
     {@render telemetry(loneChip)}
   </div>
@@ -309,6 +313,11 @@
     /* a fixed single-line height so the rail never wraps */
     padding: 2px 0;
     scrollbar-width: none;
+    /* peek cue: reserve enough room on the right so the next chip's leading edge
+       is always partially visible (straddles the clip boundary at rest). Combined
+       with the narrow right-fade below, this guarantees a real visible peek on
+       coarse-pointer / touch devices without a trackpad affordance. */
+    scroll-padding-right: 20px;
   }
   .rs-scroller::-webkit-scrollbar {
     display: none;
@@ -321,21 +330,28 @@
     gap: 4px;
     width: fit-content;
     white-space: nowrap;
+    /* trailing padding: ensures the right-most chip is never fully hidden behind
+       the fade — it protrudes into the padding, giving the eye a real partial chip
+       (the peek) even at scroll position 0. */
+    padding-right: 20px;
   }
   /* tonal edge-fade affordance: fade whichever edge hides content. No colored
-     element — a mask over the scroller's own pixels. */
+     element — a mask over the scroller's own pixels.
+     Right fade is intentionally narrower (12px vs 24px left) so the partial
+     chip behind it still reads as a chip — the fade is a secondary cue, the
+     peeking chip shape is the primary one. */
   .rs-scroller.fade-left {
     mask-image: linear-gradient(to right, transparent 0, #000 24px);
   }
   .rs-scroller.fade-right {
-    mask-image: linear-gradient(to left, transparent 0, #000 24px);
+    mask-image: linear-gradient(to left, transparent 0, #000 12px);
   }
   .rs-scroller.fade-left.fade-right {
     mask-image: linear-gradient(
       to right,
       transparent 0,
       #000 24px,
-      #000 calc(100% - 24px),
+      #000 calc(100% - 12px),
       transparent 100%
     );
   }

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -727,11 +727,13 @@ describe("TopBar — idle gear opens Settings directly", () => {
     await expect
       .element(page.getByRole("button", { name: m.actionbar_contrast_toggle() }))
       .toBeInTheDocument();
+    // mobile bottom sheet: Settings is a plain button (not role=menuitem — invalid in dialog)
     await expect
-      .element(page.getByRole("menuitem", { name: m.settings_title() }))
+      .element(page.getByRole("button", { name: m.settings_title() }))
       .toBeInTheDocument();
     // mobile footer: a link to Shepherd's home (README + docs) and the build version
-    const docs = page.getByRole("menuitem", { name: m.topbar_menu_docs() });
+    // The sheet uses plain <a>, not role=menuitem (invalid inside role=dialog)
+    const docs = page.getByRole("link", { name: m.topbar_menu_docs() });
     await expect.element(docs).toBeInTheDocument();
     await expect.element(docs).toHaveAttribute("href", REPO_URL);
     await expect.element(page.getByText(`v${version}`)).toBeInTheDocument();

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -927,3 +927,74 @@ describe("TopBar — CR extra-credit gauge", () => {
     );
   });
 });
+
+describe("TopBar — mobile gear sheet stays open on in-sheet clicks (dismissOnOutside bug)", () => {
+  // Regression guard for the critical bug: on mobile, every click inside the gear
+  // bottom sheet bubbled to <svelte:window onclick={dismissOnOutside}> and closed the
+  // sheet because the sheet is rendered OUTSIDE .gear-wrap. The fix gates the
+  // gearWrap-containment branch to !mobile; the sheet's own .menu-scrim backdrop and
+  // use:dialog handle dismissal on mobile.
+  //
+  // This test opens the mobile sheet then clicks a theme button that is rendered
+  // inside it. Without the !mobile guard that click wrongly triggers closeMenu() via
+  // the window handler. With the fix the sheet stays open.
+
+  it("mobile: clicking a theme button inside the sheet does NOT close the sheet", async () => {
+    await page.viewport(390, 800);
+    document.body.style.width = "390px";
+    // Use an idle session list so the gear always opens the menu on mobile.
+    const list = [{ id: "d1", status: "done" }] as unknown as Session[];
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.mobile,
+      sessions: list,
+    });
+
+    // Open the sheet.
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    // Confirm the sheet rendered (the theme button is one of its controls).
+    const themeBtn = page.getByRole("button", {
+      name: m.actionbar_theme_option({ label: m.theme_light() }),
+    });
+    await expect.element(themeBtn).toBeInTheDocument();
+
+    // Click the theme button — this is an in-sheet click that must NOT close the
+    // sheet (it should NOT propagate to the window dismissOnOutside handler and call
+    // closeMenu, because mobile is excluded from that branch).
+    await themeBtn.click();
+
+    // The sheet must still be in the document: the Settings button lives in the same
+    // sheet and would disappear if closeMenu() had run.
+    await expect
+      .element(page.getByRole("button", { name: m.settings_title() }))
+      .toBeInTheDocument();
+  });
+
+  it("desktop: clicking outside the gear wrap still closes the desktop dropdown", async () => {
+    // Guard that the !mobile change does NOT regress the desktop outside-click path.
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: sessions(1),
+    });
+
+    // Open the desktop dropdown.
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    await expect
+      .element(page.getByRole("menuitem", { name: m.settings_title() }))
+      .toBeInTheDocument();
+
+    // Simulate an outside click by dispatching a MouseEvent on document.body (which
+    // is outside .gear-wrap). The svelte:window handler should call closeMenu().
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextFrame();
+
+    await expect
+      .element(page.getByRole("menuitem", { name: m.settings_title() }))
+      .not.toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -414,7 +414,11 @@
   }
   function dismissOnOutside(e: MouseEvent) {
     if (popoverOpen && gaugeWrap && !gaugeWrap.contains(e.target as Node)) popoverOpen = false;
-    if (menuOpen && gearWrap && !gearWrap.contains(e.target as Node)) closeMenu();
+    // On mobile the sheet's own `.menu-scrim` backdrop (onclick={() => closeMenu()}) handles
+    // outside-tap and `use:dialog` handles Esc — so we MUST NOT gate on gearWrap containment
+    // here, or every in-sheet click (which bubbles to <svelte:window>) wrongly dismisses the
+    // sheet.  Desktop keeps the original outside-click behaviour unchanged.
+    if (menuOpen && !mobile && gearWrap && !gearWrap.contains(e.target as Node)) closeMenu();
   }
 </script>
 
@@ -891,7 +895,6 @@
             aria-hidden="true"
           ></span>{/if}{#if sheetPip && !herdrUpdateAvailable}<span
             class="sheet-pip"
-            class:shift-halt={haltable > 0}
             aria-hidden="true"
           ></span>{/if}</button
       >
@@ -1080,18 +1083,20 @@
     {/if}
 
     <!-- What's New row -->
-    <button
-      type="button"
-      class="sheet-item"
-      onclick={() => {
-        closeMenu();
-        onwhatsnew?.();
-      }}
-      aria-label={m.whatsnew_topbar_aria()}
-    >
-      <span class="sheet-glyph" aria-hidden="true">●</span>
-      <span class="sheet-label">{m.whatsnew_open()}</span>
-    </button>
+    {#if whatsNew}
+      <button
+        type="button"
+        class="sheet-item"
+        onclick={() => {
+          closeMenu();
+          onwhatsnew?.();
+        }}
+        aria-label={m.whatsnew_topbar_aria()}
+      >
+        <span class="sheet-glyph" aria-hidden="true">●</span>
+        <span class="sheet-label">{m.whatsnew_open()}</span>
+      </button>
+    {/if}
 
     <div class="sheet-sep"></div>
 
@@ -1551,13 +1556,6 @@
     border-radius: 50%;
     background: var(--color-amber);
     box-shadow: 0 0 0 2px var(--color-panel);
-  }
-  /* When halt-pip occupies top-right and shift moves gear-dot to bottom-right,
-     sheet-pip must shift to bottom-left (default) — already there, no extra rule.
-     shift-halt: when haltable>0 the halt-pip is active, sheet-pip stays bottom-left. */
-  .sheet-pip.shift-halt {
-    bottom: 3px;
-    left: 3px;
   }
   .menu-item {
     display: flex;
@@ -2157,9 +2155,6 @@
   }
   .needsyou.compact .ny-n {
     font-weight: 600;
-  }
-  .hud.mobile .update-badge {
-    min-height: 44px;
   }
 
   /* Coarse pointers (touch, any layout width): the secondary icon buttons are

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -16,6 +16,12 @@
   import { theme, type ThemePref } from "$lib/theme.svelte";
   import ThemeIcon from "$lib/components/ThemeIcon.svelte";
   import { REPO_URL, version } from "$lib/build-info";
+  import { fly } from "svelte/transition";
+  import { dialog } from "$lib/a11yDialog";
+
+  const reduceMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
 
   type TallyStatus = "running" | "idle" | "blocked";
 
@@ -331,6 +337,14 @@
   // controls live in the ActionBar, so the gear keeps its leaner behaviour: idle herd
   // opens Settings directly; only a haltable herd turns it into a menu button.
   const gearOpensMenu = $derived(mobile || haltable > 0);
+  // Mobile sheet pip: quiet indicator on the gear when the bottom sheet holds an
+  // actionable item — update available, health not ok, or what's new. Keeps moved
+  // badges discoverable when they no longer render in the top-bar right cluster.
+  // Composed alongside the halt-pip (.halt-pip) — the two use different corners
+  // (.sheet-pip sits bottom-left; .halt-pip owns top-right; .gear-dot owns top/bottom-right).
+  const sheetPip = $derived(
+    mobile && (updateAvailable || herdrUpdateAvailable || diagnosticsOverall !== "ok" || whatsNew),
+  );
   function clickGear() {
     if (!gearOpensMenu) {
       onsettings?.();
@@ -603,75 +617,133 @@
         {/if}
       </button>
     {/if}
-    {#if subscriptionOnly}
-      <span class="usage-sub-only micro">{m.usage_subscription_only()}</span>
-    {:else if touch}
-      {#if hotter || credits}
-        <!-- touch: collapse to the hotter window (or the CR gauge when credits are the
-             only signal); tap for the full breakdown. The collapsed button carries an
-             alert state while extra credits are being spent. -->
-        <div class="gauge-wrap" bind:this={gaugeWrap}>
-          {#if hotter}
-            <button
-              class="gauge gauge-btn"
-              class:stale={limits?.stale}
-              class:alert={overspend}
-              type="button"
-              aria-haspopup="dialog"
-              aria-expanded={popoverOpen}
-              aria-label={m.topbar_gauge_toggle_aria({
-                period: periodLabel(hotter.label),
-                pct: hotter.w.pct,
-              })}
-              onclick={() => (popoverOpen = !popoverOpen)}
-            >
-              <span class="g-label micro">{hotter.label}</span>
-              <span class="g-bar"
-                ><span
-                  class="g-fill"
-                  style="transform:scaleX({Math.min(Math.max(hotter.w.pct, 0), 100) /
-                    100});background:{gaugeColor(hotter.w.pct)}"
-                ></span></span
+    {#if !mobile}
+      {#if subscriptionOnly}
+        <span class="usage-sub-only micro">{m.usage_subscription_only()}</span>
+      {:else if touch}
+        {#if hotter || credits}
+          <!-- touch: collapse to the hotter window (or the CR gauge when credits are the
+               only signal); tap for the full breakdown. The collapsed button carries an
+               alert state while extra credits are being spent. -->
+          <div class="gauge-wrap" bind:this={gaugeWrap}>
+            {#if hotter}
+              <button
+                class="gauge gauge-btn"
+                class:stale={limits?.stale}
+                class:alert={overspend}
+                type="button"
+                aria-haspopup="dialog"
+                aria-expanded={popoverOpen}
+                aria-label={m.topbar_gauge_toggle_aria({
+                  period: periodLabel(hotter.label),
+                  pct: hotter.w.pct,
+                })}
+                onclick={() => (popoverOpen = !popoverOpen)}
               >
-              <span class="g-pct" style="color:{gaugeColor(hotter.w.pct)}">{hotter.w.pct}%</span>
-            </button>
-          {:else}
-            <!-- credits-only: no usage windows scraped, but extra spend exists -->
-            <button
-              class="gauge gauge-btn"
-              class:stale={credits?.stale}
-              class:alert={overspend}
-              type="button"
-              aria-haspopup="dialog"
-              aria-expanded={popoverOpen}
-              aria-label={overspend
-                ? m.topbar_credits_alert_aria({ amount: creditAmount })
-                : `${m.topbar_credits_period()} · ${creditAmount}`}
-              onclick={() => (popoverOpen = !popoverOpen)}
-            >
-              <span class="g-label micro">CR</span>
-              <span class="g-bar"
-                ><span
-                  class="g-fill"
-                  style="transform:scaleX({creditFill});background:{creditColor}"
-                ></span></span
+                <span class="g-label micro">{hotter.label}</span>
+                <span class="g-bar"
+                  ><span
+                    class="g-fill"
+                    style="transform:scaleX({Math.min(Math.max(hotter.w.pct, 0), 100) /
+                      100});background:{gaugeColor(hotter.w.pct)}"
+                  ></span></span
+                >
+                <span class="g-pct" style="color:{gaugeColor(hotter.w.pct)}">{hotter.w.pct}%</span>
+              </button>
+            {:else}
+              <!-- credits-only: no usage windows scraped, but extra spend exists -->
+              <button
+                class="gauge gauge-btn"
+                class:stale={credits?.stale}
+                class:alert={overspend}
+                type="button"
+                aria-haspopup="dialog"
+                aria-expanded={popoverOpen}
+                aria-label={overspend
+                  ? m.topbar_credits_alert_aria({ amount: creditAmount })
+                  : `${m.topbar_credits_period()} · ${creditAmount}`}
+                onclick={() => (popoverOpen = !popoverOpen)}
               >
-              <span class="g-pct credit-amount" style="color:{creditColor}">{creditAmount}</span>
-            </button>
-          {/if}
-          {#if popoverOpen}
-            <div
-              class="gauge-pop"
-              role="dialog"
-              aria-label={m.topbar_gauge_popover_title()}
-              class:stale={limits?.stale}
-            >
+                <span class="g-label micro">CR</span>
+                <span class="g-bar"
+                  ><span
+                    class="g-fill"
+                    style="transform:scaleX({creditFill});background:{creditColor}"
+                  ></span></span
+                >
+                <span class="g-pct credit-amount" style="color:{creditColor}">{creditAmount}</span>
+              </button>
+            {/if}
+            {#if popoverOpen}
+              <div
+                class="gauge-pop"
+                role="dialog"
+                aria-label={m.topbar_gauge_popover_title()}
+                class:stale={limits?.stale}
+              >
+                <div class="gauge-pop-title micro">
+                  {m.topbar_gauge_popover_title()}{limits?.stale
+                    ? m.topbar_gauge_stale_suffix()
+                    : ""}
+                </div>
+                {#each gauges as g (g.label)}
+                  <div class="gauge-pop-row">
+                    <span class="g-label micro">{g.label}</span>
+                    <span class="g-bar g-bar-wide"
+                      ><span
+                        class="g-fill"
+                        style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
+                          100});background:{gaugeColor(g.w.pct)}"
+                      ></span></span
+                    >
+                    <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+                  </div>
+                  <div class="gauge-pop-reset micro">
+                    {m.topbar_gauge_reset_rel({
+                      rel: formatResetIn(g.w.resetAt, nowMs),
+                      abs: formatReset(g.w.resetAt, nowMs),
+                    })}
+                  </div>
+                {/each}
+                {@render creditDetail()}
+              </div>
+            {/if}
+          </div>
+        {/if}
+      {:else if gauges.length || credits}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+          class="gauges-wrap"
+          onmouseenter={() => (detailOpen = true)}
+          onmouseleave={() => (detailOpen = false)}
+        >
+          <div class="gauges" class:stale={limits?.stale}>
+            {#each gauges as g (g.label)}
+              <div class="gauge" aria-label={gaugeTip(g.label, g.w.pct, g.w.resetAt)}>
+                <span class="g-label micro">{g.label}</span>
+                <span class="g-bar"
+                  ><span
+                    class="g-fill"
+                    style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
+                      100});background:{gaugeColor(g.w.pct)}"
+                  ></span></span
+                >
+                <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+              </div>
+            {/each}
+            {@render creditGauge()}
+          </div>
+          {#if detailOpen}
+            <div class="gauge-pop gauge-pop-desk" role="tooltip" class:stale={limits?.stale}>
               <div class="gauge-pop-title micro">
                 {m.topbar_gauge_popover_title()}{limits?.stale ? m.topbar_gauge_stale_suffix() : ""}
               </div>
               {#each gauges as g (g.label)}
-                <div class="gauge-pop-row">
-                  <span class="g-label micro">{g.label}</span>
+                <div class="gp-window">
+                  <div class="gp-head">
+                    <span class="gp-period">{periodLabel(g.label)}</span>
+                    <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+                  </div>
                   <span class="g-bar g-bar-wide"
                     ><span
                       class="g-fill"
@@ -679,97 +751,42 @@
                         100});background:{gaugeColor(g.w.pct)}"
                     ></span></span
                   >
-                  <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
-                </div>
-                <div class="gauge-pop-reset micro">
-                  {m.topbar_gauge_reset_rel({
-                    rel: formatResetIn(g.w.resetAt, nowMs),
-                    abs: formatReset(g.w.resetAt, nowMs),
-                  })}
+                  <div class="gauge-pop-reset micro">
+                    {m.topbar_gauge_reset_rel({
+                      rel: formatResetIn(g.w.resetAt, nowMs),
+                      abs: formatReset(g.w.resetAt, nowMs),
+                    })}
+                  </div>
                 </div>
               {/each}
-              {@render creditDetail()}
+              {#if credits}
+                <div class="gp-window">
+                  {@render creditDetail()}
+                </div>
+              {/if}
             </div>
           {/if}
         </div>
       {/if}
-    {:else if gauges.length || credits}
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div
-        class="gauges-wrap"
-        onmouseenter={() => (detailOpen = true)}
-        onmouseleave={() => (detailOpen = false)}
-      >
-        <div class="gauges" class:stale={limits?.stale}>
-          {#each gauges as g (g.label)}
-            <div class="gauge" aria-label={gaugeTip(g.label, g.w.pct, g.w.resetAt)}>
-              <span class="g-label micro">{g.label}</span>
-              <span class="g-bar"
-                ><span
-                  class="g-fill"
-                  style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
-                    100});background:{gaugeColor(g.w.pct)}"
-                ></span></span
-              >
-              <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
-            </div>
-          {/each}
-          {@render creditGauge()}
-        </div>
-        {#if detailOpen}
-          <div class="gauge-pop gauge-pop-desk" role="tooltip" class:stale={limits?.stale}>
-            <div class="gauge-pop-title micro">
-              {m.topbar_gauge_popover_title()}{limits?.stale ? m.topbar_gauge_stale_suffix() : ""}
-            </div>
-            {#each gauges as g (g.label)}
-              <div class="gp-window">
-                <div class="gp-head">
-                  <span class="gp-period">{periodLabel(g.label)}</span>
-                  <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
-                </div>
-                <span class="g-bar g-bar-wide"
-                  ><span
-                    class="g-fill"
-                    style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
-                      100});background:{gaugeColor(g.w.pct)}"
-                  ></span></span
-                >
-                <div class="gauge-pop-reset micro">
-                  {m.topbar_gauge_reset_rel({
-                    rel: formatResetIn(g.w.resetAt, nowMs),
-                    abs: formatReset(g.w.resetAt, nowMs),
-                  })}
-                </div>
-              </div>
-            {/each}
-            {#if credits}
-              <div class="gp-window">
-                {@render creditDetail()}
-              </div>
-            {/if}
-          </div>
-        {/if}
-      </div>
     {/if}
     <div class="clock tip" class:no-time={hideClockTime} data-tip={connText} aria-label={connText}>
       <span class="dot" class:on={connected}>●</span><span class="time">{clock}</span>
     </div>
-    {#if updateAvailable}
+    {#if !mobile && updateAvailable}
       <button
         class="update-badge"
-        class:mobile
         onclick={() => onupdate?.()}
         title="{update!.behind} {update!.behind === 1
           ? m.updatemodal_commits_one()
           : m.updatemodal_commits_other()}"
       >
         <span class="up-dot">▲</span>
-        {#if !mobile && !compactBadges}<span class="up-label">{m.topbar_update_badge()}</span>{/if}
+        {#if !compactBadges}<span class="up-label">{m.topbar_update_badge()}</span>{/if}
         <span class="up-n">{update!.behind}</span>
       </button>
     {/if}
     <!-- Desktop keeps the inline HERDR badge; on a phone it folds into the gear
-         (blue dot below) to free a slot in the single-row control cluster. The
+         bottom sheet to free a slot in the single-row control cluster. The
          touch-desktop badge crunch drops the label to a bare ▲ (aria-label keeps
          it named) so two stacked update badges still fit. -->
     {#if herdrUpdateAvailable && !mobile}
@@ -786,11 +803,11 @@
         {#if !compactBadges}<span class="up-label">{m.topbar_herdr_update_badge()}</span>{/if}
       </button>
     {/if}
-    {#if whatsNew}
-      <!-- Desktop: labelled button with hover-tip; Mobile (and the touch-desktop
-           multi-badge crunch) collapse to dot-only to avoid crowding the
-           single-row control cluster (mirrors .gear-dot pattern). -->
-      {#if !mobile && !compactBadges}
+    {#if whatsNew && !mobile}
+      <!-- Desktop: labelled button with hover-tip; touch-desktop multi-badge crunch
+           collapses to dot-only to avoid crowding the control cluster. On mobile,
+           What's New moves into the gear bottom sheet. -->
+      {#if !compactBadges}
         <button
           class="whatsnew-badge tip"
           type="button"
@@ -811,13 +828,14 @@
         >
       {/if}
     {/if}
-    <!-- Health pip: visible ONLY when diagnosticsOverall !== "ok".
+    <!-- Health pip: visible ONLY when diagnosticsOverall !== "ok" AND not mobile
+         (on mobile it moves into the gear bottom sheet).
          Own slot left of the gear-wrap so it never overlaps the halt-pip (gear top-right)
          or the herdr blue gear-dot. Color: slate ring with state-colored core —
          amber for warning, red for error — distinct from both the halt-pip identity
          and the herdr blue. Token choice: --color-amber / --color-red for the core,
          --color-line-bright for the ring. Never --color-green (hidden when ok anyway). -->
-    {#if diagnosticsOverall !== "ok"}
+    {#if diagnosticsOverall !== "ok" && !mobile}
       <button
         class="health-pip tip"
         class:alert={diagnosticsOverall === "error"}
@@ -831,22 +849,24 @@
       </button>
     {/if}
     <!-- ☰ RUNDOWN: opens the daily Herd Rundown digest lens. Sits just left of the
-         settings cog. Compact (icon + label dropped to a glyph) on phones and the
-         touch-desktop badge crunch, mirroring the NEEDS YOU badge's compact pattern. -->
-    <button
-      class="rundown-btn"
-      class:compact={mobile || compactBadges}
-      class:active={rundownActive}
-      type="button"
-      onclick={() => onrundown?.()}
-      title={m.topbar_rundown()}
-      aria-label={m.topbar_rundown()}
-      aria-pressed={rundownActive}
-      use:coachTarget={"herd-rundown"}
-    >
-      <span class="rd-glyph" aria-hidden="true">☰</span>
-      {#if !(mobile || compactBadges)}<span class="rd-label">{m.topbar_rundown()}</span>{/if}
-    </button>
+         settings cog. On mobile, Rundown is now a segment in the herd filter so the
+         button is dropped (keep the props intact for desktop). -->
+    {#if !mobile}
+      <button
+        class="rundown-btn"
+        class:compact={compactBadges}
+        class:active={rundownActive}
+        type="button"
+        onclick={() => onrundown?.()}
+        title={m.topbar_rundown()}
+        aria-label={m.topbar_rundown()}
+        aria-pressed={rundownActive}
+        use:coachTarget={"herd-rundown"}
+      >
+        <span class="rd-glyph" aria-hidden="true">☰</span>
+        {#if !compactBadges}<span class="rd-label">{m.topbar_rundown()}</span>{/if}
+      </button>
+    {/if}
     <!-- The gear adapts to state: idle herd → a click opens Settings directly;
          when something is haltable it becomes a menu button opening the e-stop above
          the Settings entry. A pip on the gear is the only at-rest cue that there's a
@@ -861,7 +881,7 @@
         type="button"
         onclick={clickGear}
         data-tip={gearOpensMenu ? m.topbar_menu_aria() : m.settings_title()}
-        aria-haspopup={gearOpensMenu ? "menu" : undefined}
+        aria-haspopup={gearOpensMenu ? (mobile ? "dialog" : "menu") : undefined}
         aria-expanded={gearOpensMenu ? menuOpen : undefined}
         aria-label={gearOpensMenu ? m.topbar_menu_aria() : m.topbar_settings_aria()}
         >⚙{#if haltable > 0}<span class="halt-pip" class:alert={blocked > 0} aria-hidden="true"
@@ -869,46 +889,22 @@
             class="gear-dot"
             class:shift={haltable > 0}
             aria-hidden="true"
+          ></span>{/if}{#if sheetPip && !herdrUpdateAvailable}<span
+            class="sheet-pip"
+            class:shift-halt={haltable > 0}
+            aria-hidden="true"
           ></span>{/if}</button
       >
-      {#if menuOpen}
+      {#if menuOpen && !mobile}
+        <!-- Desktop dropdown: role=menu/menuitem + arrow-key cycling. Zero change vs before. -->
         <div
           class="gear-menu"
-          class:mobile
           role="menu"
           tabindex="-1"
           aria-label={m.topbar_menu_label()}
           bind:this={menuEl}
           onkeydown={onMenuKey}
         >
-          {#if mobile}
-            <!-- Quick appearance controls, surfaced directly (not buried in Settings):
-                 dark/light theme + the high-contrast readability lift. Mirrors the
-                 desktop ActionBar recipe, sized up for touch. -->
-            <div class="quick">
-              <div class="theme-seg" role="group" aria-label={m.actionbar_theme_group_aria()}>
-                {#each QUICK_THEMES as t (t.pref)}
-                  <button
-                    type="button"
-                    class="t-opt"
-                    class:on={theme.resolved === t.pref}
-                    aria-pressed={theme.resolved === t.pref}
-                    aria-label={m.actionbar_theme_option({ label: t.label() })}
-                    onclick={() => theme.setPref(t.pref)}><ThemeIcon icon={t.icon} /></button
-                  >
-                {/each}
-              </div>
-              <button
-                type="button"
-                class="contrast-toggle"
-                class:on={theme.contrast}
-                aria-pressed={theme.contrast}
-                aria-label={m.actionbar_contrast_toggle()}
-                onclick={() => theme.toggleContrast()}><ThemeIcon icon="contrast" /></button
-              >
-            </div>
-            <div class="menu-sep" role="separator"></div>
-          {/if}
           {#if haltable > 0}
             <!-- e-stop row: first activation arms (red "Halt N?"), a second commits.
                  Full intent stays in the aria-label. -->
@@ -937,35 +933,209 @@
             <span class="menu-glyph" aria-hidden="true">⚙</span>
             <span class="menu-label">{m.settings_title()}</span>
           </button>
-          {#if mobile}
-            <!-- Mobile footer: a jump to Shepherd's home (the repo's README + docs) and the
-                 running build version. Desktop surfaces these in the ActionBar footer +
-                 Settings → About instead, so they're folded into the gear menu only here. -->
-            <div class="menu-sep" role="separator"></div>
-            <a
-              class="menu-item"
-              href={REPO_URL}
-              target="_blank"
-              rel="external noreferrer noopener"
-              role="menuitem"
-              onclick={() => closeMenu()}
-            >
-              <span class="menu-glyph" aria-hidden="true">↗</span>
-              <span class="menu-label">{m.topbar_menu_docs()}</span>
-            </a>
-            <div class="menu-foot micro" role="none">v{version}</div>
-          {/if}
         </div>
       {/if}
     </div>
   </div>
 </div>
 
-<!-- Blur backdrop behind the opened mobile menu, so the panel reads as the focus and the
-     herd recedes. Decorative only — the window-level outside-click handler closes the menu.
-     Rendered outside .gear-wrap so that outside-click detection still fires on it. -->
+<!-- Blur backdrop behind the opened mobile bottom sheet, so the panel reads as the focus
+     and the herd recedes. Rendered outside .gear-wrap so outside-click detection fires on it.
+     onclick also wires close explicitly to complement the window-level handler. -->
 {#if menuOpen && mobile}
-  <div class="menu-scrim scrim" aria-hidden="true"></div>
+  <div class="menu-scrim scrim" aria-hidden="true" onclick={() => closeMenu()}></div>
+  <!-- Mobile bottom sheet: slides up from the bottom of the screen. role=dialog + use:dialog
+       provides focus-trap + Esc→closeMenu + focus-restore. Children are plain buttons/links,
+       NOT role="menuitem" (that role is invalid inside a dialog). -->
+  <div
+    class="gear-sheet"
+    role="dialog"
+    aria-modal="true"
+    aria-label={m.topbar_sheet_title()}
+    use:dialog={{ onclose: closeMenu }}
+    transition:fly={{ y: 520, duration: reduceMotion ? 0 : 220, opacity: 1 }}
+  >
+    <!-- Grab handle + title row -->
+    <div class="sheet-handle-row" aria-hidden="true">
+      <div class="sheet-handle"></div>
+    </div>
+    <div class="sheet-title-row">
+      <span class="sheet-title micro">{m.topbar_sheet_title()}</span>
+      <button
+        type="button"
+        class="sheet-close"
+        onclick={() => closeMenu()}
+        aria-label={m.common_close()}>✕</button
+      >
+    </div>
+
+    <!-- Quick appearance: dark/light theme + high-contrast toggle -->
+    <div class="quick">
+      <div class="theme-seg" role="group" aria-label={m.actionbar_theme_group_aria()}>
+        {#each QUICK_THEMES as t (t.pref)}
+          <button
+            type="button"
+            class="t-opt"
+            class:on={theme.resolved === t.pref}
+            aria-pressed={theme.resolved === t.pref}
+            aria-label={m.actionbar_theme_option({ label: t.label() })}
+            onclick={() => theme.setPref(t.pref)}><ThemeIcon icon={t.icon} /></button
+          >
+        {/each}
+      </div>
+      <button
+        type="button"
+        class="contrast-toggle"
+        class:on={theme.contrast}
+        aria-pressed={theme.contrast}
+        aria-label={m.actionbar_contrast_toggle()}
+        onclick={() => theme.toggleContrast()}><ThemeIcon icon="contrast" /></button
+      >
+    </div>
+    <div class="sheet-sep"></div>
+
+    <!-- Usage section: full gauge breakdown (mirrors the touch popover content) -->
+    {#if gauges.length || credits || subscriptionOnly}
+      <div class="sheet-section-label micro">{m.topbar_sheet_usage()}</div>
+      {#if subscriptionOnly}
+        <div class="sheet-row-text micro">{m.usage_subscription_only()}</div>
+      {:else}
+        <div class="sheet-gauges" class:stale={limits?.stale}>
+          {#each gauges as g (g.label)}
+            <div class="sheet-gauge-row">
+              <div class="sheet-gauge-head">
+                <span class="gp-period">{periodLabel(g.label)}</span>
+                <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+              </div>
+              <span class="g-bar g-bar-wide"
+                ><span
+                  class="g-fill"
+                  style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
+                    100});background:{gaugeColor(g.w.pct)}"
+                ></span></span
+              >
+              <div class="gauge-pop-reset micro">
+                {m.topbar_gauge_reset_rel({
+                  rel: formatResetIn(g.w.resetAt, nowMs),
+                  abs: formatReset(g.w.resetAt, nowMs),
+                })}
+              </div>
+            </div>
+          {/each}
+          {@render creditDetail()}
+        </div>
+      {/if}
+      <div class="sheet-sep"></div>
+    {/if}
+
+    <!-- Diagnose row: only when health is not ok -->
+    {#if diagnosticsOverall !== "ok"}
+      <button
+        type="button"
+        class="sheet-item"
+        class:alert={diagnosticsOverall === "error"}
+        onclick={() => {
+          closeMenu();
+          ondiagnose?.();
+        }}
+        aria-label={m.diagnostics_pip_label()}
+      >
+        <span class="sheet-glyph" aria-hidden="true"
+          >{diagnosticsOverall === "error" ? "✕" : "⚠"}</span
+        >
+        <span class="sheet-label">{m.diagnostics_pip_label()}</span>
+      </button>
+    {/if}
+
+    <!-- Update row: when shepherd update is available -->
+    {#if updateAvailable}
+      <button
+        type="button"
+        class="sheet-item sheet-update"
+        onclick={() => {
+          closeMenu();
+          onupdate?.();
+        }}
+        aria-label={m.topbar_update_badge()}
+      >
+        <span class="sheet-glyph" aria-hidden="true">▲</span>
+        <span class="sheet-label">{m.topbar_update_badge()} · {update!.behind}</span>
+      </button>
+    {/if}
+
+    <!-- Herdr update row: when herdr update is available -->
+    {#if herdrUpdateAvailable}
+      <button
+        type="button"
+        class="sheet-item sheet-update"
+        onclick={() => {
+          closeMenu();
+          onherdrupdate?.();
+        }}
+        aria-label={m.topbar_herdr_update_badge()}
+      >
+        <span class="sheet-glyph" aria-hidden="true">▲</span>
+        <span class="sheet-label">{m.topbar_herdr_update_badge()}</span>
+      </button>
+    {/if}
+
+    <!-- What's New row -->
+    <button
+      type="button"
+      class="sheet-item"
+      onclick={() => {
+        closeMenu();
+        onwhatsnew?.();
+      }}
+      aria-label={m.whatsnew_topbar_aria()}
+    >
+      <span class="sheet-glyph" aria-hidden="true">●</span>
+      <span class="sheet-label">{m.whatsnew_open()}</span>
+    </button>
+
+    <div class="sheet-sep"></div>
+
+    <!-- Halt e-stop: two-step arm→confirm, same as desktop -->
+    {#if haltable > 0}
+      <button
+        class="sheet-item halt-item"
+        class:armed
+        type="button"
+        onclick={clickHalt}
+        aria-label={armed
+          ? m.halt_arm_aria({ count: haltable })
+          : m.halt_all_aria({ count: haltable })}
+      >
+        <svg class="menu-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M8 2 H16 L22 8 V16 L16 22 H8 L2 16 V8 Z" fill="currentColor" />
+        </svg>
+        <span class="sheet-label"
+          >{armed ? m.halt_arm({ count: haltable }) : m.halt_menu_item({ count: haltable })}</span
+        >
+      </button>
+      <div class="sheet-sep"></div>
+    {/if}
+
+    <!-- Settings -->
+    <button type="button" class="sheet-item" onclick={chooseSettings}>
+      <span class="sheet-glyph" aria-hidden="true">⚙</span>
+      <span class="sheet-label">{m.settings_title()}</span>
+    </button>
+
+    <!-- Docs + version footer -->
+    <div class="sheet-sep"></div>
+    <a
+      class="sheet-item"
+      href={REPO_URL}
+      target="_blank"
+      rel="external noreferrer noopener"
+      onclick={() => closeMenu()}
+    >
+      <span class="sheet-glyph" aria-hidden="true">↗</span>
+      <span class="sheet-label">{m.topbar_menu_docs()}</span>
+    </a>
+    <div class="sheet-foot micro">v{version}</div>
+  </div>
 {/if}
 
 <style>
@@ -1135,22 +1305,6 @@
     border-radius: 3px;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
   }
-  /* Mobile: the menu is a real control panel (quick theme/contrast + halt + Settings),
-     so it sits flush against the screen's right edge and reads larger and more evenly
-     spaced. The -8px pulls its right edge out past the bar's 16px content gutter to an
-     8px screen margin; min-width + roomier padding give it deliberate presence. */
-  .gear-menu.mobile {
-    right: -8px;
-    min-width: 240px;
-    gap: 4px;
-    padding: 8px;
-    border-radius: 4px;
-  }
-  .gear-menu.mobile .menu-item {
-    padding: 12px;
-    font-size: var(--fs-lg);
-    gap: 12px;
-  }
   /* Quick appearance row: dark/light segment + high-contrast toggle, mirroring the
      desktop ActionBar but sized up for touch (44px tap targets). */
   .quick {
@@ -1220,10 +1374,190 @@
     background: var(--color-inset);
     border-color: var(--color-amber);
   }
-  /* Sits below the menu (z 30) but above app content, so the herd blurs while the
-     panel stays crisp. Uses the canonical .scrim primitive (dim + blur) from app.css. */
+  /* Scrim: sits below the mobile bottom sheet (z 49) but above app content.
+     Uses the canonical .scrim primitive (dim + blur) from app.css. */
   .menu-scrim {
-    z-index: 25;
+    z-index: 49;
+  }
+
+  /* Mobile bottom sheet: slides up from the bottom. Fixed to left/right/bottom edges,
+     tall enough to hold all sections without viewport overflow. The sheet itself is
+     opaque panel chrome — the .scrim behind it dims+blurs the herd content. */
+  .gear-sheet {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 50;
+    background: var(--color-panel);
+    border-top: 1px solid var(--color-line-bright);
+    border-radius: 10px 10px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 0 8px 12px;
+    /* safe-area bottom for notched phones */
+    padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+    max-height: 90dvh;
+    overflow-y: auto;
+  }
+  .sheet-handle-row {
+    display: flex;
+    justify-content: center;
+    padding: 10px 0 4px;
+  }
+  .sheet-handle {
+    width: 40px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--color-line-bright);
+  }
+  .sheet-title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 2px 4px 6px;
+  }
+  .sheet-title {
+    color: var(--color-muted);
+  }
+  .sheet-close {
+    background: none;
+    border: 0;
+    color: var(--color-muted);
+    cursor: pointer;
+    min-width: 44px;
+    min-height: 44px;
+    font-size: var(--fs-lg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .sheet-sep {
+    height: 1px;
+    margin: 5px 4px;
+    background: var(--color-line);
+  }
+  .sheet-section-label {
+    padding: 6px 8px 2px;
+    color: var(--color-muted);
+  }
+  .sheet-row-text {
+    padding: 6px 8px;
+    color: var(--color-muted);
+  }
+  /* Full gauge breakdown in the sheet — one row per window, wider bars. */
+  .sheet-gauges {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 4px 8px 4px;
+  }
+  .sheet-gauges.stale {
+    opacity: 0.5;
+  }
+  .sheet-gauge-row {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .sheet-gauge-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    font-variant-numeric: tabular-nums;
+  }
+  /* Sheet action rows: ≥44px targets, token-driven, no role=menuitem (invalid in dialog). */
+  .sheet-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    min-height: 44px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    color: var(--color-ink);
+    font: inherit;
+    font-size: var(--fs-lg);
+    text-align: left;
+    padding: 10px 12px;
+    cursor: pointer;
+    white-space: nowrap;
+    text-decoration: none;
+  }
+  .sheet-item:hover,
+  .sheet-item:focus-visible {
+    background: color-mix(in srgb, var(--color-line-bright) 40%, transparent);
+    outline: none;
+  }
+  .sheet-item.alert {
+    color: var(--color-amber);
+  }
+  .sheet-item.alert:hover,
+  .sheet-item.alert:focus-visible {
+    background: color-mix(in srgb, var(--color-amber) 12%, transparent);
+  }
+  /* Update rows: amber accent (same semantic hue as the inline update badge). */
+  .sheet-item.sheet-update {
+    color: var(--color-amber);
+  }
+  .sheet-item.sheet-update:hover,
+  .sheet-item.sheet-update:focus-visible {
+    background: color-mix(in srgb, var(--color-amber) 12%, transparent);
+  }
+  /* e-stop row in the sheet — same muted-then-red pattern as the desktop menu. */
+  .sheet-item.halt-item {
+    color: var(--color-muted);
+  }
+  .sheet-item.halt-item:hover,
+  .sheet-item.halt-item:focus-visible {
+    background: color-mix(in srgb, var(--color-red) 14%, transparent);
+    color: var(--color-red);
+  }
+  .sheet-item.halt-item.armed {
+    background: color-mix(in srgb, var(--color-red) 22%, transparent);
+    border-color: var(--color-red);
+    color: var(--color-red);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: var(--fs-meta);
+  }
+  .sheet-item.halt-item.armed .menu-icon {
+    width: var(--fs-lg);
+    height: var(--fs-lg);
+  }
+  .sheet-glyph {
+    width: var(--fs-lg);
+    text-align: center;
+    flex-shrink: 0;
+  }
+  .sheet-label {
+    font-variant-numeric: tabular-nums;
+  }
+  .sheet-foot {
+    padding: 6px 12px 2px;
+    color: var(--color-faint);
+    font-variant-numeric: tabular-nums;
+  }
+  /* Sheet pip on the gear: quiet actionable-item indicator. Bottom-left corner so it
+     composes cleanly with .halt-pip (top-right) and .gear-dot (top/bottom-right). */
+  .sheet-pip {
+    position: absolute;
+    bottom: 3px;
+    left: 3px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--color-amber);
+    box-shadow: 0 0 0 2px var(--color-panel);
+  }
+  /* When halt-pip occupies top-right and shift moves gear-dot to bottom-right,
+     sheet-pip must shift to bottom-left (default) — already there, no extra rule.
+     shift-halt: when haltable>0 the halt-pip is active, sheet-pip stays bottom-left. */
+  .sheet-pip.shift-halt {
+    bottom: 3px;
+    left: 3px;
   }
   .menu-item {
     display: flex;
@@ -1287,13 +1621,6 @@
     height: 1px;
     margin: 3px 2px;
     background: var(--color-line);
-  }
-  /* Build-version footer under the mobile menu's docs link — a quiet, non-interactive
-     line, so it stays understated next to the tappable rows above it. */
-  .menu-foot {
-    padding: 6px 12px 2px;
-    color: var(--color-faint);
-    font-variant-numeric: tabular-nums;
   }
   /* Pip on the gear: the only at-rest cue that there's a herd to halt. Amber while
      agents merely work; red (.alert) only when something is blocked, so red stays
@@ -1630,6 +1957,13 @@
     width: 100%;
     height: 6px;
   }
+  .sheet-gauge-row .g-bar-wide {
+    width: 100%;
+    height: 6px;
+  }
+  .sheet-gauge-row .gauge-pop-reset {
+    margin: 0;
+  }
   .gauge-pop-desk .gauge-pop-reset {
     margin: 0;
   }
@@ -1655,11 +1989,6 @@
   .update-badge .up-n {
     font-variant-numeric: tabular-nums;
     font-weight: 700;
-  }
-  .update-badge.mobile {
-    padding: 4px 8px;
-    gap: 4px;
-    letter-spacing: 0.08em;
   }
   /* herdr badge: informational (operator updates manually), so it reads as calm
      blue — the informational accent — and doesn't pulse like the actionable

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1004,4 +1004,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_quota_needs_you_title",
     bodyKey: "feat_quota_needs_you_body",
   },
+  {
+    // targetId "mobile-seg-ctrl" anchors the coachmark on the segmented control
+    // wrapper in the Herd header (flow/mobile mode). 1.33.0 is the latest released
+    // tag, so this ships in 1.34.0.
+    id: "mobile-header-declutter",
+    sinceVersion: "1.34.0",
+    titleKey: "feat_mobile_header_title",
+    bodyKey: "feat_mobile_header_body",
+    targetId: "mobile-seg-ctrl",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -616,6 +616,56 @@
   }
 
   let mobileScreen = $state<"list" | "detail">("list");
+  let chromeHidden = $state(false);
+
+  // Scroll-compress the chrome header on mobile list: hide on scroll-down, restore
+  // on scroll-up or at/near top. Window (document) scroll only — the mobile list
+  // screen is a document-scroll app-shell; inner regions don't scroll.
+  $effect(() => {
+    const active = mobile.current && mobileScreen === "list";
+    if (!active) {
+      chromeHidden = false;
+      return;
+    }
+
+    // Delta threshold to avoid jitter from sub-pixel bounces.
+    const THRESHOLD = 7;
+    // Always restore when within this many px of the top.
+    const TOP_SNAP = 60;
+
+    let lastY = window.scrollY;
+    let rafId: ReturnType<typeof requestAnimationFrame> | null = null;
+
+    function onScroll() {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        const y = window.scrollY;
+        if (y < TOP_SNAP) {
+          chromeHidden = false;
+        } else {
+          const delta = y - lastY;
+          if (delta > THRESHOLD) {
+            chromeHidden = true;
+          } else if (delta < -THRESHOLD) {
+            chromeHidden = false;
+          }
+        }
+        lastY = y;
+      });
+    }
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      chromeHidden = false;
+    };
+  });
+
   let showBacklog = $state(false);
 
   // EPIC badge → open the backlog targeted at that session's repo + epic issue
@@ -1457,7 +1507,7 @@
        viewport's merged header (repo · session + back + status tint), so it's
        hidden there; settings + global chrome stay on the herd overview. -->
   {#if !(mobile.current && mobileScreen === "detail")}
-    <header class="chrome">
+    <header class="chrome" class:chrome-hidden={chromeHidden}>
       <TopBar
         sessions={store.sessions}
         {nowMs}
@@ -2239,6 +2289,18 @@
        top:0, with the opaque background filling the inset area. max(…) keeps
        the prior --mobile-shell-pad breathing room on non-notched devices. */
     padding-top: max(var(--mobile-shell-pad), env(safe-area-inset-top));
+    /* scroll-compression: slide the chrome out above the viewport on scroll-down,
+       slide it back on scroll-up / at top. translateY(-100%) covers the full
+       element box including safe-area padding — no second inset needed. */
+    will-change: transform;
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .shell.mobile.list .chrome {
+      transition: transform 0.2s ease;
+    }
+  }
+  .shell.mobile.list .chrome.chrome-hidden {
+    transform: translateY(-100%);
   }
   .shell.mobile.list .main-region,
   .shell.mobile.list .col {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1492,6 +1492,7 @@
       <RepoSwitcher
         chips={repoChips}
         {repoFilter}
+        mobile={mobile.current}
         onrepofilter={(repoPath) => (repoFilter = repoPath)}
         onlearnings={(repoPath) => {
           learningsRepo = repoPath;

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -155,6 +155,48 @@ input, select, textarea {
 }
 /* recessed child surface (input wells, terminals): var(--color-inset) */`;
 
+  const segCtrlMarkup = `<div class="seg-row">
+  <button class="seg-btn" class:seg-active={active === "a"} aria-pressed={active === "a"}
+    onclick={() => active = "a"}>A</button>
+  <button class="seg-btn" class:seg-active={active === "b"} aria-pressed={active === "b"}
+    onclick={() => active = "b"}>B</button>
+  <button class="seg-btn" class:seg-active={active === "c"} aria-pressed={active === "c"}
+    onclick={() => active = "c"}>C</button>
+</div>
+
+/* Segmented control (mobile flow mode). If placed inside a horizontally-padded
+   parent, add margin-inline: calc(-1 * var(--mobile-shell-pad)) to escape that
+   padding; not needed when the parent is already full-bleed (e.g. .panel.flow). */
+.seg-row {
+  display: flex;
+  border-bottom: 1px solid var(--color-line);
+}
+.seg-btn {
+  flex: 1;
+  min-width: 0;
+  min-height: 44px;
+  border: 0;
+  border-right: 1px solid var(--color-line);
+  background: none;
+  font-family: inherit;
+  font-size: var(--fs-base);
+  cursor: pointer;
+  padding: 0 2px;
+  color: var(--color-faint);
+  text-align: center;
+}
+.seg-btn:last-child { border-right: 0; }
+.seg-btn:hover { color: var(--color-ink); }
+.seg-btn.seg-active {
+  color: var(--color-amber);
+  background: var(--color-inset);
+  box-shadow: inset 0 -2px 0 var(--color-amber);
+}
+.seg-btn:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--color-amber);
+}`;
+
   const scrimMarkup = `<div class="scrim"><!-- dialog --></div>
 
 /* .scrim lives in app.css — one canonical backdrop for every dialog/drawer.
@@ -358,6 +400,30 @@ input, select, textarea {
       </div>
     </div>
     <pre><code>{panelMarkup}</code></pre>
+  </section>
+
+  <section class="panel">
+    <h2>Segmented control</h2>
+    <p class="when">
+      <strong>When:</strong> a single-select view switch with ≤5 equal options that must all be
+      visible at once (e.g. the Herd status filter on mobile). Prefer scrollable chips when there
+      are more than 5 options or labels vary widely in length. Equal-width segments via
+      <code>flex:1; min-width:0</code>; 44 px touch target (<code>min-height:44px</code>);
+      <code>--fs-base</code> (13 px) labels; no uppercase, no letter-spacing (monospace). Active
+      state: <code>--color-amber</code> text + <code>--color-inset</code> fill + amber 2 px bottom
+      inset. Inactive: <code>--color-faint</code>. Full-bleed on mobile via
+      <code>margin-inline: calc(-1 * var(--mobile-shell-pad))</code>.
+    </p>
+    <div class="demo">
+      <div class="seg-row-demo">
+        <button class="seg-btn-demo seg-active-demo" aria-pressed="true">All</button>
+        <button class="seg-btn-demo" aria-pressed="false">Ready</button>
+        <button class="seg-btn-demo" aria-pressed="false">Research</button>
+        <button class="seg-btn-demo" aria-pressed="false">Done</button>
+        <button class="seg-btn-demo" aria-pressed="false">Rundown</button>
+      </div>
+    </div>
+    <pre><code>{segCtrlMarkup}</code></pre>
   </section>
 
   <section class="panel">
@@ -630,6 +696,38 @@ input, select, textarea {
     position: relative;
     z-index: 1;
     background: var(--color-panel);
+  }
+
+  /* segmented control demo */
+  .seg-row-demo {
+    display: flex;
+    width: 100%;
+    max-width: 390px;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .seg-btn-demo {
+    flex: 1;
+    min-width: 0;
+    min-height: 44px;
+    border: 0;
+    border-right: 1px solid var(--color-line);
+    background: none;
+    font-family: inherit;
+    font-size: var(--fs-base);
+    cursor: pointer;
+    padding: 0 2px;
+    color: var(--color-faint);
+    text-align: center;
+  }
+  .seg-btn-demo:last-child {
+    border-right: 0;
+  }
+  .seg-active-demo {
+    color: var(--color-amber);
+    background: var(--color-inset);
+    box-shadow: inset 0 -2px 0 var(--color-amber);
   }
 
   /* glossary term — dashed underline trigger (mirrors GlossaryTerm.svelte) */

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -415,7 +415,8 @@ input, select, textarea {
       <code>flex:1; min-width:0</code>; 44 px touch target (<code>min-height:44px</code>);
       <code>--fs-base</code> (13 px) labels; no uppercase, no letter-spacing (monospace). Active
       state: <code>--color-amber</code> text + <code>--color-inset</code> fill + amber 2 px bottom
-      inset. Inactive: <code>--color-faint</code>. Full-bleed on mobile via
+      inset. Inactive: <code>--color-muted</code> (≥4.5:1 contrast — not the lower-contrast
+      <code>--color-faint</code>). Full-bleed on mobile via
       <code>margin-inline: calc(-1 * var(--mobile-shell-pad))</code>.
     </p>
     <div class="demo">

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -184,6 +184,9 @@ input, select, textarea {
   padding: 0 2px;
   color: var(--color-faint);
   text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .seg-btn:last-child { border-right: 0; }
 .seg-btn:hover { color: var(--color-ink); }
@@ -720,6 +723,9 @@ input, select, textarea {
     padding: 0 2px;
     color: var(--color-faint);
     text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .seg-btn-demo:last-child {
     border-right: 0;

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -182,7 +182,8 @@ input, select, textarea {
   font-size: var(--fs-base);
   cursor: pointer;
   padding: 0 2px;
-  color: var(--color-faint);
+  /* Inactive labels use --color-muted for ≥4.5:1 contrast; active uses --color-amber */
+  color: var(--color-muted);
   text-align: center;
   white-space: nowrap;
   overflow: hidden;
@@ -721,7 +722,7 @@ input, select, textarea {
     font-size: var(--fs-base);
     cursor: pointer;
     padding: 0 2px;
-    color: var(--color-faint);
+    color: var(--color-muted);
     text-align: center;
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
Implements the prioritized recommendations from the research note `docs/research/mobile-pwa-header-navigation.md` (#719). Reduces the mobile (iPhone-14, 390 CSS-px) head/filter zone from ~4 always-visible bands to **two at rest** — touch-safe and legible for 40–60+ eyes. **Mobile-only**: every change gates to the phone branch (`flow`/`mobile`/`.shell.mobile.list`); desktop and touch-desktop are untouched.

Closes #720.

## Stufen (one commit each)
1. **Status filter → segmented control** (`Herd.svelte`): the 5 filters (Alle/Bereit/Recherche/Fertig/Rundown) render as one full-bleed, equal-width segmented control on mobile, `min-height:44px` per segment, amber active / muted inactive. Removed the old flow-overflow band-aids; statchip hidden in flow (the active tally is the single status indicator). Added a "Segmented control" recipe to `/design-system`.
2. **Secondary chrome → gear bottom sheet** (`TopBar.svelte`): mobile `.rightside` is now just {connection dot, NEEDS-YOU (when >0), gear}. Usage gauges, health, update/herdr/what's-new, theme/contrast move into a bottom sheet (`role=dialog`, `use:dialog` focus-trap/Esc, canonical `.scrim` dim+blur, slides up from the thumb zone). The redundant ☰ RUNDOWN button is dropped on mobile (Rundown is now a segment). The desktop dropdown (`role=menu`) is untouched — the `{#if menuOpen}` block was split into mobile-sheet vs desktop-menu siblings. A quiet gear pip flags actionable moved items.
3. **Sharpen repo chips** (`RepoSwitcher.svelte`): the chip rail forces a visible right-edge **peek** on overflow (not just a fade); the lone-repo detail subline collapses out on mobile so a single repo adds no permanent band.
4. **Tally / segment precedence** (verify-only, no code): `statusFilter` (tallies) and `herdFilter` (segments) are two orthogonal axes with a precedence rule — an active tally blanks all segments; clearing it restores the retained lens. Verified, no regression from the statchip removal.
5. **Scroll-compression** (`+page.svelte`): the sticky chrome header hides on scroll-down and returns on scroll-up / near-top, reclaiming reading height. Window-scroll listener (the mobile list is document-scroll), rAF-throttled, gated to the mobile list screen with full effect cleanup, `prefers-reduced-motion` snaps. Final, independently-revertable commit.

Plus one `feature-announcements.ts` entry (`mobile-header-declutter`, `sinceVersion 1.34.0`) + EN/DE keys.

## ⚠️ Two acceptance-criterion deviations (owner-approved waivers)

**1. Segment labels are 13px, below the ≥16px label floor.** The body font is monospace; five equal-width segments on a 390px phone give ~66–70px of text room each, but the longest label "Recherche" (DE) needs ~81px at 15px — so ≥15px is geometrically impossible while keeping equal-width + one row + full labels. 13px matches Apple's segmented-control convention (13–15pt). **Live-verified at 390px in the DE locale: no clipping** — all 5 segments ~78px wide, "Recherche" `scrollWidth 77 ≤ clientWidth`, document width = window width (no overflow). Below ~360px a `text-overflow: ellipsis` fallback degrades gracefully. **Contrast measured at the 13px size** (dark theme, on the panel surface): active label (`--color-amber`) **8.49:1** (exceeds the 7:1 target for primary labels); inactive label (`--color-muted`) **5.27:1** (meets the ≥4.5:1 floor — bumped up from `--color-faint`'s failing 2.46:1).

**2. The `.ctally` counter buttons are 24px-wide × 44px-tall (WCAG 2.5.8 AA), not the 44×44 AAA target.** Widening them to 44×44 was rejected because four 44px buttons + the SHEPHERD logo + the retained dot/needs-you/gear cluster exceed the 390px single-line budget, forcing the bar back to two lines — the exact band this PR removes. The tallies are *secondary* shortcuts; the *primary* 44px status control is the segmented filter (Stufe 1). All other tap targets (segments, gear, needs-you, repo chips) meet ≥44×44.

## Verification (browser, iPhone-14 390px)
- Segmented control: DE no-clip at 390px; ellipsis fallback below ~360px; contrast 8.49 / 5.27.
- Bottom sheet: opens as `role=dialog aria-modal`, `.menu-scrim` `backdrop-filter: blur(3px)` dims+blurs the herd, Esc and scrim-tap close it, in-sheet control taps keep it open (regression-tested).
- Repo peek: forced overflow → the trailing chip is visibly clipped at the right edge.
- Tally precedence: active tally → all segments inactive; clear → retained lens restored.
- Scroll-compression: chrome hides on scroll-down, restores on scroll-up and near-top.
- `cd ui && bun run check && bun run check:i18n && bun run test`: 0 errors, locale parity (1451 keys), 1412 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
