### PR TITLE
feat(gitrail): open the linked issue from the rail

### DIFF
--- a/src/forge/index.ts
+++ b/src/forge/index.ts
@@ -13,6 +13,17 @@ function kindFor(host: string, map: ForgeMap): ForgeKind | null {
   return null;
 }
 
+/** Web URL of a forge issue, or null when the repo has no web base (LocalForge)
+ *  or the session has no linked issue. Works for GitHub (webUrl = https://github.com/{slug})
+ *  and Gitea (webUrl = {base}/{slug}); both use the /issues/{n} path. */
+export function buildIssueUrl(
+  webUrl: string | null | undefined,
+  issueNumber: number | null | undefined,
+): string | null {
+  if (!webUrl || issueNumber == null) return null;
+  return `${webUrl}/issues/${issueNumber}`;
+}
+
 /** Build a GitForge from a remote URL + forge config map, or null if unsupported. */
 export function forgeFor(remoteUrl: string, map: ForgeMap): GitForge | null {
   const parsed = parseRemote(remoteUrl);

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -153,6 +153,10 @@ export interface GitState extends PrStatus {
    *  `.shepherd/roles.json`); suppresses the outward issue-log comment, which
    *  stays opt-in to explicitly-configured roles. */
   handoffInferred?: boolean;
+  /** Web URL of the backlog issue this session was spawned for (session.issueNumber),
+   *  or absent when the session has no linked issue or the repo has no web forge
+   *  (LocalForge). Lets GitRail surface an "open issue" link. */
+  issueUrl?: string;
 }
 
 /** One job within a workflow run, mapped to the four-light CI vocab. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -79,6 +79,7 @@ import type { HerdrDriver } from "./herdr";
 import { matchAgent } from "./herdr";
 import type { GitForge, GitState, MergeMethod, PrStatus, WorkflowRun } from "./forge/types";
 import { DEPENDABOT_REBASE_COMMAND, EmptyDiffError } from "./forge/types";
+import { buildIssueUrl } from "./forge";
 import { BaseCheckoutBusyError, MergeConflictError } from "./forge/local";
 import { settleMergedSession } from "./merge-teardown";
 import { type PrCache, guardStaleTerminal, trustsTerminal } from "./pr-poller";
@@ -2288,9 +2289,12 @@ async function resolveGitState(
     session.mergingSince != null,
     session.mergingPrNumber ?? null,
   );
-  return trusted
+  const result = trusted
     ? git
     : guardStaleTerminal(git, (headSha) => deps.ownsPr?.(session, headSha) ?? null);
+  const issueUrl = buildIssueUrl(forge.webUrl, session.issueNumber);
+  if (issueUrl) result.issueUrl = issueUrl;
+  return result;
 }
 
 /**

--- a/test/forge/issue-url.test.ts
+++ b/test/forge/issue-url.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test";
+import { buildIssueUrl } from "../../src/forge";
+
+test("github-style webUrl + issueNumber → full issues URL", () => {
+  expect(buildIssueUrl("https://github.com/owner/repo", 312)).toBe(
+    "https://github.com/owner/repo/issues/312",
+  );
+});
+
+test("gitea-style webUrl + issueNumber → full issues URL", () => {
+  expect(buildIssueUrl("https://gitea.example.com/owner/repo", 7)).toBe(
+    "https://gitea.example.com/owner/repo/issues/7",
+  );
+});
+
+test("null webUrl → null", () => {
+  expect(buildIssueUrl(null, 42)).toBeNull();
+});
+
+test("undefined webUrl → null", () => {
+  expect(buildIssueUrl(undefined, 42)).toBeNull();
+});
+
+test("null issueNumber → null", () => {
+  expect(buildIssueUrl("https://github.com/owner/repo", null)).toBeNull();
+});
+
+test("undefined issueNumber → null", () => {
+  expect(buildIssueUrl("https://github.com/owner/repo", undefined)).toBeNull();
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1669,5 +1669,8 @@
   "feat_learnings_merge_title": "Doppelte Regeln mit einem Klick zusammenführen",
   "feat_learnings_merge_body": "Ein Hintergrundlauf gruppiert jetzt nahezu doppelte Hausregeln eines Repos und zeigt sie als Zusammenführungsvorschläge im Learnings-Panel. Führe eine Gruppe mit einem Klick zu einer Regel zusammen – die überlebende Regel behält ihre Bilanz, die übrigen werden mit einem Verweis auf sie zurückgezogen.",
   "feat_learnings_recur_title": "Repoübergreifende Regelvorschläge",
-  "feat_learnings_recur_body": "Wenn dieselbe Regel in mehreren Repos wiederkehrt, schlägt das Learnings-Panel jetzt vor, sie in deine benutzerglobale CLAUDE.md aufzunehmen – als Vorschlag, den du verwerfen kannst."
+  "feat_learnings_recur_body": "Wenn dieselbe Regel in mehreren Repos wiederkehrt, schlägt das Learnings-Panel jetzt vor, sie in deine benutzerglobale CLAUDE.md aufzunehmen – als Vorschlag, den du verwerfen kannst.",
+  "gitrail_open_issue": "Issue #{number} ↗",
+  "feat_open_linked_issue_title": "Verknüpftes Issue öffnen",
+  "feat_open_linked_issue_body": "GitRail zeigt jetzt einen \"Issue #N ↗\"-Link für Aufgaben, die aus einem Backlog-Issue gestartet wurden – direkt zum Issue auf GitHub oder Gitea springen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1669,5 +1669,8 @@
   "feat_learnings_merge_title": "One-click merge of duplicate rules",
   "feat_learnings_merge_body": "A background pass now clusters a repo's near-duplicate house rules and surfaces them as merge suggestions in the Learnings drawer. Consolidate a group into one rule with a single click — the survivor keeps its track record and the rest are retired with a citation back to it.",
   "feat_learnings_recur_title": "Cross-repo rule suggestions",
-  "feat_learnings_recur_body": "When the same rule recurs across several repos, the Learnings drawer now suggests promoting it to your user-global CLAUDE.md — kept as a suggestion you can dismiss."
+  "feat_learnings_recur_body": "When the same rule recurs across several repos, the Learnings drawer now suggests promoting it to your user-global CLAUDE.md — kept as a suggestion you can dismiss.",
+  "gitrail_open_issue": "Issue #{number} ↗",
+  "feat_open_linked_issue_title": "Open the linked issue",
+  "feat_open_linked_issue_body": "GitRail now shows an \"Issue #N ↗\" link for tasks spawned from a backlog issue — jump straight to the issue on GitHub or Gitea."
 }

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -554,7 +554,7 @@
   {/if}
   <span class="git-rail-wrap" class:mobile bind:this={wrapEl}>
     <span class="rail" class:mobile use:edgeFades={mobile}>
-      {#if git?.issueUrl && issueNumber != null}
+      {#if git.issueUrl && issueNumber != null}
         <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
         <a class="prlink" href={git.issueUrl} target="_blank" rel="noopener"
           >{m.gitrail_open_issue({ number: issueNumber })}</a

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -37,6 +37,7 @@
     baseBranch = "",
     drain = null,
     autopilotOn = false,
+    issueNumber = null,
   }: {
     sessionId: string;
     repoPath?: string;
@@ -54,6 +55,9 @@
     /** Effective autopilot state. When on, the agent opens the PR itself, so the manual
         Open-PR button is redundant noise and is hidden. */
     autopilotOn?: boolean;
