### PR TITLE
feat(learnings): one-click promote a cross-repo rule to global CLAUDE.md (#872)

### DIFF
--- a/src/promote.ts
+++ b/src/promote.ts
@@ -60,12 +60,19 @@ export class Promoter {
    *  process's home — see the issue's home-dir-trust caveat. */
   async promoteGlobal(rule: string): Promise<PromoteResult> {
     const path = join(homedir(), ".claude", "CLAUDE.md");
-    const current = this.readClaudeMd(path);
-    const rules = [...new Set([...extractLearningsBlockRules(current), rule])];
-    const next = upsertLearningsBlock(current, rules);
-    if (next === current) return { ok: true, url: "" };
-    this.writeClaudeMd(path, next);
-    return { ok: true, url: "" };
+    try {
+      const current = this.readClaudeMd(path);
+      const rules = [...new Set([...extractLearningsBlockRules(current), rule])];
+      const next = upsertLearningsBlock(current, rules);
+      if (next === current) return { ok: true, url: "" };
+      this.writeClaudeMd(path, next);
+      return { ok: true, url: "" };
+    } catch (err) {
+      // Don't leak raw fs stderr (EACCES/EROFS on the home dir) to the client; log it
+      // server-side and return a structured result, matching the PR-promote path.
+      console.warn(`[promote-global] failed:`, err);
+      return { ok: false, error: "global promote failed", status: 500 };
+    }
   }
 
   async resyncPromoted(repoPath: string): Promise<PromoteResult> {

--- a/src/promote.ts
+++ b/src/promote.ts
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import type { SessionStore } from "./store";
 import type { WorktreeMgr, WorktreeResult } from "./worktree";
@@ -42,7 +43,29 @@ export class Promoter {
     this.git = deps.git ?? defaultGit;
     this.readClaudeMd =
       deps.readClaudeMd ?? ((p) => (existsSync(p) ? readFileSync(p, "utf8") : ""));
-    this.writeClaudeMd = deps.writeClaudeMd ?? ((p, c) => writeFileSync(p, c));
+    // Ensure the parent dir exists before writing — harmless for worktree paths (the dir is
+    // already there), and lets the global write (issue #872) create ~/.claude if absent.
+    this.writeClaudeMd =
+      deps.writeClaudeMd ??
+      ((p, c) => {
+        mkdirSync(dirname(p), { recursive: true });
+        writeFileSync(p, c);
+      });
+  }
+
+  /** Write a single cross-repo rule into the user-global `~/.claude/CLAUDE.md` (issue #872).
+   *  No forge/branch/PR — a direct, operator-confirmed write to the home-dir file. Reads the
+   *  existing Shepherd-owned block, unions the rule in (dedup, order-preserving) and rewrites.
+   *  Idempotent: a no-op (no write) when the rule is already present. `homedir()` is the server
+   *  process's home — see the issue's home-dir-trust caveat. */
+  async promoteGlobal(rule: string): Promise<PromoteResult> {
+    const path = join(homedir(), ".claude", "CLAUDE.md");
+    const current = this.readClaudeMd(path);
+    const rules = [...new Set([...extractLearningsBlockRules(current), rule])];
+    const next = upsertLearningsBlock(current, rules);
+    if (next === current) return { ok: true, url: "" };
+    this.writeClaudeMd(path, next);
+    return { ok: true, url: "" };
   }
 
   async resyncPromoted(repoPath: string): Promise<PromoteResult> {
@@ -268,4 +291,21 @@ export function upsertLearningsBlock(content: string, rules: string[]): string {
   }
   const sep = content.length === 0 ? "" : content.endsWith("\n") ? "\n" : "\n\n";
   return content + sep + body + "\n";
+}
+
+/** Parse the rules out of the managed `shepherd:learnings` block — the inverse of
+ *  `upsertLearningsBlock`, used to accumulate across successive global promotes (#872).
+ *  Returns `[]` when no block is present. Tolerant of CRLF and leading whitespace; only
+ *  `- <rule>` bullets are returned — non-bullet/prose lines inside the block are ignored
+ *  (the block is Shepherd-owned and rewritten in full, so hand-edits aren't preserved). */
+export function extractLearningsBlockRules(content: string): string[] {
+  const start = content.indexOf(LEARNINGS_START);
+  const end = content.indexOf(LEARNINGS_END);
+  if (start === -1 || end === -1 || end <= start) return [];
+  return content
+    .slice(start + LEARNINGS_START.length, end)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "))
+    .map((line) => line.slice(2).trim());
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -298,8 +298,12 @@ export interface AppDeps {
   mergeSuggest?: {
     mergeNow: (repoPath: string) => void;
   };
-  /** Promote a curated rule into the repo's CLAUDE.md via an auto-opened PR. */
-  promoter?: { promote: (id: string) => Promise<import("./promote").PromoteResult> };
+  /** Promote a curated rule into the repo's CLAUDE.md via an auto-opened PR, or a cross-repo
+   *  recurrence rule into the user-global ~/.claude/CLAUDE.md directly (#872). */
+  promoter?: {
+    promote: (id: string) => Promise<import("./promote").PromoteResult>;
+    promoteGlobal: (rule: string) => Promise<import("./promote").PromoteResult>;
+  };
   /** Open a PR adding Shepherd's managed `.shepherd-*` ignore block to a repo's `.gitignore`. */
   gitignoreAdopter?: {
     adopt: (repoPath: string) => Promise<import("./gitignore-adopt").AdoptResult>;
@@ -1066,7 +1070,28 @@ function handleMergeSuggestionPost(
 ): Promise<Response> | null {
   if (parts[2] === "merge" && !parts[3]) return handleMergeApply(req, deps);
   if (parts[2] === "merge-dismiss") return handleMergeDismiss(req, deps);
+  if (parts[2] === "promote-global") return handleMergePromoteGlobal(req, deps);
   return null;
+}
+
+/** POST /api/learnings/promote-global — write a cross-repo recurrence rule into the user-global
+ *  ~/.claude/CLAUDE.md (issue #872), body {suggestionId}. Explicit, operator-confirmed; no PR.
+ *  Marks the suggestion `applied` so it leaves the band and isn't re-suggested (the cross dedup
+ *  set includes `applied`). 409 on a stale re-post, mirroring handleMergeApply. */
+async function handleMergePromoteGlobal(req: Request, deps: AppDeps): Promise<Response> {
+  const body = (await req.json().catch(() => ({}))) as { suggestionId?: unknown };
+  const id = typeof body.suggestionId === "string" ? body.suggestionId : "";
+  if (!id) return json({ error: "suggestionId required" }, 400);
+  const sug = deps.store.getMergeSuggestion(id);
+  if (!sug) return json({ error: "not found" }, 404);
+  if (sug.kind !== "cross") return json({ error: "not a cross-repo suggestion" }, 400);
+  if (sug.status !== "pending") return json({ error: "already resolved" }, 409);
+  if (!deps.promoter) return json({ error: "promote unavailable" }, 503);
+  const res = await deps.promoter.promoteGlobal(sug.mergedRule);
+  if (!res.ok) return json({ error: res.error }, res.status);
+  deps.store.setMergeSuggestionStatus(id, "applied");
+  deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
+  return json({ ok: true });
 }
 
 /** POST /api/learnings/merge-dismiss — dismiss a merge suggestion (intra or cross), body

--- a/src/store.ts
+++ b/src/store.ts
@@ -2797,11 +2797,18 @@ export class SessionStore implements CapStore, CreditStore {
     return this.getMergeSuggestion(id);
   }
 
-  /** Signatures of pending + dismissed suggestions of a kind, so a background pass can
-   *  skip re-proposing a group the operator already has (or rejected). `intra` is scoped
-   *  to a repo; `cross` is global (repoPath ignored). */
+  /** Signatures of suggestions of a kind, so a background pass can skip re-proposing a group
+   *  the operator already has (or rejected). `intra` is scoped to a repo; `cross` is global
+   *  (repoPath ignored).
+   *
+   *  `cross` additionally includes `applied`: promoting a cross group to the global CLAUDE.md
+   *  (#872) leaves its member rules ACTIVE, so without this carve-out the next cross pass would
+   *  re-detect and re-suggest the same group. `intra`-apply retires its members, so the group
+   *  can't recur — `applied` is intentionally excluded there. */
   mergeSuggestionSignatures(opts: { kind: MergeSuggestionKind; repoPath?: string }): Set<string> {
-    const where = [`kind = ?`, `status IN ('pending','dismissed')`];
+    const statuses =
+      opts.kind === "cross" ? `('pending','dismissed','applied')` : `('pending','dismissed')`;
+    const where = [`kind = ?`, `status IN ${statuses}`];
     const args: string[] = [opts.kind];
     if (opts.kind === "intra" && opts.repoPath !== undefined) {
       where.push(`repoPath = ?`);

--- a/test/merge-suggest.test.ts
+++ b/test/merge-suggest.test.ts
@@ -196,6 +196,32 @@ test("cross: a group whose members are all in one repo is rejected", async () =>
   void b;
 });
 
+test("cross: a group promoted to global (applied) is NOT re-suggested on a later pass (#872)", async () => {
+  const store = new SessionStore(":memory:");
+  const a = seedActive(store, "/r1", "Always write a regression test");
+  const b = seedActive(store, "/r2", "Always write a regression test first");
+  const out = {
+    groups: [{ memberIds: [a.id, b.id], canonicalRule: "Always write a regression test" }],
+  };
+  const { deps, started } = mkDeps(store, out);
+  const svc = new MergeSuggestionService(deps);
+  svc.considerCrossRepo();
+  await svc.tick();
+  const cross = store.listMergeSuggestions({ kind: "cross", status: "pending" });
+  expect(cross.length).toBe(1);
+  // Simulate promote-global: mark applied. The member rules stay ACTIVE (no retire), so the
+  // dedup set must include `applied` or the same group re-appears next pass.
+  store.setMergeSuggestionStatus(cross[0]!.id, "applied");
+
+  // Change the global active set so the cross pass isn't gated out by an unchanged signature —
+  // this forces a real second spawn that must then be suppressed by the dedup, not the gate.
+  seedActive(store, "/r3", "An entirely unrelated active rule");
+  svc.considerCrossRepo();
+  await svc.tick();
+  expect(started.length).toBe(2); // the pass genuinely re-ran (not gated out before spawn)
+  expect(store.listMergeSuggestions({ kind: "cross", status: "pending" }).length).toBe(0);
+});
+
 // ── pure helpers ────────────────────────────────────────────────────────────
 
 test("pickSurvivor: anchor wins; else most-injected; else earliest createdAt", () => {

--- a/test/promote.test.ts
+++ b/test/promote.test.ts
@@ -442,3 +442,76 @@ test("Promoter.resyncPromoted returns 400 with lightweight message for local for
   expect(openPrCalled).toBe(false);
   expect(worktreeCreated).toBe(false);
 });
+
+// --- extractLearningsBlockRules + promoteGlobal (issue #872) ---
+
+import { extractLearningsBlockRules } from "../src/promote";
+
+test("extractLearningsBlockRules returns [] when there is no managed block", () => {
+  expect(extractLearningsBlockRules("# Repo\n\nhello\n")).toEqual([]);
+  expect(extractLearningsBlockRules("")).toEqual([]);
+});
+
+test("extractLearningsBlockRules parses bullets and round-trips upsertLearningsBlock", () => {
+  const content = upsertLearningsBlock("# Repo\n", ["use bun", "rebase onto main"]);
+  expect(extractLearningsBlockRules(content)).toEqual(["use bun", "rebase onto main"]);
+});
+
+test("extractLearningsBlockRules tolerates CRLF + leading whitespace and ignores prose", () => {
+  const block = [
+    LEARNINGS_START,
+    "  - indented rule",
+    "- normal rule",
+    "some prose line", // no bullet → ignored (block is Shepherd-owned)
+    "",
+    LEARNINGS_END,
+  ].join("\r\n");
+  const content = "# Repo\r\n\r\n" + block + "\r\n";
+  expect(extractLearningsBlockRules(content)).toEqual(["indented rule", "normal rule"]);
+});
+
+/** Promoter wired only for global writes: store/worktree/forge are unused by promoteGlobal.
+ *  Injected CLAUDE.md IO operates on `state` so the real ~/.claude is never touched. */
+function globalPromoter(state: { content: string; writes: string[] }) {
+  return new Promoter({
+    store: new SessionStore(":memory:"),
+    worktree: {
+      create: () => {
+        throw new Error("worktree unused by promoteGlobal");
+      },
+      remove: () => {},
+    },
+    resolveForge: () => null,
+    git: async () => {},
+    readClaudeMd: () => state.content,
+    writeClaudeMd: (_p, c) => {
+      state.content = c;
+      state.writes.push(c);
+    },
+  });
+}
+
+test("promoteGlobal writes a fresh block when the global file is empty", async () => {
+  const state = { content: "", writes: [] as string[] };
+  const res = await globalPromoter(state).promoteGlobal("always rebase onto main");
+  expect(res.ok).toBe(true);
+  expect(state.writes.length).toBe(1);
+  expect(extractLearningsBlockRules(state.writes[0]!)).toEqual(["always rebase onto main"]);
+});
+
+test("promoteGlobal accumulates onto the existing block (dedup, order-preserving)", async () => {
+  const existing = upsertLearningsBlock("# Global\n\nintro\n", ["rule a"]);
+  const state = { content: existing, writes: [] as string[] };
+  const res = await globalPromoter(state).promoteGlobal("rule b");
+  expect(res.ok).toBe(true);
+  expect(extractLearningsBlockRules(state.writes[0]!)).toEqual(["rule a", "rule b"]);
+  expect(state.writes[0]).toContain("intro"); // content outside the block is preserved
+});
+
+test("promoteGlobal is an idempotent no-op when the rule is already present", async () => {
+  const existing = upsertLearningsBlock("", ["rule a"]);
+  const state = { content: existing, writes: [] as string[] };
+  const res = await globalPromoter(state).promoteGlobal("rule a");
+  expect(res.ok).toBe(true);
+  expect(state.writes.length).toBe(0); // already current → nothing written
+});

--- a/test/promote.test.ts
+++ b/test/promote.test.ts
@@ -515,3 +515,27 @@ test("promoteGlobal is an idempotent no-op when the rule is already present", as
   expect(res.ok).toBe(true);
   expect(state.writes.length).toBe(0); // already current → nothing written
 });
+
+test("promoteGlobal returns a structured 500 (not a throw) on an fs failure", async () => {
+  const p = new Promoter({
+    store: new SessionStore(":memory:"),
+    worktree: {
+      create: () => {
+        throw new Error("unused");
+      },
+      remove: () => {},
+    },
+    resolveForge: () => null,
+    git: async () => {},
+    writeClaudeMd: () => {},
+    readClaudeMd: () => {
+      throw new Error("EACCES: permission denied, open '/root/.claude/CLAUDE.md'");
+    },
+  });
+  const res = await p.promoteGlobal("a rule");
+  expect(res.ok).toBe(false);
+  if (!res.ok) {
+    expect(res.status).toBe(500);
+    expect(res.error).toBe("global promote failed"); // no raw fs stderr leaked
+  }
+});

--- a/test/server-learnings.test.ts
+++ b/test/server-learnings.test.ts
@@ -46,6 +46,7 @@ function harness(promoter?: AppDeps["promoter"]): {
 test("promote success → 200 with url and emits learnings:update", async () => {
   const stub: AppDeps["promoter"] = {
     promote: async (): Promise<PromoteResult> => ({ ok: true, url: "https://pr/7" }),
+    promoteGlobal: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
   };
   const { app, emitted } = harness(stub);
 
@@ -64,6 +65,7 @@ test("promote error → propagates status code from service", async () => {
       error: "only active rules can be promoted",
       status: 409,
     }),
+    promoteGlobal: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
   };
   const { app } = harness(stub);
 
@@ -83,6 +85,155 @@ test("promote with no promoter dep → 503", async () => {
   );
   expect(res.status).toBe(503);
   expect(await res.json()).toEqual({ error: "promote unavailable" });
+});
+
+// ── POST /api/learnings/promote-global (issue #872) ───────────────────────────
+
+/** Harness exposing the store so a cross suggestion can be seeded + re-read. */
+function globalHarness(promoter?: AppDeps["promoter"]): {
+  app: ReturnType<typeof makeApp>;
+  store: SessionStore;
+  emitted: Array<[string, unknown]>;
+} {
+  const store = new SessionStore(":memory:");
+  const emitted: Array<[string, unknown]> = [];
+  const events = new EventHub();
+  const origEmit = events.emit.bind(events);
+  events.emit = (event: string, data: unknown) => {
+    emitted.push([event, data]);
+    return origEmit(event, data);
+  };
+  const deps: AppDeps = {
+    store,
+    service: {} as any,
+    events,
+    usageLimits: { limits: () => ({}) } as any,
+    promoter,
+  };
+  return { app: makeApp(deps), store, emitted };
+}
+
+function seedCross(store: SessionStore) {
+  return store.addMergeSuggestion({
+    kind: "cross",
+    repoPath: null,
+    targetId: null,
+    sourceIds: ["a", "b"],
+    mergedRule: "always rebase onto main",
+    mergedRationale: "",
+    repoPaths: ["/r1", "/r2"],
+    signature: "sig-1",
+  });
+}
+
+const okGlobal: AppDeps["promoter"] = {
+  promote: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
+  promoteGlobal: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
+};
+
+test("promote-global success → marks suggestion applied + emits learnings:update", async () => {
+  let promotedRule = "";
+  const { app, store, emitted } = globalHarness({
+    promote: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
+    promoteGlobal: async (rule: string): Promise<PromoteResult> => {
+      promotedRule = rule;
+      return { ok: true, url: "" };
+    },
+  });
+  const sug = seedCross(store);
+  const res = await app.fetch(
+    new Request("http://x/api/learnings/promote-global", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ suggestionId: sug.id }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+  expect(promotedRule).toBe("always rebase onto main");
+  expect(store.getMergeSuggestion(sug.id)!.status).toBe("applied");
+  expect(emitted.some(([event]) => event === "learnings:update")).toBe(true);
+});
+
+test("promote-global on an already-applied suggestion → 409 (stale re-post, no re-write)", async () => {
+  let calls = 0;
+  const { app, store } = globalHarness({
+    promote: async (): Promise<PromoteResult> => ({ ok: true, url: "" }),
+    promoteGlobal: async (): Promise<PromoteResult> => {
+      calls++;
+      return { ok: true, url: "" };
+    },
+  });
+  const sug = seedCross(store);
+  store.setMergeSuggestionStatus(sug.id, "applied");
+  const res = await app.fetch(
+    new Request("http://x/api/learnings/promote-global", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ suggestionId: sug.id }),
+    }),
+  );
+  expect(res.status).toBe(409);
+  expect(calls).toBe(0);
+});
+
+test("promote-global with unknown suggestionId → 404", async () => {
+  const { app } = globalHarness(okGlobal);
+  const res = await app.fetch(
+    new Request("http://x/api/learnings/promote-global", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ suggestionId: "nope" }),
+    }),
+  );
+  expect(res.status).toBe(404);
+});
+
+test("promote-global on an intra suggestion → 400", async () => {
+  const { app, store } = globalHarness(okGlobal);
+  const sug = store.addMergeSuggestion({
+    kind: "intra",
+    repoPath: "/r",
+    targetId: "t",
+    sourceIds: ["a"],
+    mergedRule: "merged",
+    mergedRationale: "",
+    repoPaths: null,
+    signature: "intra-sig",
+  });
+  const res = await app.fetch(
+    new Request("http://x/api/learnings/promote-global", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ suggestionId: sug.id }),
+    }),
+  );
+  expect(res.status).toBe(400);
+});
+
+test("promote-global with missing suggestionId → 400", async () => {
+  const { app } = globalHarness(okGlobal);
+  const res = await app.fetch(
+    new Request("http://x/api/learnings/promote-global", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    }),
+  );
+  expect(res.status).toBe(400);
+});
+
+test("promote-global with no promoter dep → 503 (after suggestion validated)", async () => {
+  const { app, store } = globalHarness(undefined);
+  const sug = seedCross(store);
+  const res = await app.fetch(
+    new Request("http://x/api/learnings/promote-global", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ suggestionId: sug.id }),
+    }),
+  );
+  expect(res.status).toBe(503);
 });
 
 // ── optimizer routes ─────────────────────────────────────────────────────────

