### PR TITLE
feat(feedback): in-app bug reporting & feedback → prefilled GitHub issue forms (#971)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,25 @@
+name: Bug report
+description: Report something that isn't working
+labels: [bug]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Auto-filled by Shepherd — please leave as-is.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & ideas (Discussions)
+    url: https://github.com/erwins-enkel/shepherd/discussions
+    about: Ask questions or discuss ideas that aren't a specific bug or feature request.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem would this solve, or what's the motivation?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Auto-filled by Shepherd — please leave as-is.
+      render: text

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,16 @@
+name: Feedback
+description: Share general feedback
+labels: [feedback]
+body:
+  - type: textarea
+    id: feedback
+    attributes:
+      label: Your feedback
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Auto-filled by Shepherd — please leave as-is.
+      render: text

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1785,5 +1785,7 @@
   "feedback_dialog_submit": "Auf GitHub fortfahren",
   "feedback_dialog_note": "Öffnet ein vorausgefülltes GitHub-Issue in einem neuen Tab – vor dem Absenden prüfen und bearbeiten.",
   "settings_feedback_title": "Feedback",
-  "settings_feedback_blurb": "Fehler gefunden oder eine Idee? Sagen Sie uns Bescheid."
+  "settings_feedback_blurb": "Fehler gefunden oder eine Idee? Sagen Sie uns Bescheid.",
+  "feat_feedback_title": "Fehler melden & Feedback senden",
+  "feat_feedback_body": "Fehler gefunden oder eine Idee? Über das Zahnrad-Menü oder Einstellungen → Gerät können Sie einen Fehler melden, eine Funktion vorschlagen oder Feedback senden – es öffnet ein vorausgefülltes GitHub-Issue."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1783,5 +1783,7 @@
   "feedback_dialog_details_placeholder_feature": "Was wünschen Sie sich, und warum?",
   "feedback_dialog_details_placeholder_feedback": "Teilen Sie uns Ihre Gedanken mit …",
   "feedback_dialog_submit": "Auf GitHub fortfahren",
-  "feedback_dialog_note": "Öffnet ein vorausgefülltes GitHub-Issue in einem neuen Tab – vor dem Absenden prüfen und bearbeiten."
+  "feedback_dialog_note": "Öffnet ein vorausgefülltes GitHub-Issue in einem neuen Tab – vor dem Absenden prüfen und bearbeiten.",
+  "settings_feedback_title": "Feedback",
+  "settings_feedback_blurb": "Fehler gefunden oder eine Idee? Sagen Sie uns Bescheid."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1772,5 +1772,16 @@
   "usage_range_30d": "30d",
   "usage_range_all": "Alle",
   "feat_repo_switch_retarget_title": "Repo-Wechsel nimmt das Terminal mit",
-  "feat_repo_switch_retarget_body": "Wählst du ein Repo in der Chip-Leiste, springt jetzt auch das Terminal mit — zur Session, die auf deine Antwort wartet, sonst zur ersten aktiven. Kein Starren mehr auf eine Session aus dem gerade verlassenen Repo."
+  "feat_repo_switch_retarget_body": "Wählst du ein Repo in der Chip-Leiste, springt jetzt auch das Terminal mit — zur Session, die auf deine Antwort wartet, sonst zur ersten aktiven. Kein Starren mehr auf eine Session aus dem gerade verlassenen Repo.",
+  "feedback_dialog_title_bug": "Fehler melden",
+  "feedback_dialog_title_feature": "Funktion vorschlagen",
+  "feedback_dialog_title_feedback": "Feedback senden",
+  "feedback_dialog_summary_label": "Titel",
+  "feedback_dialog_summary_placeholder": "Kurze Zusammenfassung",
+  "feedback_dialog_details_label": "Details",
+  "feedback_dialog_details_placeholder_bug": "Was ist schiefgelaufen? Was hatten Sie erwartet?",
+  "feedback_dialog_details_placeholder_feature": "Was wünschen Sie sich, und warum?",
+  "feedback_dialog_details_placeholder_feedback": "Teilen Sie uns Ihre Gedanken mit …",
+  "feedback_dialog_submit": "Auf GitHub fortfahren",
+  "feedback_dialog_note": "Öffnet ein vorausgefülltes GitHub-Issue in einem neuen Tab – vor dem Absenden prüfen und bearbeiten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1783,5 +1783,7 @@
   "feedback_dialog_details_placeholder_feature": "What would you like to see, and why?",
   "feedback_dialog_details_placeholder_feedback": "Share your thoughts…",
   "feedback_dialog_submit": "Continue on GitHub",
-  "feedback_dialog_note": "Opens a prefilled GitHub issue in a new tab — review and edit before submitting."
+  "feedback_dialog_note": "Opens a prefilled GitHub issue in a new tab — review and edit before submitting.",
+  "settings_feedback_title": "Feedback",
+  "settings_feedback_blurb": "Found a bug or have an idea? Let us know."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1785,5 +1785,7 @@
   "feedback_dialog_submit": "Continue on GitHub",
   "feedback_dialog_note": "Opens a prefilled GitHub issue in a new tab — review and edit before submitting.",
   "settings_feedback_title": "Feedback",
-  "settings_feedback_blurb": "Found a bug or have an idea? Let us know."
+  "settings_feedback_blurb": "Found a bug or have an idea? Let us know.",
+  "feat_feedback_title": "Report bugs & send feedback",
+  "feat_feedback_body": "Found a bug or have an idea? Use the gear menu or Settings → Device to report a bug, request a feature, or send feedback — it opens a prefilled GitHub issue."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1772,5 +1772,16 @@
   "usage_range_30d": "30d",
   "usage_range_all": "All",
   "feat_repo_switch_retarget_title": "Terminal follows the repo switch",
-  "feat_repo_switch_retarget_body": "Picking a repo from the chip rail now jumps the terminal to that repo too — to the session waiting on your answer, or else the first active one. No more staring at a session from the repo you just left."
+  "feat_repo_switch_retarget_body": "Picking a repo from the chip rail now jumps the terminal to that repo too — to the session waiting on your answer, or else the first active one. No more staring at a session from the repo you just left.",
+  "feedback_dialog_title_bug": "Report a bug",
+  "feedback_dialog_title_feature": "Request a feature",
+  "feedback_dialog_title_feedback": "Send feedback",
+  "feedback_dialog_summary_label": "Title",
+  "feedback_dialog_summary_placeholder": "A short summary",
+  "feedback_dialog_details_label": "Details",
+  "feedback_dialog_details_placeholder_bug": "What went wrong? What did you expect to happen?",
+  "feedback_dialog_details_placeholder_feature": "What would you like to see, and why?",
+  "feedback_dialog_details_placeholder_feedback": "Share your thoughts…",
+  "feedback_dialog_submit": "Continue on GitHub",
+  "feedback_dialog_note": "Opens a prefilled GitHub issue in a new tab — review and edit before submitting."
 }

