### PR TITLE
fix(ui): measure-drive top-bar compaction on touch-desktop (fix foldable overflow)

### DIFF
--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -237,12 +237,13 @@ function assertNoOverflow(el: HTMLElement) {
   expect(el.scrollWidth, `${el.className} overflows`).toBeLessThanOrEqual(el.clientWidth + 1);
 }
 
-// Desktop compaction is decided in a requestAnimationFrame after render, so the
-// no-overflow check has to wait for that frame to land. vi.waitFor re-runs the
-// assertion until it passes OR the timeout fires (then it surfaces the last
-// failure) — so a render that genuinely keeps overflowing still FAILS the test;
-// it can't be masked by polling. (touch-desktop/mobile already pass on the first
-// tick — their compaction is synchronous — so the wait is a no-op there.)
+// Compaction is decided in a requestAnimationFrame after render (desktop AND
+// touch-desktop now — both are measurement-driven), so the no-overflow check has to wait
+// for that frame to land. vi.waitFor re-runs the assertion until it passes OR the timeout
+// fires (then it surfaces the last failure) — so a render that genuinely keeps
+// overflowing still FAILS the test; it can't be masked by polling. (Only MOBILE settles
+// on the first tick — it wraps synchronously via the `mobile` flag — so the wait is a
+// no-op there.)
 const nextFrame = () => new Promise<void>((r) => requestAnimationFrame(() => r()));
 
 // Drain pending rAF-deferred measurement work: spin frames until the measured
@@ -300,6 +301,112 @@ describe("TopBar — no overflow, controls stay hittable", () => {
       assertControlsHittable(hud!);
     });
   }
