### PR TITLE
fix(doc-agent): prettier-format staged docs before commit

### DIFF
--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { config } from "./config";
 import { docAgentArgv } from "./doc-agent-argv";
@@ -36,6 +36,27 @@ const execFileP = promisify(execFile);
 async function defaultGit(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFileP("git", args, { cwd });
   return stdout;
+}
+
+/** The server's own install root (the repo root, one level above src/). Used to resolve the
+ *  pinned prettier binary + node_modules — the managed target repo may have no node_modules of its
+ *  own, so prettier MUST NOT be resolved from there (it would silently no-op or fail on missing
+ *  plugins). Mirrors the pattern at egress.ts:94 and server.ts:127. */
+export const SERVER_INSTALL_ROOT = resolve(import.meta.dir, "..");
+
+/** Run the server's pinned prettier `--write` over `files`. No-op when the list is empty.
+ *  `cwd` should be SERVER_INSTALL_ROOT so bare plugin names in `configPath` resolve from the
+ *  server's pinned node_modules. Throws on prettier error — the caller catches for best-effort. */
+async function defaultPrettierWrite(args: {
+  cwd: string;
+  configPath: string;
+  files: string[];
+}): Promise<void> {
+  if (args.files.length === 0) return;
+  const binary = join(SERVER_INSTALL_ROOT, "node_modules", ".bin", "prettier");
+  await execFileP(binary, ["--write", "--config", args.configPath, "--", ...args.files], {
+    cwd: args.cwd,
+  });
 }
 
 /** Prefix for ephemeral doc-agent herdr names. Each run appends 8 hex of a fresh UUID so an
@@ -156,6 +177,7 @@ export interface DocAgentDeps {
   /** Local `YYYY-MM-DD` for `now` — the nightly once/day key. */
   dayKey?: (now: number) => string;
   git?: (cwd: string, args: string[]) => Promise<string>;
