### PR TITLE
feat(docs): doc-agent nightly + merge-triggered cadence (#904)

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -54,10 +54,27 @@ mutation, `gh`, or network access**, so it can neither commit nor push; the trus
 stages the in-scope doc files, commits, and opens a **pull request** for human review
 (never an auto-merge). Off by default; flip on per deployment to soak it.
 
+**Automated cadence.** With the same flag on, two triggers run in addition to the manual
+one (a per-repo in-flight guard means at most one run per repo at a time):
+
+- **Nightly** — once per local day per repo that has the docs tree, at/after
+  `SHEPHERD_DOC_AGENT_NIGHTLY_HOUR` (default `3`). It first freshens the repo's default
+  branch from `origin`, then spawns a run **only if the branch advanced** since the last
+  doc-agent run — quiet days cost a cheap fetch but no agent spawn. This is the reliable
+  catch-all: it picks up **any** landed change, including `fix:` commits, config-only
+  changes, and human/non-session or non-conventional merges (e.g. epic-landing PRs).
+- **Merge-triggered** — when a Shepherd-managed session's PR merges to the default branch
+  **and its title is a `feat`/`config` conventional-commit subject**, a run is considered
+  immediately (the fast path). A doc-relevant `fix:` is intentionally **not** caught here —
+  it's covered by the nightly sweep instead. `config` (type or scope) is a forward-looking
+  allowance and may not yet appear in a given repo's history. Non-conventional or untitled
+  merges simply fall through to nightly.
+
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `SHEPHERD_DOC_AGENT` | `0` (off) | Set `1` to enable the manual doc-agent trigger + its boot orphan-sweep |
+| `SHEPHERD_DOC_AGENT` | `0` (off) | Set `1` to enable the doc agent: manual trigger, nightly + merge-triggered cadence, and the boot orphan-sweep |
 | `SHEPHERD_DOC_AGENT_MODEL` | _(none)_ | Model alias for the doc-agent spawn; unset uses the spawn default |
+| `SHEPHERD_DOC_AGENT_NIGHTLY_HOUR` | `3` | Local hour (0–23) at/after which the nightly sweep evaluates each repo; invalid values fall back to `3` |
 
 ## Per-agent sandbox / permission profiles
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -277,6 +277,15 @@ export function parseSandboxProfile(v: string | undefined): SandboxProfile {
   return isSandboxProfile(v) ? v : "trusted";
 }
 
+/** Parse an hour-of-day env (0–23 integer); empty/missing/out-of-range falls back to `def`. Exported
+ *  for tests. Guards the empty string explicitly — `Number("")` is `0`, which would otherwise pass as
+ *  a valid midnight hour. */
+export function parseHour(raw: string | undefined, def: number): number {
+  if (raw == null || raw.trim() === "") return def;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 && n <= 23 ? n : def;
+}
+
 export const config = {
   port: Number(process.env.SHEPHERD_PORT ?? 7330),
   // bind to loopback only; the Tailscale-serve proxy reaches it via 127.0.0.1.
@@ -356,6 +365,10 @@ export const config = {
   // Model alias for the doc-agent spawn. Unset → no --model (spawn default). The agent does
   // substantive comprehension, so a capable model is appropriate; override per deployment.
   docAgentModel: process.env.SHEPHERD_DOC_AGENT_MODEL ?? null,
+  // Local hour (0–23) at/after which the doc agent's nightly cadence sweep evaluates each doc-tree
+  // repo (issue #904). Once/day/repo, and only spawns when the default branch advanced since the last
+  // run; default 3 (≈03:00 local). Invalid values fall back to 3.
+  docAgentNightlyHour: parseHour(process.env.SHEPHERD_DOC_AGENT_NIGHTLY_HOUR, 3),
   // Context trim for auto-spawned (drain) agents (issue #499): spawn them with
   // `--disable-slash-commands` (drops the skill catalog) plus a per-spawn settings
   // overlay disabling every operator-enabled plugin (drops plugin hook injections,

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -10,6 +10,7 @@ import { EmptyDiffError } from "./forge/types";
 import type { GitForge } from "./forge/types";
 import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
+import type { SessionStore } from "./store";
 import {
   apiKeyMembraneFields,
   apiKeyPassthroughEnv,
@@ -103,13 +104,20 @@ export interface DocAgentDeps {
   herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab">;
   worktree: Pick<WorktreeMgr, "create" | "remove" | "gitCommonDir" | "ensureBaseRef">;
   resolveForge: (repoPath: string) => GitForge | null;
-  /** Repos to enumerate in the boot orphan-sweep (herdr-independent worktree prune). */
+  /** Repos to enumerate in the boot orphan-sweep (herdr-independent worktree prune) and the nightly
+   *  cadence sweep. */
   repos: () => string[];
+  /** Persisted per-repo cadence markers (last-sha / nightly-day / merged-seen). */
+  store: Pick<SessionStore, "getSetting" | "setSetting">;
   model?: string | null;
   onChange?: (f: DocAgentFinalize) => void;
   now?: () => number;
   timeoutMs?: number;
+  /** Local hour (0–23) at/after which the nightly sweep evaluates a repo. */
+  nightlyHour?: number;
   // Injectable seams (tests).
+  /** Local `YYYY-MM-DD` for `now` — the nightly once/day key. */
+  dayKey?: (now: number) => string;
   git?: (cwd: string, args: string[]) => Promise<string>;
   detectBackend?: () => SandboxBackend;
   membraneEnv?: () => {
@@ -143,6 +151,8 @@ export class DocAgentService {
   private git: (cwd: string, args: string[]) => Promise<string>;
   private now: () => number;
   private timeoutMs: number;
+  private nightlyHour: number;
+  private dayKey: (now: number) => string;
   private fileExists: (p: string) => boolean;
   private readSentinel: (worktreePath: string) => string | null;
   private buildPrompt: (base: string) => string;
@@ -151,6 +161,8 @@ export class DocAgentService {
     this.git = deps.git ?? defaultGit;
     this.now = deps.now ?? Date.now;
     this.timeoutMs = deps.timeoutMs ?? 20 * 60 * 1000;
+    this.nightlyHour = deps.nightlyHour ?? 3;
+    this.dayKey = deps.dayKey ?? defaultDayKey;
     this.fileExists = deps.fileExists ?? existsSync;
     this.readSentinel = deps.readSentinel ?? defaultReadSentinel;
     this.buildPrompt = deps.buildPrompt ?? ((base) => docAgentPrompt(base));
@@ -190,6 +202,98 @@ export class DocAgentService {
       return await this.begin(repoPath);
     } finally {
       this.starting.delete(repoPath);
+    }
+  }
+
+  /**
+   * Merge-triggered consideration (issue #904). Called when a managed session's PR merges to the
+   * default branch. Gated on a PER-PR persisted `merged-seen` key (NOT the sha-gate): the merged
+   * `session:git` event fires ONCE (the open→merged transition; `gitStateChanged` re-emits only on
+   * state/checks/headSha/mergeable/review/handoff moves) and this method does NO fetch, so the local
+   * `origin/<base>` is still the pre-merge sha at that instant — a sha-gate would wrongly skip with no
+   * re-emit to retry. The per-PR key is freshness-independent: it fires immediately (consider() →
+   * begin() fetches via ensureBaseRef so the agent grounds on the merged commits) and is
+   * restart-idempotent (the 3s boot warm-tick replays the merged event, but the key is already set).
+   */
+  async onMergedPr(
+    repoPath: string,
+    prNumber: number | undefined,
+    prTitle: string | undefined,
+  ): Promise<DocAgentResult> {
+    if (prNumber == null) return { status: "skipped", reason: "merged event without a PR number" };
+    if (!isDocRelevantMerge(prTitle))
+      return { status: "skipped", reason: "merge subject is not doc-relevant (feat/config)" };
+    const key = mergedSeenKey(repoPath, prNumber);
+    if (this.deps.store.getSetting(key) != null)
+      return { status: "skipped", reason: "merge already handled" };
+    this.deps.store.setSetting(key, "1");
+    return this.consider(repoPath);
+  }
+
+  /**
+   * Nightly cadence sweep (issue #904). Called on the 15s tick (flag-gated in index.ts). For each
+   * doc-tree repo, at most once per local day (the `nightly-day` marker), freshens `origin/<base>`
+   * and spawns a run ONLY when the default branch advanced since the last run (the `last-sha` gate) —
+   * so quiet days cost a fetch but no agent spawn.
+   */
+  async sweepNightly(): Promise<void> {
+    if (new Date(this.now()).getHours() < this.nightlyHour) return;
+    const today = this.dayKey(this.now());
+    for (const repo of this.deps.repos()) {
+      if (!this.fileExists(join(repo, DOC_TREE_MARKER))) continue;
+      if (this.deps.store.getSetting(nightlyDayKey(repo)) === today) continue;
+      // Stamp "evaluated today" BEFORE the freshen/compare so any outcome (skip, fire, fetch failure)
+      // counts as today's evaluation and the bounded fetch runs at most once/day/repo.
+      this.deps.store.setSetting(nightlyDayKey(repo), today);
+      try {
+        await this.considerNightly(repo);
+      } catch (err) {
+        console.warn(`[doc-agent] nightly sweep failed for ${repo}:`, err);
+      }
+    }
+  }
+
+  /** Per-repo nightly decision: freshen origin/<base>, sha-gate, spawn on change. */
+  private async considerNightly(repo: string): Promise<void> {
+    const forge = this.deps.resolveForge(repo);
+    if (!forge || forge.kind === "local") return; // no PR surface; guardRepo would skip anyway
+    let base: string;
+    try {
+      base = await forge.defaultBranch();
+    } catch {
+      return;
+    }
+    // REQUIRED freshen: PrPoller polls PR state via the gh API and never `git fetch`s, and nothing
+    // else periodically fetches managed repos' base refs — so without this the local origin/<base>
+    // only advances when the doc agent itself last ran, and a quiet repo (or one whose last merge was
+    // non-conventional) would skip indefinitely. ensureBaseRef is timeout-bounded and never throws.
+    await this.deps.worktree.ensureBaseRef(repo, base);
+    const sha = await this.originSha(repo, base);
+    if (sha === null) {
+      // fetch failed AND the remote ref was never local (offline) — skip today, retry tomorrow.
+      console.warn(
+        `[doc-agent] nightly: cannot resolve origin/${base} for ${repo}; skipping today`,
+      );
+      return;
+    }
+    if (sha === this.deps.store.getSetting(lastShaKey(repo))) return; // no new commits → no spawn
+    await this.consider(repo);
+  }
+
+  /** Stamp `last-sha` = `refs/remotes/origin/<base>` (the nightly gate's ref). Best-effort. */
+  private async stampLastSha(repoPath: string, base: string): Promise<void> {
+    const sha = await this.originSha(repoPath, base);
+    if (sha !== null) this.deps.store.setSetting(lastShaKey(repoPath), sha);
+  }
+
+  /** `refs/remotes/origin/<base>` sha, or null when the ref isn't locally present. */
+  private async originSha(repoPath: string, base: string): Promise<string | null> {
+    try {
+      const out = await this.git(repoPath, ["rev-parse", `refs/remotes/origin/${base}`]);
+      const sha = out.trim();
+      return sha.length > 0 ? sha : null;
+    } catch {
+      return null;
     }
   }
 
@@ -239,6 +343,12 @@ export class DocAgentService {
       agentName: DOC_AGENT_LABEL + id8,
       startedAt: this.now(),
     });
+    // Stamp the cadence marker from the SAME ref the nightly gate reads (`refs/remotes/origin/<base>`,
+    // freshened by ensureBaseRef above) — NOT resolved.baseRef, which falls back to the branch
+    // name/local sha in the diverged/no-upstream case and could never reach equality with the gate's
+    // origin/<base> read, re-firing nightly on quiet days. Best-effort: a repo without the remote ref
+    // simply isn't sha-gated by nightly (it has its own rev-parse-failure skip).
+    await this.stampLastSha(repoPath, base);
     return { status: "started" };
   }
 
@@ -453,6 +563,37 @@ export class DocAgentService {
     flush();
     return res;
   }
+}
+
+// ── cadence markers (settings KV) ─────────────────────────────────────────────
+const lastShaKey = (repo: string) => `docagent:last-sha:${repo}`;
+const nightlyDayKey = (repo: string) => `docagent:nightly-day:${repo}`;
+const mergedSeenKey = (repo: string, prNumber: number) =>
+  `docagent:merged-seen:${repo}:${prNumber}`;
+
+/** Local `YYYY-MM-DD` for `now` — the nightly once/day key (mirrors herd-digest's dayKeyFor). */
+function defaultDayKey(now: number): string {
+  const d = new Date(now);
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${m}-${day}`;
+}
+
+/**
+ * True when a merged PR's title (the squash/merge commit subject) classifies as a documentation-
+ * relevant change: a conventional-commit header whose type is `feat`/`config` or whose scope is
+ * `config`. Returns false for an absent/empty title, a bare (non-conventional) title, and the
+ * doc-sync subject (`docs: sync …`) — so non-conventional titles cleanly degrade to the nightly path
+ * and the doc agent never self-triggers off its own merged PR. `config` is a forward-looking
+ * allowance (not yet in this repo's history). See issue #904.
+ */
+export function isDocRelevantMerge(title: string | undefined): boolean {
+  if (!title) return false;
+  const m = /^\s*(\w+)(?:\(([^)]*)\))?!?:/.exec(title);
+  if (!m) return false;
+  const type = m[1]!.toLowerCase();
+  const scope = m[2]?.toLowerCase();
+  return type === "feat" || type === "config" || scope === "config";
 }
 
 function defaultReadSentinel(worktreePath: string): string | null {

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -206,9 +206,14 @@ export class DocAgentService {
   }
 
   /**
-   * Merge-triggered consideration (issue #904). Called when a managed session's PR merges to the
-   * default branch. Gated on a PER-PR persisted `merged-seen` key (NOT the sha-gate): the merged
-   * `session:git` event fires ONCE (the open→merged transition; `gitStateChanged` re-emits only on
+   * Merge-triggered consideration (issue #904). Called when a managed session's PR merges. Only a
+   * merge INTO the repo's default branch is considered — `baseBranch` (the session's PR target) must
+   * equal `forge.defaultBranch()`; a feat/config PR merging into a non-default (epic/stacked) base
+   * would spawn a near-no-op run grounded on the default tip, and those changes reach the default
+   * branch at epic-landing time (caught by the nightly sweep) anyway.
+   *
+   * Gated on a PER-PR persisted `merged-seen` key (NOT the sha-gate): the merged `session:git` event
+   * fires ONCE (the open→merged transition; `gitStateChanged` re-emits only on
    * state/checks/headSha/mergeable/review/handoff moves) and this method does NO fetch, so the local
    * `origin/<base>` is still the pre-merge sha at that instant — a sha-gate would wrongly skip with no
    * re-emit to retry. The per-PR key is freshness-independent: it fires immediately (consider() →
@@ -219,10 +224,22 @@ export class DocAgentService {
     repoPath: string,
     prNumber: number | undefined,
     prTitle: string | undefined,
+    baseBranch: string,
   ): Promise<DocAgentResult> {
     if (prNumber == null) return { status: "skipped", reason: "merged event without a PR number" };
     if (!isDocRelevantMerge(prTitle))
       return { status: "skipped", reason: "merge subject is not doc-relevant (feat/config)" };
+    // Default-branch gate (cheap forge call, reached only for doc-relevant subjects). On a resolve
+    // failure, skip — better a missed fast-path (nightly catches it) than a wrong-tip spawn.
+    const forge = this.deps.resolveForge(repoPath);
+    let def: string;
+    try {
+      def = forge ? await forge.defaultBranch() : "";
+    } catch {
+      return { status: "skipped", reason: "could not resolve default branch" };
+    }
+    if (!forge || baseBranch !== def)
+      return { status: "skipped", reason: "merge target is not the default branch" };
     const key = mergedSeenKey(repoPath, prNumber);
     if (this.deps.store.getSetting(key) != null)
       return { status: "skipped", reason: "merge already handled" };
@@ -568,6 +585,9 @@ export class DocAgentService {
 // ── cadence markers (settings KV) ─────────────────────────────────────────────
 const lastShaKey = (repo: string) => `docagent:last-sha:${repo}`;
 const nightlyDayKey = (repo: string) => `docagent:nightly-day:${repo}`;
+// One tiny row per merged feat/config PR per repo. Bounded by the count of such PRs (finite, modest)
+// and never read back beyond an existence check, so it needs no cleanup path — same accept-and-grow
+// posture as the existing `learnings:*` per-key settings markers (e.g. learnings:retired-seen:<repo>).
 const mergedSeenKey = (repo: string, prNumber: number) =>
   `docagent:merged-seen:${repo}:${prNumber}`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -824,8 +824,10 @@ events.subscribe((event, data) => {
   if (git.state !== "merged") return;
   const s = store.get(id);
   if (!s) return;
+  // onMergedPr gates on s.baseBranch === the repo default — a feat/config PR that merged into a
+  // non-default (epic/stacked) base must not trigger a run grounded on the default tip.
   void docAgent
-    .onMergedPr(s.repoPath, git.number, git.title)
+    .onMergedPr(s.repoPath, git.number, git.title, s.baseBranch)
     .catch((err) => console.warn("[doc-agent] onMergedPr failed:", err));
 });
 setInterval(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -579,6 +579,8 @@ const docAgent = new DocAgentService({
   worktree,
   resolveForge,
   repos: () => listRepos(config.repoRoot).map((r) => r.path),
+  store,
+  nightlyHour: config.docAgentNightlyHour,
   model: config.docAgentModel,
   onChange: (f) => events.emit("doc-agent:done", f),
 });
@@ -810,6 +812,22 @@ events.subscribe((event, data) => {
     console.warn(`[issue-log] comment on #${s.issueNumber} failed:`, err),
   );
 });
+// Merge-triggered doc-agent consideration (issue #904). On a managed session's PR merging to the
+// default branch, consider a doc-sync run when the merge subject is doc-relevant (feat/config). Flag-
+// gated; idempotent across the 3s boot warm-tick replay via onMergedPr's per-PR persisted key. The
+// merge fast path only sees managed-session PRs — human/non-session/non-conventional merges (e.g.
+// epic-landing PRs) are caught by the nightly catch-all instead.
+events.subscribe((event, data) => {
+  if (!config.docAgentEnabled) return;
+  if (event !== "session:git") return;
+  const { id, git } = data as { id: string; git: import("./forge/types").GitState };
+  if (git.state !== "merged") return;
+  const s = store.get(id);
+  if (!s) return;
+  void docAgent
+    .onMergedPr(s.repoPath, git.number, git.title)
+    .catch((err) => console.warn("[doc-agent] onMergedPr failed:", err));
+});
 setInterval(() => {
   if (maintenance.active) return;
   void reviewService.tick();
@@ -819,8 +837,12 @@ setInterval(() => {
   void recapService.sweep().catch((err) => console.warn("[recap] sweep failed:", err)); // settled-idle auto-fire
   void herdDigestService.tick().catch((err) => console.warn("[rundown] tick failed:", err)); // finalize in-flight digest (restart-safe)
   void herdDigestService.sweep().catch((err) => console.warn("[rundown] sweep failed:", err)); // daily auto-spark
-  if (config.docAgentEnabled)
+  if (config.docAgentEnabled) {
     void docAgent.tick().catch((err) => console.warn("[doc-agent] tick failed:", err)); // finalize: server stages/commits/pushes/opens PR
+    void docAgent
+      .sweepNightly()
+      .catch((err) => console.warn("[doc-agent] nightly sweep failed:", err)); // cadence: once/day/repo, spawn only when base advanced
+  }
   try {
     buildQueueReminder.sweep(); // settled-idle nudge for a drifted build queue (sync)
   } catch (err) {

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -1,6 +1,11 @@
 import { test, expect } from "bun:test";
-import { DocAgentService, DOC_AGENT_LABEL, type DocAgentFinalize } from "../src/doc-agent";
-import { config } from "../src/config";
+import {
+  DocAgentService,
+  DOC_AGENT_LABEL,
+  isDocRelevantMerge,
+  type DocAgentFinalize,
+} from "../src/doc-agent";
+import { config, parseHour } from "../src/config";
 
 function withAuth(
   mode: typeof config.authMode,
@@ -35,6 +40,9 @@ interface Harness {
   openPrInputs: unknown[];
   mergeCalls: number;
   finalizes: DocAgentFinalize[];
+  ensureBaseRefCalls: { repo: string; base: string }[];
+  kv: Map<string, string>;
+  __merge: number;
 }
 
 function mkHarness(opts?: {
@@ -46,6 +54,10 @@ function mkHarness(opts?: {
   worktreeListPorcelain?: string;
   herdrAgents?: { name: string; tabId: string }[];
   repos?: string[];
+  originSha?: string | (() => string);
+  originShaThrows?: boolean;
+  now?: () => number;
+  nightlyHour?: number;
 }): Harness {
   const o = {
     forgeKind: "github" as "github" | "local" | null,
@@ -58,6 +70,10 @@ function mkHarness(opts?: {
     worktreeListPorcelain: "",
     herdrAgents: [] as { name: string; tabId: string }[],
     repos: [] as string[],
+    originSha: "origin-sha-1" as string,
+    originShaThrows: false,
+    now: () => 1000,
+    nightlyHour: 3,
     ...opts,
   };
 
@@ -67,12 +83,24 @@ function mkHarness(opts?: {
   const removedWorktrees: string[] = [];
   const openPrInputs: unknown[] = [];
   const finalizes: DocAgentFinalize[] = [];
+  const ensureBaseRefCalls: { repo: string; base: string }[] = [];
+  const kv = new Map<string, string>();
+  const store = {
+    getSetting: (key: string) => kv.get(key) ?? null,
+    setSetting: (key: string, value: string) => {
+      kv.set(key, value);
+    },
+  };
   let mergeCalls = 0;
 
   const git = async (cwd: string, args: string[]): Promise<string> => {
     gitCalls.push({ cwd, args });
     if (args[0] === "diff" && args[1] === "--cached") return o.stagedNames;
     if (args[0] === "worktree" && args[1] === "list") return o.worktreeListPorcelain;
+    if (args[0] === "rev-parse" && args[1]?.startsWith("refs/remotes/origin/")) {
+      if (o.originShaThrows) throw new Error("no such ref");
+      return typeof o.originSha === "function" ? (o.originSha as () => string)() : o.originSha;
+    }
     return "";
   };
 
@@ -113,15 +141,18 @@ function mkHarness(opts?: {
       removedWorktrees.push(p);
     },
     gitCommonDir: (p: string) => `${p}/.git`,
-    ensureBaseRef: async (_repo: string, base: string) => ({
-      baseRef: base,
-      behind: 0,
-      ahead: 0,
-      diverged: false,
-      hasUpstream: true,
-      localExists: true,
-      localFf: "not-needed" as const,
-    }),
+    ensureBaseRef: async (repo: string, base: string) => {
+      ensureBaseRefCalls.push({ repo, base });
+      return {
+        baseRef: base,
+        behind: 0,
+        ahead: 0,
+        diverged: false,
+        hasUpstream: true,
+        localExists: true,
+        localFf: "not-needed" as const,
+      };
+    },
   };
 
   const svc = new DocAgentService({
@@ -129,9 +160,11 @@ function mkHarness(opts?: {
     worktree: worktree as any,
     resolveForge: () => forge,
     repos: () => o.repos,
+    store,
+    nightlyHour: o.nightlyHour,
     model: null,
     onChange: (f) => finalizes.push(f),
-    now: () => 1000,
+    now: o.now,
     git,
     detectBackend: () => null,
     membraneEnv: () => ({ claudeDir: "/c", home: "/h", nodeBinReal: "/n", extraEnv: {} }),
@@ -150,11 +183,17 @@ function mkHarness(opts?: {
     removedWorktrees,
     openPrInputs,
     finalizes,
+    ensureBaseRefCalls,
+    kv,
     mergeCalls: 0,
     get __merge() {
       return mergeCalls;
     },
-  } as any as Harness & { __merge: number };
+  } as any as Harness & {
+    __merge: number;
+    ensureBaseRefCalls: typeof ensureBaseRefCalls;
+    kv: Map<string, string>;
+  };
 }
 
 test("happy path: in-scope edits → commit --no-verify + push + openPr (never merge)", async () => {
@@ -293,4 +332,173 @@ test("sweepOrphans: closes only __docagent__ tabs and prunes only docs-update wo
   ).toBe(true);
   // unrelated feature branch NOT deleted
   expect(h.gitCalls.some((c) => c.args.includes("shepherd/some-feature"))).toBe(false);
+});
+
+// ── cadence: scheduling (issue #904) ───────────────────────────────────────────
+
+/** Local-time timestamp at hour `h` on a fixed day → `getHours()===h` regardless of TZ. */
+const at = (h: number, day = 1) => new Date(2030, 0, day, h, 0, 0).getTime();
+const LAST_SHA = (repo: string) => `docagent:last-sha:${repo}`;
+const NIGHTLY_DAY = (repo: string) => `docagent:nightly-day:${repo}`;
+const MERGED_SEEN = (repo: string, pr: number) => `docagent:merged-seen:${repo}:${pr}`;
+
+test("isDocRelevantMerge: feat/config relevant; fix/docs/chore/bare/absent not", () => {
+  for (const t of [
+    "feat: x",
+    "feat(ui): x",
+    "feat!: x",
+    "feat(ui)!: x",
+    "config: x",
+    "config(env): x",
+    "fix(config): x",
+  ])
+    expect(isDocRelevantMerge(t)).toBe(true);
+  for (const t of [
+    "fix: x",
+    "fix(ui): x",
+    "chore: x",
+    "docs: sync docs to recent source changes",
+    "refactor(ui): x",
+    "Land epic #875: docs site",
+    "just a bare title",
+    "",
+    undefined,
+  ])
+    expect(isDocRelevantMerge(t)).toBe(false);
+});
+
+test("parseHour: valid 0–23 kept; invalid/empty/out-of-range fall back to default", () => {
+  expect(parseHour("0", 3)).toBe(0);
+  expect(parseHour("23", 3)).toBe(23);
+  expect(parseHour("5", 3)).toBe(5);
+  expect(parseHour(undefined, 3)).toBe(3);
+  expect(parseHour("", 3)).toBe(3);
+  expect(parseHour("24", 3)).toBe(3);
+  expect(parseHour("-1", 3)).toBe(3);
+  expect(parseHour("3.5", 3)).toBe(3);
+  expect(parseHour("abc", 3)).toBe(3);
+});
+
+test("nightly hour-gate: before nightlyHour → no rev-parse, no spawn, no marker writes", async () => {
+  const h = mkHarness({ repos: ["/repo"], nightlyHour: 3, now: () => at(2) });
+  await h.svc.sweepNightly();
+  expect(h.starts).toHaveLength(0);
+  expect(h.gitCalls.some((c) => c.args[0] === "rev-parse")).toBe(false);
+  expect(h.ensureBaseRefCalls).toHaveLength(0);
+  expect(h.kv.size).toBe(0);
+});
+
+test("nightly freshens origin/<base> (ensureBaseRef) before comparing, at most once/day/repo", async () => {
+  const h = mkHarness({ repos: ["/repo"], nightlyHour: 3, now: () => at(4) });
+  await h.svc.sweepNightly();
+  expect(h.ensureBaseRefCalls).toContainEqual({ repo: "/repo", base: "main" });
+  const freshenCount = h.ensureBaseRefCalls.filter((c) => c.repo === "/repo").length;
+  // second sweep same day → early-skip, no extra freshen
+  await h.svc.sweepNightly();
+  expect(h.ensureBaseRefCalls.filter((c) => c.repo === "/repo").length).toBe(freshenCount);
+});
+
+test("nightly sha-gate: base advanced → spawn + last-sha stamped from origin/<base>", async () => {
+  const h = mkHarness({ repos: ["/repo"], nightlyHour: 3, now: () => at(4), originSha: "new-sha" });
+  await h.svc.sweepNightly();
+  expect(h.starts).toHaveLength(1);
+  expect(h.kv.get(LAST_SHA("/repo"))).toBe("new-sha");
+  expect(h.kv.get(NIGHTLY_DAY("/repo"))).toBe("2030-01-01");
+});
+
+test("nightly sha-gate: base unchanged → no spawn, dayKey stamped", async () => {
+  const h = mkHarness({ repos: ["/repo"], nightlyHour: 3, now: () => at(4), originSha: "same" });
+  h.kv.set(LAST_SHA("/repo"), "same");
+  await h.svc.sweepNightly();
+  expect(h.starts).toHaveLength(0);
+  expect(h.kv.get(NIGHTLY_DAY("/repo"))).toBe("2030-01-01");
+});
+
+test("nightly once/day: second sweep same day → early-skip (no rev-parse)", async () => {
+  const h = mkHarness({ repos: ["/repo"], nightlyHour: 3, now: () => at(4), originSha: "same" });
+  h.kv.set(LAST_SHA("/repo"), "same");
+  await h.svc.sweepNightly();
+  const revParseCount = h.gitCalls.filter((c) => c.args[0] === "rev-parse").length;
+  await h.svc.sweepNightly();
+  expect(h.gitCalls.filter((c) => c.args[0] === "rev-parse").length).toBe(revParseCount);
+});
+
+test("nightly → consider skipped (already running): nightly-day stamped, last-sha NOT stamped", async () => {
+  const h = mkHarness({ repos: ["/repo"], nightlyHour: 3, now: () => at(4), originSha: "new-sha" });
+  // a run is already in flight for the repo → consider() returns skipped, begin() never reached
+  await h.svc.consider("/repo");
+  h.kv.delete(LAST_SHA("/repo")); // clear the stamp the in-flight run just wrote
+  await h.svc.sweepNightly();
+  expect(h.kv.get(NIGHTLY_DAY("/repo"))).toBe("2030-01-01");
+  expect(h.kv.has(LAST_SHA("/repo"))).toBe(false);
+  // only the one (manual) spawn — nightly did not spawn a second
+  expect(h.starts).toHaveLength(1);
+});
+
+test("nightly rev-parse failure: dayKey stamped, spawn skipped", async () => {
+  const h = mkHarness({
+    repos: ["/repo"],
+    nightlyHour: 3,
+    now: () => at(4),
+    originShaThrows: true,
+  });
+  await h.svc.sweepNightly();
+  expect(h.starts).toHaveLength(0);
+  expect(h.kv.get(NIGHTLY_DAY("/repo"))).toBe("2030-01-01");
+});
+
+test("nightly rev-parse failure then next-day success fires", async () => {
+  let throws = true;
+  let nowVal = at(4, 1);
+  const h = mkHarness({
+    repos: ["/repo"],
+    nightlyHour: 3,
+    now: () => nowVal,
+    originSha: () => {
+      if (throws) throw new Error("no ref");
+      return "fresh";
+    },
+  });
+  await h.svc.sweepNightly();
+  expect(h.starts).toHaveLength(0);
+  // next local day, ref resolves
+  throws = false;
+  nowVal = at(4, 2);
+  await h.svc.sweepNightly();
+  expect(h.starts).toHaveLength(1);
+  expect(h.kv.get(NIGHTLY_DAY("/repo"))).toBe("2030-01-02");
+});
+
+test("merge: feat-subject PR → spawn once + merged-seen persisted; no fetch in onMergedPr", async () => {
+  const h = mkHarness();
+  const res = await h.svc.onMergedPr("/repo", 42, "feat(ui): add thing");
+  expect(res.status).toBe("started");
+  expect(h.starts).toHaveLength(1);
+  expect(h.kv.get(MERGED_SEEN("/repo", 42))).toBe("1");
+  // onMergedPr itself does no rev-parse before consider(); begin()'s stampLastSha does the only one
+  const revParses = h.gitCalls.filter((c) => c.args[0] === "rev-parse");
+  expect(revParses).toHaveLength(1);
+});
+
+test("merge: non-doc-relevant subject → skip, no spawn, no merged-seen", async () => {
+  const h = mkHarness();
+  const res = await h.svc.onMergedPr("/repo", 7, "fix: a bug");
+  expect(res.status).toBe("skipped");
+  expect(h.starts).toHaveLength(0);
+  expect(h.kv.has(MERGED_SEEN("/repo", 7))).toBe(false);
+});
+
+test("merge restart-idempotency: merged-seen already set → skip (boot-replay no-op)", async () => {
+  const h = mkHarness();
+  h.kv.set(MERGED_SEEN("/repo", 42), "1");
+  const res = await h.svc.onMergedPr("/repo", 42, "feat: x");
+  expect(res.status).toBe("skipped");
+  expect(h.starts).toHaveLength(0);
+});
+
+test("merge: absent PR number → skip", async () => {
+  const h = mkHarness();
+  const res = await h.svc.onMergedPr("/repo", undefined, "feat: x");
+  expect(res.status).toBe("skipped");
+  expect(h.starts).toHaveLength(0);
 });

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -469,9 +469,9 @@ test("nightly rev-parse failure then next-day success fires", async () => {
   expect(h.kv.get(NIGHTLY_DAY("/repo"))).toBe("2030-01-02");
 });
 
-test("merge: feat-subject PR → spawn once + merged-seen persisted; no fetch in onMergedPr", async () => {
+test("merge: feat-subject PR into default base → spawn once + merged-seen persisted; no fetch in onMergedPr", async () => {
   const h = mkHarness();
-  const res = await h.svc.onMergedPr("/repo", 42, "feat(ui): add thing");
+  const res = await h.svc.onMergedPr("/repo", 42, "feat(ui): add thing", "main");
   expect(res.status).toBe("started");
   expect(h.starts).toHaveLength(1);
   expect(h.kv.get(MERGED_SEEN("/repo", 42))).toBe("1");
@@ -482,23 +482,31 @@ test("merge: feat-subject PR → spawn once + merged-seen persisted; no fetch in
 
 test("merge: non-doc-relevant subject → skip, no spawn, no merged-seen", async () => {
   const h = mkHarness();
-  const res = await h.svc.onMergedPr("/repo", 7, "fix: a bug");
+  const res = await h.svc.onMergedPr("/repo", 7, "fix: a bug", "main");
   expect(res.status).toBe("skipped");
   expect(h.starts).toHaveLength(0);
   expect(h.kv.has(MERGED_SEEN("/repo", 7))).toBe(false);
 });
 
+test("merge: feat PR into NON-default base (epic/stacked) → skip, no spawn, no merged-seen", async () => {
+  const h = mkHarness(); // forge.defaultBranch() === "main"
+  const res = await h.svc.onMergedPr("/repo", 99, "feat: epic sub-task", "epic/875-docs-site");
+  expect(res.status).toBe("skipped");
+  expect(h.starts).toHaveLength(0);
+  expect(h.kv.has(MERGED_SEEN("/repo", 99))).toBe(false);
+});
+
 test("merge restart-idempotency: merged-seen already set → skip (boot-replay no-op)", async () => {
   const h = mkHarness();
   h.kv.set(MERGED_SEEN("/repo", 42), "1");
-  const res = await h.svc.onMergedPr("/repo", 42, "feat: x");
+  const res = await h.svc.onMergedPr("/repo", 42, "feat: x", "main");
   expect(res.status).toBe("skipped");
   expect(h.starts).toHaveLength(0);
 });
 
 test("merge: absent PR number → skip", async () => {
   const h = mkHarness();
-  const res = await h.svc.onMergedPr("/repo", undefined, "feat: x");
+  const res = await h.svc.onMergedPr("/repo", undefined, "feat: x", "main");
   expect(res.status).toBe("skipped");
   expect(h.starts).toHaveLength(0);
 });


### PR DESCRIPTION
Closes #904. Follow-up to #882 (epic #875 Phase 3).

Adds automated cadence on top of the manual-only PR-gated doc agent, **bound to the same off-by-default flag** (`SHEPHERD_DOC_AGENT`) and the existing per-repo in-flight guard. The manual `POST /api/doc-agent` trigger is unchanged.

## Two new triggers

**Nightly** — once per local day per doc-tree repo, at/after `SHEPHERD_DOC_AGENT_NIGHTLY_HOUR` (default `3`). It first freshens the repo's default branch from `origin` (`ensureBaseRef`, timeout-bounded), then spawns a run **only when the branch advanced** since the last doc-agent run. Quiet days cost a cheap fetch, no agent spawn. This is the reliable catch-all — it picks up *any* landed change (incl. `fix:`, config-only, and human/non-session/non-conventional merges like epic-landing PRs).

> The in-sweep freshen is **required**: `PrPoller` polls PR state via the `gh` API and never `git fetch`s, and nothing else periodically fetches managed repos' base refs — so without it the local `origin/<base>` would only advance when the doc agent itself last ran, and a quiet repo would skip indefinitely.

**Merge-triggered** — when a managed session's PR merges to the default branch **and its title is a `feat`/`config` conventional-commit subject**, a run is considered immediately (the fast path). Gated on a **per-PR persisted `merged-seen` key**, not a sha-gate: the merged `session:git` event fires *once* (the open→merged transition) and `onMergedPr` does no fetch, so the local ref is still pre-merge at that instant — a sha-gate would wrongly skip with no re-emit to retry. The per-PR key is freshness-independent and **idempotent across the 3s boot warm-tick replay**.

## Persistence (no new table)

Per-repo markers live in the existing `settings` KV:
- `docagent:last-sha:<repo>` — stamped = `rev-parse refs/remotes/origin/<base>` (the **same ref** the nightly gate reads, so quiet-day equality is reachable; not `resolved.baseRef`, which falls back to a local sha in the diverged case).
- `docagent:nightly-day:<repo>` — once/day guard.
- `docagent:merged-seen:<repo>:<pr#>` — per-PR merge dedup.

## Config

| Variable | Default | Purpose |
| --- | --- | --- |
| `SHEPHERD_DOC_AGENT_NIGHTLY_HOUR` | `3` | Local hour (0–23) the nightly sweep evaluates each repo; empty/invalid → `3` |

## Tests

`test/doc-agent.test.ts` extended with a fake `store` KV + injectable `now`/`originSha`: nightly hour-gate, freshen-before-compare (once/day), sha-gate fire/skip, once/day dedup, consider-skipped semantics (nightly-day stamped, last-sha not), rev-parse-failure skip + next-day retry, merge classify, merge fires-once + persists key, restart-idempotency, absent PR#, and `parseHour` clamping. Full suite green (4241 pass).

`[no-feature-entry]` — server-only cadence; no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)