### PR TITLE
feat(learnings): capture-time semantic merge + composite ranking (Phase 2, #841)

### DIFF
--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -308,7 +308,6 @@ export class DistillerService {
     repoPath: string,
     raw: RawProposals | null,
   ): { added: number; updated: number; deleted: number } {
-    const have = new Set(this.deps.store.listLearnings(repoPath).map((l) => normalizeRule(l.rule)));
     const activeIds = new Set(
       this.deps.store
         .listActiveLearnings(repoPath)
@@ -317,6 +316,10 @@ export class DistillerService {
     );
     const updated = this.applyUpdates(raw, activeIds);
     const deleted = this.applyDeletes(raw, activeIds);
+    // Build the ADD dedup set AFTER updates/deletes: an UPDATE merges richer text into an
+    // existing rule, so an ADD carrying that same merged text must dedup against the
+    // just-merged rule (recomputing from the store reflects the post-merge text).
+    const have = new Set(this.deps.store.listLearnings(repoPath).map((l) => normalizeRule(l.rule)));
     const added = this.applyAdds(repoPath, raw, have);
     return { added, updated, deleted };
   }

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -98,7 +98,7 @@ export interface DistillerDeps {
     dir: string,
     signals: Signal[],
     existingRules: string[],
-    activeRules: { id: string; rule: string }[],
+    activeRules: { id: string; rule: string; promoted: boolean }[],
   ) => void;
   readProposals?: (dir: string) => RawProposals | null;
 }
@@ -211,7 +211,7 @@ export class DistillerService {
     const existing = this.deps.store.listLearnings(repoPath).map((l) => l.rule);
     const activeRules = this.deps.store
       .listActiveLearnings(repoPath)
-      .map((l) => ({ id: l.id, rule: l.rule }));
+      .map((l) => ({ id: l.id, rule: l.rule, promoted: l.status === "promoted" }));
     try {
       this.writeSignals(dir, signals, existing, activeRules);
     } catch (err) {
@@ -408,7 +408,7 @@ function distillPrompt(): string {
     "It is a JSON object with three fields:",
     "  `signals` — an array of past corrections, blocks, stalls, and critic findings for one repository;",
     "  `existingRules` — all recorded/dismissed rules (do NOT ADD any of these — they are the dedup set);",
-    "  `activeRules` — currently-active house rules as {id, rule} objects (UPDATE/DELETE targets).",
+    "  `activeRules` — currently-active house rules as {id, rule, promoted} objects. UPDATE/DELETE may target ONLY entries with promoted:false; promoted:true rules are mirrored in CLAUDE.md and may only be flagged ineffective.",
     "",
     "For each candidate finding, choose exactly ONE action:",
     "  ADD    → emit in `rules`   (new guidance, not already in existingRules)",

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -308,9 +308,6 @@ export class DistillerService {
     repoPath: string,
     raw: RawProposals | null,
   ): { added: number; updated: number; deleted: number } {
-    let added = 0;
-    let updated = 0;
-    let deleted = 0;
     const have = new Set(this.deps.store.listLearnings(repoPath).map((l) => normalizeRule(l.rule)));
     const activeIds = new Set(
       this.deps.store
@@ -318,19 +315,32 @@ export class DistillerService {
         .filter((l) => l.status === "active")
         .map((l) => l.id),
     );
+    const updated = this.applyUpdates(raw, activeIds);
+    const deleted = this.applyDeletes(raw, activeIds);
+    const added = this.applyAdds(repoPath, raw, have);
+    return { added, updated, deleted };
+  }
 
-    // UPDATE — validate id ∈ activeIds, non-blank rule, capped
+  private applyUpdates(raw: RawProposals | null, activeIds: Set<string>): number {
+    let updated = 0;
     const updates = Array.isArray(raw?.updates) ? (raw!.updates as RawUpdate[]) : [];
     for (const u of updates) {
       if (updated >= MAX_UPDATES_PER_RUN) break;
-      const id = typeof u?.id === "string" ? u.id : undefined;
-      if (!id || !activeIds.has(id)) continue;
-      if (typeof u.rule !== "string" || !u.rule.trim()) continue;
-      const rationale = typeof u.rationale === "string" ? u.rationale : undefined;
-      if (this.deps.store.mergeLearning(id, u.rule, rationale)) updated++;
+      if (this.mergeOneUpdate(u, activeIds)) updated++;
     }
+    return updated;
+  }
 
-    // DELETE — validate id ∈ activeIds, re-confirm active, capped, soft-retire "superseded"
+  private mergeOneUpdate(u: RawUpdate, activeIds: Set<string>): boolean {
+    const id = typeof u?.id === "string" ? u.id : undefined;
+    if (!id || !activeIds.has(id)) return false;
+    if (typeof u.rule !== "string" || !u.rule.trim()) return false;
+    const rationale = typeof u.rationale === "string" ? u.rationale : undefined;
+    return this.deps.store.mergeLearning(id, u.rule, rationale) !== null;
+  }
+
+  private applyDeletes(raw: RawProposals | null, activeIds: Set<string>): number {
+    let deleted = 0;
     const deletes = Array.isArray(raw?.deletes) ? (raw!.deletes as RawDelete[]) : [];
     for (const d of deletes) {
       if (deleted >= MAX_DELETES_PER_RUN) break;
@@ -339,8 +349,11 @@ export class DistillerService {
       if (this.deps.store.getLearning(id)?.status !== "active") continue; // defense-in-depth
       if (this.deps.store.retireLearning(id, "superseded")) deleted++;
     }
+    return deleted;
+  }
 
-    // ADD — unchanged from prior behavior (exact-text dedup backstop)
+  private applyAdds(repoPath: string, raw: RawProposals | null, have: Set<string>): number {
+    let added = 0;
     const rules = Array.isArray(raw?.rules) ? (raw!.rules as RawRule[]) : [];
     for (const r of rules) {
       if (typeof r?.rule !== "string" || !r.rule.trim()) continue;
@@ -357,7 +370,7 @@ export class DistillerService {
       });
       added++;
     }
-    return { added, updated, deleted };
+    return added;
   }
 
   /** Bump ineffectiveCount for any active rule the distiller cited as not working,

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -435,7 +435,7 @@ function defaultWriteSignals(
   dir: string,
   signals: Signal[],
   existingRules: string[],
-  activeRules: { id: string; rule: string }[],
+  activeRules: { id: string; rule: string; promoted: boolean }[],
 ): void {
   const payload = {
     signals: signals.map((s) => ({ kind: s.kind, payload: s.payload, ts: s.ts, id: s.id })),

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -32,6 +32,7 @@ export const DISTILL_LABEL = "__distill__";
 
 const HEALTH_FAILURE_THRESHOLD = 3;
 
+const MAX_ADDS_PER_RUN = 5;
 const MAX_UPDATES_PER_RUN = 5;
 const MAX_DELETES_PER_RUN = 5;
 
@@ -359,6 +360,7 @@ export class DistillerService {
     let added = 0;
     const rules = Array.isArray(raw?.rules) ? (raw!.rules as RawRule[]) : [];
     for (const r of rules) {
+      if (added >= MAX_ADDS_PER_RUN) break;
       if (typeof r?.rule !== "string" || !r.rule.trim()) continue;
       const key = normalizeRule(r.rule);
       if (have.has(key)) continue;

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -32,14 +32,28 @@ export const DISTILL_LABEL = "__distill__";
 
 const HEALTH_FAILURE_THRESHOLD = 3;
 
+const MAX_UPDATES_PER_RUN = 5;
+const MAX_DELETES_PER_RUN = 5;
+
 interface RawRule {
   rule?: unknown;
   rationale?: unknown;
   evidence?: unknown;
 }
+interface RawUpdate {
+  id?: unknown;
+  rule?: unknown;
+  rationale?: unknown;
+}
+interface RawDelete {
+  id?: unknown;
+  reason?: unknown;
+}
 interface RawProposals {
   rules?: unknown;
   ineffective?: unknown;
+  updates?: unknown; // NEW
+  deletes?: unknown; // NEW
 }
 interface RawIneffective {
   id?: unknown;
@@ -66,6 +80,9 @@ export interface DistillerDeps {
     | "listActiveLearnings"
     | "getRepoConfig"
     | "incrementLearningIneffective"
+    | "mergeLearning"
+    | "retireLearning"
+    | "getLearning"
   >;
   herdr: Pick<HerdrDriver, "start" | "stop">;
   scratch: { create: () => { dir: string }; remove: (dir: string) => void };
@@ -274,7 +291,7 @@ export class DistillerService {
   }
 
   private finalize(f: InFlight, raw: RawProposals | null): void {
-    const added = this.applyProposals(f.repoPath, raw);
+    const { added, updated, deleted } = this.applyProposals(f.repoPath, raw);
     const flagged = this.applyIneffective(f, raw);
     this.deps.herdr.stop(f.terminalId);
     this.deps.scratch.remove(f.dir);
@@ -283,13 +300,47 @@ export class DistillerService {
     } else {
       this.recordHealthFailure(f.repoPath, "timeout-no-output");
     }
-    if (added > 0 || flagged > 0) this.deps.onChange();
+    if (added + updated + deleted + flagged > 0) this.deps.onChange();
   }
 
-  /** Persist new (deduped) proposed rules from the distiller's output. Returns the count added. */
-  private applyProposals(repoPath: string, raw: RawProposals | null): number {
+  /** Persist new (deduped) proposed rules and apply UPDATE/DELETE from the distiller's output. */
+  private applyProposals(
+    repoPath: string,
+    raw: RawProposals | null,
+  ): { added: number; updated: number; deleted: number } {
     let added = 0;
+    let updated = 0;
+    let deleted = 0;
     const have = new Set(this.deps.store.listLearnings(repoPath).map((l) => normalizeRule(l.rule)));
+    const activeIds = new Set(
+      this.deps.store
+        .listActiveLearnings(repoPath)
+        .filter((l) => l.status === "active")
+        .map((l) => l.id),
+    );
+
+    // UPDATE — validate id ∈ activeIds, non-blank rule, capped
+    const updates = Array.isArray(raw?.updates) ? (raw!.updates as RawUpdate[]) : [];
+    for (const u of updates) {
+      if (updated >= MAX_UPDATES_PER_RUN) break;
+      const id = typeof u?.id === "string" ? u.id : undefined;
+      if (!id || !activeIds.has(id)) continue;
+      if (typeof u.rule !== "string" || !u.rule.trim()) continue;
+      const rationale = typeof u.rationale === "string" ? u.rationale : undefined;
+      if (this.deps.store.mergeLearning(id, u.rule, rationale)) updated++;
+    }
+
+    // DELETE — validate id ∈ activeIds, re-confirm active, capped, soft-retire "superseded"
+    const deletes = Array.isArray(raw?.deletes) ? (raw!.deletes as RawDelete[]) : [];
+    for (const d of deletes) {
+      if (deleted >= MAX_DELETES_PER_RUN) break;
+      const id = typeof d?.id === "string" ? d.id : undefined;
+      if (!id || !activeIds.has(id)) continue;
+      if (this.deps.store.getLearning(id)?.status !== "active") continue; // defense-in-depth
+      if (this.deps.store.retireLearning(id, "superseded")) deleted++;
+    }
+
+    // ADD — unchanged from prior behavior (exact-text dedup backstop)
     const rules = Array.isArray(raw?.rules) ? (raw!.rules as RawRule[]) : [];
     for (const r of rules) {
       if (typeof r?.rule !== "string" || !r.rule.trim()) continue;
@@ -306,7 +357,7 @@ export class DistillerService {
       });
       added++;
     }
-    return added;
+    return { added, updated, deleted };
   }
 
   /** Bump ineffectiveCount for any active rule the distiller cited as not working,
@@ -336,18 +387,29 @@ function normalizeRule(s: string): string {
 function distillPrompt(): string {
   return [
     "You are a code-review pattern analyst. Read `signals.json` in this directory.",
-    "It is a JSON object with three fields: `signals` — an array of past corrections, blocks,",
-    "stalls, and critic findings for one repository; `existingRules` — an array of rules",
-    "already recorded or previously dismissed (do NOT repeat any of these);",
-    "and `activeRules` — an array of currently-active house rules as {id, rule} objects.",
+    "It is a JSON object with three fields:",
+    "  `signals` — an array of past corrections, blocks, stalls, and critic findings for one repository;",
+    "  `existingRules` — all recorded/dismissed rules (do NOT ADD any of these — they are the dedup set);",
+    "  `activeRules` — currently-active house rules as {id, rule} objects (UPDATE/DELETE targets).",
+    "",
+    "For each candidate finding, choose exactly ONE action:",
+    "  ADD    → emit in `rules`   (new guidance, not already in existingRules)",
+    "  UPDATE → emit in `updates` (same topic AND same target; richer wording — keep the most informative version)",
+    "  DELETE → emit in `deletes` (the finding directly CONTRADICTS that activeRule — emit any corrected rule as a separate ADD)",
+    "  NOOP   → emit nothing      (already fully covered by an existingRule or activeRule)",
+    "",
+    "MULTI-VALUED GUARD: never UPDATE or DELETE a rule whose target (file / category / object) DIFFERS",
+    "from the candidate, even if the topic is similar. A UI rule and a migration rule about the same",
+    "feature must coexist — only the SAME target may be merged or contradicted.",
+    "",
     "If a signal shows an activeRule was violated or did not prevent the mistake, add an",
-    "`ineffective` entry: {id: the activeRule id, evidence: the signal ids that show it",
-    "failing}. Only cite signal ids present in `signals` — never invent ids.",
-    "Identify RECURRING, actionable mistakes worth a standing house rule for future agents.",
-    "Ignore one-off noise. Write at most 5 crisp imperative rules.",
+    "`ineffective` entry: {id: the activeRule id, evidence: the signal ids that show it failing}.",
+    "Only cite ids present in the data — never invent ids.",
+    "",
+    "Limits: at most 5 ADDs, 5 updates, 5 deletes.",
     `Write your output as JSON to \`${PROPOSALS_FILE}\` in this directory, shaped exactly:`,
-    '{"rules": [{"rule": "<=160 char imperative", "rationale": "why", "evidence": ["signalId", ...]}], "ineffective": [{"id": "activeRuleId", "evidence": ["signalId", ...]}]}',
-    'If nothing recurs, write {"rules": [], "ineffective": []}. Do not write anything else.',
+    '{"rules":[{"rule":"<=160 char imperative","rationale":"why","evidence":["signalId",...]}],"updates":[{"id":"activeRuleId","rule":"<=160 char imperative","rationale":"why"}],"deletes":[{"id":"activeRuleId","reason":"why"}],"ineffective":[{"id":"activeRuleId","evidence":["signalId",...]}]}',
+    'If nothing applies, write {"rules":[],"updates":[],"deletes":[],"ineffective":[]}. Do not write anything else.',
   ].join("\n");
 }
 

--- a/src/house-rules.ts
+++ b/src/house-rules.ts
@@ -21,11 +21,19 @@ export const HOUSE_RULES_OVERHEAD =
 // ── ranking constants (env-overridable) ───────────────────────────────────────
 
 export const DAY_MS = 86_400_000;
-const RANK_W_RECENCY = Number(process.env.SHEPHERD_LEARNINGS_RANK_W_RECENCY ?? 0.5);
-const RANK_W_HELP = Number(process.env.SHEPHERD_LEARNINGS_RANK_W_HELP ?? 0.5);
-const RANK_HALF_LIFE_DAYS = Number(process.env.SHEPHERD_LEARNINGS_RANK_HALF_LIFE_DAYS ?? 30);
-const RANK_PRIOR_STRENGTH = Number(process.env.SHEPHERD_LEARNINGS_RANK_PRIOR_STRENGTH ?? 4);
-const RANK_NEUTRAL_PRIOR = Number(process.env.SHEPHERD_LEARNINGS_RANK_NEUTRAL_PRIOR ?? 0.5);
+/** Parse a numeric env override, falling back to `def` for unset or non-numeric (NaN/±Inf)
+ *  values — a bad env var must not silently poison the score and disable ranking. */
+export function envNum(name: string, def: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return def; // unset/empty → default (Number("")===0)
+  const v = Number(raw);
+  return Number.isFinite(v) ? v : def; // non-numeric (NaN/±Inf) → default
+}
+const RANK_W_RECENCY = envNum("SHEPHERD_LEARNINGS_RANK_W_RECENCY", 0.5);
+const RANK_W_HELP = envNum("SHEPHERD_LEARNINGS_RANK_W_HELP", 0.5);
+const RANK_HALF_LIFE_DAYS = envNum("SHEPHERD_LEARNINGS_RANK_HALF_LIFE_DAYS", 30);
+const RANK_PRIOR_STRENGTH = envNum("SHEPHERD_LEARNINGS_RANK_PRIOR_STRENGTH", 4);
+const RANK_NEUTRAL_PRIOR = envNum("SHEPHERD_LEARNINGS_RANK_NEUTRAL_PRIOR", 0.5);
 /** Per-day decay factor; default half-life = 30 days → 0.5^(1/30). */
 const RANK_DECAY_BASE = Math.pow(0.5, 1 / RANK_HALF_LIFE_DAYS);
 

--- a/src/house-rules.ts
+++ b/src/house-rules.ts
@@ -18,6 +18,17 @@ const HOUSE_RULES_INTRO =
 export const HOUSE_RULES_OVERHEAD =
   `<${HOUSE_RULES_TAG}>`.length + HOUSE_RULES_INTRO.length + `</${HOUSE_RULES_TAG}>`.length + 2;
 
+// ── ranking constants (env-overridable) ───────────────────────────────────────
+
+export const DAY_MS = 86_400_000;
+const RANK_W_RECENCY = Number(process.env.SHEPHERD_LEARNINGS_RANK_W_RECENCY ?? 0.5);
+const RANK_W_HELP = Number(process.env.SHEPHERD_LEARNINGS_RANK_W_HELP ?? 0.5);
+const RANK_HALF_LIFE_DAYS = Number(process.env.SHEPHERD_LEARNINGS_RANK_HALF_LIFE_DAYS ?? 30);
+const RANK_PRIOR_STRENGTH = Number(process.env.SHEPHERD_LEARNINGS_RANK_PRIOR_STRENGTH ?? 4);
+const RANK_NEUTRAL_PRIOR = Number(process.env.SHEPHERD_LEARNINGS_RANK_NEUTRAL_PRIOR ?? 0.5);
+/** Per-day decay factor; default half-life = 30 days → 0.5^(1/30). */
+const RANK_DECAY_BASE = Math.pow(0.5, 1 / RANK_HALF_LIFE_DAYS);
+
 export interface HouseRulesPlan {
   injected: Learning[]; // priority order, fit within budget
   dropped: Learning[]; // over budget, priority order
@@ -25,24 +36,46 @@ export interface HouseRulesPlan {
   usedChars: number; // exact rendered length of the block (XML tag + intro + bullets)
 }
 
-/** Priority sort: lastEvidenceAt desc (nulls last), tie-break updatedAt desc.
- *  Stale rules with no recent evidence drop first. */
-export function prioritize(rules: Learning[]): Learning[] {
+/**
+ * Composite score for a single rule, given the current time `now` (ms since epoch).
+ *
+ * recencyDecay  ∈ (0,1] — exponential decay on lastUsedAt (falls back to lastEvidenceAt,
+ *                          then createdAt). Clamped so future timestamps don't yield >1.
+ * helpComponent ∈ [0,1] — Bayesian-smoothed mean with fixed neutral prior (0.5).
+ *                          Fixed prior keeps `proven 50/60 > lucky 1/1 > unproven 0/0 >
+ *                          unhelpful 0/2` correct independent of base rate.
+ * score = RANK_W_RECENCY * recencyDecay + RANK_W_HELP * helpComponent
+ */
+function scoreRule(r: Learning, now: number): number {
+  const effectiveLastUsed = r.lastUsedAt ?? r.lastEvidenceAt ?? r.createdAt;
+  const ageDays = Math.max(0, (now - effectiveLastUsed) / DAY_MS);
+  const recencyDecay = Math.pow(RANK_DECAY_BASE, ageDays);
+  const helpComponent =
+    (r.helpfulCount + RANK_PRIOR_STRENGTH * RANK_NEUTRAL_PRIOR) /
+    (r.injectedCount + RANK_PRIOR_STRENGTH);
+  return RANK_W_RECENCY * recencyDecay + RANK_W_HELP * helpComponent;
+}
+
+/** Priority sort: composite recency-decay + smoothed-help score, desc.
+ *  Tie-break: updatedAt desc (determinism). `now` defaults to Date.now() so
+ *  existing callers need no change. */
+export function prioritize(rules: Learning[], now: number = Date.now()): Learning[] {
   return [...rules].sort((a, b) => {
-    if (a.lastEvidenceAt !== b.lastEvidenceAt) {
-      if (a.lastEvidenceAt === null) return 1; // nulls last
-      if (b.lastEvidenceAt === null) return -1;
-      return b.lastEvidenceAt - a.lastEvidenceAt; // desc
-    }
-    return b.updatedAt - a.updatedAt; // desc
+    const diff = scoreRule(b, now) - scoreRule(a, now);
+    if (diff !== 0) return diff; // desc by score
+    return b.updatedAt - a.updatedAt; // desc by updatedAt (tie-break)
   });
 }
 
-/** Priority: lastEvidenceAt desc (nulls last) → updatedAt desc. Greedy fill: add a rule
+/** Priority: composite score desc → updatedAt desc. Greedy fill: add a rule
  *  when used + cost ≤ budget, else mark it dropped and keep checking later (shorter) rules,
  *  so `injected` is not necessarily a contiguous prefix of priority order. */
-export function planHouseRulesInjection(rules: Learning[], budgetChars: number): HouseRulesPlan {
-  const ordered = prioritize(rules);
+export function planHouseRulesInjection(
+  rules: Learning[],
+  budgetChars: number,
+  now: number = Date.now(),
+): HouseRulesPlan {
+  const ordered = prioritize(rules, now);
   const injected: Learning[] = [];
   const dropped: Learning[] = [];
   let used = HOUSE_RULES_OVERHEAD;

--- a/src/store.ts
+++ b/src/store.ts
@@ -2319,6 +2319,27 @@ export class SessionStore implements CapStore, CreditStore {
     return this.getLearning(id);
   }
 
+  /** Deliberate inverse of `reviseLearning`: enriches a rule's text while PRESERVING all
+   *  effectiveness counters (`helpfulCount`, `injectedCount`, `ineffectiveCount`, `lastUsedAt`,
+   *  `evidenceCount`, `ineffectiveSignalIds`). Use when the distiller wants to apply an
+   *  mem0-style UPDATE — merging richer text into an existing rule so the help-rate record
+   *  carries forward. Unlike `reviseLearning`, this does NOT reset counters and does NOT stamp
+   *  `autoOptimizedAt`. Hard-guards active-only: promoted rules have their text mirrored in
+   *  CLAUDE.md verbatim and must never be silently rewritten here. */
+  mergeLearning(id: string, rule: string, rationale?: string): Learning | null {
+    const cur = this.getLearning(id);
+    if (!cur || cur.status !== "active") return null;
+    const text = rule.trim().slice(0, 240);
+    if (!text) return null;
+    const resolvedRationale = rationale !== undefined ? rationale : cur.rationale;
+    const now = Date.now();
+    this.db.run(
+      `UPDATE learnings SET rule = ?, rationale = ?, updatedAt = ?, lastEvidenceAt = ? WHERE id = ?`,
+      [text, resolvedRationale, now, now, id],
+    );
+    return this.getLearning(id);
+  }
+
   /** Resolve the stored `ineffectiveSignalIds` for a rule to full Signal rows.
    *  Server-side only — `ineffectiveSignalIds` is intentionally absent from the
    *  Learning type and hydrateLearning. Returns [] for missing/unflagged rules. */

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -622,6 +622,38 @@ test("UPDATE merges rule text + rationale while preserving counters", async () =
   expect(updated.injectedCount).toBe(1); // preserved
 });
 
+test("ADD carrying text just merged by an UPDATE is deduped (no duplicate active rule)", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const learning = store.addLearning({
+    repoPath: "/r",
+    rule: "original rule",
+    rationale: "r1",
+    evidence: [],
+  });
+  store.setLearningStatus(learning.id, "active");
+
+  // The LLM both UPDATEs the rule to a richer text AND emits an ADD with that same text.
+  // The ADD must dedup against the just-merged rule — `have` is recomputed after updates.
+  const merged = "merged enriched rule text";
+  const { deps } = mkDeps(store, {
+    rules: [{ rule: merged, rationale: "dup", evidence: [] }],
+    updates: [{ id: learning.id, rule: merged, rationale: "r2" }],
+    deletes: [],
+    ineffective: [],
+  });
+  const d = new DistillerService(deps as any);
+  d.consider("/r");
+  await d.tick();
+
+  // Exactly one rule remains (the merged one); no duplicate proposed rule was added.
+  expect(store.listLearnings("/r").length).toBe(1);
+  expect(store.listLearnings("/r", { status: "proposed" }).length).toBe(0);
+  const only = store.getLearning(learning.id)!;
+  expect(only.rule).toBe(merged);
+  expect(only.status).toBe("active");
+});
+
 test("UPDATE skips promoted rules", async () => {
   const store = new SessionStore(":memory:");
   seedSignals(store, "/r", 3);

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -348,6 +348,9 @@ test("distiller increments ineffective for cited active rule ids with validated 
         bumped.push({ id, signals });
         return {} as never;
       },
+      mergeLearning: () => null,
+      retireLearning: () => null,
+      getLearning: () => null,
     },
     herdr: { start: () => ({ terminalId: "t1" }) as never, stop: () => {} },
     scratch: { create: () => ({ dir: "/tmp/x" }), remove: () => {} },
@@ -585,6 +588,177 @@ test("health — onChange fires on the unhealthy transition and on every further
   d.distillNow("/r4"); // 5 failures
   expect(changes).toBe(3);
   expect(d.health().consecutiveFailures).toBe(5);
+});
+
+// ── Task 3: UPDATE / DELETE / NOOP capture-time merge ────────────────────────
+
+test("UPDATE merges rule text + rationale while preserving counters", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const learning = store.addLearning({
+    repoPath: "/r",
+    rule: "original rule",
+    rationale: "r1",
+    evidence: [],
+  });
+  store.setLearningStatus(learning.id, "active");
+  // Seed counters via attributeInjected
+  store.attributeInjected([learning.id], { good: true }); // injected=1, helpful=1
+
+  const { deps } = mkDeps(store, {
+    rules: [],
+    updates: [{ id: learning.id, rule: "enriched rule text", rationale: "r2" }],
+    deletes: [],
+    ineffective: [],
+  });
+  const d = new DistillerService(deps as any);
+  d.consider("/r");
+  await d.tick();
+
+  const updated = store.getLearning(learning.id)!;
+  expect(updated.rule).toBe("enriched rule text");
+  expect(updated.rationale).toBe("r2");
+  expect(updated.helpfulCount).toBe(1); // preserved
+  expect(updated.injectedCount).toBe(1); // preserved
+});
+
+test("UPDATE skips promoted rules", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const learning = store.addLearning({
+    repoPath: "/r",
+    rule: "original rule",
+    rationale: "r1",
+    evidence: [],
+  });
+  store.setLearningStatus(learning.id, "active");
+  store.promoteLearning(learning.id, "https://github.com/pr/1");
+
+  const { deps } = mkDeps(store, {
+    rules: [],
+    updates: [{ id: learning.id, rule: "should not replace", rationale: "r2" }],
+    deletes: [],
+    ineffective: [],
+  });
+  const d = new DistillerService(deps as any);
+  d.consider("/r");
+  await d.tick();
+
+  const unchanged = store.getLearning(learning.id)!;
+  expect(unchanged.rule).toBe("original rule"); // not changed
+});
+
+test("UPDATE and DELETE ignore bogus and non-active ids", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const proposed = store.addLearning({
+    repoPath: "/r",
+    rule: "proposed rule",
+    rationale: "",
+    evidence: [],
+  });
+  // proposed.id is valid but status is "proposed", not "active"
+
+  const { deps } = mkDeps(store, {
+    rules: [],
+    updates: [
+      { id: "nope", rule: "bogus update", rationale: "" },
+      { id: proposed.id, rule: "should not update proposed", rationale: "" },
+    ],
+    deletes: [
+      { id: "nope", reason: "bogus delete" },
+      { id: proposed.id, reason: "should not delete proposed" },
+    ],
+    ineffective: [],
+  });
+  const d = new DistillerService(deps as any);
+  d.consider("/r");
+  await d.tick();
+
+  const unchanged = store.getLearning(proposed.id)!;
+  expect(unchanged.rule).toBe("proposed rule"); // not changed
+  expect(unchanged.status).toBe("proposed"); // not retired
+});
+
+test("DELETE soft-retires with reason 'superseded'", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const learning = store.addLearning({
+    repoPath: "/r",
+    rule: "old rule",
+    rationale: "",
+    evidence: [],
+  });
+  store.setLearningStatus(learning.id, "active");
+
+  const { deps } = mkDeps(store, {
+    rules: [],
+    updates: [],
+    deletes: [{ id: learning.id, reason: "contradicted by new evidence" }],
+    ineffective: [],
+  });
+  const d = new DistillerService(deps as any);
+  d.consider("/r");
+  await d.tick();
+
+  const retired = store.getLearning(learning.id)!;
+  expect(retired.status).toBe("retired");
+  expect(retired.retiredReason).toBe("superseded");
+});
+
+test("UPDATE cap: at most 5 updates applied per run", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+
+  const ids: string[] = [];
+  for (let i = 0; i < 6; i++) {
+    const l = store.addLearning({ repoPath: "/r", rule: `rule ${i}`, rationale: "", evidence: [] });
+    store.setLearningStatus(l.id, "active");
+    ids.push(l.id);
+  }
+
+  const updates = ids.map((id, i) => ({ id, rule: `updated rule ${i}`, rationale: "" }));
+  const { deps } = mkDeps(store, {
+    rules: [],
+    updates,
+    deletes: [],
+    ineffective: [],
+  });
+  const d = new DistillerService(deps as any);
+  d.consider("/r");
+  await d.tick();
+
+  const changed = ids.filter((id, i) => store.getLearning(id)!.rule === `updated rule ${i}`);
+  expect(changed.length).toBe(5); // capped at 5
+});
+
+test("onChange fires on update-only proposals (no rules, no ineffective)", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const learning = store.addLearning({
+    repoPath: "/r",
+    rule: "original",
+    rationale: "",
+    evidence: [],
+  });
+  store.setLearningStatus(learning.id, "active");
+
+  let fired = 0;
+  const { deps } = mkDeps(
+    store,
+    {
+      rules: [],
+      updates: [{ id: learning.id, rule: "updated text", rationale: "r" }],
+      deletes: [],
+      ineffective: [],
+    },
+    () => fired++,
+  );
+  const d = new DistillerService(deps as any);
+  d.consider("/r");
+  await d.tick();
+
+  expect(fired).toBe(1);
 });
 
 test("health — timeout-no-output counts as failure; successful finalize resets health", async () => {

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -654,6 +654,43 @@ test("ADD carrying text just merged by an UPDATE is deduped (no duplicate active
   expect(only.status).toBe("active");
 });
 
+test("activeRules payload marks promoted rules (UPDATE/DELETE eligibility)", () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const active = store.addLearning({
+    repoPath: "/r",
+    rule: "active rule",
+    rationale: "",
+    evidence: [],
+  });
+  store.setLearningStatus(active.id, "active");
+  const promoted = store.addLearning({
+    repoPath: "/r",
+    rule: "promoted rule",
+    rationale: "",
+    evidence: [],
+  });
+  store.setLearningStatus(promoted.id, "active");
+  store.promoteLearning(promoted.id, "https://github.com/pr/1");
+
+  let captured: { id: string; promoted: boolean }[] = [];
+  const { deps } = mkDeps(store, null);
+  (deps as any).writeSignals = (
+    _dir: string,
+    _sigs: unknown,
+    _existing: string[],
+    activeRules: { id: string; promoted: boolean }[],
+  ) => {
+    captured = activeRules;
+  };
+  const d = new DistillerService(deps as any);
+  d.consider("/r"); // begin() → writeSignals runs synchronously
+
+  const byId = new Map(captured.map((r) => [r.id, r]));
+  expect(byId.get(active.id)?.promoted).toBe(false);
+  expect(byId.get(promoted.id)?.promoted).toBe(true);
+});
+
 test("UPDATE skips promoted rules", async () => {
   const store = new SessionStore(":memory:");
   seedSignals(store, "/r", 3);

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -738,6 +738,23 @@ test("DELETE soft-retires with reason 'superseded'", async () => {
   expect(retired.retiredReason).toBe("superseded");
 });
 
+test("ADD cap: at most 5 rules added per run", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+
+  const rules = Array.from({ length: 6 }, (_, i) => ({
+    rule: `new rule ${i}`,
+    rationale: "",
+    evidence: [],
+  }));
+  const { deps } = mkDeps(store, { rules, updates: [], deletes: [], ineffective: [] });
+  const d = new DistillerService(deps as any);
+  d.consider("/r");
+  await d.tick();
+
+  expect(store.listLearnings("/r", { status: "proposed" }).length).toBe(5); // capped at 5
+});
+
 test("UPDATE cap: at most 5 updates applied per run", async () => {
   const store = new SessionStore(":memory:");
   seedSignals(store, "/r", 3);

--- a/test/house-rules.test.ts
+++ b/test/house-rules.test.ts
@@ -91,11 +91,14 @@ test("no inversion: lightly-helped outranks unproven (fixed prior, not Wilson LB
 });
 
 test("determinism tie-break: higher updatedAt sorts first on identical score inputs", () => {
+  // Setup designed to diverge on old vs new comparator:
+  //   New: effectiveLastUsed = lastUsedAt (set) → both = now → equal recency + equal help (0/0)
+  //        → score tie → updatedAt desc → Y(2) before X(1) → ["y","x"]
+  //   Old: lastEvidenceAt desc nulls-last → X(200) before Y(100) → ["x","y"]  ← assertion fails
   const now = 100 * DAY_MS;
-  const X = rule({ id: "X", lastUsedAt: now, helpfulCount: 5, injectedCount: 10, updatedAt: 1 });
-  const Y = rule({ id: "Y", lastUsedAt: now, helpfulCount: 5, injectedCount: 10, updatedAt: 2 });
-  // Identical recency and help → score equal → updatedAt desc: Y first.
-  expect(prioritize([X, Y], now).map((r) => r.id)).toEqual(["Y", "X"]);
+  const X = rule({ id: "x", lastUsedAt: now, lastEvidenceAt: 200, updatedAt: 1 });
+  const Y = rule({ id: "y", lastUsedAt: now, lastEvidenceAt: 100, updatedAt: 2 });
+  expect(prioritize([X, Y], now).map((r) => r.id)).toEqual(["y", "x"]);
 });
 
 // ── budget / greedy / render tests (unchanged) ─────────────────────────────────

--- a/test/house-rules.test.ts
+++ b/test/house-rules.test.ts
@@ -2,7 +2,9 @@ import { test, expect } from "bun:test";
 import {
   HOUSE_RULES_OVERHEAD,
   HOUSE_RULES_TAG,
+  DAY_MS,
   planHouseRulesInjection,
+  prioritize,
   renderHouseRulesBlock,
 } from "../src/house-rules";
 import type { Learning } from "../src/types";
@@ -17,42 +19,105 @@ function rule(p: Partial<Learning>): Learning {
     status: "active",
     evidenceCount: 0,
     ineffectiveCount: 0,
-    helpfulCount: 0,
-    injectedCount: 0,
-    lastUsedAt: null,
+    helpfulCount: p.helpfulCount ?? 0,
+    injectedCount: p.injectedCount ?? 0,
+    lastUsedAt: p.lastUsedAt ?? null,
     retiredAt: null,
     retiredReason: null,
-    createdAt: 0,
+    createdAt: p.createdAt ?? 0,
     updatedAt: p.updatedAt ?? 0,
     lastEvidenceAt: p.lastEvidenceAt ?? null,
     promotedPrUrl: p.promotedPrUrl ?? null,
   };
 }
 
-test("priority: lastEvidenceAt desc with nulls last, tie-break updatedAt desc", () => {
+// ── composite sort ─────────────────────────────────────────────────────────────
+
+// Replaces the old two-key (lastEvidenceAt desc, updatedAt desc) test.
+// With the composite score and a `now` far in the past of these timestamps
+// (all timestamps are tiny ms values relative to a now=10_000 * DAY_MS),
+// recency is near-zero for all — the tie is broken by updatedAt desc.
+test("priority: composite score, tie-break updatedAt desc", () => {
+  // now is very large so all rules are ancient → recency ≈ 0 for all.
+  // Help component differentiates: all have injectedCount=0 → helpComponent is the neutral prior (equal).
+  // So score is equal for all → updatedAt desc breaks the tie.
+  const now = 10_000 * DAY_MS;
   const a = rule({ id: "a", rule: "a", lastEvidenceAt: 100, updatedAt: 1 });
-  const b = rule({ id: "b", rule: "b", lastEvidenceAt: 200, updatedAt: 1 });
+  const b = rule({ id: "b", rule: "b", lastEvidenceAt: 200, updatedAt: 2 });
   const c = rule({ id: "c", rule: "c", lastEvidenceAt: null, updatedAt: 50 });
   const d = rule({ id: "d", rule: "d", lastEvidenceAt: null, updatedAt: 80 });
-  const plan = planHouseRulesInjection([a, b, c, d], 10_000);
-  expect(plan.injected.map((r) => r.id)).toEqual(["b", "a", "d", "c"]);
+  // All have lastUsedAt=null, lastEvidenceAt tiny relative to now → recency near-0 for all.
+  // Equal help (all 0/0) → equal score → sorted by updatedAt desc: d(80), c(50), b(2), a(1).
+  const plan = planHouseRulesInjection([a, b, c, d], 10_000, now);
+  expect(plan.injected.map((r) => r.id)).toEqual(["d", "c", "b", "a"]);
 });
 
+// ── new composite-specific tests ───────────────────────────────────────────────
+
+test("recency decays on lastUsedAt: recently-used ranks above stale", () => {
+  const now = 100 * DAY_MS;
+  const A = rule({ id: "A", lastUsedAt: now - 1 * DAY_MS });
+  const B = rule({ id: "B", lastUsedAt: now - 60 * DAY_MS });
+  // Both injectedCount=0, equal help — recency wins.
+  expect(prioritize([B, A], now).map((r) => r.id)).toEqual(["A", "B"]);
+});
+
+test("effectiveLastUsed uses lastUsedAt not lastEvidenceAt when lastUsedAt is set", () => {
+  const now = 100 * DAY_MS;
+  // A: lastUsedAt=now (very recent), lastEvidenceAt=now-90d (old) → effectiveLastUsed=now
+  const A = rule({ id: "A", lastUsedAt: now, lastEvidenceAt: now - 90 * DAY_MS });
+  // B: lastUsedAt=now-90d (old), lastEvidenceAt=now (recent) → effectiveLastUsed=now-90d (lastUsedAt wins)
+  const B = rule({ id: "B", lastUsedAt: now - 90 * DAY_MS, lastEvidenceAt: now });
+  // A has recent effectiveLastUsed; B's recent lastEvidenceAt is ignored because lastUsedAt is set.
+  expect(prioritize([B, A], now).map((r) => r.id)).toEqual(["A", "B"]);
+});
+
+test("proven outranks lucky (help component: smoothed mean)", () => {
+  const now = 100 * DAY_MS;
+  // Same recency for both.
+  const P = rule({ id: "P", lastUsedAt: now, helpfulCount: 50, injectedCount: 60 });
+  const L = rule({ id: "L", lastUsedAt: now, helpfulCount: 1, injectedCount: 1 });
+  // Smoothed: P=(50 + 4*0.5)/(60+4)=52/64≈0.81; L=(1+2)/(1+4)=3/5=0.60
+  expect(prioritize([L, P], now).map((r) => r.id)).toEqual(["P", "L"]);
+});
+
+test("no inversion: lightly-helped outranks unproven (fixed prior, not Wilson LB)", () => {
+  const now = 100 * DAY_MS;
+  const H = rule({ id: "H", lastUsedAt: now, helpfulCount: 1, injectedCount: 1 });
+  const U = rule({ id: "U", lastUsedAt: now, helpfulCount: 0, injectedCount: 0 });
+  // Smoothed: H=(1+2)/(1+4)=0.60; U=(0+2)/(0+4)=0.50. H > U.
+  // Would FAIL under Wilson LB: wilson(1,1)≈0.21 < 0.5, inverting the order.
+  expect(prioritize([U, H], now).map((r) => r.id)).toEqual(["H", "U"]);
+});
+
+test("determinism tie-break: higher updatedAt sorts first on identical score inputs", () => {
+  const now = 100 * DAY_MS;
+  const X = rule({ id: "X", lastUsedAt: now, helpfulCount: 5, injectedCount: 10, updatedAt: 1 });
+  const Y = rule({ id: "Y", lastUsedAt: now, helpfulCount: 5, injectedCount: 10, updatedAt: 2 });
+  // Identical recency and help → score equal → updatedAt desc: Y first.
+  expect(prioritize([X, Y], now).map((r) => r.id)).toEqual(["Y", "X"]);
+});
+
+// ── budget / greedy / render tests (unchanged) ─────────────────────────────────
+
 test("greedy fill picks rules that fit within budget", () => {
+  // Both rules equally ancient (lastEvidenceAt only, no lastUsedAt). a has higher lastEvidenceAt.
+  const now = 10_000 * DAY_MS;
   const a = rule({ id: "a", rule: "x".repeat(20), lastEvidenceAt: 300 });
   const b = rule({ id: "b", rule: "y".repeat(20), lastEvidenceAt: 200 });
   const budget = HOUSE_RULES_OVERHEAD + "- ".length + 20 + "\n".length; // overhead + exactly one rule
-  const plan = planHouseRulesInjection([a, b], budget);
+  const plan = planHouseRulesInjection([a, b], budget, now);
   expect(plan.injected.map((r) => r.id)).toEqual(["a"]);
   expect(plan.dropped.map((r) => r.id)).toEqual(["b"]);
 });
 
 test("greedy continues past overflow: a later shorter rule still fits (non-prefix)", () => {
-  // priority order: big (highest), small (lowest). big overflows, small fits.
+  // priority order: big (highest lastEvidenceAt), small (lowest). big overflows, small fits.
+  const now = 10_000 * DAY_MS;
   const big = rule({ id: "big", rule: "x".repeat(500), lastEvidenceAt: 300 });
   const small = rule({ id: "small", rule: "ok", lastEvidenceAt: 100 });
   const budget = HOUSE_RULES_OVERHEAD + ("- " + "ok" + "\n").length + 10; // room for small only
-  const plan = planHouseRulesInjection([big, small], budget);
+  const plan = planHouseRulesInjection([big, small], budget, now);
   expect(plan.injected.map((r) => r.id)).toEqual(["small"]);
   expect(plan.dropped.map((r) => r.id)).toEqual(["big"]);
 });
@@ -83,10 +148,11 @@ test("empty input → empty / null, usedChars 0", () => {
 });
 
 test("usedChars equals rendered block length for a multi-rule plan", () => {
+  const now = 10_000 * DAY_MS;
   const a = rule({ id: "a", rule: "first rule", lastEvidenceAt: 300 });
   const b = rule({ id: "b", rule: "second longer rule here", lastEvidenceAt: 200 });
   const c = rule({ id: "c", rule: "third", lastEvidenceAt: null, updatedAt: 5 });
-  const plan = planHouseRulesInjection([a, b, c], 10_000);
+  const plan = planHouseRulesInjection([a, b, c], 10_000, now);
   expect(plan.injected.length).toBe(3);
   const block = renderHouseRulesBlock(plan.injected)!;
   expect(block).not.toBeNull();

--- a/test/house-rules.test.ts
+++ b/test/house-rules.test.ts
@@ -3,6 +3,7 @@ import {
   HOUSE_RULES_OVERHEAD,
   HOUSE_RULES_TAG,
   DAY_MS,
+  envNum,
   planHouseRulesInjection,
   prioritize,
   renderHouseRulesBlock,
@@ -170,4 +171,20 @@ test("rendered block is wrapped in the XML tag, one bullet per rule", () => {
   expect(block.endsWith(`\n</${HOUSE_RULES_TAG}>`)).toBe(true);
   expect(block).toContain("- use bun");
   expect(block).toContain("- rebase, do not merge");
+});
+
+test("envNum: unset and non-numeric env values fall back to the default; valid values parse", () => {
+  const name = "SHEPHERD_TEST_ENVNUM_XYZ";
+  delete process.env[name];
+  expect(envNum(name, 0.5)).toBe(0.5); // unset → default
+  try {
+    process.env[name] = "abc";
+    expect(envNum(name, 0.5)).toBe(0.5); // non-numeric → default (no NaN poisoning)
+    process.env[name] = "";
+    expect(envNum(name, 0.5)).toBe(0.5); // empty → default
+    process.env[name] = "30";
+    expect(envNum(name, 0.5)).toBe(30); // valid → parsed
+  } finally {
+    delete process.env[name];
+  }
 });

--- a/test/store-learnings.test.ts
+++ b/test/store-learnings.test.ts
@@ -674,3 +674,128 @@ test("listRepoPathsWithRetiredLearnings returns multiple repos with retired rule
   const repos = s.listRepoPathsWithRetiredLearnings().sort();
   expect(repos).toEqual(["/r1", "/r2"]);
 });
+
+// ── mergeLearning ─────────────────────────────────────────────────────────────
+
+test("mergeLearning: preserves counters + updates text and rationale", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({
+    repoPath: "/r",
+    rule: "original rule",
+    rationale: "original rationale",
+    evidence: [],
+  });
+  s.setLearningStatus(l.id, "active");
+
+  // Seed counters: 2 good + 1 bad attribution → injected=3, helpful=2
+  s.attributeInjected([l.id], { good: true });
+  s.attributeInjected([l.id], { good: true });
+  s.attributeInjected([l.id], { good: false });
+  // One ineffective signal → ineffective=1
+  s.incrementLearningIneffective(l.id, ["s1"]);
+
+  const before = s.getLearning(l.id)!;
+  expect(before.injectedCount).toBe(3);
+  expect(before.helpfulCount).toBe(2);
+  expect(before.ineffectiveCount).toBe(1);
+  const lastUsedAtBefore = before.lastUsedAt;
+  const evidenceCountBefore = before.evidenceCount;
+
+  const updated = s.mergeLearning(l.id, "new longer enriched text", "new rationale")!;
+  expect(updated).not.toBeNull();
+  expect(updated.rule).toBe("new longer enriched text");
+  expect(updated.rationale).toBe("new rationale");
+  // Counters preserved
+  expect(updated.helpfulCount).toBe(2);
+  expect(updated.injectedCount).toBe(3);
+  expect(updated.ineffectiveCount).toBe(1);
+  expect(updated.lastUsedAt).toBe(lastUsedAtBefore);
+  expect(updated.evidenceCount).toBe(evidenceCountBefore);
+  // Timestamps advanced (or at least as recent)
+  expect(updated.updatedAt).toBeGreaterThanOrEqual(before.updatedAt);
+  expect(updated.lastEvidenceAt).toBeGreaterThanOrEqual(before.lastEvidenceAt ?? 0);
+  expect(updated.status).toBe("active");
+  // autoOptimizedAt not stamped (use the dedicated getter — field absent from Learning type)
+  expect(s.autoOptimizedAt(l.id)).toBeNull();
+});
+
+test("mergeLearning: omitted rationale keeps existing rationale", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({
+    repoPath: "/r",
+    rule: "rule",
+    rationale: "keep me",
+    evidence: [],
+  });
+  s.setLearningStatus(l.id, "active");
+  const updated = s.mergeLearning(l.id, "newtext")!;
+  expect(updated).not.toBeNull();
+  expect(updated.rationale).toBe("keep me");
+  expect(updated.rule).toBe("newtext");
+});
+
+test("mergeLearning: text > 240 chars is clamped to 240", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "original", rationale: "", evidence: [] });
+  s.setLearningStatus(l.id, "active");
+  const longRule = "y".repeat(300);
+  const updated = s.mergeLearning(l.id, longRule)!;
+  expect(updated.rule.length).toBe(240);
+});
+
+test("mergeLearning: blank/whitespace-only rule → returns null, row unchanged", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "keep this", rationale: "", evidence: [] });
+  s.setLearningStatus(l.id, "active");
+  expect(s.mergeLearning(l.id, "")).toBeNull();
+  expect(s.mergeLearning(l.id, "   ")).toBeNull();
+  expect(s.getLearning(l.id)!.rule).toBe("keep this");
+});
+
+test("mergeLearning: rejects non-active states (proposed, dismissed, promoted, retired, missing)", () => {
+  const s = new SessionStore(":memory:");
+
+  // proposed
+  const proposed = s.addLearning({
+    repoPath: "/r",
+    rule: "proposed rule",
+    rationale: "",
+    evidence: [],
+  });
+  expect(s.mergeLearning(proposed.id, "attempt")).toBeNull();
+  expect(s.getLearning(proposed.id)!.rule).toBe("proposed rule");
+
+  // dismissed
+  const dis = s.addLearning({
+    repoPath: "/r",
+    rule: "dismissed rule",
+    rationale: "",
+    evidence: [],
+  });
+  s.setLearningStatus(dis.id, "active");
+  s.setLearningStatus(dis.id, "dismissed");
+  expect(s.mergeLearning(dis.id, "attempt")).toBeNull();
+  expect(s.getLearning(dis.id)!.rule).toBe("dismissed rule");
+
+  // promoted
+  const prom = s.addLearning({
+    repoPath: "/r",
+    rule: "promoted rule",
+    rationale: "",
+    evidence: [],
+  });
+  s.setLearningStatus(prom.id, "active");
+  s.promoteLearning(prom.id, "https://github.com/owner/repo/pull/1");
+  expect(s.mergeLearning(prom.id, "attempt")).toBeNull();
+  expect(s.getLearning(prom.id)!.rule).toBe("promoted rule");
+
+  // retired
+  const ret = s.addLearning({ repoPath: "/r", rule: "retired rule", rationale: "", evidence: [] });
+  s.setLearningStatus(ret.id, "active");
+  s.retireLearning(ret.id, "reason");
+  expect(s.mergeLearning(ret.id, "attempt")).toBeNull();
+  expect(s.getLearning(ret.id)!.rule).toBe("retired rule");
+
+  // missing id
+  expect(s.mergeLearning("nope", "attempt")).toBeNull();
+});


