### PR TITLE
chore(docs-site): mark typedoc-plugin-markdown intentional in fallow

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -78,11 +78,19 @@
   // site/astro.config.mjs — Astro parses the package's CSS at build time and
   // self-hosts the woff2. There is no static ESM import, so fallow sees the
   // packages as unused. Build-provided, not unused (same class as the two above).
+  //
+  // typedoc-plugin-markdown is a required peer dependency of starlight-typedoc
+  // (docs-site/astro.config.mjs imports starlight-typedoc; bun.lock declares the
+  // peer ">=4.6.0"). Starlight loads it as a plugin, so there is no direct ESM
+  // import for fallow to see — it reports the devDep as unused. Removing it would
+  // break the docs-site TypeDoc → markdown API-reference build. Peer-provided,
+  // not unused (same string-loaded class as axe-core above).
   "ignoreDependencies": [
     "tailwindcss",
     "axe-core",
     "@fontsource/space-grotesk",
-    "@fontsource/jetbrains-mono"
+    "@fontsource/jetbrains-mono",
+    "typedoc-plugin-markdown"
   ],
 
   "rules": {


### PR DESCRIPTION
## What

`typedoc-plugin-markdown` (`docs-site/package.json` devDependencies) is reported by fallow's dead-code audit as an **unused devDependency**. It surfaced as inherited (non-blocking) noise during the #933 onboarding-harness audit and recurs on every PR touching `docs-site/`.

## Why it's a false positive

It is a **required peer dependency** of `starlight-typedoc`, which the docs-site uses:

- `docs-site/astro.config.mjs:4` — `import starlightTypeDoc, { typeDocSidebarGroup } from "starlight-typedoc"`
- `docs-site/bun.lock:897` — `starlight-typedoc` declares `"typedoc-plugin-markdown": ">=4.6.0"` as a peerDependency
- `docs-site/README.md` documents it as part of the TypeDoc → markdown API-reference pipeline

Starlight loads it as a plugin, so there is **no direct ESM import** for static analysis to see — same false-positive class already handled for `axe-core` / `@fontsource/*`. **Removing it would break the docs-site API-reference build.**

## Change

Add `"typedoc-plugin-markdown"` to `ignoreDependencies` in `.fallowrc.jsonc`, with a rationale comment matching the existing entries.

Verified with `bunx fallow dead-code`: the finding is gone, no new findings introduced.

Config/tooling-only, no code or build behavior change. No user-facing UX — `[no-feature-entry]`.

Closes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)