### PR TITLE
refactor: extract shared spawn/membrane tail across reviewer-style services (#937)

### DIFF
--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -1,10 +1,8 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
-import { config } from "./config";
 import { docAgentArgv } from "./doc-agent-argv";
 import { EmptyDiffError } from "./forge/types";
 import type { GitForge } from "./forge/types";
@@ -13,20 +11,8 @@ import { HerdrUnavailableError } from "./herdr";
 import type { SessionStore } from "./store";
 import type { SessionUsage } from "./usage";
 import { readSessionUsage } from "./usage";
-import {
-  apiKeyMembraneFields,
-  apiKeyPassthroughEnv,
-  isApiKeyConfigured,
-  isApiKeyMode,
-} from "./spawn-auth";
-import {
-  detectBackend as realDetectBackend,
-  wrapArgv,
-  safeRealpath,
-  collectPassthroughEnv,
-  type SandboxBackend,
-  type MembraneInputs,
-} from "./sandbox";
+import { apiKeyPassthroughEnv, isApiKeyConfigured, isApiKeyMode } from "./spawn-auth";
+import { resolveSpawnMembrane, type MembraneSeams } from "./spawn-membrane";
 import type { WorktreeMgr } from "./worktree";
 
 const execFileP = promisify(execFile);
@@ -152,7 +138,7 @@ interface InFlight {
   finalizing?: boolean;
 }
 
-export interface DocAgentDeps {
+export interface DocAgentDeps extends MembraneSeams {
   herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab">;
   worktree: Pick<WorktreeMgr, "create" | "remove" | "gitCommonDir" | "ensureBaseRef">;
   resolveForge: (repoPath: string) => GitForge | null;
@@ -182,13 +168,6 @@ export interface DocAgentDeps {
   dayKey?: (now: number) => string;
   git?: (cwd: string, args: string[]) => Promise<string>;
   prettier?: (args: { cwd: string; configPath: string; files: string[] }) => Promise<void>;
-  detectBackend?: () => SandboxBackend;
-  membraneEnv?: () => {
-    claudeDir: string;
-    home: string;
-    nodeBinReal: string;
-    extraEnv?: Record<string, string>;
-  };
   fileExists?: (p: string) => boolean;
   readSentinel?: (worktreePath: string) => string | null;
   buildPrompt?: (base: string) => string;
@@ -240,30 +219,6 @@ export class DocAgentService {
     this.buildPrompt = deps.buildPrompt ?? ((base) => docAgentPrompt(base));
     this.act = deps.act ?? false;
     this.readUsage = deps.readUsage ?? readSessionUsage;
-  }
-
-  private detectBackend(): SandboxBackend {
-    if (this.deps.detectBackend) return this.deps.detectBackend();
-    return realDetectBackend({
-      home: homedir(),
-      claudeDir: config.claudeDir,
-      nodeBinReal: safeRealpath(config.nodeBin),
-    });
-  }
-
-  private membraneEnv(): {
-    claudeDir: string;
-    home: string;
-    nodeBinReal: string;
-    extraEnv?: Record<string, string>;
-  } {
-    if (this.deps.membraneEnv) return this.deps.membraneEnv();
-    return {
-      claudeDir: config.claudeDir,
-      home: homedir(),
-      nodeBinReal: safeRealpath(config.nodeBin),
-      extraEnv: collectPassthroughEnv(),
-    };
   }
 
   /** Start a doc-agent run for `repoPath` (manual trigger). At most one per repo at a time. */
@@ -497,21 +452,13 @@ export class DocAgentService {
     base: string,
   ): { terminalId: string; spawnSessionId: string } | null {
     const { argv, sessionId } = docAgentArgv(this.deps.model ?? null, this.buildPrompt(base));
-    const backend = this.detectBackend();
-    const env = this.membraneEnv();
-    const membrane: MembraneInputs = {
+    const { wrapped, backend } = resolveSpawnMembrane({
+      argv,
       worktreePath,
-      gitCommonDir: this.deps.worktree.gitCommonDir(worktreePath),
-      isolated: true,
       repoPath,
-      claudeDir: env.claudeDir,
-      home: env.home,
-      nodeBinReal: env.nodeBinReal,
-      extraEnv: env.extraEnv,
-      // api-key mode: a bwrap-wrapped agent masks the OAuth credential + binds the helper.
-      ...apiKeyMembraneFields(),
-    };
-    const wrapped = wrapArgv(argv, { profile: "standard", backend, membrane });
+      worktree: this.deps.worktree,
+      seams: this.deps,
+    });
     try {
       const terminalId = this.deps.herdr.start(
         agentName,

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -1,7 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
-import { homedir } from "node:os";
 import { execFileSync } from "./instrument";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
@@ -15,23 +14,10 @@ import {
   groundPlanBlocks,
 } from "./visual-blocks";
 import { readonlyReviewerArgv } from "./reviewer-argv";
-import {
-  isApiKeyMode,
-  isApiKeyConfigured,
-  apiKeyMembraneFields,
-  apiKeyPassthroughEnv,
-} from "./spawn-auth";
+import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
 import { readSessionUsage, type SessionUsage } from "./usage";
 import { effectiveAutopilot } from "./effective-autopilot";
-import {
-  detectBackend as realDetectBackend,
-  wrapArgv,
-  safeRealpath,
-  collectPassthroughEnv,
-  type SandboxBackend,
-  type MembraneInputs,
-} from "./sandbox";
-import { config } from "./config";
+import { resolveSpawnMembrane, type MembraneSeams } from "./spawn-membrane";
 
 /** Outcome of an on-demand `consider()`: a reviewer actually spawned, the request was a no-op
  *  (plan unchanged / already approved / nothing to review), or a spawn attempt failed. The
@@ -113,7 +99,7 @@ export interface RawPlanVerdict {
   findings?: unknown;
 }
 
-export interface PlanGateServiceDeps {
+export interface PlanGateServiceDeps extends MembraneSeams {
   store: Pick<
     SessionStore,
     | "getPlanGate"
@@ -163,16 +149,6 @@ export interface PlanGateServiceDeps {
   /** Injectable reader of a finished reviewer's token totals from its transcript
    *  (default: readSessionUsage). null = transcript missing/unreadable → totals stay null. */
   readUsage?: (worktreePath: string, reviewerSessionId: string) => Promise<SessionUsage | null>;
-  /** Injectable sandbox backend probe seam (tests inject `() => null` so no real bwrap is
-   *  spawned). Presence-checked (not `??`) because the seam legitimately returns null. */
-  detectBackend?: () => SandboxBackend;
-  /** Injectable membrane env seam (tests inject a stub so no host paths are touched). */
-  membraneEnv?: () => {
-    claudeDir: string;
-    home: string;
-    nodeBinReal: string;
-    extraEnv?: Record<string, string>;
-  };
 }
 
 interface PlanInFlight {
@@ -213,33 +189,6 @@ export class PlanGateService {
     worktreePath: string,
     reviewerSessionId: string,
   ) => Promise<SessionUsage | null>;
-
-  /** Sandbox backend probe: injected seam (tests) or the real cached self-test. Presence-
-   *  checked (not `??`) because the seam legitimately returns null (no backend). */
-  private detectBackend(): SandboxBackend {
-    if (this.deps.detectBackend) return this.deps.detectBackend();
-    return realDetectBackend({
-      home: homedir(),
-      claudeDir: config.claudeDir,
-      nodeBinReal: safeRealpath(config.nodeBin),
-    });
-  }
-
-  /** Membrane env: injected seam (tests) or real host values. */
-  private membraneEnv(): {
-    claudeDir: string;
-    home: string;
-    nodeBinReal: string;
-    extraEnv?: Record<string, string>;
-  } {
-    if (this.deps.membraneEnv) return this.deps.membraneEnv();
-    return {
-      claudeDir: config.claudeDir,
-      home: homedir(),
-      nodeBinReal: safeRealpath(config.nodeBin),
-      extraEnv: collectPassthroughEnv(),
-    };
-  }
 
   constructor(private deps: PlanGateServiceDeps) {
     this.now = deps.now ?? Date.now;
@@ -349,21 +298,13 @@ export class PlanGateService {
       this.deps.worktree.remove(wt.worktreePath);
       return "error";
     }
-    const backend = this.detectBackend();
-    const env = this.membraneEnv();
-    const membrane: MembraneInputs = {
+    const { wrapped, backend } = resolveSpawnMembrane({
+      argv,
       worktreePath: wt.worktreePath,
-      gitCommonDir: this.deps.worktree.gitCommonDir(wt.worktreePath),
-      isolated: true,
       repoPath: session.repoPath,
-      claudeDir: env.claudeDir,
-      home: env.home,
-      nodeBinReal: env.nodeBinReal,
-      extraEnv: env.extraEnv,
-      // api-key mode: a bwrap-wrapped reviewer masks the OAuth credential + binds the helper.
-      ...apiKeyMembraneFields(),
-    };
-    const wrapped = wrapArgv(argv, { profile: "standard", backend, membrane });
+      worktree: this.deps.worktree,
+      seams: this.deps,
+    });
     let terminalId: string;
     try {
       terminalId = this.deps.herdr.start(

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,4 +1,3 @@
-import { homedir } from "node:os";
 import { existsSync } from "node:fs";
 import type { SessionStore } from "./store";
 import type { HerdrDriver, HerdrAgent } from "./herdr";
@@ -7,12 +6,7 @@ import type { GitForge, GitState, PrStatus } from "./forge/types";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "./forge/types";
 import type { ReviewVerdict, Session, ReviewerSpawnRow } from "./types";
 import { readonlyReviewerArgv } from "./reviewer-argv";
-import {
-  isApiKeyMode,
-  isApiKeyConfigured,
-  apiKeyMembraneFields,
-  apiKeyPassthroughEnv,
-} from "./spawn-auth";
+import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
 import { jsonlPathFor, readSessionUsage, type SessionUsage } from "./usage";
 import { readActivitySignal } from "./activity-signal";
 import { isSpawnWorking, decideVerdictAction } from "./json-tolerant";
@@ -29,15 +23,7 @@ import {
   CRITIC_THINKING_TOKENS,
   type RawVerdict,
 } from "./critic-core";
-import {
-  detectBackend as realDetectBackend,
-  wrapArgv,
-  safeRealpath,
-  collectPassthroughEnv,
-  type SandboxBackend,
-  type MembraneInputs,
-} from "./sandbox";
-import { config } from "./config";
+import { resolveSpawnMembrane, type MembraneSeams } from "./spawn-membrane";
 
 // Session-agnostic critic helpers now live in ./critic-core (a forthcoming standalone-PR-critic
 // service reuses them). Re-exported here so existing importers (and tests) keep their paths.
@@ -115,7 +101,7 @@ function priorStreakState(prior: ReviewVerdict | null): PriorStreakState {
   };
 }
 
-export interface ReviewServiceDeps {
+export interface ReviewServiceDeps extends MembraneSeams {
   store: Pick<
     SessionStore,
     | "getRepoConfig"
@@ -183,16 +169,6 @@ export interface ReviewServiceDeps {
   /** Injectable reader of a finished reviewer's token totals from its transcript
    *  (default: readSessionUsage). null = transcript missing/unreadable → totals stay null. */
   readUsage?: (worktreePath: string, criticSessionId: string) => Promise<SessionUsage | null>;
-  /** Injectable sandbox backend probe seam (tests inject `() => null` so no real bwrap is
-   *  spawned). Presence-checked (not `??`) because the seam legitimately returns null. */
-  detectBackend?: () => SandboxBackend;
-  /** Injectable membrane env seam (tests inject a stub so no host paths are touched). */
-  membraneEnv?: () => {
-    claudeDir: string;
-    home: string;
-    nodeBinReal: string;
-    extraEnv?: Record<string, string>;
-  };
 }
 
 export class ReviewService {
@@ -221,33 +197,6 @@ export class ReviewService {
     criticSessionId: string,
   ) => Promise<SessionUsage | null>;
   private worktreeExists: (p: string) => boolean;
-
-  /** Sandbox backend probe: injected seam (tests) or the real cached self-test. Presence-
-   *  checked (not `??`) because the seam legitimately returns null (no backend). */
-  private detectBackend(): SandboxBackend {
-    if (this.deps.detectBackend) return this.deps.detectBackend();
-    return realDetectBackend({
-      home: homedir(),
-      claudeDir: config.claudeDir,
-      nodeBinReal: safeRealpath(config.nodeBin),
-    });
-  }
-
-  /** Membrane env: injected seam (tests) or real host values. */
-  private membraneEnv(): {
-    claudeDir: string;
-    home: string;
-    nodeBinReal: string;
-    extraEnv?: Record<string, string>;
-  } {
-    if (this.deps.membraneEnv) return this.deps.membraneEnv();
-    return {
-      claudeDir: config.claudeDir,
-      home: homedir(),
-      nodeBinReal: safeRealpath(config.nodeBin),
-      extraEnv: collectPassthroughEnv(),
-    };
-  }
 
   constructor(private deps: ReviewServiceDeps) {
     this.now = deps.now ?? Date.now;
@@ -395,21 +344,13 @@ export class ReviewService {
       authorNotes,
       issueBody,
     );
-    const backend = this.detectBackend();
-    const env = this.membraneEnv();
-    const membrane: MembraneInputs = {
+    const { wrapped, backend } = resolveSpawnMembrane({
+      argv,
       worktreePath: wt.worktreePath,
-      gitCommonDir: this.deps.worktree.gitCommonDir(wt.worktreePath),
-      isolated: true,
       repoPath: session.repoPath,
-      claudeDir: env.claudeDir,
-      home: env.home,
-      nodeBinReal: env.nodeBinReal,
-      extraEnv: env.extraEnv,
-      // api-key mode: a bwrap-wrapped reviewer masks the OAuth credential + binds the helper.
-      ...apiKeyMembraneFields(),
-    };
-    const wrapped = wrapArgv(argv, { profile: "standard", backend, membrane });
+      worktree: this.deps.worktree,
+      seams: this.deps,
+    });
     let terminalId: string;
     try {
       terminalId = this.deps.herdr.start(

--- a/src/spawn-membrane.ts
+++ b/src/spawn-membrane.ts
@@ -1,0 +1,79 @@
+import { homedir } from "node:os";
+import { config } from "./config";
+import { apiKeyMembraneFields } from "./spawn-auth";
+import {
+  detectBackend as realDetectBackend,
+  wrapArgv,
+  safeRealpath,
+  collectPassthroughEnv,
+  type SandboxBackend,
+  type MembraneInputs,
+} from "./sandbox";
+
+export interface MembraneEnv {
+  claudeDir: string;
+  home: string;
+  nodeBinReal: string;
+  extraEnv?: Record<string, string>;
+}
+
+/** Injectable spawn/membrane seams shared by every reviewer-style spawner. Tests override
+ *  these so no real bwrap probe runs and no host paths are touched. */
+export interface MembraneSeams {
+  /** Injectable sandbox backend probe seam (tests inject `() => null`). PRESENCE-checked
+   *  (not `??`) because the seam legitimately returns null (no backend). */
+  detectBackend?: () => SandboxBackend;
+  /** Injectable membrane env seam (tests inject a stub so no host paths are touched). */
+  membraneEnv?: () => MembraneEnv;
+}
+
+/** Backend probe: injected seam (tests) or the real cached self-test. */
+export function resolveBackend(seams: MembraneSeams): SandboxBackend {
+  if (seams.detectBackend) return seams.detectBackend(); // PRESENCE-check, NOT ??
+  return realDetectBackend({
+    home: homedir(),
+    claudeDir: config.claudeDir,
+    nodeBinReal: safeRealpath(config.nodeBin),
+  });
+}
+
+/** Membrane env: injected seam (tests) or real host values. */
+export function resolveMembraneEnv(seams: MembraneSeams): MembraneEnv {
+  if (seams.membraneEnv) return seams.membraneEnv(); // PRESENCE-check
+  return {
+    claudeDir: config.claudeDir,
+    home: homedir(),
+    nodeBinReal: safeRealpath(config.nodeBin),
+    extraEnv: collectPassthroughEnv(),
+  };
+}
+
+/** Assemble the standard per-task FS membrane around `argv` for an isolated reviewer-style
+ *  spawn and wrap it. Returns the wrapped argv + the resolved backend (the caller needs the
+ *  backend for apiKeyPassthroughEnv). Mirrors the #601 posture: an isolated worktree gets
+ *  per-task binds (worktree + git common dir), not the whole repo; wrapArgv degrades to
+ *  passthrough when no backend. */
+export function resolveSpawnMembrane(args: {
+  argv: string[];
+  worktreePath: string;
+  repoPath: string;
+  worktree: { gitCommonDir(p: string): string };
+  seams: MembraneSeams;
+}): { wrapped: string[]; backend: SandboxBackend } {
+  const backend = resolveBackend(args.seams);
+  const env = resolveMembraneEnv(args.seams);
+  const membrane: MembraneInputs = {
+    worktreePath: args.worktreePath,
+    gitCommonDir: args.worktree.gitCommonDir(args.worktreePath),
+    isolated: true,
+    repoPath: args.repoPath,
+    claudeDir: env.claudeDir,
+    home: env.home,
+    nodeBinReal: env.nodeBinReal,
+    extraEnv: env.extraEnv,
+    // api-key mode: a bwrap-wrapped reviewer masks the OAuth credential + binds the helper.
+    ...apiKeyMembraneFields(),
+  };
+  const wrapped = wrapArgv(args.argv, { profile: "standard", backend, membrane });
+  return { wrapped, backend };
+}

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -18,7 +18,6 @@
  * patch-id churn/revert set mirrors ReviewService's clean-resets-[] / findings-appends logic so an
  * identical-diff rebase is skipped and a revert-to-an-earlier-buggy-diff is re-reviewed.
  */
-import { homedir } from "node:os";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
@@ -26,12 +25,7 @@ import type { GitForge, PrReviewMeta, PullRequest } from "./forge/types";
 import { CRITIC_REVIEW_MARKER } from "./forge/types";
 import { readonlyReviewerArgv } from "./reviewer-argv";
 import { isEpicIntegrationBranch } from "./epic-branch";
-import {
-  isApiKeyMode,
-  isApiKeyConfigured,
-  apiKeyMembraneFields,
-  apiKeyPassthroughEnv,
-} from "./spawn-auth";
+import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
 import { readSessionUsage, type SessionUsage } from "./usage";
 import {
   prReviewPrompt,
@@ -45,15 +39,7 @@ import {
   type RawVerdict,
 } from "./critic-core";
 import type { VerdictRead } from "./json-tolerant";
-import {
-  detectBackend as realDetectBackend,
-  wrapArgv,
-  safeRealpath,
-  collectPassthroughEnv,
-  type SandboxBackend,
-  type MembraneInputs,
-} from "./sandbox";
-import { config } from "./config";
+import { resolveSpawnMembrane, type MembraneSeams } from "./spawn-membrane";
 
 /** One PR critic run between its spawn (begin) and its verdict (finalize). Carries everything
  *  finalize needs without re-querying — mirrors ReviewService's InFlight, minus the streak/note
@@ -77,7 +63,7 @@ interface InFlight {
 const DEFAULT_TIMEOUT_MS = 10 * 60_000;
 const DEFAULT_CONCURRENCY = 2;
 
-export interface StandalonePrCriticDeps {
+export interface StandalonePrCriticDeps extends MembraneSeams {
   store: Pick<
     SessionStore,
     | "getRepoConfig"
@@ -119,16 +105,6 @@ export interface StandalonePrCriticDeps {
   ) => Promise<{ patchId: string | null; baseSha: string | null; files: string[] }>;
   /** Injectable reader of a finished reviewer's token totals (default: readSessionUsage). */
   readUsage?: (worktreePath: string, criticSessionId: string) => Promise<SessionUsage | null>;
-  /** Injectable sandbox backend probe seam (tests inject `() => null` so no real bwrap is
-   *  spawned). Presence-checked (not `??`) because the seam legitimately returns null. */
-  detectBackend?: () => SandboxBackend;
-  /** Injectable membrane env seam (tests inject a stub so no host paths are touched). */
-  membraneEnv?: () => {
-    claudeDir: string;
-    home: string;
-    nodeBinReal: string;
-    extraEnv?: Record<string, string>;
-  };
 }
 
 export class StandalonePrCriticService {
@@ -152,33 +128,6 @@ export class StandalonePrCriticService {
     worktreePath: string,
     criticSessionId: string,
   ) => Promise<SessionUsage | null>;
-
-  /** Sandbox backend probe: injected seam (tests) or the real cached self-test. Presence-
-   *  checked (not `??`) because the seam legitimately returns null (no backend). */
-  private detectBackend(): SandboxBackend {
-    if (this.deps.detectBackend) return this.deps.detectBackend();
-    return realDetectBackend({
-      home: homedir(),
-      claudeDir: config.claudeDir,
-      nodeBinReal: safeRealpath(config.nodeBin),
-    });
-  }
-
-  /** Membrane env: injected seam (tests) or real host values. */
-  private membraneEnv(): {
-    claudeDir: string;
-    home: string;
-    nodeBinReal: string;
-    extraEnv?: Record<string, string>;
-  } {
-    if (this.deps.membraneEnv) return this.deps.membraneEnv();
-    return {
-      claudeDir: config.claudeDir,
-      home: homedir(),
-      nodeBinReal: safeRealpath(config.nodeBin),
-      extraEnv: collectPassthroughEnv(),
-    };
-  }
 
   constructor(private deps: StandalonePrCriticDeps) {
     this.now = deps.now ?? Date.now;
@@ -462,21 +411,13 @@ export class StandalonePrCriticService {
       // the identical #597 VERIFY prompt and needs the same cross-file reasoning headroom.
       CRITIC_THINKING_TOKENS,
     );
-    const backend = this.detectBackend();
-    const env = this.membraneEnv();
-    const membrane: MembraneInputs = {
+    const { wrapped, backend } = resolveSpawnMembrane({
+      argv,
       worktreePath,
-      gitCommonDir: this.deps.worktree.gitCommonDir(worktreePath),
-      isolated: true,
       repoPath,
-      claudeDir: env.claudeDir,
-      home: env.home,
-      nodeBinReal: env.nodeBinReal,
-      extraEnv: env.extraEnv,
-      // api-key mode: a bwrap-wrapped reviewer masks the OAuth credential + binds the helper.
-      ...apiKeyMembraneFields(),
-    };
-    const wrapped = wrapArgv(argv, { profile: "standard", backend, membrane });
+      worktree: this.deps.worktree,
+      seams: this.deps,
+    });
 
     let terminalId: string;
     try {

--- a/test/spawn-membrane.test.ts
+++ b/test/spawn-membrane.test.ts
@@ -1,0 +1,88 @@
+import { test, expect, describe } from "bun:test";
+import {
+  resolveBackend,
+  resolveMembraneEnv,
+  resolveSpawnMembrane,
+  type MembraneEnv,
+} from "../src/spawn-membrane";
+
+const stubEnv: MembraneEnv = {
+  claudeDir: "/stub/.claude",
+  home: "/stub/home",
+  nodeBinReal: "/stub/bin/node",
+  extraEnv: { LANG: "C.UTF-8" },
+};
+
+function worktreeStub(gitCommonDirCalls?: string[]) {
+  return {
+    gitCommonDir: (p: string) => {
+      if (gitCommonDirCalls) gitCommonDirCalls.push(p);
+      return `${p}/.git`;
+    },
+  };
+}
+
+describe("resolveBackend", () => {
+  test("PRESENCE-CHECK REGRESSION: seam returning null returns null, NOT real probe", () => {
+    // This is the critical regression guard: if `??` were used instead of a presence-check,
+    // `() => null` would fall through to the real backend probe. It must NOT.
+    const result = resolveBackend({ detectBackend: () => null });
+    expect(result).toBeNull();
+  });
+
+  test("seam returning 'bwrap' returns 'bwrap'", () => {
+    const result = resolveBackend({ detectBackend: () => "bwrap" });
+    expect(result).toBe("bwrap");
+  });
+});
+
+describe("resolveMembraneEnv", () => {
+  test("honors injected membraneEnv seam, returns stub verbatim", () => {
+    const result = resolveMembraneEnv({ membraneEnv: () => stubEnv });
+    expect(result).toBe(stubEnv);
+  });
+});
+
+describe("resolveSpawnMembrane", () => {
+  const argv = ["claude", "--some-flag"];
+
+  test("backend null → passthrough (wrapped deep-equals input argv), gitCommonDir called with worktreePath", () => {
+    const calls: string[] = [];
+    const { wrapped, backend } = resolveSpawnMembrane({
+      argv,
+      worktreePath: "/wt/task",
+      repoPath: "/repo",
+      worktree: worktreeStub(calls),
+      seams: {
+        detectBackend: () => null,
+        membraneEnv: () => stubEnv,
+      },
+    });
+
+    expect(backend).toBeNull();
+    expect(wrapped).toEqual(argv);
+    expect(calls).toContain("/wt/task");
+  });
+
+  test("backend 'bwrap' → wrapped[0] === 'bwrap', original argv tokens preserved after '--'", () => {
+    const { wrapped, backend } = resolveSpawnMembrane({
+      argv,
+      worktreePath: "/wt/task",
+      repoPath: "/repo",
+      worktree: worktreeStub(),
+      seams: {
+        detectBackend: () => "bwrap",
+        membraneEnv: () => stubEnv,
+      },
+    });
+
+    expect(backend).toBe("bwrap");
+    expect(wrapped[0]).toBe("bwrap");
+
+    // inner argv preserved after the last `--` separator
+    const lastSep = wrapped.lastIndexOf("--");
+    expect(lastSep).toBeGreaterThan(0);
+    const innerArgv = wrapped.slice(lastSep + 1);
+    expect(innerArgv).toEqual(argv);
+  });
+});


### PR DESCRIPTION
## What

Implements #937. Pure refactor — extracts the spawn/membrane boilerplate copy-pasted across the four reviewer-style spawners into one shared helper, `src/spawn-membrane.ts`, and has all four consume it. **No behavior change.**

## Why

`doc-agent`, `plan-gate`, `review`, and `standalone-critic` each hand-rolled the same plumbing: the `detectBackend()`/`membraneEnv()` injectable-seam pair plus the `MembraneInputs` assembly + `wrapArgv` call. A fix to the membrane/egress posture had to be applied four times and could drift silently. Now it lives in one place.

## How

`src/spawn-membrane.ts` exports:
- `MembraneSeams` — the injectable `detectBackend?`/`membraneEnv?` seams (field names preserved, so existing per-service tests inject through `deps` unchanged).
- `resolveBackend(seams)` / `resolveMembraneEnv(seams)` — the host-value fallbacks, using **presence-check** semantics (`if (seams.detectBackend) …`), NOT `??`. `detectBackend` legitimately returns `null` (no backend); a `?? real()` would fall through to the real bwrap probe and break the seam.
- `resolveSpawnMembrane({ argv, worktreePath, repoPath, worktree, seams }) → { wrapped, backend }` — the `MembraneInputs` assembly (byte-faithful: same field order, `profile:"standard"`, `...apiKeyMembraneFields()`) + `wrapArgv`.

Each of the four services now `extends MembraneSeams`, deletes its private `detectBackend()`/`membraneEnv()`, and calls `resolveSpawnMembrane(...)` at its spawn site. Surrounding control flow (worktree alloc/cleanup, fail-closed api-key guards, `apiKeyPassthroughEnv(backend !== null)`, try/catch) is untouched.

Net: +199 / −262 across 6 files.

## Scope notes

- The remaining `plan-gate↔review` clones (worktree `createDetached` + post-await re-check + fail-closed block) are **separate, pre-existing debt** and deliberately out of scope — folding them in would change control flow.
- `drain.ts` / `service.ts` also call `detectBackend()` but with a different shape (`trusted` profile, non-isolated, no `membraneEnv`); left untouched. Confirmed via `fallow dupes` that the extraction creates **no** new clone group pairing the helper with them.
- No `.fallowrc.jsonc` edit: the audit gate is base-relative, so removing the boilerplate from HEAD is itself what makes the gate enforce the merged form going forward.

## Verification

- `bunx tsc --noEmit` clean; `bun run lint` clean.
- Full server suite `bun test ./test`: **4268 pass / 0 fail** (existing per-service spawn tests pass unchanged) + a new `test/spawn-membrane.test.ts` (incl. the presence-check `() => null` regression).
- `bunx fallow@2.100.0 dupes` + `audit --base origin/main --fail-on-issues`: exit 0 — the seam-pair + membrane-assembly clones across the four files are gone.

Note: #936 (the `typedoc-plugin-markdown` fallow `ignoreDependencies` change) is a separate, already-merged issue (#940) — not addressed here.

[no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
