### PR TITLE
fix(build-queue): keep step status in sync with real progress

### DIFF
--- a/src/build-queue-reminder.ts
+++ b/src/build-queue-reminder.ts
@@ -99,7 +99,8 @@ export class BuildQueueReminderService {
 
   /**
    * Periodic auto-fire. For each active session with an approved, non-empty queue, advance the
-   * settled-idle debounce and nudge once per episode when the queue is drifted. Never throws.
+   * settled-idle debounce and nudge once per episode when the queue is drifted. May surface a
+   * synchronous store (SQLite) error; the caller guards it so the timer can't die.
    */
   sweep(): void {
     const now = this.now();

--- a/src/build-queue-reminder.ts
+++ b/src/build-queue-reminder.ts
@@ -1,0 +1,160 @@
+// Build-queue reconciliation nudge — the settled-idle BACKSTOP to the deterministic
+// forward-fill cascade in store.setBuildStepStatus.
+//
+// Forward-fill keeps the queue fresh whenever the agent posts ANY step transition. This
+// service covers the one shape forward-fill cannot: an agent that posted NOTHING at all,
+// so the queue is stuck "all pending" while real work has happened. When such a session
+// settles idle, we inject ONE reminder steer asking it to post its progress (which then
+// forward-fills). It is best-effort, not a guarantee — re-asking an agent is the same lever
+// it already ignored, so correctness rests on forward-fill, not on this nudge.
+//
+// It borrows RecapService's settled-idle debounce STRUCTURE only, not its side-effect
+// profile: recap spawns a separate read-only agent, whereas this steers the LIVE pane.
+// Steering re-activates the session, so the guards below are load-bearing:
+//   - only `idle` is eligible — never `done` (would wake a FINISHED agent → autopilot
+//     continuation / PR attempts / token spend), never `running` (live work in progress).
+//   - settled (not first idle tick, per the once-on-settled-idle house rule).
+//   - `sawRunning` evidence gate — an approved+all-pending queue is indistinguishable from
+//     "just approved, not yet started", so we only nudge after observing the agent actually
+//     run, which also avoids colliding with the APPROVE_STEER "Begin now" steer.
+//   - once per idle episode + a per-session lifetime cap (runaway guard).
+// Agent-facing text is fixed English (precedent: APPROVE_STEER, AUTOPILOT_DIRECTIVE).
+
+import type { SessionStore } from "./store";
+import type { BuildQueue, SessionStatus } from "./types";
+
+const DEFAULT_IDLE_THRESHOLD_MS = 120_000;
+const DEFAULT_MAX_NUDGES = 3;
+
+/** The reconcile reminder injected into a drifted, settled-idle session. */
+export const RECONCILE_STEER =
+  "🔄 Your build-queue step statuses look out of date — they don't reflect your actual " +
+  "progress (the queue still shows steps pending that you've moved past). Reconcile them now " +
+  "via the build-queue API: mark the step you're currently on `active` and any finished steps " +
+  "`done`. Marking a later step automatically completes the earlier ones, so a single update " +
+  "is enough. Then carry on.";
+
+/**
+ * Pure drift test. A queue is "drifted" when it's approved with work outstanding but no step
+ * is signalled in-progress: at least one `pending` step and zero `active` steps. A
+ * well-behaved agent keeps the current step `active` while working and ends with no `pending`
+ * steps, so settled-idle-with-pending-but-nothing-active is the drift window.
+ */
+export function isQueueDrifted(q: BuildQueue): boolean {
+  if (!q.approved || q.steps.length === 0) return false;
+  return q.steps.some((s) => s.status === "pending") && !q.steps.some((s) => s.status === "active");
+}
+
+interface DebounceEntry {
+  /** epoch ms when the current idle episode began; null whenever the session isn't idle. */
+  idleSince: number | null;
+  /** true once a reminder fired in the current idle episode (reset when it re-activates). */
+  firedThisEpisode: boolean;
+  /** true once we've observed the session actually running since we began tracking it. */
+  sawRunning: boolean;
+  /** lifetime reminders sent to this session (runaway guard). */
+  nudgeCount: number;
+}
+
+interface Deps {
+  store: Pick<SessionStore, "list" | "getBuildQueue">;
+  /** Inject a steer into a session's live pane. Returns false for an unknown id / dead pane. */
+  steer: (id: string, text: string) => boolean;
+  now?: () => number;
+  idleThresholdMs?: number;
+  maxNudges?: number;
+}
+
+export class BuildQueueReminderService {
+  private now: () => number;
+  private idleThresholdMs: number;
+  private maxNudges: number;
+  private debounce = new Map<string, DebounceEntry>();
+
+  constructor(private deps: Deps) {
+    this.now = deps.now ?? Date.now;
+    this.idleThresholdMs = deps.idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
+    this.maxNudges = deps.maxNudges ?? DEFAULT_MAX_NUDGES;
+  }
+
+  /** Drop a session's debounce state (call on archive). */
+  forget(id: string): void {
+    this.debounce.delete(id);
+  }
+
+  private entry(id: string): DebounceEntry {
+    let e = this.debounce.get(id);
+    if (!e) {
+      e = { idleSince: null, firedThisEpisode: false, sawRunning: false, nudgeCount: 0 };
+      this.debounce.set(id, e);
+    }
+    return e;
+  }
+
+  /** Mark the current (or next) idle episode as not-yet-fired and not idle. */
+  private resetEpisode(e: DebounceEntry): void {
+    e.idleSince = null;
+    e.firedThisEpisode = false;
+  }
+
+  /**
+   * Periodic auto-fire. For each active session with an approved, non-empty queue, advance the
+   * settled-idle debounce and nudge once per episode when the queue is drifted. Never throws.
+   */
+  sweep(): void {
+    const now = this.now();
+    const live = new Set<string>();
+    for (const s of this.deps.store.list({ activeOnly: true })) {
+      live.add(s.id);
+      this.considerSession(s.id, s.status, now);
+    }
+    // Forget sessions that are no longer active/listed.
+    for (const id of [...this.debounce.keys()]) {
+      if (!live.has(id)) this.debounce.delete(id);
+    }
+  }
+
+  /** Advance one session's debounce and nudge it if it's a drifted, settled-idle queue. */
+  private considerSession(id: string, status: SessionStatus, now: number): void {
+    const q = this.deps.store.getBuildQueue(id);
+    // No approved queue yet (or none authored) → nothing to reconcile; drop any state.
+    if (!q.approved || q.steps.length === 0) {
+      this.debounce.delete(id);
+      return;
+    }
+    const e = this.entry(id);
+
+    // Only `idle` is eligible. `running` records work-seen; everything else (done/blocked/
+    // archived) is skipped without steering. All non-idle states reset the idle episode.
+    if (status !== "idle") {
+      if (status === "running") e.sawRunning = true;
+      this.resetEpisode(e);
+      return;
+    }
+
+    // idle: settle first (the first idle tick is not "settled", per the house rule).
+    if (e.idleSince === null) {
+      e.idleSince = now;
+      return;
+    }
+    if (!this.readyToNudge(e, q, now)) return;
+
+    // If the steer doesn't land (dead pane), leave state untouched so the next sweep retries.
+    if (this.deps.steer(id, RECONCILE_STEER)) {
+      e.firedThisEpisode = true;
+      e.nudgeCount++;
+    }
+  }
+
+  /** Whether a settled-idle session is eligible for a reconcile nudge this episode. */
+  private readyToNudge(e: DebounceEntry, q: BuildQueue, now: number): boolean {
+    if (e.idleSince === null) return false;
+    return (
+      now - e.idleSince >= this.idleThresholdMs && // settled long enough
+      !e.firedThisEpisode && // once per episode
+      e.sawRunning && // evidence of work → not the just-approved shape
+      e.nudgeCount < this.maxNudges && // runaway guard
+      isQueueDrifted(q)
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -768,7 +768,11 @@ setInterval(() => {
   void recapService.sweep().catch((err) => console.warn("[recap] sweep failed:", err)); // settled-idle auto-fire
   void herdDigestService.tick().catch((err) => console.warn("[rundown] tick failed:", err)); // finalize in-flight digest (restart-safe)
   void herdDigestService.sweep().catch((err) => console.warn("[rundown] sweep failed:", err)); // daily auto-spark
-  buildQueueReminder.sweep(); // settled-idle nudge for a drifted build queue (sync, never throws)
+  try {
+    buildQueueReminder.sweep(); // settled-idle nudge for a drifted build queue (sync)
+  } catch (err) {
+    console.warn("[build-queue] reminder sweep failed:", err);
+  }
 }, 15_000);
 // The standalone critic's enumeration runs on its OWN 60s timer, separate from the 15s
 // finalize tick above: a sweep lists every open PR per repo (a forge round-trip), far

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ import { normalizeAuthModeSetting } from "./auth-mode";
 import { EgressWatcher } from "./egress-watch";
 import { detectEgressHostLoopback } from "./egress";
 import { RecapService } from "./recap";
+import { BuildQueueReminderService } from "./build-queue-reminder";
 import { HerdDigestService } from "./herd-digest";
 import { readSnapshot, isStalled, DEFAULT_STALL } from "./stall";
 import { jsonlPathFor } from "./usage";
@@ -250,6 +251,13 @@ const service = new SessionService({
   // exists (the generator reads it to build its prompt). Bounded + swallowed inside
   // archive() so it can never block teardown / the merge train.
   beforeArchive: (s) => recapService.considerForArchive(s).then(() => {}),
+});
+
+// Build-queue reconciliation nudge: settled-idle backstop to the forward-fill cascade in
+// store.setBuildStepStatus. Steers a drifted, settled-idle session to post its progress.
+const buildQueueReminder = new BuildQueueReminderService({
+  store,
+  steer: (id, text) => service.reply(id, text),
 });
 
 const accountIndex = new AccountUsageIndex();
@@ -760,6 +768,7 @@ setInterval(() => {
   void recapService.sweep().catch((err) => console.warn("[recap] sweep failed:", err)); // settled-idle auto-fire
   void herdDigestService.tick().catch((err) => console.warn("[rundown] tick failed:", err)); // finalize in-flight digest (restart-safe)
   void herdDigestService.sweep().catch((err) => console.warn("[rundown] sweep failed:", err)); // daily auto-spark
+  buildQueueReminder.sweep(); // settled-idle nudge for a drifted build queue (sync, never throws)
 }, 15_000);
 // The standalone critic's enumeration runs on its OWN 60s timer, separate from the 15s
 // finalize tick above: a sweep lists every open PR per repo (a forge round-trip), far
@@ -777,6 +786,7 @@ events.subscribe((event, data) => {
     reviewService.forget(id);
     planGate.forget(id);
     recapService.onArchived(id);
+    buildQueueReminder.forget(id);
   }
 });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -486,7 +486,7 @@ const RESEARCH_DIRECTIVE =
  * Agent-facing prompt text (not operator UI), so fixed English — same precedent as
  * AUTOPILOT_DIRECTIVE, BRANCH_RENAME_NOTICE, and the other spawn-constant notices.
  */
-function buildQueueDirective(args: {
+export function buildQueueDirective(args: {
   sessionId: string;
   baseUrl: string;
   token: string | null;
@@ -524,6 +524,12 @@ function buildQueueDirective(args: {
     '     -d \'{"status":"done"}\' \\\n' +
     `     ${queueUrl}/steps/{stepId}     # when you finish a step\n` +
     '   Use "skipped" if you decide to drop a step.\n\n' +
+    "   Update as you go: mark a step `active` the moment you start it and `done` the moment you " +
+    "finish — never batch the updates at the end. Work the steps IN ORDER; when you advance a step " +
+    "the server automatically completes any earlier steps still pending, so even a single timely " +
+    "update keeps the whole queue accurate. The operator's view of your progress depends entirely " +
+    "on these. If your reported statuses ever fall behind your actual progress you may receive a " +
+    "reminder to reconcile them — do so promptly.\n\n" +
     "3. Inspect the current queue at any time:\n" +
     `   curl -s${authHeader} ${queueUrl}\n\n` +
     "Self-revision: if you discover a better approach mid-run, PUT an updated steps array. " +

--- a/src/store.ts
+++ b/src/store.ts
@@ -2270,13 +2270,48 @@ export class SessionStore implements CapStore, CreditStore {
     return this.getBuildQueue(sessionId);
   }
 
-  /** Update the status of a single step. Returns true when a row was actually changed. */
+  /**
+   * Update the status of a single step. Returns true when the TARGET row was actually
+   * changed (unchanged contract; the cascade below is additive).
+   *
+   * Monotonic forward-fill: when a step is advanced to `active` or `done`, every EARLIER
+   * step still `pending` is auto-completed to `done`, in the same transaction. The
+   * build-queue contract is ordered execution ("work the steps in order"), so reaching
+   * step N implies steps before it are done — this keeps the displayed status from lagging
+   * actual progress even when the agent under-reports (e.g. marks a later step but never
+   * the earlier ones). Deterministic and server-side: needs zero agent compliance.
+   *
+   * Strictly monotonic + safe: only `pending → done`, only at LOWER positions; never
+   * un-completes a step, never touches later steps, and never overrides `skipped` (an
+   * explicit terminal state the agent sets to drop a step). A step the agent silently
+   * jumped over (left `pending`) is treated as `done` — the reasonable default under the
+   * ordered contract; the agent has the explicit `skipped` status if it means otherwise.
+   * Only fires on `active`/`done`, never on `pending` (un-set) or `skipped`.
+   */
   setBuildStepStatus(sessionId: string, stepId: string, status: BuildStepStatus): boolean {
-    const { changes } = this.db.run(
-      `UPDATE build_queue_steps SET status = ?, updatedAt = ? WHERE id = ? AND sessionId = ?`,
-      [status, Date.now(), stepId, sessionId],
-    );
-    return changes > 0;
+    const now = Date.now();
+    let changed = false;
+    this.db.transaction(() => {
+      const { changes } = this.db.run(
+        `UPDATE build_queue_steps SET status = ?, updatedAt = ? WHERE id = ? AND sessionId = ?`,
+        [status, now, stepId, sessionId],
+      );
+      changed = changes > 0;
+      if (!changed) return;
+      if (status === "active" || status === "done") {
+        const row = this.db
+          .query(`SELECT position FROM build_queue_steps WHERE id = ? AND sessionId = ?`)
+          .get(stepId, sessionId) as { position: number } | null;
+        if (row) {
+          this.db.run(
+            `UPDATE build_queue_steps SET status = 'done', updatedAt = ?
+             WHERE sessionId = ? AND position < ? AND status = 'pending'`,
+            [now, sessionId, row.position],
+          );
+        }
+      }
+    })();
+    return changed;
   }
 
   /** Flip the human-curation gate for a session's queue. */

--- a/test/build-queue-reminder.test.ts
+++ b/test/build-queue-reminder.test.ts
@@ -1,0 +1,193 @@
+import { test, expect } from "bun:test";
+import {
+  BuildQueueReminderService,
+  isQueueDrifted,
+  RECONCILE_STEER,
+} from "../src/build-queue-reminder";
+import type { BuildQueue, BuildStep, BuildStepStatus, Session, SessionStatus } from "../src/types";
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+function step(position: number, status: BuildStepStatus): BuildStep {
+  return { id: `s${position}`, title: `Step ${position}`, detail: "", status, position };
+}
+
+function queue(approved: boolean, statuses: BuildStepStatus[]): BuildQueue {
+  return { sessionId: "S", approved, steps: statuses.map((st, i) => step(i, st)) };
+}
+
+function session(status: SessionStatus): Session {
+  // Only id + status are read by the service; the rest is filler to satisfy the type.
+  return { id: "S", status } as unknown as Session;
+}
+
+const THRESHOLD = 1000;
+
+/** Build a service over a single session whose status + queue are mutable between sweeps. */
+function harness(initialStatus: SessionStatus, initialQueue: BuildQueue) {
+  const state = { status: initialStatus, queue: initialQueue, t: 0 };
+  const steers: string[] = [];
+  const svc = new BuildQueueReminderService({
+    store: {
+      list: () => [session(state.status)],
+      getBuildQueue: () => state.queue,
+    } as never,
+    steer: (_id, text) => {
+      steers.push(text);
+      return true; // landed
+    },
+    now: () => state.t,
+    idleThresholdMs: THRESHOLD,
+    maxNudges: 3,
+  });
+  return { svc, state, steers };
+}
+
+/** Drive a session from running → settled idle so it nudges once (the happy path). */
+function settleAndSweep(h: ReturnType<typeof harness>): void {
+  h.state.status = "running";
+  h.svc.sweep(); // observe running → sawRunning
+  h.state.status = "idle";
+  h.svc.sweep(); // first idle tick → start timer
+  h.state.t += THRESHOLD + 1;
+  h.svc.sweep(); // settled → evaluate
+}
+
+// ── isQueueDrifted ──────────────────────────────────────────────────────────
+
+test("isQueueDrifted: approved + pending + no active → true", () => {
+  expect(isQueueDrifted(queue(true, ["pending", "pending"]))).toBe(true);
+  expect(isQueueDrifted(queue(true, ["done", "pending"]))).toBe(true);
+});
+
+test("isQueueDrifted: false when unapproved, empty, has active, or no pending", () => {
+  expect(isQueueDrifted(queue(false, ["pending"]))).toBe(false);
+  expect(isQueueDrifted(queue(true, []))).toBe(false);
+  expect(isQueueDrifted(queue(true, ["active", "pending"]))).toBe(false);
+  expect(isQueueDrifted(queue(true, ["done", "done"]))).toBe(false);
+  expect(isQueueDrifted(queue(true, ["done", "skipped"]))).toBe(false);
+});
+
+// ── sweep: happy path ───────────────────────────────────────────────────────
+
+test("reconciles drift: settled idle after running → exactly one steer, no double-steer", () => {
+  const h = harness("idle", queue(true, ["pending", "pending", "pending"]));
+  settleAndSweep(h);
+  expect(h.steers).toEqual([RECONCILE_STEER]);
+
+  // A second sweep in the SAME idle episode must not steer again.
+  h.state.t += THRESHOLD + 1;
+  h.svc.sweep();
+  expect(h.steers).toHaveLength(1);
+});
+
+// ── sweep: guards (no steer) ────────────────────────────────────────────────
+
+test("no collision with approval: drifted but never ran (sawRunning false) → no steer", () => {
+  const h = harness("idle", queue(true, ["pending", "pending"]));
+  // Never running: first idle tick, then settle — sawRunning stays false.
+  h.svc.sweep();
+  h.state.t += THRESHOLD + 1;
+  h.svc.sweep();
+  expect(h.steers).toHaveLength(0);
+});
+
+test("no waking a done session: status done + drifted → no steer", () => {
+  const h = harness("running", queue(true, ["pending", "pending"]));
+  h.svc.sweep(); // sawRunning
+  h.state.status = "done";
+  h.state.t += THRESHOLD + 1;
+  h.svc.sweep();
+  h.state.t += THRESHOLD + 1;
+  h.svc.sweep();
+  expect(h.steers).toHaveLength(0);
+});
+
+test("live gap honored: status running → no steer even when drifted", () => {
+  const h = harness("running", queue(true, ["pending", "pending"]));
+  h.svc.sweep();
+  h.state.t += THRESHOLD + 1;
+  h.svc.sweep();
+  expect(h.steers).toHaveLength(0);
+});
+
+test("not settled: first idle tick (below threshold) → no steer", () => {
+  const h = harness("running", queue(true, ["pending"]));
+  h.svc.sweep(); // running → sawRunning
+  h.state.status = "idle";
+  h.svc.sweep(); // first idle tick
+  h.state.t += THRESHOLD - 1; // still below threshold
+  h.svc.sweep();
+  expect(h.steers).toHaveLength(0);
+});
+
+test("negatives: has-active / all-done / unapproved / empty → no steer", () => {
+  for (const q of [
+    queue(true, ["active", "pending"]),
+    queue(true, ["done", "done"]),
+    queue(false, ["pending", "pending"]),
+    queue(true, []),
+  ]) {
+    const h = harness("idle", q);
+    settleAndSweep(h);
+    expect(h.steers).toHaveLength(0);
+  }
+});
+
+// ── sweep: episode reset + lifetime cap + retry ─────────────────────────────
+
+test("episode reset: re-running between idle episodes allows another steer", () => {
+  const h = harness("idle", queue(true, ["pending", "pending"]));
+  settleAndSweep(h);
+  expect(h.steers).toHaveLength(1);
+
+  // Re-activate, then settle again still drifted → a fresh episode steers again.
+  settleAndSweep(h);
+  expect(h.steers).toHaveLength(2);
+});
+
+test("lifetime cap halts repeated nudging after maxNudges", () => {
+  const h = harness("idle", queue(true, ["pending", "pending"]));
+  settleAndSweep(h); // 1
+  settleAndSweep(h); // 2
+  settleAndSweep(h); // 3
+  expect(h.steers).toHaveLength(3);
+  settleAndSweep(h); // capped
+  expect(h.steers).toHaveLength(3);
+});
+
+test("non-landing steer is retried (state not consumed)", () => {
+  const state = {
+    status: "idle" as SessionStatus,
+    queue: queue(true, ["pending", "pending"]),
+    t: 0,
+  };
+  let landed = false;
+  const steers: string[] = [];
+  const svc = new BuildQueueReminderService({
+    store: {
+      list: () => [session(state.status)],
+      getBuildQueue: () => state.queue,
+    } as never,
+    steer: (_id, text) => {
+      steers.push(text);
+      return landed; // first attempt fails to land
+    },
+    now: () => state.t,
+    idleThresholdMs: THRESHOLD,
+  });
+
+  state.status = "running";
+  svc.sweep();
+  state.status = "idle";
+  svc.sweep();
+  state.t += THRESHOLD + 1;
+  svc.sweep(); // attempt 1 — does not land
+  expect(steers).toHaveLength(1);
+
+  // Still same idle episode; because it didn't land, the episode is not marked fired.
+  landed = true;
+  state.t += 1;
+  svc.sweep(); // retry — lands now
+  expect(steers).toHaveLength(2);
+});

--- a/test/build-queue-store.test.ts
+++ b/test/build-queue-store.test.ts
@@ -93,6 +93,119 @@ test("setBuildStepStatus: true on hit, false for unknown id, false for wrong ses
   expect(s.getBuildQueue(sess1.id).steps[0]!.status).toBe("active");
 });
 
+test("forward-fill: marking a later step done auto-completes earlier pending steps", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [
+    { title: "Step A" },
+    { title: "Step B" },
+    { title: "Step C" },
+    { title: "Step D" },
+  ]);
+  const [a, b, c, d] = q.steps.map((x) => x.id);
+
+  // Agent jumps straight to marking step C done (the screenshot's under-reporting shape).
+  expect(s.setBuildStepStatus(sess.id, c!, "done")).toBe(true);
+
+  const after = s.getBuildQueue(sess.id).steps;
+  expect(after[0]!.status).toBe("done"); // A back-filled
+  expect(after[1]!.status).toBe("done"); // B back-filled
+  expect(after[2]!.status).toBe("done"); // C as posted
+  expect(after[3]!.status).toBe("pending"); // D (later) untouched
+  void a;
+  void b;
+  void d;
+});
+
+test("forward-fill: marking a later step active also back-fills earlier pending", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [
+    { title: "Step A" },
+    { title: "Step B" },
+    { title: "Step C" },
+  ]);
+  const c = q.steps[2]!.id;
+  s.setBuildStepStatus(sess.id, c, "active");
+  const after = s.getBuildQueue(sess.id).steps;
+  expect(after.map((x) => x.status)).toEqual(["done", "done", "active"]);
+});
+
+test("forward-fill: an explicitly skipped earlier step is preserved, not flipped to done", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [
+    { title: "Step A" },
+    { title: "Step B" },
+    { title: "Step C" },
+  ]);
+  const [a, b, c] = q.steps.map((x) => x.id);
+
+  // Agent explicitly skips B, then advances to C.
+  s.setBuildStepStatus(sess.id, b!, "skipped");
+  s.setBuildStepStatus(sess.id, c!, "done");
+
+  const after = s.getBuildQueue(sess.id).steps;
+  expect(after[0]!.status).toBe("done"); // A back-filled
+  expect(after[1]!.status).toBe("skipped"); // B preserved (terminal state)
+  expect(after[2]!.status).toBe("done"); // C as posted
+  void a;
+});
+
+test("forward-fill: posting skipped or pending does NOT cascade", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [
+    { title: "Step A" },
+    { title: "Step B" },
+    { title: "Step C" },
+  ]);
+  const c = q.steps[2]!.id;
+
+  s.setBuildStepStatus(sess.id, c, "skipped");
+  expect(s.getBuildQueue(sess.id).steps.map((x) => x.status)).toEqual([
+    "pending",
+    "pending",
+    "skipped",
+  ]);
+
+  // Re-asserting pending on the last step must not complete earlier ones either.
+  s.setBuildStepStatus(sess.id, c, "pending");
+  expect(s.getBuildQueue(sess.id).steps.map((x) => x.status)).toEqual([
+    "pending",
+    "pending",
+    "pending",
+  ]);
+});
+
+test("forward-fill: idempotent and never un-completes; already-done steps unchanged", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [
+    { title: "Step A" },
+    { title: "Step B" },
+    { title: "Step C" },
+  ]);
+  const [a, , c] = q.steps.map((x) => x.id);
+
+  s.setBuildStepStatus(sess.id, a!, "done"); // A done, nothing earlier
+  s.setBuildStepStatus(sess.id, c!, "done"); // back-fills B; A already done
+  const first = s.getBuildQueue(sess.id).steps.map((x) => x.status);
+  expect(first).toEqual(["done", "done", "done"]);
+
+  // Re-posting C done changes nothing further.
+  s.setBuildStepStatus(sess.id, c!, "done");
+  expect(s.getBuildQueue(sess.id).steps.map((x) => x.status)).toEqual(["done", "done", "done"]);
+});
+
+test("forward-fill: a missing target id does not cascade", () => {
+  const s = mk();
+  const sess = s.create(base);
+  s.replaceBuildQueue(sess.id, [{ title: "Step A" }, { title: "Step B" }]);
+  expect(s.setBuildStepStatus(sess.id, "no-such-id", "done")).toBe(false);
+  expect(s.getBuildQueue(sess.id).steps.map((x) => x.status)).toEqual(["pending", "pending"]);
+});
+
 test("replaceBuildQueue leaves approval untouched (self-revision must not re-gate)", () => {
   const s = mk();
   const sess = s.create(base);

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -24,6 +24,7 @@ import {
   DRAFT_PR_NOTE,
   planGoSteer,
   PREVIEW_START_STEER,
+  buildQueueDirective,
 } from "../src/service";
 import { HOUSE_RULES_TAG } from "../src/house-rules";
 import { config, parseTrimAutoContext } from "../src/config";
@@ -2852,6 +2853,22 @@ test("composeSystemPrompt omits <build-queue> block when null (1-arg backward co
   expect(composeSystemPrompt(null)).not.toContain("<build-queue>");
   expect(composeSystemPrompt(null, false)).not.toContain("<build-queue>");
   expect(composeSystemPrompt(null, true)).not.toContain("<build-queue>");
+});
+
+test("buildQueueDirective states the ordered contract that forward-fill relies on", () => {
+  const d = buildQueueDirective({
+    sessionId: "sess-1",
+    baseUrl: "http://127.0.0.1:7330",
+    token: null,
+    autopilot: true,
+  });
+  // The ordered contract + server auto-completion of earlier steps.
+  expect(d).toContain("IN ORDER");
+  expect(d).toMatch(/automatically completes any earlier steps/);
+  // Immediacy: update as you go, not batched.
+  expect(d).toContain("never batch the updates at the end");
+  // The reconcile-reminder heads-up.
+  expect(d).toMatch(/reminder to reconcile/);
 });
 
 test("composeSystemPrompt places <build-queue> after <autopilot-directive>", () => {


### PR DESCRIPTION
## Problem

Build-queue step status was **100% agent self-reported** (`curl POST .../queue/steps/:id`, handler `postBuildStepStatus`) with **no reconciliation**. An agent that authored a queue then under-reported left it stuck "all PENDING" while real work raced ahead — the reported symptom (queue showed Tasks 1–N pending while the agent was already past Task 7B).

## Fix — three layers, by priority

1. **Forward-fill (primary, deterministic, server-side, zero agent compliance).** The directive's contract is ordered execution, so when a step is advanced to `active`/`done`, `store.setBuildStepStatus` auto-completes every *earlier* still-`pending` step in the **same transaction**. One post reconciles everything before it — fixes the common "marked a later step, earlier ones pending" drift instantly, with no PTY re-activation. Monotonic & idempotent (only `pending → done`, only earlier positions; never un-completes, never touches later/`skipped` steps); a silently jumped-over step becomes `done` (the agent has explicit `skipped` if it means otherwise).

2. **Settled-idle nudge (backstop) — new `BuildQueueReminderService`.** Covers the shape forward-fill can't: an agent that posted *nothing at all*. When such a session settles idle, one `RECONCILE_STEER` asks it to post its progress (which then forward-fills). Guards: **idle-only** (never wake a `done`/`running` session → no autopilot continuation / PR attempts), **`sawRunning` evidence gate** (an approved+all-pending queue is indistinguishable from just-approved, so we only nudge after observing real work — avoids colliding with the APPROVE_STEER "Begin now"), once-per-idle-episode + per-session lifetime cap, and land-aware retry on a dead pane.

3. **Prompt hardening (reinforcement only).** `buildQueueDirective` now states the ordered contract + immediacy. Explicitly *not* relied upon — the directive already instructed per-step updates and the agent ignored them, so correctness rests on forward-fill (layer 1), not on re-asking.

## Scope (operator-signed-off)

One narrow case is intentionally **out of scope**: an agent that reports nothing while running **continuously** (never settles). Forward-fill needs ≥1 post; the nudge needs a settle. The only live fix for that is tool-activity→step inference — the fragile identity-mapping problem deliberately rejected during planning.

## Tests

- `test/build-queue-store.test.ts` — forward-fill cascade: later `active`/`done` back-fills earlier `pending`; `skipped` preserved; `skipped`/`pending` posts don't cascade; later/already-`done` untouched; idempotent; missing target doesn't cascade.
- `test/build-queue-reminder.test.ts` — sweep guards: reconciles drift with exactly one steer (no double-steer same episode); no steer on `sawRunning=false` / `done` / `running` / has-`active` / all-`done` / unapproved / empty / first-idle-tick; episode reset after `running`; lifetime cap; non-landing retry.
- `test/service.test.ts` — directive states the ordered contract + reminder heads-up.

Server-only; no UI/i18n surface (`fix`, not `feat`). Full root suite, `bun run lint`, and `bunx tsc --noEmit` green; fallow audit clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)