### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -50,7 +50,7 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 | -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------- |
 | **Network bind**     | `127.0.0.1:7330` (loopback only) | Run on the same host, reach it over Tailscale serve, or set `SHEPHERD_HOST` to expose another NIC |
 | **Auth token**       | `SHEPHERD_TOKEN` unset → open    | If set, send `Authorization: Bearer <token>` on every request (timing-safe compare)               |
-| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~/Work`  | `repoPath` must resolve **inside** the root, or the request is rejected `400`                     |
+| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~` (home) | `repoPath` must resolve **inside** the root, or the request is rejected `400`                     |
 
 ### Recommended setup for a remote agent
 
@@ -70,7 +70,7 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 | `repoPath`   | string                                  | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
 | `baseBranch` | string                                  | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
 | `prompt`     | string                                  | ✅       | The task instructions; 1–8000 chars                                          |
-| `model`      | `"opus" \| "sonnet" \| "haiku" \| null` | —        | Omit/`null` = Claude's default                                               |
+| `model`      | `"fable" \| "opus" \| "opus[1m]" \| "sonnet" \| "sonnet[1m]" \| "haiku" \| null` | —        | One of `MODELS` (`src/types.ts`); omit/`null`/`"default"` = Claude's default (no `--model`) |
 | `images`     | `string[]`                              | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
 
 ### Responses


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

## Changes

- **`docs/external-task-api.md`** — two grounded fixes:
  - **`model` field enum.** The request-schema table listed only
    `"opus" | "sonnet" | "haiku" | null`. The accepted set is the `MODELS` tuple in
    `src/types.ts:143` — `["fable", "opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku"]` —
    enforced by `validateModel` (`src/validate.ts:82-87`), which also maps `null`/`"default"`
    to "no `--model`". Updated the row to the full enum and noted the `"default"` alias.
  - **Repo-confinement default.** The "What actually gates access" table claimed
    `SHEPHERD_REPO_ROOT` defaults to `~/Work`. `src/config.ts:322-325` defaults both
    `rootCeiling` and `repoRoot` to `process.env.HOME` ("defaults to `$HOME` so a fresh
    install can reach any repo"), and `docs-site/.../reference/configuration.md:17` already
    documents `~` (home). Changed the default to `~` (home) so the security framing matches
    the actual (broader) default.

## Uncertain / needs human judgment

- **`docs/external-task-api.md` request schema omits several accepted keys.** `ALLOWED_KEYS`
  in `src/validate.ts:33-46` also accepts `issueRef`, `planGateEnabled`, `autopilotEnabled`,
  `sandboxProfile`, `research`, `mergeTrainPrs`, and the transport-only `force`. The doc
  intentionally documents only the core task-submission fields; whether to surface these
  advanced/optional fields to external-agent authors is an editorial call, so I left the
  table as-is rather than guess at scope.
- **`docs-site/.../reference/configuration.md` documents a curated subset of env vars.** Its
  intro says "Every environment variable," but `src/config.ts` exposes many more knobs that
  are not in the tables (e.g. `SHEPHERD_REDUCED_PUSH_MODE` added in #903, `SHEPHERD_PUSH_COOLDOWN_MS`,
  the VAPID trio, `SHEPHERD_HOOKS_INGEST`/`_SIGNALS`, `SHEPHERD_AUTH_MODE`, `SHEPHERD_DEFAULT_MODEL`,
  `SHEPHERD_FABLE_AVAILABLE`, `SHEPHERD_USAGE_HOLD_*`, the review-cycle caps, etc.). This looks
  like a deliberate operator-facing subset rather than staleness, so I did not bulk-add rows —
  flagging in case the intent is genuinely exhaustive coverage.
- **`docs/sandbox-security.md` cites specific `src/*.ts` line numbers** (e.g.
  `src/sandbox.ts:296-299`, `~L398-399`, `src/service.ts ~L757-768`). These can silently drift
  as the source is edited. I did not re-verify every anchor line-by-line; the described
  behavior (three profiles, autonomous-keyed egress, accepted residuals R3/R4) still matches
  the current `config.ts`/`sandbox.ts` surface, so I left it unchanged.
- **`docs/token-usage-analysis.md`** is a point-in-time measurement report (a fixed sample of
  TASK-286…295). It is historical by design, not a living spec, so I treated it as not subject
  to "staleness" updates.