### PR TITLE
feat(ui): show build-queue progress on session cards

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -384,6 +384,16 @@ function handleSubagentsSnapshot({ req, parts, deps }: Ctx): Response | null {
   return null;
 }
 
+function handleQueuesSnapshot({ req, parts, deps }: Ctx): Response | null {
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "queues" && !parts[2]) {
+    const queues = deps.store.listBuildQueues();
+    const map: Record<string, (typeof queues)[number]> = {};
+    for (const q of queues) map[q.sessionId] = q;
+    return json(map);
+  }
+  return null;
+}
+
 function handlePreviewSnapshot({ req, parts, deps }: Ctx): Response | null {
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "preview" && !parts[2]) {
     const preview = deps.preview?.snapshot() ?? {};
@@ -3878,6 +3888,7 @@ const ROUTE_HANDLERS = [
   handleWorkingBlockedSnapshot,
   handleSubagentsSnapshot,
   handlePreviewSnapshot,
+  handleQueuesSnapshot,
   handleReviews,
   handlePlanGates,
   handleRecaps,

--- a/src/store.ts
+++ b/src/store.ts
@@ -2195,6 +2195,43 @@ export class SessionStore implements CapStore, CreditStore {
     );
   }
 
+  /** Return one BuildQueue per session that has ≥1 step, via a single JOIN.
+   *  Sessions with no steps are omitted entirely. */
+  listBuildQueues(): BuildQueue[] {
+    const rows = this.db
+      .query(
+        `SELECT s.id AS stepId, s.sessionId, s.position, s.title, s.detail, s.status, st.approved
+         FROM build_queue_steps s
+         LEFT JOIN build_queue_state st ON st.sessionId = s.sessionId
+         ORDER BY s.sessionId, s.position`,
+      )
+      .all() as {
+      stepId: string;
+      sessionId: string;
+      position: number;
+      title: string;
+      detail: string;
+      status: string;
+      approved: number | null;
+    }[];
+    const map = new Map<string, BuildQueue>();
+    for (const r of rows) {
+      let q = map.get(r.sessionId);
+      if (!q) {
+        q = { sessionId: r.sessionId, steps: [], approved: r.approved ? !!r.approved : false };
+        map.set(r.sessionId, q);
+      }
+      q.steps.push({
+        id: r.stepId,
+        title: r.title,
+        detail: r.detail,
+        status: r.status as BuildStepStatus,
+        position: r.position,
+      });
+    }
+    return [...map.values()];
+  }
+
   // ── standalone repo-level PR reviews ─────────────────────────────────────
   getPrReview(repoPath: string, prNumber: number): PrReview | null {
     const r = this.db

--- a/src/store.ts
+++ b/src/store.ts
@@ -2218,7 +2218,7 @@ export class SessionStore implements CapStore, CreditStore {
     for (const r of rows) {
       let q = map.get(r.sessionId);
       if (!q) {
-        q = { sessionId: r.sessionId, steps: [], approved: r.approved ? !!r.approved : false };
+        q = { sessionId: r.sessionId, steps: [], approved: !!r.approved };
         map.set(r.sessionId, q);
       }
       q.steps.push({

--- a/test/build-queue-api.test.ts
+++ b/test/build-queue-api.test.ts
@@ -384,21 +384,27 @@ test("GET /api/queues returns empty object when no sessions have steps", async (
 });
 
 test("GET /api/queues route does not shadow GET /api/sessions/:id/queue", async () => {
+  // Proof: seed TWO sessions. A handler captured by /:id would only see one session's data;
+  // a genuine bulk handler returns a multi-session map → proves the right route fired.
   const { app, store } = harness();
-  const sess = makeSession(store, repoDir);
-  store.replaceBuildQueue(sess.id, [{ title: "Step A" }]);
+  const sess1 = makeSession(store, repoDir);
+  const sess2 = makeSession(store, repoDir);
+  store.replaceBuildQueue(sess1.id, [{ title: "Step A" }]);
+  store.replaceBuildQueue(sess2.id, [{ title: "Step B" }, { title: "Step C" }]);
 
-  // bulk endpoint
+  // bulk endpoint returns BOTH sessions — proves non-capture
   const bulk = await app.fetch(new Request(`http://x/api/queues`));
   expect(bulk.status).toBe(200);
   const bulkBody = (await bulk.json()) as Record<string, { sessionId: string; steps: unknown[] }>;
-  expect(bulkBody[sess.id]).toBeDefined();
-  expect(bulkBody[sess.id]!.steps).toHaveLength(1);
+  expect(bulkBody[sess1.id]).toBeDefined();
+  expect(bulkBody[sess1.id]!.steps).toHaveLength(1);
+  expect(bulkBody[sess2.id]).toBeDefined();
+  expect(bulkBody[sess2.id]!.steps).toHaveLength(2);
 
-  // per-session endpoint still works independently
-  const single = await app.fetch(new Request(`http://x/api/sessions/${sess.id}/queue`));
+  // per-session endpoint still works independently (co-existence)
+  const single = await app.fetch(new Request(`http://x/api/sessions/${sess1.id}/queue`));
   expect(single.status).toBe(200);
   const singleBody = await single.json();
-  expect(singleBody.sessionId).toBe(sess.id);
+  expect(singleBody.sessionId).toBe(sess1.id);
   expect(singleBody.steps).toHaveLength(1);
 });

--- a/test/build-queue-api.test.ts
+++ b/test/build-queue-api.test.ts
@@ -326,3 +326,79 @@ test("POST queue/approve for unknown session → 404", async () => {
   );
   expect(res.status).toBe(404);
 });
+
+// ── GET /api/queues — bulk snapshot ──────────────────────────────────────────
+
+test("GET /api/queues returns keyed map of sessions with steps, approved flag", async () => {
+  const { app, store } = harness();
+  const sess1 = makeSession(store, repoDir);
+  const sess2 = makeSession(store, repoDir);
+
+  store.replaceBuildQueue(sess1.id, [{ title: "Step A" }, { title: "Step B" }]);
+  store.setBuildQueueApproved(sess1.id, true);
+  store.replaceBuildQueue(sess2.id, [{ title: "Step C" }]);
+  // sess2 approved defaults to false
+
+  const res = await app.fetch(new Request(`http://x/api/queues`));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Record<
+    string,
+    { sessionId: string; steps: unknown[]; approved: boolean }
+  >;
+
+  // sess1: 2 steps, approved=true
+  expect(body[sess1.id]).toBeDefined();
+  expect(body[sess1.id]!.sessionId).toBe(sess1.id);
+  expect(body[sess1.id]!.steps).toHaveLength(2);
+  expect(body[sess1.id]!.approved).toBe(true);
+
+  // sess2: 1 step, approved=false
+  expect(body[sess2.id]).toBeDefined();
+  expect(body[sess2.id]!.sessionId).toBe(sess2.id);
+  expect(body[sess2.id]!.steps).toHaveLength(1);
+  expect(body[sess2.id]!.approved).toBe(false);
+});
+
+test("GET /api/queues omits sessions with no steps", async () => {
+  const { app, store } = harness();
+  const withSteps = makeSession(store, repoDir);
+  const noSteps = makeSession(store, repoDir);
+
+  store.replaceBuildQueue(withSteps.id, [{ title: "Step A" }]);
+  // noSteps has no queue entries
+
+  const res = await app.fetch(new Request(`http://x/api/queues`));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Record<string, unknown>;
+
+  expect(body[withSteps.id]).toBeDefined();
+  expect(body[noSteps.id]).toBeUndefined();
+});
+
+test("GET /api/queues returns empty object when no sessions have steps", async () => {
+  const { app } = harness();
+  const res = await app.fetch(new Request(`http://x/api/queues`));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({});
+});
+
+test("GET /api/queues route does not shadow GET /api/sessions/:id/queue", async () => {
+  const { app, store } = harness();
+  const sess = makeSession(store, repoDir);
+  store.replaceBuildQueue(sess.id, [{ title: "Step A" }]);
+
+  // bulk endpoint
+  const bulk = await app.fetch(new Request(`http://x/api/queues`));
+  expect(bulk.status).toBe(200);
+  const bulkBody = (await bulk.json()) as Record<string, { sessionId: string; steps: unknown[] }>;
+  expect(bulkBody[sess.id]).toBeDefined();
+  expect(bulkBody[sess.id]!.steps).toHaveLength(1);
+
+  // per-session endpoint still works independently
+  const single = await app.fetch(new Request(`http://x/api/sessions/${sess.id}/queue`));
+  expect(single.status).toBe(200);
+  const singleBody = await single.json();
+  expect(singleBody.sessionId).toBe(sess.id);
+  expect(singleBody.steps).toHaveLength(1);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1463,5 +1463,10 @@
   "buildqueue_collapse_aria": "Build-Queue einklappen",
   "buildqueue_expand_aria": "Build-Queue ausklappen",
   "feat_build_queue_collapse_title": "Build-Queue einklappen",
-  "feat_build_queue_collapse_body": "Die Build-Queue kann jetzt zu einer einzelnen Leiste eingeklappt werden, damit sie das Terminal nicht mehr verdeckt. Klicke auf den Pfeil in der Kopfzeile, um sie ein- oder auszuklappen."
+  "feat_build_queue_collapse_body": "Die Build-Queue kann jetzt zu einer einzelnen Leiste eingeklappt werden, damit sie das Terminal nicht mehr verdeckt. Klicke auf den Pfeil in der Kopfzeile, um sie ein- oder auszuklappen.",
+  "queuebadge_label": "{resolved}/{total}",
+  "queuebadge_title": "Build-Queue: {resolved} von {total} Schritten erledigt",
+  "queuebadge_aria": "Build-Queue: {resolved} von {total} Schritten erledigt",
+  "feat_build_queue_progress_title": "Build-Queue-Fortschritt auf einen Blick",
+  "feat_build_queue_progress_body": "Session-Karten zeigen jetzt ein kleines bernsteinfarbenes Badge mit Fortschrittsbalken, wenn eine genehmigte Build-Queue aktiv ist — erledigte / Gesamtschritte ohne Öffnen des Panels einsehbar."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1463,5 +1463,10 @@
   "buildqueue_collapse_aria": "Collapse build queue",
   "buildqueue_expand_aria": "Expand build queue",
   "feat_build_queue_collapse_title": "Collapse the build queue",
-  "feat_build_queue_collapse_body": "The build queue can now be collapsed to a single bar so it no longer covers the terminal. Click the chevron in its header to fold or unfold it."
+  "feat_build_queue_collapse_body": "The build queue can now be collapsed to a single bar so it no longer covers the terminal. Click the chevron in its header to fold or unfold it.",
+  "queuebadge_label": "{resolved}/{total}",
+  "queuebadge_title": "Build queue: {resolved} of {total} steps done",
+  "queuebadge_aria": "Build queue: {resolved} of {total} steps done",
+  "feat_build_queue_progress_title": "Build queue progress at a glance",
+  "feat_build_queue_progress_body": "Session cards now show a small amber badge with a progress meter when an approved build queue is active — see resolved / total steps without opening the panel."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1151,6 +1151,14 @@ export async function promoteLearning(id: string): Promise<{ url: string }> {
   return r.json();
 }
 
+/** Snapshot of every session's build queue that has ≥1 step, keyed by session
+ *  id (for the Herd list overview). Sessions with no steps are absent. */
+export async function getBuildQueues(): Promise<Record<string, BuildQueue>> {
+  const r = await fetch("/api/queues");
+  if (!r.ok) throw await failed(r, "build queues");
+  return r.json();
+}
+
 export async function getBuildQueue(sessionId: string): Promise<BuildQueue> {
   return getJson(`/api/sessions/${encodeURIComponent(sessionId)}/queue`, "build-queue");
 }

--- a/ui/src/lib/buildQueues.svelte.ts
+++ b/ui/src/lib/buildQueues.svelte.ts
@@ -1,0 +1,21 @@
+import type { BuildQueue } from "./types";
+
+/** Module-level reactive build-queue map keyed by sessionId.
+ *  Driven by two sources:
+ *  - WS `queue:update` events (via HerdStore.apply → upsertBuildQueue)
+ *  - The resync bootstrap GET /api/queues (via seedBuildQueues)
+ *  Components (e.g. BuildQueueBadge) read from this directly by sessionId
+ *  without needing the page-local HerdStore instance as a prop. */
+class BuildQueuesStore {
+  map = $state<Record<string, BuildQueue>>({});
+
+  upsert(q: BuildQueue) {
+    this.map = { ...this.map, [q.sessionId]: q };
+  }
+
+  seed(queues: Record<string, BuildQueue>) {
+    this.map = queues;
+  }
+}
+
+export const buildQueues = new BuildQueuesStore();

--- a/ui/src/lib/components/BuildQueueBadge.browser.test.ts
+++ b/ui/src/lib/components/BuildQueueBadge.browser.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { BuildQueue, BuildStep, BuildStepStatus } from "$lib/types";
+
+const { default: BuildQueueBadge } = await import("./BuildQueueBadge.svelte");
+const { buildQueues } = await import("$lib/buildQueues.svelte");
+
+const step = (status: BuildStepStatus, id: string): BuildStep => ({
+  id,
+  title: `Step ${id}`,
+  status,
+  position: parseInt(id),
+});
+
+const queue = (approved: boolean, steps: BuildStep[], sessionId = "s1"): BuildQueue => ({
+  sessionId,
+  approved,
+  steps,
+});
+
+beforeEach(() => {
+  buildQueues.map = {};
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("BuildQueueBadge", () => {
+  it("renders nothing when queue is unapproved (approved=false) even with steps", async () => {
+    buildQueues.map = {
+      s1: queue(false, [step("done", "1"), step("pending", "2")]),
+    };
+    render(BuildQueueBadge, { sessionId: "s1" });
+    expect(document.querySelector(".queue-badge")).toBeNull();
+  });
+
+  it("renders nothing when there is no queue for the session", async () => {
+    render(BuildQueueBadge, { sessionId: "s1" });
+    expect(document.querySelector(".queue-badge")).toBeNull();
+  });
+
+  it("renders nothing when approved but steps array is empty", async () => {
+    buildQueues.map = {
+      s1: queue(true, []),
+    };
+    render(BuildQueueBadge, { sessionId: "s1" });
+    expect(document.querySelector(".queue-badge")).toBeNull();
+  });
+
+  it("shows resolved/total — done+skipped count as resolved, pending does not", async () => {
+    // 3 done + 1 skipped + 1 pending of 5 → resolved=4, total=5 → "4/5"
+    buildQueues.map = {
+      s1: queue(true, [
+        step("done", "1"),
+        step("done", "2"),
+        step("done", "3"),
+        step("skipped", "4"),
+        step("pending", "5"),
+      ]),
+    };
+    render(BuildQueueBadge, { sessionId: "s1" });
+    await expect.element(page.getByText("4/5")).toBeInTheDocument();
+  });
+
+  it("meter fill width reflects resolved/total via --queue-pct", async () => {
+    // 4/5 = 80%
+    buildQueues.map = {
+      s1: queue(true, [
+        step("done", "1"),
+        step("done", "2"),
+        step("done", "3"),
+        step("skipped", "4"),
+        step("pending", "5"),
+      ]),
+    };
+    render(BuildQueueBadge, { sessionId: "s1" });
+    const badge = document.querySelector(".queue-badge") as HTMLElement;
+    expect(badge).not.toBeNull();
+    expect(badge.style.getPropertyValue("--queue-pct")).toBe("80%");
+  });
+
+  it("all resolved (all done) → shows 5/5 with 100% meter", async () => {
+    buildQueues.map = {
+      s1: queue(true, [
+        step("done", "1"),
+        step("done", "2"),
+        step("done", "3"),
+        step("done", "4"),
+        step("done", "5"),
+      ]),
+    };
+    render(BuildQueueBadge, { sessionId: "s1" });
+    await expect.element(page.getByText("5/5")).toBeInTheDocument();
+    const badge = document.querySelector(".queue-badge") as HTMLElement;
+    expect(badge.style.getPropertyValue("--queue-pct")).toBe("100%");
+  });
+
+  it("all resolved via mix of done+skipped → shows 5/5", async () => {
+    buildQueues.map = {
+      s1: queue(true, [
+        step("done", "1"),
+        step("done", "2"),
+        step("skipped", "3"),
+        step("skipped", "4"),
+        step("done", "5"),
+      ]),
+    };
+    render(BuildQueueBadge, { sessionId: "s1" });
+    await expect.element(page.getByText("5/5")).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/BuildQueueBadge.svelte
+++ b/ui/src/lib/components/BuildQueueBadge.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { buildQueues } from "$lib/buildQueues.svelte";
+  import { m } from "$lib/paraglide/messages";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
+
+  let { sessionId }: { sessionId: string } = $props();
+
+  const queue = $derived(buildQueues.map[sessionId] ?? null);
+  const total = $derived(queue?.steps.length ?? 0);
+  const resolved = $derived(
+    queue?.steps.filter((s) => s.status === "done" || s.status === "skipped").length ?? 0,
+  );
+  const pct = $derived(total > 0 ? (resolved / total) * 100 : 0);
+</script>
+
+{#if queue?.approved && total > 0}
+  <span
+    class="queue-badge"
+    role="img"
+    style="--queue-pct: {pct}%"
+    title={m.queuebadge_title({ resolved, total })}
+    aria-label={m.queuebadge_aria({ resolved, total })}
+    use:coachTarget={"build-queue-progress"}
+  >
+    <span class="queue-label">{m.queuebadge_label({ resolved, total })}</span>
+    <span class="queue-meter" aria-hidden="true"><span class="queue-fill"></span></span>
+  </span>
+{/if}
+
+<style>
+  .queue-badge {
+    display: inline-flex;
+    flex-direction: column;
+    flex: none;
+    gap: 2px;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-weight: 600;
+    padding: 1px 6px;
+    border: 1px solid var(--color-amber);
+    border-radius: 2px;
+    color: var(--color-amber);
+    background: transparent;
+    white-space: nowrap;
+  }
+  .queue-meter {
+    display: block;
+    height: 2px;
+    width: 100%;
+    background: var(--color-line);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .queue-fill {
+    display: block;
+    height: 100%;
+    width: var(--queue-pct);
+    background: var(--color-amber);
+  }
+</style>

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -34,6 +34,7 @@
   import PrBadge from "./PrBadge.svelte";
   import TimePopover from "./TimePopover.svelte";
   import CriticBadge from "./CriticBadge.svelte";
+  import BuildQueueBadge from "./BuildQueueBadge.svelte";
   import HeartbeatStrip from "./HeartbeatStrip.svelte";
   import Stepper from "./Stepper.svelte";
   import { reviews } from "$lib/reviews.svelte";
@@ -458,6 +459,7 @@
       <ResearchBadge {session} />
       {#if !stepperTerminal}<PrBadge {git} />{/if}
       <CriticBadge sessionId={session.id} />
+      <BuildQueueBadge sessionId={session.id} />
       <PlanGateBadge {session} />
       {#if quotaKind}
         <span

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1046,4 +1046,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_build_queue_collapse_body",
     targetId: "build-queue-collapse",
   },
+  {
+    // coachTarget "build-queue-progress" is on the BuildQueueBadge span itself
+    // (conditionally rendered when approved + steps > 0). 1.33.0 is the latest
+    // released tag, so this ships in 1.34.0.
+    id: "build-queue-progress",
+    sinceVersion: "1.34.0",
+    titleKey: "feat_build_queue_progress_title",
+    bodyKey: "feat_build_queue_progress_body",
+    targetId: "build-queue-progress",
+  },
 ];

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -28,6 +28,7 @@ import { learnings } from "./learnings.svelte";
 import { toasts } from "./toasts.svelte";
 import { m } from "$lib/paraglide/messages";
 import { offerUpdateMain } from "./pull-offer";
+import { buildQueues as buildQueuesStore } from "./buildQueues.svelte";
 
 export class HerdStore {
   sessions = $state<Session[]>([]);
@@ -144,6 +145,12 @@ export class HerdStore {
   /** Seed (or replace) the build queue for a session — called after a bootstrap GET. */
   setBuildQueue(q: BuildQueue) {
     this.buildQueues = { ...this.buildQueues, [q.sessionId]: q };
+    buildQueuesStore.upsert(q);
+  }
+  /** Bulk-replace the build queue map — called after a resync GET /api/queues. */
+  setBuildQueues(map: Record<string, BuildQueue>) {
+    this.buildQueues = map;
+    buildQueuesStore.seed(map);
   }
   /** Upsert an epic — called after GET/PUT /api/epic or on `epic:update` WS push. */
   setEpic(e: Epic) {
@@ -423,6 +430,7 @@ export class HerdStore {
         break;
       case "queue:update":
         this.buildQueues = { ...this.buildQueues, [ev.data.sessionId]: ev.data };
+        buildQueuesStore.upsert(ev.data);
         break;
       case "epic:update":
         this.setEpic(ev.data);

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -41,6 +41,7 @@
     halt as apiHalt,
     resumeQuota,
     dismissQuota,
+    getBuildQueues,
   } from "$lib/api";
   import type {
     CompletedEpic,
@@ -430,6 +431,9 @@
       .catch(() => {});
     getBacklog()
       .then((p) => (backlog = p))
+      .catch(() => {});
+    getBuildQueues()
+      .then((m) => store.setBuildQueues(m))
       .catch(() => {});
     // Reconcile critic + plan-gate verdicts and their reviewing latches from the
     // server snapshot (both self-handle errors). load() re-fetches the /inflight


### PR DESCRIPTION
## What

Surfaces a task's **build-queue progress** on its card in the Herd (session list), mirroring how epic progress is shown — a small `resolved/total` count + 2px meter.

![placement: a "QUEUE 3/5" amber badge with meter, in the card's badge rail]

A build queue belongs to a **single session** (unlike an epic, which spans many and gets a group-header badge), so the indicator lives on the session's own row.

## Behavior (confirmed product decisions)

- **Visual:** epic-style count + 2px meter (mirrors `EpicBadge`), **amber** — the in-progress semantic (matches `BuildQueuePanel`'s `.bqp-approved`; green is reserved for READY, blue for epic/preview).
- **Visibility:** renders **only** when the queue is **approved with steps** (`approved === true && steps.length > 0`). During curation (unapproved) or with no queue, the card stays clean.
- **Denominator:** `resolved / total` where `resolved = done + skipped` — a skipped step counts as resolved so an intentionally-dropped step still lets the bar reach 100%.

## How

- **Server:** new top-level `GET /api/queues` (`handleQueuesSnapshot`, mirroring `/api/git` · `/api/activity` · `/api/drain`) returns `Record<sessionId, BuildQueue>` for queues with ≥1 step, backed by a **single-JOIN** `store.listBuildQueues()` (resync-safe — no N+1). Top-level path means no `/api/sessions/:id` route collision.
- **UI:** `+page.svelte` `resync()` eagerly seeds all queues via `getBuildQueues()`; the server already broadcasts `queue:update` to all clients, so badges stay live. `BuildQueueBadge.svelte` reads a module-level `buildQueues` singleton (the `reviews`/`planGates` pattern `CriticBadge` uses) — no new prop threaded through Herd/UnitRow. Rendered in `UnitRow`'s `.u-right` rail beside `CriticBadge`.
- **i18n / discovery:** new `queuebadge_*` keys in EN + DE; one `feature-announcements.ts` entry (`build-queue-progress`, `sinceVersion 1.34.0`) with a coachmark anchor.

## Tests

- Server (`test/build-queue-api.test.ts`): bulk-map shape, empty-session exclusion, and a **route-precedence** test proving `/api/queues` returns a multi-session map (i.e. is not captured by the `/api/sessions/:id` family) while `/api/sessions/:id/queue` still works.
- UI (`BuildQueueBadge.browser.test.ts`, 7 cases): visibility gating (unapproved / no-queue / empty), `resolved = done+skipped` math, all-resolved → 100%, meter width.

## Verification

Root `bun run lint` clean · `bun test ./test` 3483 pass / 0 fail · `bunx tsc --noEmit` clean · UI `bun run check` 0 errors · `bun run test` green · `bun run check:i18n` parity · branch-hygiene + feature-catalog + glossary gates green. Executed subagent-driven (implement → per-task review → fixes → final whole-branch review, no blocking findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)