### PR TITLE
fix(ui): collapse mobile settings-gear pips into one severity dot

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -893,11 +893,15 @@
     {/if}
     <!-- The gear adapts to state: idle herd → a click opens Settings directly;
          when something is haltable it becomes a menu button opening the e-stop above
-         the Settings entry. A pip on the gear is the only at-rest cue that there's a
-         herd to halt: amber while agents simply work (matches the working colour),
-         escalating to red only when something is blocked — so red keeps meaning
-         "needs you", consistent with the rest of the bar. The blue herdr-update dot
-         (mobile) shifts to the opposite corner when both want the gear. -->
+         the Settings entry. The pip differs by platform:
+         • Desktop keeps the dedicated halt-pip — the only at-rest cue that there's a
+           herd to halt: amber while agents simply work (matches the working colour),
+           escalating to red only when something is blocked. Other signals (update,
+           health, what's-new, learnings) live in their own labelled badges.
+         • Mobile folds those badges into the gear's bottom sheet, so the gear carries
+           a SINGLE collapsed dot (gearPipTier) coloured by the most serious active
+           signal — red > orange > yellow > blue. Red still means "needs you",
+           consistent with the rest of the bar. -->
     <div class="gear-wrap" bind:this={gearWrap}>
       <button
         bind:this={gearBtn}

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -348,18 +348,22 @@
   // controls live in the ActionBar, so the gear keeps its leaner behaviour: idle herd
   // opens Settings directly; only a haltable herd turns it into a menu button.
   const gearOpensMenu = $derived(mobile || haltable > 0);
-  // Mobile sheet pip: quiet indicator on the gear when the bottom sheet holds an
-  // actionable item — update available, health not ok, or what's new. Keeps moved
-  // badges discoverable when they no longer render in the top-bar right cluster.
-  // Composed alongside the halt-pip (.halt-pip) — the two use different corners
-  // (.sheet-pip sits bottom-left; .halt-pip owns top-right; .gear-dot owns top/bottom-right).
-  const sheetPip = $derived(
-    mobile &&
-      (updateAvailable ||
-        herdrUpdateAvailable ||
-        diagnosticsOverall !== "ok" ||
-        whatsNew ||
-        learningsPresent),
+  // Mobile only: every gear-area signal collapses into ONE dot, colored by the
+  // most serious active tier (red > orange > yellow > blue). Desktop keeps its
+  // halt-pip + dedicated badges, so this stays null off-mobile.
+  type GearPipTier = "red" | "orange" | "yellow" | "blue" | null;
+  const gearPipTier = $derived<GearPipTier>(
+    !mobile
+      ? null
+      : blocked > 0 || diagnosticsOverall === "error"
+        ? "red"
+        : haltable > 0 || updateAvailable
+          ? "orange"
+          : diagnosticsOverall === "warning"
+            ? "yellow"
+            : herdrUpdateAvailable || whatsNew || learningsPresent
+              ? "blue"
+              : null,
   );
   function clickGear() {
     if (!gearOpensMenu) {
@@ -850,8 +854,8 @@
     {/if}
     <!-- Health pip: visible ONLY when diagnosticsOverall !== "ok" AND not mobile
          (on mobile it moves into the gear bottom sheet).
-         Own slot left of the gear-wrap so it never overlaps the halt-pip (gear top-right)
-         or the herdr blue gear-dot. Color: slate ring with state-colored core —
+         Own slot left of the gear-wrap so it never overlaps the halt-pip (gear top-right).
+         Color: slate ring with state-colored core —
          warn for warning, red for error — distinct from both the halt-pip identity
          and the herdr blue. Token choice: --status-warn / --color-red for the core,
          --color-line-bright for the ring. Never --color-green (hidden when ok anyway). -->
@@ -904,13 +908,13 @@
         aria-haspopup={gearOpensMenu ? (mobile ? "dialog" : "menu") : undefined}
         aria-expanded={gearOpensMenu ? menuOpen : undefined}
         aria-label={gearOpensMenu ? m.topbar_menu_aria() : m.topbar_settings_aria()}
-        >⚙{#if haltable > 0}<span class="halt-pip" class:alert={blocked > 0} aria-hidden="true"
-          ></span>{/if}{#if herdrUpdateAvailable && mobile}<span
-            class="gear-dot"
-            class:shift={haltable > 0}
+        >⚙{#if !mobile && haltable > 0}<span
+            class="halt-pip"
+            class:alert={blocked > 0}
             aria-hidden="true"
-          ></span>{/if}{#if sheetPip && !herdrUpdateAvailable}<span
-            class="sheet-pip"
+          ></span>{/if}{#if mobile && gearPipTier}<span
+            class="gear-pip"
+            data-tier={gearPipTier}
             aria-hidden="true"
           ></span>{/if}</button
       >
@@ -1575,18 +1579,6 @@
     color: var(--color-faint);
     font-variant-numeric: tabular-nums;
   }
-  /* Sheet pip on the gear: quiet actionable-item indicator. Bottom-left corner so it
-     composes cleanly with .halt-pip (top-right) and .gear-dot (top/bottom-right). */
-  .sheet-pip {
-    position: absolute;
-    bottom: 3px;
-    left: 3px;
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: var(--color-amber);
-    box-shadow: 0 0 0 2px var(--color-panel);
-  }
   .menu-item {
     display: flex;
     align-items: center;
@@ -1685,24 +1677,28 @@
   .gear:hover {
     color: var(--color-amber);
   }
-  /* phone-only: the folded HERDR-update cue — a blue pip on the gear that mirrors
-     the calm informational blue of the desktop badge and rings against the panel
-     to stay legible */
-  .gear-dot {
+  /* Mobile only: single severity dot on the gear — red > orange > yellow > blue.
+     One dot replaces the old three-pip "measles" layout on mobile. */
+  .gear-pip {
     position: absolute;
-    top: 3px;
-    right: 3px;
+    top: 2px;
+    right: 2px;
     width: 7px;
     height: 7px;
     border-radius: 50%;
-    background: var(--color-blue);
     box-shadow: 0 0 0 2px var(--color-panel);
   }
-  /* When the red halt pip owns the top-right corner, the blue herdr dot drops to the
-     bottom-right so the two cues never overlap. */
-  .gear-dot.shift {
-    top: auto;
-    bottom: 3px;
+  .gear-pip[data-tier="red"] {
+    background: var(--color-red);
+  }
+  .gear-pip[data-tier="orange"] {
+    background: var(--color-warn);
+  }
+  .gear-pip[data-tier="yellow"] {
+    background: var(--color-amber);
+  }
+  .gear-pip[data-tier="blue"] {
+    background: var(--color-blue);
   }
   /* Health pip: a standalone button placed left of the gear-wrap in .rightside.
      Visible only when diagnosticsOverall !== "ok" (hidden-when-OK via {#if}).
@@ -1759,7 +1755,7 @@
   .whatsnew-badge .wn-dot {
     font-size: var(--fs-micro);
   }
-  /* Phone-only: bare pip button, no label — mirrors .gear-dot folded pattern. */
+  /* Phone-only: bare pip button, no label. */
   .whatsnew-dot-btn {
     position: relative;
     background: transparent;


### PR DESCRIPTION
## Problem

The mobile settings gear stacked up to three notification pips at once — `halt-pip` (amber/red), `gear-dot` (blue herdr-update), and `sheet-pip` (amber catch-all) — giving it a "warts/measles" look (see the reported screenshot). Desktop was already fine: it shows a single `halt-pip` plus dedicated labelled badges.

## Change

On **mobile only**, the gear now surfaces **at most one dot**, colored by the most serious active signal on a severity-monotonic hue ramp **red > orange > yellow > blue**:

| Tier | Token | Active when |
| --- | --- | --- |
| RED | `--color-red` (#e5484d) | blocked agents **or** diagnostics error |
| ORANGE | `--color-warn` (#e8730c) | agents working **or** app update available |
| YELLOW | `--color-amber` (#e8a13a) | diagnostics warning |
| BLUE | `--color-blue` (#4a90d9) | herdr update / what's-new / learnings to review |

The dot shows iff any signal is active; color = highest active tier (e.g. blocked **and** working → red). The palette has no literal "yellow"; the four-name scale maps to red/warn/amber/blue, chosen so the hue ramps monotonically with severity. This is an intentional trade-off (a "working" dot now shows orange rather than the app-wide running amber) confirmed with the operator.

Desktop is untouched — the `.halt-pip` (amber/red) path and the separate badges are unchanged.

## Implementation

Single file: `ui/src/lib/components/TopBar.svelte`.
- Added a mobile-only `gearPipTier` derived (most-serious-first resolution).
- Gated `.halt-pip` to `!mobile`; render one `.gear-pip[data-tier]` on mobile.
- Removed the now-orphaned `sheetPip` derived and the `.sheet-pip` / `.gear-dot` / `.gear-dot.shift` CSS; tidied stale composition comments.
- Semantic tokens only; pip stays `aria-hidden` (no i18n strings added).

## Verification

- `cd ui && bun run check` → 0 errors, 0 warnings (re-run after rebasing onto latest `main`).
- `cd ui && bun run lint` → clean. `bunx prettier --check .` → clean (full pre-push gate passed).
- `grep -rnE 'sheetPip|sheet-pip|gear-dot' ui/src` → no matches (no orphans).
- Net -4 lines; reviewed for spec compliance + code quality (clean) and a final whole-branch review (ready to merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)