### PR TITLE
feat(ui): /usage token-spend dashboard — Phase 0 visual prototype (#943)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1749,5 +1749,12 @@
   "usage_overhead_cacheread_label": "Cache-Lesevorgänge",
   "usage_overhead_generation_label": "Generierung",
   "gloss_satellite_pass_term": "Satelliten-Durchlauf",
-  "gloss_satellite_pass_def": "Ein automatisierter LLM-Durchlauf, den Shepherd parallel zum Hauptaufgaben-Agenten startet — Critic / PR-Review, Plan-Gate, Recap, Rundown oder Doc-Agent. Sein Token-Verbrauch ist echter Overhead, der der Aufgabe zusätzlich zu den eigenen Authoring-Tokens angerechnet wird."
+  "gloss_satellite_pass_def": "Ein automatisierter LLM-Durchlauf, den Shepherd parallel zum Hauptaufgaben-Agenten startet — Critic / PR-Review, Plan-Gate, Recap, Rundown oder Doc-Agent. Sein Token-Verbrauch ist echter Overhead, der der Aufgabe zusätzlich zu den eigenen Authoring-Tokens angerechnet wird.",
+  "usage_limits_window_5h": "5-Stunden-Fenster",
+  "usage_limits_window_week": "Wöchentliches Fenster",
+  "usage_limits_resets_in": "Reset in {time}",
+  "usage_limits_projected": "voraussichtlich {pct}% beim Reset",
+  "usage_limits_burn_rate": "{rate}/h",
+  "usage_limits_will_exceed": "voraussichtlich Limit überschritten",
+  "usage_limits_no_data": "Keine Nutzungsfenster-Daten"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1740,5 +1740,14 @@
   "usage_units_label": "[[weighted-units|gewichtete Einheiten]]",
   "usage_more_count": "… {count} weitere",
   "gloss_weighted_units_term": "gewichtete Einheiten",
-  "gloss_weighted_units_def": "Ein modellgewichtetes Maß für den Token-Verbrauch, das angibt, was tatsächlich dein Abonnement-Limit belastet — Ausgabe-Tokens kosten deutlich mehr als Cache-Lesevorgänge, daher spiegeln gewichtete Einheiten den echten Verbrauch besser wider als rohe Token-Zahlen."
+  "gloss_weighted_units_def": "Ein modellgewichtetes Maß für den Token-Verbrauch, das angibt, was tatsächlich dein Abonnement-Limit belastet — Ausgabe-Tokens kosten deutlich mehr als Cache-Lesevorgänge, daher spiegeln gewichtete Einheiten den echten Verbrauch besser wider als rohe Token-Zahlen.",
+  "usage_overhead_tax_heading": "Prüfer-Overhead",
+  "usage_overhead_authoring_label": "Authoring",
+  "usage_overhead_satellite_label": "[[satellite-pass|Satelliten-Durchläufe]]",
+  "usage_overhead_tax_caption": "{pct} durch Satelliten-Durchläufe hinzugekommen",
+  "usage_overhead_cache_heading": "Cache-Effizienz",
+  "usage_overhead_cacheread_label": "Cache-Lesevorgänge",
+  "usage_overhead_generation_label": "Generierung",
+  "gloss_satellite_pass_term": "Satelliten-Durchlauf",
+  "gloss_satellite_pass_def": "Ein automatisierter LLM-Durchlauf, den Shepherd parallel zum Hauptaufgaben-Agenten startet — Critic / PR-Review, Plan-Gate, Recap, Rundown oder Doc-Agent. Sein Token-Verbrauch ist echter Overhead, der der Aufgabe zusätzlich zu den eigenen Authoring-Tokens angerechnet wird."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1735,5 +1735,10 @@
   "docagent_trigger_skipped": "Doc-Agent wurde nicht gestartet (läuft bereits oder nichts zu tun)",
   "docagent_trigger_failed": "Doc-Agent konnte nicht gestartet werden",
   "feat_doc_agent_ui_title": "Doc-Agent im Backlog",
-  "feat_doc_agent_ui_body": "Starte den PR-gesicherten Doc-Agent für ein Repo direkt aus der Backlog-Aktionsleiste. Ein Status-Badge verfolgt den Lauf und verlinkt die geöffnete Doku-Update-PR; ein Popover zeigt die letzten Läufe. Aktivierung über SHEPHERD_DOC_AGENT."
+  "feat_doc_agent_ui_body": "Starte den PR-gesicherten Doc-Agent für ein Repo direkt aus der Backlog-Aktionsleiste. Ein Status-Badge verfolgt den Lauf und verlinkt die geöffnete Doku-Update-PR; ein Popover zeigt die letzten Läufe. Aktivierung über SHEPHERD_DOC_AGENT.",
+  "usage_spend_heading": "Ausgaben",
+  "usage_units_label": "[[weighted-units|gewichtete Einheiten]]",
+  "usage_more_count": "… {count} weitere",
+  "gloss_weighted_units_term": "gewichtete Einheiten",
+  "gloss_weighted_units_def": "Ein modellgewichtetes Maß für den Token-Verbrauch, das angibt, was tatsächlich dein Abonnement-Limit belastet — Ausgabe-Tokens kosten deutlich mehr als Cache-Lesevorgänge, daher spiegeln gewichtete Einheiten den echten Verbrauch besser wider als rohe Token-Zahlen."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1736,7 +1736,7 @@
   "docagent_trigger_failed": "Doc-Agent konnte nicht gestartet werden",
   "feat_doc_agent_ui_title": "Doc-Agent im Backlog",
   "feat_doc_agent_ui_body": "Starte den PR-gesicherten Doc-Agent für ein Repo direkt aus der Backlog-Aktionsleiste. Ein Status-Badge verfolgt den Lauf und verlinkt die geöffnete Doku-Update-PR; ein Popover zeigt die letzten Läufe. Aktivierung über SHEPHERD_DOC_AGENT.",
-  "usage_spend_heading": "Ausgaben",
+  "usage_spend_heading": "Verbrauch",
   "usage_units_label": "[[weighted-units|gewichtete Einheiten]]",
   "usage_more_count": "… {count} weitere",
   "gloss_weighted_units_term": "gewichtete Einheiten",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1756,5 +1756,15 @@
   "usage_limits_projected": "voraussichtlich {pct}% beim Reset",
   "usage_limits_burn_rate": "{rate}/h",
   "usage_limits_will_exceed": "voraussichtlich Limit überschritten",
-  "usage_limits_no_data": "Keine Nutzungsfenster-Daten"
+  "usage_limits_no_data": "Keine Nutzungsfenster-Daten",
+  "usage_page_title": "Nutzung",
+  "usage_prototype_note": "Beispieldaten · visueller Prototyp",
+  "usage_spend_tab": "Verbrauch",
+  "usage_overhead_tab": "Overhead",
+  "usage_limits_tab": "Limits",
+  "usage_range_label": "Zeitraum",
+  "usage_range_24h": "24h",
+  "usage_range_7d": "7d",
+  "usage_range_30d": "30d",
+  "usage_range_all": "Alle"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1749,5 +1749,12 @@
   "usage_overhead_cacheread_label": "cached reads",
   "usage_overhead_generation_label": "generation",
   "gloss_satellite_pass_term": "satellite pass",
-  "gloss_satellite_pass_def": "An automated LLM pass Shepherd spawns alongside the main task agent — critic / PR-review, plan-gate, recap, rundown, or doc-agent. Its token spend is real overhead attributed back to the task, on top of the agent's own authoring."
+  "gloss_satellite_pass_def": "An automated LLM pass Shepherd spawns alongside the main task agent — critic / PR-review, plan-gate, recap, rundown, or doc-agent. Its token spend is real overhead attributed back to the task, on top of the agent's own authoring.",
+  "usage_limits_window_5h": "5-hour window",
+  "usage_limits_window_week": "Weekly window",
+  "usage_limits_resets_in": "resets in {time}",
+  "usage_limits_projected": "projected {pct}% at reset",
+  "usage_limits_burn_rate": "{rate}/h",
+  "usage_limits_will_exceed": "projected to exceed limit",
+  "usage_limits_no_data": "No usage-window data"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1740,5 +1740,14 @@
   "usage_units_label": "[[weighted-units|weighted units]]",
   "usage_more_count": "… {count} more",
   "gloss_weighted_units_term": "weighted units",
-  "gloss_weighted_units_def": "A model-weighted measure of token spend that counts what actually draws down your subscription limits — output tokens cost far more than cached reads, so weighted units, not raw token counts, reflect true usage."
+  "gloss_weighted_units_def": "A model-weighted measure of token spend that counts what actually draws down your subscription limits — output tokens cost far more than cached reads, so weighted units, not raw token counts, reflect true usage.",
+  "usage_overhead_tax_heading": "Reviewer tax",
+  "usage_overhead_authoring_label": "authoring",
+  "usage_overhead_satellite_label": "[[satellite-pass|satellite passes]]",
+  "usage_overhead_tax_caption": "{pct} added by satellite passes",
+  "usage_overhead_cache_heading": "Cache efficiency",
+  "usage_overhead_cacheread_label": "cached reads",
+  "usage_overhead_generation_label": "generation",
+  "gloss_satellite_pass_term": "satellite pass",
+  "gloss_satellite_pass_def": "An automated LLM pass Shepherd spawns alongside the main task agent — critic / PR-review, plan-gate, recap, rundown, or doc-agent. Its token spend is real overhead attributed back to the task, on top of the agent's own authoring."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1756,5 +1756,15 @@
   "usage_limits_projected": "projected {pct}% at reset",
   "usage_limits_burn_rate": "{rate}/h",
   "usage_limits_will_exceed": "projected to exceed limit",
-  "usage_limits_no_data": "No usage-window data"
+  "usage_limits_no_data": "No usage-window data",
+  "usage_page_title": "Usage",
+  "usage_prototype_note": "Sample data · visual prototype",
+  "usage_spend_tab": "Spend",
+  "usage_overhead_tab": "Overhead",
+  "usage_limits_tab": "Limits",
+  "usage_range_label": "Time range",
+  "usage_range_24h": "24h",
+  "usage_range_7d": "7d",
+  "usage_range_30d": "30d",
+  "usage_range_all": "All"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1735,5 +1735,10 @@
   "docagent_trigger_skipped": "Doc agent didn't start (already running or nothing to do)",
   "docagent_trigger_failed": "Couldn't start the doc agent",
   "feat_doc_agent_ui_title": "Doc agent in the Backlog",
-  "feat_doc_agent_ui_body": "Trigger the PR-gated doc agent for a repo from the Backlog Actions bar. A status badge tracks the run and links the doc-update PR it opens; a popover shows recent runs. Opt-in via SHEPHERD_DOC_AGENT."
+  "feat_doc_agent_ui_body": "Trigger the PR-gated doc agent for a repo from the Backlog Actions bar. A status badge tracks the run and links the doc-update PR it opens; a popover shows recent runs. Opt-in via SHEPHERD_DOC_AGENT.",
+  "usage_spend_heading": "Spend",
+  "usage_units_label": "[[weighted-units|weighted units]]",
+  "usage_more_count": "… {count} more",
+  "gloss_weighted_units_term": "weighted units",
+  "gloss_weighted_units_def": "A model-weighted measure of token spend that counts what actually draws down your subscription limits — output tokens cost far more than cached reads, so weighted units, not raw token counts, reflect true usage."
 }

