### PR TITLE
fix(drain): emit session:new on auto-spawn so the Herd refreshes live

### DIFF
--- a/src/drain.ts
+++ b/src/drain.ts
@@ -146,6 +146,8 @@ export interface DrainDeps {
   emitEpic?: (epic: Epic) => void;
   /** → events.emit("epic:completed", e). Optional — absent in tests that don't need it. */
   emitEpicCompleted?: (epic: CompletedEpic) => void;
+  /** → events.emit("session:new", s). Optional — absent in tests that don't need it. */
+  emitSessionNew?: (s: Session) => void;
   now?: () => number;
   /** Short cache for listIssues (default 10s). */
   issuesTtlMs?: number;
@@ -1251,13 +1253,20 @@ export class DrainService {
     }
     // consume the attended-mode approval on attempt; a failed spawn requires re-approval (approval is not issue-bound)
     this.approvedNext.delete(repoPath);
+    // Hold the created session so we can announce it AFTER the try/catch. Emitting
+    // inside the try would route a throwing session:new listener into the catch
+    // below (EventHub.emit has no per-listener guard), which releases the claim
+    // label for an already-created session → duplicate re-spawn next tick. The UI
+    // session list is push-only, so without this emit a drain-spawned (incl. epic
+    // sub-issue) session never appears until a full page reload.
+    let session: Session | undefined;
     try {
       const { base, prompt } = await this.resolveSpawnBase(forge, decision);
       // Auto-spawns honor an explicit operator default-model — the repo override
       // wins over the global default; when both are unset ("inherit"/"auto") they
       // fall back to no --model flag (Claude's own default). The Fable promo is a
       // client-only UI concern and is NEVER applied to autonomous spawns.
-      await this.deps.service.create({
+      session = await this.deps.service.create({
         repoPath,
         baseBranch: base,
         prompt,
@@ -1280,6 +1289,8 @@ export class DrainService {
         console.warn(`[drain] release label for issue #${number} failed:`, rerr);
       }
     }
+    // Success-only, outside the try: push the new session to the UI live.
+    if (session) this.deps.emitSessionNew?.(session);
   }
 
   // ── event handlers (public surface) ───────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -943,6 +943,7 @@ const drain = new DrainService({
   dropPrCache: (id) => prPoller.drop(id),
   emitEpic: (epic) => events.emit("epic:update", epic),
   emitEpicCompleted: (e) => events.emit("epic:completed", e),
+  emitSessionNew: (s) => events.emit("session:new", s),
 });
 
 // Drive the drain off the poller events the rest of the system already emits.

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -126,6 +126,7 @@ interface Harness {
   creates: CreateSessionInput[];
   statuses: DrainStatus[];
   epics: Epic[];
+  sessionNews: Session[];
   archived: string[];
   dropped: string[];
   prCache: Record<string, GitState>;
@@ -204,6 +205,7 @@ function makeHarness(
   const creates: CreateSessionInput[] = [];
   const statuses: Harness["statuses"] = [];
   const epics: Epic[] = [];
+  const sessionNews: Session[] = [];
   const archived: string[] = [];
   const dropped: string[] = [];
 
@@ -249,6 +251,7 @@ function makeHarness(
     creates,
     statuses,
     epics,
+    sessionNews,
     archived,
     dropped,
     prCache,
@@ -277,6 +280,7 @@ function makeHarness(
     },
     dropPrCache: (id) => dropped.push(id),
     emitEpic: (epic) => epics.push(epic),
+    emitSessionNew: (s) => sessionNews.push(s),
   });
   harness.drain = drain;
   return harness;
@@ -315,6 +319,31 @@ test("spawn fills to cap: 3 labeled issues, maxAuto 2 → creates exactly 2 auto
   }
   // last status holds on cap
   expect(h.statuses.at(-1)?.inFlight).toBe(2);
+});
+
+test("spawn emits session:new for the created session (UI session list is push-only)", async () => {
+  const h = makeHarness({ maxAuto: 1, issues: [issue(1)] });
+  await h.drain.pump(REPO);
+  expect(h.creates).toHaveLength(1);
+  // exactly one announcement, carrying the persisted session (same id the store created)
+  expect(h.sessionNews).toHaveLength(1);
+  const created = h.store.list().find((s) => s.issueNumber === 1);
+  expect(created).toBeDefined();
+  expect(h.sessionNews[0]!.id).toBe(created!.id);
+});
+
+test("spawn failure does NOT emit session:new (emit is success-only, outside the spawn try)", async () => {
+  const h = makeHarness({
+    maxAuto: 1,
+    issues: [issue(1)],
+    createImpl: async () => {
+      throw new Error("create boom");
+    },
+  });
+  await h.drain.pump(REPO);
+  // create threw → claim released, no session persisted, and nothing announced
+  expect(h.forgeRec.removed.some((r) => r.number === 1 && r.label === ACTIVE_LABEL)).toBe(true);
+  expect(h.sessionNews).toHaveLength(0);
 });
 
 test("dedupe: an existing session mapped to #1 → spawns #2 next, not #1", async () => {


### PR DESCRIPTION
## Problem

Starting an epic doesn't auto-refresh the session list — the spawned epic sub-issue session only appears after a full page reload.

## Root cause

The UI session list is **push-only**: sessions enter `store.sessions` exclusively via the `session:new` websocket event (`ui/src/lib/store.svelte.ts`), with no periodic refetch. `service.create()` deliberately does not emit `session:new` — the caller must. The human-driven callers do (`handleSessionCreate`, `finalizeRelaunch` in `src/server.ts`), but the **auto-drain spawn path** — `DrainService.doSpawn` (`src/drain.ts`, the only drain caller of `service.create`) — never did. Starting an epic flips its run to `running`, which makes the drain spawn sub-issue sessions through `doSpawn`, so they stayed invisible until reload. The defect is general to **all** auto-drain spawns, not just epic ones; fixing it at `doSpawn` covers every case.

## Fix

- Add an optional `emitSessionNew` callback to `DrainService` deps, mirroring `emitArchived`/`emitEpic`.
- Wire it in `index.ts` to `events.emit("session:new", s)`.
- Call it from `doSpawn` after a successful `create`. The UI already handles `session:new` (and dedupes by id), so no UI change.

### Placement detail
The emit is placed **outside** `doSpawn`'s spawn `try/catch`. `EventHub.emit` (`src/events.ts`) has no per-listener guard, so a throwing `session:new` listener inside the `try` would land in the catch — which calls `removeIssueLabel`, releasing the claim for an already-created session and triggering a duplicate re-spawn next tick. The session is captured in a variable before the try and emitted after, on `if (session)` — the same pattern the existing emitters use.

## Tests

`test/drain.test.ts` adds two regression tests:
- **(a)** on a successful spawn, `emitSessionNew` fires once with the created session (same `id`) — **fails on pre-fix code** (verified: disabling the emit turns this test red).
- **(b)** on the `create`-failure path, `emitSessionNew` is **not** called — locks in the outside-the-try placement and the no-over-firing guarantee.

All 136 drain tests pass; `bun run lint` and `bunx tsc --noEmit` clean.

Server-only plumbing, no user-facing UX surface or new strings → exempt from the feature catalog (`[no-feature-entry]`) and i18n gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)