### PR TITLE
fix(epic): show real title+url for queued markdown-epic issues

### DIFF
--- a/src/drain.ts
+++ b/src/drain.ts
@@ -258,11 +258,23 @@ export class DrainService {
     const struct = await this.epicStructure(repoPath, run);
     if (!struct) return null;
     const native = struct.subIssues.length > 0;
-    let openIssues: { number: number; body: string; labels: string[] }[] = [];
+    let openIssues: {
+      number: number;
+      title: string;
+      url: string;
+      body: string;
+      labels: string[];
+    }[] = [];
     let openIssuesTruncated = false;
     if (!native) {
       const open = await this.listIssues(repoPath);
-      openIssues = open.map((i) => ({ number: i.number, body: i.body, labels: i.labels }));
+      openIssues = open.map((i) => ({
+        number: i.number,
+        title: i.title,
+        url: i.url,
+        body: i.body,
+        labels: i.labels,
+      }));
       openIssuesTruncated = open.length >= 200;
     }
     const prSnap = this.deps.prCache.snapshot();

--- a/src/epic-model.ts
+++ b/src/epic-model.ts
@@ -24,7 +24,7 @@ export interface AssembleInput {
   parent: { number: number; title: string; body: string };
   subIssues: SubIssueRef[]; // native: carries closed/labels/body per child
   blockedBy: Map<number, number[]>;
-  openIssues: { number: number; body: string; labels: string[] }[]; // markdown fallback only (200-capped)
+  openIssues: { number: number; title: string; url: string; body: string; labels: string[] }[]; // markdown fallback only (200-capped)
   openIssuesTruncated: boolean; // listIssues() hit the 200 cap
   sessions: AssembleSession[];
   /** Child #s whose PR was squash-merged into the epic integration branch (persisted
@@ -80,8 +80,8 @@ function resolveMarkdown(input: AssembleInput): ResolvedGraph {
     const o = openByNum.get(n);
     // markdown: a member absent from the (capped) open list is treated closed
     resolved.set(n, {
-      title: `#${n}`,
-      url: "",
+      title: o?.title ?? `#${n}`,
+      url: o?.url ?? "",
       body: o?.body ?? "",
       closed: !o,
       claimed: !!o?.labels.includes(ACTIVE_LABEL),

--- a/test/epic-model.test.ts
+++ b/test/epic-model.test.ts
@@ -71,14 +71,20 @@ describe("assembleEpic", () => {
       parent: { number: 1, title: "p", body: "```epic-dag\n#2\n#3 <- #2\n```" },
       persistedBranch: "epic/1-p", // matches derive(1,"p") → isolate the truncation warning
       openIssues: [
-        { number: 2, body: "", labels: [] },
-        { number: 3, body: "", labels: [] },
+        { number: 2, title: "wire the thing", url: "https://forge/issues/2", body: "", labels: [] },
+        { number: 3, title: "test the thing", url: "https://forge/issues/3", body: "", labels: [] },
       ],
       openIssuesTruncated: true,
     });
     expect(e.source).toBe("markdown");
     expect(e.children.find((c) => c.number === 3)!.state).toBe("blocked"); // #2 open → not closed
     expect(e.warnings.some((w) => w.includes("truncated"))).toBe(true);
+    // markdown children carry the real openIssues title + url (not the `#${n}` placeholder /
+    // empty href) — the queue popover renders `#n <title>` linking to the issue, not `#n #n`
+    // with a dead `href=""` that reloads the app.
+    const c2 = e.children.find((c) => c.number === 2)!;
+    expect(c2.title).toBe("wire the thing");
+    expect(c2.url).toBe("https://forge/issues/2");
   });
   test("non-member + self edges dropped + warned", () => {
     const e = assembleEpic({ ...BASE, blockedBy: new Map([[322, [999, 322]]]) });


### PR DESCRIPTION
## Problem

The inline drain-queue popover (`QUEUED: <repo>` under a repo chip) rendered each queued issue as `#881 #881` — the issue number followed by a "title" that was just the number again — inside an `<a href="">` that **reloads the app** instead of opening the issue.


## Root cause

For **markdown-mode epics** (DAG declared in the parent issue body, not native sub-issues), `resolveMarkdown` in `src/epic-model.ts` hardcoded each child's `title` to the placeholder `` `#${n}` `` and `url` to `""`. The real GitHub title + url *were* available (`o` = the open issue from `listIssues()`), but `drain.buildEpic()` assembled its `openIssues` payload with only `{ number, body, labels }`, so neither reached the model. The queue surfaces these children verbatim → `#n #n` with a dead `href`.

Native sub-issue epics and label-mode drains already carry real title + url, so only markdown epics were affected.

## Fix

Thread the real `title` **and** `url` through the markdown path:
- `src/epic-model.ts` — add `title`/`url` to `AssembleInput.openIssues`; use `o?.title ?? `#${n}`` and `o?.url ?? ""` in `resolveMarkdown` (fallbacks retained for closed/missing members, which are never queued).
- `src/drain.ts` — include `title: i.title` / `url: i.url` in `buildEpic`'s `openIssues` mapping.

Every queued candidate is a live **open** issue (`selectEpicCandidates` filters `!issueClosed`; markdown `closed = !o`), so post-fix no placeholder-title / empty-url row can reach the queue — no UI guard needed (`RepoChipTelemetry.svelte` untouched).

## Test

Extended the markdown-fallback test in `test/epic-model.test.ts` to assert children expose the real title **and** a non-empty url — fails on the pre-fix `#${n}`/`""` placeholders.

`bun test`, root `tsc`, `ui`/`extension` svelte-check, lint, i18n parity all green (pre-push gate).

[no-feature-entry] — bug fix, no new user-facing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)