### PR TITLE
feat: freshen task base branch from upstream at launch

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2621,6 +2621,10 @@ function handleBranches({ req, parts, url }: Ctx): Response | null {
 // bounded, and rate-limited by the TTL cache below + client debounce (Task 5).
 
 const BRANCH_STATUS_TTL_MS = 10_000;
+// Single long-running server loop: bound the cache so it never grows without
+// limit. On each write: prune expired entries first, then evict oldest (Map
+// preserves insertion order) if the cap is still exceeded.
+const BRANCH_STATUS_CACHE_MAX = 256;
 const branchStatusCache = new Map<
   string,
   {
@@ -2662,6 +2666,13 @@ async function branchStatusCached(
     hasUpstream: st.hasUpstream,
     localExists: st.localExists,
   };
+  // Prune expired entries before writing, then cap by evicting oldest.
+  for (const [k, v] of branchStatusCache) {
+    if (now - v.at >= BRANCH_STATUS_TTL_MS) branchStatusCache.delete(k);
+  }
+  while (branchStatusCache.size >= BRANCH_STATUS_CACHE_MAX) {
+    branchStatusCache.delete(branchStatusCache.keys().next().value!);
+  }
   branchStatusCache.set(key, { at: now, value });
   return value;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2625,56 +2625,57 @@ const BRANCH_STATUS_TTL_MS = 10_000;
 // limit. On each write: prune expired entries first, then evict oldest (Map
 // preserves insertion order) if the cap is still exceeded.
 const BRANCH_STATUS_CACHE_MAX = 256;
-const branchStatusCache = new Map<
-  string,
-  {
-    at: number;
-    value: {
-      behind: number;
-      ahead: number;
-      diverged: boolean;
-      hasUpstream: boolean;
-      localExists: boolean;
-    };
-  }
->();
-
-/** Clear the in-memory branch-status cache — for use in tests only. */
-export function clearBranchStatusCacheForTests(): void {
-  branchStatusCache.clear();
-}
-
-async function branchStatusCached(
-  repoPath: string,
-  branch: string,
-): Promise<{
+type BranchStatusValue = {
   behind: number;
   ahead: number;
   diverged: boolean;
   hasUpstream: boolean;
   localExists: boolean;
-}> {
+};
+const branchStatusCache = new Map<string, { at: number; value: BranchStatusValue }>();
+// Coalesce concurrent cache misses for the same (repo, branch): each would otherwise
+// spawn its own bounded git fetch against the same tracking ref. In-flight requests
+// share ONE promise; the entry clears once it settles (success or failure).
+const branchStatusInflight = new Map<string, Promise<BranchStatusValue>>();
+
+/** Clear the in-memory branch-status cache — for use in tests only. */
+export function clearBranchStatusCacheForTests(): void {
+  branchStatusCache.clear();
+  branchStatusInflight.clear();
+}
+
+export async function branchStatusCached(
+  repoPath: string,
+  branch: string,
+): Promise<BranchStatusValue> {
   const key = `${repoPath}\0${branch}`;
   const hit = branchStatusCache.get(key);
-  const now = Date.now();
-  if (hit && now - hit.at < BRANCH_STATUS_TTL_MS) return hit.value;
-  const st = await upstreamStatus(repoPath, branch);
-  const value = {
-    behind: st.behind,
-    ahead: st.ahead,
-    diverged: st.diverged,
-    hasUpstream: st.hasUpstream,
-    localExists: st.localExists,
-  };
-  // Prune expired entries before writing, then cap by evicting oldest.
-  for (const [k, v] of branchStatusCache) {
-    if (now - v.at >= BRANCH_STATUS_TTL_MS) branchStatusCache.delete(k);
-  }
-  while (branchStatusCache.size >= BRANCH_STATUS_CACHE_MAX) {
-    branchStatusCache.delete(branchStatusCache.keys().next().value!);
-  }
-  branchStatusCache.set(key, { at: now, value });
-  return value;
+  if (hit && Date.now() - hit.at < BRANCH_STATUS_TTL_MS) return hit.value;
+  // A miss already in flight for this key: join it instead of fetching again.
+  const inflight = branchStatusInflight.get(key);
+  if (inflight) return inflight;
+  const p = (async () => {
+    const st = await upstreamStatus(repoPath, branch);
+    const value: BranchStatusValue = {
+      behind: st.behind,
+      ahead: st.ahead,
+      diverged: st.diverged,
+      hasUpstream: st.hasUpstream,
+      localExists: st.localExists,
+    };
+    const now = Date.now();
+    // Prune expired entries before writing, then cap by evicting oldest.
+    for (const [k, v] of branchStatusCache) {
+      if (now - v.at >= BRANCH_STATUS_TTL_MS) branchStatusCache.delete(k);
+    }
+    while (branchStatusCache.size >= BRANCH_STATUS_CACHE_MAX) {
+      branchStatusCache.delete(branchStatusCache.keys().next().value!);
+    }
+    branchStatusCache.set(key, { at: now, value });
+    return value;
+  })().finally(() => branchStatusInflight.delete(key));
+  branchStatusInflight.set(key, p);
+  return p;
 }
 
 async function handleBranchStatus({ req, parts, url }: Ctx): Promise<Response | null> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -109,6 +109,7 @@ import {
 import { validateHookEvent, type HookEvent, type SubagentEntry } from "./hooks-ingest";
 import { fingerprintDiffCount } from "./rundown-core";
 import { quotaBlockReason } from "./blocked";
+import { upstreamStatus } from "./upstream-status";
 
 const UI_DIR = join(import.meta.dir, "..", "ui", "build");
 
@@ -2614,6 +2615,70 @@ function handleBranches({ req, parts, url }: Ctx): Response | null {
   return null;
 }
 
+// ── /api/branch-status ────────────────────────────────────────────────────────
+// NOTE: Each call performs a bounded network git fetch (writes objects + the
+// refs/remotes/origin/<branch> tracking ref). This is intended-non-idempotent,
+// bounded, and rate-limited by the TTL cache below + client debounce (Task 5).
+
+const BRANCH_STATUS_TTL_MS = 10_000;
+const branchStatusCache = new Map<
+  string,
+  {
+    at: number;
+    value: {
+      behind: number;
+      ahead: number;
+      diverged: boolean;
+      hasUpstream: boolean;
+      localExists: boolean;
+    };
+  }
+>();
+
+/** Clear the in-memory branch-status cache — for use in tests only. */
+export function clearBranchStatusCacheForTests(): void {
+  branchStatusCache.clear();
+}
+
+async function branchStatusCached(
+  repoPath: string,
+  branch: string,
+): Promise<{
+  behind: number;
+  ahead: number;
+  diverged: boolean;
+  hasUpstream: boolean;
+  localExists: boolean;
+}> {
+  const key = `${repoPath}\0${branch}`;
+  const hit = branchStatusCache.get(key);
+  const now = Date.now();
+  if (hit && now - hit.at < BRANCH_STATUS_TTL_MS) return hit.value;
+  const st = await upstreamStatus(repoPath, branch);
+  const value = {
+    behind: st.behind,
+    ahead: st.ahead,
+    diverged: st.diverged,
+    hasUpstream: st.hasUpstream,
+    localExists: st.localExists,
+  };
+  branchStatusCache.set(key, { at: now, value });
+  return value;
+}
+
+async function handleBranchStatus({ req, parts, url }: Ctx): Promise<Response | null> {
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "branch-status" && !parts[2]) {
+    const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
+    if (!dir) return json({ error: "invalid repo" }, 400);
+    const branch = url.searchParams.get("branch") ?? "";
+    if (!/^(?!-)[A-Za-z0-9._/-]{1,200}$/.test(branch))
+      return json({ error: "invalid branch" }, 400);
+    const st = await branchStatusCached(dir, branch);
+    return json(st);
+  }
+  return null;
+}
+
 async function handleIssues({ req, parts, url, deps }: Ctx): Promise<Response | null> {
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "issues" && !parts[2]) {
     const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
@@ -3843,6 +3908,7 @@ const ROUTE_HANDLERS = [
   handleHalt,
   handleFsDirs,
   handleBranches,
+  handleBranchStatus,
   handleIssues,
   handleIssueCreate,
   handlePrsList,

--- a/src/service.ts
+++ b/src/service.ts
@@ -1233,12 +1233,19 @@ export class SessionService {
     const repoBasename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
     const herdSlug = repoBasename ? slugifyManual(repoBasename) : undefined;
     const name = this.uniqueName(await this.deps.namer(input.prompt), herdSlug);
-    // Resolve the base locally first: an epic integration branch exists only on origin, so
-    // worktree.create (which resolves baseBranch from LOCAL refs) would otherwise fail and
-    // silently drop the child into the non-isolated main checkout. The default-branch path
-    // already exists locally and early-returns, so regular spawns are unaffected.
-    await this.deps.worktree.ensureBaseRef(input.repoPath, input.baseBranch);
-    const wt = this.deps.worktree.create(input.repoPath, input.baseBranch, name);
+    // Freshen the base ref: fetch the upstream tip so the new worktree always starts at the
+    // latest upstream commit. For non-diverged branches with an upstream, resolved.baseRef is
+    // the upstream sha; for diverged / no-upstream branches it falls back to the branch name.
+    // Epic integration branches that exist only on origin are also resolved here.
+    const resolved = await this.deps.worktree.ensureBaseRef(input.repoPath, input.baseBranch);
+    // resolved.baseRef is the fresh upstream tip (a sha) when the base was behind, else the
+    // local branch name (diverged / no upstream / up to date). Fall back to the named branch
+    // if a (mock/partial) impl returns nothing — fail-safe, never undefined.
+    const baseRef = resolved?.baseRef ?? input.baseBranch;
+    console.info(
+      `[create] base ${input.baseBranch}: behind ${resolved?.behind ?? 0}, ff ${resolved?.localFf ?? "none"}, basing on ${baseRef}`,
+    );
+    const wt = this.deps.worktree.create(input.repoPath, baseRef, name);
     // The worktree is created before the agent can start, so any failure past this
     // point (e.g. herdr `tab create` rejecting) would otherwise leave an orphan
     // worktree with no session row. Roll it back so a failed create leaves nothing.

--- a/src/service.ts
+++ b/src/service.ts
@@ -1229,22 +1229,27 @@ export class SessionService {
     return input.planGateEnabled ?? repoConfig.planGateEnabled;
   }
 
-  async create(input: CreateSessionInput): Promise<Session> {
-    const repoBasename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
-    const herdSlug = repoBasename ? slugifyManual(repoBasename) : undefined;
-    const name = this.uniqueName(await this.deps.namer(input.prompt), herdSlug);
-    // Freshen the base ref: fetch the upstream tip so the new worktree always starts at the
-    // latest upstream commit. For non-diverged branches with an upstream, resolved.baseRef is
-    // the upstream sha; for diverged / no-upstream branches it falls back to the branch name.
-    // Epic integration branches that exist only on origin are also resolved here.
+  /** Freshen the base ref: fetch the upstream tip so the new worktree always starts at the
+   * latest upstream commit. For non-diverged branches with an upstream, resolved.baseRef is
+   * the upstream sha; for diverged / no-upstream branches it falls back to the branch name.
+   * Epic integration branches that exist only on origin are also resolved here.
+   * resolved.baseRef may be a sha (fresh upstream tip when behind) or the branch name
+   * (diverged / no upstream / up to date). Falls back to the named branch when the
+   * impl returns nothing — fail-safe, never undefined. */
+  private async resolveBaseRef(input: CreateSessionInput): Promise<string> {
     const resolved = await this.deps.worktree.ensureBaseRef(input.repoPath, input.baseBranch);
-    // resolved.baseRef is the fresh upstream tip (a sha) when the base was behind, else the
-    // local branch name (diverged / no upstream / up to date). Fall back to the named branch
-    // if a (mock/partial) impl returns nothing — fail-safe, never undefined.
     const baseRef = resolved?.baseRef ?? input.baseBranch;
     console.info(
       `[create] base ${input.baseBranch}: behind ${resolved?.behind ?? 0}, ff ${resolved?.localFf ?? "none"}, basing on ${baseRef}`,
     );
+    return baseRef;
+  }
+
+  async create(input: CreateSessionInput): Promise<Session> {
+    const repoBasename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
+    const herdSlug = repoBasename ? slugifyManual(repoBasename) : undefined;
+    const name = this.uniqueName(await this.deps.namer(input.prompt), herdSlug);
+    const baseRef = await this.resolveBaseRef(input);
     const wt = this.deps.worktree.create(input.repoPath, baseRef, name);
     // The worktree is created before the agent can start, so any failure past this
     // point (e.g. herdr `tab create` rejecting) would otherwise leave an orphan

--- a/src/upstream-status.ts
+++ b/src/upstream-status.ts
@@ -1,0 +1,129 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { timedAsync } from "./instrument";
+
+const execFileAsync = promisify(execFile);
+
+// Same refname regex as used in worktree.ts
+const REFNAME_RE = /^(?!-)[A-Za-z0-9._/-]{1,200}$/;
+
+const FAIL_CLOSED: UpstreamStatus = {
+  hasUpstream: false,
+  localExists: false,
+  upstreamSha: null,
+  localSha: null,
+  behind: 0,
+  ahead: 0,
+  diverged: false,
+};
+
+export interface UpstreamStatus {
+  hasUpstream: boolean; // refs/remotes/origin/<base> resolves (fresh OR pre-existing/stale)
+  localExists: boolean; // refs/heads/<base> resolves
+  upstreamSha: string | null; // sha of origin/<base> when hasUpstream, else null
+  localSha: string | null; // sha of local <base> when localExists, else null
+  behind: number; // commits local<base> is behind origin/<base>; 0 when either ref absent
+  ahead: number; // commits local<base> is ahead of origin/<base>; 0 when either ref absent
+  diverged: boolean; // ahead > 0 && behind > 0
+}
+
+export async function upstreamStatus(
+  repoPath: string,
+  baseBranch: string,
+): Promise<UpstreamStatus> {
+  // 1. Validate baseBranch — fail-closed immediately, no git calls
+  if (!REFNAME_RE.test(baseBranch)) {
+    return { ...FAIL_CLOSED };
+  }
+
+  // 2. Bounded fetch — best-effort, never throws out of the function.
+  // Uses a deterministic per-branch tracking ref (NOT FETCH_HEAD) so concurrent
+  // fetches for different bases don't collide.
+  // NOTE: The hard-timeout-kill path (SIGKILL after 5s) is exercised operationally,
+  // not in unit tests (unit tests use an immediately-failing remote).
+  try {
+    await timedAsync("git fetch", () =>
+      execFileAsync(
+        "git",
+        [
+          "-c",
+          "http.lowSpeedLimit=1000",
+          "-c",
+          "http.lowSpeedTime=5",
+          "fetch",
+          "origin",
+          `+${baseBranch}:refs/remotes/origin/${baseBranch}`,
+        ],
+        { cwd: repoPath, timeout: 5000, killSignal: "SIGKILL" },
+      ),
+    );
+  } catch {
+    // fetch failure is swallowed — offline, timeout/kill, lock contention, no remote;
+    // resolution continues against whatever refs already exist locally.
+  }
+
+  // 3. Resolve fields independently — do NOT collapse a missing local branch into a global failure.
+
+  // Resolve upstream sha
+  let upstreamSha: string | null = null;
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["rev-parse", "--verify", "--quiet", `refs/remotes/origin/${baseBranch}^{commit}`],
+      { cwd: repoPath },
+    );
+    upstreamSha = stdout.trim() || null;
+  } catch {
+    // hasUpstream = false, upstreamSha = null
+  }
+
+  // Resolve local sha
+  let localSha: string | null = null;
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["rev-parse", "--verify", "--quiet", `refs/heads/${baseBranch}^{commit}`],
+      { cwd: repoPath },
+    );
+    localSha = stdout.trim() || null;
+  } catch {
+    // localExists = false, localSha = null
+  }
+
+  // Compute behind/ahead only when both shas resolve
+  let behind = 0;
+  let ahead = 0;
+
+  if (upstreamSha !== null && localSha !== null) {
+    try {
+      const { stdout } = await execFileAsync(
+        "git",
+        ["rev-list", "--count", `${localSha}..${upstreamSha}`],
+        { cwd: repoPath },
+      );
+      behind = Number.parseInt(stdout.trim(), 10) || 0;
+    } catch {
+      // safe default
+    }
+    try {
+      const { stdout } = await execFileAsync(
+        "git",
+        ["rev-list", "--count", `${upstreamSha}..${localSha}`],
+        { cwd: repoPath },
+      );
+      ahead = Number.parseInt(stdout.trim(), 10) || 0;
+    } catch {
+      // safe default
+    }
+  }
+
+  return {
+    hasUpstream: upstreamSha !== null,
+    localExists: localSha !== null,
+    upstreamSha,
+    localSha,
+    behind,
+    ahead,
+    diverged: ahead > 0 && behind > 0,
+  };
+}

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -222,8 +222,22 @@ export class WorktreeMgr {
     }
 
     // Behind or origin-only: try to bring local branch to st.upstreamSha.
-    const upstreamSha = st.upstreamSha!;
+    base.localFf = await this.fastForwardLocalBase(repoPath, baseBranch, st.upstreamSha!);
+    if (base.localFf === "applied") base.localExists = true;
+    return base;
+  }
 
+  /** Attempt to fast-forward the local `baseBranch` ref to `upstreamSha` in `repoPath`.
+   *  Returns the `localFf` outcome:
+   *  - "applied"                     — ff succeeded (merge --ff-only or branch -f)
+   *  - "skipped-dirty"               — checked out here but tree is dirty (or ff-only failed)
+   *  - "skipped-checked-out-elsewhere" — not checked out here, branch -f refused (other worktree)
+   *  Never throws. */
+  private async fastForwardLocalBase(
+    repoPath: string,
+    baseBranch: string,
+    upstreamSha: string,
+  ): Promise<ResolvedBase["localFf"]> {
     // Is baseBranch currently checked out in repoPath?
     let checkedOutHere = false;
     try {
@@ -251,37 +265,32 @@ export class WorktreeMgr {
         console.warn(
           `[worktree] ensureBaseRef: ${baseBranch} is checked out with a dirty tree — skipping ff`,
         );
-        base.localFf = "skipped-dirty";
-        return base;
+        return "skipped-dirty";
       }
 
       // Clean + checked out → merge --ff-only
       try {
         await execFileAsync("git", ["merge", "--ff-only", upstreamSha], { cwd: repoPath });
-        base.localFf = "applied";
-        base.localExists = true;
+        return "applied";
       } catch (err) {
         console.warn(`[worktree] ensureBaseRef: ff-only merge failed for ${baseBranch}:`, err);
-        base.localFf = "skipped-dirty";
+        return "skipped-dirty";
       }
-      return base;
     }
 
     // Not checked out in repoPath — use `git branch -f` (works for create + ff,
     // fails when the branch is HEAD in another worktree).
     try {
       await execFileAsync("git", ["branch", "-f", baseBranch, upstreamSha], { cwd: repoPath });
-      base.localFf = "applied";
-      base.localExists = true;
+      return "applied";
     } catch (err) {
       // git refuses to move a ref that is HEAD in any worktree → skipped-checked-out-elsewhere
       console.warn(
         `[worktree] ensureBaseRef: branch -f ${baseBranch} failed (checked out elsewhere?):`,
         err,
       );
-      base.localFf = "skipped-checked-out-elsewhere";
+      return "skipped-checked-out-elsewhere";
     }
-    return base;
   }
 
   /** Whether the branch checked out at `worktreePath` is BEHIND `baseBranch` — i.e.

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import { timedAsync } from "./instrument";
 import { ensureShepherdExclude } from "./shepherd-exclude";
 import { removeWorktreeScratch } from "./tmp-sweep";
+import { upstreamStatus } from "./upstream-status";
 
 const execFileAsync = promisify(execFile);
 
@@ -13,6 +14,35 @@ export interface WorktreeResult {
   worktreePath: string;
   branch: string | null;
   isolated: boolean;
+}
+
+export interface ResolvedBase {
+  /** The ref or sha to pass to `worktree.create()` as the base commit. For a
+   *  non-diverged branch with an upstream, this is the upstream sha (so the new
+   *  task always starts fresh even when the local fast-forward was skipped due to
+   *  a dirty tree or a worktree checkout elsewhere). For diverged / no-upstream
+   *  branches it falls back to the branch name. */
+  baseRef: string;
+  behind: number;
+  ahead: number;
+  diverged: boolean;
+  hasUpstream: boolean;
+  localExists: boolean;
+  /** What happened to the local branch during the fast-forward attempt:
+   *  - "applied"                    — local branch was moved to the upstream sha
+   *  - "skipped-dirty"              — checked-out branch, working tree had changes
+   *  - "skipped-diverged"           — local branch has commits not on upstream
+   *  - "skipped-checked-out-elsewhere" — branch is HEAD in another worktree
+   *  - "not-needed"                 — local was already at the upstream sha
+   *  - "none"                       — no upstream to freshen toward
+   */
+  localFf:
+    | "applied"
+    | "skipped-dirty"
+    | "skipped-diverged"
+    | "skipped-checked-out-elsewhere"
+    | "not-needed"
+    | "none";
 }
 
 export class WorktreeMgr {
@@ -113,31 +143,145 @@ export class WorktreeMgr {
     }
   }
 
-  /** Ensure `baseBranch` resolves locally AND is current before a worktree bases on it.
-   *  Skips the fetch only for the main clone's checked-out branch (git refuses to fetch into
-   *  it; the default branch is normally HEAD, so regular spawns keep basing on the local tip
-   *  as before — no new network hit). For any other base (e.g. an epic integration branch that
-   *  advances on the remote as siblings merge), `git fetch origin <b>:<b>` creates-or-FFs the
-   *  local branch so the worktree bases on the latest tip. Best-effort + async (never sync on
-   *  the server loop): a failure warns and the subsequent worktree.create surfaces a real error
-   *  if the base is genuinely unresolvable. */
-  async ensureBaseRef(repoPath: string, baseBranch: string): Promise<void> {
-    if (!/^(?!-)[A-Za-z0-9._/-]{1,200}$/.test(baseBranch)) return;
+  /** Freshen `baseBranch` from upstream at task-launch time, then return a `ResolvedBase`
+   *  the caller uses to base the new worktree on.
+   *
+   *  Contract:
+   *  1. Validates `baseBranch` — fails closed (no git calls) on an invalid refname.
+   *  2. Calls `upstreamStatus()` to fetch and evaluate the branch against origin.
+   *  3. Computes `baseRef`:
+   *     - Non-diverged branch with an upstream → upstream sha (the new worktree starts fresh
+   *       even when the local fast-forward below is skipped).
+   *     - Diverged or no upstream → branch name (fall back to whatever is local).
+   *  4. Best-effort local fast-forward (never throws, never blocks):
+   *     - No upstream              → `localFf = "none"`.
+   *     - Diverged                 → warn, `localFf = "skipped-diverged"`, local untouched.
+   *     - Already up-to-date       → `localFf = "not-needed"`.
+   *     - Behind / origin-only     → determine if `baseBranch` is HEAD in `repoPath`:
+   *       - Checked out here (clean tree) → `git merge --ff-only <sha>` → "applied".
+   *       - Checked out here (dirty tree) → skip, `localFf = "skipped-dirty"` (warn).
+   *       - Not checked out here → `git branch -f <branch> <sha>` (creates or ff's the local
+   *         ref without touching any working tree). Fails when the branch is HEAD in ANOTHER
+   *         worktree → `localFf = "skipped-checked-out-elsewhere"` (warn). `baseRef` is
+   *         unaffected — the new task still starts at the upstream sha.
+   *
+   *  All git calls are async (no sync I/O on the server loop) and individually try/caught.
+   *  `ensureBaseRef` never throws. */
+  async ensureBaseRef(repoPath: string, baseBranch: string): Promise<ResolvedBase> {
+    const FAIL_CLOSED: ResolvedBase = {
+      baseRef: baseBranch,
+      behind: 0,
+      ahead: 0,
+      diverged: false,
+      hasUpstream: false,
+      localExists: false,
+      localFf: "none",
+    };
+
+    if (!/^(?!-)[A-Za-z0-9._/-]{1,200}$/.test(baseBranch)) return FAIL_CLOSED;
+
+    let st;
+    try {
+      st = await upstreamStatus(repoPath, baseBranch);
+    } catch {
+      return FAIL_CLOSED;
+    }
+
+    // Compute baseRef: prefer the upstream sha for a clean fast-forwardable branch so
+    // the new worktree starts fresh even when the local ff below is skipped.
+    const baseRef = st.hasUpstream && !st.diverged && st.upstreamSha ? st.upstreamSha : baseBranch;
+
+    const base: ResolvedBase = {
+      baseRef,
+      behind: st.behind,
+      ahead: st.ahead,
+      diverged: st.diverged,
+      hasUpstream: st.hasUpstream,
+      localExists: st.localExists,
+      localFf: "none",
+    };
+
+    // Fast-forward logic — best-effort, each step individually try/caught.
+    if (!st.hasUpstream) {
+      base.localFf = "none";
+      return base;
+    }
+
+    if (st.diverged) {
+      console.warn(
+        `[worktree] ensureBaseRef: ${baseBranch} has diverged from upstream — skipping local ff`,
+      );
+      base.localFf = "skipped-diverged";
+      return base;
+    }
+
+    // Up to date?
+    if (st.localExists && st.behind === 0) {
+      base.localFf = "not-needed";
+      return base;
+    }
+
+    // Behind or origin-only: try to bring local branch to st.upstreamSha.
+    const upstreamSha = st.upstreamSha!;
+
+    // Is baseBranch currently checked out in repoPath?
+    let checkedOutHere = false;
     try {
       const { stdout } = await execFileAsync("git", ["symbolic-ref", "--short", "HEAD"], {
         cwd: repoPath,
       });
-      if (stdout.trim() === baseBranch) return; // checked-out branch — can't/needn't fetch
+      checkedOutHere = stdout.trim() === baseBranch;
     } catch {
-      // detached HEAD or error — fall through and attempt the fetch
+      // detached HEAD or error → treat as not checked out here
     }
+
+    if (checkedOutHere) {
+      // Check working tree cleanliness — treat any error as dirty (safe default).
+      let dirty = true;
+      try {
+        const { stdout } = await execFileAsync("git", ["status", "--porcelain"], {
+          cwd: repoPath,
+        });
+        dirty = stdout.trim().length > 0;
+      } catch {
+        // can't determine → treat as dirty (safe)
+      }
+
+      if (dirty) {
+        console.warn(
+          `[worktree] ensureBaseRef: ${baseBranch} is checked out with a dirty tree — skipping ff`,
+        );
+        base.localFf = "skipped-dirty";
+        return base;
+      }
+
+      // Clean + checked out → merge --ff-only
+      try {
+        await execFileAsync("git", ["merge", "--ff-only", upstreamSha], { cwd: repoPath });
+        base.localFf = "applied";
+        base.localExists = true;
+      } catch (err) {
+        console.warn(`[worktree] ensureBaseRef: ff-only merge failed for ${baseBranch}:`, err);
+        base.localFf = "skipped-dirty";
+      }
+      return base;
+    }
+
+    // Not checked out in repoPath — use `git branch -f` (works for create + ff,
+    // fails when the branch is HEAD in another worktree).
     try {
-      await execFileAsync("git", ["fetch", "origin", `${baseBranch}:${baseBranch}`], {
-        cwd: repoPath,
-      });
+      await execFileAsync("git", ["branch", "-f", baseBranch, upstreamSha], { cwd: repoPath });
+      base.localFf = "applied";
+      base.localExists = true;
     } catch (err) {
-      console.warn(`[worktree] ensureBaseRef fetch ${baseBranch} failed:`, err);
+      // git refuses to move a ref that is HEAD in any worktree → skipped-checked-out-elsewhere
+      console.warn(
+        `[worktree] ensureBaseRef: branch -f ${baseBranch} failed (checked out elsewhere?):`,
+        err,
+      );
+      base.localFf = "skipped-checked-out-elsewhere";
     }
+    return base;
   }
 
   /** Whether the branch checked out at `worktreePath` is BEHIND `baseBranch` — i.e.

--- a/test/branch-status-endpoint.test.ts
+++ b/test/branch-status-endpoint.test.ts
@@ -1,0 +1,173 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { makeApp, clearBranchStatusCacheForTests, type AppDeps } from "../src/server";
+import type { SessionStore } from "../src/store";
+import type { SessionService } from "../src/service";
+import type { EventHub } from "../src/events";
+import { config } from "../src/config";
+
+// ── git fixture helpers ───────────────────────────────────────────────────────
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+
+function commit(dir: string, file: string, content: string, msg: string) {
+  writeFileSync(join(dir, file), content);
+  execFileSync("git", ["add", "-A"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["commit", "-qm", msg], { cwd: dir, stdio: "pipe", env: GIT_ENV });
+}
+
+let advanceCounter = 0;
+
+/** Advance origin/main by one commit from a temporary second clone. */
+function advanceOrigin(origin: string) {
+  const other = mkdtempSync(join(tmpdir(), "shepherd-bs-other-"));
+  try {
+    execFileSync("git", ["clone", "-q", "--branch", "main", origin, other], { stdio: "pipe" });
+    // Use a unique filename per call so successive advances don't no-op.
+    commit(other, `advance-${++advanceCounter}.txt`, "advance", "advance origin/main");
+    execFileSync("git", ["push", "-q", "origin", "main"], { cwd: other, stdio: "pipe" });
+  } finally {
+    rmSync(other, { recursive: true, force: true });
+  }
+}
+
+// ── app harness ───────────────────────────────────────────────────────────────
+
+function makeDeps(): AppDeps {
+  return {
+    store: {} as SessionStore,
+    service: {} as SessionService,
+    events: { emit: () => {} } as unknown as EventHub,
+    usageLimits: { limits: () => ({}) } as never,
+  };
+}
+
+function makeRequest(repo: string, branch: string): Request {
+  return new Request(
+    `http://localhost/api/branch-status?repo=${encodeURIComponent(repo)}&branch=${encodeURIComponent(branch)}`,
+  );
+}
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+// We need the repo inside config.repoRoot so safeRepoDir accepts it.
+// Strategy: create a symlink-or-subdir inside config.repoRoot that points at
+// the real repo in /tmp. Instead, we use mkdtempSync inside repoRoot directly
+// for the fixture — but our git fixture helpers use /tmp for speed. We resolve
+// this by having the clone live inside config.repoRoot.
+
+let tmpRootInRepoRoot: string;
+let origin: string;
+let repo: string; // lives inside config.repoRoot
+
+beforeEach(() => {
+  clearBranchStatusCacheForTests();
+
+  // Create a clean subdirectory inside repoRoot to hold the clone.
+  tmpRootInRepoRoot = mkdtempSync(join(config.repoRoot, "shepherd-bs-test-"));
+
+  // Build origin in /tmp (fast), clone into repoRoot subdir.
+  origin = mkdtempSync(join(tmpdir(), "shepherd-bs-origin-"));
+  execFileSync("git", ["init", "-q", "--bare", "-b", "main", origin], { stdio: "pipe" });
+
+  const seed = mkdtempSync(join(tmpdir(), "shepherd-bs-seed-"));
+  execFileSync("git", ["init", "-q", "-b", "main", seed], { stdio: "pipe" });
+  commit(seed, "a.txt", "1", "init");
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: seed, stdio: "pipe" });
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+  rmSync(seed, { recursive: true, force: true });
+
+  repo = join(tmpRootInRepoRoot, "repo");
+  execFileSync("git", ["clone", "-q", "--single-branch", "--branch", "main", origin, repo], {
+    stdio: "pipe",
+  });
+});
+
+afterEach(() => {
+  clearBranchStatusCacheForTests();
+  rmSync(tmpRootInRepoRoot, { recursive: true, force: true });
+  rmSync(origin, { recursive: true, force: true });
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+test("GET /api/branch-status: origin ahead → behind>0, ahead=0, diverged=false", async () => {
+  // Advance origin/main so local main is behind.
+  advanceOrigin(origin);
+
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(makeRequest(repo, "main"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.behind).toBeGreaterThan(0);
+  expect(body.ahead).toBe(0);
+  expect(body.diverged).toBe(false);
+  expect(body.hasUpstream).toBe(true);
+  expect(body.localExists).toBe(true);
+  // Verify the five-field shape only — shas must NOT appear.
+  expect(Object.keys(body).sort()).toEqual(
+    ["ahead", "behind", "diverged", "hasUpstream", "localExists"].sort(),
+  );
+});
+
+test("GET /api/branch-status: invalid branch ('--evil') → 400 { error: 'invalid branch' }", async () => {
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(
+    new Request(
+      `http://localhost/api/branch-status?repo=${encodeURIComponent(repo)}&branch=--evil`,
+    ),
+  );
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toBe("invalid branch");
+});
+
+test("GET /api/branch-status: missing branch param → 400 { error: 'invalid branch' }", async () => {
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(
+    new Request(`http://localhost/api/branch-status?repo=${encodeURIComponent(repo)}`),
+  );
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toBe("invalid branch");
+});
+
+test("GET /api/branch-status: repo outside repoRoot → 400 { error: 'invalid repo' }", async () => {
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(
+    new Request("http://localhost/api/branch-status?repo=%2Fetc&branch=main"),
+  );
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toBe("invalid repo");
+});
+
+test("GET /api/branch-status: TTL cache — second call returns cached value (skips fetch)", async () => {
+  // Advance origin/main so first call sees behind=1.
+  advanceOrigin(origin);
+
+  const app = makeApp(makeDeps());
+
+  // First call — populates cache with behind=1.
+  const res1 = await app.fetch(makeRequest(repo, "main"));
+  expect(res1.status).toBe(200);
+  const body1 = await res1.json();
+  expect(body1.behind).toBeGreaterThan(0);
+  const cachedBehind = body1.behind;
+
+  // Advance origin/main again — if the cache were bypassed, behind would increase.
+  advanceOrigin(origin);
+
+  // Second call — must return the same cached value (behind unchanged), proving the
+  // network fetch was skipped and the cached result was served.
+  const res2 = await app.fetch(makeRequest(repo, "main"));
+  expect(res2.status).toBe(200);
+  const body2 = await res2.json();
+  expect(body2.behind).toBe(cachedBehind); // stale cache — new commit not reflected
+});

--- a/test/branch-status-endpoint.test.ts
+++ b/test/branch-status-endpoint.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
-import { makeApp, clearBranchStatusCacheForTests, type AppDeps } from "../src/server";
+import {
+  makeApp,
+  branchStatusCached,
+  clearBranchStatusCacheForTests,
+  type AppDeps,
+} from "../src/server";
 import type { SessionStore } from "../src/store";
 import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
@@ -170,4 +175,19 @@ test("GET /api/branch-status: TTL cache — second call returns cached value (sk
   expect(res2.status).toBe(200);
   const body2 = await res2.json();
   expect(body2.behind).toBe(cachedBehind); // stale cache — new commit not reflected
+});
+
+test("branchStatusCached: concurrent misses coalesce into ONE shared fetch", async () => {
+  clearBranchStatusCacheForTests(); // ensure both calls are misses
+  advanceOrigin(origin);
+
+  // Two concurrent misses for the same (repo, branch). Coalescing means they await the
+  // same in-flight promise and therefore resolve to the SAME value object — without it,
+  // each would run its own fetch and produce a distinct object.
+  const [a, b] = await Promise.all([
+    branchStatusCached(repo, "main"),
+    branchStatusCached(repo, "main"),
+  ]);
+  expect(a).toBe(b); // same reference → single shared fetch
+  expect(a.behind).toBeGreaterThan(0);
 });

--- a/test/helpers/base-ref.ts
+++ b/test/helpers/base-ref.ts
@@ -1,0 +1,11 @@
+import type { ResolvedBase } from "../../src/worktree";
+export const stubBaseRef = (over: Partial<ResolvedBase> = {}): ResolvedBase => ({
+  baseRef: "main",
+  behind: 0,
+  ahead: 0,
+  diverged: false,
+  hasUpstream: false,
+  localExists: true,
+  localFf: "none",
+  ...over,
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1064,7 +1064,7 @@ test("archive without a reaper just closes the session (no leftover handling)", 
     store,
     namer: async () => "x",
     worktree: {
-      ensureBaseRef: async () => {},
+      ensureBaseRef: async () => ({}) as any,
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,
@@ -1106,7 +1106,7 @@ test("leftovers proxies to the reaper for the session; [] for unknown id", () =>
     store,
     namer: async () => "x",
     worktree: {
-      ensureBaseRef: async () => {},
+      ensureBaseRef: async () => ({}) as any,
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,
@@ -1150,7 +1150,7 @@ test("archive reaps only the selected leftovers, re-detected (no trusting raw cl
     store,
     namer: async () => "x",
     worktree: {
-      ensureBaseRef: async () => {},
+      ensureBaseRef: async () => ({}) as any,
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,
@@ -1192,7 +1192,7 @@ test("archive with no reap keys never calls the reaper", async () => {
     store,
     namer: async () => "x",
     worktree: {
-      ensureBaseRef: async () => {},
+      ensureBaseRef: async () => ({}) as any,
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -28,6 +28,7 @@ import {
 import { HOUSE_RULES_TAG } from "../src/house-rules";
 import { config, parseTrimAutoContext } from "../src/config";
 import { MAX_IMAGES } from "../src/validate";
+import { stubBaseRef } from "./helpers/base-ref";
 
 test("createSession: names, makes worktree, starts herdr, persists", async () => {
   const store = new SessionStore(":memory:");
@@ -856,6 +857,50 @@ test("createSession: defaults auto=false and issueNumber=null when not provided"
   expect(store.get(s.id)?.issueNumber).toBeNull();
 });
 
+test("createSession: worktree.create receives resolved baseRef (sha), persisted baseBranch stays logical name", async () => {
+  const sha = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+  const store = new SessionStore(":memory:");
+  let createBase: string | undefined;
+  const service = new SessionService({
+    store,
+    namer: async () => "resolved-base",
+    worktree: {
+      ensureBaseRef: async () => stubBaseRef({ baseRef: sha, behind: 3, hasUpstream: true }),
+      create: (_r: string, base: string, name: string) => {
+        createBase = base;
+        return { worktreePath: `/wt/${name}`, branch: `shepherd/${name}`, isolated: true };
+      },
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => ({
+        terminalId: "term_z",
+        cwd: "/wt/resolved-base",
+        agent: "claude",
+        agentStatus: "working",
+        paneId: "p",
+        tabId: "t",
+        workspaceId: "w",
+      }),
+      list: () => [],
+    } as any,
+  });
+
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "do work",
+    model: null,
+    images: [],
+  });
+
+  // worktree.create got the sha, not the logical name
+  expect(createBase).toBe(sha);
+  // persisted session still has the logical branch name
+  expect(s.baseBranch).toBe("main");
+  expect(store.get(s.id)?.baseBranch).toBe("main");
+});
+
 test("createSession: rolls back the worktree when the agent fails to start", async () => {
   const store = new SessionStore(":memory:");
   const removed: { path: string; opts: any }[] = [];
@@ -1064,7 +1109,7 @@ test("archive without a reaper just closes the session (no leftover handling)", 
     store,
     namer: async () => "x",
     worktree: {
-      ensureBaseRef: async () => ({}) as any,
+      ensureBaseRef: async () => stubBaseRef(),
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,
@@ -1106,7 +1151,7 @@ test("leftovers proxies to the reaper for the session; [] for unknown id", () =>
     store,
     namer: async () => "x",
     worktree: {
-      ensureBaseRef: async () => ({}) as any,
+      ensureBaseRef: async () => stubBaseRef(),
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,
@@ -1150,7 +1195,7 @@ test("archive reaps only the selected leftovers, re-detected (no trusting raw cl
     store,
     namer: async () => "x",
     worktree: {
-      ensureBaseRef: async () => ({}) as any,
+      ensureBaseRef: async () => stubBaseRef(),
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,
@@ -1192,7 +1237,7 @@ test("archive with no reap keys never calls the reaper", async () => {
     store,
     namer: async () => "x",
     worktree: {
-      ensureBaseRef: async () => ({}) as any,
+      ensureBaseRef: async () => stubBaseRef(),
       create: () => ({}) as any,
       remove: () => {},
       branchExists: () => false,

--- a/test/upstream-status.test.ts
+++ b/test/upstream-status.test.ts
@@ -1,0 +1,167 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { upstreamStatus } from "../src/upstream-status";
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+
+function commit(dir: string, file: string, content: string, msg: string) {
+  writeFileSync(join(dir, file), content);
+  execFileSync("git", ["add", "-A"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["commit", "-qm", msg], { cwd: dir, stdio: "pipe", env: GIT_ENV });
+}
+
+function revParse(dir: string, ref: string): string {
+  return execFileSync("git", ["rev-parse", ref], { cwd: dir, stdio: "pipe" }).toString().trim();
+}
+
+let origin: string;
+let repo: string;
+beforeEach(() => {
+  // A bare "origin" plus a clone, so a branch can live only on origin.
+  origin = mkdtempSync(join(tmpdir(), "shepherd-origin-"));
+  execFileSync("git", ["init", "-q", "--bare", "-b", "main", origin], { stdio: "pipe" });
+
+  const seed = mkdtempSync(join(tmpdir(), "shepherd-seed-"));
+  execFileSync("git", ["init", "-q", "-b", "main", seed], { stdio: "pipe" });
+  commit(seed, "a.txt", "1", "init");
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: seed, stdio: "pipe" });
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+  // an integration branch that exists ONLY on origin
+  execFileSync("git", ["checkout", "-q", "-b", "epic/9-x"], { cwd: seed, stdio: "pipe" });
+  commit(seed, "b.txt", "2", "epic work");
+  execFileSync("git", ["push", "-q", "origin", "epic/9-x"], { cwd: seed, stdio: "pipe" });
+  rmSync(seed, { recursive: true, force: true });
+
+  repo = mkdtempSync(join(tmpdir(), "shepherd-clone-"));
+  execFileSync("git", ["clone", "-q", "--single-branch", "--branch", "main", origin, repo], {
+    stdio: "pipe",
+  });
+});
+afterEach(() => {
+  rmSync(origin, { recursive: true, force: true });
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("upstreamStatus: up to date — fresh clone, no divergence", async () => {
+  const status = await upstreamStatus(repo, "main");
+  expect(status.hasUpstream).toBe(true);
+  expect(status.localExists).toBe(true);
+  expect(status.behind).toBe(0);
+  expect(status.ahead).toBe(0);
+  expect(status.diverged).toBe(false);
+  expect(status.upstreamSha).not.toBeNull();
+  expect(status.localSha).not.toBeNull();
+  expect(status.upstreamSha).toBe(status.localSha);
+});
+
+test("upstreamStatus: origin ahead (clean ff) — behind>0, ahead===0, diverged===false", async () => {
+  // Advance origin/main from a second clone+push
+  const other = mkdtempSync(join(tmpdir(), "shepherd-other-"));
+  execFileSync("git", ["clone", "-q", "--branch", "main", origin, other], { stdio: "pipe" });
+  commit(other, "z.txt", "new", "advance main");
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: other, stdio: "pipe" });
+  rmSync(other, { recursive: true, force: true });
+
+  const localSha = revParse(repo, "main");
+  const status = await upstreamStatus(repo, "main");
+
+  expect(status.hasUpstream).toBe(true);
+  expect(status.localExists).toBe(true);
+  expect(status.behind).toBeGreaterThan(0);
+  expect(status.ahead).toBe(0);
+  expect(status.diverged).toBe(false);
+  expect(status.upstreamSha).not.toBeNull();
+  expect(status.localSha).toBe(localSha);
+  expect(status.upstreamSha).not.toBe(status.localSha);
+});
+
+test("upstreamStatus: diverged — behind>0, ahead>0, diverged===true", async () => {
+  // Commit locally on main (don't push)
+  commit(repo, "local.txt", "local change", "local commit");
+  const localSha = revParse(repo, "main");
+
+  // Advance origin/main separately from a second clone
+  const other = mkdtempSync(join(tmpdir(), "shepherd-other-"));
+  execFileSync("git", ["clone", "-q", "--branch", "main", origin, other], { stdio: "pipe" });
+  commit(other, "remote.txt", "remote change", "remote commit");
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: other, stdio: "pipe" });
+  rmSync(other, { recursive: true, force: true });
+
+  const status = await upstreamStatus(repo, "main");
+
+  expect(status.hasUpstream).toBe(true);
+  expect(status.localExists).toBe(true);
+  expect(status.behind).toBeGreaterThan(0);
+  expect(status.ahead).toBeGreaterThan(0);
+  expect(status.diverged).toBe(true);
+  expect(status.localSha).toBe(localSha);
+  expect(status.upstreamSha).not.toBe(status.localSha);
+});
+
+test("upstreamStatus: origin-only branch (epic/9-x) — hasUpstream, !localExists, counts 0", async () => {
+  // epic/9-x exists on origin but NOT locally (single-branch clone of main)
+  const status = await upstreamStatus(repo, "epic/9-x");
+
+  expect(status.hasUpstream).toBe(true);
+  expect(status.localExists).toBe(false);
+  expect(status.behind).toBe(0);
+  expect(status.ahead).toBe(0);
+  expect(status.diverged).toBe(false);
+  expect(status.upstreamSha).not.toBeNull();
+  expect(status.localSha).toBeNull();
+});
+
+test("upstreamStatus: stale tracking ref / origin unreachable — no throw, hasUpstream still true", async () => {
+  // First call to populate refs/remotes/origin/main
+  const first = await upstreamStatus(repo, "main");
+  expect(first.hasUpstream).toBe(true);
+
+  // Point origin at a non-existent path so the fetch will fail
+  execFileSync("git", ["remote", "set-url", "origin", "/no/such/repo"], {
+    cwd: repo,
+    stdio: "pipe",
+  });
+
+  // Should not throw; stale tracking ref still resolves
+  const status = await upstreamStatus(repo, "main");
+  expect(status.hasUpstream).toBe(true); // stale tracking ref still resolves
+});
+
+test("upstreamStatus: no upstream at all — hasUpstream===false, no throw", async () => {
+  // A repo with no origin remote (or unreachable + no pre-existing tracking ref)
+  const bare = mkdtempSync(join(tmpdir(), "shepherd-noremote-"));
+  execFileSync("git", ["init", "-q", "-b", "main", bare], { stdio: "pipe" });
+  commit(bare, "x.txt", "1", "init");
+
+  const status = await upstreamStatus(bare, "main");
+
+  expect(status.hasUpstream).toBe(false);
+  expect(status.localExists).toBe(true); // local main exists
+  expect(status.behind).toBe(0);
+  expect(status.ahead).toBe(0);
+  expect(status.diverged).toBe(false);
+  expect(status.upstreamSha).toBeNull();
+
+  rmSync(bare, { recursive: true, force: true });
+});
+
+test("upstreamStatus: invalid base name ('--evil') — fail-closed result, no throw", async () => {
+  const status = await upstreamStatus(repo, "--evil");
+
+  expect(status.hasUpstream).toBe(false);
+  expect(status.localExists).toBe(false);
+  expect(status.upstreamSha).toBeNull();
+  expect(status.localSha).toBeNull();
+  expect(status.behind).toBe(0);
+  expect(status.ahead).toBe(0);
+  expect(status.diverged).toBe(false);
+});

--- a/test/worktree-ensure-base-ref.test.ts
+++ b/test/worktree-ensure-base-ref.test.ts
@@ -59,37 +59,70 @@ afterEach(() => {
   rmSync(repo, { recursive: true, force: true });
 });
 
-test("ensureBaseRef: checked-out (default) branch is NOT fetched → no-op, stays at local tip", async () => {
+// INVERTED from old behavior: checked-out branch IS now fast-forwarded when clean
+test("ensureBaseRef: checked-out branch IS fast-forwarded when tree is clean", async () => {
   const wt = new WorktreeMgr();
-  // main is the clone's local checkout branch — git refuses to fetch into it.
-  expect(localBranches(repo)).toEqual(["main"]);
   const before = revParse(repo, "main");
 
-  // Advance origin/main from a second clone so a fetch (if it wrongly happened) would move it.
+  // Advance origin/main so local main is behind
   const other = mkdtempSync(join(tmpdir(), "shepherd-other-"));
   execFileSync("git", ["clone", "-q", "--branch", "main", origin, other], { stdio: "pipe" });
   commit(other, "a.txt", "advanced", "advance main");
   execFileSync("git", ["push", "-q", "origin", "main"], { cwd: other, stdio: "pipe" });
+  const originTip = revParse(other, "main");
   rmSync(other, { recursive: true, force: true });
 
-  await wt.ensureBaseRef(repo, "main");
-  // still just main, still at the original local tip — the checked-out branch is skipped.
-  expect(localBranches(repo)).toEqual(["main"]);
-  expect(revParse(repo, "main")).toBe(before);
+  const resolved = await wt.ensureBaseRef(repo, "main");
+  // local main was fast-forwarded to origin tip
+  expect(revParse(repo, "main")).toBe(originTip);
+  expect(revParse(repo, "main")).not.toBe(before);
+  expect(resolved.localFf).toBe("applied");
+  expect(resolved.baseRef).toBe(originTip);
+  expect(resolved.behind).toBeGreaterThan(0);
+  expect(resolved.hasUpstream).toBe(true);
 });
 
+// Regression test: the payoff — worktree bases on upstream-only commit
+test("ensureBaseRef + wt.create: worktree HEAD contains upstream-only commit", async () => {
+  const wt = new WorktreeMgr();
+
+  const other = mkdtempSync(join(tmpdir(), "shepherd-other-"));
+  execFileSync("git", ["clone", "-q", "--branch", "main", origin, other], { stdio: "pipe" });
+  commit(other, "upstream-only.txt", "fresh", "upstream only commit");
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: other, stdio: "pipe" });
+  const originTip = revParse(other, "main");
+  rmSync(other, { recursive: true, force: true });
+
+  const resolved = await wt.ensureBaseRef(repo, "main");
+  expect(resolved.localFf).toBe("applied");
+  expect(resolved.baseRef).toBe(originTip);
+
+  const r = wt.create(repo, resolved.baseRef, "child");
+  expect(r.isolated).toBe(true);
+  // The new worktree HEAD should be at the upstream tip
+  expect(revParse(r.worktreePath, "HEAD")).toBe(originTip);
+  wt.remove(r.worktreePath);
+});
+
+// origin-only branch is materialized and baseRef points to origin sha
 test("ensureBaseRef: origin-only branch is materialized into a local branch", async () => {
   const wt = new WorktreeMgr();
   // epic/9-x exists on origin but NOT locally (single-branch clone of main)
   expect(localBranches(repo)).not.toContain("epic/9-x");
-  await wt.ensureBaseRef(repo, "epic/9-x");
+
+  const resolved = await wt.ensureBaseRef(repo, "epic/9-x");
+  expect(resolved.localFf).toBe("applied");
+  expect(resolved.hasUpstream).toBe(true);
+  expect(resolved.baseRef).toMatch(/^[0-9a-f]{40}$/);
   expect(localBranches(repo)).toContain("epic/9-x");
-  // and it now resolves locally so a worktree can base on it
+
+  // wt.create on it is isolated
   const r = wt.create(repo, "epic/9-x", "child");
   expect(r.isolated).toBe(true);
   wt.remove(r.worktreePath);
 });
 
+// existing local non-checked-out branch is fast-forwarded
 test("ensureBaseRef: existing local integration branch is fast-forwarded to origin tip", async () => {
   const wt = new WorktreeMgr();
   // C1: materialize local epic/9-x at origin's current tip.
@@ -97,7 +130,7 @@ test("ensureBaseRef: existing local integration branch is fast-forwarded to orig
   expect(localBranches(repo)).toContain("epic/9-x");
   const c1 = revParse(repo, "epic/9-x");
 
-  // C2: a sibling advances origin/epic/9-x (simulates a sibling PR squash-merging into it).
+  // C2: a sibling advances origin/epic/9-x
   const other = mkdtempSync(join(tmpdir(), "shepherd-sibling-"));
   execFileSync("git", ["clone", "-q", "--branch", "epic/9-x", origin, other], { stdio: "pipe" });
   commit(other, "c.txt", "sibling work", "sibling merge");
@@ -106,14 +139,135 @@ test("ensureBaseRef: existing local integration branch is fast-forwarded to orig
   rmSync(other, { recursive: true, force: true });
   expect(c2).not.toBe(c1); // origin genuinely advanced
 
-  // Second spawn: local epic/9-x must fast-forward to C2, not stay stale at C1.
-  await wt.ensureBaseRef(repo, "epic/9-x");
+  // Second spawn: local epic/9-x must fast-forward to C2
+  const resolved = await wt.ensureBaseRef(repo, "epic/9-x");
+  expect(resolved.localFf).toBe("applied");
+  expect(resolved.baseRef).toBe(c2);
   expect(revParse(repo, "epic/9-x")).toBe(c2);
   expect(revParse(repo, "epic/9-x")).not.toBe(c1);
 });
 
+// diverged → keep local, warn
+test("ensureBaseRef: diverged branch → localFf=skipped-diverged, local tip preserved", async () => {
+  const wt = new WorktreeMgr();
+  // Materialize epic/9-x locally
+  await wt.ensureBaseRef(repo, "epic/9-x");
+
+  // Advance local epic/9-x with a local-only commit
+  execFileSync("git", ["checkout", "-q", "epic/9-x"], { cwd: repo, stdio: "pipe", env: GIT_ENV });
+  commit(repo, "local-only.txt", "local only", "local commit on epic");
+  const localTip = revParse(repo, "epic/9-x");
+  // Return to main
+  execFileSync("git", ["checkout", "-q", "main"], { cwd: repo, stdio: "pipe", env: GIT_ENV });
+
+  // Advance origin/epic/9-x independently
+  const other = mkdtempSync(join(tmpdir(), "shepherd-diverge-"));
+  execFileSync("git", ["clone", "-q", "--branch", "epic/9-x", origin, other], { stdio: "pipe" });
+  commit(other, "origin-only.txt", "origin only", "origin commit on epic");
+  execFileSync("git", ["push", "-q", "origin", "epic/9-x"], { cwd: other, stdio: "pipe" });
+  rmSync(other, { recursive: true, force: true });
+
+  const resolved = await wt.ensureBaseRef(repo, "epic/9-x");
+  expect(resolved.diverged).toBe(true);
+  expect(resolved.localFf).toBe("skipped-diverged");
+  // baseRef is the branch name (not origin sha) for diverged case
+  expect(resolved.baseRef).toBe("epic/9-x");
+  // local tip is unchanged
+  expect(revParse(repo, "epic/9-x")).toBe(localTip);
+});
+
+// dirty checked-out tree → skip ff, but still get fresh baseRef
+test("ensureBaseRef: dirty checked-out tree → localFf=skipped-dirty, baseRef still fresh", async () => {
+  const wt = new WorktreeMgr();
+  const localTip = revParse(repo, "main");
+
+  // Advance origin/main
+  const other = mkdtempSync(join(tmpdir(), "shepherd-dirty-"));
+  execFileSync("git", ["clone", "-q", "--branch", "main", origin, other], { stdio: "pipe" });
+  commit(other, "a.txt", "origin advanced", "advance origin main");
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: other, stdio: "pipe" });
+  const originTip = revParse(other, "main");
+  rmSync(other, { recursive: true, force: true });
+
+  // Write an uncommitted change to make the tree dirty
+  writeFileSync(join(repo, "dirty.txt"), "uncommitted change");
+
+  const resolved = await wt.ensureBaseRef(repo, "main");
+  expect(resolved.localFf).toBe("skipped-dirty");
+  // local main tip is unchanged
+  expect(revParse(repo, "main")).toBe(localTip);
+  // but baseRef is still the origin sha — new task starts fresh
+  expect(resolved.baseRef).toBe(originTip);
+  expect(resolved.hasUpstream).toBe(true);
+});
+
+// checked-out in another worktree → skipped-checked-out-elsewhere
+test("ensureBaseRef: branch checked out in another worktree → skipped-checked-out-elsewhere", async () => {
+  const wt = new WorktreeMgr();
+
+  // Create a local branch "feature" and push it
+  execFileSync("git", ["checkout", "-q", "-b", "feature"], {
+    cwd: repo,
+    stdio: "pipe",
+    env: GIT_ENV,
+  });
+  commit(repo, "feat.txt", "feature start", "start feature");
+  execFileSync("git", ["push", "-q", "-u", "origin", "feature"], { cwd: repo, stdio: "pipe" });
+  const featureTip = revParse(repo, "feature");
+  // Return to main
+  execFileSync("git", ["checkout", "-q", "main"], { cwd: repo, stdio: "pipe", env: GIT_ENV });
+
+  // Add a worktree that checks out "feature" elsewhere
+  const extraWt = join(tmpdir(), "shepherd-extra-wt-" + Date.now());
+  execFileSync("git", ["worktree", "add", extraWt, "feature"], { cwd: repo, stdio: "pipe" });
+
+  try {
+    // Advance origin/feature from a sibling clone
+    const other = mkdtempSync(join(tmpdir(), "shepherd-sibling-feat-"));
+    execFileSync("git", ["clone", "-q", "--branch", "feature", origin, other], { stdio: "pipe" });
+    commit(other, "feat.txt", "more feature", "advance feature on origin");
+    execFileSync("git", ["push", "-q", "origin", "feature"], { cwd: other, stdio: "pipe" });
+    const originFeatureTip = revParse(other, "feature");
+    rmSync(other, { recursive: true, force: true });
+
+    const resolved = await wt.ensureBaseRef(repo, "feature");
+    expect(resolved.localFf).toBe("skipped-checked-out-elsewhere");
+    // local feature tip is unchanged
+    expect(revParse(repo, "feature")).toBe(featureTip);
+    // baseRef is still the origin sha (task starts fresh)
+    expect(resolved.baseRef).toBe(originFeatureTip);
+  } finally {
+    // Clean up the extra worktree
+    execFileSync("git", ["worktree", "remove", "--force", extraWt], { cwd: repo, stdio: "pipe" });
+  }
+});
+
+// up to date → not-needed
+test("ensureBaseRef: already up to date → localFf=not-needed, behind=0", async () => {
+  const wt = new WorktreeMgr();
+  // Materialize epic/9-x locally (already at origin tip)
+  await wt.ensureBaseRef(repo, "epic/9-x");
+  const tip = revParse(repo, "epic/9-x");
+
+  // Run again — origin hasn't advanced, so no ff needed
+  const resolved = await wt.ensureBaseRef(repo, "epic/9-x");
+  expect(resolved.localFf).toBe("not-needed");
+  expect(resolved.behind).toBe(0);
+  expect(resolved.hasUpstream).toBe(true);
+  expect(resolved.localExists).toBe(true);
+  expect(revParse(repo, "epic/9-x")).toBe(tip);
+});
+
+// invalid base name → fail-closed, no throw
 test("ensureBaseRef: invalid base name is ignored (no throw, no branch)", async () => {
   const wt = new WorktreeMgr();
-  await wt.ensureBaseRef(repo, "--evil");
+  const resolved = await wt.ensureBaseRef(repo, "--evil");
+  expect(resolved.baseRef).toBe("--evil");
+  expect(resolved.behind).toBe(0);
+  expect(resolved.ahead).toBe(0);
+  expect(resolved.diverged).toBe(false);
+  expect(resolved.hasUpstream).toBe(false);
+  expect(resolved.localExists).toBe(false);
+  expect(resolved.localFf).toBe("none");
   expect(localBranches(repo)).toEqual(["main"]);
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1455,5 +1455,7 @@
   "feat_repo_shortcuts_body": "Im Bereich „Neue Aufgabe“ kannst du das Repository jetzt per Tastatur wechseln, ohne das Eingabefeld zu verlassen: Alt+[ und Alt+] blättern durch alle Repos, Alt+1–3 springen zu deinen zuletzt genutzten Repos und Alt+R öffnet die Repo-Auswahl. Auf dem Mac die Wahltaste (⌥) verwenden.",
   "newtask_upstream_checking": "Upstream wird geprüft…",
   "newtask_upstream_behind": "{count} hinter origin — Aufgabe startet vom neuesten Stand",
-  "newtask_upstream_diverged": "Von origin abgewichen ({behind} hinter, {ahead} voraus) — Aufgabe startet von lokal {base}"
+  "newtask_upstream_diverged": "Von origin abgewichen ({behind} hinter, {ahead} voraus) — Aufgabe startet von lokal {base}",
+  "feat_base_freshen_title": "Basis-Branch wird vom Upstream aktualisiert",
+  "feat_base_freshen_body": "Neue Aufgaben starten jetzt vom neuesten Upstream-Stand des Basis-Branches — Shepherd holt und spult beim Start vor (fast-forward), sodass du Upstream-Änderungen nach Abschluss nicht mehr von Hand einpflegen musst. Der New-Task-Dialog weist darauf hin, wenn deine Basis zurückliegt oder von origin abgewichen ist."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1452,5 +1452,8 @@
   "topbar_sheet_usage": "Auslastung",
   "newtask_repo_shortcuts_hint": "{mod}[ / {mod}] Repo wechseln · {mod}1–3 zuletzt · {mod}R filtern",
   "feat_repo_shortcuts_title": "Repo-Wechsel per Tastatur",
-  "feat_repo_shortcuts_body": "Im Bereich „Neue Aufgabe“ kannst du das Repository jetzt per Tastatur wechseln, ohne das Eingabefeld zu verlassen: Alt+[ und Alt+] blättern durch alle Repos, Alt+1–3 springen zu deinen zuletzt genutzten Repos und Alt+R öffnet die Repo-Auswahl. Auf dem Mac die Wahltaste (⌥) verwenden."
+  "feat_repo_shortcuts_body": "Im Bereich „Neue Aufgabe“ kannst du das Repository jetzt per Tastatur wechseln, ohne das Eingabefeld zu verlassen: Alt+[ und Alt+] blättern durch alle Repos, Alt+1–3 springen zu deinen zuletzt genutzten Repos und Alt+R öffnet die Repo-Auswahl. Auf dem Mac die Wahltaste (⌥) verwenden.",
+  "newtask_upstream_checking": "Upstream wird geprüft…",
+  "newtask_upstream_behind": "{count} hinter origin — Aufgabe startet vom neuesten Stand",
+  "newtask_upstream_diverged": "Von origin abgewichen ({behind} hinter, {ahead} voraus) — Aufgabe startet von lokal {base}"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1455,5 +1455,7 @@
   "feat_repo_shortcuts_body": "In the New Task pane you can now switch repositories from the keyboard without leaving the prompt: Alt+[ and Alt+] step through every repo, Alt+1–3 jump to your recent repos, and Alt+R opens the repo picker. On macOS use the Option (⌥) key.",
   "newtask_upstream_checking": "Checking upstream…",
   "newtask_upstream_behind": "{count} behind origin — task will start from latest",
-  "newtask_upstream_diverged": "Diverged from origin ({behind} behind, {ahead} ahead) — task will start from local {base}"
+  "newtask_upstream_diverged": "Diverged from origin ({behind} behind, {ahead} ahead) — task will start from local {base}",
+  "feat_base_freshen_title": "Base branch freshens from upstream",
+  "feat_base_freshen_body": "New tasks now start from the latest upstream tip of the base branch — Shepherd fetches and fast-forwards at launch, so you no longer fold in upstream changes by hand when the task is done. The New Task dialog flags when your base is behind or has diverged from origin."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1452,5 +1452,8 @@
   "topbar_sheet_usage": "Usage",
   "newtask_repo_shortcuts_hint": "{mod}[ / {mod}] switch repo · {mod}1–3 recent · {mod}R filter",
   "feat_repo_shortcuts_title": "Keyboard repo switching",
-  "feat_repo_shortcuts_body": "In the New Task pane you can now switch repositories from the keyboard without leaving the prompt: Alt+[ and Alt+] step through every repo, Alt+1–3 jump to your recent repos, and Alt+R opens the repo picker. On macOS use the Option (⌥) key."
+  "feat_repo_shortcuts_body": "In the New Task pane you can now switch repositories from the keyboard without leaving the prompt: Alt+[ and Alt+] step through every repo, Alt+1–3 jump to your recent repos, and Alt+R opens the repo picker. On macOS use the Option (⌥) key.",
+  "newtask_upstream_checking": "Checking upstream…",
+  "newtask_upstream_behind": "{count} behind origin — task will start from latest",
+  "newtask_upstream_diverged": "Diverged from origin ({behind} behind, {ahead} ahead) — task will start from local {base}"
 }

--- a/ui/src/lib/api.branchStatus.test.ts
+++ b/ui/src/lib/api.branchStatus.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { branchStatus } from "./api";
+
+function mockFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn(
+    async () => new Response(JSON.stringify(body), { status }),
+  ) as unknown as typeof fetch;
+}
+
+describe("branchStatus", () => {
+  it("fetches the correct URL with encoded params and returns parsed result", async () => {
+    const payload = { behind: 3, ahead: 0, diverged: false, hasUpstream: true, localExists: true };
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      calls.push(url as string);
+      return new Response(JSON.stringify(payload), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await branchStatus("/my/repo path", "feature/my-branch");
+    expect(result).toEqual(payload);
+    expect(calls[0]).toBe("/api/branch-status?repo=%2Fmy%2Frepo%20path&branch=feature%2Fmy-branch");
+  });
+
+  it("returns diverged:true when server reports diverged", async () => {
+    const payload = { behind: 2, ahead: 1, diverged: true, hasUpstream: true, localExists: true };
+    globalThis.fetch = mockFetch(200, payload);
+    const result = await branchStatus("/repo", "main");
+    expect(result.diverged).toBe(true);
+    expect(result.behind).toBe(2);
+    expect(result.ahead).toBe(1);
+  });
+
+  it("returns behind:0 ahead:0 diverged:false when up to date", async () => {
+    const payload = { behind: 0, ahead: 0, diverged: false, hasUpstream: true, localExists: true };
+    globalThis.fetch = mockFetch(200, payload);
+    const result = await branchStatus("/repo", "main");
+    expect(result.behind).toBe(0);
+    expect(result.diverged).toBe(false);
+  });
+
+  it("throws on non-ok response", async () => {
+    globalThis.fetch = mockFetch(500, { error: "internal server error" });
+    await expect(branchStatus("/repo", "main")).rejects.toThrow();
+  });
+
+  it("throws on 404", async () => {
+    globalThis.fetch = mockFetch(404, { error: "not found" });
+    await expect(branchStatus("/repo", "nonexistent")).rejects.toThrow();
+  });
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -374,6 +374,23 @@ export async function listBranches(
   return r.json();
 }
 
+export async function branchStatus(
+  repoPath: string,
+  branch: string,
+): Promise<{
+  behind: number;
+  ahead: number;
+  diverged: boolean;
+  hasUpstream: boolean;
+  localExists: boolean;
+}> {
+  const r = await fetch(
+    `/api/branch-status?repo=${encodeURIComponent(repoPath)}&branch=${encodeURIComponent(branch)}`,
+  );
+  if (!r.ok) throw await failed(r, "branch status");
+  return r.json();
+}
+
 export async function getTodo(repoPath: string): Promise<{ exists: boolean; content: string }> {
   const r = await fetch(`/api/todo?repo=${encodeURIComponent(repoPath)}`);
   if (!r.ok) throw await failed(r, "todo get");

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -4,7 +4,15 @@ import { page } from "vitest/browser";
 import "../../app.css";
 import type { Issue, RepoConfig, RepoEntry } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
-import { listIssues, getEpics, getTodo, listBranches, getRepoConfig, listRepos } from "$lib/api";
+import {
+  listIssues,
+  getEpics,
+  getTodo,
+  listBranches,
+  getRepoConfig,
+  listRepos,
+  branchStatus,
+} from "$lib/api";
 
 // Mock the API so the issue picker renders deterministically with no network.
 vi.mock("$lib/api", async (importOriginal) => {
@@ -17,6 +25,7 @@ vi.mock("$lib/api", async (importOriginal) => {
     listBranches: vi.fn(),
     getRepoConfig: vi.fn(),
     listRepos: vi.fn(),
+    branchStatus: vi.fn(),
   };
 });
 
@@ -28,6 +37,7 @@ const mockGetTodo = vi.mocked(getTodo);
 const mockListBranches = vi.mocked(listBranches);
 const mockGetRepoConfig = vi.mocked(getRepoConfig);
 const mockListRepos = vi.mocked(listRepos);
+const mockBranchStatus = vi.mocked(branchStatus);
 
 // A full RepoConfig with the plan gate flag overridable; the composer only reads
 // planGateEnabled but the store ingests the whole shape.
@@ -59,6 +69,7 @@ beforeEach(() => {
   mockListBranches.mockReset();
   mockGetRepoConfig.mockReset();
   mockListRepos.mockReset();
+  mockBranchStatus.mockReset();
   // Safe defaults so any test that mounts the picker (PromptSources) gets resolved
   // promises, never `undefined`; individual tests override as needed.
   mockGetTodo.mockResolvedValue({ exists: false, content: "" });
@@ -67,6 +78,14 @@ beforeEach(() => {
   mockListBranches.mockResolvedValue({ current: "main", branches: ["main"] });
   mockGetRepoConfig.mockResolvedValue(repoConfig(false));
   mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+  // Default: up to date — no hint rendered
+  mockBranchStatus.mockResolvedValue({
+    behind: 0,
+    ahead: 0,
+    diverged: false,
+    hasUpstream: true,
+    localExists: true,
+  });
 });
 
 afterEach(() => {
@@ -629,5 +648,54 @@ describe("NewTask repo shortcuts", () => {
     press("BracketRight", { altKey: false });
     // label must remain unchanged
     expect(triggerLabel()).toBe(repoA.name);
+  });
+});
+
+describe("NewTask upstream status hint", () => {
+  it("renders behind hint when branch is behind origin and not diverged", async () => {
+    mockBranchStatus.mockResolvedValue({
+      behind: 4,
+      ahead: 0,
+      diverged: false,
+      hasUpstream: true,
+      localExists: true,
+    });
+    render(NewTask, { props: base({ initialRepoPath: "/repo/upstream-behind" }) });
+    // The effect debounces 300ms then resolves; poll until the hint appears
+    await expect
+      .poll(() => document.querySelector(".nt-upstream")?.textContent, { timeout: 2000 })
+      .toContain("4");
+    expect(document.querySelector(".nt-upstream-warn")).toBeNull();
+  });
+
+  it("renders diverged hint (with warn styling) when branch has diverged", async () => {
+    mockBranchStatus.mockResolvedValue({
+      behind: 2,
+      ahead: 3,
+      diverged: true,
+      hasUpstream: true,
+      localExists: true,
+    });
+    render(NewTask, { props: base({ initialRepoPath: "/repo/upstream-diverged" }) });
+    await expect
+      .poll(() => document.querySelector(".nt-upstream-warn")?.textContent, { timeout: 2000 })
+      .toBeTruthy();
+    const hint = document.querySelector(".nt-upstream-warn")!;
+    expect(hint.textContent).toContain("2");
+    expect(hint.textContent).toContain("3");
+  });
+
+  it("renders nothing when branch is up to date (behind:0, diverged:false)", async () => {
+    mockBranchStatus.mockResolvedValue({
+      behind: 0,
+      ahead: 0,
+      diverged: false,
+      hasUpstream: true,
+      localExists: true,
+    });
+    render(NewTask, { props: base({ initialRepoPath: "/repo/upstream-utd" }) });
+    // Give the debounce time to fire and resolve
+    await new Promise((r) => setTimeout(r, 600));
+    expect(document.querySelector(".nt-upstream")).toBeNull();
   });
 });

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -3,6 +3,7 @@
   import {
     listRepos,
     listBranches,
+    branchStatus,
     getCommands,
     getEpics,
     uploadImage,
@@ -140,6 +141,14 @@
   // Echoed on the submit button so the destination repo is visible at commit time.
   const selectedRepoName = $derived(repos.find((r) => r.path === repoPath)?.name ?? "");
   let branches = $state<string[]>([]);
+  let upstream = $state<{
+    behind: number;
+    ahead: number;
+    diverged: boolean;
+    hasUpstream: boolean;
+    localExists: boolean;
+  } | null>(null);
+  let upstreamLoading = $state(false);
   // intentional one-time seed; NewTask remounts per open
   // svelte-ignore state_referenced_locally
   let images = $state<{ path: string; name: string }[]>(initialImages ? [...initialImages] : []);
@@ -235,6 +244,40 @@
       .catch(() => {
         branches = [];
       });
+  });
+
+  // Fetch upstream status for the selected base branch; debounced 300 ms with a
+  // stale-request guard so in-flight requests from a previous (repo, branch) pair
+  // are silently dropped.
+  $effect(() => {
+    const rp = repoPath,
+      b = baseBranch;
+    upstream = null;
+    if (!rp || !b) {
+      upstreamLoading = false;
+      return;
+    }
+    upstreamLoading = true;
+    let cancelled = false;
+    const t = setTimeout(() => {
+      branchStatus(rp, b)
+        .then((s) => {
+          if (!cancelled && rp === repoPath && b === baseBranch) {
+            upstream = s;
+            upstreamLoading = false;
+          }
+        })
+        .catch(() => {
+          if (!cancelled && rp === repoPath && b === baseBranch) {
+            upstream = null;
+            upstreamLoading = false;
+          }
+        });
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
   });
 
   // Seed the plan-gate checkbox from the selected repo's stored default. ensure()
@@ -692,6 +735,19 @@
     {:else}
       <input id="nt-base" bind:value={baseBranch} placeholder={m.newtask_branch_placeholder()} />
     {/if}
+    {#if upstreamLoading}
+      <span class="nt-upstream micro">{m.newtask_upstream_checking()}</span>
+    {:else if upstream?.diverged}
+      <span class="nt-upstream micro nt-upstream-warn">
+        {m.newtask_upstream_diverged({
+          behind: upstream.behind,
+          ahead: upstream.ahead,
+          base: baseBranch,
+        })}
+      </span>
+    {:else if upstream && upstream.behind > 0}
+      <span class="nt-upstream micro">{m.newtask_upstream_behind({ count: upstream.behind })}</span>
+    {/if}
 
     <!-- Per-task run settings. Plan gate gets its own full-width row so its explainer
          reads on one line; Model + Sandbox share a 50/50 row beneath. -->
@@ -904,6 +960,17 @@
     text-transform: uppercase;
     color: var(--color-muted);
     margin-top: 6px;
+  }
+  .nt-upstream {
+    display: block;
+    margin-top: 4px;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+  }
+  .nt-upstream-warn {
+    color: var(--color-amber);
   }
   .prompt-wrap {
     position: relative;

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -970,7 +970,9 @@
     color: var(--color-muted);
   }
   .nt-upstream-warn {
-    color: var(--color-amber);
+    /* Blue = informational accent; amber is reserved for --status-running (armed/active),
+       and red/blocked would be too alarming for a heads-up "task will start from local". */
+    color: var(--color-blue);
   }
   .prompt-wrap {
     position: relative;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1025,4 +1025,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_repo_shortcuts_body",
     targetId: "nt-repo",
   },
+  {
+    // No targetId: the freshen happens at task-launch time (no persistent anchor
+    // element) and the New Task behind/diverged hint lives inside the New Task dialog
+    // (closed by default) — surface via the What's-New drawer only. 1.33.0 is the
+    // latest released tag, so this ships in 1.34.0.
+    id: "base-freshen",
+    sinceVersion: "1.34.0",
+    titleKey: "feat_base_freshen_title",
+    bodyKey: "feat_base_freshen_body",
+  },
 ];


### PR DESCRIPTION
## Why

When a new task launches off a base branch that has moved upstream, Shepherd used to base the worktree on the **stale local tip** — and `ensureBaseRef` skipped the fetch entirely for the main clone's currently-checked-out branch. For any repo whose local clone isn't kept fresh (i.e. everything except Shepherd itself, which `bun run update` keeps current), every task started behind `origin`, forcing a manual fold-in of upstream changes when the task was done.

This makes base-branch freshening an explicit step at launch.

## What

- **Launch-time freshening.** `create()` now evaluates the base against its `origin` upstream and bases the new worktree on the **fresh upstream tip**, fast-forwarding the operator's local base when it's safe (the "pull"). Never blocks launch.
- **Diverged base → keep local, warn.** If the local base has commits not on origin (no clean fast-forward), the task starts from the local tip and the dialog flags it — local work is never silently dropped or rebased.
- **New Task hint.** The dialog shows `N behind origin — will start from latest`, or a diverged warning, before you launch (`GET /api/branch-status`, bounded fetch + 10s TTL cache).

## How (design notes)

- Upstream tip read from a **per-branch tracking ref** (`+<base>:refs/remotes/origin/<base>`, forced refspec) — **not** `FETCH_HEAD`, so concurrent launches/status checks for different bases never cross. Works in single-branch clones.
- Status fields derived independently: `hasUpstream` from `origin/<base>`, `localExists` from `heads/<base>`; behind/ahead only when both resolve. **Fail-closed only** when the fetch failed *and* no `origin/<base>` resolves — a missing *local* branch is the legitimate origin-only (epic) case, not a failure.
- The `git fetch` is **bounded** (`timeout 5s` + `SIGKILL` + `http.lowSpeedLimit/Time`) so an unreachable/slow origin can't hang the launch.
- Local fast-forward: checked-out base gated on a clean `git status --porcelain` before `merge --ff-only`; non-checked-out uses `git branch -f`; every skip (dirty tree, diverged, checked-out-in-another-worktree) is recorded in `localFf` and never throws. The new worktree still bases on the fresh sha even when the local ff is skipped.
- `Session.baseBranch` still stores the **logical name** (never a sha); the resolved ref (possibly a sha) only feeds `worktree.create`.
- All new git calls are async (no sync exec on the server loop). Endpoint cache is bounded (prune-expired + size cap).

## Tests & gates

- New: `test/upstream-status.test.ts`, `test/branch-status-endpoint.test.ts`, `ui/.../api.branchStatus.test.ts`, NewTask hint cases; rewritten `worktree-ensure-base-ref.test.ts` (the old "checked-out branch is NOT fetched" assertion is **intentionally inverted** — it now fast-forwards).
- Green: root `tsc` / `lint` / 3478 tests; UI `check` / `check:i18n` (1456 keys, EN+DE parity) / 1422 tests; `fallow@2.97.0` audit; branch hygiene; feature-catalog (`base-freshen` @ 1.34.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
