### PR TITLE
fix(ui): sticky filter bar fully covers scrolling rows in SEED FROM picker

### DIFF
--- a/ui/src/lib/components/PromptSources.browser.test.ts
+++ b/ui/src/lib/components/PromptSources.browser.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import "../../app.css";
+import type { Issue, SlashCommand } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+import { getTodo, listIssues, getCommands } from "$lib/api";
+
+// Mock the API so no network fires; each test seeds the data it needs.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    getTodo: vi.fn(),
+    listIssues: vi.fn(),
+    getCommands: vi.fn(),
+  };
+});
+
+const { default: PromptSources } = await import("./PromptSources.svelte");
+
+const mockGetTodo = vi.mocked(getTodo);
+const mockListIssues = vi.mocked(listIssues);
+const mockGetCommands = vi.mocked(getCommands);
+
+const noop = () => {};
+
+beforeEach(() => {
+  mockGetTodo.mockReset();
+  mockListIssues.mockReset();
+  mockGetCommands.mockReset();
+  // No TODO.md → the panel auto-switches off the To-Do tab to Issues.
+  mockGetTodo.mockResolvedValue({ exists: false, content: "" });
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function issue(n: number): Issue {
+  return {
+    number: n,
+    title: `Issue number ${n} with a reasonably long title`,
+    body: "",
+    url: `https://example.com/issues/${n}`,
+    labels: [],
+    createdAt: 0,
+    assignees: [], // unassigned → always visible regardless of the "mine" filter
+  };
+}
+
+function command(n: number): SlashCommand {
+  return { name: `command-${n}`, description: `Description for command ${n}`, scope: "project" };
+}
+
+// Asserts the sticky .ps-filter-bar cleanly covers the rows scrolling behind it:
+// pinned to the scrollport top (no band above it) and spanning the full row width
+// (no transparent side strips). Both fail on the pre-fix CSS — see the bug repro.
+function assertStickyCovers() {
+  const body = document.querySelector(".ps-body") as HTMLElement;
+  const bar = document.querySelector(".ps-body .ps-filter-bar") as HTMLElement;
+  const row = document.querySelector(".ps-body .row") as HTMLElement;
+  expect(body).not.toBeNull();
+  expect(bar).not.toBeNull();
+  expect(row).not.toBeNull();
+
+  // The list must actually overflow, else "sticky while scrolling" is untested.
+  expect(body.scrollHeight).toBeGreaterThan(body.clientHeight);
+  body.scrollTop = 60;
+  expect(body.scrollTop).toBeGreaterThan(0);
+
+  const bodyRect = body.getBoundingClientRect();
+  const barRect = bar.getBoundingClientRect();
+  const rowRect = row.getBoundingClientRect();
+
+  // Top coverage: the bar is pinned to the scrollport top (pre-fix the 4px
+  // .ps-body top padding pinned it at bodyTop+4, leaving a bleed band above).
+  expect(barRect.top).toBeLessThanOrEqual(bodyRect.top + 1);
+  // Horizontal coverage: the bar spans the full row width (pre-fix the 8px side
+  // margins left it narrower than the rows, so text bled around it).
+  expect(barRect.left).toBeLessThanOrEqual(rowRect.left + 1);
+  expect(barRect.right + 1).toBeGreaterThanOrEqual(rowRect.right);
+}
+
+describe("PromptSources sticky filter bar covers scrolling rows", () => {
+  it("Issues tab: 'mine & unassigned' chip bar covers the rows behind it", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: Array.from({ length: 20 }, (_, i) => issue(900 - i)),
+      viewer: "me", // non-null → the filter chip (and thus .ps-filter-bar) renders
+    });
+
+    render(PromptSources, { repoPath: "/repo", onpick: noop, onpickissue: noop });
+
+    // Wait for the issues tab to load its rows.
+    await expect.poll(() => document.querySelectorAll(".ps-body .row").length).toBeGreaterThan(10);
+    await expect.poll(() => document.querySelector(".ps-body .ps-filter-bar")).toBeTruthy();
+
+    assertStickyCovers();
+  });
+
+  it("Commands tab: search-input bar covers the rows behind it", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [],
+      viewer: null,
+    });
+    mockGetCommands.mockResolvedValue({
+      commands: Array.from({ length: 20 }, (_, i) => command(i)),
+    });
+
+    render(PromptSources, { repoPath: "/repo", onpick: noop, onpickissue: noop });
+
+    // Switch to the Commands tab.
+    const commandsTab = [...document.querySelectorAll<HTMLButtonElement>(".tabs .tab")].find(
+      (b) => b.textContent?.trim() === m.promptsources_commands_tab(),
+    );
+    expect(commandsTab).toBeTruthy();
+    commandsTab!.click();
+
+    await expect.poll(() => document.querySelectorAll(".ps-body .row").length).toBeGreaterThan(10);
+    await expect.poll(() => document.querySelector(".ps-body .ps-filter-bar")).toBeTruthy();
+    // The search input lives inside the sticky bar wrapper.
+    expect(document.querySelector(".ps-body .ps-filter-bar .cmd-filter")).not.toBeNull();
+
+    assertStickyCovers();
+  });
+});

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -184,14 +184,16 @@
         {/each}
       {/if}
     {:else if tab === "commands"}
