### PR TITLE
fix(ui): restore discoverable learnings approval via a global TopBar button

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1456,5 +1456,6 @@
   "newtask_upstream_behind": "{count} hinter origin — Aufgabe startet vom neuesten Stand",
   "newtask_upstream_diverged": "Von origin abgewichen ({behind} hinter, {ahead} voraus) — Aufgabe startet von lokal {base}",
   "feat_base_freshen_title": "Basis-Branch wird vom Upstream aktualisiert",
-  "feat_base_freshen_body": "Neue Aufgaben starten jetzt vom neuesten Upstream-Stand des Basis-Branches — Shepherd holt und spult beim Start vor (fast-forward), sodass du Upstream-Änderungen nach Abschluss nicht mehr von Hand einpflegen musst. Der New-Task-Dialog weist darauf hin, wenn deine Basis zurückliegt oder von origin abgewichen ist."
+  "feat_base_freshen_body": "Neue Aufgaben starten jetzt vom neuesten Upstream-Stand des Basis-Branches — Shepherd holt und spult beim Start vor (fast-forward), sodass du Upstream-Änderungen nach Abschluss nicht mehr von Hand einpflegen musst. Der New-Task-Dialog weist darauf hin, wenn deine Basis zurückliegt oder von origin abgewichen ist.",
+  "topbar_learnings_tip": "Vorgeschlagene Hausregeln über alle deine Repos prüfen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1456,5 +1456,6 @@
   "newtask_upstream_behind": "{count} behind origin — task will start from latest",
   "newtask_upstream_diverged": "Diverged from origin ({behind} behind, {ahead} ahead) — task will start from local {base}",
   "feat_base_freshen_title": "Base branch freshens from upstream",
-  "feat_base_freshen_body": "New tasks now start from the latest upstream tip of the base branch — Shepherd fetches and fast-forwards at launch, so you no longer fold in upstream changes by hand when the task is done. The New Task dialog flags when your base is behind or has diverged from origin."
+  "feat_base_freshen_body": "New tasks now start from the latest upstream tip of the base branch — Shepherd fetches and fast-forwards at launch, so you no longer fold in upstream changes by hand when the task is done. The New Task dialog flags when your base is behind or has diverged from origin.",
+  "topbar_learnings_tip": "Review proposed house rules across all your repos"
 }

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -998,3 +998,81 @@ describe("TopBar — mobile gear sheet stays open on in-sheet clicks (dismissOnO
       .not.toBeInTheDocument();
   });
 });
+
+describe("TopBar — global learnings button", () => {
+  const idleSession = [{ id: "d1", status: "done" }] as unknown as Session[];
+
+  it("desktop, proposed: shows learnings button with correct aria-label and calls onlearnings", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const onlearnings = vi.fn();
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: idleSession,
+      learnings: 3,
+      onlearnings,
+    });
+    const btn = page.getByRole("button", { name: m.learnings_open_aria({ count: 3 }) });
+    await expect.element(btn).toBeVisible();
+    await btn.click();
+    expect(onlearnings).toHaveBeenCalledTimes(1);
+  });
+
+  it("desktop, none: no learnings button when learnings=0 and learningsCurate=0", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: idleSession,
+      learnings: 0,
+      learningsCurate: 0,
+    });
+    const hud = document.querySelector<HTMLElement>(".hud");
+    expect(hud, "TopBar .hud mounted").not.toBeNull();
+    expect(hud!.querySelector(".learnings-btn"), "no learnings button when none").toBeNull();
+  });
+
+  it("desktop, curate-only: shows button with curate aria-label and calls onlearnings", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const onlearnings = vi.fn();
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: idleSession,
+      learnings: 0,
+      learningsCurate: 2,
+      onlearnings,
+    });
+    const btn = page.getByRole("button", { name: m.learnings_open_curate_aria({ count: 2 }) });
+    await expect.element(btn).toBeVisible();
+    await btn.click();
+    expect(onlearnings).toHaveBeenCalledTimes(1);
+  });
+
+  it("mobile sheet: learnings row appears after opening gear sheet and calls onlearnings", async () => {
+    await page.viewport(390, 800);
+    document.body.style.width = "390px";
+    const onlearnings = vi.fn();
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.mobile,
+      sessions: idleSession,
+      learnings: 2,
+      onlearnings,
+    });
+    // Open the sheet by clicking the gear
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    // The sheet should contain the learnings row
+    const learningsBtn = page.getByRole("button", { name: m.learnings_open_aria({ count: 2 }) });
+    await expect.element(learningsBtn).toBeInTheDocument();
+    await learningsBtn.click();
+    expect(onlearnings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -112,6 +112,7 @@
     herdrUpdateAvailable,
     needsYou,
     whatsNew,
+    learnings: 0,
   });
   const plan = $derived(topBarPlan(mode, chrome));
 

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -60,6 +60,9 @@
     workingBlocked = {},
     diagnosticsOverall = "ok",
     ondiagnose,