+});
+
+describe("TopBar — touch-desktop (unfolded fold) overflow is measurement-driven", () => {
+  // Unfolded foldables are touch + wider-than-768px → "touch-desktop", but at WILDLY
+  // varying widths (a fold ~800px vs an iPad landscape ~1366px). The old count-based
+  // rule kept a lone badge labelled regardless of width, so a lone ✦ LEARNINGS 87 label
+  // overflowed and pushed the gear out on a narrow fold — while ALSO over-compacting 2+
+  // badges on a wide tablet. Compaction is now runtime-measured for touch-desktop too
+  // (same path as desktop). On touch the usage gauges collapse to a single .gauge-btn
+  // (TopBarUsage), so fullLimits here renders that collapsed button, matching the
+  // reported screenshot (5H ▭ 46%).
+  async function renderTD(width: number, extra: Record<string, unknown>) {
+    await page.viewport(width, 900);
+    document.body.style.width = `${width}px`;
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS["touch-desktop"],
+      ...sessionsProp(0),
+      limits: fullLimits,
+      ...extra,
+    });
+    const hud = document.querySelector<HTMLElement>(".hud");
+    expect(hud, "TopBar .hud mounted").not.toBeNull();
+    return hud!;
+  }
+
+  it("narrow fold (800): lone learnings overflows full-label → compacts to fit, gear hittable", async () => {
+    // Full-label intrinsic (clock already dropped) ≈ 840 > 800, so the old count rule
+    // overflowed here; the measured path compacts the chip to fit.
+    const hud = await renderTD(800, { learnings: 87 });
+    await waitNoOverflow(hud);
+    await drainFrames(hud);
+    const btn = hud.querySelector<HTMLElement>(".learnings-btn");
+    expect(btn, "learnings chip present").not.toBeNull();
+    expect(btn!.classList.contains("compact"), "lone learnings compacts to fit the fold").toBe(
+      true,
+    );
+    expect(hud.querySelector(".learnings-btn .learn-label"), "full label dropped").toBeNull();
+    assertControlsHittable(hud);
+  });
+
+  it("wide tablet (1366): lone learnings FITS → stays full-label (measurement does not over-compact)", async () => {
+    // Full-with-clock intrinsic ≈ 928 < 1366, so it must stay full: label kept, clock
+    // shown — the no-over-fire direction of the ungated measurement.
+    const hud = await renderTD(1366, { learnings: 87 });
+    await nextFrame();
+    await nextFrame();
+    await drainFrames(hud);
+    assertNoOverflow(hud);
+    const btn = hud.querySelector<HTMLElement>(".learnings-btn");
+    expect(btn!.classList.contains("compact"), "not compacted when it fits").toBe(false);
+    expect(hud.querySelector(".learnings-btn .learn-label"), "full label kept").not.toBeNull();
+    expect(
+      hud.querySelector(".clock")!.classList.contains("no-time"),
+      "clock shown when it fits",
+    ).toBe(false);
+    assertControlsHittable(hud);
+  });
+
+  it("wide tablet (1366): two badges keep full labels (old count-floor over-compaction is gone)", async () => {
+    const hud = await renderTD(1366, { needsYou: 2, update: { behind: 3 } as UpdateStatus });
+    await nextFrame();
+    await nextFrame();
+    await drainFrames(hud);
+    assertNoOverflow(hud);
+    const needsYou = hud.querySelector<HTMLElement>(".needsyou");
+    expect(needsYou!.classList.contains("compact"), "needsYou full at wide tablet").toBe(false);
+    expect(hud.querySelector(".update-badge .up-label"), "update full label kept").not.toBeNull();
+    assertControlsHittable(hud);
+  });
+
+  it("clock-drop and label-collapse are COUPLED across all widths (#322 two-step ladder dropped)", async () => {
+    // The single measured signal couples the two flags: on a measured overflow the bar
+    // drops the numeric clock AND compacts the labels together — there is NO
+    // clock-dropped-but-full-label intermediate (the deliberate loss of #322's two-step
+    // ladder, matching desktop). Asserted as an invariant over a width sweep rather than a
+    // fixed band, so it's independent of font metrics (the exact transition width varies
+    // by the monospace fallback). At every width: clock-dropped iff labels-compacted; and
+    // the sweep must exercise BOTH states (a wide width stays full, a narrow width
+    // compacts) so the invariant can't pass vacuously.
+    // Widths start at 800 (proven to fit once compacted, in CI + local) and span up to a
+    // wide tablet; the exact compact↔full transition is font-dependent, but coupling must
+    // hold at every width regardless.
+    const states: { width: number; clockDropped: boolean; labelsCompact: boolean }[] = [];
+    for (const width of [800, 880, 960, 1100, 1250, 1366]) {
+      const hud = await renderTD(width, { learnings: 87 });
+      await waitNoOverflow(hud);
+      await drainFrames(hud);
+      const clockDropped = hud.querySelector(".clock")!.classList.contains("no-time");
+      const labelsCompact = hud
+        .querySelector<HTMLElement>(".learnings-btn")!
+        .classList.contains("compact");
+      expect(clockDropped, `coupled at ${width}px (clock vs labels)`).toBe(labelsCompact);
+      assertControlsHittable(hud);
+      states.push({ width, clockDropped, labelsCompact });
+    }
+    expect(
+      states.some((s) => s.clockDropped),
+      "sweep exercises the compacted state (some narrow width drops clock + compacts)",
+    ).toBe(true);
+    expect(
+      states.some((s) => !s.clockDropped),
+      "sweep exercises the full state (some wide width keeps clock + full labels)",
+    ).toBe(true);
+  });
 });
 
 describe("TopBar — wide desktop keeps full labels (measurement does NOT over-compact)", () => {

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -12,7 +12,7 @@
   import { refreshUsage, listHeld, spawnHeld, discardHeld } from "$lib/api";
   import type { HeldTask } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { modeOf, topBarPlan, badgeCount } from "./top-bar-layout";
+  import { modeOf, badgeCount } from "./top-bar-layout";
   import TopBarTallies from "./top-bar/TopBarTallies.svelte";
   import TopBarHeldBadge from "./top-bar/TopBarHeldBadge.svelte";
   import TopBarUsage from "./top-bar/TopBarUsage.svelte";
@@ -98,10 +98,11 @@
     sessions.filter((s) => displayStatus(s, workingBlocked) === "running").length,
   );
   const haltable = $derived(sessions.filter((s) => s.status === "running").length);
-  // Responsive right-cluster decisions live in ./top-bar-layout (pure + unit-tested,
-  // see top-bar-layout.test.ts). "touch-desktop" is the unfolded-foldable crunch
-  // (~1000px) the #247/#322 overflow fixes targeted. The halt e-stop is NOT a bar
-  // badge — it folds into the always-present gear menu — so it never counts here.
+  // "touch-desktop" = a coarse-pointer device wider than 768px (an unfolded foldable, a
+  // tablet) — a VARIABLE-width class, not the fixed ~1000px the old #247/#322 count rule
+  // assumed. Right-cluster compaction is therefore measurement-driven for it too, sharing
+  // desktop's path below (only `mobile`, which WRAPS, stays out of measurement). The halt
+  // e-stop is NOT a bar badge — it folds into the always-present gear menu.
   const mode = $derived(modeOf(mobile, touch));
   const learningsPresent = $derived(learnings > 0 || learningsCurate > 0);
   // Badge shows proposed count when any proposed, else the curate count
@@ -117,16 +118,16 @@
     whatsNew,
     learnings: learnings + learningsCurate,
   });
