### PR TITLE
feat(ui): respect iOS system Text Size (Dynamic Type) in the PWA

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1676,5 +1676,7 @@
   "feat_learnings_retire_push_title": "Push-Benachrichtigung beim Auto-Zurückziehen",
   "feat_learnings_retire_push_body": "Wenn der tägliche Hintergrundlauf leistungsschwache Hausregeln zurückzieht, erhältst du jetzt eine Push-Benachrichtigung – so erfährst du davon, ohne das Learnings-Panel zu öffnen. Tippe darauf, um die zurückgezogenen Regeln zu prüfen und versehentlich zurückgezogene wiederherzustellen.",
   "feat_learnings_repo_glyph_title": "Repo auf einen Blick in den Erkenntnissen",
-  "feat_learnings_repo_glyph_body": "Jede Repo-Gruppe im Erkenntnisse-Panel zeigt jetzt das Projekt-Emoji (oder das ▣-Symbol) neben dem Namen – genau wie die Session-Karten – damit klar ist, zu welchem Repo eine Erkenntnis gehört."
+  "feat_learnings_repo_glyph_body": "Jede Repo-Gruppe im Erkenntnisse-Panel zeigt jetzt das Projekt-Emoji (oder das ▣-Symbol) neben dem Namen – genau wie die Session-Karten – damit klar ist, zu welchem Repo eine Erkenntnis gehört.",
+  "feat_ios_text_size_title": "Berücksichtigt deine iOS-Textgröße",
+  "feat_ios_text_size_body": "Auf iPhone und iPad folgt die Home-Bildschirm-App von Shepherd jetzt der System-Textgröße (Kontrollzentrum oder Einstellungen → Anzeige & Helligkeit → Textgröße). Die gesamte Oberfläche skaliert mit dem Regler – größer für Lesbarkeit oder kleiner für Dichte – und behält in der Standardstellung das aktuelle Erscheinungsbild bei."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1676,5 +1676,7 @@
   "feat_learnings_retire_push_title": "Auto-retire push notifications",
   "feat_learnings_retire_push_body": "When the daily background pass retires underperforming house rules, you now get a push notification so you learn of it without opening the Learnings drawer. Tap it to review the retired rules and restore any retired by mistake.",
   "feat_learnings_repo_glyph_title": "Repo at a glance in Learnings",
-  "feat_learnings_repo_glyph_body": "Each repo's group in the Learnings drawer now shows its project emoji (or the ▣ marker) beside the name — just like session cards — so it's clear which repo a learning belongs to."
+  "feat_learnings_repo_glyph_body": "Each repo's group in the Learnings drawer now shows its project emoji (or the ▣ marker) beside the name — just like session cards — so it's clear which repo a learning belongs to.",
+  "feat_ios_text_size_title": "Respects your iOS text size",
+  "feat_ios_text_size_body": "On iPhone and iPad, Shepherd's home-screen app now follows the system Text Size setting (Control Center, or Settings → Display & Brightness → Text Size). The whole interface scales with the slider — larger for readability or smaller for density — preserving the current look at the default position."
 }

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -63,13 +63,22 @@
 
   /* Type scale — single source of truth. 6 deliberate rungs anchored on
      DESIGN.md's 11px (label/numeric) + 13px (title/body); 10px is the floor for
-     dense chrome. Replaces ~16 drifted ad-hoc sizes. */
-  --fs-micro: 10px;
-  --fs-meta: 11px;
-  --fs-base: 13px;
-  --fs-lg: 16px;
-  --fs-xl: 20px;
-  --fs-2xl: 22px;
+     dense chrome. Replaces ~16 drifted ad-hoc sizes.
+
+     Every rung is multiplied by --ui-scale so the whole scale honors the iOS
+     system Text Size (Dynamic Type) setting. --ui-scale is 1 everywhere by
+     default (desktop/Android render at the exact px above, unchanged); on iOS
+     Safari the pre-paint probe in app.html sets it to the user's Dynamic Type
+     ratio (1.0 at the default slider position), so the design is preserved at
+     default and scales proportionally as the slider moves. The fallback `1`
+     keeps sizing correct if the script never runs. */
+  --ui-scale: 1;
+  --fs-micro: calc(10px * var(--ui-scale));
+  --fs-meta: calc(11px * var(--ui-scale));
+  --fs-base: calc(13px * var(--ui-scale));
+  --fs-lg: calc(16px * var(--ui-scale));
+  --fs-xl: calc(20px * var(--ui-scale));
+  --fs-2xl: calc(22px * var(--ui-scale));
 
   /* Fixed mobile action bar (list screen) — single source so the bar's sizing
      and the list's padding-bottom reservation can't drift. The bar's own
@@ -321,10 +330,13 @@ button {
    drift back under the threshold. The `:is()` wrapper deliberately lends the
    bare `textarea`/`select` the input arm's specificity (0,3,1), so this beats
    Svelte-scoped component rules like `.ep-search.svelte-x` (0,2,0) or
-   `textarea.svelte-x` (0,1,1) that set a smaller desktop size. */
+   `textarea.svelte-x` (0,1,1) that set a smaller desktop size.
+   max(16px, …) keeps the guard hard: --fs-lg now scales with the iOS Text Size
+   setting (--ui-scale), so a *smaller* Dynamic Type choice could otherwise push
+   --fs-lg under 16px and bring the focus-zoom back; the floor stays absolute. */
 @media (max-width: 768px) {
   :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]), textarea, select) {
-    font-size: var(--fs-lg);
+    font-size: max(16px, var(--fs-lg));
   }
 }
 

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -71,7 +71,12 @@
      Safari the pre-paint probe in app.html sets it to the user's Dynamic Type
      ratio (1.0 at the default slider position), so the design is preserved at
      default and scales proportionally as the slider moves. The fallback `1`
