### PR TITLE
feat(ui): collapsible build-queue panel

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1459,5 +1459,9 @@
   "feat_base_freshen_title": "Basis-Branch wird vom Upstream aktualisiert",
   "feat_base_freshen_body": "Neue Aufgaben starten jetzt vom neuesten Upstream-Stand des Basis-Branches — Shepherd holt und spult beim Start vor (fast-forward), sodass du Upstream-Änderungen nach Abschluss nicht mehr von Hand einpflegen musst. Der New-Task-Dialog weist darauf hin, wenn deine Basis zurückliegt oder von origin abgewichen ist.",
   "topbar_learnings_tip": "Vorgeschlagene Hausregeln über alle deine Repos prüfen",
-  "topbar_learnings_curate_tip": "Bereits genehmigte Regeln, die nicht ins Injektions-Budget passen — kürze einige, damit die übrigen neue Agents erreichen"
+  "topbar_learnings_curate_tip": "Bereits genehmigte Regeln, die nicht ins Injektions-Budget passen — kürze einige, damit die übrigen neue Agents erreichen",
+  "buildqueue_collapse_aria": "Build-Queue einklappen",
+  "buildqueue_expand_aria": "Build-Queue ausklappen",
+  "feat_build_queue_collapse_title": "Build-Queue einklappen",
+  "feat_build_queue_collapse_body": "Die Build-Queue kann jetzt zu einer einzelnen Leiste eingeklappt werden, damit sie das Terminal nicht mehr verdeckt. Klicke auf den Pfeil in der Kopfzeile, um sie ein- oder auszuklappen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1459,5 +1459,9 @@
   "feat_base_freshen_title": "Base branch freshens from upstream",
   "feat_base_freshen_body": "New tasks now start from the latest upstream tip of the base branch — Shepherd fetches and fast-forwards at launch, so you no longer fold in upstream changes by hand when the task is done. The New Task dialog flags when your base is behind or has diverged from origin.",
   "topbar_learnings_tip": "Review proposed house rules across all your repos",
-  "topbar_learnings_curate_tip": "Already-approved rules that don't fit the injection budget — trim some so the rest reach new agents"
+  "topbar_learnings_curate_tip": "Already-approved rules that don't fit the injection budget — trim some so the rest reach new agents",
+  "buildqueue_collapse_aria": "Collapse build queue",
+  "buildqueue_expand_aria": "Expand build queue",
+  "feat_build_queue_collapse_title": "Collapse the build queue",
+  "feat_build_queue_collapse_body": "The build queue can now be collapsed to a single bar so it no longer covers the terminal. Click the chevron in its header to fold or unfold it."
 }