+    learnings = 0,
+    learningsCurate = 0,
+    onlearnings,
   }: {
     sessions: Session[];
     nowMs: number;
@@ -87,6 +90,12 @@
     diagnosticsOverall?: DiagnosticState;
     /** Called when the health pip is clicked — should open Settings → Diagnose tab. */
     ondiagnose?: () => void;
+    /** Count of proposed learnings awaiting approve/dismiss across all repos. */
+    learnings?: number;
+    /** Count of over-budget ("curate") active rules across all repos. */
+    learningsCurate?: number;
+    /** Opens the global learnings drawer. */
+    onlearnings?: () => void;
   } = $props();
 
   // tally click: toggle — clicking the active status clears the filter
@@ -107,12 +116,15 @@
   // (~1000px) the #247/#322 overflow fixes targeted. The halt e-stop is NOT a bar
   // badge — it folds into the always-present gear menu — so it never counts here.
   const mode = $derived(modeOf(mobile, touch));
+  const learningsPresent = $derived(learnings > 0 || learningsCurate > 0);
+  // Badge shows proposed count when any proposed, else the curate count
+  const learningsCount = $derived(learnings > 0 ? learnings : learningsCurate);
   const chrome = $derived({
     updateAvailable,
     herdrUpdateAvailable,
     needsYou,
     whatsNew,
-    learnings: 0,
+    learnings: learnings + learningsCurate,
   });
   const plan = $derived(topBarPlan(mode, chrome));
 
