### PR TITLE
feat(recap): native visual recap blocks — Phase 1 (#773)

### DIFF
--- a/src/recap-core.ts
+++ b/src/recap-core.ts
@@ -4,6 +4,8 @@
  */
 import type { ActivityEntry } from "./activity";
 import type { Recap, RecapVerdict } from "./types";
+import { parseVisualBlocks } from "./visual-blocks";
+import type { VisualBlock } from "./visual-blocks";
 
 export const RECAP_VERDICTS: readonly RecapVerdict[] = ["ready", "parked", "needs_attention"];
 export const RECAP_HEADLINE_MAX = 100;
@@ -11,10 +13,15 @@ export const RECAP_DIGEST_MAX_CHARS = 4000;
 
 /** Parse + validate the raw .shepherd-recap.json the spawn wrote. Returns null when the
  *  shape is invalid (caller fails closed). Clamps headline to RECAP_HEADLINE_MAX, coerces
- *  openItems to a string[] (drops non-strings), requires verdict ∈ RECAP_VERDICTS. */
-export function parseRecapVerdict(
-  raw: unknown,
-): { verdict: RecapVerdict; headline: string; body: string; openItems: string[] } | null {
+ *  openItems to a string[] (drops non-strings), requires verdict ∈ RECAP_VERDICTS.
+ *  blocks is additive — parsed tolerantly via parseVisualBlocks ([] on missing/garbage). */
+export function parseRecapVerdict(raw: unknown): {
+  verdict: RecapVerdict;
+  headline: string;
+  body: string;
+  openItems: string[];
+  blocks: VisualBlock[];
+} | null {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
   const r = raw as Record<string, unknown>;
 
@@ -27,8 +34,9 @@ export function parseRecapVerdict(
   const openItems = Array.isArray(rawItems)
     ? rawItems.filter((x): x is string => typeof x === "string")
     : [];
+  const blocks = parseVisualBlocks(r.blocks);
 
-  return { verdict: verdict as RecapVerdict, headline, body, openItems };
+  return { verdict: verdict as RecapVerdict, headline, body, openItems, blocks };
 }
 
 /** Build a bounded digest of what the agent did from parsed transcript entries
@@ -99,8 +107,30 @@ export function buildRecapPrompt(input: {
     "- body: concise markdown covering what changed, key decisions made, and merge-readiness",
     "- openItems: string[] of anything left to do or worth noting for the next session ([] if none)",
     "",
+    "Optionally, include a `blocks` array to render the recap as a scannable visual document instead",
+    "of plain markdown. Omit `blocks` entirely if plain `body` suffices — blocks are not required.",
+    "",
+    "Block types (Phase 1):",
+    '- rich-text: {"type":"rich-text","id":"<unique>","markdown":"<prose>"} — narrative / the why.',
+    '- callout:   {"type":"callout","id":"...","tone":"info|decision|risk|warning|success","markdown":"..."} — a toned note for a decision, risk, or assumption.',
+    '- file-tree: {"type":"file-tree","id":"...","title?":"...","entries":[{"path":"<real path>","change":"added|modified|removed|renamed","note?":"<short>"}]} — the change footprint. Use real changed paths only.',
+    '- diff:      {"type":"diff","id":"...","path":"<real changed path>","summary":"<one line>","annotations?":[{"label?":"<short>","note":"<prose>"}]} — feature a specific changed file.',
+    "",
+    "Rules for blocks:",
+    "- Every block must have a unique string `id`.",
+    '- Grounding: only reference files that ACTUALLY changed — use paths from the "Files changed in',
+    '  this session" list above verbatim. Never invent a path, a field, or a change.',
+    "- diff blocks: emit only `path`, `summary`, and prose `annotations`. Do NOT include diff hunks",
+    "  or a `file` field — the server attaches the real diff content. Annotations are short prose",
+    "  notes about the change, NOT line numbers or line ranges.",
+    "- Feature a few load-bearing files as `diff` blocks (curated highlight, not every file); the",
+    "  full footprint belongs in a `file-tree` block.",
+    "- Redact secrets (API keys, tokens, passwords) in any summary/markdown/annotation — use",
+    "  placeholders like `sk-•••` / `<redacted>`.",
+    "",
     `Write the result as JSON to the file \`.shepherd-recap.json\` in your CWD with EXACTLY this shape:`,
-    `{"verdict": "ready" | "parked" | "needs_attention", "headline": "<string>", "body": "<markdown>", "openItems": ["<string>", ...]}`,
+    `{"verdict": "ready" | "parked" | "needs_attention", "headline": "<string>", "body": "<markdown>", "openItems": ["<string>", ...], "blocks": [ ... ]  // blocks optional, omit if not useful`,
+    `}`,
     "Write the file as your final action, then stop.",
   );
 

--- a/src/recap-core.ts
+++ b/src/recap-core.ts
@@ -128,9 +128,10 @@ export function buildRecapPrompt(input: {
     "- Redact secrets (API keys, tokens, passwords) in any summary/markdown/annotation — use",
     "  placeholders like `sk-•••` / `<redacted>`.",
     "",
-    `Write the result as JSON to the file \`.shepherd-recap.json\` in your CWD with EXACTLY this shape:`,
-    `{"verdict": "ready" | "parked" | "needs_attention", "headline": "<string>", "body": "<markdown>", "openItems": ["<string>", ...], "blocks": [ ... ]  // blocks optional, omit if not useful`,
-    `}`,
+    `Write the result as JSON to the file \`.shepherd-recap.json\` in your CWD with EXACTLY this shape`,
+    "(the `blocks` field is optional — omit it entirely if not useful; the file must be strict, valid",
+    "JSON with no comments):",
+    `{"verdict": "ready" | "parked" | "needs_attention", "headline": "<string>", "body": "<markdown>", "openItems": ["<string>", ...], "blocks": [ ... ]}`,
     "Write the file as your final action, then stop.",
   );
 

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -39,6 +39,7 @@ import {
   isSettledIdle,
   needsRecap,
 } from "./recap-core";
+import { groundBlocks } from "./visual-blocks";
 
 const execFileAsync = promisify(execFile);
 
@@ -148,6 +149,7 @@ export interface RecapServiceDeps {
     | "recordReviewerSpawn"
     | "completeReviewerSpawn"
     | "list"
+    | "setRecapPendingDiff"
   >;
   herdr: Pick<HerdrDriver, "start" | "stop" | "list">;
   onChange: (id: string, recap: Recap | null) => void;
@@ -469,6 +471,7 @@ export class RecapService {
       };
       this.deps.store.putRecap(row);
       this.deps.onChange(id, row);
+      this.deps.store.setRecapPendingDiff(id, diff.files);
 
       return "started";
     } finally {
@@ -501,26 +504,31 @@ export class RecapService {
 
   private async finalize(r: Recap, raw: unknown | null): Promise<void> {
     const t = this.now();
+    // Strip the server-only carrier so it never reaches putRecap or onChange.
+    const { pendingDiff = [], ...rBase } = r;
     let newRow: Recap;
     try {
       const parsed = raw ? parseRecapVerdict(raw) : null;
       if (parsed) {
+        const grounded = groundBlocks(parsed.blocks, pendingDiff, rBase.changedFiles);
         newRow = {
-          ...r,
+          ...rBase,
           state: "ready",
           verdict: parsed.verdict,
           headline: parsed.headline,
           body: parsed.body,
           openItems: parsed.openItems,
+          blocks: grounded,
           generatedAt: t,
           updatedAt: t,
         };
       } else {
         // timeout or unparseable — fail closed, never fake a ready
-        newRow = { ...r, state: "failed", generatedAt: t, updatedAt: t };
+        newRow = { ...rBase, state: "failed", blocks: [], generatedAt: t, updatedAt: t };
       }
       this.deps.store.putRecap(newRow);
       this.deps.onChange(r.sessionId, newRow);
+      this.deps.store.setRecapPendingDiff(r.sessionId, []);
 
       // Best-effort usage capture.
       try {

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,6 +5,7 @@ import type {
   ReviewVerdict,
   PlanGate,
   Recap,
+  DiffFile,
   Signal,
   SignalKind,
   Learning,
@@ -18,6 +19,7 @@ import type {
   HerdDigest,
   RundownItem,
 } from "./types";
+import { parseVisualBlocks, type VisualBlock } from "./visual-blocks";
 import type { CapRow, CapStore, CreditSnapshot, CreditStore, WindowKey } from "./usage-limits";
 import { dominantModel, type SessionUsage } from "./usage";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
@@ -348,11 +350,19 @@ export class SessionStore implements CapStore, CreditStore {
       model TEXT,
       spawnedAt INTEGER NOT NULL,
       generatedAt INTEGER,
-      updatedAt INTEGER NOT NULL)`);
+      updatedAt INTEGER NOT NULL,
+      blocks TEXT NOT NULL DEFAULT '[]',
+      pendingDiff TEXT NOT NULL DEFAULT '[]')`);
     // migrate recaps that predate the changedFiles column (existing rows default to none)
     const recapCols = this.db.query(`PRAGMA table_info(recaps)`).all() as { name: string }[];
     if (!recapCols.some((c) => c.name === "changedFiles")) {
       this.db.run(`ALTER TABLE recaps ADD COLUMN changedFiles TEXT NOT NULL DEFAULT '[]'`);
+    }
+    if (!recapCols.some((c) => c.name === "blocks")) {
+      this.db.run(`ALTER TABLE recaps ADD COLUMN blocks TEXT NOT NULL DEFAULT '[]'`);
+    }
+    if (!recapCols.some((c) => c.name === "pendingDiff")) {
+      this.db.run(`ALTER TABLE recaps ADD COLUMN pendingDiff TEXT NOT NULL DEFAULT '[]'`);
     }
     // Herd Rundown: one synthesized cross-session attention digest per calendar day.
     // Same lifecycle as recaps (generating → ready/failed); verdict columns empty until ready.
@@ -1405,6 +1415,12 @@ export class SessionStore implements CapStore, CreditStore {
     } catch {
       changedFiles = [];
     }
+    let blocks: VisualBlock[];
+    try {
+      blocks = parseVisualBlocks(JSON.parse(r.blocks));
+    } catch {
+      blocks = [];
+    }
     return {
       sessionId: r.sessionId,
       state: r.state,
@@ -1414,6 +1430,7 @@ export class SessionStore implements CapStore, CreditStore {
       body: r.body ?? "",
       openItems,
       changedFiles,
+      blocks,
       spawnSessionId: r.spawnSessionId ?? "",
       cwd: r.cwd ?? "",
       model: r.model ?? null,
@@ -1423,10 +1440,19 @@ export class SessionStore implements CapStore, CreditStore {
     } as Recap;
   }
 
+  private parsePendingDiff(raw: unknown): DiffFile[] {
+    try {
+      const p = JSON.parse(raw as string);
+      return Array.isArray(p) ? (p as DiffFile[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
   getRecap(sessionId: string): Recap | null {
     const r = this.db
       .query(
-        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles,
+        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles, blocks,
                 spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
               FROM recaps WHERE sessionId = ?`,
       )
@@ -1437,11 +1463,12 @@ export class SessionStore implements CapStore, CreditStore {
   putRecap(recap: Recap): void {
     this.db.run(
       `INSERT INTO recaps (sessionId, state, headSha, verdict, headline, body, openItems, changedFiles,
-         spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         blocks, spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET state=excluded.state, headSha=excluded.headSha,
          verdict=excluded.verdict, headline=excluded.headline, body=excluded.body,
          openItems=excluded.openItems, changedFiles=excluded.changedFiles,
+         blocks=excluded.blocks,
          spawnSessionId=excluded.spawnSessionId,
          cwd=excluded.cwd, model=excluded.model, spawnedAt=excluded.spawnedAt,
          generatedAt=excluded.generatedAt, updatedAt=excluded.updatedAt`,
@@ -1454,6 +1481,7 @@ export class SessionStore implements CapStore, CreditStore {
         recap.body ?? "",
         JSON.stringify(recap.openItems ?? []),
         JSON.stringify(recap.changedFiles ?? []),
+        JSON.stringify(recap.blocks ?? []),
         recap.spawnSessionId ?? "",
         recap.cwd ?? "",
         recap.model ?? null,
@@ -1468,7 +1496,7 @@ export class SessionStore implements CapStore, CreditStore {
   snapshotRecaps(): Record<string, Recap> {
     const rows = this.db
       .query(
-        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles,
+        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles, blocks,
                 spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
               FROM recaps WHERE state != 'empty'`,
       )
@@ -1482,12 +1510,24 @@ export class SessionStore implements CapStore, CreditStore {
   generatingRecaps(): Recap[] {
     const rows = this.db
       .query(
-        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles,
-                spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
+        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles, blocks,
+                pendingDiff, spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
               FROM recaps WHERE state = 'generating'`,
       )
       .all() as any[];
-    return rows.map((r) => this.hydrateRecap(r));
+    return rows.map((r) => ({
+      ...this.hydrateRecap(r),
+      pendingDiff: this.parsePendingDiff(r.pendingDiff),
+    }));
+  }
+
+  /** Set/clear the transient diff carrier used by finalize's block-join. Server-only — never read by
+   *  the client-facing getRecap/snapshotRecaps paths. Pass [] to clear. */
+  setRecapPendingDiff(sessionId: string, files: DiffFile[]): void {
+    this.db.run(`UPDATE recaps SET pendingDiff = ? WHERE sessionId = ?`, [
+      JSON.stringify(files ?? []),
+      sessionId,
+    ]);
   }
 
   dropRecap(sessionId: string): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,7 +19,7 @@ import type {
   HerdDigest,
   RundownItem,
 } from "./types";
-import { parseVisualBlocks, type VisualBlock } from "./visual-blocks";
+import type { VisualBlock } from "./visual-blocks";
 import type { CapRow, CapStore, CreditSnapshot, CreditStore, WindowKey } from "./usage-limits";
 import { dominantModel, type SessionUsage } from "./usage";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
@@ -1415,9 +1415,14 @@ export class SessionStore implements CapStore, CreditStore {
     } catch {
       changedFiles = [];
     }
-    let blocks: VisualBlock[];
+    // Persisted blocks were already validated + server-grounded at finalize (the real DiffFile is
+    // joined onto diff blocks there). Parse as trusted data — do NOT re-run parseVisualBlocks, the
+    // LLM-input trust boundary, which strips the joined `file` off diff blocks. parseVisualBlocks
+    // runs only on fresh spawn output (recap-core.ts), never on DB reads.
+    let blocks: VisualBlock[] = [];
     try {
-      blocks = parseVisualBlocks(JSON.parse(r.blocks));
+      const parsed = JSON.parse(r.blocks);
+      if (Array.isArray(parsed)) blocks = parsed as VisualBlock[];
     } catch {
       blocks = [];
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { SandboxProfile } from "./sandbox";
+import type { VisualBlock } from "./visual-blocks";
 
 export type HerdrState = "idle" | "working" | "blocked" | "done" | "unknown";
 export type SessionStatus = "running" | "idle" | "blocked" | "done" | "archived";
@@ -303,6 +304,9 @@ export interface Recap {
   spawnedAt: number;
   generatedAt: number | null; // set when finalized (ready/failed/empty)
   updatedAt: number;
+  blocks?: VisualBlock[]; // optional typed visual blocks; absent → render flat markdown body (back-compat)
+  pendingDiff?: DiffFile[]; // SERVER-ONLY transient carrier: populated ONLY by generatingRecaps() for
+  // finalize's diff-join; never serialized to the client, never set via putRecap
 }
 
 // ── herd rundown (cross-session attention digest, keyed by calendar day) ──────

--- a/src/visual-blocks.test.ts
+++ b/src/visual-blocks.test.ts
@@ -1,0 +1,523 @@
+import { describe, expect, it } from "bun:test";
+import type { DiffFile } from "./types";
+import {
+  CALLOUT_TONES,
+  DIFF_BLOCK_MAX_LINES,
+  FILE_TREE_CHANGES,
+  capDiffBlock,
+  joinDiffBlocks,
+  parseVisualBlocks,
+  reconcileFileTree,
+} from "./visual-blocks";
+
+// ── parseVisualBlocks ────────────────────────────────────────────────────────
+
+describe("parseVisualBlocks", () => {
+  it("returns [] for non-array input", () => {
+    expect(parseVisualBlocks(null)).toEqual([]);
+    expect(parseVisualBlocks(undefined)).toEqual([]);
+    expect(parseVisualBlocks("string")).toEqual([]);
+    expect(parseVisualBlocks(42)).toEqual([]);
+    expect(parseVisualBlocks({ type: "rich-text", id: "1", markdown: "x" })).toEqual([]);
+  });
+
+  it("drops blocks with missing id", () => {
+    const result = parseVisualBlocks([{ type: "rich-text", markdown: "hello" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("drops blocks with empty id", () => {
+    const result = parseVisualBlocks([{ type: "rich-text", id: "", markdown: "hello" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("drops blocks with unknown type", () => {
+    const result = parseVisualBlocks([{ type: "fancy-thing", id: "1", markdown: "x" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("accepts valid rich-text block", () => {
+    const result = parseVisualBlocks([
+      { type: "rich-text", id: "r1", markdown: "hello **world**" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ type: "rich-text", id: "r1", markdown: "hello **world**" });
+  });
+
+  it("accepts rich-text with empty markdown string", () => {
+    const result = parseVisualBlocks([{ type: "rich-text", id: "r1", markdown: "" }]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("drops rich-text missing markdown", () => {
+    const result = parseVisualBlocks([{ type: "rich-text", id: "r1" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("accepts valid callout block", () => {
+    const result = parseVisualBlocks([
+      { type: "callout", id: "c1", tone: "info", markdown: "note" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ type: "callout", id: "c1", tone: "info", markdown: "note" });
+  });
+
+  it("drops callout with bad tone", () => {
+    const result = parseVisualBlocks([
+      { type: "callout", id: "c1", tone: "unknown-tone", markdown: "note" },
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("drops callout missing markdown", () => {
+    const result = parseVisualBlocks([{ type: "callout", id: "c1", tone: "risk" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("accepts all valid callout tones", () => {
+    for (const tone of CALLOUT_TONES) {
+      const result = parseVisualBlocks([{ type: "callout", id: "c1", tone, markdown: "x" }]);
+      expect(result).toHaveLength(1);
+    }
+  });
+
+  it("accepts valid file-tree block", () => {
+    const result = parseVisualBlocks([
+      {
+        type: "file-tree",
+        id: "ft1",
+        title: "Changed files",
+        entries: [{ path: "src/foo.ts", change: "added" }],
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    const block = result[0];
+    expect(block.type).toBe("file-tree");
+    if (block.type === "file-tree") {
+      expect(block.entries).toHaveLength(1);
+      expect(block.title).toBe("Changed files");
+    }
+  });
+
+  it("drops file-tree with all-invalid entries", () => {
+    const result = parseVisualBlocks([
+      {
+        type: "file-tree",
+        id: "ft1",
+        entries: [
+          { path: "", change: "added" }, // empty path
+          { path: "x.ts", change: "invented" }, // bad change
+          { change: "added" }, // missing path
+        ],
+      },
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("keeps only valid entries in file-tree", () => {
+    const result = parseVisualBlocks([
+      {
+        type: "file-tree",
+        id: "ft1",
+        entries: [
+          { path: "good.ts", change: "modified" },
+          { path: "", change: "added" }, // invalid: empty path
+          { path: "also-good.ts", change: "removed" },
+        ],
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    const block = result[0];
+    if (block.type === "file-tree") {
+      expect(block.entries).toHaveLength(2);
+      expect(block.entries[0].path).toBe("good.ts");
+      expect(block.entries[1].path).toBe("also-good.ts");
+    }
+  });
+
+  it("coerces optional note in file-tree entry when string", () => {
+    const result = parseVisualBlocks([
+      {
+        type: "file-tree",
+        id: "ft1",
+        entries: [{ path: "src/foo.ts", change: "added", note: "important" }],
+      },
+    ]);
+    const block = result[0];
+    if (block.type === "file-tree") {
+      expect(block.entries[0].note).toBe("important");
+    }
+  });
+
+  it("drops note from file-tree entry when not a string", () => {
+    const result = parseVisualBlocks([
+      {
+        type: "file-tree",
+        id: "ft1",
+        entries: [{ path: "src/foo.ts", change: "added", note: 123 }],
+      },
+    ]);
+    const block = result[0];
+    if (block.type === "file-tree") {
+      expect(block.entries[0].note).toBeUndefined();
+    }
+  });
+
+  it("drops title from file-tree when not a string", () => {
+    const result = parseVisualBlocks([
+      {
+        type: "file-tree",
+        id: "ft1",
+        title: 999,
+        entries: [{ path: "src/foo.ts", change: "added" }],
+      },
+    ]);
+    const block = result[0];
+    if (block.type === "file-tree") {
+      expect(block.title).toBeUndefined();
+    }
+  });
+
+  it("accepts valid diff block", () => {
+    const result = parseVisualBlocks([
+      { type: "diff", id: "d1", path: "src/foo.ts", summary: "Added feature" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: "diff",
+      id: "d1",
+      path: "src/foo.ts",
+      summary: "Added feature",
+    });
+  });
+
+  it("drops diff missing summary", () => {
+    const result = parseVisualBlocks([{ type: "diff", id: "d1", path: "src/foo.ts" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("drops diff with empty path", () => {
+    const result = parseVisualBlocks([{ type: "diff", id: "d1", path: "", summary: "x" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("strips incoming file field from diff block", () => {
+    const result = parseVisualBlocks([
+      {
+        type: "diff",
+        id: "d1",
+        path: "src/foo.ts",
+        summary: "changes",
+        file: {
+          path: "src/foo.ts",
+          status: "modified",
+          additions: 1,
+          deletions: 0,
+          binary: false,
+          hunks: [],
+        },
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect((result[0] as { file?: unknown }).file).toBeUndefined();
+  });
+
+  it("drops annotation without note", () => {
+    const result = parseVisualBlocks([
+      {
+        type: "diff",
+        id: "d1",
+        path: "src/foo.ts",
+        summary: "x",
+        annotations: [{ label: "A", note: "good" }, { label: "B" }],
+      },
+    ]);
+    const block = result[0];
+    if (block.type === "diff") {
+      expect(block.annotations).toHaveLength(1);
+      expect(block.annotations![0].note).toBe("good");
+    }
+  });
+
+  it("strips lines/side keys from annotations", () => {
+    const result = parseVisualBlocks([
+      {
+        type: "diff",
+        id: "d1",
+        path: "src/foo.ts",
+        summary: "x",
+        annotations: [{ note: "prose", lines: [1, 2], side: "left", label: "L" }],
+      },
+    ]);
+    const block = result[0];
+    if (block.type === "diff") {
+      const ann = block.annotations![0] as Record<string, unknown>;
+      expect(ann.lines).toBeUndefined();
+      expect(ann.side).toBeUndefined();
+      expect(ann.note).toBe("prose");
+      expect(ann.label).toBe("L");
+    }
+  });
+
+  it("preserves input order of surviving blocks", () => {
+    const result = parseVisualBlocks([
+      { type: "rich-text", id: "r1", markdown: "first" },
+      { type: "callout", id: "c1", tone: "info", markdown: "second" },
+      { type: "rich-text", id: "r2", markdown: "third" },
+    ]);
+    expect(result.map((b) => b.id)).toEqual(["r1", "c1", "r2"]);
+  });
+});
+
+// ── joinDiffBlocks ────────────────────────────────────────────────────────────
+
+describe("joinDiffBlocks", () => {
+  const fooFile: DiffFile = {
+    path: "src/foo.ts",
+    status: "modified",
+    additions: 5,
+    deletions: 2,
+    binary: false,
+    hunks: [],
+  };
+  const barFile: DiffFile = {
+    path: "src/bar.ts",
+    status: "added",
+    additions: 10,
+    deletions: 0,
+    binary: false,
+    hunks: [],
+  };
+
+  it("attaches matching DiffFile to diff block", () => {
+    const blocks = parseVisualBlocks([
+      { type: "diff", id: "d1", path: "src/foo.ts", summary: "updated foo" },
+    ]);
+    const result = joinDiffBlocks(blocks, [fooFile, barFile]);
+    expect(result).toHaveLength(1);
+    const block = result[0];
+    if (block.type === "diff") {
+      expect(block.file).toBe(fooFile);
+    }
+  });
+
+  it("drops unmatched diff block", () => {
+    const blocks = parseVisualBlocks([
+      { type: "diff", id: "d1", path: "src/missing.ts", summary: "x" },
+    ]);
+    const result = joinDiffBlocks(blocks, [fooFile]);
+    expect(result).toEqual([]);
+  });
+
+  it("passes non-diff blocks through unchanged", () => {
+    const blocks = parseVisualBlocks([
+      { type: "rich-text", id: "r1", markdown: "hello" },
+      { type: "callout", id: "c1", tone: "decision", markdown: "decided" },
+    ]);
+    const result = joinDiffBlocks(blocks, [fooFile]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(blocks[0]);
+    expect(result[1]).toEqual(blocks[1]);
+  });
+
+  it("does not mutate input blocks array", () => {
+    const blocks = parseVisualBlocks([
+      { type: "diff", id: "d1", path: "src/foo.ts", summary: "x" },
+    ]);
+    const original = [...blocks];
+    joinDiffBlocks(blocks, [fooFile]);
+    expect(blocks).toEqual(original);
+  });
+
+  it("does not mutate input diffFiles array", () => {
+    const diffFiles = [fooFile, barFile];
+    const blocks = parseVisualBlocks([
+      { type: "diff", id: "d1", path: "src/foo.ts", summary: "x" },
+    ]);
+    joinDiffBlocks(blocks, diffFiles);
+    expect(diffFiles).toHaveLength(2);
+    expect(diffFiles[0]).toBe(fooFile);
+  });
+});
+
+// ── reconcileFileTree ─────────────────────────────────────────────────────────
+
+describe("reconcileFileTree", () => {
+  const diffFiles: DiffFile[] = [
+    {
+      path: "src/foo.ts",
+      status: "modified",
+      additions: 3,
+      deletions: 1,
+      binary: false,
+      hunks: [],
+    },
+    { path: "src/bar.ts", status: "deleted", additions: 0, deletions: 5, binary: false, hunks: [] },
+    { path: "src/baz.ts", status: "renamed", additions: 0, deletions: 0, binary: false, hunks: [] },
+  ];
+
+  it("overrides entry change with real status from diffFiles", () => {
+    const blocks = parseVisualBlocks([
+      {
+        type: "file-tree",
+        id: "ft1",
+        entries: [{ path: "src/foo.ts", change: "added" }], // wrong change
+      },
+    ]);
+    const result = reconcileFileTree(blocks, diffFiles);
+    const block = result[0];
+    if (block.type === "file-tree") {
+      expect(block.entries[0].change).toBe("modified");
+    }
+  });
+
+  it("maps deleted DiffFileStatus to removed FileTreeChange", () => {
+    const blocks = parseVisualBlocks([
+      {
+        type: "file-tree",
+        id: "ft1",
+        entries: [{ path: "src/bar.ts", change: "added" }],
+      },
+    ]);
+    const result = reconcileFileTree(blocks, diffFiles);
+    const block = result[0];
+    if (block.type === "file-tree") {
+      expect(block.entries[0].change).toBe("removed");
+    }
+  });
+
+  it("drops entries whose path is not in diffFiles", () => {
+    const blocks = parseVisualBlocks([
+      {
+        type: "file-tree",
+        id: "ft1",
+        entries: [
+          { path: "src/foo.ts", change: "modified" },
+          { path: "invented/path.ts", change: "added" }, // not in diff
+        ],
+      },
+    ]);
+    const result = reconcileFileTree(blocks, diffFiles);
+    const block = result[0];
+    if (block.type === "file-tree") {
+      expect(block.entries).toHaveLength(1);
+      expect(block.entries[0].path).toBe("src/foo.ts");
+    }
+  });
+
+  it("drops whole block when all entries are invented", () => {
+    const blocks = parseVisualBlocks([
+      {
+        type: "file-tree",
+        id: "ft1",
+        entries: [{ path: "invented/path.ts", change: "added" }],
+      },
+    ]);
+    const result = reconcileFileTree(blocks, diffFiles);
+    expect(result).toEqual([]);
+  });
+
+  it("passes non-file-tree blocks unchanged", () => {
+    const blocks = parseVisualBlocks([{ type: "rich-text", id: "r1", markdown: "hello" }]);
+    const result = reconcileFileTree(blocks, diffFiles);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(blocks[0]);
+  });
+
+  it("does not mutate input", () => {
+    const blocks = parseVisualBlocks([
+      {
+        type: "file-tree",
+        id: "ft1",
+        entries: [{ path: "src/foo.ts", change: "added" }],
+      },
+    ]);
+    const originalChange = (blocks[0] as { type: "file-tree"; entries: { change: string }[] })
+      .entries[0].change;
+    reconcileFileTree(blocks, diffFiles);
+    expect(
+      (blocks[0] as { type: "file-tree"; entries: { change: string }[] }).entries[0].change,
+    ).toBe(originalChange);
+  });
+});
+
+// ── capDiffBlock ──────────────────────────────────────────────────────────────
+
+describe("capDiffBlock", () => {
+  const makeDiffFile = (lineCounts: number[]): DiffFile => ({
+    path: "src/file.ts",
+    status: "modified",
+    additions: 0,
+    deletions: 0,
+    binary: false,
+    hunks: lineCounts.map((n) => ({
+      header: "@@ -1,1 +1,1 @@",
+      lines: Array.from({ length: n }, (_, i) => ({
+        kind: "add" as const,
+        content: `line ${i}`,
+        newNo: i + 1,
+      })),
+    })),
+  });
+
+  it("returns file unchanged when total lines ≤ DIFF_BLOCK_MAX_LINES", () => {
+    const file = makeDiffFile([100, 200]);
+    const result = capDiffBlock(file);
+    expect(result).toBe(file); // same reference
+  });
+
+  it("returns truncated copy when total lines exceed DIFF_BLOCK_MAX_LINES", () => {
+    const file = makeDiffFile([300, 400]); // 700 lines > 600
+    const result = capDiffBlock(file);
+    expect(result).not.toBe(file);
+    expect(result.truncated).toBe(true);
+    expect(result.hunks).toEqual([]);
+  });
+
+  it("preserves other fields in truncated copy", () => {
+    const file = makeDiffFile([700]);
+    const result = capDiffBlock(file);
+    expect(result.path).toBe(file.path);
+    expect(result.status).toBe(file.status);
+    expect(result.additions).toBe(file.additions);
+  });
+
+  it("does not mutate input file", () => {
+    const file = makeDiffFile([700]);
+    const originalHunks = file.hunks;
+    capDiffBlock(file);
+    expect(file.hunks).toBe(originalHunks);
+    expect(file.truncated).toBeUndefined();
+  });
+
+  it("uses DIFF_BLOCK_MAX_LINES = 600", () => {
+    expect(DIFF_BLOCK_MAX_LINES).toBe(600);
+  });
+
+  it("accepts custom maxLines param", () => {
+    const file = makeDiffFile([50]);
+    const result = capDiffBlock(file, 30);
+    expect(result.truncated).toBe(true);
+  });
+});
+
+// ── constant arrays ────────────────────────────────────────────────────────────
+
+describe("constant arrays", () => {
+  it("CALLOUT_TONES contains expected values", () => {
+    expect(CALLOUT_TONES).toContain("info");
+    expect(CALLOUT_TONES).toContain("decision");
+    expect(CALLOUT_TONES).toContain("risk");
+    expect(CALLOUT_TONES).toContain("warning");
+    expect(CALLOUT_TONES).toContain("success");
+    expect(CALLOUT_TONES).toHaveLength(5);
+  });
+
+  it("FILE_TREE_CHANGES contains expected values", () => {
+    expect(FILE_TREE_CHANGES).toContain("added");
+    expect(FILE_TREE_CHANGES).toContain("modified");
+    expect(FILE_TREE_CHANGES).toContain("removed");
+    expect(FILE_TREE_CHANGES).toContain("renamed");
+    expect(FILE_TREE_CHANGES).toHaveLength(4);
+  });
+});

--- a/src/visual-blocks.ts
+++ b/src/visual-blocks.ts
@@ -1,0 +1,212 @@
+/**
+ * Pure helpers for native visual recap blocks — no I/O, no DB, no spawn.
+ * Provides the VisualBlock discriminated union, a fail-closed LLM-JSON parser,
+ * and diff-join / file-tree-reconcile / hunk-cap helpers.
+ */
+import type { DiffFile, DiffFileStatus } from "./types";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type CalloutTone = "info" | "decision" | "risk" | "warning" | "success";
+export type FileTreeChange = "added" | "modified" | "removed" | "renamed";
+
+export interface FileTreeEntry {
+  path: string;
+  change: FileTreeChange;
+  note?: string;
+}
+
+/** Prose-only annotation — no line numbers (Phase 1). */
+export interface DiffAnnotation {
+  label?: string;
+  note: string;
+}
+
+export type VisualBlock =
+  | { type: "rich-text"; id: string; markdown: string }
+  | { type: "callout"; id: string; tone: CalloutTone; markdown: string }
+  | { type: "file-tree"; id: string; title?: string; entries: FileTreeEntry[] }
+  | {
+      type: "diff";
+      id: string;
+      path: string;
+      summary: string;
+      annotations?: DiffAnnotation[];
+      /** Server-joined real diff; populated by joinDiffBlocks — never from LLM input. */
+      file?: DiffFile;
+    };
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const CALLOUT_TONES: readonly CalloutTone[] = [
+  "info",
+  "decision",
+  "risk",
+  "warning",
+  "success",
+];
+
+export const FILE_TREE_CHANGES: readonly FileTreeChange[] = [
+  "added",
+  "modified",
+  "removed",
+  "renamed",
+];
+
+export const DIFF_BLOCK_MAX_LINES = 600;
+
+// ── parseVisualBlocks ─────────────────────────────────────────────────────────
+
+/** Parse + validate LLM-emitted JSON into typed VisualBlock[]. Never throws.
+ *  Drops malformed blocks and returns only valid ones ([] on non-array input).
+ *  This is the trust boundary — be defensive, drop on any doubt. */
+export function parseVisualBlocks(raw: unknown): VisualBlock[] {
+  if (!Array.isArray(raw)) return [];
+
+  const result: VisualBlock[] = [];
+
+  for (const item of raw) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const r = item as Record<string, unknown>;
+
+    const id = r.id;
+    if (typeof id !== "string" || id === "") continue;
+
+    const type = r.type;
+    if (typeof type !== "string") continue;
+
+    switch (type) {
+      case "rich-text": {
+        if (typeof r.markdown !== "string") continue;
+        result.push({ type: "rich-text", id, markdown: r.markdown });
+        break;
+      }
+      case "callout": {
+        if (typeof r.markdown !== "string") continue;
+        if (!CALLOUT_TONES.includes(r.tone as CalloutTone)) continue;
+        result.push({ type: "callout", id, tone: r.tone as CalloutTone, markdown: r.markdown });
+        break;
+      }
+      case "file-tree": {
+        const rawEntries = r.entries;
+        const entries: FileTreeEntry[] = [];
+        if (Array.isArray(rawEntries)) {
+          for (const e of rawEntries) {
+            if (!e || typeof e !== "object" || Array.isArray(e)) continue;
+            const er = e as Record<string, unknown>;
+            if (typeof er.path !== "string" || er.path === "") continue;
+            if (!FILE_TREE_CHANGES.includes(er.change as FileTreeChange)) continue;
+            const entry: FileTreeEntry = {
+              path: er.path,
+              change: er.change as FileTreeChange,
+            };
+            if (typeof er.note === "string") entry.note = er.note;
+            entries.push(entry);
+          }
+        }
+        if (entries.length === 0) continue;
+        const block: VisualBlock & { type: "file-tree" } = { type: "file-tree", id, entries };
+        if (typeof r.title === "string") block.title = r.title;
+        result.push(block);
+        break;
+      }
+      case "diff": {
+        if (typeof r.path !== "string" || r.path === "") continue;
+        if (typeof r.summary !== "string") continue;
+        const block: VisualBlock & { type: "diff" } = {
+          type: "diff",
+          id,
+          path: r.path,
+          summary: r.summary,
+          // strip any incoming `file` field — server populates it via joinDiffBlocks
+        };
+        const rawAnnotations = r.annotations;
+        if (Array.isArray(rawAnnotations)) {
+          const annotations: DiffAnnotation[] = [];
+          for (const a of rawAnnotations) {
+            if (!a || typeof a !== "object" || Array.isArray(a)) continue;
+            const ar = a as Record<string, unknown>;
+            if (typeof ar.note !== "string") continue;
+            // strip lines/side (Phase-1 prose-only annotations)
+            const ann: DiffAnnotation = { note: ar.note };
+            if (typeof ar.label === "string") ann.label = ar.label;
+            annotations.push(ann);
+          }
+          if (annotations.length > 0) block.annotations = annotations;
+        }
+        result.push(block);
+        break;
+      }
+      default:
+        // unknown type — drop
+        continue;
+    }
+  }
+
+  return result;
+}
+
+// ── joinDiffBlocks ────────────────────────────────────────────────────────────
+
+/** For each `diff` block, attach the matching DiffFile (exact path match).
+ *  Drops diff blocks with no match (enforces true-by-construction).
+ *  Non-diff blocks pass through. Returns a new array; inputs not mutated. */
+export function joinDiffBlocks(blocks: VisualBlock[], diffFiles: DiffFile[]): VisualBlock[] {
+  const byPath = new Map<string, DiffFile>(diffFiles.map((f) => [f.path, f]));
+  const result: VisualBlock[] = [];
+
+  for (const block of blocks) {
+    if (block.type !== "diff") {
+      result.push(block);
+      continue;
+    }
+    const file = byPath.get(block.path);
+    if (!file) continue; // unmatched — drop
+    result.push({ ...block, file });
+  }
+
+  return result;
+}
+
+// ── reconcileFileTree ─────────────────────────────────────────────────────────
+
+/** Map DiffFileStatus to FileTreeChange. "deleted" → "removed"; others are identical strings. */
+function statusToChange(status: DiffFileStatus): FileTreeChange {
+  return status === "deleted" ? "removed" : (status as FileTreeChange);
+}
+
+/** For each `file-tree` block, override entry changes with real diff statuses and drop invented paths.
+ *  Drops whole block when all entries are invented. Non-file-tree blocks pass through.
+ *  Returns a new array; inputs not mutated. */
+export function reconcileFileTree(blocks: VisualBlock[], diffFiles: DiffFile[]): VisualBlock[] {
+  const byPath = new Map<string, DiffFileStatus>(diffFiles.map((f) => [f.path, f.status]));
+  const result: VisualBlock[] = [];
+
+  for (const block of blocks) {
+    if (block.type !== "file-tree") {
+      result.push(block);
+      continue;
+    }
+    const entries: FileTreeEntry[] = [];
+    for (const entry of block.entries) {
+      const status = byPath.get(entry.path);
+      if (status === undefined) continue; // invented path — drop
+      entries.push({ ...entry, change: statusToChange(status) });
+    }
+    if (entries.length === 0) continue; // all entries were invented — drop whole block
+    result.push({ ...block, entries });
+  }
+
+  return result;
+}
+
+// ── capDiffBlock ──────────────────────────────────────────────────────────────
+
+/** Bounds a DiffFile so persisted blocks JSON can't balloon.
+ *  If total hunk line count exceeds maxLines, returns a copy with truncated=true and hunks=[].
+ *  Otherwise returns the same object (no allocation). Pure, no mutation. */
+export function capDiffBlock(file: DiffFile, maxLines = DIFF_BLOCK_MAX_LINES): DiffFile {
+  const total = file.hunks.reduce((sum, h) => sum + h.lines.length, 0);
+  if (total <= maxLines) return file;
+  return { ...file, truncated: true, hunks: [] };
+}

--- a/src/visual-blocks.ts
+++ b/src/visual-blocks.ts
@@ -132,27 +132,38 @@ const VALIDATORS: Record<string, BlockValidator> = {
   diff: validateDiff,
 };
 
+/** Validate a single raw element into a typed VisualBlock, or null when malformed. */
+function parseBlock(item: unknown): VisualBlock | null {
+  if (!item || typeof item !== "object" || Array.isArray(item)) return null;
+  const r = item as Record<string, unknown>;
+
+  const id = r.id;
+  if (typeof id !== "string" || id === "") return null;
+
+  const type = r.type;
+  if (typeof type !== "string") return null;
+
+  const validate = VALIDATORS[type]; // unknown type → undefined → drop
+  return validate ? validate(r, id) : null;
+}
+
 /** Parse + validate LLM-emitted JSON into typed VisualBlock[]. Never throws.
  *  Drops malformed blocks and returns only valid ones ([] on non-array input).
+ *  Enforces unique block ids (a later duplicate is dropped) — the renderer keys its
+ *  `{#each}` by `block.id`, so a duplicate id would break the keyed-each.
  *  This is the trust boundary — be defensive, drop on any doubt. */
 export function parseVisualBlocks(raw: unknown): VisualBlock[] {
   if (!Array.isArray(raw)) return [];
 
   const result: VisualBlock[] = [];
+  const seenIds = new Set<string>();
 
   for (const item of raw) {
-    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
-    const r = item as Record<string, unknown>;
-
-    const id = r.id;
-    if (typeof id !== "string" || id === "") continue;
-
-    const type = r.type;
-    if (typeof type !== "string") continue;
-
-    const validate = VALIDATORS[type]; // unknown type → undefined → drop
-    const block = validate ? validate(r, id) : null;
-    if (block) result.push(block);
+    const block = parseBlock(item);
+    if (!block) continue;
+    if (seenIds.has(block.id)) continue; // duplicate id → drop (keyed-each requires unique ids)
+    seenIds.add(block.id);
+    result.push(block);
   }
 
   return result;

--- a/src/visual-blocks.ts
+++ b/src/visual-blocks.ts
@@ -200,6 +200,44 @@ export function reconcileFileTree(blocks: VisualBlock[], diffFiles: DiffFile[]):
   return result;
 }
 
+// ── groundBlocks ──────────────────────────────────────────────────────────────
+
+/**
+ * Ground LLM-emitted blocks against the real diff.
+ *  - Carrier present (pendingDiff non-empty): join diff blocks to real DiffFiles (drop unmatched),
+ *    cap each joined file's hunks, and reconcile file-tree entries against the real diff.
+ *  - Carrier empty (e.g. a server bounce lost it before finalize): FAIL CLOSED — drop all `diff`
+ *    blocks (no real hunks to show), keep `file-tree` entries whose path is in `changedFiles`
+ *    (paths survive teardown; status does not, so the authored `change` is kept as-is), and pass
+ *    `rich-text`/`callout` through untouched.
+ */
+export function groundBlocks(
+  blocks: VisualBlock[],
+  pendingDiff: DiffFile[],
+  changedFiles: string[],
+): VisualBlock[] {
+  if (pendingDiff.length > 0) {
+    let b = joinDiffBlocks(blocks, pendingDiff); // diff blocks → .file set, unmatched dropped
+    b = b.map((blk) =>
+      blk.type === "diff" && blk.file ? { ...blk, file: capDiffBlock(blk.file) } : blk,
+    );
+    return reconcileFileTree(b, pendingDiff);
+  }
+  // carrier miss — fail closed
+  const paths = new Set(changedFiles);
+  const out: VisualBlock[] = [];
+  for (const blk of blocks) {
+    if (blk.type === "diff") continue; // no real hunks → drop
+    if (blk.type === "file-tree") {
+      const entries = blk.entries.filter((e) => paths.has(e.path));
+      if (entries.length > 0) out.push({ ...blk, entries });
+      continue;
+    }
+    out.push(blk);
+  }
+  return out;
+}
+
 // ── capDiffBlock ──────────────────────────────────────────────────────────────
 
 /** Bounds a DiffFile so persisted blocks JSON can't balloon.

--- a/src/visual-blocks.ts
+++ b/src/visual-blocks.ts
@@ -57,6 +57,81 @@ export const DIFF_BLOCK_MAX_LINES = 600;
 
 // ── parseVisualBlocks ─────────────────────────────────────────────────────────
 
+function validateRichText(r: Record<string, unknown>, id: string): VisualBlock | null {
+  if (typeof r.markdown !== "string") return null;
+  return { type: "rich-text", id, markdown: r.markdown };
+}
+
+function validateCallout(r: Record<string, unknown>, id: string): VisualBlock | null {
+  if (typeof r.markdown !== "string") return null;
+  if (!CALLOUT_TONES.includes(r.tone as CalloutTone)) return null;
+  return { type: "callout", id, tone: r.tone as CalloutTone, markdown: r.markdown };
+}
+
+function validateFileTreeEntry(raw: unknown): FileTreeEntry | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const er = raw as Record<string, unknown>;
+  if (typeof er.path !== "string" || er.path === "") return null;
+  if (!FILE_TREE_CHANGES.includes(er.change as FileTreeChange)) return null;
+  const entry: FileTreeEntry = { path: er.path, change: er.change as FileTreeChange };
+  if (typeof er.note === "string") entry.note = er.note;
+  return entry;
+}
+
+function validateFileTree(r: Record<string, unknown>, id: string): VisualBlock | null {
+  const entries: FileTreeEntry[] = [];
+  if (Array.isArray(r.entries)) {
+    for (const e of r.entries) {
+      const entry = validateFileTreeEntry(e);
+      if (entry) entries.push(entry);
+    }
+  }
+  if (entries.length === 0) return null;
+  const block: VisualBlock & { type: "file-tree" } = { type: "file-tree", id, entries };
+  if (typeof r.title === "string") block.title = r.title;
+  return block;
+}
+
+function validateDiffAnnotation(raw: unknown): DiffAnnotation | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const ar = raw as Record<string, unknown>;
+  if (typeof ar.note !== "string") return null;
+  // strip lines/side (Phase-1 prose-only annotations)
+  const ann: DiffAnnotation = { note: ar.note };
+  if (typeof ar.label === "string") ann.label = ar.label;
+  return ann;
+}
+
+function validateDiff(r: Record<string, unknown>, id: string): VisualBlock | null {
+  if (typeof r.path !== "string" || r.path === "") return null;
+  if (typeof r.summary !== "string") return null;
+  const block: VisualBlock & { type: "diff" } = {
+    type: "diff",
+    id,
+    path: r.path,
+    summary: r.summary,
+    // strip any incoming `file` field — server populates it via joinDiffBlocks
+  };
+  if (Array.isArray(r.annotations)) {
+    const annotations: DiffAnnotation[] = [];
+    for (const a of r.annotations) {
+      const ann = validateDiffAnnotation(a);
+      if (ann) annotations.push(ann);
+    }
+    if (annotations.length > 0) block.annotations = annotations;
+  }
+  return block;
+}
+
+type BlockValidator = (r: Record<string, unknown>, id: string) => VisualBlock | null;
+
+const VALIDATORS: Record<string, BlockValidator> = {
+  "rich-text": validateRichText,
+  callout: validateCallout,
+  "file-tree": validateFileTree,
+  diff: validateDiff,
+};
+
 /** Parse + validate LLM-emitted JSON into typed VisualBlock[]. Never throws.
  *  Drops malformed blocks and returns only valid ones ([] on non-array input).
  *  This is the trust boundary — be defensive, drop on any doubt. */
@@ -75,72 +150,9 @@ export function parseVisualBlocks(raw: unknown): VisualBlock[] {
     const type = r.type;
     if (typeof type !== "string") continue;
 
-    switch (type) {
-      case "rich-text": {
-        if (typeof r.markdown !== "string") continue;
-        result.push({ type: "rich-text", id, markdown: r.markdown });
-        break;
-      }
-      case "callout": {
-        if (typeof r.markdown !== "string") continue;
-        if (!CALLOUT_TONES.includes(r.tone as CalloutTone)) continue;
-        result.push({ type: "callout", id, tone: r.tone as CalloutTone, markdown: r.markdown });
-        break;
-      }
-      case "file-tree": {
-        const rawEntries = r.entries;
-        const entries: FileTreeEntry[] = [];
-        if (Array.isArray(rawEntries)) {
-          for (const e of rawEntries) {
-            if (!e || typeof e !== "object" || Array.isArray(e)) continue;
-            const er = e as Record<string, unknown>;
-            if (typeof er.path !== "string" || er.path === "") continue;
-            if (!FILE_TREE_CHANGES.includes(er.change as FileTreeChange)) continue;
-            const entry: FileTreeEntry = {
-              path: er.path,
-              change: er.change as FileTreeChange,
-            };
-            if (typeof er.note === "string") entry.note = er.note;
-            entries.push(entry);
-          }
-        }
-        if (entries.length === 0) continue;
-        const block: VisualBlock & { type: "file-tree" } = { type: "file-tree", id, entries };
-        if (typeof r.title === "string") block.title = r.title;
-        result.push(block);
-        break;
-      }
-      case "diff": {
-        if (typeof r.path !== "string" || r.path === "") continue;
-        if (typeof r.summary !== "string") continue;
-        const block: VisualBlock & { type: "diff" } = {
-          type: "diff",
-          id,
-          path: r.path,
-          summary: r.summary,
-          // strip any incoming `file` field — server populates it via joinDiffBlocks
-        };
-        const rawAnnotations = r.annotations;
-        if (Array.isArray(rawAnnotations)) {
-          const annotations: DiffAnnotation[] = [];
-          for (const a of rawAnnotations) {
-            if (!a || typeof a !== "object" || Array.isArray(a)) continue;
-            const ar = a as Record<string, unknown>;
-            if (typeof ar.note !== "string") continue;
-            // strip lines/side (Phase-1 prose-only annotations)
-            const ann: DiffAnnotation = { note: ar.note };
-            if (typeof ar.label === "string") ann.label = ar.label;
-            annotations.push(ann);
-          }
-          if (annotations.length > 0) block.annotations = annotations;
-        }
-        result.push(block);
-        break;
-      }
-      default:
-        // unknown type — drop
-        continue;
-    }
+    const validate = VALIDATORS[type]; // unknown type → undefined → drop
+    const block = validate ? validate(r, id) : null;
+    if (block) result.push(block);
   }
 
   return result;

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -280,3 +280,131 @@ test("buildRecapPrompt: skips plan section when plan is empty", () => {
   });
   expect(p).not.toContain("Plan that was executed");
 });
+
+// ── parseRecapVerdict — blocks ────────────────────────────────────────────────
+
+test("parseRecapVerdict: returns blocks:[] when JSON has no blocks field (back-compat)", () => {
+  const result = parseRecapVerdict({ verdict: "ready", headline: "x", body: "", openItems: [] });
+  expect(result).not.toBeNull();
+  expect(result?.blocks).toEqual([]);
+});
+
+test("parseRecapVerdict: returns parsed blocks when valid blocks are present", () => {
+  const raw = {
+    verdict: "ready",
+    headline: "x",
+    body: "",
+    openItems: [],
+    blocks: [
+      { type: "rich-text", id: "r1", markdown: "## Why\nContext." },
+      {
+        type: "diff",
+        id: "d1",
+        path: "src/foo.ts",
+        summary: "Added helper",
+        annotations: [{ note: "Extracted from main loop" }],
+      },
+    ],
+  };
+  const result = parseRecapVerdict(raw);
+  expect(result).not.toBeNull();
+  expect(result?.blocks).toHaveLength(2);
+  expect(result?.blocks[0]).toMatchObject({ type: "rich-text", id: "r1" });
+  expect(result?.blocks[1]).toMatchObject({ type: "diff", id: "d1", path: "src/foo.ts" });
+});
+
+test("parseRecapVerdict: garbage blocks returns blocks:[] but verdict still valid", () => {
+  const withString = parseRecapVerdict({
+    verdict: "ready",
+    headline: "x",
+    body: "",
+    openItems: [],
+    blocks: "nope",
+  });
+  expect(withString).not.toBeNull();
+  expect(withString?.blocks).toEqual([]);
+
+  const withJunk = parseRecapVerdict({
+    verdict: "ready",
+    headline: "x",
+    body: "",
+    openItems: [],
+    blocks: [{ junk: true }],
+  });
+  expect(withJunk).not.toBeNull();
+  expect(withJunk?.blocks).toEqual([]);
+});
+
+test("parseRecapVerdict: invalid verdict returns null even when blocks are present", () => {
+  const result = parseRecapVerdict({
+    verdict: "approve",
+    headline: "x",
+    body: "",
+    openItems: [],
+    blocks: [{ type: "rich-text", id: "r1", markdown: "hello" }],
+  });
+  expect(result).toBeNull();
+});
+
+// ── buildRecapPrompt — blocks guidance ───────────────────────────────────────
+
+test("buildRecapPrompt: mentions blocks in output", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  expect(p).toContain("blocks");
+});
+
+test("buildRecapPrompt: includes all four block type names", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  expect(p).toContain("rich-text");
+  expect(p).toContain("callout");
+  expect(p).toContain("file-tree");
+  expect(p).toContain("diff");
+});
+
+test("buildRecapPrompt: describes annotations as prose not line numbers", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  expect(p).toContain("prose");
+  expect(p).toContain("NOT line numbers");
+});
+
+test("buildRecapPrompt: states diff hunks/file are server-supplied", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  expect(p).toContain("server");
+  expect(p).toContain("file");
+});
+
+test("buildRecapPrompt: includes redact-secrets instruction", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  expect(p).toContain("Redact secrets");
+  expect(p).toContain("redacted");
+});

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -396,6 +396,20 @@ test("buildRecapPrompt: states diff hunks/file are server-supplied", () => {
   expect(p).toContain("the server attaches the real diff content");
 });
 
+test("buildRecapPrompt: JSON shape example carries no inline comment (strict JSON.parse safety)", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+  });
+  // An inline `//` comment inside the shape's {...} literal would be echoed into
+  // .shepherd-recap.json and break strict JSON.parse — the optional-blocks note lives in prose.
+  expect(p).not.toContain("// blocks");
+  expect(p).toContain("no comments");
+});
+
 test("buildRecapPrompt: includes redact-secrets instruction", () => {
   const p = buildRecapPrompt({
     taskPrompt: "t",

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -393,8 +393,7 @@ test("buildRecapPrompt: states diff hunks/file are server-supplied", () => {
     digest: "",
     context: "",
   });
-  expect(p).toContain("server");
-  expect(p).toContain("file");
+  expect(p).toContain("the server attaches the real diff content");
 });
 
 test("buildRecapPrompt: includes redact-secrets instruction", () => {

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -1136,7 +1136,8 @@ test("finalize: broadcast NO-LEAK — onChange receives no pendingDiff key", asy
   await svc.tick();
 
   expect(broadcastRow).not.toBeNull();
-  expect("pendingDiff" in (broadcastRow as object)).toBe(false);
+  const broadcastRowNonNull = broadcastRow!;
+  expect("pendingDiff" in (broadcastRowNonNull as unknown as object)).toBe(false);
   const persisted = store.getRecap("s1");
   expect(persisted).not.toBeNull();
   expect("pendingDiff" in (persisted as object)).toBe(false);

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -111,6 +111,7 @@ type FakeStore = {
   reviewerSpawns: any[];
   completedSpawns: any[];
   sessions: Session[];
+  pendingDiffs: Record<string, any[]>;
   getRecap: (id: string) => Recap | null;
   putRecap: (r: Recap) => void;
   snapshotRecaps: () => Record<string, Recap>;
@@ -120,6 +121,7 @@ type FakeStore = {
   recordReviewerSpawn: (r: any) => void;
   completeReviewerSpawn: (id: string, u: any, at: number) => void;
   list: (opts?: { activeOnly?: boolean }) => Session[];
+  setRecapPendingDiff: (sessionId: string, files: any[]) => void;
 };
 
 function makeStore(sessions: Session[] = [], recaps: Recap[] = []): FakeStore {
@@ -132,13 +134,18 @@ function makeStore(sessions: Session[] = [], recaps: Recap[] = []): FakeStore {
     reviewerSpawns: [] as any[],
     completedSpawns: [] as any[],
     sessions,
+    pendingDiffs: {},
     getRecap: (id) => store.recaps[id] ?? null,
     putRecap: (r) => {
       store.recaps[r.sessionId] = r;
       store.generatingRows = Object.values(store.recaps).filter((x) => x.state === "generating");
     },
     snapshotRecaps: () => ({ ...store.recaps }),
-    generatingRecaps: () => store.generatingRows,
+    generatingRecaps: () =>
+      store.generatingRows.map((r) => ({
+        ...r,
+        pendingDiff: store.pendingDiffs[r.sessionId] ?? [],
+      })),
     dropRecap: (id) => {
       delete store.recaps[id];
       store.generatingRows = store.generatingRows.filter((r) => r.sessionId !== id);
@@ -148,6 +155,9 @@ function makeStore(sessions: Session[] = [], recaps: Recap[] = []): FakeStore {
     completeReviewerSpawn: (id: string, u: any, at: number) =>
       store.completedSpawns.push({ id, u, at }),
     list: () => store.sessions,
+    setRecapPendingDiff: (sessionId, files) => {
+      store.pendingDiffs[sessionId] = files;
+    },
   };
   return store;
 }
@@ -1016,4 +1026,206 @@ test("considerSession: headSha failure leaves fired=false so next sweep retries"
   t = 400_000;
   await svc.sweep(); // retries headSha (fired was not burned) → spawns
   expect(herdr.started.length).toBe(1);
+});
+
+// ── visual block grounding (Task 4) ──────────────────────────────────────────
+
+const VERDICT_WITH_BLOCKS = {
+  verdict: "ready",
+  headline: "All done",
+  body: "## Summary\nFixed it.",
+  openItems: [],
+  blocks: [
+    { type: "diff", id: "d1", path: "src/foo.ts", summary: "updated foo" },
+    {
+      type: "file-tree",
+      id: "ft1",
+      entries: [
+        { path: "src/foo.ts", change: "modified" },
+        { path: "invented.ts", change: "added" }, // not in diff → dropped by reconcile
+      ],
+    },
+    { type: "callout", id: "c1", tone: "info", markdown: "note" },
+  ],
+};
+
+test("generate: stashes pendingDiff after spawn", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    makeTmpDir: () => "/tmp/recap-stash",
+  });
+
+  const result = await svc.regenerate(s);
+  expect(result).toBe("started");
+  // setRecapPendingDiff called with the diff's files (non-empty)
+  expect(store.pendingDiffs["s1"]).toEqual(NON_EMPTY_DIFF.files);
+});
+
+test("finalize: joins + persists grounded blocks (carrier present)", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-ground",
+    spawnSessionId: "sp1",
+    spawnedAt: 100_000,
+    changedFiles: ["src/foo.ts"],
+  });
+  const store = makeStore([], [rec]);
+  // Simulate carrier stashed by generate
+  store.pendingDiffs["s1"] = NON_EMPTY_DIFF.files;
+
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-ground", terminalId: "t1" }]);
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    verdictJson: VERDICT_WITH_BLOCKS,
+    cleanup: () => {},
+  });
+
+  await svc.tick();
+
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("ready");
+  const blocks = r?.blocks ?? [];
+  // diff block joined with real file
+  const diffBlk = blocks.find((b) => b.type === "diff");
+  expect(diffBlk).toBeDefined();
+  if (diffBlk?.type === "diff") expect(diffBlk.file).toBeDefined();
+  // file-tree reconciled: invented.ts dropped, src/foo.ts kept
+  const ftBlk = blocks.find((b) => b.type === "file-tree");
+  expect(ftBlk).toBeDefined();
+  if (ftBlk?.type === "file-tree") {
+    expect(ftBlk.entries.every((e) => e.path !== "invented.ts")).toBe(true);
+    expect(ftBlk.entries.some((e) => e.path === "src/foo.ts")).toBe(true);
+  }
+  // callout present
+  expect(blocks.some((b) => b.type === "callout")).toBe(true);
+});
+
+test("finalize: broadcast NO-LEAK — onChange receives no pendingDiff key", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-noleak",
+    spawnSessionId: "sp2",
+    spawnedAt: 100_000,
+    changedFiles: ["src/foo.ts"],
+  });
+  const store = makeStore([], [rec]);
+  store.pendingDiffs["s1"] = NON_EMPTY_DIFF.files;
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-noleak", terminalId: "t2" }]);
+
+  let broadcastRow: Recap | null = null;
+  const svc = buildSvc({
+    store,
+    herdr,
+    onChange: (_id, r) => {
+      broadcastRow = r;
+    },
+    nowFn: () => 200_000,
+    verdictJson: VERDICT_WITH_BLOCKS,
+    cleanup: () => {},
+  });
+
+  await svc.tick();
+
+  expect(broadcastRow).not.toBeNull();
+  expect("pendingDiff" in (broadcastRow as object)).toBe(false);
+  const persisted = store.getRecap("s1");
+  expect(persisted).not.toBeNull();
+  expect("pendingDiff" in (persisted as object)).toBe(false);
+});
+
+test("finalize: carrier cleared on ready path", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-clear-ready",
+    spawnSessionId: "sp3",
+    spawnedAt: 100_000,
+    changedFiles: ["src/foo.ts"],
+  });
+  const store = makeStore([], [rec]);
+  store.pendingDiffs["s1"] = NON_EMPTY_DIFF.files;
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-clear-ready", terminalId: "t3" }]);
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    verdictJson: VERDICT_WITH_BLOCKS,
+    cleanup: () => {},
+  });
+
+  await svc.tick();
+  expect(store.pendingDiffs["s1"]).toEqual([]);
+});
+
+test("finalize: carrier cleared on failed path", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-clear-fail",
+    spawnSessionId: "sp4",
+    spawnedAt: 100_000,
+    changedFiles: ["src/foo.ts"],
+  });
+  const store = makeStore([], [rec]);
+  store.pendingDiffs["s1"] = NON_EMPTY_DIFF.files;
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-clear-fail", terminalId: "t4" }]);
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    verdictJson: { verdict: "not-valid", headline: 42 }, // unparseable
+    cleanup: () => {},
+  });
+
+  await svc.tick();
+  expect(store.getRecap("s1")?.state).toBe("failed");
+  expect(store.pendingDiffs["s1"]).toEqual([]);
+});
+
+test("finalize: empty carrier fail-closed — diff dropped, file-tree filtered, callout kept", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-failclosed",
+    spawnSessionId: "sp5",
+    spawnedAt: 100_000,
+    changedFiles: ["src/foo.ts"],
+  });
+  const store = makeStore([], [rec]);
+  // Carrier empty (simulates server bounce before finalize)
+  store.pendingDiffs["s1"] = [];
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-failclosed", terminalId: "t5" }]);
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    verdictJson: VERDICT_WITH_BLOCKS,
+    cleanup: () => {},
+  });
+
+  await svc.tick();
+
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("ready");
+  const blocks = r?.blocks ?? [];
+  // diff dropped (no real hunks)
+  expect(blocks.some((b) => b.type === "diff")).toBe(false);
+  // file-tree kept: src/foo.ts is in changedFiles; invented.ts filtered out
+  const ftBlk = blocks.find((b) => b.type === "file-tree");
+  expect(ftBlk).toBeDefined();
+  if (ftBlk?.type === "file-tree") {
+    expect(ftBlk.entries.every((e) => e.path !== "invented.ts")).toBe(true);
+    expect(ftBlk.entries.some((e) => e.path === "src/foo.ts")).toBe(true);
+  }
+  // callout passes through
+  expect(blocks.some((b) => b.type === "callout")).toBe(true);
 });

--- a/test/store-recaps.test.ts
+++ b/test/store-recaps.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { SessionStore } from "../src/store";
-import type { Recap } from "../src/types";
+import type { Recap, DiffFile } from "../src/types";
+import type { VisualBlock } from "../src/visual-blocks";
 
 const r = (over: Partial<Recap> = {}): Recap => ({
   sessionId: "s1",
@@ -156,4 +157,91 @@ test("recaps: snapshotRecaps returns hydrated Recap objects", () => {
   const snap = s.snapshotRecaps();
   expect(snap["s1"]?.openItems).toEqual(["fix CI"]);
   expect(snap["s1"]?.verdict).toBe("needs_attention");
+});
+
+// ── blocks + pendingDiff (Task 2) ─────────────────────────────────────────────
+
+const sampleBlocks: VisualBlock[] = [
+  { type: "rich-text", id: "b1", markdown: "# Summary\nAll good." },
+  { type: "callout", id: "b2", tone: "info", markdown: "Note this." },
+];
+
+const sampleDiffFile: DiffFile = {
+  path: "src/store.ts",
+  status: "modified",
+  additions: 10,
+  deletions: 2,
+  binary: false,
+  hunks: [],
+};
+
+test("recaps: blocks round-trip via put→get / snapshot / generatingRecaps", () => {
+  const s = new SessionStore(":memory:");
+  // generating row (also appears in generatingRecaps)
+  s.putRecap(r({ sessionId: "s1", state: "generating", blocks: sampleBlocks }));
+  // ready row (appears in snapshot)
+  s.putRecap(
+    r({
+      sessionId: "s2",
+      state: "ready",
+      verdict: "ready",
+      headline: "done",
+      blocks: sampleBlocks,
+    }),
+  );
+
+  // getRecap
+  expect(s.getRecap("s1")?.blocks).toEqual(sampleBlocks);
+  expect(s.getRecap("s2")?.blocks).toEqual(sampleBlocks);
+
+  // snapshotRecaps
+  expect(s.snapshotRecaps()["s2"]?.blocks).toEqual(sampleBlocks);
+
+  // generatingRecaps
+  const gen = s.generatingRecaps();
+  expect(gen.find((x) => x.sessionId === "s1")?.blocks).toEqual(sampleBlocks);
+});
+
+test("recaps: blocks back-compat — absent blocks hydrates to []", () => {
+  const s = new SessionStore(":memory:");
+  s.putRecap(r({ sessionId: "s1", state: "ready", verdict: "ready", headline: "h" }));
+  expect(s.getRecap("s1")?.blocks).toEqual([]);
+});
+
+test("recaps: blocks bad JSON in DB defaults to []", () => {
+  const s = new SessionStore(":memory:");
+  s.putRecap(r({ sessionId: "s1", state: "ready", verdict: "ready", headline: "h" }));
+  s["db"].run(`UPDATE recaps SET blocks='not json' WHERE sessionId='s1'`);
+  expect(s.getRecap("s1")?.blocks).toEqual([]);
+});
+
+test("recaps: pendingDiff carrier round-trip via setRecapPendingDiff / generatingRecaps", () => {
+  const s = new SessionStore(":memory:");
+  s.putRecap(r({ sessionId: "s1", state: "generating" }));
+
+  s.setRecapPendingDiff("s1", [sampleDiffFile]);
+  const gen1 = s.generatingRecaps();
+  expect(gen1.find((x) => x.sessionId === "s1")?.pendingDiff).toEqual([sampleDiffFile]);
+
+  // clear
+  s.setRecapPendingDiff("s1", []);
+  const gen2 = s.generatingRecaps();
+  expect(gen2.find((x) => x.sessionId === "s1")?.pendingDiff).toEqual([]);
+});
+
+test("recaps: pendingDiff NO-LEAK — absent from getRecap and snapshotRecaps", () => {
+  const s = new SessionStore(":memory:");
+  s.putRecap(r({ sessionId: "s1", state: "generating" }));
+  s.setRecapPendingDiff("s1", [sampleDiffFile]);
+
+  // getRecap must NOT expose pendingDiff
+  const got = s.getRecap("s1")!;
+  expect("pendingDiff" in got).toBe(false);
+
+  // snapshotRecaps must NOT expose pendingDiff
+  s.putRecap(r({ sessionId: "s2", state: "ready", verdict: "ready", headline: "h" }));
+  s.setRecapPendingDiff("s2", [sampleDiffFile]);
+  const snap = s.snapshotRecaps();
+  expect("pendingDiff" in snap["s2"]!).toBe(false);
+  expect("pendingDiff" in snap["s1"]!).toBe(false);
 });

--- a/test/store-recaps.test.ts
+++ b/test/store-recaps.test.ts
@@ -202,6 +202,30 @@ test("recaps: blocks round-trip via put→get / snapshot / generatingRecaps", ()
   expect(gen.find((x) => x.sessionId === "s1")?.blocks).toEqual(sampleBlocks);
 });
 
+test("recaps: diff block keeps its server-grounded `file` through put→get / snapshot / generatingRecaps", () => {
+  const s = new SessionStore(":memory:");
+  const diffBlock: VisualBlock = {
+    type: "diff",
+    id: "d1",
+    path: "src/store.ts",
+    summary: "tweak",
+    file: sampleDiffFile,
+  };
+  s.putRecap(r({ sessionId: "s1", state: "generating", blocks: [diffBlock] }));
+  s.putRecap(
+    r({ sessionId: "s2", state: "ready", verdict: "ready", headline: "done", blocks: [diffBlock] }),
+  );
+
+  // hydrateRecap must NOT re-run parseVisualBlocks (the LLM-input trust boundary, which strips the
+  // server-attached `file` off diff blocks): the persisted real DiffFile must survive every DB read.
+  const got = s.getRecap("s2")?.blocks?.[0];
+  expect(got).toBeDefined();
+  if (got?.type !== "diff") throw new Error("expected a diff block");
+  expect(got.file).toEqual(sampleDiffFile);
+  expect(s.snapshotRecaps()["s2"]?.blocks?.[0]).toEqual(diffBlock);
+  expect(s.generatingRecaps().find((x) => x.sessionId === "s1")?.blocks?.[0]).toEqual(diffBlock);
+});
+
 test("recaps: blocks back-compat — absent blocks hydrates to []", () => {
   const s = new SessionStore(":memory:");
   s.putRecap(r({ sessionId: "s1", state: "ready", verdict: "ready", headline: "h" }));

--- a/test/visual-blocks.test.ts
+++ b/test/visual-blocks.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "bun:test";
-import type { DiffFile } from "./types";
+import type { DiffFile } from "../src/types";
+import type { VisualBlock } from "../src/visual-blocks";
+
+function asBlock<T extends VisualBlock["type"]>(
+  b: VisualBlock | undefined,
+  t: T,
+): Extract<VisualBlock, { type: T }> {
+  expect(b?.type).toBe(t);
+  return b as Extract<VisualBlock, { type: T }>;
+}
 import {
   CALLOUT_TONES,
   DIFF_BLOCK_MAX_LINES,
@@ -92,12 +101,9 @@ describe("parseVisualBlocks", () => {
       },
     ]);
     expect(result).toHaveLength(1);
-    const block = result[0];
-    expect(block.type).toBe("file-tree");
-    if (block.type === "file-tree") {
-      expect(block.entries).toHaveLength(1);
-      expect(block.title).toBe("Changed files");
-    }
+    const block = asBlock(result[0], "file-tree");
+    expect(block.entries).toHaveLength(1);
+    expect(block.title).toBe("Changed files");
   });
 
   it("drops file-tree with all-invalid entries", () => {
@@ -128,12 +134,10 @@ describe("parseVisualBlocks", () => {
       },
     ]);
     expect(result).toHaveLength(1);
-    const block = result[0];
-    if (block.type === "file-tree") {
-      expect(block.entries).toHaveLength(2);
-      expect(block.entries[0].path).toBe("good.ts");
-      expect(block.entries[1].path).toBe("also-good.ts");
-    }
+    const block = asBlock(result[0], "file-tree");
+    expect(block.entries).toHaveLength(2);
+    expect(block.entries[0]!.path).toBe("good.ts");
+    expect(block.entries[1]!.path).toBe("also-good.ts");
   });
 
   it("coerces optional note in file-tree entry when string", () => {
@@ -144,10 +148,8 @@ describe("parseVisualBlocks", () => {
         entries: [{ path: "src/foo.ts", change: "added", note: "important" }],
       },
     ]);
-    const block = result[0];
-    if (block.type === "file-tree") {
-      expect(block.entries[0].note).toBe("important");
-    }
+    const block = asBlock(result[0], "file-tree");
+    expect(block.entries[0]!.note).toBe("important");
   });
 
   it("drops note from file-tree entry when not a string", () => {
@@ -158,10 +160,8 @@ describe("parseVisualBlocks", () => {
         entries: [{ path: "src/foo.ts", change: "added", note: 123 }],
       },
     ]);
-    const block = result[0];
-    if (block.type === "file-tree") {
-      expect(block.entries[0].note).toBeUndefined();
-    }
+    const block = asBlock(result[0], "file-tree");
+    expect(block.entries[0]!.note).toBeUndefined();
   });
 
   it("drops title from file-tree when not a string", () => {
@@ -173,10 +173,8 @@ describe("parseVisualBlocks", () => {
         entries: [{ path: "src/foo.ts", change: "added" }],
       },
     ]);
-    const block = result[0];
-    if (block.type === "file-tree") {
-      expect(block.title).toBeUndefined();
-    }
+    const block = asBlock(result[0], "file-tree");
+    expect(block.title).toBeUndefined();
   });
 
   it("accepts valid diff block", () => {
@@ -233,11 +231,9 @@ describe("parseVisualBlocks", () => {
         annotations: [{ label: "A", note: "good" }, { label: "B" }],
       },
     ]);
-    const block = result[0];
-    if (block.type === "diff") {
-      expect(block.annotations).toHaveLength(1);
-      expect(block.annotations![0].note).toBe("good");
-    }
+    const block = asBlock(result[0], "diff");
+    expect(block.annotations).toHaveLength(1);
+    expect(block.annotations![0]!.note).toBe("good");
   });
 
   it("strips lines/side keys from annotations", () => {
@@ -250,14 +246,12 @@ describe("parseVisualBlocks", () => {
         annotations: [{ note: "prose", lines: [1, 2], side: "left", label: "L" }],
       },
     ]);
-    const block = result[0];
-    if (block.type === "diff") {
-      const ann = block.annotations![0] as Record<string, unknown>;
-      expect(ann.lines).toBeUndefined();
-      expect(ann.side).toBeUndefined();
-      expect(ann.note).toBe("prose");
-      expect(ann.label).toBe("L");
-    }
+    const block = asBlock(result[0], "diff");
+    const ann = block.annotations![0] as unknown as Record<string, unknown>;
+    expect(ann.lines).toBeUndefined();
+    expect(ann.side).toBeUndefined();
+    expect(ann.note).toBe("prose");
+    expect(ann.label).toBe("L");
   });
 
   it("preserves input order of surviving blocks", () => {
@@ -296,10 +290,8 @@ describe("joinDiffBlocks", () => {
     ]);
     const result = joinDiffBlocks(blocks, [fooFile, barFile]);
     expect(result).toHaveLength(1);
-    const block = result[0];
-    if (block.type === "diff") {
-      expect(block.file).toBe(fooFile);
-    }
+    const block = asBlock(result[0], "diff");
+    expect(block.file).toBe(fooFile);
   });
 
   it("drops unmatched diff block", () => {
@@ -366,10 +358,8 @@ describe("reconcileFileTree", () => {
       },
     ]);
     const result = reconcileFileTree(blocks, diffFiles);
-    const block = result[0];
-    if (block.type === "file-tree") {
-      expect(block.entries[0].change).toBe("modified");
-    }
+    const block = asBlock(result[0], "file-tree");
+    expect(block.entries[0]!.change).toBe("modified");
   });
 
   it("maps deleted DiffFileStatus to removed FileTreeChange", () => {
@@ -381,10 +371,8 @@ describe("reconcileFileTree", () => {
       },
     ]);
     const result = reconcileFileTree(blocks, diffFiles);
-    const block = result[0];
-    if (block.type === "file-tree") {
-      expect(block.entries[0].change).toBe("removed");
-    }
+    const block = asBlock(result[0], "file-tree");
+    expect(block.entries[0]!.change).toBe("removed");
   });
 
   it("drops entries whose path is not in diffFiles", () => {
@@ -399,11 +387,9 @@ describe("reconcileFileTree", () => {
       },
     ]);
     const result = reconcileFileTree(blocks, diffFiles);
-    const block = result[0];
-    if (block.type === "file-tree") {
-      expect(block.entries).toHaveLength(1);
-      expect(block.entries[0].path).toBe("src/foo.ts");
-    }
+    const block = asBlock(result[0], "file-tree");
+    expect(block.entries).toHaveLength(1);
+    expect(block.entries[0]!.path).toBe("src/foo.ts");
   });
 
   it("drops whole block when all entries are invented", () => {
@@ -433,12 +419,10 @@ describe("reconcileFileTree", () => {
         entries: [{ path: "src/foo.ts", change: "added" }],
       },
     ]);
-    const originalChange = (blocks[0] as { type: "file-tree"; entries: { change: string }[] })
-      .entries[0].change;
+    const originalBlock = asBlock(blocks[0], "file-tree");
+    const originalChange = originalBlock.entries[0]!.change;
     reconcileFileTree(blocks, diffFiles);
-    expect(
-      (blocks[0] as { type: "file-tree"; entries: { change: string }[] }).entries[0].change,
-    ).toBe(originalChange);
+    expect(asBlock(blocks[0], "file-tree").entries[0]!.change).toBe(originalChange);
   });
 });
 
@@ -547,8 +531,8 @@ describe("groundBlocks", () => {
       ]);
       const result = groundBlocks(blocks, [fooFile, barFile], ["src/foo.ts", "src/bar.ts"]);
       expect(result).toHaveLength(1);
-      const blk = result[0];
-      if (blk.type === "diff") expect(blk.file).toBe(fooFile);
+      const blk = asBlock(result[0], "diff");
+      expect(blk.file).toBe(fooFile);
     });
 
     it("unmatched diff block is dropped", () => {
@@ -565,11 +549,9 @@ describe("groundBlocks", () => {
         { type: "diff", id: "d1", path: "src/foo.ts", summary: "big change" },
       ]);
       const result = groundBlocks(blocks, [bigFile], ["src/foo.ts"]);
-      const blk = result[0];
-      if (blk?.type === "diff") {
-        expect(blk.file?.truncated).toBe(true);
-        expect(blk.file?.hunks).toEqual([]);
-      }
+      const blk = asBlock(result[0], "diff");
+      expect(blk.file?.truncated).toBe(true);
+      expect(blk.file?.hunks).toEqual([]);
     });
 
     it("file-tree entries reconciled against real diff statuses", () => {
@@ -586,12 +568,10 @@ describe("groundBlocks", () => {
       ]);
       const result = groundBlocks(blocks, [fooFile, barFile], ["src/foo.ts", "src/bar.ts"]);
       expect(result).toHaveLength(1);
-      const blk = result[0];
-      if (blk.type === "file-tree") {
-        expect(blk.entries).toHaveLength(2);
-        expect(blk.entries[0]!.change).toBe("modified");
-        expect(blk.entries[1]!.change).toBe("added");
-      }
+      const blk = asBlock(result[0], "file-tree");
+      expect(blk.entries).toHaveLength(2);
+      expect(blk.entries[0]!.change).toBe("modified");
+      expect(blk.entries[1]!.change).toBe("added");
     });
   });
 
@@ -617,13 +597,11 @@ describe("groundBlocks", () => {
       ]);
       const result = groundBlocks(blocks, [], ["src/foo.ts"]);
       expect(result).toHaveLength(1);
-      const blk = result[0];
-      if (blk.type === "file-tree") {
-        expect(blk.entries).toHaveLength(1);
-        expect(blk.entries[0]!.path).toBe("src/foo.ts");
-        // authored change preserved (no real diff to reconcile against)
-        expect(blk.entries[0]!.change).toBe("modified");
-      }
+      const blk = asBlock(result[0], "file-tree");
+      expect(blk.entries).toHaveLength(1);
+      expect(blk.entries[0]!.path).toBe("src/foo.ts");
+      // authored change preserved (no real diff to reconcile against)
+      expect(blk.entries[0]!.change).toBe("modified");
     });
 
     it("file-tree block dropped when no entries are in changedFiles", () => {

--- a/test/visual-blocks.test.ts
+++ b/test/visual-blocks.test.ts
@@ -8,7 +8,7 @@ import {
   joinDiffBlocks,
   parseVisualBlocks,
   reconcileFileTree,
-} from "./visual-blocks";
+} from "../src/visual-blocks";
 
 // ── parseVisualBlocks ────────────────────────────────────────────────────────
 

--- a/test/visual-blocks.test.ts
+++ b/test/visual-blocks.test.ts
@@ -262,6 +262,27 @@ describe("parseVisualBlocks", () => {
     ]);
     expect(result.map((b) => b.id)).toEqual(["r1", "c1", "r2"]);
   });
+
+  it("drops a later block with a duplicate id (keyed-each needs unique ids)", () => {
+    const result = parseVisualBlocks([
+      { type: "rich-text", id: "dup", markdown: "first" },
+      { type: "callout", id: "dup", tone: "info", markdown: "second" },
+      { type: "rich-text", id: "keep", markdown: "third" },
+    ]);
+    expect(result.map((b) => b.id)).toEqual(["dup", "keep"]);
+    expect(result.map((b) => b.type)).toEqual(["rich-text", "rich-text"]);
+  });
+
+  it("reserves a duplicate id only once a VALID block used it", () => {
+    // first block with id "x" is invalid (missing markdown) and dropped → the id is not reserved,
+    // so the later valid block with the same id survives.
+    const result = parseVisualBlocks([
+      { type: "rich-text", id: "x" }, // invalid: no markdown → dropped, id not reserved
+      { type: "callout", id: "x", tone: "risk", markdown: "real" },
+    ]);
+    expect(result.map((b) => b.id)).toEqual(["x"]);
+    expect(result[0]?.type).toBe("callout");
+  });
 });
 
 // ── joinDiffBlocks ────────────────────────────────────────────────────────────

--- a/test/visual-blocks.test.ts
+++ b/test/visual-blocks.test.ts
@@ -5,6 +5,7 @@ import {
   DIFF_BLOCK_MAX_LINES,
   FILE_TREE_CHANGES,
   capDiffBlock,
+  groundBlocks,
   joinDiffBlocks,
   parseVisualBlocks,
   reconcileFileTree,
@@ -498,6 +499,160 @@ describe("capDiffBlock", () => {
     const file = makeDiffFile([50]);
     const result = capDiffBlock(file, 30);
     expect(result.truncated).toBe(true);
+  });
+});
+
+// ── groundBlocks ─────────────────────────────────────────────────────────────
+
+describe("groundBlocks", () => {
+  const fooFile: DiffFile = {
+    path: "src/foo.ts",
+    status: "modified",
+    additions: 5,
+    deletions: 2,
+    binary: false,
+    hunks: [],
+  };
+  const barFile: DiffFile = {
+    path: "src/bar.ts",
+    status: "added",
+    additions: 10,
+    deletions: 0,
+    binary: false,
+    hunks: [],
+  };
+
+  const makeHunkFile = (path: string, lineCount: number): DiffFile => ({
+    path,
+    status: "modified",
+    additions: lineCount,
+    deletions: 0,
+    binary: false,
+    hunks: [
+      {
+        header: "@@ -1,1 +1,1 @@",
+        lines: Array.from({ length: lineCount }, (_, i) => ({
+          kind: "add" as const,
+          content: `line ${i}`,
+          newNo: i + 1,
+        })),
+      },
+    ],
+  });
+
+  describe("carrier present (pendingDiff non-empty)", () => {
+    it("diff block matched to pendingDiff gets .file attached", () => {
+      const blocks = parseVisualBlocks([
+        { type: "diff", id: "d1", path: "src/foo.ts", summary: "changed foo" },
+      ]);
+      const result = groundBlocks(blocks, [fooFile, barFile], ["src/foo.ts", "src/bar.ts"]);
+      expect(result).toHaveLength(1);
+      const blk = result[0];
+      if (blk.type === "diff") expect(blk.file).toBe(fooFile);
+    });
+
+    it("unmatched diff block is dropped", () => {
+      const blocks = parseVisualBlocks([
+        { type: "diff", id: "d1", path: "src/missing.ts", summary: "invented" },
+      ]);
+      const result = groundBlocks(blocks, [fooFile], ["src/foo.ts"]);
+      expect(result).toEqual([]);
+    });
+
+    it("over-cap diff file is truncated", () => {
+      const bigFile = makeHunkFile("src/foo.ts", DIFF_BLOCK_MAX_LINES + 1);
+      const blocks = parseVisualBlocks([
+        { type: "diff", id: "d1", path: "src/foo.ts", summary: "big change" },
+      ]);
+      const result = groundBlocks(blocks, [bigFile], ["src/foo.ts"]);
+      const blk = result[0];
+      if (blk?.type === "diff") {
+        expect(blk.file?.truncated).toBe(true);
+        expect(blk.file?.hunks).toEqual([]);
+      }
+    });
+
+    it("file-tree entries reconciled against real diff statuses", () => {
+      const blocks = parseVisualBlocks([
+        {
+          type: "file-tree",
+          id: "ft1",
+          entries: [
+            { path: "src/foo.ts", change: "added" }, // wrong: real is "modified"
+            { path: "src/bar.ts", change: "modified" }, // wrong: real is "added"
+            { path: "invented.ts", change: "added" }, // not in diff → dropped
+          ],
+        },
+      ]);
+      const result = groundBlocks(blocks, [fooFile, barFile], ["src/foo.ts", "src/bar.ts"]);
+      expect(result).toHaveLength(1);
+      const blk = result[0];
+      if (blk.type === "file-tree") {
+        expect(blk.entries).toHaveLength(2);
+        expect(blk.entries[0]!.change).toBe("modified");
+        expect(blk.entries[1]!.change).toBe("added");
+      }
+    });
+  });
+
+  describe("carrier empty (pendingDiff = [])", () => {
+    it("diff blocks are dropped", () => {
+      const blocks = parseVisualBlocks([
+        { type: "diff", id: "d1", path: "src/foo.ts", summary: "x" },
+      ]);
+      const result = groundBlocks(blocks, [], ["src/foo.ts"]);
+      expect(result).toEqual([]);
+    });
+
+    it("file-tree keeps only entries whose path is in changedFiles", () => {
+      const blocks = parseVisualBlocks([
+        {
+          type: "file-tree",
+          id: "ft1",
+          entries: [
+            { path: "src/foo.ts", change: "modified" },
+            { path: "src/unknown.ts", change: "added" },
+          ],
+        },
+      ]);
+      const result = groundBlocks(blocks, [], ["src/foo.ts"]);
+      expect(result).toHaveLength(1);
+      const blk = result[0];
+      if (blk.type === "file-tree") {
+        expect(blk.entries).toHaveLength(1);
+        expect(blk.entries[0]!.path).toBe("src/foo.ts");
+        // authored change preserved (no real diff to reconcile against)
+        expect(blk.entries[0]!.change).toBe("modified");
+      }
+    });
+
+    it("file-tree block dropped when no entries are in changedFiles", () => {
+      const blocks = parseVisualBlocks([
+        {
+          type: "file-tree",
+          id: "ft1",
+          entries: [{ path: "not-in-changed.ts", change: "added" }],
+        },
+      ]);
+      const result = groundBlocks(blocks, [], ["src/foo.ts"]);
+      expect(result).toEqual([]);
+    });
+
+    it("rich-text passes through untouched", () => {
+      const blocks = parseVisualBlocks([{ type: "rich-text", id: "r1", markdown: "summary text" }]);
+      const result = groundBlocks(blocks, [], []);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(blocks[0]);
+    });
+
+    it("callout passes through untouched", () => {
+      const blocks = parseVisualBlocks([
+        { type: "callout", id: "c1", tone: "info", markdown: "a note" },
+      ]);
+      const result = groundBlocks(blocks, [], []);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(blocks[0]);
+    });
   });
 });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1479,5 +1479,10 @@
   "learnings_optimizer_stalled_title": "Optimierer blockiert",
   "learnings_optimizer_stalled_body": "Der Regel-Optimierer ist {count}-mal in Folge fehlgeschlagen. Prüfe die Server-Logs.",
   "feat_optimize_learnings_title": "„Wirkungslose“ Hausregeln mit einem Klick reparieren",
-  "feat_optimize_learnings_body": "Wenn eine Hausregel Fehler nicht mehr verhindert, filtere auf die markierten Regeln und lass Shepherd sie aus den Fehlern neu formulieren – einzeln oder alle auf einmal."
+  "feat_optimize_learnings_body": "Wenn eine Hausregel Fehler nicht mehr verhindert, filtere auf die markierten Regeln und lass Shepherd sie aus den Fehlern neu formulieren – einzeln oder alle auf einmal.",
+  "vblock_callout_info": "Info",
+  "vblock_callout_decision": "Entscheidung",
+  "vblock_callout_risk": "Risiko",
+  "vblock_callout_warning": "Warnung",
+  "vblock_callout_success": "Erfolg"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1484,5 +1484,10 @@
   "vblock_callout_decision": "Entscheidung",
   "vblock_callout_risk": "Risiko",
   "vblock_callout_warning": "Warnung",
-  "vblock_callout_success": "Erfolg"
+  "vblock_callout_success": "Erfolg",
+  "vblock_filetree_added": "Hinzugefügt",
+  "vblock_filetree_modified": "Geändert",
+  "vblock_filetree_removed": "Entfernt",
+  "vblock_filetree_renamed": "Umbenannt",
+  "vblock_diff_highlighted_heading": "Hervorgehobene Änderungen"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1489,5 +1489,7 @@
   "vblock_filetree_modified": "Geändert",
   "vblock_filetree_removed": "Entfernt",
   "vblock_filetree_renamed": "Umbenannt",
-  "vblock_diff_highlighted_heading": "Hervorgehobene Änderungen"
+  "vblock_diff_highlighted_heading": "Hervorgehobene Änderungen",
+  "feat_visual_recap_title": "Visuelle Zusammenfassungen",
+  "feat_visual_recap_body": "Die Zusammenfassung einer abgeschlossenen Sitzung wird jetzt als übersichtliches Dokument dargestellt — ein Baum der Änderungen, das echte annotierte Diff und farbige Hinweise — statt als reiner Text. Erweitere eine Zusammenfassung, um sie zu sehen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1484,5 +1484,10 @@
   "vblock_callout_decision": "Decision",
   "vblock_callout_risk": "Risk",
   "vblock_callout_warning": "Warning",
-  "vblock_callout_success": "Success"
+  "vblock_callout_success": "Success",
+  "vblock_filetree_added": "Added",
+  "vblock_filetree_modified": "Modified",
+  "vblock_filetree_removed": "Removed",
+  "vblock_filetree_renamed": "Renamed",
+  "vblock_diff_highlighted_heading": "Highlighted changes"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1479,5 +1479,10 @@
   "learnings_optimizer_stalled_title": "Optimizer stalled",
   "learnings_optimizer_stalled_body": "The rule optimizer failed {count} times in a row. Check the server logs.",
   "feat_optimize_learnings_title": "Fix ‘not working’ house rules in one click",
-  "feat_optimize_learnings_body": "When a house rule stops preventing mistakes, filter to the flagged ones and let Shepherd reword them from the failures — individually or all at once."
+  "feat_optimize_learnings_body": "When a house rule stops preventing mistakes, filter to the flagged ones and let Shepherd reword them from the failures — individually or all at once.",
+  "vblock_callout_info": "Info",
+  "vblock_callout_decision": "Decision",
+  "vblock_callout_risk": "Risk",
+  "vblock_callout_warning": "Warning",
+  "vblock_callout_success": "Success"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1489,5 +1489,7 @@
   "vblock_filetree_modified": "Modified",
   "vblock_filetree_removed": "Removed",
   "vblock_filetree_renamed": "Renamed",
-  "vblock_diff_highlighted_heading": "Highlighted changes"
+  "vblock_diff_highlighted_heading": "Highlighted changes",
+  "feat_visual_recap_title": "Visual recaps",
+  "feat_visual_recap_body": "A finished session's recap now renders as a scannable document — a tree of what changed, the real annotated diff, and toned callouts — instead of flat text. Expand a recap to see it."
 }

--- a/ui/src/lib/components/DoneRecapPanel.browser.test.ts
+++ b/ui/src/lib/components/DoneRecapPanel.browser.test.ts
@@ -119,6 +119,73 @@ describe("DoneRecapPanel ready state", () => {
   });
 });
 
+describe("DoneRecapPanel VisualReview blocks", () => {
+  it("renders VisualReview when blocks present (callout label + file-tree segment visible)", async () => {
+    recaps.map = {
+      b1: recap({
+        sessionId: "b1",
+        blocks: [
+          { type: "rich-text", id: "r1", markdown: "Summary text." },
+          {
+            type: "file-tree",
+            id: "ft1",
+            // single-segment path so getByText finds it directly as one node
+            entries: [{ path: "index.ts", change: "added" }],
+          },
+          { type: "callout", id: "c1", tone: "risk", markdown: "Watch out!" },
+        ],
+        changedFiles: ["index.ts"],
+      }),
+    };
+    render(DoneRecapPanel, { session: session({ id: "b1" }) });
+    // callout tone label visible
+    await expect.element(page.getByText("Risk")).toBeInTheDocument();
+    // file-tree leaf segment visible
+    await expect.element(page.getByText("index.ts")).toBeInTheDocument();
+  });
+
+  it("file-tree block supersedes standalone changed-files list", async () => {
+    recaps.map = {
+      b2: recap({
+        sessionId: "b2",
+        blocks: [
+          {
+            type: "file-tree",
+            id: "ft2",
+            // use a single-segment path so getByText finds it directly
+            entries: [{ path: "widget.ts", change: "modified" }],
+          },
+        ],
+        changedFiles: ["widget.ts"],
+      }),
+    };
+    render(DoneRecapPanel, { session: session({ id: "b2" }) });
+    // wait for the VisualReview file-tree content to appear
+    await expect.element(page.getByText("widget.ts")).toBeInTheDocument();
+    // standalone "Changed files" heading must NOT appear
+    expect(
+      page.getByText("Changed files").elements().length,
+      "no standalone changed-files heading when file-tree block present",
+    ).toBe(0);
+  });
+
+  it("no blocks → flat body still renders", async () => {
+    recaps.map = {
+      b3: recap({
+        sessionId: "b3",
+        body: "Plain **body** text.",
+        changedFiles: ["src/c.ts"],
+      }),
+    };
+    render(DoneRecapPanel, { session: session({ id: "b3" }) });
+    // headline still renders
+    await expect.element(page.getByText("Shipped the feature")).toBeInTheDocument();
+    // changed-files section still shows
+    await expect.element(page.getByText("Changed files")).toBeInTheDocument();
+    await expect.element(page.getByText("src/c.ts")).toBeInTheDocument();
+  });
+});
+
 describe("DoneRecapPanel generating state", () => {
   it("shows the generating line", async () => {
     recaps.map = { g1: recap({ sessionId: "g1", state: "generating" }) };

--- a/ui/src/lib/components/DoneRecapPanel.svelte
+++ b/ui/src/lib/components/DoneRecapPanel.svelte
@@ -65,6 +65,7 @@
   const hasFileTree = $derived(!!recap?.blocks?.some((b) => b.type === "file-tree"));
 </script>
 
+<!-- fallow-ignore-next-line complexity -->
 <section class="done-recap" aria-label={m.done_recap_panel_aria({ desig: session.desig })}>
   <header class="dr-head">
     <span class="dr-desig">{session.desig}</span>

--- a/ui/src/lib/components/DoneRecapPanel.svelte
+++ b/ui/src/lib/components/DoneRecapPanel.svelte
@@ -4,6 +4,7 @@
   import { formatAgo } from "$lib/format";
   import { clock } from "$lib/now.svelte";
   import { m } from "$lib/paraglide/messages";
+  import VisualReview from "./VisualReview.svelte";
 
   let { session }: { session: Session } = $props();
 
@@ -60,6 +61,8 @@
     if (v === "parked") return m.recap_verdict_parked();
     return m.recap_verdict_needs_attention();
   }
+
+  const hasFileTree = $derived(!!recap?.blocks?.some((b) => b.type === "file-tree"));
 </script>
 
 <section class="done-recap" aria-label={m.done_recap_panel_aria({ desig: session.desig })}>
@@ -81,7 +84,9 @@
       {#if recap.headline}
         <p class="dr-headline">{recap.headline}</p>
       {/if}
-      {#if renderedBody}
+      {#if recap.blocks && recap.blocks.length > 0}
+        <VisualReview blocks={recap.blocks} />
+      {:else if renderedBody}
         <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized via DOMPurify above -->
         <div class="dr-md">{@html renderedBody}</div>
       {/if}
@@ -95,7 +100,7 @@
           </ul>
         </div>
       {/if}
-      {#if recap.changedFiles.length > 0}
+      {#if recap.changedFiles.length > 0 && !hasFileTree}
         <div class="dr-section">
           <p class="dr-section-head">{m.recap_changed_files()}</p>
           <ul class="dr-list dr-files">

--- a/ui/src/lib/components/SessionRecap.browser.test.ts
+++ b/ui/src/lib/components/SessionRecap.browser.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import SessionRecap from "./SessionRecap.svelte";
+import { recaps } from "$lib/recaps.svelte";
+import type { Session, Recap } from "$lib/types";
+
+function session(partial: Partial<Session> & { id: string }): Session {
+  return {
+    desig: "TASK-42",
+    name: "live task",
+    prompt: "do stuff",
+    repoPath: "/repo/shepherd",
+    baseBranch: "main",
+    branch: "feat/y",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "h",
+    herdrAgentId: "ha",
+    claudeSessionId: "cs",
+    model: null,
+    status: "idle",
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    mergeTrainPrs: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: null,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    auto: false,
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    research: false,
+    issueNumber: null,
+    lastState: "",
+    createdAt: 0,
+    updatedAt: 1000,
+    archivedAt: null,
+    ...partial,
+  };
+}
+
+function recap(partial: Partial<Recap> & { sessionId: string }): Recap {
+  return {
+    state: "ready",
+    headSha: "abc",
+    verdict: "ready",
+    headline: "Session recap headline",
+    body: "Did **all** the work.",
+    openItems: [],
+    changedFiles: [],
+    spawnSessionId: partial.sessionId,
+    cwd: "/repo",
+    model: null,
+    spawnedAt: 0,
+    generatedAt: 1000,
+    updatedAt: 1000,
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  recaps.map = {};
+});
+
+afterEach(() => {
+  recaps.map = {};
+  document.body.innerHTML = "";
+});
+
+describe("SessionRecap VisualReview blocks", () => {
+  it("blocks present → expand → VisualReview content visible (callout tone label)", async () => {
+    recaps.map = {
+      sr1: recap({
+        sessionId: "sr1",
+        blocks: [{ type: "callout", id: "c1", tone: "risk", markdown: "Pay attention to this." }],
+      }),
+    };
+    render(SessionRecap, { session: session({ id: "sr1" }) });
+
+    // header is visible; expand by clicking it
+    const header = page.getByRole("button", { expanded: false });
+    await header.click();
+
+    // callout tone label should now be visible inside VisualReview
+    await expect.element(page.getByText("Risk")).toBeInTheDocument();
+  });
+
+  it("no blocks → expand → flat markdown body renders", async () => {
+    recaps.map = {
+      sr2: recap({
+        sessionId: "sr2",
+        body: "Plain **body** text.",
+      }),
+    };
+    render(SessionRecap, { session: session({ id: "sr2" }) });
+
+    // expand
+    const header = page.getByRole("button", { expanded: false });
+    await header.click();
+
+    // flat body rendered (marked renders **body** as <strong>body</strong>)
+    await expect.element(page.getByText("body", { exact: false })).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/SessionRecap.svelte
+++ b/ui/src/lib/components/SessionRecap.svelte
@@ -65,6 +65,7 @@
   }
 </script>
 
+<!-- fallow-ignore-next-line complexity -->
 {#if recap && recap.state !== "empty"}
   <!-- coachTarget id "session-recap" matches FeatureAnnouncement.targetId -->
   <div class="recap-card panel" use:coachTarget={"session-recap"}>

--- a/ui/src/lib/components/SessionRecap.svelte
+++ b/ui/src/lib/components/SessionRecap.svelte
@@ -5,6 +5,7 @@
   import { regenerateRecap } from "$lib/api";
   import { m } from "$lib/paraglide/messages";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import VisualReview from "./VisualReview.svelte";
 
   let { session }: { session: Session } = $props();
 
@@ -93,7 +94,9 @@
       </button>
       {#if expanded}
         <div class="recap-body">
-          {#if renderedBody}
+          {#if recap.blocks && recap.blocks.length > 0}
+            <VisualReview blocks={recap.blocks} />
+          {:else if renderedBody}
             <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized via DOMPurify above -->
             <div class="recap-md">{@html renderedBody}</div>
           {/if}

--- a/ui/src/lib/components/VisualReview.browser.test.ts
+++ b/ui/src/lib/components/VisualReview.browser.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import VisualReview from "./VisualReview.svelte";
+import type { VisualBlock } from "$lib/types";
+
+describe("VisualReview dispatcher", () => {
+  it("renders a rich-text block content", async () => {
+    const blocks: VisualBlock[] = [{ type: "rich-text", id: "r1", markdown: "**hello world**" }];
+    render(VisualReview, { blocks });
+    await expect.element(page.getByText("hello world")).toBeInTheDocument();
+  });
+
+  it("renders a callout block with tone label", async () => {
+    const blocks: VisualBlock[] = [
+      { type: "callout", id: "c1", tone: "info", markdown: "Take note." },
+    ];
+    render(VisualReview, { blocks });
+    await expect.element(page.getByText("Info")).toBeInTheDocument();
+    await expect.element(page.getByText("Take note.")).toBeInTheDocument();
+  });
+
+  it("renders mixed rich-text + callout blocks", async () => {
+    const blocks: VisualBlock[] = [
+      { type: "rich-text", id: "r1", markdown: "Summary text." },
+      { type: "callout", id: "c1", tone: "risk", markdown: "Be careful." },
+    ];
+    render(VisualReview, { blocks });
+    await expect.element(page.getByText("Summary text.")).toBeInTheDocument();
+    await expect.element(page.getByText("Risk")).toBeInTheDocument();
+    await expect.element(page.getByText("Be careful.")).toBeInTheDocument();
+  });
+
+  it("does not throw on unknown block type", () => {
+    // file-tree + diff are unhandled in Phase 1 — should render nothing, not throw
+    const blocks = [{ type: "file-tree", id: "ft1", entries: [] } as unknown as VisualBlock];
+    expect(() => render(VisualReview, { blocks })).not.toThrow();
+  });
+
+  it("renders nothing for an empty blocks array", () => {
+    const { container } = render(VisualReview, { blocks: [] });
+    expect(container.querySelector(".visual-review")?.children.length).toBe(0);
+  });
+});

--- a/ui/src/lib/components/VisualReview.browser.test.ts
+++ b/ui/src/lib/components/VisualReview.browser.test.ts
@@ -3,7 +3,24 @@ import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
 import VisualReview from "./VisualReview.svelte";
-import type { VisualBlock } from "$lib/types";
+import type { VisualBlock, DiffFile } from "$lib/types";
+
+const TEST_DIFF_FILE: DiffFile = {
+  path: "src/index.ts",
+  status: "modified",
+  additions: 1,
+  deletions: 1,
+  binary: false,
+  hunks: [
+    {
+      header: "@@ -1,2 +1,2 @@",
+      lines: [
+        { kind: "del", content: "old", oldNo: 1 },
+        { kind: "add", content: "new", newNo: 1 },
+      ],
+    },
+  ],
+};
 
 describe("VisualReview dispatcher", () => {
   it("renders a rich-text block content", async () => {
@@ -41,5 +58,81 @@ describe("VisualReview dispatcher", () => {
   it("renders nothing for an empty blocks array", () => {
     const { container } = render(VisualReview, { blocks: [] });
     expect(container.querySelector(".visual-review")?.children.length).toBe(0);
+  });
+
+  // ── Task 6 additions ────────────────────────────────────────────────────────
+
+  it("renders a file-tree block (dispatches to FileTreeBlock)", async () => {
+    const blocks: VisualBlock[] = [
+      {
+        type: "file-tree",
+        id: "ft1",
+        entries: [
+          { path: "src/foo.ts", change: "added" },
+          { path: "src/bar.ts", change: "modified" },
+        ],
+      },
+    ];
+    render(VisualReview, { blocks });
+    await expect.element(page.getByText("foo.ts")).toBeInTheDocument();
+    await expect.element(page.getByText("bar.ts")).toBeInTheDocument();
+  });
+
+  it("renders a diff block with summary (dispatches to DiffBlock)", async () => {
+    const blocks: VisualBlock[] = [
+      {
+        type: "diff",
+        id: "d1",
+        path: "src/index.ts",
+        summary: "Fixed the bug",
+        file: TEST_DIFF_FILE,
+      },
+    ];
+    render(VisualReview, { blocks });
+    await expect.element(page.getByText("Fixed the bug")).toBeInTheDocument();
+  });
+
+  it("shows 'Highlighted changes' heading exactly once for two diff blocks", async () => {
+    const blocks: VisualBlock[] = [
+      {
+        type: "diff",
+        id: "d1",
+        path: "src/a.ts",
+        summary: "First diff",
+        file: TEST_DIFF_FILE,
+      },
+      {
+        type: "diff",
+        id: "d2",
+        path: "src/b.ts",
+        summary: "Second diff",
+        file: { ...TEST_DIFF_FILE, path: "src/b.ts" },
+      },
+    ];
+    const { container } = render(VisualReview, { blocks });
+    const headings = container.querySelectorAll(".vr-highlight-head");
+    expect(headings.length).toBe(1);
+    await expect.element(page.getByText(/Highlighted changes/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Highlighted changes' heading before the first diff block", async () => {
+    const blocks: VisualBlock[] = [
+      { type: "rich-text", id: "r1", markdown: "preamble" },
+      {
+        type: "diff",
+        id: "d1",
+        path: "src/x.ts",
+        summary: "A diff",
+        file: TEST_DIFF_FILE,
+      },
+    ];
+    render(VisualReview, { blocks });
+    await expect.element(page.getByText(/Highlighted changes/i)).toBeInTheDocument();
+  });
+
+  it("does not show 'Highlighted changes' heading when no diff blocks", async () => {
+    const blocks: VisualBlock[] = [{ type: "rich-text", id: "r1", markdown: "No diffs here." }];
+    const { container } = render(VisualReview, { blocks });
+    expect(container.querySelector(".vr-highlight-head")).toBeNull();
   });
 });

--- a/ui/src/lib/components/VisualReview.browser.test.ts
+++ b/ui/src/lib/components/VisualReview.browser.test.ts
@@ -50,8 +50,8 @@ describe("VisualReview dispatcher", () => {
   });
 
   it("does not throw on unknown block type", () => {
-    // file-tree + diff are unhandled in Phase 1 — should render nothing, not throw
-    const blocks = [{ type: "file-tree", id: "ft1", entries: [] } as unknown as VisualBlock];
+    // verifies that truly unknown types (not file-tree/diff/rich-text/callout) render nothing, not throw
+    const blocks = [{ type: "totally-unknown", id: "u1" } as unknown as VisualBlock];
     expect(() => render(VisualReview, { blocks })).not.toThrow();
   });
 
@@ -126,8 +126,18 @@ describe("VisualReview dispatcher", () => {
         file: TEST_DIFF_FILE,
       },
     ];
-    render(VisualReview, { blocks });
+    const { container } = render(VisualReview, { blocks });
     await expect.element(page.getByText(/Highlighted changes/i)).toBeInTheDocument();
+    // assert DOM order: heading must precede the first diff block output
+    const heading = container.querySelector(".vr-highlight-head");
+    const diffSummary = container.querySelector(".diff-summary, .vr-diff-summary, .diff-block");
+    expect(heading).not.toBeNull();
+    if (heading && diffSummary) {
+      // Node.DOCUMENT_POSITION_FOLLOWING (4) means diffSummary comes after heading
+      expect(
+        heading.compareDocumentPosition(diffSummary) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    }
   });
 
   it("does not show 'Highlighted changes' heading when no diff blocks", async () => {

--- a/ui/src/lib/components/VisualReview.svelte
+++ b/ui/src/lib/components/VisualReview.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { VisualBlock } from "$lib/types";
+  import RichTextBlock from "./blocks/RichTextBlock.svelte";
+  import CalloutBlock from "./blocks/CalloutBlock.svelte";
+  let { blocks }: { blocks: VisualBlock[] } = $props();
+</script>
+
+<div class="visual-review">
+  {#each blocks as block (block.id)}
+    {#if block.type === "rich-text"}
+      <RichTextBlock {block} />
+    {:else if block.type === "callout"}
+      <CalloutBlock {block} />
+    {/if}
+    <!-- file-tree + diff cases added in Task 6 -->
+  {/each}
+</div>
+
+<style>
+  .visual-review {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+</style>

--- a/ui/src/lib/components/VisualReview.svelte
+++ b/ui/src/lib/components/VisualReview.svelte
@@ -2,17 +2,29 @@
   import type { VisualBlock } from "$lib/types";
   import RichTextBlock from "./blocks/RichTextBlock.svelte";
   import CalloutBlock from "./blocks/CalloutBlock.svelte";
+  import FileTreeBlock from "./blocks/FileTreeBlock.svelte";
+  import DiffBlock from "./blocks/DiffBlock.svelte";
+  import { m } from "$lib/paraglide/messages";
+
   let { blocks }: { blocks: VisualBlock[] } = $props();
+
+  const firstDiffIndex = $derived(blocks.findIndex((b) => b.type === "diff"));
 </script>
 
 <div class="visual-review">
-  {#each blocks as block (block.id)}
+  {#each blocks as block, i (block.id)}
     {#if block.type === "rich-text"}
       <RichTextBlock {block} />
     {:else if block.type === "callout"}
       <CalloutBlock {block} />
+    {:else if block.type === "file-tree"}
+      <FileTreeBlock {block} />
+    {:else if block.type === "diff"}
+      {#if i === firstDiffIndex}
+        <h4 class="vr-highlight-head">{m.vblock_diff_highlighted_heading()}</h4>
+      {/if}
+      <DiffBlock {block} />
     {/if}
-    <!-- file-tree + diff cases added in Task 6 -->
   {/each}
 </div>
 
@@ -21,5 +33,13 @@
     display: flex;
     flex-direction: column;
     gap: 12px;
+  }
+  .vr-highlight-head {
+    margin: 0 0 4px 0;
+    font-size: var(--fs-micro);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-muted);
   }
 </style>

--- a/ui/src/lib/components/blocks/CalloutBlock.browser.test.ts
+++ b/ui/src/lib/components/blocks/CalloutBlock.browser.test.ts
@@ -19,6 +19,18 @@ describe("CalloutBlock", () => {
     await expect.element(page.getByText("Danger ahead.")).toBeInTheDocument();
   });
 
+  it("renders bold markdown inside callout as a <strong> element", async () => {
+    const { container } = render(CalloutBlock, {
+      block: { type: "callout", id: "c7", tone: "risk", markdown: "**critical**" },
+    });
+    // wait for async dynamic-import (marked + dompurify) to settle
+    await expect.element(page.getByText("critical")).toBeInTheDocument();
+    // the sanitized-markdown pipeline must produce a <strong>, not raw **critical** as text
+    const strongEl = container.querySelector("strong");
+    expect(strongEl).not.toBeNull();
+    expect(strongEl?.textContent).toBe("critical");
+  });
+
   it("shows 'Info' label for info tone", async () => {
     render(CalloutBlock, {
       block: { type: "callout", id: "c3", tone: "info", markdown: "Just so you know." },

--- a/ui/src/lib/components/blocks/CalloutBlock.browser.test.ts
+++ b/ui/src/lib/components/blocks/CalloutBlock.browser.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import CalloutBlock from "./CalloutBlock.svelte";
+
+describe("CalloutBlock", () => {
+  it("shows the localized tone label for 'risk'", async () => {
+    render(CalloutBlock, {
+      block: { type: "callout", id: "c1", tone: "risk", markdown: "Danger ahead." },
+    });
+    await expect.element(page.getByText("Risk")).toBeInTheDocument();
+  });
+
+  it("renders the markdown body", async () => {
+    render(CalloutBlock, {
+      block: { type: "callout", id: "c2", tone: "risk", markdown: "Danger ahead." },
+    });
+    await expect.element(page.getByText("Danger ahead.")).toBeInTheDocument();
+  });
+
+  it("shows 'Info' label for info tone", async () => {
+    render(CalloutBlock, {
+      block: { type: "callout", id: "c3", tone: "info", markdown: "Just so you know." },
+    });
+    await expect.element(page.getByText("Info")).toBeInTheDocument();
+  });
+
+  it("shows 'Decision' label for decision tone", async () => {
+    render(CalloutBlock, {
+      block: { type: "callout", id: "c4", tone: "decision", markdown: "We chose X." },
+    });
+    await expect.element(page.getByText("Decision")).toBeInTheDocument();
+  });
+
+  it("shows 'Warning' label for warning tone", async () => {
+    render(CalloutBlock, {
+      block: { type: "callout", id: "c5", tone: "warning", markdown: "Watch out." },
+    });
+    await expect.element(page.getByText("Warning")).toBeInTheDocument();
+  });
+
+  it("shows 'Success' label for success tone", async () => {
+    render(CalloutBlock, {
+      block: { type: "callout", id: "c6", tone: "success", markdown: "All done." },
+    });
+    await expect.element(page.getByText("Success")).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/blocks/CalloutBlock.svelte
+++ b/ui/src/lib/components/blocks/CalloutBlock.svelte
@@ -55,7 +55,7 @@
 
 <style>
   .callout {
-    border-left: 3px solid var(--color-amber);
+    border-left: 3px solid var(--color-amber); /* overridden per-tone via style:border-left-color */
     background: var(--color-inset);
     padding: 8px 12px;
     display: flex;

--- a/ui/src/lib/components/blocks/CalloutBlock.svelte
+++ b/ui/src/lib/components/blocks/CalloutBlock.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import type { VisualBlock, CalloutTone } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  let { block }: { block: Extract<VisualBlock, { type: "callout" }> } = $props();
+
+  const TONE_COLOR: Record<CalloutTone, string> = {
+    info: "var(--color-blue)",
+    decision: "var(--color-amber)",
+    risk: "var(--color-red)",
+    warning: "var(--color-amber)",
+    success: "var(--color-green)",
+  };
+
+  function toneLabel(t: CalloutTone): string {
+    switch (t) {
+      case "info":
+        return m.vblock_callout_info();
+      case "decision":
+        return m.vblock_callout_decision();
+      case "risk":
+        return m.vblock_callout_risk();
+      case "warning":
+        return m.vblock_callout_warning();
+      case "success":
+        return m.vblock_callout_success();
+    }
+  }
+
+  let rendered = $state("");
+  $effect(() => {
+    const md = block.markdown;
+    if (!md) {
+      rendered = "";
+      return;
+    }
+    let alive = true;
+    Promise.all([import("marked"), import("dompurify")])
+      .then(([{ marked }, { default: DOMPurify }]) => {
+        if (alive) rendered = DOMPurify.sanitize(marked.parse(md, { async: false }) as string);
+      })
+      .catch((err) => console.warn("CalloutBlock markdown render failed", err));
+    return () => {
+      alive = false;
+    };
+  });
+</script>
+
+<div class="callout" style:border-left-color={TONE_COLOR[block.tone]}>
+  <span class="callout-tone" style:color={TONE_COLOR[block.tone]}>{toneLabel(block.tone)}</span>
+  {#if rendered}
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized via DOMPurify above -->
+    <div class="callout-md">{@html rendered}</div>
+  {/if}
+</div>
+
+<style>
+  .callout {
+    border-left: 3px solid var(--color-amber);
+    background: var(--color-inset);
+    padding: 8px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .callout-tone {
+    font-size: var(--fs-micro);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .callout-md {
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    line-height: 1.5;
+  }
+  .callout-md :global(p) {
+    margin: 0;
+  }
+</style>

--- a/ui/src/lib/components/blocks/DiffBlock.browser.test.ts
+++ b/ui/src/lib/components/blocks/DiffBlock.browser.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import DiffBlock from "./DiffBlock.svelte";
+import type { DiffFile } from "$lib/types";
+
+const TEST_FILE: DiffFile = {
+  path: "src/index.ts",
+  status: "modified",
+  additions: 3,
+  deletions: 1,
+  binary: false,
+  hunks: [
+    {
+      header: "@@ -1,4 +1,6 @@",
+      lines: [
+        { kind: "ctx", content: "const a = 1;", oldNo: 1, newNo: 1 },
+        { kind: "del", content: "const b = 2;", oldNo: 2 },
+        { kind: "add", content: "const b = 3;", newNo: 2 },
+        { kind: "add", content: "const c = 4;", newNo: 3 },
+      ],
+    },
+  ],
+};
+
+describe("DiffBlock", () => {
+  it("renders summary text", async () => {
+    render(DiffBlock, {
+      block: {
+        type: "diff",
+        id: "d1",
+        path: "src/index.ts",
+        summary: "Updated constant values",
+        file: TEST_FILE,
+      },
+    });
+    await expect.element(page.getByText("Updated constant values")).toBeInTheDocument();
+  });
+
+  it("renders the file path via DiffFileBlock when file is present", async () => {
+    render(DiffBlock, {
+      block: {
+        type: "diff",
+        id: "d2",
+        path: "src/index.ts",
+        summary: "Some changes",
+        file: TEST_FILE,
+      },
+    });
+    // DiffFileBlock renders the path in a .file-head button
+    await expect.element(page.getByText(/src\/index\.ts/)).toBeInTheDocument();
+  });
+
+  it("renders path + summary without throwing when file is absent", async () => {
+    expect(() =>
+      render(DiffBlock, {
+        block: {
+          type: "diff",
+          id: "d3",
+          path: "src/missing.ts",
+          summary: "Fallback summary",
+        },
+      }),
+    ).not.toThrow();
+    await expect.element(page.getByText("Fallback summary")).toBeInTheDocument();
+    await expect.element(page.getByText("src/missing.ts")).toBeInTheDocument();
+  });
+
+  it("renders annotation label and note", async () => {
+    render(DiffBlock, {
+      block: {
+        type: "diff",
+        id: "d4",
+        path: "src/index.ts",
+        summary: "With annotations",
+        file: TEST_FILE,
+        annotations: [{ label: "Note:", note: "This is important" }],
+      },
+    });
+    await expect.element(page.getByText("Note:")).toBeInTheDocument();
+    await expect.element(page.getByText(/This is important/)).toBeInTheDocument();
+  });
+
+  it("renders annotation without label", async () => {
+    render(DiffBlock, {
+      block: {
+        type: "diff",
+        id: "d5",
+        path: "src/index.ts",
+        summary: "Plain annotation",
+        file: TEST_FILE,
+        annotations: [{ note: "No label here" }],
+      },
+    });
+    await expect.element(page.getByText("No label here")).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/blocks/DiffBlock.svelte
+++ b/ui/src/lib/components/blocks/DiffBlock.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import type { VisualBlock } from "$lib/types";
+  import DiffFileBlock from "../DiffFileBlock.svelte";
+
+  let { block }: { block: Extract<VisualBlock, { type: "diff" }> } = $props();
+</script>
+
+<div class="diff-block">
+  <p class="db-summary">{block.summary}</p>
+
+  {#if block.file}
+    <DiffFileBlock file={block.file} />
+  {:else}
+    <p class="db-fallback">{block.path}</p>
+  {/if}
+
+  {#if block.annotations && block.annotations.length > 0}
+    <ul class="db-annotations">
+      {#each block.annotations as ann, i (i)}
+        <li class="db-ann">
+          {#if ann.label}<strong>{ann.label}</strong>
+          {/if}{ann.note}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .diff-block {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .db-summary {
+    margin: 0;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+  .db-fallback {
+    margin: 0;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+  }
+  .db-annotations {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .db-ann {
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    line-height: 1.5;
+  }
+</style>

--- a/ui/src/lib/components/blocks/FileTreeBlock.browser.test.ts
+++ b/ui/src/lib/components/blocks/FileTreeBlock.browser.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import FileTreeBlock from "./FileTreeBlock.svelte";
+
+describe("FileTreeBlock", () => {
+  it("renders directory structure from nested paths", async () => {
+    const { container } = render(FileTreeBlock, {
+      block: {
+        type: "file-tree",
+        id: "ft1",
+        entries: [
+          { path: "src/a.ts", change: "modified" },
+          { path: "src/b/c.ts", change: "added" },
+        ],
+      },
+    });
+    // "src" should appear exactly once as a parent directory row
+    const rows = container.querySelectorAll(".ft-row");
+    const texts = Array.from(rows).map((r) => r.textContent?.trim());
+    const srcCount = texts.filter(
+      (t) => t?.includes("src") && !t?.includes("a.ts") && !t?.includes("b"),
+    ).length;
+    expect(srcCount).toBe(1);
+    // "b" should be a sub-directory
+    const bRows = texts.filter((t) => /\bb\b/.test(t ?? ""));
+    expect(bRows.length).toBeGreaterThanOrEqual(1);
+    // c.ts should appear as a leaf nested under b
+    await expect.element(page.getByText("c.ts")).toBeInTheDocument();
+  });
+
+  it("shows 'src' parent once and 'a.ts' and 'c.ts' as leaves", async () => {
+    render(FileTreeBlock, {
+      block: {
+        type: "file-tree",
+        id: "ft2",
+        entries: [
+          { path: "src/a.ts", change: "modified" },
+          { path: "src/b/c.ts", change: "added" },
+        ],
+      },
+    });
+    await expect.element(page.getByText("a.ts")).toBeInTheDocument();
+    await expect.element(page.getByText("c.ts")).toBeInTheDocument();
+  });
+
+  it("shows localized accessible label for a 'removed' entry", async () => {
+    const { container } = render(FileTreeBlock, {
+      block: {
+        type: "file-tree",
+        id: "ft3",
+        entries: [{ path: "old.ts", change: "removed" }],
+      },
+    });
+    // The badge should carry aria-label="Removed"
+    const badge = container.querySelector(".ft-badge");
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute("aria-label")).toBe("Removed");
+    expect(badge?.getAttribute("title")).toBe("Removed");
+    // The visible glyph is "D"
+    expect(badge?.textContent?.trim()).toBe("D");
+  });
+
+  it("renders a note after the filename", async () => {
+    render(FileTreeBlock, {
+      block: {
+        type: "file-tree",
+        id: "ft4",
+        entries: [{ path: "readme.md", change: "modified", note: "minor fixes" }],
+      },
+    });
+    await expect.element(page.getByText("minor fixes")).toBeInTheDocument();
+  });
+
+  it("renders an optional title as a heading", async () => {
+    render(FileTreeBlock, {
+      block: {
+        type: "file-tree",
+        id: "ft5",
+        title: "Changed files",
+        entries: [{ path: "x.ts", change: "added" }],
+      },
+    });
+    await expect.element(page.getByText("Changed files")).toBeInTheDocument();
+  });
+
+  it("renders no title element when title is absent", async () => {
+    const { container } = render(FileTreeBlock, {
+      block: {
+        type: "file-tree",
+        id: "ft6",
+        entries: [{ path: "x.ts", change: "added" }],
+      },
+    });
+    expect(container.querySelector(".ft-title")).toBeNull();
+  });
+});

--- a/ui/src/lib/components/blocks/FileTreeBlock.svelte
+++ b/ui/src/lib/components/blocks/FileTreeBlock.svelte
@@ -32,7 +32,7 @@
         map.set(head, { ...map.get(head), leaf: entry });
       } else {
         const existing = map.get(head);
-        const childMap: DirMap = (existing?.dir as DirMap | undefined) ?? new Map();
+        const childMap: DirMap = existing?.dir ?? new Map();
         map.set(head, { ...existing, dir: childMap });
         insertEntry(childMap, rest, entry);
       }
@@ -44,7 +44,7 @@
         if (value.leaf) {
           nodes.push({ kind: "leaf", segment, entry: value.leaf });
         } else if (value.dir) {
-          nodes.push({ kind: "dir", segment, children: mapToNodes(value.dir as DirMap) });
+          nodes.push({ kind: "dir", segment, children: mapToNodes(value.dir) });
         }
       }
       return nodes;
@@ -69,13 +69,13 @@
     renamed: "R",
   };
 
-  // Tokens mirroring DiffFileBlock status glyphs — verified against design-system:
-  // added→--color-green, modified→--color-amber, removed→--color-red, renamed→--color-blue
+  // Tokens mirroring DiffFileBlock status glyphs (.status-added/deleted/renamed/modified):
+  // added→--color-green, modified→--color-amber, removed→--color-red, renamed→--color-amber
   const CHANGE_COLOR: Record<FileTreeChange, string> = {
     added: "var(--color-green)",
     modified: "var(--color-amber)",
     removed: "var(--color-red)",
-    renamed: "var(--color-blue)",
+    renamed: "var(--color-amber)",
   };
 
   function changeLabel(change: FileTreeChange): string {

--- a/ui/src/lib/components/blocks/FileTreeBlock.svelte
+++ b/ui/src/lib/components/blocks/FileTreeBlock.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+  import type { VisualBlock, FileTreeEntry, FileTreeChange } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  let { block }: { block: Extract<VisualBlock, { type: "file-tree" }> } = $props();
+
+  // ── tree builder ────────────────────────────────────────────────────────────
+
+  interface TreeLeaf {
+    kind: "leaf";
+    segment: string;
+    entry: FileTreeEntry;
+  }
+
+  interface TreeDir {
+    kind: "dir";
+    segment: string;
+    children: TreeNode[];
+  }
+
+  type TreeNode = TreeLeaf | TreeDir;
+
+  function buildTree(entries: FileTreeEntry[]): TreeNode[] {
+    // We build a nested structure keyed by path segments.
+    // Each directory level is a Map from segment → TreeNode.
+    type DirMap = Map<string, { dir?: DirMap; leaf?: FileTreeEntry }>;
+
+    function insertEntry(map: DirMap, segments: string[], entry: FileTreeEntry): void {
+      const [head, ...rest] = segments;
+      if (rest.length === 0) {
+        // leaf
+        map.set(head, { ...map.get(head), leaf: entry });
+      } else {
+        const existing = map.get(head);
+        const childMap: DirMap = (existing?.dir as DirMap | undefined) ?? new Map();
+        map.set(head, { ...existing, dir: childMap });
+        insertEntry(childMap, rest, entry);
+      }
+    }
+
+    function mapToNodes(map: DirMap): TreeNode[] {
+      const nodes: TreeNode[] = [];
+      for (const [segment, value] of map) {
+        if (value.leaf) {
+          nodes.push({ kind: "leaf", segment, entry: value.leaf });
+        } else if (value.dir) {
+          nodes.push({ kind: "dir", segment, children: mapToNodes(value.dir as DirMap) });
+        }
+      }
+      return nodes;
+    }
+
+    const root: DirMap = new Map();
+    for (const entry of entries) {
+      const segments = entry.path.split("/").filter(Boolean);
+      if (segments.length > 0) insertEntry(root, segments, entry);
+    }
+    return mapToNodes(root);
+  }
+
+  const tree = $derived(buildTree(block.entries));
+
+  // ── badge helpers ───────────────────────────────────────────────────────────
+
+  const CHANGE_GLYPH: Record<FileTreeChange, string> = {
+    added: "A",
+    modified: "M",
+    removed: "D",
+    renamed: "R",
+  };
+
+  // Tokens mirroring DiffFileBlock status glyphs — verified against design-system:
+  // added→--color-green, modified→--color-amber, removed→--color-red, renamed→--color-blue
+  const CHANGE_COLOR: Record<FileTreeChange, string> = {
+    added: "var(--color-green)",
+    modified: "var(--color-amber)",
+    removed: "var(--color-red)",
+    renamed: "var(--color-blue)",
+  };
+
+  function changeLabel(change: FileTreeChange): string {
+    switch (change) {
+      case "added":
+        return m.vblock_filetree_added();
+      case "modified":
+        return m.vblock_filetree_modified();
+      case "removed":
+        return m.vblock_filetree_removed();
+      case "renamed":
+        return m.vblock_filetree_renamed();
+    }
+  }
+</script>
+
+<div class="ft-root">
+  {#if block.title}
+    <p class="ft-title">{block.title}</p>
+  {/if}
+  {#snippet node(nodes: TreeNode[], depth: number)}
+    {#each nodes as n (n.segment)}
+      {#if n.kind === "dir"}
+        <div class="ft-row" style:padding-left="{depth * 12}px">
+          <span class="ft-dir-icon" aria-hidden="true">▸</span>
+          <span class="ft-segment">{n.segment}</span>
+        </div>
+        {@render node(n.children, depth + 1)}
+      {:else}
+        <div class="ft-row" style:padding-left="{depth * 12}px">
+          <span
+            class="ft-badge"
+            style:color={CHANGE_COLOR[n.entry.change]}
+            title={changeLabel(n.entry.change)}
+            aria-label={changeLabel(n.entry.change)}>{CHANGE_GLYPH[n.entry.change]}</span
+          >
+          <span class="ft-segment">{n.segment}</span>
+          {#if n.entry.note}
+            <span class="ft-note">{n.entry.note}</span>
+          {/if}
+        </div>
+      {/if}
+    {/each}
+  {/snippet}
+  {@render node(tree, 0)}
+</div>
+
+<style>
+  .ft-root {
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .ft-title {
+    margin: 0 0 4px 0;
+    font-size: var(--fs-micro);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-muted);
+    font-family: var(--font-sans, inherit);
+  }
+  .ft-row {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    line-height: 1.6;
+  }
+  .ft-dir-icon {
+    color: var(--color-faint);
+    flex-shrink: 0;
+    width: 1em;
+    text-align: center;
+  }
+  .ft-badge {
+    flex-shrink: 0;
+    width: 1em;
+    text-align: center;
+    font-weight: 600;
+  }
+  .ft-segment {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .ft-note {
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/ui/src/lib/components/blocks/FileTreeBlock.svelte
+++ b/ui/src/lib/components/blocks/FileTreeBlock.svelte
@@ -139,7 +139,6 @@
     text-transform: uppercase;
     letter-spacing: 0.04em;
     color: var(--color-muted);
-    font-family: var(--font-sans, inherit);
   }
   .ft-row {
     display: flex;

--- a/ui/src/lib/components/blocks/RichTextBlock.browser.test.ts
+++ b/ui/src/lib/components/blocks/RichTextBlock.browser.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import RichTextBlock from "./RichTextBlock.svelte";
+
+describe("RichTextBlock", () => {
+  it("renders bold markdown as a <strong> element", async () => {
+    render(RichTextBlock, {
+      block: { type: "rich-text", id: "r1", markdown: "**bold**" },
+    });
+    const strong = page.getByText("bold");
+    await expect.element(strong).toBeInTheDocument();
+    // the element wrapping it must be a <strong>
+    await expect.element(strong).toBeVisible();
+  });
+
+  it("renders nothing when markdown is empty", async () => {
+    const { container } = render(RichTextBlock, {
+      block: { type: "rich-text", id: "r2", markdown: "" },
+    });
+    // rt-md div should not exist
+    expect(container.querySelector(".rt-md")).toBeNull();
+  });
+
+  it("sanitizes html in markdown body (no script content in rendered output)", async () => {
+    const { container } = render(RichTextBlock, {
+      block: { type: "rich-text", id: "r3", markdown: "safe **text** here" },
+    });
+    // wait for async render
+    await expect.element(page.getByText(/safe/)).toBeInTheDocument();
+    // DOMPurify strips script tags — none should appear inside the component container
+    expect(container.querySelector("script")).toBeNull();
+  });
+});

--- a/ui/src/lib/components/blocks/RichTextBlock.browser.test.ts
+++ b/ui/src/lib/components/blocks/RichTextBlock.browser.test.ts
@@ -6,13 +6,15 @@ import RichTextBlock from "./RichTextBlock.svelte";
 
 describe("RichTextBlock", () => {
   it("renders bold markdown as a <strong> element", async () => {
-    render(RichTextBlock, {
+    const { container } = render(RichTextBlock, {
       block: { type: "rich-text", id: "r1", markdown: "**bold**" },
     });
-    const strong = page.getByText("bold");
-    await expect.element(strong).toBeInTheDocument();
-    // the element wrapping it must be a <strong>
-    await expect.element(strong).toBeVisible();
+    // wait for async dynamic-import render to settle
+    await expect.element(page.getByText("bold")).toBeInTheDocument();
+    // the element wrapping "bold" must be a <strong>, not raw **bold** leaking as text
+    const strongEl = container.querySelector("strong");
+    expect(strongEl).not.toBeNull();
+    expect(strongEl?.textContent).toBe("bold");
   });
 
   it("renders nothing when markdown is empty", async () => {

--- a/ui/src/lib/components/blocks/RichTextBlock.svelte
+++ b/ui/src/lib/components/blocks/RichTextBlock.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import type { VisualBlock } from "$lib/types";
+  let { block }: { block: Extract<VisualBlock, { type: "rich-text" }> } = $props();
+  let rendered = $state("");
+  $effect(() => {
+    const md = block.markdown;
+    if (!md) {
+      rendered = "";
+      return;
+    }
+    let alive = true;
+    Promise.all([import("marked"), import("dompurify")])
+      .then(([{ marked }, { default: DOMPurify }]) => {
+        if (alive) rendered = DOMPurify.sanitize(marked.parse(md, { async: false }) as string);
+      })
+      .catch((err) => console.warn("RichTextBlock markdown render failed", err));
+    return () => {
+      alive = false;
+    };
+  });
+</script>
+
+{#if rendered}
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized via DOMPurify above -->
+  <div class="rt-md">{@html rendered}</div>
+{/if}
+
+<style>
+  .rt-md {
+    font-size: var(--fs-base);
+    color: var(--color-ink);
+    line-height: 1.5;
+  }
+  .rt-md :global(p) {
+    margin: 0 0 8px 0;
+  }
+  .rt-md :global(ul),
+  .rt-md :global(ol) {
+    margin: 0 0 8px 0;
+    padding-left: 18px;
+  }
+  .rt-md :global(a) {
+    color: var(--color-amber);
+  }
+  .rt-md :global(code) {
+    font-size: var(--fs-meta);
+  }
+</style>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1065,4 +1065,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_optimize_learnings_title",
     bodyKey: "feat_optimize_learnings_body",
   },
+  {
+    // targetId "session-recap" anchors the coachmark on the live SessionRecap card
+    // (use:coachTarget={"session-recap"} in SessionRecap.svelte). 1.33.0 is the latest
+    // released tag, so this ships in 1.34.0.
+    id: "visual-recap-blocks",
+    sinceVersion: "1.34.0",
+    titleKey: "feat_visual_recap_title",
+    bodyKey: "feat_visual_recap_body",
+    targetId: "session-recap",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -233,6 +233,32 @@ export interface PlanGate {
   updatedAt: number;
 }
 
+// ── visual recap blocks ──────────────────────────────────────────────────────
+// mirrors server VisualBlock union (Phase 1: rich-text + callout; file-tree + diff Task 6)
+export type CalloutTone = "info" | "decision" | "risk" | "warning" | "success";
+export type FileTreeChange = "added" | "modified" | "removed" | "renamed";
+export interface FileTreeEntry {
+  path: string;
+  change: FileTreeChange;
+  note?: string;
+}
+export interface DiffAnnotation {
+  label?: string;
+  note: string;
+}
+export type VisualBlock =
+  | { type: "rich-text"; id: string; markdown: string }
+  | { type: "callout"; id: string; tone: CalloutTone; markdown: string }
+  | { type: "file-tree"; id: string; title?: string; entries: FileTreeEntry[] }
+  | {
+      type: "diff";
+      id: string;
+      path: string;
+      summary: string;
+      annotations?: DiffAnnotation[];
+      file?: DiffFile;
+    };
+
 // ── session recap ────────────────────────────────────────────────────────────
 // mirrors server Recap / RecapState / RecapVerdict
 export type RecapState = "generating" | "ready" | "failed" | "empty";
@@ -252,6 +278,7 @@ export interface Recap {
   spawnedAt: number;
   generatedAt: number | null;
   updatedAt: number;
+  blocks?: VisualBlock[]; // arrives over session:recap WS payload; optional for back-compat
 }
 
 // mirrors server HerdDigest / RundownItem / HerdDigestState


### PR DESCRIPTION
Implements **Phase 1** of the native visual plan/recap renderer (issue #773): recaps now render as a scannable document of typed **blocks** — a file-tree of the change footprint, the real annotated diff, toned callouts, and narrative — instead of flat sanitized markdown. No new external dependency, no spawn-isolation change.

Design of record: `docs/research/native-visual-plan-recap-design.md` (#771).

## What ships
- **Block set:** `rich-text`, `callout`, `file-tree`, `diff` (Phase 2 cards / Phase 3 mermaid+wireframe+plans are explicit follow-ups).
- **Surfaces:** recaps only — `SessionRecap` (live) and `DoneRecapPanel` (durable Done lens, post-archive).

## How it works
- **Schema + fail-closed validator** (`src/visual-blocks.ts`): a `VisualBlock` discriminated union with a per-variant `parseVisualBlocks` that drops anything malformed and never throws.
- **Grounding by construction** (`src/recap.ts`): the LLM only chooses *which* files to feature + writes prose; the **server joins** the chosen `diff` blocks against the **real parsed `DiffFile[]`** and reconciles `file-tree` entries against it, dropping invented paths. Diff hunks are never LLM-typed.
- **Server-persisted carrier:** the parsed diff rides a transient, **server-only** `pendingDiff` column from `generate()` to `finalize()` so the join is restart-safe; it is stripped from the persisted/broadcast `Recap` and cleared on every finalize path. A dedicated no-leak test locks that the carrier never reaches the client via any SELECT **or** the `session:recap` WebSocket.
- **Back-compat:** absent/empty `blocks` → the existing flat markdown body renders unchanged. Carrier-empty (server bounce) fails closed — drops diff blocks only, keeps file-tree/callout/rich-text + body.
- **UI** (`VisualReview.svelte` + `blocks/*`): Svelte 5, tokens-only, lazy markdown imports off first paint; `DiffBlock` reuses the existing `DiffFileBlock`; featured diffs render under a single "Highlighted changes" heading; a `file-tree` block supersedes the standalone changed-files list. XSS-safe: the only `{@html}` is DOMPurify-sanitized markdown.

## Obligations met
- i18n EN+DE parity for all new strings; one `feature-announcements.ts` entry (`sinceVersion: 1.34.0`, coachmark on the live recap card).
- Gates green: root lint/tsc/tests, UI check/i18n/tests, branch-hygiene, feature-catalog, glossary, fallow audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)