### PR TITLE
feat(herd): ready lens hides tasks waiting on other parties

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1631,5 +1631,7 @@
   "settings_auto_optimize_flagged_label": "Markierte Regeln automatisch optimieren",
   "settings_auto_optimize_flagged_help": "Wenn eine Regel zu scheitern beginnt, wird sie einmalig automatisch neu formuliert, bevor sie für die automatische Deaktivierung infrage kommt.",
   "feat_learnings_auto_retire_title": "Automatische Deaktivierung von Learnings",
-  "feat_learnings_auto_retire_body": "Regeln, die Agenten konsistent nicht helfen, werden jetzt automatisch deaktiviert. Überprüfe sie in der Learnings-Leiste und stelle fälschlicherweise deaktivierte Regeln wieder her."
+  "feat_learnings_auto_retire_body": "Regeln, die Agenten konsistent nicht helfen, werden jetzt automatisch deaktiviert. Überprüfe sie in der Learnings-Leiste und stelle fälschlicherweise deaktivierte Regeln wieder her.",
+  "feat_ready_lens_hides_waiting_title": "Bereit zeigt nur, was an dir liegt",
+  "feat_ready_lens_hides_waiting_body": "Der Bereit-Filter blendet jetzt Sitzungen aus, die auf jemand anderen warten – ein PR, der an einen Reviewer oder Merger übergeben wurde, oder einer, den ein Merge-Train bereits landet. Unter dem Filter Alle bleiben sie sichtbar."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1631,5 +1631,7 @@
   "settings_auto_optimize_flagged_label": "Auto-optimize flagged rules",
   "settings_auto_optimize_flagged_help": "When a rule starts failing, rewrite it once automatically before it becomes eligible for auto-retirement.",
   "feat_learnings_auto_retire_title": "Learnings auto-retirement",
