### PR TITLE
feat(learnings): triage layer — budget visibility + sticky repo separation (#796)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -431,7 +431,7 @@
   "learnings_distill_aria": "Destillierer jetzt für {repo} ausführen",
   "learnings_distill_started": "Destillierer für {repo} gestartet",
   "learnings_injected_section": "Injizierte Projektregeln",
-  "learnings_budget_meter": "{used}/{budget} Zeichen · {injected}/{total} injiziert",
+  "learnings_budget_meter": "{injected} von {total} Regeln injiziert · {used}/{budget} Zeichen",
   "learnings_injected_badge": "Injiziert",
   "learnings_overbudget_badge": "Über Budget",
   "learnings_injection_disabled_badge": "Injektion deaktiviert",
@@ -1517,5 +1517,13 @@
   "vblock_wireframe_surface_popover": "Popover-Skizze",
   "vblock_wireframe_surface_panel": "Panel-Skizze",
   "feat_visual_recap_wireframes_title": "UI-Skizzen in Zusammenfassungen",
-  "feat_visual_recap_wireframes_body": "Zusammenfassungen von UI-Arbeit können jetzt gerenderte, gestaltete Skizzen der betroffenen Bildschirme enthalten — klar als illustrativ gekennzeichnet, nicht als Screenshots."
+  "feat_visual_recap_wireframes_body": "Zusammenfassungen von UI-Arbeit können jetzt gerenderte, gestaltete Skizzen der betroffenen Bildschirme enthalten — klar als illustrativ gekennzeichnet, nicht als Screenshots.",
+  "learnings_budget_over": "Über Budget · {dropped} nicht injiziert",
+  "learnings_not_injected_label": "Nicht injiziert — über Budget",
+  "learnings_filter_overbudget": "Über Budget ({count})",
+  "learnings_triage_heading": "Braucht Aufmerksamkeit",
+  "learnings_triage_over": "{count} über",
+  "learnings_triage_flagged": "{count} nicht funktionierend",
+  "learnings_triage_jump_aria": "Zu {repo} springen",
+  "learnings_about_budget": "Die freigegebenen Regeln jedes Repos werden bis zu einem gemeinsamen Zeichenbudget injiziert; Regeln über dem Budget werden übersprungen, bis du sie kürzt oder das Budget erhöhst."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1525,5 +1525,7 @@
   "learnings_triage_over": "{count} über",
   "learnings_triage_flagged": "{count} nicht funktionierend",
   "learnings_triage_jump_aria": "Zu {repo} springen",
-  "learnings_about_budget": "Die freigegebenen Regeln jedes Repos werden bis zu einem gemeinsamen Zeichenbudget injiziert; Regeln über dem Budget werden übersprungen, bis du sie kürzt oder das Budget erhöhst."
+  "learnings_about_budget": "Die freigegebenen Regeln jedes Repos werden bis zu einem gemeinsamen Zeichenbudget injiziert; Regeln über dem Budget werden übersprungen, bis du sie kürzt oder das Budget erhöhst.",
+  "feat_learnings_triage_title": "Learnings-Triage-Ebene",
+  "feat_learnings_triage_body": "Die Learnings-Leiste hebt jetzt Repos über Budget und nicht funktionierende Regeln nach oben, fixiert die Überschrift jedes Repos beim Scrollen, markiert Repos über Budget in Amber und bietet eine „Braucht Aufmerksamkeit“-Sprungleiste – so siehst du auf einen Blick, was zu tun ist."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1475,7 +1475,6 @@
   "learnings_optimize_started": "Markierte Regeln werden optimiert…",
   "learnings_optimize_failed": "Optimierung konnte nicht gestartet werden",
   "learnings_filter_flagged": "Wirkungslos ({count})",
-  "learnings_filter_all": "Alle anzeigen",
   "learnings_optimizer_stalled_title": "Optimierer blockiert",
   "learnings_optimizer_stalled_body": "Der Regel-Optimierer ist {count}-mal in Folge fehlgeschlagen. Prüfe die Server-Logs.",
   "feat_optimize_learnings_title": "„Wirkungslose“ Hausregeln mit einem Klick reparieren",
@@ -1523,9 +1522,9 @@
   "learnings_filter_overbudget": "Über Budget ({count})",
   "learnings_triage_heading": "Braucht Aufmerksamkeit",
   "learnings_triage_over": "{count} über",
-  "learnings_triage_flagged": "{count} nicht funktionierend",
+  "learnings_triage_flagged": "{count} wirkungslos",
   "learnings_triage_jump_aria": "Zu {repo} springen",
   "learnings_about_budget": "Die freigegebenen Regeln jedes Repos werden bis zu einem gemeinsamen Zeichenbudget injiziert; Regeln über dem Budget werden übersprungen, bis du sie kürzt oder das Budget erhöhst.",
   "feat_learnings_triage_title": "Learnings-Triage-Ebene",
-  "feat_learnings_triage_body": "Die Learnings-Leiste hebt jetzt Repos über Budget und nicht funktionierende Regeln nach oben, fixiert die Überschrift jedes Repos beim Scrollen, markiert Repos über Budget in Amber und bietet eine „Braucht Aufmerksamkeit“-Sprungleiste – so siehst du auf einen Blick, was zu tun ist."
+  "feat_learnings_triage_body": "Die Learnings-Leiste hebt jetzt Repos über Budget und wirkungslose Regeln nach oben, fixiert die Überschrift jedes Repos beim Scrollen, markiert Repos über Budget in Amber und bietet eine „Braucht Aufmerksamkeit“-Sprungleiste – so siehst du auf einen Blick, was zu tun ist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -431,7 +431,7 @@
   "learnings_distill_aria": "Run the distiller now for {repo}",
   "learnings_distill_started": "Distiller started for {repo}",
   "learnings_injected_section": "Injected house rules",
-  "learnings_budget_meter": "{used}/{budget} chars · {injected}/{total} injected",
+  "learnings_budget_meter": "{injected} of {total} rules injected · {used}/{budget} chars",
   "learnings_injected_badge": "Injected",
   "learnings_overbudget_badge": "Over budget",
   "learnings_injection_disabled_badge": "Injection disabled",
@@ -1517,5 +1517,13 @@
   "vblock_wireframe_surface_popover": "Popover mockup",
   "vblock_wireframe_surface_panel": "Panel mockup",
   "feat_visual_recap_wireframes_title": "UI mockups in recaps",
-  "feat_visual_recap_wireframes_body": "Recaps of UI work can now include rendered, themed mockups of the affected screens — clearly labelled as illustrative, not screenshots."
+  "feat_visual_recap_wireframes_body": "Recaps of UI work can now include rendered, themed mockups of the affected screens — clearly labelled as illustrative, not screenshots.",
+  "learnings_budget_over": "Over budget · {dropped} not injected",
+  "learnings_not_injected_label": "Not injected — over budget",
+  "learnings_filter_overbudget": "Over budget ({count})",
+  "learnings_triage_heading": "Needs attention",
+  "learnings_triage_over": "{count} over",
+  "learnings_triage_flagged": "{count} not working",
+  "learnings_triage_jump_aria": "Jump to {repo}",
+  "learnings_about_budget": "Each repo's approved rules are injected up to a shared character budget; rules over the budget are skipped until you trim them or raise the budget."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1475,7 +1475,6 @@
   "learnings_optimize_started": "Optimizing flagged rules…",
   "learnings_optimize_failed": "Couldn’t start optimization",
   "learnings_filter_flagged": "Not working ({count})",
-  "learnings_filter_all": "Show all",
   "learnings_optimizer_stalled_title": "Optimizer stalled",
   "learnings_optimizer_stalled_body": "The rule optimizer failed {count} times in a row. Check the server logs.",
   "feat_optimize_learnings_title": "Fix ‘not working’ house rules in one click",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1525,5 +1525,7 @@
   "learnings_triage_over": "{count} over",
   "learnings_triage_flagged": "{count} not working",
   "learnings_triage_jump_aria": "Jump to {repo}",
-  "learnings_about_budget": "Each repo's approved rules are injected up to a shared character budget; rules over the budget are skipped until you trim them or raise the budget."
+  "learnings_about_budget": "Each repo's approved rules are injected up to a shared character budget; rules over the budget are skipped until you trim them or raise the budget.",
+  "feat_learnings_triage_title": "Learnings triage layer",
+  "feat_learnings_triage_body": "The Learnings drawer now floats over-budget and not-working repos to the top, pins each repo's header while you scroll, marks over-budget repos in amber, and adds a 'needs attention' jump bar — so you can see what to act on at a glance."
 }

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -253,8 +253,17 @@
             class="triage-chip"
             type="button"
             aria-label={m.learnings_triage_jump_aria({ repo: basename(a.repoPath) })}
