### PR TITLE
fix(ui): expand collapsed build queue on click anywhere in header

### DIFF
--- a/ui/src/lib/components/BuildQueuePanel.browser.test.ts
+++ b/ui/src/lib/components/BuildQueuePanel.browser.test.ts
@@ -343,4 +343,33 @@ describe("BuildQueuePanel — collapse/expand", () => {
       .element(page.getByRole("textbox", { name: `${m.buildqueue_step_title_aria()} 1` }))
       .toBeVisible();
   });
+
+  it("clicking the header anywhere (not just the ▴ glyph) expands a collapsed queue", async () => {
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: curationQueue,
+      onbootstrap: noop,
+    });
+
+    buildQueueCollapse.set(true);
+    await expect
+      .poll(() => document.querySelector<HTMLElement>(".bqp-content.collapsed"))
+      .toBeTruthy();
+
+    // Click the title label — NOT the ▴ glyph. The whole header is the toggle
+    // button, so a click anywhere on the bar bubbles to it and expands.
+    (document.querySelector(".bqp-title") as HTMLElement).click();
+
+    await expect
+      .poll(() =>
+        document
+          .querySelector<HTMLButtonElement>("button.bqp-collapse-toggle")
+          ?.getAttribute("aria-expanded"),
+      )
+      .toBe("true");
+    await expect
+      .poll(() => document.querySelector<HTMLElement>(".bqp-content")?.offsetParent)
+      .not.toBeNull();
+  });
 });

--- a/ui/src/lib/components/BuildQueuePanel.svelte
+++ b/ui/src/lib/components/BuildQueuePanel.svelte
@@ -139,26 +139,28 @@
 
 {#if visible}
   <div class="bqp" role="region" aria-label={m.buildqueue_panel_title()}>
-    <div class="bqp-head">
+    <button
+      type="button"
+      class="bqp-head bqp-collapse-toggle"
+      onclick={() => buildQueueCollapse.toggle()}
+      aria-expanded={!buildQueueCollapse.collapsed}
+      aria-controls={contentId}
+      aria-label={buildQueueCollapse.collapsed
+        ? m.buildqueue_expand_aria()
+        : m.buildqueue_collapse_aria()}
+      title={buildQueueCollapse.collapsed
+        ? m.buildqueue_expand_aria()
+        : m.buildqueue_collapse_aria()}
+      use:coachTarget={"build-queue-collapse"}
+    >
       <span class="bqp-title">{m.buildqueue_panel_title()}</span>
       {#if approved && steps.length > 0}
         <span class="bqp-approved">{m.buildqueue_approved_header()}</span>
       {/if}
-      <button
-        type="button"
-        class="bqp-btn bqp-collapse-toggle"
-        onclick={() => buildQueueCollapse.toggle()}
-        aria-expanded={!buildQueueCollapse.collapsed}
-        aria-controls={contentId}
-        aria-label={buildQueueCollapse.collapsed
-          ? m.buildqueue_expand_aria()
-          : m.buildqueue_collapse_aria()}
-        title={buildQueueCollapse.collapsed
-          ? m.buildqueue_expand_aria()
-          : m.buildqueue_collapse_aria()}
-        use:coachTarget={"build-queue-collapse"}>{buildQueueCollapse.collapsed ? "▴" : "▾"}</button
+      <span class="bqp-collapse-glyph" aria-hidden="true"
+        >{buildQueueCollapse.collapsed ? "▴" : "▾"}</span
       >
-    </div>
+    </button>
 
     <div class="bqp-content" id={contentId} class:collapsed={buildQueueCollapse.collapsed}>
       {#if steps.length === 0}
@@ -282,11 +284,25 @@
     font-size: var(--fs-meta);
   }
 
+  /* The whole header is the collapse toggle (mirrors IntegratedEpicRow's
+     .row-head), so a click anywhere on the bar expands/collapses — not just
+     the ▴/▾ glyph. Button reset; the glyph keeps its boxed look below. */
   .bqp-head {
     display: flex;
     align-items: center;
     gap: 8px;
     flex-shrink: 0;
+    width: 100%;
+    padding: 0;
+    border: 0;
+    background: none;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+  .bqp-head:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
   }
 
   .bqp-title {
@@ -305,8 +321,22 @@
     color: var(--color-amber);
   }
 
-  .bqp-collapse-toggle {
+  /* The ▴/▾ glyph: pushed to the right edge, styled like the boxed toggle it
+     replaced; brightens when the header is hovered/focused. */
+  .bqp-collapse-glyph {
     margin-left: auto;
+    flex: none;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-size: var(--fs-micro);
+    line-height: 1.4;
+    padding: 1px 5px;
+  }
+  .bqp-head:hover .bqp-collapse-glyph,
+  .bqp-head:focus-visible .bqp-collapse-glyph {
+    color: var(--color-ink-bright);
+    border-color: var(--color-ink);
   }
 
   .bqp-content {


### PR DESCRIPTION
## What

The collapsed build-queue bar now expands (and collapses) on a click **anywhere on the header**, not just on the small ▴/▾ glyph.

## How

`.bqp-head` is now the collapse toggle `<button>` itself — mirroring the canonical sibling pattern (`IntegratedEpicRow`'s `.row-head`, `SessionRecap`'s header). The title/approved labels and the glyph live inside it; a click on any of them bubbles to the button's existing `toggle()`. The glyph keeps its boxed look and brightens on header hover/focus; all existing a11y (`aria-expanded`/`aria-controls`/`aria-label`) and the `build-queue-collapse` coachmark target move onto the header button.

No new i18n keys (reuses `buildqueue_*` messages); no new feature — refinement of existing build-queue collapse UX.

## Test

- Added a `BuildQueuePanel` browser test: with the queue collapsed, clicking the title label (not the glyph) flips `aria-expanded` to `true` and reveals the content.
- `cd ui && bun run check` clean; full UI suite green (1536 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)