### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/glossary.md
+++ b/docs-site/src/content/docs/reference/glossary.md
@@ -42,6 +42,13 @@ A repo Shepherd drives with local git only — no Forge, no GitHub, no PRs, no
 remote. When a task finishes, the agent's branch is squash-merged into the base
 branch locally; the operator pushes to a remote when they choose.
 
+### Trial
+
+A proposed house rule that Shepherd auto-promoted to active on strong,
+multi-source evidence, injected at the lowest priority while it proves itself.
+It is auto-removed if it underperforms (Wilson auto-retire) or stays inert, and
+can be reverted to the queue by hand.
+
 ## Industry terms
 
 ### PR

--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -46,11 +46,11 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 
 ## What actually gates access
 
-| Gate                 | Default                          | What Hermes must do                                                                               |
-| -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Network bind**     | `127.0.0.1:7330` (loopback only) | Run on the same host, reach it over Tailscale serve, or set `SHEPHERD_HOST` to expose another NIC |
-| **Auth token**       | `SHEPHERD_TOKEN` unset → open    | If set, send `Authorization: Bearer <token>` on every request (timing-safe compare)               |
-| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~/Work`  | `repoPath` must resolve **inside** the root, or the request is rejected `400`                     |
+| Gate                 | Default                           | What Hermes must do                                                                               |
+| -------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **Network bind**     | `127.0.0.1:7330` (loopback only)  | Run on the same host, reach it over Tailscale serve, or set `SHEPHERD_HOST` to expose another NIC |
+| **Auth token**       | `SHEPHERD_TOKEN` unset → open     | If set, send `Authorization: Bearer <token>` on every request (timing-safe compare)               |
+| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~` (home) | `repoPath` must resolve **inside** the root, or the request is rejected `400`                     |
 
 ### Recommended setup for a remote agent
 
@@ -65,13 +65,13 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 `POST /api/sessions`, `Content-Type: application/json`. Validated by
 `validateCreate` (`src/validate.ts`); unknown keys are rejected.
 
-| Field        | Type                                    | Required | Notes                                                                        |
-| ------------ | --------------------------------------- | -------- | ---------------------------------------------------------------------------- |
-| `repoPath`   | string                                  | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
-| `baseBranch` | string                                  | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
-| `prompt`     | string                                  | ✅       | The task instructions; 1–8000 chars                                          |
-| `model`      | `"opus" \| "sonnet" \| "haiku" \| null` | —        | Omit/`null` = Claude's default                                               |
-| `images`     | `string[]`                              | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
+| Field        | Type                                                                             | Required | Notes                                                                        |
+| ------------ | -------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------- |
+| `repoPath`   | string                                                                           | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
+| `baseBranch` | string                                                                           | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
+| `prompt`     | string                                                                           | ✅       | The task instructions; 1–8000 chars                                          |
+| `model`      | `"fable" \| "opus" \| "opus[1m]" \| "sonnet" \| "sonnet[1m]" \| "haiku" \| null` | —        | One of `src/types.ts` `MODELS`. Omit/`null`/`"default"` = Claude's default   |
+| `images`     | `string[]`                                                                       | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
 
 ### Responses
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

## Changes

- **`docs/external-task-api.md`** — two stale facts in the request-schema /
  access-gates tables:
  - `model` field enum was `"opus" | "sonnet" | "haiku" | null`, but the accepted
    set is `src/types.ts` `MODELS` = `["fable", "opus", "opus[1m]", "sonnet",
    "sonnet[1m]", "haiku"]` (validated by `validateModel` in `src/validate.ts:82`,
    which also treats `"default"` as null). Updated the enum to include `fable` and
    the `[1m]` variants and to note `"default"` as a no-`--model` alias. Fable as a
    first-class tier is corroborated by the in-scope `docs/token-usage-analysis.md`
    and `config.ts` `fableAvailable`.
  - Repo-confinement row claimed `SHEPHERD_REPO_ROOT` defaults to `~/Work`. Source
    (`src/config.ts:322,325`) defaults `repoRoot`/`rootCeiling` to `$HOME` (i.e.
    `~`), matching `docs-site/.../reference/configuration.md`. Changed to `~` (home).

- **`docs-site/src/content/docs/reference/glossary.md`** — added a **Trial** entry
  under "Shepherd concepts". The glossary registry it mirrors
  (`ui/src/lib/glossary.ts`) gained a `trial` term in #946 (auto-trial of strong
  learnings proposals); the page covered every other registry term but this one.
  Prose adapted from the catalog definition (`ui/messages/en.json` `gloss_trial_def`).

## Uncertain / needs human judgment

- **`docs/external-task-api.md` request schema is missing several now-accepted
  fields.** `validateCreate` (`src/validate.ts` `ALLOWED_KEYS`) accepts
  `issueRef`, `planGateEnabled`, `autopilotEnabled`, `sandboxProfile`, `research`,
  and `mergeTrainPrs` in addition to the documented `repoPath`/`baseBranch`/
  `prompt`/`model`/`images`. The page may be intentionally curated to the minimal
  task-submission surface for external agents, so I did not add rows for these —
  worth a human decision on whether to document the full option set.

- **`docs-site/.../reference/configuration.md` is not an exhaustive env-var list**
  despite its intro saying "Every environment variable." Many vars in `config.ts`
  are undocumented (e.g. `SHEPHERD_SANDBOX_EXTRA_HOSTS`, `SHEPHERD_REDUCED_PUSH_MODE`,
  `SHEPHERD_AUTH_MODE`, `SHEPHERD_USAGE_HOLD_*`, the review-cycle caps, naming/model
  knobs, VAPID/push). This looks like a deliberate curated subset rather than recent
  staleness, so I changed nothing — but the "Every environment variable" framing vs.
  the partial table is a mismatch a human may want to reconcile.

- **`docs/sandbox-security.md`** egress allowlist text ("api.anthropic.com +
  statsig.anthropic.com + the GitHub hosts") does not mention the operator
  extra-hosts allowlist (`SHEPHERD_SANDBOX_EXTRA_HOSTS` / per-repo
  `egressExtraHosts`, `src/validate.ts:591`). The note is a line-number-precise
  internal residuals doc; I left it untouched rather than risk drift, but the
  allowlist composition may deserve a refresh.