### PR TITLE
fix(ui): usage gauge goes red above 90%

### DIFF
--- a/DESIGN.json
+++ b/DESIGN.json
@@ -235,7 +235,7 @@
     "rules": [
       {
         "name": "The Four-Light Rule",
-        "body": "Status speaks in exactly four colors: amber (working), green (done/ready), red (blocked), slate (idle). These hues are reserved for state; no decorative element may borrow a status color.",
+        "body": "Status speaks in exactly four colors: amber (working), green (done/ready), red (blocked), slate (idle). These hues are reserved for state; no decorative element may borrow a status color. Narrow exception: the usage-limit gauge may go red when pct > 90 as a bar-fill/text-only signal (no halo, no status pip), so a blocked agent's red pip remains the loudest red on screen.",
         "section": "colors"
       },
       {
@@ -266,11 +266,11 @@
     ],
     "dos": [
       "Do keep everything in Berkeley Mono. Build hierarchy from size, weight, case, and ink brightness (Faint Moss -> Muted Sage -> Phosphor Ink -> Bright Phosphor).",
-      "Do reserve the four status colors (amber / green / red / slate) strictly for agent state.",
+      "Do reserve the four status colors (amber / green / red / slate) strictly for agent state. Exception: the usage-limit gauge may show red when pct > 90 as a bar-fill/text-only signal (see Four-Light Rule).",
       "Do build depth with tonal layering and 1px hairlines (inset < panel-2 < panel < head).",
       "Do keep structural panels square (0 radius) and reserve the 2px radius for buttons and chips; 12px is only for rising bottom sheets.",
       "Do use tabular figures for any number that updates in place.",
-      "Do keep the screen calm at rest and make the blocked (red) state the loudest thing on it.",
+      "Do keep the screen calm at rest and make the blocked (red) state the loudest thing on it. The usage-gauge red (bar-fill/text-only, no halo/pip) is subordinate — a blocked pip stays the loudest red on screen.",
       "Do pair every status color with a non-color cue (position, pulse, check glyph, or label), and keep touch targets thumb-reachable; phone steering is first-class."
     ],
     "donts": [

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -141,7 +141,7 @@ A desaturated, green-tinted monochrome ground with four reserved status accents.
 
 ### Named Rules
 
-**The Four-Light Rule.** Status speaks in exactly four colors: amber (working), green (ready / actionable-complete), red (blocked), slate (idle / parked, including a WAITING agent awaiting its next steer). These hues are reserved for state. No decorative element may borrow a status color, or it dilutes the only signal that must never be missed. Green is spent only on a ready-to-ship session, never on a merely finished turn — so a parked agent reads quiet, not "done, ignore me."
+**The Four-Light Rule.** Status speaks in exactly four colors: amber (working), green (ready / actionable-complete), red (blocked), slate (idle / parked, including a WAITING agent awaiting its next steer). These hues are reserved for state. No decorative element may borrow a status color, or it dilutes the only signal that must never be missed. Green is spent only on a ready-to-ship session, never on a merely finished turn — so a parked agent reads quiet, not "done, ignore me." **Narrow exception — usage gauge:** the usage-limit bar may go red when `pct > 90` (approaching cap) as a bar-fill/text-only signal; it carries no halo or status pip, so a blocked agent's red pip remains the loudest red on screen. Red stays fully reserved for blocked agent state in all other UI elements.
 
 **The Quiet Ground Rule.** The surface is desaturated green-black; visible chroma stays at or below ~10% of any screen, spent on status lights and the one amber action. If the screen looks colorful at rest, color has leaked out of its lane.
 
@@ -233,11 +233,11 @@ Shadows are permitted in exactly one situation: a summoned overlay. Bottom sheet
 ### Do:
 
 - **Do** keep everything in Berkeley Mono. Build hierarchy from size, weight, case, and ink brightness (Faint Moss -> Muted Sage -> Phosphor Ink -> Bright Phosphor).
-- **Do** reserve the four status colors (amber / green / red / slate) strictly for agent state. The Four-Light Rule is the most important rule in the system.
+- **Do** reserve the four status colors (amber / green / red / slate) strictly for agent state. The Four-Light Rule is the most important rule in the system. Exception: the usage-limit gauge may show red when `pct > 90` as a bar-fill/text-only signal (see Four-Light Rule above).
 - **Do** build depth with tonal layering and 1px hairlines (inset < panel-2 < panel < head). If a panel needs separation, step the value or brighten the hairline.
 - **Do** keep structural panels square (0 radius) and reserve the 2px radius for buttons and chips; 12px is only for rising bottom sheets.
 - **Do** use tabular figures for any number that updates in place.
-- **Do** keep the screen calm at rest and make the blocked (red) state the loudest thing on it. Spend attention only on what is actionable.
+- **Do** keep the screen calm at rest and make the blocked (red) state the loudest thing on it. The usage-gauge red (bar-fill/text-only, no halo/pip) is subordinate to this — a blocked pip remains the loudest red on screen. Spend attention only on what is actionable.
 - **Do** pair every status color with a non-color cue (position, pulse, check glyph, or label), and keep touch targets thumb-reachable; phone steering is first-class.
 
 ### Don't:

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -8,7 +8,7 @@
   } from "$lib/types";
   import { formatReset, formatResetIn, relativeAge } from "$lib/format";
   import { displayStatus } from "$lib/display-status";
-  import { gaugeList, hotterGauge, overspending, type GaugeKey } from "./usage-gauges";
+  import { gaugeList, hotterGauge, overspending, gaugeColor, type GaugeKey } from "./usage-gauges";
   import { refreshUsage } from "$lib/api";
   import { m } from "$lib/paraglide/messages";
   import { modeOf, topBarPlan, badgeCount } from "./top-bar-layout";
@@ -234,12 +234,9 @@
     connected ? m.topbar_clock_tip_connected() : m.topbar_clock_tip_disconnected(),
   );
 