-  "feat_learnings_auto_retire_body": "Rules that consistently fail to help agents are now automatically retired. Review them in the Learnings drawer and restore any that were retired by mistake."
+  "feat_learnings_auto_retire_body": "Rules that consistently fail to help agents are now automatically retired. Review them in the Learnings drawer and restore any that were retired by mistake.",
+  "feat_ready_lens_hides_waiting_title": "Ready shows only your turn",
+  "feat_ready_lens_hides_waiting_body": "The Ready filter now hides sessions that are waiting on someone else — a PR handed off to a reviewer or merger, or one a merge train is already landing. They stay visible under the All filter."
 }

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -168,7 +168,9 @@
   // local all/ready filter ENTIRELY — a "ready" remnant would drop running sessions
   // and empty the list under statusFilter="running" (sessions already arrive filtered).
   const shown = $derived(
-    statusFilter != null ? sessions : shownSessions(sessions, filter, inReview, workingBlocked),
+    statusFilter != null
+      ? sessions
+      : shownSessions(sessions, filter, inReview, workingBlocked, git, nowMs),
   );
   // label for the status chip + filtered empty states (only read when set)
   const statusLabel = $derived(

--- a/ui/src/lib/components/herd-keynav.ts
+++ b/ui/src/lib/components/herd-keynav.ts
@@ -33,7 +33,7 @@ export function railOrder(
   activeEpicKeys: Set<string> = new Set(),
   collapsedKeys: Set<string> = new Set(),
 ): string[] {
-  const shown = shownSessions(sessions, filter, isReviewing, workingBlocked);
+  const shown = shownSessions(sessions, filter, isReviewing, workingBlocked, git, now);
   const grouped = groupSessionsByEpic(shown, epics, activeEpicKeys, git, isReviewing, now);
   const groupIds = grouped.groups.flatMap((g) =>
     collapsedKeys.has(g.key) ? [] : g.sessions.map((s) => s.id),

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -365,3 +365,70 @@ test('"ready" filter drops a working-while-blocked session like a running one', 
   // "all" ignores the flag entirely
   expect(shownSessions(list, "all", () => false, { wb: true })).toHaveLength(4);
 });
+
+// ── "ready" lens hides sessions that aren't the operator's turn ────────────
+// Ready = "awaiting you". A green PR handed off to a foreign reviewer/merger, or
+// one a merge train is already carrying, is NOT your turn → hidden from Ready,
+// still shown in All.
+
+test('"ready" filter hides waitingOnReviewer + waitingOnMerger, keeps awaitingMerge', () => {
+  const list = [
+    session("rev", false, "idle"),
+    session("mrg", false, "idle"),
+    session("mine", false, "idle"),
+  ];
+  const g = {
+    rev: gitHandoff("reviewer", "scoop"),
+    mrg: gitHandoff("merger", "scoop"),
+    mine: git("open", "success"), // no handoff → awaitingMerge → your turn
+  };
+  const shown = shownSessions(list, "ready", () => false, {}, g);
+  expect(shown.map((s) => s.id)).toEqual(["mine"]);
+  // All lens still lists every session regardless of handoff
+  expect(shownSessions(list, "all", () => false, {}, g).map((s) => s.id)).toEqual([
+    "rev",
+    "mrg",
+    "mine",
+  ]);
+});
+
+test('"ready" filter hides a merging session (shared now), keeps awaitingMerge', () => {
+  const now = 1_000_000;
+  const merging = { ...session("trn", false, "idle"), mergingSince: now - 1000 };
+  const list = [merging, session("mine", false, "idle")];
+  const g = { mine: git("open", "success") };
+  // same `now` threaded into shownSessions so isMerging reads the same clock
+  const shown = shownSessions(list, "ready", () => false, {}, g, now);
+  expect(shown.map((s) => s.id)).toEqual(["mine"]);
+  // All lens keeps the merging session
+  expect(shownSessions(list, "all", () => false, {}, g, now).map((s) => s.id)).toEqual([
+    "trn",
+    "mine",
+  ]);
+});
+
+test('"ready" filter keeps your-turn stages: awaitingMerge, parked ready, draft, ciFailed, blocked, idle', () => {
+  const list = [
+    session("am", false, "idle"), // green, no handoff → awaitingMerge
+    session("rdy", true, "idle"), // operator-parked ready (wins over handoff below)
+    session("drf", false, "idle"), // green draft → draftAwaitingSignoff
+    session("cf", false, "idle"), // failed CI → ciFailed
+    session("blk", false, "blocked"), // genuinely blocked
+    session("idl", false, "idle"), // plain idle, no PR
+  ];
+  const g = {
+    am: git("open", "success"),
+    rdy: gitHandoff("merger", "scoop"), // parked ready outranks the merger handoff → kept
+    drf: gitDraft(),
+    cf: git("open", "failure"),
+  };
+  const shown = shownSessions(list, "ready", () => false, {}, g);
+  expect(shown.map((s) => s.id)).toEqual(["am", "rdy", "drf", "cf", "blk", "idl"]);
+});
+
+test('"ready" filter is unchanged with no git/now args (backward compat)', () => {
+  // No handoff git + factory-default mergingSince:null → no session resolves to an
+  // excluded stage, so the legacy 4-arg call behaves exactly as before.
+  const list = [session("a", false, "idle"), session("b", false, "blocked")];
+  expect(shownSessions(list, "ready", () => false).map((s) => s.id)).toEqual(["a", "b"]);
+});

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -58,21 +58,40 @@ type Stage =
  *  no session list) and falls through to the live set for "done" (handled by the page). */
 export type HerdFilter = "all" | "ready" | "research" | "done" | "rundown";
 
+/** Lifecycle stages the "ready" lens hides: the session is NOT awaiting the operator.
+ *  A green PR handed off to a foreign reviewer/merger (`waitingOnReviewer`/`waitingOnMerger`)
+ *  is waiting on someone else, and a PR a launched merge train is carrying (`merging`) is
+ *  in Shepherd's hands — neither is "your turn", so the Ready lens drops them (the All lens
+ *  still shows them). Draft-awaiting-signoff stays: it awaits the operator's own sign-off. */
+const NOT_YOUR_TURN: ReadonlySet<Stage> = new Set([
+  "waitingOnReviewer",
+  "waitingOnMerger",
+  "merging",
+]);
+
 /** The sessions the rail actually lists under `filter` — "ready" keeps only sessions
- *  awaiting the operator (not running, not under review); "research" keeps only sessions
- *  with `s.research` set. Single source of truth shared by Herd.svelte's list and
- *  herd-keynav's rail order, so keyboard navigation can never land on a row the rail
- *  isn't showing. Goes through `displayStatus` (a working-while-blocked session is
- *  actually mid-turn, so it is NOT awaiting the operator). */
+ *  awaiting the operator (not running, not under review, and not handed off to another
+ *  party or mid-merge-train — see NOT_YOUR_TURN); "research" keeps only sessions with
+ *  `s.research` set. Single source of truth shared by Herd.svelte's list and herd-keynav's
+ *  rail order, so keyboard navigation can never land on a row the rail isn't showing. Goes
+ *  through `displayStatus` (a working-while-blocked session is actually mid-turn, so it is
+ *  NOT awaiting the operator). `git`/`now` drive the stage check for the not-your-turn
+ *  exclusion; both default empty/now so legacy 4-arg callers keep today's behavior (no
+ *  handoff git + `mergingSince: null` → no session resolves to an excluded stage). */
 export function shownSessions(
   sessions: Session[],
   filter: HerdFilter,
   inReview: (id: string) => boolean,
   workingBlocked: Record<string, boolean> = {},
+  git: Record<string, GitState> = {},
+  now: number = Date.now(),
 ): Session[] {
   if (filter === "ready")
     return sessions.filter(
-      (s) => displayStatus(s, workingBlocked) !== "running" && !inReview(s.id),
+      (s) =>
+        displayStatus(s, workingBlocked) !== "running" &&
+        !inReview(s.id) &&
+        !NOT_YOUR_TURN.has(stageOf(s, git[s.id], inReview, now)),
     );
   if (filter === "research") return sessions.filter((s) => s.research);
   // Rundown is a panel-only lens (the digest, no session list) — show no rows.

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1217,4 +1217,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_learnings_auto_retire_title",
     bodyKey: "feat_learnings_auto_retire_body",
   },
