### PR TITLE
fix(onboarding): repoint claude-missing to rockylinux/9 + de-gate launch failures only (#926)

### DIFF
--- a/ci/onboarding-harness/incus.ts
+++ b/ci/onboarding-harness/incus.ts
@@ -1,6 +1,12 @@
 import { captureSpawn } from "./spawn";
 import type { IncusExec, IncusRunner } from "./types";
 
+/** Prefix of the error `launch()` throws when an instance fails to start (image
+ *  rot, disk-full, name-collision — all "the throw-away instance never came up",
+ *  i.e. infra, not a product regression). report.ts matches this to de-gate such
+ *  failures while keeping anything that fails AFTER launch gating. */
+export const LAUNCH_FAILURE_PREFIX = "incus launch failed: ";
+
 /** The harness's `shep-onb` Incus profile, owned in-repo so a fresh/misconfigured host
  *  self-heals. limits.memory headroom (4GiB) clears the ~2GB transient peak of claude's
  *  native installer that OOM-killed the 2GiB profile (#749). */
@@ -51,7 +57,7 @@ export class IncusDriver {
     // ("No root device could be found"). See seed.ts for the canonical list.
     for (const p of opts.profiles ?? []) args.push("--profile", p);
     const r = await this.run(args);
-    if (r.code !== 0) throw new Error(`incus launch failed: ${r.stderr || r.stdout}`);
+    if (r.code !== 0) throw new Error(`${LAUNCH_FAILURE_PREFIX}${r.stderr || r.stdout}`);
   }
 
   async exec(name: string, cmd: string[]): Promise<IncusExec> {

--- a/ci/onboarding-harness/issue.ts
+++ b/ci/onboarding-harness/issue.ts
@@ -57,6 +57,20 @@ export interface IssueOutcome {
   issueUrl: string | null;
 }
 
+/** Build the dated-comment summary naming the still-present gaps and/or harness
+ *  errors for the rolling issue's audit timeline. */
+function regressionSummary(gaps: ScenarioResult[], harnessErrors: ScenarioResult[]): string {
+  const parts: string[] = [];
+  if (gaps.length)
+    parts.push(`${gaps.length} gap(s) — ${gaps.map((g) => g.scenarioId).join(", ")}`);
+  if (harnessErrors.length) {
+    parts.push(
+      `${harnessErrors.length} harness error(s) — ${harnessErrors.map((h) => h.scenarioId).join(", ")}`,
+    );
+  }
+  return parts.join("; ");
+}
+
 /**
  * File the nightly outcome to GitHub for accountability, keeping ONE rolling
  * issue whose lifecycle mirrors the regression:
@@ -101,13 +115,7 @@ export async function reportToGitHub(
     return { summary: `opened issue: ${url}`, issueUrl: url };
   }
 
-  const gapPart = gaps.length
-    ? `${gaps.length} gap(s) — ${gaps.map((g) => g.scenarioId).join(", ")}`
-    : "";
-  const harnessPart = harnessErrors.length
-    ? `${harnessErrors.length} harness error(s) — ${harnessErrors.map((h) => h.scenarioId).join(", ")}`
-    : "";
-  const summary = [gapPart, harnessPart].filter(Boolean).join("; ");
+  const summary = regressionSummary(gaps, harnessErrors);
   const edit = await gh(["issue", "edit", String(existing.number), "--body", body]);
   if (edit.code !== 0) throw new Error(`gh issue edit failed: ${edit.stderr || edit.stdout}`);
   const comment = await gh([

--- a/ci/onboarding-harness/issue.ts
+++ b/ci/onboarding-harness/issue.ts
@@ -1,4 +1,4 @@
-import { gateGapScenarios } from "./report";
+import { gateGapScenarios, harnessErrorScenarios } from "./report";
 import { captureSpawn, type Captured } from "./spawn";
 import type { ScenarioResult } from "./types";
 
@@ -75,9 +75,10 @@ export async function reportToGitHub(
   gh: GhRunner = defaultGh,
 ): Promise<IssueOutcome> {
   const gaps = gateGapScenarios(results);
+  const harnessErrors = harnessErrorScenarios(results);
   const existing = await findOpenIssue(gh);
 
-  if (gaps.length === 0) {
+  if (gaps.length === 0 && harnessErrors.length === 0) {
     if (existing == null)
       return { summary: "clean run, no open issue — nothing to do", issueUrl: null };
     const r = await gh([
@@ -100,7 +101,13 @@ export async function reportToGitHub(
     return { summary: `opened issue: ${url}`, issueUrl: url };
   }
 
-  const scenarios = gaps.map((g) => g.scenarioId).join(", ");
+  const gapPart = gaps.length
+    ? `${gaps.length} gap(s) — ${gaps.map((g) => g.scenarioId).join(", ")}`
+    : "";
+  const harnessPart = harnessErrors.length
+    ? `${harnessErrors.length} harness error(s) — ${harnessErrors.map((h) => h.scenarioId).join(", ")}`
+    : "";
+  const summary = [gapPart, harnessPart].filter(Boolean).join("; ");
   const edit = await gh(["issue", "edit", String(existing.number), "--body", body]);
   if (edit.code !== 0) throw new Error(`gh issue edit failed: ${edit.stderr || edit.stdout}`);
   const comment = await gh([
@@ -108,7 +115,7 @@ export async function reportToGitHub(
     "comment",
     String(existing.number),
     "--body",
-    `Nightly run ${stamp}: ${gaps.length} gap(s) still present — ${scenarios}.`,
+    `Nightly run ${stamp}: ${summary}.`,
   ]);
   if (comment.code !== 0)
     throw new Error(`gh issue comment failed: ${comment.stderr || comment.stdout}`);

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -15,8 +15,9 @@ function isPreDetectionThrow(r: ScenarioResult): boolean {
  *  but still surfaced loudly (opens/keeps the rolling issue, shown in the status line)
  *  so harness rot is never silent. A pre-detection throw with any OTHER message
  *  (file-push failure, baseline crash, "Shepherd did not come up", a probe crash) is a
- *  BOOT CRASH (see classify) that DOES gate — past launch, it could be a real regression. */
-export function isHarnessError(r: ScenarioResult): boolean {
+ *  BOOT CRASH (see classify) that DOES gate — past launch, it could be a real regression.
+ *  Private: the harness consumes harnessErrorScenarios (the list form), not this predicate. */
+function isHarnessError(r: ScenarioResult): boolean {
   return isPreDetectionThrow(r) && !!r.error && r.error.startsWith(LAUNCH_FAILURE_PREFIX);
 }
 

--- a/ci/onboarding-harness/report.ts
+++ b/ci/onboarding-harness/report.ts
@@ -1,20 +1,29 @@
+import { LAUNCH_FAILURE_PREFIX } from "./incus";
 import type { ScenarioResult } from "./types";
 
-/** A scenario that THREW before its diagnostics could be evaluated — the
- *  catch-block fallback sentinel (an error paired with no detection and no
- *  recorded misses). This is an INFRASTRUCTURE failure (image-not-found, seed/boot
- *  crash), NOT a product detection gap: the instance never booted far enough to
- *  test Shepherd, so blaming detection would be a misclassification (and reads as a
- *  Shepherd onboarding defect when it's really image rot). A throw AFTER detection
- *  ran keeps its real detection result (non-empty misses or detected=true) and is
- *  classified as a normal gap instead. */
-function isHarnessError(r: ScenarioResult): boolean {
-  // install-e2e is never infra: it EXISTS to test the installer end-to-end, so a throw
-  // (install.sh non-zero, boot/probe failure) is an INSTALL regression that must gate —
-  // fail closed, never excluded as infra. (A genuinely down Incus host is handled by
-  // onboarding-gate.sh's host-unavailable bypass, not by silently dropping this scenario.)
+/** A scenario that threw BEFORE its diagnostics could be evaluated (the catch-block
+ *  sentinel: an error paired with no detection and no recorded misses). install-e2e is
+ *  never one of these — it exists to test the installer, so its throws must gate. */
+function isPreDetectionThrow(r: ScenarioResult): boolean {
   if (r.installE2E) return false;
   return !!r.error && !r.detection.detected && r.detection.misses.length === 0;
+}
+
+/** A pre-detection throw whose error is a LAUNCH failure — the instance never even
+ *  started (image rot, disk-full, name-collision). This is infrastructure, NOT a
+ *  product gap: excluded from the green tally AND de-gated (does not block a release),
+ *  but still surfaced loudly (opens/keeps the rolling issue, shown in the status line)
+ *  so harness rot is never silent. A pre-detection throw with any OTHER message
+ *  (file-push failure, baseline crash, "Shepherd did not come up", a probe crash) is a
+ *  BOOT CRASH (see classify) that DOES gate — past launch, it could be a real regression. */
+export function isHarnessError(r: ScenarioResult): boolean {
+  return isPreDetectionThrow(r) && !!r.error && r.error.startsWith(LAUNCH_FAILURE_PREFIX);
+}
+
+/** All launch-failure (infra) scenarios — used to keep them visible (issue/status)
+ *  even though they don't gate. */
+export function harnessErrorScenarios(results: ScenarioResult[]): ScenarioResult[] {
+  return results.filter(isHarnessError);
 }
 
 type Classification =
@@ -23,45 +32,59 @@ type Classification =
   | "ADVICE GAP"
   | "INSTALL GAP"
   | "DETECTION-ONLY"
-  | "HARNESS ERROR";
+  | "HARNESS ERROR"
+  | "BOOT CRASH";
 
 /** Pure: render the per-scenario outcomes as a markdown gap report. Classifies
  *  each scenario as PASS, DETECTION GAP (defect missed/misclassified), ADVICE GAP
  *  (detected but coaching didn't reach green), INSTALL GAP (the install-e2e scenario
  *  didn't reach green — an installer regression, NOT a detection failure, since it
  *  has no seeded defect), DETECTION-ONLY (detected with no apply attempted by
- *  design — e.g. claude-missing in Phase 1; NOT a gap), or HARNESS ERROR (threw
- *  before detection — infra/image-rot, not a product gap). The green tally counts
- *  only apply-able scenarios so detection-only AND harness-errored ones don't drag
- *  the denominator. */
+ *  design — e.g. claude-missing in Phase 1; NOT a gap), HARNESS ERROR (launch
+ *  failure — infra/image-rot, de-gated but visible), or BOOT CRASH (threw after
+ *  launch but before detection — gates, could be a real regression). The green tally
+ *  counts only apply-able scenarios so detection-only AND harness-errored ones don't
+ *  drag the denominator. */
 function classify(r: ScenarioResult): Classification {
   // install-e2e takes precedence over the infra check: it has no seeded defect, so a
   // miss — including a thrown install.sh/boot/probe failure — is an installer regression
   // (INSTALL GAP), never a HARNESS ERROR or a DETECTION GAP ("a defect was missed").
   if (r.installE2E) return r.reachedGreen ? "PASS" : "INSTALL GAP";
   if (isHarnessError(r)) return "HARNESS ERROR";
+  // Pre-detection throw that is NOT a launch failure: the instance launched but
+  // something past launch crashed (file-push, baseline, boot, probe). This could be a
+  // real product/harness regression, so it GATES — do NOT let it collapse into
+  // "DETECTION GAP" ("a defect was missed"), which would misinform the operator.
+  if (isPreDetectionThrow(r)) return "BOOT CRASH";
   if (r.detectionOnly) return r.detection.detected ? "DETECTION-ONLY" : "DETECTION GAP";
   if (r.reachedGreen) return "PASS";
   return r.detection.detected ? "ADVICE GAP" : "DETECTION GAP";
 }
 
 /** Gate regressions: a gate-eligible (deterministic) scenario that didn't reach
- *  green. These — and only these — drive the release verdict (status + issue).
- *  Prose/agent + detection-only scenarios are reported but never gate. */
+ *  green and is not a launch-failure harness error. These — and only these — drive
+ *  the release verdict (status + issue). Prose/agent + detection-only scenarios are
+ *  reported but never gate. Launch failures (infra) are excluded here but kept
+ *  visible via the rolling issue and status line. */
 export function gateGapScenarios(results: ScenarioResult[]): ScenarioResult[] {
-  return results.filter((r) => r.gateEligible && !r.reachedGreen);
+  return results.filter((r) => r.gateEligible && !r.reachedGreen && !isHarnessError(r));
 }
 
 /** One-line GATE outcome for a commit-status description (≤140 chars on the
  *  wire) — scoped to the deterministic subset, so an informational prose/agent
- *  gap (e.g. git-missing) doesn't flip the release verdict. */
+ *  gap (e.g. git-missing) doesn't flip the release verdict. Harness errors are
+ *  excluded from the denominator (they didn't get a fair attempt) but noted. */
 export function statusDescription(results: ScenarioResult[]): string {
-  const gate = results.filter((r) => r.gateEligible);
+  const gate = results.filter((r) => r.gateEligible && !isHarnessError(r));
   const green = gate.filter((r) => r.reachedGreen).length;
   const gaps = gateGapScenarios(results);
+  const harness = harnessErrorScenarios(results);
+  const harnessNote = harness.length
+    ? ` (${harness.length} harness error${harness.length > 1 ? "s" : ""})`
+    : "";
   return gaps.length === 0
-    ? `${green}/${gate.length} gate scenarios green`
-    : `${gaps.length} gate gap(s): ${gaps.map((g) => g.scenarioId).join(", ")}`;
+    ? `${green}/${gate.length} gate scenarios green${harnessNote}`
+    : `${gaps.length} gate gap(s): ${gaps.map((g) => g.scenarioId).join(", ")}${harnessNote}`;
 }
 
 function tableRow(r: ScenarioResult, klass: Classification): string {
@@ -70,7 +93,7 @@ function tableRow(r: ScenarioResult, klass: Classification): string {
 
 function gapEntry(
   r: ScenarioResult,
-  klass: "DETECTION GAP" | "ADVICE GAP" | "INSTALL GAP",
+  klass: "DETECTION GAP" | "ADVICE GAP" | "INSTALL GAP" | "BOOT CRASH",
 ): string {
   const misses = r.detection.misses.map((m) => `${m.id} want=${m.want} got=${m.got}`).join("; ");
   return `- **${r.scenarioId}** (${klass})${misses ? ` — ${misses}` : ""}${r.error ? ` — ${r.error}` : ""}`;
@@ -105,7 +128,12 @@ export function buildGapReport(results: ScenarioResult[]): string {
   for (const r of results) {
     const klass = classify(r);
     lines.push(tableRow(r, klass));
-    if (klass === "DETECTION GAP" || klass === "ADVICE GAP" || klass === "INSTALL GAP") {
+    if (
+      klass === "DETECTION GAP" ||
+      klass === "ADVICE GAP" ||
+      klass === "INSTALL GAP" ||
+      klass === "BOOT CRASH"
+    ) {
       gaps.push(gapEntry(r, klass));
     } else if (klass === "HARNESS ERROR") {
       errors.push(harnessErrorEntry(r));

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -8,7 +8,7 @@ import { seedInstance } from "./seed";
 import { assertUnitActive, bootShepherd, probeDiagnostics, waitForApi } from "./probe";
 import { applyAgent, applyVerbatim } from "./apply";
 import { assertDetection } from "./assert";
-import { buildGapReport, statusDescription } from "./report";
+import { buildGapReport, gateGapScenarios, statusDescription } from "./report";
 import { reportToGitHub, publishStatus } from "./issue";
 import { remediationsFor } from "../../src/remediations";
 import type { DetectionResult, Scenario, ScenarioResult } from "./types";
@@ -347,10 +347,11 @@ async function main() {
   writeFileSync(out, report);
   console.log(`\n${report}\nReport written to ${out}`);
 
-  // Verdict = the deterministic GATE subset only (structured, non-detection-only —
-  // same as onboarding-gate.sh). A prose/agent gap (git-missing) or a detection-only
-  // scenario shows in the report but never fails the run or blocks a release.
-  const gateOk = results.filter((r) => r.gateEligible).every((r) => r.reachedGreen);
+  // Release verdict = gate-eligible scenarios with a real gap; launch-failure harness
+  // errors (infra) are excluded (they stay visible via the rolling issue), so image rot
+  // never flips the gate red. Non-launch crashes (BOOT CRASH) are NOT harness errors and
+  // still gate.
+  const gateOk = gateGapScenarios(results).length === 0;
   await maybeReportRun(results, report, only, gateOk);
   process.exit(gateOk ? 0 : 1);
 }

--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -91,7 +91,7 @@ export const SCENARIOS: Scenario[] = [
     // dispatch reinstalls claude deterministically, so this IS green-able;
     // `agentIncompatible` is only the fallback if the verbatim fix were ever absent.
     id: "claude-missing",
-    image: "images:fedora/42",
+    image: "images:rockylinux/9",
     seed: ["rm -f /usr/local/bin/claude ~/.local/bin/claude"],
     expect: [{ id: "claude", state: "error" }],
     coaching: "structured",

--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -49,7 +49,7 @@ function baselineCommands(): string[] {
     // on a system path or the native build fails with "bun: not found".
     'ln -sf "$HOME/.bun/bin/bun" /usr/local/bin/bun',
     // node-pty's install is `node scripts/prebuild.js || node-gyp rebuild`. When no
-    // prebuilt binary matches the instance (arch/fedora fall through to a rebuild),
+    // prebuilt binary matches the instance (arch/rockylinux fall through to a rebuild),
     // it needs `node-gyp` — which is only a node-pty *dev*dependency, so it isn't in
     // node_modules/.bin. Install it globally + expose on PATH so the rebuild works.
     '~/.bun/bin/bun add -g node-gyp && ln -sf "$HOME/.bun/bin/node-gyp" /usr/local/bin/node-gyp',

--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -42,6 +42,9 @@ function baselineCommands(): string[] {
     // bun's installer hard-requires `unzip`; minimal images (debian/12) lack it,
     // and without it the bun install silently no-ops and Shepherd never boots.
     ensurePkg("unzip"),
+    // minimal RPM images (rockylinux/9) ship no `tar`; we extract the working-tree
+    // tarball in the next step, so tar must be present before it runs.
+    ensurePkg("tar"),
     ensureToolchain(),
     "curl -fsSL https://bun.sh/install | bash",
     // node-gyp shells out to a BARE `bun` while building node-pty; the installer

--- a/test/onboarding-harness/issue.test.ts
+++ b/test/onboarding-harness/issue.test.ts
@@ -25,6 +25,15 @@ const NON_GATE_GAP = result({
   reachedGreen: false,
   gateEligible: false,
 });
+// A gate-eligible launch-failure: de-gated (not in gateGapScenarios) but must still
+// open/keep the rolling issue so harness rot is never silent.
+const HARNESS_ERROR = result({
+  scenarioId: "fedora-git-missing",
+  reachedGreen: false,
+  gateEligible: true,
+  detection: { scenarioId: "fedora-git-missing", detected: false, misses: [] },
+  error: "incus launch failed: image couldn't be found",
+});
 
 /** Fake `gh` that records argv and replies to `issue list` with `openIssue`. */
 function fakeGh(openIssue: { number: number; url: string } | null) {
@@ -92,6 +101,31 @@ describe("reportToGitHub", () => {
     const { calls, gh } = fakeGh({ number: 42, url: "https://github.com/x/y/issues/42" });
     await reportToGitHub([PASS, NON_GATE_GAP], "REPORT", "2026-06-15", gh);
     expect(calls.some((c) => c[0] === "issue" && c[1] === "close" && c[2] === "42")).toBe(true);
+  });
+
+  it("opens the issue (or keeps it open) when the only non-green result is a launch-failure harness error", async () => {
+    // A run with no real gaps but a gate-eligible launch-failure harness error must
+    // NOT take the "clean run" close/noop branch — harness rot must stay visible.
+    // When no issue is open: opens a new issue (issue create).
+    const { calls: callsCreate, gh: ghCreate } = fakeGh(null);
+    const out = await reportToGitHub([PASS, HARNESS_ERROR], "REPORT", "2026-06-21", ghCreate);
+    expect(callsCreate.some((c) => c[0] === "issue" && c[1] === "create")).toBe(true);
+    expect(callsCreate.some((c) => c[0] === "issue" && c[1] === "close")).toBe(false);
+    expect(out.issueUrl).toBe("https://github.com/x/y/issues/99");
+
+    // When an issue is already open: keeps it open (edit + comment), does not close.
+    const { calls: callsKeep, gh: ghKeep } = fakeGh({
+      number: 42,
+      url: "https://github.com/x/y/issues/42",
+    });
+    await reportToGitHub([PASS, HARNESS_ERROR], "REPORT", "2026-06-21", ghKeep);
+    expect(callsKeep.some((c) => c[0] === "issue" && c[1] === "close")).toBe(false);
+    expect(callsKeep.some((c) => c[0] === "issue" && c[1] === "comment" && c[2] === "42")).toBe(
+      true,
+    );
+    // The comment should name the harness error scenario
+    const commentCall = callsKeep.find((c) => c[0] === "issue" && c[1] === "comment");
+    expect(commentCall?.join(" ")).toContain("harness error");
   });
 });
 

--- a/test/onboarding-harness/report.test.ts
+++ b/test/onboarding-harness/report.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { buildGapReport } from "../../ci/onboarding-harness/report";
+import {
+  buildGapReport,
+  gateGapScenarios,
+  statusDescription,
+} from "../../ci/onboarding-harness/report";
 import type { ScenarioResult } from "../../ci/onboarding-harness/types";
 
 const results: ScenarioResult[] = [
@@ -174,6 +178,87 @@ describe("buildGapReport", () => {
     expect(md).not.toContain("INSTALL GAP");
     expect(md).not.toContain("## Gaps");
     expect(md).toContain("1 / 1 scenarios reached green");
+  });
+
+  it("excludes a gate-eligible launch-failure from the gate (exact #926 shape)", () => {
+    // A gate-eligible scenario that threw with a launch failure (the #926 bug shape).
+    // Previously, gateGapScenarios returned it and flipped the gate red.
+    // Now it must be excluded: gateGapScenarios returns [].
+    const launchFail: ScenarioResult = {
+      scenarioId: "fedora-git-missing",
+      image: "images:fedora/42",
+      detection: { scenarioId: "fedora-git-missing", detected: false, misses: [] },
+      appliedVia: "skipped",
+      reachedGreen: false,
+      gateEligible: true,
+      error: "incus launch failed: image couldn't be found",
+    };
+    expect(gateGapScenarios([launchFail])).toHaveLength(0);
+  });
+
+  it("non-launch pre-detection throw (BOOT CRASH) is a gate gap that renders BOOT CRASH, not DETECTION GAP", () => {
+    // An instance that launched but crashed before detection (e.g. boot probe timeout)
+    // is NOT a harness error — it must gate. Classified as BOOT CRASH, counted in denominator.
+    const bootCrash: ScenarioResult = {
+      scenarioId: "ubuntu-bun-missing",
+      image: "images:ubuntu/24.04",
+      detection: { scenarioId: "ubuntu-bun-missing", detected: false, misses: [] },
+      appliedVia: "skipped",
+      reachedGreen: false,
+      gateEligible: true,
+      error: "Shepherd did not come up",
+    };
+    expect(gateGapScenarios([bootCrash])).toHaveLength(1);
+    const md = buildGapReport([bootCrash]);
+    expect(md).toContain("BOOT CRASH");
+    expect(md).not.toContain("DETECTION GAP");
+    // Stays in denominator: 0 / 1 reached green
+    expect(md).toContain("0 / 1 scenarios reached green");
+  });
+
+  it("any launch-failure message is de-gated (not just image-rot)", () => {
+    // A name-collision or disk-full launch failure must also be de-gated and
+    // classified as HARNESS ERROR (infra), not BOOT CRASH.
+    const nameCollision: ScenarioResult = {
+      scenarioId: "fedora-git-missing",
+      image: "images:fedora/42",
+      detection: { scenarioId: "fedora-git-missing", detected: false, misses: [] },
+      appliedVia: "skipped",
+      reachedGreen: false,
+      gateEligible: true,
+      error: "incus launch failed: name already in use",
+    };
+    expect(gateGapScenarios([nameCollision])).toHaveLength(0);
+    const md = buildGapReport([nameCollision]);
+    expect(md).toContain("HARNESS ERROR");
+    expect(md).not.toContain("BOOT CRASH");
+    expect(md).not.toContain("DETECTION GAP");
+  });
+
+  it("statusDescription excludes harness errors from denominator and appends a note", () => {
+    // One green gate scenario + one gate-eligible launch-failure harness error.
+    // statusDescription must return "1/1 gate scenarios green" (NOT "1/2") and note the harness error.
+    const greenScenario: ScenarioResult = {
+      scenarioId: "herdr-missing",
+      image: "images:archlinux",
+      detection: { scenarioId: "herdr-missing", detected: true, misses: [] },
+      appliedVia: "verbatim",
+      reachedGreen: true,
+      gateEligible: true,
+    };
+    const launchFail: ScenarioResult = {
+      scenarioId: "fedora-git-missing",
+      image: "images:fedora/42",
+      detection: { scenarioId: "fedora-git-missing", detected: false, misses: [] },
+      appliedVia: "skipped",
+      reachedGreen: false,
+      gateEligible: true,
+      error: "incus launch failed: image couldn't be found",
+    };
+    const desc = statusDescription([greenScenario, launchFail]);
+    expect(desc).toContain("1/1 gate scenarios green");
+    expect(desc).not.toContain("1/2");
+    expect(desc).toContain("harness error");
   });
 
   it("classifies a by-design no-apply scenario as DETECTION-ONLY and excludes it from the denominator", () => {

--- a/test/onboarding-harness/report.test.ts
+++ b/test/onboarding-harness/report.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   buildGapReport,
   gateGapScenarios,
+  harnessErrorScenarios,
   statusDescription,
 } from "../../ci/onboarding-harness/report";
 import type { ScenarioResult } from "../../ci/onboarding-harness/types";
@@ -259,6 +260,43 @@ describe("buildGapReport", () => {
     expect(desc).toContain("1/1 gate scenarios green");
     expect(desc).not.toContain("1/2");
     expect(desc).toContain("harness error");
+  });
+
+  it("install-e2e LAUNCH failure still gates (never de-gated as infra)", () => {
+    // installE2E=true exempts the result from isPreDetectionThrow, so a launch-failure
+    // message does NOT classify as HARNESS ERROR — it stays in the gate as INSTALL GAP.
+    const installLaunchFail: ScenarioResult = {
+      scenarioId: "install-e2e",
+      image: "images:rockylinux/9",
+      detection: { scenarioId: "install-e2e", detected: false, misses: [] },
+      appliedVia: "skipped",
+      reachedGreen: false,
+      gateEligible: true,
+      installE2E: true,
+      error: "incus launch failed: image couldn't be found",
+    };
+    expect(gateGapScenarios([installLaunchFail])).toHaveLength(1);
+    const md = buildGapReport([installLaunchFail]);
+    expect(md).toContain("INSTALL GAP");
+    expect(md).not.toContain("HARNESS ERROR");
+    expect(md).not.toContain("BOOT CRASH");
+  });
+
+  it("non-gate-eligible launch failure is visible in harnessErrorScenarios but not in gateGapScenarios", () => {
+    // gateEligible=false → gateGapScenarios excludes it; but the launch-failure shape
+    // (isPreDetectionThrow + LAUNCH_FAILURE_PREFIX) makes it a harness error, so it
+    // stays visible in harnessErrorScenarios for issue/status tracking.
+    const nonGateLaunchFail: ScenarioResult = {
+      scenarioId: "fedora-git-missing",
+      image: "images:fedora/42",
+      detection: { scenarioId: "fedora-git-missing", detected: false, misses: [] },
+      appliedVia: "skipped",
+      reachedGreen: false,
+      gateEligible: false,
+      error: "incus launch failed: name already in use",
+    };
+    expect(harnessErrorScenarios([nonGateLaunchFail])).toHaveLength(1);
+    expect(gateGapScenarios([nonGateLaunchFail])).toHaveLength(0);
   });
 
   it("classifies a by-design no-apply scenario as DETECTION-ONLY and excludes it from the denominator", () => {


### PR DESCRIPTION
Fixes #926.

## Why

The nightly onboarding harness filed #926 because the `claude-missing` scenario pinned `images:fedora/42`, and **Fedora was dropped entirely from the `images.linuxcontainers.org` incus remote** (`incus image list images: fedora` → 0 rows; only almalinux/rockylinux/centos/opensuse remain in the RPM family). The instance could no longer launch.

That launch throw is infra — `report.ts` already classifies it `HARNESS ERROR` ("infra, not a product gap") and excludes it from the green tally. But the **release-gate logic didn't honor that classification**: `gateGapScenarios` keyed on gate-eligibility alone, so pure image rot flipped the release gate red *and* opened this false "regression detected" rolling issue.

## What

**1. Repoint the rotted image** (`images:fedora/42` → `images:rockylinux/9`) — a long-lived (RHEL 9, to 2032) dnf/glibc replacement that preserves the scenario's role. The minimal Rocky 9 image ships no `tar`, so the baseline now installs it via the existing cross-distro `ensurePkg` helper.

**2. Make infra rot non-blocking but never silent** — narrow the gate-excludable predicate so it only de-gates *genuine launch failures* (the instance never even started: image-rot, disk-full, name-collision — all infra), via a single-source-of-truth `LAUNCH_FAILURE_PREFIX` shared between `incus.ts`'s throw and `report.ts`'s predicate. Anything that fails **past** launch (file-push, baseline, "Shepherd did not come up", probe crash) gets a new **`BOOT CRASH`** classification that **still gates** — it could be a real regression, so it must not be silently downgraded or mislabeled `DETECTION GAP`. Launch failures stay loud: they still open/keep the rolling issue and appear in the commit-status description.

| Result kind | Classification | Blocks release | Opens/keeps issue | In green tally |
| --- | --- | --- | --- | --- |
| Real gate gap (structured, not green) | DETECTION/ADVICE GAP | yes | yes | counted |
| **Any launch failure** (image-rot/disk-full/name-collision) | HARNESS ERROR | **no** (was: yes) | yes (kept loud) | excluded |
| **Non-launch pre-detection throw** (push/baseline/boot/probe) | **BOOT CRASH** | **yes** | yes | counted |
| install-e2e throw | INSTALL GAP | yes (fail-closed) | yes | counted |

`gateOk` (and the `onboarding-gate.sh` exit) now derives from `gateGapScenarios`, and `statusDescription` excludes harness errors from the denominator (no misleading `4/5`).

## Verification

- `bun run lint`, `bunx tsc --noEmit`, root `bun test ./test` (4251 pass), `bun test ./test/onboarding-harness` (71 pass, incl. new BOOT-CRASH / de-gate / denominator / issue-visibility / install-e2e-fail-closed locks).
- **Live end-to-end on the Incus host:** `bun run onboarding:test --scenario claude-missing` launches on `images:rockylinux/9`, the claude native installer runs on glibc 2.34, and the scenario reaches green. (The first live run before the `tar` fix correctly rendered the baseline crash as `BOOT CRASH` and gated — validating change 2 against a real failure.)

## Commits

- `repoint claude-missing to rockylinux/9` — closes the regression
- `de-gate launch failures only; BOOT CRASH for post-launch throws` — gate semantics (independently revertable)
- `install tar in baseline for rockylinux/9 minimal image`
- `lock install-e2e gate + harness-error visibility contracts` (tests)

Server/CI-only; no user-facing UI → no feature-catalog/i18n entry. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
