### PR TITLE
feat(plan): question-form answer round-trip (#803)

### DIFF
--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -8,7 +8,12 @@ import type { HerdrDriver } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
 import type { Session, PlanGate, PlanDecision } from "./types";
 import type { GitForge } from "./forge/types";
-import { type VisualBlock, parseVisualBlocks, groundPlanBlocks } from "./visual-blocks";
+import {
+  type VisualBlock,
+  type QuestionKind,
+  parseVisualBlocks,
+  groundPlanBlocks,
+} from "./visual-blocks";
 import { readonlyReviewerArgv } from "./reviewer-argv";
 import {
   isApiKeyMode,
@@ -697,6 +702,107 @@ function planSteerText(findings: string[]): string {
   return (
     "The plan reviewer raised these points on `.shepherd-plan.md`. Revise the plan to address each, then stop so it can be re-reviewed:\n\n" +
     findings.map((f, i) => `${i + 1}. ${f}`).join("\n") +
+    "\n\nDon't start implementing yet — wait for the plan to be approved."
+  );
+}
+
+// ── Operator answer round-trip (#803) ──────────────────────────────────────────
+
+/** Raw operator answer from the UI — resolved against the gate's persisted questions.
+ *  `optionIndices` is for single (one) / multi (zero+); `text` is for freeform. */
+export interface RawAnswer {
+  blockId: string;
+  questionId: string;
+  optionIndices?: number[];
+  text?: string;
+}
+
+/** A validated answer keyed to a real persisted question. `selected` holds resolved option
+ *  labels (single: 1, multi: 0+); `text` is present only for freeform. */
+export interface ResolvedAnswer {
+  prompt: string;
+  kind: QuestionKind;
+  selected: string[];
+  text?: string;
+}
+
+/** Resolve raw operator answers against a gate's persisted question-form blocks. Pure, fail-closed.
+ *  Questions are keyed by (blockId, questionId) — id uniqueness is only per-block — so the same
+ *  questionId in two blocks never clobbers. Drops answers with no matching question. Per kind:
+ *   - single: exactly one in-range index kept; otherwise dropped.
+ *   - multi: in-range indices kept (deduped, order-preserving); an empty set is kept as an
+ *     answered "none selected" (distinct from an absent answer).
+ *   - freeform: trimmed non-empty text kept; blank dropped. */
+export function resolvePlanAnswers(blocks: VisualBlock[], answers: RawAnswer[]): ResolvedAnswer[] {
+  if (!Array.isArray(answers)) return [];
+  const byKey = indexQuestions(blocks);
+  const out: ResolvedAnswer[] = [];
+  for (const a of answers) {
+    if (!a || typeof a.blockId !== "string" || typeof a.questionId !== "string") continue;
+    const q = byKey.get(`${a.blockId} ${a.questionId}`);
+    if (!q) continue;
+    const resolved = resolveOne(q, a);
+    if (resolved) out.push(resolved);
+  }
+  return out;
+}
+
+type IndexedQuestion = { prompt: string; kind: QuestionKind; options: string[] };
+
+/** Index a gate's question-form questions by (blockId, questionId) — id uniqueness is only
+ *  per-block, so this namespacing keeps the same questionId in two blocks from clobbering. */
+function indexQuestions(blocks: VisualBlock[]): Map<string, IndexedQuestion> {
+  const byKey = new Map<string, IndexedQuestion>();
+  for (const b of blocks) {
+    if (b.type !== "question-form") continue;
+    for (const q of b.questions) {
+      byKey.set(`${b.id} ${q.id}`, { prompt: q.prompt, kind: q.kind, options: q.options ?? [] });
+    }
+  }
+  return byKey;
+}
+
+/** Map raw option indices to their labels — integer, in-range, deduped, order-preserving. */
+function resolveOptionLabels(indices: unknown, options: string[]): string[] {
+  if (!Array.isArray(indices)) return [];
+  const seen = new Set<number>();
+  const out: string[] = [];
+  for (const i of indices) {
+    if (!Number.isInteger(i) || i < 0 || i >= options.length || seen.has(i)) continue;
+    seen.add(i);
+    out.push(options[i]!); // bounds-checked above
+  }
+  return out;
+}
+
+/** Resolve a single raw answer against its question, fail-closed. null = drop. Per kind:
+ *   single = exactly one in-range index; multi = in-range indices (empty kept as "none selected");
+ *   freeform = trimmed non-empty text. */
+function resolveOne(q: IndexedQuestion, a: RawAnswer): ResolvedAnswer | null {
+  if (q.kind === "freeform") {
+    const text = typeof a.text === "string" ? a.text.trim() : "";
+    return text ? { prompt: q.prompt, kind: "freeform", selected: [], text } : null;
+  }
+  const selected = resolveOptionLabels(a.optionIndices, q.options);
+  if (q.kind === "single") {
+    return selected.length === 1 ? { prompt: q.prompt, kind: "single", selected } : null;
+  }
+  return { prompt: q.prompt, kind: "multi", selected };
+}
+
+/** Agent-facing steer that carries the operator's plan answers into the planning PTY. NOT i18n'd. */
+export function planAnswerSteerText(resolved: ResolvedAnswer[]): string {
+  const lines = resolved.map((r) => {
+    let answer: string;
+    if (r.kind === "freeform") answer = r.text ?? "";
+    else if (r.kind === "multi")
+      answer = r.selected.length ? r.selected.join(", ") : "(none selected)";
+    else answer = r.selected[0] ?? "";
+    return `- ${r.prompt}\n  → ${answer}`;
+  });
+  return (
+    "The operator answered the open questions on `.shepherd-plan.md`. Incorporate each answer into the plan, then stop so it can be re-reviewed:\n\n" +
+    lines.join("\n") +
     "\n\nDon't start implementing yet — wait for the plan to be approved."
   );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import {
   validateEpicRunPatch,
   validateEgressExtraHosts,
 } from "./validate";
+import { resolvePlanAnswers, planAnswerSteerText, type RawAnswer } from "./plan-gate";
 import { slugifyManual } from "./namer";
 import { planHouseRulesInjection, prioritize } from "./house-rules";
 import {
@@ -1274,6 +1275,47 @@ function handleSessionGo({ req, parts, deps }: Ctx): Response | null {
     : json({ error: "plan not approved or not in planning phase" }, 409);
 }
 
+// POST /api/sessions/:id/answer-plan-questions — steer the operator's answers to the gate's
+// question-form blocks back into the live planning agent (#803). Planning-phase only: the gate +
+// its questions persist past approval and AUTO sessions auto-release into execution, so without the
+// guard an operator could steer "incorporate answers, stop" into an already-executing agent.
+// Mirrors handleSessionReply's content-type + body-shape guards.
+async function handleSessionAnswerPlanQuestions({
+  req,
+  parts,
+  deps,
+}: Ctx): Promise<Response | null> {
+  if (!(req.method === "POST" && parts[2] && parts[3] === "answer-plan-questions")) return null;
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+  const body = await req.json().catch(() => null);
+  const answers = (body as { answers?: unknown } | null)?.answers;
+  if (
+    !Array.isArray(answers) ||
+    !answers.every(
+      (a) =>
+        !!a &&
+        typeof a === "object" &&
+        typeof (a as RawAnswer).blockId === "string" &&
+        typeof (a as RawAnswer).questionId === "string",
+    )
+  ) {
+    return json({ error: "body must be {answers: RawAnswer[]}" }, 400);
+  }
+  const id = parts[2];
+  const s = deps.store.get(id);
+  if (!s) return json({ error: "not found" }, 404);
+  if (s.planPhase !== "planning") return json({ error: "not in planning phase" }, 409);
+  const gate = deps.store.getPlanGate(id);
+  if (!gate || !gate.blocks?.some((b) => b.type === "question-form")) {
+    return json({ error: "no plan questions" }, 409);
+  }
+  const resolved = resolvePlanAnswers(gate.blocks, answers as RawAnswer[]);
+  if (resolved.length === 0) return json({ error: "no answers resolved" }, 400);
+  const delivered = deps.service.reply(id, planAnswerSteerText(resolved));
+  return json({ ok: true, delivered });
+}
+
 // POST /api/sessions/:id/preview/start — steer the agent to start its dev server.
 // Flow: already_bound? → 409. Resolve command (body.command ?? detectDevCommand). No
 // command? → 409. Steer → true → 200; false (dead pane / unknown) → 404.
@@ -1890,6 +1932,7 @@ async function handleSessions(ctx: Ctx): Promise<Response | null> {
     handleSessionDelete,
     handleSessionReply,
     handleSessionGo,
+    handleSessionAnswerPlanQuestions,
     handleSessionReviewPlan,
     handleSessionReviewPr,
     handleSessionRecapRegenerate,

--- a/test/plan-answers.test.ts
+++ b/test/plan-answers.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import type { VisualBlock } from "../src/visual-blocks";
+import { resolvePlanAnswers, planAnswerSteerText, type RawAnswer } from "../src/plan-gate";
+
+const blocks: VisualBlock[] = [
+  {
+    type: "question-form",
+    id: "qf1",
+    questions: [
+      {
+        id: "q1",
+        prompt: "Which approach?",
+        kind: "single",
+        options: ["Reuse column", "New table"],
+      },
+      { id: "q2", prompt: "Edge cases?", kind: "multi", options: ["Empty", "Huge", "Unicode"] },
+      { id: "q3", prompt: "Notes?", kind: "freeform" },
+    ],
+  },
+];
+
+describe("resolvePlanAnswers", () => {
+  it("resolves single/multi/freeform against persisted options", () => {
+    const answers: RawAnswer[] = [
+      { blockId: "qf1", questionId: "q1", optionIndices: [1] },
+      { blockId: "qf1", questionId: "q2", optionIndices: [0, 2] },
+      { blockId: "qf1", questionId: "q3", text: "  keep it minimal  " },
+    ];
+    const r = resolvePlanAnswers(blocks, answers);
+    expect(r).toEqual([
+      { prompt: "Which approach?", kind: "single", selected: ["New table"] },
+      { prompt: "Edge cases?", kind: "multi", selected: ["Empty", "Unicode"] },
+      { prompt: "Notes?", kind: "freeform", selected: [], text: "keep it minimal" },
+    ]);
+  });
+
+  it("keeps an empty multi-select as an answered 'none selected'", () => {
+    const r = resolvePlanAnswers(blocks, [{ blockId: "qf1", questionId: "q2", optionIndices: [] }]);
+    expect(r).toEqual([{ prompt: "Edge cases?", kind: "multi", selected: [] }]);
+  });
+
+  it("drops unknown ids, out-of-range single indices, and blank freeform", () => {
+    const r = resolvePlanAnswers(blocks, [
+      { blockId: "qf1", questionId: "nope", optionIndices: [0] },
+      { blockId: "other", questionId: "q1", optionIndices: [0] },
+      { blockId: "qf1", questionId: "q1", optionIndices: [99] },
+      { blockId: "qf1", questionId: "q3", text: "   " },
+    ]);
+    expect(r).toEqual([]);
+  });
+
+  it("dedups + drops out-of-range multi indices, order-preserving", () => {
+    const r = resolvePlanAnswers(blocks, [
+      { blockId: "qf1", questionId: "q2", optionIndices: [2, 0, 2, 5] },
+    ]);
+    expect(r).toEqual([{ prompt: "Edge cases?", kind: "multi", selected: ["Unicode", "Empty"] }]);
+  });
+
+  it("does not clobber the same questionId across two blocks (namespaced by blockId)", () => {
+    const two: VisualBlock[] = [
+      {
+        type: "question-form",
+        id: "a",
+        questions: [{ id: "q", prompt: "A?", kind: "single", options: ["a0", "a1"] }],
+      },
+      {
+        type: "question-form",
+        id: "b",
+        questions: [{ id: "q", prompt: "B?", kind: "single", options: ["b0", "b1"] }],
+      },
+    ];
+    const r = resolvePlanAnswers(two, [
+      { blockId: "a", questionId: "q", optionIndices: [0] },
+      { blockId: "b", questionId: "q", optionIndices: [1] },
+    ]);
+    expect(r).toEqual([
+      { prompt: "A?", kind: "single", selected: ["a0"] },
+      { prompt: "B?", kind: "single", selected: ["b1"] },
+    ]);
+  });
+
+  it("returns [] for non-array answers", () => {
+    expect(resolvePlanAnswers(blocks, undefined as unknown as RawAnswer[])).toEqual([]);
+  });
+});
+
+describe("planAnswerSteerText", () => {
+  it("composes prose with each answered prompt + answer and the stop instruction", () => {
+    const text = planAnswerSteerText([
+      { prompt: "Which approach?", kind: "single", selected: ["New table"] },
+      { prompt: "Edge cases?", kind: "multi", selected: ["Empty", "Unicode"] },
+      { prompt: "Notes?", kind: "freeform", selected: [], text: "keep it minimal" },
+    ]);
+    expect(text).toContain(
+      "Incorporate each answer into the plan, then stop so it can be re-reviewed",
+    );
+    expect(text).toContain("- Which approach?\n  → New table");
+    expect(text).toContain("- Edge cases?\n  → Empty, Unicode");
+    expect(text).toContain("- Notes?\n  → keep it minimal");
+    expect(text).toContain("Don't start implementing yet");
+  });
+
+  it("renders an empty multi-select as (none selected)", () => {
+    const text = planAnswerSteerText([{ prompt: "Edge cases?", kind: "multi", selected: [] }]);
+    expect(text).toContain("- Edge cases?\n  → (none selected)");
+  });
+});

--- a/test/server-plan-gate.test.ts
+++ b/test/server-plan-gate.test.ts
@@ -185,6 +185,203 @@ test("POST /api/sessions/:id/review-plan → 404 for unknown id", async () => {
   expect(called).toBe(false);
 });
 
+// ── POST /api/sessions/:id/answer-plan-questions (#803) ─────────────────────
+
+function seedPlanningSession(
+  store: SessionStore,
+  opts: { suffix: string; phase?: Session["planPhase"]; withForm?: boolean },
+): string {
+  const seeded = store.create({
+    name: "p",
+    prompt: "go",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: `shepherd/${opts.suffix}`,
+    worktreePath: join(repoDir, `wt-${opts.suffix}`),
+    isolated: true,
+    herdrSession: `sess-${opts.suffix}`,
+    herdrAgentId: `term_${opts.suffix}`,
+    claudeSessionId: `claude-${opts.suffix}`,
+    model: null,
+  });
+  store.setPlanPhase(seeded.id, opts.phase ?? "planning");
+  const gate: PlanGate = {
+    sessionId: seeded.id,
+    planHash: "h",
+    decision: "approved",
+    summary: "ok",
+    body: "",
+    findings: [],
+    round: 0,
+    cap: 3,
+    approved: true,
+    plan: "the plan",
+    updatedAt: 1000,
+    blocks: opts.withForm
+      ? [
+          {
+            type: "question-form",
+            id: "qf1",
+            questions: [
+              { id: "q1", prompt: "Which approach?", kind: "single", options: ["Reuse", "New"] },
+            ],
+          },
+        ]
+      : [{ type: "rich-text", id: "rt", markdown: "no questions here" }],
+  };
+  store.putPlanGate(gate);
+  return seeded.id;
+}
+
+const POST_ANSWERS = (answers: unknown) => ({
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ answers }),
+});
+
+test("POST answer-plan-questions → composes steer, calls reply, returns delivered", async () => {
+  const replies: Array<{ id: string; text: string }> = [];
+  const store = new SessionStore(":memory:");
+  const { app } = (() => {
+    const deps: AppDeps = {
+      store,
+      service: {
+        reply: (id: string, text: string) => {
+          replies.push({ id, text });
+          return true;
+        },
+      } as any,
+      events: new EventHub(),
+      usageLimits: { limits: () => ({}) } as any,
+    };
+    return { app: makeApp(deps) };
+  })();
+  const id = seedPlanningSession(store, { suffix: "a", withForm: true });
+  const res = await app.fetch(
+    new Request(
+      `http://x/api/sessions/${id}/answer-plan-questions`,
+      POST_ANSWERS([{ blockId: "qf1", questionId: "q1", optionIndices: [1] }]),
+    ),
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, delivered: true });
+  expect(replies.length).toBe(1);
+  expect(replies[0]!.id).toBe(id);
+  expect(replies[0]!.text).toContain("- Which approach?\n  → New");
+  expect(replies[0]!.text).toContain("then stop so it can be re-reviewed");
+});
+
+test("POST answer-plan-questions → delivered:false when reply can't reach the pane", async () => {
+  const store = new SessionStore(":memory:");
+  const deps: AppDeps = {
+    store,
+    service: { reply: () => false } as any,
+    events: new EventHub(),
+    usageLimits: { limits: () => ({}) } as any,
+  };
+  const app = makeApp(deps);
+  const id = seedPlanningSession(store, { suffix: "b", withForm: true });
+  const res = await app.fetch(
+    new Request(
+      `http://x/api/sessions/${id}/answer-plan-questions`,
+      POST_ANSWERS([{ blockId: "qf1", questionId: "q1", optionIndices: [0] }]),
+    ),
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, delivered: false });
+});
+
+test("POST answer-plan-questions → 415 without JSON content-type", async () => {
+  const { app, store } = harness();
+  const id = seedPlanningSession(store, { suffix: "ct", withForm: true });
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${id}/answer-plan-questions`, {
+      method: "POST",
+      body: JSON.stringify({ answers: [] }),
+    }),
+  );
+  expect(res.status).toBe(415);
+});
+
+test("POST answer-plan-questions → 400 on bad body shape", async () => {
+  const { app, store } = harness({ service: { reply: () => true } as any });
+  const id = seedPlanningSession(store, { suffix: "shape", withForm: true });
+  const res = await app.fetch(
+    new Request(
+      `http://x/api/sessions/${id}/answer-plan-questions`,
+      POST_ANSWERS([{ questionId: "q1" }]), // missing blockId
+    ),
+  );
+  expect(res.status).toBe(400);
+});
+
+test("POST answer-plan-questions → 404 for unknown session", async () => {
+  const { app } = harness({ service: { reply: () => true } as any });
+  const res = await app.fetch(
+    new Request(
+      "http://x/api/sessions/nope/answer-plan-questions",
+      POST_ANSWERS([{ blockId: "qf1", questionId: "q1", optionIndices: [0] }]),
+    ),
+  );
+  expect(res.status).toBe(404);
+});
+
+test("POST answer-plan-questions → 409 when session is not in planning phase", async () => {
+  let called = false;
+  const { app, store } = harness({
+    service: {
+      reply: () => {
+        called = true;
+        return true;
+      },
+    } as any,
+  });
+  const id = seedPlanningSession(store, { suffix: "exec", phase: "executing", withForm: true });
+  const res = await app.fetch(
+    new Request(
+      `http://x/api/sessions/${id}/answer-plan-questions`,
+      POST_ANSWERS([{ blockId: "qf1", questionId: "q1", optionIndices: [0] }]),
+    ),
+  );
+  expect(res.status).toBe(409);
+  expect((await res.json()).error).toContain("planning");
+  expect(called).toBe(false);
+});
+
+test("POST answer-plan-questions → 409 when the gate has no question-form", async () => {
+  const { app, store } = harness({ service: { reply: () => true } as any });
+  const id = seedPlanningSession(store, { suffix: "noq", withForm: false });
+  const res = await app.fetch(
+    new Request(
+      `http://x/api/sessions/${id}/answer-plan-questions`,
+      POST_ANSWERS([{ blockId: "qf1", questionId: "q1", optionIndices: [0] }]),
+    ),
+  );
+  expect(res.status).toBe(409);
+  expect((await res.json()).error).toContain("no plan questions");
+});
+
+test("POST answer-plan-questions → 400 when nothing resolves", async () => {
+  let called = false;
+  const { app, store } = harness({
+    service: {
+      reply: () => {
+        called = true;
+        return true;
+      },
+    } as any,
+  });
+  const id = seedPlanningSession(store, { suffix: "empty", withForm: true });
+  const res = await app.fetch(
+    new Request(
+      `http://x/api/sessions/${id}/answer-plan-questions`,
+      POST_ANSWERS([{ blockId: "qf1", questionId: "unknown", optionIndices: [0] }]),
+    ),
+  );
+  expect(res.status).toBe(400);
+  expect(called).toBe(false);
+});
+
 // ── PUT /api/repo-config { planGateEnabled } (regression guard for Task 2 wiring) ──
 
 test("PUT /api/repo-config persists + echoes planGateEnabled=true", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1531,7 +1531,15 @@
   "qform_kind_multi": "Alle zutreffenden auswählen",
   "qform_kind_freeform": "Freie Antwort",
   "qform_freeform_placeholder": "Freitextantwort",
+  "qform_kind_multi_optional": "Alle zutreffenden auswählen (optional)",
+  "qform_submit": "Antworten an Planungsagent senden",
+  "qform_submitting": "Wird gesendet…",
+  "qform_sent": "Antworten an den Planungsagenten gesendet.",
+  "qform_sent_undelivered": "Planungsagent nicht erreichbar – er ist möglicherweise bereits weitergezogen.",
+  "qform_submit_error": "Antworten konnten nicht gesendet werden. Bitte erneut versuchen.",
   "planpanel_proposed_caption": "Vorschlag — noch nicht umgesetzt · der Plantext unten ist maßgeblich",
   "feat_visual_plan_title": "Visuelle Pläne",
-  "feat_visual_plan_body": "Plan-Gate-Pläne können jetzt als übersichtliches visuelles Dokument dargestellt werden — Dateibäume, Diagramme, Datenmodelle und mehr — oberhalb des Plantextes, sofern der Planungs-Agent sie ausgibt."
+  "feat_visual_plan_body": "Plan-Gate-Pläne können jetzt als übersichtliches visuelles Dokument dargestellt werden — Dateibäume, Diagramme, Datenmodelle und mehr — oberhalb des Plantextes, sofern der Planungs-Agent sie ausgibt.",
+  "feat_plan_question_answers_title": "Planfragen direkt in der App beantworten",
+  "feat_plan_question_answers_body": "Wenn ein Plan offene Fragen stellt, kannst du sie jetzt direkt in der Planansicht beantworten — Optionen auswählen oder eine Antwort eingeben und direkt an den Planungs-Agenten zurücksenden, um den Plan zu verfeinern."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1531,7 +1531,15 @@
   "qform_kind_multi": "Select all that apply",
   "qform_kind_freeform": "Free response",
   "qform_freeform_placeholder": "Free-text answer",
+  "qform_kind_multi_optional": "Select all that apply (optional)",
+  "qform_submit": "Send answers to planning agent",
+  "qform_submitting": "Sending…",
+  "qform_sent": "Answers sent to the planning agent.",
+  "qform_sent_undelivered": "Couldn't reach the planning agent — it may have already moved on.",
+  "qform_submit_error": "Couldn't send answers. Please try again.",
   "planpanel_proposed_caption": "Proposed — not yet built · the plan text below is authoritative",
   "feat_visual_plan_title": "Visual plans",
-  "feat_visual_plan_body": "Plan-gate plans can now render as a scannable visual document — file trees, diagrams, data models and more — shown above the plan text when the planning agent emits them."
+  "feat_visual_plan_body": "Plan-gate plans can now render as a scannable visual document — file trees, diagrams, data models and more — shown above the plan text when the planning agent emits them.",
+  "feat_plan_question_answers_title": "Answer plan questions in-app",
+  "feat_plan_question_answers_body": "When a plan asks you open questions, you can now answer them right in the plan view — pick options or type a response and send them straight back to the planning agent to refine the plan."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -49,6 +49,7 @@ import type {
   CompletedEpic,
   HerdDigest,
   DistillerHealth,
+  RawAnswer,
 } from "./types";
 import { m } from "$lib/paraglide/messages";
 
@@ -956,6 +957,20 @@ export async function reviewPlan(id: string): Promise<PlanReviewTrigger> {
   if (!r.ok) throw await failed(r, "review-plan");
   const body = (await r.json().catch(() => ({}))) as { status?: PlanReviewTrigger };
   return body.status ?? "skipped";
+}
+
+/** Submit operator answers to a plan's question-form (#803). The server resolves them against the
+ *  gate's persisted questions, composes a steer, and delivers it to the live planning agent.
+ *  Returns whether the steer reached the PTY (`delivered:false` ⇒ the planning pane is gone).
+ *  Throws on non-2xx (e.g. 409 once the session leaves the planning phase). */
+export async function answerPlanQuestions(
+  id: string,
+  answers: RawAnswer[],
+): Promise<{ delivered: boolean }> {
+  const r = await fetch(`/api/sessions/${id}/answer-plan-questions`, JSON_POST({ answers }));
+  if (!r.ok) throw await failed(r, "answer-plan-questions");
+  const body = (await r.json().catch(() => ({}))) as { delivered?: boolean };
+  return { delivered: body.delivered === true };
 }
 
 export type PrReviewTrigger = "started" | "skipped" | "error";

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -16,6 +16,11 @@
   const releasable = $derived(canRelease(session, gate));
   // Manual re-review only makes sense while still planning (not once executing).
   const canReviewNow = $derived(session.planPhase === "planning");
+  // question-form answers steer back to the planning agent — only while planning (the gate +
+  // its questions persist past approval), with submit locked while a review is in flight.
+  const planAnswerCtx = $derived(
+    canReviewNow ? { sessionId: session.id, locked: reviewing } : undefined,
+  );
 
   // Render the plan + reviewer body as markdown, SANITIZED before @html. Both are
   // agent-authored — the planning agent and the reviewer ingest untrusted input (issue
@@ -151,7 +156,7 @@
         {#if planBlocks.length > 0}
           <div class="plan-blocks">
             <span class="micro plan-blocks-caption">{m.planpanel_proposed_caption()}</span>
-            <VisualReview blocks={planBlocks} />
+            <VisualReview blocks={planBlocks} answerCtx={planAnswerCtx} />
           </div>
         {/if}
         {#if planHtml}

--- a/ui/src/lib/components/VisualReview.svelte
+++ b/ui/src/lib/components/VisualReview.svelte
@@ -16,7 +16,12 @@
   import QuestionFormBlock from "./blocks/QuestionFormBlock.svelte";
   import { m } from "$lib/paraglide/messages";
 
-  let { blocks }: { blocks: VisualBlock[] } = $props();
+  // `answerCtx` (plan gate, planning phase only) makes question-form blocks interactive; absent in
+  // read-only contexts (recap / Done panels), where the form renders disabled.
+  let {
+    blocks,
+    answerCtx,
+  }: { blocks: VisualBlock[]; answerCtx?: { sessionId: string; locked: boolean } } = $props();
 
   // Dispatch table — block.type → its renderer. Using `satisfies` enforces key-exhaustiveness
   // (a missing block type is a compile error) while keeping the value cast localised to the use site.
@@ -44,9 +49,13 @@
     {#if block.type === "diff" && i === firstDiffIndex}
       <h4 class="vr-highlight-head">{m.vblock_diff_highlighted_heading()}</h4>
     {/if}
-    {@const Block = COMPONENTS[block.type] as unknown as Component<{ block: VisualBlock }>}
-    {#if Block}
-      <Block {block} />
+    {#if block.type === "question-form"}
+      <QuestionFormBlock {block} {answerCtx} />
+    {:else}
+      {@const Block = COMPONENTS[block.type] as unknown as Component<{ block: VisualBlock }>}
+      {#if Block}
+        <Block {block} />
+      {/if}
     {/if}
   {/each}
 </div>

--- a/ui/src/lib/components/blocks/QuestionFormBlock.browser.test.ts
+++ b/ui/src/lib/components/blocks/QuestionFormBlock.browser.test.ts
@@ -1,8 +1,22 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../../app.css";
 import QuestionFormBlock from "./QuestionFormBlock.svelte";
+
+const answerPlanQuestions = vi.fn<
+  (id: string, answers: unknown[]) => Promise<{ delivered: boolean }>
+>(async () => ({ delivered: true }));
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    answerPlanQuestions: (...a: unknown[]) =>
+      answerPlanQuestions(...(a as Parameters<typeof answerPlanQuestions>)),
+  };
+});
+
+afterEach(() => answerPlanQuestions.mockClear());
 
 describe("QuestionFormBlock", () => {
   it("renders single-kind prompt, options as radios, and kind hint", async () => {
@@ -97,5 +111,78 @@ describe("QuestionFormBlock", () => {
     for (const input of allInputs) {
       expect(input.disabled).toBe(true);
     }
+  });
+});
+
+describe("QuestionFormBlock — interactive (answerCtx present)", () => {
+  const block = {
+    type: "question-form" as const,
+    id: "qf",
+    questions: [
+      { id: "q1", prompt: "Which approach?", kind: "single" as const, options: ["Reuse", "New"] },
+      { id: "q2", prompt: "Edge cases?", kind: "multi" as const, options: ["Empty", "Huge"] },
+      { id: "q3", prompt: "Notes?", kind: "freeform" as const },
+    ],
+  };
+
+  it("enables inputs when answerCtx is present", async () => {
+    const { container } = render(QuestionFormBlock, {
+      block,
+      answerCtx: { sessionId: "s1", locked: false },
+    });
+    const inputs = container.querySelectorAll("input");
+    expect(inputs.length).toBeGreaterThan(0);
+    for (const input of inputs) expect(input.disabled).toBe(false);
+  });
+
+  it("keeps submit disabled until single + freeform are answered, then submits the payload", async () => {
+    const { container } = render(QuestionFormBlock, {
+      block,
+      answerCtx: { sessionId: "sess-9", locked: false },
+    });
+    const button = page.getByRole("button");
+    await expect.element(button).toBeDisabled();
+
+    // Answer the required single + freeform (multi left empty on purpose).
+    const radios = container.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    await page.elementLocator(radios[1]!).click(); // "New" → index 1
+    const text = container.querySelector<HTMLInputElement>('input[type="text"]')!;
+    await page.elementLocator(text).fill("keep it minimal");
+
+    await expect.element(button).toBeEnabled();
+    await button.click();
+
+    expect(answerPlanQuestions).toHaveBeenCalledTimes(1);
+    const [sid, answers] = answerPlanQuestions.mock.calls[0]!;
+    expect(sid).toBe("sess-9");
+    expect(answers).toEqual([
+      { blockId: "qf", questionId: "q1", optionIndices: [1] },
+      { blockId: "qf", questionId: "q2", optionIndices: [] },
+      { blockId: "qf", questionId: "q3", text: "keep it minimal" },
+    ]);
+    await expect.element(page.getByText("Answers sent to the planning agent.")).toBeInTheDocument();
+  });
+
+  it("disables submit while a plan review is in flight (locked)", async () => {
+    render(QuestionFormBlock, { block, answerCtx: { sessionId: "s1", locked: true } });
+    await expect.element(page.getByRole("button")).toBeDisabled();
+  });
+
+  it("surfaces an undelivered note when the steer can't reach the agent", async () => {
+    answerPlanQuestions.mockResolvedValueOnce({ delivered: false });
+    const { container } = render(QuestionFormBlock, {
+      block: {
+        type: "question-form" as const,
+        id: "qf",
+        questions: [{ id: "q1", prompt: "Pick", kind: "single" as const, options: ["a", "b"] }],
+      },
+      answerCtx: { sessionId: "s1", locked: false },
+    });
+    const radios = container.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    await page.elementLocator(radios[0]!).click();
+    await page.getByRole("button").click();
+    await expect
+      .element(page.getByText("Couldn't reach the planning agent — it may have already moved on."))
+      .toBeInTheDocument();
   });
 });

--- a/ui/src/lib/components/blocks/QuestionFormBlock.svelte
+++ b/ui/src/lib/components/blocks/QuestionFormBlock.svelte
@@ -1,13 +1,92 @@
 <script lang="ts">
-  import type { VisualBlock } from "$lib/types";
+  import type { VisualBlock, RawAnswer } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { answerPlanQuestions } from "$lib/api";
 
-  let { block }: { block: Extract<VisualBlock, { type: "question-form" }> } = $props();
+  // `answerCtx` present → interactive (the planning-phase plan gate). Absent → read-only
+  // (recap / Done panels, or once the session has left the planning phase).
+  let {
+    block,
+    answerCtx,
+  }: {
+    block: Extract<VisualBlock, { type: "question-form" }>;
+    answerCtx?: { sessionId: string; locked: boolean };
+  } = $props();
+
+  const interactive = $derived(!!answerCtx);
+
+  // Per-question answer state (one block per component instance → keying by q.id is collision-free).
+  // Built via helpers so the initializers don't statically capture the reactive `block` prop —
+  // a question-form block is fixed for the life of an instance (keyed each by block.id).
+  const initSingle = () =>
+    Object.fromEntries(
+      block.questions.filter((q) => q.kind === "single").map((q) => [q.id, null as number | null]),
+    );
+  const initMulti = () =>
+    Object.fromEntries(
+      block.questions.filter((q) => q.kind === "multi").map((q) => [q.id, [] as number[]]),
+    );
+  const initFreeform = () =>
+    Object.fromEntries(block.questions.filter((q) => q.kind === "freeform").map((q) => [q.id, ""]));
+
+  let single = $state<Record<string, number | null>>(initSingle());
+  let multi = $state<Record<string, number[]>>(initMulti());
+  let freeform = $state<Record<string, string>>(initFreeform());
+
+  let submitting = $state(false);
+  let submitted = $state(false);
+  let delivered = $state(true);
+  let errored = $state(false);
+
+  const locked = $derived(submitting || submitted || !!answerCtx?.locked);
+  const inputsDisabled = $derived(!interactive || locked);
+
+  // Submit requires every single + freeform answered; multi is optional (empty = "none").
+  const canSubmit = $derived.by(() => {
+    if (!interactive || locked) return false;
+    for (const q of block.questions) {
+      if (q.kind === "single" && single[q.id] == null) return false;
+      if (q.kind === "freeform" && !freeform[q.id]?.trim()) return false;
+    }
+    return true;
+  });
 
   function kindLabel(kind: "single" | "multi" | "freeform"): string {
     if (kind === "single") return m.qform_kind_single();
-    if (kind === "multi") return m.qform_kind_multi();
+    if (kind === "multi") return interactive ? m.qform_kind_multi_optional() : m.qform_kind_multi();
     return m.qform_kind_freeform();
+  }
+
+  function buildAnswers(): RawAnswer[] {
+    return block.questions.map((q) => {
+      if (q.kind === "single") {
+        const i = single[q.id];
+        return { blockId: block.id, questionId: q.id, optionIndices: i == null ? [] : [i] };
+      }
+      if (q.kind === "multi") {
+        return {
+          blockId: block.id,
+          questionId: q.id,
+          optionIndices: [...(multi[q.id] ?? [])].sort((a, b) => a - b),
+        };
+      }
+      return { blockId: block.id, questionId: q.id, text: freeform[q.id] ?? "" };
+    });
+  }
+
+  async function submit() {
+    if (!answerCtx || !canSubmit) return;
+    submitting = true;
+    errored = false;
+    try {
+      const res = await answerPlanQuestions(answerCtx.sessionId, buildAnswers());
+      delivered = res.delivered;
+      submitted = true;
+    } catch {
+      errored = true;
+    } finally {
+      submitting = false;
+    }
   }
 </script>
 
@@ -20,8 +99,14 @@
         <ul class="qf-options">
           {#each q.options as option, i (i)}
             <li class="qf-option">
-              <label class="qf-label">
-                <input type="radio" name={q.id} value={i} disabled />
+              <label class="qf-label" class:qf-label-live={interactive}>
+                <input
+                  type="radio"
+                  name={`${block.id}-${q.id}`}
+                  value={i}
+                  bind:group={single[q.id]}
+                  disabled={inputsDisabled}
+                />
                 <span>{option}</span>
               </label>
             </li>
@@ -31,8 +116,14 @@
         <ul class="qf-options">
           {#each q.options as option, i (i)}
             <li class="qf-option">
-              <label class="qf-label">
-                <input type="checkbox" name={`${q.id}-${i}`} disabled />
+              <label class="qf-label" class:qf-label-live={interactive}>
+                <input
+                  type="checkbox"
+                  name={`${block.id}-${q.id}-${i}`}
+                  value={i}
+                  bind:group={multi[q.id]}
+                  disabled={inputsDisabled}
+                />
                 <span>{option}</span>
               </label>
             </li>
@@ -43,13 +134,32 @@
           <input
             type="text"
             class="qf-freeform-input"
-            disabled
+            class:qf-freeform-live={interactive}
+            bind:value={freeform[q.id]}
+            disabled={inputsDisabled}
             placeholder={m.qform_freeform_placeholder()}
           />
         </div>
       {/if}
     </div>
   {/each}
+
+  {#if interactive}
+    <div class="qf-actions">
+      {#if submitted}
+        <p class="qf-confirm" class:qf-confirm-warn={!delivered} role="status">
+          {delivered ? m.qform_sent() : m.qform_sent_undelivered()}
+        </p>
+      {:else}
+        {#if errored}
+          <p class="qf-error" role="alert">{m.qform_submit_error()}</p>
+        {/if}
+        <button type="button" class="gbtn primary" onclick={submit} disabled={!canSubmit}>
+          {submitting ? m.qform_submitting() : m.qform_submit()}
+        </button>
+      {/if}
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -95,6 +205,11 @@
     opacity: 0.7;
     cursor: default;
   }
+  /* Interactive: full opacity + pointer affordance. */
+  .qf-label-live {
+    opacity: 1;
+    cursor: pointer;
+  }
   .qf-freeform {
     margin-top: 4px;
   }
@@ -108,5 +223,63 @@
     padding: 4px 8px;
     opacity: 0.5;
     cursor: default;
+  }
+  .qf-freeform-live {
+    color: var(--color-ink-bright);
+    background: var(--color-inset);
+    border-color: var(--color-line);
+    opacity: 1;
+    cursor: text;
+  }
+  .qf-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+  .qf-confirm {
+    margin: 0;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+  .qf-confirm-warn {
+    color: var(--status-warn);
+  }
+  .qf-error {
+    margin: 0;
+    font-size: var(--fs-meta);
+    color: var(--status-warn);
+  }
+
+  /* Canonical .gbtn recipe (scoped per-component; see /design-system). */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 4px 10px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .gbtn.primary {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
   }
 </style>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1120,4 +1120,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_visual_plan_title",
     bodyKey: "feat_visual_plan_body",
   },
+  {
+    // The plan question-form is now answerable in-UI: pick options / type freeform and the
+    // answers steer back into the planning agent. No targetId — PlanPanel is an on-demand
+    // modal with no stable always-visible anchor. v1.34.0 is the latest tag → ships in 1.35.0.
+    id: "plan-question-answers",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_plan_question_answers_title",
+    bodyKey: "feat_plan_question_answers_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -335,6 +335,16 @@ export type VisualBlock =
       }[];
     };
 
+/** A single operator answer to a plan question-form question, keyed by (blockId, questionId).
+ *  `optionIndices` is for single (one) / multi (zero+); `text` is for freeform. Mirrors the
+ *  server's RawAnswer (#803). */
+export interface RawAnswer {
+  blockId: string;
+  questionId: string;
+  optionIndices?: number[];
+  text?: string;
+}
+
 // ── session recap ────────────────────────────────────────────────────────────
 // mirrors server Recap / RecapState / RecapVerdict
 export type RecapState = "generating" | "ready" | "failed" | "empty";


### PR DESCRIPTION
Closes #803. Follow-up to #799 (native visual plans), which shipped the `question-form` block read-only. This closes the answer → steer-back loop: an operator answers a plan's question-form in the UI and the answers are steered back into the live planning agent's PTY, which revises `.shepherd-plan.md` and stops for re-review.

## What changed
**Server**
- `resolvePlanAnswers` + `planAnswerSteerText` (pure, exported in `src/plan-gate.ts`, beside `planSteerText`). Answers are resolved against the gate's **persisted** questions, namespaced by `(blockId, questionId)`; the agent-facing steer prose is composed server-side (testable, out of i18n).
- `POST /api/sessions/:id/answer-plan-questions` — delivers via the existing `service.reply()` plumbing (no new transport). Guards: `requireJsonContentType` + body-shape **400**, **404** unknown session, **409** when `planPhase !== "planning"`, **409** when the gate has no question-form, **400** when nothing resolves. Returns `{ ok, delivered }` (`delivered:false` ⇒ planning PTY gone).

**UI**
- `QuestionFormBlock` is now interactive via an optional `answerCtx` prop (single/multi/freeform inputs, submit). **Absent → unchanged read-only rendering** (recap / Done panels untouched).
- `answerCtx` is threaded through `VisualReview` → `PlanPanel`, which passes it **only in the planning phase** and **locks submit while a review is in flight**.
- Submit requires every single + freeform answered (multi optional); option labels resolved server-side from indices (client never dictates option text).
- i18n EN+DE chrome + a `feature-announcements` entry (1.35.0).

## Design decisions (from the plan + adversarial review)
- **Server-composed steer**, **transient answers** (next review regenerates blocks — no persistence/migration).
- **Empty multi-select** is a meaningful "none selected", distinct from unanswered.
- **Planning-phase-only** guard on both ends (the gate persists past approval / AUTO auto-release).
- **Duplicate-submit** disabled while reviewing; the client-only post-submit lock means a reload could re-submit — accepted & documented (the agent just re-incorporates the same answers).

## Tests
- `test/plan-answers.test.ts` — resolve/compose unit tests (namespacing, empty-multi, fail-closed drops, prose).
- `test/server-plan-gate.test.ts` — endpoint guards (415/400/404/409×2/400) + happy path + `delivered` relay.
- `QuestionFormBlock.browser.test.ts` — interactive enable, submit gating, payload shape, locked, undelivered note; read-only test preserved.

Root `bun test` (3775), UI `bun run test` (1630), `bun run lint`, `cd ui && bun run check`, `check:i18n`, and the pinned `fallow@2.97.0` delta gate all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)