### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -65,13 +65,13 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 `POST /api/sessions`, `Content-Type: application/json`. Validated by
 `validateCreate` (`src/validate.ts`); unknown keys are rejected.
 
-| Field        | Type                                    | Required | Notes                                                                        |
-| ------------ | --------------------------------------- | -------- | ---------------------------------------------------------------------------- |
-| `repoPath`   | string                                  | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
-| `baseBranch` | string                                  | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
-| `prompt`     | string                                  | ✅       | The task instructions; 1–8000 chars                                          |
-| `model`      | `"opus" \| "sonnet" \| "haiku" \| null` | —        | Omit/`null` = Claude's default                                               |
-| `images`     | `string[]`                              | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
+| Field        | Type                                                                | Required | Notes                                                                                   |
+| ------------ | ------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `repoPath`   | string                                                              | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`                      |
+| `baseBranch` | string                                                              | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                             |
+| `prompt`     | string                                                              | ✅       | The task instructions; 1–8000 chars                                                     |
+| `model`      | one of `fable`, `opus`, `opus[1m]`, `sonnet`, `sonnet[1m]`, `haiku` | —        | Omit, `null`, or `"default"` = Claude's default (no `--model`); any other value → `400` |
+| `images`     | `string[]`                                                          | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`)            |
 
 ### Responses
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

## Changes

- **`docs/external-task-api.md`** — Updated the `model` field row in the request
  schema. It listed only `"opus" | "sonnet" | "haiku" | null`, which predates the
  current accepted set. `src/types.ts:143` now defines
  `MODELS = ["fable", "opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku"]`, and
  `validateModel` (`src/validate.ts:82-86`) accepts exactly those values, maps
  absent/`null`/`"default"` to Claude's default (no `--model`), and rejects any
  other value with `400 unknown model`. The doc was last touched in #719, before
  `fable` and the 1M-context variants (`opus[1m]`/`sonnet[1m]`, added in #836)
  became selectable. Updated the row to the full accepted set and clarified the
  default/reject behavior.

## Uncertain / needs human judgment

- **Undocumented operator env vars in `reference/configuration.md`.** The page's
  description says "every environment variable," but it documents a curated subset.
  Several operator-facing toggles in `src/config.ts` are absent, notably the
  usage-aware task-holding feature (`SHEPHERD_USAGE_HOLD_ENABLED`, default on, and
  `SHEPHERD_USAGE_HOLD_PCT`, default 80 — `src/config.ts:486-489`, added in #830).
  Others not listed include `SHEPHERD_EXTRA_CREDITS_DRAIN_CEILING`,
  `SHEPHERD_AUTOPILOT_STEP_CAP`, `SHEPHERD_REVIEW_CYCLES_CAP`,
  `SHEPHERD_PLAN_REVIEW_CYCLES_CAP`, `SHEPHERD_SESSION_HOUSEKEEPING`,
  `SHEPHERD_LLM_NAMING`, `SHEPHERD_DEFAULT_MODEL`, `SHEPHERD_AUTH_MODE`,
  `SHEPHERD_REDUCED_PUSH_MODE`, the push/VAPID vars, and the `SHEPHERD_HOOKS_*`
  soak flags. I did **not** add these: the page is demonstrably curated and I
  cannot infer the intended inclusion criteria, so adding only some would be
  guessing. Usage-aware holding is the most operator-visible omission and the best
  candidate if the page should grow.

- **Doc-agent now has a UI trigger (#906/#939).** `reference/configuration.md`
  describes the doc agent's manual trigger only as `POST /api/doc-agent?repo=<path>`.
  That endpoint is still correct (`src/server.ts:890-901`), but #939 also added a
  Backlog trigger button + run/PR badge and a `GET /api/doc-agent/runs` endpoint.
  The prose isn't wrong, just narrower than reality; whether to mention the UI is an
  editorial call, so I left it.

- **Line-number anchors in `docs/sandbox-security.md` have drifted.** The flag/host
  claims are still accurate against current source (`readonlyReviewerArgv` flags,
  `ANTHROPIC_EGRESS_HOSTS` = `api.anthropic.com` + `statsig.anthropic.com`,
  `GITHUB_EGRESS_HOSTS`), but some precise `src/...:NN` references have shifted
  (e.g. `readonlyReviewerArgv` is now `src/reviewer-argv.ts:14-117`, cited as
  `:13-109`). I left these — the prose content is correct and re-anchoring every
  line citation is fragile/low-value.

- **`reference/glossary.md` is a curated subset of `ui/src/lib/glossary.ts`.**
  Recent commits added new registry terms (#925, #939, #943). No existing
  definition in the doc is contradicted, so I changed nothing; expanding the list
  would be an enhancement, not a staleness fix.