### PR DESCRIPTION
## Learnings Phase 2 — capture-time semantic merge + composite ranking

Closes #841. Phase 2 of the learnings-lifecycle epic (#838), building on the Phase 1 effectiveness loop (#840 / #853). Two server-only changes; **no schema migration, no UI**.

### A. Capture-time semantic merge (distiller)
The distiller now decides **ADD / UPDATE / DELETE / NOOP** per proposal (mem0-style), LLM-judged inside the existing subscription spawn (no embeddings — it already receives all active rules in context). TypeScript validates the LLM's ids against the **active-only** rule set and applies deterministically, mirroring `applyIneffective`'s id validation.

- **UPDATE** → `store.mergeLearning(id, rule, rationale?)` — merges richer text into an existing active rule, **preserving counters** (the deliberate inverse of `reviseLearning`, which resets them for a rewrite).
- **DELETE** → `store.retireLearning(id, "superseded")` — soft-retire of a contradicted rule (reversible via the drawer's retired-undo), **decoupled** from any replacement (corrected rules flow through the normal ADD→`proposed`→approve gate; no auto-activation of unreviewed text).
- **NOOP** → the LLM omits an already-covered proposal.
- Promoted rules are excluded from UPDATE/DELETE (their text is mirrored verbatim in `CLAUDE.md`); guarded both by the active-only id set in `applyProposals` and a `status === "active"` hard-guard in `mergeLearning`.
- Deterministic per-run caps on updates/deletes; `onChange` fires on any mutation.

### B. Composite injection score (`house-rules.ts`)
`prioritize()` replaces the two-key `lastEvidenceAt, updatedAt` sort with
`W_RECENCY·recencyDecay + W_HELP·helpComponent`, decaying on **`lastUsedAt`** (the Phase 1 column), refreshed on use. The help component is a Bayesian-smoothed mean `(helpful + M·P0)/(injected + M)` with a **fixed** neutral prior `P0=0.5`, giving the ordering `proven 50/60 ≻ lucky 1/1 ≻ unproven 0/0 ≻ unhelpful 0/2` independent of repo base rate. All constants env-overridable (`SHEPHERD_LEARNINGS_RANK_*`). The `now` param is optional (defaults `Date.now()`), so existing callers are unchanged.

### Design notes
- **Similarity** is LLM-judged in the distiller spawn (not a local embedding model) — honors the "in-app LLM = subscription spawn, not API call" house rule.
- **Help component** uses a fixed neutral prior, **not** Wilson lower bound (which inverted lightly-proven below unproven) and **not** `repoBaseRate` as prior (which reintroduced a proven-below-lucky inversion at high base rates). Wilson/`repoBaseRate` stay on the *retire* path.
- Plan, the 7 plan-review revisions, and the in-execution refinement (fixed prior) are documented in the design.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` clean · `bun test ./test` → **4071 pass / 0 fail** · `fallow audit` gate exit 0 (duplication warn-only).
- New regression tests fail on pre-fix code and assert the corrected behavior across `store-learnings`, `house-rules`, and `distiller` suites.

`[no-feature-entry]` — server-only change, no user-facing UI surface (the learnings drawer reorders via the server, but no new capability is added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
