### PR TITLE
feat: one-session-one-PR invariant directive (#839)

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -437,6 +437,43 @@ const AUTOPILOT_DIRECTIVE =
   "you hit a genuine product or requirements decision that only a human can make.";
 
 /**
+ * The one-session-one-PR invariant (issue #839). Shepherd tracks ONE branch per session and
+ * resolves its PR on demand — there is no per-session list of PRs. When one session opens a second
+ * PR on a different branch (e.g. the #830/#835 "Part A / Part B" split out of #825), that PR is
+ * invisible to the session entirely: never reviewed, never merge-tracked, never recapped, never
+ * landed. The critic, pr-poller, review, merge-train, epic, and recap wiring are all
+ * session → single-tracked-PR by design.
+ *
+ * Wording is deliberately CONDITIONAL ("when you open a pull request…"), not an absolute "this
+ * session opens exactly one PR." It rides the same `!opts.research` path as non-research
+ * issue-creation / triage spawns; an absolute form would mandate a PR and contradict
+ * AUTOPILOT_DIRECTIVE's deliberately-conditional framing (see above — "for a code change that means
+ * an open PR…"), pushing those spawns toward a meaningless PR.
+ *
+ * Escape hatch (a) is worded honestly: epic drain is operator/drain-driven (server
+ * `/api/epic/approve-next` → drain.approveEpicNext + drain.tick), so an agent CANNOT self-trigger
+ * Shepherd to drain an epic — it sets the epic up and STOPS. Hatch (b) (one PR + follow-up issue)
+ * is the always-safe default.
+ *
+ * Advisory only — there is no enforcement. The data layer cannot see a second PR on another branch,
+ * so recurrence stays possible; the deferred detection guardrail (split-marker scan) is the
+ * enforcement path if guidance proves insufficient. Agent-facing prompt text (not operator UI), so
+ * fixed English — same precedent as AUTOPILOT_DIRECTIVE and the other spawn-constant directives.
+ */
+const SINGLE_PR_INVARIANT =
+  'When you open a pull request, open exactly one — never a second, and never label work "PR 1 of ' +
+  'N." This holds even when the task or its issue describes multiple parts, phases, or "Part A / ' +
+  'Part B." If the work is genuinely too large for one cohesive PR, pick ONE of:\n' +
+  "- (a) Promote to an epic: convert the issue into an epic — add one sub-issue per intended PR " +
+  "(and an `epic-dag` fence if you map dependencies) — open NO pull request yourself, then STOP " +
+  "and tell the operator the epic is ready to drain. Shepherd drains each sub-issue as its own " +
+  "session and its own PR, but that drain is operator-started — you cannot trigger it yourself.\n" +
+  "- (b) Ship one PR + file a follow-up: complete and open a single cohesive PR for the slice you " +
+  "can finish, then `gh issue create` a follow-up issue capturing the remainder for a later agent, " +
+  "and reference it from the PR body. This is the always-safe default.\n" +
+  "Never split the work across two PRs from this one session.";
+
+/**
  * Injected as the highest-priority directive for an attended RESEARCH task (`research: true`).
  * A research session does open-ended web research with sub-agents and delivers a report-only PR
  * OR a GitHub issue — never code. It SUPPRESSES the plan-gate, autopilot, and build-queue
@@ -690,7 +727,9 @@ export function planGoSteer(draftMode: boolean): string {
  * so the agent can cleanly separate persistent guidance from the task in its human turn.
  * `houseRules` is the already-wrapped `<shepherd-house-rules>` block, or null when there are
  * none / learnings are disabled; the engineering-posture, research-first, and branch-rename blocks
- * always ride. `autopilotActive` appends the autopilot directive (see above), UNLESS `opts.planGate`
+ * always ride. The `<single-pr-invariant>` block (issue #839) rides every spawn EXCEPT a research
+ * one (`opts.research`) — research already caps at one report-PR / issue, so it's redundant there.
+ * `autopilotActive` appends the autopilot directive (see above), UNLESS `opts.planGate`
  * is set: the plan gate and autopilot are mutually exclusive. During the planning phase the matching
  * plan-gate directive (interactive/auto) is appended INSTEAD of the autopilot directive, even when
  * `autopilotActive` is true — planning must suppress autopilot so the agent stops to plan/grill
@@ -724,6 +763,12 @@ export function composeSystemPrompt(
   const blocks = houseRules
     ? [posture, research, houseRules, branchNotice]
     : [posture, research, branchNotice];
+  // One-session-one-PR invariant (issue #839): rides every code spawn, suppressed only for a
+  // research session — which already caps at exactly one report-PR / issue, so the block is
+  // redundant there and would muddy that deliverable.
+  if (!opts.research) {
+    blocks.push(`<single-pr-invariant>\n${SINGLE_PR_INVARIANT}\n</single-pr-invariant>`);
+  }
   // Research is the highest-priority directive: it replaces BOTH the plan-gate and the autopilot
   // directive (none of those fit a report-PR/issue deliverable).
   if (opts.research) {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2424,6 +2424,35 @@ test("composeSystemPrompt always injects the research-first notice, with or with
   expect(composeSystemPrompt(null, true)).toContain("<research-first-notice>");
 });
 
+test("composeSystemPrompt rides the single-PR invariant on code spawns, never on research", () => {
+  // Issue #839: one session → one tracked PR. The block must ride every CODE spawn (with/without
+  // house rules, autopilot on, plan-gate variants) but be suppressed for a research session, which
+  // already caps at one report-PR / issue.
+  const withRules = `<${HOUSE_RULES_TAG}>\nintro\n- Use bun\n</${HOUSE_RULES_TAG}>`;
+  const codeSpawns = [
+    composeSystemPrompt(null),
+    composeSystemPrompt(withRules),
+    composeSystemPrompt(null, true),
+    composeSystemPrompt(null, true, { planGate: "interactive" }),
+    composeSystemPrompt(null, true, { planGate: "auto" }),
+  ];
+  for (const sp of codeSpawns) {
+    // Anchor on the STABLE tag + DURABLE phrasing (not incidental wording like "always-safe default").
+    expect(sp).toContain("<single-pr-invariant>");
+    expect(sp).toContain("</single-pr-invariant>");
+    expect(sp).toContain("Part A / Part B");
+    expect(sp).toContain("Never split the work across two PRs");
+    // Phrasing must stay CONDITIONAL — it binds "exactly one" to WHEN a PR is opened and must NOT
+    // flatly mandate opening one (which would contradict AUTOPILOT_DIRECTIVE's conditional framing).
+    expect(sp).toContain("When you open a pull request");
+    expect(sp).not.toContain("This session opens exactly one pull request");
+  }
+  // Suppressed for a research deliverable.
+  expect(composeSystemPrompt(null, false, { research: true })).not.toContain(
+    "<single-pr-invariant>",
+  );
+});
+
 test("resume adopts a live agent found by cwd under a new terminalId — no duplicate spawn", async () => {
   const store = new SessionStore(":memory:");
   let startCalls = 0;


### PR DESCRIPTION
Closes #839.

## Problem

A single task session must produce **exactly one PR**, but nothing in the agent's directives enforced this. Issue #825 was framed as "Part A … Part B," and the agent dutifully opened **two** PRs from one session (#830 + #835). Shepherd tracks **one branch per session** and resolves its PR on demand — the critic, `pr-poller`, `review`, merge-train, epic, and recap wiring are all **session → single tracked PR**. A second PR on a different branch is invisible to the session: never reviewed, never merge-tracked, never recapped, never landed.

## Fix

Add a `SINGLE_PR_INVARIANT` constant in `src/service.ts` (sibling of `AUTOPILOT_DIRECTIVE`/`ENGINEERING_POSTURE`) and ride it as a `<single-pr-invariant>` block on **every code spawn** via `composeSystemPrompt` — **suppressed under `opts.research`** (a research session already caps at exactly one report-PR / issue).

**Conditional wording, not absolute.** The directive opens with *"When you open a pull request, open exactly one…"* rather than *"this session opens exactly one PR."* It rides the same `!opts.research` path as non-research issue-creation / triage spawns, so an absolute form would mandate a PR and contradict `AUTOPILOT_DIRECTIVE`'s deliberately-conditional framing (`src/service.ts` — "for a code change that means an open PR…"), pushing those spawns toward a meaningless PR.

**Two honest escape hatches** for genuinely oversized work:
- **(a) Promote to an epic** — set up sub-issues, open NO PR, then STOP and tell the operator. Verified empirically: epic drain is **operator/drain-driven** (`/api/epic/approve-next` → `drain.approveEpicNext` + `drain.tick`); an agent **cannot** self-trigger the drain, so the wording says so honestly rather than promising a no-op path.
- **(b) Ship one PR + file a follow-up issue** — the always-safe default.

## Advisory only — no enforcement

This is **guidance, not a hard gate**. The data layer still cannot see a second PR on a different branch, so **recurrence remains possible** if an agent ignores the directive. The deferred **detection guardrail** (#845, scanning the tracked PR's title/body for split markers like `PR \d+ of \d+` / `Part A —`) is the enforcement path to revisit if guidance proves insufficient.

## Out of scope (noted honestly)

- **House-rule counterpart** — house rules are DB-stored per-repo learnings (`src/house-rules.ts`), not source-seeded; there is no source list to append to. The constant is the always-present lever; a redundant house-rule would be a live-DB curation action, not a code change here.
- **Backlog→issue authoring** emitting epics instead of "Part A/B" — separate follow-up.
- **#825 cleanup** (#830/#835 pair) — operator decision.

## Test

`test/service.test.ts` — new regression test asserts the `<single-pr-invariant>` block is present on code spawns (with/without house rules, autopilot on, both plan-gate variants), absent under `opts.research`, and that the phrasing stays **conditional** (contains "When you open a pull request", does not flatly mandate a PR). Anchored on the stable tag + durable phrases ("Part A / Part B", "Never split the work across two PRs"). **Fails on current `main`** (constant does not exist yet); verified red→green.

[no-feature-entry] — server-only directive plumbing, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
