### PR TITLE
feat: usage-aware task holding (Part A of #825)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -445,6 +445,14 @@ export const config = {
   // 0/unset = disabled. Suggested when enabled: 1800000 (30 min). No auto-wake; the
   // operator/agent restarts the dev server manually afterward.
   previewIdleStopMs: Math.max(0, Number(process.env.SHEPHERD_PREVIEW_IDLE_STOP_MS ?? 0) || 0),
+  // Usage-aware task holding: when usage is at or above holdPct, newly submitted tasks
+  // are queued in held_tasks rather than spawned immediately. Released by the 30s sweeper
+  // once usage drops back below the threshold. Default ON; set SHEPHERD_USAGE_HOLD_ENABLED=0
+  // to disable. holdPct: [0,100], default 80.
+  usageHoldEnabled: !["0", "false"].includes(
+    (process.env.SHEPHERD_USAGE_HOLD_ENABLED ?? "").toLowerCase(),
+  ),
+  usageHoldPct: clampCap(Number(process.env.SHEPHERD_USAGE_HOLD_PCT ?? 80), 0, 100, 80),
 };
 
 // Session housekeeping retention thresholds (the daily sweep's policy). The single

--- a/src/held-release.ts
+++ b/src/held-release.ts
@@ -46,6 +46,10 @@ export async function releaseHeldTasks(
       released++;
     } catch (err) {
       console.warn("[held] spawn failed for task", task.id, err);
+      // Head-of-line blocking: a task whose service.create throws (e.g. repo deleted
+      // between hold and release) stays at the queue head and re-blocks every tick
+      // until the operator explicitly discards it via the TopBar held-tasks popover.
+      // The discard action is the escape hatch — there is no automatic skip.
       break; // on failure, leave the row and stop — don't lose or skip remaining tasks
     }
   }

--- a/src/held-release.ts
+++ b/src/held-release.ts
@@ -11,7 +11,7 @@ import type { CreateSessionInput } from "./types";
 import type { UsageLimits } from "./usage-limits";
 
 export interface HeldReleaseDeps {
-  store: Pick<SessionStore, "listHeldTasks" | "removeHeldTask" | "countHeldTasks" | "list">;
+  store: Pick<SessionStore, "listHeldTasks" | "removeHeldTask" | "countHeldTasks">;
   service: { create(input: CreateSessionInput): Promise<unknown> };
   usageLimits: { limits(now: number): UsageLimits };
   events: { emit(event: string, data: unknown): void };

--- a/src/held-release.ts
+++ b/src/held-release.ts
@@ -1,0 +1,58 @@
+/**
+ * Auto-release sweeper for usage-aware task holding (#825).
+ *
+ * When called from the 30s tick, drains held_tasks FIFO whenever usage has
+ * dropped below the configured threshold. If disabled, tasks are released
+ * regardless of current usage (they were held while enabled; disabled means
+ * the operator no longer wants the gate — release everything).
+ */
+import type { SessionStore } from "./store";
+import type { CreateSessionInput } from "./types";
+import type { UsageLimits } from "./usage-limits";
+
+export interface HeldReleaseDeps {
+  store: Pick<SessionStore, "listHeldTasks" | "removeHeldTask" | "countHeldTasks" | "list">;
+  service: { create(input: CreateSessionInput): Promise<unknown> };
+  usageLimits: { limits(now: number): UsageLimits };
+  events: { emit(event: string, data: unknown): void };
+}
+
+/**
+ * Releases held tasks FIFO when usage has dropped below holdPct. Bounded per call.
+ *
+ * When `cfg.enabled` is false the threshold is ignored and held tasks are released
+ * unconditionally — the operator turned the gate off, so nothing should remain blocked.
+ */
+export async function releaseHeldTasks(
+  deps: HeldReleaseDeps,
+  cfg: { enabled: boolean; holdPct: number },
+  now: number,
+  maxPerTick = 3,
+): Promise<{ released: number }> {
+  if (cfg.enabled) {
+    const lim = deps.usageLimits.limits(now);
+    const maxPct = Math.max(lim.session5h?.pct ?? 0, lim.week?.pct ?? 0);
+    if (maxPct >= cfg.holdPct) return { released: 0 };
+  }
+
+  const tasks = deps.store.listHeldTasks();
+  let released = 0;
+
+  for (const task of tasks) {
+    if (released >= maxPerTick) break;
+    try {
+      await deps.service.create(task.input);
+      deps.store.removeHeldTask(task.id);
+      released++;
+    } catch (err) {
+      console.warn("[held] spawn failed for task", task.id, err);
+      break; // on failure, leave the row and stop — don't lose or skip remaining tasks
+    }
+  }
+
+  if (released > 0) {
+    deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
+  }
+
+  return { released };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1140,14 +1140,26 @@ setInterval(runDailySweep, 24 * 60 * 60 * 1000);
 // recompute live limit % from local JSONL ~every 30s; push to clients
 attachUsagePush(events, store, push);
 attachCreditsPush(events, store, push);
+// Re-entrancy guard: a release can still be awaiting service.create() when the next
+// 30s tick fires; without this a second tick re-reads the not-yet-removed head task and
+// double-spawns it (or errors with agent_name_taken). Mirrors the `calibrating` flag below.
+let releasingHeld = false;
 setInterval(async () => {
   await accountIndex.refresh(Date.now());
   events.emit("usage:limits", usageLimits.limits(Date.now()));
-  await releaseHeldTasks(
-    { store, service, usageLimits, events },
-    { enabled: config.usageHoldEnabled, holdPct: config.usageHoldPct },
-    Date.now(),
-  ).catch((e) => console.warn("[held] release failed:", e));
+  if (releasingHeld) return; // prior release still draining — skip this tick's release
+  releasingHeld = true;
+  try {
+    await releaseHeldTasks(
+      { store, service, usageLimits, events },
+      { enabled: config.usageHoldEnabled, holdPct: config.usageHoldPct },
+      Date.now(),
+    );
+  } catch (e) {
+    console.warn("[held] release failed:", e);
+  } finally {
+    releasingHeld = false;
+  }
 }, 30_000);
 
 // calibrate the per-window caps daily (and once on startup) by scraping `/usage`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ import { HerdDigestService } from "./herd-digest";
 import { readSnapshot, isStalled, DEFAULT_STALL } from "./stall";
 import { jsonlPathFor } from "./usage";
 import { verifyApiKey } from "./verify-key";
+import { releaseHeldTasks } from "./held-release";
 
 const execFileAsync = promisify(execFile);
 
@@ -164,6 +165,15 @@ const savedEcc = store.getSetting("extra_credits_drain_ceiling");
 if (savedEcc !== null) {
   const n = Number(savedEcc);
   if (Number.isFinite(n) && n >= 0) config.extraCreditsDrainCeiling = n;
+}
+
+// Usage-aware task holding: restore persisted operator overrides on restart.
+const savedUhe = store.getSetting("usageHoldEnabled");
+if (savedUhe !== null) config.usageHoldEnabled = savedUhe === "1";
+const savedUhp = store.getSetting("usageHoldPct");
+if (savedUhp !== null) {
+  const n = Number(savedUhp);
+  if (Number.isFinite(n)) config.usageHoldPct = Math.min(100, Math.max(0, Math.floor(n)));
 }
 
 // ── preview port range startup validation (hard-fail) ──────────────────────
@@ -1133,6 +1143,11 @@ attachCreditsPush(events, store, push);
 setInterval(async () => {
   await accountIndex.refresh(Date.now());
   events.emit("usage:limits", usageLimits.limits(Date.now()));
+  await releaseHeldTasks(
+    { store, service, usageLimits, events },
+    { enabled: config.usageHoldEnabled, holdPct: config.usageHoldPct },
+    Date.now(),
+  ).catch((e) => console.warn("[held] release failed:", e));
 }, 30_000);
 
 // calibrate the per-window caps daily (and once on startup) by scraping `/usage`.

--- a/src/server.ts
+++ b/src/server.ts
@@ -113,6 +113,8 @@ import { validateHookEvent, type HookEvent, type SubagentEntry } from "./hooks-i
 import { fingerprintDiffCount } from "./rundown-core";
 import { quotaBlockReason } from "./blocked";
 import { upstreamStatus } from "./upstream-status";
+import { shouldHold } from "./usage-hold";
+import { randomUUID } from "node:crypto";
 
 const UI_DIR = join(import.meta.dir, "..", "ui", "build");
 
@@ -1135,6 +1137,36 @@ async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response 
   const body = await req.json().catch(() => null);
   const result = validateCreate(body, config.repoRoot);
   if (!result.ok) return json({ error: result.error }, 400);
+
+  // ── usage-aware hold gate ──────────────────────────────────────────────────
+  const force = !!(
+    body &&
+    typeof body === "object" &&
+    (body as Record<string, unknown>).force === true
+  );
+  const lim = deps.usageLimits.limits(Date.now());
+  const s5h = lim.session5h?.pct ?? 0;
+  const week = lim.week?.pct ?? 0;
+  const running = deps.store
+    .list({ activeOnly: true })
+    .filter((x) => x.status === "running").length;
+  if (
+    shouldHold({
+      enabled: config.usageHoldEnabled,
+      holdPct: config.usageHoldPct,
+      session5hPct: s5h,
+      weekPct: week,
+      activeSessionCount: running,
+      force,
+    })
+  ) {
+    const id = randomUUID();
+    const createdAt = Date.now();
+    deps.store.addHeldTask({ id, repoPath: result.value.repoPath, input: result.value, createdAt });
+    deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
+    return json({ held: true, id, count: deps.store.countHeldTasks() }, 200);
+  }
+
   let s;
   try {
     s = await deps.service.create(result.value);
@@ -2531,6 +2563,9 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       authMode: config.authMode,
       // whether an apiKeyHelper script is configured; NEVER expose the key or path.
       hasApiKey: config.authApiKeyHelperPath !== null,
+      // usage-aware task holding
+      usageHoldEnabled: config.usageHoldEnabled,
+      usageHoldPct: config.usageHoldPct,
     });
   }
   if (req.method === "PUT") {
@@ -2558,6 +2593,8 @@ const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response]
   ["extraCreditsDrainCeiling", putExtraCreditsDrainCeiling],
   ["authMode", putAuthMode],
   ["anthropicApiKey", putAnthropicApiKey],
+  ["usageHoldEnabled", putUsageHoldEnabled],
+  ["usageHoldPct", putUsageHoldPct],
 ];
 
 function putRemoteControl(value: unknown, deps: Ctx["deps"]): Response {
@@ -2653,6 +2690,25 @@ function putAnthropicApiKey(value: unknown, deps: Ctx["deps"]): Response {
   }
 }
 
+function putUsageHoldEnabled(value: unknown, deps: Ctx["deps"]): Response {
+  if (typeof value !== "boolean") {
+    return json({ error: "usageHoldEnabled must be a boolean" }, 400);
+  }
+  config.usageHoldEnabled = value;
+  deps.store.setSetting("usageHoldEnabled", value ? "1" : "0");
+  return json({ usageHoldEnabled: config.usageHoldEnabled });
+}
+
+function putUsageHoldPct(value: unknown, deps: Ctx["deps"]): Response {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return json({ error: "usageHoldPct must be a number" }, 400);
+  }
+  const n = Math.min(100, Math.max(0, Math.floor(value)));
+  config.usageHoldPct = n;
+  deps.store.setSetting("usageHoldPct", String(n));
+  return json({ usageHoldPct: config.usageHoldPct });
+}
+
 function putRepoRoot(value: unknown, deps: Ctx["deps"]): Response {
   const root = validateRoot(value, config.rootCeiling);
   if (!root) {
@@ -2710,6 +2766,43 @@ async function handleBroadcast({ req, parts, deps }: Ctx): Promise<Response | nu
       return json(deps.service.broadcast(parsed.ids, parsed.text));
     }
   }