--- a/test/store-learnings.test.ts
+++ b/test/store-learnings.test.ts
@@ -869,3 +869,42 @@ test("mergeLearning: rejects non-active states (proposed, dismissed, promoted, r
   // missing id
   expect(s.mergeLearning("nope", "attempt")).toBeNull();
 });
+
+// ── mergeSuggestionSignatures: cross dedup carve-out (issue #872) ──────────────
+
+test("mergeSuggestionSignatures: cross includes 'applied' so a promoted group is not re-suggested", () => {
+  const s = new SessionStore(":memory:");
+  const sug = s.addMergeSuggestion({
+    kind: "cross",
+    repoPath: null,
+    targetId: null,
+    sourceIds: ["x", "y"],
+    mergedRule: "always rebase",
+    mergedRationale: "",
+    repoPaths: ["/r1", "/r2"],
+    signature: "cross-sig-1",
+  });
+  // Before promote it is pending → already in the dedup set.
+  expect(s.mergeSuggestionSignatures({ kind: "cross" }).has("cross-sig-1")).toBe(true);
+  // promote-global marks it applied; cross members stay active, so 'applied' MUST still dedup.
+  s.setMergeSuggestionStatus(sug.id, "applied");
+  expect(s.mergeSuggestionSignatures({ kind: "cross" }).has("cross-sig-1")).toBe(true);
+});
+
+test("mergeSuggestionSignatures: intra still EXCLUDES 'applied' (members get retired on merge)", () => {
+  const s = new SessionStore(":memory:");
+  const sug = s.addMergeSuggestion({
+    kind: "intra",
+    repoPath: "/r",
+    targetId: "t",
+    sourceIds: ["a"],
+    mergedRule: "merged",
+    mergedRationale: "",
+    repoPaths: null,
+    signature: "intra-sig-1",
+  });
+  s.setMergeSuggestionStatus(sug.id, "applied");
+  expect(s.mergeSuggestionSignatures({ kind: "intra", repoPath: "/r" }).has("intra-sig-1")).toBe(
+    false,
+  );
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1683,5 +1683,13 @@
   "issues_filter_subissues_title": "Native Unteraufgaben (Kinder eines Epics) ausblenden — stattdessen einen Epic-Drain starten",
   "issues_filter_all_sub_issues": "Alle passenden Issues sind Epic-Unteraufgaben — zum Anzeigen ausschalten oder einen Epic-Drain starten",
   "feat_issues_filter_subissues_title": "Unteraufgaben standardmäßig ausblenden",
-  "feat_issues_filter_subissues_body": "Die Issue-Listen im Backlog und in „Neue Aufgabe“ blenden GitHub-native Unteraufgaben jetzt standardmäßig aus, damit du einen Epic-Drain vom übergeordneten Issue startest, statt ein einzelnes Kinder-Issue zu bearbeiten. Mit dem Schalter „Unteraufgaben ausblenden“ kannst du sie einblenden; übergeordnete Epic-Issues (einschließlich mehrstufiger Epics) bleiben sichtbar. Die Einstellung gilt für beide Listen."
+  "feat_issues_filter_subissues_body": "Die Issue-Listen im Backlog und in „Neue Aufgabe“ blenden GitHub-native Unteraufgaben jetzt standardmäßig aus, damit du einen Epic-Drain vom übergeordneten Issue startest, statt ein einzelnes Kinder-Issue zu bearbeiten. Mit dem Schalter „Unteraufgaben ausblenden“ kannst du sie einblenden; übergeordnete Epic-Issues (einschließlich mehrstufiger Epics) bleiben sichtbar. Die Einstellung gilt für beide Listen.",
+  "learnings_recur_promote": "Zur globalen CLAUDE.md hinzufügen",
+  "learnings_recur_promote_aria": "Diese Regel zu deiner benutzerglobalen CLAUDE.md hinzufügen",
+  "learnings_recur_promote_confirm": "Dies schreibt die Regel in ~/.claude/CLAUDE.md – eine globale, nicht versionierte Datei, die für jedes Repo gilt. Shepherd verwaltet diesen Block und schreibt ihn bei jeder Übernahme neu.",
+  "learnings_recur_promote_action": "Schreiben",
+  "learnings_recur_promote_done": "Regel zu deiner globalen CLAUDE.md hinzugefügt.",
+  "learnings_recur_promote_failed": "Schreiben in deine globale CLAUDE.md fehlgeschlagen.",
+  "feat_learnings_promote_global_title": "Eine Regel global per Klick übernehmen",
+  "feat_learnings_promote_global_body": "Ein repoübergreifender Wiederholungsvorschlag lässt sich jetzt mit einem abgesicherten Klick (zweistufige Bestätigung) direkt in deine benutzerglobale ~/.claude/CLAUDE.md schreiben – ohne PR, gültig für jedes Repo."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1683,5 +1683,13 @@
   "issues_filter_subissues_title": "Hide native sub-issues (children of an epic) — start an epic drain instead",
   "issues_filter_all_sub_issues": "All matching issues are epic sub-issues — toggle off to see them, or start an epic drain",
   "feat_issues_filter_subissues_title": "Hide sub-issues by default",
-  "feat_issues_filter_subissues_body": "The Backlog and New Task issue lists now hide GitHub native sub-issues by default, so you start an epic drain from the parent instead of draining a child alone. Use the \"hide sub-issues\" toggle to show them; epic parents (including mid-level epics) stay visible. Remembered across both lists."
+  "feat_issues_filter_subissues_body": "The Backlog and New Task issue lists now hide GitHub native sub-issues by default, so you start an epic drain from the parent instead of draining a child alone. Use the \"hide sub-issues\" toggle to show them; epic parents (including mid-level epics) stay visible. Remembered across both lists.",
+  "learnings_recur_promote": "Add to global CLAUDE.md",
+  "learnings_recur_promote_aria": "Add this rule to your user-global CLAUDE.md",
+  "learnings_recur_promote_confirm": "This writes the rule into ~/.claude/CLAUDE.md — a global, unversioned file applied to every repo. Shepherd owns this block and rewrites it on each promote.",
+  "learnings_recur_promote_action": "Write",
+  "learnings_recur_promote_done": "Rule added to your global CLAUDE.md.",
+  "learnings_recur_promote_failed": "Couldn't write to your global CLAUDE.md.",
+  "feat_learnings_promote_global_title": "One-click promote a rule globally",
+  "feat_learnings_promote_global_body": "A cross-repo recurrence suggestion can now be written straight into your user-global ~/.claude/CLAUDE.md with one guarded click (a two-step confirm) — no PR, applied to every repo."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1315,6 +1315,17 @@ export async function dismissMergeSuggestion(suggestionId: string): Promise<void
   if (!r.ok) throw await failed(r, "merge dismiss");
 }
 
+/** Promote a cross-repo recurrence rule into the user-global ~/.claude/CLAUDE.md (#872).
+ *  Operator-confirmed; writes directly (no PR). Marks the suggestion applied server-side. */
+export async function promoteGlobalLearning(suggestionId: string): Promise<void> {
+  const r = await fetch(`/api/learnings/promote-global`, {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ suggestionId }),
+  });
+  if (!r.ok) throw await failed(r, "promote global");
+}
+
 /** Manually trigger the background merge-suggestion pass for a repo ("Suggest merges now").
  *  Fire-and-forget; suggestions arrive via the learnings:update event. */
 export async function mergeSuggestNow(repoPath: string): Promise<void> {

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -114,6 +114,7 @@
     onseenretired,
     onmerge,
     ondismissmerge,
+    onpromoteglobal,
     onmergenow,
     onclose,
   }: {
@@ -132,6 +133,7 @@
     onseenretired: (repoPath: string) => void;
     onmerge: (suggestionId: string) => void;
     ondismissmerge: (suggestionId: string) => void;
+    onpromoteglobal: (suggestionId: string) => void;
     onmergenow: (repoPath: string) => void;
     onclose: () => void;
   } = $props();
