### PR TITLE
refactor(ui): drop inert fallow complexity markers (#832)

### DIFF
--- a/ui/src/lib/components/AutomationSettings.svelte
+++ b/ui/src/lib/components/AutomationSettings.svelte
@@ -176,13 +176,7 @@
 </script>
 
 <!-- info/detail snippets are declared at the bottom of this file (Svelte hoists
-     top-level snippets) so the first markup node here is the main settings template,
-     keeping the fallow complexity-ignore anchored to a single, stable line. -->
-
-<!-- Intentional single cohesive settings panel: one row per per-repo toggle/field.
-     The template "complexity" is just the row count — extracted verbatim from the
-     former AutomationPanel body, not new logic. -->
-<!-- fallow-ignore-next-line complexity -->
+     top-level snippets), keeping the main settings template first. -->
 {#if showHeader}
   <div class="auto-head">{m.automation_panel_title()}</div>
   <div class="auto-sub">{m.automation_panel_subtitle()}</div>

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -143,9 +143,6 @@
 </script>
 
 <div class="backlog-view" class:mobile class:flow>
-  <!-- Pre-existing large master/detail template; this change only adds one Automation
-       tab + branch. Complexity is inherent to the multi-tab layout, not introduced here. -->
-  <!-- fallow-ignore-next-line complexity -->
   {#if payload === null}
     <!-- loading state -->
     <div class="state-full">

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1495,9 +1495,6 @@
   }
 </script>
 
-<!-- Pre-existing top-level page template; this change only threads a `drain` prop into
-     three existing BacklogView mounts. Complexity is inherent, not introduced here. -->
-<!-- fallow-ignore-next-line complexity -->
 <svelte:window onkeydown={onShortcut} />
 
 <div


### PR DESCRIPTION
Closes #832.

## What

Removes the three `<!-- fallow-ignore-next-line complexity -->` markers PR #829 added to `AutomationSettings.svelte`, `BacklogView.svelte`, and `routes/+page.svelte` (plus their now-stale rationale comments). Comment-only; **no behavior change**.

## Why this — and not the component-split #832 implies

The issue is framed around `<template>` cyclomatic/cognitive numbers (50/57, 37/70, 74/92) and suggests splitting these templates into child components. But those numbers come from fallow **2.98+/2.99**. The repo deliberately pins the gate to **`fallow@2.97.0`** (`.github/workflows/ci.yml:116`, `.husky/pre-push:70`, `CONTRIBUTING.md:85,112`) — the **last release before the synthetic `<template>` metric**, which was pinned out on purpose (it broke inherited-vs-introduced attribution — #756).

Measured against the **actual pinned gate**, with all three markers stripped:

```
$ bunx fallow@2.97.0 audit --base origin/main --fail-on-issues
■ Metrics: dead code 0 · complexity 0 · duplication 3
✓ No issues in 3 changed files        # exit 0 — PASS
  audit gate excluded 3 inherited findings
```

`complexity 0`: **2.97.0 emits no template-complexity finding for these files** — the markers suppress a metric the gate never computes. They are **inert no-ops**, so removing them satisfies #832's "Done when" (markers gone, gate green) with zero refactoring and zero behavior change. A full child-component split would be chasing a metric the repo intentionally does not enforce.

## Verification

- `bunx fallow@2.97.0 audit --base origin/main --fail-on-issues` → **exit 0**
- root `bun run lint` ✓ · `bun run typecheck` ✓ · `bun test ./test` ✓ (3890 pass / 0 fail)
- `cd ui` → `bun run check` ✓ · `check:i18n` ✓ · `bun run test` ✓ · `bun run build` ✓

## Future-bump note

If the repo later adopts fallow **2.98+**, these large files would re-trip the new `<template>` gate. Per `CONTRIBUTING.md:97` the intended remedy at that point is a deliberate `<template>` **config** (`health.thresholdOverrides` / `health.ignore`) at bump time — not per-file splitting now. Filing a complexity-reduction follow-up for the pre-existing `IssuesPanel`/`PromptSources` flags was therefore also moot under the pinned gate and is not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)