### PR TITLE
chore: adopt fallow <template> complexity metric, unpin to 2.100.0 (#851)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -125,6 +125,160 @@
     "maxCyclomatic": 20,
     "maxCognitive": 15,
     "maxCrap": 1000,
+
+    // Svelte <template> complexity (fallow 2.98+, issue #851). fallow scores a
+    // synthetic `<template>` entry per .svelte file — the whole markup block, with
+    // every {#if}/{#each}/{:else} counted as a branch — against the SAME per-function
+    // thresholds (20/15) it uses for real functions. That's a category error for an
+    // aggregate that rolls up what other frameworks split across many render helpers,
+    // so every non-trivial component trips (36 on 2.98 vs 0 on 2.97). These overrides
+    // adopt the metric deliberately instead of either ignoring it or pinning fallow
+    // back. They relax ONLY the synthetic <template> entry; <script>-block functions
+    // in these same files stay gated at the global 20/15.
+    //
+    // WHY OVERRIDES (not just the version bump): a new non-trivial Svelte component
+    // trips the library-default 20/15 as an "introduced" finding (verified — a fresh
+    // ~25-conditional template fails the audit at 20/15 and passes at the Tier-1 40/60).
+    // Without the overrides the 36 existing components also sit in every report as
+    // inherited noise. The bar below adopts the metric at a Svelte-appropriate level.
+    //
+    // ON #756: the line-shift mis-attribution that motivated the old 2.97 pin was
+    // re-tested against 2.100 and does NOT reproduce — fallow attributes inherited
+    // <template> findings correctly across line shifts AND complexity increases (the
+    // audit's new-only gate fires only when a template is a finding in HEAD that was not
+    // one in the base). So these overrides are a deliberate bar + clean adoption, not a
+    // #756 workaround. A brand-new oversized template (or one newly crossing the bar)
+    // will still trip as "introduced" — that's the gate working; fix or grandfather it.
+    //
+    // Tier 1: a real global bar for idiomatic Svelte markup (≈2× cyclo / 4× cognitive
+    //   over the per-function default; cognitive runs higher because markup nests). No
+    //   external convention exists for template thresholds — this is a deliberate
+    //   judgment call. 23 of 36 components clear it; anything over it still trips, so
+    //   the metric stays live for new code.
+    // Tier 2: the 13 giants that exceed Tier 1, each grandfathered just above its
+    //   current cyclo/cog (next multiple of 10) so it can't silently grow. Tracked for
+    //   refactor in #855.
+    // maxCrap is intentionally inert for templates: CRAP for uncovered code is pure
+    //   CC-derived noise bounded by CC²+CC; 20000 sits above the largest template's
+    //   worst case (Viewport CC 136 → ≈18632) so it never becomes the binding
+    //   constraint — the cyclo/cog bars are the real gate. Same spirit as the global
+    //   maxCrap: 1000 above. Every entry sets all three dimensions explicitly (no
+    //   cross-entry inheritance).
+    "thresholdOverrides": [
+      {
+        "files": ["ui/src/**/*.svelte", "extension/src/**/*.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 40,
+        "maxCognitive": 60,
+        "maxCrap": 20000,
+        "reason": "Tier 1: global Svelte <template> complexity bar (#851; see comment above)."
+      },
+      {
+        "files": ["ui/src/lib/components/Viewport.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 140,
+        "maxCognitive": 200,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/lib/components/TopBar.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 120,
+        "maxCognitive": 200,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/lib/components/Herd.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 110,
+        "maxCognitive": 160,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/routes/+page.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 80,
+        "maxCognitive": 100,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/lib/components/Settings.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 60,
+        "maxCognitive": 70,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/lib/components/GitRail.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 60,
+        "maxCognitive": 120,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/lib/components/UnitRow.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 60,
+        "maxCognitive": 90,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/lib/components/AutomationSettings.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 60,
+        "maxCognitive": 60,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/lib/components/NewTask.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 50,
+        "maxCognitive": 60,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/lib/components/LearningsDrawer.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 50,
+        "maxCognitive": 110,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/lib/components/BacklogView.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 40,
+        "maxCognitive": 80,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/lib/components/RepoSwitcher.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 40,
+        "maxCognitive": 70,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      },
+      {
+        "files": ["ui/src/lib/components/IssuesPanel.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 40,
+        "maxCognitive": 100,
+        "maxCrap": 20000,
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
+      }
+    ],
+
     "ignore": [
       "**/src/lib/paraglide/**",
       "**/scripts/**",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,12 @@ jobs:
         # Only new findings introduced by the PR block — inherited issues don't.
         # Skip on direct pushes to main: there's no base branch to diff against.
         # Version pinned (not @latest) so analyzer changes are adopted deliberately,
-        # not on a random CI run. 2.97.0 is the last release before the synthetic
-        # Svelte <template> complexity metric, whose unnamed entry breaks fallow's
-        # inherited-vs-introduced attribution on line shifts (#756). A future bump to
-        # 2.98+ must intentionally adopt a <template> config (thresholdOverrides /
-        # health.ignore). Keep this in sync with .husky/pre-push and CONTRIBUTING.md.
+        # not on a random CI run. The synthetic Svelte <template> complexity metric
+        # (fallow 2.98+) is adopted via health.thresholdOverrides in .fallowrc.jsonc
+        # (#851) — a Svelte-appropriate bar so new components aren't churned against the
+        # library-default 20/15. The #756 line-shift mis-attribution that forced the old
+        # 2.97 pin was re-tested against 2.100 and does NOT reproduce (inherited template
+        # findings now attribute correctly across line shifts). Keep this version in sync
+        # with .husky/pre-push and CONTRIBUTING.md.
         if: github.event_name == 'pull_request'
-        run: bunx fallow@2.97.0 audit --base origin/${{ github.base_ref }} --fail-on-issues
+        run: bunx fallow@2.100.0 audit --base origin/${{ github.base_ref }} --fail-on-issues

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ onboarding-gap-report.md
 # (the global `.env.*` rule above would otherwise swallow .env.example).
 ci/self-hosted-runner/.env
 !ci/self-hosted-runner/.env.example
+
+# fallow analyzer cache
+.fallow/

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -63,11 +63,13 @@ echo "→ extension build"
 
 # Delta audit vs the merge base — only new dead-code/complexity/dupes block.
 # Skipped when origin/main is unavailable (e.g. offline) so a push isn't wedged.
-# Version pinned (see .github/workflows/ci.yml): 2.97.0 is the last release before
-# the synthetic Svelte <template> complexity metric (#756); bump deliberately.
+# Version pinned (see .github/workflows/ci.yml): the synthetic Svelte <template>
+# complexity metric (fallow 2.98+) is adopted via .fallowrc.jsonc thresholdOverrides
+# (#851). The #756 line-shift mis-attribution that forced the old 2.97 pin was verified
+# not to reproduce on 2.100; the overrides set a Svelte-appropriate bar for new code.
 if git rev-parse --verify --quiet origin/main >/dev/null; then
   echo "→ fallow audit (delta vs origin/main)"
-  bunx fallow@2.97.0 audit --base origin/main --fail-on-issues
+  bunx fallow@2.100.0 audit --base origin/main --fail-on-issues
 else
   echo "→ fallow audit skipped (origin/main not available)"
 fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,21 +82,30 @@ The `pre-push` hook runs the **same checks as CI** so failures surface before a 
 8. `bun test ./test` (core tests)
 9. `cd ui && bun run test` (ui tests)
 10. `cd ui && bun run build` (ui build)
-11. `bunx fallow@2.97.0 audit --base origin/main --fail-on-issues` (delta dead-code/complexity
+11. `bunx fallow@2.100.0 audit --base origin/main --fail-on-issues` (delta dead-code/complexity
     audit vs `origin/main`; version pinned — see note below)
 
 > Lint and typecheck are separate gates: eslint catches lint rules, `tsc` catches
 > type errors. Bun runs `.ts` by stripping types, so it never type-checks — only
 > `tsc` does.
 
-> **fallow is pinned to `2.97.0`** (not `@latest`) so analyzer changes are adopted
-> deliberately, not on a random run. 2.97.0 is the last release before the synthetic
-> Svelte `<template>` complexity metric, whose unnamed entry breaks fallow's
-> inherited-vs-introduced attribution on line shifts and trips the gate on any PR
-> touching a large UI file ([#756](https://github.com/erwins-enkel/shepherd/issues/756)).
-> A future bump to 2.98+ must intentionally adopt a `<template>` config
-> (`health.thresholdOverrides` or `health.ignore`). Keep the version in sync with
-> `.github/workflows/ci.yml` and `.husky/pre-push`.
+> **fallow is pinned to `2.100.0`** (not `@latest`) so analyzer changes are adopted
+> deliberately, not on a random run. The synthetic Svelte `<template>` complexity metric
+> (fallow 2.98+) is adopted via `health.thresholdOverrides` in `.fallowrc.jsonc`
+> ([#851](https://github.com/erwins-enkel/shepherd/issues/851)) — a Tier-1 global bar
+> (40 cyclomatic / 60 cognitive) plus per-file grandfathers for the known-large
+> components. The bar exists because a template aggregates many conditional regions, so
+> the library-default 20/15 fires on essentially every non-trivial Svelte component (a
+> fresh ~25-conditional component trips at 20/15, passes at 40/60).
+>
+> **On [#756](https://github.com/erwins-enkel/shepherd/issues/756):** the line-shift
+> mis-attribution that forced the old 2.97 pin (an inherited `<template>` finding scored
+> as _introduced_ after lines moved) was re-tested against 2.100 and **does not
+> reproduce** — fallow attributes inherited template findings correctly across line
+> shifts and complexity changes; the audit's new-only gate fires only when a template is
+> a finding in HEAD that was not one in the base. A genuinely new oversized template will
+> still trip as _introduced_ (the gate working) — fix or grandfather it. Keep the version
+> in sync with `.github/workflows/ci.yml` and `.husky/pre-push`.
 
 Run any of these manually at any time:
 
@@ -109,7 +118,7 @@ cd ui && bun run check       # svelte-check (ui types)
 cd ui && bun run check:i18n  # locale-catalog parity (en ↔ de)
 cd ui && bun run test        # ui test suite (vitest)
 cd ui && bun run build       # ui production build
-bunx fallow@2.97.0 audit --base origin/main --fail-on-issues  # delta dead-code/complexity audit (version pinned)
+bunx fallow@2.100.0 audit --base origin/main --fail-on-issues  # delta dead-code/complexity audit (version pinned)
 ```
 
 ## Tests


### PR DESCRIPTION
Closes #851.

## What

Adopt fallow's synthetic Svelte `<template>` complexity metric (new in 2.98) and unpin from `2.97.0`:

- **`.fallowrc.jsonc`** — new `health.thresholdOverrides`: a Tier-1 global `<template>` bar (40 cyclomatic / 60 cognitive) across `ui/src` + `extension/src`, plus per-file grandfathers for the 13 components whose templates exceed it. Every entry sets all three dimensions explicitly; `maxCrap` (20000) is kept inert because for uncovered templates CRAP is pure CC-derived noise — the cyclo/cog bars are the real gate.
- **Version bump `2.97.0` → `2.100.0`** (confirmed current `latest`) in the three in-sync locations: `.github/workflows/ci.yml`, `.husky/pre-push`, `CONTRIBUTING.md`.
- **`.gitignore`** — ignore the `.fallow/` analyzer cache.

## Why

fallow 2.98 added a synthetic `<template>` entry that scores a whole `.svelte` markup block (every `{#if}`/`{#each}`/`{:else}` is a branch) against the **per-function** 20/15 thresholds. That's a category error for an aggregate that rolls up what other frameworks split into many render helpers — so it flags essentially every non-trivial component (**0 findings on 2.97 → 36 on 2.98**). Our `<script>` complexity is unaffected (avg cyclomatic 3.3). The overrides adopt the metric at a Svelte-appropriate bar; `<script>`-block functions in the same files stay gated at 20/15.

## Correction to the original framing (#756)

The plan assumed #756 (an inherited `<template>` finding mis-attributed as *introduced* on a line shift) was unfixed upstream and that the config was "load-bearing" for it. **Execution-time verification falsified that.** Running the real CI command against a giant (`Viewport`) with a template-start line shift, an in-template line change, and a genuine `{#if}` complexity increase — all stayed **GREEN**: at 2.100 fallow attributes inherited template findings correctly. The audit's new-only gate fires only when a template is a finding in HEAD that was **not** one in the base.

So the overrides are a deliberate Svelte bar + clean adoption, **not** a #756 workaround. Their verified value: a fresh ~25-conditional component trips the library-default 20/15 as *introduced* (RED) but passes the 40/60 bar (GREEN). The shipped comments in `.fallowrc.jsonc` / CI / pre-push / `CONTRIBUTING.md` reflect this corrected, evidence-based narrative.

## Verification

| Check | Result |
| --- | --- |
| `bunx fallow@2.100.0 health` template findings | **0** |
| `fallow@2.100.0 audit --base origin/main` on a no-op line-shift edit to a giant | **GREEN** (with and without overrides — #756 does not reproduce on 2.100) |
| New ~25-conditional component, no overrides | RED (trips 20/15) |
| New ~25-conditional component, with overrides | GREEN (under 40/60) |
| root `bun run lint` / `bun test ./test` | clean / 3983 pass, 0 fail |
| ui `check` / `check:i18n` / `test` / `build` | 0 errors / parity / 1718 pass / built |
| pre-push hook (full CI-equivalent suite + fallow audit) | passed |

## Grandfathered giants (refactor tracked in #855)

`Viewport` 136/194 · `TopBar` 119/191 · `Herd` 103/154 · `routes/+page` 78/96 · `Settings` 59/60 · `GitRail` 51/114 · `UnitRow` 51/83 · `AutomationSettings` 50/57 · `NewTask` 47/55 · `LearningsDrawer` 42/108 · `BacklogView` 37/70 · `RepoSwitcher` 32/63 · `IssuesPanel` 30/90.

Refactoring these (issue scope point 2, optional) is deferred to **#855**, which tightens/removes each grandfather as its template shrinks.

[no-feature-entry] — tooling/CI config only, no user-facing UX.
