### PR TITLE
fix(learnings): prettier-stabilize synced CLAUDE.md under proseWrap:always (#935)

### DIFF
--- a/src/promote.ts
+++ b/src/promote.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
+import type { Options } from "prettier";
 import type { SessionStore } from "./store";
 import type { WorktreeMgr, WorktreeResult } from "./worktree";
 import type { GitForge } from "./forge/types";
@@ -125,7 +126,11 @@ export class Promoter {
         const rules = [...new Set(promoted.map((l) => sanitizeRule(l.rule)))];
         const claudePath = join(wt.worktreePath, "CLAUDE.md");
         const current = this.readClaudeMd(claudePath);
-        const next = upsertLearningsBlock(current, rules);
+        // Best-effort prettier-stabilize the block against this target's config (#935).
+        const next = await formatLearningsBlockForTarget(
+          claudePath,
+          upsertLearningsBlock(current, rules),
+        );
         // Content-compare guard: skip commit/push/PR if block is already current.
         // Avoids a spurious git-commit error on an empty diff.
         if (next === current) return { ok: true, url: "" };
@@ -268,7 +273,12 @@ export class Promoter {
     // Dedup in sanitized space (matches promoteGlobal): a stored rule and the newly-promoted
     // one that collapse to the same sanitized bullet must dedup, not emit a duplicate.
     const rules = [...new Set([...promoted, learning.rule].map(sanitizeRule))];
-    this.writeClaudeMd(claudePath, upsertLearningsBlock(this.readClaudeMd(claudePath), rules));
+    // Best-effort prettier-stabilize the block against this target's config (#935).
+    const next = await formatLearningsBlockForTarget(
+      claudePath,
+      upsertLearningsBlock(this.readClaudeMd(claudePath), rules),
+    );
+    this.writeClaudeMd(claudePath, next);
 
     await this.git(worktreePath, ["add", "CLAUDE.md"]);
     await this.git(worktreePath, [
@@ -346,4 +356,67 @@ export function extractLearningsBlockRules(content: string): string[] {
     .map((line) => line.trim())
     .filter((line) => line.startsWith("- "))
     .map((line) => line.slice(2).trim());
+}
+
+/** Best-effort: re-format the managed `shepherd:learnings` block to match the target repo's
+ *  prettier config, closing the residual gap where a repo with `proseWrap: "always"` re-wraps
+ *  our single-line bullets and re-flags the synced `CLAUDE.md` under `prettier --check` (#935;
+ *  #928 only stabilized the *default* `proseWrap: "preserve"` case).
+ *
+ *  Uses Shepherd's *bundled* prettier with the *target's resolved config* — never the target's
+ *  own toolchain (that shell-out was rejected in #928 as fragile). Degrades to a no-op (today's
+ *  raw single-line block) whenever prettier or a config is absent, or on any error, so it never
+ *  regresses or crashes the promote path. Only `proseWrap: "always"` is handled — `"preserve"`
+ *  (default) and `"never"` already leave a single-line bullet byte-stable.
+ *
+ *  Formats only the block slice, not the whole file, so user-authored prose is never reformatted
+ *  and the PR diff stays limited to our block. The "passes `prettier --check CLAUDE.md`" guarantee
+ *  is therefore conditional on the rest of the file already being prettier-clean (true when the
+ *  target's CI enforces the check — the only scenario this bug bites). The formatted block is
+ *  normalized CRLF→LF before splicing so an `endOfLine: "crlf"` config can't introduce mixed line
+ *  endings over our LF-managed bytes.
+ *
+ *  `useCache: false` decouples config resolution from the per-attempt unique worktree path
+ *  (`learnings-resync-<uuid>` / `learnings-promote-<id>-<uuid>`) that currently defeats prettier's
+ *  path-keyed cache; a future stable-path refactor would otherwise risk serving stale config.
+ *
+ *  `prettier` is intentionally a `devDependency`: the deploy (`deploy/update.sh` → plain
+ *  `bun install`, no prune) keeps devDeps and the service runs from the full checkout, so it's
+ *  present at runtime. If the deploy is ever changed to prune devDeps, move `prettier` to
+ *  `dependencies` to keep this fix live (else the dynamic import below silently no-ops it).
+ *
+ *  Residuals (out of scope, best-effort): non-prettier formatters (dprint, markdownlint); prettier
+ *  major-version skew (we format with 3.x — a 2.x target may differ); a CRLF target keeps an LF
+ *  managed block (markers were always LF — unchanged from pre-#935). */
+export async function formatLearningsBlockForTarget(
+  claudePath: string,
+  content: string,
+): Promise<string> {
+  const prettier = await import("prettier").catch(() => null);
+  if (!prettier) return content;
+
+  let cfg: Options | null;
+  try {
+    cfg = await prettier.resolveConfig(claudePath, { useCache: false });
+  } catch {
+    return content;
+  }
+  if (cfg?.proseWrap !== "always") return content;
+
+  const start = content.indexOf(LEARNINGS_START);
+  const end = content.indexOf(LEARNINGS_END);
+  if (start === -1 || end === -1 || end <= start) return content;
+  const blockEnd = end + LEARNINGS_END.length;
+  const block = content.slice(start, blockEnd);
+
+  let formatted: string;
+  try {
+    // Strip plugins: a target's svelte/tailwind/etc. plugin refs can't load here and markdown
+    // formatting needs none — dropping them avoids a spurious load throw.
+    formatted = await prettier.format(block, { ...cfg, plugins: [], parser: "markdown" });
+  } catch {
+    return content;
+  }
+  const normalized = formatted.replace(/\r\n/g, "\n").trimEnd();
+  return content.slice(0, start) + normalized + content.slice(blockEnd);
 }

--- a/test/promote.test.ts
+++ b/test/promote.test.ts
@@ -1,6 +1,12 @@
 import { test, expect } from "bun:test";
 import * as prettier from "prettier";
-import { upsertLearningsBlock, sanitizeRule, LEARNINGS_START, LEARNINGS_END } from "../src/promote";
+import {
+  upsertLearningsBlock,
+  sanitizeRule,
+  formatLearningsBlockForTarget,
+  LEARNINGS_START,
+  LEARNINGS_END,
+} from "../src/promote";
 
 test("upsertLearningsBlock appends a block when none exists", () => {
   const out = upsertLearningsBlock("# Repo\n\nintro\n", ["use bun", "rebase onto main"]);
@@ -82,7 +88,7 @@ test("upsertLearningsBlock output is byte-for-byte prettier-stable (default mark
   }
 });
 
-import { mkdtempSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { Promoter } from "../src/promote";
@@ -636,4 +642,121 @@ test("promoteGlobal returns a structured 500 (not a throw) on an fs failure", as
     expect(res.status).toBe(500);
     expect(res.error).toBe("global promote failed"); // no raw fs stderr leaked
   }
+});
+
+// ── formatLearningsBlockForTarget (#935: prettier-stable under proseWrap:"always") ───────────
+
+const PROSE_WRAP_CFG = { proseWrap: "always", printWidth: 40 };
+// Long enough to force prettier to wrap a bullet across printWidth:40 — exercises the
+// wrap × leading-marker-escape × mid-line-token interaction, not just one generic long rule.
+const WRAP_TAIL =
+  " and then a good deal of extra trailing prose so prettier reflows this bullet across the configured print width";
+
+function tmpRepoWithPrettier(cfg: object | null): string {
+  const dir = mkdtempSync(join(tmpdir(), "promote-prosewrap-"));
+  if (cfg) writeFileSync(join(dir, ".prettierrc"), JSON.stringify(cfg));
+  return dir;
+}
+
+const blockSlice = (s: string) =>
+  s.slice(s.indexOf(LEARNINGS_START), s.indexOf(LEARNINGS_END) + LEARNINGS_END.length);
+
+test("formatLearningsBlockForTarget: proseWrap:always block passes whole-file prettier --check (full battery)", async () => {
+  const claudePath = join(tmpRepoWithPrettier(PROSE_WRAP_CFG), "CLAUDE.md");
+  const cfg = await prettier.resolveConfig(claudePath, { useCache: false });
+  expect(cfg?.proseWrap).toBe("always");
+
+  // Pre-canonicalize the surrounding prose so any whole-file diff is attributable to our block.
+  const before = await prettier.format("# Project\n\nShort intro line.\n", {
+    ...cfg,
+    parser: "markdown",
+  });
+  const after = await prettier.format("## Notes\n\nShort outro line.\n", {
+    ...cfg,
+    parser: "markdown",
+  });
+
+  for (const base of PRETTIER_STABILITY_RULES) {
+    const rule = base + WRAP_TAIL;
+    const full = upsertLearningsBlock(before, [rule]) + "\n" + after;
+    const result = await formatLearningsBlockForTarget(claudePath, full);
+
+    // The bullet actually wrapped (start marker + ≥2 bullet lines) — confirms wrapping was exercised.
+    const nonEmpty = blockSlice(result)
+      .split("\n")
+      .filter((l) => l.trim().length > 0);
+    expect(nonEmpty.length).toBeGreaterThan(3);
+
+    // Whole-file `prettier --check` is a byte-for-byte no-op: passes in context, escaping + tokens intact.
+    expect(await prettier.format(result, { ...cfg, parser: "markdown" })).toBe(result);
+    // And the helper reproduces prettier's own whole-file output.
+    expect(result).toBe(await prettier.format(full, { ...cfg, parser: "markdown" }));
+  }
+});
+
+test("formatLearningsBlockForTarget: block stays prettier-clean even when surrounding prose is dirty", async () => {
+  const claudePath = join(tmpRepoWithPrettier(PROSE_WRAP_CFG), "CLAUDE.md");
+  const cfg = await prettier.resolveConfig(claudePath, { useCache: false });
+
+  // Deliberately NON-canonical surroundings: a long unwrapped paragraph prettier WOULD reflow.
+  const dirtyBefore =
+    "# Project\n\nThis surrounding paragraph is left deliberately unwrapped and far longer than the narrow print width so prettier would reflow it.\n";
+  const full = upsertLearningsBlock(dirtyBefore, [
+    "Run `bun run lint` before every push" + WRAP_TAIL,
+  ]);
+  const result = await formatLearningsBlockForTarget(claudePath, full);
+
+  const wholeFormatted = await prettier.format(result, { ...cfg, parser: "markdown" });
+  // Our block is already canonical — a whole-file pass does not touch it...
+  expect(blockSlice(wholeFormatted)).toBe(blockSlice(result));
+  // ...even though it DOES reflow the dirty surrounding prose (the clean-surroundings precondition
+  // is about the user's content, never our block).
+  expect(wholeFormatted).not.toBe(result);
+});
+
+test("formatLearningsBlockForTarget: idempotent under re-run and external reformat (no churn on resync)", async () => {
+  const claudePath = join(tmpRepoWithPrettier(PROSE_WRAP_CFG), "CLAUDE.md");
+  const cfg = await prettier.resolveConfig(claudePath, { useCache: false });
+  const before = await prettier.format("# Project\n\nShort intro line.\n", {
+    ...cfg,
+    parser: "markdown",
+  });
+  const rule = "Use `bun run lint` before push" + WRAP_TAIL;
+  const result = await formatLearningsBlockForTarget(
+    claudePath,
+    upsertLearningsBlock(before, [rule]),
+  );
+
+  // Re-running the helper is a no-op.
+  expect(await formatLearningsBlockForTarget(claudePath, result)).toBe(result);
+  // A faithful resync round-trip (regenerate single-line block from the same rule, re-stabilize)
+  // reproduces identical bytes → next === current → no churn PR.
+  expect(
+    await formatLearningsBlockForTarget(claudePath, upsertLearningsBlock(result, [rule])),
+  ).toBe(result);
+  // An external whole-file prettier pass (e.g. a target CI that auto-formats) is also a no-op.
+  expect(await prettier.format(result, { ...cfg, parser: "markdown" })).toBe(result);
+});
+
+test("formatLearningsBlockForTarget: pass-through when no config / proseWrap not 'always'", async () => {
+  const content = upsertLearningsBlock("# Repo\n", ["Use bun, not npm" + WRAP_TAIL]);
+
+  // No .prettierrc at all → unchanged.
+  expect(
+    await formatLearningsBlockForTarget(join(tmpRepoWithPrettier(null), "CLAUDE.md"), content),
+  ).toBe(content);
+  // proseWrap:"preserve" (default) → unchanged.
+  expect(
+    await formatLearningsBlockForTarget(
+      join(tmpRepoWithPrettier({ proseWrap: "preserve", printWidth: 40 }), "CLAUDE.md"),
+      content,
+    ),
+  ).toBe(content);
+  // proseWrap:"never" → unchanged (our bullet is already single-line).
+  expect(
+    await formatLearningsBlockForTarget(
+      join(tmpRepoWithPrettier({ proseWrap: "never", printWidth: 40 }), "CLAUDE.md"),
+      content,
+    ),
+  ).toBe(content);
 });


### PR DESCRIPTION
Closes #935.

## Problem

PR #928 made the synced `<!-- shepherd:learnings -->` block prettier-stable under prettier's **default** markdown config (`proseWrap: "preserve"`). A target repo that sets **`proseWrap: "always"`** still re-wraps our long single-line bullets, so `prettier --check CLAUDE.md` re-flags the synced block.

## Fix

New best-effort helper `formatLearningsBlockForTarget` (`src/promote.ts`), called in both PR paths (`resyncPromoted`, `commitAndOpen`) before the write/no-op guard:

- Uses Shepherd's **bundled** prettier with the **target repo's resolved config** (`resolveConfig`, `useCache: false`) — never the target's own toolchain (that shell-out was rejected in #928 as fragile).
- Only acts when `proseWrap === "always"` (the one setting that rewraps a one-line bullet; `preserve`/`never`/no-config are pass-throughs).
- Formats **only the block slice**, so user-authored prose is never reformatted and the PR diff stays limited to our block.
- Normalizes the formatted block CRLF→LF before splicing (an `endOfLine: "crlf"` config can't introduce mixed line endings over our LF-managed bytes).
- Degrades to today's raw single-line block (no-op) when prettier or a config is absent, or on any error — never regresses or crashes the promote path.

`promoteGlobal` (`~/.claude/CLAUDE.md`, not a CI-linted repo) is left as-is, keeping its single-line `extractLearningsBlockRules` round-trip valid.

## Scope / residuals (documented in a code comment)

- The "passes `prettier --check`" guarantee is conditional on the **rest of the file** already being prettier-clean (block-only formatting doesn't reformat user prose — reformatting it would be the noisy whole-file diff we rejected). True whenever the target's CI enforces the check — the only scenario this bug bites.
- Out of scope: non-prettier formatters (dprint, markdownlint); prettier 2.x↔3.x major-version skew.
- `prettier` stays a `devDependency`: the deploy (`deploy/update.sh` → plain `bun install`, no prune) keeps devDeps and the service runs from the full checkout. The dynamic-import guard protects the path; a comment notes to promote prettier to `dependencies` only if the deploy ever prunes devDeps.

## Tests (`test/promote.test.ts`)

- **Whole-file `prettier --check` no-op over the full `PRETTIER_STABILITY_RULES` battery** (leading markers, numbered, heading, mid-line backtick/slash tokens, real flowagent #418 rule), each lengthened to actually wrap at `printWidth: 40` — asserts the bullet wrapped *and* the whole file is a byte-for-byte no-op in context.
- **Block stays clean when surroundings are dirty** — proves block-only formatting + makes the clean-surroundings precondition explicit.
- **Idempotent under re-run, resync round-trip, and external whole-file reformat** — the no-churn-on-resync guard.
- **Pass-through** when no config / `preserve` / `never`.

Full root suite: 4267 pass / 0 fail. `bun run lint`, `bunx tsc --noEmit`, and `prettier --check` on changed files all clean.

[no-feature-entry] — server-side learnings-sync internals, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)