### PR TITLE
feat(backlog): standalone Fast-forward action for selected repo (#861)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1638,5 +1638,9 @@
   "issues_filter_active_title": "Issues ausblenden, die bereits bearbeitet werden (shepherd:active)",
   "issues_filter_all_in_progress": "Alle passenden Issues werden bearbeitet — zum Anzeigen ausschalten",
   "feat_issues_filter_active_title": "In Arbeit befindliche Issues ausblenden",
-  "feat_issues_filter_active_body": "Die Issue-Listen im Backlog und in „Neue Aufgabe“ bieten jetzt einen Filter „in Arbeit ausblenden“, der bereits von einer laufenden Sitzung beanspruchte Issues (Label shepherd:active) ausblendet. Standardmäßig aus; die Einstellung gilt für beide Listen."
+  "feat_issues_filter_active_body": "Die Issue-Listen im Backlog und in „Neue Aufgabe“ bieten jetzt einen Filter „in Arbeit ausblenden“, der bereits von einer laufenden Sitzung beanspruchte Issues (Label shepherd:active) ausblendet. Standardmäßig aus; die Einstellung gilt für beide Listen.",
+  "backlog_ff_main": "Vorspulen",
+  "backlog_ff_main_title": "Lokalen Standard-Branch vorspulen",
+  "feat_ff_main_title": "Vorspulen auf Knopfdruck",
+  "feat_ff_main_body": "Den lokalen Standard-Branch eines Repos jederzeit aus dem Backlog auf origin vorspulen – kein PR-Merge erforderlich."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1638,5 +1638,9 @@
   "issues_filter_active_title": "Hide issues already being worked on (shepherd:active)",
   "issues_filter_all_in_progress": "All matching issues are in progress — toggle off to see them",
   "feat_issues_filter_active_title": "Hide in-progress issues",
-  "feat_issues_filter_active_body": "The Backlog and New Task issue lists now offer a \"hide in progress\" filter that hides issues already claimed by a running session (labeled shepherd:active). Off by default; the setting is remembered across both lists."
+  "feat_issues_filter_active_body": "The Backlog and New Task issue lists now offer a \"hide in progress\" filter that hides issues already claimed by a running session (labeled shepherd:active). Off by default; the setting is remembered across both lists.",
+  "backlog_ff_main": "Fast-forward",
+  "backlog_ff_main_title": "Fast-forward local default branch",
+  "feat_ff_main_title": "Fast-forward on demand",
+  "feat_ff_main_body": "Fast-forward a repo's local default branch to origin any time from the Backlog — no PR merge required."
 }

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -252,7 +252,7 @@
             <button
               class="gbtn ff-btn"
               type="button"
-              disabled={ffInFlight}
+              disabled={ffInFlight || selectedPath === null}
               onclick={handleFf}
               title={m.backlog_ff_main_title()}
               aria-label={m.backlog_ff_main_title()}
@@ -563,6 +563,11 @@
     align-items: center;
     gap: 4px;
     flex-shrink: 0;
+    white-space: nowrap;
+  }
+  .ff-btn:focus-visible {
+    outline: 2px solid var(--color-line-bright);
+    outline-offset: 2px;
   }
 
   /* ── desktop split layout ── */

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -10,6 +10,7 @@
   import AutomationSettings from "./AutomationSettings.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import { actionsTabState, filterProjects } from "./backlog-view";
