### PR TITLE
fix(test): de-flake pre-push — cross-process resource collisions (refs #817)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ ci/self-hosted-runner/.env
 
 # fallow analyzer cache
 .fallow/
+
+# Pre-push test capture logs (flake diagnosis, #817)
+.test-logs/

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -41,16 +41,24 @@ echo "→ i18n catalog parity (en ↔ de)"
 (cd ui && bun run check:i18n)
 (cd extension && bun run check:i18n)
 
+# Capture full test output so an intermittent flake's failing test name survives (#817).
+TEST_LOG_DIR="$(pwd)/.test-logs"
+mkdir -p "$TEST_LOG_DIR"
+
 echo "→ root tests"
 # server.test.ts builds a throwaway git repo under SHEPHERD_REPO_ROOT;
 # point it at a temp dir so we never touch the operator's real repo root.
-SHEPHERD_REPO_ROOT="$(mktemp -d)" bun test ./test
+ROOT_TEST_LOG="$TEST_LOG_DIR/prepush-roottest-$(date +%Y%m%dT%H%M%S).log"
+bash -o pipefail -c 'SHEPHERD_REPO_ROOT="$(mktemp -d)" bun test ./test 2>&1 | tee "$1"' _ "$ROOT_TEST_LOG" \
+  || { echo "✗ root tests failed — full output (incl. failing test name) saved to $ROOT_TEST_LOG"; exit 1; }
 
 echo "→ ensure Playwright Chromium (ui browser tests)"
 (cd ui && bunx playwright install chromium)
 
 echo "→ ui tests"
-(cd ui && bun run test)
+UI_TEST_LOG="$TEST_LOG_DIR/prepush-uitest-$(date +%Y%m%dT%H%M%S).log"
+bash -o pipefail -c 'cd ui && bun run test 2>&1 | tee "$1"' _ "$UI_TEST_LOG" \
+  || { echo "✗ ui tests failed — full output saved to $UI_TEST_LOG"; exit 1; }
 
 echo "→ extension tests"
 (cd extension && bun run test)

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -44,6 +44,8 @@ echo "→ i18n catalog parity (en ↔ de)"
 # Capture full test output so an intermittent flake's failing test name survives (#817).
 TEST_LOG_DIR="$(pwd)/.test-logs"
 mkdir -p "$TEST_LOG_DIR"
+# Bound growth: each push writes new timestamped logs, so keep only the most recent ones.
+ls -1t "$TEST_LOG_DIR"/*.log 2>/dev/null | tail -n +21 | xargs -r rm -f
 
 echo "→ root tests"
 # server.test.ts builds a throwaway git repo under SHEPHERD_REPO_ROOT;

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -305,6 +305,12 @@ interface ReapFallowOpts {
   now?: number;
   fsOps?: Pick<FsOps, "readdir" | "stat" | "rm">;
   log?: (msg: string) => void;
+  /**
+   * Overrides the directories scanned (default: computed `[claudeTmpRoot(), claude-$uid subdir,
+   * tmpdir()]` set). Lets a test isolate the scan to a controlled root so the bare-`/tmp` scan
+   * can't pull in a concurrent process's caches. Reference #817.
+   */
+  roots?: string[];
 }
 
 export interface ReapFallowResult {
@@ -388,10 +394,13 @@ export async function reapFallowCaches(opts?: ReapFallowOpts): Promise<ReapFallo
 
   // Dedupe roots: claudeTmpRoot(), claude-$uid subdir, and bare tmpdir() for caches whose
   // TMPDIR was the system default. Using a Set so a reconfigured env can't double-scan.
+  // opts?.roots overrides the computed set (lets tests isolate from bare /tmp — #817).
   const claudeRoot = claudeTmpRoot();
   const nestedRoot = join(claudeRoot, `claude-${uid()}`);
   const systemTmp = tmpdir();
-  const roots = [...new Set([claudeRoot, nestedRoot, systemTmp])];
+  const roots = opts?.roots
+    ? [...new Set(opts.roots)]
+    : [...new Set([claudeRoot, nestedRoot, systemTmp])];
 
   const ctx: ReapFallowCtx = { ops, now, staleMs, log };
   let removed = 0;

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -497,8 +497,10 @@ test("scanListeningPortsByWorktree: proc under /wt/appold is NOT attributed to /
 import { afterEach, beforeEach } from "bun:test";
 import { PreviewService } from "../src/preview";
 
-// A high, unusual base unlikely to collide with anything on the test host.
-const TEST_BASE = 39000;
+// Per-process random base avoids cross-process port collision: a fixed base (e.g. 39000)
+// collides when a concurrent or leftover `bun test` process is binding the same range.
+// A random offset in a 20k span makes overlap astronomically unlikely. Ref #817.
+const TEST_BASE = 40000 + Math.floor(Math.random() * 20000);
 const TEST_COUNT = 4;
 
 type Upstream = ReturnType<typeof Bun.serve>;

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -499,8 +499,10 @@ import { PreviewService } from "../src/preview";
 
 // Per-process random base avoids cross-process port collision: a fixed base (e.g. 39000)
 // collides when a concurrent or leftover `bun test` process is binding the same range.
-// A random offset in a 20k span makes overlap astronomically unlikely. Ref #817.
-const TEST_BASE = 40000 + Math.floor(Math.random() * 20000);
+// The range sits BELOW the Linux ephemeral port range (32768–60999) so the OS won't hand a
+// colliding ephemeral port to an unrelated socket; the random offset (10k span) isolates this
+// process from other test processes. Max bound port = base+count ≈ 30003 < 32768. Ref #817.
+const TEST_BASE = 20000 + Math.floor(Math.random() * 10000);
 const TEST_COUNT = 4;
 
 type Upstream = ReturnType<typeof Bun.serve>;

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -376,11 +376,14 @@ describe("reapFallowCaches", () => {
     const dir = join(root, name);
     mkdirSync(dir);
 
+    // roots: [root] isolates this assertion from foreign fallow-audit-base-cache-* dirs
+    // the real fallow tool / a concurrent test process leaves in the system tmpdir (#817).
     const res = await reapFallowCaches({
       now: Date.now(),
       staleMs: 24 * 3600_000,
       fsOps: fsp,
       log: () => {},
+      roots: [root],
     });
 
     expect(res.removed).toBe(0);
@@ -397,11 +400,14 @@ describe("reapFallowCaches", () => {
     const old = new Date(now - 48 * 3600_000);
     utimesSync(otherDir, old, old);
 
+    // roots: [root] isolates this assertion from foreign fallow-audit-base-cache-* dirs
+    // the real fallow tool / a concurrent test process leaves in the system tmpdir (#817).
     const res = await reapFallowCaches({
       now,
       staleMs: 24 * 3600_000,
       fsOps: fsp,
       log: () => {},
+      roots: [root],
     });
 
     expect(res.removed).toBe(0);
@@ -419,11 +425,14 @@ describe("reapFallowCaches", () => {
     writeFileSync(join(root, `${FALLOW_CACHE_PREFIX}orphan.lock`), "");
     writeFileSync(join(root, `${FALLOW_CACHE_PREFIX}orphan.last-used`), "");
 
+    // roots: [root] isolates this assertion from foreign fallow-audit-base-cache-* dirs
+    // the real fallow tool / a concurrent test process leaves in the system tmpdir (#817).
     const res = await reapFallowCaches({
       now: Date.now(),
       staleMs: 24 * 3600_000,
       fsOps: fsp,
       log: () => {},
+      roots: [root],
     });
 
     // sidecars are skipped, so removed count stays 0; the sidecar files themselves stay
@@ -449,14 +458,17 @@ describe("reapFallowCaches", () => {
     const cleanRoot = mkTmp();
     setEnv("SHEPHERD_TMP_SWEEP_DIR", cleanRoot);
 
-    const res = await reapFallowCaches({
+    await reapFallowCaches({
       now,
       staleMs: 24 * 3600_000,
       fsOps: fsp,
       log: () => {},
     });
 
-    expect(res.removed).toBeGreaterThanOrEqual(1);
+    // Count not asserted: under concurrency a different process's reaper may sweep the dir
+    // first, leaving removed: 0. The dir's removal proves tmpdir() is in the default scan
+    // set (#817) — SHEPHERD_TMP_SWEEP_DIR points to an empty cleanRoot so only the bare
+    // tmpdir() root could have removed it.
     expect(existsSync(dir)).toBe(false);
   });
 
@@ -473,11 +485,14 @@ describe("reapFallowCaches", () => {
     utimesSync(dir, old, old);
 
     // Only provide readdir/stat/rm — no statfs property at all.
+    // roots: [root] isolates this assertion from foreign fallow-audit-base-cache-* dirs
+    // the real fallow tool / a concurrent test process leaves in the system tmpdir (#817).
     const res = await reapFallowCaches({
       now,
       staleMs: 24 * 3600_000,
       fsOps: { readdir: fsp.readdir, stat: fsp.stat, rm: fsp.rm },
       log: () => {},
+      roots: [root],
     });
 
     expect(res.removed).toBe(1);
@@ -495,6 +510,8 @@ describe("reapFallowCaches", () => {
     const old = new Date(now - 48 * 3600_000);
     utimesSync(dir, old, old);
 
+    // roots: [root] isolates this assertion from foreign fallow-audit-base-cache-* dirs
+    // the real fallow tool / a concurrent test process leaves in the system tmpdir (#817).
     const res = await reapFallowCaches({
       now,
       staleMs: 24 * 3600_000,
@@ -506,6 +523,7 @@ describe("reapFallowCaches", () => {
         },
       },
       log: () => {},
+      roots: [root],
     });
 
     // rm threw, so nothing removed — but we did not reject

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -352,7 +352,15 @@ describe("reapFallowCaches", () => {
     const old = new Date(now - 48 * 3600_000);
     utimesSync(dir, old, old);
 
-    const res = await reapFallowCaches({ now, staleMs: 24 * 3600_000, fsOps: fsp, log: () => {} });
+    // Injecting the scanned root makes `removed === 1` deterministic regardless of bare-`/tmp`
+    // contents or a concurrent test process — env-independent isolation (#817).
+    const res = await reapFallowCaches({
+      now,
+      staleMs: 24 * 3600_000,
+      fsOps: fsp,
+      log: () => {},
+      roots: [root],
+    });
 
     expect(res.removed).toBe(1);
     expect(existsSync(dir)).toBe(false);

--- a/ui/src/lib/vite-config.test.ts
+++ b/ui/src/lib/vite-config.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import config from "../../vite.config";
+
+describe("vite config browser project", () => {
+  const projects = (config.test as { projects?: unknown[] })?.projects ?? [];
+  const browserProject = projects.find(
+    (p) => (p as { test?: { name?: string } })?.test?.name === "browser",
+  ) as { test?: { browser?: { api?: { strictPort?: boolean } } } } | undefined;
+
+  it("has a project named browser", () => {
+    expect(browserProject).toBeDefined();
+  });
+
+  it("sets browser.api.strictPort = false to avoid port 63315 collision (#817)", () => {
+    // vitest browser mode defaults its server to port 63315 with strictPort on;
+    // without this, concurrent test runs hard-fail. strictPort:false lets Vite
+    // pick the next free port and hand it to the browser client.
+    expect(browserProject?.test?.browser?.api?.strictPort).toBe(false);
+  });
+});

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -94,6 +94,12 @@ export default defineConfig({
             provider: playwright(),
             headless: true,
             instances: [{ browser: "chromium" }],
+            // vitest's default browser server port (63315) has strictPort on by
+            // default, causing a hard failure when a leftover/concurrent test
+            // process holds the port. strictPort:false lets Vite auto-increment
+            // to the next free port; vitest discovers the bound port and hands
+            // it to the browser client, so a predictable port isn't needed. (#817)
+            api: { strictPort: false },
           },
         },
       },


### PR DESCRIPTION
## Problem

Pre-push intermittently fails a single test, then passes on re-run (#817) — a flaky **hard gate** that blocks legitimate pushes. The issue body reported a root-suite "1 fail / 3-expect delta"; the operator's screenshot showed a *different* pre-push failure: `Error: Port 63315 is already in use` in the vitest **browser** step (UI tests themselves passed). These are **distinct failures with distinct fixes** that share **one root cause**.

## Root cause (reproduced)

Bun runs test files **sequentially in one process** — so this is never in-process concurrency. Several tests/infra claim **fixed OS-global resources** that collide when another test process overlaps (a concurrent run, or a leftover `bun test`/`vitest` process — exactly the operator's "leftover process holding a port"). A solo pre-push run is clean (why ~21 isolated reruns passed); a busy multi-agent box isn't.

Reproduced under CPU load + a 2nd overlapping suite: `reapFallowCaches` swept a concurrent suite's dirs (`removed: 3`, expected `1` → the exact 3-expect delta #817 reported), and PreviewService hit `failed to bind 39000…39003`. ~27 single-suite-under-load runs stayed clean — confirming it's **cross-process only**.

## Fixes (one bug class, distinct per resource — separate commits)

| Resource | Failure | Fix |
| --- | --- | --- |
| vitest browser server (screenshot) | fixed default port **63315** + `strictPort` → hard fail | `browser.api.strictPort: false` so Vite auto-increments (`ui/vite.config.ts`) |
| `PreviewService` tests | fixed base port **39000** range | per-process random base (`test/preview.test.ts`) |
| `reapFallowCaches` tests | always also scan **bare `/tmp`** (real `fallow-audit-base-cache-*` dirs / concurrent suites corrupt the count) | add optional `roots?: string[]` to `reapFallowCaches` (`src/tmp-sweep.ts`); inject `roots:[root]` in every exact/zero-count test; the `scans the bare tmpdir()` test asserts its own dir's removal instead of the racy shared count (`test/tmp-sweep.test.ts`) |

Plus a **diagnostics backstop** (`.husky/pre-push`): root + ui test output is now teed to a gitignored `.test-logs/` (pipefail-safe — a real failure still blocks the push and prints the log path), so any future flake records its failing test name.

## Verification

- Browser: with 63315 occupied → "Port 63315 is in use, trying another one…", tests pass.
- **18 rounds × 2 concurrent `preview`+`tmp-sweep` suites under load → 0 fails** (previously flaked).
- Regression guard: new `ui/src/lib/vite-config.test.ts` asserts the browser project resolves AND `api.strictPort === false` (red pre-fix, green after).
- Full gate green: prettier, eslint, root `tsc`, ui svelte-check, i18n parity, root tests (0 fail), ui tests (1765 pass), extension tests, fallow audit. Pre-push hook passed on push.

## Scope notes

- Ships **no** user-facing UX → no feature-catalog / i18n / glossary entries (commits are `fix(test):` / `chore(pre-push):`).
- The `src/tmp-sweep.ts` `roots` change is a no-op for production callers (who pass none) and follows the function's existing `fsOps`/`now`/`staleMs` injection convention.
- `refs #817` (not auto-close): leaving the issue open until this proves out across real pushes — close when satisfied. The `.test-logs/` capture will surface any recurrence with a test name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