+  prettier?: (args: { cwd: string; configPath: string; files: string[] }) => Promise<void>;
   detectBackend?: () => SandboxBackend;
   membraneEnv?: () => {
     claudeDir: string;
@@ -191,6 +213,7 @@ export class DocAgentService {
   private inflight = new Map<string, InFlight>();
   private starting = new Set<string>();
   private git: (cwd: string, args: string[]) => Promise<string>;
+  private prettier: (args: { cwd: string; configPath: string; files: string[] }) => Promise<void>;
   private now: () => number;
   private timeoutMs: number;
   private nightlyHour: number;
@@ -203,6 +226,7 @@ export class DocAgentService {
 
   constructor(private deps: DocAgentDeps) {
     this.git = deps.git ?? defaultGit;
+    this.prettier = deps.prettier ?? defaultPrettierWrite;
     this.now = deps.now ?? Date.now;
     this.timeoutMs = deps.timeoutMs ?? 20 * 60 * 1000;
     this.nightlyHour = deps.nightlyHour ?? 3;
@@ -527,6 +551,28 @@ export class DocAgentService {
       // edit to the Astro app, reference/cli/*, or a new file is never staged → can't reach the PR.
       const inScope = IN_SCOPE_PATHS.filter((p) => this.fileExists(join(f.worktreePath, p)));
       if (forge && inScope.length > 0) {
+        // Format root docs/*.md with the server's pinned prettier BEFORE staging so the PR passes
+        // CI's `prettier --check .` gate. Constrained to the `docs/`-prefixed in-scope files (abs
+        // paths) — docs-site/** is Astro/Starlight-governed and must never be passed to root
+        // prettier. Best-effort: a failure warns loudly and the PR still opens (no worse than
+        // today's unformatted baseline).
+        const absDocs = inScope
+          .filter((p) => p.startsWith("docs/"))
+          .map((p) => join(f.worktreePath, p));
+        if (absDocs.length > 0) {
+          try {
+            await this.prettier({
+              cwd: SERVER_INSTALL_ROOT,
+              configPath: join(f.worktreePath, ".prettierrc"),
+              files: absDocs,
+            });
+          } catch (err) {
+            console.warn(
+              `[doc-agent] prettier format failed for ${f.repoPath} — PR may fail the lint gate:`,
+              err,
+            );
+          }
+        }
         await this.git(f.worktreePath, ["add", "--", ...inScope]);
         const stagedOut = (
           await this.git(f.worktreePath, ["diff", "--cached", "--name-only"])

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -45,8 +45,12 @@ async function defaultGit(cwd: string, args: string[]): Promise<string> {
 export const SERVER_INSTALL_ROOT = resolve(import.meta.dir, "..");
 
 /** Run the server's pinned prettier `--write` over `files`. No-op when the list is empty.
- *  `cwd` should be SERVER_INSTALL_ROOT so bare plugin names in `configPath` resolve from the
- *  server's pinned node_modules. Throws on prettier error — the caller catches for best-effort. */
+ *  `cwd` should be SERVER_INSTALL_ROOT: prettier 3 resolves the bare plugin specifiers in
+ *  `configPath` (`prettier-plugin-svelte`/`-tailwindcss`) by importing from a synthetic module
+ *  anchored at the CWD (verified on 3.8.4 — a wrong cwd fails with `imported from <cwd>/noop.js`),
+ *  and those plugins are loaded for every parser, markdown included. SERVER_INSTALL_ROOT is the one
+ *  directory guaranteed to have them (co-located with this pinned prettier); the managed worktree's
+ *  own node_modules may be absent. Throws on prettier error — the caller catches for best-effort. */
 async function defaultPrettierWrite(args: {
   cwd: string;
   configPath: string;

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import {
   DocAgentService,
   DOC_AGENT_LABEL,
+  SERVER_INSTALL_ROOT,
   isDocRelevantMerge,
   type DocAgentFinalize,
 } from "../src/doc-agent";
@@ -31,6 +32,14 @@ interface GitCall {
   args: string[];
 }
 
+interface PrettierCall {
+  cwd: string;
+  configPath: string;
+  files: string[];
+  /** Snapshot of gitCalls op-names (args[0]) at the instant prettier was called. */
+  gitOpsAtCall: string[];
+}
+
 interface SpawnRow {
   reviewerSessionId: string;
   taskSessionId: string;
@@ -50,6 +59,7 @@ interface CompletedRow {
 interface Harness {
   svc: DocAgentService;
   gitCalls: GitCall[];
+  prettierCalls: PrettierCall[];
   starts: { name: string; cwd: string }[];
   closedTabs: string[];
   removedWorktrees: string[];
@@ -85,6 +95,8 @@ function mkHarness(opts?: {
   prStatusByBranch?: Record<string, "none" | "open" | "merged" | "closed">;
   /** stdout of `git for-each-ref … refs/remotes/origin/…` (git fallback path). */
   forEachRefStdout?: string;
+  /** When true, the injected prettier stub throws (exercises the best-effort failure path). */
+  prettierThrows?: boolean;
 }): Harness {
   const o = {
     forgeKind: "github" as "github" | "local" | null,
@@ -104,10 +116,12 @@ function mkHarness(opts?: {
     act: false,
     defaultBranchThrows: false,
     forEachRefStdout: "",
+    prettierThrows: false,
     ...opts,
   };
 
   const gitCalls: GitCall[] = [];
+  const prettierCalls: PrettierCall[] = [];
   const starts: { name: string; cwd: string }[] = [];
   const closedTabs: string[] = [];
   const removedWorktrees: string[] = [];
@@ -262,6 +276,11 @@ function mkHarness(opts?: {
     onChange: (f) => finalizes.push(f),
     now: o.now,
     git,
+    prettier: async (args) => {
+      // Capture a snapshot of the git op-names at call time to assert ordering in tests.
+      prettierCalls.push({ ...args, gitOpsAtCall: gitCalls.map((c) => c.args[0]!) });
+      if (o.prettierThrows) throw new Error("prettier failed (stub)");
+    },
     detectBackend: () => null,
     membraneEnv: () => ({ claudeDir: "/c", home: "/h", nodeBinReal: "/n", extraEnv: {} }),
     fileExists: (p: string) => {
@@ -286,6 +305,7 @@ function mkHarness(opts?: {
   return {
     svc,
     gitCalls,
+    prettierCalls,
     starts,
     closedTabs,
     removedWorktrees,
@@ -830,4 +850,68 @@ test("row completed at finalize: act path completes the spawn row", async () => 
   await h.svc.tick();
   expect(h.completedRows).toHaveLength(1);
   expect(h.completedRows[0]!.reviewerSessionId).toBe(h.spawnRows[0]!.reviewerSessionId);
+});
+
+// ── prettier pre-format (fix: doc-agent auto-PRs fail CI lint gate) ─────────────
+
+test("prettier: called exactly once with cwd=SERVER_INSTALL_ROOT and worktree .prettierrc", async () => {
+  const h = mkHarness({ act: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+
+  expect(h.prettierCalls).toHaveLength(1);
+  const call = h.prettierCalls[0]!;
+  // cwd must be the SERVER's install root (not the worktree — the worktree may have no node_modules)
+  expect(call.cwd).toBe(SERVER_INSTALL_ROOT);
+  // config must come from the managed repo's worktree so CI's own formatting rules drive the output
+  expect(call.configPath).toMatch(/^\/wt\/docs-update-[0-9a-f]{8}\/.prettierrc$/);
+});
+
+test("prettier: files are the absolute worktree paths of the root docs/*.md in-scope files", async () => {
+  const h = mkHarness({ act: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+
+  const call = h.prettierCalls[0]!;
+  // The three root docs/*.md entries from IN_SCOPE_PATHS (abs paths under the worktree).
+  const wtBase = call.configPath.replace("/.prettierrc", "");
+  expect(call.files).toEqual([
+    `${wtBase}/docs/external-task-api.md`,
+    `${wtBase}/docs/sandbox-security.md`,
+    `${wtBase}/docs/token-usage-analysis.md`,
+  ]);
+});
+
+test("prettier ordering: prettier runs BEFORE git add (no 'add' in gitCalls snapshot at call time)", async () => {
+  const h = mkHarness({ act: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+
+  const call = h.prettierCalls[0]!;
+  expect(call.gitOpsAtCall).not.toContain("add");
+});
+
+test("prettier regression: docs-site paths are never passed to prettier", async () => {
+  const h = mkHarness({ act: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+
+  const call = h.prettierCalls[0]!;
+  for (const f of call.files) {
+    expect(f).not.toContain("docs-site");
+  }
+});
+
+test("prettier failure path: throwing prettier stub still results in commit + push + PR (best-effort)", async () => {
+  const h = mkHarness({ act: true, prettierThrows: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+
+  // prettier threw, but the act path is best-effort — commit/push/openPr must still fire
+  expect(h.gitCalls.some((c) => c.args[0] === "commit" && c.args.includes("--no-verify"))).toBe(
+    true,
+  );
+  expect(h.gitCalls.some((c) => c.args[0] === "push")).toBe(true);
+  expect(h.openPrInputs).toHaveLength(1);
+  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: "https://forge/pr/42" }]);
 });


### PR DESCRIPTION
## Problem

Doc-agent auto-PRs fail CI's `Lint (prettier + eslint)` step (`bunx prettier --check .`) — e.g. run #927 on `docs/external-task-api.md`.

**Root cause:** the scoped agent edits markdown but runs no git (by design); the trusted server then commits with `git commit --no-verify` (`publishStaged`), deliberately skipping the repo's pre-commit hook — the only thing that runs prettier (`lint-staged` → `prettier --write`). So unformatted markdown reaches the PR and the lint gate fails.

## Fix

`finalize()` now runs the **server's own pinned** prettier `--write` over the staged root `docs/*.md` files **before** `git add`, so the staged content is prettier-clean. The `--no-verify` commit is unchanged.

Key decisions (verified empirically on prettier 3.8):
- **Resolve from the server, not the target repo.** The managed repo lives under `config.repoRoot` ($HOME) and may never have been `bun install`ed (deps-less worktree → prettier would fail/silently no-op). Prettier is resolved + run from `SERVER_INSTALL_ROOT = resolve(import.meta.dir, "..")` (existing pattern at `egress.ts` / `server.ts`), which has the pinned prettier + plugins. `cwd`=server root (bare plugin names resolve), explicit binary path, `--config <worktree>/.prettierrc`.
- **docs-site is never a prettier target.** Targets are constrained to `docs/`-prefixed in-scope files; `docs-site/**` (Astro/Starlight `:::`/MDX/frontmatter) is never passed to root prettier, so it can't be mangled. The full in-scope set is still staged unchanged.
- **Best-effort but loud.** On prettier failure, `finalize()` logs a `console.warn` ("PR may fail the lint gate") and still commits/pushes/opens the PR — no worse than today, doc work is never lost.

## Tests

`test/doc-agent.test.ts` adds coverage asserting: `cwd`=`SERVER_INSTALL_ROOT` (not the worktree), `configPath`=`<worktree>/.prettierrc`, files = abs root `docs/*.md`; ordering (prettier before `git add`); regression (docs-site never targeted); failure path (throwing prettier → commit/push/openPr still happen).

Verification: `bun test ./test/doc-agent.test.ts` (42 pass / 0 fail), `bun run lint`, `bunx tsc --noEmit` all clean.

`[no-feature-entry]` — server-only plumbing fix, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)