### PR TITLE
feat(learnings): scoped (glob-based) injection (Phase 3, #842)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -256,9 +256,9 @@
         "files": ["ui/src/lib/components/LearningsDrawer.svelte"],
         "functions": ["<template>"],
         "maxCyclomatic": 50,
-        "maxCognitive": 130,
+        "maxCognitive": 140,
         "maxCrap": 20000,
-        "reason": "Tier 2 grandfather (#851); refactor candidate #855. Cognitive bar raised 110→130 in #840: the learnings auto-retire feature added the unseen-retired banner + Retired section + help-rate stat to this component (its own UI home), per the established 'next multiple of 10 above current' convention."
+        "reason": "Tier 2 grandfather (#851); refactor candidate #855. Cognitive bar raised 110→130 in #840 (auto-retire UI), then 130→140 in #842: glob-scoped injection added the per-rule scope line + inline editor + 'Scoped' badge to this component (its own UI home), per the established 'next multiple of 10 above current' convention."
       },
       {
         "files": ["ui/src/lib/components/BacklogView.svelte"],

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -6,7 +6,7 @@ import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
 import type { Signal, SignalKind } from "./types";
-import { normalizeGlob } from "./house-rules";
+import { sanitizeScopeGlobs } from "./house-rules";
 import {
   isApiKeyMode,
   isApiKeyConfigured,
@@ -44,28 +44,6 @@ interface RawRule {
   scopeGlobs?: unknown;
 }
 
-/** Max glob patterns kept per proposed rule, and max chars per pattern — bounds the
- *  scope the distiller LLM can attach so a runaway/garbled output can't bloat a row. */
-const MAX_SCOPE_GLOBS = 5;
-const MAX_GLOB_LEN = 120;
-
-/** Sanitize the distiller's proposed `scopeGlobs`: keep only non-empty strings, trim +
- *  normalize to repo-relative form, drop overly-long patterns, dedupe, cap the count.
- *  Anything not a string array → []. */
-function sanitizeScopeGlobs(raw: unknown): string[] {
-  if (!Array.isArray(raw)) return [];
-  const out: string[] = [];
-  const seen = new Set<string>();
-  for (const g of raw) {
-    if (typeof g !== "string") continue;
-    const norm = normalizeGlob(g);
-    if (!norm || norm.length > MAX_GLOB_LEN || seen.has(norm)) continue;
-    seen.add(norm);
-    out.push(norm);
-    if (out.length >= MAX_SCOPE_GLOBS) break;
-  }
-  return out;
-}
 interface RawUpdate {
   id?: unknown;
   rule?: unknown;

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -6,6 +6,7 @@ import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
 import type { Signal, SignalKind } from "./types";
+import { normalizeGlob } from "./house-rules";
 import {
   isApiKeyMode,
   isApiKeyConfigured,
@@ -40,6 +41,30 @@ interface RawRule {
   rule?: unknown;
   rationale?: unknown;
   evidence?: unknown;
+  scopeGlobs?: unknown;
+}
+
+/** Max glob patterns kept per proposed rule, and max chars per pattern — bounds the
+ *  scope the distiller LLM can attach so a runaway/garbled output can't bloat a row. */
+const MAX_SCOPE_GLOBS = 5;
+const MAX_GLOB_LEN = 120;
+
+/** Sanitize the distiller's proposed `scopeGlobs`: keep only non-empty strings, trim +
+ *  normalize to repo-relative form, drop overly-long patterns, dedupe, cap the count.
+ *  Anything not a string array → []. */
+function sanitizeScopeGlobs(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const g of raw) {
+    if (typeof g !== "string") continue;
+    const norm = normalizeGlob(g);
+    if (!norm || norm.length > MAX_GLOB_LEN || seen.has(norm)) continue;
+    seen.add(norm);
+    out.push(norm);
+    if (out.length >= MAX_SCOPE_GLOBS) break;
+  }
+  return out;
 }
 interface RawUpdate {
   id?: unknown;
@@ -372,6 +397,7 @@ export class DistillerService {
         evidence: Array.isArray(r.evidence)
           ? r.evidence.filter((e): e is string => typeof e === "string")
           : [],
+        scopeGlobs: sanitizeScopeGlobs(r.scopeGlobs),
       });
       added++;
     }
@@ -425,8 +451,13 @@ function distillPrompt(): string {
     "Only cite ids present in the data — never invent ids.",
     "",
     "Limits: at most 5 ADDs, 5 updates, 5 deletes.",
+    "",
+    "When an ADD clearly applies only to specific files or areas (judging by the file paths",
+    "mentioned in the signals), include an optional `scopeGlobs`: an array of up to 5 repo-relative",
+    'glob patterns (e.g. "src/**", "ui/**/*.svelte") so the rule injects only for tasks touching',
+    "those files. OMIT `scopeGlobs` (or use []) for general rules — do not invent a scope when unsure.",
     `Write your output as JSON to \`${PROPOSALS_FILE}\` in this directory, shaped exactly:`,
-    '{"rules":[{"rule":"<=160 char imperative","rationale":"why","evidence":["signalId",...]}],"updates":[{"id":"activeRuleId","rule":"<=160 char imperative","rationale":"why"}],"deletes":[{"id":"activeRuleId","reason":"why"}],"ineffective":[{"id":"activeRuleId","evidence":["signalId",...]}]}',
+    '{"rules":[{"rule":"<=160 char imperative","rationale":"why","evidence":["signalId",...],"scopeGlobs":["glob",...]}],"updates":[{"id":"activeRuleId","rule":"<=160 char imperative","rationale":"why"}],"deletes":[{"id":"activeRuleId","reason":"why"}],"ineffective":[{"id":"activeRuleId","evidence":["signalId",...]}]}',
     'If nothing applies, write {"rules":[],"updates":[],"deletes":[],"ineffective":[]}. Do not write anything else.',
   ].join("\n");
 }

--- a/src/house-rules.ts
+++ b/src/house-rules.ts
@@ -38,8 +38,9 @@ const RANK_NEUTRAL_PRIOR = envNum("SHEPHERD_LEARNINGS_RANK_NEUTRAL_PRIOR", 0.5);
 const RANK_DECAY_BASE = Math.pow(0.5, 1 / RANK_HALF_LIFE_DAYS);
 
 export interface HouseRulesPlan {
-  injected: Learning[]; // priority order, fit within budget
-  dropped: Learning[]; // over budget, priority order
+  injected: Learning[]; // priority order, fit within budget (Always-rules first, then matched-scoped)
+  dropped: Learning[]; // candidates over budget, priority order
+  scoped: Learning[]; // scope-gated: have globs but no target path matched (NOT over budget)
   budgetChars: number;
   usedChars: number; // exact rendered length of the block (XML tag + intro + bullets)
 }
@@ -64,6 +65,91 @@ function scoreRule(r: Learning, now: number): number {
   return RANK_W_RECENCY * recencyDecay + RANK_W_HELP * helpComponent;
 }
 
+/** A rule with no scope globs is an "Always-rule" — a candidate for every task,
+ *  exactly the pre-#842 behavior. A rule with globs is scoped: a candidate only when
+ *  the session's target files match (see {@link learningMatchesScope}). */
+function isAlwaysRule(l: Learning): boolean {
+  return l.scopeGlobs.length === 0;
+}
+
+/** Canonicalize a glob to repo-relative forward-slash form for Bun.Glob matching
+ *  (exact-string). Strips a leading `./` and leading `/`, normalizes backslashes. */
+export function normalizeGlob(g: string): string {
+  return g.trim().replace(/\\/g, "/").replace(/^\.\//, "").replace(/^\/+/, "");
+}
+
+/** Canonicalize a path-like token scraped from task text to the same repo-relative
+ *  forward-slash form so it can be matched against {@link normalizeGlob}'d patterns.
+ *  Strips wrapping quotes/brackets and trailing sentence punctuation, and (when given)
+ *  the absolute `repoPath` prefix. Returns "" for empty / non-path tokens. */
+export function normalizeExtractedPath(token: string, repoPath?: string): string {
+  let t = token.trim().replace(/\\/g, "/");
+  t = t.replace(/^[("'`[<]+/, "").replace(/[)"'`\].,;:>]+$/, "");
+  if (!t) return "";
+  if (repoPath) {
+    const base = repoPath.replace(/\\/g, "/").replace(/\/+$/, "");
+    if (t === base) return "";
+    if (t.startsWith(base + "/")) t = t.slice(base.length + 1);
+  }
+  return t.replace(/^\.\//, "").replace(/^\/+/, "");
+}
+
+/** A token is path-like when it has a "/" or ends in a 2–6 char file extension —
+ *  so `src/foo.ts`, `house-rules.ts`, `ui/x.svelte` qualify but prose, `#842`, `4000` don't. */
+function isPathLike(s: string): boolean {
+  return s.includes("/") || /\.[a-z0-9]{2,6}$/i.test(s);
+}
+
+/** Collect path-like tokens from one text into `out`. Returns true once the cap is hit. */
+function collectPaths(text: string, repoPath: string | undefined, out: Set<string>): boolean {
+  for (const raw of text.match(/[\w./@+-]+/g) ?? []) {
+    const norm = normalizeExtractedPath(raw, repoPath);
+    if (norm && isPathLike(norm)) out.add(norm);
+    if (out.size >= 256) return true;
+  }
+  return false;
+}
+
+/** Extract repo-relative path-like tokens from free task text (prompt + issue
+ *  title/body). Deduped; capped to bound the match work at spawn. The session's *actual*
+ *  touched files are unknowable before it runs, so this is a heuristic over the task
+ *  description — a miss simply falls back to Always-rules-only (never worse than the
+ *  pre-#842 behavior). */
+export function extractTargetPaths(texts: (string | undefined)[], repoPath?: string): string[] {
+  const out = new Set<string>();
+  for (const text of texts) {
+    if (text && collectPaths(text, repoPath, out)) break;
+  }
+  return [...out];
+}
+
+/** True when normalized glob `rawGlob` matches any of `paths`. Two tiers: (1) full-path
+ *  glob match; (2) a basename fallback that lets a bare-filename token (no directory) hit a
+ *  glob whose trailing segment is a concrete file pattern (contains "."), e.g. bare `foo.ts`
+ *  matches `src/`+`**`+`/*.ts`. A trailing bare `**`/`*` is NOT used for the fallback (it
+ *  would match any filename). A malformed glob is skipped, never thrown. */
+function globMatchesAnyPath(rawGlob: string, paths: string[]): boolean {
+  const glob = normalizeGlob(rawGlob);
+  if (!glob) return false;
+  try {
+    const matcher = new Bun.Glob(glob);
+    const tail = glob.slice(glob.lastIndexOf("/") + 1);
+    const baseMatcher = tail !== glob && tail.includes(".") ? new Bun.Glob(tail) : null;
+    return paths.some(
+      (p) => matcher.match(p) || (baseMatcher !== null && !p.includes("/") && baseMatcher.match(p)),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** True when `learning` is scoped (has globs) and at least one glob matches at least one
+ *  of `paths`. Always-rules (no globs) and an empty path set never match. */
+export function learningMatchesScope(learning: Learning, paths: string[]): boolean {
+  if (learning.scopeGlobs.length === 0 || paths.length === 0) return false;
+  return learning.scopeGlobs.some((g) => globMatchesAnyPath(g, paths));
+}
+
 /** Priority sort: composite recency-decay + smoothed-help score, desc.
  *  Tie-break: updatedAt desc (determinism). `now` defaults to Date.now() so
  *  existing callers need no change. */
@@ -75,30 +161,54 @@ export function prioritize(rules: Learning[], now: number = Date.now()): Learnin
   });
 }
 
-/** Priority: composite score desc → updatedAt desc. Greedy fill: add a rule
- *  when used + cost ≤ budget, else mark it dropped and keep checking later (shorter) rules,
- *  so `injected` is not necessarily a contiguous prefix of priority order. */
+/** Plan which house rules inject under the char budget, scoped to the session's target
+ *  files (#842). Rules split three ways: Always-rules (no globs), matched-scoped (globs hit
+ *  a `targetPaths` entry), and scope-gated (globs, no match → `scoped`, never injected and
+ *  never counted against budget). Budget precedence is two-pass: **Always-rules are packed
+ *  first** (guaranteed the budget), then matched-scoped fill the remainder — so a flurry of
+ *  scoped matches can never evict a universal rule. Within each pass the fill is greedy by
+ *  the composite score (a later, shorter rule can still fit after a longer one is dropped),
+ *  so `injected` is not necessarily a contiguous prefix. `now` (test-injectable) drives the
+ *  recency decay; omitting `targetPaths` (e.g. the cross-repo injectable preview, which has
+ *  no session) gates every scoped rule. */
 export function planHouseRulesInjection(
   rules: Learning[],
   budgetChars: number,
   now: number = Date.now(),
+  targetPaths?: string[],
 ): HouseRulesPlan {
-  const ordered = prioritize(rules, now);
+  const paths = targetPaths ?? [];
+  const always: Learning[] = [];
+  const matchedScoped: Learning[] = [];
+  const gated: Learning[] = [];
+  for (const r of rules) {
+    if (isAlwaysRule(r)) always.push(r);
+    else if (learningMatchesScope(r, paths)) matchedScoped.push(r);
+    else gated.push(r);
+  }
   const injected: Learning[] = [];
   const dropped: Learning[] = [];
   let used = HOUSE_RULES_OVERHEAD;
-  for (const r of ordered) {
-    const cost = ("- " + r.rule + "\n").length;
-    if (used + cost <= budgetChars) {
-      injected.push(r);
-      used += cost;
-    } else {
-      dropped.push(r);
+  for (const group of [prioritize(always, now), prioritize(matchedScoped, now)]) {
+    for (const r of group) {
+      const cost = ("- " + r.rule + "\n").length;
+      if (used + cost <= budgetChars) {
+        injected.push(r);
+        used += cost;
+      } else {
+        dropped.push(r);
+      }
     }
   }
   // No rule made the cut → the block renders to null, so report 0 chars used
   // (not the bare overhead) to keep the drawer's budget meter truthful.
-  return { injected, dropped, budgetChars, usedChars: injected.length === 0 ? 0 : used };
+  return {
+    injected,
+    dropped,
+    scoped: prioritize(gated, now),
+    budgetChars,
+    usedChars: injected.length === 0 ? 0 : used,
+  };
 }
 
 /** Renders the injected rules into the XML-wrapped block, or null when none. */

--- a/src/house-rules.ts
+++ b/src/house-rules.ts
@@ -78,6 +78,30 @@ export function normalizeGlob(g: string): string {
   return g.trim().replace(/\\/g, "/").replace(/^\.\//, "").replace(/^\/+/, "");
 }
 
+/** Max glob patterns kept per rule, and max chars per pattern — bounds the scope so a
+ *  runaway distiller output OR a fat-fingered operator paste can't bloat a row. */
+const MAX_SCOPE_GLOBS = 5;
+const MAX_GLOB_LEN = 120;
+
+/** Sanitize proposed/edited `scopeGlobs` from ANY source (distiller LLM or operator edit):
+ *  keep only strings, normalize to repo-relative form, drop empty/over-long patterns, dedupe,
+ *  and cap the count. Anything not a string array → []. The single source of truth so both the
+ *  distiller and the operator path enforce identical caps (#842). */
+export function sanitizeScopeGlobs(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const g of raw) {
+    if (typeof g !== "string") continue;
+    const norm = normalizeGlob(g);
+    if (!norm || norm.length > MAX_GLOB_LEN || seen.has(norm)) continue;
+    seen.add(norm);
+    out.push(norm);
+    if (out.length >= MAX_SCOPE_GLOBS) break;
+  }
+  return out;
+}
+
 /** Canonicalize a path-like token scraped from task text to the same repo-relative
  *  forward-slash form so it can be matched against {@link normalizeGlob}'d patterns.
  *  Strips wrapping quotes/brackets and trailing sentence punctuation, and (when given)

--- a/src/server.ts
+++ b/src/server.ts
@@ -936,23 +936,31 @@ function handleLearningsGet({ parts, url, deps }: Ctx): Response | null {
           enabled,
           budgetChars,
           usedChars: 0,
-          rules: prioritize(rules).map((r) => ({ ...r, injected: false })),
+          rules: prioritize(rules).map((r) => ({
+            ...r,
+            injected: false,
+            scoped: r.scopeGlobs.length > 0,
+          })),
           retired,
           unseenRetired,
         };
       }
+      // No session here, so no target files: planHouseRulesInjection gates every scoped
+      // rule into `scoped` (its globs decide injection only at spawn). usedChars therefore
+      // reflects the Always-rules baseline only — scoped rules never count against budget.
       const plan = planHouseRulesInjection(rules, budgetChars);
       const injectedIds = new Set(plan.injected.map((r) => r.id));
-      // injected first (priority order), then dropped (priority order) — same
-      // ordering the drawer renders.
+      // injected (priority order), then dropped (over budget), then scope-gated — same
+      // ordering the drawer renders; `scoped` marks the glob-conditional rules.
       return {
         repoPath,
         enabled,
         budgetChars,
         usedChars: plan.usedChars,
-        rules: [...plan.injected, ...plan.dropped].map((r) => ({
+        rules: [...plan.injected, ...plan.dropped, ...plan.scoped].map((r) => ({
           ...r,
           injected: injectedIds.has(r.id),
+          scoped: r.scopeGlobs.length > 0,
         })),
         retired,
         unseenRetired,
@@ -1026,12 +1034,29 @@ async function handleLearningsPost({ req, parts, url, deps }: Ctx): Promise<Resp
     return json(updated);
   }
 
+  // POST /api/learnings/:id/scope — set/clear a rule's glob scope (operator edit, #842)
+  if (parts[2] && parts[3] === "scope") return handleLearningScope(req, deps, parts[2]);
+
   // POST /api/learnings/:id/approve  |  /:id/dismiss
   if (parts[2] && (parts[3] === "approve" || parts[3] === "dismiss")) {
     return handleLearningStatus(req, deps, parts[2], parts[3]);
   }
 
   return null;
+}
+
+/** POST /api/learnings/:id/scope — replace a rule's `scopeGlobs` (body `{globs:string[]}`).
+ *  An empty array makes it an Always-rule again. The store dedupes/trims; matching honesty
+ *  is the operator's. Refreshes the drawer via learnings:update. */
+async function handleLearningScope(req: Request, deps: AppDeps, id: string): Promise<Response> {
+  const body = (await req.json().catch(() => null)) as { globs?: unknown } | null;
+  const globs = Array.isArray(body?.globs)
+    ? body!.globs.filter((g): g is string => typeof g === "string")
+    : [];
+  const updated = deps.store.setLearningScope(id, globs);
+  if (!updated) return json({ error: "not found" }, 404);
+  deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
+  return json(updated);
 }
 
 async function handleLearningStatus(

--- a/src/service.ts
+++ b/src/service.ts
@@ -29,7 +29,7 @@ import {
 } from "./spawn-auth";
 import type { Leftover, ProcessReaper } from "./process-reaper";
 import type { PreviewService } from "./preview";
-import { planHouseRulesInjection, renderHouseRulesBlock } from "./house-rules";
+import { extractTargetPaths, planHouseRulesInjection, renderHouseRulesBlock } from "./house-rules";
 import { isGoodOutcome } from "./learnings-lifecycle";
 import { effectiveAutopilot } from "./effective-autopilot";
 import { MAX_IMAGES } from "./validate";
@@ -1236,14 +1236,23 @@ export class SessionService {
   }
 
   /** Active+promoted rules for the repo as an XML-wrapped block, or null when none /
-   *  learnings disabled. Records the injected rule ids against the session (join rows
-   *  only — counters are advanced symmetrically with the reward at archive, never here).
-   *  Injected into every new agent's system prompt via composeSystemPrompt. */
-  private recordInjectedHouseRules(sessionId: string, repoPath: string): string | null {
+   *  learnings disabled. Always-rules plus glob-scoped rules whose globs match files named
+   *  in the task text (prompt + attached issue), with the budget capping within that matched
+   *  set (#842). Records the injected rule ids against the session (join rows only — counters
+   *  are advanced symmetrically with the reward at archive, never here). Injected into every
+   *  new agent's system prompt via composeSystemPrompt. */
+  private recordInjectedHouseRules(sessionId: string, input: CreateSessionInput): string | null {
+    const { repoPath } = input;
     if (!this.deps.store.getRepoConfig(repoPath).learningsEnabled) return null;
+    const targetPaths = extractTargetPaths(
+      [input.prompt, input.issueRef?.title, input.issueRef?.body],
+      repoPath,
+    );
     const { injected } = planHouseRulesInjection(
       this.deps.store.listActiveLearnings(repoPath),
       config.houseRulesBudgetChars,
+      Date.now(),
+      targetPaths,
     );
     this.deps.store.recordInjectedLearnings(
       sessionId,
@@ -1280,7 +1289,7 @@ export class SessionService {
     baseUrl: string,
   ): string[] {
     const repoConfig = this.deps.store.getRepoConfig(input.repoPath);
-    const houseRules = this.recordInjectedHouseRules(sessionId, input.repoPath);
+    const houseRules = this.recordInjectedHouseRules(sessionId, input);
     const autopilotActive = repoConfig.autopilotEnabled;
     const planGate = planGateOn ? (input.auto ? "auto" : "interactive") : undefined;
     const buildQueue = repoConfig.buildQueueEnabled

--- a/src/store.ts
+++ b/src/store.ts
@@ -27,7 +27,7 @@ import type { CapRow, CapStore, CreditSnapshot, CreditStore, WindowKey } from ".
 import { dominantModel, type SessionUsage } from "./usage";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
 import { normalizeRepoDefaultModelSetting } from "./default-model";
-import { normalizeGlob } from "./house-rules";
+import { sanitizeScopeGlobs } from "./house-rules";
 import type { EpicRun } from "./epic-core";
 import type { EpicLandingState } from "./completed-epic";
 
@@ -2438,21 +2438,14 @@ export class SessionStore implements CapStore, CreditStore {
     return this.getLearning(id);
   }
 
-  /** Replace a rule's scope globs (operator edit, #842). Normalizes each pattern to the
-   *  same repo-relative form the distiller uses (display parity with `sanitizeScopeGlobs`),
-   *  deduping and dropping empties; `[]` makes it an Always-rule again. No-op (returns null)
-   *  for a missing rule. */
+  /** Replace a rule's scope globs (operator edit, #842). Runs the same `sanitizeScopeGlobs`
+   *  the distiller uses — normalize to repo-relative form, drop empty/over-long patterns,
+   *  dedupe, and cap the count — so both paths persist identical, bounded scope; `[]` makes
+   *  it an Always-rule again. No-op (returns null) for a missing rule. */
   setLearningScope(id: string, globs: string[]): Learning | null {
     const cur = this.getLearning(id);
     if (!cur) return null;
-    const clean = [
-      ...new Set(
-        globs
-          .filter((g) => typeof g === "string")
-          .map((g) => normalizeGlob(g))
-          .filter(Boolean),
-      ),
-    ];
+    const clean = sanitizeScopeGlobs(globs);
     this.db.run(`UPDATE learnings SET scopeGlobs = ?, updatedAt = ? WHERE id = ?`, [
       JSON.stringify(clean),
       Date.now(),

--- a/src/store.ts
+++ b/src/store.ts
@@ -27,6 +27,7 @@ import type { CapRow, CapStore, CreditSnapshot, CreditStore, WindowKey } from ".
 import { dominantModel, type SessionUsage } from "./usage";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
 import { normalizeRepoDefaultModelSetting } from "./default-model";
+import { normalizeGlob } from "./house-rules";
 import type { EpicRun } from "./epic-core";
 import type { EpicLandingState } from "./completed-epic";
 
@@ -2437,9 +2438,10 @@ export class SessionStore implements CapStore, CreditStore {
     return this.getLearning(id);
   }
 
-  /** Replace a rule's scope globs (operator edit, #842). Stores the normalized,
-   *  deduped, non-empty patterns verbatim as a JSON array; `[]` makes it an
-   *  Always-rule again. No-op (returns null) for a missing rule. */
+  /** Replace a rule's scope globs (operator edit, #842). Normalizes each pattern to the
+   *  same repo-relative form the distiller uses (display parity with `sanitizeScopeGlobs`),
+   *  deduping and dropping empties; `[]` makes it an Always-rule again. No-op (returns null)
+   *  for a missing rule. */
   setLearningScope(id: string, globs: string[]): Learning | null {
     const cur = this.getLearning(id);
     if (!cur) return null;
@@ -2447,7 +2449,7 @@ export class SessionStore implements CapStore, CreditStore {
       ...new Set(
         globs
           .filter((g) => typeof g === "string")
-          .map((g) => g.trim())
+          .map((g) => normalizeGlob(g))
           .filter(Boolean),
       ),
     ];

--- a/src/store.ts
+++ b/src/store.ts
@@ -329,6 +329,7 @@ type LearningRow = {
   lastUsedAt: number | null;
   retiredAt: number | null;
   retiredReason: string | null;
+  scopeGlobs: string;
   createdAt: number;
   updatedAt: number;
   lastEvidenceAt: number | null;
@@ -2307,6 +2308,9 @@ export class SessionStore implements CapStore, CreditStore {
     add("retiredReason", `retiredReason TEXT`);
     add("retiredFromStatus", `retiredFromStatus TEXT`);
     add("autoOptimizedAt", `autoOptimizedAt INTEGER`);
+    // Glob-scoped injection (#842). JSON array of repo-relative glob patterns; '[]'
+    // = an Always-rule (every task), matching the original always-inject behavior.
+    add("scopeGlobs", `scopeGlobs TEXT NOT NULL DEFAULT '[]'`);
   }
 
   private hydrateLearning(r: LearningRow): Learning {
@@ -2324,6 +2328,7 @@ export class SessionStore implements CapStore, CreditStore {
       lastUsedAt: r.lastUsedAt ?? null,
       retiredAt: r.retiredAt ?? null,
       retiredReason: r.retiredReason ?? null,
+      scopeGlobs: parseFindings(r.scopeGlobs),
       createdAt: r.createdAt,
       updatedAt: r.updatedAt,
       lastEvidenceAt: r.lastEvidenceAt,
@@ -2336,6 +2341,7 @@ export class SessionStore implements CapStore, CreditStore {
     rule: string;
     rationale: string;
     evidence: string[];
+    scopeGlobs?: string[];
   }): Learning {
     const now = Date.now();
     const l: Learning = {
@@ -2352,6 +2358,7 @@ export class SessionStore implements CapStore, CreditStore {
       lastUsedAt: null,
       retiredAt: null,
       retiredReason: null,
+      scopeGlobs: input.scopeGlobs ?? [],
       createdAt: now,
       updatedAt: now,
       lastEvidenceAt: input.evidence.length ? now : null,
@@ -2359,8 +2366,8 @@ export class SessionStore implements CapStore, CreditStore {
     };
     this.db.run(
       `INSERT INTO learnings
-         (id, repoPath, rule, rationale, evidence, status, evidenceCount, ineffectiveCount, createdAt, updatedAt, lastEvidenceAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+         (id, repoPath, rule, rationale, evidence, status, evidenceCount, ineffectiveCount, scopeGlobs, createdAt, updatedAt, lastEvidenceAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
       [
         l.id,
         l.repoPath,
@@ -2370,6 +2377,7 @@ export class SessionStore implements CapStore, CreditStore {
         l.status,
         l.evidenceCount,
         l.ineffectiveCount,
+        JSON.stringify(l.scopeGlobs),
         l.createdAt,
         l.updatedAt,
         l.lastEvidenceAt,
@@ -2423,6 +2431,28 @@ export class SessionStore implements CapStore, CreditStore {
     this.db.run(`UPDATE learnings SET status = ?, rule = ?, updatedAt = ? WHERE id = ?`, [
       status,
       rule ?? cur.rule,
+      Date.now(),
+      id,
+    ]);
+    return this.getLearning(id);
+  }
+
+  /** Replace a rule's scope globs (operator edit, #842). Stores the normalized,
+   *  deduped, non-empty patterns verbatim as a JSON array; `[]` makes it an
+   *  Always-rule again. No-op (returns null) for a missing rule. */
+  setLearningScope(id: string, globs: string[]): Learning | null {
+    const cur = this.getLearning(id);
+    if (!cur) return null;
+    const clean = [
+      ...new Set(
+        globs
+          .filter((g) => typeof g === "string")
+          .map((g) => g.trim())
+          .filter(Boolean),
+      ),
+    ];
+    this.db.run(`UPDATE learnings SET scopeGlobs = ?, updatedAt = ? WHERE id = ?`, [
+      JSON.stringify(clean),
       Date.now(),
       id,
     ]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -506,6 +506,12 @@ export interface Learning {
   lastUsedAt: number | null;
   retiredAt: number | null;
   retiredReason: string | null;
+  /** Optional glob patterns scoping where this rule applies (repo-relative, e.g.
+   *  "src/" + star-star or "ui/" + star-star + "/*.svelte"). Empty = an "Always-rule"
+   *  injected for every task; non-empty = injected only when the session's target files
+   *  match a glob (Phase 3, #842). Distiller-inferred from path-like signal text, or
+   *  operator-set. */
+  scopeGlobs: string[];
   createdAt: number;
   updatedAt: number;
   lastEvidenceAt: number | null;

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -888,3 +888,42 @@ test("health — timeout-no-output counts as failure; successful finalize resets
   expect(d.health().consecutiveFailures).toBe(0);
   expect(d.health().lastFailure).toBeNull();
 });
+
+test("#842: distiller persists sanitized scopeGlobs from a proposal", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const { deps } = mkDeps(store, {
+    rules: [
+      {
+        rule: "keep svelte styles scoped",
+        rationale: "ui only",
+        evidence: [],
+        // mix of valid + junk: non-string, ./-prefixed (normalized), over-long, dup
+        scopeGlobs: [
+          "./ui/**/*.svelte",
+          "ui/**/*.svelte", // dup after normalize
+          42,
+          "x".repeat(200), // over MAX_GLOB_LEN
+        ],
+      },
+    ],
+  });
+  const d = new DistillerService(deps as any);
+  d.distillNow("/r");
+  await d.tick();
+  const [l] = store.listLearnings("/r", { status: "proposed" });
+  expect(l!.scopeGlobs).toEqual(["ui/**/*.svelte"]);
+});
+
+test("#842: a proposal without scopeGlobs stays an Always-rule (empty globs)", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const { deps } = mkDeps(store, {
+    rules: [{ rule: "general rule", rationale: "", evidence: [] }],
+  });
+  const d = new DistillerService(deps as any);
+  d.distillNow("/r");
+  await d.tick();
+  const [l] = store.listLearnings("/r", { status: "proposed" });
+  expect(l!.scopeGlobs).toEqual([]);
+});

--- a/test/house-rules.test.ts
+++ b/test/house-rules.test.ts
@@ -7,6 +7,10 @@ import {
   planHouseRulesInjection,
   prioritize,
   renderHouseRulesBlock,
+  extractTargetPaths,
+  normalizeExtractedPath,
+  normalizeGlob,
+  learningMatchesScope,
 } from "../src/house-rules";
 import type { Learning } from "../src/types";
 
@@ -25,6 +29,7 @@ function rule(p: Partial<Learning>): Learning {
     lastUsedAt: p.lastUsedAt ?? null,
     retiredAt: null,
     retiredReason: null,
+    scopeGlobs: p.scopeGlobs ?? [],
     createdAt: p.createdAt ?? 0,
     updatedAt: p.updatedAt ?? 0,
     lastEvidenceAt: p.lastEvidenceAt ?? null,
@@ -187,4 +192,101 @@ test("envNum: unset and non-numeric env values fall back to the default; valid v
   } finally {
     delete process.env[name];
   }
+});
+
+// ── #842 glob-scoped injection ──────────────────────────────────────────────
+
+test("normalizeGlob strips ./ and leading slash, normalizes backslashes", () => {
+  expect(normalizeGlob("./src/**")).toBe("src/**");
+  expect(normalizeGlob("/src/foo.ts")).toBe("src/foo.ts");
+  expect(normalizeGlob("ui\\**\\*.svelte")).toBe("ui/**/*.svelte");
+  expect(normalizeGlob("  src/**  ")).toBe("src/**");
+});
+
+test("normalizeExtractedPath canonicalizes ./, absolute-under-repo, and punctuation", () => {
+  expect(normalizeExtractedPath("./src/foo.ts")).toBe("src/foo.ts");
+  expect(normalizeExtractedPath("/repo/src/foo.ts", "/repo")).toBe("src/foo.ts");
+  expect(normalizeExtractedPath("`src/foo.ts`,")).toBe("src/foo.ts");
+  expect(normalizeExtractedPath("(ui/x.svelte)")).toBe("ui/x.svelte");
+  expect(normalizeExtractedPath("/repo", "/repo")).toBe("");
+});
+
+test("extractTargetPaths keeps path-like tokens, drops prose/numbers", () => {
+  const paths = extractTargetPaths([
+    "Please fix src/house-rules.ts and update ui/x.svelte for issue #842 (4000 chars)",
+  ]);
+  expect(paths).toContain("src/house-rules.ts");
+  expect(paths).toContain("ui/x.svelte");
+  expect(paths).not.toContain("842");
+  expect(paths).not.toContain("Please");
+  // bare filename with a real extension is kept
+  expect(extractTargetPaths(["touch house-rules.ts"])).toContain("house-rules.ts");
+  // a bare word is not a path
+  expect(extractTargetPaths(["just some prose words here"])).toEqual([]);
+});
+
+test("extractTargetPaths strips an absolute repoPath prefix to repo-relative", () => {
+  expect(
+    extractTargetPaths(["edit /home/me/repo/src/a.ts now", undefined], "/home/me/repo"),
+  ).toEqual(["src/a.ts"]);
+});
+
+// token × glob match matrix (the load-bearing normalization assertions)
+const SCOPED = (globs: string[]) => rule({ id: "s", rule: "scoped", scopeGlobs: globs });
+test.each([
+  ["src/**", "src/foo.ts", true],
+  ["src/**", "src/a/b.ts", true],
+  ["src/**", "ui/x.ts", false],
+  ["src/**/*.ts", "src/foo.ts", true],
+  ["**/*.svelte", "ui/x.svelte", true],
+  // bare-filename token hits a glob whose trailing segment is a concrete file pattern
+  ["src/**/*.ts", "foo.ts", true],
+  ["src/house-rules.ts", "house-rules.ts", true],
+  // bare filename must NOT match a directory-only glob (trailing ** has no dot)
+  ["src/**", "readme.md", false],
+])("learningMatchesScope(%s vs %s) === %s", (glob, path, expected) => {
+  expect(learningMatchesScope(SCOPED([glob]), [path])).toBe(expected);
+});
+
+test("learningMatchesScope: Always-rule (no globs) never matches via scope, empty paths never match", () => {
+  expect(learningMatchesScope(rule({ id: "a", scopeGlobs: [] }), ["src/foo.ts"])).toBe(false);
+  expect(learningMatchesScope(SCOPED(["src/**"]), [])).toBe(false);
+});
+
+test("planHouseRulesInjection: Always-rules always candidates; scoped gated unless matched", () => {
+  const always = rule({ id: "always", rule: "always rule", scopeGlobs: [] });
+  const match = rule({ id: "m", rule: "src rule", scopeGlobs: ["src/**"] });
+  const nomatch = rule({ id: "n", rule: "ui rule", scopeGlobs: ["ui/**"] });
+
+  const withMatch = planHouseRulesInjection([always, match, nomatch], 10_000, undefined, [
+    "src/foo.ts",
+  ]);
+  const injectedIds = withMatch.injected.map((r) => r.id).sort();
+  expect(injectedIds).toEqual(["always", "m"]);
+  // the non-matching scoped rule is gated (scoped bucket), NOT dropped as over-budget
+  expect(withMatch.scoped.map((r) => r.id)).toEqual(["n"]);
+  expect(withMatch.dropped).toEqual([]);
+
+  // no target paths → every scoped rule gated, only Always-rules inject
+  const noPaths = planHouseRulesInjection([always, match, nomatch], 10_000);
+  expect(noPaths.injected.map((r) => r.id)).toEqual(["always"]);
+  expect(noPaths.scoped.map((r) => r.id).sort()).toEqual(["m", "n"]);
+});
+
+test("planHouseRulesInjection: Always-rules are packed before matched-scoped (never evicted)", () => {
+  // Budget fits exactly the two Always-rules + overhead, no room for the scoped match.
+  const a1 = rule({ id: "a1", rule: "AAAA", scopeGlobs: [], lastEvidenceAt: 10 });
+  const a2 = rule({ id: "a2", rule: "BBBB", scopeGlobs: [], lastEvidenceAt: 9 });
+  // a flurry of matching scoped rules with FRESHER evidence than the Always-rules
+  const scoped = Array.from({ length: 6 }, (_, i) =>
+    rule({ id: `s${i}`, rule: `SCOPED-${i}`, scopeGlobs: ["src/**"], lastEvidenceAt: 100 + i }),
+  );
+  const costOf = (s: string) => ("- " + s + "\n").length;
+  const budget = HOUSE_RULES_OVERHEAD + costOf("AAAA") + costOf("BBBB");
+  const plan = planHouseRulesInjection([...scoped, a1, a2], budget, undefined, ["src/foo.ts"]);
+  const injectedIds = plan.injected.map((r) => r.id).sort();
+  // both Always-rules guaranteed; every scoped match dropped despite fresher evidence
+  expect(injectedIds).toEqual(["a1", "a2"]);
+  expect(plan.dropped.every((r) => r.id.startsWith("s"))).toBe(true);
+  expect(plan.dropped.length).toBe(6);
 });

--- a/test/learnings-lifecycle.test.ts
+++ b/test/learnings-lifecycle.test.ts
@@ -32,6 +32,7 @@ function makeLearning(o: Partial<Learning> & { id: string }): Learning {
     lastUsedAt: null,
     retiredAt: null,
     retiredReason: null,
+    scopeGlobs: [],
     createdAt: Date.now(),
     updatedAt: Date.now(),
     lastEvidenceAt: null,
@@ -315,6 +316,20 @@ describe("shouldRetire", () => {
     // Both should pass since helpfulCount=1/10 is well below 0.5 regardless of z
     expect(withDefault).toBe(true);
     expect(withTinyZ).toBe(true);
+  });
+
+  test("#842: a scope-gated rule never injected (injectedCount=0) is not auto-retired", () => {
+    // A glob-scoped rule whose globs never matched a task stays at injectedCount=0.
+    // Even flagged ineffective, the nMin gate (injectedCount < nMin) must spare it —
+    // scoping must never turn into unfair retirement.
+    const scopedUnmatched = makeLearning({
+      id: "s",
+      scopeGlobs: ["src/**"],
+      injectedCount: 0,
+      ineffectiveCount: 3,
+      helpfulCount: 0,
+    });
+    expect(shouldRetire(scopedUnmatched, baseRate)).toBe(false);
   });
 });
 

--- a/test/server-learnings.test.ts
+++ b/test/server-learnings.test.ts
@@ -6,6 +6,7 @@ import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
 import { config } from "../src/config";
 import type { PromoteResult } from "../src/promote";
+import { HOUSE_RULES_OVERHEAD } from "../src/house-rules";
 
 let tmpRoot: string;
 let validRepo: string;
@@ -512,4 +513,110 @@ test("PUT /api/repo-config autoOptimizeFlagged:false round-trips", async () => {
   );
   expect(putRes.status).toBe(200);
   expect((await putRes.json()).autoOptimizeFlagged).toBe(false);
+});
+
+// ── #842 scope route + injectable scoped bucket ──────────────────────────────
+
+function harnessWithStore(): {
+  app: ReturnType<typeof makeApp>;
+  store: SessionStore;
+  emitted: Array<[string, unknown]>;
+} {
+  const store = new SessionStore(":memory:");
+  const emitted: Array<[string, unknown]> = [];
+  const events = new EventHub();
+  const origEmit = events.emit.bind(events);
+  events.emit = (event: string, data: unknown) => {
+    emitted.push([event, data]);
+    return origEmit(event, data);
+  };
+  const deps: AppDeps = {
+    store,
+    service: {} as any,
+    events,
+    usageLimits: { limits: () => ({}) } as any,
+  };
+  return { app: makeApp(deps), store, emitted };
+}
+
+test("POST /api/learnings/:id/scope sets globs, returns the rule, emits update", async () => {
+  const { app, store, emitted } = harnessWithStore();
+  const l = store.addLearning({ repoPath: "/r", rule: "x", rationale: "", evidence: [] });
+  const res = await app.fetch(
+    new Request(`http://x/api/learnings/${l.id}/scope`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ globs: ["src/**", "src/**", " ui/** "] }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { scopeGlobs: string[] };
+  expect(body.scopeGlobs).toEqual(["src/**", "ui/**"]);
+  expect(store.getLearning(l.id)!.scopeGlobs).toEqual(["src/**", "ui/**"]);
+  expect(emitted.some(([e]) => e === "learnings:update")).toBe(true);
+});
+
+test("POST /api/learnings/:id/scope with a bad body clears to [] (Always-rule)", async () => {
+  const { app, store } = harnessWithStore();
+  const l = store.addLearning({
+    repoPath: "/r",
+    rule: "x",
+    rationale: "",
+    evidence: [],
+    scopeGlobs: ["src/**"],
+  });
+  const res = await app.fetch(
+    new Request(`http://x/api/learnings/${l.id}/scope`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ globs: "not-an-array" }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  expect(store.getLearning(l.id)!.scopeGlobs).toEqual([]);
+});
+
+test("POST /api/learnings/:id/scope on a missing rule → 404", async () => {
+  const { app } = harnessWithStore();
+  const res = await app.fetch(
+    new Request("http://x/api/learnings/nope/scope", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ globs: ["src/**"] }),
+    }),
+  );
+  expect(res.status).toBe(404);
+});
+
+test("GET /api/learnings/injectable marks scoped rules and excludes them from usedChars", async () => {
+  const { app, store } = harnessWithStore();
+  // One Always-rule (injects) + one glob-scoped rule (gated in this no-session preview).
+  const always = store.addLearning({ repoPath: "/r", rule: "always", rationale: "", evidence: [] });
+  store.setLearningStatus(always.id, "active");
+  const scoped = store.addLearning({
+    repoPath: "/r",
+    rule: "scoped",
+    rationale: "",
+    evidence: [],
+    scopeGlobs: ["src/**"],
+  });
+  store.setLearningStatus(scoped.id, "active");
+
+  const res = await app.fetch(new Request("http://x/api/learnings/injectable"));
+  expect(res.status).toBe(200);
+  const out = (await res.json()) as {
+    repoPath: string;
+    usedChars: number;
+    rules: { id: string; injected: boolean; scoped: boolean }[];
+  }[];
+  const repo = out.find((r) => r.repoPath === "/r")!;
+  const byId = Object.fromEntries(repo.rules.map((r) => [r.id, r]));
+  expect(byId[always.id]!.injected).toBe(true);
+  expect(byId[always.id]!.scoped).toBe(false);
+  // scoped rule: not injected, flagged scoped (NOT over-budget)
+  expect(byId[scoped.id]!.injected).toBe(false);
+  expect(byId[scoped.id]!.scoped).toBe(true);
+  // usedChars reflects the Always-rule only — the scoped rule never counts against budget.
+  const alwaysCost = ("- " + "always" + "\n").length;
+  expect(repo.usedChars).toBe(alwaysCost + HOUSE_RULES_OVERHEAD);
 });

--- a/test/store-learnings.test.ts
+++ b/test/store-learnings.test.ts
@@ -390,6 +390,16 @@ test("#842: setLearningScope normalizes, dedupes, and can clear back to []", () 
   expect(s.setLearningScope("missing", ["a"])).toBeNull();
 });
 
+test("#842: setLearningScope enforces the same count/length caps as the distiller", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "x", rationale: "", evidence: [] });
+  // 8 distinct globs → capped at 5; an over-long pattern is dropped.
+  const many = Array.from({ length: 8 }, (_, i) => `src/d${i}/**`);
+  const set = s.setLearningScope(l.id, [...many, "x".repeat(200)]);
+  expect(set!.scopeGlobs.length).toBe(5);
+  expect(set!.scopeGlobs).toEqual(many.slice(0, 5));
+});
+
 test("#842: a pre-existing DB without the scopeGlobs column migrates to []", () => {
   const dir = mkdtempSync(join(tmpdir(), "shepherd-store-scopeglobs-"));
   const dbPath = join(dir, "test.db");

--- a/test/store-learnings.test.ts
+++ b/test/store-learnings.test.ts
@@ -378,10 +378,12 @@ test("#842: addLearning defaults scopeGlobs to [] and round-trips supplied globs
   expect(s.getLearning(scoped.id)!.scopeGlobs).toEqual(["src/**", "ui/**/*.svelte"]);
 });
 
-test("#842: setLearningScope replaces, trims/dedupes, and can clear back to []", () => {
+test("#842: setLearningScope normalizes, dedupes, and can clear back to []", () => {
   const s = new SessionStore(":memory:");
   const l = s.addLearning({ repoPath: "/r", rule: "x", rationale: "", evidence: [] });
-  const set = s.setLearningScope(l.id, [" src/** ", "src/**", "ui/**", ""]);
+  // " src/** " and "./src/**" both normalize to "src/**" → one entry (display parity
+  // with the distiller's sanitizeScopeGlobs); empty strings drop.
+  const set = s.setLearningScope(l.id, [" src/** ", "./src/**", "/ui/**", ""]);
   expect(set!.scopeGlobs).toEqual(["src/**", "ui/**"]);
   const cleared = s.setLearningScope(l.id, []);
   expect(cleared!.scopeGlobs).toEqual([]);

--- a/test/store-learnings.test.ts
+++ b/test/store-learnings.test.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import { SessionStore } from "../src/store";
 
 test("addSignal stores and lists newest-first within a repo", () => {
@@ -355,6 +359,60 @@ test("new learnings columns exist after migration; old-shape DB migrates cleanly
   const s2 = new SessionStore(":memory:");
   const l2 = s2.addLearning({ repoPath: "/r", rule: "r2", rationale: "", evidence: [] });
   expect(l2.helpfulCount).toBe(0);
+});
+
+// ── #842 glob scope ─────────────────────────────────────────────────────────
+
+test("#842: addLearning defaults scopeGlobs to [] and round-trips supplied globs", () => {
+  const s = new SessionStore(":memory:");
+  const always = s.addLearning({ repoPath: "/r", rule: "a", rationale: "", evidence: [] });
+  expect(always.scopeGlobs).toEqual([]);
+  const scoped = s.addLearning({
+    repoPath: "/r",
+    rule: "scoped",
+    rationale: "",
+    evidence: [],
+    scopeGlobs: ["src/**", "ui/**/*.svelte"],
+  });
+  expect(scoped.scopeGlobs).toEqual(["src/**", "ui/**/*.svelte"]);
+  expect(s.getLearning(scoped.id)!.scopeGlobs).toEqual(["src/**", "ui/**/*.svelte"]);
+});
+
+test("#842: setLearningScope replaces, trims/dedupes, and can clear back to []", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "x", rationale: "", evidence: [] });
+  const set = s.setLearningScope(l.id, [" src/** ", "src/**", "ui/**", ""]);
+  expect(set!.scopeGlobs).toEqual(["src/**", "ui/**"]);
+  const cleared = s.setLearningScope(l.id, []);
+  expect(cleared!.scopeGlobs).toEqual([]);
+  expect(s.setLearningScope("missing", ["a"])).toBeNull();
+});
+
+test("#842: a pre-existing DB without the scopeGlobs column migrates to []", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-store-scopeglobs-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    // Hand-build a learnings table at the ORIGINAL schema (no scopeGlobs / Phase-1 cols).
+    const raw = new Database(dbPath);
+    raw.run(`CREATE TABLE learnings (
+      id TEXT PRIMARY KEY, repoPath TEXT NOT NULL, rule TEXT NOT NULL,
+      rationale TEXT NOT NULL DEFAULT '', evidence TEXT NOT NULL DEFAULT '[]',
+      status TEXT NOT NULL, evidenceCount INTEGER NOT NULL DEFAULT 0,
+      ineffectiveCount INTEGER NOT NULL DEFAULT 0,
+      createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL, lastEvidenceAt INTEGER, promotedPrUrl TEXT,
+      ineffectiveSignalIds TEXT NOT NULL DEFAULT '[]')`);
+    raw.run(
+      `INSERT INTO learnings (id, repoPath, rule, status, createdAt, updatedAt) VALUES ('old','/r','legacy','active',1,1)`,
+    );
+    raw.close();
+    // Opening a store runs migrateLearningsColumns → scopeGlobs column added, defaults to [].
+    const s = new SessionStore(dbPath);
+    expect(s.getLearning("old")!.scopeGlobs).toEqual([]);
+    // And a newly-set scope persists on the migrated table.
+    expect(s.setLearningScope("old", ["src/**"])!.scopeGlobs).toEqual(["src/**"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("FSM: active→retired and promoted→retired succeed", () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1642,5 +1642,16 @@
   "backlog_ff_main": "Vorspulen",
   "backlog_ff_main_title": "Lokalen Standard-Branch vorspulen",
   "feat_ff_main_title": "Vorspulen auf Knopfdruck",
-  "feat_ff_main_body": "Den lokalen Standard-Branch eines Repos jederzeit aus dem Backlog auf origin vorspulen – kein PR-Merge erforderlich."
+  "feat_ff_main_body": "Den lokalen Standard-Branch eines Repos jederzeit aus dem Backlog auf origin vorspulen – kein PR-Merge erforderlich.",
+  "common_save": "Speichern",
+  "learnings_scoped_badge": "Begrenzt",
+  "learnings_scoped_title": "Auf Globs begrenzte Regel – wird nur für Aufgaben injiziert, deren Zieldateien zu ihren Globs passen, nicht in jede Sitzung. So bleibt das Budget für die Regeln, die eine Aufgabe wirklich braucht.",
+  "learnings_scope_label": "Geltungsbereich:",
+  "learnings_scope_always": "immer (jede Aufgabe)",
+  "learnings_scope_edit": "Bereich bearbeiten",
+  "learnings_scope_placeholder": "z. B. src/**, ui/**/*.svelte",
+  "learnings_scope_input_aria": "Glob-Muster, durch Komma oder Leerzeichen getrennt",
+  "learnings_scope_failed": "Geltungsbereich konnte nicht aktualisiert werden",
+  "feat_scoped_learnings_title": "Hausregeln auf Dateien begrenzen",
+  "feat_scoped_learnings_body": "Eine gelernte Regel kann jetzt Glob-Muster tragen (z. B. src/**), sodass sie nur für Aufgaben injiziert wird, die diese Dateien berühren – das 4000-Zeichen-Budget greift innerhalb der passenden Menge statt über das ganze Repo. Den Bereich einer Regel im Learnings-Panel setzen oder entfernen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1642,5 +1642,16 @@
   "backlog_ff_main": "Fast-forward",
   "backlog_ff_main_title": "Fast-forward local default branch",
   "feat_ff_main_title": "Fast-forward on demand",
-  "feat_ff_main_body": "Fast-forward a repo's local default branch to origin any time from the Backlog — no PR merge required."
+  "feat_ff_main_body": "Fast-forward a repo's local default branch to origin any time from the Backlog — no PR merge required.",
+  "common_save": "Save",
+  "learnings_scoped_badge": "Scoped",
+  "learnings_scoped_title": "Glob-scoped rule — injected only for tasks whose target files match its globs, not every session. Keeps the budget for the rules a task actually needs.",
+  "learnings_scope_label": "Scope:",
+  "learnings_scope_always": "always (every task)",
+  "learnings_scope_edit": "Edit scope",
+  "learnings_scope_placeholder": "e.g. src/**, ui/**/*.svelte",
+  "learnings_scope_input_aria": "Glob patterns, comma- or space-separated",
+  "learnings_scope_failed": "Couldn't update scope",
+  "feat_scoped_learnings_title": "House rules scoped to files",
+  "feat_scoped_learnings_body": "A learned rule can now carry glob patterns (e.g. src/**) so it's injected only for tasks touching those files — the 4000-char budget caps within the matched set instead of biting across the whole repo. Set or clear a rule's scope from the Learnings drawer."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1255,6 +1255,18 @@ export async function optimizeLearning(id: string): Promise<void> {
   if (!r.ok) throw await failed(r, "optimize");
 }
 
+/** Set (or clear, with `[]`) a rule's glob scope (#842). Returns the updated rule;
+ *  the drawer reloads on the learnings:update event. */
+export async function setLearningScope(id: string, globs: string[]): Promise<Learning> {
+  const r = await fetch(`/api/learnings/${id}/scope`, {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ globs }),
+  });
+  if (!r.ok) throw await failed(r, "scope");
+  return r.json();
+}
+
 /** Restore a retired learning rule back to active. */
 export async function restoreLearning(id: string): Promise<Learning> {
   const r = await fetch(`/api/learnings/${id}/restore`, { method: "POST", headers: JSON_HEADERS });

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -3,7 +3,7 @@
   import type { Action } from "svelte/action";
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
-  import type { Learning, RepoInjectable, SignalKind } from "$lib/types";
+  import type { InjectableRule, Learning, RepoInjectable, SignalKind } from "$lib/types";
   import { learnings } from "$lib/learnings.svelte";
   import {
     basename,
@@ -102,6 +102,7 @@
     onoptimize,
     onoptimizeall,
     onrestore,
+    onscope,
     onseenretired,
     onclose,
   }: {
@@ -115,12 +116,30 @@
     onoptimize: (id: string) => void;
     onoptimizeall: (repoPath: string) => void;
     onrestore: (id: string) => void;
+    onscope: (id: string, globs: string[]) => void;
     onseenretired: (repoPath: string) => void;
     onclose: () => void;
   } = $props();
 
   let drafts = $state<Record<string, string>>({});
   const draft = (l: Learning) => drafts[l.id] ?? l.rule;
+
+  // Glob-scope editing (#842): which injectable rule has its scope editor open, and the
+  // comma-separated draft text. Saving splits on commas/whitespace into a glob array.
+  let editingScope = $state<string | null>(null);
+  let scopeDraft = $state("");
+  function openScopeEditor(l: Learning & { scopeGlobs: string[] }) {
+    editingScope = l.id;
+    scopeDraft = l.scopeGlobs.join(", ");
+  }
+  function saveScope(id: string) {
+    const globs = scopeDraft
+      .split(/[,\s]+/)
+      .map((g) => g.trim())
+      .filter(Boolean);
+    onscope(id, globs);
+    editingScope = null;
+  }
 
   const reduceMotion =
     typeof window !== "undefined" &&
@@ -288,7 +307,7 @@
 
   <!-- Change 6: Injectable-rule snippet — single source, no copy-paste.
        Accepts the repo's enabled flag so the badge reflects injection state correctly. -->
-  {#snippet irule(r: Learning & { injected: boolean }, enabled: boolean)}
+  {#snippet irule(r: InjectableRule, enabled: boolean)}
     {@const badge = injectionBadge(r, enabled)}
     <article class="irule">
       <p class="itext">{r.rule}</p>
@@ -298,6 +317,10 @@
         </span>
         {#if badge === "injected"}
           <span class="badge ok">✓ {m.learnings_injected_badge()}</span>
+        {:else if badge === "scoped"}
+          <span class="badge scoped" title={m.learnings_scoped_title()}>
+            ◎ {m.learnings_scoped_badge()}
+          </span>
         {:else if badge === "over-budget"}
           <span class="badge warn" title={m.learnings_overbudget_title()}>
             ⊘ {m.learnings_overbudget_badge()}
@@ -346,6 +369,34 @@
             </a>
           {/if}
         </div>
+      </div>
+      <!-- #842: glob scope — which files this rule applies to (empty = always). -->
+      <div class="iscope">
+        {#if editingScope === r.id}
+          <input
+            class="scope-input"
+            type="text"
+            bind:value={scopeDraft}
+            placeholder={m.learnings_scope_placeholder()}
+            aria-label={m.learnings_scope_input_aria()}
+          />
+          <button class="scope-save" type="button" onclick={() => saveScope(r.id)}>
+            {m.common_save()}
+          </button>
+          <button class="scope-cancel" type="button" onclick={() => (editingScope = null)}>
+            {m.common_cancel()}
+          </button>
+        {:else}
+          <span class="scope-label">{m.learnings_scope_label()}</span>
+          {#if r.scopeGlobs.length > 0}
+            {#each r.scopeGlobs as g (g)}<code class="scope-glob">{g}</code>{/each}
+          {:else}
+            <span class="scope-always">{m.learnings_scope_always()}</span>
+          {/if}
+          <button class="scope-edit" type="button" onclick={() => openScopeEditor(r)}>
+            {m.learnings_scope_edit()}
+          </button>
+        {/if}
       </div>
     </article>
   {/snippet}
@@ -1013,6 +1064,58 @@
   }
   .badge.off {
     color: var(--color-muted);
+  }
+  .badge.scoped {
+    border-color: var(--color-blue);
+    color: var(--color-blue);
+    cursor: help;
+  }
+  .iscope {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    margin-top: 6px;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+  .scope-label {
+    color: var(--color-muted);
+  }
+  .scope-glob {
+    padding: 1px 5px;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-blue);
+    background: color-mix(in srgb, var(--color-blue) 10%, var(--color-head));
+  }
+  .scope-always {
+    color: var(--color-muted);
+    font-style: italic;
+  }
+  .scope-edit,
+  .scope-save,
+  .scope-cancel {
+    font-size: var(--fs-meta);
+    background: none;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    padding: 2px 7px;
+    cursor: pointer;
+  }
+  .scope-edit:hover,
+  .scope-save:hover,
+  .scope-cancel:hover {
+    color: var(--color-ink-bright);
+    border-color: var(--color-ink-bright);
+  }
+  .scope-input {
+    flex: 1 1 12rem;
+    min-width: 0;
+    font-size: var(--fs-meta);
+    padding: 2px 6px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-ink-bright);
   }
   .help-rate {
     font-size: var(--fs-micro);

--- a/ui/src/lib/components/learnings-drawer.test.ts
+++ b/ui/src/lib/components/learnings-drawer.test.ts
@@ -39,6 +39,7 @@ function L(id: string, repo: string, status: LearningStatus = "proposed"): Learn
     lastUsedAt: null,
     retiredAt: null,
     retiredReason: null,
+    scopeGlobs: [],
     createdAt: 0,
     updatedAt: 0,
     lastEvidenceAt: null,
@@ -48,7 +49,14 @@ function L(id: string, repo: string, status: LearningStatus = "proposed"): Learn
 
 function IR(
   repo: string,
-  rules: { id: string; injected: boolean; status?: LearningStatus; ineffectiveCount?: number }[],
+  rules: {
+    id: string;
+    injected: boolean;
+    status?: LearningStatus;
+    ineffectiveCount?: number;
+    scoped?: boolean;
+    scopeGlobs?: string[];
+  }[],
   over: Partial<RepoInjectable> = {},
 ): RepoInjectable {
   return {
@@ -59,6 +67,8 @@ function IR(
     rules: rules.map((r) => ({
       ...L(r.id, repo, r.status ?? "active"),
       injected: r.injected,
+      scoped: r.scoped ?? false,
+      scopeGlobs: r.scopeGlobs ?? [],
       ineffectiveCount: r.ineffectiveCount ?? 0,
     })),
     retired: [],
@@ -129,7 +139,11 @@ describe("mergeRepoGroups", () => {
 });
 
 describe("injectionBadge", () => {
-  const rule = (injected: boolean) => ({ ...L("1", "/a", "active"), injected });
+  const rule = (injected: boolean, scoped = false) => ({
+    ...L("1", "/a", "active"),
+    injected,
+    scoped,
+  });
   it("disabled when repo injection is off, regardless of injected flag", () => {
     expect(injectionBadge(rule(true), false)).toBe("disabled");
     expect(injectionBadge(rule(false), false)).toBe("disabled");

--- a/ui/src/lib/components/learnings-drawer.ts
+++ b/ui/src/lib/components/learnings-drawer.ts
@@ -1,4 +1,4 @@
-import type { Learning, RepoInjectable, SignalKind } from "../types";
+import type { InjectableRule, Learning, RepoInjectable, SignalKind } from "../types";
 
 /** Last non-empty path segment (repo display name). */
 export function basename(p: string): string {
@@ -60,18 +60,22 @@ export function mergeRepoGroups(proposed: Learning[], injectable: RepoInjectable
   return groups;
 }
 
-export type InjectionBadge = "injected" | "over-budget" | "disabled";
+export type InjectionBadge = "injected" | "over-budget" | "disabled" | "scoped";
 
 /** Which injection badge a rule shows, given the repo's enabled flag.
  *  - disabled: repo injection is off → rule isn't injected regardless of budget
  *  - injected: rule made the budget cut
+ *  - scoped: glob-scoped rule, injects only for matching tasks (NOT over-budget;
+ *    this preview has no session, so it's shown conditional, not dropped)
  *  - over-budget: enabled but the rule didn't fit (operator can prune to free room) */
 export function injectionBadge(
-  rule: Learning & { injected: boolean },
+  rule: Learning & { injected: boolean; scoped?: boolean },
   enabled: boolean,
 ): InjectionBadge {
   if (!enabled) return "disabled";
-  return rule.injected ? "injected" : "over-budget";
+  if (rule.injected) return "injected";
+  if (rule.scoped) return "scoped";
+  return "over-budget";
 }
 
 /** Count of rules the planner actually injected (true count for the meter). */
@@ -85,7 +89,7 @@ export function showIneffective(rule: { ineffectiveCount: number }): boolean {
 }
 
 /** Flagged ("not working") rules in a repo's injectable view (ineffectiveCount > 0). */
-export function flaggedRules(repo: RepoInjectable | null): (Learning & { injected: boolean })[] {
+export function flaggedRules(repo: RepoInjectable | null): InjectableRule[] {
   return repo ? repo.rules.filter((r) => r.ineffectiveCount > 0) : [];
 }
 /** Count of flagged rules in a repo's injectable view. */
@@ -101,9 +105,11 @@ export function totalFlagged(injectable: RepoInjectable[]): number {
 
 /** Count of rules the planner dropped (didn't fit budget) for an enabled repo.
  *  Null repo → 0. Disabled repo → 0 (rules are uninjected because injection is
- *  off, NOT budget pressure — the single authoritative "over budget" predicate). */
+ *  off, NOT budget pressure — the single authoritative "over budget" predicate).
+ *  Scope-gated rules are excluded: they're uninjected because no task matched their
+ *  globs, not because of budget pressure (#842). */
 export function droppedCount(repo: RepoInjectable | null): number {
-  return repo && repo.enabled ? repo.rules.filter((r) => !r.injected).length : 0;
+  return repo && repo.enabled ? repo.rules.filter((r) => !r.injected && !r.scoped).length : 0;
 }
 
 /** True when the repo has ≥1 rule the planner dropped due to budget pressure. */
@@ -131,14 +137,16 @@ export function sortGroupsForTriage(groups: RepoGroup[]): RepoGroup[] {
  *  without dropped rules are returned unsplit (all rules in `injected`) so the
  *  drawer doesn't mislabel a disabled repo's rules as "not injected". */
 export function splitDropped(repo: RepoInjectable | null): {
-  dropped: (Learning & { injected: boolean })[];
-  injected: (Learning & { injected: boolean })[];
+  dropped: InjectableRule[];
+  injected: InjectableRule[];
 } {
   if (!repo) return { dropped: [], injected: [] };
   if (!isOverBudget(repo)) return { dropped: [], injected: repo.rules };
+  // Scope-gated rules are not over-budget — they stay in the non-dropped bucket
+  // (rendered with their own "scoped" badge), only true budget casualties drop.
   return {
-    dropped: repo.rules.filter((r) => !r.injected),
-    injected: repo.rules.filter((r) => r.injected),
+    dropped: repo.rules.filter((r) => !r.injected && !r.scoped),
+    injected: repo.rules.filter((r) => r.injected || r.scoped),
   };
 }
 
@@ -164,15 +172,15 @@ export function reposNeedingAttention(
 export function visibleInjectableRules(
   repo: RepoInjectable | null,
   lenses: { flaggedOnly: boolean; overBudgetOnly: boolean },
-): (Learning & { injected: boolean })[] {
+): InjectableRule[] {
   if (!repo) return [];
   if (!lenses.flaggedOnly && !lenses.overBudgetOnly) return repo.rules;
   const overBudget = isOverBudget(repo);
   const ids = new Set<string>();
-  const result: (Learning & { injected: boolean })[] = [];
+  const result: InjectableRule[] = [];
   for (const r of repo.rules) {
     const wantFlagged = lenses.flaggedOnly && r.ineffectiveCount > 0;
-    const wantDropped = lenses.overBudgetOnly && !r.injected && overBudget;
+    const wantDropped = lenses.overBudgetOnly && !r.injected && !r.scoped && overBudget;
     if ((wantFlagged || wantDropped) && !ids.has(r.id)) {
       ids.add(r.id);
       result.push(r);

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -46,6 +46,7 @@ function learning(over: Partial<Learning>): Learning {
     lastUsedAt: null,
     retiredAt: null,
     retiredReason: null,
+    scopeGlobs: [],
     createdAt: 0,
     updatedAt: 0,
     lastEvidenceAt: null,
@@ -54,8 +55,11 @@ function learning(over: Partial<Learning>): Learning {
   };
 }
 
-function rule(injected: boolean): Learning & { injected: boolean } {
-  return { ...learning({}), injected };
+function rule(
+  injected: boolean,
+  scoped = false,
+): Learning & { injected: boolean; scoped: boolean } {
+  return { ...learning({}), injected, scoped };
 }
 
 function injectable(over: Partial<RepoInjectable>): RepoInjectable {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1245,4 +1245,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_ff_main_body",
     targetId: "backlog-ff-main",
   },
+  {
+    // Glob-scoped house rules (#842): a learning can carry scopeGlobs so it injects
+    // only for tasks touching matching files; surfaced in the Learnings drawer (scope
+    // line + editor + "Scoped" badge). v1.34.0 is the latest released tag → 1.35.0.
+    id: "scoped-learnings",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_scoped_learnings_title",
+    bodyKey: "feat_scoped_learnings_body",
+  },
 ];

--- a/ui/src/lib/learnings.svelte.test.ts
+++ b/ui/src/lib/learnings.svelte.test.ts
@@ -17,6 +17,7 @@ function L(id: string): Learning {
     lastUsedAt: null,
     retiredAt: null,
     retiredReason: null,
+    scopeGlobs: [],
     createdAt: 0,
     updatedAt: 0,
     lastEvidenceAt: null,

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1051,6 +1051,10 @@ export interface Learning {
   lastUsedAt: number | null;
   retiredAt: number | null;
   retiredReason: string | null;
+  // Glob patterns scoping where this rule injects (repo-relative). Empty = an
+  // Always-rule (every task); non-empty = injected only when the session's target
+  // files match a glob (#842).
+  scopeGlobs: string[];
   createdAt: number;
   updatedAt: number;
   lastEvidenceAt: number | null;
@@ -1060,13 +1064,20 @@ export interface Learning {
 /** GET /api/learnings/injectable: one entry per repo with ≥1 active/promoted rule.
  *  Drives the drawer's "Injected house rules" view; the budget value flows from
  *  here so the UI never hardcodes it. `injected` reflects the server-side planner's
- *  greedy fit; when `enabled` is false every rule is `injected:false`, `usedChars:0`. */
+ *  greedy fit; when `enabled` is false every rule is `injected:false`, `usedChars:0`.
+ *  `scoped` marks a glob-scoped rule — in this preview (no session) it never injects;
+ *  it's conditional on a task's files matching, NOT over-budget. */
+/** A learning as it appears in the injectable preview: the rule plus the planner's
+ *  per-rule verdict — `injected` (made the budget cut) and `scoped` (glob-conditional,
+ *  not injected in this no-session preview). */
+export type InjectableRule = Learning & { injected: boolean; scoped: boolean };
+
 export interface RepoInjectable {
   repoPath: string;
   enabled: boolean;
   budgetChars: number;
   usedChars: number;
-  rules: (Learning & { injected: boolean })[];
+  rules: InjectableRule[];
   retired: Learning[];
   unseenRetired: number;
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1061,17 +1061,17 @@ export interface Learning {
   promotedPrUrl: string | null;
 }
 
+/** A learning as it appears in the injectable preview: the rule plus the planner's
+ *  per-rule verdict — `injected` (made the budget cut) and `scoped` (glob-conditional,
+ *  not injected in this no-session preview). */
+export type InjectableRule = Learning & { injected: boolean; scoped: boolean };
+
 /** GET /api/learnings/injectable: one entry per repo with ≥1 active/promoted rule.
  *  Drives the drawer's "Injected house rules" view; the budget value flows from
  *  here so the UI never hardcodes it. `injected` reflects the server-side planner's
  *  greedy fit; when `enabled` is false every rule is `injected:false`, `usedChars:0`.
  *  `scoped` marks a glob-scoped rule — in this preview (no session) it never injects;
  *  it's conditional on a task's files matching, NOT over-budget. */
-/** A learning as it appears in the injectable preview: the rule plus the planner's
- *  per-rule verdict — `injected` (made the budget cut) and `scoped` (glob-conditional,
- *  not injected in this no-session preview). */
-export type InjectableRule = Learning & { injected: boolean; scoped: boolean };
-
 export interface RepoInjectable {
   repoPath: string;
   enabled: boolean;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -33,6 +33,7 @@
     optimizeLearning,
     optimizeRepoFlagged,
     restoreLearning,
+    setLearningScope,
     markRetiredSeen,
     getMergedClearable,
     clearMerged,
@@ -1962,6 +1963,10 @@
         restoreLearning(id)
           .then(() => learnings.load())
           .catch(() => toasts.info(m.learnings_restore_failed()))}
+      onscope={(id, globs) =>
+        setLearningScope(id, globs)
+          .then(() => learnings.load())
+          .catch(() => toasts.info(m.learnings_scope_failed()))}
       onseenretired={(repoPath) =>
         markRetiredSeen(repoPath)
           .then(() => learnings.load())


### PR DESCRIPTION
Phase 3 of the learnings-lifecycle epic (#838). Closes #842.

## What

Adds an optional `scopeGlobs` to each learning. At spawn, inject **Always-rules** (no globs) **plus** glob-scoped rules whose globs match files named in the task text (prompt + attached issue); the 4000-char house-rules budget then caps **within the matched set**. For large repos this makes the cap stop biting — most rules stop being candidates for most tasks. Fully backward-compatible: existing rules default to `scopeGlobs = []` = Always-rule, so behavior is unchanged until a rule gains globs.

Scope is **distiller-inferred** (from path-like text in the originating signals) **or operator-set** in the Learnings drawer.

## How

- **Schema** (`store.ts`/`types.ts`): `scopeGlobs` JSON column (+ migration, hydrate, `addLearning`, `setLearningScope`). Pre-existing rows migrate to `[]`.
- **Injection** (`house-rules.ts`): `extractTargetPaths` (heuristic over task text — actual touched files are unknowable at spawn) + `Bun.Glob` matching (dependency-free; full-path match + a basename fallback for bare-filename tokens). `planHouseRulesInjection` packs **Always-rules first** (guaranteed the budget), then matched-scoped into the remainder, and returns a distinct `scoped[]` bucket for scope-gated rules (not over-budget).
- **Spawn** (`service.ts`): derives target paths from `prompt` + `issueRef.title/body`.
- **Distiller** (`distiller.ts`): prompt emits an optional `scopeGlobs` per ADD; `sanitizeScopeGlobs` validates/normalizes/caps (≤5, ≤120 chars).
- **Server** (`server.ts`): injectable preview marks scoped rules and excludes them from `usedChars`; `POST /api/learnings/:id/scope` to set/clear globs.
- **UI** (`LearningsDrawer.svelte` + helpers): per-rule scope line + inline editor + "Scoped" badge; `droppedCount` excludes scoped rules so the budget meter stays truthful. Feature-catalog entry + EN/DE keys.

## Composition with #841 (composite ranking)

Scoping is a **pre-filter** applied before `prioritize()`, so it composes with #866's composite recency/help ranking independently (rebased onto it; `planHouseRulesInjection` now threads `now` through to the per-group sort). Never-injected scoped rules keep `injectedCount = 0`, so `shouldRetire`'s `nMin` gate spares them from unfair auto-retirement (pinned by a regression test).

## Tests

Fail-before-fix regression tests: glob/path normalization matrix, Always-first budget precedence, distiller `scopeGlobs` passthrough/validation, store roundtrip + migration + `setLearningScope`, server scope route + injectable scoped bucket, and the no-unfair-retire guard. Root + UI suites, lint, tsc, i18n parity, feature-catalog, glossary, branch-hygiene, and fallow delta audit all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)