### PR TITLE
fix(ui): distinguish over-budget "Trim" state from pending learnings in TopBar chip

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -404,6 +404,7 @@
   "triage_open_console": "Konsole",
   "triage_open_console_aria": "Volle Konsole von {desig} öffnen",
   "learnings_title": "Erkenntnisse",
+  "learnings_trim_title": "Kürzen",
   "learnings_badge_tip": "Was Shepherd aus deinen Agenten-Sitzungen lernt: vorgeschlagene Hausregeln aus deinen Korrekturen, Review-Funden, Blocks und Stalls; nur für dieses Repo, nicht global. Eine angezeigte Zahl gibt an, wie viele Vorschläge auf deine Prüfung warten.",
   "learnings_about_toggle": "Was ist das?",
   "learnings_about_lead": "Erkenntnisse sind Hausregeln, die Shepherd aus deinen Agenten-Sitzungen lernt: aus deinen Korrekturen, Code-Review-Funden, Blocks und Stalls.",
@@ -1457,5 +1458,6 @@
   "newtask_upstream_diverged": "Von origin abgewichen ({behind} hinter, {ahead} voraus) — Aufgabe startet von lokal {base}",
   "feat_base_freshen_title": "Basis-Branch wird vom Upstream aktualisiert",
   "feat_base_freshen_body": "Neue Aufgaben starten jetzt vom neuesten Upstream-Stand des Basis-Branches — Shepherd holt und spult beim Start vor (fast-forward), sodass du Upstream-Änderungen nach Abschluss nicht mehr von Hand einpflegen musst. Der New-Task-Dialog weist darauf hin, wenn deine Basis zurückliegt oder von origin abgewichen ist.",
-  "topbar_learnings_tip": "Vorgeschlagene Hausregeln über alle deine Repos prüfen"
+  "topbar_learnings_tip": "Vorgeschlagene Hausregeln über alle deine Repos prüfen",
+  "topbar_learnings_curate_tip": "Bereits genehmigte Regeln, die nicht ins Injektions-Budget passen — kürze einige, damit die übrigen neue Agents erreichen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -404,6 +404,7 @@
   "triage_open_console": "Console",
   "triage_open_console_aria": "Open the full console for {desig}",
   "learnings_title": "Learnings",
+  "learnings_trim_title": "Trim",
   "learnings_badge_tip": "What Shepherd learns from your agent sessions: proposed house rules from your corrections, review findings, blocks, and stalls; for this repo only, not global. Any number shown is how many proposals are awaiting your review.",
   "learnings_about_toggle": "What is this?",
   "learnings_about_lead": "Learnings are house rules Shepherd distils from your agent sessions: from your corrections, code-review findings, blocks, and stalls.",
@@ -1457,5 +1458,6 @@
   "newtask_upstream_diverged": "Diverged from origin ({behind} behind, {ahead} ahead) — task will start from local {base}",
   "feat_base_freshen_title": "Base branch freshens from upstream",
   "feat_base_freshen_body": "New tasks now start from the latest upstream tip of the base branch — Shepherd fetches and fast-forwards at launch, so you no longer fold in upstream changes by hand when the task is done. The New Task dialog flags when your base is behind or has diverged from origin.",
