### PR TITLE
fix(ui): tidy learnings drawer header gap + injected-rule button wrap

### DIFF
--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -339,37 +339,39 @@
                     </span>
                   {/if}
                   <span class="spacer"></span>
-                  {#if showIneffective(r)}
-                    <button
-                      class="optimize"
-                      type="button"
-                      onclick={() => onoptimize(r.id)}
-                      aria-label={m.learnings_optimize_aria()}
-                    >
-                      {m.learnings_optimize()}
-                    </button>
-                  {/if}
-                  {#if r.status === "active"}
-                    <button class="dismiss" onclick={() => ondismiss(r.id)}>
-                      {m.learnings_dismiss()}
-                    </button>
-                    <button
-                      class="promote"
-                      onclick={() => onpromote(r.id)}
-                      aria-label={m.learnings_promote_aria()}
-                    >
-                      {m.learnings_promote()}
-                    </button>
-                  {:else if r.status === "promoted" && r.promotedPrUrl}
-                    <a
-                      class="prlink"
-                      href={r.promotedPrUrl}
-                      target="_blank"
-                      rel="noopener external"
-                    >
-                      {m.learnings_promoted_pr()}
-                    </a>
-                  {/if}
+                  <div class="iactions">
+                    {#if showIneffective(r)}
+                      <button
+                        class="optimize"
+                        type="button"
+                        onclick={() => onoptimize(r.id)}
+                        aria-label={m.learnings_optimize_aria()}
+                      >
+                        {m.learnings_optimize()}
+                      </button>
+                    {/if}
+                    {#if r.status === "active"}
+                      <button class="dismiss" onclick={() => ondismiss(r.id)}>
+                        {m.learnings_dismiss()}
+                      </button>
+                      <button
+                        class="promote"
+                        onclick={() => onpromote(r.id)}
+                        aria-label={m.learnings_promote_aria()}
+                      >
+                        {m.learnings_promote()}
+                      </button>
+                    {:else if r.status === "promoted" && r.promotedPrUrl}
+                      <a
+                        class="prlink"
+                        href={r.promotedPrUrl}
+                        target="_blank"
+                        rel="noopener external"
+                      >
+                        {m.learnings_promoted_pr()}
+                      </a>
+                    {/if}
+                  </div>
                 </div>
               </article>
             {/each}
@@ -404,6 +406,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 8px;
   }
   .title {
     letter-spacing: 0.14em;
@@ -730,6 +733,15 @@
     line-height: 1.5;
   }
   .ifoot {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  /* Action group stays together as one flex item so it wraps as a unit
+     (never fragmenting Optimize/Dismiss/Promote across lines) when the
+     badge row runs out of room in the narrow drawer. */
+  .iactions {
     display: flex;
     align-items: center;
     gap: 6px;


### PR DESCRIPTION
## What

Two cosmetic fixes in the Learnings drawer (`LearningsDrawer.svelte`):

1. **Close `✕` had no breathing room** — when the "Not working / Show all" filter-toggle is present it sat flush against the close button. Added `gap: 8px` to the header `.bar`.
2. **Injected-rule action buttons wrapped ugly** — the footer packed a status chip, injection/ineffective badges, and the Optimize / Dismiss / Promote actions into one no-wrap row that overflowed and fragmented in the ~520px drawer. The actions are now grouped in a `.iactions` wrapper and `.ifoot` is `flex-wrap`, so the action group drops to its own line as a unit instead of splitting mid-group.

CSS + one wrapper `<div>` only. No new strings, no token/literal changes, no behavior change.

## Verification

- `cd ui && bun run check` → 0 errors, 0 warnings.
- Visually confirmed in the running app: `✕` clears the filter-toggle; the flagged rule's `Optimize/Dismiss/Promote` group wraps cleanly to its own line, the non-flagged rule keeps `Dismiss/Promote` right-aligned on one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)