### PR TITLE
feat(doc-agent): soak rollout phases + durable run tracking (#905)

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -52,7 +52,25 @@ hand-written docs and edits the enumerated prose pages in place. It is granted r
 git (`git diff`/`log`/`show`/`status`) for grounding plus file edits, but has **no git
 mutation, `gh`, or network access**, so it can neither commit nor push; the trusted server
 stages the in-scope doc files, commits, and opens a **pull request** for human review
-(never an auto-merge). Off by default; flip on per deployment to soak it.
+(never an auto-merge).
+
+**Phased soak (`observe → act`, mirroring `SHEPHERD_HOOKS_INGEST` → `SHEPHERD_HOOKS_SIGNALS`).**
+Roll the feature out in two stages so you can watch what it _would_ do before it touches a
+remote:
+
+1. **Observe** — set `SHEPHERD_DOC_AGENT=1` alone. The agent runs and edits on every trigger,
+   and the server computes the staged doc diff, but **finalize is log-only**: it opens **no
+   PR** and runs no `push`. Each would-be PR is logged as a one-line
+   `[doc-agent] OBSERVE: <repo> would open a doc-update PR … (<n> files): …`. Soak here until
+   the logged diffs look correct.
+2. **Act** — additionally set `SHEPHERD_DOC_AGENT_ACT=1` to escalate to actually opening PRs.
+   This flag is meaningful **only** when Phase-0 (`SHEPHERD_DOC_AGENT`) is also on. A fresh
+   enable therefore opens no PR until you explicitly opt into act.
+
+Each spawn is recorded as a durable `reviewer_spawns` row (`kind: "doc_agent"`) for cost
+attribution, and the boot reconcile **re-adopts** a run interrupted by a restart (a surviving
+worktree whose summary is already written is finalized rather than discarded) and reaps any
+orphaned remote `shepherd/docs-update-*` branch left by a crash between `push` and PR-open.
 
 **Automated cadence.** With the same flag on, two triggers run in addition to the manual
 one (a per-repo in-flight guard means at most one run per repo at a time):
@@ -72,7 +90,8 @@ one (a per-repo in-flight guard means at most one run per repo at a time):
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `SHEPHERD_DOC_AGENT` | `0` (off) | Set `1` to enable the doc agent: manual trigger, nightly + merge-triggered cadence, and the boot orphan-sweep |
+| `SHEPHERD_DOC_AGENT` | `0` (off) | Set `1` to enable the doc agent (**Phase-0 observe**): manual trigger, nightly + merge-triggered cadence, and the boot reconcile. Finalize is **log-only** (no PR) until `SHEPHERD_DOC_AGENT_ACT` is also set |
+| `SHEPHERD_DOC_AGENT_ACT` | `0` (off) | **Phase-1 act.** Set `1` to escalate finalize to actually commit, push, and open the **pull request**. Meaningful only when `SHEPHERD_DOC_AGENT` is also on |
 | `SHEPHERD_DOC_AGENT_MODEL` | _(none)_ | Model alias for the doc-agent spawn; unset uses the spawn default |
 | `SHEPHERD_DOC_AGENT_NIGHTLY_HOUR` | `3` | Local hour (0–23) at/after which the nightly sweep evaluates each repo; invalid values fall back to `3` |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -357,11 +357,15 @@ export const config = {
   // Staged after Phase 0 has confirmed the live payload shape (see issue #704).
   hooksSignals: process.env.SHEPHERD_HOOKS_SIGNALS === "1",
   // PR-gated AI doc agent (issue #882, epic #875 Phase 3). Opt-in soak flag, mirroring
-  // SHEPHERD_HOOKS_INGEST: default-off and reversible. When off, the manual trigger
-  // (POST /api/doc-agent) 404s and the boot orphan-sweep is inert. When on, the trigger
-  // spawns a scoped, dontAsk doc agent that edits stale prose docs in a disposable worktree;
-  // the trusted server — never the agent — commits/pushes/opens a PR for human review.
+  // SHEPHERD_HOOKS_INGEST→HOOKS_SIGNALS: default-off and reversible. This is now Phase-0
+  // OBSERVE — when on, the trigger spawns a scoped, dontAsk doc agent that edits stale prose
+  // docs in a disposable worktree, but finalize() is LOG-ONLY (no commit/push/openPr). Set
+  // `docAgentAct` (Phase 1) to escalate to actually opening PRs. When off, the manual trigger
+  // (POST /api/doc-agent) 404s and the boot orphan-sweep is inert.
   docAgentEnabled: process.env.SHEPHERD_DOC_AGENT === "1",
+  // Phase-1 escalation; meaningful only with `docAgentEnabled` (Phase-0 observe). When off,
+  // finalize() is log-only (it warns what PR it *would* open, then skips commit/push/openPr).
+  docAgentAct: process.env.SHEPHERD_DOC_AGENT_ACT === "1",
   // Model alias for the doc-agent spawn. Unset → no --model (spawn default). The agent does
   // substantive comprehension, so a capable model is appropriate; override per deployment.
   docAgentModel: process.env.SHEPHERD_DOC_AGENT_MODEL ?? null,

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -532,35 +532,7 @@ export class DocAgentService {
           await this.git(f.worktreePath, ["diff", "--cached", "--name-only"])
         ).trim();
         if (stagedOut.length > 0) {
-          if (!this.act) {
-            // Phase-0 OBSERVE: the agent ran + edited, but we skip every publish side-effect (no
-            // commit, no push, no openPr). Log exactly what we WOULD have opened, then fall through
-            // to cleanup. url stays null → onChange fires the same {repoPath, url:null} shape as the
-            // already-current path.
-            const staged = stagedOut.split("\n").join(", ");
-            const n = stagedOut.split("\n").length;
-            console.warn(
-              `[doc-agent] OBSERVE: ${f.repoPath} would open a doc-update PR on ${f.branch} (${n} files): ${staged}`,
-            );
-          } else {
-            // --no-verify deliberately DIVERGES from promote.ts (which commits WITH hooks): a
-            // server-side docs-only commit must not run the repo's pre-commit hooks (lint-staged
-            // etc.) on unrelated state. The change is grounded + human-reviewed via the PR.
-            await this.git(f.worktreePath, ["commit", "--no-verify", "-m", COMMIT_MSG]);
-            await this.git(f.worktreePath, ["push", "-u", "origin", f.branch]);
-            try {
-              const status = await forge.openPr({
-                head: f.branch,
-                base: f.base,
-                title: COMMIT_MSG,
-                body: docPrBody(sentinel),
-              });
-              url = status.url ?? null;
-            } catch (err) {
-              // No net diff vs base → nothing to land; not an error.
-              if (!(err instanceof EmptyDiffError)) throw err;
-            }
-          }
+          url = await this.publishStaged(f, sentinel, forge, stagedOut);
         }
       }
     } finally {
@@ -580,6 +552,44 @@ export class DocAgentService {
       }
     }
     this.deps.onChange?.({ repoPath: f.repoPath, url });