@@ -141,6 +143,9 @@
   const crossSuggestions = $derived(mergeSuggestions.filter((s) => s.kind === "cross"));
   const intraFor = (repoPath: string): MergeSuggestion[] =>
     mergeSuggestions.filter((s) => s.kind === "intra" && s.repoPath === repoPath);
+
+  // Cross-repo card pending the inline two-step confirm before a global CLAUDE.md write (#872).
+  let confirmingGlobalId = $state<string | null>(null);
 
   let drafts = $state<Record<string, string>>({});
   const draft = (l: Learning) => drafts[l.id] ?? l.rule;
@@ -326,8 +331,8 @@
     </section>
   {/if}
 
-  <!-- Phase 4: cross-repo recurrence band — rules that recur across repos, suggested for a
-       user-global CLAUDE.md. Display + dismiss only; the operator decides. -->
+  <!-- Phase 4: cross-repo recurrence band — rules that recur across repos, suggested for the
+       user-global CLAUDE.md. Promote (guarded, two-step) writes the rule there; or dismiss. -->
   {#if crossSuggestions.length > 0}
     <section class="recur" aria-label={m.learnings_recur_heading()}>
       <span class="recur-title">{m.learnings_recur_heading()}</span>
@@ -341,16 +346,43 @@
               repos: (s.repoPaths ?? []).map(basename).join(", "),
             })}
           </p>
