### PR TITLE
feat(learnings): one-click optimize for not-working house rules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import { sweepClaudeTmp, compileCacheDir, reapFallowCaches, pruneRepoWorktrees }
 import { PreviewService } from "./preview";
 import { listRepos, listReposPathForReal } from "./repos";
 import { DistillerService, defaultScratch } from "./distiller";
+import { OptimizerService } from "./optimizer";
 import { Promoter } from "./promote";
 import { GitignoreAdopter } from "./gitignore-adopt";
 import { attachSignalCapture } from "./signals";
@@ -1062,6 +1063,17 @@ setInterval(() => {
   void distiller.tick();
 }, 30_000);
 const promoter = new Promoter({ store, worktree, resolveForge });
+const optimizer = new OptimizerService({
+  store,
+  herdr,
+  scratch: defaultScratch,
+  promoter,
+  onChange: () => events.emit("learnings:update", { pending: store.pendingLearningCount() }),
+});
+setInterval(() => {
+  if (maintenance.active) return;
+  void optimizer.tick();
+}, 30_000);
 const gitignoreAdopter = new GitignoreAdopter({ worktree, resolveForge });
 // Daily: prune archived sessions, prune old signals, then consider a distill per repo
 // with enough recent signal.
@@ -1272,6 +1284,7 @@ const appDeps: AppDeps = {
     await broadcastBacklog();
   },
   distiller,
+  optimizer,
   promoter,
   gitignoreAdopter,
   drain: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ import { sweepClaudeTmp, compileCacheDir, reapFallowCaches, pruneRepoWorktrees }
 import { PreviewService } from "./preview";
 import { listRepos, listReposPathForReal } from "./repos";
 import { DistillerService, defaultScratch } from "./distiller";
-import { OptimizerService } from "./optimizer";
+import { OptimizerService, defaultOptimizerScratch } from "./optimizer";
 import { Promoter } from "./promote";
 import { GitignoreAdopter } from "./gitignore-adopt";
 import { attachSignalCapture } from "./signals";
@@ -1066,7 +1066,7 @@ const promoter = new Promoter({ store, worktree, resolveForge });
 const optimizer = new OptimizerService({
   store,
   herdr,
-  scratch: defaultScratch,
+  scratch: defaultOptimizerScratch,
   promoter,
   onChange: () => events.emit("learnings:update", { pending: store.pendingLearningCount() }),
 });

--- a/src/optimizer.ts
+++ b/src/optimizer.ts
@@ -1,0 +1,357 @@
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { SessionStore } from "./store";
+import type { HerdrDriver } from "./herdr";
+import { HerdrUnavailableError } from "./herdr";
+import type { Promoter } from "./promote";
+import {
+  isApiKeyMode,
+  isApiKeyConfigured,
+  apiKeySettingsFragment,
+  apiKeyPassthroughEnv,
+} from "./spawn-auth";
+
+const INPUT_FILE = "input.json";
+const OUTPUT_FILE = "optimized.json";
+
+/**
+ * Prefix for ephemeral optimizer agent names. Each run appends the first 8 chars of its
+ * session UUID so concurrent runs for different repos never collide on the same herdr name
+ * (`agent_name_taken`). The underscores are load-bearing: prompt-derived session slugs are
+ * `[a-z0-9-]` only (see namer.ts), so no real session can collide. The orphan-tab reaper
+ * matches tabs whose name starts with this prefix — a bare "optimize" would NOT be safe.
+ * Mirrors `DISTILL_LABEL` in distiller.ts.
+ */
+export const OPTIMIZE_LABEL = "__optimize__";
+
+const HEALTH_FAILURE_THRESHOLD = 3;
+
+/** One flagged rule handed to the optimizer agent, with its failure evidence. */
+export interface OptimizerTarget {
+  id: string;
+  rule: string;
+  rationale: string;
+  failures: { kind: string; payload: string }[];
+}
+
+/** Raw shape of the agent's `optimized.json` (all fields untrusted). */
+export interface RawOptimized {
+  revisions?: { id?: unknown; rule?: unknown; rationale?: unknown }[];
+}
+
+interface InFlight {
+  repoPath: string;
+  dir: string;
+  terminalId: string;
+  startedAt: number;
+  finalizing?: boolean;
+  /** Rule ids this run may revise — any revision with an id outside this set is ignored. */
+  targetIds: Set<string>;
+  /** Subset of targetIds whose status was `promoted` at enqueue time — drives resyncPromoted. */
+  promotedIds: Set<string>;
+}
+
+export interface OptimizerDeps {
+  store: Pick<
+    SessionStore,
+    "getLearning" | "listActiveLearnings" | "ineffectiveSignalsFor" | "reviseLearning"
+  >;
+  herdr: Pick<HerdrDriver, "start" | "stop">;
+  scratch: { create: () => { dir: string }; remove: (dir: string) => void };
+  promoter: Pick<Promoter, "resyncPromoted">;
+  onChange: () => void;
+  model?: string | null;
+  now?: () => number;
+  timeoutMs?: number; // default 10*60*1000 (match distiller)
+  maxConcurrent?: number; // default 3
+  writeInput?: (dir: string, targets: OptimizerTarget[]) => void;
+  readOutput?: (dir: string) => RawOptimized | null;
+}
+
+/**
+ * Operator-triggered LLM pass that rewrites flagged ("not working") house rules using
+ * their failure evidence, applies the rewrites in place (clearing the flag), and opens a
+ * CLAUDE.md sync PR for any revised *promoted* rule. A faithful sibling of
+ * {@link DistillerService} — same inflight/queue/tick/finalize/health shape and the same
+ * hard-won read-only claude spawn contract. NEVER runs on a timer inside the service.
+ */
+export class OptimizerService {
+  private inflight = new Map<string, InFlight>();
+  private queue: { repoPath: string; ids: string[] }[] = [];
+  private queued = new Set<string>();
+  private maxConcurrent: number;
+  private now: () => number;
+  private timeoutMs: number;
+  private writeInput: NonNullable<OptimizerDeps["writeInput"]>;
+  private readOutput: (dir: string) => RawOptimized | null;
+  private healthFailures = 0;
+  private lastFailure: { reason: string; at: number; repoPath: string } | null = null;
+
+  constructor(private deps: OptimizerDeps) {
+    this.now = deps.now ?? Date.now;
+    this.timeoutMs = deps.timeoutMs ?? 10 * 60 * 1000;
+    this.maxConcurrent = deps.maxConcurrent ?? 3;
+    this.writeInput = deps.writeInput ?? defaultWriteInput;
+    this.readOutput = deps.readOutput ?? defaultReadOutput;
+  }
+
+  health(): {
+    ok: boolean;
+    consecutiveFailures: number;
+    lastFailure: { reason: string; at: number; repoPath: string } | null;
+  } {
+    return {
+      ok: this.healthOk(),
+      consecutiveFailures: this.healthFailures,
+      lastFailure: this.lastFailure,
+    };
+  }
+
+  private healthOk(): boolean {
+    return this.healthFailures < HEALTH_FAILURE_THRESHOLD;
+  }
+
+  private recordHealthFailure(repoPath: string, reason: string): void {
+    this.healthFailures++;
+    this.lastFailure = { reason, at: this.now(), repoPath };
+    // Emit on the ok→unhealthy transition AND on every further failure while unhealthy,
+    // so an already-open drawer keeps a fresh consecutiveFailures count.
+    if (!this.healthOk()) this.deps.onChange();
+  }
+
+  private recordHealthSuccess(): void {
+    const wasUnhealthy = !this.healthOk();
+    this.healthFailures = 0;
+    this.lastFailure = null;
+    if (wasUnhealthy) this.deps.onChange();
+  }
+
+  /** Optimize a single flagged rule by id. No-op when missing, not active/promoted, or
+   *  not actually flagged. Scopes the input + applied revisions to JUST this id. */
+  optimizeOne(id: string): void {
+    const l = this.deps.store.getLearning(id);
+    if (!l) return;
+    if (l.status !== "active" && l.status !== "promoted") return;
+    if (l.ineffectiveCount <= 0) return;
+    this.enqueueOrBegin(l.repoPath, [id]);
+  }
+
+  /** Optimize every flagged (ineffectiveCount > 0) active/promoted rule in a repo. */
+  optimizeAllFlagged(repoPath: string): void {
+    const flagged = this.deps.store
+      .listActiveLearnings(repoPath)
+      .filter((l) => l.ineffectiveCount > 0)
+      .map((l) => l.id);
+    if (flagged.length === 0) return;
+    this.enqueueOrBegin(repoPath, flagged);
+  }
+
+  private enqueueOrBegin(repoPath: string, ids: string[]): void {
+    if (this.inflight.has(repoPath) || this.queued.has(repoPath)) return;
+    if (this.inflight.size < this.maxConcurrent) {
+      this.begin(repoPath, ids);
+    } else {
+      this.queue.push({ repoPath, ids });
+      this.queued.add(repoPath);
+    }
+  }
+
+  private begin(repoPath: string, ids: string[]): void {
+    const { dir } = this.deps.scratch.create();
+    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
+    if (isApiKeyMode() && !isApiKeyConfigured()) {
+      console.warn(
+        "[optimize] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
+      );
+      this.deps.scratch.remove(dir);
+      return;
+    }
+    // Resolve targets: only rules still active/promoted AND still flagged survive.
+    const targets: OptimizerTarget[] = [];
+    const targetIds = new Set<string>();
+    const promotedIds = new Set<string>();
+    for (const id of ids) {
+      const l = this.deps.store.getLearning(id);
+      if (!l || (l.status !== "active" && l.status !== "promoted")) continue;
+      if (l.ineffectiveCount <= 0) continue;
+      targets.push({
+        id: l.id,
+        rule: l.rule,
+        rationale: l.rationale,
+        failures: this.deps.store
+          .ineffectiveSignalsFor(id)
+          .map((s) => ({ kind: s.kind, payload: s.payload })),
+      });
+      targetIds.add(l.id);
+      if (l.status === "promoted") promotedIds.add(l.id);
+    }
+    if (targets.length === 0) {
+      this.deps.scratch.remove(dir);
+      return;
+    }
+    try {
+      this.writeInput(dir, targets);
+    } catch (err) {
+      console.warn(`[optimize] write input failed for ${repoPath}:`, err);
+      this.deps.scratch.remove(dir);
+      this.recordHealthFailure(repoPath, "write");
+      return;
+    }
+    // Read-only optimizer — same hard-won spawn contract as the critic/distiller
+    // (src/review.ts:begin, src/distiller.ts:begin). NOT --dangerously-skip-permissions:
+    // it reads untrusted agent/repo text. dontAsk MUST be last (after the variadic
+    // --allowedTools) so the trailing prompt isn't swallowed. Bare Write only.
+    // Subscription OAuth (NOT --bare); in api-key auth mode the key arrives via
+    // apiKeyHelper in --settings (folded in) + a credential-less CLAUDE_CONFIG_DIR.
+    const sessionId = randomUUID();
+    const agentName = OPTIMIZE_LABEL + sessionId.slice(0, 8);
+    const argv = [
+      "claude",
+      "--session-id",
+      sessionId,
+      "--settings",
+      // subscription → byte-identical `{"disableAllHooks":true}`; api-key folds in apiKeyHelper.
+      JSON.stringify({ disableAllHooks: true, ...apiKeySettingsFragment() }),
+      "--disable-slash-commands",
+      "--allowedTools",
+      "Read",
+      "Grep",
+      "Glob",
+      "Write",
+    ];
+    if (this.deps.model) argv.push("--model", this.deps.model);
+    argv.push("--permission-mode", "dontAsk");
+    argv.push(optimizePrompt());
+    let terminalId: string;
+    try {
+      terminalId = this.deps.herdr.start(
+        agentName,
+        dir,
+        argv,
+        apiKeyPassthroughEnv(false),
+      ).terminalId;
+    } catch (err) {
+      if (err instanceof HerdrUnavailableError) {
+        console.warn(`[optimize] herdr unavailable for ${repoPath}:`, err);
+      } else {
+        console.warn(`[optimize] spawn failed for ${repoPath}:`, err);
+        this.recordHealthFailure(repoPath, "spawn");
+      }
+      this.deps.scratch.remove(dir);
+      return;
+    }
+    this.inflight.set(repoPath, {
+      repoPath,
+      dir,
+      terminalId,
+      startedAt: this.now(),
+      targetIds,
+      promotedIds,
+    });
+  }
+
+  /** Finalize any run whose output file is ready or that timed out, then drain queue. */
+  async tick(): Promise<void> {
+    for (const f of [...this.inflight.values()]) {
+      if (f.finalizing) continue;
+      const raw = this.readOutput(f.dir);
+      const timedOut = this.now() - f.startedAt > this.timeoutMs;
+      if (!raw && !timedOut) continue;
+      f.finalizing = true;
+      this.finalize(f, raw);
+      this.inflight.delete(f.repoPath);
+    }
+    // Drain queue: each finalized run frees a slot.
+    while (this.inflight.size < this.maxConcurrent && this.queue.length) {
+      const e = this.queue.shift()!;
+      this.queued.delete(e.repoPath);
+      this.begin(e.repoPath, e.ids);
+    }
+  }
+
+  private finalize(f: InFlight, raw: RawOptimized | null): void {
+    const { revised, promotedRevised } = this.applyRevisions(f, raw);
+    this.deps.herdr.stop(f.terminalId);
+    this.deps.scratch.remove(f.dir);
+    if (raw !== null) {
+      this.recordHealthSuccess();
+    } else {
+      this.recordHealthFailure(f.repoPath, "timeout-no-output");
+    }
+    // A revised promoted rule changes CLAUDE.md → open a sync PR, but never block the
+    // tick on it (and a sync failure must not crash the loop).
+    if (promotedRevised) {
+      void this.deps.promoter
+        .resyncPromoted(f.repoPath)
+        .catch((err) => console.warn("[optimize] resync failed for", f.repoPath, err));
+    }
+    if (revised > 0) this.deps.onChange();
+  }
+
+  /** Apply the agent's revisions in place (clearing the flag). Honors the id-guard:
+   *  only ids in `f.targetIds` are touched; a non-empty `rule` string is required.
+   *  Returns the applied count and whether any revised id was promoted. */
+  private applyRevisions(
+    f: InFlight,
+    raw: RawOptimized | null,
+  ): { revised: number; promotedRevised: boolean } {
+    const entries = Array.isArray(raw?.revisions) ? raw!.revisions : [];
+    let revised = 0;
+    let promotedRevised = false;
+    for (const e of entries) {
+      const id = typeof e?.id === "string" ? e.id : undefined;
+      if (!id || !f.targetIds.has(id)) continue;
+      if (typeof e.rule !== "string" || !e.rule.trim()) continue;
+      const rationale = typeof e.rationale === "string" ? e.rationale : undefined;
+      if (this.deps.store.reviseLearning(id, e.rule, rationale)) {
+        revised++;
+        if (f.promotedIds.has(id)) promotedRevised = true;
+      }
+    }
+    return { revised, promotedRevised };
+  }
+}
+
+function optimizePrompt(): string {
+  return [
+    `You are a house-rule editor. Read \`${INPUT_FILE}\` in this directory.`,
+    'It is a JSON object `{ "targets": [{ "id", "rule", "rationale", "failures": [{ "kind", "payload" }] }] }`.',
+    "Each target is a standing house rule for one repository that FAILED to prevent a mistake;",
+    "`failures` are the signals (critic findings / blocks / corrections) showing it failing.",
+    "For each target, produce a STRONGER, more specific imperative rewrite (<=160 chars) that",
+    "would have prevented those failures — keep the same intent, make it concrete and actionable.",
+    "Optionally refine the rationale. Preserve each target's `id` EXACTLY; do not invent ids or",
+    "add targets. If a rule genuinely cannot be improved, omit it.",
+    `Write your output as JSON to \`${OUTPUT_FILE}\` in this directory, shaped exactly:`,
+    '{"revisions": [{"id": "<id>", "rule": "<=160 char imperative", "rationale": "why (optional)"}]}',
+    "Write nothing else.",
+  ].join("\n");
+}
+
+function defaultWriteInput(dir: string, targets: OptimizerTarget[]): void {
+  writeFileSync(join(dir, INPUT_FILE), JSON.stringify({ targets }, null, 2));
+}
+
+function defaultReadOutput(dir: string): RawOptimized | null {
+  const p = join(dir, OUTPUT_FILE);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, "utf8")) as RawOptimized;
+  } catch {
+    return null; // partial write; retry next tick
+  }
+}
+
+/** Default scratch dir: a throwaway temp dir (the optimizer needs no git, only Read/Write). */
+export const defaultOptimizerScratch = {
+  create: () => ({ dir: mkdtempSync(join(tmpdir(), "shepherd-optimize-")) }),
+  remove: (dir: string) => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  },
+};

