### PR TITLE
fix(learnings): block reverted-to-proposed trial from re-auto-trialing (#945)

### DIFF
--- a/src/learnings-lifecycle.ts
+++ b/src/learnings-lifecycle.ts
@@ -175,6 +175,10 @@ export function shouldTrial(
   opts?: { nMin?: number; sessionFloor?: number; minKinds?: number; minSessions?: number },
 ): boolean {
   if (rule.status !== "proposed") return false;
+  // #945: a reverted-to-proposed trial is blocked from auto-re-trial until genuinely fresh
+  // evidence clears the marker (accrueProposedEvidence) or the rule expires. Presence-only —
+  // the timestamp value is never compared to `now`, so no cooldown-vs-expire coupling exists.
+  if (rule.reTrialBlockedAt != null) return false;
   const K = opts?.nMin ?? TRIAL_NMIN;
   const floor = opts?.sessionFloor ?? TRIAL_SESSION_FLOOR;
   const minKinds = opts?.minKinds ?? TRIAL_MIN_KINDS;

--- a/src/store.ts
+++ b/src/store.ts
@@ -340,6 +340,7 @@ type LearningRow = {
   promotedPrUrl: string | null;
   mergedIntoId: string | null;
   trialedAt: number | null;
+  reTrialBlockedAt: number | null;
   evidenceKindsSeen: string;
   evidenceSessionsSeen: string;
 };
@@ -2379,6 +2380,9 @@ export class SessionStore implements CapStore, CreditStore {
     add("trialedAt", `trialedAt INTEGER`);
     add("evidenceKindsSeen", `evidenceKindsSeen TEXT NOT NULL DEFAULT '[]'`);
     add("evidenceSessionsSeen", `evidenceSessionsSeen TEXT NOT NULL DEFAULT '[]'`);
+    // Re-trial block marker (#945): set on revertTrial(id,"proposed"); presence suppresses
+    // auto-re-trial until fresh evidence clears it or the rule expires.
+    add("reTrialBlockedAt", `reTrialBlockedAt INTEGER`);
   }
 
   private hydrateLearning(r: LearningRow): Learning {
@@ -2403,6 +2407,7 @@ export class SessionStore implements CapStore, CreditStore {
       promotedPrUrl: r.promotedPrUrl ?? null,
       mergedIntoId: r.mergedIntoId ?? null,
       trialedAt: r.trialedAt ?? null,
+      reTrialBlockedAt: r.reTrialBlockedAt ?? null,
       distinctKinds: parseFindings(r.evidenceKindsSeen).length,
       distinctSessions: parseFindings(r.evidenceSessionsSeen).length,
     };
@@ -2468,6 +2473,7 @@ export class SessionStore implements CapStore, CreditStore {
       promotedPrUrl: null,
       mergedIntoId: null,
       trialedAt: null,
+      reTrialBlockedAt: null,
       distinctKinds: kinds.length,
       distinctSessions: sessions.length,
     };
@@ -2537,12 +2543,14 @@ export class SessionStore implements CapStore, CreditStore {
     const cur = this.getLearning(id);
     if (!cur) return null;
     if (!LEARNING_TRANSITIONS[cur.status].includes(status)) return null;
-    this.db.run(`UPDATE learnings SET status = ?, rule = ?, updatedAt = ? WHERE id = ?`, [
-      status,
-      rule ?? cur.rule,
-      Date.now(),
-      id,
-    ]);
+    // #945 fold-in: dismissing a trial (active→dismissed) must clear the auto-trial timestamp,
+    // else the terminal row carries a stale `trialedAt` (cosmetic provenance leak). Scoped to
+    // the dismissed target per the issue; active→retired via this path is a stated deferral.
+    const clearTrialed = status === "dismissed" ? ", trialedAt = NULL" : "";
+    this.db.run(
+      `UPDATE learnings SET status = ?, rule = ?, updatedAt = ?${clearTrialed} WHERE id = ?`,
+      [status, rule ?? cur.rule, Date.now(), id],
+    );
     return this.getLearning(id);
   }
 
@@ -2999,11 +3007,14 @@ export class SessionStore implements CapStore, CreditStore {
     const cur = this.getLearning(id);
     if (!cur || cur.trialedAt == null || cur.status !== "active") return null;
     const now = Date.now();
-    this.db.run(`UPDATE learnings SET status = ?, trialedAt = NULL, updatedAt = ? WHERE id = ?`, [
-      target,
-      now,
-      id,
-    ]);
+    // #945: when sending the rule back to the queue (target "proposed"), stamp the re-trial
+    // block marker so the auto-trial gate won't immediately re-promote it off its still-strong
+    // frozen diversity counters. "dismissed" is terminal — no marker needed (leave it null).
+    const blockedAt = target === "proposed" ? now : null;
+    this.db.run(
+      `UPDATE learnings SET status = ?, trialedAt = NULL, reTrialBlockedAt = ?, updatedAt = ? WHERE id = ?`,
+      [target, blockedAt, now, id],
+    );
     return this.getLearning(id);
   }
 
@@ -3043,9 +3054,11 @@ export class SessionStore implements CapStore, CreditStore {
     for (const k of freshKinds) existingKinds.add(k);
     const mergedSessions = [...new Set([...existingSessionsArr, ...freshSessions])].slice(0, 50);
     const now = Date.now();
+    // #945: genuinely fresh evidence (recurrence) lifts any re-trial block so the rule can
+    // re-qualify for auto-trial on its renewed strength.
     this.db.run(
       `UPDATE learnings SET evidence = ?, evidenceCount = ?, evidenceKindsSeen = ?,
-         evidenceSessionsSeen = ?, lastEvidenceAt = ?, updatedAt = ? WHERE id = ?`,
+         evidenceSessionsSeen = ?, lastEvidenceAt = ?, reTrialBlockedAt = NULL, updatedAt = ? WHERE id = ?`,
       [
         JSON.stringify(newEvidence),
         newEvidence.length,

--- a/src/types.ts
+++ b/src/types.ts
@@ -539,6 +539,13 @@ export interface Learning {
   /** When the rule was auto-promoted proposed→active as a trial (trialLearning).
    *  Null for manually-approved active rules and all non-trial states. */
   trialedAt: number | null;
+  /** Presence marker (#945): set when an auto-trial is reverted back to `proposed`
+   *  (`revertTrial(id,"proposed")`). While non-null the auto-trial gate (`shouldTrial`)
+   *  suppresses re-trial, so a reverted strong proposal doesn't bounce straight back to an
+   *  active trial off its frozen diversity counters. Cleared by `accrueProposedEvidence` on
+   *  genuinely fresh evidence (recurrence re-trials it). The timestamp value is provenance
+   *  only — never compared to `now` — so the block lifts only via recurrence or normal expiry. */
+  reTrialBlockedAt: number | null;
   /** Count of distinct signal kinds in the durable evidenceKindsSeen set. */
   distinctKinds: number;
   /** Count of distinct non-null session ids in the durable evidenceSessionsSeen set. */

--- a/test/house-rules.test.ts
+++ b/test/house-rules.test.ts
@@ -36,6 +36,7 @@ function rule(p: Partial<Learning>): Learning {
     promotedPrUrl: p.promotedPrUrl ?? null,
     mergedIntoId: p.mergedIntoId ?? null,
     trialedAt: p.trialedAt ?? null,
+    reTrialBlockedAt: p.reTrialBlockedAt ?? null,
     distinctKinds: p.distinctKinds ?? 0,
     distinctSessions: p.distinctSessions ?? 0,
   };

--- a/test/learnings-lifecycle.test.ts
+++ b/test/learnings-lifecycle.test.ts
@@ -62,6 +62,7 @@ function makeLearning(o: Partial<Learning> & { id: string }): Learning {
     promotedPrUrl: null,
     mergedIntoId: null,
     trialedAt: null,
+    reTrialBlockedAt: null,
     distinctKinds: 0,
     distinctSessions: 0,
     ...o,
@@ -765,6 +766,20 @@ describe("shouldTrial", () => {
     });
     expect(shouldTrial(rule)).toBe(false);
   });
+
+  test("#945: fails when reTrialBlockedAt is set, even with strong counters", () => {
+    const rule = makeLearning({
+      id: "a",
+      status: "proposed",
+      evidenceCount: 10,
+      distinctSessions: 5,
+      distinctKinds: 5,
+      reTrialBlockedAt: Date.now(),
+    });
+    expect(shouldTrial(rule, { nMin: 4, sessionFloor: 2, minKinds: 2, minSessions: 3 })).toBe(
+      false,
+    );
+  });
 });
 
 // ── runAutoTrial ──────────────────────────────────────────────────────────────
@@ -850,6 +865,21 @@ describe("runAutoTrial", () => {
     expect(rec.distinctKinds).toBe(4);
     expect(rec.distinctSessions).toBe(3);
   });
+
+  test("#945: skips a reverted rule blocked from re-trial (reTrialBlockedAt set)", () => {
+    const blocked = makeLearning({
+      id: "blk",
+      status: "proposed",
+      evidenceCount: K,
+      distinctSessions: floor,
+      distinctKinds: minKinds,
+      reTrialBlockedAt: Date.now(),
+    });
+    const { store, trialed } = makeFakeTrialDeps({ pending: [blocked] });
+    const result = runAutoTrial({ store, enabled: true, maxPerSweep: 5, gate });
+    expect(trialed).toHaveLength(0);
+    expect(result).toHaveLength(0);
+  });
 });
 
 // ── shouldExpireProposed ──────────────────────────────────────────────────────
@@ -899,6 +929,29 @@ describe("shouldExpireProposed", () => {
         gate: { nMin: 4, sessionFloor: 2, minKinds: 2, minSessions: 3 },
       }),
     ).toBe(false);
+  });
+
+  test("#945: a blocked reverted rule is no longer trial-worthy → ages out (becomes expirable)", () => {
+    const now = Date.now();
+    // Same strong counters as the "trial-worthy → never expire" case above, but the re-trial
+    // block makes shouldTrial false, so the stale reverted proposal expires instead of being
+    // pinned in the queue — this is how Revert "durably sticks" with no recurrence.
+    const rule = makeLearning({
+      id: "a",
+      status: "proposed",
+      lastEvidenceAt: now - THIRTY_DAYS - 1,
+      createdAt: now - THIRTY_DAYS - 1,
+      evidenceCount: 4,
+      distinctSessions: 2,
+      distinctKinds: 2,
+      reTrialBlockedAt: now,
+    });
+    expect(
+      shouldExpireProposed(rule, now, {
+        expireDays: 30,
+        gate: { nMin: 4, sessionFloor: 2, minKinds: 2, minSessions: 3 },
+      }),
+    ).toBe(true);
   });
 
   test("expiryFloor defers expiry (old lastEvidenceAt but floor=now → NOT expired)", () => {

--- a/test/store-learnings.test.ts
+++ b/test/store-learnings.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { SessionStore } from "../src/store";
+import { runAutoTrial } from "../src/learnings-lifecycle";
 
 test("addSignal stores and lists newest-first within a repo", () => {
   const s = new SessionStore(":memory:");
@@ -1001,6 +1002,87 @@ test("#925: revertTrial returns null for proposed/dismissed/missing rows", () =>
   const l = s.addLearning({ repoPath: "/r", rule: "r", rationale: "", evidence: [] });
   expect(s.revertTrial(l.id, "proposed")).toBeNull(); // still proposed
   expect(s.revertTrial("no-id", "proposed")).toBeNull(); // missing
+});
+
+test("#945: revertTrial('proposed') sets reTrialBlockedAt; 'dismissed' leaves it null", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "r", rationale: "", evidence: [] });
+  s.trialLearning(l.id);
+  const before = Date.now();
+  const reverted = s.revertTrial(l.id, "proposed")!;
+  expect(reverted.reTrialBlockedAt).not.toBeNull();
+  expect(reverted.reTrialBlockedAt!).toBeGreaterThanOrEqual(before);
+
+  const l2 = s.addLearning({ repoPath: "/r", rule: "r2", rationale: "", evidence: [] });
+  s.trialLearning(l2.id);
+  const dismissed = s.revertTrial(l2.id, "dismissed")!;
+  expect(dismissed.reTrialBlockedAt).toBeNull();
+});
+
+test("#945: accrueProposedEvidence clears reTrialBlockedAt on genuinely fresh evidence", () => {
+  const s = new SessionStore(":memory:");
+  const sig1 = s.addSignal({ repoPath: "/r", sessionId: "s1", kind: "reply", payload: "a" });
+  const sig2 = s.addSignal({ repoPath: "/r", sessionId: "s2", kind: "block", payload: "b" });
+  const l = s.addLearning({ repoPath: "/r", rule: "r", rationale: "", evidence: [sig1.id] });
+  s.trialLearning(l.id);
+  const reverted = s.revertTrial(l.id, "proposed")!;
+  expect(reverted.reTrialBlockedAt).not.toBeNull();
+  const updated = s.accrueProposedEvidence(l.id, [sig2.id])!;
+  expect(updated.reTrialBlockedAt).toBeNull();
+});
+
+test("#945: accrueProposedEvidence no-op (no fresh ids) leaves the block in place", () => {
+  const s = new SessionStore(":memory:");
+  const sig1 = s.addSignal({ repoPath: "/r", sessionId: "s1", kind: "reply", payload: "a" });
+  const l = s.addLearning({ repoPath: "/r", rule: "r", rationale: "", evidence: [sig1.id] });
+  s.trialLearning(l.id);
+  s.revertTrial(l.id, "proposed");
+  expect(s.accrueProposedEvidence(l.id, [sig1.id])).toBeNull(); // dup → no-op
+  expect(s.getLearning(l.id)!.reTrialBlockedAt).not.toBeNull(); // block survives
+});
+
+test("#945: setLearningStatus(active→dismissed) clears stale trialedAt", () => {
+  const s = new SessionStore(":memory:");
+  const l = s.addLearning({ repoPath: "/r", rule: "r", rationale: "", evidence: [] });
+  s.trialLearning(l.id); // active + trialedAt set
+  expect(s.getLearning(l.id)!.trialedAt).not.toBeNull();
+  const dismissed = s.setLearningStatus(l.id, "dismissed")!;
+  expect(dismissed.status).toBe("dismissed");
+  expect(dismissed.trialedAt).toBeNull();
+});
+
+test("#945: end-to-end — revert blocks the next sweep; recurrence re-trials", () => {
+  const s = new SessionStore(":memory:");
+  const gate = { nMin: 4, sessionFloor: 2, minKinds: 2, minSessions: 3 };
+  // A strong proposal: 4 signals across 4 kinds + 4 sessions → trial-worthy.
+  const sigs = [
+    s.addSignal({ repoPath: "/r", sessionId: "s1", kind: "reply", payload: "a" }),
+    s.addSignal({ repoPath: "/r", sessionId: "s2", kind: "block", payload: "b" }),
+    s.addSignal({ repoPath: "/r", sessionId: "s3", kind: "critic", payload: "c" }),
+    s.addSignal({ repoPath: "/r", sessionId: "s4", kind: "stall", payload: "d" }),
+  ];
+  const l = s.addLearning({
+    repoPath: "/r",
+    rule: "r",
+    rationale: "",
+    evidence: sigs.map((x) => x.id),
+  });
+  s.trialLearning(l.id); // it was auto-trialed
+  s.revertTrial(l.id, "proposed"); // operator sends it back to the queue
+
+  // Next sweep must NOT re-trial it off the frozen counters.
+  const first = runAutoTrial({ store: s, enabled: true, maxPerSweep: 5, gate });
+  expect(first).toHaveLength(0);
+  expect(s.getLearning(l.id)!.status).toBe("proposed");
+
+  // Genuine recurrence: a fresh signal lifts the block.
+  const fresh = s.addSignal({ repoPath: "/r", sessionId: "s5", kind: "reply", payload: "e" });
+  s.accrueProposedEvidence(l.id, [fresh.id]);
+
+  // Now the sweep re-trials it.
+  const second = runAutoTrial({ store: s, enabled: true, maxPerSweep: 5, gate });
+  expect(second.map((r) => r.id)).toContain(l.id);
+  expect(s.getLearning(l.id)!.status).toBe("active");
 });
 
 test("#925: reapStaleTrial retires a trial with reason trial-expired, clears trialedAt", () => {


### PR DESCRIPTION
Closes #945.

## Problem
`revertTrial(id,"proposed")` (the drawer's one-click **Revert** button) set `status='proposed'` and cleared `trialedAt`, but left the durable diversity counters (`evidenceCount`/`distinctKinds`/`distinctSessions`) intact. `shouldTrial` gates only on those counters + `status==='proposed'`, so the next daily sweep re-qualified the rule and `runAutoTrial` re-promoted it to an active trial within ≤1 day. There was no re-trial cooldown — exactly the strong proposals an operator is most likely to revert bounced straight back to active. Only **Dismiss** stuck.

## Fix — a presence marker
New nullable column **`reTrialBlockedAt`**, used as a presence flag (**set ⇒ blocked**):
- `revertTrial(id,"proposed")` stamps `reTrialBlockedAt = now` (the `"dismissed"` branch is terminal, leaves it null).
- `shouldTrial` returns `false` while the marker is set — its timestamp value is **never compared to `now`**, so there's no cooldown-vs-expire-window coupling that a config change could silently violate to re-create the bug.
- Because `shouldExpireProposed` keys off `shouldTrial`, a blocked rule is no longer "trial-worthy" → the normal 30-day expiry sweep reclaims it when no recurrence arrives. This is how Revert now "durably sticks".
- `accrueProposedEvidence` clears the marker on **genuinely fresh** evidence, so a *recurring* pattern re-trials later (recurrence-driven, not permanent).

No `shouldTrial` signature change (the earlier timestamp-cooldown design was dropped after plan review for the footgun above + needless `now` plumbing).

## Fold-in (per the issue's minor item)
`setLearningStatus(active→dismissed)` now clears the stale `trialedAt` on the terminal row (cosmetic provenance leak). Scoped to the `dismissed` target per the issue; `active→retired` via that path is a **stated deferral** — cosmetic, and the load-bearing retire paths are the dedicated methods that already clear `trialedAt`.

## Tests
- `shouldTrial` fails when `reTrialBlockedAt` is set even with strong counters.
- `runAutoTrial` skips a blocked rule.
- `shouldExpireProposed`: a blocked-but-strong rule becomes expirable (inverse of "trial-worthy → never expire").
- Store: `revertTrial("proposed")` sets the marker / `"dismissed"` doesn't; `accrueProposedEvidence` clears it on fresh evidence and preserves it on a no-op; `setLearningStatus(active→dismissed)` clears `trialedAt`.
- End-to-end: revert → next sweep does **not** re-trial → fresh evidence → sweep re-trials.

Server-only plumbing, no UI/strings → exempt from i18n + feature-catalog gates. `[no-feature-entry]`

Refs #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)