-          <div class="recur-foot">
-            <button
-              class="ms-dismiss"
-              type="button"
-              onclick={() => ondismissmerge(s.id)}
-              aria-label={m.learnings_recur_dismiss_aria()}
-            >
-              {m.learnings_dismiss()}
-            </button>
-          </div>
+          {#if confirmingGlobalId === s.id}
+            <p class="recur-confirm">{m.learnings_recur_promote_confirm()}</p>
+            <div class="recur-foot">
+              <button class="ms-dismiss" type="button" onclick={() => (confirmingGlobalId = null)}>
+                {m.common_cancel()}
+              </button>
+              <button
+                class="ms-apply"
+                type="button"
+                onclick={() => {
+                  onpromoteglobal(s.id);
+                  confirmingGlobalId = null;
+                }}
+              >
+                {m.learnings_recur_promote_action()}
+              </button>
+            </div>
+          {:else}
+            <div class="recur-foot">
+              <button
+                class="ms-dismiss"
+                type="button"
+                onclick={() => ondismissmerge(s.id)}
+                aria-label={m.learnings_recur_dismiss_aria()}
+              >
+                {m.learnings_dismiss()}
+              </button>
+              <button
+                class="ms-apply"
+                type="button"
+                onclick={() => (confirmingGlobalId = s.id)}
+                aria-label={m.learnings_recur_promote_aria()}
+              >
+                {m.learnings_recur_promote()}
+              </button>
+            </div>
+          {/if}
         </article>
       {/each}
     </section>
@@ -1331,6 +1363,11 @@
   .recur-repos {
     font-size: var(--fs-meta);
     color: var(--color-muted);
+    line-height: 1.45;
+  }
+  .recur-confirm {
+    font-size: var(--fs-meta);
+    color: var(--color-amber);
     line-height: 1.45;
   }
   .recur-foot,

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1317,4 +1317,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_issues_filter_subissues_body",
     targetId: "issues-filter-subissues",
   },