--- a/ui/src/lib/build-queue-collapse.svelte.test.ts
+++ b/ui/src/lib/build-queue-collapse.svelte.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Stub localStorage before importing the module so the singleton's read() call
+// at init doesn't touch a real or missing localStorage.
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => {
+    store[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete store[key];
+  },
+  clear: () => {
+    for (const k of Object.keys(store)) delete store[k];
+  },
+};
+// @ts-expect-error stubbing global
+globalThis.localStorage = localStorageMock;
+
+import { buildQueueCollapse, readBuildQueueCollapse } from "./build-queue-collapse.svelte";
+
+const KEY = "shepherd:build-queue-collapsed";
+
+beforeEach(() => {
+  localStorageMock.clear();
+  // Reset the store state to false (mirrors a fresh/unset localStorage)
+  buildQueueCollapse.set(false);
+  localStorageMock.clear(); // clear side-effect write from the reset above
+});
+
+// ---------------------------------------------------------------------------
+// Store: default / toggle / set / localStorage
+// ---------------------------------------------------------------------------
+
+describe("buildQueueCollapse store", () => {
+  it("defaults to false (expanded) when localStorage is empty", () => {
+    expect(buildQueueCollapse.collapsed).toBe(false);
+  });
+
+  it("reads true when key is '1' at construction (via set + re-read)", () => {
+    // The singleton is already constructed; we verify persistence by setting
+    // and confirming the value round-trips through the mock store.
+    buildQueueCollapse.set(true);
+    expect(store[KEY]).toBe("1");
+    expect(buildQueueCollapse.collapsed).toBe(true);
+  });
+
+  it("read() returns true when localStorage key is '1'", () => {
+    store[KEY] = "1";
+    expect(readBuildQueueCollapse()).toBe(true);
+  });
+
+  it("toggle flips collapsed from false to true", () => {
+    expect(buildQueueCollapse.collapsed).toBe(false);
+    buildQueueCollapse.toggle();
+    expect(buildQueueCollapse.collapsed).toBe(true);
+  });
+
+  it("toggle flips collapsed from true to false", () => {
+    buildQueueCollapse.set(true);
+    buildQueueCollapse.toggle();
+    expect(buildQueueCollapse.collapsed).toBe(false);
+  });
+
+  it("set(true) writes '1' to localStorage under the correct key", () => {
+    buildQueueCollapse.set(true);
+    expect(store[KEY]).toBe("1");
+  });
+
+  it("set(false) removes the key from localStorage", () => {
+    store[KEY] = "1"; // seed it
+    buildQueueCollapse.set(false);
+    expect(store[KEY]).toBeUndefined();
+  });
+
+  it("set(true) sets collapsed to true", () => {
+    buildQueueCollapse.set(true);
+    expect(buildQueueCollapse.collapsed).toBe(true);
+  });
+
+  it("set(false) sets collapsed to false", () => {
+    buildQueueCollapse.set(true);
+    buildQueueCollapse.set(false);
+    expect(buildQueueCollapse.collapsed).toBe(false);
+  });
+
+  it("absent localStorage value → false", () => {
+    // store is cleared in beforeEach; collapsed should be false
+    expect(buildQueueCollapse.collapsed).toBe(false);
+    expect(store[KEY]).toBeUndefined();
+  });
+
+  it("read() returns false when localStorage key is absent", () => {
+    // store is cleared in beforeEach
+    expect(readBuildQueueCollapse()).toBe(false);
+  });
+
+  it("read() returns false for corrupt/garbage localStorage value", () => {
+    store[KEY] = "garbage";
+    expect(readBuildQueueCollapse()).toBe(false);
+  });
+
+  it("read() returns false for empty-string localStorage value", () => {
+    store[KEY] = "";
+    expect(readBuildQueueCollapse()).toBe(false);
+  });
+});

