### PR TITLE
feat(ui): keyboard repo switching in New Task pane

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1450,5 +1450,8 @@
   "feat_mobile_header_title": "Aufgeräumterer mobiler Kopf",
   "feat_mobile_header_body": "Der Statusfilter in der Herd-Kopfzeile ist auf dem Handy jetzt ein kompaktes Segmented-Control — ein Tippen wechselt die Ansicht, Symbole entfallen, und die Leiste bleibt einzeilig auf jeder Handybreite.",
   "topbar_sheet_title": "Steuerung",
-  "topbar_sheet_usage": "Auslastung"
+  "topbar_sheet_usage": "Auslastung",
+  "newtask_repo_shortcuts_hint": "{mod}[ / {mod}] Repo wechseln · {mod}1–3 zuletzt · {mod}R filtern",
+  "feat_repo_shortcuts_title": "Repo-Wechsel per Tastatur",
+  "feat_repo_shortcuts_body": "Im Bereich „Neue Aufgabe“ kannst du das Repository jetzt per Tastatur wechseln, ohne das Eingabefeld zu verlassen: Alt+[ und Alt+] blättern durch alle Repos, Alt+1–3 springen zu deinen zuletzt genutzten Repos und Alt+R öffnet die Repo-Auswahl. Auf dem Mac die Wahltaste (⌥) verwenden."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1450,5 +1450,8 @@
   "feat_mobile_header_title": "Tidier mobile header",
   "feat_mobile_header_body": "The status filter in the Herd header is now a compact segmented control on mobile — one tap switches lens, glyphs are gone, and the bar stays single-line at any phone width.",
   "topbar_sheet_title": "Controls",
-  "topbar_sheet_usage": "Usage"
+  "topbar_sheet_usage": "Usage",
+  "newtask_repo_shortcuts_hint": "{mod}[ / {mod}] switch repo · {mod}1–3 recent · {mod}R filter",
+  "feat_repo_shortcuts_title": "Keyboard repo switching",
+  "feat_repo_shortcuts_body": "In the New Task pane you can now switch repositories from the keyboard without leaving the prompt: Alt+[ and Alt+] step through every repo, Alt+1–3 jump to your recent repos, and Alt+R opens the repo picker. On macOS use the Option (⌥) key."
 }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -511,3 +511,121 @@ describe("NewTask research toggle", () => {
     expect(onsubmit.mock.calls[0]![0]).toMatchObject({ research: false });
   });
 });