+  }
+
+  /**
+   * Phase-gated publish of the staged in-scope doc changes. Phase-0 OBSERVE (`!act`) logs exactly
+   * what it WOULD open and returns null (no commit/push/openPr) — onChange then fires the same
+   * `{repoPath, url:null}` shape as the already-current path. Phase-1 act commits `--no-verify`
+   * (deliberately DIVERGES from promote.ts, which commits WITH hooks: a server-side docs-only
+   * commit must not run the repo's pre-commit hooks on unrelated state — the change is grounded +
+   * human-reviewed via the PR), pushes, opens the PR, and returns its url (null on no net diff).
+   */
+  private async publishStaged(
+    f: InFlight,
+    sentinel: string | null,
+    forge: GitForge,
+    stagedOut: string,
+  ): Promise<string | null> {
+    if (!this.act) {
+      const staged = stagedOut.split("\n");
+      console.warn(
+        `[doc-agent] OBSERVE: ${f.repoPath} would open a doc-update PR on ${f.branch} (${staged.length} files): ${staged.join(", ")}`,
+      );
+      return null;
+    }
+    await this.git(f.worktreePath, ["commit", "--no-verify", "-m", COMMIT_MSG]);
+    await this.git(f.worktreePath, ["push", "-u", "origin", f.branch]);
+    try {
+      const status = await forge.openPr({
+        head: f.branch,
+        base: f.base,
+        title: COMMIT_MSG,
+        body: docPrBody(sentinel),
+      });
+      return status.url ?? null;
+    } catch (err) {
+      // No net diff vs base → nothing to land; not an error.
+      if (!(err instanceof EmptyDiffError)) throw err;
+      return null;
+    }
   }
 
   /** Drop a repo's in-flight tracking (e.g. on shutdown); does not touch the worktree. */

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -42,12 +42,20 @@ async function defaultGit(cwd: string, args: string[]): Promise<string> {
  *  orphaned husk (after a restart) can NEVER squat a stable name — a re-spawn always gets a new
  *  name, so `agent_name_taken` is impossible by construction (the distiller's fix; see
  *  DISTILL_LABEL). The underscores are load-bearing: prompt-derived session slugs are `[a-z0-9-]`
- *  only, so no real session collides, and sweepOrphans can match husks by this prefix safely. */
+ *  only, so no real session collides, and reapOrphans can match husks by this prefix safely. */
 export const DOC_AGENT_LABEL = "__docagent__";
 
 /** Worktree/branch name stem. worktree.create() prepends `shepherd/`, so the branch is
- *  `shepherd/docs-update-<8hex>`. sweepOrphans matches `shepherd/${DOC_BRANCH_PREFIX}`. */
+ *  `shepherd/docs-update-<8hex>`. reapOrphans matches `shepherd/${DOC_BRANCH_PREFIX}`. */
 const DOC_BRANCH_PREFIX = "docs-update-";
+
+/** Refname grammar (mirrors BranchPruner/worktree.ts): rejects a leading "-" so a branch name can
+ *  never smuggle a flag into `git push origin --delete <branch>`. */
+const BRANCH_RE = /^(?!-)[A-Za-z0-9._/-]{1,200}$/;
+
+/** Max forge prStatus lookups per boot remote-reap (matches BranchPruner). The rest wait for the
+ *  next boot — orphan remote branches are durable, so an unbounded backlog never accumulates. */
+const REMOTE_REAP_CAP = 20;
 
 /** The agent writes this at the worktree root as its FINAL action: a per-change grounding bullet
  *  list + an "Uncertain / needs human judgment" section. Its presence is the completion signal; its
@@ -174,8 +182,10 @@ export interface DocAgentDeps {
  * import("./promote").Promoter} and the spawn/membrane posture of ReviewService.
  *
  * Restart-safety: the unique-per-run herdr name (`__docagent__<8hex>`) makes name-squat impossible;
- * `sweepOrphans()` (boot) additionally clears husk tabs + orphan `shepherd/docs-update-*` worktrees,
- * working even when the herdr daemon also restarted (it parses `git worktree list`).
+ * `reapOrphans()` (boot) additionally re-adopts a finished/in-progress interrupted run, prunes dead
+ * ones (+ their husk tabs / dangling cost rows), and reaps orphan remote `shepherd/docs-update-*`
+ * branches with no PR, working even when the herdr daemon also restarted (it parses `git worktree
+ * list`).
  */
 export class DocAgentService {
   private inflight = new Map<string, InFlight>();
@@ -579,50 +589,245 @@ export class DocAgentService {
   }
 
   /**
-   * Boot reconcile. Two independent passes so it works even when the herdr daemon ALSO restarted:
-   *  1. Close any live herdr tab whose name starts with the doc-agent prefix (herdr survived).
-   *  2. herdr-independent: parse `git worktree list` per known repo and remove every
-   *     `shepherd/docs-update-*` worktree + force-delete its branch (the authoritative orphan
-   *     signal when there's no tab to read a cwd from, and no persisted run rows).
+   * Boot reconcile (issue #905). Unlike the reviewer's reapOrphans (which DISCARDS the worktree and
+   * re-kicks a fresh run), the doc agent KEEPS a finished worktree and FINALIZES the work already
+   * produced — the SENTINEL edits are the deliverable, so throwing them away on a restart that
+   * happened to land right after the agent finished would waste a whole run.
+   *
+   * Per repo (skipping any already `inflight`/`starting`), for each surviving
+   * `shepherd/docs-update-*` worktree it applies {@link reapOneWorktree}'s decision tree
+   * (re-adopt / prune / keep-across-a-forge-blip), reaps orphan REMOTE branches with no PR
+   * (the crash-between-push-and-openPr leak), and finally mops up dangling spawn rows + leftover
+   * husk tabs. Works even when the herdr daemon ALSO restarted (it parses `git worktree list`).
    * Scoped strictly to the doc-agent namespace, so it never collides with the reviewer's `review *`
    * reaper or the tmpfs sweeper.
+   *
+   * The boot callsite is best-effort (not awaited): the per-repo `starting` claim is the load-bearing
+   * double-spawn guard regardless, and a merged trigger lost during the brief reconcile window is
+   * recovered by the nightly catch-all.
    */
-  async sweepOrphans(): Promise<void> {
-    this.closeHuskTabs();
+  async reapOrphans(): Promise<void> {
     for (const repo of this.deps.repos()) {
-      if (this.inflight.has(repo)) continue; // never reap a live run
-      await this.pruneRepoOrphanWorktrees(repo);
-    }
-  }
-
-  /** Pass 1: close any live herdr tab whose name starts with the doc-agent prefix. */
-  private closeHuskTabs(): void {
-    try {
-      for (const a of this.deps.herdr.list()) {
-        if (a.name.startsWith(DOC_AGENT_LABEL)) this.deps.herdr.closeTab(a.tabId);
+      if (this.inflight.has(repo) || this.starting.has(repo)) continue; // never reap a live run
+      this.starting.add(repo); // claim BEFORE any await so a concurrent consider() short-circuits
+      let readopted = false;
+      try {
+        readopted = await this.reapRepoWorktrees(repo);
+      } catch (err) {
+        console.warn(`[doc-agent] reapOrphans: error reaping ${repo}:`, err);
+      } finally {
+        if (!readopted) this.starting.delete(repo); // re-adopt keeps the claim (handed to inflight)
       }
-    } catch (err) {
-      console.warn("[doc-agent] sweepOrphans tab pass:", err);
     }
+    await this.sweepDanglingRows();
+    this.closeHuskTabs();
   }
 
-  /** Pass 2 (per repo): remove every `shepherd/docs-update-*` worktree + force-delete its branch. */
-  private async pruneRepoOrphanWorktrees(repo: string): Promise<void> {
+  /** Per repo: walk the doc-update worktrees applying the decision tree, then reap orphan remote
+   *  branches. Returns true iff a worktree was RE-ADOPTED into `inflight` (so the caller keeps the
+   *  `starting` claim, already handed to `inflight`). At most one re-adopt per repo. */
+  private async reapRepoWorktrees(repo: string): Promise<boolean> {
     const orphanPrefix = `shepherd/${DOC_BRANCH_PREFIX}`;
     let entries: { path: string; branch: string }[];
     try {
       entries = await this.listWorktreeBranches(repo);
     } catch {
-      return;
+      return false;
     }
+    const forge = this.deps.resolveForge(repo);
+    let readopted = false;
     for (const { path, branch } of entries) {
       if (!branch.startsWith(orphanPrefix)) continue;
-      this.deps.worktree.remove(path);
-      try {
-        await this.git(repo, ["branch", "-D", branch]);
-      } catch {
-        /* best-effort */
+      if (readopted) {
+        // begin() allows one in-flight run per repo, so any extra orphan worktree is prunable.
+        await this.pruneWorktree(repo, path, branch);
+        continue;
       }
+      readopted = await this.reapOneWorktree(repo, path, branch, forge);
+    }
+    const protectedBranches = new Set<string>(readopted ? [this.inflight.get(repo)!.branch] : []);
+    if (forge && forge.kind !== "local") {
+      await this.reapOrphanRemoteBranches(repo, forge, protectedBranches);
+    }
+    return readopted;
+  }
+
+  /** Decision tree for ONE surviving doc-update worktree. Returns true iff it was re-adopted. */
+  private async reapOneWorktree(
+    repo: string,
+    path: string,
+    branch: string,
+    forge: GitForge | null,
+  ): Promise<boolean> {
+    // No PR surface (no forge / lightweight repo) → nothing to finalize against → prune.
+    if (!forge || forge.kind === "local") {
+      await this.pruneWorktree(repo, path, branch);
+      return false;
+    }
+    const sentinel = this.readSentinel(path);
+    const liveTab = this.findLiveTab(path);
+    let base: string;
+    try {
+      base = await forge.defaultBranch();
+    } catch {
+      // Transient forge failure (offline). Preserve anything worth finishing for a later boot;
+      // otherwise prune. KEEP leaves the row + tab untouched so the next reachable boot retries.
+      if (sentinel !== null || liveTab) return false;
+      await this.pruneWorktree(repo, path, branch);
+      return false;
+    }
+    if (sentinel === null && !liveTab) {
+      // Agent died mid-edit (no completion signal, no live process) → nothing to salvage.
+      await this.pruneWorktree(repo, path, branch);
+      return false;
+    }
+    // sentinel present (finished) OR a live tab (still editing after a Shepherd-only restart) →
+    // RE-ADOPT: hand the `starting` claim to `inflight`; the next tick() finalizes it (and completes
+    // the row). Recover spawnedAt + the spawn session id from the uncompleted row when present.
+    const row = this.uncompletedRowFor(path);
+    this.inflight.set(repo, {
+      repoPath: repo,
+      worktreePath: path,
+      branch,
+      base,
+      terminalId: liveTab?.terminalId ?? "",
+      agentName: liveTab?.name ?? "",
+      startedAt: row?.spawnedAt ?? this.now(),
+      spawnSessionId: row?.reviewerSessionId ?? "",
+    });
+    this.starting.delete(repo);
+    return true;
+  }
+
+  /** Reap orphan REMOTE `shepherd/docs-update-*` branches that have NO PR at all (state "none") —
+   *  the crash-between-push-and-openPr leak. open/merged/closed branches are left alone. */
+  private async reapOrphanRemoteBranches(
+    repo: string,
+    forge: GitForge,
+    protectedBranches: Set<string>,
+  ): Promise<void> {
+    let candidates: string[];
+    try {
+      candidates = await this.listRemoteDocBranches(repo, forge);
+    } catch (err) {
+      console.warn(`[doc-agent] reapOrphans: listing remote branches failed for ${repo}:`, err);
+      return;
+    }
+    let checks = 0;
+    for (const branch of candidates) {
+      if (protectedBranches.has(branch) || !BRANCH_RE.test(branch)) continue;
+      if (checks >= REMOTE_REAP_CAP) break; // bounded per sweep; the rest wait for the next boot
+      checks++;
+      let state: string;
+      try {
+        state = (await forge.prStatus(branch)).state;
+      } catch {
+        console.warn(`[doc-agent] reapOrphans: prStatus failed for ${branch}; keeping`);
+        continue;
+      }
+      if (state !== "none") continue; // an open/merged/closed PR owns the branch — keep it
+      try {
+        await this.git(repo, ["push", "origin", "--delete", branch]);
+      } catch {
+        /* best-effort: the branch may already be gone */
+      }
+    }
+  }
+
+  /** Candidate remote `shepherd/docs-update-*` short-names. Prefer the authoritative forge view
+   *  (GitHub matching-refs API, free of stale local refs); fall back to git, pruning stale
+   *  remote-tracking refs FIRST so a deleted-on-origin branch can't permanently consume the cap. */
+  private async listRemoteDocBranches(repo: string, forge: GitForge): Promise<string[]> {
+    const prefix = `shepherd/${DOC_BRANCH_PREFIX}`;
+    if (forge.listBranches) return forge.listBranches(prefix);
+    try {
+      await this.git(repo, ["remote", "prune", "origin"]);
+    } catch {
+      /* best-effort: a prune failure just leaves stale refs in the for-each-ref read */
+    }
+    const out = await this.git(repo, [
+      "for-each-ref",
+      "--format=%(refname:short)",
+      `refs/remotes/origin/${prefix}`,
+    ]);
+    return out
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => s.replace(/^origin\//, ""));
+  }
+
+  /** Remove a worktree + force-delete its local branch + complete its dangling row + close any
+   *  husk tab. The terminal prune branch of the decision tree. */
+  private async pruneWorktree(repo: string, path: string, branch: string): Promise<void> {
+    await this.completeRowFor(path);
+    const tab = this.findLiveTab(path);
+    if (tab) this.deps.herdr.closeTab(tab.tabId);
+    this.deps.worktree.remove(path);
+    try {
+      await this.git(repo, ["branch", "-D", branch]);
+    } catch {
+      /* best-effort: a never-committed branch may already be gone */
+    }
+  }
+
+  /** After the worktree loop: complete any uncompleted `doc_agent` row whose worktree no longer
+   *  exists on disk (finalize ran but never completed it, or it was pruned elsewhere) so cost
+   *  attribution never leaks. Rows owned by a live in-flight run are left for tick() to complete. */
+  private async sweepDanglingRows(): Promise<void> {
+    const owned = new Set([...this.inflight.values()].map((f) => f.worktreePath));
+    for (const row of this.deps.store.listReviewerSpawns()) {
+      if (row.kind !== "doc_agent" || row.completedAt != null) continue;
+      if (owned.has(row.worktreePath) || this.fileExists(row.worktreePath)) continue;
+      await this.completeRowFor(row.worktreePath);
+    }
+  }
+
+  /** Complete the uncompleted `doc_agent` cost row for `worktreePath` with real usage (best-effort,
+   *  zeroed fallback). No-op when no matching row exists. */
+  private async completeRowFor(worktreePath: string): Promise<void> {
+    const row = this.uncompletedRowFor(worktreePath);
+    if (!row) return;
+    const u = await this.readUsage(worktreePath, row.reviewerSessionId).catch(() => null);
+    this.deps.store.completeReviewerSpawn(row.reviewerSessionId, u ?? ZEROED_USAGE, this.now());
+  }
+
+  /** The uncompleted `doc_agent` reviewer_spawns row for a worktree path, or undefined. */
+  private uncompletedRowFor(worktreePath: string) {
+    return this.deps.store
+      .listReviewerSpawns()
+      .find(
+        (r) => r.kind === "doc_agent" && r.completedAt == null && r.worktreePath === worktreePath,
+      );
+  }
+
+  /** A live herdr agent (doc-agent prefix) whose cwd is this worktree, or undefined. */
+  private findLiveTab(
+    worktreePath: string,
+  ): { tabId: string; terminalId: string; name: string } | undefined {
+    try {
+      return this.deps.herdr
+        .list()
+        .find((a) => a.name.startsWith(DOC_AGENT_LABEL) && a.cwd === worktreePath);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Final pass: close any leftover doc-agent husk tab NOT owned by a re-adopted in-flight run. */
+  private closeHuskTabs(): void {
+    const ownedCwds = new Set([...this.inflight.values()].map((f) => f.worktreePath));
+    const ownedTerms = new Set(
+      [...this.inflight.values()].map((f) => f.terminalId).filter(Boolean),
+    );
+    try {
+      for (const a of this.deps.herdr.list()) {
+        if (!a.name.startsWith(DOC_AGENT_LABEL)) continue;
+        if (ownedTerms.has(a.terminalId) || ownedCwds.has(a.cwd)) continue; // spare re-adopted runs
+        this.deps.herdr.closeTab(a.tabId);
+      }
+    } catch (err) {
+      console.warn("[doc-agent] reapOrphans tab pass:", err);
     }
   }
 

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -755,16 +755,21 @@ export class DocAgentService {
     } catch {
       /* best-effort: a prune failure just leaves stale refs in the for-each-ref read */
     }
+    // Pattern must end on a FULL path component: `git for-each-ref` matches a literal pattern only
+    // completely or up to a slash, so a mid-component prefix (`…/shepherd/docs-update-`) matches
+    // nothing. Use the full `…/shepherd/` component (as branch-pruner does for `refs/heads/shepherd/`)
+    // and narrow to the `docs-update-` branches in code.
     const out = await this.git(repo, [
       "for-each-ref",
       "--format=%(refname:short)",
-      `refs/remotes/origin/${prefix}`,
+      `refs/remotes/origin/shepherd/`,
     ]);
     return out
       .split("\n")
       .map((s) => s.trim())
       .filter(Boolean)
-      .map((s) => s.replace(/^origin\//, ""));
+      .map((s) => s.replace(/^origin\//, ""))
+      .filter((b) => b.startsWith(prefix));
   }
 
   /** Remove a worktree + force-delete its local branch + complete its dangling row + close any

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -11,6 +11,8 @@ import type { GitForge } from "./forge/types";
 import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
 import type { SessionStore } from "./store";
+import type { SessionUsage } from "./usage";
+import { readSessionUsage } from "./usage";
 import {
   apiKeyMembraneFields,
   apiKeyPassthroughEnv,
@@ -78,6 +80,21 @@ const COMMIT_WINDOW = 50;
 
 const COMMIT_MSG = "docs: sync docs to recent source changes";
 
+/** Zeroed usage written when a finalize completes a spawn row but the transcript is unreadable
+ *  (GC'd / partial) — so the row is never left dangling. Same shape as review.ts's zeroedUsage. */
+const ZEROED_USAGE: SessionUsage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  total: 0,
+  messageCount: 0,
+  lastActivity: null,
+  byModel: {},
+  fullRecaches: 0,
+  sidechainCount: 0,
+};
+
 export type DocAgentStatus = "started" | "skipped" | "error";
 export interface DocAgentResult {
   status: DocAgentStatus;
@@ -96,6 +113,8 @@ interface InFlight {
   base: string;
   terminalId: string;
   agentName: string;
+  /** The agent's forced --session-id — the reviewer_spawns PK, used to complete the cost row. */
+  spawnSessionId: string;
   startedAt: number;
   finalizing?: boolean;
 }
@@ -107,9 +126,19 @@ export interface DocAgentDeps {
   /** Repos to enumerate in the boot orphan-sweep (herdr-independent worktree prune) and the nightly
    *  cadence sweep. */
   repos: () => string[];
-  /** Persisted per-repo cadence markers (last-sha / nightly-day / merged-seen). */
-  store: Pick<SessionStore, "getSetting" | "setSetting">;
+  /** Persisted per-repo cadence markers (last-sha / nightly-day / merged-seen) + durable
+   *  spawn-cost rows (reviewer_spawns, reused for doc-agent attribution; issue #502/#905). */
+  store: Pick<
+    SessionStore,
+    | "getSetting"
+    | "setSetting"
+    | "recordReviewerSpawn"
+    | "completeReviewerSpawn"
+    | "listReviewerSpawns"
+  >;
   model?: string | null;
+  /** Phase-1 escalation: when false (Phase-0 observe), finalize() is log-only (no commit/push/PR). */
+  act?: boolean;
   onChange?: (f: DocAgentFinalize) => void;
   now?: () => number;
   timeoutMs?: number;
@@ -129,6 +158,9 @@ export interface DocAgentDeps {
   fileExists?: (p: string) => boolean;
   readSentinel?: (worktreePath: string) => string | null;
   buildPrompt?: (base: string) => string;
+  /** Read a spawn's token usage from its transcript at finalize (cost attribution). Mirrors
+   *  herd-digest.ts's identical dep + readSessionUsage default. */
+  readUsage?: (cwd: string, spawnSessionId: string) => Promise<SessionUsage | null>;
 }
 
 /**
@@ -156,6 +188,8 @@ export class DocAgentService {
   private fileExists: (p: string) => boolean;
   private readSentinel: (worktreePath: string) => string | null;
   private buildPrompt: (base: string) => string;
+  private act: boolean;
+  private readUsage: (cwd: string, spawnSessionId: string) => Promise<SessionUsage | null>;
 
   constructor(private deps: DocAgentDeps) {
     this.git = deps.git ?? defaultGit;
@@ -166,6 +200,8 @@ export class DocAgentService {
     this.fileExists = deps.fileExists ?? existsSync;
     this.readSentinel = deps.readSentinel ?? defaultReadSentinel;
     this.buildPrompt = deps.buildPrompt ?? ((base) => docAgentPrompt(base));
+    this.act = deps.act ?? false;
+    this.readUsage = deps.readUsage ?? readSessionUsage;
   }
 
   private detectBackend(): SandboxBackend {
@@ -346,11 +382,13 @@ export class DocAgentService {
       return { status: "error", reason: "worktree creation failed" };
     }
 
-    const terminalId = this.spawnAgent(repoPath, wt.worktreePath, DOC_AGENT_LABEL + id8, base);
-    if (!terminalId) {
+    const spawned = this.spawnAgent(repoPath, wt.worktreePath, DOC_AGENT_LABEL + id8, base);
+    if (!spawned) {
       this.deps.worktree.remove(wt.worktreePath);
       return { status: "error", reason: "spawn failed" };
     }
+    const { terminalId, spawnSessionId } = spawned;
+    const startedAt = this.now();
     this.inflight.set(repoPath, {
       repoPath,
       worktreePath: wt.worktreePath,
@@ -358,7 +396,19 @@ export class DocAgentService {
       base,
       terminalId,
       agentName: DOC_AGENT_LABEL + id8,
-      startedAt: this.now(),
+      spawnSessionId,
+      startedAt,
+    });
+    // AFTER inflight.set (the ordering mirrors plan-gate's documented invariant): persist a durable
+    // reviewer_spawns row so this run's token burn is attributable even if it crashes before finalize.
+    // Session-less — repoPath is the correlation key (herd-digest uses "" for its herd-wide spawn).
+    this.deps.store.recordReviewerSpawn({
+      reviewerSessionId: spawnSessionId,
+      taskSessionId: repoPath,
+      kind: "doc_agent",
+      worktreePath: wt.worktreePath,
+      model: this.deps.model ?? null,
+      spawnedAt: startedAt,
     });
     // Stamp the cadence marker from the SAME ref the nightly gate reads (`refs/remotes/origin/<base>`,
     // freshened by ensureBaseRef above) — NOT resolved.baseRef, which falls back to the branch
@@ -398,16 +448,17 @@ export class DocAgentService {
     return { ok: true, forge };
   }
 
-  /** Build the scoped argv + membrane and spawn the agent via herdr. Returns the terminalId, or
-   *  null on a spawn failure (logged). profile "standard": the agent needs Anthropic egress (to run
-   *  claude) but not GitHub — the server pushes/opens the PR — mirroring ReviewService's spawn. */
+  /** Build the scoped argv + membrane and spawn the agent via herdr. Returns the terminalId +
+   *  the agent's forced --session-id (the reviewer_spawns PK), or null on a spawn failure (logged).
+   *  profile "standard": the agent needs Anthropic egress (to run claude) but not GitHub — the
+   *  server pushes/opens the PR — mirroring ReviewService's spawn. */
   private spawnAgent(
     repoPath: string,
     worktreePath: string,
     agentName: string,
     base: string,
-  ): string | null {
-    const { argv } = docAgentArgv(this.deps.model ?? null, this.buildPrompt(base));
+  ): { terminalId: string; spawnSessionId: string } | null {
+    const { argv, sessionId } = docAgentArgv(this.deps.model ?? null, this.buildPrompt(base));
     const backend = this.detectBackend();
     const env = this.membraneEnv();
     const membrane: MembraneInputs = {
@@ -424,12 +475,13 @@ export class DocAgentService {
     };
     const wrapped = wrapArgv(argv, { profile: "standard", backend, membrane });
     try {
-      return this.deps.herdr.start(
+      const terminalId = this.deps.herdr.start(
         agentName,
         worktreePath,
         wrapped,
         apiKeyPassthroughEnv(backend !== null),
       ).terminalId;
+      return { terminalId, spawnSessionId: sessionId };
     } catch (err) {
       if (err instanceof HerdrUnavailableError) {
         console.warn(`[doc-agent] herdr unavailable for ${repoPath}:`, err);
@@ -466,28 +518,47 @@ export class DocAgentService {
       const inScope = IN_SCOPE_PATHS.filter((p) => this.fileExists(join(f.worktreePath, p)));
       if (forge && inScope.length > 0) {
         await this.git(f.worktreePath, ["add", "--", ...inScope]);
-        const staged = (await this.git(f.worktreePath, ["diff", "--cached", "--name-only"])).trim();
-        if (staged.length > 0) {
-          // --no-verify deliberately DIVERGES from promote.ts (which commits WITH hooks): a
-          // server-side docs-only commit must not run the repo's pre-commit hooks (lint-staged
-          // etc.) on unrelated state. The change is grounded + human-reviewed via the PR.
-          await this.git(f.worktreePath, ["commit", "--no-verify", "-m", COMMIT_MSG]);
-          await this.git(f.worktreePath, ["push", "-u", "origin", f.branch]);
-          try {
-            const status = await forge.openPr({
-              head: f.branch,
-              base: f.base,
-              title: COMMIT_MSG,
-              body: docPrBody(sentinel),
-            });
-            url = status.url ?? null;
-          } catch (err) {
-            // No net diff vs base → nothing to land; not an error.
-            if (!(err instanceof EmptyDiffError)) throw err;
+        const stagedOut = (
+          await this.git(f.worktreePath, ["diff", "--cached", "--name-only"])
+        ).trim();
+        if (stagedOut.length > 0) {
+          if (!this.act) {
+            // Phase-0 OBSERVE: the agent ran + edited, but we skip every publish side-effect (no
+            // commit, no push, no openPr). Log exactly what we WOULD have opened, then fall through
+            // to cleanup. url stays null → onChange fires the same {repoPath, url:null} shape as the
+            // already-current path.
+            const staged = stagedOut.split("\n").join(", ");
+            const n = stagedOut.split("\n").length;
+            console.warn(
+              `[doc-agent] OBSERVE: ${f.repoPath} would open a doc-update PR on ${f.branch} (${n} files): ${staged}`,
+            );
+          } else {
+            // --no-verify deliberately DIVERGES from promote.ts (which commits WITH hooks): a
+            // server-side docs-only commit must not run the repo's pre-commit hooks (lint-staged
+            // etc.) on unrelated state. The change is grounded + human-reviewed via the PR.
+            await this.git(f.worktreePath, ["commit", "--no-verify", "-m", COMMIT_MSG]);
+            await this.git(f.worktreePath, ["push", "-u", "origin", f.branch]);
+            try {
+              const status = await forge.openPr({
+                head: f.branch,
+                base: f.base,
+                title: COMMIT_MSG,
+                body: docPrBody(sentinel),
+              });
+              url = status.url ?? null;
+            } catch (err) {
+              // No net diff vs base → nothing to land; not an error.
+              if (!(err instanceof EmptyDiffError)) throw err;
+            }
           }
         }
       }
     } finally {
+      // Complete the durable cost row with real usage (best-effort) on EVERY finalize path (observe
+      // and act) BEFORE the worktree is removed — mirrors herd-digest.ts / review.ts.
+      // completeReviewerSpawn no-ops on an unknown id, so an empty/missing id is safe.
+      const usage = await this.readUsage(f.worktreePath, f.spawnSessionId).catch(() => null);
+      this.deps.store.completeReviewerSpawn(f.spawnSessionId, usage ?? ZEROED_USAGE, this.now());
       // Cleanup mirrors Promoter.cleanup: stop the agent (closes its tab), remove the worktree, and
       // force-delete the local branch (the pushed remote branch backs any opened PR).
       this.deps.herdr.stop(f.terminalId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -582,6 +582,7 @@ const docAgent = new DocAgentService({
   store,
   nightlyHour: config.docAgentNightlyHour,
   model: config.docAgentModel,
+  act: config.docAgentAct,
   onChange: (f) => events.emit("doc-agent:done", f),
 });
 if (config.docAgentEnabled) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -586,10 +586,12 @@ const docAgent = new DocAgentService({
   onChange: (f) => events.emit("doc-agent:done", f),
 });
 if (config.docAgentEnabled) {
-  // Boot reconcile: clear husk tabs + orphan docs-update-* worktrees from a pre-restart run so a
-  // unique-named re-spawn never collides and stale worktrees don't accumulate (works even if the
-  // herdr daemon also restarted — it parses `git worktree list`).
-  void docAgent.sweepOrphans().catch((err) => console.warn("[doc-agent] sweepOrphans:", err));
+  // Boot reconcile: re-adopt a finished/in-progress interrupted run (its SENTINEL edits are the
+  // deliverable), prune dead ones + husk tabs + dangling cost rows, and reap orphan remote
+  // docs-update-* branches with no PR. Best-effort (not awaited): the per-repo `starting` claim is
+  // the load-bearing double-spawn guard, and a merged trigger lost during this brief reconcile
+  // window is recovered by the nightly catch-all. Works even if the herdr daemon also restarted.
+  void docAgent.reapOrphans().catch((err) => console.warn("[doc-agent] reapOrphans:", err));
 }
 
 const reviewService = new ReviewService({

--- a/src/store.ts
+++ b/src/store.ts
@@ -2025,7 +2025,7 @@ export class SessionStore implements CapStore, CreditStore {
   recordReviewerSpawn(r: {
     reviewerSessionId: string;
     taskSessionId: string;
-    kind: "review" | "plan_gate" | "recap" | "rundown";
+    kind: "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
     worktreePath: string;
     model: string | null;
     spawnedAt: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,7 +369,7 @@ export interface HerdDigest {
 export interface ReviewerSpawnRow {
   reviewerSessionId: string;
   taskSessionId: string;
-  kind: "review" | "plan_gate" | "recap" | "rundown";
+  kind: "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
   worktreePath: string;
   model: string | null;
   spawnedAt: number;

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -60,6 +60,7 @@ interface Harness {
   kv: Map<string, string>;
   spawnRows: SpawnRow[];
   completedRows: CompletedRow[];
+  deletedRemote: string[];
   __merge: number;
 }
 
@@ -70,13 +71,20 @@ function mkHarness(opts?: {
   sentinel?: string | null;
   stagedNames?: string; // stdout of `git diff --cached --name-only`
   worktreeListPorcelain?: string;
-  herdrAgents?: { name: string; tabId: string }[];
+  herdrAgents?: { name: string; tabId: string; cwd?: string; terminalId?: string }[];
   repos?: string[];
   originSha?: string | (() => string);
   originShaThrows?: boolean;
   now?: () => number;
   nightlyHour?: number;
   act?: boolean;
+  defaultBranchThrows?: boolean;
+  /** Short-names returned by forge.listBranches; when undefined, listBranches is absent. */
+  remoteBranches?: string[];
+  /** Drives forge.prStatus(branch).state for the remote-branch reap. */
+  prStatusByBranch?: Record<string, "none" | "open" | "merged" | "closed">;
+  /** stdout of `git for-each-ref … refs/remotes/origin/…` (git fallback path). */
+  forEachRefStdout?: string;
 }): Harness {
   const o = {
     forgeKind: "github" as "github" | "local" | null,
@@ -94,6 +102,8 @@ function mkHarness(opts?: {
     now: () => 1000,
     nightlyHour: 3,
     act: false,
+    defaultBranchThrows: false,
+    forEachRefStdout: "",
     ...opts,
   };
 
@@ -107,6 +117,7 @@ function mkHarness(opts?: {
   const kv = new Map<string, string>();
   const spawnRows: SpawnRow[] = [];
   const completedRows: CompletedRow[] = [];
+  const deletedRemote: string[] = [];
   const store = {
     getSetting: (key: string) => kv.get(key) ?? null,
     setSetting: (key: string, value: string) => {
@@ -139,6 +150,11 @@ function mkHarness(opts?: {
     gitCalls.push({ cwd, args });
     if (args[0] === "diff" && args[1] === "--cached") return o.stagedNames;
     if (args[0] === "worktree" && args[1] === "list") return o.worktreeListPorcelain;
+    if (args[0] === "for-each-ref") return o.forEachRefStdout;
+    if (args[0] === "push" && args[1] === "origin" && args[2] === "--delete") {
+      deletedRemote.push(args[3]!);
+      return "";
+    }
     if (args[0] === "rev-parse" && args[1]?.startsWith("refs/remotes/origin/")) {
       if (o.originShaThrows) throw new Error("no such ref");
       return typeof o.originSha === "function" ? (o.originSha as () => string)() : o.originSha;
@@ -151,7 +167,10 @@ function mkHarness(opts?: {
       ? null
       : ({
           kind: o.forgeKind,
-          defaultBranch: async () => "main",
+          defaultBranch: async () => {
+            if (o.defaultBranchThrows) throw new Error("forge offline");
+            return "main";
+          },
           openPr: async (input: unknown) => {
             openPrInputs.push(input);
             return { url: "https://forge/pr/42" };
@@ -159,6 +178,12 @@ function mkHarness(opts?: {
           merge: async () => {
             mergeCalls++;
           },
+          // listBranches is present ONLY when remoteBranches is provided (mirrors the
+          // optional GitHub matching-refs API; absent → git-fallback path exercised).
+          ...(o.remoteBranches !== undefined ? { listBranches: async () => o.remoteBranches } : {}),
+          prStatus: async (branch: string) => ({
+            state: o.prStatusByBranch?.[branch] ?? "none",
+          }),
         } as any);
 
   const herdr = {
@@ -167,7 +192,16 @@ function mkHarness(opts?: {
       return { terminalId: "term-" + starts.length } as any;
     },
     stop: () => {},
-    list: () => o.herdrAgents.map((a) => ({ name: a.name, tabId: a.tabId }) as any),
+    list: () =>
+      o.herdrAgents.map(
+        (a) =>
+          ({
+            name: a.name,
+            tabId: a.tabId,
+            cwd: a.cwd ?? "",
+            terminalId: a.terminalId ?? "",
+          }) as any,
+      ),
     closeTab: (tabId: string) => {
       closedTabs.push(tabId);
     },
@@ -242,6 +276,7 @@ function mkHarness(opts?: {
     kv,
     spawnRows,
     completedRows,
+    deletedRemote,
     mergeCalls: 0,
     get __merge() {
       return mergeCalls;
@@ -353,7 +388,7 @@ test("restart safety: unique-per-run agent names never collide", async () => {
   expect(h.starts[0]!.name).not.toBe(h.starts[1]!.name);
 });
 
-test("sweepOrphans: closes only __docagent__ tabs and prunes only docs-update worktrees", async () => {
+test("reapOrphans: closes only __docagent__ tabs and prunes only docs-update worktrees (no sentinel/no tab)", async () => {
   const porcelain = [
     "worktree /repo",
     "branch refs/heads/main",
@@ -368,12 +403,13 @@ test("sweepOrphans: closes only __docagent__ tabs and prunes only docs-update wo
   const h = mkHarness({
     repos: ["/repo"],
     worktreeListPorcelain: porcelain,
+    sentinel: null, // agent died mid-edit → prune (not re-adopt)
     herdrAgents: [
-      { name: "__docagent__deadbeef", tabId: "tab-doc" },
+      { name: "__docagent__deadbeef", tabId: "tab-doc", cwd: "/wt/gone" },
       { name: "review TASK-7", tabId: "tab-review" },
     ],
   });
-  await h.svc.sweepOrphans();
+  await h.svc.reapOrphans();
   // only the doc-agent husk tab closed
   expect(h.closedTabs).toEqual(["tab-doc"]);
   // only the docs-update worktree removed; main + unrelated feature left alone
@@ -389,6 +425,149 @@ test("sweepOrphans: closes only __docagent__ tabs and prunes only docs-update wo
   ).toBe(true);
   // unrelated feature branch NOT deleted
   expect(h.gitCalls.some((c) => c.args.includes("shepherd/some-feature"))).toBe(false);
+});
+
+// ── reapOrphans: re-adoption + dangling sweep + remote reap (issue #905) ────────
+
+const DOCS_WT_PORCELAIN = (id: string) =>
+  [
+    "worktree /repo",
+    "branch refs/heads/main",
+    "",
+    `worktree /wt/docs-update-${id}`,
+    `branch refs/heads/shepherd/docs-update-${id}`,
+    "",
+  ].join("\n");
+
+test("reapOrphans: re-adopts a sentinel-present orphan and finalizes it (not discarded)", async () => {
+  const h = mkHarness({
+    repos: ["/repo"],
+    worktreeListPorcelain: DOCS_WT_PORCELAIN("x0000001"),
+    sentinel: "## Changes\n- updated configuration.md\n",
+    act: true,
+  });
+  await h.svc.reapOrphans();
+  // re-adopted, NOT pruned by reapOrphans itself
+  expect(h.removedWorktrees).not.toContain("/wt/docs-update-x0000001");
+  // the work is finalized on the next tick (act:true → openPr fires)
+  await h.svc.tick();
+  expect(h.openPrInputs).toHaveLength(1);
+  expect((h.openPrInputs[0] as any).head).toBe("shepherd/docs-update-x0000001");
+});
+
+test("reapOrphans: prunes a no-sentinel/no-tab orphan and completes its dangling row", async () => {
+  const h = mkHarness({
+    repos: ["/repo"],
+    worktreeListPorcelain: DOCS_WT_PORCELAIN("dead0001"),
+    sentinel: null,
+  });
+  // an uncompleted doc_agent row exists for the orphan worktree
+  h.spawnRows.push({
+    reviewerSessionId: "sess-dead",
+    taskSessionId: "/repo",
+    kind: "doc_agent",
+    worktreePath: "/wt/docs-update-dead0001",
+    model: null,
+    spawnedAt: 500,
+    completedAt: null,
+  });
+  await h.svc.reapOrphans();
+  expect(h.removedWorktrees).toContain("/wt/docs-update-dead0001");
+  expect(
+    h.gitCalls.some(
+      (c) =>
+        c.args[0] === "branch" &&
+        c.args[1] === "-D" &&
+        c.args[2] === "shepherd/docs-update-dead0001",
+    ),
+  ).toBe(true);
+  expect(h.completedRows.some((r) => r.reviewerSessionId === "sess-dead")).toBe(true);
+});
+
+test("reapOrphans: transient forge (defaultBranch throws) + sentinel present → keep, do not prune/complete", async () => {
+  const h = mkHarness({
+    repos: ["/repo"],
+    worktreeListPorcelain: DOCS_WT_PORCELAIN("keep0001"),
+    sentinel: "## Changes\n- something\n",
+    defaultBranchThrows: true,
+  });
+  h.spawnRows.push({
+    reviewerSessionId: "sess-keep",
+    taskSessionId: "/repo",
+    kind: "doc_agent",
+    worktreePath: "/wt/docs-update-keep0001",
+    model: null,
+    spawnedAt: 500,
+    completedAt: null,
+  });
+  await h.svc.reapOrphans();
+  // finished edits preserved across the blip — a later boot retries
+  expect(h.removedWorktrees).not.toContain("/wt/docs-update-keep0001");
+  expect(h.completedRows.some((r) => r.reviewerSessionId === "sess-keep")).toBe(false);
+});
+
+test("reapOrphans: dangling-row sweep completes a row whose worktree is gone from disk", async () => {
+  const h = mkHarness({
+    repos: ["/repo"],
+    worktreeListPorcelain: "worktree /repo\nbranch refs/heads/main\n\n",
+    inScopeFilesPresent: false, // fileExists → false for the gone worktree path
+  });
+  h.spawnRows.push({
+    reviewerSessionId: "sess-gone",
+    taskSessionId: "/repo",
+    kind: "doc_agent",
+    worktreePath: "/wt/docs-update-gone0001",
+    model: null,
+    spawnedAt: 500,
+    completedAt: null,
+  });
+  await h.svc.reapOrphans();
+  expect(h.completedRows.some((r) => r.reviewerSessionId === "sess-gone")).toBe(true);
+});
+
+test("reapOrphans: a re-adopted repo's claim blocks a concurrent consider (no double-spawn)", async () => {
+  const h = mkHarness({
+    repos: ["/repo"],
+    worktreeListPorcelain: DOCS_WT_PORCELAIN("claim001"),
+    sentinel: "## Changes\n- x\n",
+  });
+  await h.svc.reapOrphans();
+  // the repo is now inflight → a concurrent consider is skipped
+  const res = await h.svc.consider("/repo");
+  expect(res.status).toBe("skipped");
+});
+
+test("reapOrphans: remote reap deletes only no-PR branches (state none), keeps open/merged/closed", async () => {
+  const h = mkHarness({
+    repos: ["/repo"],
+    worktreeListPorcelain: "worktree /repo\nbranch refs/heads/main\n\n",
+    remoteBranches: ["shepherd/docs-update-aaa", "shepherd/docs-update-bbb"],
+    prStatusByBranch: {
+      "shepherd/docs-update-aaa": "none",
+      "shepherd/docs-update-bbb": "open",
+    },
+  });
+  await h.svc.reapOrphans();
+  expect(h.deletedRemote).toEqual(["shepherd/docs-update-aaa"]);
+});
+
+test("reapOrphans: git fallback (no listBranches) runs `git remote prune origin` before for-each-ref", async () => {
+  const h = mkHarness({
+    repos: ["/repo"],
+    worktreeListPorcelain: "worktree /repo\nbranch refs/heads/main\n\n",
+    // remoteBranches omitted → forge.listBranches absent → git fallback
+    forEachRefStdout: "origin/shepherd/docs-update-ccc\n",
+    prStatusByBranch: { "shepherd/docs-update-ccc": "none" },
+  });
+  await h.svc.reapOrphans();
+  const pruneIdx = h.gitCalls.findIndex(
+    (c) => c.args[0] === "remote" && c.args[1] === "prune" && c.args[2] === "origin",
+  );
+  const forEachIdx = h.gitCalls.findIndex((c) => c.args[0] === "for-each-ref");
+  expect(pruneIdx).toBeGreaterThanOrEqual(0);
+  expect(forEachIdx).toBeGreaterThan(pruneIdx);
+  // the stale-but-PR-less branch is reaped (short-name, origin/ stripped)
+  expect(h.deletedRemote).toEqual(["shepherd/docs-update-ccc"]);
 });
 
 // ── cadence: scheduling (issue #904) ───────────────────────────────────────────

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -31,6 +31,22 @@ interface GitCall {
   args: string[];
 }
 
+interface SpawnRow {
+  reviewerSessionId: string;
+  taskSessionId: string;
+  kind: string;
+  worktreePath: string;
+  model: string | null;
+  spawnedAt: number;
+  completedAt: number | null;
+}
+
+interface CompletedRow {
+  reviewerSessionId: string;
+  completedAt: number;
+  total: number;
+}
+
 interface Harness {
   svc: DocAgentService;
   gitCalls: GitCall[];
@@ -42,6 +58,8 @@ interface Harness {
   finalizes: DocAgentFinalize[];
   ensureBaseRefCalls: { repo: string; base: string }[];
   kv: Map<string, string>;
+  spawnRows: SpawnRow[];
+  completedRows: CompletedRow[];
   __merge: number;
 }
 
@@ -58,6 +76,7 @@ function mkHarness(opts?: {
   originShaThrows?: boolean;
   now?: () => number;
   nightlyHour?: number;
+  act?: boolean;
 }): Harness {
   const o = {
     forgeKind: "github" as "github" | "local" | null,
@@ -74,6 +93,7 @@ function mkHarness(opts?: {
     originShaThrows: false,
     now: () => 1000,
     nightlyHour: 3,
+    act: false,
     ...opts,
   };
 
@@ -85,11 +105,33 @@ function mkHarness(opts?: {
   const finalizes: DocAgentFinalize[] = [];
   const ensureBaseRefCalls: { repo: string; base: string }[] = [];
   const kv = new Map<string, string>();
+  const spawnRows: SpawnRow[] = [];
+  const completedRows: CompletedRow[] = [];
   const store = {
     getSetting: (key: string) => kv.get(key) ?? null,
     setSetting: (key: string, value: string) => {
       kv.set(key, value);
     },
+    recordReviewerSpawn: (r: {
+      reviewerSessionId: string;
+      taskSessionId: string;
+      kind: string;
+      worktreePath: string;
+      model: string | null;
+      spawnedAt: number;
+    }) => {
+      spawnRows.push({ ...r, completedAt: null });
+    },
+    completeReviewerSpawn: (
+      reviewerSessionId: string,
+      u: { total: number },
+      completedAt: number,
+    ) => {
+      completedRows.push({ reviewerSessionId, completedAt, total: u.total });
+      const row = spawnRows.find((s) => s.reviewerSessionId === reviewerSessionId);
+      if (row) row.completedAt = completedAt;
+    },
+    listReviewerSpawns: () => spawnRows,
   };
   let mergeCalls = 0;
 
@@ -160,9 +202,10 @@ function mkHarness(opts?: {
     worktree: worktree as any,
     resolveForge: () => forge,
     repos: () => o.repos,
-    store,
+    store: store as any,
     nightlyHour: o.nightlyHour,
     model: null,
+    act: o.act,
     onChange: (f) => finalizes.push(f),
     now: o.now,
     git,
@@ -173,6 +216,18 @@ function mkHarness(opts?: {
       return o.inScopeFilesPresent;
     },
     readSentinel: () => o.sentinel,
+    readUsage: async () => ({
+      input: 5,
+      output: 7,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 12,
+      messageCount: 1,
+      lastActivity: null,
+      byModel: {},
+      fullRecaches: 0,
+      sidechainCount: 0,
+    }),
   });
 
   return {
@@ -185,6 +240,8 @@ function mkHarness(opts?: {
     finalizes,
     ensureBaseRefCalls,
     kv,
+    spawnRows,
+    completedRows,
     mergeCalls: 0,
     get __merge() {
       return mergeCalls;
@@ -197,7 +254,7 @@ function mkHarness(opts?: {
 }
 
 test("happy path: in-scope edits → commit --no-verify + push + openPr (never merge)", async () => {
-  const h = mkHarness();
+  const h = mkHarness({ act: true });
   const res = await h.svc.consider("/repo");
   expect(res.status).toBe("started");
   expect(h.starts).toHaveLength(1);
@@ -509,4 +566,70 @@ test("merge: absent PR number → skip", async () => {
   const res = await h.svc.onMergedPr("/repo", undefined, "feat: x", "main");
   expect(res.status).toBe("skipped");
   expect(h.starts).toHaveLength(0);
+});
+
+// ── soak flags: observe → act (issue #905) ─────────────────────────────────────
+
+test("observe mode (act:false): staged changes → OBSERVE warn, NO push, NO PR, worktree removed", async () => {
+  const warns: string[] = [];
+  const orig = console.warn;
+  console.warn = (...a: unknown[]) => {
+    warns.push(a.join(" "));
+  };
+  try {
+    const h = mkHarness({ act: false });
+    await h.svc.consider("/repo");
+    await h.svc.tick();
+    // no PR opened, no push run
+    expect(h.openPrInputs).toHaveLength(0);
+    expect(h.gitCalls.some((c) => c.args[0] === "push")).toBe(false);
+    expect(h.gitCalls.some((c) => c.args[0] === "commit")).toBe(false);
+    // worktree still cleaned up
+    expect(h.removedWorktrees.length).toBeGreaterThan(0);
+    // url stays null (same shape as already-current path)
+    expect(h.finalizes).toEqual([{ repoPath: "/repo", url: null }]);
+    // the OBSERVE line fired
+    expect(warns.some((w) => w.includes("[doc-agent] OBSERVE:"))).toBe(true);
+  } finally {
+    console.warn = orig;
+  }
+});
+
+test("act mode (act:true): staged changes → one PR opened (current behavior preserved)", async () => {
+  const h = mkHarness({ act: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  expect(h.openPrInputs).toHaveLength(1);
+});
+
+// ── durable spawn-row tracking (cost attribution) ──────────────────────────────
+
+test("spawn row recorded: a successful begin() persists one doc_agent reviewer_spawns row", async () => {
+  const h = mkHarness();
+  await h.svc.consider("/repo");
+  expect(h.spawnRows).toHaveLength(1);
+  const row = h.spawnRows[0]!;
+  expect(row.kind).toBe("doc_agent");
+  expect(row.taskSessionId).toBe("/repo");
+  expect(row.worktreePath).toMatch(/^\/wt\/docs-update-/);
+  expect(row.spawnedAt).not.toBeNull();
+});
+
+test("row completed at finalize: observe path completes the spawn row", async () => {
+  const h = mkHarness({ act: false });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  expect(h.completedRows).toHaveLength(1);
+  expect(h.completedRows[0]!.reviewerSessionId).toBe(h.spawnRows[0]!.reviewerSessionId);
+  // real (non-zero) usage recorded via the readUsage stub
+  expect(h.completedRows[0]!.total).toBe(12);
+  expect(h.spawnRows[0]!.completedAt).not.toBeNull();
+});
+
+test("row completed at finalize: act path completes the spawn row", async () => {
+  const h = mkHarness({ act: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  expect(h.completedRows).toHaveLength(1);
+  expect(h.completedRows[0]!.reviewerSessionId).toBe(h.spawnRows[0]!.reviewerSessionId);
 });

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -95,7 +95,7 @@ function mkHarness(opts?: {
       | null,
     stagedNames: "docs-site/src/content/docs/reference/configuration.md",
     worktreeListPorcelain: "",
-    herdrAgents: [] as { name: string; tabId: string }[],
+    herdrAgents: [] as { name: string; tabId: string; cwd?: string; terminalId?: string }[],
     repos: [] as string[],
     originSha: "origin-sha-1" as string,
     originShaThrows: false,

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -150,7 +150,26 @@ function mkHarness(opts?: {
     gitCalls.push({ cwd, args });
     if (args[0] === "diff" && args[1] === "--cached") return o.stagedNames;
     if (args[0] === "worktree" && args[1] === "list") return o.worktreeListPorcelain;
-    if (args[0] === "for-each-ref") return o.forEachRefStdout;
+    if (args[0] === "for-each-ref") {
+      // Faithfully model `git for-each-ref`'s literal-pattern matching (complete, or up to a slash:
+      // refname starts with the pattern AND ends at a component boundary, OR the pattern ends in
+      // `/`). Treat each forEachRefStdout line as a `%(refname:short)` for a `refs/remotes/*` ref.
+      // This makes a mid-component pattern (`…/shepherd/docs-update-`) correctly match nothing.
+      const pattern = args[args.length - 1] ?? "";
+      return o.forEachRefStdout
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .filter((short) => {
+          const ref = `refs/remotes/${short}`;
+          return (
+            ref.startsWith(pattern) &&
+            (ref.length === pattern.length || ref[pattern.length] === "/" || pattern.endsWith("/"))
+          );
+        })
+        .map((s) => `${s}\n`)
+        .join("");
+    }
     if (args[0] === "push" && args[1] === "origin" && args[2] === "--delete") {
       deletedRemote.push(args[3]!);
       return "";


### PR DESCRIPTION
Follow-up to #882 (epic #875 Phase 3). Hardens the PR-gated doc agent for unattended operation along three independent axes. Closes #905.

## 1. Observe → act soak flags (mirror `SHEPHERD_HOOKS_INGEST` → `SHEPHERD_HOOKS_SIGNALS`)
- `SHEPHERD_DOC_AGENT=1` is now **Phase-0 OBSERVE**: the agent runs and edits, but `finalize()` is **log-only** — no commit/push/openPr. Each would-be PR is logged as `[doc-agent] OBSERVE: <repo> would open a doc-update PR … (<n> files): …`.
- `SHEPHERD_DOC_AGENT_ACT=1` is **Phase-1**: escalates to actually committing, pushing, and opening the PR. Meaningful only when Phase-0 is on, so a fresh enable opens **no** PR until you opt in.
- This intentionally changes the prior meaning of `SHEPHERD_DOC_AGENT=1` (which used to open PRs) — acceptable because the feature is default-off and the soak rollout is the point of #905.

## 2. Durable run tracking + reviewer-style `reapOrphans`
- Each spawn persists a `reviewer_spawns` row (`kind:"doc_agent"`, no new table/migration), completed with token usage on **every** finalize path — so doc-agent burn is attributable even on crash. A row-driven sweep completes dangling rows whose worktree is gone.
- `sweepOrphans()` → `reapOrphans()`: a surviving `shepherd/docs-update-*` worktree is the orphan signal. The boot reconcile now **re-adopts** an interrupted run (sentinel present **or** a live herdr tab) so the next `tick()` finalizes the work the agent already produced, instead of discarding it. It prunes only when there is nothing to preserve (no sentinel **and** no live tab). A transient `defaultBranch()` failure on a finished worktree **keeps** it for a later boot; only a permanent no-PR-surface (null/local forge) prunes.
- A per-repo `starting`→`inflight` claim (synchronous, before any await) prevents a concurrent merged-event replay / manual `consider()` from double-spawning during the reconcile.

> **Deliberate divergence from the reviewer's `reapOrphans`:** the reviewer discards the worktree and re-kicks a fresh run; the doc agent keeps the worktree and finalizes — the `SENTINEL` edits are the deliverable. That divergence is why this task also owns the race guard, terminal-branch row completion, and transient-forge preservation.

## 3. Reap orphan remote branches
- A crash between `push` and `openPr` can leave an orphaned remote `shepherd/docs-update-*` branch. `reapOrphans` now deletes remote branches with **no PR at all** (`prStatus.state === "none"` only — merged/closed left to `BranchPruner`/GitHub), preferring the authoritative `forge.listBranches`; the git fallback runs `git remote prune origin` first so stale refs can't starve the per-sweep cap. In-flight branches are protected; branch names are validated before `git push origin --delete`.

## Scope / notes
- Server-only plumbing: no UI / i18n / glossary / feature-catalog changes. `[no-feature-entry]`
- Docs updated: `docs-site/.../reference/configuration.md` documents both flags + the observe-first soak procedure.
- Execution: subagent-driven (implementer + task review per cohesive task, broad final review — verdict **READY TO MERGE**).

## Validation
- `bun run lint` ✓ · root `bunx tsc --noEmit` ✓ · `bun test ./test` ✓ (4246 pass / 8 skip / 0 fail; 37 doc-agent tests) · `bunx fallow audit --base origin/main --fail-on-issues` ✓ (no issues in changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)