+  return null;
+}
+
+// ── /api/held — usage-hold queue management ──────────────────────────────────
+async function handleHeld({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (parts[0] !== "api" || parts[1] !== "held") return null;
+
+  // GET /api/held — list held tasks FIFO
+  if (req.method === "GET" && !parts[2]) {
+    return json(deps.store.listHeldTasks());
+  }
+
+  // POST /api/held/:id/spawn — release one held task immediately
+  if (req.method === "POST" && parts[2] && parts[3] === "spawn" && !parts[4]) {
+    const h = deps.store.getHeldTask(parts[2]);
+    if (!h) return json({ error: "not found" }, 404);
+    let s;
+    try {
+      s = await deps.service.create(h.input);
+    } catch (e) {
+      if (e instanceof SandboxAutoRefused) return json({ error: e.holdReason }, 403);
+      const msg = e instanceof Error ? e.message : "create failed";
+      const taken = /agent_name_taken/.test(msg);
+      return json({ error: taken ? "task name already in use, retry" : msg }, taken ? 409 : 502);
+    }
+    deps.store.removeHeldTask(h.id);
+    deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
+    return json(s, 201);
+  }
+
+  // DELETE /api/held/:id — discard a held task
+  if (req.method === "DELETE" && parts[2] && !parts[3]) {
+    deps.store.removeHeldTask(parts[2]);
+    deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
+    return json({ ok: true });
+  }
+
   return null;
 }
 
@@ -4059,6 +4152,7 @@ const ROUTE_HANDLERS = [
   handleSteers,
   handleProjectIcons,
   handleBroadcast,
+  handleHeld,
   handleHalt,
   handleFsDirs,
   handleBranches,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import type { SessionStore, RepoConfig } from "./store";
 import type { SessionService } from "./service";
+import type { CreateSessionInput } from "./types";
 import type { EventHub } from "./events";
 import { PtyBridge } from "./pty-bridge";
 import {
@@ -1129,16 +1130,18 @@ export async function claimLinkedIssue(forge: GitForge | null, issueNumber: numb
   }
 }
 
-// POST /api/sessions — create a session.
-async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response | null> {
-  if (!(req.method === "POST" && !parts[2])) return null;
-  const ctErr = requireJsonContentType(req);
-  if (ctErr) return ctErr;
-  const body = await req.json().catch(() => null);
-  const result = validateCreate(body, config.repoRoot);
-  if (!result.ok) return json({ error: result.error }, 400);
+/** Map a service.create() error to the appropriate Response.
+ *  SandboxAutoRefused → 403; agent_name_taken → 409; anything else → 502. */
+function createErrorResponse(e: unknown): Response {
+  if (e instanceof SandboxAutoRefused) return json({ error: e.holdReason }, 403);
+  const msg = e instanceof Error ? e.message : "create failed";
+  const taken = /agent_name_taken/.test(msg);
+  return json({ error: taken ? "task name already in use, retry" : msg }, taken ? 409 : 502);
+}
 
-  // ── usage-aware hold gate ──────────────────────────────────────────────────
+/** Check hold gate; if triggered, persist the held task and return the 200 response.
+ *  Returns null when the task should proceed to normal creation. */
+function tryHoldNewTask(body: unknown, value: CreateSessionInput, deps: AppDeps): Response | null {
   const force = !!(
     body &&
     typeof body === "object" &&
@@ -1151,7 +1154,7 @@ async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response 
     .list({ activeOnly: true })
     .filter((x) => x.status === "running").length;
   if (
-    shouldHold({
+    !shouldHold({
       enabled: config.usageHoldEnabled,
       holdPct: config.usageHoldPct,
       session5hPct: s5h,
@@ -1159,28 +1162,35 @@ async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response 
       activeSessionCount: running,
       force,
     })
-  ) {
-    const id = randomUUID();
-    const createdAt = Date.now();
-    deps.store.addHeldTask({ id, repoPath: result.value.repoPath, input: result.value, createdAt });
-    deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
-    return json({ held: true, id, count: deps.store.countHeldTasks() }, 200);
-  }
+  )
+    return null;
+  const id = randomUUID();
+  const createdAt = Date.now();
+  deps.store.addHeldTask({ id, repoPath: value.repoPath, input: value, createdAt });
+  deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
+  return json({ held: true, id, count: deps.store.countHeldTasks() }, 200);
+}
+
+// POST /api/sessions — create a session.
+async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(req.method === "POST" && !parts[2])) return null;
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+  const body = await req.json().catch(() => null);
+  const result = validateCreate(body, config.repoRoot);
+  if (!result.ok) return json({ error: result.error }, 400);
+
+  // ── usage-aware hold gate ──────────────────────────────────────────────────
+  const held = tryHoldNewTask(body, result.value, deps);
+  if (held) return held;
 
   let s;
   try {
     s = await deps.service.create(result.value);
   } catch (e) {
-    // A sandbox auto-gate refusal is a POLICY decision, not infra failure — return 403
-    // with the hold reason so the dialog shows "auto requires the autonomous profile"
-    // rather than a misleading 502.
-    if (e instanceof SandboxAutoRefused) return json({ error: e.holdReason }, 403);
     // create shells out to herdr (and git); surface the real reason instead of a
-    // bare 500 so the New Task dialog can show it. 409 ⇒ a name still collided
-    // (a slip past uniqueName under a race), anything else ⇒ 502 (herdr/git failed).
-    const msg = e instanceof Error ? e.message : "create failed";
-    const taken = /agent_name_taken/.test(msg);
-    return json({ error: taken ? "task name already in use, retry" : msg }, taken ? 409 : 502);
+    // bare 500 so the New Task dialog can show it.
+    return createErrorResponse(e);
   }
   deps.events.emit("session:new", s);
   // A human linked an issue: stamp the drain claim so the board reflects it's being
@@ -2770,38 +2780,43 @@ async function handleBroadcast({ req, parts, deps }: Ctx): Promise<Response | nu
 }
 
 // ── /api/held — usage-hold queue management ──────────────────────────────────
+
+function heldList(deps: AppDeps): Response {
+  return json(deps.store.listHeldTasks());
+}
+
+async function heldSpawn(id: string, deps: AppDeps): Promise<Response> {
+  const h = deps.store.getHeldTask(id);
+  if (!h) return json({ error: "not found" }, 404);
+  let s;
+  try {
+    s = await deps.service.create(h.input);
+  } catch (e) {
+    return createErrorResponse(e);
+  }
+  deps.store.removeHeldTask(h.id);
+  deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
+  return json(s, 201);
+}
+
+function heldDiscard(id: string, deps: AppDeps): Response {
+  deps.store.removeHeldTask(id);
+  deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
+  return json({ ok: true });
+}
+
 async function handleHeld({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (parts[0] !== "api" || parts[1] !== "held") return null;
 
   // GET /api/held — list held tasks FIFO
-  if (req.method === "GET" && !parts[2]) {
-    return json(deps.store.listHeldTasks());
-  }
+  if (req.method === "GET" && !parts[2]) return heldList(deps);
 
   // POST /api/held/:id/spawn — release one held task immediately
-  if (req.method === "POST" && parts[2] && parts[3] === "spawn" && !parts[4]) {
-    const h = deps.store.getHeldTask(parts[2]);
-    if (!h) return json({ error: "not found" }, 404);
-    let s;
-    try {
-      s = await deps.service.create(h.input);
-    } catch (e) {
-      if (e instanceof SandboxAutoRefused) return json({ error: e.holdReason }, 403);
-      const msg = e instanceof Error ? e.message : "create failed";
-      const taken = /agent_name_taken/.test(msg);
-      return json({ error: taken ? "task name already in use, retry" : msg }, taken ? 409 : 502);
-    }
-    deps.store.removeHeldTask(h.id);
-    deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
-    return json(s, 201);
-  }
+  if (req.method === "POST" && parts[2] && parts[3] === "spawn" && !parts[4])
+    return heldSpawn(parts[2], deps);
 
   // DELETE /api/held/:id — discard a held task
-  if (req.method === "DELETE" && parts[2] && !parts[3]) {
-    deps.store.removeHeldTask(parts[2]);
-    deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
-    return json({ ok: true });
-  }
+  if (req.method === "DELETE" && parts[2] && !parts[3]) return heldDiscard(parts[2], deps);
 
   return null;
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,6 +18,8 @@ import type {
   PrReview,
   HerdDigest,
   RundownItem,
+  HeldTask,
+  CreateSessionInput,
 } from "./types";
 import type { VisualBlock } from "./visual-blocks";
 import type { CapRow, CapStore, CreditSnapshot, CreditStore, WindowKey } from "./usage-limits";
@@ -334,6 +336,12 @@ export class SessionStore implements CapStore, CreditStore {
       id INTEGER PRIMARY KEY CHECK (id = 1),
       spent REAL NOT NULL, cap REAL NOT NULL, currency TEXT NOT NULL,
       pct INTEGER NOT NULL, resetAt INTEGER, scrapedAt INTEGER NOT NULL)`);
+    this.db.run(`CREATE TABLE IF NOT EXISTS held_tasks (
+      id TEXT PRIMARY KEY,
+      repoPath TEXT NOT NULL,
+      input TEXT NOT NULL,
+      createdAt INTEGER NOT NULL
+    )`);
     // small key/value store for runtime-configurable settings (e.g. repoRoot)
     this.db.run(`CREATE TABLE IF NOT EXISTS settings (
       key TEXT PRIMARY KEY, value TEXT NOT NULL)`);
@@ -2527,5 +2535,45 @@ export class SessionStore implements CapStore, CreditStore {
       mergeTrainPrs: parseMergeTrainPrsJson(r.mergeTrainPrs),
       mergingPrNumber: r.mergingPrNumber ?? null,
     } as Session;
+  }
+
+  // ── held tasks (usage-aware task holding) ──────────────────────────────────
+
+  addHeldTask(row: {
+    id: string;
+    repoPath: string;
+    input: CreateSessionInput;
+    createdAt: number;
+  }): void {
+    this.db.run(`INSERT INTO held_tasks (id, repoPath, input, createdAt) VALUES (?, ?, ?, ?)`, [
+      row.id,
+      row.repoPath,
+      JSON.stringify(row.input),
+      row.createdAt,
+    ]);
+  }
+
+  listHeldTasks(): HeldTask[] {
+    const rows = this.db
+      .query(`SELECT id, repoPath, input, createdAt FROM held_tasks ORDER BY createdAt ASC`)
+      .all() as { id: string; repoPath: string; input: string; createdAt: number }[];
+    return rows.map((r) => ({ ...r, input: JSON.parse(r.input) as CreateSessionInput }));
+  }
+
+  getHeldTask(id: string): HeldTask | null {
+    const r = this.db
+      .query(`SELECT id, repoPath, input, createdAt FROM held_tasks WHERE id = ?`)
+      .get(id) as { id: string; repoPath: string; input: string; createdAt: number } | null;
+    if (!r) return null;
+    return { ...r, input: JSON.parse(r.input) as CreateSessionInput };
+  }
+
+  removeHeldTask(id: string): void {
+    this.db.run(`DELETE FROM held_tasks WHERE id = ?`, [id]);
+  }
+
+  countHeldTasks(): number {
+    const row = this.db.query(`SELECT COUNT(*) AS n FROM held_tasks`).get() as { n: number };
+    return row.n;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -503,3 +503,12 @@ export interface Learning {
   /** URL of the CLAUDE.md promote PR, set when status becomes `promoted`. */
   promotedPrUrl: string | null;
 }
+
+/** A manually-submitted task held in the queue pending usage headroom. */
+export interface HeldTask {
+  id: string;
+  repoPath: string;
+  /** The original CreateSessionInput, replayed through service.create() when released. */
+  input: CreateSessionInput;
+  createdAt: number;
+}

--- a/src/usage-hold.ts
+++ b/src/usage-hold.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure hold-decision function for usage-aware task holding (#825).
+ *
+ * Degraded-usage convention: callers pass `0` for any window when usage is
+ * unknown (uncalibrated caps, api-key mode → `limits()` returns null windows).
+ * With 0, `Math.max(0, 0) >= holdPct` is always false, so we never hold when
+ * usage can't be measured — the safe default (don't freeze manual work we
+ * can't measure). No special-casing needed here; the `0` convention handles it.
+ */
+
+export interface HoldDecisionInput {
+  enabled: boolean; // config.usageHoldEnabled
+  holdPct: number; // config.usageHoldPct (0..100)
+  session5hPct: number; // 0 when usage unknown/uncalibrated
+  weekPct: number; // 0 when usage unknown/uncalibrated
+  activeSessionCount: number; // count of sessions with status === "running"
+  force: boolean; // operator override
+}
+
+/** Returns true if the task should be held instead of spawned. */
+export function shouldHold(i: HoldDecisionInput): boolean {
+  return (
+    i.enabled &&
+    !i.force &&
+    i.activeSessionCount >= 1 &&
+    Math.max(i.session5hPct, i.weekPct) >= i.holdPct
+  );
+}

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -42,6 +42,7 @@ const ALLOWED_KEYS = new Set([
   "sandboxProfile",
   "research",
   "mergeTrainPrs",
+  "force", // transport-only: bypass hold gate; not forwarded to CreateSessionInput
 ]);
 
 /** Max staged images per spawn. Bounds the attach list (and the relaunch merge of

--- a/test/held-release.test.ts
+++ b/test/held-release.test.ts
@@ -1,0 +1,157 @@
+import { test, expect } from "bun:test";
+import { releaseHeldTasks, type HeldReleaseDeps } from "../src/held-release";
+import type { CreateSessionInput } from "../src/types";
+import type { UsageLimits } from "../src/usage-limits";
+
+function makeInput(prompt: string): CreateSessionInput {
+  return {
+    repoPath: "/tmp/repo",
+    baseBranch: "main",
+    prompt,
+    model: null,
+    images: [],
+  };
+}
+
+function makeDeps(
+  tasks: { id: string; input: CreateSessionInput }[],
+  limits: Partial<UsageLimits> = {},
+  createFn?: (input: CreateSessionInput) => Promise<unknown>,
+): HeldReleaseDeps & {
+  emitted: { event: string; data: unknown }[];
+  creates: CreateSessionInput[];
+} {
+  const rows = tasks.map((t, i) => ({ ...t, repoPath: "/tmp/repo", createdAt: i + 1 }));
+  const emitted: { event: string; data: unknown }[] = [];
+  const creates: CreateSessionInput[] = [];
+
+  const defaultLimits: UsageLimits = {
+    session5h: null,
+    week: null,
+    credits: null,
+    stale: false,
+    calibratedAt: null,
+    subscriptionOnly: false,
+    ...limits,
+  };
+
+  return {
+    store: {
+      listHeldTasks: () => [...rows],
+      removeHeldTask: (id: string) => {
+        const i = rows.findIndex((r) => r.id === id);
+        if (i !== -1) rows.splice(i, 1);
+      },
+      countHeldTasks: () => rows.length,
+      list: () => [],
+    },
+    service: {
+      async create(input: CreateSessionInput): Promise<unknown> {
+        if (createFn) return createFn(input);
+        creates.push(input);
+        return { id: "fake-session" };
+      },
+    },
+    usageLimits: { limits: () => defaultLimits },
+    events: { emit: (event: string, data: unknown) => emitted.push({ event, data }) },
+    emitted,
+    creates,
+  };
+}
+
+// ── held-release tests ────────────────────────────────────────────────────────
+
+test("usage high (>=holdPct) + enabled → released:0, service not called", async () => {
+  const deps = makeDeps([{ id: "t1", input: makeInput("task 1") }], {
+    session5h: { pct: 85, resetAt: 0 },
+    week: null,
+  });
+
+  const result = await releaseHeldTasks(deps, { enabled: true, holdPct: 80 }, Date.now());
+  expect(result.released).toBe(0);
+  expect(deps.creates).toHaveLength(0);
+  expect(deps.emitted).toHaveLength(0);
+});
+
+test("usage low + 3 held → releases all 3 FIFO", async () => {
+  const creates: CreateSessionInput[] = [];
+  const tasks = [
+    { id: "t1", input: makeInput("task 1") },
+    { id: "t2", input: makeInput("task 2") },
+    { id: "t3", input: makeInput("task 3") },
+  ];
+
+  const deps = makeDeps(
+    tasks,
+    { session5h: { pct: 30, resetAt: 0 }, week: null },
+    async (input) => {
+      creates.push(input);
+      return { id: "fake" };
+    },
+  );
+
+  const result = await releaseHeldTasks(deps, { enabled: true, holdPct: 80 }, Date.now(), 10);
+  expect(result.released).toBe(3);
+  expect(creates).toHaveLength(3);
+  expect(creates[0]!.prompt).toBe("task 1");
+  expect(creates[1]!.prompt).toBe("task 2");
+  expect(creates[2]!.prompt).toBe("task 3");
+  expect(deps.store.countHeldTasks()).toBe(0);
+  expect(deps.emitted.some((e) => e.event === "held:changed")).toBe(true);
+});
+
+test("5 held, maxPerTick=2 → only 2 released, 3 remain", async () => {
+  const tasks = [
+    { id: "t1", input: makeInput("task 1") },
+    { id: "t2", input: makeInput("task 2") },
+    { id: "t3", input: makeInput("task 3") },
+    { id: "t4", input: makeInput("task 4") },
+    { id: "t5", input: makeInput("task 5") },
+  ];
+
+  const deps = makeDeps(tasks, {
+    session5h: { pct: 20, resetAt: 0 },
+    week: null,
+  });
+
+  const result = await releaseHeldTasks(deps, { enabled: true, holdPct: 80 }, Date.now(), 2);
+  expect(result.released).toBe(2);
+  expect(deps.store.countHeldTasks()).toBe(3);
+});
+
+test("service.create throws on 2nd → 1 released, loop stops, rows intact", async () => {
+  let callCount = 0;
+  const tasks = [
+    { id: "t1", input: makeInput("task 1") },
+    { id: "t2", input: makeInput("task 2") },
+    { id: "t3", input: makeInput("task 3") },
+  ];
+  const deps = makeDeps(tasks, { session5h: { pct: 20, resetAt: 0 }, week: null }, async () => {
+    callCount++;
+    if (callCount === 2) throw new Error("spawn failed");
+    return { id: "fake" };
+  });
+
+  const result = await releaseHeldTasks(deps, { enabled: true, holdPct: 80 }, Date.now(), 10);
+  expect(result.released).toBe(1);
+  // row for t1 removed, t2 and t3 still in the list (t2 failed → loop breaks; t3 untouched)
+  expect(deps.store.countHeldTasks()).toBe(2);
+  // held:changed emitted for the 1 successful release
+  expect(deps.emitted.some((e) => e.event === "held:changed")).toBe(true);
+});
+
+test("disabled + tasks present → releases them (below-threshold behavior)", async () => {
+  const tasks = [
+    { id: "t1", input: makeInput("task 1") },
+    { id: "t2", input: makeInput("task 2") },
+  ];
+  const deps = makeDeps(tasks, {
+    session5h: { pct: 95, resetAt: 0 },
+    week: null,
+  });
+
+  // disabled: ignore usage, release anyway
+  const result = await releaseHeldTasks(deps, { enabled: false, holdPct: 80 }, Date.now(), 10);
+  expect(result.released).toBe(2);
+  expect(deps.store.countHeldTasks()).toBe(0);
+});

--- a/test/held-release.test.ts
+++ b/test/held-release.test.ts
@@ -43,7 +43,6 @@ function makeDeps(
         if (i !== -1) rows.splice(i, 1);
       },
       countHeldTasks: () => rows.length,
-      list: () => [],
     },
     service: {
       async create(input: CreateSessionInput): Promise<unknown> {

--- a/test/hold-gate.test.ts
+++ b/test/hold-gate.test.ts
@@ -1,0 +1,308 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { config } from "../src/config";
+import type { UsageLimits } from "../src/usage-limits";
+
+let tmpRoot: string;
+let repoDir: string;
+// save/restore config fields modified in tests
+let savedEnabled: boolean;
+let savedPct: number;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(config.repoRoot, "shepherd-hold-gate-test-"));
+  repoDir = join(tmpRoot, "repo");
+  mkdirSync(repoDir);
+  savedEnabled = config.usageHoldEnabled;
+  savedPct = config.usageHoldPct;
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  config.usageHoldEnabled = savedEnabled;
+  config.usageHoldPct = savedPct;
+});
+
+interface FakeSession {
+  id: string;
+  status: string;
+  [k: string]: unknown;
+}
+
+function harness(limitsOverride?: Partial<UsageLimits>): {
+  app: ReturnType<typeof makeApp>;
+  store: SessionStore;
+  emitted: { event: string; data: unknown }[];
+  creates: unknown[];
+} {
+  const store = new SessionStore(":memory:");
+  const emitted: { event: string; data: unknown }[] = [];
+  const creates: unknown[] = [];
+
+  const hub = new EventHub();
+  hub.subscribe((event, data) => emitted.push({ event, data }));
+
+  const defaultLimits: UsageLimits = {
+    session5h: null,
+    week: null,
+    credits: null,
+    stale: false,
+    calibratedAt: null,
+    subscriptionOnly: false,
+    ...limitsOverride,
+  };
+
+  let createCount = 0;
+  const fakeService = {
+    async create(input: unknown): Promise<FakeSession> {
+      creates.push(input);
+      return {
+        id: `fake-session-${++createCount}`,
+        status: "running",
+        repoPath: (input as { repoPath: string }).repoPath,
+      };
+    },
+  };
+
+  const deps: AppDeps = {
+    store,
+    service: fakeService as any,
+    events: hub,
+    usageLimits: { limits: () => defaultLimits } as any,
+  };
+  return { app: makeApp(deps), store, emitted, creates };
+}
+
+function postSession(app: ReturnType<typeof makeApp>, extra?: Record<string, unknown>) {
+  return app.fetch(
+    new Request("http://x/api/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        repoPath: repoDir,
+        baseBranch: "main",
+        prompt: "do something",
+        model: null,
+        images: [],
+        ...extra,
+      }),
+    }),
+  );
+}
+
+// ── hold gate tests ──────────────────────────────────────────────────────────
+
+test("high usage + 1 running session + enabled → held:true, service not called", async () => {
+  config.usageHoldEnabled = true;
+  config.usageHoldPct = 80;
+
+  const { app, store, emitted, creates } = harness({
+    session5h: { pct: 85, resetAt: 0 },
+    week: { pct: 0, resetAt: 0 },
+  });
+
+  // plant a running session so activeSessionCount >= 1
+  store.create({
+    name: "running-session",
+    prompt: "running",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/running",
+    worktreePath: repoDir,
+    isolated: false,
+    herdrSession: "sess-a",
+    herdrAgentId: "agent-a",
+    claudeSessionId: "claude-a",
+    model: null,
+  });
+  store.update(store.list({ activeOnly: true })[0]!.id, { status: "running" });
+
+  const res = await postSession(app);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.held).toBe(true);
+  expect(typeof body.id).toBe("string");
+  expect(body.count).toBe(1);
+
+  // store recorded it
+  expect(store.countHeldTasks()).toBe(1);
+
+  // service.create NOT called
+  expect(creates).toHaveLength(0);
+
+  // no session:new emitted
+  expect(emitted.some((e) => e.event === "session:new")).toBe(false);
+
+  // held:changed emitted
+  expect(emitted.some((e) => e.event === "held:changed")).toBe(true);
+});
+
+test("high usage + force:true → spawns (not held)", async () => {
+  config.usageHoldEnabled = true;
+  config.usageHoldPct = 80;
+
+  const { app, store, creates } = harness({
+    session5h: { pct: 85, resetAt: 0 },
+    week: { pct: 0, resetAt: 0 },
+  });
+
+  store.create({
+    name: "running-session",
+    prompt: "running",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/running",
+    worktreePath: repoDir,
+    isolated: false,
+    herdrSession: "sess-a",
+    herdrAgentId: "agent-a",
+    claudeSessionId: "claude-a",
+    model: null,
+  });
+  store.update(store.list({ activeOnly: true })[0]!.id, { status: "running" });
+
+  const res = await postSession(app, { force: true });
+  expect(res.status).toBe(201);
+  expect(creates).toHaveLength(1);
+  expect(store.countHeldTasks()).toBe(0);
+});
+
+test("high usage + 0 running sessions → spawns (activeSessionCount gate)", async () => {
+  config.usageHoldEnabled = true;
+  config.usageHoldPct = 80;
+
+  // no running sessions planted
+  const { app, creates } = harness({
+    session5h: { pct: 85, resetAt: 0 },
+    week: { pct: 0, resetAt: 0 },
+  });
+
+  const res = await postSession(app);
+  expect(res.status).toBe(201);
+  expect(creates).toHaveLength(1);
+});
+
+test("below threshold (50%) + running → spawns", async () => {
+  config.usageHoldEnabled = true;
+  config.usageHoldPct = 80;
+
+  const { app, store, creates } = harness({
+    session5h: { pct: 50, resetAt: 0 },
+    week: { pct: 50, resetAt: 0 },
+  });
+
+  store.create({
+    name: "running-session",
+    prompt: "running",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/running",
+    worktreePath: repoDir,
+    isolated: false,
+    herdrSession: "sess-a",
+    herdrAgentId: "agent-a",
+    claudeSessionId: "claude-a",
+    model: null,
+  });
+  store.update(store.list({ activeOnly: true })[0]!.id, { status: "running" });
+
+  const res = await postSession(app);
+  expect(res.status).toBe(201);
+  expect(creates).toHaveLength(1);
+});
+
+// ── /api/held endpoints ───────────────────────────────────────────────────────
+
+test("GET /api/held returns FIFO held tasks", async () => {
+  const { app, store } = harness();
+
+  store.addHeldTask({
+    id: "held-1",
+    repoPath: repoDir,
+    input: {
+      repoPath: repoDir,
+      baseBranch: "main",
+      prompt: "task 1",
+      model: null,
+      images: [],
+    },
+    createdAt: 1000,
+  });
+  store.addHeldTask({
+    id: "held-2",
+    repoPath: repoDir,
+    input: {
+      repoPath: repoDir,
+      baseBranch: "main",
+      prompt: "task 2",
+      model: null,
+      images: [],
+    },
+    createdAt: 2000,
+  });
+
+  const res = await app.fetch(new Request("http://x/api/held"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(Array.isArray(body)).toBe(true);
+  expect(body).toHaveLength(2);
+  expect(body[0].id).toBe("held-1");
+  expect(body[1].id).toBe("held-2");
+});
+
+test("POST /api/held/:id/spawn → calls service.create, removes row, returns 201", async () => {
+  const { app, store, creates, emitted } = harness();
+
+  const input = {
+    repoPath: repoDir,
+    baseBranch: "main",
+    prompt: "task to spawn",
+    model: null,
+    images: [],
+  };
+  store.addHeldTask({ id: "held-1", repoPath: repoDir, input, createdAt: 1000 });
+
+  const res = await app.fetch(new Request("http://x/api/held/held-1/spawn", { method: "POST" }));
+  expect(res.status).toBe(201);
+
+  expect(creates).toHaveLength(1);
+  expect((creates[0] as typeof input).prompt).toBe("task to spawn");
+  expect(store.countHeldTasks()).toBe(0);
+  expect(emitted.some((e) => e.event === "held:changed")).toBe(true);
+});
+
+test("POST /api/held/:id/spawn with unknown id → 404", async () => {
+  const { app } = harness();
+  const res = await app.fetch(
+    new Request("http://x/api/held/no-such-id/spawn", { method: "POST" }),
+  );
+  expect(res.status).toBe(404);
+});
+
+test("DELETE /api/held/:id → removes row, returns {ok:true}", async () => {
+  const { app, store, emitted } = harness();
+
+  store.addHeldTask({
+    id: "held-1",
+    repoPath: repoDir,
+    input: {
+      repoPath: repoDir,
+      baseBranch: "main",
+      prompt: "task 1",
+      model: null,
+      images: [],
+    },
+    createdAt: 1000,
+  });
+
+  const res = await app.fetch(new Request("http://x/api/held/held-1", { method: "DELETE" }));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.ok).toBe(true);
+  expect(store.countHeldTasks()).toBe(0);
+  expect(emitted.some((e) => e.event === "held:changed")).toBe(true);
+});

--- a/test/store.held.test.ts
+++ b/test/store.held.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test";
+import { SessionStore } from "../src/store";
+import type { CreateSessionInput } from "../src/types";
+
+const sampleInput: CreateSessionInput = {
+  repoPath: "/home/user/myrepo",
+  baseBranch: "main",
+  prompt: "fix the bug",
+  model: "claude-sonnet-4-5",
+  images: [],
+  issueRef: { number: 42, url: "https://github.com/foo/bar/issues/42", title: "Bug", body: "" },
+  auto: false,
+  planGateEnabled: null,
+  autopilotEnabled: null,
+  sandboxProfile: null,
+  research: false,
+  mergeTrainPrs: [],
+};
+
+test("held_tasks: listHeldTasks returns FIFO order", () => {
+  const s = new SessionStore(":memory:");
+  s.addHeldTask({ id: "h1", repoPath: "/repo/a", input: sampleInput, createdAt: 1000 });
+  s.addHeldTask({
+    id: "h2",
+    repoPath: "/repo/b",
+    input: { ...sampleInput, prompt: "second task" },
+    createdAt: 2000,
+  });
+  const list = s.listHeldTasks();
+  expect(list).toHaveLength(2);
+  expect(list[0].id).toBe("h1");
+  expect(list[1].id).toBe("h2");
+});
+
+test("held_tasks: countHeldTasks returns correct count", () => {
+  const s = new SessionStore(":memory:");
+  expect(s.countHeldTasks()).toBe(0);
+  s.addHeldTask({ id: "h1", repoPath: "/repo/a", input: sampleInput, createdAt: 1000 });
+  s.addHeldTask({ id: "h2", repoPath: "/repo/b", input: sampleInput, createdAt: 2000 });
+  expect(s.countHeldTasks()).toBe(2);
+});
+
+test("held_tasks: getHeldTask round-trips full input", () => {
+  const s = new SessionStore(":memory:");
+  s.addHeldTask({ id: "h1", repoPath: "/repo/a", input: sampleInput, createdAt: 1000 });
+  const got = s.getHeldTask("h1");
+  expect(got).not.toBeNull();
+  expect(got?.id).toBe("h1");
+  expect(got?.repoPath).toBe("/repo/a");
+  expect(got?.createdAt).toBe(1000);
+  expect(got?.input).toEqual(sampleInput);
+});
+
+test("held_tasks: getHeldTask returns null for unknown id", () => {
+  const s = new SessionStore(":memory:");
+  expect(s.getHeldTask("nonexistent")).toBeNull();
+});
+
+test("held_tasks: removeHeldTask removes row and leaves others intact", () => {
+  const s = new SessionStore(":memory:");
+  s.addHeldTask({ id: "h1", repoPath: "/repo/a", input: sampleInput, createdAt: 1000 });
+  s.addHeldTask({ id: "h2", repoPath: "/repo/b", input: sampleInput, createdAt: 2000 });
+
+  s.removeHeldTask("h1");
+
+  expect(s.countHeldTasks()).toBe(1);
+  expect(s.getHeldTask("h1")).toBeNull();
+  expect(s.getHeldTask("h2")).not.toBeNull();
+  expect(s.listHeldTasks()[0].id).toBe("h2");
+});

--- a/test/store.held.test.ts
+++ b/test/store.held.test.ts
@@ -28,8 +28,8 @@ test("held_tasks: listHeldTasks returns FIFO order", () => {
   });
   const list = s.listHeldTasks();
   expect(list).toHaveLength(2);
-  expect(list[0].id).toBe("h1");
-  expect(list[1].id).toBe("h2");
+  expect(list[0]!.id).toBe("h1");
+  expect(list[1]!.id).toBe("h2");
 });
 
 test("held_tasks: countHeldTasks returns correct count", () => {
@@ -66,5 +66,5 @@ test("held_tasks: removeHeldTask removes row and leaves others intact", () => {
   expect(s.countHeldTasks()).toBe(1);
   expect(s.getHeldTask("h1")).toBeNull();
   expect(s.getHeldTask("h2")).not.toBeNull();
-  expect(s.listHeldTasks()[0].id).toBe("h2");
+  expect(s.listHeldTasks()[0]!.id).toBe("h2");
 });

--- a/test/usage-hold.test.ts
+++ b/test/usage-hold.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { shouldHold } from "../src/usage-hold";
+
+const base = {
+  enabled: true,
+  holdPct: 80,
+  session5hPct: 0,
+  weekPct: 0,
+  activeSessionCount: 0,
+  force: false,
+};
+
+test("holds when usage high, active>=1, enabled, not forced", () => {
+  expect(shouldHold({ ...base, session5hPct: 85, activeSessionCount: 1 })).toBe(true);
+});
+
+test("no hold when no active sessions (idle herd)", () => {
+  expect(shouldHold({ ...base, session5hPct: 85, activeSessionCount: 0 })).toBe(false);
+});
+
+test("no hold when force=true (operator override)", () => {
+  expect(shouldHold({ ...base, session5hPct: 85, activeSessionCount: 2, force: true })).toBe(false);
+});
+
+test("no hold when enabled=false (feature off)", () => {
+  expect(shouldHold({ ...base, session5hPct: 85, activeSessionCount: 2, enabled: false })).toBe(
+    false,
+  );
+});
+
+test("no hold when below threshold (s5h=50, week=60)", () => {
+  expect(shouldHold({ ...base, session5hPct: 50, weekPct: 60, activeSessionCount: 2 })).toBe(false);
+});
+
+test("holds on weekly-only hot (max picks weekly)", () => {
+  expect(shouldHold({ ...base, session5hPct: 10, weekPct: 85, activeSessionCount: 1 })).toBe(true);
+});
+
+test("no hold when usage unknown (degraded: 0,0 → never holds)", () => {
+  expect(shouldHold({ ...base, session5hPct: 0, weekPct: 0, activeSessionCount: 3 })).toBe(false);
+});
+
+test("holds at boundary (s5h exactly at threshold)", () => {
+  expect(shouldHold({ ...base, session5hPct: 80, activeSessionCount: 1 })).toBe(true);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1585,5 +1585,17 @@
   "diagnostics_label_git_mergetree": "git merge-tree",
   "backlog_tab_automation": "Automatisierung",
   "feat_repo_settings_backlog_title": "Repo-Einstellungen ohne Task",
-  "feat_repo_settings_backlog_body": "Die Repo-Automatisierungseinstellungen — Kritiker, Plan-Gate, Autopilot, Auto-Drain/Merge, Sandbox-Profil, Standardmodell, Drain-Konfiguration sowie Reviewer-/Merger-Rollen — sind jetzt als Automatisierungs-Tab in der Backlog-Detailansicht verfügbar. Stelle die Vorgaben jedes Repos ein, ohne einen Task zu starten; Änderungen teilen sich eine einzige Quelle der Wahrheit mit dem Task-Panel."
+  "feat_repo_settings_backlog_body": "Die Repo-Automatisierungseinstellungen — Kritiker, Plan-Gate, Autopilot, Auto-Drain/Merge, Sandbox-Profil, Standardmodell, Drain-Konfiguration sowie Reviewer-/Merger-Rollen — sind jetzt als Automatisierungs-Tab in der Backlog-Detailansicht verfügbar. Stelle die Vorgaben jedes Repos ein, ohne einen Task zu starten; Änderungen teilen sich eine einzige Quelle der Wahrheit mit dem Task-Panel.",
+  "toast_task_held": "Aufgabe zurückgehalten — Nutzung ist hoch. Sie startet beim Reset.",
+  "settings_usage_hold_enabled_label": "Neue Aufgaben bei hoher Nutzung zurückhalten",
+  "settings_usage_hold_hint": "Wenn aktiviert, werden neue manuelle Aufgaben pausiert, wenn bereits eine Sitzung läuft und die primäre Nutzung den unten stehenden Schwellenwert erreicht oder überschreitet. Sie starten automatisch, wenn die Nutzung zurückgesetzt wird.",
+  "settings_usage_hold_on": "An",
+  "settings_usage_hold_off": "Aus",
+  "settings_usage_hold_enabled_save_failed": "Einstellung für Nutzungsrückhalt konnte nicht geändert werden. Erneut versuchen.",
+  "settings_usage_hold_pct_label": "Schwellenwert für Nutzungsrückhalt",
+  "settings_usage_hold_pct_hint": "Neue Aufgaben zurückhalten, wenn die primäre Nutzung diesen Prozentsatz erreicht (0–100). Niedrigere Werte halten Aufgaben früher zurück.",
+  "settings_usage_hold_pct_field_label": "Zurückhalten ab Nutzung ≥",
+  "settings_usage_hold_pct_save_failed": "Schwellenwert für Nutzungsrückhalt konnte nicht geändert werden. Erneut versuchen.",
+  "feat_usage_aware_holding_title": "Aufgaben pausieren automatisch bei hoher Nutzung",
+  "feat_usage_aware_holding_body": "Neue Aufgaben werden jetzt automatisch pausiert, wenn Ihre Claude-Nutzung hoch ist und bereits eine Sitzung läuft — sie starten von selbst, wenn die Nutzung zurückgesetzt wird. Trotzdem einreichen zum Überschreiben oder in Einstellungen → Sitzung deaktivieren."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1597,5 +1597,13 @@
   "settings_usage_hold_pct_field_label": "Zurückhalten ab Nutzung ≥",
   "settings_usage_hold_pct_save_failed": "Schwellenwert für Nutzungsrückhalt konnte nicht geändert werden. Erneut versuchen.",
   "feat_usage_aware_holding_title": "Aufgaben pausieren automatisch bei hoher Nutzung",
-  "feat_usage_aware_holding_body": "Neue Aufgaben werden jetzt automatisch pausiert, wenn Ihre Claude-Nutzung hoch ist und bereits eine Sitzung läuft — sie starten von selbst, wenn die Nutzung zurückgesetzt wird. Trotzdem einreichen zum Überschreiben oder in Einstellungen → Sitzung deaktivieren."
+  "feat_usage_aware_holding_body": "Neue Aufgaben werden jetzt automatisch pausiert, wenn Ihre Claude-Nutzung hoch ist und bereits eine Sitzung läuft — sie starten von selbst, wenn die Nutzung zurückgesetzt wird. Trotzdem einreichen zum Überschreiben oder in Einstellungen → Sitzung deaktivieren.",
+  "newtask_hold_for_reset": "Bis zum Reset zurückhalten",
+  "newtask_submit_anyway": "Trotzdem einreichen",
+  "topbar_held_badge": "{count} zurückgehalten",
+  "topbar_held_resets": "· Reset {time}",
+  "topbar_held_title": "Zurückgehaltene Aufgaben",
+  "topbar_held_spawn_now": "Jetzt starten",
+  "topbar_held_discard": "Verwerfen",
+  "topbar_held_empty": "Keine zurückgehaltenen Aufgaben"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1585,5 +1585,17 @@
   "diagnostics_label_git_mergetree": "git merge-tree",
   "backlog_tab_automation": "Automation",
   "feat_repo_settings_backlog_title": "Repo settings without a task",
-  "feat_repo_settings_backlog_body": "The per-repo automation settings — critic, plan gate, autopilot, auto-drain/merge, sandbox profile, default model, drain config and reviewer/merger roles — are now an Automation tab in the Backlog drill-down. Tune any repo's defaults without launching a task; changes share one source of truth with the in-task panel."
+  "feat_repo_settings_backlog_body": "The per-repo automation settings — critic, plan gate, autopilot, auto-drain/merge, sandbox profile, default model, drain config and reviewer/merger roles — are now an Automation tab in the Backlog drill-down. Tune any repo's defaults without launching a task; changes share one source of truth with the in-task panel.",
+  "toast_task_held": "Task held — usage is high. It'll start when usage resets.",
+  "settings_usage_hold_enabled_label": "Hold new tasks during high usage",
+  "settings_usage_hold_hint": "When enabled, new manual tasks are paused if a session is already running and primary usage is at or above the threshold below. They start automatically when usage resets.",
+  "settings_usage_hold_on": "On",
+  "settings_usage_hold_off": "Off",
+  "settings_usage_hold_enabled_save_failed": "Couldn't change usage hold setting. Retry.",
+  "settings_usage_hold_pct_label": "Usage hold threshold",
+  "settings_usage_hold_pct_hint": "Hold new tasks when primary usage reaches this percentage (0–100). Lower values hold tasks earlier.",
+  "settings_usage_hold_pct_field_label": "Hold at usage ≥",
+  "settings_usage_hold_pct_save_failed": "Couldn't change the usage hold threshold. Retry.",
+  "feat_usage_aware_holding_title": "Tasks pause automatically when usage is high",
+  "feat_usage_aware_holding_body": "New tasks now pause automatically when your Claude usage is high and a session is already running — they start on their own when usage resets. Submit anyway to override, or turn it off in Settings → Session."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1597,5 +1597,13 @@
   "settings_usage_hold_pct_field_label": "Hold at usage ≥",
   "settings_usage_hold_pct_save_failed": "Couldn't change the usage hold threshold. Retry.",
   "feat_usage_aware_holding_title": "Tasks pause automatically when usage is high",
-  "feat_usage_aware_holding_body": "New tasks now pause automatically when your Claude usage is high and a session is already running — they start on their own when usage resets. Submit anyway to override, or turn it off in Settings → Session."
+  "feat_usage_aware_holding_body": "New tasks now pause automatically when your Claude usage is high and a session is already running — they start on their own when usage resets. Submit anyway to override, or turn it off in Settings → Session.",
+  "newtask_hold_for_reset": "Hold for reset",
+  "newtask_submit_anyway": "Submit anyway",
+  "topbar_held_badge": "{count} held",
+  "topbar_held_resets": "· resets {time}",
+  "topbar_held_title": "Held tasks",
+  "topbar_held_spawn_now": "Spawn now",
+  "topbar_held_discard": "Discard",
+  "topbar_held_empty": "No held tasks"
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,6 +1,8 @@
 import type {
   Session,
   CreateInput,
+  HeldTask,
+  HeldResult,
   RepoEntry,
   Issue,
   PullRequest,
@@ -118,7 +120,9 @@ export async function listSessions(): Promise<Session[]> {
   return r.json();
 }
 
-export async function createSession(input: CreateInput): Promise<Session> {
+export async function createSession(
+  input: CreateInput & { force?: boolean },
+): Promise<Session | HeldResult> {
   const r = await fetch("/api/sessions", {
     method: "POST",
     headers: JSON_HEADERS,
@@ -127,6 +131,35 @@ export async function createSession(input: CreateInput): Promise<Session> {
   if (!r.ok) throw await failed(r, "create");
   return r.json();
 }
+
+/** List tasks that are currently held (waiting for usage to reset). */
+export async function listHeld(): Promise<HeldTask[]> {
+  const r = await fetch("/api/held");
+  if (!r.ok) throw await failed(r, "list held");
+  return r.json();
+}
+
+/** Spawn a held task now (bypasses the usage hold). */
+export async function spawnHeld(id: string): Promise<Session> {
+  const r = await fetch(`/api/held/${id}/spawn`, { method: "POST", headers: JSON_HEADERS });
+  if (!r.ok) throw await failed(r, "spawn held");
+  return r.json();
+}
+
+/** Discard a held task without spawning it. */
+export async function discardHeld(id: string): Promise<void> {
+  const r = await fetch(`/api/held/${id}`, { method: "DELETE" });
+  if (!r.ok) throw await failed(r, "discard held");
+}
+
+// Toggle usage-aware task holding (pause new tasks when usage is high and a session is running).
+export const putUsageHoldEnabled = (enabled: boolean): Promise<{ usageHoldEnabled: boolean }> =>
+  patchSettings({ usageHoldEnabled: enabled });
+
+// Persist the usage-hold threshold percentage (0–100). New tasks are held when
+// the primary usage window is at or above this percentage.
+export const putUsageHoldPct = (pct: number): Promise<{ usageHoldPct: number }> =>
+  patchSettings({ usageHoldPct: pct });
 
 /** Upload one image; returns its absolute server path. Pass sessionId to store it
  *  inside that session's worktree (live terminal); omit for New Task staging. */

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -567,6 +567,10 @@
         error = m.newtask_create_failed({ reason: reason(err, m.newtask_submit()) });
         retry = () => submit(e);
       }
+    } finally {
+      // Always clear submitting so the dialog stays usable — on the held path the
+      // page returns early (keeping the dialog open) and we must re-enable the
+      // buttons so the operator can still click "Submit anyway".
       submitting = false;
     }
   }

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -49,6 +49,7 @@
     initialBaseBranch,
     relaunchIssueNumber,
     initialImages,
+    holdLikely = false,
   }: {
     onsubmit: (input: {
       repoPath: string;
@@ -61,6 +62,7 @@
       autopilotEnabled: boolean | null;
       sandboxProfile?: SandboxProfile;
       research: boolean;
+      force?: boolean;
     }) => Promise<void> | void;
     onclose?: () => void;
     onclone?: () => void;
@@ -75,6 +77,7 @@
     initialBaseBranch?: string;
     relaunchIssueNumber?: number | null;
     initialImages?: { path: string; name: string }[];
+    holdLikely?: boolean;
   } = $props();
 
   /** Short editable seed so the user only adds deltas; the body rides out-of-band. */
@@ -525,7 +528,7 @@
     e.stopPropagation();
   }
 
-  async function submit(e: Event) {
+  async function submit(e: Event, force = false) {
     e.preventDefault();
     if (!prompt.trim() || !repoPath.trim() || submitting) return;
     submitting = true;
@@ -550,6 +553,7 @@
         autopilotEnabled: autopilotTouched ? autopilot : null,
         sandboxProfile: sandboxProfile === "default" ? undefined : sandboxProfile,
         research,
+        force: force || undefined,
       });
     } catch (err) {
       if (isPreviewBlocked(err)) {
@@ -879,23 +883,44 @@
       </div>
     {/if}
 
-    <button
-      class="run"
-      type="submit"
-      disabled={submitting}
-      title={isMac ? "⌘ + Enter" : "Ctrl + Enter"}
-    >
-      <span
-        >{submitting
-          ? m.newtask_spawning()
-          : selectedRepoName
-            ? m.newtask_submit_in_repo({ repo: selectedRepoName })
-            : m.newtask_submit()}</span
+    {#if holdLikely}
+      <div class="run-dual">
+        <button
+          class="run run-hold"
+          type="button"
+          disabled={submitting}
+          onclick={(e) => submit(e, false)}
+        >
+          <span>{submitting ? m.newtask_spawning() : m.newtask_hold_for_reset()}</span>
+        </button>
+        <button
+          class="run run-anyway"
+          type="button"
+          disabled={submitting}
+          onclick={(e) => submit(e, true)}
+        >
+          <span>{m.newtask_submit_anyway()}</span>
+        </button>
+      </div>
+    {:else}
+      <button
+        class="run"
+        type="submit"
+        disabled={submitting}
+        title={isMac ? "⌘ + Enter" : "Ctrl + Enter"}
       >
-      {#if !submitting}
-        <kbd class="kbd">{isMac ? "⌘↵" : "Ctrl+↵"}</kbd>
-      {/if}
-    </button>
+        <span
+          >{submitting
+            ? m.newtask_spawning()
+            : selectedRepoName
+              ? m.newtask_submit_in_repo({ repo: selectedRepoName })
+              : m.newtask_submit()}</span
+        >
+        {#if !submitting}
+          <kbd class="kbd">{isMac ? "⌘↵" : "Ctrl+↵"}</kbd>
+        {/if}
+      </button>
+    {/if}
   </form>
 </div>
 
@@ -1147,6 +1172,30 @@
     color: var(--color-faint);
     border-color: var(--color-line);
     box-shadow: none;
+  }
+  /* Dual-submit row shown when a hold is likely */
+  .run-dual {
+    margin-top: 12px;
+    display: flex;
+    gap: 8px;
+  }
+  .run-dual .run {
+    margin-top: 0;
+    flex: 1;
+  }
+  /* "Hold for reset" is the primary (amber, full glow) */
+  .run-hold {
+    flex: 2 !important;
+  }
+  /* "Submit anyway" is the secondary (muted, no glow) */
+  .run-anyway {
+    border-color: var(--color-line-bright);
+    color: var(--color-ink);
+    box-shadow: none;
+  }
+  .run-anyway:not(:disabled):hover {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
   }
   .kbd {
     flex-shrink: 0;

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -568,9 +568,9 @@
         retry = () => submit(e);
       }
     } finally {
-      // Always clear submitting so the dialog stays usable — on the held path the
-      // page returns early (keeping the dialog open) and we must re-enable the
-      // buttons so the operator can still click "Submit anyway".
+      // Clear submitting on every path. This only matters for the error path, where the
+      // dialog stays open showing the error and the buttons must re-enable for a retry;
+      // the success and held paths both close the dialog page-side, so it's harmless there.
       submitting = false;
     }
   }

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -66,6 +66,8 @@ function settings(over: Partial<SettingsPayload> = {}): SettingsPayload {
     sessionRetentionDays: 30,
     sessionRetentionKeep: 250,
     previewHost: null,
+    usageHoldEnabled: true,
+    usageHoldPct: 90,
     ...over,
   };
 }

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -12,6 +12,8 @@
     putAnthropicApiKey,
     verifyApiKey,
     putExtraCreditsDrainCeiling,
+    putUsageHoldEnabled,
+    putUsageHoldPct,
     listDirs,
     getDiagnostics,
     fixDiagnostic,
@@ -170,6 +172,13 @@
   let extraCreditsCeiling = $state(0); // account-wide extra-credit spend ceiling (0 = pause on any)
   let extraCreditsCeilingSaved = 0; // last server-confirmed value, for revert on failure
   let extraCreditsBusy = $state(false);
+
+  // Usage hold — pause new tasks when usage is high and a session is already running.
+  let usageHoldEnabled = $state(true);
+  let usageHoldBusy = $state(false);
+  let usageHoldPct = $state(90); // threshold percentage (0–100)
+  let usageHoldPctSaved = 90;
+  let usageHoldPctBusy = $state(false);
 
   // Diagnose tab — local checks + re-run state.
   // untrack: initialDiagnostics is intentionally only read once as the seed value.
@@ -417,6 +426,46 @@
     }
   }
 
+  async function toggleUsageHold() {
+    if (usageHoldBusy) return;
+    usageHoldBusy = true;
+    const next = !usageHoldEnabled;
+    try {
+      const s = await putUsageHoldEnabled(next);
+      usageHoldEnabled = s.usageHoldEnabled;
+    } catch {
+      toasts.info(m.settings_usage_hold_enabled_save_failed(), {
+        key: "usage-hold-enabled",
+        duration: null,
+        alert: true,
+      });
+    } finally {
+      usageHoldBusy = false;
+    }
+  }
+
+  async function saveUsageHoldPct() {
+    if (usageHoldPctBusy) return;
+    usageHoldPctBusy = true;
+    const n = Math.round(Number(usageHoldPct));
+    const clamped = Number.isFinite(n) ? Math.min(100, Math.max(0, n)) : usageHoldPctSaved;
+    usageHoldPct = clamped;
+    try {
+      const r = await putUsageHoldPct(clamped);
+      usageHoldPct = r.usageHoldPct;
+      usageHoldPctSaved = r.usageHoldPct;
+    } catch {
+      usageHoldPct = usageHoldPctSaved;
+      toasts.info(m.settings_usage_hold_pct_save_failed(), {
+        key: "usage-hold-pct",
+        duration: null,
+        alert: true,
+      });
+    } finally {
+      usageHoldPctBusy = false;
+    }
+  }
+
   async function toggleRemoteControl() {
     if (rcBusy) return;
     rcBusy = true;
@@ -505,6 +554,9 @@
       hasApiKey = s.hasApiKey;
       extraCreditsCeiling = s.extraCreditsDrainCeiling;
       extraCreditsCeilingSaved = s.extraCreditsDrainCeiling;
+      usageHoldEnabled = s.usageHoldEnabled;
+      usageHoldPct = s.usageHoldPct;
+      usageHoldPctSaved = s.usageHoldPct;
       await browse(s.repoRoot);
     } catch {
       await browse();
@@ -861,6 +913,41 @@
             bind:value={extraCreditsCeiling}
             aria-label={m.settings_extra_credits_ceiling_title()}
             onchange={saveExtraCreditsCeiling}
+          />
+        </label>
+      </div>
+      <div class="rc">
+        <span class="micro">{m.settings_usage_hold_enabled_label()}</span>
+        <p class="hint">{m.settings_usage_hold_hint()}</p>
+        <button
+          type="button"
+          class="toggle"
+          role="switch"
+          aria-checked={usageHoldEnabled}
+          disabled={usageHoldBusy}
+          onclick={toggleUsageHold}
+        >
+          <span class="track" class:on={usageHoldEnabled}><span class="knob"></span></span>
+          <span class="state"
+            >{usageHoldEnabled ? m.settings_usage_hold_on() : m.settings_usage_hold_off()}</span
+          >
+        </button>
+      </div>
+      <div class="rc">
+        <span class="micro">{m.settings_usage_hold_pct_label()}</span>
+        <p class="hint">{m.settings_usage_hold_pct_hint()}</p>
+        <label class="cycles">
+          <span class="cycles-label">{m.settings_usage_hold_pct_field_label()}</span>
+          <input
+            class="num"
+            type="number"
+            min="0"
+            max="100"
+            step="1"
+            disabled={usageHoldPctBusy || !usageHoldEnabled}
+            bind:value={usageHoldPct}
+            aria-label={m.settings_usage_hold_pct_label()}
+            onchange={saveUsageHoldPct}
           />
         </label>
       </div>

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -176,8 +176,8 @@
   // Usage hold — pause new tasks when usage is high and a session is already running.
   let usageHoldEnabled = $state(true);
   let usageHoldBusy = $state(false);
-  let usageHoldPct = $state(90); // threshold percentage (0–100)
-  let usageHoldPctSaved = 90;
+  let usageHoldPct = $state(80); // threshold percentage (0–100); matches server default
+  let usageHoldPctSaved = 80;
   let usageHoldPctBusy = $state(false);
 
   // Diagnose tab — local checks + re-run state.

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -376,11 +376,6 @@
     const el = heldPopEl;
     if (!el) return;
     const clamp = () => {
-      if (window.matchMedia("(pointer: coarse)").matches) {
-        el.style.maxHeight = "";
-        heldPopFlipUp = false;
-        return;
-      }
       const anchor = el.offsetParent;
       if (!anchor) return;
       const rect = anchor.getBoundingClientRect();
@@ -2497,18 +2492,12 @@
     margin-bottom: 4px;
   }
   @media (pointer: coarse) {
+    /* Touch: keep the popover ANCHORED (not fixed-centered) so it stays a small
+       non-blocking popover exempt from the modal scrim rule (CLAUDE.md). The
+       flip-up + height-clamp $effect already handles overflow on coarse-pointer
+       devices. Widen slightly for thumb reach. */
     .held-pop {
-      position: fixed;
-      top: 50%;
-      left: 50%;
-      right: auto;
-      bottom: auto;
-      transform: translate(-50%, -50%);
-      margin: 0;
-      width: min(420px, 92vw);
-      max-width: none;
-      max-height: 85vh;
-      z-index: 51;
+      width: min(360px, 92vw);
     }
     .held-badge {
       min-height: 44px;

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -9,7 +9,8 @@
   import { formatReset, formatResetIn, relativeAge } from "$lib/format";
   import { displayStatus } from "$lib/display-status";
   import { gaugeList, hotterGauge, overspending, gaugeColor, type GaugeKey } from "./usage-gauges";
-  import { refreshUsage } from "$lib/api";
+  import { refreshUsage, listHeld, spawnHeld, discardHeld } from "$lib/api";
+  import type { HeldTask } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { modeOf, topBarPlan, badgeCount } from "./top-bar-layout";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
@@ -64,6 +65,7 @@
     learnings = 0,
     learningsCurate = 0,
     onlearnings,
+    heldCount = 0,
   }: {
     sessions: Session[];
     nowMs: number;
@@ -97,6 +99,8 @@
     learningsCurate?: number;
     /** Opens the global learnings drawer. */
     onlearnings?: () => void;
+    /** Number of held tasks; updated live by held:changed WS events. */
+    heldCount?: number;
   } = $props();
 
   // tally click: toggle — clicking the active status clears the filter
@@ -309,6 +313,112 @@
   // The inline bars stay for the at-a-glance read; the card is the detail view.
   let detailOpen = $state(false);
   let gaugeWrap = $state<HTMLElement | null>(null);
+
+  // ── Held-tasks popover ────────────────────────────────────────────────────
+  // Non-modal anchored popover (design-system "small anchored popover" exemption:
+  // not aria-modal on desktop, no scrim). Cloned from AutomationPanel's .auto-pop.
+  let heldPopOpen = $state(false);
+  let heldPopEl = $state<HTMLDivElement | null>(null);
+  let heldBadgeBtn = $state<HTMLButtonElement | null>(null);
+  let heldPopFlipUp = $state(false);
+  let heldItems = $state<HeldTask[]>([]);
+  let heldLoading = $state(false);
+
+  async function loadHeld() {
+    heldLoading = true;
+    try {
+      heldItems = await listHeld();
+    } catch {
+      // best-effort; count stays live via WS
+    } finally {
+      heldLoading = false;
+    }
+  }
+
+  function openHeldPop() {
+    heldPopOpen = true;
+    loadHeld();
+  }
+
+  function closeHeldPop(returnFocus = false) {
+    heldPopOpen = false;
+    if (returnFocus) heldBadgeBtn?.focus();
+  }
+
+  function toggleHeldPop() {
+    if (heldPopOpen) closeHeldPop();
+    else openHeldPop();
+  }
+
+  async function doSpawnHeld(id: string) {
+    try {
+      await spawnHeld(id);
+      await loadHeld();
+    } catch {
+      // ignore; WS will update count
+    }
+  }
+
+  async function doDiscardHeld(id: string) {
+    try {
+      await discardHeld(id);
+      await loadHeld();
+    } catch {
+      // ignore
+    }
+  }
+
+  // Flip-up + height clamp for held popover — mirrors AutomationPanel's $effect.
+  const MIN_HEIGHT_HELD = 120;
+  const EDGE_GAP_HELD = 12;
+  const ANCHOR_GAP_HELD = 4;
+  $effect(() => {
+    const el = heldPopEl;
+    if (!el) return;
+    const clamp = () => {
+      if (window.matchMedia("(pointer: coarse)").matches) {
+        el.style.maxHeight = "";
+        heldPopFlipUp = false;
+        return;
+      }
+      const anchor = el.offsetParent;
+      if (!anchor) return;
+      const rect = anchor.getBoundingClientRect();
+      const below = window.innerHeight - rect.bottom - ANCHOR_GAP_HELD - EDGE_GAP_HELD;
+      const above = rect.top - ANCHOR_GAP_HELD - EDGE_GAP_HELD;
+      heldPopFlipUp = below < MIN_HEIGHT_HELD && above > below;
+      el.style.maxHeight = `${Math.max(MIN_HEIGHT_HELD, heldPopFlipUp ? above : below)}px`;
+    };
+    let raf = 0;
+    const schedule = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        clamp();
+      });
+    };
+    clamp();
+    window.addEventListener("resize", schedule);
+    window.addEventListener("scroll", schedule, true);
+    const ro = new ResizeObserver(schedule);
+    if (el.offsetParent) ro.observe(el.offsetParent);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", schedule);
+      window.removeEventListener("scroll", schedule, true);
+      ro.disconnect();
+    };
+  });
+
+  // Auto-close held popover when count drops to 0 while open.
+  $effect(() => {
+    if (heldPopOpen && (heldCount ?? 0) === 0) closeHeldPop();
+  });
+  // Refresh held list when the WS count changes while the popover is open.
+  $effect(() => {
+    void heldCount;
+    if (heldPopOpen) loadHeld();
+  });
   $effect(() => {
     // close the popover when it can no longer be opened (no gauge AND no credit, or off touch)
     if (!touch || (!hotter && !credits)) popoverOpen = false;
@@ -429,10 +539,23 @@
   function dismissOnEscape(e: KeyboardEvent) {
     if (e.key !== "Escape") return;
     if (popoverOpen) popoverOpen = false;
+    if (heldPopOpen) {
+      closeHeldPop(true);
+      return;
+    }
     if (menuOpen) closeMenu(true);
   }
   function dismissOnOutside(e: MouseEvent) {
     if (popoverOpen && gaugeWrap && !gaugeWrap.contains(e.target as Node)) popoverOpen = false;
+    if (
+      heldPopOpen &&
+      heldBadgeBtn &&
+      heldPopEl &&
+      !heldBadgeBtn.contains(e.target as Node) &&
+      !heldPopEl.contains(e.target as Node)
+    ) {
+      closeHeldPop();
+    }
     // On mobile the sheet's own `.menu-scrim` backdrop (onclick={() => closeMenu()}) handles
     // outside-tap and `use:dialog` handles Esc — so we MUST NOT gate on gearWrap containment
     // here, or every in-sheet click (which bubbles to <svelte:window>) wrongly dismisses the
@@ -639,6 +762,71 @@
           {m.common_needs_you({ count: needsYou })}
         {/if}
       </button>
+    {/if}
+    {#if (heldCount ?? 0) > 0}
+      <!-- Held-tasks badge: non-modal anchored popover (design-system exemption). -->
+      <div class="held-wrap">
+        <button
+          bind:this={heldBadgeBtn}
+          class="held-badge"
+          class:compact={mobile || compactBadges}
+          type="button"
+          aria-haspopup="dialog"
+          aria-expanded={heldPopOpen}
+          aria-label={m.topbar_held_badge({ count: heldCount ?? 0 })}
+          onclick={toggleHeldPop}
+        >
+          {#if mobile || compactBadges}
+            <span class="held-n">{heldCount}</span>
+          {:else}
+            <span>{m.topbar_held_badge({ count: heldCount ?? 0 })}</span>
+            {#if hotter?.w.resetAt}
+              <span class="held-reset"
+                >{m.topbar_held_resets({ time: formatResetIn(hotter.w.resetAt, nowMs) })}</span
+              >
+            {/if}
+          {/if}
+        </button>
+        {#if heldPopOpen}
+          <div
+            bind:this={heldPopEl}
+            class={["held-pop", { "flip-up": heldPopFlipUp }]}
+            role="dialog"
+            aria-label={m.topbar_held_title()}
+            tabindex="-1"
+          >
+            <div class="held-pop-head">{m.topbar_held_title()}</div>
+            {#if heldLoading}
+              <div class="held-pop-empty">{m.common_loading()}</div>
+            {:else if heldItems.length === 0}
+              <div class="held-pop-empty">{m.topbar_held_empty()}</div>
+            {:else}
+              {#each heldItems as task (task.id)}
+                <div class="held-row">
+                  <div class="held-row-info">
+                    <span class="held-row-prompt">{task.input.prompt}</span>
+                    <span class="held-row-repo"
+                      >{task.repoPath.split("/").at(-1) ?? task.repoPath}</span
+                    >
+                  </div>
+                  <div class="held-row-actions">
+                    <button
+                      type="button"
+                      class="held-action held-spawn"
+                      onclick={() => doSpawnHeld(task.id)}>{m.topbar_held_spawn_now()}</button
+                    >
+                    <button
+                      type="button"
+                      class="held-action held-discard"
+                      onclick={() => doDiscardHeld(task.id)}>{m.topbar_held_discard()}</button
+                    >
+                  </div>
+                </div>
+              {/each}
+            {/if}
+          </div>
+        {/if}
+      </div>
     {/if}
     {#if !mobile}
       {#if subscriptionOnly}
@@ -2253,5 +2441,150 @@
       opacity: 1;
       transform: translateY(0);
     }
+  }
+
+  /* ── Held-tasks badge + popover ──────────────────────────────────────────── */
+  .held-wrap {
+    position: relative;
+  }
+  .held-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: transparent;
+    border: 1px solid var(--color-amber);
+    border-radius: 2px;
+    color: var(--color-amber);
+    font: inherit;
+    font-size: var(--fs-meta);
+    letter-spacing: 0.06em;
+    padding: 3px 8px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .held-badge:hover {
+    background: color-mix(in srgb, var(--color-amber) 10%, transparent);
+  }
+  .held-badge .held-n {
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+  .held-badge .held-reset {
+    color: color-mix(in srgb, var(--color-amber) 70%, transparent);
+    font-size: var(--fs-micro);
+  }
+  /* Anchored popover — mirrors .auto-pop from AutomationPanel */
+  .held-pop {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 20;
+    margin-top: 4px;
+    width: 300px;
+    max-width: 90vw;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+    color: var(--color-ink);
+    max-height: 85vh;
+    overflow-y: auto;
+  }
+  .held-pop.flip-up {
+    top: auto;
+    bottom: 100%;
+    margin-top: 0;
+    margin-bottom: 4px;
+  }
+  @media (pointer: coarse) {
+    .held-pop {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      right: auto;
+      bottom: auto;
+      transform: translate(-50%, -50%);
+      margin: 0;
+      width: min(420px, 92vw);
+      max-width: none;
+      max-height: 85vh;
+      z-index: 51;
+    }
+    .held-badge {
+      min-height: 44px;
+      min-width: 44px;
+    }
+  }
+  .held-pop-head {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    padding: 10px 12px 6px;
+  }
+  .held-pop-empty {
+    font-size: var(--fs-meta);
+    color: var(--color-faint);
+    padding: 6px 12px 10px;
+  }
+  .held-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 6px 12px;
+    border-top: 1px solid var(--color-line);
+  }
+  .held-row-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
+  }
+  .held-row-prompt {
+    font-size: var(--fs-meta);
+    color: var(--color-ink-bright);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 22ch;
+  }
+  .held-row-repo {
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+    letter-spacing: 0.04em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .held-row-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .held-action {
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    font: inherit;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.06em;
+    padding: 2px 8px;
+    cursor: pointer;
+    white-space: nowrap;
+    color: var(--color-ink);
+  }
+  .held-action:hover {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .held-spawn {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
+  }
+  .held-spawn:hover {
+    background: color-mix(in srgb, var(--color-amber) 10%, transparent);
   }
 </style>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1190,4 +1190,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_model_1m_body",
     targetId: "model-1m-context",
   },
+  {
+    // No targetId: the toggle lives in the Settings modal SESSION tab (closed by default),
+    // so a coachmark anchor would rarely be mounted — surface via the What's-New drawer only.
+    // v1.34.0 is the latest released tag → ships in 1.35.0.
+    id: "usage-aware-holding",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_usage_aware_holding_title",
+    bodyKey: "feat_usage_aware_holding_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -49,6 +49,8 @@ export class HerdStore {
   get diagnosticsOverall(): DiagnosticState {
     return this.diagnostics?.overall ?? "ok";
   }
+  /** Number of tasks currently held (waiting for usage to reset). Updated by `held:changed` WS events. */
+  heldCount = $state(0);
   /** "Star us on GitHub?" nudge state; null until the first GET/push. */
   starPrompt = $state<StarPromptStatus | null>(null);
   git = $state<Record<string, GitState>>({});
@@ -455,6 +457,9 @@ export class HerdStore {
           (e) =>
             e.repoPath !== ev.data.repoPath || e.parentIssueNumber !== ev.data.parentIssueNumber,
         );
+        break;
+      case "held:changed":
+        this.heldCount = ev.data.count;
         break;
       case "halt:done":
         // Fleet-wide stop landed: confirm the reach to EVERY connected operator (the

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -65,6 +65,10 @@ export interface Settings {
    *  when the HUD is fronted on a different host than the node. Null when tailscale is
    *  absent → fall back to the operator's own connection host. */
   previewHost: string | null;
+  /** Whether usage-aware task holding is enabled (new tasks paused when usage is high). */
+  usageHoldEnabled: boolean;
+  /** Usage percentage at or above which new tasks are held (0–100). */
+  usageHoldPct: number;
 }
 
 export interface DirEntry {
@@ -894,7 +898,8 @@ export type WsEvent =
   | { event: "epic:update"; data: Epic }
   | { event: "epic:completed"; data: CompletedEpic }
   | { event: "epic:completed-cleared"; data: { repoPath: string; parentIssueNumber: number } }
-  | { event: "session:egress-drop"; data: { id: string; host: string } };
+  | { event: "session:egress-drop"; data: { id: string; host: string } }
+  | { event: "held:changed"; data: { count: number } };
 
 /** Optional override bag for relaunch; absent fields inherit the original session. */
 export interface RelaunchOverrides {
@@ -918,6 +923,22 @@ export interface CreateInput {
   sandboxProfile?: SandboxProfile | null; // per-spawn sandbox override; absent → inherit repo default
   research?: boolean; // research task kind; absent → false
   mergeTrainPrs?: number[]; // merge-train participant PR numbers; server marks them "merging" on create
+}
+
+/** A task that was held (not immediately spawned) because usage was too high.
+ *  Returned by GET /api/held and the POST /api/sessions held-path. */
+export interface HeldTask {
+  id: string;
+  repoPath: string;
+  input: CreateInput;
+  createdAt: number;
+}
+
+/** Returned by POST /api/sessions when the task is held instead of spawned immediately. */
+export interface HeldResult {
+  held: true;
+  id: string;
+  count: number;
 }
 
 /** Selectable claude model aliases; null = claude's own default.

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -382,7 +382,7 @@
   let settings = $state<Settings_ | null>(null);
   // Usage hold settings — extracted from the settings object for the holdLikely derived.
   let usageHoldEnabled = $state(false);
-  let usageHoldPct = $state(75);
+  let usageHoldPct = $state(80);
   // First-run nudge: backlog quick-launch buttons are invisible until at least one
   // issue-scoped steer exists. The steers store updates live on editor save, so a
   // just-added action dismisses the hint without a reload.
@@ -1251,7 +1251,11 @@
     if (relaunchOriginalId !== null) return submitRelaunch(relaunchOriginalId, input);
     const r = await createSession(input);
     if ("held" in r) {
+      // Held tasks are queued (visible via the TopBar badge); close the composer like a
+      // normal submit so the populated prompt can't be re-clicked into a duplicate hold.
       toasts.info(m.toast_task_held());
+      showNew = false;
+      resetCompose();
       return;
     }
     selectedId = r.id;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -518,11 +518,12 @@
     const br = await listBranches(repoPath).catch(() => null);
     const baseBranch = pickBaseBranch(br);
     try {
-      const s = await createSession({
+      const r = await createSession({
         repoPath,
         baseBranch,
         prompt: cmd,
         model: null,
+        force: true,
         issueRef: {
           number: issue.number,
           url: issue.url,
@@ -530,7 +531,8 @@
           body: issue.body,
         },
       });
-      selectedId = s.id;
+      if ("held" in r) return;
+      selectedId = r.id;
       showBacklog = false;
       if (mobile.current) mobileScreen = "detail";
     } catch {
@@ -566,8 +568,12 @@
         const br = await listBranches(repoPath).catch(() => null);
         const baseBranch = pickBaseBranch(br);
         try {
-          const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs));
-          selectedId = s.id;
+          const r = await createSession({
+            ...mergeTrainCreateInput(repoPath, baseBranch, prs),
+            force: true,
+          });
+          if ("held" in r) return;
+          selectedId = r.id;
           showBacklog = false;
           if (mobile.current) mobileScreen = "detail";
         } catch {
@@ -595,8 +601,12 @@
         const br = await listBranches(repoPath).catch(() => null);
         const baseBranch = pickBaseBranch(br);
         try {
-          const s = await createSession(mergeTrainCreateInput(repoPath, baseBranch, prs, true));
-          selectedId = s.id;
+          const r = await createSession({
+            ...mergeTrainCreateInput(repoPath, baseBranch, prs, true),
+            force: true,
+          });
+          if ("held" in r) return;
+          selectedId = r.id;
           showBacklog = false;
           if (mobile.current) mobileScreen = "detail";
         } catch {
@@ -1216,8 +1226,12 @@
   }) {
     // Relaunch-elsewhere path branches off to submitRelaunch; otherwise the New Task create.
     if (relaunchOriginalId !== null) return submitRelaunch(relaunchOriginalId, input);
-    const s = await createSession(input);
-    selectedId = s.id;
+    const r = await createSession(input);
+    if ("held" in r) {
+      toasts.info(m.toast_task_held());
+      return;
+    }
+    selectedId = r.id;
     showNew = false;
     resetCompose();
   }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -45,6 +45,7 @@
     resumeQuota,
     dismissQuota,
     getBuildQueues,
+    listHeld,
   } from "$lib/api";
   import type {
     CompletedEpic,
@@ -379,16 +380,34 @@
   let backlog = $state<BacklogPayload | null>(null);
   // loaded once on mount (previewHost etc.); re-read on settings close.
   let settings = $state<Settings_ | null>(null);
+  // Usage hold settings — extracted from the settings object for the holdLikely derived.
+  let usageHoldEnabled = $state(false);
+  let usageHoldPct = $state(75);
   // First-run nudge: backlog quick-launch buttons are invisible until at least one
   // issue-scoped steer exists. The steers store updates live on editor save, so a
   // just-added action dismisses the hint without a reload.
   const issueActionsUnset = $derived(steers.loaded && !steers.list.some((s) => s.onIssues));
 
+  // Mirror of the server's shouldHold gate — predicts whether submitting a new task
+  // will result in it being held, so NewTask can offer the dual "Hold for reset" /
+  // "Submit anyway" buttons before the round-trip. usageLimits is null until the first
+  // snapshot lands, so the prediction is conservatively false until data is available.
+  const holdLikely = $derived(
+    usageHoldEnabled &&
+      Math.max(store.usageLimits?.session5h?.pct ?? 0, store.usageLimits?.week?.pct ?? 0) >=
+        usageHoldPct &&
+      store.sessions.filter((s) => s.status === "running").length >= 1,
+  );
+
   const selected = $derived(store.sessions.find((s) => s.id === selectedId) ?? null);
 
   function loadSettings() {
     getSettings()
-      .then((s) => (settings = s))
+      .then((s) => {
+        settings = s;
+        usageHoldEnabled = s.usageHoldEnabled;
+        usageHoldPct = s.usageHoldPct;
+      })
       .catch(() => {});
   }
 
@@ -1048,6 +1067,9 @@
     recaps.load();
     herdDigest.load();
     learnings.load();
+    listHeld()
+      .then((arr) => (store.heldCount = arr.length))
+      .catch(() => {});
     loadSettings();
     // Feature-discovery gate — synchronous, independent of loadSettings().
     // hydrate() reads localStorage; version + featureAnnouncements are compile-time constants.
@@ -1223,6 +1245,7 @@
     autopilotEnabled: boolean | null;
     sandboxProfile?: SandboxProfile;
     research: boolean;
+    force?: boolean;
   }) {
     // Relaunch-elsewhere path branches off to submitRelaunch; otherwise the New Task create.
     if (relaunchOriginalId !== null) return submitRelaunch(relaunchOriginalId, input);
@@ -1561,6 +1584,7 @@
           settingsTab = "diagnose";
           showSettings = true;
         }}
+        heldCount={store.heldCount}
       />
       <RepoSwitcher
         chips={repoChips}
@@ -1988,6 +2012,7 @@
     initialPrompt={composePrompt ?? undefined}
     initialModel={composeModel ?? undefined}
     defaultModel={settings?.defaultModel}
+    holdLikely={relaunchOriginalId === null ? holdLikely : false}
     onclose={() => {
       showNew = false;
       resetCompose();


### PR DESCRIPTION
## Part A — Usage-aware task holding (PR 1 of 2 for #825)

When the account nears its Claude usage cap, Shepherd should stop fanning out **new manual** work
that would race the limit to zero. This PR parks a newly-submitted manual task in a persistent held
queue when usage is high **and** the herd is already busy, auto-releases it FIFO once usage drops,
and always lets the operator override.

Part B (detect usage-halted sessions + one-click global retry) ships as a **separate follow-up PR**.

### Behavior
A manual `POST /api/sessions` is **held** instead of spawned only when ALL hold:
`usageHoldEnabled` (new account-global setting) **and** `max(session5h.pct, week.pct) >= usageHoldPct`
(default 80) **and** at least one session is already `running` **and** the request didn't pass
`force: true`. Held tasks auto-release FIFO on the existing 30s usage tick once usage drops below the
threshold; the operator can **Spawn now** or **discard** any held task from a TopBar popover, or
**Submit anyway** at create time.

Auto-drain is untouched — it already self-gates on per-repo `usageCeilingPct`. This covers the
**manual** path only.

### ⚠️ Disclosed default-on behavior change
`usageHoldEnabled` defaults **on**, so after upgrade manual submits begin holding when usage is high
and a session is already running — with no operator action. This is intentional (the feature is inert
otherwise) and is surfaced in the What's-New drawer; the **Submit anyway** action and the
**Settings → Session** toggle are the opt-outs.

### What's included
- **Server:** pure `shouldHold()` (`src/usage-hold.ts`); `held_tasks` SQLite table + helpers; the
  hold gate at the create chokepoint; `GET /api/held` + `POST /api/held/:id/spawn` +
  `DELETE /api/held/:id`; `held:changed` WS event; account-global `usageHoldEnabled`/`usageHoldPct`
  settings; a `.catch`-guarded, FIFO, bounded auto-release sweeper (`src/held-release.ts`).
- **UI:** `createSession` held-result handling at every call site; NewTask **Hold for reset** /
  **Submit anyway** dual submit (shown only when a hold is predicted); TopBar **"N held"** badge +
  non-modal popover (spawn-now / discard); Settings controls; feature-announcement (1.35.0); EN+DE.

### Testing
- `shouldHold` truth table; `held_tasks` round-trip; hold-gate regressions via `makeApp`
  (high-usage+busy → held; force / idle-herd / disabled → spawn); auto-release sweeper (FIFO, bounded,
  fail-stop).
- Full suites green: root **3895 tests**, ui **1684 tests**, tsc/lint/i18n parity/branch-hygiene/
  feature-catalog/glossary/Fallow complexity all pass.

Closes part of #825 (Part A). 🤖 Generated with [Claude Code](https://claude.com/claude-code)
