### PR TITLE
refactor(ui): split LearningsDrawer into learnings-drawer/, drop fallow grandfather (#855)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -169,14 +169,16 @@
     //   external convention exists for template thresholds — this is a deliberate
     //   judgment call. 27 of 36 components clear it; anything over it still trips, so
     //   the metric stays live for new code.
-    // Tier 2: the 2 giants that exceed Tier 1, each grandfathered just above its
+    // Tier 2: the 1 giant that exceeds Tier 1, grandfathered just above its
     //   current cyclo/cog (next multiple of 10) so it can't silently grow. Tracked for
-    //   refactor in #855 — which has paid down 11 of the original 13 (RepoSwitcher,
+    //   refactor in #855 — which has paid down 12 of the original 13 (RepoSwitcher,
     //   NewTask, AutomationSettings, Settings, IssuesPanel, BacklogView, UnitRow,
-    //   GitRail, TopBar, Herd, +page), each split into subcomponents that clear the
-    //   Tier-1 bar, so their grandfathers are removed. +page fell 78/96 -> 32/45 after
-    //   extracting page/AppOverlays (the modal/overlay tail + Triage/Learnings drawers,
-    //   33/23) — no main-region split was needed. Remaining: Viewport, LearningsDrawer.
+    //   GitRail, TopBar, Herd, +page, LearningsDrawer), each split into subcomponents
+    //   that clear the Tier-1 bar, so their grandfathers are removed. +page fell
+    //   78/96 -> 32/45 after extracting page/AppOverlays (the modal/overlay tail +
+    //   Triage/Learnings drawers, 33/23) — no main-region split was needed.
+    //   LearningsDrawer fell 63/157 -> 8/9 after extracting the learnings-drawer/
+    //   children (RepoGroup + the rule/band cards). Remaining: Viewport.
     // maxCrap is intentionally inert for templates: CRAP for uncovered code is pure
     //   CC-derived noise bounded by CC²+CC; 20000 sits above the largest template's
     //   worst case (Viewport CC 136 → ≈18632) so it never becomes the binding
@@ -206,14 +208,6 @@
         // 60 bar without splitting the nesting into unnatural sub-components, so
         // it stays grandfathered (just above current) and tracked in #855.
         "reason": "Tier 2 grandfather (#851), tightened by #855; remaining .vp-head identity/status split tracked in #855."
-      },
-      {
-        "files": ["ui/src/lib/components/LearningsDrawer.svelte"],
-        "functions": ["<template>"],
-        "maxCyclomatic": 70,
-        "maxCognitive": 160,
-        "maxCrap": 20000,
-        "reason": "Tier 2 grandfather (#851); refactor candidate #855. Cognitive bar raised 110→130 in #840 (auto-retire UI), 130→140 in #842 (glob-scoped injection UI), then 140→160 (cyclo 50→70) in #843: the background merge-suggestion cards + cross-repo recurrence band + 'Suggest merges' button landed in this component (its own UI home), per the established 'next multiple of 10 above current' convention."
       }
     ],
 

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -1,27 +1,17 @@
 <script lang="ts">
   import { fly } from "svelte/transition";
-  import type { Action } from "svelte/action";
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
-  import type {
-    InjectableRule,
-    Learning,
-    RepoInjectable,
-    MergeSuggestion,
-    SignalKind,
-  } from "$lib/types";
+  import type { InjectableRule, Learning, RepoInjectable, MergeSuggestion } from "$lib/types";
   import { learnings } from "$lib/learnings.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import {
     basename,
     repoAnchorId,
     mergeRepoGroups,
-    injectionBadge,
     injectedCount,
-    showIneffective,
     flaggedCount,
     totalFlagged,
-    evidenceSources,
     sortGroupsForTriage,
     isOverBudget,
     droppedCount,
@@ -31,50 +21,12 @@
     retiredRules,
     retiredCount,
     unseenRetiredCount,
-    helpRate,
   } from "./learnings-drawer";
-
-  // Human label for an evidence source kind. Mirrors the server SignalKind set;
-  // keeps the i18n call in the component (the helper stays locale-agnostic).
-  const kindLabel = (k: SignalKind): string =>
-    k === "reply"
-      ? m.learnings_kind_reply()
-      : k === "critic"
-        ? m.learnings_kind_critic()
-        : k === "block"
-          ? m.learnings_kind_block()
-          : m.learnings_kind_stall();
-
-  // Grow a rule textarea to fit its content so the full rule is always readable —
-  // no inner scroll, no clipping. Re-measures on every input and, via `update`,
-  // whenever the bound value changes programmatically (e.g. a poll refresh
-  // replacing the rule text while no local draft exists).
-  const autosize: Action<HTMLTextAreaElement, string> = (el) => {
-    let raf = 0;
-    const fit = () => {
-      el.style.height = "auto";
-      el.style.height = `${el.scrollHeight}px`;
-    };
-    // scrollHeight is unreliable mid fly-in / before the new value is flushed
-    // to the DOM; settle one frame later.
-    const fitNextFrame = () => {
-      cancelAnimationFrame(raf);
-      raf = requestAnimationFrame(fit);
-    };
-    fit();
-    fitNextFrame();
-    el.addEventListener("input", fit);
-    return {
-      update: fitNextFrame,
-      destroy() {
-        cancelAnimationFrame(raf);
-        el.removeEventListener("input", fit);
-      },
-    };
-  };
-
-  // Which rules have their evidence-source list expanded, keyed by learning id.
-  let expanded = $state<Record<string, boolean>>({});
+  import type { LearningsCtx } from "./learnings-drawer/ctx";
+  import InjectableRuleCard from "./learnings-drawer/InjectableRuleCard.svelte";
+  import ProposedRuleCard from "./learnings-drawer/ProposedRuleCard.svelte";
+  import MergeSuggestCard from "./learnings-drawer/MergeSuggestCard.svelte";
+  import RetiredRuleCard from "./learnings-drawer/RetiredRuleCard.svelte";
 
   // "What is this?" explainer at the top of the drawer. Default open so a first-time
   // user gets the plain-language explanation; collapsing is remembered (localStorage)
@@ -147,14 +99,11 @@
   // Cross-repo card pending the inline two-step confirm before a global CLAUDE.md write (#872).
   let confirmingGlobalId = $state<string | null>(null);
 
-  let drafts = $state<Record<string, string>>({});
-  const draft = (l: Learning) => drafts[l.id] ?? l.rule;
-
   // Glob-scope editing (#842): which injectable rule has its scope editor open, and the
   // comma-separated draft text. Saving splits on commas/whitespace into a glob array.
   let editingScope = $state<string | null>(null);
   let scopeDraft = $state("");
-  function openScopeEditor(l: Learning & { scopeGlobs: string[] }) {
+  function openScopeEditor(l: InjectableRule) {
     editingScope = l.id;
     scopeDraft = l.scopeGlobs.join(", ");
   }
@@ -166,6 +115,30 @@
     onscope(id, globs);
     editingScope = null;
   }
+
+  // Shared context bundle — built as $derived so children's reads of
+  // editingScope/scopeDraft stay reactive (mirroring Herd.svelte:252 rowCtx pattern).
+  const ctx = $derived<LearningsCtx>({
+    onapprove,
+    ondismiss,
+    ondistill,
+    onpromote,
+    onoptimize,
+    onoptimizeall,
+    onrestore,
+    onscope,
+    onseenretired,
+    onmerge,
+    ondismissmerge,
+    onpromoteglobal,
+    onmergenow,
+    editingScope,
+    scopeDraft,
+    onScopeOpen: openScopeEditor,
+    onScopeInput: (v: string) => (scopeDraft = v),
+    onScopeSave: saveScope,
+    onScopeCancel: () => (editingScope = null),
+  });
 
   const reduceMotion =
     typeof window !== "undefined" &&
@@ -388,102 +361,6 @@
     </section>
   {/if}
 
