### PR TITLE
fix(ui): label the repo-switcher learnings indicator (✦ LEARNINGS/TRIM + count)

### DIFF
--- a/ui/src/lib/components/RepoSwitcher.browser.test.ts
+++ b/ui/src/lib/components/RepoSwitcher.browser.test.ts
@@ -254,6 +254,32 @@ describe("RepoSwitcher — filter rail", () => {
     expect(live!.textContent?.trim()).toBe("");
   });
 
+  it("lone-repo with insights > 0 shows 'LEARNINGS' label and insights count in the telemetry button", async () => {
+    const { container } = render(RepoSwitcher, {
+      chips: [chip({ repoPath: "/repo/solo", insights: 5 })],
+      repoFilter: null,
+      onrepofilter: () => {},
+    });
+    const btn = container.querySelector<HTMLElement>(".rs-insights");
+    expect(btn, "insights button present").not.toBeNull();
+    expect(btn!.querySelector(".rs-insights-label")?.textContent?.trim()).toBe(m.learnings_title());
+    expect(btn!.querySelector(".rs-insights-n")?.textContent?.trim()).toBe("5");
+  });
+
+  it("lone-repo with insights: 0, curate > 0 shows 'TRIM' label and curate count in the telemetry button", async () => {
+    const { container } = render(RepoSwitcher, {
+      chips: [chip({ repoPath: "/repo/solo", insights: 0, curate: 3 })],
+      repoFilter: null,
+      onrepofilter: () => {},
+    });
+    const btn = container.querySelector<HTMLElement>(".rs-insights");
+    expect(btn, "insights button present").not.toBeNull();
+    expect(btn!.querySelector(".rs-insights-label")?.textContent?.trim()).toBe(
+      m.learnings_trim_title(),
+    );
+    expect(btn!.querySelector(".rs-insights-n")?.textContent?.trim()).toBe("3");
+  });
+
   it("clicking the queued button expands the inline queue (fetches via getDrainQueue)", async () => {
     getDrainQueueFn.mockResolvedValueOnce([
       { number: 42, title: "queued issue", url: "https://example.test/42" },

--- a/ui/src/lib/components/repo-switcher/RepoChipTelemetry.svelte
+++ b/ui/src/lib/components/repo-switcher/RepoChipTelemetry.svelte
@@ -16,6 +16,10 @@
   } = $props();
 
   const d = $derived(chip.drain);
+  const insightsLabel = $derived(
+    chip.insights > 0 ? m.learnings_title() : m.learnings_trim_title(),
+  );
+  const insightsCount = $derived(chip.insights > 0 ? chip.insights : chip.curate);
 
   // ── inline queue expansion (mirrors QueueStrip toggle/loading/failed) ───────
   // At most one repo's queue is expanded at a time, fetched fresh on open.
@@ -87,9 +91,9 @@
         : m.learnings_open_curate_aria({ count: chip.curate })}
       onclick={() => onlearnings?.(chip.repoPath)}
     >
-      <span class="rs-insights-icon" aria-hidden="true">✦</span>{#if chip.insights > 0}<span
-          class="rs-insights-n">{chip.insights}</span
-        >{/if}
+      <span class="rs-insights-icon" aria-hidden="true">✦</span><span class="rs-insights-label"
+        >{insightsLabel}</span
+      ><span class="rs-insights-n">{insightsCount}</span>
     </button>
   {/if}
 


### PR DESCRIPTION
## Problem
On the repo-switcher detail line, the learnings indicator rendered only `✦ <count>`. When the active/lone repo has no drain telemetry (e.g. SHEPHERD in the report), that button is the only item on the row — a whole line showing just a glyph and a number, with no indication of what it means.

## Fix
Add a visible word label to the `.rs-insights` button, mirroring the existing TopBar learnings badge (`TopBarBadges.svelte` / `TopBar.svelte:110`):

- **Order**: glyph → label → count (`✦ LEARNINGS 59`).
- **Conditional label**: proposed (`insights > 0`) → `learnings_title()` ("Learnings"); curate-only (`insights == 0, curate > 0`) → `learnings_trim_title()` ("Trim").
- **Count** now also renders in the curate-only state (`insights > 0 ? insights : curate`), matching TopBar's `learningsCount`.

Label/count are `$derived` so the two states stay in lockstep. One component change covers both the active-filtered chip and lone-repo detail lines (both render `RepoChipTelemetry`).

## Notes
- Reuses existing `learnings_title` + `learnings_trim_title` — **no new i18n keys**, EN+DE parity intact.
- `✦` stays neutral chrome on the faint ink ramp (Four-Light Rule); no new status hue, no raw color/size literals.
- Not a new feature — polish of an existing indicator — so `fix(ui):` and no feature-catalog entry.

## Tests
- Added two browser tests in `RepoSwitcher.browser.test.ts` asserting the **visible** label text + count for both the proposed and curate-only states.
- `cd ui && bun run check` clean; full `bun run test` 1815/1815 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)