### PR TITLE
feat(site): refresh landing highlights for 1.35 features

### DIFF
--- a/site/src/components/FeatureGrid.astro
+++ b/site/src/components/FeatureGrid.astro
@@ -1,5 +1,5 @@
 ---
-// Eight-card feature grid. Copy is faithful to the README "Opinionated by
+// Nine-card feature grid. Copy is faithful to the README "Opinionated by
 // design" + intro and the feature-announcement catalog
 // (ui/src/lib/feature-announcements.ts) — describes what ships, no invented
 // capabilities. Body text is rendered verbatim (no markdown), so copy stays
@@ -36,11 +36,15 @@ const features: Feature[] = [
   },
   {
     title: "Learnings",
-    body: "Distills past sessions' failure signals into proposed house rules; the ones you approve are injected into every new agent in the repo, so lessons compound.",
+    body: "Distills past sessions' failure signals into proposed house rules; the ones you approve are injected into every new agent in the repo. Rules that stop helping retire themselves, can be scoped to matching paths, and — when they recur across repos — promote to your global config.",
   },
   {
     title: "Merge train",
     body: "A finished PR lands only when it's open, CI-green, conflict-free, and up to date; one that has fallen behind is rebased and fully re-verified first.",
+  },
+  {
+    title: "Usage-aware",
+    body: "Run many agents on one subscription without burning it. When usage is high and a session is already running, new tasks hold and start on their own when usage resets — submit anyway to override. A session halted at a usage limit resumes in one click.",
   },
 ];
 ---

--- a/site/src/components/HowItWorks.astro
+++ b/site/src/components/HowItWorks.astro
@@ -15,12 +15,12 @@ const steps: Step[] = [
   {
     n: "02",
     title: "Point it at a repo",
-    body: "Shepherd readiness-scores its guardrails and turns the gaps into setup tasks.",
+    body: "GitHub-backed or local-only — Shepherd readiness-scores the repo's guardrails and turns the gaps into setup tasks.",
   },
   {
     n: "03",
     title: "Spawn the herd",
-    body: "Watch and steer agents from your browser or phone; merge only what survives plan gate, critic, and the merge train.",
+    body: "Watch and steer agents from your browser or phone. Every plan clears the plan gate first; GitHub-backed repos then merge only what survives the critic and the merge train, while local-only repos squash-merge locally.",
   },
 ];
 ---


### PR DESCRIPTION
## What

The marketing landing page (`site/`) was structurally accurate but its highlights had drifted behind the product across release 1.35.0. This refreshes the highlight copy and adds one new card — faithful to the feature-announcement catalog, no invented capabilities, no redesign.

## Changes (2 files, copy-only)

- **`FeatureGrid.astro`**
  - **Learnings** card now reflects the lifecycle that shipped: rules that stop helping **auto-retire** (#853), can be **scoped to matching paths** (#869), and — when they **recur across repos** — promote to your global config (#873/#895). Previously described only the basic distill→approve→inject flywheel.
  - New **"Usage-aware"** card (grid 8→9): run many agents on one subscription; tasks **hold when usage is high and a session is already running** and resume on reset (submit-anyway override), and a usage-halted session **resumes in one click** (#830/#835). The high-usage + already-running precondition is preserved verbatim from the catalog.
- **`HowItWorks.astro`**
  - Step 02: repos can be **GitHub-backed or local-only** (lightweight mode, #819).
  - Step 03: scopes the critic + merge-train pipeline to **GitHub-backed** repos and notes **local-only repos squash-merge locally** — so the local-only mention in step 02 doesn't falsely imply the PR pipeline runs without a Forge. (Plan gate is pre-execution and applies regardless, so it stays unscoped.)

`Guardrails.astro` deliberately left unchanged: that section frames entries as shippability gates; lifecycle detail lives on the FeatureGrid card.

## Verification

- `cd site && bun run build` ✓ and `bun run check` ✓ (0 errors; the single pre-existing `execCommand` hint in `InstallBlock.astro` is unrelated).
- Rendered `dist/index.html` confirmed: **9** feature cards; new Learnings/Usage-aware/local-only/squash-merge copy all present.
- Grid is plain CSS grid (auto-flow, no `nth-child` rules): clean 3×3 at ≥980px; the 9th card left-aligns on the trailing row at the 2-col breakpoint; stacks at 1-col — all acceptable.

Note: docs site / doc agent deliberately not added as a highlight (the Hero "Read the docs" CTA already covers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)