### PR TITLE
feat(site,docs): cross-link landing ↔ docs site (#913)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -52,7 +52,12 @@
     // ui/extension app.css roots listed above).
     "docs-site/astro.config.mjs",
     "docs-site/src/content.config.ts",
-    "docs-site/src/styles/custom.css"
+    "docs-site/src/styles/custom.css",
+    // SiteBacklink overrides Starlight's header `SocialIcons` slot. Astro loads it
+    // via the `components: { SocialIcons: "./src/components/SiteBacklink.astro" }`
+    // string path in astro.config.mjs, not a static import — so fallow reports it as
+    // an unused file (same string-path-root class as custom.css above).
+    "docs-site/src/components/SiteBacklink.astro"
   ],
 
   // sw.js is the service worker: never imported statically — the browser fetches

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -31,6 +31,12 @@ export default defineConfig({
       title: "Shepherd",
       description: "Documentation for Shepherd — interactive mission control for Claude Code agents.",
       customCss: ["./src/styles/custom.css"],
+      // Override the header social-icons slot to prepend a same-tab back-link to the
+      // marketing site (shepherd.run); the override re-renders the default so the
+      // GitHub social icon below still appears. See src/components/SiteBacklink.astro.
+      components: {
+        SocialIcons: "./src/components/SiteBacklink.astro",
+      },
       // Generate the TypeScript API reference from the server package (../src)
       // with TypeDoc, so it CANNOT drift from source. Like syncDocs() above, this
       // runs at Starlight-init time on every astro command (check/build/dev), so
@@ -95,6 +101,10 @@ export default defineConfig({
       // deterministic and the three build-time-generated reference pages
       // (external-task-api, security, house-rules) resolve by slug.
       sidebar: [
+        // Back-link to the marketing site. Starlight auto-detects the external
+        // https:// link and renders its own external-link affordance; left same-tab
+        // (no `attrs.target`) to match the header back-link.
+        { label: "shepherd.run", link: "https://shepherd.run" },
         {
           label: "Guides",
           items: [

--- a/docs-site/src/components/SiteBacklink.astro
+++ b/docs-site/src/components/SiteBacklink.astro
@@ -1,0 +1,18 @@
+---
+// Override of Starlight's `SocialIcons` header slot (registered in astro.config.mjs).
+// Prepends a same-tab back-link to the marketing site (shepherd.run), then re-renders
+// the default component so the configured `social` icons (GitHub) still appear.
+//
+// In @astrojs/starlight@^0.40.0 the default `SocialIcons` renders the `social[]`
+// array from the virtual user-config module (route data lives in
+// `Astro.locals.starlightRoute`, not `Astro.props`), so the GitHub icon survives this
+// override regardless. `{...Astro.props}` is forwarded only as harmless
+// belt-and-suspenders. The `↗` is decorative and `aria-hidden` so assistive tech
+// announces just "shepherd.run".
+import Default from "@astrojs/starlight/components/SocialIcons.astro";
+---
+
+<a class="site-backlink" href="https://shepherd.run">
+  shepherd.run <span aria-hidden="true">↗</span>
+</a>
+<Default {...Astro.props} />

--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -1,6 +1,10 @@
 ---
 title: Getting started
 description: Install Shepherd and sign in.
+# The external "shepherd.run" sidebar back-link sits first in sidebar order, so
+# Starlight's auto-pagination would otherwise make it this page's "Previous" link
+# (an off-site pager). This is the first real doc page, so it has no previous page.
+prev: false
 ---
 
 Shepherd is interactive mission control for fleets of Claude Code agents — it runs

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -67,3 +67,21 @@
   --sl-color-accent: color-mix(in srgb, var(--brand-amber) 72%, black);
   --sl-color-accent-high: color-mix(in srgb, var(--brand-amber) 40%, black);
 }
+
+/*
+ * Header back-link to the marketing site (src/components/SiteBacklink.astro).
+ * Theme-var only (no raw hex), matching this file's convention. Sits beside the
+ * GitHub social icon in the header; muted by default, accented on hover/focus.
+ */
+.site-backlink {
+  align-self: center;
+  white-space: nowrap;
+  font-size: var(--sl-text-sm);
+  color: var(--sl-color-gray-2);
+  text-decoration: none;
+}
+
+.site-backlink:hover,
+.site-backlink:focus-visible {
+  color: var(--sl-color-accent-high);
+}

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -4,6 +4,8 @@
 const GITHUB_URL = "https://github.com/erwins-enkel/shepherd";
 const LICENSE_URL =
   "https://github.com/erwins-enkel/shepherd/blob/main/LICENSE";
+// First-party docs site — same-tab navigation (no target="_blank").
+const DOCS_URL = "https://docs.shepherd.run";
 ---
 
 <footer class="footer" aria-label="Site footer">
@@ -13,6 +15,7 @@ const LICENSE_URL =
       <nav class="flinks" aria-label="Footer">
         <a href={GITHUB_URL} rel="noopener noreferrer" target="_blank">GitHub</a
         >
+        <a href={DOCS_URL}>Docs</a>
         <a href={LICENSE_URL} rel="noopener noreferrer" target="_blank"
           >License</a
         >

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -3,6 +3,8 @@ import InstallBlock from "./InstallBlock.astro";
 import FocusMock from "./FocusMock.astro";
 
 const GITHUB_URL = "https://github.com/erwins-enkel/shepherd";
+// First-party docs site — same-tab navigation (no target="_blank").
+const DOCS_URL = "https://docs.shepherd.run";
 ---
 
 <section class="hero">
@@ -35,6 +37,7 @@ const GITHUB_URL = "https://github.com/erwins-enkel/shepherd";
         rel="noopener noreferrer"
         target="_blank">View on GitHub</a
       >
+      <a class="btn btn-ghost" href={DOCS_URL}>Read the docs</a>
     </div>
 
     <InstallBlock />

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -1,6 +1,8 @@
 ---
 // Top navigation landmark. No JS — links wrap on narrow viewports.
 const GITHUB_URL = "https://github.com/erwins-enkel/shepherd";
+// First-party docs site — same-tab navigation (no target="_blank").
+const DOCS_URL = "https://docs.shepherd.run";
 ---
 
 <nav class="nav" aria-label="Primary">
@@ -28,6 +30,7 @@ const GITHUB_URL = "https://github.com/erwins-enkel/shepherd";
     <ul class="links">
       <li><a href="#features">Features</a></li>
       <li><a href="#install">Install</a></li>
+      <li><a href={DOCS_URL}>Docs</a></li>
       <li>
         <a href={GITHUB_URL} rel="noopener noreferrer" target="_blank">GitHub</a
         >


### PR DESCRIPTION
Closes #913. Follow-up to epic #875 / PR #908 — adds the missing navigation path between the marketing landing (shepherd.run) and the docs site (docs.shepherd.run) in **both** directions.

## What changed

**Landing (`site/`) → docs.shepherd.run**
- `Docs` link in the primary **Nav** (`Features · Install · Docs · GitHub`)
- `Docs` link in the **Footer** (`GitHub · Docs · License`)
- `Read the docs` ghost CTA in the **Hero** (next to Install / View on GitHub)

**Docs (`docs-site/`) → shepherd.run**
- Header **back-link** via a `SocialIcons` component override (`SiteBacklink.astro`) that re-renders Starlight's default so the GitHub social icon is preserved
- Top-level **sidebar** entry

All cross-site links are **same-tab** (first-party product surface), unlike the existing third-party GitHub links (new tab); a decorative `aria-hidden` `↗` on the header back-link cues the cross-site hop.

## ⚠️ Merge gate (dependency)

`site/` is already live, but `docs-site/README.md` confirms **docs.shepherd.run is deployment-inert** until an operator completes the manual DNS/Vercel go-live steps. This is the issue's stated *"Depends on: docs.shepherd.run being deployed."*

**Do not merge until docs.shepherd.run resolves** — merging earlier would point live landing links at a dead domain. One gate covers every link added here.

## Scope note (operator decision)

The issue frames this as "minimal" (a Docs link + a back-link). The broader placement here — **Nav + Footer + Hero CTA** on the landing and **header + sidebar** in the docs — was an explicit operator selection during the plan-gate clarification (the minimal options "Nav only" / "header-only" / "sidebar-only" were offered and the broader set chosen, for cross-surface discoverability). Recorded here as the auditable anchor.

If a strict-minimal diff is preferred, the two trimmable items are the **Hero CTA** and the **docs sidebar entry** (the latter duplicating the header back-link).

## Notes / decisions discovered during implementation

- **GitHub icon survives the override** — verified empirically: the default `SocialIcons` renders `social[]` from virtual config (route data is `Astro.locals.starlightRoute`, not `Astro.props`), so the icon is unaffected. Confirmed by grepping the built `dist/` HTML.
- **Off-site pager fix** — the external sidebar link sits first in sidebar order, so Starlight's auto-pagination made the **first guide page's "← Previous" pager point off-site** to shepherd.run. Suppressed with `prev: false` in `getting-started.md` frontmatter (that page is effectively the first real doc and has no previous page regardless).
- **No external arrow on the sidebar link** — Starlight 0.40 does *not* add one for sidebar links (verified in built HTML); left as a plain same-tab nav link rather than appending a screen-reader-announced glyph.
- **Fallow exception** — `SiteBacklink.astro` is referenced only via the `components.SocialIcons` string path in `astro.config.mjs` (not a static import), so fallow flags it as unreachable. Added as an entry root in `.fallowrc.jsonc`, same documented class as `custom.css`.

## Verification

- `bun run check` + `bun run build` pass in **both** `site/` and `docs-site/`
- Built HTML confirmed: 3 landing links → docs.shepherd.run; docs header back-link + GitHub icon both present; `aria-hidden` glyph; sidebar entry same-tab; no off-site prev/next pager
- Pre-push gates green (branch hygiene, i18n, feature catalog, glossary, fallow)

i18n / feature-catalog / glossary entries are **not** required — those gates target `ui/` (+ `extension/`); this PR touches only the standalone English Astro sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)