### PR TITLE
feat: usage-halt detection + global retry (Part B of #825)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -398,6 +398,13 @@ const poller = new StatusPoller(
   // Phase-1 (issue #704): prune dead sessions' hook ring buffers from the poller's
   // pruneInactive (so they don't grow unbounded by session count).
   (ids) => hookIngest.prune(ids),
+  undefined, // onStopWindow — use default logger
+  // onHalt: session reached done with a usage-limit tail → push live so the UI
+  // can surface the RetryDialog without waiting for a full session refresh.
+  (id: string, haltReason: string, haltedAt: number) =>
+    events.emit("session:halt", { id, haltReason, haltedAt }),
+  // usageLimits: corroborates the transcript-tail match against measured pct windows.
+  usageLimits,
 );
 
 // Phase-1 push-hook signal wiring (issue #704): feed received hook events into the

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,9 +399,9 @@ const poller = new StatusPoller(
   // pruneInactive (so they don't grow unbounded by session count).
   (ids) => hookIngest.prune(ids),
   undefined, // onStopWindow — use default logger
-  // onHalt: session reached done with a usage-limit tail → push live so the UI
-  // can surface the RetryDialog without waiting for a full session refresh.
-  (id: string, haltReason: string, haltedAt: number) =>
+  // onHalt: a session's halt flag changed (usage-limit detected, or cleared on resume)
+  // → push live so the UI updates the RetryDialog/chip/badge without a full refresh.
+  (id: string, haltReason: string | null, haltedAt: number | null) =>
     events.emit("session:halt", { id, haltReason, haltedAt }),
   // usageLimits: corroborates the transcript-tail match against measured pct windows.
   usageLimits,

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -11,6 +11,9 @@ import {
 import { isStalled, DEFAULT_STALL, type ActivitySnapshot } from "./stall";
 import { jsonlPathFor } from "./usage";
 import { readTranscriptSignals, STRIP_WINDOW_MS, type SessionActivity } from "./activity-signal";
+import { readTranscriptTail } from "./activity";
+import { classifyHalt } from "./usage-halt";
+import type { UsageLimits } from "./usage-limits";
 import { maintenance } from "./maintenance";
 import { scanListeningPortsByWorktree, scanClaudeAliveByWorktree } from "./process-reaper";
 import { resolveDevPort } from "./preview";
@@ -190,6 +193,10 @@ export class StatusPoller {
   private lastClaudeAlive = new Map<string, boolean>();
   /** The resolved liveness wiring (with real defaults filled in). */
   private readonly livenessWiring: LivenessWiring;
+  /** Emitted when a session reaches done with a usage-limit halt detected. */
+  private readonly onHaltCb: (id: string, haltReason: string, haltedAt: number) => void;
+  /** Usage-limits service for corroboration in classifyHalt. */
+  private readonly usageLimitsSvc: { limits(now: number): UsageLimits };
 
   constructor(
     private store: SessionStore,
@@ -250,10 +257,28 @@ export class StatusPoller {
      * horizon). Pure measurement — never mutates status/routing. Defaults to a single
      * greppable `[hooks]` log line; tests inject a capturer.
      */
-    private onStopWindow: (id: string, windowMs: number | null) => void = (id, windowMs) => {
+    private onStopWindow: ((id: string, windowMs: number | null) => void) | undefined = (
+      id,
+      windowMs,
+    ) => {
       const kind = windowMs === null ? "no-stop" : windowMs > 0 ? "stop-wins" : "herdr-wins";
       console.log(`[hooks] stop-window session=${id} windowMs=${windowMs ?? "null"} case=${kind}`);
     },
+    /**
+     * Pushed when a session's transcript signals a usage-limit halt at the
+     * done transition. Wired in src/index.ts to emit `session:halt`.
+     * Defaults to a no-op so existing tests that omit it still compile.
+     * Optional (undefined ⇒ no-op) so callers can skip it with a positional
+     * `undefined` after `onStopWindow`.
+     */
+    onHalt?: (id: string, haltReason: string, haltedAt: number) => void,
+    /**
+     * Usage-limits service — provides the latest window percentages for the
+     * corroboration check in `classifyHalt`. Injectable for tests; defaults to
+     * a stub that returns fully-null limits (uncalibrated fallback).
+     * Optional (undefined ⇒ stub) so callers can skip it.
+     */
+    usageLimits?: { limits(now: number): UsageLimits },
   ) {
     // Merge supplied overrides with real defaults. When preview is omitted entirely
     // we create a no-op wiring so tick() never throws on undefined access.
@@ -274,6 +299,17 @@ export class StatusPoller {
       scan: liveness?.scan ?? ((worktrees) => scanClaudeAliveByWorktree(worktrees)),
       sweepMs: liveness?.sweepMs ?? config.previewSweepMs,
       onChange: liveness?.onChange ?? (() => {}),
+    };
+    this.onHaltCb = onHalt ?? (() => {});
+    this.usageLimitsSvc = usageLimits ?? {
+      limits: () => ({
+        session5h: null,
+        week: null,
+        credits: null,
+        stale: false,
+        calibratedAt: null,
+        subscriptionOnly: false,
+      }),
     };
   }
 
@@ -372,6 +408,7 @@ export class StatusPoller {
     this.pendingStopAt.delete(s.id);
     this.pendingDoneAt.delete(s.id);
     if (s.status !== "done") {
+      this.detectUsageHalt(s);
       this.store.update(s.id, { status: "done", lastState: "done" });
       this.onChange(s.id, "done");
     }
@@ -396,6 +433,10 @@ export class StatusPoller {
     // can never swallow the measurement. Pure measurement — does not alter status/routing.
     if (config.hooksSignals && status === "done" && s.status !== "done") {
       this.measureStopWindow(s.id, this.now());
+    }
+    // Detect usage-limit halt on the done-edge (live agent herdr-reports done).
+    if (status === "done" && s.status !== "done") {
+      this.detectUsageHalt(s);
     }
     this.dropReadyToMergeIfActionable(s, status);
     // Left herdr-blocked (running/idle/done alike) → the working-while-blocked
@@ -425,6 +466,35 @@ export class StatusPoller {
     if ((status === "running" || status === "blocked") && s.readyToMerge) {
       this.store.update(s.id, { readyToMerge: false });
       this.onReady(s.id, false);
+    }
+  }
+
+  /**
+   * Detect a usage-limit halt at the done transition.
+   *
+   * Called at BOTH done-entry points (reapGone + reconcileAgent done-edge),
+   * gated by `s.haltReason` being null so it only runs once per session.
+   * Reads the transcript tail synchronously (bounded read — see readTranscriptTail),
+   * wrapped in try/catch so a missing or unreadable file never throws into the
+   * tick loop. On a confirmed halt: persists via setHaltReason and emits
+   * onHalt so the UI can patch the live row.
+   */
+  private detectUsageHalt(s: Session): void {
+    if (s.haltReason) return; // already set; skip
+    try {
+      const tail = readTranscriptTail(jsonlPathFor(s.worktreePath, s.claudeSessionId));
+      const reason = classifyHalt(
+        tail,
+        this.usageLimitsSvc.limits(this.now()),
+        config.usageHoldPct,
+      );
+      if (reason) {
+        const haltedAt = this.now();
+        this.store.setHaltReason(s.id, reason, haltedAt);
+        this.onHaltCb(s.id, reason, haltedAt);
+      }
+    } catch {
+      // file may not exist for a never-run session; degrade silently
     }
   }
 
@@ -613,7 +683,7 @@ export class StatusPoller {
     const d = this.pendingDoneAt.get(id);
     if (d !== undefined && stopAt - d <= STOP_WINDOW_MAX_MS) {
       // herdr-wins: the done-flip preceded this Stop (window ≤ 0).
-      this.onStopWindow(id, d - stopAt);
+      this.onStopWindow?.(id, d - stopAt);
       this.pendingDoneAt.delete(id);
     } else {
       this.pendingStopAt.set(id, stopAt);
@@ -634,12 +704,12 @@ export class StatusPoller {
     const st = this.pendingStopAt.get(id);
     if (st !== undefined && doneAt - st <= STOP_WINDOW_MAX_MS) {
       // stop-wins: the Stop preceded this done-flip (window ≥ 0).
-      this.onStopWindow(id, doneAt - st);
+      this.onStopWindow?.(id, doneAt - st);
       this.pendingStopAt.delete(id);
     } else {
       // No pairable Stop. A prior pending done is being superseded by this fresh one and
       // never paired → emit null for it before overwriting.
-      if (this.pendingDoneAt.has(id)) this.onStopWindow(id, null);
+      if (this.pendingDoneAt.has(id)) this.onStopWindow?.(id, null);
       this.pendingDoneAt.set(id, doneAt);
     }
   }
@@ -654,7 +724,7 @@ export class StatusPoller {
     const now = this.now();
     for (const [id, doneAt] of this.pendingDoneAt) {
       if (now - doneAt > STOP_WINDOW_MAX_MS) {
-        this.onStopWindow(id, null);
+        this.onStopWindow?.(id, null);
         this.pendingDoneAt.delete(id);
       }
     }

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -193,8 +193,13 @@ export class StatusPoller {
   private lastClaudeAlive = new Map<string, boolean>();
   /** The resolved liveness wiring (with real defaults filled in). */
   private readonly livenessWiring: LivenessWiring;
-  /** Emitted when a session reaches done with a usage-limit halt detected. */
-  private readonly onHaltCb: (id: string, haltReason: string, haltedAt: number) => void;
+  /** Emitted when a session's halt state changes: a usage-limit halt is detected
+   *  (non-null reason), or the flag is cleared when the session resumes work (null). */
+  private readonly onHaltCb: (
+    id: string,
+    haltReason: Session["haltReason"],
+    haltedAt: number | null,
+  ) => void;
   /** Usage-limits service for corroboration in classifyHalt. */
   private readonly usageLimitsSvc: { limits(now: number): UsageLimits };
 
@@ -271,7 +276,7 @@ export class StatusPoller {
      * Optional (undefined ⇒ no-op) so callers can skip it with a positional
      * `undefined` after `onStopWindow`.
      */
-    onHalt?: (id: string, haltReason: string, haltedAt: number) => void,
+    onHalt?: (id: string, haltReason: Session["haltReason"], haltedAt: number | null) => void,
     /**
      * Usage-limits service — provides the latest window percentages for the
      * corroboration check in `classifyHalt`. Injectable for tests; defaults to
@@ -430,7 +435,7 @@ export class StatusPoller {
     // Observe-only Stop↔herdr-done measurement + usage-halt detection on the done-EDGE.
     // Placed BEFORE the tryHookAwaitingBlock early-return below so a stale
     // `hookAwaitingInput` short-circuit can never swallow the measurement.
-    if (status === "done" && s.status !== "done") this.handleDoneEdge(s);
+    this.handleStatusEdge(s, status);
     this.dropReadyToMergeIfActionable(s, status);
     // Left herdr-blocked (running/idle/done alike) → the working-while-blocked
     // display flag must drop in the SAME tick, not via the throttled probe paths.
@@ -470,6 +475,29 @@ export class StatusPoller {
   private handleDoneEdge(s: Session): void {
     if (config.hooksSignals) this.measureStopWindow(s.id, this.now());
     this.detectUsageHalt(s);
+  }
+
+  /**
+   * Halt-flag transitions at the status edge, dispatched from reconcileAgent (kept as one
+   * call so that method stays under the complexity gate):
+   *  - entering done  → detect a usage-limit halt (+ Stop-window measurement);
+   *  - resuming work (running, by retry / resume() / drain / autopilot) → clear the flag,
+   *    the single authoritative clear so a resumed session stops being badged "halted".
+   */
+  private handleStatusEdge(s: Session, status: Session["status"]): void {
+    if (status === "done" && s.status !== "done") this.handleDoneEdge(s);
+    else if (status === "running" && s.haltReason) this.clearHaltOnResume(s);
+  }
+
+  /**
+   * Clear a session's usage-halt flag once it is working again. Persists null and emits
+   * the clearing onHalt(null) so the delta-driven UI (the ⟳ chip, the "halted" badge,
+   * RetryDialog preselect) drops it live. Gated by `s.haltReason` in the caller, so it
+   * fires once — the next tick reads a null flag.
+   */
+  private clearHaltOnResume(s: Session): void {
+    this.store.setHaltReason(s.id, null, null);
+    this.onHaltCb(s.id, null, null);
   }
 
   /**

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -12,7 +12,7 @@ import { isStalled, DEFAULT_STALL, type ActivitySnapshot } from "./stall";
 import { jsonlPathFor } from "./usage";
 import { readTranscriptSignals, STRIP_WINDOW_MS, type SessionActivity } from "./activity-signal";
 import { readTranscriptTail } from "./activity";
-import { classifyHalt } from "./usage-halt";
+import { classifyHalt, assistantSideText } from "./usage-halt";
 import type { UsageLimits } from "./usage-limits";
 import { maintenance } from "./maintenance";
 import { scanListeningPortsByWorktree, scanClaudeAliveByWorktree } from "./process-reaper";
@@ -514,8 +514,11 @@ export class StatusPoller {
     if (s.haltReason) return; // already set; skip
     try {
       const tail = readTranscriptTail(jsonlPathFor(s.worktreePath, s.claudeSessionId));
+      // Match only NON-user transcript content: a user prompt mentioning usage-limit
+      // phrasing must never be read as Claude's own halt notice (false positive on the
+      // uncalibrated degrade path, where the usage corroboration is bypassed).
       const reason = classifyHalt(
-        tail,
+        assistantSideText(tail),
         this.usageLimitsSvc.limits(this.now()),
         config.usageHoldPct,
       );

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -427,17 +427,10 @@ export class StatusPoller {
       this.onChange(s.id, status); // nudge clients to re-attach the PTY to the fresh terminal
     }
     if (idChanged) s = { ...s, herdrAgentId: agent.terminalId };
-    // Observe-only Stop↔herdr-done measurement (issue #713): on the done-EDGE (status flips
-    // to done; `s.status` holds the PRIOR value) record/pair the window. Placed BEFORE the
-    // tryHookAwaitingBlock early-return below so a stale `hookAwaitingInput` short-circuit
-    // can never swallow the measurement. Pure measurement — does not alter status/routing.
-    if (config.hooksSignals && status === "done" && s.status !== "done") {
-      this.measureStopWindow(s.id, this.now());
-    }
-    // Detect usage-limit halt on the done-edge (live agent herdr-reports done).
-    if (status === "done" && s.status !== "done") {
-      this.detectUsageHalt(s);
-    }
+    // Observe-only Stop↔herdr-done measurement + usage-halt detection on the done-EDGE.
+    // Placed BEFORE the tryHookAwaitingBlock early-return below so a stale
+    // `hookAwaitingInput` short-circuit can never swallow the measurement.
+    if (status === "done" && s.status !== "done") this.handleDoneEdge(s);
     this.dropReadyToMergeIfActionable(s, status);
     // Left herdr-blocked (running/idle/done alike) → the working-while-blocked
     // display flag must drop in the SAME tick, not via the throttled probe paths.
@@ -467,6 +460,16 @@ export class StatusPoller {
       this.store.update(s.id, { readyToMerge: false });
       this.onReady(s.id, false);
     }
+  }
+
+  /**
+   * On the done-EDGE (prior status ≠ "done", new status === "done") in reconcileAgent:
+   * record the Stop↔herdr-done measurement window (when hooks are enabled) and detect
+   * a usage-limit halt. Extracted to keep reconcileAgent under the complexity gate.
+   */
+  private handleDoneEdge(s: Session): void {
+    if (config.hooksSignals) this.measureStopWindow(s.id, this.now());
+    this.detectUsageHalt(s);
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ import {
   parseTermDims,
   validateSteers,
   validateBroadcast,
+  validateRetry,
   validateIconPatch,
   validateBuildSteps,
   validateBuildStepStatus,
@@ -2821,6 +2822,21 @@ async function handleHeld({ req, parts, deps }: Ctx): Promise<Response | null> {
   return null;
 }
 
+// ── retry usage-halted sessions ──
+async function handleRetry({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (parts[0] === "api" && parts[1] === "retry" && !parts[2]) {
+    if (req.method === "POST") {
+      const ctErr = requireJsonContentType(req);
+      if (ctErr) return ctErr;
+      const body = await req.json().catch(() => null);
+      const parsed = validateRetry(body);
+      if (!parsed) return json({ error: "body must be {text: string, ids: string[]}" }, 400);
+      return json(await deps.service.retryHalted(parsed.ids, parsed.text));
+    }
+  }
+  return null;
+}
+
 // ── halt the herd: interrupt every live working agent at once ──
 function handleHalt({ req, parts, deps }: Ctx): Response | null {
   if (parts[0] !== "api" || parts[1] !== "halt" || parts[2]) return null;
@@ -4168,6 +4184,7 @@ const ROUTE_HANDLERS = [
   handleProjectIcons,
   handleBroadcast,
   handleHeld,
+  handleRetry,
   handleHalt,
   handleFsDirs,
   handleBranches,

--- a/src/service.ts
+++ b/src/service.ts
@@ -1939,7 +1939,11 @@ export class SessionService {
         }
       }
       if (succeeded) {
+        // Clear immediately AND push it so the ⟳ chip / "halted" badge / RetryDialog
+        // preselect drop at once and a re-fire can't re-steer an already-resumed session
+        // — don't wait for the poller's working-transition clear to catch up.
         this.deps.store.setHaltReason(id, null, null);
+        this.deps.events?.emit("session:halt", { id, haltReason: null, haltedAt: null });
       }
     }
     return { resumed, steered, total: ids.length };

--- a/src/service.ts
+++ b/src/service.ts
@@ -1907,6 +1907,44 @@ export class SessionService {
     return { result: "stopped", killed };
   }
 
+  /**
+   * Retry a set of usage-halted sessions. For each id:
+   *  - If its pane is live (herdr still lists it) → steer with `continueText` so the
+   *    agent can continue from where it stopped (live idle/blocked state).
+   *  - Otherwise → `resume(id)` spawns a fresh `claude --resume` pane.
+   * On any success the haltReason flag is cleared so the UI badge disappears.
+   * The steer text is supplied by the caller (localized client-side) — the server
+   * stays i18n-agnostic, exactly like broadcast.
+   */
+  async retryHalted(
+    ids: string[],
+    continueText: string,
+  ): Promise<{ resumed: number; steered: number; total: number }> {
+    const live = this.liveTerminalIds();
+    let resumed = 0;
+    let steered = 0;
+    for (const id of ids) {
+      const s = this.deps.store.get(id);
+      if (!s) continue;
+      let succeeded = false;
+      if (live.has(s.herdrAgentId)) {
+        if (this.replyToLive(id, continueText, live)) {
+          steered++;
+          succeeded = true;
+        }
+      } else {
+        if (await this.resume(id)) {
+          resumed++;
+          succeeded = true;
+        }
+      }
+      if (succeeded) {
+        this.deps.store.setHaltReason(id, null, null);
+      }
+    }
+    return { resumed, steered, total: ids.length };
+  }
+
   /** Fan a steer out to many sessions (human-style). Skips unknown ids and dead panes.
    *  Lists herdr's live agents ONCE up front rather than per id, so a wide fan-out
    *  doesn't spawn one blocking `herdr agent list` per target. */

--- a/src/store.ts
+++ b/src/store.ts
@@ -158,6 +158,8 @@ type NewSession = Omit<
   | "egressApplied"
   | "egressDegraded"
   | "research"
+  | "haltReason"
+  | "haltedAt"
 > & {
   id?: string;
   model?: string | null;
@@ -182,7 +184,8 @@ const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePat
   autoMergeEnabled, autoMergeRebaseCount, autoMergeRebaseHead,
   auto, issueNumber, sandboxApplied, sandboxDegraded, egressApplied, egressDegraded,
   research,
-  createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId, mergeTrainPrs, mergingPrNumber`;
+  createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId, mergeTrainPrs, mergingPrNumber,
+  haltReason, haltedAt`;
 
 // ── repo_config row type + helpers ────────────────────────────────────────────
 
@@ -1064,6 +1067,8 @@ export class SessionStore implements CapStore, CreditStore {
       mergingTrainId: null,
       mergeTrainPrs: input.mergeTrainPrs ?? null,
       mergingPrNumber: null,
+      haltReason: null,
+      haltedAt: null,
     };
   }
 
@@ -1073,7 +1078,7 @@ export class SessionStore implements CapStore, CreditStore {
       const seq = this.nextDesignationSeq();
       const s = this.buildSessionRow(input, seq, now);
       this.db.run(
-        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
           s.id,
           s.desig,
@@ -1115,6 +1120,8 @@ export class SessionStore implements CapStore, CreditStore {
           s.mergingTrainId,
           s.mergeTrainPrs !== null ? JSON.stringify(s.mergeTrainPrs) : null,
           null, // mergingPrNumber — always null at create
+          null, // haltReason — always null at create
+          null, // haltedAt — always null at create
         ],
       );
       return s;
@@ -1792,6 +1799,15 @@ export class SessionStore implements CapStore, CreditStore {
     ]);
   }
 
+  setHaltReason(id: string, reason: Session["haltReason"], haltedAt: number | null): void {
+    this.db.run(`UPDATE sessions SET haltReason = ?, haltedAt = ?, updatedAt = ? WHERE id = ?`, [
+      reason,
+      haltedAt,
+      Date.now(),
+      id,
+    ]);
+  }
+
   // ── reviewer spawn cost attribution ──────────────────────────────────────────
   /** Record a freshly-spawned reviewer session. Token/completed columns stay NULL until
    *  finalize (`completeReviewerSpawn`). A plain INSERT is correct — every spawn forces a
@@ -1997,6 +2013,9 @@ export class SessionStore implements CapStore, CreditStore {
     add("research", `research INTEGER NOT NULL DEFAULT 0`);
     add("mergeTrainPrs", `mergeTrainPrs TEXT`);
     add("mergingPrNumber", `mergingPrNumber INTEGER`);
+    // halt detection: reason + timestamp; nullable, no default (null = not halted).
+    add("haltReason", `haltReason TEXT`);
+    add("haltedAt", `haltedAt INTEGER`);
   }
 
   // migrate repo_config that predates these opt-in columns. auto-address defaults
@@ -2534,6 +2553,8 @@ export class SessionStore implements CapStore, CreditStore {
       mergingTrainId: r.mergingTrainId ?? null,
       mergeTrainPrs: parseMergeTrainPrsJson(r.mergeTrainPrs),
       mergingPrNumber: r.mergingPrNumber ?? null,
+      haltReason: r.haltReason ?? null,
+      haltedAt: r.haltedAt ?? null,
     } as Session;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,10 @@ export interface Session {
   createdAt: number;
   updatedAt: number;
   archivedAt: number | null;
+  /** Reason the session halted mid-run; null when not halted. */
+  haltReason: "usage_limit" | "completed" | "operator" | "error" | null;
+  /** Epoch ms when haltReason was set; null when not halted. */
+  haltedAt: number | null;
 }
 
 /**

--- a/src/usage-halt.ts
+++ b/src/usage-halt.ts
@@ -1,0 +1,27 @@
+// NOTE: Positive patterns below are derived from documented/known Claude Code phrasings.
+// No real captured usage-limit output was available at authoring time.
+// Real-sample calibration is a follow-up once live samples are captured.
+
+const USAGE_LIMIT_PATTERNS: RegExp[] = [
+  // "claude usage limit" phrase
+  /claude\s+usage\s+limit/i,
+  // "usage limit reached"
+  /usage\s+limit\s+reached/i,
+  // "5-hour limit" or "5 hour limit"
+  /5[- ]hour\s+limit/i,
+  // "weekly limit"
+  /weekly\s+limit/i,
+  // "limit reached" combined with a reset mention (resets / reset at)
+  /limit\s+reached[\s\S]{0,120}reset/i,
+];
+
+/**
+ * Returns true when the given tail text matches Claude Code's usage-limit wording.
+ *
+ * Centralized here so wording drift is tuned in one place.
+ * Patterns are intentionally specific to avoid false positives on benign text
+ * such as "rate limit your requests" or "limit the number of connections".
+ */
+export function matchesUsageLimit(tail: string): boolean {
+  return USAGE_LIMIT_PATTERNS.some((re) => re.test(tail));
+}

--- a/src/usage-halt.ts
+++ b/src/usage-halt.ts
@@ -2,6 +2,8 @@
 // No real captured usage-limit output was available at authoring time.
 // Real-sample calibration is a follow-up once live samples are captured.
 
+import type { UsageLimits } from "./usage-limits";
+
 const USAGE_LIMIT_PATTERNS: RegExp[] = [
   // "claude usage limit" phrase
   /claude\s+usage\s+limit/i,
@@ -24,4 +26,32 @@ const USAGE_LIMIT_PATTERNS: RegExp[] = [
  */
 export function matchesUsageLimit(tail: string): boolean {
   return USAGE_LIMIT_PATTERNS.some((re) => re.test(tail));
+}
+
+/**
+ * Pure halt classifier — unit-testable without the poller.
+ *
+ * Returns "usage_limit" when the tail matches AND usage corroborates (or usage
+ * is unknown/uncalibrated). Returns null otherwise.
+ *
+ * Corroboration rule:
+ *  - If the tail does not match → null (fast exit).
+ *  - If usage is known (at least one window non-null) AND the highest window pct
+ *    is below `holdPct` → null (measurable but not near cap; probably not a
+ *    real halt).
+ *  - Otherwise (usage unknown OR at/above cap) → "usage_limit" (degrade
+ *    gracefully when telemetry is unavailable so real halts are never silently
+ *    dropped).
+ */
+export function classifyHalt(
+  tail: string,
+  limits: UsageLimits,
+  holdPct: number,
+): "usage_limit" | null {
+  if (!matchesUsageLimit(tail)) return null;
+  const s5h = limits.session5h;
+  const wk = limits.week;
+  const usageKnown = s5h !== null || wk !== null;
+  const nearCap = Math.max(s5h?.pct ?? 0, wk?.pct ?? 0) >= holdPct;
+  return !usageKnown || nearCap ? "usage_limit" : null;
 }

--- a/src/usage-halt.ts
+++ b/src/usage-halt.ts
@@ -40,19 +40,20 @@ export function matchesUsageLimit(tail: string): boolean {
  * Each retained entry is serialized whole so the phrasing is found wherever it sits (content
  * blocks, system text, error fields). The token-accounting `message.usage` object never trips
  * the patterns (they require "usage limit", "weekly limit", "limit reached … reset", etc.).
- * Falls back to the raw tail when it isn't parseable JSONL, so a non-JSONL transcript source
- * still gets matched.
+ *
+ * Fail-closed: when nothing parses (empty/garbled tail) or every entry is user-authored, this
+ * returns an empty string — never the raw tail. Transcripts are always JSONL, so a raw-tail
+ * fallback would only ever leak unparsed (possibly user-authored) text back into the match and
+ * re-open the false positive this filter exists to close.
  */
 export function assistantSideText(rawJsonl: string): string {
   const parts: string[] = [];
-  let parsedAny = false;
   for (const obj of eachJsonlObject(rawJsonl)) {
-    parsedAny = true;
     const role = obj?.message?.role ?? obj?.role ?? obj?.type;
     if (role === "user") continue;
     parts.push(JSON.stringify(obj));
   }
-  return parsedAny ? parts.join("\n") : rawJsonl;
+  return parts.join("\n");
 }
 
 /**

--- a/src/usage-halt.ts
+++ b/src/usage-halt.ts
@@ -3,6 +3,7 @@
 // Real-sample calibration is a follow-up once live samples are captured.
 
 import type { UsageLimits } from "./usage-limits";
+import { eachJsonlObject } from "./jsonl";
 
 const USAGE_LIMIT_PATTERNS: RegExp[] = [
   // "claude usage limit" phrase
@@ -26,6 +27,32 @@ const USAGE_LIMIT_PATTERNS: RegExp[] = [
  */
 export function matchesUsageLimit(tail: string): boolean {
   return USAGE_LIMIT_PATTERNS.some((re) => re.test(tail));
+}
+
+/**
+ * Extract the text of NON-user transcript entries (assistant, system, tool, …) from a raw
+ * JSONL tail, dropping user-authored messages. Claude's usage-limit notice is never
+ * user-authored, so excluding user prompts stops a transcript where the *user* merely typed
+ * usage-limit phrasing (e.g. a session discussing this very feature) from being mistaken for a
+ * real halt — the false-positive the corroboration gate cannot catch on the uncalibrated
+ * degrade path.
+ *
+ * Each retained entry is serialized whole so the phrasing is found wherever it sits (content
+ * blocks, system text, error fields). The token-accounting `message.usage` object never trips
+ * the patterns (they require "usage limit", "weekly limit", "limit reached … reset", etc.).
+ * Falls back to the raw tail when it isn't parseable JSONL, so a non-JSONL transcript source
+ * still gets matched.
+ */
+export function assistantSideText(rawJsonl: string): string {
+  const parts: string[] = [];
+  let parsedAny = false;
+  for (const obj of eachJsonlObject(rawJsonl)) {
+    parsedAny = true;
+    const role = obj?.message?.role ?? obj?.role ?? obj?.type;
+    if (role === "user") continue;
+    parts.push(JSON.stringify(obj));
+  }
+  return parsedAny ? parts.join("\n") : rawJsonl;
 }
 
 /**

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -872,3 +872,19 @@ export function validateBroadcast(body: unknown): { text: string; ids: string[] 
   }
   return { text, ids };
 }
+
+/** Validate a POST /api/retry payload. Returns null on any violation. */
+export function validateRetry(body: unknown): { text: string; ids: string[] } | null {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) return null;
+  const o = body as Record<string, unknown>;
+  if (typeof o.text !== "string") return null;
+  const text = o.text.trim();
+  if (text.length === 0 || text.length > STEER_TEXT_MAX) return null;
+  if (!Array.isArray(o.ids)) return null;
+  const ids: string[] = [];
+  for (const id of o.ids) {
+    if (typeof id !== "string" || id.length === 0) return null;
+    ids.push(id);
+  }
+  return { text, ids };
+}

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -58,6 +58,8 @@ function sess(over: Partial<Session> = {}): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...over,
   };
 }

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -154,6 +154,8 @@ function makeSession(planPhase: Session["planPhase"]): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
   };
 }
 

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -56,6 +56,8 @@ function makeSession(over: Partial<Session> = {}): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...over,
   };
 }

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -75,6 +75,8 @@ function makeSession(over: Partial<Session> = {}): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...over,
   };
 }

--- a/test/retry-endpoint.test.ts
+++ b/test/retry-endpoint.test.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { makeApp, type AppDeps } from "../src/server";
+
+function harness(
+  retryHalted?: (
+    ids: string[],
+    text: string,
+  ) => Promise<{ resumed: number; steered: number; total: number }>,
+) {
+  const store = new SessionStore(":memory:");
+  const deps: AppDeps = {
+    store,
+    events: new EventHub(),
+    service: { retryHalted } as any,
+    usageLimits: { limits: () => ({}) } as any,
+  };
+  return { app: makeApp(deps), store };
+}
+
+const jsonReq = (path: string, method: string, body: unknown) =>
+  new Request(`http://x${path}`, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+test("POST /api/retry returns resumed+steered+total from service", async () => {
+  const calls: { ids: string[]; text: string }[] = [];
+  const { app } = harness(async (ids, text) => {
+    calls.push({ ids, text });
+    return { resumed: 1, steered: 1, total: 2 };
+  });
+  const res = await app.fetch(
+    jsonReq("/api/retry", "POST", { text: "please continue", ids: ["a", "b"] }),
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ resumed: 1, steered: 1, total: 2 });
+  expect(calls).toEqual([{ ids: ["a", "b"], text: "please continue" }]);
+});
+
+test("POST /api/retry rejects empty text with 400", async () => {
+  const { app } = harness(async () => ({ resumed: 0, steered: 0, total: 0 }));
+  const res = await app.fetch(jsonReq("/api/retry", "POST", { text: "", ids: ["a"] }));
+  expect(res.status).toBe(400);
+});
+
+test("POST /api/retry rejects missing ids with 400", async () => {
+  const { app } = harness(async () => ({ resumed: 0, steered: 0, total: 0 }));
+  const res = await app.fetch(jsonReq("/api/retry", "POST", { text: "go" }));
+  expect(res.status).toBe(400);
+});
+
+test("POST /api/retry rejects non-JSON body with 400", async () => {
+  const { app } = harness(async () => ({ resumed: 0, steered: 0, total: 0 }));
+  const res = await app.fetch(
+    new Request("http://x/api/retry", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json",
+    }),
+  );
+  expect(res.status).toBe(400);
+});
+
+test("POST /api/retry requires content-type application/json", async () => {
+  const { app } = harness(async () => ({ resumed: 0, steered: 0, total: 0 }));
+  const res = await app.fetch(
+    new Request("http://x/api/retry", {
+      method: "POST",
+      body: JSON.stringify({ text: "go", ids: ["a"] }),
+    }),
+  );
+  expect(res.status).toBe(415);
+});

--- a/test/retry-halted.test.ts
+++ b/test/retry-halted.test.ts
@@ -14,6 +14,7 @@ function makeHarness({
   const sent: { target: string; text: string }[] = [];
   const resumed: string[] = [];
   const setHaltCalls: { id: string; reason: null; at: null }[] = [];
+  const emitted: { event: string; data: any }[] = [];
 
   const origSetHaltReason = store.setHaltReason.bind(store);
   store.setHaltReason = (id, reason, haltedAt) => {
@@ -36,6 +37,7 @@ function makeHarness({
 
   const svc = new SessionService({
     store,
+    events: { emit: (event: string, data: any) => emitted.push({ event, data }) } as any,
     namer: async () => "x",
     worktree: {
       create: () => ({}) as any,
@@ -59,7 +61,7 @@ function makeHarness({
     return resumeResult ? store.get(id) : null;
   };
 
-  return { store, svc, mk, sent, resumed, setHaltCalls };
+  return { store, svc, mk, sent, resumed, setHaltCalls, emitted };
 }
 
 test("retryHalted: live session is steered, not resumed", async () => {
@@ -149,4 +151,35 @@ test("retryHalted: steer text is passed verbatim (no hardcoded English)", async 
   await svc.retryHalted([a.id], "Fortsetzen bitte");
 
   expect(sent.some((s) => s.text.includes("Fortsetzen bitte"))).toBe(true);
+});
+
+test("retryHalted: emits a clearing session:halt(null) on success so the UI updates live", async () => {
+  const { store, svc, mk, emitted } = makeHarness({ liveIds: new Set(["term_a"]) });
+  const a = mk("a", "term_a");
+  store.setHaltReason(a.id, "usage_limit", 1000);
+
+  await svc.retryHalted([a.id], "please continue");
+
+  // Without the emit (pre-fix), the delta-driven UI never learns the clear and the
+  // ⟳ chip / "halted" badge / RetryDialog preselect stay stale until a full reload.
+  expect(
+    emitted.some(
+      (e) =>
+        e.event === "session:halt" &&
+        e.data.id === a.id &&
+        e.data.haltReason === null &&
+        e.data.haltedAt === null,
+    ),
+  ).toBe(true);
+});
+
+test("retryHalted: no clearing event when nothing succeeds", async () => {
+  const { store, svc, mk, emitted } = makeHarness({ liveIds: new Set(), resumeResult: false });
+  const a = mk("a", "term_dead");
+  store.setHaltReason(a.id, "usage_limit", 1000);
+
+  await svc.retryHalted([a.id], "please continue");
+
+  expect(emitted.some((e) => e.event === "session:halt")).toBe(false);
+  expect(store.get(a.id)?.haltReason).toBe("usage_limit");
 });

--- a/test/retry-halted.test.ts
+++ b/test/retry-halted.test.ts
@@ -1,0 +1,152 @@
+import { expect, test } from "bun:test";
+import { SessionStore } from "../src/store";
+import { SessionService } from "../src/service";
+
+/** Build a minimal service with controllable liveness + resume + replyToLive. */
+function makeHarness({
+  liveIds = new Set<string>(),
+  resumeResult = true,
+}: {
+  liveIds?: Set<string>;
+  resumeResult?: boolean;
+} = {}) {
+  const store = new SessionStore(":memory:");
+  const sent: { target: string; text: string }[] = [];
+  const resumed: string[] = [];
+  const setHaltCalls: { id: string; reason: null; at: null }[] = [];
+
+  const origSetHaltReason = store.setHaltReason.bind(store);
+  store.setHaltReason = (id, reason, haltedAt) => {
+    if (reason === null) setHaltCalls.push({ id, reason, at: haltedAt as null });
+    origSetHaltReason(id, reason, haltedAt);
+  };
+
+  const mk = (name: string, agentId: string) =>
+    store.create({
+      name,
+      prompt: "x",
+      repoPath: "/r",
+      baseBranch: "main",
+      branch: `shepherd/${name}`,
+      worktreePath: `/wt/${name}`,
+      isolated: true,
+      herdrSession: "default",
+      herdrAgentId: agentId,
+    });
+
+  const svc = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({}) as any,
+      ensureBaseRef: async () => {},
+      remove: () => {},
+      branchExists: () => false,
+    } as any,
+    herdr: {
+      start: () => ({}) as any,
+      list: () =>
+        [...liveIds].map((id) => ({ terminalId: id, agentStatus: "idle", cwd: "/", name: "" })),
+      stop: () => {},
+      send: (target: string, text: string) => sent.push({ target, text }),
+      relabel: () => {},
+    } as any,
+  });
+
+  // Patch resume so it doesn't actually spawn claude.
+  (svc as any).resume = async (id: string) => {
+    resumed.push(id);
+    return resumeResult ? store.get(id) : null;
+  };
+
+  return { store, svc, mk, sent, resumed, setHaltCalls };
+}
+
+test("retryHalted: live session is steered, not resumed", async () => {
+  const { store, svc, mk, sent, resumed, setHaltCalls } = makeHarness({
+    liveIds: new Set(["term_a"]),
+  });
+  const a = mk("a", "term_a");
+  store.setHaltReason(a.id, "usage_limit", 1000);
+
+  const result = await svc.retryHalted([a.id], "please continue");
+
+  expect(result).toEqual({ resumed: 0, steered: 1, total: 1 });
+  // replyToLive sends bracketed paste + CR
+  expect(sent.some((s) => s.target === "term_a" && s.text.includes("please continue"))).toBe(true);
+  expect(resumed).toEqual([]);
+  // flag cleared
+  expect(setHaltCalls.some((c) => c.id === a.id && c.reason === null)).toBe(true);
+  expect(store.get(a.id)?.haltReason).toBeNull();
+});
+
+test("retryHalted: dead-pane session is resumed, not steered", async () => {
+  const { store, svc, mk, sent, resumed, setHaltCalls } = makeHarness({
+    liveIds: new Set(), // nothing live
+  });
+  const a = mk("a", "term_a");
+  store.setHaltReason(a.id, "usage_limit", 1000);
+
+  const result = await svc.retryHalted([a.id], "please continue");
+
+  expect(result).toEqual({ resumed: 1, steered: 0, total: 1 });
+  expect(sent).toEqual([]);
+  expect(resumed).toEqual([a.id]);
+  expect(setHaltCalls.some((c) => c.id === a.id && c.reason === null)).toBe(true);
+  expect(store.get(a.id)?.haltReason).toBeNull();
+});
+
+test("retryHalted: unknown ids are skipped", async () => {
+  const { svc, resumed, setHaltCalls } = makeHarness();
+  const result = await svc.retryHalted(["ghost-id"], "continue");
+  expect(result).toEqual({ resumed: 0, steered: 0, total: 1 });
+  expect(resumed).toEqual([]);
+  expect(setHaltCalls).toEqual([]);
+});
+
+test("retryHalted: failed resume does not clear haltReason", async () => {
+  const { store, svc, mk, setHaltCalls } = makeHarness({
+    liveIds: new Set(),
+    resumeResult: false,
+  });
+  const a = mk("a", "term_a");
+  store.setHaltReason(a.id, "usage_limit", 1000);
+
+  const result = await svc.retryHalted([a.id], "continue");
+
+  expect(result.resumed).toBe(0);
+  expect(setHaltCalls.filter((c) => c.id === a.id)).toEqual([]);
+  expect(store.get(a.id)?.haltReason).toBe("usage_limit");
+});
+
+test("retryHalted: mixed live and dead sessions", async () => {
+  const { store, svc, mk, sent, resumed, setHaltCalls } = makeHarness({
+    liveIds: new Set(["term_a"]),
+  });
+  const a = mk("a", "term_a"); // live → steered
+  const b = mk("b", "term_b"); // dead → resumed
+  store.setHaltReason(a.id, "usage_limit", 1000);
+  store.setHaltReason(b.id, "usage_limit", 1000);
+
+  const result = await svc.retryHalted([a.id, b.id], "go");
+
+  expect(result).toEqual({ resumed: 1, steered: 1, total: 2 });
+  expect(sent.some((s) => s.target === "term_a")).toBe(true);
+  expect(resumed).toEqual([b.id]);
+  expect(
+    setHaltCalls
+      .filter((c) => c.reason === null)
+      .map((c) => c.id)
+      .sort(),
+  ).toEqual([a.id, b.id].sort());
+});
+
+test("retryHalted: steer text is passed verbatim (no hardcoded English)", async () => {
+  const { store, svc, mk, sent } = makeHarness({ liveIds: new Set(["term_a"]) });
+  const a = mk("a", "term_a");
+  store.setHaltReason(a.id, "usage_limit", 1000);
+
+  await svc.retryHalted([a.id], "Fortsetzen bitte");
+
+  expect(sent.some((s) => s.text.includes("Fortsetzen bitte"))).toBe(true);
+});

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -83,6 +83,8 @@ function session(over: Partial<Session> = {}): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...over,
   };
 }

--- a/test/rundown-core.test.ts
+++ b/test/rundown-core.test.ts
@@ -61,6 +61,8 @@ function session(over: Partial<Session> = {}): Session {
     createdAt: NOW - 1000,
     updatedAt: NOW,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...over,
   };
 }

--- a/test/server-diff.test.ts
+++ b/test/server-diff.test.ts
@@ -46,6 +46,8 @@ const SESSION: Session = {
   createdAt: 0,
   updatedAt: 0,
   archivedAt: null,
+  haltReason: null,
+  haltedAt: null,
 };
 
 function makeDeps(session: Session | null): AppDeps {

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -50,6 +50,8 @@ const SESSION: Session = {
   createdAt: 0,
   updatedAt: 0,
   archivedAt: null,
+  haltReason: null,
+  haltedAt: null,
 };
 
 function fakeForge(

--- a/test/server-quota-endpoints.test.ts
+++ b/test/server-quota-endpoints.test.ts
@@ -51,6 +51,8 @@ const SESSION: Session = {
   createdAt: 0,
   updatedAt: 0,
   archivedAt: null,
+  haltReason: null,
+  haltedAt: null,
 };
 
 /** A ReviewVerdict that triggers the "rework" quota kind (addressRound >= addressCap, no pending). */

--- a/test/server-review-pr.test.ts
+++ b/test/server-review-pr.test.ts
@@ -51,6 +51,8 @@ const SESSION: Session = {
   createdAt: 0,
   updatedAt: 0,
   archivedAt: null,
+  haltReason: null,
+  haltedAt: null,
 };
 
 function fakeForge(over: Partial<GitForge> = {}): GitForge & { log: string[] } {

--- a/test/store-halt.test.ts
+++ b/test/store-halt.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { SessionStore } from "../src/store";
+
+const base = {
+  name: "halt-test",
+  prompt: "test session",
+  repoPath: "/r",
+  baseBranch: "main",
+  branch: "shepherd/halt-test",
+  worktreePath: "/r-wt",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "term_1",
+};
+
+test("freshly created session has haltReason=null, haltedAt=null", () => {
+  const s = new SessionStore(":memory:");
+  const row = s.create(base);
+  expect(row.haltReason).toBeNull();
+  expect(row.haltedAt).toBeNull();
+});
+
+test("setHaltReason persists usage_limit + haltedAt", () => {
+  const s = new SessionStore(":memory:");
+  const row = s.create(base);
+  s.setHaltReason(row.id, "usage_limit", 123);
+  const got = s.get(row.id);
+  expect(got?.haltReason).toBe("usage_limit");
+  expect(got?.haltedAt).toBe(123);
+});
+
+test("setHaltReason with null clears halt fields (retry path)", () => {
+  const s = new SessionStore(":memory:");
+  const row = s.create(base);
+  s.setHaltReason(row.id, "usage_limit", 123);
+  s.setHaltReason(row.id, null, null);
+  const got = s.get(row.id);
+  expect(got?.haltReason).toBeNull();
+  expect(got?.haltedAt).toBeNull();
+});
+
+test("halt fields persist across store reopen (migration + round-trip)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-halt-test-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    const s1 = new SessionStore(dbPath);
+    const row = s1.create(base);
+    s1.setHaltReason(row.id, "operator", 456);
+
+    // reopen same DB
+    const s2 = new SessionStore(dbPath);
+    const got = s2.get(row.id);
+    expect(got?.haltReason).toBe("operator");
+    expect(got?.haltedAt).toBe(456);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/usage-halt.test.ts
+++ b/test/usage-halt.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { matchesUsageLimit } from "../src/usage-halt";
+
+// NOTE: All positive test strings below are SYNTHETIC — no real captured usage-limit
+// output from Claude Code was available at authoring time. Real-sample calibration is
+// a follow-up task once live samples are captured.
+
+test("matches Claude usage limit reached", () => {
+  expect(matchesUsageLimit("Claude usage limit reached. Your limit will reset at 3:00pm.")).toBe(
+    true,
+  );
+});
+
+test("matches 5-hour limit with hyphen", () => {
+  expect(matchesUsageLimit("You've hit the 5-hour limit — resets at 9:30pm")).toBe(true);
+});
+
+test("matches 5 hour limit without hyphen", () => {
+  expect(matchesUsageLimit("You have reached the 5 hour limit for this period.")).toBe(true);
+});
+
+test("matches weekly limit with resets mention", () => {
+  expect(matchesUsageLimit("Weekly limit reached. Resets Monday.")).toBe(true);
+});
+
+test("matches limit reached + reset at", () => {
+  expect(matchesUsageLimit("limit reached. Your usage will reset at midnight.")).toBe(true);
+});
+
+test("matches limit reached + resets", () => {
+  expect(matchesUsageLimit("Usage limit reached — resets in 2 hours.")).toBe(true);
+});
+
+test("no false positive: normal completion", () => {
+  expect(matchesUsageLimit("I've finished the task and committed the changes.")).toBe(false);
+});
+
+test("no false positive: empty string", () => {
+  expect(matchesUsageLimit("")).toBe(false);
+});
+
+test("no false positive: benign rate limit mention", () => {
+  expect(matchesUsageLimit("Consider adding a rate limit to your API.")).toBe(false);
+});
+
+test("no false positive: partial keyword without context", () => {
+  expect(matchesUsageLimit("You should limit your requests per second.")).toBe(false);
+});

--- a/test/usage-halt.test.ts
+++ b/test/usage-halt.test.ts
@@ -136,10 +136,20 @@ test("assistantSideText: token-usage object alone does not match", () => {
   expect(matchesUsageLimit(assistantSideText(assistantBenign))).toBe(false);
 });
 
-test("assistantSideText falls back to raw text for non-JSONL input", () => {
+test("assistantSideText fails closed (empty, no match) on unparseable / non-JSONL input", () => {
+  // A raw-tail fallback here would leak unparsed (possibly user-authored) text back into the
+  // match and re-open the degrade-path false positive — so an unparseable tail yields no match.
+  expect(assistantSideText("Claude usage limit reached — resets soon")).toBe("");
   expect(matchesUsageLimit(assistantSideText("Claude usage limit reached — resets soon"))).toBe(
-    true,
+    false,
   );
+  expect(assistantSideText("")).toBe("");
+});
+
+test("assistantSideText returns empty when every entry is user-authored", () => {
+  const text = assistantSideText(userLine);
+  expect(text).toBe("");
+  expect(matchesUsageLimit(text)).toBe(false);
 });
 
 test("classifyHalt: user-only mention on the UNCALIBRATED degrade path is NOT a halt", () => {

--- a/test/usage-halt.test.ts
+++ b/test/usage-halt.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { matchesUsageLimit, classifyHalt } from "../src/usage-halt";
+import { matchesUsageLimit, classifyHalt, assistantSideText } from "../src/usage-halt";
 import type { UsageLimits } from "../src/usage-limits";
 
 // NOTE: All positive test strings below are SYNTHETIC — no real captured usage-limit
@@ -90,4 +90,72 @@ test("classifyHalt: match + both windows at exactly holdPct → usage_limit (>= 
 
 test("classifyHalt: match + both windows just below holdPct → null", () => {
   expect(classifyHalt(MATCH, limits(79, 79), 80)).toBeNull();
+});
+
+// ── assistantSideText: drop user-authored content before matching ──────────────
+// Regression for the degrade-path false positive: a user prompt that merely mentions
+// usage-limit phrasing (e.g. a session discussing this very feature) must NOT be read
+// as Claude's own halt notice.
+
+const userLine = JSON.stringify({
+  type: "user",
+  message: {
+    role: "user",
+    content: "Does Shepherd detect when the Claude usage limit reached state happens?",
+  },
+});
+const assistantBenign = JSON.stringify({
+  type: "assistant",
+  message: {
+    role: "assistant",
+    content: "Yes — it scans the transcript tail.",
+    usage: { input_tokens: 10 },
+  },
+});
+const assistantHalt = JSON.stringify({
+  type: "assistant",
+  message: {
+    role: "assistant",
+    content: "Claude usage limit reached. Your limit will reset at 3:00pm.",
+  },
+});
+
+test("assistantSideText drops user lines so a user mention does not match", () => {
+  const tail = `${userLine}\n${assistantBenign}`;
+  const text = assistantSideText(tail);
+  expect(text.includes("usage limit reached")).toBe(false);
+  expect(matchesUsageLimit(text)).toBe(false);
+});
+
+test("assistantSideText keeps a real assistant/system halt notice", () => {
+  const tail = `${userLine}\n${assistantHalt}`;
+  expect(matchesUsageLimit(assistantSideText(tail))).toBe(true);
+});
+
+test("assistantSideText: token-usage object alone does not match", () => {
+  expect(matchesUsageLimit(assistantSideText(assistantBenign))).toBe(false);
+});
+
+test("assistantSideText falls back to raw text for non-JSONL input", () => {
+  expect(matchesUsageLimit(assistantSideText("Claude usage limit reached — resets soon"))).toBe(
+    true,
+  );
+});
+
+test("classifyHalt: user-only mention on the UNCALIBRATED degrade path is NOT a halt", () => {
+  const uncalibrated: UsageLimits = {
+    session5h: null,
+    week: null,
+    credits: null,
+    stale: true,
+    calibratedAt: null,
+    subscriptionOnly: false,
+  };
+  // Pre-fix: raw tail matched + usageKnown=false → false "usage_limit". Post-fix: user line dropped → null.
+  const tail = `${userLine}\n${assistantBenign}`;
+  expect(classifyHalt(assistantSideText(tail), uncalibrated, 80)).toBeNull();
+  // A genuine assistant halt on the same degrade path still classifies.
+  expect(classifyHalt(assistantSideText(`${userLine}\n${assistantHalt}`), uncalibrated, 80)).toBe(
+    "usage_limit",
+  );
 });

--- a/test/usage-halt.test.ts
+++ b/test/usage-halt.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { matchesUsageLimit } from "../src/usage-halt";
+import { matchesUsageLimit, classifyHalt } from "../src/usage-halt";
+import type { UsageLimits } from "../src/usage-limits";
 
 // NOTE: All positive test strings below are SYNTHETIC — no real captured usage-limit
 // output from Claude Code was available at authoring time. Real-sample calibration is
@@ -45,4 +46,48 @@ test("no false positive: benign rate limit mention", () => {
 
 test("no false positive: partial keyword without context", () => {
   expect(matchesUsageLimit("You should limit your requests per second.")).toBe(false);
+});
+
+// ── classifyHalt ──────────────────────────────────────────────────────────────
+
+const MATCH = "Claude usage limit reached. Your limit will reset at 3:00pm.";
+const NO_MATCH = "I finished the task.";
+
+function limits(session5hPct: number | null, weekPct: number | null): UsageLimits {
+  return {
+    session5h: session5hPct !== null ? { pct: session5hPct, resetAt: 0 } : null,
+    week: weekPct !== null ? { pct: weekPct, resetAt: 0 } : null,
+    credits: null,
+    stale: false,
+    calibratedAt: Date.now(),
+    subscriptionOnly: false,
+  };
+}
+
+test("classifyHalt: match + session5h=95 above holdPct=80 → usage_limit", () => {
+  expect(classifyHalt(MATCH, limits(95, null), 80)).toBe("usage_limit");
+});
+
+test("classifyHalt: match + both windows null (uncalibrated) → usage_limit (degraded)", () => {
+  expect(classifyHalt(MATCH, limits(null, null), 80)).toBe("usage_limit");
+});
+
+test("classifyHalt: match + session5h=40, week null, holdPct=80 → null (measurable below cap)", () => {
+  expect(classifyHalt(MATCH, limits(40, null), 80)).toBeNull();
+});
+
+test("classifyHalt: no match + high usage → null", () => {
+  expect(classifyHalt(NO_MATCH, limits(99, 99), 80)).toBeNull();
+});
+
+test("classifyHalt: match + week=90 above holdPct=80 → usage_limit", () => {
+  expect(classifyHalt(MATCH, limits(null, 90), 80)).toBe("usage_limit");
+});
+
+test("classifyHalt: match + both windows at exactly holdPct → usage_limit (>= is inclusive)", () => {
+  expect(classifyHalt(MATCH, limits(80, null), 80)).toBe("usage_limit");
+});
+
+test("classifyHalt: match + both windows just below holdPct → null", () => {
+  expect(classifyHalt(MATCH, limits(79, 79), 80)).toBeNull();
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1615,5 +1615,5 @@
   "retry_halted_badge": "gestoppt",
   "retry_empty": "Keine Sitzungen zum Wiederholen",
   "feat_usage_halt_retry_title": "Halted Sitzungen mit einem Klick wiederholen",
-  "feat_usage_halt_retry_body": "Wenn Sitzungen stoppen, weil dein Claude-Nutzungslimit erreicht wurde, erscheint nach dem Reset ein ⟳-Schaltfläche — sie setzt alle gestoppten Sitzungen fort und steuert sie in einem Klick weiter."
+  "feat_usage_halt_retry_body": "Wenn Sitzungen stoppen, weil dein Claude-Nutzungslimit erreicht wurde, erscheint nach dem Reset eine ⟳-Schaltfläche — sie setzt alle gestoppten Sitzungen fort und steuert sie in einem Klick weiter."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1606,7 +1606,7 @@
   "topbar_held_spawn_now": "Jetzt starten",
   "topbar_held_discard": "Verwerfen",
   "topbar_held_empty": "Keine zurückgehaltenen Aufgaben",
-  "retry_title": "HALTED WIEDERHOLEN",
+  "retry_title": "Halted wiederholen",
   "retry_confirm": "{count} Sitzungen wiederholen",
   "retry_arm": "Wiederholen bestätigen ({count})?",
   "retry_continue_steer": "Bitte fortfahren — dein Nutzungslimit sollte zurückgesetzt sein.",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1605,5 +1605,15 @@
   "topbar_held_title": "Zurückgehaltene Aufgaben",
   "topbar_held_spawn_now": "Jetzt starten",
   "topbar_held_discard": "Verwerfen",
-  "topbar_held_empty": "Keine zurückgehaltenen Aufgaben"
+  "topbar_held_empty": "Keine zurückgehaltenen Aufgaben",
+  "retry_title": "HALTED WIEDERHOLEN",
+  "retry_confirm": "{count} Sitzungen wiederholen",
+  "retry_arm": "Wiederholen bestätigen ({count})?",
+  "retry_continue_steer": "Bitte fortfahren — dein Nutzungslimit sollte zurückgesetzt sein.",
+  "retry_failed": "Wiederholung fehlgeschlagen: keine Sessions fortgesetzt. Ziele prüfen, dann erneut versuchen.",
+  "toast_retry_done": "Wiederholen gesendet · {resumed} fortgesetzt · {steered} gesteuert / {total}",
+  "retry_halted_badge": "gestoppt",
+  "retry_empty": "Keine Sitzungen zum Wiederholen",
+  "feat_usage_halt_retry_title": "Halted Sitzungen mit einem Klick wiederholen",
+  "feat_usage_halt_retry_body": "Wenn Sitzungen stoppen, weil dein Claude-Nutzungslimit erreicht wurde, erscheint nach dem Reset ein ⟳-Schaltfläche — sie setzt alle gestoppten Sitzungen fort und steuert sie in einem Klick weiter."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1605,5 +1605,15 @@
   "topbar_held_title": "Held tasks",
   "topbar_held_spawn_now": "Spawn now",
   "topbar_held_discard": "Discard",
-  "topbar_held_empty": "No held tasks"
+  "topbar_held_empty": "No held tasks",
+  "retry_title": "RETRY HALTED",
+  "retry_confirm": "Retry {count} sessions",
+  "retry_arm": "Confirm retry {count}?",
+  "retry_continue_steer": "Please continue — your usage limit should have reset.",
+  "retry_failed": "Retry failed: no sessions resumed. Check the targets, then try again.",
+  "toast_retry_done": "Retry sent · {resumed} resumed · {steered} steered / {total}",
+  "retry_halted_badge": "halted",
+  "retry_empty": "No sessions to retry",
+  "feat_usage_halt_retry_title": "One-click retry for usage-halted sessions",
+  "feat_usage_halt_retry_body": "When sessions stop because your Claude usage limit was reached, a ⟳ Retry button appears once usage resets — it resumes all halted sessions and steers them to continue in one click."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1606,7 +1606,7 @@
   "topbar_held_spawn_now": "Spawn now",
   "topbar_held_discard": "Discard",
   "topbar_held_empty": "No held tasks",
-  "retry_title": "RETRY HALTED",
+  "retry_title": "Retry halted",
   "retry_confirm": "Retry {count} sessions",
   "retry_arm": "Confirm retry {count}?",
   "retry_continue_steer": "Please continue — your usage limit should have reset.",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -915,6 +915,21 @@ export async function broadcast(
   return r.json();
 }
 
+/** Resume usage-halted sessions. Sends `text` as a steer to each selected session
+ *  (resume) and steers them to continue. Returns counts of resumed/steered/total. */
+export async function retryHalted(
+  ids: string[],
+  text: string,
+): Promise<{ resumed: number; steered: number; total: number }> {
+  const r = await fetch("/api/retry", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ ids, text }),
+  });
+  if (!r.ok) throw await failed(r, "retry");
+  return r.json();
+}
+
 /** Fleet-wide emergency stop: interrupt every live working agent at once. No body —
  *  the server computes the target set. Returns how many panes were halted. */
 export async function halt(): Promise<{ halted: number }> {

--- a/ui/src/lib/components/DoneRecapPanel.browser.test.ts
+++ b/ui/src/lib/components/DoneRecapPanel.browser.test.ts
@@ -45,6 +45,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     createdAt: 0,
     updatedAt: 1000,
     archivedAt: Date.now() - 60_000,
+    haltReason: null,
+    haltedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -45,6 +45,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -56,6 +56,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/ResearchBadge.browser.test.ts
+++ b/ui/src/lib/components/ResearchBadge.browser.test.ts
@@ -45,6 +45,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/RetryDialog.svelte
+++ b/ui/src/lib/components/RetryDialog.svelte
@@ -1,0 +1,276 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { SvelteSet } from "svelte/reactivity";
+  import type { Session } from "$lib/types";
+  import { retryHalted } from "$lib/api";
+  import { toasts } from "$lib/toasts.svelte";
+  import { dialog } from "$lib/a11yDialog";
+  import { m } from "$lib/paraglide/messages";
+
+  let { sessions, onclose }: { sessions: Session[]; onclose: () => void } = $props();
+
+  let selected = new SvelteSet<string>();
+  let sending = $state(false);
+  let result = $state<string | null>(null);
+  let failed = $state(false);
+  // Two-stage arm/fire — same pattern as BroadcastDialog and decommission/merge.
+  let armed = $state(false);
+  let armTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // Preselect all usage-halted sessions ONCE on mount. A reactive $effect would re-run on
+  // every sessions update (e.g. a session:halt WS event) and silently re-add a row the
+  // operator just unchecked, defeating manual deselection — so seed once via onMount.
+  onMount(() => {
+    for (const s of sessions) {
+      if (s.haltReason === "usage_limit") selected.add(s.id);
+    }
+  });
+
+  const allSelected = $derived(sessions.length > 0 && selected.size === sessions.length);
+  const canFire = $derived(selected.size > 0 && !sending);
+
+  function disarm() {
+    clearTimeout(armTimer);
+    armed = false;
+  }
+
+  function toggle(id: string) {
+    if (selected.has(id)) selected.delete(id);
+    else selected.add(id);
+    disarm();
+  }
+
+  function toggleAll() {
+    if (allSelected) {
+      selected.clear();
+    } else {
+      for (const s of sessions) selected.add(s.id);
+    }
+    disarm();
+  }
+
+  async function fire() {
+    if (!canFire) return;
+    if (!armed) {
+      armed = true;
+      clearTimeout(armTimer);
+      armTimer = setTimeout(() => (armed = false), 3000);
+      return;
+    }
+    clearTimeout(armTimer);
+    armed = false;
+    sending = true;
+    result = null;
+    failed = false;
+    try {
+      const r = await retryHalted([...selected], m.retry_continue_steer());
+      toasts.info(m.toast_retry_done({ resumed: r.resumed, steered: r.steered, total: r.total }));
+      onclose();
+    } catch {
+      result = m.retry_failed();
+      failed = true;
+      sending = false;
+    }
+  }
+</script>
+
+<div
+  class="overlay"
+  role="presentation"
+  onclick={(e) => {
+    if (e.target === e.currentTarget) onclose();
+  }}
+>
+  <div
+    class="card"
+    role="dialog"
+    aria-modal="true"
+    aria-label={m.retry_title()}
+    use:dialog={{ onclose }}
+  >
+    <div class="chead">
+      <span class="micro">{m.retry_title()}</span>
+      <button type="button" class="x" onclick={onclose} aria-label={m.common_close()}>✕</button>
+    </div>
+
+    <div class="row-head">
+      <span class="micro">{m.broadcast_targets()}</span>
+      <button type="button" class="link" onclick={toggleAll}>
+        {allSelected ? m.broadcast_clear_all() : m.broadcast_select_all()}
+      </button>
+    </div>
+    <div class="targets">
+      {#if sessions.length === 0}
+        <div class="placeholder">{m.retry_empty()}</div>
+      {:else}
+        {#each sessions as s (s.id)}
+          <label class="target">
+            <input type="checkbox" checked={selected.has(s.id)} onchange={() => toggle(s.id)} />
+            <span class="nm">{s.name}</span>
+            {#if s.haltReason === "usage_limit"}
+              <span class="badge halted">{m.retry_halted_badge()}</span>
+            {/if}
+          </label>
+        {/each}
+      {/if}
+    </div>
+
+    {#if result}
+      <div class="result" class:failed>
+        <span>{result}</span>
+      </div>
+    {/if}
+
+    <button class="run" class:armed type="button" disabled={!canFire} onclick={fire}>
+      {#if sending}
+        {m.broadcast_sending()}
+      {:else if armed}
+        {m.retry_arm({ count: selected.size })}
+      {:else}
+        {m.retry_confirm({ count: selected.size })}
+      {/if}
+    </button>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--color-scrim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+  }
+  .card {
+    width: min(460px, 92vw);
+    border: 1px solid var(--color-line-bright);
+    background: var(--color-panel);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .chead {
+    display: flex;
+    align-items: center;
+  }
+  .x {
+    margin-left: auto;
+    background: transparent;
+    border: 0;
+    color: var(--color-muted);
+    cursor: pointer;
+    font: inherit;
+  }
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .row-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+  }
+  .link {
+    background: transparent;
+    border: 0;
+    color: var(--color-amber);
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--fs-meta);
+  }
+  .targets {
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    border-radius: 2px;
+    max-height: 200px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+  .target {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font-size: var(--fs-base);
+    cursor: pointer;
+  }
+  .target:last-child {
+    border-bottom: 0;
+  }
+  .nm {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .badge.halted {
+    flex-shrink: 0;
+    background: var(--color-inset);
+    border: 1px solid var(--color-amber);
+    border-radius: 2px;
+    color: var(--color-amber);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.06em;
+    padding: 1px 5px;
+    text-transform: uppercase;
+  }
+  .placeholder {
+    padding: 14px 12px;
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+  }
+  .result {
+    color: var(--color-amber);
+    font-size: var(--fs-meta);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .result.failed {
+    color: var(--color-red);
+  }
+  .run {
+    margin-top: 4px;
+    border: 1px solid var(--color-amber);
+    color: var(--color-amber);
+    background: transparent;
+    padding: 9px 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: var(--fs-meta);
+    cursor: pointer;
+  }
+  .run:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    color: var(--color-faint);
+    border-color: var(--color-line);
+    box-shadow: none;
+  }
+  .run.armed:not(:disabled) {
+    box-shadow: inset 0 0 22px -10px var(--color-amber);
+    background: var(--color-hover);
+  }
+  @media (max-width: 768px) {
+    .overlay {
+      align-items: stretch;
+      justify-content: stretch;
+    }
+    .card {
+      width: 100%;
+      height: 100dvh;
+      border: 0;
+      overflow-y: auto;
+    }
+  }
+</style>

--- a/ui/src/lib/components/SessionRecap.browser.test.ts
+++ b/ui/src/lib/components/SessionRecap.browser.test.ts
@@ -45,6 +45,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     createdAt: 0,
     updatedAt: 1000,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -8,8 +8,18 @@
   let {
     focusedId,
     onbroadcast,
+    onretry,
+    retryHaltedCount = 0,
+    retryReady = false,
     onedit,
-  }: { focusedId: string; onbroadcast: () => void; onedit?: () => void } = $props();
+  }: {
+    focusedId: string;
+    onbroadcast: () => void;
+    onretry?: () => void;
+    retryHaltedCount?: number;
+    retryReady?: boolean;
+    onedit?: () => void;
+  } = $props();
 
   // Only steer-bar-scoped entries render here; issue-scoped ones live on backlog rows.
   const chips = $derived(steers.list.filter((s) => s.inSteerBar));
@@ -153,6 +163,18 @@
       aria-label={m.steerbar_broadcast_aria()}
       >⌁<span class="bc-label">{m.steerbar_broadcast()}</span></button
     >
+    {#if retryReady && retryHaltedCount > 0}
+      <button
+        type="button"
+        class="chip retry-chip"
+        onpointerdown={down}
+        onpointermove={move}
+        onpointercancel={cancel}
+        onpointerup={(e) => tap(e, () => onretry?.())}
+        title={m.retry_title()}
+        aria-label={m.retry_title()}>⟳<span class="bc-label"> {retryHaltedCount}</span></button
+      >
+    {/if}
     {#each chips as s (s.id)}
       <button
         type="button"
@@ -266,6 +288,11 @@
   .chip.bc {
     color: var(--color-amber);
     border-color: var(--color-amber);
+  }
+  .chip.retry-chip {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
+    opacity: 0.85;
   }
   .bc-label {
     margin-left: 6px;

--- a/ui/src/lib/components/TriageDrawer.browser.test.ts
+++ b/ui/src/lib/components/TriageDrawer.browser.test.ts
@@ -47,6 +47,8 @@ function session(id: string): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
   };
 }
 

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -55,6 +55,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/UnitTile.browser.test.ts
+++ b/ui/src/lib/components/UnitTile.browser.test.ts
@@ -53,6 +53,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -66,6 +66,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -77,6 +77,9 @@
     onnextneedsyou,
     nextNeedsYou = 0,
     onbroadcast,
+    onretry,
+    retryHaltedCount = 0,
+    retryReady = false,
     onedit,
     mobile = false,
     touch = false,
@@ -107,6 +110,9 @@
     /** How many *other* sessions are waiting on the operator; gates the button. */
     nextNeedsYou?: number;
     onbroadcast?: () => void;
+    onretry?: () => void;
+    retryHaltedCount?: number;
+    retryReady?: boolean;
     onedit?: () => void;
     mobile?: boolean;
     touch?: boolean;
@@ -2594,6 +2600,9 @@
     <SteerBar
       focusedId={session.id}
       onbroadcast={() => onbroadcast?.()}
+      onretry={() => onretry?.()}
+      {retryHaltedCount}
+      {retryReady}
       onedit={() => onedit?.()}
     />
   {/if}

--- a/ui/src/lib/components/epic-grouping.test.ts
+++ b/ui/src/lib/components/epic-grouping.test.ts
@@ -48,6 +48,8 @@ function session(
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
   };
 }
 

--- a/ui/src/lib/components/herd-keynav.test.ts
+++ b/ui/src/lib/components/herd-keynav.test.ts
@@ -55,6 +55,8 @@ function session(
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
   };
 }
 

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -42,6 +42,8 @@ function session(id: string, readyToMerge = false, status: SessionStatus = "runn
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
   };
 }
 

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -48,6 +48,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -242,6 +242,8 @@ function session(over: Partial<Session>): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
     ...over,
   };
 }

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1199,4 +1199,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_usage_aware_holding_title",
     bodyKey: "feat_usage_aware_holding_body",
   },
+  {
+    // No targetId: the ⟳ Retry button only renders in the SteerBar when usage-halted
+    // sessions exist and usage has dropped back below the hold threshold, so a coachmark
+    // anchor would rarely be mounted — surface via the What's-New drawer only.
+    // v1.34.0 is the latest released tag → ships in 1.35.0.
+    id: "usage-halt-retry",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_usage_halt_retry_title",
+    bodyKey: "feat_usage_halt_retry_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -64,6 +64,8 @@ function session(id: string): Session {
     createdAt: 0,
     updatedAt: 0,
     archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
   };
 }
 

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -302,18 +302,6 @@ export class HerdStore {
         recaps.drop(ev.data.id);
         this.clearDraftReconcileToast(ev.data.id);
         break;
-      case "session:git":
-        this.git = { ...this.git, [ev.data.id]: ev.data.git };
-        break;
-      case "session:activity":
-        this.activity = { ...this.activity, [ev.data.id]: ev.data.activity };
-        break;
-      case "session:subagents":
-        this.subagents = { ...this.subagents, [ev.data.id]: ev.data.subagents };
-        break;
-      case "session:claude-alive":
-        this.claudeAlive = { ...this.claudeAlive, [ev.data.id]: ev.data.claudeAlive };
-        break;
       case "session:working-blocked":
         this.setWorkingBlockedFlag(ev.data.id, ev.data.working);
         break;
@@ -326,12 +314,6 @@ export class HerdStore {
       case "session:block":
         this.setBlock(ev.data.id, ev.data.block);
         break;
-      case "session:halt":
-        this.patchSession(ev.data.id, {
-          haltReason: ev.data.haltReason,
-          haltedAt: ev.data.haltedAt,
-        });
-        break;
       case "session:egress-drop":
         toasts.info(m.toast_egress_drop({ host: ev.data.host }), {
           key: "egress-drop-" + ev.data.id,
@@ -339,10 +321,39 @@ export class HerdStore {
         });
         break;
       default:
-        // Review/plan-gate and app-global (non-per-session-row) events are handled
+        // Simple data-update, review/plan-gate, and app-global events are handled
         // out of line to keep this dispatch switch under the complexity gate.
-        if (!this.applySessionCardEvent(ev)) this.applyGlobalEvent(ev);
+        if (!this.applySessionDataEvent(ev) && !this.applySessionCardEvent(ev))
+          this.applyGlobalEvent(ev);
         break;
+    }
+  }
+
+  /** Handle the simple per-session data-update WS events (git, activity, subagents,
+   *  claude-alive, halt) — extracted from apply() to keep that dispatch switch under
+   *  the complexity gate. Returns true when `ev` was handled. */
+  private applySessionDataEvent(ev: WsEvent): boolean {
+    switch (ev.event) {
+      case "session:git":
+        this.git = { ...this.git, [ev.data.id]: ev.data.git };
+        return true;
+      case "session:activity":
+        this.activity = { ...this.activity, [ev.data.id]: ev.data.activity };
+        return true;
+      case "session:subagents":
+        this.subagents = { ...this.subagents, [ev.data.id]: ev.data.subagents };
+        return true;
+      case "session:claude-alive":
+        this.claudeAlive = { ...this.claudeAlive, [ev.data.id]: ev.data.claudeAlive };
+        return true;
+      case "session:halt":
+        this.patchSession(ev.data.id, {
+          haltReason: ev.data.haltReason,
+          haltedAt: ev.data.haltedAt,
+        });
+        return true;
+      default:
+        return false;
     }
   }
 

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -326,6 +326,12 @@ export class HerdStore {
       case "session:block":
         this.setBlock(ev.data.id, ev.data.block);
         break;
+      case "session:halt":
+        this.patchSession(ev.data.id, {
+          haltReason: ev.data.haltReason,
+          haltedAt: ev.data.haltedAt,
+        });
+        break;
       case "session:egress-drop":
         toasts.info(m.toast_egress_drop({ host: ev.data.host }), {
           key: "egress-drop-" + ev.data.id,

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -648,6 +648,10 @@ export interface Session {
   createdAt: number;
   updatedAt: number;
   archivedAt: number | null;
+  /** Reason the session halted mid-run; null when not halted. */
+  haltReason: "usage_limit" | "completed" | "operator" | "error" | null;
+  /** Epoch ms when haltReason was set; null when not halted. */
+  haltedAt: number | null;
 }
 
 export interface SessionUsage {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -67,7 +67,8 @@ export interface Settings {
   previewHost: string | null;
   /** Whether usage-aware task holding is enabled (new tasks paused when usage is high). */
   usageHoldEnabled: boolean;
-  /** Usage percentage at or above which new tasks are held (0–100). */
+  /** Usage percentage at or above which new tasks are held (0–100); also the threshold
+   *  below which the usage-halt retry trigger becomes available. */
   usageHoldPct: number;
 }
 
@@ -862,6 +863,10 @@ export type WsEvent =
   | { event: "session:renamed"; data: { id: string; name: string; branch: string | null } }
   | { event: "usage:limits"; data: UsageLimits }
   | { event: "session:block"; data: { id: string; block: BlockReason | null } }
+  | {
+      event: "session:halt";
+      data: { id: string; haltReason: Session["haltReason"]; haltedAt: number | null };
+    }
   | { event: "session:git"; data: { id: string; git: GitState } }
   | { event: "session:activity"; data: { id: string; activity: SessionActivity } }
   | { event: "session:subagents"; data: { id: string; subagents: SubagentEntry[] } }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -97,6 +97,7 @@
   import NewProject from "$lib/components/NewProject.svelte";
   import type { KickoffChoice } from "$lib/components/NewProject.svelte";
   import BroadcastDialog from "$lib/components/BroadcastDialog.svelte";
+  import RetryDialog from "$lib/components/RetryDialog.svelte";
   import ClearMergedDialog from "$lib/components/ClearMergedDialog.svelte";
   import MergeTrainConfirmDialog from "$lib/components/MergeTrainConfirmDialog.svelte";
   import ActionBar from "$lib/components/ActionBar.svelte";
@@ -183,6 +184,7 @@
   let showFork = $state(false);
   let showNewProject = $state(false);
   let showBroadcast = $state(false);
+  let showRetry = $state(false);
   // "clear all merged" confirm modal: the merged sessions to clear + their total
   // leftover subprocess count (both fetched server-side when the modal opens).
   let clearMergedSessions = $state<Session[] | null>(null);
@@ -400,6 +402,14 @@
   );
 
   const selected = $derived(store.sessions.find((s) => s.id === selectedId) ?? null);
+
+  // Retry-halted gate: how many sessions are usage-halted, and is usage back below the threshold?
+  const haltedCount = $derived(store.sessions.filter((s) => s.haltReason === "usage_limit").length);
+  const usageBelow = $derived(
+    Math.max(store.usageLimits?.session5h?.pct ?? 0, store.usageLimits?.week?.pct ?? 0) <
+      usageHoldPct,
+  );
+  const retryReady = $derived(haltedCount > 0 && usageBelow);
 
   function loadSettings() {
     getSettings()
@@ -903,6 +913,7 @@
       showSettings ||
       showBacklog ||
       showBroadcast ||
+      showRetry ||
       showTriage ||
       showUpdate ||
       showHerdrUpdate ||
@@ -1716,6 +1727,9 @@
             nextNeedsYou={otherNeedsYou.length}
             onnextneedsyou={jumpNextNeedsYou}
             onbroadcast={() => (showBroadcast = true)}
+            onretry={() => (showRetry = true)}
+            retryHaltedCount={haltedCount}
+            {retryReady}
             onedit={() => {
               settingsTab = "session";
               showSettings = true;
@@ -1852,6 +1866,9 @@
             {onarchive}
             workingBlocked={store.workingBlocked}
             onbroadcast={() => (showBroadcast = true)}
+            onretry={() => (showRetry = true)}
+            retryHaltedCount={haltedCount}
+            {retryReady}
             onedit={() => {
               settingsTab = "session";
               showSettings = true;
@@ -2133,6 +2150,10 @@
 
 {#if showBroadcast}
   <BroadcastDialog sessions={store.sessions} onclose={() => (showBroadcast = false)} />
+{/if}
+
+{#if showRetry}
+  <RetryDialog sessions={store.sessions} onclose={() => (showRetry = false)} />
 {/if}
 
 {#if clearMergedSessions}

--- a/ui/test/store.test.ts
+++ b/ui/test/store.test.ts
@@ -41,6 +41,8 @@ const s = (id: string, status: any = "running"): Session => ({
   createdAt: 0,
   updatedAt: 0,
   archivedAt: null,
+  haltReason: null,
+  haltedAt: null,
 });
 
 test("applies snapshot, new, status, archived", () => {


### PR DESCRIPTION
## Part B — Detect usage-halted sessions + one-click global retry (PR 2 of 2 for #825)

When a session stops because the Claude usage limit was reached, Shepherd now **records why**, and once
usage resets the operator can **retry every halted session in one click**. Builds on Part A
(task-holding, #830).

### Detection (the issue's stated primary risk)
There was previously **no signal** that a session halted on a usage limit — it looked like a normal
finish. This PR adds:
- `Session.haltReason` (`"usage_limit" | "completed" | "operator" | "error" | null`) + `haltedAt`,
  threaded through the store (COLS, INSERT, `migrateSessionColumns`, a dedicated `setHaltReason`
  setter, and `hydrate` — sessions have no UPSERT, so each site is wired explicitly).
- A **centralized matcher** `matchesUsageLimit` + `classifyHalt(tail, limits, holdPct)` in
  `src/usage-halt.ts`. At the done transition (`reapGone` + the `reconcileAgent` done-edge) the poller
  does a **bounded synchronous** transcript-tail read (once per session, `try/catch`) and records
  `haltReason="usage_limit"` only when the matcher hits **and** account usage corroborates (≈cap, with
  a degraded fallback so halts are still caught when usage is uncalibrated / api-key mode).

> **No real captured usage-limit sample exists** (searched `~/.claude/projects` + git history). The
> matcher is built on documented phrasings and kept centralized; the usage≈cap corroboration is the
> false-positive backstop, and **real-sample calibration is a tracked follow-up**. Matcher positives in
> tests are clearly labelled synthetic.

### Retry
- `service.retryHalted(ids, text)` → dead pane = `claude --resume`, live idle/blocked = a localized
  "continue" steer; clears `haltReason` on success; returns `{resumed, steered, total}`.
- `POST /api/retry` (mirrors broadcast; server stays i18n-agnostic — the steer text comes from the UI).
- `session:halt` WS event keeps the client live.
- **`RetryDialog.svelte`** (clone of BroadcastDialog: modal scrim, two-stage arm/fire, multi-select)
  **preselects** usage-halted sessions; a **"⟳ N halted"** trigger appears beside the broadcast control
  only when usage is back below the threshold **and** ≥1 usage-halted session exists.

### Testing
- `classifyHalt` corroboration boundaries (near-cap → record; uncalibrated → degraded record;
  measurable-but-below-cap → null; no-match → null); matcher no-false-positive on benign/normal text.
- `retryHalted` routing (dead→resume, live→steer, counts, haltReason cleared); `POST /api/retry`
  happy + 400 paths; `haltReason`/`haltedAt` store round-trip incl. a migration reopen.
- Suites green: root **3920+**, ui **1697**, tsc/lint/i18n parity/branch-hygiene/feature-catalog/
  glossary/Fallow complexity all pass.

### Note on merge order
PR2 independently introduces `config.usageHoldPct` and exposes it in `GET /api/settings` (needed for
the retry-trigger gate); **#830 owns the full setting (toggle, PUT, Settings editor)**. When #830
merges first this will produce a small, expected rebase conflict on `config.ts` / the settings payload —
resolve by keeping one copy.

Closes #825 (together with #830). 🤖 Generated with [Claude Code](https://claude.com/claude-code)
