### PR TITLE
feat(doc-agent): UI surface — Backlog trigger button + run/PR badge (#906)

### DIFF
--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -9,6 +9,7 @@ import type { GitForge } from "./forge/types";
 import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
 import type { SessionStore } from "./store";
+import type { DocAgentOutcome, DocAgentRun } from "./types";
 import type { SessionUsage } from "./usage";
 import { readSessionUsage } from "./usage";
 import { apiKeyPassthroughEnv, isApiKeyConfigured, isApiKeyMode } from "./spawn-auth";
@@ -123,6 +124,7 @@ export interface DocAgentFinalize {
   repoPath: string;
   /** PR url when a doc-update PR was opened; null when docs were already current. */
   url: string | null;
+  outcome: DocAgentOutcome;
 }
 
 interface InFlight {
@@ -154,6 +156,8 @@ export interface DocAgentDeps extends MembraneSeams {
     | "recordReviewerSpawn"
     | "completeReviewerSpawn"
     | "listReviewerSpawns"
+    | "recordDocAgentRun"
+    | "listDocAgentRuns"
   >;
   model?: string | null;
   /** Phase-1 escalation: when false (Phase-0 observe), finalize() is log-only (no commit/push/PR). */
@@ -232,6 +236,11 @@ export class DocAgentService {
     } finally {
       this.starting.delete(repoPath);
     }
+  }
+
+  /** Whether a doc-agent run is currently active (inflight or starting) for the given repo. */
+  isRunning(repoPath: string): boolean {
+    return this.inflight.has(repoPath) || this.starting.has(repoPath);
   }
 
   /**
@@ -496,6 +505,7 @@ export class DocAgentService {
 
   private async finalize(f: InFlight, sentinel: string | null): Promise<void> {
     let url: string | null = null;
+    let hadStagedChanges = false;
     try {
       const forge = this.deps.resolveForge(f.repoPath);
       // STRUCTURAL off-limits boundary: stage ONLY the in-scope list ∩ files that exist. An agent
@@ -529,6 +539,7 @@ export class DocAgentService {
           await this.git(f.worktreePath, ["diff", "--cached", "--name-only"])
         ).trim();
         if (stagedOut.length > 0) {
+          hadStagedChanges = true;
           url = await this.publishStaged(f, sentinel, forge, stagedOut);
         }
       }
@@ -548,7 +559,13 @@ export class DocAgentService {
         /* best-effort: a never-committed branch may already be gone */
       }
     }
