### PR TITLE
fix(onboarding-harness): seed forge repo so gh probe reports error (#860)

### DIFF
--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -36,6 +36,14 @@ export const SCENARIOS: Scenario[] = [
     seed: [
       "type gh >/dev/null 2>&1 || (apt-get update && apt-get install -y gh)",
       "rm -rf ~/.config/gh", // installed but never logged in
+      // Since #819 (lightweight repo mode) the gh probe only surfaces a failure as
+      // `error` when a FORGE-mode repo is configured — with zero repos it downgrades
+      // to `warning` (diagnostics_hint_gh_not_required, gh genuinely optional). A
+      // bare dir under repoRoot ($HOME=/root) is enough: listRepos() enumerates any
+      // non-dot subdir and repoMode defaults to "forge", so anyForgeRepo()→true and
+      // the unauthed gh surfaces as `error`. (The inverse no-forge-repo→warning path
+      // stays covered by test/diagnostics.test.ts, not a harness scenario.)
+      "mkdir -p ~/forge-repo",
     ],
     expect: [{ id: "gh", state: "error" }],
     coaching: "prose",
@@ -45,7 +53,14 @@ export const SCENARIOS: Scenario[] = [
     // gh install is distro-specific AND auth is interactive → detection-only.
     id: "gh-missing",
     image: "images:debian/12",
-    seed: ["apt-get remove -y gh 2>/dev/null || true", "rm -f /usr/bin/gh /usr/local/bin/gh"],
+    seed: [
+      "apt-get remove -y gh 2>/dev/null || true",
+      "rm -f /usr/bin/gh /usr/local/bin/gh",
+      // See gh-unauthed: post-#819 a configured forge repo is required for the gh
+      // probe to report `error` rather than the no-repo `warning`. A bare dir under
+      // repoRoot suffices (repoMode defaults to "forge").
+      "mkdir -p ~/forge-repo",
+    ],
     expect: [{ id: "gh", state: "error" }],
     coaching: "prose",
     detectionOnly: true,

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -7,6 +7,11 @@ import {
 import { DIAGNOSTICS_TTL_MS } from "../src/config";
 import { REMEDIATIONS } from "../src/remediations";
 import type { DiagnosticCheck } from "../src/types";
+import { SessionStore } from "../src/store";
+import { listRepos } from "../src/repos";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // ── injected-runner helpers ────────────────────────────────────────────────────
 // A runner that returns canned `--version` output per binary; throw to simulate a
@@ -620,5 +625,83 @@ describe("defaultRunRemediation (real spawn)", () => {
     // `sleep 30` would outlive the test; the 50ms budget fires the timeout path,
     // SIGKILLs the process group, and rejects — proving the budget is honored.
     await expect(defaultRunRemediation("sleep 30", 50)).rejects.toThrow("remediation timed out");
+  });
+});
+
+// ── gh probe: the REAL anyForgeRepo closure over a real filesystem + store ────
+// Regression guard for the onboarding-harness gh DETECTION GAP (#860): the gh
+// scenarios seed a bare repo dir so anyForgeRepo()→true and the probe surfaces
+// `error` (not the post-#819 no-repo `warning`). The stubbed `anyForgeRepo: () =>
+// true/false` tests above never prove that a bare, never-configured directory
+// actually resolves to forge — this exercises the exact closure src/index.ts wires
+// (listRepos(repoRoot).some(r => store.getRepoConfig(r.path).repoMode === "forge"))
+// against the real listRepos + SessionStore, the mechanism the harness fix relies on.
+describe("DiagnosticsService gh probe — real anyForgeRepo closure (bare repo dir)", () => {
+  // Build the literal index.ts closure over `root`, backed by a fresh in-memory store.
+  function forgeClosure(root: string): () => boolean {
+    const store = new SessionStore(":memory:");
+    return () => listRepos(root).some((r) => store.getRepoConfig(r.path).repoMode === "forge");
+  }
+
+  function withRepoRoot(make: (root: string) => void): string {
+    const root = mkdtempSync(join(tmpdir(), "shep-diag-gh-"));
+    make(root);
+    return root;
+  }
+
+  it("a bare non-git subdir (no DB row) resolves to forge → closure true", () => {
+    const root = withRepoRoot((r) => mkdirSync(join(r, "forge-repo")));
+    expect(forgeClosure(root)()).toBe(true);
+  });
+
+  it("an empty repoRoot resolves to no forge repo → closure false (pre-fix premise)", () => {
+    const root = withRepoRoot(() => {});
+    expect(forgeClosure(root)()).toBe(false);
+  });
+
+  it("gh auth failure + bare forge dir present → error (gh_not_authenticated)", async () => {
+    const root = withRepoRoot((r) => mkdirSync(join(r, "forge-repo")));
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runGhAuth: async () => {
+        throw new Error("not authenticated");
+      },
+      anyForgeRepo: forgeClosure(root),
+    });
+    const c = byId((await svc.check(0)).checks, "gh");
+    expect(c.state).toBe("error");
+    expect(c.hintKey).toBe("diagnostics_hint_gh_not_authenticated");
+    assertPure(c);
+  });
+
+  it("gh ENOENT + bare forge dir present → error (gh_missing)", async () => {
+    const root = withRepoRoot((r) => mkdirSync(join(r, "forge-repo")));
+    const enoent = Object.assign(new Error("gh not found"), { code: "ENOENT" });
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runGhAuth: async () => {
+        throw enoent;
+      },
+      anyForgeRepo: forgeClosure(root),
+    });
+    const c = byId((await svc.check(0)).checks, "gh");
+    expect(c.state).toBe("error");
+    expect(c.hintKey).toBe("diagnostics_hint_gh_missing");
+    assertPure(c);
+  });
+
+  it("non-vacuity: same gh failure with an EMPTY repoRoot → warning (not_required)", async () => {
+    const root = withRepoRoot(() => {}); // no repo → closure false → downgrade
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runGhAuth: async () => {
+        throw new Error("not authenticated");
+      },
+      anyForgeRepo: forgeClosure(root),
+    });
+    const c = byId((await svc.check(0)).checks, "gh");
+    expect(c.state).toBe("warning");
+    expect(c.hintKey).toBe("diagnostics_hint_gh_not_required");
+    assertPure(c);
   });
 });

