### PR TITLE
fix(doc-agent): roll up nightly docs sync onto the open docs PR (never >1)

### DIFF
--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -830,9 +830,14 @@ export class DocAgentService {
     forge: GitForge,
     stagedOut: string,
   ): Promise<string | null> {
-    if (!(await this.observeOrCommit(f, stagedOut, `would open a doc-update PR on ${f.branch}`)))
-      return null;
-    return this.openFreshPr(f, sentinel, forge);
+    const existing = await this.findOpenDocPr(forge, f.branch);
+    const intent = existing
+      ? `would roll up docs onto existing PR #${existing.number} (${existing.headBranch})`
+      : `would open a doc-update PR on ${f.branch}`;
+    if (!(await this.observeOrCommit(f, stagedOut, intent))) return null;
+    return existing
+      ? this.rollupOnto(f, existing, sentinel, forge)
+      : this.openFreshPr(f, sentinel, forge);
   }
 
   /**
@@ -853,6 +858,86 @@ export class DocAgentService {
     }
     await this.git(f.worktreePath, ["commit", "--no-verify", "-m", COMMIT_MSG]);
     return true;
+  }
+
+  /**
+   * Find the single open standalone docs PR to roll a fresh run onto, or null when none exists.
+   * Keeps open PRs whose head branch is a `shepherd/docs-update-*` branch (BRANCH_RE-valid, so the
+   * branch name can't smuggle a flag into the force-push refspec) other than our own in-flight
+   * branch, and returns the LOWEST-numbered one (a stable survivor so repeated runs converge on the
+   * same PR). On a listPullRequests failure it returns null (fail-open: the caller opens a fresh PR)
+   * and warns — a transient list failure could momentarily allow a duplicate, which is manually
+   * recoverable; failing closed would silently skip a run.
+   */
+  private async findOpenDocPr(
+    forge: GitForge,
+    excludeBranch: string,
+  ): Promise<{ number: number; headBranch: string; url: string | null } | null> {
+    let prs;
+    try {
+      prs = await forge.listPullRequests();
+    } catch (err) {
+      console.warn(`[doc-agent] roll-up: listPullRequests failed — opening fresh:`, err);
+      return null;
+    }
+    const prefix = `shepherd/${DOC_BRANCH_PREFIX}`;
+    const matches = prs.filter(
+      (p) =>
+        !!p.headRefName &&
+        p.headRefName.startsWith(prefix) &&
+        p.headRefName !== excludeBranch &&
+        BRANCH_RE.test(p.headRefName),
+    );
+    if (matches.length === 0) return null;
+    const chosen = matches.reduce((a, b) => (b.number < a.number ? b : a));
+    return { number: chosen.number, headBranch: chosen.headRefName!, url: chosen.url ?? null };
+  }
+
+  /**
+   * Roll a fresh doc-update commit onto an EXISTING open standalone docs PR (issue: never >1 open
+   * docs PR). Force-pushes our commit onto that PR's own head branch (the branch is server-owned and
+   * ephemeral — only the doc agent ever pushes `shepherd/docs-update-*` — so a force-push is safe and
+   * keeps the single PR a current "docs vs base" diff), then best-effort refreshes the PR body so it
+   * matches the new diff (title is the constant COMMIT_MSG, so it never goes stale). On a push
+   * failure it defers (returns null) rather than falling back to openFreshPr — opening a fresh PR
+   * would create the very duplicate this prevents. Returns the existing PR's url.
+   */
+  private async rollupOnto(
+    f: InFlight,
+    existing: { number: number; headBranch: string; url: string | null },
+    sentinel: string | null,
+    forge: GitForge,
+  ): Promise<string | null> {
+    try {
+      await this.git(f.worktreePath, [
+        "push",
+        "--force",
+        "origin",
+        `HEAD:refs/heads/${existing.headBranch}`,
+      ]);
+    } catch (err) {
+      console.warn(
+        `[doc-agent] roll-up: force-push onto ${existing.headBranch} failed for ${f.repoPath} — deferring:`,
+        err,
+      );
+      return null;
+    }
+    // Refresh the PR body so it matches the force-pushed diff (best-effort).
+    if (forge.editPr) {
+      try {
+        await forge.editPr(existing.number, { title: COMMIT_MSG, body: docPrBody(sentinel) });
+      } catch (err) {
+        console.warn(
+          `[doc-agent] roll-up: editPr(#${existing.number}) failed for ${f.repoPath} — PR body may be stale:`,
+          err,
+        );
+      }
+    } else {
+      console.warn(
+        `[doc-agent] roll-up: forge has no editPr — PR #${existing.number} body may be stale`,
+      );
+    }
+    return existing.url;
   }
 
   /** Push the local `shepherd/docs-update-*` branch and open a standalone doc-update PR. Shared by
@@ -913,8 +998,12 @@ export class DocAgentService {
       return null; // defer to the nightly path rather than guess
     }
     if (status.state !== "open") {
-      // PR merged/closed mid-run → open the single fresh PR instead (key already set → onMergedPr defers).
-      return this.openFreshPr(f, sentinel, forge);
+      // PR merged/closed mid-run → land the docs as exactly ONE standalone PR: roll up onto an
+      // existing open docs PR if present (never a 2nd), else open fresh. (key already set → onMergedPr defers.)
+      const existing = await this.findOpenDocPr(forge, f.branch);
+      return existing
+        ? this.rollupOnto(f, existing, sentinel, forge)
+        : this.openFreshPr(f, sentinel, forge);
     }
 
     // Push the doc commit onto the code PR's OWN head branch (never force, explicit refspec).

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -733,7 +733,7 @@ export class GithubForge implements GitForge {
     const args = ["pr", "edit", String(prNumber), "--repo", this.slug];
     if (o.title !== undefined) args.push("--title", o.title);
     if (o.body !== undefined) args.push("--body", o.body);
-    if (args.length === 4) return; // nothing to edit
+    if (args.length === 5) return; // no title/body provided — nothing to edit
     await this.run(args);
   }
 

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -729,6 +729,14 @@ export class GithubForge implements GitForge {
     await this.run(["pr", "comment", String(prNumber), "--repo", this.slug, "--body", body]);
   }
 
+  async editPr(prNumber: number, o: { title?: string; body?: string }): Promise<void> {
+    const args = ["pr", "edit", String(prNumber), "--repo", this.slug];
+    if (o.title !== undefined) args.push("--title", o.title);
+    if (o.body !== undefined) args.push("--body", o.body);
+    if (args.length === 4) return; // nothing to edit
+    await this.run(args);
+  }
+
   async ensureIssueLink(prNumber: number, issueNumber: number): Promise<void> {
     const body = (
       await this.run([

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -314,6 +314,11 @@ export interface GitForge {
    *  with a comment API (GitHub) implement it; others omit it and the
    *  dependabot-rebase endpoint 400s. */
   comment?(prNumber: number, body: string): Promise<void>;
