### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -50,7 +50,7 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 | -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------- |
 | **Network bind**     | `127.0.0.1:7330` (loopback only) | Run on the same host, reach it over Tailscale serve, or set `SHEPHERD_HOST` to expose another NIC |
 | **Auth token**       | `SHEPHERD_TOKEN` unset → open    | If set, send `Authorization: Bearer <token>` on every request (timing-safe compare)               |
-| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~/Work`  | `repoPath` must resolve **inside** the root, or the request is rejected `400`                     |
+| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~` (home) | `repoPath` must resolve **inside** the root, or the request is rejected `400`                     |
 
 ### Recommended setup for a remote agent
 
@@ -70,7 +70,7 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 | `repoPath`   | string                                  | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
 | `baseBranch` | string                                  | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
 | `prompt`     | string                                  | ✅       | The task instructions; 1–8000 chars                                          |
-| `model`      | `"opus" \| "sonnet" \| "haiku" \| null` | —        | Omit/`null` = Claude's default                                               |
+| `model`      | `"fable" \| "opus" \| "opus[1m]" \| "sonnet" \| "sonnet[1m]" \| "haiku" \| null` | —        | Omit/`null`/`"default"` = Claude's default                                   |
 | `images`     | `string[]`                              | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
 
 ### Responses


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

## Changes

- **`docs/external-task-api.md`** — two fixes to the `POST /api/sessions` request-schema /
  gates tables, both grounded in current source:
  - **`model` field enum** was `"opus" | "sonnet" | "haiku" | null` — stale. The validator
    (`validateModel`, `src/validate.ts:82-86`) accepts any member of `MODELS`
    (`src/types.ts:143` = `["fable", "opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku"]`),
    plus `null` or the string `"default"` (both → Claude's default, no `--model` flag).
    Updated the type to list all six aliases and noted `"default"` maps to the default.
  - **`SHEPHERD_REPO_ROOT` default** in the "What actually gates access" table was `~/Work`
    — stale. `src/config.ts:322-325` defaults `repoRoot` to `process.env.HOME` (i.e. `~`),
    matching what `docs-site/.../reference/configuration.md` already states (`~` (home)).
    Changed the gate-table default to `~` (home).

## Uncertain / needs human judgment

- **`docs-site/.../reference/configuration.md` is not exhaustive despite its frontmatter
  description ("Every environment variable").** Many env vars read in `src/config.ts` are
  undocumented — e.g. `SHEPHERD_USAGE_HOLD_ENABLED`/`_PCT` (#830), `SHEPHERD_REDUCED_PUSH_MODE`
  (#896), `SHEPHERD_DEFAULT_MODEL`, `SHEPHERD_FABLE_AVAILABLE` (#846), `SHEPHERD_AUTH_MODE`,
  `SHEPHERD_HOOKS_INGEST`/`_SIGNALS` (#704), `SHEPHERD_EXTRA_CREDITS_DRAIN_CEILING`,
  `SHEPHERD_AUTOMERGE_REBASE_CAP`, `SHEPHERD_REVIEW_CYCLES_CAP`,
  `SHEPHERD_PLAN_REVIEW_CYCLES_CAP`, `SHEPHERD_STANDARD_COMMAND`, `SHEPHERD_SESSION_HOUSEKEEPING`,
  `SHEPHERD_LLM_NAMING`/`SHEPHERD_NAMER_MODEL`, `SHEPHERD_HOUSE_RULES_BUDGET_CHARS`,
  `SHEPHERD_AUTOPILOT_STEP_CAP`/`_MODEL`, `SHEPHERD_VAPID_*`, `SHEPHERD_PUSH_COOLDOWN_MS`,
  `SHEPHERD_REMOTE_CONTROL_AT_STARTUP`, `SHEPHERD_HERDR_UPDATE_LOG`, `SHEPHERD_NODE_BIN`,
  `CLAUDE_PROJECTS_DIR`/`CLAUDE_CONFIG_DIR`, `SHEPHERD_SANDBOX_EXTRA_HOSTS`. This reads as a
  long-standing deliberate curation (a chosen subset), not staleness introduced by a recent
  change, so I left it. Adding these would be net-new documentation and a judgment call on
  scope — flagging rather than guessing.

- **`docs/sandbox-security.md` egress allowlist description.** The note says egress confines
  outbound to `api.anthropic.com` + `statsig.anthropic.com` + the GitHub hosts. Current
  `src/egress.ts` (`buildEgressAllowlist`, ~L383-409) also adds per-forge `baseUrl` hosts and
  operator extras (`SHEPHERD_SANDBOX_EXTRA_HOSTS` / per-repo `egressExtraHosts`). This is an
  incomplete summary rather than a clear factual error (the default github case still matches),
  and I could not confidently date it against a recent change, so I left it unchanged.

- **`docs/sandbox-security.md` precise line citations** (e.g. `src/sandbox.ts:296-299`,
  `:280-282`, `:318`, `:335`) may have drifted from the current file. I did not exhaustively
  verify each; the architectural claims they support (trusted/standard/autonomous profiles,
  egress keyed to the autonomous profile, `--clearenv`, read-only reviewers) remain accurate,
  so I made no changes. A human may want to refresh the exact line numbers.

- **`token-usage-analysis.md`** is a point-in-time report on five specific historical tasks;
  it is intentionally a snapshot and is not "stale" in the sense of disagreeing with current
  source. Left unchanged.