-            onclick={() =>
-              document.getElementById(repoAnchorId(a.repoPath))?.scrollIntoView({ block: "start" })}
+            onclick={() => {
+              // Clear both lens filters so the target repo is guaranteed to be in the DOM,
+              // then scroll on the next frame after Svelte has updated displayGroups.
+              flaggedOnly = false;
+              overBudgetOnly = false;
+              requestAnimationFrame(() => {
+                document
+                  .getElementById(repoAnchorId(a.repoPath))
+                  ?.scrollIntoView({ block: "start" });
+              });
+            }}
           >
             <span class="tc-repo">{basename(a.repoPath)}</span>
             {#if a.droppedCount > 0}<span class="tc-over"
@@ -893,7 +902,7 @@
     align-items: center;
     gap: 6px;
   }
-  /* Change 9: de-emphasised Dismiss on active/promoted rules — muted + gap from Promote */
+  /* Change 9: de-emphasised Dismiss on active rules — muted + gap from Promote */
   .dismiss-muted {
     color: var(--color-muted);
     border-color: var(--color-line);

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -12,10 +12,15 @@
     injectionBadge,
     injectedCount,
     showIneffective,
-    flaggedRules,
     flaggedCount,
     totalFlagged,
     evidenceSources,
+    sortGroupsForTriage,
+    isOverBudget,
+    droppedCount,
+    splitDropped,
+    reposNeedingAttention,
+    visibleInjectableRules,
   } from "./learnings-drawer";
 
   // Human label for an evidence source kind. Mirrors the server SignalKind set;
@@ -115,10 +120,12 @@
   // Matches the drawer width so the fly-in starts fully off-screen.
   const slide = { x: 520, duration: reduceMotion ? 0 : 220, opacity: 1 };
 
-  const groups = $derived(mergeRepoGroups(items, injectable));
+  // Change 1: Use sortGroupsForTriage to order repos by triage priority.
+  const groups = $derived(sortGroupsForTriage(mergeRepoGroups(items, injectable)));
   // Empty only when there's nothing to curate in either view.
   const empty = $derived(groups.length === 0);
 
+  // Change 2: Two independent header filters — flaggedOnly + overBudgetOnly, union semantics.
   // "Not working" filter: show only repos/rules the distiller flagged. The toggle
   // only renders when something is flagged, and auto-resets so the view can't get
   // stuck on an empty filter once the last flagged rule is optimized/dismissed away.
@@ -127,9 +134,25 @@
   $effect(() => {
     if (totalFlaggedCount === 0) flaggedOnly = false;
   });
+
+  let overBudgetOnly = $state(false);
+  const totalOverBudget = $derived(injectable.reduce((n, r) => n + droppedCount(r), 0));
+  $effect(() => {
+    if (totalOverBudget === 0) overBudgetOnly = false;
+  });
+
   const displayGroups = $derived(
-    flaggedOnly ? groups.filter((g) => flaggedCount(g.injectable) > 0) : groups,
+    !flaggedOnly && !overBudgetOnly
+      ? groups
+      : groups.filter(
+          (g) =>
+            (flaggedOnly && flaggedCount(g.injectable) > 0) ||
+            (overBudgetOnly && isOverBudget(g.injectable)),
+        ),
   );
