### PR TITLE
fix(ui): portal mobile gear sheet out of transformed header

### DIFF
--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1139,3 +1139,67 @@ describe("TopBar — learnings chip label switches between proposed and curate-o
     );
   });
 });
+
+describe("TopBar — mobile gear sheet portals out of transformed ancestor", () => {
+  // Regression guard for the fixed-containing-block bug: on mobile the sheet lives
+  // inside <header class="chrome"> which carries `will-change: transform` on
+  // `.shell.mobile.list .chrome`. That establishes a CSS containing block so
+  // `position: fixed` on `.gear-sheet` resolves against the short chrome box, not
+  // the viewport — the sheet is clipped to the top of the screen.
+  //
+  // The fix wraps .menu-scrim + .gear-sheet in a `use:portal` wrapper so they are
+  // re-parented to <body> (no transformed ancestor there), restoring honest
+  // viewport-relative fixed positioning.
+
+  let container: HTMLDivElement;
+
+  afterEach(() => {
+    container?.remove();
+  });
+
+  it("gear sheet escapes a will-change:transform ancestor and sits at the viewport bottom", async () => {
+    await page.viewport(390, 800);
+    document.body.style.width = "390px";
+
+    // Reproduce the trapping ancestor: a small container with will-change:transform,
+    // mirroring .shell.mobile.list .chrome which is top-pinned and short.
+    container = document.createElement("div");
+    container.style.cssText =
+      "will-change:transform;position:fixed;top:0;left:0;width:390px;height:60px;overflow:hidden;";
+    document.body.appendChild(container);
+
+    const list = [{ id: "d1", status: "done" }] as unknown as Session[];
+    render(TopBar, {
+      target: container,
+      props: {
+        nowMs: 1_700_000_000_000,
+        connected: true,
+        ...FLAGS.mobile,
+        sessions: list,
+      },
+    });
+
+    // Open the sheet.
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    // Wait for the sheet to appear.
+    await expect
+      .element(page.getByRole("button", { name: m.settings_title() }))
+      .toBeInTheDocument();
+
+    const gearSheet = document.querySelector<HTMLElement>(".gear-sheet");
+    expect(gearSheet, ".gear-sheet is in the document").not.toBeNull();
+
+    // Structural: sheet must have escaped the transformed container.
+    expect(
+      container.contains(gearSheet),
+      "gear-sheet must NOT be a descendant of the transformed ancestor",
+    ).toBe(false);
+
+    // Geometry: sheet bottom must sit at/near the viewport bottom (within 2px).
+    const rect = gearSheet!.getBoundingClientRect();
+    expect(
+      rect.bottom,
+      `gear-sheet bottom (${rect.bottom}) must be near viewport bottom (${window.innerHeight})`,
+    ).toBeGreaterThanOrEqual(window.innerHeight - 2);
+  });
+});

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -18,6 +18,7 @@
   import { REPO_URL, version } from "$lib/build-info";
   import { fly } from "svelte/transition";
   import { dialog } from "$lib/a11yDialog";
+  import { portal } from "$lib/portal";
 
   const reduceMotion =
     typeof window !== "undefined" &&
@@ -960,220 +961,226 @@
 
 <!-- Blur backdrop behind the opened mobile bottom sheet, so the panel reads as the focus
      and the herd recedes. Rendered outside .gear-wrap so outside-click detection fires on it.
