### PR TITLE
fix(learnings): make synced CLAUDE.md block prettier-stable

### DIFF
--- a/src/promote.ts
+++ b/src/promote.ts
@@ -62,7 +62,11 @@ export class Promoter {
     const path = join(homedir(), ".claude", "CLAUDE.md");
     try {
       const current = this.readClaudeMd(path);
-      const rules = [...new Set([...extractLearningsBlockRules(current), rule])];
+      // Dedup in *sanitized* space: extractLearningsBlockRules returns the stored rules in
+      // their already-sanitized form, while `rule` is raw — comparing them raw would miss a
+      // rule that sanitize alters (leading marker / collapsible whitespace), writing a
+      // duplicate bullet and defeating the `next === current` no-op on re-promote.
+      const rules = [...new Set([...extractLearningsBlockRules(current), rule].map(sanitizeRule))];
       const next = upsertLearningsBlock(current, rules);
       if (next === current) return { ok: true, url: "" };
       this.writeClaudeMd(path, next);

--- a/src/promote.ts
+++ b/src/promote.ts
@@ -285,12 +285,35 @@ export class Promoter {
 export const LEARNINGS_START = "<!-- shepherd:learnings:start -->";
 export const LEARNINGS_END = "<!-- shepherd:learnings:end -->";
 
+/** Normalize a free-form learning rule into a single Markdown list-item body that is
+ *  byte-for-byte stable under `prettier --check` (CommonMark). Target repos lint their
+ *  CLAUDE.md with prettier; an un-normalized rule could otherwise reparse as a nested
+ *  list / heading or get whitespace-collapsed, re-flagging the synced block (flowagent #418).
+ *  - collapses every whitespace run (incl. tabs/newlines) to a single space and trims ends
+ *  - backslash-escapes a leading Markdown list/heading marker so prettier keeps it as text
+ *    (a backslash-escaped marker renders identically). Idempotent. */
+export function sanitizeRule(rule: string): string {
+  return rule
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^([-*+]) /, "\\$1 ")
+    .replace(/^(\d+)([.)]) /, "$1\\$2 ")
+    .replace(/^(#+) /, "\\$1 ");
+}
+
 /** Insert or replace the managed shepherd:learnings block in CLAUDE.md content.
  *  Idempotent: replaces the existing block's contents rather than appending a
  *  duplicate; appends a fresh block when no markers are present. Each rule is one
- *  `- <rule>` bullet. */
+ *  `- <rule>` bullet. A blank line follows the start marker — prettier/CommonMark
+ *  requires it between an HTML-comment block and the list, else `prettier --check`
+ *  fails in target repos (flowagent #418). Each rule is sanitized for the same reason. */
 export function upsertLearningsBlock(content: string, rules: string[]): string {
-  const body = [LEARNINGS_START, ...rules.map((r) => `- ${r}`), LEARNINGS_END].join("\n");
+  const body = [
+    LEARNINGS_START,
+    "",
+    ...rules.map((r) => `- ${sanitizeRule(r)}`),
+    LEARNINGS_END,
+  ].join("\n");
   const start = content.indexOf(LEARNINGS_START);
   const end = content.indexOf(LEARNINGS_END);
   if (start !== -1 && end !== -1 && end > start) {

--- a/src/promote.ts
+++ b/src/promote.ts
@@ -120,7 +120,9 @@ export class Promoter {
         return { ok: false, error: "worktree creation failed", status: 500 };
       }
       try {
-        const rules = [...new Set(promoted.map((l) => l.rule))];
+        // Dedup in sanitized space (matches promoteGlobal): two stored rules that collapse to
+        // the same sanitized bullet must not both survive into the block.
+        const rules = [...new Set(promoted.map((l) => sanitizeRule(l.rule)))];
         const claudePath = join(wt.worktreePath, "CLAUDE.md");
         const current = this.readClaudeMd(claudePath);
         const next = upsertLearningsBlock(current, rules);
@@ -263,7 +265,9 @@ export class Promoter {
     const promoted = this.deps.store
       .listLearnings(learning.repoPath, { status: "promoted" })
       .map((l) => l.rule);
-    const rules = [...new Set([...promoted, learning.rule])];
+    // Dedup in sanitized space (matches promoteGlobal): a stored rule and the newly-promoted
+    // one that collapse to the same sanitized bullet must dedup, not emit a duplicate.
+    const rules = [...new Set([...promoted, learning.rule].map(sanitizeRule))];
     this.writeClaudeMd(claudePath, upsertLearningsBlock(this.readClaudeMd(claudePath), rules));
 
     await this.git(worktreePath, ["add", "CLAUDE.md"]);

--- a/test/promote.test.ts
+++ b/test/promote.test.ts
@@ -573,6 +573,18 @@ test("promoteGlobal is an idempotent no-op when the rule is already present", as
   expect(state.writes.length).toBe(0); // already current → nothing written
 });
 
+test("promoteGlobal re-promote of a sanitize-altered rule is an idempotent no-op", async () => {
+  // The stored block holds the *sanitized* form ("\- dash"); the incoming raw "- dash" must
+  // dedup against it, not write a second bullet. (Plain "rule a" wouldn't catch this — sanitize
+  // leaves it unchanged.)
+  const existing = upsertLearningsBlock("", ["- dash"]);
+  expect(extractLearningsBlockRules(existing)).toEqual(["\\- dash"]);
+  const state = { content: existing, writes: [] as string[] };
+  const res = await globalPromoter(state).promoteGlobal("- dash");
+  expect(res.ok).toBe(true);
+  expect(state.writes.length).toBe(0); // already current → no duplicate bullet, no write
+});
+
 test("promoteGlobal returns a structured 500 (not a throw) on an fs failure", async () => {
   const p = new Promoter({
     store: new SessionStore(":memory:"),

--- a/test/promote.test.ts
+++ b/test/promote.test.ts
@@ -326,6 +326,35 @@ test("Promoter.resyncPromoted rebuilds block and opens a PR", async () => {
   expect(removed).toContain(wtDir);
 });
 
+test("Promoter.resyncPromoted dedups two promoted rules that collapse to one sanitized bullet", async () => {
+  const store = new SessionStore(":memory:");
+  // Distinct raw rules that sanitize to the same bullet ("\- dash"): raw-space dedup would
+  // keep both and emit a duplicate; sanitized-space dedup collapses them to one.
+  for (const rule of ["- dash", "-  dash"]) {
+    const l = store.addLearning({ repoPath: "/repo-dup", rule, rationale: "", evidence: [] });
+    store.setLearningStatus(l.id, "active");
+    store.setLearningStatus(l.id, "promoted");
+  }
+  const wtDir = mkdtempSync(join(tmpdir(), "resync-dedup-"));
+  let written = "";
+  const p = new Promoter({
+    store,
+    worktree: {
+      create: () => ({ worktreePath: wtDir, branch: "learnings-resync-dedup", isolated: true }),
+      remove: () => {},
+    },
+    resolveForge: () => fakeForge(),
+    git: async () => {},
+    readClaudeMd: () => "# Repo\n",
+    writeClaudeMd: (_p, c) => {
+      written = c;
+    },
+  });
+  const res = await p.resyncPromoted("/repo-dup");
+  expect(res.ok).toBe(true);
+  expect(extractLearningsBlockRules(written)).toEqual(["\\- dash"]); // exactly one bullet
+});
+
 test("Promoter.resyncPromoted is a no-op when CLAUDE.md already has the current block", async () => {
   const store = new SessionStore(":memory:");
   const l = store.addLearning({

--- a/test/promote.test.ts
+++ b/test/promote.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
-import { upsertLearningsBlock, LEARNINGS_START, LEARNINGS_END } from "../src/promote";
+import * as prettier from "prettier";
+import { upsertLearningsBlock, sanitizeRule, LEARNINGS_START, LEARNINGS_END } from "../src/promote";
 
 test("upsertLearningsBlock appends a block when none exists", () => {
   const out = upsertLearningsBlock("# Repo\n\nintro\n", ["use bun", "rebase onto main"]);
@@ -23,6 +24,62 @@ test("upsertLearningsBlock replaces block contents idempotently", () => {
 test("upsertLearningsBlock handles empty file", () => {
   const out = upsertLearningsBlock("", ["only rule"]);
   expect(out.startsWith(LEARNINGS_START)).toBe(true);
+});
+
+test("upsertLearningsBlock puts a blank line after the start marker", () => {
+  // prettier/CommonMark requires the blank line between the HTML-comment block and the
+  // list, else `prettier --check` fails in target repos (flowagent #418).
+  const out = upsertLearningsBlock("# Repo\n", ["a", "b"]);
+  expect(out).toContain(`${LEARNINGS_START}\n\n- a\n- b\n${LEARNINGS_END}`);
+});
+
+test("sanitizeRule normalizes whitespace and escapes leading markdown markers", () => {
+  expect(sanitizeRule("  hello   world  ")).toBe("hello world");
+  expect(sanitizeRule("a\nb\tc")).toBe("a b c");
+  expect(sanitizeRule("- dash")).toBe("\\- dash");
+  expect(sanitizeRule("* star")).toBe("\\* star");
+  expect(sanitizeRule("+ plus")).toBe("\\+ plus");
+  expect(sanitizeRule("1. num")).toBe("1\\. num");
+  expect(sanitizeRule("2) paren")).toBe("2\\) paren");
+  expect(sanitizeRule("# head")).toBe("\\# head");
+  expect(sanitizeRule("Use bun.")).toBe("Use bun."); // non-marker text untouched
+  // idempotent — re-sanitizing an already-escaped rule is a no-op (matters for the
+  // global-accumulate read-back path, which re-emits extracted rules).
+  expect(sanitizeRule(sanitizeRule("- dash"))).toBe("\\- dash");
+});
+
+// Free-form rule text that would make a naive block prettier-unstable (nested-list
+// reinterpretation, whitespace collapse). Includes flowagent #418's real rule.
+const PRETTIER_STABILITY_RULES = [
+  "Use bun, not npm.",
+  "- leading dash rule",
+  "* leading asterisk rule",
+  "+ leading plus rule",
+  "1. leading numbered rule",
+  "2) paren numbered rule",
+  "# heading-like rule",
+  "internal   double   spaces",
+  "trailing whitespace here   ",
+  "line one\nline two",
+  "Use `bun run lint` before push.",
+  "Run migrations/backfills/DB tests on local Docker+mocks only, never shared Neon/Aura; scope each mutation to one org via WHERE; shared writes need approval.",
+];
+
+test("upsertLearningsBlock output is byte-for-byte prettier-stable (default markdown config)", async () => {
+  // Mirror what a target repo's `prettier --check .` does: prettier's Node API with an
+  // explicit parser uses only default options (no .prettierrc lookup), so this matches an
+  // arbitrary repo's default formatting. A stable (unchanged) result == the block won't
+  // re-trip the Lint step. Cover the whole battery in one block, each rule alone, and the
+  // empty-base case.
+  const blocks = [
+    upsertLearningsBlock("# Repo\n\nintro\n", PRETTIER_STABILITY_RULES),
+    ...PRETTIER_STABILITY_RULES.map((r) => upsertLearningsBlock("# Repo\n", [r])),
+    ...PRETTIER_STABILITY_RULES.map((r) => upsertLearningsBlock("", [r])),
+  ];
+  for (const content of blocks) {
+    const formatted = await prettier.format(content, { parser: "markdown" });
+    expect(formatted).toBe(content);
+  }
 });
 
 import { mkdtempSync, readFileSync } from "node:fs";


### PR DESCRIPTION
## Problem

Shepherd's auto-opened house-rules sync PR ([flowagent #418](https://github.com/ltdovr/flowagent/pull/418)) tripped CI on the **Lint** step. `prettier --check .` flagged the synced `CLAUDE.md`: `upsertLearningsBlock` emitted the `- rule` list directly under the `<!-- shepherd:learnings:start -->` HTML comment with **no blank line**, and copied rule text **verbatim**.

Verified against #418's real `CLAUDE.md` (head `9d84d91`): prettier (default **and** flowagent's exact `.prettierrc`, identical) wants exactly one change — a blank line after the start marker. Stress-testing also showed the block is prettier-**unstable** for free-form rules: leading `-`/`*`/`+`/`1.`/`#` reparse as nested lists/headings, and double spaces / trailing whitespace / embedded newlines get rewritten.

## Fix

`src/promote.ts` — both fixes centralized in `upsertLearningsBlock`, so resync, single-rule promote, and the global `~/.claude/CLAUDE.md` write all benefit:

1. **Blank line** after the start marker (CommonMark requires it between an HTML-comment block and a list).
2. **`sanitizeRule`** — collapse whitespace runs + trim, and backslash-escape a leading Markdown marker (renders identically). Idempotent, so the global-accumulate read-back path re-emits stably.

## Tests

`test/promote.test.ts` — asserts the generated block is **byte-for-byte prettier-stable** (prettier Node API, default markdown config — mirrors an arbitrary target repo) across a rule battery including #418's real rule; plus `sanitizeRule` unit coverage and the blank-line shape. Existing idempotency / extract round-trip stay green.

## Verification

- `bunx prettier --check` ✓ · `bun run lint` (eslint) ✓ · `bunx tsc --noEmit` ✓ · `bun test ./test` → 4249 pass, 0 fail ✓

The already-open flowagent #418 is being unblocked separately (one-line prettier-format commit to its branch); it is the only open sync/promote PR across GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)