--- a/ui/src/lib/components/FeedbackDialog.svelte
+++ b/ui/src/lib/components/FeedbackDialog.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import type { FeedbackKind } from "$lib/feedback-link";
   import { buildIssueUrl } from "$lib/feedback-link";
-  import { closeFeedback } from "$lib/feedback-dialog.svelte";
+  import { feedbackDialog, closeFeedback } from "$lib/feedback-dialog.svelte";
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
-
-  let { kind }: { kind: FeedbackKind } = $props();
 
   let title = $state("");
   let details = $state("");
@@ -23,63 +21,65 @@
   };
 
   function submit() {
-    window.open(
-      buildIssueUrl(kind, { title, description: details }),
-      "_blank",
-      "noopener,noreferrer",
-    );
+    const k = feedbackDialog.kind;
+    if (!k) return;
+    window.open(buildIssueUrl(k, { title, description: details }), "_blank", "noopener,noreferrer");
     closeFeedback();
   }
 </script>
 
-<div
-  class="overlay"
-  role="presentation"
-  onclick={(e) => {
-    if (e.target === e.currentTarget) closeFeedback();
-  }}
->
+{#if feedbackDialog.kind}
+  {@const k = feedbackDialog.kind}
   <div
-    class="card"
-    role="dialog"
-    aria-modal="true"
-    aria-label={headingFor[kind]()}
-    use:dialog={{ onclose: closeFeedback }}
+    class="overlay"
+    role="presentation"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) closeFeedback();
+    }}
   >
-    <div class="chead">
-      <span class="micro">{headingFor[kind]()}</span>
-      <button type="button" class="x" onclick={closeFeedback} aria-label={m.common_close()}
-        >✕</button
-      >
-    </div>
+    <div
+      class="card"
+      role="dialog"
+      aria-modal="true"
+      aria-label={headingFor[k]()}
+      use:dialog={{ onclose: closeFeedback }}
+    >
+      <div class="chead">
+        <span class="micro">{headingFor[k]()}</span>
+        <button type="button" class="x" onclick={closeFeedback} aria-label={m.common_close()}
+          >✕</button
+        >
+      </div>
 
-    <div class="field">
-      <label class="field-label" for="feedback-title">{m.feedback_dialog_summary_label()}</label>
-      <input
-        id="feedback-title"
-        type="text"
-        placeholder={m.feedback_dialog_summary_placeholder()}
-        bind:value={title}
-      />
-    </div>
+      <div class="field">
+        <label class="field-label" for="feedback-title">{m.feedback_dialog_summary_label()}</label>
+        <input
+          id="feedback-title"
+          type="text"
+          placeholder={m.feedback_dialog_summary_placeholder()}
+          bind:value={title}
+        />
+      </div>
 
-    <div class="field">
-      <label class="field-label" for="feedback-details">{m.feedback_dialog_details_label()}</label>
-      <textarea
-        id="feedback-details"
-        rows="5"
-        placeholder={detailsPlaceholderFor[kind]()}
-        bind:value={details}></textarea>
-    </div>
+      <div class="field">
+        <label class="field-label" for="feedback-details">{m.feedback_dialog_details_label()}</label
+        >
+        <textarea
+          id="feedback-details"
+          rows="5"
+          placeholder={detailsPlaceholderFor[k]()}
+          bind:value={details}></textarea>
+      </div>
 
-    <p class="note">{m.feedback_dialog_note()}</p>
+      <p class="note">{m.feedback_dialog_note()}</p>
 
