### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -46,11 +46,11 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 
 ## What actually gates access
 
-| Gate                 | Default                          | What Hermes must do                                                                               |
-| -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Network bind**     | `127.0.0.1:7330` (loopback only) | Run on the same host, reach it over Tailscale serve, or set `SHEPHERD_HOST` to expose another NIC |
-| **Auth token**       | `SHEPHERD_TOKEN` unset → open    | If set, send `Authorization: Bearer <token>` on every request (timing-safe compare)               |
-| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~/Work`  | `repoPath` must resolve **inside** the root, or the request is rejected `400`                     |
+| Gate                 | Default                           | What Hermes must do                                                                               |
+| -------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **Network bind**     | `127.0.0.1:7330` (loopback only)  | Run on the same host, reach it over Tailscale serve, or set `SHEPHERD_HOST` to expose another NIC |
+| **Auth token**       | `SHEPHERD_TOKEN` unset → open     | If set, send `Authorization: Bearer <token>` on every request (timing-safe compare)               |
+| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~` (home) | `repoPath` must resolve **inside** the root, or the request is rejected `400`                     |
 
 ### Recommended setup for a remote agent
 
@@ -65,13 +65,13 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 `POST /api/sessions`, `Content-Type: application/json`. Validated by
 `validateCreate` (`src/validate.ts`); unknown keys are rejected.
 
-| Field        | Type                                    | Required | Notes                                                                        |
-| ------------ | --------------------------------------- | -------- | ---------------------------------------------------------------------------- |
-| `repoPath`   | string                                  | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
-| `baseBranch` | string                                  | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
-| `prompt`     | string                                  | ✅       | The task instructions; 1–8000 chars                                          |
-| `model`      | `"opus" \| "sonnet" \| "haiku" \| null` | —        | Omit/`null` = Claude's default                                               |
-| `images`     | `string[]`                              | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
+| Field        | Type                                                                             | Required | Notes                                                                        |
+| ------------ | -------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------- |
+| `repoPath`   | string                                                                           | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
+| `baseBranch` | string                                                                           | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
+| `prompt`     | string                                                                           | ✅       | The task instructions; 1–8000 chars                                          |
+| `model`      | `"fable" \| "opus" \| "opus[1m]" \| "sonnet" \| "sonnet[1m]" \| "haiku" \| null` | —        | Omit/`null`/`"default"` = Claude's default (no `--model` flag)               |
+| `images`     | `string[]`                                                                       | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
 
 ### Responses
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

## Changes

- **`docs/external-task-api.md`** — two corrections to the `POST /api/sessions`
  request reference, both grounded in current source:
  1. **`model` field enum.** The doc listed `"opus" | "sonnet" | "haiku" | null`.
     The accepted set is now `MODELS` in `src/types.ts:143` —
     `["fable", "opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku"]` — validated by
     `validateModel` (`src/validate.ts:82-87`), which also maps `null`/`"default"`
     to "no `--model` flag". Updated the enum to the full set and the note to
     mention `"default"`.
  2. **`SHEPHERD_REPO_ROOT` default.** The "what gates access" table claimed the
     default was `~/Work`. The actual default is `$HOME` (i.e. `~`) —
     `config.ts:325` (`repoRoot: process.env.SHEPHERD_REPO_ROOT ?? process.env.HOME ?? "/"`,
     with the comment "defaults to $HOME so a fresh install can reach any repo").
     This also brings the page into agreement with
     `docs-site/.../reference/configuration.md`, which already documents `~ (home)`.

No other in-scope page was edited. `configuration.md` was refreshed recently
(commits `24f3822d`, `6b3a7305`) and already matches the current doc-agent surface
(soak phases `observe → act`, nightly + merge-triggered cadence,
`SHEPHERD_DOC_AGENT_NIGHTLY_HOUR`). `sandbox-security.md`'s egress allowlist
(`api.anthropic.com` + `statsig.anthropic.com` + the GitHub hosts) still matches
`src/egress.ts:288-299`. `token-usage-analysis.md` is a dated historical report,
not stale-able by code changes.

## Uncertain / needs human judgment

- **`configuration.md` is not exhaustive despite its framing.** Its description and
  the `index.md` link both say "every environment variable", but `config.ts`
  defines many vars the table omits — e.g. `SHEPHERD_USAGE_HOLD_ENABLED` /
  `SHEPHERD_USAGE_HOLD_PCT`, `SHEPHERD_HOOKS_INGEST` / `SHEPHERD_HOOKS_SIGNALS`,
  `SHEPHERD_REMOTE_CONTROL_AT_STARTUP`, `SHEPHERD_REDUCED_PUSH_MODE`,
  `SHEPHERD_PUSH_COOLDOWN_MS`, `SHEPHERD_VAPID_*`, `SHEPHERD_AUTH_MODE`,
  `SHEPHERD_DEFAULT_MODEL`, `SHEPHERD_FABLE_AVAILABLE`,
  `SHEPHERD_EXTRA_CREDITS_DRAIN_CEILING`, `SHEPHERD_AUTOPILOT_*`,
  `SHEPHERD_REVIEW_CYCLES_CAP` / `SHEPHERD_PLAN_REVIEW_CYCLES_CAP`,
  `SHEPHERD_SANDBOX_EXTRA_HOSTS`, `SHEPHERD_HOUSE_RULES_BUDGET_CHARS`,
  `SHEPHERD_LLM_NAMING`, `SHEPHERD_SESSION_HOUSEKEEPING`, `SHEPHERD_AUTOMERGE_REBASE_CAP`,
  etc. This is a long-standing curation gap rather than a single recent regression,
  and filling it is a sizable, error-prone sweep — left for a human to decide whether
  the page should aim to be complete or explicitly call itself a curated subset.

- **Doc-agent UI + runs endpoint not reflected in prose.** Recent commits added a
  Backlog trigger button + run/PR badge (`#939`/`e82d164b`) and a
  `GET /api/doc-agent/runs?repo=` history endpoint (`#906`, `src/server.ts:907-920`).
  `configuration.md` still describes the doc agent purely via env flags + the
  `POST /api/doc-agent` trigger. This is additive (nothing existing is now wrong), so
  I did not edit — a human may want to mention the in-app trigger.

- **`glossary.md` term coverage.** It states its definitions mirror
  `ui/src/lib/glossary.ts`, which gained entries in recent learnings-lifecycle work
  (`#946`/`f97cee03`). I could not confirm a one-to-one drift without auditing the
  registry, and the page reads as a curated subset, so I left it unchanged.