### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -51,8 +51,9 @@ spawns a tightly-scoped Claude Code agent that diffs recent source changes again
 hand-written docs and edits the enumerated prose pages in place. It is granted read-only
 git (`git diff`/`log`/`show`/`status`) for grounding plus file edits, but has **no git
 mutation, `gh`, or network access**, so it can neither commit nor push; the trusted server
-stages the in-scope doc files, commits, and opens a **pull request** for human review
-(never an auto-merge).
+stages the in-scope doc files, commits, and publishes them for human review (never an
+auto-merge) — either by **folding the doc commit into an already-open code PR** or by
+opening a standalone doc-update **pull request** (see _Automated cadence_ below).
 
 **Phased soak (`observe → act`, mirroring `SHEPHERD_HOOKS_INGEST` → `SHEPHERD_HOOKS_SIGNALS`).**
 Roll the feature out in two stages so you can watch what it _would_ do before it touches a
@@ -60,9 +61,10 @@ remote:
 
 1. **Observe** — set `SHEPHERD_DOC_AGENT=1` alone. The agent runs and edits on every trigger,
    and the server computes the staged doc diff, but **finalize is log-only**: it opens **no
-   PR** and runs no `push`. Each would-be PR is logged as a one-line
-   `[doc-agent] OBSERVE: <repo> would open a doc-update PR … (<n> files): …`. Soak here until
-   the logged diffs look correct.
+   PR** and runs no `push`. Each would-be publish is logged as a one-line
+   `[doc-agent] OBSERVE: <repo> would …  (<n> files): …` — either _would open a doc-update PR_
+   (fresh path) or _would push docs onto PR #<n> …_ (pre-merge re-target). Soak here until the
+   logged diffs look correct.
 2. **Act** — additionally set `SHEPHERD_DOC_AGENT_ACT=1` to escalate to actually opening PRs.
    This flag is meaningful **only** when Phase-0 (`SHEPHERD_DOC_AGENT`) is also on. A fresh
    enable therefore opens no PR until you explicitly opt into act.
@@ -72,21 +74,31 @@ attribution, and the boot reconcile **re-adopts** a run interrupted by a restart
 worktree whose summary is already written is finalized rather than discarded) and reaps any
 orphaned remote `shepherd/docs-update-*` branch left by a crash between `push` and PR-open.
 
-**Automated cadence.** With the same flag on, two triggers run in addition to the manual
+**Automated cadence.** With the same flag on, three triggers run in addition to the manual
 one (a per-repo in-flight guard means at most one run per repo at a time):
 
+- **Pre-merge re-target** (the default — _one PR carries both code and docs_). A settled-idle
+  sweep watches every Shepherd-managed session whose code PR is **open, CI-green, and has a
+  doc-relevant (`feat`/`config`) title**. Once such a PR has stayed idle long enough (a
+  ~120 s debounce, so a still-churning PR is never touched), the doc agent checks a worktree
+  out at the PR's head, edits the in-scope docs, and — in act mode — pushes the doc commit
+  straight onto **that PR's own head branch** (never a force-push) instead of opening a second
+  `shepherd/docs-update-*` PR. If the code PR merges/closes mid-run or the push can't
+  fast-forward, it falls back to a single standalone PR, so the docs land exactly once.
 - **Nightly** — once per local day per repo that has the docs tree, at/after
   `SHEPHERD_DOC_AGENT_NIGHTLY_HOUR` (default `3`). It first freshens the repo's default
   branch from `origin`, then spawns a run **only if the branch advanced** since the last
   doc-agent run — quiet days cost a cheap fetch but no agent spawn. This is the reliable
   catch-all: it picks up **any** landed change, including `fix:` commits, config-only
   changes, and human/non-session or non-conventional merges (e.g. epic-landing PRs).
-- **Merge-triggered** — when a Shepherd-managed session's PR merges to the default branch
-  **and its title is a `feat`/`config` conventional-commit subject**, a run is considered
-  immediately (the fast path). A doc-relevant `fix:` is intentionally **not** caught here —
-  it's covered by the nightly sweep instead. `config` (type or scope) is a forward-looking
-  allowance and may not yet appear in a given repo's history. Non-conventional or untitled
-  merges simply fall through to nightly.
+- **Merge-triggered** — a fallback fast-path for when no pre-merge re-target ran: when a
+  Shepherd-managed session's PR merges to the default branch **and its title is a
+  `feat`/`config` conventional-commit subject**, a standalone doc-update run is considered
+  immediately. If a pre-merge re-target already claimed (and pushed docs onto) that PR, this
+  trigger **defers** so no duplicate PR is opened. A doc-relevant `fix:` is intentionally
+  **not** caught here — it's covered by the nightly sweep instead. `config` (type or scope)
+  is a forward-looking allowance and may not yet appear in a given repo's history.
+  Non-conventional or untitled merges simply fall through to nightly.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |

--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -65,13 +65,13 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 `POST /api/sessions`, `Content-Type: application/json`. Validated by
 `validateCreate` (`src/validate.ts`); unknown keys are rejected.
 
-| Field        | Type                                    | Required | Notes                                                                        |
-| ------------ | --------------------------------------- | -------- | ---------------------------------------------------------------------------- |
-| `repoPath`   | string                                  | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
-| `baseBranch` | string                                  | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
-| `prompt`     | string                                  | ✅       | The task instructions; 1–8000 chars                                          |
-| `model`      | `"opus" \| "sonnet" \| "haiku" \| null` | —        | Omit/`null` = Claude's default                                               |
-| `images`     | `string[]`                              | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
+| Field        | Type                                                                             | Required | Notes                                                                        |
+| ------------ | -------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------- |
+| `repoPath`   | string                                                                           | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
+| `baseBranch` | string                                                                           | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
+| `prompt`     | string                                                                           | ✅       | The task instructions; 1–8000 chars                                          |
+| `model`      | `"fable" \| "opus" \| "opus[1m]" \| "sonnet" \| "sonnet[1m]" \| "haiku" \| null` | —        | Omit/`null` = Claude's default; `[1m]` selects the 1M-context variant        |
+| `images`     | `string[]`                                                                       | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
 
 ### Responses
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

## Changes

- **`docs-site/src/content/docs/reference/configuration.md`** — Documented the doc agent's
  new **pre-merge re-target** behavior. The "Documentation automation" section previously
  described only a nightly + merge-triggered cadence that always opened a standalone
  `shepherd/docs-update-*` PR. As of commit `a5e64422` (#956/#958, "re-target doc updates
  onto the open code PR — kill the double-PR"), the default path is a settled-idle sweep
  (`DocAgentService.sweepReadyPrs` / `considerReady` / `retargetCandidate` in
  `src/doc-agent.ts`, wired in `src/index.ts:856` under the `config.docAgentEnabled` gate)
  that, for an **open + CI-green + `feat`/`config`-titled** code PR idle past a ~120 s
  debounce (`DEFAULT_IDLE_THRESHOLD_MS`), pushes the doc commit onto **that PR's own head
  branch** instead of opening a second PR, falling back to a single standalone PR if the PR
  merges/closes mid-run or the push can't fast-forward (`publishRetarget`,
  `src/doc-agent.ts:889`). I updated: the intro (publish is now "fold into open code PR _or_
  standalone PR"), the observe-phase log example (now also `would push docs onto PR #<n> …`,
  per `observeOrCommit`), and the cadence list (added the pre-merge re-target bullet as the
  default; reframed merge-triggered as a fallback that **defers** when a re-target already
  claimed the PR — `onMergedPr` "re-target already owns this PR's docs" skip,
  `src/doc-agent.ts:339`). No new env vars were added by #958, so the variable tables were
  left unchanged.

- **`docs/external-task-api.md`** — Corrected the `model` field's accepted values. The doc
  listed `"opus" | "sonnet" | "haiku" | null`, but `validateModel` (`src/validate.ts:85`)
  accepts the full `MODELS` set (`src/types.ts:143`):
  `["fable", "opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku"]`. Updated the type cell to
  enumerate all of these (plus `null`) and noted that `[1m]` selects the 1M-context variant.

## Uncertain / needs human judgment

- **`docs-site/src/content/docs/reference/glossary.md`** — Recent commits added terms to the
  app's tooltip registry `ui/src/lib/glossary.ts` (e.g. #946 learnings auto-trial, #876
  cross-repo merge-suggestions, #954 usage dashboard). The docs glossary is clearly a
  hand-curated subset rather than a 1:1 mirror of that registry, so I did **not** invent new
  entries. A human may want to decide whether any of those concepts (or a "doc agent" entry)
  belong here.

- **`configuration.md` env-var tables** — These are an intentionally curated subset; many
  variables in `src/config.ts` are not listed (e.g. `SHEPHERD_AUTH_MODE`,
  `SHEPHERD_USAGE_HOLD_ENABLED/_PCT`, `SHEPHERD_REDUCED_PUSH_MODE`,
  `SHEPHERD_REVIEW_CYCLES_CAP`, `SHEPHERD_SANDBOX_EXTRA_HOSTS`, etc.). This predates the
  recent changes and isn't newly stale, so I left the tables as-is rather than expand scope.

- **`docs/sandbox-security.md`** — Contains specific `src/sandbox.ts` / `src/service.ts` line
  references and PR numbers (already marked approximate in the prose). No sandbox/egress
  source changes appeared in the recent commit window, so I left it unchanged. One possible
  gap: the egress-allowlist description ("`api.anthropic.com` + `statsig.anthropic.com` + the
  GitHub hosts") does not mention the operator-extra allowlist
  (`config.sandboxEgressExtraHosts` / `SHEPHERD_SANDBOX_EXTRA_HOSTS`); I couldn't confirm this
  is a recent regression, so I flagged it rather than edit.