### PR TITLE
fix(ui): shared .icon-btn recipe + recognisable SVG terminal-header controls (#767)

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -89,6 +89,11 @@
      (Herd.svelte), so the two can't drift apart. */
   --mobile-shell-pad: 10px;
 
+  /* Header icon-button recipe — single source of truth for terminal-header
+     glyph controls (.icon-btn recipe, plus .spin keyframes below). */
+  --icon-btn-hit: 28px; /* desktop square hit area for header icon buttons */
+  --icon-btn-glyph: 18px; /* canonical inline-SVG glyph size */
+
   --status-running: var(--color-amber);
   /* done = WAITING (finished turn, parked for the operator's next steer). It is
      NOT actionable-complete, so it must not read green/"ignore me" — it reads as
@@ -333,5 +338,64 @@ button {
   .overlay {
     -webkit-backdrop-filter: none;
     backdrop-filter: none;
+  }
+}
+
+/* ── Header icon-button recipe ──────────────────────────────────────────────
+   Shared .icon-btn class + .spin keyframes for terminal-header glyph controls
+   (redraw, etc.). Replaces ad-hoc per-control sizing (.vp-redraw, etc.). */
+.icon-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px; /* for the armed decom "?" adornment beside the SVG */
+  width: var(--icon-btn-hit);
+  height: var(--icon-btn-hit);
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  color: var(--color-faint); /* quiet resting default; per-control overrides allowed */
+  cursor: pointer;
+  transition:
+    color 0.12s,
+    border-color 0.12s,
+    background 0.12s;
+}
+.icon-btn:hover {
+  color: var(--color-ink-bright);
+  border-color: var(--color-line-bright);
+}
+.icon-btn:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--color-amber);
+}
+.icon-btn:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+.icon-btn.compact {
+  width: var(--mobile-actionbar-hit);
+  height: var(--mobile-actionbar-hit);
+}
+.icon-btn svg {
+  width: var(--icon-btn-glyph);
+  height: var(--icon-btn-glyph);
+  display: block;
+}
+
+/* Spin animation for busy/loading SVG glyphs. */
+@keyframes icon-btn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.spin {
+  animation: icon-btn-spin 0.8s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .spin {
+    animation: none;
   }
 }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -4073,6 +4073,11 @@
     border-color: var(--color-red);
     color: var(--color-red);
   }