+  {
+    // Ready lens now hides sessions that aren't the operator's turn (handed off to a
+    // foreign reviewer/merger, or mid-merge-train). The filter tab is always mounted,
+    // but the change is behavioral rather than a new control → What's-New drawer only.
+    id: "ready-lens-hides-waiting",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_ready_lens_hides_waiting_title",
+    bodyKey: "feat_ready_lens_hides_waiting_body",
+  },
 ];


### PR DESCRIPTION
## Why

The Herd **Ready** filter promises "sessions awaiting **you** (the operator)", but it still listed:
- green PRs handed off to a foreign reviewer/merger (`waitingOnReviewer` / `waitingOnMerger` — the *WAITING ON …* group in the screenshot), and
- PRs a launched merge train is already carrying (`merging`).

None of those are your turn. This tightens the Ready lens to drop them. They remain fully visible under the **All** filter.

## What

- `shownSessions(…, "ready", …)` in `ui/src/lib/components/herd-partition.ts` — the single source of truth shared by the rendered list **and** `herd-keynav`'s rail order — now also excludes any session whose computed `stageOf(...)` is in a new `NOT_YOUR_TURN` set (`waitingOnReviewer`, `waitingOnMerger`, `merging`).
- `draftAwaitingSignoff` **stays** in Ready — it awaits the operator's own sign-off, not another party.
- `shownSessions` gains optional, defaulted `git` / `now` params (both already in scope at the two call sites: `Herd.svelte` and `herd-keynav.ts`), so legacy callers are unchanged.

### Scope note
Hiding `merging` goes slightly beyond the literal "waiting on **other parties**" wording (a merge train is Shepherd's own automation). It was an explicit operator choice on the principle that Ready = awaiting *you*; a train-carried PR isn't your turn either.

### Side effect (analyzed, accepted)
`readyPrCount = collectReadyPrs(shown, …)` (Herd.svelte:198) now drops `merging` sessions from the merge-train link count **in the Ready lens only**. Accepted, not widened: the count was already lens-scoped (the ready filter already dropped running/in-review), the launch action runs over the full `store.sessions` so the actual train is unaffected, and a merging PR is already in a train (not a fresh-launch target). Every other `shown` consumer (epic groups, `readyAbove`/`mergedAbove`/`mergedCount`, empty-state) verified unaffected — they count only `ready`/`merged`, never an excluded stage.

## Tests
TDD: added 4 cases to `herd-partition.test.ts` asserting the Ready lens hides `waitingOnReviewer`/`waitingOnMerger`/`merging` and keeps `awaitingMerge`/parked `ready`/draft/`ciFailed`/blocked/idle, plus an All-lens and a backward-compat (no git/now) guard. The merging test threads one shared `now` into both `mergingSince` and `shownSessions` so `isMerging` reads the same clock. The two key cases fail on pre-change code.

- `cd ui && bun run check` — 0 errors
- `cd ui && bun run test` — 124 files / 1737 tests green
- `check:i18n` parity + feature-catalog gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)