+  import { pullMainAndToast } from "$lib/pull-offer";
 
   let {
     payload,
@@ -55,6 +56,17 @@
 
   type Tab = "issues" | "prs" | "actions" | "readiness" | "automation";
   let activeTab = $state<Tab>("issues");
+  let ffInFlight = $state(false);
+
+  async function handleFf() {
+    if (!selectedPath || ffInFlight) return;
+    ffInFlight = true;
+    try {
+      await pullMainAndToast(selectedPath);
+    } finally {
+      ffInFlight = false;
+    }
+  }
 
   // selectedPath: initialized from pinnedPath once payload arrives;
   // user selection is not clobbered (only set when currently null).
@@ -237,6 +249,20 @@
             >
               {m.backlog_tab_automation()}
             </button>
+            <button
+              class="gbtn ff-btn"
+              type="button"
+              disabled={ffInFlight}
+              onclick={handleFf}
+              title={m.backlog_ff_main_title()}
+              aria-label={m.backlog_ff_main_title()}
+            >
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                <path d="M1 2.5L5.5 6 1 9.5V2.5Z" fill="currentColor" />
+                <path d="M6.5 2.5L11 6 6.5 9.5V2.5Z" fill="currentColor" />
+              </svg>
+              {m.backlog_ff_main()}
+            </button>
           </div>
         </div>
         <div class="overlay-body">
@@ -353,6 +379,21 @@
             use:coachTarget={"backlog-automation"}
           >
             {m.backlog_tab_automation()}
+          </button>
+          <button
+            class="gbtn ff-btn"
+            type="button"
+            disabled={ffInFlight || selectedPath === null}
+            onclick={handleFf}
+            title={m.backlog_ff_main_title()}
+            aria-label={m.backlog_ff_main_title()}
+            use:coachTarget={"backlog-ff-main"}
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path d="M1 2.5L5.5 6 1 9.5V2.5Z" fill="currentColor" />
+              <path d="M6.5 2.5L11 6 6.5 9.5V2.5Z" fill="currentColor" />
+            </svg>
+            {m.backlog_ff_main()}
           </button>
         </div>
         <div class="detail-pane">
@@ -490,6 +531,38 @@
     color: var(--color-red);
     border-color: var(--color-red);
     background: var(--color-inset);
+  }
+
+  /* ── fast-forward button ── */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .ff-btn {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
   }
 
   /* ── desktop split layout ── */

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -552,6 +552,11 @@
     border-color: var(--color-amber);
     color: var(--color-amber);
   }
+  /* keyboard focus — flat inset amber ring (never an outer glow), per design-system */
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
   .gbtn:disabled {
     opacity: 0.4;
     cursor: not-allowed;
@@ -564,10 +569,6 @@
     gap: 4px;
     flex-shrink: 0;
     white-space: nowrap;
-  }
-  .ff-btn:focus-visible {
-    outline: 2px solid var(--color-line-bright);
-    outline-offset: 2px;
   }
 
   /* ── desktop split layout ── */

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1235,4 +1235,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_issues_filter_active_body",
     targetId: "issues-filter-active",
   },
+  {
+    // targetId "backlog-ff-main" anchors the coachmark on the Fast-forward button
+    // at the right end of the Backlog detail tab bar. v1.34.0 is the latest released
+    // tag → ships in 1.35.0.
+    id: "ff-main-standalone",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_ff_main_title",
+    bodyKey: "feat_ff_main_body",
+    targetId: "backlog-ff-main",
+  },
 ];

--- a/ui/src/lib/pull-offer.test.ts
+++ b/ui/src/lib/pull-offer.test.ts
@@ -62,6 +62,8 @@ test("pullMainAndToast: ok+updated → info toast with done key text", async () 
   vi.mocked(pullRepo).mockResolvedValue({ ok: true, branch: "main", updated: true, sha: "x" });
   await pullMainAndToast("/repo/a");
   expect(toasts.items).toHaveLength(1);
+  // "Updated local main to latest" — distinct from uptodate ("already up to date")
+  expect(toasts.items[0].text).toContain("to latest");
   // toast should auto-dismiss (finite duration) — advance past default 4s
   await vi.advanceTimersByTimeAsync(4_100);
   expect(toasts.items).toHaveLength(0);
@@ -71,6 +73,8 @@ test("pullMainAndToast: ok+not-updated → info toast that auto-dismisses", asyn
   vi.mocked(pullRepo).mockResolvedValue({ ok: true, branch: "main", updated: false, sha: "x" });
   await pullMainAndToast("/repo/a");
   expect(toasts.items).toHaveLength(1);
+  // "Local main already up to date" — distinct from updated ("to latest")
+  expect(toasts.items[0].text).toContain("already up to date");
   await vi.advanceTimersByTimeAsync(4_100);
   expect(toasts.items).toHaveLength(0);
 });
