### PR TITLE
feat(site): surface /commands portability + visual plans/recaps on landing

### DIFF
--- a/site/src/components/FeatureGrid.astro
+++ b/site/src/components/FeatureGrid.astro
@@ -1,6 +1,9 @@
 ---
-// Six-card feature grid. Copy is faithful to README "Opinionated by design" +
-// intro — describes what ships, no invented capabilities.
+// Eight-card feature grid. Copy is faithful to the README "Opinionated by
+// design" + intro and the feature-announcement catalog
+// (ui/src/lib/feature-announcements.ts) — describes what ships, no invented
+// capabilities. Body text is rendered verbatim (no markdown), so copy stays
+// plain prose with no backticks.
 interface Feature {
   title: string;
   body: string;
@@ -12,12 +15,20 @@ const features: Feature[] = [
     body: "Spawn, watch, and steer a herd of real claude sessions in isolated git worktrees, from your browser or phone.",
   },
   {
+    title: "Your /commands come with you",
+    body: "Because each session is a genuine interactive claude against your own ~/.claude, every slash command, skill, and plugin you use locally is available — type / in New Task to pick from your actual commands. The cloud Claude Code can't carry that.",
+  },
+  {
     title: "Readiness",
     body: "Scores a JS/TS repo's guardrails — typecheck, lint, tests, CI, house rules — before you point agents at it, turning gaps into an install task.",
   },
   {
     title: "Plan gate",
     body: "Before an autonomous run, the agent writes a plan a separate read-only reviewer grills adversarially; only a plan that survives review is released to implement.",
+  },
+  {
+    title: "Visual plans & recaps",
+    body: "Plan-gate plans render as a scannable document — file trees, diagrams, data models — not a wall of text. When a session finishes, its recap does the same: a tree of what changed, the annotated diff, and toned callouts.",
   },
   {
     title: "Critic",

--- a/site/src/components/FeatureGrid.astro
+++ b/site/src/components/FeatureGrid.astro
@@ -16,7 +16,7 @@ const features: Feature[] = [
   },
   {
     title: "Your /commands come with you",
-    body: "Because each session is a genuine interactive claude against your own ~/.claude, every slash command, skill, and plugin you use locally is available — type / in New Task to pick from your actual commands. The cloud Claude Code can't carry that.",
+    body: "Every slash command, skill, and plugin you use locally is available — each session is a genuine interactive claude against your own ~/.claude. The cloud Claude Code can't carry that.",
   },
   {
     title: "Readiness",


### PR DESCRIPTION
## What

Reviewed releases **v1.32.0 → v1.34.0** against the live `shepherd.run` landing page and refreshed it to reflect them. The page's copy was already factually current (install command, OS matrix, auth/footing B, all five gates), so this is a small, targeted addition: **two new cards in the feature grid** (6 → 8).

| # | Card | |
|---|------|---|
| 2 | **Your /commands come with you** | Your local slash commands, skills, and plugins work because each session is a genuine interactive `claude` against your own `~/.claude` — a differentiator vs. cloud Claude Code (documented in README, never surfaced on the page). |
| 5 | **Visual plans & recaps** | v1.34.0 (#773/#799): plan-gate plans and session recaps render as scannable visual documents (file trees, diagrams, data models, annotated diff, toned callouts). |

## Why these two

The user was offered four candidates and explicitly picked these two. **Herd rundown** (v1.32.0, #693/#700) is also new/demoable/absent but was deliberately not selected — recorded as a conscious exclusion, easy to add later.

## Notes

- Copy is **backtick-free**: `FeatureGrid.astro` renders title/body as verbatim text (no markdown/`set:html`), matching the existing grid style — so backticks would render literally. Header comment updated (count 6→8 + provenance now credits the feature-announcement catalog for the visual-plans card, which has no README mention).
- Diff is limited to `site/src/components/FeatureGrid.astro`.
- `site/` is exempt from the app's i18n / glossary / feature-catalog gates (it rides its own `shepherd-site` repo) — no catalog work needed.

## Verification

- `cd site && bun run build` ✓
- Rendered `dist/index.html`: 8 cards, 0 literal backticks, both new cards present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)