### PR TITLE
fix(git-rail): hide Open PR button when autopilot is on

### DIFF
--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -58,6 +58,9 @@ vi.mock("$lib/toasts.svelte", () => ({
 
 // Import the component AFTER the mock is registered.
 const { default: GitRail } = await import("./GitRail.svelte");
+// Test-only wrapper that flips ONLY autopilotOn (sessionId stable) — see the
+// "Open PR hidden under autopilot" describe for why rerender() can't do this.
+const { default: GitRailAutopilotHarness } = await import("./GitRailAutopilotHarness.svelte");
 // The plan-gate reviewing store drives the auto-pill pulse for plan reviews,
 // mirroring the critic (reviews) store. Imported from the same module the
 // component reads so toggling it reactively updates the rendered pill.
@@ -1190,5 +1193,78 @@ describe("GitRail — manual plan-review trigger", () => {
     const next = { ...repoConfig.enabled };
     delete next[baseProps.repoPath];
     repoConfig.enabled = next;
+  });
+});
+
+// The strip always mounts GitRail with mobile=true (Viewport.svelte), so the autopilot
+// gating is asserted on that shipped path. Pre-fix, the Open PR button always rendered
+// under state:none and the compose popover ignored autopilot — both cases below fail
+// against pre-fix code.
+describe("GitRail — Open PR hidden under autopilot", () => {
+  const noneState: GitState = {
+    kind: "github",
+    state: "none",
+    checks: "none",
+    deployConfigured: false,
+  };
+
+  // find the Open PR trigger by its label text (↟ Open PR), or null when absent
+  function openPrBtn(h: HTMLElement): HTMLButtonElement | null {
+    return (
+      [...h.querySelectorAll<HTMLButtonElement>("button")].find((b) =>
+        /Open PR/i.test(b.textContent ?? ""),
+      ) ?? null
+    );
+  }
+
+  it("shows Open PR when autopilot is off (state:none)", async () => {
+    gitStateFn.mockResolvedValue(noneState);
+    await page.viewport(400, 900);
+    const h = host(360);
+    render(GitRail, { target: h, props: { ...baseProps, mobile: true, autopilotOn: false } });
+    await vi.waitFor(() =>
+      expect(openPrBtn(h), "Open PR button present when AP off").not.toBeNull(),
+    );
+  });
+
+  it("hides Open PR when autopilot is on (state:none)", async () => {
+    gitStateFn.mockResolvedValue(noneState);
+    await page.viewport(400, 900);
+    const h = host(360);
+    // repoPath present → the automation pill still renders, so only the Open-PR slot
+    // is empty, not the rail. Wait for the pill, then assert Open PR is absent.
+    render(GitRail, { target: h, props: { ...baseProps, mobile: true, autopilotOn: true } });
+    await vi.waitFor(() =>
+      expect(h.querySelector(".auto-pill"), "automation pill renders").not.toBeNull(),
+    );
+    expect(openPrBtn(h), "Open PR button hidden when AP on").toBeNull();
+  });
+
+  // Uses the harness (NOT rerender): the live app flips autopilot via a session:autopilot
+  // WS event with the SAME sessionId, so only the autopilotOn prop changes. rerender()
+  // would swap the whole prop bag and incidentally re-run GitRail's sessionId-keyed
+  // session-reset effect, closing the popover regardless of the fix (vacuous). The harness
+  // flips ONLY autopilotOn, so this fails against pre-fix code (popover would dangle).
+  it("closes the compose popover when autopilot flips on (sessionId stable)", async () => {
+    gitStateFn.mockResolvedValue(noneState);
+    await page.viewport(400, 900);
+    const h = host(360);
+    const { component } = render(GitRailAutopilotHarness, {
+      target: h,
+      props: { ...baseProps, mobile: true },
+    });
+    // open the popover (autopilot starts off)
+    const btn = await vi.waitFor(() => {
+      const b = openPrBtn(h);
+      expect(b, "Open PR button present").not.toBeNull();
+      return b!;
+    });
+    btn.click();
+    await vi.waitFor(() => expect(h.querySelector(".pr-pop"), "popover open").not.toBeNull());
+    // autopilot flips on (WS event) → popover must close, no submit path left
+    component.setAutopilot(true);
+    await vi.waitFor(() =>
+      expect(h.querySelector(".pr-pop"), "popover closed after AP flips on").toBeNull(),
+    );
   });
 });

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -36,6 +36,7 @@
     isolated = false,
     baseBranch = "",
     drain = null,
+    autopilotOn = false,
   }: {
     sessionId: string;
     repoPath?: string;
@@ -50,6 +51,9 @@
     baseBranch?: string;
     /** Live drain status for this session's repo; passed through to AutomationPanel. */
     drain?: DrainStatus | null;
+    /** Effective autopilot state. When on, the agent opens the PR itself, so the manual
+        Open-PR button is redundant noise and is hidden. */
+    autopilotOn?: boolean;
   } = $props();
 
   let git = $state<GitState | null>(null);
@@ -113,6 +117,13 @@
     if (!awaitingPlanReview) return;
     const t = setTimeout(() => (awaitingPlanReview = false), 4000);
     return () => clearTimeout(t);
