### PR TITLE
fix(ui): keep herd Rundown filter in bounds on unfolded-fold (compact) layout

### DIFF
--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -900,6 +900,17 @@
     display: flex;
     gap: 4px;
   }
+  /* Compact (touch / unfolded-fold) layout pins the sidebar to ~288px. There the
+     .phead wraps the whole .right.filters group onto its own line, where it sizes
+     to its content width (~330px) and spills past the panel's right border (the
+     trailing "Rundown" filter). Let the group wrap onto a second row only here;
+     the non-touch desktop sidebar resolves to its 360px max where the row fits on
+     one line, so it stays single-line and unchanged. The ancestor .grid.compact
+     lives in +page.svelte (outside this component), hence the :global wrapper. */
+  :global(.grid.compact) .filters {
+    flex-wrap: wrap;
+    row-gap: 4px;
+  }
   .fbtn {
     border: 0;
     background: none;


### PR DESCRIPTION
## Problem

On an **unfolded foldable / touch tablet** (the `.grid.compact` layout, which pins the herd sidebar to ~288px), the filter row above THE HERD session list — `▦ All · ▤ Ready · ⬡ Research · ✓ Done · ☰ Rundown` — overflows the panel: the `.phead` wraps the whole `.right.filters` group onto its own line, where it sizes to its content width (~330px) and the trailing **Rundown** filter spills **past the panel's right border**.

This is the bug in the reported screenshot.

## Root cause

`.filters` (`ui/src/lib/components/Herd.svelte`) is a single-line, non-wrapping flex group. When `.phead` (which has `flex-wrap: wrap`) drops the group onto its own line, the group sizes to its content rather than the panel width — so it overflows horizontally instead of wrapping.

## Fix

Scope `flex-wrap: wrap` (+ `row-gap`) to the **compact** layout only:

```css
:global(.grid.compact) .filters {
  flex-wrap: wrap;
  row-gap: 4px;
}
```

The compact-only scope is deliberate: the non-touch desktop sidebar always resolves to its 360px max, where the row fits on a single line — so desktop is left **exactly unchanged** (no extra wrap line). `.grid.compact` is an ancestor in `+page.svelte`, hence the `:global` wrapper.

## Verification

Reproduced under **coarse-pointer / touch emulation** (compact mode is pointer-gated via `MediaQuery("(pointer: coarse)")`, not window-width-gated), measuring the RUNDOWN button's right edge vs. the panel border:

| Context | Pre-fix | Post-fix |
|---|---|---|
| Desktop, 360px sidebar | RUNDOWN −15px (1 line) | **unchanged** −15px, 1 line |
| Compact EN, 288px | RUNDOWN **+25px past border** | −120px inside, wraps to 2 rows |
| Compact DE, 288px (longer `Recherche`) | overflowed | −103px inside; trailing `‹` collapse btn at −21px; 2 rows |

In compact, `filters.scrollWidth === clientWidth` after the fix (no horizontal overflow). The inline `‹` collapse button and conditional statchip wrap cleanly onto the second row (no awkward lone line) — verified visually in EN and DE.

CSS-only, one rule. No new i18n keys, no feature-catalog entry (not a `feat`). `cd ui && bun run check` passes; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)