-  // Two-step ladder: neutral muted fill at rest, amber once the window runs hot.
-  // Usage level is telemetry, not agent state — red stays reserved for "blocked,
-  // needs you" and green for "ready to ship" (Four-Light Rule, DESIGN.md).
-  function gaugeColor(pct: number): string {
-    return pct >= 90 ? "var(--color-amber)" : "var(--color-muted)";
-  }
+  // Three-step ladder (usage-gauges.ts): muted at rest, amber 75–90 (warming),
+  // red >90 (approaching cap). Red is a documented Four-Light exception — gauge
+  // bar-fill/text only (no halo/pip), so blocked pip stays the loudest red on screen.
 
   const periodLabel = (k: GaugeKey) =>
     k === "5H" ? m.topbar_gauge_period_5h() : m.topbar_gauge_period_weekly();
@@ -278,9 +275,10 @@
       ? `${credits.currency}${credits.spent.toFixed(2)} / ${credits.currency}${credits.cap.toFixed(2)}`
       : "",
   );
-  // Alert hue: amber is the design system's caution token (reused by the usage
-  // gauges' hot state + the update badge). pct is 0 here so gaugeColor(pct) can't
-  // drive it — overspend keys off real spend instead. Stale → muted; idle → neutral.
+  // Alert hue: amber is the design system's caution token (also used by the update
+  // badge). The usage gauges now go red >90 (see gaugeColor); amber is their 75–90
+  // warning tier. pct is 0 here so gaugeColor(pct) can't drive it — overspend keys
+  // off real spend instead. Stale → muted; idle → neutral.
   const creditColor = $derived(
     credits?.stale ? "var(--color-muted)" : overspend ? "var(--color-amber)" : "var(--color-muted)",
   );

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -16,7 +16,7 @@
   import { STATUS_COLOR, statusLabel, formatTokens, canResume } from "$lib/format";
   import { displayStatus } from "$lib/display-status";
   import { projectIcons } from "$lib/projectIcons.svelte";
-  import { hotterGauge } from "./usage-gauges";
+  import { hotterGauge, gaugeColor } from "./usage-gauges";
   import { connectPty, type PtyConn } from "$lib/pty";
   import { theme, xtermTheme, xtermMinContrast } from "$lib/theme.svelte";
   import { tick } from "svelte";
@@ -387,12 +387,9 @@
     const h = hotterGauge(limits);
     return h && h.w.pct >= 70 ? h : null;
   });
-  // Two-step ladder shared with TopBar: neutral muted fill at rest, amber once
-  // the window runs hot — usage is telemetry, so red/green stay status-only
-  // (Four-Light Rule, DESIGN.md).
-  function gaugeColor(pct: number): string {
-    return pct >= 90 ? "var(--color-amber)" : "var(--color-muted)";
-  }
+  // Three-step ladder shared with TopBar (usage-gauges.ts): muted at rest, amber
+  // 75–90 (warming), red >90 (approaching cap). Documented Four-Light exception —
+  // bar-fill/text only (no halo/pip), blocked pip stays the loudest red on screen.
 
   // "needs you" queue paging: only on compact layouts (the list isn't visible there),
   // and only when more than one session waits. Wraps around so ‹/› always advance.

