### PR TITLE
refactor(ui): drop THE HERD title in compact layout to save vertical space

### DIFF
--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -519,6 +519,14 @@
   .panel.flow .phead > .micro {
     display: none;
   }
+  /* Compact (touch / unfolded-foldable) layout pins the sidebar to ~288px, where the
+     filter bar wraps onto its own row and the "THE HERD" title sits alone above it —
+     pure vertical-space cost. Drop the title here too so the filter bar leads. The
+     .grid.compact ancestor lives in +page.svelte (outside this component), hence the
+     :global wrapper. herd_title still serves the standard desktop layout. */
+  :global(.grid.compact) .phead > .micro {
+    display: none;
+  }
   .phead {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## What

In the unfolded-foldable (`.grid.compact`) layout the Herd sidebar is pinned to ~288px, so the filter bar (ALL / READY / RESEARCH / DONE / RUNDOWN + collapse chevron) wraps onto its own row and the static **THE HERD** title is pushed onto a line by itself above it — pure vertical-space cost.

Hide the title in that layout too, mirroring the existing mobile **flow** rule (`.panel.flow .phead > .micro { display: none }`). The filter bar then leads and a row of height is reclaimed.

## Notes

- CSS-only, one rule. The `herd_title` message key still serves the standard (non-touch) desktop layout, so no i18n change and no feature-catalog entry (UI space tweak, not a `feat`).
- `.grid.compact.collapsed` replaces the panel with a slim reopen tab, so only the non-collapsed compact state is affected.

## Verification

`cd ui && bun run check` → 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)