+  .ctrl-row .attach {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
   .ctrl-row .attach svg {
     width: var(--fs-lg);
     height: var(--fs-lg);

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2212,7 +2212,7 @@
         <!-- mobile space-saver: folds the tabs + PR rail + build queue away so the
              terminal claims the freed height. State persists across sessions. -->
         <button
-          class="vp-fold"
+          class="vp-fold icon-btn compact"
           type="button"
           aria-expanded={!headerCollapsed}
           aria-controls={foldRegionId}
@@ -2236,7 +2236,7 @@
            button unmounting also drops redrawBtnEl, which closes an open menu). -->
       {#if tab === "term"}
         <button
-          class="vp-redraw"
+          class="vp-redraw icon-btn"
           class:compact
           bind:this={redrawBtnEl}
           type="button"
@@ -2277,13 +2277,27 @@
              exited to a shell after a herdr restart. Forces a fresh claude --resume. -->
         <button
           class="vp-resume"
+          class:icon-btn={compact}
+          class:compact
           type="button"
           onclick={() => resumeSession(true)}
           disabled={resuming}
           title={m.viewport_resume_title()}
           aria-label={m.viewport_resume_title()}
         >
-          <span class="vp-resume-icon" aria-hidden="true">{resuming ? "⟳" : "↻"}</span>
+          <svg
+            class:spin={resuming}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            ><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /><path
+              d="M21 3v5h-5"
+            /></svg
+          >
           {#if !compact}<span>{m.cardmenu_resume_short()}</span>{/if}
         </button>
       {/if}
@@ -2296,6 +2310,8 @@
           class="decom"
           class:armed
           class:ready={!armed}
+          class:icon-btn={compact}
+          class:compact
           type="button"
           onclick={decommission}
           title={m.viewport_decommission_ready_title()}
@@ -2304,7 +2320,16 @@
           {#if compact}
             <!-- armed = destructive confirm: stay red + interrogative. Never ✓ —
                  that glyph means READY/actionable-complete elsewhere in the HUD. -->
-            {armed ? "✕?" : "✕"}
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"><path d="M18 6 6 18" /><path d="M6 6l12 12" /></svg
+            >
+            {#if armed}<span class="decom-confirm" aria-hidden="true">?</span>{/if}
           {:else}
             {armed ? m.viewport_confirm_decommission() : m.viewport_decommission()}
           {/if}
@@ -2315,14 +2340,23 @@
              Compact layouts show the same icon-only ✕ in the git strip instead.
              Same glyph rule as above: armed = red ✕?, never ✓. -->
         <button
-          class="decom quiet"
+          class="decom quiet icon-btn"
           class:armed
           type="button"
           onclick={decommission}
           title={armed ? m.viewport_confirm_decommission() : m.viewport_decommission_title()}
           aria-label={armed ? m.viewport_confirm_decommission() : m.viewport_decommission_aria()}
         >
-          {armed ? "✕?" : "✕"}
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"><path d="M18 6 6 18" /><path d="M6 6l12 12" /></svg
+          >
+          {#if armed}<span class="decom-confirm" aria-hidden="true">?</span>{/if}
         </button>
       {/if}
     </div>
@@ -2376,14 +2410,23 @@
                ready nudge. Desktop always renders decommission inline in the
                actions cluster, so it never duplicates here. -->
           <button
-            class="decom"
+            class="decom icon-btn compact"
             class:armed
             type="button"
             onclick={decommission}
             title={armed ? m.viewport_confirm_decommission() : m.viewport_decommission_title()}
             aria-label={armed ? m.viewport_confirm_decommission() : m.viewport_decommission_aria()}
           >
-            {armed ? "✕?" : "✕"}
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"><path d="M18 6 6 18" /><path d="M6 6l12 12" /></svg
+            >
+            {#if armed}<span class="decom-confirm" aria-hidden="true">?</span>{/if}
           </button>
         {/if}
       </span>
@@ -2566,7 +2609,47 @@
         onclick={() => fileInput?.click()}
         aria-label={m.viewport_attach_image()}
       >
-        {uploading ? "⟳" : uploadFailed ? "⚠" : "↥"}
+        {#if uploading}
+          <svg
+            class="spin"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            ><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /><path
+              d="M21 3v5h-5"
+            /></svg
+          >
+        {:else if uploadFailed}
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            ><path
+              d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+            /><path d="M12 9v4" /><path d="M12 17h.01" /></svg
+          >
+        {:else}
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            ><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M17 8l-5-5-5 5" /><path
+              d="M12 3v12"
+            /></svg
+          >
+        {/if}
       </button>
       {#if speechSupported}
         <button
@@ -2845,28 +2928,12 @@
     display: contents;
   }
 
-  /* mobile fold toggle: a bare chevron in the trailing actions cluster that
-     hides/shows the secondary header chrome. Mirrors the .decom ghost styling
-     so the two trailing controls read as a set. */
+  /* mobile fold toggle: now an .icon-btn.compact — ghost/sizing/hover from recipe.
+     Keep only the Unicode-chevron legibility bits the recipe doesn't provide. */
   .vp-fold {
-    flex-shrink: 0;
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 2px;
-    color: var(--color-faint);
     font-family: var(--font-mono);
     font-size: var(--fs-base);
     line-height: 1;
-    padding: 2px 7px;
-    cursor: pointer;
-    transition:
-      color 0.12s,
-      border-color 0.12s,
-      background 0.12s;
-  }
-  .vp-fold:hover {
-    color: var(--color-ink);
-    border-color: var(--color-line-bright);
   }
   /* folded tabs are display:none rather than removed from the DOM so the active
      tab + terminal mount survive the toggle (no remount, no PTY teardown) */
@@ -2935,7 +3002,7 @@
   }
   .gt-caret {
     color: var(--color-faint);
-    font-size: var(--fs-micro);
+    font-size: var(--fs-meta);
     line-height: 1;
   }
   .git-toggle.open .gt-caret,
@@ -3113,50 +3180,32 @@
     border: 1px solid transparent;
     border-radius: 2px;
     color: var(--color-faint);
-    font-family: var(--font-mono);
-    font-size: var(--fs-micro);
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    padding: 2px 7px;
     cursor: pointer;
     transition:
       color 0.12s,
       border-color 0.12s,
       background 0.12s;
   }
+  /* text-pill-only declarations — not applied when icon-btn form is used */
+  .decom:not(.icon-btn) {
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 2px 7px;
+  }
+  /* ? adornment inherits the armed red via currentColor; centered by recipe flex + gap */
+  .decom-confirm {
+    color: currentColor;
+    font-size: var(--fs-meta);
+    line-height: 1;
+  }
 
   /* Resume: the primary action of a parked session, so it stays on the identity
      row (not in the strip). Quiet neutral (not destructive, not "ready-complete"
      → no green/red), brightening to ink on hover. */
-  /* redraw-variants toggle: icon-only wrench, ghost styling matching the
-     trailing header controls cluster; compact class enlarges to touch target */
-  .vp-redraw {
-    flex-shrink: 0;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 2px;
-    color: var(--color-faint);
-    padding: 0;
-    cursor: pointer;
-    transition:
-      color 0.12s,
-      border-color 0.12s;
-  }
-  .vp-redraw.compact {
-    width: var(--mobile-actionbar-hit);
-    height: var(--mobile-actionbar-hit);
-  }
-  .vp-redraw svg {
-    width: 18px;
-    height: 18px;
-    display: block;
-  }
-  .vp-redraw:hover,
+  /* redraw-variants toggle: now an .icon-btn; only the open-state highlight
+     is kept here (hover is handled by the global recipe). */
   .vp-redraw[aria-expanded="true"] {
     color: var(--color-ink-bright);
     border-color: var(--color-line-bright);
@@ -3166,20 +3215,23 @@
     flex-shrink: 0;
     display: inline-flex;
     align-items: center;
-    gap: 5px;
     background: transparent;
     border: 1px solid transparent;
     border-radius: 2px;
     color: var(--color-ink);
+    cursor: pointer;
+    transition:
+      color 0.12s,
+      border-color 0.12s;
+  }
+  /* text-pill-only declarations — not applied when compact icon-btn form is used */
+  .vp-resume:not(.icon-btn) {
+    gap: 5px;
     font-family: var(--font-mono);
     font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 2px 7px;
-    cursor: pointer;
-    transition:
-      color 0.12s,
-      border-color 0.12s;
   }
   .vp-resume:hover {
     color: var(--color-ink-bright);
@@ -3188,9 +3240,6 @@
   .vp-resume:disabled {
     cursor: default;
     opacity: 0.6;
-  }
-  .vp-resume-icon {
-    font-size: var(--fs-meta);
   }
 
   /* PR delivered → the work is done. The decommission control graduates from its
@@ -3240,17 +3289,8 @@
     background: color-mix(in srgb, var(--color-red) 12%, transparent);
   }
 
-  /* quiet variant: the pre-PR desktop inline ✕. Rest ink stays the base .decom
-     faint; hover/armed inherit the red destructive treatment above. Glyph-only,
-     so drop the word-mark letter-spacing and size it like the neighboring
-     rename ✎ — the class stays on while armed so arming keeps the same metrics
-     (only .decom.armed's colors take over). */
-  .decom.quiet {
-    font-size: var(--fs-meta);
-    letter-spacing: 0;
-    line-height: 1;
-    padding: 2px 6px;
-  }
+  /* quiet variant: pre-PR desktop inline ✕. Now an .icon-btn — sizing/padding
+     handled by the global recipe. Color/hover/armed states still apply below. */
 
   /* rename: inline editor that takes the title's own slot in place (double-tap/
      dblclick the title to open it); the post-rename note sits in the trailing
@@ -3656,8 +3696,7 @@
   }
   /* the strip's GitRail always renders its ≥44px touch variant — match it so the
      cluster doesn't sit half-height beside the rail buttons */
-  .strip-controls .ap-toggle,
-  .strip-controls .decom {
+  .strip-controls .ap-toggle {
     min-height: 44px;
     padding: 6px 9px;
   }
@@ -3748,9 +3787,7 @@
   }
   /* finger-sized header controls on touch layouts (≥44px) */
   .vp-head.mobile .back,
-  .vp-head.mobile .next-yu,
-  .vp-head.mobile .vp-fold,
-  .vp-head.mobile .decom {
+  .vp-head.mobile .next-yu {
     min-height: 44px;
     padding: 8px 12px;
     font-size: var(--fs-base);
@@ -4035,6 +4072,11 @@
   .ctrl-row .attach.failed {
     border-color: var(--color-red);
     color: var(--color-red);
+  }
+  .ctrl-row .attach svg {
+    width: var(--fs-lg);
+    height: var(--fs-lg);
+    display: block;
   }
   /* Enter — primary affirmative action. Amber outline-ghost (transparent fill,
      amber border + text, inset amber glow) per the design-system primary recipe.

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -3233,6 +3233,15 @@
     text-transform: uppercase;
     padding: 2px 7px;
   }
+  /* desktop labeled form sizes its SVG text-scaled (beside the uppercase label);
+     the compact icon-only form has no label and sizes via the global
+     .icon-btn svg (18px) instead. Without this the labeled SVG has no sizing
+     rule and falls back to the replaced-element default (~300×150). */
+  .vp-resume:not(.icon-btn) svg {
+    width: var(--fs-base);
+    height: var(--fs-base);
+    display: block;
+  }
   .vp-resume:hover {
     color: var(--color-ink-bright);
     border-color: var(--color-line-bright);

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -206,6 +206,59 @@ input, select, textarea {
   box-shadow: inset 0 0 0 1px var(--color-amber);
 }`;
 
+  const iconBtnMarkup = `<!-- Default (28px hit area) -->
+<button type="button" class="icon-btn" aria-label="Refresh">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/>
+    <path d="M21 3v5h-5"/>
+  </svg>
+</button>
+
+<!-- Busy/loading: .spin on the glyph (reduced-motion safe) -->
+<button type="button" class="icon-btn" aria-label="Loading">
+  <svg class="spin" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/>
+    <path d="M21 3v5h-5"/>
+  </svg>
+</button>
+
+<!-- Compact (44px touch target) -->
+<button type="button" class="icon-btn compact" aria-label="Close">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M18 6 6 18"/><path d="M6 6l12 12"/>
+  </svg>
+</button>
+
+/* canonical recipe — all sizes/colors via tokens, never raw px/hex */
+.icon-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px; /* for the armed decom "?" adornment beside the SVG */
+  width: var(--icon-btn-hit);    /* 28px — desktop square hit area */
+  height: var(--icon-btn-hit);
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  color: var(--color-faint);     /* quiet resting default */
+  cursor: pointer;
+  transition: color .12s, border-color .12s, background .12s;
+}
+.icon-btn:hover { color: var(--color-ink-bright); border-color: var(--color-line-bright); }
+.icon-btn:focus-visible { outline: none; box-shadow: inset 0 0 0 1px var(--color-amber); }
+.icon-btn:disabled { cursor: default; opacity: .6; }
+.icon-btn.compact { width: var(--mobile-actionbar-hit); height: var(--mobile-actionbar-hit); } /* 44px touch target */
+.icon-btn svg { width: var(--icon-btn-glyph); height: var(--icon-btn-glyph); display: block; } /* 18px glyph */
+
+/* .spin marks a busy/loading glyph (reduced-motion guarded) */
+.spin { animation: icon-btn-spin 0.8s linear infinite; }
+@media (prefers-reduced-motion: reduce) { .spin { animation: none; } }`;
+
   const scrimMarkup = `<div class="scrim"><!-- dialog --></div>
 
 /* .scrim lives in app.css — one canonical backdrop for every dialog/drawer.
@@ -337,6 +390,145 @@ input, select, textarea {
       <button class="gbtn" disabled>Disabled</button>
     </div>
     <pre><code>{btnMarkup}</code></pre>
+  </section>
+
+  <section class="panel">
+    <h2>Icon buttons</h2>
+    <p class="when">
+      <strong>When:</strong> an icon-only chrome control that needs a clear square hit target and a
+      glyph recognisable at a distance — e.g. the Viewport header's resume, decommission, redraw
+      (wrench), and fold controls. Desktop hit area is <code>--icon-btn-hit</code> (28px); add
+      <code>.compact</code> for the <code>--mobile-actionbar-hit</code> (44px) touch target. Use a
+      <code>.spin</code> class on the glyph for a busy/loading state (reduced-motion safe).
+      <strong>When not:</strong> a control with a visible text label uses <code>.gbtn</code>
+      (icon + word), not <code>.icon-btn</code>; a decorative disclosure caret inside an
+      already-clickable labeled pill (e.g. the git-actions caret) is just a Unicode
+      <code>▾</code>/<code>▴</code> and gets no hit area of its own; destructive actions still need their
+      red treatment + confirm.
+    </p>
+    <div class="demo">
+      <button type="button" class="icon-btn" aria-label="Refresh">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /><path d="M21 3v5h-5" />
+        </svg>
+      </button>
+      <button type="button" class="icon-btn" aria-label="Loading (spinning)">
+        <svg
+          class="spin"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /><path d="M21 3v5h-5" />
+        </svg>
+      </button>
+      <button type="button" class="icon-btn" aria-label="Close">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M18 6 6 18" /><path d="M6 6l12 12" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="icon-btn"
+        aria-label="Decommission (confirm)"
+        style="color: var(--color-red)"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M18 6 6 18" /><path d="M6 6l12 12" />
+        </svg><span>?</span>
+      </button>
+      <button type="button" class="icon-btn" aria-label="Upload">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M17 8l-5-5-5 5" /><path
+            d="M12 3v12"
+          />
+        </svg>
+      </button>
+      <button type="button" class="icon-btn" aria-label="Alert">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path
+            d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+          /><path d="M12 9v4" /><path d="M12 17h.01" />
+        </svg>
+      </button>
+      <button type="button" class="icon-btn" aria-label="Disabled example" disabled>
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M18 6 6 18" /><path d="M6 6l12 12" />
+        </svg>
+      </button>
+      <button type="button" class="icon-btn compact" aria-label="Compact (44px touch target)">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /><path d="M21 3v5h-5" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="icon-btn"
+        aria-label="Fold (Unicode chevron — standalone fold control, not a labeled-pill caret)"
+        ><span aria-hidden="true">▾</span></button
+      >
+    </div>
+    <pre><code>{iconBtnMarkup}</code></pre>
   </section>
 
   <section class="panel">

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -463,7 +463,7 @@ input, select, textarea {
           aria-hidden="true"
         >
           <path d="M18 6 6 18" /><path d="M6 6l12 12" />
-        </svg><span>?</span>
+        </svg><span aria-hidden="true" style="font-size: var(--fs-meta); line-height: 1">?</span>
       </button>
       <button type="button" class="icon-btn" aria-label="Upload">
         <svg

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -232,6 +232,12 @@ input, select, textarea {
   </svg>
 </button>
 
+<!-- Unicode-glyph child (e.g. a standalone fold chevron): the recipe only sizes
+     SVG glyphs, so a text glyph needs its own font-size (matches .vp-fold) -->
+<button type="button" class="icon-btn" style="font-size: var(--fs-base)" aria-label="Fold">
+  <span aria-hidden="true">▾</span>
+</button>
+
 /* canonical recipe — all sizes/colors via tokens, never raw px/hex */
 .icon-btn {
   flex-shrink: 0;
@@ -254,6 +260,8 @@ input, select, textarea {
 .icon-btn:disabled { cursor: default; opacity: .6; }
 .icon-btn.compact { width: var(--mobile-actionbar-hit); height: var(--mobile-actionbar-hit); } /* 44px touch target */
 .icon-btn svg { width: var(--icon-btn-glyph); height: var(--icon-btn-glyph); display: block; } /* 18px glyph */
+/* the recipe sizes SVG glyphs only — a Unicode text-glyph child needs its own
+   font-size on the button (e.g. .vp-fold sets font-size: var(--fs-base)) */
 
 /* .spin marks a busy/loading glyph (reduced-motion guarded) */
 .spin { animation: icon-btn-spin 0.8s linear infinite; }
@@ -399,7 +407,10 @@ input, select, textarea {
       glyph recognisable at a distance — e.g. the Viewport header's resume, decommission, redraw
       (wrench), and fold controls. Desktop hit area is <code>--icon-btn-hit</code> (28px); add
       <code>.compact</code> for the <code>--mobile-actionbar-hit</code> (44px) touch target. Use a
-      <code>.spin</code> class on the glyph for a busy/loading state (reduced-motion safe).
+      <code>.spin</code> class on the glyph for a busy/loading state (reduced-motion safe). The
+      recipe sizes <code>svg</code> glyphs (18px) — a Unicode text-glyph child (e.g. a standalone
+      fold chevron) needs its own <code>font-size</code> on the button, as <code>.vp-fold</code>
+      does.
       <strong>When not:</strong> a control with a visible text label uses <code>.gbtn</code>
       (icon + word), not <code>.icon-btn</code>; a decorative disclosure caret inside an
       already-clickable labeled pill (e.g. the git-actions caret) is just a Unicode
@@ -524,6 +535,7 @@ input, select, textarea {
       <button
         type="button"
         class="icon-btn"
+        style="font-size: var(--fs-base)"
         aria-label="Fold (Unicode chevron — standalone fold control, not a labeled-pill caret)"
         ><span aria-hidden="true">▾</span></button
       >


### PR DESCRIPTION
Closes #767.

Audits the Viewport terminal-header interactive glyph controls for **desktop recognisability** and **consistent square hit targets**, replacing per-control ad-hoc sizing with one shared `.icon-btn` recipe and swapping the thinnest/most-ambiguous Unicode glyphs for crisp inline SVGs.

## What changed
- **New shared recipe** `.icon-btn` + tokens `--icon-btn-hit: 28px` (desktop square) / `--icon-btn-glyph: 18px`, plus a reduced-motion-guarded `.spin`, in `ui/src/app.css`. Generalised from the already-shipped `.vp-redraw` wrench (#768), which is now folded into the recipe — eliminating the duplicate ad-hoc icon-button implementation.
- **Hybrid glyph → SVG** (canonical wrench style: `viewBox 0 0 24 24`, `stroke=currentColor`, `aria-hidden`):
  - `.vp-resume` `↻`/`⟳` → refresh SVG (`.spin` when resuming)
  - `.decom` / `.decom.quiet` / git-strip decom `✕`/`✕?` → close SVG (armed keeps the red `✕?` confirm cue via a `.decom-confirm` `?` that inherits `currentColor`)
  - compose `.attach` `↥`/`⟳`/`⚠` → upload / spinner / alert-triangle SVGs
  - **Chevrons stay Unicode** (`.vp-fold`, `.gt-caret`) — a disclosure caret is unambiguous.
- **Hit areas:** `.icon-btn` = 28px desktop square / 44px (`--mobile-actionbar-hit`) when `.compact`, applied only to icon-only forms (desktop text pills stay non-square). `.attach` keeps its 44px `.ctrl-row` sizing (aligns with its `.dictate`/`.enter` siblings) — glyph-only swap. `.gt-caret` gets a legibility bump only (`--fs-micro` → `--fs-meta`), no hit area of its own (it lives inside the labeled `.git-toggle`).
- **Drift culled:** bespoke `.vp-redraw` sizing, `.vp-resume-icon`, and `.decom.quiet` sizing rules removed; mobile finger-sizing for fold/decom now comes from `.icon-btn.compact`.
- **Documented** the recipe on `/design-system` (live SVGs + copy-paste markup), per the design-system house rule.

## Notes / decisions
- **`[no-feature-entry]`**: a recognisability/hit-area refinement of existing controls, not a new capability (the feature-catalog gate confirms no `feat` commits in range).
- **No new i18n strings**: SVGs and the `?` adornment are `aria-hidden`; existing `m.*` `title`/`aria-label` keys are reused.
- **Specificity guard**: Svelte scoped styles out-specify the global `.icon-btn`, so dual-use `.decom`/`.vp-resume` text-pill props are scoped to `:not(.icon-btn)` and the git-strip decom's old padding override was removed — so icon forms actually adopt the square recipe.

## Verification
- `cd ui && bun run check` (0 errors) · `bun run test` (1454 passing) · `bun run check:i18n` (parity) — all green.
- Branch-hygiene / feature-catalog / glossary gates green; no off-token colors introduced.
- ⚠️ **Operator sign-off still wanted on the subjective criteria** the plan flagged — "recognisable at a distance" and "no narrow-desktop header-density / mistap regression" aren't covered by automated checks. Worth a quick look at the terminal header (desktop + narrow desktop) and the `/design-system` → **Icon buttons** section. The Vercel/preview build can render both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)