### PR TITLE
refactor(ui): split UnitRow + GitRail templates, drop 2 fallow grandfathers (#855)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -155,11 +155,12 @@
     //   external convention exists for template thresholds — this is a deliberate
     //   judgment call. 27 of 36 components clear it; anything over it still trips, so
     //   the metric stays live for new code.
-    // Tier 2: the 9 giants that exceed Tier 1, each grandfathered just above its
+    // Tier 2: the 6 giants that exceed Tier 1, each grandfathered just above its
     //   current cyclo/cog (next multiple of 10) so it can't silently grow. Tracked for
-    //   refactor in #855 — which has paid down 4 of the original 13 (RepoSwitcher,
-    //   NewTask, AutomationSettings, Settings), each split into subcomponents that clear
-    //   the Tier-1 bar, so their grandfathers are removed.
+    //   refactor in #855 — which has paid down 7 of the original 13 (RepoSwitcher,
+    //   NewTask, AutomationSettings, Settings, IssuesPanel, BacklogView, UnitRow), each
+    //   split into subcomponents that clear the Tier-1 bar, so their grandfathers are
+    //   removed. Remaining: Viewport, TopBar, Herd, +page, GitRail, LearningsDrawer.
     // maxCrap is intentionally inert for templates: CRAP for uncovered code is pure
     //   CC-derived noise bounded by CC²+CC; 20000 sits above the largest template's
     //   worst case (Viewport CC 136 → ≈18632) so it never becomes the binding
@@ -219,14 +220,6 @@
         "functions": ["<template>"],
         "maxCyclomatic": 60,
         "maxCognitive": 120,
-        "maxCrap": 20000,
-        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
-      },
-      {
-        "files": ["ui/src/lib/components/UnitRow.svelte"],
-        "functions": ["<template>"],
-        "maxCyclomatic": 60,
-        "maxCognitive": 90,
         "maxCrap": 20000,
         "reason": "Tier 2 grandfather (#851); refactor candidate #855."
       },

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -155,12 +155,12 @@
     //   external convention exists for template thresholds — this is a deliberate
     //   judgment call. 27 of 36 components clear it; anything over it still trips, so
     //   the metric stays live for new code.
-    // Tier 2: the 6 giants that exceed Tier 1, each grandfathered just above its
+    // Tier 2: the 5 giants that exceed Tier 1, each grandfathered just above its
     //   current cyclo/cog (next multiple of 10) so it can't silently grow. Tracked for
-    //   refactor in #855 — which has paid down 7 of the original 13 (RepoSwitcher,
-    //   NewTask, AutomationSettings, Settings, IssuesPanel, BacklogView, UnitRow), each
-    //   split into subcomponents that clear the Tier-1 bar, so their grandfathers are
-    //   removed. Remaining: Viewport, TopBar, Herd, +page, GitRail, LearningsDrawer.
+    //   refactor in #855 — which has paid down 8 of the original 13 (RepoSwitcher,
+    //   NewTask, AutomationSettings, Settings, IssuesPanel, BacklogView, UnitRow,
+    //   GitRail), each split into subcomponents that clear the Tier-1 bar, so their
+    //   grandfathers are removed. Remaining: Viewport, TopBar, Herd, +page, LearningsDrawer.
     // maxCrap is intentionally inert for templates: CRAP for uncovered code is pure
     //   CC-derived noise bounded by CC²+CC; 20000 sits above the largest template's
     //   worst case (Viewport CC 136 → ≈18632) so it never becomes the binding
@@ -212,14 +212,6 @@
         "functions": ["<template>"],
         "maxCyclomatic": 80,
         "maxCognitive": 100,
-        "maxCrap": 20000,
-        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
-      },
-      {
-        "files": ["ui/src/lib/components/GitRail.svelte"],
-        "functions": ["<template>"],
-        "maxCyclomatic": 60,
-        "maxCognitive": 120,
         "maxCrap": 20000,
         "reason": "Tier 2 grandfather (#851); refactor candidate #855."
       },

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -13,7 +13,7 @@
   import { m } from "$lib/paraglide/messages";
   import { reviews, repoConfig, planGates } from "$lib/reviews.svelte";
   import { criticChip, criticBadgeLabel } from "./critic-badge";
-  import ReadyToggle from "./ReadyToggle.svelte";
+  import RailStatusActions from "./git-rail/RailStatusActions.svelte";
   import AutomationPanel from "./AutomationPanel.svelte";
   import { automationCount, AUTOMATION_TOTAL } from "./git-rail-automation";
   import { coachTarget, coachTargets } from "$lib/actions/coachTarget.svelte";
@@ -554,129 +554,34 @@
   {/if}
   <span class="git-rail-wrap" class:mobile bind:this={wrapEl}>
     <span class="rail" class:mobile use:edgeFades={mobile}>
