### PR TITLE
fix(ui): de-dupe learnings count + drop underline in repo filter rail

### DIFF
--- a/ui/src/lib/components/RepoSwitcher.browser.test.ts
+++ b/ui/src/lib/components/RepoSwitcher.browser.test.ts
@@ -148,6 +148,51 @@ describe("RepoSwitcher — filter rail", () => {
       .toBeVisible();
   });
 
+  it("active chip with insights shows the ✦ count ONCE — telemetry line only, no chip mark (no dup)", async () => {
+    const learnChip = chip({ repoPath: "/repo/alpha", insights: 31 });
+    const { container } = render(RepoSwitcher, {
+      chips: [learnChip, chip({ repoPath: "/repo/beta" })],
+      repoFilter: "/repo/alpha",
+      onrepofilter: () => {},
+    });
+    // the active chip drops its decorative mark...
+    expect(
+      container.querySelector(".rs-learn-mark"),
+      "no decorative ✦ mark on the active chip",
+    ).toBeNull();
+    // ...the actionable ✦ count lives once, in the telemetry detail line below
+    const insightsBtns = container.querySelectorAll(".rs-insights");
+    expect(insightsBtns.length, "exactly one actionable ✦ count").toBe(1);
+    expect(insightsBtns[0].querySelector(".rs-insights-n")?.textContent).toBe("31");
+  });
+
+  it("a NON-active chip with insights keeps its ✦ mark even while another repo is filtered", async () => {
+    const { container } = render(RepoSwitcher, {
+      chips: [
+        chip({ repoPath: "/repo/alpha", insights: 5 }),
+        chip({ repoPath: "/repo/beta", insights: 9 }),
+      ],
+      repoFilter: "/repo/beta",
+      onrepofilter: () => {},
+    });
+    // beta is active → its chip mark is gone; alpha (inactive) keeps its mark
+    const marks = container.querySelectorAll(".rs-learn-mark");
+    expect(marks.length, "one mark — on the inactive chip only").toBe(1);
+    expect(marks[0].querySelector(".rs-learn-n")?.textContent).toBe("5");
+  });
+
+  it("the active filter chip carries no underline text-decoration", async () => {
+    const { container } = render(RepoSwitcher, {
+      chips: [chip({ repoPath: "/repo/alpha" }), chip({ repoPath: "/repo/beta" })],
+      repoFilter: "/repo/alpha",
+      onrepofilter: () => {},
+    });
+    const activeChip = container.querySelector<HTMLElement>(".rs-chip.active");
+    expect(activeChip, "active chip present").not.toBeNull();
+    const deco = getComputedStyle(activeChip!).textDecorationLine;
+    expect(deco, "no underline on the active chip").toBe("none");
+  });
+
   it("active-repo detail line appears only when the filtered repo has telemetry", async () => {
     const withTele = chip({
       repoPath: "/repo/alpha",

--- a/ui/src/lib/components/RepoSwitcher.svelte
+++ b/ui/src/lib/components/RepoSwitcher.svelte
@@ -143,7 +143,9 @@
             {#if chip.drain?.paused}
               <span class="rs-paused-dot" aria-hidden="true">●</span>
             {/if}
-            {#if chip.insights > 0 || chip.curate > 0}
+            {#if !active && (chip.insights > 0 || chip.curate > 0)}
+              <!-- decorative ✦ mark — suppressed on the active chip, whose actionable
+                   ✦ count already shows in the telemetry detail line below (no dup) -->
               <span class="rs-learn-mark" title={m.learnings_badge_tip()} aria-hidden="true"
                 >✦{#if chip.insights > 0}<span class="rs-learn-n">{chip.insights}</span>{/if}</span
               >
@@ -254,12 +256,10 @@
     color: var(--color-ink-bright);
     border-color: var(--color-line-bright);
   }
-  /* active filter: amber text + amber underline (mirrors .qs-repo-btn.active) */
+  /* active filter: amber text + amber border carry the selection (no underline) */
   .rs-chip.active {
     color: var(--color-amber);
     border-color: var(--color-amber);
-    text-decoration: underline;
-    text-underline-offset: 3px;
   }
   /* the repo glyph is identity, not status — keep it on the ink ramp, never a
      status hue (Four-Light Rule). */


### PR DESCRIPTION
## Problem

When a repo filter is active in the session-list **repo switcher rail**, the selected repo's learnings count rendered **twice** — once as the decorative `✦<count>` mark on the chip itself, and again as the actionable `✦<count>` button in the telemetry detail line below it. The active chip also carried an amber underline.

(From the report: `FLOWAGENT 3 ✦31` chip + `✦ 31` line below.)

## Fix

`ui/src/lib/components/RepoSwitcher.svelte`:

- **De-dupe:** suppress the chip's decorative `.rs-learn-mark` when that chip is the *active* filter — its actionable counterpart already shows in the telemetry line below. Inactive chips keep their mark, so the rail's at-a-glance learnings cue is preserved.
- **Underline:** removed `text-decoration: underline` from `.rs-chip.active`. Selection is still clearly carried by amber text + amber border. (The comment referenced `.qs-repo-btn.active`, which no longer exists in source — this was the sole occurrence.)

## Tests

Three regression tests added to `RepoSwitcher.browser.test.ts`, each verified to **fail on pre-fix code**:
- active chip with insights → ✦ count appears exactly once (telemetry line only, no chip mark)
- a non-active chip keeps its ✦ mark while another repo is filtered
- the active chip carries no underline `text-decoration`

`cd ui && bun run check` ✓ · full UI suite (1798 tests) ✓

Pure visual bug fix — no new user-facing capability, strings, or terms, so `[no-feature-entry]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)