### PR TITLE
fix(task): base new tasks off the repo default branch, not the current checkout

### DIFF
--- a/src/branches.ts
+++ b/src/branches.ts
@@ -3,10 +3,13 @@ import { execFileSync } from "./instrument";
 export interface BranchList {
   branches: string[];
   current: string | null;
+  /** Repo default branch (`origin/HEAD` symref, `origin/` stripped); null when unset. */
+  default: string | null;
 }
 
 /**
- * Local branches of a git repo, most-recently-committed first, plus the current branch.
+ * Local branches of a git repo, most-recently-committed first, plus the current branch and
+ * the repo's default branch (the base a new task should prefer).
  * Returns empty list for non-git dirs (caller falls back to a free-text branch field).
  */
 export function listBranches(repoDir: string): BranchList {
@@ -22,7 +25,7 @@ export function listBranches(repoDir: string): BranchList {
       .map((s) => s.trim())
       .filter(Boolean);
   } catch {
-    return { branches: [], current: null };
+    return { branches: [], current: null, default: null };
   }
   let current: string | null = null;
   try {
@@ -33,5 +36,20 @@ export function listBranches(repoDir: string): BranchList {
   } catch {
     /* detached HEAD or other — leave null */
   }
-  return { branches, current };
+  // Repo default branch from the local origin/HEAD symref (no network). Resolved fresh per
+  // call — /api/branches is not hot, and a cached value would go stale if origin/HEAD moves.
+  let def: string | null = null;
+  try {
+    def =
+      execFileSync("git", ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], {
+        cwd: repoDir,
+        stdio: "pipe",
+      })
+        .toString()
+        .trim()
+        .replace(/^origin\//, "") || null;
+  } catch {
+    /* origin/HEAD unset — leave null; caller falls back to current */
+  }
+  return { branches, current, default: def };
 }

--- a/test/branches.test.ts
+++ b/test/branches.test.ts
@@ -54,3 +54,19 @@ test("non-git dir → empty list, null current", () => {
     rmSync(plain, { recursive: true, force: true });
   }
 });
