### PR TITLE
fix(ui): demote push sub-headings below the section label

### DIFF
--- a/ui/src/lib/components/settings/SettingsDevicePanel.svelte
+++ b/ui/src/lib/components/settings/SettingsDevicePanel.svelte
@@ -125,7 +125,7 @@
 <div class="push">
   <span class="micro">{m.settings_push_title()}</span>
   <div class="reduced-row">
-    <span class="micro">{m.settings_reduced_push_title()}</span>
+    <span class="micro sub">{m.settings_reduced_push_title()}</span>
     <p class="hint">{m.settings_reduced_push_hint()}</p>
     <button
       type="button"
@@ -152,7 +152,7 @@
     </button>
     {#if push.subscribed}
       <fieldset class="cats">
-        <legend class="micro">{m.settings_push_cat_title()}</legend>
+        <legend class="micro sub">{m.settings_push_cat_title()}</legend>
         {#if reducedPushMode}
           <p class="hint">{m.settings_reduced_push_disabled_note()}</p>
         {/if}
@@ -209,6 +209,15 @@
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
+  }
+  /* Nested sub-section headings (REDUCED NOTIFICATIONS, NOTIFY ME ABOUT) sit one
+     level below the PUSH NOTIFICATIONS section label. Demote via size + tracking
+     only — colour stays --color-muted (the AA-safe label colour, ≥4.5:1) so the
+     sub-heading reads brighter than its --color-faint hint and never regresses
+     contrast. No font-weight axis (the design system defines no weight token). */
+  .micro.sub {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
   }
   .run {
     border: 1px solid var(--color-amber);


### PR DESCRIPTION
## Problem

In **Settings → DEVICE**, the section heading `PUSH NOTIFICATIONS` and its two nested sub-headings `REDUCED NOTIFICATIONS` and `NOTIFY ME ABOUT` rendered with the **identical** shared `.micro` recipe (`--fs-meta` 11px, `0.18em` tracking, uppercase, `--color-muted`). With no visual difference, the nesting was invisible — the reported "heading weights are identical" symptom.

## Fix

Demote the two nested sub-headings one level below the section label, via **size + letter-spacing only**:

- `--fs-meta` → `--fs-micro` (11px → 10px)
- letter-spacing `0.18em` → `0.12em`
- colour **stays `--color-muted`**; **no `font-weight`** (the design system defines no weight token)

`PUSH NOTIFICATIONS` and every other top-level section label across the settings panels are left untouched, so this one section stays consistent with its siblings.

### Why `--color-muted`, not `--color-faint`

An earlier preview used `--color-faint` for the subs. This PR deliberately keeps `--color-muted` because:

1. **AA contrast** — `/design-system` documents `--color-muted` as the AA-safe label colour (≥4.5:1) and prefers it over the lower-contrast `--color-faint`. Contrast is size-independent, so muted at 10px stays AA-safe.
2. **No colour collision** — each sub-heading's hint paragraph is already `--color-faint`. Keeping the sub-heading at `--color-muted` makes it *brighter* than its hint (and it stays UPPERCASE + tracked vs the sentence-case hint), so it still reads as a heading despite being 1px smaller.

The "identical weights" complaint is resolved structurally (size + tracking + the sub/hint colour relationship), not via a weight axis.

## Scope

- One file: `ui/src/lib/components/settings/SettingsDevicePanel.svelte` — `sub` class on the two sub-headings + one `.micro.sub` rule.
- Styling-only `fix`, no new user-facing strings → no i18n / feature-catalog / glossary entry needed. `[no-feature-entry]`

## Verification

- `cd ui && bun run check` — 0 errors
- `cd ui && bun run test` — 1815 passed (incl. `SettingsDevicePanel.browser.test.ts`)
- `cd ui && bun run check:i18n` — 2 locales in parity (1708 keys)
- Structure visually approved by operator over a Tailscale preview comparison (Option A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)