### PR TITLE
fix(feedback): clear feedback dialog fields on each open

### DIFF
--- a/ui/src/lib/components/FeedbackDialog.svelte
+++ b/ui/src/lib/components/FeedbackDialog.svelte
@@ -8,6 +8,16 @@
   let title = $state("");
   let details = $state("");
 
+  // The dialog component stays mounted (only its content is gated on the kind),
+  // so its state survives close. Clear the fields each time it (re)opens, else
+  // the previous report's title/details are still there on the next open.
+  $effect(() => {
+    if (feedbackDialog.kind) {
+      title = "";
+      details = "";
+    }
+  });
+
   const headingFor: Record<FeedbackKind, () => string> = {
     bug: m.feedback_dialog_title_bug,
     feature: m.feedback_dialog_title_feature,


### PR DESCRIPTION
## Problem

Wenn man den **Feedback-/Fehler-melden-Dialog** benutzt und ihn danach erneut öffnet, stehen die zuletzt eingegebenen Inhalte (Titel + Details) noch in den Feldern.

## Ursache

`<FeedbackDialog>` wird einmal gemountet und bleibt gemountet — nur sein Inhalt wird über `feedbackDialog.kind` ein-/ausgeblendet. Dadurch überleben die `title`/`details` Component-States das Schließen und tauchen beim nächsten Öffnen wieder auf.

## Fix

Ein `$effect` setzt `title` und `details` bei jedem (Wieder-)Öffnen des Dialogs zurück — egal wie er zuvor geschlossen wurde (Abbrechen, ✕, Esc, Außenklick, Absenden).

```
$effect(() => {
  if (feedbackDialog.kind) {
    title = "";
    details = "";
  }
});
```

`cd ui && bun run check` → 0 errors.

[no-feature-entry] — Bugfix, kein neues user-facing Feature.