--- a/test/onboarding-harness/scenarios.test.ts
+++ b/test/onboarding-harness/scenarios.test.ts
@@ -30,4 +30,27 @@ describe("scenario catalog", () => {
       expect(covered.has(id)).toBe(true);
     }
   });
+
+  // Cheap canary (subordinate to the behavioral test in test/diagnostics.test.ts):
+  // since #819 the gh probe only reports `error` when a forge-mode repo is
+  // configured, so any scenario asserting gh:error MUST seed a repo dir under
+  // repoRoot ($HOME) — else the probe downgrades to `warning` and the gap reopens.
+  // This guards against the `mkdir`-seed being silently deleted; it does NOT prove
+  // the mechanism (that is the diagnostics behavioral test).
+  it("every scenario expecting gh:error seeds a repo dir under repoRoot", () => {
+    const ghErrorScenarios = SCENARIOS.filter((s) =>
+      s.expect.some((e) => e.id === "gh" && e.state === "error"),
+    );
+    expect(ghErrorScenarios.length).toBeGreaterThan(0); // catalog still has them
+    for (const s of ghErrorScenarios) {
+      // a `mkdir` of a NON-dot dir directly under the home/repoRoot (~/… or /root/…).
+      // The negative lookahead `(?!\.)` rejects a dot final segment (e.g. ~/.config/gh),
+      // which listRepos() filters out (`!name.startsWith(".")`) — so the guard can't
+      // pass on a seed that creates no enumerable forge repo.
+      const seedsRepoDir = s.seed.some((cmd) =>
+        /mkdir\s+(-p\s+)?(~|\/root)\/(?!\.)[^/\s]+/.test(cmd),
+      );
+      expect(seedsRepoDir).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
Closes #860.

## Problem

The nightly onboarding harness reported a DETECTION GAP for `gh-unauthed` and `gh-missing`: `gh want=error got=warning`.

## Root cause (verified in code, not the report)

PR #819 (lightweight repo mode) changed `ghProbe` in `src/diagnostics.ts`: a gh failure (binary missing **or** `gh auth status` non-zero) now downgrades from `error` → `warning` (`diagnostics_hint_gh_not_required`) when **no forge-mode repo is configured** (`!anyForgeRepo()`). This is intentional and unit-tested (`test/diagnostics.test.ts`) — gh is genuinely optional until you have a forge repo.

The harness boots a throw-away instance with **zero repos** under repoRoot (`$HOME`=`/root`); the seed only extracts Shepherd to `/opt/shepherd`. So `anyForgeRepo()` is always false → gh always `warning`. The two gh scenarios predate #819 and still `expect: error`.

**This is a stale harness scenario, not a product regression.**

## Fix

`listRepos` counts any non-dot subdir of repoRoot as a repo and `repoMode` defaults to `forge`, so seeding a single bare directory under `/root` makes `anyForgeRepo()` true and restores the design-intended `error` detection (gh-unauthed/gh-missing are detection-only **errors**). `expect` is unchanged.

- `ci/onboarding-harness/scenarios.ts` — `mkdir -p ~/forge-repo` added to both gh scenario seeds (+ comments citing #819 and the coverage note).

## Tests

- **Primary, behavioral** (`test/diagnostics.test.ts`) — builds the *exact* `src/index.ts` `anyForgeRepo` closure (`listRepos(root).some(r => store.getRepoConfig(r.path).repoMode === "forge")`) over a **real temp dir + in-memory `SessionStore`**, then drives `DiagnosticsService` with a stubbed failing `runGhAuth` and asserts `gh: error` for both the auth-fail and ENOENT branches. Proves the actual mechanism the fix relies on — a bare non-git dir (no DB row) resolves to `forge`. Non-vacuity confirmed: forcing `anyForgeRepo: () => false` flips the same probe to `warning` (and the gh:error assertions fail).
- **Secondary canary** (`test/onboarding-harness/scenarios.test.ts`) — asserts every scenario expecting `gh: error` seeds a repo dir under repoRoot, guarding against the `mkdir` seed being silently deleted. Explicitly subordinate to the behavioral test.

## Coverage note

After the fix, no harness scenario exercises the #819 no-forge-repo → `gh: warning` downgrade; it stays protected by the existing `test/diagnostics.test.ts` unit tests (cheaper than a new throw-away Incus instance per nightly run). A comment in `scenarios.ts` records this.

## Verification

`bun test ./test/diagnostics.test.ts ./test/onboarding-harness` (117 pass), `bun run lint`, `bunx tsc --noEmit` all green. Full end-to-end (real `gh` removal in a real Incus instance) only confirms on the next **nightly run** — the behavioral test proves the mechanism in-repo, not the live instance path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)