### PR TITLE
fix(ui): single-row build-queue badge to match sibling height

### DIFF
--- a/ui/src/lib/components/BuildQueueBadge.browser.test.ts
+++ b/ui/src/lib/components/BuildQueueBadge.browser.test.ts
@@ -65,7 +65,7 @@ describe("BuildQueueBadge", () => {
     await expect.element(page.getByText("4/5")).toBeInTheDocument();
   });
 
-  it("meter fill width reflects resolved/total via --queue-pct", async () => {
+  it("background fill reflects resolved/total via --queue-pct", async () => {
     // 4/5 = 80%
     buildQueues.map = {
       s1: queue(true, [
@@ -82,7 +82,7 @@ describe("BuildQueueBadge", () => {
     expect(badge.style.getPropertyValue("--queue-pct")).toBe("80%");
   });
 
-  it("all resolved (all done) → shows 5/5 with 100% meter", async () => {
+  it("all resolved (all done) → shows 5/5 with 100% fill", async () => {
     buildQueues.map = {
       s1: queue(true, [
         step("done", "1"),

--- a/ui/src/lib/components/BuildQueueBadge.svelte
+++ b/ui/src/lib/components/BuildQueueBadge.svelte
@@ -23,16 +23,18 @@
     use:coachTarget={"build-queue-progress"}
   >
     <span class="queue-label">{m.queuebadge_label({ resolved, total })}</span>
-    <span class="queue-meter" aria-hidden="true"><span class="queue-fill"></span></span>
   </span>
 {/if}
 
 <style>
+  /* Single-row badge matching its siblings (PREVIEW / REWORK / status badges):
+     same outline idiom, same height. Progress is shown as a subtle amber wash
+     filling the badge box left→right to --queue-pct (hard-edged gradient stop),
+     so there's no extra meter row to make this badge taller than the others. */
   .queue-badge {
     display: inline-flex;
-    flex-direction: column;
+    align-items: center;
     flex: none;
-    gap: 2px;
     font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -41,21 +43,12 @@
     border: 1px solid var(--color-amber);
     border-radius: 2px;
     color: var(--color-amber);
-    background: transparent;
     white-space: nowrap;
-  }
-  .queue-meter {
-    display: block;
-    height: 2px;
-    width: 100%;
-    background: var(--color-line);
-    border-radius: 2px;
     overflow: hidden;
-  }
-  .queue-fill {
-    display: block;
-    height: 100%;
-    width: var(--queue-pct);
-    background: var(--color-amber);
+    background: linear-gradient(
+      to right,
+      color-mix(in srgb, var(--color-amber) 22%, transparent) var(--queue-pct),
+      transparent var(--queue-pct)
+    );
   }
 </style>


### PR DESCRIPTION
## Problem

The build-queue progress badge (`0/3`, `6/6`) on session cards rendered as a **two-row flex column** (count label + a 2px progress meter), making it visibly taller than every sibling badge (`PREVIEW`, `REWORK · 1/5`, status badges), which are single-row. Cosmetic misalignment in the badge row.

## Fix

Make `BuildQueueBadge` a single-row badge using the same outline idiom as its siblings, and show progress as a **subtle amber background fill** of the badge box (left→right to `--queue-pct`, hard-edged `linear-gradient` over a `color-mix` amber wash). The separate `.queue-meter` / `.queue-fill` rows are removed, so the badge is now the same height as the others.

- At `0/N` the badge reads identically to its siblings (outline + text only).
- The fill scales with completion; full amber wash at `N/N`.
- `--queue-pct`, the `N/M` label, `role`/`title`/`aria-label`, and the coachmark target are unchanged.

Before: `0/3` box taller than `PREVIEW` / `REWORK`, thin meter line under the count.
After: same height, progress shown as the box fill.

## Tests

- Two `BuildQueueBadge.browser.test.ts` descriptions reworded ("meter" → "background fill"); assertions (`--queue-pct`, `N/M` text) unchanged and still passing.
- `cd ui && bun run check` clean; full UI suite green (1534 passed).

## Notes

- No new user-facing capability — refinement of an already-shipped feature (#778), so no feature-announcement entry; shipped as `fix(ui):`.
- No new/changed strings → no i18n catalog change.
- On-token throughout (`--color-amber`, `--fs-micro`); no raw hex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)