### PR TITLE
feat(ui): add "hide in progress" issue filter (shepherd:active)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1633,5 +1633,10 @@
   "feat_learnings_auto_retire_title": "Automatische Deaktivierung von Learnings",
   "feat_learnings_auto_retire_body": "Regeln, die Agenten konsistent nicht helfen, werden jetzt automatisch deaktiviert. Überprüfe sie in der Learnings-Leiste und stelle fälschlicherweise deaktivierte Regeln wieder her.",
   "feat_ready_lens_hides_waiting_title": "Bereit zeigt nur, was an dir liegt",
-  "feat_ready_lens_hides_waiting_body": "Der Bereit-Filter blendet jetzt Sitzungen aus, die auf jemand anderen warten – ein PR, der an einen Reviewer oder Merger übergeben wurde, oder einer, den ein Merge-Train bereits landet. Unter dem Filter Alle bleiben sie sichtbar."
+  "feat_ready_lens_hides_waiting_body": "Der Bereit-Filter blendet jetzt Sitzungen aus, die auf jemand anderen warten – ein PR, der an einen Reviewer oder Merger übergeben wurde, oder einer, den ein Merge-Train bereits landet. Unter dem Filter Alle bleiben sie sichtbar.",
+  "issues_filter_active_label": "in Arbeit ausblenden",
+  "issues_filter_active_title": "Issues ausblenden, die bereits bearbeitet werden (shepherd:active)",
+  "issues_filter_all_in_progress": "Alle passenden Issues werden bearbeitet — zum Anzeigen ausschalten",
+  "feat_issues_filter_active_title": "In Arbeit befindliche Issues ausblenden",
+  "feat_issues_filter_active_body": "Die Issue-Listen im Backlog und in „Neue Aufgabe“ bieten jetzt einen Filter „in Arbeit ausblenden“, der bereits von einer laufenden Sitzung beanspruchte Issues (Label shepherd:active) ausblendet. Standardmäßig aus; die Einstellung gilt für beide Listen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1633,5 +1633,10 @@
   "feat_learnings_auto_retire_title": "Learnings auto-retirement",
   "feat_learnings_auto_retire_body": "Rules that consistently fail to help agents are now automatically retired. Review them in the Learnings drawer and restore any that were retired by mistake.",
   "feat_ready_lens_hides_waiting_title": "Ready shows only your turn",
