### PR TITLE
fix(namer): refine truncated task names; tighten deterministic-first gate

### DIFF
--- a/src/namer.ts
+++ b/src/namer.ts
@@ -389,8 +389,14 @@ const COMMAND_PREFIX_RE =
 /** The word-selection at the heart of {@link normalize}, exposed so the namer's
  *  "is this name strong?" judgment derives from the SAME logic that builds the name
  *  (no drift). `usedSpecific` is true when distinctive (non-COMMON) words drove the
- *  pick; `kept` is the final, deduped, ≤4-word list that normalize joins. */
-export function selectWords(s: string): { kept: string[]; usedSpecific: boolean } {
+ *  pick; `kept` is the final, deduped, ≤4-word list that normalize joins.
+ *  `truncated` is true when the distinctive-word list exceeded the 4-word cap — the
+ *  heuristic lost subject words, so the LLM refine should run to recover them. */
+export function selectWords(s: string): {
+  kept: string[];
+  usedSpecific: boolean;
+  truncated: boolean;
+} {
   const words = transliterate(s)
     .toLowerCase()
     .replace(COMMAND_PREFIX_RE, "")
@@ -399,13 +405,18 @@ export function selectWords(s: string): { kept: string[]; usedSpecific: boolean 
     .split(/\s+/)
     .filter(Boolean);
   const survivors = words.filter((w) => w.length > 1 && !STOPWORDS.has(w));
-  if (!survivors.length) return { kept: words.slice(0, 4), usedSpecific: false };
+  // truncated is dead for the gate here since usedSpecific=false already forces refine;
+  // set it for return-shape symmetry so callers never see an undefined field.
+  if (!survivors.length)
+    return { kept: words.slice(0, 4), usedSpecific: false, truncated: words.length > 4 };
   const specific = survivors.filter((w) => !COMMON.has(w));
   const usedSpecific = specific.length > 0;
   const base = usedSpecific ? specific : survivors;
   const seen = new Set<string>();
   const unique = base.filter((w) => (seen.has(w) ? false : (seen.add(w), true)));
-  return { kept: unique.slice(0, 4), usedSpecific };
+  // Compute truncated BEFORE slice — unique.length > 4 means the cap dropped words.
+  const truncated = unique.length > 4;
+  return { kept: unique.slice(0, 4), usedSpecific, truncated };
 }
 
 /**
@@ -424,12 +435,16 @@ export function normalize(s: string): string {
   return selectWords(s).kept.join("-");
 }
 
-/** True when the heuristic name already latched a distinctive multi-word subject —
- *  the deterministic name is good enough that the background Haiku refine can be skipped.
+/** True when the heuristic name captured the full distinctive subject — nothing was
+ *  dropped by the 4-word cap — so the background Haiku refine can be skipped.
+ *  Requires: specific words drove the pick (usedSpecific), at least 2 were kept, AND
+ *  the distinctive list fit within the cap (truncated=false). When a long prompt
+ *  overflows the cap the heuristic loses subject words; those prompts are NOT strong
+ *  and the LLM refine fires to recover them.
  *  Bounded quality trade, not zero-loss: a strong name may still be improvable. */
 export function isHeuristicNameStrong(prompt: string): boolean {
-  const { kept, usedSpecific } = selectWords(prompt);
-  return usedSpecific && kept.length >= 2;
+  const { kept, usedSpecific, truncated } = selectWords(prompt);
+  return usedSpecific && kept.length >= 2 && !truncated;
 }
 
 /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -1530,9 +1530,10 @@ export class SessionService {
   /** Kick off the background name refine without blocking create(). No-op when disabled. */
   private scheduleRefine(session: Session, herd?: string): void {
     if (!config.llmNaming || !this.deps.refineName) return;
-    // Deterministic-first (issue #692): when the heuristic already latched a distinctive
-    // multi-word subject, the name is good enough — skip the background Haiku refine. A
-    // bounded quality trade (strong ≠ provably optimal), not zero-loss; weaker names still refine.
+    // Deterministic-first (issue #692): skip the background Haiku refine only when the
+    // heuristic captured the full distinctive subject — nothing was dropped by the 4-word cap.
+    // Long prompts whose distinctive words overflow the cap (truncated=true) still refine.
+    // Bounded quality trade (strong ≠ provably optimal), not zero-loss; weaker names still refine.
     if (isHeuristicNameStrong(session.prompt)) return;
     void this.refineNameInBackground(session, herd).catch((err) =>
       console.warn(`[namer] refine failed for ${session.id}:`, err),

--- a/test/namer.test.ts
+++ b/test/namer.test.ts
@@ -136,20 +136,34 @@ test("normalize drops new stopwords ob, bis, denn", () => {
 // --- selectWords + isHeuristicNameStrong tests ---
 
 test("selectWords returns kept + usedSpecific for a strong prompt", () => {
-  const { kept, usedSpecific } = selectWords("the mobile footer needs settings export");
+  const { kept, usedSpecific, truncated } = selectWords("the mobile footer needs settings export");
   expect(usedSpecific).toBe(true);
   // "mobile", "footer", "settings", "export" are specific (not in STOPWORDS or COMMON)
   expect(kept).toEqual(["mobile", "footer", "settings", "export"]);
+  // exactly 4 distinctive words — fits within the cap, not truncated
+  expect(truncated).toBe(false);
+});
+
+test("selectWords returns truncated=true when distinctive words exceed the 4-word cap", () => {
+  // 5+ distinctive words: mobile, footer, settings, export, sticky, cta, scroll
+  const { kept, usedSpecific, truncated } = selectWords(
+    "the mobile footer needs settings export and a sticky CTA on scroll",
+  );
+  expect(usedSpecific).toBe(true);
+  expect(kept.length).toBe(4); // slice to 4
+  expect(truncated).toBe(true); // pre-slice list had >4
 });
 
 test("selectWords returns usedSpecific=false for an all-common fallback prompt", () => {
-  const { kept, usedSpecific } = selectWords("please can you do it");
+  const { kept, usedSpecific, truncated } = selectWords("please can you do it");
   expect(usedSpecific).toBe(false);
   expect(kept.length).toBeGreaterThan(0);
+  // truncated is set for shape symmetry; gate doesn't reach it (usedSpecific=false)
+  expect(typeof truncated).toBe("boolean");
 });
 
 test("isHeuristicNameStrong truth table", () => {
-  // strong: ≥2 distinctive words
+  // strong: ≥2 distinctive words, fits in cap (truncated=false)
   expect(isHeuristicNameStrong("the mobile footer needs settings export")).toBe(true);
   // weak: all stopwords — falls back to raw words but usedSpecific=false
   expect(isHeuristicNameStrong("please can you do it")).toBe(false);
@@ -157,11 +171,30 @@ test("isHeuristicNameStrong truth table", () => {
   expect(isHeuristicNameStrong("make the button nice")).toBe(false);
   // weak: single specific word (kept.length < 2)
   expect(isHeuristicNameStrong("export")).toBe(false);
+  // weak: 5+ distinctive words overflow the cap → truncated=true → NOT strong
+  expect(
+    isHeuristicNameStrong("the mobile footer needs settings export and a sticky CTA on scroll"),
+  ).toBe(false);
+  // --- real-prompt regression: user's actual stuck tasks (live-DB validation) ---
+  // This task's own prompt: 16 distinctive words → truncated → must refine
+  expect(
+    isHeuristicNameStrong(
+      "Did we break the task renamer? I feel like new tasks end up with just the tokenized name that never gets renamed via the LLM call",
+    ),
+  ).toBe(false);
+  // "five learnings" task: 14 distinctive words → truncated → must refine
+  expect(
+    isHeuristicNameStrong(
+      "Why does the system offer five learnings that need approval yet when I open the pane there are none",
+    ),
+  ).toBe(false);
+  // accepted residual: 3 distinctive words, fits cap → stays heuristic (documents known non-fix)
+  expect(isHeuristicNameStrong('Make "not workking" learnings actionable')).toBe(true);
 });
 
 test("no-drift pinning: normalize and isHeuristicNameStrong derive from selectWords", () => {
   // Corpus covers: strong multi-word, single-specific-word, only-COMMON fallback,
-  // all-stopword/fallback, and various prose prompts.
+  // all-stopword/fallback, various prose prompts, and a long many-keyword prompt.
   const corpus = [
     "the mobile footer needs settings export", // strong: multi-word specific
     "export", // single specific word → not strong, no "-"
@@ -176,6 +209,8 @@ test("no-drift pinning: normalize and isHeuristicNameStrong derive from selectWo
     "!!! ??? ...",
     "Even with the two recent PRs...",
     "p",
+    // long many-keyword prompt: truncated=true → not strong; normalize output unchanged
+    "Did we break the task renamer? I feel like new tasks end up with just the tokenized name that never gets renamed via the LLM call",
   ];
   for (const p of corpus) {
     const { kept } = selectWords(p);

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1852,6 +1852,28 @@ test("refine skipped (gate) when the heuristic name is already strong", async ()
   expect(refineCallCount).toBe(0);
 });
 
+test("refine fires (gate loosened) when the prompt has 5+ distinctive words (truncated)", async () => {
+  // "the mobile footer needs settings export and a sticky CTA on scroll" →
+  // isHeuristicNameStrong=false (truncated=true) → refineName IS called
+  let refineCallCount = 0;
+  const { deps } = svcDeps({
+    refineName: async () => {
+      refineCallCount++;
+      return "refined-name";
+    },
+  });
+  const svc = new SessionService(deps);
+  await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "the mobile footer needs settings export and a sticky CTA on scroll",
+    model: null,
+    images: [],
+  });
+  await new Promise((r) => setTimeout(r, 10));
+  expect(refineCallCount).toBe(1);
+});
+
 test("refine fires when the heuristic name is weak", async () => {
   // "make the button nice" → isHeuristicNameStrong=false → refineName IS called
   let refineCallCount = 0;


### PR DESCRIPTION
## Problem

New tasks were keeping their raw tokenized heuristic slug and almost never getting the Haiku LLM rename — the "task renamer feels broken" report. Not a bug per se: the deterministic-first gate from #692 (`0726141b`, reinforced by `9836f3ef`/#759) skips the background refine whenever the heuristic name is "strong", defined as merely `usedSpecific && kept.length >= 2`. Essentially every prompt with a real subject cleared that bar, so the refine almost never ran.

## Fix

Tighten the gate to skip the LLM **only when the heuristic captured the whole distinctive subject** — i.e. nothing was dropped by `normalize()`'s 4-word cap:

```ts
isHeuristicNameStrong = usedSpecific && kept.length >= 2 && !truncated
```

`selectWords()` now returns a `truncated` flag computed from the **pre-slice** deduped distinctive-word count (`> 4`) — `kept` is sliced to 4 and cannot itself reveal truncation. Prompts whose distinctive content overflows the cap (a lossy extraction, ≥5 distinctive words) now refine again; genuinely short prompts (≤4 distinctive words, nothing dropped) keep the cheap deterministic name. `normalize()` output is byte-identical (guarded by the no-drift pinning test).

## Why this threshold (empirical)

Validated against the live DB before building. Of the 16 most-recent tasks stuck on the raw heuristic slug, **15 are 5+-distinctive-word prompts that flip to refine** under this rule (distinct counts 10–27); only **1** is genuinely short and stays heuristic. The regression population is overwhelmingly long prose — exactly what this fix targets — so the truncation-only bar resolves ~94% of observed misses while preserving the cost savings for short clean names where the heuristic is already optimal. (This task's own prompt → `break-task-renamer-feel`, distinct=16, is one of the flips.)

## Tests

- `selectWords` `truncated` assertions; truth-table extended (4-word → strong, 5+-word → refine); pinning corpus extended.
- **Real-prompt regression assertions** tied to the complaint: this task's prompt and the "five learnings" prompt → refine; the short `workking-learnings-actionable` → stays (documented accepted residual).
- `test/service.test.ts`: a 5+-distinctive-word prompt now actually triggers `refineName`.
- `bun test ./test`: 3481 pass / 0 fail. `bun run lint` clean. `tsc --noEmit` exit 0.

## Scope

Server-only namer change, no UI touched, no user-facing strings — feature-catalog and i18n gates do not apply. Single commit, linear off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)