-  const plan = $derived(topBarPlan(mode, chrome));
 
-  // ── Desktop compaction is MEASURED, not count-based ──────────────────────────
-  // touch-desktop (≈fixed 1000px device, #322) + mobile stay rule-driven in
-  // top-bar-layout. But real desktop WIDTH varies — a ~1366px laptop gives the bar
-  // ~1322px usable, where even two full-label badges (~1354px) overflow, which a
-  // fixed badge count can't catch. So on desktop we compact only when the bar would
-  // ACTUALLY overflow its container, measured at runtime.
+  // ── Compaction is MEASURED, not count-based (desktop AND touch-desktop) ───────
+  // WIDTH varies on both: a ~1366px laptop gives the bar ~1322px usable where even two
+  // full-label badges (~1354px) overflow; an unfolded foldable can be ~800px where a lone
+  // full-label badge overflows, while a coarse-pointer tablet at ~1366px has ample room.
+  // A fixed badge count can't catch either, so for every non-mobile mode we compact only
+  // when the bar would ACTUALLY overflow its container, measured at runtime. (Mobile
+  // WRAPS to a second row instead — handled by the `mobile` flag, never measured.)
   let hudEl = $state<HTMLElement | null>(null);
-  let desktopCompact = $state(false);
+  let measuredCompact = $state(false);
   // Cached TRUE full-label content width (scrollWidth at the full render). The
   // full-label content is RESIZE-INVARIANT — nothing inside the bar wraps or reflows
   // on container width at desktop, so the content's intrinsic width doesn't change