--- a/src/optimizer.ts
+++ b/src/optimizer.ts
@@ -158,17 +158,13 @@ export class OptimizerService {
     }
   }
 
-  private begin(repoPath: string, ids: string[]): void {
-    const { dir } = this.deps.scratch.create();
-    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
-    if (isApiKeyMode() && !isApiKeyConfigured()) {
-      console.warn(
-        "[optimize] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
-      );
-      this.deps.scratch.remove(dir);
-      return;
-    }
-    // Resolve targets: only rules still active/promoted AND still flagged survive.
+  /** Resolve the target rules for a run: only rules still active/promoted AND still flagged
+   *  survive. Returns the agent-input targets plus the id-guard sets. */
+  private resolveTargets(ids: string[]): {
+    targets: OptimizerTarget[];
+    targetIds: Set<string>;
+    promotedIds: Set<string>;
+  } {
     const targets: OptimizerTarget[] = [];
     const targetIds = new Set<string>();
     const promotedIds = new Set<string>();
@@ -187,26 +183,16 @@ export class OptimizerService {
       targetIds.add(l.id);
       if (l.status === "promoted") promotedIds.add(l.id);
     }
-    if (targets.length === 0) {
-      this.deps.scratch.remove(dir);
-      return;
-    }
-    try {
-      this.writeInput(dir, targets);
-    } catch (err) {
-      console.warn(`[optimize] write input failed for ${repoPath}:`, err);
-      this.deps.scratch.remove(dir);
-      this.recordHealthFailure(repoPath, "write");
-      return;
-    }
-    // Read-only optimizer — same hard-won spawn contract as the critic/distiller
-    // (src/review.ts:begin, src/distiller.ts:begin). NOT --dangerously-skip-permissions:
-    // it reads untrusted agent/repo text. dontAsk MUST be last (after the variadic
-    // --allowedTools) so the trailing prompt isn't swallowed. Bare Write only.
-    // Subscription OAuth (NOT --bare); in api-key auth mode the key arrives via
-    // apiKeyHelper in --settings (folded in) + a credential-less CLAUDE_CONFIG_DIR.
-    const sessionId = randomUUID();
-    const agentName = OPTIMIZE_LABEL + sessionId.slice(0, 8);
+    return { targets, targetIds, promotedIds };
+  }
+
+  /** Build the read-only claude argv (same hard-won contract as the critic/distiller).
+   *  Read-only optimizer (src/review.ts:begin, src/distiller.ts:begin). NOT
+   *  --dangerously-skip-permissions: it reads untrusted agent/repo text. dontAsk MUST be
+   *  last (after the variadic --allowedTools) so the trailing prompt isn't swallowed. Bare
+   *  Write only. Subscription OAuth (NOT --bare); in api-key auth mode the key arrives via
+   *  apiKeyHelper in --settings (folded in) + a credential-less CLAUDE_CONFIG_DIR. */
+  private buildArgv(sessionId: string): string[] {
     const argv = [
       "claude",
       "--session-id",
@@ -224,6 +210,35 @@ export class OptimizerService {
     if (this.deps.model) argv.push("--model", this.deps.model);
     argv.push("--permission-mode", "dontAsk");
     argv.push(optimizePrompt());
+    return argv;
+  }
+
+  private begin(repoPath: string, ids: string[]): void {
+    const { dir } = this.deps.scratch.create();
+    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
+    if (isApiKeyMode() && !isApiKeyConfigured()) {
+      console.warn(
+        "[optimize] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
+      );
+      this.deps.scratch.remove(dir);
+      return;
+    }
+    const { targets, targetIds, promotedIds } = this.resolveTargets(ids);
+    if (targets.length === 0) {
+      this.deps.scratch.remove(dir);
+      return;
+    }
+    try {
+      this.writeInput(dir, targets);
+    } catch (err) {
+      console.warn(`[optimize] write input failed for ${repoPath}:`, err);
+      this.deps.scratch.remove(dir);
+      this.recordHealthFailure(repoPath, "write");
+      return;
+    }
+    const sessionId = randomUUID();
+    const agentName = OPTIMIZE_LABEL + sessionId.slice(0, 8);
+    const argv = this.buildArgv(sessionId);
     let terminalId: string;
     try {
       terminalId = this.deps.herdr.start(
@@ -301,17 +316,28 @@ export class OptimizerService {
     let revised = 0;
     let promotedRevised = false;
     for (const e of entries) {
-      const id = typeof e?.id === "string" ? e.id : undefined;
-      if (!id || !f.targetIds.has(id)) continue;
-      if (typeof e.rule !== "string" || !e.rule.trim()) continue;
-      const rationale = typeof e.rationale === "string" ? e.rationale : undefined;
-      if (this.deps.store.reviseLearning(id, e.rule, rationale)) {
+      const r = coerceRevision(e);
+      if (!r || !f.targetIds.has(r.id)) continue;
+      if (this.deps.store.reviseLearning(r.id, r.rule, r.rationale)) {
         revised++;
-        if (f.promotedIds.has(id)) promotedRevised = true;
+        if (f.promotedIds.has(r.id)) promotedRevised = true;
       }
     }
     return { revised, promotedRevised };
   }
+}
+
+/** Validate one raw revision entry → {id, rule, rationale} or null (bad shape / blank rule). */
+function coerceRevision(e: {
+  id?: unknown;
+  rule?: unknown;
+  rationale?: unknown;
+}): { id: string; rule: string; rationale?: string } | null {
+  const id = typeof e?.id === "string" ? e.id : undefined;
+  if (!id) return null;
+  if (typeof e.rule !== "string" || !e.rule.trim()) return null;
+  const rationale = typeof e.rationale === "string" ? e.rationale : undefined;
+  return { id, rule: e.rule, rationale };
 }
 
 function optimizePrompt(): string {

--- a/src/promote.ts
+++ b/src/promote.ts
@@ -45,6 +45,79 @@ export class Promoter {
     this.writeClaudeMd = deps.writeClaudeMd ?? ((p, c) => writeFileSync(p, c));
   }
 
+  async resyncPromoted(repoPath: string): Promise<PromoteResult> {
+    // Claim inflight slot synchronously — repo path can't collide with a learning id.
+    if (this.inflight.has(repoPath)) {
+      return { ok: false, error: "resync already in progress", status: 409 };
+    }
+    this.inflight.add(repoPath);
+    try {
+      const promoted = this.deps.store.listLearnings(repoPath, { status: "promoted" });
+      // Empty block sync is a no-op: nothing to write and git commit would error on empty diff.
+      if (promoted.length === 0) return { ok: true, url: "" };
+
+      const forge = this.deps.resolveForge(repoPath);
+      if (!forge) return { ok: false, error: "no forge configured for repo", status: 400 };
+
+      let base: string;
+      try {
+        base = await forge.defaultBranch();
+      } catch {
+        return { ok: false, error: "could not resolve default branch", status: 502 };
+      }
+      try {
+        await this.git(repoPath, ["fetch", "origin", "--", base]);
+      } catch {
+        /* offline / no origin — createPromoteWorktree falls back to the local base ref */
+      }
+
+      const name = `learnings-resync-${randomUUID().slice(0, 8)}`;
+      const wt = this.createPromoteWorktree(repoPath, base, name);
+      if (!wt.isolated || !wt.branch) {
+        if (wt.worktreePath !== repoPath) this.deps.worktree.remove(wt.worktreePath);
+        return { ok: false, error: "worktree creation failed", status: 500 };
+      }
+      try {
+        const rules = [...new Set(promoted.map((l) => l.rule))];
+        const claudePath = join(wt.worktreePath, "CLAUDE.md");
+        const current = this.readClaudeMd(claudePath);
+        const next = upsertLearningsBlock(current, rules);
+        // Content-compare guard: skip commit/push/PR if block is already current.
+        // Avoids a spurious git-commit error on an empty diff.
+        if (next === current) return { ok: true, url: "" };
+
+        this.writeClaudeMd(claudePath, next);
+        await this.git(wt.worktreePath, ["add", "CLAUDE.md"]);
+        await this.git(wt.worktreePath, [
+          "commit",
+          "-m",
+          "chore(learnings): sync optimized house rule to CLAUDE.md",
+        ]);
+        await this.git(wt.worktreePath, ["push", "-u", "origin", wt.branch]);
+
+        const body = [
+          "Syncing optimized Shepherd house rules into CLAUDE.md:\n",
+          ...rules.map((r) => `> ${r}`),
+        ].join("\n");
+        const status = await forge.openPr({
+          head: wt.branch,
+          base,
+          title: "chore(learnings): sync optimized house rules",
+          body,
+        });
+        if (!status.url) return { ok: false, error: "PR opened but no url returned", status: 502 };
+        return { ok: true, url: status.url };
+      } catch (err) {
+        console.warn(`[resync] failed for ${repoPath}:`, err);
+        return { ok: false, error: "resync failed", status: 500 };
+      } finally {
+        await this.cleanup(repoPath, wt.worktreePath, wt.branch);
+      }
+    } finally {
+      this.inflight.delete(repoPath);
+    }
+  }
+
   async promote(id: string): Promise<PromoteResult> {
     // Claim the in-flight slot synchronously, before any await, so a second click
     // landing mid-promote is rejected rather than racing the status transition.

--- a/src/server.ts
+++ b/src/server.ts
@@ -937,22 +937,21 @@ function handleLearningsGet({ parts, url, deps }: Ctx): Response | null {
   return null;
 }
 
-async function handleLearningsPost({ req, parts, url, deps }: Ctx): Promise<Response | null> {
-  // POST /api/learnings/distill?repo= — checked BEFORE :id so "distill" isn't an id
-  if (parts[2] === "distill") {
-    const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
-    if (!dir) return json({ error: "invalid repo" }, 400);
-    deps.distiller?.distillNow(dir);
-    return json({ ok: true });
-  }
+/** POST /api/learnings/{distill,optimize}?repo= — the two repo-scoped learning triggers
+ *  (matched before :id). Returns null when `parts[2]` is neither. */
+function handleRepoScopedLearningPost(parts: string[], url: URL, deps: AppDeps): Response | null {
+  if (parts[2] !== "distill" && parts[2] !== "optimize") return null;
+  const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
+  if (!dir) return json({ error: "invalid repo" }, 400);
+  if (parts[2] === "distill") deps.distiller?.distillNow(dir);
+  else deps.optimizer?.optimizeAllFlagged(dir);
+  return json({ ok: true });
+}
 
-  // POST /api/learnings/optimize?repo= — optimize ALL flagged rules in a repo (checked before :id)
-  if (parts[2] === "optimize") {
-    const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
-    if (!dir) return json({ error: "invalid repo" }, 400);
-    deps.optimizer?.optimizeAllFlagged(dir);
-    return json({ ok: true });
-  }
+async function handleLearningsPost({ req, parts, url, deps }: Ctx): Promise<Response | null> {
+  // POST /api/learnings/{distill,optimize}?repo= — checked BEFORE :id so they aren't ids
+  const repoScoped = handleRepoScopedLearningPost(parts, url, deps);
+  if (repoScoped) return repoScoped;
 
   // POST /api/learnings/:id/promote — open a CLAUDE.md PR for an active rule
   if (parts[2] && parts[3] === "promote") {

--- a/src/server.ts
+++ b/src/server.ts
@@ -268,6 +268,18 @@ export interface AppDeps {
       lastFailure: { reason: string; at: number; repoPath: string } | null;
     };
   };
+  /** Learning optimizer — operator-triggered LLM rewrite pass over flagged ("not working")
+   *  rules. Optional so tests that don't wire it still type-check; routes no-op when absent.
+   *  Wired to the real OptimizerService in index.ts. */
+  optimizer?: {
+    optimizeOne: (id: string) => void;
+    optimizeAllFlagged: (repoPath: string) => void;
+    health?: () => {
+      ok: boolean;
+      consecutiveFailures: number;
+      lastFailure: { reason: string; at: number; repoPath: string } | null;
+    };
+  };
   /** Promote a curated rule into the repo's CLAUDE.md via an auto-opened PR. */
   promoter?: { promote: (id: string) => Promise<import("./promote").PromoteResult> };
   /** Open a PR adding Shepherd's managed `.shepherd-*` ignore block to a repo's `.gitignore`. */
@@ -906,12 +918,10 @@ function handleLearningsGet({ parts, url, deps }: Ctx): Response | null {
 
   // GET /api/learnings/health — distiller health (fail-safe: safe default when absent)
   if (parts[2] === "health") {
-    const h = deps.distiller?.health?.() ?? {
-      ok: true,
-      consecutiveFailures: 0,
-      lastFailure: null,
-    };
-    return json(h);
+    const safe = { ok: true, consecutiveFailures: 0, lastFailure: null };
+    const distiller = deps.distiller?.health?.() ?? safe;
+    const optimizer = deps.optimizer?.health?.() ?? safe;
+    return json({ ...distiller, optimizer });
   }
 
   // GET /api/learnings?repo=&status=
@@ -936,6 +946,14 @@ async function handleLearningsPost({ req, parts, url, deps }: Ctx): Promise<Resp
     return json({ ok: true });
   }
 
+  // POST /api/learnings/optimize?repo= — optimize ALL flagged rules in a repo (checked before :id)
+  if (parts[2] === "optimize") {
+    const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
+    if (!dir) return json({ error: "invalid repo" }, 400);
+    deps.optimizer?.optimizeAllFlagged(dir);
+    return json({ ok: true });
+  }
+
   // POST /api/learnings/:id/promote — open a CLAUDE.md PR for an active rule
   if (parts[2] && parts[3] === "promote") {
     if (!deps.promoter) return json({ error: "promote unavailable" }, 503);
@@ -943,6 +961,12 @@ async function handleLearningsPost({ req, parts, url, deps }: Ctx): Promise<Resp
     if (!res.ok) return json({ error: res.error }, res.status);
     deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
     return json({ url: res.url });
+  }
+
+  // POST /api/learnings/:id/optimize — optimize a single flagged rule
+  if (parts[2] && parts[3] === "optimize") {
+    deps.optimizer?.optimizeOne(parts[2]);
+    return json({ ok: true });
   }
 
   // POST /api/learnings/:id/approve  |  /:id/dismiss

--- a/src/store.ts
+++ b/src/store.ts
@@ -2078,6 +2078,36 @@ export class SessionStore implements CapStore, CreditStore {
     return this.getLearning(id);
   }
 
+  /** Replace a flagged rule's text (and optionally rationale) and clear the visible
+   *  ineffective flag. Only operates on active/promoted rules; no-ops for
+   *  proposed/dismissed/missing. Blank rewrites are rejected (returns null).
+   *  PRESERVES `ineffectiveSignalIds` so the dedup set survives the revision — only
+   *  genuinely new failure signals can re-raise the flag after an optimization. */
+  reviseLearning(id: string, rule: string, rationale?: string): Learning | null {
+    const cur = this.getLearning(id);
+    if (!cur || (cur.status !== "active" && cur.status !== "promoted")) return null;
+    const text = rule.trim().slice(0, 240);
+    if (!text) return null;
+    const resolvedRationale = rationale !== undefined ? rationale : cur.rationale;
+    this.db.run(
+      `UPDATE learnings SET rule = ?, rationale = ?, ineffectiveCount = 0, updatedAt = ? WHERE id = ?`,
+      [text, resolvedRationale, Date.now(), id],
+    );
+    return this.getLearning(id);
+  }
+
+  /** Resolve the stored `ineffectiveSignalIds` for a rule to full Signal rows.
+   *  Server-side only — `ineffectiveSignalIds` is intentionally absent from the
+   *  Learning type and hydrateLearning. Returns [] for missing/unflagged rules. */
+  ineffectiveSignalsFor(id: string): Signal[] {
+    const row = this.db
+      .query(`SELECT ineffectiveSignalIds FROM learnings WHERE id = ?`)
+      .get(id) as { ineffectiveSignalIds?: string } | null;
+    if (!row) return [];
+    const ids = parseFindings(row.ineffectiveSignalIds);
+    return this.getSignalsByIds(ids);
+  }
+
   /** active → promoted, recording the CLAUDE.md PR url (spec §4b). Returns null
    *  when the rule is missing or not in a state that allows promotion. */
   promoteLearning(id: string, prUrl: string): Learning | null {

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import type { HerdrDriver } from "./herdr";
 import { PROBE_NAME } from "./usage-probe";
 import { DISTILL_LABEL } from "./distiller";
+import { OPTIMIZE_LABEL } from "./optimizer";
 
 export type ReapableHerdr = Pick<HerdrDriver, "closeTab" | "panes" | "paneForegroundProcs">;
 
@@ -15,22 +16,24 @@ export type ReapableHerdr = Pick<HerdrDriver, "closeTab" | "panes" | "paneForegr
  *  user slug. It is safe only because `reapOrphanTabs` never reaps a tab that has a live
  *  backing agent; a running user "rundown" session is therefore never touched.
  *
- *  **Collision-proof markers** (space-prefix or underscore): {@link PROBE_NAME} and
- *  {@link DISTILL_LABEL} contain underscores; every other helper uses a space-prefixed
+ *  **Collision-proof markers** (space-prefix or underscore): {@link PROBE_NAME},
+ *  {@link DISTILL_LABEL} and {@link OPTIMIZE_LABEL} contain underscores; every other helper uses a space-prefixed
  *  label (`"review "`, `"name "`, `"plan-review "`, `"pr-critic "`, `"recap "`,
  *  `"autopilot "`) or a multi-word exact phrase (`"verify api key"`). User sessions use
  *  prompt-derived `[a-z0-9-]` slugs — no spaces, no underscores — so none of these labels
  *  is reachable by a slug. Exception: `"rundown"` (exact, no space) relies on the
  *  liveness gate instead.
  *
- *  The distiller now spawns under a UNIQUE per-run name of the form
- *  `__distill__<8hex>` (prefix `DISTILL_LABEL`), matched here by prefix. The prefix ends
- *  in `__`, which `[a-z0-9-]` slugs can never produce, so the prefix match stays
- *  collision-proof. The per-pane liveness check remains the actual safety gate.
+ *  The distiller and optimizer each spawn under a UNIQUE per-run name of the form
+ *  `__distill__<8hex>` / `__optimize__<8hex>` (prefixes `DISTILL_LABEL` / `OPTIMIZE_LABEL`),
+ *  matched here by prefix. The prefix ends in `__`, which `[a-z0-9-]` slugs can never
+ *  produce, so the prefix match stays collision-proof. The per-pane liveness check remains
+ *  the actual safety gate.
  *
  *  Helpers covered:
  *  - `__usage_probe__`   — usage probe (PROBE_NAME)
  *  - `__distill__<hex>`  — distiller (DISTILL_LABEL prefix, unique per run)
+ *  - `__optimize__<hex>` — rule optimizer (OPTIMIZE_LABEL prefix, unique per run)
  *  - `review <desig>`    — critic / code-review spawns
  *  - `name <desig>`      — background LLM namer
  *  - `plan-review <desig>` — plan-gate reviewer (plan-gate.ts)
@@ -43,6 +46,7 @@ export function isShepherdHelperLabel(label: string): boolean {
   return (
     label === PROBE_NAME ||
     label.startsWith(DISTILL_LABEL) ||
+    label.startsWith(OPTIMIZE_LABEL) ||
     label === "rundown" ||
     label === "verify api key" ||
     label.startsWith("review ") ||

--- a/test/optimizer.test.ts
+++ b/test/optimizer.test.ts
@@ -1,0 +1,273 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { OptimizerService, OPTIMIZE_LABEL, type OptimizerTarget } from "../src/optimizer";
+import { SessionStore } from "../src/store";
+import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+
+beforeEach(() => {
+  __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
+});
+
+afterEach(() => {
+  __setApiKeyConfigDirProvisionForTest(null);
+});
+
+/** Seed an ACTIVE rule and return its id. */
+function seedActiveRule(store: SessionStore, repo: string, rule: string): string {
+  const l = store.addLearning({ repoPath: repo, rule, rationale: "", evidence: [] });
+  store.setLearningStatus(l.id, "active");
+  return l.id;
+}
+
+/** Seed a PROMOTED rule and return its id. */
+function seedPromotedRule(store: SessionStore, repo: string, rule: string): string {
+  const id = seedActiveRule(store, repo, rule);
+  store.promoteLearning(id, "https://example/pr");
+  return id;
+}
+
+/** Flag a rule as ineffective by citing one fresh signal (active/promoted only). */
+function flag(store: SessionStore, repo: string, id: string): void {
+  const s = store.addSignal({ repoPath: repo, sessionId: null, kind: "critic", payload: "failed" });
+  store.incrementLearningIneffective(id, [s.id]);
+}
+
+interface FakePromoter {
+  calls: string[];
+  resyncPromoted: (repoPath: string) => Promise<{ ok: true; url: string }>;
+}
+function fakePromoter(): FakePromoter {
+  const calls: string[] = [];
+  return {
+    calls,
+    resyncPromoted: (repoPath: string) => {
+      calls.push(repoPath);
+      return Promise.resolve({ ok: true as const, url: "" });
+    },
+  };
+}
+
+function mkDeps(
+  store: SessionStore,
+  output: RawLike,
+  opts: {
+    onChange?: () => void;
+    promoter?: FakePromoter;
+    now?: () => number;
+    timeoutMs?: number;
+    maxConcurrent?: number;
+    writeInput?: (dir: string, targets: OptimizerTarget[]) => void;
+  } = {},
+) {
+  const promoter = opts.promoter ?? fakePromoter();
+  const cap = { starts: 0, stops: 0, removed: 0 };
+  return {
+    promoter,
+    cap,
+    deps: {
+      store,
+      herdr: {
+        start: () => {
+          cap.starts++;
+          return { terminalId: `opt${cap.starts}` };
+        },
+        stop: () => cap.stops++,
+      } as any,
+      scratch: {
+        create: () => ({ dir: `/scratch/${cap.starts}` }),
+        remove: () => cap.removed++,
+      },
+      promoter,
+      onChange: opts.onChange ?? (() => {}),
+      now: opts.now ?? (() => 1000),
+      timeoutMs: opts.timeoutMs,
+      maxConcurrent: opts.maxConcurrent,
+      writeInput: opts.writeInput ?? (() => {}),
+      readOutput: () => output,
+    },
+  };
+}
+
+type RawLike = { revisions?: { id?: unknown; rule?: unknown; rationale?: unknown }[] } | null;
+
+test("applies revisions + clears flag; onChange fires", async () => {
+  const store = new SessionStore(":memory:");
+  const id = seedActiveRule(store, "/r", "old rule");
+  flag(store, "/r", id);
+  let changed = 0;
+  const { deps } = mkDeps(
+    store,
+    { revisions: [{ id, rule: "new stronger rule" }] },
+    {
+      onChange: () => changed++,
+    },
+  );
+  const svc = new OptimizerService(deps as any);
+  svc.optimizeAllFlagged("/r");
+  await svc.tick();
+  const l = store.getLearning(id)!;
+  expect(l.rule).toBe("new stronger rule");
+  expect(l.ineffectiveCount).toBe(0);
+  expect(changed).toBe(1);
+});
+
+test("optimizeOne scopes input + applied revisions to a single id", async () => {
+  const store = new SessionStore(":memory:");
+  const a = seedActiveRule(store, "/r", "rule A");
+  const b = seedActiveRule(store, "/r", "rule B");
+  flag(store, "/r", a);
+  flag(store, "/r", b);
+  let capturedTargets: OptimizerTarget[] = [];
+  // readOutput returns revisions for BOTH a and b — only a is in this run's target set.
+  const { deps } = mkDeps(
+    store,
+    {
+      revisions: [
+        { id: a, rule: "A revised" },
+        { id: b, rule: "B revised" },
+      ],
+    },
+    { writeInput: (_d, t) => (capturedTargets = t) },
+  );
+  const svc = new OptimizerService(deps as any);
+  svc.optimizeOne(a);
+  await svc.tick();
+  expect(store.getLearning(a)!.rule).toBe("A revised");
+  expect(store.getLearning(b)!.rule).toBe("rule B"); // untouched
+  expect(store.getLearning(b)!.ineffectiveCount).toBe(1); // still flagged
+  expect(capturedTargets.map((t) => t.id)).toEqual([a]); // input scoped to a only
+});
+
+test("id-guard: a revision for an id not in the target set is ignored", async () => {
+  const store = new SessionStore(":memory:");
+  const a = seedActiveRule(store, "/r", "rule A");
+  flag(store, "/r", a);
+  const { deps } = mkDeps(store, {
+    revisions: [{ id: "ghost-id", rule: "injected" }],
+  });
+  const svc = new OptimizerService(deps as any);
+  svc.optimizeAllFlagged("/r");
+  await svc.tick();
+  expect(store.getLearning(a)!.rule).toBe("rule A"); // untouched
+  expect(store.getLearning(a)!.ineffectiveCount).toBe(1); // still flagged
+});
+
+test("promoted rule revised → resyncPromoted called once with repo", async () => {
+  const store = new SessionStore(":memory:");
+  const id = seedPromotedRule(store, "/r", "promoted rule");
+  flag(store, "/r", id);
+  const promoter = fakePromoter();
+  const { deps } = mkDeps(store, { revisions: [{ id, rule: "promoted revised" }] }, { promoter });
+  const svc = new OptimizerService(deps as any);
+  svc.optimizeAllFlagged("/r");
+  await svc.tick();
+  await Promise.resolve(); // let the fire-and-forget resync settle
+  expect(promoter.calls).toEqual(["/r"]);
+});
+
+test("only an active rule revised → resyncPromoted NOT called", async () => {
+  const store = new SessionStore(":memory:");
+  const id = seedActiveRule(store, "/r", "active rule");
+  flag(store, "/r", id);
+  const promoter = fakePromoter();
+  const { deps } = mkDeps(store, { revisions: [{ id, rule: "active revised" }] }, { promoter });
+  const svc = new OptimizerService(deps as any);
+  svc.optimizeAllFlagged("/r");
+  await svc.tick();
+  await Promise.resolve();
+  expect(promoter.calls).toEqual([]);
+});
+
+test("timeout/no-output → health failure, scratch removed, herdr stopped", async () => {
+  const store = new SessionStore(":memory:");
+  const id = seedActiveRule(store, "/r", "rule");
+  flag(store, "/r", id);
+  let t = 1000;
+  const { deps, cap } = mkDeps(store, null, { now: () => t, timeoutMs: 5_000 });
+  const svc = new OptimizerService(deps as any);
+
+  // 3 timeout failures to trip the health threshold.
+  for (let i = 0; i < 3; i++) {
+    flag(store, "/r", id); // re-flag (reviseLearning never ran; but keep it flagged anyway)
+    svc.optimizeOne(id);
+    t += 6_000;
+    await svc.tick();
+  }
+  expect(svc.health().ok).toBe(false);
+  expect(svc.health().consecutiveFailures).toBe(3);
+  expect(svc.health().lastFailure?.reason).toBe("timeout-no-output");
+  expect(cap.stops).toBe(3);
+  // one scratch removed per finalized run (begin allocates, finalize removes)
+  expect(cap.removed).toBe(3);
+});
+
+test("one run per repo: a second optimizeAllFlagged is a no-op while the first is inflight", async () => {
+  const store = new SessionStore(":memory:");
+  const id = seedActiveRule(store, "/r", "rule");
+  flag(store, "/r", id);
+  const { deps, cap } = mkDeps(store, null); // readOutput null → run stays inflight
+  const svc = new OptimizerService(deps as any);
+  svc.optimizeAllFlagged("/r");
+  svc.optimizeAllFlagged("/r");
+  expect(cap.starts).toBe(1);
+});
+
+test("empty/blank rule revision is rejected", async () => {
+  const store = new SessionStore(":memory:");
+  const id = seedActiveRule(store, "/r", "keep me");
+  flag(store, "/r", id);
+  const { deps } = mkDeps(store, { revisions: [{ id, rule: "   " }] });
+  const svc = new OptimizerService(deps as any);
+  svc.optimizeAllFlagged("/r");
+  await svc.tick();
+  expect(store.getLearning(id)!.rule).toBe("keep me"); // not applied
+  expect(store.getLearning(id)!.ineffectiveCount).toBe(1); // still flagged
+});
+
+test("nothing flagged → no spawn", () => {
+  const store = new SessionStore(":memory:");
+  seedActiveRule(store, "/r", "rule"); // active but NOT flagged
+  const { deps, cap } = mkDeps(store, { revisions: [] });
+  const svc = new OptimizerService(deps as any);
+  svc.optimizeAllFlagged("/r");
+  expect(cap.starts).toBe(0);
+});
+
+test("spawn argv follows the safe contract + unique __optimize__ name", () => {
+  const store = new SessionStore(":memory:");
+  const id = seedActiveRule(store, "/r", "rule");
+  flag(store, "/r", id);
+  let argv: string[] = [];
+  let name = "";
+  const promoter = fakePromoter();
+  const deps = {
+    store,
+    herdr: {
+      start: (n: string, _cwd: string, a: string[]) => {
+        name = n;
+        argv = a;
+        return { terminalId: "o1" };
+      },
+      stop: () => {},
+    } as any,
+    scratch: { create: () => ({ dir: "/s" }), remove: () => {} },
+    promoter,
+    onChange: () => {},
+    now: () => 1000,
+    writeInput: () => {},
+    readOutput: () => null,
+  };
+  new OptimizerService(deps as any).optimizeAllFlagged("/r");
+
+  expect(name).toMatch(new RegExp(`^${OPTIMIZE_LABEL}`));
+  expect(argv).not.toContain("--dangerously-skip-permissions");
+  const allow = argv.indexOf("--allowedTools");
+  const mode = argv.indexOf("--permission-mode");
+  expect(allow).toBeGreaterThan(-1);
+  expect(mode).toBeGreaterThan(allow);
+  expect(argv[mode + 1]).toBe("dontAsk");
+  const write = argv.indexOf("Write");
+  expect(write).toBeGreaterThan(allow);
+  expect(write).toBeLessThan(mode);
+  expect(argv).toContain('{"disableAllHooks":true}');
+  expect(argv.length).toBeGreaterThan(mode + 2); // prompt trails dontAsk
+});

--- a/test/promote.test.ts
+++ b/test/promote.test.ts
@@ -207,3 +207,172 @@ test("Promoter.promote rejects a concurrent double-click with 409", async () => 
   const firstRes = await first;
   expect(firstRes.ok).toBe(true);
 });
+
+// --- resyncPromoted tests ---
+
+test("Promoter.resyncPromoted rebuilds block and opens a PR", async () => {
+  const store = new SessionStore(":memory:");
+  const l1 = store.addLearning({
+    repoPath: "/repo",
+    rule: "rule one",
+    rationale: "",
+    evidence: [],
+  });
+  const l2 = store.addLearning({
+    repoPath: "/repo",
+    rule: "rule two",
+    rationale: "",
+    evidence: [],
+  });
+  store.setLearningStatus(l1.id, "active");
+  store.setLearningStatus(l1.id, "promoted");
+  store.setLearningStatus(l2.id, "active");
+  store.setLearningStatus(l2.id, "promoted");
+
+  const wtDir = mkdtempSync(join(tmpdir(), "resync-test-"));
+  const gitCalls: string[][] = [];
+  const removed: string[] = [];
+  let prOpened = false;
+
+  const p = new Promoter({
+    store,
+    worktree: {
+      create: () => ({ worktreePath: wtDir, branch: "learnings-resync-abcd1234", isolated: true }),
+      remove: (path: string) => removed.push(path),
+    },
+    resolveForge: () =>
+      fakeForge({
+        openPr: async () => {
+          prOpened = true;
+          return {
+            state: "open",
+            number: 8,
+            url: "https://pr/8",
+            checks: "none",
+            deployConfigured: false,
+          };
+        },
+      }),
+    git: async (_cwd, args) => {
+      gitCalls.push(args);
+    },
+    // start with stale CLAUDE.md (no learnings block)
+    readClaudeMd: () => "# Repo\n\nsome existing content\n",
+    writeClaudeMd: () => {},
+  });
+
+  const res = await p.resyncPromoted("/repo");
+  expect(res).toEqual({ ok: true, url: "https://pr/8" });
+  expect(prOpened).toBe(true);
+  expect(gitCalls.some((a) => a[0] === "commit")).toBe(true);
+  expect(gitCalls.some((a) => a[0] === "push")).toBe(true);
+  // no DB status transition — rules stay promoted
+  expect(store.getLearning(l1.id)!.status).toBe("promoted");
+  expect(store.getLearning(l2.id)!.status).toBe("promoted");
+  // cleanup ran
+  expect(removed).toContain(wtDir);
+});
+
+test("Promoter.resyncPromoted is a no-op when CLAUDE.md already has the current block", async () => {
+  const store = new SessionStore(":memory:");
+  const l = store.addLearning({
+    repoPath: "/repo2",
+    rule: "stay linear",
+    rationale: "",
+    evidence: [],
+  });
+  store.setLearningStatus(l.id, "active");
+  store.setLearningStatus(l.id, "promoted");
+
+  const gitCalls: string[][] = [];
+  let prOpened = false;
+
+  // Precompute what the block should look like
+  const { upsertLearningsBlock: ulb } = await import("../src/promote");
+  const upToDate = ulb("# Repo\n\n", ["stay linear"]);
+
+  const p = new Promoter({
+    store,
+    worktree: {
+      create: () => ({ worktreePath: "/wt2", branch: "learnings-resync-xyz", isolated: true }),
+      remove: () => {},
+    },
+    resolveForge: () =>
+      fakeForge({
+        openPr: async () => {
+          prOpened = true;
+          return {
+            state: "open",
+            number: 9,
+            url: "https://pr/9",
+            checks: "none",
+            deployConfigured: false,
+          };
+        },
+      }),
+    git: async (_cwd, args) => {
+      gitCalls.push(args);
+    },
+    readClaudeMd: () => upToDate,
+    writeClaudeMd: () => {},
+  });
+
+  const res = await p.resyncPromoted("/repo2");
+  expect(res).toEqual({ ok: true, url: "" });
+  expect(prOpened).toBe(false);
+  expect(gitCalls.some((a) => a[0] === "commit")).toBe(false);
+});
+
+test("Promoter.resyncPromoted returns no-op when no promoted rules exist", async () => {
+  const store = new SessionStore(":memory:");
+  // no learnings added for /repo3
+  let worktreeCreated = false;
+
+  const p = new Promoter({
+    store,
+    worktree: {
+      create: () => {
+        worktreeCreated = true;
+        return { worktreePath: "/wt3", branch: "b", isolated: true };
+      },
+      remove: () => {},
+    },
+    resolveForge: () => fakeForge(),
+    git: async () => {},
+  });
+
+  const res = await p.resyncPromoted("/repo3");
+  expect(res).toEqual({ ok: true, url: "" });
+  expect(worktreeCreated).toBe(false);
+});
+
+test("Promoter.resyncPromoted rejects a concurrent call for the same repo with 409", async () => {
+  const store = new SessionStore(":memory:");
+  const l = store.addLearning({ repoPath: "/repo4", rule: "rule x", rationale: "", evidence: [] });
+  store.setLearningStatus(l.id, "active");
+  store.setLearningStatus(l.id, "promoted");
+
+  const wtDir = mkdtempSync(join(tmpdir(), "resync-race-"));
+  let releaseForge: () => void = () => {};
+  const gate = new Promise<void>((resolve) => (releaseForge = resolve));
+
+  const p = new Promoter({
+    store,
+    worktree: {
+      create: () => ({ worktreePath: wtDir, branch: "learnings-resync-racetest", isolated: true }),
+      remove: () => {},
+    },
+    resolveForge: () => fakeForge({ defaultBranch: async () => (await gate, "main") }),
+    git: async () => {},
+    readClaudeMd: () => "",
+    writeClaudeMd: () => {},
+  });
+
+  const first = p.resyncPromoted("/repo4");
+  const second = await p.resyncPromoted("/repo4"); // inflight → 409
+  expect(second.ok).toBe(false);
+  if (!second.ok) expect(second.status).toBe(409);
+  releaseForge();
+  const firstRes = await first;
+  expect(firstRes.ok).toBe(true);
+});

--- a/test/server-learnings.test.ts
+++ b/test/server-learnings.test.ts
@@ -1,8 +1,22 @@
-import { test, expect } from "bun:test";
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { makeApp, type AppDeps } from "../src/server";
 import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
+import { config } from "../src/config";
 import type { PromoteResult } from "../src/promote";
+
+let tmpRoot: string;
+let validRepo: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(config.repoRoot, "shepherd-learnings-test-"));
+  validRepo = join(tmpRoot, "repo");
+  mkdirSync(validRepo);
+});
+
+afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
 
 function harness(promoter?: AppDeps["promoter"]): {
   app: ReturnType<typeof makeApp>;
@@ -68,4 +82,127 @@ test("promote with no promoter dep → 503", async () => {
   );
   expect(res.status).toBe(503);
   expect(await res.json()).toEqual({ error: "promote unavailable" });
+});
+
+// ── optimizer routes ─────────────────────────────────────────────────────────
+
+function makeOptimizerDeps(optimizer?: AppDeps["optimizer"]): AppDeps {
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  return {
+    store,
+    service: {} as any,
+    events,
+    usageLimits: { limits: () => ({}) } as any,
+    optimizer,
+  };
+}
+
+test("POST /api/learnings/optimize?repo= valid → 200 {ok:true} and calls optimizeAllFlagged", async () => {
+  const called: string[] = [];
+  const optimizer: AppDeps["optimizer"] = {
+    optimizeAllFlagged: (dir) => {
+      called.push(dir);
+    },
+    optimizeOne: () => {},
+  };
+  const app = makeApp(makeOptimizerDeps(optimizer));
+
+  const res = await app.fetch(
+    new Request(`http://x/api/learnings/optimize?repo=${encodeURIComponent(validRepo)}`, {
+      method: "POST",
+    }),
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+  expect(called).toHaveLength(1);
+});
+
+test("POST /api/learnings/optimize?repo= missing → 400", async () => {
+  const optimizer: AppDeps["optimizer"] = {
+    optimizeAllFlagged: () => {},
+    optimizeOne: () => {},
+  };
+  const app = makeApp(makeOptimizerDeps(optimizer));
+
+  const res = await app.fetch(
+    new Request("http://x/api/learnings/optimize?repo=", { method: "POST" }),
+  );
+  expect(res.status).toBe(400);
+  expect(await res.json()).toHaveProperty("error");
+});
+
+test("POST /api/learnings/:id/optimize → 200 {ok:true} and calls optimizeOne", async () => {
+  const called: string[] = [];
+  const optimizer: AppDeps["optimizer"] = {
+    optimizeAllFlagged: () => {},
+    optimizeOne: (id) => {
+      called.push(id);
+    },
+  };
+  const app = makeApp(makeOptimizerDeps(optimizer));
+
+  const res = await app.fetch(
+    new Request("http://x/api/learnings/rule-abc/optimize", { method: "POST" }),
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+  expect(called).toEqual(["rule-abc"]);
+});
+
+// ── GET /api/learnings/health with optimizer ─────────────────────────────────
+
+test("GET /api/learnings/health preserves top-level distiller fields and adds optimizer", async () => {
+  const distillerHealth = {
+    ok: false,
+    consecutiveFailures: 3,
+    lastFailure: { reason: "oops", at: 1, repoPath: "/r" },
+  };
+  const optimizerHealth = { ok: true, consecutiveFailures: 0, lastFailure: null };
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const deps: AppDeps = {
+    store,
+    service: {} as any,
+    events,
+    usageLimits: { limits: () => ({}) } as any,
+    distiller: { distillNow: () => {}, health: () => distillerHealth },
+    optimizer: {
+      optimizeAllFlagged: () => {},
+      optimizeOne: () => {},
+      health: () => optimizerHealth,
+    },
+  };
+  const app = makeApp(deps);
+
+  const res = await app.fetch(new Request("http://x/api/learnings/health"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  // top-level distiller fields preserved
+  expect(body.ok).toBe(false);
+  expect(body.consecutiveFailures).toBe(3);
+  expect(body.lastFailure).toEqual(distillerHealth.lastFailure);
+  // optimizer sub-object present
+  expect(body.optimizer).toEqual(optimizerHealth);
+});
+
+test("GET /api/learnings/health without deps → safe defaults with optimizer sub-object", async () => {
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const deps: AppDeps = {
+    store,
+    service: {} as any,
+    events,
+    usageLimits: { limits: () => ({}) } as any,
+  };
+  const app = makeApp(deps);
+
+  const res = await app.fetch(new Request("http://x/api/learnings/health"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.ok).toBe(true);
+  expect(body.consecutiveFailures).toBe(0);
+  expect(body.lastFailure).toBeNull();
+  expect(body.optimizer).toBeDefined();
+  expect(body.optimizer.ok).toBe(true);
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1246,7 +1246,9 @@ test("GET /api/learnings/health returns distiller health when health() present",
   const res = await app.fetch(new Request("http://x/api/learnings/health"));
   expect(res.status).toBe(200);
   const body = await res.json();
-  expect(body).toEqual(unhealthy);
+  // top-level fields are the distiller's; optimizer is additive
+  expect(body).toMatchObject(unhealthy);
+  expect(body).toHaveProperty("optimizer");
 });
 
 test("GET /api/learnings/health returns safe default when distiller lacks health()", async () => {
@@ -1255,7 +1257,8 @@ test("GET /api/learnings/health returns safe default when distiller lacks health
   const res = await app.fetch(new Request("http://x/api/learnings/health"));
   expect(res.status).toBe(200);
   const body = await res.json();
-  expect(body).toEqual({ ok: true, consecutiveFailures: 0, lastFailure: null });
+  expect(body).toMatchObject({ ok: true, consecutiveFailures: 0, lastFailure: null });
+  expect(body).toHaveProperty("optimizer");
 });
 
 // ── clear-all-merged endpoint ────────────────────────────────────────────────

--- a/test/store-learnings.test.ts
+++ b/test/store-learnings.test.ts
@@ -185,3 +185,127 @@ test("listActiveLearnings returns active + promoted only, oldest-updated first",
   const rules = s.listActiveLearnings("/r").map((l) => l.rule);
   expect(rules.sort()).toEqual(["active rule", "promoted rule"]);
 });
+
+// ── reviseLearning ────────────────────────────────────────────────────────────
+
+test("reviseLearning: active rule — text + rationale updated, ineffectiveCount → 0, updatedAt advanced, status unchanged", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({
+    repoPath: "/r",
+    rule: "old rule",
+    rationale: "old rationale",
+    evidence: [],
+  });
+  s.setLearningStatus(l.id, "active");
+  s.incrementLearningIneffective(l.id, ["s1", "s2"]);
+  const before = s.getLearning(l.id)!;
+  expect(before.ineffectiveCount).toBe(2);
+
+  const updated = s.reviseLearning(l.id, "new rule", "new rationale")!;
+  expect(updated).not.toBeNull();
+  expect(updated.rule).toBe("new rule");
+  expect(updated.rationale).toBe("new rationale");
+  expect(updated.ineffectiveCount).toBe(0);
+  expect(updated.status).toBe("active");
+  expect(updated.updatedAt).toBeGreaterThanOrEqual(before.updatedAt);
+});
+
+test("reviseLearning: promoted rule is allowed", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "old", rationale: "", evidence: [] });
+  s.setLearningStatus(l.id, "active");
+  s.setLearningStatus(l.id, "promoted");
+  const updated = s.reviseLearning(l.id, "revised for promoted")!;
+  expect(updated).not.toBeNull();
+  expect(updated.rule).toBe("revised for promoted");
+  expect(updated.status).toBe("promoted");
+});
+
+test("reviseLearning: proposed rule → returns null, row unchanged", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "proposed rule", rationale: "", evidence: [] });
+  expect(s.reviseLearning(l.id, "attempt")).toBeNull();
+  expect(s.getLearning(l.id)!.rule).toBe("proposed rule");
+});
+
+test("reviseLearning: dismissed rule → returns null, row unchanged", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "dis rule", rationale: "", evidence: [] });
+  s.setLearningStatus(l.id, "active");
+  s.setLearningStatus(l.id, "dismissed");
+  expect(s.reviseLearning(l.id, "attempt")).toBeNull();
+  expect(s.getLearning(l.id)!.rule).toBe("dis rule");
+});
+
+test("reviseLearning: missing id → returns null", () => {
+  const s = new SessionStore(":memory:");
+  expect(s.reviseLearning("no-such-id", "text")).toBeNull();
+});
+
+test("reviseLearning: empty/whitespace-only rule → returns null, row unchanged", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "keep this", rationale: "", evidence: [] });
+  s.setLearningStatus(l.id, "active");
+  expect(s.reviseLearning(l.id, "")).toBeNull();
+  expect(s.reviseLearning(l.id, "   ")).toBeNull();
+  expect(s.getLearning(l.id)!.rule).toBe("keep this");
+});
+
+test("reviseLearning: text > 240 chars is capped to 240", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "original", rationale: "", evidence: [] });
+  s.setLearningStatus(l.id, "active");
+  const longRule = "x".repeat(300);
+  const updated = s.reviseLearning(l.id, longRule)!;
+  expect(updated.rule.length).toBe(240);
+});
+
+test("reviseLearning: omitted rationale preserves existing rationale", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "rule", rationale: "keep me", evidence: [] });
+  s.setLearningStatus(l.id, "active");
+  const updated = s.reviseLearning(l.id, "revised rule")!;
+  expect(updated.rationale).toBe("keep me");
+});
+
+test("reviseLearning: preserves ineffectiveSignalIds so old signals stay deduped after revision", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "rule", rationale: "", evidence: [] });
+  s.setLearningStatus(l.id, "active");
+  // seed count = 2
+  s.incrementLearningIneffective(l.id, ["s1", "s2"]);
+  expect(s.getLearning(l.id)!.ineffectiveCount).toBe(2);
+  // revise clears visible count
+  s.reviseLearning(l.id, "new text");
+  expect(s.getLearning(l.id)!.ineffectiveCount).toBe(0);
+  // re-presenting the same signals → still deduped → null / count stays 0
+  expect(s.incrementLearningIneffective(l.id, ["s1", "s2"])).toBeNull();
+  expect(s.getLearning(l.id)!.ineffectiveCount).toBe(0);
+  // a genuinely new signal increments to 1
+  expect(s.incrementLearningIneffective(l.id, ["s3"])!.ineffectiveCount).toBe(1);
+});
+
+// ── ineffectiveSignalsFor ─────────────────────────────────────────────────────
+
+test("ineffectiveSignalsFor: returns matching Signal rows after flagging", () => {
+  const s = new SessionStore(":memory:");
+  const sig1 = s.addSignal({ repoPath: "/r", sessionId: null, kind: "reply", payload: "a" });
+  const sig2 = s.addSignal({ repoPath: "/r", sessionId: null, kind: "critic", payload: "b" });
+  const l = s.addLearning({ repoPath: "/r", rule: "rule", rationale: "", evidence: [] });
+  s.setLearningStatus(l.id, "active");
+  s.incrementLearningIneffective(l.id, [sig1.id, sig2.id]);
+  const signals = s.ineffectiveSignalsFor(l.id);
+  expect(signals.map((sg) => sg.id).sort()).toEqual([sig1.id, sig2.id].sort());
+});
+
+test("ineffectiveSignalsFor: rule with no ineffective ids → []", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "clean", rationale: "", evidence: [] });
+  s.setLearningStatus(l.id, "active");
+  expect(s.ineffectiveSignalsFor(l.id)).toEqual([]);
+});
+
+test("ineffectiveSignalsFor: missing id → []", () => {
+  const s = new SessionStore(":memory:");
+  expect(s.ineffectiveSignalsFor("no-such-id")).toEqual([]);
+});

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/tab-reaper";
 import { PROBE_NAME } from "../src/usage-probe";
 import { DISTILL_LABEL } from "../src/distiller";
