### PR TITLE
fix(epics): hide markdown epic-dag sub-issues in backlog, not just native ones

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3961,6 +3961,24 @@ async function buildEpicSummaries(
   return result;
 }
 
+/** Issue numbers the backlog "hide sub-issues" filter should hide: native sub-issues plus the
+ *  open markdown (epic-dag) members of every candidate. Markdown epics have no GitHub-native
+ *  parent links, so their children never appear in `nativeSubIssues` — fold them in here. A
+ *  mid-level epic that is also a member stays visible (the UI guards hiding on epicParents). */
+function collectSubIssueNumbers(
+  candidates: Map<number, IssueHint | undefined>,
+  nativeSubIssues: number[],
+  openNumbers: Set<number>,
+): number[] {
+  const subIssues = new Set(nativeSubIssues);
+  for (const hint of candidates.values()) {
+    for (const m of parseEpicBody(hint?.body ?? "").members) {
+      if (openNumbers.has(m)) subIssues.add(m);
+    }
+  }
+  return [...subIssues];
+}
+
 async function handleEpicsList({ req, parts, url, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "GET" && parts[0] === "api" && parts[1] === "epics" && !parts[2]))
     return null;
@@ -4000,7 +4018,8 @@ async function handleEpicsList({ req, parts, url, deps }: Ctx): Promise<Response
     openNumbers,
     openTruncated,
   );
-  return json({ epics: result, subIssues: subIssueNumbers });
+  const subIssues = collectSubIssueNumbers(candidates, subIssueNumbers, openNumbers);
+  return json({ epics: result, subIssues });
 }
 
 // GET /api/epic?repo=&parent= — assemble the Epic for a single parent issue.

--- a/test/epic-server.test.ts
+++ b/test/epic-server.test.ts
@@ -770,6 +770,64 @@ describe("GET /api/epics", () => {
     expect(body).toEqual({ epics: [], subIssues: [] });
     expect(Array.isArray(body)).toBe(false);
   });
+
+  // ── markdown epic members count as sub-issues ────────────────────────────────
+  // A markdown (epic-dag) epic's children have no GitHub-native parent, so they never
+  // appear in the native `subIssueNumbers`. The backlog "hide sub-issues" filter must
+  // still hide them, so subIssues folds in the open markdown members too.
+  test("markdown epic: open members are surfaced in subIssues", async () => {
+    const forge: any = {
+      // #50 is a markdown epic with members #100 (closed) / #101 (open) / #102 (open).
+      // Only the open members render in the list, so only those should be hidden.
+      listIssues: async () => [
+        {
+          number: 50,
+          title: "Epic",
+          body: "- [x] #100\n- [ ] #101\n- [ ] #102",
+          url: "",
+          labels: [],
+          createdAt: 0,
+        },
+        { number: 101, title: "Open sub", body: "", url: "", labels: [], createdAt: 0 },
+        { number: 102, title: "Open sub", body: "", url: "", labels: [], createdAt: 0 },
+        { number: 200, title: "Ordinary", body: "", url: "", labels: [], createdAt: 0 },
+      ],
+      // No native sub-issues in this repo (markdown epic only).
+      listSubIssueSummaries: async () => ({ summaries: new Map(), subIssueNumbers: [] }),
+    };
+    const { app } = harness({ resolveForge: () => forge });
+    const res = await app.fetch(new Request(`http://x/api/epics?repo=${encRepo(repoDir)}`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.epics.length).toBe(1);
+    expect(body.epics[0].parentIssueNumber).toBe(50);
+    // Open members #101/#102 surface; closed #100 and the parent/ordinary do not.
+    expect([...body.subIssues].sort((a: number, b: number) => a - b)).toEqual([101, 102]);
+  });
+
+  // Native + markdown sub-issues union without duplicates.
+  test("markdown + native: subIssues unions both with no duplicates", async () => {
+    const forge: any = {
+      listIssues: async () => [
+        {
+          number: 50,
+          title: "MD Epic",
+          body: "- [ ] #101\n- [ ] #7",
+          url: "",
+          labels: [],
+          createdAt: 0,
+        },
+        { number: 101, title: "Open md sub", body: "", url: "", labels: [], createdAt: 0 },
+        { number: 7, title: "Both", body: "", url: "", labels: [], createdAt: 0 },
+      ],
+      // #7 is also a native sub-issue → must appear once, not twice.
+      listSubIssueSummaries: async () => ({ summaries: new Map(), subIssueNumbers: [7] }),
+    };
+    const { app } = harness({ resolveForge: () => forge });
+    const res = await app.fetch(new Request(`http://x/api/epics?repo=${encRepo(repoDir)}`));
+    const body = await res.json();
+    expect([...body.subIssues].sort((a: number, b: number) => a - b)).toEqual([7, 101]);
+  });
 });
 
 // ── completed-epics band (GET /api/epics/completed + dismiss) ─────────────────


### PR DESCRIPTION
## Why

PR #891 (TASK-642) added a default-ON **"hide sub-issues"** filter to the Backlog + New Task issue lists — but it only recognizes GitHub **native** sub-issues (issues with a non-null GraphQL `parent`). Shepherd's own epics are **markdown `epic-dag`** epics, whose children have no native parent link. So `/api/epics` returned `subIssues: []` for them and the filter was a **no-op**: every markdown epic's children stayed in the list.

Observed live on the shepherd repo: epic **#875** (markdown, 3/6) with the toggle ON still showed its open children **#879 / #881 / #882**.

## What

`handleEpicsList` already parses each epic candidate's markdown members and already knows which are open. This folds the **open markdown members** into the returned `subIssues` array (extracted into `collectSubIssueNumbers` to keep the handler under the cognitive-complexity gate). **No UI change** — the existing filter (`hide if subIssues.has(n) && !epicParents.has(n)`) now has data to act on, and the `epicParents` guard keeps mid-level epics visible.

## Verification

- New regression tests in `test/epic-server.test.ts` (fail on pre-fix code): markdown epic's open members surface in `subIssues`; native + markdown union without duplicates.
- Ran the **real `/api/epics` route against the live GitHub forge** for the shepherd repo → `subIssues: [879, 881, 882]` (was `[]`).
- Gates green: root `lint` + `tsc --noEmit` + `bun test ./test` (4155 pass); `fallow audit --fail-on-issues` (exit 0).

[no-feature-entry] — fixes an existing feature; ships no new user-facing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)