-      {#if git.issueUrl && issueNumber != null}
-        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
-        <a class="prlink" href={git.issueUrl} target="_blank" rel="noopener"
-          >{m.gitrail_open_issue({ number: issueNumber })}</a
-        >
-      {/if}
-      {#if git.state === "none"}
-        <!-- Hidden whenever autopilot is effectively on — the agent opens the PR itself,
-             so the manual button is redundant. This stays hidden even while autopilot is
-             PAUSED (autopilotPaused): a paused autopilot is still on and will resume and
-             open the PR; the human escape hatch is the AP toggle in the same strip.
-             autopilotPaused is surfaced separately via AutopilotBadge — not a signal to
-             re-show this button. -->
-        {#if !autopilotOn}
-          <button class="gbtn" type="button" disabled={busy} onclick={startPr}
-            >{local ? m.gitrail_open_for_merge() : m.gitrail_open_pr()}</button
-          >
-        {/if}
-      {:else if git.state === "open"}
-        {#if local}
-          <span class="prlink">{m.gitrail_ready_to_merge()} #{git.number}</span>
-        {:else if git.url}
-          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
-          <a class="prlink" href={git.url} target="_blank" rel="noopener">PR #{git.number} ↗</a>
-        {:else}
-          <span class="prlink">PR #{git.number}</span>
-        {/if}
-        {#if !local}
-          <span
-            class="dot dot-{git.checks}"
-            title={m.gitrail_ci_status({ status: git.checks })}
-            aria-label={m.gitrail_ci_status({ status: git.checks })}
-          ></span>
-        {/if}
-        <button
-          class="gbtn"
-          class:armed={armed === "merge"}
-          type="button"
-          disabled={mergeBlocked}
-          title={mergeBlockedReason}
-          onclick={() => doMerge()}
-        >
-          {#if local}
-            {armed === "merge" ? m.gitrail_confirm_merge_locally() : m.gitrail_merge_locally()}
-          {:else}
-            {armed === "merge" ? m.gitrail_confirm_merge() : m.gitrail_merge()}
-          {/if}
-        </button>
-      {:else if git.state === "merged"}
-        <span class="merged">{local ? m.gitrail_merged_locally() : m.gitrail_merged()}</span>
-        {#if git.deployConfigured}
-          <button
-            class="gbtn"
-            class:armed={armed === "redeploy"}
-            type="button"
-            disabled={busy}
-            onclick={() => doRedeploy()}
-          >
-            {armed === "redeploy" ? m.gitrail_confirm_redeploy() : m.gitrail_redeploy()}
-          </button>
-        {/if}
-      {:else}
-        <span class="merged">{m.gitrail_closed()}</span>
-      {/if}
-
-      {#if showReady && (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
-        <ReadyToggle {sessionId} {ready} {mobile} />
-      {/if}
-      <!-- while re-reviewing: keep the prior findings reachable (hasFindings ⇒ verdict body exists,
-           so the showReview popover below still has content); otherwise a plain status chip. -->
-      {#if chip.kind === "reviewing"}
-        {#if chip.hasFindings}
-          <button
-            class={["verdict-chip", "critic-reviewing", { armed: showReview }]}
-            type="button"
-            aria-haspopup="dialog"
-            aria-expanded={showReview}
-            title={m.criticbadge_reviewing_title()}
-            onclick={(e) => toggleReview(e)}
-          >
-            <span class="rev-dot" aria-hidden="true"></span>{m.criticbadge_reviewing()}
-          </button>
-        {:else}
-          <span class="verdict-chip critic-reviewing" title={m.criticbadge_reviewing_title()}>
-            <span class="rev-dot" aria-hidden="true"></span>{m.criticbadge_reviewing()}
-          </span>
-        {/if}
-      {:else if chip.kind === "verdict"}
-        <button
-          class={["verdict-chip", `critic-${chip.decision}`, { armed: showReview }]}
-          type="button"
-          aria-haspopup="dialog"
-          aria-expanded={showReview}
-          title={m.gitrail_review_title()}
-          onclick={(e) => toggleReview(e)}
-        >
-          {chip.label}
-        </button>
-      {/if}
-
-      {#if canReview}
-        <button
-          class="gbtn"
-          class:armed={armed === "review"}
-          type="button"
-          onclick={() => doReview()}
-          use:coachTarget={"manual-critic-review"}
-        >
-          {reviewLabel}
-        </button>
-      {/if}
-
-      {#if canReviewPlan}
-        <button
-          class="gbtn"
-          class:armed={armed === "review-plan"}
-          type="button"
-          disabled={planReviewing}
-          onclick={() => doReviewPlan()}
-        >
-          {planReviewLabel}
-        </button>
-      {/if}
+      <RailStatusActions
+        {git}
+        {issueNumber}
+        {local}
+        {autopilotOn}
+        {busy}
+        {armed}
+        {mergeBlocked}
+        {mergeBlockedReason}
+        {ready}
+        {showReady}
+        {status}
+        {sessionId}
+        {mobile}
+        {chip}
+        {showReview}
+        {canReview}
+        {reviewLabel}
+        {canReviewPlan}
+        {planReviewing}
+        {planReviewLabel}
+        {startPr}
+        {doMerge}
+        {doRedeploy}
+        {toggleReview}
+        {doReview}
+        {doReviewPlan}
+      />
 
       {#if repoPath}
         <span class="rail-sep" aria-hidden="true"></span>
@@ -938,36 +843,6 @@
     color: var(--color-amber);
   }
 
-  /* verdict chip: .gbtn sizing, colored by decision */
-  .verdict-chip {
-    background: transparent;
-    border: 1px solid currentColor;
-    border-radius: 2px;
-    color: var(--color-muted);
-    font-family: var(--font-mono);
-    font-size: var(--fs-meta);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    padding: 2px 8px;
-    white-space: nowrap;
-    cursor: pointer;
-    transition:
-      opacity 0.12s,
-      box-shadow 0.12s;
-  }
-  .verdict-chip:hover {
-    opacity: 0.8;
-  }
-  .verdict-chip.armed {
-    box-shadow: 0 0 0 1px currentColor inset;
-  }
-  /* The reviewing-with-no-prior-findings variant renders as a <span>, not a
-     <button> — nothing to open. Drop the base cursor:pointer so it doesn't
-     advertise a tap that does nothing. */
-  span.verdict-chip {
-    cursor: default;
-  }
-
   /* touch layouts: bigger tap targets + a single horizontally-scrollable row.
      Whole badges never wrap to a second line (that read as a vertical stack on
      phones); the rail (.rail.mobile below) scrolls instead. Because the strip
@@ -1018,16 +893,16 @@
   /* horizontal-scroll row: items keep natural width and overflow → scroll,
      never shrink-wrap (the PR link wrapped to 3 lines and the CI dot squished
      to 0px otherwise). Mirrors the .tab-scroll recipe. */
-  .rail.mobile > * {
+  .rail.mobile > :global(*) {
     flex-shrink: 0;
   }
   /* right-pin the badge group when it fits; under overflow the auto margin
      collapses to 0 so the row scrolls cleanly from the first badge (avoids the
      flex justify-content:flex-end + overflow-x start-clip bug) */
-  .rail.mobile > :first-child {
+  .rail.mobile > :global(:first-child) {
     margin-left: auto;
   }
-  .rail.mobile .gbtn {
+  .rail.mobile :global(.gbtn) {
     min-height: 40px;
     padding: 6px 9px;
     font-size: var(--fs-base);
@@ -1041,7 +916,7 @@
      tap target that obviously invites a tap. Scoped to button.verdict-chip so the
      non-interactive reviewing <span> (no prior findings) isn't blown up into a
      40px button-looking element that does nothing on tap. */
-  .rail.mobile button.verdict-chip {
+  .rail.mobile :global(button.verdict-chip) {
     min-height: 40px;
     padding: 6px 9px;
     font-size: var(--fs-base);
@@ -1049,47 +924,13 @@
     align-items: center;
     gap: 5px;
   }
-  .rail.mobile .prlink {
+  .rail.mobile :global(.prlink) {
     font-size: var(--fs-base);
     padding: 4px 2px;
   }
-  .rail.mobile .dot {
+  .rail.mobile :global(.dot) {
     width: 9px;
     height: 9px;
-  }
-
-  .prlink {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-    text-decoration: none;
-  }
-  .prlink:hover {
-    color: var(--color-ink-bright);
-  }
-
-  .merged {
-    font-size: var(--fs-meta);
-    color: var(--color-slate);
-  }
-
-  .dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    display: inline-block;
-    background: var(--color-faint);
-  }
-  .dot-pending {
-    background: var(--color-amber);
-    /* CI running — functional status motion, exempt from the reduced-motion
-       blanket (app.css): the pulse encodes "work happening", not decoration. */
-    animation: dot-pulse 1.1s ease-in-out infinite !important;
-  }
-  .dot-success {
-    background: var(--color-green);
-  }
-  .dot-failure {
-    background: var(--color-red);
   }
 
   .err,
@@ -1209,15 +1050,7 @@
     white-space: nowrap;
     color: var(--color-muted);
   }
-  .verdict-chip.critic-reviewing {
-    border-color: var(--color-amber);
-    color: var(--color-amber);
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-  }
-  /* shared pulsing status dot for both the rail chip and the popover-head label */
-  .verdict-chip.critic-reviewing .rev-dot,
+  /* pulsing status dot in the popover-head label */
   .rv-label.critic-reviewing .rev-dot {
     width: 6px;
     height: 6px;
@@ -1241,16 +1074,13 @@
     align-items: center;
     gap: 5px;
   }
-  .rv-label.critic-changes_requested,
-  .verdict-chip.critic-changes_requested {
+  .rv-label.critic-changes_requested {
     color: var(--color-amber);
   }
-  .rv-label.critic-commented,
-  .verdict-chip.critic-commented {
+  .rv-label.critic-commented {
     color: var(--color-blue);
   }
-  .rv-label.critic-error,
-  .verdict-chip.critic-error {
+  .rv-label.critic-error {
     color: var(--color-faint);
   }
   .rv-prlink {

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -17,9 +17,7 @@
 <script lang="ts">
   import type { Session, GitState, SessionActivity } from "$lib/types";
   import {
-    elapsed,
     STATUS_COLOR,
-    statusLabel,
     hideStatusBadge,
     autopilotBadgeShown,
     canResume,
@@ -31,10 +29,7 @@
   import { longPress } from "./longpress";
   import { isMerging } from "./merge-train";
   import StatusPip from "./StatusPip.svelte";
-  import PrBadge from "./PrBadge.svelte";
   import TimePopover from "./TimePopover.svelte";
-  import CriticBadge from "./CriticBadge.svelte";
-  import BuildQueueBadge from "./BuildQueueBadge.svelte";
   import HeartbeatStrip from "./HeartbeatStrip.svelte";
   import Stepper from "./Stepper.svelte";
   import { reviews } from "$lib/reviews.svelte";
@@ -42,10 +37,8 @@
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { m } from "$lib/paraglide/messages";
   import { modelLabel } from "$lib/model-label";
-  import AutopilotBadge from "./AutopilotBadge.svelte";
-  import PlanGateBadge from "./PlanGateBadge.svelte";
-  import ResearchBadge from "./ResearchBadge.svelte";
   import { onDestroy } from "svelte";
+  import UnitRowRight from "./unit-row/UnitRowRight.svelte";
   import {
     REVEAL_PX,
     snapOffset,
@@ -407,120 +400,24 @@
       </div>
     </div>
 
-    <div class="u-right">
-      {#if ondecommission && !coarse.current}
-        <!-- Fine-pointer decommission: hover/focus-revealed ✕ in the top-right
-             corner, same two-step arm/confirm as the swipe reveal. A real <button>
-             is valid here — .u-right is a sibling of the .unit-hit overlay, not
-             nested inside it, and the existing .u-right > button z-index rule
-             raises it above the overlay; its click never reaches the row select,
-             so no propagation concern. -->
-        <button
-          class="row-decom"
-          class:armed={decom === "armed"}
-          type="button"
-          onclick={pressDecommission}
-          title={decom === "armed"
-            ? m.viewport_confirm_decommission()
-            : m.viewport_decommission_title()}
-          aria-label={decom === "armed"
-            ? m.viewport_confirm_decommission()
-            : m.viewport_decommission_aria()}
-        >
-          {decom === "armed" ? "✕?" : "✕"}
-        </button>
-      {/if}
-      {#if previewPort != null}
-        <!-- Live preview available (server reports a bound listener). Selecting +
-             opening the pane is an action distinct from the row's own select, so
-             this is an actionable control; rendered as role=button (not a nested
-             <button>, which would be invalid inside the row's own button) with
-             stopPropagation so the row's select doesn't also fire. -->
-        <span
-          class="preview-badge"
-          class:preview-badge--degraded={previewServeFailed}
-          role="button"
-          tabindex="0"
-          title={previewServeFailed
-            ? m.unitrow_preview_badge_degraded()
-            : m.unitrow_preview_badge()}
-          onclick={(e) => {
-            e.stopPropagation();
-            onpreview?.(session.id);
-          }}
-          onkeydown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              e.stopPropagation();
-              onpreview?.(session.id);
-            }
-          }}>{m.unitrow_preview_badge()}</span
-        >
-      {/if}
-      <ResearchBadge {session} />
-      {#if !stepperTerminal}<PrBadge {git} />{/if}
-      <CriticBadge sessionId={session.id} />
-      <BuildQueueBadge sessionId={session.id} />
-      <PlanGateBadge {session} allowView={false} />
-      {#if quotaKind}
-        <span
-          class="badge quota-stalled"
-          role="img"
-          title={m.unitrow_quota_title()}
-          aria-label={m.unitrow_quota_title()}
-          >{#if quotaKind === "rework"}{m.unitrow_quota_rework()}{:else if quotaKind === "review"}{m.unitrow_quota_review()}{:else if quotaKind === "error"}{m.unitrow_quota_error()}{:else}{m.unitrow_quota_plan()}{/if}</span
-        >
-      {/if}
-      <!-- REVIEWING (in-flight critic) outranks the autopilot badge -->
-      {#if !reviewing}<AutopilotBadge {session} />{/if}
-      <!-- Sandbox state: degraded/unconfined are warnings (amber); confined profiles
-           are quiet informational badges (slate). Trusted-manual renders nothing. -->
-      {#if session.sandboxDegraded}
-        <span
-          class="badge sandbox-warn"
-          role="img"
-          aria-label={m.session_sandbox_degraded_label()}
-          title={m.session_sandbox_degraded_title()}>{m.session_sandbox_degraded_label()}</span
-        >
-      {:else if session.sandboxApplied === "autonomous" && session.egressDegraded}
-        <span
-          class="badge sandbox-warn"
-          role="img"
-          aria-label={m.session_sandbox_egress_degraded_label()}
-          title={m.session_sandbox_egress_degraded_title()}
-          >{m.session_sandbox_egress_degraded_label()}</span
-        >
-      {:else if session.sandboxApplied === "autonomous"}
-        <span
-          class="badge sandbox"
-          role="img"
-          aria-label={m.session_sandbox_autonomous_label()}
-          title={m.session_sandbox_autonomous_title()}>{m.session_sandbox_autonomous_label()}</span
-        >
-      {:else if session.sandboxApplied === "standard"}
-        <span
-          class="badge sandbox"
-          role="img"
-          aria-label={m.session_sandbox_standard_label()}
-          title={m.session_sandbox_standard_title()}>{m.session_sandbox_standard_label()}</span
-        >
-      {:else if session.sandboxApplied === "trusted" && session.auto}
-        <span
-          class="badge sandbox-warn"
-          role="img"
-          aria-label={m.session_sandbox_unconfined_label()}
-          title={m.session_sandbox_unconfined_title()}>{m.session_sandbox_unconfined_label()}</span
-        >
-      {/if}
-      {#if isMerging(session, nowMs)}
-        <span class="badge merging" id="u-status-{session.id}">{m.status_merging()}</span>
-      {:else if session.readyToMerge}
-        <span class="badge" id="u-status-{session.id}">{m.status_ready_to_merge()}</span>
-      {:else if !hideStatus}
-        <span class="badge" id="u-status-{session.id}">{statusLabel(dStatus)}</span>
-      {/if}
-      <span class="elapsed" bind:this={elapsedEl}>{elapsed(session.createdAt, nowMs)}</span>
-    </div>
+    <UnitRowRight
+      {session}
+      {git}
+      {nowMs}
+      {ondecommission}
+      {previewPort}
+      {previewServeFailed}
+      {onpreview}
+      {quotaKind}
+      {reviewing}
+      {hideStatus}
+      {stepperTerminal}
+      {decom}
+      {dStatus}
+      coarsePointer={coarse.current}
+      {pressDecommission}
+      bind:elapsedEl
+    />
 
     {#if live}
       <div class="u-activity">
@@ -665,13 +562,6 @@
   .unit-hit:focus-visible {
     outline: 1.5px solid var(--color-line-bright);
     outline-offset: -1.5px;
-  }
-
-  /* Raise the interactive badge above the overlay so it's clickable. */
-  .u-right > :global(button),
-  .u-right > :global([role="button"]) {
-    position: relative;
-    z-index: 1;
   }
 
   :global(.unit + .unit),
@@ -943,148 +833,14 @@
     animation: blink 1.1s steps(1) infinite !important;
   }
 
-  .u-right {
-    grid-area: right;
-    text-align: right;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    align-items: flex-end;
-    flex-shrink: 0;
-  }
-
-  /* Fine-pointer decommission ✕: opacity (not display) keeps it keyboard-
-     focusable while invisible — and the invisible button's reserved in-flow slot
-     at the top of every row's .u-right column is deliberate (rows stay aligned,
-     the button stays focusable); while invisible it's also click-inert
-     (pointer-events: none) so the invisible corner can't be tapped on
-     fine-pointer-but-hoverless hardware; revealed on row hover/focus-within
-     (hover-capable fine pointers only, so touch layouts never show a ghost
-     button) and forced visible while armed — every reveal state restores
-     pointer-events. Idle = quiet faint glyph; armed = red ✕? echoing the
-     swipe reveal's .decom.armed treatment. */
-  .row-decom {
-    margin: 0;
-    padding: 0 2px;
-    border: 0;
-    border-radius: 2px;
-    background: transparent;
-    color: var(--color-faint);
-    font: inherit;
-    font-size: var(--fs-meta);
-    line-height: 1.3;
-    cursor: pointer;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.14s ease;
-  }
+  /* Cross-boundary hover reveal for the ✕ button inside UnitRowRight. The
+     .row-decom lives in a child component so we use :global() to reach it. */
   @media (hover: hover) and (pointer: fine) {
-    .unit:hover .row-decom,
-    .unit:focus-within .row-decom {
+    .unit:hover :global(.row-decom),
+    .unit:focus-within :global(.row-decom) {
       opacity: 1;
       pointer-events: auto;
     }
-  }
-  /* outside the hover/fine gate: a keyboard-focused button must never be
-     invisible on fine-pointer-but-hoverless hardware */
-  .row-decom:focus-visible {
-    opacity: 1;
-    pointer-events: auto;
-  }
-  .row-decom:hover,
-  .row-decom:focus-visible {
-    color: var(--color-red);
-  }
-  .row-decom.armed {
-    opacity: 1;
-    pointer-events: auto;
-    background: color-mix(in srgb, var(--color-red) 26%, transparent);
-    color: var(--color-red);
-    font-weight: 600;
-  }
-
-  /* Quiet muted text, not a colored pill — the StatusPip (left) already encodes
-     status by color + pulse, so an outlined `--rule`-tinted badge here just
-     duplicated that hue (amber for running) and added to the orange wall. */
-  .badge {
-    font-size: var(--fs-micro);
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    color: var(--color-muted);
-    white-space: nowrap;
-  }
-
-  /* PREVIEW: an actionable, navigational badge — opens the live app pane. Blue is
-     the non-reserved informational accent (green = READY, amber = running/critic,
-     red = blocked, slate = done are all taken), so it reads as "go look" without
-     colliding with any status hue. Outlined + pointer to signal it's clickable. */
-  .preview-badge {
-    font-size: var(--fs-micro);
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    padding: 1px 6px;
-    border: 1px solid var(--color-blue);
-    border-radius: 2px;
-    color: var(--color-blue);
-    white-space: nowrap;
-    cursor: pointer;
-    background: transparent;
-  }
-  .preview-badge:hover,
-  .preview-badge:focus-visible {
-    background: color-mix(in srgb, var(--color-blue) 14%, transparent);
-  }
-
-  /* Degraded: the slot's tailscale serve mapping failed to register — the preview
-     still works on loopback but isn't exposed over Tailscale. Amber = attention/
-     degraded (not red, which is reserved for a blocked session). */
-  .preview-badge--degraded {
-    border-color: var(--color-amber);
-    color: var(--color-amber);
-  }
-  .preview-badge--degraded:hover,
-  .preview-badge--degraded:focus-visible {
-    background: color-mix(in srgb, var(--color-amber) 14%, transparent);
-  }
-
-  /* MERGING: the one colored, moving badge — amber + pulse marks the in-flight
-     merge train, louder than the quiet muted text badges around it. */
-  .badge.merging {
-    color: var(--color-amber);
-    animation: merge-pulse 1.5s ease-in-out infinite;
-  }
-
-  /* SANDBOX (confined): a quiet informational badge — slate reads as "noted, parked"
-     (done-state hue), not actionable. Outlined to set it apart from plain text badges. */
-  .badge.sandbox {
-    padding: 1px 6px;
-    border: 1px solid var(--color-slate);
-    border-radius: 2px;
-    color: var(--color-slate);
-  }
-  /* SANDBOX (warn): degraded sandbox or an unattended agent running unconfined —
-     amber = attention/degraded (NOT red, reserved for a blocked session). */
-  .badge.sandbox-warn {
-    padding: 1px 6px;
-    border: 1px solid var(--color-amber);
-    border-radius: 2px;
-    color: var(--color-amber);
-  }
-
-  /* QUOTA STALLED: session blocked on quota exhaustion — amber attention, same idiom
-     as sandbox-warn; needs a human to resume/take over/abandon. */
-  .badge.quota-stalled {
-    padding: 1px 6px;
-    border: 1px solid var(--color-amber);
-    border-radius: 2px;
-    color: var(--color-amber);
-    font-weight: 600;
-  }
-
-  .elapsed {
-    color: var(--color-ink);
-    font-variant-numeric: tabular-nums;
-    letter-spacing: 0.08em;
   }
 
   .meta {
@@ -1188,29 +944,6 @@
         "pip right"
         "pip meta";
     }
-    /* badge rail → left-aligned, wrapping horizontal strip on its own row */
-    :global(.units:not(.flow)) .u-right {
-      flex-direction: row;
-      flex-wrap: wrap;
-      align-items: center;
-      justify-content: flex-start;
-      text-align: left;
-      gap: 6px;
-    }
-    /* Pin the elapsed clock to the card's top-right, aligned with the name row,
-       instead of letting it ride along in the own-row badge strip. pointer-events
-       is none (MANDATORY, not cosmetic): .elapsed paints above the .unit-hit
-       overlay (it's later in the DOM), so without this it would swallow row-select
-       clicks in the top-right corner and starve onHitMove's mousemove — breaking
-       the TimePopover hover trigger. none passes events through to the overlay
-       while getBoundingClientRect() still measures the clock for the bounds test
-       + popover anchor. */
-    :global(.units:not(.flow)) .elapsed {
-      position: absolute;
-      top: 11px;
-      right: 14px;
-      pointer-events: none;
-    }
     /* Reserve room on the name row so a long name ellipsizes BEFORE the clock
        rather than sliding under it (the clock still paints over the name —
        pointer-events stops event capture, not painting). 72px clears realistic
@@ -1221,21 +954,6 @@
        just paints under the clock, same tradeoff as everywhere else here). */
     :global(.units:not(.flow)) .u-top {
       padding-right: 72px;
-    }
-    /* The decommission ✕ is invisible-but-keyboard-focusable (opacity:0 +
-       pointer-events:none from the base .row-decom rule, NOT display:none) so it
-       stays in the tab order and reveals on hover/focus. Keep it absolute and out
-       of flow, parked just below the pinned clock in the right gutter (on the
-       prompt's first line) so it clears the clock and doesn't indent the badge
-       strip. top: 30px = the clock's top: 11px + ~one clock line-height, dropping
-       the ✕ just under the clock onto the prompt's first line. Unlike .u-top, .u-sub
-       (the prompt) reserves no right gutter, so a very long prompt's first line can
-       run under the ✕ — acceptable: the ✕ is hover-only, tiny, and sits over muted
-       secondary text, so it merely paints over (same as the clock-over-name case). */
-    :global(.units:not(.flow)) .row-decom {
-      position: absolute;
-      top: 30px;
-      right: 12px;
     }
   }
 </style>

--- a/ui/src/lib/components/git-rail/RailStatusActions.svelte
+++ b/ui/src/lib/components/git-rail/RailStatusActions.svelte
@@ -1,0 +1,316 @@
+<script lang="ts">
+  import type { GitState, SessionStatus } from "$lib/types";
+  import type { CriticChip } from "../critic-badge";
+  import ReadyToggle from "../ReadyToggle.svelte";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    git,
+    issueNumber,
+    local,
+    autopilotOn,
+    busy,
+    armed,
+    mergeBlocked,
+    mergeBlockedReason,
+    ready,
+    showReady,
+    status,
+    sessionId,
+    mobile,
+    chip,
+    showReview,
+    canReview,
+    reviewLabel,
+    canReviewPlan,
+    planReviewing,
+    planReviewLabel,
+    startPr,
+    doMerge,
+    doRedeploy,
+    toggleReview,
+    doReview,
+    doReviewPlan,
+  }: {
+    git: GitState;
+    issueNumber: number | null;
+    local: boolean;
+    autopilotOn: boolean;
+    busy: boolean;
+    armed: "merge" | "redeploy" | "review" | "review-plan" | null;
+    mergeBlocked: boolean;
+    mergeBlockedReason: string | undefined;
+    ready: boolean;
+    showReady: boolean;
+    status: SessionStatus;
+    sessionId: string;
+    mobile: boolean;
+    chip: CriticChip;
+    showReview: boolean;
+    canReview: boolean;
+    reviewLabel: string;
+    canReviewPlan: boolean;
+    planReviewing: boolean;
+    planReviewLabel: string;
+    startPr: () => void;
+    doMerge: (skipArm?: boolean) => Promise<void>;
+    doRedeploy: (skipArm?: boolean) => Promise<void>;
+    toggleReview: (e?: Event) => void;
+    doReview: () => Promise<void>;
+    doReviewPlan: () => Promise<void>;
+  } = $props();
+</script>
+
+{#if git.issueUrl && issueNumber != null}
+  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
+  <a class="prlink" href={git.issueUrl} target="_blank" rel="noopener"
+    >{m.gitrail_open_issue({ number: issueNumber })}</a
+  >
+{/if}
+{#if git.state === "none"}
+  <!-- Hidden whenever autopilot is effectively on — the agent opens the PR itself,
+       so the manual button is redundant. This stays hidden even while autopilot is
+       PAUSED (autopilotPaused): a paused autopilot is still on and will resume and
+       open the PR; the human escape hatch is the AP toggle in the same strip.
+       autopilotPaused is surfaced separately via AutopilotBadge — not a signal to
+       re-show this button. -->
+  {#if !autopilotOn}
+    <button class="gbtn" type="button" disabled={busy} onclick={startPr}
+      >{local ? m.gitrail_open_for_merge() : m.gitrail_open_pr()}</button
+    >
+  {/if}
+{:else if git.state === "open"}
+  {#if local}
+    <span class="prlink">{m.gitrail_ready_to_merge()} #{git.number}</span>
+  {:else if git.url}
+    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
+    <a class="prlink" href={git.url} target="_blank" rel="noopener">PR #{git.number} ↗</a>
+  {:else}
+    <span class="prlink">PR #{git.number}</span>
+  {/if}
+  {#if !local}
+    <span
+      class="dot dot-{git.checks}"
+      title={m.gitrail_ci_status({ status: git.checks })}
+      aria-label={m.gitrail_ci_status({ status: git.checks })}
+    ></span>
+  {/if}
+  <button
+    class="gbtn"
+    class:armed={armed === "merge"}
+    type="button"
+    disabled={mergeBlocked}
+    title={mergeBlockedReason}
+    onclick={() => doMerge()}
+  >
+    {#if local}
+      {armed === "merge" ? m.gitrail_confirm_merge_locally() : m.gitrail_merge_locally()}
+    {:else}
+      {armed === "merge" ? m.gitrail_confirm_merge() : m.gitrail_merge()}
+    {/if}
+  </button>
+{:else if git.state === "merged"}
+  <span class="merged">{local ? m.gitrail_merged_locally() : m.gitrail_merged()}</span>
+  {#if git.deployConfigured}
+    <button
+      class="gbtn"
+      class:armed={armed === "redeploy"}
+      type="button"
+      disabled={busy}
+      onclick={() => doRedeploy()}
+    >
+      {armed === "redeploy" ? m.gitrail_confirm_redeploy() : m.gitrail_redeploy()}
+    </button>
+  {/if}
+{:else}
+  <span class="merged">{m.gitrail_closed()}</span>
+{/if}
+
+{#if showReady && (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
+  <ReadyToggle {sessionId} {ready} {mobile} />
+{/if}
+<!-- while re-reviewing: keep the prior findings reachable (hasFindings ⇒ verdict body exists,
+     so the showReview popover below still has content); otherwise a plain status chip. -->
+{#if chip.kind === "reviewing"}
+  {#if chip.hasFindings}
+    <button
+      class={["verdict-chip", "critic-reviewing", { armed: showReview }]}
+      type="button"
+      aria-haspopup="dialog"
+      aria-expanded={showReview}
+      title={m.criticbadge_reviewing_title()}
+      onclick={(e) => toggleReview(e)}
+    >
+      <span class="rev-dot" aria-hidden="true"></span>{m.criticbadge_reviewing()}
+    </button>
+  {:else}
+    <span class="verdict-chip critic-reviewing" title={m.criticbadge_reviewing_title()}>
+      <span class="rev-dot" aria-hidden="true"></span>{m.criticbadge_reviewing()}
+    </span>
+  {/if}
+{:else if chip.kind === "verdict"}
+  <button
+    class={["verdict-chip", `critic-${chip.decision}`, { armed: showReview }]}
+    type="button"
+    aria-haspopup="dialog"
+    aria-expanded={showReview}
+    title={m.gitrail_review_title()}
+    onclick={(e) => toggleReview(e)}
+  >
+    {chip.label}
+  </button>
+{/if}
+
+{#if canReview}
+  <button
+    class="gbtn"
+    class:armed={armed === "review"}
+    type="button"
+    onclick={() => doReview()}
+    use:coachTarget={"manual-critic-review"}
+  >
+    {reviewLabel}
+  </button>
+{/if}
+
+{#if canReviewPlan}
+  <button
+    class="gbtn"
+    class:armed={armed === "review-plan"}
+    type="button"
+    disabled={planReviewing}
+    onclick={() => doReviewPlan()}
+  >
+    {planReviewLabel}
+  </button>
+{/if}
+
+<style>
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .gbtn.armed {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+
+  .prlink {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    text-decoration: none;
+  }
+  .prlink:hover {
+    color: var(--color-ink-bright);
+  }
+
+  .merged {
+    font-size: var(--fs-meta);
+    color: var(--color-slate);
+  }
+
+  .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    display: inline-block;
+    background: var(--color-faint);
+  }
+  .dot-pending {
+    background: var(--color-amber);
+    /* CI running — functional status motion, exempt from the reduced-motion
+       blanket (app.css): the pulse encodes "work happening", not decoration. */
+    animation: dot-pulse 1.1s ease-in-out infinite !important;
+  }
+  .dot-success {
+    background: var(--color-green);
+  }
+  .dot-failure {
+    background: var(--color-red);
+  }
+
+  /* verdict chip: .gbtn sizing, colored by decision */
+  .verdict-chip {
+    background: transparent;
+    border: 1px solid currentColor;
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 2px 8px;
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+      opacity 0.12s,
+      box-shadow 0.12s;
+  }
+  .verdict-chip:hover {
+    opacity: 0.8;
+  }
+  .verdict-chip.armed {
+    box-shadow: 0 0 0 1px currentColor inset;
+  }
+  /* The reviewing-with-no-prior-findings variant renders as a <span>, not a
+     <button> — nothing to open. Drop the base cursor:pointer so it doesn't
+     advertise a tap that does nothing. */
+  span.verdict-chip {
+    cursor: default;
+  }
+
+  .verdict-chip.critic-reviewing {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+  /* shared pulsing status dot for both the rail chip and the popover-head label */
+  .verdict-chip.critic-reviewing .rev-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-amber);
+    /* functional status motion — exempt from the reduced-motion blanket (app.css) */
+    animation: rev-pulse 1.1s ease-in-out infinite !important;
+  }
+  @keyframes rev-pulse {
+    0%,
+    100% {
+      opacity: 0.3;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+  .verdict-chip.critic-changes_requested {
+    color: var(--color-amber);
+  }
+  .verdict-chip.critic-commented {
+    color: var(--color-blue);
+  }
+  .verdict-chip.critic-error {
+    color: var(--color-faint);
+  }
+</style>

--- a/ui/src/lib/components/unit-row/UnitRowRight.svelte
+++ b/ui/src/lib/components/unit-row/UnitRowRight.svelte
@@ -1,0 +1,348 @@
+<script lang="ts">
+  import type { Session, GitState, SessionStatus } from "$lib/types";
+  import { elapsed, statusLabel } from "$lib/format";
+  import { isMerging } from "../merge-train";
+  import { m } from "$lib/paraglide/messages";
+  import ResearchBadge from "../ResearchBadge.svelte";
+  import PrBadge from "../PrBadge.svelte";
+  import CriticBadge from "../CriticBadge.svelte";
+  import BuildQueueBadge from "../BuildQueueBadge.svelte";
+  import PlanGateBadge from "../PlanGateBadge.svelte";
+  import AutopilotBadge from "../AutopilotBadge.svelte";
+
+  let {
+    session,
+    git,
+    nowMs,
+    ondecommission,
+    previewPort = null,
+    previewServeFailed = false,
+    onpreview,
+    quotaKind = null,
+    reviewing,
+    hideStatus,
+    stepperTerminal,
+    decom,
+    dStatus,
+    coarsePointer,
+    pressDecommission,
+    elapsedEl = $bindable(),
+  }: {
+    session: Session;
+    git?: GitState;
+    nowMs: number;
+    ondecommission?: (id: string) => void;
+    previewPort?: number | null;
+    previewServeFailed?: boolean;
+    onpreview?: (id: string) => void;
+    quotaKind?: "rework" | "review" | "error" | "plan" | null;
+    reviewing: boolean;
+    hideStatus: boolean;
+    stepperTerminal: boolean;
+    decom: "idle" | "armed";
+    dStatus: SessionStatus;
+    coarsePointer: boolean;
+    pressDecommission: () => void;
+    elapsedEl?: HTMLSpanElement;
+  } = $props();
+</script>
+
+<div class="u-right">
+  {#if ondecommission && !coarsePointer}
+    <!-- Fine-pointer decommission: hover/focus-revealed ✕ in the top-right
+         corner, same two-step arm/confirm as the swipe reveal. A real <button>
+         is valid here — .u-right is a sibling of the .unit-hit overlay, not
+         nested inside it, and the existing .u-right > button z-index rule
+         raises it above the overlay; its click never reaches the row select,
+         so no propagation concern. -->
+    <button
+      class="row-decom"
+      class:armed={decom === "armed"}
+      type="button"
+      onclick={pressDecommission}
+      title={decom === "armed"
+        ? m.viewport_confirm_decommission()
+        : m.viewport_decommission_title()}
+      aria-label={decom === "armed"
+        ? m.viewport_confirm_decommission()
+        : m.viewport_decommission_aria()}
+    >
+      {decom === "armed" ? "✕?" : "✕"}
+    </button>
+  {/if}
+  {#if previewPort != null}
+    <!-- Live preview available (server reports a bound listener). Selecting +
+         opening the pane is an action distinct from the row's own select, so
+         this is an actionable control; rendered as role=button (not a nested
+         <button>, which would be invalid inside the row's own button) with
+         stopPropagation so the row's select doesn't also fire. -->
+    <span
+      class="preview-badge"
+      class:preview-badge--degraded={previewServeFailed}
+      role="button"
+      tabindex="0"
+      title={previewServeFailed ? m.unitrow_preview_badge_degraded() : m.unitrow_preview_badge()}
+      onclick={(e) => {
+        e.stopPropagation();
+        onpreview?.(session.id);
+      }}
+      onkeydown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.stopPropagation();
+          onpreview?.(session.id);
+        }
+      }}>{m.unitrow_preview_badge()}</span
+    >
+  {/if}
+  <ResearchBadge {session} />
+  {#if !stepperTerminal}<PrBadge {git} />{/if}
+  <CriticBadge sessionId={session.id} />
+  <BuildQueueBadge sessionId={session.id} />
+  <PlanGateBadge {session} allowView={false} />
+  {#if quotaKind}
+    <span
+      class="badge quota-stalled"
+      role="img"
+      title={m.unitrow_quota_title()}
+      aria-label={m.unitrow_quota_title()}
+      >{#if quotaKind === "rework"}{m.unitrow_quota_rework()}{:else if quotaKind === "review"}{m.unitrow_quota_review()}{:else if quotaKind === "error"}{m.unitrow_quota_error()}{:else}{m.unitrow_quota_plan()}{/if}</span
+    >
+  {/if}
+  <!-- REVIEWING (in-flight critic) outranks the autopilot badge -->
+  {#if !reviewing}<AutopilotBadge {session} />{/if}
+  <!-- Sandbox state: degraded/unconfined are warnings (amber); confined profiles
+       are quiet informational badges (slate). Trusted-manual renders nothing. -->
+  {#if session.sandboxDegraded}
+    <span
+      class="badge sandbox-warn"
+      role="img"
+      aria-label={m.session_sandbox_degraded_label()}
+      title={m.session_sandbox_degraded_title()}>{m.session_sandbox_degraded_label()}</span
+    >
+  {:else if session.sandboxApplied === "autonomous" && session.egressDegraded}
+    <span
+      class="badge sandbox-warn"
+      role="img"
+      aria-label={m.session_sandbox_egress_degraded_label()}
+      title={m.session_sandbox_egress_degraded_title()}
+      >{m.session_sandbox_egress_degraded_label()}</span
+    >
+  {:else if session.sandboxApplied === "autonomous"}
+    <span
+      class="badge sandbox"
+      role="img"
+      aria-label={m.session_sandbox_autonomous_label()}
+      title={m.session_sandbox_autonomous_title()}>{m.session_sandbox_autonomous_label()}</span
+    >
+  {:else if session.sandboxApplied === "standard"}
+    <span
+      class="badge sandbox"
+      role="img"
+      aria-label={m.session_sandbox_standard_label()}
+      title={m.session_sandbox_standard_title()}>{m.session_sandbox_standard_label()}</span
+    >
+  {:else if session.sandboxApplied === "trusted" && session.auto}
+    <span
+      class="badge sandbox-warn"
+      role="img"
+      aria-label={m.session_sandbox_unconfined_label()}
+      title={m.session_sandbox_unconfined_title()}>{m.session_sandbox_unconfined_label()}</span
+    >
+  {/if}
+  {#if isMerging(session, nowMs)}
+    <span class="badge merging" id="u-status-{session.id}">{m.status_merging()}</span>
+  {:else if session.readyToMerge}
+    <span class="badge" id="u-status-{session.id}">{m.status_ready_to_merge()}</span>
+  {:else if !hideStatus}
+    <span class="badge" id="u-status-{session.id}">{statusLabel(dStatus)}</span>
+  {/if}
+  <span class="elapsed" bind:this={elapsedEl}>{elapsed(session.createdAt, nowMs)}</span>
+</div>
+
+<style>
+  .u-right {
+    grid-area: right;
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: flex-end;
+    flex-shrink: 0;
+  }
+
+  /* Raise the interactive badge above the overlay so it's clickable. */
+  .u-right > :global(button),
+  .u-right > :global([role="button"]) {
+    position: relative;
+    z-index: 1;
+  }
+
+  /* Fine-pointer decommission ✕: opacity (not display) keeps it keyboard-
+     focusable while invisible — and the invisible button's reserved in-flow slot
+     at the top of every row's .u-right column is deliberate (rows stay aligned,
+     the button stays focusable); while invisible it's also click-inert
+     (pointer-events: none) so the invisible corner can't be tapped on
+     fine-pointer-but-hoverless hardware; revealed on row hover/focus-within
+     (hover-capable fine pointers only, so touch layouts never show a ghost
+     button) and forced visible while armed — every reveal state restores
+     pointer-events. Idle = quiet faint glyph; armed = red ✕? echoing the
+     swipe reveal's .decom.armed treatment. */
+  .row-decom {
+    margin: 0;
+    padding: 0 2px;
+    border: 0;
+    border-radius: 2px;
+    background: transparent;
+    color: var(--color-faint);
+    font: inherit;
+    font-size: var(--fs-meta);
+    line-height: 1.3;
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.14s ease;
+  }
+  /* outside the hover/fine gate: a keyboard-focused button must never be
+     invisible on fine-pointer-but-hoverless hardware */
+  .row-decom:focus-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .row-decom:hover,
+  .row-decom:focus-visible {
+    color: var(--color-red);
+  }
+  .row-decom.armed {
+    opacity: 1;
+    pointer-events: auto;
+    background: color-mix(in srgb, var(--color-red) 26%, transparent);
+    color: var(--color-red);
+    font-weight: 600;
+  }
+
+  /* Quiet muted text, not a colored pill — the StatusPip (left) already encodes
+     status by color + pulse, so an outlined `--rule`-tinted badge here just
+     duplicated that hue (amber for running) and added to the orange wall. */
+  .badge {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    white-space: nowrap;
+  }
+
+  /* PREVIEW: an actionable, navigational badge — opens the live app pane. Blue is
+     the non-reserved informational accent (green = READY, amber = running/critic,
+     red = blocked, slate = done are all taken), so it reads as "go look" without
+     colliding with any status hue. Outlined + pointer to signal it's clickable. */
+  .preview-badge {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 1px 6px;
+    border: 1px solid var(--color-blue);
+    border-radius: 2px;
+    color: var(--color-blue);
+    white-space: nowrap;
+    cursor: pointer;
+    background: transparent;
+  }
+  .preview-badge:hover,
+  .preview-badge:focus-visible {
+    background: color-mix(in srgb, var(--color-blue) 14%, transparent);
+  }
+
+  /* Degraded: the slot's tailscale serve mapping failed to register — the preview
+     still works on loopback but isn't exposed over Tailscale. Amber = attention/
+     degraded (not red, which is reserved for a blocked session). */
+  .preview-badge--degraded {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .preview-badge--degraded:hover,
+  .preview-badge--degraded:focus-visible {
+    background: color-mix(in srgb, var(--color-amber) 14%, transparent);
+  }
+
+  /* MERGING: the one colored, moving badge — amber + pulse marks the in-flight
+     merge train, louder than the quiet muted text badges around it. */
+  .badge.merging {
+    color: var(--color-amber);
+    animation: merge-pulse 1.5s ease-in-out infinite;
+  }
+
+  /* SANDBOX (confined): a quiet informational badge — slate reads as "noted, parked"
+     (done-state hue), not actionable. Outlined to set it apart from plain text badges. */
+  .badge.sandbox {
+    padding: 1px 6px;
+    border: 1px solid var(--color-slate);
+    border-radius: 2px;
+    color: var(--color-slate);
+  }
+  /* SANDBOX (warn): degraded sandbox or an unattended agent running unconfined —
+     amber = attention/degraded (NOT red, reserved for a blocked session). */
+  .badge.sandbox-warn {
+    padding: 1px 6px;
+    border: 1px solid var(--color-amber);
+    border-radius: 2px;
+    color: var(--color-amber);
+  }
+
+  /* QUOTA STALLED: session blocked on quota exhaustion — amber attention, same idiom
+     as sandbox-warn; needs a human to resume/take over/abandon. */
+  .badge.quota-stalled {
+    padding: 1px 6px;
+    border: 1px solid var(--color-amber);
+    border-radius: 2px;
+    color: var(--color-amber);
+    font-weight: 600;
+  }
+
+  .elapsed {
+    color: var(--color-ink);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.08em;
+  }
+
+  @container herd (max-width: 360px) {
+    /* badge rail → left-aligned, wrapping horizontal strip on its own row */
+    :global(.units:not(.flow)) .u-right {
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: flex-start;
+      text-align: left;
+      gap: 6px;
+    }
+    /* Pin the elapsed clock to the card's top-right, aligned with the name row,
+       instead of letting it ride along in the own-row badge strip. pointer-events
+       is none (MANDATORY, not cosmetic): .elapsed paints above the .unit-hit
+       overlay (it's later in the DOM), so without this it would swallow row-select
+       clicks in the top-right corner and starve onHitMove's mousemove — breaking
+       the TimePopover hover trigger. none passes events through to the overlay
+       while getBoundingClientRect() still measures the clock for the bounds test
+       + popover anchor. */
+    :global(.units:not(.flow)) .elapsed {
+      position: absolute;
+      top: 11px;
+      right: 14px;
+      pointer-events: none;
+    }
+    /* The decommission ✕ is invisible-but-keyboard-focusable (opacity:0 +
+       pointer-events:none from the base .row-decom rule, NOT display:none) so it
+       stays in the tab order and reveals on hover/focus. Keep it absolute and out
+       of flow, parked just below the pinned clock in the right gutter (on the
+       prompt's first line) so it clears the clock and doesn't indent the badge
+       strip. top: 30px = the clock's top: 11px + ~one clock line-height, dropping
+       the ✕ just under the clock onto the prompt's first line. Unlike .u-top, .u-sub
+       (the prompt) reserves no right gutter, so a very long prompt's first line can
+       run under the ✕ — acceptable: the ✕ is hover-only, tiny, and sits over muted
+       secondary text, so it merely paints over (same as the clock-over-name case). */
+    :global(.units:not(.flow)) .row-decom {
+      position: absolute;
+      top: 30px;
+      right: 12px;
+    }
+  }
+</style>


### PR DESCRIPTION
## What & why

Follow-up to #851/#855: split two oversized Svelte `<template>` components into subcomponents so their synthetic fallow template-complexity clears the Tier-1 bar (cyclo ≤ 40 / cog ≤ 60), then **delete** both per-file Tier-2 grandfathers from `.fallowrc.jsonc`. Pure refactor — no behavior/UX/DOM change, no new user-facing surface.

| Component | template before | after | grandfather |
| --- | --- | --- | --- |
| `UnitRow.svelte` → `unit-row/UnitRowRight.svelte` | 51 / 83 | **25 / 41** | deleted |
| `GitRail.svelte` → `git-rail/RailStatusActions.svelte` | 51 / 114 | **27 / 56** | deleted |

This pays down 2 more of the #855 list — `.fallowrc.jsonc` is now **8 of the original 13 removed**, 5 grandfathers remaining (Viewport, TopBar, Herd, +page, LearningsDrawer), each a future PR.

## How

Followed the established `viewport/` convention — extracted **presentational** children that own their **own scoped class names + styles** (`.gbtn`/`.badge`/`.verdict-chip` are component-scoped here, not global), with all `<script>` logic staying in the parent and passed down as props/callbacks.

- **UnitRow:** moved the `.u-right` badge/action column (decommission, preview, quota/sandbox/status badge chains, `.elapsed`) into `UnitRowRight`. `elapsedEl` forwarded back via `$bindable`. The narrow-sidebar `@container herd (max-width:360px)` block was **split by ownership** — `.u-right`/`.elapsed`/`.row-decom` rules moved into the child (re-wrapped in their own `@container`), `.unit`/`.u-top` rules stayed in the parent. Cross-boundary hover reveal rewritten as `.unit:hover :global(.row-decom)`.
- **GitRail:** moved the `git.state` status/merge/redeploy zone + ready toggle + critic chip + review buttons into `RailStatusActions`. The review popover and **all** its imperative logic (focus-restore `$effect`, Tab-trap, `reviewOpener`, click-outside) deliberately stayed in the parent; `toggleReview` is passed as a callback so `e.currentTarget` still captures the opener chip for focus restore. Cross-boundary mobile tap-target rules rewritten with `:global()`.

The branch was rebased onto latest `main`; a main-side "open issue" link (`git.issueUrl` / `issueNumber` / `m.gitrail_open_issue`) was folded into `RailStatusActions` during the rebase.

## Verification

- `bunx fallow@2.100.0 health` — **0 template-complexity findings**; UnitRow 25/41, GitRail 27/56. `fallow audit --base origin/main` exits 0.
- `cd ui && bun run check` 0 errors · root `bun run lint` clean · prettier clean · `check:i18n` 1675 keys parity.
- Full UI suite **1773/1773** (incl. `UnitRow.browser.test.ts`, `GitRail.browser.test.ts` 52/52 with the focus-restore test) · root server tests **4129/0**.
- Adversarial whole-branch review caught one test-invisible CSS-scoping regression (a mobile `.verdict-chip` 40px tap-target rule kept its `button` selector component-scoped, so it no longer reached the moved child button → half-height chip on touch). Fixed to `.rail.mobile :global(button.verdict-chip)` and **verified against the compiled CSS** (scope hash dropped from the `button.verdict-chip` selector). All other cross-boundary `:global()` conversions were likewise compile-checked.

Closes #855 partially (UnitRow + GitRail slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
