### PR TITLE
fix(plan): keep read-only PLAN chip off session cards; legible in top bar

### DIFF
--- a/ui/src/lib/components/PlanGateBadge.svelte
+++ b/ui/src/lib/components/PlanGateBadge.svelte
@@ -5,11 +5,14 @@
   import PlanPanel from "./PlanPanel.svelte";
   import { m } from "$lib/paraglide/messages";
 
-  let { session }: { session: Session } = $props();
+  // allowView (default true): whether to surface the read-only "view"/PLAN chip during
+  // execution. The dense session-list surfaces (UnitRow/UnitTile) pass false so this chip
+  // lives only in the per-session top bar (issue #809); see plan-gate-badge.ts.
+  let { session, allowView = true }: { session: Session; allowView?: boolean } = $props();
 
   const gate = $derived(planGates.map[session.id]);
   const reviewing = $derived(planGates.isReviewing(session.id));
-  const chip = $derived(planGateChip(session, gate, reviewing));
+  const chip = $derived(planGateChip(session, gate, reviewing, { allowView }));
 
   let open = $state(false);
 
@@ -75,6 +78,19 @@
   }
   .pg-error {
     color: var(--color-faint);
+  }
+  /* read-only re-open of the signed-off plan during execution (issue #809). Lives only in
+     the per-session top bar (the dense list cards opt out via allowView=false), so it can
+     afford to read as a real control rather than a whisper: legible ink + a visible resting
+     border. Stays NEUTRAL — green is reserved for READY, amber for in-flight; a parked,
+     read-only plan is passive, so it must not borrow a semantic hue. */
+  .pg-view {
+    color: var(--color-ink);
+    border-color: var(--color-line-bright);
+    font-weight: 500;
+  }
+  .pg-view:hover {
+    color: var(--color-ink-bright);
   }
   /* plan reviewer running now: amber outline + pulsing dot (mirrors CriticBadge) */
   .pg-reviewing {

--- a/ui/src/lib/components/PlanGateBadge.test.ts
+++ b/ui/src/lib/components/PlanGateBadge.test.ts
@@ -40,6 +40,41 @@ describe("planGateChip", () => {
 
   it("hides when executing with no gate", () => {
     expect(planGateChip(sess("executing"), undefined, false)).toEqual({ kind: "none" });
+    // ...regardless of allowView — there's nothing to view.
+    expect(planGateChip(sess("executing"), undefined, false, { allowView: false })).toEqual({
+      kind: "none",
+    });
+  });
+
+  it("suppresses the executing view chip when allowView is false (dense list surfaces)", () => {
+    // UnitRow/UnitTile pass allowView:false so the read-only PLAN chip stays off the
+    // crowded session cards; it then lives only in the per-session top bar.
+    expect(
+      planGateChip(sess("executing"), gate({ approved: true }), false, { allowView: false }),
+    ).toEqual({ kind: "none" });
+    // explicit allowView:true matches the default (top-bar) behavior.
+    expect(
+      planGateChip(sess("executing"), gate({ approved: true }), false, { allowView: true }),
+    ).toEqual({ kind: "view" });
+  });
+
+  it("allowView only affects the executing view chip, not lifecycle states", () => {
+    // A list surface still shows pre-execution lifecycle states even with allowView:false.
+    expect(
+      planGateChip(sess("planning"), gate({ approved: true, decision: "approved" }), false, {
+        allowView: false,
+      }).kind,
+    ).toBe("ready");
+    expect(
+      planGateChip(
+        sess("planning"),
+        gate({ decision: "changes_requested", round: 1, cap: 3 }),
+        false,
+        {
+          allowView: false,
+        },
+      ).kind,
+    ).toBe("changes");
   });
 
   it("reviewing wins over a stale verdict", () => {

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -460,7 +460,7 @@
       {#if !stepperTerminal}<PrBadge {git} />{/if}
       <CriticBadge sessionId={session.id} />
       <BuildQueueBadge sessionId={session.id} />
-      <PlanGateBadge {session} />
+      <PlanGateBadge {session} allowView={false} />
       {#if quotaKind}
         <span
           class="badge quota-stalled"

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -296,7 +296,7 @@
     <ResearchBadge {session} />
     <PrBadge {git} />
     <CriticBadge sessionId={session.id} />
-    <PlanGateBadge {session} />
+    <PlanGateBadge {session} allowView={false} />
     <!-- REVIEWING (in-flight critic) outranks the autopilot badge -->
     {#if !reviewing}<AutopilotBadge {session} />{/if}
     <AutoPip {session} />

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2164,9 +2164,12 @@
         aria-label={statusLabel(dStatus)}>{statusMark}</span
       >
     {/if}
-    <!-- plan-gate state in the focused view (PLANNING / REWORK / READY / REVIEW ERR);
-         self-hides outside the plan phase. Both layouts — the Review-plan trigger on
-         the git rail acts on this state. -->
+    <!-- plan-gate state in the focused view: the pre-execution lifecycle (PLANNING /
+         REWORK / READY / REVIEW ERR; the Review-plan trigger on the git rail acts on this
+         state), and during execution the legible read-only PLAN re-open of the signed-off
+         plan (issue #809). Self-hides outside the plan phase. Unlike the session-list cards
+         (UnitRow/UnitTile, which pass allowView={false}), the focused view surfaces the
+         executing read-only chip — it is its home. -->
     <PlanGateBadge {session} />
     {#if !compact}
       <!-- desktop: the full git rail (PR / CI / merge / critic / ready / verdict)

--- a/ui/src/lib/components/plan-gate-badge.ts
+++ b/ui/src/lib/components/plan-gate-badge.ts
@@ -6,10 +6,16 @@ import type { PlanGate, Session } from "../types";
  *
  * Priority order:
  *  - "none":       planPhase is null (no gate active), OR planPhase is "executing"
- *                  with no persisted gate (nothing to show).
- *  - "view":       planPhase is "executing" AND a persisted gate exists — surfaces
- *                  the signed-off plan read-only so the operator can re-open it
- *                  during execution (issue #809). No Go/Review actions are shown.
+ *                  with no persisted gate (nothing to show), OR planPhase is
+ *                  "executing" but the caller opted out of the "view" chip
+ *                  (`allowView: false`) — see below.
+ *  - "view":       planPhase is "executing" AND a persisted gate exists AND the
+ *                  caller allows it (`allowView`, default true) — surfaces the
+ *                  signed-off plan read-only so the operator can re-open it during
+ *                  execution (issue #809). No Go/Review actions are shown. The
+ *                  dense session-list surfaces (UnitRow/UnitTile) pass
+ *                  `allowView: false` to keep this read-only chip off the cards;
+ *                  it then lives only in the per-session top bar.
  *  - "reviewing":  the plan reviewer is running now — wins over any stale verdict.
  *  - "changes":    last verdict requested changes — shows the round/cap counter.
  *  - "ready":      verdict approved and still in "planning" → operator can hit Go.
@@ -29,11 +35,16 @@ export function planGateChip(
   session: Pick<Session, "planPhase">,
   gate: PlanGate | undefined,
   reviewing: boolean,
+  opts: { allowView?: boolean } = {},
 ): PlanGateChip {
+  const { allowView = true } = opts;
   if (session.planPhase == null) return { kind: "none" };
   // Executing: the gate already passed — surface the signed-off plan read-only (issue #809),
-  // but only while a persisted gate still exists.
-  if (session.planPhase === "executing") return gate ? { kind: "view" } : { kind: "none" };
+  // but only while a persisted gate still exists and the caller opts in (`allowView`).
+  // The dense session-list surfaces opt out so this chip lives only in the top bar.
+  if (session.planPhase === "executing") {
+    return gate && allowView ? { kind: "view" } : { kind: "none" };
+  }
   if (reviewing) return { kind: "reviewing" };
   if (gate?.decision === "changes_requested") {
     return { kind: "changes", round: gate.round, cap: gate.cap };


### PR DESCRIPTION
## Problem

The #809 executing-phase read-only **PLAN** (`view`) chip is rendered by the shared `PlanGateBadge`, which mounts on **three** surfaces — the two dense session-list layouts (`UnitRow`, `UnitTile`) and the per-session top bar (`Viewport`). Showing it on the cards during execution re-crowded rows that already carry PR / critic / build-queue / quota / autopilot / status badges.

Separately, the top-bar chip — the one place the read-only re-open *should* live — was a near-invisible muted-grey whisper (transparent bg, `--color-muted`, `--fs-micro`, no accent), so it read as nothing.

## Change

- **`planGateChip` gains `opts.allowView`** (default `true`). During `executing`, the `view` chip is emitted only when `gate && allowView`. Pure/testable; default preserves the top-bar behavior with zero call-site churn.
- **Both list surfaces opt out** — `UnitRow.svelte:463` and `UnitTile.svelte:299` pass `allowView={false}`, so the read-only chip no longer appears on cards. Pre-execution lifecycle states (PLANNING / REWORK / READY / REVIEW ERR) still show on cards as before.
- **Top-bar chip made legible** — `.pg-view` lifts the chip to ink text + a visible resting border (`--color-ink` / `--color-line-bright`), staying **neutral** (no green/amber — those are reserved for READY / in-flight; a parked read-only plan is passive).
- **Refreshed the stale `Viewport.svelte` comment** describing the badge's executing-phase role.

## Tests

`PlanGateBadge.test.ts` gains regression cases: `executing + gate + allowView:false → none` (fails on pre-fix code), `allowView:true → view` preserved, no-gate stays `none` regardless, and `allowView` leaves pre-execution lifecycle states untouched. All 1673 UI tests pass; `bun run check` clean.

## Notes

- No new i18n keys (`plangate_view` already EN+DE). No feature-catalog entry — refinement of shipped #809, landed as `fix(plan):` not `feat`. No server change (gates already persist into `executing`).
- Logic is fully unit-covered; the `.pg-view` styling is a token-based CSS tweak. Visual confirmation of the executing-phase top-bar chip on a live gated session is worth a glance during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)