### PR TITLE
fix(toasts): inset mobile banner above the action bar (#810)

### DIFF
--- a/ui/src/lib/components/Toasts.browser.test.ts
+++ b/ui/src/lib/components/Toasts.browser.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { tick } from "svelte";
+// MUST import the stylesheet: the inset is calc()'d from the design tokens
+// (--mobile-actionbar-hit/-pad/--actionbar-border, all defined in app.css).
+// Without it the calc is invalid and getComputedStyle().bottom is `auto`, not px.
+import "../../app.css";
+
+const { default: Toasts } = await import("./Toasts.svelte");
+const { toasts } = await import("$lib/toasts.svelte");
+
+function toastsBottomPx(): number {
+  const el = document.querySelector(".toasts") as HTMLElement;
+  expect(el, ".toasts rendered").not.toBeNull();
+  return parseFloat(getComputedStyle(el).bottom);
+}
+
+beforeEach(() => {
+  toasts.items = [];
+});
+
+afterEach(async () => {
+  toasts.items = [];
+  document.body.innerHTML = "";
+  await page.viewport(1280, 900); // restore a sane width for other suites
+});
+
+describe("Toasts mobile inset above the action bar (#810)", () => {
+  it("env(safe-area-inset-bottom) resolves to 0 in headless chromium (keeps 66px stable)", () => {
+    // Sanity: the expected inset assumes no notch safe-area. If a future headless
+    // env reported a non-zero inset, the 66px assertion below would drift — guard it.
+    const probe = document.createElement("div");
+    probe.style.paddingBottom = "env(safe-area-inset-bottom)";
+    document.body.appendChild(probe);
+    expect(parseFloat(getComputedStyle(probe).paddingBottom)).toBe(0);
+    probe.remove();
+  });
+
+  it("insets the banner above the action bar when aboveActionBar is set", async () => {
+    await page.viewport(400, 900); // ≤768px → mobile banner block
+    toasts.info("decommissioned", { duration: null });
+    render(Toasts, { aboveActionBar: true });
+    await tick();
+    // --mobile-actionbar-h (44 + 10 + 2·1 = 56px) + max(--mobile-actionbar-pad 10px, 0) = 66px
+    const inset = toastsBottomPx();
+    expect(inset).toBeCloseTo(66, 0); // within ~0.5px
+    expect(inset).toBeGreaterThan(0); // strictly above the flush (false) case
+  });
+
+  it("stays flush to the bottom edge (0px) when no action bar is present", async () => {
+    await page.viewport(400, 900);
+    toasts.info("decommissioned", { duration: null });
+    render(Toasts, { aboveActionBar: false });
+    await tick();
+    expect(toastsBottomPx()).toBe(0); // today's flush behavior; pre-fix value in both states
+  });
+});

--- a/ui/src/lib/components/Toasts.svelte
+++ b/ui/src/lib/components/Toasts.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
+
+  // True only on the mobile list screen, where the fixed ActionBar (+ New Task)
+  // shares the bottom edge with the toast banner. When set, the mobile banner is
+  // inset to float just above the bar so it never covers the button (issue #810).
+  let { aboveActionBar = false }: { aboveActionBar?: boolean } = $props();
 </script>
 
 {#if toasts.items.length}
-  <div class="toasts" aria-live="polite" aria-atomic="false">
+  <div class="toasts" class:above-bar={aboveActionBar} aria-live="polite" aria-atomic="false">
     {#each toasts.items as t (t.id)}
       <!-- hold()/release() pause timed info auto-dismiss while hovered or focused;
            the store no-ops both for undo toasts, so attaching uniformly is safe. -->
@@ -235,6 +240,22 @@
       top: 0;
       bottom: auto;
       height: 3px;
+    }
+    /* On the mobile LIST screen the fixed ActionBar (+ New Task) occupies the
+       bottom edge too; at a higher z-index the toast banner would fully cover it
+       (issue #810). When the action bar is present, inset the banner to float just
+       above it — mirroring the shell's own padding-bottom reserve so the two can't
+       drift. Compound selector (.toasts.above-bar) so it beats the base .toasts
+       rule on specificity, not source order. */
+    .toasts.above-bar {
+      bottom: calc(
+        var(--mobile-actionbar-h) + max(var(--mobile-actionbar-pad), env(safe-area-inset-bottom))
+      );
+    }
+    /* No longer flush to the screen edge, so the home-bar safe-area reserve is the
+       action bar's job — drop the first-child's extra padding to avoid doubling it. */
+    .toasts.above-bar .toast:first-child {
+      padding-bottom: 10px;
     }
   }
 </style>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -630,6 +630,12 @@
   let mobileScreen = $state<"list" | "detail">("list");
   let chromeHidden = $state(false);
 
+  // The fixed mobile ActionBar (+ New Task) is rendered iff this is true (see its
+  // render guard in the mobile list branch below). Single source for "is the action
+  // bar present?", consumed by <Toasts aboveActionBar> so the toast banner insets
+  // above the bar instead of covering it (issue #810).
+  const mobileActionBarPresent = $derived(mobile.current && mobileScreen === "list");
+
   // Scroll-compress the chrome header on mobile list: hide on scroll-down, restore
   // on scroll-up or at/near top. Window (document) scroll only — the mobile list
   // screen is a document-scroll app-shell; inner regions don't scroll.
@@ -1557,6 +1563,9 @@
 
   <main id="main-content" class="main-region">
     {#if mobile.current}
+      <!-- This list branch is the sole place the mobile ActionBar renders; its
+           presence is mirrored by `mobileActionBarPresent` above (feeds Toasts).
+           Keep the two in sync. -->
       {#if mobileScreen === "list"}
         <div class="col">
           <Herd
@@ -2120,7 +2129,7 @@
   <StarPrompt onresolve={(s) => (store.starPrompt = s)} />
 {/if}
 
-<Toasts />
+<Toasts aboveActionBar={mobileActionBarPresent} />
 
 <style>
   /* Visually-hidden utility, scoped here explicitly rather than leaning on


### PR DESCRIPTION
Closes #810.

## Problem

On mobile, the full-width toast banner flew in **flush to the bottom edge**, directly on top of the fixed `ActionBar` (`+ New Task`) at a higher z-index — so the banner fully covered the button. Worst for the exact flow that triggers it: **decommissioning fires a 5s `undo` toast with no dismiss affordance**, so the action you just took covers the button you're reaching for next, for 5 seconds.

## Fix (issue Option D)

On the mobile **list** screen (where the action bar exists), inset the toast stack's `bottom` so the banner floats **just above** the action bar. New Task stays fully visible and tappable with **zero toast interaction** (correct — the undo toast auto-commits) and the **action bar never moves** (no moving-target mis-tap). The **detail** screen (no action bar) and **desktop** keep today's behavior.

- `Toasts.svelte`: new `aboveActionBar` boolean prop → `.toasts.above-bar` mobile rule insetting `bottom` by `calc(var(--mobile-actionbar-h) + max(var(--mobile-actionbar-pad), env(safe-area-inset-bottom)))` (mirrors the shell's existing padding reserve; token already in `app.css`). Compound selector so it beats the base `.toasts` rule on **specificity**, not source order. First-child safe-area padding reset to avoid double-counting the home-bar inset.
- `+page.svelte`: single `mobileActionBarPresent` `$derived(mobile.current && mobileScreen === "list")` feeds `<Toasts aboveActionBar=...>`, with a cross-link comment beside the `ActionBar` render guard so the two can't diverge. Reactive, so the decommission-from-detail → last-session → flips-to-list path insets the already-rendered undo toast in the same pre-paint flush (no flicker).

## Test

New `Toasts.browser.test.ts` (imports `app.css` so the token `calc()` resolves): at `viewport(400×900)` asserts the inset is **≈66px** when `aboveActionBar` is set and **exactly 0px** (flush) when not, plus a sanity assert that `env(safe-area-inset-bottom)` resolves to 0. Fails on pre-fix code (no prop → `0px` in both states).

`bun run check` ✓ · `bun run test` ✓ (1636 tests) · pre-push gate ✓

## Scope notes

- Pure layout/CSS + one boolean prop — **no new i18n keys**, **no feature-catalog entry** (behavior refinement, not a new surface). Routes through the shared toast store (no parallel path).
- Out of scope (noted in the issue): the full-screen `NewTask` sheet still floats under the z-60 toast — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)