+  {
+    // One-click global promote (#872): the cross-repo recurrence card now has a guarded
+    // (two-step confirm) action that writes the rule straight into the user-global
+    // ~/.claude/CLAUDE.md — no PR. Lives in the closed-by-default drawer → What's-New only,
+    // no coachmark target. v1.34.0 latest released → ships in 1.35.0.
+    id: "learnings-promote-global",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_learnings_promote_global_title",
+    bodyKey: "feat_learnings_promote_global_body",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -37,6 +37,7 @@
     markRetiredSeen,
     applyMergeSuggestion,
     dismissMergeSuggestion,
+    promoteGlobalLearning,
     mergeSuggestNow,
     getMergedClearable,
     clearMerged,
@@ -2004,6 +2005,13 @@
         dismissMergeSuggestion(suggestionId)
           .then(() => learnings.load())
           .catch(() => {})}
+      onpromoteglobal={(suggestionId) =>
+        promoteGlobalLearning(suggestionId)
+          .then(() => {
+            toasts.info(m.learnings_recur_promote_done());
+            return learnings.load();
+          })
+          .catch(() => toasts.info(m.learnings_recur_promote_failed()))}
       onmergenow={(repoPath) =>
         mergeSuggestNow(repoPath)
           .then(() => toasts.info(m.learnings_merge_now_started({ repo: basename(repoPath) })))


### PR DESCRIPTION
Closes #872. Phase 4 follow-up (#843) of the learnings-lifecycle epic (#838).

The cross-repo recurrence band offered **display + dismiss only**. This adds the deferred convenience: an explicit, operator-confirmed one-click action that writes the recurring rule straight into the user-global `~/.claude/CLAUDE.md` — no forge/branch/PR.

## What changed

**Backend**
- `Promoter.promoteGlobal(rule)` (`src/promote.ts`) — writes to `os.homedir()/.claude/CLAUDE.md`, reusing `upsertLearningsBlock` + the `shepherd:learnings` markers. Reads the existing block, unions the rule in (dedup, order-preserving) via the new `extractLearningsBlockRules` helper, rewrites. Idempotent (no-op when already present). Default writer now `mkdirSync`s the parent so `~/.claude` is created if absent.
- `mergeSuggestionSignatures` (`src/store.ts`) — now includes `applied` **for `kind:"cross"`** (intra unchanged). Cross promote leaves member rules *active*, so without this the next cross pass would re-suggest the promoted group. Intra-apply retires its members, so `applied` stays excluded there.
- `POST /api/learnings/promote-global` (`src/server.ts`) — resolves the cross suggestion, calls `promoteGlobal(mergedRule)`, marks it `applied`, emits `learnings:update`. Guards: **409** stale re-post (status ≠ pending, parity with merge-apply), **404** unknown, **400** non-cross / missing id, **503** no promoter.

**UI**
- `promoteGlobalLearning()` client (`api.ts`); `onpromoteglobal` handler wired in `+page.svelte` with success/failure toasts + reload.
- Cross-repo card (`LearningsDrawer.svelte`) gains a guarded **Add to global CLAUDE.md** button with an **inline two-step confirm** (warning copy naming `~/.claude/CLAUDE.md` → Cancel / Write). No modal, so no scrim machinery.
- EN+DE keys + a `feature-announcements.ts` entry (`learnings-promote-global`, 1.35.0).

## Design notes (issue explicitly asked to weigh these)
- **In-app vs. manual:** built guarded in-app (operator choice). No automation — the write only fires from a confirmed click.
- **Shepherd-owned block:** the `shepherd:learnings` block is rewritten in full; hand-edits *inside* the markers aren't preserved (content outside is). Parser is CRLF/leading-whitespace tolerant.
- **Home-dir trust:** `os.homedir()` is the *server process's* home — may differ from the operator's in container/multi-user setups. Accepted + documented for the single-user local target.

## Tests
- `test/promote.test.ts` — `extractLearningsBlockRules` (parse/empty/roundtrip/CRLF/whitespace/ignores-prose) + `promoteGlobal` (fresh write, accumulate, idempotent no-op).
- `test/store-learnings.test.ts` — cross includes `applied`, intra excludes it.
- `test/server-learnings.test.ts` — route happy path + 409/404/400/503.
- `test/merge-suggest.test.ts` — **regression:** a promoted (applied) cross group is NOT re-suggested on a later pass (asserts the pass genuinely re-ran, so it exercises the dedup, not the gate).

## Verification
Root: `bun run lint`, `bunx tsc --noEmit`, `bun test ./test` (4144 pass). UI: `bun run check` (0 errors), `bun run check:i18n` (parity), `bun test` (1779 pass). Branch-hygiene + feature-catalog + glossary gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)