-     keeps sizing correct if the script never runs. */
+     keeps sizing correct if the script never runs.
+
+     The probe caps --ui-scale at 1.5: only type scales here, not spacing or the
+     fixed chrome heights below (--mobile-actionbar-hit, --icon-btn-hit), so the
+     accessibility end of Dynamic Type (~3x) would overflow those dense bars. The
+     cap honors a meaningfully larger choice while keeping the chrome intact. */
   --ui-scale: 1;
   --fs-micro: calc(10px * var(--ui-scale));
   --fs-meta: calc(11px * var(--ui-scale));

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -71,7 +71,14 @@
           document.documentElement.appendChild(probe);
           var apply = function () {
             var px = parseFloat(getComputedStyle(probe).fontSize);
-            if (px > 0) document.documentElement.style.setProperty("--ui-scale", String(px / 17));
+            if (px > 0) {
+              // Cap at 1.5. Only the type tokens scale — spacing and fixed chrome
+              // (e.g. the 44px action-bar / 28px icon-button hit targets) stay put,
+              // so the accessibility end of Dynamic Type (~3x) would overflow them.
+              // 1.5 honors a meaningfully larger choice while the dense bars hold.
+              var ratio = Math.min(px / 17, 1.5);
+              document.documentElement.style.setProperty("--ui-scale", String(ratio));
+            }
           };
           apply();
           if (window.ResizeObserver) new ResizeObserver(apply).observe(probe);

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -13,6 +13,9 @@
          values; without it iOS letterboxes content and the insets stay 0. Paired with
          apple-mobile-web-app-status-bar-style=black-translucent for a full-bleed dark shell. -->
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <!-- Standards-track opt-in (env(preferred-text-scale), Chrome Canary 2026; not
+         yet in WebKit). Harmless where unsupported; the iOS path below carries us
+         until Safari ships it. -->
     <meta name="text-scale" content="scale" />
     <title>Shepherd</title>
     <!-- Resolve the theme before first paint so there's no flash of wrong theme.
@@ -34,6 +37,45 @@
         } catch (e) {
           document.documentElement.dataset.theme = "dark";
         }