+
+describe("NewTask repo shortcuts", () => {
+  // Three repos in list order: alpha, bravo, charlie.
+  // bravo has the highest recentAgentCount → recents[0]
+  // charlie has lower count but a more recent lastUsedAt → recents[1]
+  // alpha has no recent activity → recents[2] (not in recents at all at limit=3 since only 2 have counts)
+  // So recentRepos order is: bravo, charlie (only 2 with positive counts)
+  const repoA: RepoEntry = { name: "alpha", path: "/repo/alpha", display: "alpha" };
+  const repoB: RepoEntry = {
+    name: "bravo",
+    path: "/repo/bravo",
+    display: "bravo",
+    recentAgentCount: 5,
+    lastUsedAt: 1000,
+  };
+  const repoC: RepoEntry = {
+    name: "charlie",
+    path: "/repo/charlie",
+    display: "charlie",
+    recentAgentCount: 2,
+    lastUsedAt: 2000,
+  };
+  const repos = [repoA, repoB, repoC];
+
+  function triggerLabel() {
+    return document.querySelector<HTMLElement>(".rs-trigger b")?.textContent ?? null;
+  }
+
+  function press(code: string, opts: KeyboardEventInit = {}) {
+    const ta = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    ta.focus();
+    ta.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        code,
+        altKey: true,
+        bubbles: true,
+        cancelable: true,
+        ...opts,
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    mockListRepos.mockResolvedValue({ repos, recentWindowDays: 30 });
+  });
+
+  it("Alt+] advances to the next repo; wraps from last to first", async () => {
+    // start at alpha (index 0); ] → bravo (index 1)
+    render(NewTask, { props: base({ initialRepoPath: repoA.path }) });
+    await expect.poll(() => triggerLabel()).toBe(repoA.name);
+
+    press("BracketRight");
+    await expect.poll(() => triggerLabel()).toBe(repoB.name);
+
+    // advance to charlie (index 2)
+    press("BracketRight");
+    await expect.poll(() => triggerLabel()).toBe(repoC.name);
+
+    // wrap from last → first
+    press("BracketRight");
+    await expect.poll(() => triggerLabel()).toBe(repoA.name);
+  });
+
+  it("Alt+[ moves to the previous repo; wraps from first to last", async () => {
+    // start at alpha (index 0); [ → wrap to charlie (index 2)
+    render(NewTask, { props: base({ initialRepoPath: repoA.path }) });
+    await expect.poll(() => triggerLabel()).toBe(repoA.name);
+
+    press("BracketLeft");
+    await expect.poll(() => triggerLabel()).toBe(repoC.name);
+
+    // previous from charlie → bravo
+    press("BracketLeft");
+    await expect.poll(() => triggerLabel()).toBe(repoB.name);
+  });
+
+  it("Alt+2 selects the 2nd recent repo (charlie, differs from list order)", async () => {
+    // list order: alpha, bravo, charlie
+    // recents order: bravo (count=5), charlie (count=2, more recent lastUsedAt)
+    // Digit2 → charlie (index 1 in recents)
+    render(NewTask, { props: base({ initialRepoPath: repoA.path }) });
+    await expect.poll(() => triggerLabel()).toBe(repoA.name);
+
+    press("Digit2");
+    await expect.poll(() => triggerLabel()).toBe(repoC.name);
+  });
+
+  it("Alt+3 is a silent no-op when only 2 recents exist", async () => {
+    // only repoB and repoC have recentAgentCount > 0, so recents has 2 entries
+    render(NewTask, { props: base({ initialRepoPath: repoA.path }) });
+    await expect.poll(() => triggerLabel()).toBe(repoA.name);
+
+    press("Digit3");
+    // label stays unchanged
+    await expect.poll(() => triggerLabel()).toBe(repoA.name);
+  });
+
+  it("Alt+R opens the picker and focuses the filter input", async () => {
+    render(NewTask, { props: base({ initialRepoPath: repoA.path }) });
+    await expect.poll(() => triggerLabel()).toBe(repoA.name);
+
+    press("KeyR");
+    await expect.poll(() => document.querySelector(".rs-panel")).toBeTruthy();
+    await expect
+      .poll(() => document.activeElement === document.querySelector(".rs-filter"))
+      .toBe(true);
+  });
+
+  it("bare ] without Alt does NOT change the selected repo", async () => {
+    render(NewTask, { props: base({ initialRepoPath: repoA.path }) });
+    await expect.poll(() => triggerLabel()).toBe(repoA.name);
+
+    // fire without altKey
+    press("BracketRight", { altKey: false });
+    // label must remain unchanged
+    expect(triggerLabel()).toBe(repoA.name);
+  });
+});

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -516,8 +516,10 @@ describe("NewTask repo shortcuts", () => {
   // Three repos in list order: alpha, bravo, charlie.
   // bravo has the highest recentAgentCount → recents[0]
   // charlie has lower count but a more recent lastUsedAt → recents[1]
-  // alpha has no recent activity → recents[2] (not in recents at all at limit=3 since only 2 have counts)
-  // So recentRepos order is: bravo, charlie (only 2 with positive counts)
+  // alpha has no recent activity → excluded from recents entirely
+  // So recentRepos order is: bravo, charlie (only 2 have positive counts).
+  // Note charlie is list-index 2 but recents-index 1 — proves the digit jump
+  // reads the recents ranking, not the list order.
   const repoA: RepoEntry = { name: "alpha", path: "/repo/alpha", display: "alpha" };
   const repoB: RepoEntry = {
     name: "bravo",

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -29,6 +29,7 @@
   import { repoConfig } from "$lib/reviews.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { recentRepos } from "$lib/recentRepos";
 
   let {
     onsubmit,
@@ -146,6 +147,7 @@
   let uploading = $state(false);
   let fileInput = $state<HTMLInputElement>();
   let promptInput = $state<HTMLTextAreaElement>();
+  let repoSelect: RepoSelect | undefined = $state();
   let isMac = $state(false);
 
   // ── inline slash-command autocomplete (reuses the /api/commands index) ──
@@ -432,6 +434,48 @@
     }
   }
 
+  function cycleRepo(dir: 1 | -1) {
+    const n = repos.length;
+    if (n === 0) return;
+    const cur = repos.findIndex((r) => r.path === repoPath);
+    const i = cur === -1 ? 0 : cur;
+    repoPath = repos[(i + dir + n) % n]!.path;
+  }
+
+  // Alt-tier repo switchers, keyed on physical e.code so they work on any layout
+  // (DE brackets need AltGr; macOS Option+key types glyphs) and while the prompt
+  // textarea holds focus — keydown bubbles from the textarea to the dialog <form>.
+  // Mirrors +page.svelte's handleAltCombo guard. Matched combos are swallowed
+  // (preventDefault + stopPropagation) so no browser default fires and no glyph is
+  // inserted into the prompt; the global Alt tier is already dormant while a modal
+  // is open (anyOverlayOpen), so stopPropagation is belt-and-suspenders.
+  function onRepoShortcut(e: KeyboardEvent) {
+    if (e.repeat || e.isComposing) return;
+    if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
+    switch (e.code) {
+      case "BracketLeft":
+        cycleRepo(-1);
+        break;
+      case "BracketRight":
+        cycleRepo(1);
+        break;
+      case "Digit1":
+      case "Digit2":
+      case "Digit3": {
+        const target = recentRepos(repos)[Number(e.code.slice(5)) - 1];
+        if (target) repoPath = target.path; // out of range → no selection change
+        break; // still swallow the chord below
+      }
+      case "KeyR":
+        repoSelect?.openPanel();
+        break;
+      default:
+        return; // not ours — let it through untouched
+    }
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
   async function submit(e: Event) {
     e.preventDefault();
     if (!prompt.trim() || !repoPath.trim() || submitting) return;
@@ -495,6 +539,7 @@
     aria-label={heading}
     use:dialog={{ onclose: () => onclose?.() }}
     onsubmit={submit}
+    onkeydown={onRepoShortcut}
     ondragover={(e) => {
       e.preventDefault();
       dragging = true;
@@ -518,6 +563,7 @@
     <div class="repo-field" use:coachTarget={"nt-repo"}>
       <label class="micro" for="nt-repo">{m.newtask_repo_label()}</label>
       <RepoSelect
+        bind:this={repoSelect}
         {repos}
         windowDays={recentRepoWindowDays}
         value={repoPath}
@@ -528,6 +574,10 @@
         onsync={handleSync}
       />
     </div>
+
+    <span class="hint repo-shortcuts-hint">
+      {m.newtask_repo_shortcuts_hint({ mod: isMac ? "⌥" : "Alt+" })}
+    </span>
 
     {#if relaunch}
       <div class="relaunch-note">
@@ -1133,6 +1183,16 @@
   .hint {
     font-size: var(--fs-meta);
     color: var(--color-muted);
+  }
+  .repo-shortcuts-hint {
+    display: block;
+    margin-top: 4px;
+  }
+  /* keyboard-only affordance — irrelevant on the phone sheet (mobile-declutter) */
+  @media (max-width: 768px) {
+    .repo-shortcuts-hint {
+      display: none;
+    }
   }
   .attach-relaunch-note {
     display: block;

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -3,6 +3,7 @@
   import { SvelteSet } from "svelte/reactivity";
   import type { RepoEntry } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { recentRepos } from "$lib/recentRepos";
   import EmojiPicker from "./EmojiPicker.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
@@ -61,9 +62,6 @@
     }
   }
 
-  // How many repos to pin in the "recently worked on" shortcut group at the top.
-  const RECENT_LIMIT = 3;
-
   /** Pluralized "{count} agents run here in the last {days} days" label for a pinned row. */
   function recentAgentsLabel(count: number): string {
     return count === 1
@@ -80,19 +78,7 @@
   // The top few repos we've run the most agents on lately (desc by count, then by
   // most-recently-used). Only shown when the list isn't being filtered — once the
   // user types, the shortcut just gets in the way of the search they asked for.
-  const recents = $derived(
-    filter.trim() === ""
-      ? repos
-          .filter((r) => (r.recentAgentCount ?? 0) > 0)
-          .sort(
-            (a, b) =>
-              (b.recentAgentCount ?? 0) - (a.recentAgentCount ?? 0) ||
-              (b.lastUsedAt ?? 0) - (a.lastUsedAt ?? 0) ||
-              a.name.localeCompare(b.name),
-          )
-          .slice(0, RECENT_LIMIT)
-      : [],
-  );
+  const recents = $derived(filter.trim() === "" ? recentRepos(repos) : []);
 
   // Single option sequence the keyboard cursor walks: pinned recents first, then the
   // full list. Pinned repos intentionally re-appear below — the group is a shortcut,
@@ -102,16 +88,19 @@
     ...filtered.map((r) => ({ repo: r, pinned: false })),
   ]);
 
+  export function openPanel() {
+    open = true;
+    filter = "";
+    const idx = shown.findIndex((row) => row.repo.path === value);
+    activeIdx = idx >= 0 ? idx : 0;
+    tick().then(scrollActiveIntoView);
+  }
+
   async function toggle() {
-    open = !open;
     if (open) {
-      filter = "";
-      // Point the keyboard cursor at the currently-selected repo (its first
-      // occurrence — the pinned one if it's a recent), not row 0.
-      const idx = shown.findIndex((row) => row.repo.path === value);
-      activeIdx = idx >= 0 ? idx : 0;
-      await tick();
-      scrollActiveIntoView();
+      open = false;
+    } else {
+      openPanel();
     }
   }
 

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1014,4 +1014,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_mobile_header_body",
     targetId: "mobile-seg-ctrl",
   },
+  {
+    // targetId "nt-repo" anchors the coachmark on the New Task repo field
+    // (use:coachTarget={"nt-repo"}). 1.33.0 is the latest released tag, so this
+    // ships in 1.34.0.
+    id: "repo-switch-shortcuts",
+    sinceVersion: "1.34.0",
+    titleKey: "feat_repo_shortcuts_title",
+    bodyKey: "feat_repo_shortcuts_body",
+    targetId: "nt-repo",
+  },
 ];

--- a/ui/src/lib/recentRepos.test.ts
+++ b/ui/src/lib/recentRepos.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { recentRepos, RECENT_LIMIT } from "./recentRepos";
+import type { RepoEntry } from "$lib/types";
+
+function repo(name: string, recentAgentCount?: number, lastUsedAt?: number): RepoEntry {
+  return { name, path: `/repos/${name}`, display: name, recentAgentCount, lastUsedAt };
+}
+
+describe("recentRepos", () => {
+  it("ranks by recentAgentCount descending", () => {
+    const repos = [repo("a", 1), repo("b", 5), repo("c", 3)];
+    const result = recentRepos(repos);
+    expect(result.map((r) => r.name)).toEqual(["b", "c", "a"]);
+  });
+
+  it("breaks ties by lastUsedAt descending", () => {
+    const repos = [repo("a", 3, 100), repo("b", 3, 200), repo("c", 3, 50)];
+    const result = recentRepos(repos);
+    expect(result.map((r) => r.name)).toEqual(["b", "a", "c"]);
+  });
+
+  it("breaks further ties by name (localeCompare)", () => {
+    const repos = [repo("charlie", 3, 100), repo("alpha", 3, 100), repo("beta", 3, 100)];
+    const result = recentRepos(repos);
+    expect(result.map((r) => r.name)).toEqual(["alpha", "beta", "charlie"]);
+  });
+
+  it("excludes repos with zero recentAgentCount", () => {
+    const repos = [repo("a", 0), repo("b", 2), repo("c")];
+    const result = recentRepos(repos);
+    expect(result.map((r) => r.name)).toEqual(["b"]);
+  });
+
+  it("excludes repos with undefined recentAgentCount", () => {
+    const repos = [repo("a", undefined), repo("b", 1)];
+    const result = recentRepos(repos);
+    expect(result.map((r) => r.name)).toEqual(["b"]);
+  });
+
+  it("caps result at RECENT_LIMIT (3) by default", () => {
+    const repos = [repo("a", 5), repo("b", 4), repo("c", 3), repo("d", 2), repo("e", 1)];
+    const result = recentRepos(repos);
+    expect(result).toHaveLength(RECENT_LIMIT);
+    expect(result.map((r) => r.name)).toEqual(["a", "b", "c"]);
+  });
+
+  it("respects an explicit smaller limit", () => {
+    const repos = [repo("a", 5), repo("b", 4), repo("c", 3)];
+    const result = recentRepos(repos, 2);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.name)).toEqual(["a", "b"]);
+  });
+
+  it("returns empty array when all repos have no recentAgentCount", () => {
+    const repos = [repo("a"), repo("b", 0)];
+    expect(recentRepos(repos)).toEqual([]);
+  });
+});

--- a/ui/src/lib/recentRepos.ts
+++ b/ui/src/lib/recentRepos.ts
@@ -1,0 +1,20 @@
+import type { RepoEntry } from "$lib/types";
+
+/** How many repos to pin in the "recently worked on" shortcut group. */
+export const RECENT_LIMIT = 3;
+
+/** The top repos we've run the most agents on lately: filtered to those with a
+ *  positive recentAgentCount, ranked by count desc, then most-recently-used, then
+ *  name. Single source of truth for the RepoSelect pinned group AND the New Task
+ *  pane's Alt+digit repo shortcuts. */
+export function recentRepos(repos: RepoEntry[], limit: number = RECENT_LIMIT): RepoEntry[] {
+  return repos
+    .filter((r) => (r.recentAgentCount ?? 0) > 0)
+    .sort(
+      (a, b) =>
+        (b.recentAgentCount ?? 0) - (a.recentAgentCount ?? 0) ||
+        (b.lastUsedAt ?? 0) - (a.lastUsedAt ?? 0) ||
+        a.name.localeCompare(b.name),
+    )
+    .slice(0, limit);
+}

--- a/ui/src/lib/recentRepos.ts
+++ b/ui/src/lib/recentRepos.ts
@@ -7,7 +7,10 @@ export const RECENT_LIMIT = 3;
  *  positive recentAgentCount, ranked by count desc, then most-recently-used, then
  *  name. Single source of truth for the RepoSelect pinned group AND the New Task
  *  pane's Alt+digit repo shortcuts. */
-export function recentRepos(repos: RepoEntry[], limit: number = RECENT_LIMIT): RepoEntry[] {
+export function recentRepos(
+  repos: readonly RepoEntry[],
+  limit: number = RECENT_LIMIT,
+): RepoEntry[] {
   return repos
     .filter((r) => (r.recentAgentCount ?? 0) > 0)
     .sort(


### PR DESCRIPTION
## What

Adds keyboard shortcuts to switch the selected repo in the **New Task pane**, working **even while the prompt textarea has focus**. Keyed on physical `KeyboardEvent.code` (layout-independent), following the app's existing Alt-tier "work-everywhere" convention (`+page.svelte` `handleAltCombo`).

| Shortcut (⌥ on macOS) | Action |
| --- | --- |
| `Alt + [` / `Alt + ]` | Previous / next repo across the full list (wraps) |
| `Alt + 1 / 2 / 3` | Jump to the 1st/2nd/3rd pinned **recent** repo |
| `Alt + R` | Open + focus the repo picker |

Plus a subtle desktop-only hint below the repo picker, EN+DE i18n, and a What's-New feature entry.

## How

- **Modal-scoped handler** on the dialog `<form>` — keydown bubbles up from the prompt textarea, which is what makes the shortcuts fire while it has focus. Guards `!alt || ctrl || meta || shift` + `repeat`/`isComposing`; `preventDefault()`+`stopPropagation()` only on a matched combo so non-shortcut keys still reach the textarea. Out-of-range digit is a silent no-op (chord still swallowed).
- **Shared `recentRepos` helper** (`ui/src/lib/recentRepos.ts`) — extracted verbatim from `RepoSelect`'s pinned-recents ranking so the picker group and the `Alt+1-3` jumps rank identically (single source of truth). `RepoSelect` now exposes an imperative `openPanel()` for `Alt+R`.

### Why Alt + `e.code` (not Cmd/Ctrl + brackets/digits)
- `Cmd/Ctrl+1–8` are browser tab-switches that can't be cancelled by `preventDefault()`.
- `Cmd+[`/`]` are macOS Back/Forward; and on the DE layout `[`/`]` need AltGr, so `e.key` testing fails. Physical `e.code` (`BracketLeft`/`BracketRight`) is layout-independent.
- Keys are **not** registered in `altComboKey` — that map drives the global handler + xterm PTY suppression, both dormant while the modal is open.

### Conflict safety (verified against live source)
- `+page.svelte` `onShortcut` bails on `anyOverlayOpen()` before the global Alt tier runs → no double-switch.
- Viewport's xterm Alt-suppression only fires when the terminal textarea is focused; the modal's focus-trap keeps focus inside → no PTY conflict.

## Testing
- New `recentRepos.test.ts` (ranking/limit/tie-breakers).
- 6 new behavioral browser tests in `NewTask.browser.test.ts` — dispatch keydown on the focused `#nt-prompt` textarea (exercise real bubbling → form handler): next/prev with wrap, digit jump proving recents-order ≠ list-order, out-of-range no-op, `Alt+R` opens+focuses picker, bare-`]` guard.
- `bun run check`, `bun run check:i18n` (1454 keys, parity), and the suites pass clean.

## Feature discovery
Adds `repo-switch-shortcuts` to `feature-announcements.ts` (`sinceVersion: 1.34.0`, `targetId: nt-repo`) with EN+DE title/body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)