@@ -79,6 +83,8 @@ test("pullMainAndToast: wrong_branch → benign info that auto-dismisses", async
   vi.mocked(pullRepo).mockResolvedValue({ ok: false, reason: "wrong_branch", branch: "main" });
   await pullMainAndToast("/repo/a");
   expect(toasts.items).toHaveLength(1);
+  // "Local checkout isn't on main; left it untouched"
+  expect(toasts.items[0].text).toContain("isn't on");
   await vi.advanceTimersByTimeAsync(4_100);
   expect(toasts.items).toHaveLength(0);
 });
@@ -87,6 +93,8 @@ test("pullMainAndToast: dirty → benign info that auto-dismisses", async () => 
   vi.mocked(pullRepo).mockResolvedValue({ ok: false, reason: "dirty", branch: "main" });
   await pullMainAndToast("/repo/a");
   expect(toasts.items).toHaveLength(1);
+  // "Local main has uncommitted changes; left it untouched"
+  expect(toasts.items[0].text).toContain("uncommitted changes");
   await vi.advanceTimersByTimeAsync(4_100);
   expect(toasts.items).toHaveLength(0);
 });
@@ -95,6 +103,8 @@ test("pullMainAndToast: diverged → benign info that auto-dismisses", async () 
   vi.mocked(pullRepo).mockResolvedValue({ ok: false, reason: "diverged", branch: "main" });
   await pullMainAndToast("/repo/a");
   expect(toasts.items).toHaveLength(1);
+  // "Local main has diverged; pull manually"
+  expect(toasts.items[0].text).toContain("diverged");
   await vi.advanceTimersByTimeAsync(4_100);
   expect(toasts.items).toHaveLength(0);
 });

--- a/ui/src/lib/pull-offer.test.ts
+++ b/ui/src/lib/pull-offer.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
 import { toasts } from "./toasts.svelte";
-import { offerUpdateMain } from "./pull-offer";
+import { offerUpdateMain, pullMainAndToast } from "./pull-offer";
 import { pullRepo } from "$lib/api";
 
 vi.mock("$lib/api", () => ({ pullRepo: vi.fn() }));
