### PR TITLE
fix(ui): scroll New Task pane when it outgrows the viewport

### DIFF
--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -899,12 +899,19 @@
     inset: 0;
     background: var(--color-scrim);
     display: flex;
-    align-items: center;
-    justify-content: center;
+    /* Scroll (not center-clip) when the card outgrows the viewport, so a long
+       auto-grown prompt can never push the Run button out of reach. Centering
+       is done by the card's `margin: auto` rather than align/justify-center:
+       auto margins center when there's room yet still let an over-tall card
+       scroll, sidestepping the flexbox "can't scroll to the top" bug. */
+    overflow-y: auto;
+    padding: 24px;
+    box-sizing: border-box;
     z-index: 20;
   }
   .card {
     position: relative;
+    margin: auto;
     width: min(520px, 92vw);
     border: 1px solid var(--color-line-bright);
     background: var(--color-panel);
@@ -1152,6 +1159,9 @@
     .overlay {
       align-items: stretch;
       justify-content: stretch;
+      /* Full-bleed sheet: drop the desktop breathing-room padding so the
+         100dvh card fills the screen edge-to-edge. */
+      padding: 0;
     }
     .card {
       width: 100%;


### PR DESCRIPTION
## Problem

In the **New Task** modal, the prompt textarea auto-grows with its content. On a short viewport, a long prompt grew the card taller than the screen, but the modal had no way to scroll — the **Run** button was stranded below the fold and unreachable.

`.overlay` only centered the card (`align-items/justify-content: center`, no `overflow`), and `.card` had no `max-height`/`overflow`. The textarea's `max-height: 50vh` cap wasn't enough on its own because the surrounding fields + the capped textarea + padding still exceed a short viewport. Mobile already worked (its media query gives the card `height: 100dvh; overflow-y: auto`).

## Fix (CSS-only)

Make the **whole card scroll** inside a scrollable overlay — the same behavior the mobile sheet already uses:

- `.overlay`: add `overflow-y: auto` + `padding: 24px` + `box-sizing: border-box`; remove `align-items/justify-content: center`.
- `.card`: center via `margin: auto`. Auto margins center the card when it fits **and** let an over-tall card scroll, sidestepping the well-known flexbox "can't scroll to the top of a centered overflowing item" bug.
- Scroll stays on the **overlay**, not the card, so the `.bracket` corner decorations (`top/bottom: -1px`) are **not** clipped.
- Mobile media query: reset `.overlay` `padding: 0` so the `100dvh` sheet stays full-bleed.

No JS change — `autogrow()` and the textarea `50vh` cap are untouched.

## Verification

Browser-verified against the live instance via the vite dev proxy, viewport 1100×560:

- Textarea capped at **280px (= 50vh)**; card grew to **1046px**.
- `.overlay` is **scrollable** (scrollHeight 1094 > clientHeight 560).
- Run button **scrolls fully into view** (`top ≥ 0`, `bottom 519 ≤ 560`).
- Short-prompt case still centers; brackets render intact.
- `cd ui && bun run check` passes (0 errors, 0 warnings).

Bug fix, not a user-facing feature — no i18n keys or feature-catalog entry. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)