+import { OPTIMIZE_LABEL } from "../src/optimizer";
 import type { HerdrPane } from "../src/herdr";
 
 function pane(paneId: string, tabId: string, label: string): HerdrPane {
@@ -186,6 +187,8 @@ describe("isShepherdHelperLabel", () => {
     [PROBE_NAME, "usage probe (underscore marker)"],
     [DISTILL_LABEL, "distiller bare prefix (underscore marker)"],
     [`${DISTILL_LABEL}a1b2c3d4`, "distiller unique label (prefix + 8hex suffix)"],
+    [OPTIMIZE_LABEL, "optimizer bare prefix (underscore marker)"],
+    [`${OPTIMIZE_LABEL}a1b2c3d4`, "optimizer unique label (prefix + 8hex suffix)"],
     ["review TASK-09", "critic/code-review"],
     ["name TASK-09", "background namer"],
     // new helpers (#721)
@@ -209,6 +212,7 @@ describe("isShepherdHelperLabel", () => {
     ["my-feature", "ordinary user session slug"],
     ["usage-probe", "slug form of PROBE_NAME — must NOT be reaped"],
     ["distill", "slug form of DISTILL_LABEL — must NOT be reaped"],
+    ["optimize", "slug form of OPTIMIZE_LABEL — must NOT be reaped"],
     ["my-feature-branch", "ordinary user slug (no underscores)"],
     ["reviewing-pr", "starts with 'review' but no trailing space"],
     ["autopilot-mode", "hyphen instead of space — not an autopilot helper"],

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1468,5 +1468,16 @@
   "queuebadge_title": "Build-Queue: {resolved} von {total} Schritten erledigt",
   "queuebadge_aria": "Build-Queue: {resolved} von {total} Schritten erledigt",
   "feat_build_queue_progress_title": "Build-Queue-Fortschritt auf einen Blick",
-  "feat_build_queue_progress_body": "Session-Karten zeigen jetzt ein kleines bernsteinfarbenes Badge mit Fortschrittsbalken, wenn eine genehmigte Build-Queue aktiv ist — erledigte / Gesamtschritte ohne Öffnen des Panels einsehbar."
+  "feat_build_queue_progress_body": "Session-Karten zeigen jetzt ein kleines bernsteinfarbenes Badge mit Fortschrittsbalken, wenn eine genehmigte Build-Queue aktiv ist — erledigte / Gesamtschritte ohne Öffnen des Panels einsehbar.",
+  "learnings_optimize": "Optimieren",
+  "learnings_optimize_aria": "Diese Regel optimieren",
+  "learnings_optimize_all": "Alle markierten optimieren ({count})",
+  "learnings_optimize_started": "Markierte Regeln werden optimiert…",
+  "learnings_optimize_failed": "Optimierung konnte nicht gestartet werden",
+  "learnings_filter_flagged": "Wirkungslos ({count})",
+  "learnings_filter_all": "Alle anzeigen",
+  "learnings_optimizer_stalled_title": "Optimierer blockiert",
+  "learnings_optimizer_stalled_body": "Der Regel-Optimierer ist {count}-mal in Folge fehlgeschlagen. Prüfe die Server-Logs.",
+  "feat_optimize_learnings_title": "„Wirkungslose“ Hausregeln mit einem Klick reparieren",
+  "feat_optimize_learnings_body": "Wenn eine Hausregel Fehler nicht mehr verhindert, filtere auf die markierten Regeln und lass Shepherd sie aus den Fehlern neu formulieren – einzeln oder alle auf einmal."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1468,5 +1468,16 @@
   "queuebadge_title": "Build queue: {resolved} of {total} steps done",
   "queuebadge_aria": "Build queue: {resolved} of {total} steps done",
   "feat_build_queue_progress_title": "Build queue progress at a glance",
-  "feat_build_queue_progress_body": "Session cards now show a small amber badge with a progress meter when an approved build queue is active — see resolved / total steps without opening the panel."
+  "feat_build_queue_progress_body": "Session cards now show a small amber badge with a progress meter when an approved build queue is active — see resolved / total steps without opening the panel.",
+  "learnings_optimize": "Optimize",
+  "learnings_optimize_aria": "Optimize this rule",
+  "learnings_optimize_all": "Optimize all flagged ({count})",
+  "learnings_optimize_started": "Optimizing flagged rules…",
+  "learnings_optimize_failed": "Couldn’t start optimization",
+  "learnings_filter_flagged": "Not working ({count})",
+  "learnings_filter_all": "Show all",
+  "learnings_optimizer_stalled_title": "Optimizer stalled",
+  "learnings_optimizer_stalled_body": "The rule optimizer failed {count} times in a row. Check the server logs.",
+  "feat_optimize_learnings_title": "Fix ‘not working’ house rules in one click",
+  "feat_optimize_learnings_body": "When a house rule stops preventing mistakes, filter to the flagged ones and let Shepherd reword them from the failures — individually or all at once."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1159,6 +1159,22 @@ export async function getBuildQueues(): Promise<Record<string, BuildQueue>> {
   return r.json();
 }
 
+/** Optimize a single flagged ("not working") rule via the LLM rewrite pass. Fire-and-forget;
+ *  the WS learnings:update event refreshes the drawer when the run finalizes. */
+export async function optimizeLearning(id: string): Promise<void> {
+  const r = await fetch(`/api/learnings/${id}/optimize`, { method: "POST", headers: JSON_HEADERS });
+  if (!r.ok) throw await failed(r, "optimize");
+}
+
+/** Optimize ALL flagged rules in a repo. Fire-and-forget (see optimizeLearning). */
+export async function optimizeRepoFlagged(repoPath: string): Promise<void> {
+  const r = await fetch(`/api/learnings/optimize?repo=${encodeURIComponent(repoPath)}`, {
+    method: "POST",
+    headers: JSON_HEADERS,
+  });
+  if (!r.ok) throw await failed(r, "optimize");
+}
+
 export async function getBuildQueue(sessionId: string): Promise<BuildQueue> {
   return getJson(`/api/sessions/${encodeURIComponent(sessionId)}/queue`, "build-queue");
 }

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -707,13 +707,13 @@
     color: var(--color-muted);
     font-variant-numeric: tabular-nums;
   }
-  /* Per-repo "Optimize all flagged" — token-outlined small action, mirrors .distill. */
+  /* Per-repo "Optimize all flagged" — token-outlined small action, mirrors .optimize (amber, not green). */
   .optimize-all {
     margin-left: auto;
     font-size: var(--fs-meta);
     background: none;
-    border: 1px solid var(--color-green);
-    color: var(--color-green);
+    border: 1px solid var(--color-amber);
+    color: var(--color-amber);
     padding: 3px 8px;
     cursor: pointer;
   }

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -12,6 +12,9 @@
     injectionBadge,
     injectedCount,
     showIneffective,
+    flaggedRules,
+    flaggedCount,
+    totalFlagged,
     evidenceSources,
   } from "./learnings-drawer";
 
@@ -87,6 +90,8 @@
     ondismiss,
     ondistill,
     onpromote,
+    onoptimize,
+    onoptimizeall,
     onclose,
   }: {
     items: Learning[];
@@ -96,6 +101,8 @@
     ondismiss: (id: string) => void;
     ondistill: (repoPath: string) => void;
     onpromote: (id: string) => void;
+    onoptimize: (id: string) => void;
+    onoptimizeall: (repoPath: string) => void;
     onclose: () => void;
   } = $props();
 
@@ -111,6 +118,18 @@
   const groups = $derived(mergeRepoGroups(items, injectable));
   // Empty only when there's nothing to curate in either view.
   const empty = $derived(groups.length === 0);
+
+  // "Not working" filter: show only repos/rules the distiller flagged. The toggle
+  // only renders when something is flagged, and auto-resets so the view can't get
+  // stuck on an empty filter once the last flagged rule is optimized/dismissed away.
+  let flaggedOnly = $state(false);
+  const totalFlaggedCount = $derived(totalFlagged(injectable));
+  $effect(() => {
+    if (totalFlaggedCount === 0) flaggedOnly = false;
+  });
+  const displayGroups = $derived(
+    flaggedOnly ? groups.filter((g) => flaggedCount(g.injectable) > 0) : groups,
+  );
 
   // Deep-link: when opened from a repo's status row, scroll that repo's section into
   // view. Runs once on mount (a frame later, so the fly-in has laid out the sections).
@@ -135,6 +154,18 @@
 >
   <header class="bar">
     <span class="title">{m.learnings_title()}</span>
+    {#if totalFlaggedCount > 0}
+      <button
+        class="filter-toggle"
+        type="button"
+        aria-pressed={flaggedOnly}
+        onclick={() => (flaggedOnly = !flaggedOnly)}
+      >
+        {flaggedOnly
+          ? m.learnings_filter_all()
+          : m.learnings_filter_flagged({ count: totalFlaggedCount })}
+      </button>
+    {/if}
     <button class="close" onclick={() => onclose()} aria-label={m.learnings_close_aria()}>✕</button>
   </header>
 
@@ -143,6 +174,17 @@
       <strong class="hw-title">{m.learnings_distiller_stalled_title()}</strong>
       <span class="hw-body"
         >{m.learnings_distiller_stalled_body({ count: learnings.health.consecutiveFailures })}</span
+      >
+    </div>
+  {/if}
+
+  {#if learnings.health.optimizer && !learnings.health.optimizer.ok}
+    <div class="health-warn" role="status">
+      <strong class="hw-title">{m.learnings_optimizer_stalled_title()}</strong>
+      <span class="hw-body"
+        >{m.learnings_optimizer_stalled_body({
+          count: learnings.health.optimizer.consecutiveFailures,
+        })}</span
       >
     </div>
   {/if}
@@ -169,7 +211,7 @@
   {#if empty}
     <p class="empty">{m.learnings_empty()}</p>
   {:else}
-    {#each groups as group (group.repoPath)}
+    {#each displayGroups as group (group.repoPath)}
       <section class="group" id={repoAnchorId(group.repoPath)}>
         <div class="ghead">
           <span class="repo">{basename(group.repoPath)}</span>
@@ -182,7 +224,7 @@
           </button>
         </div>
 
-        {#each group.proposed as l (l.id)}
+        {#each flaggedOnly ? [] : group.proposed as l (l.id)}
           <article class="rule">
             <textarea
               class="text"
@@ -262,8 +304,17 @@
                   total: inj.rules.length,
                 })}
               </span>
+              {#if flaggedCount(group.injectable) > 0}
+                <button
+                  class="optimize-all"
+                  type="button"
+                  onclick={() => onoptimizeall(group.repoPath)}
+                >
+                  {m.learnings_optimize_all({ count: flaggedCount(group.injectable) })}
+                </button>
+              {/if}
             </div>
-            {#each inj.rules as r (r.id)}
+            {#each flaggedOnly ? flaggedRules(group.injectable) : inj.rules as r (r.id)}
               {@const badge = injectionBadge(r, inj.enabled)}
               <article class="irule">
                 <p class="itext">{r.rule}</p>
@@ -288,6 +339,16 @@
                     </span>
                   {/if}
                   <span class="spacer"></span>
+                  {#if showIneffective(r)}
+                    <button
+                      class="optimize"
+                      type="button"
+                      onclick={() => onoptimize(r.id)}
+                      aria-label={m.learnings_optimize_aria()}
+                    >
+                      {m.learnings_optimize()}
+                    </button>
+                  {/if}
                   {#if r.status === "active"}
                     <button class="dismiss" onclick={() => ondismiss(r.id)}>
                       {m.learnings_dismiss()}
@@ -356,6 +417,24 @@
     color: var(--color-muted);
     cursor: pointer;
     font-size: var(--fs-lg);
+  }
+  /* "Not working" header filter — token-outlined like .distill; pressed state
+     reads as the active (amber) "flagged" lens. */
+  .filter-toggle {
+    margin-left: auto;
+    font-size: var(--fs-meta);
+    background: none;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    padding: 3px 8px;
+    cursor: pointer;
+  }
+  .filter-toggle:hover {
+    color: var(--color-ink-bright);
+  }
+  .filter-toggle[aria-pressed="true"] {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
   }
   /* distiller-stalled persistent warning banner */
   .health-warn {
@@ -593,6 +672,16 @@
     color: var(--color-green);
     text-decoration: none;
   }
+  /* Per-rule "Optimize" — headline action for a flagged rule, styled primary-ish
+     like .promote but in the amber "needs attention" hue that flags the rule. */
+  .optimize {
+    font-size: var(--fs-base);
+    padding: 5px 12px;
+    cursor: pointer;
+    border: 1px solid var(--color-amber);
+    background: none;
+    color: var(--color-amber);
+  }
 
   /* ── injected house rules ────────────────────────────────────────────── */
   .injected {
@@ -617,6 +706,16 @@
     font-size: var(--fs-meta);
     color: var(--color-muted);
     font-variant-numeric: tabular-nums;
+  }
+  /* Per-repo "Optimize all flagged" — token-outlined small action, mirrors .distill. */
+  .optimize-all {
+    margin-left: auto;
+    font-size: var(--fs-meta);
+    background: none;
+    border: 1px solid var(--color-green);
+    color: var(--color-green);
+    padding: 3px 8px;
+    cursor: pointer;
   }
   .irule {
     border: 1px solid var(--color-line);

--- a/ui/src/lib/components/learnings-drawer.test.ts
+++ b/ui/src/lib/components/learnings-drawer.test.ts
@@ -7,6 +7,9 @@ import {
   injectionBadge,
   injectedCount,
   showIneffective,
+  flaggedRules,
+  flaggedCount,
+  totalFlagged,
   evidenceSources,
 } from "./learnings-drawer";
 import type { Learning, LearningStatus, RepoInjectable } from "../types";
@@ -30,7 +33,7 @@ function L(id: string, repo: string, status: LearningStatus = "proposed"): Learn
 
 function IR(
   repo: string,
-  rules: { id: string; injected: boolean; status?: LearningStatus }[],
+  rules: { id: string; injected: boolean; status?: LearningStatus; ineffectiveCount?: number }[],
   over: Partial<RepoInjectable> = {},
 ): RepoInjectable {
   return {
@@ -38,7 +41,11 @@ function IR(
     enabled: true,
     budgetChars: 4000,
     usedChars: 100,
-    rules: rules.map((r) => ({ ...L(r.id, repo, r.status ?? "active"), injected: r.injected })),
+    rules: rules.map((r) => ({
+      ...L(r.id, repo, r.status ?? "active"),
+      injected: r.injected,
+      ineffectiveCount: r.ineffectiveCount ?? 0,
+    })),
     ...over,
   };
 }
@@ -134,6 +141,45 @@ describe("injectedCount", () => {
 test("showIneffective true only when ineffectiveCount > 0", () => {
   expect(showIneffective({ ineffectiveCount: 0 } as never)).toBe(false);
   expect(showIneffective({ ineffectiveCount: 3 } as never)).toBe(true);
+});
+
+describe("flaggedRules / flaggedCount", () => {
+  it("null repo → [] / 0", () => {
+    expect(flaggedRules(null)).toEqual([]);
+    expect(flaggedCount(null)).toBe(0);
+  });
+  it("returns only rules with ineffectiveCount > 0", () => {
+    const inj = IR("/a", [
+      { id: "1", injected: true, ineffectiveCount: 2 },
+      { id: "2", injected: true, ineffectiveCount: 0 },
+      { id: "3", injected: false, ineffectiveCount: 1 },
+    ]);
+    expect(flaggedRules(inj).map((r) => r.id)).toEqual(["1", "3"]);
+    expect(flaggedCount(inj)).toBe(2);
+  });
+  it("0 when none flagged", () => {
+    const inj = IR("/a", [{ id: "1", injected: true }]);
+    expect(flaggedRules(inj)).toEqual([]);
+    expect(flaggedCount(inj)).toBe(0);
+  });
+});
+
+describe("totalFlagged", () => {
+  it("sums flagged across repos", () => {
+    const a = IR("/a", [
+      { id: "1", injected: true, ineffectiveCount: 1 },
+      { id: "2", injected: true, ineffectiveCount: 0 },
+    ]);
+    const b = IR("/b", [
+      { id: "3", injected: true, ineffectiveCount: 3 },
+      { id: "4", injected: true, ineffectiveCount: 1 },
+    ]);
+    expect(totalFlagged([a, b])).toBe(3);
+  });
+  it("is 0 for an empty list", () => expect(totalFlagged([])).toBe(0));
+  it("is 0 when no repo has a flagged rule", () => {
+    expect(totalFlagged([IR("/a", [{ id: "1", injected: true }])])).toBe(0);
+  });
 });
 
 describe("evidenceSources", () => {

--- a/ui/src/lib/components/learnings-drawer.ts
+++ b/ui/src/lib/components/learnings-drawer.ts
@@ -84,6 +84,19 @@ export function showIneffective(rule: { ineffectiveCount: number }): boolean {
   return rule.ineffectiveCount > 0;
 }
 
+/** Flagged ("not working") rules in a repo's injectable view (ineffectiveCount > 0). */
+export function flaggedRules(repo: RepoInjectable | null): (Learning & { injected: boolean })[] {
+  return repo ? repo.rules.filter((r) => r.ineffectiveCount > 0) : [];
+}
+/** Count of flagged rules in a repo's injectable view. */
+export function flaggedCount(repo: RepoInjectable | null): number {
+  return flaggedRules(repo).length;
+}
+/** Total flagged rules across all repos (drives the header filter toggle + its count). */
+export function totalFlagged(injectable: RepoInjectable[]): number {
+  return injectable.reduce((n, r) => n + flaggedCount(r), 0);
+}
+
 /** Stable display order for the evidence breakdown: most operator-meaningful
  *  source first (a correction you gave) down to passive ones (a stall). */
 const KIND_ORDER: SignalKind[] = ["reply", "critic", "block", "stall"];

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1056,4 +1056,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_build_queue_progress_body",
     targetId: "build-queue-progress",
   },
+  {
+    // No targetId: the filter toggle only renders when flagged rules exist, so there's no
+    // stable anchor; surface via the What's-New drawer only. 1.33.0 is the latest released
+    // tag, so this ships in 1.34.0.
+    id: "optimize-not-working-learnings",
+    sinceVersion: "1.34.0",
+    titleKey: "feat_optimize_learnings_title",
+    bodyKey: "feat_optimize_learnings_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -913,7 +913,9 @@ export interface DistillerHealth {
   consecutiveFailures: number;
   lastFailure: { reason: string; at: number; repoPath: string } | null;
   // Additive sub-object: health of the rule optimizer (same shape as the
-  // distiller's). Present once the server has run/recorded an optimize pass.
+  // distiller's). Always present in the current server response (the endpoint
+  // defaults to a safe ok-shape when the optimizer is unwired); optional only
+  // for compat with older server responses that predate this field.
   optimizer?: {
     ok: boolean;
     consecutiveFailures: number;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -912,6 +912,13 @@ export interface DistillerHealth {
   ok: boolean;
   consecutiveFailures: number;
   lastFailure: { reason: string; at: number; repoPath: string } | null;
+  // Additive sub-object: health of the rule optimizer (same shape as the
+  // distiller's). Present once the server has run/recorded an optimize pass.
+  optimizer?: {
+    ok: boolean;
+    consecutiveFailures: number;
+    lastFailure: { reason: string; at: number; repoPath: string } | null;
+  };
 }
 
 // ── leftover subprocesses surfaced at session close ─────────────────────────

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -29,6 +29,8 @@
     dismissLearning,
     distillRepo,
     promoteLearning,
+    optimizeLearning,
+    optimizeRepoFlagged,
     getMergedClearable,
     clearMerged,
     getDrain,
@@ -1860,6 +1862,14 @@
             return learnings.load();
           })
           .catch(() => toasts.info(m.learnings_promote_failed()))}
+      onoptimize={(id) =>
+        optimizeLearning(id)
+          .then(() => toasts.info(m.learnings_optimize_started()))
+          .catch(() => toasts.info(m.learnings_optimize_failed()))}
+      onoptimizeall={(repoPath) =>
+        optimizeRepoFlagged(repoPath)
+          .then(() => toasts.info(m.learnings_optimize_started()))
+          .catch(() => toasts.info(m.learnings_optimize_failed()))}
       onclose={() => {
         showLearnings = false;
         learningsRepo = null;


### PR DESCRIPTION
## Make "not working" learnings actionable

When Shepherd's distiller flags an active/promoted house-rule learning as ineffective (`ineffectiveCount > 0`, the `⚠ Not working (N)` badge), operators previously could only **Dismiss** it — the badge tooltip's advice to "reword, strengthen, or dismiss" had no reword path. This adds a low-effort, **no-manual-editing** loop to fix flagged rules.

### What's new
- **Filter** — a one-click toggle in the Learnings drawer to view only flagged ("not working") rules across repos.
- **Optimize (mass + per-rule)** — a per-repo "Optimize all flagged (N)" button and a per-rule "Optimize" button. Both spawn a new `OptimizerService` (a read-only claude agent, identical spawn contract to the distiller) that rewords/strengthens each flagged rule from the **failure evidence** that flagged it, applies the rewrite **in place**, and clears the flag.
- **Promoted-rule sync** — promoted rules can also be flagged; their text lives in the repo's `CLAUDE.md`. Optimizing one opens a follow-up `CLAUDE.md` sync PR (`Promoter.resyncPromoted`) so the file re-converges.

### Key design decisions (operator-confirmed)
- **Apply-in-place + clear flag** (not propose-for-review): lowest operator effort. Rewrites stay the same status (never silently promoted), remain visible and Dismiss-able.
- **Manual inline editing deliberately *not* added** — the operator explicitly declined it; the LLM optimizer is the primary mechanism.
- **Re-flag invariant:** `reviseLearning` zeroes the visible `ineffectiveCount` but **preserves `ineffectiveSignalIds`**, so the next distill over the same 60-day window can't re-cite the old signals and re-raise the flag. Only genuinely-new failures re-flag.

### Implementation
- **Store:** `reviseLearning` (rewrite + clear flag, preserving the counted-signal set), `ineffectiveSignalsFor` (server-side failure-evidence accessor).
- **`OptimizerService`** (`src/optimizer.ts`): sibling of `DistillerService` — inflight/queue/tick lifecycle, one run per repo, id-guard (only target-set ids applied), api-key fail-closed, health tracking. Wired in `index.ts` with its own tick driver + scratch dir.
- **API:** `POST /api/learnings/optimize?repo=`, `POST /api/learnings/:id/optimize`, additive `optimizer` field on `/api/learnings/health`.
- **UI:** drawer filter + optimize buttons (amber = needs-attention, never the reserved green), optimizer-stalled banner, EN+DE i18n, feature-catalog entry (`sinceVersion 1.34.0`).

### Verification
Root: `lint` clean, `tsc --noEmit` clean, `bun test ./test` 3511 pass / 0 fail. UI: `check` 0 errors, `check:i18n` parity (1469 keys), `bun run test` 1462 pass / 0 fail. Feature-catalog, glossary, branch-hygiene, and fallow complexity gates all pass. New tests: store (`reviseLearning`/`ineffectiveSignalsFor`), `optimizer.test.ts` (10 cases incl. spawn-contract, id-guard, promoted-sync, timeout-health), `resyncPromoted`, drawer helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