-     onclick also wires close explicitly to complement the window-level handler. -->
+     onclick also wires close explicitly to complement the window-level handler.
+     The portal wrapper re-parents both children to <body> so position:fixed resolves
+     against the viewport, not the will-change:transform chrome header. The wrapper itself
+     is display:contents with no transform/filter/will-change so it establishes no
+     containing block of its own. -->
 {#if menuOpen && mobile}
-  <div class="menu-scrim scrim" aria-hidden="true" onclick={() => closeMenu()}></div>
-  <!-- Mobile bottom sheet: slides up from the bottom of the screen. role=dialog + use:dialog
-       provides focus-trap + Esc→closeMenu + focus-restore. Children are plain buttons/links,
-       NOT role="menuitem" (that role is invalid inside a dialog). -->
-  <div
-    class="gear-sheet"
-    role="dialog"
-    aria-modal="true"
-    aria-label={m.topbar_sheet_title()}
-    use:dialog={{ onclose: closeMenu }}
-    transition:fly={{ y: 520, duration: reduceMotion ? 0 : 220, opacity: 1 }}
-  >
-    <!-- Grab handle + title row -->
-    <div class="sheet-handle-row" aria-hidden="true">
-      <div class="sheet-handle"></div>
-    </div>
-    <div class="sheet-title-row">
-      <span class="sheet-title micro">{m.topbar_sheet_title()}</span>
-      <button
-        type="button"
-        class="sheet-close"
-        onclick={() => closeMenu()}
-        aria-label={m.common_close()}>✕</button
-      >
-    </div>
-
-    <!-- Quick appearance: dark/light theme + high-contrast toggle -->
-    <div class="quick">
-      <div class="theme-seg" role="group" aria-label={m.actionbar_theme_group_aria()}>
-        {#each QUICK_THEMES as t (t.pref)}
-          <button
-            type="button"
-            class="t-opt"
-            class:on={theme.resolved === t.pref}
-            aria-pressed={theme.resolved === t.pref}
-            aria-label={m.actionbar_theme_option({ label: t.label() })}
-            onclick={() => theme.setPref(t.pref)}><ThemeIcon icon={t.icon} /></button
-          >
-        {/each}
-      </div>
-      <button
-        type="button"
-        class="contrast-toggle"
-        class:on={theme.contrast}
-        aria-pressed={theme.contrast}
-        aria-label={m.actionbar_contrast_toggle()}
-        onclick={() => theme.toggleContrast()}><ThemeIcon icon="contrast" /></button
-      >
-    </div>
-    <div class="sheet-sep"></div>
-
-    <!-- Usage section: full gauge breakdown (mirrors the touch popover content) -->
-    {#if gauges.length || credits || subscriptionOnly}
-      <div class="sheet-section-label micro">{m.topbar_sheet_usage()}</div>
-      {#if subscriptionOnly}
-        <div class="sheet-row-text micro">{m.usage_subscription_only()}</div>
-      {:else}
-        <div class="sheet-gauges" class:stale={limits?.stale}>
-          {#each gauges as g (g.label)}
-            <div class="sheet-gauge-row">
-              <div class="sheet-gauge-head">
-                <span class="gp-period">{periodLabel(g.label)}</span>
-                <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
-              </div>
-              <span class="g-bar g-bar-wide"
-                ><span
-                  class="g-fill"
-                  style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
-                    100});background:{gaugeColor(g.w.pct)}"
-                ></span></span
-              >
-              <div class="gauge-pop-reset micro">
-                {m.topbar_gauge_reset_rel({
-                  rel: formatResetIn(g.w.resetAt, nowMs),
-                  abs: formatReset(g.w.resetAt, nowMs),
-                })}
-              </div>
-            </div>
-          {/each}
-          {@render creditDetail()}
-        </div>
-      {/if}
-      <div class="sheet-sep"></div>
-    {/if}
-
-    <!-- Diagnose row: only when health is not ok -->
-    {#if diagnosticsOverall !== "ok"}
-      <button
-        type="button"
-        class="sheet-item"
-        class:alert={diagnosticsOverall === "error"}
-        onclick={() => {
-          closeMenu();
-          ondiagnose?.();
-        }}
-        aria-label={m.diagnostics_pip_label()}
-      >
-        <span class="sheet-glyph" aria-hidden="true"
-          >{diagnosticsOverall === "error" ? "✕" : "⚠"}</span
-        >
-        <span class="sheet-label">{m.diagnostics_pip_label()}</span>
-      </button>
-    {/if}
-
-    <!-- Update row: when shepherd update is available -->
-    {#if updateAvailable}
-      <button
-        type="button"
-        class="sheet-item sheet-update"
-        onclick={() => {
-          closeMenu();
-          onupdate?.();
-        }}
-        aria-label={m.topbar_update_badge()}
-      >
-        <span class="sheet-glyph" aria-hidden="true">▲</span>
-        <span class="sheet-label">{m.topbar_update_badge()} · {update!.behind}</span>
-      </button>
-    {/if}
-
-    <!-- Herdr update row: when herdr update is available -->
-    {#if herdrUpdateAvailable}
-      <button
-        type="button"
-        class="sheet-item sheet-update"
-        onclick={() => {
-          closeMenu();
-          onherdrupdate?.();
-        }}
-        aria-label={m.topbar_herdr_update_badge()}
-      >
-        <span class="sheet-glyph" aria-hidden="true">▲</span>
-        <span class="sheet-label">{m.topbar_herdr_update_badge()}</span>
-      </button>
-    {/if}
-
-    <!-- What's New row -->
-    {#if whatsNew}
-      <button
-        type="button"
-        class="sheet-item"
-        onclick={() => {
-          closeMenu();
-          onwhatsnew?.();
-        }}
-        aria-label={m.whatsnew_topbar_aria()}
-      >
-        <span class="sheet-glyph" aria-hidden="true">●</span>
-        <span class="sheet-label">{m.whatsnew_open()}</span>
-      </button>
-    {/if}
-
-    <!-- Learnings row: review proposed house rules across all repos -->
-    {#if learningsPresent}
-      <button
-        type="button"
-        class="sheet-item"
-        onclick={() => {
-          closeMenu();
-          onlearnings?.();
-        }}
-        aria-label={learnings > 0
-          ? m.learnings_open_aria({ count: learnings })
-          : m.learnings_open_curate_aria({ count: learningsCurate })}
-      >
-        <span class="sheet-glyph" aria-hidden="true">✦</span>
-        <span class="sheet-label">{learningsLabel} · {learningsCount}</span>
-      </button>
-    {/if}
-
-    <div class="sheet-sep"></div>
-
-    <!-- Halt e-stop: two-step arm→confirm, same as desktop -->
-    {#if haltable > 0}
-      <button
-        class="sheet-item halt-item"
-        class:armed
-        type="button"
-        onclick={clickHalt}
-        aria-label={armed
-          ? m.halt_arm_aria({ count: haltable })
-          : m.halt_all_aria({ count: haltable })}
-      >
-        <svg class="menu-icon" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M8 2 H16 L22 8 V16 L16 22 H8 L2 16 V8 Z" fill="currentColor" />
-        </svg>
-        <span class="sheet-label"
-          >{armed ? m.halt_arm({ count: haltable }) : m.halt_menu_item({ count: haltable })}</span
-        >
-      </button>
-      <div class="sheet-sep"></div>
-    {/if}
-
-    <!-- Settings -->
-    <button type="button" class="sheet-item" onclick={chooseSettings}>
-      <span class="sheet-glyph" aria-hidden="true">⚙</span>
-      <span class="sheet-label">{m.settings_title()}</span>
-    </button>
-
-    <!-- Docs + version footer -->
-    <div class="sheet-sep"></div>
-    <a
-      class="sheet-item"
-      href={REPO_URL}
-      target="_blank"
-      rel="external noreferrer noopener"
-      onclick={() => closeMenu()}
+  <div class="gear-sheet-portal" use:portal>
+    <div class="menu-scrim scrim" aria-hidden="true" onclick={() => closeMenu()}></div>
+    <!-- Mobile bottom sheet: slides up from the bottom of the screen. role=dialog + use:dialog
+         provides focus-trap + Esc→closeMenu + focus-restore. Children are plain buttons/links,
+         NOT role="menuitem" (that role is invalid inside a dialog). -->
+    <div
+      class="gear-sheet"
+      role="dialog"
+      aria-modal="true"
+      aria-label={m.topbar_sheet_title()}
+      use:dialog={{ onclose: closeMenu }}
+      transition:fly={{ y: 520, duration: reduceMotion ? 0 : 220, opacity: 1 }}
     >
-      <span class="sheet-glyph" aria-hidden="true">↗</span>
-      <span class="sheet-label">{m.topbar_menu_docs()}</span>
-    </a>
-    <div class="sheet-foot micro">v{version}</div>
+      <!-- Grab handle + title row -->
+      <div class="sheet-handle-row" aria-hidden="true">
+        <div class="sheet-handle"></div>
+      </div>
+      <div class="sheet-title-row">
+        <span class="sheet-title micro">{m.topbar_sheet_title()}</span>
+        <button
+          type="button"
+          class="sheet-close"
+          onclick={() => closeMenu()}
+          aria-label={m.common_close()}>✕</button
+        >
+      </div>
+
+      <!-- Quick appearance: dark/light theme + high-contrast toggle -->
+      <div class="quick">
+        <div class="theme-seg" role="group" aria-label={m.actionbar_theme_group_aria()}>
+          {#each QUICK_THEMES as t (t.pref)}
+            <button
+              type="button"
+              class="t-opt"
+              class:on={theme.resolved === t.pref}
+              aria-pressed={theme.resolved === t.pref}
+              aria-label={m.actionbar_theme_option({ label: t.label() })}
+              onclick={() => theme.setPref(t.pref)}><ThemeIcon icon={t.icon} /></button
+            >
+          {/each}
+        </div>
+        <button
+          type="button"
+          class="contrast-toggle"
+          class:on={theme.contrast}
+          aria-pressed={theme.contrast}
+          aria-label={m.actionbar_contrast_toggle()}
+          onclick={() => theme.toggleContrast()}><ThemeIcon icon="contrast" /></button
+        >
+      </div>
+      <div class="sheet-sep"></div>
+
+      <!-- Usage section: full gauge breakdown (mirrors the touch popover content) -->
+      {#if gauges.length || credits || subscriptionOnly}
+        <div class="sheet-section-label micro">{m.topbar_sheet_usage()}</div>
+        {#if subscriptionOnly}
+          <div class="sheet-row-text micro">{m.usage_subscription_only()}</div>
+        {:else}
+          <div class="sheet-gauges" class:stale={limits?.stale}>
+            {#each gauges as g (g.label)}
+              <div class="sheet-gauge-row">
+                <div class="sheet-gauge-head">
+                  <span class="gp-period">{periodLabel(g.label)}</span>
+                  <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+                </div>
+                <span class="g-bar g-bar-wide"
+                  ><span
+                    class="g-fill"
+                    style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
+                      100});background:{gaugeColor(g.w.pct)}"
+                  ></span></span
+                >
+                <div class="gauge-pop-reset micro">
+                  {m.topbar_gauge_reset_rel({
+                    rel: formatResetIn(g.w.resetAt, nowMs),
+                    abs: formatReset(g.w.resetAt, nowMs),
+                  })}
+                </div>
+              </div>
+            {/each}
+            {@render creditDetail()}
+          </div>
+        {/if}
+        <div class="sheet-sep"></div>
+      {/if}
+
+      <!-- Diagnose row: only when health is not ok -->
+      {#if diagnosticsOverall !== "ok"}
+        <button
+          type="button"
+          class="sheet-item"
+          class:alert={diagnosticsOverall === "error"}
+          onclick={() => {
+            closeMenu();
+            ondiagnose?.();
+          }}
+          aria-label={m.diagnostics_pip_label()}
+        >
+          <span class="sheet-glyph" aria-hidden="true"
+            >{diagnosticsOverall === "error" ? "✕" : "⚠"}</span
+          >
+          <span class="sheet-label">{m.diagnostics_pip_label()}</span>
+        </button>
+      {/if}
+
+      <!-- Update row: when shepherd update is available -->
+      {#if updateAvailable}
+        <button
+          type="button"
+          class="sheet-item sheet-update"
+          onclick={() => {
+            closeMenu();
+            onupdate?.();
+          }}
+          aria-label={m.topbar_update_badge()}
+        >
+          <span class="sheet-glyph" aria-hidden="true">▲</span>
+          <span class="sheet-label">{m.topbar_update_badge()} · {update!.behind}</span>
+        </button>
+      {/if}
+
+      <!-- Herdr update row: when herdr update is available -->
+      {#if herdrUpdateAvailable}
+        <button
+          type="button"
+          class="sheet-item sheet-update"
+          onclick={() => {
+            closeMenu();
+            onherdrupdate?.();
+          }}
+          aria-label={m.topbar_herdr_update_badge()}
+        >
+          <span class="sheet-glyph" aria-hidden="true">▲</span>
+          <span class="sheet-label">{m.topbar_herdr_update_badge()}</span>
+        </button>
+      {/if}
+
+      <!-- What's New row -->
+      {#if whatsNew}
+        <button
+          type="button"
+          class="sheet-item"
+          onclick={() => {
+            closeMenu();
+            onwhatsnew?.();
+          }}
+          aria-label={m.whatsnew_topbar_aria()}
+        >
+          <span class="sheet-glyph" aria-hidden="true">●</span>
+          <span class="sheet-label">{m.whatsnew_open()}</span>
+        </button>
+      {/if}
+
+      <!-- Learnings row: review proposed house rules across all repos -->
+      {#if learningsPresent}
+        <button
+          type="button"
+          class="sheet-item"
+          onclick={() => {
+            closeMenu();
+            onlearnings?.();
+          }}
+          aria-label={learnings > 0
+            ? m.learnings_open_aria({ count: learnings })
+            : m.learnings_open_curate_aria({ count: learningsCurate })}
+        >
+          <span class="sheet-glyph" aria-hidden="true">✦</span>
+          <span class="sheet-label">{learningsLabel} · {learningsCount}</span>
+        </button>
+      {/if}
+
+      <div class="sheet-sep"></div>
+
+      <!-- Halt e-stop: two-step arm→confirm, same as desktop -->
+      {#if haltable > 0}
+        <button
+          class="sheet-item halt-item"
+          class:armed
+          type="button"
+          onclick={clickHalt}
+          aria-label={armed
+            ? m.halt_arm_aria({ count: haltable })
+            : m.halt_all_aria({ count: haltable })}
+        >
+          <svg class="menu-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M8 2 H16 L22 8 V16 L16 22 H8 L2 16 V8 Z" fill="currentColor" />
+          </svg>
+          <span class="sheet-label"
+            >{armed ? m.halt_arm({ count: haltable }) : m.halt_menu_item({ count: haltable })}</span
+          >
+        </button>
+        <div class="sheet-sep"></div>
+      {/if}
+
+      <!-- Settings -->
+      <button type="button" class="sheet-item" onclick={chooseSettings}>
+        <span class="sheet-glyph" aria-hidden="true">⚙</span>
+        <span class="sheet-label">{m.settings_title()}</span>
+      </button>
+
+      <!-- Docs + version footer -->
+      <div class="sheet-sep"></div>
+      <a
+        class="sheet-item"
+        href={REPO_URL}
+        target="_blank"
+        rel="external noreferrer noopener"
+        onclick={() => closeMenu()}
+      >
+        <span class="sheet-glyph" aria-hidden="true">↗</span>
+        <span class="sheet-label">{m.topbar_menu_docs()}</span>
+      </a>
+      <div class="sheet-foot micro">v{version}</div>
+    </div>
   </div>
 {/if}
 
@@ -1408,6 +1415,13 @@
     color: var(--color-amber);
     background: var(--color-inset);
     border-color: var(--color-amber);
+  }
+  /* Portal wrapper: re-parents scrim + sheet to <body> so position:fixed resolves
+     against the viewport, not the will-change:transform chrome header (see portal.ts).
+     display:contents collapses the wrapper in the layout — it establishes NO containing
+     block of its own (no transform, filter, will-change, or contain). */
+  .gear-sheet-portal {
+    display: contents;
   }
   /* Scrim: sits below the mobile bottom sheet (z 49) but above app content.
      Uses the canonical .scrim primitive (dim + blur) from app.css. */


### PR DESCRIPTION
## Problem

On mobile the gear menu's bottom sheet rendered clipped at the **top** of the screen — only the tail rows (Settings, README & docs, version) were visible; theme/usage/diagnose/updates/etc. were pushed off-screen. Reported on Android (see screenshot in the issue), but it affects the mobile **list** screen on any phone.

## Root cause

PR #760 ("declutter mobile PWA header", #720) introduced, in the same commit, both:

1. the mobile gear **bottom sheet** + backdrop in `TopBar.svelte` — `.gear-sheet` (`position: fixed; bottom: 0`) and `.menu-scrim` (`position: fixed`), rendered inside `<header class="chrome">`; and
2. scroll-compress on the list header — `.shell.mobile.list .chrome { will-change: transform }` (`+page.svelte`).

`will-change: transform` (like `transform`/`filter`) establishes a **containing block** for `position: fixed` descendants, so the sheet's `bottom: 0` resolved against the short, top-pinned chrome box instead of the viewport — clipping it to the top and trapping the scrim to the same box. This is exactly the failure mode `ui/src/lib/portal.ts` was written to fix.

The trigger is scoped to `.shell.mobile.list .chrome` (the only transformed ancestor); desktop and the mobile detail screen are unaffected.

## Fix

Wrap the scrim + sheet in a `display: contents` wrapper carrying the existing `use:portal` action, re-parenting them to `<body>` so `position: fixed` resolves against the viewport again. `transition:fly` and `use:dialog` stay on the inner `.gear-sheet` — portal on the wrapper, transition/dialog on the child — so the close outro plays to completion before teardown (mirrors the `PlanPanel` precedent). Removing `will-change` was not viable: `.chrome-hidden`'s `transform` would still trap `position: fixed` once the header scrolls away.

The large `TopBar.svelte` diff is almost entirely re-indentation from the one new wrapper level.

## Tests

- New browser regression test renders TopBar inside a `will-change: transform` container (reproducing `.chrome`), opens the sheet, and asserts both that it **escapes** the transformed ancestor (`container.contains(sheet) === false`) and that it **spans to the viewport bottom** (`rect.bottom >= innerHeight - 2`). Both assertions fail on pre-fix code.
- Existing `dismissOnOutside` regression test still passes.
- `cd ui && bun run check` clean; full UI suite green (1535/1535).

## Verification note

Behavioral verification (fly outro → node removal, Esc focus-restore, scrim/✕ close, all at `<body>`) was covered by the real-browser (vitest browser-mode) tests and confirmed via code review of `use:dialog`/`portal`; an interactive `agent-browser` walkthrough wasn't run because that tool isn't installed in this environment. The change is behavior-preserving (only re-parenting; the transition + dialog nodes are byte-identical).

[no-feature-entry] — bug fix, no new user-facing feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)