--- a/ui/src/lib/components/usage/LimitsLens.browser.test.ts
+++ b/ui/src/lib/components/usage/LimitsLens.browser.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import { mockLimits, mockProjections } from "$lib/usage-mock";
+
+const { default: LimitsLens } = await import("./LimitsLens.svelte");
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("LimitsLens", () => {
+  it("renders a meter block for each window", async () => {
+    const limits = mockLimits();
+    const projections = mockProjections();
+    render(LimitsLens, { limits, projections });
+
+    // Two window blocks — one per gauge (5H and WK)
+    const meterTracks = document.querySelectorAll(".meter-track");
+    expect(meterTracks.length, "one meter per window").toBe(2);
+  });
+
+  it("shows the current pct for each window", async () => {
+    const limits = mockLimits(); // session5h.pct=38, week.pct=22
+    const projections = mockProjections();
+    render(LimitsLens, { limits, projections });
+
+    await expect.element(page.getByText("38%")).toBeInTheDocument();
+    await expect.element(page.getByText("22%")).toBeInTheDocument();
+  });
+
+  it("renders reset-time captions for each window", async () => {
+    const limits = mockLimits();
+    const projections = mockProjections();
+    render(LimitsLens, { limits, projections });
+
+    // Both windows should show "resets in …"
+    const resets = document.querySelectorAll(".reset-time");
+    expect(resets.length, "reset caption per window").toBe(2);
+    // Each caption should contain "resets in"
+    for (const el of resets) {
+      expect(el.textContent).toMatch(/resets in/i);
+    }
+  });
+
+  it("renders projection info for matched windows", async () => {
+    const limits = mockLimits();
+    const projections = mockProjections(); // 5H: projectedPct=64, burnRate=48_000; WK: projectedPct=41, burnRate=31_000
+    render(LimitsLens, { limits, projections });
+
+    // Projection info rows should be present for both windows
+    const projInfos = document.querySelectorAll(".proj-info");
+    expect(projInfos.length, "projection info per window").toBe(2);
+
+    // 5H: projected 64% at reset
+    await expect.element(page.getByText(/projected 64%/i)).toBeInTheDocument();
+    // WK: projected 41% at reset
+    await expect.element(page.getByText(/projected 41%/i)).toBeInTheDocument();
+  });
+
+  it("renders burn rate captions", async () => {
+    const limits = mockLimits();
+    const projections = mockProjections();
+    render(LimitsLens, { limits, projections });
+
+    // Both windows have projections → two burn rate captions
+    const burnRates = document.querySelectorAll(".burn-rate");
+    expect(burnRates.length, "burn rate caption per matched window").toBe(2);
+
+    // 5H burn rate: 48_000 → "48K/h"
+    await expect.element(page.getByText(/48K\/h/)).toBeInTheDocument();
+    // WK burn rate: 31_000 → "31K/h"
+    await expect.element(page.getByText(/31K\/h/)).toBeInTheDocument();
+  });
+
+  it("shows projection tick on the meter", async () => {
+    const limits = mockLimits();
+    const projections = mockProjections();
+    render(LimitsLens, { limits, projections });
+
+    const ticks = document.querySelectorAll(".proj-tick");
+    expect(ticks.length, "one tick per matched projection").toBe(2);
+  });
+
+  it("renders 'no data' message when limits are empty", async () => {
+    const emptyLimits = {
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: false,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    };
+    render(LimitsLens, { limits: emptyLimits, projections: [] });
+
+    await expect.element(page.getByText(/no usage-window data/i)).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/usage/LimitsLens.svelte
+++ b/ui/src/lib/components/usage/LimitsLens.svelte
@@ -33,7 +33,7 @@
       <div class="window-block">
         <div class="window-header">
           <span class="window-label">{windowLabel(gauge.label)}</span>
-          <span class="window-badge micro">{gauge.label}</span>
+          <span class="micro">{gauge.label}</span>
           <span class="window-pct" style="color:{color}">{gauge.w.pct}%</span>
         </div>
 
@@ -106,13 +106,6 @@
     font-weight: 600;
     color: var(--color-ink-bright);
     flex: 1;
-  }
-
-  .window-badge {
-    font-size: var(--fs-meta);
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: var(--color-muted);
   }
 
   .window-pct {

--- a/ui/src/lib/components/usage/LimitsLens.svelte
+++ b/ui/src/lib/components/usage/LimitsLens.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+  import type { UsageLimits, UsageProjection } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { gaugeList, gaugeColor } from "$lib/components/usage-gauges";
+  import { formatResetIn } from "$lib/format";
+  import { formatUnits } from "./format";
+
+  const { limits, projections }: { limits: UsageLimits; projections: UsageProjection[] } = $props();
+
+  const nowMs = $derived(Date.now());
+  const gauges = $derived(gaugeList(limits));
+
+  function windowLabel(label: "5H" | "WK"): string {
+    return label === "5H" ? m.usage_limits_window_5h() : m.usage_limits_window_week();
+  }
+
+  function findProjection(label: "5H" | "WK"): UsageProjection | undefined {
+    return projections.find((p) => p.window === label);
+  }
+</script>
+
+<div class="limits-lens panel">
+  {#if gauges.length === 0}
+    <p class="no-data">{m.usage_limits_no_data()}</p>
+  {:else}
+    {#each gauges as gauge (gauge.label)}
+      {@const pct = Math.min(Math.max(gauge.w.pct, 0), 100)}
+      {@const color = gaugeColor(gauge.w.pct)}
+      {@const proj = findProjection(gauge.label)}
+      {@const projPct = proj ? Math.min(Math.max(proj.projectedPct, 0), 100) : null}
+      {@const willExceed = proj ? proj.projectedPct > 100 : false}
+
+      <div class="window-block">
+        <div class="window-header">
+          <span class="window-label">{windowLabel(gauge.label)}</span>
+          <span class="window-badge micro">{gauge.label}</span>
+          <span class="window-pct" style="color:{color}">{gauge.w.pct}%</span>
+        </div>
+
+        <div
+          class="meter-wrap"
+          role="meter"
+          aria-valuenow={gauge.w.pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={windowLabel(gauge.label)}
+        >
+          <div class="meter-track">
+            <!-- Current fill -->
+            <div class="meter-fill" style="width:{pct}%;background:{color}"></div>
+            <!-- Projection tick -->
+            {#if projPct !== null}
+              <div class="proj-tick" style="left:{projPct}%" aria-hidden="true"></div>
+            {/if}
+          </div>
+        </div>
+
+        <div class="window-meta">
+          <span class="reset-time"
+            >{m.usage_limits_resets_in({ time: formatResetIn(gauge.w.resetAt, nowMs) })}</span
+          >
+          {#if proj}
+            <span class="proj-info" class:will-exceed={willExceed}>
+              {m.usage_limits_projected({ pct: proj.projectedPct })}
+              {#if willExceed}
+                &nbsp;—&nbsp;<span class="exceed-label">{m.usage_limits_will_exceed()}</span>
+              {/if}
+            </span>
+            <span class="burn-rate"
+              >{m.usage_limits_burn_rate({ rate: formatUnits(proj.burnRatePerHour) })}</span
+            >
+          {/if}
+        </div>
+      </div>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .limits-lens {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .no-data {
+    color: var(--color-muted);
+    font-size: var(--fs-base);
+    margin: 0;
+  }
+
+  .window-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .window-header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  .window-label {
+    font-size: var(--fs-base);
+    font-weight: 600;
+    color: var(--color-ink-bright);
+    flex: 1;
+  }
+
+  .window-badge {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+
+  .window-pct {
+    font-size: var(--fs-lg);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    min-width: 3.5rem;
+    text-align: right;
+  }
+
+  .meter-wrap {
+    width: 100%;
+  }
+
+  .meter-track {
+    position: relative;
+    width: 100%;
+    height: 10px;
+    background: var(--color-line);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 3px;
+    overflow: visible;
+  }
+
+  .meter-fill {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    border-radius: 3px 0 0 3px;
+    transition: width 0.4s ease;
+  }
+
+  .proj-tick {
+    position: absolute;
+    top: -3px;
+    bottom: -3px;
+    width: 2px;
+    background: var(--color-faint);
+    border-radius: 1px;
+    transform: translateX(-50%);
+    opacity: 0.7;
+  }
+
+  .window-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem 1rem;
+  }
+
+  .reset-time {
+    font-size: var(--fs-meta);
+    color: var(--color-faint);
+  }
+
+  .proj-info {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+
+  .proj-info.will-exceed {
+    color: var(--color-red);
+  }
+
+  .exceed-label {
+    color: var(--color-red);
+  }
+
+  .burn-rate {
+    font-size: var(--fs-meta);
+    color: var(--color-faint);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+</style>

--- a/ui/src/lib/components/usage/OverheadLens.browser.test.ts
+++ b/ui/src/lib/components/usage/OverheadLens.browser.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import { mockBreakdown } from "$lib/usage-mock";
+
+const { default: OverheadLens } = await import("./OverheadLens.svelte");
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("OverheadLens", () => {
+  it("overall tax caption renders a non-empty percentage", async () => {
+    const breakdown = mockBreakdown("7d");
+    render(OverheadLens, { breakdown });
+
+    // Tax caption should contain a % sign
+    const captions = document.querySelectorAll(".tax-caption");
+    expect(captions.length, "tax caption rendered").toBeGreaterThan(0);
+    const captionText = captions[0]?.textContent ?? "";
+    expect(captionText).toMatch(/%/);
+    expect(captionText.trim().length, "caption is non-empty").toBeGreaterThan(0);
+  });
+
+  it("per-task tax list shows ≤6 rows sorted with highest-tax task first and a +% label", async () => {
+    const breakdown = mockBreakdown("7d");
+    render(OverheadLens, { breakdown });
+
+    const rows = document.querySelectorAll(".tax-task-row");
+    expect(rows.length, "at least 1 tax task row").toBeGreaterThanOrEqual(1);
+    expect(rows.length, "at most 6 tax task rows").toBeLessThanOrEqual(6);
+
+    // First row should have the highest tax — check its +% label
+    const firstPct = rows[0]?.querySelector(".tax-pct");
+    expect(firstPct, "first row has a .tax-pct element").not.toBeNull();
+    expect(firstPct?.textContent ?? "").toMatch(/^\+\d+%$/);
+
+    // All pct labels should start with +
+    rows.forEach((row, i) => {
+      const pctEl = row.querySelector(".tax-pct");
+      expect(pctEl?.textContent ?? "", `row ${i} has +% label`).toMatch(/^\+\d+%$/);
+    });
+
+    // Verify descending order: extract numeric values and check sorted
+    const pctValues = Array.from(rows).map((row) => {
+      const txt = row.querySelector(".tax-pct")?.textContent ?? "+0%";
+      return parseInt(txt.replace(/^\+/, "").replace(/%$/, ""), 10);
+    });
+    for (let i = 1; i < pctValues.length; i++) {
+      expect(pctValues[i], `row ${i} tax ≤ row ${i - 1} tax (sorted desc)`).toBeLessThanOrEqual(
+        pctValues[i - 1],
+      );
+    }
+  });
+
+  it("cacheRead ratio section renders both cached-reads and generation shares", async () => {
+    const breakdown = mockBreakdown("7d");
+    render(OverheadLens, { breakdown });
+
+    // The cache section heading should be present
+    await expect.element(page.getByText("Cache efficiency")).toBeInTheDocument();
+
+    // Both labels should be present
+    await expect.element(page.getByText("cached reads")).toBeInTheDocument();
+    await expect.element(page.getByText("generation")).toBeInTheDocument();
+
+    // Both segments should exist in the DOM
+    const cacheReadSeg = document.querySelector(".cacheread-seg");
+    const generationSeg = document.querySelector(".generation-seg");
+    expect(cacheReadSeg, "cacheread segment present").not.toBeNull();
+    expect(generationSeg, "generation segment present").not.toBeNull();
+
+    // Segments should have non-zero widths (style attribute set)
+    const crStyle = (cacheReadSeg as HTMLElement)?.style.width ?? "";
+    const genStyle = (generationSeg as HTMLElement)?.style.width ?? "";
+    expect(crStyle, "cacheread segment has width").not.toBe("");
+    expect(genStyle, "generation segment has width").not.toBe("");
+
+    // The split-share spans for the cache section should contain % values
+    const shareEls = document.querySelectorAll(".split-share");
+    const sharePcts = Array.from(shareEls).map((el) => el.textContent ?? "");
+    const hasPercent = sharePcts.some((t) => t.includes("%"));
+    expect(hasPercent, "at least one share percentage displayed").toBe(true);
+  });
+});

--- a/ui/src/lib/components/usage/OverheadLens.svelte
+++ b/ui/src/lib/components/usage/OverheadLens.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+  import type { UsageBreakdown, UsageTaskBreakdown } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import GlossaryText from "$lib/components/GlossaryText.svelte";
+  import UsageBar from "./UsageBar.svelte";
+  import SplitBar from "./SplitBar.svelte";
+  import { formatUnits, formatPct } from "./format";
+
+  const { breakdown }: { breakdown: UsageBreakdown } = $props();
+
+  // ─── Reviewer tax ────────────────────────────────────────────────────────────
+
+  /** All tasks flattened across repos. */
+  const allTasks = $derived(breakdown.repos.flatMap((r) => r.tasks));
+
+  /** Per-task tax = satelliteUnits / authoringUnits (guarded). */
+  function taskTax(task: UsageTaskBreakdown): number {
+    return task.authoringUnits > 0 ? task.satelliteUnits / task.authoringUnits : 0;
+  }
+
+  /** Top 6 tasks by tax, descending. */
+  const topTaxTasks = $derived([...allTasks].sort((a, b) => taskTax(b) - taskTax(a)).slice(0, 6));
+
+  /** Max tax in the top-6 list (for bar scaling). */
+  const maxTax = $derived(topTaxTasks.length > 0 ? taskTax(topTaxTasks[0]) : 1);
+
+  /** Overall satellite share relative to authoring (the "tax" caption). */
+  const overallTax = $derived(
+    breakdown.authoringUnits > 0 ? breakdown.satelliteUnits / breakdown.authoringUnits : 0,
+  );
+
+  // ─── Cache efficiency ────────────────────────────────────────────────────────
+
+  const cacheTotal = $derived(breakdown.cacheReadUnits + breakdown.generationUnits);
+
+  const cacheReadPct = $derived(cacheTotal > 0 ? breakdown.cacheReadUnits / cacheTotal : 0);
+  const generationPct = $derived(cacheTotal > 0 ? breakdown.generationUnits / cacheTotal : 0);
+</script>
+
+<div class="overhead-lens">
+  <!-- ── Section (a): Reviewer tax ── -->
+  <section class="panel overhead-section">
+    <h2 class="section-heading">{m.usage_overhead_tax_heading()}</h2>
+
+    <!-- Overall authoring vs satellite split bar -->
+    <div class="split-bar-wrap">
+      <div class="split-labels">
+        <span class="split-label authoring-label">{m.usage_overhead_authoring_label()}</span>
+        <span class="split-label satellite-label">
+          <GlossaryText text={m.usage_overhead_satellite_label()} />
+        </span>
+      </div>
+      <SplitBar
+        a={breakdown.authoringUnits}
+        b={breakdown.satelliteUnits}
+        aTone="var(--color-blue)"
+        bTone="var(--color-amber)"
+        aClass="authoring-seg"
+        bClass="satellite-seg"
+      />
+      <p class="tax-caption">
+        {m.usage_overhead_tax_caption({ pct: formatPct(overallTax) })}
+      </p>
+    </div>
+
+    <!-- Per-task tax list -->
+    {#if topTaxTasks.length > 0}
+      <div class="tax-task-list">
+        {#each topTaxTasks as task (task.sessionId)}
+          {@const tax = taskTax(task)}
+          <div class="tax-task-row">
+            <span class="tax-desig">{task.desig}</span>
+            <span class="tax-bar">
+              <UsageBar value={tax} max={maxTax} tone="var(--color-amber)" />
+            </span>
+            <span class="tax-pct">+{formatPct(tax)}</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  <!-- ── Section (b): Cache efficiency ── -->
+  <section class="panel overhead-section">
+    <h2 class="section-heading">{m.usage_overhead_cache_heading()}</h2>
+
+    <div class="split-bar-wrap">
+      <div class="split-labels">
+        <span class="split-label cacheread-label">
+          <span>{m.usage_overhead_cacheread_label()}</span>
+          <span class="split-units">{formatUnits(breakdown.cacheReadUnits)}</span>
+          <span class="split-share">{formatPct(cacheReadPct)}</span>
+        </span>
+        <span class="split-label generation-label">
+          <span>{m.usage_overhead_generation_label()}</span>
+          <span class="split-units">{formatUnits(breakdown.generationUnits)}</span>
+          <span class="split-share">{formatPct(generationPct)}</span>
+        </span>
+      </div>
+      <SplitBar
+        a={breakdown.cacheReadUnits}
+        b={breakdown.generationUnits}
+        aTone="var(--color-blue)"
+        bTone="var(--color-amber)"
+        aClass="cacheread-seg"
+        bClass="generation-seg"
+      />
+    </div>
+  </section>
+</div>
+
+<style>
+  .overhead-lens {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .overhead-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .section-heading {
+    font-size: var(--fs-lg);
+    font-weight: 600;
+    color: var(--color-ink-bright);
+    margin: 0;
+  }
+
+  /* ── Split bar ── */
+  .split-bar-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .split-labels {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .split-label {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  .split-units {
+    font-variant-numeric: tabular-nums;
+    color: var(--color-ink);
+  }
+
+  .split-share {
+    color: var(--color-ink-bright);
+    font-weight: 500;
+  }
+
+  /* ── Tax caption ── */
+  .tax-caption {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    margin: 0;
+  }
+
+  /* ── Per-task tax list ── */
+  .tax-task-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .tax-task-row {
+    display: grid;
+    grid-template-columns: 6rem 1fr 4rem;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    font-size: var(--fs-meta);
+  }
+
+  .tax-desig {
+    color: var(--color-muted);
+    font-variant-numeric: tabular-nums;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .tax-bar {
+    display: flex;
+    align-items: center;
+  }
+
+  .tax-pct {
+    color: var(--color-ink);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/ui/src/lib/components/usage/SpendLens.browser.test.ts
+++ b/ui/src/lib/components/usage/SpendLens.browser.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import { mockBreakdown } from "$lib/usage-mock";
+
+const { default: SpendLens } = await import("./SpendLens.svelte");
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("SpendLens", () => {
+  it("renders repo rows from fixture", async () => {
+    const breakdown = mockBreakdown("7d");
+    render(SpendLens, { breakdown });
+
+    // All 3 repos should be present
+    await expect.element(page.getByText("shepherd")).toBeInTheDocument();
+    await expect.element(page.getByText("web-app")).toBeInTheDocument();
+    await expect.element(page.getByText("infra")).toBeInTheDocument();
+  });
+
+  it("default-expands the largest repo and shows ≤3 task rows", async () => {
+    const breakdown = mockBreakdown("7d");
+    render(SpendLens, { breakdown });
+
+    // Shepherd is the largest repo in 7d fixture.
+    // Its button should have aria-expanded="true"
+    const shepherdButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-expanded="true"]',
+    );
+    expect(shepherdButton, "one repo is default-expanded").not.toBeNull();
+    expect(shepherdButton?.textContent).toContain("shepherd");
+
+    // Task rows visible in the expanded section
+    const taskRows = document.querySelectorAll(".task-row");
+    expect(taskRows.length, "at most 3 task rows visible").toBeLessThanOrEqual(3);
+    expect(taskRows.length, "at least 1 task row visible").toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows '… N more' when a repo has more than 3 tasks", async () => {
+    // Shepherd in 7d has 9 tasks (7 from 24h + 2 extra) → should show "… 6 more"
+    const breakdown = mockBreakdown("7d");
+    render(SpendLens, { breakdown });
+
+    // The default-expanded repo (shepherd, 9 tasks) should have a "more" row
+    const moreRow = document.querySelector(".task-more");
+    expect(moreRow, "task-more row present").not.toBeNull();
+
+    // Remaining count = 9 - 3 = 6
+    const moreText = moreRow?.textContent ?? "";
+    expect(moreText).toMatch(/6/);
+  });
+
+  it("toggling a collapsed repo expands it and shows task rows", async () => {
+    const breakdown = mockBreakdown("7d");
+    render(SpendLens, { breakdown });
+
+    // Shepherd is expanded by default (3 task rows). web-app and infra are collapsed.
+    const collapsedBtn = document.querySelector<HTMLButtonElement>(
+      'button.repo-row[aria-expanded="false"]',
+    );
+    expect(collapsedBtn, "collapsed repo button exists").not.toBeNull();
+
+    const tasksBefore = document.querySelectorAll(".task-row").length;
+    expect(tasksBefore, "shepherd tasks shown before toggle").toBe(3);
+
+    // Click the collapsed repo button
+    collapsedBtn!.click();
+
+    // Svelte 5 batches DOM updates; poll until the attribute flips
+    await expect.poll(() => collapsedBtn!.getAttribute("aria-expanded")).toBe("true");
+
+    // New task rows should now be visible
+    const tasksAfter = document.querySelectorAll(".task-row").length;
+    expect(tasksAfter, "task rows increased after expanding").toBeGreaterThan(tasksBefore);
+  });
+});

--- a/ui/src/lib/components/usage/SpendLens.svelte
+++ b/ui/src/lib/components/usage/SpendLens.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+  import { SvelteSet } from "svelte/reactivity";
+  import type { UsageBreakdown, UsageRepoBreakdown, UsageTaskBreakdown } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import GlossaryText from "$lib/components/GlossaryText.svelte";
+  import UsageBar from "./UsageBar.svelte";
+  import { formatUnits, formatPct } from "./format";
+
+  const { breakdown }: { breakdown: UsageBreakdown } = $props();
+
+  /** Total weighted units for a repo. */
+  function repoTotal(repo: UsageRepoBreakdown): number {
+    return repo.authoringUnits + repo.satelliteUnits;
+  }
+
+  /** Total weighted units for a task. */
+  function taskTotal(task: UsageTaskBreakdown): number {
+    return task.authoringUnits + task.satelliteUnits;
+  }
+
+  /** Repos sorted descending by total units. */
+  const sortedRepos = $derived([...breakdown.repos].sort((a, b) => repoTotal(b) - repoTotal(a)));
+
+  /** Maximum repo total — used as the scale reference for all repo bars. */
+  const maxRepoTotal = $derived(sortedRepos.length > 0 ? repoTotal(sortedRepos[0]) : 1);
+
+  /**
+   * Expanded repos tracked by repoPath.
+   * Default: largest repo (first after sort) starts expanded.
+   * We compute the initial default directly from props (not from $derived) to
+   * avoid the state_referenced_locally Svelte 5 lint error.
+   */
+  function initialExpanded(): SvelteSet<string> {
+    const set = new SvelteSet<string>();
+    if (breakdown.repos.length === 0) return set;
+    const largest = [...breakdown.repos].sort((a, b) => repoTotal(b) - repoTotal(a))[0];
+    set.add(largest.repoPath);
+    return set;
+  }
+
+  const expandedPaths = initialExpanded();
+
+  function toggleRepo(path: string) {
+    if (expandedPaths.has(path)) {
+      expandedPaths.delete(path);
+    } else {
+      expandedPaths.add(path);
+    }
+  }
+
+  /** Top 3 tasks for a repo, sorted descending. */
+  function topTasks(repo: UsageRepoBreakdown): UsageTaskBreakdown[] {
+    return [...repo.tasks].sort((a, b) => taskTotal(b) - taskTotal(a)).slice(0, 3);
+  }
+
+  /** Remaining task count beyond the top 3. */
+  function remainingTaskCount(repo: UsageRepoBreakdown): number {
+    return Math.max(0, repo.tasks.length - 3);
+  }
+
+  /** Max task total within a repo (for bar scaling). */
+  function maxTaskTotal(repo: UsageRepoBreakdown): number {
+    if (repo.tasks.length === 0) return 1;
+    return Math.max(...repo.tasks.map(taskTotal));
+  }
+</script>
+
+<div class="spend-lens">
+  <div class="spend-header">
+    <h2 class="spend-heading">{m.usage_spend_heading()}</h2>
+    <span class="units-label">
+      <GlossaryText text={m.usage_units_label()} />
+    </span>
+  </div>
+
+  <div class="repo-list">
+    {#each sortedRepos as repo (repo.repoPath)}
+      {@const total = repoTotal(repo)}
+      {@const expanded = expandedPaths.has(repo.repoPath)}
+      {@const tasks = topTasks(repo)}
+      {@const remaining = remainingTaskCount(repo)}
+      {@const maxTask = maxTaskTotal(repo)}
+
+      <div class="repo-row-wrap">
+        <button
+          class="repo-row"
+          aria-expanded={expanded}
+          onclick={() => toggleRepo(repo.repoPath)}
+          type="button"
+        >
+          <span class="caret" aria-hidden="true">{expanded ? "▾" : "▸"}</span>
+          <span class="repo-name">{repo.repoName}</span>
+          <span class="repo-bar">
+            <UsageBar value={total} max={maxRepoTotal} />
+          </span>
+          <span class="repo-pct">{formatPct(total / breakdown.totalUnits)}</span>
+          <span class="repo-units">{formatUnits(total)}</span>
+        </button>
+
+        {#if expanded}
+          <div class="task-list">
+            {#each tasks as task (task.sessionId)}
+              {@const tTotal = taskTotal(task)}
+              <div class="task-row">
+                <span class="task-desig">{task.desig}</span>
+                <span class="task-bar">
+                  <UsageBar value={tTotal} max={maxTask} tone="var(--color-slate)" />
+                </span>
+                <span class="task-units">{formatUnits(tTotal)}</span>
+              </div>
+            {/each}
+            {#if remaining > 0}
+              <div class="task-more">
+                {m.usage_more_count({ count: remaining })}
+              </div>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .spend-lens {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .spend-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .spend-heading {
+    font-size: var(--fs-lg);
+    font-weight: 600;
+    color: var(--color-ink-bright);
+    margin: 0;
+  }
+
+  .units-label {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    text-align: right;
+  }
+
+  .repo-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .repo-row-wrap {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .repo-row {
+    display: grid;
+    grid-template-columns: 1rem 8rem 1fr 3rem 5rem;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.5rem;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: left;
+    color: var(--color-ink);
+    font-size: var(--fs-base);
+    transition: background 0.1s;
+    width: 100%;
+  }
+
+  .repo-row:hover {
+    background: var(--color-hover);
+  }
+
+  .caret {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    user-select: none;
+  }
+
+  .repo-name {
+    font-weight: 500;
+    color: var(--color-ink-bright);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .repo-bar {
+    display: flex;
+    align-items: center;
+  }
+
+  .repo-pct {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    text-align: right;
+  }
+
+  .repo-units {
+    font-size: var(--fs-base);
+    color: var(--color-ink);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .task-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 0 0 0.25rem 1.5rem;
+  }
+
+  .task-row {
+    display: grid;
+    grid-template-columns: 6rem 1fr 5rem;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    font-size: var(--fs-meta);
+  }
+
+  .task-desig {
+    color: var(--color-muted);
+    font-variant-numeric: tabular-nums;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .task-bar {
+    display: flex;
+    align-items: center;
+  }
+
+  .task-units {
+    color: var(--color-ink);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .task-more {
+    font-size: var(--fs-micro);
+    color: var(--color-faint);
+    padding: 0.2rem 0.5rem;
+    font-style: italic;
+  }
+</style>

--- a/ui/src/lib/components/usage/SplitBar.svelte
+++ b/ui/src/lib/components/usage/SplitBar.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  interface Props {
+    /** Magnitude of segment A (left). */
+    a: number;
+    /** Magnitude of segment B (right). */
+    b: number;
+    /**
+     * Fill colour for segment A. MUST be a `var(--color-*)` token.
+     * @default "var(--color-blue)"
+     */
+    aTone?: string;
+    /**
+     * Fill colour for segment B. MUST be a `var(--color-*)` token.
+     * @default "var(--color-amber)"
+     */
+    bTone?: string;
+    /** Optional aria-label for segment A. */
+    aLabel?: string;
+    /** Optional aria-label for segment B. */
+    bLabel?: string;
+    /** Optional extra CSS class applied to segment A element. */
+    aClass?: string;
+    /** Optional extra CSS class applied to segment B element. */
+    bClass?: string;
+  }
+
+  const {
+    a,
+    b,
+    aTone = "var(--color-blue)",
+    bTone = "var(--color-amber)",
+    aLabel,
+    bLabel,
+    aClass,
+    bClass,
+  }: Props = $props();
+
+  const total = $derived(a + b);
+  const aPct = $derived(total > 0 ? (a / total) * 100 : 0);
+  const bPct = $derived(total > 0 ? (b / total) * 100 : 0);
+</script>
+
+<!--
+  Decorative two-segment proportion bar. Numeric shares are shown as text by the
+  parent, so the bar itself is aria-hidden to avoid screen-reader duplication.
+-->
+<div class="split-bar" aria-hidden="true">
+  {#if total > 0}
+    <div
+      class="split-segment {aClass ?? ''}"
+      style="width: {aPct}%; background: {aTone};"
+      aria-label={aLabel}
+    ></div>
+    <div
+      class="split-segment {bClass ?? ''}"
+      style="width: {bPct}%; background: {bTone};"
+      aria-label={bLabel}
+    ></div>
+  {/if}
+</div>
+
+<style>
+  .split-bar {
+    width: 100%;
+    height: 8px;
+    border-radius: 4px;
+    overflow: hidden;
+    display: flex;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+  }
+
+  .split-segment {
+    height: 100%;
+    transition: width 0.2s ease;
+  }
+</style>

--- a/ui/src/lib/components/usage/UsageBar.svelte
+++ b/ui/src/lib/components/usage/UsageBar.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  interface Props {
+    value: number;
+    max: number;
+    /**
+     * Fill colour expressed as a CSS design-token reference, e.g. `var(--color-blue)`.
+     * MUST be a `var(--color-*)` token — never a raw hex, rgba(), or any other
+     * color literal. The value is injected directly into an inline `background`
+     * style, so callers that bypass the token rule will silently break the
+     * design system. Review is the enforcement gate.
+     */
+    tone?: string;
+  }
+
+  const { value, max, tone = "var(--color-blue)" }: Props = $props();
+
+  const fillPct = $derived(max > 0 ? Math.max(2, (value / max) * 100) : 2);
+</script>
+
+<!--
+  Decorative horizontal bar. The numeric value is shown as text by the parent
+  component, so the bar itself is aria-hidden to avoid screen-reader duplication.
+-->
+<div class="usage-bar-track" aria-hidden="true">
+  <div class="usage-bar-fill" style="width: {fillPct}%; background: {tone};"></div>
+</div>
+
+<style>
+  .usage-bar-track {
+    width: 100%;
+    height: 6px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .usage-bar-fill {
+    height: 100%;
+    border-radius: 3px;
+    transition: width 0.2s ease;
+  }
+</style>

--- a/ui/src/lib/components/usage/format.test.ts
+++ b/ui/src/lib/components/usage/format.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { formatUnits, formatPct } from "./format";
+
+describe("formatUnits", () => {
+  it("renders raw counts below 1K verbatim", () => {
+    expect(formatUnits(0)).toBe("0");
+    expect(formatUnits(42)).toBe("42");
+    expect(formatUnits(999)).toBe("999");
+  });
+
+  it("renders thousands with a rounded K suffix", () => {
+    expect(formatUnits(1_000)).toBe("1K");
+    expect(formatUnits(12_400)).toBe("12K");
+    expect(formatUnits(512_000)).toBe("512K");
+  });
+
+  it("renders millions with two decimals and an M suffix", () => {
+    expect(formatUnits(1_000_000)).toBe("1.00M");
+    expect(formatUnits(1_240_000)).toBe("1.24M");
+  });
+
+  it("promotes the rounding boundary to M instead of emitting 1000K", () => {
+    expect(formatUnits(999_500)).toBe("1.00M");
+    expect(formatUnits(999_999)).toBe("1.00M");
+    // just below the boundary stays in K
+    expect(formatUnits(999_499)).toBe("999K");
+  });
+});
+
+describe("formatPct", () => {
+  it("renders a fraction as a rounded percentage", () => {
+    expect(formatPct(0)).toBe("0%");
+    expect(formatPct(0.357)).toBe("36%");
+    expect(formatPct(1)).toBe("100%");
+  });
+});

--- a/ui/src/lib/components/usage/format.ts
+++ b/ui/src/lib/components/usage/format.ts
@@ -6,7 +6,12 @@
  */
 export function formatUnits(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + "M";
-  if (n >= 1_000) return Math.round(n / 1_000) + "K";
+  if (n >= 1_000) {
+    // Guard the rounding boundary: values in [999_500, 999_999] round to
+    // 1000K — promote those to "1.00M" instead.
+    const k = Math.round(n / 1_000);
+    return k >= 1_000 ? (n / 1_000_000).toFixed(2) + "M" : k + "K";
+  }
   return String(n);
 }
 

--- a/ui/src/lib/components/usage/format.ts
+++ b/ui/src/lib/components/usage/format.ts
@@ -1,0 +1,18 @@
+/** Display helpers reused across all usage lenses. */
+
+/**
+ * Format a raw unit count into a human-readable string.
+ * ≥1M → 2 decimal places + "M"; ≥1K → rounded integer + "K"; else as-is.
+ */
+export function formatUnits(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + "M";
+  if (n >= 1_000) return Math.round(n / 1_000) + "K";
+  return String(n);
+}
+
+/**
+ * Format a fraction (0–1) as a rounded percentage string, e.g. 0.357 → "36%".
+ */
+export function formatPct(fraction: number): string {
+  return Math.round(fraction * 100) + "%";
+}

--- a/ui/src/lib/glossary.ts
+++ b/ui/src/lib/glossary.ts
@@ -78,6 +78,12 @@ const glossary: readonly GlossaryTerm[] = [
     termKey: "gloss_trial_term",
     bodyKey: "gloss_trial_def",
   },
+  {
+    id: "weighted-units",
+    kind: "internal",
+    termKey: "gloss_weighted_units_term",
+    bodyKey: "gloss_weighted_units_def",
+  },
 ];
 
 export const glossaryById = new Map<string, GlossaryTerm>(glossary.map((term) => [term.id, term]));

--- a/ui/src/lib/glossary.ts
+++ b/ui/src/lib/glossary.ts
@@ -84,6 +84,12 @@ const glossary: readonly GlossaryTerm[] = [
     termKey: "gloss_weighted_units_term",
     bodyKey: "gloss_weighted_units_def",
   },
+  {
+    id: "satellite-pass",
+    kind: "internal",
+    termKey: "gloss_satellite_pass_term",
+    bodyKey: "gloss_satellite_pass_def",
+  },
 ];
 
 export const glossaryById = new Map<string, GlossaryTerm>(glossary.map((term) => [term.id, term]));

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -739,6 +739,56 @@ export interface UsageLimits {
   subscriptionOnly: boolean;
 }
 
+export type UsageRange = "24h" | "7d" | "30d" | "all";
+
+/** Raw token detail (authoring side). */
+export interface UsageTokens {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+/** One task's spend within a repo. */
+export interface UsageTaskBreakdown {
+  sessionId: string;
+  desig: string; // e.g. "TASK-07" — data, never translated
+  model: string; // dominant model id, e.g. "claude-opus-4-8"
+  authoringUnits: number; // weighted units, main agent
+  satelliteUnits: number; // weighted units, reviewer/critic/etc spawns
+  tokens: UsageTokens; // raw authoring token detail
+  byModel: Record<string, number>; // weighted units per model id
+}
+
+/** A repo grouping its tasks. */
+export interface UsageRepoBreakdown {
+  repoPath: string;
+  repoName: string;
+  authoringUnits: number;
+  satelliteUnits: number;
+  tasks: UsageTaskBreakdown[];
+}
+
+/** Top-level breakdown — serves the Spend + Overhead lenses. */
+export interface UsageBreakdown {
+  range: UsageRange;
+  generatedAt: number; // ms epoch
+  totalUnits: number; // authoring + satellite, all repos
+  authoringUnits: number;
+  satelliteUnits: number;
+  cacheReadUnits: number; // cheap-cache share (Overhead b)
+  generationUnits: number; // non-cacheRead share (Overhead b)
+  repos: UsageRepoBreakdown[];
+}
+
+/** Burn-down projection for the Limits lens. */
+export interface UsageProjection {
+  window: "5H" | "WK";
+  projectedPct: number; // projected % at window reset if burn-rate holds
+  resetAt: number; // ms epoch of window reset
+  burnRatePerHour: number; // recent weighted units/hour
+}
+
 export interface UpdateCommit {
   sha: string;
   subject: string;

--- a/ui/src/lib/usage-mock.ts
+++ b/ui/src/lib/usage-mock.ts
@@ -1,0 +1,569 @@
+/**
+ * Mock fixtures for the /usage token-spend dashboard (Phase 0 prototype).
+ * No backend — all data is hand-written for visual prototyping.
+ */
+import type {
+  UsageBreakdown,
+  UsageLimits,
+  UsageProjection,
+  UsageRange,
+  UsageTaskBreakdown,
+} from "./types";
+
+/** Single stable base to keep all timestamps deterministic across calls. */
+const BASE = Date.now();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** ms offsets used for reset timestamps */
+const H = 3_600_000;
+
+// ---------------------------------------------------------------------------
+// Shepherd repo tasks (≥7 so "… N more" tail is exercised in the Spend lens)
+// ---------------------------------------------------------------------------
+
+const shepherdTasks24h: UsageTaskBreakdown[] = [
+  {
+    sessionId: "s-001",
+    desig: "TASK-07",
+    model: "claude-opus-4-8",
+    authoringUnits: 84_000,
+    satelliteUnits: 18_000,
+    tokens: { input: 12_000, output: 3_400, cacheRead: 210_000, cacheWrite: 4_200 },
+    byModel: { "claude-opus-4-8": 84_000 },
+  },
+  {
+    sessionId: "s-002",
+    desig: "TASK-12",
+    model: "claude-opus-4-8",
+    authoringUnits: 72_000,
+    satelliteUnits: 14_500,
+    tokens: { input: 10_500, output: 2_900, cacheRead: 180_000, cacheWrite: 3_600 },
+    byModel: { "claude-opus-4-8": 62_000, "claude-sonnet-4-5": 10_000 },
+  },
+  {
+    sessionId: "s-003",
+    desig: "TASK-15",
+    model: "claude-opus-4-8",
+    authoringUnits: 61_000,
+    satelliteUnits: 12_000,
+    tokens: { input: 9_000, output: 2_500, cacheRead: 152_000, cacheWrite: 3_000 },
+    byModel: { "claude-opus-4-8": 61_000 },
+  },
+  {
+    sessionId: "s-004",
+    desig: "TASK-18",
+    model: "claude-sonnet-4-5",
+    authoringUnits: 28_000,
+    satelliteUnits: 6_000,
+    tokens: { input: 5_200, output: 1_100, cacheRead: 65_000, cacheWrite: 1_600 },
+    byModel: { "claude-sonnet-4-5": 28_000 },
+  },
+  {
+    sessionId: "s-005",
+    desig: "TASK-21",
+    model: "claude-opus-4-8",
+    authoringUnits: 22_000,
+    satelliteUnits: 4_500,
+    tokens: { input: 3_800, output: 880, cacheRead: 55_000, cacheWrite: 1_200 },
+    byModel: { "claude-opus-4-8": 18_000, "claude-haiku-4-5": 4_000 },
+  },
+  {
+    sessionId: "s-006",
+    desig: "TASK-24",
+    model: "claude-opus-4-8",
+    authoringUnits: 17_000,
+    satelliteUnits: 3_500,
+    tokens: { input: 2_900, output: 680, cacheRead: 42_000, cacheWrite: 950 },
+    byModel: { "claude-opus-4-8": 17_000 },
+  },
+  {
+    sessionId: "s-007",
+    desig: "TASK-27",
+    model: "claude-sonnet-4-5",
+    authoringUnits: 11_000,
+    satelliteUnits: 2_200,
+    tokens: { input: 2_100, output: 440, cacheRead: 27_000, cacheWrite: 700 },
+    byModel: { "claude-sonnet-4-5": 11_000 },
+  },
+];
+
+const shepherdAuth24h = shepherdTasks24h.reduce((a, t) => a + t.authoringUnits, 0); // 295_000
+const shepherdSat24h = shepherdTasks24h.reduce((a, t) => a + t.satelliteUnits, 0); // 60_700
+
+// web-app (2 tasks)
+const webappTasks24h: UsageTaskBreakdown[] = [
+  {
+    sessionId: "s-008",
+    desig: "TASK-03",
+    model: "claude-opus-4-8",
+    authoringUnits: 76_000,
+    satelliteUnits: 15_000,
+    tokens: { input: 11_000, output: 3_100, cacheRead: 190_000, cacheWrite: 3_800 },
+    byModel: { "claude-opus-4-8": 76_000 },
+  },
+  {
+    sessionId: "s-009",
+    desig: "TASK-04",
+    model: "claude-sonnet-4-5",
+    authoringUnits: 60_000,
+    satelliteUnits: 12_200,
+    tokens: { input: 9_200, output: 2_400, cacheRead: 150_000, cacheWrite: 3_100 },
+    byModel: { "claude-sonnet-4-5": 50_000, "claude-opus-4-8": 10_000 },
+  },
+];
+const webappAuth24h = webappTasks24h.reduce((a, t) => a + t.authoringUnits, 0); // 136_000
+const webappSat24h = webappTasks24h.reduce((a, t) => a + t.satelliteUnits, 0); // 27_200
+
+// infra (1 task)
+const infraTasks24h: UsageTaskBreakdown[] = [
+  {
+    sessionId: "s-010",
+    desig: "TASK-01",
+    model: "claude-sonnet-4-5",
+    authoringUnits: 38_000,
+    satelliteUnits: 8_000,
+    tokens: { input: 5_800, output: 1_520, cacheRead: 95_000, cacheWrite: 1_900 },
+    byModel: { "claude-sonnet-4-5": 32_000, "claude-haiku-4-5": 6_000 },
+  },
+];
+const infraAuth24h = infraTasks24h.reduce((a, t) => a + t.authoringUnits, 0); // 38_000
+const infraSat24h = infraTasks24h.reduce((a, t) => a + t.satelliteUnits, 0); // 8_000
+
+// ---------------------------------------------------------------------------
+// 7d data (multiplicative scale ~4×)
+// ---------------------------------------------------------------------------
+
+const shepherdTasks7d: UsageTaskBreakdown[] = [
+  ...shepherdTasks24h,
+  {
+    sessionId: "s-101",
+    desig: "TASK-30",
+    model: "claude-opus-4-8",
+    authoringUnits: 95_000,
+    satelliteUnits: 19_000,
+    tokens: { input: 13_500, output: 3_800, cacheRead: 238_000, cacheWrite: 4_700 },
+    byModel: { "claude-opus-4-8": 95_000 },
+  },
+  {
+    sessionId: "s-102",
+    desig: "TASK-33",
+    model: "claude-opus-4-8",
+    authoringUnits: 78_000,
+    satelliteUnits: 16_000,
+    tokens: { input: 11_200, output: 3_100, cacheRead: 195_000, cacheWrite: 3_900 },
+    byModel: { "claude-opus-4-8": 68_000, "claude-sonnet-4-5": 10_000 },
+  },
+];
+
+const shepherdAuth7d = shepherdTasks7d.reduce((a, t) => a + t.authoringUnits, 0);
+const shepherdSat7d = shepherdTasks7d.reduce((a, t) => a + t.satelliteUnits, 0);
+
+const webappTasks7d: UsageTaskBreakdown[] = [
+  ...webappTasks24h,
+  {
+    sessionId: "s-110",
+    desig: "TASK-05",
+    model: "claude-opus-4-8",
+    authoringUnits: 88_000,
+    satelliteUnits: 17_500,
+    tokens: { input: 12_800, output: 3_500, cacheRead: 220_000, cacheWrite: 4_400 },
+    byModel: { "claude-opus-4-8": 88_000 },
+  },
+];
+const webappAuth7d = webappTasks7d.reduce((a, t) => a + t.authoringUnits, 0);
+const webappSat7d = webappTasks7d.reduce((a, t) => a + t.satelliteUnits, 0);
+
+const infraTasks7d: UsageTaskBreakdown[] = [
+  ...infraTasks24h,
+  {
+    sessionId: "s-120",
+    desig: "TASK-02",
+    model: "claude-sonnet-4-5",
+    authoringUnits: 42_000,
+    satelliteUnits: 8_500,
+    tokens: { input: 6_200, output: 1_680, cacheRead: 105_000, cacheWrite: 2_100 },
+    byModel: { "claude-sonnet-4-5": 42_000 },
+  },
+];
+const infraAuth7d = infraTasks7d.reduce((a, t) => a + t.authoringUnits, 0);
+const infraSat7d = infraTasks7d.reduce((a, t) => a + t.satelliteUnits, 0);
+
+// ---------------------------------------------------------------------------
+// 30d — add "docs" repo
+// ---------------------------------------------------------------------------
+
+const shepherdTasks30d: UsageTaskBreakdown[] = [
+  ...shepherdTasks7d,
+  {
+    sessionId: "s-201",
+    desig: "TASK-36",
+    model: "claude-opus-4-8",
+    authoringUnits: 110_000,
+    satelliteUnits: 22_000,
+    tokens: { input: 15_800, output: 4_400, cacheRead: 275_000, cacheWrite: 5_500 },
+    byModel: { "claude-opus-4-8": 110_000 },
+  },
+  {
+    sessionId: "s-202",
+    desig: "TASK-39",
+    model: "claude-opus-4-8",
+    authoringUnits: 92_000,
+    satelliteUnits: 18_500,
+    tokens: { input: 13_200, output: 3_680, cacheRead: 230_000, cacheWrite: 4_600 },
+    byModel: { "claude-opus-4-8": 80_000, "claude-sonnet-4-5": 12_000 },
+  },
+  {
+    sessionId: "s-203",
+    desig: "TASK-42",
+    model: "claude-sonnet-4-5",
+    authoringUnits: 45_000,
+    satelliteUnits: 9_000,
+    tokens: { input: 6_800, output: 1_800, cacheRead: 112_500, cacheWrite: 2_250 },
+    byModel: { "claude-sonnet-4-5": 45_000 },
+  },
+];
+const shepherdAuth30d = shepherdTasks30d.reduce((a, t) => a + t.authoringUnits, 0);
+const shepherdSat30d = shepherdTasks30d.reduce((a, t) => a + t.satelliteUnits, 0);
+
+const webappTasks30d: UsageTaskBreakdown[] = [
+  ...webappTasks7d,
+  {
+    sessionId: "s-210",
+    desig: "TASK-06",
+    model: "claude-opus-4-8",
+    authoringUnits: 98_000,
+    satelliteUnits: 19_600,
+    tokens: { input: 14_200, output: 3_920, cacheRead: 245_000, cacheWrite: 4_900 },
+    byModel: { "claude-opus-4-8": 98_000 },
+  },
+  {
+    sessionId: "s-211",
+    desig: "TASK-07",
+    model: "claude-opus-4-8",
+    authoringUnits: 75_000,
+    satelliteUnits: 15_000,
+    tokens: { input: 10_900, output: 3_000, cacheRead: 187_500, cacheWrite: 3_750 },
+    byModel: { "claude-opus-4-8": 65_000, "claude-sonnet-4-5": 10_000 },
+  },
+];
+const webappAuth30d = webappTasks30d.reduce((a, t) => a + t.authoringUnits, 0);
+const webappSat30d = webappTasks30d.reduce((a, t) => a + t.satelliteUnits, 0);
+
+const infraTasks30d: UsageTaskBreakdown[] = [
+  ...infraTasks7d,
+  {
+    sessionId: "s-220",
+    desig: "TASK-03",
+    model: "claude-haiku-4-5",
+    authoringUnits: 18_000,
+    satelliteUnits: 3_600,
+    tokens: { input: 2_900, output: 720, cacheRead: 45_000, cacheWrite: 900 },
+    byModel: { "claude-haiku-4-5": 18_000 },
+  },
+];
+const infraAuth30d = infraTasks30d.reduce((a, t) => a + t.authoringUnits, 0);
+const infraSat30d = infraTasks30d.reduce((a, t) => a + t.satelliteUnits, 0);
+
+const docsTasks30d: UsageTaskBreakdown[] = [
+  {
+    sessionId: "s-230",
+    desig: "TASK-01",
+    model: "claude-sonnet-4-5",
+    authoringUnits: 32_000,
+    satelliteUnits: 6_400,
+    tokens: { input: 4_800, output: 1_280, cacheRead: 80_000, cacheWrite: 1_600 },
+    byModel: { "claude-sonnet-4-5": 32_000 },
+  },
+];
+const docsAuth30d = docsTasks30d.reduce((a, t) => a + t.authoringUnits, 0);
+const docsSat30d = docsTasks30d.reduce((a, t) => a + t.satelliteUnits, 0);
+
+// ---------------------------------------------------------------------------
+// all — cumulative, adds more tasks
+// ---------------------------------------------------------------------------
+
+const shepherdTasksAll: UsageTaskBreakdown[] = [
+  ...shepherdTasks30d,
+  {
+    sessionId: "s-301",
+    desig: "TASK-45",
+    model: "claude-opus-4-8",
+    authoringUnits: 130_000,
+    satelliteUnits: 26_000,
+    tokens: { input: 18_800, output: 5_200, cacheRead: 325_000, cacheWrite: 6_500 },
+    byModel: { "claude-opus-4-8": 130_000 },
+  },
+  {
+    sessionId: "s-302",
+    desig: "TASK-48",
+    model: "claude-opus-4-8",
+    authoringUnits: 115_000,
+    satelliteUnits: 23_000,
+    tokens: { input: 16_500, output: 4_600, cacheRead: 287_500, cacheWrite: 5_750 },
+    byModel: { "claude-opus-4-8": 105_000, "claude-sonnet-4-5": 10_000 },
+  },
+  {
+    sessionId: "s-303",
+    desig: "TASK-51",
+    model: "claude-sonnet-4-5",
+    authoringUnits: 58_000,
+    satelliteUnits: 11_600,
+    tokens: { input: 8_800, output: 2_320, cacheRead: 145_000, cacheWrite: 2_900 },
+    byModel: { "claude-sonnet-4-5": 58_000 },
+  },
+];
+const shepherdAuthAll = shepherdTasksAll.reduce((a, t) => a + t.authoringUnits, 0);
+const shepherdSatAll = shepherdTasksAll.reduce((a, t) => a + t.satelliteUnits, 0);
+
+const webappTasksAll: UsageTaskBreakdown[] = [
+  ...webappTasks30d,
+  {
+    sessionId: "s-310",
+    desig: "TASK-08",
+    model: "claude-opus-4-8",
+    authoringUnits: 108_000,
+    satelliteUnits: 21_600,
+    tokens: { input: 15_600, output: 4_320, cacheRead: 270_000, cacheWrite: 5_400 },
+    byModel: { "claude-opus-4-8": 108_000 },
+  },
+];
+const webappAuthAll = webappTasksAll.reduce((a, t) => a + t.authoringUnits, 0);
+const webappSatAll = webappTasksAll.reduce((a, t) => a + t.satelliteUnits, 0);
+
+const infraTasksAll: UsageTaskBreakdown[] = [
+  ...infraTasks30d,
+  {
+    sessionId: "s-320",
+    desig: "TASK-04",
+    model: "claude-sonnet-4-5",
+    authoringUnits: 55_000,
+    satelliteUnits: 11_000,
+    tokens: { input: 8_200, output: 2_200, cacheRead: 137_500, cacheWrite: 2_750 },
+    byModel: { "claude-sonnet-4-5": 50_000, "claude-haiku-4-5": 5_000 },
+  },
+];
+const infraAuthAll = infraTasksAll.reduce((a, t) => a + t.authoringUnits, 0);
+const infraSatAll = infraTasksAll.reduce((a, t) => a + t.satelliteUnits, 0);
+
+const docsTasksAll: UsageTaskBreakdown[] = [
+  ...docsTasks30d,
+  {
+    sessionId: "s-330",
+    desig: "TASK-02",
+    model: "claude-haiku-4-5",
+    authoringUnits: 14_000,
+    satelliteUnits: 2_800,
+    tokens: { input: 2_200, output: 560, cacheRead: 35_000, cacheWrite: 700 },
+    byModel: { "claude-haiku-4-5": 14_000 },
+  },
+];
+const docsAuthAll = docsTasksAll.reduce((a, t) => a + t.authoringUnits, 0);
+const docsSatAll = docsTasksAll.reduce((a, t) => a + t.satelliteUnits, 0);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Returns a realistic per-range fixture for the /usage breakdown. */
+export function mockBreakdown(range: UsageRange): UsageBreakdown {
+  switch (range) {
+    case "24h": {
+      const totalA = shepherdAuth24h + webappAuth24h + infraAuth24h;
+      const totalS = shepherdSat24h + webappSat24h + infraSat24h;
+      const total = totalA + totalS;
+      return {
+        range,
+        generatedAt: BASE,
+        totalUnits: total,
+        authoringUnits: totalA,
+        satelliteUnits: totalS,
+        cacheReadUnits: Math.round(total * 0.75),
+        generationUnits: Math.round(total * 0.25),
+        repos: [
+          {
+            repoPath: "/home/user/shepherd",
+            repoName: "shepherd",
+            authoringUnits: shepherdAuth24h,
+            satelliteUnits: shepherdSat24h,
+            tasks: shepherdTasks24h,
+          },
+          {
+            repoPath: "/home/user/web-app",
+            repoName: "web-app",
+            authoringUnits: webappAuth24h,
+            satelliteUnits: webappSat24h,
+            tasks: webappTasks24h,
+          },
+          {
+            repoPath: "/home/user/infra",
+            repoName: "infra",
+            authoringUnits: infraAuth24h,
+            satelliteUnits: infraSat24h,
+            tasks: infraTasks24h,
+          },
+        ],
+      };
+    }
+
+    case "7d": {
+      const totalA = shepherdAuth7d + webappAuth7d + infraAuth7d;
+      const totalS = shepherdSat7d + webappSat7d + infraSat7d;
+      const total = totalA + totalS;
+      return {
+        range,
+        generatedAt: BASE,
+        totalUnits: total,
+        authoringUnits: totalA,
+        satelliteUnits: totalS,
+        cacheReadUnits: Math.round(total * 0.76),
+        generationUnits: Math.round(total * 0.24),
+        repos: [
+          {
+            repoPath: "/home/user/shepherd",
+            repoName: "shepherd",
+            authoringUnits: shepherdAuth7d,
+            satelliteUnits: shepherdSat7d,
+            tasks: shepherdTasks7d,
+          },
+          {
+            repoPath: "/home/user/web-app",
+            repoName: "web-app",
+            authoringUnits: webappAuth7d,
+            satelliteUnits: webappSat7d,
+            tasks: webappTasks7d,
+          },
+          {
+            repoPath: "/home/user/infra",
+            repoName: "infra",
+            authoringUnits: infraAuth7d,
+            satelliteUnits: infraSat7d,
+            tasks: infraTasks7d,
+          },
+        ],
+      };
+    }
+
+    case "30d": {
+      const totalA = shepherdAuth30d + webappAuth30d + infraAuth30d + docsAuth30d;
+      const totalS = shepherdSat30d + webappSat30d + infraSat30d + docsSat30d;
+      const total = totalA + totalS;
+      return {
+        range,
+        generatedAt: BASE,
+        totalUnits: total,
+        authoringUnits: totalA,
+        satelliteUnits: totalS,
+        cacheReadUnits: Math.round(total * 0.77),
+        generationUnits: Math.round(total * 0.23),
+        repos: [
+          {
+            repoPath: "/home/user/shepherd",
+            repoName: "shepherd",
+            authoringUnits: shepherdAuth30d,
+            satelliteUnits: shepherdSat30d,
+            tasks: shepherdTasks30d,
+          },
+          {
+            repoPath: "/home/user/web-app",
+            repoName: "web-app",
+            authoringUnits: webappAuth30d,
+            satelliteUnits: webappSat30d,
+            tasks: webappTasks30d,
+          },
+          {
+            repoPath: "/home/user/infra",
+            repoName: "infra",
+            authoringUnits: infraAuth30d,
+            satelliteUnits: infraSat30d,
+            tasks: infraTasks30d,
+          },
+          {
+            repoPath: "/home/user/docs",
+            repoName: "docs",
+            authoringUnits: docsAuth30d,
+            satelliteUnits: docsSat30d,
+            tasks: docsTasks30d,
+          },
+        ],
+      };
+    }
+
+    case "all": {
+      const totalA = shepherdAuthAll + webappAuthAll + infraAuthAll + docsAuthAll;
+      const totalS = shepherdSatAll + webappSatAll + infraSatAll + docsSatAll;
+      const total = totalA + totalS;
+      return {
+        range,
+        generatedAt: BASE,
+        totalUnits: total,
+        authoringUnits: totalA,
+        satelliteUnits: totalS,
+        cacheReadUnits: Math.round(total * 0.78),
+        generationUnits: Math.round(total * 0.22),
+        repos: [
+          {
+            repoPath: "/home/user/shepherd",
+            repoName: "shepherd",
+            authoringUnits: shepherdAuthAll,
+            satelliteUnits: shepherdSatAll,
+            tasks: shepherdTasksAll,
+          },
+          {
+            repoPath: "/home/user/web-app",
+            repoName: "web-app",
+            authoringUnits: webappAuthAll,
+            satelliteUnits: webappSatAll,
+            tasks: webappTasksAll,
+          },
+          {
+            repoPath: "/home/user/infra",
+            repoName: "infra",
+            authoringUnits: infraAuthAll,
+            satelliteUnits: infraSatAll,
+            tasks: infraTasksAll,
+          },
+          {
+            repoPath: "/home/user/docs",
+            repoName: "docs",
+            authoringUnits: docsAuthAll,
+            satelliteUnits: docsSatAll,
+            tasks: docsTasksAll,
+          },
+        ],
+      };
+    }
+  }
+}
+
+/** Burn-down projections for the Limits lens (one 5H, one WK). */
+export function mockProjections(): UsageProjection[] {
+  return [
+    {
+      window: "5H",
+      projectedPct: 64,
+      resetAt: BASE + 2.5 * H,
+      burnRatePerHour: 48_000,
+    },
+    {
+      window: "WK",
+      projectedPct: 41,
+      resetAt: BASE + 58 * H,
+      burnRatePerHour: 31_000,
+    },
+  ];
+}
+
+/** A fixture shaped like the real UsageLimits. */
+export function mockLimits(): UsageLimits {
+  return {
+    session5h: { pct: 38, resetAt: BASE + 2.5 * H },
+    week: { pct: 22, resetAt: BASE + 58 * H },
+    credits: null,
+    stale: false,
+    calibratedAt: BASE - 5 * 60_000,
+    subscriptionOnly: false,
+  };
+}

--- a/ui/src/routes/usage/+page.svelte
+++ b/ui/src/routes/usage/+page.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  import type { UsageRange } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { mockBreakdown, mockLimits, mockProjections } from "$lib/usage-mock";
+  import SpendLens from "$lib/components/usage/SpendLens.svelte";
+  import OverheadLens from "$lib/components/usage/OverheadLens.svelte";
+  import LimitsLens from "$lib/components/usage/LimitsLens.svelte";
+
+  type Tab = "spend" | "overhead" | "limits";
+
+  let tab = $state<Tab>("spend");
+  let range = $state<UsageRange>("7d");
+
+  const breakdown = $derived(mockBreakdown(range));
+</script>
+
+<svelte:head>
+  <title>{m.usage_page_title()}</title>
+</svelte:head>
+
+<main class="usage-page">
+  <header class="usage-header">
+    <h1 class="usage-title">{m.usage_page_title()}</h1>
+    <p class="usage-prototype-note">{m.usage_prototype_note()}</p>
+  </header>
+
+  <!-- Tab switcher -->
+  <div class="seg-row tab-row">
+    <button
+      type="button"
+      class="seg-btn"
+      class:seg-active={tab === "spend"}
+      aria-pressed={tab === "spend"}
+      onclick={() => (tab = "spend")}>{m.usage_spend_tab()}</button
+    >
+    <button
+      type="button"
+      class="seg-btn"
+      class:seg-active={tab === "overhead"}
+      aria-pressed={tab === "overhead"}
+      onclick={() => (tab = "overhead")}>{m.usage_overhead_tab()}</button
+    >
+    <button
+      type="button"
+      class="seg-btn"
+      class:seg-active={tab === "limits"}
+      aria-pressed={tab === "limits"}
+      onclick={() => (tab = "limits")}>{m.usage_limits_tab()}</button
+    >
+  </div>
+
+  <!-- Range selector (Spend + Overhead only) -->
+  {#if tab !== "limits"}
+    <div class="seg-row range-row" role="group" aria-label={m.usage_range_label()}>
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={range === "24h"}
+        aria-pressed={range === "24h"}
+        onclick={() => (range = "24h")}>{m.usage_range_24h()}</button
+      >
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={range === "7d"}
+        aria-pressed={range === "7d"}
+        onclick={() => (range = "7d")}>{m.usage_range_7d()}</button
+      >
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={range === "30d"}
+        aria-pressed={range === "30d"}
+        onclick={() => (range = "30d")}>{m.usage_range_30d()}</button
+      >
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={range === "all"}
+        aria-pressed={range === "all"}
+        onclick={() => (range = "all")}>{m.usage_range_all()}</button
+      >
+    </div>
+  {/if}
+
+  <!-- Lens body -->
+  <div class="lens-body">
+    {#if tab === "spend"}
+      <SpendLens {breakdown} />
+    {:else if tab === "overhead"}
+      <OverheadLens {breakdown} />
+    {:else}
+      <LimitsLens limits={mockLimits()} projections={mockProjections()} />
+    {/if}
+  </div>
+</main>
+
+<style>
+  .usage-page {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 24px 16px 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .usage-header {
+    margin-bottom: 20px;
+  }
+
+  .usage-title {
+    margin: 0 0 4px;
+    font-size: var(--fs-xl);
+    font-weight: 600;
+    color: var(--color-ink);
+  }
+
+  .usage-prototype-note {
+    margin: 0;
+    font-size: var(--fs-sm);
+    color: var(--color-muted);
+  }
+
+  /* Segmented controls */
+  .seg-row {
+    display: flex;
+    border-bottom: 1px solid var(--color-line);
+  }
+
+  .seg-btn {
+    flex: 1;
+    min-width: 0;
+    min-height: 44px;
+    border: 0;
+    border-right: 1px solid var(--color-line);
+    background: none;
+    font-family: inherit;
+    font-size: var(--fs-base);
+    cursor: pointer;
+    padding: 0 2px;
+    color: var(--color-muted);
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    transition:
+      color 0.12s ease,
+      background 0.12s ease;
+  }
+
+  .seg-btn:last-child {
+    border-right: 0;
+  }
+
+  .seg-btn:hover {
+    color: var(--color-ink);
+  }
+
+  .seg-btn.seg-active {
+    color: var(--color-amber);
+    background: var(--color-inset);
+    box-shadow: inset 0 -2px 0 var(--color-amber);
+  }
+
+  .seg-btn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+
+  .range-row {
+    /* Slightly smaller to visually subordinate the range picker under tabs */
+    border-top: 1px solid var(--color-line);
+  }
+
+  .range-row .seg-btn {
+    min-height: 36px;
+    font-size: var(--fs-sm);
+  }
+
+  .lens-body {
+    margin-top: 0;
+  }
+</style>

--- a/ui/src/routes/usage/+page.svelte
+++ b/ui/src/routes/usage/+page.svelte
@@ -118,7 +118,7 @@
 
   .usage-prototype-note {
     margin: 0;
-    font-size: var(--fs-sm);
+    font-size: var(--fs-meta);
     color: var(--color-muted);
   }
 
@@ -175,7 +175,7 @@
 
   .range-row .seg-btn {
     min-height: 36px;
-    font-size: var(--fs-sm);
+    font-size: var(--fs-meta);
   }
 
   .lens-body {

--- a/ui/src/routes/usage/page.browser.test.ts
+++ b/ui/src/routes/usage/page.browser.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+
+const { default: UsagePage } = await import("./+page.svelte");
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("UsagePage (/usage)", () => {
+  it("defaults to the Spend tab and renders Spend lens content", async () => {
+    render(UsagePage);
+
+    // Spend tab button is active
+    const spendBtn = document.querySelector<HTMLButtonElement>('button[aria-pressed="true"]');
+    expect(spendBtn, "one active tab button").not.toBeNull();
+    expect(spendBtn?.textContent?.trim()).toContain("Spend");
+
+    // SpendLens renders repo rows from the default 7d fixture
+    await expect.element(page.getByText("shepherd")).toBeInTheDocument();
+  });
+
+  it("clicking the Overhead tab swaps to Overhead lens content", async () => {
+    render(UsagePage);
+
+    const overheadBtn = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+      (b) => b.textContent?.trim() === "Overhead",
+    );
+    expect(overheadBtn, "Overhead tab button exists").not.toBeNull();
+
+    overheadBtn!.click();
+
+    // Overhead lens renders the reviewer-tax section
+    await expect.element(page.getByText("Reviewer tax")).toBeInTheDocument();
+  });
+
+  it("clicking the Limits tab swaps to Limits lens and hides range selector", async () => {
+    render(UsagePage);
+
+    const limitsBtn = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+      (b) => b.textContent?.trim() === "Limits",
+    );
+    expect(limitsBtn, "Limits tab button exists").not.toBeNull();
+
+    limitsBtn!.click();
+
+    // Wait for the Limits lens to appear (it has meter-track elements)
+    await expect.poll(() => document.querySelectorAll(".meter-track").length).toBe(2);
+
+    // Range selector must not be present on the Limits tab
+    const rangeGroup = document.querySelector('[role="group"][aria-label]');
+    expect(rangeGroup, "range selector hidden on Limits tab").toBeNull();
+  });
+
+  it("range selector is present on the Spend tab", async () => {
+    render(UsagePage);
+
+    // Default tab is Spend — range group should be rendered
+    const rangeGroup = document.querySelector('[role="group"][aria-label]');
+    expect(rangeGroup, "range selector present on Spend tab").not.toBeNull();
+
+    // 7d should be the default active range
+    const activeBtns = Array.from(
+      rangeGroup!.querySelectorAll<HTMLButtonElement>('button[aria-pressed="true"]'),
+    );
+    expect(activeBtns.length, "one active range button").toBe(1);
+    expect(activeBtns[0].textContent?.trim()).toBe("7d");
+  });
+});


### PR DESCRIPTION
## What

Phase 0 of #943 — a **visual prototype** of the `/usage` token-spend dashboard. Three ranked lenses (**Spend → Overhead → Limits**) on a new route `ui/src/routes/usage/+page.svelte`, driven entirely by **mock fixtures**.

> [!IMPORTANT]
> **This renders mock fixtures only and is intentionally UNLINKED from nav** — no backend, no persistence, no top-bar entry point. The page itself carries a "Sample data · visual prototype" caption so it isn't mistaken for a live dashboard. The goal (per the issue) is to lock layout + interaction cheaply *before* any real-data wiring.

Subscription-mode only — **no dollar figures anywhere** (the `$`/api-key path is deferred to Phase 2).

## Lenses

- **Spend** (headline) — ranked horizontal bars grouped by repo; each repo row expands to its top-3 tasks with a "… N more" tail. Time-range selector (24h / **7d default** / 30d / all) swaps fixtures.
- **Overhead** — (a) **reviewer tax**: authoring-vs-satellite split overall + per-task; (b) **cacheRead ratio**: cheap-cache vs expensive-generation share.
- **Limits** — enlarged 5h/weekly windows (reusing the top bar's `gaugeList`/`gaugeColor`) + a burn-down **projection** to reset.

## Design / contract notes

- The breakdown/projection **types live in `ui/src/lib/types.ts`** (the de-facto future `GET /api/usage/breakdown` contract) so Phase 1/2 swap the *source*, not the *shapes*. `usage-mock.ts` is fixtures only.
- Design-system tokens/recipes only (segmented control for tabs + range, `.panel`, shared `UsageBar`/`SplitBar`/`format.ts`). No raw hex / ad-hoc px font sizes.
- i18n: all chrome via `m.*`, EN+DE at parity. New glossary terms **weighted units** + **satellite pass** (registry + EN/DE definitions).

## Gates / opt-out

- `[no-feature-entry]` is used deliberately: this is an unlinked mock prototype that surfaces no live UX. The real `feature-announcements.ts` entry + top-bar entry point land in **Phase 2 (#953)**.

## Verification

- `cd ui && bun run check` → 0 errors · `check:i18n` → 1739 keys/locale parity · `bun run build` → `/usage` prerenders (`usage.html`) · `bun run test` → **1833 passed** (incl. new SpendLens/OverheadLens/LimitsLens/page browser tests) · glossary + branch-hygiene + feature-catalog gates green.

## Follow-ups (out of scope here)

- **#952** — Phase 1: `session_usage` table + `beforeArchive` snapshot, aggregation service, `GET /api/usage/breakdown`.
- **#953** — Phase 2: wire real data, mode-aware `$` (api-key), top-bar entry point, feature-catalog entry.

Addresses #943 (Phase 0 of 3; Phases 1–2 tracked in #952 / #953 — umbrella stays open until they land)

🤖 Generated with [Claude Code](https://claude.com/claude-code)