-  "feat_ready_lens_hides_waiting_body": "The Ready filter now hides sessions that are waiting on someone else — a PR handed off to a reviewer or merger, or one a merge train is already landing. They stay visible under the All filter."
+  "feat_ready_lens_hides_waiting_body": "The Ready filter now hides sessions that are waiting on someone else — a PR handed off to a reviewer or merger, or one a merge train is already landing. They stay visible under the All filter.",
+  "issues_filter_active_label": "hide in progress",
+  "issues_filter_active_title": "Hide issues already being worked on (shepherd:active)",
+  "issues_filter_all_in_progress": "All matching issues are in progress — toggle off to see them",
+  "feat_issues_filter_active_title": "Hide in-progress issues",
+  "feat_issues_filter_active_body": "The Backlog and New Task issue lists now offer a \"hide in progress\" filter that hides issues already claimed by a running session (labeled shepherd:active). Off by default; the setting is remembered across both lists."
 }

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -308,9 +308,24 @@ describe("IssuesPanel expandEpic", () => {
 
 describe("IssuesPanel mine & unassigned filter (#824)", () => {
   // The toggle store is a localStorage-backed singleton shared across tests;
-  // reset it to the default (on) before each case so order can't leak state.
-  beforeEach(() => issuesFilter.set(true));
-  afterEach(() => issuesFilter.set(true));
+  // reset it to the defaults (hideOthers on, hideActive off) before each case so
+  // order can't leak state.
+  beforeEach(() => {
+    issuesFilter.set(true);
+    issuesFilter.setActive(false);
+  });
+  afterEach(() => {
+    issuesFilter.set(true);
+    issuesFilter.setActive(false);
+  });
+
+  // Resolve a filter chip by its label text — the bar can hold two chips.
+  const chipByLabel = (label: string) =>
+    [...document.querySelectorAll(".filter-chip")].find(
+      (el) => el.textContent?.trim() === label,
+    ) as HTMLButtonElement | undefined;
+  const mineChip = () => chipByLabel(m.issues_filter_mine_label());
+  const activeChip = () => chipByLabel(m.issues_filter_active_label());
 
   function withAssignees(number: number, title: string, assignees: string[]): Issue {
     return {
@@ -345,7 +360,7 @@ describe("IssuesPanel mine & unassigned filter (#824)", () => {
     seedMixed("octocat");
     render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
 
-    await expect.poll(() => document.querySelector(".filter-chip")).toBeTruthy();
+    await expect.poll(() => mineChip()).toBeTruthy();
     await expect.poll(() => document.querySelectorAll(".issue-title").length).toBe(2);
     expect(titles()).toEqual(["Unassigned issue", "Mine issue"]);
     expect(titles()).not.toContain("Theirs issue");
@@ -355,20 +370,48 @@ describe("IssuesPanel mine & unassigned filter (#824)", () => {
     seedMixed("octocat");
     render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
 
-    await expect.poll(() => document.querySelector(".filter-chip")).toBeTruthy();
+    await expect.poll(() => mineChip()).toBeTruthy();
     await expect.poll(() => document.querySelectorAll(".issue-title").length).toBe(2);
 
-    (document.querySelector(".filter-chip") as HTMLButtonElement).click();
+    mineChip()!.click();
 
     await expect.poll(() => document.querySelectorAll(".issue-title").length).toBe(3);
     expect(titles()).toContain("Theirs issue");
   });
 
-  it("hides the chip and shows all issues when the viewer is unknown (fail open)", async () => {
+  it("hides the mine chip but keeps the hide-in-progress chip when viewer is unknown (fail open)", async () => {
     seedMixed(null);
     render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
 
+    // mine filter fails open (viewer unknown) → all 3 show; its chip is gone, but
+    // the viewer-agnostic hide-in-progress chip still renders.
     await expect.poll(() => document.querySelectorAll(".issue-title").length).toBe(3);
-    expect(document.querySelector(".filter-chip")).toBeNull();
+    expect(mineChip()).toBeUndefined();
+    expect(activeChip()).toBeTruthy();
+  });
+
+  it("hide-in-progress chip drops shepherd:active issues and restores them when toggled off", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      viewer: null,
+      issues: [
+        { ...withAssignees(1, "Plain issue", []), labels: [] },
+        { ...withAssignees(2, "Claimed issue", []), labels: ["shepherd:active"] },
+      ],
+    });
+    mockGetEpics.mockResolvedValue([]);
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    // Off by default → both visible.
+    await expect.poll(() => document.querySelectorAll(".issue-title").length).toBe(2);
+
+    activeChip()!.click();
+    await expect.poll(() => document.querySelectorAll(".issue-title").length).toBe(1);
+    expect(titles()).toEqual(["Plain issue"]);
+
+    activeChip()!.click();
+    await expect.poll(() => document.querySelectorAll(".issue-title").length).toBe(2);
+    expect(titles()).toContain("Claimed issue");
   });
 });

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -6,7 +6,7 @@
   import { m } from "$lib/paraglide/messages";
   import { relativeAge } from "$lib/format";
   import { clock } from "$lib/now.svelte";
-  import { filterIssues, hideOthers } from "./issues-panel";
+  import { filterIssues, hideOthers, hideActive, ACTIVE_LABEL } from "./issues-panel";
   import { issuesFilter } from "$lib/issues-filter.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import EpicPanel from "./EpicPanel.svelte";
@@ -14,10 +14,9 @@
   import { SvelteSet, SvelteMap } from "svelte/reactivity";
   import { tick } from "svelte";
 
-  // Mirrors ACTIVE_LABEL in src/drain-core.ts — the label the drain stamps on an
+  // ACTIVE_LABEL (imported from ./issues-panel) is the label the drain stamps on an
   // issue it has claimed (auto session or human-linked task). Highlighted so a
   // claimed issue reads as "already taken" at a glance in the backlog.
-  const ACTIVE_LABEL = "shepherd:active";
 
   let {
     repoPath,
@@ -52,14 +51,23 @@
   let viewer = $state<string | null>(null);
   let loading = $state(true);
   let filter = $state("");
-  // Compose the assignee filter (#824) with the text filter. The chip only shows
-  // when `viewer` is known, so hideOthers is a no-op identity otherwise (fail open).
+  // Compose the assignee filter (#824) → "hide in progress" filter → text filter.
+  // The mine chip only shows when `viewer` is known, so hideOthers is a no-op
+  // identity otherwise (fail open); hideActive is viewer-agnostic.
   let assigneeFiltered = $derived(hideOthers(issues, viewer, issuesFilter.hideOthers));
-  let visibleIssues = $derived(filterIssues(assigneeFiltered, filter));
+  let activeFiltered = $derived(hideActive(assigneeFiltered, issuesFilter.hideActive));
+  let visibleIssues = $derived(filterIssues(activeFiltered, filter));
   // True when there ARE open issues but the assignee filter hid them all — drives
   // the distinct "all assigned to others" empty state (vs the text no-match state).
   let allHiddenByAssignee = $derived(
     issues.length > 0 && assigneeFiltered.length === 0 && viewer != null && issuesFilter.hideOthers,
+  );
+  // The active filter emptied the remainder the assignee filter left behind.
+  let allHiddenByActive = $derived(
+    !allHiddenByAssignee &&
+      assigneeFiltered.length > 0 &&
+      activeFiltered.length === 0 &&
+      issuesFilter.hideActive,
   );
 
   // Epic summaries for this repo: number → EpicSummary.
@@ -186,9 +194,22 @@
             {m.issues_filter_mine_label()}
           </button>
         {/if}
+        <button
+          class="filter-chip"
+          class:active={issuesFilter.hideActive}
+          type="button"
+          aria-pressed={issuesFilter.hideActive}
+          title={m.issues_filter_active_title()}
+          onclick={() => issuesFilter.toggleActive()}
+          use:coachTarget={"issues-filter-active"}
+        >
+          {m.issues_filter_active_label()}
+        </button>
       </div>
       {#if allHiddenByAssignee}
         <div class="muted">{m.issues_filter_all_assigned_to_others()}</div>
+      {:else if allHiddenByActive}
+        <div class="muted">{m.issues_filter_all_in_progress()}</div>
       {:else if visibleIssues.length === 0}
         <div class="muted">{m.issuespanel_no_match()}</div>
       {/if}

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -3,7 +3,7 @@
   import { getTodo, listIssues, getCommands } from "$lib/api";
   import type { Issue, SlashCommand } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { hideOthers } from "./issues-panel";
+  import { hideOthers, hideActive, ACTIVE_LABEL } from "./issues-panel";
   import { issuesFilter } from "$lib/issues-filter.svelte";
 
   let {
@@ -28,10 +28,21 @@
   let viewer = $state<string | null>(null);
   let loading = $state(false);
   // "Mine & unassigned" filter (#824), shared with IssuesPanel via issuesFilter.
-  // No-op identity when the chip is hidden (viewer unknown) → fail open.
-  let visibleIssues = $derived(hideOthers(issues, viewer, issuesFilter.hideOthers));
+  // No-op identity when the chip is hidden (viewer unknown) → fail open. Composed
+  // with the viewer-agnostic "hide in progress" filter; the explicit
+  // assigneeFiltered intermediate lets each empty state be attributed to the
+  // filter that caused it.
+  let assigneeFiltered = $derived(hideOthers(issues, viewer, issuesFilter.hideOthers));
+  let visibleIssues = $derived(hideActive(assigneeFiltered, issuesFilter.hideActive));
   let allHiddenByAssignee = $derived(
-    issues.length > 0 && visibleIssues.length === 0 && viewer != null && issuesFilter.hideOthers,
+    issues.length > 0 && assigneeFiltered.length === 0 && viewer != null && issuesFilter.hideOthers,
+  );
+  // The active filter emptied the remainder the assignee filter left behind.
+  let allHiddenByActive = $derived(
+    !allHiddenByAssignee &&
+      assigneeFiltered.length > 0 &&
+      visibleIssues.length === 0 &&
+      issuesFilter.hideActive,
   );
   let filter = $state("");
   let filterInput = $state<HTMLInputElement>();
@@ -40,11 +51,8 @@
 
   const OPEN_RE = /^\s*-\s\[ \]\s+(.*)$/;
 
-  // Label the drain stamps on a claimed issue (mirrors ACTIVE_LABEL in
-  // src/drain-core.ts and IssuesPanel.svelte). Surfaced first + highlighted so a
-  // taken issue reads as already-being-worked-on, same as the Issues panel.
-  const ACTIVE_LABEL = "shepherd:active";
-
+  // ACTIVE_LABEL (imported from ./issues-panel) is surfaced first + highlighted so
+  // a taken issue reads as already-being-worked-on, same as the Issues panel.
   // Active-first ordering so the claimed marker survives the 3-chip cap below.
   const orderedLabels = (labels: string[]): string[] =>
     labels.includes(ACTIVE_LABEL)
@@ -215,8 +223,8 @@
       {:else if issues.length === 0}
         <div class="muted">{m.common_no_open_issues()}</div>
       {:else}
-        {#if viewer != null}
-          <div class="ps-filter-bar">
+        <div class="ps-filter-bar">
+          {#if viewer != null}
             <button
               class="filter-chip"
               class:active={issuesFilter.hideOthers}
@@ -227,10 +235,22 @@
             >
               {m.issues_filter_mine_label()}
             </button>
-          </div>
-        {/if}
+          {/if}
+          <button
+            class="filter-chip"
+            class:active={issuesFilter.hideActive}
+            type="button"
+            aria-pressed={issuesFilter.hideActive}
+            title={m.issues_filter_active_title()}
+            onclick={() => issuesFilter.toggleActive()}
+          >
+            {m.issues_filter_active_label()}
+          </button>
+        </div>
         {#if allHiddenByAssignee}
           <div class="muted">{m.issues_filter_all_assigned_to_others()}</div>
+        {:else if allHiddenByActive}
+          <div class="muted">{m.issues_filter_all_in_progress()}</div>
         {/if}
         {#each visibleIssues as i (i.number)}
           {@const ordered = orderedLabels(i.labels)}

--- a/ui/src/lib/components/issues-panel.test.ts
+++ b/ui/src/lib/components/issues-panel.test.ts
@@ -6,7 +6,7 @@
  * delegates to.
  */
 import { describe, it, expect } from "vitest";
-import { filterIssues, hideOthers } from "./issues-panel";
+import { filterIssues, hideOthers, hideActive, ACTIVE_LABEL } from "./issues-panel";
 import type { Issue } from "$lib/types";
 
 function issue(
@@ -116,5 +116,36 @@ describe("hideOthers", () => {
     } as unknown as Issue;
     expect(() => hideOthers([stale], me, true)).not.toThrow();
     expect(hideOthers([stale], me, true)).toEqual([stale]);
+  });
+});
+
+describe("hideActive", () => {
+  const plain = issue(1, "Plain", "", ["bug"]);
+  const active = issue(2, "Claimed", "", ["enhancement", ACTIVE_LABEL]);
+  const all = [plain, active];
+
+  it("when enabled, drops issues labeled shepherd:active", () => {
+    expect(hideActive(all, true)).toEqual([plain]);
+  });
+
+  it("keeps an issue without the active label", () => {
+    expect(hideActive([plain], true)).toEqual([plain]);
+  });
+
+  it("fails open when disabled — returns all issues incl. active ones", () => {
+    expect(hideActive(all, false)).toEqual(all);
+  });
+
+  it("does not throw on a stale payload missing labels", () => {
+    const stale = {
+      number: 3,
+      title: "No labels field",
+      body: "",
+      url: "https://example.test/3",
+      createdAt: 0,
+      assignees: [],
+    } as unknown as Issue;
+    expect(() => hideActive([stale], true)).not.toThrow();
+    expect(hideActive([stale], true)).toEqual([stale]);
   });
 });

--- a/ui/src/lib/components/issues-panel.ts
+++ b/ui/src/lib/components/issues-panel.ts
@@ -4,6 +4,13 @@
 import type { Issue } from "$lib/types";
 
 /**
+ * Label the drain stamps on an issue claimed by a running session (mirrors
+ * ACTIVE_LABEL in src/drain-core.ts). Canonical UI-side source — imported by
+ * PromptSources.svelte and IssuesPanel.svelte instead of a bare literal.
+ */
+export const ACTIVE_LABEL = "shepherd:active";
+
+/**
  * Narrow an issue list by a free-text query (the panel's search field).
  * Case-insensitive substring match against number (with or without a leading
  * `#`), title, body, and labels. A blank/whitespace query is an identity
@@ -43,4 +50,18 @@ export function hideOthers(
     const assignees = issue.assignees ?? [];
     return assignees.length === 0 || assignees.includes(viewer);
   });
+}
+
+/**
+ * Narrow an issue list to "hide in progress": drop issues already claimed by a
+ * running session (labeled `shepherd:active`). Viewer-agnostic — it keys off a
+ * label, not assignees.
+ *
+ * Fails open — returns every issue unchanged — when `enabled` is false. The
+ * `?? []` guard tolerates a stale payload that predates the `labels` field, so
+ * the helper can never throw on a missing array.
+ */
+export function hideActive(issues: readonly Issue[], enabled: boolean): Issue[] {
+  if (!enabled) return [...issues];
+  return issues.filter((issue) => !(issue.labels ?? []).includes(ACTIVE_LABEL));
 }

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1226,4 +1226,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_ready_lens_hides_waiting_title",
     bodyKey: "feat_ready_lens_hides_waiting_body",
   },
+  {
+    // "Hide in progress" issue filter — drops shepherd:active issues on both the
+    // Backlog and New Task issue lists. v1.34.0 is the latest released tag → 1.35.0.
+    id: "issues-filter-active",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_issues_filter_active_title",
+    bodyKey: "feat_issues_filter_active_body",
+    targetId: "issues-filter-active",
+  },
 ];

--- a/ui/src/lib/issues-filter.svelte.ts
+++ b/ui/src/lib/issues-filter.svelte.ts
@@ -4,6 +4,10 @@
 // others' issues out of the box. Mirrors build-queue-collapse.svelte.ts, but with an
 // inverted default — absence of the key means "on", so off is the value we persist.
 const KEY = "shepherd:issues-hide-others";
+// "Hide in progress" filter: drop issues labeled shepherd:active (claimed by a
+// running session). Independent of hideOthers, viewer-agnostic, and default OFF —
+// absence of the key means "off", so on is the value we persist ("1").
+const KEY_ACTIVE = "shepherd:issues-hide-active";
 
 function read(): boolean {
   try {
@@ -14,8 +18,18 @@ function read(): boolean {
   }
 }
 
+function readActive(): boolean {
+  try {
+    // Default false: only an explicit "1" turns it on.
+    return localStorage.getItem(KEY_ACTIVE) === "1";
+  } catch {
+    return false;
+  }
+}
+
 class IssuesFilter {
   hideOthers = $state(read());
+  hideActive = $state(readActive());
   toggle() {
     this.set(!this.hideOthers);
   }
@@ -24,6 +38,18 @@ class IssuesFilter {
     try {
       if (v) localStorage.removeItem(KEY);
       else localStorage.setItem(KEY, "0");
+    } catch {
+      /* private mode / SSR — preference just won't survive reload */
+    }
+  }
+  toggleActive() {
+    this.setActive(!this.hideActive);
+  }
+  setActive(v: boolean) {
+    this.hideActive = v;
+    try {
+      if (v) localStorage.setItem(KEY_ACTIVE, "1");
+      else localStorage.removeItem(KEY_ACTIVE);
     } catch {
       /* private mode / SSR — preference just won't survive reload */
     }


### PR DESCRIPTION
## What

Adds a second filter chip — **`hide in progress`** — to the issues filter bar that hides issues already claimed by a running session (labeled `shepherd:active`). It sits beside the existing **mine & unassigned** chip on **both** issue surfaces: the **New Task** pane (`PromptSources`) and the **Backlog** issues list (`IssuesPanel`).

## Behavior

- **Default OFF** (opt-in) — nothing is hidden until you click the chip.
- **Independent** of `mine & unassigned`; the two filters compose.
- **Viewer-agnostic** — keys off a label, not assignees — so the chip shows even offline / on a local forge (unlike the mine chip). In `PromptSources` the filter bar now renders even when `viewer` is unknown.
- Preference is persisted in `localStorage` (`shepherd:issues-hide-active`) and shared across both lists via the `issuesFilter` singleton.
- Distinct **"All matching issues are in progress — toggle off to see them"** empty state, attributed to the correct filter (a new `assigneeFiltered` intermediate in `PromptSources` keeps the active-filter case from being misreported as "all assigned to others").

## Implementation

- `issues-filter.svelte.ts` — new `hideActive` toggle (`toggleActive`/`setActive`, default off).
- `issues-panel.ts` — pure `hideActive(issues, enabled)` helper + canonical `ACTIVE_LABEL` export, now **imported** by both components (removes the two bare `"shepherd:active"` literals).
- `PromptSources.svelte` / `IssuesPanel.svelte` — compose the filter, add the chip (Backlog chip carries a `coachTarget`), add the in-progress empty state.
- i18n: EN + DE keys (parity), feature-announcement entry (`issues-filter-active`, `sinceVersion 1.35.0`).

## Tests

- `issues-panel.test.ts` — unit tests for `hideActive` (drop active, keep plain, fail-open when disabled, stale-payload guard).
- `IssuesPanel.browser.test.ts` — chip renders when viewer unknown; toggling hides/restores a `shepherd:active` issue; mine chip still gated on viewer.
- `cd ui && bun run check`, `bun run test` (1742 passed), `bun run check:i18n` — all green. Branch-hygiene, feature-catalog, glossary gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)