@@ -338,7 +350,12 @@
   // Composed alongside the halt-pip (.halt-pip) — the two use different corners
   // (.sheet-pip sits bottom-left; .halt-pip owns top-right; .gear-dot owns top/bottom-right).
   const sheetPip = $derived(
-    mobile && (updateAvailable || herdrUpdateAvailable || diagnosticsOverall !== "ok" || whatsNew),
+    mobile &&
+      (updateAvailable ||
+        herdrUpdateAvailable ||
+        diagnosticsOverall !== "ok" ||
+        whatsNew ||
+        learningsPresent),
   );
   function clickGear() {
     if (!gearOpensMenu) {
@@ -847,6 +864,25 @@
         <span class="health-dot" aria-hidden="true"></span>
       </button>
     {/if}
+    <!-- ✦ LEARNINGS: global entry point to review proposed house rules across all repos.
+         Desktop-only badge (mobile folds into the gear bottom sheet). Stays off status
+         hues — ✦ is neutral chrome, not an attention state (Four-Light Rule). -->
+    {#if !mobile && learningsPresent}
+      <button
+        class="learnings-btn"
+        class:compact={compactBadges}
+        type="button"
+        onclick={() => onlearnings?.()}
+        title={m.topbar_learnings_tip()}
+        aria-label={learnings > 0
+          ? m.learnings_open_aria({ count: learnings })
+          : m.learnings_open_curate_aria({ count: learningsCurate })}
+      >
+        <span class="learn-glyph" aria-hidden="true">✦</span>
+        {#if !compactBadges}<span class="learn-label">{m.learnings_title()}</span>{/if}
+        <span class="learn-n">{learningsCount}</span>
+      </button>
+    {/if}
     <!-- The gear adapts to state: idle herd → a click opens Settings directly;
          when something is haltable it becomes a menu button opening the e-stop above
          the Settings entry. A pip on the gear is the only at-rest cue that there's a
@@ -1074,6 +1110,24 @@
       </button>
     {/if}
 
+    <!-- Learnings row: review proposed house rules across all repos -->
+    {#if learningsPresent}
+      <button
+        type="button"
+        class="sheet-item"
+        onclick={() => {
+          closeMenu();
+          onlearnings?.();
+        }}
+        aria-label={learnings > 0
+          ? m.learnings_open_aria({ count: learnings })
+          : m.learnings_open_curate_aria({ count: learningsCurate })}
+      >
+        <span class="sheet-glyph" aria-hidden="true">✦</span>
+        <span class="sheet-label">{m.learnings_title()} · {learningsCount}</span>
+      </button>
+    {/if}
+
     <div class="sheet-sep"></div>
 
     <!-- Halt e-stop: two-step arm→confirm, same as desktop -->
@@ -1218,6 +1272,48 @@
     cursor: pointer;
     white-space: nowrap;
     flex-shrink: 0;
+  }
+  /* ✦ LEARNINGS: quiet neutral chrome control — review proposed house rules across all
+     repos. ✦ stays on the ink/faint ramp (no status hue). */
+  .learnings-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: var(--fs-meta);
+    padding: 5px 10px;
+    border-radius: 2px;
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .learnings-btn:hover {
+    color: var(--color-ink);
+    border-color: var(--color-ink);
+  }
+  .learnings-btn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-ink);
+  }
+  .learn-glyph {
+    font-size: var(--fs-lg);
+    line-height: 1;
+  }
+  /* Compact: icon-only, ≥44px tap target. */
+  .learnings-btn.compact {
+    justify-content: center;
+    min-width: 44px;
+    padding: 8px 10px;
+    letter-spacing: 0;
+  }
+  .learn-n {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
   }
   /* Gear menu: a small popup hung below-right of the gear, holding the e-stop (when
      working) above the Settings entry. Quiet panel chrome matching the gauge popover. */
@@ -2096,6 +2192,7 @@
     .gear,
     .needsyou,
     .needsyou.compact,
+    .learnings-btn,
     .gauge-btn,
     .update-badge {
       min-height: 44px;

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -4,6 +4,7 @@ import {
   chipHasTelemetry,
   chipRailVisible,
   enabledDrains,
+  globalLearningsCounts,
   mergeTrainIsAttention,
   mergeTrainLabel,
   pausedText,
@@ -450,5 +451,50 @@ describe("shouldClearRepoFilter", () => {
 
   it("TRUE when no chips remain (all sessions ended)", () => {
     expect(shouldClearRepoFilter("/repos/a", [])).toBe(true);
+  });
+});
+
+// ─── globalLearningsCounts ────────────────────────────────────────────────────
+
+describe("globalLearningsCounts", () => {
+  it("returns zeros for empty inputs", () => {
+    expect(globalLearningsCounts([], [])).toEqual({ proposed: 0, curate: 0 });
+  });
+
+  it("proposed equals items.length regardless of repoPath", () => {
+    const items = [
+      learning({ id: "l1", repoPath: "/repos/a" }),
+      learning({ id: "l2", repoPath: "/repos/b" }),
+      learning({ id: "l3", repoPath: "/repos/c" }),
+    ];
+    expect(globalLearningsCounts(items, [])).toEqual({ proposed: 3, curate: 0 });
+  });
+
+  it("curate sums non-injected rules across enabled injectables", () => {
+    const injectables = [
+      injectable({ repoPath: "/repos/a", rules: [rule(true), rule(false), rule(false)] }), // 2 over-budget
+      injectable({ repoPath: "/repos/b", rules: [rule(false)] }), // 1 over-budget
+    ];
+    expect(globalLearningsCounts([], injectables)).toEqual({ proposed: 0, curate: 3 });
+  });
+
+  it("disabled injectable contributes 0 to curate even with non-injected rules", () => {
+    const injectables = [
+      injectable({ repoPath: "/repos/a", enabled: false, rules: [rule(false), rule(false)] }),
+    ];
+    expect(globalLearningsCounts([], injectables)).toEqual({ proposed: 0, curate: 0 });
+  });
+
+  it("injected rules (injected=true) do not count toward curate", () => {
+    const injectables = [
+      injectable({ repoPath: "/repos/a", rules: [rule(true), rule(true)] }), // all injected → 0 over-budget
+    ];
+    expect(globalLearningsCounts([], injectables)).toEqual({ proposed: 0, curate: 0 });
+  });
+
+  it("combines proposed and curate independently", () => {
+    const items = [learning({ id: "l1" }), learning({ id: "l2" })];
+    const injectables = [injectable({ rules: [rule(false)] })];
+    expect(globalLearningsCounts(items, injectables)).toEqual({ proposed: 2, curate: 1 });
   });
 });

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -99,6 +99,20 @@ export function shouldClearRepoFilter(repoFilter: string | null, chips: RepoChip
   return repoFilter !== null && !chips.some((c) => c.repoPath === repoFilter);
 }
 
+/** Global learnings badge counts for the TopBar: proposed rules awaiting review
+ *  (across all repos) and over-budget ("curate") active rules across all repos.
+ *  Derived from the learnings store, NOT repoChips — so the badge reflects repos
+ *  with no live session too (the drawer shows those). */
+export function globalLearningsCounts(
+  items: Learning[],
+  injectable: RepoInjectable[],
+): { proposed: number; curate: number } {
+  return {
+    proposed: items.length,
+    curate: injectable.reduce((sum, r) => sum + overBudgetCount(r), 0),
+  };
+}
+
 /** Whether the `queued` indicator is an interactive trigger (opens the queue
  *  popover) rather than inert text — true only when something is actually queued. */
 export function queueOpenable(d: DrainStatus): boolean {

--- a/ui/src/lib/components/top-bar-layout.test.ts
+++ b/ui/src/lib/components/top-bar-layout.test.ts
@@ -8,16 +8,17 @@ import { badgeCount, topBarPlan, type Mode, type ChromeState } from "./top-bar-l
 
 const MODES: Mode[] = ["mobile", "touch-desktop", "desktop"];
 
-// Build every ChromeState from a 4-bit mask over the four badge-presence inputs.
+// Build every ChromeState from a 5-bit mask over the five badge-presence inputs.
 // The halt e-stop is NOT a bar badge (it lives in the gear menu), so it never
 // appears here.
-const ALL = 0b1111; // all four badges present
+const ALL = 0b11111; // all five badges present
 function stateFromMask(mask: number): ChromeState {
   return {
     updateAvailable: !!(mask & 1),
     herdrUpdateAvailable: !!(mask & 2),
     needsYou: mask & 4 ? 1 : 0,
     whatsNew: !!(mask & 8),
+    learnings: mask & 16 ? 1 : 0,
   };
 }
 
@@ -27,20 +28,63 @@ function expectedCount(s: ChromeState): number {
     (s.updateAvailable ? 1 : 0) +
     (s.herdrUpdateAvailable ? 1 : 0) +
     (s.needsYou > 0 ? 1 : 0) +
-    (s.whatsNew ? 1 : 0)
+    (s.whatsNew ? 1 : 0) +
+    (s.learnings > 0 ? 1 : 0)
   );
 }
 
 describe("badgeCount", () => {
-  it("counts each present badge once across all 16 presence combos", () => {
+  it("counts each present badge once across all 32 presence combos", () => {
     for (let mask = 0; mask <= ALL; mask++) {
       const s = stateFromMask(mask);
       expect(badgeCount(s)).toBe(expectedCount(s));
     }
   });
+
+  it("returns 0 for all-zero/all-false state", () => {
+    const s: ChromeState = {
+      updateAvailable: false,
+      herdrUpdateAvailable: false,
+      needsYou: 0,
+      whatsNew: false,
+      learnings: 0,
+    };
+    expect(badgeCount(s)).toBe(0);
+  });
+
+  it("counts learnings badge: learnings:3 → 1, learnings:0 → 0", () => {
+    const withLearnings: ChromeState = {
+      updateAvailable: false,
+      herdrUpdateAvailable: false,
+      needsYou: 0,
+      whatsNew: false,
+      learnings: 3,
+    };
+    expect(badgeCount(withLearnings)).toBe(1);
+
+    const noLearnings: ChromeState = {
+      updateAvailable: false,
+      herdrUpdateAvailable: false,
+      needsYou: 0,
+      whatsNew: false,
+      learnings: 0,
+    };
+    expect(badgeCount(noLearnings)).toBe(0);
+  });
+
+  it("sums learnings with another badge: needsYou:1 + learnings:2 → 2", () => {
+    const s: ChromeState = {
+      updateAvailable: false,
+      herdrUpdateAvailable: false,
+      needsYou: 1,
+      whatsNew: false,
+      learnings: 2,
+    };
+    expect(badgeCount(s)).toBe(2);
+  });
 });
 
-describe("topBarPlan — exhaustive 3 modes × 16 presence combos", () => {
+describe("topBarPlan — exhaustive 3 modes × 32 presence combos", () => {
   // Desktop compaction is measurement-driven (TopBar.svelte / TopBar.browser.test.ts),
   // so the pure layer always returns false for desktop here.
   it("hideClockTime only on touch-desktop (>=1 badge); desktop + mobile never", () => {
@@ -96,5 +140,31 @@ describe("regression anchors (#322 / #247)", () => {
     const plan = topBarPlan("mobile", all);
     expect(plan.hideClockTime).toBe(false);
     expect(plan.compactBadges).toBe(false);
+  });
+
+  it("learnings>0 as lone badge on touch-desktop: drops clock, does not compact", () => {
+    const s: ChromeState = {
+      updateAvailable: false,
+      herdrUpdateAvailable: false,
+      needsYou: 0,
+      whatsNew: false,
+      learnings: 5,
+    };
+    const plan = topBarPlan("touch-desktop", s);
+    expect(plan.hideClockTime).toBe(true);
+    expect(plan.compactBadges).toBe(false);
+  });
+
+  it("learnings>0 plus one more badge on touch-desktop: compactBadges", () => {
+    const s: ChromeState = {
+      updateAvailable: false,
+      herdrUpdateAvailable: false,
+      needsYou: 1,
+      whatsNew: false,
+      learnings: 2,
+    };
+    const plan = topBarPlan("touch-desktop", s);
+    expect(plan.hideClockTime).toBe(true);
+    expect(plan.compactBadges).toBe(true);
   });
 });

--- a/ui/src/lib/components/top-bar-layout.ts
+++ b/ui/src/lib/components/top-bar-layout.ts
@@ -21,6 +21,8 @@ export interface ChromeState {
   herdrUpdateAvailable: boolean;
   needsYou: number;
   whatsNew: boolean;
+  /** pending learnings to review across all repos; >0 renders the global learnings badge */
+  learnings: number;
 }
 
 export interface TopBarPlan {
@@ -43,7 +45,8 @@ export function badgeCount(s: ChromeState): number {
     (s.updateAvailable ? 1 : 0) +
     (s.herdrUpdateAvailable ? 1 : 0) +
     (s.needsYou > 0 ? 1 : 0) +
-    (s.whatsNew ? 1 : 0)
+    (s.whatsNew ? 1 : 0) +
+    (s.learnings > 0 ? 1 : 0)
   );
 }
 

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -98,7 +98,11 @@
   import HerdGrid from "$lib/components/HerdGrid.svelte";
   import QueueStrip from "$lib/components/QueueStrip.svelte";
   import RepoSwitcher from "$lib/components/RepoSwitcher.svelte";
-  import { repoChipRows, shouldClearRepoFilter } from "$lib/components/queue-strip";
+  import {
+    globalLearningsCounts,
+    repoChipRows,
+    shouldClearRepoFilter,
+  } from "$lib/components/queue-strip";
   import BacklogView from "$lib/components/BacklogView.svelte";
   import BacklogOverlay from "$lib/components/BacklogOverlay.svelte";
   import UpdateModal from "$lib/components/UpdateModal.svelte";
@@ -203,6 +207,7 @@
   const repoChips = $derived(
     repoChipRows(store.sessions, store.drain, learnings.items, learnings.injectable),
   );
+  const learningsCounts = $derived(globalLearningsCounts(learnings.items, learnings.injectable));
   // Clear the filter only when its repo has no live session left (no chip) —
   // a filter on a vanished repo would strand an empty view.
   $effect(() => {
@@ -1513,6 +1518,12 @@
         onherdrupdate={() => (showHerdrUpdate = true)}
         whatsNew={whatsNewDotOn}
         onwhatsnew={() => (showWhatsNew = true)}
+        learnings={learningsCounts.proposed}
+        learningsCurate={learningsCounts.curate}
+        onlearnings={() => {
+          learningsRepo = null;
+          showLearnings = true;
+        }}
         {statusFilter}
         onstatusfilter={(s) => (statusFilter = s)}
         workingBlocked={store.workingBlocked}


### PR DESCRIPTION
## Problem

Approving distilled learnings had become effectively undiscoverable. The only entry point to the
`LearningsDrawer` was a per-repo `✦` button buried in the RepoSwitcher's telemetry line, which renders
only for an active filtered chip or the lone-repo band **on desktop**. On mobile it was suppressed
entirely (`&& !mobile`, added in #720), and the per-chip `✦` markers are decorative (`aria-hidden`) and
hidden for a single repo (`chips.length < 2`). Net effect: no reliable way to find learnings approval,
and on mobile no way at all.

## What changed

Adds a persistent, global **"Learnings"** entry point in the TopBar that opens the existing drawer in
its all-repos view — restoring discoverable approval without touching the RepoSwitcher.

- **Desktop:** a right-cluster badge mirroring the existing `.rundown-btn`; it participates in the
  measured overflow/compaction machinery via `ChromeState.learnings` + `badgeCount`, collapsing to its
  `✦` icon + count under crowding.
- **Mobile:** a row in the gear bottom sheet (the established #720 home for secondary chrome), with the
  gear `sheetPip` cue when learnings are pending.
- Shows whenever there's actionable content — **proposed** rules awaiting review, or **over-budget
  ("curate")** active rules — derived from the learnings **store** (`learnings.items` /
  `learnings.injectable`), *not* `repoChips` (which excludes repos with no live session, so the badge
  reflects everything the drawer can act on).
- Opens the drawer with `focusRepo = null` (all repos) — no drawer changes needed.

The `✦` glyph stays on the neutral ink/faint ramp (Four-Light Rule); all colors/sizes use design
tokens. A new all-repos tooltip key `topbar_learnings_tip` was added (EN+DE) — the existing
`learnings_badge_tip` says "for this repo only, not global" and is **not** reused.

## Intentional scope

- The per-repo `✦` chip markers are **unchanged** (decorative cues). The single-repo display gap is by
  design now covered by the always-present global button.
- Not surfaced on the mobile **per-session detail** screen (the chrome header is hidden there); learnings
  are a herd-overview concern. See `.shepherd-plan.md` for the full reasoning (the plan went through two
  rounds of adversarial review).

## Testing

- New unit tests: `globalLearningsCounts` (enabled/disabled/injected/combined), `badgeCount` learnings
  participation (incl. touch-desktop crowding).
- New browser tests: desktop proposed / none / curate-only, and the mobile gear-sheet row — each
  asserting the `onlearnings` callback and the zero-state hiding the button.
- Full UI suite green: **1427/1427** tests (102 files); `bun run check` 0 errors; `check:i18n` parity
  (1452 keys/locale).

## Why `fix(ui)`

This restores a regressed-out-of-reach entry point to an existing feature (the approval flow + drawer
already existed) rather than shipping a net-new capability — so the `feat(...)`-only feature-catalog
gate is correctly not armed; no `feature-announcements.ts` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
