### PR TITLE
feat(learnings): show repo emoji/symbol in drawer group headers

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1674,5 +1674,7 @@
   "feat_open_linked_issue_title": "Verknüpftes Issue öffnen",
   "feat_open_linked_issue_body": "GitRail zeigt jetzt einen \"Issue #N ↗\"-Link für Aufgaben, die aus einem Backlog-Issue gestartet wurden – direkt zum Issue auf GitHub oder Gitea springen.",
   "feat_learnings_retire_push_title": "Push-Benachrichtigung beim Auto-Zurückziehen",
-  "feat_learnings_retire_push_body": "Wenn der tägliche Hintergrundlauf leistungsschwache Hausregeln zurückzieht, erhältst du jetzt eine Push-Benachrichtigung – so erfährst du davon, ohne das Learnings-Panel zu öffnen. Tippe darauf, um die zurückgezogenen Regeln zu prüfen und versehentlich zurückgezogene wiederherzustellen."
+  "feat_learnings_retire_push_body": "Wenn der tägliche Hintergrundlauf leistungsschwache Hausregeln zurückzieht, erhältst du jetzt eine Push-Benachrichtigung – so erfährst du davon, ohne das Learnings-Panel zu öffnen. Tippe darauf, um die zurückgezogenen Regeln zu prüfen und versehentlich zurückgezogene wiederherzustellen.",
+  "feat_learnings_repo_glyph_title": "Repo auf einen Blick in den Erkenntnissen",
+  "feat_learnings_repo_glyph_body": "Jede Repo-Gruppe im Erkenntnisse-Panel zeigt jetzt das Projekt-Emoji (oder das ▣-Symbol) neben dem Namen – genau wie die Session-Karten – damit klar ist, zu welchem Repo eine Erkenntnis gehört."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1674,5 +1674,7 @@
   "feat_open_linked_issue_title": "Open the linked issue",
   "feat_open_linked_issue_body": "GitRail now shows an \"Issue #N ↗\" link for tasks spawned from a backlog issue — jump straight to the issue on GitHub or Gitea.",
   "feat_learnings_retire_push_title": "Auto-retire push notifications",
-  "feat_learnings_retire_push_body": "When the daily background pass retires underperforming house rules, you now get a push notification so you learn of it without opening the Learnings drawer. Tap it to review the retired rules and restore any retired by mistake."
+  "feat_learnings_retire_push_body": "When the daily background pass retires underperforming house rules, you now get a push notification so you learn of it without opening the Learnings drawer. Tap it to review the retired rules and restore any retired by mistake.",
+  "feat_learnings_repo_glyph_title": "Repo at a glance in Learnings",
+  "feat_learnings_repo_glyph_body": "Each repo's group in the Learnings drawer now shows its project emoji (or the ▣ marker) beside the name — just like session cards — so it's clear which repo a learning belongs to."
 }

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -11,6 +11,7 @@
     SignalKind,
   } from "$lib/types";
   import { learnings } from "$lib/learnings.svelte";
+  import { projectIcons } from "$lib/projectIcons.svelte";
   import {
     basename,
     repoAnchorId,
@@ -456,10 +457,18 @@
   {:else}
     {#each displayGroups as group (group.repoPath)}
       <!-- Change 4: group container with left-accent border + faint surface -->
+      {@const repoIcon = projectIcons.iconFor(group.repoPath)}
       <section class="group" id={repoAnchorId(group.repoPath)}>
         <!-- Change 4: sticky repo header -->
         <div class="ghead">
-          <span class="repo">{basename(group.repoPath)}</span>
+          <!-- Repo identity glyph + name, mirroring the session-card label
+               (UnitRow): the configured project emoji when set, else the ▣
+               marker — makes it clear at a glance which repo a card concerns. -->
+          <span class="repo">
+            <span class="repo-glyph" class:emoji={!!repoIcon} aria-hidden="true"
+              >{repoIcon ?? "▣"}</span
+            >{basename(group.repoPath)}
+          </span>
           <button
             class="distill"
             onclick={() => onmergenow(group.repoPath)}
@@ -869,9 +878,22 @@
     background: var(--color-head);
   }
   .repo {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
     font-size: var(--fs-base);
     color: var(--color-ink-bright);
     font-weight: 600;
+  }
+  /* Repo marker before the name — muted ▣ matches the session-card glyph; a
+     configured project emoji renders at its own (slightly larger) size. */
+  .repo-glyph {
+    color: var(--color-muted);
+    font-size: var(--fs-micro);
+    flex-shrink: 0;
+  }
+  .repo-glyph.emoji {
+    font-size: var(--fs-base);
   }
   .distill {
     font-size: var(--fs-meta);

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1288,4 +1288,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_learnings_retire_push_title",
     bodyKey: "feat_learnings_retire_push_body",
   },
+  {
+    // Learnings drawer repo group headers now carry the project emoji (or the ▣
+    // marker) before the repo name, matching the session-card label so it's clear
+    // at a glance which repo each card concerns. Lives in the closed-by-default
+    // drawer → What's-New only, no coachmark target.
+    id: "learnings-repo-glyph",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_learnings_repo_glyph_title",
+    bodyKey: "feat_learnings_repo_glyph_body",
+  },
 ];


### PR DESCRIPTION
## Was

In den **Erkenntnissen** (Learnings-Drawer) zeigt jede Repo-Gruppe jetzt das **Projekt-Emoji** (bzw. das ▣-Symbol als Fallback) klein vor dem Repo-Namen an — genau wie die Karten der laufenden Agent-Sessions. So ist auf einen Blick klar, um welches Repo eine Karte geht.

## Warum

Bisher stand im Gruppenheader nur der Repo-Basename. Die Session-Karten (`UnitRow`) tragen längst Emoji + Symbol als Repo-Identität; dieselbe Sprache fehlte in den Erkenntnissen. Diese Angleichung macht die Zuordnung klarer und konsistent.

## Änderungen

- `LearningsDrawer.svelte`: Repo-Glyph (`projectIcons.iconFor` → Emoji, sonst `▣`) vor dem Namen im `.ghead`, gestylt wie der Session-Card-Marker (muted, klein; Emoji etwas größer).
- What's-New-Katalogeintrag `learnings-repo-glyph` (#feature-discovery) + EN/DE-Message-Keys.

## Verifikation

- `bun run check` ✓ · `bun run check:i18n` ✓ (Parität) · `learnings-drawer` Tests 54/54 ✓
- Lokal live: Vite auf :5174

🤖 Generated with [Claude Code](https://claude.com/claude-code)