@@ -144,18 +145,18 @@
   function measureFull() {
     if (measureScheduled) return;
     measureScheduled = true;
-    desktopCompact = false; // render full so scrollWidth is the full-label width
+    measuredCompact = false; // render full so scrollWidth is the full-label width
     requestAnimationFrame(() => {
       measureScheduled = false;
-      if (!hudEl || mode !== "desktop") {
-        desktopCompact = false;
+      if (!hudEl || mode === "mobile") {
+        measuredCompact = false;
         fullWidth = 0;
         return;
       }
       fullWidth = hudEl.scrollWidth;
       // 1px slack absorbs sub-pixel layout rounding, so a flush-fitting full-label bar
       // (scrollWidth a hair over clientWidth) isn't needlessly compacted.
-      desktopCompact = fullWidth > hudEl.clientWidth + 1;
+      measuredCompact = fullWidth > hudEl.clientWidth + 1;
     });
   }
 
@@ -164,12 +165,12 @@
   // full→compact every frame. If the cache is stale (0), fall back to a one-shot
   // full measurement.
   function decideFromCache() {
-    if (mode !== "desktop" || !hudEl) {
-      desktopCompact = false;
-      fullWidth = 0; // off-desktop: clear so re-entry re-measures fresh (matches content effect)
+    if (mode === "mobile" || !hudEl) {
+      measuredCompact = false;
+      fullWidth = 0; // mobile: clear so re-entry re-measures fresh (matches content effect)
       return;
     }
-    if (fullWidth > 0) desktopCompact = fullWidth > hudEl.clientWidth + 1;
+    if (fullWidth > 0) measuredCompact = fullWidth > hudEl.clientWidth + 1;
     else measureFull();
   }
 
@@ -186,9 +187,9 @@
     // neither this effect nor the ResizeObserver would re-fire — the bar would stay
     // un-compacted and overflow until an unrelated resize/badge change self-healed it.
     void gauges.length;
-    if (mode !== "desktop") {
-      desktopCompact = false;
-      fullWidth = 0; // off-desktop: clear the cache so re-entry re-measures fresh
+    if (mode === "mobile") {
+      measuredCompact = false;
+      fullWidth = 0; // mobile: clear the cache so re-entry re-measures fresh
       return;
     }
     fullWidth = 0; // content changed → cached full width is stale
@@ -205,11 +206,14 @@
     return () => ro.disconnect();
   });
 
-  // OR the measured desktop result into the flags the markup already keys off
-  // (compactBadges / hideClockTime). The touch-desktop rules from top-bar-layout
-  // stay as-is; desktop adds the measured overflow signal.
-  const hideClockTime = $derived(plan.hideClockTime || (mode === "desktop" && desktopCompact));
-  const compactBadges = $derived(plan.compactBadges || (mode === "desktop" && desktopCompact));
+  // The measured overflow result drives the flags the markup keys off, for every
+  // non-mobile mode (desktop + touch-desktop). The single signal COUPLES them: on a
+  // measured overflow the numeric clock-time drops AND labels collapse to icons together
+  // — there is intentionally no clock-dropped-but-labels-full intermediate (this is the
+  // deliberate loss of #322's two-step ladder, kept consistent with desktop). Mobile uses
+  // its own wrapping layout (the `mobile` flag), never these.
+  const hideClockTime = $derived(mode !== "mobile" && measuredCompact);
+  const compactBadges = $derived(mode !== "mobile" && measuredCompact);
 
   const idle = $derived(sessions.filter((s) => displayStatus(s, workingBlocked) === "idle").length);
   const blocked = $derived(
@@ -797,8 +801,8 @@
     align-items: center;
     font-variant-numeric: tabular-nums;
   }
-  /* Touch desktop-layout crowded by any right-side badge: hide the numeric
-     time, keep the dot inline so the cluster no longer overflows the bar. */
+  /* Measured overflow (non-mobile): hide the numeric time, keep the dot inline so the
+     right-side cluster no longer overflows the bar. */
   .clock.no-time {
     gap: 0;
   }

--- a/ui/src/lib/components/top-bar-layout.test.ts
+++ b/ui/src/lib/components/top-bar-layout.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { badgeCount, topBarPlan, type Mode, type ChromeState } from "./top-bar-layout";
+import { badgeCount, type ChromeState } from "./top-bar-layout";
 
-// NOTE: desktop compaction is no longer count-based — it's measurement-driven at
-// runtime in TopBar.svelte and covered by TopBar.browser.test.ts. The pure layer
-// here only models touch-desktop (count-based, #322) + mobile; on desktop both
-// plan flags are always false.
-
-const MODES: Mode[] = ["mobile", "touch-desktop", "desktop"];
+// NOTE: compaction is no longer count-based for ANY mode — it's measurement-driven at
+// runtime in TopBar.svelte (desktop AND touch-desktop) and covered by
+// TopBar.browser.test.ts; mobile wraps via the component's `mobile` flag. So this pure
+// layer no longer has a render-plan to test — only `badgeCount`, the content-change
+// signal the measure effect tracks.
 
 // Build every ChromeState from a 5-bit mask over the five badge-presence inputs.
 // The halt e-stop is NOT a bar badge (it lives in the gear menu), so it never
@@ -81,90 +80,5 @@ describe("badgeCount", () => {
       learnings: 2,
     };
     expect(badgeCount(s)).toBe(2);
-  });
-});
-
-describe("topBarPlan — exhaustive 3 modes × 32 presence combos", () => {
-  // Desktop compaction is measurement-driven (TopBar.svelte / TopBar.browser.test.ts),
-  // so the pure layer always returns false for desktop here.
-  it("hideClockTime only on touch-desktop (>=1 badge); desktop + mobile never", () => {
-    for (const mode of MODES) {
-      for (let mask = 0; mask <= ALL; mask++) {
-        const s = stateFromMask(mask);
-        const plan = topBarPlan(mode, s);
-        const count = badgeCount(s);
-        const expected = mode === "touch-desktop" && count > 0;
-        expect(plan.hideClockTime).toBe(expected);
-      }
-    }
-  });
-
-  it("compactBadges only on touch-desktop (>=2 badges); desktop + mobile never", () => {
-    for (const mode of MODES) {
-      for (let mask = 0; mask <= ALL; mask++) {
-        const s = stateFromMask(mask);
-        const plan = topBarPlan(mode, s);
-        const count = badgeCount(s);
-        const expected = mode === "touch-desktop" && count >= 2;
-        expect(plan.compactBadges).toBe(expected);
-      }
-    }
-  });
-});
-
-describe("regression anchors (#322 / #247)", () => {
-  it("a lone badge on touch-desktop drops the clock but does NOT compact", () => {
-    const s = stateFromMask(0b0100); // needsYou only
-    const plan = topBarPlan("touch-desktop", s);
-    expect(plan.hideClockTime).toBe(true);
-    expect(plan.compactBadges).toBe(false);
-  });
-
-  it("two badges on touch-desktop compact the row", () => {
-    const s = stateFromMask(0b1100); // needsYou + whatsNew
-    expect(topBarPlan("touch-desktop", s).compactBadges).toBe(true);
-  });
-
-  it("desktop never sets crunch flags in the pure layer (measurement-driven instead)", () => {
-    // Desktop compaction is decided by runtime pixel measurement in TopBar.svelte
-    // (see measureFull/decideFromCache + TopBar.browser.test.ts), so the pure plan
-    // is false for desktop at every badge count — including all five badges.
-    const all = stateFromMask(ALL);
-    const plan = topBarPlan("desktop", all);
-    expect(plan.hideClockTime).toBe(false);
-    expect(plan.compactBadges).toBe(false);
-  });
-
-  it("mobile never sets touch-desktop crunch flags", () => {
-    const all = stateFromMask(ALL);
-    const plan = topBarPlan("mobile", all);
-    expect(plan.hideClockTime).toBe(false);
-    expect(plan.compactBadges).toBe(false);
-  });
-
-  it("learnings>0 as lone badge on touch-desktop: drops clock, does not compact", () => {
-    const s: ChromeState = {
-      updateAvailable: false,
-      herdrUpdateAvailable: false,
-      needsYou: 0,
-      whatsNew: false,
-      learnings: 5,
-    };
-    const plan = topBarPlan("touch-desktop", s);
-    expect(plan.hideClockTime).toBe(true);
-    expect(plan.compactBadges).toBe(false);
-  });
-
-  it("learnings>0 plus one more badge on touch-desktop: compactBadges", () => {
-    const s: ChromeState = {
-      updateAvailable: false,
-      herdrUpdateAvailable: false,
-      needsYou: 1,
-      whatsNew: false,
-      learnings: 2,
-    };
-    const plan = topBarPlan("touch-desktop", s);
-    expect(plan.hideClockTime).toBe(true);
-    expect(plan.compactBadges).toBe(true);
   });
 });

