### PR TITLE
feat(docs): PR-gated AI doc agent (manual trigger, off by default) (#882)

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -44,6 +44,19 @@ lines), read by the systemd unit if present.
 
 See [Operating Shepherd](/operating/) for the host-level `/etc/fstab` belt.
 
+## Documentation automation (PR-gated doc agent)
+
+Opt-in, default-off. When enabled, a manual trigger (`POST /api/doc-agent?repo=<path>`)
+spawns a read-only-scoped Claude Code agent that diffs recent source changes against the
+hand-written docs and proposes edits. The agent **never** commits or pushes — the trusted
+server stages the in-scope doc files, commits, and opens a **pull request** for human
+review (never an auto-merge). Off by default; flip on per deployment to soak it.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SHEPHERD_DOC_AGENT` | `0` (off) | Set `1` to enable the manual doc-agent trigger + its boot orphan-sweep |
+| `SHEPHERD_DOC_AGENT_MODEL` | _(none)_ | Model alias for the doc-agent spawn; unset uses the spawn default |
+
 ## Per-agent sandbox / permission profiles
 
 Shepherd can wrap each spawned `claude` process in an OS-level filesystem/process

--- a/src/config.ts
+++ b/src/config.ts
@@ -344,6 +344,15 @@ export const config = {
   // Meaningful only when `hooksIngest` is also on — with ingest off no events arrive to feed.
   // Staged after Phase 0 has confirmed the live payload shape (see issue #704).
   hooksSignals: process.env.SHEPHERD_HOOKS_SIGNALS === "1",
+  // PR-gated AI doc agent (issue #882, epic #875 Phase 3). Opt-in soak flag, mirroring
+  // SHEPHERD_HOOKS_INGEST: default-off and reversible. When off, the manual trigger
+  // (POST /api/doc-agent) 404s and the boot orphan-sweep is inert. When on, the trigger
+  // spawns a scoped, dontAsk doc agent that edits stale prose docs in a disposable worktree;
+  // the trusted server — never the agent — commits/pushes/opens a PR for human review.
+  docAgentEnabled: process.env.SHEPHERD_DOC_AGENT === "1",
+  // Model alias for the doc-agent spawn. Unset → no --model (spawn default). The agent does
+  // substantive comprehension, so a capable model is appropriate; override per deployment.
+  docAgentModel: process.env.SHEPHERD_DOC_AGENT_MODEL ?? null,
   // Context trim for auto-spawned (drain) agents (issue #499): spawn them with
   // `--disable-slash-commands` (drops the skill catalog) plus a per-spawn settings
   // overlay disabling every operator-enabled plugin (drops plugin hook injections,

--- a/src/doc-agent-argv.ts
+++ b/src/doc-agent-argv.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from "node:crypto";
+import { apiKeySettingsFragment } from "./spawn-auth";
+
+/** Build the argv for the PR-gated doc agent (issue #882, epic #875 Phase 3).
+ *
+ *  Structurally a sibling of {@link import("./reviewer-argv").readonlyReviewerArgv}: it reuses the
+ *  exact hard-won spawn posture (subscription OAuth via --settings, NOT --bare; --safe-mode +
+ *  enableAllProjectMcpServers to keep MCP both unloaded AND un-gated; disableAllHooks so an
+ *  operator's SessionStart skill-injection can't thrash the unattended pane; --disable-slash-commands;
+ *  --permission-mode dontAsk auto-denying anything off the allowlist). It is deliberately NOT
+ *  --dangerously-skip-permissions: the agent reasons over recent source changes (untrusted history)
+ *  and must not be able to run arbitrary commands or escape its disposable worktree.
+ *
+ *  The ONLY divergence from the read-only reviewer allowlist is bare `Edit` (the reviewer has bare
+ *  `Write` only): the doc agent EDITS existing prose pages. It runs NO git mutation, NO `gh`, NO
+ *  network, NO general Bash — the read-only `git diff/log/show/status` is for grounding only. All
+ *  publishing (stage / commit / push / open-PR) is done by the trusted Shepherd server in
+ *  DocAgentService.finalize(), never by the agent — so "never auto-commits to a published branch" is
+ *  enforced by construction, not by prompt discipline. test/doc-agent-argv.test.ts asserts the
+ *  absence of every publish/exec token. */
+export function docAgentArgv(
+  model: string | null,
+  prompt: string,
+  // Optional extended thinking budget, emitted as env.MAX_THINKING_TOKENS in --settings (the only
+  // knob that grants a spawned session's initial positional prompt a thinking budget; a no-op on a
+  // non-thinking model). Omitted by default.
+  thinkingTokens?: number,
+): { argv: string[]; sessionId: string } {
+  const sessionId = randomUUID();
+  const settings: Record<string, unknown> = {
+    disableAllHooks: true,
+    enableAllProjectMcpServers: true,
+  };
+  if (thinkingTokens) settings.env = { MAX_THINKING_TOKENS: String(thinkingTokens) };
+  // api-key mode folds in `apiKeyHelper` after the existing keys (stable key order; subscription
+  // spreads {} → byte-identical JSON). See spawn-auth + the membrane wiring in doc-agent.ts.
+  Object.assign(settings, apiKeySettingsFragment());
+  const argv = [
+    "claude",
+    "--session-id",
+    sessionId,
+    "--settings",
+    JSON.stringify(settings),
+    "--disable-slash-commands",
+    // --safe-mode disables MCP *loading* (file + plugin sources) and other customizations; it is
+    // COUPLED to enableAllProjectMcpServers in --settings (which clears the interactive "N new MCP
+    // servers found" approval gate that neither --safe-mode nor dontAsk suppress on an interactive
+    // pane). Must sit BEFORE --allowedTools (a boolean flag; the variadic --allowedTools would
+    // otherwise swallow it). See reviewer-argv.ts for the full rationale + version caveat.
+    "--safe-mode",
+    "--allowedTools",
+    "Read",
+    "Grep",
+    "Glob",
+    // Read-only git — grounding only (diff recent changes vs current docs). NO add/commit/push.
+    "Bash(git diff *)",
+    "Bash(git log *)",
+    "Bash(git show *)",
+    "Bash(git status)",
+    // Bare Write + Edit — NOT path-scoped (scoped forms are silently denied under dontAsk). The
+    // worktree is disposable and the agent has no exec/commit/push/network, so bare file tools are
+    // an acceptable widening. Edit is the sole tool added over the read-only reviewer set.
+    "Write",
+    "Edit",
+  ];
+  if (model) argv.push("--model", model);
+  // --permission-mode LAST: --allowedTools is variadic and eats every following token until the
+  // next flag, so a single-value flag MUST sit between the allowlist and the trailing prompt
+  // positional — otherwise the prompt folds into the allowlist and the agent launches with no task.
+  argv.push("--permission-mode", "dontAsk");
+  argv.push(prompt);
+  return { argv, sessionId };
+}

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -1,0 +1,527 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { config } from "./config";
+import { docAgentArgv } from "./doc-agent-argv";
+import { EmptyDiffError } from "./forge/types";
+import type { GitForge } from "./forge/types";
+import type { HerdrDriver } from "./herdr";
+import { HerdrUnavailableError } from "./herdr";
+import {
+  apiKeyMembraneFields,
+  apiKeyPassthroughEnv,
+  isApiKeyConfigured,
+  isApiKeyMode,
+} from "./spawn-auth";
+import {
+  detectBackend as realDetectBackend,
+  wrapArgv,
+  safeRealpath,
+  collectPassthroughEnv,
+  type SandboxBackend,
+  type MembraneInputs,
+} from "./sandbox";
+import type { WorktreeMgr } from "./worktree";
+
+const execFileP = promisify(execFile);
+
+/** Async git runner (returns stdout) — keeps the single-process event loop unblocked during the
+ *  finalize stage/commit/push and the boot sweep (house rule: no blocking subprocess on the loop). */
+async function defaultGit(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileP("git", args, { cwd });
+  return stdout;
+}
+
+/** Prefix for ephemeral doc-agent herdr names. Each run appends 8 hex of a fresh UUID so an
+ *  orphaned husk (after a restart) can NEVER squat a stable name — a re-spawn always gets a new
+ *  name, so `agent_name_taken` is impossible by construction (the distiller's fix; see
+ *  DISTILL_LABEL). The underscores are load-bearing: prompt-derived session slugs are `[a-z0-9-]`
+ *  only, so no real session collides, and sweepOrphans can match husks by this prefix safely. */
+export const DOC_AGENT_LABEL = "__docagent__";
+
+/** Worktree/branch name stem. worktree.create() prepends `shepherd/`, so the branch is
+ *  `shepherd/docs-update-<8hex>`. sweepOrphans matches `shepherd/${DOC_BRANCH_PREFIX}`. */
+const DOC_BRANCH_PREFIX = "docs-update-";
+
+/** The agent writes this at the worktree root as its FINAL action: a per-change grounding bullet
+ *  list + an "Uncertain / needs human judgment" section. Its presence is the completion signal; its
+ *  content becomes the PR body. It lives OUTSIDE the staged in-scope list so it is never committed. */
+const SENTINEL = ".shepherd-doc-update.md";
+
+/** Layout guard marker: the partition/prompt/staging are Shepherd-doc-layout-specific, so a repo
+ *  that lacks this tree is rejected before any spawn (it would have nothing to stage). */
+const DOC_TREE_MARKER = "docs-site/src/content/docs";
+
+/** The EXPLICIT in-scope file list (repo-relative). finalize() stages ONLY these (∩ files that
+ *  exist), so any agent edit outside the set — the Astro app, the generated `reference/cli/*`, or a
+ *  brand-new file — is never staged and can't reach the PR. This is the structural off-limits
+ *  boundary that backs the prompt-level instruction. New-page creation is out of scope (#882). */
+const IN_SCOPE_PATHS: readonly string[] = [
+  // Repo-root hand-written prose sources (the docs-site reference/* renders are git-ignored).
+  "docs/external-task-api.md",
+  "docs/sandbox-security.md",
+  "docs/token-usage-analysis.md",
+  // docs-site-native committed prose.
+  "docs-site/src/content/docs/index.md",
+  "docs-site/src/content/docs/getting-started.md",
+  "docs-site/src/content/docs/operating.md",
+  "docs-site/src/content/docs/reference/configuration.md",
+  "docs-site/src/content/docs/reference/glossary.md",
+];
+
+/** How many recent commits the agent grounds its staleness check against. */
+const COMMIT_WINDOW = 50;
+
+const COMMIT_MSG = "docs: sync docs to recent source changes";
+
+export type DocAgentStatus = "started" | "skipped" | "error";
+export interface DocAgentResult {
+  status: DocAgentStatus;
+  reason?: string;
+}
+export interface DocAgentFinalize {
+  repoPath: string;
+  /** PR url when a doc-update PR was opened; null when docs were already current. */
+  url: string | null;
+}
+
+interface InFlight {
+  repoPath: string;
+  worktreePath: string;
+  branch: string;
+  base: string;
+  terminalId: string;
+  agentName: string;
+  startedAt: number;
+  finalizing?: boolean;
+}
+
+export interface DocAgentDeps {
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab">;
+  worktree: Pick<WorktreeMgr, "create" | "remove" | "gitCommonDir" | "ensureBaseRef">;
+  resolveForge: (repoPath: string) => GitForge | null;
+  /** Repos to enumerate in the boot orphan-sweep (herdr-independent worktree prune). */
+  repos: () => string[];
+  model?: string | null;
+  onChange?: (f: DocAgentFinalize) => void;
+  now?: () => number;
+  timeoutMs?: number;
+  // Injectable seams (tests).
+  git?: (cwd: string, args: string[]) => Promise<string>;
+  detectBackend?: () => SandboxBackend;
+  membraneEnv?: () => {
+    claudeDir: string;
+    home: string;
+    nodeBinReal: string;
+    extraEnv?: Record<string, string>;
+  };
+  fileExists?: (p: string) => boolean;
+  readSentinel?: (worktreePath: string) => string | null;
+  buildPrompt?: (base: string) => string;
+}
+
+/**
+ * PR-gated AI doc agent (issue #882, epic #875 Phase 3).
+ *
+ * Manual-trigger, flag-gated (config.docAgentEnabled). On `consider(repoPath)` it spawns a scoped,
+ * `dontAsk` Claude Code agent in a disposable worktree (see {@link docAgentArgv}); the agent EDITS
+ * stale prose docs and writes a {@link SENTINEL} summary, but runs NO git. On the next `tick()` the
+ * trusted server stages ONLY the in-scope file list, commits `--no-verify`, pushes, and opens a PR
+ * via `forge.openPr()` — never an auto-merge. Mirrors the worktree+git tail of {@link
+ * import("./promote").Promoter} and the spawn/membrane posture of ReviewService.
+ *
+ * Restart-safety: the unique-per-run herdr name (`__docagent__<8hex>`) makes name-squat impossible;
+ * `sweepOrphans()` (boot) additionally clears husk tabs + orphan `shepherd/docs-update-*` worktrees,
+ * working even when the herdr daemon also restarted (it parses `git worktree list`).
+ */
+export class DocAgentService {
+  private inflight = new Map<string, InFlight>();
+  private starting = new Set<string>();
+  private git: (cwd: string, args: string[]) => Promise<string>;
+  private now: () => number;
+  private timeoutMs: number;
+  private fileExists: (p: string) => boolean;
+  private readSentinel: (worktreePath: string) => string | null;
+  private buildPrompt: (base: string) => string;
+
+  constructor(private deps: DocAgentDeps) {
+    this.git = deps.git ?? defaultGit;
+    this.now = deps.now ?? Date.now;
+    this.timeoutMs = deps.timeoutMs ?? 20 * 60 * 1000;
+    this.fileExists = deps.fileExists ?? existsSync;
+    this.readSentinel = deps.readSentinel ?? defaultReadSentinel;
+    this.buildPrompt = deps.buildPrompt ?? ((base) => docAgentPrompt(base));
+  }
+
+  private detectBackend(): SandboxBackend {
+    if (this.deps.detectBackend) return this.deps.detectBackend();
+    return realDetectBackend({
+      home: homedir(),
+      claudeDir: config.claudeDir,
+      nodeBinReal: safeRealpath(config.nodeBin),
+    });
+  }
+
+  private membraneEnv(): {
+    claudeDir: string;
+    home: string;
+    nodeBinReal: string;
+    extraEnv?: Record<string, string>;
+  } {
+    if (this.deps.membraneEnv) return this.deps.membraneEnv();
+    return {
+      claudeDir: config.claudeDir,
+      home: homedir(),
+      nodeBinReal: safeRealpath(config.nodeBin),
+      extraEnv: collectPassthroughEnv(),
+    };
+  }
+
+  /** Start a doc-agent run for `repoPath` (manual trigger). At most one per repo at a time. */
+  async consider(repoPath: string): Promise<DocAgentResult> {
+    if (this.inflight.has(repoPath) || this.starting.has(repoPath)) {
+      return { status: "skipped", reason: "doc agent already running for this repo" };
+    }
+    this.starting.add(repoPath);
+    try {
+      return await this.begin(repoPath);
+    } finally {
+      this.starting.delete(repoPath);
+    }
+  }
+
+  private async begin(repoPath: string): Promise<DocAgentResult> {
+    const guard = this.guardRepo(repoPath);
+    if (!guard.ok) return guard.result;
+    const forge = guard.forge;
+
+    let base: string;
+    try {
+      base = await forge.defaultBranch();
+    } catch {
+      return { status: "error", reason: "could not resolve default branch" };
+    }
+    // Freshen the base ref off origin (best-effort, never throws; the fetch is timeout-bounded
+    // inside ensureBaseRef). A non-diverged branch resolves to the upstream sha so the worktree
+    // starts fresh; offline degrades to the local base.
+    const resolved = await this.deps.worktree.ensureBaseRef(repoPath, base);
+
+    // forget() can't race a manual trigger here, but a second trigger could have landed during the
+    // awaits above — the `starting` claim (held until this returns) prevents that double-spawn.
+    const id8 = randomUUID().slice(0, 8);
+    const wtName = DOC_BRANCH_PREFIX + id8;
+    let wt;
+    try {
+      wt = this.deps.worktree.create(repoPath, resolved.baseRef, wtName);
+    } catch (err) {
+      console.warn(`[doc-agent] worktree creation failed for ${repoPath}:`, err);
+      return { status: "error", reason: "worktree creation failed" };
+    }
+    if (!wt.isolated || !wt.branch) {
+      if (wt.worktreePath !== repoPath) this.deps.worktree.remove(wt.worktreePath);
+      return { status: "error", reason: "worktree creation failed" };
+    }
+
+    const terminalId = this.spawnAgent(repoPath, wt.worktreePath, DOC_AGENT_LABEL + id8, base);
+    if (!terminalId) {
+      this.deps.worktree.remove(wt.worktreePath);
+      return { status: "error", reason: "spawn failed" };
+    }
+    this.inflight.set(repoPath, {
+      repoPath,
+      worktreePath: wt.worktreePath,
+      branch: wt.branch,
+      base,
+      terminalId,
+      agentName: DOC_AGENT_LABEL + id8,
+      startedAt: this.now(),
+    });
+    return { status: "started" };
+  }
+
+  /** Pre-spawn fail-closed guards (api-key, forge, local-forge, doc-tree layout). Returns the
+   *  resolved forge on success, else the skip/error result to return from begin(). */
+  private guardRepo(
+    repoPath: string,
+  ): { ok: true; forge: GitForge } | { ok: false; result: DocAgentResult } {
+    if (isApiKeyMode() && !isApiKeyConfigured()) {
+      console.warn(
+        "[doc-agent] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
+      );
+      return {
+        ok: false,
+        result: { status: "skipped", reason: "api-key mode without a configured key" },
+      };
+    }
+    const forge = this.deps.resolveForge(repoPath);
+    if (!forge)
+      return { ok: false, result: { status: "error", reason: "no forge configured for repo" } };
+    if (forge.kind === "local") {
+      return {
+        ok: false,
+        result: { status: "skipped", reason: "lightweight repo mode has no PR surface" },
+      };
+    }
+    if (!this.fileExists(join(repoPath, DOC_TREE_MARKER))) {
+      return { ok: false, result: { status: "skipped", reason: "repo has no docs-site doc tree" } };
+    }
+    return { ok: true, forge };
+  }
+
+  /** Build the scoped argv + membrane and spawn the agent via herdr. Returns the terminalId, or
+   *  null on a spawn failure (logged). profile "standard": the agent needs Anthropic egress (to run
+   *  claude) but not GitHub — the server pushes/opens the PR — mirroring ReviewService's spawn. */
+  private spawnAgent(
+    repoPath: string,
+    worktreePath: string,
+    agentName: string,
+    base: string,
+  ): string | null {
+    const { argv } = docAgentArgv(this.deps.model ?? null, this.buildPrompt(base));
+    const backend = this.detectBackend();
+    const env = this.membraneEnv();
+    const membrane: MembraneInputs = {
+      worktreePath,
+      gitCommonDir: this.deps.worktree.gitCommonDir(worktreePath),
+      isolated: true,
+      repoPath,
+      claudeDir: env.claudeDir,
+      home: env.home,
+      nodeBinReal: env.nodeBinReal,
+      extraEnv: env.extraEnv,
+      // api-key mode: a bwrap-wrapped agent masks the OAuth credential + binds the helper.
+      ...apiKeyMembraneFields(),
+    };
+    const wrapped = wrapArgv(argv, { profile: "standard", backend, membrane });
+    try {
+      return this.deps.herdr.start(
+        agentName,
+        worktreePath,
+        wrapped,
+        apiKeyPassthroughEnv(backend !== null),
+      ).terminalId;
+    } catch (err) {
+      if (err instanceof HerdrUnavailableError) {
+        console.warn(`[doc-agent] herdr unavailable for ${repoPath}:`, err);
+      } else {
+        console.warn(`[doc-agent] spawn failed for ${repoPath}:`, err);
+      }
+      return null;
+    }
+  }
+
+  /** Finalize any run whose sentinel is ready or that timed out. */
+  async tick(): Promise<void> {
+    for (const f of [...this.inflight.values()]) {
+      if (f.finalizing) continue;
+      const sentinel = this.readSentinel(f.worktreePath);
+      const timedOut = this.now() - f.startedAt > this.timeoutMs;
+      if (sentinel === null && !timedOut) continue;
+      f.finalizing = true;
+      try {
+        await this.finalize(f, sentinel);
+      } catch (err) {
+        console.warn(`[doc-agent] finalize failed for ${f.repoPath}:`, err);
+      }
+      this.inflight.delete(f.repoPath);
+    }
+  }
+
+  private async finalize(f: InFlight, sentinel: string | null): Promise<void> {
+    let url: string | null = null;
+    try {
+      const forge = this.deps.resolveForge(f.repoPath);
+      // STRUCTURAL off-limits boundary: stage ONLY the in-scope list ∩ files that exist. An agent
+      // edit to the Astro app, reference/cli/*, or a new file is never staged → can't reach the PR.
+      const inScope = IN_SCOPE_PATHS.filter((p) => this.fileExists(join(f.worktreePath, p)));
+      if (forge && inScope.length > 0) {
+        await this.git(f.worktreePath, ["add", "--", ...inScope]);
+        const staged = (await this.git(f.worktreePath, ["diff", "--cached", "--name-only"])).trim();
+        if (staged.length > 0) {
+          // --no-verify deliberately DIVERGES from promote.ts (which commits WITH hooks): a
+          // server-side docs-only commit must not run the repo's pre-commit hooks (lint-staged
+          // etc.) on unrelated state. The change is grounded + human-reviewed via the PR.
+          await this.git(f.worktreePath, ["commit", "--no-verify", "-m", COMMIT_MSG]);
+          await this.git(f.worktreePath, ["push", "-u", "origin", f.branch]);
+          try {
+            const status = await forge.openPr({
+              head: f.branch,
+              base: f.base,
+              title: COMMIT_MSG,
+              body: docPrBody(sentinel),
+            });
+            url = status.url ?? null;
+          } catch (err) {
+            // No net diff vs base → nothing to land; not an error.
+            if (!(err instanceof EmptyDiffError)) throw err;
+          }
+        }
+      }
+    } finally {
+      // Cleanup mirrors Promoter.cleanup: stop the agent (closes its tab), remove the worktree, and
+      // force-delete the local branch (the pushed remote branch backs any opened PR).
+      this.deps.herdr.stop(f.terminalId);
+      this.deps.worktree.remove(f.worktreePath);
+      try {
+        await this.git(f.repoPath, ["branch", "-D", f.branch]);
+      } catch {
+        /* best-effort: a never-committed branch may already be gone */
+      }
+    }
+    this.deps.onChange?.({ repoPath: f.repoPath, url });
+  }
+
+  /** Drop a repo's in-flight tracking (e.g. on shutdown); does not touch the worktree. */
+  forget(repoPath: string): void {
+    this.inflight.delete(repoPath);
+    this.starting.delete(repoPath);
+  }
+
+  /**
+   * Boot reconcile. Two independent passes so it works even when the herdr daemon ALSO restarted:
+   *  1. Close any live herdr tab whose name starts with the doc-agent prefix (herdr survived).
+   *  2. herdr-independent: parse `git worktree list` per known repo and remove every
+   *     `shepherd/docs-update-*` worktree + force-delete its branch (the authoritative orphan
+   *     signal when there's no tab to read a cwd from, and no persisted run rows).
+   * Scoped strictly to the doc-agent namespace, so it never collides with the reviewer's `review *`
+   * reaper or the tmpfs sweeper.
+   */
+  async sweepOrphans(): Promise<void> {
+    this.closeHuskTabs();
+    for (const repo of this.deps.repos()) {
+      if (this.inflight.has(repo)) continue; // never reap a live run
+      await this.pruneRepoOrphanWorktrees(repo);
+    }
+  }
+
+  /** Pass 1: close any live herdr tab whose name starts with the doc-agent prefix. */
+  private closeHuskTabs(): void {
+    try {
+      for (const a of this.deps.herdr.list()) {
+        if (a.name.startsWith(DOC_AGENT_LABEL)) this.deps.herdr.closeTab(a.tabId);
+      }
+    } catch (err) {
+      console.warn("[doc-agent] sweepOrphans tab pass:", err);
+    }
+  }
+
+  /** Pass 2 (per repo): remove every `shepherd/docs-update-*` worktree + force-delete its branch. */
+  private async pruneRepoOrphanWorktrees(repo: string): Promise<void> {
+    const orphanPrefix = `shepherd/${DOC_BRANCH_PREFIX}`;
+    let entries: { path: string; branch: string }[];
+    try {
+      entries = await this.listWorktreeBranches(repo);
+    } catch {
+      return;
+    }
+    for (const { path, branch } of entries) {
+      if (!branch.startsWith(orphanPrefix)) continue;
+      this.deps.worktree.remove(path);
+      try {
+        await this.git(repo, ["branch", "-D", branch]);
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+
+  /** Parse `git worktree list --porcelain` → [{path, branch}] (branch "" for detached). */
+  private async listWorktreeBranches(repo: string): Promise<{ path: string; branch: string }[]> {
+    const out = await this.git(repo, ["worktree", "list", "--porcelain"]);
+    const res: { path: string; branch: string }[] = [];
+    let cur: { path: string; branch: string } | null = null;
+    const flush = () => {
+      if (cur) res.push(cur);
+      cur = null;
+    };
+    for (const line of out.split("\n")) {
+      if (line.startsWith("worktree ")) {
+        flush();
+        cur = { path: line.slice("worktree ".length).trim(), branch: "" };
+      } else if (line.startsWith("branch ") && cur) {
+        cur.branch = line
+          .slice("branch ".length)
+          .trim()
+          .replace(/^refs\/heads\//, "");
+      } else if (line === "") {
+        flush();
+      }
+    }
+    flush();
+    return res;
+  }
+}
+
+function defaultReadSentinel(worktreePath: string): string | null {
+  const p = join(worktreePath, SENTINEL);
+  if (!existsSync(p)) return null;
+  try {
+    const txt = readFileSync(p, "utf8");
+    return txt.trim().length > 0 ? txt : null;
+  } catch {
+    return null; // partial write — retry next tick
+  }
+}
+
+/** PR body: the agent's grounding/uncertainty summary + a human-review banner. */
+function docPrBody(sentinel: string | null): string {
+  const summary =
+    sentinel && sentinel.trim().length > 0 ? sentinel.trim() : "_(the doc agent left no summary)_";
+  return [
+    "Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.",
+    "",
+    "Each change below cites the source it was grounded in; items the agent was unsure about are",
+    "flagged for human judgment. **This PR is for review only — it is never auto-merged.**",
+    "",
+    "---",
+    "",
+    summary,
+  ].join("\n");
+}
+
+/** The doc-agent task prompt. Grounds the agent in recent source changes, restricts edits to the
+ *  enumerated existing in-scope prose, forbids touching generated docs + creating new files +
+ *  running git, and asks for a grounded/uncertainty summary written to the sentinel. */
+function docAgentPrompt(base: string): string {
+  return [
+    "You are Shepherd's documentation-maintenance agent. Your working directory is a fresh checkout",
+    `of the \`${base}\` branch. Your job: find where the documentation has gone stale relative to`,
+    "recent source changes, and update ONLY the existing prose pages listed below.",
+    "",
+    "## Ground yourself in recent changes",
+    `Use read-only git to understand what changed recently: \`git log -n ${COMMIT_WINDOW} --stat\`,`,
+    "`git show <sha>`, `git diff <ref>..<ref>` (these forms are what you are permitted to run).",
+    "Pay attention to changes in:",
+    "- `src/config.ts` — environment variables (names, defaults, behavior)",
+    "- `docs/external-task-api.md`, `docs/sandbox-security.md`, `docs/token-usage-analysis.md` — the",
+    "  repo-root prose sources (you may edit these directly)",
+    "- the `src/` public surface and operator-facing behavior",
+    "",
+    "## Edit ONLY these existing pages (the in-scope set)",
+    ...IN_SCOPE_PATHS.map((p) => `- \`${p}\``),
+    "",
+    "## Hard rules",
+    "- Make a change ONLY where a doc is demonstrably stale versus the current source. For every",
+    "  change, know the source (file / commit) that justifies it.",
+    "- If you are UNSURE whether something is stale or how to phrase it, DO NOT guess — leave the doc",
+    "  as is and flag it in the summary's uncertainty section instead.",
+    "- DO NOT create new files. New pages are out of scope and will not be shipped.",
+    "- DO NOT edit generated docs: `docs-site/src/content/docs/reference/cli/*` (generated from",
+    "  `herdr --help`), the TypeDoc `api/*` output, or the Astro app config. They are off-limits.",
+    "- DO NOT run any git command except read-only inspection (`git log/show/diff/status`). DO NOT",
+    "  stage, commit, push, or open a PR — Shepherd does all of that for you after you finish.",
+    "- Use only the `Edit` and `Write` tools to change the in-scope files.",
+    "",
+    "## Finish by writing the summary",
+    `When done, write your summary to \`${SENTINEL}\` at the repository root (do NOT edit any other`,
+    "file afterward). Shape it as Markdown with two sections:",
+    "1. **Changes** — one bullet per edited file: what you changed and the source that grounds it.",
+    "2. **Uncertain / needs human judgment** — anything you suspected was stale but did not change.",
+    "",
+    "If the docs are already current, change nothing and write a summary saying so. Writing the",
+    `\`${SENTINEL}\` file is the last thing you do — it signals you are finished.`,
+  ].join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ import { DistillerService, defaultScratch } from "./distiller";
 import { OptimizerService, defaultOptimizerScratch } from "./optimizer";
 import { runAutoRetire } from "./learnings-lifecycle";
 import { Promoter } from "./promote";
+import { DocAgentService } from "./doc-agent";
 import { GitignoreAdopter } from "./gitignore-adopt";
 import { attachSignalCapture } from "./signals";
 import { HookIngest } from "./hooks-ingest";
@@ -566,6 +567,24 @@ const branchPruner = new BranchPruner(store, resolveForge, () =>
 setTimeout(() => void branchPruner.tick(), 30_000); // first sweep shortly after boot
 branchPruner.start();
 
+// PR-gated AI doc agent (issue #882, epic #875 Phase 3). Opt-in, default-off
+// (config.docAgentEnabled / SHEPHERD_DOC_AGENT). Manual trigger only; the boot orphan-sweep +
+// 15s finalize tick below are gated on the flag so the feature is fully inert when off.
+const docAgent = new DocAgentService({
+  herdr,
+  worktree,
+  resolveForge,
+  repos: () => listRepos(config.repoRoot).map((r) => r.path),
+  model: config.docAgentModel,
+  onChange: (f) => events.emit("doc-agent:done", f),
+});
+if (config.docAgentEnabled) {
+  // Boot reconcile: clear husk tabs + orphan docs-update-* worktrees from a pre-restart run so a
+  // unique-named re-spawn never collides and stale worktrees don't accumulate (works even if the
+  // herdr daemon also restarted — it parses `git worktree list`).
+  void docAgent.sweepOrphans().catch((err) => console.warn("[doc-agent] sweepOrphans:", err));
+}
+
 const reviewService = new ReviewService({
   store,
   herdr,
@@ -784,6 +803,8 @@ setInterval(() => {
   void recapService.sweep().catch((err) => console.warn("[recap] sweep failed:", err)); // settled-idle auto-fire
   void herdDigestService.tick().catch((err) => console.warn("[rundown] tick failed:", err)); // finalize in-flight digest (restart-safe)
   void herdDigestService.sweep().catch((err) => console.warn("[rundown] sweep failed:", err)); // daily auto-spark
+  if (config.docAgentEnabled)
+    void docAgent.tick().catch((err) => console.warn("[doc-agent] tick failed:", err)); // finalize: server stages/commits/pushes/opens PR
   try {
     buildQueueReminder.sweep(); // settled-idle nudge for a drifted build queue (sync)
   } catch (err) {
@@ -1376,6 +1397,7 @@ const appDeps: AppDeps = {
   distiller,
   optimizer,
   promoter,
+  docAgent: { consider: (repoPath: string) => docAgent.consider(repoPath) },
   gitignoreAdopter,
   drain: {
     snapshot: () => drain.snapshot(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -293,6 +293,11 @@ export interface AppDeps {
   };
   /** Promote a curated rule into the repo's CLAUDE.md via an auto-opened PR. */
   promoter?: { promote: (id: string) => Promise<import("./promote").PromoteResult> };
+  /** PR-gated AI doc agent (issue #882). Optional + flag-gated (config.docAgentEnabled); the route
+   *  404s when the flag is off or the service is unwired. Wired to DocAgentService in index.ts. */
+  docAgent?: {
+    consider: (repoPath: string) => Promise<import("./doc-agent").DocAgentResult>;
+  };
   /** Open a PR adding Shepherd's managed `.shepherd-*` ignore block to a repo's `.gitignore`. */
   gitignoreAdopter?: {
     adopt: (repoPath: string) => Promise<import("./gitignore-adopt").AdoptResult>;
@@ -868,6 +873,23 @@ async function handleRepoCollaborators({ req, parts, url, deps }: Ctx): Promise<
   const me = (await forge?.currentUser?.()) ?? null;
   const list = (await forge?.listCollaborators?.()) ?? { logins: [], unavailable: true };
   return json({ logins: list.logins, me, collaboratorsUnavailable: list.unavailable });
+}
+
+// POST /api/doc-agent?repo= — manually trigger the PR-gated AI doc agent (issue #882).
+// Opt-in + flag-gated: when SHEPHERD_DOC_AGENT is off (or the service is unwired) the endpoint
+// 404s deliberately, so a disabled feature is unadvertised (a chosen divergence from the 403/null
+// precedent — see configuration.md). On success the server (never the agent) commits/pushes/opens a
+// PR for human review; this just kicks the run off.
+async function handleDocAgent({ req, parts, url, deps }: Ctx): Promise<Response | null> {
+  if (!(parts[0] === "api" && parts[1] === "doc-agent" && !parts[2])) return null;
+  if (req.method !== "POST") return null;
+  if (!config.docAgentEnabled || !deps.docAgent) return json({ error: "not found" }, 404);
+  const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
+  if (!dir) return json({ error: "invalid repo" }, 400);
+  const res = await deps.docAgent.consider(dir);
+  if (res.status === "started") return json({ ok: true }, 202);
+  if (res.status === "skipped") return json({ ok: false, reason: res.reason }, 409);
+  return json({ error: res.reason ?? "doc agent failed" }, 400);
 }
 
 // /api/learnings — list (GET ?repo=), approve/dismiss (POST :id/action), distill (POST distill ?repo=)
@@ -4237,6 +4259,7 @@ const ROUTE_HANDLERS = [
   handleRepoRoles,
   handleRepoCollaborators,
   handleLearnings,
+  handleDocAgent,
   handlePush,
   handleSessionHooks,
   handleBuildQueue,

--- a/test/doc-agent-argv.test.ts
+++ b/test/doc-agent-argv.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test";
+import { docAgentArgv } from "../src/doc-agent-argv";
+import { config } from "../src/config";
+
+// Temporarily set config auth fields, always restoring them.
+function withAuth(mode: typeof config.authMode, helper: string | null, fn: () => void): void {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  try {
+    config.authMode = mode;
+    config.authApiKeyHelperPath = helper;
+    fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
+
+function settingsOf(argv: string[]): Record<string, unknown> {
+  return JSON.parse(argv[argv.indexOf("--settings") + 1]!);
+}
+
+test("posture: dontAsk present and is the LAST flag before the trailing prompt", () => {
+  const { argv } = docAgentArgv(null, "the task prompt");
+  const modeIdx = argv.indexOf("--permission-mode");
+  expect(modeIdx).toBeGreaterThan(-1);
+  expect(argv[modeIdx + 1]).toBe("dontAsk");
+  // dontAsk must sit AFTER the variadic --allowedTools and immediately before the prompt positional.
+  expect(modeIdx).toBeGreaterThan(argv.indexOf("--allowedTools"));
+  expect(argv[argv.length - 1]).toBe("the task prompt");
+});
+
+test("posture: NEVER --dangerously-skip-permissions (untrusted source history)", () => {
+  const { argv } = docAgentArgv(null, "p");
+  expect(argv).not.toContain("--dangerously-skip-permissions");
+});
+
+test("posture: --safe-mode coupled with enableAllProjectMcpServers; hooks disabled", () => {
+  const { argv } = docAgentArgv(null, "p");
+  expect(argv).toContain("--safe-mode");
+  expect(argv).toContain("--disable-slash-commands");
+  const s = settingsOf(argv);
+  expect(s.enableAllProjectMcpServers).toBe(true);
+  expect(s.disableAllHooks).toBe(true);
+});
+
+test("allowlist: read-only set + bare Write + bare Edit (Edit is the only widening)", () => {
+  const { argv } = docAgentArgv(null, "p");
+  for (const t of [
+    "Read",
+    "Grep",
+    "Glob",
+    "Bash(git diff *)",
+    "Bash(git log *)",
+    "Bash(git show *)",
+    "Bash(git status)",
+    "Write",
+    "Edit",
+  ]) {
+    expect(argv).toContain(t);
+  }
+});
+
+test("allowlist: NO git mutation, NO gh, NO general Bash, NO network (publishing is server-side)", () => {
+  const { argv } = docAgentArgv(null, "p");
+  // The structural guarantee for "never auto-commits to a published branch": the agent literally
+  // cannot stage/commit/push/open-a-PR — only DocAgentService.finalize() (the trusted server) does.
+  const forbidden = [
+    "Bash(git add *)",
+    "Bash(git add:*)",
+    "Bash(git commit *)",
+    "Bash(git commit:*)",
+    "Bash(git push *)",
+    "Bash(git push:*)",
+    "Bash(gh *)",
+    "Bash(gh:*)",
+    "Bash", // bare general Bash
+    "Bash(*)",
+    "WebFetch",
+    "WebSearch",
+  ];
+  for (const t of forbidden) expect(argv).not.toContain(t);
+});
+
+test("model: omitted → no --model flag; provided → appended once before dontAsk", () => {
+  const noModel = docAgentArgv(null, "p").argv;
+  expect(noModel).not.toContain("--model");
+
+  const withModel = docAgentArgv("opus", "p").argv;
+  const mi = withModel.indexOf("--model");
+  expect(mi).toBeGreaterThan(-1);
+  expect(withModel[mi + 1]).toBe("opus");
+  // --model must precede --permission-mode so the variadic allowlist isn't fed the model value.
+  expect(mi).toBeLessThan(withModel.indexOf("--permission-mode"));
+});
+
+test("subscription mode → no apiKeyHelper in settings (byte-stable)", () => {
+  withAuth("subscription", null, () => {
+    const s = settingsOf(docAgentArgv(null, "p").argv);
+    expect(s.apiKeyHelper).toBeUndefined();
+  });
+});
+
+test("api-key mode (configured) → apiKeyHelper folded into settings", () => {
+  withAuth("api-key", "/usr/local/bin/key-helper", () => {
+    const s = settingsOf(docAgentArgv(null, "p").argv);
+    expect(s.apiKeyHelper).toBe("/usr/local/bin/key-helper");
+  });
+});
+
+test("each call mints a fresh session id", () => {
+  const a = docAgentArgv(null, "p").sessionId;
+  const b = docAgentArgv(null, "p").sessionId;
+  expect(a).not.toBe(b);
+});

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -1,0 +1,296 @@
+import { test, expect } from "bun:test";
+import { DocAgentService, DOC_AGENT_LABEL, type DocAgentFinalize } from "../src/doc-agent";
+import { config } from "../src/config";
+
+function withAuth(
+  mode: typeof config.authMode,
+  helper: string | null,
+  fn: () => void | Promise<void>,
+) {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  config.authMode = mode;
+  config.authApiKeyHelperPath = helper;
+  const restore = () => {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  };
+  const r = fn();
+  if (r instanceof Promise) return r.finally(restore);
+  restore();
+  return r;
+}
+
+interface GitCall {
+  cwd: string;
+  args: string[];
+}
+
+interface Harness {
+  svc: DocAgentService;
+  gitCalls: GitCall[];
+  starts: { name: string; cwd: string }[];
+  closedTabs: string[];
+  removedWorktrees: string[];
+  openPrInputs: unknown[];
+  mergeCalls: number;
+  finalizes: DocAgentFinalize[];
+}
+
+function mkHarness(opts?: {
+  forgeKind?: "github" | "local" | null;
+  docTreePresent?: boolean;
+  inScopeFilesPresent?: boolean;
+  sentinel?: string | null;
+  stagedNames?: string; // stdout of `git diff --cached --name-only`
+  worktreeListPorcelain?: string;
+  herdrAgents?: { name: string; tabId: string }[];
+  repos?: string[];
+}): Harness {
+  const o = {
+    forgeKind: "github" as "github" | "local" | null,
+    docTreePresent: true,
+    inScopeFilesPresent: true,
+    sentinel: "## Changes\n- updated configuration.md (grounded in src/config.ts)\n" as
+      | string
+      | null,
+    stagedNames: "docs-site/src/content/docs/reference/configuration.md",
+    worktreeListPorcelain: "",
+    herdrAgents: [] as { name: string; tabId: string }[],
+    repos: [] as string[],
+    ...opts,
+  };
+
+  const gitCalls: GitCall[] = [];
+  const starts: { name: string; cwd: string }[] = [];
+  const closedTabs: string[] = [];
+  const removedWorktrees: string[] = [];
+  const openPrInputs: unknown[] = [];
+  const finalizes: DocAgentFinalize[] = [];
+  let mergeCalls = 0;
+
+  const git = async (cwd: string, args: string[]): Promise<string> => {
+    gitCalls.push({ cwd, args });
+    if (args[0] === "diff" && args[1] === "--cached") return o.stagedNames;
+    if (args[0] === "worktree" && args[1] === "list") return o.worktreeListPorcelain;
+    return "";
+  };
+
+  const forge =
+    o.forgeKind === null
+      ? null
+      : ({
+          kind: o.forgeKind,
+          defaultBranch: async () => "main",
+          openPr: async (input: unknown) => {
+            openPrInputs.push(input);
+            return { url: "https://forge/pr/42" };
+          },
+          merge: async () => {
+            mergeCalls++;
+          },
+        } as any);
+
+  const herdr = {
+    start: (name: string, cwd: string) => {
+      starts.push({ name, cwd });
+      return { terminalId: "term-" + starts.length } as any;
+    },
+    stop: () => {},
+    list: () => o.herdrAgents.map((a) => ({ name: a.name, tabId: a.tabId }) as any),
+    closeTab: (tabId: string) => {
+      closedTabs.push(tabId);
+    },
+  };
+
+  const worktree = {
+    create: (_repo: string, _base: string, name: string) => ({
+      worktreePath: `/wt/${name}`,
+      branch: `shepherd/${name}`,
+      isolated: true,
+    }),
+    remove: (p: string) => {
+      removedWorktrees.push(p);
+    },
+    gitCommonDir: (p: string) => `${p}/.git`,
+    ensureBaseRef: async (_repo: string, base: string) => ({
+      baseRef: base,
+      behind: 0,
+      ahead: 0,
+      diverged: false,
+      hasUpstream: true,
+      localExists: true,
+      localFf: "not-needed" as const,
+    }),
+  };
+
+  const svc = new DocAgentService({
+    herdr: herdr as any,
+    worktree: worktree as any,
+    resolveForge: () => forge,
+    repos: () => o.repos,
+    model: null,
+    onChange: (f) => finalizes.push(f),
+    now: () => 1000,
+    git,
+    detectBackend: () => null,
+    membraneEnv: () => ({ claudeDir: "/c", home: "/h", nodeBinReal: "/n", extraEnv: {} }),
+    fileExists: (p: string) => {
+      if (p.endsWith("docs-site/src/content/docs")) return o.docTreePresent;
+      return o.inScopeFilesPresent;
+    },
+    readSentinel: () => o.sentinel,
+  });
+
+  return {
+    svc,
+    gitCalls,
+    starts,
+    closedTabs,
+    removedWorktrees,
+    openPrInputs,
+    finalizes,
+    mergeCalls: 0,
+    get __merge() {
+      return mergeCalls;
+    },
+  } as any as Harness & { __merge: number };
+}
+
+test("happy path: in-scope edits → commit --no-verify + push + openPr (never merge)", async () => {
+  const h = mkHarness();
+  const res = await h.svc.consider("/repo");
+  expect(res.status).toBe("started");
+  expect(h.starts).toHaveLength(1);
+  expect(h.starts[0]!.name.startsWith(DOC_AGENT_LABEL)).toBe(true);
+
+  await h.svc.tick();
+
+  expect(h.gitCalls.some((c) => c.args[0] === "commit" && c.args.includes("--no-verify"))).toBe(
+    true,
+  );
+  expect(h.gitCalls.some((c) => c.args[0] === "push")).toBe(true);
+  expect(h.openPrInputs).toHaveLength(1);
+  expect((h.openPrInputs[0] as any).base).toBe("main");
+  expect((h.openPrInputs[0] as any).head).toMatch(/^shepherd\/docs-update-/);
+  // never merges
+  expect((h as any).__merge).toBe(0);
+  // PR body carries the grounding summary + human-review banner
+  expect((h.openPrInputs[0] as any).body).toContain("never auto-merged");
+  expect((h.openPrInputs[0] as any).body).toContain("configuration.md");
+  // finalize emits the url
+  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: "https://forge/pr/42" }]);
+  // cleanup
+  expect(h.removedWorktrees.length).toBeGreaterThan(0);
+});
+
+test("structural off-limits: only the in-scope file list is ever staged (no cli/*, no Astro app)", async () => {
+  const h = mkHarness();
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  const add = h.gitCalls.find((c) => c.args[0] === "add");
+  expect(add).toBeDefined();
+  const staged = add!.args.slice(2); // after ["add","--"]
+  for (const p of staged) {
+    expect(p.includes("/reference/cli/")).toBe(false);
+    expect(p.endsWith("astro.config.mjs")).toBe(false);
+    expect(p.endsWith("package.json")).toBe(false);
+    expect(p).not.toBe(".shepherd-doc-update.md");
+  }
+  // and it did stage the known in-scope page
+  expect(staged).toContain("docs-site/src/content/docs/reference/configuration.md");
+});
+
+test("nothing staged (docs already current) → no commit/push/PR, no error", async () => {
+  const h = mkHarness({ stagedNames: "" });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  expect(h.gitCalls.some((c) => c.args[0] === "commit")).toBe(false);
+  expect(h.gitCalls.some((c) => c.args[0] === "push")).toBe(false);
+  expect(h.openPrInputs).toHaveLength(0);
+  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: null }]);
+});
+
+test("fail-closed: api-key mode without a configured key → skip, no spawn", async () => {
+  await withAuth("api-key", null, async () => {
+    const h = mkHarness();
+    const res = await h.svc.consider("/repo");
+    expect(res.status).toBe("skipped");
+    expect(h.starts).toHaveLength(0);
+  });
+});
+
+test("fail-closed: local forge (lightweight repo) → skip, no spawn", async () => {
+  const h = mkHarness({ forgeKind: "local" });
+  const res = await h.svc.consider("/repo");
+  expect(res.status).toBe("skipped");
+  expect(h.starts).toHaveLength(0);
+});
+
+test("guard: no forge configured → error, no spawn", async () => {
+  const h = mkHarness({ forgeKind: null });
+  const res = await h.svc.consider("/repo");
+  expect(res.status).toBe("error");
+  expect(h.starts).toHaveLength(0);
+});
+
+test("layout guard: repo without docs-site doc tree → skip, no spawn", async () => {
+  const h = mkHarness({ docTreePresent: false });
+  const res = await h.svc.consider("/repo");
+  expect(res.status).toBe("skipped");
+  expect(h.starts).toHaveLength(0);
+});
+
+test("in-flight guard: a second trigger while one runs is skipped", async () => {
+  const h = mkHarness();
+  expect((await h.svc.consider("/repo")).status).toBe("started");
+  expect((await h.svc.consider("/repo")).status).toBe("skipped");
+  expect(h.starts).toHaveLength(1);
+});
+
+test("restart safety: unique-per-run agent names never collide", async () => {
+  const h = mkHarness();
+  await h.svc.consider("/repo");
+  await h.svc.tick(); // clears inflight for /repo
+  await h.svc.consider("/repo");
+  expect(h.starts).toHaveLength(2);
+  expect(h.starts[0]!.name).not.toBe(h.starts[1]!.name);
+});
+
+test("sweepOrphans: closes only __docagent__ tabs and prunes only docs-update worktrees", async () => {
+  const porcelain = [
+    "worktree /repo",
+    "branch refs/heads/main",
+    "",
+    "worktree /wt/docs-update-abc12345",
+    "branch refs/heads/shepherd/docs-update-abc12345",
+    "",
+    "worktree /wt/feature",
+    "branch refs/heads/shepherd/some-feature",
+    "",
+  ].join("\n");
+  const h = mkHarness({
+    repos: ["/repo"],
+    worktreeListPorcelain: porcelain,
+    herdrAgents: [
+      { name: "__docagent__deadbeef", tabId: "tab-doc" },
+      { name: "review TASK-7", tabId: "tab-review" },
+    ],
+  });
+  await h.svc.sweepOrphans();
+  // only the doc-agent husk tab closed
+  expect(h.closedTabs).toEqual(["tab-doc"]);
+  // only the docs-update worktree removed; main + unrelated feature left alone
+  expect(h.removedWorktrees).toEqual(["/wt/docs-update-abc12345"]);
+  // the orphan branch force-deleted
+  expect(
+    h.gitCalls.some(
+      (c) =>
+        c.args[0] === "branch" &&
+        c.args[1] === "-D" &&
+        c.args[2] === "shepherd/docs-update-abc12345",
+    ),
+  ).toBe(true);
+  // unrelated feature branch NOT deleted
+  expect(h.gitCalls.some((c) => c.args.includes("shepherd/some-feature"))).toBe(false);
+});

--- a/test/server-doc-agent.test.ts
+++ b/test/server-doc-agent.test.ts
@@ -1,0 +1,106 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { config } from "../src/config";
+import type { DocAgentResult } from "../src/doc-agent";
+
+let tmpRoot: string;
+let repoDir: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(config.repoRoot, "shepherd-docagent-test-"));
+  repoDir = join(tmpRoot, "repo");
+  mkdirSync(repoDir);
+});
+afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+function withFlag(on: boolean, fn: () => Promise<void>): Promise<void> {
+  const prev = config.docAgentEnabled;
+  config.docAgentEnabled = on;
+  return fn().finally(() => {
+    config.docAgentEnabled = prev;
+  });
+}
+
+function harness(consider?: (repoPath: string) => Promise<DocAgentResult>) {
+  const store = new SessionStore(":memory:");
+  const deps: AppDeps = {
+    store,
+    service: {} as any,
+    events: new EventHub(),
+    usageLimits: { limits: () => ({}) } as any,
+    docAgent: consider ? { consider } : undefined,
+  };
+  return makeApp(deps);
+}
+
+const repoUrl = (repo: string) => `http://x/api/doc-agent?repo=${encodeURIComponent(repo)}`;
+
+test("flag OFF → 404 (endpoint unadvertised) even when wired", async () => {
+  await withFlag(false, async () => {
+    const app = harness(async () => ({ status: "started" }));
+    const res = await app.fetch(new Request(repoUrl(repoDir), { method: "POST" }));
+    expect(res.status).toBe(404);
+  });
+});
+
+test("flag ON but service unwired → 404", async () => {
+  await withFlag(true, async () => {
+    const app = harness(undefined);
+    const res = await app.fetch(new Request(repoUrl(repoDir), { method: "POST" }));
+    expect(res.status).toBe(404);
+  });
+});
+
+test("flag ON + started → 202", async () => {
+  await withFlag(true, async () => {
+    let calledWith = "";
+    const app = harness(async (r) => {
+      calledWith = r;
+      return { status: "started" };
+    });
+    const res = await app.fetch(new Request(repoUrl(repoDir), { method: "POST" }));
+    expect(res.status).toBe(202);
+    expect(calledWith).toContain("repo");
+  });
+});
+
+test("flag ON + skipped → 409", async () => {
+  await withFlag(true, async () => {
+    const app = harness(async () => ({ status: "skipped", reason: "already running" }));
+    const res = await app.fetch(new Request(repoUrl(repoDir), { method: "POST" }));
+    expect(res.status).toBe(409);
+  });
+});
+
+test("flag ON + error → 400", async () => {
+  await withFlag(true, async () => {
+    const app = harness(async () => ({ status: "error", reason: "no forge" }));
+    const res = await app.fetch(new Request(repoUrl(repoDir), { method: "POST" }));
+    expect(res.status).toBe(400);
+  });
+});
+
+test("flag ON + invalid/missing repo → 400, consider not called", async () => {
+  await withFlag(true, async () => {
+    let called = false;
+    const app = harness(async () => {
+      called = true;
+      return { status: "started" };
+    });
+    const res = await app.fetch(new Request("http://x/api/doc-agent", { method: "POST" }));
+    expect(res.status).toBe(400);
+    expect(called).toBe(false);
+  });
+});
+
+test("GET is not handled (POST-only trigger)", async () => {
+  await withFlag(true, async () => {
+    const app = harness(async () => ({ status: "started" }));
+    const res = await app.fetch(new Request(repoUrl(repoDir), { method: "GET" }));
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## What

Phase 3 of the docs-site epic (#875): a **PR-gated AI doc agent** — the smallest end-to-end slice per the single-PR invariant. Opt-in and **off by default**.

When enabled (`SHEPHERD_DOC_AGENT=1`), a manual trigger spawns a scoped Claude Code agent that diffs recent source changes against the hand-written docs and edits stale prose. The agent itself runs **no git**; the trusted Shepherd server stages an explicit in-scope file list, commits, pushes, and **opens a PR for human review — never auto-merges**.

## Architecture (the `promote.ts` pattern, faithfully)

- **Agent only EDITS files** — `docAgentArgv()` is the read-only-reviewer posture + bare `Edit`: `--permission-mode dontAsk`, `--safe-mode`, **never** `--dangerously-skip-permissions`. Allowlist has **no** git mutation / `gh` / network / general Bash. So "never auto-commits to a published branch" is enforced **by construction**, not by prompt.
- **Server does ALL git** — `DocAgentService.finalize()` stages **only** the explicit in-scope file list (∩ files that exist), so any edit to the Astro app, the generated `reference/cli/*`, or a new file is never staged → can't reach the PR. Then `commit --no-verify` (deliberate divergence from `promote.ts`, documented inline) → `push` → `forge.openPr()`. Empty change set → no PR.
- **Fail-closed guards** before any spawn: api-key-mode-without-key (don't bill subscription), `local` forge (no PR surface), and a layout guard (repo lacks the `docs-site` doc tree).
- **Restart-safe**: unique-per-run herdr name `__docagent__<8hex>` makes `agent_name_taken` impossible; a boot `sweepOrphans()` closes husk tabs **and** prunes orphan `shepherd/docs-update-*` worktrees via `git worktree list` (works even when the herdr daemon also restarted).

## Trigger

`POST /api/doc-agent?repo=<path>` — flag-gated (returns **404** when off, a deliberate, documented divergence from the 403/`null` route precedent so a disabled opt-in feature is unadvertised).

## Tests

- `test/doc-agent-argv.test.ts` — spawn posture (dontAsk last; no skip-perms; no git-mutation/`gh`/network; `--safe-mode`+`enableAllProjectMcpServers` coupled).
- `test/doc-agent.test.ts` — happy path (commit `--no-verify` + push + `openPr`, **never** `merge`); structural staging boundary; nothing-staged → no PR; all three fail-closed guards; in-flight guard; unique-name restart safety; `sweepOrphans` scoping.
- `test/server-doc-agent.test.ts` — route 404 (flag off / unwired) · 202 / 409 / 400 mapping · invalid-repo 400 · POST-only.

Root `tsc`, lint, full `bun test ./test`, and `fallow audit` all green locally. (The local pre-push hook flaked on pre-existing, unrelated infra — root `worktree.test.ts` `/tmp` races and the UI vitest exit-timeout; this change touches no UI and no shared-git-state test infra. CI is the authoritative gate.)

## Re-decomposition (single-PR invariant)

This issue bundles four separable concerns; this PR ships the smallest demonstrable slice (manual trigger + scoped spawn + restart-safe naming + off-by-default flag). Follow-ups filed:

- Scheduling — nightly + merge-triggered cadence (#904)
- Soak rollout phases + durable run tracking + remote-branch reaping (#905)
- UI surface — trigger button + run/PR badge (#906)

Closes #882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