+
+test("resolves the repo default branch from the origin/HEAD symref", () => {
+  // Point origin/HEAD at a non-current branch (target ref need not exist to be read).
+  execFileSync("git", ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/dev"], {
+    cwd: repo,
+    env: GIT_ENV,
+  });
+  const r = listBranches(repo);
+  expect(r.default).toBe("dev");
+  expect(r.current).toBe("main");
+});
+
+test("default is null when origin/HEAD is unset", () => {
+  const r = listBranches(repo);
+  expect(r.default).toBeNull();
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -367,12 +367,26 @@ export async function listDirs(path?: string): Promise<DirListing> {
   return r.json();
 }
 
-export async function listBranches(
-  repoPath: string,
-): Promise<{ branches: string[]; current: string | null }> {
+export interface BranchList {
+  branches: string[];
+  current: string | null;
+  /** Repo default branch (`origin/HEAD`); null when unset. */
+  default: string | null;
+}
+
+export async function listBranches(repoPath: string): Promise<BranchList> {
   const r = await fetch(`/api/branches?repo=${encodeURIComponent(repoPath)}`);
   if (!r.ok) throw await failed(r, "branches");
   return r.json();
+}
+
+/**
+ * The base branch a new task should default to: the repo default branch (origin/HEAD),
+ * falling back to the current checkout, then the most-recent branch, then "main".
+ * Single source for every New Task / quick-launch / merge-train spawn site.
+ */
+export function pickBaseBranch(b: BranchList | null | undefined): string {
+  return b?.default ?? b?.current ?? b?.branches?.[0] ?? "main";
 }
 
 export async function branchStatus(

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -757,4 +757,25 @@ describe("NewTask base branch default", () => {
     await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
     expect(onsubmit.mock.calls[0]![0]).toMatchObject({ baseBranch: "dev" });
   });
+
+  // The default branch (origin/HEAD) need not exist locally — surface it as an option so
+  // the dropdown's shown value matches the submitted base (not a silently-mismatched first
+  // option). Here `dev` is the default but only `main` exists locally.
+  it("includes a non-local default branch as a selectable option", async () => {
+    mockListBranches.mockResolvedValue({
+      current: "main",
+      branches: ["main"],
+      default: "dev",
+    });
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: "/repo/nonlocal-default" } });
+
+    await expect.poll(() => baseSelect().value).toBe("dev");
+    const options = Array.from(baseSelect().options).map((o) => o.value);
+    expect(options).toContain("dev");
+    await fillAndSubmit();
+
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({ baseBranch: "dev" });
+  });
 });

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -76,7 +76,7 @@ beforeEach(() => {
   mockGetTodo.mockResolvedValue({ exists: false, content: "" });
   mockListIssues.mockResolvedValue({ slug: null, webUrl: null, issues: [], viewer: null });
   mockGetEpics.mockResolvedValue([]);
-  mockListBranches.mockResolvedValue({ current: "main", branches: ["main"] });
+  mockListBranches.mockResolvedValue({ current: "main", branches: ["main"], default: null });
   mockGetRepoConfig.mockResolvedValue(repoConfig(false));
   mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
   // Default: up to date — no hint rendered
@@ -724,5 +724,37 @@ describe("NewTask upstream status hint", () => {
     // Give the debounce time to fire and resolve
     await new Promise((r) => setTimeout(r, 600));
     expect(document.querySelector(".nt-upstream")).toBeNull();
+  });
+});
+
+describe("NewTask base branch default", () => {
+  const submitBtn = () => document.querySelector<HTMLButtonElement>("button.run")!;
+  const baseSelect = () => document.querySelector<HTMLSelectElement>("#nt-base")!;
+
+  async function fillAndSubmit() {
+    const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    promptField.value = "do the thing";
+    promptField.dispatchEvent(new Event("input", { bubbles: true }));
+    await expect.poll(() => submitBtn().disabled).toBe(false);
+    submitBtn().click();
+  }
+
+  // Regression: the base must prefer the repo default branch (origin/HEAD) over the
+  // currently-checked-out branch. flowagent sits on `main` but defaults to `dev`; basing
+  // on `main` is what made the plan reviewer ground on a stale branch (TASK-581).
+  it("preselects the repo default branch over the current checkout", async () => {
+    mockListBranches.mockResolvedValue({
+      current: "main",
+      branches: ["main", "dev"],
+      default: "dev",
+    });
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: "/repo/default-pref" } });
+
+    await expect.poll(() => baseSelect().value).toBe("dev");
+    await fillAndSubmit();
+
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({ baseBranch: "dev" });
   });
 });

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -3,6 +3,7 @@
   import {
     listRepos,
     listBranches,
+    pickBaseBranch,
     branchStatus,
     getCommands,
     getEpics,
@@ -234,11 +235,11 @@
         if (rp !== repoPath) return;
         branches = b.branches;
         // Preserve a relaunch-seeded base on the initial repo's first load;
-        // once consumed (or on any other repo) use the repo's current branch.
+        // once consumed (or on any other repo) prefer the repo's default branch.
         if (seededBase && rp === initialRepoPath) {
           seededBase = false;
         } else {
-          baseBranch = b.current ?? b.branches[0] ?? "main";
+          baseBranch = pickBaseBranch(b);
         }
       })
       .catch(() => {

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -142,6 +142,10 @@
   // Echoed on the submit button so the destination repo is visible at commit time.
   const selectedRepoName = $derived(repos.find((r) => r.path === repoPath)?.name ?? "");
   let branches = $state<string[]>([]);
+  // The base selected by pickBaseBranch (the repo default / origin/HEAD) need not be a
+  // LOCAL branch — a fresh clone may have `dev` only as `origin/dev`. Surface it as an
+  // option so the dropdown's shown value matches the base actually submitted.
+  let baseOptions = $derived(branches.includes(baseBranch) ? branches : [baseBranch, ...branches]);
   let upstream = $state<{
     behind: number;
     ahead: number;
@@ -730,7 +734,7 @@
     <label class="micro" for="nt-base">{m.newtask_branch_label()}</label>
     {#if branches.length > 0}
       <select id="nt-base" bind:value={baseBranch}>
-        {#each branches as b (b)}
+        {#each baseOptions as b (b)}
           <option value={b}>{b}</option>
         {/each}
       </select>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -25,6 +25,7 @@
     getBacklog,
     getSettings,
     listBranches,
+    pickBaseBranch,
     approveLearning,
     dismissLearning,
     distillRepo,
@@ -515,7 +516,7 @@
       return;
     }
     const br = await listBranches(repoPath).catch(() => null);
-    const baseBranch = br?.current ?? br?.branches[0] ?? "main";
+    const baseBranch = pickBaseBranch(br);
     try {
       const s = await createSession({
         repoPath,
@@ -563,7 +564,7 @@
       otherRepoCount,
       run: async () => {
         const br = await listBranches(repoPath).catch(() => null);
-        const baseBranch = br?.current ?? br?.branches[0] ?? "main";
+        const baseBranch = pickBaseBranch(br);
         try {
           const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs));
           selectedId = s.id;
@@ -592,7 +593,7 @@
       otherRepoCount: 0,
       run: async () => {
         const br = await listBranches(repoPath).catch(() => null);
-        const baseBranch = br?.current ?? br?.branches[0] ?? "main";
+        const baseBranch = pickBaseBranch(br);
         try {
           const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs, true));
           selectedId = s.id;


### PR DESCRIPTION
## Problem (TASK-581)

The Plan reviewer kept flagging "commits that don't exist or don't make sense." Root cause: a task's base branch was wrong.

New Task derived the base from the repo's **currently-checked-out local branch** (`current ?? branches[0] ?? "main"`), not the repo's **default branch**. For Flow Agent the local checkout sits on `main` while the repo default is `dev`, and `origin/main` is **2 commits behind `origin/dev`**. So TASK-581 was recorded with `baseBranch=main`; its branch is actually identical to `dev`, and diffed against `main` it shows 2 phantom (dev-only) commits the author never wrote.

Every consumer (plan-gate grounding, critic `diffBase`, worktree cut-point, diff, PR base) reads the single `session.baseBranch` — so the agents were already *consistent*; the **value** chosen at creation was wrong. It also diverged from where `gh pr create` targets (the repo default), so the reviewer base and the eventual PR base disagreed.

## Fix

- **`src/branches.ts`**: `BranchList` gains `default`, resolved from the local `origin/HEAD` symref (no network, fresh per call — no module-level cache).
- **`ui/src/lib/api.ts`**: single shared `pickBaseBranch(b)` = `default ?? current ?? branches[0] ?? "main"`, replacing the copy-pasted chain that let one of four spawn sites drift.
- Wired into **all four** sites: `NewTask.svelte` + `+page.svelte` (quick-issue, merge-train run, hand-picked merge-train).
- **Tests**: `branches.ts` symref set/unset cases; `NewTask.browser.test.ts` regression pinning default-branch preference over the current checkout.

## Note on the silent default

Only the New Task dialog has a base dropdown to override; the quick-issue and both merge-train launchers apply the default with no override UI. This is intended (the default branch is the correct base), flagged so it isn't read as an oversight.

## Remediation done out-of-band

TASK-581's stored `baseBranch` was patched `main → dev` directly in the live DB. ⚠️ The running shepherd server holds sessions in memory — **restart shepherd** (or relaunch the session) before re-triggering the plan review, or it will still use the stale in-memory `main`.

## Verification

- root: `bun run lint` ✓ · `tsc --noEmit` ✓ · `bun test ./test` 3889 pass / 0 fail
- ui: `bun run check` 0 errors ✓ · `bun run test` 1696 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)