### PR TITLE
fix(recap): recover prose-wrapped + variant verdicts; log recap failures

### DIFF
--- a/src/json-tolerant.ts
+++ b/src/json-tolerant.ts
@@ -49,7 +49,7 @@ export function tolerantParseJson(text: string): TolerantParse {
 export type VerdictRead<T> =
   | { status: "absent" }
   | { status: "parsed"; value: T; repaired: boolean }
-  | { status: "unparseable" };
+  | { status: "unparseable"; raw?: string };
 
 /**
  * Is the verdict spawn at `cwd` still actively producing output? Only `agentStatus === "working"`

--- a/src/recap-core.ts
+++ b/src/recap-core.ts
@@ -11,9 +11,38 @@ export const RECAP_VERDICTS: readonly RecapVerdict[] = ["ready", "parked", "need
 export const RECAP_HEADLINE_MAX = 100;
 export const RECAP_DIGEST_MAX_CHARS = 4000;
 
+/** Recover the recap object from a parse that an unattended agent's chatty output mangled.
+ *  jsonrepair turns prose-wrapped JSON ("Here is the recap:\n{…}" or "{…}\nDone.") into an
+ *  ARRAY (e.g. `["Here is the recap:", {…}]`); pull the first recap-shaped element back out so a
+ *  preamble/epilogue doesn't sink an otherwise-complete verdict. A bare object passes through. */
+function unwrapRecapObject(raw: unknown): Record<string, unknown> | null {
+  if (Array.isArray(raw)) {
+    const found = raw.find(
+      (e) => !!e && typeof e === "object" && !Array.isArray(e) && "verdict" in (e as object),
+    );
+    return (found as Record<string, unknown>) ?? null;
+  }
+  if (raw && typeof raw === "object") return raw as Record<string, unknown>;
+  return null;
+}
+
+/** Normalize a verdict to the enum, tolerating formatting variance (case, surrounding
+ *  whitespace, hyphen/space separators) — e.g. "Needs-Attention" / " READY " → enum value.
+ *  Returns null for anything that is not one of RECAP_VERDICTS after normalization (no synonym
+ *  guessing: "complete"/"approve" stay rejected — we never invent the agent's intent). */
+function normalizeVerdict(v: unknown): RecapVerdict | null {
+  if (typeof v !== "string") return null;
+  const n = v
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  return (RECAP_VERDICTS as readonly string[]).includes(n) ? (n as RecapVerdict) : null;
+}
+
 /** Parse + validate the raw .shepherd-recap.json the spawn wrote. Returns null when the
  *  shape is invalid (caller fails closed). Clamps headline to RECAP_HEADLINE_MAX, coerces
- *  openItems to a string[] (drops non-strings), requires verdict ∈ RECAP_VERDICTS.
+ *  openItems to a string[] (drops non-strings), requires verdict ∈ RECAP_VERDICTS (normalized).
+ *  Unwraps a prose-wrapped array (see unwrapRecapObject) so a chatty agent doesn't fail the recap.
  *  blocks is additive — parsed tolerantly via parseVisualBlocks ([] on missing/garbage). */
 export function parseRecapVerdict(raw: unknown): {
   verdict: RecapVerdict;
@@ -22,11 +51,11 @@ export function parseRecapVerdict(raw: unknown): {
   openItems: string[];
   blocks: VisualBlock[];
 } | null {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
-  const r = raw as Record<string, unknown>;
+  const r = unwrapRecapObject(raw);
+  if (!r) return null;
 
-  const verdict = r.verdict;
-  if (!RECAP_VERDICTS.includes(verdict as RecapVerdict)) return null;
+  const verdict = normalizeVerdict(r.verdict);
+  if (!verdict) return null;
 
   const headline = typeof r.headline === "string" ? r.headline.slice(0, RECAP_HEADLINE_MAX) : "";
   const body = typeof r.body === "string" ? r.body : "";
@@ -36,7 +65,7 @@ export function parseRecapVerdict(raw: unknown): {
     : [];
   const blocks = parseVisualBlocks(r.blocks);
 
-  return { verdict: verdict as RecapVerdict, headline, body, openItems, blocks };
+  return { verdict, headline, body, openItems, blocks };
 }
 
 /** Build a bounded digest of what the agent did from parsed transcript entries

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -102,7 +102,15 @@ export function defaultReadVerdict(cwd: string): VerdictRead<unknown> {
   const r = tolerantParseJson(text);
   return r.status === "ok"
     ? { status: "parsed", value: r.value, repaired: r.repaired }
-    : { status: "unparseable" };
+    : { status: "unparseable", raw: text }; // carry bytes so tick() can log WHY it failed
+}
+
+/** Bounded, single-line snippet of a raw verdict for diagnostic logs (recap content is agent
+ *  summaries, redacted by prompt — never secrets). Keeps server logs grep-able without dumping 20KB. */
+function recapSnippet(s: string | undefined, max = 300): string {
+  if (!s) return "<empty>";
+  const oneLine = s.replace(/\s+/g, " ").trim();
+  return oneLine.length > max ? `${oneLine.slice(0, max)}…` : oneLine;
 }
 
 function defaultMakeTmpDir(): string {
@@ -520,6 +528,20 @@ export class RecapService {
       // finalize-value carries the parsed verdict; finalize-null (timeout / fail-fast) → `failed`.
       const raw = action === "finalize-value" && read.status === "parsed" ? read.value : null;
 
+      // Observability: a `failed` recap used to be a black hole (no log, raw discarded), so an
+      // intermittent malformed write was undiagnosable. Surface WHY before finalizing.
+      if (action === "finalize-null") {
+        if (read.status === "unparseable") {
+          console.warn(
+            `[recap] ${r.sessionId}: verdict file present but unparseable even after jsonrepair — failing. snippet: ${recapSnippet(read.raw)}`,
+          );
+        } else {
+          console.warn(
+            `[recap] ${r.sessionId}: no verdict file after ${Math.round(this.timeoutMs / 1000)}s — agent produced nothing.`,
+          );
+        }
+      }
+
       this.finalizing.add(r.sessionId);
       try {
         await this.finalize(r, raw);
@@ -550,7 +572,15 @@ export class RecapService {
           updatedAt: t,
         };
       } else {
-        // timeout or unparseable — fail closed, never fake a ready
+        // timeout or unparseable — fail closed, never fake a ready. When raw was non-null the JSON
+        // parsed but failed recap-shape validation (bad verdict, unrecoverable structure); log it
+        // so the otherwise-silent failure is diagnosable (tick() already logged the raw==null cases).
+        if (raw != null) {
+          const v = (raw as { verdict?: unknown })?.verdict;
+          console.warn(
+            `[recap] ${r.sessionId}: verdict parsed as JSON but failed recap-shape validation (verdict=${JSON.stringify(v)}) — failing. snippet: ${recapSnippet(JSON.stringify(raw))}`,
+          );
+        }
         newRow = { ...rBase, state: "failed", blocks: [], generatedAt: t, updatedAt: t };
       }
       this.deps.store.putRecap(newRow);

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -13,6 +13,7 @@ import {
   RECAP_DIGEST_MAX_CHARS,
 } from "../src/recap-core";
 import { defaultReadVerdict } from "../src/recap";
+import { tolerantParseJson } from "../src/json-tolerant";
 import type { Recap } from "../src/types";
 
 // ── #822 regression: malformed-JSON read path (defaultReadVerdict → parseRecapVerdict) ──────────
@@ -61,6 +62,97 @@ test("#822 content fidelity: inner-quoted phrase survives repair verbatim (not t
   );
   expect(carrier).toBeDefined();
   expect((carrier as { markdown: string }).markdown).toContain('"Open for merge"');
+});
+
+// ── TASK-561 follow-up: intermittent retry failures the #822 failsafe did NOT cover ────────────
+//
+// #822 added jsonrepair, yet TASK-561 kept failing recap generation on retry. Live capture +
+// probing showed the residual failure modes were NOT "unparseable JSON" but jsonrepair-survivable
+// output that then fails parseRecapVerdict's shape check:
+//   1. A chatty agent wrapping the JSON in prose ("Here is the recap:\n{…}" / "{…}\nDone.") —
+//      jsonrepair rescues this into an ARRAY (["Here is the recap:", {…}]), which parseRecapVerdict
+//      rejected outright (arrays → null), discarding a complete verdict.
+//   2. Verdict formatting variance (hyphen / case): "needs-attention", " READY ".
+// Both deterministically produced a `failed` recap with an empty body. These tests FAIL on pre-fix
+// code (strict array reject / strict enum membership).
+
+test("TASK-561: prose-wrapped recap (jsonrepair array shape) recovers verdict + blocks", () => {
+  // The EXACT transform production sees: agent prepends prose, JSON.parse fails, jsonrepair wraps
+  // the prose + object into an array. Build it through the real jsonrepair path, not by hand.
+  const wrapped = `Here is the session recap:\n${JSON.stringify({
+    verdict: "ready",
+    headline: "Lightweight repo mode",
+    body: 'Operator clicks "Open for merge".',
+    openItems: [],
+    blocks: [
+      { type: "rich-text", id: "b1", markdown: "Local-only git." },
+      { type: "callout", id: "b2", tone: "decision", markdown: "Merge is local." },
+    ],
+  })}\nLet me know if you need anything else.`;
+
+  const tp = tolerantParseJson(wrapped);
+  expect(tp.status).toBe("ok");
+  if (tp.status !== "ok") throw new Error("unreachable");
+  expect(Array.isArray(tp.value)).toBe(true); // jsonrepair produced the array shape we recover from
+
+  const parsed = parseRecapVerdict(tp.value);
+  expect(parsed).not.toBeNull();
+  expect(parsed!.verdict).toBe("ready");
+  expect(parsed!.headline).toBe("Lightweight repo mode");
+  expect(parsed!.body).toContain('"Open for merge"');
+  expect(parsed!.blocks).toHaveLength(2);
+});
+
+test("TASK-561: parseRecapVerdict unwraps a recap object from a prose-wrapped array directly", () => {
+  const parsed = parseRecapVerdict([
+    "Here is the recap:",
+    { verdict: "needs_attention", headline: "x", body: "b", openItems: ["fix CI"] },
+    "Done.",
+  ]);
+  expect(parsed).not.toBeNull();
+  expect(parsed!.verdict).toBe("needs_attention");
+  expect(parsed!.openItems).toEqual(["fix CI"]);
+});
+
+test("TASK-561: array with no recap-shaped element still returns null", () => {
+  expect(parseRecapVerdict(["just", "prose", 42])).toBeNull();
+  expect(parseRecapVerdict([])).toBeNull();
+});
+
+test("TASK-561: verdict formatting variance (hyphen / case / whitespace) normalizes to enum", () => {
+  expect(
+    parseRecapVerdict({ verdict: "needs-attention", headline: "x", body: "", openItems: [] })
+      ?.verdict,
+  ).toBe("needs_attention");
+  expect(
+    parseRecapVerdict({ verdict: " READY ", headline: "x", body: "", openItems: [] })?.verdict,
+  ).toBe("ready");
+  expect(
+    parseRecapVerdict({ verdict: "Parked", headline: "x", body: "", openItems: [] })?.verdict,
+  ).toBe("parked");
+});
+
+test("TASK-561: verdict synonyms are NOT guessed (only formatting variance normalizes)", () => {
+  // "complete"/"approve" are real words the agent could emit but we must not invent intent for.
+  expect(
+    parseRecapVerdict({ verdict: "complete", headline: "x", body: "", openItems: [] }),
+  ).toBeNull();
+  expect(
+    parseRecapVerdict({ verdict: "approve", headline: "x", body: "", openItems: [] }),
+  ).toBeNull();
+});
+
+test("TASK-561: defaultReadVerdict carries raw bytes on unparseable (for failure logging)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "recap-561-unparse-"));
+  // jsonrepair is aggressive (it closes up most truncations), so the genuinely-irreparable class is
+  // a written-but-empty/whitespace file (agent opened the file then bailed). Its bytes must survive
+  // to the read so tick() can log them instead of failing silently.
+  const garbage = "   \n  ";
+  writeFileSync(join(dir, ".shepherd-recap.json"), garbage);
+  const read = defaultReadVerdict(dir);
+  expect(read.status).toBe("unparseable");
+  if (read.status !== "unparseable") throw new Error("unreachable");
+  expect(read.raw).toBe(garbage);
 });
 
 // ── parseRecapVerdict ────────────────────────────────────────────────────────

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -479,6 +479,49 @@ test("tick: generating row + valid verdict → state 'ready' + usage + stop + cl
   expect(cleaned).toContain("/tmp/recap-s1");
 });
 
+// TASK-561 follow-up: the #822 failsafe still left recap generation failing on retry. A chatty
+// agent wraps the JSON in prose, jsonrepair rescues it into an ARRAY (["Here is the recap:", {…}]),
+// and the OLD finalize → parseRecapVerdict rejected arrays → `failed`. The fix unwraps the recap
+// object from that array, so the full tick→finalize path now finalizes `ready` end-to-end.
+test("TASK-561 tick: prose-wrapped (jsonrepair array) verdict → state 'ready', not 'failed'", async () => {
+  const rec = makeRecap({ state: "generating", cwd: "/tmp/recap-prose", spawnedAt: 100_000 });
+  const store = makeStore([], [rec]);
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-prose", terminalId: "t-prose" }]);
+  const cleaned: string[] = [];
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    timeoutMs: 300_000,
+    // The array shape jsonrepair produces from prose-wrapped output (strict parse already finalizes,
+    // so the read reports repaired:false here — the array recovery lives in parseRecapVerdict).
+    verdictJson: [
+      "Here is the session recap:",
+      {
+        verdict: "needs-attention", // also exercises hyphen→underscore normalization
+        headline: "Lightweight repo mode",
+        body: 'Operator clicks "Open for merge".',
+        openItems: ["Document the mode"],
+        blocks: [{ type: "rich-text", id: "b1", markdown: "Local-only git." }],
+      },
+      "Let me know if you need anything else.",
+    ],
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  await svc.tick();
+
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("ready");
+  expect(r?.verdict).toBe("needs_attention");
+  expect(r?.headline).toBe("Lightweight repo mode");
+  expect(r?.body).toContain('"Open for merge"');
+  expect(r?.openItems).toEqual(["Document the mode"]);
+  expect(r?.blocks).toHaveLength(1);
+  expect(cleaned).toContain("/tmp/recap-prose");
+});
+
 test("tick timeout: generating row, no verdict, past timeout → state 'failed', reaped", async () => {
   const rec = makeRecap({
     state: "generating",

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -486,7 +486,12 @@ test("tick: generating row + valid verdict → state 'ready' + usage + stop + cl
 test("TASK-561 tick: prose-wrapped (jsonrepair array) verdict → state 'ready', not 'failed'", async () => {
   const rec = makeRecap({ state: "generating", cwd: "/tmp/recap-prose", spawnedAt: 100_000 });
   const store = makeStore([], [rec]);
-  const herdr = makeHerdr([{ cwd: "/tmp/recap-prose", terminalId: "t-prose" }]);
+  // Production: strict JSON.parse FAILS on prose-wrapped output, so the read is recovered via
+  // jsonrepair (repaired:true) into the array shape — and a repaired parse is gated on the spawn
+  // having finished (decideVerdictAction). Model that exactly: agent idle (finished) at the cwd.
+  const herdr = makeHerdr([
+    { cwd: "/tmp/recap-prose", terminalId: "t-prose", agentStatus: "idle" },
+  ]);
   const cleaned: string[] = [];
 
   const svc = buildSvc({
@@ -494,19 +499,24 @@ test("TASK-561 tick: prose-wrapped (jsonrepair array) verdict → state 'ready',
     herdr,
     nowFn: () => 200_000,
     timeoutMs: 300_000,
-    // The array shape jsonrepair produces from prose-wrapped output (strict parse already finalizes,
-    // so the read reports repaired:false here — the array recovery lives in parseRecapVerdict).
-    verdictJson: [
-      "Here is the session recap:",
-      {
-        verdict: "needs-attention", // also exercises hyphen→underscore normalization
-        headline: "Lightweight repo mode",
-        body: 'Operator clicks "Open for merge".',
-        openItems: ["Document the mode"],
-        blocks: [{ type: "rich-text", id: "b1", markdown: "Local-only git." }],
-      },
-      "Let me know if you need anything else.",
-    ],
+    // The array shape jsonrepair produces from prose-wrapped output, surfaced through the real
+    // repaired-gated read path (repaired:true + finished spawn → finalize); the array recovery
+    // itself lives in parseRecapVerdict.
+    verdictRead: {
+      status: "parsed",
+      repaired: true,
+      value: [
+        "Here is the session recap:",
+        {
+          verdict: "needs-attention", // also exercises hyphen→underscore normalization
+          headline: "Lightweight repo mode",
+          body: 'Operator clicks "Open for merge".',
+          openItems: ["Document the mode"],
+          blocks: [{ type: "rich-text", id: "b1", markdown: "Local-only git." }],
+        },
+        "Let me know if you need anything else.",
+      ],
+    },
     cleanup: (d) => cleaned.push(d),
   });
 


### PR DESCRIPTION
## Problem

TASK-561 (the lightweight-repo-mode task, ~50 changed files / 15 recap blocks) kept **failing recap generation on retry** even after the #822 `jsonrepair` failsafe. The failsafe only covered *malformed-but-repairable JSON* (unescaped inner quotes). The residual failures were a different class.

## Root cause (investigated against the live system)

Captured the real `.shepherd-recap.json` the spawn writes by triggering live regenerates for TASK-561 and snapshotting the temp file before finalize cleanup. The failed runs **fail-fast at ~150s** (not the 5-min timeout), i.e. the file parsed but was rejected downstream. Probing `jsonrepair` + `parseRecapVerdict` on realistic agent outputs pinned two deterministic gaps the failsafe doesn't cover:

1. **Prose-wrapped JSON.** A chatty agent prepends/appends prose (`"Here is the recap:\n{…}"`). Strict parse fails, and `jsonrepair` rescues it into an **array** (`["Here is the recap:", {…}]`) — which `parseRecapVerdict` rejected outright (arrays → `null`), discarding a complete verdict.
2. **Verdict formatting variance.** `"needs-attention"` / `" READY "` missed the strict enum membership check → `null`.

Both finalized a `failed` recap with an empty body. The failure was also a **black hole**: `finalize()` logged nothing and discarded the raw bytes, so intermittent malformed writes were undiagnosable — which is *why* "we added a failsafe but it still fails."

## Fix

- **`parseRecapVerdict`** (`src/recap-core.ts`): unwrap the first recap-shaped object from a prose-wrapped array; normalize the verdict (case + hyphen/space → underscore). No synonym guessing — `"complete"`/`"approve"` are still correctly rejected (we never invent the agent's intent).
- **Observability** (`src/recap.ts`, `src/json-tolerant.ts`): `tick()`/`finalize()` now log the failure class (unparseable / timeout / shape-invalid) with a bounded raw snippet; `VerdictRead.unparseable` carries the bytes. No new DB field/migration — logs go to `~/.shepherd/shepherd.log` alongside the existing `[recap]`/`[review]` warnings.

## Verification

- New regression tests **fail on pre-fix code, pass after**: prose-array unwrap + verdict normalization (unit), and the full `tick → finalize` path finalizing `ready` not `failed` (service). Verified by stashing the source and re-running.
- Real bytes captured from a live TASK-561 regenerate confirm the parser handles production output (now `ready`, 15 blocks).
- Root suite green (3896 pass / 0 fail — critic/review share `json-tolerant` and are unaffected), `tsc`/`lint`/`prettier`/`fallow` clean.

No user-facing UX change (server-side robustness + logging) — `[no-feature-entry]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)