-    this.deps.onChange?.({ repoPath: f.repoPath, url });
+    // Compute outcome from locals set above (after try/finally so cleanup always runs first).
+    const outcome: DocAgentOutcome =
+      url !== null ? "pr" : hadStagedChanges && !this.act ? "observe" : "nochange";
+    // Record the run in the durable per-repo history (additive alongside the cost-ledger spawn row).
+    const run: DocAgentRun = { at: this.now(), url, outcome };
+    this.deps.store.recordDocAgentRun(f.repoPath, run);
+    this.deps.onChange?.({ repoPath: f.repoPath, url, outcome });
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1505,7 +1505,10 @@ const appDeps: AppDeps = {
   optimizer,
   mergeSuggest: { mergeNow: (repoPath) => mergeSuggest.mergeNow(repoPath) },
   promoter,
-  docAgent: { consider: (repoPath: string) => docAgent.consider(repoPath) },
+  docAgent: {
+    consider: (repoPath: string) => docAgent.consider(repoPath),
+    isRunning: (repoPath: string) => docAgent.isRunning(repoPath),
+  },
   gitignoreAdopter,
   drain: {
     snapshot: () => drain.snapshot(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -308,6 +308,7 @@ export interface AppDeps {
    *  404s when the flag is off or the service is unwired. Wired to DocAgentService in index.ts. */
   docAgent?: {
     consider: (repoPath: string) => Promise<import("./doc-agent").DocAgentResult>;
+    isRunning: (repoPath: string) => boolean;
   };
   /** Open a PR adding Shepherd's managed `.shepherd-*` ignore block to a repo's `.gitignore`. */
   gitignoreAdopter?: {
@@ -901,6 +902,21 @@ async function handleDocAgent({ req, parts, url, deps }: Ctx): Promise<Response 
   if (res.status === "started") return json({ ok: true }, 202);
   if (res.status === "skipped") return json({ ok: false, reason: res.reason }, 409);
   return json({ error: res.reason ?? "doc agent failed" }, 400);
+}
+
+// GET /api/doc-agent/runs?repo= — per-repo run history + live running flag (issue #906).
+// Same unadvertised 404 contract as POST /api/doc-agent when the feature is disabled or unwired.
+function handleDocAgentRuns({ req, parts, url, deps }: Ctx): Response | null {
+  if (!(parts[0] === "api" && parts[1] === "doc-agent" && parts[2] === "runs" && !parts[3]))
+    return null;
+  if (req.method !== "GET") return null;
+  if (!config.docAgentEnabled || !deps.docAgent) return json({ error: "not found" }, 404);
+  const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
+  if (!dir) return json({ error: "invalid repo" }, 400);
+  return json({
+    running: deps.docAgent.isRunning(dir),
+    runs: deps.store.listDocAgentRuns(dir),
+  });
 }
 
 // /api/learnings — list (GET ?repo=), approve/dismiss (POST :id/action), distill (POST distill ?repo=)
@@ -2819,6 +2835,9 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       usageHoldPct: config.usageHoldPct,
       // global fable availability flag; false = fable spawns reroute to opus[1m].
       fableAvailable: config.fableAvailable,
+      // doc-agent soak flags (read-only; env-driven; no PUT patch).
+      docAgentEnabled: config.docAgentEnabled,
+      docAgentAct: config.docAgentAct,
     });
   }
   if (req.method === "PUT") {
@@ -4449,6 +4468,7 @@ const ROUTE_HANDLERS = [
   handleRepoCollaborators,
   handleLearnings,
   handleDocAgent,
+  handleDocAgentRuns,
   handlePush,
   handleSessionHooks,
   handleBuildQueue,

--- a/src/store.ts
+++ b/src/store.ts
@@ -775,6 +775,25 @@ export class SessionStore implements CapStore, CreditStore {
     );
   }
 
+  // ── doc-agent run history (capped KV JSON, newest-first) ─────────────────
+  recordDocAgentRun(repoPath: string, run: import("./types").DocAgentRun): void {
+    const key = `docagent:runs:${repoPath}`;
+    const existing = this.listDocAgentRuns(repoPath);
+    const updated = [run, ...existing].slice(0, 10);
+    this.setSetting(key, JSON.stringify(updated));
+  }
+
+  listDocAgentRuns(repoPath: string): import("./types").DocAgentRun[] {
+    const key = `docagent:runs:${repoPath}`;
+    const raw = this.getSetting(key);
+    if (!raw) return [];
+    try {
+      return JSON.parse(raw) as import("./types").DocAgentRun[];
+    } catch {
+      return [];
+    }
+  }
+
   // ── per-repo config (critic on/off) ───────────────────────────────────────
   getRepoConfig(repoPath: string): RepoConfig {
     const r = this.db

--- a/src/types.ts
+++ b/src/types.ts
@@ -362,6 +362,20 @@ export interface HerdDigest {
   staleCount?: number;
 }
 
+// ── doc-agent run history ────────────────────────────────────────────────────
+/** Outcome of a completed doc-agent run, surfaced in the UI run history. */
+export type DocAgentOutcome = "pr" | "observe" | "nochange";
+
+/** One completed doc-agent run, stored newest-first in the KV under
+ *  `docagent:runs:<repoPath>` (capped at 10). */
+export interface DocAgentRun {
+  /** epoch ms when the run finalized */
+  at: number;
+  /** PR url when a doc-update PR was opened; null otherwise */
+  url: string | null;
+  outcome: DocAgentOutcome;
+}
+
 /** Append-only, archive-decoupled record of one spawned critic/plan-gate reviewer
  *  session and its token total. Keyed by the *reviewer* session id (NOT the task) and
  *  deliberately carries no FK to `sessions`, so it outlives task archive + prune —

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -157,6 +157,26 @@ function mkHarness(opts?: {
       if (row) row.completedAt = completedAt;
     },
     listReviewerSpawns: () => spawnRows,
+    recordDocAgentRun: (repoPath: string, run: import("../src/types").DocAgentRun) => {
+      const key = `docagent:runs:${repoPath}`;
+      const existing: import("../src/types").DocAgentRun[] = (() => {
+        try {
+          return JSON.parse(kv.get(key) ?? "[]") as import("../src/types").DocAgentRun[];
+        } catch {
+          return [];
+        }
+      })();
+      kv.set(key, JSON.stringify([run, ...existing].slice(0, 10)));
+    },
+    listDocAgentRuns: (repoPath: string): import("../src/types").DocAgentRun[] => {
+      try {
+        return JSON.parse(
+          kv.get(`docagent:runs:${repoPath}`) ?? "[]",
+        ) as import("../src/types").DocAgentRun[];
+      } catch {
+        return [];
+      }
+    },
   };
   let mergeCalls = 0;
 
@@ -348,8 +368,8 @@ test("happy path: in-scope edits → commit --no-verify + push + openPr (never m
   // PR body carries the grounding summary + human-review banner
   expect((h.openPrInputs[0] as any).body).toContain("never auto-merged");
   expect((h.openPrInputs[0] as any).body).toContain("configuration.md");
-  // finalize emits the url
-  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: "https://forge/pr/42" }]);
+  // finalize emits the url + outcome
+  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: "https://forge/pr/42", outcome: "pr" }]);
   // cleanup
   expect(h.removedWorktrees.length).toBeGreaterThan(0);
 });
@@ -378,7 +398,7 @@ test("nothing staged (docs already current) → no commit/push/PR, no error", as
   expect(h.gitCalls.some((c) => c.args[0] === "commit")).toBe(false);
   expect(h.gitCalls.some((c) => c.args[0] === "push")).toBe(false);
   expect(h.openPrInputs).toHaveLength(0);
-  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: null }]);
+  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: null, outcome: "nochange" }]);
 });
 
 test("fail-closed: api-key mode without a configured key → skip, no spawn", async () => {
@@ -804,8 +824,8 @@ test("observe mode (act:false): staged changes → OBSERVE warn, NO push, NO PR,
     expect(h.gitCalls.some((c) => c.args[0] === "commit")).toBe(false);
     // worktree still cleaned up
     expect(h.removedWorktrees.length).toBeGreaterThan(0);
-    // url stays null (same shape as already-current path)
-    expect(h.finalizes).toEqual([{ repoPath: "/repo", url: null }]);
+    // url stays null; observe outcome because staged changes existed but act:false
+    expect(h.finalizes).toEqual([{ repoPath: "/repo", url: null, outcome: "observe" }]);
     // the OBSERVE line fired
     expect(warns.some((w) => w.includes("[doc-agent] OBSERVE:"))).toBe(true);
   } finally {
@@ -913,5 +933,48 @@ test("prettier failure path: throwing prettier stub still results in commit + pu
   );
   expect(h.gitCalls.some((c) => c.args[0] === "push")).toBe(true);
   expect(h.openPrInputs).toHaveLength(1);
-  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: "https://forge/pr/42" }]);
+  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: "https://forge/pr/42", outcome: "pr" }]);
+});
+
+// ── outcome tracking (issue #906) ────────────────────────────────────────────
+test("finalize: act + staged changes → outcome 'pr', onChange carries it, run recorded", async () => {
+  const h = mkHarness({ act: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  expect(h.finalizes).toHaveLength(1);
+  expect(h.finalizes[0]).toEqual({ repoPath: "/repo", url: "https://forge/pr/42", outcome: "pr" });
+  const runs = h.kv.get("docagent:runs:/repo");
+  expect(runs).toBeDefined();
+  const parsed = JSON.parse(runs!) as { outcome: string; url: string | null; at: number }[];
+  expect(parsed).toHaveLength(1);
+  expect(parsed[0]!.outcome).toBe("pr");
+  expect(parsed[0]!.url).toBe("https://forge/pr/42");
+});
+
+test("finalize: observe (act:false) + staged changes → outcome 'observe', url null", async () => {
+  const orig = console.warn;
+  console.warn = () => {};
+  try {
+    const h = mkHarness({ act: false });
+    await h.svc.consider("/repo");
+    await h.svc.tick();
+    expect(h.finalizes).toHaveLength(1);
+    expect(h.finalizes[0]).toEqual({ repoPath: "/repo", url: null, outcome: "observe" });
+    const runs = h.kv.get("docagent:runs:/repo");
+    const parsed = JSON.parse(runs!) as { outcome: string }[];
+    expect(parsed[0]!.outcome).toBe("observe");
+  } finally {
+    console.warn = orig;
+  }
+});
+
+test("finalize: no staged changes → outcome 'nochange', url null", async () => {
+  const h = mkHarness({ stagedNames: "" });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  expect(h.finalizes).toHaveLength(1);
+  expect(h.finalizes[0]).toEqual({ repoPath: "/repo", url: null, outcome: "nochange" });
+  const runs = h.kv.get("docagent:runs:/repo");
+  const parsed = JSON.parse(runs!) as { outcome: string }[];
+  expect(parsed[0]!.outcome).toBe("nochange");
 });

--- a/test/server-doc-agent.test.ts
+++ b/test/server-doc-agent.test.ts
@@ -6,6 +6,7 @@ import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
 import { config } from "../src/config";
 import type { DocAgentResult } from "../src/doc-agent";
+import type { DocAgentRun } from "../src/types";
 
 let tmpRoot: string;
 let repoDir: string;
@@ -25,23 +26,40 @@ function withFlag(on: boolean, fn: () => Promise<void>): Promise<void> {
   });
 }
 
-function harness(consider?: (repoPath: string) => Promise<DocAgentResult>) {
+function harness(
+  consider?: (repoPath: string) => Promise<DocAgentResult>,
+  opts?: { isRunning?: (repoPath: string) => boolean; runs?: DocAgentRun[] },
+) {
   const store = new SessionStore(":memory:");
+  if (opts?.runs?.length) {
+    // pre-seed runs for the given repoDir
+    for (const run of [...opts.runs].reverse()) {
+      store.recordDocAgentRun(repoDir, run);
+    }
+  }
   const deps: AppDeps = {
     store,
     service: {} as any,
     events: new EventHub(),
     usageLimits: { limits: () => ({}) } as any,
-    docAgent: consider ? { consider } : undefined,
+    docAgent: consider
+      ? {
+          consider,
+          isRunning: opts?.isRunning ?? (() => false),
+        }
+      : undefined,
   };
-  return makeApp(deps);
+  return { app: makeApp(deps), store };
 }
 
 const repoUrl = (repo: string) => `http://x/api/doc-agent?repo=${encodeURIComponent(repo)}`;
+const runsUrl = (repo: string) => `http://x/api/doc-agent/runs?repo=${encodeURIComponent(repo)}`;
+
+// ── existing POST tests ──────────────────────────────────────────────────────
 
 test("flag OFF → 404 (endpoint unadvertised) even when wired", async () => {
   await withFlag(false, async () => {
-    const app = harness(async () => ({ status: "started" }));
+    const { app } = harness(async () => ({ status: "started" }));
     const res = await app.fetch(new Request(repoUrl(repoDir), { method: "POST" }));
     expect(res.status).toBe(404);
   });
@@ -49,7 +67,7 @@ test("flag OFF → 404 (endpoint unadvertised) even when wired", async () => {
 
 test("flag ON but service unwired → 404", async () => {
   await withFlag(true, async () => {
-    const app = harness(undefined);
+    const { app } = harness(undefined);
     const res = await app.fetch(new Request(repoUrl(repoDir), { method: "POST" }));
     expect(res.status).toBe(404);
   });
@@ -58,7 +76,7 @@ test("flag ON but service unwired → 404", async () => {
 test("flag ON + started → 202", async () => {
   await withFlag(true, async () => {
     let calledWith = "";
-    const app = harness(async (r) => {
+    const { app } = harness(async (r) => {
       calledWith = r;
       return { status: "started" };
     });
@@ -70,7 +88,7 @@ test("flag ON + started → 202", async () => {
 
 test("flag ON + skipped → 409", async () => {
   await withFlag(true, async () => {
-    const app = harness(async () => ({ status: "skipped", reason: "already running" }));
+    const { app } = harness(async () => ({ status: "skipped", reason: "already running" }));
     const res = await app.fetch(new Request(repoUrl(repoDir), { method: "POST" }));
     expect(res.status).toBe(409);
   });
@@ -78,7 +96,7 @@ test("flag ON + skipped → 409", async () => {
 
 test("flag ON + error → 400", async () => {
   await withFlag(true, async () => {
-    const app = harness(async () => ({ status: "error", reason: "no forge" }));
+    const { app } = harness(async () => ({ status: "error", reason: "no forge" }));
     const res = await app.fetch(new Request(repoUrl(repoDir), { method: "POST" }));
     expect(res.status).toBe(400);
   });
@@ -87,7 +105,7 @@ test("flag ON + error → 400", async () => {
 test("flag ON + invalid/missing repo → 400, consider not called", async () => {
   await withFlag(true, async () => {
     let called = false;
-    const app = harness(async () => {
+    const { app } = harness(async () => {
       called = true;
       return { status: "started" };
     });
@@ -99,8 +117,66 @@ test("flag ON + invalid/missing repo → 400, consider not called", async () => 
 
 test("GET is not handled (POST-only trigger)", async () => {
   await withFlag(true, async () => {
-    const app = harness(async () => ({ status: "started" }));
+    const { app } = harness(async () => ({ status: "started" }));
     const res = await app.fetch(new Request(repoUrl(repoDir), { method: "GET" }));
     expect(res.status).toBe(404);
+  });
+});
+
+// ── GET /api/doc-agent/runs tests ────────────────────────────────────────────
+
+test("runs: flag OFF → 404", async () => {
+  await withFlag(false, async () => {
+    const { app } = harness(async () => ({ status: "started" }));
+    const res = await app.fetch(new Request(runsUrl(repoDir), { method: "GET" }));
+    expect(res.status).toBe(404);
+  });
+});
+
+test("runs: flag ON but service unwired → 404", async () => {
+  await withFlag(true, async () => {
+    const { app } = harness(undefined);
+    const res = await app.fetch(new Request(runsUrl(repoDir), { method: "GET" }));
+    expect(res.status).toBe(404);
+  });
+});
+
+test("runs: flag ON + bad/missing repo → 400", async () => {
+  await withFlag(true, async () => {
+    const { app } = harness(async () => ({ status: "started" }));
+    const res = await app.fetch(new Request("http://x/api/doc-agent/runs", { method: "GET" }));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid repo");
+  });
+});
+
+test("runs: flag ON + valid repo → {running, runs}", async () => {
+  const seededRuns: DocAgentRun[] = [
+    { at: 2000, url: "https://forge/pr/1", outcome: "pr" },
+    { at: 1000, url: null, outcome: "nochange" },
+  ];
+  await withFlag(true, async () => {
+    const { app } = harness(async () => ({ status: "started" }), {
+      isRunning: () => false,
+      runs: seededRuns,
+    });
+    const res = await app.fetch(new Request(runsUrl(repoDir), { method: "GET" }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { running: boolean; runs: DocAgentRun[] };
+    expect(body.running).toBe(false);
+    expect(body.runs).toHaveLength(2);
+    expect(body.runs[0]!.outcome).toBe("pr");
+  });
+});
+
+test("runs: isRunning=true reflected in response", async () => {
+  await withFlag(true, async () => {
+    const { app } = harness(async () => ({ status: "started" }), { isRunning: () => true });
+    const res = await app.fetch(new Request(runsUrl(repoDir), { method: "GET" }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { running: boolean; runs: DocAgentRun[] };
+    expect(body.running).toBe(true);
+    expect(body.runs).toEqual([]);
   });
 });

--- a/test/store-doc-agent.test.ts
+++ b/test/store-doc-agent.test.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import type { DocAgentRun } from "../src/types";
+
+function mk() {
+  return new SessionStore(":memory:");
+}
+
+const run1: DocAgentRun = { at: 1000, url: "https://forge/pr/1", outcome: "pr" };
+const run2: DocAgentRun = { at: 2000, url: null, outcome: "observe" };
+const run3: DocAgentRun = { at: 3000, url: null, outcome: "nochange" };
+
+test("listDocAgentRuns returns [] for unknown repo", () => {
+  const s = mk();
+  expect(s.listDocAgentRuns("/no/such/repo")).toEqual([]);
+});
+
+test("listDocAgentRuns returns [] on corrupt stored value", () => {
+  const s = mk();
+  s.setSetting("docagent:runs:/repo", "not-valid-json{{{");
+  expect(s.listDocAgentRuns("/repo")).toEqual([]);
+});
+
+test("recordDocAgentRun prepends newest-first", () => {
+  const s = mk();
+  s.recordDocAgentRun("/repo", run1);
+  s.recordDocAgentRun("/repo", run2);
+  s.recordDocAgentRun("/repo", run3);
+  // newest first: run3 → run2 → run1
+  expect(s.listDocAgentRuns("/repo")).toEqual([run3, run2, run1]);
+});
+
+test("recordDocAgentRun caps at 10 most recent", () => {
+  const s = mk();
+  for (let i = 1; i <= 12; i++) {
+    s.recordDocAgentRun("/repo", { at: i * 100, url: null, outcome: "nochange" });
+  }
+  const runs = s.listDocAgentRuns("/repo");
+  expect(runs).toHaveLength(10);
+  // newest (i=12, at=1200) is first; oldest kept is i=3 (at=300)
+  expect(runs[0]!.at).toBe(1200);
+  expect(runs[9]!.at).toBe(300);
+});
+
+test("recordDocAgentRun is repo-isolated", () => {
+  const s = mk();
+  s.recordDocAgentRun("/repo-a", run1);
+  s.recordDocAgentRun("/repo-b", run2);
+  expect(s.listDocAgentRuns("/repo-a")).toEqual([run1]);
+  expect(s.listDocAgentRuns("/repo-b")).toEqual([run2]);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1732,5 +1732,7 @@
   "docagent_history_pr_link": "PR",
   "docagent_observe_note": "Beobachtungsmodus — Läufe protokollieren Änderungen, öffnen jedoch keine PR",
   "docagent_trigger_skipped": "Doc-Agent wurde nicht gestartet (läuft bereits oder nichts zu tun)",
-  "docagent_trigger_failed": "Doc-Agent konnte nicht gestartet werden"
+  "docagent_trigger_failed": "Doc-Agent konnte nicht gestartet werden",
+  "feat_doc_agent_ui_title": "Doc-Agent im Backlog",
+  "feat_doc_agent_ui_body": "Starte den PR-gesicherten Doc-Agent für ein Repo direkt aus der Backlog-Aktionsleiste. Ein Status-Badge verfolgt den Lauf und verlinkt die geöffnete Doku-Update-PR; ein Popover zeigt die letzten Läufe. Aktivierung über SHEPHERD_DOC_AGENT."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1720,5 +1720,17 @@
   "docagent_toast_pr_opened": "{repo}: Doku-Update-PR geöffnet",
   "docagent_toast_no_changes": "{repo}: Doku ist bereits aktuell",
   "docagent_toast_observe": "{repo}: Doc-Agent-Beobachtungslauf — keine PR geöffnet",
-  "docagent_toast_view_pr": "PR ansehen"
+  "docagent_toast_view_pr": "PR ansehen",
+  "docagent_button_label": "Doc-Agent",
+  "docagent_button_title": "Doku dieses Repos aktualisieren — öffnet eine PR zur Überprüfung",
+  "docagent_status_running": "läuft",
+  "docagent_status_pr": "PR geöffnet",
+  "docagent_status_observe": "Beobachtung",
+  "docagent_status_nochange": "keine Änderungen",
+  "docagent_history_heading": "Letzte Doc-Agent-Läufe",
+  "docagent_history_empty": "Noch keine Läufe",
+  "docagent_history_pr_link": "PR",
+  "docagent_observe_note": "Beobachtungsmodus — Läufe protokollieren Änderungen, öffnen jedoch keine PR",
+  "docagent_trigger_skipped": "Doc-Agent wurde nicht gestartet (läuft bereits oder nichts zu tun)",
+  "docagent_trigger_failed": "Doc-Agent konnte nicht gestartet werden"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1707,7 +1707,7 @@
   "issue_filter_button_aria": "Issue-Filter, {count} aktiv",
   "issue_filter_heading": "Issues filtern",
   "feat_issue_filters_menu_title": "Issue-Filter in einem Menü gebündelt",
-  "feat_issue_filters_menu_body": "Die Issue-Listen im Backlog und in „Neue Aufgabe“ bündeln ihre Filter — meine & nicht zugewiesen, in Arbeit ausblenden, Unteraufgaben ausblenden — jetzt in einem einzigen Filters-Menü mit Aktivzähler-Badge, statt als Chip-Reihe.",
+  "feat_issue_filters_menu_body": "Die Issue-Listen im Backlog und in „Neue Aufgabe” bündeln ihre Filter — meine & nicht zugewiesen, in Arbeit ausblenden, Unteraufgaben ausblenden — jetzt in einem einzigen Filters-Menü mit Aktivzähler-Badge, statt als Chip-Reihe.",
   "learnings_trial_badge": "Test",
   "learnings_trial_title": "Automatisch bei starker Evidenz aktiviert — auf Probe bis es sich bewährt; wird mit niedrigster Priorität eingefügt und bei schlechter Leistung automatisch entfernt.",
   "learnings_revert_trial": "Zurücksetzen",
@@ -1716,5 +1716,9 @@
   "gloss_trial_term": "Test",
   "gloss_trial_def": "Eine vorgeschlagene Hausregel, die bei starker, quellenübergreifender Evidenz automatisch aktiviert wird, mit niedrigster Priorität eingefügt wird und sich bewähren muss. Sie wird automatisch entfernt, wenn sie zu wenig bringt (Wilson-Auto-Retire) oder inaktiv bleibt, und kann manuell in die Warteschlange zurückgesetzt werden.",
   "feat_learnings_auto_trial_title": "Auto-Test für starke Lernregeln",
-  "feat_learnings_auto_trial_body": "Starke, wiederkehrende Regelvorschläge werden jetzt automatisch als aktiver [[trial|Test]] eingesetzt, anstatt in der manuellen Genehmigungswarteschlange zu warten — und schlecht performende Tests werden automatisch entfernt. Tests werden mit einem Badge markiert und können mit einem Klick in der Lernschublade zurückgesetzt werden."
+  "feat_learnings_auto_trial_body": "Starke, wiederkehrende Regelvorschläge werden jetzt automatisch als aktiver [[trial|Test]] eingesetzt, anstatt in der manuellen Genehmigungswarteschlange zu warten — und schlecht performende Tests werden automatisch entfernt. Tests werden mit einem Badge markiert und können mit einem Klick in der Lernschublade zurückgesetzt werden.",
+  "docagent_toast_pr_opened": "{repo}: Doku-Update-PR geöffnet",
+  "docagent_toast_no_changes": "{repo}: Doku ist bereits aktuell",
+  "docagent_toast_observe": "{repo}: Doc-Agent-Beobachtungslauf — keine PR geöffnet",
+  "docagent_toast_view_pr": "PR ansehen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1732,5 +1732,7 @@
   "docagent_history_pr_link": "PR",
   "docagent_observe_note": "Observe mode — runs log changes but open no PR",
   "docagent_trigger_skipped": "Doc agent didn't start (already running or nothing to do)",
-  "docagent_trigger_failed": "Couldn't start the doc agent"
+  "docagent_trigger_failed": "Couldn't start the doc agent",
+  "feat_doc_agent_ui_title": "Doc agent in the Backlog",
+  "feat_doc_agent_ui_body": "Trigger the PR-gated doc agent for a repo from the Backlog Actions bar. A status badge tracks the run and links the doc-update PR it opens; a popover shows recent runs. Opt-in via SHEPHERD_DOC_AGENT."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1716,5 +1716,9 @@
   "gloss_trial_term": "trial",
   "gloss_trial_def": "A proposed house rule auto-promoted to active on strong, multi-source evidence, injected at lowest priority while it proves itself. It is auto-removed if it underperforms (Wilson auto-retire) or stays inert, and can be reverted to the queue by hand.",
   "feat_learnings_auto_trial_title": "Auto-trial for strong learnings",
-  "feat_learnings_auto_trial_body": "Strong, recurring rule proposals now auto-promote to an active [[trial|trial]] instead of waiting in the manual approval queue — and underperforming trials are removed automatically. Trials are badged and one-click revertible in the learnings drawer."
+  "feat_learnings_auto_trial_body": "Strong, recurring rule proposals now auto-promote to an active [[trial|trial]] instead of waiting in the manual approval queue — and underperforming trials are removed automatically. Trials are badged and one-click revertible in the learnings drawer.",
+  "docagent_toast_pr_opened": "{repo}: doc-update PR opened",
+  "docagent_toast_no_changes": "{repo}: docs already current",
+  "docagent_toast_observe": "{repo}: doc-agent observe run — no PR opened",
+  "docagent_toast_view_pr": "View PR"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1720,5 +1720,17 @@
   "docagent_toast_pr_opened": "{repo}: doc-update PR opened",
   "docagent_toast_no_changes": "{repo}: docs already current",
   "docagent_toast_observe": "{repo}: doc-agent observe run — no PR opened",
-  "docagent_toast_view_pr": "View PR"
+  "docagent_toast_view_pr": "View PR",
+  "docagent_button_label": "Doc agent",
+  "docagent_button_title": "Update this repo's docs — opens a PR for review",
+  "docagent_status_running": "running",
+  "docagent_status_pr": "PR opened",
+  "docagent_status_observe": "observe",
+  "docagent_status_nochange": "no changes",
+  "docagent_history_heading": "Recent doc-agent runs",
+  "docagent_history_empty": "No runs yet",
+  "docagent_history_pr_link": "PR",
+  "docagent_observe_note": "Observe mode — runs log changes but open no PR",
+  "docagent_trigger_skipped": "Doc agent didn't start (already running or nothing to do)",
+  "docagent_trigger_failed": "Couldn't start the doc agent"
 }

--- a/ui/src/lib/api.docAgent.test.ts
+++ b/ui/src/lib/api.docAgent.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { triggerDocAgent, getDocAgentRuns } from "./api";
+
+function mockFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn(
+    async () => new Response(JSON.stringify(body), { status }),
+  ) as unknown as typeof fetch;
+}
+
+describe("triggerDocAgent", () => {
+  it("POSTs to /api/doc-agent with the encoded repoPath and returns started:true on 202", async () => {
+    const calls: { url?: string; method?: string }[] = [];
+    globalThis.fetch = vi.fn(async (url: unknown, init?: { method?: string }) => {
+      calls.push({ url: String(url), method: init?.method });
+      return new Response(JSON.stringify({ ok: true }), { status: 202 });
+    }) as unknown as typeof fetch;
+    const result = await triggerDocAgent("/repos/my project");
+    expect(result).toEqual({ started: true });
+    expect(calls[0]!.url).toBe("/api/doc-agent?repo=%2Frepos%2Fmy%20project");
+    expect(calls[0]!.method).toBe("POST");
+  });
+
+  it("returns started:false with reason on 409 (already running / skipped)", async () => {
+    globalThis.fetch = mockFetch(409, { ok: false, reason: "already_running" });
+    const result = await triggerDocAgent("/repos/my-project");
+    expect(result).toEqual({ started: false, reason: "already_running" });
+  });
+
+  it("throws on 404 (feature disabled)", async () => {
+    globalThis.fetch = mockFetch(404, { error: "not found" });
+    await expect(triggerDocAgent("/repos/my-project")).rejects.toThrow();
+  });
+
+  it("throws on 400 (bad request)", async () => {
+    globalThis.fetch = mockFetch(400, { error: "missing repo" });
+    await expect(triggerDocAgent("/repos/my-project")).rejects.toThrow();
+  });
+});
+
+describe("getDocAgentRuns", () => {
+  it("GETs /api/doc-agent/runs with the encoded repoPath", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      calls.push(String(url));
+      return new Response(JSON.stringify({ running: false, runs: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+    await getDocAgentRuns("/repos/my project");
+    expect(calls[0]).toBe("/api/doc-agent/runs?repo=%2Frepos%2Fmy%20project");
+  });
+
+  it("returns parsed running + runs on 200", async () => {
+    const payload = {
+      running: true,
+      runs: [{ at: 1000, url: "https://github.com/x/y/pull/1", outcome: "pr" }],
+    };
+    globalThis.fetch = mockFetch(200, payload);
+    const result = await getDocAgentRuns("/repos/my-project");
+    expect(result.running).toBe(true);
+    expect(result.runs).toHaveLength(1);
+    expect(result.runs[0]!.outcome).toBe("pr");
+  });
+
+  it("throws on non-2xx (feature disabled = 404)", async () => {
+    globalThis.fetch = mockFetch(404, { error: "not found" });
+    await expect(getDocAgentRuns("/repos/my-project")).rejects.toThrow();
+  });
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -53,6 +53,7 @@ import type {
   HerdDigest,
   DistillerHealth,
   RawAnswer,
+  DocAgentRun,
 } from "./types";
 import { m } from "$lib/paraglide/messages";
 
@@ -1529,4 +1530,29 @@ export async function ackEpicMigrations(
     { repo: repoPath, parent },
     "acknowledge epic migrations",
   );
+}
+
+/** Manually trigger the PR-gated doc agent for a repo. 202 → started; 409 → skipped
+ *  (with the server's reason); other non-2xx throws. */
+export async function triggerDocAgent(
+  repoPath: string,
+): Promise<{ started: boolean; reason?: string }> {
+  const r = await fetch(`/api/doc-agent?repo=${encodeURIComponent(repoPath)}`, {
+    method: "POST",
+    headers: JSON_HEADERS,
+  });
+  if (r.status === 202) return { started: true };
+  if (r.status === 409) {
+    const body = await r.json().catch(() => ({}) as Record<string, unknown>);
+    return { started: false, reason: body.reason as string };
+  }
+  throw await failed(r, "doc agent");
+}
+
+export async function getDocAgentRuns(
+  repoPath: string,
+): Promise<{ running: boolean; runs: DocAgentRun[] }> {
+  const r = await fetch(`/api/doc-agent/runs?repo=${encodeURIComponent(repoPath)}`);
+  if (!r.ok) throw await failed(r, "doc agent runs");
+  return r.json() as Promise<{ running: boolean; runs: DocAgentRun[] }>;
 }

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -104,7 +104,8 @@
 
   // When a run finishes for the shown repo, refresh to pick up the result.
   $effect(() => {
-    if (docAgentDone && docAgentDone.repoPath === selectedPath) {
+    const done = docAgentDone;
+    if (done && done.repoPath === untrack(() => selectedPath)) {
       void refreshDocAgentRuns();
     }
   });

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -1,7 +1,18 @@
 <script lang="ts">
   import { untrack } from "svelte";
-  import type { BacklogPayload, DrainStatus, Epic, Issue, PullRequest, Steer } from "$lib/types";
+  import type {
+    BacklogPayload,
+    DocAgentOutcome,
+    DocAgentRun,
+    DrainStatus,
+    Epic,
+    Issue,
+    PullRequest,
+    Steer,
+  } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { toasts } from "$lib/toasts.svelte";
+  import { triggerDocAgent, getDocAgentRuns } from "$lib/api";
   import ProjectBacklogList from "./ProjectBacklogList.svelte";
   import BacklogTabBar from "./backlog-view/BacklogTabBar.svelte";
   import BacklogTabContent from "./backlog-view/BacklogTabContent.svelte";
@@ -21,6 +32,9 @@
     inTrainPrs = new Set(),
     target = null,
     drain = undefined,
+    docAgentEnabled = false,
+    docAgentAct = false,
+    docAgentDone = null,
   }: {
     payload: BacklogPayload | null;
     mobile: boolean;
@@ -48,11 +62,66 @@
     /** Live drain status keyed by repoPath (store.drain), forwarded to the
      *  Automation tab so its epic banner + drain-cap reflect reality without a task. */
     drain?: Record<string, DrainStatus>;
+    /** Whether the doc-agent feature is enabled for this repo. */
+    docAgentEnabled?: boolean;
+    /** True = act/PR phase; false = observe-only phase. */
+    docAgentAct?: boolean;
+    /** Reactive signal from store: a run just finished for a repo. */
+    docAgentDone?: { repoPath: string; url: string | null; outcome: DocAgentOutcome } | null;
   } = $props();
 
   type Tab = "issues" | "prs" | "actions" | "readiness" | "automation";
   let activeTab = $state<Tab>("issues");
   let ffInFlight = $state(false);
+
+  // ── doc-agent state ──────────────────────────────────────────────────────────
+  let docAgentRunning = $state(false);
+  let docAgentRuns = $state<DocAgentRun[]>([]);
+
+  async function refreshDocAgentRuns() {
+    if (!docAgentEnabled || !selectedPath) return;
+    const path = selectedPath;
+    try {
+      const r = await getDocAgentRuns(path);
+      if (selectedPath === path) {
+        docAgentRunning = r.running;
+        docAgentRuns = r.runs;
+      }
+    } catch {
+      // best-effort display — swallow errors
+    }
+  }
+
+  // Re-fetch when repo selection or feature flag changes.
+  $effect(() => {
+    if (!docAgentEnabled || !selectedPath) {
+      docAgentRunning = false;
+      docAgentRuns = [];
+      return;
+    }
+    void refreshDocAgentRuns();
+  });
+
+  // When a run finishes for the shown repo, refresh to pick up the result.
+  $effect(() => {
+    if (docAgentDone && docAgentDone.repoPath === selectedPath) {
+      void refreshDocAgentRuns();
+    }
+  });
+
+  async function handleDocAgent() {
+    if (!selectedPath || docAgentRunning) return;
+    docAgentRunning = true; // optimistic
+    try {
+      const res = await triggerDocAgent(selectedPath);
+      if (!res.started) toasts.info(m.docagent_trigger_skipped());
+    } catch {
+      toasts.info(m.docagent_trigger_failed());
+    } finally {
+      await refreshDocAgentRuns();
+    }
+  }
+  // ────────────────────────────────────────────────────────────────────────────
 
   async function handleFf() {
     if (!selectedPath || ffInFlight) return;
@@ -200,8 +269,13 @@
             {actionsState}
             {ffInFlight}
             {selectedPath}
+            {docAgentEnabled}
+            {docAgentAct}
+            {docAgentRunning}
+            {docAgentRuns}
             onselecttab={(t) => (activeTab = t)}
             onff={handleFf}
+            ondocagent={handleDocAgent}
           />
         </div>
         <div class="overlay-body">
@@ -249,8 +323,13 @@
           {actionsState}
           {ffInFlight}
           {selectedPath}
+          {docAgentEnabled}
+          {docAgentAct}
+          {docAgentRunning}
+          {docAgentRuns}
           onselecttab={(t) => (activeTab = t)}
           onff={handleFf}
+          ondocagent={handleDocAgent}
         />
         <div class="detail-pane">
           {#if selectedPath !== null}

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -27,6 +27,10 @@
     onpr,
     onadopt,
     onlaunchtrain,
+    // `flow` is consumed by the `class:flow` directive on the root element below; fallow's
+    // prop-usage analyzer doesn't see Svelte `class:` shorthand, so it false-positives here
+    // (pre-existing main-wide finding surfaced by this branch's pre-push audit).
+    // fallow-ignore-next-line unused-component-props
     flow = false,
     epics = undefined,
     inTrainPrs = new Set(),

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -70,6 +70,8 @@ function settings(over: Partial<SettingsPayload> = {}): SettingsPayload {
     usageHoldPct: 90,
     fableAvailable: true,
     reducedPushMode: false,
+    docAgentEnabled: false,
+    docAgentAct: true,
     ...over,
   };
 }

--- a/ui/src/lib/components/backlog-view/BacklogTabBar.svelte
+++ b/ui/src/lib/components/backlog-view/BacklogTabBar.svelte
@@ -115,40 +115,34 @@
         coach={variant === "desktop"}
         ontrigger={ondocagent}
       />
-      <button
-        class="gbtn ff-btn"
-        type="button"
-        disabled={ffInFlight || selectedPath === null}
-        onclick={onff}
-        title={m.backlog_ff_main_title()}
-        aria-label={m.backlog_ff_main_title()}
-        use:coachMaybe={variant === "desktop" ? "backlog-ff-main" : undefined}
-      >
-        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-          <path d="M1 2.5L5.5 6 1 9.5V2.5Z" fill="currentColor" />
-          <path d="M6.5 2.5L11 6 6.5 9.5V2.5Z" fill="currentColor" />
-        </svg>
-        {m.backlog_ff_main()}
-      </button>
+      {@render ffButton(false)}
     </div>
   {:else}
-    <button
-      class="gbtn ff-btn ff-btn-solo"
-      type="button"
-      disabled={ffInFlight || selectedPath === null}
-      onclick={onff}
-      title={m.backlog_ff_main_title()}
-      aria-label={m.backlog_ff_main_title()}
-      use:coachMaybe={variant === "desktop" ? "backlog-ff-main" : undefined}
-    >
-      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-        <path d="M1 2.5L5.5 6 1 9.5V2.5Z" fill="currentColor" />
-        <path d="M6.5 2.5L11 6 6.5 9.5V2.5Z" fill="currentColor" />
-      </svg>
-      {m.backlog_ff_main()}
-    </button>
+    {@render ffButton(true)}
   {/if}
 </div>
+
+<!-- Fast-forward button, shared by both branches above. `solo` (no doc-agent) makes
+     it claim the right margin itself; in the cluster the wrapper owns the margin. Only
+     one branch renders, so there's a single instance + a single coach anchor. -->
+{#snippet ffButton(solo: boolean)}
+  <button
+    class="gbtn ff-btn"
+    class:ff-btn-solo={solo}
+    type="button"
+    disabled={ffInFlight || selectedPath === null}
+    onclick={onff}
+    title={m.backlog_ff_main_title()}
+    aria-label={m.backlog_ff_main_title()}
+    use:coachMaybe={variant === "desktop" ? "backlog-ff-main" : undefined}
+  >
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+      <path d="M1 2.5L5.5 6 1 9.5V2.5Z" fill="currentColor" />
+      <path d="M6.5 2.5L11 6 6.5 9.5V2.5Z" fill="currentColor" />
+    </svg>
+    {m.backlog_ff_main()}
+  </button>
+{/snippet}
 
 <style>
   /* ── tab bar (desktop) ── */

--- a/ui/src/lib/components/backlog-view/BacklogTabBar.svelte
+++ b/ui/src/lib/components/backlog-view/BacklogTabBar.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import type { BacklogProject } from "$lib/types";
+  import type { BacklogProject, DocAgentRun } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import type { ActionsTabState } from "../backlog-view";
+  import DocAgentControl from "./DocAgentControl.svelte";
 
   type Tab = "issues" | "prs" | "actions" | "readiness" | "automation";
 
@@ -17,8 +18,13 @@
     actionsState,
     ffInFlight,
     selectedPath,
+    docAgentEnabled = false,
+    docAgentAct = false,
+    docAgentRunning = false,
+    docAgentRuns = [],
     onselecttab,
     onff,
+    ondocagent = () => {},
   }: {
     variant: "desktop" | "mobile";
     activeTab: Tab;
@@ -26,8 +32,13 @@
     actionsState: ActionsTabState;
     ffInFlight: boolean;
     selectedPath: string | null;
+    docAgentEnabled?: boolean;
+    docAgentAct?: boolean;
+    docAgentRunning?: boolean;
+    docAgentRuns?: DocAgentRun[];
     onselecttab: (tab: Tab) => void;
     onff: () => void;
+    ondocagent?: () => void;
   } = $props();
 
   // coachTarget only on the desktop variant — preserves the pre-split behavior
@@ -93,21 +104,50 @@
   >
     {m.backlog_tab_automation()}
   </button>
-  <button
-    class="gbtn ff-btn"
-    type="button"
-    disabled={ffInFlight || selectedPath === null}
-    onclick={onff}
-    title={m.backlog_ff_main_title()}
-    aria-label={m.backlog_ff_main_title()}
-    use:coachMaybe={variant === "desktop" ? "backlog-ff-main" : undefined}
-  >
-    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-      <path d="M1 2.5L5.5 6 1 9.5V2.5Z" fill="currentColor" />
-      <path d="M6.5 2.5L11 6 6.5 9.5V2.5Z" fill="currentColor" />
-    </svg>
-    {m.backlog_ff_main()}
-  </button>
+  {#if docAgentEnabled}
+    <!-- Doc-agent control + FF button in a right-aligned cluster -->
+    <div class="action-cluster">
+      <DocAgentControl
+        act={docAgentAct}
+        running={docAgentRunning}
+        runs={docAgentRuns}
+        disabled={selectedPath === null}
+        coach={variant === "desktop"}
+        ontrigger={ondocagent}
+      />
+      <button
+        class="gbtn ff-btn"
+        type="button"
+        disabled={ffInFlight || selectedPath === null}
+        onclick={onff}
+        title={m.backlog_ff_main_title()}
+        aria-label={m.backlog_ff_main_title()}
+        use:coachMaybe={variant === "desktop" ? "backlog-ff-main" : undefined}
+      >
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+          <path d="M1 2.5L5.5 6 1 9.5V2.5Z" fill="currentColor" />
+          <path d="M6.5 2.5L11 6 6.5 9.5V2.5Z" fill="currentColor" />
+        </svg>
+        {m.backlog_ff_main()}
+      </button>
+    </div>
+  {:else}
+    <button
+      class="gbtn ff-btn ff-btn-solo"
+      type="button"
+      disabled={ffInFlight || selectedPath === null}
+      onclick={onff}
+      title={m.backlog_ff_main_title()}
+      aria-label={m.backlog_ff_main_title()}
+      use:coachMaybe={variant === "desktop" ? "backlog-ff-main" : undefined}
+    >
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+        <path d="M1 2.5L5.5 6 1 9.5V2.5Z" fill="currentColor" />
+        <path d="M6.5 2.5L11 6 6.5 9.5V2.5Z" fill="currentColor" />
+      </svg>
+      {m.backlog_ff_main()}
+    </button>
+  {/if}
 </div>
 
 <style>
@@ -187,12 +227,25 @@
   }
 
   .ff-btn {
-    margin-left: auto;
     display: inline-flex;
     align-items: center;
     gap: 4px;
     flex-shrink: 0;
     white-space: nowrap;
+  }
+
+  /* Standalone ff-btn (no doc-agent) claims the auto margin itself. */
+  .ff-btn-solo {
+    margin-left: auto;
+  }
+
+  /* When doc-agent is enabled, cluster owns margin-left:auto so both controls push right. */
+  .action-cluster {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
   }
 
   /* ── tab strip (mobile overlay) ──

--- a/ui/src/lib/components/backlog-view/DocAgentControl.browser.test.ts
+++ b/ui/src/lib/components/backlog-view/DocAgentControl.browser.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import "../../../app.css";
+import { m } from "$lib/paraglide/messages";
+import type { DocAgentRun } from "$lib/types";
+
+const { default: DocAgentControl } = await import("./DocAgentControl.svelte");
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+// Helpers
+const triggerBtn = () =>
+  [...document.querySelectorAll("button")].find((b) =>
+    b.textContent?.includes(m.docagent_button_label()),
+  ) as HTMLButtonElement | null;
+
+const badgeBtn = () =>
+  document.querySelector("button[aria-haspopup='dialog']") as HTMLButtonElement | null;
+
+const isPopoverOpen = () => badgeBtn()?.getAttribute("aria-expanded") === "true";
+
+const popoverEl = () => document.querySelector("[popover].da-popover") as HTMLElement | null;
+
+const defaultProps = {
+  act: true,
+  running: false,
+  runs: [] as DocAgentRun[],
+  disabled: false,
+  coach: false,
+  ontrigger: () => {},
+};
+
+describe("DocAgentControl", () => {
+  it("renders the trigger button", async () => {
+    render(DocAgentControl, { ...defaultProps });
+    await expect.poll(() => triggerBtn()).toBeTruthy();
+    expect(triggerBtn()!.textContent).toContain(m.docagent_button_label());
+  });
+
+  it("fires ontrigger when trigger button is clicked", async () => {
+    let fired = false;
+    render(DocAgentControl, {
+      ...defaultProps,
+      ontrigger: () => {
+        fired = true;
+      },
+    });
+    await expect.poll(() => triggerBtn()).toBeTruthy();
+    triggerBtn()!.click();
+    await expect.poll(() => fired).toBe(true);
+  });
+
+  it("trigger is disabled when disabled=true", async () => {
+    render(DocAgentControl, { ...defaultProps, disabled: true });
+    await expect.poll(() => triggerBtn()).toBeTruthy();
+    expect(triggerBtn()!.disabled).toBe(true);
+  });
+
+  it("trigger is disabled when running=true", async () => {
+    render(DocAgentControl, { ...defaultProps, running: true });
+    await expect.poll(() => triggerBtn()).toBeTruthy();
+    expect(triggerBtn()!.disabled).toBe(true);
+  });
+
+  it("badge is absent when running=false and runs is empty", async () => {
+    render(DocAgentControl, { ...defaultProps });
+    await expect.poll(() => triggerBtn()).toBeTruthy();
+    expect(badgeBtn()).toBeNull();
+  });
+
+  it("badge appears with 'running' label when running=true", async () => {
+    render(DocAgentControl, { ...defaultProps, running: true });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    expect(badgeBtn()!.textContent?.trim()).toBe(m.docagent_status_running());
+  });
+
+  it("badge shows 'PR opened' label for a pr outcome run", async () => {
+    const runs: DocAgentRun[] = [
+      {
+        at: Date.now() - 60000,
+        url: "https://github.com/foo/bar/pull/42",
+        outcome: "pr",
+      },
+    ];
+    render(DocAgentControl, { ...defaultProps, runs });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    expect(badgeBtn()!.textContent?.trim()).toBe(m.docagent_status_pr());
+  });
+
+  it("badge shows 'observe' label for an observe outcome run", async () => {
+    const runs: DocAgentRun[] = [{ at: Date.now() - 60000, url: null, outcome: "observe" }];
+    render(DocAgentControl, { ...defaultProps, runs });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    expect(badgeBtn()!.textContent?.trim()).toBe(m.docagent_status_observe());
+  });
+
+  it("badge shows 'no changes' label for a nochange outcome run", async () => {
+    const runs: DocAgentRun[] = [{ at: Date.now() - 60000, url: null, outcome: "nochange" }];
+    render(DocAgentControl, { ...defaultProps, runs });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    expect(badgeBtn()!.textContent?.trim()).toBe(m.docagent_status_nochange());
+  });
+
+  it("clicking badge opens history popover", async () => {
+    const runs: DocAgentRun[] = [
+      {
+        at: Date.now() - 60000,
+        url: "https://github.com/foo/bar/pull/42",
+        outcome: "pr",
+      },
+    ];
+    render(DocAgentControl, { ...defaultProps, runs });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    expect(isPopoverOpen()).toBe(false);
+    badgeBtn()!.click();
+    await expect.poll(() => isPopoverOpen()).toBe(true);
+  });
+
+  it("popover shows PR link for a pr outcome run with url", async () => {
+    const runs: DocAgentRun[] = [
+      {
+        at: Date.now() - 60000,
+        url: "https://github.com/foo/bar/pull/42",
+        outcome: "pr",
+      },
+    ];
+    render(DocAgentControl, { ...defaultProps, runs });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    badgeBtn()!.click();
+    await expect.poll(() => isPopoverOpen()).toBe(true);
+    const link = popoverEl()?.querySelector("a.run-link") as HTMLAnchorElement | null;
+    expect(link).toBeTruthy();
+    expect(link!.textContent?.trim()).toBe("#42");
+    expect(link!.href).toContain("/pull/42");
+  });
+
+  it("popover shows heading and empty state when no runs", async () => {
+    // Open with running=true so badge exists; runs is empty
+    render(DocAgentControl, { ...defaultProps, running: true });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    badgeBtn()!.click();
+    await expect.poll(() => isPopoverOpen()).toBe(true);
+    expect(popoverEl()?.textContent).toContain(m.docagent_history_heading());
+    expect(popoverEl()?.textContent).toContain(m.docagent_history_empty());
+  });
+
+  it("Esc closes the popover", async () => {
+    const runs: DocAgentRun[] = [{ at: Date.now() - 60000, url: null, outcome: "observe" }];
+    render(DocAgentControl, { ...defaultProps, runs });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    badgeBtn()!.click();
+    await expect.poll(() => isPopoverOpen()).toBe(true);
+    // Wait for dismiss listener to register (setTimeout(0) in effect)
+    await new Promise((r) => setTimeout(r, 50));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await expect.poll(() => isPopoverOpen()).toBe(false);
+  });
+
+  it("outside pointerdown closes the popover", async () => {
+    const runs: DocAgentRun[] = [{ at: Date.now() - 60000, url: null, outcome: "nochange" }];
+    render(DocAgentControl, { ...defaultProps, runs });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    badgeBtn()!.click();
+    await expect.poll(() => isPopoverOpen()).toBe(true);
+    await new Promise((r) => setTimeout(r, 50));
+    document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    await expect.poll(() => isPopoverOpen()).toBe(false);
+  });
+
+  it("observe note shown when act=false and popover open", async () => {
+    const runs: DocAgentRun[] = [{ at: Date.now() - 60000, url: null, outcome: "observe" }];
+    render(DocAgentControl, { ...defaultProps, act: false, runs });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    badgeBtn()!.click();
+    await expect.poll(() => isPopoverOpen()).toBe(true);
+    expect(popoverEl()?.textContent).toContain(m.docagent_observe_note());
+  });
+
+  it("observe note NOT shown when act=true", async () => {
+    const runs: DocAgentRun[] = [{ at: Date.now() - 60000, url: null, outcome: "pr" }];
+    render(DocAgentControl, { ...defaultProps, act: true, runs });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    badgeBtn()!.click();
+    await expect.poll(() => isPopoverOpen()).toBe(true);
+    expect(popoverEl()?.textContent).not.toContain(m.docagent_observe_note());
+  });
+});

--- a/ui/src/lib/components/backlog-view/DocAgentControl.svelte
+++ b/ui/src/lib/components/backlog-view/DocAgentControl.svelte
@@ -1,0 +1,370 @@
+<script lang="ts">
+  import type { DocAgentRun } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { anchorPopover } from "$lib/floating-anchor";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import { formatAgo } from "$lib/format";
+  import { clock } from "$lib/now.svelte";
+
+  let {
+    act,
+    running,
+    runs,
+    disabled,
+    coach,
+    ontrigger,
+  }: {
+    act: boolean;
+    running: boolean;
+    runs: DocAgentRun[];
+    disabled: boolean;
+    coach: boolean;
+    ontrigger: () => void;
+  } = $props();
+
+  // SSR-stable per-instance id for aria-controls wiring.
+  const popoverId = $props.id();
+
+  let open = $state(false);
+  let wasOpen = false;
+  let badgeBtnEl = $state<HTMLButtonElement | null>(null);
+  let popEl = $state<HTMLDivElement | null>(null);
+
+  const showBadge = $derived(running || runs.length > 0);
+
+  // Badge label + color variant
+  const badgeLabel = $derived(
+    running
+      ? m.docagent_status_running()
+      : runs[0]?.outcome === "pr"
+        ? m.docagent_status_pr()
+        : runs[0]?.outcome === "observe"
+          ? m.docagent_status_observe()
+          : m.docagent_status_nochange(),
+  );
+
+  const badgeVariant = $derived(running ? "running" : runs[0]?.outcome === "pr" ? "pr" : "muted");
+
+  // Position the popover below the badge whenever open + both elements exist.
+  $effect(() => {
+    if (!open || !badgeBtnEl || !popEl) return;
+    try {
+      popEl.showPopover();
+    } catch {
+      return;
+    }
+    return anchorPopover(badgeBtnEl, popEl, 6, "bottom");
+  });
+
+  // Dismiss on Esc + outside pointerdown.
+  $effect(() => {
+    if (!open) return;
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        open = false;
+      }
+    }
+    function onPointerdown(e: PointerEvent) {
+      if (
+        popEl &&
+        !popEl.contains(e.target as Node) &&
+        badgeBtnEl &&
+        !badgeBtnEl.contains(e.target as Node)
+      ) {
+        open = false;
+      }
+    }
+    const tid = setTimeout(() => {
+      window.addEventListener("keydown", onKeydown);
+      window.addEventListener("pointerdown", onPointerdown);
+    }, 0);
+    return () => {
+      clearTimeout(tid);
+      window.removeEventListener("keydown", onKeydown);
+      window.removeEventListener("pointerdown", onPointerdown);
+    };
+  });
+
+  // Focus management: restore trigger on close.
+  $effect(() => {
+    if (typeof window === "undefined") return;
+    if (open) {
+      wasOpen = true;
+    } else if (wasOpen) {
+      badgeBtnEl?.focus();
+    }
+  });
+
+  function prNumber(url: string): string | null {
+    return url.match(/\/(\d+)(?:[/?#]|$)/)?.[1] ?? null;
+  }
+
+  function outcomeLabel(outcome: DocAgentRun["outcome"]): string {
+    if (outcome === "pr") return m.docagent_status_pr();
+    if (outcome === "observe") return m.docagent_status_observe();
+    return m.docagent_status_nochange();
+  }
+</script>
+
+<div class="doc-agent-control">
+  <!-- Trigger button -->
+  <button
+    class="gbtn da-btn"
+    type="button"
+    disabled={disabled || running}
+    onclick={ontrigger}
+    title={m.docagent_button_title()}
+    aria-label={m.docagent_button_title()}
+    use:coachTarget={coach ? "doc-agent-trigger" : ""}
+  >
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+      <rect
+        x="1"
+        y="1"
+        width="10"
+        height="10"
+        rx="1"
+        stroke="currentColor"
+        stroke-width="1.2"
+        fill="none"
+      />
+      <line x1="3" y1="4" x2="9" y2="4" stroke="currentColor" stroke-width="1.1" />
+      <line x1="3" y1="6.5" x2="9" y2="6.5" stroke="currentColor" stroke-width="1.1" />
+      <line x1="3" y1="9" x2="6.5" y2="9" stroke="currentColor" stroke-width="1.1" />
+    </svg>
+    {m.docagent_button_label()}
+  </button>
+
+  <!-- Status badge (only when running or runs exist) -->
+  {#if showBadge}
+    <button
+      bind:this={badgeBtnEl}
+      class={["status-badge", badgeVariant]}
+      type="button"
+      aria-haspopup="dialog"
+      aria-expanded={open}
+      aria-controls={popoverId}
+      onclick={() => (open = !open)}
+    >
+      {badgeLabel}
+    </button>
+  {/if}
+</div>
+
+<!-- History popover — non-modal anchored popover, no scrim (see CLAUDE.md) -->
+<div
+  id={popoverId}
+  bind:this={popEl}
+  class="da-popover"
+  role="dialog"
+  aria-label={m.docagent_history_heading()}
+  popover="manual"
+>
+  <div class="pop-head">{m.docagent_history_heading()}</div>
+  {#if runs.length === 0}
+    <div class="pop-empty">{m.docagent_history_empty()}</div>
+  {:else}
+    <ul class="run-list">
+      {#each runs as run (run.at)}
+        <li class="run-row">
+          <span class="run-time">{formatAgo(clock.current - run.at)}</span>
+          <span class="run-outcome">{outcomeLabel(run.outcome)}</span>
+          {#if run.url}
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL, not an app route -->
+            <a class="run-link" href={run.url} target="_blank" rel="noopener">
+              #{prNumber(run.url) ?? m.docagent_history_pr_link()}
+            </a>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+  {#if !act}
+    <div class="pop-note">{m.docagent_observe_note()}</div>
+  {/if}
+</div>
+
+<style>
+  .doc-agent-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
+  /* Trigger button — mirrors .ff-btn / .gbtn in BacklogTabBar */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .da-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    white-space: nowrap;
+  }
+
+  /* Status badge — micro-badge recipe */
+  .status-badge {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 1px 6px;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    background: transparent;
+    color: var(--color-muted);
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+    transition:
+      color 0.12s,
+      border-color 0.12s;
+  }
+  .status-badge:hover {
+    border-color: var(--color-line-bright);
+    color: var(--color-ink);
+  }
+  .status-badge:focus-visible {
+    outline: 2px solid var(--color-line-bright);
+    outline-offset: 2px;
+  }
+
+  /* Running state — amber pulse (merge-pulse defined globally in app.css) */
+  .status-badge.running {
+    color: var(--color-amber);
+    border-color: color-mix(in srgb, var(--color-amber) 45%, transparent);
+    animation: merge-pulse 1.5s ease-in-out infinite;
+  }
+
+  /* PR opened state — green */
+  .status-badge.pr {
+    color: var(--color-green);
+    border-color: color-mix(in srgb, var(--color-green) 45%, transparent);
+  }
+
+  /* History popover surface — mirrors .filter-popover from IssueFilterPopover */
+  [popover].da-popover {
+    position: fixed;
+    inset: auto;
+    margin: 0;
+    min-width: 260px;
+    max-width: min(340px, 90vw);
+    padding: 0;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    color: var(--color-ink);
+    font: inherit;
+    font-size: var(--fs-meta);
+    line-height: 1.5;
+  }
+
+  @keyframes popover-in {
+    from {
+      opacity: 0;
+      transform: translateY(3px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  [popover].da-popover:popover-open {
+    animation: popover-in 120ms ease-out;
+  }
+
+  .pop-head {
+    padding: 7px 12px 6px;
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    border-bottom: 1px solid var(--color-line);
+  }
+
+  .pop-empty {
+    padding: 10px 12px;
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+  }
+
+  .run-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+  }
+
+  .run-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 12px;
+    font-size: var(--fs-meta);
+  }
+
+  .run-row:hover {
+    background: var(--color-surface);
+  }
+
+  .run-time {
+    color: var(--color-muted);
+    flex-shrink: 0;
+    min-width: 6ch;
+  }
+
+  .run-outcome {
+    color: var(--color-ink);
+    flex: 1;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .run-link {
+    color: var(--color-accent);
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    text-decoration: none;
+    flex-shrink: 0;
+  }
+  .run-link:hover {
+    text-decoration: underline;
+  }
+
+  .pop-note {
+    padding: 6px 12px 8px;
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+    border-top: 1px solid var(--color-line);
+    line-height: 1.4;
+  }
+</style>

--- a/ui/src/lib/components/backlog-view/DocAgentControl.svelte
+++ b/ui/src/lib/components/backlog-view/DocAgentControl.svelte
@@ -256,11 +256,14 @@
     outline-offset: 2px;
   }
 
-  /* Running state — amber pulse (merge-pulse defined globally in app.css) */
+  /* Running state — amber pulse (merge-pulse defined globally in app.css). No
+     !important: the badge TEXT ("running") carries the state, so the pulse is
+     decorative reinforcement and must yield to the app.css prefers-reduced-motion
+     guard (matches the sibling .badge.merging in PrRow.svelte). */
   .status-badge.running {
     color: var(--color-amber);
     border-color: color-mix(in srgb, var(--color-amber) 45%, transparent);
-    animation: merge-pulse 1.5s ease-in-out infinite !important;
+    animation: merge-pulse 1.5s ease-in-out infinite;
   }
 
   /* PR opened state — green */

--- a/ui/src/lib/components/backlog-view/DocAgentControl.svelte
+++ b/ui/src/lib/components/backlog-view/DocAgentControl.svelte
@@ -260,7 +260,7 @@
   .status-badge.running {
     color: var(--color-amber);
     border-color: color-mix(in srgb, var(--color-amber) 45%, transparent);
-    animation: merge-pulse 1.5s ease-in-out infinite;
+    animation: merge-pulse 1.5s ease-in-out infinite !important;
   }
 
   /* PR opened state — green */

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1356,4 +1356,16 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_learnings_auto_trial_title",
     bodyKey: "feat_learnings_auto_trial_body",
   },
+  {
+    // Doc-agent UI surface (#906, epic #875 P3): a per-repo Backlog trigger button +
+    // run/PR status badge + brief run-history popover for the PR-gated doc agent.
+    // targetId "doc-agent-trigger" matches use:coachTarget on the DocAgentControl button
+    // (desktop). Opt-in (SHEPHERD_DOC_AGENT) so the anchor is absent when disabled.
+    // v1.35.0 is the latest released tag → ships in 1.36.0.
+    id: "doc-agent-ui",
+    sinceVersion: "1.36.0",
+    titleKey: "feat_doc_agent_ui_title",
+    bodyKey: "feat_doc_agent_ui_body",
+    targetId: "doc-agent-trigger",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -829,3 +829,84 @@ test("seedCompletedEpics replaces the array", () => {
   expect(s.completedEpics).toHaveLength(2);
   expect(s.completedEpics[0].parentIssueNumber).toBe(7);
 });
+
+// ── doc-agent:done ────────────────────────────────────────────────────────────
+// Each test uses a unique repoPath to avoid key-dedup collisions on the shared
+// toasts singleton (resetting toasts.items doesn't clear its #keyed Map).
+
+test("doc-agent:done sets docAgentDone but fires no toast when docAgentEnabled=false", () => {
+  toasts.items = [];
+  const s = new HerdStore();
+  s.docAgentEnabled = false;
+  s.apply({
+    event: "doc-agent:done",
+    data: { repoPath: "/repos/da-disabled", url: null, outcome: "nochange" },
+  });
+  expect(s.docAgentDone?.repoPath).toBe("/repos/da-disabled");
+  expect(s.docAgentDone?.outcome).toBe("nochange");
+  expect(toasts.items).toHaveLength(0);
+});
+
+test("doc-agent:done outcome=pr fires a toast with view-PR action when url present", () => {
+  toasts.items = [];
+  const s = new HerdStore();
+  s.docAgentEnabled = true;
+  s.apply({
+    event: "doc-agent:done",
+    data: { repoPath: "/repos/da-pr-url", url: "https://github.com/x/y/pull/1", outcome: "pr" },
+  });
+  const t = toasts.items.find((x) => x.key === "doc-agent-done:/repos/da-pr-url");
+  expect(t).toBeDefined();
+  expect(t?.text).toContain("da-pr-url");
+  expect(t?.actionLabel).toBeDefined();
+});
+
+test("doc-agent:done outcome=pr with null url fires toast without action", () => {
+  toasts.items = [];
+  const s = new HerdStore();
+  s.docAgentEnabled = true;
+  s.apply({
+    event: "doc-agent:done",
+    data: { repoPath: "/repos/da-pr-nourl", url: null, outcome: "pr" },
+  });
+  const t = toasts.items.find((x) => x.key === "doc-agent-done:/repos/da-pr-nourl");
+  expect(t).toBeDefined();
+  expect(t?.actionLabel).toBeUndefined();
+});
+
+test("doc-agent:done outcome=observe fires keyed toast", () => {
+  toasts.items = [];
+  const s = new HerdStore();
+  s.docAgentEnabled = true;
+  s.apply({
+    event: "doc-agent:done",
+    data: { repoPath: "/repos/da-observe", url: null, outcome: "observe" },
+  });
+  expect(toasts.items.some((x) => x.key === "doc-agent-done:/repos/da-observe")).toBe(true);
+});
+
+test("doc-agent:done outcome=nochange fires keyed toast", () => {
+  toasts.items = [];
+  const s = new HerdStore();
+  s.docAgentEnabled = true;
+  s.apply({
+    event: "doc-agent:done",
+    data: { repoPath: "/repos/da-nochange", url: null, outcome: "nochange" },
+  });
+  expect(toasts.items.some((x) => x.key === "doc-agent-done:/repos/da-nochange")).toBe(true);
+});
+
+test("doc-agent:done dedupes repeated events for the same repo (same key)", () => {
+  toasts.items = [];
+  const s = new HerdStore();
+  s.docAgentEnabled = true;
+  s.apply({
+    event: "doc-agent:done",
+    data: { repoPath: "/repos/da-dedup", url: null, outcome: "nochange" },
+  });
+  s.apply({
+    event: "doc-agent:done",
+    data: { repoPath: "/repos/da-dedup", url: null, outcome: "nochange" },
+  });
+  expect(toasts.items.filter((x) => x.key === "doc-agent-done:/repos/da-dedup")).toHaveLength(1);
+});

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -447,12 +447,47 @@ export class HerdStore {
     return true;
   }
 
+  /** Handle the epic lifecycle WS events (update / completed / completed-cleared).
+   *  Split out of applyGlobalEvent so its dispatch switch stays under the complexity
+   *  gate (mirrors applyHerdrUpdateEvent / applyDocAgentEvent). Returns true if handled. */
+  private applyEpicEvent(ev: WsEvent): boolean {
+    switch (ev.event) {
+      case "epic:update":
+        this.setEpic(ev.data);
+        return true;
+      case "epic:completed": {
+        const key = `${ev.data.repoPath}#${ev.data.parentIssueNumber}`;
+        const filtered = this.completedEpics.filter(
+          (e) => `${e.repoPath}#${e.parentIssueNumber}` !== key,
+        );
+        this.completedEpics = [ev.data, ...filtered];
+        toasts.info(
+          m.completed_epic_toast({
+            number: ev.data.parentIssueNumber,
+            count: ev.data.children.length,
+          }),
+          { key: `epic-complete:${ev.data.repoPath}#${ev.data.parentIssueNumber}` },
+        );
+        return true;
+      }
+      case "epic:completed-cleared":
+        this.completedEpics = this.completedEpics.filter(
+          (e) =>
+            e.repoPath !== ev.data.repoPath || e.parentIssueNumber !== ev.data.parentIssueNumber,
+        );
+        return true;
+      default:
+        return false;
+    }
+  }
+
   /** Handle the app-global (non per-session-row) WS events: usage limits, the
    *  self/herdr update channels, project icons, learnings, backlog + drain.
    *  Split out of apply() so its dispatch switch stays under the complexity gate. */
   private applyGlobalEvent(ev: WsEvent) {
     if (this.applyHerdrUpdateEvent(ev)) return;
     if (this.applyDocAgentEvent(ev)) return;
+    if (this.applyEpicEvent(ev)) return;
     switch (ev.event) {
       case "usage:limits":
         this.usageLimits = ev.data;
@@ -487,30 +522,6 @@ export class HerdStore {
       case "queue:update":
         this.buildQueues = { ...this.buildQueues, [ev.data.sessionId]: ev.data };
         buildQueuesStore.upsert(ev.data);
-        break;
-      case "epic:update":
-        this.setEpic(ev.data);
-        break;
-      case "epic:completed": {
-        const key = `${ev.data.repoPath}#${ev.data.parentIssueNumber}`;
-        const filtered = this.completedEpics.filter(
-          (e) => `${e.repoPath}#${e.parentIssueNumber}` !== key,
-        );
-        this.completedEpics = [ev.data, ...filtered];
-        toasts.info(
-          m.completed_epic_toast({
-            number: ev.data.parentIssueNumber,
-            count: ev.data.children.length,
-          }),
-          { key: `epic-complete:${ev.data.repoPath}#${ev.data.parentIssueNumber}` },
-        );
-        break;
-      }
-      case "epic:completed-cleared":
-        this.completedEpics = this.completedEpics.filter(
-          (e) =>
-            e.repoPath !== ev.data.repoPath || e.parentIssueNumber !== ev.data.parentIssueNumber,
-        );
         break;
       case "held:changed":
         this.heldCount = ev.data.count;

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -18,6 +18,7 @@ import type {
   BuildQueue,
   Epic,
   CompletedEpic,
+  DocAgentOutcome,
 } from "./types";
 import type { BlockState } from "./triage";
 import { projectIcons } from "./projectIcons.svelte";
@@ -102,6 +103,12 @@ export class HerdStore {
   /** Completed-epic records (newest first); bootstrapped via GET /api/epics/completed,
    *  kept live by the `epic:completed` / `epic:completed-cleared` WS events. */
   completedEpics = $state<CompletedEpic[]>([]);
+  /** Whether the PR-gated doc agent feature is enabled; set from loadSettings(). Gates the doc-agent toast. */
+  docAgentEnabled = $state(false);
+  /** Reactive signal set on each `doc-agent:done` WS event; Task 3 components watch this to re-fetch runs. */
+  docAgentDone = $state<{ repoPath: string; url: string | null; outcome: DocAgentOutcome } | null>(
+    null,
+  );
   /** true once the user has confirmed an update; cleared by the reload it triggers */
   updating = $state(false);
   /** SHA we booted on; a different `current` after an update means a fresh build is live */
@@ -411,11 +418,41 @@ export class HerdStore {
     }
   }
 
+  /** Handle the `doc-agent:done` WS event. Sets the reactive `docAgentDone` signal and,
+   *  when `docAgentEnabled` is true, fires an outcome-keyed toast. Returns true if handled. */
+  private applyDocAgentEvent(ev: WsEvent): boolean {
+    if (ev.event !== "doc-agent:done") return false;
+    this.docAgentDone = ev.data;
+    if (!this.docAgentEnabled) return true;
+    const repo = ev.data.repoPath.split("/").pop() ?? ev.data.repoPath;
+    const key = `doc-agent-done:${ev.data.repoPath}`;
+    if (ev.data.outcome === "pr") {
+      const url = ev.data.url;
+      toasts.info(m.docagent_toast_pr_opened({ repo }), {
+        key,
+        ...(url != null
+          ? {
+              action: {
+                label: m.docagent_toast_view_pr(),
+                run: () => window.open(url, "_blank", "noopener"),
+              },
+            }
+          : {}),
+      });
+    } else if (ev.data.outcome === "observe") {
+      toasts.info(m.docagent_toast_observe({ repo }), { key });
+    } else {
+      toasts.info(m.docagent_toast_no_changes({ repo }), { key });
+    }
+    return true;
+  }
+
   /** Handle the app-global (non per-session-row) WS events: usage limits, the
    *  self/herdr update channels, project icons, learnings, backlog + drain.
    *  Split out of apply() so its dispatch switch stays under the complexity gate. */
   private applyGlobalEvent(ev: WsEvent) {
     if (this.applyHerdrUpdateEvent(ev)) return;
+    if (this.applyDocAgentEvent(ev)) return;
     switch (ev.event) {
       case "usage:limits":
         this.usageLimits = ev.data;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -74,6 +74,10 @@ export interface Settings {
   fableAvailable: boolean;
   /** Global reduced-notifications mode: when on, only the ready-after-5s push (+ usage/credit alerts) is sent. */
   reducedPushMode: boolean;
+  /** Whether the PR-gated doc agent feature is enabled. */
+  docAgentEnabled: boolean;
+  /** Whether the doc agent runs in observe-only mode (no PR opened). */
+  docAgentAct: boolean;
 }
 
 export interface DirEntry {
@@ -855,6 +859,13 @@ export interface DiagnosticsSnapshot {
   overall: DiagnosticState;
 }
 
+export type DocAgentOutcome = "pr" | "observe" | "nochange";
+export interface DocAgentRun {
+  at: number;
+  url: string | null;
+  outcome: DocAgentOutcome;
+}
+
 export type WsEvent =
   | { event: "session:new"; data: Session }
   | { event: "session:status"; data: { id: string; status: SessionStatus } }
@@ -922,7 +933,11 @@ export type WsEvent =
   | { event: "epic:completed"; data: CompletedEpic }
   | { event: "epic:completed-cleared"; data: { repoPath: string; parentIssueNumber: number } }
   | { event: "session:egress-drop"; data: { id: string; host: string } }
-  | { event: "held:changed"; data: { count: number } };
+  | { event: "held:changed"; data: { count: number } }
+  | {
+      event: "doc-agent:done";
+      data: { repoPath: string; url: string | null; outcome: DocAgentOutcome };
+    };
 
 /** Optional override bag for relaunch; absent fields inherit the original session. */
 export interface RelaunchOverrides {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -413,6 +413,7 @@
         settings = s;
         usageHoldEnabled = s.usageHoldEnabled;
         usageHoldPct = s.usageHoldPct;
+        store.docAgentEnabled = s.docAgentEnabled;
         // One-shot: loadSettings() also re-fires on tab return, so the eligibility
         // flag is consumed and `seen` re-checked here — a dismissed (or already-seen)
         // arrival must never reappear. See resolveFableArrival.

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1723,6 +1723,9 @@
               epics={store.epics}
               {inTrainPrs}
               drain={store.drain}
+              docAgentEnabled={settings?.docAgentEnabled ?? false}
+              docAgentAct={settings?.docAgentAct ?? false}
+              docAgentDone={store.docAgentDone}
             />
           {/if}
         </div>
@@ -1886,6 +1889,9 @@
             epics={store.epics}
             {inTrainPrs}
             drain={store.drain}
+            docAgentEnabled={settings?.docAgentEnabled ?? false}
+            docAgentAct={settings?.docAgentAct ?? false}
+            docAgentDone={store.docAgentDone}
           />
         {:else if selected}
           <Viewport


### PR DESCRIPTION
Closes #906. Follow-up to #882 / #904 / #905 (epic #875 Phase 3): surfaces the PR-gated doc agent in the UI, behind the existing `SHEPHERD_DOC_AGENT` flag.

## What

A per-repo **trigger button + live run/PR status badge + brief run-history popover** in the Backlog Actions area, shown only when the doc agent is enabled.

### Server
- `GET /api/settings` now exposes read-only `docAgentEnabled` + `docAgentAct` (env-driven soak flags; no PUT).
- Durable per-repo run history: capped-10 JSON KV (`docagent:runs:<repo>`) via `store.recordDocAgentRun` / `listDocAgentRuns`.
- Each run's `outcome` (`pr` | `observe` | `nochange`) is computed once at the single `finalize()` chokepoint and carried on **both** the persisted run and the `doc-agent:done` event — so history is never retroactively mislabeled when the soak flag flips.
- `DocAgentService.isRunning()` + new `GET /api/doc-agent/runs?repo=` (`{ running, runs }`), 404 when disabled (mirrors the POST's unadvertised contract).

### UI
- `WsEvent` `doc-agent:done` member + `Settings` flags; api `triggerDocAgent` / `getDocAgentRuns`.
- Store handles `doc-agent:done` with an outcome-keyed, deduped toast **gated on `docAgentEnabled`**.
- New `DocAgentControl.svelte`: `.gbtn` trigger + status badge (running pulse / PR link / observe / no-changes) + anchored **non-modal** run-history popover (mirrors `IssueFilterPopover`; Esc + outside-dismiss, no scrim). Rendered in both desktop + mobile `BacklogTabBar`; state owned by `BacklogView`; flags + signal threaded from `+page.svelte`. Trigger re-fetches on 202 **and** 409 so the badge shows "running" immediately.

### House rules
- Full EN+DE i18n (parity gate green); one feature-announcement catalog entry (`doc-agent-ui`, `sinceVersion 1.36.0`, `targetId doc-agent-trigger`); design-system tokens only.

## Notes
- The final commit (`chore: satisfy fallow pre-push gate`) clears the delta audit: extracts `applyEpicEvent` to keep `applyGlobalEvent` ≤ the cyclomatic gate after the new dispatch, plus narrow ignores for **two pre-existing, main-wide fallow false positives** the audit surfaced (`flow` used via `class:flow`; `typedoc-plugin-markdown`, a TypeDoc runtime plugin) — both verified present on clean `origin/main`.

## Testing
- Root: `bun run lint` clean · `bun test ./test` (4276 pass) · branch hygiene linear off `main`.
- UI: `bun run check` (0 errors) · `bun run check:i18n` (parity) · `bun test` (1846 pass).
- Gates: feature-catalog ✓ · glossary ✓ · fallow audit ✓.
- Reviewed via subagent-driven development: per-task spec+quality reviews + a whole-branch final review (verdict: ready to merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)