--- a/ui/src/lib/build-queue-collapse.svelte.ts
+++ b/ui/src/lib/build-queue-collapse.svelte.ts
@@ -1,0 +1,28 @@
+const KEY = "shepherd:build-queue-collapsed";
+
+function read(): boolean {
+  try {
+    return localStorage.getItem(KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+class BuildQueueCollapse {
+  collapsed = $state(read());
+  toggle() {
+    this.set(!this.collapsed);
+  }
+  set(v: boolean) {
+    this.collapsed = v;
+    try {
+      if (v) localStorage.setItem(KEY, "1");
+      else localStorage.removeItem(KEY);
+    } catch {
+      /* private mode / SSR — preference just won't survive reload */
+    }
+  }
+}
+
+export const buildQueueCollapse = new BuildQueueCollapse();
+export { read as readBuildQueueCollapse };

--- a/ui/src/lib/components/BuildQueuePanel.browser.test.ts
+++ b/ui/src/lib/components/BuildQueuePanel.browser.test.ts
@@ -5,6 +5,7 @@ import "../../app.css";
 import type { BuildQueue } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import { putBuildQueue } from "$lib/api";
+import { buildQueueCollapse } from "$lib/build-queue-collapse.svelte";
 
 // Mock the API so no real network calls are made.
 vi.mock("$lib/api", async (importOriginal) => {
@@ -27,6 +28,7 @@ const { default: BuildQueuePanel } = await import("./BuildQueuePanel.svelte");
 
 let fontStyle: HTMLStyleElement;
 beforeEach(() => {
+  buildQueueCollapse.set(false);
   fontStyle = document.createElement("style");
   fontStyle.textContent = `:root {
     --font-mono: ui-monospace, monospace;
@@ -241,5 +243,104 @@ describe("BuildQueuePanel — approved/running state", () => {
     const activeBadges = document.querySelectorAll(".badge-active");
     expect(doneBadges.length).toBeGreaterThan(0);
     expect(activeBadges.length).toBeGreaterThan(0);
+  });
+});
+
+describe("BuildQueuePanel — collapse/expand", () => {
+  const curationQueue: BuildQueue = {
+    sessionId: "s1",
+    approved: false,
+    steps: [
+      { id: "a", title: "Install deps", status: "pending", position: 0 },
+      { id: "b", title: "Run tests", status: "pending", position: 1 },
+    ],
+  };
+
+  it("initially expanded: content wrapper visible, inputs visible", async () => {
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: curationQueue,
+      onbootstrap: noop,
+    });
+    const content = document.querySelector(".bqp-content");
+    expect(content).not.toBeNull();
+    await expect
+      .element(page.getByRole("textbox", { name: `${m.buildqueue_step_title_aria()} 1` }))
+      .toBeVisible();
+    const toggleBtn = document.querySelector<HTMLButtonElement>("button.bqp-collapse-toggle");
+    expect(toggleBtn?.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("after collapse: content wrapper not visible, wrapper + id still in DOM, inputs not visible, aria-expanded false", async () => {
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: curationQueue,
+      onbootstrap: noop,
+    });
+
+    buildQueueCollapse.set(true);
+    // poll until Svelte reactivity flushes and the collapsed class appears
+    await expect
+      .poll(() => document.querySelector<HTMLElement>(".bqp-content.collapsed"))
+      .toBeTruthy();
+
+    // wrapper stays in the DOM with the correct id
+    const content = document.querySelector<HTMLElement>(".bqp-content");
+    expect(content, "wrapper stays in DOM").not.toBeNull();
+    expect(content!.id).toBe("bqp-content-s1");
+
+    // wrapper has the collapsed class applied → CSS display:none cascade hides it
+    expect(content!.classList.contains("collapsed"), "collapsed class present").toBe(true);
+
+    // wrapper itself is layout-excluded (proves display:none on .bqp-content.collapsed)
+    expect(content!.offsetParent, "wrapper hidden (offsetParent null)").toBeNull();
+
+    // each curation input is physically inside the hidden wrapper → not visible
+    const inputs = document.querySelectorAll<HTMLInputElement>("input.bqp-title-input");
+    expect(inputs.length, "inputs still in DOM").toBe(2);
+    for (const input of inputs) {
+      // offsetParent is null for elements that are not rendered (display:none on self or ancestor)
+      expect(input.offsetParent, "input hidden by cascade (offsetParent null)").toBeNull();
+    }
+
+    // toggle button reports collapsed state
+    const toggleBtn = document.querySelector<HTMLButtonElement>("button.bqp-collapse-toggle");
+    expect(toggleBtn?.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("after toggling back to expanded: wrapper and inputs visible, aria-expanded true", async () => {
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: curationQueue,
+      onbootstrap: noop,
+    });
+
+    buildQueueCollapse.set(true);
+    // wait for collapse to flush
+    await expect
+      .poll(() => document.querySelector<HTMLElement>(".bqp-content.collapsed"))
+      .toBeTruthy();
+
+    buildQueueCollapse.set(false);
+    // wait until wrapper is layout-visible again (offsetParent non-null)
+    await expect
+      .poll(() => document.querySelector<HTMLElement>(".bqp-content")?.offsetParent)
+      .not.toBeNull();
+
+    // aria-expanded should reflect expanded state
+    await expect
+      .poll(() =>
+        document
+          .querySelector<HTMLButtonElement>("button.bqp-collapse-toggle")
+          ?.getAttribute("aria-expanded"),
+      )
+      .toBe("true");
+
+    await expect
+      .element(page.getByRole("textbox", { name: `${m.buildqueue_step_title_aria()} 1` }))
+      .toBeVisible();
   });
 });

--- a/ui/src/lib/components/BuildQueuePanel.svelte
+++ b/ui/src/lib/components/BuildQueuePanel.svelte
@@ -2,6 +2,8 @@
   import type { BuildQueue, BuildStep, BuildStepStatus } from "$lib/types";
   import { getBuildQueue, putBuildQueue, approveBuildQueue } from "$lib/api";
   import { m } from "$lib/paraglide/messages";
+  import { buildQueueCollapse } from "$lib/build-queue-collapse.svelte";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
 
   let {
     sessionId,
@@ -39,6 +41,8 @@
   const visible = $derived(enabled || (queue !== null && queue.steps.length > 0));
   const steps = $derived(queue?.steps ?? []);
   const approved = $derived(queue?.approved ?? false);
+
+  const contentId = $derived(`bqp-content-${sessionId}`);
 
   // ------------- edit helpers -------------
 
@@ -140,113 +144,129 @@
       {#if approved && steps.length > 0}
         <span class="bqp-approved">{m.buildqueue_approved_header()}</span>
       {/if}
+      <button
+        type="button"
+        class="bqp-btn bqp-collapse-toggle"
+        onclick={() => buildQueueCollapse.toggle()}
+        aria-expanded={!buildQueueCollapse.collapsed}
+        aria-controls={contentId}
+        aria-label={buildQueueCollapse.collapsed
+          ? m.buildqueue_expand_aria()
+          : m.buildqueue_collapse_aria()}
+        title={buildQueueCollapse.collapsed
+          ? m.buildqueue_expand_aria()
+          : m.buildqueue_collapse_aria()}
+        use:coachTarget={"build-queue-collapse"}>{buildQueueCollapse.collapsed ? "▴" : "▾"}</button
+      >
     </div>
 
-    {#if steps.length === 0}
-      <p class="bqp-empty">{m.buildqueue_empty()}</p>
-    {:else if !approved}
-      <!-- Curation mode: editable list -->
-      <ol class="bqp-list" aria-label={m.buildqueue_panel_title()}>
-        {#each steps as step, i (step.id)}
-          <li class="bqp-row">
-            <span
-              class={["bqp-badge", statusClass(step.status)]}
-              aria-label={statusLabel(step.status)}>{statusLabel(step.status)}</span
-            >
-
-            <div class="bqp-fields">
-              <input
-                class="bqp-input bqp-title-input"
-                type="text"
-                value={step.title}
-                aria-label={`${m.buildqueue_step_title_aria()} ${i + 1}`}
-                placeholder={m.buildqueue_new_step()}
-                onblur={(e) => {
-                  commitTitle(step, (e.currentTarget as HTMLInputElement).value);
-                }}
-                onkeydown={(e) => {
-                  if (e.key === "Enter") (e.currentTarget as HTMLInputElement).blur();
-                  if (e.key === "Escape") {
-                    (e.currentTarget as HTMLInputElement).value = step.title;
-                    (e.currentTarget as HTMLInputElement).blur();
-                  }
-                }}
-              />
-              <input
-                class="bqp-input bqp-detail-input"
-                type="text"
-                value={step.detail ?? ""}
-                aria-label={`${m.buildqueue_step_detail_aria()} ${i + 1}`}
-                placeholder={m.buildqueue_step_detail_placeholder()}
-                onblur={(e) => {
-                  commitDetail(step, (e.currentTarget as HTMLInputElement).value);
-                }}
-                onkeydown={(e) => {
-                  if (e.key === "Enter") (e.currentTarget as HTMLInputElement).blur();
-                  if (e.key === "Escape") {
-                    (e.currentTarget as HTMLInputElement).value = step.detail ?? "";
-                    (e.currentTarget as HTMLInputElement).blur();
-                  }
-                }}
-              />
-            </div>
-
-            <div class="bqp-row-actions">
-              <button
-                type="button"
-                class="bqp-btn bqp-move"
-                disabled={i === 0}
-                onclick={() => moveStep(step.id, -1)}
-                aria-label={m.buildqueue_move_up_aria()}
-                title={m.buildqueue_move_up_aria()}>▲</button
+    <div class="bqp-content" id={contentId} class:collapsed={buildQueueCollapse.collapsed}>
+      {#if steps.length === 0}
+        <p class="bqp-empty">{m.buildqueue_empty()}</p>
+      {:else if !approved}
+        <!-- Curation mode: editable list -->
+        <ol class="bqp-list" aria-label={m.buildqueue_panel_title()}>
+          {#each steps as step, i (step.id)}
+            <li class="bqp-row">
+              <span
+                class={["bqp-badge", statusClass(step.status)]}
+                aria-label={statusLabel(step.status)}>{statusLabel(step.status)}</span
               >
-              <button
-                type="button"
-                class="bqp-btn bqp-move"
-                disabled={i === steps.length - 1}
-                onclick={() => moveStep(step.id, 1)}
-                aria-label={m.buildqueue_move_down_aria()}
-                title={m.buildqueue_move_down_aria()}>▼</button
-              >
-              <button
-                type="button"
-                class="bqp-btn bqp-remove"
-                onclick={() => removeStep(step.id)}
-                aria-label={m.buildqueue_remove_aria()}
-                title={m.buildqueue_remove_aria()}>✕</button
-              >
-            </div>
-          </li>
-        {/each}
-      </ol>
 
-      <div class="bqp-footer">
-        <button type="button" class="bqp-btn bqp-add" onclick={addStep}>
-          {m.buildqueue_add_step()}
-        </button>
-        <button type="button" class="bqp-btn bqp-approve" onclick={approve}>
-          {m.buildqueue_approve()}
-        </button>
-      </div>
-    {:else}
-      <!-- Approved/running: read-only list -->
-      <ol class="bqp-list" aria-label={m.buildqueue_panel_title()}>
-        {#each steps as step (step.id)}
-          <li class="bqp-row bqp-row-readonly">
-            <span
-              class={["bqp-badge", statusClass(step.status)]}
-              aria-label={statusLabel(step.status)}>{statusLabel(step.status)}</span
-            >
-            <div class="bqp-fields">
-              <span class="bqp-step-title">{step.title}</span>
-              {#if step.detail}
-                <span class="bqp-step-detail">{step.detail}</span>
-              {/if}
-            </div>
-          </li>
-        {/each}
-      </ol>
-    {/if}
+              <div class="bqp-fields">
+                <input
+                  class="bqp-input bqp-title-input"
+                  type="text"
+                  value={step.title}
+                  aria-label={`${m.buildqueue_step_title_aria()} ${i + 1}`}
+                  placeholder={m.buildqueue_new_step()}
+                  onblur={(e) => {
+                    commitTitle(step, (e.currentTarget as HTMLInputElement).value);
+                  }}
+                  onkeydown={(e) => {
+                    if (e.key === "Enter") (e.currentTarget as HTMLInputElement).blur();
+                    if (e.key === "Escape") {
+                      (e.currentTarget as HTMLInputElement).value = step.title;
+                      (e.currentTarget as HTMLInputElement).blur();
+                    }
+                  }}
+                />
+                <input
+                  class="bqp-input bqp-detail-input"
+                  type="text"
+                  value={step.detail ?? ""}
+                  aria-label={`${m.buildqueue_step_detail_aria()} ${i + 1}`}
+                  placeholder={m.buildqueue_step_detail_placeholder()}
+                  onblur={(e) => {
+                    commitDetail(step, (e.currentTarget as HTMLInputElement).value);
+                  }}
+                  onkeydown={(e) => {
+                    if (e.key === "Enter") (e.currentTarget as HTMLInputElement).blur();
+                    if (e.key === "Escape") {
+                      (e.currentTarget as HTMLInputElement).value = step.detail ?? "";
+                      (e.currentTarget as HTMLInputElement).blur();
+                    }
+                  }}
+                />
+              </div>
+
+              <div class="bqp-row-actions">
+                <button
+                  type="button"
+                  class="bqp-btn bqp-move"
+                  disabled={i === 0}
+                  onclick={() => moveStep(step.id, -1)}
+                  aria-label={m.buildqueue_move_up_aria()}
+                  title={m.buildqueue_move_up_aria()}>▲</button
+                >
+                <button
+                  type="button"
+                  class="bqp-btn bqp-move"
+                  disabled={i === steps.length - 1}
+                  onclick={() => moveStep(step.id, 1)}
+                  aria-label={m.buildqueue_move_down_aria()}
+                  title={m.buildqueue_move_down_aria()}>▼</button
+                >
+                <button
+                  type="button"
+                  class="bqp-btn bqp-remove"
+                  onclick={() => removeStep(step.id)}
+                  aria-label={m.buildqueue_remove_aria()}
+                  title={m.buildqueue_remove_aria()}>✕</button
+                >
+              </div>
+            </li>
+          {/each}
+        </ol>
+
+        <div class="bqp-footer">
+          <button type="button" class="bqp-btn bqp-add" onclick={addStep}>
+            {m.buildqueue_add_step()}
+          </button>
+          <button type="button" class="bqp-btn bqp-approve" onclick={approve}>
+            {m.buildqueue_approve()}
+          </button>
+        </div>
+      {:else}
+        <!-- Approved/running: read-only list -->
+        <ol class="bqp-list" aria-label={m.buildqueue_panel_title()}>
+          {#each steps as step (step.id)}
+            <li class="bqp-row bqp-row-readonly">
+              <span
+                class={["bqp-badge", statusClass(step.status)]}
+                aria-label={statusLabel(step.status)}>{statusLabel(step.status)}</span
+              >
+              <div class="bqp-fields">
+                <span class="bqp-step-title">{step.title}</span>
+                {#if step.detail}
+                  <span class="bqp-step-detail">{step.detail}</span>
+                {/if}
+              </div>
+            </li>
+          {/each}
+        </ol>
+      {/if}
+    </div>
   </div>
 {/if}
 
@@ -283,6 +303,20 @@
     /* In-progress, not complete — amber. Green is reserved by the design system for
        actionable-complete/READY, which a running queue is not. */
     color: var(--color-amber);
+  }
+
+  .bqp-collapse-toggle {
+    margin-left: auto;
+  }
+
+  .bqp-content {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .bqp-content.collapsed {
+    display: none;
   }
 
   .bqp-empty {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1035,4 +1035,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_base_freshen_title",
     bodyKey: "feat_base_freshen_body",
   },
+  {
+    // targetId "build-queue-collapse" anchors the coachmark on the collapse toggle
+    // button in the BuildQueuePanel header. The panel only mounts when the build-queue
+    // flag is on (or a queue exists), but the button is always mounted while the panel
+    // is visible. 1.33.0 is the latest released tag, so this ships in 1.34.0.
+    id: "build-queue-collapse",
+    sinceVersion: "1.34.0",
+    titleKey: "feat_build_queue_collapse_title",
+    bodyKey: "feat_build_queue_collapse_body",
+    targetId: "build-queue-collapse",
+  },
 ];


### PR DESCRIPTION
## Why

The build-queue panel sits as a band **above** the terminal and, on desktop, was **always visible with no way to dismiss it** — it pushed the terminal down with no way to reclaim the space or move focus past it (the curation `<input>`s sit ahead of the terminal in tab order). Reported with a screenshot of the queue obstructing the terminal.

## What

Adds a **collapse/expand toggle** to the build-queue header. Collapsing folds the panel to its one-line title bar; the terminal reclaims the freed height automatically (existing terminal `ResizeObserver` refits — no manual PTY resize). Re-toggle restores it.

- **Mechanism / default / scope** decided with the user via an interactive preview mockup: collapse toggle (not drag-resize / not pop-to-right), **start expanded**, **one global preference**.
- New global store `ui/src/lib/build-queue-collapse.svelte.ts` mirroring `sidebar-collapse.svelte.ts` (key `shepherd:build-queue-collapsed`, default expanded, persisted, SSR/private-mode guarded).
- `BuildQueuePanel.svelte`: a `.bqp-btn` chevron toggle in the always-rendered header (`▾`/`▴`); all content below the header wrapped in one **always-mounted** `.bqp-content` element hidden via a cascade-safe class (`.bqp-content.collapsed { display: none }`, not a bare `[hidden]`). So `aria-controls` always resolves, and when collapsed the curation inputs leave the tab order — keyboard focus flows straight to the terminal.
- a11y: `aria-expanded` reflects state, `aria-controls` → per-session wrapper id, i18n `aria-label`.
- i18n EN+DE keys; one feature-announcement catalog entry (`build-queue-collapse`, `sinceVersion 1.34.0`, coachmark anchor).

## Out of scope

Drag-to-resize and pop-to-right side-panel layouts (explicitly not chosen); no server/build-queue-API changes; mobile fold untouched (orthogonal).

## Testing

- `cd ui && bun run check` — 0 errors.
- `cd ui && bun run check:i18n` — parity (1462 keys both locales).
- Full UI suite — **1472/1472 pass**, incl. new store unit tests and `BuildQueuePanel.browser.test.ts` collapse/expand tests asserting true layout-exclusion (`offsetParent === null` on wrapper + curation inputs), DOM persistence, and `aria-expanded` transitions.
- PR-hygiene gates (branch-hygiene, feature-catalog, glossary) green; pre-push fallow duplication is warn-only (the store intentionally mirrors the sidebar-collapse precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
