### PR TITLE
fix(sandbox): carve out writable session-env so critic Bash/git works under bwrap

### DIFF
--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -143,7 +143,16 @@ export function detectBackend(deps: BackendProbeDeps = {}): SandboxBackend {
   };
   const flags = buildMembraneFlags(membrane, deps);
   // chain `node --version && git --version` inside the sandbox via /bin/sh -c.
-  const probe = run("bwrap", [...flags, "--", "/bin/sh", "-c", "node --version && git --version"]);
+  // The mkdir exercises the session-env carve-out specifically: if the --tmpfs for
+  // session-env is missing/regressed, the mkdir hits EROFS and the probe exits non-zero,
+  // degrading the backend to null and surfacing the regression loudly.
+  const probe = run("bwrap", [
+    ...flags,
+    "--",
+    "/bin/sh",
+    "-c",
+    `node --version && git --version && mkdir -p '${claudeDir}/session-env/.shepherd-probe'`,
+  ]);
 
   _backendCache = probe.status === 0 ? "bwrap" : null;
   return _backendCache;
@@ -353,6 +362,13 @@ export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps =
     "--bind-try",
     `${claudeDir}/shell-snapshots`,
     `${claudeDir}/shell-snapshots`,
+    // session-env: claude 2.1.181+ mkdirs `<config-dir>/session-env/<id>` before EVERY
+    // Bash command. A tmpfs (not a host bind) makes it writable + ephemeral per-session
+    // scratch — no host pollution. MUST sit AFTER claudeDirBaseBinds so it overrides both
+    // the subscription whole-dir `--ro-bind` and the api-key maskCredentials per-child
+    // `--ro-bind-try` of session-env (else the mkdir fails EROFS and Bash dies).
+    "--tmpfs",
+    `${claudeDir}/session-env`,
     // OAuth credential: rw bind (subscription) or nothing (api-key mask: absent).
     ...credentialFlags,
     // RW persisted: trust/onboarding state (else non-interactive auto hangs on onboarding).

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -335,12 +335,14 @@ describe("buildMembraneFlags", () => {
 
   test("tmpfs over /tmp and home", () => {
     const f = buildMembraneFlags(fakeMembrane(), detDeps);
-    const ti = f.indexOf("--tmpfs");
-    expect(ti).toBeGreaterThanOrEqual(0);
-    expect(f).toContain("/tmp");
-    // home tmpfs
-    const idx = f.lastIndexOf("--tmpfs");
-    expect([f[ti + 1], f[idx + 1]]).toContain("/home/me");
+    // collect all --tmpfs targets
+    const tmpfsTargets: string[] = [];
+    for (let i = 0; i + 1 < f.length; i++) {
+      const target = f[i + 1];
+      if (f[i] === "--tmpfs" && target) tmpfsTargets.push(target);
+    }
+    expect(tmpfsTargets).toContain("/tmp");
+    expect(tmpfsTargets).toContain("/home/me");
   });
 
   test("proc + dev present", () => {
@@ -561,6 +563,82 @@ describe("buildMembraneFlags", () => {
     expect(hasTriple(f, "--ro-bind-try", "/h/x.sh", "/h/x.sh")).toBe(true);
   });
 
+  test("session-env tmpfs carve-out present in subscription mode", () => {
+    const f = buildMembraneFlags(fakeMembrane(), detDeps);
+    const claudeDir = "/home/me/.claude";
+    // --tmpfs <claudeDir>/session-env must be present
+    let found = false;
+    for (let i = 0; i + 1 < f.length; i++) {
+      if (f[i] === "--tmpfs" && f[i + 1] === `${claudeDir}/session-env`) {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+  });
+
+  test("session-env tmpfs appears AFTER the claudeDir RO base bind (overrides it)", () => {
+    const f = buildMembraneFlags(fakeMembrane(), detDeps);
+    const claudeDir = "/home/me/.claude";
+    // find index of the whole-dir RO base bind (subscription mode)
+    let baseBindIdx = -1;
+    for (let i = 0; i + 2 < f.length; i++) {
+      if (f[i] === "--ro-bind" && f[i + 1] === claudeDir && f[i + 2] === claudeDir) {
+        baseBindIdx = i;
+        break;
+      }
+    }
+    expect(baseBindIdx).toBeGreaterThanOrEqual(0);
+    // find index of the session-env tmpfs
+    let sessionEnvIdx = -1;
+    for (let i = 0; i + 1 < f.length; i++) {
+      if (f[i] === "--tmpfs" && f[i + 1] === `${claudeDir}/session-env`) {
+        sessionEnvIdx = i;
+        break;
+      }
+    }
+    expect(sessionEnvIdx).toBeGreaterThan(baseBindIdx);
+  });
+
+  test("maskCredentials: session-env tmpfs still present and after per-child RO bind-try of session-env", () => {
+    const f = buildMembraneFlags(fakeMembrane({ maskCredentials: true }), {
+      ...detDeps,
+      readdir: () => [
+        ".credentials.json",
+        "skills",
+        "settings.json",
+        "projects",
+        "statsig",
+        "session-env",
+      ],
+    });
+    const claudeDir = "/home/me/.claude";
+    // session-env tmpfs must still be present
+    let tmpfsIdx = -1;
+    for (let i = 0; i + 1 < f.length; i++) {
+      if (f[i] === "--tmpfs" && f[i + 1] === `${claudeDir}/session-env`) {
+        tmpfsIdx = i;
+        break;
+      }
+    }
+    expect(tmpfsIdx).toBeGreaterThanOrEqual(0);
+    // per-child RO bind-try for session-env emitted by maskedClaudeDirBinds
+    let perChildIdx = -1;
+    for (let i = 0; i + 2 < f.length; i++) {
+      if (
+        f[i] === "--ro-bind-try" &&
+        f[i + 1] === `${claudeDir}/session-env` &&
+        f[i + 2] === `${claudeDir}/session-env`
+      ) {
+        perChildIdx = i;
+        break;
+      }
+    }
+    expect(perChildIdx).toBeGreaterThanOrEqual(0);
+    // tmpfs must come AFTER the per-child bind so it overrides the RO bind
+    expect(tmpfsIdx).toBeGreaterThan(perChildIdx);
+  });
+
   test("apiKeyHelperPath empty/whitespace-guard: empty string => no helper bind", () => {
     const f = buildMembraneFlags(fakeMembrane({ apiKeyHelperPath: "" }), detDeps);
     expect(f.some((x) => x === "")).toBe(false);
@@ -685,6 +763,28 @@ describe("detectBackend (injected run)", () => {
     resetBackendCache();
     detectBackend(deps);
     expect(calls).toBeGreaterThan(after);
+  });
+
+  test("probe argv includes session-env mkdir (exercises the carve-out)", () => {
+    let probeArgs: string[] = [];
+    const deps = {
+      run: (cmd: string, args: string[]) => {
+        if (cmd === "bwrap" && args[0] === "--version") return { status: 0 };
+        probeArgs = args;
+        return { status: 0 };
+      },
+      exists: () => false,
+      home: "/home/me",
+      claudeDir: "/home/me/.claude",
+      nodeBinReal: "/usr/bin/node",
+    };
+    detectBackend(deps);
+    // The /bin/sh -c string must contain both "session-env" and "mkdir"
+    const shCmdIdx = probeArgs.indexOf("-c");
+    expect(shCmdIdx).toBeGreaterThanOrEqual(0);
+    const shCmd = probeArgs[shCmdIdx + 1];
+    expect(shCmd).toContain("session-env");
+    expect(shCmd).toContain("mkdir");
   });
 
   // Regression (#294): with no nodeBinReal dep the default resolves a REAL node


### PR DESCRIPTION
## Problem

The read-only critic / plan-reviewer agent runs inside the `standard` bwrap membrane (`src/sandbox.ts`). The membrane does `--tmpfs \$HOME` then binds `~/.claude` **read-only**, carving out rw exceptions only for `projects`, `todos`, `statsig`, `shell-snapshots`, `.credentials.json`.

Claude Code **2.1.181** (newer than the 2.1.173 the membrane was frozen against) now `mkdir`s a per-Bash-session env dir at `<config-dir-root>/session-env/<id>/` **before running any Bash command**. `session-env` isn't a writable carve-out → the mkdir hits `EROFS: read-only file system` → **every** Bash command dies, including the critic's allowlisted `Bash(git diff *)`. The agent then flails into `HOME=/tmp git diff` workarounds that fall off the allowlist and get dontAsk-denied — banging its head against the sandbox instead of reviewing.

> Note: the critic *briefing* (`critic-core.ts`) was already correct (it tells the agent to run `git diff`, and the tool is allowlisted). The lever is the membrane, not the prompt.

## Fix

- **`buildMembraneFlags`:** add `--tmpfs \${claudeDir}/session-env`, positioned **after** the claude-dir base binds so it overrides both the subscription whole-dir `--ro-bind` and the api-key `maskCredentials` per-child `--ro-bind-try`. A tmpfs (not a host bind) keeps it ephemeral, isolated scratch — no host pollution, no new credential/host-path exposure.
- **`detectBackend` self-test:** extend the probe to `mkdir -p` under session-env, so this specific carve-out regressing fails backend detection loudly (→ `null` → degrade banner) rather than silently breaking every review. Scoped to session-env specifically — it does **not** claim to catch an arbitrary future new dir (a `/bin/sh` probe can't replay a real Bash-tool session); that case is covered by the existing "re-run the repro on each CLI upgrade" cadence.
- **Tests:** assert the carve-out's presence **and ordering/override** in both subscription and `maskCredentials` modes, plus the probe content.

### Why no env-relocation knob
Verified against the 2.1.181 binary: the path is `join(<config-dir-root>, "session-env", <id>)` with `session-env` a hardcoded subdir; the only relocation lever is `CLAUDE_CONFIG_DIR` (moves the whole dir, which must stay bound). So a tmpfs carve-out is the right tool.

## Verification
- `bun run lint`, `bunx tsc --noEmit`, `bun test ./test` green; full pre-push suite + `fallow audit` clean.
- Manual re-verify still warranted (membrane behavior can't be unit-asserted end-to-end): run a live critic review in **both** subscription and api-key auth modes and confirm `git diff` runs without EROFS and `.shepherd-review.json` is written.

[no-feature-entry] — server-side sandbox fix, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)