### PR TITLE
feat(ui): re-target terminal to the chosen repo's session on repo switch

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1770,5 +1770,7 @@
   "usage_range_24h": "24h",
   "usage_range_7d": "7d",
   "usage_range_30d": "30d",
-  "usage_range_all": "Alle"
+  "usage_range_all": "Alle",
+  "feat_repo_switch_retarget_title": "Repo-Wechsel nimmt das Terminal mit",
+  "feat_repo_switch_retarget_body": "Wählst du ein Repo in der Chip-Leiste, springt jetzt auch das Terminal mit — zur Session, die auf deine Antwort wartet, sonst zur ersten aktiven. Kein Starren mehr auf eine Session aus dem gerade verlassenen Repo."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1770,5 +1770,7 @@
   "usage_range_24h": "24h",
   "usage_range_7d": "7d",
   "usage_range_30d": "30d",
-  "usage_range_all": "All"
+  "usage_range_all": "All",
+  "feat_repo_switch_retarget_title": "Repo switch follows the terminal",
+  "feat_repo_switch_retarget_body": "Picking a repo from the chip rail now jumps the terminal to that repo too — to the session waiting on your answer, or else the first active one. No more staring at a session from the repo you just left."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1771,6 +1771,6 @@
   "usage_range_7d": "7d",
   "usage_range_30d": "30d",
   "usage_range_all": "All",
-  "feat_repo_switch_retarget_title": "Repo switch follows the terminal",
+  "feat_repo_switch_retarget_title": "Terminal follows the repo switch",
   "feat_repo_switch_retarget_body": "Picking a repo from the chip rail now jumps the terminal to that repo too — to the session waiting on your answer, or else the first active one. No more staring at a session from the repo you just left."
 }

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -9,11 +9,13 @@ import {
   mergeTrainIsAttention,
   mergeTrainLabel,
   pausedText,
+  pickRepoSwitchTarget,
   queueOpenable,
   repoChipRows,
   shouldClearRepoFilter,
 } from "./queue-strip";
 import type { RepoChip } from "./queue-strip";
+import type { BlockState } from "../triage";
 import type { AutoMergeStatus, DrainStatus, Learning, RepoInjectable, Session } from "../types";
 
 function drain(over: Partial<DrainStatus>): DrainStatus {
@@ -550,5 +552,77 @@ describe("firstCurateRepo", () => {
       injectable({ repoPath: "/repos/b", enabled: true, rules: [rule(false)] }), // enabled → match
     ];
     expect(firstCurateRepo(injectables)).toBe("/repos/b");
+  });
+});
+
+// ─── pickRepoSwitchTarget ─────────────────────────────────────────────────────
+
+function block(since: number): BlockState {
+  return { reason: { shape: "awaiting-input", options: [], tail: [] }, since };
+}
+
+describe("pickRepoSwitchTarget", () => {
+  it("re-targets onto a session waiting on the user, oldest-blocked first", () => {
+    const sessions = [
+      session({ id: "a1", repoPath: "/repos/a", status: "running" }),
+      session({ id: "b-run", repoPath: "/repos/b", status: "running" }),
+      session({ id: "b-new", repoPath: "/repos/b", status: "blocked" }),
+      session({ id: "b-old", repoPath: "/repos/b", status: "blocked" }),
+    ];
+    const blocks = { "b-new": block(200), "b-old": block(100) };
+    const sel = sessions[0]; // currently on a session in repo a
+    expect(pickRepoSwitchTarget("/repos/b", sessions, blocks, {}, sel)).toBe("b-old");
+  });
+
+  it("falls back to the first active (running) session when none are waiting", () => {
+    const sessions = [
+      session({ id: "a1", repoPath: "/repos/a", status: "running" }),
+      session({ id: "b-idle", repoPath: "/repos/b", status: "idle" }),
+      session({ id: "b-run", repoPath: "/repos/b", status: "running" }),
+    ];
+    expect(pickRepoSwitchTarget("/repos/b", sessions, {}, {}, sessions[0])).toBe("b-run");
+  });
+
+  it("falls back to the first session in the repo when none are waiting or active", () => {
+    const sessions = [
+      session({ id: "a1", repoPath: "/repos/a", status: "running" }),
+      session({ id: "b-idle", repoPath: "/repos/b", status: "idle" }),
+      session({ id: "b-done", repoPath: "/repos/b", status: "done" }),
+    ];
+    expect(pickRepoSwitchTarget("/repos/b", sessions, {}, {}, sessions[0])).toBe("b-idle");
+  });
+
+  it("excludes a working-while-blocked session from the 'waiting' pick", () => {
+    const sessions = [
+      session({ id: "a1", repoPath: "/repos/a", status: "running" }),
+      session({ id: "b-wb", repoPath: "/repos/b", status: "blocked" }),
+      session({ id: "b-wait", repoPath: "/repos/b", status: "blocked" }),
+    ];
+    // b-wb blocked earlier (10) but actively working; b-wait blocked later (50) and truly waiting.
+    const blocks = { "b-wb": block(10), "b-wait": block(50) };
+    // Without the exclusion oldest-blocked b-wb would win; it's working, so b-wait is the real wait.
+    expect(pickRepoSwitchTarget("/repos/b", sessions, blocks, { "b-wb": true }, sessions[0])).toBe(
+      "b-wait",
+    );
+  });
+
+  it("returns null when already on a session in the chosen repo", () => {
+    const sessions = [
+      session({ id: "b1", repoPath: "/repos/b", status: "running" }),
+      session({ id: "b2", repoPath: "/repos/b", status: "blocked" }),
+    ];
+    expect(
+      pickRepoSwitchTarget("/repos/b", sessions, { b2: block(1) }, {}, sessions[0]),
+    ).toBeNull();
+  });
+
+  it("returns null when the chosen repo has no session", () => {
+    const sessions = [session({ id: "a1", repoPath: "/repos/a" })];
+    expect(pickRepoSwitchTarget("/repos/empty", sessions, {}, {}, sessions[0])).toBeNull();
+  });
+
+  it("re-targets even with no session previously selected", () => {
+    const sessions = [session({ id: "b1", repoPath: "/repos/b", status: "running" })];
+    expect(pickRepoSwitchTarget("/repos/b", sessions, {}, {}, null)).toBe("b1");
   });
 });

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -1,6 +1,8 @@
 import type { AutoMergeStatus, DrainStatus, Learning, RepoInjectable, Session } from "../types";
 import { m } from "$lib/paraglide/messages";
 import { droppedCount } from "./learnings-drawer";
