### PR TITLE
fix(design): add --status-warn caution token + adopt caution consumers (#770)

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -23,6 +23,7 @@
   --color-red: var(--red);
   --color-blue: var(--blue);
   --color-slate: var(--slate);
+  --color-warn: var(--warn);
   --color-scrim: var(--scrim);
   --color-term-fg: var(--term-fg);
   --font-mono: "Berkeley Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -55,6 +56,7 @@
   --red: #e5484d;
   --blue: #4a90d9;
   --slate: #566460;
+  --warn: #e8730c;
 
   --scrim: rgba(3, 6, 5, 0.66);
   --term-fg: #c4d0cb;
@@ -94,6 +96,8 @@
      (genuinely actionable-complete), applied directly at the callsites. */
   --status-done: var(--color-slate);
   --status-blocked: var(--color-red);
+  /* Caution / heads-up — NOT running (amber) and NOT blocked/error (red). */
+  --status-warn: var(--color-warn);
   --status-idle: var(--color-slate);
 
   /* Header wash for an alert-by-exception (blocked / parked) session. On the
@@ -131,6 +135,7 @@
   --red: #c2363b;
   --blue: #2f6fb0;
   --slate: #6b7873;
+  --warn: #b5560a;
 
   --scrim: rgba(20, 28, 25, 0.42);
   --term-fg: #2b3633;
@@ -171,10 +176,12 @@
   /* Status/info hues are read as text & borders for meaning (ready/blocked/info),
      so they must clear AAA too. Brighter, more-luminous siblings of the base
      accents — kept in the green-tinted family — on the near-black --bg #0a0d0c:
-     green ~12.6:1, red ~7.8:1, blue ~9.7:1. */
+     green ~12.6:1, red ~7.8:1, blue ~9.7:1.
+     warn (orange caution) brightened to a luminous sibling that clears AA on the near-black --bg. */
   --green: #7ee3b4;
   --red: #ff7a7e;
   --blue: #7fbdf0;
+  --warn: #ff9a4d;
 }
 [data-theme="light"][data-contrast="high"] {
   --line: #9aa8a2;
@@ -191,10 +198,12 @@
 
   /* Darker siblings of the base accents — same green-tinted family — so the
      status/info text & borders clear AAA on the near-white --panel #f7f9f8:
-     green ~7.4:1, red ~7.5:1, blue ~7.2:1. */
+     green ~7.4:1, red ~7.5:1, blue ~7.2:1.
+     warn (orange caution) darkened to a deeper sibling clearing contrast on near-white --panel. */
   --green: #0c5e3a;
   --red: #9a2429;
   --blue: #1c5590;
+  --warn: #8a3f00;
 }
 
 html,

--- a/ui/src/lib/components/DiagnoseRows.svelte
+++ b/ui/src/lib/components/DiagnoseRows.svelte
@@ -59,10 +59,10 @@
   }
 
   // State → color token. Design rule: never --color-green for healthy.
-  // ok → --status-done (slate), warning → --color-amber, error → --color-red.
+  // ok → --status-done (slate), warning → --status-warn, error → --color-red.
   const stateColor: Record<DiagnosticCheck["state"], string> = {
     ok: "var(--status-done)",
-    warning: "var(--color-amber)",
+    warning: "var(--status-warn)",
     error: "var(--color-red)",
   };
 </script>

