### PR TITLE
ci: harden docs-site build against flaky @pagefind tarball-extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,16 +103,6 @@ jobs:
       - name: Build (extension)
         run: cd extension && bun run build
 
-      # The Astro Starlight docs site (docs-site/) is a 4th in-monorepo package
-      # with its own lockfile. Unlike site/ (bound for extraction, deliberately
-      # absent from CI), docs-site/ lives here, so its build is gated. `astro
-      # check` runs type + content-collection diagnostics; `astro build` emits the
-      # static dist/. NB: this workflow triggers only on `branches: [main]`, so the
-      # step is dormant on docs-epic PRs (which target the epic branch) and first
-      # runs when the epic merges to main.
-      - name: Build (docs-site)
-        run: cd docs-site && bun install --frozen-lockfile && bun run check && bun run build
-
       - name: Fallow audit (PR delta)
         # Only new findings introduced by the PR block — inherited issues don't.
         # Skip on direct pushes to main: there's no base branch to diff against.
@@ -126,3 +116,69 @@ jobs:
         # with .husky/pre-push and CONTRIBUTING.md.
         if: github.event_name == 'pull_request'
         run: bunx fallow@2.100.0 audit --base origin/${{ github.base_ref }} --fail-on-issues
+
+  # The Astro Starlight docs site (docs-site/) is a 4th in-monorepo package with
+  # its own lockfile. It builds self-contained — TypeDoc reads ../src via a
+  # dedicated typedoc.tsconfig.json (own @types/bun, skipErrorChecking, disableGit)
+  # and sync-docs.mjs reads checked-in files — so it needs only a plain checkout +
+  # its own install, NOT the root/ui/extension installs. It lives in its OWN job
+  # (not a step in `verify`) so a flaky pagefind install can't red the whole suite:
+  # `pagefind` (the search indexer) ships its native binary as optional, platform-
+  # specific deps (@pagefind/linux-x64, …) whose npm-tarball extraction during
+  # `bun install` occasionally flakes (#944). NB: this workflow triggers only on
+  # `branches: [main]`, so this job is dormant on docs-epic PRs (which target the
+  # epic branch) and first runs when an epic merges to main.
+  docs-site:
+    name: docs-site
+    # Skip release-please's generated PR (version/CHANGELOG bump only), mirroring
+    # the `verify` job's guard. head_ref is empty on push-to-main, so main runs.
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    # Same self-hosted runner toggle as `verify`: set repo var CI_RUNNER to
+    # 'self-hosted' to use the local runner; unset falls back to ubuntu-latest.
+    # MUST be deleted before the repo goes public.
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Cache bun's global store so the pagefind tarball isn't re-DOWNLOADED every
+      # run (speed + download-flake mitigation). This does NOT reduce extraction
+      # events — extraction into node_modules happens every run regardless — so the
+      # retry below, not this cache, is what absorbs the tarball-extraction flake.
+      - name: Cache bun store (docs-site)
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-docs-site-${{ hashFiles('docs-site/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-docs-site-
+
+      # Retry `bun install` to absorb a one-off @pagefind tarball-extraction flake
+      # (#944). Only the install is retried — re-running check/build on a genuine
+      # type/content error would just burn 3× the time. Before the FINAL attempt the
+      # bun store is purged so a poisoned half-written tarball is re-downloaded fresh
+      # rather than re-hit identically.
+      - name: Build (docs-site)
+        run: |
+          cd docs-site
+          n=0
+          until bun install --frozen-lockfile; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "bun install failed after $n attempts" >&2
+              exit 1
+            fi
+            if [ "$n" -eq 2 ]; then
+              echo "purging bun store before final retry…" >&2
+              rm -rf ~/.bun/install/cache
+            fi
+            echo "bun install failed (attempt $n) — retrying in 5s…" >&2
+            sleep 5
+          done
+          bun run check
+          bun run build


### PR DESCRIPTION
Closes #944

## Problem

The `verify` CI job intermittently red on **Build (docs-site)** with `error: Fail extracting tarball for "@pagefind/linux-x64"` — a transient flake when `bun install` extracts pagefind's native binary (shipped as optional, platform-specific deps). Because docs-site built as a *step inside* `verify`, that flake red the **whole** job — failing PRs that touch nothing in `docs-site/` (e.g. #941) and blocking the critic (won't review a red PR). A bare re-run cleared it with no code change.

## Fix

Three measures in `.github/workflows/ci.yml`, with distinct roles:

1. **Retry `bun install` (the real fix)** — 3 attempts with 5s backoff. The flake is bun *extracting the npm tarball*; a retry self-heals it. Before the **final** attempt the bun store is purged (`rm -rf ~/.bun/install/cache`) so a poisoned half-written tarball is re-downloaded fresh rather than re-hit identically. Only the install is retried — re-running `check`/`build` on a genuine error would just burn 3× the time.
2. **Cache bun's global store** (`~/.bun/install/cache`, keyed on `docs-site/bun.lock`) — **speed + download-flake mitigation only.** It avoids re-*downloading* the tarball on a cache hit; it does **not** reduce extraction events (extraction into `node_modules` happens every run regardless), so the retry — not the cache — is what absorbs the extraction flake.
3. **Split docs-site into its own parallel `docs-site` job** — a docs-site flake no longer reds the UI/server/extension `verify` job.

### Why docs-site can stand alone

It builds self-contained — TypeDoc reads `../src` via a dedicated `typedoc.tsconfig.json` (own `@types/bun`, `skipErrorChecking`, `disableGit`) and `sync-docs.mjs` reads only checked-in files. So the standalone job needs only a plain `checkout` + its own `bun install` (no root/ui/extension install, no `fetch-depth: 0`). This mirrors how it already builds on Vercel.

### Scope of the flake

The observed failure is **install-time tarball extraction** (the #941 error string). Starlight also invokes pagefind to *index* during `astro build`, but that is a distinct, unobserved failure mode — out of scope here.

## ⚠️ Action required before/at merge — add `docs-site` as a required status check

Splitting docs-site out means it is **no longer covered by `verify`**. If `docs-site` is not added to branch protection's required checks, a *genuine* docs-site build break stops blocking merges silently.

- GitHub → **Settings → Branches → Branch protection rules → `main` → Require status checks to pass → search and add `docs-site`**.
- CLI equivalent: `gh api -X PATCH repos/erwins-enkel/shepherd/branches/main/protection/required_status_checks -f 'contexts[]=docs-site'`

## Acceptance

- [x] A one-off `@pagefind` tarball-extraction failure no longer reds the run on first attempt (retry + store-purge absorbs it).
- [x] A docs-site flake no longer reds `verify` (separate job).
- [x] No change to what docs-site builds — same `check` + `build`.

[no-feature-entry] — CI-only change, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)