### PR TITLE
fix(ui): hide keyboard-combo hints on coarse-pointer devices

### DIFF
--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { MediaQuery } from "svelte/reactivity";
   import {
     listRepos,
     listBranches,
@@ -176,6 +177,9 @@
   let promptInput = $state<HTMLTextAreaElement>();
   let repoSelect: RepoSelect | undefined = $state();
   let isMac = $state(false);
+  // Coarse pointer = touch-primary device with no hardware Ctrl/⌘/⌥ keys: hide
+  // keyboard-combo hints it can't fulfil (submit shortcut badge + repo shortcuts).
+  const coarse = new MediaQuery("(pointer: coarse)");
 
   // ── inline slash-command autocomplete (reuses the /api/commands index) ──
   let allCommands = $state<SlashCommand[]>([]);
@@ -650,9 +654,11 @@
       />
     </div>
 
-    <span class="hint repo-shortcuts-hint">
-      {m.newtask_repo_shortcuts_hint({ mod: isMac ? "⌥" : "Alt+" })}
-    </span>
+    {#if !coarse.current}
+      <span class="hint repo-shortcuts-hint">
+        {m.newtask_repo_shortcuts_hint({ mod: isMac ? "⌥" : "Alt+" })}
+      </span>
+    {/if}
 
     {#if relaunch}
       <div class="relaunch-note">
@@ -833,7 +839,7 @@
         class="run"
         type="submit"
         disabled={submitting}
-        title={isMac ? "⌘ + Enter" : "Ctrl + Enter"}
+        title={coarse.current ? undefined : isMac ? "⌘ + Enter" : "Ctrl + Enter"}
       >
         <span
           >{submitting
@@ -842,7 +848,7 @@
               ? m.newtask_submit_in_repo({ repo: selectedRepoName })
               : m.newtask_submit()}</span
         >
-        {#if !submitting}
+        {#if !submitting && !coarse.current}
           <kbd class="kbd">{isMac ? "⌘↵" : "Ctrl+↵"}</kbd>
         {/if}
       </button>


### PR DESCRIPTION
## What

On touch-primary devices (coarse pointer, no hardware Ctrl/⌘/⌥ keys) the **New Task sheet** advertised two keyboard combos it can't fulfil:

- the submit button's `⌘↵` / `Ctrl+↵` `<kbd>` badge (and its `title`)
- the `⌥[ / ⌥] switch repo · …` repo-shortcuts line

Both are now gated on a `(pointer: coarse)` `MediaQuery`, so they show on fine-pointer desktops (where the shortcuts work) and disappear on touch — including touch tablets/foldables **wider than 768px**, which the prior width-only CSS gate missed.

## Why this is the only change

A full sweep found every other combo hint was already touch-gated:

- **ActionBar** N/B tooltips render only under `@media (hover: hover) and (pointer: fine)`.
- **Viewport** footer hints + "Next Needs You" `aria-keyshortcuts`/`title` are gated by `compact = mobile || touch` (`touch` = `(pointer: coarse)`).

So the fix is confined to `NewTask.svelte`.

## Notes

- No i18n change (removing rendered strings on touch, not adding keys) → `check:i18n` unaffected.
- No feature-catalog entry — UI refinement shipped as `fix(ui)`, not a `feat` (`[no-feature-entry]`).
- Implementation mirrors the existing `MediaQuery("(pointer: coarse)")` precedent in `UnitRow.svelte`.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- `cd ui && bun run test` → 1802 passed
- Manual: coarse-pointer (touch emulation) hides both hints; fine-pointer desktop unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)