--- a/ui/src/lib/components/IntegratedEpicRow.svelte
+++ b/ui/src/lib/components/IntegratedEpicRow.svelte
@@ -296,21 +296,21 @@
   }
   /* Quiet warning note — landing PR couldn't be opened (no link yet). */
   .landing-failed {
-    color: var(--color-amber);
+    color: var(--status-warn);
     font-size: var(--fs-micro);
   }
 
   /* Warning-tone chip — unrun migrations need operator verification before clearing the row.
-     Amber = caution (NOT success-green); mirrors the .badge recipe with the warning hue. */
+     Warn = caution (NOT success-green); mirrors the .badge recipe with the warn hue. */
   .chip-migrations {
     flex: none;
     font-size: var(--fs-micro);
     letter-spacing: 0.08em;
     padding: 1px 6px;
-    border: 1px solid var(--color-amber);
+    border: 1px solid var(--status-warn);
     border-radius: 2px;
-    color: var(--color-amber);
-    background: color-mix(in oklab, var(--color-amber) 12%, transparent);
+    color: var(--status-warn);
+    background: color-mix(in oklab, var(--status-warn) 12%, transparent);
   }
 
   /* Canonical .gbtn recipe (scoped per-component; see /design-system). */

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -971,9 +971,8 @@
     color: var(--color-muted);
   }
   .nt-upstream-warn {
-    /* Blue = informational accent; amber is reserved for --status-running (armed/active),
-       and red/blocked would be too alarming for a heads-up "task will start from local". */
-    color: var(--color-blue);
+    /* Warn (caution) — the diverged base is a heads-up: not an error (red) and not running (amber); more honest than informational blue for "task will start from local". */
+    color: var(--status-warn);
   }
   .prompt-wrap {
     position: relative;

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -848,8 +848,8 @@
          (on mobile it moves into the gear bottom sheet).
          Own slot left of the gear-wrap so it never overlaps the halt-pip (gear top-right)
          or the herdr blue gear-dot. Color: slate ring with state-colored core —
-         amber for warning, red for error — distinct from both the halt-pip identity
-         and the herdr blue. Token choice: --color-amber / --color-red for the core,
+         warn for warning, red for error — distinct from both the halt-pip identity
+         and the herdr blue. Token choice: --status-warn / --color-red for the core,
          --color-line-bright for the ring. Never --color-green (hidden when ok anyway). -->
     {#if diagnosticsOverall !== "ok" && !mobile}
       <button
@@ -1704,7 +1704,7 @@
      Visible only when diagnosticsOverall !== "ok" (hidden-when-OK via {#if}).
      Ring: --color-line-bright (neutral slate) — a quiet outline that doesn't
      read as the halt-pip or the herdr dot.
-     Core: --color-amber (warning) or --color-red (error, .alert). */
+     Core: --status-warn (warning) or --color-red (error, .alert). */
   .health-pip {
     position: relative;
     background: transparent;
@@ -1726,7 +1726,7 @@
     width: 9px;
     height: 9px;
     border-radius: 50%;
-    background: var(--color-amber);
+    background: var(--status-warn);
     display: block;
   }
   .health-pip.alert .health-dot {

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -48,6 +48,7 @@
     { name: "red", note: "Blocked / destructive / error" },
     { name: "blue", note: "Informational accent" },
     { name: "slate", note: "Idle / parked (neutral, not 'done')" },
+    { name: "warn", note: "Caution / heads-up — not running, not error" },
   ];
 
   // Type scale — the six deliberate rungs in app.css. Never hardcode a px size;
@@ -71,6 +72,10 @@
     },
     { name: "status-blocked", note: "Blocked / needs the operator (red)" },
     { name: "status-idle", note: "Idle, no active turn (slate)" },
+    {
+      name: "status-warn",
+      note: "Caution / heads-up — distinct from running (amber) and blocked (red)",
+    },
   ];
 
   // Canonical markup blocks. Rendered as escaped text inside <pre>, so agents


### PR DESCRIPTION
Closes #770.

## What

Adds a semantic **caution** token `--status-warn` (orange) to the design-system token layer, filling the gap for a "heads-up, not an error and not running" state that previously had no honest token — amber is reserved for `--status-running`, red for `--status-blocked`.

Follows the existing three-tier pattern: base `--warn` → `@theme` `--color-warn` → semantic `--status-warn`, defined across all four theme blocks:

| | dark | light | HC-dark | HC-light |
|---|---|---|---|---|
| `--warn` | `#e8730c` | `#b5560a` | `#ff9a4d` | `#8a3f00` |

Orange (not gold) was chosen against a live preview: it pulls toward red while amber-running stays gold, keeping the two visibly distinct — including in the light themes where both render as dark oranges.

Documented on `/design-system` as a `warn` accent swatch + a `status-warn` status dot.

## Consumers adopted (amber/blue → warn)

The sweep found existing caution-semantic spots borrowing the wrong hue because warn didn't exist; this PR repoints the genuine ones so the token ships with real consumers:

- **Diagnostics warning** — `DiagnoseRows.svelte` (detail rows) **and** `TopBar.svelte` `.health-dot` (summary pip), kept in sync; error stays red.
- **Epic landing warnings** — `IntegratedEpicRow.svelte` `.landing-failed` + `.chip-migrations` (was amber-as-caution).
- **New Task diverged hint** — `NewTask.svelte` `.nt-upstream-warn` (was informational blue; now honestly caution).

All adjacent comments updated to name warn.

## Deliberately deferred

- **`--wash-warn`** — the issue names it, but no header consumes a caution wash yet; omitted to avoid an unused token (no-dead-code). Add when a consumer needs it.
- **Telemetry/notification ambers** — usage gauge (`gaugeColor`), overspend (`creditColor`), update badge (`.update-badge`) — a deliberate amber channel distinct from session-status warn (Four-Light Rule); left as-is.
- **ControlBar** `.key.escape` (special/info) and `.key.danger` (^C = destructive red) — not caution; left as-is.

## Follow-up (out of scope)

The **mobile** diagnostics sheet item (`TopBar.svelte` ~`.sheet-item`) colors *error* amber and gives *warning* no caution hue — a pre-existing inconsistency with the desktop pip's warn/red mapping. Worth aligning separately; not touched here.

## Verification

- `cd ui && bun run check` — 0 errors/warnings
- `cd ui && bun run check:i18n` — catalogs in parity
- `cd ui && bun run test` — 1454 tests, 0 failures
- Token cascade resolves in all four theme blocks; warn vs amber distinguishability confirmed across dark/light/HC via the candidate preview.

No new user-facing capability ships (recolorings of existing caution UI + design-system reference, which is exempt) — no feature-catalog entry. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)