### PR TITLE
fix(learnings): stop content bleeding above sticky group header

### DIFF
--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -650,7 +650,10 @@
     gap: 8px;
     border-left: 2px solid var(--color-line-bright);
     background: var(--color-head);
-    padding: 6px 8px;
+    /* no top padding: the header (.ghead, always the first child) owns the
+       group's top spacing via its own padding-top, so the resting header gap
+       matches the pinned one instead of stacking on a group pad */
+    padding: 0 8px 6px;
   }
   /* Change 4: sticky repo header — opaque background so scrolled content doesn't bleed */
   .ghead {
@@ -658,8 +661,9 @@
     align-items: center;
     justify-content: space-between;
     border-bottom: 1px solid var(--color-line);
-    /* opaque top buffer so scrolling content disappears cleanly under the pinned
-       header's upper edge (drawer drops its top padding for this to read flush) */
+    /* single source of the header's top space (group drops its top padding): an
+       opaque buffer so scrolling content disappears cleanly under the pinned
+       header's upper edge, identical at rest and when pinned at top:0 */
     padding-top: 8px;
     padding-bottom: 4px;
     position: sticky;

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -489,7 +489,10 @@
     display: flex;
     flex-direction: column;
     gap: 10px;
-    padding: 14px;
+    /* No top padding: the sticky group header (.ghead) pins at top:0, so the
+       scroll-container's own top padding would leave a band above it through
+       which scrolling content bleeds. Top spacing is restored on .bar below. */
+    padding: 0 14px 14px;
     overflow-y: auto;
     z-index: 50;
   }
@@ -498,6 +501,8 @@
     align-items: center;
     justify-content: space-between;
     gap: 8px;
+    /* restores the drawer's top breathing room (.bar is always the first child) */
+    padding-top: 14px;
   }
   .title {
     letter-spacing: 0.14em;
@@ -653,6 +658,9 @@
     align-items: center;
     justify-content: space-between;
     border-bottom: 1px solid var(--color-line);
+    /* opaque top buffer so scrolling content disappears cleanly under the pinned
+       header's upper edge (drawer drops its top padding for this to read flush) */
+    padding-top: 8px;
     padding-bottom: 4px;
     position: sticky;
     top: 0;


### PR DESCRIPTION
## Problem

In the Learnings drawer the sticky repo-group header (`.ghead`) let scrolling rule text show **above its upper edge** as you scrolled — it looked broken (the "topography scrolling past on the upper edge" in the report).

## Root cause

`.drawer` is the scroll container with `padding: 14px` (all sides) + `overflow-y: auto`. A `position: sticky; top: 0` header pins at the scrollport's **content edge** — i.e. **14px below** the drawer's clip (padding-box) edge. Scrolled content stays visible across that 14px padding-top band, so it bled through above the pinned header. A plain `padding-top` on `.ghead` wouldn't fix it — the box top stays at the pin point and the band above remains uncovered.

## Fix (3 CSS rules, `LearningsDrawer.svelte`)

- `.drawer`: `padding: 14px` → `padding: 0 14px 14px` — drop only the top padding so the header pins flush at the clip edge.
- `.bar` (always the drawer's first child): `+ padding-top: 14px` — restores the chrome's top breathing room when scrolled to the top.
- `.ghead`: `+ padding-top: 8px` — opaque buffer above the pinned title (the requested "top padding").

No negative margin is used, so there's **no** `--color-head` overhang into the inter-group gaps (the artifact the obvious one-selector `margin-top: -14px` cap would have introduced — see the plan for the rejected alternative).

## Verification

Verified live (vite dev → live API) with browser automation, scrolling a **mid-list** group in **both light and dark themes**:
- ✅ No rule text / background bleeds above the pinned header's upper edge.
- ✅ No `--color-head` overhang strip in the 10px inter-group gaps.
- ✅ Top-of-list chrome spacing unchanged.
- ✅ Computed styles on the live elements: `.ghead` `padding-top: 8px` / `margin-top: 0px`, `.drawer` `padding-top: 0`, `.bar` `padding-top: 14px`.
- ✅ `cd ui && bun run check` passes (0 errors).

Pure cosmetic CSS — no new user-facing string or capability, so no feature-catalog / i18n / glossary entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)