### PR TITLE
fix(docs): make TypeDoc API build self-contained for Vercel

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -39,13 +39,22 @@ export default defineConfig({
       plugins: [
         starlightTypeDoc({
           entryPoints: ["../src"],
-          tsconfig: "../tsconfig.json",
+          // Dedicated, docs-site-local tsconfig (NOT the root one): scopes the
+          // TypeDoc program to ../src and resolves Bun/node globals from this
+          // package's own @types/bun, so the API reference builds on Vercel where
+          // only docs-site/ is installed. See typedoc.tsconfig.json for the why.
+          tsconfig: "./typedoc.tsconfig.json",
           output: "api",
           sidebar: { label: "API reference", collapsed: true },
           typeDoc: {
             // `expand` documents every .ts under ../src (there is no public-API
             // barrel to use as a single entry point).
             entryPointStrategy: "expand",
+            // Generate docs even if a stray type can't be resolved in the docs-site
+            // install — the docs build must not gate on a type diagnostic (the root
+            // `tsc`/CI is the real type gate). Belt-and-suspenders with the scoped
+            // tsconfig above, which already makes ../src resolve cleanly here.
+            skipErrorChecking: true,
             // Drop the lone test file and the zero-export entry script.
             exclude: ["**/*.test.ts", "**/src/index.ts"],
             readme: "none",

--- a/docs-site/bun.lock
+++ b/docs-site/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
+        "@types/bun": "^1.3.14",
         "starlight-llms-txt": "^0.10.0",
         "starlight-typedoc": "^0.23.0",
         "typedoc": "^0.28.19",
@@ -277,6 +278,8 @@
 
     "@types/braces": ["@types/braces@3.0.5", "", {}, "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
@@ -364,6 +367,8 @@
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@types/bun": "^1.3.14",
     "starlight-llms-txt": "^0.10.0",
     "starlight-typedoc": "^0.23.0",
     "typedoc": "^0.28.19",

--- a/docs-site/typedoc.tsconfig.json
+++ b/docs-site/typedoc.tsconfig.json
@@ -1,0 +1,25 @@
+{
+  // Dedicated tsconfig for starlight-typedoc's API-reference generation — NOT the
+  // root tsconfig. On Vercel the project root is `docs-site/`, so only this
+  // package's deps are installed; the root `node_modules` (and its `bun-types`)
+  // never exist there. Pointing TypeDoc at `../tsconfig.json` therefore failed two
+  // ways on deploy: its `types: ["bun-types"]` couldn't resolve (TS2688), and its
+  // include-less program pulled in the whole repo (ci/, deploy/, scripts/) whose
+  // node/bun globals were unresolved.
+  //
+  // This config fixes both: the program is scoped to `../src` ONLY (the sole thing
+  // we document), and Bun + node globals resolve from docs-site's own `@types/bun`
+  // (a devDependency here), so the API reference builds self-contained on Vercel.
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true
+  },
+  "include": ["../src/**/*.ts"],
+  "exclude": ["../src/**/*.test.ts", "../src/index.ts"]
+}


### PR DESCRIPTION
## Problem

The docs-site Vercel deploy (commit `6d65b12`, from epic #875 / #908) **failed**:

```
[ERROR] [starlight-typedoc-plugin] error TS2688: Cannot find type definition file for 'bun-types'.
[ERROR] ../ci/onboarding-harness/run.ts: error TS2591: Cannot find name 'process'. …
… (cascade across ci/, deploy/, scripts/)
```

Vercel's project root is `docs-site/`, so **only that package is installed** — the root `node_modules` (and its `bun-types`) never exist on the build machine. But `astro build` regenerates the TypeScript API reference via `starlight-typedoc`, which was pointed at the **root** `../tsconfig.json`. That config:

1. sets `types: ["bun-types"]` → unresolvable on Vercel (**TS2688**), and
2. has no `include`, so its program spans the whole repo (`ci/`, `deploy/`, `scripts/`) whose node/bun globals are also unresolved (**TS2591/TS2339 cascade**).

It only passed locally because the developer's root `node_modules` happened to supply `bun-types`.

## Fix — make the API build self-contained

- **`docs-site/typedoc.tsconfig.json`** (new): a dedicated TypeDoc tsconfig whose program is scoped to `../src` only, resolving Bun/node globals from this package's own `@types/bun`.
- **`@types/bun`** added as a `docs-site` devDependency (so Vercel installs it; `bun.lock` updated).
- **`skipErrorChecking: true`** on the TypeDoc options so a stray unresolved type can never gate the docs deploy — the root `tsc`/CI remains the real type gate.

## Verification

Reproduced Vercel faithfully by hiding the root `node_modules` and building `docs-site/` alone:

- **Before:** red — identical `TS2688` + cascade.
- **After:** green — 809 pages built, Pagefind index OK, `astro check` 0 errors. Spot-checked the generated API pages: real resolved types (`Promise<ActivityEntry[]>` etc.), not `any` — `skipErrorChecking` is insurance, not masking degraded output.

[no-feature-entry] — server/docs-build plumbing fix, no user-facing UX.