### PR TITLE
fix(ui): restore space between recap annotation label + note

### DIFF
--- a/ui/src/lib/components/blocks/AnnotatedCodeBlock.browser.test.ts
+++ b/ui/src/lib/components/blocks/AnnotatedCodeBlock.browser.test.ts
@@ -31,6 +31,25 @@ describe("AnnotatedCodeBlock", () => {
     await expect.element(page.getByText(/This sets up the main handler\./)).toBeInTheDocument();
   });
 
+  it("separates annotation label and note with whitespace", async () => {
+    render(AnnotatedCodeBlock, {
+      block: {
+        type: "annotated-code",
+        id: "ac2ws",
+        filename: "src/api.ts",
+        code: "export function init() {}",
+        annotations: [{ label: "Placeholder", note: "removed resolveMarkdown call" }],
+      },
+    });
+    const li = page
+      .getByText(/removed resolveMarkdown call/)
+      .element()
+      .closest("li");
+    expect(li?.textContent?.replace(/\s+/g, " ").trim()).toBe(
+      "Placeholder removed resolveMarkdown call",
+    );
+  });
+
   it("renders annotation without label", async () => {
     render(AnnotatedCodeBlock, {
       block: {

--- a/ui/src/lib/components/blocks/AnnotatedCodeBlock.svelte
+++ b/ui/src/lib/components/blocks/AnnotatedCodeBlock.svelte
@@ -20,8 +20,7 @@
     <ul class="acb-annotations">
       {#each block.annotations as ann, i (i)}
         <li class="acb-ann">
-          {#if ann.label}<strong>{ann.label}</strong>
-          {/if}{ann.note}
+          {#if ann.label}<strong>{ann.label}</strong>{/if}{ann.label ? " " : ""}{ann.note}
         </li>
       {/each}
     </ul>

--- a/ui/src/lib/components/blocks/DiffBlock.browser.test.ts
+++ b/ui/src/lib/components/blocks/DiffBlock.browser.test.ts
@@ -82,6 +82,24 @@ describe("DiffBlock", () => {
     await expect.element(page.getByText(/This is important/)).toBeInTheDocument();
   });
 
+  it("separates annotation label and note with whitespace", async () => {
+    render(DiffBlock, {
+      block: {
+        type: "diff",
+        id: "d4ws",
+        path: "src/index.ts",
+        summary: "With annotations",
+        file: TEST_FILE,
+        annotations: [{ label: "Type", note: "widened openIssues element" }],
+      },
+    });
+    const li = page
+      .getByText(/widened openIssues element/)
+      .element()
+      .closest("li");
+    expect(li?.textContent?.replace(/\s+/g, " ").trim()).toBe("Type widened openIssues element");
+  });
+
   it("renders annotation without label", async () => {
     render(DiffBlock, {
       block: {

--- a/ui/src/lib/components/blocks/DiffBlock.svelte
+++ b/ui/src/lib/components/blocks/DiffBlock.svelte
@@ -18,8 +18,7 @@
     <ul class="db-annotations">
       {#each block.annotations as ann, i (i)}
         <li class="db-ann">
-          {#if ann.label}<strong>{ann.label}</strong>
-          {/if}{ann.note}
+          {#if ann.label}<strong>{ann.label}</strong>{/if}{ann.label ? " " : ""}{ann.note}
         </li>
       {/each}
     </ul>


### PR DESCRIPTION
## Problem

In the task recap, annotation entries in the **HIGHLIGHTED CHANGES** / annotated-code sections rendered the bold lead-in word glued to the following text with no space — e.g. *"Type**widened**openIssues…"* showed as `Typewidened openIssues…`, `Placeholderremoved resolveMarkdown…`, `Mappingextended Each issue…`.

## Cause

`DiffBlock.svelte` and `AnnotatedCodeBlock.svelte` rendered:

```svelte
{#if ann.label}<strong>{ann.label}</strong>
{/if}{ann.note}
```

Svelte trims the whitespace text node at the **end of the `{#if}` block**, so `</strong>` ran straight into `{ann.note}`. A literal same-line space is trimmed the same way, and `{' '}` trips `svelte/no-useless-mustaches`.

## Fix

Emit the separator through a `{ann.label ? " " : ""}` expression — expression text is not subject to Svelte's whitespace trimming, only renders when a label is present, and passes lint. Applied to both block components.

## Tests

Added a regression test to each block's browser test asserting the rendered `<li>` text carries the space between label and note. Verified the new tests **fail on pre-fix markup** and pass after the fix.

- `cd ui && bun run test:browser` (block tests) — 11/11 pass
- `cd ui && bun run check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)