@@ -54,4 +54,57 @@ test("failure toast from the offer's action stays persistent", async () => {
 
   await vi.advanceTimersByTimeAsync(120_000); // far past 15s
   expect(toasts.items).toHaveLength(1); // duration null: must not vanish
+});
+
+// ── pullMainAndToast PullResult → toast mapping ──────────────────────────────
+
+test("pullMainAndToast: ok+updated → info toast with done key text", async () => {
+  vi.mocked(pullRepo).mockResolvedValue({ ok: true, branch: "main", updated: true, sha: "x" });
+  await pullMainAndToast("/repo/a");
+  expect(toasts.items).toHaveLength(1);
+  // toast should auto-dismiss (finite duration) — advance past default 4s
+  await vi.advanceTimersByTimeAsync(4_100);
+  expect(toasts.items).toHaveLength(0);
+});
+
+test("pullMainAndToast: ok+not-updated → info toast that auto-dismisses", async () => {
+  vi.mocked(pullRepo).mockResolvedValue({ ok: true, branch: "main", updated: false, sha: "x" });
+  await pullMainAndToast("/repo/a");
+  expect(toasts.items).toHaveLength(1);
+  await vi.advanceTimersByTimeAsync(4_100);
+  expect(toasts.items).toHaveLength(0);
+});
+
+test("pullMainAndToast: wrong_branch → benign info that auto-dismisses", async () => {
+  vi.mocked(pullRepo).mockResolvedValue({ ok: false, reason: "wrong_branch", branch: "main" });
+  await pullMainAndToast("/repo/a");
+  expect(toasts.items).toHaveLength(1);
+  await vi.advanceTimersByTimeAsync(4_100);
+  expect(toasts.items).toHaveLength(0);
+});
+
+test("pullMainAndToast: dirty → benign info that auto-dismisses", async () => {
+  vi.mocked(pullRepo).mockResolvedValue({ ok: false, reason: "dirty", branch: "main" });
+  await pullMainAndToast("/repo/a");
+  expect(toasts.items).toHaveLength(1);
+  await vi.advanceTimersByTimeAsync(4_100);
+  expect(toasts.items).toHaveLength(0);
+});
+
+test("pullMainAndToast: diverged → benign info that auto-dismisses", async () => {
+  vi.mocked(pullRepo).mockResolvedValue({ ok: false, reason: "diverged", branch: "main" });
+  await pullMainAndToast("/repo/a");
+  expect(toasts.items).toHaveLength(1);
+  await vi.advanceTimersByTimeAsync(4_100);
+  expect(toasts.items).toHaveLength(0);
+});
+
+test("pullMainAndToast: error → persistent alert toast keyed to repo", async () => {
+  vi.mocked(pullRepo).mockResolvedValue({ ok: false, reason: "error" });
+  await pullMainAndToast("/repo/a");
+  expect(toasts.items).toHaveLength(1);
+  expect(toasts.items.find((t) => t.key === "update-main:/repo/a")).toBeDefined();
+  // Persistent: must survive far past any finite default duration
+  await vi.advanceTimersByTimeAsync(120_000);
+  expect(toasts.items).toHaveLength(1);
 });

--- a/ui/src/lib/pull-offer.ts
+++ b/ui/src/lib/pull-offer.ts
@@ -2,48 +2,51 @@ import { pullRepo } from "$lib/api";
 import { toasts } from "$lib/toasts.svelte";
 import { m } from "$lib/paraglide/messages";
 
