### PR TITLE
fix(ui): make linked issue clickable in Done view

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1377,14 +1377,30 @@ function sessionRead(id: string, deps: AppDeps): Response {
   return s ? json(s) : json({ error: "not found" }, 404);
 }
 
+// Recently-archived sessions for the Done lens, each enriched with the web URL of its
+// linked forge issue (when derivable). The archived session row carries `issueNumber` but
+// no URL, and the live GitState.issueUrl is keyed by *active* session id — gone once
+// archived — so we derive it here. Forge `webUrl` is resolved once per unique repoPath
+// (not per session): the window can hold many sessions across a few repos, and the first
+// resolveForge() call per dir shells out to git on a cold cache. Warm cache → no shell-out.
+function doneSessionsWithIssueUrl(deps: AppDeps): Array<Session & { issueUrl?: string }> {
+  const sessions = deps.store.listRecentlyArchived(Date.now() - DONE_LENS_WINDOW_MS);
+  const repoWebUrl = new Map<string, string | null>();
+  for (const path of new Set(sessions.map((s) => s.repoPath)))
+    repoWebUrl.set(path, deps.resolveForge?.(path)?.webUrl ?? null);
+  return sessions.map((s) => {
+    const issueUrl = buildIssueUrl(repoWebUrl.get(s.repoPath), s.issueNumber);
+    return issueUrl ? { ...s, issueUrl } : s;
+  });
+}
+
 // GET reads on /api/sessions[/:id[/usage|/activity|/diff|/leftovers]].
 async function handleSessionReads({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (req.method !== "GET") return null;
   if (!parts[2]) return json(deps.store.list({ activeOnly: true }));
   // "Done" lens: sessions archived within the last DONE_LENS_WINDOW_MS, newest-first.
   // Must precede the bare sessionRead fall-through so "done" isn't read as a session id.
-  if (parts[2] === "done" && !parts[3])
-    return json(deps.store.listRecentlyArchived(Date.now() - DONE_LENS_WINDOW_MS));
+  if (parts[2] === "done" && !parts[3]) return json(doneSessionsWithIssueUrl(deps));
   if (parts[3] === "usage") return sessionUsageRead(parts[2], deps);
   if (parts[3] === "activity") return sessionActivityRead(parts[2], deps);
   if (parts[3] === "diff") return sessionDiffRead(parts[2], deps);

--- a/test/server-recap.test.ts
+++ b/test/server-recap.test.ts
@@ -100,6 +100,63 @@ test("GET /api/sessions/done returns recently-archived sessions, excludes live o
   expect(ids).not.toContain(live.id);
 });
 
+test("GET /api/sessions/done enriches issueUrl when the repo resolves to a forge webUrl", async () => {
+  // resolveForge is not wired by default — inject one exposing a webUrl so the handler
+  // can derive {webUrl}/issues/{n} for the archived session's issueNumber.
+  const { app, store } = harness({
+    resolveForge: () => ({ webUrl: "https://github.com/o/r" }) as any,
+  });
+  const s = store.create({
+    name: "done-issue",
+    prompt: "go",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/done-issue",
+    worktreePath: join(repoDir, "done-issue"),
+    isolated: true,
+    herdrSession: "sess-done-issue",
+    herdrAgentId: "term_done-issue",
+    claudeSessionId: "claude-done-issue",
+    model: null,
+    issueNumber: 42,
+  });
+  store.archive(s.id);
+
+  const res = await app.fetch(new Request("http://x/api/sessions/done"));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Array<Session & { issueUrl?: string }>;
+  expect(body).toHaveLength(1);
+  expect(body[0]!.issueUrl).toBe("https://github.com/o/r/issues/42");
+});
+
+test("GET /api/sessions/done omits issueUrl when no forge resolves (default harness)", async () => {
+  // No resolveForge dep → no webUrl → buildIssueUrl returns null → field omitted, even
+  // though the session carries an issueNumber.
+  const { app, store } = harness();
+  const s = store.create({
+    name: "done-noforge",
+    prompt: "go",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/done-noforge",
+    worktreePath: join(repoDir, "done-noforge"),
+    isolated: true,
+    herdrSession: "sess-done-noforge",
+    herdrAgentId: "term_done-noforge",
+    claudeSessionId: "claude-done-noforge",
+    model: null,
+    issueNumber: 7,
+  });
+  store.archive(s.id);
+
+  const res = await app.fetch(new Request("http://x/api/sessions/done"));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Array<Session & { issueUrl?: string }>;
+  expect(body).toHaveLength(1);
+  expect(body[0]!.issueNumber).toBe(7);
+  expect(body[0]!.issueUrl).toBeUndefined();
+});
+
 // ── POST /api/sessions/:id/recap/regenerate ───────────────────────────────────
 
 test("POST /api/sessions/:id/recap/regenerate → 202, calls regenerate, relays status:started", async () => {

--- a/ui/src/lib/components/DoneRecapPanel.browser.test.ts
+++ b/ui/src/lib/components/DoneRecapPanel.browser.test.ts
@@ -106,6 +106,21 @@ describe("DoneRecapPanel ready state", () => {
     expect(document.querySelector("a"), "no fabricated PR link in header").toBeNull();
   });
 
+  it("renders the header issue as a forge link when issueUrl is present", async () => {
+    recaps.map = { s1l: recap({ sessionId: "s1l" }) };
+    render(DoneRecapPanel, {
+      session: session({
+        id: "s1l",
+        issueNumber: 855,
+        issueUrl: "https://github.com/o/r/issues/855",
+      }),
+    });
+    const link = page.getByRole("link", { name: "Issue #855" });
+    await expect.element(link).toBeInTheDocument();
+    await expect.element(link).toHaveAttribute("href", "https://github.com/o/r/issues/855");
+    await expect.element(link).toHaveAttribute("target", "_blank");
+  });
+
   it("omits the changed-files section when the list is empty", async () => {
     recaps.map = { s2: recap({ sessionId: "s2", changedFiles: [] }) };
     render(DoneRecapPanel, { session: session({ id: "s2" }) });

--- a/ui/src/lib/components/DoneRecapPanel.svelte
+++ b/ui/src/lib/components/DoneRecapPanel.svelte
@@ -71,7 +71,14 @@
     <span class="dr-desig">{session.desig}</span>
     <span class="dr-finished">{m.done_recap_finished({ ago: finishedAgo })}</span>
     {#if session.issueNumber != null}
-      <span class="dr-issue">{m.recap_issue({ n: session.issueNumber })}</span>
+      {#if session.issueUrl}
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL, not an app route -->
+        <a class="dr-issue dr-issue-link" href={session.issueUrl} target="_blank" rel="noopener"
+          >{m.recap_issue({ n: session.issueNumber })}</a
+        >
+      {:else}
+        <span class="dr-issue">{m.recap_issue({ n: session.issueNumber })}</span>
+      {/if}
     {/if}
   </header>
 
@@ -162,6 +169,17 @@
     margin-left: auto;
     font-size: var(--fs-meta);
     color: var(--color-faint);
+  }
+
+  /* Clickable variant when the Done payload carries a forge issue URL. Amber accent
+     matches the panel's markdown links (.dr-md a); underline on hover signals interactivity. */
+  .dr-issue-link {
+    color: var(--color-amber);
+    text-decoration: none;
+  }
+
+  .dr-issue-link:hover {
+    text-decoration: underline;
   }
 
   .dr-body {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -652,6 +652,11 @@ export interface Session {
   egressDegraded: boolean;
   /** Issue number that seeded this session; null when launched without an issue. */
   issueNumber: number | null;
+  /** Web URL of the linked forge issue. Populated **only** by the Done-list endpoint
+   *  (`GET /api/sessions/done`) for archived sessions — the live counterpart is
+   *  {@link GitState.issueUrl}, keyed by active session id and absent once archived. Same
+   *  semantic URL, two distinct population paths; neither is a single source of truth. */
+  issueUrl?: string;
   lastState: string;
   createdAt: number;
   updatedAt: number;


### PR DESCRIPTION
## Problem

In the Done lens, `DoneRecapPanel` rendered the seeding issue (`Issue #855`, top-right of the header) as plain text — not a link.

## Root cause

The panel only receives the archived `session`, which carries `issueNumber` but **no issue URL**. The live `GitState.issueUrl` (built server-side via `buildIssueUrl`) is keyed by *active* session id and is gone once a session is archived. The repo's forge `webUrl` is only known server-side, so the URL can't be derived in the browser.

## Fix

- **`src/server.ts`** — the Done-list endpoint now enriches each archived session with a derived `issueUrl` (`{webUrl}/issues/{n}`), reusing the existing `buildIssueUrl` helper + the memoized `resolveForge`. The forge `webUrl` is resolved **once per unique `repoPath`** (not per session) so a cold cache can't fan out into N synchronous `git remote` shell-outs on the single Bun loop.
- **`ui/src/lib/types.ts`** — adds `Session.issueUrl?: string`, documented as populated *only* by the Done-list endpoint (distinct from the live `GitState.issueUrl`).
- **`ui/src/lib/components/DoneRecapPanel.svelte`** — renders the header issue as an external link (new tab, on-token amber accent) when `issueUrl` is present; plain-text fallback for local/no-forge repos or sessions with no linked issue.

## Tests

- Server: Done payload carries `issueUrl` when a forge resolves; omitted otherwise (negative case with no `resolveForge`).
- Panel: renders an `<a href>` to the forge issue when `issueUrl` is set; existing plain-text case preserved.

## Notes

No new i18n keys (reuses `recap_issue`); a `fix:` (not `feat`), so the feature-catalog and i18n-parity gates are untouched.

Root `lint`/`tsc`/`bun test` and UI `check`/`check:i18n`/`bun test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)