-  <!-- Change 6: Injectable-rule snippet — single source, no copy-paste.
-       Accepts the repo's enabled flag so the badge reflects injection state correctly. -->
-  {#snippet irule(r: InjectableRule, enabled: boolean)}
-    {@const badge = injectionBadge(r, enabled)}
-    <article class="irule">
-      <p class="itext">{r.rule}</p>
-      <div class="ifoot">
-        <span class="chip" class:promoted={r.status === "promoted"}>
-          {r.status === "promoted" ? m.learnings_status_promoted() : m.learnings_status_active()}
-        </span>
-        {#if badge === "injected"}
-          <span class="badge ok">✓ {m.learnings_injected_badge()}</span>
-        {:else if badge === "scoped"}
-          <span class="badge scoped" title={m.learnings_scoped_title()}>
-            ◎ {m.learnings_scoped_badge()}
-          </span>
-        {:else if badge === "over-budget"}
-          <span class="badge warn" title={m.learnings_overbudget_title()}>
-            ⊘ {m.learnings_overbudget_badge()}
-          </span>
-        {:else}
-          <span class="badge off">⊘ {m.learnings_injection_disabled_badge()}</span>
-        {/if}
-        {#if showIneffective(r)}
-          <span class="badge bad" title={m.learnings_ineffective_title()}>
-            ⚠ {m.learnings_ineffective_badge({ count: r.ineffectiveCount })}
-          </span>
-        {/if}
-        {#if helpRate(r) !== null}
-          {@const hr = helpRate(r)!}
-          <span class="help-rate"
-            >{m.learnings_help_rate({ helped: hr.helped, pulls: hr.pulls })}</span
-          >
-        {/if}
-        <span class="spacer"></span>
-        <div class="iactions">
-          {#if showIneffective(r)}
-            <button
-              class="optimize"
-              type="button"
-              onclick={() => onoptimize(r.id)}
-              aria-label={m.learnings_optimize_aria()}
-            >
-              {m.learnings_optimize()}
-            </button>
-          {/if}
-          {#if r.status === "active"}
-            <!-- Change 9: de-emphasised Dismiss with margin-left gap from Promote -->
-            <button class="dismiss dismiss-muted" onclick={() => ondismiss(r.id)}>
-              {m.learnings_dismiss()}
-            </button>
-            <button
-              class="promote"
-              onclick={() => onpromote(r.id)}
-              aria-label={m.learnings_promote_aria()}
-            >
-              {m.learnings_promote()}
-            </button>
-          {:else if r.status === "promoted" && r.promotedPrUrl}
-            <a class="prlink" href={r.promotedPrUrl} target="_blank" rel="noopener external">
-              {m.learnings_promoted_pr()}
-            </a>
-          {/if}
-        </div>
-      </div>
-      <!-- #842: glob scope — which files this rule applies to (empty = always). -->
-      <div class="iscope">
-        {#if editingScope === r.id}
-          <input
-            class="scope-input"
-            type="text"
-            bind:value={scopeDraft}
-            placeholder={m.learnings_scope_placeholder()}
-            aria-label={m.learnings_scope_input_aria()}
-          />
-          <button class="scope-save" type="button" onclick={() => saveScope(r.id)}>
-            {m.common_save()}
-          </button>
-          <button class="scope-cancel" type="button" onclick={() => (editingScope = null)}>
-            {m.common_cancel()}
-          </button>
-        {:else}
-          <span class="scope-label">{m.learnings_scope_label()}</span>
-          {#if r.scopeGlobs.length > 0}
-            {#each r.scopeGlobs as g (g)}<code class="scope-glob">{g}</code>{/each}
-          {:else}
-            <span class="scope-always">{m.learnings_scope_always()}</span>
-          {/if}
-          <button class="scope-edit" type="button" onclick={() => openScopeEditor(r)}>
-            {m.learnings_scope_edit()}
-          </button>
-        {/if}
-      </div>
-    </article>
-  {/snippet}
-
   {#if empty}
     <p class="empty">{m.learnings_empty()}</p>
   {:else}
@@ -532,70 +409,7 @@
 
         <!-- Change 7: hide proposals under either active lens -->
         {#each flaggedOnly || overBudgetOnly ? [] : group.proposed as l (l.id)}
-          <article class="rule">
-            <textarea
-              class="text"
-              rows="2"
-              data-1p-ignore
-              use:autosize={draft(l)}
-              value={draft(l)}
-              oninput={(e) => (drafts = { ...drafts, [l.id]: e.currentTarget.value })}
-              aria-label={m.learnings_rule_aria()}></textarea>
-            {#if l.rationale}
-              <p class="why"><span>{m.learnings_rationale_label()}:</span> {l.rationale}</p>
-            {/if}
-            <div class="evidence" title={m.learnings_evidence_help()}>
-              <span class="evi">{m.learnings_evidence({ count: l.evidenceCount })}</span>
-              {#each evidenceSources(l) as src (src.kind)}
-                <span class="src">{src.count}× {kindLabel(src.kind)}</span>
-              {/each}
-              <!-- render whenever the payload carries provenance (even an empty,
-                   fully-pruned list): the toggle is the focusable route to the
-                   help text for keyboard/touch users -->
-              {#if l.evidenceDetail}
-                <button
-                  class="sources-toggle"
-                  type="button"
-                  title={m.learnings_evidence_help()}
-                  aria-expanded={!!expanded[l.id]}
-                  aria-controls="sources-{l.id}"
-                  aria-label={m.learnings_sources_toggle_aria()}
-                  onclick={() => (expanded = { ...expanded, [l.id]: !expanded[l.id] })}
-                >
-                  {m.learnings_sources_toggle()}
-                  <span class="caret" class:open={expanded[l.id]} aria-hidden="true">▸</span>
-                </button>
-              {/if}
-            </div>
-            {#if expanded[l.id] && l.evidenceDetail}
-              <!-- disclosed region the toggle's aria-controls points at; carries a
-                   visible copy of the provenance explanation, reachable for
-                   keyboard/touch users who can't hover the title tooltip -->
-              <div class="sources-region" id="sources-{l.id}">
-                <p class="shelp">{m.learnings_evidence_help()}</p>
-                {#if l.evidenceDetail.length > 0}
-                  <ul class="sources">
-                    {#each l.evidenceDetail as ev (ev.id)}
-                      <li class="source">
-                        <span class="src">{kindLabel(ev.kind)}</span>
-                        <span class="desig">{ev.desig ?? m.learnings_source_unknown()}</span>
-                        <span class="excerpt">{ev.excerpt}</span>
-                      </li>
-                    {/each}
-                  </ul>
-                {/if}
-              </div>
-            {/if}
-            <div class="foot">
-              <span class="spacer"></span>
-              <button class="dismiss" onclick={() => ondismiss(l.id)}
-                >{m.learnings_dismiss()}</button
-              >
-              <button class="approve" onclick={() => onapprove(l.id, draft(l))}>
-                {m.learnings_approve()}
-              </button>
-            </div>
-          </article>
+          <ProposedRuleCard learning={l} {ctx} />
         {/each}
 
         <!-- Phase 4: intra-repo merge-group suggestions (hidden under the active lenses,
@@ -604,25 +418,7 @@
           <div class="merge-suggest">
             <span class="ms-title">{m.learnings_merge_heading()}</span>
             {#each intraFor(group.repoPath) as s (s.id)}
-              <article class="ms-card">
-                <ul class="ms-members">
-                  {#each s.members ?? [] as mem (mem.id)}
-                    <li class="ms-member">{mem.rule}</li>
-                  {/each}
-                </ul>
-                <p class="ms-result">
-                  <span class="ms-result-label">{m.learnings_merge_result_label()}</span>
-                  {s.mergedRule}
-                </p>
-                <div class="ms-foot">
-                  <button class="ms-dismiss" type="button" onclick={() => ondismissmerge(s.id)}>
-                    {m.learnings_dismiss()}
-                  </button>
-                  <button class="ms-apply" type="button" onclick={() => onmerge(s.id)}>
-                    {m.learnings_merge_apply()}
-                  </button>
-                </div>
-              </article>
+              <MergeSuggestCard suggestion={s} {ctx} />
             {/each}
           </div>
         {/if}
@@ -658,18 +454,26 @@
                 </button>
               {/if}
             </div>
-            <!-- Change 6: dropped-first rendering via snippet + splitDropped -->
+            <!-- Change 6: dropped-first rendering via component + splitDropped -->
             {#if lensActive}
               {#each visibleInjectableRules(inj, { flaggedOnly, overBudgetOnly }) as r (r.id)}
-                {@render irule(r, inj.enabled)}
+                <InjectableRuleCard rule={r} enabled={inj.enabled} {ctx} />
               {/each}
             {:else}
               {@const split = splitDropped(inj)}
               {#if split.dropped.length > 0}
                 <p class="not-injected-label">{m.learnings_not_injected_label()}</p>
-                {#each split.dropped as r (r.id)}{@render irule(r, inj.enabled)}{/each}
+                {#each split.dropped as r (r.id)}<InjectableRuleCard
+                    rule={r}
+                    enabled={inj.enabled}
+                    {ctx}
+                  />{/each}
               {/if}
-              {#each split.injected as r (r.id)}{@render irule(r, inj.enabled)}{/each}
+              {#each split.injected as r (r.id)}<InjectableRuleCard
+                  rule={r}
+                  enabled={inj.enabled}
+                  {ctx}
+                />{/each}
             {/if}
           </div>
         {/if}
@@ -682,27 +486,7 @@
               >
             </div>
             {#each retiredRules(group.injectable) as r (r.id)}
-              <article class="retired-rule">
-                <p class="retired-text">{r.rule}</p>
-                <p class="retired-reason">
-                  {m.learnings_retired_reason({
-                    helped: r.helpfulCount,
-                    pulls: r.injectedCount,
-                    flagged: r.ineffectiveCount,
-                  })}
-                </p>
-                <div class="retired-foot">
-                  <span class="spacer"></span>
-                  <button
-                    class="restore"
-                    type="button"
-                    aria-label={m.learnings_restore_aria()}
-                    onclick={() => onrestore(r.id)}
-                  >
-                    {m.learnings_restore()}
-                  </button>
-                </div>
-              </article>
+              <RetiredRuleCard rule={r} {ctx} />
             {/each}
           </div>
         {/if}
@@ -935,79 +719,6 @@
     padding: 3px 8px;
     cursor: pointer;
   }
-  .rule {
-    border: 1px solid var(--color-line);
-    padding: 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-  .text {
-    width: 100%;
-    /* height is driven by the autosize action so the full rule always shows */
-    resize: none;
-    overflow: hidden;
-    background: var(--color-inset);
-    color: var(--color-ink-bright);
-    border: 1px solid var(--color-line);
-    padding: 8px 10px;
-    font: inherit;
-    font-size: var(--fs-base);
-    line-height: 1.5;
-  }
-  .why {
-    font-size: var(--fs-base);
-    color: var(--color-muted);
-    line-height: 1.5;
-  }
-  .why span {
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: var(--fs-micro);
-  }
-  /* Evidence provenance — its own row so the source breakdown has room to wrap.
-     Hover the row for the help tooltip explaining what a signal is. */
-  .evidence {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 4px 6px;
-    cursor: help;
-  }
-  .foot {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .evi {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-  }
-  .src {
-    font-size: var(--fs-meta);
-    color: var(--color-ink-bright);
-    background: var(--color-inset);
-    border: 1px solid var(--color-line);
-    border-radius: 3px;
-    padding: 1px 6px;
-    white-space: nowrap;
-  }
-  .sources-toggle {
-    margin-left: auto;
-    display: inline-flex;
-    align-items: center;
-    gap: 3px;
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    font: inherit;
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-  }
-  .sources-toggle:hover {
-    color: var(--color-ink-bright);
-  }
   .caret {
     display: inline-block;
     transition: transform 0.12s ease;
@@ -1015,83 +726,6 @@
   .caret.open {
     transform: rotate(90deg);
   }
-  /* Evidence provenance: the actual signals this rule was distilled from. */
-  .sources-region {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-  .shelp {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-    line-height: 1.5;
-  }
-  .sources {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-  .source {
-    display: grid;
-    grid-template-columns: auto auto 1fr;
-    align-items: baseline;
-    gap: 6px;
-    font-size: var(--fs-base);
-    line-height: 1.4;
-  }
-  .desig {
-    color: var(--color-ink-bright);
-    font-weight: 600;
-    white-space: nowrap;
-    font-variant-numeric: tabular-nums;
-  }
-  .excerpt {
-    color: var(--color-muted);
-    min-width: 0;
-  }
-  .spacer {
-    flex: 1;
-  }
-  .dismiss,
-  .approve {
-    font-size: var(--fs-base);
-    padding: 5px 12px;
-    cursor: pointer;
-    border: 1px solid var(--color-line-bright);
-    background: none;
-    color: var(--color-muted);
-  }
-  .approve {
-    border-color: var(--color-green);
-    color: var(--color-green);
-  }
-  .promote {
-    font-size: var(--fs-base);
-    padding: 5px 12px;
-    cursor: pointer;
-    border: 1px solid var(--color-green);
-    background: none;
-    color: var(--color-green);
-  }
-  .prlink {
-    font-size: var(--fs-base);
-    color: var(--color-green);
-    text-decoration: none;
-  }
-  /* Per-rule "Optimize" — headline action for a flagged rule, styled primary-ish
-     like .promote but in the amber "needs attention" hue that flags the rule. */
-  .optimize {
-    font-size: var(--fs-base);
-    padding: 5px 12px;
-    cursor: pointer;
-    border: 1px solid var(--color-amber);
-    background: none;
-    color: var(--color-amber);
-  }
-
   /* ── injected house rules ────────────────────────────────────────────── */
   .injected {
     display: flex;
@@ -1139,128 +773,6 @@
     color: var(--color-amber);
     margin: 4px 0 2px;
   }
-  .irule {
-    border: 1px solid var(--color-line);
-    padding: 8px 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-  .itext {
-    font-size: var(--fs-base);
-    color: var(--color-ink-bright);
-    line-height: 1.5;
-  }
-  .ifoot {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 6px;
-  }
-  /* Action group stays together as one flex item so it wraps as a unit
-     (never fragmenting Optimize/Dismiss/Promote across lines) when the
-     badge row runs out of room in the narrow drawer. */
-  .iactions {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-  }
-  /* Change 9: de-emphasised Dismiss on active rules — muted + gap from Promote */
-  .dismiss-muted {
-    color: var(--color-muted);
-    border-color: var(--color-line);
-    margin-right: 4px;
-  }
-  .chip {
-    font-size: var(--fs-micro);
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    padding: 2px 6px;
-    border: 1px solid var(--color-line-bright);
-    color: var(--color-muted);
-  }
-  .chip.promoted {
-    border-color: var(--color-green);
-    color: var(--color-green);
-  }
-  .badge {
-    font-size: var(--fs-meta);
-    padding: 2px 6px;
-    border: 1px solid var(--color-line);
-  }
-  .badge.ok {
-    border-color: var(--color-green);
-    color: var(--color-green);
-  }
-  .badge.warn {
-    border-color: var(--color-amber);
-    color: var(--color-amber);
-    cursor: help;
-  }
-  .badge.bad {
-    border-color: var(--color-red, var(--color-amber));
-    color: var(--color-red, var(--color-amber));
-    cursor: help;
-  }
-  .badge.off {
-    color: var(--color-muted);
-  }
-  .badge.scoped {
-    border-color: var(--color-blue);
-    color: var(--color-blue);
-    cursor: help;
-  }
-  .iscope {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 6px;
-    margin-top: 6px;
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-  }
-  .scope-label {
-    color: var(--color-muted);
-  }
-  .scope-glob {
-    padding: 1px 5px;
-    border: 1px solid var(--color-line-bright);
-    color: var(--color-blue);
-    background: color-mix(in srgb, var(--color-blue) 10%, var(--color-head));
-  }
-  .scope-always {
-    color: var(--color-muted);
-    font-style: italic;
-  }
-  .scope-edit,
-  .scope-save,
-  .scope-cancel {
-    font-size: var(--fs-meta);
-    background: none;
-    border: 1px solid var(--color-line-bright);
-    color: var(--color-muted);
-    padding: 2px 7px;
-    cursor: pointer;
-  }
-  .scope-edit:hover,
-  .scope-save:hover,
-  .scope-cancel:hover {
-    color: var(--color-ink-bright);
-    border-color: var(--color-ink-bright);
-  }
-  .scope-input {
-    flex: 1 1 12rem;
-    min-width: 0;
-    font-size: var(--fs-meta);
-    padding: 2px 6px;
-    background: var(--color-inset);
-    border: 1px solid var(--color-line-bright);
-    color: var(--color-ink-bright);
-  }
-  .help-rate {
-    font-size: var(--fs-micro);
-    color: var(--color-muted);
-  }
   .hw-review {
     align-self: flex-start;
     font-size: var(--fs-meta);
@@ -1290,42 +802,6 @@
     letter-spacing: 0.1em;
     color: var(--color-muted);
   }
-  .retired-rule {
-    border: 1px solid var(--color-line);
-    padding: 8px 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    opacity: 0.7;
-  }
-  .retired-text {
-    font-size: var(--fs-base);
-    color: var(--status-done);
-    line-height: 1.5;
-  }
-  .retired-reason {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-    line-height: 1.45;
-  }
-  .retired-foot {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .restore {
-    font-size: var(--fs-base);
-    padding: 4px 10px;
-    cursor: pointer;
-    border: 1px solid var(--color-line-bright);
-    background: none;
-    color: var(--color-muted);
-  }
-  .restore:hover {
-    color: var(--color-ink-bright);
-    border-color: var(--color-ink-bright);
-  }
-
   /* Phase 4: cross-repo recurrence band (top-level, repo-agnostic) */
   .recur {
     display: flex;
@@ -1390,36 +866,6 @@
     text-transform: uppercase;
     letter-spacing: 0.1em;
     color: var(--color-muted);
-  }
-  .ms-members {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-  }
-  .ms-member {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-    line-height: 1.45;
-    padding-left: 12px;
-    position: relative;
-  }
-  .ms-member::before {
-    content: "•";
-    position: absolute;
-    left: 2px;
-    color: var(--color-line-bright);
-  }
-  .ms-result {
-    font-size: var(--fs-base);
-    color: var(--color-ink-bright);
-    line-height: 1.5;
-  }
-  .ms-result-label {
-    color: var(--color-muted);
-    font-size: var(--fs-meta);
   }
   /* Merge = actionable consolidation → green (matches .promote) */
   .ms-apply {

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -114,7 +114,6 @@
     onoptimize,
     onoptimizeall,
     onrestore,
-    onscope,
     onseenretired,
     onmerge,
     ondismissmerge,

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -27,6 +27,8 @@
   import ProposedRuleCard from "./learnings-drawer/ProposedRuleCard.svelte";
   import MergeSuggestCard from "./learnings-drawer/MergeSuggestCard.svelte";
   import RetiredRuleCard from "./learnings-drawer/RetiredRuleCard.svelte";
+  import TriageBand from "./learnings-drawer/TriageBand.svelte";
+  import RecurrenceBand from "./learnings-drawer/RecurrenceBand.svelte";
 
   // "What is this?" explainer at the top of the drawer. Default open so a first-time
   // user gets the plain-language explanation; collapsing is remembered (localStorage)
@@ -95,9 +97,6 @@
   const crossSuggestions = $derived(mergeSuggestions.filter((s) => s.kind === "cross"));
   const intraFor = (repoPath: string): MergeSuggestion[] =>
     mergeSuggestions.filter((s) => s.kind === "intra" && s.repoPath === repoPath);
-
-  // Cross-repo card pending the inline two-step confirm before a global CLAUDE.md write (#872).
-  let confirmingGlobalId = $state<string | null>(null);
 
   // Glob-scope editing (#842): which injectable rule has its scope editor open, and the
   // comma-separated draft text. Saving splits on commas/whitespace into a glob array.
@@ -189,6 +188,16 @@
       document.getElementById(id)?.scrollIntoView({ block: "start" });
     });
   });
+
+  // Triage chip handler: reset both lens filters so the target repo is guaranteed to
+  // be in the DOM, then rAF-scroll to it (lens reset stays here; TriageBand emits onjump).
+  function jumpToRepo(repoPath: string) {
+    flaggedOnly = false;
+    overBudgetOnly = false;
+    requestAnimationFrame(() => {
+      document.getElementById(repoAnchorId(repoPath))?.scrollIntoView({ block: "start" });
+    });
+  }
 </script>
 
 <div class="scrim" aria-hidden="true" onclick={() => onclose()}></div>
@@ -270,96 +279,11 @@
   </section>
 
   <!-- Change 3: Triage summary band — stable above group list, reflects ALL attention repos -->
-  {#if attention.length > 0}
-    <section class="triage" aria-label={m.learnings_triage_heading()}>
-      <span class="triage-label">{m.learnings_triage_heading()}</span>
-      <div class="triage-chips">
-        {#each attention as a (a.repoPath)}
-          <button
-            class="triage-chip"
-            type="button"
-            aria-label={m.learnings_triage_jump_aria({ repo: basename(a.repoPath) })}
-            onclick={() => {
-              // Clear both lens filters so the target repo is guaranteed to be in the DOM,
-              // then scroll on the next frame after Svelte has updated displayGroups.
-              flaggedOnly = false;
-              overBudgetOnly = false;
-              requestAnimationFrame(() => {
-                document
-                  .getElementById(repoAnchorId(a.repoPath))
-                  ?.scrollIntoView({ block: "start" });
-              });
-            }}
-          >
-            <span class="tc-repo">{basename(a.repoPath)}</span>
-            {#if a.droppedCount > 0}<span class="tc-over"
-                >{m.learnings_triage_over({ count: a.droppedCount })}</span
-              >{/if}
-            {#if a.flaggedCount > 0}<span class="tc-flagged"
-                >{m.learnings_triage_flagged({ count: a.flaggedCount })}</span
-              >{/if}
-          </button>
-        {/each}
-      </div>
-    </section>
-  {/if}
+  <TriageBand {attention} onjump={jumpToRepo} />
 
   <!-- Phase 4: cross-repo recurrence band — rules that recur across repos, suggested for the
        user-global CLAUDE.md. Promote (guarded, two-step) writes the rule there; or dismiss. -->
-  {#if crossSuggestions.length > 0}
-    <section class="recur" aria-label={m.learnings_recur_heading()}>
-      <span class="recur-title">{m.learnings_recur_heading()}</span>
-      <p class="recur-lead">{m.learnings_recur_lead()}</p>
-      {#each crossSuggestions as s (s.id)}
-        <article class="recur-card">
-          <p class="recur-rule">{s.mergedRule}</p>
-          <p class="recur-repos">
-            {m.learnings_recur_repos({
-              count: s.repoPaths?.length ?? 0,
-              repos: (s.repoPaths ?? []).map(basename).join(", "),
-            })}
-          </p>
-          {#if confirmingGlobalId === s.id}
-            <p class="recur-confirm">{m.learnings_recur_promote_confirm()}</p>
-            <div class="recur-foot">
-              <button class="ms-dismiss" type="button" onclick={() => (confirmingGlobalId = null)}>
-                {m.common_cancel()}
-              </button>
-              <button
-                class="ms-apply"
-                type="button"
-                onclick={() => {
-                  onpromoteglobal(s.id);
-                  confirmingGlobalId = null;
-                }}
-              >
-                {m.learnings_recur_promote_action()}
-              </button>
-            </div>
-          {:else}
-            <div class="recur-foot">
-              <button
-                class="ms-dismiss"
-                type="button"
-                onclick={() => ondismissmerge(s.id)}
-                aria-label={m.learnings_recur_dismiss_aria()}
-              >
-                {m.learnings_dismiss()}
-              </button>
-              <button
-                class="ms-apply"
-                type="button"
-                onclick={() => (confirmingGlobalId = s.id)}
-                aria-label={m.learnings_recur_promote_aria()}
-              >
-                {m.learnings_recur_promote()}
-              </button>
-            </div>
-          {/if}
-        </article>
-      {/each}
-    </section>
-  {/if}
+  <RecurrenceBand suggestions={crossSuggestions} {onpromoteglobal} {ondismissmerge} />
 
   {#if empty}
     <p class="empty">{m.learnings_empty()}</p>
@@ -617,49 +541,6 @@
     color: var(--color-ink-bright);
     font-weight: 600;
   }
-  /* Change 3: Triage summary band */
-  .triage {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 8px 10px;
-    border: 1px solid var(--color-line);
-    background: var(--color-head);
-  }
-  .triage-label {
-    font-size: var(--fs-micro);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-muted);
-  }
-  .triage-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-  }
-  .triage-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    background: none;
-    border: 1px solid var(--color-line-bright);
-    padding: 3px 8px;
-    cursor: pointer;
-    font: inherit;
-    font-size: var(--fs-meta);
-  }
-  .triage-chip:hover {
-    border-color: var(--color-ink-bright);
-  }
-  .tc-repo {
-    color: var(--color-ink-bright);
-    font-weight: 600;
-  }
-  .tc-over,
-  .tc-flagged {
-    color: var(--color-amber);
-    font-size: var(--fs-meta);
-  }
   .empty {
     color: var(--color-muted);
     font-size: var(--fs-base);
@@ -802,58 +683,6 @@
     letter-spacing: 0.1em;
     color: var(--color-muted);
   }
-  /* Phase 4: cross-repo recurrence band (top-level, repo-agnostic) */
-  .recur {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 8px 10px;
-    border: 1px solid var(--color-line);
-    background: var(--color-head);
-  }
-  .recur-title {
-    font-size: var(--fs-micro);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-muted);
-  }
-  .recur-lead {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-    line-height: 1.45;
-  }
-  .recur-card,
-  .ms-card {
-    border: 1px solid var(--color-line);
-    background: var(--color-inset);
-    padding: 8px 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-  .recur-rule {
-    font-size: var(--fs-base);
-    color: var(--color-ink-bright);
-    line-height: 1.5;
-  }
-  .recur-repos {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-    line-height: 1.45;
-  }
-  .recur-confirm {
-    font-size: var(--fs-meta);
-    color: var(--color-amber);
-    line-height: 1.45;
-  }
-  .recur-foot,
-  .ms-foot {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 8px;
-  }
-
   /* Phase 4: intra-repo merge-group suggestion cards */
   .merge-suggest {
     display: flex;
@@ -866,26 +695,5 @@
     text-transform: uppercase;
     letter-spacing: 0.1em;
     color: var(--color-muted);
-  }
-  /* Merge = actionable consolidation → green (matches .promote) */
-  .ms-apply {
-    font-size: var(--fs-base);
-    padding: 4px 12px;
-    cursor: pointer;
-    border: 1px solid var(--color-green);
-    background: none;
-    color: var(--color-green);
-  }
-  .ms-dismiss {
-    font-size: var(--fs-base);
-    padding: 4px 10px;
-    cursor: pointer;
-    border: 1px solid var(--color-line-bright);
-    background: none;
-    color: var(--color-muted);
-  }
-  .ms-dismiss:hover {
-    color: var(--color-ink-bright);
-    border-color: var(--color-ink-bright);
   }
 </style>

--- a/ui/src/lib/components/LearningsDrawer.svelte
+++ b/ui/src/lib/components/LearningsDrawer.svelte
@@ -4,31 +4,20 @@
   import { m } from "$lib/paraglide/messages";
   import type { InjectableRule, Learning, RepoInjectable, MergeSuggestion } from "$lib/types";
   import { learnings } from "$lib/learnings.svelte";
-  import { projectIcons } from "$lib/projectIcons.svelte";
   import {
-    basename,
     repoAnchorId,
     mergeRepoGroups,
-    injectedCount,
     flaggedCount,
     totalFlagged,
     sortGroupsForTriage,
     isOverBudget,
     droppedCount,
-    splitDropped,
     reposNeedingAttention,
-    visibleInjectableRules,
-    retiredRules,
-    retiredCount,
-    unseenRetiredCount,
   } from "./learnings-drawer";
   import type { LearningsCtx } from "./learnings-drawer/ctx";
-  import InjectableRuleCard from "./learnings-drawer/InjectableRuleCard.svelte";
-  import ProposedRuleCard from "./learnings-drawer/ProposedRuleCard.svelte";
-  import MergeSuggestCard from "./learnings-drawer/MergeSuggestCard.svelte";
-  import RetiredRuleCard from "./learnings-drawer/RetiredRuleCard.svelte";
   import TriageBand from "./learnings-drawer/TriageBand.svelte";
   import RecurrenceBand from "./learnings-drawer/RecurrenceBand.svelte";
+  import RepoGroup from "./learnings-drawer/RepoGroup.svelte";
 
   // "What is this?" explainer at the top of the drawer. Default open so a first-time
   // user gets the plain-language explanation; collapsing is remembered (localStorage)
@@ -289,132 +278,7 @@
     <p class="empty">{m.learnings_empty()}</p>
   {:else}
     {#each displayGroups as group (group.repoPath)}
-      <!-- Change 4: group container with left-accent border + faint surface -->
-      {@const repoIcon = projectIcons.iconFor(group.repoPath)}
-      <section class="group" id={repoAnchorId(group.repoPath)}>
-        <!-- Change 4: sticky repo header -->
-        <div class="ghead">
-          <!-- Repo identity glyph + name, mirroring the session-card label
-               (UnitRow): the configured project emoji when set, else the ▣
-               marker — makes it clear at a glance which repo a card concerns. -->
-          <span class="repo">
-            <span class="repo-glyph" class:emoji={!!repoIcon} aria-hidden="true"
-              >{repoIcon ?? "▣"}</span
-            >{basename(group.repoPath)}
-          </span>
-          <button
-            class="distill"
-            onclick={() => onmergenow(group.repoPath)}
-            aria-label={m.learnings_merge_now_aria({ repo: basename(group.repoPath) })}
-          >
-            {m.learnings_merge_now()}
-          </button>
-          <button
-            class="distill"
-            onclick={() => ondistill(group.repoPath)}
-            aria-label={m.learnings_distill_aria({ repo: basename(group.repoPath) })}
-          >
-            {m.learnings_distill()}
-          </button>
-        </div>
-
-        {#if unseenRetiredCount(group.injectable) > 0}
-          <div class="health-warn" role="status">
-            <strong class="hw-title"
-              >{m.learnings_auto_retired_banner({
-                count: unseenRetiredCount(group.injectable),
-              })}</strong
-            >
-            <button class="hw-review" type="button" onclick={() => onseenretired(group.repoPath)}>
-              {m.learnings_auto_retired_review()}
-            </button>
-          </div>
-        {/if}
-
-        <!-- Change 7: hide proposals under either active lens -->
-        {#each flaggedOnly || overBudgetOnly ? [] : group.proposed as l (l.id)}
-          <ProposedRuleCard learning={l} {ctx} />
-        {/each}
-
-        <!-- Phase 4: intra-repo merge-group suggestions (hidden under the active lenses,
-             same as proposals). One-click consolidation; survivor counters preserved. -->
-        {#if !(flaggedOnly || overBudgetOnly) && intraFor(group.repoPath).length > 0}
-          <div class="merge-suggest">
-            <span class="ms-title">{m.learnings_merge_heading()}</span>
-            {#each intraFor(group.repoPath) as s (s.id)}
-              <MergeSuggestCard suggestion={s} {ctx} />
-            {/each}
-          </div>
-        {/if}
-
-        {#if group.injectable && group.injectable.rules.length > 0}
-          {@const inj = group.injectable}
-          {@const lensActive = flaggedOnly || overBudgetOnly}
-          <div class="injected">
-            <div class="ihead">
-              <span class="ititle">{m.learnings_injected_section()}</span>
-              <!-- Change 5: conditional meter — dominant amber when over budget -->
-              {#if isOverBudget(inj)}
-                <span class="meter over"
-                  >{m.learnings_budget_over({ dropped: droppedCount(inj) })}</span
-                >
-              {:else}
-                <span class="meter">
-                  {m.learnings_budget_meter({
-                    injected: injectedCount(inj),
-                    total: inj.rules.length,
-                    used: inj.usedChars,
-                    budget: inj.budgetChars,
-                  })}
-                </span>
-              {/if}
-              {#if flaggedCount(group.injectable) > 0}
-                <button
-                  class="optimize-all"
-                  type="button"
-                  onclick={() => onoptimizeall(group.repoPath)}
-                >
-                  {m.learnings_optimize_all({ count: flaggedCount(group.injectable) })}
-                </button>
-              {/if}
-            </div>
-            <!-- Change 6: dropped-first rendering via component + splitDropped -->
-            {#if lensActive}
-              {#each visibleInjectableRules(inj, { flaggedOnly, overBudgetOnly }) as r (r.id)}
-                <InjectableRuleCard rule={r} enabled={inj.enabled} {ctx} />
-              {/each}
-            {:else}
-              {@const split = splitDropped(inj)}
-              {#if split.dropped.length > 0}
-                <p class="not-injected-label">{m.learnings_not_injected_label()}</p>
-                {#each split.dropped as r (r.id)}<InjectableRuleCard
-                    rule={r}
-                    enabled={inj.enabled}
-                    {ctx}
-                  />{/each}
-              {/if}
-              {#each split.injected as r (r.id)}<InjectableRuleCard
-                  rule={r}
-                  enabled={inj.enabled}
-                  {ctx}
-                />{/each}
-            {/if}
-          </div>
-        {/if}
-
-        {#if retiredCount(group.injectable) > 0}
-          <div class="retired-section">
-            <div class="retired-head">
-              <span class="retired-title"
-                >{m.learnings_retired_heading({ count: retiredCount(group.injectable) })}</span
-              >
-            </div>
-            {#each retiredRules(group.injectable) as r (r.id)}
-              <RetiredRuleCard rule={r} {ctx} />
-            {/each}
-          </div>
-        {/if}
-      </section>
+      <RepoGroup {group} {flaggedOnly} {overBudgetOnly} intra={intraFor(group.repoPath)} {ctx} />
     {/each}
   {/if}
 </div>
@@ -546,154 +410,11 @@
     font-size: var(--fs-base);
     line-height: 1.5;
   }
-  /* Change 4: group container with left-accent border + faint surface */
-  .group {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    border-left: 2px solid var(--color-line-bright);
-    background: var(--color-head);
-    /* no top padding: the header (.ghead, always the first child) owns the
-       group's top spacing via its own padding-top, so the resting header gap
-       matches the pinned one instead of stacking on a group pad */
-    padding: 0 8px 6px;
-  }
-  /* Change 4: sticky repo header — opaque background so scrolled content doesn't bleed */
-  .ghead {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border-bottom: 1px solid var(--color-line);
-    /* single source of the header's top space (group drops its top padding): an
-       opaque buffer so scrolling content disappears cleanly under the pinned
-       header's upper edge, identical at rest and when pinned at top:0 */
-    padding-top: 8px;
-    padding-bottom: 4px;
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    background: var(--color-head);
-  }
-  .repo {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    font-size: var(--fs-base);
-    color: var(--color-ink-bright);
-    font-weight: 600;
-  }
-  /* Repo marker before the name — muted ▣ matches the session-card glyph; a
-     configured project emoji renders at its own (slightly larger) size. */
-  .repo-glyph {
-    color: var(--color-muted);
-    font-size: var(--fs-micro);
-    flex-shrink: 0;
-  }
-  .repo-glyph.emoji {
-    font-size: var(--fs-base);
-  }
-  .distill {
-    font-size: var(--fs-meta);
-    background: none;
-    border: 1px solid var(--color-line-bright);
-    color: var(--color-muted);
-    padding: 3px 8px;
-    cursor: pointer;
-  }
   .caret {
     display: inline-block;
     transition: transform 0.12s ease;
   }
   .caret.open {
     transform: rotate(90deg);
-  }
-  /* ── injected house rules ────────────────────────────────────────────── */
-  .injected {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    margin-top: 2px;
-  }
-  .ihead {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 8px;
-  }
-  .ititle {
-    font-size: var(--fs-micro);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-muted);
-  }
-  .meter {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-    font-variant-numeric: tabular-nums;
-  }
-  /* Change 5: over-budget meter variant — dominant amber headline */
-  .meter.over {
-    color: var(--color-amber);
-    font-weight: 600;
-  }
-  /* Per-repo "Optimize all flagged" — token-outlined small action, mirrors .optimize (amber, not green). */
-  .optimize-all {
-    margin-left: auto;
-    font-size: var(--fs-meta);
-    background: none;
-    border: 1px solid var(--color-amber);
-    color: var(--color-amber);
-    padding: 3px 8px;
-    cursor: pointer;
-  }
-  /* Change 6: "Not injected — over budget" sub-label */
-  .not-injected-label {
-    font-size: var(--fs-micro);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-amber);
-    margin: 4px 0 2px;
-  }
-  .hw-review {
-    align-self: flex-start;
-    font-size: var(--fs-meta);
-    background: none;
-    border: 1px solid var(--color-amber);
-    color: var(--color-amber);
-    padding: 3px 8px;
-    cursor: pointer;
-    margin-top: 4px;
-  }
-  .retired-section {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    margin-top: 2px;
-    border-top: 1px solid var(--color-line);
-    padding-top: 6px;
-  }
-  .retired-head {
-    display: flex;
-    align-items: baseline;
-    gap: 8px;
-  }
-  .retired-title {
-    font-size: var(--fs-micro);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-muted);
-  }
-  /* Phase 4: intra-repo merge-group suggestion cards */
-  .merge-suggest {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    margin-top: 2px;
-  }
-  .ms-title {
-    font-size: var(--fs-micro);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-muted);
   }
 </style>

--- a/ui/src/lib/components/learnings-drawer/InjectableRuleCard.svelte
+++ b/ui/src/lib/components/learnings-drawer/InjectableRuleCard.svelte
@@ -1,0 +1,268 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { InjectableRule } from "$lib/types";
+  import { injectionBadge, showIneffective, helpRate } from "../learnings-drawer";
+  import type { LearningsCtx } from "./ctx";
+
+  let {
+    rule,
+    enabled,
+    ctx,
+  }: {
+    rule: InjectableRule;
+    enabled: boolean;
+    ctx: LearningsCtx;
+  } = $props();
+
+  const badge = $derived(injectionBadge(rule, enabled));
+  const isEditing = $derived(ctx.editingScope === rule.id);
+</script>
+
+<article class="irule">
+  <p class="itext">{rule.rule}</p>
+  <div class="ifoot">
+    <span class="chip" class:promoted={rule.status === "promoted"}>
+      {rule.status === "promoted" ? m.learnings_status_promoted() : m.learnings_status_active()}
+    </span>
+    {#if badge === "injected"}
+      <span class="badge ok">✓ {m.learnings_injected_badge()}</span>
+    {:else if badge === "scoped"}
+      <span class="badge scoped" title={m.learnings_scoped_title()}>
+        ◎ {m.learnings_scoped_badge()}
+      </span>
+    {:else if badge === "over-budget"}
+      <span class="badge warn" title={m.learnings_overbudget_title()}>
+        ⊘ {m.learnings_overbudget_badge()}
+      </span>
+    {:else}
+      <span class="badge off">⊘ {m.learnings_injection_disabled_badge()}</span>
+    {/if}
+    {#if showIneffective(rule)}
+      <span class="badge bad" title={m.learnings_ineffective_title()}>
+        ⚠ {m.learnings_ineffective_badge({ count: rule.ineffectiveCount })}
+      </span>
+    {/if}
+    {#if helpRate(rule) !== null}
+      {@const hr = helpRate(rule)!}
+      <span class="help-rate">{m.learnings_help_rate({ helped: hr.helped, pulls: hr.pulls })}</span>
+    {/if}
+    <span class="spacer"></span>
+    <div class="iactions">
+      {#if showIneffective(rule)}
+        <button
+          class="optimize"
+          type="button"
+          onclick={() => ctx.onoptimize(rule.id)}
+          aria-label={m.learnings_optimize_aria()}
+        >
+          {m.learnings_optimize()}
+        </button>
+      {/if}
+      {#if rule.status === "active"}
+        <!-- Change 9: de-emphasised Dismiss with margin-left gap from Promote -->
+        <button class="dismiss dismiss-muted" onclick={() => ctx.ondismiss(rule.id)}>
+          {m.learnings_dismiss()}
+        </button>
+        <button
+          class="promote"
+          onclick={() => ctx.onpromote(rule.id)}
+          aria-label={m.learnings_promote_aria()}
+        >
+          {m.learnings_promote()}
+        </button>
+      {:else if rule.status === "promoted" && rule.promotedPrUrl}
+        <a class="prlink" href={rule.promotedPrUrl} target="_blank" rel="noopener external">
+          {m.learnings_promoted_pr()}
+        </a>
+      {/if}
+    </div>
+  </div>
+  <!-- #842: glob scope — which files this rule applies to (empty = always). -->
+  <div class="iscope">
+    {#if isEditing}
+      <input
+        class="scope-input"
+        type="text"
+        value={ctx.scopeDraft}
+        oninput={(e) => ctx.onScopeInput(e.currentTarget.value)}
+        placeholder={m.learnings_scope_placeholder()}
+        aria-label={m.learnings_scope_input_aria()}
+      />
+      <button class="scope-save" type="button" onclick={() => ctx.onScopeSave(rule.id)}>
+        {m.common_save()}
+      </button>
+      <button class="scope-cancel" type="button" onclick={() => ctx.onScopeCancel()}>
+        {m.common_cancel()}
+      </button>
+    {:else}
+      <span class="scope-label">{m.learnings_scope_label()}</span>
+      {#if rule.scopeGlobs.length > 0}
+        {#each rule.scopeGlobs as g (g)}<code class="scope-glob">{g}</code>{/each}
+      {:else}
+        <span class="scope-always">{m.learnings_scope_always()}</span>
+      {/if}
+      <button class="scope-edit" type="button" onclick={() => ctx.onScopeOpen(rule)}>
+        {m.learnings_scope_edit()}
+      </button>
+    {/if}
+  </div>
+</article>
+
+<style>
+  .irule {
+    border: 1px solid var(--color-line);
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .itext {
+    font-size: var(--fs-base);
+    color: var(--color-ink-bright);
+    line-height: 1.5;
+  }
+  .ifoot {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  /* Action group stays together as one flex item so it wraps as a unit
+     (never fragmenting Optimize/Dismiss/Promote across lines) when the
+     badge row runs out of room in the narrow drawer. */
+  .iactions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .chip {
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 2px 6px;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+  }
+  .chip.promoted {
+    border-color: var(--color-green);
+    color: var(--color-green);
+  }
+  .badge {
+    font-size: var(--fs-meta);
+    padding: 2px 6px;
+    border: 1px solid var(--color-line);
+  }
+  .badge.ok {
+    border-color: var(--color-green);
+    color: var(--color-green);
+  }
+  .badge.warn {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+    cursor: help;
+  }
+  .badge.bad {
+    border-color: var(--color-red, var(--color-amber));
+    color: var(--color-red, var(--color-amber));
+    cursor: help;
+  }
+  .badge.off {
+    color: var(--color-muted);
+  }
+  .badge.scoped {
+    border-color: var(--color-blue);
+    color: var(--color-blue);
+    cursor: help;
+  }
+  .help-rate {
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+  }
+  .spacer {
+    flex: 1;
+  }
+  .dismiss {
+    font-size: var(--fs-base);
+    padding: 5px 12px;
+    cursor: pointer;
+    border: 1px solid var(--color-line-bright);
+    background: none;
+    color: var(--color-muted);
+  }
+  /* Change 9: de-emphasised Dismiss on active rules — muted + gap from Promote */
+  .dismiss-muted {
+    color: var(--color-muted);
+    border-color: var(--color-line);
+    margin-right: 4px;
+  }
+  .promote {
+    font-size: var(--fs-base);
+    padding: 5px 12px;
+    cursor: pointer;
+    border: 1px solid var(--color-green);
+    background: none;
+    color: var(--color-green);
+  }
+  .prlink {
+    font-size: var(--fs-base);
+    color: var(--color-green);
+    text-decoration: none;
+  }
+  /* Per-rule "Optimize" — headline action for a flagged rule, styled primary-ish
+     like .promote but in the amber "needs attention" hue that flags the rule. */
+  .optimize {
+    font-size: var(--fs-base);
+    padding: 5px 12px;
+    cursor: pointer;
+    border: 1px solid var(--color-amber);
+    background: none;
+    color: var(--color-amber);
+  }
+  .iscope {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    margin-top: 6px;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+  .scope-label {
+    color: var(--color-muted);
+  }
+  .scope-glob {
+    padding: 1px 5px;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-blue);
+    background: color-mix(in srgb, var(--color-blue) 10%, var(--color-head));
+  }
+  .scope-always {
+    color: var(--color-muted);
+    font-style: italic;
+  }
+  .scope-edit,
+  .scope-save,
+  .scope-cancel {
+    font-size: var(--fs-meta);
+    background: none;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    padding: 2px 7px;
+    cursor: pointer;
+  }
+  .scope-edit:hover,
+  .scope-save:hover,
+  .scope-cancel:hover {
+    color: var(--color-ink-bright);
+    border-color: var(--color-ink-bright);
+  }
+  .scope-input {
+    flex: 1 1 12rem;
+    min-width: 0;
+    font-size: var(--fs-meta);
+    padding: 2px 6px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-ink-bright);
+  }
+</style>

--- a/ui/src/lib/components/learnings-drawer/MergeSuggestCard.svelte
+++ b/ui/src/lib/components/learnings-drawer/MergeSuggestCard.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { MergeSuggestion } from "$lib/types";
+  import type { LearningsCtx } from "./ctx";
+
+  let {
+    suggestion,
+    ctx,
+  }: {
+    suggestion: MergeSuggestion;
+    ctx: LearningsCtx;
+  } = $props();
+</script>
+
+<article class="ms-card">
+  <ul class="ms-members">
+    {#each suggestion.members ?? [] as mem (mem.id)}
+      <li class="ms-member">{mem.rule}</li>
+    {/each}
+  </ul>
+  <p class="ms-result">
+    <span class="ms-result-label">{m.learnings_merge_result_label()}</span>
+    {suggestion.mergedRule}
+  </p>
+  <div class="ms-foot">
+    <button class="ms-dismiss" type="button" onclick={() => ctx.ondismissmerge(suggestion.id)}>
+      {m.learnings_dismiss()}
+    </button>
+    <button class="ms-apply" type="button" onclick={() => ctx.onmerge(suggestion.id)}>
+      {m.learnings_merge_apply()}
+    </button>
+  </div>
+</article>
+
+<style>
+  .ms-card {
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ms-members {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .ms-member {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    line-height: 1.45;
+    padding-left: 12px;
+    position: relative;
+  }
+  .ms-member::before {
+    content: "•";
+    position: absolute;
+    left: 2px;
+    color: var(--color-line-bright);
+  }
+  .ms-result {
+    font-size: var(--fs-base);
+    color: var(--color-ink-bright);
+    line-height: 1.5;
+  }
+  .ms-result-label {
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+  }
+  .ms-foot {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+  /* Merge = actionable consolidation → green (matches .promote) */
+  .ms-apply {
+    font-size: var(--fs-base);
+    padding: 4px 12px;
+    cursor: pointer;
+    border: 1px solid var(--color-green);
+    background: none;
+    color: var(--color-green);
+  }
+  .ms-dismiss {
+    font-size: var(--fs-base);
+    padding: 4px 10px;
+    cursor: pointer;
+    border: 1px solid var(--color-line-bright);
+    background: none;
+    color: var(--color-muted);
+  }
+  .ms-dismiss:hover {
+    color: var(--color-ink-bright);
+    border-color: var(--color-ink-bright);
+  }
+</style>

--- a/ui/src/lib/components/learnings-drawer/ProposedRuleCard.svelte
+++ b/ui/src/lib/components/learnings-drawer/ProposedRuleCard.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { Action } from "svelte/action";
-  import { untrack } from "svelte";
   import { m } from "$lib/paraglide/messages";
   import type { Learning, SignalKind } from "$lib/types";
   import { evidenceSources } from "../learnings-drawer";
@@ -54,9 +53,11 @@
   };
 
   // Per-card local state (independent, no shared invariant).
-  // Snapshot learning.rule once at mount so the draft diverges from any prop refresh.
-  // untrack signals intentional one-time capture of the reactive prop value.
-  let draft = $state(untrack(() => learning.rule));
+  // "Live until edited, then frozen": an untouched card tracks the live learning.rule prop
+  // (so a poll refresh replacing the rule text updates the textarea and re-fits autosize),
+  // while a user-edited draft stays frozen until the card is approved or dismissed.
+  let edited = $state<string | null>(null);
+  const draft = $derived(edited ?? learning.rule);
   let expanded = $state(false);
 </script>
 
@@ -67,7 +68,7 @@
     data-1p-ignore
     use:autosize={draft}
     value={draft}
-    oninput={(e) => (draft = e.currentTarget.value)}
+    oninput={(e) => (edited = e.currentTarget.value)}
     aria-label={m.learnings_rule_aria()}></textarea>
   {#if learning.rationale}
     <p class="why"><span>{m.learnings_rationale_label()}:</span> {learning.rationale}</p>

--- a/ui/src/lib/components/learnings-drawer/ProposedRuleCard.svelte
+++ b/ui/src/lib/components/learnings-drawer/ProposedRuleCard.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+  import type { Action } from "svelte/action";
+  import { untrack } from "svelte";
+  import { m } from "$lib/paraglide/messages";
+  import type { Learning, SignalKind } from "$lib/types";
+  import { evidenceSources } from "../learnings-drawer";
+  import type { LearningsCtx } from "./ctx";
+
+  let {
+    learning,
+    ctx,
+  }: {
+    learning: Learning;
+    ctx: LearningsCtx;
+  } = $props();
+
+  // Human label for an evidence source kind. Mirrors the server SignalKind set;
+  // keeps the i18n call in the component (the helper stays locale-agnostic).
+  const kindLabel = (k: SignalKind): string =>
+    k === "reply"
+      ? m.learnings_kind_reply()
+      : k === "critic"
+        ? m.learnings_kind_critic()
+        : k === "block"
+          ? m.learnings_kind_block()
+          : m.learnings_kind_stall();
+
+  // Grow a rule textarea to fit its content so the full rule is always readable —
+  // no inner scroll, no clipping. Re-measures on every input and, via `update`,
+  // whenever the bound value changes programmatically (e.g. a poll refresh
+  // replacing the rule text while no local draft exists).
+  const autosize: Action<HTMLTextAreaElement, string> = (el) => {
+    let raf = 0;
+    const fit = () => {
+      el.style.height = "auto";
+      el.style.height = `${el.scrollHeight}px`;
+    };
+    // scrollHeight is unreliable mid fly-in / before the new value is flushed
+    // to the DOM; settle one frame later.
+    const fitNextFrame = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(fit);
+    };
+    fit();
+    fitNextFrame();
+    el.addEventListener("input", fit);
+    return {
+      update: fitNextFrame,
+      destroy() {
+        cancelAnimationFrame(raf);
+        el.removeEventListener("input", fit);
+      },
+    };
+  };
+
+  // Per-card local state (independent, no shared invariant).
+  // Snapshot learning.rule once at mount so the draft diverges from any prop refresh.
+  // untrack signals intentional one-time capture of the reactive prop value.
+  let draft = $state(untrack(() => learning.rule));
+  let expanded = $state(false);
+</script>
+
+<article class="rule">
+  <textarea
+    class="text"
+    rows="2"
+    data-1p-ignore
+    use:autosize={draft}
+    value={draft}
+    oninput={(e) => (draft = e.currentTarget.value)}
+    aria-label={m.learnings_rule_aria()}></textarea>
+  {#if learning.rationale}
+    <p class="why"><span>{m.learnings_rationale_label()}:</span> {learning.rationale}</p>
+  {/if}
+  <div class="evidence" title={m.learnings_evidence_help()}>
+    <span class="evi">{m.learnings_evidence({ count: learning.evidenceCount })}</span>
+    {#each evidenceSources(learning) as src (src.kind)}
+      <span class="src">{src.count}× {kindLabel(src.kind)}</span>
+    {/each}
+    <!-- render whenever the payload carries provenance (even an empty,
+         fully-pruned list): the toggle is the focusable route to the
+         help text for keyboard/touch users -->
+    {#if learning.evidenceDetail}
+      <button
+        class="sources-toggle"
+        type="button"
+        title={m.learnings_evidence_help()}
+        aria-expanded={expanded}
+        aria-controls="sources-{learning.id}"
+        aria-label={m.learnings_sources_toggle_aria()}
+        onclick={() => (expanded = !expanded)}
+      >
+        {m.learnings_sources_toggle()}
+        <span class="caret" class:open={expanded} aria-hidden="true">▸</span>
+      </button>
+    {/if}
+  </div>
+  {#if expanded && learning.evidenceDetail}
+    <!-- disclosed region the toggle's aria-controls points at; carries a
+         visible copy of the provenance explanation, reachable for
+         keyboard/touch users who can't hover the title tooltip -->
+    <div class="sources-region" id="sources-{learning.id}">
+      <p class="shelp">{m.learnings_evidence_help()}</p>
+      {#if learning.evidenceDetail.length > 0}
+        <ul class="sources">
+          {#each learning.evidenceDetail as ev (ev.id)}
+            <li class="source">
+              <span class="src">{kindLabel(ev.kind)}</span>
+              <span class="desig">{ev.desig ?? m.learnings_source_unknown()}</span>
+              <span class="excerpt">{ev.excerpt}</span>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  {/if}
+  <div class="foot">
+    <span class="spacer"></span>
+    <button class="dismiss" onclick={() => ctx.ondismiss(learning.id)}
+      >{m.learnings_dismiss()}</button
+    >
+    <button class="approve" onclick={() => ctx.onapprove(learning.id, draft)}>
+      {m.learnings_approve()}
+    </button>
+  </div>
+</article>
+
+<style>
+  .rule {
+    border: 1px solid var(--color-line);
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .text {
+    width: 100%;
+    /* height is driven by the autosize action so the full rule always shows */
+    resize: none;
+    overflow: hidden;
+    background: var(--color-inset);
+    color: var(--color-ink-bright);
+    border: 1px solid var(--color-line);
+    padding: 8px 10px;
+    font: inherit;
+    font-size: var(--fs-base);
+    line-height: 1.5;
+  }
+  .why {
+    font-size: var(--fs-base);
+    color: var(--color-muted);
+    line-height: 1.5;
+  }
+  .why span {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: var(--fs-micro);
+  }
+  /* Evidence provenance — its own row so the source breakdown has room to wrap.
+     Hover the row for the help tooltip explaining what a signal is. */
+  .evidence {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px 6px;
+    cursor: help;
+  }
+  .foot {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .evi {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+  .src {
+    font-size: var(--fs-meta);
+    color: var(--color-ink-bright);
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 3px;
+    padding: 1px 6px;
+    white-space: nowrap;
+  }
+  .sources-toggle {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+  .sources-toggle:hover {
+    color: var(--color-ink-bright);
+  }
+  .caret {
+    display: inline-block;
+    transition: transform 0.12s ease;
+  }
+  .caret.open {
+    transform: rotate(90deg);
+  }
+  /* Evidence provenance: the actual signals this rule was distilled from. */
+  .sources-region {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .shelp {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    line-height: 1.5;
+  }
+  .sources {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .source {
+    display: grid;
+    grid-template-columns: auto auto 1fr;
+    align-items: baseline;
+    gap: 6px;
+    font-size: var(--fs-base);
+    line-height: 1.4;
+  }
+  .desig {
+    color: var(--color-ink-bright);
+    font-weight: 600;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+  .excerpt {
+    color: var(--color-muted);
+    min-width: 0;
+  }
+  .spacer {
+    flex: 1;
+  }
+  .dismiss {
+    font-size: var(--fs-base);
+    padding: 5px 12px;
+    cursor: pointer;
+    border: 1px solid var(--color-line-bright);
+    background: none;
+    color: var(--color-muted);
+  }
+  .approve {
+    font-size: var(--fs-base);
+    padding: 5px 12px;
+    cursor: pointer;
+    border: 1px solid var(--color-green);
+    background: none;
+    color: var(--color-green);
+  }
+</style>

--- a/ui/src/lib/components/learnings-drawer/RecurrenceBand.svelte
+++ b/ui/src/lib/components/learnings-drawer/RecurrenceBand.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { MergeSuggestion } from "$lib/types";
+  import { basename } from "../learnings-drawer";
+
+  let {
+    suggestions,
+    onpromoteglobal,
+    ondismissmerge,
+  }: {
+    suggestions: MergeSuggestion[];
+    onpromoteglobal: (id: string) => void;
+    ondismissmerge: (id: string) => void;
+  } = $props();
+
+  // Cross-repo card pending the inline two-step confirm before a global CLAUDE.md write (#872).
+  // Owned here (not the parent) because this component renders ALL cross cards, so
+  // single-open is fully preserved within this component.
+  let confirmingGlobalId = $state<string | null>(null);
+</script>
+
+{#if suggestions.length > 0}
+  <section class="recur" aria-label={m.learnings_recur_heading()}>
+    <span class="recur-title">{m.learnings_recur_heading()}</span>
+    <p class="recur-lead">{m.learnings_recur_lead()}</p>
+    {#each suggestions as s (s.id)}
+      <article class="recur-card">
+        <p class="recur-rule">{s.mergedRule}</p>
+        <p class="recur-repos">
+          {m.learnings_recur_repos({
+            count: s.repoPaths?.length ?? 0,
+            repos: (s.repoPaths ?? []).map(basename).join(", "),
+          })}
+        </p>
+        {#if confirmingGlobalId === s.id}
+          <p class="recur-confirm">{m.learnings_recur_promote_confirm()}</p>
+          <div class="recur-foot">
+            <button class="ms-dismiss" type="button" onclick={() => (confirmingGlobalId = null)}>
+              {m.common_cancel()}
+            </button>
+            <button
+              class="ms-apply"
+              type="button"
+              onclick={() => {
+                onpromoteglobal(s.id);
+                confirmingGlobalId = null;
+              }}
+            >
+              {m.learnings_recur_promote_action()}
+            </button>
+          </div>
+        {:else}
+          <div class="recur-foot">
+            <button
+              class="ms-dismiss"
+              type="button"
+              onclick={() => ondismissmerge(s.id)}
+              aria-label={m.learnings_recur_dismiss_aria()}
+            >
+              {m.learnings_dismiss()}
+            </button>
+            <button
+              class="ms-apply"
+              type="button"
+              onclick={() => (confirmingGlobalId = s.id)}
+              aria-label={m.learnings_recur_promote_aria()}
+            >
+              {m.learnings_recur_promote()}
+            </button>
+          </div>
+        {/if}
+      </article>
+    {/each}
+  </section>
+{/if}
+
+<style>
+  /* Phase 4: cross-repo recurrence band (top-level, repo-agnostic) */
+  .recur {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 10px;
+    border: 1px solid var(--color-line);
+    background: var(--color-head);
+  }
+  .recur-title {
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-muted);
+  }
+  .recur-lead {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    line-height: 1.45;
+  }
+  .recur-card {
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .recur-rule {
+    font-size: var(--fs-base);
+    color: var(--color-ink-bright);
+    line-height: 1.5;
+  }
+  .recur-repos {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    line-height: 1.45;
+  }
+  .recur-confirm {
+    font-size: var(--fs-meta);
+    color: var(--color-amber);
+    line-height: 1.45;
+  }
+  .recur-foot {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+  /* Merge = actionable consolidation → green (matches .promote) */
+  .ms-apply {
+    font-size: var(--fs-base);
+    padding: 4px 12px;
+    cursor: pointer;
+    border: 1px solid var(--color-green);
+    background: none;
+    color: var(--color-green);
+  }
+  .ms-dismiss {
+    font-size: var(--fs-base);
+    padding: 4px 10px;
+    cursor: pointer;
+    border: 1px solid var(--color-line-bright);
+    background: none;
+    color: var(--color-muted);
+  }
+  .ms-dismiss:hover {
+    color: var(--color-ink-bright);
+    border-color: var(--color-ink-bright);
+  }
+</style>

--- a/ui/src/lib/components/learnings-drawer/RepoGroup.svelte
+++ b/ui/src/lib/components/learnings-drawer/RepoGroup.svelte
@@ -1,0 +1,323 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { MergeSuggestion } from "$lib/types";
+  import { projectIcons } from "$lib/projectIcons.svelte";
+  import {
+    basename,
+    repoAnchorId,
+    unseenRetiredCount,
+    isOverBudget,
+    droppedCount,
+    injectedCount,
+    flaggedCount,
+    visibleInjectableRules,
+    splitDropped,
+    retiredRules,
+    retiredCount,
+  } from "../learnings-drawer";
+  import type { RepoGroup as RepoGroupData } from "../learnings-drawer";
+  import type { LearningsCtx } from "./ctx";
+  import InjectableRuleCard from "./InjectableRuleCard.svelte";
+  import ProposedRuleCard from "./ProposedRuleCard.svelte";
+  import MergeSuggestCard from "./MergeSuggestCard.svelte";
+  import RetiredRuleCard from "./RetiredRuleCard.svelte";
+
+  let {
+    group,
+    flaggedOnly,
+    overBudgetOnly,
+    intra,
+    ctx,
+  }: {
+    group: RepoGroupData;
+    flaggedOnly: boolean;
+    overBudgetOnly: boolean;
+    intra: MergeSuggestion[];
+    ctx: LearningsCtx;
+  } = $props();
+
+  const repoIcon = $derived(projectIcons.iconFor(group.repoPath));
+</script>
+
+<!-- Change 4: group container with left-accent border + faint surface -->
+<section class="group" id={repoAnchorId(group.repoPath)}>
+  <!-- Change 4: sticky repo header -->
+  <div class="ghead">
+    <!-- Repo identity glyph + name, mirroring the session-card label
+         (UnitRow): the configured project emoji when set, else the ▣
+         marker — makes it clear at a glance which repo a card concerns. -->
+    <span class="repo">
+      <span class="repo-glyph" class:emoji={!!repoIcon} aria-hidden="true">{repoIcon ?? "▣"}</span
+      >{basename(group.repoPath)}
+    </span>
+    <button
+      class="distill"
+      onclick={() => ctx.onmergenow(group.repoPath)}
+      aria-label={m.learnings_merge_now_aria({ repo: basename(group.repoPath) })}
+    >
+      {m.learnings_merge_now()}
+    </button>
+    <button
+      class="distill"
+      onclick={() => ctx.ondistill(group.repoPath)}
+      aria-label={m.learnings_distill_aria({ repo: basename(group.repoPath) })}
+    >
+      {m.learnings_distill()}
+    </button>
+  </div>
+
+  {#if unseenRetiredCount(group.injectable) > 0}
+    <div class="health-warn" role="status">
+      <strong class="hw-title"
+        >{m.learnings_auto_retired_banner({
+          count: unseenRetiredCount(group.injectable),
+        })}</strong
+      >
+      <button class="hw-review" type="button" onclick={() => ctx.onseenretired(group.repoPath)}>
+        {m.learnings_auto_retired_review()}
+      </button>
+    </div>
+  {/if}
+
+  <!-- Change 7: hide proposals under either active lens -->
+  {#each flaggedOnly || overBudgetOnly ? [] : group.proposed as l (l.id)}
+    <ProposedRuleCard learning={l} {ctx} />
+  {/each}
+
+  <!-- Phase 4: intra-repo merge-group suggestions (hidden under the active lenses,
+       same as proposals). One-click consolidation; survivor counters preserved. -->
+  {#if !(flaggedOnly || overBudgetOnly) && intra.length > 0}
+    <div class="merge-suggest">
+      <span class="ms-title">{m.learnings_merge_heading()}</span>
+      {#each intra as s (s.id)}
+        <MergeSuggestCard suggestion={s} {ctx} />
+      {/each}
+    </div>
+  {/if}
+
+  {#if group.injectable && group.injectable.rules.length > 0}
+    {@const inj = group.injectable}
+    {@const lensActive = flaggedOnly || overBudgetOnly}
+    <div class="injected">
+      <div class="ihead">
+        <span class="ititle">{m.learnings_injected_section()}</span>
+        <!-- Change 5: conditional meter — dominant amber when over budget -->
+        {#if isOverBudget(inj)}
+          <span class="meter over">{m.learnings_budget_over({ dropped: droppedCount(inj) })}</span>
+        {:else}
+          <span class="meter">
+            {m.learnings_budget_meter({
+              injected: injectedCount(inj),
+              total: inj.rules.length,
+              used: inj.usedChars,
+              budget: inj.budgetChars,
+            })}
+          </span>
+        {/if}
+        {#if flaggedCount(group.injectable) > 0}
+          <button
+            class="optimize-all"
+            type="button"
+            onclick={() => ctx.onoptimizeall(group.repoPath)}
+          >
+            {m.learnings_optimize_all({ count: flaggedCount(group.injectable) })}
+          </button>
+        {/if}
+      </div>
+      <!-- Change 6: dropped-first rendering via component + splitDropped -->
+      {#if lensActive}
+        {#each visibleInjectableRules(inj, { flaggedOnly, overBudgetOnly }) as r (r.id)}
+          <InjectableRuleCard rule={r} enabled={inj.enabled} {ctx} />
+        {/each}
+      {:else}
+        {@const split = splitDropped(inj)}
+        {#if split.dropped.length > 0}
+          <p class="not-injected-label">{m.learnings_not_injected_label()}</p>
+          {#each split.dropped as r (r.id)}<InjectableRuleCard
+              rule={r}
+              enabled={inj.enabled}
+              {ctx}
+            />{/each}
+        {/if}
+        {#each split.injected as r (r.id)}<InjectableRuleCard
+            rule={r}
+            enabled={inj.enabled}
+            {ctx}
+          />{/each}
+      {/if}
+    </div>
+  {/if}
+
+  {#if retiredCount(group.injectable) > 0}
+    <div class="retired-section">
+      <div class="retired-head">
+        <span class="retired-title"
+          >{m.learnings_retired_heading({ count: retiredCount(group.injectable) })}</span
+        >
+      </div>
+      {#each retiredRules(group.injectable) as r (r.id)}
+        <RetiredRuleCard rule={r} {ctx} />
+      {/each}
+    </div>
+  {/if}
+</section>
+
+<style>
+  /* Change 4: group container with left-accent border + faint surface */
+  .group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    border-left: 2px solid var(--color-line-bright);
+    background: var(--color-head);
+    /* no top padding: the header (.ghead, always the first child) owns the
+       group's top spacing via its own padding-top, so the resting header gap
+       matches the pinned one instead of stacking on a group pad */
+    padding: 0 8px 6px;
+  }
+  /* Change 4: sticky repo header — opaque background so scrolled content doesn't bleed */
+  .ghead {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--color-line);
+    /* single source of the header's top space (group drops its top padding): an
+       opaque buffer so scrolling content disappears cleanly under the pinned
+       header's upper edge, identical at rest and when pinned at top:0 */
+    padding-top: 8px;
+    padding-bottom: 4px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--color-head);
+  }
+  .repo {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: var(--fs-base);
+    color: var(--color-ink-bright);
+    font-weight: 600;
+  }
+  /* Repo marker before the name — muted ▣ matches the session-card glyph; a
+     configured project emoji renders at its own (slightly larger) size. */
+  .repo-glyph {
+    color: var(--color-muted);
+    font-size: var(--fs-micro);
+    flex-shrink: 0;
+  }
+  .repo-glyph.emoji {
+    font-size: var(--fs-base);
+  }
+  .distill {
+    font-size: var(--fs-meta);
+    background: none;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    padding: 3px 8px;
+    cursor: pointer;
+  }
+  /* distiller-stalled persistent warning banner (auto-retired variant) */
+  .health-warn {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 10px;
+    border: 1px solid var(--color-amber);
+    background: color-mix(in srgb, var(--color-amber) 12%, var(--color-head));
+    font-size: var(--fs-base);
+  }
+  .hw-title {
+    color: var(--color-amber);
+    font-weight: 600;
+  }
+  .hw-review {
+    align-self: flex-start;
+    font-size: var(--fs-meta);
+    background: none;
+    border: 1px solid var(--color-amber);
+    color: var(--color-amber);
+    padding: 3px 8px;
+    cursor: pointer;
+    margin-top: 4px;
+  }
+  /* ── injected house rules ────────────────────────────────────────────── */
+  .injected {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 2px;
+  }
+  .ihead {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .ititle {
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-muted);
+  }
+  .meter {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    font-variant-numeric: tabular-nums;
+  }
+  /* Change 5: over-budget meter variant — dominant amber headline */
+  .meter.over {
+    color: var(--color-amber);
+    font-weight: 600;
+  }
+  /* Per-repo "Optimize all flagged" — token-outlined small action, mirrors .optimize (amber, not green). */
+  .optimize-all {
+    margin-left: auto;
+    font-size: var(--fs-meta);
+    background: none;
+    border: 1px solid var(--color-amber);
+    color: var(--color-amber);
+    padding: 3px 8px;
+    cursor: pointer;
+  }
+  /* Change 6: "Not injected — over budget" sub-label */
+  .not-injected-label {
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-amber);
+    margin: 4px 0 2px;
+  }
+  .retired-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 2px;
+    border-top: 1px solid var(--color-line);
+    padding-top: 6px;
+  }
+  .retired-head {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .retired-title {
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-muted);
+  }
+  /* Phase 4: intra-repo merge-group suggestion cards */
+  .merge-suggest {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 2px;
+  }
+  .ms-title {
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-muted);
+  }
+</style>

--- a/ui/src/lib/components/learnings-drawer/RetiredRuleCard.svelte
+++ b/ui/src/lib/components/learnings-drawer/RetiredRuleCard.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { Learning } from "$lib/types";
+  import type { LearningsCtx } from "./ctx";
+
+  let {
+    rule,
+    ctx,
+  }: {
+    rule: Learning;
+    ctx: LearningsCtx;
+  } = $props();
+</script>
+
+<article class="retired-rule">
+  <p class="retired-text">{rule.rule}</p>
+  <p class="retired-reason">
+    {m.learnings_retired_reason({
+      helped: rule.helpfulCount,
+      pulls: rule.injectedCount,
+      flagged: rule.ineffectiveCount,
+    })}
+  </p>
+  <div class="retired-foot">
+    <span class="spacer"></span>
+    <button
+      class="restore"
+      type="button"
+      aria-label={m.learnings_restore_aria()}
+      onclick={() => ctx.onrestore(rule.id)}
+    >
+      {m.learnings_restore()}
+    </button>
+  </div>
+</article>
+
+<style>
+  .retired-rule {
+    border: 1px solid var(--color-line);
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    opacity: 0.7;
+  }
+  .retired-text {
+    font-size: var(--fs-base);
+    color: var(--status-done);
+    line-height: 1.5;
+  }
+  .retired-reason {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    line-height: 1.45;
+  }
+  .retired-foot {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .spacer {
+    flex: 1;
+  }
+  .restore {
+    font-size: var(--fs-base);
+    padding: 4px 10px;
+    cursor: pointer;
+    border: 1px solid var(--color-line-bright);
+    background: none;
+    color: var(--color-muted);
+  }
+  .restore:hover {
+    color: var(--color-ink-bright);
+    border-color: var(--color-ink-bright);
+  }
+</style>

--- a/ui/src/lib/components/learnings-drawer/TriageBand.svelte
+++ b/ui/src/lib/components/learnings-drawer/TriageBand.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import { basename } from "../learnings-drawer";
+  import type { reposNeedingAttention } from "../learnings-drawer";
+
+  type AttentionItem = ReturnType<typeof reposNeedingAttention>[number];
+
+  let {
+    attention,
+    onjump,
+  }: {
+    attention: AttentionItem[];
+    onjump: (repoPath: string) => void;
+  } = $props();
+</script>
+
+{#if attention.length > 0}
+  <section class="triage" aria-label={m.learnings_triage_heading()}>
+    <span class="triage-label">{m.learnings_triage_heading()}</span>
+    <div class="triage-chips">
+      {#each attention as a (a.repoPath)}
+        <button
+          class="triage-chip"
+          type="button"
+          aria-label={m.learnings_triage_jump_aria({ repo: basename(a.repoPath) })}
+          onclick={() => onjump(a.repoPath)}
+        >
+          <span class="tc-repo">{basename(a.repoPath)}</span>
+          {#if a.droppedCount > 0}<span class="tc-over"
+              >{m.learnings_triage_over({ count: a.droppedCount })}</span
+            >{/if}
+          {#if a.flaggedCount > 0}<span class="tc-flagged"
+              >{m.learnings_triage_flagged({ count: a.flaggedCount })}</span
+            >{/if}
+        </button>
+      {/each}
+    </div>
+  </section>
+{/if}
+
+<style>
+  /* Change 3: Triage summary band */
+  .triage {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 10px;
+    border: 1px solid var(--color-line);
+    background: var(--color-head);
+  }
+  .triage-label {
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-muted);
+  }
+  .triage-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .triage-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: none;
+    border: 1px solid var(--color-line-bright);
+    padding: 3px 8px;
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--fs-meta);
+  }
+  .triage-chip:hover {
+    border-color: var(--color-ink-bright);
+  }
+  .tc-repo {
+    color: var(--color-ink-bright);
+    font-weight: 600;
+  }
+  .tc-over,
+  .tc-flagged {
+    color: var(--color-amber);
+    font-size: var(--fs-meta);
+  }
+</style>

--- a/ui/src/lib/components/learnings-drawer/ctx.ts
+++ b/ui/src/lib/components/learnings-drawer/ctx.ts
@@ -12,7 +12,6 @@ export type LearningsCtx = {
   onoptimize: (id: string) => void;
   onoptimizeall: (repoPath: string) => void;
   onrestore: (id: string) => void;
-  onscope: (id: string, globs: string[]) => void;
   onseenretired: (repoPath: string) => void;
   onmerge: (suggestionId: string) => void;
   ondismissmerge: (suggestionId: string) => void;

--- a/ui/src/lib/components/learnings-drawer/ctx.ts
+++ b/ui/src/lib/components/learnings-drawer/ctx.ts
@@ -1,0 +1,30 @@
+import type { InjectableRule } from "$lib/types";
+
+/** Shared context bundle passed from LearningsDrawer to all leaf-card children.
+ *  Must be built as $derived in the parent so editingScope/scopeDraft stay reactive
+ *  (a plain object literal would be a one-time snapshot and break single-open). */
+export type LearningsCtx = {
+  // Prop callbacks mirrored from LearningsDrawer's own props
+  onapprove: (id: string, rule: string) => void;
+  ondismiss: (id: string) => void;
+  ondistill: (repoPath: string) => void;
+  onpromote: (id: string) => void;
+  onoptimize: (id: string) => void;
+  onoptimizeall: (repoPath: string) => void;
+  onrestore: (id: string) => void;
+  onscope: (id: string, globs: string[]) => void;
+  onseenretired: (repoPath: string) => void;
+  onmerge: (suggestionId: string) => void;
+  ondismissmerge: (suggestionId: string) => void;
+  onpromoteglobal: (suggestionId: string) => void;
+  onmergenow: (repoPath: string) => void;
+
+  // Shared scope-editor state — kept in parent to preserve single-open semantics.
+  // When editingScope === rule.id, that card's editor is open.
+  editingScope: string | null;
+  scopeDraft: string;
+  onScopeOpen: (rule: InjectableRule) => void;
+  onScopeInput: (v: string) => void;
+  onScopeSave: (id: string) => void;
+  onScopeCancel: () => void;
+};


### PR DESCRIPTION
Final actionable paydown for #855. Splits the last un-refactored giant, `LearningsDrawer.svelte`, into focused children under `learnings-drawer/` so its `<template>` clears fallow's Tier-1 40/60 bar — then removes its Tier-2 grandfather from `.fallowrc.jsonc`. Only `Viewport` (deliberately tighten-and-tracked since PR #858) remains grandfathered.

## Result

| | template cyclo / cog |
| --- | --- |
| `LearningsDrawer.svelte` before | 63 / 157 (grandfather 70/160) |
| `LearningsDrawer.svelte` after | **8 / 9** ✓ |

New children (each well under 40/60):
- `RepoGroup.svelte` (22/37) — one repo's whole `<section>` (keeps `repoAnchorId` on its root for deep-link + triage-jump)
- `InjectableRuleCard` (14/19), `ProposedRuleCard`, `MergeSuggestCard`, `RetiredRuleCard` — the rule/suggestion cards
- `TriageBand`, `RecurrenceBand` — the two top-level bands
- `ctx.ts` — shared `LearningsCtx` callback bundle (built as a `$derived` so the shared single-open scope-editor state stays reactive)

## Pure relocation

No behavior/UX/ARIA change and **no message-catalog change**. Invariants explicitly preserved:
- single-open scope editor (shared state threaded via the `$derived` ctx)
- single-open cross-repo promote-confirm (owned by `RecurrenceBand`)
- deep-link (`focusRepo`) + triage-jump (`jumpToRepo` resets both lens flags, then rAF-scrolls to the repo's `RepoGroup` section)
- live-until-edited draft fallback on proposed rules (restored after review)

CSS duplicated per the plan's audited migration map (`.health-warn`/`.hw-*`, `.dismiss`/`.dismiss-muted`, `.spacer`, `.caret`, `.ms-*`); grouped cross-component selectors split. The fallow audit's duplication findings are this intended utility-CSS duplication (warn-level).

## Verification

- `bunx fallow@2.100.0 health` — **0 template-complexity findings**; parent no longer flagged
- `bunx fallow@2.100.0 audit --base origin/main --fail-on-issues` — exit 0
- `cd ui && bun run check` — 0 errors / 0 warnings
- `bun run test` — 1817/1817 pass
- `cd ui && bun run check:i18n` — parity (1708 keys)
- pre-push gates (branch-hygiene, i18n, feature-catalog, glossary) — pass

Executed subagent-driven (fresh implementer + spec/quality review per task; whole-branch review on Opus; its one Important finding — proposed-rule draft reactivity — fixed in `c390606f`).

Closes #855.

[no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)