### PR TITLE
refactor(ui): split 4 near-bar Svelte templates, delete their fallow grandfathers (#855)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -213,14 +213,6 @@
         "reason": "Tier 2 grandfather (#851); refactor candidate #855."
       },
       {
-        "files": ["ui/src/lib/components/Settings.svelte"],
-        "functions": ["<template>"],
-        "maxCyclomatic": 60,
-        "maxCognitive": 70,
-        "maxCrap": 20000,
-        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
-      },
-      {
         "files": ["ui/src/lib/components/GitRail.svelte"],
         "functions": ["<template>"],
         "maxCyclomatic": 60,

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -153,11 +153,13 @@
     // Tier 1: a real global bar for idiomatic Svelte markup (≈2× cyclo / 4× cognitive
     //   over the per-function default; cognitive runs higher because markup nests). No
     //   external convention exists for template thresholds — this is a deliberate
-    //   judgment call. 23 of 36 components clear it; anything over it still trips, so
+    //   judgment call. 27 of 36 components clear it; anything over it still trips, so
     //   the metric stays live for new code.
-    // Tier 2: the 13 giants that exceed Tier 1, each grandfathered just above its
+    // Tier 2: the 9 giants that exceed Tier 1, each grandfathered just above its
     //   current cyclo/cog (next multiple of 10) so it can't silently grow. Tracked for
-    //   refactor in #855.
+    //   refactor in #855 — which has paid down 4 of the original 13 (RepoSwitcher,
+    //   NewTask, AutomationSettings, Settings), each split into subcomponents that clear
+    //   the Tier-1 bar, so their grandfathers are removed.
     // maxCrap is intentionally inert for templates: CRAP for uncovered code is pure
     //   CC-derived noise bounded by CC²+CC; 20000 sits above the largest template's
     //   worst case (Viewport CC 136 → ≈18632) so it never becomes the binding

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -237,14 +237,6 @@
         "reason": "Tier 2 grandfather (#851); refactor candidate #855."
       },
       {
-        "files": ["ui/src/lib/components/AutomationSettings.svelte"],
-        "functions": ["<template>"],
-        "maxCyclomatic": 60,
-        "maxCognitive": 60,
-        "maxCrap": 20000,
-        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
-      },
-      {
         "files": ["ui/src/lib/components/LearningsDrawer.svelte"],
         "functions": ["<template>"],
         "maxCyclomatic": 50,

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -269,14 +269,6 @@
         "reason": "Tier 2 grandfather (#851); refactor candidate #855."
       },
       {
-        "files": ["ui/src/lib/components/RepoSwitcher.svelte"],
-        "functions": ["<template>"],
-        "maxCyclomatic": 40,
-        "maxCognitive": 70,
-        "maxCrap": 20000,
-        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
-      },
-      {
         "files": ["ui/src/lib/components/IssuesPanel.svelte"],
         "functions": ["<template>"],
         "maxCyclomatic": 40,

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -245,14 +245,6 @@
         "reason": "Tier 2 grandfather (#851); refactor candidate #855."
       },
       {
-        "files": ["ui/src/lib/components/NewTask.svelte"],
-        "functions": ["<template>"],
-        "maxCyclomatic": 50,
-        "maxCognitive": 60,
-        "maxCrap": 20000,
-        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
-      },
-      {
         "files": ["ui/src/lib/components/LearningsDrawer.svelte"],
         "functions": ["<template>"],
         "maxCyclomatic": 50,

--- a/ui/src/lib/components/AutomationSettings.svelte
+++ b/ui/src/lib/components/AutomationSettings.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
-  import { untrack } from "svelte";
   import { m } from "$lib/paraglide/messages";
   import { reviews, repoConfig, planGates } from "$lib/reviews.svelte";
-  import { clampCap, clampCeiling, sanitizeLabel } from "./git-rail-drain";
-  import { getRepoRoles, getRepoCollaborators, putRepoRoles } from "$lib/api";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
-  import { MODELS } from "$lib/types";
-  import { modelLabel } from "$lib/model-label";
-  import type { Session, RepoRoles, SandboxProfile, DrainStatus } from "$lib/types";
+  import AutomationRepoFields from "./automation-settings/AutomationRepoFields.svelte";
+  import type { Session, SandboxProfile, DrainStatus } from "$lib/types";
 
   let {
     repoPath,
@@ -67,113 +63,6 @@
       ? m.automation_plan_gate_task_planning()
       : m.automation_plan_gate_task_executing(),
   );
-
-  // Drain config fields, seeded from stored config and re-seeded whenever the
-  // section becomes visible (drain turned on) or the repo changes.
-  // svelte-ignore state_referenced_locally
-  let drainCap = $state(repoConfig.maxAutoFor(repoPath));
-  // svelte-ignore state_referenced_locally
-  let drainLabel = $state(repoConfig.autoLabelFor(repoPath));
-  // svelte-ignore state_referenced_locally
-  let drainCeiling = $state(repoConfig.usageCeilingFor(repoPath));
-  $effect(() => {
-    // Re-seed the inputs when the repo changes or the drain section (re)appears.
-    // untrack the store reads so committing a field (which writes back to the
-    // store) never retriggers this effect and clobbers an in-flight edit.
-    const repo = repoPath;
-    if (!flags.autoDrain) return;
-    untrack(() => {
-      drainCap = repoConfig.maxAutoFor(repo);
-      drainLabel = repoConfig.autoLabelFor(repo);
-      drainCeiling = repoConfig.usageCeilingFor(repo);
-    });
-  });
-
-  async function commitDrainCap() {
-    const n = clampCap(drainCap);
-    drainCap = n;
-    await repoConfig.setMaxAuto(repoPath, n);
-    drainCap = repoConfig.maxAutoFor(repoPath);
-  }
-  async function commitDrainLabel() {
-    const t = sanitizeLabel(drainLabel);
-    if (t === null) {
-      drainLabel = repoConfig.autoLabelFor(repoPath);
-      return;
-    }
-    drainLabel = t;
-    await repoConfig.setAutoLabel(repoPath, t);
-    drainLabel = repoConfig.autoLabelFor(repoPath);
-  }
-  async function commitDrainCeiling() {
-    const n = clampCeiling(drainCeiling);
-    drainCeiling = n;
-    await repoConfig.setUsageCeiling(repoPath, n);
-    drainCeiling = repoConfig.usageCeilingFor(repoPath);
-  }
-
-  // Repo responsibilities (.shepherd/roles.json): who reviews, who merges. Loaded
-  // lazily when the panel mounts / the repo changes — the herd reads the computed
-  // handoff off the cached git state, so this fetch is panel-only.
-  let roles = $state<RepoRoles>({ reviewer: null, merger: null });
-  let me = $state<string | null>(null);
-  let collaborators = $state<string[]>([]);
-  let collaboratorsUnavailable = $state(false);
-  let rolesError = $state<string | null>(null);
-  $effect(() => {
-    const repo = repoPath;
-    rolesError = null;
-    void (async () => {
-      try {
-        const [r, c] = await Promise.all([getRepoRoles(repo), getRepoCollaborators(repo)]);
-        if (repo !== repoPath) return; // repo switched mid-flight — drop stale result
-        roles = r.roles;
-        me = r.me ?? c.me;
-        collaborators = c.logins;
-        collaboratorsUnavailable = c.collaboratorsUnavailable;
-      } catch {
-        /* leave defaults; the free-text fallback still lets the user set roles */
-      }
-    })();
-  });
-
-  function normalizeLogin(v: string): string | null {
-    const t = v.trim().replace(/^@/, "");
-    return t || null;
-  }
-
-  // GitHub logins are case-insensitive — fold so a differently-cased stored login
-  // isn't treated as a distinct person (duplicate option / wrong "self" match).
-  const eqLogin = (a: string | null, b: string | null) =>
-    !!a && !!b && a.toLowerCase() === b.toLowerCase();
-
-  // Map a stored login onto the exact casing of its <option> so the dropdown
-  // reflects it — a casing-only difference (stored "Kai" vs me/collaborator "kai")
-  // would otherwise match no option and fall back to "— anyone / me —".
-  function optionValue(value: string | null): string {
-    if (!value) return "";
-    if (eqLogin(value, me)) return me ?? value;
-    return collaborators.find((c) => eqLogin(c, value)) ?? value;
-  }
-
-  async function setRole(role: "reviewer" | "merger", value: string | null) {
-    const prev = roles;
-    roles = { ...roles, [role]: value }; // optimistic
-    rolesError = null;
-    try {
-      const res = await putRepoRoles(repoPath, { [role]: value });
-      if (res.pushError) {
-        roles = prev; // push rejected (protected branch / auth) → revert + surface
-        rolesError = res.pushError;
-        return;
-      }
-      roles = res.roles;
-      if (res.me) me = res.me;
-    } catch (e) {
-      roles = prev;
-      rolesError = String((e as Error)?.message ?? e);
-    }
-  }
 </script>
 
 <!-- info/detail snippets are declared at the bottom of this file (Svelte hoists
@@ -530,113 +419,7 @@
   </div>
 </div>
 
-<!-- Default model: a repo-wide override of the global default (Settings → Session).
-     "Inherit" defers to the global setting; an explicit choice wins for both the
-     New-Task picker preselect and autonomous drain/autopilot spawns in this repo. -->
-<div class="drain-fields">
-  <label class="drain-field">
-    <span class="drain-label">{m.automation_default_model_label()}</span>
-    <select
-      class="num model-select"
-      aria-label={m.automation_default_model_label()}
-      value={repoConfig.defaultModelFor(repoPath)}
-      onchange={(e) =>
-        repoConfig.setDefaultModel(repoPath, (e.currentTarget as HTMLSelectElement).value)}
-    >
-      <option value="inherit">{m.automation_default_model_inherit()}</option>
-      <option value="auto">{m.settings_default_model_auto()}</option>
-      <option value="default">{m.newtask_model_default()}</option>
-      {#each MODELS as mdl (mdl)}
-        <option value={mdl}>{modelLabel(mdl)}</option>
-      {/each}
-    </select>
-  </label>
-  <div class="signoff-note">{m.automation_default_model_hint()}</div>
-</div>
-{#if flags.autoDrain}
-  <div class="drain-fields">
-    <label class="drain-field">
-      <span class="drain-label">{m.drain_cap_label()}</span>
-      <input
-        class="num"
-        type="number"
-        min="1"
-        max="20"
-        bind:value={drainCap}
-        aria-label={m.drain_cap_label()}
-        onchange={commitDrainCap}
-      />
-    </label>
-    <label class="drain-field">
-      <span class="drain-label">{m.drain_label_label()}</span>
-      <input
-        class="num txt"
-        type="text"
-        bind:value={drainLabel}
-        aria-label={m.drain_label_label()}
-        onchange={commitDrainLabel}
-        onblur={commitDrainLabel}
-      />
-    </label>
-    <label class="drain-field">
-      <span class="drain-label">{m.drain_ceiling_label()}</span>
-      <input
-        class="num"
-        type="number"
-        min="0"
-        max="100"
-        bind:value={drainCeiling}
-        aria-label={m.drain_ceiling_label()}
-        onchange={commitDrainCeiling}
-      />
-    </label>
-  </div>
-{/if}
-
-<!-- Repo responsibilities: reviewer + merger (committed to .shepherd/roles.json) -->
-<div class="auto-group" id="repo-roles">{m.automation_group_roles()}</div>
-{#snippet roleRow(label: string, role: "reviewer" | "merger", value: string | null)}
-  <div class="auto-row">
-    <div class="auto-meta">
-      <div class="auto-name">{label}</div>
-    </div>
-    {#if collaboratorsUnavailable}
-      <input
-        class="role-input"
-        type="text"
-        placeholder={m.roles_freetext_placeholder()}
-        value={value ?? ""}
-        aria-label={label}
-        onchange={(e) => setRole(role, normalizeLogin(e.currentTarget.value))}
-      />
-    {:else}
-      <select
-        class="role-select"
-        aria-label={label}
-        value={optionValue(value)}
-        onchange={(e) => setRole(role, e.currentTarget.value || null)}
-      >
-        <option value="">{m.roles_unset_option()}</option>
-        {#if me}<option value={me}>{m.roles_self_option()} (@{me})</option>{/if}
-        {#each collaborators.filter((c) => !eqLogin(c, me)) as login (login)}
-          <option value={login}>@{login}</option>
-        {/each}
-        {#if value && !eqLogin(value, me) && !collaborators.some((c) => eqLogin(c, value))}
-          <option {value}>@{value}</option>
-        {/if}
-      </select>
-    {/if}
-  </div>
-{/snippet}
-{@render roleRow(m.roles_reviewer_label(), "reviewer", roles.reviewer)}
-{@render roleRow(m.roles_merger_label(), "merger", roles.merger)}
-<div class="roles-note">
-  {#if rolesError}
-    <span class="roles-err">{m.roles_push_failed()}: {rolesError}</span>
-  {:else}
-    {m.automation_roles_hint()}
-  {/if}
-</div>
+<AutomationRepoFields {repoPath} autoDrain={flags.autoDrain} />
 
 <!-- Clickable "ⓘ" that toggles a row's long-form explanation, and the detail
      block it reveals. Reused by every row so each function carries a thorough,
@@ -838,36 +621,6 @@
     font-size: var(--fs-base);
     padding: 3px 6px;
     text-align: right;
-  }
-  /* The label is free text (e.g. "shepherd:auto") that overflows the fixed
-     numeric width on narrow screens — let it grow with the row and read from
-     the start instead of clipping the left side under right-alignment. */
-  .num.txt {
-    flex: 1 1 auto;
-    width: auto;
-    min-width: 0;
-    text-align: left;
-  }
-  .role-select,
-  .role-input {
-    flex: 0 0 auto;
-    width: 140px;
-    max-width: 50%;
-    background: var(--color-panel);
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    color: var(--color-ink);
-    font-family: var(--font-mono);
-    font-size: var(--fs-meta);
-    padding: 3px 6px;
-  }
-  .roles-note {
-    font-size: var(--fs-meta);
-    color: var(--color-faint);
-    padding: 6px 12px 12px;
-  }
-  .roles-err {
-    color: var(--color-red);
   }
   /* Sign-off authority selector — inherits .num token styling, left-aligned */
   .signoff-select {

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -14,7 +14,6 @@
   import { toasts } from "$lib/toasts.svelte";
   import { handleImagePaste } from "$lib/clipboard";
   import {
-    MODELS,
     type Issue,
     type IssueRef,
     type RepoEntry,
@@ -26,12 +25,11 @@
   import RepoSelect from "./RepoSelect.svelte";
   import PromptSources from "./PromptSources.svelte";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
-  import InfoTip from "./InfoTip.svelte";
+  import NewTaskRunSettings from "./new-task/NewTaskRunSettings.svelte";
   import { dialog } from "$lib/a11yDialog";
   import { repoConfig } from "$lib/reviews.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import { m } from "$lib/paraglide/messages";
-  import { modelLabel } from "$lib/model-label";
   import { recentRepos } from "$lib/recentRepos";
 
   let {
@@ -775,124 +773,22 @@
       <span class="nt-upstream micro">{m.newtask_upstream_behind({ count: upstream.behind })}</span>
     {/if}
 
-    <!-- Per-task run settings. Plan gate gets its own full-width row so its explainer
-         reads on one line; Model + Sandbox share a 50/50 row beneath. -->
-    <div class="opts-row">
-      <!-- Each toggle's long explainer now lives behind an InfoTip "i" rather than a
-           wrapped hint paragraph — keeps this stack of options compact, which matters
-           most on the phone sheet. The InfoTip is a sibling of the <label> (not nested
-           inside it) so a tap on the "i" never toggles the checkbox. -->
-      <div class="pg-row">
-        <label class="plan-gate" use:coachTarget={"plan-gate"}>
-          <input
-            type="checkbox"
-            bind:checked={planGate}
-            onchange={() => {
-              planGateTouched = true;
-              if (planGate) research = false;
-            }}
-            disabled={planGateLoading}
-          />
-          <span class="pg-label">{m.newtask_plan_gate_label()}</span>
-        </label>
-        {#if planGateLoading}
-          <span class="pg-loading">{m.common_loading()}</span>
-        {/if}
-        <InfoTip
-          text={m.newtask_plan_gate_hint()}
-          label={m.newtask_info_aria({ topic: m.newtask_plan_gate_label() })}
-        />
-      </div>
-
-      <!-- Relaunch intentionally CARRIES the original session's autopilot value
-           (server-side, src/service.ts relaunch()), so RelaunchOverrides has no
-           autopilotEnabled field and the override wouldn't take effect here.
-           Hide the control in relaunch so it never implies an override it can't honor. -->
-      {#if !relaunch}
-        <div class="pg-row">
-          <label class="plan-gate" use:coachTarget={"task-autopilot"}>
-            <input
-              type="checkbox"
-              bind:checked={autopilot}
-              onchange={() => (autopilotTouched = true)}
-              disabled={autopilotLoading}
-            />
-            <span class="pg-label">{m.newtask_autopilot_label()}</span>
-          </label>
-          <!-- The repo's standing default, shown alongside so it's clear how this repo
-               normally handles it — the checkbox is seeded from it on open, so unchecking
-               here is a visible, deliberate opt-out for this one task. -->
-          {#if autopilotLoading}
-            <span class="pg-loading">{m.common_loading()}</span>
-          {:else if repoPath}
-            <span class="repo-default" class:on={autopilotDefault}>
-              {autopilotDefault
-                ? m.newtask_autopilot_repo_default_on()
-                : m.newtask_autopilot_repo_default_off()}
-            </span>
-          {/if}
-          <InfoTip
-            text={m.newtask_autopilot_hint()}
-            label={m.newtask_info_aria({ topic: m.newtask_autopilot_label() })}
-          />
-        </div>
-      {/if}
-
-      <div class="pg-row">
-        <label class="plan-gate">
-          <input
-            type="checkbox"
-            bind:checked={research}
-            onchange={() => {
-              if (research) {
-                planGate = false;
-                // pin touched so a later repo switch doesn't re-seed/re-enable plan-gate while research is active
-                planGateTouched = true;
-                autopilot = false;
-                // pin touched so a later repo switch doesn't re-seed/re-enable autopilot while research is active
-                autopilotTouched = true;
-                if (sandboxProfile === "autonomous") sandboxProfile = "default";
-              }
-            }}
-          />
-          <span class="pg-label">{m.newtask_research_label()}</span>
-        </label>
-        <InfoTip
-          text={m.newtask_research_hint()}
-          label={m.newtask_info_aria({ topic: m.newtask_research_label() })}
-        />
-      </div>
-
-      <div class="run-config">
-        <div class="model-field" use:coachTarget={"model-1m-context"}>
-          <label class="micro" for="nt-model">{m.newtask_model_label()}</label>
-          <select id="nt-model" bind:value={model} onchange={() => (modelTouched = true)}>
-            <option value="default">{m.newtask_model_default()}</option>
-            {#each MODELS as mdl (mdl)}
-              {#if mdl !== "fable" || fableAvailable}
-                <option value={mdl}>{modelLabel(mdl)}</option>
-              {/if}
-            {/each}
-          </select>
-          {#if !fableAvailable}
-            <p class="micro">{m.newtask_fable_unavailable()}</p>
-          {/if}
-        </div>
-
-        <div class="model-field">
-          <label class="micro" for="nt-sandbox">{m.newtask_sandbox_label()}</label>
-          <select id="nt-sandbox" bind:value={sandboxProfile} title={m.newtask_sandbox_hint()}>
-            <option value="default">{m.newtask_sandbox_default()}</option>
-            <option value="trusted">{m.sandbox_profile_trusted()}</option>
-            <option value="standard">{m.sandbox_profile_standard()}</option>
-            <option value="autonomous" disabled={research}>{m.sandbox_profile_autonomous()}</option>
-          </select>
-          {#if research}
-            <span class="pg-hint">{m.newtask_research_sandbox_note()}</span>
-          {/if}
-        </div>
-      </div>
-    </div>
+    <NewTaskRunSettings
+      bind:planGate
+      bind:research
+      bind:autopilot
+      bind:model
+      bind:sandboxProfile
+      onPlanGateTouched={() => (planGateTouched = true)}
+      onAutopilotTouched={() => (autopilotTouched = true)}
+      onModelTouched={() => (modelTouched = true)}
+      {planGateLoading}
+      {autopilotLoading}
+      {autopilotDefault}
+      {repoPath}
+      {relaunch}
+      {fableAvailable}
+    />
 
     {#if error}
       <div class="err" role="alert">
@@ -1065,80 +961,6 @@
   select:focus {
     outline: none;
     border-color: var(--color-line-bright);
-  }
-  .opts-row {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    margin-top: 10px;
-  }
-  /* One toggle: the label (checkbox + name) plus its trailing InfoTip / repo-default
-     badge, laid out on a single baseline-centered line. */
-  .pg-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    min-width: 0;
-  }
-  .plan-gate {
-    min-width: 0;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    cursor: pointer;
-  }
-  .pg-loading {
-    flex: 0 0 auto;
-    font-size: var(--fs-micro);
-    color: var(--color-muted);
-  }
-  /* Standing repo default for autopilot — a quiet pill; amber when "on" to echo the
-     checkbox accent (green is reserved for actionable-complete per the design system). */
-  .repo-default {
-    flex: 0 0 auto;
-    font-size: var(--fs-micro);
-    letter-spacing: 0.04em;
-    color: var(--color-muted);
-    border: 1px solid var(--color-line);
-    border-radius: 999px;
-    padding: 1px 8px;
-    white-space: nowrap;
-  }
-  .repo-default.on {
-    color: var(--color-amber);
-    border-color: var(--color-amber);
-  }
-  .run-config {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 14px;
-  }
-  .model-field {
-    flex: 1 1 0;
-    min-width: 120px;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-  .model-field .micro {
-    margin-top: 0;
-  }
-  .plan-gate input {
-    width: auto;
-    flex: 0 0 auto;
-    accent-color: var(--color-amber);
-  }
-  .plan-gate:has(input:disabled) {
-    cursor: progress;
-    opacity: 0.6;
-  }
-  .pg-label {
-    color: var(--color-ink-bright);
-    font-size: var(--fs-base);
-  }
-  .pg-hint {
-    color: var(--color-muted);
-    font-size: var(--fs-meta);
   }
   .err {
     color: var(--color-red);

--- a/ui/src/lib/components/RepoSwitcher.svelte
+++ b/ui/src/lib/components/RepoSwitcher.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import type { DrainStatus, QueuedItem } from "$lib/types";
   import type { RepoChip } from "./queue-strip";
   import { m } from "$lib/paraglide/messages";
-  import { getDrainQueue } from "$lib/api";
   import { basename } from "./learnings-drawer";
   import { projectIcons } from "$lib/projectIcons.svelte";
-  import { chipRailVisible, chipHasTelemetry, queueOpenable, pausedText } from "./queue-strip";
+  import { chipRailVisible, chipHasTelemetry, pausedText } from "./queue-strip";
+  import RepoChipTelemetry from "./repo-switcher/RepoChipTelemetry.svelte";
 
   let {
     chips,
@@ -51,43 +50,6 @@
       .join(" "),
   );
 
-  // ── inline queue expansion (mirrors QueueStrip toggle/loading/failed) ───────
-  // At most one repo's queue is expanded at a time, fetched fresh on open.
-  let expandedRepo = $state<string | null>(null);
-  let queueItems = $state<QueuedItem[]>([]);
-  let loading = $state(false);
-  let failed = $state(false);
-
-  async function toggleQueue(d: DrainStatus) {
-    if (expandedRepo === d.repoPath) {
-      expandedRepo = null;
-      return;
-    }
-    const repo = d.repoPath;
-    expandedRepo = repo;
-    queueItems = [];
-    failed = false;
-    loading = true;
-    try {
-      const q = await getDrainQueue(repo);
-      if (expandedRepo === repo) queueItems = q; // ignore a stale (since-switched) response
-    } catch {
-      if (expandedRepo === repo) failed = true;
-    } finally {
-      if (expandedRepo === repo) loading = false;
-    }
-  }
-
-  function onWindowKeydown(e: KeyboardEvent) {
-    if (e.key === "Escape") expandedRepo = null;
-  }
-
-  // A whitespace/special-char-safe DOM id for the inline queue panel, so the toggle's
-  // aria-controls (an IDREF — space-separated, so a repoPath with whitespace would parse
-  // as multiple tokens) and the panel id stay valid. Only one queue is expanded at a
-  // time, so a cross-repo collision after sanitizing can't occur.
-  const queueId = (repoPath: string) => `rs-queue-${repoPath.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
-
   // ── edge-fade scroll affordance ─────────────────────────────────────────────
   let scroller = $state<HTMLElement | null>(null);
   // inner track: width == scroll content width; observing it catches content-width
@@ -107,14 +69,6 @@
     canScrollLeft = el.scrollLeft > 1;
     canScrollRight = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
   }
-
-  // A repo-filter switch invalidates any open inline queue: the expanded repo
-  // may no longer be visible, and its cached queueItems are stale. Collapse it
-  // so a re-expand refetches. (Writes expandedRepo only; reads repoFilter — no loop.)
-  $effect(() => {
-    void repoFilter;
-    expandedRepo = null;
-  });
 
   // Recompute whenever the chip set changes (and on mount).
   $effect(() => {
@@ -147,86 +101,6 @@
     recomputeScroll();
   }
 </script>
-
-<svelte:window onkeydown={onWindowKeydown} />
-
-<!-- Shared per-repo telemetry: drain inflight/queue + learnings + pause. -->
-{#snippet telemetry(chip: RepoChip)}
-  {@const d = chip.drain}
-  <div class="rs-tele">
-    {#if d}
-      <span class="rs-inflight">{m.drain_inflight({ count: d.inFlight, max: d.max })}</span>
-      {#if queueOpenable(d)}
-        {@const repo = basename(d.repoPath)}
-        <button
-          type="button"
-          class="rs-queued rs-queued-btn"
-          aria-expanded={expandedRepo === d.repoPath}
-          aria-controls={queueId(d.repoPath)}
-          aria-label={m.drain_queue_open_aria({ count: d.queued, repo })}
-          onclick={() => toggleQueue(d)}
-        >
-          {m.drain_queued({ count: d.queued })}
-        </button>
-      {:else}
-        <span class="rs-queued">{m.drain_queued({ count: d.queued })}</span>
-      {/if}
-    {/if}
-
-    {#if chip.insights > 0 || chip.curate > 0}
-      <button
-        type="button"
-        class="rs-insights"
-        title={m.learnings_badge_tip()}
-        aria-label={chip.insights > 0
-          ? m.learnings_open_aria({ count: chip.insights })
-          : m.learnings_open_curate_aria({ count: chip.curate })}
-        onclick={() => onlearnings?.(chip.repoPath)}
-      >
-        <span class="rs-insights-icon" aria-hidden="true">✦</span>{#if chip.insights > 0}<span
-            class="rs-insights-n">{chip.insights}</span
-          >{/if}
-      </button>
-    {/if}
-
-    {#if d?.paused}
-      <span class="rs-pause" title={pausedText(d)}>{pausedText(d)}</span>
-    {/if}
-  </div>
-
-  {#if d && expandedRepo === d.repoPath}
-    {@const repo = basename(d.repoPath)}
-    <div class="rs-queue" id={queueId(d.repoPath)}>
-      <div class="rs-queue-head">{m.drain_queue_title({ repo })}</div>
-      {#if loading}
-        <div class="rs-queue-state">{m.common_loading()}</div>
-      {:else if failed}
-        <div class="rs-queue-state rs-queue-fail">{m.drain_queue_error()}</div>
-      {:else if queueItems.length === 0}
-        <div class="rs-queue-state">{m.drain_queue_empty()}</div>
-      {:else}
-        <ul class="rs-queue-list">
-          {#each queueItems as it (it.number)}
-            <li>
-              <!-- eslint-disable svelte/no-navigation-without-resolve -- external forge URL, not an app route -->
-              <a
-                class="rs-queue-item"
-                href={it.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={m.drain_queue_item_aria({ number: it.number })}
-              >
-                <span class="rs-queue-num">#{it.number}</span>
-                <span class="rs-queue-title">{it.title}</span>
-              </a>
-              <!-- eslint-enable svelte/no-navigation-without-resolve -->
-            </li>
-          {/each}
-        </ul>
-      {/if}
-    </div>
-  {/if}
-{/snippet}
 
 {#if railVisible}
   <div class="rs" role="group" aria-label={m.repo_switcher_label()}>
@@ -280,12 +154,14 @@
     </div>
 
     {#if activeChip}
-      {@render telemetry(activeChip)}
+      {#key activeChip.repoPath}
+        <RepoChipTelemetry chip={activeChip} {onlearnings} />
+      {/key}
     {/if}
   </div>
 {:else if loneChip && !mobile}
   <div class="rs">
-    {@render telemetry(loneChip)}
+    <RepoChipTelemetry chip={loneChip} {onlearnings} />
   </div>
 {/if}
 
@@ -422,136 +298,6 @@
     font-variant-numeric: tabular-nums;
   }
 
-  /* active-repo / lone-repo detail line */
-  .rs-tele {
-    display: inline-flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 8px;
-    font-size: var(--fs-micro);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--color-muted);
-  }
-  .rs-inflight {
-    color: var(--color-ink);
-    font-variant-numeric: tabular-nums;
-  }
-  .rs-queued {
-    color: var(--color-faint);
-    font-variant-numeric: tabular-nums;
-  }
-  .rs-queued-btn {
-    font: inherit;
-    letter-spacing: inherit;
-    text-transform: inherit;
-    background: none;
-    border: none;
-    padding: 0;
-    margin: 0;
-    cursor: pointer;
-    text-decoration: underline dotted;
-    text-underline-offset: 2px;
-  }
-  .rs-queued-btn:hover,
-  .rs-queued-btn:focus-visible {
-    color: var(--color-ink-bright);
-  }
-  .rs-insights {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    font: inherit;
-    letter-spacing: inherit;
-    background: none;
-    border: none;
-    padding: 0;
-    margin: 0;
-    cursor: pointer;
-    color: var(--color-faint);
-  }
-  .rs-insights:hover,
-  .rs-insights:focus-visible {
-    color: var(--color-ink-bright);
-  }
-  .rs-insights-n {
-    font-variant-numeric: tabular-nums;
-  }
-  /* a paused drain is the loud thing in the detail line: red, reason inline */
-  .rs-pause {
-    color: var(--color-red);
-    background: color-mix(in oklab, var(--color-red) 12%, transparent);
-    padding: 1px 6px;
-    border-radius: 2px;
-    text-transform: none;
-    letter-spacing: 0.04em;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: min(320px, 50vw);
-  }
-
-  /* inline queue expansion — chrome mirrors QueueStrip's .qs-pop, but flows
-     inline below the detail line (not a floating popover) */
-  .rs-queue {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 8px;
-    width: min(360px, 90vw);
-    max-height: 50vh;
-    overflow: hidden;
-    background: var(--color-inset);
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-  }
-  .rs-queue-head {
-    font-size: var(--fs-micro);
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    color: var(--color-muted);
-  }
-  .rs-queue-state {
-    font-size: var(--fs-base);
-    color: var(--color-muted);
-  }
-  .rs-queue-fail {
-    color: var(--color-red);
-  }
-  .rs-queue-list {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    overflow-y: auto;
-  }
-  .rs-queue-item {
-    display: flex;
-    align-items: baseline;
-    gap: 8px;
-    padding: 3px 4px;
-    border-radius: 2px;
-    color: var(--color-ink);
-    text-decoration: none;
-    font-size: var(--fs-base);
-  }
-  .rs-queue-item:hover,
-  .rs-queue-item:focus-visible {
-    background: var(--color-panel);
-    color: var(--color-ink-bright);
-  }
-  .rs-queue-num {
-    color: var(--color-faint);
-    font-variant-numeric: tabular-nums;
-    flex-shrink: 0;
-  }
-  .rs-queue-title {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
   /* visually-hidden live region (no .sr-only util in app.css) */
   .rs-live {
     position: absolute;
@@ -562,24 +308,13 @@
     white-space: nowrap;
   }
 
-  /* Coarse pointers: ≥44px tap targets on the chips and the inline action
-     buttons (mirrors the QueueStrip / TopBar coarse-pointer pattern). */
+  /* Coarse pointers: ≥44px tap targets on the chips (mirrors the QueueStrip /
+     TopBar coarse-pointer pattern). */
   @media (pointer: coarse) {
-    .rs-chip,
-    .rs-queued-btn,
-    .rs-insights {
-      min-height: 44px;
-    }
     .rs-chip {
+      min-height: 44px;
       min-width: 44px;
       justify-content: center;
-    }
-    .rs-queued-btn,
-    .rs-insights {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 44px;
     }
   }
 </style>

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -135,6 +135,13 @@
   let fableAvailable = $state(true);
   let fableAvailableBusy = $state(false);
 
+  // Repo root, resolved by the single getSettings() below and handed to the
+  // workspace panel as props so it never re-fetches. settingsLoaded flips once
+  // that load settles (success OR failure) so the child knows when to browse.
+  let repoRoot = $state<string | null>(null);
+  let repoRootDisplay = $state<string | null>(null);
+  let settingsLoaded = $state(false);
+
   async function savePrReviewCycles() {
     if (prRcyBusy) return;
     prRcyBusy = true;
@@ -444,8 +451,13 @@
       usageHoldPct = s.usageHoldPct;
       usageHoldPctSaved = s.usageHoldPct;
       fableAvailable = s.fableAvailable;
+      repoRoot = s.repoRoot;
+      repoRootDisplay = s.repoRootDisplay;
     } catch {
-      // settings load failed — session fields keep their defaults
+      // settings load failed — session fields keep their defaults; the workspace
+      // panel falls back to browsing the default dir (repoRoot stays null)
+    } finally {
+      settingsLoaded = true;
     }
   });
 </script>
@@ -517,7 +529,15 @@
       tabindex="0"
       hidden={tab !== "workspace"}
     >
-      <SettingsWorkspacePanel {onclone} {onfork} {onsaved} {onclose} />
+      <SettingsWorkspacePanel
+        {repoRoot}
+        {repoRootDisplay}
+        {settingsLoaded}
+        {onclone}
+        {onfork}
+        {onsaved}
+        {onclose}
+      />
     </div>
 
     <div

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -2,7 +2,6 @@
   import { onMount, untrack } from "svelte";
   import {
     getSettings,
-    putSettings,
     putRemoteControl,
     putSessionHousekeeping,
     putPrReviewCyclesCap,
@@ -15,51 +14,17 @@
     putUsageHoldEnabled,
     putUsageHoldPct,
     putFableAvailable,
-    listDirs,
-    getDiagnostics,
-    fixDiagnostic,
   } from "$lib/api";
   import { verifyFailureMessage } from "$lib/verify-key";
   import { modelLabel } from "$lib/model-label";
-  import {
-    MODELS,
-    PREMIUM_MODELS,
-    type DirListing,
-    type HerdrUpdateStatus,
-    type DiagnosticCheck,
-  } from "$lib/types";
-  import DiagnoseRows from "$lib/components/DiagnoseRows.svelte";
-  import PwaInstallRow from "$lib/components/PwaInstallRow.svelte";
+  import { MODELS, PREMIUM_MODELS, type HerdrUpdateStatus, type DiagnosticCheck } from "$lib/types";
   import SteersEditor from "$lib/components/SteersEditor.svelte";
-  import ThemeIcon from "$lib/components/ThemeIcon.svelte";
+  import SettingsWorkspacePanel from "$lib/components/settings/SettingsWorkspacePanel.svelte";
+  import SettingsDevicePanel from "$lib/components/settings/SettingsDevicePanel.svelte";
+  import SettingsDiagnosePanel from "$lib/components/settings/SettingsDiagnosePanel.svelte";
   import { dialog } from "$lib/a11yDialog";
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
-  import {
-    pushState,
-    enablePush,
-    disablePush,
-    getPushCategories,
-    setPushCategories,
-    type PushStatus,
-    type PushCategories,
-  } from "$lib/push";
-  import { theme, type ThemePref } from "$lib/theme.svelte";
-  import { REPO, REPO_URL, sha, version, commitUrl } from "$lib/build-info";
-
-  // Theme picker — mobile only: the desktop switcher lives in the ActionBar,
-  // but on phones the ActionBar hides it and it was dropped from the top bar,
-  // so Settings (reachable via the gear from any mobile screen) is its home.
-  const THEMES: { pref: ThemePref; icon: "moon" | "sun" | "auto"; label: () => string }[] = [
-    { pref: "dark", icon: "moon", label: m.theme_dark },
-    { pref: "light", icon: "sun", label: m.theme_light },
-    { pref: "system", icon: "auto", label: m.theme_system },
-  ];
-
-  // Build/repo facts ($lib/build-info) come from the same source the desktop
-  // ActionBar footer uses. That footer is hidden on mobile, so the Device tab is
-  // where phone users read them (mirrors the theme picker, surfaced for the same
-  // reason).
 
   // Settings group into three jobs so the modal never outgrows the viewport:
   // WORKSPACE (which repo root), SESSION (how agents start + steer), DEVICE
@@ -124,21 +89,6 @@
   // On a phone the HERDR badge folds into the gear; its update flow lands here.
   const herdrUpdateAvailable = $derived(!!herdrUpdate && herdrUpdate.updateAvailable);
 
-  let currentRoot = $state(""); // the persisted root (display form)
-  let listing = $state<DirListing | null>(null);
-  let loading = $state(false);
-  let saving = $state(false);
-  let error = $state<string | null>(null);
-  let push = $state<PushStatus>({ supported: false, permission: "unsupported", subscribed: false });
-  let pushBusy = $state(false);
-  let categories = $state<PushCategories>({ agent: true, reviews: true, ci: true });
-
-  // Category metadata drives the checkbox list; keys index into `categories`.
-  const categoryRows: { key: keyof PushCategories; label: () => string }[] = [
-    { key: "agent", label: () => m.settings_push_cat_agent() },
-    { key: "reviews", label: () => m.settings_push_cat_reviews() },
-    { key: "ci", label: () => m.settings_push_cat_ci() },
-  ];
   let remoteControl = $state(false); // Claude Code Remote Control auto-start in sessions
   let rcBusy = $state(false);
   let housekeeping = $state(true); // daily prune of old archived sessions (kill switch)
@@ -184,55 +134,6 @@
   // Fable availability — operator kill-switch while Fable is globally unavailable.
   let fableAvailable = $state(true);
   let fableAvailableBusy = $state(false);
-
-  // Diagnose tab — local checks + re-run state.
-  // untrack: initialDiagnostics is intentionally only read once as the seed value.
-  let diagChecks = $state<DiagnosticCheck[] | null>(untrack(() => initialDiagnostics ?? null));
-  let diagBusy = $state(false);
-  let diagError = $state<string | null>(null);
-
-  async function rerunDiagnostics() {
-    if (diagBusy) return;
-    diagBusy = true;
-    diagError = null;
-    try {
-      const snap = await getDiagnostics(true);
-      diagChecks = snap.checks;
-    } catch {
-      diagError = m.diagnostics_rerun_error();
-    } finally {
-      diagBusy = false;
-    }
-  }
-
-  // One-click fix: run the check's remediation server-side, re-render from the
-  // re-probed snapshot. Fail closed on two levels: a non-2xx surfaces a persistent,
-  // deduped failure toast (and rethrows so DiagnoseRows clears busy); a 2xx whose
-  // re-probe shows the target check STILL not ok (the command exited 0 but didn't
-  // clear it) surfaces a persistent "unresolved" toast — never a green success.
-  async function fixCheck(checkId: string) {
-    try {
-      const snap = await fixDiagnostic(checkId);
-      diagChecks = snap.checks;
-      const cleared = snap.checks.find((c) => c.id === checkId)?.state === "ok";
-      if (cleared) {
-        toasts.info(m.diagnostics_fix_success(), { duration: 3000 });
-      } else {
-        toasts.info(m.diagnostics_fix_unresolved(), {
-          duration: null,
-          alert: true,
-          key: `diagnose-fix:${checkId}`,
-        });
-      }
-    } catch {
-      toasts.info(m.diagnostics_fix_failed(), {
-        duration: null,
-        alert: true,
-        key: `diagnose-fix:${checkId}`,
-      });
-      throw new Error("fix failed");
-    }
-  }
 
   async function savePrReviewCycles() {
     if (prRcyBusy) return;
@@ -517,47 +418,9 @@
     }
   }
 
-  async function refreshPush() {
-    push = await pushState();
-    if (push.subscribed) categories = await getPushCategories();
-  }
-
-  async function toggleCategory(key: keyof PushCategories) {
-    const prev = categories;
-    const next = { ...categories, [key]: !categories[key] };
-    categories = next; // optimistic; server is authoritative at send time
-    if (!(await setPushCategories(next))) categories = prev; // persist failed → revert
-  }
-
-  async function togglePush() {
-    if (pushBusy) return;
-    pushBusy = true;
-    try {
-      if (push.subscribed) await disablePush();
-      else await enablePush();
-      await refreshPush();
-    } finally {
-      pushBusy = false;
-    }
-  }
-
-  async function browse(path?: string) {
-    loading = true;
-    error = null;
-    try {
-      listing = await listDirs(path);
-    } catch (e) {
-      error = e instanceof Error ? e.message : "failed to list directory";
-    } finally {
-      loading = false;
-    }
-  }
-
   onMount(async () => {
-    await refreshPush();
     try {
       const s = await getSettings();
-      currentRoot = s.repoRootDisplay;
       remoteControl = s.remoteControlAtStartup;
       housekeeping = s.sessionHousekeepingEnabled;
       retentionDays = s.sessionRetentionDays;
@@ -581,39 +444,10 @@
       usageHoldPct = s.usageHoldPct;
       usageHoldPctSaved = s.usageHoldPct;
       fableAvailable = s.fableAvailable;
-      await browse(s.repoRoot);
     } catch {
-      await browse();
-    }
-    // Seed diagnose tab: if no pre-seeded checks from the store, fetch once on mount.
-    if (diagChecks === null) {
-      try {
-        const snap = await getDiagnostics();
-        diagChecks = snap.checks;
-      } catch {
-        // diagnostics unavailable — panel shows empty state gracefully
-      }
+      // settings load failed — session fields keep their defaults
     }
   });
-
-  const isCurrent = $derived(
-    listing != null && currentRoot !== "" && listing.display === currentRoot,
-  );
-
-  async function useThisFolder() {
-    if (!listing || saving) return;
-    saving = true;
-    error = null;
-    try {
-      const s = await putSettings(listing.path);
-      currentRoot = s.repoRootDisplay;
-      onsaved?.(s.repoRoot);
-      onclose?.();
-    } catch (e) {
-      error = e instanceof Error ? e.message : "failed to save";
-      saving = false;
-    }
-  }
 </script>
 
 <div
@@ -683,66 +517,7 @@
       tabindex="0"
       hidden={tab !== "workspace"}
     >
-      <div class="cur">
-        <span class="micro">{m.settings_current_root_label()}</span>
-        <code>{currentRoot || "—"}</code>
-      </div>
-
-      <span class="micro path-label">{m.settings_browse_label()}</span>
-      <div class="crumbs">
-        <button
-          type="button"
-          class="up"
-          disabled={!listing?.parent || loading}
-          onclick={() => listing?.parent && browse(listing.parent)}
-          title={m.settings_up_level()}
-        >
-          ↑
-        </button>
-        <code class="here">{listing?.display ?? "…"}</code>
-      </div>
-
-      <div class="list">
-        {#if loading}
-          <div class="placeholder">{m.settings_loading()}</div>
-        {:else if listing && listing.entries.length === 0}
-          <div class="placeholder">{m.settings_no_subfolders()}</div>
-        {:else if listing}
-          {#each listing.entries as e (e.path)}
-            <button type="button" class="row" onclick={() => browse(e.path)}>
-              <span class="ico">▸</span><span class="nm">{e.name}</span>
-              <span class="chev">›</span>
-            </button>
-          {/each}
-        {/if}
-      </div>
-
-      {#if error}<div class="err">{error}</div>{/if}
-
-      <button
-        class="run"
-        type="button"
-        disabled={!listing || saving || isCurrent}
-        onclick={useThisFolder}
-      >
-        {#if saving}
-          {m.settings_saving()}
-        {:else if isCurrent}
-          {m.settings_already_current()}
-        {:else}
-          {m.settings_use_folder()}
-        {/if}
-      </button>
-      {#if onclone}
-        <button type="button" class="clone-trigger" onclick={() => onclone?.()}
-          >{m.clonerepo_trigger()}</button
-        >
-      {/if}
-      {#if onfork}
-        <button type="button" class="clone-trigger" onclick={() => onfork?.()}
-          >{m.forkrepo_trigger()}</button
-        >
-      {/if}
+      <SettingsWorkspacePanel {onclone} {onfork} {onsaved} {onclose} />
     </div>
 
     <div
@@ -1003,111 +778,7 @@
       tabindex="0"
       hidden={tab !== "device"}
     >
-      <div class="theme-row">
-        <span class="micro">{m.actionbar_theme_group_aria()}</span>
-        <div class="theme-seg" role="group" aria-label={m.actionbar_theme_group_aria()}>
-          {#each THEMES as t (t.pref)}
-            <button
-              type="button"
-              class="t-opt"
-              class:on={theme.pref === t.pref}
-              aria-pressed={theme.pref === t.pref}
-              aria-label={m.actionbar_theme_option({ label: t.label() })}
-              onclick={() => theme.setPref(t.pref)}><ThemeIcon icon={t.icon} /></button
-            >
-          {/each}
-        </div>
-      </div>
-      <div class="contrast-row">
-        <span class="micro">{m.settings_contrast_title()}</span>
-        <p class="hint">{m.settings_contrast_hint()}</p>
-        <button
-          type="button"
-          class="toggle"
-          role="switch"
-          aria-checked={theme.contrast}
-          onclick={() => theme.toggleContrast()}
-        >
-          <span class="track" class:on={theme.contrast}><span class="knob"></span></span>
-          <span class="state"
-            >{theme.contrast ? m.settings_contrast_on() : m.settings_contrast_off()}</span
-          >
-        </button>
-      </div>
-      <div class="rc">
-        <span class="micro">{m.settings_colorblind_title()}</span>
-        <p class="hint">{m.settings_colorblind_hint()}</p>
-        <button
-          type="button"
-          class="toggle"
-          role="switch"
-          aria-checked={theme.colorblind}
-          onclick={() => theme.toggleColorblind()}
-        >
-          <span class="track" class:on={theme.colorblind}><span class="knob"></span></span>
-          <span class="state"
-            >{theme.colorblind ? m.settings_colorblind_on() : m.settings_colorblind_off()}</span
-          >
-        </button>
-      </div>
-      <div class="push">
-        <span class="micro">{m.settings_push_title()}</span>
-        {#if !push.supported}
-          <p class="hint">{m.settings_push_unsupported()}</p>
-        {:else if push.permission === "denied"}
-          <p class="hint">{m.settings_push_denied()}</p>
-        {:else}
-          <button type="button" class="run" disabled={pushBusy} onclick={togglePush}>
-            {#if pushBusy}…{:else if push.subscribed}{m.settings_push_disable()}{:else}{m.settings_push_enable()}{/if}
-          </button>
-          {#if push.subscribed}
-            <fieldset class="cats">
-              <legend class="micro">{m.settings_push_cat_title()}</legend>
-              {#each categoryRows as row (row.key)}
-                <label class="cat">
-                  <input
-                    type="checkbox"
-                    checked={categories[row.key]}
-                    onchange={() => toggleCategory(row.key)}
-                  />
-                  <span>{row.label()}</span>
-                </label>
-              {/each}
-            </fieldset>
-          {/if}
-        {/if}
-      </div>
-      <div class="about">
-        <span class="micro">{m.settings_about_title()}</span>
-        <p class="hint">{m.settings_about_blurb()}</p>
-        <dl class="about-grid">
-          <dt>{m.settings_about_version()}</dt>
-          <dd>
-            v{version}
-            <button type="button" class="clone-trigger whatsnew-btn" onclick={() => onwhatsnew?.()}
-              >{m.whatsnew_open()}</button
-            >
-          </dd>
-          <dt>{m.settings_about_commit()}</dt>
-          <dd>
-            <a
-              href={commitUrl}
-              target="_blank"
-              rel="external noreferrer noopener"
-              title={m.actionbar_commit_title({ sha })}>{sha}</a
-            >
-          </dd>
-          <dt>{m.settings_about_repo()}</dt>
-          <dd>
-            <a
-              href={REPO_URL}
-              target="_blank"
-              rel="external noreferrer noopener"
-              title={m.actionbar_repo_link({ repo: REPO })}>{REPO}</a
-            >
-          </dd>
-        </dl>
-      </div>
+      <SettingsDevicePanel {onwhatsnew} />
     </div>
 
     <div
@@ -1118,20 +789,7 @@
       tabindex="0"
       hidden={tab !== "diagnose"}
     >
-      <div class="rc">
-        <span class="micro">{m.diagnostics_title()}</span>
-        <p class="hint">{m.diagnostics_subtitle()}</p>
-      </div>
-      <DiagnoseRows checks={diagChecks} onfix={fixCheck} />
-      <!-- Client-only: install/standalone state can't come from /api/diagnostics, so this
-           row renders independently of the server snapshot's load/fail/empty state. -->
-      <PwaInstallRow />
-      {#if diagError}
-        <p class="hint err">{diagError}</p>
-      {/if}
-      <button type="button" class="run" disabled={diagBusy} onclick={rerunDiagnostics}>
-        {diagBusy ? m.common_loading() : m.diagnostics_rerun()}
-      </button>
+      <SettingsDiagnosePanel {initialDiagnostics} />
     </div>
   </div>
 </div>
@@ -1288,171 +946,6 @@
     color: var(--color-green);
     font-size: var(--fs-xl);
     line-height: 1;
-  }
-  .cur {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    border: 1px solid var(--color-line);
-    background: var(--color-inset);
-    padding: 8px 10px;
-    border-radius: 2px;
-  }
-  .cur code {
-    color: var(--color-amber);
-    font-size: var(--fs-base);
-    word-break: break-all;
-  }
-  .path-label {
-    margin-top: 4px;
-  }
-  .crumbs {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .up {
-    background: var(--color-inset);
-    border: 1px solid var(--color-line-bright);
-    color: var(--color-ink);
-    font: inherit;
-    font-size: var(--fs-lg);
-    line-height: 1;
-    padding: 5px 9px;
-    border-radius: 2px;
-    cursor: pointer;
-  }
-  .up:disabled {
-    opacity: 0.4;
-    cursor: default;
-  }
-  .here {
-    color: var(--color-ink-bright);
-    font-size: var(--fs-base);
-    word-break: break-all;
-  }
-  .list {
-    border: 1px solid var(--color-line);
-    background: var(--color-inset);
-    border-radius: 2px;
-    max-height: 280px;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-  }
-  .placeholder {
-    padding: 14px 12px;
-    color: var(--color-faint);
-    font-size: var(--fs-meta);
-    letter-spacing: 0.06em;
-  }
-  .row {
-    display: flex;
-    align-items: center;
-    gap: 9px;
-    background: transparent;
-    border: 0;
-    border-bottom: 1px solid var(--color-line);
-    color: var(--color-ink-bright);
-    font: inherit;
-    font-size: var(--fs-base);
-    text-align: left;
-    padding: 9px 11px;
-    cursor: pointer;
-  }
-  .row:last-child {
-    border-bottom: 0;
-  }
-  .row:hover {
-    background: var(--color-panel);
-  }
-  .ico {
-    opacity: 0.85;
-  }
-  .nm {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .chev {
-    color: var(--color-faint);
-  }
-  .err {
-    color: var(--color-red);
-    font-size: var(--fs-meta);
-    margin-top: 2px;
-  }
-  .run {
-    border: 1px solid var(--color-amber);
-    color: var(--color-amber);
-    background: transparent;
-    padding: 9px 14px;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    font: inherit;
-    font-size: var(--fs-meta);
-    cursor: pointer;
-    box-shadow: inset 0 0 18px -10px var(--color-amber);
-  }
-  .run:disabled {
-    opacity: 0.5;
-    cursor: default;
-    box-shadow: none;
-  }
-  /* Secondary/outline button — same shape as .run but uses the panel's neutral
-     line colour rather than amber, so it reads as a lower-priority action. */
-  .clone-trigger {
-    border: 1px solid var(--color-line-bright);
-    color: var(--color-ink);
-    background: var(--color-inset);
-    padding: 9px 14px;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    font: inherit;
-    font-size: var(--fs-meta);
-    cursor: pointer;
-  }
-  .clone-trigger:hover {
-    color: var(--color-ink-bright);
-    border-color: var(--color-ink);
-  }
-  .whatsnew-btn {
-    padding: 4px 8px;
-    vertical-align: middle;
-    margin-left: 6px;
-  }
-  .push {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-  .push .hint {
-    color: var(--color-faint);
-    font-size: var(--fs-meta);
-    margin: 0;
-  }
-  .cats {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    border: 0;
-    margin: 2px 0 0;
-    padding: 0;
-  }
-  .cats legend {
-    padding: 0;
-    margin-bottom: 4px;
-  }
-  .cat {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: var(--fs-base);
-    cursor: pointer;
-  }
-  .cat input {
-    cursor: pointer;
   }
   .rc {
     display: flex;
@@ -1638,85 +1131,6 @@
     text-transform: uppercase;
     color: var(--color-ink-bright);
   }
-  /* The theme switcher and high-contrast toggle live in the Settings dialog on
-     every viewport so the menu reads identically on mobile and desktop — desktop
-     additionally mirrors the theme switcher in the ActionBar for quick access. */
-  .theme-row,
-  .contrast-row {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-  .contrast-row .hint {
-    color: var(--color-faint);
-    font-size: var(--fs-meta);
-    margin: 0;
-  }
-  .theme-seg {
-    display: flex;
-    border: 1px solid var(--color-line-bright);
-    border-radius: 2px;
-    overflow: hidden;
-    align-self: flex-start;
-  }
-  .t-opt {
-    background: transparent;
-    border: 0;
-    border-left: 1px solid var(--color-line-bright);
-    color: var(--color-muted);
-    font-size: var(--fs-lg);
-    line-height: 1;
-    padding: 0 16px;
-    min-height: 44px;
-    cursor: pointer;
-  }
-  .t-opt:first-child {
-    border-left: 0;
-  }
-  .t-opt.on {
-    color: var(--color-amber);
-    background: var(--color-inset);
-  }
-  /* The about block — blurb plus the version / commit / repo rows — shows on
-     every viewport; desktop additionally surfaces the same metadata in the
-     ActionBar footer. */
-  .about {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    margin-top: 4px;
-    border-top: 1px solid var(--color-line);
-    padding-top: 12px;
-  }
-  .about .hint {
-    color: var(--color-faint);
-    font-size: var(--fs-meta);
-    margin: 0;
-  }
-  .about-grid {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 4px 14px;
-    margin: 0;
-  }
-  .about-grid dt {
-    color: var(--color-faint);
-    font-size: var(--fs-meta);
-    letter-spacing: 0.06em;
-  }
-  .about-grid dd {
-    margin: 0;
-    font-size: var(--fs-base);
-    color: var(--color-ink-bright);
-    word-break: break-all;
-  }
-  .about-grid a {
-    color: var(--color-amber);
-    text-decoration: none;
-  }
-  .about-grid a:hover {
-    text-decoration: underline;
-  }
 
   @media (max-width: 768px) {
     .overlay {
@@ -1730,17 +1144,6 @@
       max-height: none;
       border: 0;
       overflow: hidden;
-    }
-    /* Lift the list cap on mobile: the list flexes to fill the bounded panel
-       and stays the single scroll region (button pinned below), instead of a
-       capped list nested inside a separately-scrolling panel. */
-    .list {
-      max-height: none;
-    }
-    .row,
-    .up,
-    .run {
-      min-height: 44px;
     }
   }
 </style>

--- a/ui/src/lib/components/automation-settings/AutomationRepoFields.svelte
+++ b/ui/src/lib/components/automation-settings/AutomationRepoFields.svelte
@@ -1,0 +1,330 @@
+<script lang="ts">
+  import { untrack } from "svelte";
+  import { m } from "$lib/paraglide/messages";
+  import { repoConfig } from "$lib/reviews.svelte";
+  import { clampCap, clampCeiling, sanitizeLabel } from "../git-rail-drain";
+  import { getRepoRoles, getRepoCollaborators, putRepoRoles } from "$lib/api";
+  import { MODELS } from "$lib/types";
+  import { modelLabel } from "$lib/model-label";
+  import type { RepoRoles } from "$lib/types";
+
+  let {
+    repoPath,
+    autoDrain,
+  }: {
+    repoPath: string;
+    autoDrain: boolean;
+  } = $props();
+
+  // Drain config fields, seeded from stored config and re-seeded whenever the
+  // section becomes visible (drain turned on) or the repo changes.
+  // svelte-ignore state_referenced_locally
+  let drainCap = $state(repoConfig.maxAutoFor(repoPath));
+  // svelte-ignore state_referenced_locally
+  let drainLabel = $state(repoConfig.autoLabelFor(repoPath));
+  // svelte-ignore state_referenced_locally
+  let drainCeiling = $state(repoConfig.usageCeilingFor(repoPath));
+  $effect(() => {
+    // Re-seed the inputs when the repo changes or the drain section (re)appears.
+    // untrack the store reads so committing a field (which writes back to the
+    // store) never retriggers this effect and clobbers an in-flight edit.
+    const repo = repoPath;
+    if (!autoDrain) return;
+    untrack(() => {
+      drainCap = repoConfig.maxAutoFor(repo);
+      drainLabel = repoConfig.autoLabelFor(repo);
+      drainCeiling = repoConfig.usageCeilingFor(repo);
+    });
+  });
+
+  async function commitDrainCap() {
+    const n = clampCap(drainCap);
+    drainCap = n;
+    await repoConfig.setMaxAuto(repoPath, n);
+    drainCap = repoConfig.maxAutoFor(repoPath);
+  }
+  async function commitDrainLabel() {
+    const t = sanitizeLabel(drainLabel);
+    if (t === null) {
+      drainLabel = repoConfig.autoLabelFor(repoPath);
+      return;
+    }
+    drainLabel = t;
+    await repoConfig.setAutoLabel(repoPath, t);
+    drainLabel = repoConfig.autoLabelFor(repoPath);
+  }
+  async function commitDrainCeiling() {
+    const n = clampCeiling(drainCeiling);
+    drainCeiling = n;
+    await repoConfig.setUsageCeiling(repoPath, n);
+    drainCeiling = repoConfig.usageCeilingFor(repoPath);
+  }
+
+  // Repo responsibilities (.shepherd/roles.json): who reviews, who merges. Loaded
+  // lazily when the panel mounts / the repo changes — the herd reads the computed
+  // handoff off the cached git state, so this fetch is panel-only.
+  let roles = $state<RepoRoles>({ reviewer: null, merger: null });
+  let me = $state<string | null>(null);
+  let collaborators = $state<string[]>([]);
+  let collaboratorsUnavailable = $state(false);
+  let rolesError = $state<string | null>(null);
+  $effect(() => {
+    const repo = repoPath;
+    rolesError = null;
+    void (async () => {
+      try {
+        const [r, c] = await Promise.all([getRepoRoles(repo), getRepoCollaborators(repo)]);
+        if (repo !== repoPath) return; // repo switched mid-flight — drop stale result
+        roles = r.roles;
+        me = r.me ?? c.me;
+        collaborators = c.logins;
+        collaboratorsUnavailable = c.collaboratorsUnavailable;
+      } catch {
+        /* leave defaults; the free-text fallback still lets the user set roles */
+      }
+    })();
+  });
+
+  function normalizeLogin(v: string): string | null {
+    const t = v.trim().replace(/^@/, "");
+    return t || null;
+  }
+
+  // GitHub logins are case-insensitive — fold so a differently-cased stored login
+  // isn't treated as a distinct person (duplicate option / wrong "self" match).
+  const eqLogin = (a: string | null, b: string | null) =>
+    !!a && !!b && a.toLowerCase() === b.toLowerCase();
+
+  // Map a stored login onto the exact casing of its <option> so the dropdown
+  // reflects it — a casing-only difference (stored "Kai" vs me/collaborator "kai")
+  // would otherwise match no option and fall back to "— anyone / me —".
+  function optionValue(value: string | null): string {
+    if (!value) return "";
+    if (eqLogin(value, me)) return me ?? value;
+    return collaborators.find((c) => eqLogin(c, value)) ?? value;
+  }
+
+  async function setRole(role: "reviewer" | "merger", value: string | null) {
+    const prev = roles;
+    roles = { ...roles, [role]: value }; // optimistic
+    rolesError = null;
+    try {
+      const res = await putRepoRoles(repoPath, { [role]: value });
+      if (res.pushError) {
+        roles = prev; // push rejected (protected branch / auth) → revert + surface
+        rolesError = res.pushError;
+        return;
+      }
+      roles = res.roles;
+      if (res.me) me = res.me;
+    } catch (e) {
+      roles = prev;
+      rolesError = String((e as Error)?.message ?? e);
+    }
+  }
+</script>
+
+<!-- Default model: a repo-wide override of the global default (Settings → Session).
+     "Inherit" defers to the global setting; an explicit choice wins for both the
+     New-Task picker preselect and autonomous drain/autopilot spawns in this repo. -->
+<div class="drain-fields">
+  <label class="drain-field">
+    <span class="drain-label">{m.automation_default_model_label()}</span>
+    <select
+      class="num model-select"
+      aria-label={m.automation_default_model_label()}
+      value={repoConfig.defaultModelFor(repoPath)}
+      onchange={(e) =>
+        repoConfig.setDefaultModel(repoPath, (e.currentTarget as HTMLSelectElement).value)}
+    >
+      <option value="inherit">{m.automation_default_model_inherit()}</option>
+      <option value="auto">{m.settings_default_model_auto()}</option>
+      <option value="default">{m.newtask_model_default()}</option>
+      {#each MODELS as mdl (mdl)}
+        <option value={mdl}>{modelLabel(mdl)}</option>
+      {/each}
+    </select>
+  </label>
+  <div class="signoff-note">{m.automation_default_model_hint()}</div>
+</div>
+{#if autoDrain}
+  <div class="drain-fields">
+    <label class="drain-field">
+      <span class="drain-label">{m.drain_cap_label()}</span>
+      <input
+        class="num"
+        type="number"
+        min="1"
+        max="20"
+        bind:value={drainCap}
+        aria-label={m.drain_cap_label()}
+        onchange={commitDrainCap}
+      />
+    </label>
+    <label class="drain-field">
+      <span class="drain-label">{m.drain_label_label()}</span>
+      <input
+        class="num txt"
+        type="text"
+        bind:value={drainLabel}
+        aria-label={m.drain_label_label()}
+        onchange={commitDrainLabel}
+        onblur={commitDrainLabel}
+      />
+    </label>
+    <label class="drain-field">
+      <span class="drain-label">{m.drain_ceiling_label()}</span>
+      <input
+        class="num"
+        type="number"
+        min="0"
+        max="100"
+        bind:value={drainCeiling}
+        aria-label={m.drain_ceiling_label()}
+        onchange={commitDrainCeiling}
+      />
+    </label>
+  </div>
+{/if}
+
+<!-- Repo responsibilities: reviewer + merger (committed to .shepherd/roles.json) -->
+<div class="auto-group" id="repo-roles">{m.automation_group_roles()}</div>
+{#snippet roleRow(label: string, role: "reviewer" | "merger", value: string | null)}
+  <div class="auto-row">
+    <div class="auto-meta">
+      <div class="auto-name">{label}</div>
+    </div>
+    {#if collaboratorsUnavailable}
+      <input
+        class="role-input"
+        type="text"
+        placeholder={m.roles_freetext_placeholder()}
+        value={value ?? ""}
+        aria-label={label}
+        onchange={(e) => setRole(role, normalizeLogin(e.currentTarget.value))}
+      />
+    {:else}
+      <select
+        class="role-select"
+        aria-label={label}
+        value={optionValue(value)}
+        onchange={(e) => setRole(role, e.currentTarget.value || null)}
+      >
+        <option value="">{m.roles_unset_option()}</option>
+        {#if me}<option value={me}>{m.roles_self_option()} (@{me})</option>{/if}
+        {#each collaborators.filter((c) => !eqLogin(c, me)) as login (login)}
+          <option value={login}>@{login}</option>
+        {/each}
+        {#if value && !eqLogin(value, me) && !collaborators.some((c) => eqLogin(c, value))}
+          <option {value}>@{value}</option>
+        {/if}
+      </select>
+    {/if}
+  </div>
+{/snippet}
+{@render roleRow(m.roles_reviewer_label(), "reviewer", roles.reviewer)}
+{@render roleRow(m.roles_merger_label(), "merger", roles.merger)}
+<div class="roles-note">
+  {#if rolesError}
+    <span class="roles-err">{m.roles_push_failed()}: {rolesError}</span>
+  {:else}
+    {m.automation_roles_hint()}
+  {/if}
+</div>
+
+<style>
+  /* Generic per-row layout classes — duplicated from the parent (every toggle row
+     there uses them); the role rows here reuse the same conventions. */
+  .auto-group {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-amber);
+    padding: 8px 12px 4px;
+  }
+  .auto-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 12px;
+    border-top: 1px solid var(--color-line);
+  }
+  .auto-meta {
+    min-width: 0;
+  }
+  .auto-name {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-mono);
+    font-size: var(--fs-base);
+    color: var(--color-ink-bright);
+  }
+  .drain-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 12px 12px 22px;
+    border-top: 1px solid var(--color-line);
+    background: var(--color-panel);
+  }
+  .drain-field {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .drain-label {
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    white-space: nowrap;
+  }
+  .num {
+    flex: 0 0 auto;
+    width: 90px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font-family: var(--font-mono);
+    font-size: var(--fs-base);
+    padding: 3px 6px;
+    text-align: right;
+  }
+  /* The label is free text (e.g. "shepherd:auto") that overflows the fixed
+     numeric width on narrow screens — let it grow with the row and read from
+     the start instead of clipping the left side under right-alignment. */
+  .num.txt {
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
+    text-align: left;
+  }
+  .role-select,
+  .role-input {
+    flex: 0 0 auto;
+    width: 140px;
+    max-width: 50%;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    padding: 3px 6px;
+  }
+  .roles-note {
+    font-size: var(--fs-meta);
+    color: var(--color-faint);
+    padding: 6px 12px 12px;
+  }
+  .roles-err {
+    color: var(--color-red);
+  }
+  .signoff-note {
+    font-size: var(--fs-meta);
+    color: var(--color-faint);
+    padding: 0 12px 6px;
+  }
+</style>

--- a/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
+++ b/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
@@ -1,0 +1,268 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import InfoTip from "../InfoTip.svelte";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import { modelLabel } from "$lib/model-label";
+  import { MODELS, type SandboxProfile } from "$lib/types";
+
+  let {
+    planGate = $bindable(),
+    research = $bindable(),
+    autopilot = $bindable(),
+    model = $bindable(),
+    sandboxProfile = $bindable(),
+    onPlanGateTouched,
+    onAutopilotTouched,
+    onModelTouched,
+    planGateLoading,
+    autopilotLoading,
+    autopilotDefault,
+    repoPath,
+    relaunch,
+    fableAvailable,
+  }: {
+    planGate: boolean;
+    research: boolean;
+    autopilot: boolean;
+    model: string;
+    sandboxProfile: "default" | SandboxProfile;
+    // touched flags live in the parent; the child only signals a manual change
+    // (write-only `$bindable` would trip no-useless-assignment here)
+    onPlanGateTouched: () => void;
+    onAutopilotTouched: () => void;
+    onModelTouched: () => void;
+    planGateLoading: boolean;
+    autopilotLoading: boolean;
+    autopilotDefault: boolean;
+    repoPath: string;
+    relaunch: boolean;
+    fableAvailable: boolean;
+  } = $props();
+</script>
+
+<!-- Per-task run settings. Plan gate gets its own full-width row so its explainer
+     reads on one line; Model + Sandbox share a 50/50 row beneath. -->
+<div class="opts-row">
+  <!-- Each toggle's long explainer now lives behind an InfoTip "i" rather than a
+       wrapped hint paragraph — keeps this stack of options compact, which matters
+       most on the phone sheet. The InfoTip is a sibling of the <label> (not nested
+       inside it) so a tap on the "i" never toggles the checkbox. -->
+  <div class="pg-row">
+    <label class="plan-gate" use:coachTarget={"plan-gate"}>
+      <input
+        type="checkbox"
+        bind:checked={planGate}
+        onchange={() => {
+          onPlanGateTouched();
+          if (planGate) research = false;
+        }}
+        disabled={planGateLoading}
+      />
+      <span class="pg-label">{m.newtask_plan_gate_label()}</span>
+    </label>
+    {#if planGateLoading}
+      <span class="pg-loading">{m.common_loading()}</span>
+    {/if}
+    <InfoTip
+      text={m.newtask_plan_gate_hint()}
+      label={m.newtask_info_aria({ topic: m.newtask_plan_gate_label() })}
+    />
+  </div>
+
+  <!-- Relaunch intentionally CARRIES the original session's autopilot value
+       (server-side, src/service.ts relaunch()), so RelaunchOverrides has no
+       autopilotEnabled field and the override wouldn't take effect here.
+       Hide the control in relaunch so it never implies an override it can't honor. -->
+  {#if !relaunch}
+    <div class="pg-row">
+      <label class="plan-gate" use:coachTarget={"task-autopilot"}>
+        <input
+          type="checkbox"
+          bind:checked={autopilot}
+          onchange={() => onAutopilotTouched()}
+          disabled={autopilotLoading}
+        />
+        <span class="pg-label">{m.newtask_autopilot_label()}</span>
+      </label>
+      <!-- The repo's standing default, shown alongside so it's clear how this repo
+           normally handles it — the checkbox is seeded from it on open, so unchecking
+           here is a visible, deliberate opt-out for this one task. -->
+      {#if autopilotLoading}
+        <span class="pg-loading">{m.common_loading()}</span>
+      {:else if repoPath}
+        <span class="repo-default" class:on={autopilotDefault}>
+          {autopilotDefault
+            ? m.newtask_autopilot_repo_default_on()
+            : m.newtask_autopilot_repo_default_off()}
+        </span>
+      {/if}
+      <InfoTip
+        text={m.newtask_autopilot_hint()}
+        label={m.newtask_info_aria({ topic: m.newtask_autopilot_label() })}
+      />
+    </div>
+  {/if}
+
+  <div class="pg-row">
+    <label class="plan-gate">
+      <input
+        type="checkbox"
+        bind:checked={research}
+        onchange={() => {
+          if (research) {
+            planGate = false;
+            // pin touched so a later repo switch doesn't re-seed/re-enable plan-gate while research is active
+            onPlanGateTouched();
+            autopilot = false;
+            // pin touched so a later repo switch doesn't re-seed/re-enable autopilot while research is active
+            onAutopilotTouched();
+            if (sandboxProfile === "autonomous") sandboxProfile = "default";
+          }
+        }}
+      />
+      <span class="pg-label">{m.newtask_research_label()}</span>
+    </label>
+    <InfoTip
+      text={m.newtask_research_hint()}
+      label={m.newtask_info_aria({ topic: m.newtask_research_label() })}
+    />
+  </div>
+
+  <div class="run-config">
+    <div class="model-field" use:coachTarget={"model-1m-context"}>
+      <label class="micro" for="nt-model">{m.newtask_model_label()}</label>
+      <select id="nt-model" bind:value={model} onchange={() => onModelTouched()}>
+        <option value="default">{m.newtask_model_default()}</option>
+        {#each MODELS as mdl (mdl)}
+          {#if mdl !== "fable" || fableAvailable}
+            <option value={mdl}>{modelLabel(mdl)}</option>
+          {/if}
+        {/each}
+      </select>
+      {#if !fableAvailable}
+        <p class="micro">{m.newtask_fable_unavailable()}</p>
+      {/if}
+    </div>
+
+    <div class="model-field">
+      <label class="micro" for="nt-sandbox">{m.newtask_sandbox_label()}</label>
+      <select id="nt-sandbox" bind:value={sandboxProfile} title={m.newtask_sandbox_hint()}>
+        <option value="default">{m.newtask_sandbox_default()}</option>
+        <option value="trusted">{m.sandbox_profile_trusted()}</option>
+        <option value="standard">{m.sandbox_profile_standard()}</option>
+        <option value="autonomous" disabled={research}>{m.sandbox_profile_autonomous()}</option>
+      </select>
+      {#if research}
+        <span class="pg-hint">{m.newtask_research_sandbox_note()}</span>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  /* Field primitives shared with the parent composer — duplicated here so the moved
+     <input>/<select>s keep their styling (the parent keeps its copy for its fields). */
+  input,
+  select {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    padding: 8px 10px;
+    border-radius: 2px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  select {
+    appearance: none;
+    cursor: pointer;
+  }
+  input:focus,
+  select:focus {
+    outline: none;
+    border-color: var(--color-line-bright);
+  }
+  /* Shared utility — duplicated (the parent keeps its copy for its own labels). */
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-top: 6px;
+  }
+  .opts-row {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 10px;
+  }
+  /* One toggle: the label (checkbox + name) plus its trailing InfoTip / repo-default
+     badge, laid out on a single baseline-centered line. */
+  .pg-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .plan-gate {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+  }
+  .pg-loading {
+    flex: 0 0 auto;
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+  }
+  /* Standing repo default for autopilot — a quiet pill; amber when "on" to echo the
+     checkbox accent (green is reserved for actionable-complete per the design system). */
+  .repo-default {
+    flex: 0 0 auto;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.04em;
+    color: var(--color-muted);
+    border: 1px solid var(--color-line);
+    border-radius: 999px;
+    padding: 1px 8px;
+    white-space: nowrap;
+  }
+  .repo-default.on {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
+  }
+  .run-config {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+  }
+  .model-field {
+    flex: 1 1 0;
+    min-width: 120px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .model-field .micro {
+    margin-top: 0;
+  }
+  .plan-gate input {
+    width: auto;
+    flex: 0 0 auto;
+    accent-color: var(--color-amber);
+  }
+  .plan-gate:has(input:disabled) {
+    cursor: progress;
+    opacity: 0.6;
+  }
+  .pg-label {
+    color: var(--color-ink-bright);
+    font-size: var(--fs-base);
+  }
+  .pg-hint {
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+  }
+</style>

--- a/ui/src/lib/components/repo-switcher/RepoChipTelemetry.svelte
+++ b/ui/src/lib/components/repo-switcher/RepoChipTelemetry.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+  import type { DrainStatus, QueuedItem } from "$lib/types";
+  import type { RepoChip } from "../queue-strip";
+  import { m } from "$lib/paraglide/messages";
+  import { getDrainQueue } from "$lib/api";
+  import { basename } from "../learnings-drawer";
+  import { queueOpenable, pausedText } from "../queue-strip";
+
+  let {
+    chip,
+    onlearnings,
+  }: {
+    chip: RepoChip;
+    // open the learnings drawer for a repo
+    onlearnings?: (repoPath: string) => void;
+  } = $props();
+
+  const d = $derived(chip.drain);
+
+  // ── inline queue expansion (mirrors QueueStrip toggle/loading/failed) ───────
+  // At most one repo's queue is expanded at a time, fetched fresh on open.
+  let expandedRepo = $state<string | null>(null);
+  let queueItems = $state<QueuedItem[]>([]);
+  let loading = $state(false);
+  let failed = $state(false);
+
+  async function toggleQueue(d: DrainStatus) {
+    if (expandedRepo === d.repoPath) {
+      expandedRepo = null;
+      return;
+    }
+    const repo = d.repoPath;
+    expandedRepo = repo;
+    queueItems = [];
+    failed = false;
+    loading = true;
+    try {
+      const q = await getDrainQueue(repo);
+      if (expandedRepo === repo) queueItems = q; // ignore a stale (since-switched) response
+    } catch {
+      if (expandedRepo === repo) failed = true;
+    } finally {
+      if (expandedRepo === repo) loading = false;
+    }
+  }
+
+  function onWindowKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") expandedRepo = null;
+  }
+
+  // A whitespace/special-char-safe DOM id for the inline queue panel, so the toggle's
+  // aria-controls (an IDREF — space-separated, so a repoPath with whitespace would parse
+  // as multiple tokens) and the panel id stay valid. Only one queue is expanded at a
+  // time, so a cross-repo collision after sanitizing can't occur.
+  const queueId = (repoPath: string) => `rs-queue-${repoPath.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+</script>
+
+<svelte:window onkeydown={onWindowKeydown} />
+
+<div class="rs-tele">
+  {#if d}
+    <span class="rs-inflight">{m.drain_inflight({ count: d.inFlight, max: d.max })}</span>
+    {#if queueOpenable(d)}
+      {@const repo = basename(d.repoPath)}
+      <button
+        type="button"
+        class="rs-queued rs-queued-btn"
+        aria-expanded={expandedRepo === d.repoPath}
+        aria-controls={queueId(d.repoPath)}
+        aria-label={m.drain_queue_open_aria({ count: d.queued, repo })}
+        onclick={() => toggleQueue(d)}
+      >
+        {m.drain_queued({ count: d.queued })}
+      </button>
+    {:else}
+      <span class="rs-queued">{m.drain_queued({ count: d.queued })}</span>
+    {/if}
+  {/if}
+
+  {#if chip.insights > 0 || chip.curate > 0}
+    <button
+      type="button"
+      class="rs-insights"
+      title={m.learnings_badge_tip()}
+      aria-label={chip.insights > 0
+        ? m.learnings_open_aria({ count: chip.insights })
+        : m.learnings_open_curate_aria({ count: chip.curate })}
+      onclick={() => onlearnings?.(chip.repoPath)}
+    >
+      <span class="rs-insights-icon" aria-hidden="true">✦</span>{#if chip.insights > 0}<span
+          class="rs-insights-n">{chip.insights}</span
+        >{/if}
+    </button>
+  {/if}
+
+  {#if d?.paused}
+    <span class="rs-pause" title={pausedText(d)}>{pausedText(d)}</span>
+  {/if}
+</div>
+
+{#if d && expandedRepo === d.repoPath}
+  {@const repo = basename(d.repoPath)}
+  <div class="rs-queue" id={queueId(d.repoPath)}>
+    <div class="rs-queue-head">{m.drain_queue_title({ repo })}</div>
+    {#if loading}
+      <div class="rs-queue-state">{m.common_loading()}</div>
+    {:else if failed}
+      <div class="rs-queue-state rs-queue-fail">{m.drain_queue_error()}</div>
+    {:else if queueItems.length === 0}
+      <div class="rs-queue-state">{m.drain_queue_empty()}</div>
+    {:else}
+      <ul class="rs-queue-list">
+        {#each queueItems as it (it.number)}
+          <li>
+            <!-- eslint-disable svelte/no-navigation-without-resolve -- external forge URL, not an app route -->
+            <a
+              class="rs-queue-item"
+              href={it.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={m.drain_queue_item_aria({ number: it.number })}
+            >
+              <span class="rs-queue-num">#{it.number}</span>
+              <span class="rs-queue-title">{it.title}</span>
+            </a>
+            <!-- eslint-enable svelte/no-navigation-without-resolve -->
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  /* active-repo / lone-repo detail line */
+  .rs-tele {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .rs-inflight {
+    color: var(--color-ink);
+    font-variant-numeric: tabular-nums;
+  }
+  .rs-queued {
+    color: var(--color-faint);
+    font-variant-numeric: tabular-nums;
+  }
+  .rs-queued-btn {
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+  }
+  .rs-queued-btn:hover,
+  .rs-queued-btn:focus-visible {
+    color: var(--color-ink-bright);
+  }
+  .rs-insights {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font: inherit;
+    letter-spacing: inherit;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    color: var(--color-faint);
+  }
+  .rs-insights:hover,
+  .rs-insights:focus-visible {
+    color: var(--color-ink-bright);
+  }
+  .rs-insights-n {
+    font-variant-numeric: tabular-nums;
+  }
+  /* a paused drain is the loud thing in the detail line: red, reason inline */
+  .rs-pause {
+    color: var(--color-red);
+    background: color-mix(in oklab, var(--color-red) 12%, transparent);
+    padding: 1px 6px;
+    border-radius: 2px;
+    text-transform: none;
+    letter-spacing: 0.04em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: min(320px, 50vw);
+  }
+
+  /* inline queue expansion — chrome mirrors QueueStrip's .qs-pop, but flows
+     inline below the detail line (not a floating popover) */
+  .rs-queue {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+    width: min(360px, 90vw);
+    max-height: 50vh;
+    overflow: hidden;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+  }
+  .rs-queue-head {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .rs-queue-state {
+    font-size: var(--fs-base);
+    color: var(--color-muted);
+  }
+  .rs-queue-fail {
+    color: var(--color-red);
+  }
+  .rs-queue-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    overflow-y: auto;
+  }
+  .rs-queue-item {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 3px 4px;
+    border-radius: 2px;
+    color: var(--color-ink);
+    text-decoration: none;
+    font-size: var(--fs-base);
+  }
+  .rs-queue-item:hover,
+  .rs-queue-item:focus-visible {
+    background: var(--color-panel);
+    color: var(--color-ink-bright);
+  }
+  .rs-queue-num {
+    color: var(--color-faint);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+  .rs-queue-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Coarse pointers: ≥44px tap targets on the inline action buttons
+     (mirrors the QueueStrip / TopBar coarse-pointer pattern). */
+  @media (pointer: coarse) {
+    .rs-queued-btn,
+    .rs-insights {
+      min-height: 44px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 44px;
+    }
+  }
+</style>

--- a/ui/src/lib/components/settings/SettingsDevicePanel.svelte
+++ b/ui/src/lib/components/settings/SettingsDevicePanel.svelte
@@ -1,0 +1,398 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import {
+    pushState,
+    enablePush,
+    disablePush,
+    getPushCategories,
+    setPushCategories,
+    type PushStatus,
+    type PushCategories,
+  } from "$lib/push";
+  import { theme, type ThemePref } from "$lib/theme.svelte";
+  import { REPO, REPO_URL, sha, version, commitUrl } from "$lib/build-info";
+  import ThemeIcon from "$lib/components/ThemeIcon.svelte";
+  import { m } from "$lib/paraglide/messages";
+
+  let { onwhatsnew }: { onwhatsnew?: () => void } = $props();
+
+  // Theme picker — mobile only: the desktop switcher lives in the ActionBar,
+  // but on phones the ActionBar hides it and it was dropped from the top bar,
+  // so Settings (reachable via the gear from any mobile screen) is its home.
+  const THEMES: { pref: ThemePref; icon: "moon" | "sun" | "auto"; label: () => string }[] = [
+    { pref: "dark", icon: "moon", label: m.theme_dark },
+    { pref: "light", icon: "sun", label: m.theme_light },
+    { pref: "system", icon: "auto", label: m.theme_system },
+  ];
+
+  let push = $state<PushStatus>({ supported: false, permission: "unsupported", subscribed: false });
+  let pushBusy = $state(false);
+  let categories = $state<PushCategories>({ agent: true, reviews: true, ci: true });
+
+  // Category metadata drives the checkbox list; keys index into `categories`.
+  const categoryRows: { key: keyof PushCategories; label: () => string }[] = [
+    { key: "agent", label: () => m.settings_push_cat_agent() },
+    { key: "reviews", label: () => m.settings_push_cat_reviews() },
+    { key: "ci", label: () => m.settings_push_cat_ci() },
+  ];
+
+  async function refreshPush() {
+    push = await pushState();
+    if (push.subscribed) categories = await getPushCategories();
+  }
+
+  async function toggleCategory(key: keyof PushCategories) {
+    const prev = categories;
+    const next = { ...categories, [key]: !categories[key] };
+    categories = next; // optimistic; server is authoritative at send time
+    if (!(await setPushCategories(next))) categories = prev; // persist failed → revert
+  }
+
+  async function togglePush() {
+    if (pushBusy) return;
+    pushBusy = true;
+    try {
+      if (push.subscribed) await disablePush();
+      else await enablePush();
+      await refreshPush();
+    } finally {
+      pushBusy = false;
+    }
+  }
+
+  onMount(async () => {
+    await refreshPush();
+  });
+</script>
+
+<div class="theme-row">
+  <span class="micro">{m.actionbar_theme_group_aria()}</span>
+  <div class="theme-seg" role="group" aria-label={m.actionbar_theme_group_aria()}>
+    {#each THEMES as t (t.pref)}
+      <button
+        type="button"
+        class="t-opt"
+        class:on={theme.pref === t.pref}
+        aria-pressed={theme.pref === t.pref}
+        aria-label={m.actionbar_theme_option({ label: t.label() })}
+        onclick={() => theme.setPref(t.pref)}><ThemeIcon icon={t.icon} /></button
+      >
+    {/each}
+  </div>
+</div>
+<div class="contrast-row">
+  <span class="micro">{m.settings_contrast_title()}</span>
+  <p class="hint">{m.settings_contrast_hint()}</p>
+  <button
+    type="button"
+    class="toggle"
+    role="switch"
+    aria-checked={theme.contrast}
+    onclick={() => theme.toggleContrast()}
+  >
+    <span class="track" class:on={theme.contrast}><span class="knob"></span></span>
+    <span class="state"
+      >{theme.contrast ? m.settings_contrast_on() : m.settings_contrast_off()}</span
+    >
+  </button>
+</div>
+<div class="rc">
+  <span class="micro">{m.settings_colorblind_title()}</span>
+  <p class="hint">{m.settings_colorblind_hint()}</p>
+  <button
+    type="button"
+    class="toggle"
+    role="switch"
+    aria-checked={theme.colorblind}
+    onclick={() => theme.toggleColorblind()}
+  >
+    <span class="track" class:on={theme.colorblind}><span class="knob"></span></span>
+    <span class="state"
+      >{theme.colorblind ? m.settings_colorblind_on() : m.settings_colorblind_off()}</span
+    >
+  </button>
+</div>
+<div class="push">
+  <span class="micro">{m.settings_push_title()}</span>
+  {#if !push.supported}
+    <p class="hint">{m.settings_push_unsupported()}</p>
+  {:else if push.permission === "denied"}
+    <p class="hint">{m.settings_push_denied()}</p>
+  {:else}
+    <button type="button" class="run" disabled={pushBusy} onclick={togglePush}>
+      {#if pushBusy}…{:else if push.subscribed}{m.settings_push_disable()}{:else}{m.settings_push_enable()}{/if}
+    </button>
+    {#if push.subscribed}
+      <fieldset class="cats">
+        <legend class="micro">{m.settings_push_cat_title()}</legend>
+        {#each categoryRows as row (row.key)}
+          <label class="cat">
+            <input
+              type="checkbox"
+              checked={categories[row.key]}
+              onchange={() => toggleCategory(row.key)}
+            />
+            <span>{row.label()}</span>
+          </label>
+        {/each}
+      </fieldset>
+    {/if}
+  {/if}
+</div>
+<div class="about">
+  <span class="micro">{m.settings_about_title()}</span>
+  <p class="hint">{m.settings_about_blurb()}</p>
+  <dl class="about-grid">
+    <dt>{m.settings_about_version()}</dt>
+    <dd>
+      v{version}
+      <button type="button" class="clone-trigger whatsnew-btn" onclick={() => onwhatsnew?.()}
+        >{m.whatsnew_open()}</button
+      >
+    </dd>
+    <dt>{m.settings_about_commit()}</dt>
+    <dd>
+      <a
+        href={commitUrl}
+        target="_blank"
+        rel="external noreferrer noopener"
+        title={m.actionbar_commit_title({ sha })}>{sha}</a
+      >
+    </dd>
+    <dt>{m.settings_about_repo()}</dt>
+    <dd>
+      <a
+        href={REPO_URL}
+        target="_blank"
+        rel="external noreferrer noopener"
+        title={m.actionbar_repo_link({ repo: REPO })}>{REPO}</a
+      >
+    </dd>
+  </dl>
+</div>
+
+<style>
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .run {
+    border: 1px solid var(--color-amber);
+    color: var(--color-amber);
+    background: transparent;
+    padding: 9px 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: var(--fs-meta);
+    cursor: pointer;
+    box-shadow: inset 0 0 18px -10px var(--color-amber);
+  }
+  .run:disabled {
+    opacity: 0.5;
+    cursor: default;
+    box-shadow: none;
+  }
+  /* Secondary/outline button — same shape as .run but uses the panel's neutral
+     line colour rather than amber, so it reads as a lower-priority action. */
+  .clone-trigger {
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-ink);
+    background: var(--color-inset);
+    padding: 9px 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: var(--fs-meta);
+    cursor: pointer;
+  }
+  .clone-trigger:hover {
+    color: var(--color-ink-bright);
+    border-color: var(--color-ink);
+  }
+  .whatsnew-btn {
+    padding: 4px 8px;
+    vertical-align: middle;
+    margin-left: 6px;
+  }
+  .push {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .push .hint {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    margin: 0;
+  }
+  .cats {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    border: 0;
+    margin: 2px 0 0;
+    padding: 0;
+  }
+  .cats legend {
+    padding: 0;
+    margin-bottom: 4px;
+  }
+  .cat {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: var(--fs-base);
+    cursor: pointer;
+  }
+  .cat input {
+    cursor: pointer;
+  }
+  .rc {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .rc .hint {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    margin: 0;
+  }
+  .toggle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    align-self: flex-start;
+    background: transparent;
+    border: 0;
+    padding: 4px 0;
+    cursor: pointer;
+    font: inherit;
+    min-height: 44px;
+  }
+  .toggle:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .track {
+    position: relative;
+    width: 38px;
+    height: 20px;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    background: var(--color-inset);
+    transition: background 0.12s;
+  }
+  .track.on {
+    background: color-mix(in srgb, var(--color-ink) 22%, transparent);
+    border-color: var(--color-line-bright);
+  }
+  .knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--color-muted);
+    transition:
+      transform 0.12s,
+      background 0.12s;
+  }
+  .track.on .knob {
+    transform: translateX(18px);
+    background: var(--color-ink-bright);
+  }
+  .toggle .state {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-ink-bright);
+  }
+  /* The theme switcher and high-contrast toggle live in the Settings dialog on
+     every viewport so the menu reads identically on mobile and desktop — desktop
+     additionally mirrors the theme switcher in the ActionBar for quick access. */
+  .theme-row,
+  .contrast-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .contrast-row .hint {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    margin: 0;
+  }
+  .theme-seg {
+    display: flex;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    overflow: hidden;
+    align-self: flex-start;
+  }
+  .t-opt {
+    background: transparent;
+    border: 0;
+    border-left: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    font-size: var(--fs-lg);
+    line-height: 1;
+    padding: 0 16px;
+    min-height: 44px;
+    cursor: pointer;
+  }
+  .t-opt:first-child {
+    border-left: 0;
+  }
+  .t-opt.on {
+    color: var(--color-amber);
+    background: var(--color-inset);
+  }
+  /* The about block — blurb plus the version / commit / repo rows — shows on
+     every viewport; desktop additionally surfaces the same metadata in the
+     ActionBar footer. */
+  .about {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 4px;
+    border-top: 1px solid var(--color-line);
+    padding-top: 12px;
+  }
+  .about .hint {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    margin: 0;
+  }
+  .about-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 14px;
+    margin: 0;
+  }
+  .about-grid dt {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.06em;
+  }
+  .about-grid dd {
+    margin: 0;
+    font-size: var(--fs-base);
+    color: var(--color-ink-bright);
+    word-break: break-all;
+  }
+  .about-grid a {
+    color: var(--color-amber);
+    text-decoration: none;
+  }
+  .about-grid a:hover {
+    text-decoration: underline;
+  }
+
+  @media (max-width: 768px) {
+    .run {
+      min-height: 44px;
+    }
+  }
+</style>

--- a/ui/src/lib/components/settings/SettingsDiagnosePanel.svelte
+++ b/ui/src/lib/components/settings/SettingsDiagnosePanel.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import { onMount, untrack } from "svelte";
+  import { getDiagnostics, fixDiagnostic } from "$lib/api";
+  import { type DiagnosticCheck } from "$lib/types";
+  import DiagnoseRows from "$lib/components/DiagnoseRows.svelte";
+  import PwaInstallRow from "$lib/components/PwaInstallRow.svelte";
+  import { toasts } from "$lib/toasts.svelte";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    initialDiagnostics = null,
+  }: {
+    /** Pre-seeded diagnostics checks from the store; loaded fresh on tab open if absent. */
+    initialDiagnostics?: DiagnosticCheck[] | null;
+  } = $props();
+
+  // Diagnose tab — local checks + re-run state.
+  // untrack: initialDiagnostics is intentionally only read once as the seed value.
+  let diagChecks = $state<DiagnosticCheck[] | null>(untrack(() => initialDiagnostics ?? null));
+  let diagBusy = $state(false);
+  let diagError = $state<string | null>(null);
+
+  async function rerunDiagnostics() {
+    if (diagBusy) return;
+    diagBusy = true;
+    diagError = null;
+    try {
+      const snap = await getDiagnostics(true);
+      diagChecks = snap.checks;
+    } catch {
+      diagError = m.diagnostics_rerun_error();
+    } finally {
+      diagBusy = false;
+    }
+  }
+
+  // One-click fix: run the check's remediation server-side, re-render from the
+  // re-probed snapshot. Fail closed on two levels: a non-2xx surfaces a persistent,
+  // deduped failure toast (and rethrows so DiagnoseRows clears busy); a 2xx whose
+  // re-probe shows the target check STILL not ok (the command exited 0 but didn't
+  // clear it) surfaces a persistent "unresolved" toast — never a green success.
+  async function fixCheck(checkId: string) {
+    try {
+      const snap = await fixDiagnostic(checkId);
+      diagChecks = snap.checks;
+      const cleared = snap.checks.find((c) => c.id === checkId)?.state === "ok";
+      if (cleared) {
+        toasts.info(m.diagnostics_fix_success(), { duration: 3000 });
+      } else {
+        toasts.info(m.diagnostics_fix_unresolved(), {
+          duration: null,
+          alert: true,
+          key: `diagnose-fix:${checkId}`,
+        });
+      }
+    } catch {
+      toasts.info(m.diagnostics_fix_failed(), {
+        duration: null,
+        alert: true,
+        key: `diagnose-fix:${checkId}`,
+      });
+      throw new Error("fix failed");
+    }
+  }
+
+  onMount(async () => {
+    // Seed diagnose tab: if no pre-seeded checks from the store, fetch once on mount.
+    if (diagChecks === null) {
+      try {
+        const snap = await getDiagnostics();
+        diagChecks = snap.checks;
+      } catch {
+        // diagnostics unavailable — panel shows empty state gracefully
+      }
+    }
+  });
+</script>
+
+<div class="rc">
+  <span class="micro">{m.diagnostics_title()}</span>
+  <p class="hint">{m.diagnostics_subtitle()}</p>
+</div>
+<DiagnoseRows checks={diagChecks} onfix={fixCheck} />
+<!-- Client-only: install/standalone state can't come from /api/diagnostics, so this
+     row renders independently of the server snapshot's load/fail/empty state. -->
+<PwaInstallRow />
+{#if diagError}
+  <p class="hint err">{diagError}</p>
+{/if}
+<button type="button" class="run" disabled={diagBusy} onclick={rerunDiagnostics}>
+  {diagBusy ? m.common_loading() : m.diagnostics_rerun()}
+</button>
+
+<style>
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .err {
+    color: var(--color-red);
+    font-size: var(--fs-meta);
+    margin-top: 2px;
+  }
+  .run {
+    border: 1px solid var(--color-amber);
+    color: var(--color-amber);
+    background: transparent;
+    padding: 9px 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: var(--fs-meta);
+    cursor: pointer;
+    box-shadow: inset 0 0 18px -10px var(--color-amber);
+  }
+  .run:disabled {
+    opacity: 0.5;
+    cursor: default;
+    box-shadow: none;
+  }
+  .rc {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .rc .hint {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    margin: 0;
+  }
+
+  @media (max-width: 768px) {
+    .run {
+      min-height: 44px;
+    }
+  }
+</style>

--- a/ui/src/lib/components/settings/SettingsWorkspacePanel.svelte
+++ b/ui/src/lib/components/settings/SettingsWorkspacePanel.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { getSettings, listDirs, putSettings } from "$lib/api";
+  import { type DirListing } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    onclone,
+    onfork,
+    onsaved,
+    onclose,
+  }: {
+    onclone?: () => void;
+    onfork?: () => void;
+    onsaved?: (root: string) => void;
+    onclose?: () => void;
+  } = $props();
+
+  let currentRoot = $state(""); // the persisted root (display form)
+  let listing = $state<DirListing | null>(null);
+  let loading = $state(false);
+  let saving = $state(false);
+  let error = $state<string | null>(null);
+
+  async function browse(path?: string) {
+    loading = true;
+    error = null;
+    try {
+      listing = await listDirs(path);
+    } catch (e) {
+      error = e instanceof Error ? e.message : "failed to list directory";
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(async () => {
+    try {
+      const s = await getSettings();
+      currentRoot = s.repoRootDisplay;
+      await browse(s.repoRoot);
+    } catch {
+      await browse();
+    }
+  });
+
+  const isCurrent = $derived(
+    listing != null && currentRoot !== "" && listing.display === currentRoot,
+  );
+
+  async function useThisFolder() {
+    if (!listing || saving) return;
+    saving = true;
+    error = null;
+    try {
+      const s = await putSettings(listing.path);
+      currentRoot = s.repoRootDisplay;
+      onsaved?.(s.repoRoot);
+      onclose?.();
+    } catch (e) {
+      error = e instanceof Error ? e.message : "failed to save";
+      saving = false;
+    }
+  }
+</script>
+
+<div class="cur">
+  <span class="micro">{m.settings_current_root_label()}</span>
+  <code>{currentRoot || "—"}</code>
+</div>
+
+<span class="micro path-label">{m.settings_browse_label()}</span>
+<div class="crumbs">
+  <button
+    type="button"
+    class="up"
+    disabled={!listing?.parent || loading}
+    onclick={() => listing?.parent && browse(listing.parent)}
+    title={m.settings_up_level()}
+  >
+    ↑
+  </button>
+  <code class="here">{listing?.display ?? "…"}</code>
+</div>
+
+<div class="list">
+  {#if loading}
+    <div class="placeholder">{m.settings_loading()}</div>
+  {:else if listing && listing.entries.length === 0}
+    <div class="placeholder">{m.settings_no_subfolders()}</div>
+  {:else if listing}
+    {#each listing.entries as e (e.path)}
+      <button type="button" class="row" onclick={() => browse(e.path)}>
+        <span class="ico">▸</span><span class="nm">{e.name}</span>
+        <span class="chev">›</span>
+      </button>
+    {/each}
+  {/if}
+</div>
+
+{#if error}<div class="err">{error}</div>{/if}
+
+<button
+  class="run"
+  type="button"
+  disabled={!listing || saving || isCurrent}
+  onclick={useThisFolder}
+>
+  {#if saving}
+    {m.settings_saving()}
+  {:else if isCurrent}
+    {m.settings_already_current()}
+  {:else}
+    {m.settings_use_folder()}
+  {/if}
+</button>
+{#if onclone}
+  <button type="button" class="clone-trigger" onclick={() => onclone?.()}
+    >{m.clonerepo_trigger()}</button
+  >
+{/if}
+{#if onfork}
+  <button type="button" class="clone-trigger" onclick={() => onfork?.()}
+    >{m.forkrepo_trigger()}</button
+  >
+{/if}
+
+<style>
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .cur {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    padding: 8px 10px;
+    border-radius: 2px;
+  }
+  .cur code {
+    color: var(--color-amber);
+    font-size: var(--fs-base);
+    word-break: break-all;
+  }
+  .path-label {
+    margin-top: 4px;
+  }
+  .crumbs {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .up {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-ink);
+    font: inherit;
+    font-size: var(--fs-lg);
+    line-height: 1;
+    padding: 5px 9px;
+    border-radius: 2px;
+    cursor: pointer;
+  }
+  .up:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .here {
+    color: var(--color-ink-bright);
+    font-size: var(--fs-base);
+    word-break: break-all;
+  }
+  .list {
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    border-radius: 2px;
+    max-height: 280px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+  .placeholder {
+    padding: 14px 12px;
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.06em;
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    text-align: left;
+    padding: 9px 11px;
+    cursor: pointer;
+  }
+  .row:last-child {
+    border-bottom: 0;
+  }
+  .row:hover {
+    background: var(--color-panel);
+  }
+  .ico {
+    opacity: 0.85;
+  }
+  .nm {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .chev {
+    color: var(--color-faint);
+  }
+  .err {
+    color: var(--color-red);
+    font-size: var(--fs-meta);
+    margin-top: 2px;
+  }
+  .run {
+    border: 1px solid var(--color-amber);
+    color: var(--color-amber);
+    background: transparent;
+    padding: 9px 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: var(--fs-meta);
+    cursor: pointer;
+    box-shadow: inset 0 0 18px -10px var(--color-amber);
+  }
+  .run:disabled {
+    opacity: 0.5;
+    cursor: default;
+    box-shadow: none;
+  }
+  /* Secondary/outline button — same shape as .run but uses the panel's neutral
+     line colour rather than amber, so it reads as a lower-priority action. */
+  .clone-trigger {
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-ink);
+    background: var(--color-inset);
+    padding: 9px 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: var(--fs-meta);
+    cursor: pointer;
+  }
+  .clone-trigger:hover {
+    color: var(--color-ink-bright);
+    border-color: var(--color-ink);
+  }
+
+  @media (max-width: 768px) {
+    /* Lift the list cap on mobile: the list flexes to fill the bounded panel
+       and stays the single scroll region (button pinned below), instead of a
+       capped list nested inside a separately-scrolling panel. */
+    .list {
+      max-height: none;
+    }
+    .row,
+    .up,
+    .run {
+      min-height: 44px;
+    }
+  }
+</style>

--- a/ui/src/lib/components/settings/SettingsWorkspacePanel.svelte
+++ b/ui/src/lib/components/settings/SettingsWorkspacePanel.svelte
@@ -1,22 +1,31 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import { getSettings, listDirs, putSettings } from "$lib/api";
+  import { listDirs, putSettings } from "$lib/api";
   import { type DirListing } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
 
   let {
+    repoRoot,
+    repoRootDisplay,
+    settingsLoaded,
     onclone,
     onfork,
     onsaved,
     onclose,
   }: {
+    // resolved by the parent's single getSettings() call (no second fetch here):
+    // repoRoot drives the initial browse, repoRootDisplay is the current-root label.
+    // null until the load settles (or if it failed). settingsLoaded flips once it has.
+    repoRoot: string | null;
+    repoRootDisplay: string | null;
+    settingsLoaded: boolean;
     onclone?: () => void;
     onfork?: () => void;
     onsaved?: (root: string) => void;
     onclose?: () => void;
   } = $props();
 
-  let currentRoot = $state(""); // the persisted root (display form)
+  // the persisted root (display form), authoritative from the parent
+  const currentRoot = $derived(repoRootDisplay ?? "");
   let listing = $state<DirListing | null>(null);
   let loading = $state(false);
   let saving = $state(false);
@@ -34,14 +43,14 @@
     }
   }
 
-  onMount(async () => {
-    try {
-      const s = await getSettings();
-      currentRoot = s.repoRootDisplay;
-      await browse(s.repoRoot);
-    } catch {
-      await browse();
-    }
+  // Browse once the parent's settings load settles: into repoRoot on success,
+  // or the default dir if it failed (repoRoot stays null). Guarded so a later
+  // prop change can't re-trigger the initial listing.
+  let browsed = false;
+  $effect(() => {
+    if (browsed || !settingsLoaded) return;
+    browsed = true;
+    void browse(repoRoot ?? undefined);
   });
 
   const isCurrent = $derived(
@@ -54,7 +63,8 @@
     error = null;
     try {
       const s = await putSettings(listing.path);
-      currentRoot = s.repoRootDisplay;
+      // onsaved bubbles the new root up; onclose dismisses immediately, so the
+      // displayed currentRoot (derived from the parent prop) needs no local write.
       onsaved?.(s.repoRoot);
       onclose?.();
     } catch (e) {


### PR DESCRIPTION
## What

Pays down **4 of the 13** `<template>` complexity grandfathers from #851 — the cluster
sitting just over the Tier-1 **40/60** bar. Each component is split into self-contained
subcomponent(s) so its synthetic `<template>` clears 40/60, and its per-file
`thresholdOverrides` entry in `.fallowrc.jsonc` is **deleted** (not merely tightened).

| Component | `<template>` before | after | grandfather |
| --- | --- | --- | --- |
| `RepoSwitcher.svelte` | 32 / 63 | 18 / 36 | **deleted** |
| `NewTask.svelte` | 47 / 55 | 37 / 41 | **deleted** |
| `AutomationSettings.svelte` | 50 / 57 | 39 / 37 | **deleted** |
| `Settings.svelte` | 59 / 60 | clears 40/60 (≥19 cyclo cut) | **deleted** |

New children (each well under the Tier-1 bar): `repo-switcher/RepoChipTelemetry`,
`new-task/NewTaskRunSettings`, `automation-settings/AutomationRepoFields`,
`settings/{SettingsWorkspacePanel,SettingsDevicePanel,SettingsDiagnosePanel}` —
co-located in per-component subfolders, following the `viewport/` precedent from #858.

After this PR: **9** Tier-2 grandfathers remain; the explanatory comment in
`.fallowrc.jsonc` is refreshed (13→9 giants, 23→27 of 36 clear the bar).

## Deliberate deviation from "worst-first"

The issue prescribes worst-first; the literal worst remaining is TopBar (191). This PR
**intentionally** does the **near-bar cluster** instead — chosen with the operator — because
these four sit just over the bar and can each be *fully cleared with their grandfather
deleted* in one cohesive PR, whereas the giants only tighten. Viewport (the original #1) was
already handled in #858. Worst-first (TopBar, Herd, …) resumes in follow-up sessions under
#855.

## Approach notes

- Pure mechanical extraction — **no behavior / UX / markup-semantics / visual change**. No new
  i18n keys, glossary terms, or feature-catalog entries (refactor, not `feat`).
- `RepoSwitcher`: the telemetry/queue snippet + its queue state move to the child; a `{#key}`
  remount replaces the parent's reset-on-repoFilter `$effect` (only one telemetry renders at a
  time, so this is equivalent).
- `NewTask`: the run-settings panel moves out; editable state stays in the parent via `bind:`,
  while the write-only `*Touched` signals use `on*Touched` callback props (a write-only
  `$bindable` trips `no-useless-assignment` in the child).
- `AutomationSettings`: the self-contained per-repo config-fields cluster (default-model,
  auto-drain fields, roles) — none of which use the shared `info`/`detail` snippets — moves
  wholesale with its state, `$effect`s and helpers.
- `Settings`: the three lighter, independently-loaded tab panels (workspace, device, diagnose)
  become self-loading children; the heavy session panel (30+ state vars + the `steersEl`
  scroll) stays in the parent untouched. Trade-off: `getSettings()` is now read twice on open
  (parent for session fields, workspace child for `currentRoot`) — an idempotent GET, no UX
  change.
- Scoped CSS handled per the move-vs-duplicate rule (shared utility classes duplicated into
  children that use them + kept in the parent; block-local classes moved); verified by
  `svelte-check` reporting zero `css_unused_selector` warnings.

## Verification

- `cd ui && bun run check` → 0 errors, **0 warnings**.
- `cd ui && bun run test` → **1757 passed** (incl. NewTask/RepoSwitcher/Settings browser tests).
- `bunx fallow@2.100.0 audit --base origin/main --fail-on-issues` → **clean** (dead-code 0,
  complexity 0; duplication is warn-only and pre-existing among the modal-composer family).
- `bunx fallow@2.100.0 health` → **0 template-complexity findings** (the only finding,
  `todo.ts:cleanupTodo`, is pre-existing non-template debt on `main` — out of scope).

Closes part of #855.