### PR TITLE
fix(top-bar): keep docs link reachable under measured overflow

### DIFF
--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -890,6 +890,36 @@ describe("TopBar — idle gear opens Settings directly", () => {
     await expect.element(docs).toBeInTheDocument();
     await expect.element(docs).toHaveAttribute("href", DOCS_URL);
   });
+
+  it("desktop compact + idle herd: docs folds away from the bar but the gear menu carries it", async () => {
+    await page.viewport(1236, 900);
+    document.body.style.width = "1236px";
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      limits: fullLimits,
+      ...allBadges,
+      sessions: sessions(0), // idle herd → gear would normally open Settings directly
+    });
+    const hud = document.querySelector<HTMLElement>(".hud");
+    await waitNoOverflow(hud!);
+    await drainFrames(hud!);
+    // measured overflow → the standalone bar docs link folds away with the labels/clock…
+    expect(
+      hud!.querySelector(".needsyou")?.classList.contains("compact"),
+      "bar is compacted at 1236 with full chrome",
+    ).toBe(true);
+    await expect
+      .element(page.getByRole("link", { name: m.topbar_docs_aria() }))
+      .not.toBeInTheDocument();
+    // …but the gear now opens a menu (not Settings directly) that still carries Documentation,
+    // so the docs stay reachable in the compact + idle state.
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    const docs = page.getByRole("menuitem", { name: m.topbar_docs() });
+    await expect.element(docs).toBeInTheDocument();
+    await expect.element(docs).toHaveAttribute("href", DOCS_URL);
+  });
 });
 
 describe("TopBar — CR extra-credit gauge", () => {

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -438,8 +438,11 @@
   // On mobile the gear ALWAYS opens the menu — it now also hosts the quick theme /
   // contrast controls, which must be reachable with an idle herd. On desktop those
   // controls live in the ActionBar, so the gear keeps its leaner behaviour: idle herd
-  // opens Settings directly; only a haltable herd turns it into a menu button.
-  const gearOpensMenu = $derived(mobile || haltable > 0);
+  // opens Settings directly; only a haltable herd turns it into a menu button — EXCEPT
+  // under measured overflow (compactBadges), where the standalone docs link folds away,
+  // so the gear must open the menu (which carries Documentation + Settings) to keep the
+  // docs reachable even with an idle herd in that compact state.
+  const gearOpensMenu = $derived(mobile || haltable > 0 || compactBadges);
   // Mobile only: every gear-area signal collapses into ONE dot, colored by the
   // most serious active tier (red > orange > yellow > blue). Desktop keeps its
   // halt-pip + dedicated badges, so this stays null off-mobile.
@@ -510,6 +513,12 @@
     // On mobile the menu also hosts the quick theme/contrast controls, so it stays
     // valid with an idle herd — keep it open and just drop any armed e-stop state.
     if (mobile) {
+      disarmHalt();
+      return;
+    }
+    // Under measured overflow the gear is a menu button even with an idle herd (it hosts
+    // the folded-away docs link), so keep the menu open here too — just drop armed state.
+    if (compactBadges) {
       disarmHalt();
       return;
     }


### PR DESCRIPTION
Follow-up to #969 (already merged). Addresses the PR critic's review point.

## Problem (critic finding on #969)
Under measured overflow the standalone docs bar link folds away. On a narrow desktop viewport with an **idle herd**, the gear opens Settings directly (no dropdown) — so in that compact + idle state the documentation link was unreachable entirely.

## Fix
Under measured overflow (`compactBadges`), the gear now becomes a menu button even with an idle herd, so its dropdown — which already carries **Documentation** + **Settings** — keeps the docs reachable. This mirrors the existing mobile pattern (badges fold into the gear bottom sheet). The `haltable === 0` auto-close effect is guarded so it no longer dismisses that legitimately-open compact menu.

## Verification
- New test: desktop compact + idle herd → the standalone bar link is absent, but the gear opens a menu carrying the Documentation entry (`href` = docs.shepherd.run).
- `bun run check` — 0 errors · `bun run test` (TopBar) — 55/55 green.

Note: this had to be a follow-up PR because #969 was merged before the critic fix could be added to it. `[no-feature-entry]` — the docs feature catalog entry already shipped in #969; this is a reachability fix with no new user-facing surface.