### PR TITLE
feat(doc-agent): re-target doc updates onto the open code PR (kill the double-PR) (#956)

### DIFF
--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -1,15 +1,16 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { docAgentArgv } from "./doc-agent-argv";
 import { EmptyDiffError } from "./forge/types";
-import type { GitForge } from "./forge/types";
+import type { GitForge, GitState } from "./forge/types";
+import { isSettledIdle } from "./recap-core";
 import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
 import type { SessionStore } from "./store";
-import type { DocAgentOutcome, DocAgentRun } from "./types";
+import type { DocAgentOutcome, DocAgentRun, Session } from "./types";
 import type { SessionUsage } from "./usage";
 import { readSessionUsage } from "./usage";
 import { apiKeyPassthroughEnv, isApiKeyConfigured, isApiKeyMode } from "./spawn-auth";
@@ -78,6 +79,17 @@ const SENTINEL = ".shepherd-doc-update.md";
  *  that lacks this tree is rejected before any spawn (it would have nothing to stage). */
 const DOC_TREE_MARKER = "docs-site/src/content/docs";
 
+/** Re-target run marker (issue #956 Option B): written at the worktree root so a restart can
+ *  re-adopt a re-target run with its mode + target PR even after the in-flight map is lost. Holds
+ *  `{ prNumber, headBranch, base }`. It lives OUTSIDE {@link IN_SCOPE_PATHS}, so the staging
+ *  `git add -- <inScope>` already excludes it (same posture as {@link SENTINEL}). */
+const RETARGET_MARKER = ".shepherd-doc-retarget.json";
+
+/** Default settled-idle debounce before a re-target run fires (mirrors recap's
+ *  DEFAULT_IDLE_THRESHOLD_MS): a code-PR session must be idle+green this long before we push docs
+ *  onto its branch, so we never re-target a still-churning PR. */
+const DEFAULT_IDLE_THRESHOLD_MS = 120_000;
+
 /** The EXPLICIT in-scope file list (repo-relative). finalize() stages ONLY these (∩ files that
  *  exist), so any agent edit outside the set — the Astro app, the generated `reference/cli/*`, or a
  *  brand-new file — is never staged and can't reach the PR. This is the structural off-limits
@@ -138,6 +150,23 @@ interface InFlight {
   spawnSessionId: string;
   startedAt: number;
   finalizing?: boolean;
+  /** "fresh" = the nightly/merge path (opens a standalone `shepherd/docs-update-*` PR).
+   *  "retarget" = issue #956 Option B (pushes the doc commit onto an OPEN code PR's head branch). */
+  mode: "fresh" | "retarget";
+  /** The code PR number being re-targeted (retarget only). */
+  prNumber?: number;
+  /** The code PR's head branch = the push target for the doc commit (retarget only). */
+  headBranch?: string;
+  /** The originating session's worktree path, for the best-effort owner-branch ff (retarget only). */
+  ownerWorktreePath?: string;
+  /** The code PR head SHA at re-target start — the worktree base + the ff safety guard (retarget). */
+  headSha?: string;
+}
+
+/** Re-target grounding context: the open code PR the doc agent is checked out at the head of. */
+export interface RetargetPromptCtx {
+  prNumber: number;
+  prTitle: string;
 }
 
 export interface DocAgentDeps extends MembraneSeams {
@@ -158,6 +187,7 @@ export interface DocAgentDeps extends MembraneSeams {
     | "listReviewerSpawns"
     | "recordDocAgentRun"
     | "listDocAgentRuns"
+    | "list"
   >;
   model?: string | null;
   /** Phase-1 escalation: when false (Phase-0 observe), finalize() is log-only (no commit/push/PR). */
@@ -174,10 +204,21 @@ export interface DocAgentDeps extends MembraneSeams {
   prettier?: (args: { cwd: string; configPath: string; files: string[] }) => Promise<void>;
   fileExists?: (p: string) => boolean;
   readSentinel?: (worktreePath: string) => string | null;
-  buildPrompt?: (base: string) => string;
+  /** Cached PR state per session (Task 2 wires it to `prPoller.get`). The re-target sweep reads it
+   *  to find open+green+doc-relevant code PRs. */
+  gitState?: (sessionId: string) => GitState | undefined;
+  /** Settled-idle debounce before a re-target run fires (default {@link DEFAULT_IDLE_THRESHOLD_MS}). */
+  idleThresholdMs?: number;
+  /** Build the agent task prompt. `ctx` (re-target only) grounds the agent on the open PR's diff
+   *  instead of the recent-commit window. */
+  buildPrompt?: (base: string, ctx?: RetargetPromptCtx) => string;
   /** Read a spawn's token usage from its transcript at finalize (cost attribution). Mirrors
    *  herd-digest.ts's identical dep + readSessionUsage default. */
   readUsage?: (cwd: string, spawnSessionId: string) => Promise<SessionUsage | null>;
+  /** Write the re-target marker (tests inject a fake; default `writeFileSync`). */
+  writeMarker?: (path: string, contents: string) => void;
+  /** Read the re-target marker on boot re-adopt (tests inject a fake; default `readFileSync`). */
+  readMarker?: (path: string) => string | null;
 }
 
 /**
@@ -207,9 +248,14 @@ export class DocAgentService {
   private dayKey: (now: number) => string;
   private fileExists: (p: string) => boolean;
   private readSentinel: (worktreePath: string) => string | null;
-  private buildPrompt: (base: string) => string;
+  private buildPrompt: (base: string, ctx?: RetargetPromptCtx) => string;
   private act: boolean;
   private readUsage: (cwd: string, spawnSessionId: string) => Promise<SessionUsage | null>;
+  private idleThresholdMs: number;
+  private writeMarkerFn: (path: string, contents: string) => void;
+  private readMarkerFn: (path: string) => string | null;
+  /** Per-session settled-idle debounce for the re-target sweep (mirrors RecapService.debounce). */
+  private readyDebounce = new Map<string, { stamp: number; fired: boolean }>();
 
   constructor(private deps: DocAgentDeps) {
     this.git = deps.git ?? defaultGit;
@@ -220,9 +266,20 @@ export class DocAgentService {
     this.dayKey = deps.dayKey ?? defaultDayKey;
     this.fileExists = deps.fileExists ?? existsSync;
     this.readSentinel = deps.readSentinel ?? defaultReadSentinel;
-    this.buildPrompt = deps.buildPrompt ?? ((base) => docAgentPrompt(base));
+    this.buildPrompt = deps.buildPrompt ?? ((base, ctx) => docAgentPrompt(base, ctx));
     this.act = deps.act ?? false;
     this.readUsage = deps.readUsage ?? readSessionUsage;
+    this.idleThresholdMs = deps.idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
+    this.writeMarkerFn = deps.writeMarker ?? ((p, c) => writeFileSync(p, c, "utf8"));
+    this.readMarkerFn = deps.readMarker ?? defaultReadMarker;
+  }
+
+  /** Serialize + write the re-target marker JSON (best-effort caller catches). */
+  private writeMarker(
+    path: string,
+    data: { prNumber: number; headBranch: string; base: string },
+  ): void {
+    this.writeMarkerFn(path, JSON.stringify(data));
   }
 
   /** Start a doc-agent run for `repoPath` (manual trigger). At most one per repo at a time. */
@@ -278,6 +335,12 @@ export class DocAgentService {
     }
     if (!forge || baseBranch !== def)
       return { status: "skipped", reason: "merge target is not the default branch" };
+    // Re-target ownership (issue #956): a re-target run claims this PR's docs at its START (it sets
+    // prSyncedKey before spawning). If that key is set the doc commit is already (or about to be) on
+    // this PR's own branch — DEFER, and crucially do NOT consume the per-PR mergedSeenKey below, so
+    // the merge fast-path stays available should the re-target run later fall through to a fresh PR.
+    if (this.deps.store.getSetting(prSyncedKey(repoPath, prNumber)) != null)
+      return { status: "skipped", reason: "re-target already owns this PR's docs" };
     const key = mergedSeenKey(repoPath, prNumber);
     if (this.deps.store.getSetting(key) != null)
       return { status: "skipped", reason: "merge already handled" };
@@ -352,6 +415,163 @@ export class DocAgentService {
     }
   }
 
+  /**
+   * Pre-merge re-target sweep (issue #956 Option B). Called on the tick (flag-gated in index.ts).
+   * For each managed session whose code PR is OPEN + green + doc-relevant and has been settled-idle
+   * long enough, spawn a re-target run that pushes the doc commit onto THAT PR's own head branch —
+   * one PR carries both code and docs, instead of a second `shepherd/docs-update-*` PR after merge.
+   *
+   * Modeled on {@link import("./recap").RecapService.sweep}/considerSession: a per-session
+   * settled-idle debounce ({@link readyDebounce}) ensures we never re-target a still-churning PR, and
+   * the per-repo `inflight`/`starting` lock serializes against the fresh path (one doc run per repo).
+   */
+  async sweepReadyPrs(): Promise<void> {
+    const now = this.now();
+    for (const s of this.deps.store.list()) {
+      try {
+        await this.considerReady(s, now);
+      } catch (err) {
+        console.warn(`[doc-agent] re-target sweep failed for ${s.id}:`, err);
+      }
+    }
+  }
+
+  /** Per-session re-target decision: gate → settled-idle debounce → per-repo lock → beginRetarget. */
+  private async considerReady(s: Session, now: number): Promise<void> {
+    if (s.status === "archived") return;
+    // Not settled (still working) → reset the debounce so a later settle re-evaluates cleanly.
+    if (s.status === "running" || s.status === "blocked") {
+      this.readyDebounce.delete(s.id);
+      return;
+    }
+    // Eligibility gates (cheap, no spawn). A miss leaves the debounce untouched so it can fire once
+    // the session becomes eligible without restarting the idle clock.
+    if (!s.branch) return;
+    if (!this.fileExists(join(s.repoPath, DOC_TREE_MARKER))) return;
+    const git = this.deps.gitState?.(s.id);
+    if (!git || git.state !== "open" || git.checks !== "success") return;
+    if (!git.headSha || git.number == null) return;
+    if (!isDocRelevantMerge(git.title)) return;
+    if (this.deps.store.getSetting(prSyncedKey(s.repoPath, git.number)) != null) return;
+
+    // Settled-idle debounce (mirrors RecapService.considerSession).
+    const e = this.readyDebounce.get(s.id);
+    if (!e) {
+      this.readyDebounce.set(s.id, { stamp: now, fired: false });
+      return; // first settle tick — start the idle clock
+    }
+    if (e.fired) return; // already fired this idle episode
+    if (!isSettledIdle(s.status, now - e.stamp, this.idleThresholdMs)) return;
+
+    // Per-repo lock: don't fire while a doc run is in flight/starting for this repo. Do NOT set
+    // `fired` — retry next tick once the lock frees (a missed episode would otherwise never fire).
+    if (this.inflight.has(s.repoPath) || this.starting.has(s.repoPath)) return;
+
+    e.fired = true;
+    await this.beginRetarget(s, git);
+  }
+
+  /**
+   * Start a re-target run for `session` against its open code PR (issue #956). Mirrors {@link begin}
+   * but checks the worktree out at the PR's HEAD sha and, on finalize, pushes the doc commit onto the
+   * PR's own head branch instead of opening a standalone PR.
+   *
+   * Sets the {@link prSyncedKey} ownership claim BEFORE the spawn so {@link onMergedPr} defers even if
+   * the code PR merges mid-run. Re-checks the per-repo lock (the sweep checked it without holding it).
+   * Does NOT call stampLastSha — that is the nightly gate's marker, irrelevant to a PR-targeted run.
+   */
+  private async beginRetarget(session: Session, git: GitState): Promise<DocAgentResult> {
+    const repoPath = session.repoPath;
+    if (this.inflight.has(repoPath) || this.starting.has(repoPath))
+      return { status: "skipped", reason: "doc agent already running for this repo" };
+    this.starting.add(repoPath);
+    try {
+      const guard = this.guardRepo(repoPath);
+      if (!guard.ok) return guard.result;
+      const forge = guard.forge;
+      const prNumber = git.number!;
+      const headSha = git.headSha!;
+
+      let base: string;
+      try {
+        base = await forge.defaultBranch();
+      } catch {
+        return { status: "error", reason: "could not resolve default branch" };
+      }
+
+      // Claim ownership BEFORE the spawn: if the code PR merges mid-run, onMergedPr now defers and the
+      // re-target run's own finalize fallback opens the single fresh PR (no double PR).
+      this.deps.store.setSetting(prSyncedKey(repoPath, prNumber), "1");
+
+      const id8 = randomUUID().slice(0, 8);
+      const wtName = DOC_BRANCH_PREFIX + id8;
+      let wt;
+      try {
+        wt = this.deps.worktree.create(repoPath, headSha, wtName);
+      } catch (err) {
+        console.warn(`[doc-agent] re-target worktree creation failed for ${repoPath}:`, err);
+        return { status: "error", reason: "worktree creation failed" };
+      }
+      if (!wt.isolated || !wt.branch) {
+        if (wt.worktreePath !== repoPath) this.deps.worktree.remove(wt.worktreePath);
+        return { status: "error", reason: "worktree creation failed" };
+      }
+
+      // Drop the restart marker so a boot reconcile re-adopts this as a re-target run.
+      try {
+        this.writeMarker(join(wt.worktreePath, RETARGET_MARKER), {
+          prNumber,
+          headBranch: session.branch!,
+          base,
+        });
+      } catch (err) {
+        console.warn(`[doc-agent] writing re-target marker failed for ${repoPath}:`, err);
+      }
+
+      const promptCtx: RetargetPromptCtx = { prNumber, prTitle: git.title ?? "" };
+      const spawned = this.spawnAgent(
+        repoPath,
+        wt.worktreePath,
+        DOC_AGENT_LABEL + id8,
+        base,
+        promptCtx,
+      );
+      if (!spawned) {
+        this.deps.worktree.remove(wt.worktreePath);
+        return { status: "error", reason: "spawn failed" };
+      }
+      const { terminalId, spawnSessionId } = spawned;
+      const startedAt = this.now();
+      this.inflight.set(repoPath, {
+        repoPath,
+        worktreePath: wt.worktreePath,
+        branch: wt.branch,
+        base,
+        terminalId,
+        agentName: DOC_AGENT_LABEL + id8,
+        spawnSessionId,
+        startedAt,
+        mode: "retarget",
+        prNumber,
+        headBranch: session.branch!,
+        ownerWorktreePath: session.worktreePath,
+        headSha,
+      });
+      // Durable cost row (same posture as begin): attributable even if the run crashes pre-finalize.
+      this.deps.store.recordReviewerSpawn({
+        reviewerSessionId: spawnSessionId,
+        taskSessionId: repoPath,
+        kind: "doc_agent",
+        worktreePath: wt.worktreePath,
+        model: this.deps.model ?? null,
+        spawnedAt: startedAt,
+      });
+      return { status: "started" };
+    } finally {
+      this.starting.delete(repoPath);
+    }
+  }
+
   private async begin(repoPath: string): Promise<DocAgentResult> {
     const guard = this.guardRepo(repoPath);
     if (!guard.ok) return guard.result;
@@ -400,6 +620,7 @@ export class DocAgentService {
       agentName: DOC_AGENT_LABEL + id8,
       spawnSessionId,
       startedAt,
+      mode: "fresh",
     });
     // AFTER inflight.set (the ordering mirrors plan-gate's documented invariant): persist a durable
     // reviewer_spawns row so this run's token burn is attributable even if it crashes before finalize.
@@ -459,8 +680,12 @@ export class DocAgentService {
     worktreePath: string,
     agentName: string,
     base: string,
+    promptCtx?: RetargetPromptCtx,
   ): { terminalId: string; spawnSessionId: string } | null {
-    const { argv, sessionId } = docAgentArgv(this.deps.model ?? null, this.buildPrompt(base));
+    const { argv, sessionId } = docAgentArgv(
+      this.deps.model ?? null,
+      this.buildPrompt(base, promptCtx),
+    );
     const { wrapped, backend } = resolveSpawnMembrane({
       argv,
       worktreePath,
@@ -540,7 +765,10 @@ export class DocAgentService {
         ).trim();
         if (stagedOut.length > 0) {
           hadStagedChanges = true;
-          url = await this.publishStaged(f, sentinel, forge, stagedOut);
+          url =
+            f.mode === "retarget"
+              ? await this.publishRetarget(f, sentinel, forge, stagedOut)
+              : await this.publishStaged(f, sentinel, forge, stagedOut);
         }
       }
     } finally {
@@ -590,6 +818,17 @@ export class DocAgentService {
       return null;
     }
     await this.git(f.worktreePath, ["commit", "--no-verify", "-m", COMMIT_MSG]);
+    return this.openFreshPr(f, sentinel, forge);
+  }
+
+  /** Push the local `shepherd/docs-update-*` branch and open a standalone doc-update PR. Shared by
+   *  the fresh path and the re-target merged-first fallback. Assumes the commit is already made.
+   *  Returns the PR url (null on no net diff vs base). */
+  private async openFreshPr(
+    f: InFlight,
+    sentinel: string | null,
+    forge: GitForge,
+  ): Promise<string | null> {
     await this.git(f.worktreePath, ["push", "-u", "origin", f.branch]);
     try {
       const status = await forge.openPr({
@@ -603,6 +842,83 @@ export class DocAgentService {
       // No net diff vs base → nothing to land; not an error.
       if (!(err instanceof EmptyDiffError)) throw err;
       return null;
+    }
+  }
+
+  /**
+   * Re-target publish (issue #956 Option B). Commits the staged doc changes, then — IF the code PR is
+   * still open — pushes the commit onto that PR's own head branch (no new PR opened) and best-effort
+   * fast-forwards the owner session's local branch. If the PR is no longer open (merged/closed
+   * mid-run), falls through to {@link openFreshPr} so the doc change still lands as exactly ONE
+   * standalone PR. OBSERVE (`!act`) logs what it would push and returns null (no commit/push/PR).
+   */
+  private async publishRetarget(
+    f: InFlight,
+    sentinel: string | null,
+    forge: GitForge,
+    stagedOut: string,
+  ): Promise<string | null> {
+    if (!this.act) {
+      const staged = stagedOut.split("\n");
+      console.warn(
+        `[doc-agent] OBSERVE: ${f.repoPath} would push docs onto PR #${f.prNumber} branch ${f.headBranch} (${staged.length} files): ${staged.join(", ")}`,
+      );
+      return null;
+    }
+    await this.git(f.worktreePath, ["commit", "--no-verify", "-m", COMMIT_MSG]);
+
+    // Re-check the PR right before the push: it may have merged/closed since the run started.
+    let status;
+    try {
+      status = await forge.prStatus(f.headBranch!);
+    } catch (err) {
+      console.warn(
+        `[doc-agent] re-target: prStatus(${f.headBranch}) failed for ${f.repoPath}:`,
+        err,
+      );
+      return null; // defer to the nightly path rather than guess
+    }
+    if (status.state !== "open") {
+      // PR merged/closed mid-run → open the single fresh PR instead (key already set → onMergedPr defers).
+      return this.openFreshPr(f, sentinel, forge);
+    }
+
+    // Push the doc commit onto the code PR's OWN head branch (never force, explicit refspec).
+    try {
+      await this.git(f.worktreePath, ["push", "origin", `HEAD:refs/heads/${f.headBranch}`]);
+    } catch (err) {
+      // Non-ff or other push failure → defer to the nightly fresh path; do NOT throw or force.
+      console.warn(
+        `[doc-agent] re-target: pushing onto ${f.headBranch} failed for ${f.repoPath} — deferring to nightly:`,
+        err,
+      );
+      return null;
+    }
+    // Best-effort: fast-forward the owner session's local branch so it isn't left behind origin.
+    await this.ffOwnerBranch(f);
+    return status.url ?? null;
+  }
+
+  /**
+   * Best-effort fast-forward of the originating session's local branch to the just-pushed head
+   * (issue #956). NEVER throws, NEVER force-pushes, NEVER rewrites the owner's branch: it fetches the
+   * code PR's branch and `merge --ff-only`s, but only when the owner worktree is clean AND still at
+   * the pre-push head (so an operator who resumed work mid-run is never clobbered).
+   */
+  private async ffOwnerBranch(f: InFlight): Promise<void> {
+    if (!f.ownerWorktreePath || !f.headBranch || !f.headSha) return;
+    try {
+      const dirty = (await this.git(f.ownerWorktreePath, ["status", "--porcelain"])).trim();
+      if (dirty.length > 0) return; // uncommitted work — never touch it
+      const head = (await this.git(f.ownerWorktreePath, ["rev-parse", "HEAD"])).trim();
+      if (head !== f.headSha) return; // owner moved on since we forked — leave it alone
+      await this.git(f.ownerWorktreePath, ["fetch", "origin", f.headBranch]);
+      await this.git(f.ownerWorktreePath, ["merge", "--ff-only", `origin/${f.headBranch}`]);
+    } catch (err) {
+      console.warn(
+        `[doc-agent] re-target: owner-branch ff skipped for ${f.ownerWorktreePath}:`,
+        err,
+      );
     }
   }
 
@@ -709,6 +1025,10 @@ export class DocAgentService {
     // RE-ADOPT: hand the `starting` claim to `inflight`; the next tick() finalizes it (and completes
     // the row). Recover spawnedAt + the spawn session id from the uncompleted row when present.
     const row = this.uncompletedRowFor(path);
+    // Restart-safety (issue #956): a re-target run dropped a marker; re-adopt it as such so the next
+    // tick()→finalize routes to publishRetarget (which re-checks prStatus and either pushes onto the
+    // open PR or falls through to a fresh PR). Absent/unparseable marker → fresh path (unchanged).
+    const marker = this.readRetargetMarker(path);
     this.inflight.set(repo, {
       repoPath: repo,
       worktreePath: path,
@@ -718,6 +1038,8 @@ export class DocAgentService {
       agentName: liveTab?.name ?? "",
       startedAt: row?.spawnedAt ?? this.now(),
       spawnSessionId: row?.reviewerSessionId ?? "",
+      mode: marker ? "retarget" : "fresh",
+      ...(marker ? { prNumber: marker.prNumber, headBranch: marker.headBranch } : {}),
     });
     this.starting.delete(repo);
     return true;
@@ -860,6 +1182,25 @@ export class DocAgentService {
     }
   }
 
+  /** Read + parse the re-target marker at a worktree root, or null when absent/unparseable. */
+  private readRetargetMarker(
+    worktreePath: string,
+  ): { prNumber: number; headBranch: string; base: string } | null {
+    const raw = this.readMarkerFn(join(worktreePath, RETARGET_MARKER));
+    if (raw == null) return null;
+    try {
+      const m = JSON.parse(raw) as { prNumber?: unknown; headBranch?: unknown; base?: unknown };
+      if (typeof m.prNumber !== "number" || typeof m.headBranch !== "string") return null;
+      return {
+        prNumber: m.prNumber,
+        headBranch: m.headBranch,
+        base: typeof m.base === "string" ? m.base : "",
+      };
+    } catch {
+      return null;
+    }
+  }
+
   /** Parse `git worktree list --porcelain` → [{path, branch}] (branch "" for detached). */
   private async listWorktreeBranches(repo: string): Promise<{ path: string; branch: string }[]> {
     const out = await this.git(repo, ["worktree", "list", "--porcelain"]);
@@ -895,6 +1236,10 @@ const nightlyDayKey = (repo: string) => `docagent:nightly-day:${repo}`;
 // posture as the existing `learnings:*` per-key settings markers (e.g. learnings:retired-seen:<repo>).
 const mergedSeenKey = (repo: string, prNumber: number) =>
   `docagent:merged-seen:${repo}:${prNumber}`;
+// Re-target ownership claim (issue #956 Option B). Set at re-target START (in beginRetarget, before
+// the spawn) so onMergedPr defers even if the code PR merges mid-run. Same accept-and-grow posture
+// as mergedSeenKey — one tiny row per re-targeted PR, never cleaned up.
+const prSyncedKey = (repo: string, prNumber: number) => `docagent:pr-synced:${repo}:${prNumber}`;
 
 /** Local `YYYY-MM-DD` for `now` — the nightly once/day key (mirrors herd-digest's dayKeyFor). */
 function defaultDayKey(now: number): string {
@@ -932,6 +1277,16 @@ function defaultReadSentinel(worktreePath: string): string | null {
   }
 }
 
+/** Read the re-target marker file at an absolute path, or null when absent/unreadable. */
+function defaultReadMarker(path: string): string | null {
+  if (!existsSync(path)) return null;
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
 /** PR body: the agent's grounding/uncertainty summary + a human-review banner. */
 function docPrBody(sentinel: string | null): string {
   const summary =
@@ -951,16 +1306,31 @@ function docPrBody(sentinel: string | null): string {
 /** The doc-agent task prompt. Grounds the agent in recent source changes, restricts edits to the
  *  enumerated existing in-scope prose, forbids touching generated docs + creating new files +
  *  running git, and asks for a grounded/uncertainty summary written to the sentinel. */
-function docAgentPrompt(base: string): string {
+function docAgentPrompt(base: string, ctx?: RetargetPromptCtx): string {
+  const grounding = ctx
+    ? [
+        "You are Shepherd's documentation-maintenance agent. Your working directory is checked out at",
+        `the HEAD of open PR #${ctx.prNumber} (\`${ctx.prTitle}\`). The change under review is`,
+        `\`git diff ${base}...HEAD\`. Focus your doc review on what THIS change made stale, and update`,
+        "ONLY the existing prose pages listed below.",
+        "",
+        "## Ground yourself in this PR's diff",
+        `Use read-only git to understand exactly what this PR changed: \`git diff ${base}...HEAD\`,`,
+        `\`git log ${base}..HEAD --stat\`, \`git show <sha>\` (these forms are what you may run).`,
+        "Pay attention to changes in:",
+      ]
+    : [
+        "You are Shepherd's documentation-maintenance agent. Your working directory is a fresh checkout",
+        `of the \`${base}\` branch. Your job: find where the documentation has gone stale relative to`,
+        "recent source changes, and update ONLY the existing prose pages listed below.",
+        "",
+        "## Ground yourself in recent changes",
+        `Use read-only git to understand what changed recently: \`git log -n ${COMMIT_WINDOW} --stat\`,`,
+        "`git show <sha>`, `git diff <ref>..<ref>` (these forms are what you are permitted to run).",
+        "Pay attention to changes in:",
+      ];
   return [
-    "You are Shepherd's documentation-maintenance agent. Your working directory is a fresh checkout",
-    `of the \`${base}\` branch. Your job: find where the documentation has gone stale relative to`,
-    "recent source changes, and update ONLY the existing prose pages listed below.",
-    "",
-    "## Ground yourself in recent changes",
-    `Use read-only git to understand what changed recently: \`git log -n ${COMMIT_WINDOW} --stat\`,`,
-    "`git show <sha>`, `git diff <ref>..<ref>` (these forms are what you are permitted to run).",
-    "Pay attention to changes in:",
+    ...grounding,
     "- `src/config.ts` — environment variables (names, defaults, behavior)",
     "- `docs/external-task-api.md`, `docs/sandbox-security.md`, `docs/token-usage-analysis.md` — the",
     "  repo-root prose sources (you may edit these directly)",

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -929,6 +929,20 @@ export class DocAgentService {
   }
 
   /**
+   * Free the per-session re-target debounce on archive (mirrors RecapService.onArchived).
+   *
+   * Without this the `readyDebounce` Map leaks entries for archived sessions — they never
+   * re-enter the sweep's active-session list to be cleared (considerReady() early-returns on
+   * `status === "archived"` before touching the map).
+   *
+   * Deliberately does NOT touch `inflight`/`starting` — a doc run is keyed by repoPath, not
+   * sessionId, so archiving a session has no bearing on an in-flight run for its repo.
+   */
+  onArchived(sessionId: string): void {
+    this.readyDebounce.delete(sessionId);
+  }
+
+  /**
    * Boot reconcile (issue #905). Unlike the reviewer's reapOrphans (which DISCARDS the worktree and
    * re-kicks a fresh run), the doc agent KEEPS a finished worktree and FINALIZES the work already
    * produced — the SENTINEL edits are the deliverable, so throwing them away on a restart that

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -446,13 +446,8 @@ export class DocAgentService {
     }
     // Eligibility gates (cheap, no spawn). A miss leaves the debounce untouched so it can fire once
     // the session becomes eligible without restarting the idle clock.
-    if (!s.branch) return;
-    if (!this.fileExists(join(s.repoPath, DOC_TREE_MARKER))) return;
-    const git = this.deps.gitState?.(s.id);
-    if (!git || git.state !== "open" || git.checks !== "success") return;
-    if (!git.headSha || git.number == null) return;
-    if (!isDocRelevantMerge(git.title)) return;
-    if (this.deps.store.getSetting(prSyncedKey(s.repoPath, git.number)) != null) return;
+    const git = this.retargetCandidate(s);
+    if (!git) return;
 
     // Settled-idle debounce (mirrors RecapService.considerSession).
     const e = this.readyDebounce.get(s.id);
@@ -469,6 +464,24 @@ export class DocAgentService {
 
     e.fired = true;
     await this.beginRetarget(s, git);
+  }
+
+  /**
+   * Cheap, no-spawn eligibility gate for the re-target sweep: returns the validated cached
+   * {@link GitState} when `s` is a re-target candidate (has a branch, lives in a doc-tree repo, and
+   * its cached PR state is open + green + has a head sha + number + a doc-relevant title + is not
+   * already claimed by a prior re-target), else null. A null leaves the caller's idle debounce
+   * untouched so it can fire once the session becomes eligible without restarting the idle clock.
+   */
+  private retargetCandidate(s: Session): GitState | null {
+    if (!s.branch) return null;
+    if (!this.fileExists(join(s.repoPath, DOC_TREE_MARKER))) return null;
+    const git = this.deps.gitState?.(s.id);
+    if (!git || git.state !== "open" || git.checks !== "success") return null;
+    if (!git.headSha || git.number == null) return null;
+    if (!isDocRelevantMerge(git.title)) return null;
+    if (this.deps.store.getSetting(prSyncedKey(s.repoPath, git.number)) != null) return null;
+    return git;
   }
 
   /**
@@ -503,73 +516,114 @@ export class DocAgentService {
       // re-target run's own finalize fallback opens the single fresh PR (no double PR).
       this.deps.store.setSetting(prSyncedKey(repoPath, prNumber), "1");
 
-      const id8 = randomUUID().slice(0, 8);
-      const wtName = DOC_BRANCH_PREFIX + id8;
-      let wt;
-      try {
-        wt = this.deps.worktree.create(repoPath, headSha, wtName);
-      } catch (err) {
-        console.warn(`[doc-agent] re-target worktree creation failed for ${repoPath}:`, err);
-        return { status: "error", reason: "worktree creation failed" };
-      }
-      if (!wt.isolated || !wt.branch) {
-        if (wt.worktreePath !== repoPath) this.deps.worktree.remove(wt.worktreePath);
-        return { status: "error", reason: "worktree creation failed" };
-      }
-
-      // Drop the restart marker so a boot reconcile re-adopts this as a re-target run.
-      try {
-        this.writeMarker(join(wt.worktreePath, RETARGET_MARKER), {
+      const promptCtx: RetargetPromptCtx = { prNumber, prTitle: git.title ?? "" };
+      const launched = this.launchRun(
+        repoPath,
+        headSha,
+        base,
+        {
+          mode: "retarget",
           prNumber,
           headBranch: session.branch!,
-          base,
-        });
-      } catch (err) {
-        console.warn(`[doc-agent] writing re-target marker failed for ${repoPath}:`, err);
-      }
-
-      const promptCtx: RetargetPromptCtx = { prNumber, prTitle: git.title ?? "" };
-      const spawned = this.spawnAgent(
-        repoPath,
-        wt.worktreePath,
-        DOC_AGENT_LABEL + id8,
-        base,
+          ownerWorktreePath: session.worktreePath,
+          headSha,
+        },
         promptCtx,
+        // Drop the restart marker so a boot reconcile re-adopts this as a re-target run. Runs after
+        // worktree creation, before the spawn — same position as the original inline write.
+        (worktreePath) => {
+          try {
+            this.writeMarker(join(worktreePath, RETARGET_MARKER), {
+              prNumber,
+              headBranch: session.branch!,
+              base,
+            });
+          } catch (err) {
+            console.warn(`[doc-agent] writing re-target marker failed for ${repoPath}:`, err);
+          }
+        },
       );
-      if (!spawned) {
-        this.deps.worktree.remove(wt.worktreePath);
-        return { status: "error", reason: "spawn failed" };
-      }
-      const { terminalId, spawnSessionId } = spawned;
-      const startedAt = this.now();
-      this.inflight.set(repoPath, {
-        repoPath,
-        worktreePath: wt.worktreePath,
-        branch: wt.branch,
-        base,
-        terminalId,
-        agentName: DOC_AGENT_LABEL + id8,
-        spawnSessionId,
-        startedAt,
-        mode: "retarget",
-        prNumber,
-        headBranch: session.branch!,
-        ownerWorktreePath: session.worktreePath,
-        headSha,
-      });
-      // Durable cost row (same posture as begin): attributable even if the run crashes pre-finalize.
-      this.deps.store.recordReviewerSpawn({
-        reviewerSessionId: spawnSessionId,
-        taskSessionId: repoPath,
-        kind: "doc_agent",
-        worktreePath: wt.worktreePath,
-        model: this.deps.model ?? null,
-        spawnedAt: startedAt,
-      });
+      if (!launched.ok) return launched.result;
       return { status: "started" };
     } finally {
       this.starting.delete(repoPath);
     }
+  }
+
+  /**
+   * Shared run-launch mechanics for {@link begin} (fresh) and {@link beginRetarget} (retarget):
+   * create a disposable `shepherd/docs-update-<8hex>` worktree off `baseRef`, optionally run
+   * `afterCreate` (the re-target marker write — between create and spawn), spawn the scoped agent,
+   * register it in `inflight` (merging `extra` for mode + the retarget-only fields), and persist the
+   * durable cost row. Returns `{ ok: true }` on success or `{ ok: false, result }` carrying the
+   * skip/error result the caller returns. The worktree is removed on any post-create failure.
+   *
+   * `baseRef` is the worktree start point — `resolved.baseRef` (fresh) or the PR head sha (retarget).
+   * `base` is the default-branch name stored on the run + threaded into the prompt. `promptCtx`
+   * (retarget only) grounds the agent on the open PR's diff. Callers keep their own pre/post steps
+   * (begin's stampLastSha, beginRetarget's prSyncedKey claim) outside this helper.
+   */
+  private launchRun(
+    repoPath: string,
+    baseRef: string,
+    base: string,
+    extra: Partial<InFlight>,
+    promptCtx?: RetargetPromptCtx,
+    afterCreate?: (worktreePath: string) => void,
+  ): { ok: true } | { ok: false; result: DocAgentResult } {
+    const id8 = randomUUID().slice(0, 8);
+    const wtName = DOC_BRANCH_PREFIX + id8;
+    let wt;
+    try {
+      wt = this.deps.worktree.create(repoPath, baseRef, wtName);
+    } catch (err) {
+      console.warn(`[doc-agent] worktree creation failed for ${repoPath}:`, err);
+      return { ok: false, result: { status: "error", reason: "worktree creation failed" } };
+    }
+    if (!wt.isolated || !wt.branch) {
+      if (wt.worktreePath !== repoPath) this.deps.worktree.remove(wt.worktreePath);
+      return { ok: false, result: { status: "error", reason: "worktree creation failed" } };
+    }
+
+    afterCreate?.(wt.worktreePath);
+
+    const spawned = this.spawnAgent(
+      repoPath,
+      wt.worktreePath,
+      DOC_AGENT_LABEL + id8,
+      base,
+      promptCtx,
+    );
+    if (!spawned) {
+      this.deps.worktree.remove(wt.worktreePath);
+      return { ok: false, result: { status: "error", reason: "spawn failed" } };
+    }
+    const { terminalId, spawnSessionId } = spawned;
+    const startedAt = this.now();
+    this.inflight.set(repoPath, {
+      repoPath,
+      worktreePath: wt.worktreePath,
+      branch: wt.branch,
+      base,
+      terminalId,
+      agentName: DOC_AGENT_LABEL + id8,
+      spawnSessionId,
+      startedAt,
+      mode: "fresh",
+      ...extra,
+    });
+    // AFTER inflight.set (the ordering mirrors plan-gate's documented invariant): persist a durable
+    // reviewer_spawns row so this run's token burn is attributable even if it crashes before finalize.
+    // Session-less — repoPath is the correlation key (herd-digest uses "" for its herd-wide spawn).
+    this.deps.store.recordReviewerSpawn({
+      reviewerSessionId: spawnSessionId,
+      taskSessionId: repoPath,
+      kind: "doc_agent",
+      worktreePath: wt.worktreePath,
+      model: this.deps.model ?? null,
+      spawnedAt: startedAt,
+    });
+    return { ok: true };
   }
 
   private async begin(repoPath: string): Promise<DocAgentResult> {
@@ -590,49 +644,8 @@ export class DocAgentService {
 
     // forget() can't race a manual trigger here, but a second trigger could have landed during the
     // awaits above — the `starting` claim (held until this returns) prevents that double-spawn.
-    const id8 = randomUUID().slice(0, 8);
-    const wtName = DOC_BRANCH_PREFIX + id8;
-    let wt;
-    try {
-      wt = this.deps.worktree.create(repoPath, resolved.baseRef, wtName);
-    } catch (err) {
-      console.warn(`[doc-agent] worktree creation failed for ${repoPath}:`, err);
-      return { status: "error", reason: "worktree creation failed" };
-    }
-    if (!wt.isolated || !wt.branch) {
-      if (wt.worktreePath !== repoPath) this.deps.worktree.remove(wt.worktreePath);
-      return { status: "error", reason: "worktree creation failed" };
-    }
-
-    const spawned = this.spawnAgent(repoPath, wt.worktreePath, DOC_AGENT_LABEL + id8, base);
-    if (!spawned) {
-      this.deps.worktree.remove(wt.worktreePath);
-      return { status: "error", reason: "spawn failed" };
-    }
-    const { terminalId, spawnSessionId } = spawned;
-    const startedAt = this.now();
-    this.inflight.set(repoPath, {
-      repoPath,
-      worktreePath: wt.worktreePath,
-      branch: wt.branch,
-      base,
-      terminalId,
-      agentName: DOC_AGENT_LABEL + id8,
-      spawnSessionId,
-      startedAt,
-      mode: "fresh",
-    });
-    // AFTER inflight.set (the ordering mirrors plan-gate's documented invariant): persist a durable
-    // reviewer_spawns row so this run's token burn is attributable even if it crashes before finalize.
-    // Session-less — repoPath is the correlation key (herd-digest uses "" for its herd-wide spawn).
-    this.deps.store.recordReviewerSpawn({
-      reviewerSessionId: spawnSessionId,
-      taskSessionId: repoPath,
-      kind: "doc_agent",
-      worktreePath: wt.worktreePath,
-      model: this.deps.model ?? null,
-      spawnedAt: startedAt,
-    });
+    const launched = this.launchRun(repoPath, resolved.baseRef, base, { mode: "fresh" });
+    if (!launched.ok) return launched.result;
     // Stamp the cadence marker from the SAME ref the nightly gate reads (`refs/remotes/origin/<base>`,
     // freshened by ensureBaseRef above) — NOT resolved.baseRef, which falls back to the branch
     // name/local sha in the diverged/no-upstream case and could never reach equality with the gate's
@@ -728,41 +741,48 @@ export class DocAgentService {
     }
   }
 
+  /**
+   * Stage the in-scope doc edits and return the staged-file diff (`git diff --cached --name-only`,
+   * trimmed; "" when nothing staged or no in-scope file exists). STRUCTURAL off-limits boundary:
+   * stages ONLY {@link IN_SCOPE_PATHS} ∩ files that exist, so an agent edit to the Astro app,
+   * reference/cli/*, or a brand-new file is never staged → can't reach the PR.
+   *
+   * Before staging it formats the `docs/`-prefixed in-scope files (abs paths) with the server's
+   * pinned prettier so the PR passes CI's `prettier --check .` gate — docs-site/** is
+   * Astro/Starlight-governed and must NEVER be passed to root prettier. Prettier is best-effort: a
+   * failure warns loudly and the PR still opens (no worse than today's unformatted baseline).
+   */
+  private async stageInScope(f: InFlight): Promise<string> {
+    const inScope = IN_SCOPE_PATHS.filter((p) => this.fileExists(join(f.worktreePath, p)));
+    if (inScope.length === 0) return "";
+    const absDocs = inScope
+      .filter((p) => p.startsWith("docs/"))
+      .map((p) => join(f.worktreePath, p));
+    if (absDocs.length > 0) {
+      try {
+        await this.prettier({
+          cwd: SERVER_INSTALL_ROOT,
+          configPath: join(f.worktreePath, ".prettierrc"),
+          files: absDocs,
+        });
+      } catch (err) {
+        console.warn(
+          `[doc-agent] prettier format failed for ${f.repoPath} — PR may fail the lint gate:`,
+          err,
+        );
+      }
+    }
+    await this.git(f.worktreePath, ["add", "--", ...inScope]);
+    return (await this.git(f.worktreePath, ["diff", "--cached", "--name-only"])).trim();
+  }
+
   private async finalize(f: InFlight, sentinel: string | null): Promise<void> {
     let url: string | null = null;
     let hadStagedChanges = false;
     try {
       const forge = this.deps.resolveForge(f.repoPath);
-      // STRUCTURAL off-limits boundary: stage ONLY the in-scope list ∩ files that exist. An agent
-      // edit to the Astro app, reference/cli/*, or a new file is never staged → can't reach the PR.
-      const inScope = IN_SCOPE_PATHS.filter((p) => this.fileExists(join(f.worktreePath, p)));
-      if (forge && inScope.length > 0) {
-        // Format root docs/*.md with the server's pinned prettier BEFORE staging so the PR passes
-        // CI's `prettier --check .` gate. Constrained to the `docs/`-prefixed in-scope files (abs
-        // paths) — docs-site/** is Astro/Starlight-governed and must never be passed to root
-        // prettier. Best-effort: a failure warns loudly and the PR still opens (no worse than
-        // today's unformatted baseline).
-        const absDocs = inScope
-          .filter((p) => p.startsWith("docs/"))
-          .map((p) => join(f.worktreePath, p));
-        if (absDocs.length > 0) {
-          try {
-            await this.prettier({
-              cwd: SERVER_INSTALL_ROOT,
-              configPath: join(f.worktreePath, ".prettierrc"),
-              files: absDocs,
-            });
-          } catch (err) {
-            console.warn(
-              `[doc-agent] prettier format failed for ${f.repoPath} — PR may fail the lint gate:`,
-              err,
-            );
-          }
-        }
-        await this.git(f.worktreePath, ["add", "--", ...inScope]);
-        const stagedOut = (
-          await this.git(f.worktreePath, ["diff", "--cached", "--name-only"])
-        ).trim();
+      if (forge) {
+        const stagedOut = await this.stageInScope(f);
         if (stagedOut.length > 0) {
           hadStagedChanges = true;
           url =
@@ -810,15 +830,29 @@ export class DocAgentService {
     forge: GitForge,
     stagedOut: string,
   ): Promise<string | null> {
+    if (!(await this.observeOrCommit(f, stagedOut, `would open a doc-update PR on ${f.branch}`)))
+      return null;
+    return this.openFreshPr(f, sentinel, forge);
+  }
+
+  /**
+   * Shared OBSERVE-vs-commit gate for both publish paths. Phase-0 OBSERVE (`!act`) logs `intent` (the
+   * per-mode "would …" phrase) with the repo path + the staged file count/list appended, and returns
+   * false (the caller then returns null — no commit/push/PR). Phase-1 act commits `--no-verify`
+   * (deliberately DIVERGES from promote.ts, which commits WITH hooks: a server-side docs-only commit
+   * must not run the repo's pre-commit hooks on unrelated state — the change is grounded +
+   * human-reviewed via the PR) and returns true so the caller proceeds to push/open the PR.
+   */
+  private async observeOrCommit(f: InFlight, stagedOut: string, intent: string): Promise<boolean> {
     if (!this.act) {
       const staged = stagedOut.split("\n");
       console.warn(
-        `[doc-agent] OBSERVE: ${f.repoPath} would open a doc-update PR on ${f.branch} (${staged.length} files): ${staged.join(", ")}`,
+        `[doc-agent] OBSERVE: ${f.repoPath} ${intent} (${staged.length} files): ${staged.join(", ")}`,
       );
-      return null;
+      return false;
     }
     await this.git(f.worktreePath, ["commit", "--no-verify", "-m", COMMIT_MSG]);
-    return this.openFreshPr(f, sentinel, forge);
+    return true;
   }
 
   /** Push the local `shepherd/docs-update-*` branch and open a standalone doc-update PR. Shared by
@@ -858,14 +892,14 @@ export class DocAgentService {
     forge: GitForge,
     stagedOut: string,
   ): Promise<string | null> {
-    if (!this.act) {
-      const staged = stagedOut.split("\n");
-      console.warn(
-        `[doc-agent] OBSERVE: ${f.repoPath} would push docs onto PR #${f.prNumber} branch ${f.headBranch} (${staged.length} files): ${staged.join(", ")}`,
-      );
+    if (
+      !(await this.observeOrCommit(
+        f,
+        stagedOut,
+        `would push docs onto PR #${f.prNumber} branch ${f.headBranch}`,
+      ))
+    )
       return null;
-    }
-    await this.git(f.worktreePath, ["commit", "--no-verify", "-m", COMMIT_MSG]);
 
     // Re-check the PR right before the push: it may have merged/closed since the run started.
     let status;

--- a/src/index.ts
+++ b/src/index.ts
@@ -585,6 +585,7 @@ const docAgent = new DocAgentService({
   resolveForge,
   repos: () => listRepos(config.repoRoot).map((r) => r.path),
   store,
+  gitState: (id) => prPoller.get(id),
   nightlyHour: config.docAgentNightlyHour,
   model: config.docAgentModel,
   act: config.docAgentAct,
@@ -852,6 +853,9 @@ setInterval(() => {
     void docAgent
       .sweepNightly()
       .catch((err) => console.warn("[doc-agent] nightly sweep failed:", err)); // cadence: once/day/repo, spawn only when base advanced
+    void docAgent
+      .sweepReadyPrs()
+      .catch((err) => console.warn("[doc-agent] sweepReadyPrs failed:", err)); // pre-merge: re-target docs onto an open code PR (settled-idle)
   }
   try {
     buildQueueReminder.sweep(); // settled-idle nudge for a drifted build queue (sync)

--- a/src/index.ts
+++ b/src/index.ts
@@ -880,6 +880,7 @@ events.subscribe((event, data) => {
     planGate.forget(id);
     recapService.onArchived(id);
     buildQueueReminder.forget(id);
+    docAgent.onArchived(id);
   }
 });
 

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -7,6 +7,8 @@ import {
   type DocAgentFinalize,
 } from "../src/doc-agent";
 import { config, parseHour } from "../src/config";
+import type { GitState } from "../src/forge/types";
+import type { Session } from "../src/types";
 
 function withAuth(
   mode: typeof config.authMode,
@@ -71,7 +73,74 @@ interface Harness {
   spawnRows: SpawnRow[];
   completedRows: CompletedRow[];
   deletedRemote: string[];
+  /** Re-target marker files written by the service, keyed by absolute path. */
+  markers: Map<string, string>;
+  /** Args of every herdr.start (incl. the wrapped argv) for prompt-grounding assertions. */
+  startArgs: { name: string; cwd: string; argv: string[] }[];
   __merge: number;
+}
+
+/** Minimal Session stub for the re-target sweep tests. */
+function mkSession(o: Partial<Session> & { id: string }): Session {
+  return {
+    desig: "TASK-01",
+    name: "task",
+    prompt: "",
+    repoPath: "/repo",
+    baseBranch: "main",
+    branch: "feature/x",
+    worktreePath: "/owner/wt",
+    isolated: true,
+    herdrSession: "",
+    herdrAgentId: "",
+    claudeSessionId: "",
+    model: null,
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    mergeTrainPrs: null,
+    mergingPrNumber: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: null,
+    research: false,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    autoMergeRebaseHead: null,
+    auto: false,
+    issueNumber: null,
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    status: "idle",
+    lastState: "idle" as Session["lastState"],
+    createdAt: 0,
+    updatedAt: 0,
+    archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
+    ...o,
+  } as Session;
+}
+
+/** Minimal open+green+doc-relevant GitState for a re-targetable session. */
+function mkGitState(o: Partial<GitState> = {}): GitState {
+  return {
+    kind: "github",
+    state: "open",
+    checks: "success",
+    number: 7,
+    headSha: "headsha1",
+    title: "feat(ui): add thing",
+    url: "https://forge/pr/7",
+    deployConfigured: false,
+    ...o,
+  } as GitState;
 }
 
 function mkHarness(opts?: {
@@ -97,6 +166,20 @@ function mkHarness(opts?: {
   forEachRefStdout?: string;
   /** When true, the injected prettier stub throws (exercises the best-effort failure path). */
   prettierThrows?: boolean;
+  /** Sessions the re-target sweep iterates (store.list()). */
+  sessions?: Session[];
+  /** Cached PR state per session id (the gitState seam). */
+  gitStateById?: Record<string, GitState | undefined>;
+  /** Settled-idle debounce threshold (ms) for the re-target sweep. */
+  idleThresholdMs?: number;
+  /** Full prStatus (state + url) per branch — drives the re-target finalize re-check. Falls back to
+   *  prStatusByBranch (state only) when absent. */
+  prStatusFull?: Record<string, { state: "none" | "open" | "merged" | "closed"; url?: string }>;
+  /** Pre-seeded re-target marker files (abs path → JSON), read by reapOneWorktree. */
+  markerFiles?: Record<string, string>;
+  /** Owner-worktree git responses for the ff guard: porcelain status + rev-parse HEAD. */
+  ownerStatusPorcelain?: string;
+  ownerHead?: string;
 }): Harness {
   const o = {
     forgeKind: "github" as "github" | "local" | null,
@@ -117,12 +200,19 @@ function mkHarness(opts?: {
     defaultBranchThrows: false,
     forEachRefStdout: "",
     prettierThrows: false,
+    sessions: [] as Session[],
+    gitStateById: {} as Record<string, GitState | undefined>,
+    markerFiles: {} as Record<string, string>,
+    ownerStatusPorcelain: "",
+    ownerHead: "headsha1",
     ...opts,
   };
 
   const gitCalls: GitCall[] = [];
   const prettierCalls: PrettierCall[] = [];
   const starts: { name: string; cwd: string }[] = [];
+  const startArgs: { name: string; cwd: string; argv: string[] }[] = [];
+  const markers = new Map<string, string>(Object.entries(o.markerFiles));
   const closedTabs: string[] = [];
   const removedWorktrees: string[] = [];
   const openPrInputs: unknown[] = [];
@@ -177,6 +267,7 @@ function mkHarness(opts?: {
         return [];
       }
     },
+    list: () => o.sessions,
   };
   let mergeCalls = 0;
 
@@ -212,6 +303,8 @@ function mkHarness(opts?: {
       if (o.originShaThrows) throw new Error("no such ref");
       return typeof o.originSha === "function" ? (o.originSha as () => string)() : o.originSha;
     }
+    if (args[0] === "rev-parse" && args[1] === "HEAD") return o.ownerHead;
+    if (args[0] === "status" && args[1] === "--porcelain") return o.ownerStatusPorcelain;
     return "";
   };
 
@@ -234,14 +327,17 @@ function mkHarness(opts?: {
           // listBranches is present ONLY when remoteBranches is provided (mirrors the
           // optional GitHub matching-refs API; absent → git-fallback path exercised).
           ...(o.remoteBranches !== undefined ? { listBranches: async () => o.remoteBranches } : {}),
-          prStatus: async (branch: string) => ({
-            state: o.prStatusByBranch?.[branch] ?? "none",
-          }),
+          prStatus: async (branch: string) => {
+            const full = o.prStatusFull?.[branch];
+            if (full) return full;
+            return { state: o.prStatusByBranch?.[branch] ?? "none" };
+          },
         } as any);
 
   const herdr = {
-    start: (name: string, cwd: string) => {
+    start: (name: string, cwd: string, wrapped?: string[]) => {
       starts.push({ name, cwd });
+      startArgs.push({ name, cwd, argv: wrapped ?? [] });
       return { terminalId: "term-" + starts.length } as any;
     },
     stop: () => {},
@@ -308,6 +404,12 @@ function mkHarness(opts?: {
       return o.inScopeFilesPresent;
     },
     readSentinel: () => o.sentinel,
+    gitState: (id: string) => o.gitStateById[id],
+    idleThresholdMs: o.idleThresholdMs,
+    writeMarker: (p: string, c: string) => {
+      markers.set(p, c);
+    },
+    readMarker: (p: string) => markers.get(p) ?? null,
     readUsage: async () => ({
       input: 5,
       output: 7,
@@ -336,6 +438,8 @@ function mkHarness(opts?: {
     spawnRows,
     completedRows,
     deletedRemote,
+    markers,
+    startArgs,
     mergeCalls: 0,
     get __merge() {
       return mergeCalls;
@@ -977,4 +1081,350 @@ test("finalize: no staged changes → outcome 'nochange', url null", async () =>
   const runs = h.kv.get("docagent:runs:/repo");
   const parsed = JSON.parse(runs!) as { outcome: string }[];
   expect(parsed[0]!.outcome).toBe("nochange");
+});
+
+// ── re-target: fold docs into the open code PR (issue #956 Option B) ─────────────
+
+const PR_SYNCED = (repo: string, pr: number) => `docagent:pr-synced:${repo}:${pr}`;
+const RETARGET_MARKER_FILE = ".shepherd-doc-retarget.json";
+
+/** A re-target sweep fixture: one idle session whose code PR is open+green+doc-relevant, with the
+ *  debounce threshold at 0 so a single sweep tick fires immediately (no idle-clock advance needed). */
+function mkRetargetHarness(over?: Parameters<typeof mkHarness>[0]) {
+  const session = mkSession({
+    id: "sess-1",
+    repoPath: "/repo",
+    branch: "feature/x",
+    worktreePath: "/owner/wt",
+    status: "idle",
+  });
+  return mkHarness({
+    idleThresholdMs: 0,
+    sessions: [session],
+    gitStateById: {
+      "sess-1": mkGitState({ number: 7, headSha: "headsha1", url: "https://forge/pr/7" }),
+    },
+    ...over,
+  });
+}
+
+test("re-target sweep: open+green+doc-relevant+settled → beginRetarget, claims prSyncedKey, worktree at headSha", async () => {
+  const h = mkRetargetHarness();
+  // first tick starts the idle clock (threshold 0 → still needs the second tick per the debounce model)
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(1);
+  expect(h.kv.get(PR_SYNCED("/repo", 7))).toBe("1");
+  // a durable doc_agent cost row was recorded for the re-target run
+  expect(h.spawnRows).toHaveLength(1);
+  expect(h.spawnRows[0]!.kind).toBe("doc_agent");
+  // a re-target marker was written into the new worktree root
+  const markerEntry = [...h.markers.entries()].find(([p]) => p.endsWith(RETARGET_MARKER_FILE));
+  expect(markerEntry).toBeDefined();
+  const parsed = JSON.parse(markerEntry![1]) as { prNumber: number; headBranch: string };
+  expect(parsed.prNumber).toBe(7);
+  expect(parsed.headBranch).toBe("feature/x");
+});
+
+test("re-target gate: running/blocked session → no fire, debounce reset", async () => {
+  for (const status of ["running", "blocked"] as const) {
+    const h = mkRetargetHarness({
+      sessions: [mkSession({ id: "sess-1", status })],
+    });
+    await h.svc.sweepReadyPrs();
+    await h.svc.sweepReadyPrs();
+    expect(h.starts).toHaveLength(0);
+  }
+});
+
+test("re-target gate: checks !== success → no fire", async () => {
+  const h = mkRetargetHarness({
+    gitStateById: { "sess-1": mkGitState({ checks: "pending" }) },
+  });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+});
+
+test("re-target gate: state !== open → no fire", async () => {
+  const h = mkRetargetHarness({
+    gitStateById: { "sess-1": mkGitState({ state: "merged" }) },
+  });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+});
+
+test("re-target gate: non-doc-relevant title → no fire", async () => {
+  const h = mkRetargetHarness({
+    gitStateById: { "sess-1": mkGitState({ title: "fix: a bug" }) },
+  });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+});
+
+test("re-target gate: prSyncedKey already set → no fire", async () => {
+  const h = mkRetargetHarness();
+  h.kv.set(PR_SYNCED("/repo", 7), "1");
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+});
+
+test("re-target gate: missing git / headSha / number / branch / doc-tree → no fire", async () => {
+  // no git state
+  let h = mkRetargetHarness({ gitStateById: {} });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+  // missing headSha
+  h = mkRetargetHarness({ gitStateById: { "sess-1": mkGitState({ headSha: undefined }) } });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+  // missing number
+  h = mkRetargetHarness({ gitStateById: { "sess-1": mkGitState({ number: undefined }) } });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+  // missing branch
+  h = mkRetargetHarness({ sessions: [mkSession({ id: "sess-1", branch: null })] });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+  // no doc tree
+  h = mkRetargetHarness({ docTreePresent: false });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+});
+
+test("re-target debounce: first settle tick does NOT fire; fires only after idleMs >= threshold", async () => {
+  let nowVal = 1000;
+  const h = mkRetargetHarness({ idleThresholdMs: 5000, now: () => nowVal });
+  await h.svc.sweepReadyPrs(); // first settle tick: starts the clock
+  expect(h.starts).toHaveLength(0);
+  nowVal = 1000 + 4999; // not yet settled long enough
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+  nowVal = 1000 + 5000; // threshold reached
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(1);
+});
+
+test("re-target debounce: resets when the session goes running then settles again", async () => {
+  let nowVal = 1000;
+  const session = mkSession({ id: "sess-1", status: "idle" });
+  const h = mkHarness({
+    idleThresholdMs: 5000,
+    now: () => nowVal,
+    sessions: [session],
+    gitStateById: { "sess-1": mkGitState() },
+  });
+  await h.svc.sweepReadyPrs(); // start clock
+  session.status = "running"; // re-activated → debounce reset
+  nowVal = 1000 + 6000;
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+  // settles again — clock restarts from now
+  session.status = "idle";
+  await h.svc.sweepReadyPrs(); // restart clock
+  expect(h.starts).toHaveLength(0);
+  nowVal = nowVal + 5000;
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(1);
+});
+
+test("re-target debounce: per-repo inflight lock blocks fire WITHOUT setting fired (retries next tick)", async () => {
+  const session = mkSession({ id: "sess-1", status: "idle" });
+  const h = mkHarness({
+    idleThresholdMs: 0,
+    sessions: [session],
+    gitStateById: { "sess-1": mkGitState() },
+  });
+  // a fresh run is in flight for the repo (occupies the lock)
+  await h.svc.consider("/repo");
+  expect(h.svc.isRunning("/repo")).toBe(true);
+  await h.svc.sweepReadyPrs(); // start clock
+  await h.svc.sweepReadyPrs(); // would fire, but the lock blocks it (fired NOT set)
+  expect(h.starts).toHaveLength(1); // only the fresh consider's spawn
+  // free the lock by finalizing the fresh run, then the next sweep fires the re-target
+  await h.svc.tick();
+  expect(h.svc.isRunning("/repo")).toBe(false);
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(2);
+});
+
+test("re-target finalize, PR still open: commits + pushes HEAD:refs/heads/<headBranch>, opens NO new PR, outcome 'pr'", async () => {
+  const h = mkRetargetHarness({
+    act: true,
+    prStatusFull: { "feature/x": { state: "open", url: "https://forge/pr/7" } },
+  });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  await h.svc.tick();
+  // committed --no-verify
+  expect(h.gitCalls.some((c) => c.args[0] === "commit" && c.args.includes("--no-verify"))).toBe(
+    true,
+  );
+  // pushed onto the code PR's head branch with the exact refspec (no force, no -u of docs-update)
+  const push = h.gitCalls.find((c) => c.args[0] === "push");
+  expect(push!.args).toEqual(["push", "origin", "HEAD:refs/heads/feature/x"]);
+  // NO new PR opened
+  expect(h.openPrInputs).toHaveLength(0);
+  // outcome pr with the existing PR url
+  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: "https://forge/pr/7", outcome: "pr" }]);
+  // never force-pushed
+  expect(h.gitCalls.some((c) => c.args.includes("--force") || c.args.includes("-f"))).toBe(false);
+});
+
+test("re-target finalize cleanup: deletes the local docs-update branch, never the code PR head branch", async () => {
+  const h = mkRetargetHarness({
+    act: true,
+    prStatusFull: { "feature/x": { state: "open", url: "https://forge/pr/7" } },
+  });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  await h.svc.tick();
+  const branchDeletes = h.gitCalls.filter((c) => c.args[0] === "branch" && c.args[1] === "-D");
+  expect(branchDeletes).toHaveLength(1);
+  expect(branchDeletes[0]!.args[2]).toMatch(/^shepherd\/docs-update-/);
+  // the code PR head branch is NEVER deleted
+  expect(h.gitCalls.some((c) => c.args.includes("feature/x") && c.args.includes("-D"))).toBe(false);
+});
+
+test("re-target merged-first: PR not open at finalize → ONE fresh PR (openPr + push docs-update), onMergedPr then skipped", async () => {
+  const h = mkRetargetHarness({
+    act: true,
+    prStatusFull: { "feature/x": { state: "merged" } },
+  });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  await h.svc.tick();
+  // fell through to the fresh path: pushed the docs-update branch + opened exactly one PR
+  expect(h.openPrInputs).toHaveLength(1);
+  expect((h.openPrInputs[0] as any).head).toMatch(/^shepherd\/docs-update-/);
+  const push = h.gitCalls.find((c) => c.args[0] === "push");
+  expect(push!.args[1]).toBe("-u");
+  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: "https://forge/pr/42", outcome: "pr" }]);
+  // the prSyncedKey is set → a now-merged onMergedPr for that PR is deferred (no second doc run)
+  const res = await h.svc.onMergedPr("/repo", 7, "feat(ui): add thing", "main");
+  expect(res.status).toBe("skipped");
+  expect(res.reason).toContain("re-target already owns");
+});
+
+test("re-target owner ff: runs when owner worktree clean + at pre-push head; never force", async () => {
+  const h = mkRetargetHarness({
+    act: true,
+    prStatusFull: { "feature/x": { state: "open", url: "https://forge/pr/7" } },
+    ownerStatusPorcelain: "",
+    ownerHead: "headsha1", // equals git.headSha
+  });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  await h.svc.tick();
+  // ff fetched the code branch + merged --ff-only into the owner worktree
+  const fetch = h.gitCalls.find((c) => c.args[0] === "fetch" && c.cwd === "/owner/wt");
+  expect(fetch!.args).toEqual(["fetch", "origin", "feature/x"]);
+  const ff = h.gitCalls.find((c) => c.args[0] === "merge" && c.cwd === "/owner/wt");
+  expect(ff!.args).toEqual(["merge", "--ff-only", "origin/feature/x"]);
+});
+
+test("re-target owner ff: skipped when owner worktree dirty", async () => {
+  const h = mkRetargetHarness({
+    act: true,
+    prStatusFull: { "feature/x": { state: "open", url: "https://forge/pr/7" } },
+    ownerStatusPorcelain: " M src/index.ts", // dirty
+    ownerHead: "headsha1",
+  });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  await h.svc.tick();
+  expect(h.gitCalls.some((c) => c.args[0] === "merge" && c.cwd === "/owner/wt")).toBe(false);
+  expect(h.gitCalls.some((c) => c.args[0] === "fetch" && c.cwd === "/owner/wt")).toBe(false);
+});
+
+test("re-target owner ff: skipped when owner HEAD moved off the pre-push head", async () => {
+  const h = mkRetargetHarness({
+    act: true,
+    prStatusFull: { "feature/x": { state: "open", url: "https://forge/pr/7" } },
+    ownerStatusPorcelain: "",
+    ownerHead: "movedsha", // != git.headSha
+  });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  await h.svc.tick();
+  expect(h.gitCalls.some((c) => c.args[0] === "merge" && c.cwd === "/owner/wt")).toBe(false);
+});
+
+test("onMergedPr: skips when prSyncedKey set; fires fresh consider when unset", async () => {
+  // unset → fires (current behavior)
+  const h1 = mkHarness();
+  const r1 = await h1.svc.onMergedPr("/repo", 7, "feat: x", "main");
+  expect(r1.status).toBe("started");
+  // set → defers, and crucially does NOT consume mergedSeenKey
+  const h2 = mkHarness();
+  h2.kv.set(PR_SYNCED("/repo", 7), "1");
+  const r2 = await h2.svc.onMergedPr("/repo", 7, "feat: x", "main");
+  expect(r2.status).toBe("skipped");
+  expect(h2.starts).toHaveLength(0);
+  expect(h2.kv.has(MERGED_SEEN("/repo", 7))).toBe(false);
+});
+
+test("reapOrphans: worktree with a re-target marker re-adopts as mode:retarget and pushes onto the PR head", async () => {
+  const markerPath = "/wt/docs-update-rt000001/.shepherd-doc-retarget.json";
+  const h = mkHarness({
+    repos: ["/repo"],
+    worktreeListPorcelain: DOCS_WT_PORCELAIN("rt000001"),
+    sentinel: "## Changes\n- updated configuration.md\n",
+    act: true,
+    markerFiles: {
+      [markerPath]: JSON.stringify({ prNumber: 7, headBranch: "feature/x", base: "main" }),
+    },
+    prStatusFull: { "feature/x": { state: "open", url: "https://forge/pr/7" } },
+  });
+  await h.svc.reapOrphans();
+  await h.svc.tick();
+  // re-adopted as a re-target run → pushed onto the code PR's head branch, opened no new PR
+  const push = h.gitCalls.find((c) => c.args[0] === "push");
+  expect(push!.args).toEqual(["push", "origin", "HEAD:refs/heads/feature/x"]);
+  expect(h.openPrInputs).toHaveLength(0);
+});
+
+test("reapOrphans: worktree WITHOUT a marker re-adopts as mode:fresh (opens a standalone PR)", async () => {
+  const h = mkHarness({
+    repos: ["/repo"],
+    worktreeListPorcelain: DOCS_WT_PORCELAIN("fr000001"),
+    sentinel: "## Changes\n- updated configuration.md\n",
+    act: true,
+  });
+  await h.svc.reapOrphans();
+  await h.svc.tick();
+  expect(h.openPrInputs).toHaveLength(1);
+  expect((h.openPrInputs[0] as any).head).toBe("shepherd/docs-update-fr000001");
+});
+
+test("re-target OBSERVE (act:false): logs, does not push or openPr", async () => {
+  const warns: string[] = [];
+  const orig = console.warn;
+  console.warn = (...a: unknown[]) => {
+    warns.push(a.join(" "));
+  };
+  try {
+    const h = mkRetargetHarness({
+      act: false,
+      prStatusFull: { "feature/x": { state: "open", url: "https://forge/pr/7" } },
+    });
+    await h.svc.sweepReadyPrs();
+    await h.svc.sweepReadyPrs();
+    await h.svc.tick();
+    expect(h.gitCalls.some((c) => c.args[0] === "push")).toBe(false);
+    expect(h.gitCalls.some((c) => c.args[0] === "commit")).toBe(false);
+    expect(h.openPrInputs).toHaveLength(0);
+    expect(h.finalizes).toEqual([{ repoPath: "/repo", url: null, outcome: "observe" }]);
+    expect(warns.some((w) => w.includes("[doc-agent] OBSERVE:") && w.includes("PR #7"))).toBe(true);
+  } finally {
+    console.warn = orig;
+  }
 });

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -1428,3 +1428,20 @@ test("re-target OBSERVE (act:false): logs, does not push or openPr", async () =>
     console.warn = orig;
   }
 });
+
+test("onArchived: frees the readyDebounce entry so a re-archive session is treated as a fresh first-tick", async () => {
+  // Build a harness with idleThresholdMs=0 so the second sweep tick fires immediately.
+  const h = mkRetargetHarness({ idleThresholdMs: 0 });
+  // First tick starts the idle clock (records a readyDebounce entry, does NOT fire).
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0);
+  // Archive the session — onArchived should delete the debounce entry.
+  h.svc.onArchived("sess-1");
+  // A subsequent settled sweep must treat this as a fresh first-tick (NOT fire immediately),
+  // because the debounce entry was cleared and the idle clock needs to restart.
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(0); // still on first tick post-archive
+  // One more tick crosses the threshold (idleThresholdMs=0, so any non-zero elapsed qualifies).
+  await h.svc.sweepReadyPrs();
+  expect(h.starts).toHaveLength(1); // fires only on the second post-archive tick
+});


### PR DESCRIPTION
Closes #956.

Implements **Option B** from the #956 evaluation: instead of opening a *second* `shepherd/docs-update-*` PR after a code PR merges, the PR-gated doc agent now writes its grounded doc update onto the **open code PR's own branch** — one PR carries both code and docs. The post-merge fresh-PR path is kept only as a guarded backstop, with the nightly sweep as the deepest catch-all.

## How it works
- **New pre-merge trigger** (`sweepReadyPrs`, 15s tick): for a managed session whose PR is `open` + CI-green + doc-relevant (feat/config title) and whose session has gone **settled-idle** (mirrors `RecapService`'s debounce — first-idle does *not* fire), spawn a re-target run.
- **Re-target run** checks the worktree out at the PR's **head SHA** on a `shepherd/docs-update-<hex>` branch (so `reapOrphans` + the `*-review-*` disk-sweep coverage are unchanged), the agent edits in-scope prose grounded on `git diff <base>...HEAD`, then the server commits `--no-verify` and pushes `HEAD:refs/heads/<headBranch>` onto the code PR — **no new PR**.
- **Ownership claim** (`docagent:pr-synced:<repo>:<pr>`) is set at re-target *start*, so the per-repo `inflight` lock can't cause `onMergedPr` to silently drop coverage; `onMergedPr` defers (without consuming its once-key) when the claim is set, else opens a **prompt** fresh docs PR.
- **Merged-mid-run** → the re-target run's own fallback opens exactly **one** fresh PR (reusing the work) — never two PRs for one code PR.
- **Owner-branch reconciliation**: after a successful push, best-effort `merge --ff-only` of the owning session's local branch, guarded by clean-tree + still-at-pre-push-head. Never force-pushes, never rewrites the code PR's branch.
- **Restart-safe**: a `RETARGET_MARKER` lets the boot reconcile re-adopt and finalize an interrupted re-target run (push-to-head if the PR is still open, else a single fresh PR).

## Scope
Server-only (`src/doc-agent.ts`, `src/index.ts`) — no UI/i18n/feature-catalog/glossary changes, no new env var (reuses the 120s settled-idle default). The FRESH/nightly path is behavior-unchanged.

## Verification
- `bun test ./test` — full root suite green (incl. 66 doc-agent tests covering the trigger gating, settled-idle debounce, exact push refspec, merged-first single-PR fallback, owner-ff guards, OBSERVE mode, marker re-adopt, and the `onMergedPr` defer ordering).
- `bun run typecheck`, `bun run lint`, `prettier --check`, fallow delta audit — all clean (full pre-push gate passed).

## Known follow-up minors (non-blocking)
- A non-fast-forward push (owner pushed mid-run) defers to nightly *and* suppresses the prompt post-merge backstop for that PR (plan-conformant trade-off).
- `RETARGET_MARKER.base` is written but re-resolved (not consumed) on re-adopt — cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