+  });
+
+  // Close the Open-PR compose popover if autopilot flips on while it's open (toggle, or a
+  // WS session:autopilot event): the trigger button is gated on !autopilotOn, but the
+  // popover renders on its own showPr flag — without this it could dangle and still submit.
+  $effect(() => {
+    if (autopilotOn) showPr = false;
   });
 
   $effect(() => {
@@ -538,9 +549,17 @@
   <span class="git-rail-wrap" class:mobile bind:this={wrapEl}>
     <span class="rail" class:mobile use:edgeFades={mobile}>
       {#if git.state === "none"}
-        <button class="gbtn" type="button" disabled={busy} onclick={startPr}
-          >{m.gitrail_open_pr()}</button
-        >
+        <!-- Hidden whenever autopilot is effectively on — the agent opens the PR itself,
+             so the manual button is redundant. This stays hidden even while autopilot is
+             PAUSED (autopilotPaused): a paused autopilot is still on and will resume and
+             open the PR; the human escape hatch is the AP toggle in the same strip.
+             autopilotPaused is surfaced separately via AutopilotBadge — not a signal to
+             re-show this button. -->
+        {#if !autopilotOn}
+          <button class="gbtn" type="button" disabled={busy} onclick={startPr}
+            >{m.gitrail_open_pr()}</button
+          >
+        {/if}
       {:else if git.state === "open"}
         {#if git.url}
           <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->

--- a/ui/src/lib/components/GitRailAutopilotHarness.svelte
+++ b/ui/src/lib/components/GitRailAutopilotHarness.svelte
@@ -1,0 +1,57 @@
+<!--
+  Test-only harness for GitRail.browser.test.ts.
+
+  Reproduces production's autopilot-flip path faithfully: `autopilotOn` lives in internal
+  $state and is flipped LATER via the exported setAutopilot(), mirroring how the live app
+  toggles it via a `session:autopilot` WS event with the SAME sessionId. Flipping only this
+  one prop — not the whole prop bag — is what isolates the popover-close $effect: GitRail's
+  session-reset effect reads `sessionId` only, so it must NOT re-fire here. (vitest-browser-
+  svelte's rerender() swaps the entire currentProps object, which incidentally re-runs that
+  session-reset effect and closes the popover regardless of the fix — masking the bug. Same
+  rationale as TopBarLimitsHarness.)
+-->
+<script lang="ts">
+  import GitRail from "./GitRail.svelte";
+  import type { Session, SessionStatus } from "$lib/types";
+
+  let {
+    sessionId,
+    repoPath = "",
+    name = "",
+    prompt = "",
+    mobile = false,
+    ready = false,
+    status = "idle",
+    showReady = true,
+    planPhase = null,
+  }: {
+    sessionId: string;
+    repoPath?: string;
+    name?: string;
+    prompt?: string;
+    mobile?: boolean;
+    ready?: boolean;
+    status?: SessionStatus;
+    showReady?: boolean;
+    planPhase?: Session["planPhase"];
+  } = $props();
+
+  let autopilotOn = $state(false);
+
+  export function setAutopilot(next: boolean) {
+    autopilotOn = next;
+  }
+</script>
+
+<GitRail
+  {sessionId}
+  {repoPath}
+  {name}
+  {prompt}
+  {mobile}
+  {ready}
+  {status}
+  {showReady}
+  {planPhase}
+  {autopilotOn}
+/>

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2379,6 +2379,7 @@
         isolated={session.isolated}
         baseBranch={session.baseBranch}
         {drain}
+        autopilotOn={autopilotEffective}
         mobile
       />
       <span class="strip-controls">


### PR DESCRIPTION
## What

In the session git strip, the manual **Open PR** button (left, in `GitRail`) and the **AP on** toggle (right, in `.strip-controls`) are effectively mutually exclusive: under autopilot the agent opens the PR itself, so the manual button is redundant noise. This hides it whenever autopilot is effectively on.

## How

- `GitRail.svelte` — new `autopilotOn?: boolean` prop (default `false`); the Open PR trigger (`git.state === "none"` branch) is gated on `!autopilotOn`.
- `Viewport.svelte` — passes `autopilotOn={autopilotEffective}` (the same state the AP toggle reflects) into `GitRail`.
- An `$effect` closes the compose popover if autopilot flips on while it's open (e.g. a `session:autopilot` WS event), so it can't dangle and submit a PR after the gate engages.

## Decisions

- **Paused → stays hidden.** A paused autopilot is still on and will resume and open the PR; the escape hatch is the AP toggle in the same strip (an inline comment records this so it isn't misread as an oversight).
- **Scope: Open PR only.** Merge / Review are untouched — they only render once a PR exists, and auto-merge is a separate concern.

## Behavior preserved

Pre-PR with autopilot **off** still shows Open PR. Under autopilot the automation pill still renders (gated on `repoPath`), so only the Open-PR slot is empty, not the rail.

## Tests

New `GitRail.browser.test.ts` block (rendered `mobile: true`, the only shipped strip path):
- shows Open PR when AP off (control),
- hides Open PR when AP on,
- closes the compose popover when AP flips on — via a `GitRailAutopilotHarness.svelte` fixture that flips **only** `autopilotOn` with `sessionId` stable (mirrors the WS path; `rerender()` would swap the whole prop bag and incidentally re-run the session-reset effect, masking the bug).

All three negative cases were verified to **fail against pre-fix code**. Full UI suite: 1633 passed. `bun run check` clean.

## Catalog / i18n

No new user-facing strings (no i18n/glossary changes). No `feature-announcements.ts` entry — this is a subtraction, not a discoverable new capability; commit labelled `fix(...)` so `check-feature-catalog.sh` stays disarmed. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)