### PR TITLE
fix(design-system): render live GlossaryText in glossary recipe

### DIFF
--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -16,6 +16,7 @@
   // below just read/drive the shared controller.
   import { theme } from "$lib/theme.svelte";
   import IssueFilterPopover from "$lib/components/IssueFilterPopover.svelte";
+  import GlossaryText from "$lib/components/GlossaryText.svelte";
 
   type Token = { name: string; note: string };
 
@@ -582,18 +583,20 @@ input, select, textarea {
     <p class="when">
       <strong>When:</strong> a dashed underline marks a term that has a definition in the glossary
       registry. Internal terms (kind <code>"internal"</code>) show an in-app definition only.
-      External terms (kind <code>"external"</code>) add a locale-aware Wikipedia link. The tooltip
-      is a small anchored, <strong>non-blocking popover</strong> (no scrim) that opens on hover or
-      focus (desktop) or tap (touch), and dismisses on Esc, outside pointerdown, or scroll/resize.
+      External terms (kind <code>"external"</code>) add a locale-aware Wikipedia link. The
+      presentation is chosen <strong>per interaction</strong>: hover or focus (fine pointer) opens a
+      small anchored,
+      <strong>non-blocking popover</strong> (no scrim) that dismisses on Esc, outside pointerdown,
+      or scroll/resize; tap (coarse pointer) opens an <strong>in-flow inline disclosure</strong>
+      that pushes content down and dismisses on Esc or outside pointerdown — but not on scroll.
       <strong>When not:</strong> do not use for decorative underlines or links — every dashed-underline
       term must resolve to a glossary entry.
     </p>
     <div class="demo">
       <p class="gloss-demo-text">
-        Shepherd groups sessions under an
-        <span class="gloss-term">epic</span>
-        and posts results to a
-        <span class="gloss-term">PR</span>.
+        <GlossaryText
+          text="Shepherd groups sessions under an [[epic|epic]] and posts results to a [[pr|PR]]."
+        />
       </p>
     </div>
     <pre><code>{glossMarkup}</code></pre>
@@ -964,18 +967,6 @@ input, select, textarea {
     box-shadow: inset 0 -2px 0 var(--color-amber);
   }
 
-  /* glossary term — dashed underline trigger (mirrors GlossaryTerm.svelte) */
-  .gloss-term {
-    background: none;
-    border: none;
-    padding: 0;
-    font: inherit;
-    color: inherit;
-    cursor: help;
-    text-decoration: underline dashed;
-    text-decoration-color: var(--color-line-bright);
-    text-underline-offset: 3px;
-  }
   .gloss-demo-text {
     margin: 0;
     color: var(--color-ink);


### PR DESCRIPTION
## Problem

The `/design-system` **Glossary term** recipe rendered a hand-authored static `<span class="gloss-term">` mock instead of the real `GlossaryText` / `GlossaryTerm`, so the "live reference" exercised nothing — no trigger button, no popover, no inline disclosure. It had already drifted, and #931 widened the gap (touch now reveals the definition as an in-flow inline disclosure, which a static span can't show). Fixes #938.

## Change (docs/recipe-only — `/design-system` is i18n- and feature-catalog-exempt)

- Replace the static spans with a live `<GlossaryText text="…[[epic|epic]]…[[pr|PR]]…" />` — `epic` (internal → in-app definition only) and `pr` (external → definition + locale-aware Wikipedia link) cover both variants.
- Rewrite the *when* note, which still described pre-#931 behavior, to state both presentations distinctly: hover/focus (fine pointer) → anchored non-blocking floating popover (dismiss on Esc/outside/scroll); tap (coarse pointer) → in-flow inline disclosure that pushes content down and dismisses on Esc/outside but **not** scroll.
- Drop the now-orphaned local `.gloss-term` style (the real component ships its own scoped style).

## Verification

- `cd ui && bun run check` → 0 errors, 0 warnings (confirms no unused-selector after the style removal).
- Browser-verified on the live page (`bun run dev`):
  - **Renders the real component:** 2 `button.gloss-term` (epic, PR), 0 spans; definitions resolve from the catalog.
  - **Hover (fine pointer):** exactly one `:popover-open` floating `.gloss-tooltip` (role=dialog for the external `pr`) with the Wikipedia link.
  - **Coarse-pointer tap:** in-flow `.gloss-inline` (`position: static`), `aria-expanded="true"`, no floating popover open — confirms the touch branch (which needs `(pointer: coarse)`, as `GlossaryTerm.onClick` early-returns on fine pointers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)