+import { sortBlocked, type BlockState } from "../triage";
+import { displayStatus } from "../display-status";
 
 /** Enabled drains only, sorted by repo path — the per-repo drain lookup feeding repoChipRows. */
 export function enabledDrains(drain: Record<string, DrainStatus>): DrainStatus[] {
@@ -92,6 +94,32 @@ export function chipHasTelemetry(chip: RepoChip): boolean {
  *  session (no chip) — a filter on a vanished repo would strand an empty view. */
 export function shouldClearRepoFilter(repoFilter: string | null, chips: RepoChip[]): boolean {
   return repoFilter !== null && !chips.some((c) => c.repoPath === repoFilter);
+}
+
+/**
+ * The session the terminal should re-target onto after the user picks a repo chip.
+ * Narrowing the herd to a repo would otherwise leave the terminal on whatever session
+ * was selected before — now in a *different* repo than the visible list. This chooses,
+ * within the chosen repo: a session waiting on the user's answer (oldest-blocked first,
+ * excluding working-while-blocked, which is actively running not waiting), else the first
+ * active (running) session, else the first session in the repo. Returns null when nothing
+ * should change — the user is already on a session in this repo, the repo has no session,
+ * or the best target is already selected.
+ */
+export function pickRepoSwitchTarget(
+  repoFilter: string,
+  sessions: Session[],
+  blocks: Record<string, BlockState>,
+  workingBlocked: Record<string, boolean>,
+  selected: Session | null,
+): string | null {
+  if (selected && selected.repoPath === repoFilter) return null;
+  const inRepo = sessions.filter((s) => s.repoPath === repoFilter);
+  if (inRepo.length === 0) return null;
+  const waiting = sortBlocked(inRepo, blocks).find((e) => !workingBlocked[e.session.id])?.session;
+  const active = inRepo.find((s) => displayStatus(s, workingBlocked) === "running");
+  const next = waiting ?? active ?? inRepo[0];
+  return next.id !== selected?.id ? next.id : null;
 }
 
 /** Global learnings badge counts for the TopBar: proposed rules awaiting review

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1378,4 +1378,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_docs_link_body",
     targetId: "docs-link",
   },
+  {
+    // No targetId: the behaviour fires on a repo-chip switch in the RepoSwitcher rail
+    // (only rendered when ≥2 repos have a live session), and the effect re-targets the
+    // terminal rather than highlighting a control — there's no stable anchor to point a
+    // coachmark at. Surface via the What's-New drawer only. v1.35.0 is the latest
+    // released tag → ships in 1.36.0.
+    id: "repo-switch-retarget",
+    sinceVersion: "1.36.0",
+    titleKey: "feat_repo_switch_retarget_title",
+    bodyKey: "feat_repo_switch_retarget_body",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -219,7 +219,8 @@
         store.workingBlocked,
         selected,
       );
-      if (target) selectUnit(target, false);
+      // toDetail=false: filtering the list must not fling a phone user into a terminal.
+      if (target) selectUnit(target, false, false);
     });
   });
   // Session-status filter toggled from the TopBar tallies; null = all statuses.
@@ -789,14 +790,18 @@
   // keyboard back to the terminal that plain-key navigation kept it out of.
   let viewportRef: Viewport | undefined = $state();
 
-  function selectUnit(id: string, focusTerm = true) {
+  // toDetail=false re-targets the selection WITHOUT opening the mobile detail screen —
+  // used when the switch is a side effect of another action (e.g. a repo-filter change)
+  // rather than the user tapping a session row, so a list-level action doesn't fling a
+  // phone user into a terminal.
+  function selectUnit(id: string, focusTerm = true, toDetail = true) {
     // only a *real* switch remounts the terminal and consumes the intent; a
     // self-selection (e.g. plain j wrapping back to the only visible session)
     // must not park a stale `false` that would suppress a later
     // resumeEpoch-driven auto-focus.
     if (id !== selectedId) keynavFocusIntent = focusTerm;
     selectedId = id;
-    if (mobile.current) mobileScreen = "detail";
+    if (toDetail && mobile.current) mobileScreen = "detail";
   }
 
   // Deep-link a Rundown item to its live session: leave the panel-only Rundown lens

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, tick } from "svelte";
+  import { onMount, tick, untrack } from "svelte";
   import { MediaQuery, SvelteSet } from "svelte/reactivity";
   import { HerdStore } from "$lib/store.svelte";
   import {
@@ -88,6 +88,7 @@
   import {
     firstCurateRepo,
     globalLearningsCounts,
+    pickRepoSwitchTarget,
     repoChipRows,
     shouldClearRepoFilter,
   } from "$lib/components/queue-strip";
@@ -200,6 +201,26 @@
   // a filter on a vanished repo would strand an empty view.
   $effect(() => {
     if (shouldClearRepoFilter(repoFilter, repoChips)) repoFilter = null;
+  });
+  // Picking a repo chip narrows the herd list to that repo — but the terminal would
+  // otherwise keep showing whatever session was selected before, which now lives in a
+  // different repo than the visible list. Re-target selection onto the chosen repo
+  // (waiting-on-you session first, then first active, then any). Tracks ONLY repoFilter
+  // (everything else is untracked) so it fires on a chip switch, never on a later
+  // session/block update that would yank the user off their session.
+  $effect(() => {
+    const rf = repoFilter;
+    if (rf == null) return; // "all repos" view keeps selection whole
+    untrack(() => {
+      const target = pickRepoSwitchTarget(
+        rf,
+        store.sessions,
+        store.blocks,
+        store.workingBlocked,
+        selected,
+      );
+      if (target) selectUnit(target, false);
+    });
   });
   // Session-status filter toggled from the TopBar tallies; null = all statuses.
   // Independent of the repo filter — both compose into herdSessions below. Sticky


### PR DESCRIPTION
## Problem

Switching the repo filter (the chip rail) correctly narrows the session list on the left — but the **terminal stays on the session that was selected before the switch**, which now belongs to a *different* repo than the visible list. The terminal and the list disagree. Pure UX papercut.

## Fix

When the repo filter changes to a specific repo, re-target the selected session onto that repo. Priority:

1. A session **waiting on the user's answer** — oldest-blocked first, excluding working-while-blocked (those are actively running, not waiting).
2. Otherwise the **first active (running)** session in the repo.
3. Otherwise the **first session** in the repo (so the terminal never strands on the old repo).

If the user is already viewing a session in the chosen repo, or the repo has no session, nothing changes.

### Implementation notes

- The selection logic is extracted as the pure helper `pickRepoSwitchTarget` in `ui/src/lib/components/queue-strip.ts`, alongside the other repo-filter helpers — fully unit-tested (`queue-strip.test.ts`).
- The `$effect` in `+page.svelte` tracks **only** `repoFilter` (everything else read inside `untrack`), so it fires on a chip switch and **never** on a later session/block update that would otherwise yank the user off their session.
- Switching back to "all repos" (null filter) keeps the current selection whole, unchanged.

## Tests

- 8 new cases for `pickRepoSwitchTarget` (waiting-first, active fallback, any-fallback, working-while-blocked exclusion, already-in-repo no-op, empty-repo no-op, no-prior-selection).
- `bun run check`, `check:i18n`, and the test suite pass.

## Feature discovery

- Added catalog entry `repo-switch-retarget` (ships 1.36.0) + EN/DE message keys.