+    /** Backlog issue this session was spawned for; drives the leftmost open-issue link.
+        null = no linked issue. */
+    issueNumber?: number | null;
   } = $props();
 
   let git = $state<GitState | null>(null);
@@ -550,6 +554,12 @@
   {/if}
   <span class="git-rail-wrap" class:mobile bind:this={wrapEl}>
     <span class="rail" class:mobile use:edgeFades={mobile}>
+      {#if git?.issueUrl && issueNumber != null}
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
+        <a class="prlink" href={git.issueUrl} target="_blank" rel="noopener"
+          >{m.gitrail_open_issue({ number: issueNumber })}</a
+        >
+      {/if}
       {#if git.state === "none"}
         <!-- Hidden whenever autopilot is effectively on — the agent opens the PR itself,
              so the manual button is redundant. This stays hidden even while autopilot is

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1962,6 +1962,7 @@
         baseBranch={session.baseBranch}
         {drain}
         autopilotOn={autopilotEffective}
+        issueNumber={session.issueNumber}
         mobile
       />
       <span class="strip-controls">

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1271,4 +1271,12 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_learnings_recur_title",
     bodyKey: "feat_learnings_recur_body",
   },
+  {
+    // Open linked issue (#876): GitRail shows "Issue #N ↗" link for sessions spawned
+    // from a backlog issue, letting the user jump straight to the issue on GitHub/Gitea.
+    id: "open-linked-issue",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_open_linked_issue_title",
+    bodyKey: "feat_open_linked_issue_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -579,6 +579,9 @@ export interface GitState extends PrStatus {
   handoff?: "reviewer" | "merger";
   /** The login to display for {@link handoff} (e.g. "scoop"). */
   handoffWho?: string;
+  /** Web URL of the backlog issue this session was spawned for, or absent when the
+   *  session has no linked issue or the repo has no web forge (local mode). */
+  issueUrl?: string;
 }
 
 /** Per-repo reviewer + merger logins, from `.shepherd/roles.json`. */


### PR DESCRIPTION
## What

Adds a one-click way to open the GitHub/Gitea **issue a task was spawned for**, directly from the GitRail control strip. A compact leftmost `Issue #N ↗` text link (styled with the existing `.prlink` recipe) opens the issue in a new tab — shown in every PR state (none/open/merged/closed), hidden for manual sessions (no linked issue) and lightweight/local repos (no web forge).

Before this, sessions stored `issueNumber` but offered no affordance to jump to the originating issue.

## How

- **Server (`resolveGitState`) computes the URL.** The UI has no repo slug/web base, so the full issue URL is built server-side where a forge is already in hand and serialized on the existing `GitState` payload (`GET /api/sessions/:id/git`). New pure helper `buildIssueUrl(webUrl, issueNumber)` → `${webUrl}/issues/${n}`, correct for GitHub (`https://github.com/{slug}`) and Gitea (`{base}/{slug}`), `null` for `LocalForge`. **No new DB field, no migration** — `issueNumber` already existed.
- **Guard-safe placement.** `issueUrl` is stamped on the object actually returned by `resolveGitState`, *after* the `guardStaleTerminal` branch is chosen, so the stale-terminal rebuild can't drop it.
- **Scope: GitRail only.** The pr-poller / list-overview `GitState` is intentionally untouched (field is optional there).
- **UI.** `GitRail` gains an optional `issueNumber` prop (passed from `session.issueNumber` in `Viewport`); renders the link as the first child of `.rail` via the i18n message.

## i18n & feature discovery

- `gitrail_open_issue` = `Issue #{number} ↗` added to `en.json` + `de.json`.
- Feature-catalog entry `open-linked-issue` (`sinceVersion: 1.35.0`) + `feat_open_linked_issue_title`/`_body` keys in both locales.

## Tests / gates

- New `test/forge/issue-url.test.ts` — unit-tests `buildIssueUrl` (GitHub + Gitea URLs, null webUrl, null/undefined issueNumber).
- Root: `bun run lint` ✓, `bun test` (4113 pass) ✓.
- UI: `bun run check` ✓, `bun run check:i18n` ✓ (parity), `bun run test` (vitest, 1761 pass) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)