### PR TITLE
refactor(ui): split IssuesPanel + BacklogView templates, drop fallow grandfathers (#855)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -237,22 +237,6 @@
         "maxCognitive": 140,
         "maxCrap": 20000,
         "reason": "Tier 2 grandfather (#851); refactor candidate #855. Cognitive bar raised 110→130 in #840 (auto-retire UI), then 130→140 in #842: glob-scoped injection added the per-rule scope line + inline editor + 'Scoped' badge to this component (its own UI home), per the established 'next multiple of 10 above current' convention."
-      },
-      {
-        "files": ["ui/src/lib/components/BacklogView.svelte"],
-        "functions": ["<template>"],
-        "maxCyclomatic": 40,
-        "maxCognitive": 80,
-        "maxCrap": 20000,
-        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
-      },
-      {
-        "files": ["ui/src/lib/components/IssuesPanel.svelte"],
-        "functions": ["<template>"],
-        "maxCyclomatic": 40,
-        "maxCognitive": 100,
-        "maxCrap": 20000,
-        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
       }
     ],
 

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -3,12 +3,8 @@
   import type { BacklogPayload, DrainStatus, Epic, Issue, PullRequest, Steer } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import ProjectBacklogList from "./ProjectBacklogList.svelte";
-  import IssuesPanel from "./IssuesPanel.svelte";
-  import PrsPanel from "./PrsPanel.svelte";
-  import ActionsPanel from "./ActionsPanel.svelte";
-  import ReadinessPanel from "./ReadinessPanel.svelte";
-  import AutomationSettings from "./AutomationSettings.svelte";
-  import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import BacklogTabBar from "./backlog-view/BacklogTabBar.svelte";
+  import BacklogTabContent from "./backlog-view/BacklogTabContent.svelte";
   import { actionsTabState, filterProjects } from "./backlog-view";
   import { pullMainAndToast } from "$lib/pull-offer";
 
@@ -197,112 +193,31 @@
           >
             ‹ {m.common_close()}
           </button>
