### PR TITLE
fix(herd): hide CI-running tasks from the Ready lens

### DIFF
--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -407,6 +407,27 @@ test('"ready" filter hides a merging session (shared now), keeps awaitingMerge',
   ]);
 });
 
+test('"ready" filter hides a CI-running session, keeps ciFailed + awaitingMerge', () => {
+  const list = [
+    session("run", false, "idle"), // open + pending → ciRunning → awaiting CI, hidden
+    session("fail", false, "idle"), // open + failure → ciFailed → your turn, kept
+    session("mine", false, "idle"), // open + success → awaitingMerge → your turn, kept
+  ];
+  const g = {
+    run: git("open", "pending"),
+    fail: git("open", "failure"),
+    mine: git("open", "success"),
+  };
+  const shown = shownSessions(list, "ready", () => false, {}, g);
+  expect(shown.map((s) => s.id)).toEqual(["fail", "mine"]);
+  // All lens still lists the CI-running session
+  expect(shownSessions(list, "all", () => false, {}, g).map((s) => s.id)).toEqual([
+    "run",
+    "fail",
+    "mine",
+  ]);
+});
+
 test('"ready" filter keeps your-turn stages: awaitingMerge, parked ready, draft, ciFailed, blocked, idle', () => {
   const list = [
     session("am", false, "idle"), // green, no handoff → awaitingMerge

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -59,11 +59,14 @@ type Stage =
 export type HerdFilter = "all" | "ready" | "research" | "done" | "rundown";
 
 /** Lifecycle stages the "ready" lens hides: the session is NOT awaiting the operator.
- *  A green PR handed off to a foreign reviewer/merger (`waitingOnReviewer`/`waitingOnMerger`)
- *  is waiting on someone else, and a PR a launched merge train is carrying (`merging`) is
- *  in Shepherd's hands — neither is "your turn", so the Ready lens drops them (the All lens
- *  still shows them). Draft-awaiting-signoff stays: it awaits the operator's own sign-off. */
+ *  A PR with CI still in flight (`ciRunning`) is awaiting CI, a green PR handed off to a
+ *  foreign reviewer/merger (`waitingOnReviewer`/`waitingOnMerger`) is waiting on someone
+ *  else, and a PR a launched merge train is carrying (`merging`) is in Shepherd's hands —
+ *  none is "your turn", so the Ready lens drops them (the All lens still shows them).
+ *  `ciFailed` is NOT hidden — a failed CI run is back in your court. Draft-awaiting-signoff
+ *  stays too: it awaits the operator's own sign-off. */
 const NOT_YOUR_TURN: ReadonlySet<Stage> = new Set([
+  "ciRunning",
   "waitingOnReviewer",
   "waitingOnMerger",
   "merging",
@@ -76,8 +79,9 @@ const NOT_YOUR_TURN: ReadonlySet<Stage> = new Set([
  *  rail order, so keyboard navigation can never land on a row the rail isn't showing. Goes
  *  through `displayStatus` (a working-while-blocked session is actually mid-turn, so it is
  *  NOT awaiting the operator). `git`/`now` drive the stage check for the not-your-turn
- *  exclusion; both default empty/now so legacy 4-arg callers keep today's behavior (no
- *  handoff git + `mergingSince: null` → no session resolves to an excluded stage). */
+ *  exclusion; both default empty/now so legacy 4-arg callers keep today's behavior (no git
+ *  → no CI checks, no handoff, `mergingSince: null` → no session resolves to an excluded
+ *  stage). */
 export function shownSessions(
   sessions: Session[],
   filter: HerdFilter,


### PR DESCRIPTION
## What

The Herd **Ready** lens means "awaiting *you*". A session whose PR has CI in flight (`open` + checks `pending`) is awaiting **CI**, not the operator — so it now drops out of Ready, exactly like the other not-your-turn stages (`waitingOnReviewer`, `waitingOnMerger`, `merging`). It still appears in the **All** lens.

## Change

Single source of truth is `ui/src/lib/components/herd-partition.ts`. The `ciRunning` stage was already classified by `stageOf`; it was simply absent from the `NOT_YOUR_TURN` exclusion set the Ready lens filters on. Added `"ciRunning"` to that set and refreshed the doc comments.

| Stage | Ready (before) | Ready (after) | All |
| --- | --- | --- | --- |
| `ciRunning` (open + pending) | shown | **hidden** | shown |
| `ciFailed` (open + failure) | shown | shown | shown |
| `awaitingMerge` (open + success) | shown | shown | shown |
| `waitingOnReviewer` / `waitingOnMerger` / `merging` | hidden | hidden | shown |

`ciFailed` deliberately stays in Ready — a failed run is back in your court. Keynav's rail derives from the same `shownSessions`, so it stays consistent by construction.

## Tests

Added a regression test in `herd-partition.test.ts`: a `ciRunning` session is hidden from Ready and kept in All. Verified it **fails on pre-fix code** and passes after. Full UI suite green (`bun run check` 0 errors, 1757 tests pass).

No new user-facing strings (no i18n change); a refinement of the existing Ready lens (#863), so no feature-catalog entry required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)