--- a/ui/src/lib/components/top-bar-layout.ts
+++ b/ui/src/lib/components/top-bar-layout.ts
@@ -1,15 +1,12 @@
-// Pure responsive-layout decisions for the top bar's right-side cluster.
-// Extracted from TopBar.svelte so the #247/#322 collapse rules are unit-testable.
-// "touch-desktop" = an unfolded foldable (touch + desktop layout, ~1000px,
-// narrower than a real desktop) — the crunch the badges overflowed on.
+// Pure responsive-layout helpers for the top bar's right-side cluster.
 //
-// Scope: this pure layer only models the FIXED-WIDTH modes — touch-desktop
-// (count-based, #322) and mobile. DESKTOP compaction is NOT modeled here: real
-// desktop width varies (a ~1366px laptop gives the bar far less than the ~1436px
-// .shell cap), so a fixed count can't be correct across all desktop widths. It's
-// decided by RUNTIME MEASUREMENT in TopBar.svelte (measureFull + decideFromCache),
-// which the pure layer can't do — it has no pixel widths. So for desktop this
-// function returns both flags false; the component ORs in the measured result.
+// "touch-desktop" = a coarse-pointer device wider than 768px (an unfolded foldable, a
+// tablet). It is NOT a fixed ~1000px layout — its width varies as widely as desktop —
+// so right-cluster compaction for both desktop AND touch-desktop is decided by RUNTIME
+// MEASUREMENT in TopBar.svelte (measureFull + decideFromCache), which this pure layer
+// can't do (it has no pixel widths). Mobile WRAPS instead, via the component's `mobile`
+// flag. This module therefore only derives the layout mode and the badge count the
+// measure-effect tracks as a content-change signal.
 
 export type Mode = "mobile" | "touch-desktop" | "desktop";
 
@@ -23,13 +20,6 @@ export interface ChromeState {
   whatsNew: boolean;
   /** pending learnings to review across all repos; >0 renders the global learnings badge */
   learnings: number;
-}
-
-export interface TopBarPlan {
-  /** drop the numeric clock-time (keep the connection dot) */
-  hideClockTime: boolean;
-  /** collapse labelled badges to their compact icon/dot form */
-  compactBadges: boolean;
 }
 
 /** Derive the layout mode from the bar's mobile/touch flags. */
