### PR TITLE
fix(ui): Escape closes repo picker, not the whole New Task modal (#765)

### DIFF
--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -621,6 +621,30 @@ describe("NewTask repo shortcuts", () => {
       .toBe(true);
   });
 
+  it("Escape in open picker closes dropdown but not the modal, refocuses prompt", async () => {
+    const onclose = vi.fn();
+    render(NewTask, { props: base({ initialRepoPath: repoA.path, onclose }) });
+    await expect.poll(() => triggerLabel()).toBe(repoA.name);
+
+    // Open the picker via Alt+R
+    press("KeyR");
+    await expect.poll(() => document.querySelector(".rs-panel")).toBeTruthy();
+
+    // Dispatch Escape from inside .rs-root (mirroring real focus on the filter input)
+    const filter = document.querySelector<HTMLInputElement>(".rs-filter")!;
+    filter.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+
+    // Dropdown closes
+    await expect.poll(() => document.querySelector(".rs-panel")).toBeFalsy();
+    // Modal stays mounted (onclose did NOT fire)
+    expect(document.querySelector("#nt-prompt")).toBeTruthy();
+    expect(onclose).not.toHaveBeenCalled();
+    // Prompt is refocused
+    expect(document.activeElement).toBe(document.querySelector("#nt-prompt"));
+  });
+
   it("bare ] without Alt does NOT change the selected repo", async () => {
     render(NewTask, { props: base({ initialRepoPath: repoA.path }) });
     await expect.poll(() => triggerLabel()).toBe(repoA.name);

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -572,6 +572,7 @@
         {onfork}
         {onnewproject}
         onsync={handleSync}
+        onescape={() => promptInput?.focus()}
       />
     </div>
 

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -17,6 +17,7 @@
     onnewproject,
     onsync,
     windowDays,
+    onescape,
   }: {
     repos: RepoEntry[];
     value: string;
@@ -29,6 +30,9 @@
     onsync?: (repo: RepoEntry) => Promise<void> | void;
     /** Day count the server computed recentAgentCount over — named in the per-row label. */
     windowDays: number;
+    /** Invoked when an open panel is dismissed via Escape, so the parent can restore
+     *  focus — e.g. NewTask refocuses its prompt. */
+    onescape?: () => void;
   } = $props();
 
   let open = $state(false);
@@ -145,7 +149,7 @@
         if (r) pick(r.path);
         break;
       }
-      // Escape falls through to the window handler that closes the panel.
+      // Escape is handled by the root-node keydown listener below, which closes the panel.
     }
   }
 
@@ -157,24 +161,29 @@
   }
 
   $effect(() => {
+    const node: HTMLElement | null = root;
+    if (!node) return;
+    // Re-alias after the guard: TS drops the $state null-narrowing inside the closures below.
+    const n = node;
     function onKeydown(e: KeyboardEvent) {
-      if (e.key === "Escape" && open) {
-        open = false;
-        pickerFor = null;
-        filter = "";
-      }
+      if (e.key !== "Escape" || !open || e.defaultPrevented) return;
+      e.preventDefault();
+      open = false;
+      pickerFor = null;
+      filter = "";
+      onescape?.();
     }
     function onClick(e: MouseEvent) {
-      if (open && root && !root.contains(e.target as Node)) {
+      if (open && !n.contains(e.target as Node)) {
         open = false;
         pickerFor = null;
         filter = "";
       }
     }
-    window.addEventListener("keydown", onKeydown);
+    n.addEventListener("keydown", onKeydown);
     window.addEventListener("click", onClick, true);
     return () => {
-      window.removeEventListener("keydown", onKeydown);
+      n.removeEventListener("keydown", onKeydown);
       window.removeEventListener("click", onClick, true);
     };
   });


### PR DESCRIPTION
## Problem

In the New Task modal, pressing **Escape** while the repository dropdown (`RepoSelect`) is open — e.g. opened via the new **Alt+R** shortcut (#765) — dismissed the **entire modal** instead of just closing the dropdown.

## Root cause

The modal's Escape-to-close handler (`a11yDialog.ts`) lives on the **`<form>` node**. RepoSelect's Escape handler was registered on **`window`**. The form is an ancestor of the dropdown, so in the bubble phase the form's handler fired **first** — closing the modal before RepoSelect's window handler ran. RepoSelect also never called `preventDefault()`, so the dialog's existing `if (e.defaultPrevented) return` guard couldn't protect it.

## Fix

- Move RepoSelect's Escape keydown listener from `window` to the bound **`root` node** (a descendant of the form, bubble phase), so it fires **before** the form's dialog handler.
- Call `e.preventDefault()` and make the handler `defaultPrevented`-aware: a nested popover (the inline emoji/icon picker, itself a `use:dialog` surface) consumes the first Escape, so RepoSelect only acts when nothing inner did → **close innermost first**.
- Close **only** the dropdown (`open`/`pickerFor`/`filter`) and call a new optional `onescape` prop.
- NewTask wires `onescape={() => promptInput?.focus()}` to refocus the prompt textarea.
- The `window` click-outside listener is unchanged.

No `a11yDialog.ts` change needed — the fix uses the contract it already honors.

## Behavior after fix

- Dropdown open (Alt+R or click) + Escape → dropdown closes, **modal stays open**, prompt refocused.
- Emoji/icon picker open + Escape → closes **only** the picker; a second Escape closes the dropdown.
- Dropdown closed + Escape → still closes the modal (unchanged).

### Known, documented edge case (not a regression)
Tabbing focus out of the dropdown onto the prompt while the panel is still open means an Escape there bubbles straight to the form and closes the modal — same as today, and an unusual path (focus opens in the filter input).

## Tests

- Added a regression test in `NewTask.browser.test.ts` asserting Escape closes only the dropdown, keeps the modal mounted (`onclose` not fired), and refocuses the prompt. Confirmed red on the old code, green after.
- Full UI suite green (1429/1429); `bun run check` clean (0 errors, 0 warnings).

Bug fix to already-shipped feature #765 → no feature-catalog/i18n/glossary entries (`[no-feature-entry]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)