### PR TITLE
feat(learnings): push notification for auto-retire (#852)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1171,8 +1171,23 @@ const runDailySweep = () => {
   // repo base rate (gated on real harm evidence). Returns the retired set so we only
   // nudge clients (banner refresh) when something actually changed.
   const retired = runAutoRetire({ store, optimizer });
-  if (retired.length > 0)
+  if (retired.length > 0) {
     events.emit("learnings:update", { pending: store.pendingLearningCount() });
+    // Best-effort push so operators learn of background retirements without opening the
+    // drawer (issue #852). One summary push across all repos; suppressed while the app is
+    // active and for devices that muted the "agent" category. Guarded so a rejection can't
+    // crash the sweep — the in-drawer banner remains the durable surface either way.
+    void push
+      .notify({
+        kind: "learnings_retired",
+        sessionId: "",
+        tag: "learnings-retired",
+        name: "learnings",
+        retiredCount: retired.length,
+        cooldownKey: "learnings_retired:all",
+      })
+      .catch((err) => console.warn("[push] learnings_retired notify failed:", err));
+  }
   // Reclaim session_injected_learnings rows for sessions that vanished without archive()
   // (force-removed/crashed) — archive() consumes the rest.
   store.pruneOrphanInjectedLearnings();

--- a/src/push.ts
+++ b/src/push.ts
@@ -19,7 +19,8 @@ export interface PushPayload {
     | "autopilot-done"
     | "merge_attention"
     | "usage_limit"
-    | "extra_credits";
+    | "extra_credits"
+    | "learnings_retired";
   tag: string;
 }
 
@@ -38,6 +39,7 @@ const KIND_CATEGORY: Record<PushPayload["kind"], PushCategory> = {
   merge_attention: "ci",
   usage_limit: "agent",
   extra_credits: "agent",
+  learnings_retired: "agent",
 };
 
 /** A notification described by intent, not text — localized per device at send time. */
@@ -52,7 +54,8 @@ export interface NotifyInput {
     | "autopilot-done"
     | "merge_attention"
     | "usage_limit"
-    | "extra_credits";
+    | "extra_credits"
+    | "learnings_retired";
   sessionId: string;
   tag: string;
   name: string;
@@ -79,6 +82,8 @@ export interface NotifyInput {
   creditCap?: number;
   /** For kind "extra_credits": currency symbol/prefix for the amounts. */
   currency?: string;
+  /** For kind "learnings_retired": how many rules the auto-retire sweep retired. */
+  retiredCount?: number;
   /** Overrides the cooldown key (default `${kind}:${sessionId}`). */
   cooldownKey?: string;
 }
@@ -131,6 +136,9 @@ const NOTIFY_TEXT = {
       time ? `Approaching the usage cap — resets at ${time}.` : "Approaching the usage cap.",
     extraCreditsTitle: "Extra credits in use",
     extraCreditsBody: (amount: string) => `Now spending paid extra usage — ${amount} this period.`,
+    learningsRetiredTitle: "Learnings auto-retired",
+    learningsRetiredBody: (n: number) =>
+      `${n} ${n === 1 ? "rule" : "rules"} auto-retired — tap to review.`,
   },
   de: {
     doneTitle: (name: string) => `${name} — wartet`,
@@ -169,6 +177,9 @@ const NOTIFY_TEXT = {
     extraCreditsTitle: "Zusatzguthaben aktiv",
     extraCreditsBody: (amount: string) =>
       `Kostenpflichtige Zusatznutzung läuft — ${amount} in diesem Zeitraum.`,
+    learningsRetiredTitle: "Learnings automatisch zurückgezogen",
+    learningsRetiredBody: (n: number) =>
+      `${n} ${n === 1 ? "Regel" : "Regeln"} zurückgezogen — zum Prüfen tippen.`,
   },
 } as const;
 
@@ -293,6 +304,12 @@ export function buildPayload(input: NotifyInput, locale: string): PushPayload {
       };
     case "extra_credits":
       return { ...base, title: t.extraCreditsTitle, body: extraCreditsBody(t, input) };
+    case "learnings_retired":
+      return {
+        ...base,
+        title: t.learningsRetiredTitle,
+        body: t.learningsRetiredBody(input.retiredCount ?? 0),
+      };
     default:
       return {
         ...base,

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -329,6 +329,48 @@ test("buildPayload review kind varies copy by decision", () => {
   expect(buildPayload(noDecision, "en").body).toBe("Critic requested changes on the PR.");
 });
 
+test("buildPayload learnings_retired localizes title + body and pluralizes by count", () => {
+  const one: NotifyInput = {
+    kind: "learnings_retired",
+    sessionId: "",
+    tag: "learnings-retired",
+    name: "learnings",
+    retiredCount: 1,
+  };
+  expect(buildPayload(one, "en")).toMatchObject({
+    title: "Learnings auto-retired",
+    body: "1 rule auto-retired — tap to review.",
+  });
+  expect(buildPayload(one, "de")).toMatchObject({
+    title: "Learnings automatisch zurückgezogen",
+    body: "1 Regel zurückgezogen — zum Prüfen tippen.",
+  });
+  const many: NotifyInput = { ...one, retiredCount: 3 };
+  expect(buildPayload(many, "en").body).toBe("3 rules auto-retired — tap to review.");
+  expect(buildPayload(many, "de").body).toBe("3 Regeln zurückgezogen — zum Prüfen tippen.");
+});
+
+test("notify honors the agent category opt-out for learnings_retired", async () => {
+  const sent: string[] = [];
+  const send: SendFn = async (s) => {
+    sent.push(s.endpoint);
+    return {};
+  };
+  const { store, push } = svc(send);
+  store.putPushSub(sub("agent-on"), "");
+  store.putPushSub(sub("agent-off"), "");
+  store.setPushPrefs("agent-off", { agent: false, reviews: true, ci: true });
+  // learnings_retired is an agent-category kind → only the device that kept agent on hears it
+  await push.notify({
+    kind: "learnings_retired",
+    sessionId: "",
+    tag: "learnings-retired",
+    name: "learnings",
+    retiredCount: 2,
+  });
+  expect(sent).toEqual(["agent-on"]);
+});
+
 test("attachReviewPush notifies on changes_requested and commented, ignores error/null", async () => {
   const calls: any[] = [];
   const { store, push } = svc(async () => ({}));

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1672,5 +1672,7 @@
   "feat_learnings_recur_body": "Wenn dieselbe Regel in mehreren Repos wiederkehrt, schlägt das Learnings-Panel jetzt vor, sie in deine benutzerglobale CLAUDE.md aufzunehmen – als Vorschlag, den du verwerfen kannst.",
   "gitrail_open_issue": "Issue #{number} ↗",
   "feat_open_linked_issue_title": "Verknüpftes Issue öffnen",
-  "feat_open_linked_issue_body": "GitRail zeigt jetzt einen \"Issue #N ↗\"-Link für Aufgaben, die aus einem Backlog-Issue gestartet wurden – direkt zum Issue auf GitHub oder Gitea springen."
+  "feat_open_linked_issue_body": "GitRail zeigt jetzt einen \"Issue #N ↗\"-Link für Aufgaben, die aus einem Backlog-Issue gestartet wurden – direkt zum Issue auf GitHub oder Gitea springen.",
+  "feat_learnings_retire_push_title": "Push-Benachrichtigung beim Auto-Zurückziehen",
+  "feat_learnings_retire_push_body": "Wenn der tägliche Hintergrundlauf leistungsschwache Hausregeln zurückzieht, erhältst du jetzt eine Push-Benachrichtigung – so erfährst du davon, ohne das Learnings-Panel zu öffnen. Tippe darauf, um die zurückgezogenen Regeln zu prüfen und versehentlich zurückgezogene wiederherzustellen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1672,5 +1672,7 @@
   "feat_learnings_recur_body": "When the same rule recurs across several repos, the Learnings drawer now suggests promoting it to your user-global CLAUDE.md — kept as a suggestion you can dismiss.",
   "gitrail_open_issue": "Issue #{number} ↗",
   "feat_open_linked_issue_title": "Open the linked issue",
-  "feat_open_linked_issue_body": "GitRail now shows an \"Issue #N ↗\" link for tasks spawned from a backlog issue — jump straight to the issue on GitHub or Gitea."
+  "feat_open_linked_issue_body": "GitRail now shows an \"Issue #N ↗\" link for tasks spawned from a backlog issue — jump straight to the issue on GitHub or Gitea.",
+  "feat_learnings_retire_push_title": "Auto-retire push notifications",
+  "feat_learnings_retire_push_body": "When the daily background pass retires underperforming house rules, you now get a push notification so you learn of it without opening the Learnings drawer. Tap it to review the retired rules and restore any retired by mistake."
 }

--- a/ui/src/lib/components/learnings-drawer.test.ts
+++ b/ui/src/lib/components/learnings-drawer.test.ts
@@ -21,6 +21,7 @@ import {
   retiredCount,
   unseenRetiredCount,
   helpRate,
+  shouldCloseLearningsDrawer,
 } from "./learnings-drawer";
 import type { Learning, LearningStatus, RepoInjectable } from "../types";
 
@@ -523,5 +524,27 @@ describe("helpRate", () => {
 
   it("helped can equal pulls (100% rate)", () => {
     expect(helpRate({ helpfulCount: 7, injectedCount: 7 })).toEqual({ helped: 7, pulls: 7 });
+  });
+});
+
+describe("shouldCloseLearningsDrawer", () => {
+  // Regression for #852: a deep-link opens the drawer (open=true) before the async
+  // learnings.load() resolves, so items/injectable are still 0. WITHOUT the loaded gate
+  // this returned true and slammed the drawer shut before retired rules arrived.
+  it("does NOT close an open drawer while the first load is still pending", () => {
+    expect(shouldCloseLearningsDrawer(true, false, 0, 0)).toBe(false);
+  });
+
+  it("closes once loaded confirms both lists are genuinely empty", () => {
+    expect(shouldCloseLearningsDrawer(true, true, 0, 0)).toBe(true);
+  });
+
+  it("stays open after load when there is content to show", () => {
+    expect(shouldCloseLearningsDrawer(true, true, 1, 0)).toBe(false);
+    expect(shouldCloseLearningsDrawer(true, true, 0, 2)).toBe(false);
+  });
+
+  it("never closes a drawer that isn't open", () => {
+    expect(shouldCloseLearningsDrawer(false, true, 0, 0)).toBe(false);
   });
 });

--- a/ui/src/lib/components/learnings-drawer.ts
+++ b/ui/src/lib/components/learnings-drawer.ts
@@ -216,6 +216,19 @@ export function helpRate(rule: {
   return { helped: rule.helpfulCount, pulls: rule.injectedCount };
 }
 
+/** Whether the open Learnings drawer should auto-close because it has nothing to show.
+ *  Gated on `loaded` (the first learnings fetch resolved): a deep-link that opens the
+ *  drawer before the async load populates the lists must NOT be closed by the still-empty
+ *  initial state (issue #852) — only once a load has confirmed there is genuinely nothing. */
+export function shouldCloseLearningsDrawer(
+  open: boolean,
+  loaded: boolean,
+  itemCount: number,
+  injectableCount: number,
+): boolean {
+  return open && loaded && itemCount === 0 && injectableCount === 0;
+}
+
 /** Stable display order for the evidence breakdown: most operator-meaningful
  *  source first (a correction you gave) down to passive ones (a stall). */
 const KIND_ORDER: SignalKind[] = ["reply", "critic", "block", "stall"];

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1279,4 +1279,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_open_linked_issue_title",
     bodyKey: "feat_open_linked_issue_body",
   },
+  {
+    // Auto-retire push surface (#852): a daily background pass that retires underperforming
+    // rules now also fires a push notification. No targetId — the surface is an OS push, not
+    // an on-screen element. v1.34.0 latest released → 1.35.0.
+    id: "learnings-retire-push",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_learnings_retire_push_title",
+    bodyKey: "feat_learnings_retire_push_body",
+  },
 ];

--- a/ui/src/lib/push.ts
+++ b/ui/src/lib/push.ts
@@ -142,3 +142,14 @@ export function onSelectSession(cb: (id: string) => void): () => void {
   navigator.serviceWorker.addEventListener("message", handler);
   return () => navigator.serviceWorker.removeEventListener("message", handler);
 }
+
+/** Subscribe to "open-learnings" messages posted by the SW when a learnings-retire
+ *  notification is clicked (issue #852). Returns a disposer. */
+export function onOpenLearnings(cb: () => void): () => void {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return () => {};
+  const handler = (e: MessageEvent) => {
+    if (e.data?.type === "open-learnings") cb();
+  };
+  navigator.serviceWorker.addEventListener("message", handler);
+  return () => navigator.serviceWorker.removeEventListener("message", handler);
+}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -122,7 +122,7 @@
   import HerdrUpdateModal from "$lib/components/HerdrUpdateModal.svelte";
   import StarPrompt from "$lib/components/StarPrompt.svelte";
   import Toasts from "$lib/components/Toasts.svelte";
-  import { registerSW, onSelectSession } from "$lib/push";
+  import { registerSW, onSelectSession, onOpenLearnings } from "$lib/push";
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
   import type { FeatureAnnouncement } from "$lib/feature-announcements";
@@ -1041,7 +1041,11 @@
     registerSW();
     const params = new URLSearchParams(location.search);
     const deepLink = params.get("session");
+    // Learnings-retire push deep-link (issue #852): ?learnings=1 (cold open) or an
+    // "open-learnings" message from the SW (open/backgrounded window) opens the drawer.
+    if (params.get("learnings") === "1") showLearnings = true;
     const disposeSelect = onSelectSession((id) => selectUnit(id));
+    const disposeLearnings = onOpenLearnings(() => (showLearnings = true));
     listSessions()
       .then((list) => {
         store.setAll(list);
@@ -1152,6 +1156,7 @@
     return () => {
       dispose();
       disposeSelect();
+      disposeLearnings();
       document.removeEventListener("visibilitychange", onWake);
       window.removeEventListener("pageshow", onPageShow);
     };

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -77,7 +77,7 @@
   import TopBar from "$lib/components/TopBar.svelte";
   import TriageDrawer from "$lib/components/TriageDrawer.svelte";
   import LearningsDrawer from "$lib/components/LearningsDrawer.svelte";
-  import { basename } from "$lib/components/learnings-drawer";
+  import { basename, shouldCloseLearningsDrawer } from "$lib/components/learnings-drawer";
   import Herd from "$lib/components/Herd.svelte";
   import {
     railOrder,
@@ -209,6 +209,10 @@
   } | null>(null);
   let showTriage = $state(false);
   let showLearnings = $state(false);
+  // True once the first learnings.load() has resolved. Gates the auto-close effect so a
+  // deep-link (issue #852: ?learnings=1 / "open-learnings") that opens the drawer before
+  // the async load populates items/injectable isn't reversed by the still-empty lists.
+  let learningsLoaded = $state(false);
   // When the learnings drawer is opened from a repo's chip (its ✦ in the RepoSwitcher
   // rail), this carries that repoPath so the drawer scrolls to the matching section;
   // null = opened globally.
@@ -367,7 +371,16 @@
   $effect(() => {
     // Close only when both the proposed list and the injected view are empty —
     // a repo can have injected rules to curate with zero outstanding proposals.
-    if (showLearnings && learnings.items.length === 0 && learnings.injectable.length === 0)
+    // Gated on learningsLoaded so a deep-link that opens the drawer before the async
+    // load resolves (empty lists) isn't immediately closed (issue #852).
+    if (
+      shouldCloseLearningsDrawer(
+        showLearnings,
+        learningsLoaded,
+        learnings.items.length,
+        learnings.injectable.length,
+      )
+    )
       showLearnings = false;
   });
   let viewMode = $state<"focus" | "all">("focus");
@@ -1102,7 +1115,7 @@
     planGates.load();
     recaps.load();
     herdDigest.load();
-    learnings.load();
+    learnings.load().then(() => (learningsLoaded = true));
     listHeld()
       .then((arr) => (store.heldCount = arr.length))
       .catch(() => {});

--- a/ui/static/sw.js
+++ b/ui/static/sw.js
@@ -19,7 +19,7 @@ self.addEventListener("push", (event) => {
         payload = null;
       }
       if (!payload) return;
-      const { body, sessionId, tag } = payload;
+      const { body, sessionId, tag, kind } = payload;
       // buildPayload always sets a title; fall back to the app name so a payload
       // that somehow lacks one still surfaces a real banner rather than letting the
       // event settle (which on mobile yields the browser's generic banner).
@@ -35,7 +35,7 @@ self.addEventListener("push", (event) => {
         body: body ?? "",
         tag: tag ?? sessionId,
         renotify: true,
-        data: { sessionId },
+        data: { sessionId, kind },
         icon: "/icons/icon-192.png",
         badge: "/icons/badge-96.png",
       };
@@ -53,14 +53,24 @@ self.addEventListener("push", (event) => {
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
   const sessionId = event.notification.data?.sessionId;
-  const target = sessionId ? "/?session=" + encodeURIComponent(sessionId) : "/";
+  const kind = event.notification.data?.kind;
+  // Learnings-retire pushes (issue #852) aren't session-scoped: open the Learnings drawer
+  // instead of selecting a session. An open (possibly backgrounded) window is reopened in
+  // place via postMessage; only when no window exists do we openWindow the URL-param route.
+  const learnings = kind === "learnings_retired";
+  const target = learnings
+    ? "/?learnings=1"
+    : sessionId
+      ? "/?session=" + encodeURIComponent(sessionId)
+      : "/";
   event.waitUntil(
     (async () => {
       const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
       for (const c of clients) {
         if ("focus" in c) {
           await c.focus();
-          if (sessionId) c.postMessage({ type: "select-session", id: sessionId });
+          if (learnings) c.postMessage({ type: "open-learnings" });
+          else if (sessionId) c.postMessage({ type: "select-session", id: sessionId });
           return;
         }
       }


### PR DESCRIPTION
Closes #852.

Phase 1 (#840, epic #838) shipped learnings auto-retire with a **persistent in-drawer banner** as the sole visibility surface; a push notification was explicitly deferred because `PushPayload["kind"]` had no learnings kind. This adds that wiring as an additive convenience — the banner remains load-bearing.

## What it does
- New `kind: "learnings_retired"` in `PushPayload`/`NotifyInput` (`src/push.ts`), mapped to the existing **`agent`** category in `KIND_CATEGORY` — no new category, so the per-device opt-out the issue requires is honored for free.
- `buildPayload` case with EN+DE copy (real singular/plural: `1 rule`/`N rules`, `1 Regel`/`N Regeln`). Push copy lives server-side in `NOTIFY_TEXT` like every other kind.
- Fired **best-effort** from `runDailySweep` (`src/index.ts`), consuming the `RetiredRecord[]` that `runAutoRetire` already returns (same `retired.length > 0` guard as the existing `learnings:update` emit) — no re-derivation. Guarded with `.catch` so a rejection can't crash the sweep. One summary push across all repos.
- **Deep-link to the Learnings drawer on click** (operator-approved over "open app root"): `sw.js` carries `kind` in the notification `data`; on click it focuses an open/backgrounded window and posts `open-learnings`, or `openWindow("/?learnings=1")` when no window is open. `+page.svelte` opens the drawer from either the `?learnings=1` param or the `onOpenLearnings` message. Mirrors the existing `session`/`select-session` path.

## Notes
- **Suppressed-while-active = dropped, not deferred.** Unlike `usage_limit`/`extra_credits` (which re-fire on each ~30s tick), the once-daily sweep has no retry tick — if every device is active/opted-out when it fires, that day's push is lost until a future sweep retires new rules. Acceptable: the in-drawer banner is the durable surface; the push is opportunistic.
- Feature-catalog entry added (`learnings-retire-push`, anchorless — a push surface has no on-screen anchor; well-precedented).

## Tests
- `test/push.test.ts`: `buildPayload` localization + singular/plural for the new kind (EN+DE); `agent`-category opt-out routing. Both fail on pre-fix code (the kind didn't exist).
- Full suites green: root `bun run lint` + `bun test` (4123 pass), `ui` `bun run check` + `check:i18n` (parity) + `bun run test` (1765 pass), strict `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)