### PR TITLE
feat: reduced push notifications mode (ready-after-5s only) (#896)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -334,6 +334,9 @@ export const config = {
   // (and its notification noise) for agent sessions; `/remote-control` (`/rc`) still
   // works in the terminal to turn it on per-session. UI-configurable + persisted.
   remoteControlAtStartup: process.env.SHEPHERD_REMOTE_CONTROL_AT_STARTUP === "1",
+  // Reduced push mode: global; UI-configurable + persisted; when on, the push
+  // layer sends only `ready` notifications plus cost alerts (quieter devices).
+  reducedPushMode: process.env.SHEPHERD_REDUCED_PUSH_MODE === "1",
   // Push-based agent-info ingestion via Claude Code hooks (issue #704), additive on top
   // of polling, staged behind two default-off flags so each phase is independently reversible.
   // Phase 0: inject PostToolUse/PostToolUseFailure/Notification HTTP hooks into spawned

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import {
   attachUsagePush,
   attachCreditsPush,
 } from "./push";
+import { ReadyNotifier } from "./ready-notify";
 import { Presence } from "./presence";
 import { ReviewService } from "./review";
 import { StandalonePrCriticService } from "./standalone-critic";
@@ -732,6 +733,18 @@ setInterval(() => sweepStaleReviewWorktrees(), 60 * 60 * 1000);
 attachReviewPush(events, store, push);
 attachGitPush(events, store, push);
 attachMergePush(events, push);
+
+// Reduced-push "ready-after-5s" evaluator (#896): while reducedPushMode is on, fire the
+// `ready` push once a session holds the ready set for ≥5s (with warm-up + seed-on-arm guard).
+const readyNotifier = new ReadyNotifier({
+  listSessions: () => store.list({ activeOnly: true }),
+  workingBlocked: () => poller.workingBlockedSnapshot(),
+  gitSnapshot: () => prPoller.snapshot(),
+  reviewingIds: () => [...reviewService.reviewingIds(), ...planGate.reviewingIds()],
+  notify: (input) => push.notify(input),
+  reducedMode: () => config.reducedPushMode,
+});
+readyNotifier.start();
 // drive the critic off PR-state changes: open + CI green + unreviewed head → review
 events.subscribe((event, data) => {
   if (event !== "session:git") return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,8 @@ if (savedRoot) {
 // env default; absent → keep the config default. Stored as "1"/"0".
 const savedRc = store.getSetting("remoteControlAtStartup");
 if (savedRc !== null) config.remoteControlAtStartup = savedRc === "1";
+const savedRpm = store.getSetting("reducedPushMode");
+if (savedRpm !== null) config.reducedPushMode = savedRpm === "1";
 // a UI-chosen session-housekeeping preference (persisted) overrides the env default;
 // absent → keep the config default (on). Stored as "1"/"0".
 const savedHk = store.getSetting("sessionHousekeepingEnabled");

--- a/src/push.ts
+++ b/src/push.ts
@@ -20,7 +20,8 @@ export interface PushPayload {
     | "merge_attention"
     | "usage_limit"
     | "extra_credits"
-    | "learnings_retired";
+    | "learnings_retired"
+    | "ready";
   tag: string;
 }
 
@@ -40,6 +41,7 @@ const KIND_CATEGORY: Record<PushPayload["kind"], PushCategory> = {
   usage_limit: "agent",
   extra_credits: "agent",
   learnings_retired: "agent",
+  ready: "agent",
 };
 
 /** A notification described by intent, not text — localized per device at send time. */
@@ -55,7 +57,8 @@ export interface NotifyInput {
     | "merge_attention"
     | "usage_limit"
     | "extra_credits"
-    | "learnings_retired";
+    | "learnings_retired"
+    | "ready";
   sessionId: string;
   tag: string;
   name: string;
@@ -91,6 +94,9 @@ export interface NotifyInput {
 export type SendResult = { statusCode?: number };
 export type SendFn = (sub: PushSubInput, payload: string) => Promise<SendResult>;
 type GenKeys = () => { publicKey: string; privateKey: string };
+
+/** Kinds that are allowed through even when reducedPushMode is on. */
+const REDUCED_ALLOWED = new Set<NotifyInput["kind"]>(["ready", "usage_limit", "extra_credits"]);
 
 const defaultSend: SendFn = (sub, payload) =>
   webpush.sendNotification(sub as webpush.PushSubscription, payload) as Promise<SendResult>;
@@ -139,6 +145,8 @@ const NOTIFY_TEXT = {
     learningsRetiredTitle: "Learnings auto-retired",
     learningsRetiredBody: (n: number) =>
       `${n} ${n === 1 ? "rule" : "rules"} auto-retired — tap to review.`,
+    readyTitle: (name: string) => `${name} — your turn`,
+    readyBody: "Waiting on you for 5s — your turn.",
   },
   de: {
     doneTitle: (name: string) => `${name} — wartet`,
@@ -180,6 +188,8 @@ const NOTIFY_TEXT = {
     learningsRetiredTitle: "Learnings automatisch zurückgezogen",
     learningsRetiredBody: (n: number) =>
       `${n} ${n === 1 ? "Regel" : "Regeln"} zurückgezogen — zum Prüfen tippen.`,
+    readyTitle: (name: string) => `${name} — du bist dran`,
+    readyBody: "Wartet seit 5s auf dich — du bist dran.",
   },
 } as const;
 
@@ -310,6 +320,8 @@ export function buildPayload(input: NotifyInput, locale: string): PushPayload {
         title: t.learningsRetiredTitle,
         body: t.learningsRetiredBody(input.retiredCount ?? 0),
       };
+    case "ready":
+      return { ...base, title: t.readyTitle(input.name), body: t.readyBody };
     default:
       return {
         ...base,
@@ -377,6 +389,7 @@ export class PushService {
     // push under userVisibleOnly:true (Android substitutes its own banner). We
     // don't touch the cooldown clock here: nothing was sent.
     if (this.isActive()) return false;
+    if (config.reducedPushMode && !REDUCED_ALLOWED.has(input.kind)) return false;
     const cooldownMs = config.pushCooldownMs;
     const key = input.cooldownKey ?? `${input.kind}:${input.sessionId}`;
     const t = this.now();
@@ -392,7 +405,9 @@ export class PushService {
     for (const row of this.store.listPushSubs()) {
       // Honor the device's category selection: a sub that muted this category
       // never receives the push (filtered server-side so it works app-closed).
-      if (!row.cats[category]) continue;
+      // Exception: "ready" bypasses the category filter unconditionally — it must
+      // reach all devices regardless of their agent/reviews/ci selection.
+      if (input.kind !== "ready" && !row.cats[category]) continue;
       if (await this.deliver(row, input)) sent = true;
     }
     if (sent && cooldownMs > 0) this.lastNotified.set(key, t);

--- a/src/push.ts
+++ b/src/push.ts
@@ -393,13 +393,7 @@ export class PushService {
     const cooldownMs = config.pushCooldownMs;
     const key = input.cooldownKey ?? `${input.kind}:${input.sessionId}`;
     const t = this.now();
-    // Suppress repeats within the window of the last send that actually fired; a
-    // sustained flap stays suppressed until a full quiet window passes. Distinct
-    // kinds (done vs blocked) live under separate keys and never collapse.
-    if (cooldownMs > 0) {
-      const last = this.lastNotified.get(key);
-      if (last !== undefined && t - last < cooldownMs) return false;
-    }
+    if (this.withinCooldown(key, t, cooldownMs)) return false;
     const category = KIND_CATEGORY[input.kind];
     let sent = false;
     for (const row of this.store.listPushSubs()) {
@@ -412,6 +406,16 @@ export class PushService {
     }
     if (sent && cooldownMs > 0) this.lastNotified.set(key, t);
     return sent;
+  }
+
+  /** True when a prior send under `key` still falls inside the cooldown window.
+   *  Suppresses repeats within the window of the last send that actually fired; a
+   *  sustained flap stays suppressed until a full quiet window passes. Distinct
+   *  kinds (done vs blocked) live under separate keys and never collapse. */
+  private withinCooldown(key: string, t: number, cooldownMs: number): boolean {
+    if (cooldownMs <= 0) return false;
+    const last = this.lastNotified.get(key);
+    return last !== undefined && t - last < cooldownMs;
   }
 
   /** Send one notification; prune dead subs, log diagnostics. Returns true if delivered. */

--- a/src/ready-notify.ts
+++ b/src/ready-notify.ts
@@ -98,10 +98,7 @@ export class ReadyNotifier {
     this.ticking = true;
     try {
       if (!this.deps.reducedMode()) {
-        // Mode OFF resets everything; the next ON re-seeds.
-        this.dwell.clear();
-        this.firstSeen.clear();
-        this.armed = false;
+        this.resetOff();
         return;
       }
 
@@ -111,56 +108,87 @@ export class ReadyNotifier {
       const git = this.deps.gitSnapshot();
       const reviewing = new Set(this.deps.reviewingIds());
       const isReviewing = (id: string) => reviewing.has(id);
-      const activeIds = new Set(sessions.map((s) => s.id));
 
-      // Prune state for sessions that disappeared.
-      for (const id of [...this.dwell.keys()]) if (!activeIds.has(id)) this.dwell.delete(id);
-      for (const id of [...this.firstSeen.keys()])
-        if (!activeIds.has(id)) this.firstSeen.delete(id);
-
-      // Warm-up baseline from first sighting.
-      for (const s of sessions) if (!this.firstSeen.has(s.id)) this.firstSeen.set(s.id, now);
+      this.syncSeen(sessions, now);
 
       // Seed on arm (off→on transition / first armed tick): mark currently-ready
       // sessions as already-notified and fire nothing this tick.
       if (!this.armed) {
-        this.armed = true;
-        for (const s of sessions) {
-          if (this.isReady(s, git[s.id], isReviewing, wb, now)) {
-            this.dwell.set(s.id, { since: now, notified: true });
-          }
-        }
+        this.seedOnArm(sessions, git, isReviewing, wb, now);
         return;
       }
 
       // Normal evaluation. Sequential awaits (no Promise.all) so `ticking` genuinely
       // serializes I/O; fine for the session counts involved.
       for (const s of sessions) {
-        const ready = this.isReady(s, git[s.id], isReviewing, wb, now);
-        const entry = this.dwell.get(s.id);
-        if (!ready) {
-          if (entry) this.dwell.delete(s.id); // resets dwell + notified
-          continue;
-        }
-        if (!entry) {
-          this.dwell.set(s.id, { since: now, notified: false });
-          continue;
-        }
-        if (entry.notified) continue;
-        if (now - entry.since < READY_DWELL_MS) continue; // dwell not met
-        if (now - (this.firstSeen.get(s.id) ?? now) < READY_WARMUP_MS) continue; // warm-up not met
-
-        const sent = await this.deps.notify({
-          kind: "ready",
-          sessionId: s.id,
-          tag: `ready:${s.id}`,
-          name: s.name ?? s.id,
-          cooldownKey: `ready:${s.id}`,
-        });
-        if (sent) entry.notified = true; // ONLY mark on a real send
+        await this.evaluateSession(s, git, isReviewing, wb, now);
       }
     } finally {
       this.ticking = false;
     }
+  }
+
+  /** Mode OFF resets everything; the next ON re-seeds. */
+  private resetOff(): void {
+    this.dwell.clear();
+    this.firstSeen.clear();
+    this.armed = false;
+  }
+
+  /** Prune state for vanished sessions, then record the warm-up baseline for new ones. */
+  private syncSeen(sessions: Session[], now: number): void {
+    const activeIds = new Set(sessions.map((s) => s.id));
+    for (const id of [...this.dwell.keys()]) if (!activeIds.has(id)) this.dwell.delete(id);
+    for (const id of [...this.firstSeen.keys()]) if (!activeIds.has(id)) this.firstSeen.delete(id);
+    // Warm-up baseline from first sighting.
+    for (const s of sessions) if (!this.firstSeen.has(s.id)) this.firstSeen.set(s.id, now);
+  }
+
+  /** First armed tick: mark currently-ready sessions already-notified, fire nothing. */
+  private seedOnArm(
+    sessions: Session[],
+    git: Record<string, GitState>,
+    isReviewing: (id: string) => boolean,
+    wb: Record<string, boolean>,
+    now: number,
+  ): void {
+    this.armed = true;
+    for (const s of sessions) {
+      if (this.isReady(s, git[s.id], isReviewing, wb, now)) {
+        this.dwell.set(s.id, { since: now, notified: true });
+      }
+    }
+  }
+
+  /** Per-session ready/entry/dwell/warm-up/fire decision; awaits the send when it fires. */
+  private async evaluateSession(
+    s: Session,
+    git: Record<string, GitState>,
+    isReviewing: (id: string) => boolean,
+    wb: Record<string, boolean>,
+    now: number,
+  ): Promise<void> {
+    const ready = this.isReady(s, git[s.id], isReviewing, wb, now);
+    const entry = this.dwell.get(s.id);
+    if (!ready) {
+      if (entry) this.dwell.delete(s.id); // resets dwell + notified
+      return;
+    }
+    if (!entry) {
+      this.dwell.set(s.id, { since: now, notified: false });
+      return;
+    }
+    if (entry.notified) return;
+    if (now - entry.since < READY_DWELL_MS) return; // dwell not met
+    if (now - (this.firstSeen.get(s.id) ?? now) < READY_WARMUP_MS) return; // warm-up not met
+
+    const sent = await this.deps.notify({
+      kind: "ready",
+      sessionId: s.id,
+      tag: `ready:${s.id}`,
+      name: s.name ?? s.id,
+      cooldownKey: `ready:${s.id}`,
+    });
+    if (sent) entry.notified = true; // ONLY mark on a real send
   }
 }

--- a/src/ready-notify.ts
+++ b/src/ready-notify.ts
@@ -1,0 +1,166 @@
+// ReadyNotifier — the "ready-after-5s" push evaluator for reducedPushMode (#896).
+//
+// While reduced-push mode is on, fire the `ready` push exactly once when a session
+// has sat continuously in the ready set for ≥READY_DWELL_MS. Four subtleties:
+//
+//  - Dwell IS the debounce. We don't push the instant a session turns ready —
+//    PR/CI state churns; a green flicker that immediately reverts shouldn't ping
+//    the operator. The session must hold ready for the full dwell window; leaving
+//    the set deletes the dwell entry, so re-entry restarts a fresh 5s.
+//
+//  - Seed-on-arm (boot + runtime toggle-on). On the first armed tick we mark every
+//    currently-ready session as already-notified WITHOUT firing. This kills the
+//    boot burst (a restart would otherwise re-announce everything ready) and the
+//    runtime mode-flip burst (turning the toggle ON shouldn't replay the backlog).
+//    Turning the mode OFF clears all state, so the next ON re-seeds.
+//
+//  - Warm-up (cold git cache). prPoller's snapshot is empty right after a session
+//    is first seen; isReadyForNotify can briefly read a session as "ready" only
+//    because git state hasn't loaded. We hold off firing until a session has been
+//    seen for READY_WARMUP_MS (one fast prPoller cycle) so the predicate runs on
+//    warm state, not a cold cache. firstSeen is per-session (pruned when a session
+//    disappears, so a re-created id warms up afresh).
+//
+//  - Send-gating. We mark a dwell entry `notified` ONLY when notify() reports a
+//    real send (returns true). push.notify returns false when the app is focused
+//    (isActive), in cooldown, or has no devices — in those cases the ping is
+//    deferred, not dropped: subsequent ticks keep trying, and the moment a send
+//    lands we mark notified and stop. (Mirrors attachUsagePush's send-gating.)
+import type { Session } from "./types";
+import type { GitState } from "./forge/types";
+import type { NotifyInput } from "./push";
+import { isReadyForNotify } from "./ready-stage";
+
+/** Continuous time a session must hold "ready" before the push fires. */
+export const READY_DWELL_MS = 5000;
+/** Time a session must have been seen before it can fire (covers the cold git cache).
+ *  One prPoller fast-poll cycle. */
+export const READY_WARMUP_MS = 15000;
+
+export interface ReadyNotifierDeps {
+  listSessions: () => Session[]; // store.list({ activeOnly: true })
+  workingBlocked: () => Record<string, boolean>; // poller.workingBlockedSnapshot()
+  gitSnapshot: () => Record<string, GitState>; // prPoller.snapshot()
+  reviewingIds: () => string[]; // critic UNION plan-gate ids
+  notify: (input: NotifyInput) => Promise<boolean>; // push.notify
+  reducedMode: () => boolean; // () => config.reducedPushMode
+  now?: () => number; // default Date.now
+  intervalMs?: number; // default 1000
+  // Injectable ONLY so the evaluator's tests stay focused on the dwell/seed/
+  // send-gating state machine (the predicate itself is covered by ready-stage.test.ts):
+  isReady?: (
+    s: Session,
+    git: GitState | undefined,
+    isReviewing: (id: string) => boolean,
+    workingBlocked: Record<string, boolean>,
+    now: number,
+  ) => boolean; // default isReadyForNotify
+}
+
+interface DwellEntry {
+  since: number;
+  notified: boolean;
+}
+
+export class ReadyNotifier {
+  private readonly deps: ReadyNotifierDeps;
+  private readonly now: () => number;
+  private readonly intervalMs: number;
+  private readonly isReady: NonNullable<ReadyNotifierDeps["isReady"]>;
+
+  private dwell = new Map<string, DwellEntry>();
+  private firstSeen = new Map<string, number>();
+  private armed = false;
+  private ticking = false;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(deps: ReadyNotifierDeps) {
+    this.deps = deps;
+    this.now = deps.now ?? Date.now;
+    this.intervalMs = deps.intervalMs ?? 1000;
+    this.isReady = deps.isReady ?? isReadyForNotify;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => void this.tick(), this.intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async tick(): Promise<void> {
+    if (this.ticking) return; // notify awaits I/O; never overlap two ticks
+    this.ticking = true;
+    try {
+      if (!this.deps.reducedMode()) {
+        // Mode OFF resets everything; the next ON re-seeds.
+        this.dwell.clear();
+        this.firstSeen.clear();
+        this.armed = false;
+        return;
+      }
+
+      const now = this.now();
+      const sessions = this.deps.listSessions();
+      const wb = this.deps.workingBlocked();
+      const git = this.deps.gitSnapshot();
+      const reviewing = new Set(this.deps.reviewingIds());
+      const isReviewing = (id: string) => reviewing.has(id);
+      const activeIds = new Set(sessions.map((s) => s.id));
+
+      // Prune state for sessions that disappeared.
+      for (const id of [...this.dwell.keys()]) if (!activeIds.has(id)) this.dwell.delete(id);
+      for (const id of [...this.firstSeen.keys()])
+        if (!activeIds.has(id)) this.firstSeen.delete(id);
+
+      // Warm-up baseline from first sighting.
+      for (const s of sessions) if (!this.firstSeen.has(s.id)) this.firstSeen.set(s.id, now);
+
+      // Seed on arm (off→on transition / first armed tick): mark currently-ready
+      // sessions as already-notified and fire nothing this tick.
+      if (!this.armed) {
+        this.armed = true;
+        for (const s of sessions) {
+          if (this.isReady(s, git[s.id], isReviewing, wb, now)) {
+            this.dwell.set(s.id, { since: now, notified: true });
+          }
+        }
+        return;
+      }
+
+      // Normal evaluation. Sequential awaits (no Promise.all) so `ticking` genuinely
+      // serializes I/O; fine for the session counts involved.
+      for (const s of sessions) {
+        const ready = this.isReady(s, git[s.id], isReviewing, wb, now);
+        const entry = this.dwell.get(s.id);
+        if (!ready) {
+          if (entry) this.dwell.delete(s.id); // resets dwell + notified
+          continue;
+        }
+        if (!entry) {
+          this.dwell.set(s.id, { since: now, notified: false });
+          continue;
+        }
+        if (entry.notified) continue;
+        if (now - entry.since < READY_DWELL_MS) continue; // dwell not met
+        if (now - (this.firstSeen.get(s.id) ?? now) < READY_WARMUP_MS) continue; // warm-up not met
+
+        const sent = await this.deps.notify({
+          kind: "ready",
+          sessionId: s.id,
+          tag: `ready:${s.id}`,
+          name: s.name ?? s.id,
+          cooldownKey: `ready:${s.id}`,
+        });
+        if (sent) entry.notified = true; // ONLY mark on a real send
+      }
+    } finally {
+      this.ticking = false;
+    }
+  }
+}

--- a/src/ready-stage.ts
+++ b/src/ready-stage.ts
@@ -9,7 +9,7 @@ import { isMerging } from "./rundown-core";
  *  A session herdr reports "blocked" but the server flagged as working-while-blocked
  *  renders with the full working treatment (upgrades blocked → running).
  *  The flag only ever upgrades blocked — a stale entry on a non-blocked session is inert. */
-export function displayStatus(
+function displayStatus(
   s: Pick<Session, "id" | "status">,
   workingBlocked: Record<string, boolean>,
 ): SessionStatus {
@@ -17,7 +17,7 @@ export function displayStatus(
 }
 
 /** Lifecycle stage of a session — mirrors herd-partition.ts's Stage type. */
-export type Stage =
+type Stage =
   | "merged"
   | "merging"
   | "ready"
@@ -59,7 +59,7 @@ function handoffStage(g: GitState): Stage {
  *  Port of herd-partition.ts's stageOf.
  *  Precedence: merged > merging > ready > reviewerRunning > ciRunning > ciFailed >
  *  (greenIdle → draftAwaitingSignoff | waitingOnReviewer | waitingOnMerger | awaitingMerge) > active. */
-export function stageOf(
+function stageOf(
   s: Session,
   g: GitState | undefined,
   isReviewing: (id: string) => boolean,

--- a/src/ready-stage.ts
+++ b/src/ready-stage.ts
@@ -1,0 +1,106 @@
+// DRIFT: keep in sync with ui/src/lib/components/herd-partition.ts (stageOf/shownSessions ready filter)
+// + ui/src/lib/display-status.ts
+// Intentional delta vs the UI: `merged` is also excluded from isReadyForNotify (terminal ≠ your turn).
+import type { Session, SessionStatus } from "./types";
+import type { GitState } from "./forge/types";
+import { isMerging } from "./rundown-core";
+
+/** Display-side session status — port of ui/src/lib/display-status.ts.
+ *  A session herdr reports "blocked" but the server flagged as working-while-blocked
+ *  renders with the full working treatment (upgrades blocked → running).
+ *  The flag only ever upgrades blocked — a stale entry on a non-blocked session is inert. */
+export function displayStatus(
+  s: Pick<Session, "id" | "status">,
+  workingBlocked: Record<string, boolean>,
+): SessionStatus {
+  return s.status === "blocked" && workingBlocked[s.id] ? "running" : s.status;
+}
+
+/** Lifecycle stage of a session — mirrors herd-partition.ts's Stage type. */
+export type Stage =
+  | "merged"
+  | "merging"
+  | "ready"
+  | "reviewerRunning"
+  | "ciRunning"
+  | "ciFailed"
+  | "draftAwaitingSignoff"
+  | "waitingOnReviewer"
+  | "waitingOnMerger"
+  | "awaitingMerge"
+  | "active";
+
+/** Terminal / in-flight stages that win before the green-idle handoff decision, or null
+ *  when none apply. Port of herd-partition.ts's terminalStage. */
+function terminalStage(
+  s: Session,
+  g: GitState | undefined,
+  isReviewing: (id: string) => boolean,
+  now: number,
+): Stage | null {
+  if (g?.state === "merged") return "merged";
+  if (isMerging(s, now)) return "merging";
+  if (s.readyToMerge) return "ready";
+  if (isReviewing(s.id)) return "reviewerRunning";
+  if (g?.state === "open" && g.checks === "pending") return "ciRunning";
+  if (g?.state === "open" && g.checks === "failure") return "ciFailed";
+  return null;
+}
+
+/** Bucket a green, idle (handed-off) PR. Port of herd-partition.ts's handoffStage. */
+function handoffStage(g: GitState): Stage {
+  if (g.isDraft) return "draftAwaitingSignoff";
+  if (g.handoff === "reviewer") return "waitingOnReviewer";
+  if (g.handoff === "merger") return "waitingOnMerger";
+  return "awaitingMerge";
+}
+
+/** Classify one session into its lifecycle stage (first-match precedence).
+ *  Port of herd-partition.ts's stageOf.
+ *  Precedence: merged > merging > ready > reviewerRunning > ciRunning > ciFailed >
+ *  (greenIdle → draftAwaitingSignoff | waitingOnReviewer | waitingOnMerger | awaitingMerge) > active. */
+export function stageOf(
+  s: Session,
+  g: GitState | undefined,
+  isReviewing: (id: string) => boolean,
+  now: number,
+): Stage {
+  const terminal = terminalStage(s, g, isReviewing, now);
+  if (terminal) return terminal;
+  // Raw status by design: a working-while-blocked session (display "running") is raw
+  // "blocked" — both are excluded from greenIdle, so the display flag can't change
+  // the partition and doesn't need threading through here.
+  const greenIdle =
+    g?.state === "open" &&
+    g.checks === "success" &&
+    s.status !== "running" &&
+    s.status !== "blocked";
+  return greenIdle ? handoffStage(g) : "active";
+}
+
+/** Stages the "ready" lens hides — the session is NOT awaiting the operator.
+ *  Delta from NOT_YOUR_TURN in herd-partition.ts: also excludes `merged`
+ *  (terminal ≠ your turn) for the push-notification evaluator. */
+const NOT_NOTIFY: ReadonlySet<Stage> = new Set([
+  "ciRunning",
+  "waitingOnReviewer",
+  "waitingOnMerger",
+  "merging",
+  "merged", // intentional delta: terminal stage excluded from push notify
+]);
+
+/** Ready-for-notify predicate. Equivalent to the UI's shownSessions(filter="ready") filter:
+ *  displayStatus !== "running" && !isReviewing(s.id) && stage ∉ NOT_NOTIFY.
+ *  Intentional delta vs the UI's NOT_YOUR_TURN: also excludes `merged`. */
+export function isReadyForNotify(
+  s: Session,
+  git: GitState | undefined,
+  isReviewing: (id: string) => boolean,
+  workingBlocked: Record<string, boolean>,
+  now: number,
+): boolean {
+  if (displayStatus(s, workingBlocked) === "running") return false;
+  if (isReviewing(s.id)) return false;
+  const stage = stageOf(s, git, isReviewing, now);
+  return !NOT_NOTIFY.has(stage);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -2733,6 +2733,7 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       repoRoot: config.repoRoot,
       repoRootDisplay: collapseHome(config.repoRoot),
       remoteControlAtStartup: config.remoteControlAtStartup,
+      reducedPushMode: config.reducedPushMode,
       sessionHousekeepingEnabled: config.sessionHousekeepingEnabled,
       prReviewCyclesCap: config.prReviewCyclesCap,
       planReviewCyclesCap: config.planReviewCyclesCap,
@@ -2784,6 +2785,7 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
 // validates the value, live-updates config, and persists to the store.
 const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response][] = [
   ["remoteControlAtStartup", putRemoteControl],
+  ["reducedPushMode", putReducedPushMode],
   ["sessionHousekeepingEnabled", putSessionHousekeeping],
   ["prReviewCyclesCap", putPrReviewCyclesCap],
   ["planReviewCyclesCap", putPlanReviewCyclesCap],
@@ -2803,6 +2805,15 @@ function putRemoteControl(value: unknown, deps: Ctx["deps"]): Response {
   config.remoteControlAtStartup = value; // live: next spawn picks it up
   deps.store.setSetting("remoteControlAtStartup", value ? "1" : "0"); // persist
   return json({ remoteControlAtStartup: config.remoteControlAtStartup });
+}
+
+function putReducedPushMode(value: unknown, deps: Ctx["deps"]): Response {
+  if (typeof value !== "boolean") {
+    return json({ error: "reducedPushMode must be a boolean" }, 400);
+  }
+  config.reducedPushMode = value; // live: the push gate reads it immediately
+  deps.store.setSetting("reducedPushMode", value ? "1" : "0"); // persist
+  return json({ reducedPushMode: config.reducedPushMode });
 }
 
 function putSessionHousekeeping(value: unknown, deps: Ctx["deps"]): Response {

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { test, expect, afterEach } from "bun:test";
 import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
 import {
@@ -16,6 +16,7 @@ import {
   type SendFn,
 } from "../src/push";
 import type { BlockReason } from "../src/blocked";
+import { config } from "../src/config";
 
 const sub = (endpoint: string) => ({ endpoint, keys: { p256dh: "p", auth: "a" } });
 const keys = () => ({ publicKey: "PUB", privateKey: "PRIV" });
@@ -967,5 +968,139 @@ test("attachMergePush notifies on merge_error and rebase_cap, ignores other stat
     desig: "TASK-09",
     tag: "merge_attention:sess-c",
     cooldownKey: "merge_error:sess-c",
+  });
+});
+
+// ── reducedPushMode tests ─────────────────────────────────────────────────────
+
+let _savedReducedPushMode: boolean;
+// Save and restore config.reducedPushMode around each test that mutates it.
+// afterEach runs for all tests; guard ensures only our mutation is restored.
+afterEach(() => {
+  if (_savedReducedPushMode !== undefined) {
+    config.reducedPushMode = _savedReducedPushMode;
+    (_savedReducedPushMode as unknown) = undefined;
+  }
+});
+function setReducedMode(on: boolean): void {
+  _savedReducedPushMode = config.reducedPushMode;
+  config.reducedPushMode = on;
+}
+
+test("reducedPushMode ON: drops blocked, done, ci, review, merge_attention, learnings_retired", async () => {
+  setReducedMode(true);
+  let count = 0;
+  const send: SendFn = async () => {
+    count++;
+    return {};
+  };
+  const { store, push } = svc(send);
+  store.putPushSub(sub("e1"), "");
+
+  await push.notify({ kind: "blocked", sessionId: "s", tag: "t", name: "T" });
+  await push.notify({ kind: "done", sessionId: "s", tag: "t", name: "T" });
+  await push.notify({ kind: "ci", sessionId: "s", tag: "t", name: "T", ciState: "success" });
+  await push.notify({ kind: "review", sessionId: "s", tag: "t", name: "T" });
+  await push.notify({
+    kind: "merge_attention",
+    sessionId: "s",
+    tag: "t",
+    name: "T",
+    mergeState: "merge_error",
+    desig: "T",
+  });
+  await push.notify({
+    kind: "learnings_retired",
+    sessionId: "",
+    tag: "lr",
+    name: "learnings",
+    retiredCount: 1,
+  });
+  expect(count).toBe(0);
+});
+
+test("reducedPushMode ON: allows ready, usage_limit, extra_credits through", async () => {
+  setReducedMode(true);
+  const sent: string[] = [];
+  const send: SendFn = async (_s, payload) => {
+    sent.push(payload);
+    return {};
+  };
+  const { store, push } = svc(send);
+  store.putPushSub(sub("e1"), "");
+
+  await push.notify({ kind: "ready", sessionId: "s", tag: "t", name: "TASK-01" });
+  await push.notify({ kind: "usage_limit", sessionId: "", tag: "ul", name: "5h", pct: 85 });
+  await push.notify({
+    kind: "extra_credits",
+    sessionId: "",
+    tag: "ec",
+    name: "credits",
+    creditSpent: 1,
+    creditCap: 50,
+    currency: "$",
+  });
+  expect(sent.length).toBe(3);
+  expect(sent[0]).toContain('"kind":"ready"');
+  expect(sent[1]).toContain('"kind":"usage_limit"');
+  expect(sent[2]).toContain('"kind":"extra_credits"');
+});
+
+test("reducedPushMode OFF: blocked sends normally (guard is inert)", async () => {
+  setReducedMode(false);
+  const sent: string[] = [];
+  const send: SendFn = async (_s, payload) => {
+    sent.push(payload);
+    return {};
+  };
+  const { store, push } = svc(send);
+  store.putPushSub(sub("e1"), "");
+  await push.notify({ kind: "blocked", sessionId: "s", tag: "t", name: "T" });
+  expect(sent.length).toBe(1);
+  expect(sent[0]).toContain('"kind":"blocked"');
+});
+
+test("ready bypasses category filter unconditionally (reducedPushMode ON)", async () => {
+  setReducedMode(true);
+  const sent: string[] = [];
+  const send: SendFn = async (s) => {
+    sent.push(s.endpoint);
+    return {};
+  };
+  const { store, push } = svc(send);
+  // Device has all categories muted
+  store.putPushSub(sub("all-muted"), "");
+  store.setPushPrefs("all-muted", { agent: false, reviews: false, ci: false });
+  await push.notify({ kind: "ready", sessionId: "s", tag: "t", name: "TASK-01" });
+  expect(sent).toEqual(["all-muted"]);
+});
+
+test("ready bypasses category filter even when reducedPushMode is OFF", async () => {
+  setReducedMode(false);
+  const sent: string[] = [];
+  const send: SendFn = async (s) => {
+    sent.push(s.endpoint);
+    return {};
+  };
+  const { store, push } = svc(send);
+  // Device has agent muted (ready's category is "agent")
+  store.putPushSub(sub("agent-muted"), "");
+  store.setPushPrefs("agent-muted", { agent: false, reviews: true, ci: true });
+  await push.notify({ kind: "ready", sessionId: "s", tag: "t", name: "TASK-01" });
+  // category bypass is unconditional on kind, regardless of mode
+  expect(sent).toEqual(["agent-muted"]);
+});
+
+test("buildPayload ready: localizes title + body in en and de", () => {
+  const ready: NotifyInput = { kind: "ready", sessionId: "s", tag: "t", name: "TASK-01" };
+  expect(buildPayload(ready, "en")).toMatchObject({
+    title: "TASK-01 — your turn",
+    body: "Waiting on you for 5s — your turn.",
+    kind: "ready",
+  });
+  expect(buildPayload(ready, "de")).toMatchObject({
+    title: "TASK-01 — du bist dran",
+    body: "Wartet seit 5s auf dich — du bist dran.",
+    kind: "ready",
   });
 });

--- a/test/ready-notify.test.ts
+++ b/test/ready-notify.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "bun:test";
+import { ReadyNotifier, READY_DWELL_MS, READY_WARMUP_MS } from "../src/ready-notify";
+import type { ReadyNotifierDeps } from "../src/ready-notify";
+import type { Session } from "../src/types";
+import type { NotifyInput } from "../src/push";
+
+// Minimal Session stub — the fake `isReady` ignores the contents, so only `id`/`name` matter.
+function sess(id: string): Session {
+  return { id, name: id } as Session;
+}
+
+interface Harness {
+  notifier: ReadyNotifier;
+  notifyCalls: NotifyInput[];
+  set: (...ids: string[]) => void;
+  advance: (ms: number) => void;
+  setSessions: (...ids: string[]) => void;
+  setReducedMode: (on: boolean) => void;
+  setNotifyResult: (ok: boolean) => void;
+  now: () => number;
+}
+
+function makeHarness(opts?: { sessions?: string[]; ready?: string[] }): Harness {
+  let t = 1_000_000;
+  let reduced = true;
+  let notifyResult = true;
+  const readyIds = new Set<string>(opts?.ready ?? []);
+  let sessionIds = new Set<string>(opts?.sessions ?? []);
+  const notifyCalls: NotifyInput[] = [];
+
+  const deps: ReadyNotifierDeps = {
+    listSessions: () => [...sessionIds].map(sess),
+    workingBlocked: () => ({}),
+    gitSnapshot: () => ({}),
+    reviewingIds: () => [],
+    notify: async (input) => {
+      notifyCalls.push(input);
+      return notifyResult;
+    },
+    reducedMode: () => reduced,
+    now: () => t,
+    isReady: (s) => readyIds.has(s.id),
+  };
+
+  return {
+    notifier: new ReadyNotifier(deps),
+    notifyCalls,
+    set: (...ids) => {
+      readyIds.clear();
+      for (const id of ids) readyIds.add(id);
+    },
+    advance: (ms) => {
+      t += ms;
+    },
+    setSessions: (...ids) => {
+      sessionIds = new Set(ids);
+    },
+    setReducedMode: (on) => {
+      reduced = on;
+    },
+    setNotifyResult: (ok) => {
+      notifyResult = ok;
+    },
+    now: () => t,
+  };
+}
+
+const readyCalls = (h: Harness) => h.notifyCalls.filter((c) => c.kind === "ready");
+
+describe("ReadyNotifier", () => {
+  it("exports the documented constants", () => {
+    expect(READY_DWELL_MS).toBe(5000);
+    expect(READY_WARMUP_MS).toBe(15000);
+  });
+
+  it("seed/boot grace: a session already ready at arm never fires", async () => {
+    const h = makeHarness({ sessions: ["a"], ready: ["a"] });
+    await h.notifier.tick(); // arm tick — seeds "a" as notified, no fire
+    expect(readyCalls(h).length).toBe(0);
+    // Even after dwell + warm-up elapse it must stay silent (seeded notified).
+    h.advance(READY_WARMUP_MS + READY_DWELL_MS + 1000);
+    await h.notifier.tick();
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0);
+  });
+
+  it("new entrant fires exactly once after warm-up + dwell", async () => {
+    const h = makeHarness({ sessions: ["a"], ready: [] });
+    await h.notifier.tick(); // arm tick (nothing ready → nothing seeded)
+    // Satisfy warm-up first (firstSeen baseline was set on arm tick).
+    h.advance(READY_WARMUP_MS + 1);
+    h.set("a"); // now ready → dwell starts this tick
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0); // dwell not met
+    h.advance(READY_DWELL_MS + 1);
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(1);
+    expect(readyCalls(h)[0]).toMatchObject({ kind: "ready", sessionId: "a", tag: "ready:a" });
+    // Further ticks: no repeat.
+    await h.notifier.tick();
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(1);
+  });
+
+  it("dwell: <5s no fire, crossing 5s one fire (warm-up already met)", async () => {
+    const h = makeHarness({ sessions: ["a"], ready: [] });
+    await h.notifier.tick(); // arm
+    h.advance(READY_WARMUP_MS + 1); // warm-up satisfied
+    h.set("a");
+    await h.notifier.tick(); // dwell starts
+    h.advance(READY_DWELL_MS - 1);
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0);
+    h.advance(2);
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(1);
+  });
+
+  it("warm-up: a session leaving before warm-up never fires", async () => {
+    const h = makeHarness({ sessions: ["a"], ready: [] });
+    await h.notifier.tick(); // arm, firstSeen("a") = now
+    h.set("a"); // ready immediately
+    await h.notifier.tick(); // dwell starts
+    h.advance(READY_DWELL_MS + 1); // dwell met but warm-up NOT met
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0); // warm-up gate holds
+    h.set(); // leaves the ready set before warm-up elapses
+    await h.notifier.tick();
+    h.advance(READY_WARMUP_MS);
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0);
+  });
+
+  it("warm-up: ready does not fire until warm-up elapses even with dwell met", async () => {
+    const h = makeHarness({ sessions: ["a"], ready: [] });
+    await h.notifier.tick(); // arm
+    h.set("a");
+    await h.notifier.tick(); // dwell starts
+    h.advance(READY_DWELL_MS + 1); // dwell met, warm-up not
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0);
+    h.advance(READY_WARMUP_MS); // now warm-up met too
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(1);
+  });
+
+  it("send-gating: notify=false (focused) defers, never drops; flips to fire once", async () => {
+    const h = makeHarness({ sessions: ["a"], ready: [] });
+    h.setNotifyResult(false);
+    await h.notifier.tick(); // arm
+    h.advance(READY_WARMUP_MS + 1);
+    h.set("a");
+    await h.notifier.tick(); // dwell starts
+    h.advance(READY_DWELL_MS + 1);
+    await h.notifier.tick();
+    await h.notifier.tick();
+    // notify called but returned false → notified stays false → keeps trying.
+    expect(readyCalls(h).length).toBeGreaterThanOrEqual(2);
+    const callsBefore = readyCalls(h).length;
+    // Flip to focused-off → real send.
+    h.setNotifyResult(true);
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(callsBefore + 1);
+    // Now notified → no more calls.
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(callsBefore + 1);
+  });
+
+  it("re-entry: leaving and re-entering restarts the dwell", async () => {
+    const h = makeHarness({ sessions: ["a"], ready: [] });
+    await h.notifier.tick(); // arm
+    h.advance(READY_WARMUP_MS + 1); // warm-up satisfied for life
+    h.set("a");
+    await h.notifier.tick(); // dwell starts
+    h.advance(READY_DWELL_MS - 1);
+    h.set(); // leaves before firing → entry deleted
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0);
+    h.set("a"); // re-enters → fresh dwell
+    await h.notifier.tick();
+    h.advance(READY_DWELL_MS - 1);
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0); // fresh dwell not yet met
+    h.advance(2);
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(1);
+  });
+
+  it("mode off: never fires; toggling off mid-dwell re-seeds (no fire) on re-enable", async () => {
+    const h = makeHarness({ sessions: ["a"], ready: ["a"] });
+    h.setReducedMode(false);
+    await h.notifier.tick();
+    h.advance(READY_WARMUP_MS + READY_DWELL_MS + 1000);
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0);
+
+    // Turn on → arm tick seeds "a" (already ready) as notified.
+    h.setReducedMode(true);
+    await h.notifier.tick();
+    h.advance(READY_WARMUP_MS + READY_DWELL_MS + 1000);
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0);
+
+    // Mid-flight: a NEW session arrives and reaches ready, mid-dwell, then mode toggles off.
+    h.setSessions("a", "b");
+    h.set("a", "b");
+    await h.notifier.tick(); // b dwell starts
+    h.advance(READY_DWELL_MS - 1);
+    h.setReducedMode(false); // clears state mid-dwell
+    await h.notifier.tick();
+    h.setReducedMode(true); // re-arm → re-seed b (ready) as notified
+    await h.notifier.tick();
+    h.advance(READY_WARMUP_MS + READY_DWELL_MS + 1000);
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0); // re-seeded, must not fire
+  });
+
+  it("prunes dwell/firstSeen for sessions that disappear", async () => {
+    const h = makeHarness({ sessions: ["a"], ready: [] });
+    await h.notifier.tick(); // arm
+    h.advance(READY_WARMUP_MS + 1);
+    h.set("a");
+    await h.notifier.tick(); // dwell for a
+    h.setSessions(); // a disappears
+    h.set();
+    await h.notifier.tick();
+    // a comes back as a brand-new session → warm-up restarts (firstSeen pruned).
+    h.setSessions("a");
+    h.set("a");
+    await h.notifier.tick(); // firstSeen(a)=now, dwell starts
+    h.advance(READY_DWELL_MS + 1); // dwell met but fresh warm-up not
+    await h.notifier.tick();
+    expect(readyCalls(h).length).toBe(0);
+  });
+});

--- a/test/ready-stage.test.ts
+++ b/test/ready-stage.test.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect } from "bun:test";
+import { isReadyForNotify } from "../src/ready-stage";
+import type { Session } from "../src/types";
+import type { GitState } from "../src/forge/types";
+
+const NOW = 1_700_000_000_000; // fixed epoch
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "s1",
+    desig: "TASK-01",
+    name: "test",
+    prompt: "do something",
+    repoPath: "/repo",
+    baseBranch: "main",
+    branch: "shepherd/task-01",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "h1",
+    herdrAgentId: "a1",
+    claudeSessionId: "",
+    model: null,
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    mergeTrainPrs: null,
+    mergingPrNumber: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: null,
+    research: false,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    autoMergeRebaseHead: null,
+    auto: false,
+    issueNumber: null,
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    status: "idle",
+    lastState: "idle",
+    createdAt: NOW - 10_000,
+    updatedAt: NOW - 1_000,
+    archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
+    ...overrides,
+  } as Session;
+}
+
+function makeGit(overrides: Partial<GitState> = {}): GitState {
+  return {
+    kind: "github",
+    state: "open",
+    checks: "none",
+    deployConfigured: false,
+    ...overrides,
+  } as GitState;
+}
+
+const noReview: (_id: string) => boolean = () => false;
+const noBlocked: Record<string, boolean> = {};
+
+describe("isReadyForNotify", () => {
+  test("plain idle session, no git → READY", () => {
+    const s = makeSession({ status: "idle" });
+    expect(isReadyForNotify(s, undefined, noReview, noBlocked, NOW)).toBe(true);
+  });
+
+  test("running session → NOT ready", () => {
+    const s = makeSession({ status: "running" });
+    expect(isReadyForNotify(s, undefined, noReview, noBlocked, NOW)).toBe(false);
+  });
+
+  test("working-while-blocked (status=blocked + workingBlocked[id]=true) → NOT ready", () => {
+    const s = makeSession({ status: "blocked" });
+    const wb = { s1: true };
+    expect(isReadyForNotify(s, undefined, noReview, wb, NOW)).toBe(false);
+  });
+
+  test("isReviewing(id)=true → NOT ready", () => {
+    const s = makeSession({ status: "idle" });
+    const isReviewing = (id: string) => id === "s1";
+    expect(isReadyForNotify(s, undefined, isReviewing, noBlocked, NOW)).toBe(false);
+  });
+
+  test("open PR + checks pending (ciRunning) → NOT ready", () => {
+    const s = makeSession({ status: "idle" });
+    const git = makeGit({ state: "open", checks: "pending" });
+    expect(isReadyForNotify(s, git, noReview, noBlocked, NOW)).toBe(false);
+  });
+
+  test("open PR + checks failure (ciFailed) → READY (failed CI is your turn)", () => {
+    const s = makeSession({ status: "idle" });
+    const git = makeGit({ state: "open", checks: "failure" });
+    expect(isReadyForNotify(s, git, noReview, noBlocked, NOW)).toBe(true);
+  });
+
+  test("open PR + checks success + idle + handoff=reviewer (waitingOnReviewer) → NOT ready", () => {
+    const s = makeSession({ status: "idle" });
+    const git = makeGit({ state: "open", checks: "success", handoff: "reviewer" });
+    expect(isReadyForNotify(s, git, noReview, noBlocked, NOW)).toBe(false);
+  });
+
+  test("open PR + checks success + idle + handoff=merger (waitingOnMerger) → NOT ready", () => {
+    const s = makeSession({ status: "idle" });
+    const git = makeGit({ state: "open", checks: "success", handoff: "merger" });
+    expect(isReadyForNotify(s, git, noReview, noBlocked, NOW)).toBe(false);
+  });
+
+  test("open PR + checks success + idle, no handoff (awaitingMerge) → READY", () => {
+    const s = makeSession({ status: "idle" });
+    const git = makeGit({ state: "open", checks: "success" });
+    expect(isReadyForNotify(s, git, noReview, noBlocked, NOW)).toBe(true);
+  });
+
+  test("open PR + checks success + idle + isDraft (draftAwaitingSignoff) → READY", () => {
+    const s = makeSession({ status: "idle" });
+    const git = makeGit({ state: "open", checks: "success", isDraft: true });
+    expect(isReadyForNotify(s, git, noReview, noBlocked, NOW)).toBe(true);
+  });
+
+  test("readyToMerge=true (ready stage) → READY", () => {
+    const s = makeSession({ status: "idle", readyToMerge: true });
+    expect(isReadyForNotify(s, undefined, noReview, noBlocked, NOW)).toBe(true);
+  });
+
+  test("mergingSince=now (merging) → NOT ready", () => {
+    const s = makeSession({ status: "idle", mergingSince: NOW });
+    expect(isReadyForNotify(s, undefined, noReview, noBlocked, NOW)).toBe(false);
+  });
+
+  test("git.state=merged → NOT ready (intentional delta: merged excluded)", () => {
+    const s = makeSession({ status: "idle" });
+    const git = makeGit({ state: "merged" });
+    // Regression anchor: must fail if the merged exclusion is removed
+    expect(isReadyForNotify(s, git, noReview, noBlocked, NOW)).toBe(false);
+  });
+});

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -12,6 +12,7 @@ let tmp: string;
 let savedRoot: string;
 let savedCeiling: string;
 let savedRc: boolean;
+let savedRpm: boolean;
 let savedHk: boolean;
 let savedPrCap: number;
 let savedPlanCap: number;
@@ -28,6 +29,7 @@ beforeEach(() => {
   savedRoot = config.repoRoot; // PUT mutates the shared config; restore after
   savedCeiling = config.rootCeiling;
   savedRc = config.remoteControlAtStartup;
+  savedRpm = config.reducedPushMode;
   savedHk = config.sessionHousekeepingEnabled;
   savedPrCap = config.prReviewCyclesCap;
   savedPlanCap = config.planReviewCyclesCap;
@@ -47,6 +49,7 @@ afterEach(() => {
   config.repoRoot = savedRoot;
   config.rootCeiling = savedCeiling;
   config.remoteControlAtStartup = savedRc;
+  config.reducedPushMode = savedRpm;
   config.sessionHousekeepingEnabled = savedHk;
   config.prReviewCyclesCap = savedPrCap;
   config.planReviewCyclesCap = savedPlanCap;
@@ -223,6 +226,29 @@ test("PUT /api/settings toggles remoteControlAtStartup, persists, leaves repoRoo
 test("PUT /api/settings rejects a non-boolean remoteControlAtStartup", async () => {
   const { app } = harness();
   const res = await put(app, { remoteControlAtStartup: "yes" });
+  expect(res.status).toBe(400);
+});
+
+test('PUT /api/settings toggles reducedPushMode, persists ("1"/"0"), leaves repoRoot intact', async () => {
+  config.repoRoot = tmp;
+  config.reducedPushMode = false;
+  const { app, store } = harness();
+  const res = await put(app, { reducedPushMode: true });
+  expect(res.status).toBe(200);
+  expect((await res.json()).reducedPushMode).toBe(true);
+  expect(config.reducedPushMode).toBe(true); // live
+  expect(store.getSetting("reducedPushMode")).toBe("1"); // persisted as "1"/"0"
+  expect(config.repoRoot).toBe(tmp); // a reducedPushMode patch must not touch the repo root
+  // reflected by GET, and toggling back persists "0"
+  const got = await (await app.fetch(new Request("http://x/api/settings"))).json();
+  expect(got.reducedPushMode).toBe(true);
+  await put(app, { reducedPushMode: false });
+  expect(store.getSetting("reducedPushMode")).toBe("0");
+});
+
+test("PUT /api/settings rejects a non-boolean reducedPushMode", async () => {
+  const { app } = harness();
+  const res = await put(app, { reducedPushMode: "yes" });
   expect(res.status).toBe(400);
 });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1691,5 +1691,11 @@
   "learnings_recur_promote_done": "Regel zu deiner globalen CLAUDE.md hinzugefügt.",
   "learnings_recur_promote_failed": "Schreiben in deine globale CLAUDE.md fehlgeschlagen.",
   "feat_learnings_promote_global_title": "Eine Regel global per Klick übernehmen",
-  "feat_learnings_promote_global_body": "Ein repoübergreifender Wiederholungsvorschlag lässt sich jetzt mit einem abgesicherten Klick (zweistufige Bestätigung) direkt in deine benutzerglobale ~/.claude/CLAUDE.md schreiben – ohne PR, gültig für jedes Repo."
+  "feat_learnings_promote_global_body": "Ein repoübergreifender Wiederholungsvorschlag lässt sich jetzt mit einem abgesicherten Klick (zweistufige Bestätigung) direkt in deine benutzerglobale ~/.claude/CLAUDE.md schreiben – ohne PR, gültig für jedes Repo.",
+  "settings_reduced_push_title": "Reduzierte Benachrichtigungen",
+  "settings_reduced_push_hint": "Schaltet alle Benachrichtigungen stumm außer einer Sitzung, die 5s auf dich wartet (Nutzungs- und Kostenhinweise kommen weiterhin).",
+  "settings_reduced_push_on": "An",
+  "settings_reduced_push_off": "Aus",
+  "settings_reduced_push_disabled_note": "Reduzierter Modus: nur Benachrichtigungen für „seit 5s wartend“ werden gesendet.",
+  "settings_reduced_push_save_failed": "Einstellung für reduzierte Benachrichtigungen konnte nicht gespeichert werden."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1697,5 +1697,7 @@
   "settings_reduced_push_on": "An",
   "settings_reduced_push_off": "Aus",
   "settings_reduced_push_disabled_note": "Reduzierter Modus: nur Benachrichtigungen für „seit 5s wartend“ werden gesendet.",
-  "settings_reduced_push_save_failed": "Einstellung für reduzierte Benachrichtigungen konnte nicht gespeichert werden."
+  "settings_reduced_push_save_failed": "Einstellung für reduzierte Benachrichtigungen konnte nicht gespeichert werden.",
+  "feat_reduced_push_title": "Reduzierter Benachrichtigungsmodus",
+  "feat_reduced_push_body": "Ein neuer globaler Schalter unter Einstellungen → Gerät schaltet alle Push-Benachrichtigungen stumm — bis auf eine: eine Sitzung, die seit 5 Sekunden auf dich wartet. Nutzungs- und Kostenhinweise kommen weiterhin durch. Aktiviere ihn für einen ruhigen Tag, an dem die einzige Meldung „etwas braucht dich und hat sich nicht von selbst erledigt“ lautet."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1691,5 +1691,11 @@
   "learnings_recur_promote_done": "Rule added to your global CLAUDE.md.",
   "learnings_recur_promote_failed": "Couldn't write to your global CLAUDE.md.",
   "feat_learnings_promote_global_title": "One-click promote a rule globally",
-  "feat_learnings_promote_global_body": "A cross-repo recurrence suggestion can now be written straight into your user-global ~/.claude/CLAUDE.md with one guarded click (a two-step confirm) — no PR, applied to every repo."
+  "feat_learnings_promote_global_body": "A cross-repo recurrence suggestion can now be written straight into your user-global ~/.claude/CLAUDE.md with one guarded click (a two-step confirm) — no PR, applied to every repo.",
+  "settings_reduced_push_title": "Reduced notifications",
+  "settings_reduced_push_hint": "Mute every notification except a session waiting on you for 5s (usage and cost alerts still come through).",
+  "settings_reduced_push_on": "On",
+  "settings_reduced_push_off": "Off",
+  "settings_reduced_push_disabled_note": "Reduced mode: only ready-after-5s notifications are sent.",
+  "settings_reduced_push_save_failed": "Couldn't save reduced notifications setting."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1697,5 +1697,7 @@
   "settings_reduced_push_on": "On",
   "settings_reduced_push_off": "Off",
   "settings_reduced_push_disabled_note": "Reduced mode: only ready-after-5s notifications are sent.",
-  "settings_reduced_push_save_failed": "Couldn't save reduced notifications setting."
+  "settings_reduced_push_save_failed": "Couldn't save reduced notifications setting.",
+  "feat_reduced_push_title": "Reduced notifications mode",
+  "feat_reduced_push_body": "A new global switch in Settings → Device silences every push notification except one: a session that's been waiting on you for 5 seconds. Usage and cost alerts still come through. Turn it on for a low-noise day where the only banner you get is \"something needs you and didn't resolve itself\"."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -166,6 +166,10 @@ export const putUsageHoldPct = (pct: number): Promise<{ usageHoldPct: number }> 
 export const putFableAvailable = (value: boolean): Promise<{ fableAvailable: boolean }> =>
   patchSettings<{ fableAvailable: boolean }>({ fableAvailable: value });
 
+// Toggle the global reduced-notifications mode (only ready-after-5s + cost alerts when on).
+export const putReducedPushMode = (enabled: boolean): Promise<{ reducedPushMode: boolean }> =>
+  patchSettings({ reducedPushMode: enabled });
+
 /** Upload one image; returns its absolute server path. Pass sessionId to store it
  *  inside that session's worktree (live terminal); omit for New Task staging. */
 export async function uploadImage(file: File, sessionId?: string): Promise<string> {

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -69,6 +69,7 @@ function settings(over: Partial<SettingsPayload> = {}): SettingsPayload {
     usageHoldEnabled: true,
     usageHoldPct: 90,
     fableAvailable: true,
+    reducedPushMode: false,
     ...over,
   };
 }

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -14,6 +14,7 @@
     putUsageHoldEnabled,
     putUsageHoldPct,
     putFableAvailable,
+    putReducedPushMode,
   } from "$lib/api";
   import { verifyFailureMessage } from "$lib/verify-key";
   import { modelLabel } from "$lib/model-label";
@@ -134,6 +135,10 @@
   // Fable availability — operator kill-switch while Fable is globally unavailable.
   let fableAvailable = $state(true);
   let fableAvailableBusy = $state(false);
+
+  // Reduced-notifications mode — mutes all pushes except ready-after-5s + cost alerts.
+  let reducedPushMode = $state(false);
+  let reducedPushBusy = $state(false);
 
   // Repo root, resolved by the single getSettings() below and handed to the
   // workspace panel as props so it never re-fetches. settingsLoaded flips once
@@ -375,6 +380,23 @@
     }
   }
 
+  async function toggleReducedPush() {
+    if (reducedPushBusy) return;
+    reducedPushBusy = true;
+    try {
+      const r = await putReducedPushMode(!reducedPushMode);
+      reducedPushMode = r.reducedPushMode;
+    } catch {
+      toasts.info(m.settings_reduced_push_save_failed(), {
+        key: "reduced-push-mode",
+        duration: null,
+        alert: true,
+      });
+    } finally {
+      reducedPushBusy = false;
+    }
+  }
+
   async function saveUsageHoldPct() {
     if (usageHoldPctBusy) return;
     usageHoldPctBusy = true;
@@ -451,6 +473,7 @@
       usageHoldPct = s.usageHoldPct;
       usageHoldPctSaved = s.usageHoldPct;
       fableAvailable = s.fableAvailable;
+      reducedPushMode = s.reducedPushMode;
       repoRoot = s.repoRoot;
       repoRootDisplay = s.repoRootDisplay;
     } catch {
@@ -798,7 +821,12 @@
       tabindex="0"
       hidden={tab !== "device"}
     >
-      <SettingsDevicePanel {onwhatsnew} />
+      <SettingsDevicePanel
+        {onwhatsnew}
+        {reducedPushMode}
+        {reducedPushBusy}
+        onToggleReducedPush={toggleReducedPush}
+      />
     </div>
 
     <div

--- a/ui/src/lib/components/settings/SettingsDevicePanel.browser.test.ts
+++ b/ui/src/lib/components/settings/SettingsDevicePanel.browser.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import { m } from "$lib/paraglide/messages";
+
+// Stub $lib/push so pushState resolves to unsupported — avoids navigator.
+vi.mock("$lib/push", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/push")>();
+  return {
+    ...actual,
+    pushState: vi.fn(async () => ({
+      supported: false,
+      permission: "unsupported" as const,
+      subscribed: false,
+    })),
+    getPushCategories: vi.fn(async () => ({ agent: true, reviews: true, ci: true })),
+  };
+});
+
+const { default: SettingsDevicePanel } = await import("./SettingsDevicePanel.svelte");
+
+let fontStyle: HTMLStyleElement;
+beforeEach(() => {
+  fontStyle = document.createElement("style");
+  fontStyle.textContent = `:root {
+    --font-mono: ui-monospace, monospace;
+    --color-panel: #1a1a1a;
+    --color-line: #333;
+    --color-line-bright: #555;
+    --color-inset: #111;
+    --color-ink: #ccc;
+    --color-ink-bright: #fff;
+    --color-muted: #666;
+    --color-faint: #444;
+    --color-amber: #f5a623;
+    --color-green: #4caf50;
+    --color-red: #f44336;
+    --fs-base: 13px;
+    --fs-meta: 12px;
+    --fs-micro: 10px;
+    --fs-lg: 15px;
+    --fs-xl: 18px;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  body { margin: 0; }`;
+  document.head.appendChild(fontStyle);
+});
+afterEach(() => {
+  fontStyle.remove();
+  document.body.innerHTML = "";
+});
+
+const switchEl = () => page.getByRole("switch", { name: m.settings_reduced_push_title() });
+
+describe("SettingsDevicePanel reduced-notifications switch", () => {
+  it("renders aria-checked=true and On state when reducedPushMode is true", async () => {
+    render(SettingsDevicePanel, { reducedPushMode: true });
+
+    await expect.element(switchEl()).toBeInTheDocument();
+    await expect.element(switchEl()).toHaveAttribute("aria-checked", "true");
+    await expect
+      .element(page.getByText(m.settings_reduced_push_on(), { exact: true }))
+      .toBeInTheDocument();
+  });
+
+  it("renders aria-checked=false when reducedPushMode is false", async () => {
+    render(SettingsDevicePanel, { reducedPushMode: false });
+
+    await expect.element(switchEl()).toBeInTheDocument();
+    await expect.element(switchEl()).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("calls onToggleReducedPush when the switch is clicked", async () => {
+    const spy = vi.fn();
+    render(SettingsDevicePanel, { reducedPushMode: false, onToggleReducedPush: spy });
+
+    await expect.element(switchEl()).toBeInTheDocument();
+    await switchEl().click();
+
+    expect(spy).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/lib/components/settings/SettingsDevicePanel.svelte
+++ b/ui/src/lib/components/settings/SettingsDevicePanel.svelte
@@ -14,7 +14,17 @@
   import ThemeIcon from "$lib/components/ThemeIcon.svelte";
   import { m } from "$lib/paraglide/messages";
 
-  let { onwhatsnew }: { onwhatsnew?: () => void } = $props();
+  let {
+    onwhatsnew,
+    reducedPushMode = false,
+    reducedPushBusy = false,
+    onToggleReducedPush,
+  }: {
+    onwhatsnew?: () => void;
+    reducedPushMode?: boolean;
+    reducedPushBusy?: boolean;
+    onToggleReducedPush?: () => void;
+  } = $props();
 
   // Theme picker — mobile only: the desktop switcher lives in the ActionBar,
   // but on phones the ActionBar hides it and it was dropped from the top bar,
@@ -114,6 +124,24 @@
 </div>
 <div class="push">
   <span class="micro">{m.settings_push_title()}</span>
+  <div class="reduced-row">
+    <span class="micro">{m.settings_reduced_push_title()}</span>
+    <p class="hint">{m.settings_reduced_push_hint()}</p>
+    <button
+      type="button"
+      class="toggle"
+      role="switch"
+      aria-label={m.settings_reduced_push_title()}
+      aria-checked={reducedPushMode}
+      disabled={reducedPushBusy}
+      onclick={() => onToggleReducedPush?.()}
+    >
+      <span class="track" class:on={reducedPushMode}><span class="knob"></span></span>
+      <span class="state"
+        >{reducedPushMode ? m.settings_reduced_push_on() : m.settings_reduced_push_off()}</span
+      >
+    </button>
+  </div>
   {#if !push.supported}
     <p class="hint">{m.settings_push_unsupported()}</p>
   {:else if push.permission === "denied"}
@@ -125,11 +153,15 @@
     {#if push.subscribed}
       <fieldset class="cats">
         <legend class="micro">{m.settings_push_cat_title()}</legend>
+        {#if reducedPushMode}
+          <p class="hint">{m.settings_reduced_push_disabled_note()}</p>
+        {/if}
         {#each categoryRows as row (row.key)}
           <label class="cat">
             <input
               type="checkbox"
               checked={categories[row.key]}
+              disabled={reducedPushMode}
               onchange={() => toggleCategory(row.key)}
             />
             <span>{row.label()}</span>
@@ -216,6 +248,16 @@
     padding: 4px 8px;
     vertical-align: middle;
     margin-left: 6px;
+  }
+  .reduced-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .reduced-row .hint {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    margin: 0;
   }
   .push {
     display: flex;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1327,4 +1327,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_learnings_promote_global_title",
     bodyKey: "feat_learnings_promote_global_body",
   },
+  {
+    // Reduced notifications mode (#896): a global switch (Settings → Device) that
+    // silences every push except a session sitting in the "ready" filter for 5s,
+    // keeping only usage/cost alerts. The control lives behind the settings gear +
+    // Device tab → no always-visible anchor, so What's-New only, no coachmark.
+    // v1.34.0 is the latest released tag → ships in 1.35.0.
+    id: "reduced-push-mode",
+    sinceVersion: "1.35.0",
+    titleKey: "feat_reduced_push_title",
+    bodyKey: "feat_reduced_push_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -72,6 +72,8 @@ export interface Settings {
   usageHoldPct: number;
   /** Whether Fable is globally available; when false, Fable selections run on Opus (1M context). */
   fableAvailable: boolean;
+  /** Global reduced-notifications mode: when on, only the ready-after-5s push (+ usage/credit alerts) is sent. */
+  reducedPushMode: boolean;
 }
 
 export interface DirEntry {


### PR DESCRIPTION
Closes #896.

## Reduced push notifications mode

A single global, exclusive toggle (default **off**) that silences the usual push categories and replaces them with **one** signal: *a session entered the server-computed "ready" filter (your turn) and stayed there for ≥ 5 s*.

### Behavior when ON
- `push.notify` drops every kind **except** the allowlist `{ ready, usage_limit, extra_credits }` — per-session `agent`/`reviews`/`ci`, `merge_attention`, and `learnings_retired` are muted; **usage and cost alerts are kept** (operator decision).
- The new `ready` push fires **once per ready-stint**, gated by a 5 s dwell, a 15 s per-session warm-up, and active-window suppression. It **bypasses** the per-device category filter (those categories are muted by definition) and reaches all subscribed devices.

### How "ready" is computed server-side
`src/ready-stage.ts` ports the UI's `shownSessions(filter="ready")` predicate (`herd-partition.ts` `stageOf` + `display-status.ts`) so server and UI can't drift, with **one** intentional delta: terminal `merged` is excluded (a merged PR isn't "your turn"). A `DRIFT:` comment + a parity fixture test lock it. `isReviewing` is the **union** of critic (`ReviewService`) and plan-gate (`PlanGateService`) in-flight ids, matching the UI's `reviews || planGates`.

### The evaluator — `src/ready-notify.ts` `ReadyNotifier`
~1 s tick (only while reduced mode is on):
- **Send-gating** — `notified` is set `true` *only when `push.notify` returns true*, so a dwell that elapses while the app is focused **defers** and fires once on unfocus rather than being silently dropped.
- **Seed-on-arm** — on boot / off→on toggle, currently-ready sessions are seeded as already-notified, killing the startup banner burst.
- **Warm-up** — a session fires only after it's been tracked ≥ 15 s, closing the cold-git-cache false positive (a PR with no snapshot yet looks `active`/ready before CI registers).
- Re-entry restarts the dwell; mode-off clears all state; a re-entrancy guard serializes async ticks; maps are pruned for vanished sessions.

### Setting + UI
- Reuses the KV settings layer (no DB migration): `config.reducedPushMode`, boot-loaded, exposed in `GET/PUT /api/settings` (mirrors `usageHoldEnabled`).
- A global "Reduced notifications" switch in **Settings → Device**, next to the push controls; when ON it disables the `agent/reviews/ci` checkboxes with a note. Full EN+DE i18n; What's-New catalog entry (`sinceVersion 1.35.0`).

## Tests
New/extended: `ready-stage` (stage parity incl. merged-delta anchor), `ready-notify` (dwell, send-gating defer-not-drop, warm-up/cold-cache, re-entry, seed/boot grace, mode-off, prune), `push` (exclusive guard, category bypass, off-default, `ready` payload EN/DE), `server-settings` (PUT/GET + reject), `SettingsDevicePanel.browser` (switch render/toggle).

## Verification
- Root: `bun test ./test` → 4168 pass / 0 fail · `tsc --noEmit` clean · `lint` clean
- UI: `bun run test` → 1791 pass · `bun run check` clean · `check:i18n` parity
- Gates: feature-catalog, branch-hygiene, glossary, fallow audit — all green

Built subagent-driven (fresh implementer + task review per step, final whole-branch review: READY TO MERGE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
