### PR TITLE
feat: lightweight repo mode — local-only git, merge branches locally at task completion (#807)

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -79,6 +79,11 @@ export interface AutopilotDeps {
   /** Whether the session already has a PR in any state (open/merged/closed). True → autopilot
    *  stands down (open = critic territory; merged/closed = pre-PR mission over). */
   hasPr: (id: string) => boolean;
+  /** Register a lightweight (local) session's pseudo-PR server-side. Replaces the forge-mode
+   *  open-a-PR steer for a `lightweight` repo: the agent has no `gh`, so the deliberate
+   *  completion barrier runs here instead of being typed into the PTY. Best-effort — the
+   *  wiring guards a rejection so a failure never crashes the autopilot tick. */
+  openLocalPr: (id: string) => Promise<void>;
   /** The cached PR snapshot for a session (the PR poller's last poll), or null when there is
    *  none. The recurring tick reads this directly — NOT off a `session:git` emit — so it can
    *  re-engage an idle agent stuck on an UNCHANGED open+red head, the case the event-driven
@@ -204,6 +209,12 @@ export class AutopilotService {
         if (s.research) {
           // Research sessions never open a code PR — mark complete instead of steering open-a-PR.
           this.markComplete(s, v.summary || COMPLETE_MESSAGE);
+          return;
+        }
+        if (this.deps.store.getRepoConfig(s.repoPath).repoMode === "lightweight") {
+          // Lightweight repo: the agent has no `gh`, so register the pseudo-PR server-side
+          // (the deliberate completion barrier) instead of steering `gh pr create`.
+          await this.deps.openLocalPr(s.id);
           return;
         }
         await this.driveSteer(

--- a/src/backlog-poller.ts
+++ b/src/backlog-poller.ts
@@ -13,16 +13,6 @@ import type { RepoCounts } from "./backlog";
  */
 export class BacklogPoller {
   private timer: ReturnType<typeof setInterval> | null = null;
-  /**
-   * Memoised "is this repo forge-backed?" per path for non-local forges.
-   * `resolveForge` shells out to `git remote get-url` for forge repos — uncached
-   * it would block the event loop on N git subprocesses every tick.
-   *
-   * Local forges (`kind === "local"`) are NOT cached here: repoMode can be
-   * toggled at runtime, so we recompute the backed verdict per tick for them.
-   * Forge repos are immutably backed once detected.
-   */
-  private readonly forgeBackedCache = new Map<string, boolean>();
 
   constructor(
     private listRepos: () => Array<{ path: string }>,
@@ -46,19 +36,12 @@ export class BacklogPoller {
   }
 
   private isForgeBacked(path: string): boolean {
+    // Not forge-backed: no forge, or a local forge (no remote issues/PRs to count).
+    // Computed per tick with no local cache so a repoMode flip propagates without a
+    // restart; the underlying `git remote get-url` shell-out is memoized upstream in
+    // the production `resolveForge` (makeForgeResolver), so this stays cheap.
     const forge = this.resolveForge(path);
-    // Local forge is not considered forge-backed (no remote issues/PRs to count).
-    // Recompute each time so a repoMode flip propagates without a restart.
-    if (forge?.kind === "local") return false;
-    if (forge === null || forge === undefined) return false;
-
-    // Genuine remote forge: memoize to avoid repeated git shell-outs.
-    let cached = this.forgeBackedCache.get(path);
-    if (cached === undefined) {
-      cached = true; // forge != null && kind !== "local"
-      this.forgeBackedCache.set(path, cached);
-    }
-    return cached;
+    return forge != null && forge.kind !== "local";
   }
 
   start(): void {

--- a/src/backlog-poller.ts
+++ b/src/backlog-poller.ts
@@ -14,16 +14,19 @@ import type { RepoCounts } from "./backlog";
 export class BacklogPoller {
   private timer: ReturnType<typeof setInterval> | null = null;
   /**
-   * Memoised "is this repo forge-backed?" per path. `resolveForge` (detectForge)
-   * shells out to a synchronous `git remote get-url` — uncached it would block
-   * the event loop on N git subprocesses every tick. Forge↔repo is effectively
-   * immutable, so resolving once per path is safe.
+   * Memoised "is this repo forge-backed?" per path for non-local forges.
+   * `resolveForge` shells out to `git remote get-url` for forge repos — uncached
+   * it would block the event loop on N git subprocesses every tick.
+   *
+   * Local forges (`kind === "local"`) are NOT cached here: repoMode can be
+   * toggled at runtime, so we recompute the backed verdict per tick for them.
+   * Forge repos are immutably backed once detected.
    */
-  private readonly forgeBacked = new Map<string, boolean>();
+  private readonly forgeBackedCache = new Map<string, boolean>();
 
   constructor(
     private listRepos: () => Array<{ path: string }>,
-    private resolveForge: (repoPath: string) => unknown | null,
+    private resolveForge: (repoPath: string) => { kind?: string } | null,
     private warm: (repoPath: string) => Promise<RepoCounts>,
     private intervalMs = 45_000,
     /**
@@ -43,12 +46,19 @@ export class BacklogPoller {
   }
 
   private isForgeBacked(path: string): boolean {
-    let backed = this.forgeBacked.get(path);
-    if (backed === undefined) {
-      backed = this.resolveForge(path) != null;
-      this.forgeBacked.set(path, backed);
+    const forge = this.resolveForge(path);
+    // Local forge is not considered forge-backed (no remote issues/PRs to count).
+    // Recompute each time so a repoMode flip propagates without a restart.
+    if (forge?.kind === "local") return false;
+    if (forge === null || forge === undefined) return false;
+
+    // Genuine remote forge: memoize to avoid repeated git shell-outs.
+    let cached = this.forgeBackedCache.get(path);
+    if (cached === undefined) {
+      cached = true; // forge != null && kind !== "local"
+      this.forgeBackedCache.set(path, cached);
     }
-    return backed;
+    return cached;
   }
 
   start(): void {

--- a/src/backlog.ts
+++ b/src/backlog.ts
@@ -139,6 +139,9 @@ export class CountsService {
     private readonly run: CountsRunner,
     private readonly fetchFn: typeof fetch = fetch,
     maxConcurrency = DEFAULT_MAX_CONCURRENCY,
+    /** Optional: when provided, lightweight repos are treated as not-forge-backed.
+     *  Read per call so a runtime repoMode toggle propagates without a restart. */
+    private readonly getRepoConfig?: (repoPath: string) => { repoMode: string },
   ) {
     this.gate = new Semaphore(maxConcurrency);
   }
@@ -207,6 +210,10 @@ export class CountsService {
   }
 
   private async fetch(repoPath: string): Promise<RepoCounts> {
+    // Lightweight repos have no remote forge — skip counts regardless of origin URL.
+    // Read repoMode per call so a runtime toggle propagates without a restart.
+    if (this.getRepoConfig?.(repoPath)?.repoMode === "lightweight") return NULL_COUNTS;
+
     const forge = this.resolveForge(repoPath);
     if (!forge) return NULL_COUNTS;
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -352,7 +352,7 @@ export class DiagnosticsService {
     return list;
   }
 
-  /** Force a fresh run of all 7 probes; sets the TTL cache. A probe that throws /
+  /** Force a fresh run of all probes; sets the TTL cache. A probe that throws /
    *  times out resolves to its defined non-OK fallback — the batch never rejects. */
   async check(now: number): Promise<DiagnosticsSnapshot> {
     const checks = await Promise.all(

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -10,6 +10,7 @@ import {
   config,
   findServedPort,
 } from "./config";
+import { parseGitVersion, gitVersionAtLeast } from "./forge/local";
 import { compareSemver } from "./herdr-update";
 import { autoFixCommandFor } from "./remediations";
 import { resolveNodeHost } from "./tailscale";
@@ -45,6 +46,12 @@ export interface DiagnosticsDeps {
    *  Resolves on exit 0; rejects on non-zero exit or timeout. Default spawns a
    *  detached process group and SIGKILLs the whole group on timeout. Injected in tests. */
   runRemediation?: (cmd: string) => Promise<void>;
+  /** Returns true when at least one configured repo has repoMode "forge".
+   *  Default `() => true` preserves today's behavior (gh failure = error). */
+  anyForgeRepo?: () => boolean;
+  /** Returns true when at least one configured repo has repoMode "lightweight".
+   *  Default `() => false` (no extra git capability warning unless opted in). */
+  anyLightweightRepo?: () => boolean;
 }
 
 /** A single probe: an async fn returning ONLY `{ id, state, hintKey }`. */
@@ -129,6 +136,8 @@ export class DiagnosticsService {
   private resolveHost: () => Promise<string | null>;
   private runServeStatus: () => Promise<string>;
   private runRemediation: (cmd: string) => Promise<void>;
+  private anyForgeRepo: () => boolean;
+  private anyLightweightRepo: () => boolean;
   private last: DiagnosticsSnapshot | null = null;
   private lastAt = 0;
 
@@ -162,6 +171,8 @@ export class DiagnosticsService {
         return stdout.toString();
       });
     this.runRemediation = deps.runRemediation ?? defaultRunRemediation;
+    this.anyForgeRepo = deps.anyForgeRepo ?? (() => true);
+    this.anyLightweightRepo = deps.anyLightweightRepo ?? (() => false);
   }
 
   /** Parse a (major.minor.patch) out of arbitrary `--version` output; null if none. */
@@ -218,17 +229,38 @@ export class DiagnosticsService {
 
   /** gh: presence + `gh auth status` exit code (NEVER its stdout). ENOENT ⇒
    *  binary missing; non-zero exit ⇒ not authenticated. Timeout propagates to the
-   *  `probes()` catch which resolves to `diagnostics_hint_gh_not_authenticated`. */
+   *  `probes()` catch which resolves to `diagnostics_hint_gh_not_authenticated`.
+   *  When no forge-mode repos are configured, failures downgrade to warnings — gh
+   *  is optional when all repos are lightweight. */
   private ghProbe = async (): Promise<DiagnosticCheck> => {
     try {
       await this.runGhAuth();
       return { id: "gh", state: "ok", hintKey: "diagnostics_hint_gh_ok" };
     } catch (err) {
+      const forgeRequired = this.anyForgeRepo();
       if (err && typeof err === "object" && (err as NodeJS.ErrnoException).code === "ENOENT") {
+        if (!forgeRequired) {
+          return { id: "gh", state: "warning", hintKey: "diagnostics_hint_gh_not_required" };
+        }
         return { id: "gh", state: "error", hintKey: "diagnostics_hint_gh_missing" };
+      }
+      if (!forgeRequired) {
+        return { id: "gh", state: "warning", hintKey: "diagnostics_hint_gh_not_required" };
       }
       return { id: "gh", state: "error", hintKey: "diagnostics_hint_gh_not_authenticated" };
     }
+  };
+
+  /** git capability check for lightweight mode: requires git ≥ 2.38 for
+   *  `git merge-tree --write-tree`. Only meaningful when at least one lightweight
+   *  repo is configured — otherwise returns ok immediately. */
+  private gitMergetreeProbe = async (): Promise<DiagnosticCheck> => {
+    const out = await this.runVersion("git", ["--version"]);
+    const v = parseGitVersion(out);
+    if (!v || !gitVersionAtLeast(v, 2, 38)) {
+      return { id: "git_mergetree", state: "warning", hintKey: "diagnostics_hint_gitcap_old" };
+    }
+    return { id: "git_mergetree", state: "ok", hintKey: "diagnostics_hint_gitcap_ok" };
   };
 
   /** claude is PRESENCE-ONLY (brief No-Go: no login/auth probe, no ~/.claude
@@ -265,9 +297,11 @@ export class DiagnosticsService {
     return { id: "tailscale", state: "ok", hintKey: "diagnostics_hint_tailscale_ok" };
   };
 
-  /** The 7 probes, each paired with its timed-out non-OK fallback. */
+  /** The probes, each paired with its timed-out non-OK fallback. The
+   *  git_mergetree check is only added when at least one lightweight repo is
+   *  configured — a conditional push so forge-only setups are unaffected. */
   private probes(): Array<{ run: Probe; onTimeout: DiagnosticCheck }> {
-    return [
+    const list: Array<{ run: Probe; onTimeout: DiagnosticCheck }> = [
       {
         run: this.herdrProbe,
         onTimeout: { id: "herdr", state: "error", hintKey: "diagnostics_hint_herdr_missing" },
@@ -305,6 +339,17 @@ export class DiagnosticsService {
         onTimeout: { id: "node", state: "error", hintKey: "diagnostics_hint_node_missing" },
       },
     ];
+    if (this.anyLightweightRepo()) {
+      list.push({
+        run: this.gitMergetreeProbe,
+        onTimeout: {
+          id: "git_mergetree",
+          state: "warning",
+          hintKey: "diagnostics_hint_gitcap_old",
+        },
+      });
+    }
+    return list;
   }
 
   /** Force a fresh run of all 7 probes; sets the TTL cache. A probe that throws /

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -10,7 +10,7 @@ import {
   config,
   findServedPort,
 } from "./config";
-import { parseGitVersion, gitVersionAtLeast } from "./forge/local";
+import { parseGitVersion, gitVersionAtLeast, MIN_GIT_MAJOR, MIN_GIT_MINOR } from "./forge/local";
 import { compareSemver } from "./herdr-update";
 import { autoFixCommandFor } from "./remediations";
 import { resolveNodeHost } from "./tailscale";
@@ -257,7 +257,7 @@ export class DiagnosticsService {
   private gitMergetreeProbe = async (): Promise<DiagnosticCheck> => {
     const out = await this.runVersion("git", ["--version"]);
     const v = parseGitVersion(out);
-    if (!v || !gitVersionAtLeast(v, 2, 38)) {
+    if (!v || !gitVersionAtLeast(v, MIN_GIT_MAJOR, MIN_GIT_MINOR)) {
       return { id: "git_mergetree", state: "warning", hintKey: "diagnostics_hint_gitcap_old" };
     }
     return { id: "git_mergetree", state: "ok", hintKey: "diagnostics_hint_gitcap_ok" };

--- a/src/forge/index.ts
+++ b/src/forge/index.ts
@@ -21,6 +21,7 @@ export function forgeFor(remoteUrl: string, map: ForgeMap): GitForge | null {
   if (!kind) return null;
   const cfg = map[parsed.host] ?? {};
   if (kind === "github") return new GithubForge(parsed.slug, cfg);
+  if (kind === "local") return null; // local repos have no remote forge
   return new GiteaForge(parsed.slug, cfg);
 }
 

--- a/src/forge/local.ts
+++ b/src/forge/local.ts
@@ -2,7 +2,15 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { timedAsync } from "../instrument";
 import type { SessionStore } from "../store";
-import type { GitForge, Issue, MergeMethod, OpenPrInput, PrStatus, PullRequest } from "./types";
+import {
+  EmptyDiffError,
+  type GitForge,
+  type Issue,
+  type MergeMethod,
+  type OpenPrInput,
+  type PrStatus,
+  type PullRequest,
+} from "./types";
 
 const execFileAsync = promisify(execFile);
 
@@ -335,6 +343,14 @@ export class LocalForge implements GitForge {
   }
 
   async openPr(o: OpenPrInput): Promise<PrStatus> {
+    // No commits ahead of base ⇒ nothing to open a pseudo-PR for (and a later squash
+    // would be an empty commit). Forge-agnostic signal: callers resolve "nothing to land".
+    const ahead = await gitOrThrow(
+      this.repoPath,
+      ["rev-list", "--count", `${o.base}..${o.head}`],
+      GIT_READ_TIMEOUT_MS,
+    );
+    if (Number(ahead) === 0) throw new EmptyDiffError(o.head, o.base);
     const row = this.store.ensureLocalPr(this.repoPath, o.head, o.base);
     return {
       state: "open",

--- a/src/forge/local.ts
+++ b/src/forge/local.ts
@@ -22,8 +22,8 @@ const GIT_TIMEOUT_MS = 60_000;
 /** Lighter bound for the pure-read probes (rev-parse / merge-tree dry run / --version). */
 const GIT_READ_TIMEOUT_MS = 15_000;
 
-const MIN_GIT_MAJOR = 2;
-const MIN_GIT_MINOR = 38;
+export const MIN_GIT_MAJOR = 2;
+export const MIN_GIT_MINOR = 38;
 
 /** Thrown when the squash would conflict (`git merge-tree --write-tree` non-zero).
  *  No refs are touched when this is thrown. */

--- a/src/forge/local.ts
+++ b/src/forge/local.ts
@@ -25,7 +25,8 @@ const GIT_READ_TIMEOUT_MS = 15_000;
 export const MIN_GIT_MAJOR = 2;
 export const MIN_GIT_MINOR = 38;
 
-/** Thrown when the squash would conflict (`git merge-tree --write-tree` non-zero).
+/** Thrown when the squash would conflict (`git merge-tree --write-tree` exits 1).
+ *  A higher exit code is a genuine git error and surfaces as a plain Error instead.
  *  No refs are touched when this is thrown. */
 export class MergeConflictError extends Error {
   constructor(
@@ -138,6 +139,26 @@ async function gitOrThrow(cwd: string, args: string[], timeout = GIT_TIMEOUT_MS)
   return r.stdout.trim();
 }
 
+/** Run `git merge-tree --write-tree <base> <branch>`, decoding git's exit codes:
+ *  - exit 0   → clean merge; returns the merged tree OID (first line of stdout).
+ *  - exit 1   → genuine merge CONFLICT (`{ conflict: true }`).
+ *  - exit >1  → a real git failure (bad object, missing ref, etc.) → THROWS with
+ *               stderr, so a genuine error is never misreported as a merge conflict.
+ *  Shared by the merge path and the mergeability dry run. */
+export async function mergeTreeWriteTree(
+  repoPath: string,
+  base: string,
+  branch: string,
+): Promise<{ conflict: boolean; tree?: string }> {
+  const r = await gitRun(repoPath, ["merge-tree", "--write-tree", base, branch]);
+  if (r.code === 0) return { conflict: false, tree: r.stdout.split("\n")[0]?.trim() };
+  if (r.code === 1) return { conflict: true };
+  throw new Error(
+    `git merge-tree --write-tree ${base} ${branch} → exit ${r.code}: ` +
+      `${r.stderr.trim() || r.stdout.trim()}`,
+  );
+}
+
 interface WorktreeEntry {
   path: string;
   head?: string;
@@ -203,11 +224,12 @@ export async function squashMergeLocal(
     GIT_READ_TIMEOUT_MS,
   );
 
-  // 3. Compute the merged tree off the working tree. Non-zero exit ⇒ conflict.
-  //    On success the merged tree OID is the first line of stdout. NO refs touched.
-  const mt = await gitRun(repoPath, ["merge-tree", "--write-tree", base, branch]);
-  if (mt.code !== 0) throw new MergeConflictError(branch, base);
-  const tree = mt.stdout.split("\n")[0]?.trim();
+  // 3. Compute the merged tree off the working tree. Exit 1 ⇒ a real conflict;
+  //    exit >1 ⇒ a genuine git failure (surfaced by mergeTreeWriteTree, NOT
+  //    misreported as a conflict). NO refs touched either way.
+  const mt = await mergeTreeWriteTree(repoPath, base, branch);
+  if (mt.conflict) throw new MergeConflictError(branch, base);
+  const tree = mt.tree;
   if (!tree) {
     throw new Error(`git merge-tree produced no tree OID for ${branch} into ${base}`);
   }
@@ -315,8 +337,10 @@ export class LocalForge implements GitForge {
    *  rather than a silently-wrong boolean. */
   private async dryRunMergeable(branch: string, base: string): Promise<boolean> {
     await assertGitCapable(this.versionProbe);
-    const r = await gitRun(this.repoPath, ["merge-tree", "--write-tree", base, branch]);
-    return r.code === 0;
+    // Exit 1 ⇒ conflict (not mergeable); exit >1 ⇒ a genuine git error, which
+    // mergeTreeWriteTree throws (the poller keeps its last value) rather than
+    // silently reporting a wrong `mergeable: false`.
+    return !(await mergeTreeWriteTree(this.repoPath, base, branch)).conflict;
   }
 
   async prStatus(headBranch: string): Promise<PrStatus> {

--- a/src/forge/local.ts
+++ b/src/forge/local.ts
@@ -1,0 +1,367 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { timedAsync } from "../instrument";
+import type { SessionStore } from "../store";
+import type { GitForge, Issue, MergeMethod, OpenPrInput, PrStatus, PullRequest } from "./types";
+
+const execFileAsync = promisify(execFile);
+
+/** Per-git-call timeout (ms). Every invocation in this module is bounded — the
+ *  ref-writing merge path is NOT exempt (house rule: never label a ref-writing
+ *  path read-only/fail-fast). Generous enough for a full off-working-tree squash
+ *  + an in-worktree fast-forward checkout on a large repo. */
+const GIT_TIMEOUT_MS = 60_000;
+/** Lighter bound for the pure-read probes (rev-parse / merge-tree dry run / --version). */
+const GIT_READ_TIMEOUT_MS = 15_000;
+
+const MIN_GIT_MAJOR = 2;
+const MIN_GIT_MINOR = 38;
+
+/** Thrown when the squash would conflict (`git merge-tree --write-tree` non-zero).
+ *  No refs are touched when this is thrown. */
+export class MergeConflictError extends Error {
+  constructor(
+    readonly branch: string,
+    readonly base: string,
+  ) {
+    super(`merge conflict squashing ${branch} into ${base}`);
+    this.name = "MergeConflictError";
+  }
+}
+
+/** Thrown when `base` is checked out in a worktree that is dirty or whose HEAD has
+ *  moved off the base tip we computed — advancing it would desync that working tree,
+ *  so we abort having moved nothing. */
+export class BaseCheckoutBusyError extends Error {
+  constructor(readonly base: string) {
+    super(
+      `base branch '${base}' is checked out in a worktree that is dirty or has moved; ` +
+        `commit/clean it (or move off it) before merging`,
+    );
+    this.name = "BaseCheckoutBusyError";
+  }
+}
+
+/** An async `git --version` probe; injectable so tests can simulate an old git. */
+export type GitVersionProbe = () => Promise<string>;
+
+export interface GitVersion {
+  major: number;
+  minor: number;
+}
+
+/** Parse "git version 2.54.0" → { major: 2, minor: 54 }; null when unparseable. */
+export function parseGitVersion(out: string): GitVersion | null {
+  const m = /git version (\d+)\.(\d+)/.exec(out);
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]) };
+}
+
+export function gitVersionAtLeast(v: GitVersion, major: number, minor: number): boolean {
+  return v.major > major || (v.major === major && v.minor >= minor);
+}
+
+const defaultVersionProbe: GitVersionProbe = async () => {
+  const { stdout } = await timedAsync("git --version", () =>
+    execFileAsync("git", ["--version"], { timeout: GIT_READ_TIMEOUT_MS }),
+  );
+  return stdout;
+};
+
+/** Module-level memoized version (the installed git doesn't change mid-process). */
+let cachedVersionOut: string | undefined;
+
+/** Throw a clear, actionable error if git < 2.38 (required for `merge-tree
+ *  --write-tree`). Returns the raw version string on success. */
+async function assertGitCapable(probe: GitVersionProbe): Promise<string> {
+  // Cache only the default probe's result; an injected probe (tests) is honored each call.
+  let out: string;
+  if (probe === defaultVersionProbe) {
+    if (cachedVersionOut === undefined) cachedVersionOut = await probe();
+    out = cachedVersionOut;
+  } else {
+    out = await probe();
+  }
+  const v = parseGitVersion(out);
+  const found = out.trim() || "unknown";
+  if (!v || !gitVersionAtLeast(v, MIN_GIT_MAJOR, MIN_GIT_MINOR)) {
+    throw new Error(
+      `Lightweight repo mode requires git >= ${MIN_GIT_MAJOR}.${MIN_GIT_MINOR} ` +
+        `(for 'git merge-tree --write-tree'); found ${found}`,
+    );
+  }
+  return out;
+}
+
+interface ExecResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run a git command in `cwd`, returning code+stdout+stderr WITHOUT throwing on a
+ *  non-zero exit (so callers can branch on the exit code — e.g. merge-tree's
+ *  conflict signal). A spawn failure (ENOENT etc.) still rejects. */
+async function gitRun(cwd: string, args: string[], timeout = GIT_TIMEOUT_MS): Promise<ExecResult> {
+  try {
+    const { stdout, stderr } = await timedAsync(`git ${args[0]}`, () =>
+      execFileAsync("git", args, { cwd, timeout, maxBuffer: 64 * 1024 * 1024 }),
+    );
+    return { code: 0, stdout: stdout.toString(), stderr: stderr.toString() };
+  } catch (err) {
+    const e = err as { code?: unknown; stdout?: unknown; stderr?: unknown };
+    // execFile sets a numeric `code` on a non-zero exit; a spawn failure has no
+    // numeric code (e.g. "ENOENT") → rethrow, it's not a clean non-zero exit.
+    if (typeof e.code === "number") {
+      return { code: e.code, stdout: String(e.stdout ?? ""), stderr: String(e.stderr ?? "") };
+    }
+    throw err;
+  }
+}
+
+/** Run git and throw on a non-zero exit (stderr in the message). */
+async function gitOrThrow(cwd: string, args: string[], timeout = GIT_TIMEOUT_MS): Promise<string> {
+  const r = await gitRun(cwd, args, timeout);
+  if (r.code !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} → exit ${r.code}: ${r.stderr.trim() || r.stdout.trim()}`,
+    );
+  }
+  return r.stdout.trim();
+}
+
+interface WorktreeEntry {
+  path: string;
+  head?: string;
+  branch?: string; // short name (refs/heads/ stripped)
+  detached: boolean;
+}
+
+/** Parse `git worktree list --porcelain` into structured entries. Blocks are
+ *  separated by blank lines; lines are `worktree <path>`, `HEAD <sha>`,
+ *  `branch refs/heads/<name>`, or `detached`. */
+function parseWorktrees(porcelain: string): WorktreeEntry[] {
+  const out: WorktreeEntry[] = [];
+  let cur: WorktreeEntry | null = null;
+  for (const raw of porcelain.split("\n")) {
+    const line = raw.trimEnd();
+    if (line.startsWith("worktree ")) {
+      if (cur) out.push(cur);
+      cur = { path: line.slice("worktree ".length), detached: false };
+    } else if (!cur) {
+      continue;
+    } else if (line.startsWith("HEAD ")) {
+      cur.head = line.slice("HEAD ".length);
+    } else if (line.startsWith("branch ")) {
+      cur.branch = line.slice("branch ".length).replace(/^refs\/heads\//, "");
+    } else if (line === "detached") {
+      cur.detached = true;
+    }
+  }
+  if (cur) out.push(cur);
+  return out;
+}
+
+/**
+ * Off-working-tree squash-merge of `branch` into `base` in `repoPath`, with NO
+ * checkout of the base in the primary worktree required.
+ *
+ * ORDER IS LOAD-BEARING — the shared base ref is moved only AFTER the
+ * base-checkout strategy is decided, and ONLY ONE of the three strategies runs:
+ *
+ *  - base checked out in a worktree, clean, HEAD === baseTip → advance it via
+ *    `git -C <wt> merge --ff-only <newCommit>` (ref + index + files atomically;
+ *    no bare update-ref, no desync). This is the headline case.
+ *  - base checked out but dirty, or its HEAD !== baseTip → throw
+ *    BaseCheckoutBusyError having moved NOTHING.
+ *  - base checked out nowhere → `git update-ref refs/heads/<base> <newCommit>
+ *    <baseTip>` (3-arg compare-and-swap; a stale baseTip lets it throw).
+ *
+ * A conflict (merge-tree non-zero) throws MergeConflictError before any ref moves.
+ */
+export async function squashMergeLocal(
+  repoPath: string,
+  branch: string,
+  base: string,
+  versionProbe: GitVersionProbe = defaultVersionProbe,
+): Promise<void> {
+  // 1. Capability guard — git >= 2.38 for `merge-tree --write-tree`.
+  await assertGitCapable(versionProbe);
+
+  // 2. Snapshot the base tip (compare-and-swap anchor; nothing moved yet).
+  const baseTip = await gitOrThrow(
+    repoPath,
+    ["rev-parse", "--verify", `refs/heads/${base}`],
+    GIT_READ_TIMEOUT_MS,
+  );
+
+  // 3. Compute the merged tree off the working tree. Non-zero exit ⇒ conflict.
+  //    On success the merged tree OID is the first line of stdout. NO refs touched.
+  const mt = await gitRun(repoPath, ["merge-tree", "--write-tree", base, branch]);
+  if (mt.code !== 0) throw new MergeConflictError(branch, base);
+  const tree = mt.stdout.split("\n")[0]?.trim();
+  if (!tree) {
+    throw new Error(`git merge-tree produced no tree OID for ${branch} into ${base}`);
+  }
+
+  // 4. Deterministic squash commit message: subject = branch, body = the squashed
+  //    commit subjects (base..branch), oldest-first.
+  const subjects = (
+    await gitOrThrow(repoPath, ["log", "--reverse", "--format=%s", `${base}..${branch}`])
+  )
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const message =
+    subjects.length > 0 ? `${branch}\n\n${subjects.map((s) => `* ${s}`).join("\n")}` : branch;
+
+  // 5. Build the squash commit (single parent = base tip). STILL no refs moved.
+  const newCommit = await gitOrThrow(repoPath, ["commit-tree", tree, "-p", baseTip, "-m", message]);
+
+  // 6. Decide the base-checkout strategy, then move the ref EXACTLY ONCE.
+  const worktrees = parseWorktrees(
+    await gitOrThrow(repoPath, ["worktree", "list", "--porcelain"], GIT_READ_TIMEOUT_MS),
+  );
+  const baseWt = worktrees.find((w) => w.branch === base);
+
+  if (baseWt) {
+    // base is checked out somewhere — never bare-update a checked-out ref.
+    const dirty = (await gitOrThrow(baseWt.path, ["status", "--porcelain"], GIT_READ_TIMEOUT_MS))
+      .length;
+    if (dirty > 0 || baseWt.head !== baseTip) {
+      throw new BaseCheckoutBusyError(base); // nothing moved yet
+    }
+    // clean + at baseTip → advance ref + index + files atomically.
+    await gitOrThrow(baseWt.path, ["merge", "--ff-only", newCommit]);
+  } else {
+    // checked out nowhere → compare-and-swap; a stale baseTip makes this throw.
+    await gitOrThrow(repoPath, ["update-ref", `refs/heads/${base}`, newCommit, baseTip]);
+  }
+
+  // 7. Branch cleanup hook: point the (about-to-be-removed) task branch at the
+  //    squash commit so the ancestry-gated pruneMergedBranch deletes it later.
+  //    update-ref does NOT refuse a branch checked out in another worktree.
+  const branchRef = await gitRun(
+    repoPath,
+    ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`],
+    GIT_READ_TIMEOUT_MS,
+  );
+  if (branchRef.code === 0) {
+    await gitOrThrow(repoPath, ["update-ref", `refs/heads/${branch}`, newCommit]);
+  }
+}
+
+/** Local-only forge (#807, lightweight repo mode): drives a repo with local git
+ *  only — no remote, no `gh`. Completion squash-merges the branch into its base
+ *  locally. Deliberately implements only the GitForge methods that make sense
+ *  without a host; every optional method is OMITTED so forge-only features
+ *  (drain claims, epics, standalone critic, fork UI, deploy) self-disable. */
+export class LocalForge implements GitForge {
+  readonly kind = "local" as const;
+  readonly slug = null;
+  readonly mergeMethod: MergeMethod = "squash";
+  readonly deployWorkflow = null;
+  readonly webUrl = null;
+
+  constructor(
+    readonly repoPath: string,
+    private readonly store: Pick<
+      SessionStore,
+      "ensureLocalPr" | "getLocalPr" | "getLocalPrByNumber" | "markLocalPrMerged"
+    >,
+    private readonly versionProbe: GitVersionProbe = defaultVersionProbe,
+  ) {}
+
+  async listIssues(): Promise<Issue[]> {
+    return [];
+  }
+
+  async listPullRequests(): Promise<PullRequest[]> {
+    return [];
+  }
+
+  async defaultBranch(): Promise<string> {
+    try {
+      return (
+        (
+          await gitOrThrow(this.repoPath, ["symbolic-ref", "--short", "HEAD"], GIT_READ_TIMEOUT_MS)
+        ).trim() || "main"
+      );
+    } catch {
+      return "main";
+    }
+  }
+
+  /** Tip sha of a local branch, or undefined when the branch is gone. */
+  private async tipOf(branch: string): Promise<string | undefined> {
+    const r = await gitRun(
+      this.repoPath,
+      ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`],
+      GIT_READ_TIMEOUT_MS,
+    );
+    return r.code === 0 ? r.stdout.trim() : undefined;
+  }
+
+  /** Cleanly-mergeable dry run via `git merge-tree --write-tree`: exit 0 ⇒ true.
+   *  Goes through the capability guard so an old git surfaces the guard error
+   *  rather than a silently-wrong boolean. */
+  private async dryRunMergeable(branch: string, base: string): Promise<boolean> {
+    await assertGitCapable(this.versionProbe);
+    const r = await gitRun(this.repoPath, ["merge-tree", "--write-tree", base, branch]);
+    return r.code === 0;
+  }
+
+  async prStatus(headBranch: string): Promise<PrStatus> {
+    const row = this.store.getLocalPr(this.repoPath, headBranch);
+    if (!row) return { state: "none", checks: "none", deployConfigured: false };
+    if (row.state === "merged") {
+      return {
+        state: "merged",
+        number: row.number,
+        checks: "success",
+        deployConfigured: false,
+      };
+    }
+    // open
+    return {
+      state: "open",
+      number: row.number,
+      checks: "success",
+      mergeable: await this.dryRunMergeable(headBranch, row.base),
+      headSha: await this.tipOf(headBranch),
+      createdAt: row.createdAt,
+      deployConfigured: false,
+    };
+  }
+
+  async openPr(o: OpenPrInput): Promise<PrStatus> {
+    const row = this.store.ensureLocalPr(this.repoPath, o.head, o.base);
+    return {
+      state: "open",
+      number: row.number,
+      checks: "success",
+      mergeable: await this.dryRunMergeable(o.head, row.base),
+      headSha: await this.tipOf(o.head),
+      createdAt: row.createdAt,
+      deployConfigured: false,
+    };
+  }
+
+  async merge(prNumber: number): Promise<void> {
+    const row = this.store.getLocalPrByNumber(prNumber);
+    if (!row) throw new Error(`no local PR with number ${prNumber}`);
+    await squashMergeLocal(row.repoPath, row.branch, row.base, this.versionProbe);
+    this.store.markLocalPrMerged(prNumber);
+  }
+
+  async postReview(): Promise<{ url?: string }> {
+    // No-op: the verdict is persisted to the `reviews` table and shown in the UI
+    // independently of any host review.
+    return {};
+  }
+
+  async redeploy(): Promise<void> {
+    // Unreachable backstop: deployWorkflow is null so the endpoint 400s first.
+    throw new Error("redeploy is not supported in lightweight mode");
+  }
+}

--- a/src/forge/local.ts
+++ b/src/forge/local.ts
@@ -17,9 +17,12 @@ const execFileAsync = promisify(execFile);
 /** Per-git-call timeout (ms). Every invocation in this module is bounded — the
  *  ref-writing merge path is NOT exempt (house rule: never label a ref-writing
  *  path read-only/fail-fast). Generous enough for a full off-working-tree squash
- *  + an in-worktree fast-forward checkout on a large repo. */
+ *  + an in-worktree fast-forward checkout on a large repo. Also covers
+ *  `merge-tree --write-tree` (the mergeability dry run AND the squash compute):
+ *  it is a real 3-way merge that writes a tree, not a trivial metadata read. */
 const GIT_TIMEOUT_MS = 60_000;
-/** Lighter bound for the pure-read probes (rev-parse / merge-tree dry run / --version). */
+/** Lighter bound for the trivial metadata reads (rev-parse / status / worktree
+ *  list / --version). */
 const GIT_READ_TIMEOUT_MS = 15_000;
 
 export const MIN_GIT_MAJOR = 2;

--- a/src/forge/resolve.ts
+++ b/src/forge/resolve.ts
@@ -1,0 +1,77 @@
+import type { GitForge, ForgeMap } from "./types";
+import type { SessionStore } from "../store";
+import { LocalForge } from "./local";
+import { detectForge } from ".";
+
+/** Minimal store slice `makeProductionForgeResolver` needs — injectable for tests. */
+export type ForgeResolverStore = Pick<
+  SessionStore,
+  "getRepoConfig" | "ensureLocalPr" | "getLocalPr" | "getLocalPrByNumber" | "markLocalPrMerged"
+>;
+
+/** Deps injected into makeForgeResolver — split out so tests can stub them. */
+export interface ForgeResolverDeps {
+  getRepoConfig: (dir: string) => { repoMode: "forge" | "lightweight" };
+  detectForge: (dir: string) => GitForge | null;
+  makeLocalForge: (dir: string) => LocalForge;
+}
+
+/**
+ * Build the mode-aware `resolveForge` closure used in src/index.ts.
+ *
+ * Per-call repoMode read (cheap PK lookup) means a runtime toggle propagates
+ * immediately — no restart required:
+ *  - "lightweight" → returns a cached LocalForge instance for `dir`
+ *  - "forge" (or absent) → returns the memoized detectForge result for `dir`
+ *
+ * Two separate caches keep the invariants clean:
+ *  - `localForgeCache`: reuse the LocalForge instance across calls while the
+ *    repo stays in lightweight mode. If the mode flips to "forge", the local
+ *    entry is simply skipped; if it flips back, the same instance is reused.
+ *  - `forgeCache`: the existing detectForge memoization (git shell-out is
+ *    expensive — once per path is enough for forge repos).
+ */
+export function makeForgeResolver(deps: ForgeResolverDeps): (dir: string) => GitForge | null {
+  const localForgeCache = new Map<string, LocalForge>();
+  const forgeCache = new Map<string, GitForge | null>();
+
+  return (dir: string): GitForge | null => {
+    const { repoMode } = deps.getRepoConfig(dir);
+
+    if (repoMode === "lightweight") {
+      let local = localForgeCache.get(dir);
+      if (!local) {
+        local = deps.makeLocalForge(dir);
+        localForgeCache.set(dir, local);
+      }
+      return local;
+    }
+
+    // forge mode — memoized detectForge
+    if (!forgeCache.has(dir)) {
+      forgeCache.set(dir, deps.detectForge(dir));
+    }
+    return forgeCache.get(dir) ?? null;
+  };
+}
+
+/**
+ * Wire `makeForgeResolver` for production use (index.ts).
+ * Returns the same `(dir) => GitForge | null` shape the rest of the app expects.
+ */
+export function makeProductionForgeResolver(
+  store: ForgeResolverStore,
+  forges: ForgeMap,
+): (dir: string) => GitForge | null {
+  return makeForgeResolver({
+    getRepoConfig: (dir) => store.getRepoConfig(dir),
+    detectForge: (dir) => detectForge(dir, forges),
+    makeLocalForge: (dir) =>
+      new LocalForge(dir, {
+        ensureLocalPr: store.ensureLocalPr.bind(store),
+        getLocalPr: store.getLocalPr.bind(store),
+        getLocalPrByNumber: store.getLocalPrByNumber.bind(store),
+        markLocalPrMerged: store.markLocalPrMerged.bind(store),
+      }),
+  });
+}

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -21,7 +21,7 @@ export interface Issue {
   createdAt: number;
 }
 
-export type ForgeKind = "github" | "gitea";
+export type ForgeKind = "github" | "gitea" | "local";
 export type MergeMethod = "merge" | "squash" | "rebase";
 
 /** Invisible marker appended to every critic-posted review body so the review

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { reconcile } from "./reconcile";
 import { reapOrphanTabs, reapStaleReviewWorktrees } from "./tab-reaper";
 import { scanClaudeAliveByWorktree } from "./process-reaper";
 import { serve, serveAgentIngress, buildBacklogPayload, type AppDeps } from "./server";
-import { detectForge } from "./forge";
+import { makeProductionForgeResolver } from "./forge/resolve";
 import { AccountUsageIndex } from "./usage";
 import { UsageLimitsService, calibrateDelay, type UsageLimits } from "./usage-limits";
 import { HerdrUsageProbe } from "./usage-probe";
@@ -329,20 +329,10 @@ setTimeout(sweepOrphanTabs, 5_000);
 setTimeout(sweepOrphanTabs, 45_000);
 setInterval(sweepOrphanTabs, 60 * 60 * 1000);
 
-// Memoize forge resolution: detectForge shells out to a synchronous
-// `git remote get-url` per repo. forge↔repo is effectively immutable, so resolve
-// once per dir and share the result across the pollers, the critic, and the
-// per-request /api/backlog path — which otherwise re-shells git for every repo
-// on every hit, blocking the event loop even when the counts cache is fully warm.
-const forgeResolutionCache = new Map<string, ReturnType<typeof detectForge>>();
-const resolveForge = (dir: string): ReturnType<typeof detectForge> => {
-  let forge = forgeResolutionCache.get(dir);
-  if (forge === undefined) {
-    forge = detectForge(dir, config.forges);
-    forgeResolutionCache.set(dir, forge);
-  }
-  return forge;
-};
+// Mode-aware forge resolution: lightweight repos get a LocalForge; forge repos
+// get the memoized detectForge result (git shell-out). repoMode is read per call
+// (cheap PK lookup) so a runtime toggle takes effect without a restart.
+const resolveForge = makeProductionForgeResolver(store, config.forges);
 
 const tailscaleServe = new TailscaleServeService({
   base: config.previewPortBase,
@@ -1180,7 +1170,9 @@ const ghRunnerAsync = async (args: string[]): Promise<string> => {
   const { stdout } = await execFileAsync("gh", args, { maxBuffer: 16 * 1024 * 1024 });
   return stdout.toString();
 };
-const backlog = new CountsService(config.forges, ghRunnerAsync);
+const backlog = new CountsService(config.forges, ghRunnerAsync, fetch, undefined, (dir) =>
+  store.getRepoConfig(dir),
+);
 
 // gentle "star us on GitHub?" nudge — surfaces once the operator has used Shepherd
 // for a few days, stars erwins-enkel/shepherd through their existing gh auth. The

--- a/src/index.ts
+++ b/src/index.ts
@@ -1181,7 +1181,12 @@ setInterval(checkHerdrUpdate, 6 * 60 * 60 * 1000);
 // a TTL cache and push the snapshot to clients. Like the herdr-update check, a
 // delayed boot kick + a 6h background re-check keep the UI's health pip live with
 // no client polling — the request path otherwise reads the TTL snapshot.
-const diagnostics = new DiagnosticsService();
+const diagnostics = new DiagnosticsService({
+  anyForgeRepo: () =>
+    listRepos(config.repoRoot).some((r) => store.getRepoConfig(r.path).repoMode === "forge"),
+  anyLightweightRepo: () =>
+    listRepos(config.repoRoot).some((r) => store.getRepoConfig(r.path).repoMode === "lightweight"),
+});
 const checkDiagnostics = async () =>
   events.emit("diagnostics:status", await diagnostics.check(Date.now()));
 setTimeout(checkDiagnostics, 4_000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ import { reapOrphanTabs, reapStaleReviewWorktrees } from "./tab-reaper";
 import { scanClaudeAliveByWorktree } from "./process-reaper";
 import { serve, serveAgentIngress, buildBacklogPayload, type AppDeps } from "./server";
 import { makeProductionForgeResolver } from "./forge/resolve";
+import { EmptyDiffError, type GitState } from "./forge/types";
+import { annotateHandoff } from "./repo-roles";
 import { AccountUsageIndex } from "./usage";
 import { UsageLimitsService, calibrateDelay, type UsageLimits } from "./usage-limits";
 import { HerdrUsageProbe } from "./usage-probe";
@@ -795,6 +797,31 @@ const autopilot = new AutopilotService({
   hasPr: (id) => {
     const st = prPoller.snapshot()[id]?.state;
     return st !== undefined && st !== "none";
+  },
+  // Lightweight completion barrier (#807): mirror forgeOpenPr server-side (no Request) so an
+  // agent with no `gh` still registers its pseudo-PR. Self-guarding: an EmptyDiff is a clean
+  // "nothing to open" no-op and any other failure is logged, never rejected — so the awaiting
+  // autopilot tick can't crash (house rule: no unguarded await on a fallible async).
+  openLocalPr: async (id) => {
+    try {
+      const s = store.get(id);
+      if (!s || !s.branch) return;
+      const forge = resolveForge(s.repoPath);
+      if (!forge || forge.kind !== "local") return; // defensive: only the local forge has no host
+      const status = await forge.openPr({
+        head: s.branch,
+        base: s.baseBranch,
+        title: s.name,
+        body: s.prompt,
+      });
+      const me = (await forge.currentUser?.()) ?? null;
+      const git: GitState = annotateHandoff({ kind: forge.kind, ...status }, s.repoPath, me);
+      prPoller.set(s.id, git);
+      events.emit("session:git", { id: s.id, git });
+    } catch (err) {
+      if (err instanceof EmptyDiffError) return; // nothing to open — clean no-op
+      console.warn("[autopilot] openLocalPr:", err);
+    }
   },
   prGit: (id) => prPoller.snapshot()[id] ?? null,
   fullAuto: (id) => {

--- a/src/promote.ts
+++ b/src/promote.ts
@@ -58,6 +58,14 @@ export class Promoter {
 
       const forge = this.deps.resolveForge(repoPath);
       if (!forge) return { ok: false, error: "no forge configured for repo", status: 400 };
+      // Local-commit promotion is a deferred follow-up (#807 out-of-scope v1).
+      if (forge.kind === "local") {
+        return {
+          ok: false,
+          error: "learnings promotion is not available in lightweight repo mode",
+          status: 400,
+        };
+      }
 
       let base: string;
       try {
@@ -140,6 +148,14 @@ export class Promoter {
     }
     const forge = this.deps.resolveForge(learning.repoPath);
     if (!forge) return { ok: false, error: "no forge configured for repo", status: 400 };
+    // Local-commit promotion is a deferred follow-up (#807 out-of-scope v1).
+    if (forge.kind === "local") {
+      return {
+        ok: false,
+        error: "learnings promotion is not available in lightweight repo mode",
+        status: 400,
+      };
+    }
 
     let base: string;
     try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -528,6 +528,15 @@ function parseSignoffAuthority(v: unknown): "human" | "critic" | "either" | { er
   return v as "human" | "critic" | "either";
 }
 
+// repoMode: "forge" | "lightweight"
+const REPO_MODE_VALUES = ["forge", "lightweight"] as const;
+function parseRepoMode(v: unknown): "forge" | "lightweight" | { error: string } {
+  if (!REPO_MODE_VALUES.includes(v as (typeof REPO_MODE_VALUES)[number])) {
+    return { error: `repoMode must be one of: ${REPO_MODE_VALUES.join(", ")}` };
+  }
+  return v as "forge" | "lightweight";
+}
+
 // sandboxProfile: one of the three valid profile values
 function parseSandboxProfile(v: unknown): SandboxProfile | { error: string } {
   if (!isSandboxProfile(v)) {
@@ -576,6 +585,7 @@ type RepoCfgBody = {
   maxAuto?: unknown;
   autoLabel?: unknown;
   usageCeilingPct?: unknown;
+  repoMode?: unknown;
 };
 
 // true when any present boolean field is not actually a boolean
@@ -594,6 +604,7 @@ type RepoCfgScalars = {
   sandboxProfile?: SandboxProfile;
   defaultModel?: string;
   egressExtraHosts?: string[];
+  repoMode?: "forge" | "lightweight";
 };
 
 /** Adapt validateEgressExtraHosts (a Field result) to the scalar-parser contract:
@@ -613,6 +624,7 @@ const REPO_CFG_SCALAR_PARSERS: readonly [keyof RepoCfgScalars, (v: unknown) => u
   ["sandboxProfile", parseSandboxProfile],
   ["defaultModel", parseRepoDefaultModel],
   ["egressExtraHosts", parseRepoEgressExtraHosts],
+  ["repoMode", parseRepoMode],
 ];
 
 /** Validate the non-boolean (scalar/enum) repo-config fields, or the 400 Response to
@@ -648,6 +660,7 @@ async function parseRepoConfigPatch(req: Request): Promise<
       maxAuto?: number;
       autoLabel?: string;
       usageCeilingPct?: number;
+      repoMode?: "forge" | "lightweight";
     }
   | Response
 > {
@@ -671,6 +684,7 @@ async function parseRepoConfigPatch(req: Request): Promise<
     sandboxProfile,
     defaultModel,
     egressExtraHosts,
+    repoMode,
   } = scalars;
   const present =
     REPO_CFG_BOOL_FIELDS.some((k) => body[k] !== undefined) ||
@@ -680,12 +694,13 @@ async function parseRepoConfigPatch(req: Request): Promise<
     signoffAuthority !== undefined ||
     sandboxProfile !== undefined ||
     defaultModel !== undefined ||
-    egressExtraHosts !== undefined;
+    egressExtraHosts !== undefined ||
+    repoMode !== undefined;
   if (!present) {
     return json(
       {
         error:
-          "body must set at least one of: criticEnabled, autoAddressEnabled, learningsEnabled, autopilotEnabled, autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, signoffAuthority, sandboxProfile, defaultModel, egressExtraHosts, maxAuto, autoLabel, usageCeilingPct",
+          "body must set at least one of: criticEnabled, autoAddressEnabled, learningsEnabled, autopilotEnabled, autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, signoffAuthority, sandboxProfile, defaultModel, egressExtraHosts, maxAuto, autoLabel, usageCeilingPct, repoMode",
       },
       400,
     );
@@ -708,6 +723,7 @@ async function parseRepoConfigPatch(req: Request): Promise<
     maxAuto,
     autoLabel,
     usageCeilingPct,
+    repoMode,
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,8 +74,9 @@ import type {
 } from "./types";
 import type { HerdrDriver } from "./herdr";
 import { matchAgent } from "./herdr";
-import type { GitForge, GitState, MergeMethod, WorkflowRun } from "./forge/types";
-import { DEPENDABOT_REBASE_COMMAND } from "./forge/types";
+import type { GitForge, GitState, MergeMethod, PrStatus, WorkflowRun } from "./forge/types";
+import { DEPENDABOT_REBASE_COMMAND, EmptyDiffError } from "./forge/types";
+import { settleMergedSession } from "./merge-teardown";
 import { type PrCache, guardStaleTerminal, trustsTerminal } from "./pr-poller";
 import {
   readRepoRoles,
@@ -1981,13 +1982,20 @@ async function forgeOpenPr(
   const head = session.branch ?? "";
   const body = (await req.json().catch(() => ({}))) as { title?: string; body?: string };
   const cfg = deps.store.getRepoConfig(session.repoPath);
-  const status = await forge.openPr({
-    head,
-    base: session.baseBranch,
-    title: body.title?.trim() || session.name,
-    body: body.body ?? session.prompt,
-    draft: cfg.draftMode,
-  });
+  let status: PrStatus;
+  try {
+    status = await forge.openPr({
+      head,
+      base: session.baseBranch,
+      title: body.title?.trim() || session.name,
+      body: body.body ?? session.prompt,
+      draft: cfg.draftMode,
+    });
+  } catch (err) {
+    // Nothing to open a PR for (no net diff vs base) → a clean 409, not a 500.
+    if (err instanceof EmptyDiffError) return json({ error: "no commits to merge" }, 409);
+    throw err;
+  }
   const me = (await forge.currentUser?.()) ?? null;
   const git: GitState = annotateHandoff({ kind: forge.kind, ...status }, session.repoPath, me);
   deps.prCache?.set(session.id, git);
@@ -2014,6 +2022,20 @@ async function forgeMerge(
     method: body.method ?? forge.mergeMethod,
     deleteBranch: body.deleteBranch ?? true,
   });
+  // Lightweight (local) merge happened in-tree — nobody else tears the session down (no host
+  // poller path, no merge train), so the worktree/branch would leak. Settle it here, mirroring
+  // AutoMergeService.doMerge's callbacks. Forge sessions keep the current behavior: a human
+  // merges on the host and the poller-driven archive path handles teardown.
+  if (forge.kind === "local") {
+    await settleMergedSession(session, {
+      resolveForge: (repoPath) => deps.resolveForge?.(repoPath) ?? null,
+      archive: (id) => deps.service.archive(id),
+      dropPrCache: (id) => deps.prCache?.drop(id),
+      emitArchived: (id) => deps.events.emit("session:archived", { id }),
+      retainClaim: (id) => deps.drain?.retainClaim(id),
+    });
+    return json({ ...cur, state: "merged" as const });
+  }
   const status = await forge.prStatus(head);
   const me = (await forge.currentUser?.()) ?? null;
   const git: GitState = annotateHandoff({ kind: forge.kind, ...status }, session.repoPath, me);

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,6 +76,7 @@ import type { HerdrDriver } from "./herdr";
 import { matchAgent } from "./herdr";
 import type { GitForge, GitState, MergeMethod, PrStatus, WorkflowRun } from "./forge/types";
 import { DEPENDABOT_REBASE_COMMAND, EmptyDiffError } from "./forge/types";
+import { BaseCheckoutBusyError, MergeConflictError } from "./forge/local";
 import { settleMergedSession } from "./merge-teardown";
 import { type PrCache, guardStaleTerminal, trustsTerminal } from "./pr-poller";
 import {
@@ -2018,10 +2019,21 @@ async function forgeMerge(
   if (cur.state !== "open" || !cur.number) {
     return json({ error: "no open PR to merge" }, 409);
   }
-  await forge.merge(cur.number, {
-    method: body.method ?? forge.mergeMethod,
-    deleteBranch: body.deleteBranch ?? true,
-  });
+  try {
+    await forge.merge(cur.number, {
+      method: body.method ?? forge.mergeMethod,
+      deleteBranch: body.deleteBranch ?? true,
+    });
+  } catch (err) {
+    if (err instanceof MergeConflictError)
+      return json({ error: "merge conflict — resolve manually before merging" }, 409);
+    if (err instanceof BaseCheckoutBusyError)
+      return json(
+        { error: "base branch checkout has uncommitted changes or moved — commit/stash and retry" },
+        409,
+      );
+    throw err;
+  }
   // Lightweight (local) merge happened in-tree — nobody else tears the session down (no host
   // poller path, no merge train), so the worktree/branch would leak. Settle it here, mirroring
   // AutoMergeService.doMerge's callbacks. Forge sessions keep the current behavior: a human

--- a/src/store.ts
+++ b/src/store.ts
@@ -87,6 +87,18 @@ export interface RepoConfig {
   defaultModel: string;
   /** Per-repo extra allowlisted hosts appended to the autonomous egress allowlist. */
   egressExtraHosts: string[];
+  /** Repo mode: 'forge' (GitHub-backed, default) or 'lightweight' (local-only, no GitHub). */
+  repoMode: "forge" | "lightweight";
+}
+
+export interface LocalPr {
+  number: number;
+  repoPath: string;
+  branch: string;
+  base: string;
+  state: "open" | "merged";
+  createdAt: number;
+  mergedAt: number | null;
 }
 
 export interface PushSubInput {
@@ -190,6 +202,7 @@ type RepoCfgRow = {
   sandboxProfile: string;
   defaultModel: string;
   egressExtraHosts: string | null;
+  repoMode: string;
 };
 
 /** Tolerantly parse the persisted mergeTrainPrs JSON back to number[] | null (never throws). */
@@ -242,6 +255,7 @@ function repoConfigFromRow(r: RepoCfgRow | null): RepoConfig {
       sandboxProfile: "trusted",
       defaultModel: "inherit",
       egressExtraHosts: [],
+      repoMode: "forge",
     };
   }
   return {
@@ -262,6 +276,29 @@ function repoConfigFromRow(r: RepoCfgRow | null): RepoConfig {
     sandboxProfile: isSandboxProfile(r.sandboxProfile) ? r.sandboxProfile : "trusted",
     defaultModel: normalizeRepoDefaultModelSetting(r.defaultModel) ?? "inherit",
     egressExtraHosts: parseEgressExtraHostsJson(r.egressExtraHosts),
+    repoMode: r?.repoMode === "lightweight" ? "lightweight" : "forge",
+  };
+}
+
+type LocalPrRow = {
+  number: number;
+  repoPath: string;
+  branch: string;
+  base: string;
+  state: string;
+  createdAt: number;
+  mergedAt: number | null;
+};
+
+function localPrFromRow(r: LocalPrRow): LocalPr {
+  return {
+    number: r.number,
+    repoPath: r.repoPath,
+    branch: r.branch,
+    base: r.base,
+    state: r.state === "merged" ? "merged" : "open",
+    createdAt: r.createdAt,
+    mergedAt: r.mergedAt ?? null,
   };
 }
 
@@ -309,8 +346,19 @@ export class SessionStore implements CapStore, CreditStore {
       maxAuto INTEGER NOT NULL DEFAULT 1,
       autoLabel TEXT NOT NULL DEFAULT 'shepherd:auto',
       usageCeilingPct INTEGER NOT NULL DEFAULT 80,
+      repoMode TEXT NOT NULL DEFAULT 'forge',
       updatedAt INTEGER NOT NULL)`);
     this.migrateRepoConfigColumns();
+    this.db.run(`CREATE TABLE IF NOT EXISTS local_prs (
+      number    INTEGER PRIMARY KEY AUTOINCREMENT,
+      repoPath  TEXT NOT NULL,
+      branch    TEXT NOT NULL,
+      base      TEXT NOT NULL,
+      state     TEXT NOT NULL DEFAULT 'open',
+      createdAt INTEGER NOT NULL,
+      mergedAt  INTEGER,
+      UNIQUE(repoPath, branch)
+    )`);
     this.db.run(`CREATE TABLE IF NOT EXISTS reviews (
       sessionId TEXT PRIMARY KEY, headSha TEXT NOT NULL, patchId TEXT NOT NULL DEFAULT '',
       decision TEXT NOT NULL,
@@ -516,7 +564,7 @@ export class SessionStore implements CapStore, CreditStore {
       .query(
         `SELECT criticEnabled, criticAllPrs, autoAddressEnabled, learningsEnabled, autopilotEnabled, planGateEnabled,
                 autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, signoffAuthority,
-                maxAuto, autoLabel, usageCeilingPct, sandboxProfile, defaultModel, egressExtraHosts
+                maxAuto, autoLabel, usageCeilingPct, sandboxProfile, defaultModel, egressExtraHosts, repoMode
          FROM repo_config WHERE repoPath = ?`,
       )
       .get(repoPath) as RepoCfgRow | null;
@@ -528,8 +576,8 @@ export class SessionStore implements CapStore, CreditStore {
       `INSERT INTO repo_config
          (repoPath, criticEnabled, criticAllPrs, autoAddressEnabled, learningsEnabled, autopilotEnabled, planGateEnabled,
           autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, signoffAuthority,
-          maxAuto, autoLabel, usageCeilingPct, sandboxProfile, defaultModel, egressExtraHosts, updatedAt)
-         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+          maxAuto, autoLabel, usageCeilingPct, sandboxProfile, defaultModel, egressExtraHosts, repoMode, updatedAt)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(repoPath) DO UPDATE SET criticEnabled = excluded.criticEnabled,
          criticAllPrs = excluded.criticAllPrs,
          autoAddressEnabled = excluded.autoAddressEnabled,
@@ -547,6 +595,7 @@ export class SessionStore implements CapStore, CreditStore {
          sandboxProfile = excluded.sandboxProfile,
          defaultModel = excluded.defaultModel,
          egressExtraHosts = excluded.egressExtraHosts,
+         repoMode = excluded.repoMode,
          updatedAt = excluded.updatedAt`,
       [
         repoPath,
@@ -567,9 +616,50 @@ export class SessionStore implements CapStore, CreditStore {
         cfg.sandboxProfile,
         cfg.defaultModel,
         JSON.stringify(cfg.egressExtraHosts ?? []),
+        cfg.repoMode,
         Date.now(),
       ],
     );
+  }
+
+  // ── local_prs (lightweight-mode pseudo-PRs) ──────────────────────────────
+
+  ensureLocalPr(repoPath: string, branch: string, base: string): LocalPr {
+    const existing = this.getLocalPr(repoPath, branch);
+    if (existing) return existing;
+    this.db.run(
+      `INSERT INTO local_prs (repoPath, branch, base, state, createdAt, mergedAt)
+       VALUES (?, ?, ?, 'open', ?, NULL)`,
+      [repoPath, branch, base, Date.now()],
+    );
+    return this.getLocalPr(repoPath, branch)!;
+  }
+
+  getLocalPr(repoPath: string, branch: string): LocalPr | null {
+    const r = this.db
+      .query(
+        `SELECT number, repoPath, branch, base, state, createdAt, mergedAt
+         FROM local_prs WHERE repoPath = ? AND branch = ?`,
+      )
+      .get(repoPath, branch) as LocalPrRow | null;
+    return r ? localPrFromRow(r) : null;
+  }
+
+  getLocalPrByNumber(number: number): LocalPr | null {
+    const r = this.db
+      .query(
+        `SELECT number, repoPath, branch, base, state, createdAt, mergedAt
+         FROM local_prs WHERE number = ?`,
+      )
+      .get(number) as LocalPrRow | null;
+    return r ? localPrFromRow(r) : null;
+  }
+
+  markLocalPrMerged(number: number): void {
+    this.db.run(`UPDATE local_prs SET state = 'merged', mergedAt = ? WHERE number = ?`, [
+      Date.now(),
+      number,
+    ]);
   }
 
   // ── web push subscriptions ────────────────────────────────────────────────
@@ -1926,6 +2016,8 @@ export class SessionStore implements CapStore, CreditStore {
     add("defaultModel", `defaultModel TEXT NOT NULL DEFAULT 'inherit'`);
     // per-repo egress extra-hosts: JSON-encoded string array (nullable, default []).
     add("egressExtraHosts", `egressExtraHosts TEXT`);
+    // per-repo mode: 'forge' (GitHub-backed, default) or 'lightweight' (local-only).
+    add("repoMode", `repoMode TEXT NOT NULL DEFAULT 'forge'`);
   }
 
   private migrateEpicIntegratedColumns(): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -276,7 +276,7 @@ function repoConfigFromRow(r: RepoCfgRow | null): RepoConfig {
     sandboxProfile: isSandboxProfile(r.sandboxProfile) ? r.sandboxProfile : "trusted",
     defaultModel: normalizeRepoDefaultModelSetting(r.defaultModel) ?? "inherit",
     egressExtraHosts: parseEgressExtraHostsJson(r.egressExtraHosts),
-    repoMode: r?.repoMode === "lightweight" ? "lightweight" : "forge",
+    repoMode: r.repoMode === "lightweight" ? "lightweight" : "forge",
   };
 }
 

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -71,6 +71,7 @@ function harness(opts: {
   verdict?: AutopilotVerdict;
   repoEnabled?: boolean;
   repoDraftMode?: boolean;
+  repoMode?: "forge" | "lightweight";
   openPr?: boolean;
   paneAlive?: boolean;
   resumeOk?: boolean;
@@ -94,6 +95,7 @@ function harness(opts: {
           learningsEnabled: true,
           autopilotEnabled: opts.repoEnabled ?? false,
           draftMode: opts.repoDraftMode ?? false,
+          repoMode: opts.repoMode ?? "forge",
         }) as any,
       setAutopilotState: (
         _id: string,
@@ -142,6 +144,9 @@ function harness(opts: {
     paneAlive: () => opts.paneAlive ?? true,
     readTail: () => ["finished, nothing else"],
     hasPr: () => opts.openPr ?? false,
+    openLocalPr: async (id) => {
+      events.push({ openLocalPr: id });
+    },
     prGit: () => opts.prGit ?? null,
     fullAuto: () => opts.fullAuto ?? false,
     refreshPr: (id) => events.push({ refreshPr: id }),
@@ -172,6 +177,30 @@ test("finished verdict → open-PR steer", async () => {
   await h.svc.onBlock("s1", block(["I'm done."]));
   expect(h.events).toContainEqual({ steer: OPEN_PR_STEER_MAIN });
   expect(h.state().autopilotStepCount).toBe(1);
+});
+
+test("finished verdict in lightweight repo → openLocalPr, no gh-pr-create steer", async () => {
+  const h = harness({
+    session: sess(),
+    verdict: { kind: "finished", summary: "done, no PR" },
+    repoMode: "lightweight",
+  });
+  await h.svc.onBlock("s1", block(["I'm done."]));
+  expect(h.events).toContainEqual({ openLocalPr: "s1" });
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  // no PTY steer landed → step count unchanged (server-side barrier, not a steer)
+  expect(h.state().autopilotStepCount).toBe(0);
+});
+
+test("finished verdict in forge repo → openPrSteer, never openLocalPr", async () => {
+  const h = harness({
+    session: sess(),
+    verdict: { kind: "finished", summary: "done, no PR" },
+    repoMode: "forge",
+  });
+  await h.svc.onBlock("s1", block(["I'm done."]));
+  expect(h.events).toContainEqual({ steer: OPEN_PR_STEER_MAIN });
+  expect(h.events.some((e) => "openLocalPr" in e)).toBe(false);
 });
 
 test("openPrSteer carries an explicit --base for the session's base branch", () => {
@@ -519,6 +548,7 @@ test("re-entrant onBlock during an in-flight classify spawns + steers only once"
     paneAlive: () => true,
     readTail: () => [],
     hasPr: () => false,
+    openLocalPr: async () => {},
     prGit: () => null,
     fullAuto: () => false,
     onPause: () => {},

--- a/test/backlog-poller.test.ts
+++ b/test/backlog-poller.test.ts
@@ -40,7 +40,11 @@ test("a rejecting warm does not sink the tick or sibling repos", async () => {
   expect(warmed.sort()).toEqual(["/bad", "/good"]);
 });
 
-test("resolves forge once per path, even across ticks (no per-tick git I/O)", async () => {
+test("resolveForge is called per tick so repoMode flips propagate", async () => {
+  // resolveForge is called per isForgeBacked call — BacklogPoller no longer
+  // permanently caches the verdict so a repoMode toggle takes effect immediately.
+  // The git shell-out avoidance is now the responsibility of makeForgeResolver
+  // (which memoizes detectForge for forge repos internally).
   const resolveCalls: string[] = [];
   const poller = new BacklogPoller(
     () => [{ path: "/a" }, { path: "/no-forge" }],
@@ -53,10 +57,10 @@ test("resolves forge once per path, even across ticks (no per-tick git I/O)", as
 
   await poller.tick();
   await poller.tick();
-  await poller.tick();
 
-  // each path resolved exactly once despite three ticks
-  expect(resolveCalls.sort()).toEqual(["/a", "/no-forge"]);
+  // resolveForge is called every tick (twice per path across 2 ticks)
+  expect(resolveCalls.filter((p) => p === "/a").length).toBe(2);
+  expect(resolveCalls.filter((p) => p === "/no-forge").length).toBe(2);
 });
 
 test("empty repo list is a no-op", async () => {
@@ -119,4 +123,59 @@ test("start/stop manage the interval timer without throwing", () => {
   poller.start();
   poller.stop();
   expect(true).toBe(true);
+});
+
+// ── mode-aware forge-backed tests ─────────────────────────────────────────────
+
+test("local forge (kind=local) is NOT forge-backed — not warmed", async () => {
+  const warmed: string[] = [];
+  const poller = new BacklogPoller(
+    () => [{ path: "/local-repo" }, { path: "/github-repo" }],
+    (p) => (p === "/local-repo" ? { kind: "local" } : { kind: "github", slug: "o/r" }),
+    async (p) => {
+      warmed.push(p);
+      return { openIssues: 1, openPRs: 0, ciStatus: null, prKinds: null };
+    },
+  );
+
+  await poller.tick();
+
+  // local-repo must NOT be warmed; only the github-repo should be
+  expect(warmed).toEqual(["/github-repo"]);
+});
+
+test("github forge (kind=github) is forge-backed", async () => {
+  const warmed: string[] = [];
+  const poller = new BacklogPoller(
+    () => [{ path: "/gh" }],
+    () => ({ kind: "github", slug: "o/r" }),
+    async (p) => {
+      warmed.push(p);
+      return { openIssues: 0, openPRs: 0, ciStatus: null, prKinds: null };
+    },
+  );
+
+  await poller.tick();
+  expect(warmed).toEqual(["/gh"]);
+});
+
+test("repoMode flip propagates: local→github → repo starts being warmed", async () => {
+  let forgeKind: "local" | "github" = "local";
+  const warmed: string[] = [];
+
+  const poller = new BacklogPoller(
+    () => [{ path: "/flip" }],
+    () => ({ kind: forgeKind }),
+    async (p) => {
+      warmed.push(p);
+      return { openIssues: 0, openPRs: 0, ciStatus: null, prKinds: null };
+    },
+  );
+
+  await poller.tick(); // kind=local → not warmed
+  expect(warmed).toEqual([]);
+
+  forgeKind = "github"; // flip
+  await poller.tick(); // kind=github → warmed
+  expect(warmed).toEqual(["/flip"]);
 });

--- a/test/backlog.test.ts
+++ b/test/backlog.test.ts
@@ -500,3 +500,56 @@ test("CountsService: Gitea repo → prKinds null", async () => {
   const svc = new CountsService(forges, async () => "", fn);
   expect((await svc.counts(repoDir)).prKinds).toBeNull();
 });
+
+// 18. lightweight mode: even a GitHub-origin repo returns null counts when repoMode=lightweight
+test("CountsService: lightweight repo → null counts regardless of origin", async () => {
+  // GitHub origin — would normally trigger a gh graphql fetch
+  const repoDir = gitInit(join(tmpBase, "lw-repo"), "https://github.com/o/lw");
+  const forges: ForgeMap = {};
+
+  let runnerCalled = false;
+  const run: GhRunner = async () => {
+    runnerCalled = true;
+    return JSON.stringify({
+      data: { repository: { issues: { totalCount: 99 }, pullRequests: { totalCount: 5 } } },
+    });
+  };
+
+  const svc = new CountsService(forges, run, fetch, undefined, () => ({ repoMode: "lightweight" }));
+
+  const result = await svc.counts(repoDir);
+  expect(result.openIssues).toBeNull();
+  expect(result.openPRs).toBeNull();
+  expect(runnerCalled).toBe(false); // runner must never be invoked
+});
+
+// 19. lightweight toggle: flipping repoMode propagates without restart
+test("CountsService: repoMode toggle propagates — flip lightweight→forge triggers fetch", async () => {
+  const repoDir = gitInit(join(tmpBase, "lw-toggle"), "https://github.com/o/toggle");
+  const forges: ForgeMap = {};
+
+  let repoMode: "forge" | "lightweight" = "lightweight";
+  let runnerCalled = 0;
+  const run: GhRunner = async () => {
+    runnerCalled++;
+    return JSON.stringify({
+      data: { repository: { issues: { totalCount: 7 }, pullRequests: { totalCount: 2 } } },
+    });
+  };
+
+  const svc = new CountsService(forges, run, fetch, undefined, () => ({ repoMode }));
+
+  // lightweight → null, no runner invocation
+  const r1 = await svc.counts(repoDir);
+  expect(r1.openIssues).toBeNull();
+  expect(runnerCalled).toBe(0);
+
+  // flip to forge — expire the cache entry so the next call re-fetches
+  repoMode = "forge";
+  const entry = (svc as any).cache.get(repoDir);
+  if (entry) entry.at = 0; // force TTL expiry
+
+  const r2 = await svc.counts(repoDir);
+  expect(r2.openIssues).toBe(7);
+  expect(runnerCalled).toBe(1);
+});

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -287,6 +287,140 @@ describe("DiagnosticsService probes", () => {
   });
 });
 
+// ── gh probe: repo-mode-aware downgrade ──────────────────────────────────────
+describe("DiagnosticsService gh probe repo-mode awareness", () => {
+  it("gh failure + anyForgeRepo=false → warning + not_required hint", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runGhAuth: async () => {
+        throw new Error("not authenticated");
+      },
+      anyForgeRepo: () => false,
+    });
+    const c = byId((await svc.check(0)).checks, "gh");
+    expect(c.state).toBe("warning");
+    expect(c.hintKey).toBe("diagnostics_hint_gh_not_required");
+    assertPure(c);
+  });
+
+  it("gh ENOENT + anyForgeRepo=false → warning + not_required hint", async () => {
+    const enoent = Object.assign(new Error("gh not found"), { code: "ENOENT" });
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runGhAuth: async () => {
+        throw enoent;
+      },
+      anyForgeRepo: () => false,
+    });
+    const c = byId((await svc.check(0)).checks, "gh");
+    expect(c.state).toBe("warning");
+    expect(c.hintKey).toBe("diagnostics_hint_gh_not_required");
+    assertPure(c);
+  });
+
+  it("gh ENOENT + anyForgeRepo=true → error + gh_missing hint (unchanged)", async () => {
+    const enoent = Object.assign(new Error("gh not found"), { code: "ENOENT" });
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runGhAuth: async () => {
+        throw enoent;
+      },
+      anyForgeRepo: () => true,
+    });
+    const c = byId((await svc.check(0)).checks, "gh");
+    expect(c.state).toBe("error");
+    expect(c.hintKey).toBe("diagnostics_hint_gh_missing");
+    assertPure(c);
+  });
+
+  it("gh auth failure + anyForgeRepo=true → error (unchanged behavior)", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runGhAuth: async () => {
+        throw new Error("not logged in");
+      },
+      anyForgeRepo: () => true,
+    });
+    const c = byId((await svc.check(0)).checks, "gh");
+    expect(c.state).toBe("error");
+    expect(c.hintKey).toBe("diagnostics_hint_gh_not_authenticated");
+    assertPure(c);
+  });
+});
+
+// ── git_mergetree capability check ───────────────────────────────────────────
+describe("DiagnosticsService git_mergetree capability check", () => {
+  it("git_mergetree absent when no lightweight repos (default)", async () => {
+    const svc = new DiagnosticsService(healthyDeps());
+    const snap = await svc.check(0);
+    expect(snap.checks.find((c) => c.id === "git_mergetree")).toBeUndefined();
+  });
+
+  it("git_mergetree absent when anyLightweightRepo=false", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      anyLightweightRepo: () => false,
+    });
+    const snap = await svc.check(0);
+    expect(snap.checks.find((c) => c.id === "git_mergetree")).toBeUndefined();
+  });
+
+  it("git_mergetree ok for git 2.40.0 with lightweight repo", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runVersion: versionRunner({ ...HEALTHY_VERSIONS, git: "git version 2.40.0" }),
+      anyLightweightRepo: () => true,
+    });
+    const c = byId((await svc.check(0)).checks, "git_mergetree");
+    expect(c.state).toBe("ok");
+    expect(c.hintKey).toBe("diagnostics_hint_gitcap_ok");
+    assertPure(c);
+  });
+
+  it("git_mergetree warning for git 2.37.0 with lightweight repo", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runVersion: versionRunner({ ...HEALTHY_VERSIONS, git: "git version 2.37.0" }),
+      anyLightweightRepo: () => true,
+    });
+    const c = byId((await svc.check(0)).checks, "git_mergetree");
+    expect(c.state).toBe("warning");
+    expect(c.hintKey).toBe("diagnostics_hint_gitcap_old");
+    assertPure(c);
+  });
+
+  it("git_mergetree ok at exactly git 2.38 (boundary)", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runVersion: versionRunner({ ...HEALTHY_VERSIONS, git: "git version 2.38.0" }),
+      anyLightweightRepo: () => true,
+    });
+    const c = byId((await svc.check(0)).checks, "git_mergetree");
+    expect(c.state).toBe("ok");
+    expect(c.hintKey).toBe("diagnostics_hint_gitcap_ok");
+  });
+
+  it("git_mergetree check appears in overall snapshot with lightweight repos", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runVersion: versionRunner({ ...HEALTHY_VERSIONS, git: "git version 2.40.0" }),
+      anyLightweightRepo: () => true,
+    });
+    const snap = await svc.check(0);
+    expect(snap.checks).toHaveLength(8);
+    expect(snap.checks.map((c) => c.id).sort()).toEqual([
+      "bun",
+      "claude",
+      "gh",
+      "git",
+      "git_mergetree",
+      "herdr",
+      "node",
+      "tailscale",
+    ]);
+  });
+});
+
 describe("DiagnosticsService timeout discipline", () => {
   it("a never-resolving probe still settles the batch to its non-OK fallback", async () => {
     // herdr's runVersion hangs forever — simulate by rejecting after the wrapper

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -303,6 +303,7 @@ test("consider does nothing when learnings disabled for the repo", () => {
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   const { deps, started } = mkDeps(store, { rules: [] });
   const d = new DistillerService(deps as any);
@@ -339,6 +340,7 @@ test("distiller increments ineffective for cited active rule ids with validated 
         sandboxProfile: "trusted",
         defaultModel: "inherit",
         egressExtraHosts: [],
+        repoMode: "forge",
       }),
       incrementLearningIneffective: (id: string, signals: string[]) => {
         bumped.push({ id, signals });

--- a/test/drain-epic-completed.test.ts
+++ b/test/drain-epic-completed.test.ts
@@ -100,6 +100,7 @@ function makeHarness(opts: HarnessOpts): Harness {
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   store.setEpicRun({
     repoPath: REPO,

--- a/test/drain-epic-divergence.test.ts
+++ b/test/drain-epic-divergence.test.ts
@@ -82,6 +82,7 @@ function makeHarness(branchesRef: BranchesRef, clock: { t: number }) {
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   store.setEpicRun({ repoPath: REPO, parentIssueNumber: PARENT, mode: "auto", status: "running" });
   // Pin the canonical name up front so divergence is measured against PINNED.

--- a/test/drain-epic-landing.test.ts
+++ b/test/drain-epic-landing.test.ts
@@ -131,6 +131,7 @@ function makeHarness(opts: {
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   if (!opts.noEpicRun) {
     store.setEpicRun({

--- a/test/drain-epic-pin-branch.test.ts
+++ b/test/drain-epic-pin-branch.test.ts
@@ -81,6 +81,7 @@ function makeHarness(parentTitleRef: { title: string }, subIssues: SubIssueRef[]
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   store.setEpicRun({ repoPath: REPO, parentIssueNumber: PARENT, mode: "auto", status: "running" });
 

--- a/test/drain-epic-retire-base.test.ts
+++ b/test/drain-epic-retire-base.test.ts
@@ -119,6 +119,7 @@ function makeHarness(
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   store.setEpicRun({
     repoPath: REPO,

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -100,6 +100,7 @@ function makeHarness(
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   if (opts.epicStatus) {
     store.setEpicRun({

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -126,6 +126,7 @@ function makeHarness(
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
 
   const forgeRec: ForgeRec = { listIssuesCalls: 0, added: [], ensured: [] };

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -173,6 +173,7 @@ function makeHarness(
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
 
   const forgeRec: ForgeRec = {
@@ -733,6 +734,7 @@ test("tick + snapshot over repos: only drain-enabled repo is acted on and report
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   store.setRepoConfig(REPO2, {
     criticEnabled: true,
@@ -752,6 +754,7 @@ test("tick + snapshot over repos: only drain-enabled repo is acted on and report
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
 
   const forgeRec: ForgeRec = {
@@ -1406,6 +1409,7 @@ test("#790: spawn-failure cooldown: failed issue is skipped until window expires
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
 
   const candidateIssue = issue(42);

--- a/test/forge-resolve.test.ts
+++ b/test/forge-resolve.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the makeForgeResolver helper (src/forge/resolve.ts).
+ *
+ * All deps are stubs — no git I/O, no real store.
+ */
+import { test, expect } from "bun:test";
+import { makeForgeResolver } from "../src/forge/resolve";
+import type { LocalForge } from "../src/forge/local";
+import type { GitForge } from "../src/forge/types";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function stubLocalForge(dir: string): LocalForge {
+  return { kind: "local", repoPath: dir } as unknown as LocalForge;
+}
+
+function stubGithubForge(): GitForge {
+  return { kind: "github", slug: "org/repo" } as unknown as GitForge;
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+test("lightweight dir → LocalForge (kind=local)", () => {
+  const resolver = makeForgeResolver({
+    getRepoConfig: () => ({ repoMode: "lightweight" }),
+    detectForge: () => null,
+    makeLocalForge: stubLocalForge,
+  });
+
+  const forge = resolver("/repo/a");
+  expect(forge?.kind).toBe("local");
+});
+
+test("forge dir → detectForge result (kind=github)", () => {
+  const ghForge = stubGithubForge();
+  const resolver = makeForgeResolver({
+    getRepoConfig: () => ({ repoMode: "forge" }),
+    detectForge: () => ghForge,
+    makeLocalForge: stubLocalForge,
+  });
+
+  const forge = resolver("/repo/b");
+  expect(forge?.kind).toBe("github");
+  expect(forge).toBe(ghForge); // same reference
+});
+
+test("forge dir with no remote → null", () => {
+  const resolver = makeForgeResolver({
+    getRepoConfig: () => ({ repoMode: "forge" }),
+    detectForge: () => null,
+    makeLocalForge: stubLocalForge,
+  });
+
+  const forge = resolver("/repo/no-remote");
+  expect(forge).toBeNull();
+});
+
+test("lightweight dir reuses the same LocalForge instance across calls", () => {
+  let makeCount = 0;
+  const resolver = makeForgeResolver({
+    getRepoConfig: () => ({ repoMode: "lightweight" }),
+    detectForge: () => null,
+    makeLocalForge: (dir) => {
+      makeCount++;
+      return stubLocalForge(dir);
+    },
+  });
+
+  const f1 = resolver("/repo/c");
+  const f2 = resolver("/repo/c");
+  expect(f1).toBe(f2);
+  expect(makeCount).toBe(1);
+});
+
+test("forge dir memoizes detectForge (only one call per dir)", () => {
+  let detectCount = 0;
+  const ghForge = stubGithubForge();
+  const resolver = makeForgeResolver({
+    getRepoConfig: () => ({ repoMode: "forge" }),
+    detectForge: () => {
+      detectCount++;
+      return ghForge;
+    },
+    makeLocalForge: stubLocalForge,
+  });
+
+  resolver("/repo/d");
+  resolver("/repo/d");
+  resolver("/repo/d");
+  expect(detectCount).toBe(1);
+});
+
+test("toggle: flipping repoMode lightweight→forge propagates immediately", () => {
+  let mode: "forge" | "lightweight" = "lightweight";
+  const ghForge = stubGithubForge();
+  const resolver = makeForgeResolver({
+    getRepoConfig: () => ({ repoMode: mode }),
+    detectForge: () => ghForge,
+    makeLocalForge: stubLocalForge,
+  });
+
+  // starts lightweight → LocalForge
+  expect(resolver("/repo/e")?.kind).toBe("local");
+
+  // flip to forge → now returns the detectForge result
+  mode = "forge";
+  expect(resolver("/repo/e")?.kind).toBe("github");
+});
+
+test("toggle: flipping repoMode forge→lightweight propagates immediately", () => {
+  let mode: "forge" | "lightweight" = "forge";
+  const ghForge = stubGithubForge();
+  const resolver = makeForgeResolver({
+    getRepoConfig: () => ({ repoMode: mode }),
+    detectForge: () => ghForge,
+    makeLocalForge: stubLocalForge,
+  });
+
+  // starts forge → GitHub
+  expect(resolver("/repo/f")?.kind).toBe("github");
+
+  // flip to lightweight → now returns LocalForge
+  mode = "lightweight";
+  expect(resolver("/repo/f")?.kind).toBe("local");
+});
+
+test("two dirs are independent", () => {
+  const resolver = makeForgeResolver({
+    getRepoConfig: (dir) => ({
+      repoMode: dir === "/repo/lightweight" ? "lightweight" : "forge",
+    }),
+    detectForge: () => stubGithubForge(),
+    makeLocalForge: stubLocalForge,
+  });
+
+  expect(resolver("/repo/lightweight")?.kind).toBe("local");
+  expect(resolver("/repo/forge")?.kind).toBe("github");
+});

--- a/test/local-forge.test.ts
+++ b/test/local-forge.test.ts
@@ -1,0 +1,337 @@
+// test/local-forge.test.ts — LocalForge against REAL git in temp repos.
+import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { SessionStore } from "../src/store";
+import {
+  LocalForge,
+  squashMergeLocal,
+  parseGitVersion,
+  gitVersionAtLeast,
+  BaseCheckoutBusyError,
+  MergeConflictError,
+} from "../src/forge/local";
+
+const ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+const git = (repo: string, ...args: string[]) =>
+  execFileSync("git", args, { cwd: repo, env: ENV, stdio: "pipe" }).toString().trim();
+
+/** A repo on `main` with one commit (file a=1). */
+function mkRepo(): string {
+  const repo = mkdtempSync(join(tmpdir(), "shepherd-lf-"));
+  git(repo, "init", "-q", "-b", "main");
+  writeFileSync(join(repo, "a.txt"), "1\n");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-q", "-m", "init");
+  return repo;
+}
+
+/** Cut `branch` off main and add `n` commits each touching its own file. */
+function featureBranch(repo: string, branch: string, n = 2): void {
+  git(repo, "checkout", "-q", "-b", branch);
+  for (let i = 0; i < n; i++) {
+    writeFileSync(join(repo, `f${i}.txt`), `feature ${i}\n`);
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", `feat ${i}`);
+  }
+}
+
+function revParse(repo: string, ref: string): string {
+  return git(repo, "rev-parse", ref);
+}
+
+function isAncestor(repo: string, a: string, b: string): boolean {
+  try {
+    execFileSync("git", ["merge-base", "--is-ancestor", a, b], {
+      cwd: repo,
+      env: ENV,
+      stdio: "pipe",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── version helper ──────────────────────────────────────────────────────────
+
+test("parseGitVersion parses major/minor from `git version` strings", () => {
+  expect(parseGitVersion("git version 2.54.0")).toEqual({ major: 2, minor: 54 });
+  expect(parseGitVersion("git version 2.38.1.windows.1")).toEqual({ major: 2, minor: 38 });
+  expect(parseGitVersion("git version 2.37.0")).toEqual({ major: 2, minor: 37 });
+  expect(parseGitVersion("garbage")).toBeNull();
+});
+
+test("gitVersionAtLeast: 2.37 rejected, 2.38 and 2.54 accepted", () => {
+  expect(gitVersionAtLeast({ major: 2, minor: 37 }, 2, 38)).toBe(false);
+  expect(gitVersionAtLeast({ major: 2, minor: 38 }, 2, 38)).toBe(true);
+  expect(gitVersionAtLeast({ major: 2, minor: 54 }, 2, 38)).toBe(true);
+  expect(gitVersionAtLeast({ major: 3, minor: 0 }, 2, 38)).toBe(true);
+  expect(gitVersionAtLeast({ major: 1, minor: 99 }, 2, 38)).toBe(false);
+});
+
+// ── prStatus / openPr ───────────────────────────────────────────────────────
+
+test("prStatus for an unknown branch → state:none", async () => {
+  const repo = mkRepo();
+  try {
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+    const st = await forge.prStatus("feature/nope");
+    expect(st.state).toBe("none");
+    expect(st.checks).toBe("none");
+    expect(st.deployConfigured).toBe(false);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("openPr then prStatus → open, positive number, mergeable:true, headSha=tip", async () => {
+  const repo = mkRepo();
+  try {
+    featureBranch(repo, "feature/x");
+    git(repo, "checkout", "-q", "main");
+    const tip = revParse(repo, "feature/x");
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+
+    const opened = await forge.openPr({ head: "feature/x", base: "main", title: "t", body: "b" });
+    expect(opened.state).toBe("open");
+    expect(opened.number).toBeGreaterThan(0);
+    expect(opened.checks).toBe("success");
+    expect(opened.mergeable).toBe(true);
+    expect(opened.headSha).toBe(tip);
+
+    const st = await forge.prStatus("feature/x");
+    expect(st.state).toBe("open");
+    expect(st.number).toBe(opened.number);
+    expect(st.mergeable).toBe(true);
+    expect(st.headSha).toBe(tip);
+    expect(st.createdAt).toBeGreaterThan(0);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("defaultBranch returns the primary checkout branch", async () => {
+  const repo = mkRepo();
+  try {
+    const forge = new LocalForge(repo, new SessionStore(":memory:"));
+    expect(await forge.defaultBranch()).toBe("main");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── squash merge: base NOT checked out ──────────────────────────────────────
+
+test("squash merge with base detached (not checked out) advances base by one squash commit", async () => {
+  const repo = mkRepo();
+  try {
+    const baseTip = revParse(repo, "main");
+    featureBranch(repo, "feature/y", 3);
+    const branchCommits = git(repo, "rev-list", "main..feature/y").split("\n").filter(Boolean);
+    // detach primary checkout so main is checked out nowhere
+    git(repo, "checkout", "-q", "--detach");
+
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+    const pr = await forge.openPr({ head: "feature/y", base: "main", title: "t", body: "b" });
+    await forge.merge(pr.number!);
+
+    const newMain = revParse(repo, "refs/heads/main");
+    // exactly one new commit, parent = old base tip
+    expect(revParse(repo, "refs/heads/main^")).toBe(baseTip);
+    expect(newMain).not.toBe(baseTip);
+    // tree equals the feature tree (full merge result)
+    expect(revParse(repo, "refs/heads/main^{tree}")).toBe(revParse(repo, "feature/y^{tree}"));
+    // squash: the feature's individual commits are NOT in base history
+    for (const c of branchCommits) {
+      expect(isAncestor(repo, c, "refs/heads/main")).toBe(false);
+    }
+    // row merged
+    expect(store.getLocalPrByNumber(pr.number!)!.state).toBe("merged");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── squash merge: base CHECKED OUT clean (headline) ─────────────────────────
+
+test("squash merge with base checked out clean advances HEAD without dirtying the tree", async () => {
+  const repo = mkRepo();
+  try {
+    const baseTip = revParse(repo, "main");
+    featureBranch(repo, "feature/z", 2);
+    git(repo, "checkout", "-q", "main"); // base IS checked out in the primary worktree
+
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+    const pr = await forge.openPr({ head: "feature/z", base: "main", title: "t", body: "b" });
+    await forge.merge(pr.number!);
+
+    // HEAD advanced to the squash commit
+    expect(revParse(repo, "HEAD^")).toBe(baseTip);
+    expect(revParse(repo, "HEAD")).toBe(revParse(repo, "refs/heads/main"));
+    // working tree still clean (no desync)
+    const status = git(repo, "status", "--porcelain");
+    expect(status).toBe("");
+    expect(store.getLocalPrByNumber(pr.number!)!.state).toBe("merged");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── squash merge: base checked out DIRTY → abort, nothing moves ─────────────
+
+test("squash merge with base checked out dirty throws BaseCheckoutBusyError and moves no ref", async () => {
+  const repo = mkRepo();
+  try {
+    const baseTip = revParse(repo, "main");
+    featureBranch(repo, "feature/d", 1);
+    git(repo, "checkout", "-q", "main");
+    writeFileSync(join(repo, "a.txt"), "dirty\n"); // uncommitted change in the base worktree
+
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+    const pr = await forge.openPr({ head: "feature/d", base: "main", title: "t", body: "b" });
+
+    let threw: unknown;
+    try {
+      await forge.merge(pr.number!);
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toBeInstanceOf(BaseCheckoutBusyError);
+    // no ref moved
+    expect(revParse(repo, "refs/heads/main")).toBe(baseTip);
+    // row still open
+    expect(store.getLocalPrByNumber(pr.number!)!.state).toBe("open");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── merge conflict → throw, nothing moves ───────────────────────────────────
+
+test("squash merge with a real conflict throws MergeConflictError and moves no ref", async () => {
+  const repo = mkRepo();
+  try {
+    // base edits a.txt
+    git(repo, "checkout", "-q", "main");
+    writeFileSync(join(repo, "a.txt"), "base-line\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "base edit");
+    const baseTip = revParse(repo, "main");
+    // branch off the ORIGINAL commit and edit the same line differently
+    git(repo, "checkout", "-q", "-b", "feature/c", "main~1");
+    writeFileSync(join(repo, "a.txt"), "branch-line\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "branch edit");
+    git(repo, "checkout", "-q", "--detach");
+
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+    const pr = await forge.openPr({ head: "feature/c", base: "main", title: "t", body: "b" });
+
+    let threw: unknown;
+    try {
+      await forge.merge(pr.number!);
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toBeInstanceOf(MergeConflictError);
+    expect(revParse(repo, "refs/heads/main")).toBe(baseTip);
+    expect(store.getLocalPrByNumber(pr.number!)!.state).toBe("open");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── branch prune hook: branch becomes ancestor of base ──────────────────────
+
+test("after merge the feature branch ref points at the squash commit (ancestor of base)", async () => {
+  const repo = mkRepo();
+  try {
+    featureBranch(repo, "feature/p", 2);
+    git(repo, "checkout", "-q", "--detach");
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+    const pr = await forge.openPr({ head: "feature/p", base: "main", title: "t", body: "b" });
+    await forge.merge(pr.number!);
+
+    // branch still exists (we passed deleteBranch:false / forge ignores it) and is now
+    // the squash commit == an ancestor of base, so pruneMergedBranch will delete it.
+    expect(revParse(repo, "refs/heads/feature/p")).toBe(revParse(repo, "refs/heads/main"));
+    expect(isAncestor(repo, "refs/heads/feature/p", "refs/heads/main")).toBe(true);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── direct squashMergeLocal export ──────────────────────────────────────────
+
+test("squashMergeLocal is exported and merges directly (base detached)", async () => {
+  const repo = mkRepo();
+  try {
+    const baseTip = revParse(repo, "main");
+    featureBranch(repo, "feature/direct", 1);
+    git(repo, "checkout", "-q", "--detach");
+    await squashMergeLocal(repo, "feature/direct", "main");
+    expect(revParse(repo, "refs/heads/main^")).toBe(baseTip);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── merge of an unknown number throws ───────────────────────────────────────
+
+test("merge of an unknown PR number throws a clear error", async () => {
+  const repo = mkRepo();
+  try {
+    const forge = new LocalForge(repo, new SessionStore(":memory:"));
+    let threw: unknown;
+    try {
+      await forge.merge(424242);
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toBeInstanceOf(Error);
+    expect((threw as Error).message).toContain("424242");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── capability guard ────────────────────────────────────────────────────────
+
+test("squashMergeLocal surfaces a clear error when git is too old (injected probe)", async () => {
+  const repo = mkRepo();
+  try {
+    featureBranch(repo, "feature/old", 1);
+    git(repo, "checkout", "-q", "--detach");
+    const baseTip = revParse(repo, "main");
+    let threw: unknown;
+    try {
+      // inject a fake version probe simulating git 2.37
+      await squashMergeLocal(repo, "feature/old", "main", async () => "git version 2.37.0");
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toBeInstanceOf(Error);
+    expect((threw as Error).message).toContain("2.38");
+    expect((threw as Error).message).toContain("2.37.0");
+    // nothing moved
+    expect(revParse(repo, "refs/heads/main")).toBe(baseTip);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/test/local-forge.test.ts
+++ b/test/local-forge.test.ts
@@ -8,6 +8,7 @@ import { SessionStore } from "../src/store";
 import {
   LocalForge,
   squashMergeLocal,
+  mergeTreeWriteTree,
   parseGitVersion,
   gitVersionAtLeast,
   BaseCheckoutBusyError,
@@ -296,6 +297,55 @@ test("squash merge with a real conflict throws MergeConflictError and moves no r
     expect(store.getLocalPrByNumber(pr.number!)!.state).toBe("open");
   } finally {
     rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── merge-tree exit-code decoding: clean / conflict / genuine error ─────────
+
+test("mergeTreeWriteTree returns a tree on a clean merge, conflict flag on a conflict", async () => {
+  const repo = mkRepo();
+  try {
+    featureBranch(repo, "feature/clean", 1);
+    git(repo, "checkout", "-q", "--detach");
+    const clean = await mergeTreeWriteTree(repo, "main", "feature/clean");
+    expect(clean.conflict).toBe(false);
+    expect(clean.tree).toMatch(/^[0-9a-f]{40}$/);
+
+    // a real conflict (exit 1) → conflict flag, no throw
+    git(repo, "checkout", "-q", "main");
+    writeFileSync(join(repo, "a.txt"), "base-line\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "base edit");
+    git(repo, "checkout", "-q", "-b", "feature/cf", "main~1");
+    writeFileSync(join(repo, "a.txt"), "branch-line\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "branch edit");
+    git(repo, "checkout", "-q", "--detach");
+    const conflict = await mergeTreeWriteTree(repo, "main", "feature/cf");
+    expect(conflict.conflict).toBe(true);
+    expect(conflict.tree).toBeUndefined();
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("mergeTreeWriteTree throws (NOT a conflict) on a genuine git error — exit >1", async () => {
+  // A non-git directory makes `git merge-tree` exit 128 (fatal: not a git repository).
+  // git reserves exit 1 for a real conflict and >1 for genuine failures — the >1 case
+  // must surface as a plain Error, never be decoded as a MergeConflictError (a 409).
+  const nongit = mkdtempSync(join(tmpdir(), "shepherd-lf-nongit-"));
+  try {
+    let threw: unknown;
+    try {
+      await mergeTreeWriteTree(nongit, "main", "x");
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toBeInstanceOf(Error);
+    expect(threw).not.toBeInstanceOf(MergeConflictError);
+    expect(String((threw as Error).message)).toContain("merge-tree");
+  } finally {
+    rmSync(nongit, { recursive: true, force: true });
   }
 });
 

--- a/test/local-forge.test.ts
+++ b/test/local-forge.test.ts
@@ -13,6 +13,7 @@ import {
   BaseCheckoutBusyError,
   MergeConflictError,
 } from "../src/forge/local";
+import { EmptyDiffError } from "../src/forge/types";
 
 const ENV = {
   ...process.env,
@@ -116,6 +117,48 @@ test("openPr then prStatus → open, positive number, mergeable:true, headSha=ti
     expect(st.mergeable).toBe(true);
     expect(st.headSha).toBe(tip);
     expect(st.createdAt).toBeGreaterThan(0);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("openPr throws EmptyDiffError when the branch has no commits ahead of base", async () => {
+  const repo = mkRepo();
+  try {
+    // a branch off main with NO further commits → nothing to open a PR for
+    git(repo, "checkout", "-q", "-b", "feature/empty");
+    git(repo, "checkout", "-q", "main");
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+    let threw: unknown;
+    try {
+      await forge.openPr({ head: "feature/empty", base: "main", title: "t", body: "b" });
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toBeInstanceOf(EmptyDiffError);
+    // no pseudo-PR row registered
+    expect(store.getLocalPr(repo, "feature/empty")).toBeNull();
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("openPr succeeds for a branch with commits ahead of base", async () => {
+  const repo = mkRepo();
+  try {
+    featureBranch(repo, "feature/has-commits", 1);
+    git(repo, "checkout", "-q", "main");
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+    const opened = await forge.openPr({
+      head: "feature/has-commits",
+      base: "main",
+      title: "t",
+      body: "b",
+    });
+    expect(opened.state).toBe("open");
+    expect(opened.number).toBeGreaterThan(0);
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }

--- a/test/local-prs.test.ts
+++ b/test/local-prs.test.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { SessionStore } from "../src/store";
+
+// ── Part A: repoMode column ────────────────────────────────────────────────
+
+test("repoMode defaults to 'forge' for a repo with no repo_config row", () => {
+  const store = new SessionStore(":memory:");
+  expect(store.getRepoConfig("/repo/new").repoMode).toBe("forge");
+});
+
+test("repoMode round-trips 'lightweight' through setRepoConfig/getRepoConfig", () => {
+  const store = new SessionStore(":memory:");
+  const cfg = store.getRepoConfig("/repo/lw");
+  store.setRepoConfig("/repo/lw", { ...cfg, repoMode: "lightweight" });
+  expect(store.getRepoConfig("/repo/lw").repoMode).toBe("lightweight");
+});
+
+test("repoMode round-trips 'forge' after updating from lightweight", () => {
+  const store = new SessionStore(":memory:");
+  const cfg = store.getRepoConfig("/repo/fg");
+  store.setRepoConfig("/repo/fg", { ...cfg, repoMode: "lightweight" });
+  store.setRepoConfig("/repo/fg", { ...cfg, repoMode: "forge" });
+  expect(store.getRepoConfig("/repo/fg").repoMode).toBe("forge");
+});
+
+test("migration: store opened on pre-existing DB without repoMode column yields forge default", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-lpr-test-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    // Build the old-schema DB at the file path (no repoMode column)
+    const oldDb = new Database(dbPath);
+    oldDb.run(`CREATE TABLE IF NOT EXISTS repo_config (
+      repoPath TEXT PRIMARY KEY, criticEnabled INTEGER NOT NULL DEFAULT 1,
+      criticAllPrs INTEGER NOT NULL DEFAULT 0,
+      learningsEnabled INTEGER NOT NULL DEFAULT 1,
+      autoDrainEnabled INTEGER NOT NULL DEFAULT 0,
+      autoMergeEnabled INTEGER NOT NULL DEFAULT 0,
+      maxAuto INTEGER NOT NULL DEFAULT 1,
+      autoLabel TEXT NOT NULL DEFAULT 'shepherd:auto',
+      usageCeilingPct INTEGER NOT NULL DEFAULT 80,
+      updatedAt INTEGER NOT NULL
+    )`);
+    oldDb.run(
+      `INSERT INTO repo_config (repoPath, criticEnabled, criticAllPrs, learningsEnabled,
+        autoDrainEnabled, autoMergeEnabled, maxAuto, autoLabel, usageCeilingPct, updatedAt)
+       VALUES ('/repo/old', 1, 0, 1, 0, 0, 1, 'shepherd:auto', 80, ${Date.now()})`,
+    );
+    oldDb.close();
+
+    // Open via SessionStore (triggers migrations)
+    const store = new SessionStore(dbPath);
+    expect(store.getRepoConfig("/repo/old").repoMode).toBe("forge");
+
+    // Opening a second time (re-running migration) must not throw
+    const store2 = new SessionStore(dbPath);
+    expect(store2.getRepoConfig("/repo/old").repoMode).toBe("forge");
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});
+
+// ── Part B: local_prs table ────────────────────────────────────────────────
+
+test("ensureLocalPr creates a row with a positive number and open state", () => {
+  const store = new SessionStore(":memory:");
+  const pr = store.ensureLocalPr("/repo/x", "feature/abc", "main");
+  expect(pr.number).toBeGreaterThan(0);
+  expect(pr.repoPath).toBe("/repo/x");
+  expect(pr.branch).toBe("feature/abc");
+  expect(pr.base).toBe("main");
+  expect(pr.state).toBe("open");
+  expect(pr.createdAt).toBeGreaterThan(0);
+  expect(pr.mergedAt).toBeNull();
+});
+
+test("ensureLocalPr is idempotent — same (repoPath, branch) returns same row", () => {
+  const store = new SessionStore(":memory:");
+  const first = store.ensureLocalPr("/repo/x", "feature/abc", "main");
+  const second = store.ensureLocalPr("/repo/x", "feature/abc", "main");
+  expect(second.number).toBe(first.number);
+  expect(second.createdAt).toBe(first.createdAt);
+  expect(second.state).toBe("open");
+});
+
+test("ensureLocalPr for two different branches returns distinct, increasing numbers", () => {
+  const store = new SessionStore(":memory:");
+  const a = store.ensureLocalPr("/repo/x", "feature/a", "main");
+  const b = store.ensureLocalPr("/repo/x", "feature/b", "main");
+  expect(b.number).toBeGreaterThan(a.number);
+});
+
+test("getLocalPr returns the row by (repoPath, branch); null for missing", () => {
+  const store = new SessionStore(":memory:");
+  const pr = store.ensureLocalPr("/repo/x", "feature/abc", "main");
+  const found = store.getLocalPr("/repo/x", "feature/abc");
+  expect(found).not.toBeNull();
+  expect(found!.number).toBe(pr.number);
+  expect(store.getLocalPr("/repo/x", "feature/nonexistent")).toBeNull();
+});
+
+test("getLocalPrByNumber returns the row; null for missing number", () => {
+  const store = new SessionStore(":memory:");
+  const pr = store.ensureLocalPr("/repo/x", "feature/abc", "main");
+  const found = store.getLocalPrByNumber(pr.number);
+  expect(found).not.toBeNull();
+  expect(found!.branch).toBe("feature/abc");
+  expect(store.getLocalPrByNumber(9999)).toBeNull();
+});
+
+test("markLocalPrMerged flips state to merged and sets mergedAt", () => {
+  const store = new SessionStore(":memory:");
+  const before = Date.now();
+  const pr = store.ensureLocalPr("/repo/x", "feature/abc", "main");
+  expect(pr.state).toBe("open");
+  expect(pr.mergedAt).toBeNull();
+  store.markLocalPrMerged(pr.number);
+  const after = store.getLocalPrByNumber(pr.number)!;
+  expect(after.state).toBe("merged");
+  expect(after.mergedAt).not.toBeNull();
+  expect(after.mergedAt!).toBeGreaterThanOrEqual(before);
+});

--- a/test/promote.test.ts
+++ b/test/promote.test.ts
@@ -372,3 +372,73 @@ test("Promoter.resyncPromoted rejects a concurrent call for the same repo with 4
   const firstRes = await first;
   expect(firstRes.ok).toBe(true);
 });
+
+// --- lightweight repo mode guard tests ---
+
+test("Promoter.promote returns 400 with lightweight message for local forge and never calls openPr", async () => {
+  const store = new SessionStore(":memory:");
+  const l = store.addLearning({ repoPath: "/r", rule: "x", rationale: "", evidence: [] });
+  store.setLearningStatus(l.id, "active");
+  let openPrCalled = false;
+  const localForge = fakeForge({
+    kind: "local",
+    openPr: async () => {
+      openPrCalled = true;
+      return { state: "open", number: 1, url: "u", checks: "none", deployConfigured: false };
+    },
+  });
+  const p = new Promoter({
+    store,
+    worktree: {
+      create: () => ({ worktreePath: "/x", branch: "b", isolated: true }),
+      remove: () => {},
+    },
+    resolveForge: () => localForge,
+    git: async () => {},
+  });
+  const res = await p.promote(l.id);
+  expect(res.ok).toBe(false);
+  if (!res.ok) {
+    expect(res.status).toBe(400);
+    expect(res.error).toBe("learnings promotion is not available in lightweight repo mode");
+  }
+  expect(openPrCalled).toBe(false);
+  // rule stays active (never wedged to promoted without a real PR)
+  expect(store.getLearning(l.id)!.status).toBe("active");
+});
+
+test("Promoter.resyncPromoted returns 400 with lightweight message for local forge and never calls openPr", async () => {
+  const store = new SessionStore(":memory:");
+  const l = store.addLearning({ repoPath: "/repo5", rule: "rule a", rationale: "", evidence: [] });
+  store.setLearningStatus(l.id, "active");
+  store.setLearningStatus(l.id, "promoted");
+  let openPrCalled = false;
+  const localForge = fakeForge({
+    kind: "local",
+    openPr: async () => {
+      openPrCalled = true;
+      return { state: "open", number: 2, url: "u", checks: "none", deployConfigured: false };
+    },
+  });
+  let worktreeCreated = false;
+  const p = new Promoter({
+    store,
+    worktree: {
+      create: () => {
+        worktreeCreated = true;
+        return { worktreePath: "/wt5", branch: "b", isolated: true };
+      },
+      remove: () => {},
+    },
+    resolveForge: () => localForge,
+    git: async () => {},
+  });
+  const res = await p.resyncPromoted("/repo5");
+  expect(res.ok).toBe(false);
+  if (!res.ok) {
+    expect(res.status).toBe(400);
+    expect(res.error).toBe("learnings promotion is not available in lightweight repo mode");
+  }
+  expect(openPrCalled).toBe(false);
+  expect(worktreeCreated).toBe(false);
+});

--- a/test/sandbox-wiring.test.ts
+++ b/test/sandbox-wiring.test.ts
@@ -584,6 +584,7 @@ function defaultRepoConfig() {
     sandboxProfile: "trusted" as const,
     defaultModel: "inherit",
     egressExtraHosts: [] as string[],
+    repoMode: "forge" as const,
   };
 }
 

--- a/test/server-reviews.test.ts
+++ b/test/server-reviews.test.ts
@@ -107,6 +107,7 @@ test("GET /api/repo-config defaults to critic on + auto-address off", async () =
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
 });
 
@@ -156,6 +157,7 @@ test("PUT /api/repo-config sets criticEnabled=false, GET reflects it", async () 
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
 
   const get = await app.fetch(new Request(url));
@@ -178,6 +180,7 @@ test("PUT /api/repo-config sets criticEnabled=false, GET reflects it", async () 
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
 });
 
@@ -210,6 +213,7 @@ test("PUT /api/repo-config toggles autoAddressEnabled independently of criticEna
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
 });
 
@@ -242,6 +246,7 @@ test("PUT /api/repo-config sets learningsEnabled independently of criticEnabled"
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
 });
 

--- a/test/server-reviews.test.ts
+++ b/test/server-reviews.test.ts
@@ -300,3 +300,36 @@ test("PUT /api/repo-config with repo outside root → 400", async () => {
   );
   expect(res.status).toBe(400);
 });
+
+// ── repoMode ──────────────────────────────────────────────────────────────────
+
+test("PUT /api/repo-config repoMode=lightweight persists, GET returns lightweight", async () => {
+  const { app } = harness();
+  const url = `http://x/api/repo-config?repo=${encodeURIComponent(repoDir)}`;
+  const put = await app.fetch(
+    new Request(url, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repoMode: "lightweight" }),
+    }),
+  );
+  expect(put.status).toBe(200);
+  expect(((await put.json()) as { repoMode: string }).repoMode).toBe("lightweight");
+
+  const get = await app.fetch(new Request(url));
+  expect(get.status).toBe(200);
+  expect(((await get.json()) as { repoMode: string }).repoMode).toBe("lightweight");
+});
+
+test("PUT /api/repo-config repoMode=bogus → 400", async () => {
+  const { app } = harness();
+  const url = `http://x/api/repo-config?repo=${encodeURIComponent(repoDir)}`;
+  const res = await app.fetch(
+    new Request(url, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repoMode: "bogus" }),
+    }),
+  );
+  expect(res.status).toBe(400);
+});

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1221,6 +1221,7 @@ test("GET /api/learnings/injectable marks all rules uninjected when learnings di
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
 
   const res = await app.fetch(new Request("http://x/api/learnings/injectable"));

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2215,6 +2215,7 @@ test("create omits house rules when learnings disabled for the repo", async () =
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   const captured: { argv?: string[] } = {};
   const svc = new SessionService(injectDeps(store, captured) as any);
@@ -2258,6 +2259,7 @@ test("create seeds the autopilot directive when the repo has autopilot on", asyn
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   const captured: { argv?: string[] } = {};
   const svc = new SessionService(injectDeps(store, captured) as any);
@@ -2953,6 +2955,7 @@ function buildQueueDeps(
       sandboxProfile: "trusted",
       defaultModel: "inherit",
       egressExtraHosts: [],
+      repoMode: "forge",
       ...repoConfig,
     });
   }
@@ -4128,6 +4131,7 @@ test("create research under autonomous: downgrades to standard (sandboxApplied=s
     sandboxProfile: "autonomous",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   const captured: { argv?: string[] } = {};
   const svc = new SessionService(sandboxResearchDeps(store, captured) as any);
@@ -4166,6 +4170,7 @@ test("create NON-research under autonomous: stays autonomous (no downgrade)", as
     sandboxProfile: "autonomous",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   const captured: { argv?: string[] } = {};
   const svc = new SessionService(sandboxResearchDeps(store, captured) as any);

--- a/test/store-autopilot.test.ts
+++ b/test/store-autopilot.test.ts
@@ -109,6 +109,7 @@ test("repo config autopilotEnabled defaults off and round-trips", () => {
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   expect(store.getRepoConfig("/repo").autopilotEnabled).toBe(true);
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -76,6 +76,7 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   store.setRepoConfig("/repo/a", {
     criticEnabled: false,
@@ -95,6 +96,7 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   expect(store.getRepoConfig("/repo/a")).toEqual({
     criticEnabled: false,
@@ -114,6 +116,7 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   store.setRepoConfig("/repo/a", {
     criticEnabled: true,
@@ -133,6 +136,7 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   expect(store.getRepoConfig("/repo/a")).toEqual({
     criticEnabled: true,
@@ -152,6 +156,7 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
 });
 
@@ -183,6 +188,7 @@ test("repo_config: drain fields default off/cap-1/default-label/ceiling-80, pers
     sandboxProfile: "trusted",
     defaultModel: "inherit",
     egressExtraHosts: [],
+    repoMode: "forge",
   });
   expect(store.getRepoConfig("/repo/d")).toMatchObject({
     autoDrainEnabled: true,

--- a/test/task5-completion-barrier.test.ts
+++ b/test/task5-completion-barrier.test.ts
@@ -9,7 +9,7 @@ import { execFileSync } from "node:child_process";
 import { makeApp } from "../src/server";
 import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
-import { LocalForge } from "../src/forge/local";
+import { LocalForge, MergeConflictError, BaseCheckoutBusyError } from "../src/forge/local";
 import { computeMerge, type MergeRepoState, type MergeSessionView } from "../src/automerge-core";
 
 const ENV = {
@@ -279,4 +279,108 @@ test("computeMerge → merge for a LocalForge-shaped ready view (proves auto-mer
     prNumber: 1,
     headSha: "h1",
   });
+});
+
+// ── forgeMerge: local merge errors → 409, session stays "open" ───────────────
+
+test("forgeMerge on a local session returns 409 (not 500) when MergeConflictError thrown, pr row stays open", async () => {
+  const { repo } = mkRepoWithBranch("feature/conflict", 1);
+  try {
+    const store = new SessionStore(":memory:");
+    // Stub LocalForge: openPr succeeds, merge throws MergeConflictError
+    const stubForge = {
+      kind: "local" as const,
+      mergeMethod: "squash" as const,
+      prStatus: async () => ({
+        state: "open" as const,
+        number: 1,
+        checks: "success" as const,
+        deployConfigured: false,
+      }),
+      merge: async () => {
+        throw new MergeConflictError("feature/conflict", "main");
+      },
+      openPr: async () => ({
+        state: "open" as const,
+        number: 1,
+        checks: "success" as const,
+        deployConfigured: false,
+      }),
+      currentUser: async () => null,
+    };
+    const app = makeApp({
+      store,
+      service: { archive: async () => 1 } as any,
+      events: new EventHub(),
+      usageLimits: { limits: () => ({}) } as any,
+      resolveForge: () => stubForge as any,
+      prCache: { snapshot: () => ({}), get: () => undefined, set: () => {}, drop: () => {} } as any,
+      drain: { retainClaim: () => {} } as any,
+    });
+    const s = mkSession(store, repo, "feature/conflict");
+
+    const res = await app.fetch(
+      new Request(`http://x/api/sessions/${s.id}/git/merge`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/merge conflict/);
+    // session must NOT have been archived (nothing partially settled)
+    expect(store.get(s.id)!.status).not.toBe("archived");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("forgeMerge on a local session returns 409 (not 500) when BaseCheckoutBusyError thrown, pr row stays open", async () => {
+  const { repo } = mkRepoWithBranch("feature/busy", 1);
+  try {
+    const store = new SessionStore(":memory:");
+    const stubForge = {
+      kind: "local" as const,
+      mergeMethod: "squash" as const,
+      prStatus: async () => ({
+        state: "open" as const,
+        number: 1,
+        checks: "success" as const,
+        deployConfigured: false,
+      }),
+      merge: async () => {
+        throw new BaseCheckoutBusyError("main");
+      },
+      openPr: async () => ({
+        state: "open" as const,
+        number: 1,
+        checks: "success" as const,
+        deployConfigured: false,
+      }),
+      currentUser: async () => null,
+    };
+    const app = makeApp({
+      store,
+      service: { archive: async () => 1 } as any,
+      events: new EventHub(),
+      usageLimits: { limits: () => ({}) } as any,
+      resolveForge: () => stubForge as any,
+      prCache: { snapshot: () => ({}), get: () => undefined, set: () => {}, drop: () => {} } as any,
+      drain: { retainClaim: () => {} } as any,
+    });
+    const s = mkSession(store, repo, "feature/busy");
+
+    const res = await app.fetch(
+      new Request(`http://x/api/sessions/${s.id}/git/merge`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/base branch checkout/);
+    expect(store.get(s.id)!.status).not.toBe("archived");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
 });

--- a/test/task5-completion-barrier.test.ts
+++ b/test/task5-completion-barrier.test.ts
@@ -1,0 +1,282 @@
+// test/task5-completion-barrier.test.ts — #807 lightweight completion barrier + local merge cleanup.
+// Real git temp repos + real SessionStore + real LocalForge, driven through the actual
+// makeApp HTTP routes (forgeMerge / forgeOpenPr) and the merge-train decision core.
+import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { makeApp } from "../src/server";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { LocalForge } from "../src/forge/local";
+import { computeMerge, type MergeRepoState, type MergeSessionView } from "../src/automerge-core";
+
+const ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+const git = (repo: string, ...args: string[]) =>
+  execFileSync("git", args, { cwd: repo, env: ENV, stdio: "pipe" }).toString().trim();
+
+/** A repo on `main` with one commit + a feature branch with `n` commits, base detached
+ *  (checked out nowhere) so squashMergeLocal takes the bare update-ref path. */
+function mkRepoWithBranch(branch: string, n = 2): { repo: string; baseTip: string } {
+  const repo = mkdtempSync(join(tmpdir(), "shepherd-t5-"));
+  git(repo, "init", "-q", "-b", "main");
+  writeFileSync(join(repo, "a.txt"), "1\n");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-q", "-m", "init");
+  const baseTip = git(repo, "rev-parse", "main");
+  git(repo, "checkout", "-q", "-b", branch);
+  for (let i = 0; i < n; i++) {
+    writeFileSync(join(repo, `f${i}.txt`), `feature ${i}\n`);
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", `feat ${i}`);
+  }
+  git(repo, "checkout", "-q", "--detach"); // base checked out nowhere
+  return { repo, baseTip };
+}
+
+/** Build an app over a real store + a single resolved forge, tracking settle side effects. */
+function appOver(
+  store: SessionStore,
+  forge: any,
+): {
+  app: ReturnType<typeof makeApp>;
+  archived: string[];
+  dropped: string[];
+} {
+  const archived: string[] = [];
+  const dropped: string[] = [];
+  const app = makeApp({
+    store,
+    service: { archive: async (id: string) => (archived.push(id), 1) } as any,
+    events: new EventHub(),
+    usageLimits: { limits: () => ({}) } as any,
+    resolveForge: () => forge,
+    prCache: {
+      snapshot: () => ({}),
+      get: () => undefined,
+      set: () => {},
+      drop: (id: string) => dropped.push(id),
+    } as any,
+    drain: { retainClaim: () => {} } as any,
+  });
+  return { app, archived, dropped };
+}
+
+function mkSession(store: SessionStore, repo: string, branch: string) {
+  return store.create({
+    name: "feat",
+    prompt: "p",
+    repoPath: repo,
+    baseBranch: "main",
+    branch,
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: false,
+    issueNumber: null,
+  });
+}
+
+// ── forgeMerge: lightweight (local) merge tears the session down ─────────────
+
+test("forgeMerge on a local session merges then settles (archive + drop pr cache)", async () => {
+  const { repo, baseTip } = mkRepoWithBranch("feature/local", 2);
+  try {
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+    const { app, archived, dropped } = appOver(store, forge);
+
+    const s = mkSession(store, repo, "feature/local");
+    await forge.openPr({ head: "feature/local", base: "main", title: "t", body: "b" });
+
+    const res = await app.fetch(
+      new Request(`http://x/api/sessions/${s.id}/git/merge`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { state: string };
+    expect(body.state).toBe("merged");
+
+    // base ref advanced by the squash commit
+    expect(git(repo, "rev-parse", "refs/heads/main^")).toBe(baseTip);
+    expect(git(repo, "rev-parse", "refs/heads/main")).not.toBe(baseTip);
+    // session settled: archived + pr cache dropped
+    expect(archived).toEqual([s.id]);
+    expect(dropped).toEqual([s.id]);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── forgeMerge: a forge (github-shaped) session must NOT settle ──────────────
+
+test("forgeMerge on a non-local (forge) session does NOT settle", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "shepherd-t5-forge-"));
+  try {
+    const store = new SessionStore(":memory:");
+    const archived: string[] = [];
+    const dropped: string[] = [];
+    let merged = false;
+    const fakeForge = {
+      kind: "github" as const,
+      mergeMethod: "squash" as const,
+      prStatus: async () => ({
+        state: merged ? "merged" : "open",
+        number: 5,
+        checks: "success" as const,
+        deployConfigured: false,
+      }),
+      merge: async () => {
+        merged = true;
+      },
+      currentUser: async () => null,
+    };
+    const app = makeApp({
+      store,
+      service: { archive: async (id: string) => (archived.push(id), 1) } as any,
+      events: new EventHub(),
+      usageLimits: { limits: () => ({}) } as any,
+      resolveForge: () => fakeForge as any,
+      prCache: {
+        snapshot: () => ({}),
+        get: () => undefined,
+        set: () => {},
+        drop: (id: string) => dropped.push(id),
+      } as any,
+      drain: { retainClaim: () => {} } as any,
+    });
+    const s = mkSession(store, repo, "feature/gh");
+    const res = await app.fetch(
+      new Request(`http://x/api/sessions/${s.id}/git/merge`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(res.status).toBe(200);
+    // forge path is unchanged: NO settle (no archive, no drop on this branch)
+    expect(archived).toEqual([]);
+    expect(dropped).toEqual([]);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── forgeOpenPr: empty diff → clean 409, not a 500 ──────────────────────────
+
+test("forgeOpenPr returns 409 when a local branch has no commits to merge", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "shepherd-t5-empty-"));
+  try {
+    git(repo, "init", "-q", "-b", "main");
+    writeFileSync(join(repo, "a.txt"), "1\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "init");
+    git(repo, "branch", "feature/empty"); // branch at main's tip, no commits ahead
+
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+    const app = makeApp({
+      store,
+      service: {} as any,
+      events: new EventHub(),
+      usageLimits: { limits: () => ({}) } as any,
+      resolveForge: () => forge,
+      prCache: { snapshot: () => ({}), get: () => undefined, set: () => {}, drop: () => {} } as any,
+    });
+    const s = mkSession(store, repo, "feature/empty");
+    const res = await app.fetch(
+      new Request(`http://x/api/sessions/${s.id}/git/pr`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { error: string }).toEqual({ error: "no commits to merge" });
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── headline integration: register pseudo-PR, merge, base advanced + settled ─
+
+test("headline: openPr then merge advances base AND archives the session", async () => {
+  const { repo, baseTip } = mkRepoWithBranch("feature/headline", 3);
+  try {
+    const store = new SessionStore(":memory:");
+    const forge = new LocalForge(repo, store);
+    const { app, archived, dropped } = appOver(store, forge);
+    const s = mkSession(store, repo, "feature/headline");
+
+    // register the pseudo-PR (the server-side completion barrier)
+    const opened = await forge.openPr({
+      head: "feature/headline",
+      base: "main",
+      title: "t",
+      body: "b",
+    });
+    expect(opened.state).toBe("open");
+
+    const res = await app.fetch(
+      new Request(`http://x/api/sessions/${s.id}/git/merge`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    // exactly one squash commit on base, the pr row is merged, session settled
+    expect(git(repo, "rev-parse", "refs/heads/main^")).toBe(baseTip);
+    expect(store.getLocalPrByNumber(opened.number!)!.state).toBe("merged");
+    expect(archived).toEqual([s.id]);
+    expect(dropped).toEqual([s.id]);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ── merge train fires for a LocalForge-shaped view (readyToMerge true) ───────
+
+test("computeMerge → merge for a LocalForge-shaped ready view (proves auto-merge fires locally)", () => {
+  // LocalForge.prStatus shape for an open PR: checks success, mergeable true, a number.
+  const view: MergeSessionView = {
+    id: "s1",
+    desig: "TASK-01",
+    state: "open",
+    checks: "success",
+    mergeable: true,
+    number: 1,
+    headSha: "h1",
+    behind: false,
+    reviewDecision: null,
+    reviewHeadSha: null,
+    isDraft: false,
+    humanApproved: false,
+    findings: [],
+    rebaseCount: 0,
+    rebaseSteeredHead: null,
+    mergeBlocked: false,
+  };
+  const state: MergeRepoState = {
+    enabled: true,
+    criticEnabled: false, // standalone critic self-disables in lightweight mode
+    draftMode: false,
+    signoffAuthority: "human",
+    rebaseCap: 5,
+    sessions: [view],
+  };
+  expect(computeMerge(state)).toEqual({
+    kind: "merge",
+    sessionId: "s1",
+    prNumber: 1,
+    headSha: "h1",
+  });
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1570,7 +1570,7 @@
   "gitrail_merged_locally": "lokal gemergt ✓",
   "gitrail_ready_to_merge": "bereit zum Mergen",
   "diagnostics_hint_gitcap_ok": "git unterstützt Lightweight-Merge (≥ 2.38).",
-  "diagnostics_hint_gitcap_old": "git < 2.38 erkannt — der Lightweight-Repo-Modus benötigt git merge-tree --write-tree (git ≥ 2.38). Aktualisiere git, um Lightweight-Repos zu nutzen.",
+  "diagnostics_hint_gitcap_old": "git ≥ 2.38 nicht verfügbar — der Lightweight-Repo-Modus benötigt git merge-tree --write-tree (git ≥ 2.38) für lokale Merges. git fehlt möglicherweise (siehe git-Prüfung) oder ist zu alt; installiere oder aktualisiere es, um Lightweight-Repos zu nutzen.",
   "diagnostics_hint_gh_not_required": "GitHub CLI ist nicht installiert oder nicht authentifiziert, es sind jedoch keine Forge-basierten Repos konfiguriert — gh ist optional, wenn ausschließlich Lightweight-Repos verwendet werden.",
   "diagnostics_label_git_mergetree": "git merge-tree"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1568,5 +1568,8 @@
   "gitrail_merge_locally": "Lokal mergen",
   "gitrail_confirm_merge_locally": "bestätigen ✓",
   "gitrail_merged_locally": "lokal gemergt ✓",
-  "gitrail_ready_to_merge": "bereit zum Mergen"
+  "gitrail_ready_to_merge": "bereit zum Mergen",
+  "diagnostics_hint_gitcap_ok": "git unterstützt Lightweight-Merge (≥ 2.38).",
+  "diagnostics_hint_gitcap_old": "git < 2.38 erkannt — der Lightweight-Repo-Modus benötigt git merge-tree --write-tree (git ≥ 2.38). Aktualisiere git, um Lightweight-Repos zu nutzen.",
+  "diagnostics_hint_gh_not_required": "GitHub CLI ist nicht installiert oder nicht authentifiziert, es sind jedoch keine Forge-basierten Repos konfiguriert — gh ist optional, wenn ausschließlich Lightweight-Repos verwendet werden."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1555,5 +1555,13 @@
   "feat_activity_visual_feed_body": "Der Aktivitäts-Tab zeigt während der Arbeit einen Live-Baum der geänderten Dateien und einen gruppierten Tool-Verlauf und wechselt nach Abschluss der Sitzung zur vollständigen visuellen Zusammenfassung.",
   "plangate_view": "PLAN",
   "feat_plan_reopen_title": "Plan jederzeit erneut öffnen",
-  "feat_plan_reopen_body": "Dein freigegebener Plan bleibt während der Ausführung erreichbar. Tippe bei einer laufenden Session auf den PLAN-Chip — in Zeile, Kachel oder Viewport — um ihn schreibgeschützt anzusehen, am Desktop oder mobil."
+  "feat_plan_reopen_body": "Dein freigegebener Plan bleibt während der Ausführung erreichbar. Tippe bei einer laufenden Session auf den PLAN-Chip — in Zeile, Kachel oder Viewport — um ihn schreibgeschützt anzusehen, am Desktop oder mobil.",
+  "automation_lightweight_name": "Lightweight (nur lokal)",
+  "automation_lightweight_desc": "Nur lokales Git — kein Forge, keine PRs. Branch wird lokal squash-gemergt bei Abschluss.",
+  "automation_lightweight_detail": "Im Lightweight-Modus steuert Shepherd das Repo ausschließlich mit lokalem Git: kein GitHub, keine Pull Requests, kein Remote. Auto-Drain, Alle-PRs-Kritiker und Entwurfs-Abgleich sind nicht verfügbar. Wenn die Aufgabe abgeschlossen ist, wird der Agent-Branch lokal in den Basis-Branch squash-gemergt; Sie pushen, wann Sie möchten.",
+  "automation_lightweight_unavailable": "Nicht verfügbar im Lightweight-Modus",
+  "gloss_lightweight_repo_term": "Lightweight-Repo",
+  "gloss_lightweight_repo_def": "Ein Repo, das Shepherd ausschließlich mit lokalem Git steuert — kein Forge, kein GitHub, keine PRs, kein Remote. Wenn eine Aufgabe abgeschlossen ist, wird der Agent-Branch lokal in den Basis-Branch squash-gemergt; der Betreiber pusht zu einem Remote nach eigenem Ermessen.",
+  "feat_lightweight_repo_title": "Lightweight-Modus (nur lokal)",
+  "feat_lightweight_repo_body": "Repos ohne GitHub-Remote können jetzt im [[lightweight_repo|Lightweight]]-Modus betrieben werden: Shepherd steuert nur lokales Git — keine PRs, kein Forge. Im Automatisierungsfenster aktivieren; der Agent-Branch wird lokal bei Abschluss squash-gemergt."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1571,5 +1571,6 @@
   "gitrail_ready_to_merge": "bereit zum Mergen",
   "diagnostics_hint_gitcap_ok": "git unterstützt Lightweight-Merge (≥ 2.38).",
   "diagnostics_hint_gitcap_old": "git < 2.38 erkannt — der Lightweight-Repo-Modus benötigt git merge-tree --write-tree (git ≥ 2.38). Aktualisiere git, um Lightweight-Repos zu nutzen.",
-  "diagnostics_hint_gh_not_required": "GitHub CLI ist nicht installiert oder nicht authentifiziert, es sind jedoch keine Forge-basierten Repos konfiguriert — gh ist optional, wenn ausschließlich Lightweight-Repos verwendet werden."
+  "diagnostics_hint_gh_not_required": "GitHub CLI ist nicht installiert oder nicht authentifiziert, es sind jedoch keine Forge-basierten Repos konfiguriert — gh ist optional, wenn ausschließlich Lightweight-Repos verwendet werden.",
+  "diagnostics_label_git_mergetree": "git merge-tree"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1563,5 +1563,10 @@
   "gloss_lightweight_repo_term": "Lightweight-Repo",
   "gloss_lightweight_repo_def": "Ein Repo, das Shepherd ausschließlich mit lokalem Git steuert — kein Forge, kein GitHub, keine PRs, kein Remote. Wenn eine Aufgabe abgeschlossen ist, wird der Agent-Branch lokal in den Basis-Branch squash-gemergt; der Betreiber pusht zu einem Remote nach eigenem Ermessen.",
   "feat_lightweight_repo_title": "Lightweight-Modus (nur lokal)",
-  "feat_lightweight_repo_body": "Repos ohne GitHub-Remote können jetzt im [[lightweight_repo|Lightweight]]-Modus betrieben werden: Shepherd steuert nur lokales Git — keine PRs, kein Forge. Im Automatisierungsfenster aktivieren; der Agent-Branch wird lokal bei Abschluss squash-gemergt."
+  "feat_lightweight_repo_body": "Repos ohne GitHub-Remote können jetzt im [[lightweight_repo|Lightweight]]-Modus betrieben werden: Shepherd steuert nur lokales Git — keine PRs, kein Forge. Im Automatisierungsfenster aktivieren; der Agent-Branch wird lokal bei Abschluss squash-gemergt.",
+  "gitrail_open_for_merge": "↟ Für Merge öffnen",
+  "gitrail_merge_locally": "Lokal mergen",
+  "gitrail_confirm_merge_locally": "bestätigen ✓",
+  "gitrail_merged_locally": "lokal gemergt ✓",
+  "gitrail_ready_to_merge": "bereit zum Mergen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1571,5 +1571,6 @@
   "gitrail_ready_to_merge": "ready to merge",
   "diagnostics_hint_gitcap_ok": "git supports lightweight merge (≥ 2.38).",
   "diagnostics_hint_gitcap_old": "git < 2.38 detected — lightweight repo mode requires git merge-tree --write-tree (git ≥ 2.38). Update git to use lightweight repos.",
-  "diagnostics_hint_gh_not_required": "GitHub CLI is not installed or not authenticated, but no forge-backed repos are configured — gh is optional when using only lightweight repos."
+  "diagnostics_hint_gh_not_required": "GitHub CLI is not installed or not authenticated, but no forge-backed repos are configured — gh is optional when using only lightweight repos.",
+  "diagnostics_label_git_mergetree": "git merge-tree"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1555,5 +1555,13 @@
   "feat_activity_visual_feed_body": "The Activity tab shows a live tree of changed files and a grouped tool stream while the agent works, then graduates to the full visual recap once the session settles.",
   "plangate_view": "PLAN",
   "feat_plan_reopen_title": "Reopen your plan anytime",
-  "feat_plan_reopen_body": "Your signed-off plan stays reachable while work runs. Tap the PLAN chip on any executing session — row, tile, or viewport — to view it read-only, on desktop or mobile."
+  "feat_plan_reopen_body": "Your signed-off plan stays reachable while work runs. Tap the PLAN chip on any executing session — row, tile, or viewport — to view it read-only, on desktop or mobile.",
+  "automation_lightweight_name": "Lightweight (local-only)",
+  "automation_lightweight_desc": "Local git only — no Forge, no PRs. Branch squash-merged locally at completion.",
+  "automation_lightweight_detail": "In lightweight mode Shepherd drives the repo with local git only: no GitHub, no pull requests, no remote. Auto-Drain, All-PRs Critic and Draft reconcile are unavailable. When the task finishes the agent's branch is squash-merged into the base branch locally; you push when you choose.",
+  "automation_lightweight_unavailable": "Unavailable in lightweight mode",
+  "gloss_lightweight_repo_term": "lightweight repo",
+  "gloss_lightweight_repo_def": "A repo Shepherd drives with local git only — no Forge, no GitHub, no PRs, no remote. When a task finishes, the agent's branch is squash-merged into the base branch locally; the operator pushes to a remote when they choose.",
+  "feat_lightweight_repo_title": "Lightweight (local-only) mode",
+  "feat_lightweight_repo_body": "Repos without a GitHub remote can now run in [[lightweight_repo|lightweight]] mode: Shepherd drives local git only — no PRs, no Forge. Enable it in the automation panel; the agent's branch is squash-merged locally at completion."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1568,5 +1568,8 @@
   "gitrail_merge_locally": "Merge locally",
   "gitrail_confirm_merge_locally": "confirm ✓",
   "gitrail_merged_locally": "merged locally ✓",
-  "gitrail_ready_to_merge": "ready to merge"
+  "gitrail_ready_to_merge": "ready to merge",
+  "diagnostics_hint_gitcap_ok": "git supports lightweight merge (≥ 2.38).",
+  "diagnostics_hint_gitcap_old": "git < 2.38 detected — lightweight repo mode requires git merge-tree --write-tree (git ≥ 2.38). Update git to use lightweight repos.",
+  "diagnostics_hint_gh_not_required": "GitHub CLI is not installed or not authenticated, but no forge-backed repos are configured — gh is optional when using only lightweight repos."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1570,7 +1570,7 @@
   "gitrail_merged_locally": "merged locally ✓",
   "gitrail_ready_to_merge": "ready to merge",
   "diagnostics_hint_gitcap_ok": "git supports lightweight merge (≥ 2.38).",
-  "diagnostics_hint_gitcap_old": "git < 2.38 detected — lightweight repo mode requires git merge-tree --write-tree (git ≥ 2.38). Update git to use lightweight repos.",
+  "diagnostics_hint_gitcap_old": "git ≥ 2.38 not available — lightweight repo mode needs git merge-tree --write-tree (git ≥ 2.38) for local merges. git may be missing (see the git check) or too old; install or update it to use lightweight repos.",
   "diagnostics_hint_gh_not_required": "GitHub CLI is not installed or not authenticated, but no forge-backed repos are configured — gh is optional when using only lightweight repos.",
   "diagnostics_label_git_mergetree": "git merge-tree"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1563,5 +1563,10 @@
   "gloss_lightweight_repo_term": "lightweight repo",
   "gloss_lightweight_repo_def": "A repo Shepherd drives with local git only — no Forge, no GitHub, no PRs, no remote. When a task finishes, the agent's branch is squash-merged into the base branch locally; the operator pushes to a remote when they choose.",
   "feat_lightweight_repo_title": "Lightweight (local-only) mode",
-  "feat_lightweight_repo_body": "Repos without a GitHub remote can now run in [[lightweight_repo|lightweight]] mode: Shepherd drives local git only — no PRs, no Forge. Enable it in the automation panel; the agent's branch is squash-merged locally at completion."
+  "feat_lightweight_repo_body": "Repos without a GitHub remote can now run in [[lightweight_repo|lightweight]] mode: Shepherd drives local git only — no PRs, no Forge. Enable it in the automation panel; the agent's branch is squash-merged locally at completion.",
+  "gitrail_open_for_merge": "↟ Open for merge",
+  "gitrail_merge_locally": "Merge locally",
+  "gitrail_confirm_merge_locally": "confirm ✓",
+  "gitrail_merged_locally": "merged locally ✓",
+  "gitrail_ready_to_merge": "ready to merge"
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1039,6 +1039,7 @@ export async function putRepoConfig(
       | "maxAuto"
       | "autoLabel"
       | "usageCeilingPct"
+      | "repoMode"
     >
   >,
 ): Promise<RepoConfig> {

--- a/ui/src/lib/components/AutomationPanel.svelte
+++ b/ui/src/lib/components/AutomationPanel.svelte
@@ -26,6 +26,8 @@
   const epicActive = $derived(drain?.epicParent != null);
 
   const flags = $derived(repoConfig.flags(repoPath));
+  /** True when this repo is configured for local-only (lightweight) mode. */
+  const lightweight = $derived(repoConfig.repoModeFor(repoPath) === "lightweight");
   const reviewing = $derived(reviews.isReviewing(sessionId));
   const planReviewing = $derived(planGates.isReviewing(sessionId));
 
@@ -299,6 +301,28 @@
     <p id="auto-detail-{id}" class="auto-detail" role="note" hidden={openDetail !== id}>{text}</p>
   {/snippet}
 
+  <!-- Repo mode: lightweight (local-only) vs forge (GitHub/PRs) -->
+  <div class="auto-row" use:coachTarget={"lightweight-repo"}>
+    <div class="auto-meta">
+      <div class="auto-name">
+        ⊙ {m.automation_lightweight_name()}
+        {@render info("lightweight", m.automation_lightweight_name())}
+      </div>
+      <div class="auto-desc">{m.automation_lightweight_desc()}</div>
+      {@render detail("lightweight", m.automation_lightweight_detail())}
+    </div>
+    <button
+      class={["sw", { on: lightweight }]}
+      type="button"
+      role="switch"
+      aria-checked={lightweight}
+      aria-label={m.automation_lightweight_name()}
+      onclick={() => repoConfig.setRepoMode(repoPath, lightweight ? "forge" : "lightweight")}
+    >
+      <span class="knob"></span>
+    </button>
+  </div>
+
   <!-- Code review -->
   <div class="auto-group">{m.automation_group_review()}</div>
   <div class="auto-row">
@@ -322,7 +346,7 @@
       <span class="knob"></span>
     </button>
   </div>
-  <div class="auto-row">
+  <div class={["auto-row", { disabled: lightweight }]}>
     <div class="auto-meta">
       <div class="auto-name">
         ⌗ {m.automation_allprs_name()}
@@ -332,12 +356,14 @@
       {@render detail("critic-all-prs", m.automation_allprs_detail())}
     </div>
     <button
-      class={["sw", { on: flags.criticAllPrs }]}
+      class={["sw", { on: flags.criticAllPrs && !lightweight }]}
       type="button"
       role="switch"
-      aria-checked={flags.criticAllPrs}
+      aria-checked={flags.criticAllPrs && !lightweight}
+      disabled={lightweight}
+      title={lightweight ? m.automation_lightweight_unavailable() : undefined}
       aria-label={m.automation_allprs_name()}
-      onclick={() => repoConfig.toggleAllPrs(repoPath)}
+      onclick={() => !lightweight && repoConfig.toggleAllPrs(repoPath)}
     >
       <span class="knob"></span>
     </button>
@@ -440,7 +466,7 @@
       ◈ {m.epic_mode_active({ parent: drain!.epicParent! })}
     </div>
   {/if}
-  <div class={["auto-row", { disabled: epicActive }]}>
+  <div class={["auto-row", { disabled: epicActive || lightweight }]}>
     <div class="auto-meta">
       <div class="auto-name">
         ▽ {m.automation_autodrain_name()}
@@ -450,14 +476,18 @@
       {@render detail("auto-drain", m.automation_autodrain_detail())}
     </div>
     <button
-      class={["sw", { on: flags.autoDrain && !epicActive }]}
+      class={["sw", { on: flags.autoDrain && !epicActive && !lightweight }]}
       type="button"
       role="switch"
-      aria-checked={flags.autoDrain && !epicActive}
-      disabled={epicActive}
-      title={epicActive ? m.epic_mode_active({ parent: drain!.epicParent! }) : undefined}
+      aria-checked={flags.autoDrain && !epicActive && !lightweight}
+      disabled={epicActive || lightweight}
+      title={lightweight
+        ? m.automation_lightweight_unavailable()
+        : epicActive
+          ? m.epic_mode_active({ parent: drain!.epicParent! })
+          : undefined}
       aria-label={m.automation_autodrain_name()}
-      onclick={() => repoConfig.toggleAutoDrain(repoPath)}
+      onclick={() => !(epicActive || lightweight) && repoConfig.toggleAutoDrain(repoPath)}
     >
       <span class="knob"></span>
     </button>
@@ -508,7 +538,10 @@
       <span class="knob"></span>
     </button>
   </div>
-  <div class={["auto-row", { disabled: flags.autoMerge }]} use:coachTarget={"draft-mode"}>
+  <div
+    class={["auto-row", { disabled: flags.autoMerge || lightweight }]}
+    use:coachTarget={"draft-mode"}
+  >
     <div class="auto-meta">
       <div class="auto-name">□ {m.automation_draftmode_name()}</div>
       <div class="auto-desc">
@@ -518,14 +551,18 @@
       </div>
     </div>
     <button
-      class={["sw", { on: flags.draftMode && !flags.autoMerge }]}
+      class={["sw", { on: flags.draftMode && !flags.autoMerge && !lightweight }]}
       type="button"
       role="switch"
-      aria-checked={flags.draftMode && !flags.autoMerge}
-      disabled={flags.autoMerge}
-      title={flags.autoMerge ? m.automation_draftmode_excludes_automerge() : undefined}
+      aria-checked={flags.draftMode && !flags.autoMerge && !lightweight}
+      disabled={flags.autoMerge || lightweight}
+      title={lightweight
+        ? m.automation_lightweight_unavailable()
+        : flags.autoMerge
+          ? m.automation_draftmode_excludes_automerge()
+          : undefined}
       aria-label={m.automation_draftmode_name()}
-      onclick={() => repoConfig.toggleDraftMode(repoPath)}
+      onclick={() => !(flags.autoMerge || lightweight) && repoConfig.toggleDraftMode(repoPath)}
     >
       <span class="knob"></span>
     </button>

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -329,6 +329,8 @@
                     undefined,
   );
 
+  const local = $derived(git?.kind === "local");
+
   const verdict = $derived(reviews.map[sessionId]);
   const reviewing = $derived(reviews.isReviewing(sessionId));
   const pillReviewing = $derived(reviewing || planGates.isReviewing(sessionId));
@@ -557,21 +559,25 @@
              re-show this button. -->
         {#if !autopilotOn}
           <button class="gbtn" type="button" disabled={busy} onclick={startPr}
-            >{m.gitrail_open_pr()}</button
+            >{local ? m.gitrail_open_for_merge() : m.gitrail_open_pr()}</button
           >
         {/if}
       {:else if git.state === "open"}
-        {#if git.url}
+        {#if local}
+          <span class="prlink">{m.gitrail_ready_to_merge()} #{git.number}</span>
+        {:else if git.url}
           <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
           <a class="prlink" href={git.url} target="_blank" rel="noopener">PR #{git.number} ↗</a>
         {:else}
           <span class="prlink">PR #{git.number}</span>
         {/if}
-        <span
-          class="dot dot-{git.checks}"
-          title={m.gitrail_ci_status({ status: git.checks })}
-          aria-label={m.gitrail_ci_status({ status: git.checks })}
-        ></span>
+        {#if !local}
+          <span
+            class="dot dot-{git.checks}"
+            title={m.gitrail_ci_status({ status: git.checks })}
+            aria-label={m.gitrail_ci_status({ status: git.checks })}
+          ></span>
+        {/if}
         <button
           class="gbtn"
           class:armed={armed === "merge"}
@@ -580,10 +586,14 @@
           title={mergeBlockedReason}
           onclick={() => doMerge()}
         >
-          {armed === "merge" ? m.gitrail_confirm_merge() : m.gitrail_merge()}
+          {#if local}
+            {armed === "merge" ? m.gitrail_confirm_merge_locally() : m.gitrail_merge_locally()}
+          {:else}
+            {armed === "merge" ? m.gitrail_confirm_merge() : m.gitrail_merge()}
+          {/if}
         </button>
       {:else if git.state === "merged"}
-        <span class="merged">{m.gitrail_merged()}</span>
+        <span class="merged">{local ? m.gitrail_merged_locally() : m.gitrail_merged()}</span>
         {#if git.deployConfigured}
           <button
             class="gbtn"

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -59,6 +59,7 @@ function repoConfig(planGateEnabled: boolean): RepoConfig {
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     defaultModel: "inherit",
+    repoMode: "forge",
   };
 }
 

--- a/ui/src/lib/components/automation-panel-epic.test.ts
+++ b/ui/src/lib/components/automation-panel-epic.test.ts
@@ -22,6 +22,11 @@ function makeDrain(epicParent: number | null): DrainStatus {
   };
 }
 
+// Pure helper mirroring the `lightweight` derived in AutomationPanel.
+function isLightweight(repoMode: "forge" | "lightweight" | undefined): boolean {
+  return (repoMode ?? "forge") === "lightweight";
+}
+
 describe("AutomationPanel epic-mode precedence indicator", () => {
   it("epicActive is true when epicParent is set", () => {
     expect(isEpicActive(makeDrain(42))).toBe(true);
@@ -41,5 +46,19 @@ describe("AutomationPanel epic-mode precedence indicator", () => {
 
   it("epicActive is false when drain is undefined", () => {
     expect(isEpicActive(undefined)).toBe(false);
+  });
+});
+
+describe("AutomationPanel lightweight-mode derived", () => {
+  it("isLightweight is true when repoMode is 'lightweight'", () => {
+    expect(isLightweight("lightweight")).toBe(true);
+  });
+
+  it("isLightweight is false when repoMode is 'forge'", () => {
+    expect(isLightweight("forge")).toBe(false);
+  });
+
+  it("isLightweight defaults to false (forge) when repoMode is undefined", () => {
+    expect(isLightweight(undefined)).toBe(false);
   });
 });

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1149,4 +1149,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_plan_reopen_title",
     bodyKey: "feat_plan_reopen_body",
   },
+  {
+    // targetId "lightweight-repo" matches use:coachTarget on the lightweight toggle row
+    // in AutomationPanel. v1.34.0 is the latest released tag → ships in 1.35.0.
+    id: "lightweight-repo-mode",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_lightweight_repo_title",
+    bodyKey: "feat_lightweight_repo_body",
+    targetId: "lightweight-repo",
+  },
 ];

--- a/ui/src/lib/glossary.ts
+++ b/ui/src/lib/glossary.ts
@@ -66,6 +66,12 @@ const glossary: readonly GlossaryTerm[] = [
     termKey: "gloss_inferred_term",
     bodyKey: "gloss_inferred_def",
   },
+  {
+    id: "lightweight_repo",
+    kind: "internal",
+    termKey: "gloss_lightweight_repo_term",
+    bodyKey: "gloss_lightweight_repo_def",
+  },
 ];
 
 export const glossaryById = new Map<string, GlossaryTerm>(glossary.map((term) => [term.id, term]));

--- a/ui/src/lib/reviews.svelte.test.ts
+++ b/ui/src/lib/reviews.svelte.test.ts
@@ -29,6 +29,7 @@ const rc = (overrides: Partial<RepoConfig> = {}): RepoConfig => ({
   maxAuto: 1,
   autoLabel: "shepherd:auto",
   usageCeilingPct: 80,
+  repoMode: "forge",
   ...overrides,
 });
 
@@ -61,6 +62,7 @@ beforeEach(() => {
   repoConfig.draftMode = {};
   repoConfig.allPrs = {};
   repoConfig.signoffAuthority = {};
+  repoConfig.repoMode = {};
   repoConfig.maxAuto = {};
   repoConfig.autoLabel = {};
   repoConfig.usageCeiling = {};
@@ -459,4 +461,30 @@ test("repoConfig.setSignoffAuthority reverts on error", async () => {
   repoConfig.signoffAuthority = { "/repo": "human" };
   await repoConfig.setSignoffAuthority("/repo", "critic");
   expect(repoConfig.signoffAuthorityFor("/repo")).toBe("human"); // reverted
+});
+
+// ── repoMode ───────────────────────────────────────────────────────────────
+
+test("repoConfig.repoModeFor defaults to forge for unknown repo", () => {
+  expect(repoConfig.repoModeFor("/unknown")).toBe("forge");
+});
+
+test("repoConfig.setRepoMode updates the value optimistically", async () => {
+  vi.mocked(putRepoConfig).mockResolvedValue(rc({ repoMode: "lightweight" }));
+  await repoConfig.setRepoMode("/repo", "lightweight");
+  expect(putRepoConfig).toHaveBeenCalledWith("/repo", { repoMode: "lightweight" });
+  expect(repoConfig.repoModeFor("/repo")).toBe("lightweight");
+});
+
+test("repoConfig.setRepoMode reverts on error", async () => {
+  vi.mocked(putRepoConfig).mockRejectedValueOnce(new Error("boom"));
+  repoConfig.repoMode = { "/repo": "forge" };
+  await repoConfig.setRepoMode("/repo", "lightweight");
+  expect(repoConfig.repoModeFor("/repo")).toBe("forge"); // reverted
+});
+
+test("repoConfig.ensure caches repoMode", async () => {
+  vi.mocked(getRepoConfig).mockResolvedValue(rc({ repoMode: "lightweight" }));
+  await repoConfig.ensure("/repo");
+  expect(repoConfig.repoModeFor("/repo")).toBe("lightweight");
 });

--- a/ui/src/lib/reviews.svelte.ts
+++ b/ui/src/lib/reviews.svelte.ts
@@ -164,6 +164,7 @@ class RepoConfigStore {
   planGate = $state<Record<string, boolean>>({}); // pre-execution plan gate (default off)
   draftMode = $state<Record<string, boolean>>({}); // open PRs as drafts (default off; mutually exclusive with autoMerge)
   signoffAuthority = $state<Record<string, "human" | "critic" | "either">>({}); // who may promote draft PRs (default "human")
+  repoMode = $state<Record<string, "forge" | "lightweight">>({}); // forge vs lightweight local mode (default "forge")
   sandboxProfile = $state<Record<string, SandboxProfile>>({}); // per-repo sandbox confinement (default "trusted")
   defaultModel = $state<Record<string, string>>({}); // per-repo default-model override (default "inherit")
   maxAuto = $state<Record<string, number>>({}); // max concurrent auto sessions (default 1)
@@ -187,6 +188,7 @@ class RepoConfigStore {
     this.planGate = { ...this.planGate, [repoPath]: c.planGateEnabled };
     this.draftMode = { ...this.draftMode, [repoPath]: c.draftMode };
     this.signoffAuthority = { ...this.signoffAuthority, [repoPath]: c.signoffAuthority };
+    this.repoMode = { ...this.repoMode, [repoPath]: c.repoMode };
     this.sandboxProfile = { ...this.sandboxProfile, [repoPath]: c.sandboxProfile };
     this.defaultModel = { ...this.defaultModel, [repoPath]: c.defaultModel };
     this.maxAuto = { ...this.maxAuto, [repoPath]: c.maxAuto };
@@ -246,6 +248,7 @@ class RepoConfigStore {
         | "maxAuto"
         | "autoLabel"
         | "usageCeilingPct"
+        | "repoMode"
       >
     >,
     revert: () => void,
@@ -353,6 +356,14 @@ class RepoConfigStore {
     });
   }
 
+  async setRepoMode(repoPath: string, mode: "forge" | "lightweight") {
+    const prev = this.repoMode[repoPath];
+    this.repoMode = { ...this.repoMode, [repoPath]: mode }; // optimistic
+    await this.apply(repoPath, { repoMode: mode }, () => {
+      this.repoMode = { ...this.repoMode, [repoPath]: prev };
+    });
+  }
+
   async setSandboxProfile(repoPath: string, profile: SandboxProfile) {
     const prev = this.sandboxProfile[repoPath];
     this.sandboxProfile = { ...this.sandboxProfile, [repoPath]: profile }; // optimistic
@@ -453,6 +464,10 @@ class RepoConfigStore {
 
   signoffAuthorityFor(repoPath: string): "human" | "critic" | "either" {
     return this.signoffAuthority[repoPath] ?? "human";
+  }
+
+  repoModeFor(repoPath: string): "forge" | "lightweight" {
+    return this.repoMode[repoPath] ?? "forge";
   }
 
   sandboxProfileFor(repoPath: string): SandboxProfile {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -119,7 +119,7 @@ export interface BlockReason {
   quotaKind?: "rework" | "review" | "error" | "plan";
 }
 
-export type ForgeKind = "github" | "gitea";
+export type ForgeKind = "github" | "gitea" | "local";
 export type MergeMethod = "merge" | "squash" | "rebase";
 export type ChecksState = "none" | "pending" | "success" | "failure";
 /** GitHub's mergeStateStatus (mirrors server `MergeStateStatus`); absent for Gitea. */
@@ -437,6 +437,8 @@ export interface RepoConfig {
   maxAuto: number;
   autoLabel: string;
   usageCeilingPct: number;
+  /** Whether this repo uses a forge (GitHub/Gitea) or lightweight local-only mode. */
+  repoMode: "forge" | "lightweight";
 }
 
 /** Live per-repo merge-train status pushed to clients (mirrors server AutoMergeStatus). */
@@ -757,7 +759,7 @@ export interface BacklogProject {
   path: string;
   display: string;
   slug: string | null;
-  kind: "github" | "gitea";
+  kind: ForgeKind;
   lastUsedAt?: number;
   /** Agents run on this repo in the server's recent window — same metric the
    *  New Task repo picker pins its "recently worked on" group by. */


### PR DESCRIPTION
## Lightweight repo mode — local-only git, no Forge (#807)

Adds a **per-repo** `repoMode: "forge" | "lightweight"`. In **lightweight** mode Shepherd drives a repo with **local git only** — no GitHub/Gitea, no `gh`, no PRs, no remote. The agent works in a worktree as today; at task completion its branch is **squash-merged into the base branch locally**, and the operator pushes whenever they choose. Forge repos are completely unaffected (default `repoMode = "forge"`).

Closes #807.

### Architecture — one pivot
A third `GitForge` implementation, **`LocalForge`** (`src/forge/local.ts`), selected by making the single `resolveForge(dir)` closure repoMode-aware (`src/forge/resolve.ts`). Every service already obtains forges through `resolveForge`, so downstream code barely changes.

- **Pseudo-PR** persisted in a new `local_prs` table (durable AUTOINCREMENT number + open/merged lifecycle). `prStatus` is a pure row read (`checks:"success"`, `mergeable` from a live `merge-tree` dry-run); `postReview` is a no-op (the critic verdict already lives in the `reviews` table and renders in the UI).
- **Off-working-tree squash merge** (`squashMergeLocal`): `merge-tree --write-tree` → `commit-tree` → advance base. The base-checkout strategy is decided **before any ref moves** — if base is checked out clean at the old tip it is fast-forwarded atomically (`git -C <wt> merge --ff-only`, no desync); dirty/moved base or a conflict **aborts with no ref moved** (surfaced as a clean 409); base checked out nowhere uses a compare-and-swap `update-ref`. The squashed branch ref is repointed so the existing ancestry-gated prune cleans it up. Every git call has an explicit timeout. Requires git ≥ 2.38 (guarded with a clear error + a diagnostics check).

### Completion → merge
The pseudo-PR is created only at an **explicit completion barrier** (never from mere commit-presence), the local analog of the agent's deliberate `gh pr create`:
- **Autonomous:** at autopilot's terminal "finished" classification, lightweight repos register the pseudo-PR server-side (`openLocalPr`) instead of steering `gh pr create`. Auto-merge ON then merges locally at completion via the existing `readyToMerge` → `LocalForge.merge` → `settleMergedSession` path.
- **Attended:** the operator clicks **"Open for merge"** then **"Merge locally"** in the git rail. The manual merge endpoint now runs `settleMergedSession` (archive + worktree prune) for local sessions.

### UI
- **AutomationPanel:** a repoMode toggle at the top; when lightweight, the forge-only rows (All-PRs critic, Auto-drain, Draft reconcile) are greyed + disabled. Critic, Auto-Address, Plan Gate, Learnings, Autopilot, Sandbox, Default Model, and Auto-merge stay active.
- **Git rail (GitRail):** relabels for local sessions — "Open for merge", "Merge locally", "ready to merge", "Merged locally"; no external PR link; CI dot hidden (no CI). Forge sessions render identically.
- Glossary entry (`lightweight_repo`), a What's-New feature announcement (`sinceVersion 1.35.0`), and full EN+DE i18n for every new string.

### Non-task-loop consumers
The learnings **Promoter** is guarded so it never opens a stray pseudo-PR in local mode. gitignore-adopt (no `canPush`), redeploy (null `deployWorkflow` → 400), and the standalone/draft-reconcile/epic services self-disable via empty issue/PR lists + omitted optional methods. Backlog forge-backedness (`BacklogPoller`, `CountsService`) is mode-aware so a runtime toggle propagates without a restart.

### Out of scope (v1)
Local backlog source (auto-drain stays off in local mode); Shepherd never touches a remote (the operator owns all pushing); per-repo merge-method config; add-repo-by-arbitrary-path; a local test-command "CI" gate. A lightweight repo still appears as a selectable project (so you can start tasks in it); its issue/PR backlog counts are N/A and degrade cleanly.

### Verification
- Root: `tsc` clean, lint clean, `bun test ./test` 3841 pass.
- UI: `svelte-check` 0 errors, `bun run test` 1680 pass, `check:i18n` parity (1573 keys).
- Glossary, branch-hygiene, feature-catalog gates pass; `fallow audit` exit 0 (no new dead code; the two flagged template-complexity findings are pre-existing on GitRail/AutomationPanel).
- New tests exercise **real git** in temp repos: open/status, squash-merge with base checked-out-clean (no desync), dirty/moved-base abort, conflict abort, branch prune, the git-version guard, completion barriers, and merge teardown.

Built subagent-driven (fresh implementer + spec/quality review per task, plus a final whole-branch review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
