### PR TITLE
fix(worktree): abort instead of silent non-isolated fallback (#790)

### DIFF
--- a/src/drain.ts
+++ b/src/drain.ts
@@ -1191,8 +1191,11 @@ export class DrainService {
     const { number, url, title, body } = decision.issue;
     const failKey = `${repoPath}#${number}`;
     const lastFail = this.spawnFailures.get(failKey);
-    if (lastFail !== undefined && this.now() - lastFail < SPAWN_FAIL_COOLDOWN_MS) {
-      return; // #790: recently failed to spawn this issue — back off to avoid claim/label churn
+    if (lastFail !== undefined) {
+      if (this.now() - lastFail < SPAWN_FAIL_COOLDOWN_MS) {
+        return; // #790: recently failed to spawn this issue — back off to avoid claim/label churn
+      }
+      this.spawnFailures.delete(failKey); // #790: cooldown elapsed — drop the stale entry so the map can't grow unbounded
     }
     // Sandbox auto-gate pre-check: skip a held issue cleanly BEFORE claiming the label
     // or spawning, so a repo whose profile refuses auto (standard, or autonomous with no

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -41,6 +41,12 @@ const EPIC_BLOCKED_BY_CONCURRENCY = 8;
  *  keeps `gh api matching-refs` off the per-pump hot path. */
 const EPIC_BRANCH_SCAN_TTL_MS = 5 * 60_000;
 
+/** #790: after a drain spawn for an issue fails (e.g. worktree isolation aborted), back off
+ *  re-attempting that issue for this long. Without it, abort + the ~30s tick would loop
+ *  spawn→abort→re-claim with GitHub label-API churn. A transient failure self-heals after the
+ *  window; a persistent one stops churning. */
+const SPAWN_FAIL_COOLDOWN_MS = 5 * 60_000;
+
 /** #645 (Task 2): once a child's PR is found targeting the wrong base, don't re-pay the
  *  `prReviewMeta` API call on every pump while the operator hasn't fixed it — recheck at most
  *  this often per child. Bounds the cost to ≤1 call/child/~60s while a child stays blocked. */
@@ -192,6 +198,9 @@ export class DrainService {
   // recomputing on restart is fine — no persisted column).
   private epicBranchScanCache = new Map<string, { at: number; divergent: string[] }>();
   private lastEpicSig = new Map<string, string>();
+  /** #790: `${repoPath}#${issueNumber}` → last spawn-failure timestamp; throttles re-spawn
+   *  of an issue whose create() keeps throwing. Cleared on a successful spawn. In-memory. */
+  private spawnFailures = new Map<string, number>();
   private approvedNext = new Set<string>();
   private now: () => number;
   private issuesTtlMs: number;
@@ -1180,6 +1189,11 @@ export class DrainService {
     const forge = this.deps.resolveForge(repoPath);
     if (!forge) return;
     const { number, url, title, body } = decision.issue;
+    const failKey = `${repoPath}#${number}`;
+    const lastFail = this.spawnFailures.get(failKey);
+    if (lastFail !== undefined && this.now() - lastFail < SPAWN_FAIL_COOLDOWN_MS) {
+      return; // #790: recently failed to spawn this issue — back off to avoid claim/label churn
+    }
     // Sandbox auto-gate pre-check: skip a held issue cleanly BEFORE claiming the label
     // or spawning, so a repo whose profile refuses auto (standard, or autonomous with no
     // backend) doesn't churn the claim label every tick. create() re-checks and throws as
@@ -1249,10 +1263,12 @@ export class DrainService {
         auto: true,
         issueRef: { number, url, title, body },
       });
+      this.spawnFailures.delete(failKey); // #790: clear any prior failure cooldown on success
       // The new auto session appears in the next buildState → counts toward the
       // cap AND mappedIssueNumbers, so the loop won't re-spawn this issue and
       // naturally stops at cap.
     } catch (err) {
+      this.spawnFailures.set(failKey, this.now());
       console.warn(`[drain] spawn failed for issue #${number}:`, err);
       // Release the claim so the unspawned issue returns to the pool (best-effort).
       try {

--- a/src/gitignore-adopt.ts
+++ b/src/gitignore-adopt.ts
@@ -101,7 +101,13 @@ export class GitignoreAdopter {
     // Unique per-attempt branch: a partial failure (push ok but PR url missing → 502)
     // must not wedge a retry on a stale branch name / non-fast-forward push.
     const name = `adopt-gitignore-${randomUUID().slice(0, 8)}`;
-    const wt = this.createAdoptWorktree(repoPath, base, name);
+    let wt: WorktreeResult;
+    try {
+      wt = this.createAdoptWorktree(repoPath, base, name);
+    } catch (err) {
+      console.warn("[gitignore-adopt] worktree isolation failed for", repoPath, err);
+      return { ok: false, error: "worktree creation failed", status: 500 };
+    }
     if (!wt.isolated || !wt.branch) {
       if (wt.worktreePath !== repoPath) this.deps.worktree.remove(wt.worktreePath);
       return { ok: false, error: "worktree creation failed", status: 500 };
@@ -147,9 +153,11 @@ export class GitignoreAdopter {
    *  head (branch hygiene). Falls back to the local base ref when `origin/<base>`
    *  isn't available — offline, or a fresh repo with no remote-tracking ref. */
   private createAdoptWorktree(repoPath: string, base: string, name: string): WorktreeResult {
-    const wt = this.deps.worktree.create(repoPath, `origin/${base}`, name);
-    if (wt.isolated && wt.branch) return wt;
-    return this.deps.worktree.create(repoPath, base, name);
+    try {
+      return this.deps.worktree.create(repoPath, `origin/${base}`, name);
+    } catch {
+      return this.deps.worktree.create(repoPath, base, name);
+    }
   }
 
   /** Tear down the throwaway worktree and force-delete its local branch. The pushed

--- a/src/promote.ts
+++ b/src/promote.ts
@@ -156,7 +156,13 @@ export class Promoter {
     // Unique per-attempt branch: a partial failure (push ok but PR url missing → 502)
     // must not wedge a retry on a stale branch name / non-fast-forward push.
     const name = `learnings-promote-${id.slice(0, 8)}-${randomUUID().slice(0, 8)}`;
-    const wt = this.createPromoteWorktree(learning.repoPath, base, name);
+    let wt: WorktreeResult;
+    try {
+      wt = this.createPromoteWorktree(learning.repoPath, base, name);
+    } catch (err) {
+      console.warn(`[promote] worktree isolation failed for ${id}:`, err);
+      return { ok: false, error: "worktree creation failed", status: 500 };
+    }
     if (!wt.isolated || !wt.branch) {
       if (wt.worktreePath !== learning.repoPath) this.deps.worktree.remove(wt.worktreePath);
       return { ok: false, error: "worktree creation failed", status: 500 };
@@ -177,9 +183,11 @@ export class Promoter {
    *  isn't available — offline, or a fresh repo with no remote-tracking ref — so an
    *  unreachable remote degrades to a local-base PR rather than an opaque 500. */
   private createPromoteWorktree(repoPath: string, base: string, name: string): WorktreeResult {
-    const wt = this.deps.worktree.create(repoPath, `origin/${base}`, name);
-    if (wt.isolated && wt.branch) return wt;
-    return this.deps.worktree.create(repoPath, base, name);
+    try {
+      return this.deps.worktree.create(repoPath, `origin/${base}`, name);
+    } catch {
+      return this.deps.worktree.create(repoPath, base, name);
+    }
   }
 
   /** Tear down the throwaway worktree and force-delete its local branch. The pushed

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -66,10 +66,10 @@ export class WorktreeMgr {
     const branch = `shepherd/${name}`;
     const parent = join(dirname(repoPath), ".shepherd-worktrees");
     const worktreePath = join(parent, `${basename(repoPath)}-${name}`);
-    mkdirSync(parent, { recursive: true });
 
     // First attempt
     try {
+      mkdirSync(parent, { recursive: true });
       execFileSync("git", ["worktree", "add", "-b", branch, worktreePath, baseBranch], {
         cwd: repoPath,
         stdio: "pipe",

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -62,22 +62,93 @@ export class WorktreeMgr {
     if (!this.isGit(repoPath)) {
       return { worktreePath: repoPath, branch: null, isolated: false };
     }
-    // Must run before the try so it covers both the worktree-add success path and the
-    // catch fallback where the session runs in the main checkout (isolated: false) —
-    // the exact case that would drop .shepherd-* artifacts into the operator's tree.
     ensureShepherdExclude(repoPath);
     const branch = `shepherd/${name}`;
     const parent = join(dirname(repoPath), ".shepherd-worktrees");
     const worktreePath = join(parent, `${basename(repoPath)}-${name}`);
+    mkdirSync(parent, { recursive: true });
+
+    // First attempt
     try {
-      mkdirSync(parent, { recursive: true });
       execFileSync("git", ["worktree", "add", "-b", branch, worktreePath, baseBranch], {
         cwd: repoPath,
         stdio: "pipe",
       });
       return { worktreePath, branch, isolated: true };
+    } catch (err) {
+      const stderr =
+        String((err as { stderr?: unknown }).stderr ?? "").trim() ||
+        (err instanceof Error ? err.message : String(err));
+
+      // Fast-fail: invalid base ref — git created nothing, no cleanup needed
+      if (/invalid reference|not a valid object name|unknown revision/i.test(stderr)) {
+        console.error(
+          `[worktree] create: invalid base ref — worktreePath=${worktreePath} branch=${branch} stderr=${stderr}`,
+        );
+        throw new Error(`worktree isolation failed for ${branch} at ${worktreePath}: ${stderr}`, {
+          cause: err,
+        });
+      }
+
+      // Transient-looking failure: cleanup + retry
+      console.warn(
+        `[worktree] create: first worktree add failed, will cleanup+retry — branch=${branch} worktreePath=${worktreePath} stderr=${stderr}`,
+      );
+      this.cleanupPartial(repoPath, worktreePath);
+
+      // If git auto-created the branch before dying (e.g. dir already existed), it
+      // sits at baseBranch with no extra commits — safe to reuse.
+      // If the branch pre-existed with unmerged commits, abort to preserve that work.
+      const branchAhead = this.branchExists(repoPath, branch)
+        ? this.commitsAhead(repoPath, baseBranch, branch)
+        : -1; // -1 = branch does not exist
+
+      if (branchAhead > 0) {
+        // Pre-existing branch has unmerged work → abort, no cleanup (preserve the branch)
+        console.error(
+          `[worktree] create: branch ${branch} has ${branchAhead} unmerged commit(s), refusing shared checkout — worktreePath=${worktreePath}`,
+        );
+        throw new Error(`worktree isolation failed for ${branch} at ${worktreePath}: ${stderr}`, {
+          cause: err,
+        });
+      }
+
+      const retryArgs =
+        branchAhead === 0
+          ? ["worktree", "add", worktreePath, branch] // reuse orphaned branch at baseBranch
+          : ["worktree", "add", "-b", branch, worktreePath, baseBranch]; // fresh branch
+
+      try {
+        execFileSync("git", retryArgs, { cwd: repoPath, stdio: "pipe" });
+        console.info(
+          `[worktree] create: retry succeeded — branch=${branch} worktreePath=${worktreePath}`,
+        );
+        return { worktreePath, branch, isolated: true };
+      } catch (err2) {
+        const stderr2 =
+          String((err2 as { stderr?: unknown }).stderr ?? "").trim() ||
+          (err2 instanceof Error ? err2.message : String(err2));
+        this.cleanupPartial(repoPath, worktreePath);
+        console.error(
+          `[worktree] create: retry also failed, refusing shared checkout — worktreePath=${worktreePath} branch=${branch} stderr=${stderr2}`,
+        );
+        throw new Error(`worktree isolation failed for ${branch} at ${worktreePath}: ${stderr2}`, {
+          cause: err2,
+        });
+      }
+    }
+  }
+
+  private cleanupPartial(repoPath: string, worktreePath: string): void {
+    try {
+      if (existsSync(worktreePath)) rmSync(worktreePath, { recursive: true, force: true });
     } catch {
-      return { worktreePath: repoPath, branch: null, isolated: false };
+      /* best-effort */
+    }
+    try {
+      execFileSync("git", ["worktree", "prune"], { cwd: repoPath, stdio: "pipe" });
+    } catch {
+      /* best-effort */
     }
   }
 

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -67,7 +67,6 @@ export class WorktreeMgr {
     const parent = join(dirname(repoPath), ".shepherd-worktrees");
     const worktreePath = join(parent, `${basename(repoPath)}-${name}`);
 
-    // First attempt
     try {
       mkdirSync(parent, { recursive: true });
       execFileSync("git", ["worktree", "add", "-b", branch, worktreePath, baseBranch], {
@@ -76,66 +75,90 @@ export class WorktreeMgr {
       });
       return { worktreePath, branch, isolated: true };
     } catch (err) {
-      const stderr =
-        String((err as { stderr?: unknown }).stderr ?? "").trim() ||
-        (err instanceof Error ? err.message : String(err));
+      return this.recoverFromAddFailure(repoPath, baseBranch, branch, worktreePath, err);
+    }
+  }
 
-      // Fast-fail: invalid base ref — git created nothing, no cleanup needed
-      if (/invalid reference|not a valid object name|unknown revision/i.test(stderr)) {
-        console.error(
-          `[worktree] create: invalid base ref — worktreePath=${worktreePath} branch=${branch} stderr=${stderr}`,
-        );
-        throw new Error(`worktree isolation failed for ${branch} at ${worktreePath}: ${stderr}`, {
-          cause: err,
-        });
-      }
+  private gitStderr(err: unknown): string {
+    return (
+      String((err as { stderr?: unknown }).stderr ?? "").trim() ||
+      (err instanceof Error ? err.message : String(err))
+    );
+  }
 
-      // Transient-looking failure: cleanup + retry
-      console.warn(
-        `[worktree] create: first worktree add failed, will cleanup+retry — branch=${branch} worktreePath=${worktreePath} stderr=${stderr}`,
+  private recoverFromAddFailure(
+    repoPath: string,
+    baseBranch: string,
+    branch: string,
+    worktreePath: string,
+    err: unknown,
+  ): WorktreeResult {
+    const stderr = this.gitStderr(err);
+
+    // Fast-fail: invalid base ref — git created nothing, no cleanup needed
+    if (/invalid reference|not a valid object name|unknown revision/i.test(stderr)) {
+      console.error(
+        `[worktree] create: invalid base ref — worktreePath=${worktreePath} branch=${branch} stderr=${stderr}`,
       );
+      throw new Error(`worktree isolation failed for ${branch} at ${worktreePath}: ${stderr}`, {
+        cause: err,
+      });
+    }
+
+    // Transient-looking failure: cleanup + retry
+    console.warn(
+      `[worktree] create: first worktree add failed, will cleanup+retry — branch=${branch} worktreePath=${worktreePath} stderr=${stderr}`,
+    );
+    this.cleanupPartial(repoPath, worktreePath);
+    return this.retryWorktreeAdd(repoPath, baseBranch, branch, worktreePath, err, stderr);
+  }
+
+  private retryWorktreeAdd(
+    repoPath: string,
+    baseBranch: string,
+    branch: string,
+    worktreePath: string,
+    firstErr: unknown,
+    firstStderr: string,
+  ): WorktreeResult {
+    // If git auto-created the branch before dying (e.g. dir already existed), it
+    // sits at baseBranch with no extra commits — safe to reuse.
+    // If the branch pre-existed with unmerged commits, abort to preserve that work.
+    const branchAhead = this.branchExists(repoPath, branch)
+      ? this.commitsAhead(repoPath, baseBranch, branch)
+      : -1; // -1 = branch does not exist
+
+    if (branchAhead > 0) {
+      // Pre-existing branch has unmerged work → abort, no cleanup (preserve the branch)
+      console.error(
+        `[worktree] create: branch ${branch} has ${branchAhead} unmerged commit(s), refusing shared checkout — worktreePath=${worktreePath}`,
+      );
+      throw new Error(
+        `worktree isolation failed for ${branch} at ${worktreePath}: ${firstStderr}`,
+        { cause: firstErr },
+      );
+    }
+
+    const retryArgs =
+      branchAhead === 0
+        ? ["worktree", "add", worktreePath, branch] // reuse orphaned branch at baseBranch
+        : ["worktree", "add", "-b", branch, worktreePath, baseBranch]; // fresh branch
+
+    try {
+      execFileSync("git", retryArgs, { cwd: repoPath, stdio: "pipe" });
+      console.info(
+        `[worktree] create: retry succeeded — branch=${branch} worktreePath=${worktreePath}`,
+      );
+      return { worktreePath, branch, isolated: true };
+    } catch (err2) {
+      const stderr2 = this.gitStderr(err2);
       this.cleanupPartial(repoPath, worktreePath);
-
-      // If git auto-created the branch before dying (e.g. dir already existed), it
-      // sits at baseBranch with no extra commits — safe to reuse.
-      // If the branch pre-existed with unmerged commits, abort to preserve that work.
-      const branchAhead = this.branchExists(repoPath, branch)
-        ? this.commitsAhead(repoPath, baseBranch, branch)
-        : -1; // -1 = branch does not exist
-
-      if (branchAhead > 0) {
-        // Pre-existing branch has unmerged work → abort, no cleanup (preserve the branch)
-        console.error(
-          `[worktree] create: branch ${branch} has ${branchAhead} unmerged commit(s), refusing shared checkout — worktreePath=${worktreePath}`,
-        );
-        throw new Error(`worktree isolation failed for ${branch} at ${worktreePath}: ${stderr}`, {
-          cause: err,
-        });
-      }
-
-      const retryArgs =
-        branchAhead === 0
-          ? ["worktree", "add", worktreePath, branch] // reuse orphaned branch at baseBranch
-          : ["worktree", "add", "-b", branch, worktreePath, baseBranch]; // fresh branch
-
-      try {
-        execFileSync("git", retryArgs, { cwd: repoPath, stdio: "pipe" });
-        console.info(
-          `[worktree] create: retry succeeded — branch=${branch} worktreePath=${worktreePath}`,
-        );
-        return { worktreePath, branch, isolated: true };
-      } catch (err2) {
-        const stderr2 =
-          String((err2 as { stderr?: unknown }).stderr ?? "").trim() ||
-          (err2 instanceof Error ? err2.message : String(err2));
-        this.cleanupPartial(repoPath, worktreePath);
-        console.error(
-          `[worktree] create: retry also failed, refusing shared checkout — worktreePath=${worktreePath} branch=${branch} stderr=${stderr2}`,
-        );
-        throw new Error(`worktree isolation failed for ${branch} at ${worktreePath}: ${stderr2}`, {
-          cause: err2,
-        });
-      }
+      console.error(
+        `[worktree] create: retry also failed, refusing shared checkout — worktreePath=${worktreePath} branch=${branch} stderr=${stderr2}`,
+      );
+      throw new Error(`worktree isolation failed for ${branch} at ${worktreePath}: ${stderr2}`, {
+        cause: err2,
+      });
     }
   }
 

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -1380,3 +1380,85 @@ describe("drain epic mode", () => {
     expect(h.epics.length).toBeGreaterThan(epicsBefore);
   });
 });
+
+// ── #790: per-issue spawn-failure cooldown ────────────────────────────────────
+
+test("#790: spawn-failure cooldown: failed issue is skipped until window expires", async () => {
+  // Mutable clock injected as `now` dep so we control time deterministically.
+  let clock = 1_000_000;
+
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: false,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: false,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: true,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 2,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+  });
+
+  const candidateIssue = issue(42);
+  const forgeRec: ForgeRec = {
+    merges: [],
+    links: [],
+    listIssuesCalls: 0,
+    closedIssues: [],
+    added: [],
+    removed: [],
+    getIssueCalls: [],
+  };
+  // Count ACTIVE_LABEL claim calls only (addIssueLabel with ACTIVE_LABEL).
+  let claimCount = 0;
+  const forge = fakeForge([candidateIssue], forgeRec, {
+    addIssueLabel: async (n, label) => {
+      if (label === ACTIVE_LABEL) claimCount++;
+    },
+  });
+
+  const drain = new DrainService({
+    store,
+    service: {
+      create: async () => {
+        throw new Error("isolation failed");
+      },
+      archive: async (id: string): Promise<number> => {
+        store.archive(id);
+        return 1;
+      },
+    },
+    resolveForge: () => forge,
+    prCache: { snapshot: () => ({}) },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    emitStatus: () => {},
+    emitArchived: () => {},
+    dropPrCache: () => {},
+    now: () => clock,
+    // Zero TTL so the issues list is never served from cache between pumps.
+    issuesTtlMs: 0,
+  });
+
+  // Step 3: first pump — one claim attempt, create throws, cooldown recorded.
+  await drain.pump(REPO);
+  expect(claimCount).toBe(1);
+
+  // Step 4: second pump, clock unchanged — still within cooldown window, skipped.
+  await drain.pump(REPO);
+  expect(claimCount).toBe(1);
+
+  // Step 5: advance clock past the 5-minute cooldown, pump again — re-attempted.
+  clock += 5 * 60_000 + 1;
+  await drain.pump(REPO);
+  expect(claimCount).toBe(2);
+});

--- a/test/promote.test.ts
+++ b/test/promote.test.ts
@@ -99,15 +99,11 @@ test("Promoter.promote falls back to the local base ref when origin/<base> is un
     store,
     worktree: {
       // origin/main unavailable (offline); local main works — mirrors worktree.create
-      // returning isolated:false on an unresolvable base rather than throwing.
+      // now throwing on an unresolvable base ref rather than returning isolated:false.
       create: (_repo: string, baseRef: string) => {
         baseRefs.push(baseRef);
-        const ok = baseRef === "main";
-        return {
-          worktreePath: ok ? wtDir : "/r",
-          branch: ok ? "shepherd/fallback" : null,
-          isolated: ok,
-        };
+        if (baseRef !== "main") throw new Error(`invalid reference: ${baseRef}`);
+        return { worktreePath: wtDir, branch: "shepherd/fallback", isolated: true };
       },
       remove: () => {},
     },

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname, basename } from "node:path";
 import { execFileSync } from "node:child_process";
 import { WorktreeMgr } from "../src/worktree";
 
@@ -359,6 +359,81 @@ test("createDetached: a fork head only reachable via pullRef is fetched and chec
   rmSync(seed, { recursive: true, force: true });
   rmSync(base, { recursive: true, force: true });
 });
+
+// ── Task A: four new tests for the reworked create() failure path ────────────
+
+const gitEnvBasic = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+
+test("create: invalid base ref throws with stderr in message", () => {
+  const wt = new WorktreeMgr();
+  expect(() => wt.create(repo, "no-such-base", "x")).toThrow(/invalid reference/i);
+});
+
+test("create: non-git directory returns non-isolated, no throw", () => {
+  const nonGitDir = mkdtempSync(join(tmpdir(), "shepherd-nongit-"));
+  try {
+    const wt = new WorktreeMgr();
+    const r = wt.create(nonGitDir, "main", "x");
+    expect(r.isolated).toBe(false);
+    expect(r.branch).toBeNull();
+    expect(r.worktreePath).toBe(nonGitDir);
+  } finally {
+    rmSync(nonGitDir, { recursive: true, force: true });
+  }
+});
+
+test("create: branch-exists collision → retry → abort, branch + commit preserved", () => {
+  // Pre-create shepherd/dup with an extra commit not on main
+  execFileSync("git", ["checkout", "-b", "shepherd/dup"], { cwd: repo });
+  execFileSync("git", ["commit", "--allow-empty", "-m", "dup-extra"], {
+    cwd: repo,
+    env: gitEnvBasic,
+  });
+  const dupSha = execFileSync("git", ["rev-parse", "shepherd/dup"], { cwd: repo })
+    .toString()
+    .trim();
+  execFileSync("git", ["checkout", "main"], { cwd: repo });
+
+  const wt = new WorktreeMgr();
+  expect(() => wt.create(repo, "main", "dup")).toThrow(/already exists/i);
+
+  // shepherd/dup still points at the extra commit (branch -D was NOT run)
+  const shaAfter = execFileSync("git", ["rev-parse", "shepherd/dup"], { cwd: repo })
+    .toString()
+    .trim();
+  expect(shaAfter).toBe(dupSha);
+  // The extra commit is NOT on main → branch genuinely preserved
+  expect(() =>
+    execFileSync("git", ["merge-base", "--is-ancestor", "shepherd/dup", "main"], {
+      cwd: repo,
+      stdio: "pipe",
+    }),
+  ).toThrow();
+});
+
+test("create: cleanupPartial removes leftover dir → retry succeeds", () => {
+  // Pre-create a non-empty directory at the exact path create() will use
+  const parent = join(dirname(repo), ".shepherd-worktrees");
+  const worktreePath = join(parent, `${basename(repo)}-recover`);
+  mkdirSync(parent, { recursive: true });
+  mkdirSync(worktreePath, { recursive: true });
+  writeFileSync(join(worktreePath, "leftover.txt"), "stale");
+
+  const wt = new WorktreeMgr();
+  const r = wt.create(repo, "main", "recover");
+  expect(r.isolated).toBe(true);
+  expect(r.branch).toBe("shepherd/recover");
+  expect(existsSync(r.worktreePath)).toBe(true);
+  wt.remove(r.worktreePath);
+});
+
+// ── end Task A tests ──────────────────────────────────────────────────────────
 
 test("behindBase: false when up-to-date, true when base advanced", async () => {
   const dir = mkdtempSync(join(tmpdir(), "wt-"));


### PR DESCRIPTION
## Problem (#790)

`WorktreeMgr.create` swallowed **any** `git worktree add` failure with a bare `catch {}` and silently returned the **shared main checkout** (`worktreePath == repoPath`, `branch: null`, `isolated: false`). Two distinct harms, one cause:

1. **Work landed in the live/deploy checkout** — the agent ran in `/home/patrick/Work/shepherd` instead of an isolated worktree.
2. **The PR never auto-associated** — the poller + `syncWorktreeBranch` hard-gate on `branch`/`isolated`, so a `branch: null` session could never link its PR (had to be hand-fixed in the store on TASK-546).

The failure was also **unlogged**, so the cause was unrecoverable after the fact.

## Fix

Make the failure **loud and reliable** — log it, attempt one self-scoped cleanup+retry, and on persistent failure **abort (throw)** rather than silently dropping into the live checkout. Because an isolated session always has a branch, abort makes PR association "just work" — both harms are removed by guaranteeing isolation-or-abort.

### `src/worktree.ts`
- `create` no longer returns the shared checkout for a git repo: it returns an isolated worktree or **throws** with the git stderr in the message (and in `~/.shepherd/shepherd.log`).
- **Invalid base ref** (`fatal: invalid reference: …`) → throws immediately, no cleanup/retry (git created nothing) — keeps the offline `promote`/`adopt` path cheap.
- **Transient-looking failure** → `cleanupPartial` (`rmSync` of our own uniquely-named worktree path + plain `git worktree prune` — only ever touches our own missing-dir registration, never a live sibling) → one retry.
- **No `git branch -D`, no `core.bare` mutation.** Verified `core.bare=true` does *not* break `git worktree add`. git 2.54 *does* create the branch before failing on a pre-occupied dir, so the retry **reuses a 0-commits-ahead orphan** (`git worktree add <path> <branch>`, no `-b`) and **aborts, preserving the branch**, when the leftover has unmerged commits (`commitsAhead > 0`). Unmerged work is never destroyed.
- Non-git repos are unchanged (`isolated: false`, no throw).

### `src/promote.ts`, `src/gitignore-adopt.ts`
The two internal callers depended on the old silent fallback to detect "`origin/<base>` absent → use local base". Adapted to try/catch (prefer origin, fall back to local) and wrapped the create call site so a genuine isolation failure still returns the existing clean `500` instead of an uncaught throw. The non-git `!wt.isolated || !wt.branch` guard stays live.

### `src/drain.ts`
Abort releases the issue claim and drain ticks every ~30s, so a *persistent* failure would loop spawn→abort→re-claim with GitHub label-API churn. Added a minimal **per-issue spawn-failure cooldown** (5 min, keyed `${repoPath}#${number}`): set when `create` throws, cleared on a successful spawn, checked before the label claim. A transient failure still self-heals after the window.

## Tests
- `test/worktree.test.ts`: invalid-ref throws (stderr in message); non-git → `isolated:false` no throw; branch-exists collision with unmerged commit → retry → abort + branch/commit preserved; non-empty leftover dir at target path → `cleanupPartial` removes it → retry succeeds.
- `test/promote.test.ts`: offline-fallback mock updated to throw on the unresolvable ref.
- `test/drain.test.ts`: deterministic cooldown test (claim count 1 → 1 within window → 2 after advancing the injected clock).

Full root suite green (3670 pass / 0 fail), `bun run lint` clean, `bunx tsc --noEmit` clean, `fallow` complexity gate green.

## Notes
- Built subagent-driven (implement → per-task review → fix loop → whole-branch review); 3 rounds of adversarial plan review preceded execution. The git-2.54 branch-creation behavior was a verified correction to the plan's premise (recorded in `.shepherd-plan.md`).
- Raw git stderr appears in the New Task 502 body — accepted under the single-operator threat model (the operator already sees absolute paths throughout the UI).

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)