-      <input
-        class="cmd-filter"
-        type="text"
-        bind:this={filterInput}
-        bind:value={filter}
-        placeholder={m.promptsources_commands_filter()}
-        aria-label={m.promptsources_commands_filter()}
-      />
+      <div class="ps-filter-bar">
+        <input
+          class="cmd-filter"
+          type="text"
+          bind:this={filterInput}
+          bind:value={filter}
+          placeholder={m.promptsources_commands_filter()}
+          aria-label={m.promptsources_commands_filter()}
+        />
+      </div>
       {#if filteredCommands.length === 0}
         <div class="muted">{m.promptsources_no_commands()}</div>
       {:else}
@@ -287,6 +289,10 @@
     align-items: center;
     gap: 8px;
     padding: 5px 8px 4px;
+    /* Breathing room below the header divider lives here — OUTSIDE the scroll
+       area — not as .ps-body top padding (which would let a scrolled row bleed
+       above the sticky filter bar). */
+    margin-bottom: 4px;
     border-bottom: 1px solid var(--color-line);
   }
 
@@ -336,7 +342,10 @@
   .ps-body {
     max-height: 180px;
     overflow-y: auto;
-    padding: 4px 2px;
+    /* No top padding: it sits inside the scroll area and constrains the sticky
+       filter bar to pin below it, leaving a band where a scrolled row bleeds
+       above the bar. The top gap lives on .ps-head instead. */
+    padding: 0 2px 4px;
     display: flex;
     flex-direction: column;
   }
@@ -401,12 +410,11 @@
     font-size: var(--fs-meta);
   }
 
-  /* Sticky so it stays put while the (potentially long) command list scrolls. */
+  /* Search input fills the sticky .ps-filter-bar wrapper (which provides the
+     sticky behaviour + full-width opaque coverage + 12px inset). */
   .cmd-filter {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    margin: 0 8px 4px;
+    flex: 1;
+    min-width: 0;
     background: var(--color-inset);
     border: 1px solid var(--color-line);
     color: var(--color-ink-bright);
@@ -421,13 +429,19 @@
     border-color: var(--color-line-bright);
   }
 
-  /* "Mine & unassigned" toggle bar above the issue list — sticky like .cmd-filter. */
+  /* Sticky bar pinned above the scrolling rows — hosts the "mine & unassigned"
+     chip (Issues tab) and the search input (Commands tab). It reaches the full
+     scroll width via the flex-column .ps-body's `align-items: stretch` (no
+     explicit width here) — KEEP it a direct flex child of .ps-body, or scrolled
+     rows bleed past its sides. The 0 10px padding (+ .ps-body's 2px) insets the
+     chip/input to 12px, matching the rows' text. */
   .ps-filter-bar {
     position: sticky;
     top: 0;
     z-index: 1;
     display: flex;
-    margin: 0 8px 4px;
+    margin: 0 0 4px;
+    padding: 0 10px;
     background: var(--color-inset);
   }
 


### PR DESCRIPTION
## Problem

In the New Task launcher's **SEED FROM** picker (`PromptSources.svelte`), the sticky **mine & unassigned** chip (Issues tab) and the sticky search input (Commands tab) did not cover the rows scrolling behind them — mid-scroll, row text bled **above and around** the bar. "Looks really shitty" per the report:


## Root cause (reproduced in an isolated copy of the exact CSS at 360px)

1. `.ps-body { padding: 4px 2px }` — the **4px top padding** sits inside the scroll area, constraining the sticky bar to pin *below* it, leaving a band where a scrolled row shows **above** the bar.
2. `.ps-filter-bar` & `.cmd-filter` used `margin: 0 8px 4px` — the **8px side margins** made each sticky element narrower than the full-width rows, so text bled **around** it.

Both sticky elements shared the defect (Issues chip + Commands search input). `IssuesPanel.svelte` (Backlog) was already correct — no top padding, no side margin — and is untouched.

## Fix (CSS + one small markup wrap, scoped to `PromptSources.svelte`)

- Drop `.ps-body` top padding; relocate the breathing room to `.ps-head { margin-bottom }` — **outside** the scroll area, so no bleed band returns and the To-Do / non-overflowing lists aren't cramped.
- Make `.ps-filter-bar` full-width opaque (`margin: 0 0 4px`), insetting its content 12px via `padding: 0 10px` to align with the rows' text. Coverage comes from the flex-column `.ps-body`'s `align-items: stretch` (commented inline so a later edit doesn't break it).
- Wrap the Commands `<input>` in the **same** `.ps-filter-bar` the chip uses, so both tabs align identically and the input gets full-width coverage (a margin-inset input would re-open the side bleed).

## Verification

- New `PromptSources.browser.test.ts` (real-browser layout, same harness as `IssuesPanel.browser.test.ts`) asserts, while scrolled, the sticky bar (a) stays pinned to the scrollport top and (b) spans the full row width — on both the Issues and Commands tabs. **Both assertions fail on the pre-fix CSS** (verified by temporarily reverting), pass after.
- `cd ui && bun run check` clean; full UI suite green (**1720 passed**).
- Re-screenshotted all three tabs mid-scroll at mobile width: no bleed; chip/input aligned with rows; To-Do tab not cramped.

`fix:` shipping no new user-facing capability, no new/changed message keys → `[no-feature-entry]`, no i18n/catalog work due.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
