### PR TITLE
fix(glossary): keep popovers anchored to their trigger in scrolled containers

### DIFF
--- a/ui/src/lib/floating-anchor.ts
+++ b/ui/src/lib/floating-anchor.ts
@@ -7,6 +7,12 @@ import { autoUpdate, computePosition, flip, offset, type Placement, shift } from
 // teardown live in one place rather than being duplicated per popover component.
 // `placement` defaults to "bottom"; `flip()` still re-homes it to the opposite side
 // when the preferred side lacks room.
+//
+// strategy:"fixed" matches the `position: fixed` these popovers carry in CSS (they
+// live in the top layer, whose containing block is the viewport). Without it Floating
+// UI computes document-relative coords while the browser interprets left/top as
+// viewport-relative, so inside a scrolled container the popover drifts from its anchor
+// by exactly the scroll offset.
 export function anchorPopover(
   reference: HTMLElement,
   floating: HTMLElement,
@@ -16,6 +22,7 @@ export function anchorPopover(
   const stop = autoUpdate(reference, floating, () => {
     computePosition(reference, floating, {
       placement,
+      strategy: "fixed",
       middleware: [offset(gap), flip(), shift({ padding: 8 })],
     }).then(({ x, y }) => {
       floating.style.left = x + "px";


### PR DESCRIPTION
## Problem

Im Plan-Modal (`PLAN VOR DER AUSFÜHRUNG`) schwebte die Glossar-Tooltip des **abgeleitet**-Badges weit über ihrem Trigger – mitten im Mermaid-Diagramm statt am Badge, das ganz unten sitzt (gemeldete Screenshots).

## Ursache

Die drei Top-Layer-Popover-Komponenten (`Coachmark`, `InfoTip`, `GlossaryTerm`) tragen im CSS `position: fixed` (Containing-Block = Viewport). `anchorPopover` rief Floating UI aber mit der Default-Strategy `"absolute"` auf, die dokument-/scrollrelative Koordinaten liefert. Der Browser interpretiert `left/top` bei `position: fixed` jedoch viewport-relativ → in einem **gescrollten** Container driftet das Popover exakt um den Scroll-Offset von seinem Anker weg. Beim `abgeleitet`-Badge tief im scrollbaren Plan wurde das sichtbar.

## Fix

`strategy: "fixed"` an Floating UIs `computePosition` durchreichen, passend zum CSS. Korrigiert alle drei Konsumenten (Coachmark, InfoTip, GlossaryTerm) an einer Stelle.

## Verifikation

- `bun run check` ✅
- MermaidBlock- & VisualReview-Tests ✅

[no-feature-entry] — reiner Positionierungs-Bugfix, keine neue user-facing Capability.