+
+  // Change 3: Triage summary band — repos needing attention.
+  const attention = $derived(reposNeedingAttention(groups));
 
   // Deep-link: when opened from a repo's status row, scroll that repo's section into
   // view. Runs once on mount (a frame later, so the fly-in has laid out the sections).
@@ -155,15 +178,25 @@
   <header class="bar">
     <span class="title">{m.learnings_title()}</span>
     {#if totalFlaggedCount > 0}
+      <!-- Change 2: stable-labeled press toggle (no label swap) -->
       <button
         class="filter-toggle"
         type="button"
         aria-pressed={flaggedOnly}
         onclick={() => (flaggedOnly = !flaggedOnly)}
       >
-        {flaggedOnly
-          ? m.learnings_filter_all()
-          : m.learnings_filter_flagged({ count: totalFlaggedCount })}
+        {m.learnings_filter_flagged({ count: totalFlaggedCount })}
+      </button>
+    {/if}
+    {#if totalOverBudget > 0}
+      <!-- Change 2: over-budget toggle beside the not-working toggle -->
+      <button
+        class="filter-toggle"
+        type="button"
+        aria-pressed={overBudgetOnly}
+        onclick={() => (overBudgetOnly = !overBudgetOnly)}
+      >
+        {m.learnings_filter_overbudget({ count: totalOverBudget })}
       </button>
     {/if}
     <button class="close" onclick={() => onclose()} aria-label={m.learnings_close_aria()}>✕</button>
@@ -205,14 +238,102 @@
     <div class="about-body" id="learnings-about" hidden={!aboutOpen}>
       <p>{m.learnings_about_lead()} <strong>{m.learnings_about_scope()}</strong></p>
       <p>{m.learnings_about_flow()}</p>
+      <!-- Change 8: Budget explainer line -->
+      <p>{m.learnings_about_budget()}</p>
     </div>
   </section>
+
+  <!-- Change 3: Triage summary band — stable above group list, reflects ALL attention repos -->
+  {#if attention.length > 0}
+    <section class="triage" aria-label={m.learnings_triage_heading()}>
+      <span class="triage-label">{m.learnings_triage_heading()}</span>
+      <div class="triage-chips">
+        {#each attention as a (a.repoPath)}
+          <button
+            class="triage-chip"
+            type="button"
+            aria-label={m.learnings_triage_jump_aria({ repo: basename(a.repoPath) })}
+            onclick={() =>
+              document.getElementById(repoAnchorId(a.repoPath))?.scrollIntoView({ block: "start" })}
+          >
+            <span class="tc-repo">{basename(a.repoPath)}</span>
+            {#if a.droppedCount > 0}<span class="tc-over"
+                >{m.learnings_triage_over({ count: a.droppedCount })}</span
+              >{/if}
+            {#if a.flaggedCount > 0}<span class="tc-flagged"
+                >{m.learnings_triage_flagged({ count: a.flaggedCount })}</span
+              >{/if}
+          </button>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  <!-- Change 6: Injectable-rule snippet — single source, no copy-paste.
+       Accepts the repo's enabled flag so the badge reflects injection state correctly. -->
+  {#snippet irule(r: Learning & { injected: boolean }, enabled: boolean)}
+    {@const badge = injectionBadge(r, enabled)}
+    <article class="irule">
+      <p class="itext">{r.rule}</p>
+      <div class="ifoot">
+        <span class="chip" class:promoted={r.status === "promoted"}>
+          {r.status === "promoted" ? m.learnings_status_promoted() : m.learnings_status_active()}
+        </span>
+        {#if badge === "injected"}
+          <span class="badge ok">✓ {m.learnings_injected_badge()}</span>
+        {:else if badge === "over-budget"}
+          <span class="badge warn" title={m.learnings_overbudget_title()}>
+            ⊘ {m.learnings_overbudget_badge()}
+          </span>
+        {:else}
+          <span class="badge off">⊘ {m.learnings_injection_disabled_badge()}</span>
+        {/if}
+        {#if showIneffective(r)}
+          <span class="badge bad" title={m.learnings_ineffective_title()}>
+            ⚠ {m.learnings_ineffective_badge({ count: r.ineffectiveCount })}
+          </span>
+        {/if}
+        <span class="spacer"></span>
+        <div class="iactions">
+          {#if showIneffective(r)}
+            <button
+              class="optimize"
+              type="button"
+              onclick={() => onoptimize(r.id)}
+              aria-label={m.learnings_optimize_aria()}
+            >
+              {m.learnings_optimize()}
+            </button>
+          {/if}
+          {#if r.status === "active"}
+            <!-- Change 9: de-emphasised Dismiss with margin-left gap from Promote -->
+            <button class="dismiss dismiss-muted" onclick={() => ondismiss(r.id)}>
+              {m.learnings_dismiss()}
+            </button>
+            <button
+              class="promote"
+              onclick={() => onpromote(r.id)}
+              aria-label={m.learnings_promote_aria()}
+            >
+              {m.learnings_promote()}
+            </button>
+          {:else if r.status === "promoted" && r.promotedPrUrl}
+            <a class="prlink" href={r.promotedPrUrl} target="_blank" rel="noopener external">
+              {m.learnings_promoted_pr()}
+            </a>
+          {/if}
+        </div>
+      </div>
+    </article>
+  {/snippet}
 
   {#if empty}
     <p class="empty">{m.learnings_empty()}</p>
   {:else}
     {#each displayGroups as group (group.repoPath)}
+      <!-- Change 4: group container with left-accent border + faint surface -->
       <section class="group" id={repoAnchorId(group.repoPath)}>
+        <!-- Change 4: sticky repo header -->
         <div class="ghead">
           <span class="repo">{basename(group.repoPath)}</span>
           <button
@@ -224,7 +345,8 @@
           </button>
         </div>
 
-        {#each flaggedOnly ? [] : group.proposed as l (l.id)}
+        <!-- Change 7: hide proposals under either active lens -->
+        {#each flaggedOnly || overBudgetOnly ? [] : group.proposed as l (l.id)}
           <article class="rule">
             <textarea
               class="text"
@@ -293,17 +415,25 @@
 
         {#if group.injectable && group.injectable.rules.length > 0}
           {@const inj = group.injectable}
+          {@const lensActive = flaggedOnly || overBudgetOnly}
           <div class="injected">
             <div class="ihead">
               <span class="ititle">{m.learnings_injected_section()}</span>
-              <span class="meter">
-                {m.learnings_budget_meter({
-                  used: inj.usedChars,
-                  budget: inj.budgetChars,
-                  injected: injectedCount(inj),
-                  total: inj.rules.length,
-                })}
-              </span>
+              <!-- Change 5: conditional meter — dominant amber when over budget -->
+              {#if isOverBudget(inj)}
+                <span class="meter over"
+                  >{m.learnings_budget_over({ dropped: droppedCount(inj) })}</span
+                >
+              {:else}
+                <span class="meter">
+                  {m.learnings_budget_meter({
+                    injected: injectedCount(inj),
+                    total: inj.rules.length,
+                    used: inj.usedChars,
+                    budget: inj.budgetChars,
+                  })}
+                </span>
+              {/if}
               {#if flaggedCount(group.injectable) > 0}
                 <button
                   class="optimize-all"
@@ -314,67 +444,19 @@
                 </button>
               {/if}
             </div>
-            {#each flaggedOnly ? flaggedRules(group.injectable) : inj.rules as r (r.id)}
-              {@const badge = injectionBadge(r, inj.enabled)}
-              <article class="irule">
-                <p class="itext">{r.rule}</p>
-                <div class="ifoot">
-                  <span class="chip" class:promoted={r.status === "promoted"}>
-                    {r.status === "promoted"
-                      ? m.learnings_status_promoted()
-                      : m.learnings_status_active()}
-                  </span>
-                  {#if badge === "injected"}
-                    <span class="badge ok">✓ {m.learnings_injected_badge()}</span>
-                  {:else if badge === "over-budget"}
-                    <span class="badge warn" title={m.learnings_overbudget_title()}>
-                      ⊘ {m.learnings_overbudget_badge()}
-                    </span>
-                  {:else}
-                    <span class="badge off">⊘ {m.learnings_injection_disabled_badge()}</span>
-                  {/if}
-                  {#if showIneffective(r)}
-                    <span class="badge bad" title={m.learnings_ineffective_title()}>
-                      ⚠ {m.learnings_ineffective_badge({ count: r.ineffectiveCount })}
-                    </span>
-                  {/if}
-                  <span class="spacer"></span>
-                  <div class="iactions">
-                    {#if showIneffective(r)}
-                      <button
-                        class="optimize"
-                        type="button"
-                        onclick={() => onoptimize(r.id)}
-                        aria-label={m.learnings_optimize_aria()}
-                      >
-                        {m.learnings_optimize()}
-                      </button>
-                    {/if}
-                    {#if r.status === "active"}
-                      <button class="dismiss" onclick={() => ondismiss(r.id)}>
-                        {m.learnings_dismiss()}
-                      </button>
-                      <button
-                        class="promote"
-                        onclick={() => onpromote(r.id)}
-                        aria-label={m.learnings_promote_aria()}
-                      >
-                        {m.learnings_promote()}
-                      </button>
-                    {:else if r.status === "promoted" && r.promotedPrUrl}
-                      <a
-                        class="prlink"
-                        href={r.promotedPrUrl}
-                        target="_blank"
-                        rel="noopener external"
-                      >
-                        {m.learnings_promoted_pr()}
-                      </a>
-                    {/if}
-                  </div>
-                </div>
-              </article>
-            {/each}
+            <!-- Change 6: dropped-first rendering via snippet + splitDropped -->
+            {#if lensActive}
+              {#each visibleInjectableRules(inj, { flaggedOnly, overBudgetOnly }) as r (r.id)}
+                {@render irule(r, inj.enabled)}
+              {/each}
+            {:else}
+              {@const split = splitDropped(inj)}
+              {#if split.dropped.length > 0}
+                <p class="not-injected-label">{m.learnings_not_injected_label()}</p>
+                {#each split.dropped as r (r.id)}{@render irule(r, inj.enabled)}{/each}
+              {/if}
+              {#each split.injected as r (r.id)}{@render irule(r, inj.enabled)}{/each}
+            {/if}
           </div>
         {/if}
       </section>
@@ -421,8 +503,8 @@
     cursor: pointer;
     font-size: var(--fs-lg);
   }
-  /* "Not working" header filter — token-outlined like .distill; pressed state
-     reads as the active (amber) "flagged" lens. */
+  /* Header filters — token-outlined like .distill; pressed state
+     reads as the active (amber) lens. Both toggles share the same class. */
   .filter-toggle {
     margin-left: auto;
     font-size: var(--fs-meta);
@@ -499,22 +581,74 @@
     color: var(--color-ink-bright);
     font-weight: 600;
   }
+  /* Change 3: Triage summary band */
+  .triage {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 10px;
+    border: 1px solid var(--color-line);
+    background: var(--color-head);
+  }
+  .triage-label {
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-muted);
+  }
+  .triage-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .triage-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: none;
+    border: 1px solid var(--color-line-bright);
+    padding: 3px 8px;
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--fs-meta);
+  }
+  .triage-chip:hover {
+    border-color: var(--color-ink-bright);
+  }
+  .tc-repo {
+    color: var(--color-ink-bright);
+    font-weight: 600;
+  }
+  .tc-over,
+  .tc-flagged {
+    color: var(--color-amber);
+    font-size: var(--fs-meta);
+  }
   .empty {
     color: var(--color-muted);
     font-size: var(--fs-base);
     line-height: 1.5;
   }
+  /* Change 4: group container with left-accent border + faint surface */
   .group {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    border-left: 2px solid var(--color-line-bright);
+    background: var(--color-head);
+    padding: 6px 8px;
   }
+  /* Change 4: sticky repo header — opaque background so scrolled content doesn't bleed */
   .ghead {
     display: flex;
     align-items: center;
     justify-content: space-between;
     border-bottom: 1px solid var(--color-line);
     padding-bottom: 4px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--color-head);
   }
   .repo {
     font-size: var(--fs-base);
@@ -710,6 +844,11 @@
     color: var(--color-muted);
     font-variant-numeric: tabular-nums;
   }
+  /* Change 5: over-budget meter variant — dominant amber headline */
+  .meter.over {
+    color: var(--color-amber);
+    font-weight: 600;
+  }
   /* Per-repo "Optimize all flagged" — token-outlined small action, mirrors .optimize (amber, not green). */
   .optimize-all {
     margin-left: auto;
@@ -719,6 +858,14 @@
     color: var(--color-amber);
     padding: 3px 8px;
     cursor: pointer;
+  }
+  /* Change 6: "Not injected — over budget" sub-label */
+  .not-injected-label {
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-amber);
+    margin: 4px 0 2px;
   }
   .irule {
     border: 1px solid var(--color-line);
@@ -745,6 +892,12 @@
     display: flex;
     align-items: center;
     gap: 6px;
+  }
+  /* Change 9: de-emphasised Dismiss on active/promoted rules — muted + gap from Promote */
+  .dismiss-muted {
+    color: var(--color-muted);
+    border-color: var(--color-line);
+    margin-right: 4px;
   }
   .chip {
     font-size: var(--fs-micro);

--- a/ui/src/lib/components/learnings-drawer.test.ts
+++ b/ui/src/lib/components/learnings-drawer.test.ts
@@ -11,6 +11,12 @@ import {
   flaggedCount,
   totalFlagged,
   evidenceSources,
+  droppedCount,
+  isOverBudget,
+  sortGroupsForTriage,
+  splitDropped,
+  reposNeedingAttention,
+  visibleInjectableRules,
 } from "./learnings-drawer";
 import type { Learning, LearningStatus, RepoInjectable } from "../types";
 
@@ -193,5 +199,249 @@ describe("evidenceSources", () => {
   });
   it("returns [] when the server sent no breakdown (older payload)", () => {
     expect(evidenceSources(L("1", "/a"))).toEqual([]);
+  });
+});
+
+// ─── droppedCount / isOverBudget ─────────────────────────────────────────────
+
+describe("droppedCount / isOverBudget", () => {
+  it("enabled repo with dropped rules returns dropped count / true", () => {
+    const repo = IR("/a", [
+      { id: "1", injected: true },
+      { id: "2", injected: false },
+      { id: "3", injected: false },
+    ]);
+    expect(droppedCount(repo)).toBe(2);
+    expect(isOverBudget(repo)).toBe(true);
+  });
+
+  it("enabled all-injected → 0 / false", () => {
+    const repo = IR("/a", [
+      { id: "1", injected: true },
+      { id: "2", injected: true },
+    ]);
+    expect(droppedCount(repo)).toBe(0);
+    expect(isOverBudget(repo)).toBe(false);
+  });
+
+  it("disabled repo with all-uninjected rules → 0 / false (anti-mislabel case)", () => {
+    const repo = IR(
+      "/a",
+      [
+        { id: "1", injected: false },
+        { id: "2", injected: false },
+      ],
+      { enabled: false },
+    );
+    expect(droppedCount(repo)).toBe(0);
+    expect(isOverBudget(repo)).toBe(false);
+  });
+
+  it("null → 0 / false", () => {
+    expect(droppedCount(null)).toBe(0);
+    expect(isOverBudget(null)).toBe(false);
+  });
+});
+
+// ─── sortGroupsForTriage ──────────────────────────────────────────────────────
+
+describe("sortGroupsForTriage", () => {
+  it("reorders [plain, flagged, overBudget] → [overBudget, flagged, plain]", () => {
+    const plain = mergeRepoGroups(
+      [L("1", "/plain")],
+      [IR("/plain", [{ id: "1", injected: true }])],
+    )[0]!;
+    const flagged = mergeRepoGroups(
+      [L("2", "/flagged")],
+      [IR("/flagged", [{ id: "2", injected: true, ineffectiveCount: 1 }])],
+    )[0]!;
+    const overBudget = mergeRepoGroups(
+      [L("3", "/over")],
+      [IR("/over", [{ id: "3", injected: false }])],
+    )[0]!;
+
+    // input order: plain, flagged, overBudget (first-seen ≠ triage order)
+    const result = sortGroupsForTriage([plain, flagged, overBudget]);
+    expect(result.map((g) => g.repoPath)).toEqual(["/over", "/flagged", "/plain"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const groups = [
+      mergeRepoGroups([L("1", "/plain")], [IR("/plain", [{ id: "1", injected: true }])])[0]!,
+      mergeRepoGroups([L("2", "/over")], [IR("/over", [{ id: "2", injected: false }])])[0]!,
+    ];
+    const original = [...groups];
+    sortGroupsForTriage(groups);
+    expect(groups.map((g) => g.repoPath)).toEqual(original.map((g) => g.repoPath));
+  });
+
+  it("two over-budget repos preserve their relative input order (stability)", () => {
+    const over1 = mergeRepoGroups(
+      [L("1", "/over1")],
+      [IR("/over1", [{ id: "1", injected: false }])],
+    )[0]!;
+    const over2 = mergeRepoGroups(
+      [L("2", "/over2")],
+      [IR("/over2", [{ id: "2", injected: false }])],
+    )[0]!;
+    const result = sortGroupsForTriage([over1, over2]);
+    expect(result.map((g) => g.repoPath)).toEqual(["/over1", "/over2"]);
+  });
+
+  it("repo that is BOTH over-budget and flagged → tier 0 (over-budget wins)", () => {
+    const bothFlags = mergeRepoGroups(
+      [L("1", "/both")],
+      [IR("/both", [{ id: "1", injected: false, ineffectiveCount: 2 }])],
+    )[0]!;
+    const flaggedOnly = mergeRepoGroups(
+      [L("2", "/flagged")],
+      [IR("/flagged", [{ id: "2", injected: true, ineffectiveCount: 1 }])],
+    )[0]!;
+    const result = sortGroupsForTriage([flaggedOnly, bothFlags]);
+    expect(result[0]!.repoPath).toBe("/both");
+  });
+});
+
+// ─── splitDropped ─────────────────────────────────────────────────────────────
+
+describe("splitDropped", () => {
+  it("over-budget repo: dropped rules split from injected, each preserving order", () => {
+    const repo = IR("/a", [
+      { id: "1", injected: true },
+      { id: "2", injected: false },
+      { id: "3", injected: true },
+      { id: "4", injected: false },
+    ]);
+    const { dropped, injected } = splitDropped(repo);
+    expect(dropped.map((r) => r.id)).toEqual(["2", "4"]);
+    expect(injected.map((r) => r.id)).toEqual(["1", "3"]);
+  });
+
+  it("disabled repo → {dropped: [], injected: all rules} (no split, anti-mislabel)", () => {
+    const repo = IR(
+      "/a",
+      [
+        { id: "1", injected: false },
+        { id: "2", injected: false },
+      ],
+      { enabled: false },
+    );
+    const { dropped, injected } = splitDropped(repo);
+    expect(dropped).toEqual([]);
+    expect(injected.map((r) => r.id)).toEqual(["1", "2"]);
+  });
+
+  it("enabled all-injected → no split (dropped: [], injected: all)", () => {
+    const repo = IR("/a", [
+      { id: "1", injected: true },
+      { id: "2", injected: true },
+    ]);
+    const { dropped, injected } = splitDropped(repo);
+    expect(dropped).toEqual([]);
+    expect(injected.map((r) => r.id)).toEqual(["1", "2"]);
+  });
+
+  it("null → {dropped: [], injected: []}", () => {
+    const { dropped, injected } = splitDropped(null);
+    expect(dropped).toEqual([]);
+    expect(injected).toEqual([]);
+  });
+});
+
+// ─── reposNeedingAttention ────────────────────────────────────────────────────
+
+describe("reposNeedingAttention", () => {
+  it("returns only repos that are over-budget or flagged, in triage order", () => {
+    const plain = mergeRepoGroups(
+      [L("1", "/plain")],
+      [IR("/plain", [{ id: "1", injected: true }])],
+    )[0]!;
+    const flaggedG = mergeRepoGroups(
+      [L("2", "/flagged")],
+      [IR("/flagged", [{ id: "2", injected: true, ineffectiveCount: 1 }])],
+    )[0]!;
+    const overBudgetG = mergeRepoGroups(
+      [L("3", "/over")],
+      [IR("/over", [{ id: "3", injected: false }])],
+    )[0]!;
+
+    // input order: plain, flagged, overBudget
+    const result = reposNeedingAttention([plain, flaggedG, overBudgetG]);
+    // plain excluded; over-budget comes first; correct counts
+    expect(result).toEqual([
+      { repoPath: "/over", droppedCount: 1, flaggedCount: 0 },
+      { repoPath: "/flagged", droppedCount: 0, flaggedCount: 1 },
+    ]);
+  });
+
+  it("returns [] when no repo needs attention", () => {
+    const plain = mergeRepoGroups(
+      [L("1", "/plain")],
+      [IR("/plain", [{ id: "1", injected: true }])],
+    )[0]!;
+    expect(reposNeedingAttention([plain])).toEqual([]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(reposNeedingAttention([])).toEqual([]);
+  });
+});
+
+// ─── visibleInjectableRules ───────────────────────────────────────────────────
+
+describe("visibleInjectableRules", () => {
+  it("null repo → []", () => {
+    expect(visibleInjectableRules(null, { flaggedOnly: false, overBudgetOnly: false })).toEqual([]);
+    expect(visibleInjectableRules(null, { flaggedOnly: true, overBudgetOnly: true })).toEqual([]);
+  });
+
+  it("no lens active → all rules in original order", () => {
+    const repo = IR("/a", [
+      { id: "1", injected: true },
+      { id: "2", injected: false },
+      { id: "3", injected: true, ineffectiveCount: 1 },
+    ]);
+    const rules = visibleInjectableRules(repo, { flaggedOnly: false, overBudgetOnly: false });
+    expect(rules.map((r) => r.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("flaggedOnly → only flagged rules", () => {
+    const repo = IR("/a", [
+      { id: "1", injected: true, ineffectiveCount: 2 },
+      { id: "2", injected: true, ineffectiveCount: 0 },
+      { id: "3", injected: false, ineffectiveCount: 0 },
+    ]);
+    const rules = visibleInjectableRules(repo, { flaggedOnly: true, overBudgetOnly: false });
+    expect(rules.map((r) => r.id)).toEqual(["1"]);
+  });
+
+  it("overBudgetOnly → only dropped rules (and empty when repo is not over-budget)", () => {
+    const repo = IR("/a", [
+      { id: "1", injected: true },
+      { id: "2", injected: false },
+      { id: "3", injected: false },
+    ]);
+    const rules = visibleInjectableRules(repo, { flaggedOnly: false, overBudgetOnly: true });
+    expect(rules.map((r) => r.id)).toEqual(["2", "3"]);
+
+    // disabled repo: not over-budget → empty
+    const disabledRepo = IR("/b", [{ id: "4", injected: false }], { enabled: false });
+    const disabledRules = visibleInjectableRules(disabledRepo, {
+      flaggedOnly: false,
+      overBudgetOnly: true,
+    });
+    expect(disabledRules).toEqual([]);
+  });
+
+  it("both lenses: union deduped — a rule that is both flagged AND dropped appears once", () => {
+    const repo = IR("/a", [
+      { id: "1", injected: false, ineffectiveCount: 2 }, // both flagged + dropped
+      { id: "2", injected: true, ineffectiveCount: 1 }, // flagged only
+      { id: "3", injected: false, ineffectiveCount: 0 }, // dropped only
+      { id: "4", injected: true, ineffectiveCount: 0 }, // neither
+    ]);
+    const rules = visibleInjectableRules(repo, { flaggedOnly: true, overBudgetOnly: true });
+    // union: ids 1 (flagged+dropped), 2 (flagged), 3 (dropped); in repo order
+    expect(rules.map((r) => r.id)).toEqual(["1", "2", "3"]);
   });
 });

--- a/ui/src/lib/components/learnings-drawer.ts
+++ b/ui/src/lib/components/learnings-drawer.ts
@@ -97,6 +97,89 @@ export function totalFlagged(injectable: RepoInjectable[]): number {
   return injectable.reduce((n, r) => n + flaggedCount(r), 0);
 }
 
+// ─── triage helpers ───────────────────────────────────────────────────────────
+
+/** Count of rules the planner dropped (didn't fit budget) for an enabled repo.
+ *  Null repo → 0. Disabled repo → 0 (rules are uninjected because injection is
+ *  off, NOT budget pressure — the single authoritative "over budget" predicate). */
+export function droppedCount(repo: RepoInjectable | null): number {
+  return repo && repo.enabled ? repo.rules.filter((r) => !r.injected).length : 0;
+}
+
+/** True when the repo has ≥1 rule the planner dropped due to budget pressure. */
+export function isOverBudget(repo: RepoInjectable | null): boolean {
+  return droppedCount(repo) > 0;
+}
+
+/** Sort a repo-group array into triage order (new array, input not mutated):
+ *  tier 0 = over-budget, tier 1 = flagged-only, tier 2 = everything else.
+ *  Within each tier the original (first-seen) order is preserved (stable). */
+export function sortGroupsForTriage(groups: RepoGroup[]): RepoGroup[] {
+  function tier(g: RepoGroup): number {
+    if (isOverBudget(g.injectable)) return 0;
+    if (flaggedCount(g.injectable) > 0) return 1;
+    return 2;
+  }
+  return groups
+    .map((g, i) => ({ g, i }))
+    .sort((a, b) => tier(a.g) - tier(b.g) || a.i - b.i)
+    .map(({ g }) => g);
+}
+
+/** Split a repo's rules into dropped vs injected subsets for over-budget display.
+ *  Only splits when `isOverBudget(repo)` is true — disabled repos and repos
+ *  without dropped rules are returned unsplit (all rules in `injected`) so the
+ *  drawer doesn't mislabel a disabled repo's rules as "not injected". */
+export function splitDropped(repo: RepoInjectable | null): {
+  dropped: (Learning & { injected: boolean })[];
+  injected: (Learning & { injected: boolean })[];
+} {
+  if (!repo) return { dropped: [], injected: [] };
+  if (!isOverBudget(repo)) return { dropped: [], injected: repo.rules };
+  return {
+    dropped: repo.rules.filter((r) => !r.injected),
+    injected: repo.rules.filter((r) => r.injected),
+  };
+}
+
+/** Repos that need operator attention (over-budget OR flagged), in triage order.
+ *  Returns one entry per qualifying group with its dropped/flagged counts. */
+export function reposNeedingAttention(
+  groups: RepoGroup[],
+): { repoPath: string; droppedCount: number; flaggedCount: number }[] {
+  return sortGroupsForTriage(groups)
+    .filter((g) => isOverBudget(g.injectable) || flaggedCount(g.injectable) > 0)
+    .map((g) => ({
+      repoPath: g.repoPath,
+      droppedCount: droppedCount(g.injectable),
+      flaggedCount: flaggedCount(g.injectable),
+    }));
+}
+
+/** Rules visible under the active lens combination for a repo.
+ *  No lens → all rules (caller handles dropped-first ordering via splitDropped).
+ *  A lens active → union (deduped by id, preserving repo.rules order) of:
+ *    flaggedOnly  → rules with ineffectiveCount > 0
+ *    overBudgetOnly → dropped rules (only when repo is actually over-budget) */
+export function visibleInjectableRules(
+  repo: RepoInjectable | null,
+  lenses: { flaggedOnly: boolean; overBudgetOnly: boolean },
+): (Learning & { injected: boolean })[] {
+  if (!repo) return [];
+  if (!lenses.flaggedOnly && !lenses.overBudgetOnly) return repo.rules;
+  const ids = new Set<string>();
+  const result: (Learning & { injected: boolean })[] = [];
+  for (const r of repo.rules) {
+    const wantFlagged = lenses.flaggedOnly && r.ineffectiveCount > 0;
+    const wantDropped = lenses.overBudgetOnly && !r.injected && isOverBudget(repo);
+    if ((wantFlagged || wantDropped) && !ids.has(r.id)) {
+      ids.add(r.id);
+      result.push(r);
+    }
+  }
+  return result;
+}
+
 /** Stable display order for the evidence breakdown: most operator-meaningful
  *  source first (a correction you gave) down to passive ones (a stall). */
 const KIND_ORDER: SignalKind[] = ["reply", "critic", "block", "stall"];

--- a/ui/src/lib/components/learnings-drawer.ts
+++ b/ui/src/lib/components/learnings-drawer.ts
@@ -167,11 +167,12 @@ export function visibleInjectableRules(
 ): (Learning & { injected: boolean })[] {
   if (!repo) return [];
   if (!lenses.flaggedOnly && !lenses.overBudgetOnly) return repo.rules;
+  const overBudget = isOverBudget(repo);
   const ids = new Set<string>();
   const result: (Learning & { injected: boolean })[] = [];
   for (const r of repo.rules) {
     const wantFlagged = lenses.flaggedOnly && r.ineffectiveCount > 0;
-    const wantDropped = lenses.overBudgetOnly && !r.injected && isOverBudget(repo);
+    const wantDropped = lenses.overBudgetOnly && !r.injected && overBudget;
     if ((wantFlagged || wantDropped) && !ids.has(r.id)) {
       ids.add(r.id);
       result.push(r);

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -1,17 +1,12 @@
 import type { AutoMergeStatus, DrainStatus, Learning, RepoInjectable, Session } from "../types";
 import { m } from "$lib/paraglide/messages";
+import { droppedCount } from "./learnings-drawer";
 
 /** Enabled drains only, sorted by repo path — the per-repo drain lookup feeding repoChipRows. */
 export function enabledDrains(drain: Record<string, DrainStatus>): DrainStatus[] {
   return Object.values(drain)
     .filter((d) => d.enabled)
     .sort((a, b) => a.repoPath.localeCompare(b.repoPath));
-}
-
-/** Count of an injectable repo's active rules that didn't fit its budget — only
- *  meaningful when injection is enabled (pruning can free room; disabled → 0). */
-function overBudgetCount(repo: RepoInjectable): number {
-  return repo.enabled ? repo.rules.filter((r) => !r.injected).length : 0;
 }
 
 /** Shared map-building for insights (Learning counts per repo) and curate
@@ -25,7 +20,7 @@ function buildInsightsCurateMaps(
 
   const curateByRepo = new Map<string, number>();
   for (const r of injectable) {
-    const n = overBudgetCount(r);
+    const n = droppedCount(r);
     if (n > 0) curateByRepo.set(r.repoPath, n);
   }
   return { insightsByRepo, curateByRepo };
@@ -109,7 +104,7 @@ export function globalLearningsCounts(
 ): { proposed: number; curate: number } {
   return {
     proposed: items.length,
-    curate: injectable.reduce((sum, r) => sum + overBudgetCount(r), 0),
+    curate: injectable.reduce((sum, r) => sum + droppedCount(r), 0),
   };
 }
 
@@ -117,7 +112,7 @@ export function globalLearningsCounts(
  *  rule, or null. Used to deep-link the global learnings chip straight to the
  *  rules that need trimming when there's nothing to approve. */
 export function firstCurateRepo(injectable: RepoInjectable[]): string | null {
-  return injectable.find((r) => overBudgetCount(r) > 0)?.repoPath ?? null;
+  return injectable.find((r) => droppedCount(r) > 0)?.repoPath ?? null;
 }
 
 /** Whether the `queued` indicator is an interactive trigger (opens the queue

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1102,4 +1102,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_visual_recap_wireframes_body",
     targetId: "session-recap",
   },
+  {
+    // No targetId: the triage band, over-budget meter, and header filters all render conditionally
+    // (only when a repo needs attention), so there's no stable anchor element; surface via the
+    // What's-New drawer only. 1.33.0 is the latest released tag, so this ships in 1.34.0.
+    id: "learnings-triage-layer",
+    sinceVersion: "1.34.0",
+    titleKey: "feat_learnings_triage_title",
+    bodyKey: "feat_learnings_triage_body",
+  },
 ];


### PR DESCRIPTION
Closes #796. Adds a triage layer to the Learnings drawer so an operator can see at a glance which repos need attention, without scrolling and doing budget math rule-by-rule — and never loses track of which repo they're acting in. Implements the #794 UX pass (items 1–4 + quick wins). **No data-model/server changes** — all triage state is derived client-side from the existing `RepoInjectable` payload.

## Key design decision
The issue's literal trigger `usedChars > budgetChars` **never fires** — the planner greedily fits rules *under* budget (`src/house-rules.ts`), so `usedChars ≤ budgetChars` always. "Over budget" is instead the app-wide signal already used by the TopBar curate badge: **`enabled && ≥1 rule dropped (!injected)`**. The over-budget headline leads with the **dropped count**; the always-≤budget `used/budget` ratio is **omitted** in that state (showing `3900/4000` while flagged amber reads as "within budget" — contradictory).

## What's in it
- **Sticky repo headers + group container** — `.ghead` pins while scrolling within a repo; each `.group` gets a faint container (left accent + `--color-head`) so a new repo reads as a new container.
- **Over-budget as a visible state** — amber meter leading with `Over budget · N not injected`; over-budget rules render **first** under a "Not injected — over budget" sub-label (gated strictly on `isOverBudget`, so disabled repos — all-uninjected but *not* over budget — keep current ordering/labeling).
- **Triage floats up** — `sortGroupsForTriage`: over-budget → flagged → first-seen, stable within tier. `mergeRepoGroups`' first-seen contract left intact (sort is a separate pure pass).
- **Triage summary band** — one jump chip per attention repo (built from unfiltered groups so it's a stable jump aid); a chip click clears active filters then scrolls so it always lands. Hidden when nothing needs attention.
- **Quick wins** — "Over budget" header filter beside "Not working" (independent toggles, union semantics; `visibleInjectableRules` returns flagged ∪ dropped deduped); de-emphasised destructive Dismiss on active rules; clarified meter string; explainer line on the shared global budget.

## Single authoritative predicate
`droppedCount`/`isOverBudget` live once in `learnings-drawer.ts`; `queue-strip.ts` drops its private `overBudgetCount` and imports it — triage count, curate badge, and meter can't drift.

## Out of scope (follow-up, touches data model)
Non-destructive budget remedy + Dismiss confirm, and per-rule char-cost cue — per the issue these warrant a design note and a separate PR. Dismiss here is only spatially de-emphasised, no behavior change.

## Tests & gates
- 20 new unit tests for the pure helpers in `learnings-drawer.test.ts` (the `sortGroupsForTriage` regression test fails on first-seen output; disabled-repo anti-mislabel cases covered). Full suite: **1616 pass**.
- `bun run check` (0 errors), `check:i18n` (1528 keys, EN+DE parity), fallow delta audit (0 issues) — all green.
- One `feature-announcements.ts` entry (`learnings-triage-layer`, `sinceVersion 1.34.0`) + EN/DE keys.

## Review process
Built subagent-driven: 3 implementer tasks each spec+quality reviewed, then a whole-branch review (returned READY TO MERGE; its one Important finding — triage chips dead-jumping under an active filter — is fixed in 94fe5102).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