-  "topbar_learnings_tip": "Review proposed house rules across all your repos"
+  "topbar_learnings_tip": "Review proposed house rules across all your repos",
+  "topbar_learnings_curate_tip": "Already-approved rules that don't fit the injection budget — trim some so the rest reach new agents"
 }

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1076,3 +1076,66 @@ describe("TopBar — global learnings button", () => {
     expect(onlearnings).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("TopBar — learnings chip label switches between proposed and curate-only mode", () => {
+  // At 1436px wide desktop, the chip is NOT compacted (confirmed by the
+  // "wide desktop keeps full labels" suite), so .learn-label renders.
+  const desktopBase = {
+    nowMs: 1_700_000_000_000,
+    connected: true,
+    ...FLAGS.desktop,
+    ...sessionsProp(0),
+    limits: null as UsageLimits | null,
+  };
+
+  it("curate-only: chip reads TRIM with curate tooltip and curate aria-label", async () => {
+    await page.viewport(1436, 900);
+    document.body.style.width = "1436px";
+    render(TopBar, { ...desktopBase, learnings: 0, learningsCurate: 5 });
+
+    await nextFrame();
+    await nextFrame();
+
+    const btn = document.querySelector<HTMLElement>(".learnings-btn");
+    expect(btn, ".learnings-btn rendered").not.toBeNull();
+
+    const label = btn!.querySelector<HTMLElement>(".learn-label");
+    expect(label, ".learn-label rendered (not compacted at 1436px)").not.toBeNull();
+    expect(label!.textContent, "chip label is TRIM in curate-only mode").toBe(
+      m.learnings_trim_title(),
+    );
+
+    const countEl = btn!.querySelector<HTMLElement>(".learn-n");
+    expect(countEl, ".learn-n rendered").not.toBeNull();
+    expect(countEl!.textContent, "chip count is curate count").toBe("5");
+
+    expect(btn!.getAttribute("title"), "tooltip is curate tip").toBe(
+      m.topbar_learnings_curate_tip(),
+    );
+    expect(btn!.getAttribute("aria-label"), "aria-label is curate aria").toBe(
+      m.learnings_open_curate_aria({ count: 5 }),
+    );
+  });
+
+  it("proposed: chip reads LEARNINGS with proposed aria-label", async () => {
+    await page.viewport(1436, 900);
+    document.body.style.width = "1436px";
+    render(TopBar, { ...desktopBase, learnings: 5, learningsCurate: 0 });
+
+    await nextFrame();
+    await nextFrame();
+
+    const btn = document.querySelector<HTMLElement>(".learnings-btn");
+    expect(btn, ".learnings-btn rendered").not.toBeNull();
+
+    const label = btn!.querySelector<HTMLElement>(".learn-label");
+    expect(label, ".learn-label rendered (not compacted at 1436px)").not.toBeNull();
+    expect(label!.textContent, "chip label is LEARNINGS in proposed mode").toBe(
+      m.learnings_title(),
+    );
+
+    expect(btn!.getAttribute("aria-label"), "aria-label is proposed aria").toBe(
+      m.learnings_open_aria({ count: 5 }),
+    );
+  });
+});

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -119,6 +119,10 @@
   const learningsPresent = $derived(learnings > 0 || learningsCurate > 0);
   // Badge shows proposed count when any proposed, else the curate count
   const learningsCount = $derived(learnings > 0 ? learnings : learningsCurate);
+  const learningsLabel = $derived(learnings > 0 ? m.learnings_title() : m.learnings_trim_title());
+  const learningsTip = $derived(
+    learnings > 0 ? m.topbar_learnings_tip() : m.topbar_learnings_curate_tip(),
+  );
   const chrome = $derived({
     updateAvailable,
     herdrUpdateAvailable,
@@ -873,13 +877,13 @@
         class:compact={compactBadges}
         type="button"
         onclick={() => onlearnings?.()}
-        title={m.topbar_learnings_tip()}
+        title={learningsTip}
         aria-label={learnings > 0
           ? m.learnings_open_aria({ count: learnings })
           : m.learnings_open_curate_aria({ count: learningsCurate })}
       >
         <span class="learn-glyph" aria-hidden="true">✦</span>
-        {#if !compactBadges}<span class="learn-label">{m.learnings_title()}</span>{/if}
+        {#if !compactBadges}<span class="learn-label">{learningsLabel}</span>{/if}
         <span class="learn-n">{learningsCount}</span>
       </button>
     {/if}
@@ -1124,7 +1128,7 @@
           : m.learnings_open_curate_aria({ count: learningsCurate })}
       >
         <span class="sheet-glyph" aria-hidden="true">✦</span>
-        <span class="sheet-label">{m.learnings_title()} · {learningsCount}</span>
+        <span class="sheet-label">{learningsLabel} · {learningsCount}</span>
       </button>
     {/if}
 

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -4,6 +4,7 @@ import {
   chipHasTelemetry,
   chipRailVisible,
   enabledDrains,
+  firstCurateRepo,
   globalLearningsCounts,
   mergeTrainIsAttention,
   mergeTrainLabel,
@@ -496,5 +497,45 @@ describe("globalLearningsCounts", () => {
     const items = [learning({ id: "l1" }), learning({ id: "l2" })];
     const injectables = [injectable({ rules: [rule(false)] })];
     expect(globalLearningsCounts(items, injectables)).toEqual({ proposed: 2, curate: 1 });
+  });
+});
+
+// ─── firstCurateRepo ──────────────────────────────────────────────────────────
+
+describe("firstCurateRepo", () => {
+  it("returns null for empty list", () => {
+    expect(firstCurateRepo([])).toBeNull();
+  });
+
+  it("returns null when no repo has over-budget rules", () => {
+    const injectables = [
+      injectable({ repoPath: "/repos/a", rules: [rule(true), rule(true)] }),
+      injectable({ repoPath: "/repos/b", rules: [rule(true)] }),
+    ];
+    expect(firstCurateRepo(injectables)).toBeNull();
+  });
+
+  it("returns the repoPath of the first repo with ≥1 over-budget rule", () => {
+    const injectables = [
+      injectable({ repoPath: "/repos/a", rules: [rule(true)] }), // all injected
+      injectable({ repoPath: "/repos/b", rules: [rule(true), rule(false)] }), // 1 over-budget
+      injectable({ repoPath: "/repos/c", rules: [rule(false), rule(false)] }), // 2 over-budget
+    ];
+    expect(firstCurateRepo(injectables)).toBe("/repos/b");
+  });
+
+  it("returns null when the only over-budget repo is disabled", () => {
+    const injectables = [
+      injectable({ repoPath: "/repos/a", enabled: false, rules: [rule(false)] }),
+    ];
+    expect(firstCurateRepo(injectables)).toBeNull();
+  });
+
+  it("skips disabled repos and returns the first enabled over-budget repo", () => {
+    const injectables = [
+      injectable({ repoPath: "/repos/a", enabled: false, rules: [rule(false)] }), // disabled → skip
+      injectable({ repoPath: "/repos/b", enabled: true, rules: [rule(false)] }), // enabled → match
+    ];
+    expect(firstCurateRepo(injectables)).toBe("/repos/b");
   });
 });

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -113,6 +113,13 @@ export function globalLearningsCounts(
   };
 }
 
+/** The repoPath of the first injectable repo with ≥1 over-budget ("curate")
+ *  rule, or null. Used to deep-link the global learnings chip straight to the
+ *  rules that need trimming when there's nothing to approve. */
+export function firstCurateRepo(injectable: RepoInjectable[]): string | null {
+  return injectable.find((r) => overBudgetCount(r) > 0)?.repoPath ?? null;
+}
+
 /** Whether the `queued` indicator is an interactive trigger (opens the queue
  *  popover) rather than inert text — true only when something is actually queued. */
 export function queueOpenable(d: DrainStatus): boolean {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -99,6 +99,7 @@
   import QueueStrip from "$lib/components/QueueStrip.svelte";
   import RepoSwitcher from "$lib/components/RepoSwitcher.svelte";
   import {
+    firstCurateRepo,
     globalLearningsCounts,
     repoChipRows,
     shouldClearRepoFilter,
@@ -1521,7 +1522,8 @@
         learnings={learningsCounts.proposed}
         learningsCurate={learningsCounts.curate}
         onlearnings={() => {
-          learningsRepo = null;
+          learningsRepo =
+            learningsCounts.proposed > 0 ? null : firstCurateRepo(learnings.injectable);
           showLearnings = true;
         }}
         {statusFilter}


### PR DESCRIPTION
## Problem

The TopBar `✦ LEARNINGS <n>` chip rendered **identically** whether `<n>` were learnings *awaiting approval* or already-approved house rules that are *over the injection budget* (the "curate" state, which the count silently falls through to when `proposed == 0 && curate > 0`). Only the invisible `aria-label` differed.

Reported symptom: *"the system offers five learnings that need approval, yet when I open the pane there's nothing to approve — only ones already approved."* Verified against the live DB: **0 proposed**, 62 active, 40 dismissed — the badge's `5` was over-budget active rules in the `shepherd`/`flowagent` repos, not approvals. Worse, clicking the chip opened the drawer at its approval-framed top (the "What is this?" explainer leads), leaving the over-budget rules buried as `⊘ Over budget` badges.

## Fix

- **Relabel curate-only mode:** the chip reads `✦ TRIM <n>` (DE `Kürzen`) with a curate-specific tooltip, so it never reads as pending approvals. Proposed mode is unchanged (`✦ LEARNINGS <n>`). Chip stays neutral chrome — no new hue (Four-Light Rule).
- **Deep-link the click:** in curate-only mode, opening the chip focuses the first over-budget repo via the existing `focusRepo` mechanism, scrolling past the explainer onto the rules that need trimming. New helper `firstCurateRepo()` reuses the existing `overBudgetCount` (same `enabled` gate).

Why a worded `TRIM <n>` and not the repo-chip's bare `✦` idiom: the TopBar is a standalone global surface (its proposed mode is word + count), so a wordless glyph there would be *more* ambiguous, not less. Suppressing the badge was rejected because over-budget curation must stay discoverable for repos with no live session (exactly this case).

## Changes
- `ui/messages/en.json` + `de.json`: `learnings_trim_title`, `topbar_learnings_curate_tip` (parity gated by `check:i18n`).
- `ui/src/lib/components/TopBar.svelte`: `learningsLabel` + `learningsTip` deriveds (desktop badge + mobile sheet); aria-labels untouched.
- `ui/src/lib/components/queue-strip.ts`: export `firstCurateRepo()`.
- `ui/src/routes/+page.svelte`: curate-only deep-link in the TopBar `onlearnings` handler.
- Tests: `TopBar.browser.test.ts` (TRIM vs LEARNINGS label/tooltip/aria) + `queue-strip.test.ts` (`firstCurateRepo`, incl. enabled gate + null fallback).

## Verification
- `bun run check` — 0 errors · `bun run check:i18n` — 1460 keys parity · `bun test` — green (new tests pass).

Ships as `fix:` — no feature-catalog entry; "Trim" is plain English, no glossary term. Subagent-implemented + reviewed (spec ✅, Approved); two Minor non-blocking notes recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)