### PR TITLE
refactor(ui): extract page/AppOverlays from +page, drop fallow grandfather (#855)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -164,12 +164,14 @@
     //   external convention exists for template thresholds — this is a deliberate
     //   judgment call. 27 of 36 components clear it; anything over it still trips, so
     //   the metric stays live for new code.
-    // Tier 2: the 3 giants that exceed Tier 1, each grandfathered just above its
+    // Tier 2: the 2 giants that exceed Tier 1, each grandfathered just above its
     //   current cyclo/cog (next multiple of 10) so it can't silently grow. Tracked for
-    //   refactor in #855 — which has paid down 10 of the original 13 (RepoSwitcher,
+    //   refactor in #855 — which has paid down 11 of the original 13 (RepoSwitcher,
     //   NewTask, AutomationSettings, Settings, IssuesPanel, BacklogView, UnitRow,
-    //   GitRail, TopBar, Herd), each split into subcomponents that clear the Tier-1 bar,
-    //   so their grandfathers are removed. Remaining: Viewport, +page, LearningsDrawer.
+    //   GitRail, TopBar, Herd, +page), each split into subcomponents that clear the
+    //   Tier-1 bar, so their grandfathers are removed. +page fell 78/96 -> 32/45 after
+    //   extracting page/AppOverlays (the modal/overlay tail + Triage/Learnings drawers,
+    //   33/23) — no main-region split was needed. Remaining: Viewport, LearningsDrawer.
     // maxCrap is intentionally inert for templates: CRAP for uncovered code is pure
     //   CC-derived noise bounded by CC²+CC; 20000 sits above the largest template's
     //   worst case (Viewport CC 136 → ≈18632) so it never becomes the binding
@@ -199,14 +201,6 @@
         // 60 bar without splitting the nesting into unnatural sub-components, so
         // it stays grandfathered (just above current) and tracked in #855.
         "reason": "Tier 2 grandfather (#851), tightened by #855; remaining .vp-head identity/status split tracked in #855."
-      },
-      {
-        "files": ["ui/src/routes/+page.svelte"],
-        "functions": ["<template>"],
-        "maxCyclomatic": 80,
-        "maxCognitive": 100,
-        "maxCrap": 20000,
-        "reason": "Tier 2 grandfather (#851); refactor candidate #855."
       },
       {
         "files": ["ui/src/lib/components/LearningsDrawer.svelte"],

--- a/ui/src/lib/components/page/AppOverlays.browser.test.ts
+++ b/ui/src/lib/components/page/AppOverlays.browser.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import AppOverlays from "./AppOverlays.svelte";
+import type { HerdStore } from "$lib/store.svelte";
+
+// NewTask calls listRepos() on mount; stub it so the dialog mounts without a server.
+// Keep every other $lib/api export real (AppOverlays imports many for the
+// learnings/triage drawers, but those only fire on interaction, not on mount).
+vi.mock("$lib/api", async (orig) => ({
+  ...((await orig()) as object),
+  listRepos: vi.fn().mockResolvedValue({ repos: [], recentWindowDays: 30 }),
+}));
+
+// store is only read by overlay blocks that are not shown in these tests (update,
+// herdr-update, broadcast, retry, backlog, star-prompt); the NewTask path never
+// touches it. A bare stub avoids HerdStore construction side-effects.
+const store = {} as unknown as HerdStore;
+
+type Props = Parameters<typeof AppOverlays>[1];
+
+function baseProps(): Props {
+  return {
+    store,
+    settings: null,
+    mobile: false,
+    showTriage: false,
+    blockedEntries: [],
+    nowMs: 0,
+    ontriageopen: vi.fn(),
+    ontriageclose: vi.fn(),
+    onresumequota: vi.fn(),
+    ontakeoverquota: vi.fn(),
+    onabandonquota: vi.fn(),
+    showLearnings: false,
+    learningsRepo: null,
+    onlearningsclose: vi.fn(),
+    showUpdate: false,
+    deploy: null,
+    onupdateconfirm: vi.fn(),
+    onupdateclose: vi.fn(),
+    showHerdrUpdate: false,
+    herdrUpdating: false,
+    onherdrupdateconfirm: vi.fn(),
+    onherdrupdateclose: vi.fn(),
+    showOnboarding: false,
+    diagnosticsLoadFailed: false,
+    ononboardingretry: vi.fn(),
+    ononboardingdismiss: vi.fn(),
+    showWhatsNew: false,
+    whatsNewEntries: [],
+    onwhatsnewdismiss: vi.fn(),
+    onwhatsnewclose: vi.fn(),
+    showFableArrival: false,
+    onfabletry: vi.fn(),
+    onfableclose: vi.fn(),
+    showNew: false,
+    onsubmit: vi.fn(),
+    relaunchOriginal: false,
+    composeRepoPath: null,
+    repoFilter: null,
+    composeBaseBranch: null,
+    composeIssue: null,
+    relaunchIssueNumber: null,
+    composeImages: [],
+    composePrompt: null,
+    composeModel: null,
+    holdLikely: false,
+    onnewclose: vi.fn(),
+    onnewclone: vi.fn(),
+    onnewfork: vi.fn(),
+    onnewnewproject: vi.fn(),
+    showSettings: false,
+    settingsTab: "workspace",
+    onsettingsclose: vi.fn(),
+    onsettingsherdrupdate: vi.fn(),
+    onsettingsclone: vi.fn(),
+    onsettingsfork: vi.fn(),
+    onsettingswhatsnew: vi.fn(),
+    showClone: false,
+    oncloneclose: vi.fn(),
+    onclonedone: vi.fn(),
+    showFork: false,
+    onforkclose: vi.fn(),
+    onforkdone: vi.fn(),
+    showNewProject: false,
+    onnewprojectclose: vi.fn(),
+    onnewprojectdone: vi.fn(),
+    showBroadcast: false,
+    onbroadcastclose: vi.fn(),
+    showRetry: false,
+    onretryclose: vi.fn(),
+    clearMergedSessions: null,
+    clearMergedLeftovers: 0,
+    onclearmergedclose: vi.fn(),
+    onclearmergedconfirm: vi.fn(),
+    showBacklog: false,
+    backlog: null,
+    epicTarget: null,
+    inTrainPrs: new Set<string>(),
+    onissue: vi.fn(),
+    onquick: vi.fn(),
+    onpr: vi.fn(),
+    onadopt: vi.fn(),
+    onlaunchtrain: vi.fn(),
+    onbacklogclose: vi.fn(),
+    pendingTrain: null,
+    ontrainclose: vi.fn(),
+    ontrainconfirm: vi.fn(),
+    onstarresolve: vi.fn(),
+  };
+}
+
+// Regression guard for the #855 +page → AppOverlays extraction: the
+// NewTask↔Clone↔Fork↔NewProject handoff wiring now flows through AppOverlays
+// props (onnewclone/onnewfork/onnewnewproject), so verify each repo-picker
+// shortcut still reaches the route-owned handler that runs resetCompose + opens
+// the next dialog.
+describe("AppOverlays — NewTask repo-picker handoffs", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  async function openRepoPicker() {
+    await page.getByRole("button", { name: /select a repo/i }).click();
+  }
+
+  it("forwards the Clone shortcut to onnewclone", async () => {
+    const props = baseProps();
+    props.showNew = true;
+    render(AppOverlays, props);
+    await openRepoPicker();
+    await page.getByRole("button", { name: "+ Clone repository" }).click();
+    expect(props.onnewclone).toHaveBeenCalledOnce();
+    expect(props.onnewfork).not.toHaveBeenCalled();
+    expect(props.onnewnewproject).not.toHaveBeenCalled();
+  });
+
+  it("forwards the Fork shortcut to onnewfork", async () => {
+    const props = baseProps();
+    props.showNew = true;
+    render(AppOverlays, props);
+    await openRepoPicker();
+    await page.getByRole("button", { name: "+ Fork a GitHub repo" }).click();
+    expect(props.onnewfork).toHaveBeenCalledOnce();
+    expect(props.onnewclone).not.toHaveBeenCalled();
+    expect(props.onnewnewproject).not.toHaveBeenCalled();
+  });
+
+  it("forwards the New-project shortcut to onnewnewproject", async () => {
+    const props = baseProps();
+    props.showNew = true;
+    render(AppOverlays, props);
+    await openRepoPicker();
+    await page.getByRole("button", { name: "+ New project" }).click();
+    expect(props.onnewnewproject).toHaveBeenCalledOnce();
+    expect(props.onnewclone).not.toHaveBeenCalled();
+    expect(props.onnewfork).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -1,0 +1,498 @@
+<script lang="ts">
+  import type { ComponentProps } from "svelte";
+  import { m } from "$lib/paraglide/messages";
+  import { displayStatus } from "$lib/display-status";
+  import { learnings } from "$lib/learnings.svelte";
+  import { toasts } from "$lib/toasts.svelte";
+  import { basename } from "$lib/components/learnings-drawer";
+  import {
+    replySession,
+    dismissStall,
+    approveLearning,
+    dismissLearning,
+    distillRepo,
+    promoteLearning,
+    optimizeLearning,
+    optimizeRepoFlagged,
+    restoreLearning,
+    setLearningScope,
+    markRetiredSeen,
+    applyMergeSuggestion,
+    dismissMergeSuggestion,
+    promoteGlobalLearning,
+    mergeSuggestNow,
+  } from "$lib/api";
+  import type { HerdStore } from "$lib/store.svelte";
+  import type { BlockedEntry } from "$lib/triage";
+  import type {
+    BacklogPayload,
+    DeployState,
+    Issue,
+    PullRequest,
+    Session,
+    Settings as Settings_,
+    StarPromptStatus,
+    Steer,
+  } from "$lib/types";
+  import type { FeatureAnnouncement } from "$lib/feature-announcements";
+  import TriageDrawer from "$lib/components/TriageDrawer.svelte";
+  import LearningsDrawer from "$lib/components/LearningsDrawer.svelte";
+  import NewTask from "$lib/components/NewTask.svelte";
+  import Settings from "$lib/components/Settings.svelte";
+  import CloneRepo from "$lib/components/CloneRepo.svelte";
+  import ForkRepo from "$lib/components/ForkRepo.svelte";
+  import NewProject from "$lib/components/NewProject.svelte";
+  import type { KickoffChoice } from "$lib/components/NewProject.svelte";
+  import BroadcastDialog from "$lib/components/BroadcastDialog.svelte";
+  import RetryDialog from "$lib/components/RetryDialog.svelte";
+  import ClearMergedDialog from "$lib/components/ClearMergedDialog.svelte";
+  import MergeTrainConfirmDialog from "$lib/components/MergeTrainConfirmDialog.svelte";
+  import BacklogOverlay from "$lib/components/BacklogOverlay.svelte";
+  import UpdateModal from "$lib/components/UpdateModal.svelte";
+  import HerdrUpdateModal from "$lib/components/HerdrUpdateModal.svelte";
+  import StarPrompt from "$lib/components/StarPrompt.svelte";
+  import WhatsNew from "$lib/components/WhatsNew.svelte";
+  import FableArrival from "$lib/components/FableArrival.svelte";
+  import Onboarding from "$lib/components/Onboarding.svelte";
+
+  type PendingTrain = {
+    repoLabel: string;
+    items: { number: number; title: string }[];
+    handpicked: boolean;
+    otherRepoCount: number;
+    run: () => Promise<void>;
+  } | null;
+
+  let {
+    store,
+    settings,
+    mobile,
+    // in-shell drawers
+    showTriage,
+    blockedEntries,
+    nowMs,
+    ontriageopen,
+    ontriageclose,
+    onresumequota,
+    ontakeoverquota,
+    onabandonquota,
+    showLearnings,
+    learningsRepo,
+    onlearningsclose,
+    // system / announcement modals
+    showUpdate,
+    deploy,
+    onupdateconfirm,
+    onupdateclose,
+    showHerdrUpdate,
+    herdrUpdating,
+    onherdrupdateconfirm,
+    onherdrupdateclose,
+    showOnboarding,
+    diagnosticsLoadFailed,
+    ononboardingretry,
+    ononboardingdismiss,
+    showWhatsNew,
+    whatsNewEntries,
+    onwhatsnewdismiss,
+    onwhatsnewclose,
+    showFableArrival,
+    onfabletry,
+    onfableclose,
+    // compose flow
+    showNew,
+    onsubmit,
+    relaunchOriginal,
+    composeRepoPath,
+    repoFilter,
+    composeBaseBranch,
+    composeIssue,
+    relaunchIssueNumber,
+    composeImages,
+    composePrompt,
+    composeModel,
+    holdLikely,
+    onnewclose,
+    onnewclone,
+    onnewfork,
+    onnewnewproject,
+    showSettings,
+    settingsTab,
+    onsettingsclose,
+    onsettingsherdrupdate,
+    onsettingsclone,
+    onsettingsfork,
+    onsettingswhatsnew,
+    showClone,
+    oncloneclose,
+    onclonedone,
+    showFork,
+    onforkclose,
+    onforkdone,
+    showNewProject,
+    onnewprojectclose,
+    onnewprojectdone,
+    // session-action dialogs
+    showBroadcast,
+    onbroadcastclose,
+    showRetry,
+    onretryclose,
+    clearMergedSessions,
+    clearMergedLeftovers,
+    onclearmergedclose,
+    onclearmergedconfirm,
+    showBacklog,
+    backlog,
+    epicTarget,
+    inTrainPrs,
+    onissue,
+    onquick,
+    onpr,
+    onadopt,
+    onlaunchtrain,
+    onbacklogclose,
+    pendingTrain,
+    ontrainclose,
+    ontrainconfirm,
+    onstarresolve,
+  }: {
+    store: HerdStore;
+    settings: Settings_ | null;
+    mobile: boolean;
+    showTriage: boolean;
+    blockedEntries: BlockedEntry[];
+    nowMs: number;
+    ontriageopen: (id: string) => void;
+    ontriageclose: () => void;
+    onresumequota: (id: string) => void;
+    ontakeoverquota: (id: string) => void;
+    onabandonquota: (id: string) => void;
+    showLearnings: boolean;
+    learningsRepo: string | null;
+    onlearningsclose: () => void;
+    showUpdate: boolean;
+    deploy: DeployState | null;
+    onupdateconfirm: () => void;
+    onupdateclose: () => void;
+    showHerdrUpdate: boolean;
+    herdrUpdating: boolean;
+    onherdrupdateconfirm: () => void;
+    onherdrupdateclose: () => void;
+    showOnboarding: boolean;
+    diagnosticsLoadFailed: boolean;
+    ononboardingretry: () => void;
+    ononboardingdismiss: () => void;
+    showWhatsNew: boolean;
+    whatsNewEntries: FeatureAnnouncement[];
+    onwhatsnewdismiss: () => void;
+    onwhatsnewclose: () => void;
+    showFableArrival: boolean;
+    onfabletry: () => void;
+    onfableclose: () => void;
+    showNew: boolean;
+    onsubmit: ComponentProps<typeof NewTask>["onsubmit"];
+    relaunchOriginal: boolean;
+    composeRepoPath: string | null;
+    repoFilter: string | null;
+    composeBaseBranch: string | null;
+    composeIssue: Issue | null;
+    relaunchIssueNumber: number | null;
+    composeImages: { path: string; name: string }[];
+    composePrompt: string | null;
+    composeModel: string | null;
+    holdLikely: boolean;
+    onnewclose: () => void;
+    onnewclone: () => void;
+    onnewfork: () => void;
+    onnewnewproject: () => void;
+    showSettings: boolean;
+    settingsTab: "workspace" | "session" | "device" | "diagnose";
+    onsettingsclose: () => void;
+    onsettingsherdrupdate: () => void;
+    onsettingsclone: () => void;
+    onsettingsfork: () => void;
+    onsettingswhatsnew: () => void;
+    showClone: boolean;
+    oncloneclose: () => void;
+    onclonedone: (entry: { path: string }) => void;
+    showFork: boolean;
+    onforkclose: () => void;
+    onforkdone: (entry: { path: string }) => void;
+    showNewProject: boolean;
+    onnewprojectclose: () => void;
+    onnewprojectdone: (
+      entry: { path: string; warning?: string },
+      kickoff: KickoffChoice,
+      idea: string,
+    ) => void;
+    showBroadcast: boolean;
+    onbroadcastclose: () => void;
+    showRetry: boolean;
+    onretryclose: () => void;
+    clearMergedSessions: Session[] | null;
+    clearMergedLeftovers: number;
+    onclearmergedclose: () => void;
+    onclearmergedconfirm: () => void;
+    showBacklog: boolean;
+    backlog: BacklogPayload | null;
+    epicTarget: { repoPath: string; issueNumber: number } | null;
+    inTrainPrs: Set<string>;
+    onissue: (repoPath: string, issue: Issue) => void;
+    onquick: (repoPath: string, issue: Issue, action: Steer) => void;
+    onpr: (repoPath: string, pr: PullRequest) => void;
+    onadopt: (repoPath: string, prompt: string) => void;
+    onlaunchtrain: (repoPath: string, prs: PullRequest[]) => void;
+    onbacklogclose: () => void;
+    pendingTrain: PendingTrain;
+    ontrainclose: () => void;
+    ontrainconfirm: () => void;
+    onstarresolve: (s: StarPromptStatus) => void;
+  } = $props();
+
+  // NewTask seed props pre-resolved here so their nullish-coalescing fallbacks live
+  // in <script> rather than the overlay template (keeps this template's synthetic
+  // complexity under the Tier-1 bar).
+  const newTaskInitialRepo = $derived(composeRepoPath ?? repoFilter ?? undefined);
+  const newTaskInitialBaseBranch = $derived(composeBaseBranch ?? undefined);
+  const newTaskInitialIssue = $derived(composeIssue ?? undefined);
+  const newTaskInitialPrompt = $derived(composePrompt ?? undefined);
+  const newTaskInitialModel = $derived(composeModel ?? undefined);
+  const newTaskFableAvailable = $derived(settings?.fableAvailable ?? true);
+</script>
+
+{#if showTriage}
+  <TriageDrawer
+    entries={blockedEntries}
+    {nowMs}
+    onreply={(id, text) => replySession(id, text).catch(() => {})}
+    ondismiss={(id) => dismissStall(id).catch(() => {})}
+    onopen={ontriageopen}
+    onclose={ontriageclose}
+    onresume={onresumequota}
+    ontakeover={ontakeoverquota}
+    onabandon={onabandonquota}
+  />
+{/if}
+
+{#if showLearnings}
+  <LearningsDrawer
+    items={learnings.items}
+    injectable={learnings.injectable}
+    mergeSuggestions={learnings.mergeSuggestions}
+    focusRepo={learningsRepo}
+    onapprove={(id, rule) =>
+      approveLearning(id, rule)
+        .then(() => learnings.load())
+        .catch(() => {})}
+    ondismiss={(id) =>
+      dismissLearning(id)
+        .then(() => learnings.load())
+        .catch(() => {})}
+    ondistill={(repoPath) =>
+      distillRepo(repoPath)
+        .then(() => toasts.info(m.learnings_distill_started({ repo: basename(repoPath) })))
+        .catch(() => {})}
+    onpromote={(id) =>
+      promoteLearning(id)
+        .then(() => {
+          toasts.info(m.learnings_promote_started());
+          return learnings.load();
+        })
+        .catch(() => toasts.info(m.learnings_promote_failed()))}
+    onoptimize={(id) =>
+      optimizeLearning(id)
+        .then(() => toasts.info(m.learnings_optimize_started()))
+        .catch(() => toasts.info(m.learnings_optimize_failed()))}
+    onoptimizeall={(repoPath) =>
+      optimizeRepoFlagged(repoPath)
+        .then(() => toasts.info(m.learnings_optimize_started()))
+        .catch(() => toasts.info(m.learnings_optimize_failed()))}
+    onrestore={(id) =>
+      restoreLearning(id)
+        .then(() => learnings.load())
+        .catch(() => toasts.info(m.learnings_restore_failed()))}
+    onscope={(id, globs) =>
+      setLearningScope(id, globs)
+        .then(() => learnings.load())
+        .catch(() => toasts.info(m.learnings_scope_failed()))}
+    onseenretired={(repoPath) =>
+      markRetiredSeen(repoPath)
+        .then(() => learnings.load())
+        .catch(() => {})}
+    onmerge={(suggestionId) =>
+      applyMergeSuggestion(suggestionId)
+        .then(() => {
+          toasts.info(m.learnings_merge_applied());
+          return learnings.load();
+        })
+        .catch(() => toasts.info(m.learnings_merge_failed()))}
+    ondismissmerge={(suggestionId) =>
+      dismissMergeSuggestion(suggestionId)
+        .then(() => learnings.load())
+        .catch(() => {})}
+    onpromoteglobal={(suggestionId) =>
+      promoteGlobalLearning(suggestionId)
+        .then(() => {
+          toasts.info(m.learnings_recur_promote_done());
+          return learnings.load();
+        })
+        .catch(() => toasts.info(m.learnings_recur_promote_failed()))}
+    onmergenow={(repoPath) =>
+      mergeSuggestNow(repoPath)
+        .then(() => toasts.info(m.learnings_merge_now_started({ repo: basename(repoPath) })))
+        .catch(() => {})}
+    onclose={onlearningsclose}
+  />
+{/if}
+
+{#if showUpdate && store.update && store.update.behind > 0}
+  <UpdateModal
+    update={store.update}
+    updating={store.updating}
+    {deploy}
+    onconfirm={onupdateconfirm}
+    onclose={onupdateclose}
+  />
+{/if}
+
+{#if showHerdrUpdate && store.herdrUpdate && (store.herdrUpdate.updateAvailable || herdrUpdating)}
+  <!-- displayStatus: the warning counts agents the herdr restart interrupts — a
+       working-while-blocked agent is genuinely mid-turn, so it counts as working -->
+  <HerdrUpdateModal
+    update={store.herdrUpdate}
+    sessions={store.sessions.filter((s) => displayStatus(s, store.workingBlocked) === "running")
+      .length}
+    log={store.herdrUpdateLog}
+    done={store.herdrUpdateDone}
+    onconfirm={onherdrupdateconfirm}
+    onclose={onherdrupdateclose}
+  />
+{/if}
+
+{#if showOnboarding}
+  <Onboarding
+    checks={store.diagnostics?.checks ?? null}
+    failed={diagnosticsLoadFailed}
+    onretry={ononboardingretry}
+    ondismiss={ononboardingdismiss}
+  />
+{/if}
+
+{#if showWhatsNew}
+  <WhatsNew entries={whatsNewEntries} ondismiss={onwhatsnewdismiss} onclose={onwhatsnewclose} />
+{/if}
+
+{#if showFableArrival}
+  <FableArrival ontry={onfabletry} onclose={onfableclose} />
+{/if}
+
+{#if showNew}
+  <!-- Preselect: explicit backlog/PR context first, else the repo the herd is
+       currently filtered to, else NewTask falls back to the most-recently-used repo. -->
+  <NewTask
+    {onsubmit}
+    relaunch={relaunchOriginal}
+    initialRepoPath={newTaskInitialRepo}
+    initialBaseBranch={newTaskInitialBaseBranch}
+    initialIssue={newTaskInitialIssue}
+    {relaunchIssueNumber}
+    initialImages={composeImages}
+    initialPrompt={newTaskInitialPrompt}
+    initialModel={newTaskInitialModel}
+    defaultModel={settings?.defaultModel}
+    fableAvailable={newTaskFableAvailable}
+    {holdLikely}
+    onclose={onnewclose}
+    onclone={onnewclone}
+    onfork={onnewfork}
+    onnewproject={onnewnewproject}
+  />
+{/if}
+
+{#if showSettings}
+  <Settings
+    initialTab={settingsTab}
+    initialDiagnostics={store.diagnostics?.checks ?? null}
+    onclose={onsettingsclose}
+    herdrUpdate={store.herdrUpdate}
+    onherdrupdate={onsettingsherdrupdate}
+    onclone={onsettingsclone}
+    onfork={onsettingsfork}
+    onwhatsnew={onsettingswhatsnew}
+  />
+{/if}
+
+{#if showClone}
+  <!-- Close whichever dialog launched Clone (NewTask or Settings) is already done
+       before we get here; ondone reopens NewTask preselected on the fresh repo. -->
+  <CloneRepo
+    onclose={oncloneclose}
+    ondone={onclonedone}
+    repoRootDisplay={settings?.repoRootDisplay}
+  />
+{/if}
+
+{#if showFork}
+  <!-- Same flow as CloneRepo: ondone reopens NewTask preselected on the forked repo. -->
+  <ForkRepo onclose={onforkclose} ondone={onforkdone} repoRootDisplay={settings?.repoRootDisplay} />
+{/if}
+
+{#if showNewProject}
+  <!-- ondone auto-selects the new repo in NewTask + prefills the kickoff seed.
+       A warning (partial success: local ok, GitHub failed) surfaces as a non-blocking
+       info toast — the flow still proceeds to NewTask with the repo preselected. -->
+  <NewProject
+    repoRootDisplay={settings?.repoRootDisplay}
+    onclose={onnewprojectclose}
+    ondone={onnewprojectdone}
+  />
+{/if}
+
+{#if showBroadcast}
+  <BroadcastDialog sessions={store.sessions} onclose={onbroadcastclose} />
+{/if}
+
+{#if showRetry}
+  <RetryDialog sessions={store.sessions} onclose={onretryclose} />
+{/if}
+
+{#if clearMergedSessions}
+  <ClearMergedDialog
+    sessions={clearMergedSessions}
+    leftovers={clearMergedLeftovers}
+    onclose={onclearmergedclose}
+    onconfirm={onclearmergedconfirm}
+  />
+{/if}
+
+{#if showBacklog}
+  <BacklogOverlay
+    payload={backlog}
+    {mobile}
+    {onissue}
+    {onquick}
+    {onpr}
+    {onadopt}
+    {onlaunchtrain}
+    onclose={onbacklogclose}
+    epics={store.epics}
+    {inTrainPrs}
+    target={epicTarget}
+    drain={store.drain}
+  />
+{/if}
+
+{#if pendingTrain}
+  <MergeTrainConfirmDialog
+    repoLabel={pendingTrain.repoLabel}
+    items={pendingTrain.items}
+    handpicked={pendingTrain.handpicked}
+    otherRepoCount={pendingTrain.otherRepoCount}
+    onclose={ontrainclose}
+    onconfirm={ontrainconfirm}
+  />
+{/if}
+
+{#if store.starPrompt?.shouldPrompt}
+  <StarPrompt onresolve={onstarresolve} />
+{/if}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -10,8 +10,6 @@
     stageRelaunchImages,
     ApiError,
     getUsageLimits,
-    replySession,
-    dismissStall,
     getUpdate,
     getUpdateLog,
     getHerdrUpdate,
@@ -26,19 +24,6 @@
     getSettings,
     listBranches,
     pickBaseBranch,
-    approveLearning,
-    dismissLearning,
-    distillRepo,
-    promoteLearning,
-    optimizeLearning,
-    optimizeRepoFlagged,
-    restoreLearning,
-    setLearningScope,
-    markRetiredSeen,
-    applyMergeSuggestion,
-    dismissMergeSuggestion,
-    promoteGlobalLearning,
-    mergeSuggestNow,
     getMergedClearable,
     clearMerged,
     getDrain,
@@ -76,8 +61,6 @@
   import { doneSessions } from "$lib/done.svelte";
   import { learnings } from "$lib/learnings.svelte";
   import TopBar from "$lib/components/TopBar.svelte";
-  import TriageDrawer from "$lib/components/TriageDrawer.svelte";
-  import LearningsDrawer from "$lib/components/LearningsDrawer.svelte";
   import { basename, shouldCloseLearningsDrawer } from "$lib/components/learnings-drawer";
   import Herd from "$lib/components/Herd.svelte";
   import {
@@ -97,16 +80,7 @@
   } from "$lib/components/merge-train";
   import Viewport from "$lib/components/Viewport.svelte";
   import DoneRecapPanel from "$lib/components/DoneRecapPanel.svelte";
-  import NewTask from "$lib/components/NewTask.svelte";
-  import Settings from "$lib/components/Settings.svelte";
-  import CloneRepo from "$lib/components/CloneRepo.svelte";
-  import ForkRepo from "$lib/components/ForkRepo.svelte";
-  import NewProject from "$lib/components/NewProject.svelte";
   import type { KickoffChoice } from "$lib/components/NewProject.svelte";
-  import BroadcastDialog from "$lib/components/BroadcastDialog.svelte";
-  import RetryDialog from "$lib/components/RetryDialog.svelte";
-  import ClearMergedDialog from "$lib/components/ClearMergedDialog.svelte";
-  import MergeTrainConfirmDialog from "$lib/components/MergeTrainConfirmDialog.svelte";
   import ActionBar from "$lib/components/ActionBar.svelte";
   import HerdGrid from "$lib/components/HerdGrid.svelte";
   import QueueStrip from "$lib/components/QueueStrip.svelte";
@@ -118,10 +92,7 @@
     shouldClearRepoFilter,
   } from "$lib/components/queue-strip";
   import BacklogView from "$lib/components/BacklogView.svelte";
-  import BacklogOverlay from "$lib/components/BacklogOverlay.svelte";
-  import UpdateModal from "$lib/components/UpdateModal.svelte";
-  import HerdrUpdateModal from "$lib/components/HerdrUpdateModal.svelte";
-  import StarPrompt from "$lib/components/StarPrompt.svelte";
+  import AppOverlays from "$lib/components/page/AppOverlays.svelte";
   import Toasts from "$lib/components/Toasts.svelte";
   import { registerSW, onSelectSession, onOpenLearnings } from "$lib/push";
   import { toasts } from "$lib/toasts.svelte";
@@ -132,9 +103,6 @@
   import { featureDiscovery } from "$lib/featureDiscovery.svelte";
   import { computeNewEntries } from "$lib/feature-gate";
   import { version } from "$lib/build-info";
-  import WhatsNew from "$lib/components/WhatsNew.svelte";
-  import FableArrival from "$lib/components/FableArrival.svelte";
-  import Onboarding from "$lib/components/Onboarding.svelte";
   import { sidebarCollapse, sidebarShouldCollapse } from "$lib/sidebar-collapse.svelte";
 
   const store = new HerdStore();
@@ -425,6 +393,9 @@
         usageHoldPct &&
       store.sessions.filter((s) => s.status === "running").length >= 1,
   );
+  // Held only when creating fresh (not a relaunch). Pre-computed here so the
+  // ternary lives in <script>, keeping it out of the AppOverlays mount markup.
+  const composeHoldLikely = $derived(relaunchOriginalId === null ? holdLikely : false);
 
   const selected = $derived(store.sessions.find((s) => s.id === selectedId) ?? null);
 
@@ -1205,6 +1176,36 @@
     composeImages = [];
   }
 
+  // NewProject partial-success warning code → message map. A lookup (not a ternary
+  // ladder) keeps onNewProjectDone under the function complexity bar; unknown codes
+  // fall back to the generic GitHub warning.
+  const NEW_PROJECT_WARNINGS: Record<string, () => string> = {
+    newproject_failed_gh_missing: m.newproject_failed_gh_missing,
+    newproject_failed_gh_auth: m.newproject_failed_gh_auth,
+    newproject_failed_gh_exists: m.newproject_failed_gh_exists,
+    newproject_failed_remote: m.newproject_failed_remote,
+    newproject_failed_timeout: m.newproject_failed_timeout,
+  };
+
+  // NewProject.ondone: auto-select the new repo in NewTask + prefill the kickoff seed.
+  // A warning (partial success: local ok, GitHub failed) surfaces as a non-blocking
+  // info toast — the flow still proceeds to NewTask with the repo preselected.
+  // Named here (not inline in the AppOverlays mount) so its branching stays out of
+  // the route template.
+  function onNewProjectDone(
+    entry: { path: string; warning?: string },
+    kickoff: KickoffChoice,
+    idea: string,
+  ) {
+    showNewProject = false;
+    composeRepoPath = entry.path;
+    composePrompt = buildKickoffSeed(kickoff, idea);
+    if (entry.warning) {
+      toasts.info((NEW_PROJECT_WARNINGS[entry.warning] ?? m.newproject_warning_github)());
+    }
+    showNew = true;
+  }
+
   // Relaunch-elsewhere submit: route to relaunchSession(originalId, overrides) instead of
   // createSession. The server owns issue handling (cross-repo drops it + releases its claim),
   // so we never pass issueRef. Errors THROW so NewTask renders them inline (keeps the dialog
@@ -1931,347 +1932,163 @@
     mobile={mobile.current}
     desktopOnly
   />
-
-  {#if showTriage}
-    <TriageDrawer
-      entries={blockedEntries}
-      {nowMs}
-      onreply={(id, text) => replySession(id, text).catch(() => {})}
-      ondismiss={(id) => dismissStall(id).catch(() => {})}
-      onopen={(id) => {
-        selectUnit(id);
-        showTriage = false;
-      }}
-      onclose={() => (showTriage = false)}
-      onresume={(id) => handleResumeQuota(id)}
-      ontakeover={(id) => handleTakeoverQuota(id)}
-      onabandon={(id) => handleAbandonQuota(id)}
-    />
-  {/if}
-
-  {#if showLearnings}
-    <LearningsDrawer
-      items={learnings.items}
-      injectable={learnings.injectable}
-      mergeSuggestions={learnings.mergeSuggestions}
-      focusRepo={learningsRepo}
-      onapprove={(id, rule) =>
-        approveLearning(id, rule)
-          .then(() => learnings.load())
-          .catch(() => {})}
-      ondismiss={(id) =>
-        dismissLearning(id)
-          .then(() => learnings.load())
-          .catch(() => {})}
-      ondistill={(repoPath) =>
-        distillRepo(repoPath)
-          .then(() => toasts.info(m.learnings_distill_started({ repo: basename(repoPath) })))
-          .catch(() => {})}
-      onpromote={(id) =>
-        promoteLearning(id)
-          .then(() => {
-            toasts.info(m.learnings_promote_started());
-            return learnings.load();
-          })
-          .catch(() => toasts.info(m.learnings_promote_failed()))}
-      onoptimize={(id) =>
-        optimizeLearning(id)
-          .then(() => toasts.info(m.learnings_optimize_started()))
-          .catch(() => toasts.info(m.learnings_optimize_failed()))}
-      onoptimizeall={(repoPath) =>
-        optimizeRepoFlagged(repoPath)
-          .then(() => toasts.info(m.learnings_optimize_started()))
-          .catch(() => toasts.info(m.learnings_optimize_failed()))}
-      onrestore={(id) =>
-        restoreLearning(id)
-          .then(() => learnings.load())
-          .catch(() => toasts.info(m.learnings_restore_failed()))}
-      onscope={(id, globs) =>
-        setLearningScope(id, globs)
-          .then(() => learnings.load())
-          .catch(() => toasts.info(m.learnings_scope_failed()))}
-      onseenretired={(repoPath) =>
-        markRetiredSeen(repoPath)
-          .then(() => learnings.load())
-          .catch(() => {})}
-      onmerge={(suggestionId) =>
-        applyMergeSuggestion(suggestionId)
-          .then(() => {
-            toasts.info(m.learnings_merge_applied());
-            return learnings.load();
-          })
-          .catch(() => toasts.info(m.learnings_merge_failed()))}
-      ondismissmerge={(suggestionId) =>
-        dismissMergeSuggestion(suggestionId)
-          .then(() => learnings.load())
-          .catch(() => {})}
-      onpromoteglobal={(suggestionId) =>
-        promoteGlobalLearning(suggestionId)
-          .then(() => {
-            toasts.info(m.learnings_recur_promote_done());
-            return learnings.load();
-          })
-          .catch(() => toasts.info(m.learnings_recur_promote_failed()))}
-      onmergenow={(repoPath) =>
-        mergeSuggestNow(repoPath)
-          .then(() => toasts.info(m.learnings_merge_now_started({ repo: basename(repoPath) })))
-          .catch(() => {})}
-      onclose={() => {
-        showLearnings = false;
-        learningsRepo = null;
-      }}
-    />
-  {/if}
 </div>
 
-{#if showUpdate && store.update && store.update.behind > 0}
-  <UpdateModal
-    update={store.update}
-    updating={store.updating}
-    {deploy}
-    onconfirm={onUpdateConfirm}
-    onclose={closeUpdate}
-  />
-{/if}
-
-{#if showHerdrUpdate && store.herdrUpdate && (store.herdrUpdate.updateAvailable || herdrUpdating)}
-  <!-- displayStatus: the warning counts agents the herdr restart interrupts — a
-       working-while-blocked agent is genuinely mid-turn, so it counts as working -->
-  <HerdrUpdateModal
-    update={store.herdrUpdate}
-    sessions={store.sessions.filter((s) => displayStatus(s, store.workingBlocked) === "running")
-      .length}
-    log={store.herdrUpdateLog}
-    done={store.herdrUpdateDone}
-    onconfirm={() => {
-      herdrUpdating = true;
-      store.herdrUpdateDone = null; // fresh run: clear any prior result
-      store.herdrUpdateLog = [];
-    }}
-    onclose={() => {
-      showHerdrUpdate = false;
-      herdrUpdating = false;
-      store.herdrUpdateDone = null;
-    }}
-  />
-{/if}
-
-{#if showOnboarding}
-  <Onboarding
-    checks={store.diagnostics?.checks ?? null}
-    failed={diagnosticsLoadFailed}
-    onretry={loadDiagnostics}
-    ondismiss={() => {
-      featureDiscovery.markSeen("onboarding");
-      showOnboarding = false;
-    }}
-  />
-{/if}
-
-{#if showWhatsNew}
-  <WhatsNew
-    entries={whatsNewEntries}
-    ondismiss={() => {
-      featureDiscovery.lastSeenVersion = version;
-      whatsNewDotOn = false;
-    }}
-    onclose={() => (showWhatsNew = false)}
-  />
-{/if}
-
-{#if showFableArrival}
-  <FableArrival
-    ontry={() => {
-      featureDiscovery.markSeen(FABLE_FEATURE_ID);
-      showFableArrival = false;
-      composeModel = "fable";
-      showNew = true;
-    }}
-    onclose={() => {
-      featureDiscovery.markSeen(FABLE_FEATURE_ID);
-      showFableArrival = false;
-    }}
-  />
-{/if}
-
-{#if showNew}
-  <!-- Preselect: explicit backlog/PR context first, else the repo the herd is
-       currently filtered to, else NewTask falls back to the most-recently-used repo. -->
-  <NewTask
-    {onsubmit}
-    relaunch={relaunchOriginalId !== null}
-    initialRepoPath={composeRepoPath ?? repoFilter ?? undefined}
-    initialBaseBranch={composeBaseBranch ?? undefined}
-    initialIssue={composeIssue ?? undefined}
-    {relaunchIssueNumber}
-    initialImages={composeImages}
-    initialPrompt={composePrompt ?? undefined}
-    initialModel={composeModel ?? undefined}
-    defaultModel={settings?.defaultModel}
-    fableAvailable={settings?.fableAvailable ?? true}
-    holdLikely={relaunchOriginalId === null ? holdLikely : false}
-    onclose={() => {
-      showNew = false;
-      resetCompose();
-    }}
-    onclone={() => {
-      // Clear stale relaunch/compose state before handing off to Clone: its ondone
-      // reopens NewTask, and a lingering relaunchOriginalId would wrongly put that
-      // fresh-create into relaunch mode (archiving the original session).
-      resetCompose();
-      showNew = false;
-      showClone = true;
-    }}
-    onfork={() => {
-      // Same handoff contract as onclone: ForkRepo.ondone reopens NewTask.
-      resetCompose();
-      showNew = false;
-      showFork = true;
-    }}
-    onnewproject={() => {
-      // Same as onclone: NewProject.ondone reopens NewTask, so drop any stale
-      // relaunch/compose seed first to avoid an unintended relaunch.
-      resetCompose();
-      showNew = false;
-      showNewProject = true;
-    }}
-  />
-{/if}
-
-{#if showSettings}
-  <Settings
-    initialTab={settingsTab}
-    initialDiagnostics={store.diagnostics?.checks ?? null}
-    onclose={() => {
-      showSettings = false;
-      loadSettings();
-    }}
-    herdrUpdate={store.herdrUpdate}
-    onherdrupdate={() => {
-      showSettings = false;
-      showHerdrUpdate = true;
-    }}
-    onclone={() => {
-      showSettings = false;
-      showClone = true;
-    }}
-    onfork={() => {
-      showSettings = false;
-      showFork = true;
-    }}
-    onwhatsnew={() => {
-      showSettings = false;
-      showWhatsNew = true;
-    }}
-  />
-{/if}
-
-{#if showClone}
-  <!-- Close whichever dialog launched Clone (NewTask or Settings) is already done
-       before we get here; ondone reopens NewTask preselected on the fresh repo. -->
-  <CloneRepo
-    onclose={() => (showClone = false)}
-    ondone={(entry) => {
-      showClone = false;
-      composeRepoPath = entry.path;
-      showNew = true;
-    }}
-    repoRootDisplay={settings?.repoRootDisplay}
-  />
-{/if}
-
-{#if showFork}
-  <!-- Same flow as CloneRepo: ondone reopens NewTask preselected on the forked repo. -->
-  <ForkRepo
-    onclose={() => (showFork = false)}
-    ondone={(entry) => {
-      showFork = false;
-      composeRepoPath = entry.path;
-      showNew = true;
-    }}
-    repoRootDisplay={settings?.repoRootDisplay}
-  />
-{/if}
-
-{#if showNewProject}
-  <!-- ondone auto-selects the new repo in NewTask + prefills the kickoff seed.
-       A warning (partial success: local ok, GitHub failed) surfaces as a non-blocking
-       info toast — the flow still proceeds to NewTask with the repo preselected. -->
-  <NewProject
-    repoRootDisplay={settings?.repoRootDisplay}
-    onclose={() => (showNewProject = false)}
-    ondone={(entry, kickoff, idea) => {
-      showNewProject = false;
-      composeRepoPath = entry.path;
-      composePrompt = buildKickoffSeed(kickoff, idea);
-      if (entry.warning) {
-        const warningMsg =
-          entry.warning === "newproject_failed_gh_missing"
-            ? m.newproject_failed_gh_missing()
-            : entry.warning === "newproject_failed_gh_auth"
-              ? m.newproject_failed_gh_auth()
-              : entry.warning === "newproject_failed_gh_exists"
-                ? m.newproject_failed_gh_exists()
-                : entry.warning === "newproject_failed_remote"
-                  ? m.newproject_failed_remote()
-                  : entry.warning === "newproject_failed_timeout"
-                    ? m.newproject_failed_timeout()
-                    : m.newproject_warning_github();
-        toasts.info(warningMsg);
-      }
-      showNew = true;
-    }}
-  />
-{/if}
-
-{#if showBroadcast}
-  <BroadcastDialog sessions={store.sessions} onclose={() => (showBroadcast = false)} />
-{/if}
-
-{#if showRetry}
-  <RetryDialog sessions={store.sessions} onclose={() => (showRetry = false)} />
-{/if}
-
-{#if clearMergedSessions}
-  <ClearMergedDialog
-    sessions={clearMergedSessions}
-    leftovers={clearMergedLeftovers}
-    onclose={() => (clearMergedSessions = null)}
-    onconfirm={confirmClearMerged}
-  />
-{/if}
-
-{#if showBacklog}
-  <BacklogOverlay
-    payload={backlog}
-    mobile={mobile.current}
-    {onissue}
-    onquick={onquickissue}
-    {onpr}
-    {onadopt}
-    {onlaunchtrain}
-    onclose={() => (showBacklog = false)}
-    epics={store.epics}
-    {inTrainPrs}
-    target={epicTarget}
-    drain={store.drain}
-  />
-{/if}
-
-{#if pendingTrain}
-  <MergeTrainConfirmDialog
-    repoLabel={pendingTrain.repoLabel}
-    items={pendingTrain.items}
-    handpicked={pendingTrain.handpicked}
-    otherRepoCount={pendingTrain.otherRepoCount}
-    onclose={() => (pendingTrain = null)}
-    onconfirm={confirmTrain}
-  />
-{/if}
-
-{#if store.starPrompt?.shouldPrompt}
-  <StarPrompt onresolve={(s) => (store.starPrompt = s)} />
-{/if}
+<AppOverlays
+  {store}
+  {settings}
+  mobile={mobile.current}
+  {showTriage}
+  {blockedEntries}
+  {nowMs}
+  ontriageopen={(id) => {
+    selectUnit(id);
+    showTriage = false;
+  }}
+  ontriageclose={() => (showTriage = false)}
+  onresumequota={(id) => handleResumeQuota(id)}
+  ontakeoverquota={(id) => handleTakeoverQuota(id)}
+  onabandonquota={(id) => handleAbandonQuota(id)}
+  {showLearnings}
+  {learningsRepo}
+  onlearningsclose={() => {
+    showLearnings = false;
+    learningsRepo = null;
+  }}
+  {showUpdate}
+  {deploy}
+  onupdateconfirm={onUpdateConfirm}
+  onupdateclose={closeUpdate}
+  {showHerdrUpdate}
+  {herdrUpdating}
+  onherdrupdateconfirm={() => {
+    herdrUpdating = true;
+    store.herdrUpdateDone = null; // fresh run: clear any prior result
+    store.herdrUpdateLog = [];
+  }}
+  onherdrupdateclose={() => {
+    showHerdrUpdate = false;
+    herdrUpdating = false;
+    store.herdrUpdateDone = null;
+  }}
+  {showOnboarding}
+  {diagnosticsLoadFailed}
+  ononboardingretry={loadDiagnostics}
+  ononboardingdismiss={() => {
+    featureDiscovery.markSeen("onboarding");
+    showOnboarding = false;
+  }}
+  {showWhatsNew}
+  {whatsNewEntries}
+  onwhatsnewdismiss={() => {
+    featureDiscovery.lastSeenVersion = version;
+    whatsNewDotOn = false;
+  }}
+  onwhatsnewclose={() => (showWhatsNew = false)}
+  {showFableArrival}
+  onfabletry={() => {
+    featureDiscovery.markSeen(FABLE_FEATURE_ID);
+    showFableArrival = false;
+    composeModel = "fable";
+    showNew = true;
+  }}
+  onfableclose={() => {
+    featureDiscovery.markSeen(FABLE_FEATURE_ID);
+    showFableArrival = false;
+  }}
+  {showNew}
+  {onsubmit}
+  relaunchOriginal={relaunchOriginalId !== null}
+  {composeRepoPath}
+  {repoFilter}
+  {composeBaseBranch}
+  {composeIssue}
+  {relaunchIssueNumber}
+  {composeImages}
+  {composePrompt}
+  {composeModel}
+  holdLikely={composeHoldLikely}
+  onnewclose={() => {
+    showNew = false;
+    resetCompose();
+  }}
+  onnewclone={() => {
+    resetCompose();
+    showNew = false;
+    showClone = true;
+  }}
+  onnewfork={() => {
+    resetCompose();
+    showNew = false;
+    showFork = true;
+  }}
+  onnewnewproject={() => {
+    resetCompose();
+    showNew = false;
+    showNewProject = true;
+  }}
+  {showSettings}
+  {settingsTab}
+  onsettingsclose={() => {
+    showSettings = false;
+    loadSettings();
+  }}
+  onsettingsherdrupdate={() => {
+    showSettings = false;
+    showHerdrUpdate = true;
+  }}
+  onsettingsclone={() => {
+    showSettings = false;
+    showClone = true;
+  }}
+  onsettingsfork={() => {
+    showSettings = false;
+    showFork = true;
+  }}
+  onsettingswhatsnew={() => {
+    showSettings = false;
+    showWhatsNew = true;
+  }}
+  {showClone}
+  oncloneclose={() => (showClone = false)}
+  onclonedone={(entry) => {
+    showClone = false;
+    composeRepoPath = entry.path;
+    showNew = true;
+  }}
+  {showFork}
+  onforkclose={() => (showFork = false)}
+  onforkdone={(entry) => {
+    showFork = false;
+    composeRepoPath = entry.path;
+    showNew = true;
+  }}
+  {showNewProject}
+  onnewprojectclose={() => (showNewProject = false)}
+  onnewprojectdone={onNewProjectDone}
+  {showBroadcast}
+  onbroadcastclose={() => (showBroadcast = false)}
+  {showRetry}
+  onretryclose={() => (showRetry = false)}
+  {clearMergedSessions}
+  {clearMergedLeftovers}
+  onclearmergedclose={() => (clearMergedSessions = null)}
+  onclearmergedconfirm={confirmClearMerged}
+  {showBacklog}
+  {backlog}
+  {epicTarget}
+  {inTrainPrs}
+  {onissue}
+  onquick={onquickissue}
+  {onpr}
+  {onadopt}
+  {onlaunchtrain}
+  onbacklogclose={() => (showBacklog = false)}
+  {pendingTrain}
+  ontrainclose={() => (pendingTrain = null)}
+  ontrainconfirm={confirmTrain}
+  onstarresolve={(s) => (store.starPrompt = s)}
+/>
 
 <Toasts aboveActionBar={mobileActionBarPresent} />
 


### PR DESCRIPTION
## What

Pays down the `+page.svelte` `<template>` complexity grandfather (issue #855, worst-first paydown of #851's synthetic Svelte-template metric).

Extracts the modal/overlay tail (16 top-level dialogs) plus the **Triage** and **Learnings** drawers out of `+page.svelte` into a new `page/AppOverlays.svelte` child (matching the established `herd/` / `top-bar/` / `viewport/` split pattern).

## Result

| Component | before | after | Tier-1 bar |
| --- | --- | --- | --- |
| `+page.svelte` `<template>` | **78 / 96** | **32 / 45** | 40 / 60 ✓ |
| `page/AppOverlays.svelte` `<template>` | — | **33 / 23** | 40 / 60 ✓ |

`+page` now clears the Tier-1 bar, so its Tier-2 grandfather is **removed** from `.fallowrc.jsonc`. `bunx fallow@2.100.0 health` reports **0** template-complexity findings; `audit --base origin/main` is clean.

## Why this shape

The boolean/ternary/nullish-heavy overlay markup (`showX && …`, `?? undefined`, the NewProject warning ternary ladder) was the dominant driver of the route template's *cyclomatic* cost — extracting it alone took `+page` from 78/96 to 32/45. The planned mobile/desktop main-region split turned out **unnecessary**: `+page` already clears the bar, so the nested view ladder (the highest-regression, scoped-style-migration part) was left untouched — simplest change that removes the grandfather, lowest app-shell risk.

`AppOverlays` is a **controlled component**: overlay state stays in `+page`, passed one-way with close/handoff callbacks (no blanket `$bindable`); the learnings/triage api wiring moves in directly. The NewProject warning ladder moved to a `<script>` lookup map (kept its function under the complexity bar).

## Tests / verification

- New `page/AppOverlays.browser.test.ts` covers the `NewTask`↔`Clone`/`Fork`/`NewProject` repo-picker handoff (mirrors the #911 `Herd.browser.test.ts` precedent — the refactored surface had no automated coverage before).
- `cd ui && bun run check` ✓ · `bun run test` (1805 ✓) · `check:i18n` parity ✓ · eslint ✓ · branch hygiene ✓ · fallow audit ✓
- Live-verified against the running app (vite proxy): shell renders clean (no console errors); Onboarding modal, Learnings drawer, and NewTask compose all open/render correctly via `AppOverlays`.

Pure refactor — no new user-facing strings (moved verbatim), so no feature-catalog / i18n / glossary additions. `[no-feature-entry]`

Remaining #855 grandfathers after this: Viewport (tighten-and-tracked) and LearningsDrawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)