### PR TITLE
fix(ui): armed decommission solid-fill, drop crammed "?" adornment

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -349,7 +349,6 @@ button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 2px; /* for the armed decom "?" adornment beside the SVG */
   width: var(--icon-btn-hit);
   height: var(--icon-btn-hit);
   padding: 0;

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -427,3 +427,91 @@ describe("Viewport mobile page-swipe scoping", () => {
     expect(onnavigate).not.toHaveBeenCalled();
   });
 });
+
+// ── Armed decommission icon-only: solid red fill, no "?" adornment (#776 fix) ──
+// Regression guard: the three icon-only decom buttons must NOT render a
+// .decom-confirm child when armed, and the armed button must have a solid red
+// background (not the faint tint of .decom.armed, which is overridden by
+// .decom.icon-btn.armed for the icon-only forms).
+describe("Viewport armed decommission icon-only rendering", () => {
+  it("armed compact decom button has no .decom-confirm child and has solid red background", async () => {
+    // mobile=true + readyToMerge=false → the git-strip icon-only decom button renders.
+    // Viewport.svelte CSS is scoped; app.css (imported at test top) provides tokens.
+    const { container } = render(Viewport, {
+      session: session({ id: "dc-compact", readyToMerge: false }),
+      mobile: true,
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+
+    // Find the compact decom button
+    const decomBtn = container.querySelector<HTMLButtonElement>("button.decom.icon-btn.compact");
+    expect(decomBtn, "compact decom button should render").not.toBeNull();
+
+    // Pre-arm: no .decom-confirm child
+    expect(decomBtn!.querySelector(".decom-confirm"), "no .decom-confirm before arming").toBeNull();
+
+    // Arm it: direct DOM click (same pattern as stop-preview test above)
+    decomBtn!.click();
+
+    // Wait for Svelte reactivity to settle and the .armed class to appear
+    await vi.waitFor(() =>
+      expect(decomBtn!.classList.contains("armed"), "button gains .armed class after click").toBe(
+        true,
+      ),
+    );
+
+    // After arming: still no .decom-confirm child (the "?" adornment must not exist)
+    expect(decomBtn!.querySelector(".decom-confirm"), "no .decom-confirm after arming").toBeNull();
+
+    // Armed state CSS: background resolves to --color-red (solid fill).
+    // Resolve the token value by probing a temp element with color: var(--color-red).
+    const probe = document.createElement("div");
+    probe.style.color = "var(--color-red)";
+    document.body.appendChild(probe);
+    const expectedRgb = getComputedStyle(probe).color;
+    document.body.removeChild(probe);
+
+    // Assert the token actually resolved — fail loudly if the test environment is
+    // misconfigured (rather than silently skipping the solid-fill assertion).
+    expect(
+      expectedRgb && expectedRgb !== "rgba(0, 0, 0, 0)" && expectedRgb !== "",
+      "--color-red must resolve to a real color in the test environment",
+    ).toBe(true);
+    // Wait for the 0.12s CSS transition to complete before sampling the computed style.
+    await vi.waitFor(
+      () => {
+        const bg = getComputedStyle(decomBtn!).backgroundColor;
+        expect(bg, "armed icon-btn decom background is solid --color-red").toBe(expectedRgb);
+      },
+      { timeout: 500 },
+    );
+  });
+
+  it("armed quiet desktop decom button has no .decom-confirm child", async () => {
+    // compact=false + readyToMerge=false → the desktop quiet icon-only decom button
+    const { container } = render(Viewport, {
+      session: session({ id: "dc-quiet", readyToMerge: false }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+
+    const decomBtn = container.querySelector<HTMLButtonElement>("button.decom.quiet.icon-btn");
+    expect(decomBtn, "quiet decom button should render").not.toBeNull();
+
+    // Arm it
+    decomBtn!.click();
+
+    // Wait for .armed class
+    await vi.waitFor(() =>
+      expect(decomBtn!.classList.contains("armed"), "quiet button gains .armed after click").toBe(
+        true,
+      ),
+    );
+
+    expect(
+      decomBtn!.querySelector(".decom-confirm"),
+      "no .decom-confirm after arming quiet form",
+    ).toBeNull();
+  });
+});

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2314,12 +2314,14 @@
           class:compact
           type="button"
           onclick={decommission}
-          title={m.viewport_decommission_ready_title()}
-          aria-label={m.viewport_decommission_ready_aria()}
+          title={armed ? m.viewport_confirm_decommission() : m.viewport_decommission_ready_title()}
+          aria-label={armed
+            ? m.viewport_confirm_decommission()
+            : m.viewport_decommission_ready_aria()}
         >
           {#if compact}
-            <!-- armed = destructive confirm: stay red + interrogative. Never ✓ —
-                 that glyph means READY/actionable-complete elsewhere in the HUD. -->
+            <!-- armed = destructive confirm: the square fills solid red (no glyph
+                 swap). Never ✓ — that glyph means READY/actionable-complete in the HUD. -->
             <svg
               viewBox="0 0 24 24"
               fill="none"
@@ -2329,7 +2331,6 @@
               stroke-linejoin="round"
               aria-hidden="true"><path d="M18 6 6 18" /><path d="M6 6l12 12" /></svg
             >
-            {#if armed}<span class="decom-confirm" aria-hidden="true">?</span>{/if}
           {:else}
             {armed ? m.viewport_confirm_decommission() : m.viewport_decommission()}
           {/if}
@@ -2338,7 +2339,8 @@
         <!-- no PR yet → desktop still keeps decommission one click away, but quiet:
              a faint icon-only ✕ (the green nudge is earned by delivering a PR).
              Compact layouts show the same icon-only ✕ in the git strip instead.
-             Same glyph rule as above: armed = red ✕?, never ✓. -->
+             Same armed treatment as above: the square fills solid red (no glyph
+             swap). Never ✓ — that glyph means READY/actionable-complete. -->
         <button
           class="decom quiet icon-btn"
           class:armed
@@ -2356,7 +2358,6 @@
             stroke-linejoin="round"
             aria-hidden="true"><path d="M18 6 6 18" /><path d="M6 6l12 12" /></svg
           >
-          {#if armed}<span class="decom-confirm" aria-hidden="true">?</span>{/if}
         </button>
       {/if}
     </div>
@@ -2426,7 +2427,6 @@
               stroke-linejoin="round"
               aria-hidden="true"><path d="M18 6 6 18" /><path d="M6 6l12 12" /></svg
             >
-            {#if armed}<span class="decom-confirm" aria-hidden="true">?</span>{/if}
           </button>
         {/if}
       </span>
@@ -3194,13 +3194,6 @@
     text-transform: uppercase;
     padding: 2px 7px;
   }
-  /* ? adornment inherits the armed red via currentColor; centered by recipe flex + gap */
-  .decom-confirm {
-    color: currentColor;
-    font-size: var(--fs-meta);
-    line-height: 1;
-  }
-
   /* Resume: the primary action of a parked session, so it stays on the identity
      row (not in the strip). Quiet neutral (not destructive, not "ready-complete"
      → no green/red), brightening to ink on hover. */
@@ -3296,6 +3289,17 @@
     color: var(--color-red);
     border-color: var(--color-red);
     background: color-mix(in srgb, var(--color-red) 12%, transparent);
+  }
+
+  /* Icon-only armed decom: no "?" adornment (the square has no room for it); the
+     armed/destructive-confirm state reads as a solid red fill instead. Scoped to
+     .icon-btn so the labeled "confirm ✕" text form keeps its faint-red treatment. */
+  .decom.icon-btn.armed {
+    background: var(--color-red);
+    border-color: var(--color-red);
+    /* knockout ✕ in the surface color — clears WCAG ≥3:1 non-text contrast on the
+       red fill in all four themes (ink-bright fails the high-contrast themes). */
+    color: var(--color-bg);
   }
 
   /* quiet variant: pre-PR desktop inline ✕. Now an .icon-btn — sizing/padding

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -244,7 +244,6 @@ input, select, textarea {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 2px; /* for the armed decom "?" adornment beside the SVG */
   width: var(--icon-btn-hit);    /* 28px — desktop square hit area */
   height: var(--icon-btn-hit);
   padding: 0;
@@ -462,7 +461,7 @@ input, select, textarea {
         type="button"
         class="icon-btn"
         aria-label="Decommission (confirm)"
-        style="color: var(--color-red)"
+        style="background: var(--color-red); border-color: var(--color-red); color: var(--color-bg)"
       >
         <svg
           viewBox="0 0 24 24"
@@ -474,7 +473,7 @@ input, select, textarea {
           aria-hidden="true"
         >
           <path d="M18 6 6 18" /><path d="M6 6l12 12" />
-        </svg><span aria-hidden="true" style="font-size: var(--fs-meta); line-height: 1">?</span>
+        </svg>
       </button>
       <button type="button" class="icon-btn" aria-label="Upload">
         <svg


### PR DESCRIPTION
## Problem

The armed decommission button rendered as a misshapen red box — an 18px SVG `✕` with an 11px `?` span crammed into a rigid square.

**Recent regression from PR #776** (`de04bd8b`, "shared `.icon-btn` recipe"): it moved the three *icon-only* decommission forms onto the fixed-size `.icon-btn` square (28px / 44px) but kept bolting a separate `?` adornment beside the 18px SVG `✕` — which never fit. Before #776 the armed state was the literal text `✕?` in an auto-width pill, so it sat fine. (The catalog word-mark `confirm ✕` only ever drove the *labeled* desktop form, which was unaffected.)

## Fix (Option C — chosen by maintainer after reviewing rendered options)

Three candidate treatments (uniform-text `✕?` pill, keep-SVG-enlarge-`?` pill, drop-`?`-solid-fill) were rendered live and the maintainer selected **drop the `?`, solid red fill**:

- **Drop** all three `{#if armed}…?…{/if}` spans; the armed `✕` SVG stays.
- Armed state now reads as a **solid red fill**, scoped to `.decom.icon-btn.armed` so the labeled `confirm ✕` text form keeps its existing faint-red tint.
- **A11y**: the prReady-compact button's `title`/`aria-label` are now armed-aware (`confirm`) so the armed state isn't conveyed by color alone.
- **Glyph contrast**: the `✕` knocks out in `var(--color-bg)`. (Initial `--color-ink-bright` failed WCAG ≥3:1 non-text contrast in the two high-contrast themes — 2.52 / 2.66; `--color-bg` clears it in all four: 4.99 / 4.49 / 7.75 / 6.57.)
- **Parity**: updated the `/design-system` armed-decom demo to match; removed the now-orphaned `.decom-confirm` rule and the stale `gap`/comment from the `.icon-btn` recipe in both `app.css` and the design-system mirror.

## Verification

- New browser tests in `Viewport.browser.test.ts`: after arming, the icon-only decom button has **no** `.decom-confirm` child and a computed background equal to `--color-red` (token resolution asserted, fails loudly — no silent skip).
- `bun run check` (0 errors), `check:i18n` (parity, no new keys), feature-catalog + branch-hygiene gates, full UI test suite — all green.
- Visual sign-off across all four themes (default/light × normal/high-contrast), desktop 28px + compact 44px: clean solid-red square with legible knockout `✕`, resting state and dimensions unchanged, labeled form untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)