+      })();
+    </script>
+    <!-- iOS Dynamic Type bridge. The whole type scale is `calc(<px> * var(--ui-scale))`
+         in app.css; this resolves --ui-scale to the user's iOS system Text Size so the
+         UI honors that setting (the slider in Control Center / Settings → Display).
+         WebKit only exposes the preference through the `-apple-system-body` font
+         keyword — never a number — so we render a hidden probe with that font and read
+         its computed size, dividing by 17 (the iOS default "body" px) to get a ratio:
+         1.0 at the default slider (design preserved exactly), >1 / <1 as it moves.
+         Guarded to iOS Safari: `-webkit-touch-callout: default` is supported there but
+         NOT on macOS Safari (which also resolves -apple-system-body, smaller than 17,
+         and would otherwise shrink the desktop UI). Runs pre-paint to avoid a resize
+         flash; a ResizeObserver tracks live slider changes. --ui-scale defaults to 1
+         in app.css, so non-iOS and any failure here leave the px scale untouched. -->
+    <script>
+      (function () {
+        try {
+          if (
+            !(
+              window.CSS &&
+              CSS.supports &&
+              CSS.supports("font: -apple-system-body") &&
+              CSS.supports("-webkit-touch-callout: default")
+            )
+          )
+            return;
+          var probe = document.createElement("div");
+          probe.setAttribute("aria-hidden", "true");
+          probe.style.cssText =
+            "position:absolute;top:-9999px;left:-9999px;visibility:hidden;font:-apple-system-body;";
+          probe.textContent = "M";
+          document.documentElement.appendChild(probe);
+          var apply = function () {
+            var px = parseFloat(getComputedStyle(probe).fontSize);
+            if (px > 0) document.documentElement.style.setProperty("--ui-scale", String(px / 17));
+          };
+          apply();
+          if (window.ResizeObserver) new ResizeObserver(apply).observe(probe);
+        } catch (e) {}
       })();
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1298,4 +1298,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_learnings_repo_glyph_title",
     bodyKey: "feat_learnings_repo_glyph_body",
   },
+  {
+    // The iOS home-screen PWA now honors the system Text Size (Dynamic Type)
+    // setting — the whole type scale scales from the Control Center / Settings
+    // slider. No anchor element, so no coachmark. v1.34.0 is the latest released
+    // tag → ships in 1.35.0.
+    id: "ios-dynamic-type",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_ios_text_size_title",
+    bodyKey: "feat_ios_text_size_body",
+  },
 ];


### PR DESCRIPTION
## Problem

On iPhone/iPad, Shepherd's home-screen PWA ignored the system **Text Size** setting (Control Center, or Settings → Display & Brightness → Text Size). The slider had no effect.

**Root cause:** the entire type scale is authored in absolute `px` — 6 tokens (`--fs-micro`…`--fs-2xl`) consumed ~735× — plus `html,body { font-size: 13px }`. Absolute `px` never responds to iOS Dynamic Type. A prior `<meta name="text-scale">` attempt is a not-yet-shipped standard and does nothing in WebKit today.

## Fix

Make the type scale honor iOS Dynamic Type **without** changing the design at the default slider position and **without** touching desktop/Android.

- **`ui/src/app.css`** — each `--fs-*` rung is now `calc(<px> * var(--ui-scale))`. `--ui-scale` defaults to `1`, so every non-iOS surface renders the exact same px as before (zero drift; the 3 existing layout `rem` values are untouched since the root font-size is unchanged).
- **`ui/src/app.html`** — a pre-paint probe reads the user's Dynamic Type size. WebKit only exposes the preference through the `-apple-system-body` font keyword (never a number), so we render a hidden probe with that font and divide its computed size by `17` (the iOS default body px) to get a ratio: **1.0 at the default slider** → larger/smaller as it moves. A `ResizeObserver` tracks live changes; runs before paint to avoid a resize flash.
- **iOS-guarded** with `-webkit-touch-callout: default` (true on iOS Safari, false on macOS Safari, which also resolves `-apple-system-body` and would otherwise shrink the desktop UI). On any failure, `--ui-scale` stays `1`.
- The iOS input zoom-floor becomes `max(16px, var(--fs-lg))` so a *smaller* Text Size can't push inputs under 16px and bring back focus-zoom.

## Why this shape

Approach confirmed against current WebKit guidance (`-apple-system-body` is the only iOS Dynamic Type opt-in; `-webkit-text-size-adjust` is unrelated auto-inflation). A pure-CSS root swap was rejected: it forces the iOS default base to 17px (≈31% bigger than the tuned 13px design) and would shift the 3 existing layout `rem` widths on desktop. The `--ui-scale` multiplier keeps the change surgical and the design intact at default.

## Verification

- `bun run check` — 0 errors, `check:i18n` — 2 locales in parity
- `bun run build` — succeeds; probe + scaled tokens confirmed in the bundle
- branch-hygiene + feature-catalog gates pass
- Feature-announcement entry (`ios-dynamic-type`, v1.35.0) + EN/DE keys added

> Note: requires testing on a physical iOS device — `-apple-system-body` / Dynamic Type can't be exercised in a desktop browser.