--- a/ui/src/lib/components/usage-gauges.test.ts
+++ b/ui/src/lib/components/usage-gauges.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { gaugeList, hotterGauge, overspending } from "./usage-gauges";
+import { gaugeList, hotterGauge, overspending, gaugeColor } from "./usage-gauges";
 import type { UsageLimits, LimitWindow, CreditWindow } from "../types";
 
 function w(pct: number, resetAt = 0): LimitWindow {
@@ -64,6 +64,27 @@ describe("hotterGauge", () => {
   it("returns the only present window", () => {
     expect(hotterGauge(limits({ session5h: w(40) }))?.label).toBe("5H");
     expect(hotterGauge(limits({ week: w(40) }))?.label).toBe("WK");
+  });
+});
+
+describe("gaugeColor", () => {
+  it("0 → muted", () => {
+    expect(gaugeColor(0)).toBe("var(--color-muted)");
+  });
+  it("74 → muted", () => {
+    expect(gaugeColor(74)).toBe("var(--color-muted)");
+  });
+  it("75 → amber", () => {
+    expect(gaugeColor(75)).toBe("var(--color-amber)");
+  });
+  it("90 → amber", () => {
+    expect(gaugeColor(90)).toBe("var(--color-amber)");
+  });
+  it("91 → red", () => {
+    expect(gaugeColor(91)).toBe("var(--color-red)");
+  });
+  it("100 → red", () => {
+    expect(gaugeColor(100)).toBe("var(--color-red)");
   });
 });
 

--- a/ui/src/lib/components/usage-gauges.ts
+++ b/ui/src/lib/components/usage-gauges.ts
@@ -26,6 +26,17 @@ export function hotterGauge(limits: UsageLimits | null): Gauge | null {
   return gauges.reduce((hot, g) => (g.w.pct >= hot.w.pct ? g : hot));
 }
 
+/** Usage-gauge fill/text color. Three-step ladder: muted at rest, amber as the window
+ *  warms (75–90), red once it runs critically hot (>90). Red here is a deliberate,
+ *  documented exception to the Four-Light Rule (DESIGN.md / DESIGN.json) — usage telemetry
+ *  near cap is an operator-attention signal, but it stays a bar-fill/text hue only (no halo,
+ *  no status pip) so a blocked agent's red pip remains the loudest red on screen. */
+export function gaugeColor(pct: number): string {
+  if (pct > 90) return "var(--color-red)";
+  if (pct >= 75) return "var(--color-amber)";
+  return "var(--color-muted)";
+}
+
 /** True when paid extra-credit spend is actually happening on a fresh snapshot — the signal that
  *  drives the elevated alert. Keyed off `spent` (pct rounds to 0 while money is already spent) and
  *  gated on freshness so a stale snapshot never raises a false alarm. */


### PR DESCRIPTION
## What

The usage-limit gauges (5H / weekly windows in the top bar + the viewport-header inline gauge) previously went **amber at ≥90%** and muted below. They now use a three-step ladder:

| pct       | fill / text          |
| --------- | -------------------- |
| `> 90`    | `var(--color-red)`   |
| `75 – 90` | `var(--color-amber)` |
| `< 75`    | `var(--color-muted)` |

Red is strictly `>90`; `90` stays amber. The amber `75–90` warning tier is new (previously only muted below 90).

## Why / design note

This deliberately **overrides the Four-Light Rule** (red reserved for blocked agent state — DESIGN.md's "most important rule"). Operator-confirmed. The exception is documented in **both** `DESIGN.md` and `DESIGN.json` (hand-maintained mirrors, kept in lockstep here), and scoped narrowly: the gauge red is **bar-fill/text-only** (no halo, no status pip), so a blocked agent's red pip remains the loudest red on screen.

## How

- Extracts `gaugeColor` into the shared `ui/src/lib/components/usage-gauges.ts` (it was duplicated verbatim in `TopBar.svelte` and `Viewport.svelte` — both now import it; single source of truth, no drift).
- Adds `gaugeColor` boundary unit tests (`74→muted, 75→amber, 90→amber, 91→red`, + `0`/`100` anchors).
- Updates the stale `creditColor` comment in `TopBar.svelte` (amber is no longer the usage gauges' hot state).
- Credit/overage gauge behavior unchanged (its alert color is CSS-driven via `overspending`, not `gaugeColor`).

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- `cd ui && bun run test` → 1541/1541 pass (incl. the 6 new gaugeColor tests)
- Color-only change: no new strings (i18n parity unaffected); `fix(ui):` so the feature-catalog gate correctly stays disarmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)