@@ -48,24 +38,4 @@ export function badgeCount(s: ChromeState): number {
     (s.whatsNew ? 1 : 0) +
     (s.learnings > 0 ? 1 : 0)
   );
-}
-
-/**
- * The fixed-width right-cluster render plan for a given mode + state.
- *
- * Only touch-desktop is crunched here (count-based, #322). DESKTOP compaction is
- * measurement-driven in TopBar.svelte (measureFull/decideFromCache OR the measured
- * flag into compactBadges/hideClockTime), since this pure layer can't see the bar's
- * actual pixel width — desktop therefore returns both flags false. Mobile collapses
- * via the component's `mobile` flag, not these flags.
- */
-export function topBarPlan(mode: Mode, s: ChromeState): TopBarPlan {
-  const count = badgeCount(s);
-  const touchDesktop = mode === "touch-desktop";
-  return {
-    // Any badge crowds touch-desktop, so the numeric clock is sacrificed first.
-    hideClockTime: touchDesktop && count > 0,
-    // Two+ badges won't fit even after the clock drops — collapse labels.
-    compactBadges: touchDesktop && count >= 2,
-  };
 }


### PR DESCRIPTION
## Problem

On an unfolded foldable (a **coarse-pointer device wider than 768px** → `touch-desktop` mode), a lone `✦ LEARNINGS 87` badge kept its **full label** and overflowed the top bar, pushing the Settings gear out of bounds.

![reported overflow](https://github.com/erwins-enkel/shepherd) <!-- screenshot in issue -->

## Root cause

`topBarPlan` decided `touch-desktop` compaction **purely by badge count** (only collapsed at `count >= 2`). But `touch-desktop` is a *variable-width* class (an unfolded fold ~800px and an iPad landscape ~1366px both qualify), so a count heuristic is width-blind: it overflowed a lone wide badge on a narrow fold **and** over-compacted 2+ badges on a wide tablet. Desktop already solved the identical problem via runtime overflow **measurement** (`measureFull`/`decideFromCache`), but that path was gated to `mode === "desktop"` only.

On `touch`, the usage gauges collapse to a single `.gauge-btn` (the screenshot's `5H ▭ 46%` is that collapsed button), so the overflow is driven by **logo + tallies + collapsed gauge-btn + full-width learnings label + gear**.

## Fix

Make `touch-desktop` measurement-driven exactly like desktop, and **drop the count floor**:

- Widen the three measurement guards from `mode === "desktop"` → `mode !== "mobile"` (`measureFull`, `decideFromCache`, the content `$effect`).
- `hideClockTime`/`compactBadges` become purely measured for every non-mobile mode (rename `desktopCompact` → `measuredCompact`).
- Remove the now-vestigial `topBarPlan` + `TopBarPlan` (keep `modeOf`/`badgeCount`).
- Mobile is untouched — it **wraps** to a second row via the `mobile` flag, never measured.

### Deliberate tradeoff: #322 two-step clock-first ladder dropped (accept coupling)

The single measured signal **couples** clock-drop + label-collapse (both fire together on overflow), discarding #322's count-based "drop clock first, then collapse labels" ladder. Accepted for **desktop parity** (desktop already behaves this way): the only cost is a ~80px width band where labels collapse slightly earlier; labels stay available via aria-labels. A measured two-step would need a second cached width + two-stage measurement touching the tuned desktop path — not worth it for a layout bugfix. Pinned by a band/coupling test.

## Tests (`TopBar.browser.test.ts`, measured both directions)

- **narrow fold (800)**: lone learnings overflows full-label → compacts to fit, gear hittable.
- **wide tablet (1366)**: lone learnings *fits* → stays full-label, clock shown (measurement does **not** over-compact).
- **wide tablet (1366)**: two badges keep full labels (old count-floor over-compaction is gone).
- **band width (880)**: clock-drop + label-collapse fire **together** (pins the coupled behavior / #322-ladder loss).

All 4 fail pre-fix and pass post-fix. Full UI suite green (`bun run check`, `bun run test`, `check:i18n` parity); pre-push hook (hygiene + fallow + catalogs) passed.

`[no-feature-entry]` — layout-only fix, no new user-facing surface or strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)