-          <div class="overlay-tabs">
-            <button
-              class="tab-btn"
-              class:active={activeTab === "issues"}
-              type="button"
-              onclick={() => (activeTab = "issues")}
-            >
-              {selected && selected.openIssues !== null
-                ? m.backlog_tab_issues_count({ count: selected.openIssues })
-                : m.backlog_tab_issues()}
-            </button>
-            <button
-              class="tab-btn"
-              class:active={activeTab === "prs"}
-              type="button"
-              onclick={() => (activeTab = "prs")}
-            >
-              {selected && selected.openPRs !== null
-                ? m.backlog_tab_prs_count({ count: selected.openPRs })
-                : m.backlog_tab_prs()}
-            </button>
-            <button
-              class="tab-btn"
-              class:active={activeTab === "actions"}
-              class:failing={actionsState.kind === "failing"}
-              type="button"
-              onclick={() => (activeTab = "actions")}
-            >
-              {#if actionsState.kind === "failing"}
-                {m.backlog_tab_actions_failing()}
-              {:else if actionsState.kind === "count"}
-                {m.backlog_tab_actions_count({ count: actionsState.count })}
-              {:else}
-                {m.backlog_tab_actions()}
-              {/if}
-            </button>
-            <button
-              class="tab-btn"
-              class:active={activeTab === "readiness"}
-              type="button"
-              onclick={() => (activeTab = "readiness")}
-            >
-              {m.backlog_tab_readiness()}
-            </button>
-            <button
-              class="tab-btn"
-              class:active={activeTab === "automation"}
-              type="button"
-              onclick={() => (activeTab = "automation")}
-            >
-              {m.backlog_tab_automation()}
-            </button>
-            <button
-              class="gbtn ff-btn"
-              type="button"
-              disabled={ffInFlight || selectedPath === null}
-              onclick={handleFf}
-              title={m.backlog_ff_main_title()}
-              aria-label={m.backlog_ff_main_title()}
-            >
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-                <path d="M1 2.5L5.5 6 1 9.5V2.5Z" fill="currentColor" />
-                <path d="M6.5 2.5L11 6 6.5 9.5V2.5Z" fill="currentColor" />
-              </svg>
-              {m.backlog_ff_main()}
-            </button>
-          </div>
+          <BacklogTabBar
+            variant="mobile"
+            {activeTab}
+            {selected}
+            {actionsState}
+            {ffInFlight}
+            {selectedPath}
+            onselecttab={(t) => (activeTab = t)}
+            onff={handleFf}
+          />
         </div>
         <div class="overlay-body">
-          {#if activeTab === "issues"}
-            <IssuesPanel
-              repoPath={selectedPath}
-              onnewtask={(issue) => {
-                onissue(selectedPath!, issue);
-              }}
-              onquick={onquick
-                ? (issue, action) => onquick(selectedPath!, issue, action)
-                : undefined}
-              bodyPreview
-              age
-              {epics}
-              expandEpic={target && target.repoPath === selectedPath ? target.issueNumber : null}
-            />
-          {:else if activeTab === "prs"}
-            <PrsPanel
-              repoPath={selectedPath}
-              onreview={(pr) => onpr(selectedPath!, pr)}
-              {onlaunchtrain}
-              {inTrainPrs}
-              age
-            />
-          {:else if activeTab === "actions"}
-            <ActionsPanel repoPath={selectedPath} />
-          {:else if activeTab === "automation"}
-            <div class="automation-scroll">
-              {#if selectedPath !== null}
-                <AutomationSettings
-                  repoPath={selectedPath}
-                  drain={drain?.[selectedPath] ?? null}
-                  showHeader={false}
-                />
-              {/if}
-            </div>
-          {:else}
-            <ReadinessPanel repoPath={selectedPath} onadopt={(rp, p) => onadopt(rp, p)} />
-          {/if}
+          <BacklogTabContent
+            {activeTab}
+            {selectedPath}
+            {onissue}
+            {onquick}
+            {onpr}
+            {onlaunchtrain}
+            {onadopt}
+            {epics}
+            {inTrainPrs}
+            {target}
+            {drain}
+          />
         </div>
       </div>
     {/if}
@@ -327,112 +242,31 @@
         />
       </div>
       <div class="detail-column">
-        <div class="tab-bar">
-          <button
-            class="tab-btn"
-            class:active={activeTab === "issues"}
-            type="button"
-            onclick={() => (activeTab = "issues")}
-          >
-            {selected && selected.openIssues !== null
-              ? m.backlog_tab_issues_count({ count: selected.openIssues })
-              : m.backlog_tab_issues()}
-          </button>
-          <button
-            class="tab-btn"
-            class:active={activeTab === "prs"}
-            type="button"
-            onclick={() => (activeTab = "prs")}
-          >
-            {selected && selected.openPRs !== null
-              ? m.backlog_tab_prs_count({ count: selected.openPRs })
-              : m.backlog_tab_prs()}
-          </button>
-          <button
-            class="tab-btn"
-            class:active={activeTab === "actions"}
-            class:failing={actionsState.kind === "failing"}
-            type="button"
-            onclick={() => (activeTab = "actions")}
-          >
-            {#if actionsState.kind === "failing"}
-              {m.backlog_tab_actions_failing()}
-            {:else if actionsState.kind === "count"}
-              {m.backlog_tab_actions_count({ count: actionsState.count })}
-            {:else}
-              {m.backlog_tab_actions()}
-            {/if}
-          </button>
-          <button
-            class="tab-btn"
-            class:active={activeTab === "readiness"}
-            type="button"
-            onclick={() => (activeTab = "readiness")}
-          >
-            {m.backlog_tab_readiness()}
-          </button>
-          <button
-            class="tab-btn"
-            class:active={activeTab === "automation"}
-            type="button"
-            onclick={() => (activeTab = "automation")}
-            use:coachTarget={"backlog-automation"}
-          >
-            {m.backlog_tab_automation()}
-          </button>
-          <button
-            class="gbtn ff-btn"
-            type="button"
-            disabled={ffInFlight || selectedPath === null}
-            onclick={handleFf}
-            title={m.backlog_ff_main_title()}
-            aria-label={m.backlog_ff_main_title()}
-            use:coachTarget={"backlog-ff-main"}
-          >
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-              <path d="M1 2.5L5.5 6 1 9.5V2.5Z" fill="currentColor" />
-              <path d="M6.5 2.5L11 6 6.5 9.5V2.5Z" fill="currentColor" />
-            </svg>
-            {m.backlog_ff_main()}
-          </button>
-        </div>
+        <BacklogTabBar
+          variant="desktop"
+          {activeTab}
+          {selected}
+          {actionsState}
+          {ffInFlight}
+          {selectedPath}
+          onselecttab={(t) => (activeTab = t)}
+          onff={handleFf}
+        />
         <div class="detail-pane">
           {#if selectedPath !== null}
-            {#if activeTab === "issues"}
-              <IssuesPanel
-                repoPath={selectedPath}
-                onnewtask={(issue) => {
-                  onissue(selectedPath!, issue);
-                }}
-                onquick={onquick
-                  ? (issue, action) => onquick(selectedPath!, issue, action)
-                  : undefined}
-                bodyPreview
-                age
-                {epics}
-                expandEpic={target && target.repoPath === selectedPath ? target.issueNumber : null}
-              />
-            {:else if activeTab === "prs"}
-              <PrsPanel
-                repoPath={selectedPath}
-                onreview={(pr) => onpr(selectedPath!, pr)}
-                {onlaunchtrain}
-                {inTrainPrs}
-                age
-              />
-            {:else if activeTab === "actions"}
-              <ActionsPanel repoPath={selectedPath} />
-            {:else if activeTab === "automation"}
-              <div class="automation-scroll">
-                <AutomationSettings
-                  repoPath={selectedPath}
-                  drain={drain?.[selectedPath] ?? null}
-                  showHeader={false}
-                />
-              </div>
-            {:else}
-              <ReadinessPanel repoPath={selectedPath} onadopt={(rp, p) => onadopt(rp, p)} />
-            {/if}
+            <BacklogTabContent
+              {activeTab}
+              {selectedPath}
+              {onissue}
+              {onquick}
+              {onpr}
+              {onlaunchtrain}
+              {onadopt}
+              {epics}
+              {inTrainPrs}
+              {target}
+              {drain}
+            />
           {:else}
             <div class="detail-empty">
               <span class="detail-empty-label">{m.backlog_select_a_project()}</span>
@@ -485,90 +319,6 @@
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--color-faint);
-  }
-
-  /* ── tab bar ── */
-  .tab-bar {
-    display: flex;
-    gap: 2px;
-    padding: 6px 10px;
-    border-bottom: 1px solid var(--color-line);
-    background: var(--color-head);
-    flex-shrink: 0;
-  }
-
-  .tab-btn {
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 2px;
-    color: var(--color-muted);
-    font-family: var(--font-mono);
-    font-size: var(--fs-meta);
-    letter-spacing: 0.1em;
-    padding: 2px 8px;
-    cursor: pointer;
-    transition:
-      color 0.12s,
-      border-color 0.12s;
-  }
-
-  .tab-btn:hover {
-    color: var(--color-ink);
-  }
-
-  .tab-btn.active {
-    color: var(--color-ink-bright);
-    border-color: var(--color-line-bright);
-    background: var(--color-inset);
-  }
-
-  .tab-btn.failing {
-    color: var(--color-red);
-    border-color: color-mix(in srgb, var(--color-red) 45%, transparent);
-  }
-
-  .tab-btn.failing.active {
-    color: var(--color-red);
-    border-color: var(--color-red);
-    background: var(--color-inset);
-  }
-
-  /* ── fast-forward button ── */
-  .gbtn {
-    background: transparent;
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    color: var(--color-muted);
-    font-family: var(--font-mono);
-    font-size: var(--fs-meta);
-    letter-spacing: 0.08em;
-    padding: 2px 8px;
-    cursor: pointer;
-    transition:
-      border-color 0.12s,
-      color 0.12s;
-  }
-  .gbtn:hover:not(:disabled) {
-    border-color: var(--color-amber);
-    color: var(--color-amber);
-  }
-  /* keyboard focus — flat inset amber ring (never an outer glow), per design-system */
-  .gbtn:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 1px var(--color-amber);
-  }
-  .gbtn:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  .ff-btn {
-    margin-left: auto;
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    flex-shrink: 0;
-    white-space: nowrap;
   }
 
   /* ── desktop split layout ── */
@@ -696,46 +446,10 @@
     background: var(--color-hover);
   }
 
-  /* Tab strip sits after the fixed close button and scrolls horizontally when
-     tabs exceed the available width. Scrollbar is hidden (matches ControlBar
-     convention). */
-  .overlay-tabs {
-    display: flex;
-    gap: 2px;
-    flex: 1 1 0;
-    min-width: 0;
-    overflow-x: auto;
-    white-space: nowrap;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-  }
-
-  .overlay-tabs::-webkit-scrollbar {
-    display: none;
-  }
-
-  .overlay-tabs .tab-btn {
-    min-height: 40px;
-    padding: 0 12px;
-    touch-action: manipulation;
-    flex-shrink: 0;
-  }
-
   .overlay-body {
     flex: 1;
     overflow: hidden;
     display: flex;
     flex-direction: column;
-  }
-
-  /* Automation tab owns its scroll: AutomationSettings is height-neutral and
-     non-scrolling (so the in-task popover's own clamp stays the only scroller
-     there), and both .detail-pane / .overlay-body are overflow:hidden — so this
-     wrapper is the scroll region that keeps the full rows + roles section
-     reachable. Mirrors ReadinessPanel's .scroll. */
-  .automation-scroll {
-    flex: 1;
-    min-height: 0;
-    overflow-y: auto;
   }
 </style>

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -1,22 +1,19 @@
 <script lang="ts">
   import { listIssues, getEpics, getEpic } from "$lib/api";
   import { steers } from "$lib/steers.svelte";
-  import { fitLabels } from "$lib/fit-labels";
   import type { Issue, Steer, EpicSummary, Epic } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { relativeAge } from "$lib/format";
-  import { clock } from "$lib/now.svelte";
-  import { filterIssues, hideOthers, hideActive, ACTIVE_LABEL } from "./issues-panel";
+  import { filterIssues, hideOthers, hideActive } from "./issues-panel";
   import { issuesFilter } from "$lib/issues-filter.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
-  import EpicPanel from "./EpicPanel.svelte";
+  import IssueRow from "./issues-panel/IssueRow.svelte";
   import RepoLink from "./RepoLink.svelte";
   import { SvelteSet, SvelteMap } from "svelte/reactivity";
   import { tick } from "svelte";
 
-  // ACTIVE_LABEL (imported from ./issues-panel) is the label the drain stamps on an
-  // issue it has claimed (auto session or human-linked task). Highlighted so a
-  // claimed issue reads as "already taken" at a glance in the backlog.
+  // ACTIVE_LABEL (used in IssueRow) is the label the drain stamps on an issue it has
+  // claimed (auto session or human-linked task). Highlighted so a claimed issue reads
+  // as "already taken" at a glance in the backlog.
 
   let {
     repoPath,
@@ -214,107 +211,20 @@
         <div class="muted">{m.issuespanel_no_match()}</div>
       {/if}
       {#each visibleIssues as issue (issue.number)}
-        {@const epicSummary = epicByNumber.get(issue.number)}
-        {@const isEpicParent = !!epicSummary}
         {@const isExpanded = expanded.has(issue.number)}
-        <div class="issue-row" id={`epic-issue-row-${issue.number}`}>
-          <div class="issue-top">
-            <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an app route -->
-            <a
-              class="issue-num"
-              href={issue.url}
-              target="_blank"
-              rel="noopener"
-              title={m.issuespanel_open_on_github()}>#{issue.number}</a
-            >
-            <a
-              class="issue-title"
-              href={issue.url}
-              target="_blank"
-              rel="noopener"
-              title={m.issuespanel_open_on_github()}>{issue.title}</a
-            >
-            <!-- eslint-enable svelte/no-navigation-without-resolve -->
-            {#if epicSummary}
-              {@const isNative = epicSummary.source === "native"}
-              <button
-                class="epic-badge"
-                class:expanded={isExpanded}
-                type="button"
-                aria-expanded={isExpanded}
-                aria-label={isNative
-                  ? isExpanded
-                    ? m.subissues_badge_collapse_aria({ parent: issue.number })
-                    : m.subissues_badge_expand_aria({ parent: issue.number })
-                  : isExpanded
-                    ? m.epic_badge_collapse_aria({ parent: issue.number })
-                    : m.epic_badge_expand_aria({ parent: issue.number })}
-                onclick={() => toggleEpic(issue.number)}
-                >{isNative
-                  ? m.subissues_badge({ merged: epicSummary.merged, total: epicSummary.total })
-                  : m.epic_badge({ merged: epicSummary.merged, total: epicSummary.total })}</button
-              >
-            {/if}
-          </div>
-          {#if bodyPreview && issue.body}
-            <div class="body-preview">{issue.body}</div>
-          {/if}
-          {#if issue.labels.length > 0 || age}
-            <div class="label-row">
-              {#each issue.labels as label (label)}
-                <span
-                  class="label-chip"
-                  class:active={label === ACTIVE_LABEL}
-                  title={label === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}
-                  >{label}</span
-                >
-              {/each}
-              {#if age}
-                <span class="age-chip">{relativeAge(issue.createdAt, clock.current)}</span>
-              {/if}
-            </div>
-          {/if}
-          <!-- fitLabels toggles `compact` when the buttons overflow the row: emoji-
-               carrying buttons collapse to their emoji (label stays in title/aria). -->
-          <div class="issue-actions" use:fitLabels>
-            {#if onquick}
-              {#each issueActions as a (a.id)}
-                <button
-                  class="quick-btn"
-                  class:has-emoji={!!a.emoji}
-                  disabled={isEpicParent}
-                  onclick={() => onquick(issue, a)}
-                  aria-label={isEpicParent
-                    ? m.issuespanel_task_button_epic_disabled()
-                    : m.issuespanel_action_aria({ label: a.label })}
-                  title={isEpicParent ? m.issuespanel_task_button_epic_disabled() : a.text}
-                  >{#if a.emoji}<span class="act-emoji" aria-hidden="true">{a.emoji}</span
-                    >{/if}<span class="act-label">{a.label}</span></button
-                >
-              {/each}
-            {/if}
-            <button
-              class="task-btn has-emoji"
-              disabled={isEpicParent}
-              onclick={() => onnewtask(issue)}
-              title={isEpicParent ? m.issuespanel_task_button_epic_disabled() : undefined}
-              aria-label={isEpicParent
-                ? m.issuespanel_task_button_epic_disabled()
-                : m.issuespanel_task_button()}
-              ><span class="act-emoji" aria-hidden="true">+</span><span class="act-label"
-                >{m.issuespanel_task_button()}</span
-              ></button
-            >
-          </div>
-          {#if epicSummary && isExpanded}
-            {@const e = epicFor(issue.number)}
-            {#if e}
-              <EpicPanel {repoPath} parent={issue.number} epic={e} />
-            {:else}
-              <div class="muted">{m.common_loading()}</div>
-            {/if}
-          {/if}
-        </div>
+        <IssueRow
+          {issue}
+          epicSummary={epicByNumber.get(issue.number)}
+          {isExpanded}
+          epic={isExpanded ? epicFor(issue.number) : undefined}
+          {repoPath}
+          {bodyPreview}
+          {age}
+          {issueActions}
+          {onnewtask}
+          {onquick}
+          ontoggleepic={toggleEpic}
+        />
       {/each}
     {/if}
   </div>
@@ -419,217 +329,15 @@
     background: var(--color-inset);
   }
 
-  .issue-row {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    padding: 7px 8px;
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    background: var(--color-inset);
-  }
-
-  .issue-top {
-    display: flex;
-    align-items: baseline;
-    gap: 6px;
-  }
-
-  .issue-num {
-    font-size: var(--fs-meta);
-    color: var(--color-faint);
-    flex-shrink: 0;
-    text-decoration: none;
-    transition: color 0.12s;
-  }
-
-  .issue-num:hover {
-    color: var(--color-ink-bright);
-  }
-
-  .issue-title {
-    flex: 1;
-    font-size: var(--fs-base);
-    color: var(--color-ink);
-    line-height: 1.4;
-    word-break: break-word;
-    text-decoration: none;
-    transition: color 0.12s;
-  }
-
-  .issue-title:hover {
-    color: var(--color-ink-bright);
-  }
-
-  .label-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-  }
-
-  .label-chip {
-    font-size: var(--fs-micro);
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--color-muted);
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    padding: 1px 5px;
-  }
-
-  /* shepherd:active — claimed work. Uses the semantic running/in-progress token so a
-     taken issue stands out from neutral labels with the same hue as running sessions. */
-  .label-chip.active {
-    color: var(--status-running);
-    border-color: var(--status-running);
-    background: color-mix(in srgb, var(--status-running) 14%, transparent);
-  }
-
-  .body-preview {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-    line-height: 1.4;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    word-break: break-word;
-  }
-
-  .age-chip {
-    font-size: var(--fs-micro);
-    letter-spacing: 0.1em;
-    color: var(--color-faint);
-    padding: 1px 0;
-  }
-
-  .issue-actions {
-    display: flex;
-    gap: 6px;
-    margin-top: 2px;
-    min-width: 0;
-    /* Final fallback when even the compact (emoji-only) rendering overflows — e.g.
-       several emoji-less actions: scroll instead of clipping. Right-alignment comes
-       from the first child's auto margin (NOT justify-content: flex-end, whose
-       start-side overflow would be unreachable in a scroll container). */
-    overflow-x: auto;
-    scrollbar-width: none;
-    -webkit-overflow-scrolling: touch;
-  }
-  .issue-actions::-webkit-scrollbar {
-    display: none;
-  }
-  .issue-actions > :first-child {
-    margin-left: auto;
-  }
-  .issue-actions button {
-    flex: 0 0 auto;
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-  }
-  /* compact (set by fitLabels on overflow): emoji-carrying buttons shed their label —
-     the emoji is the identifier (full label stays in title/aria-label). */
-  .issue-actions:global(.compact) .has-emoji .act-label {
-    display: none;
-  }
-
-  /* Quick-launch: amber-accented to signal it's the fast path that skips the dialog. */
-  .quick-btn {
-    background: transparent;
-    border: 1px solid var(--color-amber);
-    border-radius: 2px;
-    color: var(--color-amber);
-    font-family: var(--font-mono);
-    font-size: var(--fs-meta);
-    letter-spacing: 0.08em;
-    padding: 2px 8px;
-    cursor: pointer;
-    transition:
-      background 0.12s,
-      border-color 0.12s,
-      color 0.12s;
-  }
-
-  .quick-btn:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--color-amber) 14%, transparent);
-  }
-
-  /* Epic-parent rows disable quick-launch steers for the same reason +Task is
-     disabled: an epic is launched via the epic panel's Start, not by spawning a
-     manual session linked to the parent tracking issue (footgun). */
-  .quick-btn:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-
-  .task-btn {
-    background: transparent;
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    color: var(--color-muted);
-    font-family: var(--font-mono);
-    font-size: var(--fs-meta);
-    letter-spacing: 0.08em;
-    padding: 2px 8px;
-    cursor: pointer;
-    transition:
-      border-color 0.12s,
-      color 0.12s;
-  }
-
-  .task-btn:hover:not(:disabled) {
-    border-color: var(--color-amber);
-    color: var(--color-amber);
-  }
-
-  /* Epic-parent rows disable +Task: an epic is launched via the epic panel's Start,
-     not by spawning a manual task against the parent tracking issue (footgun). */
-  .task-btn:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-
   .muted {
     font-size: var(--fs-base);
     color: var(--color-faint);
     padding: 4px 0;
   }
 
-  /* Epic badge: compact EPIC merged/total pill that toggles the inline EpicPanel.
-     Uses the status-running token (amber) — an epic is active/in-progress work.
-     .expanded state darkens the fill to signal the panel is open. */
-  .epic-badge {
-    flex-shrink: 0;
-    font-family: var(--font-mono);
-    font-size: var(--fs-micro);
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--status-running);
-    background: color-mix(in oklab, var(--status-running) 12%, transparent);
-    border: 1px solid var(--status-running);
-    border-radius: 2px;
-    padding: 1px 5px;
-    cursor: pointer;
-    transition:
-      background 0.12s,
-      color 0.12s;
-  }
-
-  .epic-badge.expanded,
-  .epic-badge:hover {
-    background: color-mix(in oklab, var(--status-running) 22%, transparent);
-  }
-
   @media (max-width: 768px) {
     .issues-list {
       -webkit-overflow-scrolling: touch;
-    }
-    .task-btn,
-    .quick-btn {
-      min-height: 40px;
-      padding: 2px 14px;
     }
   }
 </style>

--- a/ui/src/lib/components/backlog-view/BacklogTabBar.svelte
+++ b/ui/src/lib/components/backlog-view/BacklogTabBar.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+  import type { BacklogProject } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import type { ActionsTabState } from "../backlog-view";
+
+  type Tab = "issues" | "prs" | "actions" | "readiness" | "automation";
+
+  // The Issues/PRs/Actions/Readiness/Automation tab strip + Fast-forward button,
+  // shared by BacklogView's desktop split and mobile overlay (#855). `variant`
+  // only swaps the wrapper class (the desktop `.tab-bar` vs the horizontally-
+  // scrolling mobile `.overlay-tabs`); the buttons are identical.
+  let {
+    variant,
+    activeTab,
+    selected = null,
+    actionsState,
+    ffInFlight,
+    selectedPath,
+    onselecttab,
+    onff,
+  }: {
+    variant: "desktop" | "mobile";
+    activeTab: Tab;
+    selected?: BacklogProject | null;
+    actionsState: ActionsTabState;
+    ffInFlight: boolean;
+    selectedPath: string | null;
+    onselecttab: (tab: Tab) => void;
+    onff: () => void;
+  } = $props();
+
+  // coachTarget only on the desktop variant — preserves the pre-split behavior
+  // where only the desktop tab bar carried the backlog coachmark anchors. The
+  // guard returns the real action when an id is given, else a no-op. variant is
+  // fixed per instance (mobile/desktop are separate {#if} branches that mount
+  // distinct instances), so the id never flips at runtime.
+  function coachMaybe(node: HTMLElement, id: string | undefined) {
+    return id ? coachTarget(node, id) : undefined;
+  }
+</script>
+
+<div class={variant === "mobile" ? "overlay-tabs" : "tab-bar"}>
+  <button
+    class="tab-btn"
+    class:active={activeTab === "issues"}
+    type="button"
+    onclick={() => onselecttab("issues")}
+  >
+    {selected && selected.openIssues !== null
+      ? m.backlog_tab_issues_count({ count: selected.openIssues })
+      : m.backlog_tab_issues()}
+  </button>
+  <button
+    class="tab-btn"
+    class:active={activeTab === "prs"}
+    type="button"
+    onclick={() => onselecttab("prs")}
+  >
+    {selected && selected.openPRs !== null
+      ? m.backlog_tab_prs_count({ count: selected.openPRs })
+      : m.backlog_tab_prs()}
+  </button>
+  <button
+    class="tab-btn"
+    class:active={activeTab === "actions"}
+    class:failing={actionsState.kind === "failing"}
+    type="button"
+    onclick={() => onselecttab("actions")}
+  >
+    {#if actionsState.kind === "failing"}
+      {m.backlog_tab_actions_failing()}
+    {:else if actionsState.kind === "count"}
+      {m.backlog_tab_actions_count({ count: actionsState.count })}
+    {:else}
+      {m.backlog_tab_actions()}
+    {/if}
+  </button>
+  <button
+    class="tab-btn"
+    class:active={activeTab === "readiness"}
+    type="button"
+    onclick={() => onselecttab("readiness")}
+  >
+    {m.backlog_tab_readiness()}
+  </button>
+  <button
+    class="tab-btn"
+    class:active={activeTab === "automation"}
+    type="button"
+    onclick={() => onselecttab("automation")}
+    use:coachMaybe={variant === "desktop" ? "backlog-automation" : undefined}
+  >
+    {m.backlog_tab_automation()}
+  </button>
+  <button
+    class="gbtn ff-btn"
+    type="button"
+    disabled={ffInFlight || selectedPath === null}
+    onclick={onff}
+    title={m.backlog_ff_main_title()}
+    aria-label={m.backlog_ff_main_title()}
+    use:coachMaybe={variant === "desktop" ? "backlog-ff-main" : undefined}
+  >
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+      <path d="M1 2.5L5.5 6 1 9.5V2.5Z" fill="currentColor" />
+      <path d="M6.5 2.5L11 6 6.5 9.5V2.5Z" fill="currentColor" />
+    </svg>
+    {m.backlog_ff_main()}
+  </button>
+</div>
+
+<style>
+  /* ── tab bar (desktop) ── */
+  .tab-bar {
+    display: flex;
+    gap: 2px;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--color-line);
+    background: var(--color-head);
+    flex-shrink: 0;
+  }
+
+  .tab-btn {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.1em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      color 0.12s,
+      border-color 0.12s;
+  }
+
+  .tab-btn:hover {
+    color: var(--color-ink);
+  }
+
+  .tab-btn.active {
+    color: var(--color-ink-bright);
+    border-color: var(--color-line-bright);
+    background: var(--color-inset);
+  }
+
+  .tab-btn.failing {
+    color: var(--color-red);
+    border-color: color-mix(in srgb, var(--color-red) 45%, transparent);
+  }
+
+  .tab-btn.failing.active {
+    color: var(--color-red);
+    border-color: var(--color-red);
+    background: var(--color-inset);
+  }
+
+  /* ── fast-forward button ── */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  /* keyboard focus — flat inset amber ring (never an outer glow), per design-system */
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .ff-btn {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  /* ── tab strip (mobile overlay) ──
+     Sits after the fixed close button and scrolls horizontally when tabs exceed
+     the available width. Scrollbar is hidden (matches ControlBar convention). */
+  .overlay-tabs {
+    display: flex;
+    gap: 2px;
+    flex: 1 1 0;
+    min-width: 0;
+    overflow-x: auto;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+
+  .overlay-tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .overlay-tabs .tab-btn {
+    min-height: 40px;
+    padding: 0 12px;
+    touch-action: manipulation;
+    flex-shrink: 0;
+  }
+</style>

--- a/ui/src/lib/components/backlog-view/BacklogTabContent.svelte
+++ b/ui/src/lib/components/backlog-view/BacklogTabContent.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import type { DrainStatus, Epic, Issue, PullRequest, Steer } from "$lib/types";
+  import IssuesPanel from "../IssuesPanel.svelte";
+  import PrsPanel from "../PrsPanel.svelte";
+  import ActionsPanel from "../ActionsPanel.svelte";
+  import ReadinessPanel from "../ReadinessPanel.svelte";
+  import AutomationSettings from "../AutomationSettings.svelte";
+
+  type Tab = "issues" | "prs" | "actions" | "readiness" | "automation";
+
+  // The selected repo's detail panel for the active tab — shared by BacklogView's
+  // desktop split and mobile overlay (#855). Only rendered for a non-null
+  // selection, so `selectedPath` is a plain string here.
+  let {
+    activeTab,
+    selectedPath,
+    onissue,
+    onquick = undefined,
+    onpr,
+    onlaunchtrain,
+    onadopt,
+    epics = undefined,
+    inTrainPrs = new Set(),
+    target = null,
+    drain = undefined,
+  }: {
+    activeTab: Tab;
+    selectedPath: string;
+    onissue: (repoPath: string, issue: Issue) => void;
+    onquick?: (repoPath: string, issue: Issue, action: Steer) => void;
+    onpr: (repoPath: string, pr: PullRequest) => void;
+    onlaunchtrain: (repoPath: string, prs: PullRequest[]) => void;
+    onadopt: (repoPath: string, prompt: string) => void;
+    epics?: Record<string, Epic>;
+    inTrainPrs?: Set<string>;
+    target?: { repoPath: string; issueNumber: number } | null;
+    drain?: Record<string, DrainStatus>;
+  } = $props();
+</script>
+
+{#if activeTab === "issues"}
+  <IssuesPanel
+    repoPath={selectedPath}
+    onnewtask={(issue) => {
+      onissue(selectedPath, issue);
+    }}
+    onquick={onquick ? (issue, action) => onquick(selectedPath, issue, action) : undefined}
+    bodyPreview
+    age
+    {epics}
+    expandEpic={target && target.repoPath === selectedPath ? target.issueNumber : null}
+  />
+{:else if activeTab === "prs"}
+  <PrsPanel
+    repoPath={selectedPath}
+    onreview={(pr) => onpr(selectedPath, pr)}
+    {onlaunchtrain}
+    {inTrainPrs}
+    age
+  />
+{:else if activeTab === "actions"}
+  <ActionsPanel repoPath={selectedPath} />
+{:else if activeTab === "automation"}
+  <div class="automation-scroll">
+    <AutomationSettings
+      repoPath={selectedPath}
+      drain={drain?.[selectedPath] ?? null}
+      showHeader={false}
+    />
+  </div>
+{:else}
+  <ReadinessPanel repoPath={selectedPath} onadopt={(rp, p) => onadopt(rp, p)} />
+{/if}
+
+<style>
+  /* Automation tab owns its scroll: AutomationSettings is height-neutral and
+     non-scrolling (so the in-task popover's own clamp stays the only scroller
+     there), and both .detail-pane / .overlay-body are overflow:hidden — so this
+     wrapper is the scroll region that keeps the full rows + roles section
+     reachable. Mirrors ReadinessPanel's .scroll. */
+  .automation-scroll {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+</style>

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -1,0 +1,357 @@
+<script lang="ts">
+  import type { Issue, Steer, EpicSummary, Epic } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { fitLabels } from "$lib/fit-labels";
+  import { relativeAge } from "$lib/format";
+  import { clock } from "$lib/now.svelte";
+  import { ACTIVE_LABEL } from "../issues-panel";
+  import EpicPanel from "../EpicPanel.svelte";
+
+  // One backlog issue row, extracted from IssuesPanel so the panel template clears the
+  // Tier-1 <template> complexity bar (#855). The row owns all its nested conditionals
+  // (epic badge, body preview, labels/age, quick + task actions, inline EpicPanel).
+  let {
+    issue,
+    epicSummary = undefined,
+    isExpanded = false,
+    epic = undefined,
+    repoPath,
+    bodyPreview = false,
+    age = false,
+    issueActions,
+    onnewtask,
+    onquick = undefined,
+    ontoggleepic,
+  }: {
+    issue: Issue;
+    /** Epic summary for this issue (number → EpicSummary), when it parents an epic. */
+    epicSummary?: EpicSummary | undefined;
+    /** Whether the inline EpicPanel is expanded. */
+    isExpanded?: boolean;
+    /** Resolved Epic record for the expanded panel (live store value or one-shot fetch). */
+    epic?: Epic | undefined;
+    repoPath: string;
+    bodyPreview?: boolean;
+    age?: boolean;
+    issueActions: Steer[];
+    onnewtask: (issue: Issue) => void;
+    onquick?: (issue: Issue, action: Steer) => void;
+    ontoggleepic: (number: number) => void;
+  } = $props();
+
+  // Epic-parent rows disable quick-launch + Task: an epic is launched via the epic
+  // panel's Start, not by spawning a manual session against the parent tracking issue.
+  const isEpicParent = $derived(!!epicSummary);
+</script>
+
+<div class="issue-row" id={`epic-issue-row-${issue.number}`}>
+  <div class="issue-top">
+    <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an app route -->
+    <a
+      class="issue-num"
+      href={issue.url}
+      target="_blank"
+      rel="noopener"
+      title={m.issuespanel_open_on_github()}>#{issue.number}</a
+    >
+    <a
+      class="issue-title"
+      href={issue.url}
+      target="_blank"
+      rel="noopener"
+      title={m.issuespanel_open_on_github()}>{issue.title}</a
+    >
+    <!-- eslint-enable svelte/no-navigation-without-resolve -->
+    {#if epicSummary}
+      {@const isNative = epicSummary.source === "native"}
+      <button
+        class="epic-badge"
+        class:expanded={isExpanded}
+        type="button"
+        aria-expanded={isExpanded}
+        aria-label={isNative
+          ? isExpanded
+            ? m.subissues_badge_collapse_aria({ parent: issue.number })
+            : m.subissues_badge_expand_aria({ parent: issue.number })
+          : isExpanded
+            ? m.epic_badge_collapse_aria({ parent: issue.number })
+            : m.epic_badge_expand_aria({ parent: issue.number })}
+        onclick={() => ontoggleepic(issue.number)}
+        >{isNative
+          ? m.subissues_badge({ merged: epicSummary.merged, total: epicSummary.total })
+          : m.epic_badge({ merged: epicSummary.merged, total: epicSummary.total })}</button
+      >
+    {/if}
+  </div>
+  {#if bodyPreview && issue.body}
+    <div class="body-preview">{issue.body}</div>
+  {/if}
+  {#if issue.labels.length > 0 || age}
+    <div class="label-row">
+      {#each issue.labels as label (label)}
+        <span
+          class="label-chip"
+          class:active={label === ACTIVE_LABEL}
+          title={label === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}
+          >{label}</span
+        >
+      {/each}
+      {#if age}
+        <span class="age-chip">{relativeAge(issue.createdAt, clock.current)}</span>
+      {/if}
+    </div>
+  {/if}
+  <!-- fitLabels toggles `compact` when the buttons overflow the row: emoji-
+       carrying buttons collapse to their emoji (label stays in title/aria). -->
+  <div class="issue-actions" use:fitLabels>
+    {#if onquick}
+      {#each issueActions as a (a.id)}
+        <button
+          class="quick-btn"
+          class:has-emoji={!!a.emoji}
+          disabled={isEpicParent}
+          onclick={() => onquick(issue, a)}
+          aria-label={isEpicParent
+            ? m.issuespanel_task_button_epic_disabled()
+            : m.issuespanel_action_aria({ label: a.label })}
+          title={isEpicParent ? m.issuespanel_task_button_epic_disabled() : a.text}
+          >{#if a.emoji}<span class="act-emoji" aria-hidden="true">{a.emoji}</span>{/if}<span
+            class="act-label">{a.label}</span
+          ></button
+        >
+      {/each}
+    {/if}
+    <button
+      class="task-btn has-emoji"
+      disabled={isEpicParent}
+      onclick={() => onnewtask(issue)}
+      title={isEpicParent ? m.issuespanel_task_button_epic_disabled() : undefined}
+      aria-label={isEpicParent
+        ? m.issuespanel_task_button_epic_disabled()
+        : m.issuespanel_task_button()}
+      ><span class="act-emoji" aria-hidden="true">+</span><span class="act-label"
+        >{m.issuespanel_task_button()}</span
+      ></button
+    >
+  </div>
+  {#if epicSummary && isExpanded}
+    {#if epic}
+      <EpicPanel {repoPath} parent={issue.number} {epic} />
+    {:else}
+      <div class="muted">{m.common_loading()}</div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .issue-row {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 7px 8px;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    background: var(--color-inset);
+  }
+
+  .issue-top {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+
+  .issue-num {
+    font-size: var(--fs-meta);
+    color: var(--color-faint);
+    flex-shrink: 0;
+    text-decoration: none;
+    transition: color 0.12s;
+  }
+
+  .issue-num:hover {
+    color: var(--color-ink-bright);
+  }
+
+  .issue-title {
+    flex: 1;
+    font-size: var(--fs-base);
+    color: var(--color-ink);
+    line-height: 1.4;
+    word-break: break-word;
+    text-decoration: none;
+    transition: color 0.12s;
+  }
+
+  .issue-title:hover {
+    color: var(--color-ink-bright);
+  }
+
+  .label-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .label-chip {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 1px 5px;
+  }
+
+  /* shepherd:active — claimed work. Uses the semantic running/in-progress token so a
+     taken issue stands out from neutral labels with the same hue as running sessions. */
+  .label-chip.active {
+    color: var(--status-running);
+    border-color: var(--status-running);
+    background: color-mix(in srgb, var(--status-running) 14%, transparent);
+  }
+
+  .body-preview {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    word-break: break-word;
+  }
+
+  .age-chip {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.1em;
+    color: var(--color-faint);
+    padding: 1px 0;
+  }
+
+  .issue-actions {
+    display: flex;
+    gap: 6px;
+    margin-top: 2px;
+    min-width: 0;
+    /* Final fallback when even the compact (emoji-only) rendering overflows — e.g.
+       several emoji-less actions: scroll instead of clipping. Right-alignment comes
+       from the first child's auto margin (NOT justify-content: flex-end, whose
+       start-side overflow would be unreachable in a scroll container). */
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .issue-actions::-webkit-scrollbar {
+    display: none;
+  }
+  .issue-actions > :first-child {
+    margin-left: auto;
+  }
+  .issue-actions button {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+  /* compact (set by fitLabels on overflow): emoji-carrying buttons shed their label —
+     the emoji is the identifier (full label stays in title/aria-label). */
+  .issue-actions:global(.compact) .has-emoji .act-label {
+    display: none;
+  }
+
+  /* Quick-launch: amber-accented to signal it's the fast path that skips the dialog. */
+  .quick-btn {
+    background: transparent;
+    border: 1px solid var(--color-amber);
+    border-radius: 2px;
+    color: var(--color-amber);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      background 0.12s,
+      border-color 0.12s,
+      color 0.12s;
+  }
+
+  .quick-btn:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--color-amber) 14%, transparent);
+  }
+
+  /* Epic-parent rows disable quick-launch steers for the same reason +Task is
+     disabled: an epic is launched via the epic panel's Start, not by spawning a
+     manual session linked to the parent tracking issue (footgun). */
+  .quick-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  .task-btn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+
+  .task-btn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+
+  /* Epic-parent rows disable +Task: an epic is launched via the epic panel's Start,
+     not by spawning a manual task against the parent tracking issue (footgun). */
+  .task-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  .muted {
+    font-size: var(--fs-base);
+    color: var(--color-faint);
+    padding: 4px 0;
+  }
+
+  /* Epic badge: compact EPIC merged/total pill that toggles the inline EpicPanel.
+     Uses the status-running token (amber) — an epic is active/in-progress work.
+     .expanded state darkens the fill to signal the panel is open. */
+  .epic-badge {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--status-running);
+    background: color-mix(in oklab, var(--status-running) 12%, transparent);
+    border: 1px solid var(--status-running);
+    border-radius: 2px;
+    padding: 1px 5px;
+    cursor: pointer;
+    transition:
+      background 0.12s,
+      color 0.12s;
+  }
+
+  .epic-badge.expanded,
+  .epic-badge:hover {
+    background: color-mix(in oklab, var(--status-running) 22%, transparent);
+  }
+
+  @media (max-width: 768px) {
+    .task-btn,
+    .quick-btn {
+      min-height: 40px;
+      padding: 2px 14px;
+    }
+  }
+</style>


### PR DESCRIPTION
Follow-up to #851 / #868 — pays down two of the oversized Svelte `<template>` grandfathers tracked in #855 by splitting their high-cognitive regions into child components, then **deleting** both `.fallowrc.jsonc` Tier-2 entries.

Both targets already cleared cyclomatic and only exceeded cognitive, making them the cheapest full removals (same pattern as #868):

| Component | before (cyclo/cog) | after | grandfather |
| --- | --- | --- | --- |
| `IssuesPanel.svelte` | 30 / 91 | < 40/60 | **deleted** |
| `BacklogView.svelte` | 37 / 72 | < 40/60 | **deleted** |

## What changed

- **IssuesPanel** → extracted the `{#each visibleIssues}` per-issue row (epic badge, body preview, labels/age, quick + task actions, inline `EpicPanel`) into **`issues-panel/IssueRow.svelte`**.
- **BacklogView** → its cognitive came from rendering the tab bar **and** the 5-way `activeTab` content switch **twice** (mobile overlay + desktop split). Extracted both into **`backlog-view/BacklogTabBar.svelte`** (`variant: desktop | mobile`) and **`backlog-view/BacklogTabContent.svelte`**, composed by both branches.
- Deleted the `IssuesPanel` + `BacklogView` `thresholdOverrides` entries in `.fallowrc.jsonc` (9 grandfathers → **7** remaining).

## Behavior-preserving

- DOM + authored class names are identical — `IssuesPanel.browser.test.ts` (asserts DOM by class through the parent render) passes unchanged.
- `coachTarget` anchors (`backlog-automation`, `backlog-ff-main`) stay **desktop-only** via a small `coachMaybe` guard, so the coachmark registry is exactly what it is today (no mobile delta).
- No user-facing string/UX change → `[no-feature-entry]`, no i18n/glossary/catalog entry needed.

## Verification

- `bunx fallow@2.100.0 health` → **0 template-complexity findings** (both parents + all 3 new children clear the Tier-1 40/60 bar). The only remaining finding is the pre-existing, non-template `cleanupTodo` in `todo.ts` — untouched, out of scope.
- `bunx fallow@2.100.0 audit --base origin/main --fail-on-issues` → **green** on changed files.
- `cd ui && bun run check` → 0 errors / 0 warnings; `bun run test` → 1759 passed.

Note: the duplication clone-warnings fallow lists (e.g. BacklogView's mobile vs desktop `ProjectBacklogList` wrapper, IssueRow/BacklogTabBar markup matching the `/design-system` recipes) are pre-existing patterns and warn-only — they don't fail the gate.

Refs #855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)