+  /** Edit an open PR's title and/or body (`gh pr edit`). Used to refresh a rolled-up
+   *  docs PR's body so it matches the force-pushed diff (doc agent). Optional: only hosts
+   *  with a PR-edit API (GitHub) implement it; others omit it and the caller logs that the
+   *  body may be stale. */
+  editPr?(prNumber: number, o: { title?: string; body?: string }): Promise<void>;
   /** Flip an open draft PR to ready-for-review (`gh pr ready <n>`). Optional: only
    *  hosts with a draft API implement it; the draft-reconcile service treats absence
    *  as "cannot promote on this host". */

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -77,6 +77,8 @@ interface Harness {
   markers: Map<string, string>;
   /** Args of every herdr.start (incl. the wrapped argv) for prompt-grounding assertions. */
   startArgs: { name: string; cwd: string; argv: string[] }[];
+  /** Captured editPr calls (prNumber + patch). */
+  editPrCalls: { prNumber: number; title?: string; body?: string }[];
   __merge: number;
 }
 
@@ -180,6 +182,16 @@ function mkHarness(opts?: {
   /** Owner-worktree git responses for the ff guard: porcelain status + rev-parse HEAD. */
   ownerStatusPorcelain?: string;
   ownerHead?: string;
+  /** Open standalone docs PRs returned by forge.listPullRequests (roll-up tests). */
+  openDocPrs?: { number: number; headRefName: string; url?: string }[];
+  /** When true, forge.listPullRequests throws (fail-open test). */
+  listPullRequestsThrows?: boolean;
+  /** When true, `git push --force` throws (deferred roll-up test). */
+  forcePushThrows?: boolean;
+  /** When true, forge.editPr throws after recording the call. */
+  editPrThrows?: boolean;
+  /** When true, forge has no editPr method (stale-body fallback test). */
+  noEditPr?: boolean;
 }): Harness {
   const o = {
     forgeKind: "github" as "github" | "local" | null,
@@ -205,6 +217,11 @@ function mkHarness(opts?: {
     markerFiles: {} as Record<string, string>,
     ownerStatusPorcelain: "",
     ownerHead: "headsha1",
+    openDocPrs: undefined as { number: number; headRefName: string; url?: string }[] | undefined,
+    listPullRequestsThrows: false,
+    forcePushThrows: false,
+    editPrThrows: false,
+    noEditPr: false,
     ...opts,
   };
 
@@ -222,6 +239,7 @@ function mkHarness(opts?: {
   const spawnRows: SpawnRow[] = [];
   const completedRows: CompletedRow[] = [];
   const deletedRemote: string[] = [];
+  const editPrCalls: { prNumber: number; title?: string; body?: string }[] = [];
   const store = {
     getSetting: (key: string) => kv.get(key) ?? null,
     setSetting: (key: string, value: string) => {
@@ -305,6 +323,8 @@ function mkHarness(opts?: {
     }
     if (args[0] === "rev-parse" && args[1] === "HEAD") return o.ownerHead;
     if (args[0] === "status" && args[1] === "--porcelain") return o.ownerStatusPorcelain;
+    if (args[0] === "push" && args[1] === "--force" && o.forcePushThrows)
+      throw new Error("non-ff (stub)");
     return "";
   };
 
@@ -332,6 +352,30 @@ function mkHarness(opts?: {
             if (full) return full;
             return { state: o.prStatusByBranch?.[branch] ?? "none" };
           },
+          listPullRequests: async () => {
+            if (o.listPullRequestsThrows) throw new Error("gh pr list failed (stub)");
+            return (o.openDocPrs ?? []).map((p) => ({
+              number: p.number,
+              title: "docs: sync docs to recent source changes",
+              url: p.url ?? `https://forge/pr/${p.number}`,
+              author: "shepherd",
+              kind: "other",
+              createdAt: 0,
+              isDraft: false,
+              mergeable: true,
+              checks: "success",
+              jobs: [],
+              headRefName: p.headRefName,
+            }));
+          },
+          ...(o.noEditPr
+            ? {}
+            : {
+                editPr: async (prNumber: number, eo: { title?: string; body?: string }) => {
+                  editPrCalls.push({ prNumber, title: eo.title, body: eo.body });
+                  if (o.editPrThrows) throw new Error("gh pr edit failed (stub)");
+                },
+              }),
         } as any);
 
   const herdr = {
@@ -440,6 +484,7 @@ function mkHarness(opts?: {
     deletedRemote,
     markers,
     startArgs,
+    editPrCalls,
     mergeCalls: 0,
     get __merge() {
       return mergeCalls;
@@ -1444,4 +1489,164 @@ test("onArchived: frees the readyDebounce entry so a re-archive session is treat
   // One more tick crosses the threshold (idleThresholdMs=0, so any non-zero elapsed qualifies).
   await h.svc.sweepReadyPrs();
   expect(h.starts).toHaveLength(1); // fires only on the second post-archive tick
+});
+
+// ── roll-up: never >1 open standalone docs PR ─────────────────────────────────
+
+test("roll-up: one existing docs PR → rolls up, no openPr, body refreshed", async () => {
+  const h = mkHarness({
+    act: true,
+    openDocPrs: [{ number: 5, headRefName: "shepherd/docs-update-old00001" }],
+  });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  // no new PR opened
+  expect(h.openPrInputs).toHaveLength(0);
+  // force-pushed onto the existing PR's head branch
+  expect(
+    h.gitCalls.some(
+      (c) =>
+        c.args[0] === "push" &&
+        c.args[1] === "--force" &&
+        c.args[2] === "origin" &&
+        c.args[3] === "HEAD:refs/heads/shepherd/docs-update-old00001",
+    ),
+  ).toBe(true);
+  // editPr called once with PR #5 and body containing expected content
+  expect(h.editPrCalls).toHaveLength(1);
+  expect(h.editPrCalls[0]!.prNumber).toBe(5);
+  expect(h.editPrCalls[0]!.body).toContain("never auto-merged");
+  expect(h.editPrCalls[0]!.body).toContain("configuration.md");
+  // finalize emits the existing PR url + outcome pr
+  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: "https://forge/pr/5", outcome: "pr" }]);
+});
+
+test("roll-up: two existing docs PRs → rolls up onto LOWEST number, opens no PR", async () => {
+  const h = mkHarness({
+    act: true,
+    openDocPrs: [
+      { number: 9, headRefName: "shepherd/docs-update-bbb99999" },
+      { number: 4, headRefName: "shepherd/docs-update-aaa44444" },
+    ],
+  });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  // force-pushed onto the LOWEST-numbered PR's branch
+  expect(
+    h.gitCalls.some(
+      (c) =>
+        c.args[0] === "push" &&
+        c.args[1] === "--force" &&
+        c.args[3] === "HEAD:refs/heads/shepherd/docs-update-aaa44444",
+    ),
+  ).toBe(true);
+  expect(h.openPrInputs).toHaveLength(0);
+  expect(h.editPrCalls[0]!.prNumber).toBe(4);
+  expect(h.finalizes[0]!.url).toBe("https://forge/pr/4");
+});
+
+test("roll-up: zero existing docs PRs → opens fresh PR (regression)", async () => {
+  const h = mkHarness({ act: true, openDocPrs: [] });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  expect(h.openPrInputs).toHaveLength(1);
+  expect(h.gitCalls.some((c) => c.args.includes("--force"))).toBe(false);
+});
+
+test("roll-up OBSERVE (act:false): logs roll-up intent, no side effects", async () => {
+  const warnings: string[] = [];
+  const orig = console.warn;
+  console.warn = (...a: unknown[]) => {
+    warnings.push(a.map(String).join(" "));
+  };
+  try {
+    const h = mkHarness({
+      openDocPrs: [{ number: 5, headRefName: "shepherd/docs-update-old00001" }],
+    });
+    await h.svc.consider("/repo");
+    await h.svc.tick();
+    // no commit, no push, no openPr, no editPr
+    expect(h.gitCalls.some((c) => c.args[0] === "commit")).toBe(false);
+    expect(h.gitCalls.some((c) => c.args[0] === "push")).toBe(false);
+    expect(h.openPrInputs).toHaveLength(0);
+    expect(h.editPrCalls).toHaveLength(0);
+    // observe outcome
+    expect(h.finalizes[0]!.outcome).toBe("observe");
+    // OBSERVE log mentions roll-up + PR number
+    expect(warnings.some((w) => w.includes("roll up") && w.includes("#5"))).toBe(true);
+  } finally {
+    console.warn = orig;
+  }
+});
+
+test("roll-up: force-push fails → defer (null url), no fresh PR, no editPr", async () => {
+  const h = mkHarness({
+    act: true,
+    openDocPrs: [{ number: 5, headRefName: "shepherd/docs-update-old00001" }],
+    forcePushThrows: true,
+  });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  expect(h.openPrInputs).toHaveLength(0);
+  expect(h.editPrCalls).toHaveLength(0);
+  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: null, outcome: "nochange" }]);
+});
+
+test("roll-up: editPr absent → push lands, outcome pr (stale-body fallback)", async () => {
+  const h = mkHarness({
+    act: true,
+    openDocPrs: [{ number: 5, headRefName: "shepherd/docs-update-old00001" }],
+    noEditPr: true,
+  });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  // force-push still happened
+  expect(h.gitCalls.some((c) => c.args[0] === "push" && c.args[1] === "--force")).toBe(true);
+  expect(h.openPrInputs).toHaveLength(0);
+  expect(h.finalizes[0]).toEqual({ repoPath: "/repo", url: "https://forge/pr/5", outcome: "pr" });
+});
+
+test("roll-up: editPr throws → push lands, outcome pr, edit was attempted", async () => {
+  const h = mkHarness({
+    act: true,
+    openDocPrs: [{ number: 5, headRefName: "shepherd/docs-update-old00001" }],
+    editPrThrows: true,
+  });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  expect(h.editPrCalls).toHaveLength(1);
+  expect(h.openPrInputs).toHaveLength(0);
+  expect(h.finalizes[0]!.url).toBe("https://forge/pr/5");
+  expect(h.finalizes[0]!.outcome).toBe("pr");
+});
+
+test("roll-up: listPullRequests throws → fail-open opens fresh PR", async () => {
+  const h = mkHarness({ act: true, listPullRequestsThrows: true });
+  await h.svc.consider("/repo");
+  await h.svc.tick();
+  expect(h.openPrInputs).toHaveLength(1);
+  expect(h.gitCalls.some((c) => c.args.includes("--force"))).toBe(false);
+});
+
+test("roll-up: re-target merged-mid-run fallback with existing docs PR → rolls up, no fresh PR", async () => {
+  const h = mkRetargetHarness({
+    act: true,
+    prStatusFull: { "feature/x": { state: "merged" } },
+    openDocPrs: [{ number: 5, headRefName: "shepherd/docs-update-old00001" }],
+  });
+  await h.svc.sweepReadyPrs();
+  await h.svc.sweepReadyPrs();
+  await h.svc.tick();
+  // rolled up rather than opening a fresh PR
+  expect(h.openPrInputs).toHaveLength(0);
+  expect(
+    h.gitCalls.some(
+      (c) =>
+        c.args[0] === "push" &&
+        c.args[1] === "--force" &&
+        c.args[3] === "HEAD:refs/heads/shepherd/docs-update-old00001",
+    ),
+  ).toBe(true);
+  expect(h.editPrCalls[0]!.prNumber).toBe(5);
+  expect(h.finalizes[0]).toEqual({ repoPath: "/repo", url: "https://forge/pr/5", outcome: "pr" });
 });


### PR DESCRIPTION
## Problem

The PR-gated doc agent opens a standalone `shepherd/docs-update-*` PR on every run (nightly cadence + on doc-relevant merges). The **fresh path** (`openFreshPr`) always opened a *brand-new* PR — so a run firing while a prior nightly docs PR was still open created a **second** open docs PR, and they accumulated unbounded.

Enforces the invariant: **at most one open standalone docs-site PR per repo.**

The re-target-onto-code-PR path (#956) already avoids a second PR by design and is out of scope (those are code PRs, not standalone docs PRs).

## Change

- **`findOpenDocPr`** — detects open standalone docs PRs via `forge.listPullRequests()`, filtered to head branches `shepherd/docs-update-*` (`BRANCH_RE`-valid, excluding our own in-flight branch), and returns the **lowest-numbered** one (a stable survivor so repeated runs converge on the same PR).
- **`rollupOnto`** — when one exists, force-pushes the freshly-synced commit onto that PR's own branch (server-owned ephemeral branch → safe; explicit `HEAD:refs/heads/<branch>` refspec + `BRANCH_RE` block injection) and best-effort refreshes the PR body so it matches the new diff. On push failure it **defers** (returns null) rather than opening a fresh PR — opening one would create the duplicate this prevents.
- **`publishStaged`** reworked to detect before the OBSERVE/commit gate (so OBSERVE logs the accurate roll-up intent), then rolls up when ≥1 docs PR exists, else opens fresh.
- The `publishRetarget` **merged-mid-run fallback** routes through the same detect→rollup-or-fresh logic, so it never opens a 2nd standalone PR either.
- **`forge.editPr`** — new optional `GitForge` method (`gh pr edit`) used to refresh the rolled-up PR's body. Best-effort: absent/failing `editPr` warns (`body may be stale`) but the rollup still lands. Title is the constant commit subject, so it never goes stale.

Behavior: **0** open docs PRs → open fresh (unchanged). **≥1** → roll up onto the lowest-numbered, open no new PR — the count never grows.

Always-on within the existing flag-gated agent (`SHEPHERD_DOC_AGENT` / `_ACT`); no new config, no UI, no i18n.

## ⚠️ Rollout prerequisite (one-time)

This guarantees the count **never grows** from the first run, but it does **not** auto-close pre-existing surplus PRs (operator declined `forge.closePr()` auto-heal). A live repo likely starts at N≥2 open `shepherd/docs-update-*` PRs. **At deploy, manually close surplus docs PRs down to ≤1** (`gh pr list --head shepherd/docs-update-` → close all but one). Until then, only *non-growth* is enforced, not ≤1.

## Tests

- 9 new doc-agent tests: lowest-number survivor; rollup force-push refspec + no `openPr`; body refresh content; defer-on-push-failure; fail-open on `listPullRequests` error; `editPr` absent/throws still lands; OBSERVE logs intent with no side effects; retarget merged-mid-run fallback rolls up.
- Full root suite: **4384 pass / 0 fail**; `tsc` + `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)