+/** Execute a fast-forward pull of `repoPath`'s default branch and queue the
+ *  appropriate outcome toast. The `branch` hint is optional — when omitted the
+ *  server resolves the repo's default branch. */
+export async function pullMainAndToast(repoPath: string, branch?: string): Promise<void> {
+  const r = await pullRepo(repoPath, branch);
+  if (r.ok) {
+    toasts.info(
+      r.updated
+        ? m.toast_update_main_done({ branch: r.branch })
+        : m.toast_update_main_uptodate({ branch: r.branch }),
+    );
+    return;
+  }
+  const b = r.branch ?? "";
+  switch (r.reason) {
+    // Benign non-fast-forwardable local states: the checkout simply isn't updatable
+    // right now. Plain transient info, not a failure.
+    case "wrong_branch":
+      toasts.info(m.toast_update_main_wrong_branch({ branch: b }));
+      return;
+    case "dirty":
+      toasts.info(m.toast_update_main_dirty({ branch: b }));
+      return;
+    case "diverged":
+      toasts.info(m.toast_update_main_diverged({ branch: b }));
+      return;
+    // Genuine unexpected git/network failure: persistent + assertive.
+    case "error":
+      toasts.info(m.toast_update_main_failed(), {
+        duration: null,
+        alert: true,
+        key: `update-main:${repoPath}`,
+      });
+      return;
+  }
+}
+
 /** After a PR merge, offer a one-click fast-forward of the repo's local default-branch
  *  checkout. Auto-dismisses after 15s (paused while hovered/focused) and per-repo
  *  deduped so repeated merges to one repo re-arm a single offer. */
 export function offerUpdateMain(repoPath: string, branch?: string): void {
   if (!repoPath) return;
 
-  async function run(): Promise<void> {
-    const r = await pullRepo(repoPath, branch);
-    if (r.ok) {
-      toasts.info(
-        r.updated
-          ? m.toast_update_main_done({ branch: r.branch })
-          : m.toast_update_main_uptodate({ branch: r.branch }),
-      );
-      return;
-    }
-    const b = r.branch ?? "";
-    switch (r.reason) {
-      // Benign non-fast-forwardable local states: the checkout simply isn't updatable
-      // right now. Plain transient info, not a failure.
-      case "wrong_branch":
-        toasts.info(m.toast_update_main_wrong_branch({ branch: b }));
-        return;
-      case "dirty":
-        toasts.info(m.toast_update_main_dirty({ branch: b }));
-        return;
-      case "diverged":
-        toasts.info(m.toast_update_main_diverged({ branch: b }));
-        return;
-      // Genuine unexpected git/network failure: persistent + assertive.
-      case "error":
-        toasts.info(m.toast_update_main_failed(), {
-          duration: null,
-          alert: true,
-          key: `update-main:${repoPath}`,
-        });
-        return;
-    }
-  }
-
   toasts.info(m.toast_update_main_offer(), {
-    action: { label: m.toast_update_main_action(), run: () => run() },
+    action: { label: m.toast_update_main_action(), run: () => pullMainAndToast(repoPath, branch) },
     duration: 15_000,
     key: `update-main-offer:${repoPath}`,
   });


### PR DESCRIPTION
## Summary

Adds an **always-available "Fast-forward" button** for the selected managed repo in the Backlog detail pane, decoupled from any PR-merge event. Previously the local default-branch fast-forward was only reachable as a transient toast offer fired by merge events (`offerUpdateMain`); when `origin` advanced for any other reason there was no in-app way to pull it into the local checkout. Closes #861.

This is **UI-only** — the backend operation already existed end-to-end with the desired strict **FF-only**, fail-closed semantics (`fastForwardDefaultBranch` → `POST /api/repos/pull` → `pullRepo`). No new endpoint, DB field, or service.

## Changes

- **`ui/src/lib/pull-offer.ts`** — extracted the `pullRepo(...)` call + per-`PullResult` toast mapping out of `offerUpdateMain`'s action into an exported `pullMainAndToast(repoPath, branch?)`. `offerUpdateMain` now delegates to it, so the merge offer and the new button share one code path and the existing `toast_update_main_*` keys. Pure refactor — no behavior change.
- **`ui/src/lib/components/BacklogView.svelte`** — new icon + text "Fast-forward" button at the right end of the detail tab bar (desktop `.tab-bar` and mobile `.overlay-tabs`). Calls `pullMainAndToast(selectedPath)` with **no branch hint** so the server resolves the real default branch. Disabled while a fast-forward is in flight or when no repo is selected (`ffInFlight` + `selectedPath` guard, reset in `finally`).
- **i18n** — `backlog_ff_main`, `backlog_ff_main_title`, `feat_ff_main_title`, `feat_ff_main_body` added to both `en.json` and `de.json`.
- **Feature discovery** — one `ff-main-standalone` `FeatureAnnouncement` (`sinceVersion: 1.35.0`) + `use:coachTarget={"backlog-ff-main"}` anchor.
- **Tests** — `pullMainAndToast` mapping tests in `pull-offer.test.ts` assert the specific toast per `PullResult` (done / up-to-date / wrong_branch / dirty / diverged, and the persistent keyed `error` alert). Existing `offerUpdateMain` tests unchanged.

## Design notes

- **Branch-agnostic by design.** The default branch is resolved server-side (`resolveDefaultBranch`: hint → `origin/HEAD` → forge) and can be `master`/`develop`/etc. The button sends no hint and its label never hardcodes "main"; outcome toasts interpolate the real `{branch}`.
- Considered + ruled out a behind/ahead indicator endpoint — determining "behind" needs a network fetch anyway, so the button just runs the FF and reports `updated:false` when already current. Zero new state.

## Verification

- `cd ui && bun run check` — 0 errors, 0 warnings
- `cd ui && bun run check:i18n` — EN/DE parity (1636 keys)
- `cd ui && bun run test` — 1741 passed
- `scripts/check-feature-catalog.sh` — ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)