### PR TITLE
fix(plan): re-open signed-off plan read-only during execution (#809)

### DIFF
--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -109,8 +109,14 @@ export function quotaBlockReason(
   // Guard: running session is still working — never fire prematurely.
   if (session.status === "running") return null;
 
-  // Plan gate (pre-execution domain): check first.
-  if (gate !== null && gate.decision === "changes_requested" && gate.round >= gate.cap) {
+  // Plan gate (pre-execution domain): check first. The plan-gate quota is a pre-execution
+  // concern; outside the plan phase the retained gate is inert.
+  if (
+    gate !== null &&
+    session.planPhase === "planning" &&
+    gate.decision === "changes_requested" &&
+    gate.round >= gate.cap
+  ) {
     return { shape: "quota", quotaKind: "plan", options: [], tail: gate.findings };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -732,7 +732,9 @@ events.subscribe((event, data) => {
   // Only reap the plan reviewer when a real transition happened — avoids redundant
   // work and log spam on every subsequent poll tick (mirrors how session:archived
   // gates forget() on the id being present before calling it).
-  if (advanced) planGate.forget(id);
+  // The gate row is intentionally retained for the life of the session (dropped at
+  // archive via forget()) so the UI can re-open the signed-off plan read-only.
+  if (advanced) planGate.reapReviewer(id);
 });
 
 // Workflow protocol on the session's backlog issue: one comment when the PR enters

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -680,7 +680,11 @@ export class PlanGateService {
     this.deps.onChange(session.id, reset);
   }
 
-  forget(sessionId: string): void {
+  /** Reap any in-flight plan reviewer for a session WITHOUT dropping its persisted gate.
+   *  Used when a planning session advances to execution (manual-steer-then-PR): the reviewer
+   *  must stop, but the gate's verdict + blocks stay reachable read-only for the life of the
+   *  session. dropPlanGate is deferred to forget() at archive. */
+  reapReviewer(sessionId: string): void {
     // Clear the `starting` tombstone so an archived session can't get a review after
     // forget(). begin() now awaits a best-effort network `getIssue` AFTER allocating its
     // disposable worktree, so (like ReviewService.begin) it re-checks `starting` on resume and
@@ -693,6 +697,10 @@ export class PlanGateService {
       this.inflight.delete(sessionId);
       this.deps.onReviewing?.(sessionId, false);
     }
+  }
+
+  forget(sessionId: string): void {
+    this.reapReviewer(sessionId);
     this.deps.store.dropPlanGate(sessionId);
   }
 }

--- a/src/rundown-core.ts
+++ b/src/rundown-core.ts
@@ -88,7 +88,10 @@ const ATTENTION_RULES: Array<{
     signal: "blocked-decision",
     when: (s) => s.status === "blocked" || Boolean(s.autopilotPaused && s.autopilotQuestion),
   },
-  { signal: "plan-rework", when: (_s, c) => c.gate?.decision === "changes_requested" },
+  {
+    signal: "plan-rework",
+    when: (s, c) => s.planPhase === "planning" && c.gate?.decision === "changes_requested",
+  },
   { signal: "critic-rework", when: (_s, c) => c.review?.decision === "changes_requested" },
   { signal: "ci-red", when: (_s, c) => c.git?.checks === "failure" },
   // Tier 2: HIGH — needs a look soon, not yet a hard stop.
@@ -248,7 +251,8 @@ function toAssembledSession(
   if (git?.number != null) item.prNumber = git.number;
   if (git?.url) item.prUrl = git.url;
   if (review?.findings?.length) item.findings = review.findings;
-  if (gate && gate.decision === "changes_requested") item.planRound = gate.round;
+  if (s.planPhase === "planning" && gate && gate.decision === "changes_requested")
+    item.planRound = gate.round;
   return item;
 }
 

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
-import { classifyBlocked, hasActiveSpinner } from "../src/blocked";
+import { classifyBlocked, hasActiveSpinner, quotaBlockReason } from "../src/blocked";
+import type { Session, PlanGate } from "../src/types";
 
 test("classifies a numbered permission menu", () => {
   const tail = [
@@ -107,4 +108,80 @@ test("strips ANSI escape codes before classifying a menu", () => {
   ]);
   // tail itself should be free of escape codes
   expect(r.tail.join("\n")).not.toContain("\x1b");
+});
+
+// ── quotaBlockReason: retained gate is inert during execution (issue #809) ───
+
+function makeSession(planPhase: Session["planPhase"]): Session {
+  return {
+    id: "s1",
+    desig: "TASK-01",
+    name: "task",
+    prompt: "",
+    repoPath: "/repo",
+    baseBranch: "main",
+    branch: "feat",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "h",
+    herdrAgentId: "a",
+    claudeSessionId: "",
+    model: null,
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    mergeTrainPrs: null,
+    mergingPrNumber: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase,
+    research: false,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    autoMergeRebaseHead: null,
+    auto: false,
+    issueNumber: null,
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    status: "idle",
+    lastState: "working",
+    createdAt: 0,
+    updatedAt: 0,
+    archivedAt: null,
+  };
+}
+
+const atCapGate: PlanGate = {
+  sessionId: "s1",
+  planHash: "abc",
+  decision: "changes_requested",
+  summary: "needs rework",
+  body: "## issues",
+  findings: ["fix X", "address Y"],
+  round: 3,
+  cap: 3,
+  approved: false,
+  plan: "do stuff",
+  updatedAt: 1000,
+};
+
+test("quotaBlockReason: executing session with retained at-cap gate returns null (gate inert)", () => {
+  // A gate retained into execution must NOT raise a quotaKind:"plan" block.
+  const session = makeSession("executing");
+  const result = quotaBlockReason(session, null, atCapGate, 2000);
+  expect(result).toBeNull();
+});
+
+test("quotaBlockReason: planning session with at-cap gate still raises plan block (guard not over-suppressing)", () => {
+  // Contrast: the same gate while planPhase:"planning" must still produce the quota block.
+  const session = makeSession("planning");
+  const result = quotaBlockReason(session, null, atCapGate, 2000);
+  expect(result).not.toBeNull();
+  expect(result?.quotaKind).toBe("plan");
 });

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -713,6 +713,48 @@ test("gcStaleReviewWorktrees reaps only non-inflight plan_gate worktrees", async
   expect(h.removed).not.toContain("/wt-review");
 });
 
+// ── reapReviewer (gate-durability split, issue #809) ─────────────────────────
+
+test("reapReviewer reaps terminal+worktree+inflight but does NOT drop the persisted gate", async () => {
+  // Prove the split: reapReviewer does everything forget() does EXCEPT dropPlanGate.
+  // After consider() sets up an inflight reviewer, reapReviewer() must:
+  //   - reap the terminal and worktree
+  //   - remove the inflight entry (reviewingIds becomes empty)
+  //   - clear the starting tombstone
+  //   - NOT call store.dropPlanGate
+  // While forget() DOES call dropPlanGate.
+  const dropped: string[] = [];
+  const stopped: string[] = [];
+  const h = harness({
+    store: {
+      dropPlanGate(id: string) {
+        dropped.push(id);
+      },
+    },
+    herdr: {
+      start: () => ({ terminalId: "t-rev" }),
+      stop: (id: string) => stopped.push(id),
+      list: () => [],
+    },
+  });
+  // Spin up an inflight reviewer.
+  await h.svc.consider(planningSession() as any);
+  expect(h.svc.reviewingIds()).toEqual(["s1"]);
+
+  // reapReviewer: terminal reaped, worktree reaped, inflight cleared — gate row untouched.
+  h.svc.reapReviewer("s1");
+  expect(stopped).toContain("t-rev"); // terminal was stopped
+  expect(h.removed).toContain("/wt-detached"); // worktree was reaped
+  expect(h.svc.reviewingIds()).toEqual([]); // inflight entry cleared
+  expect(dropped).toHaveLength(0); // gate row NOT dropped
+
+  // forget(): builds on reapReviewer AND drops the gate row.
+  // Set up fresh inflight for the forget() assertion.
+  await h.svc.consider(planningSession() as any);
+  h.svc.forget("s1");
+  expect(dropped).toEqual(["s1"]); // gate row now dropped exactly once
+});
+
 test("gcStaleReviewWorktrees leaves an inflight plan_gate worktree alone", async () => {
   const adopted = orphanSpawn({ worktreePath: "/wt-detached" });
   const h = harness({

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -2757,6 +2757,7 @@ test("quota: blocked session goes through maybeClassify, not the quota branch", 
 // Property 5: plan kind emits quotaKind "plan"
 test("quota: idle session with exhausted plan gate (no review) emits quotaKind 'plan'", () => {
   const { store, s, blocks, poller } = idleQuotaHarness();
+  store.setPlanPhase(s.id, "planning");
   store.putPlanGate(makeExhaustedGate(s.id));
 
   poller.tick();

--- a/test/quota-block-reason.test.ts
+++ b/test/quota-block-reason.test.ts
@@ -209,7 +209,7 @@ test("error takes precedence over rework when both conditions met", () => {
 
 // 9. Plan gate: decision changes_requested, round === cap → quotaKind "plan".
 test("plan gate exhausted → quotaKind plan with gate findings as tail", () => {
-  const session = makeSession("idle");
+  const session = { ...makeSession("idle"), planPhase: "planning" as const };
   const findings = ["address concern X"];
   const gate = makeGate({ decision: "changes_requested", round: 5, cap: 5, findings });
   const result = quotaBlockReason(session, null, gate, NOW);

--- a/test/rundown-core.test.ts
+++ b/test/rundown-core.test.ts
@@ -135,7 +135,9 @@ test("classifyAttention: each signal maps to the correct tier", () => {
   expect(c(session({ autopilotPaused: true, autopilotQuestion: "which?" })).signals).toContain(
     "blocked-decision",
   );
-  expect(c(session(), { gate: { decision: "changes_requested" } as any }).tier).toBe(1);
+  expect(
+    c(session({ planPhase: "planning" }), { gate: { decision: "changes_requested" } as any }).tier,
+  ).toBe(1);
   expect(c(session(), { review: { decision: "changes_requested" } as any }).tier).toBe(1);
   expect(c(session({ status: "idle" }), { git: git({ checks: "failure" }) }).tier).toBe(1);
 
@@ -387,4 +389,64 @@ test("isMerging: marked within backstop true, beyond false, unmarked false", () 
   expect(isMerging({ mergingSince: NOW - 1000 }, NOW)).toBe(true);
   expect(isMerging({ mergingSince: NOW - MERGE_MARK_BACKSTOP_MS - 1 }, NOW)).toBe(false);
   expect(isMerging({ mergingSince: null }, NOW)).toBe(false);
+});
+
+// ── retained gate is inert during execution (issue #809) ─────────────────────
+
+import type { PlanGate } from "../src/types";
+
+const retainedAtCapGate: PlanGate = {
+  sessionId: "s1",
+  planHash: "abc",
+  decision: "changes_requested",
+  summary: "needs rework",
+  body: "## issues",
+  findings: ["fix X", "address Y"],
+  round: 3,
+  cap: 3,
+  approved: false,
+  plan: "do stuff",
+  updatedAt: 1000,
+};
+
+test("classifyAttention + assemble: executing session with retained gate has no plan-rework signal and no planRound", () => {
+  // An executing session whose retained gate is changes_requested at cap must NOT get the
+  // plan-rework signal and must NOT have planRound set. Both L91 and L251 must be guarded.
+  const executingSession = session({ planPhase: "executing", status: "idle" });
+  const caches: ClassifyCaches = { gate: retainedAtCapGate };
+
+  const attn = classifyAttention(executingSession, caches, NOW);
+  expect(attn.signals).not.toContain("plan-rework"); // L91 guard
+
+  // assembleHerdState to check planRound (L251 guard)
+  const out = assembleHerdState({
+    sessions: [executingSession],
+    gates: { s1: retainedAtCapGate },
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-19",
+    now: NOW,
+  });
+  const item = out.sessions.find((s) => s.sessionId === "s1");
+  // The session must still appear (it has an in-flight signal from idle status + some tier).
+  // planRound must be absent — the retained gate must not leak planRound into execution.
+  expect(item?.planRound).toBeUndefined(); // L251 guard
+});
+
+test("classifyAttention + assemble: planning session with same at-cap gate still gets plan-rework + planRound (guard not over-suppressing)", () => {
+  // Contrast: planPhase:"planning" with the same gate must still produce plan-rework and planRound.
+  const planningSession = session({ planPhase: "planning", status: "idle" });
+  const caches: ClassifyCaches = { gate: retainedAtCapGate };
+
+  const attn = classifyAttention(planningSession, caches, NOW);
+  expect(attn.signals).toContain("plan-rework"); // still fires during planning
+
+  const out = assembleHerdState({
+    sessions: [planningSession],
+    gates: { s1: retainedAtCapGate },
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-19",
+    now: NOW,
+  });
+  const item = out.sessions.find((s) => s.sessionId === "s1");
+  expect(item?.planRound).toBe(3); // planRound still set during planning
 });

--- a/test/server-quota-endpoints.test.ts
+++ b/test/server-quota-endpoints.test.ts
@@ -177,7 +177,9 @@ test("quota/resume, plan kind → calls planGate.resume, status:resumed when it 
     },
     dismiss: () => {},
   };
-  const app = makeApp(makeDeps({ gate: PLAN_GATE, planGate }));
+  const app = makeApp(
+    makeDeps({ session: { ...SESSION, planPhase: "planning" }, gate: PLAN_GATE, planGate }),
+  );
   const res = await app.fetch(post("/api/sessions/s1/quota/resume"));
   expect(res.status).toBe(202);
   expect(await res.json()).toEqual({ ok: true, status: "resumed" });
@@ -191,7 +193,9 @@ test("quota/resume, plan kind → status:unreachable when planGate.resume return
     resume: () => false,
     dismiss: () => {},
   };
-  const app = makeApp(makeDeps({ gate: PLAN_GATE, planGate }));
+  const app = makeApp(
+    makeDeps({ session: { ...SESSION, planPhase: "planning" }, gate: PLAN_GATE, planGate }),
+  );
   const res = await app.fetch(post("/api/sessions/s1/quota/resume"));
   expect(res.status).toBe(202);
   expect(await res.json()).toEqual({ ok: true, status: "unreachable" });
@@ -324,7 +328,9 @@ test("quota/dismiss, plan kind → calls planGate.dismiss, status:dismissed", as
       dismissed.push(s);
     },
   };
-  const app = makeApp(makeDeps({ gate: PLAN_GATE, planGate }));
+  const app = makeApp(
+    makeDeps({ session: { ...SESSION, planPhase: "planning" }, gate: PLAN_GATE, planGate }),
+  );
   const res = await app.fetch(post("/api/sessions/s1/quota/dismiss"));
   expect(res.status).toBe(202);
   expect(await res.json()).toEqual({ ok: true, status: "dismissed" });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1552,5 +1552,6 @@
   "feat_plan_question_answers_title": "Planfragen direkt in der App beantworten",
   "feat_plan_question_answers_body": "Wenn ein Plan offene Fragen stellt, kannst du sie jetzt direkt in der Planansicht beantworten — Optionen auswählen oder eine Antwort eingeben und direkt an den Planungs-Agenten zurücksenden, um den Plan zu verfeinern.",
   "feat_activity_visual_feed_title": "Aktivität ist jetzt ein visueller Feed",
-  "feat_activity_visual_feed_body": "Der Aktivitäts-Tab zeigt während der Arbeit einen Live-Baum der geänderten Dateien und einen gruppierten Tool-Verlauf und wechselt nach Abschluss der Sitzung zur vollständigen visuellen Zusammenfassung."
+  "feat_activity_visual_feed_body": "Der Aktivitäts-Tab zeigt während der Arbeit einen Live-Baum der geänderten Dateien und einen gruppierten Tool-Verlauf und wechselt nach Abschluss der Sitzung zur vollständigen visuellen Zusammenfassung.",
+  "plangate_view": "PLAN"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1553,5 +1553,7 @@
   "feat_plan_question_answers_body": "Wenn ein Plan offene Fragen stellt, kannst du sie jetzt direkt in der Planansicht beantworten — Optionen auswählen oder eine Antwort eingeben und direkt an den Planungs-Agenten zurücksenden, um den Plan zu verfeinern.",
   "feat_activity_visual_feed_title": "Aktivität ist jetzt ein visueller Feed",
   "feat_activity_visual_feed_body": "Der Aktivitäts-Tab zeigt während der Arbeit einen Live-Baum der geänderten Dateien und einen gruppierten Tool-Verlauf und wechselt nach Abschluss der Sitzung zur vollständigen visuellen Zusammenfassung.",
-  "plangate_view": "PLAN"
+  "plangate_view": "PLAN",
+  "feat_plan_reopen_title": "Plan jederzeit erneut öffnen",
+  "feat_plan_reopen_body": "Dein freigegebener Plan bleibt während der Ausführung erreichbar. Tippe bei einer laufenden Session auf den PLAN-Chip — in Zeile, Kachel oder Viewport — um ihn schreibgeschützt anzusehen, am Desktop oder mobil."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1552,5 +1552,6 @@
   "feat_plan_question_answers_title": "Answer plan questions in-app",
   "feat_plan_question_answers_body": "When a plan asks you open questions, you can now answer them right in the plan view — pick options or type a response and send them straight back to the planning agent to refine the plan.",
   "feat_activity_visual_feed_title": "Activity is now a visual feed",
-  "feat_activity_visual_feed_body": "The Activity tab shows a live tree of changed files and a grouped tool stream while the agent works, then graduates to the full visual recap once the session settles."
+  "feat_activity_visual_feed_body": "The Activity tab shows a live tree of changed files and a grouped tool stream while the agent works, then graduates to the full visual recap once the session settles.",
+  "plangate_view": "PLAN"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1553,5 +1553,7 @@
   "feat_plan_question_answers_body": "When a plan asks you open questions, you can now answer them right in the plan view — pick options or type a response and send them straight back to the planning agent to refine the plan.",
   "feat_activity_visual_feed_title": "Activity is now a visual feed",
   "feat_activity_visual_feed_body": "The Activity tab shows a live tree of changed files and a grouped tool stream while the agent works, then graduates to the full visual recap once the session settles.",
-  "plangate_view": "PLAN"
+  "plangate_view": "PLAN",
+  "feat_plan_reopen_title": "Reopen your plan anytime",
+  "feat_plan_reopen_body": "Your signed-off plan stays reachable while work runs. Tap the PLAN chip on any executing session — row, tile, or viewport — to view it read-only, on desktop or mobile."
 }

--- a/ui/src/lib/components/PlanGateBadge.svelte
+++ b/ui/src/lib/components/PlanGateBadge.svelte
@@ -35,6 +35,8 @@
       {m.plangate_ready()}
     {:else if chip.kind === "error"}
       {m.plangate_error()}
+    {:else if chip.kind === "view"}
+      {m.plangate_view()}
     {:else}
       {m.plangate_planning()}
     {/if}

--- a/ui/src/lib/components/PlanGateBadge.test.ts
+++ b/ui/src/lib/components/PlanGateBadge.test.ts
@@ -23,16 +23,23 @@ describe("planGateChip", () => {
     expect(planGateChip(sess(null), undefined, false).kind).toBe("none");
   });
 
-  it("hides when executing (gate already passed)", () => {
-    expect(planGateChip(sess("executing"), gate({ approved: true }), false).kind).toBe("none");
+  it("shows view chip when executing with a persisted gate (issue #809)", () => {
+    expect(planGateChip(sess("executing"), gate({ approved: true }), false)).toEqual({
+      kind: "view",
+    });
   });
 
-  it("hides when executing even if changes_requested verdict still in gate cache (reconnect scenario)", () => {
+  it("shows view chip when executing even if changes_requested verdict in gate cache (reconnect scenario)", () => {
     // Simulates a client that reconnected after planPhase flipped to "executing":
     // the gate cache is repopulated with a stale changes_requested verdict, but
-    // planPhase is persisted as "executing" — the badge must still be hidden.
+    // planPhase is persisted as "executing" — the signed-off plan is still viewable
+    // read-only (issue #809).
     const staleGate = gate({ decision: "changes_requested", round: 2, cap: 3, approved: false });
-    expect(planGateChip(sess("executing"), staleGate, false)).toEqual({ kind: "none" });
+    expect(planGateChip(sess("executing"), staleGate, false)).toEqual({ kind: "view" });
+  });
+
+  it("hides when executing with no gate", () => {
+    expect(planGateChip(sess("executing"), undefined, false)).toEqual({ kind: "none" });
   });
 
   it("reviewing wins over a stale verdict", () => {

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -80,6 +80,40 @@ describe("PlanPanel portal", () => {
   });
 });
 
+describe("PlanPanel read-only during execution", () => {
+  it("shows plan content but no Go or Review buttons when planPhase is executing", async () => {
+    const id = "s-executing";
+    planGates.map = {
+      [id]: {
+        sessionId: id,
+        planHash: "xyz",
+        decision: "approved",
+        summary: "plan approved",
+        body: "",
+        findings: [],
+        round: 1,
+        cap: 3,
+        approved: true,
+        plan: "# Execution plan",
+        blocks: [{ type: "rich-text", id: "b1", markdown: "Step overview" }],
+        updatedAt: Date.now(),
+      },
+    };
+
+    render(PlanPanel, {
+      props: { session: session({ id, planPhase: "executing" }), onclose: vi.fn() },
+    });
+
+    // Plan content renders (the blocks caption is visible).
+    await expect
+      .element(page.getByText("Proposed — not yet built · the plan text below is authoritative"))
+      .toBeVisible();
+
+    // Actions block is absent — no Go, no Review.
+    expect(document.querySelector(".actions")).toBeNull();
+  });
+});
+
 describe("PlanPanel visual blocks", () => {
   it("augments: shows caption + VisualReview blocks above plan markdown when blocks present", async () => {
     const id = "s-blocks";

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -16,6 +16,8 @@
   const releasable = $derived(canRelease(session, gate));
   // Manual re-review only makes sense while still planning (not once executing).
   const canReviewNow = $derived(session.planPhase === "planning");
+  // During execution the plan is viewable read-only — hide Go + Review (issue #809).
+  const readonly = $derived(session.planPhase !== "planning");
   // question-form answers steer back to the planning agent — only while planning (the gate +
   // its questions persist past approval), with submit locked while a review is in flight.
   const planAnswerCtx = $derived(
@@ -194,20 +196,22 @@
         <p class="note err" role="alert">{m.planpanel_review_failed()}</p>
       {/if}
 
-      <div class="actions">
-        {#if canReviewNow}
-          <button type="button" class="review" onclick={review} disabled={inFlight}>
-            {#if inFlight}
-              <span class="rev-dot" aria-hidden="true"></span>{m.planpanel_reviewing()}
-            {:else}
-              {m.planpanel_review_now()}
-            {/if}
+      {#if !readonly}
+        <div class="actions">
+          {#if canReviewNow}
+            <button type="button" class="review" onclick={review} disabled={inFlight}>
+              {#if inFlight}
+                <span class="rev-dot" aria-hidden="true"></span>{m.planpanel_reviewing()}
+              {:else}
+                {m.planpanel_review_now()}
+              {/if}
+            </button>
+          {/if}
+          <button type="button" class="go" onclick={go} disabled={busy || !releasable}>
+            {m.planpanel_go()}
           </button>
-        {/if}
-        <button type="button" class="go" onclick={go} disabled={busy || !releasable}>
-          {m.planpanel_go()}
-        </button>
-      </div>
+        </div>
+      {/if}
     </div>
   </div>
 </div>

--- a/ui/src/lib/components/plan-gate-badge.ts
+++ b/ui/src/lib/components/plan-gate-badge.ts
@@ -4,9 +4,12 @@ import type { PlanGate, Session } from "../types";
  * Which plan-gate chip a session card should show, or "none" to hide it.
  * Pure state selection so it can be unit-tested without rendering.
  *
- * Priority order (the badge only renders while the session is in the plan phase):
- *  - "none":       planPhase is null (no gate active) OR planPhase is "executing"
- *                  (the gate already passed — nothing more to surface).
+ * Priority order:
+ *  - "none":       planPhase is null (no gate active), OR planPhase is "executing"
+ *                  with no persisted gate (nothing to show).
+ *  - "view":       planPhase is "executing" AND a persisted gate exists — surfaces
+ *                  the signed-off plan read-only so the operator can re-open it
+ *                  during execution (issue #809). No Go/Review actions are shown.
  *  - "reviewing":  the plan reviewer is running now — wins over any stale verdict.
  *  - "changes":    last verdict requested changes — shows the round/cap counter.
  *  - "ready":      verdict approved and still in "planning" → operator can hit Go.
@@ -15,6 +18,7 @@ import type { PlanGate, Session } from "../types";
  */
 export type PlanGateChip =
   | { kind: "none" }
+  | { kind: "view" }
   | { kind: "reviewing" }
   | { kind: "changes"; round: number; cap: number }
   | { kind: "ready" }
@@ -26,8 +30,10 @@ export function planGateChip(
   gate: PlanGate | undefined,
   reviewing: boolean,
 ): PlanGateChip {
-  // Gate only lives during the plan phase; executing means it already passed.
-  if (session.planPhase == null || session.planPhase === "executing") return { kind: "none" };
+  if (session.planPhase == null) return { kind: "none" };
+  // Executing: the gate already passed — surface the signed-off plan read-only (issue #809),
+  // but only while a persisted gate still exists.
+  if (session.planPhase === "executing") return gate ? { kind: "view" } : { kind: "none" };
   if (reviewing) return { kind: "reviewing" };
   if (gate?.decision === "changes_requested") {
     return { kind: "changes", round: gate.round, cap: gate.cap };

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1139,4 +1139,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_activity_visual_feed_body",
     targetId: "activity-tab",
   },
+  {
+    // #809: a signed-off plan is now reachable during execution via a read-only PLAN chip on the
+    // session row/tile/viewport. No targetId — the chip only appears in the executing phase and the
+    // plan opens in an on-demand modal (PlanPanel), with no stable always-visible anchor (mirrors
+    // the plan-question-answers entry). v1.34.0 is the latest tag → ships in 1.35.0.
+    id: "plan-reopen-execution",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_plan_reopen_title",
+    bodyKey: "feat_plan_reopen_body",
+  },
 ];


### PR DESCRIPTION
Closes #809.

## Problem
Once a session's plan is signed off and work starts (`planPhase` flips `planning → executing`), there was **no way to re-open the visual plan**. The plan-gate badge — the only entry point to `PlanPanel`/`VisualReview` — disappears, with no tab, link, or row action to bring it back. Most painful on mobile, but not mobile-specific. The blocks only resurfaced read-only post-completion in the Done recap.

## Fix (two parts, no new table/column)
**1. UI — read-only plan view during `executing`.** `planGateChip` now returns a quiet, neutral **`PLAN`** chip when `planPhase === "executing"` and a persisted gate exists (else `none`). It opens the existing `PlanPanel` → `VisualReview` read-only: the `.actions` block (Go / Review) is hidden when not planning, and `answerCtx` is already `undefined` outside planning so question-forms are disabled. One `PlanGateBadge` change covers the row, tile, and viewport mount points.

**2. Server — keep the gate alive into execution.** `PlanGateService.forget` is split into `reapReviewer` (stop the in-flight reviewer, **keep** the `plan_gates` row) and `forget` (reap + `dropPlanGate`). The PR-advance path (`session:git`) now calls `reapReviewer`, so the signed-off plan survives the manual-steer-then-PR path; the full drop stays only at `session:archived`. The Go-release path already kept the row.

**Containment.** Retaining the row exposes three execution-phase consumers of a `changes_requested`-at-cap gate, each now guarded with `planPhase === "planning"`:
- `quotaBlockReason` (`src/blocked.ts`) — no `quotaKind:"plan"` block in exec.
- `plan-rework` rundown rule (`src/rundown-core.ts`) — no spurious attention signal.
- `planRound` assembly (`src/rundown-core.ts`) — no stale round stamped into the digest LLM prompt.

## Acceptance
- ✅ During `executing`, the plan re-opens from row/tile/viewport (desktop + mobile).
- ✅ Read-only: no Go, no re-review, no question-form submission.
- ✅ Both the Go-release and manual-steer-then-PR paths (incl. after reload).
- ✅ Gate still dropped at archive (no leak); Done recap unaffected.
- ✅ A retained at-cap gate during execution raises no quota-plan block, no plan-rework signal, and no `planRound` — but all three still fire while planning.

## Tests
- `reapReviewer` keeps the gate row; `forget` still drops it (`test/plan-gate-service.test.ts`).
- **Load-bearing** (`test/blocked.test.ts`, `test/rundown-core.test.ts`): an executing at-cap gate yields no plan block, no `plan-rework` signal, and `item.planRound === undefined`; the same gate while planning still yields all three. Fails on pre-fix code.
- Chip unit cases + read-only browser test (`PlanGateBadge.test.ts`, `PlanPanel.browser.test.ts`).
- Existing plan-quota fixtures updated to `planPhase: "planning"` to match the new contract.

Discovery: one `feature-announcements.ts` entry (`sinceVersion 1.35.0`) + EN/DE keys (`plangate_view`, `feat_plan_reopen_*`).

Green: root lint+tsc+tests, ui check+tests, check:i18n (parity), branch-hygiene, feature-catalog, glossary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)