-    <div class="actions">
-      <button type="button" class="ghost" onclick={closeFeedback}>{m.common_cancel()}</button>
-      <button type="button" class="run" onclick={submit}>{m.feedback_dialog_submit()}</button>
+      <div class="actions">
+        <button type="button" class="ghost" onclick={closeFeedback}>{m.common_cancel()}</button>
+        <button type="button" class="run" onclick={submit}>{m.feedback_dialog_submit()}</button>
+      </div>
     </div>
   </div>
-</div>
+{/if}
 
 <style>
   .overlay {

--- a/ui/src/lib/components/FeedbackDialog.svelte
+++ b/ui/src/lib/components/FeedbackDialog.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  import type { FeedbackKind } from "$lib/feedback-link";
+  import { buildIssueUrl } from "$lib/feedback-link";
+  import { closeFeedback } from "$lib/feedback-dialog.svelte";
+  import { dialog } from "$lib/a11yDialog";
+  import { m } from "$lib/paraglide/messages";
+
+  let { kind }: { kind: FeedbackKind } = $props();
+
+  let title = $state("");
+  let details = $state("");
+
+  const headingFor: Record<FeedbackKind, () => string> = {
+    bug: m.feedback_dialog_title_bug,
+    feature: m.feedback_dialog_title_feature,
+    feedback: m.feedback_dialog_title_feedback,
+  };
+
+  const detailsPlaceholderFor: Record<FeedbackKind, () => string> = {
+    bug: m.feedback_dialog_details_placeholder_bug,
+    feature: m.feedback_dialog_details_placeholder_feature,
+    feedback: m.feedback_dialog_details_placeholder_feedback,
+  };
+
+  function submit() {
+    window.open(
+      buildIssueUrl(kind, { title, description: details }),
+      "_blank",
+      "noopener,noreferrer",
+    );
+    closeFeedback();
+  }
+</script>
+
+<div
+  class="overlay"
+  role="presentation"
+  onclick={(e) => {
+    if (e.target === e.currentTarget) closeFeedback();
+  }}
+>
+  <div
+    class="card"
+    role="dialog"
+    aria-modal="true"
+    aria-label={headingFor[kind]()}
+    use:dialog={{ onclose: closeFeedback }}
+  >
+    <div class="chead">
+      <span class="micro">{headingFor[kind]()}</span>
+      <button type="button" class="x" onclick={closeFeedback} aria-label={m.common_close()}
+        >✕</button
+      >
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="feedback-title">{m.feedback_dialog_summary_label()}</label>
+      <input
+        id="feedback-title"
+        type="text"
+        placeholder={m.feedback_dialog_summary_placeholder()}
+        bind:value={title}
+      />
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="feedback-details">{m.feedback_dialog_details_label()}</label>
+      <textarea
+        id="feedback-details"
+        rows="5"
+        placeholder={detailsPlaceholderFor[kind]()}
+        bind:value={details}></textarea>
+    </div>
+
+    <p class="note">{m.feedback_dialog_note()}</p>
+
+    <div class="actions">
+      <button type="button" class="ghost" onclick={closeFeedback}>{m.common_cancel()}</button>
+      <button type="button" class="run" onclick={submit}>{m.feedback_dialog_submit()}</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--color-scrim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+  }
+  .card {
+    width: min(480px, 92vw);
+    border: 1px solid var(--color-line-bright);
+    background: var(--color-panel);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .chead {
+    display: flex;
+    align-items: center;
+  }
+  .x {
+    margin-left: auto;
+    background: transparent;
+    border: 0;
+    color: var(--color-muted);
+    cursor: pointer;
+    font: inherit;
+  }
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .field-label {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+  input,
+  textarea {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    padding: 8px 10px;
+    border-radius: 2px;
+    width: 100%;
+    box-sizing: border-box;
+    resize: vertical;
+  }
+  .note {
+    margin: 0;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    line-height: 1.4;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 2px;
+  }
+  .ghost,
+  .run {
+    border: 1px solid var(--color-line-bright);
+    background: transparent;
+    color: var(--color-ink);
+    padding: 9px 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font: inherit;
+    font-size: var(--fs-meta);
+    cursor: pointer;
+  }
+  .run {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  @media (max-width: 768px) {
+    .overlay {
+      align-items: stretch;
+      justify-content: stretch;
+    }
+    .card {
+      width: 100%;
+      height: 100dvh;
+      border: 0;
+      overflow-y: auto;
+    }
+  }
+</style>

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -24,6 +24,8 @@
   import SettingsDevicePanel from "$lib/components/settings/SettingsDevicePanel.svelte";
   import SettingsDiagnosePanel from "$lib/components/settings/SettingsDiagnosePanel.svelte";
   import { dialog } from "$lib/a11yDialog";
+  import { openFeedback } from "$lib/feedback-dialog.svelte";
+  import type { FeedbackKind } from "$lib/feedback-link";
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
 
@@ -826,6 +828,10 @@
         {reducedPushMode}
         {reducedPushBusy}
         onToggleReducedPush={toggleReducedPush}
+        onfeedback={(kind: FeedbackKind) => {
+          onclose?.();
+          openFeedback(kind);
+        }}
       />
     </div>
 

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -14,6 +14,8 @@
   import { m } from "$lib/paraglide/messages";
   import { DOCS_URL } from "$lib/build-info";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import { openFeedback } from "$lib/feedback-dialog.svelte";
+  import type { FeedbackKind } from "$lib/feedback-link";
   import { modeOf, badgeCount } from "./top-bar-layout";
   import TopBarTallies from "./top-bar/TopBarTallies.svelte";
   import TopBarHeldBadge from "./top-bar/TopBarHeldBadge.svelte";
@@ -435,6 +437,10 @@
     if (menuOpen) closeMenu();
     else menuOpen = true;
   }
+  function onFeedback(kind: FeedbackKind) {
+    closeMenu();
+    openFeedback(kind);
+  }
   // On mobile the gear ALWAYS opens the menu — it now also hosts the quick theme /
   // contrast controls, which must be reachable with an idle herd. On desktop those
   // controls live in the ActionBar, so the gear keeps its leaner behaviour: idle herd
@@ -707,6 +713,7 @@
       {clickHalt}
       {chooseSettings}
       {onMenuKey}
+      {onFeedback}
     />
   </div>
 </div>
@@ -745,6 +752,7 @@
     {onherdrupdate}
     {onwhatsnew}
     {onlearnings}
+    {onFeedback}
   />
 {/if}
 

--- a/ui/src/lib/components/settings/SettingsDevicePanel.svelte
+++ b/ui/src/lib/components/settings/SettingsDevicePanel.svelte
@@ -13,17 +13,20 @@
   import { REPO, REPO_URL, sha, version, commitUrl } from "$lib/build-info";
   import ThemeIcon from "$lib/components/ThemeIcon.svelte";
   import { m } from "$lib/paraglide/messages";
+  import type { FeedbackKind } from "$lib/feedback-link";
 
   let {
     onwhatsnew,
     reducedPushMode = false,
     reducedPushBusy = false,
     onToggleReducedPush,
+    onfeedback,
   }: {
     onwhatsnew?: () => void;
     reducedPushMode?: boolean;
     reducedPushBusy?: boolean;
     onToggleReducedPush?: () => void;
+    onfeedback?: (kind: FeedbackKind) => void;
   } = $props();
 
   // Theme picker — mobile only: the desktop switcher lives in the ActionBar,
@@ -170,6 +173,21 @@
       </fieldset>
     {/if}
   {/if}
+</div>
+<div class="feedback">
+  <span class="micro">{m.settings_feedback_title()}</span>
+  <p class="hint">{m.settings_feedback_blurb()}</p>
+  <div class="feedback-btns">
+    <button type="button" class="clone-trigger" onclick={() => onfeedback?.("bug")}
+      >{m.feedback_dialog_title_bug()}</button
+    >
+    <button type="button" class="clone-trigger" onclick={() => onfeedback?.("feature")}
+      >{m.feedback_dialog_title_feature()}</button
+    >
+    <button type="button" class="clone-trigger" onclick={() => onfeedback?.("feedback")}
+      >{m.feedback_dialog_title_feedback()}</button
+    >
+  </div>
 </div>
 <div class="about">
   <span class="micro">{m.settings_about_title()}</span>
@@ -399,6 +417,24 @@
   .t-opt.on {
     color: var(--color-amber);
     background: var(--color-inset);
+  }
+  .feedback {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 4px;
+    border-top: 1px solid var(--color-line);
+    padding-top: 12px;
+  }
+  .feedback .hint {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    margin: 0;
+  }
+  .feedback-btns {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
   }
   /* The about block — blurb plus the version / commit / repo rows — shows on
      every viewport; desktop additionally surfaces the same metadata in the

--- a/ui/src/lib/components/top-bar/TopBarGear.svelte
+++ b/ui/src/lib/components/top-bar/TopBarGear.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
   import { DOCS_URL } from "$lib/build-info";
+  import type { FeedbackKind } from "$lib/feedback-link";
 
   type GearPipTier = "red" | "orange" | "yellow" | "blue" | null;
 
@@ -19,6 +20,7 @@
     clickHalt,
     chooseSettings,
     onMenuKey,
+    onFeedback,
   }: {
     mobile: boolean;
     haltable: number;
@@ -34,6 +36,7 @@
     clickHalt: () => void;
     chooseSettings: () => void;
     onMenuKey: (e: KeyboardEvent) => void;
+    onFeedback: (kind: FeedbackKind) => void;
   } = $props();
 </script>
 
@@ -108,6 +111,23 @@
         <span class="menu-glyph" aria-hidden="true">↗</span>
         <span class="menu-label">{m.topbar_docs()}</span>
       </a>
+      <button class="menu-item" type="button" role="menuitem" onclick={() => onFeedback("bug")}>
+        <span class="menu-glyph" aria-hidden="true">🐛</span>
+        <span class="menu-label">{m.feedback_dialog_title_bug()}</span>
+      </button>
+      <button class="menu-item" type="button" role="menuitem" onclick={() => onFeedback("feature")}>
+        <span class="menu-glyph" aria-hidden="true">✨</span>
+        <span class="menu-label">{m.feedback_dialog_title_feature()}</span>
+      </button>
+      <button
+        class="menu-item"
+        type="button"
+        role="menuitem"
+        onclick={() => onFeedback("feedback")}
+      >
+        <span class="menu-glyph" aria-hidden="true">💬</span>
+        <span class="menu-label">{m.feedback_dialog_title_feedback()}</span>
+      </button>
     </div>
   {/if}
 </div>

--- a/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
+++ b/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
@@ -8,6 +8,7 @@
   import { gaugeColor } from "../usage-gauges";
   import { formatResetIn, formatReset } from "$lib/format";
   import { REPO_URL, DOCS_URL, version } from "$lib/build-info";
+  import type { FeedbackKind } from "$lib/feedback-link";
   import { fly } from "svelte/transition";
   import { dialog } from "$lib/a11yDialog";
   import { portal } from "$lib/portal";
@@ -62,6 +63,7 @@
     onherdrupdate,
     onwhatsnew,
     onlearnings,
+    onFeedback,
   }: {
     gauges: Gauge[];
     credits: CreditWindow | null;
@@ -95,6 +97,7 @@
     onherdrupdate: (() => void) | undefined;
     onwhatsnew: (() => void) | undefined;
     onlearnings: (() => void) | undefined;
+    onFeedback: (kind: FeedbackKind) => void;
   } = $props();
 </script>
 
@@ -307,6 +310,21 @@
       </button>
       <div class="sheet-sep"></div>
     {/if}
+
+    <!-- Feedback -->
+    <button type="button" class="sheet-item" onclick={() => onFeedback("bug")}>
+      <span class="sheet-glyph" aria-hidden="true">🐛</span>
+      <span class="sheet-label">{m.feedback_dialog_title_bug()}</span>
+    </button>
+    <button type="button" class="sheet-item" onclick={() => onFeedback("feature")}>
+      <span class="sheet-glyph" aria-hidden="true">✨</span>
+      <span class="sheet-label">{m.feedback_dialog_title_feature()}</span>
+    </button>
+    <button type="button" class="sheet-item" onclick={() => onFeedback("feedback")}>
+      <span class="sheet-glyph" aria-hidden="true">💬</span>
+      <span class="sheet-label">{m.feedback_dialog_title_feedback()}</span>
+    </button>
+    <div class="sheet-sep"></div>
 
     <!-- Settings -->
     <button type="button" class="sheet-item" onclick={chooseSettings}>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1389,4 +1389,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_repo_switch_retarget_title",
     bodyKey: "feat_repo_switch_retarget_body",
   },
+  {
+    // In-app feedback (#971): gear menu, mobile sheet, and Settings → Device each expose
+    // Report a bug / Request a feature / Send feedback, opening a prefilled GitHub issue form.
+    // No targetId — the menu/sheet anchors aren't persistently mounted, so it's drawer-only.
+    // v1.35.0 is the latest released tag → ships in 1.36.0.
+    id: "in-app-feedback",
+    sinceVersion: "1.36.0",
+    titleKey: "feat_feedback_title",
+    bodyKey: "feat_feedback_body",
+  },
 ];

--- a/ui/src/lib/feedback-dialog.svelte.ts
+++ b/ui/src/lib/feedback-dialog.svelte.ts
@@ -1,0 +1,21 @@
+import type { FeedbackKind } from "$lib/feedback-link";
+
+// Shared store for the feedback modal. Call openFeedback(kind) to open it;
+// closeFeedback() to dismiss. Mount <FeedbackDialog> once in +page.svelte and
+// gate it on feedbackDialog.kind.
+
+let kind = $state<FeedbackKind | null>(null);
+
+export const feedbackDialog = {
+  get kind() {
+    return kind;
+  },
+};
+
+export function openFeedback(k: FeedbackKind): void {
+  kind = k;
+}
+
+export function closeFeedback(): void {
+  kind = null;
+}

--- a/ui/src/lib/feedback-link.test.ts
+++ b/ui/src/lib/feedback-link.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { buildIssueUrl, buildEnvironment } from "./feedback-link";
+import { version } from "./build-info";
+
+describe("buildIssueUrl", () => {
+  it("bug: sets template=bug.yml, title round-trips, description in what-happened", () => {
+    const url = buildIssueUrl("bug", { title: "It broke", description: "Steps to reproduce" });
+    const params = new URL(url).searchParams;
+    expect(params.get("template")).toBe("bug.yml");
+    expect(params.get("title")).toBe("It broke");
+    expect(params.get("what-happened")).toBe("Steps to reproduce");
+  });
+
+  it("feature: template=feature.yml, description in proposal", () => {
+    const url = buildIssueUrl("feature", { title: "My idea", description: "Add this" });
+    const params = new URL(url).searchParams;
+    expect(params.get("template")).toBe("feature.yml");
+    expect(params.get("proposal")).toBe("Add this");
+  });
+
+  it("feedback: template=feedback.yml, description in feedback", () => {
+    const url = buildIssueUrl("feedback", { description: "Great tool!" });
+    const params = new URL(url).searchParams;
+    expect(params.get("template")).toBe("feedback.yml");
+    expect(params.get("feedback")).toBe("Great tool!");
+  });
+
+  it("environment param is present, non-empty, and contains the version", () => {
+    const url = buildIssueUrl("bug", {});
+    const params = new URL(url).searchParams;
+    const env = params.get("environment") ?? "";
+    expect(env.length).toBeGreaterThan(0);
+    expect(env).toContain(version);
+  });
+
+  it("truncation: >50 KB description yields URL <= 7000 chars ending with truncation marker", () => {
+    const bigDesc = "A".repeat(60_000);
+    const url = buildIssueUrl("bug", { description: bigDesc });
+    expect(url.length).toBeLessThanOrEqual(7000);
+    const params = new URL(url).searchParams;
+    const decoded = params.get("what-happened") ?? "";
+    expect(decoded.endsWith("\n…[truncated]")).toBe(true);
+  });
+});
+
+describe("buildEnvironment", () => {
+  it("always includes Shepherd version and commit lines", () => {
+    const env = buildEnvironment();
+    expect(env).toContain(`v${version}`);
+    expect(env).toContain("- Commit:");
+  });
+});

--- a/ui/src/lib/feedback-link.test.ts
+++ b/ui/src/lib/feedback-link.test.ts
@@ -41,6 +41,15 @@ describe("buildIssueUrl", () => {
     const decoded = params.get("what-happened") ?? "";
     expect(decoded.endsWith("\n…[truncated]")).toBe(true);
   });
+
+  it("bounds an oversized title so it can't blow the URL past the cap on its own", () => {
+    const bigTitle = "T".repeat(60_000);
+    const url = buildIssueUrl("bug", { title: bigTitle });
+    expect(url.length).toBeLessThanOrEqual(7000);
+    const title = new URL(url).searchParams.get("title") ?? "";
+    expect(title.length).toBeLessThanOrEqual(257); // 256 chars + the "…" marker
+    expect(title.endsWith("…")).toBe(true);
+  });
 });
 
 describe("buildEnvironment", () => {

--- a/ui/src/lib/feedback-link.test.ts
+++ b/ui/src/lib/feedback-link.test.ts
@@ -11,11 +11,11 @@ describe("buildIssueUrl", () => {
     expect(params.get("what-happened")).toBe("Steps to reproduce");
   });
 
-  it("feature: template=feature.yml, description in proposal", () => {
+  it("feature: template=feature.yml, description in problem (the required field)", () => {
     const url = buildIssueUrl("feature", { title: "My idea", description: "Add this" });
     const params = new URL(url).searchParams;
     expect(params.get("template")).toBe("feature.yml");
-    expect(params.get("proposal")).toBe("Add this");
+    expect(params.get("problem")).toBe("Add this");
   });
 
   it("feedback: template=feedback.yml, description in feedback", () => {

--- a/ui/src/lib/feedback-link.ts
+++ b/ui/src/lib/feedback-link.ts
@@ -8,7 +8,7 @@
 // URLs longer than ~8 KB trigger HTTP 414 from GitHub's edge. We cap at 7000
 // bytes to leave headroom for browser/proxy overhead.
 
-import { version, sha, commitUrl } from "./build-info";
+import { version, sha, commitUrl, REPO_URL } from "./build-info";
 
 export type FeedbackKind = "bug" | "feature" | "feedback";
 
@@ -44,7 +44,7 @@ export function buildIssueUrl(
   kind: FeedbackKind,
   opts: { title?: string; description?: string },
 ): string {
-  const base = `https://github.com/erwins-enkel/shepherd/issues/new`;
+  const base = `${REPO_URL}/issues/new`;
   const fieldId = KIND_FIELD[kind];
 
   function buildUrl(description: string): string {

--- a/ui/src/lib/feedback-link.ts
+++ b/ui/src/lib/feedback-link.ts
@@ -5,18 +5,22 @@
 // silently ignored — the form opens blank. Field ids map verbatim to query param
 // names (e.g. `what-happened=...`).
 //
-// URLs longer than ~8 KB trigger HTTP 414 from GitHub's edge. We cap at 7000
-// bytes to leave headroom for browser/proxy overhead.
+// URLs longer than ~8 KB trigger HTTP 414 from GitHub's edge. We cap the URL
+// at 7000 characters to leave headroom for browser/proxy overhead. The cap is
+// byte-accurate because a GitHub deep-link URL is all-ASCII (URLSearchParams
+// percent-encodes every non-ASCII byte), so one char == one byte here.
 
 import { version, sha, commitUrl, REPO_URL } from "./build-info";
 
 export type FeedbackKind = "bug" | "feature" | "feedback";
 
 // Maps each kind to the GitHub issue-form field id that receives the user's
-// free-text description.
+// free-text description. Each is the form's REQUIRED field — routing the
+// description elsewhere would leave the required field blank and GitHub would
+// block submission.
 const KIND_FIELD: Record<FeedbackKind, string> = {
   bug: "what-happened",
-  feature: "proposal",
+  feature: "problem",
   feedback: "feedback",
 };
 
@@ -35,7 +39,7 @@ export function buildEnvironment(): string {
   return lines.join("\n");
 }
 
-const MAX_URL_BYTES = 7000;
+const MAX_URL_CHARS = 7000;
 const TRUNCATION_MARKER = "\n…[truncated]";
 const TRUNCATION_CHUNK = 256;
 
@@ -58,7 +62,7 @@ export function buildIssueUrl(
 
   let url = buildUrl(opts.description ?? "");
 
-  if (url.length <= MAX_URL_BYTES || !opts.description) {
+  if (url.length <= MAX_URL_CHARS || !opts.description) {
     return url;
   }
 
@@ -68,7 +72,7 @@ export function buildIssueUrl(
   while (length > 0) {
     const shortened = original.slice(0, length).trimEnd() + TRUNCATION_MARKER;
     url = buildUrl(shortened);
-    if (url.length <= MAX_URL_BYTES) return url;
+    if (url.length <= MAX_URL_CHARS) return url;
     length -= TRUNCATION_CHUNK;
   }
 

--- a/ui/src/lib/feedback-link.ts
+++ b/ui/src/lib/feedback-link.ts
@@ -1,0 +1,77 @@
+// Deep-link builder for GitHub issue forms.
+//
+// GitHub field-id pre-fill works by passing field ids as query params alongside
+// `template=<file>.yml`. Without the template param the field-id params are
+// silently ignored — the form opens blank. Field ids map verbatim to query param
+// names (e.g. `what-happened=...`).
+//
+// URLs longer than ~8 KB trigger HTTP 414 from GitHub's edge. We cap at 7000
+// bytes to leave headroom for browser/proxy overhead.
+
+import { version, sha, commitUrl } from "./build-info";
+
+export type FeedbackKind = "bug" | "feature" | "feedback";
+
+// Maps each kind to the GitHub issue-form field id that receives the user's
+// free-text description.
+const KIND_FIELD: Record<FeedbackKind, string> = {
+  bug: "what-happened",
+  feature: "proposal",
+  feedback: "feedback",
+};
+
+/** Returns a lean, SSR-safe multi-line environment block. */
+export function buildEnvironment(): string {
+  const lines: string[] = [`- Shepherd: v${version} (${sha})`, `- Commit: ${commitUrl}`];
+  if (typeof navigator !== "undefined") {
+    lines.push(`- User agent: ${navigator.userAgent}`);
+    if (navigator.language) {
+      lines.push(`- Locale: ${navigator.language}`);
+    }
+  }
+  if (typeof window !== "undefined") {
+    lines.push(`- Viewport: ${window.innerWidth}×${window.innerHeight}`);
+  }
+  return lines.join("\n");
+}
+
+const MAX_URL_BYTES = 7000;
+const TRUNCATION_MARKER = "\n…[truncated]";
+const TRUNCATION_CHUNK = 256;
+
+/** Builds a GitHub new-issue deep-link URL for the given kind and options. */
+export function buildIssueUrl(
+  kind: FeedbackKind,
+  opts: { title?: string; description?: string },
+): string {
+  const base = `https://github.com/erwins-enkel/shepherd/issues/new`;
+  const fieldId = KIND_FIELD[kind];
+
+  function buildUrl(description: string): string {
+    const params = new URLSearchParams();
+    params.set("template", `${kind}.yml`);
+    if (opts.title) params.set("title", opts.title);
+    if (description) params.set(fieldId, description);
+    params.set("environment", buildEnvironment());
+    return `${base}?${params.toString()}`;
+  }
+
+  let url = buildUrl(opts.description ?? "");
+
+  if (url.length <= MAX_URL_BYTES || !opts.description) {
+    return url;
+  }
+
+  // Iteratively shorten the description until under budget.
+  const original = opts.description;
+  let length = original.length - TRUNCATION_CHUNK;
+  while (length > 0) {
+    const shortened = original.slice(0, length).trimEnd() + TRUNCATION_MARKER;
+    url = buildUrl(shortened);
+    if (url.length <= MAX_URL_BYTES) return url;
+    length -= TRUNCATION_CHUNK;
+  }
+
+  // Last resort: drop description entirely.
+  return buildUrl("");
+}

--- a/ui/src/lib/feedback-link.ts
+++ b/ui/src/lib/feedback-link.ts
@@ -42,6 +42,11 @@ export function buildEnvironment(): string {
 const MAX_URL_CHARS = 7000;
 const TRUNCATION_MARKER = "\n…[truncated]";
 const TRUNCATION_CHUNK = 256;
+// Hard bound on the title so a pasted, oversized title can't blow the URL past
+// MAX_URL_CHARS on its own (the description-shortening loop never trims title).
+// 256 is well under GitHub's stored-title limit; the issue form's title is a
+// short summary anyway.
+const MAX_TITLE_CHARS = 256;
 
 /** Builds a GitHub new-issue deep-link URL for the given kind and options. */
 export function buildIssueUrl(
@@ -51,10 +56,16 @@ export function buildIssueUrl(
   const base = `${REPO_URL}/issues/new`;
   const fieldId = KIND_FIELD[kind];
 
+  const rawTitle = opts.title ?? "";
+  const title =
+    rawTitle.length > MAX_TITLE_CHARS
+      ? rawTitle.slice(0, MAX_TITLE_CHARS).trimEnd() + "…"
+      : rawTitle;
+
   function buildUrl(description: string): string {
     const params = new URLSearchParams();
     params.set("template", `${kind}.yml`);
-    if (opts.title) params.set("title", opts.title);
+    if (title) params.set("title", title);
     if (description) params.set(fieldId, description);
     params.set("environment", buildEnvironment());
     return `${base}?${params.toString()}`;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -95,7 +95,6 @@
   import BacklogView from "$lib/components/BacklogView.svelte";
   import AppOverlays from "$lib/components/page/AppOverlays.svelte";
   import FeedbackDialog from "$lib/components/FeedbackDialog.svelte";
-  import { feedbackDialog } from "$lib/feedback-dialog.svelte";
   import Toasts from "$lib/components/Toasts.svelte";
   import { registerSW, onSelectSession, onOpenLearnings } from "$lib/push";
   import { toasts } from "$lib/toasts.svelte";
@@ -2125,9 +2124,7 @@
   onstarresolve={(s) => (store.starPrompt = s)}
 />
 
-{#if feedbackDialog.kind}
-  <FeedbackDialog kind={feedbackDialog.kind} />
-{/if}
+<FeedbackDialog />
 
 <Toasts aboveActionBar={mobileActionBarPresent} />
 

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -94,6 +94,8 @@
   } from "$lib/components/queue-strip";
   import BacklogView from "$lib/components/BacklogView.svelte";
   import AppOverlays from "$lib/components/page/AppOverlays.svelte";
+  import FeedbackDialog from "$lib/components/FeedbackDialog.svelte";
+  import { feedbackDialog } from "$lib/feedback-dialog.svelte";
   import Toasts from "$lib/components/Toasts.svelte";
   import { registerSW, onSelectSession, onOpenLearnings } from "$lib/push";
   import { toasts } from "$lib/toasts.svelte";
@@ -2122,6 +2124,10 @@
   ontrainconfirm={confirmTrain}
   onstarresolve={(s) => (store.starPrompt = s)}
 />
+
+{#if feedbackDialog.kind}
+  <FeedbackDialog kind={feedbackDialog.kind} />
+{/if}
 
 <Toasts aboveActionBar={mobileActionBarPresent} />
 


### PR DESCRIPTION
Phase 1 of #971 — an in-app way to **report a bug**, **request a feature**, and **send feedback**, routing to GitHub Issues via **prefilled issue-form deep links**. Zero backend.

## What ships
- **Issue forms** (`.github/ISSUE_TEMPLATE/`): `bug.yml` / `feature.yml` / `feedback.yml` (textarea-only, so URL-prefillable; labels in YAML) + `config.yml` chooser (`blank_issues_enabled: false`, Discussions contact link).
- **Deep-link builder** (`ui/src/lib/feedback-link.ts`): `buildIssueUrl(kind, {title, description})` → `…/issues/new?template=<kind>.yml&…` with an auto-filled `environment` block (build version/sha/commit + UA/locale/viewport). Description is truncated to stay under the undocumented ~8 KB → HTTP 414 ceiling. Unit-tested (6/6).
- **Modal + shared store**: `FeedbackDialog.svelte` (canonical `.overlay` scrim + `use:dialog`, dims+blurs, tokens only) self-renders from a `$state` store (`feedback-dialog.svelte.ts`); collects title+details, then opens the prefilled form in a new tab (`window.open(..., "noopener,noreferrer")`).
- **Entry points on three surfaces**: desktop gear menu, mobile gear sheet, and Settings → Device. Each **closes its own surface before opening the modal**, so only one `use:dialog` focus trap is ever active (no nested dialogs).
- **Discovery**: one What's-New catalog entry (`in-app-feedback`, `sinceVersion 1.36.0`) + EN/DE keys.

## Design decisions (from the approved plan)
- **No custom `title` form field** — GitHub's built-in title is prefilled via `?title=`.
- **No coachmark `targetId`** — the menu/sheet anchors aren't persistently mounted; the feature is announced via the What's-New drawer instead (matches the #969 convention).
- Modal self-renders from the store so `+page.svelte` mounts it unconditionally (keeps that template under the fallow complexity bar).

## ⚠️ Two operator follow-ups (outward repo-config; not done in this PR)
The PR is complete and mergeable without these, but they make the `feedback` label and Discussions off-ramp actually resolve:
1. **Create the `feedback` label** — `bug`/`enhancement` exist; `feedback` does not, so `feedback.yml`'s `labels: [feedback]` no-ops until created: `gh label create feedback --color FBCA04 --description "User feedback"`.
2. **Enable Discussions** — currently `has_discussions: false`, so the chooser's Discussions link 404s until enabled: `gh api -X PATCH repos/erwins-enkel/shepherd -f has_discussions=true`.

## Out of scope (deferred — stays documented in #971)
Phase 2 (server-side `createIssue`, screenshots/attachments, large logs, account-less external users, mobile-app prefill robustness). The GitHub **mobile app** drops all prefill params — a known Phase-2 concern; the operator audience is desktop.

## Verification
`bun run check` (0 errors), `check:i18n` (parity), `bun run test` (green incl. builder), fallow audit (exit 0), branch-hygiene / feature-catalog / glossary gates green. Whole-branch review: ready to merge.

Closes #971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)