### PR TITLE
fix(top-bar): polish Extra Credits detail card

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1149,6 +1149,7 @@
   "topbar_credits_period": "Zusatzguthaben",
   "topbar_credits_amount": "{spent} von {cap} verbraucht",
   "topbar_credits_age": "abgerufen vor {age}",
+  "topbar_credits_age_now": "gerade abgerufen",
   "topbar_credits_stale": "Snapshot veraltet — für Live-Verbrauch aktualisieren",
   "topbar_credits_alert_aria": "Zusatzguthaben in Nutzung: {amount}",
   "topbar_credits_refresh": "Aktualisieren",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1149,6 +1149,7 @@
   "topbar_credits_period": "Extra credits",
   "topbar_credits_amount": "{spent} of {cap} spent",
   "topbar_credits_age": "scraped {age} ago",
+  "topbar_credits_age_now": "scraped just now",
   "topbar_credits_stale": "snapshot stale — refresh for live spend",
   "topbar_credits_alert_aria": "Extra credits in use: {amount}",
   "topbar_credits_refresh": "Refresh",

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -961,6 +961,18 @@ describe("TopBar — CR extra-credit gauge", () => {
     expect(detail!.querySelector(".credit-refresh"), "refresh button present").not.toBeNull();
   });
 
+  it("shows 'just now' (not 'now ago') for a fresh scrape", async () => {
+    const hud = await renderDesktop(
+      limitsWithCredit({ scrapedAt: 1_700_000_000_000 - 10_000 }), // 10s before nowMs
+    );
+    const wrap = hud.querySelector<HTMLElement>(".gauges-wrap");
+    wrap!.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await nextFrame();
+    const txt = hud.querySelector<HTMLElement>(".credit-detail")!.textContent ?? "";
+    expect(txt, "just-now line").toContain(m.topbar_credits_age_now());
+    expect(txt, "no 'now ago'").not.toContain(m.topbar_credits_age({ age: "now" }));
+  });
+
   it("shows the stale note in the popover for a stale snapshot", async () => {
     const hud = await renderDesktop(limitsWithCredit({ stale: true }));
     const wrap = hud.querySelector<HTMLElement>(".gauges-wrap");

--- a/ui/src/lib/components/top-bar/CreditDetail.svelte
+++ b/ui/src/lib/components/top-bar/CreditDetail.svelte
@@ -24,6 +24,10 @@
     onRefresh: () => void;
     wide?: boolean;
   } = $props();
+
+  // relativeAge returns the "now" sentinel for <60s; branch it to a natural phrase
+  // ("scraped just now") rather than feeding "now" into the "scraped {age} ago" template.
+  const age = $derived(credits ? relativeAge(credits.scrapedAt, nowMs) : "");
 </script>
 
 {#if credits}
@@ -48,7 +52,7 @@
       </div>
     {/if}
     <div class="gauge-pop-reset micro">
-      {m.topbar_credits_age({ age: relativeAge(credits.scrapedAt, nowMs) })}
+      {age === "now" ? m.topbar_credits_age_now() : m.topbar_credits_age({ age })}
     </div>
     {#if credits.stale}
       <div class="credit-stale micro">{m.topbar_credits_stale()}</div>
@@ -144,21 +148,20 @@
     display: flex;
     align-items: baseline;
     justify-content: space-between;
+    gap: 0.75rem;
     font-variant-numeric: tabular-nums;
   }
   .gp-period {
     color: var(--color-text);
     font-size: var(--fs-meta);
     text-transform: capitalize;
+    white-space: nowrap;
   }
   .gauge-pop-reset {
-    margin: 0 0 6px 30px;
+    margin: 0;
     text-transform: none;
     letter-spacing: 0.04em;
     color: var(--color-faint);
-  }
-  .gauge-pop-reset:last-child {
-    margin-bottom: 0;
   }
   .micro {
     font-size: var(--fs-meta);


### PR DESCRIPTION
Cosmetic cleanup of the **Extra Credits** detail popover (top bar), from the attached report.

## Changes
- **Header spacing** — `.gp-head` had `justify-content: space-between` with no `gap`, so when the header was the widest line the label and amount glued together ("Extra credits€79.16 / €100.00"). Added `gap: 0.75rem` + `white-space: nowrap` on the label.
- **"scraped now ago"** — `relativeAge()` returns the literal `"now"` for <60s, which was dropped into the `"scraped {age} ago"` template. Now branches on the `"now"` sentinel to a dedicated message: **"scraped just now"** / DE **"gerade abgerufen"**. `relativeAge`/`format.ts` is unchanged (its bare `"now"` is correct for the shared age chips).
- **Subline alignment** — CreditDetail's scoped `.gauge-pop-reset` kept a `30px` left indent (the parent's reset rule can't reach it through Svelte style scoping), so the SCRAPED/reset lines sat indented vs. the SPENT line. Dropped the indent and the redundant `margin-bottom` (the parent flex `gap: 6px` already spaces lines).

## Tests
- New `TopBar.browser.test.ts` case asserts a fresh scrape renders "scraped just now" and **not** "now ago".
- Existing `TopBar.browser.test.ts:959` still covers the non-`now` branch (`age: "5m"`).
- `bun run check`, `check:i18n`, and the full UI suite (1824 tests) pass.

[no-feature-entry] cosmetic bugfix — no new user-facing capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)