### PR TITLE
fix(visual-blocks): stop Mermaid error graphic leaking into the UI

### DIFF
--- a/ui/src/lib/components/blocks/MermaidBlock.browser.test.ts
+++ b/ui/src/lib/components/blocks/MermaidBlock.browser.test.ts
@@ -16,6 +16,7 @@ vi.mock("mermaid", () => ({
   },
 }));
 
+import mermaid from "mermaid";
 import MermaidBlock from "./MermaidBlock.svelte";
 
 describe("MermaidBlock", () => {
@@ -47,6 +48,18 @@ describe("MermaidBlock", () => {
     await expect.element(page.getByText("graph TD; BOOM")).toBeInTheDocument();
     // No svg injected.
     expect(document.querySelector("[data-testid='mmsvg']")).toBeNull();
+  });
+
+  it("config-pin: mermaid.initialize is called with suppressErrorRendering:true", async () => {
+    // Pins the config that triggers Mermaid's documented temp-node cleanup on
+    // failure. Proves configuration, not DOM cleanup — the real-mermaid test does that.
+    render(MermaidBlock, {
+      block: { type: "mermaid", id: "m4", source: "graph TD; A-->B" },
+    });
+    await expect.element(page.getByTestId("mmsvg")).toBeInTheDocument();
+    const calls = vi.mocked(mermaid.initialize).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.at(-1)?.[0]).toMatchObject({ suppressErrorRendering: true });
   });
 
   it("dirty id: block.id with whitespace and special chars renders success (no error fallback)", async () => {

--- a/ui/src/lib/components/blocks/MermaidBlock.real.browser.test.ts
+++ b/ui/src/lib/components/blocks/MermaidBlock.real.browser.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+
+// NO vi.mock here — vi.mock is file-scoped, so this suite loads the REAL mermaid
+// module in real chromium. This is the test that actually proves the leak fix:
+// a failed render must show our .mb-error fallback AND leave no Mermaid error
+// graphic (the bomb / "Syntax error in text") orphaned in document.body.
+import MermaidBlock from "./MermaidBlock.svelte";
+
+// Returns true if any Mermaid-authored error graphic leaked into the document.
+// Covers the temp wrapper (`d` + our `mm-…` render id), the bomb's `.error-icon`,
+// and the version-stamped error text Mermaid renders into it.
+function hasLeakedMermaidError(): boolean {
+  if (document.querySelector('[id^="dmm-"]')) return true; // orphaned temp wrapper
+  if (document.querySelector(".error-icon, .error-text")) return true; // bomb graphic
+  const text = document.body.textContent ?? "";
+  if (/Syntax error in text/i.test(text)) return true;
+  if (/mermaid version/i.test(text)) return true;
+  return false;
+}
+
+describe("MermaidBlock (real mermaid)", () => {
+  it("invalid syntax: shows .mb-error fallback and leaks no bomb into document.body", async () => {
+    // Genuinely-invalid Mermaid. (Note: 'graph TD; BOOM' parses as VALID and would
+    // render — it only fails under the unit mock's string match.)
+    render(MermaidBlock, {
+      block: { type: "mermaid", id: "real-bad", source: "@@@ not valid :::" },
+    });
+
+    // Fallback appearing proves mermaid still RE-THROWS under suppressErrorRendering:true
+    // (the catch sets error=true). If it swallowed the error, neither svg nor
+    // .mb-error would render and this would fail.
+    await expect
+      .element(page.getByText("Diagram could not be rendered"), { timeout: 15000 })
+      .toBeInTheDocument();
+
+    // The raw source is shown in the localized fallback (data passthrough).
+    await expect.element(page.getByText("@@@ not valid :::")).toBeInTheDocument();
+
+    // No Mermaid error graphic anywhere in the document — the actual regression guard.
+    expect(hasLeakedMermaidError()).toBe(false);
+  }, 20000);
+
+  it("valid syntax: renders an svg and no fallback (real module path works)", async () => {
+    render(MermaidBlock, {
+      block: { type: "mermaid", id: "real-good", source: "graph TD; A-->B" },
+    });
+
+    await expect
+      .poll(() => document.querySelector(".mb-svg svg") !== null, { timeout: 15000 })
+      .toBe(true);
+    expect(document.querySelector(".mb-error")).toBeNull();
+    expect(hasLeakedMermaidError()).toBe(false);
+  }, 20000);
+});

--- a/ui/src/lib/components/blocks/MermaidBlock.svelte
+++ b/ui/src/lib/components/blocks/MermaidBlock.svelte
@@ -47,6 +47,11 @@
           startOnLoad: false,
           securityLevel: "strict",
           theme: "base",
+          // Without this, a failed render leaves Mermaid's default error graphic
+          // (the bomb / "Syntax error in text") orphaned in document.body — it leaks
+          // into the UI. With it, Mermaid removes its temp node and re-throws cleanly,
+          // so only our own .mb-error fallback shows.
+          suppressErrorRendering: true,
           themeVariables: Object.keys(themeVariables).length > 0 ? themeVariables : undefined,
         });
 
@@ -58,7 +63,11 @@
           svg = result.svg;
           error = false;
         }
-      } catch {
+      } catch (e) {
+        // Diagnostic only — Mermaid's message is English, so it must NOT reach the
+        // localized UI (that would re-leak untranslated internals). The visible
+        // fallback stays localized (m.vblock_mermaid_error) + raw source.
+        console.error("MermaidBlock render failed", e);
         if (alive) {
           svg = null;
           error = true;


### PR DESCRIPTION
## Problem

When a Mermaid diagram fails to parse, Mermaid's **default error graphic** (the bomb + "Syntax error in text — mermaid version 11.15.0") leaked into the app UI:

![bomb leak](.shepherd-uploads/d0a144c8-1c47-49fa-92e9-e6b61d3130e4.png)

## Root cause

`MermaidBlock.svelte` already caught render failures and showed a clean `.mb-error` fallback. The leak came from Mermaid itself: `mermaid.render(id, source)` (no container arg) appends a temporary `<div id="d{id}">` to `document.body`. On the **success** path Mermaid removes it; on a **parse/draw failure** — unless `suppressErrorRendering` is set — it instead draws the bomb into that node and re-throws **without removing it**, leaving the graphic orphaned in `document.body`.

Server-side validation isn't the right layer: the source is free-form LLM output, and headless Mermaid needs a DOM + async work — wrong for the synchronous block validators on the single Bun loop. Mermaid only runs in the browser, so the browser is the validator (render-and-catch).

## Fix

- Set `suppressErrorRendering: true` in `mermaid.initialize()` → Mermaid removes its temp node and re-throws cleanly; **no bomb ever enters the DOM**. Only our localized `.mb-error` fallback shows.
- Log the caught error via `console.error` for developer diagnosability. It is **not** rendered in the UI (Mermaid's message is English-only; the app is localized EN+DE — rendering it would re-leak untranslated internals).

## Tests

- **New `MermaidBlock.real.browser.test.ts`** (un-mocked, real chromium): renders genuinely-invalid syntax (`@@@ not valid :::`), asserts the `.mb-error` fallback appears (which also proves Mermaid still **re-throws** under the flag) **and** that no Mermaid error/bomb node leaks into `document.body`. Also asserts a valid diagram renders an `<svg>`.
- **Config-pin** in the existing mocked suite: asserts `mermaid.initialize` receives `suppressErrorRendering: true`.

`bun run check`, both test suites, `check:i18n`, and prettier all pass.

No new i18n keys; `fix:` with no new UX surface, so no feature-catalog entry. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)