### PR TITLE
fix(ui): quiet redraw control to an icon-only wrench

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -607,7 +607,6 @@
   "viewport_resume_title": "Session zurückholen",
   "viewport_resume_sub": "Tippen zum Fortsetzen",
   "viewport_resume_failed": "Konnte nicht fortsetzen. Nochmal tippen",
-  "viewport_redraw_btn": "Neu zeichnen",
   "viewport_redraw_title": "Neu zeichnen: gestauchten Terminal-Text reparieren (Testvarianten)",
   "redrawmenu_label": "Neuzeichnen-Varianten",
   "redrawmenu_nudge": "Resize-Impuls",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -607,7 +607,6 @@
   "viewport_resume_title": "Resume session",
   "viewport_resume_sub": "Tap to bring it back",
   "viewport_resume_failed": "Couldn't resume. Tap to retry",
-  "viewport_redraw_btn": "Redraw",
   "viewport_redraw_title": "Redraw: fix squished terminal text (test variants)",
   "redrawmenu_label": "Redraw variants",
   "redrawmenu_nudge": "Resize nudge",

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2237,6 +2237,7 @@
       {#if tab === "term"}
         <button
           class="vp-redraw"
+          class:compact
           bind:this={redrawBtnEl}
           type="button"
           aria-haspopup="menu"
@@ -2245,8 +2246,18 @@
           title={m.viewport_redraw_title()}
           aria-label={m.viewport_redraw_title()}
         >
-          <span aria-hidden="true">↔</span>
-          {#if !compact}<span>{m.viewport_redraw_btn()}</span>{/if}
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            ><path
+              d="M14.7 6.3a4 4 0 0 0-5.4 5.4L3 18v3h3l6.3-6.3a4 4 0 0 0 5.4-5.4l-2.6 2.6-2.4-.6-.6-2.4 2.6-2.6Z"
+            /></svg
+          >
         </button>
         {#if redrawOpen && redrawBtnEl}
           <RedrawMenu
@@ -3117,26 +3128,33 @@
   /* Resume: the primary action of a parked session, so it stays on the identity
      row (not in the strip). Quiet neutral (not destructive, not "ready-complete"
      → no green/red), brightening to ink on hover. */
-  /* redraw-variants toggle: mirrors .vp-resume's quiet ghost styling so the
-     trailing header controls read as one set */
+  /* redraw-variants toggle: icon-only wrench, ghost styling matching the
+     trailing header controls cluster; compact class enlarges to touch target */
   .vp-redraw {
     flex-shrink: 0;
     display: inline-flex;
     align-items: center;
-    gap: 5px;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
     background: transparent;
     border: 1px solid transparent;
     border-radius: 2px;
     color: var(--color-faint);
-    font-family: var(--font-mono);
-    font-size: var(--fs-micro);
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    padding: 2px 7px;
+    padding: 0;
     cursor: pointer;
     transition:
       color 0.12s,
       border-color 0.12s;
+  }
+  .vp-redraw.compact {
+    width: var(--mobile-actionbar-hit);
+    height: var(--mobile-actionbar-hit);
+  }
+  .vp-redraw svg {
+    width: 18px;
+    height: 18px;
+    display: block;
   }
   .vp-redraw:hover,
   .vp-redraw[aria-expanded="true"] {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2229,7 +2229,7 @@
         </button>
       {/if}
       <!-- squished-history repair variants under field test (see redrawNudge etc.
-           above) — a quiet ↔ toggle opening an anchored popover with the four
+           above) — a quiet icon-only wrench toggle opening an anchored popover with the four
            candidates. The losing variants get removed after testing. Terminal-tab
            only: every variant acts on the terminal, so the control can't issue a
            silent nudge/fullscreen against a hidden mount from another tab (the


### PR DESCRIPTION
## What
The terminal-header **Redraw** control was a full labelled `↔ REDRAW` button riding the trailing action row of every terminal — as loud as Decommission, despite still being a field-test diagnostic. Its `↔` glyph also twinned with the adjacent Resume `↻`. This buries it: it becomes a single quiet **icon-only wrench** button in the same slot, named for AT/tooltip via `aria-label`.

Before: `↔ REDRAW` (labelled, prominent) · After: a wrench icon button (28px desktop / 44px touch target).

## Why
The operator reported the control sits too prominently "where it sits" and that text "runs over its boundaries". It's useful occasionally but not something to ship loudly yet.

## Decisions (confirmed interactively with the operator during planning)
- **Burial = icon-only, in place.** Keep it in the same cluster, just quiet it. Relocating into a `⋯` overflow menu was considered and **deferred** until that menu holds more than one item.
- **Icon = wrench (repair)** — bold, non-arrow, reads as "fix this", and stops mirroring Resume's `↻`.
- **Scope kept narrow:** only `.vp-redraw` changes. The broader "audit all header glyphs" ask (Resume/decom/caret/fold/upload sizing + a shared recipe) is split out to **#767** to avoid header-density / mistap regressions in this PR.

## Changes
- `Viewport.svelte`: `.vp-redraw` contents → inline Lucide wrench `<svg aria-hidden>`; visible label dropped; all behaviour wiring (`aria-haspopup`/`aria-expanded`/toggle/anchor/`title`/`aria-label`) preserved. CSS reworked to a square icon button — 28px desktop box / 18px icon with the existing ghost hover language, and a 44px touch target on compact via the `--mobile-actionbar-hit` token. Tokens only.
- `messages/en.json` + `de.json`: removed the now-orphaned `viewport_redraw_btn` key (parity preserved).
- `RedrawMenu.svelte`: **no change** — analysed the reported popover overflow; the menu is `width: min(320px, calc(100vw-16px))` with wrapping `.rm-hint` and no `white-space:nowrap`, so hint text cannot spill on current code (the original screenshot predates that fixed width). The desktop label — removed here — was the real overflow culprit.

## Not a feature
Declutter of an existing control → committed `fix(ui)`, no `feature-announcements.ts` entry (existing `viewport-redraw-menu` entry stays).

## Verification
- `bun run check` — 0 errors
- `bun run check:i18n` — 2 locales in parity (1452 keys)
- `bun run test` — 1428 passed
- `fallow audit --base origin/main` — no issues in changed files
- Rebased onto latest `origin/main` (linear, single commit)

## Follow-up
- #767 — header-wide glyph recognisability + tap-target audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)